### PR TITLE
runtime/gguf: clamp invalid general.alignment to default (fix divide-by-zero)

### DIFF
--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -97,6 +97,11 @@ bool GGUF::open(const std::string& path) {
     if (!c.ok) { fprintf(stderr, "[gguf] metadata parse error\n"); return false; }
 
     long alignment = ints_.count("general.alignment") ? ints_["general.alignment"] : 32;
+    // general.alignment is file-controlled; it must be a positive power of two (the
+    // spec default is 32). A present-but-zero value would divide-by-zero (SIGFPE) when
+    // computing data_start below, and a negative value would mis-align it. Clamp any
+    // invalid alignment back to the default instead of trusting it.
+    if (alignment <= 0) alignment = 32;
 
     // tensor infos
     struct Info { std::string name; GGUFTensor t; uint64_t offset; };


### PR DESCRIPTION
## Summary

Guard the GGUF loader against an invalid file-controlled `general.alignment`. The value is used as a divisor when resolving the tensor-data section, so a declared `general.alignment = 0` divides by zero (SIGFPE) and a negative value mis-aligns `data_start`. The existing guard only handled a *missing* key, not a present-but-invalid value.

Fixes #24

**Change.** After reading `general.alignment`, clamp any non-positive value back to the spec default (32):

```cpp
long alignment = ints_.count("general.alignment") ? ints_["general.alignment"] : 32;
if (alignment <= 0) alignment = 32;
```

This matches how the loader already fails safe on other malformed metadata (unsupported array element types, out-of-range spans, `n_dims > 4`).

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — robustness-only change to the host-side GGUF loader, not a perf change. Well-formed files carry a positive power-of-two alignment (or omit the key, defaulting to 32), so they parse byte-identically; the model-load path and accuracy gate are unchanged. Only a malformed `alignment <= 0` changes behavior (SIGFPE → safe default). No decode-throughput impact.

**Benchmark log** (before → after):

```text
N/A — non-perf robustness fix; decode path unchanged.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |
