### PR TITLE
eval: fair label — anchor the tier to llama.cpp, not the frontier

### DIFF
--- a/bench/scripts/label.py
+++ b/bench/scripts/label.py
@@ -9,11 +9,17 @@ Emits one line:  RESULT_JSON {...}
   REJECT (score 0). A pass with KL above the preferred 0.15 is flagged `accuracy_warn` — accuracy is
   first; a speed gain that erodes parity with llama.cpp is not worth taking.
 - Significance gate: the gain must exceed SIG (2% of the frontier, a CI/noise proxy), else "none".
-- Label = bucket of the **relative speedup over the frontier** (delta / frontier). Same denominator
-  as the significance gate, so all five tiers stay reachable as decode speed grows — a
-  fraction-of-headroom rule collapsed XS/S once the frontier neared the ceiling (the 2% noise floor
-  alone already exceeded their headroom bands). The tiers are adaptive in that the *absolute* tok/s
-  required for each grows with the frontier. Thresholds are governance-tunable.
+  A gain that clears it floors at XS (verified but small); "none" always means "not verified".
+- Label tier = bucket of the gain **sized against the llama.cpp reference** (delta / llama_ref), NOT
+  the frontier. llama.cpp is a constant maturity anchor for every model, so the same tok/s of real
+  work earns the same tier whether the model started at 23 or 493 tok/s. This fixes the unfairness of
+  delta/frontier: over an un-optimized frontier (e.g. Qwen3.6 at 23 tok/s) a small absolute gain used
+  to explode to XL, while a mature model (past llama) couldn't clear XS for equal effort. The
+  past-llama difficulty boost (Option B) still multiplies the *tier* once the frontier is beyond the
+  reference. Significance still gates on raw %-over-frontier (a gain must beat the current best);
+  pct_over_frontier reports the honest measured speedup; pct_of_llama is the tier basis.
+  llama_ref (SPARKINFER_DIFFICULTY_REF) <= 0 falls back to the legacy delta/frontier basis.
+  Thresholds are governance-tunable.
 """
 import sys, json, os
 
@@ -71,21 +77,33 @@ elif frontier <= 0:
     res.update(pass_=True, label="BASELINE", note="no frontier set; this submission becomes it")
 else:
     delta = tps - frontier
-    g = delta / frontier                                # relative speedup over the frontier
+    g = delta / frontier                                # relative speedup over the frontier — SIGNIFICANCE basis
     if g <= SIG:
         res.update(pass_=True, label="none", delta_tps=round(delta, 2),
                    pct_over_frontier=round(100 * g, 1),
                    note="within significance gate — not a verified improvement")
     else:
-        D = difficulty_mult(frontier)
-        g_eff = g * D                                   # boost the label tier, not the raw % or the gate
-        label = next(l for thr, l in BUCKETS if g_eff >= thr)
+        # FAIR label tier: size the gain against the llama.cpp reference (DIFF_REF — a constant maturity
+        # anchor for EVERY model), not the possibly-unoptimized frontier. So the same tok/s of real work
+        # earns the same tier whether the model started at 23 or 493 tok/s — an un-optimized model can no
+        # longer mint XLs from low-hanging fruit while a mature one (past llama) can't clear XS. Significance
+        # still gates on raw %-over-frontier above (a gain must beat the current best); only the TIER is
+        # llama-anchored. Past-llama difficulty boost (Option B) is unchanged. DIFF_REF<=0 -> legacy basis.
+        ref = DIFF_REF if DIFF_REF > 0 else frontier
+        g_fair = delta / ref
+        D = difficulty_mult(frontier)                   # hard-gain boost once past the reference
+        g_eff = g_fair * D
+        # A verified improvement over the frontier floors at XS (real but small); the higher tiers
+        # (S/M/L/XL) are earned by the llama-anchored size. So "none" always means "not a verified
+        # improvement", never "real but tiny".
+        label = next((l for thr, l in BUCKETS if g_eff >= thr), "XS")
         res.update(pass_=True, label=label, delta_tps=round(delta, 2),
-                   pct_over_frontier=round(100 * g, 1),   # RAW measured speedup (honest reporting)
+                   pct_over_frontier=round(100 * g, 1),      # RAW measured speedup (honest reporting)
+                   pct_of_llama=round(100 * g_fair, 1),      # gain as a fraction of llama.cpp — the label basis
                    pct_of_ceiling=round(100 * tps / ceiling, 1) if ceiling > 0 else None)
+        res["effective_pct"] = round(100 * g_eff, 1)
         if D != 1.0:                                    # transparency: expose the boost in the verdict
             res["difficulty_mult"] = round(D, 2)
-            res["effective_pct"] = round(100 * g_eff, 1)
 
 # Soft accuracy flag: passed the gate but above the preferred KL ceiling — accepted, margin is thin.
 if res.get("label") != "REJECT" and kl > KL_PREFER:

--- a/bench/scripts/test_label.py
+++ b/bench/scripts/test_label.py
@@ -50,12 +50,24 @@ class LabelPolicyTest(unittest.TestCase):
         self.assertEqual(just_above["label"], "XS")
         self.assertTrue(just_above["pass"])
 
-    def test_raw_speedup_buckets_without_difficulty_boost(self):
-        env = {"SPARKINFER_DIFFICULTY_BOOST": "0"}
-        self.assertEqual(score(104.0, env=env)["label"], "S")
-        self.assertEqual(score(107.0, env=env)["label"], "M")
-        self.assertEqual(score(111.0, env=env)["label"], "L")
-        self.assertEqual(score(119.0, env=env)["label"], "XL")
+    def test_llama_anchored_buckets_without_difficulty_boost(self):
+        # The label tier is sized against the llama.cpp reference (DIFF_REF), not the frontier — so
+        # equal tok/s of work earns the same tier at any maturity. With DIFF_REF=365.85 and frontier=100
+        # (below the reference -> no boost), the S/M/L/XL thresholds (3.5/6/10/18% of llama) fall at
+        # delta ~= 12.8/22/36.6/65.9 tok/s. A verified-but-smaller gain floors at XS.
+        env = {"SPARKINFER_DIFFICULTY_BOOST": "0", "SPARKINFER_DIFFICULTY_REF": "365.85"}
+        self.assertEqual(score(105.0, env=env)["label"], "XS")   # +5: verified over frontier, < S vs llama
+        self.assertEqual(score(113.0, env=env)["label"], "S")    # +13 = 3.55% of llama
+        self.assertEqual(score(122.0, env=env)["label"], "M")    # +22 = 6.01%
+        self.assertEqual(score(137.0, env=env)["label"], "L")    # +37 = 10.11%
+        self.assertEqual(score(166.0, env=env)["label"], "XL")   # +66 = 18.04%
+
+    def test_unoptimized_model_does_not_mint_xl_from_low_hanging_fruit(self):
+        # The unfairness this policy fixes: over an un-optimized frontier a small absolute gain used to
+        # explode to XL. Sized against llama.cpp it earns a fair tier. (frontier 23, llama 190.)
+        env = {"SPARKINFER_DIFFICULTY_BOOST": "1", "SPARKINFER_DIFFICULTY_REF": "190"}
+        self.assertEqual(score(28.0, frontier=23.0, env=env)["label"], "XS")   # +5 (+22% over frontier) but 2.6% of llama
+        self.assertEqual(score(171.0, frontier=23.0, env=env)["label"], "XL")  # a real 7x IS an XL (78% of llama)
 
     def test_difficulty_boost_changes_label_but_not_raw_percent(self):
         res = score(484.79, frontier=469.13, ceiling=366.0, top1=0.9612, kl=0.0175,
@@ -96,7 +108,7 @@ class LabelPolicyTest(unittest.TestCase):
             "guard_32k_ratio": 1.125,
             "guard_32k_pass": True,
         }
-        res = score(120.0, frontier=100.0, prov=prov)
+        res = score(170.0, frontier=100.0, prov=prov)   # +70 = 19.1% of llama -> XL
         self.assertEqual(res["label"], "XL")
         self.assertEqual(res["eval_mode"], "longctx")
         self.assertEqual(res["score_context"], 16384)

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -772,6 +772,8 @@ def main():
         "512": float(os.environ.get("SPARKINFER_QWEN36_512", "23.16")),
         "4k":  float(os.environ.get("SPARKINFER_QWEN36_4K",  "23.03")),
         "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "190")),
+        "llama512": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_512", "188")),
+        "llama4k":  float(os.environ.get("SPARKINFER_QWEN36_LLAMA_4K",  "176")),
     }
 
     dash = load_dash()
@@ -999,7 +1001,9 @@ def main():
                 "--p-guard-128-baseline", str(QWEN36_BASE["128"]),
                 "--p-guard-512-baseline", str(QWEN36_BASE["512"]),
                 "--p-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
-                "--p-llama-128-baseline", str(QWEN36_BASE["llama128"])]
+                "--p-llama-128-baseline", str(QWEN36_BASE["llama128"]),
+                "--p-llama-512-baseline", str(QWEN36_BASE["llama512"]),
+                "--p-llama-4k-baseline",  str(QWEN36_BASE["llama4k"])]
         if PINNED_INSTANCE and str(cur_iid) == PINNED_INSTANCE:
             cmd.append("--pinned")  # never destroy the pin; retry-then-fallback on bring-up failure
         pinned = "--pinned" in cmd


### PR DESCRIPTION
Fixes the "everything is XL" unfairness: the label was `bucket(delta / frontier)`, which rewards low-hanging fruit and punishes mature models. Over an un-optimized frontier (Qwen3.6 at 23 tok/s) a small absolute gain exploded to XL; a mature model already 30% past llama.cpp couldn't clear XS for equal effort.

**Now the tier is sized against the llama.cpp reference** (`delta / llama_ref`) — a constant maturity anchor for every model — so equal tok/s of real work earns the same tier no matter where you started. Significance still gates on raw %-over-frontier (a gain must beat the current best, and floors at XS if verified but small); the past-llama difficulty boost is unchanged.

| case | old | **new** |
|---|---|---|
| Qwen3.6 23→171 (7×, 78% of llama) | XL | **XL** (a real breakthrough) |
| Qwen3.6 171→175 (marginal) | XL | **XS** |
| Qwen3.6 24→25 (tiny) | XS-ish | **XS** (verified floor) |
| Qwen3 +10 over 493 (mature, hard) | XS/M | **L** (boosted) |

Also adds Qwen3.6 512/4k llama refs so every scored context is anchored, and exposes `pct_of_llama` in the verdict. Tests updated + a new fairness test; `test_label.py` 7/7, `test_pr_eval_bot.py` 4/4.

**Note:** this makes the *tier* fair. The complementary piece — the Qwen3.6 *frontier advancing on merge* so a repeat at the plateau scores `none` — is a follow-up in the bot's merge-sync (Qwen3.6 baselines are still config constants).