### PR TITLE
perf(decode): emit Q8_1(attn) from the flash-decode combine, dropping the O-proj activation quantize

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -12,12 +12,18 @@
 // One warp per block; head_dim=128 (Qwen3). Portable CUDA — sm_89 .. sm_120/121.
 
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #endif
 
 namespace sparkinfer {
 namespace kernels {
+
+// Activation Q8_1 block, layout-identical to gemm.cu's si_block_q8_1 (the format the
+// llama-port Q4_K/Q6_K MMVQ kernels read). The combine kernel can emit it directly so the
+// O-projection's standalone activation quantize is deleted from the per-layer decode chain.
+struct fa_q8_block { __half2 ds; signed char qs[32]; };   // 36 B / 32 values
 
 __device__ __forceinline__ float fa_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
 __device__ __forceinline__ float fa_wsum(float v) {
@@ -84,6 +90,7 @@ template <int HEAD_DIM, int DG, int NW>
 __global__ void fa_combine_kernel(
     const float* __restrict__ part_m, const float* __restrict__ part_l,
     const float* __restrict__ part_acc, __nv_bfloat16* __restrict__ out,
+    fa_q8_block* __restrict__ out_q8,   // optional: Q8_1(out) for the O-proj MMVQ (nullptr = skip)
     int num_q_heads, int n_splits
 ) {
     constexpr int ELEMS = HEAD_DIM / (32 * DG);
@@ -127,8 +134,34 @@ __global__ void fa_combine_kernel(
     }
     const float inv = (gl > 0.f) ? (1.f / gl) : 0.f;
     __nv_bfloat16* op = out + (size_t)(seq * num_q_heads + qh) * HEAD_DIM;
+
+    // Each (qh, dg) block runs ONE warp (warp 0) over 32 lanes, and for each ELEMS step the
+    // 32 lanes write a contiguous 32-element slice of head qh: doff = dg*(HEAD_DIM/DG)+lane,
+    // so {lane, lane+32, ...} cover head-elements [(dg*ELEMS+e)*32 .. +32). That slice is
+    // EXACTLY one si_block_q8_1, so when out_q8 is given we quantize it here (warp amax/sum
+    // over the same 32 lanes) — bit-identical to running si_quantize_q8_1_blocks on `out`
+    // afterwards (same bf16-rounded value, d=amax/127, qi=round(v/d), ds=(d, d*sum)) — and the
+    // runtime drops that per-layer kernel. Works for any DG: each e is its own 32-block.
+    const int bph = HEAD_DIM >> 5;   // 32-element blocks per head
     #pragma unroll
-    for (int e = 0; e < ELEMS; e++) op[doff + e * 32] = __float2bfloat16(acc[e] * inv);
+    for (int e = 0; e < ELEMS; e++) {
+        const __nv_bfloat16 ob = __float2bfloat16(acc[e] * inv);
+        op[doff + e * 32] = ob;
+        if (out_q8 != nullptr) {
+            const float bv = __bfloat162float(ob);   // bf16-rounded value, as the standalone reads back
+            float a = fabsf(bv);
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
+            const float d = a / 127.0f;
+            const int qi = (a == 0.0f) ? 0 : (int)roundf(bv / d);
+            int qsum = qi;
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) qsum += __shfl_xor_sync(0xffffffffu, qsum, m);
+            const int ib = (seq * num_q_heads + qh) * bph + dg * ELEMS + e;   // 32-block index in out
+            out_q8[ib].qs[lane] = (signed char)qi;
+            if (lane == 0) out_q8[ib].ds = __floats2half2_rn(d, d * (float)qsum);
+        }
+    }
 }
 
 #ifndef FA_COMBINE_DG
@@ -139,7 +172,7 @@ __global__ void fa_combine_kernel(
 #endif
 template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
-template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int);
+template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, fa_q8_block*, int, int);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -149,7 +182,7 @@ void launch_flash_decode_split(
     const int* block_table, const int* seq_lens, void* out,
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
-    int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream
+    int block_size, int max_blocks, int n_splits, float scale, void* out_q8, cudaStream_t stream
 ) {
     dim3 g1(num_q_heads * n_splits, num_seqs);
     fa_split_kernel<128><<<g1, 32, 0, stream>>>(
@@ -158,7 +191,8 @@ void launch_flash_decode_split(
         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
     dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
     fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
-        part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits);
+        part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+        reinterpret_cast<fa_q8_block*>(out_q8), num_q_heads, n_splits);
     (void)head_dim;
 }
 #endif

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -77,13 +77,16 @@ void launch_flash_decode_local_hd256(
 // (seq_len read in-kernel) so it is CUDA-graph capturable. head_dim=128.
 //   part_m/part_l: [num_seqs*num_q_heads*n_splits] (fp32 scratch)
 //   part_acc:      [num_seqs*num_q_heads*n_splits*head_dim] (fp32 scratch)
+// out_q8 (optional): when non-null, the combine pass also emits a Q8_1 quantization of `out`
+//   (si_block_q8_1 layout, num_seqs*num_q_heads*head_dim/32 blocks) so the O-projection MMVQ
+//   skips its standalone activation quantize. Bit-identical to quantizing `out` afterwards.
 void launch_flash_decode_split(
     const void* q, const void* k_pool, const void* v_pool,
     const int* block_table, const int* seq_lens, void* out,
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale,
-    cudaStream_t stream = nullptr);
+    void* out_q8 = nullptr, cudaStream_t stream = nullptr);
 
 // Flash decode for GLOBAL layers: full context, head_dim=512, GQA 8:1.
 // Two-phase dot product splits 512-dim head into two 256-dim halves.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -89,6 +89,8 @@ struct Qwen35Model::Impl {
     bool use_ropekv = true;// default ON: fused RoPE + KV-append (1 kernel vs 2). =0 disables
     bool use_fnq = true;   // default ON: post-MoE add_rmsnorm2 also emits Q8_1(xn), deleting the
                            // next layer's standalone QKV-input quantize node. =0 disables
+    bool use_attnq8 = true;// default ON: the flash-decode combine emits Q8_1(attn), deleting the
+                           // O-proj's standalone activation quantize node (1 kernel/layer). =0 disables
 
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -149,6 +151,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_QKFUSE")) p_->use_qkfuse = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ROPEKV")) p_->use_ropekv = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_ATTNQ8")) p_->use_attnq8 = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKVSTREAM")) p_->use_qkvstream = !(e[0] == '0');
 }
 
