### PR TITLE
runtime: guard forward_token position range

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -180,6 +180,12 @@ void Qwen35Model::copy_logits(float* host_logits) const {
 int Qwen35Model::forward_token(int token_id, int position) {
     Impl& s = *p_;
     const Qwen35Config& c = s.cfg;
+
+    if (position < 0 || position >= c.max_seq) {
+        fprintf(stderr, "[qwen35] forward_token: position %d out of range [0, %d)\n", position, c.max_seq);
+        return c.eos_id;
+    }
+
     const int H = c.hidden;
     kernels::GemmConfig gc{};
     int seqlen = position + 1;

--- a/runtime/tests/qwen35_gpu_test.cpp
+++ b/runtime/tests/qwen35_gpu_test.cpp
@@ -88,5 +88,20 @@ int main() {
     printf("[PASS] qwen35_gpu_test: generated 8 tokens:");
     for (int id : out) printf(" %d", id);
     printf("\n");
+
+    int invalid_pos_neg = model.forward_token(1, -1);
+    if (invalid_pos_neg != cfg.eos_id) {
+        printf("[FAIL] expected forward_token(1, -1) to return eos_id=%d, got %d\n", cfg.eos_id, invalid_pos_neg);
+        return 1;
+    }
+
+    int invalid_pos_oob = model.forward_token(1, cfg.max_seq);
+    if (invalid_pos_oob != cfg.eos_id) {
+        printf("[FAIL] expected forward_token(1, max_seq) to return eos_id=%d, got %d\n", cfg.eos_id, invalid_pos_oob);
+        return 1;
+    }
+
+    printf("[PASS] qwen35_gpu_test: forward_token rejects out-of-range positions\n");
+
     return 0;
 }


### PR DESCRIPTION
## Summary

Adds explicit bounds validation for token position in `Qwen35Model::forward_token()` before entering the decode path.

## Problem

`forward_token(int token_id, int position)` can receive an invalid `position` and still reach KV/position-sensitive internals. A negative position or `position >= cfg.max_seq` can create invalid write positions for KV append/block-addressing paths.

## Changes

- `runtime/src/models/qwen35.cpp`
  - Add guard: return `c.eos_id` with a warning when `position < 0` or `position >= c.max_seq`.
- `runtime/tests/qwen35_gpu_test.cpp`
  - Add regressions for:
    - `model.forward_token(1, -1)`
    - `model.forward_token(1, cfg.max_seq)`

Both cases assert the result is `cfg.eos_id` and avoid launching decode on invalid positions.

## Testing

- `git diff --check`
- CUDA runtime unavailable in this environment (`nvcc` missing), so GPU tests were not executed here.

Closes #96