### PR TITLE
perf(moe): drop self round-trip in Q6_K split-K down reduction (bit-identical)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -673,13 +673,19 @@ __global__ void down_q6k_mmvq_splitk_qwen_kernel(
         }
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
-        if (lane == 0) s_part[hh_local][split] = acc;
+        // split==0's partial is read back from `acc` below, so only split>0 warps need to
+        // publish to shared (their cells are the cross-warp inputs to the split==0 reducer).
+        if (lane == 0 && split != 0) s_part[hh_local][split] = acc;
     }
     __syncthreads();
     if (hh < H && split == 0 && lane == 0) {
+        // acc still holds this thread's own partial (== the old s_part[hh_local][0]); read it
+        // from the register instead of shared. Keep the leading `0.0f +` so the fp add sequence
+        // — and its -0.0f/NaN sign behavior — stays bit-identical to the all-shared reduction.
         float o = 0.f;
+        o += acc;
         #pragma unroll
-        for (int s = 0; s < S; s++) o += s_part[hh_local][s];
+        for (int s = 1; s < S; s++) o += s_part[hh_local][s];
         output[(size_t)token * H + hh] = __float2bfloat16(o);
     }
 }


### PR DESCRIPTION
## Summary

Removes a redundant shared-memory self round-trip in the final reduction of `down_q6k_mmvq_splitk_qwen_kernel` ([kernels/csrc/cuda/moe/expert_ffn_q4k.cu](../blob/main/kernels/csrc/cuda/moe/expert_ffn_q4k.cu)) — the **default decode down-projection kernel** and the single biggest decode cost for this MoE model. **Bit-identical output**; pure shared-traffic reduction.

## Where it runs (default path, verified)

For Qwen3-30B-A3B the dispatch is unambiguous: `SPARKINFER_DOWN_MMVQ`=1 (default) → `down_type==14` (Q6_K) → `down_splitk_s_q6()`=2 (default) → `SPARKINFER_DOWN_SPEC`=1 (default) with `F==768, top_k==8` selects `down_q6k_mmvq_splitk_qwen_kernel<2, 3, 8>`. Launched `<<<(tokens, hidden/RPB), WPB*32 = 256>>>`.

## The redundancy

Each warp reduces its partial into `acc`, then the `lane==0` thread stores it and the `split==0` reducer reads all `S` partials back:

```cpp
if (lane == 0) s_part[hh_local][split] = acc;   // writer
__syncthreads();
if (hh < H && split == 0 && lane == 0) {
    float o = 0.f;
    for (int s = 0; s < S; s++) o += s_part[hh_local][s];   // s==0 re-reads its OWN write
    output[token * H + hh] = __float2bfloat16(o);
}
```

`warpId → (hh_local = warpId/S, split = warpId%S)` is a bijection over `[0,RPB)×[0,S)`, so **each `s_part` cell has exactly one writer warp**. The `split==0, lane==0` reducer's `s==0` term re-reads `s_part[hh_local][0]` — a value it still holds bit-for-bit in `acc`.

## The change

```cpp
if (lane == 0 && split != 0) s_part[hh_local][split] = acc;   // split==0 store now dead — skip it
__syncthreads();
if (hh < H && split == 0 && lane == 0) {
    float o = 0.f;
    o += acc;                                    // was s_part[hh_local][0]
    for (int s = 1; s < S; s++) o += s_part[hh_local][s];
    output[token * H + hh] = __float2bfloat16(o);
}
```

Removes one of the `S=2` shared loads **and** a shared store from the dependent tail, on every one of the `hidden` output rows. `__syncthreads()` is retained (the reducer still reads the *other* warp's cell).

## Why bit-identical (not within-tolerance)

- A `float` store+load of `s_part` is a pure bit-preserving round trip — no conversion, no rounding, preserves `-0.0f` and `NaN`. So `s_part[hh_local][0]` has the **same 32 bits** as `acc`.
- The reduction keeps the leading `0.0f +` (`o = 0.f; o += acc; …`), so the fp add sequence — operands, order, rounding mode, and `-0.0f`/`NaN` sign behavior — is unchanged. (I deliberately did **not** write `float o = acc;`, which could flip `-0.0f`→`+0.0f` and diverge in the bf16 sign bit.)
- The `split==0` cell is provably dead after the read change (sole-owner, no longer read), so skipping its store changes nothing observable.

`out` and the final `__float2bfloat16(o)` are unchanged bit-for-bit → expected eval gate **~100% top-1, KL = 0**.

## Scope & caveats

- Scoped to the active default-path kernel for a minimal, fully-verified diff. The identical self-read pattern exists in the sibling split-K down variants (generic Q6_K/Q4_K, non-default toggles); left untouched here.
- No Blackwell GPU locally, so the verified tok/s is up to the same-box eval bot. Argued correctness-neutral and traffic-reducing; if the decode delta is under the 2% gate it should score `none` rather than regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)