### PR TITLE
perf(moe): int8 dp4a MMVQ for the Q5_K expert down projection (+6.6% Qwen3.6 decode)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -442,6 +442,50 @@ __device__ __forceinline__ float si_vec_dot_q4_K(const si_block_q4_K* bq4, const
     float2 dm4f = __half22float2(bq4->dm);
     return dm4f.x * sumf_d - dm4f.y * sumf_m;
 }
+
+// Q5_K int8 dp4a vec-dot for the MoE down. Q5_K is Q4_K plus one high bit per quant (qh[32]), so
+// this reuses the faithful Q4_K vec_dot structure (same qs / scales / activation indexing, same
+// iqs = 2*L convention as si_vec_dot_q4_K) and only widens each 4-bit weight to 5 bits. The qh bit
+// for a nibble is derived from the fp reference (q4kf_deq_dot, t==13): for a qs byte b the low
+// nibble takes qh bit 2*(b/32) and the high nibble bit 2*(b/32)+1; across the four bytes v[0]/v[1]
+// cover, b/32 == bq8_offset/2, so nibble half i uses qh bit (bq8_offset + i). Result matches the
+// fp Q5_K down up to the int8 activation rounding (validated by self-consistency).
+struct si_block_q5_K { __half2 dm; unsigned char scales[12]; unsigned char qh[32]; unsigned char qs[128]; };  // 176 B
+__device__ __forceinline__ float si_vec_dot_q5_K(const si_block_q5_K* bq5, const si_block_q8_1* bq8_1, int iqs) {
+    int v[2], u[4]; float d8[2];
+    const int L = iqs >> 1;                              // 0..15, same position index as the Q4_K path
+    const int bq8_offset = 2 * (L / 4);
+    const int* q4 = (const int*)(bq5->qs + 16 * bq8_offset + 4 * (L % 4));
+    v[0] = q4[0]; v[1] = q4[4];
+    const int* qhp = (const int*)(bq5->qh + 4 * (L % 4));  // qh ints aligned with q4[0] and q4[4]
+    const int qh0 = qhp[0], qh1 = qhp[4];
+    const unsigned short* scales = (const unsigned short*)bq5->scales;   // 6-bit scales/mins, as Q4_K
+    unsigned short aux[2]; const int j = bq8_offset / 2;
+    if (j < 2) { aux[0] = scales[j] & 0x3f3f; aux[1] = scales[j + 2] & 0x3f3f; }
+    else { aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+           aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+    const unsigned char* sc = (const unsigned char*)aux; const unsigned char* m = sc + 2;
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const si_block_q8_1* bq8i = bq8_1 + bq8_offset + i;
+        d8[i] = __low2float(bq8i->ds);
+        const int* q8 = (const int*)bq8i->qs + (L % 4);
+        u[2 * i] = q8[0]; u[2 * i + 1] = q8[4];
+    }
+    float sumf_d = 0.f, sumf_m = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int hs = bq8_offset + i;                    // qh bit for this nibble half (low=+0, high=+1)
+        const int v0i = ((v[0] >> (4 * i)) & 0x0F0F0F0F) | (((qh0 >> hs) & 0x01010101) << 4);
+        const int v1i = ((v[1] >> (4 * i)) & 0x0F0F0F0F) | (((qh1 >> hs) & 0x01010101) << 4);
+        const int dot1 = __dp4a(v0i, u[2 * i], __dp4a(v1i, u[2 * i + 1], 0));
+        const int dot2 = __dp4a(0x01010101, u[2 * i], __dp4a(0x01010101, u[2 * i + 1], 0));
+        sumf_d += d8[i] * (dot1 * sc[i]);
+        sumf_m += d8[i] * (dot2 * m[i]);
+    }
+    float2 dm5f = __half22float2(bq5->dm);
+    return dm5f.x * sumf_d - dm5f.y * sumf_m;
+}
 __global__ void gate_up_mmvq2_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
@@ -663,6 +707,84 @@ __global__ void down_q4k_mmvq_splitk_kernel(
     }
 }
 
+// int8 dp4a MMVQ down (Q5_K). Mirrors the Q4_K down (one warp per output row, top_k experts folded,
+// vdr=2 positions per superblock strided across the warp) with the Q5_K block size (176 B) and the
+// 5-bit vec_dot above. This is the down projection quant that the UD Q4_K_M Qwen3.6 experts use, and
+// the only MoE GEMV still on the fp register-dequant path.
+__global__ void down_q5k_mmvq_kernel(
+    const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
+    const float* __restrict__ expert_weights, const si_block_q8_1* __restrict__ hq8,
+    __nv_bfloat16* __restrict__ output, int H, int F, int top_k, int pdl
+) {
+    if (pdl) si_pdl_sync();
+    const int token = blockIdx.x;
+    const int lane = threadIdx.x & 31;
+    const int hh = blockIdx.y * WPB + (threadIdx.x >> 5);
+    if (hh >= H) return;
+    const int nblk = F >> 8;
+    const int q8pb = F >> 5;
+    const int work = nblk * 16;
+    float acc = 0.f;
+    for (int j = 0; j < top_k; j++) {
+        const int ts = token * top_k + j;
+        const int e = expert_ids[ts];
+        const float w = expert_weights[ts];
+        const si_block_q5_K* drow = reinterpret_cast<const si_block_q5_K*>(
+            down_q + ((size_t)e * H + hh) * nblk * 176);
+        const si_block_q8_1* h8 = hq8 + (size_t)ts * q8pb;
+        float t = 0.f;
+        for (int wi = lane; wi < work; wi += 32) {
+            const int kbx = wi >> 4, kqs = (wi & 15) << 1;
+            t += si_vec_dot_q5_K(drow + kbx, h8 + (size_t)kbx * 8, kqs);
+        }
+        acc += w * t;
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+    if (lane == 0) output[(size_t)token * H + hh] = __float2bfloat16(acc);
+}
+
+template <int S>
+__global__ void down_q5k_mmvq_splitk_kernel(
+    const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
+    const float* __restrict__ expert_weights, const si_block_q8_1* __restrict__ hq8,
+    __nv_bfloat16* __restrict__ output, int H, int F, int top_k, int pdl
+) {
+    if (pdl) si_pdl_sync();
+    constexpr int RPB = WPB / S;
+    __shared__ float s_part[RPB][S];
+    const int token = blockIdx.x, lane = threadIdx.x & 31, warpId = threadIdx.x >> 5;
+    const int hh_local = warpId / S, split = warpId % S;
+    const int hh = blockIdx.y * RPB + hh_local;
+    const int nblk = F >> 8;
+    const int q8pb = F >> 5;
+    const int work = nblk * 16;
+    float acc = 0.f;
+    if (hh < H) {
+        const int total = top_k * work;
+        for (int wi = split * 32 + lane; wi < total; wi += S * 32) {
+            const int j = wi / work, r = wi % work;
+            const int kbx = r >> 4, kqs = (r & 15) << 1;
+            const int ts = token * top_k + j, e = expert_ids[ts];
+            const float w = expert_weights[ts];
+            const si_block_q5_K* drow = reinterpret_cast<const si_block_q5_K*>(
+                down_q + ((size_t)e * H + hh) * nblk * 176);
+            const si_block_q8_1* h8 = hq8 + (size_t)ts * q8pb;
+            acc += w * si_vec_dot_q5_K(drow + kbx, h8 + (size_t)kbx * 8, kqs);
+        }
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+        if (lane == 0) s_part[hh_local][split] = acc;
+    }
+    __syncthreads();
+    if (hh < H && split == 0 && lane == 0) {
+        float o = 0.f;
+        #pragma unroll
+        for (int s = 0; s < S; s++) o += s_part[hh_local][s];
+        output[(size_t)token * H + hh] = __float2bfloat16(o);
+    }
+}
+
 template <int S, int NBLK, int TOPK>
 __global__ void down_q6k_mmvq_splitk_qwen_kernel(
     const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
@@ -780,6 +902,17 @@ static inline int down_splitk_s_q4() {
     return s;
 }
 
+static inline int down_splitk_s_q5() {
+    static int s = -2;
+    if (s == -2) {
+        const char* v = getenv("SPARKINFER_DOWN_SPLITK_S_Q5");
+        if (!v) return down_splitk_s();
+        s = atoi(v);
+        if (!(s == 0 || s == 1 || s == 2 || s == 4 || s == 8)) s = down_splitk_s();
+    }
+    return s;
+}
+
 static inline int down_mmvq_pdl() {
     static int v = -1;
     if (v < 0) {
@@ -850,6 +983,19 @@ static inline bool launch_down_q4k_mmvq_splitk(
         case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         case 8: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+        default: return false;
+    }
+}
+static inline bool launch_down_q5k_mmvq_splitk(
+    int S, int pdl, dim3 grid, const unsigned char* down_q, const int* expert_ids,
+    const float* expert_weights, const si_block_q8_1* hq8, __nv_bfloat16* output,
+    int H, int F, int top_k, cudaStream_t stream
+) {
+    const dim3 block(WPB * 32);
+    switch (S) {
+        case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+        case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+        case 8: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         default: return false;
     }
 }
@@ -967,6 +1113,35 @@ void launch_moe_expert_ffn_q4k(
         }
         dim3 dnm(num_tokens, (hidden + WPB - 1) / WPB);
         launch_mmvq_down_kernel(pdl, dnm, dim3(WPB * 32), stream, down_q4k_mmvq_kernel,
+            reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
+            reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, pdl);
+        return;
+    }
+
+    // int8 dp4a MMVQ down (Q5_K) — default ON; SPARKINFER_DOWN_Q5K=0 restores the fp dequant down for
+    // the Q5_K rows. The UD Q4_K_M Qwen3.6 experts keep their down at Q5_K, which fell through both the
+    // Q6_K and Q4_K MMVQ paths onto the fp register-dequant down. Same quantize-once + faithful vec_dot
+    // pipeline, widened to the 5th bit.
+    static int down_q5k = -1;
+    if (down_q5k < 0) { const char* qv = getenv("SPARKINFER_DOWN_Q5K"); down_q5k = (qv && qv[0] == '0') ? 0 : 1; }
+    if (down_mmvq && down_q5k && down_type == 13) {   // 13 = ggml Q5_K
+        si_block_q8_1* hq8 = reinterpret_cast<si_block_q8_1*>(out_scratch);
+        const int nqb = num_tokens * top_k * (ffn >> 5);
+        const int qthreads = 256;
+        const int pdl = down_mmvq_pdl();
+        quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
+            h_scratch, hq8, nqb, pdl);
+        const int S = down_splitk_s_q5();
+        if (S > 1) {
+            const int RPB = WPB / S;
+            dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
+            if (launch_down_q5k_mmvq_splitk(S, pdl, dns,
+                    reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
+                    reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, stream))
+                return;
+        }
+        dim3 dnm(num_tokens, (hidden + WPB - 1) / WPB);
+        launch_mmvq_down_kernel(pdl, dnm, dim3(WPB * 32), stream, down_q5k_mmvq_kernel,
             reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
             reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, pdl);
         return;


### PR DESCRIPTION
## What

Adds the int8 dp4a MMVQ path for the **Q5_K** routed-expert down projection, the one MoE GEMV still on the fp register-dequant path for the UD Q4_K_M Qwen3.6-35B-A3B experts.

## Why

`down_q6k_mmvq` (Q6_K) and `down_q4k_mmvq` (Q4_K) already run the down projection as int8 dp4a MMVQ, but the launcher falls back to the fp register-dequant down (`down_q6k_kernel`) for every other quant. In the UD Q4_K_M file the Qwen3.6 experts keep `ffn_down_exps` at **Q5_K** (ggml type 13), so the down never took an MMVQ path and stayed on the fp dequant, which an nsys node-trace shows is ~9.5% of decode (the largest kernel after the projection GEMV and the Gated-DeltaNet update).

## How

`si_vec_dot_q5_K` reuses the faithful Q4_K vec_dot structure (Q5_K shares the qs / 6-bit scales layout and the `iqs = 2*L` convention) and only widens each 4-bit weight to 5 bits. The extra high bit is taken from `qh[32]`; its placement is derived from the in-tree fp reference (`q4kf_deq_dot`, type 13): for a qs byte b the low nibble uses qh bit `2*(b/32)` and the high nibble bit `2*(b/32)+1`, and across the bytes `v[0]`/`v[1]` cover, `b/32 == bq8_offset/2`, so nibble half i uses qh bit `bq8_offset + i`. The activation h is quantized to Q8_1 once and dp4a'd, identical to the Q6_K/Q4_K down; `down_q5k_mmvq` and its split-K variant mirror the Q4_K down kernels with the 176 B block size.

Behind `SPARKINFER_DOWN_Q5K` (default on; set to 0 to restore the fp dequant down). Scoped to `kernels/csrc/cuda/moe/expert_ffn_q4k.cu` only.

## Correctness

- `ctest` all pass (7/7).
- Self-consistency vs the fp Q5_K down, teacher-forced over 100 positions: top-1 agreement **0.96**, mean KL **0.008**, every divergence at a near-tied position (top1/top2 logprob gap < 0.10). Same quantize-once + faithful vec_dot pipeline the merged Q6_K/Q4_K down already ship.
- `SPARKINFER_DOWN_Q5K=0` reproduces the fp down path exactly.
- No-regression: Qwen3-30B-A3B decode ratio 1.0004 / 0.9999 / 0.9986 at ctx 128/512/4k (>= 0.98).

## Benchmark

Measured on an RTX 5090 (sm_120), Qwen3.6-35B-A3B-UD-Q4_K_M, interleaved A/B in one build (before = `SPARKINFER_DOWN_Q5K=0` = fp dequant down, after = default on):

- [x] Tested on **RTX 5090** (`sm_120`)

| context | before (main) | after (this PR) | gain |
|---|---|---|---|
| 128  | 168.75 | 179.85 | +6.6% |
| 512  | 168.72 | 179.96 | +6.7% |
| 4096 | 162.95 | 173.45 | +6.4% |

Strongest context (512), for the greenlight check:

| stage | decode tok/s |
|---|---|
| before (main) | 168.72 |
| after (this PR) | 179.96 |
