### PR TITLE
perf(qwen3.6): fuse Q-gate + O-proj Q8_1 quantize into one launch

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -444,6 +444,34 @@ __global__ void gated_norm_q8_warp_kernel(const __nv_bfloat16* __restrict__ x,
 template __global__ void gated_norm_q8_warp_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*,
     const __nv_bfloat16*, si_blk_q8_1*, int, float);
 
+// Q-gate (x *= sigmoid(gate)) fused with the O-proj input Q8_1 quantize — bit-identical to
+// mul_sigmoid_kernel (bf16 store) followed by si_quantize_q8_1_blocks (bf16 reload + q8_1).
+// One warp owns one 32-value q8_1 block. The bf16-rounded product (__bfloat162float o
+// __float2bfloat16) reproduces mul_sigmoid's bf16 store byte-for-byte, and the amax/round/
+// scale reduction matches si_quantize_q8_1_blocks exactly. Runs on the gated-Q attention
+// layers of Qwen3.6 only; deletes one launch (the standalone quant) per such layer per token.
+__global__ void mul_sigmoid_q8_kernel(const __nv_bfloat16* __restrict__ x,
+                                      const __nv_bfloat16* __restrict__ gate,
+                                      si_blk_q8_1* __restrict__ out_q8, int n) {
+    const int warpsPB = blockDim.x >> 5;
+    const int ib = blockIdx.x * warpsPB + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (ib >= (n >> 5)) return;
+    const int idx = ib * 32 + lane;
+    const float prod = q36_to_f(x[idx]) * q36_sigmoid(q36_to_f(gate[idx]));
+    const float bv = __bfloat162float(__float2bfloat16(prod));   // bf16-round: matches mul_sigmoid store
+    float a = fabsf(bv);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
+    const float d = a / 127.0f;
+    const int qi = (a == 0.0f) ? 0 : (int)roundf(bv / d);
+    out_q8[ib].qs[lane] = (signed char)qi;
+    int s = qi;
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+    if (lane == 0) out_q8[ib].ds = __floats2half2_rn(d, d * (float)s);
+}
+
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/fused.h"
 
@@ -470,6 +498,16 @@ void launch_qwen36_mul_sigmoid(void* x_bf16, const void* gate_bf16, int n,
     mul_sigmoid_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
         reinterpret_cast<__nv_bfloat16*>(x_bf16),
         reinterpret_cast<const __nv_bfloat16*>(gate_bf16), n);
+}
+
+void launch_qwen36_mul_sigmoid_q8(const void* x_bf16, const void* gate_bf16, void* out_q8,
+                                  int n, cudaStream_t stream) {
+    const int nb = n >> 5, warpsPB = 8;                          // n must be a multiple of 32
+    dim3 grid((nb + warpsPB - 1) / warpsPB);
+    mul_sigmoid_q8_kernel<<<grid, warpsPB * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(gate_bf16),
+        reinterpret_cast<si_blk_q8_1*>(out_q8), n);
 }
 
 void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32,

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -57,6 +57,12 @@ void launch_qwen36_split_q_gate(const void* qg_bf16, void* q_bf16, void* gate_bf
 void launch_qwen36_mul_sigmoid(void* x_bf16, const void* gate_bf16, int n,
                                cudaStream_t stream = nullptr);
 
+// Fused Q-gate + O-proj-input Q8_1 quant: out_q8 = quantize_q8_1(x * sigmoid(gate)).
+// Bit-identical to launch_qwen36_mul_sigmoid followed by launch_quantize_q8_1_blocks.
+// n must be a multiple of 32.
+void launch_qwen36_mul_sigmoid_q8(const void* x_bf16, const void* gate_bf16, void* out_q8,
+                                  int n, cudaStream_t stream = nullptr);
+
 void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32,
                                   cudaStream_t stream = nullptr);
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -559,13 +559,26 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                                s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits,
                                                1.f / sqrtf((float)c.head_dim), st,
                                                emit_attn_q8 ? s.aq81 : nullptr, seqlen, kscale, vscale, kv8 ? 1 : 0);
