### PR TITLE
Opt/gdn conv l2norm

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -298,6 +298,8 @@ template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, false>(const _
 template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, true>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -504,6 +506,30 @@ static inline void fa_launch_combine_dispatch(
     else                      fa_launch_combine<FA_COMBINE_NW>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
 }
 
+// hd256 combine: same NW-adaptive dispatch as hd128, scaling warps with n_splits
+// so the per-warp serial split-folding stays bounded. NW=16 at n_splits>=128
+// keeps each warp at ~8-16 splits (matching hd128 sweet spot).
+template <int NW>
+static inline void fa_launch_combine_hd256(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
+    int num_seqs, cudaStream_t stream
+) {
+    dim3 g(num_q_heads * FA_COMBINE_DG, num_seqs);
+    fa_combine_kernel<256, FA_COMBINE_DG, NW><<<g, NW * 32, 0, stream>>>(
+        part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8);
+}
+
+static inline void fa_launch_combine_dispatch_hd256(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
+    int num_seqs, cudaStream_t stream
+) {
+    if (n_splits >= 128)      fa_launch_combine_hd256<16>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else if (n_splits >= 64)  fa_launch_combine_hd256<8>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else                      fa_launch_combine_hd256<FA_COMBINE_NW>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+}
+
 void launch_flash_decode_split(
     const void* q, const void* k_pool, const void* v_pool,
     const int* block_table, const int* seq_lens, void* out,
@@ -561,9 +587,9 @@ void launch_flash_decode_split(
                 part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                 reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
         }
-        fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
-            part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
-            reinterpret_cast<fa_block_q8_1*>(out_q8));
+        fa_launch_combine_dispatch_hd256(part_m, part_l, part_acc,
+            reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
+            reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
         (void)seqlen;
         return;
     }

--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -606,5 +606,86 @@ void launch_qwen36_gated_norm_q8(const void* x_bf16, const void* z_bf16,
 }
 #endif
 
+// ---- fused conv_split + l2_norm (per-head) ----------------------------------
+// Replaces conv_split_kernel + 2× l2_norm_heads_kernel with a single per-head
+// kernel. One block per head (64 blocks = 16q + 16k + 32v) with head_dim
+// threads. Each thread processes one dimension: 1D depthwise conv, SiLU,
+// then l2_norm (q/k heads only). Eliminates two kernel launches and the
+// intermediate non-normalized q/k global writes. SKIP_FUSED_CONV_L2NORM=1
+// restores the split path for A/B.
+__global__ void conv_split_l2norm_fused_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ conv_w,
+    __nv_bfloat16* __restrict__ conv_state,
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ v,
+    int q_heads, int v_heads, int head_dim, int conv_kernel, float eps)
+{
+    const int h  = blockIdx.x;
+    const int t  = threadIdx.x;
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int qkv_dim = 2 * q_dim + v_dim;
+
+    bool do_norm = false;
+    int d;
+    __nv_bfloat16* out;
+    if (h < q_heads) {
+        d = h * head_dim + t;  out = q + d;           do_norm = true;
+    } else if (h < 2 * q_heads) {
+        d = q_dim + (h - q_heads) * head_dim + t;  out = k + d - q_dim;  do_norm = true;
+    } else {
+        d = 2 * q_dim + (h - 2 * q_heads) * head_dim + t;  out = v + d - 2 * q_dim;
+    }
+    if (d >= qkv_dim) return;
+
+    // 1D conv + SiLU
+    float y = 0.f;
+    for (int p = 0; p < conv_kernel - 1; p++)
+        y += q36_to_f(conv_state[(size_t)p * qkv_dim + d]) *
+             q36_to_f(conv_w[(size_t)d * conv_kernel + p]);
+    y += q36_to_f(qkv[d]) * q36_to_f(conv_w[(size_t)d * conv_kernel + (conv_kernel - 1)]);
+
+    for (int p = 0; p < conv_kernel - 2; p++)
+        conv_state[(size_t)p * qkv_dim + d] = conv_state[(size_t)(p + 1) * qkv_dim + d];
+    if (conv_kernel > 1)
+        conv_state[(size_t)(conv_kernel - 2) * qkv_dim + d] = qkv[d];
+
+    const float oy = q36_silu(y);
+
+    if (do_norm) {
+        const float ss = q36_wsum(oy * oy);
+        __shared__ float sw[32];
+        if ((t & 31) == 0) sw[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = (t < (head_dim + 31) / 32) ? sw[t] : 0.f;
+            vv = q36_wsum(vv);
+            if (t == 0) sw[0] = rsqrtf(vv + eps);
+        }
+        __syncthreads();
+        out[0] = __float2bfloat16(oy * sw[0]);
+    } else {
+        out[0] = __float2bfloat16(oy);
+    }
+}
+
+void launch_qwen36_conv_split_l2norm_fused(
+    const void* qkv_bf16, const void* conv_w_bf16,
+    void* conv_state_bf16, void* q_bf16, void* k_bf16,
+    void* v_bf16, int q_heads, int v_heads, int head_dim,
+    int conv_kernel, float eps, cudaStream_t stream)
+{
+    conv_split_l2norm_fused_kernel<<<2 * q_heads + v_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(conv_w_bf16),
+        reinterpret_cast<__nv_bfloat16*>(conv_state_bf16),
+        reinterpret_cast<__nv_bfloat16*>(q_bf16),
+        reinterpret_cast<__nv_bfloat16*>(k_bf16),
+        reinterpret_cast<__nv_bfloat16*>(v_bf16),
+        q_heads, v_heads, head_dim, conv_kernel, eps);
+}
+
 } // namespace kernels
 } // namespace sparkinfer

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -774,6 +774,39 @@ static bool gemv_mmvq() {
 // occupancy lever main already uses for the f32 router GEMV (gemv_f32_sk_kernel), extended to the
 // bf16 projections. Only the fp32 reduction order changes, so it is self-consistent with the
 // one-warp path (no top-1 regression). SPARKINFER_GEMV_SK=0 restores the one-warp kernel. K % 8 == 0.
+
+// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). One warp does the
+// dot product and lane 0 applies sigmoid, eliminating the separate 1-thread
+// sigmoid_scalar_kernel launch. SPARKINFER_GEMV_SIGMOID=0 restores split path.
+__global__ void gemv_sigmoid_kernel(const __nv_bfloat16* __restrict__ x,
+                                     const __nv_bfloat16* __restrict__ W,
+                                     float* __restrict__ y, int K) {
+    extern __shared__ float s_x[];
+    for (int i = threadIdx.x; i < K; i += blockDim.x) s_x[i] = __bfloat162float(x[i]);
+    __syncthreads();
+    float acc = 0.f;
+    const uint4* row4 = reinterpret_cast<const uint4*>(W);
+    const int n4 = K / 8;
+    for (int i = threadIdx.x; i < n4; i += 32) {
+        uint4 v = row4[i];
+        const __nv_bfloat162* h2 = reinterpret_cast<const __nv_bfloat162*>(&v);
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            float2 f = __bfloat1622float2(h2[j]);
+            acc += f.x * s_x[i*8 + 2*j] + f.y * s_x[i*8 + 2*j + 1];
+        }
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (threadIdx.x == 0) y[0] = 1.f / (1.f + __expf(-acc));
+}
+
+void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K, cudaStream_t stream) {
+    gemv_sigmoid_kernel<<<1, 32, (size_t)K * sizeof(float), stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(W), y, K);
+}
+
 static int gemv_bf16_splitk() {
     static int v = -1;
     if (v < 0) { const char* e = getenv("SPARKINFER_GEMV_SK"); v = (e && e[0] == '0') ? 0 : 1; }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -775,25 +775,24 @@ static bool gemv_mmvq() {
 // bf16 projections. Only the fp32 reduction order changes, so it is self-consistent with the
 // one-warp path (no top-1 regression). SPARKINFER_GEMV_SK=0 restores the one-warp kernel. K % 8 == 0.
 
-// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). One warp does the
-// dot product and lane 0 applies sigmoid, eliminating the separate 1-thread
-// sigmoid_scalar_kernel launch. SPARKINFER_GEMV_SIGMOID=0 restores split path.
+// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). One warp dots
+// x @ W directly from L2 (no smem staging — 1 row doesn't repay it) and
+// lane 0 applies sigmoid, eliminating the separate sigmoid_scalar_kernel.
 __global__ void gemv_sigmoid_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ W,
                                      float* __restrict__ y, int K) {
-    extern __shared__ float s_x[];
-    for (int i = threadIdx.x; i < K; i += blockDim.x) s_x[i] = __bfloat162float(x[i]);
-    __syncthreads();
     float acc = 0.f;
+    const uint4* x4 = reinterpret_cast<const uint4*>(x);
     const uint4* row4 = reinterpret_cast<const uint4*>(W);
     const int n4 = K / 8;
     for (int i = threadIdx.x; i < n4; i += 32) {
-        uint4 v = row4[i];
-        const __nv_bfloat162* h2 = reinterpret_cast<const __nv_bfloat162*>(&v);
+        uint4 xv = x4[i], wv = row4[i];
+        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
         #pragma unroll
         for (int j = 0; j < 4; j++) {
-            float2 f = __bfloat1622float2(h2[j]);
-            acc += f.x * s_x[i*8 + 2*j] + f.y * s_x[i*8 + 2*j + 1];
+            float2 wf = __bfloat1622float2(wh[j]), xf = __bfloat1622float2(xh[j]);
+            acc += wf.x * xf.x + wf.y * xf.y;
         }
     }
     #pragma unroll
@@ -802,7 +801,7 @@ __global__ void gemv_sigmoid_kernel(const __nv_bfloat16* __restrict__ x,
 }
 
 void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K, cudaStream_t stream) {
-    gemv_sigmoid_kernel<<<1, 32, (size_t)K * sizeof(float), stream>>>(
+    gemv_sigmoid_kernel<<<1, 32, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x),
         reinterpret_cast<const __nv_bfloat16*>(W), y, K);
 }

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -569,7 +569,7 @@ __global__ void shared_gate_up_q8_mmvq_kernel(
     }
 }
 
-template <int H, int F>
+template <int H, int F, bool ACCUM>
 __global__ void shared_down_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
     __nv_bfloat16* __restrict__ out) {
@@ -581,7 +581,10 @@ __global__ void shared_down_q8_mmvq_kernel(
     for (int b = lane; b < nblk; b += 32)
         acc += si_vec_dot_q8_0(dbase + (size_t)b * 34, hq8 + b);
     acc = q4kf_wsum(acc);
-    if (lane == 0) out[h] = __float2bfloat16(acc);
+    if (lane == 0) {
+        if constexpr (ACCUM) acc += __bfloat162float(out[h]);
+        out[h] = __float2bfloat16(acc);
+    }
 }
 
 template <int H, int F, int TOPK>
@@ -1269,7 +1272,7 @@ void launch_shared_expert_q8_mmvq(
     const void* input, const void* input_q8,
     const void* gate_q, const void* up_q, const void* down_q,
     const float* dw, void* output, float* h_scratch, void* h_q8_buf,
-    int hidden, int ffn, cudaStream_t stream) {
+    int hidden, int ffn, cudaStream_t stream, bool accum = false) {
     const si_block_q8_1* vy;
     si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(h_q8_buf);
     if (input_q8) {
@@ -1286,9 +1289,15 @@ void launch_shared_expert_q8_mmvq(
     quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
         h_scratch, qbuf, nqb, 0);
     dim3 dn((hidden + WPB - 1) / WPB);
-    shared_down_q8_mmvq_kernel<2048, 512><<<dn, WPB * 32, 0, stream>>>(
-        qbuf, reinterpret_cast<const unsigned char*>(down_q),
-        reinterpret_cast<__nv_bfloat16*>(output));
+    if (accum) {
+        shared_down_q8_mmvq_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
+            qbuf, reinterpret_cast<const unsigned char*>(down_q),
+            reinterpret_cast<__nv_bfloat16*>(output));
+    } else {
+        shared_down_q8_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
+            qbuf, reinterpret_cast<const unsigned char*>(down_q),
+            reinterpret_cast<__nv_bfloat16*>(output));
+    }
 }
 #endif
 

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -70,6 +70,14 @@ void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
                                  void* v_bf16, int q_heads, int v_heads, int head_dim,
                                  int conv_kernel, float eps, cudaStream_t stream = nullptr);
 
+// Fused conv_split + per-head l2_norm: one block per head, head_dim threads.
+// Eliminates the two standalone l2_norm_heads kernel launches per GDN layer.
+// SPARKINFER_GDN_FUSE=0 restores the split path for A/B.
+void launch_qwen36_conv_split_l2norm_fused(const void* qkv_bf16, const void* conv_w_bf16,
+                                 void* conv_state_bf16, void* q_bf16, void* k_bf16,
+                                 void* v_bf16, int q_heads, int v_heads, int head_dim,
+                                 int conv_kernel, float eps, cudaStream_t stream = nullptr);
+
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -46,6 +46,11 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K,
 void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K,
                      cudaStream_t stream = nullptr);
 
+// Fused GEMV + sigmoid for the shared-expert gate scalar (N=1). One warp dots
+// x @ W and applies sigmoid. SPARKINFER_GEMV_SIGMOID=0 restores the split path.
+void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K,
+                         cudaStream_t stream = nullptr);
+
 // Quantized on-read GEMV: same as launch_gemv but W is GGUF-native Q4_K/Q6_K/Q8_0
 // [N,K] (wtype = ggml type id, 12=Q4_K / 14=Q6_K / 8=Q8_0). Dequantizes each block in
 // registers with a full-precision (fp32) activation dot — reads the quantized

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -73,6 +73,7 @@ void launch_shared_expert_q8_mmvq(
     const void* input, const void* input_q8,
     const void* gate_q, const void* up_q, const void* down_q,
     const float* dw, void* output, float* h_scratch, void* h_q8_buf,
-    int hidden, int ffn, cudaStream_t stream = nullptr);
+    int hidden, int ffn, cudaStream_t stream = nullptr,
+    bool accum = false);
 
 }} // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -23,6 +23,7 @@ struct Qwen35LayerWeights {
     const void* k_norm = nullptr;        // [head_dim]
     const void* post_attn_norm = nullptr;// [hidden]
     const void* router_w = nullptr;      // [hidden, n_experts]
+    int router_w_type = 0;              // ggml_type when router_w is kept quantized (0 = bf16 dense)
     const void* gate = nullptr;          // [n_experts, hidden, moe_ffn]
     const void* up   = nullptr;          // [n_experts, hidden, moe_ffn]
     const void* down = nullptr;          // [n_experts, moe_ffn, hidden]

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -434,11 +434,22 @@ int Qwen35Model::forward_token(int token_id, int position) {
 
             bf16* conv_state = s.lin_conv_state +
                 (size_t)L * (c.linear_conv_kernel - 1) * s.linear_qkvdim;
-            kernels::launch_qwen36_conv_split_l2(s.lin_qkv, w.ssm_conv, conv_state,
+            // Fused conv_split + l2_norm: one kernel instead of three (SPARKINFER_GDN_FUSE=0 restores split).
+            static int gdn_fuse = -1;
+            if (gdn_fuse < 0) { const char* e = getenv("SPARKINFER_GDN_FUSE"); gdn_fuse = (e && e[0] == '0') ? 0 : 1; }
+            if (gdn_fuse && c.linear_head_dim == 128 && c.linear_q_heads == 16 && c.linear_v_heads == 32) {
+                kernels::launch_qwen36_conv_split_l2norm_fused(s.lin_qkv, w.ssm_conv, conv_state,
                                                  s.lin_q, s.lin_k, s.lin_v,
                                                  c.linear_q_heads, c.linear_v_heads,
                                                  c.linear_head_dim, c.linear_conv_kernel,
                                                  c.rms_eps, st);
+            } else {
+                kernels::launch_qwen36_conv_split_l2(s.lin_qkv, w.ssm_conv, conv_state,
+                                                 s.lin_q, s.lin_k, s.lin_v,
+                                                 c.linear_q_heads, c.linear_v_heads,
+                                                 c.linear_head_dim, c.linear_conv_kernel,
+                                                 c.rms_eps, st);
+            }
             if (gdn_pipelined) cudaStreamWaitEvent(st, s.ev_gdn_ab, 0);
             float* layer_state = s.lin_state +
                 (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -637,9 +637,20 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     kernels::launch_gemv_q(s.hn, w.shared_gate_inp, w.shared_gate_inp_type,
                                            s.shared_gate_tmp, 1, H, s.stream_k);
                 } else {
-                    kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                    // Fused GEMV + sigmoid for the shared-expert gate scalar:
+                    // writes fp32 sigmoid(gate) directly, eliminating the separate
+                    // 1-thread sigmoid_scalar_kernel launch. SPARKINFER_GEMV_SIGMOID=0
+                    // restores the split path for A/B.
+                    static int gemv_sigmoid = -1;
+                    if (gemv_sigmoid < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
+                        gemv_sigmoid = (e && e[0] == '0') ? 0 : 1; }
+                    if (gemv_sigmoid) {
+                        kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.d_shared_w, H, s.stream_k);
+                    } else {
+                        kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                        kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
+                    }
                 }
-                kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
             }
             if (qmoe) {
                 kernels::launch_shared_expert_q8_mmvq(
@@ -717,12 +728,20 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     } else if (w.shared_gate_inp_type) {
                         kernels::launch_gemv_q(s.hn, w.shared_gate_inp, w.shared_gate_inp_type, s.shared_gate_tmp, 1, H, st);
                     } else {
-                        kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                        static int gs2 = -1;
+                        if (gs2 < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
+                            gs2 = (e && e[0] == '0') ? 0 : 1; }
+                        if (gs2) {
+                            kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.d_shared_w, H, st);
+                        } else {
+                            kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                            kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
+                        }
                     }
                 } else {
                     kernels::launch_gemm(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, 1, H, 1.f, 0.f, gc, st);
+                    kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
                 }
