### PR TITLE
perf(moe): __ldg quantized weight reads in expert FFN decode (+1.3%)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -44,15 +44,22 @@ __device__ __forceinline__ void si_pdl_sync() {
 __device__ __forceinline__ float q4kf_h2f(const unsigned char* p) {
     __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
 }
+// Read-only texture/L2 path for quantized weight bytes (decode is weight-bandwidth bound).
+__device__ __forceinline__ unsigned char q4kf_ldg_u8(const unsigned char* p) { return __ldg(p); }
+__device__ __forceinline__ signed char q4kf_ldg_i8(const signed char* p) { return __ldg(p); }
+__device__ __forceinline__ float q4kf_h2f_ldg(const unsigned char* p) {
+    __half h; unsigned short v = __ldg(reinterpret_cast<const unsigned short*>(p));
+    *((unsigned short*)&h) = v; return __half2float(h);
+}
+__device__ __forceinline__ void q4kf_scale_min_ldg(int j, const unsigned char* q, int* d, int* m) {
+    if (j < 4) { *d = q4kf_ldg_u8(q + j) & 63; *m = q4kf_ldg_u8(q + j + 4) & 63; }
+    else { *d = (q4kf_ldg_u8(q + j + 4) & 0xF) | ((q4kf_ldg_u8(q + j - 4) >> 6) << 4);
+           *m = (q4kf_ldg_u8(q + j + 4) >> 4)  | ((q4kf_ldg_u8(q + j)     >> 6) << 4); }
+}
 __device__ __forceinline__ float q4kf_wsum(float v) {
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffff, v, m);
     return v;
-}
-__device__ __forceinline__ void q4kf_scale_min(int j, const unsigned char* q, int* d, int* m) {
-    if (j < 4) { *d = q[j] & 63; *m = q[j + 4] & 63; }
-    else { *d = (q[j + 4] & 0xF) | ((q[j - 4] >> 6) << 4);
-           *m = (q[j + 4] >> 4)  | ((q[j]     >> 6) << 4); }
 }
 __device__ __forceinline__ float q4kf_silu(float x) { return x / (1.f + __expf(-x)); }
 
