### PR TITLE
fix(runtime,kernels,moe): bounds guards for GGUF dims, KV cache, generate(), scheduler, and MoE router

### DIFF
--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -12,6 +12,7 @@
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #include <cstdlib>
+#include <cstdio>
 #endif
 
 namespace sparkinfer {
@@ -149,6 +150,10 @@ void launch_moe_router(
     int normalize, cudaStream_t stream
 ) {
     if (num_tokens <= 0 || num_experts <= 0 || top_k <= 0 || top_k > num_experts) return;
+    if (top_k > 16) {
+        fprintf(stderr, "[moe] router: top_k %d exceeds max supported 16\n", top_k);
+        return;
+    }
     size_t smem = (size_t)num_experts * sizeof(float);
     // Default ON: single-pass rank-select top-k (one thread/expert). SPARKINFER_ROUTER2=0
     // restores the k-pass single-warp kernel. Falls back automatically if num_experts > 1024.

--- a/runtime/csrc/cuda/kv_ops.cu
+++ b/runtime/csrc/cuda/kv_ops.cu
@@ -24,6 +24,7 @@ __global__ void kv_append_kernel(
 
     const int pos    = write_pos[seq];
     const int blk    = pos / block_size;
+    if (blk >= max_blocks_per_seq) return;
     const int within = pos % block_size;
     const int phys   = block_table[seq * max_blocks_per_seq + blk];
     const size_t dst = ((size_t)(phys * block_size + within) * num_kv_heads + h) * head_dim + d;

--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -5,6 +5,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <climits>
 #include <vector>
 #include <fcntl.h>
 #include <unistd.h>
@@ -116,7 +117,16 @@ bool GGUF::open(const std::string& path) {
         if (!c.ok || nd > 4) { fprintf(stderr, "[gguf] tensor %s has invalid n_dims=%u (max 4)\n", in.name.c_str(), nd); return false; }
         in.t.n_dims = nd;
         long nv = 1;
-        for (uint32_t d = 0; d < nd; d++) { long e = (long)c.rd<uint64_t>(); in.t.dims[d] = e; nv *= e; }
+        bool dims_ok = true;
+        for (uint32_t d = 0; d < nd; d++) {
+            long e = (long)c.rd<uint64_t>(); in.t.dims[d] = e;
+            if (e <= 0 || nv > LONG_MAX / e) dims_ok = false;
+            else nv *= e;
+        }
+        if (!c.ok || !dims_ok) {
+            fprintf(stderr, "[gguf] tensor %s has invalid dimensions\n", in.name.c_str());
+            return false;
+        }
         in.t.ggml_type = c.rd<uint32_t>();
         in.offset = c.rd<uint64_t>();
         in.t.n_values = nv;

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -66,6 +66,10 @@ bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
     if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
     if (need > kMaxBlocksPerSeq) return false;
 
+    auto existing = impl_->seq_blocks.find(seq_id);
+    const int have = (existing != impl_->seq_blocks.end()) ? (int)existing->second.size() : 0;
+    if (have + need > kMaxBlocksPerSeq) return false;
+
     auto& blocks = impl_->seq_blocks[seq_id];
     for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -385,7 +385,16 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         return out;
     }
     int next = -1;
-    for (size_t i = 0; i < prompt.size(); i++) next = forward_token(prompt[i], (int)i);
+    for (size_t i = 0; i < prompt.size(); i++) {
+        const int t = prompt[i];
+        if (t < 0 || t >= s.cfg.vocab) {
+            fprintf(stderr, "[qwen35] prompt token %d at index %zu out of range [0,%d)\n",
+                    t, i, s.cfg.vocab);
+            s.kv->free(s.seq_id);
+            return out;
+        }
+        next = forward_token(t, (int)i);
+    }
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
         if (next == s.cfg.eos_id) break;

--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -28,7 +28,7 @@ ScheduleBatch Scheduler::schedule() {
     std::sort(ordered.begin(), ordered.end(),
               [](const SequenceGroup* a, const SequenceGroup* b) { return a->priority > b->priority; });
     for (auto* g : ordered) {
-        if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
+        if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) continue;
         for (int i = 0; i < g->num_seqs; i++) batch.decode_seq_ids.push_back(g->group_id);
         batch.total_tokens += g->num_seqs;
     }


### PR DESCRIPTION
## Summary

Adds defensive bounds checks across six open safety/liveness issues. Each fix rejects malformed or out-of-range inputs early instead of allowing OOB device/host memory access or scheduler starvation. Well-formed inputs (real Qwen3/Gemma GGUF files, normal decode paths, typical batch sizes) are unchanged.

Fixes gittensor-ai-lab/sparkinfer#29, #31, #33, #35, #37, #41.

## Changes

| Area | Issue | Fix |
|------|-------|-----|
| `runtime/src/gguf.cpp` | #29 | Reject non-positive tensor extents and signed-long product overflow when parsing dims |
| `runtime/src/scheduler.cpp` | #31 | Use `continue` instead of `break` when a group exceeds the token budget — avoids head-of-line blocking and starvation |
| `runtime/src/kv_cache.cpp` | #33 | Bound cumulative block count (`have + need`) against `kMaxBlocksPerSeq` before appending on grow |
| `runtime/csrc/cuda/kv_ops.cu` | #41 | Refuse KV append when logical block index exceeds allocated block-table capacity |
| `runtime/src/models/qwen35.cpp` | #37 | Validate prompt token ids in `[0, vocab)` before embedding gather (matches `bench_decode()` intent) |
| `kernels/csrc/cuda/moe/router.cu` | #35 | Reject `top_k > 16` before launch — `sel_logit[16]`/`sel_id[16]` are fixed-size |

## Impact

- **Robustness / liveness only** — no intentional behavior change on valid workloads
- **GGUF loader:** malformed dimension products fail loudly at parse time (complements merged data-region bounds checks in #27)
- **Scheduler:** lower-priority groups can still pack into a batch when a higher-priority group does not fit
- **Decode path:** bad CLI/tokenizer input or oversized `expert_used_count` fails early with a stderr diagnostic

## Test plan

- [ ] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j && ctest --test-dir build`
- [ ] `bench/scripts/bench.sh --download` (decode throughput unchanged on well-formed model)
- [ ] `bench/scripts/accuracy.sh --download` (correctness gate still passes)