### PR TITLE
eval: seal Qwen3.6 llama.cpp reference — pinned measurements

### DIFF
--- a/bench/scripts/reference.lock
+++ b/bench/scripts/reference.lock
@@ -20,3 +20,11 @@ QWEN36_MODEL_SHA256="ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e
 # llama.cpp commit the reference is pinned to. HEAD of master drifts run-to-run (non-reproducible and
 # unpinnable); we check out exactly this commit, verify a clean tree, and rebuild if either differs.
 LLAMACPP_COMMIT="6f4f53f2b7da54fcdbbecaaa734337c337ad6176"
+
+# Qwen3.6-35B-A3B llama.cpp decode baselines — 3-rep median on RTX 5090, same pinned commit + GGUF
+# sha (QWEN36_MODEL_SHA256 above). These anchor the fair-label scoring (delta/llama_ref) at each
+# scored context and the difficulty-reference boost once the Qwen3.6 frontier passes them.
+# Measured 2026-07-06. Env-overridable.
+QWEN36_LLAMA_128="${QWEN36_LLAMA_128:-275.81}"
+QWEN36_LLAMA_512="${QWEN36_LLAMA_512:-275.61}"
+QWEN36_LLAMA_4K="${QWEN36_LLAMA_4K:-276.30}"

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -792,9 +792,9 @@ def main():
         "128": float(os.environ.get("SPARKINFER_QWEN36_128", "23.22")),
         "512": float(os.environ.get("SPARKINFER_QWEN36_512", "23.16")),
         "4k":  float(os.environ.get("SPARKINFER_QWEN36_4K",  "23.03")),
-        "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "190")),
-        "llama512": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_512", "188")),
-        "llama4k":  float(os.environ.get("SPARKINFER_QWEN36_LLAMA_4K",  "176")),
+        "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "275.81")),
+        "llama512": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_512", "275.61")),
+        "llama4k":  float(os.environ.get("SPARKINFER_QWEN36_LLAMA_4K",  "276.30")),
     }
 
     dash = load_dash()


### PR DESCRIPTION
The Qwen3.6 fair-label scoring was anchored to unvalidated llama.cpp baselines (190/188/176) from one quick run. Now properly measured at the pinned commit with the pinned model sha:

| context | old guess | **pinned (3-rep median)** |
|---|---|---|
| 128-token | 190 | **275.81** |
| 512-context | 188 | **275.61** |
| 4k-context | 176 | **276.30** |

- All at llama.cpp `6f4f53f` + model sha `ac0e2c11…`, verified for factual correctness (Paris, H2O, Jupiter).
- Locked in `reference.lock` (`QWEN36_LLAMA_{128,512,4K}`), env-overridable but default-pinned.
- Bot `QWEN36_BASE` reads from the same overridable defaults.

Scoring unchanged in practice: breakthrough 23→171 is XL (53.6% of pinned llama), marginal 171→175 is XS, tiny wins floor at XS.