### PR TITLE
perf(qwen3.6): bf16 recurrent state for the Gated-DeltaNet AR kernel (+31% decode)

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -214,6 +214,75 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
     if (lane == 0) out[(size_t)vh * HEAD_DIM + j] = __float2bfloat16(y);
 }
 
+// bf16 recurrent-state Gated-DeltaNet AR (SPARKINFER_GDN_BF16, default ON). Same math as the naive
+// kernel, but the per-layer recurrent state S is stored in BF16 rather than FP32 — halving the ~2 MB/
+// layer state HBM traffic (read+write, 30x/token) that dominates this kernel. Grid-filled one warp per
+// state column. Each lane owns a CONTIGUOUS run of ROWS_PER_LANE rows and moves them as ONE vectorized
+// bf16x4 (uint2) load/store, so a warp reads/writes its whole HEAD_DIM column in a single coalesced
+// 256 B transaction; the decay is folded into the read so the column is touched exactly once each.
+// bf16 state is value-close to the fp32 path over a full sequence (the recurrent decay g<1 bounds
+// accumulation): measured top-1 agreement 0.978 / KL 0.010 vs the naive fp32 kernel. Requires HEAD_DIM
+// a multiple of 128 (ROWS_PER_LANE = HEAD_DIM/32 must be a multiple of 4 for the uint2 packing); the
+// bf16 state layout is internal to this kernel, so it is all-or-nothing for the run (static flag).
+template <int WPB, int HEAD_DIM>
+__global__ void gdn_ar_bf16state_kernel(const __nv_bfloat16* __restrict__ q,
+                                        const __nv_bfloat16* __restrict__ k,
+                                        const __nv_bfloat16* __restrict__ v,
+                                        const __nv_bfloat16* __restrict__ alpha,
+                                        const __nv_bfloat16* __restrict__ beta,
+                                        const __nv_bfloat16* __restrict__ dt,
+                                        const __nv_bfloat16* __restrict__ a,
+                                        __nv_bfloat16* __restrict__ state,   // BF16 [head][col][row]
+                                        __nv_bfloat16* __restrict__ out,
+                                        int q_heads, int v_heads) {
+    constexpr int RPL = HEAD_DIM / 32;            // rows per lane (compile-time -> registers)
+    constexpr int NVEC = RPL / 4;                 // uint2 (4 bf16) chunks per lane
+    const int head = blockIdx.x;
+    const int col  = blockIdx.y * WPB + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (head >= v_heads || col >= HEAD_DIM) return;
+    const int qh = head % q_heads;
+    const float rscale = rsqrtf((float)HEAD_DIM);
+    const float beta_g = q36_sigmoid(q36_to_f(beta[head]));
+    const float decay  = __expf(q36_softplus(q36_to_f(alpha[head]) + q36_to_f(dt[head])) * q36_to_f(a[head]));
+    const __nv_bfloat16* qrow = q + (size_t)qh   * HEAD_DIM;
+    const __nv_bfloat16* krow = k + (size_t)qh   * HEAD_DIM;
+    const __nv_bfloat16* vrow = v + (size_t)head * HEAD_DIM;
+    __nv_bfloat16* scol = state + ((size_t)head * HEAD_DIM + col) * HEAD_DIM;
+
+    float sdec[RPL], kv[RPL];
+    float dot_k = 0.f;
+    #pragma unroll
+    for (int c = 0; c < NVEC; c++) {
+        const int r0 = (lane + c * 32) * 4;       // contiguous 4-row chunk owned by this lane
+        uint2 raw = *reinterpret_cast<const uint2*>(scol + r0);
+        const __nv_bfloat16* sp = reinterpret_cast<const __nv_bfloat16*>(&raw);
+        #pragma unroll
+        for (int e = 0; e < 4; e++) {
+            sdec[c*4+e] = q36_to_f(sp[e]) * decay;              // decayed state (touched once)
+            kv[c*4+e]   = q36_to_f(krow[r0 + e]);
+            dot_k += sdec[c*4+e] * kv[c*4+e];
+        }
+    }
+    const float sk = q36_wsum(dot_k);
+    const float delta = (q36_to_f(vrow[col]) - sk) * beta_g;
+    float dot_y = 0.f;
+    #pragma unroll
+    for (int c = 0; c < NVEC; c++) {
+        const int r0 = (lane + c * 32) * 4;
+        __nv_bfloat16 packed[4];
+        #pragma unroll
+        for (int e = 0; e < 4; e++) {
+            const float snew = sdec[c*4+e] + kv[c*4+e] * delta;  // S*decay + k*delta
+            packed[e] = __float2bfloat16(snew);
+            dot_y += snew * q36_to_f(qrow[r0 + e]) * rscale;
+        }
+        *reinterpret_cast<uint2*>(scol + r0) = *reinterpret_cast<const uint2*>(packed);
+    }
+    const float y = q36_wsum(dot_y);
+    if (lane == 0) out[(size_t)head * HEAD_DIM + col] = __float2bfloat16(y);
+}
+
 __global__ void gated_norm_kernel(const __nv_bfloat16* __restrict__ x,
                                   const __nv_bfloat16* __restrict__ z,
                                   const __nv_bfloat16* __restrict__ weight,
@@ -298,8 +367,27 @@ void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,
-                          float* state_f32, void* out_bf16,
-                          int q_heads, int v_heads, int head_dim, cudaStream_t stream) {
+                          void* state, void* out_bf16,
+                          int q_heads, int v_heads, int head_dim, int bf16state, cudaStream_t stream) {
+    // SPARKINFER_GDN_BF16 (default ON): bf16 recurrent state — grid-filled warp-per-column, halves the
+    // state HBM traffic. The bf16 state layout is internal to this kernel so it is all-or-nothing per run
+    // (the caller decides the buffer dtype from the same flag). Requires head_dim == 128 (Qwen3.6).
+    if (bf16state && head_dim == 128) {
+        constexpr int WPB = 8, HD = 128;                     // 8 warps (columns)/block -> 256 threads
+        dim3 grid(v_heads, (HD + WPB - 1) / WPB);
+        gdn_ar_bf16state_kernel<WPB, HD><<<grid, WPB * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(k_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(v_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(a_bf16),
+            reinterpret_cast<__nv_bfloat16*>(state), reinterpret_cast<__nv_bfloat16*>(out_bf16),
+            q_heads, v_heads);
+        return;
+    }
+    float* state_f32 = reinterpret_cast<float*>(state);
     // SPARKINFER_GDN_FAST: warp-per-column, register-cached, transposed-state kernel (fills the GPU +
     // 2x state traffic). Uses a transposed internal state layout, so it MUST be all-or-nothing for the
     // run — the static flag guarantees that. Requires head_dim a multiple of 32 (128 -> NROW=4).

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -65,8 +65,8 @@ void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,
-                          float* state_f32, void* out_bf16,
-                          int q_heads, int v_heads, int head_dim, cudaStream_t stream = nullptr);
+                          void* state, void* out_bf16,
+                          int q_heads, int v_heads, int head_dim, int bf16state, cudaStream_t stream = nullptr);
 
 void launch_qwen36_gated_norm(const void* x_bf16, const void* z_bf16,
                               const void* weight_bf16, void* out_bf16,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -117,7 +117,8 @@ struct Qwen35Model::Impl {
     bf16 *lin_gdn = nullptr, *lin_norm = nullptr, *shared_gate_tmp = nullptr;
     bf16 *sh_gate = nullptr, *sh_up = nullptr, *sh_h = nullptr;   // shared-expert GEMV scratch [moe_ffn]
     bf16 *lin_conv_state = nullptr;
-    float* lin_state = nullptr;
+    float* lin_state = nullptr;   // GDN recurrent state buffer (fp32-sized; reinterpreted bf16 when gdn_bf16)
+    bool gdn_bf16 = true;         // SPARKINFER_GDN_BF16 (default ON): store the GDN state in bf16
     float* logits;
     int *d_scalars, *d_tok, *d_out_id, *d_pos, *d_seqlen, *d_writepos, *d_shared_ids;
     int *h_scalars = nullptr, *h_out_id = nullptr;
@@ -231,6 +232,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKVSTREAM")) p_->use_qkvstream = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ATTNIN")) p_->use_attnin = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_GDN_BF16")) p_->gdn_bf16 = !(e[0] == '0');
 }
 
 Qwen35Model::~Qwen35Model() {
@@ -397,13 +399,17 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                                  c.linear_q_heads, c.linear_v_heads,
                                                  c.linear_head_dim, c.linear_conv_kernel,
                                                  c.rms_eps, st);
