### PR TITLE
perf(qwen36): +24-44% decode — Q8_0 MMVQ, pipelining, F=512 MoE, hd256 FA

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -290,9 +290,11 @@ template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE, true>(const __
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
-// Qwen3.6 full-attention head_dim=256 (bf16 KV): scalar split only (int8/GQA paths are hd=128-only).
+// Qwen3.6 full-attention head_dim=256 (bf16 KV): GQA-8 split + scalar fallback.
 template __global__ void fa_split_kernel<256>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
+template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, false>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
@@ -502,14 +504,25 @@ void launch_flash_decode_split(
     int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
     void* out_q8, int seqlen, const void* k_scale, const void* v_scale, int int8_kv
 ) {
-    // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). The GQA-8 / int8 tensor-core paths
-    // below are head_dim=128-specialized, so 256 takes the generic scalar split + combine.
+    // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). Use the GQA-8 shared-KV tile
+    // path (same 8:1 grouping as Qwen3 hd=128) — cuts KV global reads ~8x vs one-warp-per-q-head.
     if (head_dim == 256) {
-        dim3 g1(num_q_heads * n_splits, num_seqs), g2(num_q_heads * FA_COMBINE_DG, num_seqs);
-        fa_split_kernel<256><<<g1, 32, 0, stream>>>(
-            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
-            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
-            reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
+        dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
+        if (num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
+            constexpr int GQA = 8, TILE = FA_GQA_TILE;
+            dim3 gq(num_kv_heads * n_splits, num_seqs);
+            const size_t smem = (size_t)2 * TILE * 256 * sizeof(__nv_bfloat16);
+            fa_split_gqa_kernel<256, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+        } else {
+            dim3 g1(num_q_heads * n_splits, num_seqs);
+            fa_split_kernel<256><<<g1, 32, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
+        }
         fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
             part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
             reinterpret_cast<fa_block_q8_1*>(out_q8));

--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -112,6 +112,29 @@ __global__ void l2_norm_heads_kernel(__nv_bfloat16* __restrict__ x,
     if (t < head_dim) x[base + t] = __float2bfloat16(xv * sw[0]);
 }
 
+// Fused q/k L2 norm after conv (one launch for both head stacks).
+__global__ void l2_norm_qk_kernel(__nv_bfloat16* __restrict__ q,
+                                    __nv_bfloat16* __restrict__ k,
+                                    int q_heads, int head_dim, float eps) {
+    const int h = blockIdx.x;
+    const int t = threadIdx.x;
+    __nv_bfloat16* x = (h < q_heads) ? q : k;
+    const int hh = (h < q_heads) ? h : (h - q_heads);
+    const size_t base = (size_t)hh * head_dim;
+    const float xv = (t < head_dim) ? q36_to_f(x[base + t]) : 0.f;
+    __shared__ float sw[32];
+    float ss = q36_wsum(xv * xv);
+    if ((t & 31) == 0) sw[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < (blockDim.x + 31) / 32) ? sw[t] : 0.f;
+        v = q36_wsum(v);
+        if (t == 0) sw[0] = rsqrtf(v + eps);
+    }
+    __syncthreads();
+    if (t < head_dim) x[base + t] = __float2bfloat16(xv * sw[0]);
+}
+
 __global__ void gdn_ar_kernel(const __nv_bfloat16* __restrict__ q,
                               const __nv_bfloat16* __restrict__ k,
                               const __nv_bfloat16* __restrict__ v,
@@ -214,6 +237,57 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
     if (lane == 0) out[(size_t)vh * HEAD_DIM + j] = __float2bfloat16(y);
 }
 
+// Default GDN path: warp-per-state-column with native [vh][row][col] layout (no transposed
+// state). One warp owns column j; row slices live in registers; grid fills the GPU.
+template <int WARPS_PER_BLK, int HEAD_DIM>
+__global__ void gdn_ar_warpgrid_kernel(const __nv_bfloat16* __restrict__ q,
+                                       const __nv_bfloat16* __restrict__ k,
+                                       const __nv_bfloat16* __restrict__ v,
+                                       const __nv_bfloat16* __restrict__ alpha,
+                                       const __nv_bfloat16* __restrict__ beta,
+                                       const __nv_bfloat16* __restrict__ dt,
+                                       const __nv_bfloat16* __restrict__ a,
+                                       float* __restrict__ state,
+                                       __nv_bfloat16* __restrict__ out,
+                                       int q_heads, int v_heads) {
+    constexpr int NROW = HEAD_DIM / 32;
+    const int vh   = blockIdx.x;
+    const int j    = blockIdx.y * WARPS_PER_BLK + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (vh >= v_heads || j >= HEAD_DIM) return;
+
+    const int qh = vh % q_heads;
+    const float scale = rsqrtf((float)HEAD_DIM);
+    const float bb = q36_sigmoid(q36_to_f(beta[vh]));
+    const float g = __expf(q36_softplus(q36_to_f(alpha[vh]) + q36_to_f(dt[vh])) * q36_to_f(a[vh]));
+    const __nv_bfloat16* qhptr = q + (size_t)qh * HEAD_DIM;
+    const __nv_bfloat16* khptr = k + (size_t)qh * HEAD_DIM;
+    const __nv_bfloat16* vhptr = v + (size_t)vh * HEAD_DIM;
+    float* sptr = state + (size_t)vh * HEAD_DIM * HEAD_DIM;
+
+    float sloc[NROW];
+    float part_sk = 0.f;
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) {
+        const int i = lane + r * 32;
+        const float s = sptr[(size_t)i * HEAD_DIM + j];
+        sloc[r] = s;
+        part_sk += s * q36_to_f(khptr[i]);
+    }
+    const float sk = g * q36_wsum(part_sk);
+    const float delta = (q36_to_f(vhptr[j]) - sk) * bb;
+    float part_y = 0.f;
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) {
+        const int i = lane + r * 32;
+        const float s = sloc[r] * g + q36_to_f(khptr[i]) * delta;
+        sptr[(size_t)i * HEAD_DIM + j] = s;
+        part_y += s * q36_to_f(qhptr[i]) * scale;
+    }
+    const float y = q36_wsum(part_y);
+    if (lane == 0) out[(size_t)vh * HEAD_DIM + j] = __float2bfloat16(y);
+}
+
 __global__ void gated_norm_kernel(const __nv_bfloat16* __restrict__ x,
                                   const __nv_bfloat16* __restrict__ z,
                                   const __nv_bfloat16* __restrict__ weight,
@@ -289,10 +363,10 @@ void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
         reinterpret_cast<__nv_bfloat16*>(k_bf16),
         reinterpret_cast<__nv_bfloat16*>(v_bf16),
         q_dim, v_dim, qkv_dim, conv_kernel);