-            if (w.q_has_gate)
-                kernels::launch_qwen36_mul_sigmoid(s.attn, s.qgate, s.qdim, st);
+            // When the O-proj takes the llama block-q8_1 mmvq path (wo_type Q4_K/Q8_0), fuse the
+            // Q-gate (mul_sigmoid) with that path's input Q8_1 quantize into ONE launch instead of
+            // two — bit-identical (bf16-rounded x*sigmoid(gate) -> same q8_1 blocks). Off => the
+            // original mul_sigmoid + standalone quantize_q8_1_blocks. Guard keeps Qwen3-30B (no
+            // q_has_gate) and non-mmvq wo paths on the unchanged code.
+            static int gate_q8 = -1;
+            if (gate_q8 < 0) { const char* e = getenv("SPARKINFER_GATE_Q8"); gate_q8 = (e && e[0] == '0') ? 0 : 1; }
+            const bool gate_q8_fuse = gate_q8 && w.q_has_gate && s.gguf && s.use_pq && s.use_llama &&
+                                      (w.wo_type == 12 || w.wo_type == 8) && (s.qdim % 32 == 0);
+            if (w.q_has_gate) {
+                if (gate_q8_fuse)
+                    kernels::launch_qwen36_mul_sigmoid_q8(s.attn, s.qgate, s.aq81, s.qdim, st);
+                else
+                    kernels::launch_qwen36_mul_sigmoid(s.attn, s.qgate, s.qdim, st);
+            }
 
             // ---- O projection (main's int8 mmvq path) ----
             if (s.gguf && s.use_pq && w.wo_type == 12) {
                 if (s.use_llama) {
-                    if (!emit_attn_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                    if (!emit_attn_q8 && !gate_q8_fuse) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
                     kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
                 } else {
                     kernels::launch_quantize_q8_1(s.attn, s.aq8, s.aq8_d, s.aq8_s, s.qdim, st);
@@ -573,7 +586,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
             }
             else if (s.gguf && s.use_pq && s.use_llama && w.wo_type == 8) {
-                kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
+                if (!gate_q8_fuse) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
                 kernels::launch_mmvq_q80(s.aq81, w.wo, s.ao, H, s.qdim, st);
             }
             else if (s.gguf && w.wo_type) kernels::launch_gemv_q(s.attn, w.wo, w.wo_type, s.ao, H, s.qdim, st);


### PR DESCRIPTION
## Summary

One bit-identical launch fusion on the Qwen3.6 gated-Q attention decode path. On the full-attention (gated-Q) layers, the Q-gate `attn *= sigmoid(qgate)` (`mul_sigmoid_kernel`, bf16 store) is immediately followed by the O-projection mmvq path re-reading `attn` to produce its Q8_1 activation (`si_quantize_q8_1_blocks`) — two back-to-back launches. `mul_sigmoid_q8_kernel` does both in **one** launch (one warp per 32-value Q8_1 block), deleting a per-layer graph node. Decode is CUDA-graph / launch-bound, so per-layer launches cost real time.

**Bit-identical to `main`:** the fused kernel bf16-rounds `x*sigmoid(gate)` (`__bfloat162float(__float2bfloat16(...))`) exactly as `mul_sigmoid`'s bf16 store, then runs the amax/round/scale reduction copied verbatim from `si_quantize_q8_1_blocks`. It mirrors the existing `gated_norm_q8_warp_kernel` (same gated-op + quant fusion, already validated bit-identical). `SPARKINFER_GATE_Q8=0` reproduces `main` exactly. **No-op for Qwen3-30B** (no `q_has_gate`) and for non-mmvq `wo` paths — the guard cannot regress them. Touches only the Q-gate→quant pair; does not modify any mmvq/GDN/MoE/router/shared-expert kernel.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

Decode tok/s (end-to-end, `qwen3_gguf_bench Qwen3.6-35B-A3B-UD-Q4_K_M 256`, ctx=0, bs=1). Interleaved A/B on one binary (`SPARKINFER_GATE_Q8` toggled), 3 runs each:

| | decode tok/s |
|---|--:|
| before (`SPARKINFER_GATE_Q8=0`, == main) | 405.79 |
| after (this PR, default) | 407.21 |

+1.42 tok/s (**+0.35%**). Small and honestly reported — the fusion applies only to the 10 full-attention layers (the 30 GDN-linear layers have no uncontested fusable pair). `SPARKINFER_GATE_Q8=0` reproduces `main` exactly.

## Correctness

- **Bit-identical** to `main` by construction (bf16-rounded product → identical Q8_1 blocks; reduction order copied verbatim from the standalone quantizer).
- `ctest` **7/7 passed** (incl. both GPU tests).
- `compute-sanitizer --tool memcheck` **0 errors**.
