### PR TITLE
gitignore: keep .env.eval out of version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ __pycache__/
 /models/
 dist/
 .claude
+.env.eval


### PR DESCRIPTION
Small housekeeping — .env.eval holds local eval-bot secrets and shouldn't be tracked.