### PR TITLE
fix(kv): expose allocated_tokens and bound decode write positions

### DIFF
--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -50,6 +50,9 @@ public:
     int num_free_blocks() const;
     int num_total_blocks() const;
 
+    // Tokens covered by currently allocated physical blocks (0 if seq not allocated).
+    int allocated_tokens(uint64_t seq_id) const;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -68,7 +68,23 @@ void DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
         return;
     }
     std::vector<int> after(n);
-    for (int i = 0; i < n; i++) after[i] = seq_lens_before[i] + 1;   // include the new token
+    for (int i = 0; i < n; i++) {
+        if (seq_lens_before[i] < 0) {
+            fprintf(stderr, "[decode] begin_step: seq %d negative length %d\n", i, seq_lens_before[i]);
+            return;
+        }
+        const int cap = p_->kv->allocated_tokens((uint64_t)i);
+        if (cap <= 0) {
+            fprintf(stderr, "[decode] begin_step: seq %d has no KV blocks allocated\n", i);
+            return;
+        }
+        if (seq_lens_before[i] >= cap) {
+            fprintf(stderr, "[decode] begin_step: seq %d position %d >= allocated %d tokens\n",
+                    i, seq_lens_before[i], cap);
+            return;
+        }
+        after[i] = seq_lens_before[i] + 1;   // include the new token
+    }
     cu(cudaMemcpy(p_->d_write_pos, seq_lens_before.data(), n * sizeof(int), cudaMemcpyHostToDevice), "wpos");
     cu(cudaMemcpy(p_->d_seq_lens,  after.data(),           n * sizeof(int), cudaMemcpyHostToDevice), "slens");
 }

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -103,4 +103,10 @@ int    KVCacheManager::max_blocks_per_seq() const { return kMaxBlocksPerSeq; }
 int    KVCacheManager::num_free_blocks() const { return (int)impl_->free_list.size(); }
 int    KVCacheManager::num_total_blocks() const { return impl_->total_blocks; }
 
+int KVCacheManager::allocated_tokens(uint64_t seq_id) const {
+    auto it = impl_->seq_blocks.find(seq_id);
+    if (it == impl_->seq_blocks.end()) return 0;
+    return (int)it->second.size() * impl_->cfg.block_size;
+}
+
 } // namespace sparkinfer


### PR DESCRIPTION
## Summary
- Add `KVCacheManager::allocated_tokens`.
- `DecodeRunner::begin_step` rejects positions beyond allocated KV capacity.

## Test plan
- [ ] Decode past allocated KV is refused
- [ ] CI build