### PR TITLE
fix(moe): bound router top_k to prevent stack buffer overflow

### DIFF
--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -16,6 +16,11 @@
 namespace sparkinfer {
 namespace kernels {
 
+// Upper bound on top_k. The per-token selection holds the chosen logits/ids in
+// fixed-size registers (sel_logit/sel_id below), so top_k must not exceed this —
+// the launcher rejects larger values instead of overrunning those arrays.
+static constexpr int MOE_ROUTER_MAX_TOPK = 16;
+
 // Warp arg-max: returns the max value across the warp; *idx is set on every lane
 // to the index that owns it (ties resolved to the lowest index).
 __device__ __forceinline__ float warp_argmax(float val, int& idx) {
@@ -44,8 +49,8 @@ __global__ void moe_router_kernel(
     for (int e = lane; e < num_experts; e += 32) s_logits[e] = row[e];
     __syncwarp();
 
-    float sel_logit[16];                   // top_k <= 16
-    int   sel_id[16];
+    float sel_logit[MOE_ROUTER_MAX_TOPK];  // top_k <= MOE_ROUTER_MAX_TOPK (launcher-enforced)
+    int   sel_id[MOE_ROUTER_MAX_TOPK];
 
     for (int j = 0; j < top_k; j++) {
         float best = -1e30f; int best_i = -1;
@@ -94,6 +99,7 @@ void launch_moe_router(
     int normalize, cudaStream_t stream
 ) {
     if (num_tokens <= 0 || num_experts <= 0 || top_k <= 0 || top_k > num_experts) return;
+    if (top_k > MOE_ROUTER_MAX_TOPK) return;   // sel_logit/sel_id are sized to MOE_ROUTER_MAX_TOPK
     size_t smem = (size_t)num_experts * sizeof(float);
     moe_router_kernel<<<num_tokens, 32, smem, stream>>>(
         logits, expert_ids, expert_weights, tokens_per_expert,


### PR DESCRIPTION
## Summary

The MoE router stages each token's selected experts in fixed-size per-thread arrays sized for `top_k <= 16`, but nothing enforces that bound. A model or config with `top_k > 16` overruns those arrays — undefined behavior and stack corruption on every warp. This adds the missing guard.

## Background

`moe_router_kernel` selects the top-k experts into stack arrays:

    float sel_logit[16];   // top_k <= 16
    int   sel_id[16];

and writes `sel_logit[j]` / `sel_id[j]` for `j` in `[0, top_k)`.

#22 ("validate router inputs before launching top-k kernel") added input validation for `top_k <= 0` and `top_k > num_experts`, but did **not** enforce `top_k <= 16`. Any config with `top_k > 16` (and `num_experts >= top_k`) passes validation and writes out of bounds.

Currently supported models (Qwen3.5 / Gemma4, `top_k = 8`) stay within bounds, so this is a latent landmine rather than an active failure — the exact class of input bug #22 set out to close.

## Changes

`kernels/csrc/cuda/moe/router.cu`

- Introduce `MOE_ROUTER_MAX_TOPK = 16` as the single source of truth.
- Size `sel_logit` / `sel_id` from the constant instead of a bare `16`.
- Reject `top_k > MOE_ROUTER_MAX_TOPK` in `launch_moe_router`, next to the existing #22 guards, before any kernel launch.

The array bound and the launcher limit now reference the same constant, so they cannot drift apart in future edits.

## Behavior

- No change for any in-range `top_k` (all supported models: `top_k <= 8`).
- Out-of-range `top_k` now early-returns, consistent with the other router guards, instead of corrupting the stack.

## Testing

- Pure host-side guard plus a compile-time constant substitution; kernel math is unchanged.
- `ctest` to confirm the build. No accuracy or throughput impact.
