### PR TITLE
eval: difficulty-compensated scoring — boost late-game label tiers (Option B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 Notable changes to sparkinfer. Format loosely follows [Keep a Changelog](https://keepachangelog.com);
 versions track the GitHub [releases](https://github.com/gittensor-ai-lab/sparkinfer/releases).
 
+## [Unreleased]
+
+### Changed — difficulty-compensated scoring (perpetual-progress incentive)
+As the frontier pulls past llama.cpp, each further % gain gets much harder (near the roofline the
+easy headroom is gone), so a fixed %-band scale under-rewards late-game work — a hard +4% now took
+more than an easy +20% at cold start. `label.py` now scales the **label tier** by a difficulty
+multiplier `D = 1 + K·max(0, frontier/ref − 1)` (K=8, ref = llama.cpp 365.85, capped at 4×): a gain
+scores like the effort it took relative to a mature baseline. Safeguards: the boost multiplies the
+**label only** — `pct_over_frontier` still reports the true measured speedup, the significance gate
+stays on the **raw** delta (noise is never boosted), and the cold-start era (frontier ≤ ref) is
+untouched (D=1, no retroactive inflation). Applied from new evals onward. On the real history #83/#89/#86
+move S→M/L; everything below llama is unchanged. Governance-tunable (`SPARKINFER_DIFFICULTY_{BOOST,K,REF,MAX}`);
+replay with [`eval/sim_difficulty.py`](eval/sim_difficulty.py).
+
 ## [0.3.2] — 2026-06-30
 
 The lead over llama.cpp **doubles to ~24%**, and the evaluation that proves it is **substantially

--- a/bench/scripts/label.py
+++ b/bench/scripts/label.py
@@ -44,6 +44,23 @@ SIG = 0.02                                              # noise floor: gain must
 # min relative speedup (delta/frontier) for each tier; XS starts at the noise floor SIG.
 BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
 
+# ---- Optional difficulty compensation (Option B — opt-in, governance-tunable) ----
+# As the frontier pulls past a mature reference (llama.cpp), each further % gain is harder; scale the
+# LABEL up so a late-game hard PR scores like the effort it took. D = 1 for a frontier at/below the
+# reference (the cold-start era is untouched — no retroactive inflation), grows with distance past it,
+# and is bounded by DIFF_MAX so nothing runs away to XL. Crucially the boost multiplies the *label*
+# only: the significance gate stays on the RAW delta (so noise is never boosted) and pct_over_frontier
+# still reports the true measured speedup. OFF by default.
+DIFF_BOOST = os.environ.get("SPARKINFER_DIFFICULTY_BOOST", "0") == "1"
+DIFF_K     = float(os.environ.get("SPARKINFER_DIFFICULTY_K",   "8"))
+DIFF_REF   = float(os.environ.get("SPARKINFER_DIFFICULTY_REF", "365.85"))  # llama.cpp 128-tok tok/s
+DIFF_MAX   = float(os.environ.get("SPARKINFER_DIFFICULTY_MAX", "4"))
+
+def difficulty_mult(frontier):
+    if not DIFF_BOOST or DIFF_REF <= 0:
+        return 1.0
+    return min(1.0 + DIFF_K * max(0.0, frontier / DIFF_REF - 1.0), DIFF_MAX)
+
 res = {"commit": commit, "tps": round(tps, 2), "top1": round(top1, 4),
        "kl": round(kl, 4), "frontier_tps": round(frontier, 2)}
 
@@ -60,10 +77,15 @@ else:
                    pct_over_frontier=round(100 * g, 1),
                    note="within significance gate — not a verified improvement")
     else:
-        label = next(l for thr, l in BUCKETS if g >= thr)
+        D = difficulty_mult(frontier)
+        g_eff = g * D                                   # boost the label tier, not the raw % or the gate
+        label = next(l for thr, l in BUCKETS if g_eff >= thr)
         res.update(pass_=True, label=label, delta_tps=round(delta, 2),
-                   pct_over_frontier=round(100 * g, 1),
+                   pct_over_frontier=round(100 * g, 1),   # RAW measured speedup (honest reporting)
                    pct_of_ceiling=round(100 * tps / ceiling, 1) if ceiling > 0 else None)
+        if D != 1.0:                                    # transparency: expose the boost in the verdict
+            res["difficulty_mult"] = round(D, 2)
+            res["effective_pct"] = round(100 * g_eff, 1)
 
 # Soft accuracy flag: passed the gate but above the preferred KL ceiling — accepted, margin is thin.
 if res.get("label") != "REJECT" and kl > KL_PREFER:

--- a/eval/sim_difficulty.py
+++ b/eval/sim_difficulty.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Replay the sparkinfer frontier history through the difficulty-compensated labeling (Option B), so a
+governance change to the K / reference / cap can be judged on real data instead of vibes.
+
+  eval/sim_difficulty.py [K ...]        # default K = 6 8 10
+
+Mirrors bench/scripts/label.py: D = 1 + K*max(0, frontier/ref - 1), capped at DIFF_MAX; g_eff = g*D;
+the significance gate stays on the RAW delta so noise is never boosted. Reads the landed frontier
+journey from origin/main's dashboard/data.json.
+"""
+import json, subprocess, sys
+
+REF = 365.85          # llama.cpp 128-tok reference (SPARKINFER_DIFFICULTY_REF)
+DIFF_MAX = 4.0        # cap (SPARKINFER_DIFFICULTY_MAX)
+SIG = 0.02
+BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
+
+
+def bucket(g):
+    return "none" if g <= SIG else next(l for thr, l in BUCKETS if g >= thr)
+
+
+def sim(K, landed):
+    print(f"\n===== K = {K}  (ref = {REF}, cap = {DIFF_MAX}) =====")
+    print(f"{'PR':>5} {'base':>7} {'->tps':>7} {'g_raw':>6} {'cur':>5} {'D':>5} {'g_eff':>6} {'boosted':>7}  change")
+    prev = None
+    for m in landed:
+        tps = m["tps"]
+        if prev is None or tps <= prev:
+            prev = tps; continue
+        g = (tps - prev) / prev
+        cur = bucket(g)
+        D = min(1.0 + K * max(0.0, prev / REF - 1.0), DIFF_MAX)
+        g_eff = g * D if g > SIG else g            # gate on raw, boost only real gains
+        boosted = bucket(g_eff)
+        chg = "" if boosted == cur else f"  {cur} -> {boosted}"
+        print(f"#{m['pr']:>4} {prev:7.1f} {tps:7.1f} {100*g:5.1f}% {cur:>5} {D:5.2f} {100*g_eff:5.1f}% {boosted:>7}{chg}")
+        prev = tps
+
+
+def main():
+    Ks = [float(x) for x in sys.argv[1:]] or [6, 8, 10]
+    data = json.loads(subprocess.run(["git", "show", "origin/main:dashboard/data.json"],
+                                     capture_output=True, text=True).stdout)
+    landed = sorted(data["landed"], key=lambda m: m["tps"])
+    for K in Ks:
+        sim(K, landed)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -368,8 +368,12 @@ def main():
         # prompt. The seed is echoed into the verdict (eval_seed) so the prompt stays reproducible.
         eval_seed = os.urandom(8).hex()
         print(f">> held-out eval prompt seed: {eval_seed}")
+        # Difficulty compensation ON (Option B): as the frontier pulls past llama.cpp each further %
+        # gain is harder, so label.py scales the label tier up (raw % + significance gate unchanged).
+        # Governance-tunable via SPARKINFER_DIFFICULTY_{K,REF,MAX}; applies from new evals onward.
         ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
-              f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
+              f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} SPARKINFER_DIFFICULTY_BOOST=1 "
+              f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
               f"bench/scripts/evaluate.sh --ref {args.ref} --frontier {args.frontier} --ceiling {args.ceiling}")
         got_result = False
         r = sh(host, port, ev, timeout=10800)


### PR DESCRIPTION
## Why
As the frontier pulls past llama.cpp, each further % gain gets much harder (near the roofline the easy headroom is gone). A fixed %-band scale under-rewards late-game work — a hard **+4% now** took more effort than an easy **+20% at cold start** — which discourages continued attempts as competition matures.

## What
`label.py` scales the **label tier** by a difficulty multiplier:
```
D = 1 + K · max(0, frontier/ref − 1)      # K=8, ref = llama 365.85, capped at 4×
g_eff = (delta/frontier) · D              # bucket g_eff instead of the raw g
```
A late-game gain scores like the effort it took relative to a mature baseline.

## Safeguards
- **Label-only boost** — `pct_over_frontier` still reports the **true** measured speedup; `difficulty_mult` + `effective_pct` are added for transparency.
- **Significance gate stays on the raw delta** — noise (< 2%) is never boosted (still `none`).
- **Cold-start era untouched** — frontier ≤ ref → D=1, no retroactive inflation.
- **Bounded** (cap 4×) — nothing runs away to XL; discrimination preserved.

## Effect on the real history (K=8)
| PR | raw | today | D | → |
|---|---|---|---|---|
| below llama (#44–#76) | — | unchanged | 1.00 | — |
| #83 | +4.2% | S | 1.63 | **M** |
| #89 | +6.0% | S | 1.98 | **L** |
| #86 | +4.2% | S | 2.52 | **L** |
| #72/#74 (sub-2%) | — | none | — | still **none** |

## Rollout
Enabled in `vast_eval.py` (`SPARKINFER_DIFFICULTY_BOOST=1`) — **applies from new evals onward**, not retroactive. Governance-tunable via `SPARKINFER_DIFFICULTY_{BOOST,K,REF,MAX}`. Replay any setting with `eval/sim_difficulty.py`.

Touches maintainer-only paths (`bench/scripts/`, `eval/`).