### PR TITLE
feat(runtime): expose compute_capability on Runtime

### DIFF
--- a/runtime/include/sparkinfer/runtime.h
+++ b/runtime/include/sparkinfer/runtime.h
@@ -32,6 +32,9 @@ public:
     // Returns number of available CUDA SMs
     virtual int num_sms() const = 0;
 
+    virtual int compute_capability_major() const = 0;
+    virtual int compute_capability_minor() const = 0;
+
     // Engine-level GPU observability: a live sample of heat (°C) + VRAM (+ power/clock) on this
     // runtime's device. Safe to poll periodically (e.g. while decoding) to watch thermals/throttle.
     virtual GpuStats gpu_stats() const = 0;

--- a/runtime/src/runtime.cpp
+++ b/runtime/src/runtime.cpp
@@ -35,6 +35,8 @@ public:
     void shutdown() override { cudaDeviceSynchronize(); }
     float memory_bandwidth_gbps() const override { return bandwidth_gbps_; }
     int   num_sms() const override { return num_sms_; }
+    int   compute_capability_major() const override { return cc_major_; }
+    int   compute_capability_minor() const override { return cc_minor_; }
     GpuStats gpu_stats() const override { return query_gpu_stats(cfg_.device_id); }
 
 private:


### PR DESCRIPTION
Fixes #203

## Summary

expose compute_capability on Runtime

## Proof of speedup

N/A — correctness / test / API improvement (no decode-path performance change).

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |