### PR TITLE
fix(runtime): handle tied embeddings in convert_qwen35.py (fixes #219)

### DIFF
--- a/runtime/tools/convert_qwen35.py
+++ b/runtime/tools/convert_qwen35.py
@@ -60,7 +60,10 @@ def main():
     # globals
     write("embed_tokens", get("model.embed_tokens.weight"))          # [vocab, H]
     write("final_norm",   get("model.norm.weight"))                  # [H]
-    write("lm_head",      get("lm_head.weight").T)                   # [vocab,H] -> [H,vocab]
+    # lm_head.weight is absent when the model ties input/output embeddings; fall back to
+    # the input embedding (same [vocab, H] layout), matching convert_gguf.py's tied handling.
+    lm_head_name = "lm_head.weight" if "lm_head.weight" in tensors else "model.embed_tokens.weight"
+    write("lm_head",      get(lm_head_name).T)                       # [vocab,H] -> [H,vocab]
 
     for i in range(n_layers):
         p = f"model.layers.{i}."


### PR DESCRIPTION
## Summary

Fixes #219. `convert_qwen35.py` read `lm_head.weight` unconditionally, so a checkpoint that ties its input/output embeddings (no `lm_head.weight` tensor) aborted conversion with a `KeyError`. This falls back to `model.embed_tokens.weight` when `lm_head.weight` is absent - the same `[vocab, hidden]` layout, mirroring `convert_gguf.py`'s existing tied-weight handling. Untied checkpoints are unaffected.

## Proof of speedup

Not a performance change - host-side weight-conversion robustness fix, off the decode/benchmark path. No decode tok/s impact, so the RTX 5090 box is intentionally left unticked.

- [ ] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s:** n/a (no runtime speed change).