### PR TITLE
eval(copycat): layer 4 — per-function containment + LLM judge (catches dilution)

### DIFF
--- a/.github/workflows/copycat-guard.yml
+++ b/.github/workflows/copycat-guard.yml
@@ -1,23 +1,26 @@
 name: copycat-guard
 # Real-time copycat detection — fires the instant a PR is opened (pull_request_target
 # runs from the BASE branch context, so it has full repo access to read all PRs, label,
-# comment, and close). No GPU, no eval — just fingerprint comparison against all earlier
-# open PRs. If >=80% containment in a different author's earlier PR, the new PR is
-# flagged, the account blocked, and the PR closed within seconds of creation.
+# comment, and close). Four-layer detection:
+#   L1: containment >=80% -> block+close (zero tolerance)
+#   L2: containment 70-79% -> copycat-warn + comment
+#   L3: containment 40-69% + Levenshtein>=0.70 + bigram_cosine>=0.60 -> bump to WARN
+#   L4: per-function containment 30-79% + DeepSeek LLM judge -> bump to WARN
+#   2nd warning strike (any layer) -> block+close
 
 on:
   pull_request_target:
     types: [opened]
 
 permissions:
-  contents: write          # push policy files (copycats.json, blocked-contributors.txt)
+  contents: write          # push policy files
   pull-requests: write     # label + comment + close
-  issues: write            # PR comment (shares the Issues permission)
+  issues: write            # PR comment
 
 jobs:
   guard:
     runs-on: ubuntu-latest
-    # Don't block maintainer PRs — only guard external contributions
+    # Skip maintainer PRs
     if: github.event.pull_request.author_association != 'OWNER' && github.event.pull_request.author_association != 'MEMBER' && github.event.pull_request.author_association != 'COLLABORATOR'
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +31,7 @@ jobs:
       - name: Run copycat guard
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
           PR_NUM: ${{ github.event.pull_request.number }}
         run: |
           PR_NUM="$PR_NUM" python3 eval/copycat_guard.py

--- a/eval/copycat_guard.py
+++ b/eval/copycat_guard.py
@@ -29,6 +29,10 @@ MAX_WARNINGS         = 2      # block on this many warnings across any PRs
 LEV_THRESH           = 0.70   # layer 3: token Levenshtein ratio ≥ this
 BIGRAM_COSINE_THRESH = 0.60   # layer 3: bigram cosine similarity ≥ this
 STRUCT_MIN            = 0.40   # layer 3: containment must be at least this to trigger
+# Layer 4: LLM judge (DeepSeek) — catches per-function copycats diluted by larger PR
+LLM_FUNC_MIN          = 0.30   # per-function containment must be ≥30% to escalate
+LLM_CONFIDENCE_MIN    = 0.70   # LLM must be ≥70% confident to flag
+DEEPSEEK_API          = "https://api.deepseek.com/v1/chat/completions"
 
 
 def gh(args):
@@ -112,6 +116,112 @@ def structural_similarity(repo, copy_num, orig_num, containment_pct):
     return lev, cos, fired
 
 
