### PR TITLE
fix(dashboard): proof URLs for #237/#239/#241/#243

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -149,7 +149,8 @@ window.SPARKINFER = {
       "delta_pct": 0,
       "top1": 0.97,
       "kl": 0.02,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/243"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/243",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/243#issuecomment-4889142494"
     },
     {
       "num": 241,
@@ -163,7 +164,8 @@ window.SPARKINFER = {
       "delta_pct": 0,
       "top1": 0.97,
       "kl": 0.02,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/241"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/241",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/241#issuecomment-4889091778"
     },
     {
       "num": 239,
@@ -177,7 +179,8 @@ window.SPARKINFER = {
       "delta_pct": 0,
       "top1": 0.97,
       "kl": 0.02,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/239"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/239",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/239#issuecomment-4889090888"
     },
     {
       "num": 237,
@@ -191,7 +194,8 @@ window.SPARKINFER = {
       "delta_pct": 0.0,
       "top1": 0.9885,
       "kl": 0.0096,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/237"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/237",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/237#issuecomment-4889090598"
     },
     {
       "num": 234,

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -148,7 +148,8 @@
       "delta_pct": 0,
       "top1": 0.97,
       "kl": 0.02,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/243"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/243",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/243#issuecomment-4889142494"
     },
     {
       "num": 241,
@@ -162,7 +163,8 @@
       "delta_pct": 0,
       "top1": 0.97,
       "kl": 0.02,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/241"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/241",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/241#issuecomment-4889091778"
     },
     {
       "num": 239,
@@ -176,7 +178,8 @@
       "delta_pct": 0,
       "top1": 0.97,
       "kl": 0.02,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/239"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/239",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/239#issuecomment-4889090888"
     },
     {
       "num": 237,
@@ -190,7 +193,8 @@
       "delta_pct": 0.0,
       "top1": 0.9885,
       "kl": 0.0096,
-      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/237"
+      "url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/237",
+      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/pull/237#issuecomment-4889090598"
     },
     {
       "num": 234,


### PR DESCRIPTION
These PRs have real bot eval comments but the log site URLs were never created (runs killed mid-execution). Point proof links to the PR comments containing the full verdict tables.