### PR TITLE
fix(kernels): correct hd256 int8-MMA flash-decode output beyond the MMA engagement depth

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -353,12 +353,16 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
     float* s_l  = s_m + 16;                                           // [16]
 
     // Quantize Q per q-head row (warp w owns rows 2w, 2w+1; rows >= GQA are zero pad).
+    // EPT spans the whole head vector: 4 elems/lane at hd128, 8 at hd256. Hardcoding 4 left
+    // s_qi dims 128..255 uninitialized at hd256 (and computed amax over half the row), so the
+    // QK mma k-tiles 8..15 multiplied against stale shared memory.
+    constexpr int EPT = HEAD_DIM / 32;
     #pragma unroll
     for (int rr = 0; rr < 2; rr++) {
         const int r = warp * 2 + rr;
-        float qv[4], amax = 0.f;
+        float qv[EPT], amax = 0.f;
         #pragma unroll
-        for (int e = 0; e < 4; e++) {
+        for (int e = 0; e < EPT; e++) {
             qv[e] = (r < GQA) ? __bfloat162float(q[(size_t)(seq * num_q_heads + kvh * GQA + r) * HEAD_DIM + lane + e * 32]) : 0.f;
             amax = fmaxf(amax, fabsf(qv[e]));
         }
@@ -367,7 +371,7 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
         const float d = amax / 127.0f;
         if (lane == 0) s_qs[r] = d;
         #pragma unroll
-        for (int e = 0; e < 4; e++)
+        for (int e = 0; e < EPT; e++)
             s_qi[r * HEAD_DIM + lane + e * 32] = (signed char)((amax == 0.f) ? 0 : (int)roundf(qv[e] / d));
     }
     for (int i = tid; i < GQA * HEAD_DIM; i += blockDim.x) s_o[i] = 0.f;
@@ -403,7 +407,13 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
                 load_matrix_sync(bf, kb + ks * 16, KVLD);
                 mma_sync(cf, af, bf, cf);
             }
-            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, HEAD_DIM, mem_row_major);
+            // ldm = 128: the QK result is a [16 q-rows x up-to-128 tokens] score tile, so its row
+            // stride is the group token width (128), not HEAD_DIM — the two only coincide at
+            // hd128. With HEAD_DIM as ldm, the hd256 instantiation stored rows 256 apart while
+            // the softmax below reads them 128 apart: rows interleave with garbage, and every
+            // decoded token past the mma-engagement depth is wrong (verified: 100% argmax
+            // divergence vs the exact tile path at >16k on Qwen3.6).
+            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, 128, mem_row_major);
         }
         __syncthreads();
         // Read the raw int32 QK scores directly and apply the per-row/per-token scales inline in the
@@ -453,26 +463,32 @@ __global__ void __launch_bounds__(GQA * 32, 5) fa_split_gqa_mma_i8_kernel(
         }
         __syncthreads();
 
-        // PV int8 mma -> int32; O += int32 * p_scale[m].
-        {
+        // PV int8 mma -> int32; O += int32 * p_scale[m]. The 8 warps cover a 128-wide dim slab
+        // per pass (warp*16 each), so hd128 takes one pass and hd256 two (dh = 0, 128). The
+        // hd256 instantiation previously ran a single pass with HEAD_DIM strides: it computed
+        // only dims 0..127 of O (128..255 stayed at their zero init) and read P' rows at the
+        // wrong stride — both fixed here; ldm for the P' fragment and the int32 store is 128
+        // (the token/slab width), which coincided with HEAD_DIM only at hd128.
+        for (int dh = 0; dh < HEAD_DIM; dh += 128) {
+            fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
+            fragment<matrix_b, 16, 16, 16, signed char, row_major> bf;
             fragment<accumulator, 16, 16, 16, int> cf;
             fill_fragment(cf, 0);
             for (int ks = 0; ks < gblk; ks++) {
                 const int pb = block_table[seq * max_blocks + first_blk + g0 + ks];
-                const signed char* vb = v_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM + warp * 16;
-                fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
-                fragment<matrix_b, 16, 16, 16, signed char, row_major> bf;
-                load_matrix_sync(af, s_pi + ks * 16, HEAD_DIM);
+                const signed char* vb = v_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM + dh + warp * 16;
+                load_matrix_sync(af, s_pi + ks * 16, 128);
                 load_matrix_sync(bf, vb, KVLD);
                 mma_sync(cf, af, bf, cf);
             }
-            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, HEAD_DIM, mem_row_major);
+            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, 128, mem_row_major);
+            __syncthreads();
+            // Only the GQA real q-head rows are kept (rows GQA..15 are wmma M-padding, never
+            // written to the partials) — accumulate this 128-wide slab into s_o at its dh offset.
+            for (int i = tid; i < GQA * 128; i += blockDim.x)
+                s_o[(i >> 7) * HEAD_DIM + dh + (i & 127)] += (float)reinterpret_cast<int*>(s_s)[i] * s_ps[i >> 7];
+            __syncthreads();
         }
