### PR TITLE
Add triple-eval pipeline for Qwythos-9B miner target

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -15,7 +15,17 @@ EVAL_SSH_PORT=50200
 # GH_TOKEN=
 # FRONTIER=285
 # CEILING=366
-# DUAL=1
+# DUAL=1          # Qwen3.6 primary + Qwen3-30B guard (legacy)
+# TRIPLE=1        # Qwythos-9B primary + Qwen3.6 + Qwen3-30B guards (miner target)
+# PRIMARY_QUANT=Q4_K_M   # Qwythos quant: Q4_K_M | Q8_0 | BF16
+
+# --- Qwythos / Qwen3.5-9B (triple-eval primary) ---
+# QWYTHOS_REPO=empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF
+# QWYTHOS_MODELS_DIR=/workspace/models35
+# QWEN35_9B_Q4K_SHA256=   # pin after first download (sha256sum on eval box)
+# QWEN35_9B_Q8_SHA256=
+# QWEN35_9B_BF16_SHA256=
+# QWEN35_9B_LLAMA_128=0    # llama.cpp reference tok/s (optional display baseline)
 
 # --- optional ---
 # HF_TOKEN=

--- a/bench/configs/models/qwythos_9b.yaml
+++ b/bench/configs/models/qwythos_9b.yaml
@@ -1,0 +1,40 @@
+# Qwythos-9B (Qwen3.5-9B fine-tune) — miner optimization target.
+# Guards: Qwen3.6-35B-A3B + Qwen3-30B-A3B must not regress (evaluate_triple.sh).
+#
+# HF: https://huggingface.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF
+# Architecture: qwen35 (dense MoE 9B, 1M YaRN context in llama.cpp)
+
+model_id: qwythos-9b
+display_name: Qwythos-9B (Qwen3.5-9B)
+hf_repo: empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF
+tokenizer_repo: Qwen/Qwen3.5-9B
+models_dir: /workspace/models35
+
+quants:
+  Q4_K_M:
+    file: Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf
+    size_gib: 5.24
+    default: true
+  Q8_0:
+    file: Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf
+    size_gib: 8.87
+  BF16:
+    file: Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf
+    size_gib: 16.69
+
+guards:
+  - model: Qwen3.6-35B-A3B
+    file: Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
+    dir: /workspace/models36
+  - model: Qwen3-30B-A3B
+    file: Qwen3-30B-A3B-Q4_K_M.gguf
+    dir: /workspace/models
+
+# YaRN enables up to 1M in llama.cpp; probe_max_ctx_llama.sh measured RTX 5090 (32GB) ceiling.
+context:
+  eval_sweep: [128, 512, 4096, 16384, 32768]
+  probe_candidates: [32768, 65536, 131072, 262144, 524288, 786432, 819200, 851968, 1048576]
+  rtx5090_max_ctx_llama:
+    Q4_K_M: 819200   # ~800k tokens
+    Q8_0: 524288     # ~512k tokens
+    BF16: 262144     # ~256k tokens (weights ~17 GiB)

--- a/bench/scripts/_qwythos.sh
+++ b/bench/scripts/_qwythos.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Qwythos-9B (Qwen3.5-9B) model paths — sourced by evaluate_triple.sh and probe_max_ctx.sh.
+# HF: https://huggingface.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF
+
+QWYTHOS_REPO="${QWYTHOS_REPO:-empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF}"
+QWYTHOS_TOK_REPO="${QWYTHOS_TOK_REPO:-Qwen/Qwen3.5-9B}"
+QWYTHOS_MODELS_DIR="${QWYTHOS_MODELS_DIR:-${MODELS_DIR:-/workspace/models}35}"
+
+# PRIMARY_QUANT: Q4_K_M (default) | Q8_0 | BF16
+qwythos_quant_file() {
+  local q="${PRIMARY_QUANT:-Q4_K_M}"
+  case "${q^^}" in
+    BF16)   echo "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf" ;;
+    Q8_0)   echo "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf" ;;
+    Q4_K_M|Q4K|*) echo "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf" ;;
+  esac
+}
+
+qwythos_sha_var() {
+  local q="${PRIMARY_QUANT:-Q4_K_M}"
+  case "${q^^}" in
+    BF16)   echo "${QWEN35_9B_BF16_SHA256:-}" ;;
+    Q8_0)   echo "${QWEN35_9B_Q8_SHA256:-}" ;;
+    *)      echo "${QWEN35_9B_Q4K_SHA256:-}" ;;
+  esac
+}

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -10,6 +10,7 @@
 # measured artifact is the submitted code.
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; source "$HERE/_common.sh"
+[ -f "$HERE/_qwythos.sh" ] && source "$HERE/_qwythos.sh"
 
 REF=""; FRONTIER=0; CEILING=0; GGUF=""
 while [ $# -gt 0 ]; do case "$1" in
@@ -21,6 +22,9 @@ export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"   # persist llama.cp
 # Single-model Qwen3.6 evals must pin the Qwen3.6 GGUF sha (evaluate_dual.sh does this per-model).
 case "$MODEL_FILE" in
   *Qwen3.6*) MODEL_SHA256="${MODEL_SHA256:-${QWEN36_MODEL_SHA256:-}}" ;;
+  *Qwythos*|*Qwen3.5*)
+    _qsha="$(qwythos_sha_var 2>/dev/null || true)"
+    [ -n "$_qsha" ] && MODEL_SHA256="${MODEL_SHA256:-$_qsha}" ;;
 esac
 ARCH="$(detect_arch)"
 

--- a/bench/scripts/evaluate_triple.sh
+++ b/bench/scripts/evaluate_triple.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+# Triple-model evaluation: score Qwythos-9B (Qwen3.5-9B primary) and guard BOTH
+# Qwen3.6-35B-A3B + Qwen3-30B-A3B against no-regression — one build, one box.
+#
+#   bench/scripts/evaluate_triple.sh [--ref GIT_REF] [--ceiling TPS]
+#
+# PRIMARY_QUANT: Q4_K_M (default) | Q8_0 | BF16
+#
+# Env (all optional):
+#   SPARKINFER_P_GUARD_*     Qwythos same-box main tok/s (scored target guards)
+#   SPARKINFER_P_LLAMA_*     Qwythos llama.cpp refs
+#   SPARKINFER_G36_GUARD_*   Qwen3.6 guard baselines
+#   SPARKINFER_G3_GUARD_*    Qwen3-30B guard baselines
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+source "$HERE/_qwythos.sh"
+
+REF=""; CEILING=0
+while [ $# -gt 0 ]; do case "$1" in
+  --ref) shift; REF="$1" ;; --ceiling) shift; CEILING="$1" ;; *) ;;
+esac; shift; done
+
+export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"
+ARCH="$(detect_arch)"
+
+if [ -n "$REF" ] && [ -z "${SI_NO_CHECKOUT:-}" ]; then
+  git -C "$ROOT" fetch -q origin "$REF" 2>/dev/null || true; git -C "$ROOT" checkout -q "$REF"
+fi
+COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
+
+echo ">> [build] submission ($COMMIT) from source (sm_$ARCH) — shared by all models ..." >&2
+rm -rf "$ROOT/build"
+if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
+  echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
+  printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": 0, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false}\n' "$COMMIT"
+  exit 0
+fi
+
+P_FILE="$(qwythos_quant_file)"
+P_REPO="${QWYTHOS_REPO}"
+P_TOK="${QWYTHOS_TOK_REPO}"
+P_DIR="${QWYTHOS_MODELS_DIR}"
+P_SHA="$(qwythos_sha_var)"
+
+G36_FILE="${GUARD36_MODEL_FILE:-Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
+G36_REPO="${GUARD36_MODEL_REPO:-unsloth/Qwen3.6-35B-A3B-GGUF}"
+G36_TOK="${GUARD36_TOK_REPO:-Qwen/Qwen3.6-35B-A3B}"
+G36_DIR="${GUARD36_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}36}"
+
+G3_FILE="${GUARD3_MODEL_FILE:-Qwen3-30B-A3B-Q4_K_M.gguf}"
+G3_REPO="${GUARD3_MODEL_REPO:-Qwen/Qwen3-30B-A3B-GGUF}"
+G3_TOK="${GUARD3_TOK_REPO:-Qwen/Qwen3-30B-A3B}"
+G3_DIR="${GUARD3_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}}"
+
+echo ">> primary: $P_FILE (quant=${PRIMARY_QUANT:-Q4_K_M})" >&2
+echo ">> guards:  Qwen3.6=$G36_FILE  Qwen3-30B=$G3_FILE" >&2
+
+reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
+
+run_model() {
+  local role="$1" file="$2" repo="$3" tok="$4" frontier="$5"; shift 5
+  reap
+  echo ">> [$role] scoring model $file ..." >&2
+  env SI_SKIP_BUILD=1 SI_NO_CHECKOUT=1 \
+      MODEL_FILE="$file" MODEL_REPO="$repo" TOK_REPO="$tok" \
+      "$@" \
+      "$HERE/evaluate.sh" --ref "$REF" --frontier "$frontier" --ceiling "$CEILING" \
+    | sed -n 's/^RESULT_JSON //p' | tail -1
+}
+
+# Auto-measure Qwythos same-box main if baselines unset.
+if [ "${SPARKINFER_P_GUARD_128_BASELINE:-0}" = "0" ]; then
+  echo ">> measuring Qwythos same-box main baseline (5-context sweep) ..." >&2
+  P_GGUF="${P_DIR}/${P_FILE}"
+  resolve_runner "$ARCH"
+  for ctx in 0 512 4096 16384 32768; do
+    t="$(si_run qwen3_gguf_bench "$P_GGUF" 128 "$ctx" 2>/dev/null | \
+         sed -n 's/.*decode tg *: *\([0-9.][0-9.]*\).*/\1/p' | tail -1)"
+    case "$ctx" in
+      0)     P_128="${t:-0}" ;;
+      512)   P_512="${t:-0}" ;;
+      4096)  P_4K="${t:-0}" ;;
+      16384) P_16K="${t:-0}" ;;
+      32768) P_32K="${t:-0}" ;;
+    esac
+  done
+  echo ">> Qwythos main: 128=${P_128:-0} 512=${P_512:-0} 4k=${P_4K:-0} 16k=${P_16K:-0} 32k=${P_32K:-0} tok/s" >&2
+fi
+
+PRIMARY_JSON="$(run_model primary "$P_FILE" "$P_REPO" "$P_TOK" 0 \
+  MODELS_DIR="$P_DIR" MODEL_SHA256="${P_SHA}" \
+  SPARKINFER_SCORE_REPS=3 SPARKINFER_GUARD_32K_REPS=1 \
+  SPARKINFER_GUARD_REPS=3 SPARKINFER_GUARD_512_REPS=3 SPARKINFER_GUARD_4K_REPS=3 \
+  SPARKINFER_DIFFICULTY_BOOST=1 SPARKINFER_DIFFICULTY_REF="${SPARKINFER_DIFFICULTY_REF_OVERRIDE:-365.85}" \
+  SPARKINFER_GUARD_128_BASELINE="${P_128:-${SPARKINFER_P_GUARD_128_BASELINE:-0}}" \
+  SPARKINFER_GUARD_512_BASELINE="${P_512:-${SPARKINFER_P_GUARD_512_BASELINE:-0}}" \
+  SPARKINFER_GUARD_4K_BASELINE="${P_4K:-${SPARKINFER_P_GUARD_4K_BASELINE:-0}}" \
+  SPARKINFER_GUARD_16K_BASELINE="${P_16K:-${SPARKINFER_P_GUARD_16K_BASELINE:-0}}" \
+  SPARKINFER_GUARD_32K_BASELINE="${P_32K:-${SPARKINFER_P_GUARD_32K_BASELINE:-0}}" \
+  SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P_LLAMA_128_BASELINE:-${QWEN35_9B_LLAMA_128:-0}}" \
+  SPARKINFER_LLAMA_512_BASELINE="${SPARKINFER_P_LLAMA_512_BASELINE:-${QWEN35_9B_LLAMA_512:-0}}" \
+  SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P_LLAMA_4K_BASELINE:-${QWEN35_9B_LLAMA_4K:-0}}" \
+  SPARKINFER_LLAMA_16K_BASELINE="${SPARKINFER_P_LLAMA_16K_BASELINE:-0}" \
+  SPARKINFER_LLAMA_32K_BASELINE="${SPARKINFER_P_LLAMA_32K_BASELINE:-0}")"
+
+GUARD36_JSON="$(run_model guard36 "$G36_FILE" "$G36_REPO" "$G36_TOK" 0 \
+  MODELS_DIR="$G36_DIR" MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" \
+  SPARKINFER_GUARD_128_BASELINE="${SPARKINFER_G36_GUARD_128_BASELINE:-0}" \
+  SPARKINFER_GUARD_512_BASELINE="${SPARKINFER_G36_GUARD_512_BASELINE:-0}" \
+  SPARKINFER_GUARD_4K_BASELINE="${SPARKINFER_G36_GUARD_4K_BASELINE:-0}" \
+  SPARKINFER_GUARD_16K_BASELINE="${SPARKINFER_G36_GUARD_16K_BASELINE:-0}" \
+  SPARKINFER_GUARD_32K_BASELINE="${SPARKINFER_G36_GUARD_32K_BASELINE:-0}")"
+
+GUARD3_JSON="$(run_model guard3 "$G3_FILE" "$G3_REPO" "$G3_TOK" 0 \
+  MODELS_DIR="$G3_DIR" \
+  SPARKINFER_GUARD_128_BASELINE="${SPARKINFER_G3_GUARD_128_BASELINE:-0}" \
+  SPARKINFER_GUARD_512_BASELINE="${SPARKINFER_G3_GUARD_512_BASELINE:-0}" \
+  SPARKINFER_GUARD_4K_BASELINE="${SPARKINFER_G3_GUARD_4K_BASELINE:-0}" \
+  SPARKINFER_GUARD_16K_BASELINE="${SPARKINFER_G3_GUARD_16K_BASELINE:-0}" \
+  SPARKINFER_GUARD_32K_BASELINE="${SPARKINFER_G3_GUARD_32K_BASELINE:-0}")"
+reap
+
+PRIMARY_JSON="$PRIMARY_JSON" GUARD36_JSON="$GUARD36_JSON" GUARD3_JSON="$GUARD3_JSON" \
+COMMIT="$COMMIT" P_FILE="$P_FILE" G36_FILE="$G36_FILE" G3_FILE="$G3_FILE" \
+PRIMARY_QUANT="${PRIMARY_QUANT:-Q4_K_M}" python3 - <<'PY'
+import json, os
+
+def load(name):
+    raw = os.environ.get(name, "").strip()
+    try:
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+
+def guard_ok(guard, prefix):
+    gctx = ["guard_128_pass", "guard_512_pass", "guard_4k_pass", "guard_16k_pass", "guard_32k_pass"]
+    present = [k for k in gctx if k in guard]
+    top1_bar = float(os.environ.get("SPARKINFER_TOP1_BAR", "0.90"))
+    kl_bar = float(os.environ.get("SPARKINFER_KL_BAR", "0.20"))
+    speed_ok = all(guard.get(k, True) for k in present)
+    g_top1 = float(guard.get("top1", 0)); g_kl = float(guard.get("kl", 99))
+    acc_ok = g_top1 >= top1_bar and g_kl <= kl_bar
+    label_map = {"guard_128_pass": "128", "guard_512_pass": "512", "guard_4k_pass": "4k",
+                 "guard_16k_pass": "16k", "guard_32k_pass": "32k"}
+    regressed = [label_map[k] for k in present if not guard.get(k, True)]
+    return bool(guard) and speed_ok and acc_ok, regressed, speed_ok, acc_ok
+
+primary = load("PRIMARY_JSON")
+g36 = load("GUARD36_JSON")
+g3 = load("GUARD3_JSON")
+commit = os.environ["COMMIT"]
+quant = os.environ.get("PRIMARY_QUANT", "Q4_K_M")
+
+if not primary:
+    print("RESULT_JSON " + json.dumps({
+        "commit": commit, "label": "REJECT", "pass": False,
+        "reason": "primary (Qwythos-9B) eval produced no verdict (infra error)"}))
+    raise SystemExit(0)
+
+g36_ok, g36_reg, g36_speed, g36_acc = guard_ok(g36, "qwen36")
+g3_ok, g3_reg, g3_speed, g3_acc = guard_ok(g3, "qwen3")
+
+final = dict(primary)
+final["commit"] = commit
+final["model"] = f"Qwythos-9B ({quant})"
+final["guard36_model"] = "Qwen3.6-35B-A3B"
+final["guard3_model"] = "Qwen3-30B-A3B"
+final["primary_quant"] = quant
+final["guard36"] = {k: g36.get(k) for k in (
+    "pass", "top1", "kl", "label", "ctx_128_tps", "ctx_512_tps", "ctx_4096_tps",
+    "ctx_16384_tps", "ctx_32768_tps", "guard_128_pass", "guard_512_pass", "guard_4k_pass",
+    "guard_16k_pass", "guard_32k_pass") if k in g36}
+final["guard36"]["speed_ok"] = g36_speed
+final["guard36"]["accuracy_ok"] = g36_acc
+final["guard3"] = {k: g3.get(k) for k in (
+    "pass", "top1", "kl", "label", "ctx_128_tps", "ctx_512_tps", "ctx_4096_tps",
+    "ctx_16384_tps", "ctx_32768_tps", "guard_128_pass", "guard_512_pass", "guard_4k_pass",
+    "guard_16k_pass", "guard_32k_pass") if k in g3}
+final["guard3"]["speed_ok"] = g3_speed
+final["guard3"]["accuracy_ok"] = g3_acc
+
+if not (g36_ok and g3_ok):
+    reasons = []
+    if g36_reg:
+        reasons.append("Qwen3.6 decode regressed at: " + ", ".join(g36_reg))
+    if not g36_acc and g36:
+        reasons.append(f"Qwen3.6 accuracy broke (top1={g36.get('top1')}, kl={g36.get('kl')})")
+    if not bool(g36):
+        reasons.append("Qwen3.6 guard produced no verdict")
+    if g3_reg:
+        reasons.append("Qwen3-30B decode regressed at: " + ", ".join(g3_reg))
+    if not g3_acc and g3:
+        reasons.append(f"Qwen3-30B accuracy broke (top1={g3.get('top1')}, kl={g3.get('kl')})")
+    if not bool(g3):
+        reasons.append("Qwen3-30B guard produced no verdict")
+    final["label"] = "REJECT"
+    final["pass"] = False
+    final["reason"] = "no-regression guard: " + "; ".join(reasons or ["guard failed"])
+    labels = []
+    labels += ["regression-qwen36-" + c for c in g36_reg]
+    labels += ["regression-qwen3-" + c for c in g3_reg]
+    final["regression_labels"] = labels
+
+print("RESULT_JSON " + json.dumps(final))
+PY

--- a/bench/scripts/probe_all_quants.sh
+++ b/bench/scripts/probe_all_quants.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Probe max context for all Qwythos quants (llama.cpp reference on RTX 5090).
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+for q in Q4_K_M Q8_0 BF16; do
+  echo ">> === quant $q ===" >&2
+  PRIMARY_QUANT="$q" "$HERE/probe_max_ctx_llama.sh"
+done

--- a/bench/scripts/probe_max_ctx.sh
+++ b/bench/scripts/probe_max_ctx.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Probe maximum decode context for Qwythos-9B on the current GPU (RTX 5090 target).
+# Steps upward from 32k until qwen3_gguf_bench fails (OOM or error).
+#
+#   PRIMARY_QUANT=Q4_K_M|Q8_0|BF16 ./bench/scripts/probe_max_ctx.sh [model.gguf]
+#
+# Prints JSON: {"quant":"...","max_ctx":N,"attempts":[...]}
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+source "$HERE/_qwythos.sh"
+
+reap() { pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
+
+ARCH="$(detect_arch)"
+FILE="${1:-${QWYTHOS_MODELS_DIR}/$(qwythos_quant_file)}"
+QUANT="${PRIMARY_QUANT:-Q4_K_M}"
+NTOK=32
+OUT_JSON="${PROBE_OUT_JSON:-/tmp/qwythos_max_ctx_${QUANT}.json}"
+
+[ -f "$FILE" ] || { echo "!! missing model: $FILE" >&2; exit 1; }
+ensure_sparkinfer "$ARCH"
+resolve_runner "$ARCH"
+
+# Candidate contexts (KV prefill tokens). YaRN supports 1M in llama.cpp; find sparkinfer limit.
+CANDIDATES=(32768 65536 98304 131072 196608 262144 393216 524288 786432 1048576)
+MAX_OK=0
+ATTEMPTS_JSON="[]"
+
+try_ctx() {
+  local ctx="$1"
+  local out rc tps err
+  out="$(si_run qwen3_gguf_bench "$FILE" "$NTOK" "$ctx" 2>&1)" && rc=0 || rc=$?
+  tps="$(echo "$out" | sed -n 's/.*decode tg *: *\([0-9.][0-9.]*\).*/\1/p' | tail -1)"
+  if [ "$rc" -eq 0 ] && [ -n "$tps" ]; then
+    ATTEMPTS_JSON="$(python3 -c "import json; a=json.loads('''$ATTEMPTS_JSON'''); a.append({'ctx':$ctx,'ok':True,'tps':float('$tps')}); print(json.dumps(a))")"
+    return 0
+  fi
+  err="$(echo "$out" | tail -3 | tr '\n' ' ' | sed 's/"/\\"/g')"
+  ATTEMPTS_JSON="$(python3 -c "import json; a=json.loads('''$ATTEMPTS_JSON'''); a.append({'ctx':$ctx,'ok':False,'error':'''${err}'''}); print(json.dumps(a))")"
+  return 1
+}
+
+echo ">> probing max context: $FILE (quant=$QUANT, arch=sm_$ARCH)" >&2
+for ctx in "${CANDIDATES[@]}"; do
+  echo ">> try ctx=$ctx ..." >&2
+  if try_ctx "$ctx"; then
+    MAX_OK="$ctx"
+  else
+    echo ">> failed at ctx=$ctx — stopping" >&2
+    break
+  fi
+  reap
+  sleep 2
+done
+reap
+
+python3 - <<PY | tee "$OUT_JSON"
+import json, os
+print(json.dumps({
+    "model": os.path.basename("$FILE"),
+    "quant": "$QUANT",
+    "gpu_arch": "sm_$ARCH",
+    "max_ctx": int("$MAX_OK"),
+    "decode_tokens": $NTOK,
+    "attempts": json.loads('''$ATTEMPTS_JSON'''),
+}, indent=2))
+PY

--- a/bench/scripts/probe_max_ctx_llama.sh
+++ b/bench/scripts/probe_max_ctx_llama.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Probe maximum context for Qwythos via llama.cpp (reference ceiling on RTX 5090).
+# Use until sparkinfer loads Qwen3.5-9B dense hybrid GGUFs (probe_max_ctx.sh).
+#
+#   PRIMARY_QUANT=Q4_K_M|Q8_0|BF16 ./bench/scripts/probe_max_ctx_llama.sh [model.gguf]
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_qwythos.sh"
+
+LLAMA_BENCH="${LLAMA_BENCH:-/workspace/.llamacpp/build/bin/llama-bench}"
+FILE="${1:-${QWYTHOS_MODELS_DIR}/$(qwythos_quant_file)}"
+QUANT="${PRIMARY_QUANT:-Q4_K_M}"
+NTOK=32
+OUT_JSON="${PROBE_LLAMA_OUT_JSON:-/tmp/qwythos_max_ctx_llama_${QUANT}.json}"
+
+[ -x "$LLAMA_BENCH" ] || { echo "!! missing llama-bench: $LLAMA_BENCH" >&2; exit 1; }
+[ -f "$FILE" ] || { echo "!! missing model: $FILE" >&2; exit 1; }
+
+CANDIDATES=(32768 65536 131072 262144 524288 786432 819200 851968 917504 983040 1048576)
+MAX_OK=0
+ATTEMPTS_JSON="[]"
+
+try_ctx() {
+  local ctx="$1" out rc tps err
+  out="$("$LLAMA_BENCH" -m "$FILE" -p "$ctx" -n "$NTOK" -r 1 --no-warmup -o json 2>&1)" && rc=0 || rc=$?
+  tps="$(python3 -c "import re,sys; m=re.findall(r'\"samples_ts\":\s*\[\s*([0-9.]+)', sys.stdin.read()); print(m[-1] if m else '')" <<<"$out")"
+  if [ "$rc" -eq 0 ] && [ -n "$tps" ]; then
+    ATTEMPTS_JSON="$(python3 -c "import json; a=json.loads('''$ATTEMPTS_JSON'''); a.append({'ctx':$ctx,'ok':True,'tps':float('$tps')}); print(json.dumps(a))")"
+    return 0
+  fi
+  err="$(echo "$out" | grep -E 'error|failed|OOM' | tail -1 | tr '\n' ' ' | sed 's/"/\\"/g')"
+  ATTEMPTS_JSON="$(python3 -c "import json; a=json.loads('''$ATTEMPTS_JSON'''); a.append({'ctx':$ctx,'ok':False,'error':'''${err:-load failed}'''}); print(json.dumps(a))")"
+  return 1
+}
+
+echo ">> llama.cpp max-context probe: $FILE (quant=$QUANT)" >&2
+for ctx in "${CANDIDATES[@]}"; do
+  echo ">> try ctx=$ctx ..." >&2
+  if try_ctx "$ctx"; then MAX_OK="$ctx"; else echo ">> failed at ctx=$ctx" >&2; break; fi
+done
+
+python3 - <<PY | tee "$OUT_JSON"
+import json
+print(json.dumps({
+    "engine": "llama.cpp",
+    "model": "$(basename "$FILE")",
+    "quant": "$QUANT",
+    "gpu": "RTX 5090",
+    "max_ctx": int("$MAX_OK"),
+    "decode_tokens": $NTOK,
+    "attempts": json.loads('''$ATTEMPTS_JSON'''),
+}, indent=2))
+PY

--- a/bench/scripts/reference.lock
+++ b/bench/scripts/reference.lock
@@ -17,6 +17,16 @@ MODEL_SHA256="${MODEL_SHA256:-0d003f6662faee786ed5da3e31b29c978de5ae5d275c8794c6
 # sha256 of the Qwen3.6-35B-A3B UD-Q4_K_M GGUF (unsloth) — the dual-eval primary baseline weights.
 QWEN36_MODEL_SHA256="ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61"
 
+# Qwythos-9B (Qwen3.5-9B) — triple-eval primary. Empty = warn-only until pinned after first download.
+QWEN35_9B_Q4K_SHA256="${QWEN35_9B_Q4K_SHA256:-88c75f5a2684d07ac4b08e47f06cf6f65045072b1aeb29b33cf50cdae2d8cea1}"
+QWEN35_9B_Q8_SHA256="${QWEN35_9B_Q8_SHA256:-8966d06dad609fa20092a3f1c27f09836fe9e4ebb9ef9500cb86e6af543fd2a4}"
+QWEN35_9B_BF16_SHA256="${QWEN35_9B_BF16_SHA256:-fc0b8347f3d87d23ff13ac636a1989579b4cceeb25ab67979c3bae767721de02}"
+
+# Qwythos llama.cpp decode refs (RTX 5090) — fill after first benchmark run.
+QWEN35_9B_LLAMA_128="${QWEN35_9B_LLAMA_128:-0}"
+QWEN35_9B_LLAMA_512="${QWEN35_9B_LLAMA_512:-0}"
+QWEN35_9B_LLAMA_4K="${QWEN35_9B_LLAMA_4K:-0}"
+
 # llama.cpp commit the reference is pinned to. HEAD of master drifts run-to-run (non-reproducible and
 # unpinnable); we check out exactly this commit, verify a clean tree, and rebuild if either differs.
 LLAMACPP_COMMIT="6f4f53f2b7da54fcdbbecaaa734337c337ad6176"

--- a/eval/README.md
+++ b/eval/README.md
@@ -104,6 +104,27 @@ The on-box orchestrator is `bench/scripts/evaluate_dual.sh` (builds once, calls 
 `evaluate.sh` twice via `SI_SKIP_BUILD=1`, merges). Qwen3.6 runs the same UD-Q4_K_M GGUF the runtime
 now loads by default (mixed Q5_K experts).
 
+## Triple-model scoring: Qwythos-9B primary, Qwen3.6 + Qwen3-30B guards
+
+`--triple` (or `TRIPLE=1` in `.env.eval`) scores **Qwythos-9B** (Qwen3.5-9B, miner optimization target)
+and guards **both** Qwen3.6-35B-A3B and Qwen3-30B-A3B against no-regression in one build.
+
+```
+build once ─► PRIMARY  Qwythos-9B (Q4_K_M|Q8_0|BF16) ─► eval:<LABEL>
+           ├► GUARD36 Qwen3.6  : 5-context speed + accuracy ─► must NOT regress
+           └► GUARD3  Qwen3-30B : 5-context speed + accuracy ─► must NOT regress
+```
+
+- `PRIMARY_QUANT` selects the Qwythos GGUF: `Q4_K_M` (default), `Q8_0`, or `BF16`.
+- Models live in `/workspace/models35` (Qwythos), `/workspace/models36` (Qwen3.6), `/workspace/models` (Qwen3-30B).
+- Orchestrator: `bench/scripts/evaluate_triple.sh`.
+- Max context on RTX 5090 (32 GB): see `bench/results/qwythos_max_ctx_rtx5090.json` (`probe_max_ctx_llama.sh` until sparkinfer loads dense Qwen3.5-9B GGUFs).
+
+```bash
+python eval/vast_eval.py --ssh HOST:PORT --triple --primary-quant Q4_K_M --ref main
+./eval/run_bot.sh --triple
+```
+
 ## Verdict (stdout)
 
 ```json

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -350,13 +350,18 @@ def render(res, oid):
     # verdict can REJECT on the GUARD even when every scored-model gate passes, so the guard's own
     # per-context results must be shown — otherwise the table reads "all pass" next to a REJECT.
     guard = res.get("guard") or {}
+    guard36 = res.get("guard36") or {}
+    guard3 = res.get("guard3") or {}
     scored_model = res.get("model")
-    dual = bool(guard) and bool(scored_model)
-    short = scored_model.split("-")[0] if scored_model else ""       # "Qwen3.6"
+    dual = bool(guard) and bool(scored_model) and not (guard36 or guard3)
+    triple = bool(guard36 or guard3) and bool(scored_model)
+    short = scored_model.split("(")[0].strip() if scored_model else ""
+    if not short and scored_model:
+        short = scored_model.split("-")[0]
     gname = res.get("guard_model", "Qwen3-30B")
     rows = [f"| **label** | `eval:{label}` |",
-            f"| scored decode ({res.get('score_context', 128)} ctx{f' · {ctx_label}' if ctx_label else ''}{f' · {short}' if dual else ''}) | {res.get('tps','?')} tok/s |",
-            f"| correctness{f' ({short} vs llama.cpp)' if dual else ''} | top-1 {res.get('top1',0)*100:.1f}% · KL {res.get('kl','?')} |"]
+            f"| scored decode ({res.get('score_context', 128)} ctx{f' · {ctx_label}' if ctx_label else ''}{f' · {short}' if dual or triple else ''}) | {res.get('tps','?')} tok/s |",
+            f"| correctness{f' ({short} vs llama.cpp)' if dual or triple else ''} | top-1 {res.get('top1',0)*100:.1f}% · KL {res.get('kl','?')} |"]
     # scored-model per-context no-regression gates — SKIP contexts not measured (tps 0/None) so a
     # deliberately-skipped 16k/32k never renders a misleading "0.0 tok/s · pass".
     for key, gkey, bkey, lbl in [("ctx_128_tps", "guard_128_pass", "guard_128_baseline", "128-token"),
@@ -369,7 +374,7 @@ def render(res, oid):
             continue
         gate = "pass" if res.get(gkey, True) else "fail"
         base = res.get(bkey) or _GUARD_BASE_FALLBACK.get(bkey, 0)
-        rows.append(f"| {f'{short} ' if dual else ''}{lbl} no-regression gate | {tps} tok/s"
+        rows.append(f"| {f'{short} ' if dual or triple else ''}{lbl} no-regression gate | {tps} tok/s"
                     f"{f' vs main {base} tok/s' if base else ''} · {gate} |")
     if res.get("ctx_2048_tps") is not None and res.get("ctx_512_tps") is None:
         gate = "pass" if res.get("guard_2k_pass", True) else "fail"
@@ -389,6 +394,22 @@ def render(res, oid):
             if not tps:
                 continue
             rows.append(f"| {gname} guard — {lbl} | {tps} tok/s · {'pass' if guard.get(gkey, True) else '**fail**'} |")
+    if triple:
+        for gblock, gtitle in [(guard36, res.get("guard36_model", "Qwen3.6")),
+                               (guard3, res.get("guard3_model", "Qwen3-30B"))]:
+            if not gblock:
+                continue
+            acc_ok = "pass" if gblock.get("accuracy_ok", True) else "**FAIL**"
+            rows.append(f"| **{gtitle} guard — accuracy** | top-1 {gblock.get('top1',0)*100:.1f}% · KL {gblock.get('kl','?')} · {acc_ok} |")
+            for key, gkey, lbl in [("ctx_128_tps", "guard_128_pass", "128-token"),
+                                   ("ctx_512_tps", "guard_512_pass", "512-context"),
+                                   ("ctx_4096_tps", "guard_4k_pass", "4k-context"),
+                                   ("ctx_16384_tps", "guard_16k_pass", "16k-context"),
+                                   ("ctx_32768_tps", "guard_32k_pass", "32k-context")]:
+                tps = gblock.get(key)
+                if not tps:
+                    continue
+                rows.append(f"| {gtitle} guard — {lbl} | {tps} tok/s · {'pass' if gblock.get(gkey, True) else '**fail**'} |")
     if res.get("regression_labels") or res.get("guard_regression_labels"):
         allregs = (res.get("regression_labels") or []) + (res.get("guard_regression_labels") or [])
         rows.append(f"| regressions | {', '.join(allregs)} |")
@@ -870,6 +891,11 @@ def main():
     # not a passed-in frontier number — so the gain is hardware-independent and always current.
     ap.add_argument("--dual", action="store_true",
                     help="score Qwen3.6 (primary) + guard Qwen3-30B (no-regression) via evaluate_dual.sh")
+    ap.add_argument("--triple", action="store_true",
+                    help="score Qwythos-9B (primary) + guard Qwen3.6 + Qwen3-30B via evaluate_triple.sh")
+    ap.add_argument("--primary-quant", default=os.environ.get("PRIMARY_QUANT", "Q4_K_M"),
+                    choices=["Q4_K_M", "Q8_0", "BF16"],
+                    help="[--triple] Qwythos GGUF quant (default Q4_K_M)")
     ap.add_argument("--polaris", action="store_true",
                     help="generate a Polaris verifiable receipt for each eval")
     ap.add_argument("--only-pr", type=int, default=0,
@@ -877,6 +903,8 @@ def main():
     ap.add_argument("--reeval", action="store_true",
                     help="re-run eval even if this commit was already graded (use with --only-pr)")
     args = ap.parse_args()
+    if args.triple and args.dual:
+        ap.error("--triple and --dual are mutually exclusive")
     if not ssh_box_enabled() and not args.instance:
         ap.error("--instance is required for vast.ai transport (or set EVAL_TRANSPORT=ssh + EVAL_SSH_HOST)")
     if ssh_box_enabled():
@@ -894,6 +922,16 @@ def main():
         "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "275.81")),
         "llama512": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_512", "275.61")),
         "llama4k":  float(os.environ.get("SPARKINFER_QWEN36_LLAMA_4K",  "276.30")),
+    }
+    QWYTHOS_BASE = {
+        "128": float(os.environ.get("SPARKINFER_QWYTHOS_128", "0")),
+        "512": float(os.environ.get("SPARKINFER_QWYTHOS_512", "0")),
+        "4k":  float(os.environ.get("SPARKINFER_QWYTHOS_4K",  "0")),
+        "16k": float(os.environ.get("SPARKINFER_QWYTHOS_16K", "0")),
+        "32k": float(os.environ.get("SPARKINFER_QWYTHOS_32K", "0")),
+        "llama128": float(os.environ.get("QWEN35_9B_LLAMA_128", "0")),
+        "llama512": float(os.environ.get("QWEN35_9B_LLAMA_512", "0")),
+        "llama4k":  float(os.environ.get("QWEN35_9B_LLAMA_4K",  "0")),
     }
 
     # --- Polaris verifiable compute ---
@@ -1154,9 +1192,9 @@ def main():
               f"Aborting; NO PRs graded. Re-run on a warm, stable box.")
         return
 
-    # Dual mode: bench Qwen3.6 main directly on the box — the same build the Qwen3-30B
+    # Dual/triple mode: bench model mains directly on the box — the same build the Qwen3-30B
     # baseline already verified. No accuracy gate, just a 5-context decode sweep.
-    if args.dual and _vast_sh:
+    if (args.dual or args.triple) and _vast_sh:
         ssh_ep = ssh_box_endpoint()
         if ssh_ep:
             host, port = ssh_ep
@@ -1167,37 +1205,43 @@ def main():
             host, port = _vast_endpoint(info) if info else (None, None)
         else:
             host = port = None
-        if host and port:
-            M36 = "/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
-            B36 = "/root/sparkinfer/build/runtime/qwen3_gguf_bench"
-            tps128 = tps512 = tps4k = tps16k = tps32k = 0.0
-            for label, ctx in [("128", 0), ("512", 512), ("4k", 4096),
-                               ("16k", 16384), ("32k", 32768)]:
-                cmd = f"export PATH=/usr/local/cuda/bin:$PATH; {B36} '{M36}' 128 {ctx}"
+
+        def _ctx_sweep(host, port, gguf, label, store):
+            B = "/root/sparkinfer/build/runtime/qwen3_gguf_bench"
+            tps = {}
+            for lbl, ctx in [("128", 0), ("512", 512), ("4k", 4096),
+                             ("16k", 16384), ("32k", 32768)]:
+                cmd = f"export PATH=/usr/local/cuda/bin:$PATH; {B} '{gguf}' 128 {ctx}"
                 r = _vast_sh(host, port, cmd, timeout=600)
                 m = re.search(r"decode\s+tg\s*:\s*([0-9.]+)", r.stdout + r.stderr)
-                if m: tps = float(m.group(1))
-                else: tps = 0.0
-                if label == "128": tps128 = tps
-                elif label == "512": tps512 = tps
-                elif label == "4k":  tps4k  = tps
-                elif label == "16k": tps16k = tps
-                else:               tps32k = tps
-                print(f"    ctx={label} tps={tps}")
-            if tps128 > 0:
-                QWEN36_BASE["128"] = tps128
-                QWEN36_BASE["512"] = tps512 if tps512 > 0 else round(tps128 * 0.98, 2)
-                QWEN36_BASE["4k"]  = tps4k  if tps4k  > 0 else round(tps128 * 0.93, 2)
-                QWEN36_BASE["16k"] = tps16k if tps16k > 0 else QWEN36_BASE["16k"]
-                QWEN36_BASE["32k"] = tps32k if tps32k > 0 else QWEN36_BASE["32k"]
-                print(f"  Qwen3.6 same-box main: 128={tps128} 512={QWEN36_BASE['512']} "
-                      f"4k={QWEN36_BASE['4k']} 16k={QWEN36_BASE['16k']} 32k={QWEN36_BASE['32k']} tok/s")
+                tps[lbl] = float(m.group(1)) if m else 0.0
+                print(f"    [{label}] ctx={lbl} tps={tps[lbl]}")
+            if tps.get("128", 0) > 0:
+                store["128"] = tps["128"]
+                store["512"] = tps["512"] if tps["512"] > 0 else round(tps["128"] * 0.98, 2)
+                store["4k"]  = tps["4k"]  if tps["4k"]  > 0 else round(tps["128"] * 0.93, 2)
+                store["16k"] = tps["16k"] if tps["16k"] > 0 else store.get("16k", 0)
+                store["32k"] = tps["32k"] if tps["32k"] > 0 else store.get("32k", 0)
+                print(f"  {label} same-box main: 128={store['128']} 512={store['512']} "
+                      f"4k={store['4k']} 16k={store['16k']} 32k={store['32k']} tok/s")
             else:
-                print(f"  Qwen3.6 bench failed — using defaults: "
-                      f"{QWEN36_BASE['128']}/{QWEN36_BASE['512']}/{QWEN36_BASE['4k']}/"
-                      f"{QWEN36_BASE['16k']}/{QWEN36_BASE['32k']}")
+                print(f"  {label} bench failed — using config defaults")
+
+        if host and port:
+            if args.dual or args.triple:
+                _ctx_sweep(host, port, "/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                           "Qwen3.6", QWEN36_BASE)
+            if args.triple:
+                qmap = {
+                    "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
+                    "Q8_0":   "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
+                    "BF16":   "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf",
+                }
+                qfile = qmap[args.primary_quant]
+                _ctx_sweep(host, port, f"/workspace/models35/{qfile}",
+                           f"Qwythos ({args.primary_quant})", QWYTHOS_BASE)
         else:
-            print(f"  could not reach eval box for Qwen3.6 bench — using config defaults")
+            print(f"  could not reach eval box for model bench — using config defaults")
 
     # Run all pending evals on the SAME instance: pass --keep so vast_eval.py never stops/destroys
     # the box mid-queue. The bot stops the instance once after ALL PRs finish (or if the instance
@@ -1221,7 +1265,24 @@ def main():
                "--guard-16k-baseline", str(run_guard_16k),
                "--guard-32k-baseline", str(run_guard_32k),
                "--keep"]
-        if args.dual:
+        if args.triple:
+            cmd[cmd.index("--keep"):cmd.index("--keep")] = [
+                "--triple",
+                "--primary-quant", args.primary_quant,
+                "--p-guard-128-baseline", str(QWYTHOS_BASE["128"]),
+                "--p-guard-512-baseline", str(QWYTHOS_BASE["512"]),
+                "--p-guard-4k-baseline",  str(QWYTHOS_BASE["4k"]),
+                "--p-guard-16k-baseline", str(QWYTHOS_BASE["16k"]),
+                "--p-guard-32k-baseline", str(QWYTHOS_BASE["32k"]),
+                "--p-llama-128-baseline", str(QWYTHOS_BASE["llama128"]),
+                "--p-llama-512-baseline", str(QWYTHOS_BASE["llama512"]),
+                "--p-llama-4k-baseline",  str(QWYTHOS_BASE["llama4k"]),
+                "--g36-guard-128-baseline", str(QWEN36_BASE["128"]),
+                "--g36-guard-512-baseline", str(QWEN36_BASE["512"]),
+                "--g36-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
+                "--g36-guard-16k-baseline", str(QWEN36_BASE["16k"]),
+                "--g36-guard-32k-baseline", str(QWEN36_BASE["32k"])]
+        elif args.dual:
             # Qwen3.6 scored (128/512/4k); the --guard-*-baseline above become the Qwen3-30B guard.
             # Scoring base = same-box origin/main baseline (the guard baselines), not a passed-in frontier.
             cmd[cmd.index("--keep"):cmd.index("--keep")] = [

--- a/eval/run_bot.sh
+++ b/eval/run_bot.sh
@@ -4,6 +4,7 @@
 #   ./eval/run_bot.sh              # full run on SSH box (or vast if EVAL_TRANSPORT=vast)
 #   ./eval/run_bot.sh --dry-run    # poll PRs + print plan, no GPU eval
 #   ./eval/run_bot.sh --dual       # force dual-model eval (Qwen3.6 + Qwen3-30B guard)
+#   ./eval/run_bot.sh --triple     # Qwythos-9B primary + Qwen3.6 + Qwen3-30B guards
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -30,7 +31,9 @@ BOT_ARGS=(
 if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
   BOT_ARGS+=(--instance "${VAST_INSTANCE:-42682383}")
 fi
-if [ -n "${DUAL:-}" ] || printf '%s\n' "$@" | grep -qx -- '--dual'; then
+if [ -n "${TRIPLE:-}" ] || printf '%s\n' "$@" | grep -qx -- '--triple'; then
+  BOT_ARGS+=(--triple --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
+elif [ -n "${DUAL:-}" ] || printf '%s\n' "$@" | grep -qx -- '--dual'; then
   BOT_ARGS+=(--dual)
 fi
 if [ -n "${POLARIS:-}" ] || printf '%s\n' "$@" | grep -qx -- '--polaris'; then

--- a/eval/run_bot_cron.sh
+++ b/eval/run_bot_cron.sh
@@ -37,6 +37,7 @@ BOT_ARGS=(
 if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
   BOT_ARGS+=(--instance "${VAST_INSTANCE:-42682383}")
 fi
-[ -n "${DUAL:-}" ] && BOT_ARGS+=(--dual)
+[ -n "${TRIPLE:-}" ] && BOT_ARGS+=(--triple --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
+[ -z "${TRIPLE:-}" ] && [ -n "${DUAL:-}" ] && BOT_ARGS+=(--dual)
 
 python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}"

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -228,6 +228,17 @@ def main():
     ap.add_argument("--p-llama-4k-baseline",  type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 4k-context tok/s")
     ap.add_argument("--p-llama-16k-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 16k-context tok/s")
     ap.add_argument("--p-llama-32k-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 32k-context tok/s")
+    # --- triple-model: Qwythos-9B (primary) + Qwen3.6 guard + Qwen3-30B guard ---
+    ap.add_argument("--triple", action="store_true",
+                    help="score Qwythos-9B (Qwen3.5) and guard Qwen3.6 + Qwen3-30B via evaluate_triple.sh")
+    ap.add_argument("--primary-quant", default=os.environ.get("PRIMARY_QUANT", "Q4_K_M"),
+                    choices=["Q4_K_M", "Q8_0", "BF16"],
+                    help="[--triple] Qwythos GGUF quant to score (default Q4_K_M)")
+    ap.add_argument("--g36-guard-128-baseline", type=float, default=0, help="[--triple] Qwen3.6 guard 128-token tok/s")
+    ap.add_argument("--g36-guard-512-baseline", type=float, default=0, help="[--triple] Qwen3.6 guard 512-context tok/s")
+    ap.add_argument("--g36-guard-4k-baseline",  type=float, default=0, help="[--triple] Qwen3.6 guard 4k-context tok/s")
+    ap.add_argument("--g36-guard-16k-baseline", type=float, default=0, help="[--triple] Qwen3.6 guard 16k-context tok/s")
+    ap.add_argument("--g36-guard-32k-baseline", type=float, default=0, help="[--triple] Qwen3.6 guard 32k-context tok/s")
     ap.add_argument("--eval-mode", default=os.environ.get("SPARKINFER_EVAL_MODE", "longctx"),
                     choices=["longctx", "short"],
                     help="longctx scores 16k with a 128-token decode no-regression guard; short keeps legacy 128-token scoring")
@@ -246,6 +257,8 @@ def main():
     ap.add_argument("--polaris", action="store_true",
                     help="generate a Polaris verifiable receipt (unsigned attestation from eval box)")
     args = ap.parse_args()
+    if args.triple and args.dual:
+        ap.error("--triple and --dual are mutually exclusive")
 
     if not args.ssh and ssh_box_enabled():
         args.ssh = ssh_box_arg()
@@ -450,8 +463,25 @@ def main():
             if not wait_model(host, port):
                 print("!! model download timed out — evaluate.sh will retry (may add time)")
 
-        if args.dual:
-            # Dual-model needs the Qwen3.6 GGUF too. Google Drive first (gdown handles the large-file
+        def _prefetch_hf(gguf_path, hf_repo, hf_file, ready_path, log_path):
+            """Background-download a single GGUF into gguf_path; poll ready_path sentinel."""
+            d = os.path.dirname(gguf_path)
+            return (
+                f"if [ -f '{gguf_path}' ]; then touch '{ready_path}' && echo cached; "
+                f"elif [ -f '{ready_path}' ]; then echo already_running; "
+                f"else mkdir -p {d} && rm -f '{ready_path}'; "
+                f"nohup bash -c '"
+                f"  [ -f {gguf_path} ] "
+                f"  || HF_HUB_DISABLE_XET=1 hf download {hf_repo} "
+                f"       {hf_file} --local-dir {d} >>{log_path} 2>&1 "
+                f"  || curl -fL -C - https://huggingface.co/{hf_repo}/resolve/main/{hf_file}"
+                f"       -o {gguf_path} >>{log_path} 2>&1; "
+                f"  [ -f {gguf_path} ] && touch {ready_path}"
+                f"' >/dev/null 2>&1 & echo started; fi"
+            )
+
+        if args.triple or args.dual:
+            # Dual/triple needs the Qwen3.6 GGUF too. Google Drive first (gdown handles the large-file
             # confirm token) — HF is throttled to ~KB/s from many vast hosts; HF/curl are the fallback.
             # Override the Drive id with MODEL36_GDRIVE_ID="" to disable. Separate dir from Qwen3 (the
             # two models have different tokenizers); evaluate_dual.sh's primary MODELS_DIR defaults to
@@ -494,6 +524,38 @@ def main():
                 else:
                     print("!! Qwen3.6 download slow — evaluate_dual.sh will retry (may add time)")
 
+        if args.triple:
+            # Qwythos-9B (Qwen3.5) primary — separate dir (/workspace/models35).
+            qmap = {
+                "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
+                "Q8_0":   "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
+                "BF16":   "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf",
+            }
+            qfile = qmap[args.primary_quant]
+            P35_DIR = "/workspace/models35"
+            P35_PATH = f"{P35_DIR}/{qfile}"
+            P35_READY = "/tmp/sparkinfer_model35_ready"
+            p35 = _prefetch_hf(
+                P35_PATH,
+                "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF",
+                qfile,
+                P35_READY,
+                "/tmp/dl35.log",
+            )
+            s35 = sh(host, port, p35, timeout=30).stdout.strip()
+            if s35 == "cached":
+                print(f">> Qwythos model ({args.primary_quant}) already cached — skipping download")
+            else:
+                print(f">> Qwythos model download started ({s35}) — polling ...")
+                deadline = time.time() + 3600
+                while time.time() < deadline:
+                    r = sh(host, port, f"test -f '{P35_READY}' && echo yes || echo no", timeout=60)
+                    if r.returncode == 0 and r.stdout.strip() == "yes":
+                        break
+                    time.sleep(20)
+                else:
+                    print("!! Qwythos download slow — evaluate_triple.sh will retry (may add time)")
+
         # Reap any leftover reference server / runner from a previous PR on this kept-alive box —
         # a leaked llama-server holding port 8081 would make this PR's accuracy.sh fail to bind.
         sh(host, port, "pkill -f llama-server 2>/dev/null; pkill -f qwen3_gguf 2>/dev/null; sleep 1; true", timeout=30)
@@ -508,7 +570,35 @@ def main():
         # Difficulty compensation ON (Option B): as the frontier pulls past llama.cpp each further %
         # gain is harder, so label.py scales the label tier up (raw % + significance gate unchanged).
         # Governance-tunable via SPARKINFER_DIFFICULTY_{K,REF,MAX}; applies from new evals onward.
-        if args.dual:
+        if args.triple:
+            ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
+                  f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
+                  f"SPARKINFER_EVAL_MODE={args.eval_mode} PRIMARY_QUANT={args.primary_quant} "
+                  f"SPARKINFER_G3_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
+                  f"SPARKINFER_G3_GUARD_512_BASELINE={args.guard_512_baseline} "
+                  f"SPARKINFER_G3_GUARD_4K_BASELINE={args.guard_4k_baseline} "
+                  f"SPARKINFER_G3_GUARD_16K_BASELINE={args.guard_16k_baseline} "
+                  f"SPARKINFER_G3_GUARD_32K_BASELINE={args.guard_32k_baseline} "
+                  f"SPARKINFER_G36_GUARD_128_BASELINE={args.g36_guard_128_baseline} "
+                  f"SPARKINFER_G36_GUARD_512_BASELINE={args.g36_guard_512_baseline} "
+                  f"SPARKINFER_G36_GUARD_4K_BASELINE={args.g36_guard_4k_baseline} "
+                  f"SPARKINFER_G36_GUARD_16K_BASELINE={args.g36_guard_16k_baseline} "
+                  f"SPARKINFER_G36_GUARD_32K_BASELINE={args.g36_guard_32k_baseline} "
+                  f"SPARKINFER_P_GUARD_128_BASELINE={args.p_guard_128_baseline} "
+                  f"SPARKINFER_P_GUARD_512_BASELINE={args.p_guard_512_baseline} "
+                  f"SPARKINFER_P_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
+                  f"SPARKINFER_P_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
+                  f"SPARKINFER_P_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
+                  f"SPARKINFER_P_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
+                  f"SPARKINFER_P_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
+                  f"SPARKINFER_P_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
+                  f"SPARKINFER_P_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
+                  f"SPARKINFER_P_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
+                  f"MODELS_DIR=/workspace/models QWYTHOS_MODELS_DIR=/workspace/models35 "
+                  f"LLAMACPP_DIR={LLAMACPP_DIR} "
+                  f"bench/scripts/evaluate_triple.sh --ref {args.ref} "
+                  f"--ceiling {args.ceiling}")
+        elif args.dual:
             # Dual-model: score Qwen3.6 (primary) + guard Qwen3-30B (no-regression). The existing
             # --guard-*-baseline are the Qwen3-30B guard (G_*); --p-* carry the Qwen3.6 scored target.
             if args.polaris:


### PR DESCRIPTION
## Summary
- Score Qwythos (Q4_K_M/Q8_0/BF16) as primary while guarding Qwen3.6 and Qwen3-30B against regression.
- Pin GGUF SHA256s and document RTX 5090 context limits.

Commit: `92bc0cba8c33cd3880a0129b491b9867aeb62d0b`

**Merge order:** merge #311 (revert squash) → this PR → #313 → #314.

## Test plan
- [ ] `evaluate_triple.sh` dry-run on eval box
- [ ] CI guard passes


Made with [Cursor](https://cursor.com)