### PR TITLE
runtime: guard forward_token token_id range

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -180,6 +180,12 @@ void Qwen35Model::copy_logits(float* host_logits) const {
 int Qwen35Model::forward_token(int token_id, int position) {
     Impl& s = *p_;
     const Qwen35Config& c = s.cfg;
+
+    if (token_id < 0 || token_id >= c.vocab) {
+        fprintf(stderr, "[qwen35] forward_token: token %d out of range [0, %d)\n", token_id, c.vocab);
+        return c.eos_id;
+    }
+
     const int H = c.hidden;
     kernels::GemmConfig gc{};
     int seqlen = position + 1;

--- a/runtime/tests/qwen35_gpu_test.cpp
+++ b/runtime/tests/qwen35_gpu_test.cpp
@@ -88,5 +88,21 @@ int main() {
     printf("[PASS] qwen35_gpu_test: generated 8 tokens:");
     for (int id : out) printf(" %d", id);
     printf("\n");
+
+    const int eos = cfg.eos_id;
+    int invalid_neg = model.forward_token(-1, 0);
+    if (invalid_neg != eos) {
+        printf("[FAIL] expected forward_token(-1, ...) to return eos_id=%d, got %d\n", eos, invalid_neg);
+        return 1;
+    }
+
+    int invalid_oob = model.forward_token(cfg.vocab, 0);
+    if (invalid_oob != eos) {
+        printf("[FAIL] expected forward_token(vocab, ...) to return eos_id=%d, got %d\n", eos, invalid_oob);
+        return 1;
+    }
+
+    printf("[PASS] qwen35_gpu_test: forward_token rejects out-of-range token ids\n");
+
     return 0;
 }


### PR DESCRIPTION
## Summary

Fixes direct token-ID OOB safety in `Qwen35Model::forward_token()`.

- Adds explicit validation for `token_id` before embedding lookup.
- On invalid IDs, logs a bounded-range error and returns `cfg.eos_id`.

## Why

`forward_token()` is a public API and can be called directly. Without a guard, out-of-range token IDs can trigger out-of-bounds embedding reads even when `generate()` path checks are in place.

## Changes

- `runtime/src/models/qwen35.cpp`
  - Add range check in `Qwen35Model::forward_token()`.
- `runtime/tests/qwen35_gpu_test.cpp`
  - Add regression assertions for negative and out-of-range token IDs.

## Testing

- `git diff --check`
- CUDA runtime not available in this environment (`nvcc` missing), so this test was not executed here.

## Related

- Fixes: https://github.com/gittensor-ai-lab/sparkinfer/issues/94
