### PR TITLE
bench: add frontier baseline correctness gate to eval harness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,9 @@ bench/scripts/bench.sh --download            # and --compare for the llama.cpp g
 
 # 3. accuracy — did it stay correct?  (this is the gate that blocks regressions)
 bench/scripts/accuracy.sh --download
+
+# 4. self-consistency — did the optimization change greedy output?  (tightest kernel gate)
+bench/scripts/self_consistency.sh --download
 ```
 
 **Accuracy gate.** Run `bench/scripts/accuracy.sh` (or `qwen3_gguf_score`) on the build

--- a/bench/scripts/README.md
+++ b/bench/scripts/README.md
@@ -55,12 +55,21 @@ PPL llama.cpp         : 7.76   (top-k+floor; inflated — see accuracy results d
 
 ## Using the accuracy gate for optimization (no silent regressions)
 
-The same `score` tool gates an optimization against the **previous** sparkinfer build,
-not just llama.cpp — expect **~100% top-1 + KL ≈ 0**:
+Gate against the **previous** sparkinfer build, not just llama.cpp — expect **≥99% argmax
+agreement + self-KL ≈ 0**:
+
 ```bash
-build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...>   # baseline, save output
-# ... apply your kernel optimization, rebuild ...
-build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...>   # compare argmax + logprobs
+# MMVQ / kernel swap self-consistency (runs score twice, compares dumps)
+bench/scripts/self_consistency.sh --download
+
+# Manual score-vs-baseline (two builds)
+build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...> > /tmp/baseline.txt
+# ... rebuild with your optimization ...
+build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...> > /tmp/candidate.txt
+bench/scripts/self_consistency.sh /tmp/baseline.txt /tmp/candidate.txt
+
+# Eval loop (on a GPU box) — adds baseline gate to the PR bot path
+bench/scripts/evaluate.sh --ref <branch> --baseline-ref main --frontier 164 --ceiling 366
 ```
 
 ## Knobs (env vars)

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -3,31 +3,66 @@
 # Runs ON a GPU box (the vast orchestrator clones the repo + invokes this). Emits a JSON
 # verdict as the last stdout line:  RESULT_JSON {...}
 #
-#   bench/scripts/evaluate.sh [--ref GIT_REF] [--frontier TPS] [--ceiling TPS] [--gguf PATH]
+#   bench/scripts/evaluate.sh [--ref GIT_REF] [--baseline-ref GIT_REF]
+#                           [--frontier TPS] [--ceiling TPS] [--gguf PATH]
 #
-# correctness = token-match / KL vs llama.cpp (accuracy.sh) · speed = median of 3 bench runs
-# · label = significance gate + headroom bucket (label.py). Source-built (NO_PREBUILT) so the
-# measured artifact is the submitted code.
+# correctness = token-match / KL vs llama.cpp (accuracy.sh)
+#             + optional score-vs-baseline gate (--baseline-ref, ~100% top-1 + self-KL≈0)
+# speed = median of 3 bench runs · label = significance gate + headroom bucket (label.py).
+# Source-built (NO_PREBUILT) so the measured artifact is the submitted code.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$HERE/_common.sh"
 
-REF=""; FRONTIER=0; CEILING=0; GGUF=""
+REF=""; BASELINE_REF=""; FRONTIER=0; CEILING=0; GGUF=""
 while [ $# -gt 0 ]; do case "$1" in
-  --ref) shift; REF="$1" ;; --frontier) shift; FRONTIER="$1" ;;
-  --ceiling) shift; CEILING="$1" ;; --gguf) shift; GGUF="$1" ;; *) ;;
+  --ref) shift; REF="$1" ;;
+  --baseline-ref) shift; BASELINE_REF="$1" ;;
+  --frontier) shift; FRONTIER="$1" ;;
+  --ceiling) shift; CEILING="$1" ;;
+  --gguf) shift; GGUF="$1" ;;
+  *) ;;
 esac; shift; done
 [ -z "$GGUF" ] && GGUF="$MODELS_DIR/$MODEL_FILE"
 export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"   # persist llama.cpp across evals
 ARCH="$(detect_arch)"
+TEXT="$HERE/eval_text.txt"
+
+score_token_ids() {
+  python3 -c "from tokenizers import Tokenizer; print(' '.join(map(str, Tokenizer.from_file('$MODELS_DIR/tokenizer.json').encode(open('$TEXT').read().strip()).ids)))"
+}
+
+run_score_dump() {
+  local out="$1"
+  local ids; ids="$(score_token_ids)"
+  si_run qwen3_gguf_score "$GGUF" 20 $ids > "$out" 2>/dev/null || true
+  if ! grep -q "^PPL" "$out"; then
+    fallback_build "$ARCH"
+    si_run qwen3_gguf_score "$GGUF" 20 $ids > "$out" 2>/dev/null
+  fi
+}
+
+BASELINE_AGREE=""; BASELINE_SELFKL=""
+if [ -n "$BASELINE_REF" ]; then
+  SUBMISSION_REF="$(git -C "$ROOT" rev-parse HEAD)"
+  echo ">> [0/4] baseline score ($BASELINE_REF) from source (sm_$ARCH) ..." >&2
+  git -C "$ROOT" fetch -q origin "$BASELINE_REF" 2>/dev/null || true
+  git -C "$ROOT" checkout -q "$BASELINE_REF"
+  BASELINE_COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
+  rm -rf "$ROOT/build"
+  NO_PREBUILT=1 ensure_sparkinfer "$ARCH"
+  ensure_tokenizer
+  run_score_dump /tmp/baseline_score.txt
+  git -C "$ROOT" checkout -q "$SUBMISSION_REF"
+  echo ">> baseline commit: $BASELINE_COMMIT" >&2
+fi
 
 if [ -n "$REF" ]; then git -C "$ROOT" fetch -q origin "$REF" 2>/dev/null || true; git -C "$ROOT" checkout -q "$REF"; fi
 COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
 
-echo ">> [1/3] build submission ($COMMIT) from source (sm_$ARCH) ..." >&2
+echo ">> [1/4] build submission ($COMMIT) from source (sm_$ARCH) ..." >&2
 rm -rf "$ROOT/build"; NO_PREBUILT=1 ensure_sparkinfer "$ARCH"
-SI_BIN="$ROOT/build/runtime"; SI_LD=""
 
-echo ">> [2/3] speed — median of 3 bench runs ..." >&2
+echo ">> [2/4] speed — median of 3 bench runs ..." >&2
 ts=()
 for _ in 1 2 3; do
   t=$(si_run qwen3_gguf_bench "$GGUF" 128 2>/dev/null | sed -n 's/.*decode tg *: *\([0-9.][0-9.]*\).*/\1/p')
@@ -35,11 +70,28 @@ for _ in 1 2 3; do
 done
 TPS=$(printf '%s\n' "${ts[@]}" | sort -n | awk '{a[NR]=$1} END{print a[int((NR+1)/2)]}')
 
-echo ">> [3/3] correctness — token-match / KL vs llama.cpp ..." >&2
+echo ">> [3/4] correctness — token-match / KL vs llama.cpp ..." >&2
 acc=$("$HERE/accuracy.sh" "$GGUF" 2>/dev/null || true)
 # parse the unambiguous METRIC line (not the human-readable text, which contains "bar >= 0.90")
 TOP1=$(printf '%s\n' "$acc" | sed -n 's/.*METRIC .*top1=\([0-9.][0-9.]*\).*/\1/p' | head -1)
 KL=$(printf   '%s\n' "$acc" | sed -n 's/.*METRIC .*kl=\([0-9.][0-9.]*\).*/\1/p' | head -1)
 TOP1="${TOP1:-0}"; KL="${KL:-99}"
 
-python3 "$HERE/label.py" "$TPS" "$FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT"
+if [ -n "$BASELINE_REF" ]; then
+  echo ">> [4/4] baseline gate — score vs $BASELINE_REF ($BASELINE_COMMIT) ..." >&2
+  cp /tmp/spark_score.txt /tmp/submission_score.txt 2>/dev/null || run_score_dump /tmp/submission_score.txt
+  sc_out="$(python3 "$HERE/self_consistency.py" /tmp/baseline_score.txt /tmp/submission_score.txt)"
+  echo "$sc_out" >&2
+  BASELINE_AGREE=$(printf '%s\n' "$sc_out" | sed -n 's/.*METRIC agree=\([0-9.][0-9.]*\).*/\1/p' | head -1)
+  BASELINE_SELFKL=$(printf '%s\n' "$sc_out" | sed -n 's/.*selfkl=\([0-9.][0-9eE+-]*\).*/\1/p' | head -1)
+  BASELINE_AGREE="${BASELINE_AGREE:-0}"; BASELINE_SELFKL="${BASELINE_SELFKL:-99}"
+else
+  echo ">> [4/4] label (no --baseline-ref; skip score-vs-baseline gate) ..." >&2
+fi
+
+if [ -n "$BASELINE_AGREE" ]; then
+  python3 "$HERE/label.py" "$TPS" "$FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT" \
+    "$BASELINE_AGREE" "$BASELINE_SELFKL" "$BASELINE_COMMIT"
+else
+  python3 "$HERE/label.py" "$TPS" "$FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT"
+fi

--- a/bench/scripts/label.py
+++ b/bench/scripts/label.py
@@ -2,10 +2,15 @@
 """Eval-loop label = deterministic function of measurements (so validators converge).
 
   label.py <tps> <frontier_tps> <ceiling_tps> <top1> <kl> <commit>
+           [<baseline_agree> <baseline_selfkl> <baseline_commit>]
 
 Emits one line:  RESULT_JSON {...}
 
-- Correctness gate first: top-1 token agreement >= 0.90 and KL <= 0.5, else REJECT (score 0).
+- Correctness gate first: top-1 token agreement >= 0.90 and KL <= 0.5 vs llama.cpp,
+  else REJECT (score 0).
+- Optional baseline gate (when baseline_agree provided): argmax agreement >= 0.99 and
+  self-KL <= 0.01 vs the previous frontier build — catches silent output drift that
+  still passes the llama.cpp reference.
 - Significance gate: improvement must exceed ~2% of the frontier (a CI proxy), else label "none".
 - Label = bucket of the **fraction of remaining headroom closed** (maturity-adaptive: a small
   absolute gain near the ceiling still maps to a high label). Thresholds are governance-tunable.
@@ -15,19 +20,36 @@ import sys, json
 tps      = float(sys.argv[1])   # measured median tok/s of the submission
 frontier = float(sys.argv[2])   # current best verified tok/s (0 = none yet)
 ceiling  = float(sys.argv[3])   # roofline / strong-reference cap (0 = scale by frontier)
-top1     = float(sys.argv[4])   # token-match vs reference, 0..1
-kl       = float(sys.argv[5])   # mean KL vs reference (nats)
+top1     = float(sys.argv[4])   # token-match vs llama.cpp, 0..1
+kl       = float(sys.argv[5])   # mean KL vs llama.cpp (nats)
 commit   = sys.argv[6]
 
+baseline_agree   = float(sys.argv[7]) if len(sys.argv) > 7 else None
+baseline_selfkl  = float(sys.argv[8]) if len(sys.argv) > 8 else None
+baseline_commit  = sys.argv[9] if len(sys.argv) > 9 else None
+
 TOP1_BAR, KL_BAR = 0.90, 0.50
+BASELINE_AGREE_BAR, BASELINE_SELFKL_BAR = 0.99, 0.01
 SIG = 0.02                                              # significance: >2% over frontier
 BUCKETS = [(0.25, "XL"), (0.10, "L"), (0.03, "M"), (0.01, "S"), (0.0, "XS")]
 
 res = {"commit": commit, "tps": round(tps, 2), "top1": round(top1, 4),
        "kl": round(kl, 4), "frontier_tps": round(frontier, 2)}
 
+if baseline_agree is not None:
+    res["baseline_commit"] = baseline_commit
+    res["baseline_top1"] = round(baseline_agree, 4)
+    res["baseline_selfkl"] = round(baseline_selfkl, 6)
+
+reasons = []
 if top1 < TOP1_BAR or kl > KL_BAR:
-    res.update(pass_=False, label="REJECT", reason=f"correctness (top1={top1}, kl={kl})")
+    reasons.append(f"llama.cpp correctness (top1={top1}, kl={kl})")
+if baseline_agree is not None and (baseline_agree < BASELINE_AGREE_BAR
+                                   or baseline_selfkl > BASELINE_SELFKL_BAR):
+    reasons.append(f"baseline drift (agree={baseline_agree}, selfkl={baseline_selfkl})")
+
+if reasons:
+    res.update(pass_=False, label="REJECT", reason="; ".join(reasons))
 elif frontier <= 0:
     res.update(pass_=True, label="BASELINE", note="no frontier set; this submission becomes it")
 else:

--- a/bench/scripts/self_consistency.sh
+++ b/bench/scripts/self_consistency.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Self-consistency gate: compare two qwen3_gguf_score dumps on the same token sequence.
+#
+#   bench/scripts/self_consistency.sh [--download | <model.gguf>]
+#
+# Default mode runs the score tool twice on the same build:
+#   SPARKINFER_MMVQ=0  (bf16 dequant-GEMV)
+#   SPARKINFER_MMVQ=1  (int8 dp4a MMVQ)
+# and asserts greedy-identical output (argmax agreement = 1.0, self-KL ≈ 0).
+#
+# Pass two existing score files to compare arbitrary builds:
+#   bench/scripts/self_consistency.sh /tmp/baseline.txt /tmp/candidate.txt
+#
+# Env overrides: MODELS_DIR, MODEL_FILE, ARCH (see _common.sh).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+
+SCORE_A=""; SCORE_B=""
+while [ $# -gt 0 ]; do case "$1" in
+  --download) GGUF="$MODELS_DIR/$MODEL_FILE" ;;
+  -h|--help)
+    sed -n '2,14p' "$0"
+    exit 0
+    ;;
+  *)
+    if [ -z "$SCORE_A" ]; then SCORE_A="$1"
+    elif [ -z "$SCORE_B" ]; then SCORE_B="$1"
+    else echo "!! unexpected arg: $1"; exit 1
+    fi
+    ;;
+esac; shift; done
+
+if [ -n "$SCORE_A" ] && [ -n "$SCORE_B" ]; then
+  echo "=== self-consistency: score dump comparison ==="
+  python3 "$HERE/self_consistency.py" "$SCORE_A" "$SCORE_B"
+  exit $?
+fi
+
+GGUF="${GGUF:-$MODELS_DIR/$MODEL_FILE}"
+ARCH="$(detect_arch)"
+resolve_runner "$ARCH"
+[ "$GGUF" = "$MODELS_DIR/$MODEL_FILE" ] && ensure_model
+ensure_tokenizer
+[ -f "$GGUF" ] || { echo "!! GGUF not found: $GGUF"; exit 1; }
+
+IDS="$(python3 -c "from tokenizers import Tokenizer; print(' '.join(map(str, Tokenizer.from_file('$MODELS_DIR/tokenizer.json').encode(open('$HERE/eval_text.txt').read().strip()).ids)))")"
+echo ">> eval tokens: $(echo "$IDS" | wc -w)"
+
+run_score() {
+  local out="$1" mmvq="$2"
+  SPARKINFER_MMVQ="$mmvq" si_run qwen3_gguf_score "$GGUF" 20 $IDS > "$out" 2>/dev/null || true
+  if ! grep -q "^PPL" "$out"; then
+    fallback_build "$ARCH"
+    SPARKINFER_MMVQ="$mmvq" si_run qwen3_gguf_score "$GGUF" 20 $IDS > "$out" 2>/dev/null
+  fi
+}
+
+echo ">> sparkinfer score (SPARKINFER_MMVQ=0) ..."
+run_score /tmp/spark_score_mmvq0.txt 0
+echo ">> sparkinfer score (SPARKINFER_MMVQ=1) ..."
+run_score /tmp/spark_score_mmvq1.txt 1
+
+echo
+echo "=== self-consistency: MMVQ=0 vs MMVQ=1 ==="
+out="$(python3 "$HERE/self_consistency.py" /tmp/spark_score_mmvq0.txt /tmp/spark_score_mmvq1.txt)"
+echo "$out"
+
+AGREE="$(printf '%s\n' "$out" | sed -n 's/.*METRIC agree=\([0-9.][0-9.]*\).*/\1/p' | head -1)"
+SELFKL="$(printf '%s\n' "$out" | sed -n 's/.*selfkl=\([0-9.][0-9eE+-]*\).*/\1/p' | head -1)"
+AGREE="${AGREE:-0}"; SELFKL="${SELFKL:-99}"
+
+python3 - "$AGREE" "$SELFKL" <<'PY'
+import sys
+agree, selfkl = float(sys.argv[1]), float(sys.argv[2])
+if agree < 0.99 or selfkl > 0.01:
+    print(f"!! FAIL self-consistency gate (agree={agree:.4f}, selfkl={selfkl:.6f})")
+    sys.exit(1)
+print(f">> PASS self-consistency gate (agree={agree:.4f}, selfkl={selfkl:.6f})")
+PY

--- a/bench/scripts/test_label.py
+++ b/bench/scripts/test_label.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Unit tests for bench/scripts/label.py (no GPU required)."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+LABEL = HERE / "label.py"
+
+
+def run_label(*args: str) -> dict:
+    out = subprocess.check_output([sys.executable, str(LABEL), *args], text=True)
+    assert out.startswith("RESULT_JSON ")
+    return json.loads(out[len("RESULT_JSON "):])
+
+
+def test_accepts_valid_improvement():
+    res = run_label("170", "164", "366", "1.0", "0.14", "abc1234")
+    assert res["pass"] is True
+    assert res["label"] in {"XL", "L", "M", "S", "XS", "none"}
+
+
+def test_rejects_llama_correctness_failure():
+    res = run_label("170", "164", "366", "0.85", "0.14", "abc1234")
+    assert res["pass"] is False
+    assert res["label"] == "REJECT"
+    assert "llama.cpp" in res["reason"]
+
+
+def test_rejects_baseline_drift():
+    res = run_label("170", "164", "366", "1.0", "0.14", "abc1234",
+                    "0.95", "0.02", "base001")
+    assert res["pass"] is False
+    assert res["label"] == "REJECT"
+    assert "baseline drift" in res["reason"]
+    assert res["baseline_top1"] == 0.95
+
+
+def test_accepts_baseline_match():
+    res = run_label("170", "164", "366", "1.0", "0.14", "abc1234",
+                    "1.0", "0.0", "base001")
+    assert res["pass"] is True
+    assert res["baseline_top1"] == 1.0
+    assert res["baseline_selfkl"] == 0.0
+
+
+def test_baseline_gate_without_llama_failure():
+    # llama gate passes; baseline fails
+    res = run_label("170", "0", "0", "0.95", "0.1", "abc1234",
+                    "0.98", "0.005", "base001")
+    assert res["pass"] is False
+    assert "baseline drift" in res["reason"]
+
+
+if __name__ == "__main__":
+    import pytest
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/eval/README.md
+++ b/eval/README.md
@@ -76,7 +76,8 @@ still comes from the deterministic evaluator so validators converge.)
   to run — validate the vast-specific calls (offer query, `--image`, instance field names) on the
   first run and adjust if your account's defaults differ.
 - First eval on a fresh box builds llama.cpp (~10–15 min); it persists at `/workspace/.llamacpp`.
-- Correctness currently gates vs **llama.cpp**. For an optimization PR, also gate vs the **previous
-  frontier build** (score-vs-baseline: ~100% top-1 + KL≈0) — a small extension to `evaluate.sh`.
+- Correctness gates vs **llama.cpp** and, when `--baseline-ref` is passed to `evaluate.sh`, vs the
+  **previous frontier build** (score-vs-baseline: ≥99% argmax agreement + self-KL ≤ 0.01). Run
+  `bench/scripts/self_consistency.sh` locally before kernel swaps (e.g. MMVQ on/off).
 - Anti-gaming (an LLM/KDA agent reading the diff for benchmark-special-casing, weakened tolerances,
   harness edits) is a layer *on top* — it flags, it doesn't set the numeric label.


### PR DESCRIPTION
## Summary
- Wire **score-vs-baseline** into `evaluate.sh` and `label.py` via `--baseline-ref` (≥99% argmax agreement, self-KL ≤ 0.01 vs the prior frontier build)
- Add `self_consistency.sh` for local kernel-swap checks (MMVQ=0 vs MMVQ=1, or arbitrary score dumps)
- Add GPU-free unit tests in `test_label.py` (5 cases)
- Document the workflow in `CONTRIBUTING.md`, `bench/scripts/README.md`, and `eval/README.md`

Closes the gap noted in `eval/README.md`: optimizations must not silently drift greedy output while still passing the llama.cpp reference.

## Test plan
- [x] `python3 bench/scripts/test_label.py` — 5/5 passed
- [ ] On Blackwell GPU: `bench/scripts/self_consistency.sh --download`
- [ ] On Blackwell GPU: `bench/scripts/evaluate.sh --ref <branch> --baseline-ref main --frontier 164 --ceiling 366`
- [ ] Verify REJECT when baseline drift is injected (argmax change)

