### PR TITLE
dashboard: show eval log run IDs in proof column

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -182,7 +182,8 @@ window.SPARKINFER = {
       "guard_32k_baseline": 363.55,
       "guard_32k_ratio": 1.0003,
       "guard_32k_pass": true,
-      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/blob/main/eval/logs/?run=0239-bffc3e7"
+      "proof_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0239-bffc3e7",
+      "proof_run": "0239-bffc3e7"
     },
     {
       "num": 282,
@@ -229,7 +230,8 @@ window.SPARKINFER = {
       "guard_32k_baseline": 351.42,
       "guard_32k_ratio": 1.0343,
       "guard_32k_pass": true,
-      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/blob/main/eval/logs/?run=0282-1e75ffe"
+      "proof_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0282-1e75ffe",
+      "proof_run": "0282-1e75ffe"
     },
     {
       "num": 284,

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -181,7 +181,8 @@
       "guard_32k_baseline": 363.55,
       "guard_32k_ratio": 1.0003,
       "guard_32k_pass": true,
-      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/blob/main/eval/logs/?run=0239-bffc3e7"
+      "proof_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0239-bffc3e7",
+      "proof_run": "0239-bffc3e7"
     },
     {
       "num": 282,
@@ -228,7 +229,8 @@
       "guard_32k_baseline": 351.42,
       "guard_32k_ratio": 1.0343,
       "guard_32k_pass": true,
-      "proof_url": "https://github.com/gittensor-ai-lab/sparkinfer/blob/main/eval/logs/?run=0282-1e75ffe"
+      "proof_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0282-1e75ffe",
+      "proof_run": "0282-1e75ffe"
     },
     {
       "num": 284,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -429,12 +429,13 @@
   $("labels").innerHTML = D.labels.map(x=>`<span class="lg"><span class="dot" style="background:${x.c}"></span><b style="color:var(--title)">${x.l}</b> — ${x.d}</span>`).join("");
 
   const lc = Object.fromEntries(D.labels.map(x=>[x.l,x.c]));
+  const proofRun = p => p.proof_run || ((p.proof_url||"").match(/[?&]run=([^&]+)/)||[])[1] || "log";
   $("prs").innerHTML = D.prs.length ? D.prs.map(p=>`
     <tr><td><a href="${p.url||'#'}">#${p.num}</a> ${p.title||''}</td>
     <td>${(p.areas||[]).map(a=>`<span class="area">${a}</span>`).join("")||"—"}</td>
     <td><span class="tag" style="background:${lc[p.label]||'#888'}">${p.label}</span></td>
     <td>${p.tps??"—"}</td><td>${p.delta_pct!=null?(p.delta_pct>0?"+":"")+p.delta_pct+"%":"—"}</td>
-    <td>${p.proof_url?`<a href="${p.proof_url}" target="_blank" title="verifiable eval log">🔒 log</a>`:"—"}</td></tr>`).join("")
+    <td>${p.proof_url?`<a href="${p.proof_url}" target="_blank" title="verifiable eval log" class="mono">🔒 ${proofRun(p)}</a>`:"—"}</td></tr>`).join("")
     : `<tr><td colspan="6" class="empty">No PRs evaluated yet — open one and the bot posts an <code>eval:&lt;label&gt;</code> within ~30 min.</td></tr>`;
 </script>
 </body>

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -449,7 +449,7 @@ def push_dash(msg):
 
 LOG_REPO  = os.environ.get("SPARKINFER_LOG_REPO", "https://github.com/gittensor-ai-lab/sparkinfer.git")
 LOG_DIR   = os.path.expanduser(os.environ.get("SPARKINFER_LOG_DIR", "~/.sparkinfer_log_checkout"))
-LOG_PAGE  = "https://github.com/gittensor-ai-lab/sparkinfer/blob/main/eval/logs/?run="
+LOG_PAGE  = "https://gittensor-ai-lab.github.io/sparkinfer-log/?run="
 
 def upload_eval_log(repo, num, title, oid, res, log_text, baseline):
     """Commit this eval's raw log + result to the public sparkinfer-log repo (immutable record),
@@ -581,7 +581,11 @@ def update_dashboard(repo, pr, areas, res, proof_url=None):
               "guard_2k_baseline", "guard_2k_ratio", "guard_2k_pass"):
         if res.get(k) is not None:
             entry[k] = res.get(k)
-    if proof_url: entry["proof_url"] = proof_url
+    if proof_url:
+        entry["proof_url"] = proof_url
+        m = re.search(r"[?&]run=([^&]+)", proof_url)
+        if m:
+            entry["proof_run"] = m.group(1)
     data["prs"] = [p for p in data.get("prs", []) if p.get("num") != num]
     data["prs"].insert(0, entry)
     data["prs"] = data["prs"][:50]


### PR DESCRIPTION
## Summary
- Proof column now links to the actual sparkinfer-log run ID (e.g. `0239-bffc3e7`, `0282-1e75ffe`) instead of generic "🔒 log"
- Fix #239 and #282 `proof_url` to use sparkinfer-log GitHub Pages URLs
- Eval bot now writes `proof_run` and uses the correct `LOG_PAGE` base URL for future evals

## Test plan
- [x] Regenerated `data.js` from `data.json`
- [ ] Open dashboard → Evaluated PRs table shows run IDs for #239 and #282
- [ ] Links resolve to `https://gittensor-ai-lab.github.io/sparkinfer-log/?run=...`


Made with [Cursor](https://cursor.com)