### PR TITLE
fix(runtime): DecodeRunner use block_tables device base

### DIFF
--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -39,6 +39,10 @@ public:
     // Shape: [num_layers, max_blocks_per_seq]
     int* block_table(uint64_t seq_id) const;
 
+    // Full device block-table array [kMaxSeqs, max_blocks_per_seq].
+    // Batched decode uses row i for batch index i (seq_id i allocated with slot i).
+    int* block_tables_device() const;
+
     // Device pointers to K and V storage pools (base = layer 0).
     // Per-layer pointer = (bf16*)k_pool() + layer * layer_stride_elems().
     void* k_pool() const;

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -96,7 +96,7 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     // 3. append new K/V into the paged cache for this layer
     bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)layer * s.kv->layer_stride_elems();
     bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)layer * s.kv->layer_stride_elems();
-    int* btable = s.kv->block_table(0);   // batch occupies slots 0..num_seqs-1
+    int* btable = s.kv->block_tables_device();   // row i == batch index i
     launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
                      num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
                      s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -89,6 +89,8 @@ void KVCacheManager::free(uint64_t seq_id) {
     if (s != impl_->seq_slot.end()) { impl_->free_slots.push_back(s->second); impl_->seq_slot.erase(s); }
 }
 
+int* KVCacheManager::block_tables_device() const { return impl_->d_block_tables; }
+
 int* KVCacheManager::block_table(uint64_t seq_id) const {
     auto it = impl_->seq_slot.find(seq_id);
     if (it == impl_->seq_slot.end()) return nullptr;


### PR DESCRIPTION
Fixes #202

## Summary

DecodeRunner use block_tables device base

## Proof of speedup

N/A — correctness / test / API improvement (no decode-path performance change).

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |