### PR TITLE
perf(decode): emit Q8_1 from gate/up MMVQ tail, drop the MoE-down quantize node

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -424,16 +424,35 @@ __device__ __forceinline__ float si_vec_dot_q4_K(const si_block_q4_K* bq4, const
     float2 dm4f = __half22float2(bq4->dm);
     return dm4f.x * sumf_d - dm4f.y * sumf_m;
 }
+// Bit-identical to quant_h_q8_1_kernel for one ib, reading h[ts*F + f0 + lane].
+__device__ __forceinline__ void si_quant_h_block_q8_1(
+    const float* __restrict__ h, int ts, int f0, int F, int ib, si_block_q8_1* __restrict__ y) {
+    const int lane = threadIdx.x & 31;
+    float xv = h[(size_t)ts * F + f0 + lane], a = fabsf(xv);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
+    float d = a / 127.0f;
+    int qi = (a == 0.0f) ? 0 : (int)roundf(xv / d);
+    y[ib].qs[lane] = (signed char)qi;
+    int s = qi;
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+    if (lane == 0) y[ib].ds = __floats2half2_rn(d, d * (float)s);
+}
+
 __global__ void gate_up_mmvq2_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
-    float* __restrict__ h_scratch, int H, int F, int top_k
+    float* __restrict__ h_scratch, int H, int F, int top_k,
+    si_block_q8_1* __restrict__ hq8, unsigned int* __restrict__ q8_ready
 ) {
     si_pdl_lc();
     constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
     const int row = blockIdx.x, ts = row / F, f = row % F, tok = ts / top_k;
     const int e = expert_ids[ts];
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int q8pb = F >> 5;
+    const int ib = ts * q8pb + (f >> 5);
     const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
     const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 144);
     const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 144);
@@ -445,6 +464,7 @@ __global__ void gate_up_mmvq2_kernel(
         tu += si_vec_dot_q4_K(u_row + kbx, vrow + kby, kqs);
     }
     __shared__ float sg[NW - 1][WS], su[NW - 1][WS];
+    __shared__ int s_do_q8;
     if (warp > 0) { sg[warp - 1][lane] = tg; su[warp - 1][lane] = tu; }
     __syncthreads();
     if (warp > 0) return;
@@ -453,6 +473,18 @@ __global__ void gate_up_mmvq2_kernel(
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+
+    if (!hq8) return;
+
+    __threadfence();
+    if (lane == 0) {
+        const unsigned bit = 1u << (f & 31);
+        const unsigned prev = atomicOr(q8_ready + ib, bit);
+        s_do_q8 = ((prev | bit) == 0xFFFFFFFFu) ? 1 : 0;
+    }
+    __syncthreads();
+    if (!s_do_q8) return;
+    si_quant_h_block_q8_1(h_scratch, ts, (f >> 5) << 5, F, ib, hq8);
 }
 
 // int8 dp4a MMVQ down (Q4_K). The Q4_K-quantized down rows in Q4_K_M were the last MoE GEMV
@@ -627,7 +659,8 @@ void launch_moe_expert_ffn_q4k(
     int gate_type, int up_type, int down_type,
     const int* expert_ids, const float* expert_weights, void* output,
     float* h_scratch, float* out_scratch,
-    int num_tokens, int top_k, int hidden, int ffn, const void* input_q8, cudaStream_t stream
+    int num_tokens, int top_k, int hidden, int ffn, const void* input_q8,
+    unsigned int* q8_ready, cudaStream_t stream
 ) {
     // int8 dp4a path for Q4_K gate/up (decode parity with llama.cpp's MMVQ). Default
     // ON — the largest single decode cost; down stays on the fp path (Q6_K). Set
@@ -637,6 +670,10 @@ void launch_moe_expert_ffn_q4k(
 
     static int gu2 = -1;   // default ON: faithful 4-warp Q4_K mmvq gate/up. =0 falls back to #50 path
     if (gu2 < 0) { const char* g2 = getenv("SPARKINFER_GU2"); gu2 = (g2 && g2[0] == '0') ? 0 : 1; }
+    static int moedq = -1; // default ON: emit Q8_1(h) from gate_up tail, drop down quantize node. =0 disables
+    if (moedq < 0) { const char* md = getenv("SPARKINFER_MOEDQ"); moedq = (md && md[0] == '0') ? 0 : 1; }
+    const bool fuse_down_q8 = moedq && q8_ready != nullptr && input_q8 != nullptr;
+    si_block_q8_1* hq8 = fuse_down_q8 ? reinterpret_cast<si_block_q8_1*>(out_scratch) : nullptr;
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
     if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
         const si_block_q8_1* q;
@@ -651,7 +688,8 @@ void launch_moe_expert_ffn_q4k(
         }
         gate_up_mmvq2_kernel<<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
             q, reinterpret_cast<const unsigned char*>(gate_q),
-            reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, hidden, ffn, top_k);
+            reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, hidden, ffn, top_k,
+            hq8, fuse_down_q8 ? q8_ready : nullptr);
     } else if (mmvq && gate_type == 12 && up_type == 12) {   // 12 = ggml Q4_K
         size_t sm = 2 * (size_t)(hidden >> 5) * sizeof(float) + (size_t)hidden;  // s_xd+s_xs+s_xq8
         gate_up_q4k_mmvq_kernel<<<gu, WPB * 32, sm, stream>>>(
@@ -676,11 +714,13 @@ void launch_moe_expert_ffn_q4k(
     static int down_mmvq = -1;
     if (down_mmvq < 0) { const char* dv = getenv("SPARKINFER_DOWN_MMVQ"); down_mmvq = (dv && dv[0] == '0') ? 0 : 1; }
     if (down_mmvq && down_type == 14) {   // 14 = ggml Q6_K
-        si_block_q8_1* hq8 = reinterpret_cast<si_block_q8_1*>(out_scratch);   // <= hidden floats; fits
-        const int nqb = num_tokens * top_k * (ffn >> 5);
-        const int qthreads = 256;
-        quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
-            h_scratch, hq8, nqb);
+        si_block_q8_1* down_q8 = reinterpret_cast<si_block_q8_1*>(out_scratch);
+        if (!fuse_down_q8) {
+            const int nqb = num_tokens * top_k * (ffn >> 5);
+            const int qthreads = 256;
+            quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
+                h_scratch, down_q8, nqb);
+        }
         // split-K MMVQ down (default S=4): S warps/row -> S*H warps in flight, hiding
         // the bs=1 occupancy stall the one-warp kernel hits. Falls back to one-warp if disabled.
         const int S = down_splitk_s();
@@ -688,13 +728,13 @@ void launch_moe_expert_ffn_q4k(
             const int RPB = WPB / S;
             dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
             if (launch_down_q6k_mmvq_splitk(S, dns,
-                    reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
+                    reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, down_q8,
                     reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, stream))
                 return;
         }
         dim3 dnm(num_tokens, (hidden + WPB - 1) / WPB);
         down_q6k_mmvq_kernel<<<dnm, WPB * 32, 0, stream>>>(
-            reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
+            reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, down_q8,
             reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k);
         return;
     }
@@ -704,23 +744,25 @@ void launch_moe_expert_ffn_q4k(
     static int down_q4k = -1;
     if (down_q4k < 0) { const char* qv = getenv("SPARKINFER_DOWN_Q4K"); down_q4k = (qv && qv[0] == '0') ? 0 : 1; }
     if (down_mmvq && down_q4k && down_type == 12) {   // 12 = ggml Q4_K
-        si_block_q8_1* hq8 = reinterpret_cast<si_block_q8_1*>(out_scratch);
-        const int nqb = num_tokens * top_k * (ffn >> 5);
-        const int qthreads = 256;
-        quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
-            h_scratch, hq8, nqb);
+        si_block_q8_1* down_q8 = reinterpret_cast<si_block_q8_1*>(out_scratch);
+        if (!fuse_down_q8) {
+            const int nqb = num_tokens * top_k * (ffn >> 5);
+            const int qthreads = 256;
+            quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
+                h_scratch, down_q8, nqb);
+        }
         const int S = down_splitk_s();
         if (S > 1) {
             const int RPB = WPB / S;
             dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
             if (launch_down_q4k_mmvq_splitk(S, dns,
-                    reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
+                    reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, down_q8,
                     reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, stream))
                 return;
         }
         dim3 dnm(num_tokens, (hidden + WPB - 1) / WPB);
         down_q4k_mmvq_kernel<<<dnm, WPB * 32, 0, stream>>>(
-            reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
+            reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, down_q8,
             reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k);
         return;
     }

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -65,6 +65,7 @@ void launch_moe_expert_ffn_q4k(
     float* h_scratch, float* out_scratch,
     int num_tokens, int top_k, int hidden, int ffn,
     const void* input_q8 = nullptr,   // pre-quantized Q8_1(input) from the fused norm; nullptr = quantize internally
+    unsigned int* q8_ready = nullptr, // per-layer slice for gate/up->down Q8_1 fusion; nullptr = standalone quant
     cudaStream_t stream = nullptr);
 
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -89,6 +89,11 @@ struct Qwen35Model::Impl {
     bool use_ropekv = true;// default ON: fused RoPE + KV-append (1 kernel vs 2). =0 disables
     bool use_fnq = true;   // default ON: post-MoE add_rmsnorm2 also emits Q8_1(xn), deleting the
                            // next layer's standalone QKV-input quantize node. =0 disables
+    bool use_moedq = true; // default ON: gate/up MMVQ tail emits Q8_1(h) for the down MMVQ,
+                           // deleting the per-layer quant_h node. =0 disables
+
+    unsigned int* q8_ready = nullptr;
+    int q8_ready_layer_stride = 0;
 
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -143,12 +148,15 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->aq8_d = p_->alloc<float>(kmax >> 5);
     p_->aq8_s = p_->alloc<float>(kmax >> 5);
     p_->aq81  = p_->alloc<char>(kernels::llama_q8_1_bytes(kmax));
+    p_->q8_ready_layer_stride = cfg.top_k * (cfg.moe_ffn >> 5);
+    p_->q8_ready = p_->alloc<unsigned int>((size_t)cfg.n_layers * p_->q8_ready_layer_stride);
     if (const char* e = getenv("SPARKINFER_PQ"))    p_->use_pq    = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_LLAMA")) p_->use_llama = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_Q6MMVQ")) p_->use_q6mmvq = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKFUSE")) p_->use_qkfuse = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ROPEKV")) p_->use_ropekv = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_MOEDQ"))  p_->use_moedq = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKVSTREAM")) p_->use_qkvstream = !(e[0] == '0');
 }
 
