### PR TITLE
Skip LM head on teacher-forced prompt tokens

### DIFF
--- a/kernels/csrc/cuda/fused/model_ops.cu
+++ b/kernels/csrc/cuda/fused/model_ops.cu
@@ -92,6 +92,13 @@ __global__ void argmax_p2_kernel(int* __restrict__ out_id) {
     if (t == 0) out_id[0] = s_idx[0];
 }
 
+// Increment decode step counters on device (one block) after each graph replay.
+__global__ void decode_step_bump_kernel(int* pos, int* writepos, int* seqlen) {
+    if (threadIdx.x == 0) {
+        pos[0]++; writepos[0]++; seqlen[0]++;
+    }
+}
+
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/fused.h"
 
@@ -109,6 +116,10 @@ void launch_argmax(const float* logits, int* out_id, int n_rows, int vocab, cuda
     } else {
         argmax_kernel<<<n_rows, 1024, 0, stream>>>(logits, out_id, vocab);
     }
+}
+
+void launch_decode_step_bump(int* d_pos, int* d_writepos, int* d_seqlen, cudaStream_t stream) {
+    decode_step_bump_kernel<<<1, 1, 0, stream>>>(d_pos, d_writepos, d_seqlen);
 }
 #endif
 

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -39,4 +39,9 @@ void launch_embedding(const int* ids, const void* table, void* out,
 void launch_argmax(const float* logits, int* out_id, int n_rows, int vocab,
                    cudaStream_t stream = nullptr);
 
+// After a captured decode step: pos++, writepos++, seqlen++ (CUDA-graph safe).
+// Lets graph replay upload only the next token id instead of four int buffers.
+void launch_decode_step_bump(int* d_pos, int* d_writepos, int* d_seqlen,
+                             cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -57,6 +57,8 @@ if(BUILD_EXAMPLES)
     target_link_libraries(qwen3_gguf_bench PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(qwen3_gguf_score examples/qwen3_gguf_score.cpp)
     target_link_libraries(qwen3_gguf_score PRIVATE sparkinfer_runtime CUDA::cudart)
+    add_executable(qwen35_ttft_bench examples/qwen35_ttft_bench.cpp)
+    target_link_libraries(qwen35_ttft_bench PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(thermal_sweep examples/thermal_sweep.cpp)   # force each thermal mode, measure W/°C/tok/s
     target_link_libraries(thermal_sweep PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)
 endif()

--- a/runtime/examples/qwen35_ttft_bench.cpp
+++ b/runtime/examples/qwen35_ttft_bench.cpp
@@ -1,0 +1,95 @@
+// TTFT + decode micro-benchmark on a tiny Qwen3.5-shaped model (random weights).
+// Fits on 8 GB GPUs — exercises the real device forward path without a 17 GB GGUF.
+//
+// Usage: qwen35_ttft_bench [prompt_len] [decode_n]
+//   prompt_len  teacher-forced prompt tokens (default 64)
+//   decode_n    steady-state decode tokens timed (default 32)
+
+#include "sparkinfer/runtime.h"
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/moe/engine.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+static void* rand_bf16(size_t n, float s) {
+    std::vector<uint16_t> h(n);
+    for (size_t i = 0; i < n; i++) {
+        float f = s * (2.f * ((i * 2654435761u + 40503u) % 1000) / 1000.f - 1.f);
+        uint32_t b; std::memcpy(&b, &f, 4); h[i] = (uint16_t)(b >> 16);
+    }
+    void* d = nullptr; cudaMalloc(&d, n * sizeof(uint16_t));
+    cudaMemcpy(d, h.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    return d;
+}
+
+int main(int argc, char** argv) {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no CUDA device\n"); return 0;
+    }
+    const int prompt_len = argc > 1 ? atoi(argv[1]) : 64;
+    const int decode_n   = argc > 2 ? atoi(argv[2]) : 32;
+
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, 0);
+
+    auto rt = sparkinfer::Runtime::create({}); rt->initialize();
+
+    sparkinfer::Qwen35Config cfg;
+    cfg.vocab = 2000; cfg.hidden = 2048; cfg.n_layers = 2;
+    cfg.n_q_heads = 16; cfg.n_kv_heads = 2; cfg.head_dim = 128;
+    cfg.n_experts = 8; cfg.top_k = 2; cfg.n_shared = 1; cfg.moe_ffn = 64;
+    cfg.max_seq = 512; cfg.eos_id = -1;
+
+    const int H = cfg.hidden, Q = cfg.n_q_heads * cfg.head_dim, KV = cfg.n_kv_heads * cfg.head_dim;
+    const int E = cfg.n_experts, F = cfg.moe_ffn;
+
+    sparkinfer::KVCacheConfig kvc;
+    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads;
+    kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    sparkinfer::KVCacheManager kv(kvc, 128ull * 1024 * 1024);
+
+    sparkinfer::moe::MoEConfig mc;
+    mc.num_experts = E; mc.top_k = cfg.top_k; mc.hidden_dim = H; mc.ffn_dim = F; mc.num_layers = cfg.n_layers;
+    auto engine = sparkinfer::moe::MoEEngine::create(mc);
+
+    sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
+
+    sparkinfer::Qwen35Weights w;
+    w.embed_tokens = rand_bf16((size_t)cfg.vocab * H, 1.f);
+    w.final_norm   = rand_bf16(H, 0.5f);
+    w.lm_head      = rand_bf16((size_t)H * cfg.vocab, 0.05f);
+    w.layers.resize(cfg.n_layers);
+    for (int l = 0; l < cfg.n_layers; l++) {
+        auto& lw = w.layers[l];
+        lw.input_norm = rand_bf16(H, 0.5f);
+        lw.wq = rand_bf16((size_t)H * Q, 0.04f); lw.wk = rand_bf16((size_t)H * KV, 0.04f);
+        lw.wv = rand_bf16((size_t)H * KV, 0.04f); lw.wo = rand_bf16((size_t)Q * H, 0.04f);
+        lw.q_norm = rand_bf16(cfg.head_dim, 0.5f); lw.k_norm = rand_bf16(cfg.head_dim, 0.5f);
+        lw.post_attn_norm = rand_bf16(H, 0.5f);
+        lw.router_w = rand_bf16((size_t)H * E, 0.1f);
+        lw.gate = rand_bf16((size_t)E * H * F, 0.04f); lw.up = rand_bf16((size_t)E * H * F, 0.04f);
+        lw.down = rand_bf16((size_t)E * F * H, 0.04f);
+        lw.shared_gate = rand_bf16((size_t)H * F, 0.04f); lw.shared_up = rand_bf16((size_t)H * F, 0.04f);
+        lw.shared_down = rand_bf16((size_t)F * H, 0.04f);
+    }
+    model.set_weights(w);
+
+    std::vector<int> prompt((size_t)prompt_len);
+    for (int i = 0; i < prompt_len; i++) prompt[i] = 1 + (i % 100);
+
+    double ttft_ms = model.bench_ttft(prompt);
+    double decode_tps = model.bench_decode(4, decode_n);
+
+    printf("\n=== sparkinfer qwen35_ttft_bench ===\n");
+    printf("GPU          : %s (sm_%d.%d)\n", prop.name, prop.major, prop.minor);
+    printf("prompt_len   : %d\n", prompt_len);
+    printf("TTFT         : %.2f ms  (prompt + first sample)\n", ttft_ms);
+    printf("decode tg    : %.2f tok/s  (n=%d, bs=1)\n", decode_tps, decode_n);
+    return 0;
+}

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -100,11 +100,18 @@ public:
     // steps then times `n_tokens` more. Returns tokens/sec. Requires weights.
     double bench_decode(int warmup, int n_tokens);
 
+    // Time-to-first-token benchmark: ingests `prompt` then samples once.
+    // Returns milliseconds for prompt ingestion + first argmax. Requires weights.
+    double bench_ttft(const std::vector<int>& prompt);
+
     const Qwen35Config& config() const;
 
 private:
     struct Impl;
     Impl* p_;
+
+    // prefill_only skips LM head + argmax and never captures/replays the decode graph.
+    int forward_token_impl(int token_id, int position, bool prefill_only);
 };
 
 } // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -179,7 +179,13 @@ void Qwen35Model::copy_logits(float* host_logits) const {
     cudaMemcpy(host_logits, p_->logits, (size_t)p_->cfg.vocab * sizeof(float), cudaMemcpyDeviceToHost);
 }
 
+// prefill_only: teacher-forced prompt ingestion — skip LM head + argmax and never
+// touch the decode CUDA graph. The graph is captured on the first sampled step.
 int Qwen35Model::forward_token(int token_id, int position) {
+    return forward_token_impl(token_id, position, false);
+}
+
+int Qwen35Model::forward_token_impl(int token_id, int position, bool prefill_only) {
     Impl& s = *p_;
     const Qwen35Config& c = s.cfg;
     const int H = c.hidden;
@@ -192,17 +198,16 @@ int Qwen35Model::forward_token(int token_id, int position) {
     cu(cudaMemcpyAsync(s.d_writepos, &position, sizeof(int), cudaMemcpyHostToDevice, st), "wpos");
     cu(cudaMemcpyAsync(s.d_seqlen, &seqlen, sizeof(int), cudaMemcpyHostToDevice, st), "slen");
 
-    // Capture the decode compute into a CUDA graph on the first token, then
-    // replay it every token (per-token inputs live in the d_tok/pos/seqlen/
-    // writepos device buffers uploaded above, so replay produces fresh results).
-    if (s.graph_ready) {
+    // Replay the captured decode graph (per-token inputs uploaded above).
+    if (!prefill_only && s.graph_ready) {
         cu(cudaGraphLaunch(s.cu_exec, st), "graph launch");
         int out_id = 0;
         cu(cudaMemcpyAsync(&out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");
         cu(cudaStreamSynchronize(st), "sync");
         return out_id;
     }
-    cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), "begin capture");
+    if (!prefill_only)
+        cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), "begin capture");
 
     kernels::launch_embedding(s.d_tok, s.w.embed_tokens, s.x, 1, H, st);
 
@@ -341,6 +346,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
             kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
     }
     // xn now holds RMSNorm(x_final, final_norm)