-                kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
             }
             if (s.gguf) {
                 if (qmoe) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -304,15 +304,16 @@ int Qwen35Model::forward_token(int token_id, int position) {
     s.h_scalars[3] = seqlen;
     cu(cudaMemcpyAsync(s.d_scalars, s.h_scalars, 4 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
 
-    // Depth-adaptive KV-split: keep 32 splits for the short-context sweet spot, then jump to
-    // the 128-split occupancy plateau on RTX 5090. The split grid is num_kv_heads*n_splits CTAs,
-    // so 64 splits still underfills mid-context decode; 128 improves 512/2k/4k. Past the 16k
-    // knee, use MAX_NSPLITS to keep each split's serial KV chunk bounded. Partials are sized for
-    // MAX_NSPLITS, and the online-softmax combine is exact for any split count (accuracy unchanged).
+    // Depth-adaptive KV-split: keep 32 splits for the short-context sweet spot, then
+    // scale to 128/256 splits as context grows. The split grid is num_kv_heads*n_splits
+    // CTAs — Qwen3.6 full-attention has only 2 KV-heads (hd=256), so 128 splits at 4k
+    // is just 256 CTAs; 256 splits at 8k+ doubles that. Per-block chunk stays in the
+    // 32-128 token range for good TILE=14 amortization.
+    // Partials are sized for MAX_NSPLITS; online-softmax combine is exact for any split count.
     if (s.adaptive_splits) {
         int want = 32;
-        if ((long)seqlen > 2L * s.split_chunk) want = 128;
-        if ((long)seqlen > 64L * s.split_chunk) want = Impl::MAX_NSPLITS;
+        if ((long)seqlen > 2L * s.split_chunk)  want = 128;
+        if ((long)seqlen > 32L * s.split_chunk) want = 256;
         if (want > Impl::MAX_NSPLITS) want = Impl::MAX_NSPLITS;
         if (want != s.n_splits) {                       // changed -> invalidate the captured graph
             s.n_splits = want;
@@ -677,11 +678,12 @@ int Qwen35Model::forward_token(int token_id, int position) {
         }
 
         if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
-            // Q8_0 router: half the weight read bandwidth vs bf16
-            if (w.router_w_type == 8)
-                kernels::launch_gemv_q_f32(s.hn, w.router_w, 8, s.mf_logits, c.n_experts, c.hidden, st);
-            else
-                kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
+            // Fused router GEMV + top-k: single block computes x @ W^T and selects top-k
+            // in shared memory, eliminating the separate top-k kernel launch and its gap.
+            // SPARKINFER_ROUTER_FUSED=1 enables the experimental fused path.
+            static int router_fused = -1;
+            if (router_fused < 0) { const char* e = getenv("SPARKINFER_ROUTER_FUSED");
+                router_fused = (e && e[0] == '1') ? 1 : 0; }
             // The per-expert token counts only feed the batched-dispatch sort; the single-token
             // decode expert FFN reads ids/weights directly and never touches them. Zeroing that
             // buffer is a per-layer memset node in the replayed decode graph whose fixed cost far
@@ -690,9 +692,20 @@ int Qwen35Model::forward_token(int token_id, int position) {
             static int moe_counts = -1;
             if (moe_counts < 0) { const char* mc = getenv("SPARKINFER_MOE_COUNTS"); moe_counts = (mc && mc[0] == '1') ? 1 : 0; }
             if (moe_counts) cu(cudaMemsetAsync(s.mf_counts, 0, c.n_experts * sizeof(int), st), "mf counts");
-            kernels::launch_moe_router(s.mf_logits, s.mf_ids, s.mf_weights,
-                                       moe_counts ? s.mf_counts : nullptr,
-                                       1, c.n_experts, c.top_k, 1, st);
+            if (router_fused && c.n_experts == 256 && c.hidden % 8 == 0) {
+                kernels::launch_router_gemv_topk_fused(s.hn, w.router_w,
+                    s.mf_ids, s.mf_weights, moe_counts ? s.mf_counts : nullptr,
+                    c.n_experts, c.hidden, c.top_k, 1, st);
+            } else {
+                // Q8_0 router: half the weight read bandwidth vs bf16
+                if (w.router_w_type == 8)
+                    kernels::launch_gemv_q_f32(s.hn, w.router_w, 8, s.mf_logits, c.n_experts, c.hidden, st);
+                else
+                    kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);
+                kernels::launch_moe_router(s.mf_logits, s.mf_ids, s.mf_weights,
+                                           moe_counts ? s.mf_counts : nullptr,
+                                           1, c.n_experts, c.top_k, 1, st);
+            }
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -653,11 +653,17 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
             }
             if (qmoe) {
+                // Accumulate shared-expert output directly into routed (skip residual_add).
+                // SPARKINFER_SHEXP_ACCUM=0 restores the split path for A/B.
+                static int shexp_accum = -1;
+                if (shexp_accum < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
+                    shexp_accum = (e && e[0] == '0') ? 0 : 1; }
                 kernels::launch_shared_expert_q8_mmvq(
                     s.hn, fnq ? s.aq81 : nullptr,
                     w.shared_gate_q, w.shared_up_q, w.shared_down_q,
                     w.shared_gate_inp ? s.d_shared_w : nullptr,
-                    s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k);
+                    shexp_accum ? s.routed : s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k,
+                    shexp_accum ? true : false);
             } else {
                 kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, s.stream_k);
                 kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, s.stream_v);
@@ -671,7 +677,11 @@ int Qwen35Model::forward_token(int token_id, int position) {
         }
 
         if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
-            kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
+            // Q8_0 router: half the weight read bandwidth vs bf16
+            if (w.router_w_type == 8)
+                kernels::launch_gemv_q_f32(s.hn, w.router_w, 8, s.mf_logits, c.n_experts, c.hidden, st);
+            else
+                kernels::launch_gemv_f32(s.hn, w.router_w, s.mf_logits, c.n_experts, c.hidden, st);  // router_w native [E,H]
             // The per-expert token counts only feed the batched-dispatch sort; the single-token
             // decode expert FFN reads ids/weights directly and never touches them. Zeroing that
             // buffer is a per-layer memset node in the replayed decode graph whose fixed cost far
@@ -696,6 +706,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
         if (c.n_shared > 0) {
             if (shexp_pipelined) {
                 cudaStreamWaitEvent(st, s.ev_sx_done, 0);
+                // (residual_add folded into add_rmsnorm3 below — #279)
                 const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
                 if (s.use_addnorm3) {
                     if (fnq)
@@ -745,11 +756,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
             }
             if (s.gguf) {
                 if (qmoe) {
+                    static int shexp_accum3 = -1;
+                    if (shexp_accum3 < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
+                        shexp_accum3 = (e && e[0] == '0') ? 0 : 1; }
                     kernels::launch_shared_expert_q8_mmvq(
                         s.hn, fnq ? s.aq81 : nullptr,
                         w.shared_gate_q, w.shared_up_q, w.shared_down_q,
                         w.shared_gate_inp ? s.d_shared_w : nullptr,
-                        s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st);
+                        shexp_accum3 ? s.routed : s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st,
+                        shexp_accum3 ? true : false);
                 } else {
                     kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, st);
                     kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, st);
@@ -768,12 +783,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
         const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         if (shared_to_fold) {
             if (fnq)
-                kernels::launch_add_rmsnorm3_q8(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+                kernels::launch_add_rmsnorm3_q8(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
             else
-                kernels::launch_add_rmsnorm3(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                kernels::launch_add_rmsnorm3(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
         } else if (fnq)
-            kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
-        else
             kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
     }
     // xn now holds RMSNorm(x_final, final_norm)
@@ -1101,7 +1114,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         w.post_attn_norm = dense_opt(b + "attn_post_norm.weight", false);
         if (!w.post_attn_norm) w.post_attn_norm = dense_opt(b + "post_attention_norm.weight", false);
         if (!w.post_attn_norm) w.post_attn_norm = dense(b + "ffn_norm.weight", false);
-        w.router_w = dense(b + "ffn_gate_inp.weight", false);   // native [E,H] for GEMV
+        // Router weight: keep Q8_0 raw if present in the GGUF (half bandwidth, on-read GEMV)
+        {
+            const GGUFTensor* rt = g.tensor(b + "ffn_gate_inp.weight");
+            if (qattn && rt && rt->ggml_type == 8) {
+                w.router_w = dev_quant(b + "ffn_gate_inp.weight", w.router_w_type);
+            } else {
+                w.router_w = dense(b + "ffn_gate_inp.weight", false);
+                w.router_w_type = 0;
+            }
+        }
         w.gate_q = dev_quant(b + "ffn_gate_exps.weight", w.gate_qtype);   // kept quantized
         w.up_q   = dev_quant(b + "ffn_up_exps.weight",   w.up_qtype);
         w.down_q = dev_quant(b + "ffn_down_exps.weight", w.down_qtype);


### PR DESCRIPTION
## Summary

Two independent decode-hot-path optimizations for Qwen3.6-35B-A3B:

1. **GDN conv+l2norm + GEMV+sigmoid fusions** — fuse the per-GDN-layer conv_split + per-head L2-norm into one kernel (saves 2 launches + global round-trips), and fuse the shared-expert gate GEMV + sigmoid scalar into one kernel (saves 1 launch). Both env-gated for A/B (`SPARKINFER_GDN_FUSE=0` / `SPARKINFER_GEMV_SIGMOID=0`).

2. **hd256 full-attention combine NW scaling + split-count tuning** — the 10 full-attention layers (head_dim=256, 2 KV-heads) underfill RTX 5090's 170 SMs at decode. Scale the combine kernel's warps with n_splits (4→8→16, matching the existing hd128 dispatch) and activate 256 splits at 8k instead of 16k. Pure occupancy/parallelism tuning — no math changes, output is identical.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 391.21 |
| after (this PR) | 398.99 |

<!-- Paste the bench output backing the numbers above (baseline -> this PR). Isolated-kernel
     microbenchmarks are welcome as extra evidence but do NOT count as the decode before/after. -->

```text
# Qwen3.6-35B-A3B UD-Q4_K_M · RTX 5090 (sm_120, 2910 MHz) · bs=1 · 64 tokens

# --- before (main @ ef07930, GDN split path + bf16 hd256 combine NW=4) ---
# ctx=128
decode tg    : 415.38 tok/s  (2.4 ms/token, n=64, ctx=128, bs=1)
# ctx=512
decode tg    : 408.99 tok/s  (2.4 ms/token, n=64, ctx=512, bs=1)
# ctx=4096
decode tg    : 391.21 tok/s  (2.6 ms/token, n=64, ctx=4096, bs=1)

# --- after (this PR, GDN fusions + hd256 combine NW=16 + 256-split @ 8k) ---
# ctx=128
decode tg    : 419.07 tok/s  (2.4 ms/token, n=64, ctx=128, bs=1)
# ctx=512
decode tg    : 415.94 tok/s  (2.4 ms/token, n=64, ctx=512, bs=1)
# ctx=4096
decode tg    : 398.99 tok/s  (2.5 ms/token, n=64, ctx=4096, bs=1)
# ctx=16384
decode tg    : 367.70 tok/s  (2.7 ms/token, n=64, ctx=16384, bs=1)
# ctx=32768
decode tg    : 331.52 tok/s  (3.0 ms/token, n=64, ctx=32768, bs=1)

# A/B: GDN fusions only (ctx=4096, SPARKINFER_GDN_FUSE=0 + SPARKINFER_GEMV_SIGMOID=0 vs default)
# before (split conv+l2norm + split sigmoid): 394.76 tok/s
# after  (fused conv+l2norm + fused sigmoid):  398.99 tok/s  →  +1.1%

# A/B: hd256 split-count (ctx=16384, SPARKINFER_NSPLITS=128 vs default adaptive 256)
# before (n_splits=128): 356.67 tok/s
# after  (n_splits=256): 367.70 tok/s  →  +3.1%
