### PR TITLE
runtime/scheduler: pack past oversized groups instead of breaking (avoid starvation)

### DIFF
--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -28,7 +28,13 @@ ScheduleBatch Scheduler::schedule() {
     std::sort(ordered.begin(), ordered.end(),
               [](const SequenceGroup* a, const SequenceGroup* b) { return a->priority > b->priority; });
     for (auto* g : ordered) {
-        if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
+        // Skip a group that doesn't fit and keep packing smaller ones (greedy
+        // bin-packing, per "pack ... until the token budget is hit" above). Using
+        // break here head-of-line-blocks every lower-priority group behind an
+        // oversized one, and a single group with num_seqs > max_tokens_per_batch
+        // would return an empty batch forever (starvation). continue keeps the
+        // batch filled up to the budget.
+        if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) continue;
         for (int i = 0; i < g->num_seqs; i++) batch.decode_seq_ids.push_back(g->group_id);
         batch.total_tokens += g->num_seqs;
     }


### PR DESCRIPTION
## Summary

Fix `Scheduler::schedule()` to keep packing the batch past a group that doesn't fit, instead of `break`ing on the first one.

Fixes #31

**Why.** `schedule()` orders groups by priority and packs decode steps "until the token budget is hit." The `break` on the first over-budget group head-of-line-blocks every lower-priority group behind an oversized one (batch left under-filled), and in the degenerate case where one group has `num_seqs > max_tokens_per_batch` it returns an **empty batch on every call** — that group never fits and permanently starves all others.

**Change.** Use `continue` so groups that don't fit are skipped and the batch keeps filling from the rest (greedy bin-packing, matching the documented intent). No behavior change when every group fits within the budget.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — host-only scheduler **liveness/throughput correctness** fix; not a kernel/perf change and not on the single-stream decode path the eval exercises. Decode output and the accuracy gate are unaffected; the change only alters multi-group batch packing (skip-and-continue vs. stop), so there is no measurable decode-throughput delta to report.

**Benchmark log** (before → after):

```text
N/A — scheduling-policy correctness fix, no kernel/perf change.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |

## Scope

One-line logic fix (+ explanatory comment) in `runtime/src/scheduler.cpp`. One fix per PR per CONTRIBUTING.md, scoped to `runtime/`.