### PR TITLE
runtime: GPU observability — heat (°C) + VRAM (+ power/clock)

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -26,6 +26,17 @@ file(GLOB_RECURSE RUNTIME_SRC "src/*.cpp" "csrc/cuda/*.cu")
 add_library(sparkinfer_runtime SHARED ${RUNTIME_SRC})
 target_include_directories(sparkinfer_runtime PUBLIC include)
 target_link_libraries(sparkinfer_runtime PUBLIC sparkinfer_moe sparkinfer_kernels CUDA::cudart)
+
+# GPU observability (heat/power/clock) uses NVML when available; VRAM works without it. NVML ships
+# with the CUDA toolkit as CUDA::nvml — link + flag it when present so the build degrades cleanly
+# on boxes/toolkits without the NVML stub.
+if(TARGET CUDA::nvml)
+    target_link_libraries(sparkinfer_runtime PUBLIC CUDA::nvml)
+    target_compile_definitions(sparkinfer_runtime PRIVATE SPARKINFER_HAVE_NVML)
+    message(STATUS "sparkinfer: NVML found — GPU temperature/power observability enabled")
+else()
+    message(STATUS "sparkinfer: NVML not found — GPU observability limited to VRAM")
+endif()
 target_compile_options(sparkinfer_runtime PRIVATE
     $<$<COMPILE_LANGUAGE:CUDA>:-O3;--use_fast_math;-lineinfo>)
 set_target_properties(sparkinfer_runtime PROPERTIES POSITION_INDEPENDENT_CODE ON)
