### PR TITLE
fix: guard KV cache against sequence position overflow

### DIFF
--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -62,12 +62,22 @@ KVCacheManager::~KVCacheManager() {
 }
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
+    if (num_tokens <= 0) return false;
     const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
-    if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
     if (need > kMaxBlocksPerSeq) return false;
 
     auto& blocks = impl_->seq_blocks[seq_id];
-    for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
+    const int have = (int)blocks.size();
+    const int grow = need - have;
+    if (grow > 0) {
+        if ((int)impl_->free_list.size() < grow) return false;
+        if (have == 0 && impl_->free_slots.empty()) return false;
+        for (int i = 0; i < grow; i++) {
+            blocks.push_back(impl_->free_list.back());
+            impl_->free_list.pop_back();
+        }
+    }
+    if (blocks.empty()) return false;
 
     int slot;
     auto it = impl_->seq_slot.find(seq_id);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -196,6 +196,16 @@ void Qwen35Model::copy_logits(float* host_logits) const {
 int Qwen35Model::forward_token(int token_id, int position) {
     Impl& s = *p_;
     const Qwen35Config& c = s.cfg;
+    if (position < 0 || position >= c.max_seq) {
+        fprintf(stderr, "[qwen35] forward_token: position %d out of range [0, %d)\n",
+                position, c.max_seq);
+        return -1;
+    }
+    if (token_id < 0 || token_id >= c.vocab) {
+        fprintf(stderr, "[qwen35] forward_token: token_id %d out of range [0, %d)\n",
+                token_id, c.vocab);
+        return -1;
+    }
     const int H = c.hidden;
     kernels::GemmConfig gc{};
     int seqlen = position + 1;
@@ -467,9 +477,21 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
         return out;
     }
+    const int last_pos = (int)prompt.size() + max_new - 1;
+    if (last_pos >= s.cfg.max_seq) {
+        fprintf(stderr,
+                "[qwen35] prompt (%zu) + generation (%d) needs position %d; max_seq=%d\n",
+                prompt.size(), max_new, last_pos, s.cfg.max_seq);
+        s.kv->free(s.seq_id);
+        return out;
+    }
     int next = -1;
-    for (size_t i = 0; i < prompt.size(); i++) next = forward_token(prompt[i], (int)i);
+    for (size_t i = 0; i < prompt.size(); i++) {
+        next = forward_token(prompt[i], (int)i);
+        if (next < 0) break;
+    }
     for (int i = 0; i < max_new; i++) {
+        if (next < 0) break;
         out.push_back(next);
         if (next == s.cfg.eos_id) break;
         next = forward_token(next, (int)prompt.size() + i);


### PR DESCRIPTION
## Summary

- **Root cause:** `forward_token()` and `generate()` did not validate that decode position stays within `max_seq`. Once `position >= max_seq`, KV append/flash-decode index past the allocated block table and write/read outside the KV pool (GPU OOB).
- **Fix:** Reject out-of-range `position`/`token_id` in `forward_token()`, preflight `prompt + max_new` in `generate()`, and make `KVCacheManager::allocate()` grow idempotently instead of appending duplicate blocks on re-entry.
- **Impact:** Prevents silent KV corruption and GPU memory safety failures on long prompts or misconfigured `max_seq` (e.g. `qwen3_gguf_generate` default 2048 context).

## Risk / tradeoffs

- Callers that previously relied on undefined overflow behavior now get `-1` from `forward_token()` and an early empty return from `generate()` with a stderr diagnostic. This is intentional fail-closed behavior.

## Test plan

- [ ] `generate()` with prompt length + `max_new` exceeding `max_seq` logs error and returns without CUDA faults
- [ ] Normal short-context decode/bench unchanged
- [ ] Repeated `KVCacheManager::allocate()` for the same `seq_id` does not double-allocate blocks