### PR TITLE
perf(qwen36): Q8_0→Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1241,7 +1241,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     const std::string attn_requant_mode =
         attn_env ? std::string(attn_env)
                  : (q35_dense9b_requant_default ? std::string("qkv")
-                    : (q36_ud_requant_default ? std::string("attn_q,attn_output") : std::string()));
+                    : (q36_ud_requant_default ? std::string("attn_q,attn_output,qkv,attn_gate") : std::string()));
     auto mode_token = [&](const char* want) {
         const std::string w(want);
         size_t p = 0;
@@ -1325,6 +1325,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if ((mode_token("k") || mode_token("attn_k")) && has_suffix(name, "attn_k.weight")) return true;
         if ((mode_token("o") || mode_token("out") || mode_token("attn_output")) &&
             has_suffix(name, "attn_output.weight")) return true;
+        // Qwen3.6 GDN input projections ship Q8_0 (the single largest per-token weight read):
+        // attn_qkv (wqkv, handled by the "qkv" token above) + attn_gate (the z gate). Requant
+        // both to Q4_K so they route through the existing Q4_K fused GDN qkv+z kernel (~47% fewer
+        // bytes). SPARKINFER_ATTN_REQUANT_Q4K=attn_q,attn_output restores the #353-only behavior.
+        if (mode_token("attn_gate") && has_suffix(name, "attn_gate.weight")) return true;
         return false;
     };
     const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K", q35_dense9b_requant_default);


### PR DESCRIPTION
## Summary

Load-time **Q8_0 → Q4_K requant of the Qwen3.6 Gated-DeltaNet *input* projections** — `attn_qkv` (wqkv) and `attn_gate` (the z gate), shipped Q8_0 on all 30 GDN layers. These are the single largest per-token weight read in decode — larger than the full-attention q/o requantized by #353 or the `ssm_out` of #355. This extends the merged #353 requant path to these two tensors, reading ~47% fewer bytes on those matvecs. Gated to the Qwen3.6 fingerprint; a strict no-op on every other model.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench`, Qwen3.6-35B-A3B UD-Q4_K_M, same-box A/B):

| | decode tok/s |
|---|--:|
| before (main) | 437.70 |
| after (this PR) | 487.96 |

<!-- headline pair above is ctx=128 (base scored context); full sweep below -->

```text
# Qwen3.6-35B-A3B-UD-Q4_K_M — RTX 5090, same-binary A/B via env toggle
#   before = SPARKINFER_ATTN_REQUANT_Q4K=attn_q,attn_output   (main / #353-only, GDN input stays Q8_0)
#   after  = default                                          (adds qkv,attn_gate)
ctx=128    before 437.70   after 487.96   +11.48%
ctx=4096   before 415.79   after 461.19   +10.92%
ctx=16384  before 410.65   after 455.78   +10.99%
ctx=32768  before 394.31   after 433.94   +10.05%
```

## Correctness

The GDN input projections feed the recurrent state, so the lossy Q4_K fit was validated carefully. Natural text (Project-Gutenberg-style corpus), 1500 teacher-forced positions, this PR (Q4_K) vs main (Q8_0):

```text
top-1 agreement : 1444/1499 = 96.3%   (gate >= 0.90)
KL(Q8_0 || Q4_K): 0.021                (gate <= 0.20)
PPL             : 2.820  vs  2.788 (Q8_0)   (+1.15%)
```

All 30 GDN layers stay inside the accuracy gate with ~10x margin because the fit reuses the merged **Lloyd-max coordinate-descent Q4_K quantizer** (`proj_q4k_lloyd.cu`, from #353). A plain affine fit is not accuracy-safe at full layer coverage on this tensor. `SPARKINFER_ATTN_REQUANT_Q4K=attn_q,attn_output` restores the #353-only behavior for A/B.

## Changes

- `runtime/src/models/qwen35.cpp` only (+6/-1): extends the Qwen3.6 default `SPARKINFER_ATTN_REQUANT_Q4K` mode to `attn_q,attn_output,qkv,attn_gate` and adds the `attn_gate` handler to `req_attn_q4`. No new kernel — after the stored type flips to Q4_K, the GDN qkv+z projection site already branches on tensor type and routes through the existing `launch_mmvq_gdn_qkv_z_pack2` (Q4_K fused) path automatically.

## Test plan

- [x] Build `qwen3_gguf_bench` + `qwen3_gguf_score` on RTX 5090 (`sm_120`)
- [x] Same-box A/B at 128/4096/16384/32768 ctx (default vs `attn_q,attn_output`)
- [x] Natural-text top-1/KL vs the Q8_0 baseline over 1500 teacher-forced positions
- [x] No-op confirmed on non-matching models (gated to the Qwen3.6 fingerprint)
