### PR TITLE
Switch eval to bidirectional Qwen3.5 + Qwen3.6 scoring

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -15,9 +15,9 @@ EVAL_SSH_PORT=50200
 # GH_TOKEN=
 # FRONTIER=285
 # CEILING=366
-# DUAL=1          # Qwen3.6 primary + Qwen3-30B guard (legacy)
-# TRIPLE=1        # Qwythos-9B primary + Qwen3.6 + Qwen3-30B guards (miner target)
-# PRIMARY_QUANT=Q4_K_M   # Qwythos quant: Q4_K_M | Q8_0 | BF16
+# BIDIR=1          # Qwen3.5 + Qwen3.6 bidirectional eval (default; set 0 for legacy single-model)
+# TRIPLE=1          # legacy alias for BIDIR=1
+# PRIMARY_QUANT=Q4_K_M   # Qwen3.5 quant: Q4_K_M | Q8_0 | BF16
 
 # --- Qwythos / Qwen3.5-9B (triple-eval primary) ---
 # QWYTHOS_REPO=empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF

--- a/bench/configs/models/qwythos_9b.yaml
+++ b/bench/configs/models/qwythos_9b.yaml
@@ -1,5 +1,5 @@
-# Qwythos-9B (Qwen3.5-9B fine-tune) — miner optimization target.
-# Guards: Qwen3.6-35B-A3B + Qwen3-30B-A3B must not regress (evaluate_triple.sh).
+# Qwythos-9B (Qwen3.5-9B) — bidirectional eval with Qwen3.6 (evaluate_bidir.sh).
+# Guards: Qwen3.6-35B-A3B must not regress when optimizing Qwen3.5, and vice versa.
 #
 # HF: https://huggingface.co/empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF
 # Architecture: qwen35 (dense MoE 9B, 1M YaRN context in llama.cpp)
@@ -26,13 +26,10 @@ guards:
   - model: Qwen3.6-35B-A3B
     file: Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
     dir: /workspace/models36
-  - model: Qwen3-30B-A3B
-    file: Qwen3-30B-A3B-Q4_K_M.gguf
-    dir: /workspace/models
 
 # YaRN enables up to 1M in llama.cpp; probe_max_ctx_llama.sh measured RTX 5090 (32GB) ceiling.
 context:
