### PR TITLE
fix(decode): match Qwen35 attention math in DecodeRunner

### DIFF
--- a/runtime/include/sparkinfer/decode.h
+++ b/runtime/include/sparkinfer/decode.h
@@ -11,7 +11,9 @@ struct AttnConfig {
     int num_q_heads;
     int num_kv_heads;
     int head_dim;
-    float scale;     // 1/sqrt(head_dim)
+    float scale;        // 1/sqrt(head_dim)
+    float rope_theta = 1e6f;
+    float rms_eps    = 1e-6f;
 };
 
 // Device weight pointers (bf16) for one MoE transformer layer.
@@ -21,12 +23,14 @@ struct TransformerLayerWeights {
     const void* wk = nullptr;          // [hidden, num_kv_heads*head_dim]
     const void* wv = nullptr;          // [hidden, num_kv_heads*head_dim]
     const void* wo = nullptr;          // [num_q_heads*head_dim, hidden]
+    const void* q_norm = nullptr;      // [head_dim] per-head Q RMSNorm (Qwen3; null = skip)
+    const void* k_norm = nullptr;      // [head_dim] per-head K RMSNorm (Qwen3; null = skip)
     const void* ffn_norm = nullptr;    // [hidden]
     moe::LayerWeights moe;             // router_w, gate_w, up_w, down_w
 };
 
 // Drives a batch of single-token decode steps through the full stack:
-//   RMSNorm -> Q/K/V proj -> KV append -> GQA flash decode -> O proj
+//   RMSNorm -> Q/K/V proj -> QK-norm + RoPE + KV append -> GQA flash decode -> O proj
 //   -> residual+RMSNorm -> sync-free MoE -> residual.
 // Attention uses the gqa8 kernel (Qwen3.5-35B-A3B: 16 Q / 2 KV heads, hd=128).
 class DecodeRunner {
@@ -35,8 +39,12 @@ public:
                  int max_batch = 256);
     ~DecodeRunner();
 
-    // Begin a decode step: set the new-token position for each sequence
-    // (host seq_lens = length BEFORE this token). Uploads positions to device.
+    // Begin a decode step: set write positions and gather each sequence's block table
+    // into batch-indexed rows (seq_lens = length BEFORE this token).
+    void begin_step(const std::vector<uint64_t>& seq_ids,
+                    const std::vector<int>& seq_lens_before);
+
+    // Convenience when batch row b maps to KV sequence id b.
     void begin_step(const std::vector<int>& seq_lens_before);
 
     // Run one layer in-place on x: [num_seqs, hidden] (bf16, device).

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -28,7 +28,7 @@ struct DecodeRunner::Impl {
 
     // scratch (bf16 unless noted)
     bf16 *xn, *q, *k, *v, *attnout, *ao, *h, *hn, *moeout;
-    int *d_seq_lens, *d_write_pos;
+    int *d_seq_lens, *d_write_pos, *d_batch_btable;
 
     template <class T> T* alloc(size_t n) { void* p = nullptr; cu(cudaMalloc(&p, n * sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -51,26 +51,51 @@ DecodeRunner::DecodeRunner(int hidden, AttnConfig attn, KVCacheManager* kv,
     p_->moeout  = p_->alloc<bf16>((size_t)M * hidden);
     p_->d_seq_lens  = p_->alloc<int>(M);
     p_->d_write_pos = p_->alloc<int>(M);
+    p_->d_batch_btable = p_->alloc<int>((size_t)M * kv->max_blocks_per_seq());
 }
 
 DecodeRunner::~DecodeRunner() {
     cudaFree(p_->xn); cudaFree(p_->q); cudaFree(p_->k); cudaFree(p_->v);
     cudaFree(p_->attnout); cudaFree(p_->ao); cudaFree(p_->h); cudaFree(p_->hn); cudaFree(p_->moeout);
-    cudaFree(p_->d_seq_lens); cudaFree(p_->d_write_pos);
+    cudaFree(p_->d_seq_lens); cudaFree(p_->d_write_pos); cudaFree(p_->d_batch_btable);
     delete p_;
 }
 
-void DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
+void DecodeRunner::begin_step(const std::vector<uint64_t>& seq_ids,
+                              const std::vector<int>& seq_lens_before) {
     const int n = (int)seq_lens_before.size();
     if (n <= 0 || n > p_->max_batch) {
         fprintf(stderr, "[decode] begin_step: num_seqs %d out of range (max_batch=%d)\n",
                 n, p_->max_batch);
         return;
     }
+    if ((int)seq_ids.size() != n) {
+        fprintf(stderr, "[decode] begin_step: seq_ids size %zu != seq_lens size %d\n",
+                seq_ids.size(), n);
+        return;
+    }
+    const int row_ints = p_->kv->max_blocks_per_seq();
+    const size_t row_bytes = (size_t)row_ints * sizeof(int);
+    for (int b = 0; b < n; b++) {
+        int* src = p_->kv->block_table(seq_ids[b]);
+        if (!src) {
+            fprintf(stderr, "[decode] begin_step: seq_id %llu (batch %d) has no KV blocks\n",
+                    (unsigned long long)seq_ids[b], b);
+            return;
+        }
+        cu(cudaMemcpy(p_->d_batch_btable + (size_t)b * row_ints, src, row_bytes,
+                      cudaMemcpyDeviceToDevice), "pack block table");
+    }
     std::vector<int> after(n);
     for (int i = 0; i < n; i++) after[i] = seq_lens_before[i] + 1;   // include the new token
     cu(cudaMemcpy(p_->d_write_pos, seq_lens_before.data(), n * sizeof(int), cudaMemcpyHostToDevice), "wpos");
     cu(cudaMemcpy(p_->d_seq_lens,  after.data(),           n * sizeof(int), cudaMemcpyHostToDevice), "slens");
+}
+
+void DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
+    std::vector<uint64_t> seq_ids(seq_lens_before.size());
+    for (size_t i = 0; i < seq_ids.size(); i++) seq_ids[i] = i;
+    begin_step(seq_ids, seq_lens_before);
 }
 
 void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
@@ -83,23 +108,36 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
         return;
     }
     const int H = s.hidden, Q = s.qdim, KV = s.kvdim;
+    const float eps = s.attn.rms_eps;
     kernels::GemmConfig gc{};
 
     // 1. pre-attention norm
-    kernels::launch_rmsnorm(x, w.attn_norm, s.xn, num_seqs, H, 1e-6f, stream);
+    kernels::launch_rmsnorm(x, w.attn_norm, s.xn, num_seqs, H, eps, stream);
 
     // 2. Q/K/V projections
     kernels::launch_gemm(s.xn, w.wq, s.q, num_seqs, Q,  H, 1.f, 0.f, gc, stream);
     kernels::launch_gemm(s.xn, w.wk, s.k, num_seqs, KV, H, 1.f, 0.f, gc, stream);
     kernels::launch_gemm(s.xn, w.wv, s.v, num_seqs, KV, H, 1.f, 0.f, gc, stream);
 
-    // 3. append new K/V into the paged cache for this layer
+    // 3. per-head QK-norm + RoPE + paged KV append (matches Qwen35Model::forward_token)
     bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)layer * s.kv->layer_stride_elems();
     bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)layer * s.kv->layer_stride_elems();
-    int* btable = s.kv->block_table(0);   // batch occupies slots 0..num_seqs-1
-    launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
-                     num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
-                     s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    int* btable = s.d_batch_btable;   // batch-indexed rows packed in begin_step()
+    if (w.q_norm && w.k_norm) {
+        kernels::launch_qknorm_rope_kv_append(
+            s.q, s.k, s.v, w.q_norm, w.k_norm, kpool, vpool, btable, s.d_write_pos,
+            num_seqs, s.attn.num_q_heads, s.attn.num_kv_heads, s.attn.head_dim,
+            s.attn.rope_theta, eps, s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    } else if (s.attn.rope_theta > 0.f) {
+        kernels::launch_rope_kv_append(
+            s.q, s.k, s.v, kpool, vpool, btable, s.d_write_pos,
+            num_seqs, s.attn.num_q_heads, s.attn.num_kv_heads, s.attn.head_dim,
+            s.attn.rope_theta, s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    } else {
+        launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
+                         num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
+                         s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);
+    }
 
     // 4. GQA flash decode over the paged cache
     kernels::launch_flash_decode_gqa8(s.q, kpool, vpool, btable, s.d_seq_lens, s.attnout,
@@ -110,7 +148,7 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     // 5. output projection + residual + post-attention norm
     kernels::launch_gemm(s.attnout, w.wo, s.ao, num_seqs, H, Q, 1.f, 0.f, gc, stream);
     launch_residual_add(x, s.ao, s.h, num_seqs * H, stream);          // h = x + attn
-    kernels::launch_rmsnorm(s.h, w.ffn_norm, s.hn, num_seqs, H, 1e-6f, stream);
+    kernels::launch_rmsnorm(s.h, w.ffn_norm, s.hn, num_seqs, H, eps, stream);
 
     // 6. sync-free MoE FFN + residual
     s.moe->set_layer_weights(layer, w.moe);

--- a/runtime/tests/decode_runner_gpu_test.cpp
+++ b/runtime/tests/decode_runner_gpu_test.cpp
@@ -44,7 +44,7 @@ int main() {
 
     const int H = 2048, nkv = 2, nq = 16, hd = 128;        // gqa8 / Qwen3.5 attention
     const int E = 8, K = 2, F = 64, layers = 2, seqs = 2;
-    AttnConfig ac{nq, nkv, hd, 1.f / std::sqrt((float)hd)};
+    AttnConfig ac{nq, nkv, hd, 1.f / std::sqrt((float)hd), 1e6f, 1e-6f};
 
     KVCacheConfig kvc; kvc.num_layers = layers; kvc.num_kv_heads = nkv; kvc.head_dim = hd; kvc.block_size = 16;
     KVCacheManager kv(kvc, 64ull * 1024 * 1024);
@@ -61,6 +61,8 @@ int main() {
         w[l].wk = dev_rand_bf16((size_t)H * KVd, 0.05f);
         w[l].wv = dev_rand_bf16((size_t)H * KVd, 0.05f);
         w[l].wo = dev_rand_bf16((size_t)Q * H, 0.05f);
+        w[l].q_norm = dev_rand_bf16(hd, 0.5f);
+        w[l].k_norm = dev_rand_bf16(hd, 0.5f);
         w[l].ffn_norm = dev_rand_bf16(H, 0.5f);
         w[l].moe.router_w = dev_rand_bf16((size_t)H * E, 0.1f);
         w[l].moe.gate_w = dev_rand_bf16((size_t)E * H * F, 0.05f);
@@ -73,7 +75,8 @@ int main() {
 
     cudaStream_t stream; cudaStreamCreate(&stream);
     std::vector<int> lens(seqs, 7);                 // 7 tokens already cached
-    runner.begin_step(lens);
+    std::vector<uint64_t> seq_ids = {0, 1};
+    runner.begin_step(seq_ids, lens);
     for (int l = 0; l < layers; l++) runner.decode_layer(l, x, seqs, w[l], stream);
     cudaStreamSynchronize(stream);
 


### PR DESCRIPTION
## Problem
`DecodeRunner::decode_layer` projected Q/K/V and appended raw K/V to the paged cache, then ran flash decode. Qwen3 requires per-head QK-RMSNorm and RoPE before caching K and before attention reads Q — `Qwen35Model::forward_token` already does this via `launch_qknorm_rope_kv_append`.

Without RoPE/QK-norm, every layer produces wrong hidden states. The existing GPU test only checked finiteness, so this passed while being semantically incorrect.

A second bug: the runner always used `block_table(0)` for all batch rows. KV kernels index `block_table[seq * max_blocks + blk]`, so batch row 1+ read seq 0's mapping and wrote KV to the wrong physical blocks.

## Fix
- Extend `AttnConfig` / `TransformerLayerWeights` with `rope_theta`, `rms_eps`, `q_norm`, `k_norm`.
- After Q/K/V projection, call `launch_qknorm_rope_kv_append` (or `launch_rope_kv_append` fallback) — same as `Qwen35Model`.
- Pack each sequence's block table into batch-indexed device rows in `begin_step(seq_ids, seq_lens)`.

## Test plan
- [ ] `decode_runner_gpu_test` on RTX 5090 (2 seqs, QK-norm weights wired)
- [ ] Compare DecodeRunner vs Qwen35Model layer output on a single token (optional)