### PR TITLE
fix(decode): wire QK-norm and RoPE into DecodeRunner attention

### DIFF
--- a/runtime/include/sparkinfer/decode.h
+++ b/runtime/include/sparkinfer/decode.h
@@ -11,7 +11,9 @@ struct AttnConfig {
     int num_q_heads;
     int num_kv_heads;
     int head_dim;
-    float scale;     // 1/sqrt(head_dim)
+    float scale;        // 1/sqrt(head_dim)
+    float rope_theta = 1e6f;
+    float rms_eps    = 1e-6f;
 };
 
 // Device weight pointers (bf16) for one MoE transformer layer.
@@ -21,12 +23,14 @@ struct TransformerLayerWeights {
     const void* wk = nullptr;          // [hidden, num_kv_heads*head_dim]
     const void* wv = nullptr;          // [hidden, num_kv_heads*head_dim]
     const void* wo = nullptr;          // [num_q_heads*head_dim, hidden]
+    const void* q_norm = nullptr;      // [head_dim] per-head Q RMSNorm (Qwen3; null = skip)
+    const void* k_norm = nullptr;      // [head_dim] per-head K RMSNorm (Qwen3; null = skip)
     const void* ffn_norm = nullptr;    // [hidden]
     moe::LayerWeights moe;             // router_w, gate_w, up_w, down_w
 };
 
 // Drives a batch of single-token decode steps through the full stack:
-//   RMSNorm -> Q/K/V proj -> KV append -> GQA flash decode -> O proj
+//   RMSNorm -> Q/K/V proj -> QK-norm + RoPE + KV append -> GQA flash decode -> O proj
 //   -> residual+RMSNorm -> sync-free MoE -> residual.
 // Attention uses the gqa8 kernel (Qwen3.5-35B-A3B: 16 Q / 2 KV heads, hd=128).
 class DecodeRunner {

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -83,23 +83,36 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
         return;
     }
     const int H = s.hidden, Q = s.qdim, KV = s.kvdim;
+    const float eps = s.attn.rms_eps;
     kernels::GemmConfig gc{};
 
     // 1. pre-attention norm
-    kernels::launch_rmsnorm(x, w.attn_norm, s.xn, num_seqs, H, 1e-6f, stream);
+    kernels::launch_rmsnorm(x, w.attn_norm, s.xn, num_seqs, H, eps, stream);
 
     // 2. Q/K/V projections
     kernels::launch_gemm(s.xn, w.wq, s.q, num_seqs, Q,  H, 1.f, 0.f, gc, stream);
     kernels::launch_gemm(s.xn, w.wk, s.k, num_seqs, KV, H, 1.f, 0.f, gc, stream);
     kernels::launch_gemm(s.xn, w.wv, s.v, num_seqs, KV, H, 1.f, 0.f, gc, stream);
 
-    // 3. append new K/V into the paged cache for this layer
+    // 3. per-head QK-norm + RoPE + paged KV append (matches Qwen35Model::forward_token)
     bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)layer * s.kv->layer_stride_elems();
     bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)layer * s.kv->layer_stride_elems();
     int* btable = s.kv->block_table(0);   // batch occupies slots 0..num_seqs-1
-    launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
-                     num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
-                     s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    if (w.q_norm && w.k_norm) {
+        kernels::launch_qknorm_rope_kv_append(
+            s.q, s.k, s.v, w.q_norm, w.k_norm, kpool, vpool, btable, s.d_write_pos,
+            num_seqs, s.attn.num_q_heads, s.attn.num_kv_heads, s.attn.head_dim,
+            s.attn.rope_theta, eps, s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    } else if (s.attn.rope_theta > 0.f) {
+        kernels::launch_rope_kv_append(
+            s.q, s.k, s.v, kpool, vpool, btable, s.d_write_pos,
+            num_seqs, s.attn.num_q_heads, s.attn.num_kv_heads, s.attn.head_dim,
+            s.attn.rope_theta, s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    } else {
+        launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
+                         num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
+                         s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    }
 
     // 4. GQA flash decode over the paged cache
     kernels::launch_flash_decode_gqa8(s.q, kpool, vpool, btable, s.d_seq_lens, s.attnout,
@@ -110,7 +123,7 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     // 5. output projection + residual + post-attention norm
     kernels::launch_gemm(s.attnout, w.wo, s.ao, num_seqs, H, Q, 1.f, 0.f, gc, stream);
     launch_residual_add(x, s.ao, s.h, num_seqs * H, stream);          // h = x + attn
-    kernels::launch_rmsnorm(s.h, w.ffn_norm, s.hn, num_seqs, H, 1e-6f, stream);
+    kernels::launch_rmsnorm(s.h, w.ffn_norm, s.hn, num_seqs, H, eps, stream);
 
     // 6. sync-free MoE FFN + residual
     s.moe->set_layer_weights(layer, w.moe);

--- a/runtime/tests/decode_runner_gpu_test.cpp
+++ b/runtime/tests/decode_runner_gpu_test.cpp
@@ -44,7 +44,7 @@ int main() {
 
     const int H = 2048, nkv = 2, nq = 16, hd = 128;        // gqa8 / Qwen3.5 attention
     const int E = 8, K = 2, F = 64, layers = 2, seqs = 2;
-    AttnConfig ac{nq, nkv, hd, 1.f / std::sqrt((float)hd)};
+    AttnConfig ac{nq, nkv, hd, 1.f / std::sqrt((float)hd), 1e6f, 1e-6f};
 
     KVCacheConfig kvc; kvc.num_layers = layers; kvc.num_kv_heads = nkv; kvc.head_dim = hd; kvc.block_size = 16;
     KVCacheManager kv(kvc, 64ull * 1024 * 1024);
@@ -61,6 +61,8 @@ int main() {
         w[l].wk = dev_rand_bf16((size_t)H * KVd, 0.05f);
         w[l].wv = dev_rand_bf16((size_t)H * KVd, 0.05f);
         w[l].wo = dev_rand_bf16((size_t)Q * H, 0.05f);
+        w[l].q_norm = dev_rand_bf16(hd, 0.5f);
+        w[l].k_norm = dev_rand_bf16(hd, 0.5f);
         w[l].ffn_norm = dev_rand_bf16(H, 0.5f);
         w[l].moe.router_w = dev_rand_bf16((size_t)H * E, 0.1f);
         w[l].moe.gate_w = dev_rand_bf16((size_t)E * H * F, 0.05f);


### PR DESCRIPTION
## Problem

DecodeRunner::decode_layer() ran Q/K/V GEMMs then called launch_kv_append + launch_flash_decode_gqa8 directly. It never applied per-head QK-norm or RoPE.

Qwen3/Qwen3.5 models require both before KV write and attention (Qwen35Model::forward_token uses launch_qknorm_rope_kv_append). Without them, flash-decode reads **un-rotated, unnormed** keys - systematic logit error for any batched decode path built on DecodeRunner.

decode_runner_gpu_test only checked finite output, so this stayed hidden.

## Fix

- Extend AttnConfig with ope_theta and ms_eps (Qwen defaults: 1e6, 1e-6).
- Extend TransformerLayerWeights with optional q_norm / k_norm ([head_dim]).
- After Q/K/V projection:
  - q_norm && k_norm ? launch_qknorm_rope_kv_append (Qwen path)
  - else ope_theta > 0 ? launch_rope_kv_append
  - else ? legacy launch_kv_append (non-RoPE models)
- GPU test supplies Q/K norm weights and Qwen ope_theta.

## Impact

Correct attention math for continuous-batching / multi-seq decode via DecodeRunner. Complements #144 (block-table pack) - that PR fixes *which* table row is read; this fixes *what* is stored in KV.

## Test plan

- [ ] decode_runner_gpu_test on RTX 5090 (finite output, exercises fused QK-norm+RoPE+KV path)
- [ ] Future: compare against qwen35_cpu_test reference for a single-layer step

## Risks

Backward compatible: callers that omit q_norm/k_norm and set ope_theta=0 keep the old raw-KV path.