### PR TITLE
fix(runtime): thread seq_id through decode_layer's KV block-table lookup

### DIFF
--- a/runtime/include/sparkinfer/decode.h
+++ b/runtime/include/sparkinfer/decode.h
@@ -35,9 +35,12 @@ public:
                  int max_batch = 256);
     ~DecodeRunner();
 
-    // Begin a decode step: set the new-token position for each sequence
-    // (host seq_lens = length BEFORE this token). Uploads positions to device.
-    void begin_step(const std::vector<int>& seq_lens_before);
+    // Begin a decode step: bind each batch row to its sequence and set its new-token
+    // position (host seq_lens = length BEFORE this token). Uploads positions to device and
+    // gathers each seq_id's KV block table into a contiguous per-batch scratch buffer —
+    // batch row order is not guaranteed to match physical KV-slot order once sequences have
+    // been freed/reallocated, so decode_layer can no longer assume row i lives in slot i.
+    void begin_step(const std::vector<uint64_t>& seq_ids, const std::vector<int>& seq_lens_before);
 
     // Run one layer in-place on x: [num_seqs, hidden] (bf16, device).
     void decode_layer(int layer, void* x, int num_seqs,

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -29,6 +29,8 @@ struct DecodeRunner::Impl {
     // scratch (bf16 unless noted)
     bf16 *xn, *q, *k, *v, *attnout, *ao, *h, *hn, *moeout;
     int *d_seq_lens, *d_write_pos;
+    int mbps = 0;                    // kv->max_blocks_per_seq(), cached at construction
+    int* d_batch_block_table = nullptr;  // [max_batch, mbps] gathered per begin_step, shared across layers
 
     template <class T> T* alloc(size_t n) { void* p = nullptr; cu(cudaMalloc(&p, n * sizeof(T)), "malloc"); return (T*)p; }
 };
@@ -39,6 +41,7 @@ DecodeRunner::DecodeRunner(int hidden, AttnConfig attn, KVCacheManager* kv,
     p_->hidden = hidden; p_->attn = attn; p_->kv = kv; p_->moe = moe; p_->max_batch = max_batch;
     p_->qdim  = attn.num_q_heads  * attn.head_dim;
     p_->kvdim = attn.num_kv_heads * attn.head_dim;
+    p_->mbps  = kv->max_blocks_per_seq();
     const int M = max_batch;
     p_->xn      = p_->alloc<bf16>((size_t)M * hidden);
     p_->q       = p_->alloc<bf16>((size_t)M * p_->qdim);
@@ -51,26 +54,44 @@ DecodeRunner::DecodeRunner(int hidden, AttnConfig attn, KVCacheManager* kv,
     p_->moeout  = p_->alloc<bf16>((size_t)M * hidden);
     p_->d_seq_lens  = p_->alloc<int>(M);
     p_->d_write_pos = p_->alloc<int>(M);
+    p_->d_batch_block_table = p_->alloc<int>((size_t)M * p_->mbps);
 }
 
 DecodeRunner::~DecodeRunner() {
     cudaFree(p_->xn); cudaFree(p_->q); cudaFree(p_->k); cudaFree(p_->v);
     cudaFree(p_->attnout); cudaFree(p_->ao); cudaFree(p_->h); cudaFree(p_->hn); cudaFree(p_->moeout);
-    cudaFree(p_->d_seq_lens); cudaFree(p_->d_write_pos);
+    cudaFree(p_->d_seq_lens); cudaFree(p_->d_write_pos); cudaFree(p_->d_batch_block_table);
     delete p_;
 }
 
-void DecodeRunner::begin_step(const std::vector<int>& seq_lens_before) {
+void DecodeRunner::begin_step(const std::vector<uint64_t>& seq_ids,
+                              const std::vector<int>& seq_lens_before) {
     const int n = (int)seq_lens_before.size();
-    if (n <= 0 || n > p_->max_batch) {
-        fprintf(stderr, "[decode] begin_step: num_seqs %d out of range (max_batch=%d)\n",
-                n, p_->max_batch);
+    if (n <= 0 || n > p_->max_batch || (int)seq_ids.size() != n) {
+        fprintf(stderr, "[decode] begin_step: num_seqs %d (seq_ids=%zu) out of range/mismatched (max_batch=%d)\n",
+                n, seq_ids.size(), p_->max_batch);
         return;
     }
     std::vector<int> after(n);
     for (int i = 0; i < n; i++) after[i] = seq_lens_before[i] + 1;   // include the new token
     cu(cudaMemcpy(p_->d_write_pos, seq_lens_before.data(), n * sizeof(int), cudaMemcpyHostToDevice), "wpos");
     cu(cudaMemcpy(p_->d_seq_lens,  after.data(),           n * sizeof(int), cudaMemcpyHostToDevice), "slens");
+
+    // Gather each row's block table into a contiguous per-batch scratch buffer. The KV-append
+    // and flash-decode kernels index block_table[row * max_blocks_per_seq], which assumes row i
+    // lives at offset i in the source buffer — that only holds for seq_ids[i]'s *actual* physical
+    // slot, not for a fixed row==slot layout (KVCacheManager recycles slots via a LIFO free-list
+    // independent of batch position, so slot reuse breaks that assumption).
+    for (int i = 0; i < n; i++) {
+        const int* src = p_->kv->block_table(seq_ids[i]);
+        if (!src) {
+            fprintf(stderr, "[decode] begin_step: seq_id %llu has no allocated KV slot\n",
+                    (unsigned long long)seq_ids[i]);
+            return;
+        }
+        cu(cudaMemcpy(p_->d_batch_block_table + (size_t)i * p_->mbps, src,
+                      p_->mbps * sizeof(int), cudaMemcpyDeviceToDevice), "gather block table");
+    }
 }
 
 void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
@@ -96,7 +117,7 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     // 3. append new K/V into the paged cache for this layer
     bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)layer * s.kv->layer_stride_elems();
     bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)layer * s.kv->layer_stride_elems();
-    int* btable = s.kv->block_table(0);   // batch occupies slots 0..num_seqs-1
+    int* btable = s.d_batch_block_table;  // gathered per-row (seq_id -> slot) in begin_step
     launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
                      num_seqs, s.attn.num_kv_heads, s.attn.head_dim,
                      s.kv->block_size(), s.kv->max_blocks_per_seq(), stream);

--- a/runtime/tests/decode_runner_gpu_test.cpp
+++ b/runtime/tests/decode_runner_gpu_test.cpp
@@ -72,8 +72,9 @@ int main() {
     void* x = dev_rand_bf16((size_t)seqs * H, 1.f);
 
     cudaStream_t stream; cudaStreamCreate(&stream);
-    std::vector<int> lens(seqs, 7);                 // 7 tokens already cached
-    runner.begin_step(lens);
+    std::vector<uint64_t> seq_ids = {0, 1};          // matches kv.allocate(0,...), kv.allocate(1,...)
+    std::vector<int> lens(seqs, 7);                  // 7 tokens already cached
+    runner.begin_step(seq_ids, lens);
     for (int l = 0; l < layers; l++) runner.decode_layer(l, x, seqs, w[l], stream);
     cudaStreamSynchronize(stream);
 
@@ -85,5 +86,30 @@ int main() {
     for (size_t i = 0; i < hx.size(); i++) if (!std::isfinite(bf162f(hx[i]))) { printf("[FAIL] non-finite output at %zu\n", i); return 1; }
 
     printf("[PASS] decode_runner_gpu_test: %d layers x %d seqs, output finite\n", layers, seqs);
+
+    // --- Regression: KV slot reuse must not desync batch row -> physical slot -------------
+    // Free seq 1's slot and allocate a brand-new sequence (id 99) into it. Under the old
+    // block_table(0)-based code this recycled slot would silently break the row<->slot
+    // assumption; here begin_step's per-row gather keeps it correct regardless of physical
+    // slot layout. Batch order is deliberately non-slot-order: [seq 0, seq 99].
+    kv.free(1);
+    const uint64_t reused_id = 99;
+    if (!kv.allocate(reused_id, 64)) { printf("[FAIL] kv allocate (reused slot)\n"); return 1; }
+
+    void* x2 = dev_rand_bf16((size_t)seqs * H, 1.f);
+    std::vector<uint64_t> seq_ids2 = {0, reused_id};
+    std::vector<int> lens2 = {7, 0};                 // reused_id is a fresh sequence: 0 cached tokens
+    runner.begin_step(seq_ids2, lens2);
+    for (int l = 0; l < layers; l++) runner.decode_layer(l, x2, seqs, w[l], stream);
+    cudaStreamSynchronize(stream);
+
+    err = cudaGetLastError();
+    if (err != cudaSuccess) { printf("[FAIL] cuda error after slot reuse: %s\n", cudaGetErrorString(err)); return 1; }
+
+    std::vector<uint16_t> hx2((size_t)seqs * H);
+    cudaMemcpy(hx2.data(), x2, hx2.size() * sizeof(uint16_t), cudaMemcpyDeviceToHost);
+    for (size_t i = 0; i < hx2.size(); i++) if (!std::isfinite(bf162f(hx2[i]))) { printf("[FAIL] non-finite output after slot reuse at %zu\n", i); return 1; }
+
+    printf("[PASS] decode_runner_gpu_test: slot-reuse regression (free+realloc mid-stream), output finite\n");
     return 0;
 }


### PR DESCRIPTION
Closes #289

## Summary

`DecodeRunner::decode_layer` looked up the batch's KV block table via a hardcoded
`block_table(0)`, implicitly assuming batch row *i* always lives in physical KV slot *i*. That
only holds on a cold start; once any sequence is freed and a slot is recycled (normal
continuous-batching churn — `KVCacheManager` reuses slots via a LIFO free-list keyed by
`seq_id`, independent of batch position), it either null-derefs (if seq_id 0 isn't currently
live) or silently cross-contaminates unrelated sequences' KV history (if slots aren't
contiguous after seq_id 0).

Fix: `DecodeRunner::begin_step` now takes the batch's `seq_ids` and gathers each row's real
block table (`kv->block_table(seq_ids[i])`) into a contiguous per-batch scratch buffer once
per step (paging is layer-independent, so this is reused across all layers). `decode_layer`
reads from that gathered buffer instead of assuming row == slot.

## Changes

- `runtime/include/sparkinfer/decode.h` — `begin_step(seq_ids, seq_lens_before)`.
- `runtime/src/decode_layer.cpp` — per-batch block-table scratch buffer + gather in
  `begin_step`; `decode_layer` uses the gathered buffer instead of `block_table(0)`.
- `runtime/tests/decode_runner_gpu_test.cpp` — updated call site; added a slot-reuse
  regression (free a sequence, allocate a new one into the recycled slot, decode a batch
  ordered out of slot order, assert no crash / finite output).

## Proof of speedup

N/A — correctness/API fix, no decode-path performance change. Per CONTRIBUTING.md this scores
`eval:none` (0 SN74 reward) but is eligible for normal review/merge.

- [ ] Tested on **RTX 5090** (`sm_120`)

**Benchmark log** (before → after):

```text
N/A
```

| | decode tok/s |
|---|--:|
| before | N/A |
| after  | N/A |

## Verification checklist (fill in before opening)

- [ ] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j`
- [ ] `ctest --test-dir build` — 5/5, including the new slot-reuse case in
      `decode_runner_gpu_test`
- [ ] `bench/scripts/accuracy.sh --download` — confirm no regression (this PR shouldn't
      change accuracy at all; it only fixes a batching-identity bug not yet exercised by any
      production caller)
- [ ] `compute-sanitizer` clean, if available

*Not yet run in this environment — no CUDA toolkit or GPU available here. Run the above on
your RTX 5090 box before submitting.*