-  eval_sweep: [128, 512, 4096, 16384, 32768]
+  eval_sweep: [128, 512, 4096]
   probe_candidates: [32768, 65536, 131072, 262144, 524288, 786432, 819200, 851968, 1048576]
   rtx5090_max_ctx_llama:
     Q4_K_M: 819200   # ~800k tokens

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Bidirectional evaluation: Qwen3.5-9B (Qwythos) and Qwen3.6-35B-A3B — one build, one box.
+#
+# Runs BOTH scoring directions in one submission:
+#   • score_qwen35 — optimize Qwen3.5 (128/512/4k only), guard Qwen3.6 (no regression, 5 contexts)
+#   • score_qwen36 — optimize Qwen3.6 (5 contexts), guard Qwen3.5 (no regression, 128/512/4k only)
+#
+#   bench/scripts/evaluate_bidir.sh [--ref GIT_REF] [--ceiling TPS]
+#
+# PRIMARY_QUANT: Q4_K_M (default) | Q8_0 | BF16
+#
+# Env (optional):
+#   SPARKINFER_P35_GUARD_*   Qwen3.5 same-box main tok/s (128/512/4k)
+#   SPARKINFER_P36_GUARD_*   Qwen3.6 same-box main tok/s (128/512/4k/16k/32k)
+#   SPARKINFER_G36_GUARD_*   Qwen3.6 guard baselines (for score_qwen35)
+#   SPARKINFER_G35_GUARD_*   Qwen3.5 guard baselines (for score_qwen36)
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+source "$HERE/_qwythos.sh"
+
+REF=""; CEILING=0
+while [ $# -gt 0 ]; do case "$1" in
+  --ref) shift; REF="$1" ;; --ceiling) shift; CEILING="$1" ;; *) ;;
+esac; shift; done
+
+export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"
+ARCH="$(detect_arch)"
+
+if [ -n "$REF" ] && [ -z "${SI_NO_CHECKOUT:-}" ]; then
+  git -C "$ROOT" fetch -q origin "$REF" 2>/dev/null || true; git -C "$ROOT" checkout -q "$REF"
+fi
+COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
+
+echo ">> [build] submission ($COMMIT) from source (sm_$ARCH) — shared by both models ..." >&2
+rm -rf "$ROOT/build"
+if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
+  echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
+  printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": 0, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false, "mode": "bidir"}\n' "$COMMIT"
+  exit 0
+fi
+
+P35_FILE="$(qwythos_quant_file)"
+P35_REPO="${QWYTHOS_REPO}"
+P35_TOK="${QWYTHOS_TOK_REPO}"
+P35_DIR="${QWYTHOS_MODELS_DIR}"
+P35_SHA="$(qwythos_sha_var)"
+
+P36_FILE="${PRIMARY36_MODEL_FILE:-Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
+P36_REPO="${PRIMARY36_MODEL_REPO:-unsloth/Qwen3.6-35B-A3B-GGUF}"
+P36_TOK="${PRIMARY36_TOK_REPO:-Qwen/Qwen3.6-35B-A3B}"
+P36_DIR="${PRIMARY36_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}36}"
+
+QUANT="${PRIMARY_QUANT:-Q4_K_M}"
+echo ">> bidir: Qwen3.5=$P35_FILE (quant=$QUANT, ctx=128/512/4k) + Qwen3.6=$P36_FILE (ctx=128/512/4k/16k/32k)" >&2
+
+reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
+
+run_model() {
+  local role="$1" file="$2" repo="$3" tok="$4" frontier="$5"; shift 5
+  reap
+  echo ">> [$role] model $file ..." >&2
+  env SI_SKIP_BUILD=1 SI_NO_CHECKOUT=1 \
+      MODEL_FILE="$file" MODEL_REPO="$repo" TOK_REPO="$tok" \
+      "$@" \
+      "$HERE/evaluate.sh" --ref "$REF" --frontier "$frontier" --ceiling "$CEILING" \
+    | sed -n 's/^RESULT_JSON //p' | tail -1
+}
+
+# Qwen3.5: score/guard at 128/512/4k only (skip 16k/32k measurement).
+Q35_SHORT_ENVS=(
+  SPARKINFER_SCORE_REPS=0
+  SPARKINFER_GUARD_32K_REPS=0
+  SPARKINFER_GUARD_REPS=3
+  SPARKINFER_GUARD_512_REPS=3
+  SPARKINFER_GUARD_4K_REPS=3
+  SPARKINFER_GUARD_16K_BASELINE=0
+  SPARKINFER_GUARD_32K_BASELINE=0
+)
+
+# Qwen3.6: full 5-context sweep.
+Q36_FULL_ENVS=(
+  SPARKINFER_SCORE_REPS=3
+  SPARKINFER_GUARD_32K_REPS=1
+  SPARKINFER_GUARD_REPS=3
+  SPARKINFER_GUARD_512_REPS=3
+  SPARKINFER_GUARD_4K_REPS=3
+)
+
+# Auto-measure same-box main baselines when unset.
+resolve_runner "$ARCH"
+if [ "${SPARKINFER_P36_GUARD_128_BASELINE:-0}" = "0" ]; then
+  echo ">> measuring Qwen3.6 same-box main (5 contexts) ..." >&2
+  P36_GGUF="${P36_DIR}/${P36_FILE}"
+  for ctx in 0 512 4096 16384 32768; do
+    t="$(si_run qwen3_gguf_bench "$P36_GGUF" 128 "$ctx" 2>/dev/null | \
+         sed -n 's/.*decode tg *: *\([0-9.][0-9.]*\).*/\1/p' | tail -1)"
+    case "$ctx" in
+      0)     B36_128="${t:-0}" ;;
+      512)   B36_512="${t:-0}" ;;
+      4096)  B36_4K="${t:-0}" ;;
+      16384) B36_16K="${t:-0}" ;;
+      32768) B36_32K="${t:-0}" ;;
+    esac
+  done
+  echo ">> Qwen3.6 main: 128=${B36_128:-0} 512=${B36_512:-0} 4k=${B36_4K:-0} 16k=${B36_16K:-0} 32k=${B36_32K:-0} tok/s" >&2
+fi
+
+if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ]; then
+  echo ">> measuring Qwen3.5 same-box main (128/512/4k) ..." >&2
+  P35_GGUF="${P35_DIR}/${P35_FILE}"
+  for ctx in 0 512 4096; do
+    t="$(si_run qwen3_gguf_bench "$P35_GGUF" 128 "$ctx" 2>/dev/null | \
+         sed -n 's/.*decode tg *: *\([0-9.][0-9.]*\).*/\1/p' | tail -1)"
+    case "$ctx" in
+      0)    B35_128="${t:-0}" ;;
+      512)  B35_512="${t:-0}" ;;
+      4096) B35_4K="${t:-0}" ;;
+    esac
+  done
+  echo ">> Qwen3.5 main: 128=${B35_128:-0} 512=${B35_512:-0} 4k=${B35_4K:-0} tok/s" >&2
+fi
+
+# Resolved baselines (bot-passed or auto-measured or hardcoded Qwen3.6 defaults).
+B36_128="${B36_128:-${SPARKINFER_P36_GUARD_128_BASELINE:-0}}"
+B36_512="${B36_512:-${SPARKINFER_P36_GUARD_512_BASELINE:-0}}"
+B36_4K="${B36_4K:-${SPARKINFER_P36_GUARD_4K_BASELINE:-0}}"
+B36_16K="${B36_16K:-${SPARKINFER_P36_GUARD_16K_BASELINE:-0}}"
+B36_32K="${B36_32K:-${SPARKINFER_P36_GUARD_32K_BASELINE:-0}}"
+[ "${B36_128}" = "0" ] && B36_128="300.16"
+[ "${B36_512}" = "0" ] && B36_512="296.76"
+[ "${B36_4K}"  = "0" ] && B36_4K="287.91"
+[ "${B36_16K}" = "0" ] && B36_16K="338.55"
+[ "${B36_32K}" = "0" ] && B36_32K="301.19"
+
+B35_128="${B35_128:-${SPARKINFER_P35_GUARD_128_BASELINE:-0}}"
+B35_512="${B35_512:-${SPARKINFER_P35_GUARD_512_BASELINE:-0}}"
+B35_4K="${B35_4K:-${SPARKINFER_P35_GUARD_4K_BASELINE:-0}}"
+
+G36_128="${SPARKINFER_G36_GUARD_128_BASELINE:-$B36_128}"
+G36_512="${SPARKINFER_G36_GUARD_512_BASELINE:-$B36_512}"
+G36_4K="${SPARKINFER_G36_GUARD_4K_BASELINE:-$B36_4K}"
+G36_16K="${SPARKINFER_G36_GUARD_16K_BASELINE:-$B36_16K}"
+G36_32K="${SPARKINFER_G36_GUARD_32K_BASELINE:-$B36_32K}"
+
+G35_128="${SPARKINFER_G35_GUARD_128_BASELINE:-$B35_128}"
+G35_512="${SPARKINFER_G35_GUARD_512_BASELINE:-$B35_512}"
+G35_4K="${SPARKINFER_G35_GUARD_4K_BASELINE:-$B35_4K}"
+
+P_DIFF_REF="${SPARKINFER_DIFFICULTY_REF_OVERRIDE:-365.85}"
+
+# --- Direction A: optimize Qwen3.5, guard Qwen3.6 -----------------------------------------------
+PRIMARY35_JSON="$(run_model primary-qwen35 "$P35_FILE" "$P35_REPO" "$P35_TOK" 0 \
+  MODELS_DIR="$P35_DIR" MODEL_SHA256="${P35_SHA}" \
+  "${Q35_SHORT_ENVS[@]}" \
+  SPARKINFER_DIFFICULTY_BOOST=1 SPARKINFER_DIFFICULTY_REF="${P_DIFF_REF}" \
+  SPARKINFER_GUARD_128_BASELINE="${B35_128}" \
+  SPARKINFER_GUARD_512_BASELINE="${B35_512}" \
+  SPARKINFER_GUARD_4K_BASELINE="${B35_4K}" \
+  SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P35_LLAMA_128_BASELINE:-${QWEN35_9B_LLAMA_128:-0}}" \
+  SPARKINFER_LLAMA_512_BASELINE="${SPARKINFER_P35_LLAMA_512_BASELINE:-${QWEN35_9B_LLAMA_512:-0}}" \
+  SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P35_LLAMA_4K_BASELINE:-${QWEN35_9B_LLAMA_4K:-0}}")"
+
+GUARD36_JSON="$(run_model guard36 "$P36_FILE" "$P36_REPO" "$P36_TOK" 0 \
+  MODELS_DIR="$P36_DIR" MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" \
+  "${Q36_FULL_ENVS[@]}" \
+  SPARKINFER_GUARD_128_BASELINE="${G36_128}" \
+  SPARKINFER_GUARD_512_BASELINE="${G36_512}" \
+  SPARKINFER_GUARD_4K_BASELINE="${G36_4K}" \
+  SPARKINFER_GUARD_16K_BASELINE="${G36_16K}" \
+  SPARKINFER_GUARD_32K_BASELINE="${G36_32K}")"
+
+# --- Direction B: optimize Qwen3.6, guard Qwen3.5 -----------------------------------------------
+PRIMARY36_JSON="$(run_model primary-qwen36 "$P36_FILE" "$P36_REPO" "$P36_TOK" 0 \
+  MODELS_DIR="$P36_DIR" MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" \
+  "${Q36_FULL_ENVS[@]}" \
+  SPARKINFER_DIFFICULTY_BOOST=1 SPARKINFER_DIFFICULTY_REF="${P_DIFF_REF}" \
+  SPARKINFER_GUARD_128_BASELINE="${B36_128}" \
+  SPARKINFER_GUARD_512_BASELINE="${B36_512}" \
+  SPARKINFER_GUARD_4K_BASELINE="${B36_4K}" \
+  SPARKINFER_GUARD_16K_BASELINE="${B36_16K}" \
+  SPARKINFER_GUARD_32K_BASELINE="${B36_32K}" \
+  SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P36_LLAMA_128_BASELINE:-275.81}" \
+  SPARKINFER_LLAMA_512_BASELINE="${SPARKINFER_P36_LLAMA_512_BASELINE:-275.61}" \
+  SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P36_LLAMA_4K_BASELINE:-276.30}" \
+  SPARKINFER_LLAMA_16K_BASELINE="${SPARKINFER_P36_LLAMA_16K_BASELINE:-280.66}" \
+  SPARKINFER_LLAMA_32K_BASELINE="${SPARKINFER_P36_LLAMA_32K_BASELINE:-279.83}")"
+
+GUARD35_JSON="$(run_model guard35 "$P35_FILE" "$P35_REPO" "$P35_TOK" 0 \
+  MODELS_DIR="$P35_DIR" MODEL_SHA256="${P35_SHA}" \
+  "${Q35_SHORT_ENVS[@]}" \
+  SPARKINFER_GUARD_128_BASELINE="${G35_128}" \
+  SPARKINFER_GUARD_512_BASELINE="${G35_512}" \
+  SPARKINFER_GUARD_4K_BASELINE="${G35_4K}")"
+reap
+
+PRIMARY35_JSON="$PRIMARY35_JSON" GUARD36_JSON="$GUARD36_JSON" \
+PRIMARY36_JSON="$PRIMARY36_JSON" GUARD35_JSON="$GUARD35_JSON" \
+COMMIT="$COMMIT" QUANT="$QUANT" python3 - <<'PY'
+import json, os
+
+TIER_RANK = {"XL": 6, "L": 5, "M": 4, "S": 3, "XS": 2, "none": 1, "BASELINE": 0, "REJECT": -1}
+
+def load(name):
+    raw = os.environ.get(name, "").strip()
+    try:
+        return json.loads(raw) if raw else {}
+    except json.JSONDecodeError:
+        return {}
+
+def guard_ok(guard):
+    gctx = ["guard_128_pass", "guard_512_pass", "guard_4k_pass", "guard_16k_pass", "guard_32k_pass"]
+    present = [k for k in gctx if k in guard]
+    top1_bar = float(os.environ.get("SPARKINFER_TOP1_BAR", "0.90"))
+    kl_bar = float(os.environ.get("SPARKINFER_KL_BAR", "0.20"))
+    speed_ok = all(guard.get(k, True) for k in present)
+    g_top1 = float(guard.get("top1", 0)); g_kl = float(guard.get("kl", 99))
+    acc_ok = g_top1 >= top1_bar and g_kl <= kl_bar
+    label_map = {"guard_128_pass": "128", "guard_512_pass": "512", "guard_4k_pass": "4k",
+                 "guard_16k_pass": "16k", "guard_32k_pass": "32k"}
+    regressed = [label_map[k] for k in present if not guard.get(k, True)]
+    return bool(guard) and speed_ok and acc_ok, regressed, speed_ok, acc_ok
+
+def merge_primary(primary, guard, scored_model, guard_model, guard_prefix):
+    if not primary:
+        return {"label": "REJECT", "pass": False,
+                "reason": f"primary ({scored_model}) produced no verdict (infra error)"}
+    speed_ok, regressed, _, acc_ok = guard_ok(guard)
+    out = dict(primary)
+    out["model"] = scored_model
+    out["guard_model"] = guard_model
+    out["guard"] = {k: guard.get(k) for k in (
+        "pass", "top1", "kl", "label", "ctx_128_tps", "ctx_512_tps", "ctx_4096_tps",
+        "ctx_16384_tps", "ctx_32768_tps", "guard_128_pass", "guard_512_pass", "guard_4k_pass",
+        "guard_16k_pass", "guard_32k_pass") if k in guard}
+    out["guard"]["speed_ok"] = speed_ok
+    out["guard"]["accuracy_ok"] = acc_ok
+    if not speed_ok or not acc_ok:
+        reasons = []
+        if regressed:
+            reasons.append(f"{guard_model} decode regressed at: " + ", ".join(regressed))
+        if not acc_ok and guard:
+            reasons.append(f"{guard_model} accuracy broke (top1={guard.get('top1')}, kl={guard.get('kl')})")
+        if not guard:
+            reasons.append(f"{guard_model} guard produced no verdict")
+        out["label"] = "REJECT"
+        out["pass"] = False
+        out["reason"] = "no-regression guard: " + "; ".join(reasons or ["guard failed"])
+        out["guard_regression_labels"] = [f"regression-{guard_prefix}-" + c for c in regressed]
+    return out
+
+commit = os.environ["COMMIT"]
+quant = os.environ.get("QUANT", "Q4_K_M")
+q35_name = f"Qwythos-9B ({quant})"
+q36_name = "Qwen3.6-35B-A3B"
+
+score35 = merge_primary(load("PRIMARY35_JSON"), load("GUARD36_JSON"), q35_name, q36_name, "qwen36")
+score36 = merge_primary(load("PRIMARY36_JSON"), load("GUARD35_JSON"), q36_name, q35_name, "qwen35")
+
+def pick_best(a, b):
+    ra, rb = TIER_RANK.get(a.get("label"), -1), TIER_RANK.get(b.get("label"), -1)
+    if ra != rb:
+        return a if ra > rb else b
+    return a if float(a.get("tps") or 0) >= float(b.get("tps") or 0) else b
+
+passing = [s for s in (score35, score36) if s.get("pass")]
+best = pick_best(score35, score36) if passing else pick_best(score35, score36)
+
+final = dict(best)
+final["commit"] = commit
+final["mode"] = "bidir"
+final["score_qwen35"] = score35
+final["score_qwen36"] = score36
+final["label_qwen35"] = score35.get("label")
+final["label_qwen36"] = score36.get("label")
+final["pass_qwen35"] = bool(score35.get("pass"))
+final["pass_qwen36"] = bool(score36.get("pass"))
+final["model"] = "bidir"
+final["primary_quant"] = quant
+final["regression_labels"] = list(dict.fromkeys(
+    (score35.get("guard_regression_labels") or []) + (score36.get("guard_regression_labels") or [])))
+
+print("RESULT_JSON " + json.dumps(final))
+PY

--- a/eval/README.md
+++ b/eval/README.md
@@ -69,61 +69,35 @@ The default eval target is now multi-context decode:
 
 Set `SPARKINFER_EVAL_MODE=short` or pass `--eval-mode short` to keep the legacy 128-token scoring path.
 
-## Dual-model scoring: Qwen3.6 primary, Qwen3-30B no-regression guard
+## Bidirectional scoring: Qwen3.5 + Qwen3.6 (default)
 
-`--dual` scores **Qwen3.6-35B-A3B** (the current optimization frontier) and, in the same build on the
-same box, **guards Qwen3-30B-A3B against regression** — an optimization that speeds up Qwen3.6 must
-not quietly break or slow the shipped Qwen3 path.
+`--bidir` (or `BIDIR=1` / legacy `TRIPLE=1` in `.env.eval`) scores **both directions** in one build:
 
 ```
-build once ─► PRIMARY  Qwen3.6 : 128/512/4k/16k/32k speed + token-match/KL vs llama.cpp ─► eval:<LABEL>
-           └► GUARD    Qwen3-30B: same speed sweep + accuracy gate ─► must NOT regress, else REJECT
+build once ─► score_qwen35  Qwythos-9B : 128/512/4k speed + accuracy ─► eval-qwen35:<LABEL>
+           │              guard Qwen3.6  : 5 contexts ─► must NOT regress
+           └► score_qwen36  Qwen3.6      : 128/512/4k/16k/32k ─► eval-qwen36:<LABEL>
+                          guard Qwen3.5  : 128/512/4k ─► must NOT regress
 ```
 
-- The **eval:<label>** (XS…XL / none / REJECT) is driven **only by Qwen3.6** — its strongest single
-  context improvement over the Qwen3.6 frontier, same significance/bucket/difficulty rules as above.
-- The **Qwen3-30B guard** re-runs the full 5-context speed sweep **and** the top-1/KL accuracy gate.
-  If Qwen3 drops below 98% of its own same-box `origin/main` at *any* context, **or** breaks parity
-  with llama.cpp (top-1 < 0.90 or KL > 0.20), the whole submission is **REJECTed** with a
-  `no-regression guard` reason and `regression-qwen3-<ctx>` detail — regardless of the Qwen3.6 gain.
-- Both models' measurements merge into one `RESULT_JSON`; the Qwen3 guard block is under `guard`.
-- Cost: two ~20 GB model loads + two llama.cpp accuracy passes, run **sequentially** (they don't fit
-  in VRAM together), so a dual eval is ~2× a single-model eval.
+- **Qwen3.5** (Qwythos-9B) is measured at **128, 512, 4k only** — not 16k/32k.
+- **Qwen3.6** runs the full **5-context** sweep (128/512/4k/16k/32k).
+- Each direction gets its own label: `eval-qwen35:<tier>` and `eval-qwen36:<tier>`.
+- Headline `eval:<label>` is the best verified tier among passing directions.
+- Qwen3-30B is **no longer** part of the eval pipeline.
+- `PRIMARY_QUANT` selects the Qwen3.5 GGUF: `Q4_K_M` (default), `Q8_0`, or `BF16`.
+- Models: `/workspace/models35` (Qwythos), `/workspace/models36` (Qwen3.6).
+- Orchestrator: `bench/scripts/evaluate_bidir.sh`.
 
 ```bash
-# Qwen3.6 scored, Qwen3-30B guarded (baselines are same-box origin/main tok/s per context):
-python eval/vast_eval.py --reuse <id> --dual \
-  --primary-frontier <qwen36_best_tps> --ceiling <roofline> \
-  --p-guard-128-baseline 23.2 --p-guard-512-baseline 23.2 --p-guard-4k-baseline 23.0 \
-  --p-guard-16k-baseline <..> --p-guard-32k-baseline <..> \
-  --guard-128-baseline 331 --guard-512-baseline 331 --guard-4k-baseline 322 \
-  --guard-16k-baseline 330 --guard-32k-baseline 300
+python eval/vast_eval.py --ssh HOST:PORT --bidir --primary-quant Q4_K_M --ref main
+./eval/run_bot.sh --bidir
 ```
 