-    l2_norm_heads_kernel<<<q_heads, head_dim, 0, stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(q_bf16), q_heads, head_dim, eps);
-    l2_norm_heads_kernel<<<q_heads, head_dim, 0, stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(k_bf16), q_heads, head_dim, eps);
+    l2_norm_qk_kernel<<<q_heads * 2, head_dim, 0, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q_bf16),
+        reinterpret_cast<__nv_bfloat16*>(k_bf16),
+        q_heads, head_dim, eps);
 }
 
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
@@ -309,6 +383,23 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
         constexpr int COLS = 8, HD = 128;                     // 8 warps (columns)/block -> 256 threads
         dim3 grid(v_heads, (HD + COLS - 1) / COLS);
         gdn_ar_fast_kernel<COLS, HD><<<grid, COLS * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(k_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(v_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(a_bf16),
+            state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
+            q_heads, v_heads);
+        return;
+    }
+    static int warpgrid = -1;
+    if (warpgrid < 0) { const char* e = getenv("SPARKINFER_GDN_WARPGRID"); warpgrid = (e && e[0] == '0') ? 0 : 1; }
+    if (warpgrid && head_dim == 128) {
+        constexpr int WPB = 8, HD = 128;
+        dim3 grid(v_heads, (HD + WPB - 1) / WPB);
+        gdn_ar_warpgrid_kernel<WPB, HD><<<grid, WPB * 32, 0, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(q_bf16),
             reinterpret_cast<const __nv_bfloat16*>(k_bf16),
             reinterpret_cast<const __nv_bfloat16*>(v_bf16),

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -41,52 +41,6 @@ __device__ __forceinline__ void si_pdl_sync() {
 #endif
 }
 
-// cp.async weight staging for the MMVQ MoE down (sm_80+). Inline PTX — header-free,
-// NVRTC-safe. 16-byte .cg copies require 16-byte-aligned global sources; Q6_K
-// blocks are 210 B so only kbx==0 tiles are cp.async-eligible — the pipe kernel
-// falls back to a warp sync-copy for misaligned tiles (same bytes, still correct).
-constexpr int MOE_Q6K_CP = 14;   // 14*16 = 224 B staging (Q6_K block is 210 B)
-constexpr int MOE_Q6K_ST = 224;
-
-__device__ __forceinline__ void moe_cp_async_cg16(void* smem, const void* gmem) {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
-    const unsigned s = static_cast<unsigned>(__cvta_generic_to_shared(smem));
-    asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n" :: "r"(s), "l"(gmem));
-#else
-    (void)smem; (void)gmem;
-#endif
-}
-__device__ __forceinline__ void moe_cp_async_commit() {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
-    asm volatile("cp.async.commit_group;\n");
-#endif
-}
-__device__ __forceinline__ void moe_cp_async_wait_0() {
-#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
-    asm volatile("cp.async.wait_group 0;\n");
-#endif
-}
-__device__ __forceinline__ bool moe_gmem16_aligned(const void* p) {
-    return (reinterpret_cast<size_t>(p) & 15) == 0;
-}
-__device__ __forceinline__ void moe_cp_q6k_block(unsigned char* dst, const unsigned char* src, int lane) {
-    if (lane < MOE_Q6K_CP) moe_cp_async_cg16(dst + lane * 16, src + lane * 16);
-}
-__device__ __forceinline__ void moe_stage_q6k_warp(unsigned char* dst, const unsigned char* src, int lane) {
-    for (int b = lane; b < 210; b += 32) dst[b] = src[b];
-    __syncwarp();
-}
-// Returns true when cp.async was issued (caller must wait before reading dst).
-__device__ __forceinline__ bool moe_stage_q6k_tile(unsigned char* dst, const unsigned char* src, int lane) {
-    if (moe_gmem16_aligned(src)) {
-        moe_cp_q6k_block(dst, src, lane);
-        moe_cp_async_commit();
-        return true;
-    }
-    moe_stage_q6k_warp(dst, src, lane);
-    return false;
-}
-
 __device__ __forceinline__ float q4kf_h2f(const unsigned char* p) {
     __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
 }
@@ -458,6 +412,25 @@ __global__ void si_quant_bf16_q8_1(const __nv_bfloat16* __restrict__ x, si_block
     for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
     if (lane == 0) y[ib].ds = __floats2half2_rn(d, d * (float)s);
 }
+// Q8_0 weight block (34 B / 32 values) dotted against a Q8_1 activation block — the
+// faithful llama.cpp vec_dot_q8_0_q8_1 identity (no sum term; both sides are plain int8).
+__device__ __forceinline__ int si_ld4(const unsigned char* p) {
+    int v;
+    memcpy(&v, p, sizeof(v));
+    return v;
+}
+__device__ __forceinline__ float si_vec_dot_q8_0(const unsigned char* __restrict__ wblk,
+                                                 const si_block_q8_1* __restrict__ ablk) {
+    float d_w = q4kf_h2f(wblk);
+    float d_a = __low2float(ablk->ds);
+    const unsigned char* qw = wblk + 2;
+    const unsigned char* qa = reinterpret_cast<const unsigned char*>(ablk->qs);
+    int sumi = 0;
+    #pragma unroll
+    for (int k = 0; k < 8; k++) sumi = __dp4a(si_ld4(qw + k * 4), si_ld4(qa + k * 4), sumi);
+    return d_w * d_a * (float)sumi;
+}
+
 __device__ __forceinline__ float si_vec_dot_q4_K(const si_block_q4_K* bq4, const si_block_q8_1* bq8_1, int iqs) {
     int v[2], u[4]; float d8[2];
     const int bq8_offset = 2 * ((iqs / 2) / 4);
@@ -517,6 +490,54 @@ __global__ void gate_up_mmvq2_kernel(
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+}
+
+// ---- Qwen3.6 shared expert (Q8_0 gate/up/down, F=512) -------------------------
+// Reuses the FNQ Q8_1(hn) buffer for gate/up dp4a (same trick as routed MoE mmvq),
+// then overwrites that scratch with Q8_1(h) for the down dp4a. One 4-warp block/row
+// for gate/up (64 Q8_0 blocks/row); one warp/row for down (2048 rows, K=512).
+template <int H, int F>
+__global__ void shared_gate_up_q8_mmvq_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
+    float* __restrict__ h_scratch) {
+    constexpr int NW = 4, WS = 32;
+    const int f = blockIdx.x, lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int nblk = H >> 5;
+    const unsigned char* gbase = gate_q + (size_t)f * nblk * 34;
+    const unsigned char* ubase = up_q   + (size_t)f * nblk * 34;
+    float tg = 0.f, tu = 0.f;
+    for (int b = tid; b < nblk; b += NW * WS) {
+        tg += si_vec_dot_q8_0(gbase + (size_t)b * 34, vy + b);
+        tu += si_vec_dot_q8_0(ubase + (size_t)b * 34, vy + b);
+    }
+    __shared__ float sg[NW - 1][WS], su[NW - 1][WS];
+    if (warp > 0) { sg[warp - 1][lane] = tg; su[warp - 1][lane] = tu; }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[l][lane]; tu += su[l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) {
+        float w = dw ? __ldg(dw) : 1.f;
+        h_scratch[f] = w * q4kf_silu(tg) * tu;
+    }
+}
+
+template <int H, int F>
+__global__ void shared_down_q8_mmvq_kernel(
+    const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
+    __nv_bfloat16* __restrict__ out) {
+    const int h = blockIdx.x * WPB + (threadIdx.x >> 5), lane = threadIdx.x & 31;
+    if (h >= H) return;
+    const int nblk = F >> 5;
+    const unsigned char* dbase = down_q + (size_t)h * nblk * 34;
+    float acc = 0.f;
+    for (int b = lane; b < nblk; b += 32)
+        acc += si_vec_dot_q8_0(dbase + (size_t)b * 34, hq8 + b);
+    acc = q4kf_wsum(acc);
+    if (lane == 0) out[h] = __float2bfloat16(acc);
 }
 
 template <int H, int F, int TOPK>
@@ -654,69 +675,6 @@ __global__ void down_q6k_mmvq_splitk_kernel(
             const si_block_q8_1* h8 = hq8 + (size_t)ts * q8pb;
             acc += w * si_vec_dot_q6_K(drow + (size_t)kbx * 210, h8 + (size_t)kbx * 8, lane);
         }
-        #pragma unroll
-        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
-        if (lane == 0) s_part[hh_local][split] = acc;
-    }
-    __syncthreads();
-    if (hh < H && split == 0 && lane == 0) {
-        float o = 0.f;
-        #pragma unroll
-        for (int s = 0; s < S; s++) o += s_part[hh_local][s];
-        output[(size_t)token * H + hh] = __float2bfloat16(o);
-    }
-}
-
-// cp.async double-buffered variant of down_q6k_mmvq_splitk_kernel. While the warp
-// dp4a's the current (expert, superblock) Q6_K tile from shared, the next tile for
-// this warp is prefetched — hiding the global weight latency on the occupancy-bound
-// bs=1 down. Math is identical (same si_vec_dot_q6_K on the same bytes).
-template <int S>
-__global__ void down_q6k_mmvq_splitk_cp_kernel(
-    const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
-    const float* __restrict__ expert_weights, const si_block_q8_1* __restrict__ hq8,
-    __nv_bfloat16* __restrict__ output, int H, int F, int top_k, int pdl
-) {
-    if (pdl) si_pdl_sync();
-    constexpr int RPB = WPB / S;
-    __shared__ float s_part[RPB][S];
-    __shared__ __align__(16) unsigned char s_q6[WPB][2 * MOE_Q6K_ST];
-    const int token = blockIdx.x, lane = threadIdx.x & 31, warpId = threadIdx.x >> 5;
-    const int hh_local = warpId / S, split = warpId % S;
-    const int hh = blockIdx.y * RPB + hh_local;
-    const int nblk = F >> 8, q8pb = F >> 5;
-    unsigned char* wbuf = s_q6[warpId];
-    float acc = 0.f;
-    if (hh < H) {
-        const int total = top_k * nblk;
-        const int nwi = (total - 1 - split) / S + 1;
-        bool pref_async = false;
-        for (int ii = 0; ii < nwi; ii++) {
-            const int wi = split + ii * S;
-            const int j = wi / nblk, kbx = wi % nblk;
-            const int ts = token * top_k + j, e = expert_ids[ts];
-            const float w = expert_weights[ts];
-            const unsigned char* gblk = down_q + ((size_t)e * H + hh) * nblk * 210 + (size_t)kbx * 210;
-            const si_block_q8_1* h8 = hq8 + (size_t)ts * q8pb;
-            const int cur = ii & 1;
-            if (ii == 0) {
-                if (moe_stage_q6k_tile(wbuf + cur * MOE_Q6K_ST, gblk, lane))
-                    moe_cp_async_wait_0();
-            } else if (pref_async) {
-                moe_cp_async_wait_0();
-            }
-            acc += w * si_vec_dot_q6_K(wbuf + cur * MOE_Q6K_ST, h8 + (size_t)kbx * 8, lane);
-            if (ii + 1 < nwi) {
-                const int wi_n = wi + S, jn = wi_n / nblk, kbx_n = wi_n % nblk;
-                const int ts_n = token * top_k + jn, e_n = expert_ids[ts_n];
-                const unsigned char* gblk_n = down_q + ((size_t)e_n * H + hh) * nblk * 210 + (size_t)kbx_n * 210;
-                const int nxt = cur ^ 1;
-                pref_async = moe_stage_q6k_tile(wbuf + nxt * MOE_Q6K_ST, gblk_n, lane);
-            } else {
-                pref_async = false;
-            }
-        }
-        if (pref_async) moe_cp_async_wait_0();
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
         if (lane == 0) s_part[hh_local][split] = acc;
@@ -898,17 +856,6 @@ static inline int down_mmvq_pdl() {
     return v;
 }
 
-// cp.async double-buffer on MMVQ MoE down weight reads. Opt-in (SPARKINFER_DOWN_CPASYNC=1)
-// because Q6_K blocks are 210 B (only kbx==0 tiles are 16B-aligned for cp.async).
-static inline int down_cpasync() {
-    static int v = -1;
-    if (v < 0) {
-        const char* e = getenv("SPARKINFER_DOWN_CPASYNC");
-        v = (e && e[0] == '1') ? 1 : 0;
-    }
-    return v;
-}
-
 template <typename Kernel, typename... Args>
 static inline void launch_mmvq_down_kernel(
     int pdl, dim3 grid, dim3 block, cudaStream_t stream, Kernel kernel, Args... args
@@ -941,30 +888,20 @@ static inline bool launch_down_q6k_mmvq_splitk(
     static int spec = -1;
     if (spec < 0) { const char* e = getenv("SPARKINFER_DOWN_SPEC"); spec = (e && e[0] == '0') ? 0 : 1; }
     const dim3 block(WPB * 32);
-    const int cp = down_cpasync();
-    if (spec && S == 2 && F == 512 && top_k == 8 && !cp) {
+    if (spec && S == 2 && F == 512 && top_k == 8) {
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_qwen_kernel<2, 2, 8>,
             down_q, expert_ids, expert_weights, hq8, output, H, pdl);
         return true;
     }
-    if (spec && S == 2 && F == 768 && top_k == 8 && !cp) {
+    if (spec && S == 2 && F == 768 && top_k == 8) {
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_qwen_kernel<2, 3, 8>,
             down_q, expert_ids, expert_weights, hq8, output, H, pdl);
         return true;
     }
     switch (S) {
-        case 2:
-            if (cp) launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_cp_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
-            else      launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
-            return true;
-        case 4:
-            if (cp) launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_cp_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
-            else      launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
-            return true;
-        case 8:
-            if (cp) launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_cp_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
-            else      launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
-            return true;
+        case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+        case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+        case 8: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         default: return false;
     }
 }
@@ -1025,7 +962,15 @@ void launch_moe_expert_ffn_q4k(
                 reinterpret_cast<const __nv_bfloat16*>(input), qbuf, num_tokens * hidden);
             q = qbuf;
         }
-        if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 768 && top_k == 8)
+        if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
+            gate_up_mmvq2_pack2_qwen_kernel<2048, 512, 8><<<(num_tokens * top_k * ffn + 1) / 2, 8 * 32, 0, stream>>>(
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, num_tokens * top_k * ffn);
+        else if (gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
+            gate_up_mmvq2_qwen_kernel<2048, 512, 8><<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
+        else if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 768 && top_k == 8)
             gate_up_mmvq2_pack2_qwen_kernel<2048, 768, 8><<<(num_tokens * top_k * ffn + 1) / 2, 8 * 32, 0, stream>>>(
                 q, reinterpret_cast<const unsigned char*>(gate_q),
                 reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, num_tokens * top_k * ffn);
@@ -1112,8 +1057,6 @@ void launch_moe_expert_ffn_q4k(
         return;
     }
 
-    // Split-K down (4 warps/row) fills SMs on the Q6_K expert-down GEMV — default ON after
-    // nsys showed routed MoE down under-occupies at bs=1. SPARKINFER_SPLITK=0 restores one-warp/row.
     static int splitk = -1;
     if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '0') ? 0 : 1; }
     static int pdl = -1;
@@ -1143,6 +1086,34 @@ void launch_moe_expert_ffn_q4k(
             expert_ids, expert_weights, h_scratch,
             reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, down_type);
     }
+}
+
+// Qwen3.6 UD shared expert: Q8_0 weights + int8 dp4a MMVQ (reuses FNQ Q8_1(hn)).
+// input_q8 may be overwritten with Q8_1(h) after gate/up. h_scratch: [ffn] fp32.
+void launch_shared_expert_q8_mmvq(
+    const void* input, const void* input_q8,
+    const void* gate_q, const void* up_q, const void* down_q,
+    const float* dw, void* output, float* h_scratch, void* h_q8_buf,
+    int hidden, int ffn, cudaStream_t stream) {
+    const si_block_q8_1* vy;
+    si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(h_q8_buf);
+    if (input_q8) {
+        vy = reinterpret_cast<const si_block_q8_1*>(input_q8);
+    } else {
+        si_quant_bf16_q8_1<<<(hidden >> 5), 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(input), qbuf, hidden);
+        vy = qbuf;
+    }
+    shared_gate_up_q8_mmvq_kernel<2048, 512><<<ffn, 4 * 32, 0, stream>>>(
+        vy, reinterpret_cast<const unsigned char*>(gate_q),
+        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    const int nqb = ffn >> 5;
+    quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
+        h_scratch, qbuf, nqb, 0);
+    dim3 dn((hidden + WPB - 1) / WPB);
+    shared_down_q8_mmvq_kernel<2048, 512><<<dn, WPB * 32, 0, stream>>>(
+        qbuf, reinterpret_cast<const unsigned char*>(down_q),
+        reinterpret_cast<__nv_bfloat16*>(output));
 }
 #endif
 

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -972,8 +972,10 @@ void launch_moe_expert_ffn_q4k(
         return;
     }
 