+    if (prefill_only) {
+        cu(cudaStreamSynchronize(st), "sync prefill");
+        return -1;
+    }
     if (s.gguf && s.use_q6mmvq && s.w.lm_head_type == 14) {   // int8 Q6_K dp4a LM head (1 warp/row)
         if (!fnq) kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);  // else aq81 = Q8_1(xn) from final norm
         kernels::launch_gemv_q6k_dp4a_f32(s.aq81, s.w.lm_head, s.logits, c.vocab, H, st);
@@ -384,8 +393,10 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
         return out;
     }
-    int next = -1;
-    for (size_t i = 0; i < prompt.size(); i++) next = forward_token(prompt[i], (int)i);
+    // Teacher-forced prompt tokens only populate KV; skip the vocab-sized LM head.
+    for (size_t i = 0; i + 1 < prompt.size(); i++)
+        forward_token_impl(prompt[i], (int)i, true);
+    int next = forward_token_impl(prompt.back(), (int)prompt.size() - 1, false);
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
         if (next == s.cfg.eos_id) break;
@@ -394,6 +405,25 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
     }
     s.kv->free(s.seq_id);
     return out;
+}
+
+double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
+    Impl& s = *p_;
+    if (prompt.empty()) return -1.;
+    if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
+        fprintf(stderr, "[bench] kv allocate failed\n");
+        return -1.;
+    }
+    cudaDeviceSynchronize();
+    auto t0 = std::chrono::high_resolution_clock::now();
+    for (size_t i = 0; i + 1 < prompt.size(); i++)
+        forward_token_impl(prompt[i], (int)i, true);
+    forward_token_impl(prompt.back(), (int)prompt.size() - 1, false);
+    cudaDeviceSynchronize();
+    auto t1 = std::chrono::high_resolution_clock::now();
+    s.kv->free(s.seq_id);
+    double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+    return ms;
 }
 
 // ----- weight loading from a sparkinfer weight directory -----

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -90,6 +90,24 @@ struct Qwen35Model::Impl {
     bool use_fnq = true;   // default ON: post-MoE add_rmsnorm2 also emits Q8_1(xn), deleting the
                            // next layer's standalone QKV-input quantize node. =0 disables
 
+    void reset_decode_step(cudaStream_t st) {
+        int z = 0, one = 1;
+        cu(cudaMemcpyAsync(d_pos, &z, sizeof(int), cudaMemcpyHostToDevice, st), "pos reset");
+        cu(cudaMemcpyAsync(d_writepos, &z, sizeof(int), cudaMemcpyHostToDevice, st), "wpos reset");
+        cu(cudaMemcpyAsync(d_seqlen, &one, sizeof(int), cudaMemcpyHostToDevice, st), "slen reset");
+    }
+
+    void reset_decode_session(cudaStream_t st) {
+        if (graph_ready) {
+            cu(cudaGraphExecDestroy(cu_exec), "graph exec destroy");
+            cu(cudaGraphDestroy(cu_graph), "graph destroy");
+            graph_ready = false;
+            cu_graph = {};
+            cu_exec = {};
+        }
+        reset_decode_step(st);
+    }
+
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
 
@@ -193,19 +211,21 @@ int Qwen35Model::forward_token_impl(int token_id, int position, bool prefill_onl
     int seqlen = position + 1;
     cudaStream_t st = s.stream;
 
-    cu(cudaMemcpyAsync(s.d_tok, &token_id, sizeof(int), cudaMemcpyHostToDevice, st), "tok");
-    cu(cudaMemcpyAsync(s.d_pos, &position, sizeof(int), cudaMemcpyHostToDevice, st), "pos");
-    cu(cudaMemcpyAsync(s.d_writepos, &position, sizeof(int), cudaMemcpyHostToDevice, st), "wpos");
-    cu(cudaMemcpyAsync(s.d_seqlen, &seqlen, sizeof(int), cudaMemcpyHostToDevice, st), "slen");
-
-    // Replay the captured decode graph (per-token inputs uploaded above).
+    // Graph replay: only the token id changes; pos/seqlen advance on-device (see bump below).
     if (!prefill_only && s.graph_ready) {
+        cu(cudaMemcpyAsync(s.d_tok, &token_id, sizeof(int), cudaMemcpyHostToDevice, st), "tok");
         cu(cudaGraphLaunch(s.cu_exec, st), "graph launch");
         int out_id = 0;
         cu(cudaMemcpyAsync(&out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");
         cu(cudaStreamSynchronize(st), "sync");
         return out_id;
     }
+
+    cu(cudaMemcpyAsync(s.d_tok, &token_id, sizeof(int), cudaMemcpyHostToDevice, st), "tok");
+    cu(cudaMemcpyAsync(s.d_pos, &position, sizeof(int), cudaMemcpyHostToDevice, st), "pos");
+    cu(cudaMemcpyAsync(s.d_writepos, &position, sizeof(int), cudaMemcpyHostToDevice, st), "wpos");
+    cu(cudaMemcpyAsync(s.d_seqlen, &seqlen, sizeof(int), cudaMemcpyHostToDevice, st), "slen");
+
     if (!prefill_only)
         cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), "begin capture");
 
@@ -358,6 +378,7 @@ int Qwen35Model::forward_token_impl(int token_id, int position, bool prefill_onl
     else if (s.gguf)                kernels::launch_gemv_f32(s.xn, s.w.lm_head, s.logits, c.vocab, H, st);  // lm_head native [vocab,H]
     else        kernels::launch_linear_f32(s.xn, s.w.lm_head, s.logits, 1, c.vocab, H, st);
     kernels::launch_argmax(s.logits, s.d_out_id, 1, c.vocab, st);
+    kernels::launch_decode_step_bump(s.d_pos, s.d_writepos, s.d_seqlen, st);
 
     cu(cudaStreamEndCapture(st, &s.cu_graph), "end capture");
     cu(cudaGraphInstantiate(&s.cu_exec, s.cu_graph, 0), "graph instantiate");
@@ -373,6 +394,7 @@ int Qwen35Model::forward_token_impl(int token_id, int position, bool prefill_onl
 double Qwen35Model::bench_decode(int warmup, int n) {
     Impl& s = *p_;
     if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) { fprintf(stderr, "[bench] kv allocate failed\n"); return -1; }
+    s.reset_decode_session(s.stream);
     int pos = 0, tok = 100;
     for (int i = 0; i < warmup; i++) { tok = forward_token(tok, pos++); if (tok < 0 || tok >= s.cfg.vocab) tok = 100; }
     cudaDeviceSynchronize();
@@ -393,6 +415,7 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
         return out;
     }
+    s.reset_decode_session(s.stream);
     // Teacher-forced prompt tokens only populate KV; skip the vocab-sized LM head.
     for (size_t i = 0; i + 1 < prompt.size(); i++)
         forward_token_impl(prompt[i], (int)i, true);
@@ -414,6 +437,7 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
         fprintf(stderr, "[bench] kv allocate failed\n");
         return -1.;
     }
+    s.reset_decode_session(s.stream);
     cudaDeviceSynchronize();
     auto t0 = std::chrono::high_resolution_clock::now();
     for (size_t i = 0; i + 1 < prompt.size(); i++)


### PR DESCRIPTION
## Summary

Closes #106. Two decode-path wins:

1. **TTFT** — skip LM head on teacher-forced prompt tokens; defer CUDA graph capture to the first sampled step.
2. **Decode** — on CUDA graph replay, upload only `token_id` (not pos/seqlen/writepos); bump step counters on-GPU after each captured step (`launch_decode_step_bump`).

Adds `bench_ttft()` and `qwen35_ttft_bench` for local validation on 8 GB GPUs.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) the **decode tok/s** table shows a **real end-to-end improvement** (`after > before`,
> filled from `bench/scripts/bench.sh` — *not* an isolated-kernel microbenchmark). A ticked box
> with an empty/placeholder table gets `needs-benchmark` and is **not** evaluated (no point spending
> a GPU when there's no claimed decode gain).
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [ ] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | _(run `bench/scripts/bench.sh --download` on main)_ |
| after (this PR) | _(run on this branch — expect modest gain from fewer H2D copies/token)_ |

```text
# Run on RTX 5090:
#   git checkout main && bench/scripts/bench.sh --download
#   git checkout feat/prompt-prefill-skip-lmhead && bench/scripts/bench.sh --download
#
# TTFT micro-bench (any GPU with build):
#   cmake --build build --target qwen35_ttft_bench
#   ./build/runtime/qwen35_ttft_bench 64
```

## Test plan

- [ ] `ctest --test-dir build` passes
- [ ] `bench/scripts/bench.sh` shows `after > before` on RTX 5090
- [ ] `qwen35_ttft_bench 64` shows lower TTFT vs main
- [ ] `generate()` / `qwen3_gguf_score` output unchanged vs main