-        __syncthreads();
-        // Only the GQA real q-head rows are kept (rows GQA..15 are wmma M-padding, never written to
-        // the partials) — accumulate just those, halving this thread-parallel epilogue at GQA=8.
-        for (int i = tid; i < GQA * 128; i += blockDim.x) s_o[i] += (float)reinterpret_cast<int*>(s_s)[i] * s_ps[i >> 7];
-        __syncthreads();
     }
 
     for (int r = 0; r < GQA; r++) {


### PR DESCRIPTION
## Summary

The hd256 instantiation of `fa_split_gqa_mma_i8_kernel` — the int8 tensor-core flash-decode split enabled for Qwen3.6's ten full-attention layers in #284 — computes wrong output wherever its gate engages (>16k ctx with the current n_splits policy). #299 has the black-box evidence: on current main, 1113/1114 argmax mismatches vs the exact tile path past position 16384, |Δlogprob| 3.9 at the first engaged position on a bit-identical KV prefix.

Four hd256-specific defects, all in the kernel body (hd128 was correct by coincidence of strides):

1. The QK score `store_matrix_sync` used `HEAD_DIM` as ldm. The score tile is [16 q-rows × 128 group tokens], so the row stride is the token width 128; at hd256 rows were stored 256 apart and read 128 apart — the softmax consumed interleaved garbage.
2. The P′ fragment `load_matrix_sync` in the PV phase had the same ldm bug.
3. The PV phase ran a single 128-wide dim pass: O dims 128..255 were never computed and stayed at their zero init.
4. Q quantization hardcoded 4 elems/lane (=128 dims): at hd256, `s_qi` dims 128..255 fed the QK mma uninitialized shared memory, and the per-row amax scale ignored half the vector.

All four fixes are generic in HEAD_DIM; hd128 behavior is unchanged by construction (EPT = HEAD_DIM/32 = 4, ldm 128 == HEAD_DIM, single dh pass), so Qwen3-30B and the Qwen3.6 GDN layers are untouched.

Correctness validation (same probe as #299, RTX 5090, base ee2ff71):

| comparison | ≤16384 | 16385..17499 (MMA engaged) |
| --- | --- | --- |
| main FAMMA=1 vs exact tile (FAMMA=0) | 1 mismatch | 1113/1114 (99.9%), mean abs Δlp 5.32 |
| **this PR** FAMMA=1 vs exact tile | 0 | 168/1114 (15.1%), mean abs Δlp 0.60 |

The residual 15% is flat across the window (14–17% in every 300-position bucket, not accumulating) — the int8 Q/P quantization noise the scheme carries by design, vs a bf16-exact reference at 17k-token attention depth.

ctest: 7/7. accuracy.sh (Qwen3-30B vs pinned llama.cpp): top-1 96/100 = 0.960 (bar >= 0.90), mean KL 0.0495 nats (bar <= 0.20).

## Speed: what this costs vs current main, and what it keeps vs the correct baseline

Straight talk: the broken kernel is artificially fast — it skips half the PV math and half the V reads. Correct math costs some of that back, but keeps most of #284's long-context win over the tile path:

**Decode tok/s** (`qwen3_gguf_bench <gguf> 128 <ctx>`, median of 3, same box, base ee2ff71):

| ctx | main (broken MMA) | main FAMMA=0 (exact tile) | this PR | vs main | vs tile |
| --- | --- | --- | --- | --- | --- |
| 128 | 407.61 | — | 407.72 | +0.03% | — |
| 512 | 400.95 | — | 400.99 | +0.01% | — |
| 4k | 383.70 | — | 383.71 | +0.00% | — |
| 16k | 363.84 | 348.67 | 359.54 | −1.18% (98.82%) | **+3.12%** |
| 32k | 341.27 | 304.10 | 334.91 | −1.86% (98.14%) | **+10.13%** |

All contexts hold ≥98% of main on both models. Qwen3-30B guard (hd128, behavior unchanged by construction): 16k 99.80%, 32k 99.92%, short contexts flat across the full 5-context sweep.

Put differently: the broken kernel inflates the current 16k/32k frontier by +4.35% and +12.22% over the exact tile path. This PR keeps +3.12% / +10.13% of #284's long-context win while producing output that actually matches the model.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

```text
# qwen3_gguf_bench <gguf> 128 <ctx>, interleaved A/B, per-rep decode tok/s (RTX 5090 locked 2550 MHz)
# Qwen3.6-35B-A3B UD-Q4_K_M
ctx      main(1,2,3)              FAMMA=0 tile(1,2,3)      this PR(1,2,3)
128      407.64 407.61 407.61     -                        407.81 407.72 407.72
512      400.90 400.95 400.96     -                        401.07 400.99 400.81
4096     383.71 383.70 383.64     -                        383.69 383.75 383.71
16384    363.79 363.84 363.76*    348.67 348.67 348.68     359.53 359.54 359.38*
32768    341.35 341.27 341.26*    304.10 304.09 304.33     334.91 334.94 334.71*
# Qwen3-30B-A3B Q4_K_M (guard)
16384    309.96 309.69            -                        308.70 309.69
32768    242.28 242.09            -                        242.08 241.91
# *16k/32k main + PR values from the 3-arm run (benchD2); short-ctx rows from the 45-run sweep (benchD).
```

Fixes #299.
