### PR TITLE
perf(qwen3.6): adaptive combine warps for the hd256 flash-decode (long-context occupancy)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -298,6 +298,10 @@ template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, false>(const _
 template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, true>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+// hd256 adaptive combine: at long context n_splits reaches 128/256, so scale the folding warps
+// (NW) like the hd128 path instead of a fixed NW=4 that serially folds 64 partials per warp.
+template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -504,6 +508,27 @@ static inline void fa_launch_combine_dispatch(
     else                      fa_launch_combine<FA_COMBINE_NW>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
 }
 
+// hd256 counterpart — same adaptive NW selection (byte-exact combine; only the fold parallelism changes).
+template <int NW>
+static inline void fa_launch_combine_hd256(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
+    int num_seqs, cudaStream_t stream
+) {
+    dim3 g(num_q_heads * FA_COMBINE_DG, num_seqs);
+    fa_combine_kernel<256, FA_COMBINE_DG, NW><<<g, NW * 32, 0, stream>>>(
+        part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8);
+}
+static inline void fa_launch_combine_dispatch_hd256(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
+    int num_seqs, cudaStream_t stream
+) {
+    if (n_splits >= 128)      fa_launch_combine_hd256<16>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else if (n_splits >= 64)  fa_launch_combine_hd256<8>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else                      fa_launch_combine_hd256<FA_COMBINE_NW>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+}
+
 void launch_flash_decode_split(
     const void* q, const void* k_pool, const void* v_pool,
     const int* block_table, const int* seq_lens, void* out,
@@ -515,7 +540,6 @@ void launch_flash_decode_split(
     // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). Use the GQA-8 shared-KV tile
     // path (same 8:1 grouping as Qwen3 hd=128) — cuts KV global reads ~8x vs one-warp-per-q-head.
     if (head_dim == 256) {
-        dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
         // int8-KV tensor-core path for hd256 (long context): same gating as the hd128 MMA path
         // (block_size==16 so each warp maps to one physical block, chunk >= 2 blocks to fill the GPU).
         static int famma256 = -1;
@@ -534,9 +558,8 @@ void launch_flash_decode_split(
                     reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
                     part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                     reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
-                fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
-                    part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
-                    reinterpret_cast<fa_block_q8_1*>(out_q8));
+                fa_launch_combine_dispatch_hd256(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                    num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
                 (void)seqlen;
                 return;
             }
@@ -561,9 +584,8 @@ void launch_flash_decode_split(
                 part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                 reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
         }
-        fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
-            part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
-            reinterpret_cast<fa_block_q8_1*>(out_q8));
+        fa_launch_combine_dispatch_hd256(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+            num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
         (void)seqlen;
         return;
     }


### PR DESCRIPTION
## Summary

The hd256 (Qwen3.6 full-attention) split-combine launched a **fixed `NW=4`** folding warps regardless of `n_splits`, so at long context (16k/32k → `n_splits`=128/256) each of 4 warps serially folds 32–64 split-partials on only `num_q_heads × DG = 64` CTAs — badly underfilling the GPU on the exact long-context path #284 just sped up. This mirrors the **hd128** path's adaptive dispatch (`NW=16` at `n_splits≥128`, `8` at `≥64`, else `4`).

Byte-exact: only the fold parallelism changes — the combine result is identical (same as the shipped hd128 adaptive combine), so **accuracy is unaffected**. Pure long-context occupancy win.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `bench/scripts/bench.sh --download --ctx 16384`, Qwen3.6-35B-A3B UD-Q4_K_M, bs=1 — long-context optimization; contexts < 8k are unchanged):

| | decode tok/s |
|---|--:|
| before (main) | 364.53 |
| after (this PR) | 371.56 |

At 32k the gain is larger (more splits → worse combine underfill): main 337.76 → this PR **349.86** (+3.6%).

```text
== ctx=16384 ==
before (main, fixed NW=4)  : decode tg  364.53 tok/s  (n=128, ctx=16384, bs=1)
after  (this PR, adaptive) : decode tg  371.56 tok/s  (n=128, ctx=16384, bs=1)
== ctx=32768 ==
before (main, fixed NW=4)  : decode tg  337.76 tok/s  (n=128, ctx=32768, bs=1)
after  (this PR, adaptive) : decode tg  349.86 tok/s  (n=128, ctx=32768, bs=1)
```

## What changed
- `flash_decode_split.cu`: instantiate `fa_combine_kernel<256,DG,8>` / `<256,DG,16>`, add `fa_launch_combine_dispatch_hd256` (adaptive NW by `n_splits`, mirroring the hd128 dispatch), and route both hd256 combine sites (int8-MMA and tile paths) through it. Accuracy-preserving (byte-exact combine).