### PR TITLE
kernels/attention: fix flash_prefill causal mask for seqlen_q != seqlen_kv

### DIFF
--- a/kernels/csrc/cuda/attention/flash_prefill.cu
+++ b/kernels/csrc/cuda/attention/flash_prefill.cu
@@ -48,7 +48,9 @@ __global__ void flash_prefill_kernel(
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
 
-    const int kv_end = causal ? min(seqlen_kv, qpos + 1) : seqlen_kv;
+    // Causal: query position qpos maps to absolute KV position qpos + (seqlen_kv - seqlen_q)
+    // and may attend through it inclusive. Reduces to qpos+1 when seqlen_q == seqlen_kv.
+    const int kv_end = causal ? min(seqlen_kv, qpos + 1 + (seqlen_kv - seqlen_q)) : seqlen_kv;
     for (int t = 0; t < kv_end; t++) {
         const size_t kv_off = (((size_t)b * seqlen_kv + t) * num_kv_heads + kv_head) * HEAD_DIM;
         float partial = 0.f;


### PR DESCRIPTION
## Summary

Fix the causal-mask boundary in `flash_prefill_kernel` so it is correct when `seqlen_q != seqlen_kv` (chunked prefill / prefix-cache attention). Reduces to the existing behavior when the lengths are equal.

Fixes #3

**Why.** `kernels/csrc/cuda/attention/flash_prefill.cu` computed `kv_end = causal ? min(seqlen_kv, qpos + 1) : seqlen_kv`, which only holds when the query and key sequences are co-aligned from index 0. The kernel API explicitly takes **separate** `seqlen_q`/`seqlen_kv` (see `attention.h` + the file header) for when the query chunk is the tail of a longer KV sequence; there, query position `qpos` maps to absolute KV position `qpos + (seqlen_kv - seqlen_q)` and may attend through it inclusive. With `seqlen_kv > seqlen_q` the old bound masked out the most recent `seqlen_kv - seqlen_q` cached keys, under-attending and producing wrong output.

**Change.** `kv_end = causal ? min(seqlen_kv, qpos + 1 + (seqlen_kv - seqlen_q)) : seqlen_kv;` (one line + a clarifying comment).

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — this is a **correctness-only** change, not a perf change. When `seqlen_q == seqlen_kv` the expression is identical to before, so the full-prefill path (and its accuracy gate: top-1 / KL vs the prior build) is byte-for-byte unchanged; only the unequal-length path is corrected. No decode-throughput impact is expected or claimed.

**Benchmark log** (before → after):

```text
N/A — correctness fix, no performance delta. Equal-length prefill output is bit-identical to baseline; unequal-length prefill is corrected.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |
