### PR TITLE
fix(decode): return bool from begin_step/decode_layer and guard GQA ratio

### DIFF
--- a/runtime/include/sparkinfer/decode.h
+++ b/runtime/include/sparkinfer/decode.h
@@ -37,10 +37,12 @@ public:
 
     // Begin a decode step: set the new-token position for each sequence
     // (host seq_lens = length BEFORE this token). Uploads positions to device.
-    void begin_step(const std::vector<int>& seq_lens_before);
+    // Returns false on invalid batch size.
+    bool begin_step(const std::vector<int>& seq_lens_before);
 
     // Run one layer in-place on x: [num_seqs, hidden] (bf16, device).
-    void decode_layer(int layer, void* x, int num_seqs,
+    // Returns false when inputs are invalid or the layer is skipped.
+    bool decode_layer(int layer, void* x, int num_seqs,
                       const TransformerLayerWeights& w, cudaStream_t stream);
 
 private:

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -102,7 +102,12 @@ bool DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
                      num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
                      s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
 
-    // 4. GQA flash decode over the paged cache
+    // 4. GQA flash decode over the paged cache (kernel assumes 8:1 Q:KV ratio)
+    if (s.attn.num_q_heads != s.attn.num_kv_heads * 8) {
+        fprintf(stderr, "[decode] decode_layer: GQA ratio %d:%d unsupported (need 8:1)\n",
+                s.attn.num_q_heads, s.attn.num_kv_heads);
+        return false;
+    }
     kernels::launch_flash_decode_gqa8(s.q, kpool, vpool, btable, s.d_seq_lens, s.attnout,
                                       num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
                                       s.kv->block_size(), s.kv->max_blocks_per_seq(),

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -60,27 +60,28 @@ DecodeRunner::~DecodeRunner() {
     delete p_;
 }
 
-void DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
+bool DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
     const int n = (int)seq_lens_before.size();
     if (n <= 0 || n > p_->max_batch) {
         fprintf(stderr, "[decode] begin_step: num_seqs %d out of range (max_batch=%d)\n",
                 n, p_->max_batch);
-        return;
+        return false;
     }
     std::vector<int> after(n);
     for (int i = 0; i < n; i++) after[i] = seq_lens_before[i] + 1;   // include the new token
     cu(cudaMemcpy(p_->d_write_pos, seq_lens_before.data(), n * sizeof(int), cudaMemcpyHostToDevice), "wpos");
     cu(cudaMemcpy(p_->d_seq_lens,  after.data(),           n * sizeof(int), cudaMemcpyHostToDevice), "slens");
+    return true;
 }
 
-void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
+bool DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
                                 const TransformerLayerWeights& w, cudaStream_t stream) {
     Impl& s = *p_;
-    if (num_seqs <= 0) return;
+    if (num_seqs <= 0) return false;
     if (num_seqs > s.max_batch) {
         fprintf(stderr, "[decode] decode_layer: num_seqs %d exceeds max_batch %d — skipping\n",
                 num_seqs, s.max_batch);
-        return;
+        return false;
     }
     const int H = s.hidden, Q = s.qdim, KV = s.kvdim;
     kernels::GemmConfig gc{};
@@ -116,6 +117,7 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     s.moe->set_layer_weights(layer, w.moe);
     s.moe->forward(s.hn, s.moeout, num_seqs, layer, stream);
     launch_residual_add(s.h, s.moeout, x, num_seqs * H, stream);      // x = h + moe
+    return true;
 }
 
 } // namespace sparkinfer

--- a/runtime/tests/decode_runner_gpu_test.cpp
+++ b/runtime/tests/decode_runner_gpu_test.cpp
@@ -73,8 +73,10 @@ int main() {
 
     cudaStream_t stream; cudaStreamCreate(&stream);
     std::vector<int> lens(seqs, 7);                 // 7 tokens already cached
-    runner.begin_step(lens);
-    for (int l = 0; l < layers; l++) runner.decode_layer(l, x, seqs, w[l], stream);
+    if (!runner.begin_step(lens)) { printf("[FAIL] begin_step\n"); return 1; }
+    for (int l = 0; l < layers; l++) {
+        if (!runner.decode_layer(l, x, seqs, w[l], stream)) { printf("[FAIL] decode_layer %d\n", l); return 1; }
+    }
     cudaStreamSynchronize(stream);
 
     cudaError_t err = cudaGetLastError();


### PR DESCRIPTION
## Summary
- Propagate failure from `DecodeRunner` instead of silent no-op.
- Reject non 8:1 GQA configs before `flash_decode_gqa8`.

## Test plan
- [ ] decode_runner_gpu_test
- [ ] CI build