### PR TITLE
runtime/kv_cache: bound cumulative per-seq blocks to prevent block-table OOB write

### DIFF
--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -64,7 +64,14 @@ KVCacheManager::~KVCacheManager() {
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
     const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
     if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
-    if (need > kMaxBlocksPerSeq) return false;
+    // Bound the CUMULATIVE per-seq block count, not just this request. A
+    // re-allocate (grow) for an existing seq appends to its row, and each row in
+    // d_block_tables is exactly kMaxBlocksPerSeq wide — so checking only `need`
+    // lets blocks.size() exceed the row, and the cudaMemcpy below would then
+    // write past it into the adjacent sequence's block table (OOB device write).
+    auto existing = impl_->seq_blocks.find(seq_id);
+    const int have = (existing != impl_->seq_blocks.end()) ? (int)existing->second.size() : 0;
+    if (have + need > kMaxBlocksPerSeq) return false;
 
     auto& blocks = impl_->seq_blocks[seq_id];
     for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }


### PR DESCRIPTION
## Summary

Make `KVCacheManager::allocate()` cap the **cumulative** per-sequence block count, not just the current request, so growing a sequence can't overrun its block-table row.

Fixes #33

**Why.** `allocate()` appends `need` blocks to the sequence's existing list, but checked only `need > kMaxBlocksPerSeq`. Each `d_block_tables` row is exactly `kMaxBlocksPerSeq` ints wide, so a re-allocate (grow) of a sequence that already holds blocks can make `blocks.size()` exceed the row; the subsequent `cudaMemcpy(..., blocks.size()*sizeof(int), ...)` then writes past the row into the adjacent sequence's table — an out-of-bounds device write / cross-sequence corruption. (Latent today since callers `free()` before re-`allocate()`, but nothing enforced the invariant.)

**Change.** Check `existing + need` against `kMaxBlocksPerSeq` before appending:

```cpp
auto existing = impl_->seq_blocks.find(seq_id);
const int have = (existing != impl_->seq_blocks.end()) ? (int)existing->second.size() : 0;
if (have + need > kMaxBlocksPerSeq) return false;
```

Fresh sequences (`have == 0`) behave exactly as before.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — host-side **memory-safety** guard in the KV-cache manager, not a kernel/perf change. The single-stream decode path the eval exercises allocates once per sequence (`have == 0`), so it takes the identical code path; decode output and the accuracy gate are unchanged. No decode-throughput delta.

**Benchmark log** (before → after):

```text
N/A — bounds-check hardening, no kernel/perf change. Valid (fresh-seq) allocation behavior unchanged.
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |

## Scope

Focused guard in `runtime/src/kv_cache.cpp`. One fix per PR per CONTRIBUTING.md, scoped to `runtime/`.