### PR TITLE
docs: fix prebuilt binary version in bench README (v0.1.0 → v0.2.0)

### DIFF
--- a/bench/scripts/README.md
+++ b/bench/scripts/README.md
@@ -28,7 +28,7 @@ bench/scripts/bench.sh /path/to/model.gguf --tokens 256 --compare
 ## Prebuilt binaries (no toolkit needed)
 
 To avoid compiling, the scripts first try the **prebuilt binaries** from the
-[v0.1.0 release](https://github.com/gittensor-ai-lab/sparkinfer/releases/tag/v0.1.0)
+[v0.2.0 release](https://github.com/gittensor-ai-lab/sparkinfer/releases/tag/v0.2.0)
 (sm_120 / CUDA 13 / glibc 2.39 — RTX 5090 & PRO 6000). If the prebuilt is
 incompatible with your box (different arch like sm_121, older driver/CUDA, older
 glibc), they **automatically fall back to a source build** — so it just works either
@@ -36,7 +36,7 @@ way. Order of preference: existing local `build/` → prebuilt → source build.
 
 Force a source build with `NO_PREBUILT=1`. Manual use of the bundle:
 ```bash
-tar xzf sparkinfer-v0.1.0-linux-x86_64-cuda13-sm120.tar.gz
+tar xzf sparkinfer-v0.2.0-linux-x86_64-cuda13-sm120.tar.gz
 ./sparkinfer-bin/run qwen3_gguf_bench model.gguf 128
 ```
 


### PR DESCRIPTION
## What

Updates `bench/scripts/README.md` to reference the **v0.2.0** prebuilt release instead of the stale **v0.1.0**.

## Why

The bench scripts already fetch prebuilt binaries from **v0.2.0** — [`_common.sh`](../blob/main/bench/scripts/_common.sh) defaults `PREBUILT_TAG` / `PREBUILT_TGZ` to `v0.2.0`:

```sh
PREBUILT_TAG="${PREBUILT_TAG:-v0.2.0}"
PREBUILT_TGZ="${PREBUILT_TGZ:-sparkinfer-v0.2.0-linux-x86_64-cuda13-sm120.tar.gz}"
```

But `bench/scripts/README.md` still pointed users at the **v0.1.0** release link and told them to `tar xzf sparkinfer-v0.1.0-...tar.gz` for manual use — a tarball name that no longer matches what the scripts download. Anyone following the manual-extract instructions would grab the wrong (older) artifact.

## Change

Both references (`releases/tag/v0.1.0` link + the `tar xzf` example) bumped to `v0.2.0` so the docs match the code. Docs-only.

## Scoring note

Docs-only — scores 0 on SN74 by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)