### PR TITLE
fix(runtime): auto-enable shared expert from GGUF shexp tensors

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -528,12 +528,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     GGUF g;
     if (!g.open(path)) return false;
 
-    // Shared-expert tensors are optional in GGUF (Qwen3-30B-A3B has none). The
-    // default config sets n_shared=1, so clamp it to what the file actually
-    // contains before forward_token can launch a null-weight FFN.
+    // Shared-expert tensors are optional in GGUF (Qwen3-30B-A3B has none; Qwen3.5-35B-A3B
+    // and Gemma4 have one). Clamp down when absent; auto-enable when present so callers
+    // that hardcode n_shared=0 (all GGUF examples) still run the correct graph.
     const bool gguf_has_shared =
         g.tensor("blk.0.ffn_gate_shexp.weight") != nullptr;
-    if (c.n_shared > 0 && !gguf_has_shared) {
+    if (gguf_has_shared && s.cfg.n_shared == 0) {
+        fprintf(stderr,
+                "[gguf] shared-expert tensors present; enabling n_shared=1\n");
+        s.cfg.n_shared = 1;
+    } else if (s.cfg.n_shared > 0 && !gguf_has_shared) {
         fprintf(stderr,
                 "[gguf] no shared-expert tensors; forcing n_shared=0 "
                 "(safe for models without a shared FFN)\n");


### PR DESCRIPTION
## Problem

Qwen3.5-35B-A3B and Gemma4 include an **always-on shared MoE expert** (fn_*_shexp tensors). The architecture spec and moe/configs/qwen35_35b_a3b.yaml document shared_expert: true.

load_gguf() already **clamps down** (
_shared -> 0) when shexp tensors are absent (Qwen3-30B-A3B). But it never **clamps up** when tensors are present. Every GGUF entrypoint hardcodes cfg.n_shared = 0 (qwen3_gguf_generate, qwen3_gguf_bench, qwen3_gguf_score, 	hermal_sweep).

Result: loading a model that *has* shared-expert weights still runs decode with 
_shared == 0, so orward_token() skips the shared FFN on all 40 layers. Routed top-8 MoE runs, but the always-on expert branch is silently dropped - systematic logit error vs llama.cpp / HF reference.

## Root cause

Asymmetric detection in Qwen35Model::load_gguf(): only the no-tensor case was handled. Callers inherited a 30B-oriented 
_shared=0 default.

## Fix

Mirror the existing clamp-down logic: if lk.0.ffn_gate_shexp.weight exists and 
_shared==0, set 
_shared=1 before weight upload. Qwen3-30B-A3B (no shexp tensors) is unchanged.

## Impact

- **Qwen3-30B-A3B eval path**: no change (no shexp tensors).
- **Qwen3.5-35B / Gemma4 GGUF**: correct full MoE graph without requiring every caller to know tensor naming.
- Fixes silent correctness failure, not a perf tweak.

## Testing

- Logic-only change in load_gguf(); no kernel changes.
- Qwen3-30B: 
_shared stays 0 (existing behavior).
- Qwen3.5-35B GGUF: stderr logs enabling n_shared=1; shared weights loaded in per-layer loop.
- Please verify token-match vs llama.cpp on a 35B GGUF with shared expert.

## Risks

None for 30B. For 35B/Gemma, logits will change to the **correct** reference - any workflow that accidentally depended on the broken graph will see different (correct) tokens.