### PR TITLE
scoring: eliminate frontier — score directly against same-box origin/main

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -192,13 +192,12 @@ contexts = [
   {"ctx":32768, "label":"32k-context", "tps":float("$GUARD_32K_TPS"), "base":float("$GUARD_32K_BASELINE"), "llama":float("$LLAMA_32K_BASELINE")},
 ]
 for c in contexts:
-    # The scored frontier (--frontier) is the advanceable best; the regression guard baseline
-    # is a fixed same-box origin/main number. For the gain computation, use whichever is higher
-    # so a PR is always scored against the current frontier, never against a stale 23-tok/s
-    # baseline from before any optimization landed. Without this, a model's first big PR sets
-    # the real frontier but every subsequent PR re-scores against the cold-start baseline.
-    if float("$FRONTIER") > 0 and float("$FRONTIER") > c["base"]:
-        c["base"] = float("$FRONTIER")
+    # The scoring base is the SAME-BOX origin/main measurement — not a passed-in frontier number.
+    # The bot already measures main on this box at the start of every run and passes it as the
+    # GUARD_BASELINE. Each PR scores directly against that same-box baseline: the gain is "how
+    # much faster is this PR than main on the same box?" — hardware-independent and always current.
+    # The only exception is 16k, which falls back to the old FRONTIER if no baseline is set;
+    # for models that skip 16k (reps=0), it never enters scoring anyway.
     c["gain"] = 0.0 if c["base"] <= 0 else (c["tps"] - c["base"]) / c["base"]
 # A context measured with 0 reps (tps<=0) was intentionally skipped (e.g. Qwen3.6 runs only
 # 128/512/4k for now) — exclude it from scoring so a skipped context is never chosen or penalized.

--- a/bench/scripts/evaluate_dual.sh
+++ b/bench/scripts/evaluate_dual.sh
@@ -22,10 +22,9 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$HERE/_common.sh"
 
-REF=""; CEILING=0; PRIMARY_FRONTIER=0
+REF=""; CEILING=0
 while [ $# -gt 0 ]; do case "$1" in
-  --ref) shift; REF="$1" ;; --ceiling) shift; CEILING="$1" ;;
-  --primary-frontier) shift; PRIMARY_FRONTIER="$1" ;; *) ;;
+  --ref) shift; REF="$1" ;; --ceiling) shift; CEILING="$1" ;; *) ;;
 esac; shift; done
 
 export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"
@@ -43,7 +42,7 @@ echo ">> [build] submission ($COMMIT) from source (sm_$ARCH) — shared by both 
 rm -rf "$ROOT/build"
 if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
   echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
-  printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": %s, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false}\n' "$COMMIT" "$PRIMARY_FRONTIER"
+  printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": 0, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false}\n' "$COMMIT"
   exit 0
 fi
 
@@ -82,7 +81,7 @@ P_DIFF_REF="${SPARKINFER_P_LLAMA_128_BASELINE:-0}"
 # too slow (35B MoE dequant-bound) to sweep every eval. SCORE_REPS=0 skips the 16k context, GUARD_32K
 # _REPS=0 skips 32k (median_ctx returns 0 -> excluded from scoring + guards); the 3 live contexts get
 # 3-rep medians for a stable scored number. Re-enable 16k/32k by passing their reps + baselines.
