### PR TITLE
eval: dual-model scoring — Qwen3.6 primary + Qwen3-30B no-regression guard

### DIFF
--- a/bench/scripts/README.md
+++ b/bench/scripts/README.md
@@ -85,5 +85,15 @@ build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...>   # compare argmax +
 | `PREBUILT_TAG` | `latest` | newest matching prebuilt release; set a tag like `v0.2.0` to pin |
 | `PREBUILT_URL` | auto | override with an exact prebuilt tarball URL |
 
-Files: `bench.sh`, `accuracy.sh`, `accuracy_compare.py`, `eval_text.txt`, `_common.sh`.
+## Automatic PR evaluation
+
+`evaluate.sh` grades one submission (build → correctness → 128/512/4k/16k/32k speed → `label.py`).
+`evaluate_dual.sh` wraps it for **dual-model scoring**: it builds once, then scores **Qwen3.6-35B-A3B**
+(the primary target, 128/512/4k for now) and guards **Qwen3-30B-A3B** against regression (full sweep +
+accuracy) — any Qwen3 speed drop <98% of its main or broken llama.cpp parity REJECTs the submission.
+Each model uses its own `MODELS_DIR` (different tokenizers) and weight-sha pin (`reference.lock`).
+See [`eval/README.md`](../../eval/README.md) for the vast.ai orchestration and `--dual`.
+
+Files: `bench.sh`, `accuracy.sh`, `accuracy_compare.py`, `evaluate.sh`, `evaluate_dual.sh`, `label.py`,
+`eval_text.txt`, `reference.lock`, `_common.sh`.
 Results from reference runs live in [`../results/`](../results).

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -28,14 +28,21 @@ if [ -n "$REF" ] && [ -z "${SI_NO_CHECKOUT:-}" ]; then
 fi
 COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
 
-echo ">> [1/3] build submission ($COMMIT) from source (sm_$ARCH) ..." >&2
-rm -rf "$ROOT/build"
-# A submission that does not compile is invalid -> clean REJECT (not an infra error). The `if !`
-# guard suppresses `set -e` for the build so we can emit a verdict instead of aborting silently.
-if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
-  echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
-  printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": %s, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false}\n' "$COMMIT" "$FRONTIER"
-  exit 0
+# SI_SKIP_BUILD=1: the caller (evaluate_dual.sh) already built this exact tree from source and is
+# now scoring a second model against the same binaries — skip the rebuild so a two-model eval pays
+# the (model-agnostic) compile cost once, not twice.
+if [ -n "${SI_SKIP_BUILD:-}" ] && [ -x "$ROOT/build/runtime/qwen3_gguf_bench" ]; then
+  echo ">> [1/3] reusing pre-built submission ($COMMIT) (SI_SKIP_BUILD) ..." >&2
+else
+  echo ">> [1/3] build submission ($COMMIT) from source (sm_$ARCH) ..." >&2
+  rm -rf "$ROOT/build"
+  # A submission that does not compile is invalid -> clean REJECT (not an infra error). The `if !`
+  # guard suppresses `set -e` for the build so we can emit a verdict instead of aborting silently.
+  if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
+    echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
+    printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": %s, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false}\n' "$COMMIT" "$FRONTIER"
+    exit 0
+  fi
 fi
 SI_BIN="$ROOT/build/runtime"; SI_LD=""
 

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -88,8 +88,9 @@ pin_clocks
 trap 'unpin_clocks' EXIT
 
 gclks=()
-median_ctx() {  # $1=context tokens, $2=repetitions
+median_ctx() {  # $1=context tokens, $2=repetitions ; reps<=0 SKIPS the context (returns 0, no run)
   local ctx="$1" reps="$2" vals=() t
+  [ "${reps:-0}" -le 0 ] && { echo 0; return; }
   for _ in $(seq 1 "$reps"); do
     t=$(si_run qwen3_gguf_bench "$GGUF" "$DECODE_TOKENS" "$ctx" 2>/dev/null |
         sed -n 's/.*decode tg *: *\([0-9.][0-9.]*\).*/\1/p' || true)
@@ -192,7 +193,9 @@ contexts = [
 ]
 for c in contexts:
     c["gain"] = 0.0 if c["base"] <= 0 else (c["tps"] - c["base"]) / c["base"]
-scorable = [c for c in contexts if c["base"] > 0]
+# A context measured with 0 reps (tps<=0) was intentionally skipped (e.g. Qwen3.6 runs only
+# 128/512/4k for now) — exclude it from scoring so a skipped context is never chosen or penalized.
+scorable = [c for c in contexts if c["base"] > 0 and c["tps"] > 0]
 chosen = max(scorable, key=lambda c: c["gain"]) if scorable else next(c for c in contexts if c["ctx"] == int("$SCORE_CTX"))
 print(json.dumps({"chosen": chosen, "contexts": contexts}, separators=(",", ":")))
 PY
@@ -230,7 +233,7 @@ PY
 )"
   CONTEXT_GAINS_JSON="$(SCORE_SELECT="$SCORE_SELECT" python3 - <<'PY'
 import json, os
-print(json.dumps({c["label"]: round(100*c["gain"], 2) for c in json.loads(os.environ["SCORE_SELECT"])["contexts"]}, separators=(",", ":")))
+print(json.dumps({c["label"]: round(100*c["gain"], 2) for c in json.loads(os.environ["SCORE_SELECT"])["contexts"] if c["tps"] > 0}, separators=(",", ":")))
 PY
 )"
   REGRESSION_LABELS_JSON="$(python3 - <<PY

