### PR TITLE
Enable split-K down projection by default (+6% decode)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -318,8 +318,11 @@ void launch_moe_expert_ffn_q4k(
             expert_ids, h_scratch, hidden, ffn, top_k, gate_type, up_type);
     }
 
+    // split-K down (4 warps/row) default ON: the down GEMV is occupancy-bound at bs=1
+    // (H rows = H warps -> ~25% occupancy); 4x warps in flight is +6% decode on RTX 5090,
+    // accuracy-safe (same fp math, only the partial-sum reduction order changes). =0 disables.
     static int splitk = -1;
-    if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '1') ? 1 : 0; }
+    if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '0') ? 0 : 1; }
     static int pdl = -1;
     if (pdl < 0) { const char* pv = getenv("SPARKINFER_PDL"); pdl = (pv && pv[0] == '1') ? 1 : 0; }
     if (splitk) {   // split-K down: 4 warps/row -> 4x warps in flight (occupancy lever)


### PR DESCRIPTION
## Summary

Enable the split-K `down` projection by default — a **+6% decode** follow-up to the dp4a MMVQ work (#50). The split-K kernel already shipped in-tree behind `SPARKINFER_SPLITK`; this one-line change makes it the default so the scored binary uses it.

### Why
After #50 (Q4_K dp4a) landed, `nsys` showed the MoE `down` GEMV (Q6_K experts) at ~21% of decode. It's **occupancy-bound** at bs=1: one warp per output row → only H warps in flight → ~25% occupancy. The split-K kernel runs 4 warps per row (4× warps in flight) and the A/B confirmed the classification — it's the occupancy, not bandwidth.

### Result (RTX 5090, Qwen3-30B-A3B Q4_K_M, bs=1, n=128)
- **265.3 → 281.3 tok/s (+6.0%)** vs the post-#50 default.
- Accuracy-safe: split-K only changes the **partial-sum reduction order** (same fp math). Gate vs llama.cpp: **top-1 0.970** (bar ≥0.90), **KL 0.149** (bar ≤0.50).
- `SPARKINFER_SPLITK=0` restores the one-warp path.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

```text
# post-#50 default (split-K off)
decode tg : 265.3 tok/s
# this PR (split-K on)
decode tg : 281.3 tok/s   (+6.0%)
# accuracy gate (bench/scripts/accuracy.sh vs llama.cpp)
METRIC top1=0.970000 kl=0.1487
```

| | decode tok/s |
|---|--:|
| before (#50 default) | 265.3 |
| after (this PR) | **281.3** |

One optimization, one line, accuracy-safe. Verified on a clean from-source build + ctest.
