### PR TITLE
fix(runtime): guard launch_kv_append when head_dim exceeds 1024

### DIFF
--- a/runtime/csrc/cuda/kv_ops.cu
+++ b/runtime/csrc/cuda/kv_ops.cu
@@ -41,11 +41,16 @@ __global__ void residual_add_kernel(const __nv_bfloat16* __restrict__ a,
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kv_ops.h"
+#include <cstdio>
 
 void launch_kv_append(void* k_pool, void* v_pool, const void* k_new, const void* v_new,
                       const int* block_table, const int* write_pos,
                       int num_seqs, int num_kv_heads, int head_dim,
                       int block_size, int max_blocks_per_seq, cudaStream_t stream) {
+    if (head_dim <= 0 || head_dim > 1024) {
+        fprintf(stderr, "[kv] launch_kv_append: head_dim %d invalid (must be 1..1024)\n", head_dim);
+        return;
+    }
     dim3 grid(num_seqs, num_kv_heads);
     kv_append_kernel<<<grid, head_dim, 0, stream>>>(
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),


### PR DESCRIPTION
Fixes #201

## Summary

guard launch_kv_append when head_dim exceeds 1024

## Proof of speedup

N/A — correctness / test / API improvement (no decode-path performance change).

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |