### PR TITLE
runtime/gpu_stats: fix chained-snprintf buffer overrun in GpuStats::str()

### DIFF
--- a/runtime/src/gpu_stats.cpp
+++ b/runtime/src/gpu_stats.cpp
@@ -26,11 +26,21 @@ static bool nvml_ready() {
 std::string GpuStats::str() const {
     if (!valid) return "GPU stats unavailable";
     char buf[192];
-    int n = snprintf(buf, sizeof buf, "%d°C · %.1f/%.1f GB VRAM",
-                     temp_c, vram_used_gb(), vram_total_gb());
-    if (power_w      >= 0) n += snprintf(buf + n, sizeof buf - n, " · %d W", power_w);
-    if (sm_clock_mhz >= 0) n += snprintf(buf + n, sizeof buf - n, " · %d MHz", sm_clock_mhz);
-    return std::string(buf, n > 0 ? n : 0);
+    const int cap = (int)sizeof buf;
+    // snprintf returns the length it WOULD have written; on truncation that exceeds the
+    // buffer, so advancing `buf + n` with `cap - n` (size_t) would point past the buffer
+    // and underflow the size. Append() clamps the cursor to what was actually written.
+    int n = 0;
+    auto append = [&](const char* fmt, auto... args) {
+        if (n >= cap - 1) return;
+        int m = snprintf(buf + n, (size_t)(cap - n), fmt, args...);
+        if (m < 0) return;
+        n += (m < cap - 1 - n) ? m : cap - 1 - n;   // clamp to bytes actually written
+    };
+    append("%d°C · %.1f/%.1f GB VRAM", temp_c, vram_used_gb(), vram_total_gb());
+    if (power_w      >= 0) append(" · %d W", power_w);
+    if (sm_clock_mhz >= 0) append(" · %d MHz", sm_clock_mhz);
+    return std::string(buf, n);
 }
 
 GpuStats query_gpu_stats(int device_id) {


### PR DESCRIPTION
## Summary

Fix a latent buffer overrun in `GpuStats::str()`: it advanced its cursor by `snprintf`'s return value (the would-have-written length), so a truncating field makes `buf + n` point past the buffer and `sizeof buf - n` underflow — an out-of-bounds write, and the final `std::string(buf, n)` an out-of-bounds read.

Fixes #79

**Change.** Append through a small helper that clamps the cursor to the bytes actually written and stops once the buffer is full, so every offset/size handed to `snprintf` stays in range. Output is byte-identical for normal stats strings.

**Verification.** Built from source and ran the test suite on an **RTX 5090 (sm_120)**: `gpu_stats.cpp` compiles clean, `ctest` 5/5 (well, 6/6 incl. GPU tests) pass. This is a host-side robustness fix on the observability path — not a decode/perf change.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — robustness/memory-safety fix in host observability code; no kernel or decode-path change, so no decode-throughput delta. (Built + `ctest` verified on a 5090; the box is unticked because there is no perf claim to benchmark.)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`):

| | decode tok/s |
|---|--:|
| before (main) | N/A (no perf change) |
| after (this PR) | N/A (no perf change) |

```text
N/A — host-side string-formatting hardening; decode output and speed unchanged.
```

## Scope

Single focused change in `runtime/src/gpu_stats.cpp`; one fix per PR per CONTRIBUTING.md, scoped to `runtime/`.