### PR TITLE
runtime/tools/convert_gguf: fix dead vocab-from-token_embd fallback

### DIFF
--- a/runtime/tools/convert_gguf.py
+++ b/runtime/tools/convert_gguf.py
@@ -56,8 +56,12 @@ def main():
     )
     # vocab from token_embd if metadata missing
     ten = {t.name: t for t in r.tensors}
-    if "token_embd.weight" in ten:
-        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
+    if not meta(A + "vocab_size") and "token_embd.weight" in ten:
+        # token_embd.weight is [vocab, hidden] (see embed_tokens write below), so the
+        # vocab axis is shape[0]. The previous `... if False else cfg["vocab"]` made this
+        # fallback a no-op, leaving cfg["vocab"] at the hardcoded 151936 default whenever
+        # the GGUF lacks <arch>.vocab_size — which mis-sizes the LM head for such models.
+        cfg["vocab"] = int(ten["token_embd.weight"].shape[0])
 
     with open(os.path.join(out, "config.txt"), "w") as f:
         for k, v in cfg.items():


### PR DESCRIPTION
## Summary

Fix the converter's vocab fallback so it actually derives vocab from the embedding tensor when the GGUF lacks `<arch>.vocab_size`.

Fixes #81

**Why.** The line `cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]` is a no-op (`if False`), so the documented fallback never runs — a GGUF without `vocab_size` keeps the hardcoded `151936` default and mis-sizes the LM head/config for any other-vocab model. It also read `shape[-1]` (the hidden axis); `token_embd.weight` is `[vocab, hidden]` here, so the vocab axis is `shape[0]`.

**Change.** Run the fallback only when `vocab_size` metadata is absent, and read `shape[0]`:

```python
if not meta(A + "vocab_size") and "token_embd.weight" in ten:
    cfg["vocab"] = int(ten["token_embd.weight"].shape[0])   # [vocab, hidden]
```

GGUFs that carry `vocab_size` (the common case) are unaffected.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — correctness fix in the offline GGUF→sparkinfer conversion tool (`runtime/tools/convert_gguf.py`); it does not touch the runtime/decode path, so there is no decode-throughput change to benchmark.

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`):

| | decode tok/s |
|---|--:|
| before (main) | N/A (offline tool, no perf change) |
| after (this PR) | N/A (offline tool, no perf change) |

```text
N/A — offline conversion-tool correctness fix; runtime decode output/speed unchanged.
```

## Scope

Single focused change in `runtime/tools/convert_gguf.py`; one fix per PR per CONTRIBUTING.md, scoped to `runtime/`.