@@ -281,13 +284,19 @@ int Qwen35Model::forward_token(int token_id, int position) {
             launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_writepos, 1,
                              c.n_kv_heads, c.head_dim, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
         }
+        // When the O-proj takes the llama Q4_K MMVQ path (reads a Q8_1 of attn), emit that Q8_1
+        // straight from the flash-decode combine — bit-identical to quantizing attn afterwards —
+        // and drop the standalone quantize node. Needs head_dim==128 (the only split instantiation).
+        const bool attnq8 = s.gguf && s.use_pq && s.use_llama && s.use_attnq8
+                            && (w.wo_type == 12) && (c.head_dim == 128);
         kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,
                                            s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,
                                            s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
-                                           1.f / sqrtf((float)c.head_dim), st);
+                                           1.f / sqrtf((float)c.head_dim), attnq8 ? s.aq81 : nullptr, st);
         if (s.gguf && s.use_pq && w.wo_type == 12) {   // O proj reads attn: quantize once + dp4a
             if (s.use_llama) {
-                kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                if (!attnq8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                // else: s.aq81 already holds Q8_1(s.attn), emitted by the combine pass above
                 kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
             } else {
                 kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);


### PR DESCRIPTION
## Summary

The O-projection takes the llama Q4_K MMVQ path, which needs a Q8_1 of the attention
output. Today that's a standalone per-layer kernel (`launch_quantize_q8_1_blocks(attn)`)
on the bs=1 decode critical path — between the flash-decode combine and the O-proj MMVQ —
that reads the whole `attn` vector back just to write its Q8_1 blocks.

The combine pass already produces `attn`. With `FA_COMBINE_DG` splitting each head into
32-wide groups, warp 0's 32 lanes write exactly one contiguous 32-element slice per `ELEMS`
step — i.e. exactly one `si_block_q8_1`. So the combine now emits the Q8_1 itself (warp
amax/sum over those same 32 lanes) and the runtime drops the standalone quantize entirely:
**1 kernel/layer (40/token) off the dependency chain, plus the attn readback.**

This is the O-projection analog of the already-merged residual-RMSNorm Q8_1 fusion (#83),
which did the same for the QKV-input and gate/up-input quantizes but not the attention output.

**Correctness — bit-for-bit identical, gate cannot move.** The Q8_1 is derived from the
**bf16-rounded** combine output (the exact value the standalone quantizer reads back), with
the same arithmetic as `si_quantize_q8_1_blocks`: amax via `shfl_xor`, `d = amax/127`,
`qi = roundf(v/d)` (0 when `amax == 0`), `ds = (d, d*sum)`. Every written byte is unchanged.

- Works for any `FA_COMBINE_DG` — each `ELEMS` step is its own 32-block, so it doesn't depend
  on the sweepable combine layout.
- Default ON; `SPARKINFER_ATTNQ8=0` disables for A/B. Gated on the llama Q4_K O-proj path
  (`use_pq && use_llama`, `wo_type == 12`) and `head_dim == 128` (the only `flash_decode_split`
  instantiation); falls back to the standalone quantize otherwise, so every other path is unchanged.
- Stream ordering for `aq81` is unchanged: the combine writes it on the main stream after the
  Q/K/V projections (which read it) have joined back — the same point the standalone wrote it.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`):

```text
# paste bench/scripts/bench.sh output here (before -> after)
```

Accuracy gate (`bench/scripts/accuracy.sh`): top-1 ≈100% / KL ≈0 vs the prior build — holds by
construction (output bytes are identical; only the kernel count drops).