-The on-box orchestrator is `bench/scripts/evaluate_dual.sh` (builds once, calls the model-agnostic
-`evaluate.sh` twice via `SI_SKIP_BUILD=1`, merges). Qwen3.6 runs the same UD-Q4_K_M GGUF the runtime
-now loads by default (mixed Q5_K experts).
+## Legacy dual/triple modes
 
-## Triple-model scoring: Qwythos-9B primary, Qwen3.6 + Qwen3-30B guards
-
-`--triple` (or `TRIPLE=1` in `.env.eval`) scores **Qwythos-9B** (Qwen3.5-9B, miner optimization target)
-and guards **both** Qwen3.6-35B-A3B and Qwen3-30B-A3B against no-regression in one build.
-
-```
-build once ─► PRIMARY  Qwythos-9B (Q4_K_M|Q8_0|BF16) ─► eval:<LABEL>
-           ├► GUARD36 Qwen3.6  : 5-context speed + accuracy ─► must NOT regress
-           └► GUARD3  Qwen3-30B : 5-context speed + accuracy ─► must NOT regress
-```
-
-- `PRIMARY_QUANT` selects the Qwythos GGUF: `Q4_K_M` (default), `Q8_0`, or `BF16`.
-- Models live in `/workspace/models35` (Qwythos), `/workspace/models36` (Qwen3.6), `/workspace/models` (Qwen3-30B).
-- Orchestrator: `bench/scripts/evaluate_triple.sh`.
-- Max context on RTX 5090 (32 GB): see `bench/results/qwythos_max_ctx_rtx5090.json` (`probe_max_ctx_llama.sh` until sparkinfer loads dense Qwen3.5-9B GGUFs).
-
-```bash
-python eval/vast_eval.py --ssh HOST:PORT --triple --primary-quant Q4_K_M --ref main
-./eval/run_bot.sh --triple
-```
+`--dual` and `--triple` are aliases for `--bidir`. The old Qwen3-30B guard paths
+(`evaluate_dual.sh`, `evaluate_triple.sh`) are retained for reference but no longer used by the bot.
 
 ## Verdict (stdout)
 

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -353,15 +353,22 @@ def render(res, oid):
     guard36 = res.get("guard36") or {}
     guard3 = res.get("guard3") or {}
     scored_model = res.get("model")
-    dual = bool(guard) and bool(scored_model) and not (guard36 or guard3)
-    triple = bool(guard36 or guard3) and bool(scored_model)
+    bidir = res.get("mode") == "bidir" or bool(res.get("score_qwen35"))
+    dual = bool(guard) and bool(scored_model) and not (guard36 or guard3) and not bidir
+    triple = bool(guard36 or guard3) and bool(scored_model) and not bidir
     short = scored_model.split("(")[0].strip() if scored_model else ""
     if not short and scored_model:
         short = scored_model.split("-")[0]
     gname = res.get("guard_model", "Qwen3-30B")
-    rows = [f"| **label** | `eval:{label}` |",
-            f"| scored decode ({res.get('score_context', 128)} ctx{f' · {ctx_label}' if ctx_label else ''}{f' · {short}' if dual or triple else ''}) | {res.get('tps','?')} tok/s |",
-            f"| correctness{f' ({short} vs llama.cpp)' if dual or triple else ''} | top-1 {res.get('top1',0)*100:.1f}% · KL {res.get('kl','?')} |"]
+    rows = [f"| **label** | `eval:{label}` |"]
+    if bidir:
+        rows.append(f"| Qwen3.5 score | `eval-qwen35:{res.get('label_qwen35', '?')}` "
+                    f"({'pass' if res.get('pass_qwen35') else 'fail'}) |")
+        rows.append(f"| Qwen3.6 score | `eval-qwen36:{res.get('label_qwen36', '?')}` "
+                    f"({'pass' if res.get('pass_qwen36') else 'fail'}) |")
+    rows += [
+            f"| scored decode ({res.get('score_context', 128)} ctx{f' · {ctx_label}' if ctx_label else ''}{f' · {short}' if dual or triple or bidir else ''}) | {res.get('tps','?')} tok/s |",
+            f"| correctness{f' ({short} vs llama.cpp)' if dual or triple or bidir else ''} | top-1 {res.get('top1',0)*100:.1f}% · KL {res.get('kl','?')} |"]
     # scored-model per-context no-regression gates — SKIP contexts not measured (tps 0/None) so a
     # deliberately-skipped 16k/32k never renders a misleading "0.0 tok/s · pass".
     for key, gkey, bkey, lbl in [("ctx_128_tps", "guard_128_pass", "guard_128_baseline", "128-token"),
@@ -382,6 +389,29 @@ def render(res, oid):
         rows.append(f"| legacy 2k no-regression gate | {res.get('ctx_2048_tps')} tok/s"
                     f"{f' vs main {base} tok/s' if base else ''} · {gate} |")
     # The Qwen3-30B no-regression guard — the check that actually gates a dual verdict.
+    if bidir:
+        for title, block in [("Qwen3.5 optimize", res.get("score_qwen35") or {}),
+                             ("Qwen3.6 optimize", res.get("score_qwen36") or {})]:
+            if not block:
+                continue
+            rows.append(f"| **{title}** | `eval:{block.get('label','?')}` · "
+                        f"{block.get('tps','?')} tok/s · {'pass' if block.get('pass') else 'fail'} |")
+            g = block.get("guard") or {}
+            gname = block.get("guard_model", "guard")
+            if g:
+                rows.append(f"| {title} — {gname} guard accuracy | "
+                            f"top-1 {g.get('top1',0)*100:.1f}% · KL {g.get('kl','?')} · "
+                            f"{'pass' if g.get('accuracy_ok', True) else '**FAIL**'} |")
+                for key, gkey, lbl in [("ctx_128_tps", "guard_128_pass", "128"),
+                                       ("ctx_512_tps", "guard_512_pass", "512"),
+                                       ("ctx_4096_tps", "guard_4k_pass", "4k"),
+                                       ("ctx_16384_tps", "guard_16k_pass", "16k"),
+                                       ("ctx_32768_tps", "guard_32k_pass", "32k")]:
+                    tps = g.get(key)
+                    if not tps:
+                        continue
+                    rows.append(f"| {title} — {gname} {lbl} | {tps} tok/s · "
+                                f"{'pass' if g.get(gkey, True) else '**fail**'} |")
     if dual:
         acc_ok = "pass" if guard.get("accuracy_ok", True) else "**FAIL**"
         rows.append(f"| **{gname} guard — accuracy** | top-1 {guard.get('top1',0)*100:.1f}% · KL {guard.get('kl','?')} · {acc_ok} |")
@@ -678,7 +708,49 @@ def record_merge(repo, num):
     data = load_dash()
     if data is None: return
     e = next((p for p in data.get("prs", []) if p.get("num") == num), None)
-    if not e or e.get("label") not in SPEEDUP_LABELS: return                 # only verified speedups
+    if not e:
+        return
+    if e.get("mode") == "bidir":
+        if not ((e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS) or
+                (e.get("pass_qwen36") and e.get("label_qwen36") in SPEEDUP_LABELS) or
+                e.get("label") in SPEEDUP_LABELS):
+            return
+        changed = False
+        if e.get("pass_qwen36") and e.get("label_qwen36") in SPEEDUP_LABELS:
+            sub = e.get("score_qwen36") or e
+            q36 = data.setdefault("qwen36", {})
+            old_f = round(q36.get("frontier_tps") or q36.get("baseline_tps") or 0, 2)
+            new_f = round(max(old_f, sub.get("tps") or 0), 2)
+            q36["frontier_tps"] = new_f
+            if sub.get("top1") is not None: q36["token_match"] = round(sub["top1"], 4)
+            if sub.get("kl") is not None:   q36["kl"] = round(sub["kl"], 4)
+            short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
+            landed = [m for m in data.get("landed_qwen36", []) if m.get("pr") != num and not m.get("baseline")]
+            landed.append({"name": short or f"PR #{num}", "tps": new_f, "pr": num,
+                           "date": datetime.date.today().isoformat(), "label": e.get("label_qwen36")})
+            data["landed_qwen36"] = sorted(landed, key=lambda m: m["tps"])
+            changed = True
+        if e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS:
+            sub = e.get("score_qwen35") or e
+            q35 = data.setdefault("qwen35", {})
+            old_f = round(q35.get("frontier_tps") or q35.get("baseline_tps") or 0, 2)
+            new_f = round(max(old_f, sub.get("tps") or 0), 2)
+            q35["frontier_tps"] = new_f
+            if sub.get("top1") is not None: q35["token_match"] = round(sub["top1"], 4)
+            if sub.get("kl") is not None:   q35["kl"] = round(sub["kl"], 4)
+            short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
+            landed = [m for m in data.get("landed_qwen35", []) if m.get("pr") != num]
+            landed.append({"name": short or f"PR #{num}", "tps": new_f, "pr": num,
+                           "date": datetime.date.today().isoformat(), "label": e.get("label_qwen35")})
+            data["landed_qwen35"] = sorted(landed, key=lambda m: m["tps"])
+            changed = True
+        if changed:
+            data["updated"] = datetime.date.today().isoformat()
+            write_dash(data)
+            push_dash(f"dashboard: PR #{num} merged -> bidir frontier update")
+        return
+    if e.get("label") not in SPEEDUP_LABELS:
+        return
     # A Qwen3.6 dual-eval result must advance the Qwen3.6 frontier/journey, not Qwen3-MoE's — its
     # delta_pct was measured against a different baseline (23 tok/s, +635%), and applying that gain
     # to Qwen3-MoE's 493 frontier inflates the chart 7.4× per PR. Route to landed_qwen36.
@@ -889,10 +961,12 @@ def main():
     # Dual-model: score Qwen3.6-35B-A3B (primary) and guard Qwen3-30B against no-regression.
     # Each PR is scored directly against the SAME-BOX origin/main baseline (measured once per run),
     # not a passed-in frontier number — so the gain is hardware-independent and always current.
+    ap.add_argument("--bidir", action="store_true",
+                    help="bidirectional Qwen3.5 + Qwen3.6 eval via evaluate_bidir.sh")
     ap.add_argument("--dual", action="store_true",
-                    help="score Qwen3.6 (primary) + guard Qwen3-30B (no-regression) via evaluate_dual.sh")
+                    help="legacy alias for --bidir")
     ap.add_argument("--triple", action="store_true",
-                    help="score Qwythos-9B (primary) + guard Qwen3.6 + Qwen3-30B via evaluate_triple.sh")
+                    help="legacy alias for --bidir")
     ap.add_argument("--primary-quant", default=os.environ.get("PRIMARY_QUANT", "Q4_K_M"),
                     choices=["Q4_K_M", "Q8_0", "BF16"],
                     help="[--triple] Qwythos GGUF quant (default Q4_K_M)")
@@ -903,8 +977,11 @@ def main():
     ap.add_argument("--reeval", action="store_true",
                     help="re-run eval even if this commit was already graded (use with --only-pr)")
     args = ap.parse_args()
-    if args.triple and args.dual:
-        ap.error("--triple and --dual are mutually exclusive")
+    if args.triple or args.dual:
+        args.bidir = True
+    if os.environ.get("BIDIR", "1") != "0" and not any(
+            a in sys.argv for a in ("--bidir", "--triple", "--dual")):
+        args.bidir = True
     if not ssh_box_enabled() and not args.instance:
         ap.error("--instance is required for vast.ai transport (or set EVAL_TRANSPORT=ssh + EVAL_SSH_HOST)")
     if ssh_box_enabled():
@@ -927,8 +1004,6 @@ def main():
         "128": float(os.environ.get("SPARKINFER_QWYTHOS_128", "0")),
         "512": float(os.environ.get("SPARKINFER_QWYTHOS_512", "0")),
         "4k":  float(os.environ.get("SPARKINFER_QWYTHOS_4K",  "0")),
-        "16k": float(os.environ.get("SPARKINFER_QWYTHOS_16K", "0")),
-        "32k": float(os.environ.get("SPARKINFER_QWYTHOS_32K", "0")),
         "llama128": float(os.environ.get("QWEN35_9B_LLAMA_128", "0")),
         "llama512": float(os.environ.get("QWEN35_9B_LLAMA_512", "0")),
         "llama4k":  float(os.environ.get("QWEN35_9B_LLAMA_4K",  "0")),
@@ -1142,6 +1217,8 @@ def main():
             *_vast_eval_transport_args(args.instance),
             "--ref", "origin/main", "--frontier", "0", "--ceiling", str(args.ceiling),
             "--eval-mode", "longctx", "--keep"]
+    if args.bidir:
+        bcmd += ["--bidir", "--primary-quant", args.primary_quant]
     if PINNED_INSTANCE and not ssh_box_enabled() and str(base_iid) == PINNED_INSTANCE:
         bcmd.append("--pinned")
     box_label = ssh_box_arg() if ssh_box_enabled() else f"instance {base_iid}"
@@ -1160,17 +1237,34 @@ def main():
             except Exception: pass
     bline = next((l for l in br.stdout.splitlines() if l.startswith("RESULT_JSON")), None)
     bres = json.loads(bline[len("RESULT_JSON "):]) if bline else {}
-    if not bres.get("pass") or not bres.get("tps"):
+    if not bres.get("label"):
         log = (br.stdout + br.stderr)[-1200:]
         print(f">> same-box baseline (origin/main) failed ({bres.get('label','no result')}) — "
               f"aborting; no PRs graded.\n{log}"); return
-    run_baseline = bres["tps"]
-    run_guard_128 = float(bres.get("ctx_128_tps") or bres.get("tps") or 0)
-    run_guard_512 = float(bres.get("ctx_512_tps") or 0)
-    run_guard_4k = float(bres.get("ctx_4096_tps") or 0)
-    run_guard_16k = float(bres.get("ctx_16384_tps") or bres.get("tps") or 0)
-    run_guard_32k = float(bres.get("ctx_32768_tps") or 0)
-    score_ctx = int(bres.get("score_context") or 128)
+    if args.bidir and not (bres.get("pass") or bres.get("score_qwen35") or bres.get("score_qwen36")):
+        log = (br.stdout + br.stderr)[-1200:]
+        print(f">> bidir baseline (origin/main) failed — aborting; no PRs graded.\n{log}"); return
+    if not args.bidir and (not bres.get("pass") or not bres.get("tps")):
+        log = (br.stdout + br.stderr)[-1200:]
+        print(f">> same-box baseline (origin/main) failed ({bres.get('label','no result')}) — "
+              f"aborting; no PRs graded.\n{log}"); return
+    if args.bidir:
+        run_baseline = float((bres.get("score_qwen36") or {}).get("tps") or bres.get("tps") or 0)
+        s36 = bres.get("score_qwen36") or {}
+        run_guard_128 = float(s36.get("ctx_128_tps") or run_baseline)
+        run_guard_512 = float(s36.get("ctx_512_tps") or 0)
+        run_guard_4k = float(s36.get("ctx_4096_tps") or 0)
+        run_guard_16k = float(s36.get("ctx_16384_tps") or run_baseline)
+        run_guard_32k = float(s36.get("ctx_32768_tps") or 0)
+        score_ctx = int(s36.get("score_context") or bres.get("score_context") or 128)
+    else:
+        run_baseline = bres["tps"]
+        run_guard_128 = float(bres.get("ctx_128_tps") or bres.get("tps") or 0)
+        run_guard_512 = float(bres.get("ctx_512_tps") or 0)
+        run_guard_4k = float(bres.get("ctx_4096_tps") or 0)
+        run_guard_16k = float(bres.get("ctx_16384_tps") or bres.get("tps") or 0)
+        run_guard_32k = float(bres.get("ctx_32768_tps") or 0)
+        score_ctx = int(bres.get("score_context") or 128)
     if score_ctx == 128:
         print(f">> same-box baseline: origin/main = {run_baseline} tok/s on this box")
     else:
