### PR TITLE
moe/engine: guard forward() against num_tokens exceeding scratch capacity

### DIFF
--- a/moe/src/engine.cpp
+++ b/moe/src/engine.cpp
@@ -45,6 +45,14 @@ public:
 
     void forward(const void* input, void* output, int num_tokens, int layer,
                  cudaStream_t stream) override {
+        if (num_tokens <= 0) return;
+        if (num_tokens > max_tokens_) {
+            // Router/top-k scratch is sized for max_tokens_; a larger batch would
+            // overflow d_logits_/d_ids_/d_weights_ (OOB device writes). Refuse instead.
+            fprintf(stderr, "[moe] forward: num_tokens %d exceeds scratch capacity %d — skipping\n",
+                    num_tokens, max_tokens_);
+            return;
+        }
         const LayerWeights& w = weights_[layer];
         const int E = cfg_.num_experts, K = cfg_.top_k;
         const int H = cfg_.hidden_dim, F = cfg_.ffn_dim;


### PR DESCRIPTION
## Summary

Guard `MoEEngineImpl::forward()` so a batch larger than the engine's router scratch can't overflow it.

Fixes #18

**Why.** The router/top-k scratch (`d_logits_`, `d_ids_`, `d_weights_`) is allocated once for `max_tokens_ = 4096`, but `forward()` passed the caller's `num_tokens` into the kernels with no bound check. A batch with `num_tokens > max_tokens_` would write past those allocations — out-of-bounds device writes (memory corruption / crash). The current single-token decode path never hits it, but nothing enforced the invariant.

**Change.** Before launching any kernel, no-op on `num_tokens <= 0` and refuse (with a diagnostic) on `num_tokens > max_tokens_`:

```cpp
if (num_tokens <= 0) return;
if (num_tokens > max_tokens_) {
    fprintf(stderr, "[moe] forward: num_tokens %d exceeds scratch capacity %d — skipping\n", num_tokens, max_tokens_);
    return;
}
```

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — this is a **robustness/memory-safety-only** change to the MoE host engine, not a perf change. Valid batches (`num_tokens <= max_tokens_`, e.g. the single-token decode path) take exactly the same code path as before — the guard only triggers on out-of-range inputs that previously caused OOB device writes. No decode-throughput impact.

**Benchmark log** (before → after):

```text
N/A — host-side bounds guard, no kernel/perf change. Valid-batch behavior unchanged.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |

## Scope

Single focused change in `moe/src/engine.cpp`; one fix per PR per CONTRIBUTING.md, scoped to `moe/`.