### PR TITLE
perf(qwen3.6): Q8_0 on-read GEMV for dense projections (+8.9% decode, 128/512/4k)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -170,6 +170,39 @@ __global__ void gemv_q_kernel(const __nv_bfloat16* __restrict__ x,
 template __global__ void gemv_q_kernel<__nv_bfloat16>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int, int);
 template __global__ void gemv_q_kernel<float>(const __nv_bfloat16*, const unsigned char*, float*, int, int, int);
 
+// ---- Q8_0 on-read GEMV (W = GGUF-native Q8_0 [N,K]) ---------------------------
+// Q8_0 block = 34 B / 32 values: one fp16 scale d, then 32 int8. Dequant-on-read (d*int8)
+// dotted with the fp32-staged activation — reads the int8 weight bytes (~2x less than bf16)
+// with NO activation quantization. Replaces the Q8_0->bf16 load-time dequant + dense bf16
+// GEMV: this is MORE faithful (fp32 accumulate of the exact Q8_0 value, vs bf16-rounded weight)
+// and reads half the weight memory. One warp per output row (lane j owns value j of each block).
+template <typename OutT>
+__global__ void gemv_q80_kernel(const __nv_bfloat16* __restrict__ x,
+                                const unsigned char* __restrict__ W,
+                                OutT* __restrict__ y, int N, int K) {
+    extern __shared__ float s_x[];                 // K floats
+    for (int i = threadIdx.x; i < K; i += blockDim.x) s_x[i] = __bfloat162float(x[i]);
+    __syncthreads();
+
+    const int warp = threadIdx.x / 32, lane = threadIdx.x % 32;
+    const int n = blockIdx.x * GEMV_WPB + warp;
+    if (n >= N) return;
+    const int nblk = K / 32;                        // Q8_0: 32 values / block
+    const unsigned char* base = W + (size_t)n * nblk * 34;
+    float acc = 0.f;
+    for (int blk = 0; blk < nblk; blk++) {
+        const unsigned char* b = base + (size_t)blk * 34;
+        const float d = gq_h2f(b);                  // fp16 block scale
+        const signed char q = reinterpret_cast<const signed char*>(b + 2)[lane];
+        acc += d * (float)q * s_x[blk * 32 + lane];
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) gemv_write(y + n, acc);
+}
+template __global__ void gemv_q80_kernel<__nv_bfloat16>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void gemv_q80_kernel<float>(const __nv_bfloat16*, const unsigned char*, float*, int, int);
+
 // ---- faithful llama.cpp int8 MMVQ for a dense Q4_K [N,K] GEMV --------------------
 // Quantizes the activation to Q8_1 (int8 + per-32 scale + sum) once per token, then
 // dp4a's the Q4_K weight nibbles against it — the same vec_dot_q4_K_q8_1 math llama.cpp
@@ -637,6 +670,10 @@ void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int 
         gemv_q_dp4a_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, sm, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), N, K);
+    } else if (wtype == 8) {            // Q8_0: half the weight read of the bf16 GEMV
+        gemv_q80_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), N, K);
     } else {
         gemv_q_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
@@ -648,6 +685,9 @@ void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N,
     if (gemv_mmvq() && wtype == 12) {
         size_t sm = 2 * (size_t)(K >> 5) * sizeof(float) + (size_t)K;
         gemv_q_dp4a_kernel<float><<<grid, GEMV_WPB * 32, sm, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W), y, N, K);
+    } else if (wtype == 8) {            // Q8_0
+        gemv_q80_kernel<float><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W), y, N, K);
     } else {
         gemv_q_kernel<float><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -811,9 +811,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     // uses ~1.5 GB less VRAM. Set SPARKINFER_QATTN=0 to load dense bf16 instead.
     const bool qattn = []{ const char* a = getenv("SPARKINFER_QATTN");
                            return !(a && a[0] == '0'); }();
+    // Keep Q8_0 (ggml type 8) projection weights quantized in VRAM and decode them on-read
+    // (gemv_q80_kernel), instead of the load-time Q8_0->bf16 dequant + dense bf16 GEMV. Halves
+    // the weight read of the ~44%-of-decode dense GEMV and is more faithful (fp32 accumulate of
+    // the exact Q8_0 value vs a bf16-rounded weight). Default ON; SPARKINFER_QGEMV8=0 = bf16.
+    const bool q80 = []{ const char* a = getenv("SPARKINFER_QGEMV8");
+                         return !(a && a[0] == '0'); }();
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
-        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
+        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || (q80 && t->ggml_type == 8)))
+            return dev_quant(name, type);
         type = 0; return dense(name, false);
     };
     auto attn_w_opt = [&](const std::string& name, int& type) -> const void* {


### PR DESCRIPTION
## Summary

Q8_0 on-read GEMV for the dense projections. Keep Q8_0 (ggml type 8) projection weights quantized
in VRAM and decode them on-read (new `gemv_q80_kernel`) instead of the load-time Q8_0→bf16 dequant +
dense bf16 GEMV. The dense projection GEMV (GDN `wqkv`/`wqkv_gate`/`ssm_alpha`/`ssm_beta`/`ssm_out`,
attention `q`/`k`/`v`/`o`, `lm_head`) is ~44% of Qwen3.6 decode (nsys, on top of the shared-expert
fix). Reading int8 weights (~2× less than bf16) on the decode's biggest kernel gives ~+8.9%
end-to-end, is more faithful than the old path (fp32 accumulate of the exact int8×scale, no bf16
weight rounding, no activation quant), and frees ~half the VRAM of those tensors.

Scope: `kernels/csrc/cuda/gemm/gemv.cu` + one dispatch condition in `runtime/src/models/qwen35.cpp`.
Gated by `SPARKINFER_QGEMV8` (default on; `=0` restores the exact previous bf16 path). Independent
of the shared-expert (#230) and gdn_ar_fast (#229) merges — different kernels; they stack.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 169.69 |
| after (this PR) | 184.98 |

<!-- Qwen3.6-35B-A3B-UD-Q4_K_M, qwen3_gguf_bench, n=128, bs=1, RTX 5090 sm_120, CUDA 13.
     SPARKINFER_QGEMV8=0 reproduces main exactly (new path gated off); =1 is this PR (default). -->

```text
Qwen3.6-35B-A3B-UD-Q4_K_M  ·  RTX 5090 (sm_120)  ·  qwen3_gguf_bench n=128 bs=1
SPARKINFER_QGEMV8=0 (= main, gated off)  ->  =1 (= this PR, default on)
  ctx=128    169.69  ->  184.98   (+9.0%)
  ctx=512    169.39  ->  184.45   (+8.9%)
  ctx=4096   163.12  ->  177.32   (+8.7%)
```

Per-context (Qwen3.6 is scored on 128/512/4k):

| context | main | this PR | speedup |
|---|--:|--:|--:|
| 128 | 169.69 | 184.98 | +9.0% |
| 512 | 169.39 | 184.45 | +8.9% |
| 4k  | 163.12 | 177.32 | +8.7% |

**Correctness** — teacher-forced vs llama.cpp, same held-out prompt (gen_eval_prompt seed 42, 271
positions, matched-depth top-64 KL). `ctest` 7/7 pass.

| build | top-1 vs llama | mean KL | sparkinfer PPL |
|---|--:|--:|--:|
| main (bf16) | 0.956 | 0.0177 | 6.610 |
| this PR (Q8_0) | 0.941 | 0.0169 | 6.564 |

Clears the accuracy gate with margin (top-1 ≥ 0.90, KL ≤ 0.20 — below the preferred 0.15); **lower
KL and better PPL than main** (the exact int8 weight is more faithful than the bf16-rounded one).