@@ -163,6 +171,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->mf_ids); cudaFree(p_->mf_counts);
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
+    cudaFree(p_->q8_ready);
     if (p_->graph_ready) { cudaGraphExecDestroy(p_->cu_exec); cudaGraphDestroy(p_->cu_graph); }
     cudaEventDestroy(p_->ev_qkv); cudaEventDestroy(p_->ev_k); cudaEventDestroy(p_->ev_v);
     cudaStreamDestroy(p_->stream_v); cudaStreamDestroy(p_->stream_k);
@@ -322,7 +331,9 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,
                                                1, c.top_k, c.hidden, c.moe_ffn,
-                                               fnq ? s.aq81 : nullptr, st);
+                                               fnq ? s.aq81 : nullptr,
+                                               (s.use_moedq && fnq) ? s.q8_ready + (size_t)L * s.q8_ready_layer_stride : nullptr,
+                                               st);
         } else {
             s.engine->set_layer_weights(L, {w.router_w, w.gate, w.up, w.down});
             s.engine->forward(s.hn, s.routed, 1, L, st);


### PR DESCRIPTION
## Summary

Each decode layer runs `quant_h_q8_1_kernel` as its own CUDA-graph node between the MoE gate/up MMVQ and the int8 down MMVQ. That kernel only re-quantizes the SwiGLU activation `h` that `gate_up_mmvq2_kernel` just wrote to `h_scratch` — same `amax/127` + `roundf(x/d)` path as today, but as a separate graph replay.

This folds that Q8_1 emission into `gate_up_mmvq2_kernel`: once all 32 floats in a Q8_1 block are written, the completing block quantizes from `h_scratch` into `out_scratch` and the standalone `quant_h_q8_1` launch is skipped. Per-layer `q8_ready` slices (indexed by layer id) keep the atomic completion flags CUDA-graph safe across the 40-layer capture without a per-layer memset.

Complements #83 (`SPARKINFER_FNQ`): FNQ removes the gate/up **input** quantize; this removes the down **activation** quantize. Requires FNQ (pre-quantized `aq81` for gate/up input) so `out_scratch` stays free for down Q8_1.

`SPARKINFER_MOEDQ=0` restores the standalone quantize path.

## What changed

### Kernels (`kernels/csrc/cuda/moe/expert_ffn_q4k.cu`)

- **`gate_up_mmvq2_kernel`** — optional tail: atomic completion per Q8_1 block, then bit-identical `si_quant_h_block_q8_1`.
- **`launch_moe_expert_ffn_q4k`** — new `q8_ready` argument; skips `quant_h_q8_1_kernel` when fusion is active (`SPARKINFER_MOEDQ=1`, default).

### Runtime (`runtime/src/models/qwen35.cpp`)

- Allocate `q8_ready[n_layers * top_k * (moe_ffn/32)]` (device, zero-init).
- Pass per-layer slice to `launch_moe_expert_ffn_q4k` when `SPARKINFER_FNQ=1` and `SPARKINFER_MOEDQ=1`.

### API (`kernels/include/sparkinfer/kernels/moe.h`)

- Document `q8_ready` parameter on `launch_moe_expert_ffn_q4k`.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`bench/scripts/bench.sh`, Qwen3-30B-A3B Q4_K_M, n=128, bs=1):

| | decode tok/s |
|---|---:|
| before (`SPARKINFER_MOEDQ=0`) | 440.75 |
| after (this PR, default) | 441.98 |

- [x] `ctest --test-dir build`: 6/6 passed
- [x] `compute-sanitizer --tool memcheck`: 0 errors

## Test plan

- [x] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j`
- [x] `ctest --test-dir build`
- [x] `bench/scripts/bench.sh --tokens 128` (5090)
- [x] `bench/scripts/accuracy.sh`
- [x] A/B: `SPARKINFER_MOEDQ=0` vs default — tok/s + KL

## Env flags

| Flag | Default | Effect |
|---|---|---|
| `SPARKINFER_MOEDQ` | `1` | Fuse down Q8_1 into gate/up tail |
| `SPARKINFER_FNQ` | `1` | Required for fusion (separates `aq81` from `out_scratch`) |
