### PR TITLE
perf(qwen3.6): int8 Q8_0 dp4a MMVQ for attention/GDN projections (+24% decode)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -439,17 +439,24 @@ template __global__ void si_mmvq_q4k_kernel<float>(const si_block_q8_1*, const u
 // simplest mmvq (no 4-bit unpack) and byte-faithful to llama.cpp vec_dot_q8_0_q8_1: Q8_0 is symmetric
 // so there is no Q8_1 offset term -> dot = d_w * d_a * sum(w_i * a_i). Q8_0 blocks are 34 B (2-byte
 // aligned only), so the weight ints are read 2-byte-aligned like the Q6_K path.
-struct si_block_q8_0 { __half d; signed char qs[32]; };                  // 34 B / 32 values
-__device__ __forceinline__ int si_q80_get_int_b2(const void* p, int i32) {
+// A Q8_0 block is 34 B ([fp16 d][int8 qs[32]]) and only 2-byte aligned, so read it via explicit byte
+// offsets + a copy-based fp16 read (like the Q6_K path's gq_h2f / si_get_int_b2) — a typed __half load
+// or a struct stride would assume 4-byte alignment and read garbage.
+__device__ __forceinline__ float si_q80_h2f(const unsigned char* p) {
+    __half h; *reinterpret_cast<unsigned short*>(&h) = *reinterpret_cast<const unsigned short*>(p);
+    return __half2float(h);
+}
+__device__ __forceinline__ int si_q80_get_int_b2(const unsigned char* p, int i32) {
     const unsigned short* u = reinterpret_cast<const unsigned short*>(p);
     return (int)u[2 * i32] | ((int)u[2 * i32 + 1] << 16);
 }
-__device__ __forceinline__ float si_vec_dot_q8_0(const si_block_q8_0* bw, const si_block_q8_1* ba) {
+__device__ __forceinline__ float si_vec_dot_q8_0(const unsigned char* bw, const si_block_q8_1* ba) {
+    const float dw = si_q80_h2f(bw);                       // fp16 scale @ block offset 0
     const int* a = reinterpret_cast<const int*>(ba->qs);   // q8_1 qs is 4-byte aligned (follows half2 ds)
     int sumi = 0;
     #pragma unroll
-    for (int i = 0; i < 8; i++) sumi = __dp4a(si_q80_get_int_b2(bw->qs, i), a[i], sumi);
-    return __half2float(bw->d) * __low2float(ba->ds) * (float)sumi;
+    for (int i = 0; i < 8; i++) sumi = __dp4a(si_q80_get_int_b2(bw + 2, i), a[i], sumi);  // qs @ offset 2
+    return dw * __low2float(ba->ds) * (float)sumi;
 }
 template <typename OutT>
 __global__ void si_mmvq_q80_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
@@ -458,10 +465,10 @@ __global__ void si_mmvq_q80_kernel(const si_block_q8_1* __restrict__ vy, const u
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
     const int row = blockIdx.x;
     const int nb = K >> 5;                                                // 32-weight Q8_0 blocks per row
-    const si_block_q8_0* w_row = reinterpret_cast<const si_block_q8_0*>(W + (size_t)row * nb * 34);
+    const unsigned char* w_row = W + (size_t)row * nb * 34;               // explicit 34-byte block stride
     float tmp = 0.0f;
     for (int kb = tid; kb < nb; kb += NW * WS)
-        tmp += si_vec_dot_q8_0(w_row + kb, vy + kb);
+        tmp += si_vec_dot_q8_0(w_row + (size_t)kb * 34, vy + kb);
     __shared__ float tmp_shared[NW - 1][WS];
     if (warp > 0) tmp_shared[warp - 1][lane] = tmp;
     __syncthreads();

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -432,6 +432,49 @@ __global__ void si_mmvq_q4k_kernel(const si_block_q8_1* __restrict__ vy, const u
 template __global__ void si_mmvq_q4k_kernel<__nv_bfloat16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
 template __global__ void si_mmvq_q4k_kernel<float>(const si_block_q8_1*, const unsigned char*, float*, int, int);
 
+// ---- faithful llama.cpp Q8_0 x Q8_1 dp4a mmvq (weights stay int8, no bf16 expansion) ----
+// The Unsloth UD-Q4_K_M Qwen3.6 GGUF stores the attention/GDN/shared-expert projections as Q8_0
+// (the routed experts are Q4_K). Without a Q8_0 mmvq those weights were dequantized to bf16 at load
+// and run the generic bf16 GEMV — ~60% of Qwen3.6 decode. Q8_0 is already int8, so this is the
+// simplest mmvq (no 4-bit unpack) and byte-faithful to llama.cpp vec_dot_q8_0_q8_1: Q8_0 is symmetric
+// so there is no Q8_1 offset term -> dot = d_w * d_a * sum(w_i * a_i). Q8_0 blocks are 34 B (2-byte
+// aligned only), so the weight ints are read 2-byte-aligned like the Q6_K path.
+struct si_block_q8_0 { __half d; signed char qs[32]; };                  // 34 B / 32 values
+__device__ __forceinline__ int si_get_int_b2(const void* p, int i32) {
+    const unsigned short* u = reinterpret_cast<const unsigned short*>(p);
+    return (int)u[2 * i32] | ((int)u[2 * i32 + 1] << 16);
+}
+__device__ __forceinline__ float si_vec_dot_q8_0(const si_block_q8_0* bw, const si_block_q8_1* ba) {
+    const int* a = reinterpret_cast<const int*>(ba->qs);   // q8_1 qs is 4-byte aligned (follows half2 ds)
+    int sumi = 0;
+    #pragma unroll
+    for (int i = 0; i < 8; i++) sumi = __dp4a(si_get_int_b2(bw->qs, i), a[i], sumi);
+    return __half2float(bw->d) * __low2float(ba->ds) * (float)sumi;
+}
+template <typename OutT>
+__global__ void si_mmvq_q80_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
+                                   OutT* __restrict__ y, int N, int K) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    const int nb = K >> 5;                                                // 32-weight Q8_0 blocks per row
+    const si_block_q8_0* w_row = reinterpret_cast<const si_block_q8_0*>(W + (size_t)row * nb * 34);
+    float tmp = 0.0f;
+    for (int kb = tid; kb < nb; kb += NW * WS)
+        tmp += si_vec_dot_q8_0(w_row + kb, vy + kb);
+    __shared__ float tmp_shared[NW - 1][WS];
+    if (warp > 0) tmp_shared[warp - 1][lane] = tmp;
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += tmp_shared[l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+template __global__ void si_mmvq_q80_kernel<__nv_bfloat16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_kernel<float>(const si_block_q8_1*, const unsigned char*, float*, int, int);
+
 template <typename OutT, int NSUPER>
 __global__ void si_mmvq_q4k_kfixed_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
                                           OutT* __restrict__ y, int N) {
@@ -757,6 +800,15 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
     if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
+}
+void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
+    si_mmvq_q80_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(
+        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
+        reinterpret_cast<__nv_bfloat16*>(y), N, K);
+}
+void launch_mmvq_q80_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
+    si_mmvq_q80_kernel<float><<<N, 4 * 32, 0, stream>>>(
+        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, K);
 }
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -440,7 +440,7 @@ template __global__ void si_mmvq_q4k_kernel<float>(const si_block_q8_1*, const u
 // so there is no Q8_1 offset term -> dot = d_w * d_a * sum(w_i * a_i). Q8_0 blocks are 34 B (2-byte
 // aligned only), so the weight ints are read 2-byte-aligned like the Q6_K path.
 struct si_block_q8_0 { __half d; signed char qs[32]; };                  // 34 B / 32 values
-__device__ __forceinline__ int si_get_int_b2(const void* p, int i32) {
+__device__ __forceinline__ int si_q80_get_int_b2(const void* p, int i32) {
     const unsigned short* u = reinterpret_cast<const unsigned short*>(p);
     return (int)u[2 * i32] | ((int)u[2 * i32 + 1] << 16);
 }
@@ -448,7 +448,7 @@ __device__ __forceinline__ float si_vec_dot_q8_0(const si_block_q8_0* bw, const 
     const int* a = reinterpret_cast<const int*>(ba->qs);   // q8_1 qs is 4-byte aligned (follows half2 ds)
     int sumi = 0;
     #pragma unroll
-    for (int i = 0; i < 8; i++) sumi = __dp4a(si_get_int_b2(bw->qs, i), a[i], sumi);
+    for (int i = 0; i < 8; i++) sumi = __dp4a(si_q80_get_int_b2(bw->qs, i), a[i], sumi);
     return __half2float(bw->d) * __low2float(ba->ds) * (float)sumi;
 }
 template <typename OutT>

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -74,6 +74,9 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
 // Same, for Q6_K weights (attn-V upgrades + LM head). q81 = block_q8_1(activation).
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
+// Q8_0 x Q8_1 dp4a mmvq (Q8_0 weights kept int8; the Qwen3.6 UD-quant attention/GDN/shared projections)
+void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
+void launch_mmvq_q80_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 // 1-warp-per-row Q6_K dp4a GEMV (large-N, e.g. LM head): GEMV_WPB rows/block.
 void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -355,10 +355,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
         bool xn_q8_ready = fnq && L > 0;
-        auto prepare_xn_quant = [&](bool any_q4k, bool any_q6k) {
+        auto prepare_xn_quant = [&](bool any_q4k, bool any_q6k, bool any_q80) {
             if (!s.gguf || !s.use_pq) return;
             if (xn_q8_ready) return;
-            if (s.use_llama && (any_q4k || (s.use_q6mmvq && any_q6k))) {
+            if (s.use_llama && (any_q4k || any_q80 || (s.use_q6mmvq && any_q6k))) {
                 kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
                 xn_q8_ready = true;
             } else if (any_q4k) {
@@ -373,6 +373,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
                 else if (s.use_pq && s.use_llama && s.use_q6mmvq && t == 14)
                     kernels::launch_mmvq_q6k(s.aq81, W, y, N, H, pst);
+                else if (s.use_pq && s.use_llama && t == 8)
+                    kernels::launch_mmvq_q80(s.aq81, W, y, N, H, pst);
                 else if (t) kernels::launch_gemv_q(s.xn, W, t, y, N, H, pst);
                 else        kernels::launch_gemv(s.xn, W, y, N, H, pst);
             } else {
@@ -392,6 +394,9 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 } else if (s.use_pq && s.use_llama && s.use_q6mmvq && t == 14) {
                     kernels::launch_quantize_q8_1_blocks(x, s.aq81, K, st);
                     kernels::launch_mmvq_q6k(s.aq81, W, y, N, K, st);
+                } else if (s.use_pq && s.use_llama && t == 8) {
+                    kernels::launch_quantize_q8_1_blocks(x, s.aq81, K, st);
+                    kernels::launch_mmvq_q80(s.aq81, W, y, N, K, st);
                 } else if (t) kernels::launch_gemv_q(x, W, t, y, N, K, st);
                 else          kernels::launch_gemv(x, W, y, N, K, st);
             } else {
@@ -404,7 +409,9 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                   w.ssm_alpha_type == 12 || w.ssm_beta_type == 12);
             const bool any_q6k = (w.wqkv_type == 14 || w.wqkv_gate_type == 14 ||
                                   w.ssm_alpha_type == 14 || w.ssm_beta_type == 14);
-            prepare_xn_quant(any_q4k, any_q6k);
+            const bool any_q80 = (w.wqkv_type == 8 || w.wqkv_gate_type == 8 ||
+                                  w.ssm_alpha_type == 8 || w.ssm_beta_type == 8);
+            prepare_xn_quant(any_q4k, any_q6k, any_q80);
             const bool gdn_pipelined = s.gguf && s.use_gdn_pipe;
             if (gdn_pipelined) {
                 cudaEventRecord(s.ev_pipe_fork, st);
@@ -447,7 +454,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
             if (s.gguf) {
                 const bool any_q4k = (w.wq_type == 12 || w.wk_type == 12 || w.wv_type == 12);
                 const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
-                prepare_xn_quant(any_q4k, any_q6k);
+                const bool any_q80 = (w.wq_type == 8 || w.wk_type == 8 || w.wv_type == 8);
+                prepare_xn_quant(any_q4k, any_q6k, any_q80);
                 if (s.use_qkvstream) {
                     cudaEventRecord(s.ev_qkv, st);
                     cudaStreamWaitEvent(s.stream_k, s.ev_qkv, 0);
@@ -530,6 +538,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);
                     kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s, w.wo, s.ao, H, s.qdim, st);
                 }
+            }
+            else if (s.gguf && s.use_pq && s.use_llama && w.wo_type == 8) {   // Q8_0 O-proj (UD-quant)
+                kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                kernels::launch_mmvq_q80(s.aq81, w.wo, s.ao, H, s.qdim, st);
             }
             else if (s.gguf && w.wo_type) kernels::launch_gemv_q(s.attn, w.wo, w.wo_type, s.ao, H, s.qdim, st);
             else if (s.gguf)         kernels::launch_gemv(s.attn, w.wo, s.ao, H, s.qdim, st);
@@ -906,15 +918,17 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     // uses ~1.5 GB less VRAM. Set SPARKINFER_QATTN=0 to load dense bf16 instead.
     const bool qattn = []{ const char* a = getenv("SPARKINFER_QATTN");
                            return !(a && a[0] == '0'); }();
+    // Q8_0 (8) joins Q4_K/Q6_K on the keep-raw dp4a path: the Qwen3.6 UD-quant stores attention/GDN
+    // projections as Q8_0, which otherwise expand to bf16 and run the slow generic GEMV (~60% of decode).
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
-        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
+        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8)) return dev_quant(name, type);
         type = 0; return dense(name, false);
     };
     auto attn_w_opt = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
         if (!t) { type = 0; return nullptr; }
-        if (qattn && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
+        if (qattn && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8)) return dev_quant(name, type);
         type = 0; return dense(name, false);
     };
     auto dense_opt = [&](const std::string& name, bool transpose) -> const void* {


### PR DESCRIPTION
## What

Adds the missing **Q8_0 × Q8_1 dp4a MMVQ** path so Qwen3.6's attention and Gated-DeltaNet projections run int8 on-read instead of being expanded to bf16 at load.

## Why

Profiling **Qwen3.6-35B-A3B** (the dual-eval primary, Unsloth `UD-Q4_K_M`) on an RTX 5090 at ctx=512 showed `gemv_kernel<bf16>` at **59.7% of decode**. Cause: the UD quant stores the attention/GDN projections (`attn_q/k/v/output`, `attn_qkv`, `ssm_out`) as **Q8_0**, and sparkinfer had MMVQ only for Q4_K/Q6_K — so every Q8_0 weight was dequantized to bf16 at load (`deq_q8_0_kernel`, +2.7 GB VRAM) and ran the slow generic GEMV. The routed experts (Q4_K) already run int8.

## How

Q8_0 is already int8, so this is the simplest MMVQ (no 4-bit unpack) and byte-faithful to llama.cpp `vec_dot_q8_0_q8_1` (Q8_0 is symmetric → no Q8_1 offset term: `dot = d_w·d_a·Σ w_i·a_i`). Q8_0 blocks are 34 B / 2-byte aligned, so weight ints are read 2-byte-aligned like the Q6_K path.

- **kernels:** `si_mmvq_q80_kernel` + `launch_mmvq_q80/_f32`.
- **loader:** `attn_w` keeps Q8_0 raw (joins Q4_K/Q6_K); `SPARKINFER_QATTN=0` still reverts to dense bf16.
- **dispatch:** `proj_xn` / `proj_from` / O-projection route ggml type 8 → `mmvq_q80`; `prepare_xn_quant` emits the shared Q8_1 activation when any projection is Q8_0.

## Results (RTX 5090, Qwen3.6-35B-A3B UD-Q4_K_M, ctx=512, bs=1)

| | decode tok/s | VRAM |
|---|---|---|
| main (Q8_0 → bf16 GEMV) | 221.3 | 25.3 GB |
| **this PR (Q8_0 MMVQ)** | **273.96** | 23.6 GB |

**+24% decode**, and lower VRAM (weights stay int8).

**Accuracy** (teacher-forced `qwen3_gguf_score`, this PR vs the bf16 path on the same sequence): top-1 argmax agrees at 16/19 positions on a *random* token sequence (the 3 diffs are sub-0.2-nat near-ties), logprobs track within ~0.05–0.2 nats, PPL 7552 vs 7807 ≈ identical. Q8_0 is 8-bit — higher precision than the Q4_K attention path already at top-1 0.99 — so it should clear the gate on natural text.

## Follow-up

The shared expert (`ffn_{gate,up,down}_shexp`, also Q8_0) still runs `dense`+`launch_gemv` — another slice of that 59.7%, for a subsequent PR.