### PR TITLE
fix(gguf): reject tensors whose dimension product overflows signed long

### DIFF
--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -115,8 +115,22 @@ bool GGUF::open(const std::string& path) {
         uint32_t nd = c.rd<uint32_t>();
         if (!c.ok || nd > 4) { fprintf(stderr, "[gguf] tensor %s has invalid n_dims=%u (max 4)\n", in.name.c_str(), nd); return false; }
         in.t.n_dims = nd;
+        // dims are file-controlled. A crafted product (e.g. {2^32, 2^32}) would
+        // overflow signed long — UB — and wrap to a small/zero n_values that then
+        // slips past the data-bounds check below (n_bytes==0 always fits), so a
+        // bogus tensor with billion-element real dims gets silently accepted.
+        // Reject negative dims and any product that overflows.
         long nv = 1;
-        for (uint32_t d = 0; d < nd; d++) { long e = (long)c.rd<uint64_t>(); in.t.dims[d] = e; nv *= e; }
+        bool dim_overflow = false;
+        for (uint32_t d = 0; d < nd; d++) {
+            long e = (long)c.rd<uint64_t>();
+            in.t.dims[d] = e;
+            if (e < 0 || __builtin_mul_overflow(nv, e, &nv)) dim_overflow = true;
+        }
+        if (!c.ok || dim_overflow) {
+            fprintf(stderr, "[gguf] tensor %s has an out-of-range dimension product\n", in.name.c_str());
+            return false;
+        }
         in.t.ggml_type = c.rd<uint32_t>();
         in.offset = c.rd<uint64_t>();
         in.t.n_values = nv;

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -7,6 +7,12 @@ add_executable(qwen35_cpu_test qwen35_cpu_test.cpp)
 set_target_properties(qwen35_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME qwen35_cpu_test COMMAND qwen35_cpu_test)
 
+# GGUF reader tensor-table parsing — pure host C++ (no GPU); compiles the reader source directly.
+add_executable(gguf_cpu_test gguf_cpu_test.cpp ${CMAKE_CURRENT_SOURCE_DIR}/../src/gguf.cpp)
+target_include_directories(gguf_cpu_test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+set_target_properties(gguf_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME gguf_cpu_test COMMAND gguf_cpu_test)
+
 # Thermal governor — pure tiering policy (no GPU); links the runtime for classify()/pace() symbols.
 add_executable(thermal_governor_cpu_test thermal_governor_cpu_test.cpp)
 target_link_libraries(thermal_governor_cpu_test PRIVATE sparkinfer_runtime)

--- a/runtime/tests/gguf_cpu_test.cpp
+++ b/runtime/tests/gguf_cpu_test.cpp
@@ -1,0 +1,101 @@
+// CPU test for the GGUF reader's tensor-table parsing. Builds tiny in-memory
+// GGUF files and checks that a tensor whose dimension product overflows signed
+// long is rejected (regression for the silent-accept bug where the product
+// wraps to a small/zero n_values that slips past the data-bounds check), while
+// a well-formed tensor still loads. Pure host C++, no GPU/CUDA needed.
+//
+// Build: g++ -O2 -std=c++17 gguf_cpu_test.cpp ../src/gguf.cpp -I../include -o gguf_cpu_test
+
+#include "sparkinfer/gguf.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <unistd.h>
+
+using std::vector;
+
+static void put_u32(vector<uint8_t>& b, uint32_t v) {
+    for (int i = 0; i < 4; i++) b.push_back((uint8_t)((v >> (8 * i)) & 0xFF));
+}
+static void put_u64(vector<uint8_t>& b, uint64_t v) {
+    for (int i = 0; i < 8; i++) b.push_back((uint8_t)((v >> (8 * i)) & 0xFF));
+}
+static void put_str(vector<uint8_t>& b, const std::string& s) {
+    put_u64(b, s.size());
+    for (char c : s) b.push_back((uint8_t)c);
+}
+
+static std::string write_temp(const vector<uint8_t>& bytes) {
+    char path[] = "/tmp/sparkinfer_gguf_XXXXXX";
+    int fd = mkstemp(path);
+    if (fd < 0) { perror("mkstemp"); std::abort(); }
+    ssize_t n = write(fd, bytes.data(), bytes.size());
+    if (n != (ssize_t)bytes.size()) { perror("write"); std::abort(); }
+    close(fd);
+    return std::string(path);
+}
+
+static int failures = 0;
+#define CHECK(cond, msg)                                                       \
+    do {                                                                       \
+        if (!(cond)) { fprintf(stderr, "FAIL: %s\n", msg); failures++; }       \
+    } while (0)
+
+int main() {
+    using namespace sparkinfer;
+
+    // 1) A tensor whose dimension product overflows signed long must be rejected.
+    {
+        vector<uint8_t> b;
+        b.insert(b.end(), {'G', 'G', 'U', 'F'});
+        put_u32(b, 3);                 // version
+        put_u64(b, 1);                 // n_tensors
+        put_u64(b, 0);                 // n_kv
+        put_str(b, "t");               // tensor name
+        put_u32(b, 2);                 // n_dims
+        put_u64(b, 0x100000000ull);    // 2^32
+        put_u64(b, 0x100000000ull);    // 2^32 -> product 2^64 overflows long
+        // ggml_type/offset are intentionally omitted: open() must bail at the
+        // dimension-product guard before it ever reads them.
+        std::string p = write_temp(b);
+        GGUF g;
+        bool ok = g.open(p);
+        unlink(p.c_str());
+        CHECK(!ok, "tensor with overflowing dimension product was accepted");
+    }
+
+    // 2) A well-formed single tensor still loads (the guard is not over-eager).
+    {
+        vector<uint8_t> b;
+        b.insert(b.end(), {'G', 'G', 'U', 'F'});
+        put_u32(b, 3);                 // version
+        put_u64(b, 1);                 // n_tensors
+        put_u64(b, 0);                 // n_kv
+        put_str(b, "t");               // name
+        put_u32(b, 1);                 // n_dims
+        put_u64(b, 4);                 // dims[0] = 4
+        put_u32(b, 0);                 // ggml_type = F32 (4 bytes/elem) -> 16 bytes
+        put_u64(b, 0);                 // data offset = 0
+        // Header ends at byte 57; tensor data aligns to 32 -> starts at byte 64.
+        while (b.size() < 64) b.push_back(0);
+        for (int i = 0; i < 16; i++) b.push_back(0);  // 16 bytes of tensor data
+        std::string p = write_temp(b);
+        GGUF g;
+        bool ok = g.open(p);
+        const GGUFTensor* t = g.tensor("t");
+        unlink(p.c_str());
+        CHECK(ok, "well-formed GGUF failed to open");
+        CHECK(t != nullptr && t->n_values == 4 && t->n_bytes == 16,
+              "well-formed tensor parsed with wrong shape");
+    }
+
+    if (failures == 0) {
+        printf("gguf_cpu_test: all checks passed\n");
+        return 0;
+    }
+    fprintf(stderr, "gguf_cpu_test: %d check(s) failed\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

Fixes a memory-safety bug in the GGUF reader: a tensor's dimension product is accumulated into a signed `long` with no overflow check, so a crafted/corrupt file can wrap the product to a small or zero value that then slips past the data-bounds check. Closes #29. (Correctness fix — no decode speedup, so the eval box below is intentionally left unticked.)

## Details

In `runtime/src/gguf.cpp`, the tensor-table loop did:

```cpp
long nv = 1;
for (uint32_t d = 0; d < nd; d++) { long e = (long)c.rd<uint64_t>(); in.t.dims[d] = e; nv *= e; }
...
in.t.n_values = nv;
long bb, be; block_info(in.t.ggml_type, bb, be);
in.t.n_bytes = be ? (nv / be) * bb : 0;
```

`nv *= e` over file-controlled `uint64_t` dims is signed-overflow (UB). A file with dims like `{2^32, 2^32}` makes the product `2^64`, which wraps to `0`. Then `n_values == 0` and `n_bytes == 0`, and the existing data-bounds guard (which checks `n_bytes` against the file size) passes — so a bogus tensor with billion-element real dims is silently accepted, and downstream allocations/copies use the wrong sizes.

The fix rejects negative dims and detects the product overflow with `__builtin_mul_overflow` (consistent with the file's existing "fail loudly on malformed metadata" guards, and with the codebase's existing use of GCC/Clang builtins/pragmas), bailing before the bogus tensor is stored.

## Test

Adds `runtime/tests/gguf_cpu_test.cpp` (registered in `runtime/tests/CMakeLists.txt`) — a pure host C++ CPU test (no GPU/CUDA) that:

1. Builds a minimal in-memory GGUF whose single tensor has dims `{2^32, 2^32}` and asserts `GGUF::open()` now returns `false` (it returned `true` with a silently-wrong `n_values == 0` before the fix).
2. Builds a well-formed single-tensor GGUF and asserts it still opens and parses with the correct shape (guards against an over-eager check).

Build/run: `cmake -B build … && cmake --build build -j && ctest --test-dir build --output-on-failure` (the new test is host-only and needs no device).

> Note: prepared in an environment without a CUDA toolkit / C++ build available, so I could not run `ctest` locally; the reader source (`gguf.cpp`) and the new test are pure POSIX host C++ and are expected to build/pass in CI.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

N/A — this is a memory-safety bug fix, not a decode optimization. No tok/s change is claimed.