+# ---- layer 4: function-block containment + LLM judge (catches dilution) ----
+
+def split_into_blocks(repo, num):
+    """Split a PR's added lines into logical CUDA code blocks (kernel functions, device
+    functions, and other named scopes). Each block is a (signature, body) pair."""
+    diff = gh(["pr", "diff", str(num), "-R", repo]).stdout or ""
+    blocks = []
+    current_sig = None; current_body = []
+    for line in diff.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        s = line[1:].strip()
+        if not s or s.startswith(("//", "#", "/*", "*")):
+            continue
+        # CUDA function boundaries: __global__, __device__, __host__, template<>, or a top-level
+        # function signature (return_type name( ... ) { ). Also catch if/for/while blocks that
+        # start new logical units (launch sites, conditionals).
+        is_func_start = any(kw in s for kw in (
+            "__global__", "__device__", "__host__", "template <", "template<"))
+        if is_func_start or (s.endswith("{") and ("(" in s or "kernel" in s.lower())):
+            if current_sig and current_body:
+                blocks.append((current_sig, "\n".join(current_body)))
+            current_sig = s
+            current_body = []
+        elif current_sig is not None:
+            current_body.append(line[1:])
+    if current_sig and current_body:
+        blocks.append((current_sig, "\n".join(current_body)))
+    return blocks
+
+
+def per_function_containment(repo, copy_num, orig_num):
+    """Return the HIGHEST per-function containment across all shared blocks. If the original
+    PR has one function (focused change) and the copy PR adds it inside a larger PR, this
+    will catch it even when PR-level containment is low."""
+    copy_blocks = split_into_blocks(repo, copy_num)
+    orig_blocks = split_into_blocks(repo, orig_num)
+    if not copy_blocks or not orig_blocks:
+        return 0.0, "", ""
+    best = 0.0; best_copy_sig = ""; best_orig_sig = ""
+    for csig, cb in copy_blocks:
+        ctokens = set(cb.split())
+        if len(ctokens) < 5:
+            continue
+        for osig, ob in orig_blocks:
+            otokens = set(ob.split())
+            if len(otokens) < 5:
+                continue
+            if not (ctokens & otokens):
+                continue
+            c = len(ctokens & otokens) / len(ctokens)
+            if c > best:
+                best = c; best_copy_sig = csig; best_orig_sig = osig
+    return best, best_copy_sig, best_orig_sig
+
+
+def llm_judge_copycat(copy_func_body, orig_func_body, copy_sig, orig_sig):
+    """Call DeepSeek API to judge whether two code blocks are substantially the same.
+    Returns (is_copy: bool, confidence: float, explanation: str)."""
+    api_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+    if not api_key:
+        return False, 0.0, "no API key configured"
+    import urllib.request
+    prompt = (
+        "You are a code-copycat detector for a GPU kernel optimization contest. "
+        "Two contributors submitted CUDA kernels. Determine if the COPY function is "
+        "substantially derived from the ORIGINAL function (same computation, same memory "
+        "access pattern, same numerical method) even if variable names or minor structure differ.\n\n"
+        f"ORIGINAL function signature: {orig_sig}\n"
+        f"```cpp\n{orig_func_body[:3000]}\n```\n\n"
+        f"COPY function signature: {copy_sig}\n"
+        f"```cpp\n{copy_func_body[:3000]}\n```\n\n"
+        "Answer in this exact format:\n"
+        "COPYCAT: YES|NO\n"
+        "CONFIDENCE: 0.XX\n"
+        "REASON: one sentence explaining why")
+    try:
+        req = urllib.request.Request(
+            DEEPSEEK_API,
+            data=json.dumps({
+                "model": "deepseek-chat",
+                "messages": [{"role": "user", "content": prompt}],
+                "temperature": 0.0, "max_tokens": 200
+            }).encode(),
+            headers={"Content-Type": "application/json",
+                     "Authorization": f"Bearer {api_key}"})
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            body = json.loads(resp.read())
+        reply = body["choices"][0]["message"]["content"].strip()
+        # parse
+        is_copy = "COPYCAT: YES" in reply.upper()
+        conf = 0.0
+        for line in reply.splitlines():
+            if "CONFIDENCE:" in line.upper():
+                try: conf = float(line.split(":")[-1].strip())
+                except: pass
+        reason = ""
+        for line in reply.splitlines():
+            if "REASON:" in line.upper():
+                reason = line.split(":", 1)[-1].strip()
+                break
+        return is_copy, conf, f"LLM judge: {reply[:180]}"
+    except Exception as e:
+        return False, 0.0, f"API error: {str(e)[:120]}"
+
+
 # ---- policy state management ----
 
 def load_denylist():
@@ -164,13 +274,21 @@ def flag_copycat(repo, num, original, author):
     subprocess.run(["gh", "pr", "comment", str(num), "-R", repo, "--body", body], capture_output=True)
 
 
-def warn_copycat(repo, num, original, author, strike_count, containment_pct, structural=False):
-    """Layer 2/3: 70–79% or structural flip → warning. Block on 2nd strike."""
+def warn_copycat(repo, num, original, author, strike_count, containment_pct, structural=False, llm_conf=0.0):
+    """Layer 2/3/4: 70–79%, structural flip, or LLM verdict → warning. Block on 2nd strike."""
     subprocess.run(["gh", "pr", "edit", str(num), "-R", repo, "--add-label", "copycat-warn"], capture_output=True)
     will_block = bool(strike_count >= MAX_WARNINGS)
-    if structural:
-        head = f"**{containment_pct:.0f}% containment** + structural similarity "
-        head += "(Levenshtein + bigram cosine both above threshold vs this PR's code shape)"
+    if llm_conf > 0:
+        head = (f"AI semantic analysis (DeepSeek) identified a function in this PR as "
+                f"substantially copied from #{original} (confidence {llm_conf:.0%}). "
+                f"Combined per-function containment: {containment_pct:.0%}.")
+    elif structural and containment_pct >= COPYCAT_WARN:
+        head = (f"A specific function in this PR ({containment_pct:.0%} per-function containment) "
+                f"is substantially contained in #{original} by a different author — the PR-level "
+                f"containment is low because the copied function is embedded inside a larger diff.")
+    elif structural:
+        head = (f"**{containment_pct:.0f}% containment** + structural similarity "
+                "(Levenshtein + bigram cosine both above threshold vs this PR's code shape)")
     else:
         head = f"**{containment_pct:.0f}% containment** in the earlier #{original}"
     if will_block:
@@ -251,6 +369,34 @@ def main():
                     original = e_num; orig_author = e_author; best_containment = c
                 print(f"  structural copycat: lev={lev:.2f} cos={cos:.2f} c={c:.2f} vs #{e_num}")
 
