### PR TITLE
fix(runtime): pack KV block tables for multi-sequence DecodeRunner

### DIFF
--- a/runtime/include/sparkinfer/decode.h
+++ b/runtime/include/sparkinfer/decode.h
@@ -35,8 +35,13 @@ public:
                  int max_batch = 256);
     ~DecodeRunner();
 
-    // Begin a decode step: set the new-token position for each sequence
-    // (host seq_lens = length BEFORE this token). Uploads positions to device.
+    // Begin a decode step: set the new-token position for each batch row and
+    // gather each sequence's paged block table into batch-indexed device layout
+    // (seq_lens = length BEFORE this token; seq_ids[b] = KV owner for batch row b).
+    void begin_step(const std::vector<uint64_t>& seq_ids,
+                    const std::vector<int>& seq_lens_before);
+
+    // Convenience when batch row b maps to KV sequence id b.
     void begin_step(const std::vector<int>& seq_lens_before);
 
     // Run one layer in-place on x: [num_seqs, hidden] (bf16, device).

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -28,7 +28,7 @@ struct DecodeRunner::Impl {
 
     // scratch (bf16 unless noted)
     bf16 *xn, *q, *k, *v, *attnout, *ao, *h, *hn, *moeout;
-    int *d_seq_lens, *d_write_pos;
+    int *d_seq_lens, *d_write_pos, *d_batch_btable;
 
     template <class T> T* alloc(size_t n) { void* p = nullptr; cu(cudaMalloc(&p, n * sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -51,26 +51,51 @@ DecodeRunner::DecodeRunner(int hidden, AttnConfig attn, KVCacheManager* kv,
     p_->moeout  = p_->alloc<bf16>((size_t)M * hidden);
     p_->d_seq_lens  = p_->alloc<int>(M);
     p_->d_write_pos = p_->alloc<int>(M);
+    p_->d_batch_btable = p_->alloc<int>((size_t)M * kv->max_blocks_per_seq());
 }
 
 DecodeRunner::~DecodeRunner() {
     cudaFree(p_->xn); cudaFree(p_->q); cudaFree(p_->k); cudaFree(p_->v);
     cudaFree(p_->attnout); cudaFree(p_->ao); cudaFree(p_->h); cudaFree(p_->hn); cudaFree(p_->moeout);
-    cudaFree(p_->d_seq_lens); cudaFree(p_->d_write_pos);
+    cudaFree(p_->d_seq_lens); cudaFree(p_->d_write_pos); cudaFree(p_->d_batch_btable);
     delete p_;
 }
 
-void DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
+void DecodeRunner::begin_step(const std::vector<uint64_t>& seq_ids,
+                              const std::vector<int>& seq_lens_before) {
     const int n = (int)seq_lens_before.size();
     if (n <= 0 || n > p_->max_batch) {
         fprintf(stderr, "[decode] begin_step: num_seqs %d out of range (max_batch=%d)\n",
                 n, p_->max_batch);
         return;
     }
+    if ((int)seq_ids.size() != n) {
+        fprintf(stderr, "[decode] begin_step: seq_ids size %zu != seq_lens size %d\n",
+                seq_ids.size(), n);
+        return;
+    }
+    const int row_ints = p_->kv->max_blocks_per_seq();
+    const size_t row_bytes = (size_t)row_ints * sizeof(int);
+    for (int b = 0; b < n; b++) {
+        int* src = p_->kv->block_table(seq_ids[b]);
+        if (!src) {
+            fprintf(stderr, "[decode] begin_step: seq_id %llu (batch %d) has no KV blocks\n",
+                    (unsigned long long)seq_ids[b], b);
+            return;
+        }
+        cu(cudaMemcpy(p_->d_batch_btable + (size_t)b * row_ints, src, row_bytes,
+                      cudaMemcpyDeviceToDevice), "pack block table");
+    }
     std::vector<int> after(n);
     for (int i = 0; i < n; i++) after[i] = seq_lens_before[i] + 1;   // include the new token
     cu(cudaMemcpy(p_->d_write_pos, seq_lens_before.data(), n * sizeof(int), cudaMemcpyHostToDevice), "wpos");
     cu(cudaMemcpy(p_->d_seq_lens,  after.data(),           n * sizeof(int), cudaMemcpyHostToDevice), "slens");
+}
+
+void DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
+    std::vector<uint64_t> seq_ids(seq_lens_before.size());
+    for (size_t i = 0; i < seq_ids.size(); i++) seq_ids[i] = i;
+    begin_step(seq_ids, seq_lens_before);
 }
 
 void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
@@ -96,7 +121,7 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     // 3. append new K/V into the paged cache for this layer
     bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)layer * s.kv->layer_stride_elems();
     bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)layer * s.kv->layer_stride_elems();
-    int* btable = s.kv->block_table(0);   // batch occupies slots 0..num_seqs-1
+    int* btable = s.d_batch_btable;   // batch-indexed rows packed in begin_step()
     launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
                      num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
                      s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);

--- a/runtime/tests/decode_runner_gpu_test.cpp
+++ b/runtime/tests/decode_runner_gpu_test.cpp
@@ -73,7 +73,8 @@ int main() {
 
     cudaStream_t stream; cudaStreamCreate(&stream);
     std::vector<int> lens(seqs, 7);                 // 7 tokens already cached
-    runner.begin_step(lens);
+    std::vector<uint64_t> seq_ids = {0, 1};
+    runner.begin_step(seq_ids, lens);               // pack per-seq slots -> batch rows
     for (int l = 0; l < layers; l++) runner.decode_layer(l, x, seqs, w[l], stream);
     cudaStreamSynchronize(stream);
 


### PR DESCRIPTION
## Problem

`DecodeRunner` passed `KVCacheManager::block_table(0)` into the paged KV kernels, but those kernels index the table as `[batch_row][block]` (`block_table[seq * max_blocks + blk]`).

`KVCacheManager` stores each sequence in an arbitrary slot row (`seq_id -> slot`), not necessarily slot `0..num_seqs-1`. For any batch with more than one sequence, rows `1..N-1` read the wrong device memory - wrong KV append and wrong flash-decode attention.

The existing `decode_runner_gpu_test` (2 sequences) exercised this path but only checked for finite output, so the bug stayed hidden.

## Root cause

Mismatch between **batch-indexed** kernel API and **seq-id slot** KV layout. The comment `batch occupies slots 0..num_seqs-1` was incorrect.

## Fix

- Allocate a batch-indexed device block table in `DecodeRunner`.
- Extend `begin_step` to accept `seq_ids` alongside `seq_lens` and D2D-gather each sequence's row into batch row `b`.
- Keep a convenience overload `begin_step(seq_lens)` that assumes `seq_ids[b] == b`.
- Use the packed table in `decode_layer` for KV append + flash-decode.

## Why this approach

- No kernel changes; fixes the wiring layer where the mismatch lives.
- Matches how `Qwen35Model` already passes a single sequence's table (batch size 1).
- Ready for `Scheduler` batches that carry arbitrary `uint64_t` sequence ids.

## Testing

- Updated `decode_runner_gpu_test` to call `begin_step(seq_ids, lens)` explicitly.
- No CUDA GPU on CI host here; change is a small D2D memcpy + pointer swap. Please run `ctest` / `decode_runner_gpu_test` on a 5090.

## Risks

- `begin_step` now does `num_seqs` D2D copies per decode step (bounded by `max_batch`). Cost is negligible vs attention/MoE; can be fused later if needed.