### PR TITLE
perf(kernels): two-pass multi-block decode argmax (1 SM -> all SMs)

### DIFF
--- a/kernels/csrc/cuda/fused/model_ops.cu
+++ b/kernels/csrc/cuda/fused/model_ops.cu
@@ -21,10 +21,14 @@ __global__ void embedding_kernel(const int* __restrict__ ids,
         out[(size_t)t * hidden + h] = table[(size_t)id * hidden + h];
 }
 
+// argmax tie-break (matches the reference): keep the smaller index on equal values.
+__device__ __forceinline__ void argmax_merge(float& bv, int& bi, float ov, int oi) {
+    if (ov > bv || (ov == bv && oi < bi)) { bv = ov; bi = oi; }
+}
+
 // out_id[r] = argmax_v logits[r, v]   (greedy).  One block per row.
-// Decode runs a single row over a ~152k vocab, so size the block wide (1024 threads):
-// at bs=1 there is only one row, so more warps per block — not more blocks — is what
-// hides the global-load latency of the scan. ~165us -> tens of us.
+// Fallback path for n_rows > 1 (prefill scoring); decode (n_rows == 1) uses the
+// two-pass kernels below which scale across all SMs.
 __global__ void argmax_kernel(const float* __restrict__ logits, int* __restrict__ out_id,
                               int vocab) {
     const int row = blockIdx.x;
@@ -39,16 +43,53 @@ __global__ void argmax_kernel(const float* __restrict__ logits, int* __restrict_
     __syncthreads();
 
     for (int stride = blockDim.x / 2; stride > 0; stride >>= 1) {
-        if (threadIdx.x < stride) {
-            if (s_val[threadIdx.x + stride] > s_val[threadIdx.x] ||
-                (s_val[threadIdx.x + stride] == s_val[threadIdx.x] && s_idx[threadIdx.x + stride] < s_idx[threadIdx.x])) {
-                s_val[threadIdx.x] = s_val[threadIdx.x + stride];
-                s_idx[threadIdx.x] = s_idx[threadIdx.x + stride];
-            }
-        }
+        if (threadIdx.x < stride)
+            argmax_merge(s_val[threadIdx.x], s_idx[threadIdx.x],
+                         s_val[threadIdx.x + stride], s_idx[threadIdx.x + stride]);
         __syncthreads();
     }
     if (threadIdx.x == 0) out_id[row] = s_idx[0];
+}
+
+// ---- two-pass single-row argmax (decode) --------------------------------------
+// The bs=1 decode argmax scans one ~152k–262k row. The single-block kernel above
+// pins that scan to ONE SM (1 of 170 on a 5090) — the rest idle. This splits the
+// scan across ARGMAX_BLOCKS blocks (pass 1), each emitting one (val,idx) partial to
+// a static device buffer, then a single block reduces the partials (pass 2). Result
+// and tie-break are identical to argmax_kernel; only the scan is parallelized.
+// Static scratch => no allocation, CUDA-graph safe (argmax is captured in the graph).
+static constexpr int ARGMAX_BLOCKS = 512;
+__device__ float g_argmax_pv[ARGMAX_BLOCKS];
+__device__ int   g_argmax_pi[ARGMAX_BLOCKS];
+
+__global__ void argmax_p1_kernel(const float* __restrict__ logits, int vocab) {
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int stride = blockDim.x * gridDim.x;
+    __shared__ float s_val[256];
+    __shared__ int   s_idx[256];
+    float best = -1e30f; int bi = 0;
+    for (int v = tid; v < vocab; v += stride) if (logits[v] > best) { best = logits[v]; bi = v; }
+    s_val[threadIdx.x] = best; s_idx[threadIdx.x] = bi;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s)
+            argmax_merge(s_val[threadIdx.x], s_idx[threadIdx.x], s_val[threadIdx.x + s], s_idx[threadIdx.x + s]);
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) { g_argmax_pv[blockIdx.x] = s_val[0]; g_argmax_pi[blockIdx.x] = s_idx[0]; }
+}
+
+__global__ void argmax_p2_kernel(int* __restrict__ out_id) {
+    __shared__ float s_val[ARGMAX_BLOCKS];
+    __shared__ int   s_idx[ARGMAX_BLOCKS];
+    const int t = threadIdx.x;
+    s_val[t] = g_argmax_pv[t]; s_idx[t] = g_argmax_pi[t];
+    __syncthreads();
+    for (int s = ARGMAX_BLOCKS / 2; s > 0; s >>= 1) {
+        if (t < s) argmax_merge(s_val[t], s_idx[t], s_val[t + s], s_idx[t + s]);
+        __syncthreads();
+    }
+    if (t == 0) out_id[0] = s_idx[0];
 }
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
@@ -62,7 +103,12 @@ void launch_embedding(const int* ids, const void* table, void* out,
 }
 
 void launch_argmax(const float* logits, int* out_id, int n_rows, int vocab, cudaStream_t stream) {
-    argmax_kernel<<<n_rows, 1024, 0, stream>>>(logits, out_id, vocab);
+    if (n_rows == 1) {   // decode: parallelize the single-row scan across all SMs
+        argmax_p1_kernel<<<ARGMAX_BLOCKS, 256, 0, stream>>>(logits, vocab);
+        argmax_p2_kernel<<<1, ARGMAX_BLOCKS, 0, stream>>>(out_id);
+    } else {
+        argmax_kernel<<<n_rows, 1024, 0, stream>>>(logits, out_id, vocab);
+    }
 }
 #endif
 

--- a/kernels/tests/cpu_reference_test.cpp
+++ b/kernels/tests/cpu_reference_test.cpp
@@ -264,6 +264,39 @@ static double test_add_rmsnorm2_seq(int cols) {
     return err;  // expect 0: scalar and 8-wide grouping are bit-identical here
 }
 
+// ---------------------------------------------------------------------------
+// argmax two-pass (decode): the multi-block scan + final reduce must return the
+// SAME index as a serial argmax, including the smallest-index tie-break.
+// ---------------------------------------------------------------------------
+static double test_argmax_twopass(int vocab, int nblocks, bool ties) {
+    vector<float> L(vocab);
+    for (auto& v : L) v = frand();
+    if (ties) { for (auto& v : L) v = 0.f; for (int i : {1000 % vocab, 5, 77777 % vocab, 250}) L[i] = 7.f; }
+
+    auto merge = [](float& bv, int& bi, float ov, int oi) {
+        if (ov > bv || (ov == bv && oi < bi)) { bv = ov; bi = oi; }
+    };
+    // serial ground truth (smallest index on ties)
+    float gv = -1e30f; int gi = 0;
+    for (int v = 0; v < vocab; v++) merge(gv, gi, L[v], v);
+
+    // pass 1: nblocks grid-stride partials, each block 256 threads
+    const int BT = 256;
+    vector<float> pv(nblocks); vector<int> pi(nblocks);
+    for (int b = 0; b < nblocks; b++) {
+        float bbv = -1e30f; int bbi = 0;
+        vector<float> tv(BT, -1e30f); vector<int> ti(BT, 0);
+        for (int t = 0; t < BT; t++)
+            for (int v = b * BT + t; v < vocab; v += BT * nblocks) merge(tv[t], ti[t], L[v], v);
+        for (int t = 0; t < BT; t++) merge(bbv, bbi, tv[t], ti[t]);
+        pv[b] = bbv; pi[b] = bbi;
+    }
+    // pass 2: reduce partials
+    float rv = -1e30f; int ri = 0;
+    for (int b = 0; b < nblocks; b++) merge(rv, ri, pv[b], pi[b]);
+    return (double)std::abs(ri - gi);   // expect 0: same index as serial argmax
+}
+
 int main() {
     printf("sparkinfer kernel algorithm correctness (CPU reference)\n");
     check("attention hd128 kv1",   test_attention(128, 1),    1e-4);
@@ -281,6 +314,9 @@ int main() {
     check("rmsnorm vec8 cols128",  test_rmsnorm_vec8(128),    1e-4);
     check("add_rmsnorm2 seq c2048",test_add_rmsnorm2_seq(2048),1e-9);
     check("add_rmsnorm2 seq c1536",test_add_rmsnorm2_seq(1536),1e-9);
+    check("argmax 2pass qwen vocab",test_argmax_twopass(151936, 512, false), 0.0);
+    check("argmax 2pass gemma vocab",test_argmax_twopass(262144, 512, false), 0.0);
+    check("argmax 2pass tie-break",  test_argmax_twopass(151936, 512, true),  0.0);
     printf("%s (%d failures)\n", g_fail ? "FAILED" : "ALL PASSED", g_fail);
     return g_fail ? 1 : 0;
 }


### PR DESCRIPTION
## Summary

At bs=1 decode the LM-head argmax scans one ~152k–262k-element logit row, but the kernel launches a **single block** — pinning that scan to **1 of the RTX 5090's ~170 SMs** while the rest sit idle. This splits it into two passes: pass 1 runs `ARGMAX_BLOCKS` grid-stride blocks that each emit one `(val, idx)` partial into a **static device buffer** (no allocation → CUDA-graph safe, and argmax is captured in the decode graph); pass 2 reduces the partials in a single block. The result and the smallest-index tie-break are **identical** to the original kernel — only the scan is parallelized. The `n_rows > 1` prefill path keeps the original single-block-per-row kernel.

It targets the **shared** LM-head argmax, so it helps **both Qwen3-MoE and Gemma** (general, not a model-specific path), and it's a natural continuation of the argmax widen in #50.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**End-to-end decode bench** (`bench/scripts/bench.sh`, Qwen3-30B-A3B Q4_K_M GGUF, n=128, bs=1, source build `sm_120`, CUDA 12.8, g++-12 host):

```text
# before = main (36cd9cf)
>> GPU arch: sm_120
decode tg    : 274.58 tok/s  (3.6 ms/token, n=128, bs=1)
# 3-run median: 274.64 tok/s

# after = this branch (perf/argmax-twopass-multiblock)
>> GPU arch: sm_120
decode tg    : 277.48 tok/s  (3.6 ms/token, n=128, bs=1)
# 3-run median: 277.42 tok/s
```

| | decode tok/s |
|---|--:|
| before | **274.6** |
| after  | **277.4** (+2.8 tok/s, +1.0%) |

**Isolated kernel** (same branch, NVRTC on 5090): Qwen3 vocab 4.0×, Gemma vocab 6.65×; correctness exact vs old kernel + numpy (6 seeds incl. tie-stress). CPU reference tests (`argmax 2pass qwen` / `gemma` / `tie-break`) — all err 0.
