### PR TITLE
perf(qwen3.6): fused router GEMV+top-k + folded residual-norm (decode)

### DIFF
--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -232,6 +232,135 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
 }
 
+// 3-input variant of add_rmsnorm2_q8: out_sum = x + (res1 + res2), so a per-layer
+// residual_add node is folded away. res1 + res2 is summed with the SAME bf16 rounding the
+// standalone residual_add_kernel uses (out = bf16(a + b)), then x is added exactly as
+// add_rmsnorm2_q8 does — so out_sum / out_norm / out_q8 are bit-identical to the unfused
+// residual_add + add_rmsnorm2_q8 pair. Used for Qwen3.6's every-layer shared expert, where
+// it deletes the routed+shared residual_add (one graph node per layer, 40/token).
+__global__ void add_rmsnorm3_q8_kernel(const __nv_bfloat16* __restrict__ x,
+                                       const __nv_bfloat16* __restrict__ res1,
+                                       const __nv_bfloat16* __restrict__ res2,
+                                       const __nv_bfloat16* __restrict__ weight,
+                                       __nv_bfloat16* __restrict__ out_sum,
+                                       __nv_bfloat16* __restrict__ out_norm,
+                                       si_blk_q8_1* __restrict__ out_q8,
+                                       int cols, float eps) {
+    __shared__ float s_warp[32];
+    const int t = threadIdx.x;
+    const uint4* x4  = reinterpret_cast<const uint4*>(x);
+    const uint4* r14 = reinterpret_cast<const uint4*>(res1);
+    const uint4* r24 = reinterpret_cast<const uint4*>(res2);
+    uint4* osum4 = reinterpret_cast<uint4*>(out_sum);
+
+    float xv[8], r1v[8], r2v[8];
+    rn_unpack8(__ldg(x4 + t), xv); rn_unpack8(__ldg(r14 + t), r1v); rn_unpack8(__ldg(r24 + t), r2v);
+    float sv[8]; float ss = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        // bf16(res1+res2) reproduces residual_add_kernel exactly, then x + that == add_rmsnorm2_q8.
+        float rs = __bfloat162float(__float2bfloat16(r1v[j] + r2v[j]));
+        sv[j] = xv[j] + rs;
+        ss = __fmaf_rn(sv[j], sv[j], ss);
+    }
+    osum4[t] = rn_pack8(sv);
+    ss = rn_warp_sum(ss);
+    if ((t & 31) == 0) s_warp[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < (blockDim.x + 31) / 32) ? s_warp[t] : 0.f;
+        v = rn_warp_sum(v);
+        if (t == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum);
+    float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
+    float ov[8], bv[8];
+    #pragma unroll
+    for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
+    reinterpret_cast<uint4*>(out_norm)[t] = rn_pack8(ov);
+
+    float amax = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(bv[j]));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+    const float d = amax / 127.0f;
+    const int b = t >> 2, r = t & 3;
+    int s = 0;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
+        out_q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+    }
+    s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
+    if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
+}
+
+// Non-Q8 3-input variant (out_sum = x + (res1 + res2); out_norm = rmsnorm(out_sum)*weight).
+// Bit-identical to residual_add(res1,res2) + add_rmsnorm2. General rows/cols.
+__global__ void add_rmsnorm3_kernel(const __nv_bfloat16* __restrict__ x,
+                                    const __nv_bfloat16* __restrict__ res1,
+                                    const __nv_bfloat16* __restrict__ res2,
+                                    const __nv_bfloat16* __restrict__ weight,
+                                    __nv_bfloat16* __restrict__ out_sum,
+                                    __nv_bfloat16* __restrict__ out_norm,
+                                    int rows, int cols, float eps) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    const int npack = cols >> 3;
+    const int tail  = npack << 3;
+    const uint4* x4  = reinterpret_cast<const uint4*>(x + base);
+    const uint4* r14 = reinterpret_cast<const uint4*>(res1 + base);
+    const uint4* r24 = reinterpret_cast<const uint4*>(res2 + base);
+    uint4* osum4 = reinterpret_cast<uint4*>(out_sum + base);
+
+    float ss = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float xv[8], r1v[8], r2v[8];
+        rn_unpack8(__ldg(x4 + p), xv); rn_unpack8(__ldg(r14 + p), r1v); rn_unpack8(__ldg(r24 + p), r2v);
+        float sv[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) sv[j] = xv[j] + __bfloat162float(__float2bfloat16(r1v[j] + r2v[j]));
+        osum4[p] = rn_pack8(sv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss = __fmaf_rn(sv[j], sv[j], ss);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+        float rs = __bfloat162float(__float2bfloat16(__bfloat162float(res1[base + c]) + __bfloat162float(res2[base + c])));
+        float v = __bfloat162float(x[base + c]) + rs;
+        out_sum[base + c] = __float2bfloat16(v);
+        ss = __fmaf_rn(v, v, ss);
+    }
+    ss = rn_warp_sum(ss);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum + base);
+    uint4* onorm4 = reinterpret_cast<uint4*>(out_norm + base);
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float sv[8], wv[8]; rn_unpack8(__ldg(osum4r + p), sv); rn_unpack8(__ldg(w4 + p), wv);
+        float ov[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ov[j] = sv[j] * inv_rms * wv[j];
+        onorm4[p] = rn_pack8(ov);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x)
+        out_norm[base + c] = __float2bfloat16(__bfloat162float(out_sum[base + c]) * inv_rms * __bfloat162float(weight[c]));
+}
+
 // Fused per-head Q-norm + K-norm: ONE kernel over (n_q_heads + n_kv_heads) heads
 // (each block normalizes one head), vs two launch_rmsnorm calls. 1 graph node saved.
 __global__ void rmsnorm_qk_kernel(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k,
@@ -313,6 +442,34 @@ void launch_add_rmsnorm2_q8(const void* x, const void* residual, const void* wei
         reinterpret_cast<__nv_bfloat16*>(out_sum),
         reinterpret_cast<__nv_bfloat16*>(out_norm),
         reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
+}
+
+// 3-input add_rmsnorm2 (folds a residual_add): out_sum = x + (res1 + res2). Same shape
+// constraints as launch_add_rmsnorm2_q8.
+void launch_add_rmsnorm3_q8(const void* x, const void* res1, const void* res2, const void* weight,
+                            void* out_sum, void* out_norm, void* out_q8, int cols, float eps,
+                            cudaStream_t stream) {
+    assert(cols % 256 == 0 && (cols >> 3) <= 1024);
+    add_rmsnorm3_q8_kernel<<<1, cols >> 3, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(res1),
+        reinterpret_cast<const __nv_bfloat16*>(res2),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out_sum),
+        reinterpret_cast<__nv_bfloat16*>(out_norm),
+        reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
+}
+
+void launch_add_rmsnorm3(const void* x, const void* res1, const void* res2, const void* weight,
+                         void* out_sum, void* out_norm, int rows, int cols, float eps,
+                         cudaStream_t stream) {
+    add_rmsnorm3_kernel<<<rows, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(res1),
+        reinterpret_cast<const __nv_bfloat16*>(res2),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out_sum),
+        reinterpret_cast<__nv_bfloat16*>(out_norm), rows, cols, eps);
 }
 #endif
 

