### PR TITLE
fix(moe): validate router inputs before launching top-k kernel

### DIFF
--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -93,6 +93,7 @@ void launch_moe_router(
     int* tokens_per_expert, int num_tokens, int num_experts, int top_k,
     int normalize, cudaStream_t stream
 ) {
+    if (num_tokens <= 0 || num_experts <= 0 || top_k <= 0 || top_k > num_experts) return;
     size_t smem = (size_t)num_experts * sizeof(float);
     moe_router_kernel<<<num_tokens, 32, smem, stream>>>(
         logits, expert_ids, expert_weights, tokens_per_expert,

--- a/moe/README.md
+++ b/moe/README.md
@@ -64,7 +64,7 @@ Kernel implementation lives in [sparkinfer-kernels](https://github.com/gittensor
 ## Build
 
 ```bash
-cmake -B build -DCMAKE_CUDA_ARCHITECTURES="100"
+cmake -B build -DCMAKE_CUDA_ARCHITECTURES="120"
 cmake --build build -j$(nproc)
 ```
 

--- a/moe/src/router.cpp
+++ b/moe/src/router.cpp
@@ -7,6 +7,7 @@
 #include "sparkinfer/kernels/moe.h"
 
 #include <memory>
+#include <cstdio>
 
 namespace sparkinfer {
 namespace moe {
@@ -20,9 +21,15 @@ Router::~Router() = default;
 
 void Router::route(const float* router_logits, int* expert_ids, float* expert_weights,
                    int* tokens_per_expert, int num_tokens, cudaStream_t stream) {
+    if (num_tokens <= 0) return;
+    const int E = impl_->cfg.num_experts, K = impl_->cfg.top_k;
+    if (E <= 0 || K <= 0 || K > E) {
+        fprintf(stderr, "[moe] route: invalid config (num_experts=%d top_k=%d)\n", E, K);
+        return;
+    }
     kernels::launch_moe_router(
         router_logits, expert_ids, expert_weights, tokens_per_expert,
-        num_tokens, impl_->cfg.num_experts, impl_->cfg.top_k,
+        num_tokens, E, K,
         impl_->cfg.normalize_weights ? 1 : 0, stream);
 }
 


### PR DESCRIPTION
## Summary
- Guard `Router::route()` against empty batches and invalid `num_experts` / `top_k`
- Early-return in `launch_moe_router` for the same invalid shapes (avoids zero/negative grid dims)
- Fix `moe/README.md` build example: `sm_120` (consumer Blackwell), not `sm_100` (datacenter)

## Test plan
- [x] No maintainer-only paths touched
- [ ] `ctest --test-dir build` on Blackwell
- [ ] MoE routing bench unchanged on valid configs

