### PR TITLE
fix(embedding): clamp out-of-range token ids in GPU gather kernel

### DIFF
--- a/kernels/csrc/cuda/fused/model_ops.cu
+++ b/kernels/csrc/cuda/fused/model_ops.cu
@@ -11,12 +11,15 @@ namespace sparkinfer {
 namespace kernels {
 
 // out[t, :] = table[ids[t], :]   grid = n_tokens, threads over hidden.
+// ids outside [0, vocab) clamp to 0 — CUDA-graph replay and decode_feedback
+// can reach this kernel without a host-side token check on every path.
 __global__ void embedding_kernel(const int* __restrict__ ids,
                                  const __nv_bfloat16* __restrict__ table,
                                  __nv_bfloat16* __restrict__ out,
-                                 int hidden) {
+                                 int hidden, int vocab) {
     const int t  = blockIdx.x;
-    const int id = ids[t];
+    const int raw = ids[t];
+    const int id = (raw >= 0 && raw < vocab) ? raw : 0;
     for (int h = threadIdx.x; h < hidden; h += blockDim.x)
         out[(size_t)t * hidden + h] = table[(size_t)id * hidden + h];
 }
@@ -104,10 +107,10 @@ __global__ void decode_feedback_kernel(int* __restrict__ scalars,
 #include "sparkinfer/kernels/fused.h"
 
 void launch_embedding(const int* ids, const void* table, void* out,
-                      int n_tokens, int hidden, cudaStream_t stream) {
+                      int n_tokens, int hidden, int vocab, cudaStream_t stream) {
     embedding_kernel<<<n_tokens, 256, 0, stream>>>(
         ids, reinterpret_cast<const __nv_bfloat16*>(table),
-        reinterpret_cast<__nv_bfloat16*>(out), hidden);
+        reinterpret_cast<__nv_bfloat16*>(out), hidden, vocab);
 }
 
 void launch_argmax(const float* logits, int* out_id, int n_rows, int vocab, cudaStream_t stream) {

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -32,7 +32,7 @@ void launch_rmsnorm_qk(void* q, void* k, const void* q_w, const void* k_w,
 // Token embedding gather: out[t,:] = table[ids[t],:]  (bf16).
 //   ids: [n_tokens] (int32), table: [vocab, hidden], out: [n_tokens, hidden]
 void launch_embedding(const int* ids, const void* table, void* out,
-                      int n_tokens, int hidden, cudaStream_t stream = nullptr);
+                      int n_tokens, int hidden, int vocab, cudaStream_t stream = nullptr);
 
 // Greedy argmax over each row of logits.  logits: [n_rows, vocab] (fp32),
 // out_id: [n_rows] (int32).

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -236,7 +236,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
     }
     cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), "begin capture");
 
-    kernels::launch_embedding(s.d_tok, s.w.embed_tokens, s.x, 1, H, st);
+    kernels::launch_embedding(s.d_tok, s.w.embed_tokens, s.x, 1, H, c.vocab, st);
 
     int* btable = s.kv->block_table(s.seq_id);
     // Prime: xn = RMSNorm(x, layer0.input_norm). Each layer's tail then fuses the


### PR DESCRIPTION
## Problem

The token embedding gather has no vocab bounds check:

```
id = ids[t];
out[...] = table[id * hidden + h];   // id unchecked
```

On main, `forward_token` / `generate` accept arbitrary `token_id` values. Once a CUDA graph is captured, `d_tok` is updated each step (host upload or `decode_feedback` on the bench path) and `embedding_kernel` replays without any host re-validation in the graph body.

An out-of-range id (bad prompt token, tokenizer bug, or corrupted `d_tok`) casts `id * hidden` to `size_t` and indexes megabytes past `embed_tokens` -> **GPU illegal access**.

PR **#143** adds host-side rejection but does not protect the device path inside a captured graph.

## Fix

- Thread `vocab` through `launch_embedding` / `embedding_kernel`
- Clamp `ids[t]` to `[0, vocab)` before the table gather (use token 0 as safe fallback)

## Impact

- Last-line GPU defense for embed-table OOB on the decode hot path
- Valid tokens unchanged; only affects already-undefined ids
- Complements #143 host validation without duplicating it

## Test plan

- [ ] `qwen35_gpu_test` / `qwen3_gguf_generate` on RTX 5090
- [ ] `forward_token(vocab, 0)` must not fault (clamps to 0)
- [ ] Normal prompt tokens produce identical output to main

## Risks

Minimal. Clamping to token 0 on invalid ids may mask upstream bugs, but is strictly safer than OOB.