### PR TITLE
perf(gemv): Q8_0 on-read GEMV with split-K for native Q8_0 projection…

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -174,6 +174,78 @@ __global__ void gemv_q_kernel(const __nv_bfloat16* __restrict__ x,
 template __global__ void gemv_q_kernel<__nv_bfloat16>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int, int);
 template __global__ void gemv_q_kernel<float>(const __nv_bfloat16*, const unsigned char*, float*, int, int, int);
 
+// ---- Q8_0 on-read GEMV (W = Q8_0 [N,K]) ------------------------------------
+// Q8_0 block = 34 B / 32 values: one fp16 scale d, then 32 signed int8.
+// Dequant-on-read (d*int8) dotted with the fp32 activation — reads the int8
+// weight bytes (~2x less than bf16) with NO shared-memory staging. The activation
+// x[K] is read straight from L2/L1 (no smem + __syncthreads overhead), making
+// this kernel latency-competitive for moderate K where smem staging would dominate.
+// One warp per output row (lane j owns value j of each block). K % 32 == 0.
+template <typename OutT>
+__global__ void gemv_q80_kernel(const __nv_bfloat16* __restrict__ x,
+                                const unsigned char* __restrict__ W,
+                                OutT* __restrict__ y, int N, int K) {
+    const int warp = threadIdx.x / 32, lane = threadIdx.x & 31;
+    const int n = blockIdx.x * GEMV_WPB + warp;
+    if (n >= N) return;
+    const int nblk = K / 32;                        // Q8_0: 32 values / block
+    const unsigned char* base = W + (size_t)n * nblk * 34;
+    float acc = 0.f;
+    for (int blk = 0; blk < nblk; blk++) {
+        const unsigned char* b = base + (size_t)blk * 34;
+        const float d = gq_h2f(b);                  // fp16 block scale
+        const signed char q = reinterpret_cast<const signed char*>(b + 2)[lane];
+        acc += d * (float)q * __bfloat162float(x[blk * 32 + lane]);
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) gemv_write(y + n, acc);
+}
+template __global__ void gemv_q80_kernel<__nv_bfloat16>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void gemv_q80_kernel<float>(const __nv_bfloat16*, const unsigned char*, float*, int, int);
+
+// split-K Q8_0 GEMV: S warps cooperate per output row, each summing a 1/S stride
+// of the K reduction. Same occupancy lever as the bf16 split-K kernel (gemv_f32_sk_kernel)
+// but reads Q8_0 int8 weights (2x less than bf16). No smem staging for x -- x is read
+// straight from L2 coalesced per warp. RPB = GEMV_WPB/S rows per block.
+template <typename OutT, int S>
+__global__ void gemv_q80_sk_kernel(const __nv_bfloat16* __restrict__ x,
+                                    const unsigned char* __restrict__ W,
+                                    OutT* __restrict__ y, int N, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float s_part[RPB][S];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n = blockIdx.x * RPB + row_local;
+    float acc = 0.f;
+    if (n < N) {
+        const int nblk = K / 32;
+        const unsigned char* base = W + (size_t)n * nblk * 34;
+        for (int blk = split; blk < nblk; blk += S) {
+            const unsigned char* b = base + (size_t)blk * 34;
+            const float d = gq_h2f(b);
+            const signed char q = reinterpret_cast<const signed char*>(b + 2)[lane];
+            acc += d * (float)q * __bfloat162float(x[blk * 32 + lane]);
+        }
+    }
+    if (n < N) s_part[row_local][split] = acc;
+    __syncthreads();
+    if (n < N) {
+        acc = 0.f;
+        #pragma unroll
+        for (int s = 0; s < S; s++) acc += s_part[row_local][s];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+        if (lane == 0) gemv_write(y + n, acc);
+    }
+}
+template __global__ void gemv_q80_sk_kernel<__nv_bfloat16, 2>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void gemv_q80_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void gemv_q80_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void gemv_q80_sk_kernel<float, 2>(const __nv_bfloat16*, const unsigned char*, float*, int, int);
+template __global__ void gemv_q80_sk_kernel<float, 4>(const __nv_bfloat16*, const unsigned char*, float*, int, int);
+template __global__ void gemv_q80_sk_kernel<float, 8>(const __nv_bfloat16*, const unsigned char*, float*, int, int);
+
 // ---- faithful llama.cpp int8 MMVQ for a dense Q4_K [N,K] GEMV --------------------
 // Quantizes the activation to Q8_1 (int8 + per-32 scale + sum) once per token, then
 // dp4a's the Q4_K weight nibbles against it — the same vec_dot_q4_K_q8_1 math llama.cpp
@@ -675,6 +747,26 @@ void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int 
         gemv_q_dp4a_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, sm, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), N, K);
