### PR TITLE
perf(moe): default split-K down + PDL for decode on RTX 5090

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -318,10 +318,15 @@ void launch_moe_expert_ffn_q4k(
             expert_ids, h_scratch, hidden, ffn, top_k, gate_type, up_type);
     }
 
+    // split-K down: 4 warps/row -> 4x warps in flight (occupancy lever at bs=1).
+    // Default ON — accuracy-safe (same fp math, only reduction order). Opt out:
+    // SPARKINFER_SPLITK=0.
     static int splitk = -1;
-    if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '1') ? 1 : 0; }
+    if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '0') ? 0 : 1; }
+    // PDL: overlap down grid spin-up with gate_up tail. Default ON with split-K.
+    // Opt out: SPARKINFER_PDL=0. CUDA-graph safe on the qwen3 decode path.
     static int pdl = -1;
-    if (pdl < 0) { const char* pv = getenv("SPARKINFER_PDL"); pdl = (pv && pv[0] == '1') ? 1 : 0; }
+    if (pdl < 0) { const char* pv = getenv("SPARKINFER_PDL"); pdl = (pv && pv[0] == '0') ? 0 : 1; }
     if (splitk) {   // split-K down: 4 warps/row -> 4x warps in flight (occupancy lever)
         const int RPB = WPB / 4;
         dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);


### PR DESCRIPTION
## Summary

The fused MoE expert FFN already ships **split-K down** (4 warps/output row → higher occupancy at bs=1) and **PDL** (programmatic dependent launch: overlap the down kernel's grid spin-up with gate_up's tail), but both were **opt-in** via `SPARKINFER_SPLITK=1` / `SPARKINFER_PDL=1`. This flips them to **default-ON** with opt-out (`SPARKINFER_SPLITK=0` / `SPARKINFER_PDL=0`).

Accuracy-safe: same fp math, only reduction order changes. CUDA-graph safe on the qwen3 decode path (verified via `qwen3_gguf_bench`).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**End-to-end decode bench** (`bench/scripts/bench.sh` / `qwen3_gguf_bench`, Qwen3-30B-A3B Q4_K_M GGUF, n=128, bs=1, source build `sm_120`, CUDA 12.8, g++-12 host):

```text
# before = main (42d2d96, split-K/PDL opt-in)
decode tg    : 277.40 / 277.20 / 277.27 tok/s  (median 277.3)

# after = this branch (split-K + PDL default ON)
decode tg    : 279.72 / 279.80 / 279.80 tok/s  (median 279.8)
```

| | decode tok/s |
|---|--:|
| before | **277.3** |
| after  | **279.8** (+2.5 tok/s, +0.9%) |
