### PR TITLE
perf(qwen3.6): shared expert as coalesced GEMVs — 7.2× decode (23→167 tok/s)

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -52,6 +52,18 @@ __global__ void sigmoid_scalar_kernel(const __nv_bfloat16* __restrict__ x,
     out[0] = q36_sigmoid(q36_to_f(x[0]));
 }
 
+// Shared-expert SwiGLU: out[i] = dw * SiLU(gate[i]) * up[i]. The shared-expert
+// gate scalar dw folds in here (down is linear, so scaling the intermediate is
+// identical to scaling the output), letting the caller finish with a plain add.
+__global__ void shared_swiglu_kernel(const __nv_bfloat16* __restrict__ gate,
+                                     const __nv_bfloat16* __restrict__ up,
+                                     const float* __restrict__ dw,
+                                     __nv_bfloat16* __restrict__ out, int n) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    out[i] = __float2bfloat16((*dw) * q36_silu(q36_to_f(gate[i])) * q36_to_f(up[i]));
+}
+
 __global__ void conv_split_kernel(const __nv_bfloat16* __restrict__ qkv,
                                   const __nv_bfloat16* __restrict__ conv_w,
                                   __nv_bfloat16* __restrict__ conv_state,
@@ -167,6 +179,15 @@ __global__ void gated_norm_kernel(const __nv_bfloat16* __restrict__ x,
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/fused.h"
+
+void launch_qwen36_shared_swiglu(const void* gate_bf16, const void* up_bf16,
+                                 const float* dw_f32, void* out_bf16, int n,
+                                 cudaStream_t stream) {
+    shared_swiglu_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gate_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(up_bf16),
+        dw_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16), n);
+}
 
 void launch_qwen36_split_q_gate(const void* qg_bf16, void* q_bf16, void* gate_bf16,
                                 int n_heads, int head_dim, cudaStream_t stream) {

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -52,6 +52,11 @@ void launch_qwen36_mul_sigmoid(void* x_bf16, const void* gate_bf16, int n,
 void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32,
                                   cudaStream_t stream = nullptr);
 
+// Shared-expert SwiGLU with folded gate scalar: out[i] = dw * SiLU(gate[i]) * up[i].
+void launch_qwen36_shared_swiglu(const void* gate_bf16, const void* up_bf16,
+                                 const float* dw_f32, void* out_bf16, int n,
+                                 cudaStream_t stream = nullptr);
+
 void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
                                  void* conv_state_bf16, void* q_bf16, void* k_bf16,
                                  void* v_bf16, int q_heads, int v_heads, int head_dim,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -115,6 +115,7 @@ struct Qwen35Model::Impl {
     bf16 *lin_qkv = nullptr, *lin_q = nullptr, *lin_k = nullptr, *lin_v = nullptr;
     bf16 *lin_z = nullptr, *lin_alpha = nullptr, *lin_beta = nullptr;
     bf16 *lin_gdn = nullptr, *lin_norm = nullptr, *shared_gate_tmp = nullptr;
+    bf16 *sh_gate = nullptr, *sh_up = nullptr, *sh_h = nullptr;   // shared-expert GEMV scratch [moe_ffn]
     bf16 *lin_conv_state = nullptr;
     float* lin_state = nullptr;
     float* logits;
@@ -554,9 +555,21 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
                 kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
             }
-            kernels::launch_moe_expert_ffn(s.hn, w.shared_gate, w.shared_up, w.shared_down,
-                                           s.d_shared_ids, s.d_shared_w, s.shared,
-                                           1, 1, 1, H, c.moe_ffn, st);
+            if (s.gguf) {
+                // Shared expert as three coalesced GEMVs (one warp/row, full grid) instead of
+                // the single-block moe_expert_ffn kernel (1 SM, ~961us/layer -> the decode wall).
+                // gate/up: [ffn]=hn@shared_{gate,up}^T; SwiGLU folds the gate scalar d_shared_w;
+                // down: [H]=h@shared_down^T. GGUF-native [out,in] layout (see load_gguf).
+                kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, st);
+                kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, st);
+                kernels::launch_qwen36_shared_swiglu(s.sh_gate, s.sh_up, s.d_shared_w, s.sh_h, c.moe_ffn, st);
+                kernels::launch_gemv(s.sh_h, w.shared_down, s.shared, H, c.moe_ffn, st);
+            } else {
+                // set_weights path: shared weights are [hidden,ffn]/[ffn,hidden] dense.
+                kernels::launch_moe_expert_ffn(s.hn, w.shared_gate, w.shared_up, w.shared_down,
+                                               s.d_shared_ids, s.d_shared_w, s.shared,
+                                               1, 1, 1, H, c.moe_ffn, st);
+            }
             launch_residual_add(s.routed, s.shared, s.routed, H, st);
         }
         // fused: x = h + routed ; xn = RMSNorm(x, next input_norm or final_norm)
