### PR TITLE
perf(qwen3.6): GQA-8 flash decode for head_dim=256 (+4% @16k ctx)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -290,9 +290,11 @@ template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE, true>(const __
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
-// Qwen3.6 full-attention head_dim=256 (bf16 KV): scalar split only (int8/GQA paths are hd=128-only).
+// Qwen3.6 full-attention head_dim=256 (bf16 KV): GQA-8 split + scalar fallback.
 template __global__ void fa_split_kernel<256>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
+template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, false>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
@@ -502,14 +504,25 @@ void launch_flash_decode_split(
     int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
     void* out_q8, int seqlen, const void* k_scale, const void* v_scale, int int8_kv
 ) {
-    // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). The GQA-8 / int8 tensor-core paths
-    // below are head_dim=128-specialized, so 256 takes the generic scalar split + combine.
+    // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). Use the GQA-8 shared-KV tile
+    // path (same 8:1 grouping as Qwen3 hd=128) — cuts KV global reads ~8x vs one-warp-per-q-head.
     if (head_dim == 256) {
-        dim3 g1(num_q_heads * n_splits, num_seqs), g2(num_q_heads * FA_COMBINE_DG, num_seqs);
-        fa_split_kernel<256><<<g1, 32, 0, stream>>>(
-            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
-            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
-            reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
+        dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
+        if (num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
+            constexpr int GQA = 8, TILE = FA_GQA_TILE;
+            dim3 gq(num_kv_heads * n_splits, num_seqs);
+            const size_t smem = (size_t)2 * TILE * 256 * sizeof(__nv_bfloat16);
+            fa_split_gqa_kernel<256, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+        } else {
+            dim3 g1(num_q_heads * n_splits, num_seqs);
+            fa_split_kernel<256><<<g1, 32, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
+        }
         fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
             part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
             reinterpret_cast<fa_block_q8_1*>(out_q8));


### PR DESCRIPTION
## Summary

Post-#229/#230 marginal speedup on **Qwen3.6 full-attention layers** (`head_dim=256`, 8:1 GQA).

Previously `launch_flash_decode_split` routed hd=256 to a generic one-warp-per-q-head scalar split. This wires the **GQA-8 shared-KV tile** path (`fa_split_gqa_kernel<256,8,...>`) so each kv-head split stages K/V once and reuses it across 8 query heads (~8× less KV global traffic).

**Scope:** single file — `kernels/csrc/cuda/attention/flash_decode_split.cu`. Qwen3 hd=128 paths untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 153.05 |
| after (this PR) | 159.24 |

Model: `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf` (unsloth), `n=128`, `bs=1`, `SPARKINFER_BENCH_DEVICE_LOOP=0`, default env (no feature flags). Primary context **16384** (full-attn KV work dominates).

### Full sweep (RTX 5090, same settings)

| context | before (main) | after (this PR) | delta |
|--------:|--------------:|----------------:|------:|
| **4096** | 162.25 tok/s | **165.51 tok/s** | **+2.0%** |
| **16384** | 153.05 tok/s | **159.24 tok/s** | **+4.0%** |

Short ctx (128/512) is GDN/MoE dominated — gains appear once full-attn KV work grows (10/40 layers).

```text
# before (upstream/main @ RTX 5090)
=== sparkinfer — decode (n=128, ctx=4096, bs=1) ===
decode tg    : 162.25 tok/s  (6.2 ms/token, n=128, ctx=4096, bs=1)
=== sparkinfer — decode (n=128, ctx=16384, bs=1) ===
decode tg    : 153.05 tok/s  (6.5 ms/token, n=128, ctx=16384, bs=1)

# after (perf/qwen36-fa-gqa256-hd256 @ RTX 5090)
=== sparkinfer — decode (n=128, ctx=4096, bs=1) ===
decode tg    : 165.51 tok/s  (6.0 ms/token, n=128, ctx=4096, bs=1)
=== sparkinfer — decode (n=128, ctx=16384, bs=1) ===
decode tg    : 159.24 tok/s  (6.3 ms/token, n=128, ctx=16384, bs=1)
```

## Reproduce

```bash
NO_PREBUILT=1 cmake -S . -B build -DCMAKE_CUDA_ARCHITECTURES=120 -DCMAKE_BUILD_TYPE=Release -DCMAKE_CUDA_HOST_COMPILER=g++-12
cmake --build build --target qwen3_gguf_bench -j2

MODEL=/path/to/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
SPARKINFER_BENCH_DEVICE_LOOP=0 ./build/runtime/qwen3_gguf_bench "$MODEL" 128 4096
SPARKINFER_BENCH_DEVICE_LOOP=0 ./build/runtime/qwen3_gguf_bench "$MODEL" 128 16384
```

## Test plan

- [x] Qwen3.6 decode @4096/16384 — default env on RTX 5090
- [ ] Qwen3-30B guard @128
- [ ] Eval bot on RTX 5090
