### PR TITLE
feat(qwen): add Qwen3.6 hybrid (Gated-DeltaNet) decode — re-implemented on the int8 main

### DIFF
--- a/bench/competitors/results/qwen3_awq_rtx5090_20260703/sparkinfer/rerun_20260703.log
+++ b/bench/competitors/results/qwen3_awq_rtx5090_20260703/sparkinfer/rerun_20260703.log
@@ -1,0 +1,72 @@
+auth gguf download Fri Jul  3 20:26:23 UTC 2026
+######################################################################### 100.0%######################################################################### 100.0%######################################################################### 100.0%
+-rw-r--r-- 1 root root 18G Jul  3 15:40 /workspace/qwen_awq_bench/sparkinfer/models/Qwen3-30B-A3B-Q4_K_M.gguf
+>> sparkinfer ctx=128 Fri Jul  3 20:26:24 UTC 2026
+>> GPU arch: sm_120
+>> using local build
+>> model sha256 OK
+
+=== sparkinfer — decode (n=128, ctx=128, bs=1) ===
+[gguf] layer 0 loaded
+[gguf] layer 47 loaded
+[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
+loading /workspace/qwen_awq_bench/sparkinfer/models/Qwen3-30B-A3B-Q4_K_M.gguf (native GGUF, experts quantized) ...
+
+=== sparkinfer bench (Q4_K_M native) ===
+model        : Qwen3-30B-A3B  (48 layers, 128 experts top-8)
+VRAM used    : 20.0 GB
+max seq      : 2048
+decode tg    : 471.28 tok/s  (2.1 ms/token, n=128, ctx=128, bs=1)
+GPU          : 47°C · 208 W · 2385 MHz (peak under load)
+>> sparkinfer ctx=512 Fri Jul  3 20:26:43 UTC 2026
+>> GPU arch: sm_120
+>> using local build
+>> model sha256 OK
+
+=== sparkinfer — decode (n=128, ctx=512, bs=1) ===
+[gguf] layer 0 loaded
+[gguf] layer 47 loaded
+[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
+loading /workspace/qwen_awq_bench/sparkinfer/models/Qwen3-30B-A3B-Q4_K_M.gguf (native GGUF, experts quantized) ...
+
+=== sparkinfer bench (Q4_K_M native) ===
+model        : Qwen3-30B-A3B  (48 layers, 128 experts top-8)
+VRAM used    : 20.0 GB
+max seq      : 2048
+decode tg    : 471.99 tok/s  (2.1 ms/token, n=128, ctx=512, bs=1)
+GPU          : 52°C · 404 W · 2865 MHz (peak under load)
+>> sparkinfer ctx=4096 Fri Jul  3 20:26:57 UTC 2026
+>> GPU arch: sm_120
+>> using local build
+>> model sha256 OK
+
+=== sparkinfer — decode (n=128, ctx=4096, bs=1) ===
+[gguf] layer 0 loaded
+[gguf] layer 47 loaded
+[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
+loading /workspace/qwen_awq_bench/sparkinfer/models/Qwen3-30B-A3B-Q4_K_M.gguf (native GGUF, experts quantized) ...
+
+=== sparkinfer bench (Q4_K_M native) ===
+model        : Qwen3-30B-A3B  (48 layers, 128 experts top-8)
+VRAM used    : 20.2 GB
+max seq      : 4240
+decode tg    : 389.96 tok/s  (2.6 ms/token, n=128, ctx=4096, bs=1)
+GPU          : 59°C · 476 W · 2857 MHz (peak under load)
+>> sparkinfer ctx=16384 Fri Jul  3 20:27:20 UTC 2026
+>> GPU arch: sm_120
+>> using local build
+>> model sha256 OK
+
+=== sparkinfer — decode (n=128, ctx=16384, bs=1) ===
+[gguf] layer 0 loaded
+[gguf] layer 47 loaded
+[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
+loading /workspace/qwen_awq_bench/sparkinfer/models/Qwen3-30B-A3B-Q4_K_M.gguf (native GGUF, experts quantized) ...
+
+=== sparkinfer bench (Q4_K_M native) ===
+model        : Qwen3-30B-A3B  (48 layers, 128 experts top-8)
+VRAM used    : 21.4 GB
+max seq      : 16528
+decode tg    : 266.26 tok/s  (3.8 ms/token, n=128, ctx=16384, bs=1)
+GPU          : 67°C · 532 W · 2835 MHz (peak under load)
+done sparkinfer Fri Jul  3 20:28:25 UTC 2026

--- a/bench/configs/models/qwen36_35b_a3b.yaml
+++ b/bench/configs/models/qwen36_35b_a3b.yaml
@@ -1,0 +1,97 @@
+# Qwen3.6-35B-A3B architecture specification
+# Sources:
+#   https://huggingface.co/Qwen/Qwen3.6-35B-A3B/blob/main/config.json
+#   https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF
+
+model:
+  name: Qwen3.6-35B-A3B
+  family: qwen3_5_moe
+  modality: image_text_to_text
+  total_params_b: 35
+  active_params_b: 3
+
+text:
+  num_hidden_layers: 40
+  hidden_size: 2048
+  max_position_embeddings: 262144
+  vocab_size: 248320
+  dtype: bfloat16
+  rms_norm_eps: 1e-6
+
+attention:
+  layout: hybrid_gated_deltanet
+  # 10 repeats of: 3 linear-attention layers, then 1 full-attention layer.
+  linear_attention_layers: 30
+  full_attention_layers: 10
+  full_attention_interval: 4
+
+  linear_attention:
+    type: gated_deltanet
+    num_qk_heads: 16
+    num_value_heads: 32
+    key_head_dim: 128
+    value_head_dim: 128
+    conv_kernel_dim: 4
+    ssm_dtype: float32
+
+  full_attention:
+    num_attention_heads: 16
+    num_key_value_heads: 2
+    head_dim: 256
+    rotary_dim: 64
+    partial_rotary_factor: 0.25
+    rope_theta: 10000000
+    mrope_interleaved: true
+    mrope_section: [11, 11, 10]
+
+moe:
+  num_experts: 256
+  num_experts_per_tok: 8
+  shared_expert: true
+  total_routed_per_tok: 9
+  moe_intermediate_size: 512
+  router_aux_loss_coef: 0.001
+
+mtp:
+  num_hidden_layers: 1
+  use_dedicated_embeddings: false
+
+vision:
+  enabled: true
+  hidden_size: 1152
+  depth: 27
+  num_heads: 16
+  patch_size: 16
+  temporal_patch_size: 2
+  spatial_merge_size: 2
+  out_hidden_size: 2048
+
+special_tokens:
+  bos_token_id: 248044
+  eos_token_id: 248044
+  image_token_id: 248056
+  video_token_id: 248057
+  vision_start_token_id: 248053
+  vision_end_token_id: 248054
+
+# --- Derived optimization-relevant values ---
+derived:
+  # Only the 10 full-attention layers have a KV cache. The 30 Gated DeltaNet
+  # layers use recurrent linear-attention state instead of full-context KV.
+  full_attention_kv_bytes_per_token: 20480
+  full_attention_kv_bytes_at_262k_ctx_gb: 5.4
+  expert_up_shape: [2048, 512]
+  expert_down_shape: [512, 2048]
+  router_dim: 256
+
+runtime:
+  sparkinfer_native_decode: true
+  implemented_runtime_work:
+    - gated_deltanet_linear_attention_decode
+    - linear_attention_recurrent_state_cache
+    - hybrid_layer_scheduler
+    - qwen3_5_moe_partial_rotary_decode
+  pending_validation:
+    - cuda_build_on_sm120_or_sm121
+    - qwen3_5_moe_mrope_parity_against_llama_cpp
+    - multimodal_token_and_vision_plumbing

--- a/bench/configs/targets/qwen36_q4km_rtx_spark.yaml
+++ b/bench/configs/targets/qwen36_q4km_rtx_spark.yaml
@@ -1,0 +1,66 @@
+# Benchmark target: Qwen3.6-35B-A3B GGUF on RTX Spark
+# RTX Spark: 128GB unified LPDDR5X, Blackwell sm_121, ~273 GB/s bandwidth.
+
+model:   configs/models/qwen36_35b_a3b.yaml
+quant:   q4_k_m
+
+hardware:
+  name: RTX Spark
+  arch: sm_121
+  unified_memory_gb: 128
+  bandwidth_gbps: 273
+  cuda_cores: 6144
+
+decode:
+  batch_sizes: [1, 2, 4, 8]
+  context_lens: [2048, 8192, 32768, 131072, 262144]
+  dtype: bfloat16
+
+  # Native sparkinfer decode exists for the hybrid Gated DeltaNet stack. These
+  # slots remain null until the sm_120/sm_121 build and benchmark are rerun on
+  # the pinned GGUF with the same-box llama.cpp baseline.
+  baseline_toks_per_sec:
+    bs1_ctx2k: null
+    bs1_ctx32k: null
+    bs1_ctx262k: null
+
+  target_toks_per_sec:
+    bs1_ctx2k: 90
+    bs1_ctx32k: 80
+    bs1_ctx262k: 60
+
+runtime:
+  sparkinfer_native_decode: true
+  required_work:
+    - cuda_build_validation
+    - llama_cpp_same_gguf_baseline_128_512
+    - sparkinfer_same_gguf_baseline_128_512
+    - qwen3_5_moe_mrope_parity_validation
+
+memory:
+  expert_eviction_needed: false
+  can_preload_all_experts: true
+  full_attention_kv_bytes_per_token: 20480
+
+attention:
+  linear_attention:
+    layers: 30
+    qk_heads: 16
+    value_heads: 32
+    head_dim: 128
+    bench_recurrent_state: true
+
+  full_attention:
+    layers: 10
+    num_kv_heads: 2
+    head_dim: 256
+    rotary_dim: 64
+    bench_full_ctx_attn: true
+
+moe:
+  bench_router_standalone: true
+  bench_expert_gemm: true
+  num_experts: 256
+  top_k: 8
+  shared_expert: true
+  expert_shape: [2048, 512]

--- a/bench/scripts/qwen36_compare_128_512.sh
+++ b/bench/scripts/qwen36_compare_128_512.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Same-GGUF Qwen3.6 decode comparison: sparkinfer vs llama.cpp at 128 and 512
+# generated tokens, batch size 1.
+#
+# Usage:
+#   bench/scripts/qwen36_compare_128_512.sh [model.gguf]
+#
+# Defaults to the Unsloth Qwen3.6 35B-A3B Q4_K_M GGUF:
+#   unsloth/Qwen3.6-35B-A3B-GGUF / Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
+set -euo pipefail
+
+export MODEL_REPO="${MODEL_REPO:-unsloth/Qwen3.6-35B-A3B-GGUF}"
+export MODEL_FILE="${MODEL_FILE:-Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
+export TOK_REPO="${TOK_REPO:-Qwen/Qwen3.6-35B-A3B}"
+
+source "$(dirname "${BASH_SOURCE[0]}")/_common.sh"
+
+GGUF="${1:-$MODELS_DIR/$MODEL_FILE}"
+ARCH="$(detect_arch)"
+
+echo ">> GPU arch: sm_$ARCH"
+resolve_runner "$ARCH"
+if [ "$GGUF" = "$MODELS_DIR/$MODEL_FILE" ]; then
+  ensure_model
+else
+  [ -f "$GGUF" ] || { echo "!! GGUF not found: $GGUF"; exit 1; }
+fi
+ensure_llamacpp "$ARCH"
+
+echo ">> model: $GGUF"
+echo ">> sparkinfer commit: $(git -C "$ROOT" rev-parse --short HEAD)"
+echo ">> llama.cpp commit: $(git -C "$LLAMACPP_DIR" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+for TOKENS in 128 512; do
+  echo
+  echo "================= sparkinfer Qwen3.6 (n=$TOKENS, bs=1) ================="
+  si_run qwen3_gguf_bench "$GGUF" "$TOKENS"
+
+  echo
+  echo "================= llama.cpp Qwen3.6 (n=$TOKENS, bs=1) ================="
+  "$LLAMACPP_DIR/build/bin/llama-bench" -m "$GGUF" -p 0 -n "$TOKENS" -ngl 99
+done

--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -290,6 +290,10 @@ template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE, true>(const __
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+// Qwen3.6 full-attention head_dim=256 (bf16 KV): scalar split only (int8/GQA paths are hd=128-only).
+template __global__ void fa_split_kernel<256>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
+template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -498,6 +502,20 @@ void launch_flash_decode_split(
     int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
     void* out_q8, int seqlen, const void* k_scale, const void* v_scale, int int8_kv
 ) {
+    // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). The GQA-8 / int8 tensor-core paths
+    // below are head_dim=128-specialized, so 256 takes the generic scalar split + combine.
+    if (head_dim == 256) {
+        dim3 g1(num_q_heads * n_splits, num_seqs), g2(num_q_heads * FA_COMBINE_DG, num_seqs);
+        fa_split_kernel<256><<<g1, 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+            reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
+        fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
+            part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
+            reinterpret_cast<fa_block_q8_1*>(out_q8));
+        (void)seqlen;
+        return;
+    }
     static int fagqa = -1;
     if (fagqa < 0) {
         const char* e = getenv("SPARKINFER_FAGQA");

--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -243,6 +243,62 @@ template __global__ void qknorm_rope_kv_kernel<false>(
 template __global__ void qknorm_rope_kv_kernel<true>(
     __nv_bfloat16*, __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     void*, void*, __half*, __half*, const int*, const int*, int, int, int, float, int, int, float);
+__global__ void rope_kv_append_partial_kernel(
+    __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k,
+    const __nv_bfloat16* __restrict__ v,
+    __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    const int* __restrict__ block_table, const int* __restrict__ positions,
+    int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta,
+    int block_size, int max_blocks_per_seq
+) {
+    const int tok  = blockIdx.y;
+    const int rhalf = rotary_dim >> 1;
+    const int nq = n_q_heads  * rhalf;
+    const int nk = n_kv_heads * rhalf;
+    const int ktail = n_kv_heads * (head_dim - rotary_dim);
+    const int nv = n_kv_heads * head_dim;
+    const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gid >= nq + nk + ktail + nv) return;
+
+    const int pos    = positions[tok];
+    const int blk    = pos / block_size;
+    const int within = pos % block_size;
+    const int phys   = block_table[tok * max_blocks_per_seq + blk];
+    const size_t ctok = (size_t)(phys * block_size + within);
+
+    if (gid < nq) {
+        const int hh = gid / rhalf, i = gid - hh * rhalf;
+        const float freq = __powf(theta, -2.f * (float)i / (float)rotary_dim);
+        const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
+        const size_t base = ((size_t)(tok * n_q_heads + hh)) * head_dim;
+        const float x0 = __bfloat162float(q[base + i]);
+        const float x1 = __bfloat162float(q[base + i + rhalf]);
+        q[base + i]         = __float2bfloat16(x0 * c - x1 * s);
+        q[base + i + rhalf] = __float2bfloat16(x1 * c + x0 * s);
+    } else if (gid < nq + nk) {
+        const int g = gid - nq, hh = g / rhalf, i = g - hh * rhalf;
+        const float freq = __powf(theta, -2.f * (float)i / (float)rotary_dim);
+        const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
+        const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
+        const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+        const float x0 = __bfloat162float(k[base + i]);
+        const float x1 = __bfloat162float(k[base + i + rhalf]);
+        k_pool[dst + i]         = __float2bfloat16(x0 * c - x1 * s);
+        k_pool[dst + i + rhalf] = __float2bfloat16(x1 * c + x0 * s);
+    } else if (gid < nq + nk + ktail) {
+        const int g = gid - nq - nk;
+        const int hh = g / (head_dim - rotary_dim);
+        const int d = rotary_dim + (g - hh * (head_dim - rotary_dim));
+        const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
+        const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+        k_pool[dst + d] = k[base + d];
+    } else {
+        const int g = gid - nq - nk - ktail, hh = g / head_dim, d = g - hh * head_dim;
+        const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
+        const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+        v_pool[dst + d] = v[base + d];
+    }
+}
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -292,6 +348,30 @@ void launch_rope_kv_append(void* q, const void* k, const void* v, void* k_pool, 
         reinterpret_cast<const __nv_bfloat16*>(v),
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
         block_table, positions, n_q_heads, n_kv_heads, head_dim, theta, block_size, max_blocks_per_seq);
+}
+
+void launch_rope_kv_append_partial(void* q, const void* k, const void* v, void* k_pool, void* v_pool,
+                                   const int* block_table, const int* positions,
+                                   int n_tokens, int n_q_heads, int n_kv_heads,
+                                   int head_dim, int rotary_dim, float theta,
+                                   int block_size, int max_blocks_per_seq, cudaStream_t stream) {
+    if (rotary_dim <= 0 || rotary_dim >= head_dim) {
+        launch_rope_kv_append(q, k, v, k_pool, v_pool, block_table, positions,
+                              n_tokens, n_q_heads, n_kv_heads, head_dim, theta,
+                              block_size, max_blocks_per_seq, stream);
+        return;
+    }
+    const int rhalf = rotary_dim >> 1;
+    const int total = n_q_heads * rhalf + n_kv_heads * rhalf +
+                      n_kv_heads * (head_dim - rotary_dim) +
+                      n_kv_heads * head_dim;
+    dim3 grid((total + 255) / 256, n_tokens);
+    rope_kv_append_partial_kernel<<<grid, 256, 0, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v),
+        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        block_table, positions, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta,
+        block_size, max_blocks_per_seq);
 }
 
 void launch_rope(void* q, void* k, const int* positions,

--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -1,0 +1,245 @@
+// Qwen3.5/Qwen3.6 hybrid-layer helpers.
+//
+// These kernels implement the single-token decode path for the Gated DeltaNet
+// recurrent layers used by Qwen3.6-35B-A3B. They favor clear, graph-capturable
+// device-side state updates over aggressive specialization.
+
+#include <cuda_bf16.h>
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include <cuda_runtime.h>
+#endif
+
+namespace sparkinfer {
+namespace kernels {
+
+__device__ __forceinline__ float q36_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ float q36_silu(float x) { return x / (1.f + __expf(-x)); }
+__device__ __forceinline__ float q36_sigmoid(float x) { return 1.f / (1.f + __expf(-x)); }
+__device__ __forceinline__ float q36_softplus(float x) {
+    return x > 20.f ? x : __logf(1.f + __expf(x));
+}
+__device__ __forceinline__ float q36_wsum(float v) {
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffffu, v, m);
+    return v;
+}
+
+__global__ void split_q_gate_kernel(const __nv_bfloat16* __restrict__ qg,
+                                    __nv_bfloat16* __restrict__ q,
+                                    __nv_bfloat16* __restrict__ gate,
+                                    int n_heads, int head_dim) {
+    const int gid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int n = n_heads * head_dim;
+    if (gid >= n) return;
+    const int h = gid / head_dim;
+    const int d = gid - h * head_dim;
+    const size_t src = (size_t)h * 2 * head_dim + d;
+    q[gid] = qg[src];
+    gate[gid] = qg[src + head_dim];
+}
+
+__global__ void mul_sigmoid_kernel(__nv_bfloat16* __restrict__ x,
+                                   const __nv_bfloat16* __restrict__ gate,
+                                   int n) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    const float y = q36_to_f(x[i]) * q36_sigmoid(q36_to_f(gate[i]));
+    x[i] = __float2bfloat16(y);
+}
+
+__global__ void sigmoid_scalar_kernel(const __nv_bfloat16* __restrict__ x,
+                                      float* __restrict__ out) {
+    out[0] = q36_sigmoid(q36_to_f(x[0]));
+}
+
+__global__ void conv_split_kernel(const __nv_bfloat16* __restrict__ qkv,
+                                  const __nv_bfloat16* __restrict__ conv_w,
+                                  __nv_bfloat16* __restrict__ conv_state,
+                                  __nv_bfloat16* __restrict__ q,
+                                  __nv_bfloat16* __restrict__ k,
+                                  __nv_bfloat16* __restrict__ v,
+                                  int q_dim, int v_dim, int qkv_dim,
+                                  int conv_kernel) {
+    const int d = blockIdx.x * blockDim.x + threadIdx.x;
+    if (d >= qkv_dim) return;
+
+    float y = 0.f;
+    for (int t = 0; t < conv_kernel - 1; t++)
+        y += q36_to_f(conv_state[(size_t)t * qkv_dim + d]) *
+             q36_to_f(conv_w[(size_t)d * conv_kernel + t]);
+    y += q36_to_f(qkv[d]) * q36_to_f(conv_w[(size_t)d * conv_kernel + (conv_kernel - 1)]);
+
+    for (int t = 0; t < conv_kernel - 2; t++)
+        conv_state[(size_t)t * qkv_dim + d] = conv_state[(size_t)(t + 1) * qkv_dim + d];
+    if (conv_kernel > 1)
+        conv_state[(size_t)(conv_kernel - 2) * qkv_dim + d] = qkv[d];
+
+    const __nv_bfloat16 oy = __float2bfloat16(q36_silu(y));
+    if (d < q_dim) q[d] = oy;
+    else if (d < 2 * q_dim) k[d - q_dim] = oy;
+    else if (d < 2 * q_dim + v_dim) v[d - 2 * q_dim] = oy;
+}
+
+__global__ void l2_norm_heads_kernel(__nv_bfloat16* __restrict__ x,
+                                     int n_heads, int head_dim, float eps) {
+    const int h = blockIdx.x;
+    if (h >= n_heads) return;
+    const int t = threadIdx.x;
+    const size_t base = (size_t)h * head_dim;
+    const float xv = (t < head_dim) ? q36_to_f(x[base + t]) : 0.f;
+    __shared__ float sw[32];
+    float ss = q36_wsum(xv * xv);
+    if ((t & 31) == 0) sw[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < (blockDim.x + 31) / 32) ? sw[t] : 0.f;
+        v = q36_wsum(v);
+        if (t == 0) sw[0] = rsqrtf(v + eps);
+    }
+    __syncthreads();
+    if (t < head_dim) x[base + t] = __float2bfloat16(xv * sw[0]);
+}
+
+__global__ void gdn_ar_kernel(const __nv_bfloat16* __restrict__ q,
+                              const __nv_bfloat16* __restrict__ k,
+                              const __nv_bfloat16* __restrict__ v,
+                              const __nv_bfloat16* __restrict__ alpha,
+                              const __nv_bfloat16* __restrict__ beta,
+                              const __nv_bfloat16* __restrict__ dt,
+                              const __nv_bfloat16* __restrict__ a,
+                              float* __restrict__ state,
+                              __nv_bfloat16* __restrict__ out,
+                              int q_heads, int v_heads, int head_dim) {
+    const int vh = blockIdx.x;
+    if (vh >= v_heads) return;
+    const int j = threadIdx.x;
+    if (j >= head_dim) return;
+    const int qh = vh % q_heads;
+    const float scale = rsqrtf((float)head_dim);
+    const float b = q36_sigmoid(q36_to_f(beta[vh]));
+    const float g = __expf(q36_softplus(q36_to_f(alpha[vh]) + q36_to_f(dt[vh])) * q36_to_f(a[vh]));
+    const __nv_bfloat16* qhptr = q + (size_t)qh * head_dim;
+    const __nv_bfloat16* khptr = k + (size_t)qh * head_dim;
+    const __nv_bfloat16* vhptr = v + (size_t)vh * head_dim;
+    float* sptr = state + (size_t)vh * head_dim * head_dim;
+
+    float sk = 0.f;
+    for (int i = 0; i < head_dim; i++) {
+        float s = sptr[(size_t)i * head_dim + j] * g;
+        sptr[(size_t)i * head_dim + j] = s;
+        sk += s * q36_to_f(khptr[i]);
+    }
+    const float delta = (q36_to_f(vhptr[j]) - sk) * b;
+    float y = 0.f;
+    for (int i = 0; i < head_dim; i++) {
+        float s = sptr[(size_t)i * head_dim + j] + q36_to_f(khptr[i]) * delta;
+        sptr[(size_t)i * head_dim + j] = s;
+        y += s * q36_to_f(qhptr[i]) * scale;
+    }
+    out[(size_t)vh * head_dim + j] = __float2bfloat16(y);
+}
+
+__global__ void gated_norm_kernel(const __nv_bfloat16* __restrict__ x,
+                                  const __nv_bfloat16* __restrict__ z,
+                                  const __nv_bfloat16* __restrict__ weight,
+                                  __nv_bfloat16* __restrict__ out,
+                                  int v_heads, int head_dim, float eps) {
+    const int h = blockIdx.x;
+    if (h >= v_heads) return;
+    const int t = threadIdx.x;
+    const size_t base = (size_t)h * head_dim;
+    const float xv = (t < head_dim) ? q36_to_f(x[base + t]) : 0.f;
+    __shared__ float sw[32];
+    float ss = q36_wsum(xv * xv);
+    if ((t & 31) == 0) sw[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < (blockDim.x + 31) / 32) ? sw[t] : 0.f;
+        v = q36_wsum(v);
+        if (t == 0) sw[0] = rsqrtf(v / head_dim + eps);
+    }
+    __syncthreads();
+    if (t < head_dim) {
+        const float y = xv * sw[0] * q36_to_f(weight[t]) * q36_silu(q36_to_f(z[base + t]));
+        out[base + t] = __float2bfloat16(y);
+    }
+}
+
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include "sparkinfer/kernels/fused.h"
+
+void launch_qwen36_split_q_gate(const void* qg_bf16, void* q_bf16, void* gate_bf16,
+                                int n_heads, int head_dim, cudaStream_t stream) {
+    const int n = n_heads * head_dim;
+    split_q_gate_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qg_bf16),
+        reinterpret_cast<__nv_bfloat16*>(q_bf16),
+        reinterpret_cast<__nv_bfloat16*>(gate_bf16), n_heads, head_dim);
+}
+
+void launch_qwen36_mul_sigmoid(void* x_bf16, const void* gate_bf16, int n,
+                               cudaStream_t stream) {
+    mul_sigmoid_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(x_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(gate_bf16), n);
+}
+
+void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32,
+                                  cudaStream_t stream) {
+    sigmoid_scalar_kernel<<<1, 1, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x_bf16), out_f32);
+}
+
+void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
+                                 void* conv_state_bf16, void* q_bf16, void* k_bf16,
+                                 void* v_bf16, int q_heads, int v_heads, int head_dim,
+                                 int conv_kernel, float eps, cudaStream_t stream) {
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int qkv_dim = 2 * q_dim + v_dim;
+    conv_split_kernel<<<(qkv_dim + 255) / 256, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(conv_w_bf16),
+        reinterpret_cast<__nv_bfloat16*>(conv_state_bf16),
+        reinterpret_cast<__nv_bfloat16*>(q_bf16),
+        reinterpret_cast<__nv_bfloat16*>(k_bf16),
+        reinterpret_cast<__nv_bfloat16*>(v_bf16),
+        q_dim, v_dim, qkv_dim, conv_kernel);
+    l2_norm_heads_kernel<<<q_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q_bf16), q_heads, head_dim, eps);
+    l2_norm_heads_kernel<<<q_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(k_bf16), q_heads, head_dim, eps);
+}
+
+void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
+                          const void* alpha_bf16, const void* beta_bf16,
+                          const void* dt_bf16, const void* a_bf16,
+                          float* state_f32, void* out_bf16,
+                          int q_heads, int v_heads, int head_dim, cudaStream_t stream) {
+    gdn_ar_kernel<<<v_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(q_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(k_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(v_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(a_bf16),
+        state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
+        q_heads, v_heads, head_dim);
+}
+
+void launch_qwen36_gated_norm(const void* x_bf16, const void* z_bf16,
+                              const void* weight_bf16, void* out_bf16,
+                              int v_heads, int head_dim, float eps,
+                              cudaStream_t stream) {
+    gated_norm_kernel<<<v_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(z_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(weight_bf16),
+        reinterpret_cast<__nv_bfloat16*>(out_bf16),
+        v_heads, head_dim, eps);
+}
+#endif
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -45,6 +45,14 @@ void launch_rope_kv_append(
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, float theta,
     int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr);
 
+// Variant for models with partial rotary embeddings (e.g. Qwen3.6: 64 of 256
+// dimensions rotate, the remaining per-head dimensions are copied unchanged).
+void launch_rope_kv_append_partial(
+    void* q, const void* k, const void* v, void* k_pool, void* v_pool,
+    const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
+    float theta, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr);
+
 // Flash prefill: full causal attention for prompt processing.
 // q/k/v:  [batch, seqlen, num_heads, head_dim]
 // out:    same shape as q

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -42,5 +42,30 @@ void launch_argmax(const float* logits, int* out_id, int n_rows, int vocab,
 // Benchmark-only decode feedback: tok = out_id; pos/writepos/seqlen += 1.
 // Capturable, so a decode CUDA graph can self-feed during throughput timing.
 void launch_decode_feedback(int* scalars, const int* out_id, cudaStream_t stream = nullptr);
+// Qwen3.5/Qwen3.6 hybrid Gated DeltaNet helpers.
+void launch_qwen36_split_q_gate(const void* qg_bf16, void* q_bf16, void* gate_bf16,
+                                int n_heads, int head_dim, cudaStream_t stream = nullptr);
+
+void launch_qwen36_mul_sigmoid(void* x_bf16, const void* gate_bf16, int n,
+                               cudaStream_t stream = nullptr);
+
+void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32,
+                                  cudaStream_t stream = nullptr);
+
+void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
+                                 void* conv_state_bf16, void* q_bf16, void* k_bf16,
+                                 void* v_bf16, int q_heads, int v_heads, int head_dim,
+                                 int conv_kernel, float eps, cudaStream_t stream = nullptr);
+
+void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
+                          const void* alpha_bf16, const void* beta_bf16,
+                          const void* dt_bf16, const void* a_bf16,
+                          float* state_f32, void* out_bf16,
+                          int q_heads, int v_heads, int head_dim, cudaStream_t stream = nullptr);
+
+void launch_qwen36_gated_norm(const void* x_bf16, const void* z_bf16,
+                              const void* weight_bf16, void* out_bf16,
+                              int v_heads, int head_dim, float eps,
+                              cudaStream_t stream = nullptr);
 
 }} // namespace sparkinfer::kernels

