### PR TITLE
bench: basket model harness scaffolding (Qwen + Gemma 4)

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -44,9 +44,10 @@ configs/
 ├── targets/
 │   ├── qwen35_q4km_rtx5090.yaml  # baseline 80 tok/s, target 130 tok/s
 │   ├── qwen35_q4km_rtx_spark.yaml
-│   └── gemma4_q4km_rtx5090.yaml  # 20.2 GB @ 256K ctx
-├── rtx5090.yaml                  # hardware spec: 32 GB, 1.79 TB/s, sm_100
-└── rtx_spark.yaml                # hardware spec: 128 GB, 273 GB/s, sm_100
+│   ├── gemma4_q4km_rtx5090.yaml  # 20.2 GB @ 256K ctx
+│   └── gemma4_q4km_rtx_spark.yaml
+├── rtx5090.yaml                  # hardware spec: 32 GB, 1.79 TB/s, sm_120
+└── rtx_spark.yaml                # hardware spec: 128 GB, 273 GB/s, sm_121
 
 scripts/
 └── run_all.sh                    # run all benchmarks and emit results/ JSON

--- a/bench/configs/targets/gemma4_q4km_rtx5090.yaml
+++ b/bench/configs/targets/gemma4_q4km_rtx5090.yaml
@@ -5,7 +5,7 @@ quant:   q4_k_m
 
 hardware:
   name: RTX 5090
-  arch: sm_100
+  arch: sm_120
   vram_gb: 32
   bandwidth_tbps: 1.79
 

--- a/bench/configs/targets/gemma4_q4km_rtx_spark.yaml
+++ b/bench/configs/targets/gemma4_q4km_rtx_spark.yaml
@@ -1,0 +1,72 @@
+# Benchmark target: Gemma 4 26B-A4B Q4_K_M on RTX Spark
+# RTX Spark: 128GB unified LPDDR5X, Blackwell sm_121, ~273 GB/s bandwidth
+# All 128 experts fit in unified memory — no eviction (unlike RTX 5090)
+
+model:   configs/models/gemma4_26b_a4b.yaml
+quant:   q4_k_m
+
+hardware:
+  name: RTX Spark
+  arch: sm_121
+  unified_memory_gb: 128
+  bandwidth_gbps: 273
+  cuda_cores: 6144
+
+decode:
+  batch_sizes: [1, 2, 4, 8]
+  context_lens: [2048, 8192, 32768, 131072, 262144]
+  dtype: bfloat16
+
+  # RTX Spark baseline (estimated vs llama.cpp, bandwidth-limited)
+  baseline_toks_per_sec:
+    bs1_ctx2k:   12
+    bs1_ctx32k:  10
+    bs1_ctx262k:  6
+
+  target_toks_per_sec:
+    bs1_ctx2k:   20
+    bs1_ctx32k:  16
+    bs1_ctx262k: 12
+
+  # Memory at max context (256K):
+  #   model Q4_K_M:    14.6 GB
+  #   local KV (capped): 0.2 GB
+  #   global KV:         5.4 GB
+  #   total:            ~20.2 GB  → 107 GB headroom on 128 GB unified memory
+  memory_at_max_ctx_gb: 20.2
+  rtx_spark_headroom_gb: 107.8
+
+memory:
+  expert_eviction_needed: false
+  can_preload_all_experts: true
+
+prefill:
+  seq_lens: [512, 2048, 8192, 32768]
+  batch_size: 1
+  dtype: bfloat16
+
+attention:
+  local:
+    num_layers: 25
+    sliding_window: 1024
+    num_kv_heads: 8
+    head_dim: 256
+    bench_sw_attn: true
+    kv_tokens_always: 1024
+
+  global:
+    num_layers: 5
+    sliding_window: null
+    num_kv_heads: 2
+    head_dim: 512
+    bench_full_ctx_attn: true
+    ecosystem_gap: true
+
+moe:
+  bench_router_standalone: true
+  bench_expert_gemm: true
+  num_experts: 128
+  top_k: 8
+  expert_shape: [2112, 704]
+
+compare_against: configs/targets/gemma4_q4km_rtx5090.yaml

--- a/bench/configs/targets/qwen35_q4km_rtx5090.yaml
+++ b/bench/configs/targets/qwen35_q4km_rtx5090.yaml
@@ -6,7 +6,7 @@ quant:   q4_k_m
 
 hardware:
   name: RTX 5090
-  arch: sm_100         # Blackwell
+  arch: sm_120         # Blackwell (RTX 5090 / PRO 6000)
   vram_gb: 32
   bandwidth_tbps: 1.79
   cuda_cores: 21760

--- a/bench/configs/targets/qwen35_q4km_rtx_spark.yaml
+++ b/bench/configs/targets/qwen35_q4km_rtx_spark.yaml
@@ -7,7 +7,7 @@ quant:   q4_k_m
 
 hardware:
   name: RTX Spark
-  arch: sm_100
+  arch: sm_121
   unified_memory_gb: 128
   bandwidth_gbps: 273     # LPDDR5X — 6-7× slower than RTX 5090 GDDR7
   cuda_cores: 6144

--- a/bench/scripts/README.md
+++ b/bench/scripts/README.md
@@ -18,11 +18,16 @@ bench/scripts/bench.sh --download --compare
 
 # 3) Accuracy gate vs llama.cpp (token-match / KL / perplexity)
 bench/scripts/accuracy.sh --download
+
+# 4) Basket gate — Qwen today; Gemma skipped until runtime wiring lands
+bench/scripts/accuracy_basket.sh --download
 ```
 
 Use your own model instead of `--download`:
 ```bash
 bench/scripts/bench.sh /path/to/model.gguf --tokens 256 --compare
+bench/scripts/bench.sh --model gemma4 --download   # when Gemma runtime lands
+bench/scripts/accuracy.sh --model qwen --download
 ```
 
 ## Prebuilt binaries (no toolkit needed)
@@ -68,10 +73,11 @@ build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...>   # compare argmax +
 | var | default | purpose |
 |---|---|---|
 | `ARCH` | auto (`compute_cap`) | CUDA arch, e.g. `121` for RTX Spark |
+| `MODEL_PRESET` | `qwen` | basket model: `qwen` or `gemma4` (also `--model` flag) |
 | `MODELS_DIR` | `./models` | where the GGUF + tokenizer live |
-| `MODEL_REPO` / `MODEL_FILE` | Qwen3-30B-A3B GGUF | model to fetch |
+| `MODEL_REPO` / `MODEL_FILE` | preset-specific | model to fetch (override per preset) |
 | `LLAMACPP_DIR` | `./.llamacpp` | reuse an existing llama.cpp checkout/build |
 | `NO_PREBUILT` | `0` | set `1` to skip prebuilt binaries and build from source |
 
-Files: `bench.sh`, `accuracy.sh`, `accuracy_compare.py`, `eval_text.txt`, `_common.sh`.
+Files: `bench.sh`, `accuracy.sh`, `accuracy_basket.sh`, `accuracy_compare.py`, `eval_text.txt`, `_common.sh`.
 Results from reference runs live in [`../results/`](../results).

--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -5,10 +5,39 @@
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"   # repo root (bench/scripts -> root)
 MODELS_DIR="${MODELS_DIR:-$ROOT/models}"
-MODEL_REPO="${MODEL_REPO:-Qwen/Qwen3-30B-A3B-GGUF}"
-MODEL_FILE="${MODEL_FILE:-Qwen3-30B-A3B-Q4_K_M.gguf}"
-TOK_REPO="${TOK_REPO:-Qwen/Qwen3-30B-A3B}"
+MODEL_PRESET="${MODEL_PRESET:-qwen}"   # qwen | gemma4 — see apply_model_preset
+MODEL_REPO="${MODEL_REPO:-}"
+MODEL_FILE="${MODEL_FILE:-}"
+TOK_REPO="${TOK_REPO:-}"
+SCORE_TOOL="${SCORE_TOOL:-qwen3_gguf_score}"
+BENCH_TOOL="${BENCH_TOOL:-qwen3_gguf_bench}"
 LLAMACPP_DIR="${LLAMACPP_DIR:-$ROOT/.llamacpp}"   # override to reuse an existing checkout
+
+# Basket model presets (Qwen3-MoE + Gemma 4). Env vars above override these defaults.
+apply_model_preset() {
+  case "${MODEL_PRESET}" in
+    qwen)
+      MODEL_REPO="${MODEL_REPO:-Qwen/Qwen3-30B-A3B-GGUF}"
+      MODEL_FILE="${MODEL_FILE:-Qwen3-30B-A3B-Q4_K_M.gguf}"
+      TOK_REPO="${TOK_REPO:-Qwen/Qwen3-30B-A3B}"
+      SCORE_TOOL="qwen3_gguf_score"
+      BENCH_TOOL="qwen3_gguf_bench"
+      ;;
+    gemma4)
+      # Override MODEL_REPO/MODEL_FILE when the official Gemma 4 GGUF lands on HF.
+      MODEL_REPO="${MODEL_REPO:-google/gemma-4-27b-it-GGUF}"
+      MODEL_FILE="${MODEL_FILE:-gemma-4-27b-it-Q4_K_M.gguf}"
+      TOK_REPO="${TOK_REPO:-google/gemma-4-27b-it}"
+      SCORE_TOOL="gemma4_gguf_score"
+      BENCH_TOOL="gemma4_gguf_bench"
+      ;;
+    *)
+      echo "!! unknown MODEL_PRESET: ${MODEL_PRESET} (want qwen or gemma4)" >&2
+      return 1
+      ;;
+  esac
+}
+apply_model_preset
 
 # compute capability -> CUDA arch (12.0 -> 120). RTX 5090 / PRO 6000 = 120, Spark/Thor = 121.
 detect_arch() {
@@ -17,8 +46,9 @@ detect_arch() {
 }
 
 ensure_sparkinfer() {  # $1 = arch
-  [ -x "$ROOT/build/runtime/qwen3_gguf_bench" ] && [ -x "$ROOT/build/runtime/qwen3_gguf_score" ] && return
-  echo ">> building sparkinfer (sm_$1) ..." >&2
+  apply_model_preset
+  [ -x "$ROOT/build/runtime/$BENCH_TOOL" ] && [ -x "$ROOT/build/runtime/$SCORE_TOOL" ] && return
+  echo ">> building sparkinfer (sm_$1, preset=${MODEL_PRESET}) ..." >&2
   cmake -S "$ROOT" -B "$ROOT/build" -DCMAKE_CUDA_ARCHITECTURES="$1" -DCMAKE_BUILD_TYPE=Release >/dev/null
   cmake --build "$ROOT/build" -j"$(nproc)" >/dev/null
 }
@@ -57,7 +87,9 @@ PREBUILT_DIR="$ROOT/.prebuilt/sparkinfer-bin"
 SI_BIN=""; SI_LD=""   # set by resolve_runner: binary dir + LD_LIBRARY_PATH
 
 try_prebuilt() {   # download+extract the release bundle; sets SI_BIN/SI_LD; returns 1 if unavailable
+  apply_model_preset
   [ "${NO_PREBUILT:-0}" = 1 ] && return 1
+  [ "$SCORE_TOOL" != "qwen3_gguf_score" ] && return 1   # v0.1.0 prebuilt is Qwen-only
   if [ ! -x "$PREBUILT_DIR/bin/qwen3_gguf_bench" ]; then
     command -v curl >/dev/null || return 1
     echo ">> fetching prebuilt $PREBUILT_TGZ ..." >&2
@@ -69,7 +101,8 @@ try_prebuilt() {   # download+extract the release bundle; sets SI_BIN/SI_LD; ret
 }
 
 resolve_runner() {   # $1=arch. Prefer an existing local build, else prebuilt, else build from source.
-  if [ -x "$ROOT/build/runtime/qwen3_gguf_bench" ]; then SI_BIN="$ROOT/build/runtime"; SI_LD=""; echo ">> using local build" >&2; return; fi
+  apply_model_preset
+  if [ -x "$ROOT/build/runtime/$BENCH_TOOL" ]; then SI_BIN="$ROOT/build/runtime"; SI_LD=""; echo ">> using local build ($MODEL_PRESET)" >&2; return; fi
   if try_prebuilt; then echo ">> using prebuilt binaries (will fall back to source build if incompatible)" >&2; return; fi
   ensure_sparkinfer "$1"; SI_BIN="$ROOT/build/runtime"; SI_LD=""
 }

--- a/bench/scripts/accuracy.sh
+++ b/bench/scripts/accuracy.sh
@@ -12,6 +12,7 @@ source "$HERE/_common.sh"
 GGUF=""; TEXT="$HERE/eval_text.txt"
 while [ $# -gt 0 ]; do case "$1" in
   --download) GGUF="$MODELS_DIR/$MODEL_FILE" ;;
+  --model)    shift; MODEL_PRESET="$1"; apply_model_preset ;;
   --text)     shift; TEXT="$1" ;;
   -h|--help)  sed -n '2,8p' "$0"; exit 0 ;;
   *)          GGUF="$1" ;;
@@ -28,11 +29,11 @@ ensure_llamacpp "$ARCH"
 IDS="$(python3 -c "from tokenizers import Tokenizer; print(' '.join(map(str, Tokenizer.from_file('$MODELS_DIR/tokenizer.json').encode(open('$TEXT').read().strip()).ids)))")"
 echo ">> eval tokens: $(echo "$IDS" | wc -w)"
 
-echo ">> sparkinfer teacher-forced score ..."
-si_run qwen3_gguf_score "$GGUF" 20 $IDS > /tmp/spark_score.txt 2>/dev/null || true
+echo ">> sparkinfer teacher-forced score ($SCORE_TOOL) ..."
+si_run "$SCORE_TOOL" "$GGUF" 20 $IDS > /tmp/spark_score.txt 2>/dev/null || true
 if ! grep -q "^PPL" /tmp/spark_score.txt; then   # prebuilt incompatible -> rebuild
   fallback_build "$ARCH"
-  si_run qwen3_gguf_score "$GGUF" 20 $IDS > /tmp/spark_score.txt 2>/dev/null
+  si_run "$SCORE_TOOL" "$GGUF" 20 $IDS > /tmp/spark_score.txt 2>/dev/null
 fi
 
 echo ">> starting llama.cpp server (reference) ..."

--- a/bench/scripts/accuracy_basket.sh
+++ b/bench/scripts/accuracy_basket.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Basket accuracy gate: run the correctness harness for each SN74 basket model.
+#
+#   bench/scripts/accuracy_basket.sh [--download] [--text FILE]
+#
+# Today Qwen3-MoE runs end-to-end; Gemma 4 is skipped gracefully until
+# gemma4_gguf_score is wired in the runtime (see dashboard "wiring" status).
+#
+# Env overrides: MODELS_DIR, ARCH, LLAMACPP_DIR (see _common.sh).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+
+DOWNLOAD=0; EXTRA=()
+while [ $# -gt 0 ]; do case "$1" in
+  --download) DOWNLOAD=1 ;;
+  --text)     EXTRA+=(--text); shift; EXTRA+=("$1") ;;
+  -h|--help)
+    sed -n '2,10p' "$0"
+    exit 0
+    ;;
+  *) echo "!! unexpected arg: $1"; exit 1 ;;
+esac; shift; done
+
+ARCH="$(detect_arch)"
+FAILED=0; SKIPPED=0; PASSED=0
+
+run_preset() {
+  local preset="$1"
+  export MODEL_PRESET="$preset"
+  apply_model_preset
+
+  if [ ! -x "$ROOT/build/runtime/$SCORE_TOOL" ]; then
+    resolve_runner "$ARCH" 2>/dev/null || true
+  fi
+  if [ ! -x "${SI_BIN:-$ROOT/build/runtime}/$SCORE_TOOL" ] && [ ! -x "$ROOT/build/runtime/$SCORE_TOOL" ]; then
+    echo
+    echo "=== SKIP $preset — $SCORE_TOOL not built (runtime wiring pending) ==="
+    SKIPPED=$((SKIPPED + 1))
+    return 0
+  fi
+
+  echo
+  echo "========================================"
+  echo " basket: $preset  ($SCORE_TOOL)"
+  echo "========================================"
+  local args=()
+  [ "$DOWNLOAD" = 1 ] && args+=(--download)
+  args+=("${EXTRA[@]}")
+  if "$HERE/accuracy.sh" --model "$preset" "${args[@]}"; then
+    PASSED=$((PASSED + 1))
+  else
+    echo "!! FAIL basket accuracy: $preset"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+echo ">> basket accuracy gate (sm_$ARCH)"
+run_preset qwen
+run_preset gemma4
+
+echo
+echo "=== basket summary ==="
+echo "passed : $PASSED"
+echo "skipped: $SKIPPED"
+echo "failed : $FAILED"
+
+[ "$FAILED" -eq 0 ]

--- a/bench/scripts/bench.sh
+++ b/bench/scripts/bench.sh
@@ -15,6 +15,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 GGUF=""; TOKENS=128; COMPARE=0
 while [ $# -gt 0 ]; do case "$1" in
   --download) GGUF="$MODELS_DIR/$MODEL_FILE" ;;
+  --model)    shift; MODEL_PRESET="$1"; apply_model_preset ;;
   --tokens)   shift; TOKENS="$1" ;;
   --compare)  COMPARE=1 ;;
   -h|--help)  sed -n '2,9p' "$0"; exit 0 ;;
@@ -27,12 +28,12 @@ resolve_runner "$ARCH"     # prebuilt binaries if available, else build from sou
 [ "$GGUF" = "$MODELS_DIR/$MODEL_FILE" ] && ensure_model
 [ -f "$GGUF" ] || { echo "!! GGUF not found: $GGUF  (pass a path or use --download)"; exit 1; }
 
-echo; echo "=== sparkinfer — decode (n=$TOKENS, bs=1) ==="
-out="$(si_run qwen3_gguf_bench "$GGUF" "$TOKENS" 2>&1)" || true
+echo; echo "=== sparkinfer — decode ($BENCH_TOOL, n=$TOKENS, bs=1, preset=$MODEL_PRESET) ==="
+out="$(si_run "$BENCH_TOOL" "$GGUF" "$TOKENS" 2>&1)" || true
 echo "$out"
 if ! echo "$out" | grep -q "decode tg"; then   # prebuilt incompatible (arch/driver/glibc) -> rebuild
   fallback_build "$ARCH"
-  si_run qwen3_gguf_bench "$GGUF" "$TOKENS"
+  si_run "$BENCH_TOOL" "$GGUF" "$TOKENS"
 fi
 
 if [ "$COMPARE" = 1 ]; then

--- a/bench/scripts/test_basket_preset.sh
+++ b/bench/scripts/test_basket_preset.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Smoke test for basket model presets in _common.sh (no GPU required).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+check_preset() {
+  local preset="$1" score="$2" bench="$3"
+  local got
+  got="$(MODEL_PRESET="$preset" bash -c "source '$HERE/_common.sh' && printf '%s:%s' \"\$SCORE_TOOL\" \"\$BENCH_TOOL\"")"
+  local got_score="${got%%:*}" got_bench="${got#*:}"
+  [ "$got_score" = "$score" ] || { echo "!! $preset: expected SCORE_TOOL=$score got $got_score"; exit 1; }
+  [ "$got_bench" = "$bench" ] || { echo "!! $preset: expected BENCH_TOOL=$bench got $got_bench"; exit 1; }
+  echo "ok preset=$preset score=$got_score bench=$got_bench"
+}
+
+check_preset qwen   qwen3_gguf_score   qwen3_gguf_bench
+check_preset gemma4 gemma4_gguf_score   gemma4_gguf_bench
+echo ">> all basket preset checks passed"


### PR DESCRIPTION
## Summary
- Add **`MODEL_PRESET` / `--model`** (`qwen` | `gemma4`) across `_common.sh`, `bench.sh`, and `accuracy.sh`
- Add **`accuracy_basket.sh`** — runs the basket gate for Qwen; gracefully skips Gemma until `gemma4_gguf_score` is wired
- Add **`gemma4_q4km_rtx_spark.yaml`** target config (128 GB unified memory, sm_121)
- Fix **`sm_100` → `sm_120`/`sm_121`** arch labels in existing target YAMLs
- Add smoke test `test_basket_preset.sh` (no GPU)

Aligns the harness with CONTRIBUTING's **Qwen3-MoE + Gemma 4 basket** requirement. Gemma E2E remains blocked on runtime wiring (dashboard: "wiring"); this PR prepares the measurement infra.

## Test plan
- [x] `bash bench/scripts/test_basket_preset.sh` — passed
- [ ] `bench/scripts/accuracy_basket.sh --download` on RTX 5090 (Qwen passes, Gemma skips)
- [ ] `bench/scripts/bench.sh --model qwen --download` — unchanged behavior
- [ ] After Gemma runtime lands: `bench/scripts/accuracy.sh --model gemma4 --download`
