### PR TITLE
fix(kv-cache): grow sequences by block delta, not append — prevents block leak + device block-table overrun (RTX 5090 verified)

### DIFF
--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -63,15 +63,26 @@ KVCacheManager::~KVCacheManager() {
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
     const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
-    if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
     if (need > kMaxBlocksPerSeq) return false;
 
+    // `need` is the TOTAL blocks the sequence must own for num_tokens. Grow only by the
+    // delta over what it already holds -- the seq_slot reuse branch below is designed to
+    // re-allocate an existing seq_id, and appending `need` blocks unconditionally would
+    // (a) leak the blocks it already held and (b) push seq_blocks past kMaxBlocksPerSeq,
+    // making the cudaMemcpy of blocks.data() overrun the fixed-width device table row into
+    // the next sequence. A fresh seq_id has have==0, so this is identical to the old path.
     auto& blocks = impl_->seq_blocks[seq_id];
-    for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
+    const int have = (int)blocks.size();
+    const int add  = need - have;
+    auto it = impl_->seq_slot.find(seq_id);
+    const bool need_new_slot = (it == impl_->seq_slot.end());
+    // Check every precondition before mutating any free-list / slot state (fail clean).
+    if (add > 0 && (int)impl_->free_list.size() < add) return false;
+    if (need_new_slot && impl_->free_slots.empty()) return false;
+    for (int i = 0; i < add; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
 
     int slot;
-    auto it = impl_->seq_slot.find(seq_id);
-    if (it != impl_->seq_slot.end()) slot = it->second;
+    if (!need_new_slot) slot = it->second;
     else { slot = impl_->free_slots.back(); impl_->free_slots.pop_back(); impl_->seq_slot[seq_id] = slot; }
 
     cu(cudaMemcpy(impl_->d_block_tables + (size_t)slot * kMaxBlocksPerSeq, blocks.data(),

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -21,3 +21,10 @@ add_test(NAME decode_runner_gpu_test COMMAND decode_runner_gpu_test)
 add_executable(qwen35_gpu_test qwen35_gpu_test.cpp)
 target_link_libraries(qwen35_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME qwen35_gpu_test COMMAND qwen35_gpu_test)
+
+add_executable(kv_cache_gpu_test kv_cache_gpu_test.cpp)
+target_link_libraries(kv_cache_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
+add_test(NAME kv_cache_gpu_test COMMAND kv_cache_gpu_test)
+
+add_executable(kv_allocate_repro kv_allocate_repro.cpp)
+target_link_libraries(kv_allocate_repro PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/tests/kv_allocate_repro.cpp
+++ b/runtime/tests/kv_allocate_repro.cpp
@@ -1,0 +1,58 @@
+// Standalone repro: allocate(1,100) -> grow allocate(1,200) on live seq_id.
+// Matches the bug report scenario (block_size=16 -> 7 blocks, grow to 13).
+
+#include "sparkinfer/kv_cache.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+using sparkinfer::KVCacheConfig;
+using sparkinfer::KVCacheManager;
+
+static int used(KVCacheManager& kv) {
+    return kv.num_total_blocks() - kv.num_free_blocks();
+}
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no CUDA device\n");
+        return 0;
+    }
+
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, 0);
+
+    KVCacheConfig cfg{};
+    cfg.num_layers = 2;
+    cfg.num_kv_heads = 4;
+    cfg.head_dim = 128;
+    cfg.block_size = 16;
+
+    KVCacheManager kv(cfg, 32ull * 1024 * 1024);
+    const int total = kv.num_total_blocks();
+
+    if (!kv.allocate(1, 100)) { printf("RESULT: FAIL (allocate 100)\n"); return 1; }
+    const int u100 = used(kv);
+    printf("after allocate(1,100):  used=%d  (expect 7)\n", u100);
+    if (u100 != 7) { printf("RESULT: FAIL\n"); return 1; }
+
+    if (!kv.allocate(1, 200)) { printf("RESULT: FAIL (allocate 200)\n"); return 1; }
+    const int u200 = used(kv);
+    printf("after allocate(1,200):  used=%d  (correct=13)\n", u200);
+    if (u200 != 13) { printf("RESULT: FAIL (expected 13, got %d)\n", u200); return 1; }
+
+    if (!kv.allocate(1, 200)) { printf("RESULT: FAIL (idempotent)\n"); return 1; }
+    const int u200b = used(kv);
+    printf("re-allocate same size:  used=%d  (expect 13)\n", u200b);
+    if (u200b != 13) { printf("RESULT: FAIL\n"); return 1; }
+
+    kv.free(1);
+    const int free_after = kv.num_free_blocks();
+    printf("free(1):                free=%d  (total=%d)\n", free_after, total);
+    if (free_after != total) { printf("RESULT: FAIL (leak: %d blocks missing)\n", total - free_after); return 1; }
+
+    printf("GPU: %s (sm_%d.%d)\n", prop.name, prop.major, prop.minor);
+    printf("RESULT: PASS\n");
+    return 0;
+}

--- a/runtime/tests/kv_cache_gpu_test.cpp
+++ b/runtime/tests/kv_cache_gpu_test.cpp
@@ -1,0 +1,84 @@
+// GPU test for KVCacheManager block growth — exercises seq_id re-allocation.
+
+#include "sparkinfer/kv_cache.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <vector>
+
+using sparkinfer::KVCacheConfig;
+using sparkinfer::KVCacheManager;
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no CUDA device — kv_cache_gpu_test requires a GPU\n");
+        return 0;
+    }
+
+    cudaDeviceProp prop{};
+    cudaGetDeviceProperties(&prop, 0);
+
+    constexpr int block_size = 16;
+    KVCacheConfig cfg{};
+    cfg.num_layers = 2;
+    cfg.num_kv_heads = 4;
+    cfg.head_dim = 128;
+    cfg.block_size = block_size;
+
+    KVCacheManager kv(cfg, 32ull * 1024 * 1024);
+    const int total = kv.num_total_blocks();
+    const int free0 = kv.num_free_blocks();
+    if (free0 != total) {
+        printf("[FAIL] expected all blocks free at start (got %d, total %d)\n", free0, total);
+        return 1;
+    }
+
+    if (!kv.allocate(0, 32)) { printf("[FAIL] first allocate(0, 32)\n"); return 1; }
+    const int free1 = kv.num_free_blocks();
+    if (free1 != free0 - 2) {
+        printf("[FAIL] first allocate should take 2 blocks (free %d -> %d)\n", free0, free1);
+        return 1;
+    }
+
+    std::vector<int> seq0_blocks(2);
+    cudaMemcpy(seq0_blocks.data(), kv.block_table(0), 2 * sizeof(int), cudaMemcpyDeviceToHost);
+
+    if (!kv.allocate(0, 64)) { printf("[FAIL] re-allocate(0, 64)\n"); return 1; }
+    const int free2 = kv.num_free_blocks();
+    if (free2 != free1 - 2) {
+        printf("[FAIL] re-allocate should add 2 blocks (free %d -> %d, want %d)\n",
+               free1, free2, free1 - 2);
+        return 1;
+    }
+
+    std::vector<int> seq0_grown(4);
+    cudaMemcpy(seq0_grown.data(), kv.block_table(0), 4 * sizeof(int), cudaMemcpyDeviceToHost);
+    for (int i = 0; i < 2; i++) {
+        if (seq0_grown[i] != seq0_blocks[i]) {
+            printf("[FAIL] re-allocate changed existing block id at %d (%d != %d)\n",
+                   i, seq0_grown[i], seq0_blocks[i]);
+            return 1;
+        }
+    }
+
+    if (!kv.allocate(1, 32)) { printf("[FAIL] allocate(1, 32)\n"); return 1; }
+    std::vector<int> seq1_blocks(2);
+    cudaMemcpy(seq1_blocks.data(), kv.block_table(1), 2 * sizeof(int), cudaMemcpyDeviceToHost);
+    if (seq1_blocks[0] == seq0_grown[0] && seq1_blocks[1] == seq0_grown[1]) {
+        printf("[FAIL] seq 1 block table aliases seq 0 (table row corruption)\n");
+        return 1;
+    }
+
+    const int free3 = kv.num_free_blocks();
+    if (!kv.allocate(0, 64)) { printf("[FAIL] idempotent re-allocate(0, 64)\n"); return 1; }
+    if (kv.num_free_blocks() != free3) {
+        printf("[FAIL] idempotent re-allocate consumed blocks (%d -> %d)\n",
+               free3, kv.num_free_blocks());
+        return 1;
+    }
+
+    printf("[PASS] kv_cache_gpu_test on %s: fresh allocate, delta re-grow, no leak, "
+           "seq isolation (%d blocks total)\n", prop.name, total);
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fix `KVCacheManager::allocate()` to grow a sequence's block table by the **delta** (`add = need - have`) instead of unconditionally appending `need` blocks on every call. Prevents block leaks and device block-table row overruns when the same `seq_id` is re-allocated (the slot-reuse branch already anticipates this call pattern).

**Correctness/robustness fix — no expected decode speedup.** Callers today pre-allocate full `max_seq` once; the e2e bench confirms no perf regression.

## The bug

`KVCacheManager::allocate(seq_id, num_tokens)` (`runtime/src/kv_cache.cpp:64`) computes `need = ceil(num_tokens / block_size)` as the total blocks the sequence should own, then unconditionally appends `need` blocks to `seq_blocks[seq_id]`. The `seq_slot` reuse branch right below it is explicitly written to handle an already-allocated `seq_id` (`if (it != seq_slot.end()) slot = it->second;`), so re-allocation is an anticipated call pattern — but the block-append path breaks it two ways:

1. **Block leak.** Growing a live sequence 100→200 tokens (`block_size=16`) allocates 13 more blocks on top of the 7 it already held (20 total) instead of the correct 6 delta — 7 blocks orphaned, unrecoverable until `free()`.
2. **Device out-of-bounds write.** The only size guard is `need > kMaxBlocksPerSeq`; nothing bounds `blocks.size()`. Repeated growth pushes the vector past `kMaxBlocksPerSeq` (4096), and the `cudaMemcpy(d_block_tables + slot*kMaxBlocksPerSeq, blocks.data(), blocks.size()*4, …)` then overruns the fixed-width device table row into the next sequence's row — silent cross-sequence corruption.

Today both callers (`generate`, `bench_decode`) pre-allocate the full `max_seq` once and `free()` before re-allocating, so it's latent — but it's a memory-safety landmine that fires the moment KV blocks are allocated incrementally (prefill-then-extend), which the slot-reuse logic already presumes.

## The fix

Grow by the delta only: `add = need - have`, append `add` blocks (0 when the sequence already has enough). A fresh `seq_id` has `have == 0`, so the common path is unchanged. Preconditions (free-list depth for `add`, a free table row only when the `seq_id` is new) are all checked before any free-list/slot mutation, preserving the original fail-clean behavior. `blocks.size()` is now always `== need ≤ kMaxBlocksPerSeq`, so the `cudaMemcpy` can never overrun the row.

---

⚠️ Tick the box only if you actually ran it on an RTX 5090. False attestation is treated as gaming.

- [x] **Tested on RTX 5090 (sm_120)**

## Proof of correctness (RTX 5090)

**Hardware:** NVIDIA GeForce RTX 5090, compute capability 12.0, 170 SMs, 1792 GB/s BW  
**Date:** 2026-07-03 UTC  
**Repro command:** `cmake --build build --target kv_allocate_repro kv_cache_gpu_test && ./build/runtime/tests/kv_allocate_repro`

### KV allocate repro (`runtime/tests/kv_allocate_repro`)

`allocate(1,100)` → grow `allocate(1,200)` on live `seq_id`, `block_size=16`:

| step | main (buggy) | this PR (patched) |
|------|-------------|-------------------|
| after `allocate(1,100)` | used=7 ✓ | used=7 ✓ |
| after `allocate(1,200)` | used=**20** (leaked 7) | used=**13** ✓ |
| re-allocate same size | unbounded growth | used=13 (idempotent) ✓ |
| `free(1)` | blocks leaked | free=512 == total ✓ |
| **RESULT** | **FAIL** | **PASS** |

**main (buggy):**
after allocate(1,100):  used=7  (expect 7)
after allocate(1,200):  used=20  (correct=13)   ← 7 blocks leaked
RESULT: FAIL (expected 13, got 20)

**this PR (patched):**
after allocate(1,100):  used=7  (expect 7)
after allocate(1,200):  used=13  (correct=13)
re-allocate same size:  used=13  (expect 13)
free(1):                free=512  (total=512)
GPU: NVIDIA GeForce RTX 5090 (sm_12.0)
RESULT: PASS

### Additional GPU tests (RTX 5090, no regression)

[PASS] kv_cache_gpu_test on NVIDIA GeForce RTX 5090: fresh allocate, delta re-grow, no leak, seq isolation (512 blocks total)
[PASS] decode_runner_gpu_test: 2 layers x 2 seqs, output finite
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
[PASS] qwen35_gpu_test: generated 8 tokens: 136 136 136 136 136 136 136 136
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s

## Decode tok/s (end-to-end, from `bench/scripts/bench.sh`)

No expected speedup — correctness fix only. Bench confirms **no regression** vs `main`:

| ctx | before (main) | after (this PR) | Δ |
|-----|--------------|-----------------|---|
| 128 | 482.49 tok/s | 482.74 tok/s | +0.05% |
| 512 | 462.05 tok/s | 462.21 tok/s | +0.03% |
| 2048 | 407.16 tok/s | 407.16 tok/s | 0.00% |
| 4096 | 349.60 tok/s | 349.26 tok/s | −0.10% |
| 16384 | 268.55 tok/s | 268.64 tok/s | +0.03% |

# RTX 5090, Qwen3-30B-A3B-Q4_K_M.gguf, n=128 decode tokens, bs=1
# before: main + cmake --build build --target qwen3_gguf_bench
# after:  fix/kv-allocate-delta-blocks + cmake --build build --target qwen3_gguf_bench

ctx=128:
before (main):    482.49 tok/s
after (this PR):  482.74 tok/s

ctx=512:
before (main):    462.05 tok/s
after (this PR):  462.21 tok/s

ctx=2048:
before (main):    407.16 tok/s
after (this PR):  407.16 tok/s

ctx=4096:
before (main):    349.60 tok/s
after (this PR):  349.26 tok/s

ctx=16384:
before (main):    268.55 tok/s
after (this PR):  268.64 tok/s

### Build

cmake --build build --target sparkinfer_runtime
links clean

Fresh-allocate decode path is byte-for-byte unchanged (identical block accounting on the first `allocate`).

## Notes for reviewers

- Fix: single hunk in `runtime/src/kv_cache.cpp:64` on branch `fix/kv-allocate-delta-blocks`
- Tests added: `runtime/tests/kv_allocate_repro.cpp`, `runtime/tests/kv_cache_gpu_test.cpp`
- Correctness/robustness fix — no perf delta expected; request manual merge for correctness