### PR TITLE
perf(decode): pack2 MMVQ for attention Q4_K Wq and O projections

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -621,6 +621,43 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16>(const si_b
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
 
+// Pack-2 rows per CTA for attn Q4_K mmvq (faithful 4-warp math per row).
+// Wq (K=2048, N=4096): halves graph nodes on the largest Q projection.
+// Wo (K=4096, N=2048): halves O-proj launches; uses the full kfixed block loop when NSUPER=16.
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q4k_kfixed_pack2_kernel(const si_block_q8_1* __restrict__ vy,
+                                                const unsigned char* __restrict__ W,
+                                                OutT* __restrict__ y, int N) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, gw = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    if (row >= N) return;
+    const int tid4 = gw * WS + lane;
+    const si_block_q4_K* x_row = (const si_block_q4_K*)(W + (size_t)row * NSUPER * 144);
+    constexpr int blocks_per_iter = vdr * NW * WS / qi;
+    float tmp = 0.0f;
+    #pragma unroll
+    for (int kbx = tid4 / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+        const int kby = kbx * 8;
+        const int kqs = vdr * (tid4 % (qi / vdr));
+        tmp += si_vec_dot_q4_K(x_row + kbx, vy + kby, kqs);
+    }
+    __shared__ float s_acc[2][NW - 1][WS];
+    if (gw > 0) s_acc[group][gw - 1][lane] = tmp;
+    __syncthreads();
+    if (gw > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += s_acc[group][l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 8>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+
 // ===== faithful llama Q6_K mmvq for the fp32-path GEMVs (attn-V upgrades + LM head) =====
 // Same 4-warp-per-row structure as the Q4_K mmvq, with vec_dot_q6_K_q8_1 (coalesced
 // ql/qh int loads + __vsubss4 reconstruct + dp4a). Mirrors the #65 MoE-down dot.
@@ -939,18 +976,33 @@ void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t str
     si_quantize_q8_1_blocks<<<grid, warpsPB * 32, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<si_block_q8_1*>(y), K);
 }
+static int attn_pack2_enabled() {
+    static int v = -1;
+    if (v < 0) { const char* e = getenv("SPARKINFER_ATTN_PACK2"); v = (e && e[0] == '0') ? 0 : 1; }
+    return v;
+}
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
     __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
-    if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    const int pack2 = attn_pack2_enabled();
+    if (K == 2048 && pack2 && N >= 2048)
+        si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 8><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 4096 && pack2)
+        si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else                si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
-    if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    const int pack2 = attn_pack2_enabled();
+    if (K == 2048 && pack2 && N >= 2048)
+        si_mmvq_q4k_kfixed_pack2_kernel<float, 8><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, y, N);
+    else if (K == 4096 && pack2)
+        si_mmvq_q4k_kfixed_pack2_kernel<float, 16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, y, N);
+    else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1073,7 +1073,7 @@ void launch_mmvq_q4k_qkv_fused(const void* q81, const void* Wq, const void* Wk, 
     if (!attn_pack2_enabled() || K != 2048) {
         launch_mmvq_q4k(q81, Wq, yq, Nq, K, stream);
         launch_mmvq_q4k(q81, Wk, yk, Nk, K, stream);
-        launch_mmvq_q4k(q81, Wv, yv, Nv, K, stream);
+        if (Nv > 0) launch_mmvq_q4k(q81, Wv, yv, Nv, K, stream);
         return;
     }
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -658,6 +658,79 @@ template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 8>(const si_bloc
 template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
 template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
 
+// Fused Q+K+V pack2: stage the full Q8_1(xn) activation in smem once per CTA, then run the
+// faithful kfixed dot loop for all three projections. Cuts 2 DRAM passes over aq81 per layer
+// (the dominant cost of three separate mmvq launches at bs=1) while halving row launches.
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q4k_qkv_fused_pack2_kernel(
+    const si_block_q8_1* __restrict__ vy,
+    const unsigned char* __restrict__ Wq, const unsigned char* __restrict__ Wk,
+    const unsigned char* __restrict__ Wv,
+    OutT* __restrict__ yq, OutT* __restrict__ yk, OutT* __restrict__ yv,
+    int Nq, int Nk, int Nv
+) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    constexpr int NVB = NSUPER * 8;
+    __shared__ si_block_q8_1 s_vy[NVB];
+    const int tid = threadIdx.x;
+    const int n4 = (NVB * (int)sizeof(si_block_q8_1)) / 16;
+    for (int i = tid; i < n4; i += blockDim.x)
+        reinterpret_cast<uint4*>(s_vy)[i] = __ldg(reinterpret_cast<const uint4*>(vy) + i);
+    __syncthreads();
+
+    const int lane = tid & 31, warp = tid >> 5;
+    const int group = warp >> 2, gw = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    const bool do_q = row < Nq, do_k = row < Nk, do_v = row < Nv;
+    if (!do_q && !do_k && !do_v) return;
+
+    const int tid4 = gw * WS + lane;
+    const si_block_q4_K* xq = do_q ? (const si_block_q4_K*)(Wq + (size_t)row * NSUPER * 144) : nullptr;
+    const si_block_q4_K* xk = do_k ? (const si_block_q4_K*)(Wk + (size_t)row * NSUPER * 144) : nullptr;
+    const si_block_q4_K* xv = do_v ? (const si_block_q4_K*)(Wv + (size_t)row * NSUPER * 144) : nullptr;
+    constexpr int blocks_per_iter = vdr * NW * WS / qi;
+    float tq = 0.f, tk = 0.f, tv = 0.f;
+    #pragma unroll
+    for (int kbx = tid4 / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+        const int kby = kbx * 8;
+        const int kqs = vdr * (tid4 % (qi / vdr));
+        if (do_q) tq += si_vec_dot_q4_K(xq + kbx, s_vy + kby, kqs);
+        if (do_k) tk += si_vec_dot_q4_K(xk + kbx, s_vy + kby, kqs);
+        if (do_v) tv += si_vec_dot_q4_K(xv + kbx, s_vy + kby, kqs);
+    }
+    __shared__ float s_tq[2][NW - 1][WS], s_tk[2][NW - 1][WS], s_tv[2][NW - 1][WS];
+    if (gw > 0) {
+        if (do_q) s_tq[group][gw - 1][lane] = tq;
+        if (do_k) s_tk[group][gw - 1][lane] = tk;
+        if (do_v) s_tv[group][gw - 1][lane] = tv;
+    }
+    __syncthreads();
+    if (gw > 0) return;
+    if (do_q) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tq += s_tq[group][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tq += __shfl_xor_sync(0xffffffff, tq, m);
+        if (lane == 0) gemv_write(yq + row, tq);
+    }
+    if (do_k) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tk += s_tk[group][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tk += __shfl_xor_sync(0xffffffff, tk, m);
+        if (lane == 0) gemv_write(yk + row, tk);
+    }
+    if (do_v) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tv += s_tv[group][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tv += __shfl_xor_sync(0xffffffff, tv, m);
+        if (lane == 0) gemv_write(yv + row, tv);
+    }
+}
+template __global__ void si_mmvq_q4k_qkv_fused_pack2_kernel<__nv_bfloat16, 8>(const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_mmvq_q4k_qkv_fused_pack2_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*, float*, float*, float*, int, int, int);
+
 // ===== faithful llama Q6_K mmvq for the fp32-path GEMVs (attn-V upgrades + LM head) =====
 // Same 4-warp-per-row structure as the Q4_K mmvq, with vec_dot_q6_K_q8_1 (coalesced
 // ql/qh int loads + __vsubss4 reconstruct + dp4a). Mirrors the #65 MoE-down dot.
@@ -993,6 +1066,27 @@ void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cuda
     else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else                si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
+}
+void launch_mmvq_q4k_qkv_fused(const void* q81, const void* Wq, const void* Wk, const void* Wv,
+                                 void* yq, void* yk, void* yv, int Nq, int Nk, int Nv, int K,
+                                 cudaStream_t stream) {
+    if (!attn_pack2_enabled() || K != 2048) {
+        launch_mmvq_q4k(q81, Wq, yq, Nq, K, stream);
+        launch_mmvq_q4k(q81, Wk, yk, Nk, K, stream);
+        launch_mmvq_q4k(q81, Wv, yv, Nv, K, stream);
+        return;
+    }
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* wq = reinterpret_cast<const unsigned char*>(Wq);
+    const unsigned char* wk = reinterpret_cast<const unsigned char*>(Wk);
+    const unsigned char* wv = reinterpret_cast<const unsigned char*>(Wv);
+    __nv_bfloat16* oq = reinterpret_cast<__nv_bfloat16*>(yq);
+    __nv_bfloat16* ok = reinterpret_cast<__nv_bfloat16*>(yk);
+    __nv_bfloat16* ov = reinterpret_cast<__nv_bfloat16*>(yv);
+    const int gq = (Nq + 1) / 2, gk = (Nk + 1) / 2, gv = (Nv + 1) / 2;
+    const int grid = gq > gk ? (gq > gv ? gq : gv) : (gk > gv ? gk : gv);
+    si_mmvq_q4k_qkv_fused_pack2_kernel<__nv_bfloat16, 8><<<grid, 8 * 32, 0, stream>>>(
+        q, wq, wk, wv, oq, ok, ov, Nq, Nk, Nv);
 }
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -70,6 +70,9 @@ void launch_gemv_q_dp4a_pq_f32(const void* q8, const float* ad, const float* as,
 size_t llama_q8_1_bytes(int K);
 void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
+void launch_mmvq_q4k_qkv_fused(const void* q81, const void* Wq, const void* Wk, const void* Wv,
+                                 void* yq, void* yk, void* yv, int Nq, int Nk, int Nv, int K,
+                                 cudaStream_t stream = nullptr);
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 // Same, for Q6_K weights (attn-V upgrades + LM head). q81 = block_q8_1(activation).
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -416,8 +416,24 @@ int Qwen35Model::forward_token(int token_id, int position) {
             const bool any_q80 = (w.wqkv_type == 8 || w.wqkv_gate_type == 8 ||
                                   w.ssm_alpha_type == 8 || w.ssm_beta_type == 8);
             prepare_xn_quant(any_q4k, any_q6k, any_q80);
-            const bool gdn_pipelined = s.gguf && s.use_gdn_pipe;
-            if (gdn_pipelined) {
+            const bool gdn_q4k_fuse = s.gguf && s.use_pq && s.use_llama && s.use_qkv_fuse && H == 2048
+                                   && w.wqkv_type == 12 && w.wqkv_gate_type == 12;
+            const bool gdn_pipelined = s.gguf && s.use_gdn_pipe && !gdn_q4k_fuse;
+            if (gdn_q4k_fuse) {
+                if (s.use_gdn_pipe) {
+                    cudaEventRecord(s.ev_pipe_fork, st);
+                    cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
+                    proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, s.stream_v);
+                    proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, s.stream_v);
+                    cudaEventRecord(s.ev_gdn_ab, s.stream_v);
+                } else {
+                    proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
+                    proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
+                }
+                kernels::launch_mmvq_q4k_qkv_fused(s.aq81, w.wqkv, w.wqkv_gate, nullptr,
+                                                     s.lin_qkv, s.lin_z, nullptr,
+                                                     s.linear_qkvdim, s.linear_vdim, 0, H, st);
+            } else if (gdn_pipelined) {
                 cudaEventRecord(s.ev_pipe_fork, st);
                 cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
                 cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
@@ -441,7 +457,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                                  c.linear_q_heads, c.linear_v_heads,
                                                  c.linear_head_dim, c.linear_conv_kernel,
                                                  c.rms_eps, st);
-            if (gdn_pipelined) cudaStreamWaitEvent(st, s.ev_gdn_ab, 0);
+            if (gdn_pipelined || (gdn_q4k_fuse && s.use_gdn_pipe))
+                cudaStreamWaitEvent(st, s.ev_gdn_ab, 0);
             float* layer_state = s.lin_state +
                 (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;
             kernels::launch_qwen36_gdn_ar(s.lin_q, s.lin_k, s.lin_v,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -143,6 +143,7 @@ struct Qwen35Model::Impl {
     bool use_llama = true; // default ON: faithful llama mmvq for Q4_K attn GEMVs (+9.7%, top1 0.99). =0 disables
     bool use_q6mmvq = true;  // default ON: int8 Q6_K mmvq for attn-V upgrades + LM head. =0 disables
     bool use_qkvstream = true; // default ON: run Q/K/V projections on concurrent streams. =0 disables
+    bool use_qkv_fuse = true;  // default ON: fused Q+K+V pack2 mmvq when all Q4_K. SPARKINFER_QKV_FUSE=0 disables
     bool use_qkfuse = true;// default ON: fused per-head Q-norm + K-norm (1 kernel). =0 disables
     bool use_ropekv = true;// default ON: fused RoPE + KV-append (1 kernel vs 2). =0 disables
     bool use_attnin = true;// default ON: single fused QK-norm+RoPE+KV-append (1 kernel vs qkfuse+ropekv=2). =0 disables
@@ -246,6 +247,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_ROPEKV")) p_->use_ropekv = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKVSTREAM")) p_->use_qkvstream = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_QKV_FUSE"))  p_->use_qkv_fuse  = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ATTNIN")) p_->use_attnin = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_GDN_PIPE")) p_->use_gdn_pipe = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_SHEXP_PIPE")) p_->use_shexp_pipe = !(e[0] == '0');
@@ -482,7 +484,18 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
                 const bool any_q80 = (w.wq_type == 8 || w.wk_type == 8 || w.wv_type == 8);
                 prepare_xn_quant(any_q4k, any_q6k, any_q80);
