### PR TITLE
Enable GQA split path at 32 splits

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -288,7 +288,7 @@ void launch_flash_decode_split(
         const char* e = getenv("SPARKINFER_FAGQA");
         fagqa = e ? ((e[0] == '0') ? 0 : 1) : -2;   // -2 = auto: long-context only
     }
-    const bool use_gqa = (fagqa == 1) || (fagqa == -2 && n_splits >= 64);
+    const bool use_gqa = (fagqa == 1) || (fagqa == -2 && n_splits >= 32);
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
         constexpr int GQA = 8, TILE = FA_GQA_TILE;
         dim3 gq(num_kv_heads * n_splits, num_seqs);


### PR DESCRIPTION
## Summary

Enable the existing GQA-shared flash-decode split path earlier, at `n_splits >= 32` instead of `n_splits >= 64`.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) the **decode tok/s** table shows a **real end-to-end improvement** (`after > before`,
> filled from `bench/scripts/bench.sh` — *not* an isolated-kernel microbenchmark). A ticked box
> with an empty/placeholder table gets `needs-benchmark` and is **not** evaluated (no point spending
> a GPU when there's no claimed decode gain).
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main, ctx=4096) | 192.85 |
| after (this PR, ctx=4096) | 342.85 |

```text
# RTX 5090, Qwen3-30B-A3B-Q4_K_M.gguf
# clean build-sm120 vs this PR build-sm120-gqa32

ctx=128:
before (main):    447.79 tok/s
after (this PR):  468.56 tok/s

ctx=2048:
before (main):    273.31 tok/s
after (this PR):  398.80 tok/s

ctx=4096:
before (main):    192.85 tok/s
after (this PR):  342.85 tok/s

ctx=16384:
before (main):    250.59 tok/s
after (this PR):  264.15 tok/s

Byte-identical qwen3_gguf_score checks vs clean build:
SCORE_GQA32_CMP_2048:0
SCORE_GQA32_CMP_4096:0
SCORE_GQA32_CMP_16384:0
```
