### PR TITLE
perf(gemv): specialize q4 mmvq common K

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -155,6 +155,150 @@ __global__ void fa_split_gqa_kernel(
     for (int e = 0; e < ELEMS; e++) part_acc[(size_t)idx * HEAD_DIM + lane + e * 32] = acc[e];
 }
 
+template <int HEAD_DIM, int GQA, int TILE, int NSPLITS, int BLOCK_SIZE, int NUM_KV_HEADS, int KV_MODE>
+__global__ void fa_split_gqa_fixed_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens,
+    float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
+    float scale, int max_blocks, int kv_base
+) {
+    constexpr int ELEMS = HEAD_DIM / 32;
+    constexpr int NUM_Q_HEADS = NUM_KV_HEADS * GQA;
+    const int seq   = blockIdx.y;
+    const int split = blockIdx.x % NSPLITS;
+    const int kvh   = blockIdx.x / NSPLITS;
+    const int warp  = threadIdx.x >> 5;
+    const int lane  = threadIdx.x & 31;
+    const int qh    = kvh * GQA + warp;
+
+    float qr[ELEMS];
+    const __nv_bfloat16* qp = q + (size_t)(seq * NUM_Q_HEADS + qh) * HEAD_DIM;
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) qr[e] = fa_to_f(qp[lane + e * 32]);
+
+    const int sl    = seq_lens[seq];
+    const int chunk = (sl + NSPLITS - 1) / NSPLITS;
+    const int start = split * chunk;
+    const int end   = min(sl, start + chunk);
+
+    float m = -1e30f, l = 0.f, acc[ELEMS];
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
+
+    extern __shared__ __nv_bfloat16 s_kv[];
+    __nv_bfloat16* s_k = s_kv;
+    __nv_bfloat16* s_v = s_kv + (size_t)TILE * HEAD_DIM;
+    __shared__ size_t s_rowbase[TILE];
+
+    for (int t0 = start; t0 < end; t0 += TILE) {
+        const int valid = min(TILE, end - t0);
+        if ((int)threadIdx.x < valid) {
+            const int t = t0 + threadIdx.x;
+            const int blk = t / BLOCK_SIZE, wb = t % BLOCK_SIZE;
+            int phys;
+            if constexpr (KV_MODE == 1)      phys = blk;
+            else if constexpr (KV_MODE == 2) phys = kv_base + blk;
+            else                             phys = block_table[seq * max_blocks + blk];
+            s_rowbase[threadIdx.x] = ((size_t)(phys * BLOCK_SIZE + wb) * NUM_KV_HEADS + kvh) * HEAD_DIM;
+        }
+        __syncthreads();
+        for (int i = threadIdx.x * 2; i < valid * HEAD_DIM; i += blockDim.x * 2) {
+            const int within = i / HEAD_DIM, d = i % HEAD_DIM;
+            const size_t base = s_rowbase[within] + d;
+            const __nv_bfloat162 k2 = *reinterpret_cast<const __nv_bfloat162*>(k_pool + base);
+            const __nv_bfloat162 v2 = *reinterpret_cast<const __nv_bfloat162*>(v_pool + base);
+            *reinterpret_cast<__nv_bfloat162*>(s_k + i) = k2;
+            *reinterpret_cast<__nv_bfloat162*>(s_v + i) = v2;
+        }
+        __syncthreads();
+        for (int tt = 0; tt < valid; tt++) {
+            float p = 0.f;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; e++) p += qr[e] * fa_to_f(s_k[tt * HEAD_DIM + lane + e * 32]);
+            const float score = fa_wsum(p) * scale;
+            const float mn = fmaxf(m, score), corr = __expf(m - mn), pe = __expf(score - mn);
+            l = l * corr + pe;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; e++) acc[e] = acc[e] * corr + pe * fa_to_f(s_v[tt * HEAD_DIM + lane + e * 32]);
+            m = mn;
+        }
+        __syncthreads();
+    }
+
+    const int idx = (seq * NUM_Q_HEADS + qh) * NSPLITS + split;
+    if (lane == 0) { part_m[idx] = m; part_l[idx] = l; }
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) part_acc[(size_t)idx * HEAD_DIM + lane + e * 32] = acc[e];
+}
+
+template <int HEAD_DIM, int GQA, int TILE, int NSPLITS, int BLOCK_SIZE, int NUM_KV_HEADS>
+__global__ void fa_split_gqa_fixed_base0_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens,
+    float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
+    float scale, int max_blocks
+) {
+    constexpr int ELEMS = HEAD_DIM / 32;
+    constexpr int NUM_Q_HEADS = NUM_KV_HEADS * GQA;
+    const int seq   = blockIdx.y;
+    const int split = blockIdx.x % NSPLITS;
+    const int kvh   = blockIdx.x / NSPLITS;
+    const int warp  = threadIdx.x >> 5;
+    const int lane  = threadIdx.x & 31;
+    const int qh    = kvh * GQA + warp;
+
+    float qr[ELEMS];
+    const __nv_bfloat16* qp = q + (size_t)(seq * NUM_Q_HEADS + qh) * HEAD_DIM;
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) qr[e] = fa_to_f(qp[lane + e * 32]);
+
+    const int sl    = seq_lens[seq];
+    const int chunk = (sl + NSPLITS - 1) / NSPLITS;
+    const int start = split * chunk;
+    const int end   = min(sl, start + chunk);
+
+    float m = -1e30f, l = 0.f, acc[ELEMS];
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
+
+    extern __shared__ __nv_bfloat16 s_kv[];
+    __nv_bfloat16* s_k = s_kv;
+    __nv_bfloat16* s_v = s_kv + (size_t)TILE * HEAD_DIM;
+
+    for (int t0 = start; t0 < end; t0 += TILE) {
+        const int valid = min(TILE, end - t0);
+        for (int i = threadIdx.x * 2; i < valid * HEAD_DIM; i += blockDim.x * 2) {
+            const int within = i / HEAD_DIM, d = i % HEAD_DIM;
+            const size_t base = (((size_t)(t0 + within) * NUM_KV_HEADS + kvh) * HEAD_DIM) + d;
+            const __nv_bfloat162 k2 = *reinterpret_cast<const __nv_bfloat162*>(k_pool + base);
+            const __nv_bfloat162 v2 = *reinterpret_cast<const __nv_bfloat162*>(v_pool + base);
+            *reinterpret_cast<__nv_bfloat162*>(s_k + i) = k2;
+            *reinterpret_cast<__nv_bfloat162*>(s_v + i) = v2;
+        }
+        __syncthreads();
+        for (int tt = 0; tt < valid; tt++) {
+            float p = 0.f;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; e++) p += qr[e] * fa_to_f(s_k[tt * HEAD_DIM + lane + e * 32]);
+            const float score = fa_wsum(p) * scale;
+            const float mn = fmaxf(m, score), corr = __expf(m - mn), pe = __expf(score - mn);
+            l = l * corr + pe;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; e++) acc[e] = acc[e] * corr + pe * fa_to_f(s_v[tt * HEAD_DIM + lane + e * 32]);
+            m = mn;
+        }
+        __syncthreads();
+    }
+
+    const int idx = (seq * NUM_Q_HEADS + qh) * NSPLITS + split;
+    if (lane == 0) { part_m[idx] = m; part_l[idx] = l; }
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) part_acc[(size_t)idx * HEAD_DIM + lane + e * 32] = acc[e];
+    (void)block_table; (void)max_blocks;
+}
+
 // llama Q8_1 activation block (matches si_block_q8_1 used by the int8 MMVQ O-projection).
 struct fa_block_q8_1 { __half2 ds; signed char qs[32]; };
 
@@ -234,6 +378,73 @@ __global__ void fa_combine_kernel(
     }
 }
 
+template <int HEAD_DIM, int DG, int NW, int NSPLITS>
+__global__ void fa_combine_fixed_kernel(
+    const float* __restrict__ part_m, const float* __restrict__ part_l,
+    const float* __restrict__ part_acc, __nv_bfloat16* __restrict__ out,
+    int num_q_heads, fa_block_q8_1* __restrict__ out_q8 = nullptr
+) {
+    constexpr int ELEMS = HEAD_DIM / (32 * DG);
+    const int seq = blockIdx.y, qh = blockIdx.x / DG, dg = blockIdx.x % DG;
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int idxbase = (seq * num_q_heads + qh) * NSPLITS;
+    const int doff = dg * (HEAD_DIM / DG) + lane;
+
+    float lm = -1e30f;
+    #pragma unroll
+    for (int s = warp; s < NSPLITS; s += NW) lm = fmaxf(lm, part_m[idxbase + s]);
+    float ll = 0.f, lacc[ELEMS];
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) lacc[e] = 0.f;
+    #pragma unroll
+    for (int s = warp; s < NSPLITS; s += NW) {
+        const float sc = __expf(part_m[idxbase + s] - lm);
+        ll += part_l[idxbase + s] * sc;
+        #pragma unroll
+        for (int e = 0; e < ELEMS; e++) lacc[e] += sc * part_acc[(size_t)(idxbase + s) * HEAD_DIM + doff + e * 32];
+    }
+
+    __shared__ float s_m[NW], s_l[NW], s_acc[NW][32 * ELEMS];
+    if (lane == 0) { s_m[warp] = lm; s_l[warp] = ll; }
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) s_acc[warp][lane * ELEMS + e] = lacc[e];
+    __syncthreads();
+    if (warp != 0) return;
+
+    float gm = -1e30f;
+    #pragma unroll
+    for (int w = 0; w < NW; w++) gm = fmaxf(gm, s_m[w]);
+    float gl = 0.f, acc[ELEMS];
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
+    #pragma unroll
+    for (int w = 0; w < NW; w++) {
+        const float sc = __expf(s_m[w] - gm);
+        gl += s_l[w] * sc;
+        #pragma unroll
+        for (int e = 0; e < ELEMS; e++) acc[e] += sc * s_acc[w][lane * ELEMS + e];
+    }
+    const float inv = (gl > 0.f) ? (1.f / gl) : 0.f;
+    __nv_bfloat16* op = out + (size_t)(seq * num_q_heads + qh) * HEAD_DIM;
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) op[doff + e * 32] = __float2bfloat16(acc[e] * inv);
+
+    if (out_q8 != nullptr && ELEMS == 1) {
+        const float bv = __bfloat162float(__float2bfloat16(acc[0] * inv));
+        float amax = fabsf(bv);
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
+        const float d = amax / 127.0f;
+        const int qi = (amax == 0.0f) ? 0 : (int)roundf(bv / d);
+        const int blk = (seq * num_q_heads + qh) * (HEAD_DIM / 32) + dg;
+        out_q8[blk].qs[lane] = (signed char)qi;
+        int s = qi;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+        if (lane == 0) out_q8[blk].ds = __floats2half2_rn(d, d * (float)s);
+    }
+}
+
 #ifndef FA_COMBINE_DG
 #define FA_COMBINE_DG 4     // head-dim groups (DG x blocks); sweepable
 #endif
@@ -243,13 +454,25 @@ __global__ void fa_combine_kernel(
 #ifndef FA_GQA_TILE
 #define FA_GQA_TILE 14      // bf16 smem + uint4 ldg sweet spot at n_splits=128
 #endif
+#ifndef FA_GQA_TILE_FIXED
+#define FA_GQA_TILE_FIXED 8 // measured for the fixed n_splits=256 GQA path on RTX 5090
+#endif
 template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
 template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
+template __global__ void fa_split_gqa_fixed_kernel<128, 8, FA_GQA_TILE_FIXED, 256, 16, 4, 0>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    const int*, const int*, float*, float*, float*, float, int, int);
+template __global__ void fa_split_gqa_fixed_kernel<128, 8, FA_GQA_TILE_FIXED, 256, 16, 4, 1>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    const int*, const int*, float*, float*, float*, float, int, int);
+template __global__ void fa_split_gqa_fixed_kernel<128, 8, FA_GQA_TILE_FIXED, 256, 16, 4, 2>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    const int*, const int*, float*, float*, float*, float, int, int);
+template __global__ void fa_split_gqa_fixed_base0_kernel<128, 8, FA_GQA_TILE_FIXED, 256, 16, 4>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    const int*, const int*, float*, float*, float*, float, int);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+template __global__ void fa_combine_fixed_kernel<128, FA_COMBINE_DG, 16, 256>(const float*, const float*, const float*, __nv_bfloat16*, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -270,7 +493,12 @@ static inline void fa_launch_combine_dispatch(
     __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
     int num_seqs, cudaStream_t stream
 ) {
-    if (n_splits >= 128)      fa_launch_combine<16>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    if (n_splits == 256) {
+        dim3 g(num_q_heads * FA_COMBINE_DG, num_seqs);
+        fa_combine_fixed_kernel<128, FA_COMBINE_DG, 16, 256><<<g, 16 * 32, 0, stream>>>(
+            part_m, part_l, part_acc, out, num_q_heads, out_q8);
+    }
+    else if (n_splits >= 128) fa_launch_combine<16>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
     else if (n_splits >= 64)  fa_launch_combine<8>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
     else                      fa_launch_combine<FA_COMBINE_NW>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
 }
@@ -281,7 +509,7 @@ void launch_flash_decode_split(
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
-    void* out_q8
+    void* out_q8, int kv_contiguous_base
 ) {
     static int fagqa = -1;
     if (fagqa < 0) {
@@ -290,7 +518,32 @@ void launch_flash_decode_split(
     }
     const bool use_gqa = (fagqa == 1) || (fagqa == -2 && n_splits >= 64);
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
-        constexpr int GQA = 8, TILE = FA_GQA_TILE;
+        constexpr int GQA = 8;
+        if (head_dim == 128 && n_splits == 256 && block_size == 16 && num_kv_heads == 4) {
+            constexpr int TILE = FA_GQA_TILE_FIXED;
+            dim3 gq(4 * 256, num_seqs);
+            size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
+            if (num_seqs == 1 && kv_contiguous_base == 0) {
+                fa_split_gqa_fixed_base0_kernel<128, GQA, TILE, 256, 16, 4><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
+                    reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, max_blocks);
+            } else if (num_seqs == 1 && kv_contiguous_base > 0) {
+                fa_split_gqa_fixed_kernel<128, GQA, TILE, 256, 16, 4, 2><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
+                    reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, max_blocks, kv_contiguous_base);
+            } else {
+                fa_split_gqa_fixed_kernel<128, GQA, TILE, 256, 16, 4, 0><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
+                    reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, max_blocks, -1);
+            }
+            fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                                       num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
+            return;
+        }
+        constexpr int TILE = FA_GQA_TILE;
         dim3 gq(num_kv_heads * n_splits, num_seqs);
         size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
         fa_split_gqa_kernel<128, GQA, TILE><<<gq, GQA * 32, smem, stream>>>(

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -428,6 +428,37 @@ __global__ void si_mmvq_q4k_kernel(const si_block_q8_1* __restrict__ vy, const u
 template __global__ void si_mmvq_q4k_kernel<__nv_bfloat16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
 template __global__ void si_mmvq_q4k_kernel<float>(const si_block_q8_1*, const unsigned char*, float*, int, int);
 
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q4k_kfixed_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
+                                          OutT* __restrict__ y, int N) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    const si_block_q4_K* x_row = (const si_block_q4_K*)(W + (size_t)row * NSUPER * 144);
+    const int blocks_per_iter = vdr * NW * WS / qi;          // = 8
+    float tmp = 0.0f;
+    #pragma unroll
+    for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+        const int kby = kbx * 8;                             // q8_1 blocks per superblock = 8
+        const int kqs = vdr * (tid % (qi / vdr));
+        tmp += si_vec_dot_q4_K(x_row + kbx, vy + kby, kqs);
+    }
+    __shared__ float tmp_shared[NW - 1][WS];
+    if (warp > 0) tmp_shared[warp - 1][lane] = tmp;
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += tmp_shared[l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+
+template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q4k_kfixed_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
+template __global__ void si_mmvq_q4k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+
 // ===== faithful llama Q6_K mmvq for the fp32-path GEMVs (attn-V upgrades + LM head) =====
 // Same 4-warp-per-row structure as the Q4_K mmvq, with vec_dot_q6_K_q8_1 (coalesced
 // ql/qh int loads + __vsubss4 reconstruct + dp4a). Mirrors the #65 MoE-down dot.
@@ -644,13 +675,19 @@ void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t str
         reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<si_block_q8_1*>(y), K);
 }
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
-    si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
-        reinterpret_cast<__nv_bfloat16*>(y), N, K);
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
+    if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 4096) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else                si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
-    si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, K);
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    else if (K == 4096) si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     si_mmvq_q6k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -518,6 +518,37 @@ __global__ void si_mmvq_q6k_kernel(const si_block_q8_1* __restrict__ vy, const u
 template __global__ void si_mmvq_q6k_kernel<__nv_bfloat16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
 template __global__ void si_mmvq_q6k_kernel<float>(const si_block_q8_1*, const unsigned char*, float*, int, int);
 
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q6k_kfixed_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
+                                          OutT* __restrict__ y, int N) {
+    constexpr int NW = 4, WS = 32, vdr = 1, qi = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    const unsigned char* x_row = W + (size_t)row * NSUPER * 210;    // Q6_K: 210 B / 256-superblock
+    const int blocks_per_iter = vdr * NW * WS / qi;                 // = 4
+    float tmp = 0.0f;
+    #pragma unroll
+    for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+        const int kby = kbx * 8;                                    // q8_1 blocks per superblock
+        const int kqs = vdr * (tid % (qi / vdr));                   // = lane
+        tmp += si_vec_dot_q6_K(x_row + (size_t)kbx * 210, vy + kby, kqs);
+    }
+    __shared__ float tmp_shared[NW - 1][WS];
+    if (warp > 0) tmp_shared[warp - 1][lane] = tmp;
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += tmp_shared[l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+
+template __global__ void si_mmvq_q6k_kfixed_kernel<__nv_bfloat16, 8>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q6k_kfixed_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q6k_kfixed_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
+template __global__ void si_mmvq_q6k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+
 // 1-warp-per-row Q6_K dp4a GEMV: keeps the fp32 gemv_q block structure (GEMV_WPB rows/block,
 // well-occupied for large N like the LM head's 151936 rows) but dp4a instead of fp32 dequant.
 // The 4-warp si_mmvq is right for small-N rows (attn-V); this is right for the huge LM head.
@@ -690,13 +721,19 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
     else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
-    si_mmvq_q6k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
-        reinterpret_cast<__nv_bfloat16*>(y), N, K);
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
+    if (K == 2048)      si_mmvq_q6k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 4096) si_mmvq_q6k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else                si_mmvq_q6k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }
 void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
-    si_mmvq_q6k_kernel<float><<<N, 4 * 32, 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, K);
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    if (K == 2048)      si_mmvq_q6k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    else if (K == 4096) si_mmvq_q6k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    else                si_mmvq_q6k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
 void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
     static int wpb = -1;

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -519,6 +519,40 @@ __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
 }
 
+template <int H, int F, int TOPK>
+__global__ void gate_up_mmvq2_pack2_qwen_2d_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch
+) {
+    si_pdl_lc();
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int ts = blockIdx.y;
+    const int f = blockIdx.x * 2 + group;
+    if (f >= F) return;
+    const int tok = ts / TOPK;
+    const int e = expert_ids[ts];
+    const int tid4 = group_warp * WS + lane;
+    const int kbx = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
+    const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 144);
+    const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 144);
+    float tg = si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    float tu = si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    __shared__ float sg[2][NW - 1][WS], su[2][NW - 1][WS];
+    if (group_warp > 0) { sg[group][group_warp - 1][lane] = tg; su[group][group_warp - 1][lane] = tu; }
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[group][l][lane]; tu += su[group][l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+}
+
 // int8 dp4a MMVQ down (Q4_K). The Q4_K-quantized down rows in Q4_K_M were the last MoE GEMV
 // still on the fp register-dequant path (Q6_K down + gate/up + attention already run int8).
 // Reuses the Q8_1-quantized activation and the faithful vec_dot_q4_K_q8_1, one warp per
