### PR TITLE
fix(scoring): Qwen3.6 frontier advance — use max(guard_baseline, frontier) as scoring base

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -192,6 +192,13 @@ contexts = [
   {"ctx":32768, "label":"32k-context", "tps":float("$GUARD_32K_TPS"), "base":float("$GUARD_32K_BASELINE"), "llama":float("$LLAMA_32K_BASELINE")},
 ]
 for c in contexts:
+    # The scored frontier (--frontier) is the advanceable best; the regression guard baseline
+    # is a fixed same-box origin/main number. For the gain computation, use whichever is higher
+    # so a PR is always scored against the current frontier, never against a stale 23-tok/s
+    # baseline from before any optimization landed. Without this, a model's first big PR sets
+    # the real frontier but every subsequent PR re-scores against the cold-start baseline.
+    if float("$FRONTIER") > 0 and float("$FRONTIER") > c["base"]:
+        c["base"] = float("$FRONTIER")
     c["gain"] = 0.0 if c["base"] <= 0 else (c["tps"] - c["base"]) / c["base"]
 # A context measured with 0 reps (tps<=0) was intentionally skipped (e.g. Qwen3.6 runs only
 # 128/512/4k for now) — exclude it from scoring so a skipped context is never chosen or penalized.


### PR DESCRIPTION
The Qwen3.6 score always used the cold-start 23-tok/s regression guard baseline as the
gain denominator. So every PR at ~170 got +708% XL — the plateau where everything was XL
and there was no gradation.

**Root cause:** `evaluate.sh`'s `SCORE_SELECT` used `GUARD_BASELINE` (frozen same-box
origin/main number, 23.22 for Qwen3.6) instead of the advanceable `FRONTIER` (170.84)
as the base for computing gains.

**Fix:** `base = max(GUARD_BASELINE, FRONTIER)` — the advanceable frontier wins once set.

| scenario | old base | old gain | **new base** | **new gain** |
|---|---|---|---|---|
| Qwen3.6 187.8 vs frontier 170.84 | 23.22 | +708% XL | 170.84 | +9.9% **M** |
| Qwen3-MoE 503 vs frontier 494 | 494 | +1.9% | 494 | +1.9% (unchanged) |

Qwen3-MoE is unaffected (its guard_baseline == frontier). Qwen3.6 now correctly
advances and shows real gradation.