--- a/bench/scripts/evaluate_dual.sh
+++ b/bench/scripts/evaluate_dual.sh
@@ -48,12 +48,17 @@ if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
 fi
 
 # Primary = Qwen3.6 (Unsloth Dynamic UD-Q4_K_M — mixes Q5_K, the default UD path). Guard = Qwen3-30B.
+# The two models have DIFFERENT tokenizers (Qwen3.6 vocab 248k vs Qwen3 152k), and each model's dir
+# holds its own GGUF + tokenizer.json — so they must live in SEPARATE MODELS_DIRs or accuracy.sh would
+# score one model's ids against the other's tokenizer. Guard keeps the inherited MODELS_DIR.
 P_FILE="${PRIMARY_MODEL_FILE:-Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
 P_REPO="${PRIMARY_MODEL_REPO:-unsloth/Qwen3.6-35B-A3B-GGUF}"
 P_TOK="${PRIMARY_TOK_REPO:-Qwen/Qwen3.6-35B-A3B}"
+P_DIR="${PRIMARY_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}36}"    # e.g. /workspace/models -> /workspace/models36
 G_FILE="${GUARD_MODEL_FILE:-Qwen3-30B-A3B-Q4_K_M.gguf}"
 G_REPO="${GUARD_MODEL_REPO:-Qwen/Qwen3-30B-A3B-GGUF}"
 G_TOK="${GUARD_TOK_REPO:-Qwen/Qwen3-30B-A3B}"
+G_DIR="${GUARD_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}}"
 
 reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
 
@@ -73,22 +78,28 @@ run_model() {  # $1=role  $2=file $3=repo $4=tok  $5=frontier  $6..=SPARKINFER_*
 # distance), mirroring the single-model eval. The guard is never scored, so no boost there.
 P_DIFF_REF="${SPARKINFER_P_LLAMA_128_BASELINE:-0}"
 
+# Qwen3.6 is scored on 128/512/4k ONLY for now — its long-context (16k/32k) decode is currently far
+# too slow (35B MoE dequant-bound) to sweep every eval. SCORE_REPS=0 skips the 16k context, GUARD_32K
+# _REPS=0 skips 32k (median_ctx returns 0 -> excluded from scoring + guards); the 3 live contexts get
+# 3-rep medians for a stable scored number. Re-enable 16k/32k by passing their reps + baselines.
 PRIMARY_JSON="$(run_model primary "$P_FILE" "$P_REPO" "$P_TOK" "$PRIMARY_FRONTIER" \
+  MODELS_DIR="$P_DIR" \
+  SPARKINFER_SCORE_REPS=0 SPARKINFER_GUARD_32K_REPS=0 \
+  SPARKINFER_GUARD_REPS=3 SPARKINFER_GUARD_512_REPS=3 SPARKINFER_GUARD_4K_REPS=3 \
   SPARKINFER_DIFFICULTY_BOOST=1 SPARKINFER_DIFFICULTY_REF="${P_DIFF_REF:-365.85}" \
   SPARKINFER_GUARD_128_BASELINE="${SPARKINFER_P_GUARD_128_BASELINE:-0}" \
   SPARKINFER_GUARD_512_BASELINE="${SPARKINFER_P_GUARD_512_BASELINE:-0}" \
   SPARKINFER_GUARD_4K_BASELINE="${SPARKINFER_P_GUARD_4K_BASELINE:-0}" \
-  SPARKINFER_GUARD_16K_BASELINE="${SPARKINFER_P_GUARD_16K_BASELINE:-0}" \
-  SPARKINFER_GUARD_32K_BASELINE="${SPARKINFER_P_GUARD_32K_BASELINE:-0}" \
-  SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P_LLAMA_128_BASELINE:-365.85}" \
-  SPARKINFER_LLAMA_512_BASELINE="${SPARKINFER_P_LLAMA_512_BASELINE:-342.59}" \
-  SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P_LLAMA_4K_BASELINE:-292.99}" \
-  SPARKINFER_LLAMA_16K_BASELINE="${SPARKINFER_P_LLAMA_16K_BASELINE:-245.53}" \
-  SPARKINFER_LLAMA_32K_BASELINE="${SPARKINFER_P_LLAMA_32K_BASELINE:-192.62}")"
+  SPARKINFER_GUARD_16K_BASELINE=0 \
+  SPARKINFER_GUARD_32K_BASELINE=0 \
+  SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P_LLAMA_128_BASELINE:-0}" \
+  SPARKINFER_LLAMA_512_BASELINE="${SPARKINFER_P_LLAMA_512_BASELINE:-0}" \
+  SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P_LLAMA_4K_BASELINE:-0}")"
 
 # Guard runs at frontier 0 (never scored). Its main-branch baselines make every context a
 # no-regression gate; the merge below fails the submission if any gate or the accuracy gate breaks.
 GUARD_JSON="$(run_model guard "$G_FILE" "$G_REPO" "$G_TOK" 0 \
+  MODELS_DIR="$G_DIR" \
   SPARKINFER_GUARD_128_BASELINE="${SPARKINFER_G_GUARD_128_BASELINE:-0}" \
   SPARKINFER_GUARD_512_BASELINE="${SPARKINFER_G_GUARD_512_BASELINE:-0}" \
   SPARKINFER_GUARD_4K_BASELINE="${SPARKINFER_G_GUARD_4K_BASELINE:-0}" \

--- a/bench/scripts/evaluate_dual.sh
+++ b/bench/scripts/evaluate_dual.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# Dual-model evaluation: score Qwen3.6-35B-A3B (the primary target) and guard
+# Qwen3-30B-A3B against no-regression — in one build, on one box.
+#
+#   bench/scripts/evaluate_dual.sh [--ref GIT_REF] [--ceiling TPS] [--primary-frontier TPS]
+#
+# Builds the submission ONCE (the build is model-agnostic), then:
+#   • PRIMARY  (Qwen3.6): full speed sweep + token-match/KL vs llama.cpp -> the scored eval:<label>.
+#   • GUARD    (Qwen3-30B): the same speed sweep + accuracy gate, but never scored — it only has to
+#                           NOT regress. If Qwen3 loses speed at any context OR breaks parity with
+#                           llama.cpp, the whole submission is REJECTed (an optimization that helps
+#                           Qwen3.6 must not quietly wreck the shipped Qwen3 path).
+#
+# Final verdict = the Qwen3.6 label, forced to REJECT if the Qwen3 guard fails. Both models'
+# measurements are merged into one RESULT_JSON so the record is self-describing.
+#
+# Model / baseline selection (env, all optional — sane Qwen3.6/Qwen3 defaults):
+#   PRIMARY_MODEL_FILE/REPO/TOK, GUARD_MODEL_FILE/REPO/TOK
+#   SPARKINFER_P_GUARD_{128,512,4K,16K,32K}_BASELINE   Qwen3.6 same-box main tok/s (its guards)
+#   SPARKINFER_P_LLAMA_{128,512,4K,16K,32K}_BASELINE   Qwen3.6 llama.cpp tok/s (display + difficulty ref)
+#   SPARKINFER_G_GUARD_{128,512,4K,16K,32K}_BASELINE   Qwen3-30B same-box main tok/s (its guards)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$HERE/_common.sh"
+
+REF=""; CEILING=0; PRIMARY_FRONTIER=0
+while [ $# -gt 0 ]; do case "$1" in
+  --ref) shift; REF="$1" ;; --ceiling) shift; CEILING="$1" ;;
+  --primary-frontier) shift; PRIMARY_FRONTIER="$1" ;; *) ;;
+esac; shift; done
+
+export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"
+ARCH="$(detect_arch)"
+
+# Same trust model as evaluate.sh: the bot pre-checks-out the submission + pins bench/scripts to the
+# protected branch and sets SI_NO_CHECKOUT=1. A manual self-test with --ref checks it out here.
+if [ -n "$REF" ] && [ -z "${SI_NO_CHECKOUT:-}" ]; then
+  git -C "$ROOT" fetch -q origin "$REF" 2>/dev/null || true; git -C "$ROOT" checkout -q "$REF"
+fi
+COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
+
+# --- build ONCE (model-agnostic) ; a non-compiling submission is a clean REJECT ------------------
+echo ">> [build] submission ($COMMIT) from source (sm_$ARCH) — shared by both models ..." >&2
+rm -rf "$ROOT/build"
+if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
+  echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
+  printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": %s, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false}\n' "$COMMIT" "$PRIMARY_FRONTIER"
+  exit 0
+fi
+
+# Primary = Qwen3.6 (Unsloth Dynamic UD-Q4_K_M — mixes Q5_K, the default UD path). Guard = Qwen3-30B.
+P_FILE="${PRIMARY_MODEL_FILE:-Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
+P_REPO="${PRIMARY_MODEL_REPO:-unsloth/Qwen3.6-35B-A3B-GGUF}"
+P_TOK="${PRIMARY_TOK_REPO:-Qwen/Qwen3.6-35B-A3B}"
+G_FILE="${GUARD_MODEL_FILE:-Qwen3-30B-A3B-Q4_K_M.gguf}"
+G_REPO="${GUARD_MODEL_REPO:-Qwen/Qwen3-30B-A3B-GGUF}"
+G_TOK="${GUARD_TOK_REPO:-Qwen/Qwen3-30B-A3B}"
+
+reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
+
+run_model() {  # $1=role  $2=file $3=repo $4=tok  $5=frontier  $6..=SPARKINFER_* baseline assignments
+  local role="$1" file="$2" repo="$3" tok="$4" frontier="$5"; shift 5
+  reap
+  echo ">> [$role] scoring model $file ..." >&2
+  # SI_SKIP_BUILD reuses the single build; SI_NO_CHECKOUT keeps the trusted-harness pin intact.
+  env SI_SKIP_BUILD=1 SI_NO_CHECKOUT=1 \
+      MODEL_FILE="$file" MODEL_REPO="$repo" TOK_REPO="$tok" \
+      "$@" \
+      "$HERE/evaluate.sh" --ref "$REF" --frontier "$frontier" --ceiling "$CEILING" \
+    | sed -n 's/^RESULT_JSON //p' | tail -1
+}
+
+# Difficulty-boost the PRIMARY label against Qwen3.6's own llama.cpp 128-tok reference (its moat
+# distance), mirroring the single-model eval. The guard is never scored, so no boost there.
+P_DIFF_REF="${SPARKINFER_P_LLAMA_128_BASELINE:-0}"
+
+PRIMARY_JSON="$(run_model primary "$P_FILE" "$P_REPO" "$P_TOK" "$PRIMARY_FRONTIER" \
+  SPARKINFER_DIFFICULTY_BOOST=1 SPARKINFER_DIFFICULTY_REF="${P_DIFF_REF:-365.85}" \
+  SPARKINFER_GUARD_128_BASELINE="${SPARKINFER_P_GUARD_128_BASELINE:-0}" \
+  SPARKINFER_GUARD_512_BASELINE="${SPARKINFER_P_GUARD_512_BASELINE:-0}" \
+  SPARKINFER_GUARD_4K_BASELINE="${SPARKINFER_P_GUARD_4K_BASELINE:-0}" \
+  SPARKINFER_GUARD_16K_BASELINE="${SPARKINFER_P_GUARD_16K_BASELINE:-0}" \
+  SPARKINFER_GUARD_32K_BASELINE="${SPARKINFER_P_GUARD_32K_BASELINE:-0}" \
+  SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P_LLAMA_128_BASELINE:-365.85}" \
+  SPARKINFER_LLAMA_512_BASELINE="${SPARKINFER_P_LLAMA_512_BASELINE:-342.59}" \
+  SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P_LLAMA_4K_BASELINE:-292.99}" \
+  SPARKINFER_LLAMA_16K_BASELINE="${SPARKINFER_P_LLAMA_16K_BASELINE:-245.53}" \
+  SPARKINFER_LLAMA_32K_BASELINE="${SPARKINFER_P_LLAMA_32K_BASELINE:-192.62}")"
+
+# Guard runs at frontier 0 (never scored). Its main-branch baselines make every context a
+# no-regression gate; the merge below fails the submission if any gate or the accuracy gate breaks.
+GUARD_JSON="$(run_model guard "$G_FILE" "$G_REPO" "$G_TOK" 0 \
+  SPARKINFER_GUARD_128_BASELINE="${SPARKINFER_G_GUARD_128_BASELINE:-0}" \
+  SPARKINFER_GUARD_512_BASELINE="${SPARKINFER_G_GUARD_512_BASELINE:-0}" \
+  SPARKINFER_GUARD_4K_BASELINE="${SPARKINFER_G_GUARD_4K_BASELINE:-0}" \
+  SPARKINFER_GUARD_16K_BASELINE="${SPARKINFER_G_GUARD_16K_BASELINE:-0}" \
+  SPARKINFER_GUARD_32K_BASELINE="${SPARKINFER_G_GUARD_32K_BASELINE:-0}")"
+reap
+
+# --- merge: final = Qwen3.6 verdict, REJECTed if the Qwen3 guard regressed (speed OR accuracy) ----
+PRIMARY_JSON="$PRIMARY_JSON" GUARD_JSON="$GUARD_JSON" COMMIT="$COMMIT" \
+P_FILE="$P_FILE" G_FILE="$G_FILE" python3 - <<'PY'
+import json, os
+
+def load(name):
+    raw = os.environ.get(name, "").strip()
+    try:
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+
+primary = load("PRIMARY_JSON")
+guard   = load("GUARD_JSON")
+commit  = os.environ["COMMIT"]
+TOP1_BAR = float(os.environ.get("SPARKINFER_TOP1_BAR", "0.90"))
+KL_BAR   = float(os.environ.get("SPARKINFER_KL_BAR",   "0.20"))
+
+# An empty/garbled sub-verdict is an infra failure, not a pass — fail closed.
+if not primary:
+    print("RESULT_JSON " + json.dumps({
+        "commit": commit, "label": "REJECT", "pass": False,
+        "reason": "primary (Qwen3.6) eval produced no verdict (infra error)"}))
+    raise SystemExit(0)
+
+# Guard verdict: strict — EVERY measured context must hold >= tol of Qwen3 main, and Qwen3 must keep
+# llama.cpp parity. Read the measured per-context pass flags directly (not the guard's own lenient
+# "one win excuses a regression" scoring path, which we deliberately bypass for the guard role).
+gctx = ["guard_128_pass", "guard_512_pass", "guard_4k_pass", "guard_16k_pass", "guard_32k_pass"]
+present = [k for k in gctx if k in guard]
+speed_ok = all(guard.get(k, True) for k in present)
+g_top1 = float(guard.get("top1", 0)); g_kl = float(guard.get("kl", 99))
+acc_ok = g_top1 >= TOP1_BAR and g_kl <= KL_BAR
+guard_ok = bool(guard) and speed_ok and acc_ok
+
+# Which Qwen3 contexts regressed (for the reason + labels).
+label_map = {"guard_128_pass": "128", "guard_512_pass": "512", "guard_4k_pass": "4k",
+             "guard_16k_pass": "16k", "guard_32k_pass": "32k"}
+regressed = [label_map[k] for k in present if not guard.get(k, True)]
+
+final = dict(primary)                       # carry the Qwen3.6 label, metrics, provenance verbatim
+final["commit"] = commit
+final["model"] = "Qwen3.6-35B-A3B"
+final["guard_model"] = "Qwen3-30B-A3B"
+final["guard"] = {k: guard.get(k) for k in (
+    "pass", "top1", "kl", "label", "ctx_128_tps", "ctx_512_tps", "ctx_4096_tps",
+    "ctx_16384_tps", "ctx_32768_tps", "guard_128_pass", "guard_512_pass", "guard_4k_pass",
+    "guard_16k_pass", "guard_32k_pass") if k in guard}
+final["guard"]["speed_ok"] = speed_ok
+final["guard"]["accuracy_ok"] = acc_ok
+
+if not guard_ok:
+    reasons = []
+    if regressed:
+        reasons.append("Qwen3-30B decode regressed at context(s): " + ", ".join(regressed))
+    if not acc_ok:
+        reasons.append(f"Qwen3-30B accuracy broke (top1={g_top1} need>={TOP1_BAR}, kl={g_kl} need<={KL_BAR})")
+    if not bool(guard):
+        reasons.append("Qwen3-30B guard produced no verdict (infra error)")
+    if not reasons:
+        reasons.append("Qwen3-30B no-regression guard failed")
+    final["label"] = "REJECT"
+    final["pass"] = False
+    final["reason"] = "no-regression guard: " + "; ".join(reasons)
+    final["guard_regression_labels"] = ["regression-qwen3-" + c for c in regressed]
+
+print("RESULT_JSON " + json.dumps(final))
+PY

--- a/bench/scripts/evaluate_dual.sh
+++ b/bench/scripts/evaluate_dual.sh
@@ -83,7 +83,7 @@ P_DIFF_REF="${SPARKINFER_P_LLAMA_128_BASELINE:-0}"
 # _REPS=0 skips 32k (median_ctx returns 0 -> excluded from scoring + guards); the 3 live contexts get
 # 3-rep medians for a stable scored number. Re-enable 16k/32k by passing their reps + baselines.
 PRIMARY_JSON="$(run_model primary "$P_FILE" "$P_REPO" "$P_TOK" "$PRIMARY_FRONTIER" \
-  MODELS_DIR="$P_DIR" \
+  MODELS_DIR="$P_DIR" MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" \
   SPARKINFER_SCORE_REPS=0 SPARKINFER_GUARD_32K_REPS=0 \
   SPARKINFER_GUARD_REPS=3 SPARKINFER_GUARD_512_REPS=3 SPARKINFER_GUARD_4K_REPS=3 \
   SPARKINFER_DIFFICULTY_BOOST=1 SPARKINFER_DIFFICULTY_REF="${P_DIFF_REF:-365.85}" \

--- a/bench/scripts/reference.lock
+++ b/bench/scripts/reference.lock
@@ -10,7 +10,12 @@
 # An EMPTY value means "warn-only" (compute + log, don't enforce) — used until a value is pinned.
 
 # sha256 of the Q4_K_M GGUF baseline weights. Verified before every eval; mismatch -> re-download.
-MODEL_SHA256="0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5"
+# Env-overridable (`:-`) so the dual-model eval can pin a DIFFERENT sha per model — the Qwen3.6
+# primary passes QWEN36_MODEL_SHA256 (below); the Qwen3-30B guard uses this default.
+MODEL_SHA256="${MODEL_SHA256:-0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c606a7f3c01aa8f5}"
+
+# sha256 of the Qwen3.6-35B-A3B UD-Q4_K_M GGUF (unsloth) — the dual-eval primary baseline weights.
+QWEN36_MODEL_SHA256="ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61"
 
 # llama.cpp commit the reference is pinned to. HEAD of master drifts run-to-run (non-reproducible and
 # unpinnable); we check out exactly this commit, verify a clean tree, and rebuild if either differs.

--- a/eval/README.md
+++ b/eval/README.md
@@ -48,6 +48,41 @@ The default eval target is now multi-context decode:
 
 Set `SPARKINFER_EVAL_MODE=short` or pass `--eval-mode short` to keep the legacy 128-token scoring path.
 
+## Dual-model scoring: Qwen3.6 primary, Qwen3-30B no-regression guard
+
+`--dual` scores **Qwen3.6-35B-A3B** (the current optimization frontier) and, in the same build on the
+same box, **guards Qwen3-30B-A3B against regression** — an optimization that speeds up Qwen3.6 must
+not quietly break or slow the shipped Qwen3 path.
+
+```
+build once ─► PRIMARY  Qwen3.6 : 128/512/4k/16k/32k speed + token-match/KL vs llama.cpp ─► eval:<LABEL>
+           └► GUARD    Qwen3-30B: same speed sweep + accuracy gate ─► must NOT regress, else REJECT
+```
+
+- The **eval:<label>** (XS…XL / none / REJECT) is driven **only by Qwen3.6** — its strongest single
+  context improvement over the Qwen3.6 frontier, same significance/bucket/difficulty rules as above.
+- The **Qwen3-30B guard** re-runs the full 5-context speed sweep **and** the top-1/KL accuracy gate.
+  If Qwen3 drops below 98% of its own same-box `origin/main` at *any* context, **or** breaks parity
+  with llama.cpp (top-1 < 0.90 or KL > 0.20), the whole submission is **REJECTed** with a
+  `no-regression guard` reason and `regression-qwen3-<ctx>` detail — regardless of the Qwen3.6 gain.
+- Both models' measurements merge into one `RESULT_JSON`; the Qwen3 guard block is under `guard`.
+- Cost: two ~20 GB model loads + two llama.cpp accuracy passes, run **sequentially** (they don't fit
+  in VRAM together), so a dual eval is ~2× a single-model eval.
+
+```bash
+# Qwen3.6 scored, Qwen3-30B guarded (baselines are same-box origin/main tok/s per context):
+python eval/vast_eval.py --reuse <id> --dual \
+  --primary-frontier <qwen36_best_tps> --ceiling <roofline> \
+  --p-guard-128-baseline 23.2 --p-guard-512-baseline 23.2 --p-guard-4k-baseline 23.0 \
+  --p-guard-16k-baseline <..> --p-guard-32k-baseline <..> \
+  --guard-128-baseline 331 --guard-512-baseline 331 --guard-4k-baseline 322 \
+  --guard-16k-baseline 330 --guard-32k-baseline 300
+```
+
+The on-box orchestrator is `bench/scripts/evaluate_dual.sh` (builds once, calls the model-agnostic
+`evaluate.sh` twice via `SI_SKIP_BUILD=1`, merges). Qwen3.6 runs the same UD-Q4_K_M GGUF the runtime
+now loads by default (mixed Q5_K experts).
+
 ## Verdict (stdout)
 
 ```json

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -745,7 +745,23 @@ def main():
     ap.add_argument("--ceiling", type=float, default=0)
     ap.add_argument("--repo", default="gittensor-ai-lab/sparkinfer")
     ap.add_argument("--dry-run", action="store_true", help="evaluate + print, but don't label/comment")
+    # Dual-model: score Qwen3.6-35B-A3B (primary) and guard Qwen3-30B against no-regression. The
+    # Qwen3-30B guard baselines are still measured same-box each run (run_guard_*); the Qwen3.6
+    # primary baselines are stable config constants (no Qwen3.6-optimizing PR has moved them yet) —
+    # overridable via env until a same-box Qwen3.6 baseline pass is added.
+    ap.add_argument("--dual", action="store_true",
+                    help="score Qwen3.6 (primary) + guard Qwen3-30B (no-regression) via evaluate_dual.sh")
+    ap.add_argument("--primary-frontier", type=float,
+                    default=float(os.environ.get("SPARKINFER_QWEN36_FRONTIER", "23.0")),
+                    help="[--dual] Qwen3.6 current best verified 128/512/4k tok/s (the scored frontier)")
     args = ap.parse_args()
+    # Qwen3.6 same-box origin/main baselines (128/512/4k). Env-overridable; measured 2026-07 on RTX 5090.
+    QWEN36_BASE = {
+        "128": float(os.environ.get("SPARKINFER_QWEN36_128", "23.22")),
+        "512": float(os.environ.get("SPARKINFER_QWEN36_512", "23.16")),
+        "4k":  float(os.environ.get("SPARKINFER_QWEN36_4K",  "23.03")),
+        "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "190")),
+    }
 
     dash = load_dash()
     frontier = dash["status"]["frontier_tps"] if dash else args.frontier   # live ledger frontier
@@ -965,6 +981,14 @@ def main():
                "--guard-16k-baseline", str(run_guard_16k),
                "--guard-32k-baseline", str(run_guard_32k),
                "--keep"]            # keep instance alive — bot stops it after all PRs
+        if args.dual:
+            # Qwen3.6 scored (128/512/4k); the --guard-*-baseline above become the Qwen3-30B guard.
+            cmd[cmd.index("--keep"):cmd.index("--keep")] = [
+                "--dual", "--primary-frontier", str(args.primary_frontier),
+                "--p-guard-128-baseline", str(QWEN36_BASE["128"]),
+                "--p-guard-512-baseline", str(QWEN36_BASE["512"]),
+                "--p-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
+                "--p-llama-128-baseline", str(QWEN36_BASE["llama128"])]
         if PINNED_INSTANCE and str(cur_iid) == PINNED_INSTANCE:
             cmd.append("--pinned")  # never destroy the pin; retry-then-fallback on bring-up failure
         pinned = "--pinned" in cmd

--- a/eval/run_bot_cron.sh
+++ b/eval/run_bot_cron.sh
@@ -26,4 +26,5 @@ python3 eval/pr_eval_bot.py \
   --instance "${VAST_INSTANCE:-42682383}" \
   --frontier "${FRONTIER:-285}" \
   --ceiling  "${CEILING:-366}" \
-  --repo     "${REPO:-gittensor-ai-lab/sparkinfer}"
+  --repo     "${REPO:-gittensor-ai-lab/sparkinfer}" \
+  ${DUAL:+--dual}                                     # DUAL=1 -> score Qwen3.6 + guard Qwen3-30B

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -206,6 +206,22 @@ def main():
     ap.add_argument("--guard-32k-baseline", type=float, default=0,
                     help="main/origin 32k-context decode tok/s used as the no-regression guard baseline")
     ap.add_argument("--guard-2k-baseline", type=float, default=0, help=argparse.SUPPRESS)
+    # --- dual-model scoring: Qwen3.6 (primary, scored) + Qwen3-30B (no-regression guard) ---
+    ap.add_argument("--dual", action="store_true",
+                    help="score Qwen3.6-35B-A3B and guard Qwen3-30B-A3B against no-regression in one build "
+                         "(--guard-*-baseline are the Qwen3-30B guard; --p-* are the Qwen3.6 scored target)")
+    ap.add_argument("--primary-frontier", type=float, default=0,
+                    help="[--dual] Qwen3.6 current best verified tok/s (the scored frontier); falls back to --frontier")
+    ap.add_argument("--p-guard-128-baseline", type=float, default=0, help="[--dual] Qwen3.6 main 128-token decode tok/s")
+    ap.add_argument("--p-guard-512-baseline", type=float, default=0, help="[--dual] Qwen3.6 main 512-context tok/s")
+    ap.add_argument("--p-guard-4k-baseline",  type=float, default=0, help="[--dual] Qwen3.6 main 4k-context tok/s")
+    ap.add_argument("--p-guard-16k-baseline", type=float, default=0, help="[--dual] Qwen3.6 main 16k-context tok/s")
+    ap.add_argument("--p-guard-32k-baseline", type=float, default=0, help="[--dual] Qwen3.6 main 32k-context tok/s")
+    ap.add_argument("--p-llama-128-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 128-token tok/s (display + difficulty ref)")
+    ap.add_argument("--p-llama-512-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 512-context tok/s")
+    ap.add_argument("--p-llama-4k-baseline",  type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 4k-context tok/s")
+    ap.add_argument("--p-llama-16k-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 16k-context tok/s")
+    ap.add_argument("--p-llama-32k-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 32k-context tok/s")
     ap.add_argument("--eval-mode", default=os.environ.get("SPARKINFER_EVAL_MODE", "longctx"),
                     choices=["longctx", "short"],
                     help="longctx scores 16k with a 128-token decode no-regression guard; short keeps legacy 128-token scoring")
@@ -371,6 +387,38 @@ def main():
             if not wait_model(host, port):
                 print("!! model download timed out — evaluate.sh will retry (may add time)")
 
+        if args.dual:
+            # Dual-model needs the Qwen3.6 GGUF too. HF (unsloth) — no Drive mirror; slow on some
+            # hosts but cached in /workspace after the first pull. evaluate_dual's ensure_model is the
+            # backstop if this times out. tokenizer.json comes from ensure_tokenizer at score time.
+            P36_PATH = "/workspace/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+            P36_READY = "/tmp/sparkinfer_model36_ready"
+            p36 = (
+                f"if [ -f '{P36_PATH}' ]; then touch '{P36_READY}' && echo cached; "
+                f"elif [ -f '{P36_READY}' ]; then echo already_running; "
+                f"else mkdir -p /workspace/models && rm -f '{P36_READY}'; "
+                f"nohup bash -c '"
+                f"  HF_HUB_DISABLE_XET=1 hf download unsloth/Qwen3.6-35B-A3B-GGUF "
+                f"       Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --local-dir /workspace/models >>/tmp/dl36.log 2>&1 "
+                f"  || curl -fL -C - https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+                f"       -o {P36_PATH} >>/tmp/dl36.log 2>&1; "
+                f"  [ -f {P36_PATH} ] && touch {P36_READY}"
+                f"' >/dev/null 2>&1 & echo started; fi"
+            )
+            s36 = sh(host, port, p36, timeout=30).stdout.strip()
+            if s36 == "cached":
+                print(">> Qwen3.6 model already cached — skipping download")
+            else:
+                print(f">> Qwen3.6 model download started ({s36}) — polling ...")
+                deadline = time.time() + 3000
+                while time.time() < deadline:
+                    r = sh(host, port, f"test -f '{P36_READY}' && echo yes || echo no", timeout=60)
+                    if r.returncode == 0 and r.stdout.strip() == "yes":
+                        break
+                    time.sleep(20)
+                else:
+                    print("!! Qwen3.6 download slow — evaluate_dual.sh will retry (may add time)")
+
         # Reap any leftover reference server / runner from a previous PR on this kept-alive box —
         # a leaked llama-server holding port 8081 would make this PR's accuracy.sh fail to bind.
         sh(host, port, "pkill -f llama-server 2>/dev/null; pkill -f qwen3_gguf 2>/dev/null; sleep 1; true", timeout=30)
@@ -385,16 +433,41 @@ def main():
         # Difficulty compensation ON (Option B): as the frontier pulls past llama.cpp each further %
         # gain is harder, so label.py scales the label tier up (raw % + significance gate unchanged).
         # Governance-tunable via SPARKINFER_DIFFICULTY_{K,REF,MAX}; applies from new evals onward.
-        ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
-              f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} SPARKINFER_DIFFICULTY_BOOST=1 "
-              f"SPARKINFER_EVAL_MODE={args.eval_mode} "
-              f"SPARKINFER_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
-              f"SPARKINFER_GUARD_512_BASELINE={args.guard_512_baseline} "
-              f"SPARKINFER_GUARD_4K_BASELINE={args.guard_4k_baseline} "
-              f"SPARKINFER_GUARD_16K_BASELINE={args.guard_16k_baseline} "
-              f"SPARKINFER_GUARD_32K_BASELINE={args.guard_32k_baseline} "
-              f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
-              f"bench/scripts/evaluate.sh --ref {args.ref} --frontier {args.frontier} --ceiling {args.ceiling}")
+        if args.dual:
+            # Dual-model: score Qwen3.6 (primary) + guard Qwen3-30B (no-regression). The existing
+            # --guard-*-baseline are the Qwen3-30B guard (G_*); --p-* carry the Qwen3.6 scored target.
+            ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
+                  f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
+                  f"SPARKINFER_EVAL_MODE={args.eval_mode} "
+                  f"SPARKINFER_G_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
+                  f"SPARKINFER_G_GUARD_512_BASELINE={args.guard_512_baseline} "
+                  f"SPARKINFER_G_GUARD_4K_BASELINE={args.guard_4k_baseline} "
+                  f"SPARKINFER_G_GUARD_16K_BASELINE={args.guard_16k_baseline} "
+                  f"SPARKINFER_G_GUARD_32K_BASELINE={args.guard_32k_baseline} "
+                  f"SPARKINFER_P_GUARD_128_BASELINE={args.p_guard_128_baseline} "
+                  f"SPARKINFER_P_GUARD_512_BASELINE={args.p_guard_512_baseline} "
+                  f"SPARKINFER_P_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
+                  f"SPARKINFER_P_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
+                  f"SPARKINFER_P_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
+                  f"SPARKINFER_P_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
+                  f"SPARKINFER_P_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
+                  f"SPARKINFER_P_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
+                  f"SPARKINFER_P_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
+                  f"SPARKINFER_P_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
+                  f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
+                  f"bench/scripts/evaluate_dual.sh --ref {args.ref} "
+                  f"--primary-frontier {args.primary_frontier or args.frontier} --ceiling {args.ceiling}")
+        else:
+            ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
+                  f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} SPARKINFER_DIFFICULTY_BOOST=1 "
+                  f"SPARKINFER_EVAL_MODE={args.eval_mode} "
+                  f"SPARKINFER_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
+                  f"SPARKINFER_GUARD_512_BASELINE={args.guard_512_baseline} "
+                  f"SPARKINFER_GUARD_4K_BASELINE={args.guard_4k_baseline} "
+                  f"SPARKINFER_GUARD_16K_BASELINE={args.guard_16k_baseline} "
+                  f"SPARKINFER_GUARD_32K_BASELINE={args.guard_32k_baseline} "
+                  f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
+                  f"bench/scripts/evaluate.sh --ref {args.ref} --frontier {args.frontier} --ceiling {args.ceiling}")
         got_result = False
         r = sh(host, port, ev, timeout=10800)
         sys.stdout.write(r.stdout[-4000:])

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -391,15 +391,18 @@ def main():
             # Dual-model needs the Qwen3.6 GGUF too. HF (unsloth) — no Drive mirror; slow on some
             # hosts but cached in /workspace after the first pull. evaluate_dual's ensure_model is the
             # backstop if this times out. tokenizer.json comes from ensure_tokenizer at score time.
-            P36_PATH = "/workspace/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+            # Separate dir from Qwen3 — the two models have different tokenizers; evaluate_dual.sh's
+            # primary MODELS_DIR defaults to <guard dir>36 (i.e. /workspace/models -> /workspace/models36).
+            P36_DIR  = "/workspace/models36"
+            P36_PATH = f"{P36_DIR}/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
             P36_READY = "/tmp/sparkinfer_model36_ready"
             p36 = (
                 f"if [ -f '{P36_PATH}' ]; then touch '{P36_READY}' && echo cached; "
                 f"elif [ -f '{P36_READY}' ]; then echo already_running; "
-                f"else mkdir -p /workspace/models && rm -f '{P36_READY}'; "
+                f"else mkdir -p {P36_DIR} && rm -f '{P36_READY}'; "
                 f"nohup bash -c '"
                 f"  HF_HUB_DISABLE_XET=1 hf download unsloth/Qwen3.6-35B-A3B-GGUF "
-                f"       Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --local-dir /workspace/models >>/tmp/dl36.log 2>&1 "
+                f"       Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --local-dir {P36_DIR} >>/tmp/dl36.log 2>&1 "
                 f"  || curl -fL -C - https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
                 f"       -o {P36_PATH} >>/tmp/dl36.log 2>&1; "
                 f"  [ -f {P36_PATH} ] && touch {P36_READY}"


### PR DESCRIPTION
Adds **dual-model evaluation**: score **Qwen3.6-35B-A3B** (the current optimization frontier) and, in one build on one box, **guard Qwen3-30B-A3B against regression**. Opt-in via `--dual` / `DUAL=1` — the live single-model bot is unchanged by default.

### What it does
```
build once ─► PRIMARY  Qwen3.6 : 128/512/4k speed + top-1/KL vs llama.cpp ─► eval:<LABEL>
           └► GUARD    Qwen3-30B: full 5-ctx speed + accuracy gate ─► must NOT regress, else REJECT
```
- `eval:<label>` is driven **only by Qwen3.6** (strongest of 128/512/4k over the Qwen3.6 frontier).
- The **Qwen3-30B guard** re-runs the full speed sweep + accuracy; any Qwen3 speed <98% of its own same-box `origin/main`, or broken llama.cpp parity (top-1<0.90 / KL>0.20), REJECTs the submission with a `no-regression guard` reason + `regression-qwen3-<ctx>` detail.
- Qwen3.6 scored on **128/512/4k only** for now (its 16k/32k decode is too slow to sweep every eval).

### Changes
- **`bench/scripts/evaluate_dual.sh`** — the orchestrator (builds once, calls the model-agnostic `evaluate.sh` twice, merges into one `RESULT_JSON`).
- **`evaluate.sh`** — `SI_SKIP_BUILD` (share one build) + skip-context support (0 reps → context excluded from scoring/guards, never falsely flagged). Backward-compatible for single-model.
- **`reference.lock`** — `MODEL_SHA256` is env-overridable + a `QWEN36_MODEL_SHA256` pin, so each model verifies against its own weights (fixed a spurious 17 GB re-download).
- **`vast_eval.py --dual`** (downloads Qwen3.6 to a separate dir, passes P_*/G_* baselines) · **`pr_eval_bot.py --dual`** (Qwen3.6 baselines as config constants; Qwen3 guard stays same-box) · **`run_bot_cron.sh`** `DUAL=1` toggle.
- Docs: `eval/README.md`, `bench/scripts/README.md`.

### Measured baselines (RTX 5090, sm_120)
- Qwen3.6 sparkinfer: **23.2 / 23.2 / 23.0** tok/s (128/512/4k) · llama.cpp: **~190** — sparkinfer is **8× slower on Qwen3.6**, the headroom this scoring targets.
- Qwen3-30B guard: **470 / 472 / 390 / 329** tok/s (128/512/4k/16k).

### Validated
- Merge logic (unit-tested): guard-OK keeps primary label; speed/accuracy regression + infra failure all REJECT.
- Skip-context scoring (unit-tested): 16k/32k excluded, no false regression.
- Pinned llama.cpp `6f4f53f` **supports Qwen3.6** (no re-pin).
- On-box: build-once + `SI_SKIP_BUILD` reuse works; per-model sha verifies OK.

**Note:** the first full live dual verdict (final merged JSON + Qwen3.6's exact top-1/KL) still needs a completed `--dual` run to confirm; dual mode is opt-in so `main`'s live bot behavior is unchanged until `DUAL=1` is set.