### PR TITLE
fix(qwen36): bf16 KV for hybrid in score/bench — resolves Qwen3.6 accuracy REJECT

### DIFF
--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -61,7 +61,8 @@ int main(int argc, char** argv) {
     // int8 KV pays off only once the halved long-context read outweighs its fixed per-token write cost,
     // so enable it context-adaptively (>= 8k) by default; short contexts stay bf16 (no regression).
     // SPARKINFER_KV_INT8=1/0 forces it on/off regardless.
-    { const char* e8 = getenv("SPARKINFER_KV_INT8"); kvc.int8_kv = e8 ? (e8[0] != '0') : (context_tokens >= 8192); }
+    // int8 KV is the Qwen3-MoE head_dim=128 path; the hybrid Qwen3.6 (gated head_dim=256) writes bf16 KV.
+    { const char* e8 = getenv("SPARKINFER_KV_INT8"); kvc.int8_kv = !cfg.hybrid && (e8 ? (e8[0] != '0') : (context_tokens >= 8192)); }
     const size_t epb=(size_t)16*cfg.n_kv_heads*cfg.head_dim, blocks=(cfg.max_seq+15)/16+8;
     sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers*2*epb*2*blocks);
     sparkinfer::moe::MoEConfig mc;

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -45,7 +45,11 @@ int main(int argc, char** argv) {
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16; kvc.int8_kv = !(getenv("SPARKINFER_KV_INT8") && getenv("SPARKINFER_KV_INT8")[0]=='0');
+    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    // int8 KV is the Qwen3-MoE head_dim=128 tensor-core path; Qwen3.6 (hybrid, gated head_dim=256)
+    // writes bf16 KV. Scoring with int8 KV on the hybrid model corrupts attention -> false accuracy
+    // divergence vs llama.cpp. Mirror generate.cpp: bf16 KV for hybrid.
+    kvc.int8_kv = !cfg.hybrid && !(getenv("SPARKINFER_KV_INT8") && getenv("SPARKINFER_KV_INT8")[0]=='0');
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
     sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);


### PR DESCRIPTION
The dual-eval was REJECTing Qwen3.6 on correctness (top-1 ~0.75, KL ~0.67 vs llama.cpp). Root cause: the **accuracy tool `qwen3_gguf_score` defaulted `int8_kv=true`** and scored Qwen3.6 — a hybrid model with gated `head_dim=256` attention — through the **Qwen3-MoE `head_dim=128` int8 tensor-core KV path**. That corrupts the attention KV and diverges from llama.cpp, so the model *decodes coherently* but fails the top-1/KL gate.

`generate.cpp` already guarded this (`int8_kv = !cfg.hybrid && …`); `score.cpp` and `bench.cpp` didn't. This applies the same guard to both.

### Verified (RTX 5090, Qwen3.6 UD-Q4_K_M, seed=fixed)
| metric | before (int8 KV) | after (bf16 KV) | bar |
|---|---|---|---|
| top-1 | 0.75 | **0.930** | ≥ 0.90 ✓ |
| KL | 0.67 | **0.020** | ≤ 0.20 ✓ |

Qwen3.6 now **passes the correctness gate** — dual-model scoring can reward Qwen3.6 optimization. `bench.cpp` also had the bug at ≥8k context (bf16 KV now forced for hybrid there too).