### PR TITLE
fix(qwen35): reset gguf flag when loading bin weights

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -497,6 +497,7 @@ void* load_bin(const std::string& path, std::vector<void*>& owned) {
 
 bool Qwen35Model::load_weights(const std::string& dir) {
     Impl& s = *p_;
+    s.gguf = false;   // bin layout uses GEMM, not GGUF GEMV
     auto L = [&](const std::string& n) { return load_bin(dir + "/" + n + ".bin", s.owned); };
     s.w.embed_tokens = L("embed_tokens");
     s.w.final_norm   = L("final_norm");


### PR DESCRIPTION
## Summary
- Set `s.gguf = false` in `load_weights` so bin-layout weights use GEMM instead of GGUF GEMV paths.

## Test plan
- [ ] Load bin weights after GGUF and verify decode uses GEMM path
- [ ] CI build