### PR TITLE
fix(runtime/gguf): reject malformed metadata arrays instead of desyncing the parse cursor

### DIFF
--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -80,7 +80,20 @@ bool GGUF::open(const std::string& path) {
         else if (vt == VT_ARR) {
             uint32_t et = c.rd<uint32_t>(); uint64_t n = c.rd<uint64_t>();
             if (et == VT_STR) { for (uint64_t k = 0; k < n && c.ok; k++) c.rd_str(); }
-            else c.skip((size_t)n * scalar_size(et));
+            else {
+                // An unknown array element type (scalar_size == 0, e.g. a nested
+                // VT_ARR) would advance the cursor 0 bytes and silently desync every
+                // later key + the whole tensor table. n * es can also overflow size_t
+                // on a corrupt file, slipping past skip()'s post-hoc bounds check. Fail
+                // loudly instead — consistent with the unknown-scalar path below.
+                int es = scalar_size(et);
+                if (es == 0 || n > (c.size - c.off) / (size_t)es) {
+                    fprintf(stderr, "[gguf] bad metadata array (elem type %u, n=%llu) for %s\n",
+                            et, (unsigned long long)n, key.c_str());
+                    return false;
+                }
+                c.skip((size_t)n * (size_t)es);
+            }
         } else { fprintf(stderr, "[gguf] unknown vt %u for %s\n", vt, key.c_str()); return false; }
     }
     if (!c.ok) { fprintf(stderr, "[gguf] metadata parse error\n"); return false; }


### PR DESCRIPTION
## Summary

Fixes #5. The GGUF metadata reader skips arrays with `c.skip((size_t)n * scalar_size(et))`. For any element type `scalar_size()` does not enumerate — a nested `VT_ARR`, or any unrecognized/future type — it returns `0`, so the cursor advances by **0 bytes** instead of over the array payload. Every subsequent metadata key and the entire tensor table are then parsed from the middle of that array, silently producing wrong config values and wrong tensor data offsets (OOB reads from the mmap) instead of failing.

A second defect on the same line: `(size_t)n * scalar_size(et)` multiplies a file-controlled `uint64_t` count by the element size. On a corrupt/malicious file this product can overflow `size_t` and wrap to a small value, so `skip()`'s post-hoc `off > size` check passes and parsing continues desynchronized.

Notably, the unknown-*scalar* path (the final `else`) already aborts loudly; only the unknown-*array-element* path mis-advanced silently. This change makes the array path consistent with it.

## What changed

`runtime/src/gguf.cpp` — the `VT_ARR` non-string branch now:

- rejects unknown element types (`scalar_size(et) == 0`), and
- rejects arrays whose declared span would run past the file, using the overflow-safe check `n > (c.size - c.off) / es` (instead of computing `n * es` first),

failing the parse with a clear diagnostic rather than mis-advancing the cursor.

```cpp
else {
    int es = scalar_size(et);
    if (es == 0 || n > (c.size - c.off) / (size_t)es) {
        fprintf(stderr, "[gguf] bad metadata array (elem type %u, n=%llu) for %s\n",
                et, (unsigned long long)n, key.c_str());
        return false;
    }
    c.skip((size_t)n * (size_t)es);
}
```

## Impact

Correctness / robustness only. **No effect on well-formed GGUF files** whose metadata arrays use the supported scalar/string element types — those take the identical `skip()` as before. Malformed/unsupported arrays now fail fast instead of silently corrupting all downstream config and tensor pointers.

## Scope & scoring

- Touches only `runtime/src/gguf.cpp` — no maintainer-owned/protected path (`eval/`, `bench/scripts/`, `.gittensor/`, `dashboard/data.json`, `.github/`).
- Per `CONTRIBUTING.md`, this is a non-speedup bug fix: it earns **no SN74 reward (scores 0)** but is the kind of correctness fix the guide invites for review/merge. The change is a host-side parser fix and does not alter any kernel output, so the accuracy gate is unaffected.
