### PR TITLE
perf(gemm): default MMVQ dp4a for Q4_K decode GEMVs

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -190,9 +190,15 @@ template __global__ void gemv_q_dp4a_kernel<float>(const __nv_bfloat16*, const u
 #include <cstdlib>
 
 // SPARKINFER_MMVQ=1 -> faithful int8 dp4a for Q4_K GEMVs (matches llama.cpp).
+// Default on for decode: avoids bf16 dequant round-trips on the memory-bound path.
 static bool gemv_mmvq() {
     static int v = -1;
-    if (v < 0) { const char* e = getenv("SPARKINFER_MMVQ"); v = (e && e[0] == '1') ? 1 : 0; }
+    if (v < 0) {
+        const char* e = std::getenv("SPARKINFER_MMVQ");
+        if (!e || !e[0]) v = 1;
+        else if (e[0] == '0') v = 0;
+        else v = 1;
+    }
     return v;
 }
 


### PR DESCRIPTION
## Summary

Default the faithful **int8 dp4a MMVQ** path for Q4_K quantized GEMVs in `gemv.cu` (attention/dense projections during decode). Matches llama.cpp's MMVQ numerics; avoids bf16 dequant round-trips on the memory-bound path. Opt out with `SPARKINFER_MMVQ=0`.

Complements MoE expert-FFN MMVQ (separate PR) by covering non-MoE Q4_K GEMVs in the decode graph.

## Proof of speedup

- [ ] Tested on **RTX 5090 (sm_120)** or **RTX Spark (sm_121)**

| | decode tok/s |
|---|---:|
| before | baseline with bf16 dequant GEMV |
| after  | MMVQ dp4a default |

## Test plan

- [ ] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j && ctest --test-dir build`
- [ ] `bench/scripts/self_consistency.py` (MMVQ vs bf16 path agreement)
- [ ] `bench/scripts/accuracy.sh --download`
