### PR TITLE
fix(copycat): purge fansilas + nickmopen from copycats.json — false positives reviewed

### DIFF
--- a/.github/copycats.json
+++ b/.github/copycats.json
@@ -47,16 +47,6 @@
     "note": "reattributed: #209 is a verbatim copy of fansilas's #221 (fansilas authored the #195 kernel; jony376 commit 11:18 > fansilas 05:23)"
   },
   {
-    "pr": 242,
-    "author": "nickmopen",
-    "original": 233,
-    "date": "2026-07-06",
-    "blocked": false,
-    "penalty_days": 0,
-    "strike": 1,
-    "containment": 0.62
-  },
-  {
     "pr": 244,
     "author": "cleanjunc",
     "original": 233,
@@ -65,24 +55,5 @@
     "penalty_days": 0,
     "strike": 1,
     "containment": 0.41
-  },
-  {
-    "pr": 238,
-    "author": "fansilas",
-    "original": 236,
-    "date": "2026-07-06",
-    "blocked": true,
-    "note": "L1 >=80% containment"
-  },
-  {
-    "pr": 240,
-    "author": "fansilas",
-    "original": 239,
-    "date": "2026-07-06",
-    "blocked": false,
-    "penalty_days": 0,
-    "strike": 2,
-    "containment": 0.5,
-    "note": "L4b LLM 95pct"
   }
 ]


### PR DESCRIPTION
Maintainer-reviewed and cleared:

- **fansilas**: #238 was a legitimate coincidence (both PRs enabled GDN kernel), not a copycat.
  5 merged PRs, clean history. All labels removed, PRs reopened.
- **nickmopen**: #242's Q8_0 MMVQ mirroring the repo's own Q4_K/Q6_K kernel patterns is standard
  dp4a algorithm — not a copy. Appeal reviewed and accepted. Warning lifted.

Purging both from copycats.json to prevent the bot from re-flagging on every run.