### PR TITLE
fix(moe): guard k-pass router fallback when top_k exceeds 16

### DIFF
--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -12,6 +12,7 @@
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #include <cstdlib>
+#include <cstdio>
 #endif
 
 namespace sparkinfer {
@@ -159,6 +160,10 @@ void launch_moe_router(
         moe_router_kernel2<<<num_tokens, bd, smem, stream>>>(
             logits, expert_ids, expert_weights, tokens_per_expert,
             num_tokens, num_experts, top_k, normalize);
+        return;
+    }
+    if (top_k > 16) {
+        fprintf(stderr, "[moe_router] k-pass fallback requires top_k <= 16 (got %d)\n", top_k);
         return;
     }
     moe_router_kernel<<<num_tokens, 32, smem, stream>>>(


### PR DESCRIPTION
## Summary
- k-pass fallback kernel uses fixed top-16 stack arrays; refuse top_k > 16.

## Test plan
- [ ] CI build