### PR TITLE
fix(moe): bounds-check layer and reject null weights in MoEEngine::forward (#55)

### DIFF
--- a/moe/src/engine.cpp
+++ b/moe/src/engine.cpp
@@ -53,7 +53,22 @@ public:
                     num_tokens, max_tokens_);
             return;
         }
+        if (layer < 0 || layer >= (int)weights_.size()) {
+            // set_layer_weights() bounds-checks on write; mirror it here so a bad
+            // layer index from a caller bug can't index weights_[] out of bounds.
+            fprintf(stderr, "[moe] forward: layer %d out of range [0, %d) — skipping\n",
+                    layer, (int)weights_.size());
+            return;
+        }
         const LayerWeights& w = weights_[layer];
+        if (!w.router_w || !w.gate_w || !w.up_w || !w.down_w) {
+            // Weights for this layer were never registered (default LayerWeights is
+            // all-null); launching router/FFN kernels on null device pointers is an
+            // illegal access. Refuse instead.
+            fprintf(stderr, "[moe] forward: layer %d has unregistered (null) weights — skipping\n",
+                    layer);
+            return;
+        }
         const int E = cfg_.num_experts, K = cfg_.top_k;
         const int H = cfg_.hidden_dim, F = cfg_.ffn_dim;
 


### PR DESCRIPTION
## Summary

`MoEEngine::forward()` indexed `weights_[layer]` without validating `layer`, and dispatched router/FFN kernels even when a layer's weights were never registered (default `LayerWeights` is all-null device pointers). This adds two host-side guards before the `weights_[layer]` access ? a `[0, num_layers)` bounds check and a null-pointer check ? mirroring the existing `num_tokens` scratch-capacity guard (early `fprintf` + `return`, no host sync, CUDA-graph safe). `set_layer_weights()` already bounds-checks on write; this closes the read side.

Fixes the out-of-bounds host read / null device-pointer launch described in #55.

Closes #55

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A ? correctness/safety fix (a defensive guard on bad caller input). It adds two integer comparisons + a null check on the bs=1 decode path, before any kernel launch, so it has no measurable effect on decode throughput and changes no model output. Per CONTRIBUTING this is a non-speedup PR (scores 0) but mirrors the merged guard PRs (#19 num_tokens, #21 decode-runner, #22 router).

**Benchmark log** (before ? after):

```text
N/A ? no kernel or numeric change; output is bit-identical.
```

| | decode tok/s |
|---|--:|
| before | unchanged |
| after  | unchanged |
