### PR TITLE
perf(decode): fuse the Q8_1 activation quantize into the residual RMSNorm v2

### DIFF
--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -5,12 +5,16 @@
 // Portable CUDA — runs on sm_89 .. sm_120 (RTX 5090).
 
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #endif
 
 namespace sparkinfer {
 namespace kernels {
+
+// llama mmvq activation block (matches si_block_q8_1 used by the int8 GEMVs/MMVQ).
+struct si_blk_q8_1 { __half2 ds; signed char qs[32]; };
 
 __device__ __forceinline__ float rn_warp_sum(float v) {
     #pragma unroll
@@ -164,6 +168,70 @@ __global__ void add_rmsnorm2_kernel(const __nv_bfloat16* __restrict__ x,
         out_norm[base + c] = __float2bfloat16(__bfloat162float(out_sum[base + c]) * inv_rms * __bfloat162float(weight[c]));
 }
 
+// add_rmsnorm2 that ALSO emits a Q8_1 quantization of out_norm (si_block_q8_1), so the
+// downstream int8 GEMV/MMVQ skips its separate per-layer quantize node. Specialized to the
+// decode residual width: one row, cols a multiple of 256, exactly one 8-wide pack per thread
+// (blockDim*8 == cols), so each 32-element Q8_1 block maps to 4 consecutive threads. The Q8_1
+// is computed from the bf16-rounded out_norm, so it is bit-identical to running the standalone
+// quantizer on out_norm afterwards.
+__global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
+                                       const __nv_bfloat16* __restrict__ residual,
+                                       const __nv_bfloat16* __restrict__ weight,
+                                       __nv_bfloat16* __restrict__ out_sum,
+                                       __nv_bfloat16* __restrict__ out_norm,
+                                       si_blk_q8_1* __restrict__ out_q8,
+                                       int cols, float eps) {
+    const size_t base = 0;
+    __shared__ float s_warp[32];
+    const int t = threadIdx.x;
+    const uint4* x4 = reinterpret_cast<const uint4*>(x);
+    const uint4* r4 = reinterpret_cast<const uint4*>(residual);
+    uint4* osum4 = reinterpret_cast<uint4*>(out_sum);
+
+    float xv[8], rv[8]; rn_unpack8(__ldg(x4 + t), xv); rn_unpack8(__ldg(r4 + t), rv);
+    float sv[8]; float ss = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) { sv[j] = xv[j] + rv[j]; ss = __fmaf_rn(sv[j], sv[j], ss); }
+    osum4[t] = rn_pack8(sv);
+    ss = rn_warp_sum(ss);
+    if ((t & 31) == 0) s_warp[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < (blockDim.x + 31) / 32) ? s_warp[t] : 0.f;
+        v = rn_warp_sum(v);
+        if (t == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    // Re-read the bf16-rounded residual sum (exactly as add_rmsnorm2_kernel does), so out_norm
+    // is bit-identical to the unfused path; then derive Q8_1 from the bf16-rounded out_norm.
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum);
+    float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
+    float ov[8], bv[8];
+    #pragma unroll
+    for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
+    reinterpret_cast<uint4*>(out_norm)[t] = rn_pack8(ov);
+
+    // Q8_1 of the bf16-rounded out_norm. 32-block = 4 consecutive threads (t&~3 .. +3).
+    float amax = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(bv[j]));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+    const float d = amax / 127.0f;
+    const int b = t >> 2, r = t & 3;
+    int s = 0;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
+        out_q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+    }
+    s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
+    if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
+}
+
 // Fused per-head Q-norm + K-norm: ONE kernel over (n_q_heads + n_kv_heads) heads
 // (each block normalizes one head), vs two launch_rmsnorm calls. 1 graph node saved.
 __global__ void rmsnorm_qk_kernel(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k,
@@ -191,6 +259,7 @@ __global__ void rmsnorm_qk_kernel(__nv_bfloat16* __restrict__ q, __nv_bfloat16* 
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/fused.h"
+#include <cassert>
 
 void launch_rmsnorm_qk(void* q, void* k, const void* q_w, const void* k_w,
                        int n_q_heads, int n_kv_heads, int head_dim, float eps, cudaStream_t stream) {
@@ -226,6 +295,24 @@ void launch_add_rmsnorm2(const void* x, const void* residual, const void* weight
         reinterpret_cast<const __nv_bfloat16*>(weight),
         reinterpret_cast<__nv_bfloat16*>(out_sum),
         reinterpret_cast<__nv_bfloat16*>(out_norm), rows, cols, eps);
+}
+
+// add_rmsnorm2 that also emits Q8_1(out_norm). Requires rows==1 and cols%256==0 (decode
+// residual width); uses cols/8 threads so each thread owns one 8-wide pack.
+void launch_add_rmsnorm2_q8(const void* x, const void* residual, const void* weight,
+                            void* out_sum, void* out_norm, void* out_q8, int cols, float eps,
+                            cudaStream_t stream) {
+    // One row, one 8-wide pack per thread, a Q8_1 block = 4 consecutive threads: requires
+    // cols % 256 == 0 (every warp full, each 32-block within one warp) and cols/8 <= 1024
+    // (max block dim). The decode residual width (hidden = 2048) satisfies both.
+    assert(cols % 256 == 0 && (cols >> 3) <= 1024);
+    add_rmsnorm2_q8_kernel<<<1, cols >> 3, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out_sum),
+        reinterpret_cast<__nv_bfloat16*>(out_norm),
+        reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
 }
 #endif
 

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -627,7 +627,7 @@ void launch_moe_expert_ffn_q4k(
     int gate_type, int up_type, int down_type,
     const int* expert_ids, const float* expert_weights, void* output,
     float* h_scratch, float* out_scratch,
-    int num_tokens, int top_k, int hidden, int ffn, cudaStream_t stream
+    int num_tokens, int top_k, int hidden, int ffn, const void* input_q8, cudaStream_t stream
 ) {
     // int8 dp4a path for Q4_K gate/up (decode parity with llama.cpp's MMVQ). Default
     // ON — the largest single decode cost; down stays on the fp path (Q6_K). Set
@@ -639,10 +639,16 @@ void launch_moe_expert_ffn_q4k(
     if (gu2 < 0) { const char* g2 = getenv("SPARKINFER_GU2"); gu2 = (g2 && g2[0] == '0') ? 0 : 1; }
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
     if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
-        si_block_q8_1* q = reinterpret_cast<si_block_q8_1*>(out_scratch);    // Q8_1(hn) once
-        const int nqb = num_tokens * (hidden >> 5);
-        si_quant_bf16_q8_1<<<nqb, 32, 0, stream>>>(
-            reinterpret_cast<const __nv_bfloat16*>(input), q, num_tokens * hidden);
+        const si_block_q8_1* q;
+        if (input_q8) {   // pre-quantized Q8_1(hn) from the fused norm: skip the quantize node
+            q = reinterpret_cast<const si_block_q8_1*>(input_q8);
+        } else {
+            si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(out_scratch);  // Q8_1(hn) once
+            const int nqb = num_tokens * (hidden >> 5);
+            si_quant_bf16_q8_1<<<nqb, 32, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(input), qbuf, num_tokens * hidden);
+            q = qbuf;
+        }
         gate_up_mmvq2_kernel<<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
             q, reinterpret_cast<const unsigned char*>(gate_q),
             reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, hidden, ffn, top_k);

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -19,6 +19,12 @@ void launch_add_rmsnorm2(const void* x_bf16, const void* residual_bf16, const vo
                          void* out_sum_bf16, void* out_norm_bf16,
                          int rows, int cols, float eps, cudaStream_t stream = nullptr);
 
+// add_rmsnorm2 that additionally emits a Q8_1 quantization of out_norm (si_block_q8_1),
+// so the downstream int8 GEMV skips its own quantize node. rows==1, cols % 256 == 0.
+void launch_add_rmsnorm2_q8(const void* x_bf16, const void* residual_bf16, const void* weight_bf16,
+                            void* out_sum_bf16, void* out_norm_bf16, void* out_q8,
+                            int cols, float eps, cudaStream_t stream = nullptr);
+
 // Fused per-head Q-norm + K-norm in one kernel (1 graph node vs 2). In-place on q/k.
 void launch_rmsnorm_qk(void* q, void* k, const void* q_w, const void* k_w,
                        int n_q_heads, int n_kv_heads, int head_dim, float eps, cudaStream_t stream = nullptr);

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -64,6 +64,7 @@ void launch_moe_expert_ffn_q4k(
     const int* expert_ids, const float* expert_weights, void* output,
     float* h_scratch, float* out_scratch,
     int num_tokens, int top_k, int hidden, int ffn,
+    const void* input_q8 = nullptr,   // pre-quantized Q8_1(input) from the fused norm; nullptr = quantize internally
     cudaStream_t stream = nullptr);
 
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -83,6 +83,8 @@ struct Qwen35Model::Impl {
     bool use_llama = true; // default ON: faithful llama mmvq for Q4_K attn GEMVs (+9.7%, top1 0.99). =0 disables
     bool use_q6mmvq = true;  // default ON: int8 Q6_K mmvq for attn-V upgrades + LM head. =0 disables
     bool use_qkfuse = true;// default ON: fused per-head Q-norm + K-norm (1 kernel). =0 disables
+    bool use_fnq = true;   // default ON: post-MoE add_rmsnorm2 also emits Q8_1(xn), deleting the
+                           // next layer's standalone QKV-input quantize node. =0 disables
 
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -137,6 +139,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_LLAMA")) p_->use_llama = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_Q6MMVQ")) p_->use_q6mmvq = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKFUSE")) p_->use_qkfuse = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
 }
 
 Qwen35Model::~Qwen35Model() {
@@ -197,6 +200,11 @@ int Qwen35Model::forward_token(int token_id, int position) {
     // per-layer input RMSNorm + two residual-adds collapse into two fused kernels.
     kernels::launch_rmsnorm(s.x, s.w.layers[0].input_norm, s.xn, 1, H, c.rms_eps, st);
 
+    // When the fused norm+quant path is on, each layer's post-MoE add_rmsnorm2 also emits
+    // Q8_1(xn) into aq81, so the next layer's QKV-input quantize (and the LM-head quantize)
+    // are already done. Only the prime norm above still needs the standalone quant (layer 0).
+    const bool fnq = s.gguf && s.use_fnq && s.use_pq && s.use_llama;
+
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
         if (s.gguf) {   // GGUF dense weights are native [out,in] -> coalesced GEMV
@@ -204,7 +212,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
             // (no per-block, per-GEMV re-quant). Q6_K/bf16 weights keep their existing path.
             const bool any_q4k = (w.wq_type == 12 || w.wk_type == 12 || w.wv_type == 12);
             const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
-            if (s.use_pq && s.use_llama && (any_q4k || any_q6k))
+            if (fnq && L > 0) { /* aq81 = Q8_1(xn) already emitted by layer L-1's post-MoE norm */ }
+            else if (s.use_pq && s.use_llama && (any_q4k || any_q6k))
                 kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);   // shared Q8_1(xn) for Q4_K + Q6_K mmvq
             else if (s.use_pq && any_q4k)
                 kernels::launch_quantize_q8_1(s.xn, s.aq8, s.aq8_d, s.aq8_s, H, st);
@@ -256,8 +265,12 @@ int Qwen35Model::forward_token(int token_id, int position) {
         else if (s.gguf)         kernels::launch_gemv(s.attn, w.wo, s.ao, H, s.qdim, st);
         else                     kernels::launch_gemm(s.attn, w.wo, s.ao, 1, H, s.qdim, 1.f, 0.f, gc, st);
 
-        // fused: h = x + ao ; hn = RMSNorm(h, post_attn_norm)
-        kernels::launch_add_rmsnorm2(s.x, s.ao, w.post_attn_norm, s.h, s.hn, 1, H, c.rms_eps, st);
+        // fused: h = x + ao ; hn = RMSNorm(h, post_attn_norm). When fnq, also emit Q8_1(hn) into
+        // aq81 so the MoE gate/up mmvq skips its own quantize node (the router below reads bf16 hn).
+        if (fnq)
+            kernels::launch_add_rmsnorm2_q8(s.x, s.ao, w.post_attn_norm, s.h, s.hn, s.aq81, H, c.rms_eps, st);
+        else
+            kernels::launch_add_rmsnorm2(s.x, s.ao, w.post_attn_norm, s.h, s.hn, 1, H, c.rms_eps, st);
 
         if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
             kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
@@ -275,7 +288,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,
-                                               1, c.top_k, c.hidden, c.moe_ffn, st);
+                                               1, c.top_k, c.hidden, c.moe_ffn,
+                                               fnq ? s.aq81 : nullptr, st);
         } else {
             s.engine->set_layer_weights(L, {w.router_w, w.gate, w.up, w.down});
             s.engine->forward(s.hn, s.routed, 1, L, st);
@@ -288,11 +302,14 @@ int Qwen35Model::forward_token(int token_id, int position) {
         }
         // fused: x = h + routed ; xn = RMSNorm(x, next input_norm or final_norm)
         const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+        if (fnq)
+            kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+        else
+            kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
     }
     // xn now holds RMSNorm(x_final, final_norm)
     if (s.gguf && s.use_q6mmvq && s.w.lm_head_type == 14) {   // int8 Q6_K dp4a LM head (1 warp/row)
-        kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
+        if (!fnq) kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);  // else aq81 = Q8_1(xn) from final norm
         kernels::launch_gemv_q6k_dp4a_f32(s.aq81, s.w.lm_head, s.logits, c.vocab, H, st);
     }
     else if (s.gguf && s.w.lm_head_type) kernels::launch_gemv_q_f32(s.xn, s.w.lm_head, s.w.lm_head_type, s.logits, c.vocab, H, st);


### PR DESCRIPTION
## Summary

Each decode layer quantizes its RMSNorm output to Q8_1 in a standalone kernel before the int8 MMVQ projections: the post-MoE norm output feeds the next layer's Q/K/V, and the post-attention norm output feeds the MoE gate/up. Both quantizes are their own nodes on the captured decode graph, one of each per layer, plus one more at the LM head.

This folds the Q8_1 quantization into `add_rmsnorm2`. The norm already holds the normalized row in registers, so it also emits the `si_block_q8_1` activation. The next layer's Q/K/V-input quantize, the MoE gate/up input quantize, and the final LM-head quantize then go away, removing two graph nodes per layer plus one at the head. This is the same node-deletion lever as the merged fused Q/K-norm and RoPE work: small per-layer nodes carry real fill/drain overhead on the replayed graph, and removing them recovers it.

The emitted Q8_1 is computed from the bf16-rounded norm output with the same `amax/127` scale and `roundf(x/d)` rounding the standalone quantizers (`quantize_q8_1_blocks`, `si_quant_bf16_q8_1`) use, so it is bit-identical to running them on the norm output. Accuracy is unchanged. `SPARKINFER_FNQ=0` restores the standalone quantize path.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`bench/scripts/bench.sh`, Qwen3-30B-A3B Q4_K_M, n=128, bs=1):

| | decode tok/s |
|---|--:|
| before (`SPARKINFER_FNQ=0`) | 384.7 |
| after (this PR) | 395.3 |

About **+2.75%** decode (mean of 6 alternating runs, `SPARKINFER_FNQ` default vs `=0`).

```text
run 1: FNQ_on=396.01  FNQ_off=385.61
run 2: FNQ_on=395.97  FNQ_off=384.36
run 3: FNQ_on=394.22  FNQ_off=385.05
run 4: FNQ_on=395.20  FNQ_off=384.55
run 5: FNQ_on=395.93  FNQ_off=384.80
run 6: FNQ_on=394.37  FNQ_off=383.78
```

## Accuracy (bit-identical to baseline)

`bench/scripts/accuracy.sh` vs llama.cpp, FNQ on:

| metric | this PR | baseline (FNQ off) |
|---|--:|--:|
| token-match (top-1) | 0.970 | 0.970 |
| mean KL(llama‖spark) | 0.1417 | 0.1417 |

Identical, as expected for a bit-exact change (well under the 0.15 KL gate).

`ctest --test-dir build`: 6/6 passed. `compute-sanitizer --tool memcheck`: 0 errors.
