### PR TITLE
fix(moe): sanitize expert ids before Q4K expert FFN launch

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -24,6 +24,14 @@
 namespace sparkinfer {
 namespace kernels {
 
+// Clamp corrupted router output before any Q4K/Q6K weight indexing (GGUF decode path).
+__global__ void sanitize_expert_ids_kernel(int* __restrict__ ids, int n, int num_experts) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n || num_experts <= 0) return;
+    const int e = ids[i];
+    if (e < 0 || e >= num_experts) ids[i] = 0;
+}
+
 static constexpr int WPB = 8;   // warps per block
 
 // Programmatic Dependent Launch (PDL): overlap a kernel's grid spin-up with its
@@ -843,8 +851,13 @@ void launch_moe_expert_ffn_q4k(
     int gate_type, int up_type, int down_type,
     const int* expert_ids, const float* expert_weights, void* output,
     float* h_scratch, float* out_scratch,
-    int num_tokens, int top_k, int hidden, int ffn, const void* input_q8, cudaStream_t stream
+    int num_tokens, int top_k, int hidden, int ffn, int num_experts,
+    const void* input_q8, cudaStream_t stream
 ) {
+    if (num_tokens <= 0 || top_k <= 0 || num_experts <= 0) return;
+    const int n_ids = num_tokens * top_k;
+    sanitize_expert_ids_kernel<<<(n_ids + 255) / 256, 256, 0, stream>>>(
+        const_cast<int*>(expert_ids), n_ids, num_experts);
     // int8 dp4a path for Q4_K gate/up (decode parity with llama.cpp's MMVQ). Default
     // ON — the largest single decode cost; down stays on the fp path (Q6_K). Set
     // SPARKINFER_MMVQ=0 to fall back to the bf16 dequant-GEMV.

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -63,7 +63,7 @@ void launch_moe_expert_ffn_q4k(
     int gate_type, int up_type, int down_type,
     const int* expert_ids, const float* expert_weights, void* output,
     float* h_scratch, float* out_scratch,
-    int num_tokens, int top_k, int hidden, int ffn,
+    int num_tokens, int top_k, int hidden, int ffn, int num_experts,
     const void* input_q8 = nullptr,   // pre-quantized Q8_1(input) from the fused norm; nullptr = quantize internally
     cudaStream_t stream = nullptr);
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -364,7 +364,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,
-                                               1, c.top_k, c.hidden, c.moe_ffn,
+                                               1, c.top_k, c.hidden, c.moe_ffn, c.n_experts,
                                                fnq ? s.aq81 : nullptr, st);
         } else {
             s.engine->set_layer_weights(L, {w.router_w, w.gate, w.up, w.down});


### PR DESCRIPTION
## Problem
GGUF decode uses `launch_moe_expert_ffn_q4k` (production path). Every gate/up/down kernel indexes expert stacks as `weights + e * stride` with **no bounds check** on router output.

PR **#157** guards the bf16 `expert_ffn` path only. Corrupted `mf_ids` or scratch reuse can pass `e < 0` or `e >= num_experts` -> **GPU OOB** across dozens of specialized Q4K/Q6K kernels.

## Fix
- Add `num_experts` to `launch_moe_expert_ffn_q4k`
- Run a tiny `sanitize_expert_ids_kernel` before gate/up/down (clamp invalid ids to 0)

One launch-site fix protects all Q4K kernel variants without touching each template.

## Test plan
- [ ] `qwen3_gguf_generate` / bench on RTX 5090 unchanged
- [ ] Normal routing identical (valid ids untouched)

## Risks
Invalid ids map to expert 0 instead of crashing - wrong logits possible but strictly safer than OOB.