+    } else if (wtype == 8) {            // Q8_0: split-K or 1-warp-per-row
+        if (gemv_bf16_splitk() && (K & 31) == 0 && N < 16384) {
+            const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+            const auto* Wp = reinterpret_cast<const unsigned char*>(W);
+            auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
+            if (N >= 8192) {
+                constexpr int S = 2, RPB = GEMV_WPB / S;
+                gemv_q80_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, Wp, yp, N, K);
+            } else if (N >= 4096) {
+                constexpr int S = 4, RPB = GEMV_WPB / S;
+                gemv_q80_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, Wp, yp, N, K);
+            } else {
+                constexpr int S = 8, RPB = GEMV_WPB / S;
+                gemv_q80_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, Wp, yp, N, K);
+            }
+            return;
+        }
+        gemv_q80_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), N, K);
     } else {
         gemv_q_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
@@ -686,6 +778,24 @@ void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N,
     if (gemv_mmvq() && wtype == 12) {
         size_t sm = 2 * (size_t)(K >> 5) * sizeof(float) + (size_t)K;
         gemv_q_dp4a_kernel<float><<<grid, GEMV_WPB * 32, sm, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W), y, N, K);
+    } else if (wtype == 8) {            // Q8_0: split-K or 1-warp-per-row
+        if (gemv_bf16_splitk() && (K & 31) == 0 && N < 16384) {
+            const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+            const auto* Wp = reinterpret_cast<const unsigned char*>(W);
+            if (N >= 8192) {
+                constexpr int S = 2, RPB = GEMV_WPB / S;
+                gemv_q80_sk_kernel<float, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, Wp, y, N, K);
+            } else if (N >= 4096) {
+                constexpr int S = 4, RPB = GEMV_WPB / S;
+                gemv_q80_sk_kernel<float, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, Wp, y, N, K);
+            } else {
+                constexpr int S = 8, RPB = GEMV_WPB / S;
+                gemv_q80_sk_kernel<float, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, Wp, y, N, K);
+            }
+            return;
+        }
+        gemv_q80_kernel<float><<<grid, GEMV_WPB * 32, 0, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W), y, N, K);
     } else {
         gemv_q_kernel<float><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -206,8 +206,9 @@ template __global__ void gemv_q80_kernel<float>(const __nv_bfloat16*, const unsi
 
 // split-K Q8_0 GEMV: S warps cooperate per output row, each summing a 1/S stride
 // of the K reduction. Same occupancy lever as the bf16 split-K kernel (gemv_f32_sk_kernel)
-// but reads Q8_0 int8 weights (2x less than bf16). No smem staging for x -- x is read
-// straight from L2 coalesced per warp. RPB = GEMV_WPB/S rows per block.
+// but reads Q8_0 int8 weights (2x less than bf16). Each lane processes 8 blocks per
+// inner iteration (same amortized throughput as bf16's uint4-per-iteration). No smem
+// staging for x -- x is read straight from L2 coalesced per warp. RPB = GEMV_WPB/S.
 template <typename OutT, int S>
 __global__ void gemv_q80_sk_kernel(const __nv_bfloat16* __restrict__ x,
                                     const unsigned char* __restrict__ W,
@@ -221,22 +222,39 @@ __global__ void gemv_q80_sk_kernel(const __nv_bfloat16* __restrict__ x,
     if (n < N) {
         const int nblk = K / 32;
         const unsigned char* base = W + (size_t)n * nblk * 34;
-        for (int blk = split; blk < nblk; blk += S) {
-            const unsigned char* b = base + (size_t)blk * 34;
-            const float d = gq_h2f(b);
-            const signed char q = reinterpret_cast<const signed char*>(b + 2)[lane];
+        const int n_my = (nblk - split + S - 1) / S;    // blocks assigned to this split
+        const int ngroups = n_my >> 3;                    // full groups of 8
+        // Groups of 8 blocks — same amortised iteration count as bf16 uint4 path
+        for (int g = 0; g < ngroups; g++) {
+            const int blk0 = split + g * (8 * S);
+            #pragma unroll
+            for (int b = 0; b < 8; b++) {
+                const int blk = blk0 + b * S;
+                const unsigned char* bb = base + (size_t)blk * 34;
+                const float d = gq_h2f(bb);
+                const signed char q = reinterpret_cast<const signed char*>(bb + 2)[lane];
+                acc += d * (float)q * __bfloat162float(x[blk * 32 + lane]);
+            }
+        }
+        // Tail: any remaining blocks (< 8)
+        #pragma unroll
+        for (int b = ngroups * 8; b < n_my; b++) {
+            const int blk = split + b * S;
+            const unsigned char* bb = base + (size_t)blk * 34;
+            const float d = gq_h2f(bb);
+            const signed char q = reinterpret_cast<const signed char*>(bb + 2)[lane];
             acc += d * (float)q * __bfloat162float(x[blk * 32 + lane]);
         }
-    }
-    if (n < N) s_part[row_local][split] = acc;
-    __syncthreads();
-    if (n < N) {
-        acc = 0.f;
-        #pragma unroll
-        for (int s = 0; s < S; s++) acc += s_part[row_local][s];
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
-        if (lane == 0) gemv_write(y + n, acc);
+        if (lane == 0) s_part[row_local][split] = acc;
+    }
+    __syncthreads();
+    if (n < N && split == 0 && lane == 0) {
+        float o = s_part[row_local][0];
+        #pragma unroll
+        for (int s = 1; s < S; s++) o += s_part[row_local][s];
+        gemv_write(y + n, o);
     }
 }
 template __global__ void gemv_q80_sk_kernel<__nv_bfloat16, 2>(const __nv_bfloat16*, const unsigned char*, __nv_bfloat16*, int, int);
@@ -747,8 +765,8 @@ void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int 
         gemv_q_dp4a_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, sm, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), N, K);
-    } else if (wtype == 8) {            // Q8_0: split-K or 1-warp-per-row
-        if (gemv_bf16_splitk() && (K & 31) == 0 && N < 16384) {
+    } else if (wtype == 8) {            // Q8_0: split-K (fill GPU) or 1-warp
+        if (gemv_bf16_splitk() && N < 16384) {
             const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
             const auto* Wp = reinterpret_cast<const unsigned char*>(W);
             auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
@@ -779,8 +797,8 @@ void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N,
         size_t sm = 2 * (size_t)(K >> 5) * sizeof(float) + (size_t)K;
         gemv_q_dp4a_kernel<float><<<grid, GEMV_WPB * 32, sm, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const unsigned char*>(W), y, N, K);
-    } else if (wtype == 8) {            // Q8_0: split-K or 1-warp-per-row
-        if (gemv_bf16_splitk() && (K & 31) == 0 && N < 16384) {
+    } else if (wtype == 8) {            // Q8_0: split-K (fill GPU) or 1-warp
+        if (gemv_bf16_splitk() && N < 16384) {
             const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
             const auto* Wp = reinterpret_cast<const unsigned char*>(W);
             if (N >= 8192) {

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -46,10 +46,10 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K,
 void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K,
                      cudaStream_t stream = nullptr);
 
-// Quantized on-read GEMV: same as launch_gemv but W is GGUF-native Q4_K/Q6_K
-// [N,K] (wtype = ggml type id, 12=Q4_K / 14=Q6_K). Dequantizes each block in
+// Quantized on-read GEMV: same as launch_gemv but W is GGUF-native Q4_K/Q6_K/Q8_0
+// [N,K] (wtype = ggml type id, 12=Q4_K / 14=Q6_K / 8=Q8_0). Dequantizes each block in
 // registers with a full-precision (fp32) activation dot — reads the quantized
-// bytes (4x less than bf16) with no int8 activation, so token-match is preserved.
+// bytes (2-4x less than bf16) with no int8 activation, so token-match is preserved.
 void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int K,
                    cudaStream_t stream = nullptr);
 void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N, int K,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -908,13 +908,13 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                            return !(a && a[0] == '0'); }();
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
-        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
+        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8)) return dev_quant(name, type);
         type = 0; return dense(name, false);
     };
     auto attn_w_opt = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
         if (!t) { type = 0; return nullptr; }
