### PR TITLE
perf(moe): skip the unused per-expert token count in single-token decode (+6% decode)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -261,8 +261,16 @@ int Qwen35Model::forward_token(int token_id, int position) {
 
         if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
             kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
-            cu(cudaMemsetAsync(s.mf_counts, 0, c.n_experts * sizeof(int), st), "mf counts");
-            kernels::launch_moe_router(s.mf_logits, s.mf_ids, s.mf_weights, s.mf_counts,
+            // The per-expert token counts only feed the batched-dispatch sort; the single-token
+            // decode expert FFN reads ids/weights directly and never touches them. Zeroing that
+            // buffer is a per-layer memset node in the replayed decode graph whose fixed cost far
+            // outweighs the handful of atomics that fill it, so skip the count on this path.
+            // SPARKINFER_MOE_COUNTS=1 restores the memset + on-device counting.
+            static int moe_counts = -1;
+            if (moe_counts < 0) { const char* mc = getenv("SPARKINFER_MOE_COUNTS"); moe_counts = (mc && mc[0] == '1') ? 1 : 0; }
+            if (moe_counts) cu(cudaMemsetAsync(s.mf_counts, 0, c.n_experts * sizeof(int), st), "mf counts");
+            kernels::launch_moe_router(s.mf_logits, s.mf_ids, s.mf_weights,
+                                       moe_counts ? s.mf_counts : nullptr,
                                        1, c.n_experts, c.top_k, 1, st);
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,


### PR DESCRIPTION
## Summary

The MoE router writes a per-expert token count (`tokens_per_expert`) that only the batched-dispatch sort consumes. At decode the path is single-token and the fused expert FFN reads `mf_ids` and `mf_weights` directly, so that count buffer is never read. Zeroing it every layer is a `cudaMemsetAsync` baked into the replayed decode CUDA graph as its own node, and at this size the node's fixed cost dwarfs the handful of atomics that fill it. Skipping the count on the single-token path removes one memset node per layer (48 per token) with no change to the model output.

## What changed

`Qwen35Model::forward_token` no longer zeroes `mf_counts` and passes a null counter to `launch_moe_router` on the GGUF fused MoE path. The top-k kernel already guards the counter (`if (tokens_per_expert ...)`), so the on-device counting is simply skipped. Only dead work is removed, so the selected experts and their softmax weights stay bit-for-bit identical. `SPARKINFER_MOE_COUNTS=1` restores the memset plus the atomic counting for parity checks.

A node-trace breakdown attributes nearly all of the gain to the memset: dropping the memset alone is about +5.8%, dropping only the atomics is about +0.4%, which confirms the cost was the graph node rather than the counting work.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`, n=128, bs=1):

| | decode tok/s |
|---|--:|
| before (main) | 331.4 |
| after (this PR) | 351.8 |

About +6.1% decode, stable across three alternating runs. The accuracy gate vs llama.cpp (`bench/scripts/accuracy.sh`) is unchanged from baseline because the change removes dead work only: top-1 `0.970`, KL `0.151` nats. `ctest` 5/5, `compute-sanitizer --tool memcheck` clean (0 errors).

```text
# before (baseline: SPARKINFER_MOE_COUNTS=1)
decode tg    : 331.47 tok/s  (3.0 ms/token, n=128, bs=1)
decode tg    : 331.16 tok/s  (3.0 ms/token, n=128, bs=1)
decode tg    : 331.46 tok/s  (3.0 ms/token, n=128, bs=1)
# after (this PR, default)
decode tg    : 351.71 tok/s  (2.8 ms/token, n=128, bs=1)
decode tg    : 351.76 tok/s  (2.8 ms/token, n=128, bs=1)
decode tg    : 351.88 tok/s  (2.8 ms/token, n=128, bs=1)
```