-            float* layer_state = s.lin_state +
-                (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;
+            // One GDN state buffer, sized fp32; when gdn_bf16 the layer slice is addressed (and the
+            // kernel reads/writes it) as bf16 — half the elements, so half the HBM traffic.
+            const size_t st_stride = (size_t)c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;
+            void* layer_state = s.gdn_bf16
+                ? (void*)(reinterpret_cast<bf16*>(s.lin_state) + (size_t)L * st_stride)
+                : (void*)(s.lin_state + (size_t)L * st_stride);
             kernels::launch_qwen36_gdn_ar(s.lin_q, s.lin_k, s.lin_v,
                                           s.lin_alpha, s.lin_beta, w.ssm_dt, w.ssm_a,
                                           layer_state, s.lin_gdn,
                                           c.linear_q_heads, c.linear_v_heads,
-                                          c.linear_head_dim, st);
+                                          c.linear_head_dim, s.gdn_bf16 ? 1 : 0, st);
             kernels::launch_qwen36_gated_norm(s.lin_gdn, s.lin_z, w.ssm_norm, s.lin_norm,
                                               c.linear_v_heads, c.linear_head_dim, c.rms_eps, st);
             proj_from(s.lin_norm, w.ssm_out, w.ssm_out_type, s.ao, H, s.linear_vdim);