-PRIMARY_JSON="$(run_model primary "$P_FILE" "$P_REPO" "$P_TOK" "$PRIMARY_FRONTIER" \
+PRIMARY_JSON="$(run_model primary "$P_FILE" "$P_REPO" "$P_TOK" 0 \
   MODELS_DIR="$P_DIR" MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" \
   SPARKINFER_SCORE_REPS=0 SPARKINFER_GUARD_32K_REPS=0 \
   SPARKINFER_GUARD_REPS=3 SPARKINFER_GUARD_512_REPS=3 SPARKINFER_GUARD_4K_REPS=3 \

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -356,22 +356,20 @@ def render(res, oid):
     if res.get("regression_labels") or res.get("guard_regression_labels"):
         allregs = (res.get("regression_labels") or []) + (res.get("guard_regression_labels") or [])
         rows.append(f"| regressions | {', '.join(allregs)} |")
-    if "frontier_tps" in res and res["frontier_tps"]:
-        # Label it "prior frontier" when this PR superseded it, so the old value isn't mistaken
-        # for the current live frontier (which is now this PR's tps).
-        rows.insert(2, f"| {'vs prior frontier' if advanced else 'vs frontier'} | {res['frontier_tps']} tok/s → "
+    if "frontier_tps" in res and res.get("frontier_tps", 0) > 0:
+        # "frontier_tps" is now the SAME-BOX origin/main baseline — the gain is measured directly
+        # against main on the same GPU in the same run, not a passed-in frontier number.
+        rows.insert(2, f"| vs same-box main | {res['frontier_tps']} tok/s → "
                        f"{res.get('pct_over_frontier', 0):+.1f}% ({res.get('delta_tps',0):+.1f}) |")
-    if advanced:
-        rows.insert(3, f"| **→ new frontier** | **{res.get('tps')} tok/s** |")
     note = {"REJECT": f"**Rejected** — {res.get('reason','')}.",
-            "none": "Within the significance gate — no *verified* speedup over the current frontier.",
-            "BASELINE": "No frontier was set; this run establishes it."
-            }.get(label, f"Verified speedup — **sets the new frontier to {res.get('tps')} tok/s** "
-                         f"(was {res.get('frontier_tps','?')}).")
+            "none": "Within the significance gate — no *verified* speedup over same-box main.",
+            "BASELINE": "No same-box main baseline was set; this run establishes one."
+            }.get(label, f"Verified speedup over same-box origin/main — "
+                         f"{res.get('tps')} tok/s (main was {res.get('frontier_tps','?')} tok/s).")
     if label == "REJECT" and res.get("auto_close"):
         note = "No context cleared the 2% significance gate while at least one context regressed. Auto-closing this PR."
-    target_note = ("128/512/4k/16k/32k guarded · strongest context scores"
-                   if res.get("eval_mode") == "longctx" else "128-token decode frontier")
+    target_note = ("128/512/4k/16k/32k guarded · scored vs same-box main · strongest context scores"
+                   if res.get("eval_mode") == "longctx" else "128-token decode scored vs same-box main")
     return (f"<!-- sparkinfer-eval:{oid} -->\n"
             f"## {icon} sparkinfer auto-eval — `{oid}`\n\n"
             f"| metric | value |\n|---|---|\n" + "\n".join(rows) + "\n\n"
@@ -773,19 +771,15 @@ def reconcile_merge_labels(repo):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--instance", type=int, required=True, help="vast.ai instance id to reuse")
-    ap.add_argument("--frontier", type=float, default=0)
+    ap.add_argument("--frontier", type=float, default=0, help="DEPRECATED: scoring now uses same-box origin/main baseline")
     ap.add_argument("--ceiling", type=float, default=0)
     ap.add_argument("--repo", default="gittensor-ai-lab/sparkinfer")
     ap.add_argument("--dry-run", action="store_true", help="evaluate + print, but don't label/comment")
-    # Dual-model: score Qwen3.6-35B-A3B (primary) and guard Qwen3-30B against no-regression. The
-    # Qwen3-30B guard baselines are still measured same-box each run (run_guard_*); the Qwen3.6
-    # primary baselines are stable config constants (no Qwen3.6-optimizing PR has moved them yet) —
-    # overridable via env until a same-box Qwen3.6 baseline pass is added.
+    # Dual-model: score Qwen3.6-35B-A3B (primary) and guard Qwen3-30B against no-regression.
+    # Each PR is scored directly against the SAME-BOX origin/main baseline (measured once per run),
+    # not a passed-in frontier number — so the gain is hardware-independent and always current.
     ap.add_argument("--dual", action="store_true",
                     help="score Qwen3.6 (primary) + guard Qwen3-30B (no-regression) via evaluate_dual.sh")
-    ap.add_argument("--primary-frontier", type=float,
-                    default=float(os.environ.get("SPARKINFER_QWEN36_FRONTIER", "23.0")),
-                    help="[--dual] Qwen3.6 current best verified 128/512/4k tok/s (the scored frontier)")
     args = ap.parse_args()
     # Qwen3.6 same-box origin/main baselines (128/512/4k). Env-overridable; measured 2026-07 on RTX 5090.
     QWEN36_BASE = {
@@ -1004,11 +998,10 @@ def main():
         # optimizations STACK, re-evaluate the second after merging the first. Literal duplicates are
         # caught by copycat detection; emission only pays MERGED PRs, so the maintainer's merge choice
         # (not eval order) decides what counts.
-        cur_frontier = run_baseline
         cur_iid = current_instance(args.instance)
         cmd = [sys.executable, os.path.join(HERE, "vast_eval.py"),
                "--reuse", str(cur_iid), "--ref", ref,
-               "--frontier", str(cur_frontier), "--ceiling", str(args.ceiling),
+               "--frontier", "0", "--ceiling", str(args.ceiling),
                "--eval-mode", "longctx", "--guard-128-baseline", str(run_guard_128),
                "--guard-512-baseline", str(run_guard_512),
                "--guard-4k-baseline", str(run_guard_4k),
@@ -1017,8 +1010,9 @@ def main():
                "--keep"]            # keep instance alive — bot stops it after all PRs
         if args.dual:
             # Qwen3.6 scored (128/512/4k); the --guard-*-baseline above become the Qwen3-30B guard.
+            # Scoring base = same-box origin/main baseline (the guard baselines), not a passed-in frontier.
             cmd[cmd.index("--keep"):cmd.index("--keep")] = [
-                "--dual", "--primary-frontier", str(args.primary_frontier),
+                "--dual",
                 "--p-guard-128-baseline", str(QWEN36_BASE["128"]),
                 "--p-guard-512-baseline", str(QWEN36_BASE["512"]),
                 "--p-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
@@ -1028,7 +1022,7 @@ def main():
         if PINNED_INSTANCE and str(cur_iid) == PINNED_INSTANCE:
             cmd.append("--pinned")  # never destroy the pin; retry-then-fallback on bring-up failure
         pinned = "--pinned" in cmd
-        print(f"PR #{num} @ {oid}: evaluating '{ref}' (frontier={cur_frontier}) on instance "
+        print(f"PR #{num} @ {oid}: evaluating '{ref}' (vs same-box main) on instance "
               f"{cur_iid}{' [pinned]' if pinned else ''} ...")
         r = subprocess.run(cmd, cwd=ROOT, capture_output=True, text=True, timeout=14400)
         if r.returncode == PINNED_RETRY_RC:

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -210,8 +210,6 @@ def main():
     ap.add_argument("--dual", action="store_true",
                     help="score Qwen3.6-35B-A3B and guard Qwen3-30B-A3B against no-regression in one build "
                          "(--guard-*-baseline are the Qwen3-30B guard; --p-* are the Qwen3.6 scored target)")
-    ap.add_argument("--primary-frontier", type=float, default=0,
-                    help="[--dual] Qwen3.6 current best verified tok/s (the scored frontier); falls back to --frontier")
     ap.add_argument("--p-guard-128-baseline", type=float, default=0, help="[--dual] Qwen3.6 main 128-token decode tok/s")
     ap.add_argument("--p-guard-512-baseline", type=float, default=0, help="[--dual] Qwen3.6 main 512-context tok/s")
     ap.add_argument("--p-guard-4k-baseline",  type=float, default=0, help="[--dual] Qwen3.6 main 4k-context tok/s")
@@ -478,7 +476,7 @@ def main():
                   f"SPARKINFER_P_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
                   f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
                   f"bench/scripts/evaluate_dual.sh --ref {args.ref} "
-                  f"--primary-frontier {args.primary_frontier or args.frontier} --ceiling {args.ceiling}")
+                  f"--ceiling {args.ceiling}")
         else:
             ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
                   f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} SPARKINFER_DIFFICULTY_BOOST=1 "


### PR DESCRIPTION
Every PR scores against the **same-box origin/main baseline** (measured once per run).

**Before:** `base = max(guard_baseline, frontier)` — frontier could be stale (23→XL inflate) or missing.

**Now:** `base = guard_baseline` — same-box main speed. Each PR is: 'how much faster than main on this box?'

| scenario | old base | old label | **new** |
|---|---|---|---|
| Q36 +17 over 171 main | 23 | XL +708% | **M +10%** |
| Q36 marginal +4 | 23 | XL | **XS** |
| Q36 tiny +1 | 23 | XS | **none** |
| Q3 +10 over 493 main | 493 | L | L (unchanged) |