### PR TITLE
fix(dashboard): Qwen3.6 frontier leak into Qwen3-MoE journey

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -4,19 +4,19 @@ window.SPARKINFER = {
   "status": {
     "gpu": "RTX 5090 · sm_120 · CUDA 13",
     "model": "Qwen3-30B-A3B · Q4_K_M",
-    "frontier_tps": 26712.71,
+    "frontier_tps": 493.56,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
-    "token_match": 0.9724,
-    "kl": 0.0108,
+    "token_match": 0.9612,
+    "kl": 0.0175,
     "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
     "longctx_kl": 0.0368,
-    "longctx_512_tps": 25143.09,
-    "longctx_4k_tps": 19741.98,
+    "longctx_512_tps": 469.58,
+    "longctx_4k_tps": 392.65,
     "longctx_32k_tps": 260.3
   },
   "context_baselines": [
@@ -25,7 +25,7 @@ window.SPARKINFER = {
       "label": "128",
       "color": "#D14D72",
       "tokens": 128,
-      "sparkinfer_tps": 26712.71,
+      "sparkinfer_tps": 493.56,
       "llamacpp_decode_tps": 365.85,
       "llamacpp_note": "128-token decode, no prefill context"
     },
@@ -34,7 +34,7 @@ window.SPARKINFER = {
       "label": "512",
       "color": "#7B5DFF",
       "tokens": 128,
-      "sparkinfer_tps": 25143.09,
+      "sparkinfer_tps": 469.58,
       "llamacpp_decode_tps": 342.59,
       "llamacpp_note": "llama-batched-bench npp=512 ntg=128 npl=1"
     },
@@ -43,7 +43,7 @@ window.SPARKINFER = {
       "label": "4k",
       "color": "#0E8A16",
       "tokens": 128,
-      "sparkinfer_tps": 19741.98,
+      "sparkinfer_tps": 392.65,
       "llamacpp_decode_tps": 292.99,
       "llamacpp_note": "llama-batched-bench npp=4096 ntg=128 npl=1"
     },
@@ -1222,18 +1222,6 @@ window.SPARKINFER = {
       "tps": 484.79,
       "pr": 122,
       "date": "2026-07-02"
-    },
-    {
-      "name": "shared expert as coalesced G",
-      "tps": 3631.12,
-      "pr": 230,
-      "date": "2026-07-05"
-    },
-    {
-      "name": "add optimized Gated-DeltaNet",
-      "tps": 26712.14,
-      "pr": 229,
-      "date": "2026-07-05"
     }
   ],
   "landed_longctx": [

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -3,19 +3,19 @@
   "status": {
     "gpu": "RTX 5090 · sm_120 · CUDA 13",
     "model": "Qwen3-30B-A3B · Q4_K_M",
-    "frontier_tps": 26712.71,
+    "frontier_tps": 493.56,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
-    "token_match": 0.9724,
-    "kl": 0.0108,
+    "token_match": 0.9612,
+    "kl": 0.0175,
     "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
     "longctx_kl": 0.0368,
-    "longctx_512_tps": 25143.09,
-    "longctx_4k_tps": 19741.98,
+    "longctx_512_tps": 469.58,
+    "longctx_4k_tps": 392.65,
     "longctx_32k_tps": 260.3
   },
   "context_baselines": [
@@ -24,7 +24,7 @@
       "label": "128",
       "color": "#D14D72",
       "tokens": 128,
-      "sparkinfer_tps": 26712.71,
+      "sparkinfer_tps": 493.56,
       "llamacpp_decode_tps": 365.85,
       "llamacpp_note": "128-token decode, no prefill context"
     },
@@ -33,7 +33,7 @@
       "label": "512",
       "color": "#7B5DFF",
       "tokens": 128,
-      "sparkinfer_tps": 25143.09,
+      "sparkinfer_tps": 469.58,
       "llamacpp_decode_tps": 342.59,
       "llamacpp_note": "llama-batched-bench npp=512 ntg=128 npl=1"
     },
@@ -42,7 +42,7 @@
       "label": "4k",
       "color": "#0E8A16",
       "tokens": 128,
-      "sparkinfer_tps": 19741.98,
+      "sparkinfer_tps": 392.65,
       "llamacpp_decode_tps": 292.99,
       "llamacpp_note": "llama-batched-bench npp=4096 ntg=128 npl=1"
     },
