### PR TITLE
ci: cap open PRs per contributor at 5 (auto-close excess)

### DIFF
--- a/.github/workflows/cap-open-prs.yml
+++ b/.github/workflows/cap-open-prs.yml
@@ -1,0 +1,94 @@
+name: cap-open-prs
+
+# Anti-spam: cap the number of OPEN pull requests a single contributor may have.
+# When a contributor is over the cap, their excess PRs (newest first) are auto-closed
+# with an explanatory comment. Maintainers and bots are exempt.
+#
+#  - pull_request_target(opened/reopened): enforces the cap for that author on every new PR.
+#    (pull_request_target runs in the base-repo context so the token can close FORK PRs.)
+#  - workflow_dispatch: one-off sweep over ALL authors — use it to clear an existing backlog.
+#
+# Safe by design: it never checks out or runs PR code — it only calls the GitHub API.
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+  workflow_dispatch:
+    inputs:
+      max:
+        description: "Max open PRs allowed per contributor"
+        default: "5"
+        required: false
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: cap-open-prs
+  cancel-in-progress: false
+
+jobs:
+  cap:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce per-author open-PR cap
+        uses: actions/github-script@v7
+        env:
+          MAX_OPEN: ${{ github.event.inputs.max || '5' }}
+        with:
+          script: |
+            const MAX = parseInt(process.env.MAX_OPEN, 10) || 5;
+            const { owner, repo } = context.repo;
+            const isSweep = context.eventName === 'workflow_dispatch';
+
+            // Never touch these accounts.
+            const EXEMPT_LOGIN = new Set(['ai-hpc']);
+            const EXEMPT_ASSOC = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+
+            // All open PRs (author_association is included on each item).
+            const all = await github.paginate(github.rest.pulls.list, {
+              owner, repo, state: 'open', per_page: 100,
+            });
+
+            // Which authors to enforce this run.
+            const authors = isSweep
+              ? [...new Set(all.map(p => p.user.login))]
+              : [context.payload.pull_request.user.login];
+
+            let closed = 0;
+            for (const author of authors) {
+              const mine = all.filter(p => p.user.login === author);
+              const sample = mine[0];
+              if (!sample) continue;
+              if (EXEMPT_LOGIN.has(author)) continue;
+              if (sample.user.type === 'Bot') continue;
+              // If any of their PRs shows maintainer association, treat them as a maintainer.
+              if (mine.some(p => EXEMPT_ASSOC.has(p.author_association))) continue;
+              if (mine.length <= MAX) continue;
+
+              // Keep the MAX oldest; close the newest excess.
+              mine.sort((a, b) => a.number - b.number);
+              const excess = mine.slice(MAX);
+              for (const p of excess) {
+                try {
+                  await github.rest.issues.createComment({
+                    owner, repo, issue_number: p.number,
+                    body:
+                      `Auto-closed to keep the review queue manageable.\n\n` +
+                      `**@${author}** has more than the limit of **${MAX} open pull requests** in this ` +
+                      `repository (${mine.length} open). Please get some of your open PRs reviewed, merged, ` +
+                      `or closed, then **reopen this one** — a smaller set gets reviewed much faster.\n\n` +
+                      `<sub>Automated by the per-author open-PR cap. Maintainers are exempt.</sub>`,
+                  });
+                  await github.rest.pulls.update({
+                    owner, repo, pull_number: p.number, state: 'closed',
+                  });
+                  closed++;
+                  core.info(`closed #${p.number} (@${author}, ${mine.length} open, cap ${MAX})`);
+                } catch (e) {
+                  core.warning(`#${p.number}: ${e.message}`);
+                }
+              }
+            }
+            core.notice(`cap-open-prs: closed ${closed} PR(s) over the cap of ${MAX}.`);

--- a/bench/competitors/README.md
+++ b/bench/competitors/README.md
@@ -1,0 +1,28 @@
+# RTX 5090 Competitor Benchmarks
+
+This folder is for competitor engine runs that are not apples-to-apples with
+sparkinfer's native GGUF path unless explicitly marked as the same GGUF file.
+
+sparkinfer's public baseline uses Qwen3-30B-A3B `Q4_K_M` GGUF. vLLM and
+TensorRT-LLM normally benchmark Hugging Face quantized checkpoints such as FP8,
+NVFP4, or GPTQ. Record the exact weight format with every result.
+
+## Run
+
+```bash
+bench/competitors/run_vllm_trtllm_rtx5090.sh
+```
+
+Useful overrides:
+
+```bash
+OUT_DIR=/root/competitor-results \
+VLLM_MODEL=nvidia/Qwen3-30B-A3B-NVFP4 \
+TRTLLM_MODEL=nvidia/Qwen3-30B-A3B-NVFP4 \
+CONTEXTS="128 512 4096 16384" \
+bench/competitors/run_vllm_trtllm_rtx5090.sh
+```
+
+The harness tries vLLM first, then TensorRT-LLM. If TensorRT-LLM does not
+support the selected checkpoint or the wheel stack on the host, the failure log
+is kept in `OUT_DIR/trtllm/`.

--- a/bench/competitors/latest-results.md
+++ b/bench/competitors/latest-results.md
@@ -1,0 +1,39 @@
+# Latest Competitor Results
+
+Last run: 2026-07-03 on Vast RTX 5090 instance `43698008` (destroyed after run).
+
+## vLLM NVFP4
+
+Engine: vLLM `0.23.1rc1.dev757+ga14f57a3a`
+
+Model: `nvidia/Qwen3-30B-A3B-NVFP4`
+
+Hardware: RTX 5090, driver `580.159.03`, CUDA `13.0`
+
+Benchmark shape: `vllm bench latency`, batch size 1, 128 generated tokens, 2 warmup iterations, 8 measured iterations, `kv_cache_dtype=fp8_e4m3`.
+
+Important caveat: this is not the same weight format as sparkinfer's GGUF `Q4_K_M` path. It is an HF NVFP4 checkpoint running through vLLM FlashInfer/CUTLASS kernels.
+
+| Context | Avg latency (s) | Output tok/s |
+|---:|---:|---:|
+| 128 | 0.574194 | 222.92 |
+| 512 | 0.578056 | 221.43 |
+| 4,096 | 0.662612 | 193.17 |
+| 16,384 | 1.348394 | 94.93 |
+
+Run notes:
+
+- `HF_HUB_DISABLE_XET=1` was required because HF Xet token requests failed with TLS handshake EOF on this Vast host.
+- Cold checkpoint download took `3432.46s` for a 16.85 GiB checkpoint.
+- `datasets` was upgraded from `1.1.1` to `5.0.0` to fix incompatibility with `pyarrow==24`.
+- 16k context was run with `MAX_MODEL_LEN=32768` because vLLM requires `max_model_len >= input_len + output_len`.
+
+## TensorRT-LLM NVFP4
+
+Target: `nvidia/Qwen3-30B-A3B-NVFP4`, `trtllm-bench`, 128 context, 128 generated tokens.
+
+Result: no benchmark number.
+
+TensorRT-LLM was not preinstalled on the Vast CUDA 13 image. The setup reached apt dependencies for `libopenmpi-dev` and then PyTorch/CUDA wheel installation in a TensorRT-LLM virtualenv. After about 11 minutes it was still preparing/downloading PyTorch/CUDA wheels and had not reached `pip install tensorrt_llm` or `trtllm-bench`, so the attempt was stopped to avoid continuing paid GPU time on setup-only work.
+
+Better next path: run NVIDIA's TensorRT-LLM NGC container directly, or prebuild a Vast image with TensorRT-LLM installed, then run `trtllm-bench` against the same NVFP4 checkpoint and contexts.

--- a/bench/competitors/run_vllm_trtllm_rtx5090.sh
+++ b/bench/competitors/run_vllm_trtllm_rtx5090.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+# Benchmark vLLM and TensorRT-LLM on an RTX 5090 with quantized Qwen MoE weights.
+#
+# This intentionally lives outside sparkinfer's runtime benchmark scripts because
+# these engines usually use HF FP8/NVFP4/GPTQ weights rather than sparkinfer's
+# GGUF Q4_K_M file. Keep the model format in the output when reporting results.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_DIR="${OUT_DIR:-$ROOT/bench/competitors/results/$(date -u +%Y%m%dT%H%M%SZ)}"
+CONTEXTS="${CONTEXTS:-128 512 4096 16384}"
+OUTPUT_TOKENS="${OUTPUT_TOKENS:-128}"
+VLLM_MODEL="${VLLM_MODEL:-nvidia/Qwen3-30B-A3B-NVFP4}"
+TRTLLM_MODEL="${TRTLLM_MODEL:-nvidia/Qwen3-30B-A3B-NVFP4}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.88}"
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-16384}"
+SKIP_VLLM="${SKIP_VLLM:-0}"
+SKIP_TRTLLM="${SKIP_TRTLLM:-0}"
+
+mkdir -p "$OUT_DIR"/{vllm,trtllm,system}
+
+log() { printf '\n>> %s\n' "$*" | tee -a "$OUT_DIR/run.log"; }
+run_logged() {
+  local name="$1"; shift
+  log "$name"
+  ("$@") 2>&1 | tee "$OUT_DIR/$name.log"
+}
+
+python_bin() {
+  if command -v python3 >/dev/null 2>&1; then
+    command -v python3
+  else
+    command -v python
+  fi
+}
+
+PYTHON="$(python_bin)"
+
+log "writing system metadata to $OUT_DIR/system"
+{
+  date -u
+  uname -a
+  "$PYTHON" --version || true
+} > "$OUT_DIR/system/host.txt"
+nvidia-smi > "$OUT_DIR/system/nvidia-smi.txt" 2>&1 || true
+nvcc --version > "$OUT_DIR/system/nvcc.txt" 2>&1 || true
+
+install_uv() {
+  if ! command -v uv >/dev/null 2>&1; then
+    "$PYTHON" -m pip install --upgrade pip
+    "$PYTHON" -m pip install --retries 20 --timeout 120 uv
+  fi
+}
+
+uv_in_venv() {
+  local venv="$1"; shift
+  VIRTUAL_ENV="$venv" PATH="$venv/bin:$PATH" uv pip "$@"
+}
+
+install_vllm() {
+  install_uv
+  if [ ! -x "$OUT_DIR/vllm-env/bin/python" ]; then
+    uv venv "$OUT_DIR/vllm-env"
+  fi
+  # Nightly wheels are preferred for Blackwell/NVFP4 support. If that fails,
+  # fall back to the public release so the log records the compatibility state.
+  if ! uv_in_venv "$OUT_DIR/vllm-env" show vllm >/dev/null 2>&1; then
+    uv_in_venv "$OUT_DIR/vllm-env" install \
+      --extra-index-url https://wheels.vllm.ai/nightly \
+      "vllm[bench]" || \
+    uv_in_venv "$OUT_DIR/vllm-env" install \
+      "vllm[bench]"
+  fi
+  uv_in_venv "$OUT_DIR/vllm-env" freeze > "$OUT_DIR/vllm/pip-freeze.txt"
+}
+
+run_vllm() {
+  install_vllm
+  local vllm_bin="$OUT_DIR/vllm-env/bin/vllm"
+  [ -x "$vllm_bin" ] || { echo "vLLM executable not found after install: $vllm_bin" >&2; return 1; }
+  "$vllm_bin" bench latency --help > "$OUT_DIR/vllm/bench-latency-help.txt" 2>&1 || true
+
+  for ctx in $CONTEXTS; do
+    local json="$OUT_DIR/vllm/vllm_ctx${ctx}_out${OUTPUT_TOKENS}.json"
+    local log_file="$OUT_DIR/vllm/vllm_ctx${ctx}_out${OUTPUT_TOKENS}.log"
+    log "vLLM latency: model=$VLLM_MODEL ctx=$ctx out=$OUTPUT_TOKENS"
+    set +e
+    "$vllm_bin" bench latency \
+      --model "$VLLM_MODEL" \
+      --trust-remote-code \
+      --input-len "$ctx" \
+      --output-len "$OUTPUT_TOKENS" \
+      --batch-size 1 \
+      --num-iters-warmup 2 \
+      --num-iters 8 \
+      --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION" \
+      --max-model-len "$MAX_MODEL_LEN" \
+      --disable-detokenize \
+      --output-json "$json" \
+      > "$log_file" 2>&1
+    local rc=$?
+    set -e
+    echo "$rc" > "$OUT_DIR/vllm/vllm_ctx${ctx}_exitcode.txt"
+    tail -80 "$log_file" || true
+  done
+}
+
+install_trtllm() {
+  install_uv
+  if [ ! -x "$OUT_DIR/trtllm-env/bin/python" ]; then
+    uv venv "$OUT_DIR/trtllm-env"
+  fi
+  if ! uv_in_venv "$OUT_DIR/trtllm-env" show tensorrt_llm >/dev/null 2>&1; then
+    apt-get update
+    DEBIAN_FRONTEND=noninteractive apt-get install -y libopenmpi-dev git-lfs
+    uv_in_venv "$OUT_DIR/trtllm-env" install \
+      torch torchvision --index-url https://download.pytorch.org/whl/cu130
+    uv_in_venv "$OUT_DIR/trtllm-env" install \
+      tensorrt_llm
+  fi
+  uv_in_venv "$OUT_DIR/trtllm-env" freeze > "$OUT_DIR/trtllm/pip-freeze.txt"
+}
+
+run_trtllm() {
+  install_trtllm
+  local trt_bench="$OUT_DIR/trtllm-env/bin/trtllm-bench"
+  "$trt_bench" --help > "$OUT_DIR/trtllm/trtllm-bench-help.txt" 2>&1 || true
+
+  for ctx in $CONTEXTS; do
+    local run_dir="$OUT_DIR/trtllm/ctx${ctx}_out${OUTPUT_TOKENS}"
+    mkdir -p "$run_dir"
+    log "TensorRT-LLM bench: model=$TRTLLM_MODEL ctx=$ctx out=$OUTPUT_TOKENS"
+    set +e
+    "$trt_bench" \
+      --model "$TRTLLM_MODEL" \
+      throughput \
+      --backend pytorch \
+      --dataset "token-norm-dist://input_mean=${ctx},input_stdev=0,output_mean=${OUTPUT_TOKENS},output_stdev=0,num_requests=16" \
+      --output_dir "$run_dir" \
+      > "$run_dir/trtllm.log" 2>&1
+    local rc=$?
+    set -e
+    echo "$rc" > "$run_dir/exitcode.txt"
+    tail -100 "$run_dir/trtllm.log" || true
+  done
+}
+
+if [ "$SKIP_VLLM" != 1 ]; then
+  run_vllm || true
+fi
+
+if [ "$SKIP_TRTLLM" != 1 ]; then
+  run_trtllm || true
+fi
+
+log "done: $OUT_DIR"


### PR DESCRIPTION
Adds `.github/workflows/cap-open-prs.yml` — an anti-spam control that caps each contributor at **5 open PRs** and auto-closes the excess (newest first) with a polite comment to consolidate and reopen.

**How it works**
- `pull_request_target` on opened/reopened → enforces the cap for that author on every new PR (base-repo token, so it works on fork PRs).
- `workflow_dispatch` → one-off sweep over all authors to clear a backlog.
- **Exempt:** maintainers (`ai-hpc`), org members/collaborators, and bots.
- **Safe:** never checks out or runs PR code — it only calls the GitHub API. Permissions scoped to `pull-requests: write` + `issues: write`.

Keeps the 5 oldest open PRs per author, closes the rest. Configurable cap via the workflow-dispatch `max` input.