### PR TITLE
fix(runtime): guarantee forward progress in Scheduler::schedule() (fixes #217)

### DIFF
--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -28,7 +28,13 @@ ScheduleBatch Scheduler::schedule() {
     std::sort(ordered.begin(), ordered.end(),
               [](const SequenceGroup* a, const SequenceGroup* b) { return a->priority > b->priority; });
     for (auto* g : ordered) {
-        if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
+        // Strict priority: stop at the first group that doesn't fit the token budget — but
+        // never return an empty batch while a runnable group exists. A group whose num_seqs
+        // exceeds max_tokens_per_batch would otherwise break on the very first iteration and
+        // never be scheduled (starvation / no forward progress), so admit the highest-priority
+        // group even when it alone overflows the budget.
+        if (!batch.decode_seq_ids.empty() &&
+            batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
         for (int i = 0; i < g->num_seqs; i++) batch.decode_seq_ids.push_back(g->group_id);
         batch.total_tokens += g->num_seqs;
     }

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -13,6 +13,12 @@ target_link_libraries(thermal_governor_cpu_test PRIVATE sparkinfer_runtime)
 set_target_properties(thermal_governor_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME thermal_governor_cpu_test COMMAND thermal_governor_cpu_test)
 
+# Scheduler — pure host continuous-batching policy (no GPU); links the runtime for its symbols.
+add_executable(scheduler_cpu_test scheduler_cpu_test.cpp)
+target_link_libraries(scheduler_cpu_test PRIVATE sparkinfer_runtime)
+set_target_properties(scheduler_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME scheduler_cpu_test COMMAND scheduler_cpu_test)
+
 # GPU integration tests — run the real device path; skip without a device.
 add_executable(decode_runner_gpu_test decode_runner_gpu_test.cpp)
 target_link_libraries(decode_runner_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/tests/scheduler_cpu_test.cpp
+++ b/runtime/tests/scheduler_cpu_test.cpp
@@ -1,0 +1,84 @@
+// CPU test for the continuous-batching scheduler — pure host policy, no GPU needed.
+// Covers priority ordering, the token-budget stop, the forward-progress guarantee
+// (an oversized group must still be scheduled, never starved), and preemption order.
+
+#include "sparkinfer/scheduler.h"
+#include <cstdio>
+
+using namespace sparkinfer;
+#define CHECK(x) do{ if(!(x)){ printf("FAIL: %s (line %d)\n", #x, __LINE__); return 1; } }while(0)
+
+static SequenceGroup grp(uint64_t id, int num_seqs, int priority) {
+    return SequenceGroup{ id, num_seqs, /*max_new_tokens=*/16, priority };
+}
+
+int main() {
+    // 1. Priority packing: higher-priority group is scheduled first, within budget.
+    {
+        Scheduler s(SchedulePolicy::PRIORITY, /*max_tokens_per_batch=*/8);
+        s.add_sequence_group(grp(1, 2, /*prio=*/5));
+        s.add_sequence_group(grp(2, 3, /*prio=*/9));
+        ScheduleBatch b = s.schedule();
+        CHECK(b.total_tokens == 5);
+        CHECK(b.decode_seq_ids.size() == 5);
+        // group 2 (priority 9) comes before group 1 (priority 5)
+        CHECK(b.decode_seq_ids[0] == 2 && b.decode_seq_ids[1] == 2 && b.decode_seq_ids[2] == 2);
+        CHECK(b.decode_seq_ids[3] == 1 && b.decode_seq_ids[4] == 1);
+    }
+
+    // 2. Token-budget stop: strict priority halts once the next group would overflow.
+    {
+        Scheduler s(SchedulePolicy::PRIORITY, /*max_tokens_per_batch=*/4);
+        s.add_sequence_group(grp(1, 2, /*prio=*/5));   // lower priority, would push total to 5
+        s.add_sequence_group(grp(2, 3, /*prio=*/9));   // higher priority, fits (3 <= 4)
+        ScheduleBatch b = s.schedule();
+        CHECK(b.total_tokens == 3);
+        CHECK(b.decode_seq_ids.size() == 3);
+        for (auto id : b.decode_seq_ids) CHECK(id == 2);  // only the higher-priority group ran
+    }
+
+    // 3. Forward-progress guarantee (the fixed bug): a group larger than the whole
+    //    batch budget must still be scheduled — never an empty batch while work exists.
+    {
+        Scheduler s(SchedulePolicy::PRIORITY, /*max_tokens_per_batch=*/4);
+        s.add_sequence_group(grp(7, 10, /*prio=*/1));   // 10 > 4 budget
+        ScheduleBatch b = s.schedule();
+        CHECK(!b.decode_seq_ids.empty());               // pre-fix: this was empty (starvation)
+        CHECK(b.total_tokens == 10);
+        CHECK(b.decode_seq_ids.size() == 10);
+        for (auto id : b.decode_seq_ids) CHECK(id == 7);
+    }
+
+    // 4. Empty scheduler yields an empty batch.
+    {
+        Scheduler s(SchedulePolicy::PRIORITY, 8);
+        ScheduleBatch b = s.schedule();
+        CHECK(b.decode_seq_ids.empty());
+        CHECK(b.total_tokens == 0);
+    }
+
+    // 5. Preemption evicts lowest-priority groups first, until enough is freed.
+    {
+        Scheduler s(SchedulePolicy::PRIORITY, 8);
+        s.add_sequence_group(grp(1, 2, /*prio=*/5));
+        s.add_sequence_group(grp(2, 3, /*prio=*/1));   // lowest priority -> first victim
+        s.add_sequence_group(grp(3, 1, /*prio=*/9));
+        auto victims = s.preempt(/*tokens_needed=*/3);
+        CHECK(victims.size() == 1);
+        CHECK(victims[0] == 2);                          // freeing 3 tokens from group 2 suffices
+    }
+
+    // 6. Preemption accumulates across groups when one is not enough.
+    {
+        Scheduler s(SchedulePolicy::PRIORITY, 8);
+        s.add_sequence_group(grp(1, 2, /*prio=*/5));
+        s.add_sequence_group(grp(2, 3, /*prio=*/1));
+        s.add_sequence_group(grp(3, 1, /*prio=*/9));
+        auto victims = s.preempt(/*tokens_needed=*/4);
+        CHECK(victims.size() == 2);                      // group 2 (3) + group 1 (2) = 5 >= 4
+        CHECK(victims[0] == 2 && victims[1] == 1);       // ascending priority order
+    }
+
+    printf("scheduler_cpu_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Fixes #217. `Scheduler::schedule()` returned an empty batch when the highest-priority sequence group's `num_seqs` exceeded `max_tokens_per_batch` (it `break`s on the first iteration), so that group could never run - starvation / no forward progress. This admits the top-priority group even when it alone overflows the soft token budget, guaranteeing a batch is never empty while runnable work exists. Strict-priority behaviour is unchanged once at least one group is already scheduled.

Also adds `scheduler_cpu_test` - the first test coverage for the scheduler (priority packing, token-budget stop, the forward-progress regression, empty scheduler, preemption order). Pure host logic, no GPU.

## Proof of speedup

Not a performance change - this is a host-side correctness fix plus new CPU test coverage, off the decode/benchmark path. No decode tok/s impact, so the RTX 5090 box is intentionally left unticked.

- [ ] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s:** n/a (no runtime speed change).