### PR TITLE
perf(attn): uint4 ldg KV staging + GQA TILE=14

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -127,14 +127,12 @@ __global__ void fa_split_gqa_kernel(
             s_rowbase[threadIdx.x] = ((size_t)(phys * block_size + wb) * num_kv_heads + kvh) * HEAD_DIM;
         }
         __syncthreads();
-        // Vectorized load: bf16x2 into bf16 smem (halves load instructions vs per-element).
-        for (int i = threadIdx.x * 2; i < valid * HEAD_DIM; i += blockDim.x * 2) {
+        // Vectorized load: uint4 (8×bf16) via __ldg into bf16 smem.
+        for (int i = threadIdx.x * 8; i < valid * HEAD_DIM; i += blockDim.x * 8) {
             const int within = i / HEAD_DIM, d = i % HEAD_DIM;
             const size_t base = s_rowbase[within] + d;
-            const __nv_bfloat162 k2 = *reinterpret_cast<const __nv_bfloat162*>(k_pool + base);
-            const __nv_bfloat162 v2 = *reinterpret_cast<const __nv_bfloat162*>(v_pool + base);
-            s_k[i] = k2.x; s_k[i + 1] = k2.y;
-            s_v[i] = v2.x; s_v[i + 1] = v2.y;
+            *reinterpret_cast<uint4*>(s_k + i) = __ldg(reinterpret_cast<const uint4*>(k_pool + base));
+            *reinterpret_cast<uint4*>(s_v + i) = __ldg(reinterpret_cast<const uint4*>(v_pool + base));
         }
         __syncthreads();
         for (int tt = 0; tt < valid; tt++) {
@@ -243,7 +241,7 @@ __global__ void fa_combine_kernel(
 #define FA_COMBINE_NW 4     // warps/block folding the split stripes; sweepable
 #endif
 #ifndef FA_GQA_TILE
-#define FA_GQA_TILE 12      // bf16 smem sweet spot at n_splits=256 (~64 tok/chunk)
+#define FA_GQA_TILE 14      // bf16 smem + uint4 ldg sweet spot at n_splits=128
 #endif
 template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int);


### PR DESCRIPTION
## Summary

Builds on #126 (bf16 GQA smem + adaptive combine). At 16k the GQA split kernel is still KV bandwidth-bound in the global→shared staging loop. This PR adds:

1. **uint4 `__ldg` vectorized global→smem copies** — 8×bf16 per load (vs bf16x2 in #126), cutting load instructions and improving read-only cache behavior on the KV staging path.
2. **`FA_GQA_TILE` 12→14** — retuned for the wider uint4 load path at `n_splits=128`.

Distinct from #123: no GQA grid layout, `SPARKINFER_FAGQA` policy, or adaptive `target_chunk` halving. Layers on #126 only; does not duplicate #125 (TILE=16).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench`, n=256, bs=1):

| decode tok/s | |
|---|---|
| before (main #126) | 237.3 |
| after (this PR) | **253.6** |

~**+6.9%** at 16k ctx (3-run average, same box/session). 2k guard: 264.7 → 265.0 (no regression). 128 ctx: 438.6 tok/s (unchanged).

```
=== MAIN #126 (3 runs, ctx=16384) ===
decode tg    : 237.27 tok/s
decode tg    : 237.23 tok/s
decode tg    : 237.30 tok/s

=== OPT (3 runs, ctx=16384) ===
decode tg    : 253.60 tok/s
decode tg    : 253.68 tok/s
decode tg    : 253.47 tok/s

2k guard: 264.66 → 265.15 tok/s
128 ctx: 438.63 tok/s (unchanged)
ctest: 6/6 passed
```

## Test plan

- [x] Local `qwen3_gguf_bench` at ctx=16384 (scored), 2048 (guard), 128 (short)
- [x] `ctest` 6/6 pass
- [x] Rebased on latest main (#126)
- [ ] sparkinfer auto-eval on RTX 5090
