### PR TITLE
runtime/qwen35: range-check prompt token ids in generate() (fix OOB embedding read)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -267,7 +267,18 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         return out;
     }
     int next = -1;
-    for (size_t i = 0; i < prompt.size(); i++) next = forward_token(prompt[i], (int)i);
+    for (size_t i = 0; i < prompt.size(); i++) {
+        // Prompt ids are caller-supplied; an out-of-range id would index the embedding
+        // table out of bounds in launch_embedding. Validate before decoding.
+        const int t = prompt[i];
+        if (t < 0 || t >= s.cfg.vocab) {
+            fprintf(stderr, "[qwen35] prompt token %d at index %zu out of range [0,%d)\n",
+                    t, i, s.cfg.vocab);
+            s.kv->free(s.seq_id);
+            return out;
+        }
+        next = forward_token(t, (int)i);
+    }
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
         if (next == s.cfg.eos_id) break;


### PR DESCRIPTION
## Summary

`Qwen35Model::generate()` fed each caller-supplied prompt id straight into `forward_token` → `launch_embedding`, whose kernel gathers `table[(size_t)id * hidden + h]` with no bounds check. A prompt id `< 0` or `>= vocab` (a tokenizer that doesn't match the model, or a bad CLI argument) indexes the embedding table out of bounds — an out-of-range device read.

This validates prompt ids against `[0, vocab)` before decoding and fails loudly — the same range condition the file's own `bench_decode()` already enforces on the token it feeds. Valid prompts (every id in `[0, vocab)`) decode identically.

Fixes #37

## Proof of speedup

N/A — robustness fix, no kernel/perf path changed. Identical output for every valid prompt.

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A — no perf change; only an out-of-range prompt id changes behavior (OOB read -> diagnosed early return).
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |