### PR TITLE
runtime/gguf: fail loudly on bad metadata array instead of desyncing the cursor

### DIFF
--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -80,7 +80,18 @@ bool GGUF::open(const std::string& path) {
         else if (vt == VT_ARR) {
             uint32_t et = c.rd<uint32_t>(); uint64_t n = c.rd<uint64_t>();
             if (et == VT_STR) { for (uint64_t k = 0; k < n && c.ok; k++) c.rd_str(); }
-            else c.skip((size_t)n * scalar_size(et));
+            else {
+                // Skip the scalar payload, but fail loudly on an unsupported element
+                // type (scalar_size==0 -> a 0-byte skip would desync the cursor) or a
+                // declared span that overflows / runs past the file.
+                int es = scalar_size(et);
+                if (es == 0 || n > (c.size - c.off) / (size_t)es) {
+                    fprintf(stderr, "[gguf] bad metadata array (elem type %u, n=%llu) for %s\n",
+                            et, (unsigned long long)n, key.c_str());
+                    return false;
+                }
+                c.skip((size_t)n * es);
+            }
         } else { fprintf(stderr, "[gguf] unknown vt %u for %s\n", vt, key.c_str()); return false; }
     }
     if (!c.ok) { fprintf(stderr, "[gguf] metadata parse error\n"); return false; }


### PR DESCRIPTION
## Summary

Make the GGUF metadata array-skip path robust: abort the parse on an unsupported element type or an out-of-range declared span instead of silently mis-advancing the cursor.

Fixes #5

**Why.** `runtime/src/gguf.cpp` skipped metadata arrays with `c.skip((size_t)n * scalar_size(et))`. Two problems: (1) for any element type `scalar_size` does not enumerate (a nested array, or any unknown/future type) it returns `0`, so the cursor advances 0 bytes and every subsequent metadata key + the whole tensor table is parsed from the middle of the array data — silently yielding wrong config / tensor offsets (OOB mmap reads); the unknown-*scalar* path already aborts loudly, only this array path did not. (2) `(size_t)n * scalar_size(et)` can overflow for a file-controlled count `n`, slipping past `skip()`'s post-hoc bounds check.

**Change.** Validate the element size and the declared span before skipping, and abort the parse (matching the unknown-scalar path) when either is bad. Well-formed files using supported scalar/string array elements are unaffected.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — this is a **robustness/correctness-only** change to the host-side GGUF loader, not a perf change. Valid GGUF files (e.g. Qwen3-30B-A3B Q4_K_M) parse identically, so the model-load path and the accuracy gate are unchanged; only malformed/unsupported arrays change behavior (silent mis-parse → clean diagnosed failure). No decode-throughput impact.

**Benchmark log** (before → after):

```text
N/A — host-side parser hardening, no kernel/perf change. Valid-file load output unchanged.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |
