### PR TITLE
perf(qwen3.6): default the merged gdn_ar_fast_kernel ON

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -303,8 +303,13 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
     // SPARKINFER_GDN_FAST: warp-per-column, register-cached, transposed-state kernel (fills the GPU +
     // 2x state traffic). Uses a transposed internal state layout, so it MUST be all-or-nothing for the
     // run — the static flag guarantees that. Requires head_dim a multiple of 32 (128 -> NROW=4).
+    // Default ON (=0 restores the naive kernel): the eval harness never sets feature env vars, so this
+    // opt-in-only flag meant the merged kernel never ran in scoring -- gdn_ar_kernel's <<<v_heads,128>>>
+    // launch (32 blocks on a 170-SM part) stayed the decode path's #2 cost by far. Byte-exact math,
+    // verified: score PPL 2.76957->2.76956, generate() token-identical; only the fp32 reduction order
+    // (and thus the rare near-tied-argmax pick) differs, same as any other split/tiling change here.
     static int fast = -1;
-    if (fast < 0) { const char* e = getenv("SPARKINFER_GDN_FAST"); fast = (e && e[0] == '1') ? 1 : 0; }
+    if (fast < 0) { const char* e = getenv("SPARKINFER_GDN_FAST"); fast = (e && e[0] == '0') ? 0 : 1; }
     if (fast && head_dim == 128) {                            // Qwen3.6 linear_head_dim; other dims -> naive
         constexpr int COLS = 8, HD = 128;                     // 8 warps (columns)/block -> 256 threads
         dim3 grid(v_heads, (HD + COLS - 1) / COLS);


### PR DESCRIPTION
## Summary

`SPARKINFER_GDN_FAST` (merged in #229) only activates `gdn_ar_fast_kernel` when the
env var is explicitly set to `1`. **The eval harness (`bench/scripts/evaluate.sh`,
`evaluate_dual.sh`) never sets feature env vars** -- it only passes
guard/baseline/difficulty scoring parameters (`SPARKINFER_GUARD_*`,
`SPARKINFER_DIFFICULTY_*`, `SPARKINFER_EVAL_MODE`, etc.) -- so the merged kernel has
never actually run during scoring. The naive `gdn_ar_kernel`
(`<<<v_heads=32, head_dim>>>`, ~81% of the SMs idle every token, two serial
head_dim-long dependent-load loops, as described in #229's own summary) has stayed
the decode path's largest single non-GEMV cost the whole time.

This flips the default to **ON** (opt-out via `SPARKINFER_GDN_FAST=0`), matching
every other feature flag in this runtime (`use_pq`, `use_llama`, `use_q6mmvq`,
`use_fnq` are all default-on / opt-out-via-`0`). **No kernel code changes** --
`gdn_ar_fast_kernel` is #229's kernel, unmodified; this is a one-line default flip
plus a comment explaining why.

Scope: `kernels/csrc/cuda/fused/qwen36.cu`, single function
(`launch_qwen36_gdn_ar`), single line changed.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`bench/scripts/bench.sh`, Qwen3.6-35B-A3B-UD-Q4_K_M.gguf, bs=1, same box):

| context | before (main default) | after (this PR) | delta |
|---:|---:|---:|---:|
| 128 | 171.90 | 224.47 | **+30.6%** |
| 512 | 170.46 | 222.07 | **+30.3%** |

```text
=== before (main, SPARKINFER_GDN_FAST unset -> naive gdn_ar_kernel) ===
model        : Qwen3.5/Qwen3.6-35B-A3B hybrid  (40 layers, 256 experts top-8)
VRAM used    : 25.3 GB
decode tg    : 171.90 tok/s  (5.8 ms/token, n=128, ctx=0, bs=1)
decode tg    : 170.46 tok/s  (5.9 ms/token, n=512, ctx=0, bs=1)

=== after (this PR, default now runs gdn_ar_fast_kernel) ===
model        : Qwen3.5/Qwen3.6-35B-A3B hybrid  (40 layers, 256 experts top-8)
VRAM used    : 25.3 GB
decode tg    : 224.47 tok/s  (4.5 ms/token, n=128, ctx=0, bs=1)
decode tg    : 222.07 tok/s  (4.5 ms/token, n=512, ctx=0, bs=1)
```

**Correctness** (teacher-forced, same held-out prompt, vs `main` default):
- `generate()`: token-for-token **identical** across 48 generated tokens.
- `score`: PPL 2.76957 -> 2.76956, ARGMATCH 73/101 -> 71/101 (0.7228 -> 0.7030,
  both far above bar). The tiny ARGMATCH delta is the same kind of fp32
  reduction-order noise any split/tiling change in this codebase produces (#229's
  own PR notes this is byte-exact math, different order); PPL is unchanged to 5
  significant figures.
- `ctest --test-dir build`: 7/7 pass.

## Why this wasn't caught by #229's own eval

#229 was rebased on top of #230 (shared-expert fix, 23->167 tok/s) before its final
eval run, and #230's fix alone is a 7x win -- enough to land `eval:XL` even with
`gdn_ar_fast_kernel` sitting inactive behind its opt-in flag the whole time. The
gap only shows up when you diff default-vs-explicit-flag on the *current* main,
which is what this PR does.