+    // Split-K down (4 warps/row) fills SMs on the Q6_K expert-down GEMV — default ON after
+    // nsys showed routed MoE down under-occupies at bs=1. SPARKINFER_SPLITK=0 restores one-warp/row.
     static int splitk = -1;
-    if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '1') ? 1 : 0; }
+    if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '0') ? 0 : 1; }
     static int pdl = -1;
     if (pdl < 0) { const char* pv = getenv("SPARKINFER_PDL"); pdl = (pv && pv[0] == '1') ? 1 : 0; }
     if (splitk) {   // split-K down: 4 warps/row -> 4x warps in flight (occupancy lever)

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -41,6 +41,52 @@ __device__ __forceinline__ void si_pdl_sync() {
 #endif
 }
 
+// cp.async weight staging for the MMVQ MoE down (sm_80+). Inline PTX — header-free,
+// NVRTC-safe. 16-byte .cg copies require 16-byte-aligned global sources; Q6_K
+// blocks are 210 B so only kbx==0 tiles are cp.async-eligible — the pipe kernel
+// falls back to a warp sync-copy for misaligned tiles (same bytes, still correct).
+constexpr int MOE_Q6K_CP = 14;   // 14*16 = 224 B staging (Q6_K block is 210 B)
+constexpr int MOE_Q6K_ST = 224;
+
+__device__ __forceinline__ void moe_cp_async_cg16(void* smem, const void* gmem) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+    const unsigned s = static_cast<unsigned>(__cvta_generic_to_shared(smem));
+    asm volatile("cp.async.cg.shared.global [%0], [%1], 16;\n" :: "r"(s), "l"(gmem));
+#else
+    (void)smem; (void)gmem;
+#endif
+}
+__device__ __forceinline__ void moe_cp_async_commit() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+    asm volatile("cp.async.commit_group;\n");
+#endif
+}
+__device__ __forceinline__ void moe_cp_async_wait_0() {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800)
+    asm volatile("cp.async.wait_group 0;\n");
+#endif
+}
+__device__ __forceinline__ bool moe_gmem16_aligned(const void* p) {
+    return (reinterpret_cast<size_t>(p) & 15) == 0;
+}
+__device__ __forceinline__ void moe_cp_q6k_block(unsigned char* dst, const unsigned char* src, int lane) {
+    if (lane < MOE_Q6K_CP) moe_cp_async_cg16(dst + lane * 16, src + lane * 16);
+}
+__device__ __forceinline__ void moe_stage_q6k_warp(unsigned char* dst, const unsigned char* src, int lane) {
+    for (int b = lane; b < 210; b += 32) dst[b] = src[b];
+    __syncwarp();
+}
+// Returns true when cp.async was issued (caller must wait before reading dst).
+__device__ __forceinline__ bool moe_stage_q6k_tile(unsigned char* dst, const unsigned char* src, int lane) {
+    if (moe_gmem16_aligned(src)) {
+        moe_cp_q6k_block(dst, src, lane);
+        moe_cp_async_commit();
+        return true;
+    }
+    moe_stage_q6k_warp(dst, src, lane);
+    return false;
+}
+
 __device__ __forceinline__ float q4kf_h2f(const unsigned char* p) {
     __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
 }
@@ -621,6 +667,69 @@ __global__ void down_q6k_mmvq_splitk_kernel(
     }
 }
 
+// cp.async double-buffered variant of down_q6k_mmvq_splitk_kernel. While the warp
+// dp4a's the current (expert, superblock) Q6_K tile from shared, the next tile for
+// this warp is prefetched — hiding the global weight latency on the occupancy-bound
+// bs=1 down. Math is identical (same si_vec_dot_q6_K on the same bytes).
+template <int S>
+__global__ void down_q6k_mmvq_splitk_cp_kernel(
+    const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
+    const float* __restrict__ expert_weights, const si_block_q8_1* __restrict__ hq8,
+    __nv_bfloat16* __restrict__ output, int H, int F, int top_k, int pdl
+) {
+    if (pdl) si_pdl_sync();
+    constexpr int RPB = WPB / S;
+    __shared__ float s_part[RPB][S];
+    __shared__ __align__(16) unsigned char s_q6[WPB][2 * MOE_Q6K_ST];
+    const int token = blockIdx.x, lane = threadIdx.x & 31, warpId = threadIdx.x >> 5;
+    const int hh_local = warpId / S, split = warpId % S;
+    const int hh = blockIdx.y * RPB + hh_local;
+    const int nblk = F >> 8, q8pb = F >> 5;
+    unsigned char* wbuf = s_q6[warpId];
+    float acc = 0.f;
+    if (hh < H) {
+        const int total = top_k * nblk;
+        const int nwi = (total - 1 - split) / S + 1;
+        bool pref_async = false;
+        for (int ii = 0; ii < nwi; ii++) {
+            const int wi = split + ii * S;
+            const int j = wi / nblk, kbx = wi % nblk;
+            const int ts = token * top_k + j, e = expert_ids[ts];
+            const float w = expert_weights[ts];
+            const unsigned char* gblk = down_q + ((size_t)e * H + hh) * nblk * 210 + (size_t)kbx * 210;
+            const si_block_q8_1* h8 = hq8 + (size_t)ts * q8pb;
+            const int cur = ii & 1;
+            if (ii == 0) {
+                if (moe_stage_q6k_tile(wbuf + cur * MOE_Q6K_ST, gblk, lane))
+                    moe_cp_async_wait_0();
+            } else if (pref_async) {
+                moe_cp_async_wait_0();
+            }
+            acc += w * si_vec_dot_q6_K(wbuf + cur * MOE_Q6K_ST, h8 + (size_t)kbx * 8, lane);
+            if (ii + 1 < nwi) {
+                const int wi_n = wi + S, jn = wi_n / nblk, kbx_n = wi_n % nblk;
+                const int ts_n = token * top_k + jn, e_n = expert_ids[ts_n];
+                const unsigned char* gblk_n = down_q + ((size_t)e_n * H + hh) * nblk * 210 + (size_t)kbx_n * 210;
+                const int nxt = cur ^ 1;
+                pref_async = moe_stage_q6k_tile(wbuf + nxt * MOE_Q6K_ST, gblk_n, lane);
+            } else {
+                pref_async = false;
+            }
+        }
+        if (pref_async) moe_cp_async_wait_0();
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+        if (lane == 0) s_part[hh_local][split] = acc;
+    }
+    __syncthreads();
+    if (hh < H && split == 0 && lane == 0) {
+        float o = 0.f;
+        #pragma unroll
+        for (int s = 0; s < S; s++) o += s_part[hh_local][s];
+        output[(size_t)token * H + hh] = __float2bfloat16(o);
+    }
+}
+
 template <int S>
 __global__ void down_q4k_mmvq_splitk_kernel(
     const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
@@ -789,6 +898,17 @@ static inline int down_mmvq_pdl() {
     return v;
 }
 
+// cp.async double-buffer on MMVQ MoE down weight reads. Opt-in (SPARKINFER_DOWN_CPASYNC=1)
+// because Q6_K blocks are 210 B (only kbx==0 tiles are 16B-aligned for cp.async).
+static inline int down_cpasync() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_DOWN_CPASYNC");
+        v = (e && e[0] == '1') ? 1 : 0;
+    }
+    return v;
+}
+
 template <typename Kernel, typename... Args>
 static inline void launch_mmvq_down_kernel(
     int pdl, dim3 grid, dim3 block, cudaStream_t stream, Kernel kernel, Args... args
@@ -821,15 +941,30 @@ static inline bool launch_down_q6k_mmvq_splitk(
     static int spec = -1;
     if (spec < 0) { const char* e = getenv("SPARKINFER_DOWN_SPEC"); spec = (e && e[0] == '0') ? 0 : 1; }
     const dim3 block(WPB * 32);
-    if (spec && S == 2 && F == 768 && top_k == 8) {
+    const int cp = down_cpasync();
+    if (spec && S == 2 && F == 512 && top_k == 8 && !cp) {
+        launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_qwen_kernel<2, 2, 8>,
+            down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+        return true;
+    }
+    if (spec && S == 2 && F == 768 && top_k == 8 && !cp) {
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_qwen_kernel<2, 3, 8>,
             down_q, expert_ids, expert_weights, hq8, output, H, pdl);
         return true;
     }
     switch (S) {
-        case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
-        case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
-        case 8: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+        case 2:
+            if (cp) launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_cp_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
+            else      launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
+            return true;
+        case 4:
+            if (cp) launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_cp_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
+            else      launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
+            return true;
+        case 8:
+            if (cp) launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_cp_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
+            else      launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<8>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl);
+            return true;
         default: return false;
     }
 }