--- a/moe/configs/qwen36_35b_a3b.yaml
+++ b/moe/configs/qwen36_35b_a3b.yaml
@@ -1,0 +1,39 @@
+# MoE engine configuration for Qwen3.6-35B-A3B
+# Attention is hybrid Gated DeltaNet + full attention; this file only captures
+# the per-layer MoE shape used after both attention types.
+
+num_experts: 256
+top_k: 8
+shared_expert: true
+hidden_dim: 2048
+ffn_dim: 512
+num_layers: 40
+
+router:
+  type: softmax_top_k
+  normalize_weights: true
+  aux_loss_coeff: 0.001
+
+expert_cache:
+  # RTX Spark / GB10 class: all experts fit in unified memory. RTX 5090-class
+  # cards need quantized residency and careful eviction/prefetch.
+  strategy: lru
+  prefetch: true
+  async_prefetch_depth: 2
+
+gemm:
+  strategy: skinny_grouped
+  min_tokens_for_batching: 4
+  use_gemv_for_single_token: true
+
+architecture_notes:
+  text_layers: 40
+  linear_attention_layers: 30
+  full_attention_layers: 10
+  full_attention_interval: 4
+  full_attention_heads: 16
+  full_attention_kv_heads: 2
+  full_attention_head_dim: 256
+  linear_attention_qk_heads: 16
+  linear_attention_value_heads: 32
+  linear_attention_head_dim: 128

--- a/runtime/examples/qwen3_gguf_config.h
+++ b/runtime/examples/qwen3_gguf_config.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include "sparkinfer/gguf.h"
+#include "sparkinfer/models/qwen_config.h"
+
+#include <limits>
+#include <string>
+
+static long qwen3_meta_int(const sparkinfer::GGUF& g, const std::string& key, long def) {
+    const long missing = std::numeric_limits<long>::min();
+    long v = g.meta_int("qwen35moe." + key, missing);
+    if (v != missing) return v;
+    v = g.meta_int("qwen3moe." + key, missing);
+    if (v != missing) return v;
+    v = g.meta_int("qwen3_5_moe." + key, missing);
+    return v != missing ? v : def;
+}
+
+static double qwen3_meta_float(const sparkinfer::GGUF& g, const std::string& key, double def) {
+    const double missing = -std::numeric_limits<double>::infinity();
+    double v = g.meta_float("qwen35moe." + key, missing);
+    if (v != missing) return v;
+    v = g.meta_float("qwen3moe." + key, missing);
+    if (v != missing) return v;
+    v = g.meta_float("qwen3_5_moe." + key, missing);
+    return v != missing ? v : def;
+}
+
+static bool qwen3_is_hybrid_35b(const sparkinfer::GGUF& g) {
+    const std::string name = g.meta_str("general.name");
+    if (name.find("Qwen3.5-35B-A3B") != std::string::npos ||
+        name.find("Qwen3.6-35B-A3B") != std::string::npos)
+        return true;
+    return g.tensor("blk.0.attn_qkv.weight") != nullptr &&
+           g.tensor("blk.3.attn_q.weight") != nullptr;
+}
+
+static void qwen3_config_from_gguf(const sparkinfer::GGUF& g, sparkinfer::Qwen35Config& cfg) {
+    cfg.n_layers   = (int)qwen3_meta_int(g, "block_count", cfg.n_layers);
+    cfg.hidden     = (int)qwen3_meta_int(g, "embedding_length", cfg.hidden);
+    cfg.n_q_heads  = (int)qwen3_meta_int(g, "attention.head_count", cfg.n_q_heads);
+    cfg.n_kv_heads = (int)qwen3_meta_int(g, "attention.head_count_kv", cfg.n_kv_heads);
+    cfg.head_dim   = (int)qwen3_meta_int(g, "attention.key_length", cfg.head_dim);
+    cfg.n_experts  = (int)qwen3_meta_int(g, "expert_count", cfg.n_experts);
+    cfg.top_k      = (int)qwen3_meta_int(g, "expert_used_count", cfg.top_k);
+    cfg.moe_ffn    = (int)qwen3_meta_int(g, "expert_feed_forward_length", cfg.moe_ffn);
+    cfg.rope_theta = (float)qwen3_meta_float(g, "rope.freq_base", cfg.rope_theta);
+    cfg.rms_eps    = (float)qwen3_meta_float(g, "attention.layer_norm_rms_epsilon", cfg.rms_eps);
+    cfg.eos_id     = (int)g.meta_int("tokenizer.ggml.eos_token_id", cfg.eos_id);
+    cfg.n_shared   = g.tensor("blk.0.ffn_gate_shexp.weight") ? 1 : 0;
+    cfg.vocab      = (int)qwen3_meta_int(g, "vocab_size", cfg.vocab);
+    const sparkinfer::GGUFTensor* emb = g.tensor("token_embd.weight");
+    if (emb && emb->n_dims >= 2) cfg.vocab = (int)emb->dims[1];
+
+    cfg.hybrid = qwen3_is_hybrid_35b(g);
+    if (!cfg.hybrid) {
+        cfg.rope_dim = 0;
+        return;
+    }
+
+    cfg.full_attn_interval = 4;
+    cfg.rope_dim = (cfg.head_dim == 256) ? 64 : cfg.rope_dim;
+    cfg.linear_head_dim = (int)qwen3_meta_int(g, "ssm.state_size", 128);
+    cfg.linear_q_heads = cfg.n_q_heads;
+    cfg.linear_v_heads = (int)qwen3_meta_int(g, "ssm.group_count", 32);
+    if (const sparkinfer::GGUFTensor* qkv = g.tensor("blk.0.attn_qkv.weight")) {
+        const int qkv_out = qkv->n_dims >= 2 ? (int)qkv->dims[1] : 0;
+        const int q_dim = cfg.linear_q_heads * cfg.linear_head_dim;
+        const int v_dim = qkv_out - 2 * q_dim;
+        if (v_dim > 0 && v_dim % cfg.linear_head_dim == 0)
+            cfg.linear_v_heads = v_dim / cfg.linear_head_dim;
+    }
+    cfg.linear_conv_kernel = (int)qwen3_meta_int(g, "ssm.conv_kernel", 4);
+    if (const sparkinfer::GGUFTensor* conv = g.tensor("blk.0.ssm_conv1d.weight"))
+        if (conv->n_dims >= 1) cfg.linear_conv_kernel = (int)conv->dims[0];
+}
+
+static const char* qwen3_model_label(const sparkinfer::Qwen35Config& cfg) {
+    return cfg.hybrid ? "Qwen3.5/Qwen3.6-35B-A3B hybrid" : "Qwen3-MoE";
+}

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -3,35 +3,17 @@
 #include <vector>
 #include <string>
 #include "sparkinfer/kv_cache.h"
