### PR TITLE
fix(kv-cache): sanitize block-table rows on allocate and free

### DIFF
--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -12,6 +12,7 @@
 #include <cuda_runtime.h>
 #include <vector>
 #include <unordered_map>
+#include <cstring>
 #include <cstdio>
 
 namespace sparkinfer {
@@ -22,6 +23,7 @@ inline void cu(cudaError_t e, const char* what) {
 }
 constexpr int kMaxSeqs = 256;
 constexpr int kMaxBlocksPerSeq = 4096;   // 4096 * block_size tokens per sequence
+constexpr int kInvalidBlock = -1;        // sentinel for unused logical block slots
 }
 
 struct KVCacheManager::Impl {
@@ -51,6 +53,7 @@ KVCacheManager::KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes)
     cu(cudaMalloc(&impl_->k_pool, pool_elems * sizeof(unsigned short)), "malloc k_pool");
     cu(cudaMalloc(&impl_->v_pool, pool_elems * sizeof(unsigned short)), "malloc v_pool");
     cu(cudaMalloc(&impl_->d_block_tables, (size_t)kMaxSeqs * kMaxBlocksPerSeq * sizeof(int)), "malloc tables");
+    cu(cudaMemset(impl_->d_block_tables, 0xFF, (size_t)kMaxSeqs * kMaxBlocksPerSeq * sizeof(int)), "init tables");
 
     impl_->free_list.reserve(impl_->total_blocks);
     for (int i = impl_->total_blocks - 1; i >= 0; --i) impl_->free_list.push_back(i);
@@ -62,31 +65,50 @@ KVCacheManager::~KVCacheManager() {
 }
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
+    if (num_tokens <= 0) return false;
     const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
-    if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
     if (need > kMaxBlocksPerSeq) return false;
 
     auto& blocks = impl_->seq_blocks[seq_id];
-    for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
+    const int have = (int)blocks.size();
+    const int grow = need - have;
+    if (grow > 0) {
+        if ((int)impl_->free_list.size() < grow) return false;
+        if (have == 0 && impl_->free_slots.empty()) return false;
+        for (int i = 0; i < grow; i++) {
+            blocks.push_back(impl_->free_list.back());
+            impl_->free_list.pop_back();
+        }
+    }
+    if (blocks.empty()) return false;
 
     int slot;
     auto it = impl_->seq_slot.find(seq_id);
     if (it != impl_->seq_slot.end()) slot = it->second;
     else { slot = impl_->free_slots.back(); impl_->free_slots.pop_back(); impl_->seq_slot[seq_id] = slot; }
 
-    cu(cudaMemcpy(impl_->d_block_tables + (size_t)slot * kMaxBlocksPerSeq, blocks.data(),
-                  blocks.size() * sizeof(int), cudaMemcpyHostToDevice), "copy block table");
+    // Upload the full row so tail slots never retain stale mappings from a prior
+    // occupant of this table row (slot reuse) or from cudaMalloc garbage.
+    std::vector<int> row(kMaxBlocksPerSeq, kInvalidBlock);
+    std::memcpy(row.data(), blocks.data(), blocks.size() * sizeof(int));
+    int* dst = impl_->d_block_tables + (size_t)slot * kMaxBlocksPerSeq;
+    cu(cudaMemcpy(dst, row.data(), (size_t)kMaxBlocksPerSeq * sizeof(int), cudaMemcpyHostToDevice), "copy block table");
     return true;
 }
 
 void KVCacheManager::free(uint64_t seq_id) {
+    auto s = impl_->seq_slot.find(seq_id);
+    if (s != impl_->seq_slot.end()) {
+        int* row = impl_->d_block_tables + (size_t)s->second * kMaxBlocksPerSeq;
+        cu(cudaMemset(row, 0xFF, (size_t)kMaxBlocksPerSeq * sizeof(int)), "clear block table");
+        impl_->free_slots.push_back(s->second);
+        impl_->seq_slot.erase(s);
+    }
     auto it = impl_->seq_blocks.find(seq_id);
     if (it != impl_->seq_blocks.end()) {
         for (int b : it->second) impl_->free_list.push_back(b);
         impl_->seq_blocks.erase(it);
     }
-    auto s = impl_->seq_slot.find(seq_id);
-    if (s != impl_->seq_slot.end()) { impl_->free_slots.push_back(s->second); impl_->seq_slot.erase(s); }
 }
 
 int* KVCacheManager::block_table(uint64_t seq_id) const {


### PR DESCRIPTION
## Problem

Paged KV attention kernels resolve logical block index lk = pos / block_size via:

```
phys = block_table[seq * max_blocks + blk]
```

KVCacheManager::allocate() only cudaMemcpy'd locks.size() ints into a table row. Tail entries were never cleared:

1. **Slot reuse** - ree() recycled the table row but left stale physical block IDs on device. A shorter re-allocation on the same slot left indices >= new_block_count pointing at freed or foreign pages.
2. **Uninitialized memory** - cudaMalloc does not zero table rows; first partial upload left garbage past the copied prefix.
3. **Double allocate** - each llocate() call appended another full 
eed blocks instead of growing by delta, leaking pool blocks and bloating tables.

### Repro

```cpp
kv.allocate(0, 65536);   // 4096 blocks in slot 0
kv.free(0);
kv.allocate(0, 64);      // 4 blocks - only 4 ints copied
forward_token(..., pos=64);  // blk=4 reads stale mapping from prior session
```

Attention then reads/writes the wrong KV pages ? silent logit corruption or GPU OOB.

Single-sequence generate() allocates max_seq upfront, which masks this for the default one-shot path. Any multi-turn server, slot reuse, or partial allocation (DecodeRunner test uses llocate(i, 64)) is affected.

## Fix

- Initialize all table rows to -1 at construction.
- **Grow by delta** on llocate() (grow = need - have) - idempotent re-call for the same capacity.
- Upload the **full** kMaxBlocksPerSeq row: valid prefix from locks, tail filled with -1.
- **cudaMemset the row to -1 on ree()** before recycling the slot.

Complements open grow-by-delta PRs (#127, #139) by fixing the stale-tail invariant those PRs do not address.

## Impact

- Fixes silent wrong KV / cross-sequence corruption on slot reuse.
- Prevents block-pool leak on repeated llocate() without ree().
- No-op for generate() when it always allocates max_seq once (full row overwritten each time).

## Test plan

- [ ] llocate(0, N); free(0); allocate(0, N/4); decode past N/4 tokens - should fail fast (invalid phys) or be caught by position guards, not return wrong logits.
- [ ] llocate(0, max_seq) twice without ree - block count unchanged, no pool drain.
- [ ] Existing decode_runner_gpu_test and qwen35_gpu_test pass on GPU.
- [ ] Multi-seq: two sequences with different context lengths, free one, allocate a third - no cross-talk in KV reads.