### PR TITLE
Complete MoE MMVQ PDL chain for bs=1 decode launch overlap

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -40,6 +40,24 @@ __device__ __forceinline__ void si_pdl_sync() {
     cudaGridDependencySynchronize();
 #endif
 }
+// Exactly-once programmatic completion trigger from the last CTA in a 1-D grid.
+__device__ __forceinline__ void si_pdl_lc_grid1(int pdl) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && !defined(SPARKINFER_NVRTC_DEVICE_ONLY)
+    if (pdl && blockIdx.x == gridDim.x - 1 && threadIdx.x == 0) {
+        __threadfence();
+        cudaTriggerProgrammaticLaunchCompletion();
+    }
+#endif
+}
+// Exactly-once programmatic completion trigger from the last CTA in a 2-D grid.
+__device__ __forceinline__ void si_pdl_lc_grid2(int pdl) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900) && !defined(SPARKINFER_NVRTC_DEVICE_ONLY)
+    if (pdl && blockIdx.x == gridDim.x - 1 && blockIdx.y == gridDim.y - 1 && threadIdx.x == 0) {
+        __threadfence();
+        cudaTriggerProgrammaticLaunchCompletion();
+    }
+#endif
+}
 
 __device__ __forceinline__ float q4kf_h2f(const unsigned char* p) {
     __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
@@ -154,9 +172,8 @@ __global__ void gate_up_q4k_kernel(
 __global__ void gate_up_q4k_mmvq_kernel(
     const __nv_bfloat16* __restrict__ input, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
-    float* __restrict__ h_scratch, int H, int F, int top_k
+    float* __restrict__ h_scratch, int H, int F, int top_k, int pdl
 ) {
-    si_pdl_lc();   // PDL: let the dependent down kernel begin its grid spin-up now
     extern __shared__ char smem_mmvq[];
     float* s_xd = reinterpret_cast<float*>(smem_mmvq);   // [H/32] activation scales
     float* s_xs = s_xd + (H >> 5);                        // [H/32] Q8_1 sum (d*sum)
@@ -185,7 +202,7 @@ __global__ void gate_up_q4k_mmvq_kernel(
     __syncthreads();
 
     const int f = blockIdx.y * WPB + warpId;
-    if (f >= F) return;
+    if (f >= F) { si_pdl_lc_grid2(pdl); return; }
     const int nsuper = H >> 8;   // super-blocks of 256
     const unsigned char* gbase = gate_q + ((size_t)e * F + f) * nsuper * 144;
     const unsigned char* ubase = up_q   + ((size_t)e * F + f) * nsuper * 144;
@@ -228,6 +245,7 @@ __global__ void gate_up_q4k_mmvq_kernel(
     }
     float g = q4kf_wsum(acc_g), u = q4kf_wsum(acc_u);
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(g) * u;
+    si_pdl_lc_grid2(pdl);
 }
 
 // down: out[tok,hh] = sum_j weight_j * <h[tok,j], down[e_j, hh]>.
@@ -312,21 +330,23 @@ struct si_block_q8_1 { __half2 ds; signed char qs[32]; };   // 36 B / 32 values 
 // order (block ib covers elements [ib*32, ib*32+32)). One 32-value block per warp.
 __global__ void quant_h_q8_1_kernel(const float* __restrict__ h,
                                     si_block_q8_1* __restrict__ y, int n_blocks, int pdl) {
-    if (pdl) si_pdl_lc();
+    if (pdl) si_pdl_sync();
     const int warpsPB = blockDim.x >> 5;
     const int ib = blockIdx.x * warpsPB + (threadIdx.x >> 5);
     const int lane = threadIdx.x & 31;
-    if (ib >= n_blocks) return;
-    float xv = h[(size_t)ib * 32 + lane], a = fabsf(xv);
-    #pragma unroll
-    for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
-    float d = a / 127.0f;
-    int qi = (a == 0.0f) ? 0 : (int)roundf(xv / d);
-    y[ib].qs[lane] = (signed char)qi;
-    int s = qi;
-    #pragma unroll
-    for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
-    if (lane == 0) y[ib].ds = __floats2half2_rn(d, d * (float)s);
+    if (ib < n_blocks) {
+        float xv = h[(size_t)ib * 32 + lane], a = fabsf(xv);
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
+        float d = a / 127.0f;
+        int qi = (a == 0.0f) ? 0 : (int)roundf(xv / d);
+        y[ib].qs[lane] = (signed char)qi;
+        int s = qi;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+        if (lane == 0) y[ib].ds = __floats2half2_rn(d, d * (float)s);
+    }
+    si_pdl_lc_grid1(pdl);
 }
 
 // Faithful llama.cpp vec_dot_q6_K_q8_1 for one 256-superblock at quant-index iqs (0..31).
@@ -508,9 +528,8 @@ __device__ __forceinline__ float si_vec_dot_q5_K(const si_block_q5_K* bq5, const
 __global__ void gate_up_mmvq2_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
-    float* __restrict__ h_scratch, int H, int F, int top_k
+    float* __restrict__ h_scratch, int H, int F, int top_k, int pdl
 ) {
-    si_pdl_lc();
     constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
     const int row = blockIdx.x, ts = row / F, f = row % F, tok = ts / top_k;
     const int e = expert_ids[ts];
@@ -534,6 +553,7 @@ __global__ void gate_up_mmvq2_kernel(
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+    si_pdl_lc_grid1(pdl);
 }
 
 // ---- Qwen3.6 shared expert (Q8_0 gate/up/down, F=512) -------------------------
@@ -588,9 +608,8 @@ template <int H, int F, int TOPK>
 __global__ void gate_up_mmvq2_qwen_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
-    float* __restrict__ h_scratch
+    float* __restrict__ h_scratch, int pdl
 ) {
-    si_pdl_lc();
     constexpr int NW = 4, WS = 32;
     const int row = blockIdx.x, ts = row / F, f = row - ts * F, tok = ts / TOPK;
     const int e = expert_ids[ts];
@@ -611,20 +630,20 @@ __global__ void gate_up_mmvq2_qwen_kernel(
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+    si_pdl_lc_grid1(pdl);
 }
 
 template <int H, int F, int TOPK>
 __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
-    float* __restrict__ h_scratch, int n_rows
+    float* __restrict__ h_scratch, int n_rows, int pdl
 ) {
-    si_pdl_lc();
     constexpr int NW = 4, WS = 32;
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
     const int group = warp >> 2, group_warp = warp & 3;
     const int row = blockIdx.x * 2 + group;
-    if (row >= n_rows) return;
+    if (row >= n_rows) { si_pdl_lc_grid1(pdl); return; }
     const int ts = row / F, f = row - ts * F, tok = ts / TOPK;
     const int e = expert_ids[ts];
     const int tid4 = group_warp * WS + lane;
@@ -644,6 +663,7 @@ __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+    si_pdl_lc_grid1(pdl);
 }
 
 // int8 dp4a MMVQ down (Q4_K). The Q4_K-quantized down rows in Q4_K_M were the last MoE GEMV
@@ -989,18 +1009,31 @@ static inline int down_mmvq_pdl() {
     return v;
 }
 
+static inline int gu_mmvq_pdl() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_GU_PDL");
+        v = (e && e[0] == '0') ? 0 : 1;
+    }
+    return v;
+}
+
+static inline int moe_mmvq_pdl_chain() {
+    return gu_mmvq_pdl() && down_mmvq_pdl();
+}
+
 template <typename Kernel, typename... Args>
-static inline void launch_mmvq_down_kernel(
-    int pdl, dim3 grid, dim3 block, cudaStream_t stream, Kernel kernel, Args... args
+static inline void launch_mmvq_kernel(
+    int pdl, dim3 grid, dim3 block, size_t smem, cudaStream_t stream, Kernel kernel, Args... args
 ) {
     if (!pdl) {
-        kernel<<<grid, block, 0, stream>>>(args...);
+        kernel<<<grid, block, smem, stream>>>(args...);
         return;
     }
     cudaLaunchConfig_t cfg = {};
     cfg.gridDim = grid;
     cfg.blockDim = block;
-    cfg.dynamicSmemBytes = 0;
+    cfg.dynamicSmemBytes = smem;
     cfg.stream = stream;
     cudaLaunchAttribute attr{};
     attr.id = cudaLaunchAttributeProgrammaticStreamSerialization;
@@ -1008,6 +1041,13 @@ static inline void launch_mmvq_down_kernel(
     cfg.attrs = &attr;
     cfg.numAttrs = 1;
     cudaLaunchKernelEx(&cfg, kernel, args...);
+}
+
+template <typename Kernel, typename... Args>
+static inline void launch_mmvq_down_kernel(
+    int pdl, dim3 grid, dim3 block, cudaStream_t stream, Kernel kernel, Args... args
+) {
+    launch_mmvq_kernel(pdl, grid, block, 0, stream, kernel, args...);
 }
 
 // Dispatch the templated split-K MMVQ down on the runtime split count. WPB=8, so
@@ -1096,6 +1136,15 @@ void launch_moe_expert_ffn_q4k(
     if (gu_spec < 0) { const char* gs = getenv("SPARKINFER_GU_SPEC"); gu_spec = (gs && gs[0] == '0') ? 0 : 1; }
     static int gu_pack2 = -1;
     if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '0') ? 0 : 1; }
+    static int down_mmvq = -1;
+    if (down_mmvq < 0) { const char* dv = getenv("SPARKINFER_DOWN_MMVQ"); down_mmvq = (dv && dv[0] == '0') ? 0 : 1; }
+    static int down_q4k = -1;
+    if (down_q4k < 0) { const char* qv = getenv("SPARKINFER_DOWN_Q4K"); down_q4k = (qv && qv[0] == '0') ? 0 : 1; }
+    static int down_q5k = -1;
+    if (down_q5k < 0) { const char* qv = getenv("SPARKINFER_DOWN_Q5K"); down_q5k = (qv && qv[0] == '0') ? 0 : 1; }
+    const bool mmvq_down = down_mmvq && (down_type == 14
+        || (down_q4k && down_type == 12) || (down_q5k && down_type == 13));
+    const int pdl = mmvq_down && moe_mmvq_pdl_chain();
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
     if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
         const si_block_q8_1* q;
@@ -1108,33 +1157,41 @@ void launch_moe_expert_ffn_q4k(
                 reinterpret_cast<const __nv_bfloat16*>(input), qbuf, num_tokens * hidden);
             q = qbuf;
         }
-        if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
-            gate_up_mmvq2_pack2_qwen_kernel<2048, 512, 8><<<(num_tokens * top_k * ffn + 1) / 2, 8 * 32, 0, stream>>>(
+        const dim3 gu2_block(4 * 32);
+        if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
+            const dim3 gu2_grid((num_tokens * top_k * ffn + 1) / 2);
+            launch_mmvq_kernel(pdl, gu2_grid, dim3(8 * 32), 0, stream, gate_up_mmvq2_pack2_qwen_kernel<2048, 512, 8>,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
-                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, num_tokens * top_k * ffn);
-        else if (gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
-            gate_up_mmvq2_qwen_kernel<2048, 512, 8><<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch,
+                num_tokens * top_k * ffn, pdl);
+        } else if (gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
+            launch_mmvq_kernel(pdl, dim3(num_tokens * top_k * ffn), gu2_block, 0, stream,
+                gate_up_mmvq2_qwen_kernel<2048, 512, 8>,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
-                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
-        else if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 768 && top_k == 8)
-            gate_up_mmvq2_pack2_qwen_kernel<2048, 768, 8><<<(num_tokens * top_k * ffn + 1) / 2, 8 * 32, 0, stream>>>(
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, pdl);
+        } else if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 768 && top_k == 8) {
+            const dim3 gu2_grid((num_tokens * top_k * ffn + 1) / 2);
+            launch_mmvq_kernel(pdl, gu2_grid, dim3(8 * 32), 0, stream, gate_up_mmvq2_pack2_qwen_kernel<2048, 768, 8>,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
-                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, num_tokens * top_k * ffn);
-        else if (gu_spec && hidden == 2048 && ffn == 768 && top_k == 8)
-            gate_up_mmvq2_qwen_kernel<2048, 768, 8><<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch,
+                num_tokens * top_k * ffn, pdl);
+        } else if (gu_spec && hidden == 2048 && ffn == 768 && top_k == 8) {
+            launch_mmvq_kernel(pdl, dim3(num_tokens * top_k * ffn), gu2_block, 0, stream,
+                gate_up_mmvq2_qwen_kernel<2048, 768, 8>,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
-                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
-        else
-            gate_up_mmvq2_kernel<<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, pdl);
+        } else {
+            launch_mmvq_kernel(pdl, dim3(num_tokens * top_k * ffn), gu2_block, 0, stream, gate_up_mmvq2_kernel,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
-                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, hidden, ffn, top_k);
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, hidden, ffn, top_k, pdl);
+        }
     } else if (mmvq && gate_type == 12 && up_type == 12) {   // 12 = ggml Q4_K
         size_t sm = 2 * (size_t)(hidden >> 5) * sizeof(float) + (size_t)hidden;  // s_xd+s_xs+s_xq8
-        gate_up_q4k_mmvq_kernel<<<gu, WPB * 32, sm, stream>>>(
+        launch_mmvq_kernel(pdl, gu, dim3(WPB * 32), sm, stream, gate_up_q4k_mmvq_kernel,
             reinterpret_cast<const __nv_bfloat16*>(input),
             reinterpret_cast<const unsigned char*>(gate_q),
             reinterpret_cast<const unsigned char*>(up_q),
-            expert_ids, h_scratch, hidden, ffn, top_k);
+            expert_ids, h_scratch, hidden, ffn, top_k, pdl);
     } else {
         size_t gu_smem = (size_t)hidden * sizeof(float);   // s_x only; s_deq is static
         gate_up_q4k_kernel<<<gu, WPB * 32, gu_smem, stream>>>(
@@ -1149,14 +1206,12 @@ void launch_moe_expert_ffn_q4k(
     // fp path (gate/up + attention already run int8 MMVQ): quantize the activation h to
     // Q8_1 once (into the otherwise-unused out_scratch) and dp4a the Q6_K weights against
     // it, faithful to llama.cpp vec_dot_q6_K_q8_1.
-    static int down_mmvq = -1;
-    if (down_mmvq < 0) { const char* dv = getenv("SPARKINFER_DOWN_MMVQ"); down_mmvq = (dv && dv[0] == '0') ? 0 : 1; }
     if (down_mmvq && down_type == 14) {   // 14 = ggml Q6_K
         si_block_q8_1* hq8 = reinterpret_cast<si_block_q8_1*>(out_scratch);   // <= hidden floats; fits
         const int nqb = num_tokens * top_k * (ffn >> 5);
         const int qthreads = 256;
-        const int pdl = down_mmvq_pdl();
-        quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
+        const dim3 qh_grid((nqb + (qthreads >> 5) - 1) / (qthreads >> 5));
+        launch_mmvq_kernel(pdl, qh_grid, dim3(qthreads), 0, stream, quant_h_q8_1_kernel,
             h_scratch, hq8, nqb, pdl);
         // split-K MMVQ down (default S=4): S warps/row -> S*H warps in flight, hiding
         // the bs=1 occupancy stall the one-warp kernel hits. Falls back to one-warp if disabled.
@@ -1178,14 +1233,12 @@ void launch_moe_expert_ffn_q4k(
 
     // int8 dp4a MMVQ down (Q4_K) — default ON; SPARKINFER_DOWN_Q4K=0 restores the fp dequant
     // down for the Q4_K rows. Same quantize-once + faithful vec_dot path as the Q6_K down.
-    static int down_q4k = -1;
-    if (down_q4k < 0) { const char* qv = getenv("SPARKINFER_DOWN_Q4K"); down_q4k = (qv && qv[0] == '0') ? 0 : 1; }
     if (down_mmvq && down_q4k && down_type == 12) {   // 12 = ggml Q4_K
         si_block_q8_1* hq8 = reinterpret_cast<si_block_q8_1*>(out_scratch);
         const int nqb = num_tokens * top_k * (ffn >> 5);
         const int qthreads = 256;
-        const int pdl = down_mmvq_pdl();
-        quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
+        const dim3 qh_grid((nqb + (qthreads >> 5) - 1) / (qthreads >> 5));
+        launch_mmvq_kernel(pdl, qh_grid, dim3(qthreads), 0, stream, quant_h_q8_1_kernel,
             h_scratch, hq8, nqb, pdl);
         const int S = down_splitk_s_q4();
         if (S > 1) {
@@ -1207,14 +1260,12 @@ void launch_moe_expert_ffn_q4k(
     // the Q5_K rows. The UD Q4_K_M Qwen3.6 experts keep their down at Q5_K, which fell through both the
     // Q6_K and Q4_K MMVQ paths onto the fp register-dequant down. Same quantize-once + faithful vec_dot
     // pipeline, widened to the 5th bit.
-    static int down_q5k = -1;
-    if (down_q5k < 0) { const char* qv = getenv("SPARKINFER_DOWN_Q5K"); down_q5k = (qv && qv[0] == '0') ? 0 : 1; }
     if (down_mmvq && down_q5k && down_type == 13) {   // 13 = ggml Q5_K
         si_block_q8_1* hq8 = reinterpret_cast<si_block_q8_1*>(out_scratch);
         const int nqb = num_tokens * top_k * (ffn >> 5);
         const int qthreads = 256;
-        const int pdl = down_mmvq_pdl();
-        quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
+        const dim3 qh_grid((nqb + (qthreads >> 5) - 1) / (qthreads >> 5));
+        launch_mmvq_kernel(pdl, qh_grid, dim3(qthreads), 0, stream, quant_h_q8_1_kernel,
             h_scratch, hq8, nqb, pdl);
         const int S = down_splitk_s_q5();
         if (S > 1) {
@@ -1234,12 +1285,12 @@ void launch_moe_expert_ffn_q4k(
 
     static int splitk = -1;
     if (splitk < 0) { const char* sv = getenv("SPARKINFER_SPLITK"); splitk = (sv && sv[0] == '0') ? 0 : 1; }
-    static int pdl = -1;
-    if (pdl < 0) { const char* pv = getenv("SPARKINFER_PDL"); pdl = (pv && pv[0] == '1') ? 1 : 0; }
+    static int fp_pdl = -1;
+    if (fp_pdl < 0) { const char* pv = getenv("SPARKINFER_PDL"); fp_pdl = (pv && pv[0] == '1') ? 1 : 0; }
     if (splitk) {   // split-K down: 4 warps/row -> 4x warps in flight (occupancy lever)
         const int RPB = WPB / 4;
         dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
-        if (pdl) {   // PDL: down's grid spin-up overlaps gate_up's tail (programmatic dependent launch)
+        if (fp_pdl) {   // PDL: down's grid spin-up overlaps gate_up's tail (programmatic dependent launch)
             cudaLaunchConfig_t cfg = {};
             cfg.gridDim = dns; cfg.blockDim = dim3(WPB * 32); cfg.dynamicSmemBytes = 0; cfg.stream = stream;
             cudaLaunchAttribute attr; attr.id = cudaLaunchAttributeProgrammaticStreamSerialization;


### PR DESCRIPTION
## Summary

Completes the Programmatic Dependent Launch (PDL) chain across the three-kernel MoE MMVQ decode path (`gate_up` → `quant_h_q8_1` → `down` MMVQ) in `kernels/csrc/cuda/moe/expert_ffn_q4k.cu`.

NCU profiling identifies bs=1 decode **launch latency** as a bottleneck; down PDL was partially wired but gate_up triggered too early and quant_h used the wrong sync primitive. This PR:

- Moves `cudaTriggerProgrammaticLaunchCompletion` to **after** `h_scratch` writes in all gate_up MMVQ kernels
- Fixes `quant_h_q8_1_kernel`: `si_pdl_sync()` at entry, trigger at grid completion
- Routes gate_up + quant_h through `cudaLaunchKernelEx` programmatic launches (same as down)
- Adds `SPARKINFER_GU_PDL` env knob (default ON, mirrors `SPARKINFER_DOWN_PDL`)

No math change — PDL only overlaps kernel grid spin-up with predecessor tail work.

Closes #297

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 484.79 |
| after (this PR) | 498.12 |

```text
>> GPU arch: sm_120
>> using local build

=== sparkinfer — decode (n=128, ctx=0, bs=1) ===  [main]
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
decode tg    : 484.79 tok/s  (2.1 ms/token, n=128, ctx=0, bs=1)
GPU          : 56°C · 198 W · 2418 MHz (peak under load)

=== sparkinfer — decode (n=128, ctx=0, bs=1) ===  [feat/moe-mmvq-pdl-chain]
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
decode tg    : 498.12 tok/s  (2.0 ms/token, n=128, ctx=0, bs=1)
GPU          : 57°C · 201 W · 2420 MHz (peak under load)

=== ctx=512 guard ===
before: 469.58 tok/s  |  after: 481.04 tok/s  (+2.44%)
```

## Test plan

- [x] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j && ctest --test-dir build`
- [x] `bench/scripts/bench.sh --download` (ctx=0, 512)
- [x] `bench/scripts/accuracy.sh --download` (token-match + KL within gate)