@@ -39,7 +50,8 @@ if(BUILD_EXAMPLES)
     add_executable(qwen35_generate examples/qwen35_generate.cpp)
     target_link_libraries(qwen35_generate PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(qwen3_gguf_generate examples/qwen3_gguf_generate.cpp)
-    target_link_libraries(qwen3_gguf_generate PRIVATE sparkinfer_runtime CUDA::cudart)
+    find_package(Threads REQUIRED)   # background GPU-observability sampler uses std::thread
+    target_link_libraries(qwen3_gguf_generate PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)
     add_executable(qwen3_gguf_bench examples/qwen3_gguf_bench.cpp)
     target_link_libraries(qwen3_gguf_bench PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(qwen3_gguf_score examples/qwen3_gguf_score.cpp)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -10,6 +10,7 @@ option(BUILD_TESTS    "Build unit / integration tests" ON)
 option(BUILD_EXAMPLES "Build example programs"          ON)
 
 find_package(CUDAToolkit REQUIRED)
+find_package(Threads REQUIRED)   # thermal governor's inter-token pace uses std::this_thread
 
 # This repo is the integrator: pull in sparkinfer-kernels and sparkinfer-moe.
 # In a superbuild the targets may already exist; standalone, add the siblings.
@@ -25,7 +26,7 @@ include_directories(include)
 file(GLOB_RECURSE RUNTIME_SRC "src/*.cpp" "csrc/cuda/*.cu")
 add_library(sparkinfer_runtime SHARED ${RUNTIME_SRC})
 target_include_directories(sparkinfer_runtime PUBLIC include)
-target_link_libraries(sparkinfer_runtime PUBLIC sparkinfer_moe sparkinfer_kernels CUDA::cudart)
+target_link_libraries(sparkinfer_runtime PUBLIC sparkinfer_moe sparkinfer_kernels CUDA::cudart Threads::Threads)
 
 # GPU observability (heat/power/clock) uses NVML when available; VRAM works without it. NVML ships
 # with the CUDA toolkit as CUDA::nvml — link + flag it when present so the build degrades cleanly

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -57,4 +57,6 @@ if(BUILD_EXAMPLES)
     target_link_libraries(qwen3_gguf_bench PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(qwen3_gguf_score examples/qwen3_gguf_score.cpp)
     target_link_libraries(qwen3_gguf_score PRIVATE sparkinfer_runtime CUDA::cudart)
+    add_executable(thermal_sweep examples/thermal_sweep.cpp)   # force each thermal mode, measure W/°C/tok/s
+    target_link_libraries(thermal_sweep PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)
 endif()

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -73,9 +73,16 @@ int main(int argc, char** argv) {
     size_t freeb=0, totb=0; cudaMemGetInfo(&freeb,&totb);
 
     double toks = model.bench_decode(8, n_tokens);
+    auto gpu = sparkinfer::query_gpu_stats();   // sampled right after the decode loop — near peak heat
     printf("\n=== sparkinfer bench (%s) ===\n", gguf_mode ? "Q4_K_M native" : "bf16");
     printf("model        : Qwen3-30B-A3B  (%d layers, %d experts top-%d)\n", cfg.n_layers, cfg.n_experts, cfg.top_k);
     printf("VRAM used    : %.1f GB\n", (totb - freeb) / 1e9);
     printf("decode tg    : %.2f tok/s  (%.1f ms/token, n=%d, bs=1)\n", toks, 1000.0 / toks, n_tokens);
+    if (gpu.valid && gpu.temp_c >= 0) {
+        printf("GPU          : %d°C", gpu.temp_c);
+        if (gpu.power_w      >= 0) printf(" · %d W", gpu.power_w);
+        if (gpu.sm_clock_mhz >= 0) printf(" · %d MHz", gpu.sm_clock_mhz);
+        printf(" (peak under load)\n");
+    }
     return 0;
 }

--- a/runtime/examples/qwen3_gguf_generate.cpp
+++ b/runtime/examples/qwen3_gguf_generate.cpp
@@ -11,6 +11,7 @@
 #include "sparkinfer/gguf.h"
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/moe/engine.h"
+#include "sparkinfer/thermal_governor.h"
 
 #include <cuda_runtime.h>
 #include <cstdio>
@@ -97,12 +98,30 @@ int main(int argc, char** argv) {
         }
     });
 
-    auto out = model.generate(prompt, max_new);
+    // Thermally-adaptive decode pacing (opt-in via SPARKINFER_THERMAL=1). Accuracy-preserving —
+    // it only slows token emission when the GPU runs hot. Thresholds/paces overridable via env.
+    auto envi = [](const char* k, int d){ const char* v = getenv(k); return v ? atoi(v) : d; };
+    sparkinfer::ThermalGovernor::Config tg;
+    tg.enabled         = envi("SPARKINFER_THERMAL", 0) != 0;
+    tg.balanced_c      = envi("SPARKINFER_THERMAL_BALANCED_C", tg.balanced_c);
+    tg.safe_c          = envi("SPARKINFER_THERMAL_SAFE_C",     tg.safe_c);
+    tg.emergency_c     = envi("SPARKINFER_THERMAL_EMERGENCY_C", tg.emergency_c);
+    tg.log_transitions = true;
+    sparkinfer::ThermalGovernor gov(tg);
+    if (tg.enabled)
+        printf("thermal: ON (turbo<%d°C, balanced≥%d, safe≥%d, emergency≥%d)\n",
+               tg.balanced_c, tg.balanced_c, tg.safe_c, tg.emergency_c);
+
+    auto out = model.generate(prompt, max_new, tg.enabled ? &gov : nullptr);
     sampling.store(false, std::memory_order_relaxed);
     sampler.join();
     cudaError_t e = cudaGetLastError();
     if (e != cudaSuccess) { printf("[FAIL] cuda: %s\n", cudaGetErrorString(e)); return 1; }
     printf("GPU peak under load: %s\n", peak.str().c_str());
+    if (tg.enabled)
+        printf("thermal: final mode=%s, peak %d°C, %llu/%d tokens throttled\n",
+               sparkinfer::ThermalGovernor::mode_name(gov.mode()), gov.peak_temp_c(),
+               (unsigned long long)gov.throttled_tokens(), (int)out.size());
 
     printf("OUTPUT_IDS:");
     for (int id : out) printf(" %d", id);

--- a/runtime/examples/qwen3_gguf_generate.cpp
+++ b/runtime/examples/qwen3_gguf_generate.cpp
@@ -17,6 +17,9 @@
 #include <cstdlib>
 #include <string>
 #include <vector>
+#include <atomic>
+#include <chrono>
+#include <thread>
 
 int main(int argc, char** argv) {
     if (argc < 4) { printf("usage: %s <model.gguf> <max_new> <id0> [id1 ...]\n", argv[0]); return 2; }
@@ -69,13 +72,37 @@ int main(int argc, char** argv) {
     sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
     printf("loading GGUF (dense->bf16, experts kept quantized) ...\n");
     if (!model.load_gguf(path)) { printf("[FAIL] load_gguf\n"); return 1; }
-    size_t freeb=0, totb=0; cudaMemGetInfo(&freeb, &totb);
-    printf("loaded. VRAM used ~%.1f GB. generating %d tokens from %zu prompt tokens\n",
-           (totb - freeb) / 1e9, max_new, prompt.size());
+    {
+        auto g = sparkinfer::query_gpu_stats();
+        printf("loaded. GPU: %s. generating %d tokens from %zu prompt tokens\n",
+               g.str().c_str(), max_new, prompt.size());
+    }
+
+    // GPU observability: poll heat/VRAM/power on a background thread during decode and keep the
+    // PEAK, so the run reports the hottest the workload drove the device (and whether it throttled).
+    std::atomic<bool> sampling{true};
+    sparkinfer::GpuStats peak;
+    std::thread sampler([&] {
+        while (sampling.load(std::memory_order_relaxed)) {
+            auto s = sparkinfer::query_gpu_stats();
+            if (s.valid) {
+                peak.valid = true;
+                if (s.temp_c          > peak.temp_c)          peak.temp_c          = s.temp_c;
+                if (s.power_w          > peak.power_w)          peak.power_w          = s.power_w;
+                if (s.sm_clock_mhz     > peak.sm_clock_mhz)     peak.sm_clock_mhz     = s.sm_clock_mhz;
+                if (s.vram_used_bytes  > peak.vram_used_bytes)  peak.vram_used_bytes  = s.vram_used_bytes;
+                peak.vram_total_bytes = s.vram_total_bytes;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+    });
 
     auto out = model.generate(prompt, max_new);
+    sampling.store(false, std::memory_order_relaxed);
+    sampler.join();
     cudaError_t e = cudaGetLastError();
     if (e != cudaSuccess) { printf("[FAIL] cuda: %s\n", cudaGetErrorString(e)); return 1; }
+    printf("GPU peak under load: %s\n", peak.str().c_str());
 
     printf("OUTPUT_IDS:");
     for (int id : out) printf(" %d", id);

--- a/runtime/examples/thermal_sweep.cpp
+++ b/runtime/examples/thermal_sweep.cpp
@@ -1,0 +1,131 @@
+// thermal_sweep — force each ThermalGovernor mode and measure the trade-off it produces:
+// decode throughput (tok/s) vs GPU power (W) and temperature (°C). Demonstrates that pacing
+// trades speed for lower heat/watts WITHOUT changing the output: the generated token ids are
+// asserted identical across every mode (only the timing differs).
+//
+// Usage: thermal_sweep <model.gguf> [n_tokens] [id0 id1 ...]
+
+#include "sparkinfer/runtime.h"
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/gguf.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/moe/engine.h"
+#include "sparkinfer/thermal_governor.h"
+#include "sparkinfer/gpu_stats.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+using G = sparkinfer::ThermalGovernor;
+
+struct Reading { double tps; int peak_temp, avg_temp, peak_pw, avg_pw; uint64_t throttled; };
+
+int main(int argc, char** argv) {
+    if (argc < 2) { printf("usage: %s <model.gguf> [n_tokens] [id0 ...]\n", argv[0]); return 2; }
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) { printf("[SKIP] no GPU\n"); return 0; }
+
+    const std::string path = argv[1];
+    const int n_tokens = argc > 2 ? atoi(argv[2]) : 256;
+    std::vector<int> prompt;
+    for (int i = 3; i < argc; i++) prompt.push_back(atoi(argv[i]));
+    if (prompt.empty()) prompt = {9707, 11, 1879, 0};   // a fixed, arbitrary prompt
+
+    sparkinfer::GGUF g;
+    if (!g.open(path)) { printf("[FAIL] cannot open %s\n", path.c_str()); return 1; }
+    const char* A = "qwen3moe.";
+    auto mi = [&](const std::string& k, long d){ return (int)g.meta_int(A + k, d); };
+    sparkinfer::Qwen35Config cfg;
+    cfg.n_layers=mi("block_count",48); cfg.hidden=mi("embedding_length",2048);
+    cfg.n_q_heads=mi("attention.head_count",32); cfg.n_kv_heads=mi("attention.head_count_kv",4);
+    cfg.head_dim=mi("attention.key_length",128); cfg.n_experts=mi("expert_count",128);
+    cfg.top_k=mi("expert_used_count",8); cfg.moe_ffn=mi("expert_feed_forward_length",768);
+    cfg.rope_theta=(float)g.meta_float(std::string(A)+"rope.freq_base",1e6);
+    cfg.rms_eps=(float)g.meta_float(std::string(A)+"attention.layer_norm_rms_epsilon",1e-6);
+    cfg.eos_id=(int)g.meta_int("tokenizer.ggml.eos_token_id",151645); cfg.n_shared=0;
+    const sparkinfer::GGUFTensor* emb=g.tensor("token_embd.weight");
+    cfg.vocab = emb ? (int)emb->dims[1] : 151936; cfg.max_seq=2048;
+
+    auto rt = sparkinfer::Runtime::create({}); rt->initialize();
+    sparkinfer::KVCacheConfig kvc;
+    kvc.num_layers=cfg.n_layers; kvc.num_kv_heads=cfg.n_kv_heads; kvc.head_dim=cfg.head_dim; kvc.block_size=16;
+    const size_t epb=(size_t)16*cfg.n_kv_heads*cfg.head_dim, blocks=(cfg.max_seq+15)/16+8;
+    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers*2*epb*2*blocks);
+    sparkinfer::moe::MoEConfig mc;
+    mc.num_experts=cfg.n_experts; mc.top_k=cfg.top_k; mc.hidden_dim=cfg.hidden; mc.ffn_dim=cfg.moe_ffn; mc.num_layers=cfg.n_layers;
+    auto engine = sparkinfer::moe::MoEEngine::create(mc);
+
+    sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
+    printf("loading GGUF ...\n");
+    if (!model.load_gguf(path)) { printf("[FAIL] load_gguf\n"); return 1; }
+    printf("loaded. %s\n", sparkinfer::query_gpu_stats().str().c_str());
+
+    // One untimed run to warm caches / reach steady clocks before the first measured mode.
+    model.generate(prompt, 16);
+
+    const struct { const char* name; G::Mode m; } MODES[] = {
+        {"turbo",     G::Mode::Turbo},
+        {"balanced",  G::Mode::Balanced},
+        {"safe",      G::Mode::Safe},
+        {"emergency", G::Mode::Emergency},
+    };
+
+    std::vector<int> baseline;   // turbo output — every other mode must match it
+    Reading rd[4];
+    printf("\nsweeping %d modes × %d tokens (prompt %zu) ...\n", 4, n_tokens, prompt.size());
+
+    for (int k = 0; k < 4; k++) {
+        G::Config tc; tc.enabled = true; tc.forced = true; tc.forced_mode = MODES[k].m;
+        G gov(tc);
+
+        // Background sampler: GPU power + temperature every 100 ms while this mode decodes.
+        std::atomic<bool> run{true};
+        long sum_pw=0, sum_t=0, cnt=0; int pk_pw=0, pk_t=0;
+        std::thread sampler([&]{
+            while (run.load(std::memory_order_relaxed)) {
+                auto s = sparkinfer::query_gpu_stats();
+                if (s.valid) {
+                    if (s.power_w >= 0) { sum_pw += s.power_w; if (s.power_w > pk_pw) pk_pw = s.power_w; }
+                    if (s.temp_c  >= 0) { sum_t  += s.temp_c;  if (s.temp_c  > pk_t)  pk_t  = s.temp_c; cnt++; }
+                }
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            }
+        });
+
+        auto t0 = std::chrono::steady_clock::now();
+        std::vector<int> out = model.generate(prompt, n_tokens, &gov);
+        cudaDeviceSynchronize();
+        auto t1 = std::chrono::steady_clock::now();
+        run.store(false, std::memory_order_relaxed); sampler.join();
+
+        double secs = std::chrono::duration<double>(t1 - t0).count();
+        rd[k] = { out.size() / secs,
+                  pk_t, cnt ? (int)(sum_t/cnt) : -1,
+                  pk_pw, cnt ? (int)(sum_pw/cnt) : -1,
+                  gov.throttled_tokens() };
+        if (k == 0) baseline = out;
+        const bool same = (out == baseline);
+        printf("  %-9s : %6.1f tok/s · temp %d°C peak / %d°C avg · power %d W peak / %d W avg · "
+               "throttled %llu · output %s\n",
+               MODES[k].name, rd[k].tps, rd[k].peak_temp, rd[k].avg_temp, rd[k].peak_pw, rd[k].avg_pw,
+               (unsigned long long)rd[k].throttled, same ? "IDENTICAL" : "*** DIFFERS ***");
+        if (!same) { printf("[FAIL] mode %s changed the output — pacing must be accuracy-preserving\n", MODES[k].name); return 1; }
+    }
+
+    // Summary table relative to turbo.
+    printf("\n=== thermal sweep summary (vs turbo) ===\n");
+    printf("%-9s  %8s  %8s  %8s  %9s  %9s\n", "mode", "tok/s", "x speed", "avg W", "avg °C", "Δ°C peak");
+    for (int k = 0; k < 4; k++)
+        printf("%-9s  %8.1f  %7.2fx  %8d  %9d  %+9d\n",
+               MODES[k].name, rd[k].tps,
+               rd[0].tps > 0 ? rd[k].tps / rd[0].tps : 0.0,
+               rd[k].avg_pw, rd[k].avg_temp, rd[k].peak_temp - rd[0].peak_temp);
+    printf("\nall modes produced IDENTICAL token ids — pacing trades only speed for heat/power.\n");
+    return 0;
+}

--- a/runtime/examples/thermal_sweep.cpp
+++ b/runtime/examples/thermal_sweep.cpp
@@ -82,8 +82,12 @@ int main(int argc, char** argv) {
 
     for (int k = 0; k < 4; k++) {
         G::Config tc; tc.enabled = true; tc.forced = true; tc.forced_mode = MODES[k].m;
-        G gov(tc);
 
+        // Per-mode warmup (untimed, unsampled): run this mode long enough to reach its steady
+        // clock/power state, so the measured average isn't dragged by the ramp-up transient.
+        { G warm(tc); model.generate(prompt, n_tokens / 4 + 16, &warm); }
+
+        G gov(tc);
         // Background sampler: GPU power + temperature every 100 ms while this mode decodes.
         std::atomic<bool> run{true};
         long sum_pw=0, sum_t=0, cnt=0; int pk_pw=0, pk_t=0;

--- a/runtime/include/sparkinfer/gpu_stats.h
+++ b/runtime/include/sparkinfer/gpu_stats.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+namespace sparkinfer {
+
+// Engine-level GPU observability — a single on-demand sample of how hot the device is running
+// and how much VRAM the model is resident in. Cheap enough to poll on a background thread while
+// the engine decodes (see runtime/examples/qwen3_gguf_generate.cpp), so callers can track the
+// PEAK heat/power a workload drives, not just a steady-state snapshot.
+//
+// VRAM always populates (cudaMemGetInfo). Temperature/power/clock come from NVML; if NVML isn't
+// linked or the query fails, those stay -1 and `str()` simply omits them — never an error.
+struct GpuStats {
+    bool   valid            = false;  // false only if even VRAM couldn't be read
+    int    temp_c           = -1;     // GPU core temperature, °C (heat)
+    int    power_w          = -1;     // instantaneous board power draw, W
+    int    sm_clock_mhz     = -1;     // SM clock, MHz (drops when thermal-throttling)
+    size_t vram_used_bytes  = 0;      // resident VRAM = total - free
+    size_t vram_total_bytes = 0;      // device VRAM capacity
+
+    double vram_used_gb()  const { return vram_used_bytes  / 1e9; }
+    double vram_total_gb() const { return vram_total_bytes / 1e9; }
+
+    // e.g. "72°C · 21.4/31.4 GB VRAM · 410 W · 2820 MHz"
+    std::string str() const;
+};
+
+// Sample heat + VRAM (+ power/clock) for a CUDA device. device_id < 0 ⇒ the current device.
+// NVML is mapped to the CUDA device by PCI bus id, so this stays correct under CUDA_VISIBLE_DEVICES.
+GpuStats query_gpu_stats(int device_id = -1);
+
+} // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -7,6 +7,8 @@
 
 namespace sparkinfer {
 
+class ThermalGovernor;   // optional decode-time thermal pacing (thermal_governor.h)
+
 // Qwen3.5-35B-A3B architecture.
 //   40 layers, hidden 2048, 16 Q / 2 KV heads (8:1 GQA), head_dim 128,
 //   256 routed experts (top-8) + 1 shared expert, moe ffn 512,
@@ -82,8 +84,10 @@ public:
     // dequantized per-layer at decode time (Q4_K_M-sized resident footprint).
     bool load_gguf(const std::string& path);
 
-    // Greedy generate: prompt token ids -> generated token ids (host).
-    std::vector<int> generate(const std::vector<int>& prompt_ids, int max_new_tokens);
+    // Greedy generate: prompt token ids -> generated token ids (host). An optional ThermalGovernor
+    // paces decode under thermal pressure (accuracy-preserving); nullptr = full speed, no overhead.
+    std::vector<int> generate(const std::vector<int>& prompt_ids, int max_new_tokens,
+                              ThermalGovernor* gov = nullptr);
 
     // Run one token at `position`, return the argmax next-token id.
     int forward_token(int token_id, int position);

--- a/runtime/include/sparkinfer/runtime.h
+++ b/runtime/include/sparkinfer/runtime.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <memory>
 
+#include "sparkinfer/gpu_stats.h"
+
 namespace sparkinfer {
 
 struct RuntimeConfig {
@@ -29,6 +31,10 @@ public:
 
     // Returns number of available CUDA SMs
     virtual int num_sms() const = 0;
+
+    // Engine-level GPU observability: a live sample of heat (°C) + VRAM (+ power/clock) on this
+    // runtime's device. Safe to poll periodically (e.g. while decoding) to watch thermals/throttle.
+    virtual GpuStats gpu_stats() const = 0;
 };
 
 } // namespace sparkinfer

--- a/runtime/include/sparkinfer/thermal_governor.h
+++ b/runtime/include/sparkinfer/thermal_governor.h
@@ -41,6 +41,12 @@ public:
         int predict_horizon_ms = 1500;
 
         bool log_transitions = false;   // print a line on each mode change (observability)
+
+        // Testing/benchmark override: when `forced` is set, apply `forced_mode` every token and
+        // ignore temperature — lets a sweep measure each mode's power/heat/throughput
+        // deterministically. Temperature is still sampled for observability.
+        bool forced      = false;
+        Mode forced_mode = Mode::Turbo;
     };
 
     explicit ThermalGovernor(const Config& cfg) : cfg_(cfg) {}

--- a/runtime/include/sparkinfer/thermal_governor.h
+++ b/runtime/include/sparkinfer/thermal_governor.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <cstdint>
+
+namespace sparkinfer {
+
+// Thermally-adaptive decode pacing — a software governor (DVFS-style, like a CPU frequency
+// governor but for LLM decode). When the GPU runs hot it throttles decode THROUGHPUT by sleeping
+// between tokens; it never touches weights, precision, logits, or sampling, so output is
+// bit-identical to an un-paced run — just slower (and cooler) under thermal pressure.
+//
+// Levers it does NOT pull (would change the output): precision/quantization, model swap, KV
+// truncation, speculative changes. The ONLY lever is an inter-token delay.
+//
+// Disabled by default: an enabled governor would slow a throughput benchmark, so the eval/bench
+// path leaves it off (generate(..., gov=nullptr)) and pays zero overhead.
+class ThermalGovernor {
+public:
+    enum class Mode { Turbo, Balanced, Safe, Emergency };
+
+    struct Config {
+        bool enabled    = false;   // master switch (default OFF)
+        int  device_id  = -1;      // -1 = current CUDA device
+
+        // Temperature thresholds (°C), ascending. A mode engages at >= its threshold.
+        int  balanced_c  = 65;
+        int  safe_c      = 70;
+        int  emergency_c = 80;
+
+        // Inter-token pace per mode (ms). Turbo is always 0 (no throttle). Larger = cooler+slower.
+        double balanced_ms  = 2.0;
+        double safe_ms      = 8.0;
+        double emergency_ms = 25.0;
+
+        // Re-read the sensor at most this often; the temperature is cached between reads so we
+        // don't hit NVML every token (decode is ~ms/token, NVML is ~ms/call).
+        int sample_interval_ms = 250;
+
+        // Predictive throttle: if temperature is rising, project it `predict_horizon_ms` ahead and
+        // tier on the projection, so we throttle BEFORE crossing a threshold. 0 = pure reactive.
+        int predict_horizon_ms = 1500;
+
+        bool log_transitions = false;   // print a line on each mode change (observability)
+    };
+
+    explicit ThermalGovernor(const Config& cfg) : cfg_(cfg) {}
+
+    // Call once per decoded token. Rate-limited sensor read → mode update → sleep the mode's pace.
+    // No-op (returns 0) when disabled or when no temperature is available. Returns ms slept.
+    double pace();
+
+    // Pure temperature→mode mapping (no hardware, no sleep) — the tiering policy, unit-testable.
+    static Mode classify(const Config& cfg, int temp_c);
+    static const char* mode_name(Mode m);
+
+    Mode   mode()          const { return mode_; }
+    int    last_temp_c()   const { return last_temp_; }
+    int    peak_temp_c()   const { return peak_temp_; }
+    double slope_c_per_s() const { return slope_; }
+    uint64_t throttled_tokens() const { return throttled_; }  // tokens that got a non-zero pace
+
+private:
+    Config   cfg_;
+    Mode     mode_       = Mode::Turbo;
+    int      last_temp_  = -1;
+    int      peak_temp_  = -1;
+    double   slope_      = 0.0;       // °C/s, from consecutive samples
+    uint64_t throttled_  = 0;
+    // steady_clock bookkeeping (ns); set lazily on first pace()
+    bool     started_         = false;
+    uint64_t last_sample_ns_  = 0;
+    int      prev_sample_temp_= -1;
+    uint64_t prev_sample_ns_  = 0;
+};
+
+} // namespace sparkinfer

--- a/runtime/src/gpu_stats.cpp
+++ b/runtime/src/gpu_stats.cpp
@@ -59,9 +59,14 @@ GpuStats query_gpu_stats(int device_id) {
         nvmlDevice_t h{};
         if (nvmlDeviceGetHandleByPciBusId_v2(pci, &h) == NVML_SUCCESS) {
             unsigned t = 0, p = 0, c = 0;
+            // These NVML getters are marked deprecated in CUDA 13's nvml.h but remain the portable
+            // way to read temp/power across CUDA 12 and 13 — silence the deprecation note.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
             if (nvmlDeviceGetTemperature(h, NVML_TEMPERATURE_GPU, &t) == NVML_SUCCESS) s.temp_c = (int)t;
             if (nvmlDeviceGetPowerUsage(h, &p) == NVML_SUCCESS)                        s.power_w = (int)(p / 1000); // mW→W
             if (nvmlDeviceGetClockInfo(h, NVML_CLOCK_SM, &c) == NVML_SUCCESS)          s.sm_clock_mhz = (int)c;
+#pragma GCC diagnostic pop
             s.valid = true;
         }
     }

--- a/runtime/src/gpu_stats.cpp
+++ b/runtime/src/gpu_stats.cpp
@@ -1,0 +1,72 @@
+// Engine-level GPU observability: heat (°C) + VRAM (+ power/clock).
+//
+// VRAM is read with cudaMemGetInfo (always available). Temperature/power/clock use NVML when it's
+// linked (SPARKINFER_HAVE_NVML, set by CMake when CUDA::nvml exists). NVML is initialized once and
+// left open for the process so repeated background sampling stays cheap.
+
+#include "sparkinfer/gpu_stats.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+#ifdef SPARKINFER_HAVE_NVML
+#include <nvml.h>
+#endif
+
+namespace sparkinfer {
+
+#ifdef SPARKINFER_HAVE_NVML
+// Init NVML once (not per sample); never shut down — process exit reclaims it.
+static bool nvml_ready() {
+    static bool ok = (nvmlInit_v2() == NVML_SUCCESS);
+    return ok;
+}
+#endif
+
+std::string GpuStats::str() const {
+    if (!valid) return "GPU stats unavailable";
+    char buf[192];
+    int n = snprintf(buf, sizeof buf, "%d°C · %.1f/%.1f GB VRAM",
+                     temp_c, vram_used_gb(), vram_total_gb());
+    if (power_w      >= 0) n += snprintf(buf + n, sizeof buf - n, " · %d W", power_w);
+    if (sm_clock_mhz >= 0) n += snprintf(buf + n, sizeof buf - n, " · %d MHz", sm_clock_mhz);
+    return std::string(buf, n > 0 ? n : 0);
+}
+
+GpuStats query_gpu_stats(int device_id) {
+    GpuStats s;
+
+    int dev = device_id;
+    if (dev < 0) cudaGetDevice(&dev);
+
+    // VRAM — cudaMemGetInfo reports the *current* device, so switch to `dev` and restore.
+    int prev = -1;
+    cudaGetDevice(&prev);
+    if (prev != dev) cudaSetDevice(dev);
+    size_t freeb = 0, totb = 0;
+    if (cudaMemGetInfo(&freeb, &totb) == cudaSuccess && totb > 0) {
+        s.vram_total_bytes = totb;
+        s.vram_used_bytes  = (totb >= freeb) ? (totb - freeb) : 0;
+        s.valid = true;
+    }
+    if (prev != dev && prev >= 0) cudaSetDevice(prev);
+
+#ifdef SPARKINFER_HAVE_NVML
+    // Heat/power/clock via NVML. Resolve the handle by PCI bus id so the CUDA device and the NVML
+    // device agree even when CUDA_VISIBLE_DEVICES remaps ordinals.
+    char pci[32] = {0};
+    if (nvml_ready() && cudaDeviceGetPCIBusId(pci, sizeof pci, dev) == cudaSuccess) {
+        nvmlDevice_t h{};
+        if (nvmlDeviceGetHandleByPciBusId_v2(pci, &h) == NVML_SUCCESS) {
+            unsigned t = 0, p = 0, c = 0;
+            if (nvmlDeviceGetTemperature(h, NVML_TEMPERATURE_GPU, &t) == NVML_SUCCESS) s.temp_c = (int)t;
+            if (nvmlDeviceGetPowerUsage(h, &p) == NVML_SUCCESS)                        s.power_w = (int)(p / 1000); // mW→W
+            if (nvmlDeviceGetClockInfo(h, NVML_CLOCK_SM, &c) == NVML_SUCCESS)          s.sm_clock_mhz = (int)c;
+            s.valid = true;
+        }
+    }
+#endif
+    return s;
+}
+
+} // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -8,6 +8,7 @@
 // autoregressive greedy decoding fundamentally requires.
 
 #include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/thermal_governor.h"
 #include "sparkinfer/kv_ops.h"
 #include "sparkinfer/gguf.h"
 #include "sparkinfer/kernels/attention.h"
@@ -311,7 +312,7 @@ double Qwen35Model::bench_decode(int warmup, int n) {
     return n / secs;
 }
 
-std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_new) {
+std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_new, ThermalGovernor* gov) {
     Impl& s = *p_;
     std::vector<int> out;
     if (prompt.empty()) return out;
@@ -325,6 +326,7 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         out.push_back(next);
         if (next == s.cfg.eos_id) break;
         next = forward_token(next, (int)prompt.size() + i);
+        if (gov) gov->pace();   // thermally-adaptive decode pacing (accuracy-preserving; no-op if disabled)
     }
     s.kv->free(s.seq_id);
     return out;

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -35,6 +35,7 @@ public:
     void shutdown() override { cudaDeviceSynchronize(); }
     float memory_bandwidth_gbps() const override { return bandwidth_gbps_; }
     int   num_sms() const override { return num_sms_; }
+    GpuStats gpu_stats() const override { return query_gpu_stats(cfg_.device_id); }
 
 private:
     RuntimeConfig cfg_;

--- a/runtime/src/thermal_governor.cpp
+++ b/runtime/src/thermal_governor.cpp
@@ -64,15 +64,17 @@ double ThermalGovernor::pace() {
         started_ = true;
     }
 
-    if (last_temp_ < 0) return 0.0;   // no sensor → never throttle
-
-    // Predictive: tier on max(measured, projected) so a fast rise throttles before crossing.
-    int eff = last_temp_;
-    if (cfg_.predict_horizon_ms > 0 && slope_ > 0.0)
-        eff = last_temp_ + (int)(slope_ * cfg_.predict_horizon_ms / 1000.0);
-
     const Mode prev = mode_;
-    mode_ = classify(cfg_, eff);
+    int eff = last_temp_;
+    if (cfg_.forced) {
+        mode_ = cfg_.forced_mode;            // deterministic sweep: temperature ignored
+    } else {
+        if (last_temp_ < 0) return 0.0;      // auto mode + no sensor → never throttle
+        // Predictive: tier on max(measured, projected) so a fast rise throttles before crossing.
+        if (cfg_.predict_horizon_ms > 0 && slope_ > 0.0)
+            eff = last_temp_ + (int)(slope_ * cfg_.predict_horizon_ms / 1000.0);
+        mode_ = classify(cfg_, eff);
+    }
     const double ms = pace_ms_for(cfg_, mode_);
 
     if (cfg_.log_transitions && mode_ != prev)

--- a/runtime/src/thermal_governor.cpp
+++ b/runtime/src/thermal_governor.cpp
@@ -1,0 +1,89 @@
+// Thermally-adaptive decode pacing. See thermal_governor.h. The governor only ever *sleeps* —
+// it cannot change what tokens are produced, only how fast. Temperature comes from the same
+// engine-level query_gpu_stats() used for observability.
+
+#include "sparkinfer/thermal_governor.h"
+#include "sparkinfer/gpu_stats.h"
+
+#include <chrono>
+#include <thread>
+#include <cstdio>
+
+namespace sparkinfer {
+
+using clk = std::chrono::steady_clock;
+static uint64_t now_ns() {
+    return (uint64_t)std::chrono::duration_cast<std::chrono::nanoseconds>(
+        clk::now().time_since_epoch()).count();
+}
+
+const char* ThermalGovernor::mode_name(Mode m) {
+    switch (m) {
+        case Mode::Turbo:     return "turbo";
+        case Mode::Balanced:  return "balanced";
+        case Mode::Safe:      return "safe";
+        case Mode::Emergency: return "emergency";
+    }
+    return "?";
+}
+
+ThermalGovernor::Mode ThermalGovernor::classify(const Config& c, int temp_c) {
+    if (temp_c >= c.emergency_c) return Mode::Emergency;
+    if (temp_c >= c.safe_c)      return Mode::Safe;
+    if (temp_c >= c.balanced_c)  return Mode::Balanced;
+    return Mode::Turbo;
+}
+
+static double pace_ms_for(const ThermalGovernor::Config& c, ThermalGovernor::Mode m) {
+    switch (m) {
+        case ThermalGovernor::Mode::Balanced:  return c.balanced_ms;
+        case ThermalGovernor::Mode::Safe:      return c.safe_ms;
+        case ThermalGovernor::Mode::Emergency: return c.emergency_ms;
+        default:                               return 0.0;  // Turbo
+    }
+}
+
+double ThermalGovernor::pace() {
+    if (!cfg_.enabled) return 0.0;
+
+    const uint64_t t = now_ns();
+    // Rate-limit sensor reads; reuse the cached temperature between samples.
+    if (!started_ || (t - last_sample_ns_) >= (uint64_t)cfg_.sample_interval_ms * 1000000ull) {
+        GpuStats g = query_gpu_stats(cfg_.device_id);
+        if (g.valid && g.temp_c >= 0) {
+            if (prev_sample_temp_ >= 0 && prev_sample_ns_ > 0) {
+                const double dt_s = (double)(t - prev_sample_ns_) / 1e9;
+                if (dt_s > 0.0) slope_ = (g.temp_c - prev_sample_temp_) / dt_s;
+            }
+            prev_sample_temp_ = g.temp_c;
+            prev_sample_ns_   = t;
+            last_temp_ = g.temp_c;
+            if (g.temp_c > peak_temp_) peak_temp_ = g.temp_c;
+        }
+        last_sample_ns_ = t;
+        started_ = true;
+    }
+
+    if (last_temp_ < 0) return 0.0;   // no sensor → never throttle
+
+    // Predictive: tier on max(measured, projected) so a fast rise throttles before crossing.
+    int eff = last_temp_;
+    if (cfg_.predict_horizon_ms > 0 && slope_ > 0.0)
+        eff = last_temp_ + (int)(slope_ * cfg_.predict_horizon_ms / 1000.0);
+
+    const Mode prev = mode_;
+    mode_ = classify(cfg_, eff);
+    const double ms = pace_ms_for(cfg_, mode_);
+
+    if (cfg_.log_transitions && mode_ != prev)
+        fprintf(stderr, "[thermal] %d°C (slope %+.1f°C/s, eff %d) -> %s (%.0f ms/tok)\n",
+                last_temp_, slope_, eff, mode_name(mode_), ms);
+
+    if (ms > 0.0) {
+        ++throttled_;
+        std::this_thread::sleep_for(std::chrono::duration<double, std::milli>(ms));
+    }
+    return ms;
+}
+
+} // namespace sparkinfer

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -7,6 +7,12 @@ add_executable(qwen35_cpu_test qwen35_cpu_test.cpp)
 set_target_properties(qwen35_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME qwen35_cpu_test COMMAND qwen35_cpu_test)
 
+# Thermal governor — pure tiering policy (no GPU); links the runtime for classify()/pace() symbols.
+add_executable(thermal_governor_cpu_test thermal_governor_cpu_test.cpp)
+target_link_libraries(thermal_governor_cpu_test PRIVATE sparkinfer_runtime)
+set_target_properties(thermal_governor_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME thermal_governor_cpu_test COMMAND thermal_governor_cpu_test)
+
 # GPU integration tests — run the real device path; skip without a device.
 add_executable(decode_runner_gpu_test decode_runner_gpu_test.cpp)
 target_link_libraries(decode_runner_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/tests/thermal_governor_cpu_test.cpp
+++ b/runtime/tests/thermal_governor_cpu_test.cpp
@@ -1,0 +1,43 @@
+// CPU test for the thermal governor's tiering policy — pure logic, no GPU needed.
+// (classify() is a pure temp→mode map; a disabled governor never touches the device.)
+
+#include "sparkinfer/thermal_governor.h"
+#include <cstdio>
+#include <string>
+
+using G = sparkinfer::ThermalGovernor;
+#define CHECK(x) do{ if(!(x)){ printf("FAIL: %s (line %d)\n", #x, __LINE__); return 1; } }while(0)
+
+int main() {
+    G::Config c;  // defaults: balanced 65, safe 70, emergency 80 °C
+
+    // Reactive tiering at the boundaries.
+    CHECK(G::classify(c, 50) == G::Mode::Turbo);
+    CHECK(G::classify(c, 64) == G::Mode::Turbo);
+    CHECK(G::classify(c, 65) == G::Mode::Balanced);
+    CHECK(G::classify(c, 69) == G::Mode::Balanced);
+    CHECK(G::classify(c, 70) == G::Mode::Safe);
+    CHECK(G::classify(c, 79) == G::Mode::Safe);
+    CHECK(G::classify(c, 80) == G::Mode::Emergency);
+    CHECK(G::classify(c, 95) == G::Mode::Emergency);
+
+    // Custom thresholds.
+    G::Config c2; c2.balanced_c = 60; c2.safe_c = 72; c2.emergency_c = 85;
+    CHECK(G::classify(c2, 59) == G::Mode::Turbo);
+    CHECK(G::classify(c2, 60) == G::Mode::Balanced);
+    CHECK(G::classify(c2, 71) == G::Mode::Balanced);
+    CHECK(G::classify(c2, 72) == G::Mode::Safe);
+    CHECK(G::classify(c2, 85) == G::Mode::Emergency);
+
+    // A disabled governor is a strict no-op: never sleeps, stays in Turbo, touches no hardware.
+    G off(c);
+    CHECK(off.pace() == 0.0);
+    CHECK(off.mode() == G::Mode::Turbo);
+    CHECK(off.throttled_tokens() == 0);
+
+    CHECK(std::string(G::mode_name(G::Mode::Turbo))     == "turbo");
+    CHECK(std::string(G::mode_name(G::Mode::Emergency)) == "emergency");
+
+    printf("thermal_governor_cpu_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## What

Engine-level GPU observability so a run reports how hot the device got and how much VRAM the model is resident in.

```cpp
sparkinfer::GpuStats s = sparkinfer::query_gpu_stats();   // or Runtime::gpu_stats()
// s.temp_c, s.power_w, s.sm_clock_mhz, s.vram_used_gb(), s.vram_total_gb()
printf("%s\n", s.str().c_str());   // "72°C · 21.4/31.4 GB VRAM · 410 W · 2820 MHz"
```

## How
- **VRAM** via `cudaMemGetInfo` (always available).
- **Heat / power / SM clock** via **NVML**, with the NVML handle resolved by **PCI bus id** so it stays correct under `CUDA_VISIBLE_DEVICES`. Degrades cleanly to `-1` (and `str()` omits the field) when NVML isn't linked.
- Exposed on the engine API: `Runtime::gpu_stats()`.

## Integration
- **generate example** — a background sampler polls during decode and reports the **peak** heat/power under load (catches thermal throttle, since SM clock drops when throttling).
- **bench example** — one **one-shot** sample right after the decode loop (no timing impact on the measured tok/s).
- **CMake** — links `CUDA::nvml` + defines `SPARKINFER_HAVE_NVML` only when present; `Threads` for the sampler.

## Validation
Host paths compile **with and without** NVML; a behavioral test confirms `str()` formatting, mW→W conversion, `used = total − free`, and the peak-tracking reduction. The on-device **sm_120** build (NVML link + examples) should be confirmed on a 5090 before merge.