### PR TITLE
Add CPU unit tests for continuous-batching scheduler

### DIFF
--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -13,6 +13,12 @@ target_link_libraries(thermal_governor_cpu_test PRIVATE sparkinfer_runtime)
 set_target_properties(thermal_governor_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME thermal_governor_cpu_test COMMAND thermal_governor_cpu_test)
 
+# Continuous-batching scheduler — pure host policy (no GPU).
+add_executable(scheduler_cpu_test scheduler_cpu_test.cpp)
+target_link_libraries(scheduler_cpu_test PRIVATE sparkinfer_runtime)
+set_target_properties(scheduler_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME scheduler_cpu_test COMMAND scheduler_cpu_test)
+
 # GPU integration tests — run the real device path; skip without a device.
 add_executable(decode_runner_gpu_test decode_runner_gpu_test.cpp)
 target_link_libraries(decode_runner_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/tests/scheduler_cpu_test.cpp
+++ b/runtime/tests/scheduler_cpu_test.cpp
@@ -1,0 +1,110 @@
+// CPU test for the continuous-batching scheduler — pure host policy, no GPU needed.
+// Validates priority ordering, token-budget packing, and preemption victim selection.
+
+#include "sparkinfer/scheduler.h"
+#include <cstdio>
+#include <vector>
+
+using S = sparkinfer::Scheduler;
+using SG = sparkinfer::SequenceGroup;
+#define CHECK(x) do { if (!(x)) { printf("FAIL: %s (line %d)\n", #x, __LINE__); return 1; } } while (0)
+
+static SG group(uint64_t id, int num_seqs, int priority) {
+    return SG{id, num_seqs, /*max_new_tokens=*/128, priority};
+}
+
+int main() {
+    // Empty scheduler → empty batch.
+    {
+        S sched;
+        auto batch = sched.schedule();
+        CHECK(batch.decode_seq_ids.empty());
+        CHECK(batch.prefill_seq_ids.empty());
+        CHECK(batch.total_tokens == 0);
+    }
+
+    // Single group fills the batch.
+    {
+        S sched(/*policy=*/sparkinfer::SchedulePolicy::PRIORITY, /*max_tokens=*/4);
+        sched.add_sequence_group(group(10, 2, 5));
+        auto batch = sched.schedule();
+        CHECK(batch.total_tokens == 2);
+        CHECK(batch.decode_seq_ids.size() == 2u);
+        CHECK(batch.decode_seq_ids[0] == 10);
+        CHECK(batch.decode_seq_ids[1] == 10);
+    }
+
+    // Higher priority groups are scheduled first.
+    {
+        S sched(sparkinfer::SchedulePolicy::PRIORITY, 8);
+        sched.add_sequence_group(group(1, 1, 1));
+        sched.add_sequence_group(group(2, 1, 10));
+        sched.add_sequence_group(group(3, 1, 5));
+        auto batch = sched.schedule();
+        CHECK(batch.decode_seq_ids.size() == 3u);
+        CHECK(batch.decode_seq_ids[0] == 2);
+        CHECK(batch.decode_seq_ids[1] == 3);
+        CHECK(batch.decode_seq_ids[2] == 1);
+        CHECK(batch.total_tokens == 3);
+    }
+
+    // Token budget stops packing when the next whole group would exceed the limit.
+    {
+        S sched(sparkinfer::SchedulePolicy::PRIORITY, 5);
+        sched.add_sequence_group(group(1, 2, 10));
+        sched.add_sequence_group(group(2, 2, 5));
+        sched.add_sequence_group(group(3, 2, 1));
+        auto batch = sched.schedule();
+        CHECK(batch.total_tokens == 4);
+        CHECK(batch.decode_seq_ids.size() == 4u);
+        // Groups 1 and 2 fit (2+2=4); group 3 would push to 6 > 5.
+        CHECK(batch.decode_seq_ids[0] == 1);
+        CHECK(batch.decode_seq_ids[1] == 1);
+        CHECK(batch.decode_seq_ids[2] == 2);
+        CHECK(batch.decode_seq_ids[3] == 2);
+    }
+
+    // remove_sequence_group drops a group from future schedules.
+    {
+        S sched(sparkinfer::SchedulePolicy::PRIORITY, 8);
+        sched.add_sequence_group(group(1, 1, 1));
+        sched.add_sequence_group(group(2, 1, 5));
+        sched.remove_sequence_group(1);
+        auto batch = sched.schedule();
+        CHECK(batch.decode_seq_ids.size() == 1u);
+        CHECK(batch.decode_seq_ids[0] == 2);
+    }
+
+    // preempt() evicts lowest-priority groups until enough tokens are freed.
+    {
+        S sched(sparkinfer::SchedulePolicy::PRIORITY, 8);
+        sched.add_sequence_group(group(1, 2, 1));
+        sched.add_sequence_group(group(2, 3, 5));
+        sched.add_sequence_group(group(3, 1, 10));
+        auto victims = sched.preempt(4);
+        CHECK(victims.size() == 2u);
+        CHECK(victims[0] == 1);  // lowest priority, 2 seqs
+        CHECK(victims[1] == 2);  // next lowest, 3 seqs → 5 freed total
+    }
+
+    // preempt() returns a single group when it alone satisfies the budget.
+    {
+        S sched(sparkinfer::SchedulePolicy::PRIORITY, 8);
+        sched.add_sequence_group(group(1, 5, 1));
+        sched.add_sequence_group(group(2, 2, 10));
+        auto victims = sched.preempt(3);
+        CHECK(victims.size() == 1u);
+        CHECK(victims[0] == 1);
+    }
+
+    // preempt() with zero need returns empty.
+    {
+        S sched;
+        sched.add_sequence_group(group(1, 1, 1));
+        auto victims = sched.preempt(0);
+        CHECK(victims.empty());
+    }
+
+    printf("scheduler_cpu_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `scheduler_cpu_test` — pure host-side tests for the runtime continuous-batching scheduler (`runtime/src/scheduler.cpp`)
- Covers priority ordering, token-budget packing (whole-group limits), preemption victim selection, and group add/remove lifecycle
- Wired into `runtime/tests/CMakeLists.txt` alongside existing CPU tests

Closes #100.

## Test plan
- [ ] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j`
- [ ] `ctest --test-dir build -R scheduler_cpu_test`
- [ ] `ctest --test-dir build` — all CPU tests pass (GPU tests self-skip without device)

No RTX 5090 / decode benchmark required — scheduler policy is host-only.