### PR TITLE
runtime/gguf: bound tensor n_dims to GGML_MAX_DIMS before writing dims[]

### DIFF
--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -92,7 +92,13 @@ bool GGUF::open(const std::string& path) {
     std::vector<Info> infos; infos.reserve(n_tensors);
     for (uint64_t i = 0; i < n_tensors && c.ok; i++) {
         Info in; in.name = c.rd_str();
-        uint32_t nd = c.rd<uint32_t>(); in.t.n_dims = nd;
+        // n_dims is file-controlled; GGUFTensor::dims is fixed at ggml's
+        // GGML_MAX_DIMS (4). Reject nd > 4 before the loop so a malformed or
+        // future-format tensor cannot write past dims[4] (which would clobber
+        // the adjacent n_values/n_bytes/data members) and desync the cursor.
+        uint32_t nd = c.rd<uint32_t>();
+        if (!c.ok || nd > 4) { fprintf(stderr, "[gguf] tensor %s has invalid n_dims=%u (max 4)\n", in.name.c_str(), nd); return false; }
+        in.t.n_dims = nd;
         long nv = 1;
         for (uint32_t d = 0; d < nd; d++) { long e = (long)c.rd<uint64_t>(); in.t.dims[d] = e; nv *= e; }
         in.t.ggml_type = c.rd<uint32_t>();


### PR DESCRIPTION
## Summary

The GGUF tensor-table parser reads each tensor's dimension count `nd` directly from the file and writes `in.t.dims[d]` for `d` in `[0, nd)`, but `GGUFTensor::dims` is a fixed 4-element array (`long dims[4]`, ggml's `GGML_MAX_DIMS`). `nd` is a file-controlled `uint32_t` with no bound check, so a GGUF declaring `n_dims > 4` writes past `dims[4]` — clobbering the adjacent `n_values`/`n_bytes`/`data` members and desyncing the cursor for the rest of the tensor table (an out-of-bounds write rather than a loud parse failure).

This adds a single guard before the dims loop that rejects `nd > 4` (and a failed read), mirroring the existing loud-abort error handling in the same parser.

Closes #10.

## Change

- `runtime/src/gguf.cpp`: after reading `nd`, fail the parse with a clear message when `!c.ok || nd > 4`, before any write to `in.t.dims[]`.

## Correctness

- Well-formed GGUF files declare 1..4 dimensions per tensor (ggml caps at `GGML_MAX_DIMS == 4`), so this rejects only malformed/unsupported inputs and does not change parsing or numerics for any valid model. The eval is therefore expected to be `eval:none` (correctness/robustness fix, not a speedup).
