### PR TITLE
perf(rmsnorm): drop redundant out_sum reload in fused add_rmsnorm2_q8 (bit-identical)

### DIFF
--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -204,11 +204,15 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     __syncthreads();
     const float inv_rms = s_warp[0];
 
-    // Re-read the bf16-rounded residual sum (exactly as add_rmsnorm2_kernel does), so out_norm
-    // is bit-identical to the unfused path; then derive Q8_1 from the bf16-rounded out_norm.
+    // svb is the bf16-rounded residual sum. Thread t is the sole writer of osum4[t] (one 8-wide
+    // pack per thread, blockDim*8 == cols) and sv[] is still live in registers, so re-round it
+    // here instead of reading out_sum back from global: __bfloat162float(__float2bfloat16(sv[j]))
+    // is exactly what rn_unpack8(__ldg(osum4r+t)) returned, so out_norm stays bit-identical to the
+    // unfused path — minus one redundant hidden-width (4 KB) global load per invocation.
     const uint4* w4 = reinterpret_cast<const uint4*>(weight);
-    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum);
-    float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
+    float svb[8], wv[8]; rn_unpack8(__ldg(w4 + t), wv);
+    #pragma unroll
+    for (int j = 0; j < 8; j++) svb[j] = __bfloat162float(__float2bfloat16(sv[j]));
     float ov[8], bv[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }


### PR DESCRIPTION
## Summary

Removes a redundant global-memory read-back in `add_rmsnorm2_q8_kernel` ([kernels/csrc/cuda/fused/rmsnorm.cu](../blob/main/kernels/csrc/cuda/fused/rmsnorm.cu)) on the bs=1 decode hot path. **Bit-identical output** — this is a pure bytes-per-token reduction, not a numerics change.

## Where it runs

`add_rmsnorm2_q8_kernel` executes **twice per transformer layer** (post-attention + post-MoE fused norm→quant, the default path) as a **single 256-thread block**. At decode (bs=1) a one-block kernel is gated by global-memory latency, so shaving a full-width load off it matters per token, every layer.

## The redundancy

Phase 1 computes the fp32 residual sum `sv[8]`, bf16-rounds it, and stores it to `out_sum`:

```cpp
osum4[t] = rn_pack8(sv);                 // rn_pack8 stores __float2bfloat16(sv[j])
```

Phase 2 then **re-reads that exact pack back from global** just to obtain the bf16-rounded value:

```cpp
const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum);
float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); ...   // svb[j] = __bfloat162float(stored)
```

The kernel is launched with **exactly one 8-wide pack per thread** (`blockDim*8 == cols`), so **thread `t` is the sole writer and reader of `osum4[t]`**, and `sv[]` is still live in registers. The reloaded value is therefore precisely `__bfloat162float(__float2bfloat16(sv[j]))` — recomputable from the live registers with the identical two intrinsics.

## The change

```cpp
const uint4* w4 = reinterpret_cast<const uint4*>(weight);
float svb[8], wv[8]; rn_unpack8(__ldg(w4 + t), wv);
#pragma unroll
for (int j = 0; j < 8; j++) svb[j] = __bfloat162float(__float2bfloat16(sv[j]));
```

- `out_sum` is **still written** (phase 1 unchanged) because downstream graph nodes consume it — only the read-back is dropped.
- Removes one hidden-width (~4 KB for hidden=2048) global load per invocation × 2 per layer × all layers.

## Correctness

**Bit-exact by construction:** `rn_pack8`/`rn_unpack8` are exactly `__float2bfloat16`/`__bfloat162float`, so the register recompute reproduces the reloaded bytes identically. `out_norm` and the derived Q8_1 block are unchanged bit-for-bit. Expected eval-gate result: **~100% top-1, KL = 0** vs the prior build.

## Note

I don't have Blackwell hardware to benchmark locally, so I'm relying on the same-box eval bot for the verified speedup number. The change is argued as correctness-neutral and latency-reducing; if the measured decode delta doesn't clear the significance gate it should score `none` rather than regress. Happy to iterate on reviewer feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)