### PR DESCRIPTION
## Summary

The Gated-DeltaNet (linear-attention) recurrent state update is the single hottest kernel in Qwen3.6-35B-A3B decode. Skip-toggle differential profiling on an RTX 5090 puts it at ~25% of per-token decode time: the naive kernel launches only `<<<v_heads=32, head_dim>>>` = 32 blocks on ~170 SMs and is latency-bound on two serial 128-iteration dependent-load loops over the ~2 MB/layer **fp32** recurrent state, 30x per token.

This PR stores that recurrent state in **bf16** instead of fp32, halving its HBM read+write traffic (the kernel's dominant cost). The new kernel fills the grid one warp per state column; each lane owns a contiguous 4-row run moved as a single vectorized bf16x4 (`uint2`) load/store, so a warp reads and writes its whole 128-row column in one coalesced 256 B transaction, with the gated decay folded into the read so the column is touched exactly once.

bf16 precision is safe for the recurrent state because the gated decay (`g < 1`) bounds accumulation over the sequence. Value-closeness to the fp32 path is verified below.

## Decode throughput (RTX 5090, sm_120, Qwen3.6-35B-A3B-UD-Q4_K_M)

Tightly interleaved A/B on one build via `SPARKINFER_GDN_BF16` (default on; `=0` restores the exact fp32 path, which reproduces current main):

| context | before fp32 state | after bf16 state | gain |
| --- | --- | --- | --- |
| 128  | 168.83 | 221.39 | +31.1% |
| 512  | 168.73 | 221.16 | +31.1% |
| 4096 | 162.83 | 211.10 | +29.6% |

| stage | Qwen3.6 decode tok/s |
| --- | --- |
| before (main) | 168.73 |
| after (this PR) | 221.16 |

- [x] Tested on **RTX 5090** (`sm_120`)

## Accuracy vs llama.cpp (the eval gate)

Teacher-forced against the pinned llama.cpp reference over seed-fuzzed prompts (`accuracy_compare.py`), across three seeds:

| seed | tokens | top-1 (bar >= 0.90) | KL llama-vs-spark (bar <= 0.20) |
| --- | --- | --- | --- |
| 42   | 271 | 0.930 | 0.017 |
| 7    | 250 | 0.956 | 0.036 |
| 2026 | 189 | 0.958 | 0.018 |

For reference, current main (fp32 state) scores top-1 0.956 / KL 0.018 on seed 42, so bf16 costs a few near-tie flips but stays well inside the gate. `ctest` 7/7 pass.

## Scope and safety

- **Qwen3.6-only.** The bf16 kernel and the bf16 state buffer are reached solely from the hybrid GDN path (`w.linear_attn`, `head_dim == 128`). Qwen3-30B is not hybrid, never enters this code, and is byte-for-byte unchanged, so the no-regression guard is untouched.
- **Env-gated** (`SPARKINFER_GDN_BF16`, default on) with a clean fallback to the fp32 kernel.
- The bf16 state layout is internal to this kernel and all-or-nothing for the run (static flag), so it stays self-consistent across the captured decode graph. The state buffer is allocated fp32-sized and reinterpreted, so no allocation path changes.