--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -9,6 +9,7 @@
 // Portable CUDA — runs on sm_89 .. sm_120 (RTX 5090).
 
 #include <cuda_fp16.h>
+#include <cuda_bf16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #include <cstdlib>
@@ -142,6 +143,131 @@ __global__ void moe_router_kernel2(
     }
 }
 
+#define SI_CEXG(av, ai, bv, bi) do {                                     \
+    bool _ge = ((av) > (bv)) || ((av) == (bv) && (ai) < (bi));          \
+    if (!_ge) { float _t = (av); (av) = (bv); (bv) = _t;                \
+                int _u = (ai); (ai) = (bi); (bi) = _u; }               \
+  } while (0)
+
+// Warp-0 bitonic top-8 over 256 logits staged in shared memory. Lane owns experts {lane,lane+32,...
+// lane+224}; per-lane sort to descending, then a 5-step reduction tree bitonic-merging sorted-8 lists.
+// Writes out_ids[0..top_k) / out_w[0..top_k) (softmax when normalize). Must be entered by all of warp 0.
+__device__ __forceinline__ void si_warp_bitonic_top8(
+    const float* __restrict__ s_lg, int lane, int top_k, int normalize,
+    int* __restrict__ out_ids, float* __restrict__ out_w, int* __restrict__ counts)
+{
+    float r[8]; int ri[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) { r[i] = s_lg[lane + 32 * i]; ri[i] = lane + 32 * i; }
+    #pragma unroll
+    for (int k = 2; k <= 8; k <<= 1)
+        #pragma unroll
+        for (int j = k >> 1; j > 0; j >>= 1)
+            #pragma unroll
+            for (int i = 0; i < 8; i++) {
+                int l = i ^ j;
+                if (l > i) {
+                    if ((i & k) == 0) SI_CEXG(r[i], ri[i], r[l], ri[l]);
+                    else              SI_CEXG(r[l], ri[l], r[i], ri[i]);
+                }
+            }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        float pr[8]; int pri[8];
+        #pragma unroll
+        for (int m = 0; m < 8; m++) {
+            pr[m]  = __shfl_down_sync(0xffffffffu, r[m],  off);
+            pri[m] = __shfl_down_sync(0xffffffffu, ri[m], off);
+        }
+        float cv[16]; int cci[16];
+        #pragma unroll
+        for (int m = 0; m < 8; m++) {
+            cv[m] = r[m];          cci[m] = ri[m];
+            cv[8 + m] = pr[7 - m]; cci[8 + m] = pri[7 - m];
+        }
+        #pragma unroll
+        for (int i = 0; i < 8; i++) SI_CEXG(cv[i], cci[i], cv[i + 8], cci[i + 8]);
+        #pragma unroll
+        for (int stride = 4; stride > 0; stride >>= 1)
+            #pragma unroll
+            for (int i = 0; i < 8; i++) {
+                int l = i ^ stride;
+                if (l > i && l < 8) SI_CEXG(cv[i], cci[i], cv[l], cci[l]);
+            }
+        #pragma unroll
+        for (int m = 0; m < 8; m++) { r[m] = cv[m]; ri[m] = cci[m]; }
+    }
+    if (lane == 0) {
+        float denom = 1.f, mx = r[0];                   // r sorted descending -> r[0] is the max
+        if (normalize) { denom = 0.f; for (int j = 0; j < top_k; j++) denom += __expf(r[j] - mx); }
+        for (int j = 0; j < top_k; j++) {
+            out_ids[j] = ri[j];
+            out_w[j]   = normalize ? __expf(r[j] - mx) / denom : r[j];
+            if (counts) atomicAdd(&counts[ri[j]], 1);
+        }
+    }
+}
+
+// FUSED router GEMV + top-8: a faithful copy of gemv_f32_sk<float,SPL> (each block writes its RPB
+// final logits) followed by grid completion (atomicInc self-resets the counter to 0 for the next
+// CUDA-graph replay); the last block to arrive reads all 256 logits and runs the same bitonic top-8
+// in-kernel. Removes the separate top-k launch and its dependent-load gap from the decode critical
+// path. Byte-identical logits + selection to gemv_f32 + kernel6. Requires num_experts==256, K%8==0.
+template <int SPL>
+__global__ void moe_router_fused_kernel(
+    const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ W,
+    float* __restrict__ logits, unsigned int* __restrict__ gridctr,
+    int* __restrict__ expert_ids, float* __restrict__ expert_weights,
+    int N, int K, int top_k, int normalize)
+{
+    constexpr int RPB = 8 / SPL;
+    __shared__ float s_part[8 / SPL][SPL];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / SPL, split = warp % SPL;
+    const int n = blockIdx.x * RPB + row_local;
+    float acc = 0.f;
+    if (n < N) {
+        const uint4* row4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+        const uint4* x4   = reinterpret_cast<const uint4*>(x);
+        const int n4 = K / 8;
+        for (int i = split * 32 + lane; i < n4; i += SPL * 32) {
+            uint4 wv = row4[i], xv = x4[i];
+            const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+            const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+            #pragma unroll
+            for (int j = 0; j < 4; j++) {
+                float2 wf = __bfloat1622float2(wh[j]), xf = __bfloat1622float2(xh[j]);
+                acc += wf.x * xf.x + wf.y * xf.y;
+            }
+        }
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+        if (lane == 0) s_part[row_local][split] = acc;
+    }
+    __syncthreads();
+    if (n < N && split == 0 && lane == 0) {
+        float o = 0.f;
+        #pragma unroll
+        for (int s = 0; s < SPL; s++) o += s_part[row_local][s];
+        logits[n] = o;
+    }
+    // grid completion: make this block's logits visible, then signal. atomicInc(.,B-1) wraps to 0
+    // after B increments -> the counter is self-clearing for the next graph replay.
+    __threadfence();
+    __syncthreads();
+    __shared__ unsigned int s_last;
+    if (threadIdx.x == 0) s_last = atomicInc(gridctr, gridDim.x - 1);
+    __syncthreads();
+    if (s_last != gridDim.x - 1) return;
+    __shared__ float s_lg[256];
+    for (int e = threadIdx.x; e < N; e += blockDim.x) s_lg[e] = logits[e];
+    __syncthreads();
+    if (threadIdx.x < 32)
+        si_warp_bitonic_top8(s_lg, threadIdx.x & 31, top_k, normalize, expert_ids, expert_weights, nullptr);
+}
+#undef SI_CEXG
+
+
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 void launch_moe_router(
     const float* logits, int* expert_ids, float* expert_weights,
@@ -164,6 +290,20 @@ void launch_moe_router(
     moe_router_kernel<<<num_tokens, 32, smem, stream>>>(
         logits, expert_ids, expert_weights, tokens_per_expert,
         num_tokens, num_experts, top_k, normalize);
+}
+
+// Fused single-token router: split-K GEMV (writes `logits` scratch) + in-kernel bitonic top-8 in
+// the grid's last block. `gridctr` is a persistent unsigned counter, zero-initialized once by the
+// caller; atomicInc self-resets it each call so it is CUDA-graph-replay safe. Requires num_experts
+// == 256 and K % 8 == 0 (both hold for the Qwen3.6 router). Byte-identical to gemv_f32 + kernel6.
+void launch_router_fused(const void* x, const void* W, float* logits, unsigned int* gridctr,
+                         int* expert_ids, float* expert_weights,
+                         int num_experts, int K, int top_k, int normalize, cudaStream_t stream) {
+    constexpr int SPL = 4, RPB = 8 / SPL;              // GEMV_WPB = 8, matches gemv_f32_sk<float,4>
+    dim3 grid((num_experts + RPB - 1) / RPB);
+    moe_router_fused_kernel<SPL><<<grid, 8 * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W),
+        logits, gridctr, expert_ids, expert_weights, num_experts, K, top_k, normalize);
 }
 #endif
 

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -25,6 +25,15 @@ void launch_add_rmsnorm2_q8(const void* x_bf16, const void* residual_bf16, const
                             void* out_sum_bf16, void* out_norm_bf16, void* out_q8,
                             int cols, float eps, cudaStream_t stream = nullptr);
 
+// 3-input variants that fold a residual_add: out_sum = x + (res1 + res2). Bit-identical to
+// residual_add(res1,res2) + add_rmsnorm2[_q8]. Deletes one graph node per call site.
+void launch_add_rmsnorm3(const void* x_bf16, const void* res1_bf16, const void* res2_bf16,
+                         const void* weight_bf16, void* out_sum_bf16, void* out_norm_bf16,
+                         int rows, int cols, float eps, cudaStream_t stream = nullptr);
+void launch_add_rmsnorm3_q8(const void* x_bf16, const void* res1_bf16, const void* res2_bf16,
+                            const void* weight_bf16, void* out_sum_bf16, void* out_norm_bf16,
+                            void* out_q8, int cols, float eps, cudaStream_t stream = nullptr);
+
 // Fused per-head Q-norm + K-norm in one kernel (1 graph node vs 2). In-place on q/k.
 void launch_rmsnorm_qk(void* q, void* k, const void* q_w, const void* k_w,
                        int n_q_heads, int n_kv_heads, int head_dim, float eps, cudaStream_t stream = nullptr);

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -30,6 +30,16 @@ void launch_moe_router(
     int normalize,
     cudaStream_t stream = nullptr);
 
+// Fused single-token router: split-K GEMV (x @ W -> logits scratch) + in-kernel bitonic top-8 in the
+// grid's last block, removing the separate top-k launch. gridctr is a persistent unsigned counter,
+// zero-initialized once by the caller; atomicInc self-resets it so it is CUDA-graph-replay safe.
+// Requires num_experts == 256 and K % 8 == 0. W is native [num_experts, K].
+void launch_router_fused(
+    const void* x, const void* W, float* logits, unsigned int* gridctr,
+    int* expert_ids, float* expert_weights,
+    int num_experts, int K, int top_k, int normalize,
+    cudaStream_t stream = nullptr);
+
 // Fused MoE expert FFN with SwiGLU activation.
 // For each token i and each of its top_k experts e (weight w):
 //   h = SiLU(X[i] @ gate_w[e]) * (X[i] @ up_w[e])     // [ffn_dim]

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -130,6 +130,7 @@ struct Qwen35Model::Impl {
     float *sx_h = nullptr;   // pipelined shared-expert h_scratch (avoids racing routed mf_h)
     void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
+    unsigned int *mf_rc = nullptr;   // fused-router grid-completion counter (persistent, zero-init)
     // flash-decoding (KV-split) attention partials
     static constexpr int MAX_NSPLITS = 256;   // partials sized for this; adaptive n_splits <= this
     int n_splits = 32;
@@ -152,6 +153,8 @@ struct Qwen35Model::Impl {
     bool use_shexp_pipe = true; // default ON: overlap shared expert with routed MoE. =0 disables
     bool use_addnorm3 = true;   // default ON: fold the per-layer routed+shared residual_add into the
                                 // post-MoE add_rmsnorm (one fewer graph node/layer). =0 disables
+    bool use_router_fused = true; // default ON (256-expert path): fuse the router GEMV + bitonic top-k
+                                  // into one kernel (grid-completion), dropping the top-k launch. =0 disables
 
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -225,6 +228,8 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->mf_ids     = p_->alloc<int>(cfg.top_k);
     p_->mf_weights = p_->alloc<float>(cfg.top_k);
     p_->mf_counts  = p_->alloc<int>(cfg.n_experts);
+    p_->mf_rc      = p_->alloc<unsigned int>(1);
+    cu(cudaMemset(p_->mf_rc, 0, sizeof(unsigned int)), "mf_rc zero");   // grid-completion counter starts at 0
     p_->mf_h       = p_->alloc<float>((size_t)cfg.top_k * cfg.moe_ffn);
     p_->mf_out     = p_->alloc<float>(cfg.hidden);
     if (cfg.n_shared > 0) {
@@ -251,6 +256,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_GDN_PIPE")) p_->use_gdn_pipe = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_SHEXP_PIPE")) p_->use_shexp_pipe = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ADDNORM3")) p_->use_addnorm3 = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_ROUTER_FUSED")) p_->use_router_fused = !(e[0] == '0');
 }
 
 Qwen35Model::~Qwen35Model() {
@@ -270,7 +276,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->shared_gate_tmp);
     cudaFree(p_->mf_logits); cudaFree(p_->mf_weights); cudaFree(p_->mf_h); cudaFree(p_->mf_out);
     cudaFree(p_->sx_h); cudaFree(p_->sx_q8);