@@ -1192,9 +1286,8 @@ def main():
               f"Aborting; NO PRs graded. Re-run on a warm, stable box.")
         return
 
-    # Dual/triple mode: bench model mains directly on the box — the same build the Qwen3-30B
-    # baseline already verified. No accuracy gate, just a 5-context decode sweep.
-    if (args.dual or args.triple) and _vast_sh:
+    # Bidir mode: bench both model mains on the box (Qwen3.5 at 128/512/4k only).
+    if args.bidir and _vast_sh:
         ssh_ep = ssh_box_endpoint()
         if ssh_ep:
             host, port = ssh_ep
@@ -1206,11 +1299,12 @@ def main():
         else:
             host = port = None
 
-        def _ctx_sweep(host, port, gguf, label, store):
+        def _ctx_sweep(host, port, gguf, label, store, ctx_list=None):
             B = "/root/sparkinfer/build/runtime/qwen3_gguf_bench"
             tps = {}
-            for lbl, ctx in [("128", 0), ("512", 512), ("4k", 4096),
-                             ("16k", 16384), ("32k", 32768)]:
+            sweep = ctx_list or [("128", 0), ("512", 512), ("4k", 4096),
+                                 ("16k", 16384), ("32k", 32768)]
+            for lbl, ctx in sweep:
                 cmd = f"export PATH=/usr/local/cuda/bin:$PATH; {B} '{gguf}' 128 {ctx}"
                 r = _vast_sh(host, port, cmd, timeout=600)
                 m = re.search(r"decode\s+tg\s*:\s*([0-9.]+)", r.stdout + r.stderr)
@@ -1228,18 +1322,17 @@ def main():
                 print(f"  {label} bench failed — using config defaults")
 
         if host and port:
