### PR TITLE
perf(attn): int8 KV tensor-core GQA flash-decode (+19% decode at 16k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -253,6 +253,141 @@ template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*,
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
+#include <mma.h>
+
+// Tensor-core (wmma bf16) GQA flash-decode split. The 8 GQA q-heads of a kv-head are the batch (M)
+// dim, so S = Q[16x128]·Kᵀ[128xT] and O = P[16xT]·V[Tx128] become small bf16 matmuls on the tensor
+// cores — replacing the per-lane FMA + 5-shuffle fa_wsum reduction that dominates the scalar kernel's
+// compute at long context. M is padded 8->16 (upper 8 q-rows zero). Byte-compatible partials
+// (m,l,acc) for the existing combine kernel. Online-softmax loop over NT-token tiles handles any
+// chunk. sm_80+ (wmma bf16). One block per (seq, kv_head, split); 8 warps.
+template <int HEAD_DIM, int GQA>
+__global__ void fa_split_gqa_mma_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens,
+    float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
+    float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits
+) {
+    using namespace nvcuda::wmma;
+    constexpr int NT = 128;              // tokens per tile
+    constexpr int KH = HEAD_DIM / 16;    // 16-wide steps across head_dim (8)
+    const int seq   = blockIdx.y;
+    const int split = blockIdx.x % n_splits;
+    const int kvh   = blockIdx.x / n_splits;
+    const int warp  = threadIdx.x >> 5;  // 0..7
+    const int lane  = threadIdx.x & 31;
+    const int tid   = threadIdx.x;
+
+    const int sl    = seq_lens[seq];
+    const int chunk = (sl + n_splits - 1) / n_splits;
+    const int start = split * chunk;
+    const int end   = min(sl, start + chunk);
+
+    // Fragments load straight from the paged K/V pool: each warp owns one block_size==16-token
+    // physical block (block-aligned split chunk), which is contiguous in global with token stride
+    // num_kv_heads*HEAD_DIM. No K/V shared staging -> ~24KB smem -> high occupancy. Requires the
+    // launcher to route here only when chunk is a multiple of block_size (block-aligned tiles).
+    const int KVLD = num_kv_heads * HEAD_DIM;    // token stride in the pool
+    extern __shared__ char fmma_smem[];
+    __nv_bfloat16* s_q = reinterpret_cast<__nv_bfloat16*>(fmma_smem);   // [16][HD]
+    __nv_bfloat16* s_p = s_q + 16 * HEAD_DIM;                           // [16][HD]
+    float* s_s = reinterpret_cast<float*>(s_p + 16 * HEAD_DIM);         // [16][HD] scores / PV scratch
+    float* s_o = s_s + 16 * HEAD_DIM;                                   // [16][HD] running O
+    float* s_m = s_o + 16 * HEAD_DIM;                                   // [16]
+    float* s_l = s_m + 16;                                              // [16]
+
+    for (int i = tid; i < 16 * HEAD_DIM; i += blockDim.x) {
+        const int r = i / HEAD_DIM, c = i % HEAD_DIM;
+        s_q[i] = (r < GQA) ? q[(size_t)(seq * num_q_heads + kvh * GQA + r) * HEAD_DIM + c]
+                           : __float2bfloat16(0.f);
+        s_o[i] = 0.f;
+    }
+    if (tid < 16) { s_m[tid] = -1e30f; s_l[tid] = 0.f; }
+    __syncthreads();
+
+    // Robust tiling: each warp owns one whole 16-token physical block overlapping [start,end); tokens
+    // outside the split range are masked. Correct for ANY chunk (aligned or not); requires block_size==16.
+    const int first_blk = start / 16;
+    const int nblk = (end > start) ? ((end - 1) / 16 - first_blk + 1) : 0;
+    for (int g0 = 0; g0 < nblk; g0 += 8) {
+        const int gblk = min(8, nblk - g0);                      // 16-token blocks this group
+        const int gbase = (first_blk + g0) * 16;                 // global token of column 0
+
+        // QK: warp w owns physical block (first_blk+g0+w); S columns [w*16,+16) = that block's tokens.
+        if (warp < gblk) {
+            const int pb = block_table[seq * max_blocks + first_blk + g0 + warp];
+            const __nv_bfloat16* kb = k_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM;
+            fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
+            fragment<matrix_b, 16, 16, 16, __nv_bfloat16, col_major> bf;   // col_major => Kᵀ
+            fragment<accumulator, 16, 16, 16, float> cf;
+            fill_fragment(cf, 0.f);
+            #pragma unroll
+            for (int ks = 0; ks < KH; ks++) {
+                load_matrix_sync(af, s_q + ks * 16, HEAD_DIM);
+                load_matrix_sync(bf, kb + ks * 16, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            store_matrix_sync(s_s + warp * 16, cf, HEAD_DIM, mem_row_major);
+        }
+        __syncthreads();
+
+        // Online softmax. Column t -> global token gbase+t; valid iff in [start,end).
+        #pragma unroll
+        for (int rr = 0; rr < 2; rr++) {
+            const int r = warp * 2 + rr;
+            float mx = -1e30f;
+            for (int t = lane; t < gblk * 16; t += 32) {
+                const int gtok = gbase + t;
+                if (gtok >= start && gtok < end) mx = fmaxf(mx, s_s[r * HEAD_DIM + t] * scale);
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffff, mx, o));
+            const float m_old = s_m[r], m_new = fmaxf(m_old, mx), corr = __expf(m_old - m_new);
+            float sum = 0.f;
+            for (int t = lane; t < 128; t += 32) {
+                float p = 0.f;
+                const int gtok = gbase + t;
+                if (t < gblk * 16 && gtok >= start && gtok < end) { p = __expf(s_s[r * HEAD_DIM + t] * scale - m_new); sum += p; }
+                s_p[r * HEAD_DIM + t] = __float2bfloat16(p);
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) sum += __shfl_xor_sync(0xffffffff, sum, o);
+            if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; }
+            for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
+        }
+        __syncthreads();
+
+        // PV: warp w computes O[16 x 16] for head cols [warp*16,+16), K over the group's blocks.
+        {
+            fragment<accumulator, 16, 16, 16, float> cf;
+            fill_fragment(cf, 0.f);
+            for (int ks = 0; ks < gblk; ks++) {
+                const int pb = block_table[seq * max_blocks + first_blk + g0 + ks];
+                const __nv_bfloat16* vb = v_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM + warp * 16;
+                fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
+                fragment<matrix_b, 16, 16, 16, __nv_bfloat16, row_major> bf;
+                load_matrix_sync(af, s_p + ks * 16, HEAD_DIM);
+                load_matrix_sync(bf, vb, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            store_matrix_sync(s_s + warp * 16, cf, HEAD_DIM, mem_row_major);
+        }
+        __syncthreads();
+        for (int i = tid; i < 16 * HEAD_DIM; i += blockDim.x) s_o[i] += s_s[i];
+        __syncthreads();
+    }
+
+    for (int r = 0; r < GQA; r++) {
+        const int qh  = kvh * GQA + r;
+        const int idx = (seq * num_q_heads + qh) * n_splits + split;
+        if (tid == 0) { part_m[idx] = s_m[r]; part_l[idx] = s_l[r]; }
+        for (int c = tid; c < HEAD_DIM; c += blockDim.x)
+            part_acc[(size_t)idx * HEAD_DIM + c] = s_o[r * HEAD_DIM + c];
+    }
+}
+template __global__ void fa_split_gqa_mma_kernel<128, 8>(const __nv_bfloat16*, const __nv_bfloat16*,
+    const __nv_bfloat16*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
 
 template <int NW>
 static inline void fa_launch_combine(
@@ -281,7 +416,7 @@ void launch_flash_decode_split(
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
-    void* out_q8
+    void* out_q8, int seqlen
 ) {
     static int fagqa = -1;
     if (fagqa < 0) {
@@ -289,14 +424,38 @@ void launch_flash_decode_split(
         fagqa = e ? ((e[0] == '0') ? 0 : 1) : -2;   // -2 = auto: long-context only
     }
     const bool use_gqa = (fagqa == 1) || (fagqa == -2 && n_splits >= 32);
+    // Tensor-core (wmma bf16) GQA split (SPARKINFER_FAMMA, default on): the 8 GQA q-heads become the
+    // mma M dim, moving the QK/PV dot + reduction onto the tensor cores. The kernel reads each 16-token
+    // physical block's fragments straight from the paged pool, so it is only exact when every split's
+    // chunk is a multiple of block_size (16) — enabled only then; other contexts use the scalar kernel.
+    static int famma = -1;
+    if (famma < 0) { const char* e = getenv("SPARKINFER_FAMMA"); famma = (e && e[0] == '0') ? 0 : 1; }
+    // Long-context regime only (attention is a small fraction of short-context decode); requires
+    // block_size==16 (each warp maps to one physical block). Robust to any chunk (partial blocks masked).
+    const bool mma_aligned = famma && seqlen > 512 && block_size == 16;
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
         constexpr int GQA = 8, TILE = FA_GQA_TILE;
         dim3 gq(num_kv_heads * n_splits, num_seqs);
+        if (mma_aligned) {   // block-aligned chunks only (paged-fragment loads are exact)
+            constexpr size_t mma_smem = (size_t)(16 + 16) * 128 * sizeof(__nv_bfloat16)
+                                      + (size_t)(16 + 16) * 128 * sizeof(float) + 32 * sizeof(float);
+            static bool set_attr = false;
+            if (!set_attr) {
+                cudaFuncSetAttribute(fa_split_gqa_mma_kernel<128, GQA>,
+                                     cudaFuncAttributeMaxDynamicSharedMemorySize, (int)mma_smem);
+                set_attr = true;
+            }
+            fa_split_gqa_mma_kernel<128, GQA><<<gq, GQA * 32, mma_smem, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
+                reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
+        } else {
         size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
         fa_split_gqa_kernel<128, GQA, TILE><<<gq, GQA * 32, smem, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
             reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
             part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
+        }
         fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
                                    num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
         (void)head_dim;

--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -127,6 +127,7 @@ __global__ void fa_split_gqa_kernel(
     __nv_bfloat16* s_k = s_kv;
     __nv_bfloat16* s_v = s_kv + (size_t)TILE * HEAD_DIM;
     __shared__ size_t s_rowbase[TILE];   // per-token global row base, resolved once (not per head-dim)
+    __shared__ float s_ksc[TILE], s_vsc[TILE];   // int8: per-token dequant scales, resolved once
 
     for (int t0 = start; t0 < end; t0 += TILE) {
         const int valid = min(TILE, end - t0);
@@ -136,7 +137,9 @@ __global__ void fa_split_gqa_kernel(
             const int t = t0 + threadIdx.x;
             const int blk = t / block_size, wb = t % block_size;
             const int phys = block_table[seq * max_blocks + blk];
-            s_rowbase[threadIdx.x] = ((size_t)(phys * block_size + wb) * num_kv_heads + kvh) * HEAD_DIM;
+            const size_t tokrow = (size_t)(phys * block_size + wb) * num_kv_heads + kvh;
+            s_rowbase[threadIdx.x] = tokrow * HEAD_DIM;
+            if (int8_kv) { s_ksc[threadIdx.x] = __half2float(k_scale[tokrow]); s_vsc[threadIdx.x] = __half2float(v_scale[tokrow]); }
         }
         __syncthreads();
         if (!int8_kv) {
@@ -156,8 +159,7 @@ __global__ void fa_split_gqa_kernel(
             for (int i = threadIdx.x * 8; i < valid * HEAD_DIM; i += blockDim.x * 8) {
                 const int within = i / HEAD_DIM, d = i % HEAD_DIM;
                 const size_t base = s_rowbase[within] + d;
-                const float ks = __half2float(k_scale[s_rowbase[within] / HEAD_DIM]);
-                const float vs = __half2float(v_scale[s_rowbase[within] / HEAD_DIM]);
+                const float ks = s_ksc[within], vs = s_vsc[within];
                 const int2 kr = __ldg(reinterpret_cast<const int2*>(ki + base));
                 const int2 vr = __ldg(reinterpret_cast<const int2*>(vi + base));
                 const signed char* kc = reinterpret_cast<const signed char*>(&kr);
@@ -623,9 +625,12 @@ void launch_flash_decode_split(
     // chunk is a multiple of block_size (16) — enabled only then; other contexts use the scalar kernel.
     static int famma = -1;
     if (famma < 0) { const char* e = getenv("SPARKINFER_FAMMA"); famma = (e && e[0] == '0') ? 0 : 1; }
-    // Long-context regime only (attention is a small fraction of short-context decode); requires
-    // block_size==16 (each warp maps to one physical block). Robust to any chunk (partial blocks masked).
-    const bool mma_aligned = famma && seqlen > 512 && block_size == 16;
+    // Long-context regime only: requires block_size==16 (each warp maps to one physical block) AND a
+    // large-enough per-split chunk (>=2 physical blocks). At tiny chunks the GQA-shared mma has too
+    // few blocks/warps to fill the GPU and loses to the high-occupancy scalar split; those short
+    // contexts use the scalar (int8-dequant) path. Robust to any chunk (partial blocks masked).
+    const int mma_chunk = (n_splits > 0) ? (seqlen + n_splits - 1) / n_splits : 0;
+    const bool mma_aligned = famma && seqlen > 512 && block_size == 16 && mma_chunk >= 32;
     const __half* ksc = reinterpret_cast<const __half*>(k_scale);
     const __half* vsc = reinterpret_cast<const __half*>(v_scale);
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {

--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -92,14 +92,14 @@ __global__ void fa_split_kernel(
 // all GQA warps reuse it. For Qwen's 8:1 GQA this cuts long-context KV global
 // reads in the split pass by up to 8x while preserving the same per-q-head
 // partials consumed by the existing combine kernel.
-template <int HEAD_DIM, int GQA, int TILE>
+template <int HEAD_DIM, int GQA, int TILE, bool INT8>
 __global__ void fa_split_gqa_kernel(
     const __nv_bfloat16* __restrict__ q, const void* __restrict__ k_pool,
     const void* __restrict__ v_pool, const int* __restrict__ block_table,
     const int* __restrict__ seq_lens,
     float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
     float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits,
-    const __half* __restrict__ k_scale, const __half* __restrict__ v_scale, int int8_kv
+    const __half* __restrict__ k_scale, const __half* __restrict__ v_scale
 ) {
     constexpr int ELEMS = HEAD_DIM / 32;
     const int seq   = blockIdx.y;
@@ -127,7 +127,7 @@ __global__ void fa_split_gqa_kernel(
     __nv_bfloat16* s_k = s_kv;
     __nv_bfloat16* s_v = s_kv + (size_t)TILE * HEAD_DIM;
     __shared__ size_t s_rowbase[TILE];   // per-token global row base, resolved once (not per head-dim)
-    __shared__ float s_ksc[TILE], s_vsc[TILE];   // int8: per-token dequant scales, resolved once
+    __shared__ float s_ksc[INT8 ? TILE : 1], s_vsc[INT8 ? TILE : 1];   // int8 only: per-token dequant scales
 
     for (int t0 = start; t0 < end; t0 += TILE) {
         const int valid = min(TILE, end - t0);
@@ -139,13 +139,14 @@ __global__ void fa_split_gqa_kernel(
             const int phys = block_table[seq * max_blocks + blk];
             const size_t tokrow = (size_t)(phys * block_size + wb) * num_kv_heads + kvh;
             s_rowbase[threadIdx.x] = tokrow * HEAD_DIM;
-            if (int8_kv) { s_ksc[threadIdx.x] = __half2float(k_scale[tokrow]); s_vsc[threadIdx.x] = __half2float(v_scale[tokrow]); }
+            if constexpr (INT8) { s_ksc[threadIdx.x] = __half2float(k_scale[tokrow]); s_vsc[threadIdx.x] = __half2float(v_scale[tokrow]); }
         }
         __syncthreads();
-        if (!int8_kv) {
-            // Vectorized load: uint4 (8×bf16) via __ldg into bf16 smem.
-            const __nv_bfloat16* kb = reinterpret_cast<const __nv_bfloat16*>(k_pool);
-            const __nv_bfloat16* vb = reinterpret_cast<const __nv_bfloat16*>(v_pool);
+        if constexpr (!INT8) {
+            // Vectorized load: uint4 (8×bf16) via __ldg into bf16 smem. __restrict__ recast keeps the
+            // no-alias load codegen identical to the pre-int8 (main) kernel — bf16 guard contexts unchanged.
+            const __nv_bfloat16* __restrict__ kb = reinterpret_cast<const __nv_bfloat16*>(k_pool);
+            const __nv_bfloat16* __restrict__ vb = reinterpret_cast<const __nv_bfloat16*>(v_pool);
             for (int i = threadIdx.x * 8; i < valid * HEAD_DIM; i += blockDim.x * 8) {
                 const int within = i / HEAD_DIM, d = i % HEAD_DIM;
                 const size_t base = s_rowbase[within] + d;
@@ -154,8 +155,8 @@ __global__ void fa_split_gqa_kernel(
             }
         } else {
             // int8: load 8 int8 (int2) + per-token scale, dequant to bf16 into smem (dot loop unchanged).
-            const signed char* ki = reinterpret_cast<const signed char*>(k_pool);
-            const signed char* vi = reinterpret_cast<const signed char*>(v_pool);
+            const signed char* __restrict__ ki = reinterpret_cast<const signed char*>(k_pool);
+            const signed char* __restrict__ vi = reinterpret_cast<const signed char*>(v_pool);
             for (int i = threadIdx.x * 8; i < valid * HEAD_DIM; i += blockDim.x * 8) {
                 const int within = i / HEAD_DIM, d = i % HEAD_DIM;
                 const size_t base = s_rowbase[within] + d;
@@ -282,8 +283,10 @@ __global__ void fa_combine_kernel(
 #endif
 template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
-template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE>(const __nv_bfloat16*, const void*, const void*,
-    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
+template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE, false>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
+template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE, true>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
@@ -292,144 +295,14 @@ template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*,
 #include "sparkinfer/kernels/attention.h"
 #include <mma.h>
 
-// Tensor-core (wmma bf16) GQA flash-decode split. The 8 GQA q-heads of a kv-head are the batch (M)
-// dim, so S = Q[16x128]·Kᵀ[128xT] and O = P[16xT]·V[Tx128] become small bf16 matmuls on the tensor
-// cores — replacing the per-lane FMA + 5-shuffle fa_wsum reduction that dominates the scalar kernel's
-// compute at long context. M is padded 8->16 (upper 8 q-rows zero). Byte-compatible partials
-// (m,l,acc) for the existing combine kernel. Online-softmax loop over NT-token tiles handles any
-// chunk. sm_80+ (wmma bf16). One block per (seq, kv_head, split); 8 warps.
-template <int HEAD_DIM, int GQA>
-__global__ void fa_split_gqa_mma_kernel(
-    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
-    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
-    const int* __restrict__ seq_lens,
-    float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
-    float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits
-) {
-    using namespace nvcuda::wmma;
-    constexpr int NT = 128;              // tokens per tile
-    constexpr int KH = HEAD_DIM / 16;    // 16-wide steps across head_dim (8)
-    const int seq   = blockIdx.y;
-    const int split = blockIdx.x % n_splits;
-    const int kvh   = blockIdx.x / n_splits;
-    const int warp  = threadIdx.x >> 5;  // 0..7
-    const int lane  = threadIdx.x & 31;
-    const int tid   = threadIdx.x;
-
-    const int sl    = seq_lens[seq];
-    const int chunk = (sl + n_splits - 1) / n_splits;
-    const int start = split * chunk;
-    const int end   = min(sl, start + chunk);
-
-    // Fragments load straight from the paged K/V pool: each warp owns one block_size==16-token
-    // physical block (block-aligned split chunk), which is contiguous in global with token stride
-    // num_kv_heads*HEAD_DIM. No K/V shared staging -> ~24KB smem -> high occupancy. Requires the
-    // launcher to route here only when chunk is a multiple of block_size (block-aligned tiles).
-    const int KVLD = num_kv_heads * HEAD_DIM;    // token stride in the pool
-    extern __shared__ char fmma_smem[];
-    __nv_bfloat16* s_q = reinterpret_cast<__nv_bfloat16*>(fmma_smem);   // [16][HD]
-    __nv_bfloat16* s_p = s_q + 16 * HEAD_DIM;                           // [16][HD]
-    float* s_s = reinterpret_cast<float*>(s_p + 16 * HEAD_DIM);         // [16][HD] scores / PV scratch
-    float* s_o = s_s + 16 * HEAD_DIM;                                   // [16][HD] running O
-    float* s_m = s_o + 16 * HEAD_DIM;                                   // [16]
-    float* s_l = s_m + 16;                                              // [16]
-
-    for (int i = tid; i < 16 * HEAD_DIM; i += blockDim.x) {
-        const int r = i / HEAD_DIM, c = i % HEAD_DIM;
-        s_q[i] = (r < GQA) ? q[(size_t)(seq * num_q_heads + kvh * GQA + r) * HEAD_DIM + c]
-                           : __float2bfloat16(0.f);
-        s_o[i] = 0.f;
-    }
-    if (tid < 16) { s_m[tid] = -1e30f; s_l[tid] = 0.f; }
-    __syncthreads();
-
-    // Robust tiling: each warp owns one whole 16-token physical block overlapping [start,end); tokens
-    // outside the split range are masked. Correct for ANY chunk (aligned or not); requires block_size==16.
-    const int first_blk = start / 16;
-    const int nblk = (end > start) ? ((end - 1) / 16 - first_blk + 1) : 0;
-    for (int g0 = 0; g0 < nblk; g0 += 8) {
-        const int gblk = min(8, nblk - g0);                      // 16-token blocks this group
-        const int gbase = (first_blk + g0) * 16;                 // global token of column 0
-
-        // QK: warp w owns physical block (first_blk+g0+w); S columns [w*16,+16) = that block's tokens.
-        if (warp < gblk) {
-            const int pb = block_table[seq * max_blocks + first_blk + g0 + warp];
-            const __nv_bfloat16* kb = k_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM;
-            fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
-            fragment<matrix_b, 16, 16, 16, __nv_bfloat16, col_major> bf;   // col_major => Kᵀ
-            fragment<accumulator, 16, 16, 16, float> cf;
-            fill_fragment(cf, 0.f);
-            #pragma unroll
-            for (int ks = 0; ks < KH; ks++) {
-                load_matrix_sync(af, s_q + ks * 16, HEAD_DIM);
-                load_matrix_sync(bf, kb + ks * 16, KVLD);
-                mma_sync(cf, af, bf, cf);
-            }
-            store_matrix_sync(s_s + warp * 16, cf, HEAD_DIM, mem_row_major);
-        }
-        __syncthreads();
-
-        // Online softmax. Column t -> global token gbase+t; valid iff in [start,end).
-        #pragma unroll
-        for (int rr = 0; rr < 2; rr++) {
-            const int r = warp * 2 + rr;
-            float mx = -1e30f;
-            for (int t = lane; t < gblk * 16; t += 32) {
-                const int gtok = gbase + t;
-                if (gtok >= start && gtok < end) mx = fmaxf(mx, s_s[r * HEAD_DIM + t] * scale);
-            }
-            #pragma unroll
-            for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffff, mx, o));
-            const float m_old = s_m[r], m_new = fmaxf(m_old, mx), corr = __expf(m_old - m_new);
-            float sum = 0.f;
-            for (int t = lane; t < 128; t += 32) {
-                float p = 0.f;
-                const int gtok = gbase + t;
-                if (t < gblk * 16 && gtok >= start && gtok < end) { p = __expf(s_s[r * HEAD_DIM + t] * scale - m_new); sum += p; }
-                s_p[r * HEAD_DIM + t] = __float2bfloat16(p);
-            }
-            #pragma unroll
-            for (int o = 16; o > 0; o >>= 1) sum += __shfl_xor_sync(0xffffffff, sum, o);
-            if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; }
-            for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
-        }
-        __syncthreads();
-
-        // PV: warp w computes O[16 x 16] for head cols [warp*16,+16), K over the group's blocks.
-        {
-            fragment<accumulator, 16, 16, 16, float> cf;
-            fill_fragment(cf, 0.f);
-            for (int ks = 0; ks < gblk; ks++) {
-                const int pb = block_table[seq * max_blocks + first_blk + g0 + ks];
-                const __nv_bfloat16* vb = v_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM + warp * 16;
-                fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
-                fragment<matrix_b, 16, 16, 16, __nv_bfloat16, row_major> bf;
-                load_matrix_sync(af, s_p + ks * 16, HEAD_DIM);
-                load_matrix_sync(bf, vb, KVLD);
-                mma_sync(cf, af, bf, cf);
-            }
-            store_matrix_sync(s_s + warp * 16, cf, HEAD_DIM, mem_row_major);
-        }
-        __syncthreads();
-        for (int i = tid; i < 16 * HEAD_DIM; i += blockDim.x) s_o[i] += s_s[i];
-        __syncthreads();
-    }
-
-    for (int r = 0; r < GQA; r++) {
-        const int qh  = kvh * GQA + r;
-        const int idx = (seq * num_q_heads + qh) * n_splits + split;
-        if (tid == 0) { part_m[idx] = s_m[r]; part_l[idx] = s_l[r]; }
-        for (int c = tid; c < HEAD_DIM; c += blockDim.x)
-            part_acc[(size_t)idx * HEAD_DIM + c] = s_o[r * HEAD_DIM + c];
-    }
-}
-template __global__ void fa_split_gqa_mma_kernel<128, 8>(const __nv_bfloat16*, const __nv_bfloat16*,
-    const __nv_bfloat16*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
-
-// int8 variant: K/V are int8 with one fp16 scale per (token, kv_head) head vector. Q is quantized
-// per-q-head and P (with the per-token V scale folded in) per-row, so QK and PV run on int8 tensor
-// cores (int32 accumulate); the per-token/per-head fp16 scales are applied to the int32 results.
-// Halves the KV global read (the bottleneck) and uses 2x-throughput int8 tensor cores.
+// Tensor-core (wmma int8) GQA flash-decode split for long context. The 8 GQA q-heads of a kv-head are
+// the batch (M) dim, so S = Q·Kᵀ and O = P·V become small matmuls on the tensor cores, replacing the
+// per-lane FMA + 5-shuffle fa_wsum reduction that dominates the scalar kernel at long context. K/V are
+// int8 with one fp16 scale per (token, kv_head) head vector. Q is quantized per-q-head and P (with the
+// per-token V scale folded in) per-row, so QK and PV run on int8 tensor cores (int32 accumulate); the
+// per-token/per-head fp16 scales are applied to the int32 results. This halves the KV global read (the
+// bottleneck) and uses 2x-throughput int8 tensor cores. M is padded 8->16; partials (m,l,acc) stay
+// byte-compatible with the combine kernel. sm_80+ (wmma). One block per (seq, kv_head, split); 8 warps.
 template <int HEAD_DIM, int GQA>
 __global__ void fa_split_gqa_mma_i8_kernel(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
@@ -619,16 +492,17 @@ void launch_flash_decode_split(
         fagqa = e ? ((e[0] == '0') ? 0 : 1) : -2;   // -2 = auto: long-context only
     }
     const bool use_gqa = (fagqa == 1) || (fagqa == -2 && n_splits >= 32);
-    // Tensor-core (wmma bf16) GQA split (SPARKINFER_FAMMA, default on): the 8 GQA q-heads become the
-    // mma M dim, moving the QK/PV dot + reduction onto the tensor cores. The kernel reads each 16-token
-    // physical block's fragments straight from the paged pool, so it is only exact when every split's
-    // chunk is a multiple of block_size (16) — enabled only then; other contexts use the scalar kernel.
+    // Tensor-core (wmma int8) GQA split (SPARKINFER_FAMMA, default on): the 8 GQA q-heads become the
+    // mma M dim, moving the QK/PV dot + reduction onto the int8 tensor cores while halving the KV read.
+    // The kernel reads each 16-token physical block's fragments straight from the paged pool, so it is
+    // only exact when every split's chunk is a multiple of block_size (16), and it needs the int8 cache;
+    // otherwise the scalar split runs. bf16 (int8 off) always uses the scalar path (== main).
     static int famma = -1;
     if (famma < 0) { const char* e = getenv("SPARKINFER_FAMMA"); famma = (e && e[0] == '0') ? 0 : 1; }
     // Long-context regime only: requires block_size==16 (each warp maps to one physical block) AND a
     // large-enough per-split chunk (>=2 physical blocks). At tiny chunks the GQA-shared mma has too
     // few blocks/warps to fill the GPU and loses to the high-occupancy scalar split; those short
-    // contexts use the scalar (int8-dequant) path. Robust to any chunk (partial blocks masked).
+    // contexts use the scalar path. Robust to any chunk (partial blocks masked).
     const int mma_chunk = (n_splits > 0) ? (seqlen + n_splits - 1) / n_splits : 0;
     const bool mma_aligned = famma && seqlen > 512 && block_size == 16 && mma_chunk >= 32;
     const __half* ksc = reinterpret_cast<const __half*>(k_scale);
@@ -636,7 +510,7 @@ void launch_flash_decode_split(
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
         constexpr int GQA = 8, TILE = FA_GQA_TILE;
         dim3 gq(num_kv_heads * n_splits, num_seqs);
-        if (mma_aligned && int8_kv) {   // int8 tensor-core (halved KV read)
+        if (mma_aligned && int8_kv) {   // int8 tensor-core (halved KV read) — the long-context win
             const size_t i8_smem = (size_t)2 * 16 * 128 * sizeof(signed char)
                                  + (size_t)2 * 16 * 128 * sizeof(float)
                                  + (size_t)(16 + 16 + 128 + 128 + 16 + 16) * sizeof(float);
@@ -645,19 +519,21 @@ void launch_flash_decode_split(
                 reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
                 part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                 ksc, vsc);
-        } else if (mma_aligned) {   // bf16 tensor-core; block-aligned chunks (paged-fragment loads exact)
-            constexpr size_t mma_smem = (size_t)(16 + 16) * 128 * sizeof(__nv_bfloat16)
-                                      + (size_t)(16 + 16) * 128 * sizeof(float) + 32 * sizeof(float);
-            fa_split_gqa_mma_kernel<128, GQA><<<gq, GQA * 32, mma_smem, stream>>>(
-                reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
-                reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
-                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
         } else {
-        size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
-        fa_split_gqa_kernel<128, GQA, TILE><<<gq, GQA * 32, smem, stream>>>(
-            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
-            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
-            ksc, vsc, int8_kv);
+            // Scalar split. The bf16 instantiation is byte-identical to the pre-int8 (main) kernel, so the
+            // guard contexts (128/512/4k, int8 off) match main exactly; the int8 instantiation serves the
+            // forced-int8 short/unaligned path (accuracy gate) and never touches the bf16 codegen.
+            const size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
+            if (int8_kv)
+                fa_split_gqa_kernel<128, GQA, TILE, true><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    ksc, vsc);
+            else
+                fa_split_gqa_kernel<128, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    ksc, vsc);
         }
         fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
                                    num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);

--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -12,6 +12,7 @@
 // One warp per block; head_dim=128 (Qwen3). Portable CUDA — sm_89 .. sm_120/121.
 
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #endif
@@ -26,13 +27,15 @@ __device__ __forceinline__ float fa_wsum(float v) {
     return v;
 }
 
+// int8_kv: k_pool/v_pool hold int8 and k_scale/v_scale one __half per (token, kv_head) head vector.
 template <int HEAD_DIM>
 __global__ void fa_split_kernel(
-    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
-    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    const __nv_bfloat16* __restrict__ q, const void* __restrict__ k_pool,
+    const void* __restrict__ v_pool, const int* __restrict__ block_table,
     const int* __restrict__ seq_lens,
     float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
-    float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits
+    float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits,
+    const __half* __restrict__ k_scale, const __half* __restrict__ v_scale, int int8_kv
 ) {
     constexpr int ELEMS = HEAD_DIM / 32;
     const int seq   = blockIdx.y;
@@ -40,6 +43,10 @@ __global__ void fa_split_kernel(
     const int qh    = blockIdx.x / n_splits;
     const int lane  = threadIdx.x;
     const int kvh   = qh / (num_q_heads / num_kv_heads);
+    const __nv_bfloat16* kb = reinterpret_cast<const __nv_bfloat16*>(k_pool);
+    const __nv_bfloat16* vb = reinterpret_cast<const __nv_bfloat16*>(v_pool);
+    const signed char* ki = reinterpret_cast<const signed char*>(k_pool);
+    const signed char* vi = reinterpret_cast<const signed char*>(v_pool);
 
     float qr[ELEMS];
     const __nv_bfloat16* qp = q + (size_t)(seq * num_q_heads + qh) * HEAD_DIM;
@@ -59,14 +66,18 @@ __global__ void fa_split_kernel(
         const int blk = t / block_size, within = t % block_size;
         const int phys = block_table[seq * max_blocks + blk];
         const size_t base = ((size_t)(phys * block_size + within) * num_kv_heads + kvh) * HEAD_DIM;
+        const float ks = int8_kv ? __half2float(k_scale[base / HEAD_DIM]) : 0.f;
+        const float vs = int8_kv ? __half2float(v_scale[base / HEAD_DIM]) : 0.f;
         float p = 0.f;
         #pragma unroll
-        for (int e = 0; e < ELEMS; e++) p += qr[e] * fa_to_f(k_pool[base + lane + e * 32]);
+        for (int e = 0; e < ELEMS; e++)
+            p += qr[e] * (int8_kv ? (float)ki[base + lane + e * 32] * ks : fa_to_f(kb[base + lane + e * 32]));
         const float score = fa_wsum(p) * scale;
         const float mn = fmaxf(m, score), corr = __expf(m - mn), pe = __expf(score - mn);
         l = l * corr + pe;
         #pragma unroll
-        for (int e = 0; e < ELEMS; e++) acc[e] = acc[e] * corr + pe * fa_to_f(v_pool[base + lane + e * 32]);
+        for (int e = 0; e < ELEMS; e++)
+            acc[e] = acc[e] * corr + pe * (int8_kv ? (float)vi[base + lane + e * 32] * vs : fa_to_f(vb[base + lane + e * 32]));
         m = mn;
     }
 
@@ -83,11 +94,12 @@ __global__ void fa_split_kernel(
 // partials consumed by the existing combine kernel.
 template <int HEAD_DIM, int GQA, int TILE>
 __global__ void fa_split_gqa_kernel(
-    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
-    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    const __nv_bfloat16* __restrict__ q, const void* __restrict__ k_pool,
+    const void* __restrict__ v_pool, const int* __restrict__ block_table,
     const int* __restrict__ seq_lens,
     float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
-    float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits
+    float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits,
+    const __half* __restrict__ k_scale, const __half* __restrict__ v_scale, int int8_kv
 ) {
     constexpr int ELEMS = HEAD_DIM / 32;
     const int seq   = blockIdx.y;
@@ -127,12 +139,35 @@ __global__ void fa_split_gqa_kernel(
             s_rowbase[threadIdx.x] = ((size_t)(phys * block_size + wb) * num_kv_heads + kvh) * HEAD_DIM;
         }
         __syncthreads();
-        // Vectorized load: uint4 (8×bf16) via __ldg into bf16 smem.
-        for (int i = threadIdx.x * 8; i < valid * HEAD_DIM; i += blockDim.x * 8) {
-            const int within = i / HEAD_DIM, d = i % HEAD_DIM;
-            const size_t base = s_rowbase[within] + d;
-            *reinterpret_cast<uint4*>(s_k + i) = __ldg(reinterpret_cast<const uint4*>(k_pool + base));
-            *reinterpret_cast<uint4*>(s_v + i) = __ldg(reinterpret_cast<const uint4*>(v_pool + base));
+        if (!int8_kv) {
+            // Vectorized load: uint4 (8×bf16) via __ldg into bf16 smem.
+            const __nv_bfloat16* kb = reinterpret_cast<const __nv_bfloat16*>(k_pool);
+            const __nv_bfloat16* vb = reinterpret_cast<const __nv_bfloat16*>(v_pool);
+            for (int i = threadIdx.x * 8; i < valid * HEAD_DIM; i += blockDim.x * 8) {
+                const int within = i / HEAD_DIM, d = i % HEAD_DIM;
+                const size_t base = s_rowbase[within] + d;
+                *reinterpret_cast<uint4*>(s_k + i) = __ldg(reinterpret_cast<const uint4*>(kb + base));
+                *reinterpret_cast<uint4*>(s_v + i) = __ldg(reinterpret_cast<const uint4*>(vb + base));
+            }
+        } else {
+            // int8: load 8 int8 (int2) + per-token scale, dequant to bf16 into smem (dot loop unchanged).
+            const signed char* ki = reinterpret_cast<const signed char*>(k_pool);
+            const signed char* vi = reinterpret_cast<const signed char*>(v_pool);
+            for (int i = threadIdx.x * 8; i < valid * HEAD_DIM; i += blockDim.x * 8) {
+                const int within = i / HEAD_DIM, d = i % HEAD_DIM;
+                const size_t base = s_rowbase[within] + d;
+                const float ks = __half2float(k_scale[s_rowbase[within] / HEAD_DIM]);
+                const float vs = __half2float(v_scale[s_rowbase[within] / HEAD_DIM]);
+                const int2 kr = __ldg(reinterpret_cast<const int2*>(ki + base));
+                const int2 vr = __ldg(reinterpret_cast<const int2*>(vi + base));
+                const signed char* kc = reinterpret_cast<const signed char*>(&kr);
+                const signed char* vc = reinterpret_cast<const signed char*>(&vr);
+                #pragma unroll
+                for (int j = 0; j < 8; j++) {
+                    s_k[i + j] = __float2bfloat16((float)kc[j] * ks);
+                    s_v[i + j] = __float2bfloat16((float)vc[j] * vs);
+                }
+            }
         }
         __syncthreads();
         for (int tt = 0; tt < valid; tt++) {
@@ -243,10 +278,10 @@ __global__ void fa_combine_kernel(
 #ifndef FA_GQA_TILE
 #define FA_GQA_TILE 14      // bf16 smem + uint4 ldg sweet spot at n_splits=128
 #endif
-template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
-    const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
-template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
-    const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
+template __global__ void fa_split_kernel<128>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
+template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
@@ -389,6 +424,164 @@ __global__ void fa_split_gqa_mma_kernel(
 template __global__ void fa_split_gqa_mma_kernel<128, 8>(const __nv_bfloat16*, const __nv_bfloat16*,
     const __nv_bfloat16*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int);
 
+// int8 variant: K/V are int8 with one fp16 scale per (token, kv_head) head vector. Q is quantized
+// per-q-head and P (with the per-token V scale folded in) per-row, so QK and PV run on int8 tensor
+// cores (int32 accumulate); the per-token/per-head fp16 scales are applied to the int32 results.
+// Halves the KV global read (the bottleneck) and uses 2x-throughput int8 tensor cores.
+template <int HEAD_DIM, int GQA>
+__global__ void fa_split_gqa_mma_i8_kernel(
+    const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
+    const signed char* __restrict__ v_pool, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens,
+    float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
+    float scale, int num_q_heads, int num_kv_heads, int block_size, int max_blocks, int n_splits,
+    const __half* __restrict__ k_scale, const __half* __restrict__ v_scale
+) {
+    using namespace nvcuda::wmma;
+    constexpr int KH = HEAD_DIM / 16;
+    const int seq = blockIdx.y, split = blockIdx.x % n_splits, kvh = blockIdx.x / n_splits;
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31, tid = threadIdx.x;
+    const int sl = seq_lens[seq];
+    const int chunk = (sl + n_splits - 1) / n_splits;
+    const int start = split * chunk, end = min(sl, start + chunk);
+    const size_t KVLD = (size_t)num_kv_heads * HEAD_DIM;   // int8 token stride in the pool
+    const int SLD = num_kv_heads;                          // scale stride (one per token, kv_head)
+
+    extern __shared__ char i8smem[];
+    signed char* s_qi = reinterpret_cast<signed char*>(i8smem);       // [16][HD] quantized Q
+    signed char* s_pi = s_qi + 16 * HEAD_DIM;                         // [16][HD] quantized P'
+    float* s_s  = reinterpret_cast<float*>(s_pi + 16 * HEAD_DIM);     // [16][HD] scores / int32 mma scratch
+    float* s_o  = s_s + 16 * HEAD_DIM;                                // [16][HD] running O
+    float* s_qs = s_o + 16 * HEAD_DIM;                                // [16] Q scale
+    float* s_ps = s_qs + 16;                                          // [16] P' row scale
+    float* s_ks = s_ps + 16;                                          // [128] group K scales
+    float* s_vs = s_ks + 128;                                         // [128] group V scales
+    float* s_m  = s_vs + 128;                                         // [16]
+    float* s_l  = s_m + 16;                                           // [16]
+
+    // Quantize Q per q-head row (warp w owns rows 2w, 2w+1; rows >= GQA are zero pad).
+    #pragma unroll
+    for (int rr = 0; rr < 2; rr++) {
+        const int r = warp * 2 + rr;
+        float qv[4], amax = 0.f;
+        #pragma unroll
+        for (int e = 0; e < 4; e++) {
+            qv[e] = (r < GQA) ? __bfloat162float(q[(size_t)(seq * num_q_heads + kvh * GQA + r) * HEAD_DIM + lane + e * 32]) : 0.f;
+            amax = fmaxf(amax, fabsf(qv[e]));
+        }
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
+        const float d = amax / 127.0f;
+        if (lane == 0) s_qs[r] = d;
+        #pragma unroll
+        for (int e = 0; e < 4; e++)
+            s_qi[r * HEAD_DIM + lane + e * 32] = (signed char)((amax == 0.f) ? 0 : (int)roundf(qv[e] / d));
+    }
+    for (int i = tid; i < 16 * HEAD_DIM; i += blockDim.x) s_o[i] = 0.f;
+    if (tid < 16) { s_m[tid] = -1e30f; s_l[tid] = 0.f; }
+    __syncthreads();
+
+    const int first_blk = start / 16;
+    const int nblk = (end > start) ? ((end - 1) / 16 - first_blk + 1) : 0;
+    for (int g0 = 0; g0 < nblk; g0 += 8) {
+        const int gblk = min(8, nblk - g0);
+        const int gbase = (first_blk + g0) * 16;
+        for (int j = tid; j < gblk * 16; j += blockDim.x) {   // stage per-token K/V scales for the group
+            const int lb = first_blk + g0 + j / 16, within = j & 15;
+            const int pb = block_table[seq * max_blocks + lb];
+            const size_t si = (size_t)(pb * 16 + within) * SLD + kvh;
+            s_ks[j] = __half2float(k_scale[si]);
+            s_vs[j] = __half2float(v_scale[si]);
+        }
+        __syncthreads();
+
+        // QK int8 mma -> int32; scale to float scores in s_s.
+        if (warp < gblk) {
+            const int pb = block_table[seq * max_blocks + first_blk + g0 + warp];
+            const signed char* kb = k_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM;
+            fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
+            fragment<matrix_b, 16, 16, 16, signed char, col_major> bf;
+            fragment<accumulator, 16, 16, 16, int> cf;
+            fill_fragment(cf, 0);
+            #pragma unroll
+            for (int ks = 0; ks < KH; ks++) {
+                load_matrix_sync(af, s_qi + ks * 16, HEAD_DIM);
+                load_matrix_sync(bf, kb + ks * 16, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, HEAD_DIM, mem_row_major);
+        }
+        __syncthreads();
+        for (int i = tid; i < 16 * 128; i += blockDim.x) {
+            const int m = i >> 7, col = i & 127;
+            if (col < gblk * 16) s_s[i] = (float)reinterpret_cast<int*>(s_s)[i] * s_qs[m] * s_ks[col];
+        }
+        __syncthreads();
+
+        // Online softmax; fold V scale into P', quantize P' per-row into s_pi.
+        #pragma unroll
+        for (int rr = 0; rr < 2; rr++) {
+            const int r = warp * 2 + rr;
+            float mx = -1e30f;
+            for (int t = lane; t < gblk * 16; t += 32) {
+                const int gtok = gbase + t;
+                if (gtok >= start && gtok < end) mx = fmaxf(mx, s_s[r * 128 + t] * scale);
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffff, mx, o));
+            const float m_old = s_m[r], m_new = fmaxf(m_old, mx), corr = __expf(m_old - m_new);
+            float sum = 0.f, pamax = 0.f;
+            for (int t = lane; t < 128; t += 32) {
+                float pv = 0.f;
+                const int gtok = gbase + t;
+                if (t < gblk * 16 && gtok >= start && gtok < end) {
+                    const float p = __expf(s_s[r * 128 + t] * scale - m_new);
+                    sum += p; pv = p * s_vs[t]; pamax = fmaxf(pamax, fabsf(pv));
+                }
+                s_s[r * 128 + t] = pv;   // stash P' (score no longer needed for this row)
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) { sum += __shfl_xor_sync(0xffffffff, sum, o); pamax = fmaxf(pamax, __shfl_xor_sync(0xffffffff, pamax, o)); }
+            const float pd = pamax / 127.0f;
+            if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; s_ps[r] = pd; }
+            for (int t = lane; t < 128; t += 32)
+                s_pi[r * 128 + t] = (signed char)((pamax == 0.f) ? 0 : (int)roundf(s_s[r * 128 + t] / pd));
+            for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
+        }
+        __syncthreads();
+
+        // PV int8 mma -> int32; O += int32 * p_scale[m].
+        {
+            fragment<accumulator, 16, 16, 16, int> cf;
+            fill_fragment(cf, 0);
+            for (int ks = 0; ks < gblk; ks++) {
+                const int pb = block_table[seq * max_blocks + first_blk + g0 + ks];
+                const signed char* vb = v_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM + warp * 16;
+                fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
+                fragment<matrix_b, 16, 16, 16, signed char, row_major> bf;
+                load_matrix_sync(af, s_pi + ks * 16, HEAD_DIM);
+                load_matrix_sync(bf, vb, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, HEAD_DIM, mem_row_major);
+        }
+        __syncthreads();
+        for (int i = tid; i < 16 * 128; i += blockDim.x) s_o[i] += (float)reinterpret_cast<int*>(s_s)[i] * s_ps[i >> 7];
+        __syncthreads();
+    }
+
+    for (int r = 0; r < GQA; r++) {
+        const int qh = kvh * GQA + r;
+        const int idx = (seq * num_q_heads + qh) * n_splits + split;
+        if (tid == 0) { part_m[idx] = s_m[r]; part_l[idx] = s_l[r]; }
+        for (int c = tid; c < HEAD_DIM; c += blockDim.x)
+            part_acc[(size_t)idx * HEAD_DIM + c] = s_o[r * HEAD_DIM + c];
+    }
+}
+template __global__ void fa_split_gqa_mma_i8_kernel<128, 8>(const __nv_bfloat16*, const signed char*,
+    const signed char*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int,
+    const __half*, const __half*);
+
 template <int NW>
 static inline void fa_launch_combine(
     const float* part_m, const float* part_l, const float* part_acc,
@@ -416,7 +609,7 @@ void launch_flash_decode_split(
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
-    void* out_q8, int seqlen
+    void* out_q8, int seqlen, const void* k_scale, const void* v_scale, int int8_kv
 ) {
     static int fagqa = -1;
     if (fagqa < 0) {
@@ -433,18 +626,23 @@ void launch_flash_decode_split(
     // Long-context regime only (attention is a small fraction of short-context decode); requires
     // block_size==16 (each warp maps to one physical block). Robust to any chunk (partial blocks masked).
     const bool mma_aligned = famma && seqlen > 512 && block_size == 16;
+    const __half* ksc = reinterpret_cast<const __half*>(k_scale);
+    const __half* vsc = reinterpret_cast<const __half*>(v_scale);
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
         constexpr int GQA = 8, TILE = FA_GQA_TILE;
         dim3 gq(num_kv_heads * n_splits, num_seqs);
-        if (mma_aligned) {   // block-aligned chunks only (paged-fragment loads are exact)
+        if (mma_aligned && int8_kv) {   // int8 tensor-core (halved KV read)
+            const size_t i8_smem = (size_t)2 * 16 * 128 * sizeof(signed char)
+                                 + (size_t)2 * 16 * 128 * sizeof(float)
+                                 + (size_t)(16 + 16 + 128 + 128 + 16 + 16) * sizeof(float);
+            fa_split_gqa_mma_i8_kernel<128, GQA><<<gq, GQA * 32, i8_smem, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const signed char*>(k_pool),
+                reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                ksc, vsc);
+        } else if (mma_aligned) {   // bf16 tensor-core; block-aligned chunks (paged-fragment loads exact)
             constexpr size_t mma_smem = (size_t)(16 + 16) * 128 * sizeof(__nv_bfloat16)
                                       + (size_t)(16 + 16) * 128 * sizeof(float) + 32 * sizeof(float);
-            static bool set_attr = false;
-            if (!set_attr) {
-                cudaFuncSetAttribute(fa_split_gqa_mma_kernel<128, GQA>,
-                                     cudaFuncAttributeMaxDynamicSharedMemorySize, (int)mma_smem);
-                set_attr = true;
-            }
             fa_split_gqa_mma_kernel<128, GQA><<<gq, GQA * 32, mma_smem, stream>>>(
                 reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
                 reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
@@ -452,9 +650,9 @@ void launch_flash_decode_split(
         } else {
         size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
         fa_split_gqa_kernel<128, GQA, TILE><<<gq, GQA * 32, smem, stream>>>(
-            reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
-            reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
-            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
+            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+            ksc, vsc, int8_kv);
         }
         fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
                                    num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
@@ -463,9 +661,9 @@ void launch_flash_decode_split(
     }
     dim3 g1(num_q_heads * n_splits, num_seqs);
     fa_split_kernel<128><<<g1, 32, 0, stream>>>(
-        reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
-        reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table, seq_lens,
-        part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits);
+        reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+        part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+        ksc, vsc, int8_kv);
     fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
                                num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
     (void)head_dim;

--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -9,6 +9,7 @@
 // Portable CUDA — runs on sm_89 .. sm_120 (RTX 5090).
 
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #endif
@@ -127,10 +128,13 @@ __global__ void rope_kv_append_kernel(
 // The normed head is staged in shared so RoPE can pair element i with i+half. The roped/normed
 // q,k are value-identical to rmsnorm_qk followed by rope_kv_append (same per-head RMS, same
 // bf16 rounding, same rope angle); the cached V is identical to kv_append. positions == write_pos.
+// int8_kv: k_pool/v_pool hold signed int8 and k_scale/v_scale one __half per (token slot, kv_head)
+// head vector (per-token max-abs quant). int8_kv==0 is byte-identical bf16.
 __global__ void qknorm_rope_kv_kernel(
     __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
-    __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    void* __restrict__ k_pool, void* __restrict__ v_pool,
+    __half* __restrict__ k_scale, __half* __restrict__ v_scale, int int8_kv,
     const int* __restrict__ block_table, const int* __restrict__ positions,
     int n_q_heads, int n_kv_heads, int head_dim, float theta,
     int block_size, int max_blocks_per_seq, float eps
@@ -142,13 +146,28 @@ __global__ void qknorm_rope_kv_kernel(
     const int pos  = positions[tok];
     const int blk = pos / block_size, within = pos % block_size;
     const size_t ctok = (size_t)((size_t)block_table[tok * max_blocks_per_seq + blk] * block_size + within);
+    __shared__ float s_red[32];                    // warp-partials for block reductions
 
     const bool is_v = (b >= n_q_heads + n_kv_heads);
     if (is_v) {                                    // V: copy head straight to the cache (no norm/rope)
         const int hh = b - n_q_heads - n_kv_heads;
         const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
-        v_pool[dst + t] = v[base + t];
+        if (!int8_kv) { reinterpret_cast<__nv_bfloat16*>(v_pool)[dst + t] = v[base + t]; return; }
+        const float val = __bfloat162float(v[base + t]);   // per-token max-abs int8 quant over head_dim
+        float amax = fabsf(val);
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
+        if ((t & 31) == 0) s_red[t >> 5] = amax;
+        __syncthreads();
+        if (t < 32) { float a = (t < (head_dim + 31) / 32) ? s_red[t] : 0.f;
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffff, a, m));
+            if (t == 0) s_red[0] = a; }
+        __syncthreads();
+        const float d = s_red[0] / 127.0f;
+        reinterpret_cast<signed char*>(v_pool)[dst + t] = (signed char)((s_red[0] == 0.f) ? 0 : (int)roundf(val / d));
+        if (t == 0) v_scale[ctok * n_kv_heads + hh] = __float2half(d);
         return;
     }
 
@@ -179,18 +198,37 @@ __global__ void qknorm_rope_kv_kernel(
     __syncthreads();
 
     // RoPE (HF rotate-half): pair (i, i+half). Threads [0,half) own a pair and write both halves.
+    float o0 = 0.f, o1 = 0.f;
     if (t < half) {
         const float freq = __powf(theta, -2.f * (float)t / (float)head_dim);
         const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
         const float x0 = s_h[t], x1 = s_h[t + half];
-        const __nv_bfloat16 o0 = __float2bfloat16(x0 * c - x1 * s);
-        const __nv_bfloat16 o1 = __float2bfloat16(x1 * c + x0 * s);
-        if (is_q) {                                // Q: rope in place
-            q[base + t] = o0; q[base + t + half] = o1;
-        } else {                                   // K: rope straight into the paged cache
+        o0 = __bfloat162float(__float2bfloat16(x0 * c - x1 * s));   // bf16-rounded (matches bf16 path)
+        o1 = __bfloat162float(__float2bfloat16(x1 * c + x0 * s));
+        if (is_q) { q[base + t] = __float2bfloat16(o0); q[base + t + half] = __float2bfloat16(o1); }
+        else if (!int8_kv) {
             const size_t dst = (ctok * n_kv_heads + head) * head_dim;
-            k_pool[dst + t] = o0; k_pool[dst + t + half] = o1;
+            reinterpret_cast<__nv_bfloat16*>(k_pool)[dst + t] = __float2bfloat16(o0);
+            reinterpret_cast<__nv_bfloat16*>(k_pool)[dst + t + half] = __float2bfloat16(o1);
         }
+    }
+    if (!is_q && int8_kv) {                        // K int8: per-token max-abs over all head_dim
+        float amax = fmaxf(fabsf(o0), fabsf(o1));  // thread t<half holds dims t and t+half
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
+        if ((t & 31) == 0 && t < half) s_red[t >> 5] = amax;
+        __syncthreads();
+        if (t == 0) { float a = 0.f; const int nw = half / 32;
+            for (int i = 0; i < nw; i++) a = fmaxf(a, s_red[i]); s_red[0] = a; }
+        __syncthreads();
+        const float d = s_red[0] / 127.0f;
+        if (t < half) {
+            const size_t dst = (ctok * n_kv_heads + head) * head_dim;
+            signed char* kp = reinterpret_cast<signed char*>(k_pool);
+            kp[dst + t]        = (signed char)((s_red[0] == 0.f) ? 0 : (int)roundf(o0 / d));
+            kp[dst + t + half] = (signed char)((s_red[0] == 0.f) ? 0 : (int)roundf(o1 / d));
+        }
+        if (t == 0) k_scale[ctok * n_kv_heads + head] = __float2half(d);
     }
 }
 
@@ -206,14 +244,15 @@ void launch_qknorm_rope_kv_append(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
     void* k_pool, void* v_pool, const int* block_table, const int* positions,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, float theta,
-    float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream
+    float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream,
+    void* k_scale, void* v_scale, int int8_kv
 ) {
     dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
     qknorm_rope_kv_kernel<<<grid, head_dim, head_dim * sizeof(float), stream>>>(
         reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
         reinterpret_cast<const __nv_bfloat16*>(v),
         reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
-        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        k_pool, v_pool, reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale), int8_kv,
         block_table, positions, n_q_heads, n_kv_heads, head_dim, theta,
         block_size, max_blocks_per_seq, eps);
 }

--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -130,11 +130,12 @@ __global__ void rope_kv_append_kernel(
 // bf16 rounding, same rope angle); the cached V is identical to kv_append. positions == write_pos.
 // int8_kv: k_pool/v_pool hold signed int8 and k_scale/v_scale one __half per (token slot, kv_head)
 // head vector (per-token max-abs quant). int8_kv==0 is byte-identical bf16.
+template <bool INT8>
 __global__ void qknorm_rope_kv_kernel(
     __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
     void* __restrict__ k_pool, void* __restrict__ v_pool,
-    __half* __restrict__ k_scale, __half* __restrict__ v_scale, int int8_kv,
+    __half* __restrict__ k_scale, __half* __restrict__ v_scale,
     const int* __restrict__ block_table, const int* __restrict__ positions,
     int n_q_heads, int n_kv_heads, int head_dim, float theta,
     int block_size, int max_blocks_per_seq, float eps
@@ -153,21 +154,25 @@ __global__ void qknorm_rope_kv_kernel(
         const int hh = b - n_q_heads - n_kv_heads;
         const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
-        if (!int8_kv) { reinterpret_cast<__nv_bfloat16*>(v_pool)[dst + t] = v[base + t]; return; }
-        const float val = __bfloat162float(v[base + t]);   // per-token max-abs int8 quant over head_dim
-        float amax = fabsf(val);
-        #pragma unroll
-        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
-        if ((t & 31) == 0) s_red[t >> 5] = amax;
-        __syncthreads();
-        if (t < 32) { float a = (t < (head_dim + 31) / 32) ? s_red[t] : 0.f;
+        if constexpr (!INT8) {                         // bf16: straight copy — byte-identical to main
+            __nv_bfloat16* __restrict__ vp = reinterpret_cast<__nv_bfloat16*>(v_pool);
+            vp[dst + t] = v[base + t];
+        } else {
+            const float val = __bfloat162float(v[base + t]);   // per-token max-abs int8 quant over head_dim
+            float amax = fabsf(val);
             #pragma unroll
-            for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffff, a, m));
-            if (t == 0) s_red[0] = a; }
-        __syncthreads();
-        const float d = s_red[0] / 127.0f;
-        reinterpret_cast<signed char*>(v_pool)[dst + t] = (signed char)((s_red[0] == 0.f) ? 0 : (int)roundf(val / d));
-        if (t == 0) v_scale[ctok * n_kv_heads + hh] = __float2half(d);
+            for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
+            if ((t & 31) == 0) s_red[t >> 5] = amax;
+            __syncthreads();
+            if (t < 32) { float a = (t < (head_dim + 31) / 32) ? s_red[t] : 0.f;
+                #pragma unroll
+                for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffff, a, m));
+                if (t == 0) s_red[0] = a; }
+            __syncthreads();
+            const float d = s_red[0] / 127.0f;
+            reinterpret_cast<signed char*>(v_pool)[dst + t] = (signed char)((s_red[0] == 0.f) ? 0 : (int)roundf(val / d));
+            if (t == 0) v_scale[ctok * n_kv_heads + hh] = __float2half(d);
+        }
         return;
     }
 
@@ -206,13 +211,14 @@ __global__ void qknorm_rope_kv_kernel(
         o0 = __bfloat162float(__float2bfloat16(x0 * c - x1 * s));   // bf16-rounded (matches bf16 path)
         o1 = __bfloat162float(__float2bfloat16(x1 * c + x0 * s));
         if (is_q) { q[base + t] = __float2bfloat16(o0); q[base + t + half] = __float2bfloat16(o1); }
-        else if (!int8_kv) {
+        else if constexpr (!INT8) {                    // bf16 K write — byte-identical to main
             const size_t dst = (ctok * n_kv_heads + head) * head_dim;
-            reinterpret_cast<__nv_bfloat16*>(k_pool)[dst + t] = __float2bfloat16(o0);
-            reinterpret_cast<__nv_bfloat16*>(k_pool)[dst + t + half] = __float2bfloat16(o1);
+            __nv_bfloat16* __restrict__ kp = reinterpret_cast<__nv_bfloat16*>(k_pool);
+            kp[dst + t] = __float2bfloat16(o0);
+            kp[dst + t + half] = __float2bfloat16(o1);
         }
     }
-    if (!is_q && int8_kv) {                        // K int8: per-token max-abs over all head_dim
+    if constexpr (INT8) if (!is_q) {               // K int8: per-token max-abs over all head_dim
         float amax = fmaxf(fabsf(o0), fabsf(o1));  // thread t<half holds dims t and t+half
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
@@ -231,6 +237,12 @@ __global__ void qknorm_rope_kv_kernel(
         if (t == 0) k_scale[ctok * n_kv_heads + head] = __float2half(d);
     }
 }
+template __global__ void qknorm_rope_kv_kernel<false>(
+    __nv_bfloat16*, __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    void*, void*, __half*, __half*, const int*, const int*, int, int, int, float, int, int, float);
+template __global__ void qknorm_rope_kv_kernel<true>(
+    __nv_bfloat16*, __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    void*, void*, __half*, __half*, const int*, const int*, int, int, int, float, int, int, float);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -248,13 +260,24 @@ void launch_qknorm_rope_kv_append(
     void* k_scale, void* v_scale, int int8_kv
 ) {
     dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
-    qknorm_rope_kv_kernel<<<grid, head_dim, head_dim * sizeof(float), stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
-        reinterpret_cast<const __nv_bfloat16*>(v),
-        reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
-        k_pool, v_pool, reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale), int8_kv,
-        block_table, positions, n_q_heads, n_kv_heads, head_dim, theta,
-        block_size, max_blocks_per_seq, eps);
+    const int smem = head_dim * sizeof(float);
+    // int8 off (bf16) instantiates with no int8 code -> byte-identical to the pre-int8 (main) kernel.
+    if (int8_kv)
+        qknorm_rope_kv_kernel<true><<<grid, head_dim, smem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v),
+            reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+            k_pool, v_pool, reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+            block_table, positions, n_q_heads, n_kv_heads, head_dim, theta,
+            block_size, max_blocks_per_seq, eps);
+    else
+        qknorm_rope_kv_kernel<false><<<grid, head_dim, smem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v),
+            reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+            k_pool, v_pool, reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+            block_table, positions, n_q_heads, n_kv_heads, head_dim, theta,
+            block_size, max_blocks_per_seq, eps);
 }
 
 void launch_rope_kv_append(void* q, const void* k, const void* v, void* k_pool, void* v_pool,

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -34,7 +34,8 @@ void launch_qknorm_rope_kv_append(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
     void* k_pool, void* v_pool, const int* block_table, const int* positions,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, float theta,
-    float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr);
+    float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr,
+    void* k_scale = nullptr, void* v_scale = nullptr, int int8_kv = 0);
 
 // Fused RoPE + paged KV-append: ropes Q in place, ropes K straight into k_pool, copies V into
 // v_pool — one kernel replacing launch_rope + launch_kv_append. positions == write_pos (decode).
@@ -94,7 +95,8 @@ void launch_flash_decode_split(
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale,
-    cudaStream_t stream = nullptr, void* out_q8 = nullptr, int seqlen = -1);
+    cudaStream_t stream = nullptr, void* out_q8 = nullptr, int seqlen = -1,
+    const void* k_scale = nullptr, const void* v_scale = nullptr, int int8_kv = 0);
 
 // Flash decode for GLOBAL layers: full context, head_dim=512, GQA 8:1.
 // Two-phase dot product splits 512-dim head into two 256-dim halves.

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -94,7 +94,7 @@ void launch_flash_decode_split(
     float* part_m, float* part_l, float* part_acc,
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale,
-    cudaStream_t stream = nullptr, void* out_q8 = nullptr);
+    cudaStream_t stream = nullptr, void* out_q8 = nullptr, int seqlen = -1);
 
 // Flash decode for GLOBAL layers: full context, head_dim=512, GQA 8:1.
 // Two-phase dot product splits 512-dim head into two 256-dim halves.

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -65,7 +65,11 @@ int main(int argc, char** argv) {
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers=cfg.n_layers; kvc.num_kv_heads=cfg.n_kv_heads; kvc.head_dim=cfg.head_dim; kvc.block_size=16; kvc.int8_kv = !(getenv("SPARKINFER_KV_INT8") && getenv("SPARKINFER_KV_INT8")[0]=='0');
+    kvc.num_layers=cfg.n_layers; kvc.num_kv_heads=cfg.n_kv_heads; kvc.head_dim=cfg.head_dim; kvc.block_size=16;
+    // int8 KV pays off only once the halved long-context read outweighs its fixed per-token write cost,
+    // so enable it context-adaptively (>= 8k) by default; short contexts stay bf16 (no regression).
+    // SPARKINFER_KV_INT8=1/0 forces it on/off regardless.
+    { const char* e8 = getenv("SPARKINFER_KV_INT8"); kvc.int8_kv = e8 ? (e8[0] != '0') : (context_tokens >= 8192); }
     const size_t epb=(size_t)16*cfg.n_kv_heads*cfg.head_dim, blocks=(cfg.max_seq+15)/16+8;
     sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers*2*epb*2*blocks);
     sparkinfer::moe::MoEConfig mc;

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers=cfg.n_layers; kvc.num_kv_heads=cfg.n_kv_heads; kvc.head_dim=cfg.head_dim; kvc.block_size=16;
+    kvc.num_layers=cfg.n_layers; kvc.num_kv_heads=cfg.n_kv_heads; kvc.head_dim=cfg.head_dim; kvc.block_size=16; kvc.int8_kv = !(getenv("SPARKINFER_KV_INT8") && getenv("SPARKINFER_KV_INT8")[0]=='0');
     const size_t epb=(size_t)16*cfg.n_kv_heads*cfg.head_dim, blocks=(cfg.max_seq+15)/16+8;
     sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers*2*epb*2*blocks);
     sparkinfer::moe::MoEConfig mc;

--- a/runtime/examples/qwen3_gguf_generate.cpp
+++ b/runtime/examples/qwen3_gguf_generate.cpp
@@ -60,7 +60,7 @@ int main(int argc, char** argv) {
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
 
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16; kvc.int8_kv = !(getenv("SPARKINFER_KV_INT8") && getenv("SPARKINFER_KV_INT8")[0]=='0');
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
     sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -59,7 +59,7 @@ int main(int argc, char** argv) {
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16; kvc.int8_kv = !(getenv("SPARKINFER_KV_INT8") && getenv("SPARKINFER_KV_INT8")[0]=='0');
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
     sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);

--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -19,6 +19,7 @@ struct KVCacheConfig {
     int block_size = 16;        // tokens per page block
     KVLayout layout = KVLayout::PAGED;
     bool fp8_kv = false;        // FP8 KV cache compression
+    bool int8_kv = false;       // int8 (Q8-style) KV cache; halves the long-context KV read
 };
 
 // GPU-side KV block pool.

--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -45,6 +45,14 @@ public:
     void* v_pool() const;
     size_t layer_stride_elems() const;   // elements between consecutive layers' sub-pools
 
+    // int8 KV (Q8-style int8 + per-(token,kv_head) fp16 scale). When int8_kv(), k_pool/v_pool hold
+    // int8 and k_scale_pool/v_scale_pool hold one __half scale per head vector.
+    // Per-layer scale pointer = (__half*)k_scale_pool() + layer * scale_layer_stride_elems().
+    bool int8_kv() const;
+    void* k_scale_pool() const;
+    void* v_scale_pool() const;
+    size_t scale_layer_stride_elems() const;
+
     int block_size() const;
     int max_blocks_per_seq() const;
     int num_free_blocks() const;

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -46,8 +46,9 @@ KVCacheManager::KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes)
     : impl_(new Impl()) {
     impl_->cfg = cfg;
     // int8 KV (Q8-style, per-token per-kv-head fp16 scale): 1 byte/elem + one scale per head vector,
-    // halving the long-context KV read for the tensor-core flash-decode. SPARKINFER_KV_INT8=0 -> bf16.
-    { const char* e = getenv("SPARKINFER_KV_INT8"); impl_->int8_kv = !(e && e[0] == '0'); }
+    // halving the long-context KV read for the tensor-core flash-decode. Opt-in via cfg.int8_kv (the
+    // Qwen3 example mains set it from SPARKINFER_KV_INT8, default on); other consumers stay bf16.
+    impl_->int8_kv = cfg.int8_kv;
     const int elem_bytes = impl_->int8_kv ? 1 : (int)sizeof(unsigned short);
     const size_t elems_per_block = (size_t)cfg.block_size * cfg.num_kv_heads * cfg.head_dim;
     // total_blocks sized against the bf16 budget so callers/capacity are unchanged; int8 just mallocs

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -13,6 +13,7 @@
 #include <vector>
 #include <unordered_map>
 #include <cstdio>
+#include <cstdlib>
 
 namespace sparkinfer {
 
@@ -28,8 +29,12 @@ struct KVCacheManager::Impl {
     KVCacheConfig cfg;
     int total_blocks = 0;
     size_t layer_stride = 0;         // elements per layer in each pool
+    size_t scale_layer_stride = 0;   // int8 path: fp16 scales per layer (= layer_stride / head_dim)
+    bool int8_kv = false;
     void* k_pool = nullptr;
     void* v_pool = nullptr;
+    void* k_scale = nullptr;         // int8 path only: [num_layers, ..., 1] __half per (token, kv_head)
+    void* v_scale = nullptr;
     int* d_block_tables = nullptr;   // [kMaxSeqs, kMaxBlocksPerSeq]
     std::vector<int> free_list;
     std::unordered_map<uint64_t, std::vector<int>> seq_blocks;
@@ -40,16 +45,28 @@ struct KVCacheManager::Impl {
 KVCacheManager::KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes)
     : impl_(new Impl()) {
     impl_->cfg = cfg;
+    // int8 KV (Q8-style, per-token per-kv-head fp16 scale): 1 byte/elem + one scale per head vector,
+    // halving the long-context KV read for the tensor-core flash-decode. SPARKINFER_KV_INT8=0 -> bf16.
+    { const char* e = getenv("SPARKINFER_KV_INT8"); impl_->int8_kv = !(e && e[0] == '0'); }
+    const int elem_bytes = impl_->int8_kv ? 1 : (int)sizeof(unsigned short);
     const size_t elems_per_block = (size_t)cfg.block_size * cfg.num_kv_heads * cfg.head_dim;
-    const size_t bytes_per_block = elems_per_block * sizeof(unsigned short); // bf16
-    // pool_bytes covers K and V across all layers.
+    // total_blocks sized against the bf16 budget so callers/capacity are unchanged; int8 just mallocs
+    // fewer bytes (+ the small scale pools).
+    const size_t bytes_per_block = elems_per_block * sizeof(unsigned short); // bf16 budget
     const size_t denom = (size_t)cfg.num_layers * 2 * bytes_per_block;
     impl_->total_blocks = denom ? (int)(pool_bytes / denom) : 0;
     impl_->layer_stride = (size_t)impl_->total_blocks * elems_per_block;
 
     const size_t pool_elems = (size_t)cfg.num_layers * impl_->layer_stride;
-    cu(cudaMalloc(&impl_->k_pool, pool_elems * sizeof(unsigned short)), "malloc k_pool");
-    cu(cudaMalloc(&impl_->v_pool, pool_elems * sizeof(unsigned short)), "malloc v_pool");
+    cu(cudaMalloc(&impl_->k_pool, pool_elems * elem_bytes), "malloc k_pool");
+    cu(cudaMalloc(&impl_->v_pool, pool_elems * elem_bytes), "malloc v_pool");
+    if (impl_->int8_kv) {
+        // one fp16 scale per (token slot, kv_head): scale stride = layer_stride / head_dim.
+        impl_->scale_layer_stride = impl_->layer_stride / cfg.head_dim;
+        const size_t scale_elems = (size_t)cfg.num_layers * impl_->scale_layer_stride;
+        cu(cudaMalloc(&impl_->k_scale, scale_elems * sizeof(unsigned short)), "malloc k_scale");
+        cu(cudaMalloc(&impl_->v_scale, scale_elems * sizeof(unsigned short)), "malloc v_scale");
+    }
     cu(cudaMalloc(&impl_->d_block_tables, (size_t)kMaxSeqs * kMaxBlocksPerSeq * sizeof(int)), "malloc tables");
 
     impl_->free_list.reserve(impl_->total_blocks);
@@ -59,6 +76,8 @@ KVCacheManager::KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes)
 
 KVCacheManager::~KVCacheManager() {
     cudaFree(impl_->k_pool); cudaFree(impl_->v_pool); cudaFree(impl_->d_block_tables);
+    if (impl_->k_scale) cudaFree(impl_->k_scale);
+    if (impl_->v_scale) cudaFree(impl_->v_scale);
 }
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
@@ -98,6 +117,10 @@ int* KVCacheManager::block_table(uint64_t seq_id) const {
 void*  KVCacheManager::k_pool() const { return impl_->k_pool; }
 void*  KVCacheManager::v_pool() const { return impl_->v_pool; }
 size_t KVCacheManager::layer_stride_elems() const { return impl_->layer_stride; }
+bool   KVCacheManager::int8_kv() const { return impl_->int8_kv; }
+void*  KVCacheManager::k_scale_pool() const { return impl_->k_scale; }
+void*  KVCacheManager::v_scale_pool() const { return impl_->v_scale; }
+size_t KVCacheManager::scale_layer_stride_elems() const { return impl_->scale_layer_stride; }
 int    KVCacheManager::block_size() const { return impl_->cfg.block_size; }
 int    KVCacheManager::max_blocks_per_seq() const { return kMaxBlocksPerSeq; }
 int    KVCacheManager::num_free_blocks() const { return (int)impl_->free_list.size(); }

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -327,7 +327,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                            s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,
                                            s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
                                            1.f / sqrtf((float)c.head_dim), st,
-                                           emit_attn_q8 ? s.aq81 : nullptr);
+                                           emit_attn_q8 ? s.aq81 : nullptr, seqlen);
         if (s.gguf && s.use_pq && w.wo_type == 12) {   // O proj reads attn: quantize once + dp4a
             if (s.use_llama) {
                 if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -296,13 +296,19 @@ int Qwen35Model::forward_token(int token_id, int position) {
             kernels::launch_gemm(s.xn, w.wk, s.k, 1, s.kvdim, H, 1.f, 0.f, gc, st);
             kernels::launch_gemm(s.xn, w.wv, s.v, 1, s.kvdim, H, 1.f, 0.f, gc, st);
         }
-        bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems();
-        bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems();
-        if (s.use_attnin) {   // fused QK-norm + RoPE + KV-append: 1 node vs qk-norm + rope-kv (2)
+        // int8 KV: byte-scaled layer offset (1 B int8 / 2 B bf16) + parallel per-(token,kv_head) scale pool.
+        const bool kv8 = s.kv->int8_kv();
+        const int kv_elem = kv8 ? 1 : 2;
+        void* kpool = (char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+        void* vpool = (char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+        void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+        void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+        if (s.use_attnin || kv8) {   // fused QK-norm + RoPE + KV-append (int8-capable writer; required for int8 KV)
             kernels::launch_qknorm_rope_kv_append(s.q, s.k, s.v, w.q_norm, w.k_norm, kpool, vpool,
                                                   btable, s.d_pos, 1, c.n_q_heads, c.n_kv_heads,
                                                   c.head_dim, c.rope_theta, c.rms_eps,
-                                                  s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
+                                                  s.kv->block_size(), s.kv->max_blocks_per_seq(), st,
+                                                  kscale, vscale, kv8 ? 1 : 0);
         } else {
         if (s.use_qkfuse)
             kernels::launch_rmsnorm_qk(s.q, s.k, w.q_norm, w.k_norm, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rms_eps, st);
@@ -327,7 +333,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                            s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,
                                            s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
                                            1.f / sqrtf((float)c.head_dim), st,
-                                           emit_attn_q8 ? s.aq81 : nullptr, seqlen);
+                                           emit_attn_q8 ? s.aq81 : nullptr, seqlen, kscale, vscale, kv8 ? 1 : 0);
         if (s.gguf && s.use_pq && w.wo_type == 12) {   // O proj reads attn: quantize once + dp4a
             if (s.use_llama) {
                 if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);


### PR DESCRIPTION
## Summary

Long-context decode is dominated by `fa_split_gqa` (~34% of decode at 16k). A gutted-dot experiment (keep the KV loads, remove the per-token dot + reduction) speeds the kernel up ~25%, showing it is compute-bound on the per-token QK dot, the 5-shuffle `fa_wsum` warp reduction, and the V-accumulate, not on memory bandwidth. This change moves that work onto the tensor cores and halves the KV read, and does so with **zero regression** at short and mid contexts.

**int8 tensor-core split.** For block-aligned long context the 8 GQA q-heads of a kv-head become the batch (M) dimension, so `S = Q·Kt` and `O = P·V` become small `wmma` matmuls, replacing the per-lane FMA + shuffle reduction. K/V are stored int8 (Q8-style, one fp16 scale per token per kv-head) so the matmuls run entirely on the 2x-throughput int8 tensor cores (int32 accumulate) while the KV global read (the exposed cost once the dot leaves the ALUs) is halved. Q and P are quantized per-row and the per-token/per-head scales are applied to the int32 results (the V scale folds into P). M is padded 8->16; partials (m, l, acc) stay byte-compatible with the existing combine kernel. Fragments load straight from the paged KV pool (one 16-token physical block per warp), so there is no shared-memory staging and occupancy stays high.

**Context-adaptive, zero-regression elsewhere.** The tensor-core kernel runs only for block-aligned long context with a per-split chunk of at least 32 tokens (enough physical blocks to fill the GPU), and only with the int8 cache. int8's fixed per-token write cost only pays off once the halved long-context read outweighs it, so the int8 cache is enabled context-adaptively (from 8k); shorter contexts stay on the scalar bf16 split. Both touched kernels (the scalar `fa_split_gqa` and the fused QK-norm+RoPE+KV-append) are template-specialized on a compile-time `int8` flag, so the int8-off instantiation carries no int8 code or pointer indirection and is byte-identical to the pre-change (main) kernel. Result: 128/512/4k decode is unchanged (within run-to-run noise), only 16k engages the int8 tensor cores. `SPARKINFER_KV_INT8=1/0` forces int8 on/off; `SPARKINFER_FAMMA=0` restores the scalar split.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `bench/scripts/bench.sh --tokens 128 --ctx 16384`, greedy bs=1, Qwen3-30B-A3B Q4_K_M, the scored long-context regime where the int8 path engages; median of 3 runs):

| | decode tok/s |
|---|--:|
| before (main) | 257.3 |
| after (this PR) | 307.9 |

That is **+19.7%** at 16k. int8 engages context-adaptively (from 8k), so short contexts stay on the bf16 path; the full no-regression sweep (this PR vs main, same box, `bench.sh`, n=128, median of 3):

| context | main (bf16) | this PR | delta |
|---|--:|--:|--:|
| 128  | 485.8 | 487.2 | +0.3% |
| 512  | 471.5 | 471.6 | +0.0% |
| 4k   | 387.4 | 387.5 | +0.0% |
| 16k  | 257.3 | 307.9 | **+19.7%** |

Only the 16k path switches to int8 tensor cores; 128/512/4k stay on the scalar bf16 path, byte-identical to main.

## Correctness

token-match / KL vs llama.cpp on the same GGUF (`bench/scripts/accuracy.sh`, held-out prompt):

- short context (scalar int8 read): top-1 0.960, mean KL 0.0495 nats
- long context (int8 tensor-core, `SPARKINFER_NSPLITS=16`): top-1 0.980, mean KL 0.0368 nats

Both clear the 0.90 top-1 / 0.20 KL bars with wide margin. `SPARKINFER_KV_INT8=0` is bit-identical to the bf16 cache; `SPARKINFER_FAMMA=0` restores the scalar split. `ctest` 6/6 green; compute-sanitizer memcheck clean on the int8 decode path.
