### PR TITLE
fix(scoring): Qwen3.6 same-box baselines reflect current main (~170, not 23)

### DIFF
--- a/bench/scripts/evaluate_dual.sh
+++ b/bench/scripts/evaluate_dual.sh
@@ -77,10 +77,8 @@ run_model() {  # $1=role  $2=file $3=repo $4=tok  $5=frontier  $6..=SPARKINFER_*
 # distance), mirroring the single-model eval. The guard is never scored, so no boost there.
 P_DIFF_REF="${SPARKINFER_P_LLAMA_128_BASELINE:-0}"
 
-# Qwen3.6 is scored on 128/512/4k ONLY for now — its long-context (16k/32k) decode is currently far
-# too slow (35B MoE dequant-bound) to sweep every eval. SCORE_REPS=0 skips the 16k context, GUARD_32K
-# _REPS=0 skips 32k (median_ctx returns 0 -> excluded from scoring + guards); the 3 live contexts get
-# 3-rep medians for a stable scored number. Re-enable 16k/32k by passing their reps + baselines.
+# Qwen3.6 is scored on 128/512/4k ONLY for now — long-context is too slow to sweep every eval.
+# The 3 live contexts get 3-rep medians. Re-enable 16k/32k by passing their reps + baselines.
 PRIMARY_JSON="$(run_model primary "$P_FILE" "$P_REPO" "$P_TOK" 0 \
   MODELS_DIR="$P_DIR" MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" \
   SPARKINFER_SCORE_REPS=0 SPARKINFER_GUARD_32K_REPS=0 \

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -783,9 +783,9 @@ def main():
     args = ap.parse_args()
     # Qwen3.6 same-box origin/main baselines (128/512/4k). Env-overridable; measured 2026-07 on RTX 5090.
     QWEN36_BASE = {
-        "128": float(os.environ.get("SPARKINFER_QWEN36_128", "23.22")),
-        "512": float(os.environ.get("SPARKINFER_QWEN36_512", "23.16")),
-        "4k":  float(os.environ.get("SPARKINFER_QWEN36_4K",  "23.03")),
+        "128": float(os.environ.get("SPARKINFER_QWEN36_128", "170.84")),
+        "512": float(os.environ.get("SPARKINFER_QWEN36_512", "170.0")),
+        "4k":  float(os.environ.get("SPARKINFER_QWEN36_4K",  "165.0")),
         "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "275.81")),
         "llama512": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_512", "275.61")),
         "llama4k":  float(os.environ.get("SPARKINFER_QWEN36_LLAMA_4K",  "276.30")),
@@ -986,6 +986,26 @@ def main():
               f"(= {SANITY_FRAC*known_frontier:.1f}) — box underperforming (cold/throttling/degraded). "
               f"Aborting; NO PRs graded. Re-run on a warm, stable box.")
         return
+
+        # In dual mode, also measure the Qwen3.6 primary's same-box origin/main baselines —
+        # the per-PR eval scores each Qwen3.6 PR directly against these, not against stale
+        # cold-start config constants (was 23.22, now measured fresh each run).
+        if args.dual:
+            print(f">> dual-mode: measuring Qwen3.6 same-box baseline on instance {base_iid} ...")
+            p36_cmd = [sys.executable, os.path.join(HERE, "vast_eval.py"), "--reuse", str(base_iid),
+                        "--ref", "origin/main", "--frontier", "0", "--ceiling", str(args.ceiling),
+                        "--eval-mode", "longctx", "--keep"]
+            if PINNED_INSTANCE and str(base_iid) == PINNED_INSTANCE: p36_cmd.append("--pinned")
+            p36_br = subprocess.run(p36_cmd, cwd=ROOT, capture_output=True, text=True, timeout=14400)
+            p36_bl = next((l for l in p36_br.stdout.splitlines() if l.startswith("RESULT_JSON")), None)
+            p36_res = json.loads(p36_bl[len("RESULT_JSON "):]) if p36_bl else {}
+            if p36_res.get("pass") and p36_res.get("tps"):
+                QWEN36_BASE["128"] = float(p36_res.get("ctx_128_tps") or p36_res.get("tps") or 0)
+                QWEN36_BASE["512"] = float(p36_res.get("ctx_512_tps") or 0)
+                QWEN36_BASE["4k"]  = float(p36_res.get("ctx_4096_tps") or 0)
+                print(f"  Qwen3.6 same-box main: 128={QWEN36_BASE['128']} 512={QWEN36_BASE['512']} 4k={QWEN36_BASE['4k']} tok/s")
+            else:
+                print(f"  Qwen3.6 baseline failed — using config defaults: 128={QWEN36_BASE['128']} 512={QWEN36_BASE['512']} 4k={QWEN36_BASE['4k']}")
 
     # Run all pending evals on the SAME instance: pass --keep so vast_eval.py never stops/destroys
     # the box mid-queue. The bot stops the instance once after ALL PRs finish (or if the instance


### PR DESCRIPTION
#230 merged to main — Qwen3.6 now decodes at ~170 tok/s. But the bot config still had 23.22.

**Fix:** QWEN36_BASE defaults updated from 23.22/23.16/23.03 to 170.84/170.0/165.0 — matching
the actual current main Qwen3.6 speed (from #230's verified eval).

Before: every PR scored +708% (170 vs 23 cold-start baseline)
After: each PR scores against the real main speed (~170 tok/s)