-    cudaFree(p_->mf_ids); cudaFree(p_->mf_counts);
+    cudaFree(p_->mf_ids); cudaFree(p_->mf_counts); cudaFree(p_->mf_rc);
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
     if (p_->graph_ready) { cudaGraphExecDestroy(p_->cu_exec); cudaGraphDestroy(p_->cu_graph); }
@@ -593,7 +599,6 @@ int Qwen35Model::forward_token(int token_id, int position) {
         }
 
         if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
-            kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
             // The per-expert token counts only feed the batched-dispatch sort; the single-token
             // decode expert FFN reads ids/weights directly and never touches them. Zeroing that
             // buffer is a per-layer memset node in the replayed decode graph whose fixed cost far
@@ -601,10 +606,18 @@ int Qwen35Model::forward_token(int token_id, int position) {
             // SPARKINFER_MOE_COUNTS=1 restores the memset + on-device counting.
             static int moe_counts = -1;
             if (moe_counts < 0) { const char* mc = getenv("SPARKINFER_MOE_COUNTS"); moe_counts = (mc && mc[0] == '1') ? 1 : 0; }
-            if (moe_counts) cu(cudaMemsetAsync(s.mf_counts, 0, c.n_experts * sizeof(int), st), "mf counts");
-            kernels::launch_moe_router(s.mf_logits, s.mf_ids, s.mf_weights,
-                                       moe_counts ? s.mf_counts : nullptr,
-                                       1, c.n_experts, c.top_k, 1, st);
+            const bool rfuse = s.use_router_fused && !moe_counts && c.n_experts == 256 && (c.hidden % 8) == 0;
+            if (rfuse) {
+                // one kernel: router GEMV -> logits scratch, then in-kernel bitonic top-8 (last block)
+                kernels::launch_router_fused(s.hn, w.router_w, s.mf_logits, s.mf_rc,
+                                             s.mf_ids, s.mf_weights, c.n_experts, c.hidden, c.top_k, 1, st);
+            } else {
+                kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
+                if (moe_counts) cu(cudaMemsetAsync(s.mf_counts, 0, c.n_experts * sizeof(int), st), "mf counts");
+                kernels::launch_moe_router(s.mf_logits, s.mf_ids, s.mf_weights,
+                                           moe_counts ? s.mf_counts : nullptr,
+                                           1, c.n_experts, c.top_k, 1, st);
+            }
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -150,6 +150,8 @@ struct Qwen35Model::Impl {
                            // next layer's standalone QKV-input quantize node. =0 disables
     bool use_gdn_pipe = true;   // default ON: overlap GDN gate/scalar projections on side streams. =0 disables
     bool use_shexp_pipe = true; // default ON: overlap shared expert with routed MoE. =0 disables
+    bool use_addnorm3 = true;   // default ON: fold the per-layer routed+shared residual_add into the
+                                // post-MoE add_rmsnorm (one fewer graph node/layer). =0 disables
 
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -248,6 +250,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_ATTNIN")) p_->use_attnin = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_GDN_PIPE")) p_->use_gdn_pipe = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_SHEXP_PIPE")) p_->use_shexp_pipe = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_ADDNORM3")) p_->use_addnorm3 = !(e[0] == '0');
 }
 
 Qwen35Model::~Qwen35Model() {
@@ -611,15 +614,23 @@ int Qwen35Model::forward_token(int token_id, int position) {
             s.engine->set_layer_weights(L, {w.router_w, w.gate, w.up, w.down});
             s.engine->forward(s.hn, s.routed, 1, L, st);
         }
+        const void* shared_to_fold = nullptr;   // if set, folded into the post-MoE add_rmsnorm3
         if (c.n_shared > 0) {
             if (shexp_pipelined) {
                 cudaStreamWaitEvent(st, s.ev_sx_done, 0);
-                launch_residual_add(s.routed, s.shared, s.routed, H, st);
                 const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-                if (fnq)
-                    kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
-                else
-                    kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                if (s.use_addnorm3) {   // x = h + (routed + shared) in one kernel; residual_add node dropped
+                    if (fnq)
+                        kernels::launch_add_rmsnorm3_q8(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+                    else
+                        kernels::launch_add_rmsnorm3(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                } else {
+                    launch_residual_add(s.routed, s.shared, s.routed, H, st);
+                    if (fnq)
+                        kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+                    else
+                        kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                }
                 continue;
             }
             if (w.shared_gate_inp) {
@@ -665,11 +676,17 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                                s.d_shared_ids, s.d_shared_w, s.shared,
                                                1, 1, 1, H, c.moe_ffn, st);
             }
-            launch_residual_add(s.routed, s.shared, s.routed, H, st);
+            if (s.use_addnorm3) shared_to_fold = s.shared;   // fold routed+shared into the norm below
+            else launch_residual_add(s.routed, s.shared, s.routed, H, st);
         }
-        // fused: x = h + routed ; xn = RMSNorm(x, next input_norm or final_norm)
+        // fused: x = h + routed (+ shared, when folded) ; xn = RMSNorm(x, next input_norm or final_norm)
         const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        if (fnq)
+        if (shared_to_fold) {
+            if (fnq)
+                kernels::launch_add_rmsnorm3_q8(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+            else
+                kernels::launch_add_rmsnorm3(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+        } else if (fnq)
             kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
         else
             kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);


### PR DESCRIPTION
## Summary

Two decode critical-path latency cuts for Qwen3.6-35B-A3B (256-expert MoE), both bit-identical to main's output.

1. **Fused router GEMV + top-k.** The router today runs a split-K GEMV that writes 256 expert logits to global memory, then a *separate* single-block kernel reads them back and selects the top-8 with an O(num_experts^2) rank scan. On an nsys node trace that top-k kernel is ~6.6% of the 128-context token, sitting serial on the decode critical path (router -> gate/up). This PR fuses both into one kernel: the same split-K GEMV writes its logits, a grid-completion handshake (an `atomicInc` that wraps back to 0, so it is CUDA-graph-replay safe with no reset node) lets the last block run an in-kernel top-8. The select is a bitonic reduction tree that replaces the 8 serial warp-argmax passes with a 5-level tree of independent (ILP) shuffles, and the fusion removes the separate top-k launch plus its dependent-load gap. Selection is byte-identical to the existing rank-select (value descending, ties to the lower expert index; checked against a reference over 4000 tie-heavy cases and confirmed by a bit-exact decode score diff). Only the 256-expert path is fused; the Qwen3-30B guard (128 experts) keeps the existing rank-select unchanged.

2. **Fold the routed+shared residual into the post-MoE norm.** Each layer's `residual_add(routed, shared)` is folded into a 3-input `add_rmsnorm3`, deleting one graph node per layer on the latency-bound decode path. Bit-identical to main's bf16 rounding. Active only when n_shared > 0 (Qwen3.6); the guard (n_shared = 0) path is unchanged.

Distinct from open work: #237 tunes the router GEMV split factor and keeps the warp top-k (no fused kernel, no top-k rewrite); #188 / #191 remove a reload inside the 2-input `add_rmsnorm2_q8` (a different function than the new 3-input fold).

Toggles for the A/B below (both default ON, 256-expert path): `SPARKINFER_ROUTER_FUSED=0` restores the separate GEMV + top-k, `SPARKINFER_ADDNORM3=0` restores the separate residual add.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench`, `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`, 128 decode tokens, 128-context):

| | decode tok/s |
|---|--:|
| before (main) | 392.7 |
| after (this PR) | 409.3 |

Interleaved same-binary A/B (median of 3, env toggle flips both levers), all three scored contexts:

```text
# ctx=128:  before 392.7 -> after 409.3  (+4.2%)
# ctx=512:  before 385.2 -> after 400.4  (+3.9%)
# ctx=4096: before 369.0 -> after 382.4  (+3.6%)

-- ctx=128 (before / after) --
392.93 409.42
392.77 409.25
392.46 409.18
-- ctx=512 --
385.50 400.47
385.28 400.29
384.83 400.32
-- ctx=4096 --
369.98 383.16
368.86 382.15
368.31 381.75
```

Accuracy: the fused router's selection and the folded norm are both byte-identical to main, so the decode score is unchanged (a top-5 score diff over 48 fuzzed prompts is empty). Qwen3-30B-A3B guard paths (128-expert router, n_shared=0 norm) are untouched.

## Relation to open PRs

All new kernels here are original and implement optimizations no open PR does. `moe_router_fused_kernel` reuses the base-repo `gemv_f32_sk<float,4>` body verbatim (it is base code, unchanged by any PR) and adds the grid-completion + bitonic top-8; `add_rmsnorm3` is a new 3-input sibling of the base `add_rmsnorm2`, not a copy of any PR.

The only file this shares with other open PRs is `runtime/src/models/qwen35.cpp`, whose `forward_token` many decode PRs edit in disjoint regions. The changed hunks here do not coincide with any of them:
- vs #237 (`router.cu`): #237 only edits `launch_moe_router`'s dispatch; this PR does not touch that function and instead adds new symbols.
- vs #239 (shared-expert gate/up/swiglu fusion, ~line 556) and #267 (shared-gate `gemv_sigmoid`, ~639, and GDN proj ~406): those edits sit between/outside this PR's router edit (~599) and residual-fold edit (~665-700); no shared changed line.
- vs #134 (adaptive n_splits ladder, ~207-225): ~380 lines away from any edit here.
- vs #188/#191 (`add_rmsnorm2_q8` reload removal): this PR does not modify `add_rmsnorm2_q8`; its new `add_rmsnorm3_q8` keeps the reload (the opposite change).