@@ -870,9 +904,9 @@ void launch_moe_expert_ffn_q4k(
             q = qbuf;
         }
         if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 768 && top_k == 8)
-            gate_up_mmvq2_pack2_qwen_kernel<2048, 768, 8><<<(num_tokens * top_k * ffn + 1) / 2, 8 * 32, 0, stream>>>(
+            gate_up_mmvq2_pack2_qwen_2d_kernel<2048, 768, 8><<<dim3((ffn + 1) / 2, num_tokens * top_k), 8 * 32, 0, stream>>>(
                 q, reinterpret_cast<const unsigned char*>(gate_q),
-                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, num_tokens * top_k * ffn);
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
         else if (gu_spec && hidden == 2048 && ffn == 768 && top_k == 8)
             gate_up_mmvq2_qwen_kernel<2048, 768, 8><<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
                 q, reinterpret_cast<const unsigned char*>(gate_q),

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -94,7 +94,7 @@ void launch_flash_decode_split(
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale,
-    cudaStream_t stream = nullptr, void* out_q8 = nullptr);
+    cudaStream_t stream = nullptr, void* out_q8 = nullptr, int kv_contiguous_base = -1);
 
 // Flash decode for GLOBAL layers: full context, head_dim=512, GQA 8:1.
 // Two-phase dot product splits 512-dim head into two 256-dim halves.

--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -50,6 +50,11 @@ public:
     int num_free_blocks() const;
     int num_total_blocks() const;
 
+    // Returns the first physical block when seq_id owns one linear block run
+    // (base, base+1, ...), otherwise -1. Kernels can use this to skip page-table
+    // lookups without changing correctness for fragmented allocations.
+    int contiguous_block_base(uint64_t seq_id) const;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -103,4 +103,15 @@ int    KVCacheManager::max_blocks_per_seq() const { return kMaxBlocksPerSeq; }
 int    KVCacheManager::num_free_blocks() const { return (int)impl_->free_list.size(); }
 int    KVCacheManager::num_total_blocks() const { return impl_->total_blocks; }
 
+int KVCacheManager::contiguous_block_base(uint64_t seq_id) const {
+    auto it = impl_->seq_blocks.find(seq_id);
+    if (it == impl_->seq_blocks.end() || it->second.empty()) return -1;
+    const std::vector<int>& blocks = it->second;
+    const int base = blocks[0];
+    for (size_t i = 1; i < blocks.size(); i++) {
+        if (blocks[i] != base + (int)i) return -1;
+    }
+    return base;
+}
+
 } // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -66,6 +66,7 @@ struct Qwen35Model::Impl {
     cudaGraphExec_t cu_exec{};
     bool graph_ready = false;
     bool bench_feedback_graph = false;
+    int graph_kv_contiguous_base = -2;
 
     // scratch (bf16)
     bf16 *x, *xn, *q, *k, *v, *attn, *ao, *h, *hn, *routed, *shared;
@@ -221,8 +222,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
             s.n_splits = want;
             if (s.graph_ready) {
                 cudaGraphExecDestroy(s.cu_exec); cudaGraphDestroy(s.cu_graph); s.graph_ready = false;
+                s.graph_kv_contiguous_base = -2;
             }
         }
+    }
+
+    const int kv_contiguous_base = s.kv->contiguous_block_base(s.seq_id);
+    if (s.graph_ready && s.graph_kv_contiguous_base != kv_contiguous_base) {
+        cudaGraphExecDestroy(s.cu_exec); cudaGraphDestroy(s.cu_graph); s.graph_ready = false;
+        s.graph_kv_contiguous_base = -2;
     }
 
     // Capture the decode compute into a CUDA graph on the first token, then
@@ -327,7 +335,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                            s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,
                                            s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
                                            1.f / sqrtf((float)c.head_dim), st,
-                                           emit_attn_q8 ? s.aq81 : nullptr);
+                                           emit_attn_q8 ? s.aq81 : nullptr, kv_contiguous_base);
         if (s.gguf && s.use_pq && w.wo_type == 12) {   // O proj reads attn: quantize once + dp4a
             if (s.use_llama) {
                 if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
@@ -397,6 +405,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
     cu(cudaStreamEndCapture(st, &s.cu_graph), "end capture");
     cu(cudaGraphInstantiate(&s.cu_exec, s.cu_graph, 0), "graph instantiate");
     s.graph_ready = true;
+    s.graph_kv_contiguous_base = kv_contiguous_base;
     cu(cudaGraphLaunch(s.cu_exec, st), "graph launch (first)");
 
     cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");


### PR DESCRIPTION
## Summary

Specializes Qwen long-context decode for the common 256-split GQA path. The PR keeps the existing fixed-K MMVQ work and adds a contiguous-KV fast path that skips page-table row-base staging for the RTX 5090 16k-context decode case.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) the **decode tok/s** table shows a **real end-to-end improvement** (`after > before`,
> filled from `bench/scripts/bench.sh` — *not* an isolated-kernel microbenchmark). A ticked box
> with an empty/placeholder table gets `needs-benchmark` and is **not** evaluated (no point spending
> a GPU when there's no claimed decode gain).
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from RTX 5090 `qwen3_gguf_bench`, the runner used by `bench/scripts/bench.sh`):

| | decode tok/s |
|---|--:|
| before (main) | 260.53 |
| after (this PR) | 267.02 |

```text
# RTX 5090, CUDA 13.0.1 container, Qwen3-30B-A3B-Q4_K_M.gguf
# token count: 64, context: 16384, batch size: 1
# before is a bracket average from current main; after is this PR.

current-main opening:
decode tg    : 261.01 tok/s  (3.8 ms/token, n=64, ctx=16384, bs=1)

this PR:
decode tg    : 267.02 tok/s  (3.7 ms/token, n=64, ctx=16384, bs=1)

current-main closing:
decode tg    : 260.04 tok/s  (3.8 ms/token, n=64, ctx=16384, bs=1)

bracketed main avg: 260.53 tok/s
this PR speedup: +2.49%

ctest --test-dir build-sm120-final-direct --output-on-failure
100% tests passed, 0 tests failed out of 6

qwen3_gguf_score /work/models/Qwen3-30B-A3B-Q4_K_M.gguf 5 100..700
PPL 14823.16730 over 600 positions
ARGMATCH 33/600 0.0550
SCORE_MATCH

long-context argmax probe, positions 2047/8191/16383/16556..16559
current hash: 9723170976384756342
this PR hash: 9723170976384756342
PROBE_MATCH
```