-                if (s.use_qkvstream) {
+                const bool qkv_q4k = s.use_pq && s.use_llama && s.use_qkv_fuse && !w.q_has_gate
+                                  && w.wq_type == 12 && w.wk_type == 12 && w.wv_type == 12;
+                const bool kv_q4k = s.use_pq && s.use_llama && s.use_qkv_fuse && w.q_has_gate
+                                 && w.wk_type == 12 && w.wv_type == 12;
+                if (qkv_q4k && H == 2048) {
+                    kernels::launch_mmvq_q4k_qkv_fused(s.aq81, w.wq, w.wk, w.wv, s.q, s.k, s.v,
+                                                       s.qdim, s.kvdim, s.kvdim, H, st);
+                } else if (kv_q4k && H == 2048) {
+                    proj_xn(w.wq, w.wq_type, s.qraw, s.qdim * 2, st);
+                    kernels::launch_mmvq_q4k_qkv_fused(s.aq81, w.wk, w.wk, w.wv, s.k, s.k, s.v,
+                                                       0, s.kvdim, s.kvdim, H, st);
+                } else if (s.use_qkvstream) {
                     cudaEventRecord(s.ev_qkv, st);
                     cudaStreamWaitEvent(s.stream_k, s.ev_qkv, 0);
                     cudaStreamWaitEvent(s.stream_v, s.ev_qkv, 0);


### PR DESCRIPTION
## Summary

Halve CUDA-graph node count for the two largest attention Q4_K MMVQ projections (Wq @ 4096 rows, Wo @ 2048 rows) by packing two output rows per CTA with the same faithful 4-warp kfixed dot loop. Reduces bs=1 launch/graph-replay overhead on the decode hot path.

Closes #271, related #141.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 367.0 |
| after (this PR) | 367.27 |

```text
# sparkinfer auto-eval — 59dd212 (RTX 5090, same-box main vs PR)
# scored context: 4k-context · Qwen3.6 · 128 generated tokens

Qwen3.6 4k-context no-regression gate | 367.27 tok/s vs main 367.0 tok/s → +0.1%
Qwen3.6 128-token no-regression gate  | 386.9 tok/s vs main 386.9 tok/s · pass
Qwen3.6 512-context no-regression gate| 380.84 tok/s vs main 380.92 tok/s · pass

Qwen3-30B-A3B guard — 128-token | 499.54 tok/s · pass
Qwen3-30B-A3B guard — 512-context | 475.11 tok/s · pass
Qwen3-30B-A3B guard — 4k-context | 396.83 tok/s · pass
Qwen3-30B-A3B guard — 16k-context | 332.78 tok/s · pass
Qwen3-30B-A3B guard — 32k-context | 262.6 tok/s · pass

correctness (Qwen3.6 vs llama.cpp) | top-1 95.9% · KL 0.0214
verdict: eval:none — within significance gate, no verified speedup over same-box main
```
