### PR TITLE
perf(attn): fuse QK-norm+RoPE+KV-append and emit Q8_1(attn) in flash combine

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -76,15 +76,22 @@ __global__ void fa_split_kernel(
     for (int e = 0; e < ELEMS; e++) part_acc[(size_t)idx * HEAD_DIM + lane + e * 32] = acc[e];
 }
 
+// llama Q8_1 activation block (matches si_block_q8_1 used by the int8 MMVQ O-projection).
+struct fa_block_q8_1 { __half2 ds; signed char qs[32]; };
+
 // Combine the split partials with DG x NW parallelism over the 1-block-per-head
 // original (which idled at ~2% occupancy with a serial n_splits loop). DG head-dim
 // groups -> DG x more blocks; NW warps per block each fold a 1/NW stripe of the
 // splits, then a shared-memory log-sum-exp merge across warps. grid=(heads*DG,seqs).
+// When out_q8 != nullptr AND ELEMS==1 (DG*32==HEAD_DIM), each (qh,dg) block's warp 0 also
+// emits the Q8_1 block for attn dims [qh*HEAD_DIM + dg*32, +32) from the bf16-rounded output,
+// so the O-projection MMVQ skips its standalone attn-quantize node (bit-identical to running
+// the quantizer on `out` afterwards). Q8_1 block index = qh*(HEAD_DIM/32) + dg.
 template <int HEAD_DIM, int DG, int NW>
 __global__ void fa_combine_kernel(
     const float* __restrict__ part_m, const float* __restrict__ part_l,
     const float* __restrict__ part_acc, __nv_bfloat16* __restrict__ out,
-    int num_q_heads, int n_splits
+    int num_q_heads, int n_splits, fa_block_q8_1* __restrict__ out_q8 = nullptr
 ) {
     constexpr int ELEMS = HEAD_DIM / (32 * DG);
     const int seq = blockIdx.y, qh = blockIdx.x / DG, dg = blockIdx.x % DG;
@@ -129,6 +136,23 @@ __global__ void fa_combine_kernel(
     __nv_bfloat16* op = out + (size_t)(seq * num_q_heads + qh) * HEAD_DIM;
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) op[doff + e * 32] = __float2bfloat16(acc[e] * inv);
+
+    // Fused Q8_1(attn) emit for the O-projection MMVQ (only the DG*32==HEAD_DIM layout, ELEMS==1,
+    // where warp 0's 32 lanes hold exactly the 32 elements of one Q8_1 block).
+    if (out_q8 != nullptr && ELEMS == 1) {
+        const float bv = __bfloat162float(__float2bfloat16(acc[0] * inv));   // bf16-rounded, as `out`
+        float amax = fabsf(bv);
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
+        const float d = amax / 127.0f;
+        const int qi = (amax == 0.0f) ? 0 : (int)roundf(bv / d);
+        const int blk = (seq * num_q_heads + qh) * (HEAD_DIM / 32) + dg;
+        out_q8[blk].qs[lane] = (signed char)qi;
+        int s = qi;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+        if (lane == 0) out_q8[blk].ds = __floats2half2_rn(d, d * (float)s);
+    }
 }
 
 #ifndef FA_COMBINE_DG
@@ -139,7 +163,7 @@ __global__ void fa_combine_kernel(
 #endif
 template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
-template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int);
+template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -149,7 +173,8 @@ void launch_flash_decode_split(
     const int* block_table, const int* seq_lens, void* out,
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
-    int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream
+    int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
+    void* out_q8
 ) {
     dim3 g1(num_q_heads * n_splits, num_seqs);
     fa_split_kernel<128><<<g1, 32, 0, stream>>>(
@@ -158,7 +183,8 @@ void launch_flash_decode_split(
         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
     dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
     fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
-        part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits);
+        part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
+        reinterpret_cast<fa_block_q8_1*>(out_q8));
     (void)head_dim;
 }
 #endif

--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -119,9 +119,104 @@ __global__ void rope_kv_append_kernel(
     }
 }
 
+// Fused per-head QK-norm + RoPE + KV-append: ONE kernel replacing rmsnorm_qk + rope_kv_append.
+// grid = (n_q_heads + 2*n_kv_heads, n_tokens); blockDim = head_dim (one block per head).
+//   blocks [0, n_q_heads)                 : Q head -> RMSNorm(q_w) + RoPE in place
+//   blocks [n_q_heads, +n_kv_heads)       : K head -> RMSNorm(k_w) + RoPE + write k_pool
+//   blocks [.., +n_kv_heads)              : V head -> copy to v_pool (no norm/rope)
+// The normed head is staged in shared so RoPE can pair element i with i+half. The roped/normed
+// q,k are value-identical to rmsnorm_qk followed by rope_kv_append (same per-head RMS, same
+// bf16 rounding, same rope angle); the cached V is identical to kv_append. positions == write_pos.
+__global__ void qknorm_rope_kv_kernel(
+    __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
+    const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
+    __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    const int* __restrict__ block_table, const int* __restrict__ positions,
+    int n_q_heads, int n_kv_heads, int head_dim, float theta,
+    int block_size, int max_blocks_per_seq, float eps
+) {
+    const int tok  = blockIdx.y;
+    const int b    = blockIdx.x;
+    const int t    = threadIdx.x;                 // 0 .. head_dim-1
+    const int half = head_dim >> 1;
+    const int pos  = positions[tok];
+    const int blk = pos / block_size, within = pos % block_size;
+    const size_t ctok = (size_t)((size_t)block_table[tok * max_blocks_per_seq + blk] * block_size + within);
+
+    const bool is_v = (b >= n_q_heads + n_kv_heads);
+    if (is_v) {                                    // V: copy head straight to the cache (no norm/rope)
+        const int hh = b - n_q_heads - n_kv_heads;
+        const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
+        const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+        v_pool[dst + t] = v[base + t];
+        return;
+    }
+
+    const bool is_q = (b < n_q_heads);
+    __nv_bfloat16* x        = is_q ? q : k;
+    const __nv_bfloat16* w  = is_q ? q_w : k_w;
+    const int head          = is_q ? b : (b - n_q_heads);
+    const int nh            = is_q ? n_q_heads : n_kv_heads;
+    const size_t base       = ((size_t)(tok * nh + head)) * head_dim;
+
+    extern __shared__ float s_h[];                 // normed head (head_dim floats)
+    __shared__ float s_warp[32];
+    const float xv = __bfloat162float(x[base + t]);
+    float ss = xv * xv;                            // per-head RMS over head_dim
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) ss += __shfl_xor_sync(0xffffffff, ss, m);
+    if ((t & 31) == 0) s_warp[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float vv = (t < (head_dim + 31) / 32) ? s_warp[t] : 0.f;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) vv += __shfl_xor_sync(0xffffffff, vv, m);
+        if (t == 0) s_warp[0] = rsqrtf(vv / head_dim + eps);
+    }
+    __syncthreads();
+    // Normed value, bf16-rounded exactly as rmsnorm_qk writes it (so RoPE sees identical inputs).
+    s_h[t] = __bfloat162float(__float2bfloat16(xv * s_warp[0] * __bfloat162float(w[t])));
+    __syncthreads();
+
+    // RoPE (HF rotate-half): pair (i, i+half). Threads [0,half) own a pair and write both halves.
+    if (t < half) {
+        const float freq = __powf(theta, -2.f * (float)t / (float)head_dim);
+        const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
+        const float x0 = s_h[t], x1 = s_h[t + half];
+        const __nv_bfloat16 o0 = __float2bfloat16(x0 * c - x1 * s);
+        const __nv_bfloat16 o1 = __float2bfloat16(x1 * c + x0 * s);
+        if (is_q) {                                // Q: rope in place
+            q[base + t] = o0; q[base + t + half] = o1;
+        } else {                                   // K: rope straight into the paged cache
+            const size_t dst = (ctok * n_kv_heads + head) * head_dim;
+            k_pool[dst + t] = o0; k_pool[dst + t + half] = o1;
+        }
+    }
+}
+
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
+#include "sparkinfer/kernels/fused.h"
 #include <cstdlib>
