### PR TITLE
fix(runtime): grow-aware KV cache allocate; bound cumulative blocks

### DIFF
--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -62,11 +62,18 @@ KVCacheManager::~KVCacheManager() {
 }
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
-    const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
-    if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
-    if (need > kMaxBlocksPerSeq) return false;
+    const int want = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
+    if (want > kMaxBlocksPerSeq) return false;
 
     auto& blocks = impl_->seq_blocks[seq_id];
+    const int have = (int)blocks.size();
+    const int need = want - have;
+    if (need <= 0) return true;  // already sufficient (including exact fit)
+
+    const bool new_seq = impl_->seq_slot.find(seq_id) == impl_->seq_slot.end();
+    if (new_seq && impl_->free_slots.empty()) return false;
+    if ((int)impl_->free_list.size() < need) return false;
+
     for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
 
     int slot;

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -21,3 +21,7 @@ add_test(NAME decode_runner_gpu_test COMMAND decode_runner_gpu_test)
 add_executable(qwen35_gpu_test qwen35_gpu_test.cpp)
 target_link_libraries(qwen35_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME qwen35_gpu_test COMMAND qwen35_gpu_test)
+
+add_executable(kv_cache_gpu_test kv_cache_gpu_test.cpp)
+target_link_libraries(kv_cache_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
+add_test(NAME kv_cache_gpu_test COMMAND kv_cache_gpu_test)

--- a/runtime/tests/kv_cache_gpu_test.cpp
+++ b/runtime/tests/kv_cache_gpu_test.cpp
@@ -1,0 +1,65 @@
+// GPU test for grow-aware KV block allocation.
+// Verifies that re-allocating the same seq_id tops up by delta only (no block leak
+// or block-table overrun). Skips when no CUDA device is present.
+
+#include "sparkinfer/kv_cache.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+using sparkinfer::KVCacheConfig;
+using sparkinfer::KVCacheManager;
+
+static int blocks_for(int tokens, int block_size) {
+    return (tokens + block_size - 1) / block_size;
+}
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no CUDA device — kv_cache_gpu_test requires a GPU\n");
+        return 0;
+    }
+
+    KVCacheConfig cfg;
+    cfg.num_layers = 2;
+    cfg.num_kv_heads = 2;
+    cfg.head_dim = 128;
+    cfg.block_size = 16;
+    KVCacheManager kv(cfg, 64ull * 1024 * 1024);
+
+    const int free0 = kv.num_free_blocks();
+    const uint64_t seq = 42;
+
+    if (!kv.allocate(seq, 32)) { printf("[FAIL] initial allocate(32)\n"); return 1; }
+    const int b32 = blocks_for(32, cfg.block_size);
+    if (free0 - kv.num_free_blocks() != b32) {
+        printf("[FAIL] expected %d blocks for 32 tokens, got %d\n", b32, free0 - kv.num_free_blocks());
+        return 1;
+    }
+
+    // Same token count — must not consume additional blocks.
+    const int free1 = kv.num_free_blocks();
+    if (!kv.allocate(seq, 32)) { printf("[FAIL] re-allocate(32)\n"); return 1; }
+    if (kv.num_free_blocks() != free1) {
+        printf("[FAIL] re-allocate(32) leaked blocks: free %d -> %d\n", free1, kv.num_free_blocks());
+        return 1;
+    }
+
+    // Grow to 48 tokens — only the delta should be charged.
+    if (!kv.allocate(seq, 48)) { printf("[FAIL] grow allocate(48)\n"); return 1; }
+    const int b48 = blocks_for(48, cfg.block_size);
+    if (free1 - kv.num_free_blocks() != b48 - b32) {
+        printf("[FAIL] grow to 48: expected delta %d, got %d\n", b48 - b32, free1 - kv.num_free_blocks());
+        return 1;
+    }
+
+    kv.free(seq);
+    if (kv.num_free_blocks() != free0) {
+        printf("[FAIL] free did not return all blocks: %d vs %d\n", kv.num_free_blocks(), free0);
+        return 1;
+    }
+
+    printf("[PASS] kv_cache grow-aware allocate\n");
+    return 0;
+}


### PR DESCRIPTION
Fixes #110

## Summary

Make `KVCacheManager::allocate()` grow-aware: compute total blocks wanted for `num_tokens`, allocate only the delta over what the sequence already holds, and reject cumulative totals above `kMaxBlocksPerSeq`. Prevents block leaks and device block-table row overruns when a sequence grows past its initial reservation.

## Proof of speedup

N/A — runtime correctness fix (no decode-path performance change).

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |

## Test plan

- [x] `kv_cache_gpu_test` — initial allocate, idempotent re-allocate, grow-by-delta, free reclaim
- [ ] `ctest --test-dir build` on RTX 5090 build
