### PR TITLE
perf(decode): default gate/up to 1-row mmvq2_qwen + rmsnorm load elimination (sm_120)

### DIFF
--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -204,11 +204,15 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     __syncthreads();
     const float inv_rms = s_warp[0];
 
-    // Re-read the bf16-rounded residual sum (exactly as add_rmsnorm2_kernel does), so out_norm
-    // is bit-identical to the unfused path; then derive Q8_1 from the bf16-rounded out_norm.
+    // The bf16-rounded residual sum is already in registers (sv, just stored to out_sum):
+    // round it in-place instead of reloading osum4[t]. bf16(sv) is bit-identical to the
+    // store+reload rn_pack8/rn_unpack8 round-trip, so out_norm/Q8_1 stay bit-identical to
+    // the unfused path — but the dependent global load (right after the store, on this
+    // single-block latency-bound kernel) is removed from the critical path.
     const uint4* w4 = reinterpret_cast<const uint4*>(weight);
-    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum);
-    float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
+    float svb[8], wv[8]; rn_unpack8(__ldg(w4 + t), wv);
+    #pragma unroll
+    for (int j = 0; j < 8; j++) svb[j] = __bfloat162float(__float2bfloat16(sv[j]));
     float ov[8], bv[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -855,8 +855,12 @@ void launch_moe_expert_ffn_q4k(
     if (gu2 < 0) { const char* g2 = getenv("SPARKINFER_GU2"); gu2 = (g2 && g2[0] == '0') ? 0 : 1; }
     static int gu_spec = -1;
     if (gu_spec < 0) { const char* gs = getenv("SPARKINFER_GU_SPEC"); gu_spec = (gs && gs[0] == '0') ? 0 : 1; }
+    // gate/up row-packing (2 rows/block, 8 warps). Default OFF: on RTX 5090 (sm_120) the
+    // 1-row-per-block gate_up_mmvq2_qwen_kernel is measurably faster than the packed variant
+    // — same 4 warps/row and identical math, but a smaller reduction footprint (sg/su[3][32]
+    // vs sg/su[2][3][32]) and no group indexing. Set SPARKINFER_GU_PACK2=1 to re-enable packing.
     static int gu_pack2 = -1;
-    if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '0') ? 0 : 1; }
+    if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '1') ? 1 : 0; }
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
     if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
         const si_block_q8_1* q;


### PR DESCRIPTION
## Summary

Two small decode-path fixes from an nsys profile sweep on RTX 5090 (sm_120), Qwen3-30B-A3B-Q4_K_M:

1. **Gate/up kernel default** — flip `SPARKINFER_GU_PACK2` default from ON → OFF so Qwen3 decode uses the 1-row-per-block `gate_up_mmvq2_qwen_kernel` instead of the packed `gate_up_mmvq2_pack2_qwen_kernel`. Same 4-warp/row math and bit-identical output; smaller shared-memory reduction footprint on sm_120.
2. **`add_rmsnorm2_q8` micro-opt** — reuse the bf16-rounded residual sum already in registers instead of store→reload from `out_sum`, removing a dependent global load from this single-block, latency-bound kernel. Provably bit-identical bf16 round-trip.

No env vars required; set `SPARKINFER_GU_PACK2=1` to restore the old packed gate/up path.

## Proof of speedup

**Tested on RTX 5090 (sm_120)**

Decode tok/s (end-to-end, from `qwen3_gguf_bench`; `Qwen3-30B-A3B-Q4_K_M.gguf`, 128 decode tokens):

| | decode tok/s |
|---|---|
| before (main) | 393.97 |
| after (this PR) | 395.48 |

Main is latest `origin/main` (`8aa997a`). The after value is the median of 3 repeated 4096-context runs below.

| context | main | this PR | gain vs main |
|---|---:|---:|---:|
| 128 | 491.67 | 494.03 | +0.48% |
| 512 | 472.80 | 474.91 | +0.45% |
| 4096 | 393.97 | 395.48 | +0.38% |

RTX 5090, sm_120, CUDA 13.0.1 container, Release build
qwen3_gguf_bench Qwen3-30B-A3B-Q4_K_M.gguf 128 <ctx>
main vs branch: separate Release rebuilds per side

ctx=128:   main 491.67,  this PR 494.03
ctx=512:   main 472.80,  this PR 474.91
ctx=4096:  main 393.91 / 393.97 / 394.29  -> median 393.97
           this PR 395.66 / 395.48 / 395.31 -> median 395.48

**Correctness:** bit-identical — both gate/up kernel paths use identical math; the rmsnorm change is a provable bf16 round-trip (same token IDs as main on greedy decode).

**Note:** Gain is ~0.4%, near run-to-run thermal/clock noise on this box. Included for completeness per bot requirements; a scoreable win likely needs kernel-level fusion (Q/K/V projection is the top target at ~19% of decode).

## Test plan

- [x] Built sm_120 Release with CUDA 13.0.1 (`cmake --build … qwen3_gguf_bench`)
- [x] Ran `qwen3_gguf_bench` at ctx=128, 512, and 4096 (128 decode tokens, bs=1)
- [x] Repeated 4096-context runs ×3 on main and branch; reported medians
- [x] Separate Release rebuild per side (main checkout vs this branch)
- [x] `bench/scripts/bench.sh --download` entrypoint verified

bench/scripts/bench.sh --download   # baseline (main)
bench/scripts/bench.sh --download   # this branch (after)