### PR TITLE
kernels/quant: reject unsupported GGUF types instead of silently decoding as F32

### DIFF
--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -10,6 +10,7 @@
 #include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
+#include <cstdio>
 #endif
 
 namespace sparkinfer {
@@ -98,7 +99,6 @@ __global__ void transpose3d_kernel(const __nv_bfloat16* __restrict__ src, __nv_b
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/quant.h"
-#include <cstdio>
 
 void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_values, cudaStream_t stream) {
     auto* d = reinterpret_cast<__nv_bfloat16*>(dst_bf16);

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -98,6 +98,7 @@ __global__ void transpose3d_kernel(const __nv_bfloat16* __restrict__ src, __nv_b
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/quant.h"
+#include <cstdio>
 
 void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_values, cudaStream_t stream) {
     auto* d = reinterpret_cast<__nv_bfloat16*>(dst_bf16);
@@ -107,7 +108,8 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
     else if (ggml_type == GGML_Q6_K) { long nb = n_values/256; deq_q6k_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_Q8_0) { long nb = n_values/32;  deq_q8_0_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_F16)  { deq_f16_kernel<<<(n_values+T-1)/T,T,0,stream>>>(s,d,n_values); }
-    else /* F32 */                   { deq_f32_kernel<<<(n_values+T-1)/T,T,0,stream>>>(reinterpret_cast<const float*>(src),d,n_values); }
+    else if (ggml_type == GGML_F32)  { deq_f32_kernel<<<(n_values+T-1)/T,T,0,stream>>>(reinterpret_cast<const float*>(src),d,n_values); }
+    else { fprintf(stderr, "[gguf] launch_gguf_dequant: unsupported ggml type %d — no decoder (e.g. Q5_K=13); refusing to reinterpret as F32\n", ggml_type); }
 }
 
 void launch_transpose_bf16(const void* src, void* dst, int rows, int cols, cudaStream_t stream) {


### PR DESCRIPTION
## Summary

Make `launch_gguf_dequant` fail loudly on a GGUF type it has no decoder for, instead of silently reinterpreting it as F32.

Fixes #16

**Why.** `kernels/csrc/cuda/quant/dequant_gguf.cu` decoded Q4_K/Q6_K/Q8_0/F16 and let every other ggml type fall through to the F32 decoder. That is reachable: `runtime/src/gguf.cpp` `block_info()` already sizes **Q5_K** (ggml type 13, 176 B / 256), so a Q5_K_M GGUF loads and its tensors reach `launch_gguf_dequant`, which has no Q5_K branch → the `else /* F32 */` path reinterprets 176-byte Q5_K blocks as raw float32 → silent garbage, no error (and a confusing downstream correctness failure rather than a fast, clear load error).

**Change.** Give F32 its own explicit branch and reject any type without a decoder:

```cpp
else if (ggml_type == GGML_F32) { deq_f32_kernel<<<...>>>(reinterpret_cast<const float*>(src),d,n_values); }
else { fprintf(stderr, "[gguf] launch_gguf_dequant: unsupported ggml type %d — no decoder ...\n", ggml_type); }
```

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — this is a **correctness/robustness-only** change in the GGUF dequant dispatch, not a perf change. Valid Q4_K/Q6_K/Q8_0/F16/F32 weights are dequantized by the exact same kernels as before (the supported-type paths are untouched), so decode throughput and the accuracy gate are unaffected. Only genuinely-unsupported types change behavior (silent garbage → diagnosed refusal).

**Benchmark log** (before → after):

```text
N/A — dispatch hardening, no kernel math / perf change. Supported-type dequant output is bit-identical to baseline.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |

## Scope

Single focused change in `kernels/csrc/cuda/quant/dequant_gguf.cu`; one fix per PR per CONTRIBUTING.md, scoped to `kernels/`.