### PR TITLE
perf(gemv): Q8_0 on-read GEMV for dense projections (+12% Qwen3.6 dec…

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -170,6 +170,39 @@ __global__ void gemv_q_kernel(const __nv_bfloat16* __restrict__ x,
 template __global__ void gemv_q_kernel<__nv_bfloat16>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int, int);
 template __global__ void gemv_q_kernel<float>(const __nv_bfloat16*, const unsigned char*, float*, int, int, int);
 
+// ---- Q8_0 on-read GEMV (W = GGUF-native Q8_0 [N,K]) ---------------------------
+// Q8_0 block = 34 B / 32 values: one fp16 scale d, then 32 int8. Dequant-on-read (d*int8)
+// dotted with the fp32-staged activation — reads the int8 weight bytes (~2x less than bf16)
+// with NO activation quantization. Replaces the Q8_0->bf16 load-time dequant + dense bf16
+// GEMV: this is MORE faithful (fp32 accumulate of the exact Q8_0 value, vs bf16-rounded weight)
+// and reads half the weight memory. One warp per output row (lane j owns value j of each block).
+template <typename OutT>
+__global__ void gemv_q80_kernel(const __nv_bfloat16* __restrict__ x,
+                                const unsigned char* __restrict__ W,
+                                OutT* __restrict__ y, int N, int K) {
+    extern __shared__ float s_x[];                 // K floats
+    for (int i = threadIdx.x; i < K; i += blockDim.x) s_x[i] = __bfloat162float(x[i]);
+    __syncthreads();
+
+    const int warp = threadIdx.x / 32, lane = threadIdx.x % 32;
+    const int n = blockIdx.x * GEMV_WPB + warp;
+    if (n >= N) return;
+    const int nblk = K / 32;                        // Q8_0: 32 values / block
+    const unsigned char* base = W + (size_t)n * nblk * 34;
+    float acc = 0.f;
+    for (int blk = 0; blk < nblk; blk++) {
+        const unsigned char* b = base + (size_t)blk * 34;
+        const float d = gq_h2f(b);                  // fp16 block scale
+        const signed char q = reinterpret_cast<const signed char*>(b + 2)[lane];
+        acc += d * (float)q * s_x[blk * 32 + lane];
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) gemv_write(y + n, acc);
+}
+template __global__ void gemv_q80_kernel<__nv_bfloat16>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void gemv_q80_kernel<float>(const __nv_bfloat16*, const unsigned char*, float*, int, int);
+
 // ---- faithful llama.cpp int8 MMVQ for a dense Q4_K [N,K] GEMV --------------------
 // Quantizes the activation to Q8_1 (int8 + per-32 scale + sum) once per token, then
 // dp4a's the Q4_K weight nibbles against it — the same vec_dot_q4_K_q8_1 math llama.cpp
@@ -637,6 +670,10 @@ void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int 
         gemv_q_dp4a_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, sm, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), N, K);
+    } else if (wtype == 8) {            // Q8_0: half the weight read of the bf16 GEMV
+        gemv_q80_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), N, K);
     } else {
         gemv_q_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
@@ -648,6 +685,9 @@ void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N,
     if (gemv_mmvq() && wtype == 12) {
         size_t sm = 2 * (size_t)(K >> 5) * sizeof(float) + (size_t)K;
         gemv_q_dp4a_kernel<float><<<grid, GEMV_WPB * 32, sm, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W), y, N, K);
+    } else if (wtype == 8) {            // Q8_0
+        gemv_q80_kernel<float><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W), y, N, K);
     } else {
         gemv_q_kernel<float><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -811,9 +811,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     // uses ~1.5 GB less VRAM. Set SPARKINFER_QATTN=0 to load dense bf16 instead.
     const bool qattn = []{ const char* a = getenv("SPARKINFER_QATTN");
                            return !(a && a[0] == '0'); }();
+    // Keep Q8_0 (ggml type 8) projection weights quantized in VRAM and decode them on-read
+    // (gemv_q80_kernel), instead of the load-time Q8_0->bf16 dequant + dense bf16 GEMV. Halves
+    // the weight read of the ~44%-of-decode dense GEMV and is more faithful (fp32 accumulate of
+    // the exact Q8_0 value vs a bf16-rounded weight). Default ON; SPARKINFER_QGEMV8=0 = bf16.
+    const bool q80 = []{ const char* a = getenv("SPARKINFER_QGEMV8");
+                         return !(a && a[0] == '0'); }();
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
-        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
+        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || (q80 && t->ggml_type == 8)))
+            return dev_quant(name, type);
         type = 0; return dense(name, false);
     };
     auto attn_w_opt = [&](const std::string& name, int& type) -> const void* {


### PR DESCRIPTION
## Summary

Q8_0 on-read GEMV for the dense projections. Keep Q8_0 (ggml type 8) projection weights
quantized in VRAM and decode them on-read (new `gemv_q80_kernel`), instead of the load-time
Q8_0-to-bf16 dequant + dense bf16 GEMV. The dense projection GEMV is the single biggest kernel
in Qwen3.6 decode after the GDN and shared-expert optimizations landed. Reading Q8_0 int8 halves
the weight read on ~54% of kernel time.

Scope: `kernels/csrc/cuda/gemm/gemv.cu` + one dispatch condition in
`runtime/src/models/qwen35.cpp`. Gated by `SPARKINFER_QGEMV8` (default on, `=0` restores the
exact bf16 path for same-box A/B). Fully additive — independent of shared-expert (#230) and
gdn_ar_fast (#229); they stack.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 223.17 |
| after (this PR) | 250.58 |

```text
Qwen3.6-35B-A3B-UD-Q4_K_M · RTX 5090 sm_120 · CUDA 13 · qwen3_gguf_bench n=128 bs=1
SPARKINFER_GDN_FAST=1 (matching eval frontier)
SPARKINFER_QGEMV8=0 (=main) -> SPARKINFER_QGEMV8=1 (=PR, default)
  128-ctx: 223.17 -> 250.58 (+12.3%)
  512-ctx: 222.65 -> 249.43 (+12.0%)
  4k-ctx:  212.17 -> 236.61 (+11.5%)
```

Per-scored-context (SPARKINFER_GDN_FAST=1 matching the eval frontier; QGEMV8=0 vs =1):

| model | context | main (bf16) | this PR (Q8_0) | delta |
|---|--:|--:|--:|--:|
| Qwen3.6 | 128 | 223.17 | 250.58 | +12.3% |
| Qwen3.6 | 512 | 222.65 | 249.43 | +12.0% |
| Qwen3.6 | 4k | 212.17 | 236.61 | +11.5% |
| Qwen3-30B | 128 | 491.66 | 491.51 | -0.03% |
| Qwen3-30B | 512 | 476.42 | 476.31 | -0.02% |
| Qwen3-30B | 4k | 389.98 | 390.06 | +0.02% |

Qwen3-30B guard: zero regression (all within noise; QGEMV8=0 reproduces baseline exactly).

**Correctness** — teacher-forced vs llama.cpp on held-out prompt (gen_eval_prompt seed 42, 271
positions, matched-depth top-64 KL). ctest 7/7 pass.

| build | top-1 vs llama | mean KL | sparkinfer PPL |
|---|--:|--:|--:|
| main (bf16) | 0.956 | 0.0177 | 6.610 |
| this PR (Q8_0) | 0.941 | 0.0169 | 6.564 |

Clears the correctness gate (top-1 >= 0.90, KL <= 0.20; also below the preferred 0.15). Lower KL
and better PPL than main — the exact int8 weight is more faithful than a bf16-rounded weight.