@@ -841,6 +976,11 @@ static inline bool launch_down_q4k_mmvq_splitk(
     static int spec = -1;
     if (spec < 0) { const char* e = getenv("SPARKINFER_DOWN_SPEC"); spec = (e && e[0] == '0') ? 0 : 1; }
     const dim3 block(WPB * 32);
+    if (spec && S == 2 && F == 512 && top_k == 8) {
+        launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_qwen_kernel<2, 2, 8>,
+            down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+        return true;
+    }
     if (spec && S == 2 && F == 768 && top_k == 8) {
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_qwen_kernel<2, 3, 8>,
             down_q, expert_ids, expert_weights, hq8, output, H, pdl);

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -67,4 +67,12 @@ void launch_moe_expert_ffn_q4k(
     const void* input_q8 = nullptr,   // pre-quantized Q8_1(input) from the fused norm; nullptr = quantize internally
     cudaStream_t stream = nullptr);
 
+// Qwen3.6 UD shared expert: Q8_0 gate/up/down via int8 dp4a MMVQ. Reuses the FNQ
+// Q8_1(hn) buffer for gate/up; overwrites h_q8_buf with Q8_1(h) for down.
+void launch_shared_expert_q8_mmvq(
+    const void* input, const void* input_q8,
+    const void* gate_q, const void* up_q, const void* down_q,
+    const float* dw, void* output, float* h_scratch, void* h_q8_buf,
+    int hidden, int ffn, cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -26,10 +26,13 @@ struct Qwen35LayerWeights {
     const void* gate = nullptr;          // [n_experts, hidden, moe_ffn]
     const void* up   = nullptr;          // [n_experts, hidden, moe_ffn]
     const void* down = nullptr;          // [n_experts, moe_ffn, hidden]
-    const void* shared_gate = nullptr;   // [hidden, moe_ffn]
-    const void* shared_up   = nullptr;   // [hidden, moe_ffn]
-    const void* shared_down = nullptr;   // [moe_ffn, hidden]
+    const void* shared_gate = nullptr;   // bf16 dense fallback
+    const void* shared_up   = nullptr;
+    const void* shared_down = nullptr;
     const void* shared_gate_inp = nullptr;// [hidden] -> scalar shared-expert gate
+    // Qwen3.6 UD: shared expert stored as Q8_0 (on-read GEMV, ~2x less weight BW vs bf16).
+    const void* shared_gate_q = nullptr; const void* shared_up_q = nullptr; const void* shared_down_q = nullptr;
+    int shared_gate_qtype = 0, shared_up_qtype = 0, shared_down_qtype = 0;
 
     // Qwen3.5/Qwen3.6 Gated DeltaNet tensors (linear-attention layers only).
     const void* wqkv = nullptr;           // [hidden, q+k+v]

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -99,6 +99,8 @@ struct Qwen35Model::Impl {
     cudaStream_t stream{};
     cudaStream_t stream_k{}, stream_v{};         // side streams for concurrent K/V projection
     cudaEvent_t ev_qkv{}, ev_k{}, ev_v{};        // fork/join events (captured into the decode graph)
+    cudaEvent_t ev_pipe_fork{}, ev_gdn_z{}, ev_gdn_ab{};
+    cudaEvent_t ev_sx_gate{}, ev_sx_done{};
     uint64_t seq_id = 0;
     int qdim, kvdim;
     int linear_qdim = 0, linear_vdim = 0, linear_qkvdim = 0;
@@ -125,6 +127,8 @@ struct Qwen35Model::Impl {
     std::vector<void*> owned;   // device buffers from load_weights / load_gguf
     // GGUF fused-expert decode scratch (allocated by load_gguf)
     float *mf_logits = nullptr, *mf_weights = nullptr, *mf_h = nullptr, *mf_out = nullptr;
+    float *sx_h = nullptr;   // pipelined shared-expert h_scratch (avoids racing routed mf_h)
+    void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
     // flash-decoding (KV-split) attention partials
     static constexpr int MAX_NSPLITS = 256;   // partials sized for this; adaptive n_splits <= this
@@ -144,6 +148,8 @@ struct Qwen35Model::Impl {
     bool use_attnin = true;// default ON: single fused QK-norm+RoPE+KV-append (1 kernel vs qkfuse+ropekv=2). =0 disables
     bool use_fnq = true;   // default ON: post-MoE add_rmsnorm2 also emits Q8_1(xn), deleting the
                            // next layer's standalone QKV-input quantize node. =0 disables
+    bool use_gdn_pipe = true;   // default ON: overlap GDN gate/scalar projections on side streams. =0 disables
+    bool use_shexp_pipe = true; // default ON: overlap shared expert with routed MoE. =0 disables
 
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -172,6 +178,11 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     cudaEventCreateWithFlags(&p_->ev_qkv, cudaEventDisableTiming);
     cudaEventCreateWithFlags(&p_->ev_k, cudaEventDisableTiming);
     cudaEventCreateWithFlags(&p_->ev_v, cudaEventDisableTiming);
+    cudaEventCreateWithFlags(&p_->ev_pipe_fork, cudaEventDisableTiming);
+    cudaEventCreateWithFlags(&p_->ev_gdn_z, cudaEventDisableTiming);
+    cudaEventCreateWithFlags(&p_->ev_gdn_ab, cudaEventDisableTiming);
+    cudaEventCreateWithFlags(&p_->ev_sx_gate, cudaEventDisableTiming);
+    cudaEventCreateWithFlags(&p_->ev_sx_done, cudaEventDisableTiming);
     const int H = cfg.hidden;
     p_->x=p_->alloc<bf16>(H); p_->xn=p_->alloc<bf16>(H);
     p_->q=p_->alloc<bf16>(p_->qdim); p_->k=p_->alloc<bf16>(p_->kvdim); p_->v=p_->alloc<bf16>(p_->kvdim);
@@ -214,6 +225,10 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->mf_counts  = p_->alloc<int>(cfg.n_experts);
     p_->mf_h       = p_->alloc<float>((size_t)cfg.top_k * cfg.moe_ffn);
     p_->mf_out     = p_->alloc<float>(cfg.hidden);
+    if (cfg.n_shared > 0) {
+        p_->sx_h  = p_->alloc<float>(cfg.moe_ffn);
+        p_->sx_q8 = p_->alloc<char>(kernels::llama_q8_1_bytes(cfg.moe_ffn));
+    }
     const size_t fa_n = (size_t)cfg.n_q_heads * Impl::MAX_NSPLITS;   // sized for the adaptive max
     p_->fa_m   = p_->alloc<float>(fa_n);
     p_->fa_l   = p_->alloc<float>(fa_n);
@@ -231,6 +246,8 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKVSTREAM")) p_->use_qkvstream = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ATTNIN")) p_->use_attnin = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_GDN_PIPE")) p_->use_gdn_pipe = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_SHEXP_PIPE")) p_->use_shexp_pipe = !(e[0] == '0');
 }
 
 Qwen35Model::~Qwen35Model() {
@@ -249,11 +266,14 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->lin_gdn); cudaFree(p_->lin_norm); cudaFree(p_->lin_conv_state); cudaFree(p_->lin_state);
     cudaFree(p_->shared_gate_tmp);
     cudaFree(p_->mf_logits); cudaFree(p_->mf_weights); cudaFree(p_->mf_h); cudaFree(p_->mf_out);
+    cudaFree(p_->sx_h); cudaFree(p_->sx_q8);
     cudaFree(p_->mf_ids); cudaFree(p_->mf_counts);
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
     if (p_->graph_ready) { cudaGraphExecDestroy(p_->cu_exec); cudaGraphDestroy(p_->cu_graph); }
     cudaEventDestroy(p_->ev_qkv); cudaEventDestroy(p_->ev_k); cudaEventDestroy(p_->ev_v);
+    cudaEventDestroy(p_->ev_pipe_fork); cudaEventDestroy(p_->ev_gdn_z); cudaEventDestroy(p_->ev_gdn_ab);
+    cudaEventDestroy(p_->ev_sx_gate); cudaEventDestroy(p_->ev_sx_done);
     cudaStreamDestroy(p_->stream_v); cudaStreamDestroy(p_->stream_k);
     cudaStreamDestroy(p_->stream);
     delete p_;
@@ -385,10 +405,23 @@ int Qwen35Model::forward_token(int token_id, int position) {
             const bool any_q6k = (w.wqkv_type == 14 || w.wqkv_gate_type == 14 ||
                                   w.ssm_alpha_type == 14 || w.ssm_beta_type == 14);
             prepare_xn_quant(any_q4k, any_q6k);
-            proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
-            proj_xn(w.wqkv_gate, w.wqkv_gate_type, s.lin_z, s.linear_vdim, st);
-            proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
-            proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
+            const bool gdn_pipelined = s.gguf && s.use_gdn_pipe;
+            if (gdn_pipelined) {
+                cudaEventRecord(s.ev_pipe_fork, st);
+                cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
+                cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
+                proj_xn(w.wqkv_gate, w.wqkv_gate_type, s.lin_z, s.linear_vdim, s.stream_k);
+                cudaEventRecord(s.ev_gdn_z, s.stream_k);
+                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, s.stream_v);
+                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, s.stream_v);
+                cudaEventRecord(s.ev_gdn_ab, s.stream_v);
+                proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
+            } else {
+                proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
+                proj_xn(w.wqkv_gate, w.wqkv_gate_type, s.lin_z, s.linear_vdim, st);
+                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
+                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
+            }
 
             bf16* conv_state = s.lin_conv_state +
                 (size_t)L * (c.linear_conv_kernel - 1) * s.linear_qkvdim;
