### PR TITLE
fix(bench): correct Blackwell arch labels in target configs

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -44,9 +44,10 @@ configs/
 ├── targets/
 │   ├── qwen35_q4km_rtx5090.yaml  # baseline 80 tok/s, target 130 tok/s
 │   ├── qwen35_q4km_rtx_spark.yaml
-│   └── gemma4_q4km_rtx5090.yaml  # 20.2 GB @ 256K ctx
-├── rtx5090.yaml                  # hardware spec: 32 GB, 1.79 TB/s, sm_100
-└── rtx_spark.yaml                # hardware spec: 128 GB, 273 GB/s, sm_100
+│   ├── gemma4_q4km_rtx5090.yaml  # 20.2 GB @ 256K ctx
+│   └── gemma4_q4km_rtx_spark.yaml
+├── rtx5090.yaml                  # hardware spec: 32 GB, 1.79 TB/s, sm_120
+└── rtx_spark.yaml                # hardware spec: 128 GB, 273 GB/s, sm_121
 
 scripts/
 └── run_all.sh                    # run all benchmarks and emit results/ JSON

--- a/bench/configs/targets/gemma4_q4km_rtx5090.yaml
+++ b/bench/configs/targets/gemma4_q4km_rtx5090.yaml
@@ -5,7 +5,7 @@ quant:   q4_k_m
 
 hardware:
   name: RTX 5090
-  arch: sm_100
+  arch: sm_120
   vram_gb: 32
   bandwidth_tbps: 1.79
 

--- a/bench/configs/targets/gemma4_q4km_rtx_spark.yaml
+++ b/bench/configs/targets/gemma4_q4km_rtx_spark.yaml
@@ -1,0 +1,60 @@
+# Benchmark target: Gemma 4 26B-A4B Q4_K_M on RTX Spark
+# RTX Spark: 128GB unified LPDDR5X, Blackwell sm_121, ~273 GB/s bandwidth
+
+model:   configs/models/gemma4_26b_a4b.yaml
+quant:   q4_k_m
+
+hardware:
+  name: RTX Spark
+  arch: sm_121
+  unified_memory_gb: 128
+  bandwidth_gbps: 273
+  cuda_cores: 6144
+
+decode:
+  batch_sizes: [1, 2, 4, 8]
+  context_lens: [2048, 8192, 32768, 131072, 262144]
+  dtype: bfloat16
+
+  baseline_toks_per_sec:
+    bs1_ctx2k:   12
+    bs1_ctx32k:  10
+    bs1_ctx262k:  6
+
+  target_toks_per_sec:
+    bs1_ctx2k:   20
+    bs1_ctx32k:  16
+    bs1_ctx262k: 12
+
+  memory_at_max_ctx_gb: 20.2
+  rtx_spark_headroom_gb: 107.8
+
+memory:
+  expert_eviction_needed: false
+  can_preload_all_experts: true
+
+attention:
+  local:
+    num_layers: 25
+    sliding_window: 1024
+    num_kv_heads: 8
+    head_dim: 256
+    bench_sw_attn: true
+    kv_tokens_always: 1024
+
+  global:
+    num_layers: 5
+    sliding_window: null
+    num_kv_heads: 2
+    head_dim: 512
+    bench_full_ctx_attn: true
+    ecosystem_gap: true
+
+moe:
+  bench_router_standalone: true
+  bench_expert_gemm: true
+  num_experts: 128
+  top_k: 8
+  expert_shape: [2112, 704]
+
+compare_against: configs/targets/gemma4_q4km_rtx5090.yaml

--- a/bench/configs/targets/qwen35_q4km_rtx5090.yaml
+++ b/bench/configs/targets/qwen35_q4km_rtx5090.yaml
@@ -6,7 +6,7 @@ quant:   q4_k_m
 
 hardware:
   name: RTX 5090
-  arch: sm_100         # Blackwell
+  arch: sm_120         # Blackwell (RTX 5090 / PRO 6000)
   vram_gb: 32
   bandwidth_tbps: 1.79
   cuda_cores: 21760

--- a/bench/configs/targets/qwen35_q4km_rtx_spark.yaml
+++ b/bench/configs/targets/qwen35_q4km_rtx_spark.yaml
@@ -7,7 +7,7 @@ quant:   q4_k_m
 
 hardware:
   name: RTX Spark
-  arch: sm_100
+  arch: sm_121
   unified_memory_gb: 128
   bandwidth_gbps: 273     # LPDDR5X — 6-7× slower than RTX 5090 GDDR7
   cuda_cores: 6144


### PR DESCRIPTION
## Summary
- Fix `sm_100` → `sm_120` / `sm_121` in `bench/configs/targets/*` (matches README/CONTRIBUTING: consumer Blackwell only)
- Add `gemma4_q4km_rtx_spark.yaml` for the Gemma 4 basket on RTX Spark
- Update `bench/README.md` structure diagram

Touches `bench/configs/` only — not the maintainer-owned `bench/scripts/` harness.

## Test plan
- [x] YAML syntax valid
- [x] Passes sensitive-paths-guard (no `bench/scripts/` edits)
- [ ] Configs align with `bench/configs/rtx5090.yaml` (sm_120) and `rtx_spark.yaml` (sm_121)

