### PR TITLE
runtime/gguf: bounds-check tensor data region against file size (fix OOB read)

### DIFF
--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -123,6 +123,18 @@ bool GGUF::open(const std::string& path) {
 
     size_t data_start = (c.off + alignment - 1) / alignment * alignment;
     for (auto& in : infos) {
+        // The tensor offset/size are file-controlled. The metadata is already validated
+        // against the file, but the resolved data region is not — bounds-check it against
+        // size_ so a truncated/malformed GGUF fails loudly here instead of producing an
+        // out-of-bounds pointer that is later dereferenced (e.g. cudaMemcpy on upload).
+        // Written with subtraction so the address arithmetic itself cannot overflow.
+        if (data_start > size_ ||
+            in.offset > size_ - data_start ||
+            (uint64_t)in.t.n_bytes > size_ - data_start - in.offset) {
+            fprintf(stderr, "[gguf] tensor %s data out of bounds (offset=%llu n_bytes=%ld file=%zu)\n",
+                    in.name.c_str(), (unsigned long long)in.offset, in.t.n_bytes, size_);
+            return false;
+        }
         in.t.data = (const uint8_t*)base_ + data_start + in.offset;
         tensors_[in.name] = in.t;
     }


### PR DESCRIPTION
## Summary

Bounds-check each GGUF tensor's resolved data region against the file size before publishing its pointer. The loader already validates the *metadata* (array spans, `n_dims`) against the file, but the *tensor data* pointer — `base_ + data_start + offset` — was trusted unconditionally. A truncated download or a file with an out-of-range tensor `offset`/size produces an out-of-bounds pointer that is later dereferenced on upload (`cudaMemcpy(d, t->data, t->n_bytes, ...)` in `models/qwen35.cpp`) → OOB host read / SIGSEGV.

Fixes #25

**Change.** In the tensor-data resolution loop, verify `[data_start + offset, +n_bytes)` lies within `size_` and abort the parse otherwise. The check is written with subtraction (`offset > size_ - data_start`, …) so the address arithmetic cannot itself overflow:

```cpp
if (data_start > size_ ||
    in.offset > size_ - data_start ||
    (uint64_t)in.t.n_bytes > size_ - data_start - in.offset) {
    fprintf(stderr, "[gguf] tensor %s data out of bounds ...\n", ...);
    return false;
}
```

This matches the loader's existing fail-loud handling of other untrusted metadata.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — robustness/memory-safety-only change to the host-side GGUF loader, not a perf change. Well-formed files (e.g. Qwen3-30B-A3B Q4_K_M) have every tensor inside the file, so they resolve identically and the load path + accuracy gate are unchanged; only an out-of-range tensor turns a silent OOB read into a clean diagnosed failure. No decode-throughput impact.

**Benchmark log** (before → after):

```text
N/A — non-perf robustness fix; decode path unchanged.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |
