### PR TITLE
fix(runtime): drop CUDA graph when KV session ends

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -97,6 +97,14 @@ struct Qwen35Model::Impl {
                            // next layer's standalone QKV-input quantize node. =0 disables
 
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
+
+    void invalidate_decode_graph() {
+        if (graph_ready) {
+            cudaGraphExecDestroy(cu_exec);
+            cudaGraphDestroy(cu_graph);
+            graph_ready = false;
+        }
+    }
 };
 
 Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEngine* engine)
@@ -219,10 +227,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
         if (want > Impl::MAX_NSPLITS) want = Impl::MAX_NSPLITS;
         if (want != s.n_splits) {                       // changed -> invalidate the captured graph
             s.n_splits = want;
-            if (s.graph_ready) {
-                cudaGraphExecDestroy(s.cu_exec); cudaGraphDestroy(s.cu_graph); s.graph_ready = false;
-            }
+            s.invalidate_decode_graph();
         }
+    }
+
+    if (!s.kv->block_table(s.seq_id)) {
+        s.invalidate_decode_graph();
+        fprintf(stderr, "[qwen35] forward_token: KV not allocated for seq %llu\n",
+                (unsigned long long)s.seq_id);
+        return -1;
     }
 
     // Capture the decode compute into a CUDA graph on the first token, then
@@ -416,6 +429,7 @@ double Qwen35Model::bench_decode(int warmup, int n, int context_tokens) {
         fprintf(stderr, "[bench] requested ctx=%d warmup=%d n=%d exceeds max_seq=%d\n",
                 start_pos, warmup, n, s.cfg.max_seq);
         s.kv->free(s.seq_id);
+        s.invalidate_decode_graph();
         return -1;
     }
     static int bench_device_loop = -1;
@@ -445,6 +459,7 @@ double Qwen35Model::bench_decode(int warmup, int n, int context_tokens) {
         auto t1 = std::chrono::high_resolution_clock::now();
         s.kv->free(s.seq_id);
         s.bench_feedback_graph = false;
+        s.invalidate_decode_graph();
         double secs = std::chrono::duration<double>(t1 - t0).count();
         return n / secs;
     }
@@ -455,6 +470,7 @@ double Qwen35Model::bench_decode(int warmup, int n, int context_tokens) {
     auto t1 = std::chrono::high_resolution_clock::now();
     s.kv->free(s.seq_id);
     s.bench_feedback_graph = false;
+    s.invalidate_decode_graph();
     double secs = std::chrono::duration<double>(t1 - t0).count();
     return n / secs;
 }
@@ -476,6 +492,7 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         if (gov) gov->pace();   // thermally-adaptive decode pacing (accuracy-preserving; no-op if disabled)
     }
     s.kv->free(s.seq_id);
+    s.invalidate_decode_graph();
     return out;
 }
 


### PR DESCRIPTION
## Problem

orward_token() captures a CUDA graph on the first token. Kernel arguments include kv->block_table(seq_id) - a device pointer into a specific paged-KV table row.

generate() and ench_decode() call kv->free(seq_id) at session end but left graph_ready == true. The graph still pointed at the **freed slot's row**. Any later orward_token() (e.g. qwen3_gguf_score after a warmup generate(), or generate() ? teacher-forced scoring on the same model) replayed kernels against a stale or recycled block table:

- **Silent wrong KV** when the slot is reused for a different mapping
- **GPU OOB** when the row holds garbage or -1 sentinels (especially pre-#146)

PR #147 invalidates the graph at generate() **entry** and on weight reload, but not after kv->free() at session **exit** - so generate() ? orward_token() on the same model remained broken even with #147 merged.

## Fix

- Add Impl::invalidate_decode_graph().
- Call it after every kv->free() in generate() and ench_decode() (including error paths).
- In orward_token(), if KV is not allocated, invalidate any stale graph and return -1 instead of replaying.

## Impact

- Fixes multi-session reuse: generate() then orward_token() / qwen3_gguf_score on one Qwen35Model.
- Complements #146 (row contents) and #147 (weight reload / session start) - this closes the **post-free stale pointer** gap.
- No change for single generate()-then-exit workloads (graph was already discarded at process end).

## Test plan

- [ ] generate(prompt, N) then kv.allocate(0, max_seq) then orward_token(...) - logits sane, no CUDA fault
- [ ] 	hermal_sweep-style repeated generate() on one model - tokens stable across modes
- [ ] Existing qwen35_gpu_test unchanged

## Risks

One extra graph re-capture on the first token of each new KV session after a prior generate() - intended and required for correctness.