### PR TITLE
fix(moe): reject MoEEngine forward when layer weights unset

### DIFF
--- a/moe/src/engine.cpp
+++ b/moe/src/engine.cpp
@@ -56,6 +56,10 @@ public:
         const LayerWeights& w = weights_[layer];
         const int E = cfg_.num_experts, K = cfg_.top_k;
         const int H = cfg_.hidden_dim, F = cfg_.ffn_dim;
+        if (!w.router_w || !w.gate_w || !w.up_w || !w.down_w) {
+            fprintf(stderr, "[moe] forward: layer %d weights not set\n", layer);
+            return;
+        }
 
         // 1. router projection -> logits [num_tokens, E]
         kernels::launch_moe_router_gemm(input, w.router_w, d_logits_, num_tokens, H, E, stream);


### PR DESCRIPTION
Fixes #204

## Summary

reject MoEEngine forward when layer weights unset

## Proof of speedup

N/A — correctness / test / API improvement (no decode-path performance change).

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |