### PR TITLE
Parallelize flash-decode combine + n_splits=32 (+2.7% decode)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -76,37 +76,70 @@ __global__ void fa_split_kernel(
     for (int e = 0; e < ELEMS; e++) part_acc[(size_t)idx * HEAD_DIM + lane + e * 32] = acc[e];
 }
 
-template <int HEAD_DIM>
+// Combine the split partials with DG x NW parallelism over the 1-block-per-head
+// original (which idled at ~2% occupancy with a serial n_splits loop). DG head-dim
+// groups -> DG x more blocks; NW warps per block each fold a 1/NW stripe of the
+// splits, then a shared-memory log-sum-exp merge across warps. grid=(heads*DG,seqs).
+template <int HEAD_DIM, int DG, int NW>
 __global__ void fa_combine_kernel(
     const float* __restrict__ part_m, const float* __restrict__ part_l,
     const float* __restrict__ part_acc, __nv_bfloat16* __restrict__ out,
     int num_q_heads, int n_splits
 ) {
-    constexpr int ELEMS = HEAD_DIM / 32;
-    const int seq = blockIdx.y, qh = blockIdx.x, lane = threadIdx.x;
+    constexpr int ELEMS = HEAD_DIM / (32 * DG);
+    const int seq = blockIdx.y, qh = blockIdx.x / DG, dg = blockIdx.x % DG;
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
     const int idxbase = (seq * num_q_heads + qh) * n_splits;
+    const int doff = dg * (HEAD_DIM / DG) + lane;     // first head-dim this lane owns
+
+    // per-warp local combine over its split stripe (local max -> weighted l/acc)
+    float lm = -1e30f;
+    for (int s = warp; s < n_splits; s += NW) lm = fmaxf(lm, part_m[idxbase + s]);
+    float ll = 0.f, lacc[ELEMS];
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) lacc[e] = 0.f;
+    for (int s = warp; s < n_splits; s += NW) {
+        const float sc = __expf(part_m[idxbase + s] - lm);
+        ll += part_l[idxbase + s] * sc;
+        #pragma unroll
+        for (int e = 0; e < ELEMS; e++) lacc[e] += sc * part_acc[(size_t)(idxbase + s) * HEAD_DIM + doff + e * 32];
+    }
+
+    __shared__ float s_m[NW], s_l[NW], s_acc[NW][32 * ELEMS];
+    if (lane == 0) { s_m[warp] = lm; s_l[warp] = ll; }
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) s_acc[warp][lane * ELEMS + e] = lacc[e];
+    __syncthreads();
+    if (warp != 0) return;
 
     float gm = -1e30f;
-    for (int s = 0; s < n_splits; s++) gm = fmaxf(gm, part_m[idxbase + s]);
+    #pragma unroll
+    for (int w = 0; w < NW; w++) gm = fmaxf(gm, s_m[w]);
     float gl = 0.f, acc[ELEMS];
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
-    for (int s = 0; s < n_splits; s++) {
-        const float ms = part_m[idxbase + s], ls = part_l[idxbase + s];
-        const float sc = __expf(ms - gm);
-        gl += ls * sc;
+    #pragma unroll
+    for (int w = 0; w < NW; w++) {
+        const float sc = __expf(s_m[w] - gm);
+        gl += s_l[w] * sc;
         #pragma unroll
-        for (int e = 0; e < ELEMS; e++) acc[e] += sc * part_acc[(size_t)(idxbase + s) * HEAD_DIM + lane + e * 32];
+        for (int e = 0; e < ELEMS; e++) acc[e] += sc * s_acc[w][lane * ELEMS + e];
     }
     const float inv = (gl > 0.f) ? (1.f / gl) : 0.f;
     __nv_bfloat16* op = out + (size_t)(seq * num_q_heads + qh) * HEAD_DIM;
     #pragma unroll
-    for (int e = 0; e < ELEMS; e++) op[lane + e * 32] = __float2bfloat16(acc[e] * inv);
+    for (int e = 0; e < ELEMS; e++) op[doff + e * 32] = __float2bfloat16(acc[e] * inv);
 }
 
+#ifndef FA_COMBINE_DG
+#define FA_COMBINE_DG 4     // head-dim groups (DG x blocks); sweepable
+#endif
+#ifndef FA_COMBINE_NW
+#define FA_COMBINE_NW 4     // warps/block folding the split stripes; sweepable
+#endif
 template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
-template __global__ void fa_combine_kernel<128>(const float*, const float*, const float*, __nv_bfloat16*, int, int);
+template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -123,8 +156,8 @@ void launch_flash_decode_split(
         reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
         reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
-    dim3 g2(num_q_heads, num_seqs);
-    fa_combine_kernel<128><<<g2, 32, 0, stream>>>(
+    dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
+    fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
         part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits);
     (void)head_dim;
 }

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -73,7 +73,7 @@ struct Qwen35Model::Impl {
     float *mf_logits = nullptr, *mf_weights = nullptr, *mf_h = nullptr, *mf_out = nullptr;
     int   *mf_ids = nullptr, *mf_counts = nullptr;
     // flash-decoding (KV-split) attention partials
-    int n_splits = 16;
+    int n_splits = 32;
     float *fa_m = nullptr, *fa_l = nullptr, *fa_acc = nullptr;
     // pre-quantized Q8_1 activation (computed once per projection input, shared across Q/K/V)
     signed char* aq8 = nullptr; float *aq8_d = nullptr, *aq8_s = nullptr;


### PR DESCRIPTION
## Summary

Parallelize the flash-decoding **combine** kernel and raise `n_splits` 16→32 — **+2.7% decode** on top of the merged #59 attention mmvq. ncu showed flash-decoding was ~16% of decode but catastrophically occupancy-starved: `fa_combine` ran 1 block per q-head (32 blocks, ~2% occupancy, a serial `n_splits` reduction) and `fa_split` filled only ~5%.

### What changed
- **combine** now runs `DG=4` head-dim groups × `NW=4` warps/block: 4× more blocks + a shared-memory log-sum-exp merge that folds the split reduction 4-ways instead of one serial loop. 32 → 128 blocks, ~2% → ~8% occupancy, 6.9µs → 3.9µs.
- a cheap combine makes more KV-splits worthwhile, so **`n_splits` 16 → 32** (re-swept: 16=301, 24=304, **32=306**, 48=305 tok/s). The split kernel parallelizes further and the combine absorbs the extra partials.

`fa_combine_kernel` is templated `<HEAD_DIM, DG, NW>`; `SPARKINFER_NSPLITS` still overrides the split count at runtime. The NW-way merge re-associates the fp reduction (top-1 0.99 → 0.97, still well clear of the 0.90 bar).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 297.9 |
| after (this PR) | 305.9 |

Accuracy gate vs llama.cpp (`bench/scripts/accuracy.sh`): `top1=0.970, KL=0.134` (bar: top1≥0.90).

```text
# before (main, with #59 merged)
decode tg : 297.9 tok/s   (n=128, bs=1)
# after (this PR)
decode tg : 305.9 tok/s   (n=128, bs=1)   (+2.7%)
```
