### PR TITLE
perf(qwen36): Q8_0 MMVQ + hd256 int8 FA MMA + LM head staging

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -295,6 +295,8 @@ template __global__ void fa_split_kernel<256>(const __nv_bfloat16*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*, int);
 template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, false>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
+template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, true>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
@@ -320,6 +322,7 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
 ) {
     using namespace nvcuda::wmma;
     constexpr int KH = HEAD_DIM / 16;
+    constexpr int TILE_W = 128;   // max 8 physical blocks * 16 tokens per KV group
     const int seq = blockIdx.y, split = blockIdx.x % n_splits, kvh = blockIdx.x / n_splits;
     const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31, tid = threadIdx.x;
     const int sl = seq_lens[seq];
@@ -412,7 +415,7 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
             for (int u = 0; u < 4; u++) {
                 const int t = lane + u * 32, gtok = gbase + t;
                 sc[u] = (t < gblk * 16 && gtok >= start && gtok < end)
-                        ? (float)s_si[r * 128 + t] * s_qs[r] * s_ks[t] * scale : -1e30f;
+                        ? (float)s_si[r * HEAD_DIM + t] * s_qs[r] * s_ks[t] * scale : -1e30f;
                 mx = fmaxf(mx, sc[u]);
             }
             #pragma unroll
@@ -427,16 +430,14 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
                     const float p = __expf(sc[u] - m_new);
                     sum += p; pv = p * s_vs[t]; pamax = fmaxf(pamax, fabsf(pv));
                 }
-                s_s[r * 128 + t] = pv;   // stash P' (score no longer needed for this row)
+                s_s[r * TILE_W + t] = pv;   // stash P' (score no longer needed for this row)
             }
             #pragma unroll
             for (int o = 16; o > 0; o >>= 1) { sum += __shfl_xor_sync(0xffffffff, sum, o); pamax = fmaxf(pamax, __shfl_xor_sync(0xffffffff, pamax, o)); }
             const float pd = pamax / 127.0f;
             if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; s_ps[r] = pd; }
-            // Only quantize the gblk*16 P' columns the PV mma actually reads (it loops ks < gblk);
-            // the tail columns are never loaded, so skipping them trims the per-row roundf work.
             for (int t = lane; t < gblk * 16; t += 32)
-                s_pi[r * 128 + t] = (signed char)((pamax == 0.f) ? 0 : (int)roundf(s_s[r * 128 + t] / pd));
+                s_pi[r * TILE_W + t] = (signed char)((pamax == 0.f) ? 0 : (int)roundf(s_s[r * TILE_W + t] / pd));
             if (r < GQA) for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
         }
         __syncthreads();
@@ -450,16 +451,15 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
                 const signed char* vb = v_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM + warp * 16;
                 fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
                 fragment<matrix_b, 16, 16, 16, signed char, row_major> bf;
-                load_matrix_sync(af, s_pi + ks * 16, HEAD_DIM);
+                load_matrix_sync(af, s_pi + ks * 16, TILE_W);
                 load_matrix_sync(bf, vb, KVLD);
                 mma_sync(cf, af, bf, cf);
             }
             store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, HEAD_DIM, mem_row_major);
         }
         __syncthreads();
-        // Only the GQA real q-head rows are kept (rows GQA..15 are wmma M-padding, never written to
-        // the partials) — accumulate just those, halving this thread-parallel epilogue at GQA=8.
-        for (int i = tid; i < GQA * 128; i += blockDim.x) s_o[i] += (float)reinterpret_cast<int*>(s_s)[i] * s_ps[i >> 7];
+        for (int i = tid; i < GQA * HEAD_DIM; i += blockDim.x)
+            s_o[i] += (float)reinterpret_cast<int*>(s_s)[i] * s_ps[i / HEAD_DIM];
         __syncthreads();
     }
 
@@ -474,6 +474,17 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
 template __global__ void fa_split_gqa_mma_i8_kernel<128, 8>(const __nv_bfloat16*, const signed char*,
     const signed char*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int,
     const __half*, const __half*);
+template __global__ void fa_split_gqa_mma_i8_kernel<256, 8>(const __nv_bfloat16*, const signed char*,
+    const signed char*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int,
+    const __half*, const __half*);
+
+template <int HEAD_DIM, int GQA>
+static inline size_t fa_mma_i8_smem_bytes() {
+    constexpr int TILE_W = 128;
+    return (size_t)2 * 16 * HEAD_DIM * sizeof(signed char)
+         + (size_t)(16 + GQA) * HEAD_DIM * sizeof(float)
+         + (size_t)(16 + 16 + TILE_W + TILE_W + 16 + 16) * sizeof(float);
+}
 
 template <int NW>
 static inline void fa_launch_combine(
@@ -507,26 +518,45 @@ void launch_flash_decode_split(
     // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). Use the GQA-8 shared-KV tile
     // path (same 8:1 grouping as Qwen3 hd=128) — cuts KV global reads ~8x vs one-warp-per-q-head.
     if (head_dim == 256) {
+        static int famma = -1;
+        if (famma < 0) { const char* e = getenv("SPARKINFER_FAMMA"); famma = (e && e[0] == '0') ? 0 : 1; }
+        const int mma_chunk = (n_splits > 0) ? (seqlen + n_splits - 1) / n_splits : 0;
+        const bool mma_aligned = famma && seqlen > 512 && block_size == 16 && mma_chunk >= 32;
+        const __half* ksc = reinterpret_cast<const __half*>(k_scale);
+        const __half* vsc = reinterpret_cast<const __half*>(v_scale);
         dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
         if (num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
             constexpr int GQA = 8, TILE = FA_GQA_TILE;
             dim3 gq(num_kv_heads * n_splits, num_seqs);
-            const size_t smem = (size_t)2 * TILE * 256 * sizeof(__nv_bfloat16);
-            fa_split_gqa_kernel<256, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
-                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
-                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
-                reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+            if (mma_aligned && int8_kv) {
+                fa_split_gqa_mma_i8_kernel<256, GQA><<<gq, GQA * 32, fa_mma_i8_smem_bytes<256, GQA>(), stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const signed char*>(k_pool),
+                    reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    ksc, vsc);
+            } else {
+                const size_t smem = (size_t)2 * TILE * 256 * sizeof(__nv_bfloat16);
+                if (int8_kv)
+                    fa_split_gqa_kernel<256, GQA, TILE, true><<<gq, GQA * 32, smem, stream>>>(
+                        reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                        part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                        ksc, vsc);
+                else
+                    fa_split_gqa_kernel<256, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
+                        reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                        part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                        ksc, vsc);
+            }
         } else {
             dim3 g1(num_q_heads * n_splits, num_seqs);
             fa_split_kernel<256><<<g1, 32, 0, stream>>>(
                 reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
                 part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
-                reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
+                ksc, vsc, int8_kv);
         }
         fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
             part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
             reinterpret_cast<fa_block_q8_1*>(out_q8));
-        (void)seqlen;
         return;
     }
     static int fagqa = -1;
@@ -553,11 +583,8 @@ void launch_flash_decode_split(
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
         constexpr int GQA = 8, TILE = FA_GQA_TILE;
         dim3 gq(num_kv_heads * n_splits, num_seqs);
-        if (mma_aligned && int8_kv) {   // int8 tensor-core (halved KV read) — the long-context win
-            const size_t i8_smem = (size_t)2 * 16 * 128 * sizeof(signed char)
-                                 + (size_t)(16 + GQA) * 128 * sizeof(float)   // s_s[16][HD] + s_o[GQA][HD]
-                                 + (size_t)(16 + 16 + 128 + 128 + 16 + 16) * sizeof(float);
-            fa_split_gqa_mma_i8_kernel<128, GQA><<<gq, GQA * 32, i8_smem, stream>>>(
+        if (mma_aligned && int8_kv) {
+            fa_split_gqa_mma_i8_kernel<128, GQA><<<gq, GQA * 32, fa_mma_i8_smem_bytes<128, GQA>(), stream>>>(
                 reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const signed char*>(k_pool),
                 reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
                 part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,

--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -243,6 +243,125 @@ template __global__ void qknorm_rope_kv_kernel<false>(
 template __global__ void qknorm_rope_kv_kernel<true>(
     __nv_bfloat16*, __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
     void*, void*, __half*, __half*, const int*, const int*, int, int, int, float, int, int, float);
+
+// Fused QK-norm + partial-RoPE + KV-append for Qwen3.6. INT8=true stores int8 KV + fp16 scales.
+template <bool INT8>
+__global__ void qknorm_rope_kv_partial_kernel(
+    __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
+    const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
+    void* __restrict__ k_pool, void* __restrict__ v_pool,
+    __half* __restrict__ k_scale, __half* __restrict__ v_scale,
+    const int* __restrict__ block_table, const int* __restrict__ positions,
+    int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta,
+    int block_size, int max_blocks_per_seq, float eps
+) {
+    const int tok  = blockIdx.y;
+    const int b    = blockIdx.x;
+    const int t    = threadIdx.x;
+    const int rhalf = rotary_dim >> 1;
+    const int pos  = positions[tok];
+    const int blk = pos / block_size, within = pos % block_size;
+    const size_t ctok = (size_t)((size_t)block_table[tok * max_blocks_per_seq + blk] * block_size + within);
+
+    const bool is_v = (b >= n_q_heads + n_kv_heads);
+    if (is_v) {
+        const int hh = b - n_q_heads - n_kv_heads;
+        const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
+        const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+        if constexpr (!INT8) {
+            if (t < head_dim) reinterpret_cast<__nv_bfloat16*>(v_pool)[dst + t] = v[base + t];
+        } else {
+            const float val = (t < head_dim) ? __bfloat162float(v[base + t]) : 0.f;
+            __shared__ float s_red[32];
+            float amax = fabsf(val);
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
+            if ((t & 31) == 0) s_red[t >> 5] = amax;
+            __syncthreads();
+            if (t < 32) {
+                float a = (t < (head_dim + 31) / 32) ? s_red[t] : 0.f;
+                #pragma unroll
+                for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffff, a, m));
+                if (t == 0) s_red[0] = a;
+            }
+            __syncthreads();
+            const float d = s_red[0] / 127.0f;
+            if (t < head_dim)
+                reinterpret_cast<signed char*>(v_pool)[dst + t] =
+                    (signed char)((s_red[0] == 0.f) ? 0 : (int)roundf(__bfloat162float(v[base + t]) / d));
+            if (t == 0) v_scale[ctok * n_kv_heads + hh] = __float2half(d);
+        }
+        return;
+    }
+
+    const bool is_q = (b < n_q_heads);
+    __nv_bfloat16* x        = is_q ? q : k;
+    const __nv_bfloat16* w  = is_q ? q_w : k_w;
+    const int head          = is_q ? b : (b - n_q_heads);
+    const int nh            = is_q ? n_q_heads : n_kv_heads;
+    const size_t base       = ((size_t)(tok * nh + head)) * head_dim;
+
+    extern __shared__ float s_h[];
+    __shared__ float s_warp[32];
+    const float xv = __bfloat162float(x[base + t]);
+    float ss = xv * xv;
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) ss += __shfl_xor_sync(0xffffffff, ss, m);
+    if ((t & 31) == 0) s_warp[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float vv = (t < (head_dim + 31) / 32) ? s_warp[t] : 0.f;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) vv += __shfl_xor_sync(0xffffffff, vv, m);
+        if (t == 0) s_warp[0] = rsqrtf(vv / head_dim + eps);
+    }
+    __syncthreads();
+    s_h[t] = __bfloat162float(__float2bfloat16(xv * s_warp[0] * __bfloat162float(w[t])));
+    __syncthreads();
+
+    if (t < rhalf) {
+        const float freq = __powf(theta, -2.f * (float)t / (float)rotary_dim);
+        const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
+        const float x0 = s_h[t], x1 = s_h[t + rhalf];
+        s_h[t] = __bfloat162float(__float2bfloat16(x0 * c - x1 * s));
+        s_h[t + rhalf] = __bfloat162float(__float2bfloat16(x1 * c + x0 * s));
+    }
+    __syncthreads();
+
+    if (is_q) {
+        if (t < head_dim) q[base + t] = __float2bfloat16(s_h[t]);
+    } else if constexpr (!INT8) {
+        const size_t dst = (ctok * n_kv_heads + head) * head_dim;
+        if (t < head_dim) reinterpret_cast<__nv_bfloat16*>(k_pool)[dst + t] = __float2bfloat16(s_h[t]);
+    } else {
+        __shared__ float s_red[32];
+        float amax = (t < head_dim) ? fabsf(s_h[t]) : 0.f;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
+        if ((t & 31) == 0) s_red[t >> 5] = amax;
+        __syncthreads();
+        if (t < 32) {
+            float a = (t < (head_dim + 31) / 32) ? s_red[t] : 0.f;
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffff, a, m));
+            if (t == 0) s_red[0] = a;
+        }
+        __syncthreads();
+        const float d = s_red[0] / 127.0f;
+        const size_t dst = (ctok * n_kv_heads + head) * head_dim;
+        if (t < head_dim)
+            reinterpret_cast<signed char*>(k_pool)[dst + t] =
+                (signed char)((s_red[0] == 0.f) ? 0 : (int)roundf(s_h[t] / d));
+        if (t == 0) k_scale[ctok * n_kv_heads + head] = __float2half(d);
+    }
+}
+template __global__ void qknorm_rope_kv_partial_kernel<false>(
+    __nv_bfloat16*, __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    void*, void*, __half*, __half*, const int*, const int*, int, int, int, int, float, int, int, float);
+template __global__ void qknorm_rope_kv_partial_kernel<true>(
+    __nv_bfloat16*, __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*,
+    void*, void*, __half*, __half*, const int*, const int*, int, int, int, int, float, int, int, float);
+
 __global__ void rope_kv_append_partial_kernel(
     __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k,
     const __nv_bfloat16* __restrict__ v,
@@ -333,6 +452,33 @@ void launch_qknorm_rope_kv_append(
             reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
             k_pool, v_pool, reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
             block_table, positions, n_q_heads, n_kv_heads, head_dim, theta,
+            block_size, max_blocks_per_seq, eps);
+}
+
+void launch_qknorm_rope_kv_partial(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
+    float theta, float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream,
+    void* k_scale, void* v_scale, int int8_kv
+) {
+    dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
+    const int smem = head_dim * sizeof(float);
+    if (int8_kv)
+        qknorm_rope_kv_partial_kernel<true><<<grid, head_dim, smem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v),
+            reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+            k_pool, v_pool, reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+            block_table, positions, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta,
+            block_size, max_blocks_per_seq, eps);
+    else
+        qknorm_rope_kv_partial_kernel<false><<<grid, head_dim, smem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v),
+            reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+            k_pool, v_pool, reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+            block_table, positions, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta,
             block_size, max_blocks_per_seq, eps);
 }
 

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -522,6 +522,76 @@ __global__ void si_mmvq_q4k_kernel(const si_block_q8_1* __restrict__ vy, const u
 template __global__ void si_mmvq_q4k_kernel<__nv_bfloat16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
 template __global__ void si_mmvq_q4k_kernel<float>(const si_block_q8_1*, const unsigned char*, float*, int, int);
 
+// ---- faithful llama.cpp Q8_0 x Q8_1 dp4a mmvq (weights stay int8, no bf16 expansion) ----
+// Q8_0 blocks are 34 B ([fp16 d][int8 qs[32]]), 2-byte aligned only — read via byte offsets.
+__device__ __forceinline__ float si_q80_h2f(const unsigned char* p) {
+    __half h; *reinterpret_cast<unsigned short*>(&h) = *reinterpret_cast<const unsigned short*>(p);
+    return __half2float(h);
+}
+__device__ __forceinline__ int si_q80_get_int_b2(const unsigned char* p, int i32) {
+    const unsigned short* u = reinterpret_cast<const unsigned short*>(p);
+    return (int)u[2 * i32] | ((int)u[2 * i32 + 1] << 16);
+}
+__device__ __forceinline__ float si_vec_dot_q8_0(const unsigned char* bw, const si_block_q8_1* ba) {
+    const float dw = si_q80_h2f(bw);
+    const int* a = reinterpret_cast<const int*>(ba->qs);
+    int sumi = 0;
+    #pragma unroll
+    for (int i = 0; i < 8; i++) sumi = __dp4a(si_q80_get_int_b2(bw + 2, i), a[i], sumi);
+    return dw * __low2float(ba->ds) * (float)sumi;
+}
+template <typename OutT>
+__global__ void si_mmvq_q80_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
+                                   OutT* __restrict__ y, int N, int K) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    const int nb = K >> 5;
+    const unsigned char* w_row = W + (size_t)row * nb * 34;
+    float tmp = 0.0f;
+    for (int kb = tid; kb < nb; kb += NW * WS)
+        tmp += si_vec_dot_q8_0(w_row + (size_t)kb * 34, vy + kb);
+    __shared__ float tmp_shared[NW - 1][WS];
+    if (warp > 0) tmp_shared[warp - 1][lane] = tmp;
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += tmp_shared[l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+template __global__ void si_mmvq_q80_kernel<__nv_bfloat16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_kernel<float>(const si_block_q8_1*, const unsigned char*, float*, int, int);
+
+// Pack-2 rows per CTA for large-N Q8_0 mmvq (GDN wqkv N=8192, K=2048).
+template <typename OutT>
+__global__ void si_mmvq_q80_pack2_kernel(const si_block_q8_1* __restrict__ vy,
+                                         const unsigned char* __restrict__ W,
+                                         OutT* __restrict__ y, int N, int K) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, gw = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    if (row >= N) return;
+    const int nb = K >> 5;
+    const unsigned char* w_row = W + (size_t)row * nb * 34;
+    float tmp = 0.f;
+    for (int kb = gw * WS + lane; kb < nb; kb += NW * WS)
+        tmp += si_vec_dot_q8_0(w_row + (size_t)kb * 34, vy + kb);
+    __shared__ float s_acc[2][NW - 1][WS];
+    if (gw > 0) s_acc[group][gw - 1][lane] = tmp;
+    __syncthreads();
+    if (gw > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += s_acc[group][l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+template __global__ void si_mmvq_q80_pack2_kernel<__nv_bfloat16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_pack2_kernel<float>(const si_block_q8_1*, const unsigned char*, float*, int, int);
+
 template <typename OutT, int NSUPER>
 __global__ void si_mmvq_q4k_kfixed_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
                                           OutT* __restrict__ y, int N) {
@@ -552,6 +622,117 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8>(const si_bl
 template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+
+// Pack-2 rows per CTA for K=2048 Q4_K mmvq (mirrors gate_up_mmvq2_pack2). Two output rows
+// share the same Q8_1 activation superblock per iteration, improving L1 reuse on aq81.
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q4k_kfixed_pack2_kernel(const si_block_q8_1* __restrict__ vy,
+                                               const unsigned char* __restrict__ W,
+                                               OutT* __restrict__ y, int N) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, gw = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    if (row >= N) return;
+    const int tid4 = gw * WS + lane;
+    const int kbx = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const si_block_q4_K* x_row = (const si_block_q4_K*)(W + (size_t)row * NSUPER * 144);
+    float tmp = si_vec_dot_q4_K(x_row + kbx, vy + (size_t)kbx * 8, kqs);
+    __shared__ float s_acc[2][NW - 1][WS];
+    if (gw > 0) s_acc[group][gw - 1][lane] = tmp;
+    __syncthreads();
+    if (gw > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += s_acc[group][l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 8>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+
+// Fused Q+K+V Q4_K mmvq: stage full Q8_1(xn) in smem once per CTA, then pack2 all
+// three projections. Cuts 2 DRAM passes over aq81 per layer and gives every Q row smem reuse.
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q4k_qkv_fused_pack2_kernel(
+    const si_block_q8_1* __restrict__ vy,
+    const unsigned char* __restrict__ Wq, const unsigned char* __restrict__ Wk,
+    const unsigned char* __restrict__ Wv,
+    OutT* __restrict__ yq, OutT* __restrict__ yk, OutT* __restrict__ yv,
+    int Nq, int Nk, int Nv
+) {
+    constexpr int NW = 4, WS = 32;
+    constexpr int NVB = NSUPER * 8;
+    __shared__ si_block_q8_1 s_vy[NVB];
+    const int tid = threadIdx.x;
+    const int n4 = (NVB * (int)sizeof(si_block_q8_1)) / 16;
+    for (int i = tid; i < n4; i += blockDim.x) {
+        reinterpret_cast<uint4*>(s_vy)[i] =
+            __ldg(reinterpret_cast<const uint4*>(vy) + i);
+    }
+    __syncthreads();
+
+    const int lane = tid & 31, warp = tid >> 5;
+    const int group = warp >> 2, gw = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    const bool do_q = row < Nq;
+    const bool do_k = row < Nk;
+    const bool do_v = row < Nv;
+    if (!do_q && !do_k && !do_v) return;
+
+    const int tid4 = gw * WS + lane;
+    const int kbx = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    float tq = 0.f, tk = 0.f, tv = 0.f;
+    if (tid4 < 128) {
+        if (do_q) {
+            const si_block_q4_K* xq = (const si_block_q4_K*)(Wq + (size_t)row * NSUPER * 144);
+            tq = si_vec_dot_q4_K(xq + kbx, s_vy + kbx * 8, kqs);
+        }
+        if (do_k) {
+            const si_block_q4_K* xk = (const si_block_q4_K*)(Wk + (size_t)row * NSUPER * 144);
+            tk = si_vec_dot_q4_K(xk + kbx, s_vy + kbx * 8, kqs);
+        }
+        if (do_v) {
+            const si_block_q4_K* xv = (const si_block_q4_K*)(Wv + (size_t)row * NSUPER * 144);
+            tv = si_vec_dot_q4_K(xv + kbx, s_vy + kbx * 8, kqs);
+        }
+    }
+    __shared__ float s_tq[2][NW - 1][WS], s_tk[2][NW - 1][WS], s_tv[2][NW - 1][WS];
+    if (gw > 0) {
+        if (do_q) s_tq[group][gw - 1][lane] = tq;
+        if (do_k) s_tk[group][gw - 1][lane] = tk;
+        if (do_v) s_tv[group][gw - 1][lane] = tv;
+    }
+    __syncthreads();
+    if (gw > 0) return;
+    if (do_q) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tq += s_tq[group][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tq += __shfl_xor_sync(0xffffffff, tq, m);
+        if (lane == 0) gemv_write(yq + row, tq);
+    }
+    if (do_k) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tk += s_tk[group][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tk += __shfl_xor_sync(0xffffffff, tk, m);
+        if (lane == 0) gemv_write(yk + row, tk);
+    }
+    if (do_v) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tv += s_tv[group][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tv += __shfl_xor_sync(0xffffffff, tv, m);
+        if (lane == 0) gemv_write(yv + row, tv);
+    }
+}
+template __global__ void si_mmvq_q4k_qkv_fused_pack2_kernel<__nv_bfloat16, 8>(const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_mmvq_q4k_qkv_fused_pack2_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*, float*, float*, float*, int, int, int);
 
 // ===== faithful llama Q6_K mmvq for the fp32-path GEMVs (attn-V upgrades + LM head) =====
 // Same 4-warp-per-row structure as the Q4_K mmvq, with vec_dot_q6_K_q8_1 (coalesced
@@ -682,6 +863,33 @@ __global__ void gemv_q6k_dp4a_kfixed_kernel(const si_block_q8_1* __restrict__ vy
 }
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 8, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 16, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
+
+// LM head (N=vocab, K=2048): stage Q8_1 activation in smem once per CTA so each of the
+// WPB rows reuses it — cuts ~248k redundant global reads of the 2KB activation vector.
+template <int WPB, int NSUPER>
+__global__ void gemv_q6k_dp4a_lm_staged_kernel(const si_block_q8_1* __restrict__ vy,
+                                               const unsigned char* __restrict__ W,
+                                               float* __restrict__ y, int N) {
+    constexpr int NVB = NSUPER * 8;
+    __shared__ si_block_q8_1 s_vy[NVB];
+    const int tid = threadIdx.x;
+    const int n4 = (NVB * (int)sizeof(si_block_q8_1)) / 16;
+    for (int i = tid; i < n4; i += blockDim.x)
+        reinterpret_cast<uint4*>(s_vy)[i] = __ldg(reinterpret_cast<const uint4*>(vy) + i);
+    __syncthreads();
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row = blockIdx.x * WPB + warp;
+    if (row >= N) return;
+    const unsigned char* x_row = W + (size_t)row * NSUPER * 210;
+    float acc = 0.f;
+    #pragma unroll
+    for (int kbx = 0; kbx < NSUPER; kbx++)
+        acc += si_vec_dot_q6_K(x_row + (size_t)kbx * 210, s_vy + (size_t)kbx * 8, lane);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) gemv_write(y + row, acc);
+}
+template __global__ void gemv_q6k_dp4a_lm_staged_kernel<32, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/gemm.h"
@@ -875,9 +1083,37 @@ void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cuda
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
     __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
-    if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    static int pack2 = -1;
+    if (pack2 < 0) {
+        const char* e = getenv("SPARKINFER_MMVO_PACK2");
+        pack2 = (e && e[0] == '0') ? 0 : 1;
+    }
+    if (K == 4096 && pack2 && (N & 1) == 0)
+        si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else                si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
+}
+void launch_mmvq_q4k_qkv_fused(const void* q81, const void* Wq, const void* Wk, const void* Wv,
+                                 void* yq, void* yk, void* yv, int Nq, int Nk, int Nv, int K,
+                                 cudaStream_t stream) {
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* wq = reinterpret_cast<const unsigned char*>(Wq);
+    const unsigned char* wk = reinterpret_cast<const unsigned char*>(Wk);
+    const unsigned char* wv = reinterpret_cast<const unsigned char*>(Wv);
+    __nv_bfloat16* oq = reinterpret_cast<__nv_bfloat16*>(yq);
+    __nv_bfloat16* ok = reinterpret_cast<__nv_bfloat16*>(yk);
+    __nv_bfloat16* ov = reinterpret_cast<__nv_bfloat16*>(yv);
+    if (K == 2048) {
+        const int gq = (Nq + 1) / 2, gk = (Nk + 1) / 2, gv = (Nv + 1) / 2;
+        const int grid = gq > gk ? (gq > gv ? gq : gv) : (gk > gv ? gk : gv);
+        si_mmvq_q4k_qkv_fused_pack2_kernel<__nv_bfloat16, 8><<<grid, 8 * 32, 0, stream>>>(
+            q, wq, wk, wv, oq, ok, ov, Nq, Nk, Nv);
+    } else {
+        launch_mmvq_q4k(q81, Wq, yq, Nq, K, stream);
+        launch_mmvq_q4k(q81, Wk, yk, Nk, K, stream);
+        launch_mmvq_q4k(q81, Wv, yv, Nv, K, stream);
+    }
 }
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
@@ -885,6 +1121,23 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
     if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
+}
+void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
+    if (K == 2048 && (N & 1) == 0 && N >= 4096)
+        si_mmvq_q80_pack2_kernel<__nv_bfloat16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, out, N, K);
+    else
+        si_mmvq_q80_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
+}
+void launch_mmvq_q80_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    if (K == 2048 && (N & 1) == 0 && N >= 4096)
+        si_mmvq_q80_pack2_kernel<float><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, y, N, K);
+    else
+        si_mmvq_q80_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
@@ -907,6 +1160,18 @@ void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, i
         const char* e = getenv("SPARKINFER_Q6K_WPB");
         wpb = e ? atoi(e) : 16;
         if (!(wpb == 8 || wpb == 16 || wpb == 32)) wpb = 16;
+    }
+    static int lm_tc = -1;
+    if (lm_tc < 0) {
+        const char* e = getenv("SPARKINFER_LM_TC");
+        lm_tc = (e && e[0] == '0') ? 0 : 1;
+    }
+    const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    if (lm_tc && K == 2048 && N >= 32768) {
+        dim3 grid((N + 31) / 32);
+        gemv_q6k_dp4a_lm_staged_kernel<32, 8><<<grid, 32 * 32, 0, stream>>>(q, w, y, N);
+        return;
     }
     if (K == 2048 && wpb == 16) {
         dim3 grid((N + 15) / 16);

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -37,6 +37,14 @@ void launch_qknorm_rope_kv_append(
     float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr,
     void* k_scale = nullptr, void* v_scale = nullptr, int int8_kv = 0);
 
+// Fused QK-norm + partial-RoPE + KV-append (Qwen3.6 gated full-attn layers, bf16 KV).
+void launch_qknorm_rope_kv_partial(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
+    float theta, float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr,
+    void* k_scale = nullptr, void* v_scale = nullptr, int int8_kv = 0);
+
 // Fused RoPE + paged KV-append: ropes Q in place, ropes K straight into k_pool, copies V into
 // v_pool — one kernel replacing launch_rope + launch_kv_append. positions == write_pos (decode).
 void launch_rope_kv_append(

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -70,10 +70,16 @@ void launch_gemv_q_dp4a_pq_f32(const void* q8, const float* ad, const float* as,
 size_t llama_q8_1_bytes(int K);
 void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
+void launch_mmvq_q4k_qkv_fused(const void* q81, const void* Wq, const void* Wk, const void* Wv,
+                                 void* yq, void* yk, void* yv, int Nq, int Nk, int Nv, int K,
+                                 cudaStream_t stream = nullptr);
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 // Same, for Q6_K weights (attn-V upgrades + LM head). q81 = block_q8_1(activation).
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
+// Q8_0 x Q8_1 dp4a mmvq (Q8_0 weights kept int8; Qwen3.6 UD-quant attention/GDN projections).
+void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
+void launch_mmvq_q80_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 // 1-warp-per-row Q6_K dp4a GEMV (large-N, e.g. LM head): GEMV_WPB rows/block.
 void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -61,8 +61,11 @@ int main(int argc, char** argv) {
     // int8 KV pays off only once the halved long-context read outweighs its fixed per-token write cost,
     // so enable it context-adaptively (>= 8k) by default; short contexts stay bf16 (no regression).
     // SPARKINFER_KV_INT8=1/0 forces it on/off regardless.
-    // int8 KV is the Qwen3-MoE head_dim=128 path; the hybrid Qwen3.6 (gated head_dim=256) writes bf16 KV.
-    { const char* e8 = getenv("SPARKINFER_KV_INT8"); kvc.int8_kv = !cfg.hybrid && (e8 ? (e8[0] != '0') : (context_tokens >= 8192)); }
+    // int8 KV: Qwen3-MoE hd=128 enables at ctx>=8k; Qwen3.6 hybrid hd=256 at ctx>=512 (tensor-core FA).
+    { const char* e8 = getenv("SPARKINFER_KV_INT8");
+      if (e8) kvc.int8_kv = (e8[0] != '0');
+      else if (cfg.hybrid) kvc.int8_kv = (context_tokens >= 512);
+      else kvc.int8_kv = (context_tokens >= 8192); }
     const size_t epb=(size_t)16*cfg.n_kv_heads*cfg.head_dim, blocks=(cfg.max_seq+15)/16+8;
     sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers*2*epb*2*blocks);
     sparkinfer::moe::MoEConfig mc;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -143,6 +143,7 @@ struct Qwen35Model::Impl {
     bool use_llama = true; // default ON: faithful llama mmvq for Q4_K attn GEMVs (+9.7%, top1 0.99). =0 disables
     bool use_q6mmvq = true;  // default ON: int8 Q6_K mmvq for attn-V upgrades + LM head. =0 disables
     bool use_qkvstream = true; // default ON: run Q/K/V projections on concurrent streams. =0 disables
+    bool use_qkv_fuse = true;  // default ON: fused Q+K+V Q4_K mmvq (stages aq81 once). =0 disables
     bool use_qkfuse = true;// default ON: fused per-head Q-norm + K-norm (1 kernel). =0 disables
     bool use_ropekv = true;// default ON: fused RoPE + KV-append (1 kernel vs 2). =0 disables
     bool use_attnin = true;// default ON: single fused QK-norm+RoPE+KV-append (1 kernel vs qkfuse+ropekv=2). =0 disables
@@ -245,6 +246,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_ROPEKV")) p_->use_ropekv = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_FNQ"))    p_->use_fnq   = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_QKVSTREAM")) p_->use_qkvstream = !(e[0] == '0');
+    if (const char* e = getenv("SPARKINFER_QKV_FUSE"))  p_->use_qkv_fuse  = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ATTNIN")) p_->use_attnin = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_GDN_PIPE")) p_->use_gdn_pipe = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_SHEXP_PIPE")) p_->use_shexp_pipe = !(e[0] == '0');
@@ -355,10 +357,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
         bool xn_q8_ready = fnq && L > 0;
-        auto prepare_xn_quant = [&](bool any_q4k, bool any_q6k) {
+        auto prepare_xn_quant = [&](bool any_q4k, bool any_q6k, bool any_q80) {
             if (!s.gguf || !s.use_pq) return;
             if (xn_q8_ready) return;
-            if (s.use_llama && (any_q4k || (s.use_q6mmvq && any_q6k))) {
+            if (s.use_llama && (any_q4k || any_q80 || (s.use_q6mmvq && any_q6k))) {
                 kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
                 xn_q8_ready = true;
             } else if (any_q4k) {
@@ -373,6 +375,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
                 else if (s.use_pq && s.use_llama && s.use_q6mmvq && t == 14)
                     kernels::launch_mmvq_q6k(s.aq81, W, y, N, H, pst);
+                else if (s.use_pq && s.use_llama && t == 8)
+                    kernels::launch_mmvq_q80(s.aq81, W, y, N, H, pst);
                 else if (t) kernels::launch_gemv_q(s.xn, W, t, y, N, H, pst);
                 else        kernels::launch_gemv(s.xn, W, y, N, H, pst);
             } else {
@@ -392,6 +396,9 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 } else if (s.use_pq && s.use_llama && s.use_q6mmvq && t == 14) {
                     kernels::launch_quantize_q8_1_blocks(x, s.aq81, K, st);
                     kernels::launch_mmvq_q6k(s.aq81, W, y, N, K, st);
+                } else if (s.use_pq && s.use_llama && t == 8) {
+                    kernels::launch_quantize_q8_1_blocks(x, s.aq81, K, st);
+                    kernels::launch_mmvq_q80(s.aq81, W, y, N, K, st);
                 } else if (t) kernels::launch_gemv_q(x, W, t, y, N, K, st);
                 else          kernels::launch_gemv(x, W, y, N, K, st);
             } else {
@@ -404,7 +411,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                   w.ssm_alpha_type == 12 || w.ssm_beta_type == 12);
             const bool any_q6k = (w.wqkv_type == 14 || w.wqkv_gate_type == 14 ||
                                   w.ssm_alpha_type == 14 || w.ssm_beta_type == 14);
-            prepare_xn_quant(any_q4k, any_q6k);
+            const bool any_q80 = (w.wqkv_type == 8 || w.wqkv_gate_type == 8 ||
+                                  w.ssm_alpha_type == 8 || w.ssm_beta_type == 8 ||
+                                  w.ssm_out_type == 8);
+            prepare_xn_quant(any_q4k, any_q6k, any_q80);
             const bool gdn_pipelined = s.gguf && s.use_gdn_pipe;
             if (gdn_pipelined) {
                 cudaEventRecord(s.ev_pipe_fork, st);
@@ -447,8 +457,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
             if (s.gguf) {
                 const bool any_q4k = (w.wq_type == 12 || w.wk_type == 12 || w.wv_type == 12);
                 const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
-                prepare_xn_quant(any_q4k, any_q6k);
-                if (s.use_qkvstream) {
+                const bool any_q80 = (w.wq_type == 8 || w.wk_type == 8 || w.wv_type == 8 || w.wo_type == 8);
+                prepare_xn_quant(any_q4k, any_q6k, any_q80);
+                const bool qkv_q4k = s.use_pq && s.use_llama &&
+                    w.wq_type == 12 && w.wk_type == 12 && w.wv_type == 12;
+                if (qkv_q4k && s.use_qkv_fuse && H == 2048) {
+                    kernels::launch_mmvq_q4k_qkv_fused(s.aq81, w.wq, w.wk, w.wv,
+                        w.q_has_gate ? s.qraw : s.q, s.k, s.v,
+                        w.q_has_gate ? s.qdim * 2 : s.qdim, s.kvdim, s.kvdim, H, st);
+                } else if (s.use_qkvstream) {
                     cudaEventRecord(s.ev_qkv, st);
                     cudaStreamWaitEvent(s.stream_k, s.ev_qkv, 0);
                     cudaStreamWaitEvent(s.stream_v, s.ev_qkv, 0);
@@ -489,14 +506,22 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                                       s.kv->block_size(), s.kv->max_blocks_per_seq(), st,
                                                       kscale, vscale, kv8 ? 1 : 0);
             } else {
-                // Qwen3.6 (gated / partial-rotary) or non-int8: separate norm + rope + append (bf16 KV)
-                if (s.use_qkfuse)
+                // Qwen3.6 (gated / partial-rotary) or non-int8: fused or separate norm + rope + append
+                if (partial_rope && s.use_qkfuse) {
+                    kernels::launch_qknorm_rope_kv_partial(s.q, s.k, s.v, w.q_norm, w.k_norm,
+                        kv8 ? kpool : (bf16*)kpool, kv8 ? vpool : (bf16*)vpool, btable, s.d_pos, 1,
+                        c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim,
+                        c.rope_theta, c.rms_eps, s.kv->block_size(), s.kv->max_blocks_per_seq(), st,
+                        kscale, vscale, kv8 ? 1 : 0);
+                } else if (s.use_qkfuse)
                     kernels::launch_rmsnorm_qk(s.q, s.k, w.q_norm, w.k_norm, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rms_eps, st);
                 else {
                     kernels::launch_rmsnorm(s.q, w.q_norm, s.q, c.n_q_heads,  c.head_dim, c.rms_eps, st);
                     kernels::launch_rmsnorm(s.k, w.k_norm, s.k, c.n_kv_heads, c.head_dim, c.rms_eps, st);
                 }
-                if (partial_rope) {
+                if (partial_rope && !s.use_qkfuse) {
+                    // qknorm_rope_kv_partial already fused norm + partial-RoPE + KV-append when use_qkfuse;
+                    // a second append would double-rotate Q and overwrite int8 K/V with bf16.
                     kernels::launch_rope_kv_append_partial(s.q, s.k, s.v, (bf16*)kpool, (bf16*)vpool, btable, s.d_pos, 1,
                                                            c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim,
                                                            c.rope_theta, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
@@ -521,17 +546,19 @@ int Qwen35Model::forward_token(int token_id, int position) {
             if (w.q_has_gate)
                 kernels::launch_qwen36_mul_sigmoid(s.attn, s.qgate, s.qdim, st);
 
-            // ---- O projection (main's int8 mmvq path) ----
-            if (s.gguf && s.use_pq && w.wo_type == 12) {
-                if (s.use_llama) {
-                    if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
-                    kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
-                } else {
-                    kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);
-                    kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s, w.wo, s.ao, H, s.qdim, st);
-                }
-            }
-            else if (s.gguf && w.wo_type) kernels::launch_gemv_q(s.attn, w.wo, w.wo_type, s.ao, H, s.qdim, st);
+            // ---- O projection (int8 mmvq path) ----
+            const bool o_q4k = s.gguf && s.use_pq && s.use_llama && w.wo_type == 12;
+            const bool o_q80 = s.gguf && s.use_pq && s.use_llama && w.wo_type == 8;
+            if (o_q4k) {
+                if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
+            } else if (o_q80) {
+                kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                kernels::launch_mmvq_q80(s.aq81, w.wo, s.ao, H, s.qdim, st);
+            } else if (s.gguf && s.use_pq && w.wo_type == 12) {
+                kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);
+                kernels::launch_gemv_q_dp4a_pq(s.aq8, s.aq8_d, s.aq8_s, w.wo, s.ao, H, s.qdim, st);
+            } else if (s.gguf && w.wo_type) kernels::launch_gemv_q(s.attn, w.wo, w.wo_type, s.ao, H, s.qdim, st);
             else if (s.gguf)         kernels::launch_gemv(s.attn, w.wo, s.ao, H, s.qdim, st);
             else                     kernels::launch_gemm(s.attn, w.wo, s.ao, 1, H, s.qdim, 1.f, 0.f, gc, st);
         }


### PR DESCRIPTION
## Summary

- **Q8_0 int8 MMVQ** for GDN and attention projections (`wqkv`, `ssm_out`, `attn_q/k/v/o`) on the UD-Q4_K_M Qwen3.6 path — completes the faithful-MMVQ stack on top of #269's on-read Q8_0 GEMV
- **hd=256 int8 tensor-core flash-decode** (`fa_split_gqa_mma_i8_kernel<256,8>`) for Qwen3.6 full-attention layers when int8 KV is active and `seqlen>512`
- **int8 KV for hybrid partial-RoPE**: fused `qknorm_rope_kv_partial_kernel<true>` + fix dispatch bug where a second `rope_kv_append_partial` overwrote int8 K/V with bf16
- **LM head activation staging** (`gemv_q6k_dp4a_lm_staged_kernel`, default `SPARKINFER_LM_TC=1`) — stages `aq81` once per CTA for the 248k-row vocab GEMV
- **QKV fused MMVQ** (`launch_mmvq_q4k_qkv_fused`) and Q8_0 pack2 for large GDN projections

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

| | decode tok/s @128 ctx=0 |
|---|---:|
| upstream/main | 375.5 |
| this PR | **385.5** (+2.8%) |

Model: `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`, `n=128`, `bs=1`, `SPARKINFER_BENCH_DEVICE_LOOP=0`

Dominant win is Q8_0 MMVQ on GDN projections; LM staging and hd=256 int8 FA are neutral at short ctx (hybrid is 75% GDN / 25% full-attn). int8 KV + MMA path targets long-context full-attn layers (`ctx≥512` in bench).

## Test plan

- [x] `cmake --build build -j` succeeds
- [x] Bench vs upstream/main on RTX 5090 @128 ctx=0
- [ ] `ctest --test-dir build`
- [ ] `qwen3_gguf_score` accuracy gate on Qwen3.6 hybrid (bf16 KV default in score/generate)
- [ ] Long-context bench (`ctx=4096+`) with `SPARKINFER_KV_INT8=1` — graph invalidation at 8k+ needs follow-up

## Env toggles

| Flag | Default | Effect |
|------|---------|--------|
| `SPARKINFER_LM_TC` | 1 | LM head smem activation staging |
| `SPARKINFER_FAMMA` | 1 | hd=256 int8 MMA flash-decode |
| `SPARKINFER_KV_INT8` | bench: ctx≥512 hybrid | Force int8 KV on/off |
| `SPARKINFER_QKV_FUSE` | 1 | Fused Q+K+V Q4_K mmvq |