@@ -742,6 +755,13 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 "(safe for models without a shared FFN)\n");
         s.cfg.n_shared = 0;
     }
+    // Shared-expert GEMV scratch [moe_ffn]. Allocated only on the GGUF path (native
+    // [out,in] shared weights); the set_weights path keeps the moe_expert_ffn kernel.
+    if (s.cfg.n_shared > 0 && !s.sh_gate) {
+        s.sh_gate = s.alloc<bf16>(s.cfg.moe_ffn);
+        s.sh_up   = s.alloc<bf16>(s.cfg.moe_ffn);
+        s.sh_h    = s.alloc<bf16>(s.cfg.moe_ffn);
+    }
 
     // upload raw quantized blocks, keep on device (for experts)
     auto dev_quant = [&](const std::string& name, int& qtype) -> const void* {
@@ -893,9 +913,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 !expect_dims(b + "ffn_up_shexp.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_down_shexp.weight", {c.moe_ffn, H}) ||
                 !expect_dims_opt(b + "ffn_gate_inp_shexp.weight", {H})) return false;
-            w.shared_gate = dense(b + "ffn_gate_shexp.weight", true);
-            w.shared_up   = dense(b + "ffn_up_shexp.weight", true);
-            w.shared_down = dense(b + "ffn_down_shexp.weight", true);
+            // GGUF-native [out,in] layout (no transpose) so the shared expert runs as
+            // three fast one-warp-per-row GEMVs instead of the single-block dense kernel.
+            w.shared_gate = dense(b + "ffn_gate_shexp.weight", false);   // [ffn, H]
+            w.shared_up   = dense(b + "ffn_up_shexp.weight", false);     // [ffn, H]
+            w.shared_down = dense(b + "ffn_down_shexp.weight", false);   // [H, ffn]
             w.shared_gate_inp = attn_w_opt(b + "ffn_gate_inp_shexp.weight", w.shared_gate_inp_type);
             if (!w.shared_gate || !w.shared_up || !w.shared_down) return false;
         }


### PR DESCRIPTION
## Summary
Speeds up **Qwen3.6-35B-A3B decode 7.2×** by replacing the single-block shared-expert kernel with three coalesced GEMVs. Qwen3-30B is untouched (it has no shared expert), so its decode path is unchanged.

The always-on shared expert ran through `moe_expert_ffn` — **1 SM of 170, ~961 µs/layer = 85% of Qwen3.6 decode**. On the GGUF path it now runs as three one-warp-per-row GEMVs + a SwiGLU that folds the shared-gate scalar (down is linear, so scaling the intermediate is exact). Shared weights load in GGUF-native `[out,in]` layout; the `set_weights` path keeps the original kernel (gated on `s.gguf`).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — Qwen3.6-35B-A3B-UD-Q4_K_M (dual-eval primary model), n=128 bs=1:

| | decode tok/s |
|---|--:|
| before (main) | 23.1 |
| after (this PR) | 166.9 |

**Qwen3-30B no-regression guard** (this PR vs main, n=128): **472.9 vs ~470 — no regression** (30B has no shared expert; decode path unchanged).

Correctness (Qwen3.6, teacher-forced on the same tokens): ARGMATCH 145→144 / 280 — fp reduction-order only. `ctest` 7/7.

```text
# RTX 5090 (sm_120, CUDA 13), n=128 bs=1
# Qwen3.6-35B-A3B-UD-Q4_K_M  (qwen3_gguf_bench)
before (main, single-block shared expert):   decode tg : 23.1 tok/s   (43 ms/token)
after  (this PR, GEMV shared expert):         decode tg : 166.9 tok/s  (6.0 ms/token)   # 7.2x
# Qwen3-30B-A3B-Q4_K_M (no shared expert):     decode tg : 472.9 tok/s  (unchanged vs main)
# ctest: 100% tests passed, 0 failed out of 7
```
