### PR TITLE
fix(kv): prevent stale block-table slots from corrupting paged KV

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_gqa8.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_gqa8.cu
@@ -64,6 +64,7 @@ __global__ void flash_decode_gqa8_kernel(
 
     for (int blk = 0; blk < n_blocks; blk++) {
         const int phys  = block_table[seq * max_blocks_per_seq + blk];
+        if (phys < 0) continue;
         const int valid = min(BLOCK_SIZE, seq_len - blk * BLOCK_SIZE);
 
         // Cooperative load of this KV block into shared memory (all NWARPS warps).

--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -58,6 +58,7 @@ __global__ void fa_split_kernel(
     for (int t = start; t < end; t++) {
         const int blk = t / block_size, within = t % block_size;
         const int phys = block_table[seq * max_blocks + blk];
+        if (phys < 0) continue;
         const size_t base = ((size_t)(phys * block_size + within) * num_kv_heads + kvh) * HEAD_DIM;
         float p = 0.f;
         #pragma unroll

--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -92,6 +92,7 @@ __global__ void rope_kv_append_kernel(
     const int blk    = pos / block_size;
     const int within = pos % block_size;
     const int phys   = block_table[tok * max_blocks_per_seq + blk];
+    if (phys < 0) return;
     const size_t ctok = (size_t)(phys * block_size + within);   // cache token slot
 
     if (gid < nq) {                          // Q: rope in place
@@ -141,10 +142,12 @@ __global__ void qknorm_rope_kv_kernel(
     const int half = head_dim >> 1;
     const int pos  = positions[tok];
     const int blk = pos / block_size, within = pos % block_size;
-    const size_t ctok = (size_t)((size_t)block_table[tok * max_blocks_per_seq + blk] * block_size + within);
+    const int phys = block_table[tok * max_blocks_per_seq + blk];
+    const size_t ctok = (phys >= 0) ? (size_t)(phys * block_size + within) : 0;
 
     const bool is_v = (b >= n_q_heads + n_kv_heads);
     if (is_v) {                                    // V: copy head straight to the cache (no norm/rope)
+        if (phys < 0) return;
         const int hh = b - n_q_heads - n_kv_heads;
         const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
@@ -187,7 +190,7 @@ __global__ void qknorm_rope_kv_kernel(
         const __nv_bfloat16 o1 = __float2bfloat16(x1 * c + x0 * s);
         if (is_q) {                                // Q: rope in place
             q[base + t] = o0; q[base + t + half] = o1;
-        } else {                                   // K: rope straight into the paged cache
+        } else if (phys >= 0) {                  // K: rope straight into the paged cache
             const size_t dst = (ctok * n_kv_heads + head) * head_dim;
             k_pool[dst + t] = o0; k_pool[dst + t + half] = o1;
         }

--- a/runtime/csrc/cuda/kv_ops.cu
+++ b/runtime/csrc/cuda/kv_ops.cu
@@ -26,6 +26,7 @@ __global__ void kv_append_kernel(
     const int blk    = pos / block_size;
     const int within = pos % block_size;
     const int phys   = block_table[seq * max_blocks_per_seq + blk];
+    if (phys < 0) return;
     const size_t dst = ((size_t)(phys * block_size + within) * num_kv_heads + h) * head_dim + d;
     const size_t src = ((size_t)seq * num_kv_heads + h) * head_dim + d;
     k_pool[dst] = k_new[src];

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -12,6 +12,7 @@
 #include <cuda_runtime.h>
 #include <vector>
 #include <unordered_map>
+#include <cstring>
 #include <cstdio>
 
 namespace sparkinfer {
@@ -22,6 +23,7 @@ inline void cu(cudaError_t e, const char* what) {
 }
 constexpr int kMaxSeqs = 256;
 constexpr int kMaxBlocksPerSeq = 4096;   // 4096 * block_size tokens per sequence
+constexpr int kInvalidBlock = -1;        // sentinel for unmapped logical blocks
 }
 
 struct KVCacheManager::Impl {
@@ -51,6 +53,7 @@ KVCacheManager::KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes)
     cu(cudaMalloc(&impl_->k_pool, pool_elems * sizeof(unsigned short)), "malloc k_pool");
     cu(cudaMalloc(&impl_->v_pool, pool_elems * sizeof(unsigned short)), "malloc v_pool");
     cu(cudaMalloc(&impl_->d_block_tables, (size_t)kMaxSeqs * kMaxBlocksPerSeq * sizeof(int)), "malloc tables");
+    cu(cudaMemset(impl_->d_block_tables, 0xFF, (size_t)kMaxSeqs * kMaxBlocksPerSeq * sizeof(int)), "init tables");
 
     impl_->free_list.reserve(impl_->total_blocks);
     for (int i = impl_->total_blocks - 1; i >= 0; --i) impl_->free_list.push_back(i);
@@ -62,31 +65,49 @@ KVCacheManager::~KVCacheManager() {
 }
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
+    if (num_tokens <= 0) return false;
     const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
-    if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
     if (need > kMaxBlocksPerSeq) return false;
 
     auto& blocks = impl_->seq_blocks[seq_id];
-    for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
+    const int have = (int)blocks.size();
+    const int grow = need - have;
+    if (grow > 0) {
+        if ((int)impl_->free_list.size() < grow) return false;
+        if (have == 0 && impl_->free_slots.empty()) return false;
+        for (int i = 0; i < grow; i++) {
+            blocks.push_back(impl_->free_list.back());
+            impl_->free_list.pop_back();
+        }
+    }
+    if (blocks.empty()) return false;
 
     int slot;
     auto it = impl_->seq_slot.find(seq_id);
     if (it != impl_->seq_slot.end()) slot = it->second;
     else { slot = impl_->free_slots.back(); impl_->free_slots.pop_back(); impl_->seq_slot[seq_id] = slot; }
 
-    cu(cudaMemcpy(impl_->d_block_tables + (size_t)slot * kMaxBlocksPerSeq, blocks.data(),
-                  blocks.size() * sizeof(int), cudaMemcpyHostToDevice), "copy block table");
+    // Upload the full row: tail slots must not retain stale mappings from slot reuse.
+    std::vector<int> row(kMaxBlocksPerSeq, kInvalidBlock);
+    std::memcpy(row.data(), blocks.data(), blocks.size() * sizeof(int));
+    int* dst = impl_->d_block_tables + (size_t)slot * kMaxBlocksPerSeq;
+    cu(cudaMemcpy(dst, row.data(), (size_t)kMaxBlocksPerSeq * sizeof(int), cudaMemcpyHostToDevice), "copy block table");
     return true;
 }
 
 void KVCacheManager::free(uint64_t seq_id) {
+    auto s = impl_->seq_slot.find(seq_id);
+    if (s != impl_->seq_slot.end()) {
+        int* row = impl_->d_block_tables + (size_t)s->second * kMaxBlocksPerSeq;
+        cu(cudaMemset(row, 0xFF, (size_t)kMaxBlocksPerSeq * sizeof(int)), "clear block table");
+        impl_->free_slots.push_back(s->second);
+        impl_->seq_slot.erase(s);
+    }
     auto it = impl_->seq_blocks.find(seq_id);
     if (it != impl_->seq_blocks.end()) {
         for (int b : it->second) impl_->free_list.push_back(b);
         impl_->seq_blocks.erase(it);
     }
-    auto s = impl_->seq_slot.find(seq_id);
-    if (s != impl_->seq_slot.end()) { impl_->free_slots.push_back(s->second); impl_->seq_slot.erase(s); }
 }
 
 int* KVCacheManager::block_table(uint64_t seq_id) const {


### PR DESCRIPTION
## Problem
`KVCacheManager::allocate` only uploaded `blocks.size()` ints to the device block-table row. Unused tail slots retained stale physical block IDs from:
1. cudaMalloc garbage on first use
2. A prior sequence that occupied the same table row (slot reuse after `free`)

When decode position exceeds allocated blocks (or logical block index points past the uploaded prefix), `kv_append` / flash-decode kernels read those stale `phys` values and read/write arbitrary pool blocks — silent wrong tokens or memory corruption.

`allocate` also always `push_back(need)` blocks, leaking/duplicating on re-allocate without `free`.

## Fix
- Grow-only allocation: only append `grow = need - have` new physical blocks.
- Upload the full `kMaxBlocksPerSeq` row with `-1` sentinel for unmapped slots; memset table rows on `free`.
- Skip KV read/write in `kv_append`, `rope`/`qknorm_rope`, `flash_decode_gqa8`, and `flash_decode_split` when `phys < 0`.

## Test plan
- [ ] Allocate/free/reallocate same seq_id; verify tail slots are `-1` on device
- [ ] Long prompt that would exceed allocated blocks is refused upstream (pairs with generate bounds PR)
- [ ] CI build