+        # 4b) Layer 4: per-function containment + LLM judge. The copier's evasion tactic is to
+        #     embed a verbatim-copied kernel inside a much larger PR to dilute the PR-level ratio.
+        #     4b-i:  ANY single function >=70% contained → deterministic bump to WARN (no API).
+        #     4b-ii: 30-69% → escalate to LLM judge for semantic verification.
+        if c < COPYCAT_WARN and not structural_fired:
+            func_c, func_csig, func_osig = per_function_containment(REPO, pr_num, e_num)
+            if func_c >= COPYCAT_WARN:
+                # Deterministic: a single copied function is >=70% contained even though the PR
+                # as a whole appears different (dilution). Bump to WARN — same tier as layer 2,
+                # but the comment surfaces the function-level evidence.
+                structural_fired = True; best_lev = func_c; best_cos = -1.0  # cos=-1 = "func-level"
+                best_containment = max(best_containment, func_c, COPYCAT_WARN)
+                if not original or func_c > (best_containment if original==e_num else 0):
+                    original = e_num; orig_author = e_author
+                print(f"  per-function bump: {func_csig[:60]}... is {func_c:.0%} contained in #{e_num} -> WARN")
+            elif func_c >= LLM_FUNC_MIN:
+                print(f"  layer 4: per-function containment={func_c:.1%} (vs #{e_num}) -> escalating to LLM")
+                cb = next((b for s,b in split_into_blocks(REPO,pr_num) if s==func_csig), "")
+                ob = next((b for s,b in split_into_blocks(REPO,e_num) if s==func_osig), "")
+                is_copy, llm_conf, reason = llm_judge_copycat(cb, ob, func_csig, func_osig)
+                print(f"  LLM: copycat={is_copy} confidence={llm_conf:.2f} reason={reason[:120]}")
+                if is_copy and llm_conf >= LLM_CONFIDENCE_MIN:
+                    structural_fired = True; best_lev = llm_conf; best_cos = 0.0
+                    best_containment = max(best_containment, func_c, COPYCAT_WARN)
+                    if not original or func_c > (best_containment if original==e_num else 0):
+                        original = e_num; orig_author = e_author
+                    print(f"  LLM verdict: COPYCAT CONFIRMED -> bumping to WARN vs #{e_num}")
+
     if original is None or (best_containment < COPYCAT_WARN and not structural_fired):
         print("  no copycat detected — clean"); return
 
@@ -271,9 +417,12 @@ def main():
     else:
         warn_strikes = sum(1 for e in log if e.get("author") == author and not e.get("blocked", True))
         strike = warn_strikes + 1
-        tag = "structural" if structural_fired else "containment"
+        tag = "LLM" if (structural_fired and best_cos == 0.0) else ("structural" if structural_fired else "containment")
         print(f"  COPYCAT WARN ({tag}): #{pr_num} vs #{original} (strike {strike}/{MAX_WARNINGS})")
-        will_block = warn_copycat(REPO, pr_num, original, author, strike, best_containment, structural_fired)
+        is_llm = structural_fired and best_cos == 0.0      # LLM judge (cos=0 sentinel)
+        is_func = structural_fired and best_cos == -1.0     # per-function deterministic (cos=-1)
+        llm_conf_val = best_lev if is_llm else 0.0
+        will_block = warn_copycat(REPO, pr_num, original, author, strike, best_containment, structural_fired, llm_conf_val)
         log.append({"pr": pr_num, "author": author, "original": original,
                     "date": date.today().isoformat(), "blocked": False,
                     "penalty_days": 0, "strike": strike,


### PR DESCRIPTION
Catches the copier who embeds a verbatim kernel inside a much larger diff to evade
PR-level containment. #233 is the real case: 97.1% per-function containment vs #229,
but only 14.1% at the PR level — all existing layers missed.

**Layer 4a: deterministic per-function bump**
- Splits both PRs' diffs into logical function blocks
- Any single function >=70% contained in a competitor's earlier PR -> bump to WARN
- No API cost — pure code analysis
- Verified: #233's `gdn_ar_warpgrid_kernel` is 97.1% contained in #229's `gdn_ar_fast_kernel`

**Layer 4b: LLM judge (30-69% per-function)**
- Escalates ambiguous borderline cases to DeepSeek API
- Two code excerpts, YES/NO verdict with confidence
- Only fires when all other layers miss + per-function ratio is in the borderline zone
- ~$0.001 per call, fires rarely

**All 4 layers now:**

| layer | trigger | response |
|---|---|---|
| 1 | containment >=80% | block+close |
| 2 | containment 70-79% | warn |
| 3 | 40-69% + lev>=0.70 + cos>=0.60 | warn |
| 4a | per-function >=70% (PR-level low) | warn |
| 4b | per-function 30-69% + LLM judge | warn |
| — | 2nd strike (any) | block+close |