### PR TITLE
fix(qwen35): reject forward_token when weights or KV are missing

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -196,6 +196,15 @@ void Qwen35Model::copy_logits(float* host_logits) const {
 int Qwen35Model::forward_token(int token_id, int position) {
     Impl& s = *p_;
     const Qwen35Config& c = s.cfg;
+    if (!s.w.embed_tokens || s.w.layers.empty() || !s.w.layers[0].input_norm) {
+        fprintf(stderr, "[qwen35] forward_token: weights not loaded\n");
+        return -1;
+    }
+    if (!s.kv->block_table(s.seq_id)) {
+        fprintf(stderr, "[qwen35] forward_token: KV not allocated for seq %llu\n",
+                (unsigned long long)s.seq_id);
+        return -1;
+    }
     const int H = c.hidden;
     kernels::GemmConfig gc{};
     int seqlen = position + 1;


### PR DESCRIPTION
## Problem
`forward_token()` dereferences `embed_tokens`, layer weights, and `kv->block_table()` with no preflight checks.

Calling `forward_token` before `load_gguf` / `set_weights`, or before `kv->allocate`, passes **null pointers** into embedding / attention / KV kernels -> **GPU illegal access**.

`qwen3_gguf_score` allocates KV explicitly; other callers may not.

## Fix
Return -1 early when:
- `embed_tokens` is null or `layers` empty
- `block_table(seq_id)` is null (KV not allocated)

## Test plan
- [ ] Normal generate/score unchanged
- [ ] `forward_token` before load -> -1, no CUDA fault
- [ ] `forward_token` without `kv->allocate` -> -1

## Note
Complements **#150** (graph invalidation after `kv->free`); this PR adds the missing API guard without graph changes.