@@ -1221,18 +1221,6 @@
       "tps": 484.79,
       "pr": 122,
       "date": "2026-07-02"
-    },
-    {
-      "name": "shared expert as coalesced G",
-      "tps": 3631.12,
-      "pr": 230,
-      "date": "2026-07-05"
-    },
-    {
-      "name": "add optimized Gated-DeltaNet",
-      "tps": 26712.14,
-      "pr": 229,
-      "date": "2026-07-05"
     }
   ],
   "landed_longctx": [

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -500,7 +500,8 @@ def update_dashboard(repo, pr, areas, res, proof_url=None):
              "label": res.get("label"), "tps": res.get("tps"),
              "delta_pct": res.get("pct_over_frontier"),
              "top1": res.get("top1"), "kl": res.get("kl"),
-             "url": f"https://github.com/{repo}/pull/{num}"}
+             "url": f"https://github.com/{repo}/pull/{num}",
+             "model": res.get("model", "")}
     for k in ("eval_mode", "score_context", "best_context_label", "context_gains_pct",
               "regression_labels", "auto_close",
               "ctx_128_tps", "ctx_512_tps", "ctx_2048_tps", "ctx_4096_tps",
@@ -577,6 +578,26 @@ def record_merge(repo, num):
     if data is None: return
     e = next((p for p in data.get("prs", []) if p.get("num") == num), None)
     if not e or e.get("label") not in SPEEDUP_LABELS: return                 # only verified speedups
+    # A Qwen3.6 dual-eval result must advance the Qwen3.6 frontier/journey, not Qwen3-MoE's — its
+    # delta_pct was measured against a different baseline (23 tok/s, +635%), and applying that gain
+    # to Qwen3-MoE's 493 frontier inflates the chart 7.4× per PR. Route to landed_qwen36.
+    scored_qwen36 = str(e.get("model") or "").startswith("Qwen3.6")
+    if scored_qwen36:
+        q36 = data.setdefault("qwen36", {})
+        old_f = round(q36.get("frontier_tps") or q36.get("baseline_tps") or 0, 2)
+        new_f = round(max(old_f, e.get("tps") or 0), 2)          # Qwen3.6 frontier: take the max tps seen
+        q36["frontier_tps"] = new_f
+        if e.get("top1") is not None: q36["token_match"] = round(e["top1"], 4)
+        if e.get("kl") is not None:   q36["kl"] = round(e["kl"], 4)
+        short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
+        landed = [m for m in data.get("landed_qwen36", []) if m.get("pr") != num and not m.get("baseline")]
+        landed.append({"name": short or f"PR #{num}", "tps": new_f, "pr": num,
+                       "date": datetime.date.today().isoformat(), "label": e.get("label")})
+        data["landed_qwen36"] = sorted(landed, key=lambda m: m["tps"])
+        data["updated"] = datetime.date.today().isoformat()
+        write_dash(data)
+        push_dash(f"dashboard: PR #{num} merged -> Qwen3.6 frontier {new_f} tok/s")
+        return
     if e.get("eval_mode") == "longctx" and int(e.get("score_context") or 0) in (512, 4096, 16384, 32768):
         if any(m.get("pr") == num for m in data.get("landed_longctx", [])): return
         score_ctx = int(e.get("score_context") or 0)


### PR DESCRIPTION
The Qwen3-MoE optimization journey was corrupted: Qwen3.6 dual-eval results (+635%) were
applied to the Qwen3-MoE frontier, inflating it to 26,712 tok/s (493 × 7.36 × 7.36). Both
#229 and #230 appeared in the wrong `landed` list.

**Root cause:** `record_merge()` was model-blind — it applied any PR's `delta_pct` to
Qwen3-MoE's `frontier_tps` regardless of which model was scored. A Qwen3.6 gain measured
against the 23 tok/s baseline blew up Qwen3-MoE's 493 frontier.

**Fix:**
- `update_dashboard()` now stores `res['model']` in the `prs` entry
- `record_merge()` routes Qwen3.6 results to `landed_qwen36` + `data['qwen36']['frontier_tps']`
  and early-returns, leaving Qwen3-MoE's frontier untouched
- `data.json` restored from the last clean commit (48e2aae, frontier 493.56)

Tests pass (4/4 bot + 7/7 label); synthetic Qwen3.6 merge routing verified: frontier advances
to 170.84 in the Qwen3.6 journey, Qwen3-MoE stays at 493.56.