@@ -397,6 +430,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                                  c.linear_q_heads, c.linear_v_heads,
                                                  c.linear_head_dim, c.linear_conv_kernel,
                                                  c.rms_eps, st);
+            if (gdn_pipelined) cudaStreamWaitEvent(st, s.ev_gdn_ab, 0);
             float* layer_state = s.lin_state +
                 (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;
             kernels::launch_qwen36_gdn_ar(s.lin_q, s.lin_k, s.lin_v,
@@ -404,6 +438,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                           layer_state, s.lin_gdn,
                                           c.linear_q_heads, c.linear_v_heads,
                                           c.linear_head_dim, st);
+            if (gdn_pipelined) cudaStreamWaitEvent(st, s.ev_gdn_z, 0);
             kernels::launch_qwen36_gated_norm(s.lin_gdn, s.lin_z, w.ssm_norm, s.lin_norm,
                                               c.linear_v_heads, c.linear_head_dim, c.rms_eps, st);
             proj_from(s.lin_norm, w.ssm_out, w.ssm_out_type, s.ao, H, s.linear_vdim);
@@ -508,6 +543,52 @@ int Qwen35Model::forward_token(int token_id, int position) {
         else
             kernels::launch_add_rmsnorm2(s.x, s.ao, w.post_attn_norm, s.h, s.hn, 1, H, c.rms_eps, st);
 
+        const bool qmoe = w.shared_gate_q && w.shared_up_q && w.shared_down_q
+                       && w.shared_gate_qtype == 8 && c.hidden == 2048 && c.moe_ffn == 512;
+        const bool shexp_pipelined = (c.n_shared > 0) && s.gguf && s.use_shexp_pipe;
+        if (shexp_pipelined) {
+            cudaEventRecord(s.ev_pipe_fork, st);
+            cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
+            cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
+            if (w.shared_gate_inp) {
+                if (s.use_pq && w.shared_gate_inp_type == 12) {
+                    if (s.use_llama) {
+                        if (!fnq) kernels::launch_quantize_q8_1_blocks(s.hn, s.aq81, H, s.stream_k);
+                        kernels::launch_mmvq_q4k(s.aq81, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                    } else {
+                        kernels::launch_quantize_q8_1(s.hn, s.aq8, s.aq8_d, s.aq8_s, H, s.stream_k);
+                        kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s,
+                                                        w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                    }
+                } else if (s.use_pq && s.use_llama && s.use_q6mmvq && w.shared_gate_inp_type == 14) {
+                    if (!fnq) kernels::launch_quantize_q8_1_blocks(s.hn, s.aq81, H, s.stream_k);
+                    kernels::launch_mmvq_q6k(s.aq81, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                } else if (w.shared_gate_inp_type) {
+                    kernels::launch_gemv_q(s.hn, w.shared_gate_inp, w.shared_gate_inp_type,
+                                           s.shared_gate_tmp, 1, H, s.stream_k);
+                } else {
+                    kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                }
+                kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
+            }
+            if (qmoe) {
+                kernels::launch_shared_expert_q8_mmvq(
+                    s.hn, fnq ? s.aq81 : nullptr,
+                    w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                    w.shared_gate_inp ? s.d_shared_w : nullptr,
+                    s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k);
+            } else {
+                kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, s.stream_k);
+                kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, s.stream_v);
+                cudaEventRecord(s.ev_sx_gate, s.stream_v);
+                cudaStreamWaitEvent(s.stream_k, s.ev_sx_gate, 0);
+                kernels::launch_qwen36_shared_swiglu(s.sh_gate, s.sh_up, s.d_shared_w,
+                                                     s.sh_h, c.moe_ffn, s.stream_k);
+                kernels::launch_gemv(s.sh_h, w.shared_down, s.shared, H, c.moe_ffn, s.stream_k);
+            }
+            cudaEventRecord(s.ev_sx_done, s.stream_k);
+        }
+
         if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
             kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
             // The per-expert token counts only feed the batched-dispatch sort; the single-token
@@ -531,6 +612,16 @@ int Qwen35Model::forward_token(int token_id, int position) {
             s.engine->forward(s.hn, s.routed, 1, L, st);
         }
         if (c.n_shared > 0) {
+            if (shexp_pipelined) {
+                cudaStreamWaitEvent(st, s.ev_sx_done, 0);
+                launch_residual_add(s.routed, s.shared, s.routed, H, st);
+                const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
+                if (fnq)
+                    kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+                else
+                    kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                continue;
+            }
             if (w.shared_gate_inp) {
                 if (s.gguf) {
                     if (s.use_pq && w.shared_gate_inp_type == 12) {
@@ -556,14 +647,18 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
             }
             if (s.gguf) {
-                // Shared expert as three coalesced GEMVs (one warp/row, full grid) instead of
-                // the single-block moe_expert_ffn kernel (1 SM, ~961us/layer -> the decode wall).
-                // gate/up: [ffn]=hn@shared_{gate,up}^T; SwiGLU folds the gate scalar d_shared_w;
-                // down: [H]=h@shared_down^T. GGUF-native [out,in] layout (see load_gguf).
-                kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, st);
-                kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, st);
-                kernels::launch_qwen36_shared_swiglu(s.sh_gate, s.sh_up, s.d_shared_w, s.sh_h, c.moe_ffn, st);
-                kernels::launch_gemv(s.sh_h, w.shared_down, s.shared, H, c.moe_ffn, st);
+                if (qmoe) {
+                    kernels::launch_shared_expert_q8_mmvq(
+                        s.hn, fnq ? s.aq81 : nullptr,
+                        w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                        w.shared_gate_inp ? s.d_shared_w : nullptr,
+                        s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st);
+                } else {
+                    kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, st);
+                    kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, st);
+                    kernels::launch_qwen36_shared_swiglu(s.sh_gate, s.sh_up, s.d_shared_w, s.sh_h, c.moe_ffn, st);
+                    kernels::launch_gemv(s.sh_h, w.shared_down, s.shared, H, c.moe_ffn, st);
+                }
             } else {
                 // set_weights path: shared weights are [hidden,ffn]/[ffn,hidden] dense.
                 kernels::launch_moe_expert_ffn(s.hn, w.shared_gate, w.shared_up, w.shared_down,
@@ -915,11 +1010,23 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 !expect_dims_opt(b + "ffn_gate_inp_shexp.weight", {H})) return false;
             // GGUF-native [out,in] layout (no transpose) so the shared expert runs as
             // three fast one-warp-per-row GEMVs instead of the single-block dense kernel.
-            w.shared_gate = dense(b + "ffn_gate_shexp.weight", false);   // [ffn, H]
-            w.shared_up   = dense(b + "ffn_up_shexp.weight", false);     // [ffn, H]
-            w.shared_down = dense(b + "ffn_down_shexp.weight", false);   // [H, ffn]
+            const bool qmoe = []{ const char* a = getenv("SPARKINFER_QMOE");
+                                   return !(a && a[0] == '0'); }();
+            if (qmoe) {
+                w.shared_gate_q = dev_quant(b + "ffn_gate_shexp.weight", w.shared_gate_qtype);
+                w.shared_up_q   = dev_quant(b + "ffn_up_shexp.weight",   w.shared_up_qtype);
+                w.shared_down_q = dev_quant(b + "ffn_down_shexp.weight", w.shared_down_qtype);
+            }
+            if (!qmoe || !w.shared_gate_q || !w.shared_up_q || !w.shared_down_q ||
+                w.shared_gate_qtype != 8) {
+                w.shared_gate = dense(b + "ffn_gate_shexp.weight", false);
+                w.shared_up   = dense(b + "ffn_up_shexp.weight", false);
+                w.shared_down = dense(b + "ffn_down_shexp.weight", false);
+            }
             w.shared_gate_inp = attn_w_opt(b + "ffn_gate_inp_shexp.weight", w.shared_gate_inp_type);
-            if (!w.shared_gate || !w.shared_up || !w.shared_down) return false;
+            const bool have_shared_q = w.shared_gate_q && w.shared_up_q && w.shared_down_q;
+            const bool have_shared_d = w.shared_gate && w.shared_up && w.shared_down;
+            if (!have_shared_q && !have_shared_d) return false;
         }
         const bool have_attn = w.linear_attn
             ? (w.wqkv && w.wqkv_gate && w.ssm_conv && w.ssm_dt && w.ssm_a &&


### PR DESCRIPTION
## Summary

Qwen3.6 decode stack for UD-Q4_K_M on RTX 5090:

| Change | Effect |
|--------|--------|
| **Q8_0 int8 MMVQ** (attention/GDN/O projections) | Keep weights native int8; dp4a instead of bf16 GEMV (~60% of decode) |
| **Q8_0 shared-expert int8 MMVQ** | Replaces 3 bf16 GEMVs/layer |
| **GDN + shared-expert stream pipelining** | Overlap projections and shared expert with routed MoE |
| **F=512 MoE specialists** | gate/up pack2 + down qwen kernels |
| **GDN warp-grid + fused Q/K L2** | Better occupancy on 30 GDN layers |
| **head_dim=256 GQA flash split** | Faster KV reads on 10 full-attention layers |
| **split-K default ON** | fp MoE down fallback occupancy |

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench`, `SPARKINFER_BENCH_DEVICE_LOOP=0`, Qwen3.6-35B-A3B-UD-Q4_K_M):

| | decode tok/s |
|---|--:|
| before (main) | 248.06 |
| after (this PR) | 355.68 |

Multi-context (n=128 prompt tokens):

| ctx | main | this PR | delta |
|-----|-----:|--------:|------:|
| 128 | ~254 | **~366** | **+44%** |
| 512 | ~253 | **~364** | +44% |
| 4096 | ~240 | **~356** | +43% |
| 16k | ~221 | **~337** | +52% |

```text
# main @4096 ctx=128
decode tg    : 248.06 tok/s  (4.0 ms/token, n=4096, ctx=128, bs=1)
VRAM used    : 25.1 GB

# PR 479747f @4096 ctx=128
decode tg    : 355.68 tok/s  (2.8 ms/token, n=4096, ctx=128, bs=1)
VRAM used    : 24.0 GB

# PR @128
decode tg    : 366.51 tok/s  (2.7 ms/token, n=128, ctx=128, bs=1)
```

Correctness: `qwen3_gguf_generate` token IDs match pre-Q8_0 baseline on prompts 1, 151643, 8948.