-            if args.dual or args.triple:
-                _ctx_sweep(host, port, "/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-                           "Qwen3.6", QWEN36_BASE)
-            if args.triple:
-                qmap = {
-                    "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
-                    "Q8_0":   "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
-                    "BF16":   "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf",
-                }
-                qfile = qmap[args.primary_quant]
-                _ctx_sweep(host, port, f"/workspace/models35/{qfile}",
-                           f"Qwythos ({args.primary_quant})", QWYTHOS_BASE)
+            _ctx_sweep(host, port, "/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                       "Qwen3.6", QWEN36_BASE)
+            qmap = {
+                "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
+                "Q8_0":   "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
+                "BF16":   "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf",
+            }
+            qfile = qmap[args.primary_quant]
+            _ctx_sweep(host, port, f"/workspace/models35/{qfile}",
+                       f"Qwythos ({args.primary_quant})", QWYTHOS_BASE,
+                       ctx_list=[("128", 0), ("512", 512), ("4k", 4096)])
         else:
             print(f"  could not reach eval box for model bench — using config defaults")
 
@@ -1265,33 +1358,26 @@ def main():
                "--guard-16k-baseline", str(run_guard_16k),
                "--guard-32k-baseline", str(run_guard_32k),
                "--keep"]
-        if args.triple:
+        if args.bidir:
             cmd[cmd.index("--keep"):cmd.index("--keep")] = [
-                "--triple",
+                "--bidir",
                 "--primary-quant", args.primary_quant,
-                "--p-guard-128-baseline", str(QWYTHOS_BASE["128"]),
-                "--p-guard-512-baseline", str(QWYTHOS_BASE["512"]),
-                "--p-guard-4k-baseline",  str(QWYTHOS_BASE["4k"]),
-                "--p-guard-16k-baseline", str(QWYTHOS_BASE["16k"]),
-                "--p-guard-32k-baseline", str(QWYTHOS_BASE["32k"]),
-                "--p-llama-128-baseline", str(QWYTHOS_BASE["llama128"]),
-                "--p-llama-512-baseline", str(QWYTHOS_BASE["llama512"]),
-                "--p-llama-4k-baseline",  str(QWYTHOS_BASE["llama4k"]),
-                "--g36-guard-128-baseline", str(QWEN36_BASE["128"]),
-                "--g36-guard-512-baseline", str(QWEN36_BASE["512"]),
-                "--g36-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
-                "--g36-guard-16k-baseline", str(QWEN36_BASE["16k"]),
-                "--g36-guard-32k-baseline", str(QWEN36_BASE["32k"])]
-        elif args.dual:
-            # Qwen3.6 scored (128/512/4k); the --guard-*-baseline above become the Qwen3-30B guard.
-            # Scoring base = same-box origin/main baseline (the guard baselines), not a passed-in frontier.
-            cmd[cmd.index("--keep"):cmd.index("--keep")] = [
-                "--dual",
+                "--p35-guard-128-baseline", str(QWYTHOS_BASE["128"]),
+                "--p35-guard-512-baseline", str(QWYTHOS_BASE["512"]),
+                "--p35-guard-4k-baseline",  str(QWYTHOS_BASE["4k"]),
                 "--p-guard-128-baseline", str(QWEN36_BASE["128"]),
                 "--p-guard-512-baseline", str(QWEN36_BASE["512"]),
                 "--p-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
                 "--p-guard-16k-baseline", str(QWEN36_BASE["16k"]),
                 "--p-guard-32k-baseline", str(QWEN36_BASE["32k"]),
+                "--g36-guard-128-baseline", str(QWEN36_BASE["128"]),
+                "--g36-guard-512-baseline", str(QWEN36_BASE["512"]),
+                "--g36-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
+                "--g36-guard-16k-baseline", str(QWEN36_BASE["16k"]),
+                "--g36-guard-32k-baseline", str(QWEN36_BASE["32k"]),
+                "--g35-guard-128-baseline", str(QWYTHOS_BASE["128"]),
+                "--g35-guard-512-baseline", str(QWYTHOS_BASE["512"]),
+                "--g35-guard-4k-baseline",  str(QWYTHOS_BASE["4k"]),
                 "--p-llama-128-baseline", str(QWEN36_BASE["llama128"]),
                 "--p-llama-512-baseline", str(QWEN36_BASE["llama512"]),
                 "--p-llama-4k-baseline",  str(QWEN36_BASE["llama4k"])]
@@ -1378,9 +1464,14 @@ def main():
             print("--- dry-run, not posting ---\n" + body); continue
         if label:
             cur = labels_on(args.repo, num)
-            for lab in {l for l in cur if l.startswith("eval:")}:
+            for lab in {l for l in cur if l.startswith("eval:") or l.startswith("eval-qwen")}:
                 remove_label(args.repo, num, lab)
             add_label(args.repo, num, f"eval:{label}")
+            if res and res.get("mode") == "bidir":
+                if res.get("label_qwen35"):
+                    add_label(args.repo, num, f"eval-qwen35:{res['label_qwen35']}")
+                if res.get("label_qwen36"):
+                    add_label(args.repo, num, f"eval-qwen36:{res['label_qwen36']}")
             apply_context_label(args.repo, num, cur, res.get("best_context_label"))
             apply_regression_labels(args.repo, num, cur, res.get("regression_labels"))
             # This was just graded against the CURRENT main, so it's no longer stale: clear

--- a/eval/run_bot.sh
+++ b/eval/run_bot.sh
@@ -3,8 +3,8 @@
 #
 #   ./eval/run_bot.sh              # full run on SSH box (or vast if EVAL_TRANSPORT=vast)
 #   ./eval/run_bot.sh --dry-run    # poll PRs + print plan, no GPU eval
-#   ./eval/run_bot.sh --dual       # force dual-model eval (Qwen3.6 + Qwen3-30B guard)
-#   ./eval/run_bot.sh --triple     # Qwythos-9B primary + Qwen3.6 + Qwen3-30B guards
+#   ./eval/run_bot.sh --bidir      # Qwen3.5 + Qwen3.6 bidirectional eval (default)
+#   ./eval/run_bot.sh --triple     # legacy alias for --bidir
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -31,10 +31,10 @@ BOT_ARGS=(
 if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
   BOT_ARGS+=(--instance "${VAST_INSTANCE:-42682383}")
 fi
-if [ -n "${TRIPLE:-}" ] || printf '%s\n' "$@" | grep -qx -- '--triple'; then
-  BOT_ARGS+=(--triple --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
-elif [ -n "${DUAL:-}" ] || printf '%s\n' "$@" | grep -qx -- '--dual'; then
-  BOT_ARGS+=(--dual)
+if printf '%s\n' "$@" | grep -qx -- '--bidir' || \
+   [ -n "${BIDIR:-${TRIPLE:-1}}" ] && [ "${BIDIR:-${TRIPLE:-1}}" != "0" ] || \
+   [ -n "${DUAL:-}" ] || printf '%s\n' "$@" | grep -qxE -- '--triple|--dual'; then
+  BOT_ARGS+=(--bidir --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
 fi
 if [ -n "${POLARIS:-}" ] || printf '%s\n' "$@" | grep -qx -- '--polaris'; then
   BOT_ARGS+=(--polaris)

--- a/eval/run_bot_cron.sh
+++ b/eval/run_bot_cron.sh
@@ -37,7 +37,6 @@ BOT_ARGS=(
 if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
   BOT_ARGS+=(--instance "${VAST_INSTANCE:-42682383}")
 fi
-[ -n "${TRIPLE:-}" ] && BOT_ARGS+=(--triple --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
-[ -z "${TRIPLE:-}" ] && [ -n "${DUAL:-}" ] && BOT_ARGS+=(--dual)
+[ "${BIDIR:-${TRIPLE:-1}}" != "0" ] && BOT_ARGS+=(--bidir --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
 
 python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}"

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -228,9 +228,19 @@ def main():
     ap.add_argument("--p-llama-4k-baseline",  type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 4k-context tok/s")
     ap.add_argument("--p-llama-16k-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 16k-context tok/s")
     ap.add_argument("--p-llama-32k-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 32k-context tok/s")
-    # --- triple-model: Qwythos-9B (primary) + Qwen3.6 guard + Qwen3-30B guard ---
+    # --- bidirectional: Qwen3.5-9B + Qwen3.6-35B (both directions scored) ---
+    ap.add_argument("--bidir", action="store_true",
+                    help="bidirectional eval: score Qwen3.5 (128/512/4k) and Qwen3.6 (5 contexts), "
+                         "each guarding the other via evaluate_bidir.sh")
+    ap.add_argument("--p35-guard-128-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 128-token tok/s")
+    ap.add_argument("--p35-guard-512-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 512-context tok/s")
+    ap.add_argument("--p35-guard-4k-baseline",  type=float, default=0, help="[--bidir] Qwen3.5 main 4k-context tok/s")
+    ap.add_argument("--g35-guard-128-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 128-token tok/s")
+    ap.add_argument("--g35-guard-512-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 512-context tok/s")
+    ap.add_argument("--g35-guard-4k-baseline",  type=float, default=0, help="[--bidir] Qwen3.5 guard 4k-context tok/s")
+    # --- triple-model: legacy alias for --bidir ---
     ap.add_argument("--triple", action="store_true",
-                    help="score Qwythos-9B (Qwen3.5) and guard Qwen3.6 + Qwen3-30B via evaluate_triple.sh")
+                    help="alias for --bidir (Qwen3.5 + Qwen3.6 only; Qwen3-30B removed)")
     ap.add_argument("--primary-quant", default=os.environ.get("PRIMARY_QUANT", "Q4_K_M"),
                     choices=["Q4_K_M", "Q8_0", "BF16"],
                     help="[--triple] Qwythos GGUF quant to score (default Q4_K_M)")
@@ -257,8 +267,8 @@ def main():
     ap.add_argument("--polaris", action="store_true",
                     help="generate a Polaris verifiable receipt (unsigned attestation from eval box)")
     args = ap.parse_args()
-    if args.triple and args.dual:
-        ap.error("--triple and --dual are mutually exclusive")
+    if args.triple or args.dual:
+        args.bidir = True
 
     if not args.ssh and ssh_box_enabled():
         args.ssh = ssh_box_arg()
@@ -434,7 +444,9 @@ def main():
         # Pre-cache the model in a nohup background job so SSH drops don't abort the download.
         # If the file is already present (reused box), this is instant. Otherwise we poll for the
         # sentinel file created when the download completes.
-        prefetch = (
+        # Pre-cache Qwen3-30B only for legacy single-model eval (not bidir).
+        if not args.bidir:
+            prefetch = (
             f"if [ -f '{MODEL_PATH}' ]; then touch '{MODEL_READY}' && echo cached; "
             f"elif [ -f '{MODEL_READY}' ]; then echo already_running; "
             f"else mkdir -p /workspace/models && rm -f '{MODEL_READY}'; "
@@ -453,15 +465,15 @@ def main():
             f"       -o {MODEL_PATH} >>/tmp/dl.log 2>&1; "
             f"  [ -f {MODEL_PATH} ] && touch {MODEL_READY}"
             f"' >/dev/null 2>&1 & echo started; fi"
-        )
-        pr = sh(host, port, prefetch, timeout=30)
-        status = pr.stdout.strip()
-        if status == "cached":
-            print(">> model already cached — skipping download")
-        else:
-            print(f">> model download started in background ({status}) — polling for completion ...")
-            if not wait_model(host, port):
-                print("!! model download timed out — evaluate.sh will retry (may add time)")
+            )
+            pr = sh(host, port, prefetch, timeout=30)
+            status = pr.stdout.strip()
+            if status == "cached":
+                print(">> model already cached — skipping download")
+            else:
+                print(f">> model download started in background ({status}) — polling for completion ...")
+                if not wait_model(host, port):
+                    print("!! model download timed out — evaluate.sh will retry (may add time)")
 
         def _prefetch_hf(gguf_path, hf_repo, hf_file, ready_path, log_path):
             """Background-download a single GGUF into gguf_path; poll ready_path sentinel."""
@@ -480,7 +492,7 @@ def main():
                 f"' >/dev/null 2>&1 & echo started; fi"
             )
 
-        if args.triple or args.dual:
+        if args.bidir:
             # Dual/triple needs the Qwen3.6 GGUF too. Google Drive first (gdown handles the large-file
             # confirm token) — HF is throttled to ~KB/s from many vast hosts; HF/curl are the fallback.
             # Override the Drive id with MODEL36_GDRIVE_ID="" to disable. Separate dir from Qwen3 (the
@@ -524,8 +536,8 @@ def main():
                 else:
                     print("!! Qwen3.6 download slow — evaluate_dual.sh will retry (may add time)")
 
-        if args.triple:
-            # Qwythos-9B (Qwen3.5) primary — separate dir (/workspace/models35).
+        if args.bidir:
+            # Qwythos-9B (Qwen3.5) — separate dir (/workspace/models35).
             qmap = {
                 "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
                 "Q8_0":   "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
@@ -554,7 +566,7 @@ def main():
                         break
                     time.sleep(20)
                 else:
-                    print("!! Qwythos download slow — evaluate_triple.sh will retry (may add time)")
+                    print("!! Qwythos download slow — evaluate_bidir.sh will retry (may add time)")
 
         # Reap any leftover reference server / runner from a previous PR on this kept-alive box —
         # a leaked llama-server holding port 8081 would make this PR's accuracy.sh fail to bind.
@@ -570,88 +582,39 @@ def main():
         # Difficulty compensation ON (Option B): as the frontier pulls past llama.cpp each further %
         # gain is harder, so label.py scales the label tier up (raw % + significance gate unchanged).
         # Governance-tunable via SPARKINFER_DIFFICULTY_{K,REF,MAX}; applies from new evals onward.
-        if args.triple:
+        if args.bidir:
             ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
                   f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
                   f"SPARKINFER_EVAL_MODE={args.eval_mode} PRIMARY_QUANT={args.primary_quant} "
-                  f"SPARKINFER_G3_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
-                  f"SPARKINFER_G3_GUARD_512_BASELINE={args.guard_512_baseline} "
-                  f"SPARKINFER_G3_GUARD_4K_BASELINE={args.guard_4k_baseline} "
-                  f"SPARKINFER_G3_GUARD_16K_BASELINE={args.guard_16k_baseline} "
-                  f"SPARKINFER_G3_GUARD_32K_BASELINE={args.guard_32k_baseline} "
+                  f"SPARKINFER_P35_GUARD_128_BASELINE={args.p35_guard_128_baseline} "
+                  f"SPARKINFER_P35_GUARD_512_BASELINE={args.p35_guard_512_baseline} "
+                  f"SPARKINFER_P35_GUARD_4K_BASELINE={args.p35_guard_4k_baseline} "
+                  f"SPARKINFER_P36_GUARD_128_BASELINE={args.p_guard_128_baseline} "
+                  f"SPARKINFER_P36_GUARD_512_BASELINE={args.p_guard_512_baseline} "
+                  f"SPARKINFER_P36_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
+                  f"SPARKINFER_P36_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
+                  f"SPARKINFER_P36_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
                   f"SPARKINFER_G36_GUARD_128_BASELINE={args.g36_guard_128_baseline} "
                   f"SPARKINFER_G36_GUARD_512_BASELINE={args.g36_guard_512_baseline} "
                   f"SPARKINFER_G36_GUARD_4K_BASELINE={args.g36_guard_4k_baseline} "
                   f"SPARKINFER_G36_GUARD_16K_BASELINE={args.g36_guard_16k_baseline} "
                   f"SPARKINFER_G36_GUARD_32K_BASELINE={args.g36_guard_32k_baseline} "
-                  f"SPARKINFER_P_GUARD_128_BASELINE={args.p_guard_128_baseline} "
-                  f"SPARKINFER_P_GUARD_512_BASELINE={args.p_guard_512_baseline} "
-                  f"SPARKINFER_P_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
-                  f"SPARKINFER_P_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
-                  f"SPARKINFER_P_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
-                  f"SPARKINFER_P_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
-                  f"SPARKINFER_P_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
-                  f"SPARKINFER_P_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
-                  f"SPARKINFER_P_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
-                  f"SPARKINFER_P_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
-                  f"MODELS_DIR=/workspace/models QWYTHOS_MODELS_DIR=/workspace/models35 "
+                  f"SPARKINFER_G35_GUARD_128_BASELINE={args.g35_guard_128_baseline} "
+                  f"SPARKINFER_G35_GUARD_512_BASELINE={args.g35_guard_512_baseline} "
+                  f"SPARKINFER_G35_GUARD_4K_BASELINE={args.g35_guard_4k_baseline} "
+                  f"SPARKINFER_P35_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
+                  f"SPARKINFER_P35_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
+                  f"SPARKINFER_P35_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
+                  f"SPARKINFER_P36_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
+                  f"SPARKINFER_P36_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
+                  f"SPARKINFER_P36_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
+                  f"SPARKINFER_P36_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
+                  f"SPARKINFER_P36_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
+                  f"MODELS_DIR=/workspace/models36 QWYTHOS_MODELS_DIR=/workspace/models35 "
+                  f"PRIMARY36_MODELS_DIR=/workspace/models36 "
                   f"LLAMACPP_DIR={LLAMACPP_DIR} "
-                  f"bench/scripts/evaluate_triple.sh --ref {args.ref} "
+                  f"bench/scripts/evaluate_bidir.sh --ref {args.ref} "
                   f"--ceiling {args.ceiling}")
-        elif args.dual:
-            # Dual-model: score Qwen3.6 (primary) + guard Qwen3-30B (no-regression). The existing
-            # --guard-*-baseline are the Qwen3-30B guard (G_*); --p-* carry the Qwen3.6 scored target.
-            if args.polaris:
-                # Polaris: run judge.py which wraps evaluate_dual.sh and produces an unsigned
-                # attestation (POLARIS_ATTESTATION) alongside the normal RESULT_JSON.
-                # Pin eval/polaris/ to origin/main — same trust model as bench/scripts.
-                ev = (f"cd /root/sparkinfer && git fetch -q origin main && "
-                      f"git checkout -q origin/main -- bench/scripts eval/polaris/ && "
-                      f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
-                      f"SPARKINFER_EVAL_MODE={args.eval_mode} "
-                      f"SPARKINFER_G_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
-                      f"SPARKINFER_G_GUARD_512_BASELINE={args.guard_512_baseline} "
-                      f"SPARKINFER_G_GUARD_4K_BASELINE={args.guard_4k_baseline} "
-                      f"SPARKINFER_G_GUARD_16K_BASELINE={args.guard_16k_baseline} "
-                      f"SPARKINFER_G_GUARD_32K_BASELINE={args.guard_32k_baseline} "
-                      f"SPARKINFER_P_GUARD_128_BASELINE={args.p_guard_128_baseline} "
-                      f"SPARKINFER_P_GUARD_512_BASELINE={args.p_guard_512_baseline} "
-                      f"SPARKINFER_P_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
-                      f"SPARKINFER_P_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
-                      f"SPARKINFER_P_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
-                      f"SPARKINFER_P_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
-                      f"SPARKINFER_P_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
-                      f"SPARKINFER_P_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
-                      f"SPARKINFER_P_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
-                      f"SPARKINFER_P_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
-                      f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
-                      f"python3 eval/polaris/judge.py --ref {args.ref} "
-                      f"--ceiling {args.ceiling} --script bench/scripts/evaluate_dual.sh "
-                      f"--model-file /workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf "
-                      f"--guard-model-file /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf "
-                      f"--build-dir /root/sparkinfer/build/runtime")
-            else:
-                ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
-                      f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
-                      f"SPARKINFER_EVAL_MODE={args.eval_mode} "
-                      f"SPARKINFER_G_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
-                      f"SPARKINFER_G_GUARD_512_BASELINE={args.guard_512_baseline} "
-                      f"SPARKINFER_G_GUARD_4K_BASELINE={args.guard_4k_baseline} "
-                      f"SPARKINFER_G_GUARD_16K_BASELINE={args.guard_16k_baseline} "
-                      f"SPARKINFER_G_GUARD_32K_BASELINE={args.guard_32k_baseline} "
-                      f"SPARKINFER_P_GUARD_128_BASELINE={args.p_guard_128_baseline} "
-                      f"SPARKINFER_P_GUARD_512_BASELINE={args.p_guard_512_baseline} "
-                      f"SPARKINFER_P_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
-                      f"SPARKINFER_P_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
-                      f"SPARKINFER_P_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
-                      f"SPARKINFER_P_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
-                      f"SPARKINFER_P_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
-                      f"SPARKINFER_P_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
-                      f"SPARKINFER_P_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
-                      f"SPARKINFER_P_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
-                      f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
-                      f"bench/scripts/evaluate_dual.sh --ref {args.ref} "
-                      f"--ceiling {args.ceiling}")
         else:
             ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
                   f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} SPARKINFER_DIFFICULTY_BOOST=1 "


### PR DESCRIPTION
## Summary
- Replace triple/dual Qwen3-30B guards with `evaluate_bidir.sh`.
- Score both optimization directions: Qwen3.5 @ 128/512/4k, Qwen3.6 @ five contexts.

Commit: `7cca2da5131c83516de1d6bb64d14261e4d80e34`

Replaces closed #313.

## Test plan
- [ ] CI guard passes


Made with [Cursor](https://cursor.com)