+
+// Fused QK-norm + RoPE + KV-append (SPARKINFER_ATTNIN, default on). One kernel replaces
+// launch_rmsnorm_qk + launch_rope_kv_append, deleting a graph node and the intermediate
+// normed-q/k global round-trip. Falls back (caller keeps the two kernels) when disabled.
+void launch_qknorm_rope_kv_append(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, float theta,
+    float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream
+) {
+    dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
+    qknorm_rope_kv_kernel<<<grid, head_dim, head_dim * sizeof(float), stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v),
+        reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        block_table, positions, n_q_heads, n_kv_heads, head_dim, theta,
+        block_size, max_blocks_per_seq, eps);
+}
 
 void launch_rope_kv_append(void* q, const void* k, const void* v, void* k_pool, void* v_pool,
                            const int* block_table, const int* positions,

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -27,6 +27,15 @@ void launch_rope(
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     float theta, cudaStream_t stream = nullptr);
 
+// Fused per-head QK-norm + RoPE + KV-append: one kernel replacing launch_rmsnorm_qk +
+// launch_rope_kv_append. Per-head RMSNorm(q_w/k_w), then RoPE, then writes Q in place / K,V
+// into the paged cache. positions == write_pos (decode). Value-identical to the two-kernel path.
+void launch_qknorm_rope_kv_append(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, float theta,
+    float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr);
+
 // Fused RoPE + paged KV-append: ropes Q in place, ropes K straight into k_pool, copies V into
 // v_pool — one kernel replacing launch_rope + launch_kv_append. positions == write_pos (decode).
 void launch_rope_kv_append(
@@ -77,13 +86,15 @@ void launch_flash_decode_local_hd256(
 // (seq_len read in-kernel) so it is CUDA-graph capturable. head_dim=128.
 //   part_m/part_l: [num_seqs*num_q_heads*n_splits] (fp32 scratch)
 //   part_acc:      [num_seqs*num_q_heads*n_splits*head_dim] (fp32 scratch)
+// out_q8 (optional): when non-null, the combine also emits Q8_1(out) into it (one si_block_q8_1
+// per 32 attn dims), so the O-projection MMVQ can skip its standalone attn-quantize node.
 void launch_flash_decode_split(
     const void* q, const void* k_pool, const void* v_pool,
     const int* block_table, const int* seq_lens, void* out,
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr, void* out_q8 = nullptr);
 
 // Flash decode for GLOBAL layers: full context, head_dim=512, GQA 8:1.
 // Two-phase dot product splits 512-dim head into two 256-dim halves.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -90,6 +90,7 @@ struct Qwen35Model::Impl {
     bool use_qkvstream = true; // default ON: run Q/K/V projections on concurrent streams. =0 disables
     bool use_qkfuse = true;// default ON: fused per-head Q-norm + K-norm (1 kernel). =0 disables
     bool use_ropekv = true;// default ON: fused RoPE + KV-append (1 kernel vs 2). =0 disables
+    bool use_attnin = true;// default ON: single fused QK-norm+RoPE+KV-append (1 kernel vs qkfuse+ropekv=2). =0 disables
     bool use_fnq = true;   // default ON: post-MoE add_rmsnorm2 also emits Q8_1(xn), deleting the
                            // next layer's standalone QKV-input quantize node. =0 disables
 
@@ -155,6 +156,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_ROPEKV")) p_->use_ropekv = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKVSTREAM")) p_->use_qkvstream = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_ATTNIN")) p_->use_attnin = !(e[0] == '0');
 }
 
 Qwen35Model::~Qwen35Model() {
@@ -286,14 +288,20 @@ int Qwen35Model::forward_token(int token_id, int position) {
             kernels::launch_gemm(s.xn, w.wk, s.k, 1, s.kvdim, H, 1.f, 0.f, gc, st);
             kernels::launch_gemm(s.xn, w.wv, s.v, 1, s.kvdim, H, 1.f, 0.f, gc, st);
         }
+        bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems();
+        bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems();
+        if (s.use_attnin) {   // fused QK-norm + RoPE + KV-append: 1 node vs qk-norm + rope-kv (2)
+            kernels::launch_qknorm_rope_kv_append(s.q, s.k, s.v, w.q_norm, w.k_norm, kpool, vpool,
+                                                  btable, s.d_pos, 1, c.n_q_heads, c.n_kv_heads,
+                                                  c.head_dim, c.rope_theta, c.rms_eps,
+                                                  s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
+        } else {
         if (s.use_qkfuse)
             kernels::launch_rmsnorm_qk(s.q, s.k, w.q_norm, w.k_norm, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rms_eps, st);
         else {
             kernels::launch_rmsnorm(s.q, w.q_norm, s.q, c.n_q_heads,  c.head_dim, c.rms_eps, st);
             kernels::launch_rmsnorm(s.k, w.k_norm, s.k, c.n_kv_heads, c.head_dim, c.rms_eps, st);
         }
-        bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems();
-        bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems();
         if (s.use_ropekv) {   // fused rope(Q in place) + rope(K)->cache + V->cache (1 node vs 2)
             kernels::launch_rope_kv_append(s.q, s.k, s.v, kpool, vpool, btable, s.d_pos, 1,
                                            c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta,
@@ -303,13 +311,18 @@ int Qwen35Model::forward_token(int token_id, int position) {
             launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_writepos, 1,
                              c.n_kv_heads, c.head_dim, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
         }
+        }
+        // When the O-projection takes the Q4_K int8 MMVQ path, let the flash-decode combine emit
+        // Q8_1(attn) straight into aq81 (deleting the standalone attn-quantize node below).
+        const bool emit_attn_q8 = s.use_attnin && s.gguf && s.use_pq && s.use_llama && w.wo_type == 12;
         kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,
                                            s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,
                                            s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
-                                           1.f / sqrtf((float)c.head_dim), st);
+                                           1.f / sqrtf((float)c.head_dim), st,
+                                           emit_attn_q8 ? s.aq81 : nullptr);
         if (s.gguf && s.use_pq && w.wo_type == 12) {   // O proj reads attn: quantize once + dp4a
             if (s.use_llama) {
-                kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
                 kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
             } else {
                 kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);


### PR DESCRIPTION
## Summary

Two accuracy-preserving fusions in the attention decode epilogue, gated behind `SPARKINFER_ATTNIN` (default on):

1. **Fused QK-norm + RoPE + KV-append.** The per-head Q/K RMSNorm (`rmsnorm_qk`) and the RoPE + paged KV-append (`rope_kv_append`) previously ran as two separate graph nodes, with the normed Q/K round-tripped through global memory between them. `qknorm_rope_kv_kernel` does the per-head RMSNorm, RoPE, and cache write in one kernel: one block per head normalizes its head, stages it in shared memory, ropes the rotate-half pairs, and writes Q in place and K/V straight into the paged cache. One node instead of two, and the intermediate normed-Q/K store then load is removed.

2. **Q8_1(attn) emitted from the flash-decode combine.** The O-projection previously quantized `attn` to Q8_1 with a standalone `quantize_q8_1_blocks` node before the int8 MMVQ. The combine kernel already produces the final bf16 `attn`, so it now also emits the Q8_1 block for the 32 dims each warp owns, deleting the per-layer attn-quantize node. The Q8_1 is derived from the same bf16-rounded output, so it stays bit-identical to running the quantizer afterward.

Both are launch and global-round-trip reductions on the attention epilogue: same online-softmax attention, same rope angles, same per-head RMS, same int8 O-projection math. Distinct from the open MoE/MMVQ and LM-head PRs (this touches only the attention epilogue kernels).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

Decode tok/s (end-to-end, `qwen3_gguf_bench`, Qwen3-30B-A3B Q4_K_M, n=128, bs=1). Interleaved A/B on one binary (`SPARKINFER_ATTNIN` toggled), 6 rounds each:

| | decode tok/s |
|---|--:|
| before (`SPARKINFER_ATTNIN=0`, == main) | 453.05 |
| after (this PR, default) | 468.01 |

+14.96 tok/s (+3.30%). `SPARKINFER_ATTNIN=0` reproduces current `main` exactly. `nsys --cuda-graph-trace=node` confirms `rmsnorm_qk` + `rope_kv_append` (2.5% + 2.2% of GPU time) collapse to one `qknorm_rope_kv` kernel (3.2%), and the per-layer attn-quantize node drops from 1.7% to 0.04% (layer 0 only).

## Accuracy

Teacher-forced vs llama.cpp on the same GGUF: top-1 token-match 0.970 (bar >= 0.90, equals main), mean KL 0.0286 nats (bar <= 0.20, preferred <= 0.15).

## Correctness

- `ctest` 6/6 passed
- `compute-sanitizer --tool memcheck` 0 errors