### PR TITLE
fix(runtime/qwen35): force n_shared=0 on GGUF loads without shared-expert tensors

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -311,6 +311,18 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     GGUF g;
     if (!g.open(path)) return false;
 
+    // The GGUF path below loads only the routed experts (gate_q/up_q/down_q); it
+    // never populates the shared-expert weights (w.shared_gate/up/down), which
+    // stay at their nullptr initializers. forward_token launches the shared-expert
+    // FFN whenever cfg.n_shared > 0 (default 1), so a default-config GGUF load
+    // would dereference three null device pointers and crash decode. Qwen3-30B-A3B
+    // has no shared expert, so if the file carries no shared-expert tensor, force
+    // n_shared = 0 here to keep the default-config GGUF path self-consistent.
+    if (s.cfg.n_shared > 0 && !g.tensor("blk.0.ffn_gate_shexp.weight")) {
+        fprintf(stderr, "[gguf] no shared-expert tensors in file; forcing n_shared=0\n");
+        s.cfg.n_shared = 0;
+    }
+
     // upload raw quantized blocks, keep on device (for experts)
     auto dev_quant = [&](const std::string& name, int& qtype) -> const void* {
         const GGUFTensor* t = g.tensor(name);


### PR DESCRIPTION
## Summary

Closes #7. `Qwen35Model::load_gguf()` loads only the routed experts (`gate_q`/`up_q`/`down_q`) and never populates the shared-expert weights (`w.shared_gate`/`up`/`down`), which stay at their `nullptr` initializers. But `forward_token()` launches the shared-expert FFN whenever `cfg.n_shared > 0` — and `n_shared` defaults to **1** — so any caller loading a GGUF with the default config dereferences three null device pointers inside `launch_moe_expert_ffn` and crashes decode.

Every shipped GGUF example explicitly sets `cfg.n_shared = 0`, which masks the bug; it's a latent trap for any new default-config caller.

## Fix

In `load_gguf()`, detect whether the file carries shared-expert tensors (`blk.0.ffn_gate_shexp.weight`). If not, force `s.cfg.n_shared = 0` with a one-line warning, so `forward_token` never launches the shared FFN with null weights. Qwen3-30B-A3B has no shared expert, so `n_shared = 0` is in fact correct for it — this just makes the GGUF path self-consistent instead of relying on every caller to set it by hand.

## Test plan

- Existing examples (which set `n_shared = 0`) are unaffected.
- A default-config GGUF load (`n_shared = 1`) of a file without shared-expert tensors now downshifts to `n_shared = 0` instead of crashing on null device pointers.
- Compiled/validated by maintainer CI (no local CUDA toolchain available).

Correctness/robustness only; no speedup (scores 0 under the speedup-only rubric per `CONTRIBUTING.md`).
