### PR TITLE
fix(runtime): clip generate max_new to max_seq budget

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -373,6 +373,26 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
     Impl& s = *p_;
     std::vector<int> out;
     if (prompt.empty()) return out;
+
+    const int prompt_len = (int)prompt.size();
+    if (s.cfg.max_seq <= 0) {
+        fprintf(stderr, "[qwen35] generate: max_seq must be > 0 (got %d)\n", s.cfg.max_seq);
+        return out;
+    }
+
+    if (max_new <= 0) return out;
+
+    if (prompt_len >= s.cfg.max_seq) {
+        fprintf(stderr, "[qwen35] generate: prompt length %d exceeds or equals max_seq %d\n", prompt_len, s.cfg.max_seq);
+        return out;
+    }
+
+    int max_allow = s.cfg.max_seq - prompt_len;
+    if (max_new > max_allow) {
+        fprintf(stderr, "[qwen35] generate: max_new clipped from %d to %d to fit max_seq=%d\n", max_new, max_allow, s.cfg.max_seq);
+        max_new = max_allow;
+    }
+
     if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
         fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
         return out;

--- a/runtime/tests/qwen35_gpu_test.cpp
+++ b/runtime/tests/qwen35_gpu_test.cpp
@@ -88,5 +88,20 @@ int main() {
     printf("[PASS] qwen35_gpu_test: generated 8 tokens:");
     for (int id : out) printf(" %d", id);
     printf("\n");
+
+    sparkinfer::Qwen35Config clipped_cfg = cfg;
+    clipped_cfg.max_seq = 4;
+    sparkinfer::KVCacheManager clipped_kv(kvc, 128ull<<20);
+    sparkinfer::Qwen35Model clipped_model(clipped_cfg, &clipped_kv, engine.get());
+    clipped_model.set_weights(w);
+
+    std::vector<int> short_prompt = {2, 8};
+    auto clipped = clipped_model.generate(short_prompt, 8);
+    if ((int)clipped.size() != 2) {
+        printf("[FAIL] expected clipped output 2 tokens, got %zu\n", clipped.size());
+        return 1;
+    }
+
+    printf("[PASS] qwen35_gpu_test: output clipping honors max_seq budget (max_new=8, max_seq=4, prompt_len=2 => 2 tokens)\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

 now validates sequence budget before decoding:
- rejects invalid configs ()
- rejects zero/negative generation requests
- rejects prompts that already fill/overflow 
- clips  to available budget () and logs clipping

This prevents silent overrun scenarios in generation where caller intent requests more tokens than the configured sequence capacity.

## Changes

- 
  - Added explicit /prompt budget validation in .
  - Added deterministic clip for  when it exceeds remaining budget.

- 
  - Added regression coverage for clipping behavior with  < .

## Why

Currently the function allocates KV for  and then loops requested  tokens, which can produce undefined/unexpected behavior for oversize requests. This is a safety/correctness fix.

## Testing

- 
- Build/test attempted locally, but CUDA toolkit is unavailable in this environment ( not found), so runtime test execution is not possible here.

## Related

- Fixes: https://github.com/gittensor-ai-lab/sparkinfer/issues/92