@@ -63,29 +70,29 @@ __device__ __forceinline__ float q4kf_deq_dot(int t, const unsigned char* b, con
     float p = 0.f;
     if (t == 14) {   // Q6_K
         const unsigned char* ql = b; const unsigned char* qh = b + 128;
-        const signed char* sc = (const signed char*)(b + 192); float d = q4kf_h2f(b + 208);
+        const signed char* sc = (const signed char*)(b + 192); float d = q4kf_h2f_ldg(b + 208);
         #pragma unroll
         for (int nn = 0; nn < 2; nn++) {
             const unsigned char* qln = ql + nn*64; const unsigned char* qhn = qh + nn*32; const signed char* scn = sc + nn*8;
             int is = lane / 16;
-            int q1 = (int)((qln[lane]    & 0xF) | (((qhn[lane] >> 0) & 3) << 4)) - 32;
-            int q2 = (int)((qln[lane+32] & 0xF) | (((qhn[lane] >> 2) & 3) << 4)) - 32;
-            int q3 = (int)((qln[lane]    >> 4)  | (((qhn[lane] >> 4) & 3) << 4)) - 32;
-            int q4 = (int)((qln[lane+32] >> 4)  | (((qhn[lane] >> 6) & 3) << 4)) - 32;
-            p += d * scn[is+0] * q1 * sx[nn*128 + lane];
-            p += d * scn[is+2] * q2 * sx[nn*128 + lane + 32];
-            p += d * scn[is+4] * q3 * sx[nn*128 + lane + 64];
-            p += d * scn[is+6] * q4 * sx[nn*128 + lane + 96];
+            int q1 = (int)((q4kf_ldg_u8(qln + lane)    & 0xF) | (((q4kf_ldg_u8(qhn + lane) >> 0) & 3) << 4)) - 32;
+            int q2 = (int)((q4kf_ldg_u8(qln + lane+32) & 0xF) | (((q4kf_ldg_u8(qhn + lane) >> 2) & 3) << 4)) - 32;
+            int q3 = (int)((q4kf_ldg_u8(qln + lane)    >> 4)  | (((q4kf_ldg_u8(qhn + lane) >> 4) & 3) << 4)) - 32;
+            int q4 = (int)((q4kf_ldg_u8(qln + lane+32) >> 4)  | (((q4kf_ldg_u8(qhn + lane) >> 6) & 3) << 4)) - 32;
+            p += d * (float)q4kf_ldg_i8(scn + is+0) * q1 * sx[nn*128 + lane];
+            p += d * (float)q4kf_ldg_i8(scn + is+2) * q2 * sx[nn*128 + lane + 32];
+            p += d * (float)q4kf_ldg_i8(scn + is+4) * q3 * sx[nn*128 + lane + 64];
+            p += d * (float)q4kf_ldg_i8(scn + is+6) * q4 * sx[nn*128 + lane + 96];
         }
     } else {         // Q4_K
-        float d = q4kf_h2f(b), dmin = q4kf_h2f(b + 2);
+        float d = q4kf_h2f_ldg(b), dmin = q4kf_h2f_ldg(b + 2);
         const unsigned char* sc = b + 4; const unsigned char* qs = b + 16;
         #pragma unroll
         for (int g = 0; g < 4; g++) {
             int s1, m1, s2, m2;
-            q4kf_scale_min(2*g, sc, &s1, &m1); q4kf_scale_min(2*g+1, sc, &s2, &m2);
+            q4kf_scale_min_ldg(2*g, sc, &s1, &m1); q4kf_scale_min_ldg(2*g+1, sc, &s2, &m2);
             float d1 = d*s1, mm1 = dmin*m1, d2 = d*s2, mm2 = dmin*m2;
-            unsigned char qb = qs[g*32 + lane];
+            unsigned char qb = q4kf_ldg_u8(qs + g*32 + lane);
             p += (d1 * (qb & 0xF) - mm1) * sx[g*64 + lane];
             p += (d2 * (qb >> 4)  - mm2) * sx[g*64 + 32 + lane];
         }
@@ -184,13 +191,13 @@ __global__ void gate_up_q4k_mmvq_kernel(
         // gate
         {
             const unsigned char* blk = gbase + (size_t)super * 144;
-            float d = q4kf_h2f(blk), dmin = q4kf_h2f(blk + 2);
-            int scd, scm; q4kf_scale_min(sib, blk + 4, &scd, &scm);
+            float d = q4kf_h2f_ldg(blk), dmin = q4kf_h2f_ldg(blk + 2);
+            int scd, scm; q4kf_scale_min_ldg(sib, blk + 4, &scd, &scm);
             const int* q = reinterpret_cast<const int*>(blk + 16 + boff);
             int sumi = 0;
             #pragma unroll
             for (int k = 0; k < 8; k++) {
-                int w = hi ? ((q[k] >> 4) & 0x0F0F0F0F) : (q[k] & 0x0F0F0F0F);
+                int w = hi ? ((__ldg(q + k) >> 4) & 0x0F0F0F0F) : (__ldg(q + k) & 0x0F0F0F0F);
                 sumi = __dp4a(w, aint[k], sumi);
             }
             acc_g += d * (float)scd * xd * (float)sumi - dmin * (float)scm * xs;
@@ -198,13 +205,13 @@ __global__ void gate_up_q4k_mmvq_kernel(
         // up
         {
             const unsigned char* blk = ubase + (size_t)super * 144;
-            float d = q4kf_h2f(blk), dmin = q4kf_h2f(blk + 2);
-            int scd, scm; q4kf_scale_min(sib, blk + 4, &scd, &scm);
+            float d = q4kf_h2f_ldg(blk), dmin = q4kf_h2f_ldg(blk + 2);
+            int scd, scm; q4kf_scale_min_ldg(sib, blk + 4, &scd, &scm);
             const int* q = reinterpret_cast<const int*>(blk + 16 + boff);
             int sumi = 0;
             #pragma unroll
             for (int k = 0; k < 8; k++) {
-                int w = hi ? ((q[k] >> 4) & 0x0F0F0F0F) : (q[k] & 0x0F0F0F0F);
+                int w = hi ? ((__ldg(q + k) >> 4) & 0x0F0F0F0F) : (__ldg(q + k) & 0x0F0F0F0F);
                 sumi = __dp4a(w, aint[k], sumi);
             }
             acc_u += d * (float)scd * xd * (float)sumi - dmin * (float)scm * xs;

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -66,7 +66,12 @@ __device__ __forceinline__ float q4kf_silu(float x) { return x / (1.f + __expf(-
 // Dequant a 256-block in registers and return THIS lane's partial dot with sx[0..255]
 // (8 weights/lane). No shared round-trip — caller warp-reduces the accumulated partials
 // once at the end. Same math as warp_deq + the shared dot, just fused and register-resident.
+// Quantized weight bytes go through __ldg (read-only cache). GlobalH=true additionally
+// routes the activation reads through __ldg — used by the down pass, whose activation
+// (h_scratch) lives in global memory, not shared.
+template <bool GlobalH = false>
 __device__ __forceinline__ float q4kf_deq_dot(int t, const unsigned char* b, const float* sx, int lane) {
+    auto hx = [&](int i) -> float { return GlobalH ? __ldg(sx + i) : sx[i]; };
     float p = 0.f;
     if (t == 14) {   // Q6_K
         const unsigned char* ql = b; const unsigned char* qh = b + 128;
@@ -79,10 +84,10 @@ __device__ __forceinline__ float q4kf_deq_dot(int t, const unsigned char* b, con
             int q2 = (int)((q4kf_ldg_u8(qln + lane+32) & 0xF) | (((q4kf_ldg_u8(qhn + lane) >> 2) & 3) << 4)) - 32;
             int q3 = (int)((q4kf_ldg_u8(qln + lane)    >> 4)  | (((q4kf_ldg_u8(qhn + lane) >> 4) & 3) << 4)) - 32;
             int q4 = (int)((q4kf_ldg_u8(qln + lane+32) >> 4)  | (((q4kf_ldg_u8(qhn + lane) >> 6) & 3) << 4)) - 32;
-            p += d * (float)q4kf_ldg_i8(scn + is+0) * q1 * sx[nn*128 + lane];
-            p += d * (float)q4kf_ldg_i8(scn + is+2) * q2 * sx[nn*128 + lane + 32];
-            p += d * (float)q4kf_ldg_i8(scn + is+4) * q3 * sx[nn*128 + lane + 64];
-            p += d * (float)q4kf_ldg_i8(scn + is+6) * q4 * sx[nn*128 + lane + 96];
+            p += d * (float)q4kf_ldg_i8(scn + is+0) * q1 * hx(nn*128 + lane);
+            p += d * (float)q4kf_ldg_i8(scn + is+2) * q2 * hx(nn*128 + lane + 32);
+            p += d * (float)q4kf_ldg_i8(scn + is+4) * q3 * hx(nn*128 + lane + 64);
+            p += d * (float)q4kf_ldg_i8(scn + is+6) * q4 * hx(nn*128 + lane + 96);
         }
     } else {         // Q4_K
         float d = q4kf_h2f_ldg(b), dmin = q4kf_h2f_ldg(b + 2);
@@ -93,8 +98,8 @@ __device__ __forceinline__ float q4kf_deq_dot(int t, const unsigned char* b, con
             q4kf_scale_min_ldg(2*g, sc, &s1, &m1); q4kf_scale_min_ldg(2*g+1, sc, &s2, &m2);
             float d1 = d*s1, mm1 = dmin*m1, d2 = d*s2, mm2 = dmin*m2;
             unsigned char qb = q4kf_ldg_u8(qs + g*32 + lane);
-            p += (d1 * (qb & 0xF) - mm1) * sx[g*64 + lane];
-            p += (d2 * (qb >> 4)  - mm2) * sx[g*64 + 32 + lane];
+            p += (d1 * (qb & 0xF) - mm1) * hx(g*64 + lane);
+            p += (d2 * (qb >> 4)  - mm2) * hx(g*64 + 32 + lane);
         }
     }
     return p;
@@ -113,7 +118,7 @@ __global__ void gate_up_q4k_kernel(
     extern __shared__ float s_x[];           // s_x[H]
     const int ts = blockIdx.x, tok = ts / top_k;
     const int e = expert_ids[ts];
-    for (int i = threadIdx.x; i < H; i += blockDim.x) s_x[i] = __bfloat162float(input[(size_t)tok * H + i]);
+    for (int i = threadIdx.x; i < H; i += blockDim.x) s_x[i] = __bfloat162float(__ldg(input + (size_t)tok * H + i));
     __syncthreads();
 
     const int lane = threadIdx.x % 32;
@@ -161,7 +166,7 @@ __global__ void gate_up_q4k_mmvq_kernel(
 
     // quantize activation -> Q8_1, one 32-block per warp-iteration (lane = element)
     for (int b = warpId; b < nsb; b += WPB) {
-        float xv = __bfloat162float(input[(size_t)tok * H + b * 32 + lane]);
+        float xv = __bfloat162float(__ldg(input + (size_t)tok * H + b * 32 + lane));
         float a = fabsf(xv);
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
@@ -239,12 +244,12 @@ __global__ void down_q6k_kernel(
     float acc = 0.f;   // sum_j w_j * <h_j, down[e_j, hh]> ; fold w into the per-lane partials
     for (int j = 0; j < top_k; j++) {
         const int ts = token * top_k + j;
-        const int e = expert_ids[ts];
-        const float w = expert_weights[ts];
+        const int e = __ldg(expert_ids + ts);
+        const float w = __ldg(expert_weights + ts);
         const unsigned char* dbase = down_q + ((size_t)e * H + hh) * nblk * dbb;
         const float* hbase = h_scratch + (size_t)ts * F;
         for (int blk = 0; blk < nblk; blk++)
-            acc += w * q4kf_deq_dot(down_type, dbase + (size_t)blk * dbb, hbase + blk*256, lane);
+            acc += w * q4kf_deq_dot<true>(down_type, dbase + (size_t)blk * dbb, hbase + blk*256, lane);
     }
     acc = q4kf_wsum(acc);
     if (lane == 0) output[(size_t)token * H + hh] = __float2bfloat16(acc);
@@ -275,8 +280,8 @@ __global__ void down_q6k_splitk_kernel(
             const int ts = token * top_k + j, e = expert_ids[ts];
             const float w = expert_weights[ts];
             const unsigned char* drow = down_q + ((size_t)e * H + hh) * nblk * dbb;
-            acc += w * q4kf_deq_dot(down_type, drow + (size_t)blk * dbb,
-                                    h_scratch + (size_t)ts * F + blk * 256, lane);
+            acc += w * q4kf_deq_dot<true>(down_type, drow + (size_t)blk * dbb,
+                                          h_scratch + (size_t)ts * F + blk * 256, lane);
         }
         acc = q4kf_wsum(acc);
         if (lane == 0) s_part[hh_local][split] = acc;


### PR DESCRIPTION
## Summary

Route MoE expert-FFN quantized **weight** reads through `__ldg` in `expert_ffn_q4k.cu` (Q4_K gate/up MMVQ + Q6_K down dequant). Decode is weight-bandwidth bound; this mirrors the flash-decode `__ldg` pattern from #58 but targets the MoE GEMV path. Math is unchanged — bit-exact vs main (100% greedy argmax agreement, self-KL = 0).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh --tokens 256`):

| | decode tok/s |
|---|--:|
| before (main) | 288.21 |
| after (this PR) | 291.86 |

```text
=== sparkinfer — decode (n=256, bs=1) ===
before: decode tg    : 288.21 tok/s  (3.5 ms/token, n=256, bs=1)
after:  decode tg    : 291.86 tok/s  (3.4 ms/token, n=256, bs=1)

self_consistency (before vs after build):
  argmax agreement     : 100/100 = 1.0000
  mean self-KL(a||b)   : 0.000000 nats
```
