### PR TITLE
fix(kernels/attention): offset flash_prefill causal mask by seqlen_kv - seqlen_q

### DIFF
--- a/kernels/csrc/cuda/attention/flash_prefill.cu
+++ b/kernels/csrc/cuda/attention/flash_prefill.cu
@@ -48,7 +48,12 @@ __global__ void flash_prefill_kernel(
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
 
-    const int kv_end = causal ? min(seqlen_kv, qpos + 1) : seqlen_kv;
+    // Under causal attention a query at chunk-relative position qpos maps to
+    // absolute KV position qpos + (seqlen_kv - seqlen_q) and may attend to all
+    // keys up to and including it. Offsetting by the KV/query length difference
+    // makes chunked / prefix-cached prefill (seqlen_kv > seqlen_q) correct;
+    // when seqlen_q == seqlen_kv this reduces to qpos + 1 (full prefill, unchanged).
+    const int kv_end = causal ? min(seqlen_kv, qpos + 1 + (seqlen_kv - seqlen_q)) : seqlen_kv;
     for (int t = 0; t < kv_end; t++) {
         const size_t kv_off = (((size_t)b * seqlen_kv + t) * num_kv_heads + kv_head) * HEAD_DIM;
         float partial = 0.f;


### PR DESCRIPTION
## Summary

Closes #3. `flash_prefill_kernel` computed the causal mask boundary as `min(seqlen_kv, qpos + 1)`, which assumes query and key sequences are co-aligned from index 0 — only true when `seqlen_q == seqlen_kv`. The kernel's API takes **separate** `seqlen_q`/`seqlen_kv` for chunked / prefix-cache prefill, where the query chunk is the tail of a longer KV sequence.

Under causal attention, query position `qpos` maps to absolute KV position `qpos + (seqlen_kv - seqlen_q)` and may attend to all keys up to and including it. The old bound capped attention at `qpos`, so when `seqlen_kv > seqlen_q` every query masked out the most recent `seqlen_kv - seqlen_q` cached keys and under-attended. Fix:

```cpp
const int kv_end = causal ? min(seqlen_kv, qpos + 1 + (seqlen_kv - seqlen_q)) : seqlen_kv;
```

## Test plan

- `seqlen_q == seqlen_kv` (full prefill, the currently-exercised path) reduces to `qpos + 1` — **unchanged**.
- `seqlen_kv > seqlen_q` (chunked / prefix-cached prefill) now attends to the cached context correctly.
- Compiled/validated by maintainer CI (no local CUDA toolchain available).

Correctness only; no measurable speed delta (scores 0 under the speedup-only rubric per `CONTRIBUTING.md`).