+#include "sparkinfer/models/qwen_config.h"
 #include "sparkinfer/moe/engine.h"
 
 namespace sparkinfer {
 
 class ThermalGovernor;   // optional decode-time thermal pacing (thermal_governor.h)
 
-// Qwen3.5-35B-A3B architecture.
-//   40 layers, hidden 2048, 16 Q / 2 KV heads (8:1 GQA), head_dim 128,
-//   256 routed experts (top-8) + 1 shared expert, moe ffn 512,
-//   RoPE + per-head QK-norm, RMSNorm, SwiGLU.
-struct Qwen35Config {
-    int   vocab       = 151936;
-    int   hidden      = 2048;
-    int   n_layers    = 40;
-    int   n_q_heads   = 16;
-    int   n_kv_heads  = 2;
-    int   head_dim    = 128;
-    int   n_experts   = 256;
-    int   top_k       = 8;
-    int   n_shared    = 1;
-    int   moe_ffn     = 512;
-    float rope_theta  = 1000000.f;
-    float rms_eps     = 1e-6f;
-    int   max_seq     = 4096;   // KV-cache cap for a sequence
-    int   eos_id      = 151645;
-};
-
 // Device (bf16) weight pointers for one layer.
 struct Qwen35LayerWeights {
+    bool linear_attn = false;
+    bool q_has_gate = false;
     const void* input_norm   = nullptr;  // [hidden]
     const void* wq = nullptr;            // [hidden, n_q_heads*head_dim]
     const void* wk = nullptr;            // [hidden, n_kv_heads*head_dim]
@@ -47,6 +29,18 @@ struct Qwen35LayerWeights {
     const void* shared_gate = nullptr;   // [hidden, moe_ffn]
     const void* shared_up   = nullptr;   // [hidden, moe_ffn]
     const void* shared_down = nullptr;   // [moe_ffn, hidden]
+    const void* shared_gate_inp = nullptr;// [hidden] -> scalar shared-expert gate
+
+    // Qwen3.5/Qwen3.6 Gated DeltaNet tensors (linear-attention layers only).
+    const void* wqkv = nullptr;           // [hidden, q+k+v]
+    const void* wqkv_gate = nullptr;      // [hidden, value_dim]
+    const void* ssm_conv = nullptr;       // [conv_kernel, q+k+v]
+    const void* ssm_dt = nullptr;         // [value_heads]
+    const void* ssm_a = nullptr;          // [value_heads]
+    const void* ssm_beta = nullptr;       // [hidden, value_heads]
+    const void* ssm_alpha = nullptr;      // [hidden, value_heads]
+    const void* ssm_norm = nullptr;       // [linear_head_dim]
+    const void* ssm_out = nullptr;        // [value_dim, hidden]
 
     // GGUF path: experts kept quantized in VRAM (gguf-native [E,out,in] layout).
     // When gate_q != nullptr the model dequantizes these per-layer into scratch
@@ -56,6 +50,8 @@ struct Qwen35LayerWeights {
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
     int wq_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;
+    int wqkv_type = 0, wqkv_gate_type = 0, ssm_beta_type = 0, ssm_alpha_type = 0, ssm_out_type = 0;
+    int shared_gate_inp_type = 0;
 };
 
 struct Qwen35Weights {
@@ -66,7 +62,7 @@ struct Qwen35Weights {
     std::vector<Qwen35LayerWeights> layers;
 };
 
-// Single-sequence (batch=1) greedy decoder for Qwen3.5. Owns scratch buffers and
+// Single-sequence (batch=1) greedy decoder for Qwen MoE. Owns scratch buffers and
 // drives embed -> N layers -> final norm -> LM head -> argmax per token.
 class Qwen35Model {
 public:

--- a/runtime/include/sparkinfer/models/qwen_config.h
+++ b/runtime/include/sparkinfer/models/qwen_config.h
@@ -1,0 +1,36 @@
+#pragma once
+
+namespace sparkinfer {
+
+// Qwen MoE decode configuration. Defaults match the original full-attention
+// Qwen3.5-style target; GGUF metadata can switch this to the Qwen3.5/Qwen3.6
+// 35B-A3B hybrid stack with Gated DeltaNet recurrent layers.
+struct Qwen35Config {
+    int   vocab       = 151936;
+    int   hidden      = 2048;
+    int   n_layers    = 40;
+    int   n_q_heads   = 16;
+    int   n_kv_heads  = 2;
+    int   head_dim    = 128;
+    int   n_experts   = 256;
+    int   top_k       = 8;
+    int   n_shared    = 1;
+    int   moe_ffn     = 512;
+    float rope_theta  = 1000000.f;
+    float rms_eps     = 1e-6f;
+    int   max_seq     = 4096;   // KV-cache cap for a sequence
+    int   eos_id      = 151645;
+
+    // Qwen3.5/Qwen3.6 35B-A3B GGUFs use a hybrid stack: 3 Gated DeltaNet
+    // recurrent layers followed by 1 full-attention layer. The legacy Qwen3
+    // MoE path leaves these fields at their defaults.
+    bool  hybrid      = false;
+    int   full_attn_interval = 4;
+    int   rope_dim    = 0;      // 0 = rotate the full attention head
+    int   linear_q_heads = 16;
+    int   linear_v_heads = 32;
+    int   linear_head_dim = 128;
+    int   linear_conv_kernel = 4;
+};
+
+} // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1,9 +1,11 @@
-// Qwen3.5-35B-A3B single-sequence greedy decoder.
+// Qwen MoE single-sequence greedy decoder.
 //
 // Per token: embed -> [40x Qwen layer] -> final RMSNorm -> LM head -> argmax.
-// Qwen layer: RMSNorm -> Q/K/V -> per-head QK-norm -> RoPE -> KV append ->
-//             GQA flash decode -> O-proj -> residual -> RMSNorm ->
+// Qwen full-attention layer: RMSNorm -> Q/K/V -> per-head QK-norm -> RoPE ->
+//             KV append -> GQA flash decode -> O-proj -> residual -> RMSNorm ->
 //             routed top-8 MoE (+ shared expert) -> residual.
+// Qwen3.5/Qwen3.6 hybrid layers replace full attention with a single-token
+// Gated DeltaNet recurrent update on the 3-of-4 linear-attention layers.
 // All steps run on one stream; only the sampled id is copied to the host, which
 // autoregressive greedy decoding fundamentally requires.
 
@@ -25,6 +27,7 @@
 #include <vector>
 #include <string>
 #include <fstream>
+#include <limits>
 
 namespace sparkinfer {
 
@@ -48,6 +51,43 @@ bool ggml_dequant_supported(int ggml_type) {
             return false;
     }
 }
+
+long qwen_moe_meta_int(const GGUF& g, const std::string& key, long def) {
+    const long missing = std::numeric_limits<long>::min();
+    long v = g.meta_int("qwen35moe." + key, missing);
+    if (v != missing) return v;
+    v = g.meta_int("qwen3moe." + key, missing);
+    if (v != missing) return v;
+    v = g.meta_int("qwen3_5_moe." + key, missing);
+    return v != missing ? v : def;
+}
+
+bool is_qwen35_or_qwen36_hybrid_moe(const GGUF& g) {
+    const std::string name = g.meta_str("general.name");
+    if (name.find("Qwen3.5-35B-A3B") != std::string::npos ||
+        name.find("Qwen3.6-35B-A3B") != std::string::npos)
+        return true;
+
+    const GGUFTensor* emb = g.tensor("token_embd.weight");
+    const long vocab = emb ? emb->dims[1] : qwen_moe_meta_int(g, "vocab_size", -1);
+    const bool hybrid_tensor_layout =
+        g.tensor("blk.0.attn_q.weight") == nullptr &&
+        g.tensor("blk.3.attn_q.weight") != nullptr;
+    return qwen_moe_meta_int(g, "block_count", -1) == 40 &&
+           qwen_moe_meta_int(g, "embedding_length", -1) == 2048 &&
+           qwen_moe_meta_int(g, "attention.head_count", -1) == 16 &&
+           qwen_moe_meta_int(g, "attention.head_count_kv", -1) == 2 &&
+           qwen_moe_meta_int(g, "attention.key_length", -1) == 256 &&
+           qwen_moe_meta_int(g, "expert_count", -1) == 256 &&
+           qwen_moe_meta_int(g, "expert_used_count", -1) == 8 &&
+           qwen_moe_meta_int(g, "expert_feed_forward_length", -1) == 512 &&
+           vocab == 248320 &&
+           hybrid_tensor_layout;
+}
+
+bool is_linear_layer(const Qwen35Config& c, int layer) {
+    return c.hybrid && c.full_attn_interval > 0 && ((layer + 1) % c.full_attn_interval) != 0;
+}
 }
 
 struct Qwen35Model::Impl {
@@ -60,6 +100,7 @@ struct Qwen35Model::Impl {
     cudaEvent_t ev_qkv{}, ev_k{}, ev_v{};        // fork/join events (captured into the decode graph)
     uint64_t seq_id = 0;
     int qdim, kvdim;
+    int linear_qdim = 0, linear_vdim = 0, linear_qkvdim = 0;
     bool gguf = false;   // true after load_gguf: dense weights are native [out,in], use GEMV
     // CUDA-graph capture of the decode compute (captured once, replayed each token)
     cudaGraph_t cu_graph{};
@@ -69,6 +110,12 @@ struct Qwen35Model::Impl {
 
     // scratch (bf16)
     bf16 *x, *xn, *q, *k, *v, *attn, *ao, *h, *hn, *routed, *shared;
+    bf16 *qraw = nullptr, *qgate = nullptr;
+    bf16 *lin_qkv = nullptr, *lin_q = nullptr, *lin_k = nullptr, *lin_v = nullptr;
+    bf16 *lin_z = nullptr, *lin_alpha = nullptr, *lin_beta = nullptr;
+    bf16 *lin_gdn = nullptr, *lin_norm = nullptr, *shared_gate_tmp = nullptr;
+    bf16 *lin_conv_state = nullptr;
+    float* lin_state = nullptr;
     float* logits;
     int *d_scalars, *d_tok, *d_out_id, *d_pos, *d_seqlen, *d_writepos, *d_shared_ids;
     int *h_scalars = nullptr, *h_out_id = nullptr;
@@ -115,6 +162,9 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* c = getenv("SPARKINFER_SPLIT_CHUNK")) { int v = atoi(c); if (v > 0) p_->split_chunk = v; }
     p_->qdim = cfg.n_q_heads * cfg.head_dim;
     p_->kvdim = cfg.n_kv_heads * cfg.head_dim;
+    p_->linear_qdim = cfg.linear_q_heads * cfg.linear_head_dim;
+    p_->linear_vdim = cfg.linear_v_heads * cfg.linear_head_dim;
+    p_->linear_qkvdim = 2 * p_->linear_qdim + p_->linear_vdim;
     cudaStreamCreate(&p_->stream);
     cudaStreamCreate(&p_->stream_k); cudaStreamCreate(&p_->stream_v);
     cudaEventCreateWithFlags(&p_->ev_qkv, cudaEventDisableTiming);
@@ -126,6 +176,22 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->attn=p_->alloc<bf16>(p_->qdim); p_->ao=p_->alloc<bf16>(H);
     p_->h=p_->alloc<bf16>(H); p_->hn=p_->alloc<bf16>(H);
     p_->routed=p_->alloc<bf16>(H); p_->shared=p_->alloc<bf16>(H);
+    if (cfg.hybrid) {
+        p_->qraw=p_->alloc<bf16>(p_->qdim * 2);
+        p_->qgate=p_->alloc<bf16>(p_->qdim);
+        p_->lin_qkv=p_->alloc<bf16>(p_->linear_qkvdim);
+        p_->lin_q=p_->alloc<bf16>(p_->linear_qdim);
+        p_->lin_k=p_->alloc<bf16>(p_->linear_qdim);
+        p_->lin_v=p_->alloc<bf16>(p_->linear_vdim);
+        p_->lin_z=p_->alloc<bf16>(p_->linear_vdim);
+        p_->lin_alpha=p_->alloc<bf16>(cfg.linear_v_heads);
+        p_->lin_beta=p_->alloc<bf16>(cfg.linear_v_heads);
+        p_->lin_gdn=p_->alloc<bf16>(p_->linear_vdim);
+        p_->lin_norm=p_->alloc<bf16>(p_->linear_vdim);
+        p_->lin_conv_state=p_->alloc<bf16>((size_t)cfg.n_layers * (cfg.linear_conv_kernel - 1) * p_->linear_qkvdim);
+        p_->lin_state=p_->alloc<float>((size_t)cfg.n_layers * cfg.linear_v_heads * cfg.linear_head_dim * cfg.linear_head_dim);
+        p_->shared_gate_tmp=p_->alloc<bf16>(1);
+    }
     p_->logits=p_->alloc<float>(cfg.vocab);
     p_->d_scalars=p_->alloc<int>(4);
     p_->d_tok=p_->d_scalars + 0; p_->d_pos=p_->d_scalars + 1;
@@ -170,9 +236,16 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->x); cudaFree(p_->xn); cudaFree(p_->q); cudaFree(p_->k); cudaFree(p_->v);
     cudaFree(p_->attn); cudaFree(p_->ao); cudaFree(p_->h); cudaFree(p_->hn);
     cudaFree(p_->routed); cudaFree(p_->shared); cudaFree(p_->logits);
+    // main's packed decode scalars (d_tok/d_pos/d_seqlen/d_writepos alias into d_scalars — not freed separately)
     cudaFree(p_->d_scalars); cudaFree(p_->d_out_id);
     cudaFreeHost(p_->h_scalars); cudaFreeHost(p_->h_out_id);
     cudaFree(p_->d_shared_ids); cudaFree(p_->d_shared_w);
+    // Qwen3.6 Gated-DeltaNet buffers (allocated only for the hybrid model)
+    cudaFree(p_->qraw); cudaFree(p_->qgate);
+    cudaFree(p_->lin_qkv); cudaFree(p_->lin_q); cudaFree(p_->lin_k); cudaFree(p_->lin_v);
+    cudaFree(p_->lin_z); cudaFree(p_->lin_alpha); cudaFree(p_->lin_beta);
+    cudaFree(p_->lin_gdn); cudaFree(p_->lin_norm); cudaFree(p_->lin_conv_state); cudaFree(p_->lin_state);
+    cudaFree(p_->shared_gate_tmp);
     cudaFree(p_->mf_logits); cudaFree(p_->mf_weights); cudaFree(p_->mf_h); cudaFree(p_->mf_out);
     cudaFree(p_->mf_ids); cudaFree(p_->mf_counts);
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
@@ -224,6 +297,14 @@ int Qwen35Model::forward_token(int token_id, int position) {
             }
         }
     }
+    if (c.hybrid && position == 0) {
+        cu(cudaMemsetAsync(s.lin_state, 0,
+                           (size_t)c.n_layers * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim * sizeof(float), st),
+           "linear state reset");
+        cu(cudaMemsetAsync(s.lin_conv_state, 0,
+                           (size_t)c.n_layers * (c.linear_conv_kernel - 1) * s.linear_qkvdim * sizeof(bf16), st),
+           "linear conv reset");
+    }
 
     // Capture the decode compute into a CUDA graph on the first token, then
     // replay it every token (per-token inputs live in the d_tok/pos/seqlen/
@@ -251,101 +332,172 @@ int Qwen35Model::forward_token(int token_id, int position) {
 
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
-        if (s.gguf) {   // GGUF dense weights are native [out,in] -> coalesced GEMV
-            // Q/K/V all read xn: quantize it to Q8_1 ONCE, then dp4a each Q4_K proj against it
-            // (no per-block, per-GEMV re-quant). Q6_K/bf16 weights keep their existing path.
-            const bool any_q4k = (w.wq_type == 12 || w.wk_type == 12 || w.wv_type == 12);
-            const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
-            if (fnq && L > 0) { /* aq81 = Q8_1(xn) already emitted by layer L-1's post-MoE norm */ }
-            else if (s.use_pq && s.use_llama && (any_q4k || any_q6k))
-                kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);   // shared Q8_1(xn) for Q4_K + Q6_K mmvq
-            else if (s.use_pq && any_q4k)
+        bool xn_q8_ready = fnq && L > 0;
+        auto prepare_xn_quant = [&](bool any_q4k, bool any_q6k) {
+            if (!s.gguf || !s.use_pq) return;
+            if (xn_q8_ready) return;
+            if (s.use_llama && (any_q4k || (s.use_q6mmvq && any_q6k))) {
+                kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
+                xn_q8_ready = true;
+            } else if (any_q4k) {
                 kernels::launch_quantize_q8_1(s.xn, s.aq8, s.aq8_d, s.aq8_s, H, st);
-            auto proj = [&](const void* W, int t, void* y, int N, cudaStream_t pst) {
+            }
+        };
+        auto proj_xn = [&](const void* W, int t, void* y, int N, cudaStream_t pst) {
+            if (s.gguf) {
                 if (s.use_pq && t == 12) {
                     if (s.use_llama) kernels::launch_mmvq_q4k(s.aq81, W, y, N, H, pst);
                     else             kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s, W, y, N, H, pst);
                 }
-                else if (s.use_q6mmvq && t == 14)
-                    kernels::launch_mmvq_q6k(s.aq81, W, y, N, H, pst);       // Q6_K mmvq (attn-V upgrades); reuses aq81
-
+                else if (s.use_pq && s.use_llama && s.use_q6mmvq && t == 14)
+                    kernels::launch_mmvq_q6k(s.aq81, W, y, N, H, pst);
                 else if (t) kernels::launch_gemv_q(s.xn, W, t, y, N, H, pst);
                 else        kernels::launch_gemv(s.xn, W, y, N, H, pst);
-            };
-            if (s.use_qkvstream) {
-                // Each Q/K/V GEMV under-occupies the GPU at bs=1 (latency-bound); run them
-                // concurrently on 3 streams so their memory traffic overlaps. Fork after the
-                // shared activation quantize, join before QK-norm. Captured into the decode graph.
-                cudaEventRecord(s.ev_qkv, st);
-                cudaStreamWaitEvent(s.stream_k, s.ev_qkv, 0);
-                cudaStreamWaitEvent(s.stream_v, s.ev_qkv, 0);
-                proj(w.wq, w.wq_type, s.q, s.qdim, st);
-                proj(w.wk, w.wk_type, s.k, s.kvdim, s.stream_k);
-                proj(w.wv, w.wv_type, s.v, s.kvdim, s.stream_v);
-                cudaEventRecord(s.ev_k, s.stream_k);
-                cudaEventRecord(s.ev_v, s.stream_v);
-                cudaStreamWaitEvent(st, s.ev_k, 0);
-                cudaStreamWaitEvent(st, s.ev_v, 0);
             } else {
-                proj(w.wq, w.wq_type, s.q, s.qdim, st);
-                proj(w.wk, w.wk_type, s.k, s.kvdim, st);
-                proj(w.wv, w.wv_type, s.v, s.kvdim, st);
+                kernels::launch_gemm(s.xn, W, y, 1, N, H, 1.f, 0.f, gc, pst);
             }
-        } else {
-            kernels::launch_gemm(s.xn, w.wq, s.q, 1, s.qdim,  H, 1.f, 0.f, gc, st);
-            kernels::launch_gemm(s.xn, w.wk, s.k, 1, s.kvdim, H, 1.f, 0.f, gc, st);
-            kernels::launch_gemm(s.xn, w.wv, s.v, 1, s.kvdim, H, 1.f, 0.f, gc, st);
-        }
-        // int8 KV: byte-scaled layer offset (1 B int8 / 2 B bf16) + parallel per-(token,kv_head) scale pool.
-        const bool kv8 = s.kv->int8_kv();
-        const int kv_elem = kv8 ? 1 : 2;
-        void* kpool = (char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-        void* vpool = (char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-        void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-        void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-        if (s.use_attnin || kv8) {   // fused QK-norm + RoPE + KV-append (int8-capable writer; required for int8 KV)
-            kernels::launch_qknorm_rope_kv_append(s.q, s.k, s.v, w.q_norm, w.k_norm, kpool, vpool,
-                                                  btable, s.d_pos, 1, c.n_q_heads, c.n_kv_heads,
-                                                  c.head_dim, c.rope_theta, c.rms_eps,
-                                                  s.kv->block_size(), s.kv->max_blocks_per_seq(), st,
-                                                  kscale, vscale, kv8 ? 1 : 0);
-        } else {
-        if (s.use_qkfuse)
-            kernels::launch_rmsnorm_qk(s.q, s.k, w.q_norm, w.k_norm, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rms_eps, st);
-        else {
-            kernels::launch_rmsnorm(s.q, w.q_norm, s.q, c.n_q_heads,  c.head_dim, c.rms_eps, st);
-            kernels::launch_rmsnorm(s.k, w.k_norm, s.k, c.n_kv_heads, c.head_dim, c.rms_eps, st);
-        }
-        if (s.use_ropekv) {   // fused rope(Q in place) + rope(K)->cache + V->cache (1 node vs 2)
-            kernels::launch_rope_kv_append(s.q, s.k, s.v, kpool, vpool, btable, s.d_pos, 1,
-                                           c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta,
-                                           s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
-        } else {
-            kernels::launch_rope(s.q, s.k, s.d_pos, 1, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta, st);
-            launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_writepos, 1,
-                             c.n_kv_heads, c.head_dim, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
-        }
-        }
-        // When the O-projection takes the Q4_K int8 MMVQ path, let the flash-decode combine emit
-        // Q8_1(attn) straight into aq81 (deleting the standalone attn-quantize node below).
-        const bool emit_attn_q8 = s.use_attnin && s.gguf && s.use_pq && s.use_llama && w.wo_type == 12;
-        kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,
-                                           s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                                           s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
-                                           1.f / sqrtf((float)c.head_dim), st,
-                                           emit_attn_q8 ? s.aq81 : nullptr, seqlen, kscale, vscale, kv8 ? 1 : 0);
-        if (s.gguf && s.use_pq && w.wo_type == 12) {   // O proj reads attn: quantize once + dp4a
-            if (s.use_llama) {
-                if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
-                kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
+        };
+        auto proj_from = [&](const void* x, const void* W, int t, void* y, int N, int K) {
+            if (s.gguf) {
+                if (s.use_pq && t == 12) {
+                    if (s.use_llama) {
+                        kernels::launch_quantize_q8_1_blocks(x, s.aq81, K, st);
+                        kernels::launch_mmvq_q4k(s.aq81, W, y, N, K, st);
+                    } else {
+                        kernels::launch_quantize_q8_1(x, s.aq8, s.aq8_d, s.aq8_s, K, st);
+                        kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s, W, y, N, K, st);
+                    }
+                } else if (s.use_pq && s.use_llama && s.use_q6mmvq && t == 14) {
+                    kernels::launch_quantize_q8_1_blocks(x, s.aq81, K, st);
+                    kernels::launch_mmvq_q6k(s.aq81, W, y, N, K, st);
+                } else if (t) kernels::launch_gemv_q(x, W, t, y, N, K, st);
+                else          kernels::launch_gemv(x, W, y, N, K, st);
             } else {
-                kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);
-                kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s, w.wo, s.ao, H, s.qdim, st);
+                kernels::launch_gemm(x, W, y, 1, N, K, 1.f, 0.f, gc, st);
             }
+        };
+
+        if (w.linear_attn) {
+            const bool any_q4k = (w.wqkv_type == 12 || w.wqkv_gate_type == 12 ||
+                                  w.ssm_alpha_type == 12 || w.ssm_beta_type == 12);
+            const bool any_q6k = (w.wqkv_type == 14 || w.wqkv_gate_type == 14 ||
+                                  w.ssm_alpha_type == 14 || w.ssm_beta_type == 14);
+            prepare_xn_quant(any_q4k, any_q6k);
+            proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
+            proj_xn(w.wqkv_gate, w.wqkv_gate_type, s.lin_z, s.linear_vdim, st);
+            proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
+            proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
+
+            bf16* conv_state = s.lin_conv_state +
+                (size_t)L * (c.linear_conv_kernel - 1) * s.linear_qkvdim;
+            kernels::launch_qwen36_conv_split_l2(s.lin_qkv, w.ssm_conv, conv_state,
+                                                 s.lin_q, s.lin_k, s.lin_v,
+                                                 c.linear_q_heads, c.linear_v_heads,
+                                                 c.linear_head_dim, c.linear_conv_kernel,
+                                                 c.rms_eps, st);
+            float* layer_state = s.lin_state +
+                (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;
+            kernels::launch_qwen36_gdn_ar(s.lin_q, s.lin_k, s.lin_v,
+                                          s.lin_alpha, s.lin_beta, w.ssm_dt, w.ssm_a,
+                                          layer_state, s.lin_gdn,
+                                          c.linear_q_heads, c.linear_v_heads,
+                                          c.linear_head_dim, st);
+            kernels::launch_qwen36_gated_norm(s.lin_gdn, s.lin_z, w.ssm_norm, s.lin_norm,
+                                              c.linear_v_heads, c.linear_head_dim, c.rms_eps, st);
+            proj_from(s.lin_norm, w.ssm_out, w.ssm_out_type, s.ao, H, s.linear_vdim);
+        } else {
+            // ---- Q/K/V projection (q_has_gate-aware; q_has_gate=false is byte-identical to Qwen3-MoE) ----
+            if (s.gguf) {
+                const bool any_q4k = (w.wq_type == 12 || w.wk_type == 12 || w.wv_type == 12);
+                const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
+                prepare_xn_quant(any_q4k, any_q6k);
+                if (s.use_qkvstream) {
+                    cudaEventRecord(s.ev_qkv, st);
+                    cudaStreamWaitEvent(s.stream_k, s.ev_qkv, 0);
+                    cudaStreamWaitEvent(s.stream_v, s.ev_qkv, 0);
+                    proj_xn(w.wq, w.wq_type, w.q_has_gate ? s.qraw : s.q, w.q_has_gate ? s.qdim * 2 : s.qdim, st);
+                    proj_xn(w.wk, w.wk_type, s.k, s.kvdim, s.stream_k);
+                    proj_xn(w.wv, w.wv_type, s.v, s.kvdim, s.stream_v);
+                    cudaEventRecord(s.ev_k, s.stream_k);
+                    cudaEventRecord(s.ev_v, s.stream_v);
+                    cudaStreamWaitEvent(st, s.ev_k, 0);
+                    cudaStreamWaitEvent(st, s.ev_v, 0);
+                } else {
+                    proj_xn(w.wq, w.wq_type, w.q_has_gate ? s.qraw : s.q, w.q_has_gate ? s.qdim * 2 : s.qdim, st);
+                    proj_xn(w.wk, w.wk_type, s.k, s.kvdim, st);
+                    proj_xn(w.wv, w.wv_type, s.v, s.kvdim, st);
+                }
+            } else {
+                kernels::launch_gemm(s.xn, w.wq, w.q_has_gate ? s.qraw : s.q,
+                                     1, w.q_has_gate ? s.qdim * 2 : s.qdim, H, 1.f, 0.f, gc, st);
+                kernels::launch_gemm(s.xn, w.wk, s.k, 1, s.kvdim, H, 1.f, 0.f, gc, st);
+                kernels::launch_gemm(s.xn, w.wv, s.v, 1, s.kvdim, H, 1.f, 0.f, gc, st);
+            }
+            if (w.q_has_gate)
+                kernels::launch_qwen36_split_q_gate(s.qraw, s.q, s.qgate, c.n_q_heads, c.head_dim, st);
+
+            // ---- QK-norm + RoPE + KV-append ----
+            const bool kv8 = s.kv->int8_kv();
+            const int kv_elem = kv8 ? 1 : 2;
+            void* kpool = (char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+            void* vpool = (char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            const bool partial_rope = (c.rope_dim > 0 && c.rope_dim < c.head_dim);
+            if (!w.q_has_gate && !partial_rope && (s.use_attnin || kv8)) {
+                // Qwen3-MoE frontier: fused int8 QK-norm + RoPE + KV-append (unchanged vs main)
+                kernels::launch_qknorm_rope_kv_append(s.q, s.k, s.v, w.q_norm, w.k_norm, kpool, vpool,
+                                                      btable, s.d_pos, 1, c.n_q_heads, c.n_kv_heads,
+                                                      c.head_dim, c.rope_theta, c.rms_eps,
+                                                      s.kv->block_size(), s.kv->max_blocks_per_seq(), st,
+                                                      kscale, vscale, kv8 ? 1 : 0);
+            } else {
+                // Qwen3.6 (gated / partial-rotary) or non-int8: separate norm + rope + append (bf16 KV)
+                if (s.use_qkfuse)
+                    kernels::launch_rmsnorm_qk(s.q, s.k, w.q_norm, w.k_norm, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rms_eps, st);
+                else {
+                    kernels::launch_rmsnorm(s.q, w.q_norm, s.q, c.n_q_heads,  c.head_dim, c.rms_eps, st);
+                    kernels::launch_rmsnorm(s.k, w.k_norm, s.k, c.n_kv_heads, c.head_dim, c.rms_eps, st);
+                }
+                if (partial_rope) {
+                    kernels::launch_rope_kv_append_partial(s.q, s.k, s.v, (bf16*)kpool, (bf16*)vpool, btable, s.d_pos, 1,
+                                                           c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim,
+                                                           c.rope_theta, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
+                } else if (s.use_ropekv) {
+                    kernels::launch_rope_kv_append(s.q, s.k, s.v, (bf16*)kpool, (bf16*)vpool, btable, s.d_pos, 1,
+                                                   c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta,
+                                                   s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
+                } else {
+                    kernels::launch_rope(s.q, s.k, s.d_pos, 1, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta, st);
+                    launch_kv_append((bf16*)kpool, (bf16*)vpool, s.k, s.v, btable, s.d_writepos, 1,
+                                     c.n_kv_heads, c.head_dim, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
+                }
+            }
+
+            // ---- attention (Q8-emit only when output is not gated: the gate mutates attn after decode) ----
+            const bool emit_attn_q8 = !w.q_has_gate && s.use_attnin && s.gguf && s.use_pq && s.use_llama && w.wo_type == 12;
+            kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,
+                                               s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                                               s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
+                                               1.f / sqrtf((float)c.head_dim), st,
+                                               emit_attn_q8 ? s.aq81 : nullptr, seqlen, kscale, vscale, kv8 ? 1 : 0);
+            if (w.q_has_gate)
+                kernels::launch_qwen36_mul_sigmoid(s.attn, s.qgate, s.qdim, st);
+
+            // ---- O projection (main's int8 mmvq path) ----
+            if (s.gguf && s.use_pq && w.wo_type == 12) {
+                if (s.use_llama) {
+                    if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                    kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
+                } else {
+                    kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);
+                    kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s, w.wo, s.ao, H, s.qdim, st);
+                }
+            }
+            else if (s.gguf && w.wo_type) kernels::launch_gemv_q(s.attn, w.wo, w.wo_type, s.ao, H, s.qdim, st);
+            else if (s.gguf)         kernels::launch_gemv(s.attn, w.wo, s.ao, H, s.qdim, st);
+            else                     kernels::launch_gemm(s.attn, w.wo, s.ao, 1, H, s.qdim, 1.f, 0.f, gc, st);
         }
-        else if (s.gguf && w.wo_type) kernels::launch_gemv_q(s.attn, w.wo, w.wo_type, s.ao, H, s.qdim, st);
-        else if (s.gguf)         kernels::launch_gemv(s.attn, w.wo, s.ao, H, s.qdim, st);
-        else                     kernels::launch_gemm(s.attn, w.wo, s.ao, 1, H, s.qdim, 1.f, 0.f, gc, st);
 
         // fused: h = x + ao ; hn = RMSNorm(h, post_attn_norm). When fnq, also emit Q8_1(hn) into
         // aq81 so the MoE gate/up mmvq skips its own quantize node (the router below reads bf16 hn).
@@ -377,6 +529,30 @@ int Qwen35Model::forward_token(int token_id, int position) {
             s.engine->forward(s.hn, s.routed, 1, L, st);
         }
         if (c.n_shared > 0) {
+            if (w.shared_gate_inp) {
+                if (s.gguf) {
+                    if (s.use_pq && w.shared_gate_inp_type == 12) {
+                        if (s.use_llama) {
+                            if (!fnq) kernels::launch_quantize_q8_1_blocks(s.hn, s.aq81, H, st);
+                            kernels::launch_mmvq_q4k(s.aq81, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                        } else {
+                            kernels::launch_quantize_q8_1(s.hn, s.aq8, s.aq8_d, s.aq8_s, H, st);
+                            kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s,
+                                                            w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                        }
+                    } else if (s.use_pq && s.use_llama && s.use_q6mmvq && w.shared_gate_inp_type == 14) {
+                        if (!fnq) kernels::launch_quantize_q8_1_blocks(s.hn, s.aq81, H, st);
+                        kernels::launch_mmvq_q6k(s.aq81, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                    } else if (w.shared_gate_inp_type) {
+                        kernels::launch_gemv_q(s.hn, w.shared_gate_inp, w.shared_gate_inp_type, s.shared_gate_tmp, 1, H, st);
+                    } else {
+                        kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                    }
+                } else {
+                    kernels::launch_gemm(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, 1, H, 1.f, 0.f, gc, st);
+                }
+                kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
+            }
             kernels::launch_moe_expert_ffn(s.hn, w.shared_gate, w.shared_up, w.shared_down,
                                            s.d_shared_ids, s.d_shared_w, s.shared,
                                            1, 1, 1, H, c.moe_ffn, st);
@@ -529,16 +705,36 @@ bool Qwen35Model::load_weights(const std::string& dir) {
 // ----- native GGUF load: dense -> bf16 (dequant + transpose), experts kept quantized -----
 bool Qwen35Model::load_gguf(const std::string& path) {
     Impl& s = *p_;
-    const Qwen35Config& c = s.cfg;
-    s.gguf = true;   // dense weights kept native [out,in]; forward uses GEMV
     GGUF g;
     if (!g.open(path)) return false;
+    const bool hybrid_file = is_qwen35_or_qwen36_hybrid_moe(g);
+    if (hybrid_file && !s.cfg.hybrid) {
+        fprintf(stderr,
+                "[qwen35] Qwen3.5/Qwen3.6 hybrid GGUF requires constructing "
+                "Qwen35Model with cfg.hybrid=true and the GGUF metadata-derived "
+                "head dimensions before load_gguf(), so scratch buffers and KV "
+                "cache are sized correctly.\n");
+        return false;
+    }
+    if (hybrid_file) {
+        s.cfg.hybrid = true;
+        if (s.cfg.full_attn_interval <= 0) s.cfg.full_attn_interval = 4;
+        if (s.cfg.rope_dim <= 0 && s.cfg.head_dim == 256) s.cfg.rope_dim = 64;
+        if (s.cfg.linear_q_heads <= 0) s.cfg.linear_q_heads = 16;
+        if (s.cfg.linear_v_heads <= 0) s.cfg.linear_v_heads = 32;
+        if (s.cfg.linear_head_dim <= 0) s.cfg.linear_head_dim = 128;
+        if (s.cfg.linear_conv_kernel <= 0) s.cfg.linear_conv_kernel = 4;
+    }
+    const Qwen35Config& c = s.cfg;
+    const int H = c.hidden;
+    s.gguf = true;   // dense weights kept native [out,in]; forward uses GEMV
 
     // Shared-expert tensors are optional in GGUF (Qwen3-30B-A3B has none). The
     // default config sets n_shared=1, so clamp it to what the file actually
     // contains before forward_token can launch a null-weight FFN.
     const bool gguf_has_shared =
         g.tensor("blk.0.ffn_gate_shexp.weight") != nullptr;
+    if (hybrid_file && gguf_has_shared && s.cfg.n_shared == 0) s.cfg.n_shared = 1;
     if (c.n_shared > 0 && !gguf_has_shared) {
         fprintf(stderr,
                 "[gguf] no shared-expert tensors; forcing n_shared=0 "
@@ -599,6 +795,37 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
         type = 0; return dense(name, false);
     };
+    auto attn_w_opt = [&](const std::string& name, int& type) -> const void* {
+        const GGUFTensor* t = g.tensor(name);
+        if (!t) { type = 0; return nullptr; }
+        if (qattn && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
+        type = 0; return dense(name, false);
+    };
+    auto dense_opt = [&](const std::string& name, bool transpose) -> const void* {
+        return g.tensor(name) ? dense(name, transpose) : nullptr;
+    };
+    auto expect_dims = [&](const std::string& name, std::initializer_list<long> dims) -> bool {
+        const GGUFTensor* t = g.tensor(name);
+        if (!t) { fprintf(stderr, "[gguf] missing %s\n", name.c_str()); return false; }
+        if (t->n_dims != (int)dims.size()) {
+            fprintf(stderr, "[gguf] bad rank for %s: got %d want %zu\n",
+                    name.c_str(), t->n_dims, dims.size());
+            return false;
+        }
+        int i = 0;
+        for (long want : dims) {
+            if (t->dims[i] != want) {
+                fprintf(stderr, "[gguf] bad shape for %s dim%d: got %ld want %ld\n",
+                        name.c_str(), i, t->dims[i], want);
+                return false;
+            }
+            i++;
+        }
+        return true;
+    };
+    auto expect_dims_opt = [&](const std::string& name, std::initializer_list<long> dims) -> bool {
+        return !g.tensor(name) || expect_dims(name, dims);
+    };
 
     s.w.embed_tokens = dense("token_embd.weight", false);     // [vocab,hidden] as-is
     s.w.final_norm   = dense("output_norm.weight", false);
@@ -610,22 +837,70 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     for (int i = 0; i < c.n_layers; i++) {
         std::string b = "blk." + std::to_string(i) + ".";
         Qwen35LayerWeights& w = s.w.layers[i];
+        w.linear_attn = is_linear_layer(c, i);
+        if (!expect_dims(b + "attn_norm.weight", {H})) return false;
         w.input_norm = dense(b + "attn_norm.weight", false);
-        w.wq = attn_w(b + "attn_q.weight", w.wq_type); w.wk = attn_w(b + "attn_k.weight", w.wk_type);
-        w.wv = attn_w(b + "attn_v.weight", w.wv_type); w.wo = attn_w(b + "attn_output.weight", w.wo_type);
-        w.q_norm = dense(b + "attn_q_norm.weight", false); w.k_norm = dense(b + "attn_k_norm.weight", false);
-        w.post_attn_norm = dense(b + "ffn_norm.weight", false);
+        if (w.linear_attn) {
+            if (!expect_dims(b + "attn_qkv.weight", {H, s.linear_qkvdim}) ||
+                !expect_dims(b + "attn_gate.weight", {H, s.linear_vdim}) ||
+                !expect_dims(b + "ssm_conv1d.weight", {c.linear_conv_kernel, s.linear_qkvdim}) ||
+                !expect_dims(b + "ssm_dt.bias", {c.linear_v_heads}) ||
+                !expect_dims(b + "ssm_a", {c.linear_v_heads}) ||
+                !expect_dims(b + "ssm_beta.weight", {H, c.linear_v_heads}) ||
+                !expect_dims(b + "ssm_alpha.weight", {H, c.linear_v_heads}) ||
+                !expect_dims(b + "ssm_norm.weight", {c.linear_head_dim}) ||
+                !expect_dims(b + "ssm_out.weight", {s.linear_vdim, H})) return false;
+            w.wqkv = attn_w(b + "attn_qkv.weight", w.wqkv_type);
+            w.wqkv_gate = attn_w(b + "attn_gate.weight", w.wqkv_gate_type);
+            w.ssm_conv = dense(b + "ssm_conv1d.weight", false);
+            w.ssm_dt = dense(b + "ssm_dt.bias", false);
+            w.ssm_a = dense(b + "ssm_a", false);
+            w.ssm_beta = attn_w(b + "ssm_beta.weight", w.ssm_beta_type);
+            w.ssm_alpha = attn_w(b + "ssm_alpha.weight", w.ssm_alpha_type);
+            w.ssm_norm = dense(b + "ssm_norm.weight", false);
+            w.ssm_out = attn_w(b + "ssm_out.weight", w.ssm_out_type);
+        } else {
+            w.q_has_gate = c.hybrid;
+            const int q_out = w.q_has_gate ? s.qdim * 2 : s.qdim;
+            if (!expect_dims(b + "attn_q.weight", {H, q_out}) ||
+                !expect_dims(b + "attn_k.weight", {H, s.kvdim}) ||
+                !expect_dims(b + "attn_v.weight", {H, s.kvdim}) ||
+                !expect_dims(b + "attn_output.weight", {s.qdim, H}) ||
+                !expect_dims(b + "attn_q_norm.weight", {c.head_dim}) ||
+                !expect_dims(b + "attn_k_norm.weight", {c.head_dim})) return false;
+            w.wq = attn_w(b + "attn_q.weight", w.wq_type);
+            w.wk = attn_w(b + "attn_k.weight", w.wk_type);
+            w.wv = attn_w(b + "attn_v.weight", w.wv_type);
+            w.wo = attn_w(b + "attn_output.weight", w.wo_type);
+            w.q_norm = dense(b + "attn_q_norm.weight", false);
+            w.k_norm = dense(b + "attn_k_norm.weight", false);
+        }
+        if (!expect_dims_opt(b + "attn_post_norm.weight", {H}) ||
+            !expect_dims_opt(b + "ffn_norm.weight", {H}) ||
+            !expect_dims(b + "ffn_gate_inp.weight", {H, c.n_experts})) return false;
+        w.post_attn_norm = dense_opt(b + "attn_post_norm.weight", false);
+        if (!w.post_attn_norm) w.post_attn_norm = dense(b + "ffn_norm.weight", false);
         w.router_w = dense(b + "ffn_gate_inp.weight", false);   // native [E,H] for GEMV
         w.gate_q = dev_quant(b + "ffn_gate_exps.weight", w.gate_qtype);   // kept quantized
         w.up_q   = dev_quant(b + "ffn_up_exps.weight",   w.up_qtype);
         w.down_q = dev_quant(b + "ffn_down_exps.weight", w.down_qtype);
         if (s.cfg.n_shared > 0) {
+            if (!expect_dims(b + "ffn_gate_shexp.weight", {H, c.moe_ffn}) ||
+                !expect_dims(b + "ffn_up_shexp.weight", {H, c.moe_ffn}) ||
+                !expect_dims(b + "ffn_down_shexp.weight", {c.moe_ffn, H}) ||
+                !expect_dims_opt(b + "ffn_gate_inp_shexp.weight", {H})) return false;
             w.shared_gate = dense(b + "ffn_gate_shexp.weight", true);
             w.shared_up   = dense(b + "ffn_up_shexp.weight", true);
             w.shared_down = dense(b + "ffn_down_shexp.weight", true);
+            w.shared_gate_inp = attn_w_opt(b + "ffn_gate_inp_shexp.weight", w.shared_gate_inp_type);
             if (!w.shared_gate || !w.shared_up || !w.shared_down) return false;
         }
-        if (!w.wq || !w.router_w || !w.gate_q || !w.up_q || !w.down_q) return false;
+        const bool have_attn = w.linear_attn
+            ? (w.wqkv && w.wqkv_gate && w.ssm_conv && w.ssm_dt && w.ssm_a &&
+               w.ssm_beta && w.ssm_alpha && w.ssm_norm && w.ssm_out)
+            : (w.wq && w.wk && w.wv && w.wo && w.q_norm && w.k_norm);
+        if (!have_attn || !w.input_norm || !w.post_attn_norm ||
+            !w.router_w || !w.gate_q || !w.up_q || !w.down_q) return false;
         if (i == 0 || i == c.n_layers - 1) fprintf(stderr, "[gguf] layer %d loaded\n", i);
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -7,6 +7,10 @@ add_executable(qwen35_cpu_test qwen35_cpu_test.cpp)
 set_target_properties(qwen35_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME qwen35_cpu_test COMMAND qwen35_cpu_test)
 
+add_executable(qwen36_config_cpu_test qwen36_config_cpu_test.cpp ../src/gguf.cpp)
+set_target_properties(qwen36_config_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME qwen36_config_cpu_test COMMAND qwen36_config_cpu_test)
+
 # Thermal governor — pure tiering policy (no GPU); links the runtime for classify()/pace() symbols.
 add_executable(thermal_governor_cpu_test thermal_governor_cpu_test.cpp)
 target_link_libraries(thermal_governor_cpu_test PRIVATE sparkinfer_runtime)

--- a/runtime/tests/qwen36_config_cpu_test.cpp
+++ b/runtime/tests/qwen36_config_cpu_test.cpp
@@ -1,0 +1,151 @@
+// CPU-only test for Qwen3.6 GGUF metadata parsing.
+//
+// Writes a tiny GGUF with Qwen3.6-style scalar metadata and hybrid tensor names,
+// then verifies qwen3_config_from_gguf() derives the config needed before
+// Qwen35Model construction sizes CUDA scratch buffers and KV cache.
+
+#include "../examples/qwen3_gguf_config.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+namespace {
+enum { VT_U32 = 4, VT_F32 = 6, VT_STR = 8 };
+
+template <typename T>
+void put(std::vector<uint8_t>& b, T v) {
+    const uint8_t* p = reinterpret_cast<const uint8_t*>(&v);
+    b.insert(b.end(), p, p + sizeof(T));
+}
+
+void put_str(std::vector<uint8_t>& b, const std::string& s) {
+    put<uint64_t>(b, (uint64_t)s.size());
+    b.insert(b.end(), s.begin(), s.end());
+}
+
+struct Meta {
+    std::string key;
+    int type;
+    uint32_t u = 0;
+    float f = 0.f;
+    std::string s;
+};
+
+struct Tensor {
+    std::string name;
+    std::vector<uint64_t> dims;
+    uint32_t type = 0; // F32
+    uint64_t offset = 0;
+    uint64_t bytes = 0;
+};
+
+uint64_t tensor_bytes(const Tensor& t) {
+    uint64_t n = 1;
+    for (uint64_t d : t.dims) n *= d;
+    return n * 4;
+}
+
+bool write_tiny_gguf(const std::string& path) {
+    std::vector<Meta> meta = {
+        {"general.name", VT_STR, 0, 0.f, "Qwen3.6-35B-A3B"},
+        {"general.alignment", VT_U32, 32},
+        {"qwen35moe.block_count", VT_U32, 40},
+        {"qwen35moe.embedding_length", VT_U32, 64},
+        {"qwen35moe.vocab_size", VT_U32, 1234},
+        {"qwen35moe.attention.head_count", VT_U32, 4},
+        {"qwen35moe.attention.head_count_kv", VT_U32, 1},
+        {"qwen35moe.attention.key_length", VT_U32, 16},
+        {"qwen35moe.expert_count", VT_U32, 8},
+        {"qwen35moe.expert_used_count", VT_U32, 2},
+        {"qwen35moe.expert_feed_forward_length", VT_U32, 32},
+        {"qwen35moe.rope.freq_base", VT_F32, 0, 10000000.f},
+        {"qwen35moe.attention.layer_norm_rms_epsilon", VT_F32, 0, 1e-6f},
+        {"qwen35moe.ssm.state_size", VT_U32, 32},
+        {"qwen35moe.ssm.group_count", VT_U32, 8},
+        {"qwen35moe.ssm.conv_kernel", VT_U32, 4},
+        {"tokenizer.ggml.eos_token_id", VT_U32, 248044},
+    };
+    std::vector<Tensor> tensors = {
+        {"token_embd.weight", {64, 1234}},
+        {"blk.0.attn_qkv.weight", {64, 512}},
+        {"blk.0.ssm_conv1d.weight", {4, 512}},
+        {"blk.0.ffn_gate_shexp.weight", {64, 32}},
+        {"blk.3.attn_q.weight", {64, 128}},
+    };
+
+    uint64_t off = 0;
+    for (Tensor& t : tensors) {
+        t.offset = off;
+        t.bytes = tensor_bytes(t);
+        off += t.bytes;
+    }
+
+    std::vector<uint8_t> b;
+    b.insert(b.end(), {'G', 'G', 'U', 'F'});
+    put<uint32_t>(b, 3);
+    put<uint64_t>(b, tensors.size());
+    put<uint64_t>(b, meta.size());
+
+    for (const Meta& m : meta) {
+        put_str(b, m.key);
+        put<uint32_t>(b, (uint32_t)m.type);
+        if (m.type == VT_STR) put_str(b, m.s);
+        else if (m.type == VT_F32) put<float>(b, m.f);
+        else put<uint32_t>(b, m.u);
+    }
+
+    for (const Tensor& t : tensors) {
+        put_str(b, t.name);
+        put<uint32_t>(b, (uint32_t)t.dims.size());
+        for (uint64_t d : t.dims) put<uint64_t>(b, d);
+        put<uint32_t>(b, t.type);
+        put<uint64_t>(b, t.offset);
+    }
+
+    while (b.size() % 32) b.push_back(0);
+    for (const Tensor& t : tensors) b.insert(b.end(), (size_t)t.bytes, 0);
+
+    std::ofstream out(path, std::ios::binary);
+    if (!out) return false;
+    out.write(reinterpret_cast<const char*>(b.data()), (std::streamsize)b.size());
+    return out.good();
+}
+
+#define CHECK(x) do { if (!(x)) { std::printf("FAIL: %s line %d\n", #x, __LINE__); return 1; } } while (0)
+} // namespace
+
+int main() {
+    const std::string path = "/tmp/sparkinfer_qwen36_config_cpu_test.gguf";
+    CHECK(write_tiny_gguf(path));
+
+    sparkinfer::GGUF g;
+    CHECK(g.open(path));
+
+    sparkinfer::Qwen35Config cfg;
+    qwen3_config_from_gguf(g, cfg);
+
+    CHECK(cfg.hybrid);
+    CHECK(cfg.n_layers == 40);
+    CHECK(cfg.hidden == 64);
+    CHECK(cfg.vocab == 1234);
+    CHECK(cfg.n_q_heads == 4);
+    CHECK(cfg.n_kv_heads == 1);
+    CHECK(cfg.head_dim == 16);
+    CHECK(cfg.n_experts == 8);
+    CHECK(cfg.top_k == 2);
+    CHECK(cfg.n_shared == 1);
+    CHECK(cfg.moe_ffn == 32);
+    CHECK(cfg.full_attn_interval == 4);
+    CHECK(cfg.linear_head_dim == 32);
+    CHECK(cfg.linear_q_heads == 4);
+    CHECK(cfg.linear_v_heads == 8);
+    CHECK(cfg.linear_conv_kernel == 4);
+    CHECK(cfg.eos_id == 248044);
+
+    std::printf("qwen36_config_cpu_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Re-implements the Qwen3.6-35B-A3B hybrid decode path on **current main** (the int8 tensor-core base), superseding the stale #118 (113 commits behind, conflicting).

**Both models supported.** Qwen3-MoE stays on main's exact fused-int8 path (`q_has_gate=false` → byte-identical); Qwen3.6's 30 GDN layers + 10 gated/head_dim-256 attention layers take the new paths. Model detected at GGUF load — no user config.

**Verified on RTX 5090 (CUDA 13):**
- build rc=0, `ctest` 7/7 (incl. new qwen36_config_cpu_test)
- Qwen3-MoE accuracy vs llama.cpp: **top-1 0.960** (== main), ppl 6.41 vs 7.76 — **frontier unchanged**
- Qwen3.6 paths are isolated (dormant unless a Qwen3.6 GGUF is loaded), so they cannot affect Qwen3-MoE.

Supersedes #118.