### PR TITLE
Document Qwen3-30B and Qwen3.6 quality benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Runtime footprint, excluding model weights and Python launcher scripts:
 | SGLang | runtime + native kernel packages | 1.9 GB | 743x smaller |
 | TensorRT-LLM | runtime package | 3.6 GB | 1,430x smaller |
 
-LLM quality check, 25% benchmark tier, 196 items:
+LLM quality check (`bench/quality`), 25% benchmark tier, 196 items, RTX 5090, greedy decode:
+
+**Qwen3-30B-A3B** (`Qwen3-30B-A3B-Q4_K_M.gguf`):
 
 | runtime | BFCL | GSM8K | HumanEval | IFEval | MMLU-Pro | overall |
 |---|---:|---:|---:|---:|---:|---:|
@@ -42,9 +44,17 @@ LLM quality check, 25% benchmark tier, 196 items:
 | llama.cpp GGUF | 72.00% | 90.91% | 80.00% | 64.58% | 48.00% | 65.90% |
 | vLLM AWQ | 76.00% | 84.85% | 80.00% | 77.08% | 48.00% | 66.92% |
 
-sparkinfer and llama.cpp use the same GGUF on the same RTX 5090. Other runtimes cannot load
-GGUF, so the table uses their fastest successful HF quantized path: vLLM/SGLang GPTQ Int4,
-TensorRT-LLM NVFP4. Details: [`bench/competitors/latest-results.md`](bench/competitors/latest-results.md).
+**Qwen3.6-35B-A3B** (`Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`):
+
+| runtime | BFCL | GSM8K | HumanEval | IFEval | MMLU-Pro | overall |
+|---|---:|---:|---:|---:|---:|---:|
+| sparkinfer GGUF | 74.67% | 63.64% | 60.00% | 83.33% | 64.00% | 68.72% |
+| llama.cpp GGUF | 74.67% | 57.58% | 60.00% | 87.50% | 62.67% | 67.30% |
+
+For each model, sparkinfer and llama.cpp use the **same GGUF** on the same RTX 5090. Other
+runtimes cannot load GGUF, so the Qwen3-30B table includes vLLM AWQ (fastest successful HF
+quant path). Details: [`bench/quality/README.md`](bench/quality/README.md) and
+[`bench/competitors/latest-results.md`](bench/competitors/latest-results.md).
 
 ## How we move fast on SN74
 

--- a/bench/quality/README.md
+++ b/bench/quality/README.md
@@ -46,7 +46,11 @@ python3 run_quality.py --backend sparkinfer \
     --bin ./build/qwen3_gguf_generate \
     --tokenizer /workspace/models/tokenizer.json
 
-# 3. score the llama.cpp reference the same way:
+# 3. score the llama.cpp reference (start llama-server first, then):
+python3 run_quality.py --backend llama-server --llama-url http://localhost:8082 \
+    --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf
+
+# or one-shot llama-cli (reloads model each item — slow for benchmark tier):
 python3 run_quality.py --backend llama \
     --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf \
     --llama-cli /workspace/.llamacpp/build/bin/llama-cli
@@ -69,7 +73,11 @@ diff the per-benchmark percentages. Equal scores mean the optimization is qualit
 | `--tier development` | fast pre-merge capability check | 78 |
 | `--tier benchmark` | heavier release/frontier quality check | 196 |
 
-Current `benchmark` tier comparison on RTX 5090, Qwen3-30B-A3B, greedy decode:
+Current `benchmark` tier comparison on RTX 5090, greedy decode (`bench/quality/run_quality.py --tier benchmark`):
+
+### Qwen3-30B-A3B (Q4_K_M GGUF)
+
+Model: `Qwen/Qwen3-30B-A3B-GGUF` · `Qwen3-30B-A3B-Q4_K_M.gguf`
 
 | Backend | BFCL | GSM8K | HumanEval | IFEval | MMLU-Pro | Overall |
 |---|---:|---:|---:|---:|---:|---:|
@@ -77,8 +85,20 @@ Current `benchmark` tier comparison on RTX 5090, Qwen3-30B-A3B, greedy decode:
 | llama.cpp GGUF | 72.00% | 90.91% | 80.00% | 64.58% | 48.00% | 65.90% |
 | vLLM AWQ | 76.00% | 84.85% | 80.00% | 77.08% | 48.00% | 66.92% |
 
-The vLLM row uses HF AWQ weights because vLLM does not load GGUF. The sparkinfer and llama.cpp
-rows use the same GGUF.
+vLLM uses `cognitivecomputations/Qwen3-30B-A3B-AWQ` (HF AWQ, not GGUF).
+
+### Qwen3.6-35B-A3B (UD-Q4_K_M GGUF)
+
+Model: `unsloth/Qwen3.6-35B-A3B-GGUF` · `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf`  
+Orchestrator: `bench/quality/run_qwen36_benchmark.sh` (sparkinfer first on exclusive GPU, then llama-server).
+
+| Backend | BFCL | GSM8K | HumanEval | IFEval | MMLU-Pro | Overall |
+|---|---:|---:|---:|---:|---:|---:|
+| sparkinfer GGUF | 74.67% | 63.64% | 60.00% | 83.33% | 64.00% | 68.72% |
+| llama.cpp GGUF | 74.67% | 57.58% | 60.00% | 87.50% | 62.67% | 67.30% |
+
+Measured 2026-07-10 on RTX 5090 (`/tmp/qwen36_quality_rerun/`). sparkinfer and llama.cpp rows
+use the same GGUF. Do **not** run both engines resident on GPU simultaneously on 32 GB cards.
 
 ## Data - real ~10% dev samples
 


### PR DESCRIPTION
## Summary
- Add 25% benchmark-tier quality scores for Qwen3-30B-A3B (sparkinfer, llama.cpp, vLLM AWQ) to the main README and `bench/quality/README.md`.
- Add Qwen3.6-35B-A3B quality comparison (sparkinfer vs llama.cpp, same GGUF) from the RTX 5090 rerun.

## Test plan
- [x] Verified tables match measured benchmark results (196 items, greedy decode)
- [x] Links to `bench/quality/README.md` and `bench/competitors/latest-results.md` intact

Made with [Cursor](https://cursor.com)