### PR TITLE
kernels/moe/router: bound top_k to the fixed sel_logit[16]/sel_id[16] capacity

### DIFF
--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -11,6 +11,7 @@
 #include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
+#include <cstdio>
 #endif
 
 namespace sparkinfer {
@@ -94,6 +95,13 @@ void launch_moe_router(
     int normalize, cudaStream_t stream
 ) {
     if (num_tokens <= 0 || num_experts <= 0 || top_k <= 0 || top_k > num_experts) return;
+    // moe_router_kernel stages the selection in fixed per-thread arrays
+    // sel_logit[16]/sel_id[16]; top_k is file-controlled (GGUF expert_used_count), so a
+    // value beyond 16 would overrun those local arrays on the device. Reject it loudly.
+    if (top_k > 16) {
+        fprintf(stderr, "[moe] router: top_k %d exceeds max supported 16\n", top_k);
+        return;
+    }
     size_t smem = (size_t)num_experts * sizeof(float);
     moe_router_kernel<<<num_tokens, 32, smem, stream>>>(
         logits, expert_ids, expert_weights, tokens_per_expert,


### PR DESCRIPTION
## Summary

Bound `top_k` to the fixed top-k capacity (16) of the router's per-thread arrays. `moe_router_kernel` stages each token's selection in `sel_logit[16]`/`sel_id[16]`, but `launch_moe_router` only validated `top_k` against `num_experts`. `top_k` is file-controlled (GGUF `expert_used_count`), so a value in `(16, num_experts]` passed the guard and the kernel then wrote `sel_logit[j]`/`sel_id[j]` for `j >= 16`, overrunning those local arrays on the device. This matches the fixed-array guard the loader already applies to `n_dims` (bounded to `GGML_MAX_DIMS`).

Well-formed Qwen3-MoE configs use `top_k = 8` and are unaffected — only an out-of-range `top_k` changes behavior (device local-array overrun → clean diagnosed early return).

Fixes #35

## Proof of speedup

N/A — robustness fix, no kernel/perf path changed. Identical output for every well-formed model.

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A — no perf change; behavior is identical for all valid configs (top_k <= 16).
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |