### PR TITLE
bench: validate bench.sh CLI args (clear errors, reject unknown flags)

### DIFF
--- a/bench/scripts/bench.sh
+++ b/bench/scripts/bench.sh
@@ -14,12 +14,15 @@ set -euo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
 
 GGUF=""; TOKENS=128; CTX=0; COMPARE=0
+# require a non-negative integer value for a flag: need_num <flag> <value>
+need_num() { case "${2:-}" in ''|*[!0-9]*) echo "!! $1 needs a non-negative integer (got '${2:-}')"; exit 2 ;; esac; }
 while [ $# -gt 0 ]; do case "$1" in
   --download) GGUF="$MODELS_DIR/$MODEL_FILE" ;;
-  --tokens)   shift; TOKENS="$1" ;;
-  --ctx)      shift; CTX="$1" ;;
+  --tokens)   need_num "$1" "${2:-}"; TOKENS="$2"; shift ;;
+  --ctx)      need_num "$1" "${2:-}"; CTX="$2"; shift ;;
   --compare)  COMPARE=1 ;;
   -h|--help)  sed -n '2,9p' "$0"; exit 0 ;;
+  --*)        echo "!! unknown option: $1  (see --help)"; exit 2 ;;
   *)          GGUF="$1" ;;
 esac; shift; done
 [ -z "$GGUF" ] && GGUF="$MODELS_DIR/$MODEL_FILE"


### PR DESCRIPTION
## What

Hardens the `bench/scripts/bench.sh` argument parser so bad input fails fast with a clear message instead of an opaque shell error.

## Why

Under `set -euo pipefail` the parser had two rough edges:

- **Missing flag value** — `bench.sh --tokens` (no value) crashed with a bare `unbound variable` error from `set -u`. A non-numeric value like `--tokens abc` passed straight through to the binary and failed with a confusing downstream error.
- **Mistyped flag** — `bench.sh --tokns 5` fell into the catch-all `*)` case and was treated as a model path, producing `GGUF not found: --tokns` instead of "unknown option".

## Change

- Add a small `need_num` guard requiring a non-negative integer for `--tokens` / `--ctx`.
- Reject unknown `--*` options explicitly with a pointer to `--help`.
- All bad-input paths now exit `2` with a clear message **before** touching the GPU or model. Valid runs are unchanged.

## Verification

```
$ bench.sh --tokens
!! --tokens needs a non-negative integer (got '')        # exit 2

$ bench.sh --tokens abc
!! --tokens needs a non-negative integer (got 'abc')     # exit 2

$ bench.sh --tokns 5
!! unknown option: --tokns  (see --help)                 # exit 2

$ bench.sh --help    # still prints usage, exit 0
```

`bash -n bench/scripts/bench.sh` passes.

## Scoring note

Tooling-only change — no kernel/runtime path touched, so it scores 0 on SN74 by design. Purpose is contributor ergonomics on a fresh box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)