### PR TITLE
polaris: bump TDX attest timeout to 300s

### DIFF
--- a/eval/polaris/client.py
+++ b/eval/polaris/client.py
@@ -103,7 +103,7 @@ class PolarisClient:
         )
 
         try:
-            with urllib.request.urlopen(req, timeout=120) as resp:
+            with urllib.request.urlopen(req, timeout=300) as resp:
                 return json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as e:
             body_text = ""


### PR DESCRIPTION
## Summary
Full Polaris pipeline test hit `TimeoutError` at 120s after a ~17 min GPU eval; retry succeeded in ~16s. Bump TDX attest timeout to 300s for cold enclave spawns.

## Test plan
- [x] Smoke test: `intel_verified=True`
- [x] Full pipeline: GPU eval + `POLARIS_ATTESTATION` + TDX receipt verified (16/16 checks)
- [x] sparkinfer-log upload with Polaris bundle OK