-        if (qattn && (t->ggml_type == 12 || t->ggml_type == 14)) return dev_quant(name, type);
+        if (qattn && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8)) return dev_quant(name, type);
         type = 0; return dense(name, false);
     };
     auto dense_opt = [&](const std::string& name, bool transpose) -> const void* {


### PR DESCRIPTION
## Summary

Keep Q8_0 (ggml type 8) attention/GDN projection weights quantized in VRAM and decode them
on-read with a new no-smem split-K GEMV kernel, instead of the load-time Q8_0→bf16 dequant +
dense bf16 GEMV. The Q8_0 path halves the weight read bandwidth on projection GEMVs — the
single largest compute slice in Qwen3.6 decode after the GDN and expert optimizations landed.

Two kernels:
- `gemv_q80_kernel`: one warp per row, reads activation x straight from L2 (zero shared
  memory, no `__syncthreads` overhead)
- `gemv_q80_sk_kernel`: S=2/4/8 warps cooperate per row for GPU occupancy — same split-K
  lever as the bf16 GEMV. Processes 8 Q8_0 blocks per inner iteration to match bf16's
  uint4 throughput. Warp-reduce + lane-0 store (matching bf16 split-K pattern).

No new env vars — Q8_0 tensors follow the existing `SPARKINFER_QATTN` flag (default ON).
Token-match is preserved (fp32 accumulate of the exact Q8_0 value vs a bf16-rounded weight).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 315.0 |
| after (this PR) | 383.0 |

```text
Qwen3.6-35B-A3B-UD-Q4_K_M · RTX 5090 sm_120 · CUDA 13
SPARKINFER_GDN_FAST=1 (matching eval frontier)

main (before):
  ctx128:  315.0 tok/s
  ctx4096: 303.6 tok/s

this PR (after):
  ctx128:  383.0 tok/s  (+21.7%)
  ctx4096: 365.0 tok/s  (+20.1%)

Per-context:
| context | main (before) | this PR (after) | delta |
|---|--:|--:|--:|
| 128  | 315.0 | 383.0 | +21.7% |
| 4096 | 303.6 | 365.0 | +20.1% |
