### PR TITLE
perf(qwen3.6): Q4_K on-read LM head for the 35B-A3B hybrid-MoE (reuses #329)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1315,7 +1315,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             has_suffix(name, "attn_output.weight")) return true;
         return false;
     };
-    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K", q35_dense9b_requant_default);
+    // The scored Qwen3.6-35B-A3B hybrid-MoE keeps its output projection in Q6_K. Its LM head is the
+    // single largest weight read per decoded token (vocab 248320 x hidden 2048), so requantizing it
+    // Q6_K->Q4_K at load (via the shared dev_quant_requant_q4k) trims ~2 bits/weight off that read and
+    // decodes it through the same int8 dp4a Q4_K MMVQ. #329's dense-9B default leaves this model
+    // untouched (not dense_ffn); enable it here. SPARKINFER_LMHEAD_REQUANT_Q4K=0 restores Q6_K.
+    const bool q36_moe35b_requant_default =
+        c.hybrid && !c.dense_ffn && c.vocab == 248320 && c.n_layers == 40 &&
+        H == 2048 && c.n_experts == 256 && c.top_k == 8;
+    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K",
+                                       q35_dense9b_requant_default || q36_moe35b_requant_default);
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
         if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8))


### PR DESCRIPTION
## What

Enable the **Q6_K→Q4_K LM-head requant for the scored Qwen3.6-35B-A3B hybrid-MoE**. The output projection (`vocab 248320 × hidden 2048`) is the single largest weight read per decoded token; requantizing it Q6_K→Q4_K at load trims that read ~31% (6.5625 → 4.5 bpw) and decodes it on-read via the existing int8 dp4a Q4_K MMVQ.

## Rebased onto #329 — now a config gate, not new machinery

This PR originally shipped its own requant kernel + load path. Since then **#329 (`perf(qwen35): requant Qwythos Q6 reads to Q4_K`) merged the exact machinery**:

- the shared load-time `dev_quant_requant_q4k()` helper (dequant → Q4_K fit → swap, `type→12`), and
- the `lm_head_type == 12 → launch_mmvq_q4k_f32` decode dispatch.

**#329 defaults the LM-head requant on only for the dense-9B Qwythos** config (`q35_dense9b_requant_default`: `dense_ffn && n_layers==32 && H==4096 && top_k==1`). The scored **Qwen3.6-35B-A3B is hybrid-MoE** (`hidden 2048`, `40` layers, `256` experts, `top_k 8`, **not** `dense_ffn`), so `req_lm_q4` defaults **false** there and its output projection stays Q6_K.

So this PR is now a **10-line diff**: it adds a `q36_moe35b_requant_default` predicate matching that exact config and ORs it into `req_lm_q4`. No new kernel — it reuses #329's merged helper and dispatch. `SPARKINFER_LMHEAD_REQUANT_Q4K=0` restores Q6_K; the Qwen3-30B guard model (different vocab) is untouched.

## Why

The output projection runs once per token and is the largest single weight read on the decode path (~11–12% of decode bandwidth). Every other big projection already runs int8 dp4a / split-K; on the MoE model the LM head was still full Q6_K on-read.

## Results — RTX 5090 (sm_120), same-box A/B

Measured on the **equivalent Q4_K path before #329 merged** (identical dequant + Q4_K fit + `mmvq_q4k_f32`); the numbers carry over since the code path is now #329's. The RTX 5090 eval bot re-confirms the **marginal** gain on the post-#329 frontier.

| context | Q6_K tok/s | Q4_K tok/s | Δ |
|---|---|---|---|
| 128 | 280.08 | 289.47 | **+3.35%** |
| 512 | 277.42 | 286.59 | **+3.31%** |
| 4k | 265.78 | 273.91 | **+3.06%** |

No regression at any context (uniform +3%, since it only shrinks a per-token read).

**Accuracy vs llama.cpp** (pinned reference `6f4f53f`, teacher-forced, 100 positions):

- top-1 token agreement: **0.970** (bar ≥ 0.90)
- mean KL(llama‖spark): **0.0197 nats** (bar ≤ 0.20)
- PPL: 2.83 → 2.86

Correctness stays well inside the gate because the reduction is confined to the final projection.
