### PR TITLE
fix(moe): bounds-check expert ids before tokens_per_expert atomicAdd

### DIFF
--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -84,7 +84,10 @@ __global__ void moe_router_kernel(
     }
 
     if (tokens_per_expert && lane == 0) {
-        for (int j = 0; j < top_k; j++) atomicAdd(&tokens_per_expert[sel_id[j]], 1);
+        for (int j = 0; j < top_k; j++) {
+            const int id = sel_id[j];
+            if (id >= 0 && id < num_experts) atomicAdd(&tokens_per_expert[id], 1);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
`moe_router_kernel` bumps `tokens_per_expert[sel_id[j]]` via `atomicAdd` with no bounds check. `tokens_per_expert` is sized `[num_experts]` only. A corrupted `sel_id` of -1 or >= num_experts writes **OOB device memory**.

## Fix
Only atomicAdd when `0 <= id < num_experts`.

## Test plan
- [ ] Normal routed MoE decode unchanged
- [ ] Router2 path already bounds via `e < num_experts` thread guard