### PR TITLE
perf: GDN H=4096 + dense FFN fuse + hd256 32k combine (rebased)

### DIFF
--- a/bench/scripts/bisect_qwen36_acc.sh
+++ b/bench/scripts/bisect_qwen36_acc.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Quick Qwen3.6 accuracy bisect: compare teacher-forced argmax top-1 vs a reference dump.
+# Usage: bisect_qwen36_acc.sh <ref_score.txt> <label> [env exports...]
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$HERE/_common.sh"
+
+REF="${1:?ref score dump}"; LABEL="${2:?label}"; shift 2
+GGUF="${GGUF:-/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
+ARCH="$(detect_arch)"
+resolve_runner "$ARCH"
+ensure_tokenizer
+
+SEED="${SPARKINFER_EVAL_SEED:-fixed}"
+IDS_FILE="/tmp/bisect_ids.txt"
+python3 "$HERE/gen_eval_prompt.py" "$SEED" "$MODELS_DIR/tokenizer.json" \
+  "$HERE/eval_corpus.txt" "$HERE/eval_text.txt" > "$IDS_FILE"
+IDS="$(cat "$IDS_FILE")"
+NT=$(echo "$IDS" | wc -w)
+
+OUT="/tmp/bisect_${LABEL}.txt"
+env "$@" si_run qwen3_gguf_score "$GGUF" 128 $IDS > "$OUT"
+
+python3 - "$REF" "$OUT" "$LABEL" <<'PY'
+import re, sys
+ref_path, cand_path, label = sys.argv[1:4]
+
+def argmatch(path):
+    for line in open(path):
+        m = re.search(r"ARGMATCH (\d+)/(\d+)", line)
+        if m:
+            return int(m.group(1)), int(m.group(2))
+    tops = []
+    for line in open(path):
+        m = re.match(r"S i=\d+ tgt=(\d+) am=(\d+)", line)
+        if m:
+            tops.append(int(m.group(1)) == int(m.group(2)))
+    if tops:
+        return sum(tops), len(tops)
+    return 0, 0
+
+rm, rn = argmatch(ref_path)
+cm, cn = argmatch(cand_path)
+n = min(rn, cn)
+if n == 0:
+    print(f"{label}: ERROR no positions parsed"); sys.exit(1)
+# per-position agreement with reference argmax (not tgt)
+ref_am = []
+for line in open(ref_path):
+    m = re.match(r"S i=\d+ tgt=\d+ am=(\d+)", line)
+    if m: ref_am.append(int(m.group(1)))
+cand_am = []
+for line in open(cand_path):
+    m = re.match(r"S i=\d+ tgt=\d+ am=(\d+)", line)
+    if m: cand_am.append(int(m.group(1)))
+match = sum(1 for a, b in zip(ref_am, cand_am) if a == b)
+print(f"{label}: argmax match {match}/{len(ref_am)} ({100*match/max(1,len(ref_am)):.1f}%) vs reference")
+PY

--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -298,6 +298,8 @@ template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, false>(const _
 template __global__ void fa_split_gqa_kernel<256, 8, FA_GQA_TILE, true>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, 8>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
+template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, 16>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/attention.h"
@@ -504,6 +506,30 @@ static inline void fa_launch_combine_dispatch(
     else                      fa_launch_combine<FA_COMBINE_NW>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
 }
 
+// hd256 combine: same NW-adaptive dispatch as hd128, scaling warps with n_splits
+// so the per-warp serial split-folding stays bounded. NW=16 at n_splits>=128
+// keeps each warp at ~8-16 splits (matching hd128 sweet spot).
+template <int NW>
+static inline void fa_launch_combine_hd256(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
+    int num_seqs, cudaStream_t stream
+) {
+    dim3 g(num_q_heads * FA_COMBINE_DG, num_seqs);
+    fa_combine_kernel<256, FA_COMBINE_DG, NW><<<g, NW * 32, 0, stream>>>(
+        part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8);
+}
+
+static inline void fa_launch_combine_dispatch_hd256(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
+    int num_seqs, cudaStream_t stream
+) {
+    if (n_splits >= 128)      fa_launch_combine_hd256<16>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else if (n_splits >= 64)  fa_launch_combine_hd256<8>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else                      fa_launch_combine_hd256<FA_COMBINE_NW>(part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8, num_seqs, stream);
+}
+
 void launch_flash_decode_split(
     const void* q, const void* k_pool, const void* v_pool,
     const int* block_table, const int* seq_lens, void* out,
@@ -561,9 +587,9 @@ void launch_flash_decode_split(
                 part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                 reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale), int8_kv);
         }
-        fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
-            part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
-            reinterpret_cast<fa_block_q8_1*>(out_q8));
+        fa_launch_combine_dispatch_hd256(part_m, part_l, part_acc,
+            reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
+            reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
         (void)seqlen;
         return;
     }

--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -541,7 +541,6 @@ void launch_flash_decode_split(
     // Qwen3.6 full-attention layers run head_dim=256 (bf16 KV). Use the GQA-8 shared-KV tile
     // path (same 8:1 grouping as Qwen3 hd=128) — cuts KV global reads ~8x vs one-warp-per-q-head.
     if (head_dim == 256) {
-        dim3 g2(num_q_heads * FA_COMBINE_DG, num_seqs);
         // int8-KV tensor-core path for hd256 (long context): same gating as the hd128 MMA path
         // (block_size==16 so each warp maps to one physical block, chunk >= 2 blocks to fill the GPU).
         static int famma256 = -1;
@@ -560,9 +559,9 @@ void launch_flash_decode_split(
                     reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
                     part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                     reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
-                fa_combine_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW><<<g2, FA_COMBINE_NW * 32, 0, stream>>>(
-                    part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
-                    reinterpret_cast<fa_block_q8_1*>(out_q8));
+                fa_launch_combine_dispatch_hd256(part_m, part_l, part_acc,
+                    reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
+                    reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
                 (void)seqlen;
                 return;
             }

--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -606,5 +606,86 @@ void launch_qwen36_gated_norm_q8(const void* x_bf16, const void* z_bf16,
 }
 #endif
 
+// ---- fused conv_split + l2_norm (per-head) ----------------------------------
+// Replaces conv_split_kernel + 2× l2_norm_heads_kernel with a single per-head
+// kernel. One block per head (64 blocks = 16q + 16k + 32v) with head_dim
+// threads. Each thread processes one dimension: 1D depthwise conv, SiLU,
+// then l2_norm (q/k heads only). Eliminates two kernel launches and the
+// intermediate non-normalized q/k global writes. SKIP_FUSED_CONV_L2NORM=1
+// restores the split path for A/B.
+__global__ void conv_split_l2norm_fused_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ conv_w,
+    __nv_bfloat16* __restrict__ conv_state,
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ v,
+    int q_heads, int v_heads, int head_dim, int conv_kernel, float eps)
+{
+    const int h  = blockIdx.x;
+    const int t  = threadIdx.x;
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int qkv_dim = 2 * q_dim + v_dim;
+
+    bool do_norm = false;
+    int d;
+    __nv_bfloat16* out;
+    if (h < q_heads) {
+        d = h * head_dim + t;  out = q + d;           do_norm = true;
+    } else if (h < 2 * q_heads) {
+        d = q_dim + (h - q_heads) * head_dim + t;  out = k + d - q_dim;  do_norm = true;
+    } else {
+        d = 2 * q_dim + (h - 2 * q_heads) * head_dim + t;  out = v + d - 2 * q_dim;
+    }
+    if (d >= qkv_dim) return;
+
+    // 1D conv + SiLU
+    float y = 0.f;
+    for (int p = 0; p < conv_kernel - 1; p++)
+        y += q36_to_f(conv_state[(size_t)p * qkv_dim + d]) *
+             q36_to_f(conv_w[(size_t)d * conv_kernel + p]);
+    y += q36_to_f(qkv[d]) * q36_to_f(conv_w[(size_t)d * conv_kernel + (conv_kernel - 1)]);
+
+    for (int p = 0; p < conv_kernel - 2; p++)
+        conv_state[(size_t)p * qkv_dim + d] = conv_state[(size_t)(p + 1) * qkv_dim + d];
+    if (conv_kernel > 1)
+        conv_state[(size_t)(conv_kernel - 2) * qkv_dim + d] = qkv[d];
+
+    const float oy = q36_silu(y);
+
+    if (do_norm) {
+        const float ss = q36_wsum(oy * oy);
+        __shared__ float sw[32];
+        if ((t & 31) == 0) sw[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = (t < (head_dim + 31) / 32) ? sw[t] : 0.f;
+            vv = q36_wsum(vv);
+            if (t == 0) sw[0] = rsqrtf(vv + eps);
+        }
+        __syncthreads();
+        out[0] = __float2bfloat16(oy * sw[0]);
+    } else {
+        out[0] = __float2bfloat16(oy);
+    }
+}
+
+void launch_qwen36_conv_split_l2norm_fused(
+    const void* qkv_bf16, const void* conv_w_bf16,
+    void* conv_state_bf16, void* q_bf16, void* k_bf16,
+    void* v_bf16, int q_heads, int v_heads, int head_dim,
+    int conv_kernel, float eps, cudaStream_t stream)
+{
+    conv_split_l2norm_fused_kernel<<<2 * q_heads + v_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(conv_w_bf16),
+        reinterpret_cast<__nv_bfloat16*>(conv_state_bf16),
+        reinterpret_cast<__nv_bfloat16*>(q_bf16),
+        reinterpret_cast<__nv_bfloat16*>(k_bf16),
+        reinterpret_cast<__nv_bfloat16*>(v_bf16),
+        q_heads, v_heads, head_dim, conv_kernel, eps);
+}
+
 } // namespace kernels
 } // namespace sparkinfer

--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -522,19 +522,51 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
     // run — the static flag guarantees that. Requires head_dim a multiple of 32 (128 -> NROW=4).
     static int fast = -1;
     if (fast < 0) { const char* e = getenv("SPARKINFER_GDN_FAST"); fast = (e && e[0] == '0') ? 0 : 1; }
-    if (fast && head_dim == 128) {                            // Qwen3.6 linear_head_dim; other dims -> naive
-        constexpr int COLS = 8, HD = 128;                     // 8 warps (columns)/block -> 256 threads
-        dim3 grid(v_heads, (HD + COLS - 1) / COLS);
-        gdn_ar_fast_kernel<COLS, HD><<<grid, COLS * 32, 0, stream>>>(
-            reinterpret_cast<const __nv_bfloat16*>(q_bf16),
-            reinterpret_cast<const __nv_bfloat16*>(k_bf16),
-            reinterpret_cast<const __nv_bfloat16*>(v_bf16),
-            reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
-            reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
-            reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
-            reinterpret_cast<const __nv_bfloat16*>(a_bf16),
-            state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
-            q_heads, v_heads);
+    if (fast && head_dim == 128) {                            // Qwen3.6/Qwythos linear_head_dim=128
+        static int cols = -1;
+        if (cols < 0) {
+            const char* e = getenv("SPARKINFER_GDN_FAST_COLS");
+            if (e) cols = atoi(e);
+            else cols = (v_heads >= 32) ? 4 : 8;              // 32 v-heads -> 1024 blocks @ COLS=4
+            if (!(cols == 4 || cols == 8 || cols == 16)) cols = 8;
+        }
+        constexpr int HD = 128;
+        const int c = cols;
+        dim3 grid(v_heads, (HD + c - 1) / c);
+        if (c == 4) {
+            gdn_ar_fast_kernel<4, HD><<<grid, 4 * 32, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(k_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(v_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(a_bf16),
+                state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
+                q_heads, v_heads);
+        } else if (c == 16) {
+            gdn_ar_fast_kernel<16, HD><<<grid, 16 * 32, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(k_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(v_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(a_bf16),
+                state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
+                q_heads, v_heads);
+        } else {
+            gdn_ar_fast_kernel<8, HD><<<grid, 8 * 32, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(k_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(v_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
+                reinterpret_cast<const __nv_bfloat16*>(a_bf16),
+                state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
+                q_heads, v_heads);
+        }
         return;
     }
     static int warpgrid = -1;

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -774,6 +774,39 @@ static bool gemv_mmvq() {
 // occupancy lever main already uses for the f32 router GEMV (gemv_f32_sk_kernel), extended to the
 // bf16 projections. Only the fp32 reduction order changes, so it is self-consistent with the
 // one-warp path (no top-1 regression). SPARKINFER_GEMV_SK=0 restores the one-warp kernel. K % 8 == 0.
+
+// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). One warp does the
+// dot product and lane 0 applies sigmoid, eliminating the separate 1-thread
+// sigmoid_scalar_kernel launch. SPARKINFER_GEMV_SIGMOID=0 restores split path.
+__global__ void gemv_sigmoid_kernel(const __nv_bfloat16* __restrict__ x,
+                                     const __nv_bfloat16* __restrict__ W,
+                                     float* __restrict__ y, int K) {
+    extern __shared__ float s_x[];
+    for (int i = threadIdx.x; i < K; i += blockDim.x) s_x[i] = __bfloat162float(x[i]);
+    __syncthreads();
+    float acc = 0.f;
+    const uint4* row4 = reinterpret_cast<const uint4*>(W);
+    const int n4 = K / 8;
+    for (int i = threadIdx.x; i < n4; i += 32) {
+        uint4 v = row4[i];
+        const __nv_bfloat162* h2 = reinterpret_cast<const __nv_bfloat162*>(&v);
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            float2 f = __bfloat1622float2(h2[j]);
+            acc += f.x * s_x[i*8 + 2*j] + f.y * s_x[i*8 + 2*j + 1];
+        }
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (threadIdx.x == 0) y[0] = 1.f / (1.f + __expf(-acc));
+}
+
+void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K, cudaStream_t stream) {
+    gemv_sigmoid_kernel<<<1, 32, (size_t)K * sizeof(float), stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(W), y, K);
+}
+
 static int gemv_bf16_splitk() {
     static int v = -1;
     if (v < 0) { const char* e = getenv("SPARKINFER_GEMV_SK"); v = (e && e[0] == '0') ? 0 : 1; }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -775,25 +775,24 @@ static bool gemv_mmvq() {
 // bf16 projections. Only the fp32 reduction order changes, so it is self-consistent with the
 // one-warp path (no top-1 regression). SPARKINFER_GEMV_SK=0 restores the one-warp kernel. K % 8 == 0.
 
-// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). One warp does the
-// dot product and lane 0 applies sigmoid, eliminating the separate 1-thread
-// sigmoid_scalar_kernel launch. SPARKINFER_GEMV_SIGMOID=0 restores split path.
+// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). One warp dots
+// x @ W directly from L2 (no smem staging — 1 row doesn't repay it) and
+// lane 0 applies sigmoid, eliminating the separate sigmoid_scalar_kernel.
 __global__ void gemv_sigmoid_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ W,
                                      float* __restrict__ y, int K) {
-    extern __shared__ float s_x[];
-    for (int i = threadIdx.x; i < K; i += blockDim.x) s_x[i] = __bfloat162float(x[i]);
-    __syncthreads();
     float acc = 0.f;
+    const uint4* x4 = reinterpret_cast<const uint4*>(x);
     const uint4* row4 = reinterpret_cast<const uint4*>(W);
     const int n4 = K / 8;
     for (int i = threadIdx.x; i < n4; i += 32) {
-        uint4 v = row4[i];
-        const __nv_bfloat162* h2 = reinterpret_cast<const __nv_bfloat162*>(&v);
+        uint4 xv = x4[i], wv = row4[i];
+        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
         #pragma unroll
         for (int j = 0; j < 4; j++) {
-            float2 f = __bfloat1622float2(h2[j]);
-            acc += f.x * s_x[i*8 + 2*j] + f.y * s_x[i*8 + 2*j + 1];
+            float2 wf = __bfloat1622float2(wh[j]), xf = __bfloat1622float2(xh[j]);
+            acc += wf.x * xf.x + wf.y * xf.y;
         }
     }
     #pragma unroll
@@ -802,7 +801,7 @@ __global__ void gemv_sigmoid_kernel(const __nv_bfloat16* __restrict__ x,
 }
 
 void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K, cudaStream_t stream) {
-    gemv_sigmoid_kernel<<<1, 32, (size_t)K * sizeof(float), stream>>>(
+    gemv_sigmoid_kernel<<<1, 32, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x),
         reinterpret_cast<const __nv_bfloat16*>(W), y, K);
 }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1165,7 +1165,7 @@ void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, i
     static int lm_pack2 = -1;
     if (lm_pack2 < 0) {
         const char* e = getenv("SPARKINFER_LM_PACK2");
-        lm_pack2 = (e && e[0] == '0') ? 0 : 1;
+        lm_pack2 = (e && e[0] == '1') ? 1 : 0;   // opt-in: pack2 LM head needs parity proof on each model
     }
     if (K == 4096 && lm_pack2) {
         gemv_q6k_dp4a_kfixed_pack2_kernel<16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -621,6 +621,94 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16>(const si_b
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
 
+// pack2: two output rows per block (4 warps/row). Halves the grid for large projections
+// (GDN attn_qkv N=6144, full-attn Q N=8192) without changing the dp4a math.
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q4k_kfixed_pack2_kernel(const si_block_q8_1* __restrict__ vy,
+                                                const unsigned char* __restrict__ W,
+                                                OutT* __restrict__ y, int N) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    if (row >= N) return;
+    const int tid4 = group_warp * WS + lane;
+    const int kbx0 = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const si_block_q4_K* x_row = (const si_block_q4_K*)(W + (size_t)row * NSUPER * 144);
+    float tmp = 0.f;
+    #pragma unroll
+    for (int kbx = kbx0; kbx < NSUPER; kbx += 8)
+        tmp += si_vec_dot_q4_K(x_row + kbx, vy + (size_t)kbx * 8, kqs);
+    __shared__ float tmp_shared[2][NW - 1][WS];
+    if (group_warp > 0) tmp_shared[group][group_warp - 1][lane] = tmp;
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += tmp_shared[group][l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+
+// Fused GDN input projections: qkv[N_qkv,K] and z[N_z,K] share one Q8_1 activation.
+// One block does pack2 rows for qkv (warps 0-3) and pack2 rows for z (warps 4-7), keeping
+// vy hot in L2 across both. Grid = max(ceil(N_qkv/2), ceil(N_z/2)).
+template <int NSUPER>
+__global__ void si_mmvq_gdn_qkv_z_pack2_kernel(const si_block_q8_1* __restrict__ vy,
+                                               const unsigned char* __restrict__ qkv_w,
+                                               const unsigned char* __restrict__ z_w,
+                                               __nv_bfloat16* __restrict__ qkv_out,
+                                               __nv_bfloat16* __restrict__ z_out,
+                                               int n_qkv, int n_z) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int half = warp >> 2, sub = warp & 3;
+    const int row = blockIdx.x * 2 + half;
+    const int tid4 = sub * WS + lane;
+    const int kbx0 = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    float tmp = 0.f;
+    if (warp < 4) {
+        if (row >= n_qkv) return;
+        const si_block_q4_K* x_row = (const si_block_q4_K*)(qkv_w + (size_t)row * NSUPER * 144);
+        #pragma unroll
+        for (int kbx = kbx0; kbx < NSUPER; kbx += 8)
+            tmp += si_vec_dot_q4_K(x_row + kbx, vy + (size_t)kbx * 8, kqs);
+        __shared__ float tq[2][NW - 1][WS];
+        if (sub > 0) tq[half][sub - 1][lane] = tmp;
+        __syncthreads();
+        if (sub > 0) return;
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tmp += tq[half][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+        if (lane == 0) gemv_write(qkv_out + row, tmp);
+    } else {
+        if (row >= n_z) return;
+        const si_block_q4_K* x_row = (const si_block_q4_K*)(z_w + (size_t)row * NSUPER * 144);
+        #pragma unroll
+        for (int kbx = kbx0; kbx < NSUPER; kbx += 8)
+            tmp += si_vec_dot_q4_K(x_row + kbx, vy + (size_t)kbx * 8, kqs);
+        __shared__ float tz[2][NW - 1][WS];
+        if (sub > 0) tz[half][sub - 1][lane] = tmp;
+        __syncthreads();
+        if (sub > 0) return;
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tmp += tz[half][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+        if (lane == 0) gemv_write(z_out + row, tmp);
+    }
+}
+
+template __global__ void si_mmvq_gdn_qkv_z_pack2_kernel<16>(const si_block_q8_1*, const unsigned char*,
+                                                          const unsigned char*, __nv_bfloat16*,
+                                                          __nv_bfloat16*, int, int);
+
 // ===== faithful llama Q6_K mmvq for the fp32-path GEMVs (attn-V upgrades + LM head) =====
 // Same 4-warp-per-row structure as the Q4_K mmvq, with vec_dot_q6_K_q8_1 (coalesced
 // ql/qh int loads + __vsubss4 reconstruct + dp4a). Mirrors the #65 MoE-down dot.
@@ -750,6 +838,36 @@ __global__ void gemv_q6k_dp4a_kfixed_kernel(const si_block_q8_1* __restrict__ vy
 }
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 8, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 16, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
+template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 16, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+
+// pack2 LM head: two vocab rows per block (K=4096, NSUPER=16).
+template <int NSUPER>
+__global__ void gemv_q6k_dp4a_kfixed_pack2_kernel(const si_block_q8_1* __restrict__ vy,
+                                                   const unsigned char* __restrict__ W,
+                                                   float* __restrict__ y, int N) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    if (row >= N) return;
+    const unsigned char* x_row = W + (size_t)row * NSUPER * 210;
+    const int tid4 = group_warp * WS + lane;
+    const int kbx0 = tid4 >> 4;
+    const int iqs = 2 * (tid4 & 15);
+    float acc = 0.f;
+    for (int kbx = kbx0; kbx < NSUPER; kbx += 8)
+        acc += si_vec_dot_q6_K(x_row + (size_t)kbx * 210, vy + (size_t)kbx * 8, iqs);
+    __shared__ float sg[2][NW - 1][WS];
+    if (group_warp > 0) sg[group][group_warp - 1][lane] = acc;
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) acc += sg[group][l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) y[row] = acc;
+}
+template __global__ void gemv_q6k_dp4a_kfixed_pack2_kernel<16>(const si_block_q8_1*, const unsigned char*, float*, int);
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/gemm.h"
@@ -975,16 +1093,37 @@ void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cuda
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
     __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
-    if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
-    else if (K == 4096) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
-    else                si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
+    static int pack2 = -1;
+    if (pack2 < 0) { const char* e = getenv("SPARKINFER_MMVQ_PACK2"); pack2 = (e && e[0] == '0') ? 0 : 1; }
+    if (pack2 && K == 4096 && N >= 2048)
+        si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 4096)      si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else                       si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
-    if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
-    else if (K == 4096) si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
-    else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
+    static int pack2 = -1;
+    if (pack2 < 0) { const char* e = getenv("SPARKINFER_MMVQ_PACK2"); pack2 = (e && e[0] == '0') ? 0 : 1; }
+    if (pack2 && K == 4096 && N >= 2048)
+        si_mmvq_q4k_kfixed_pack2_kernel<float, 16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, y, N);
+    else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    else if (K == 4096)      si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    else                       si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
+}
+void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void* z_w,
+                                 void* qkv_out, void* z_out, int n_qkv, int n_z,
+                                 cudaStream_t stream) {
+    const int grid = (n_qkv + 1) / 2 > (n_z + 1) / 2 ? (n_qkv + 1) / 2 : (n_z + 1) / 2;
+    if (grid <= 0) return;
+    si_mmvq_gdn_qkv_z_pack2_kernel<16><<<grid, 8 * 32, 0, stream>>>(
+        reinterpret_cast<const si_block_q8_1*>(q81),
+        reinterpret_cast<const unsigned char*>(qkv_w),
+        reinterpret_cast<const unsigned char*>(z_w),
+        reinterpret_cast<__nv_bfloat16*>(qkv_out),
+        reinterpret_cast<__nv_bfloat16*>(z_out),
+        n_qkv, n_z);
 }
 void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
@@ -1023,7 +1162,22 @@ void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, i
         wpb = e ? atoi(e) : 16;
         if (!(wpb == 8 || wpb == 16 || wpb == 32)) wpb = 16;
     }
-    if (K == 2048 && wpb == 16) {
+    static int lm_pack2 = -1;
+    if (lm_pack2 < 0) {
+        const char* e = getenv("SPARKINFER_LM_PACK2");
+        lm_pack2 = (e && e[0] == '0') ? 0 : 1;
+    }
+    if (K == 4096 && lm_pack2) {
+        gemv_q6k_dp4a_kfixed_pack2_kernel<16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N);
+        return;
+    }
+    if (K == 4096 && wpb == 16) {
+        dim3 grid((N + 15) / 16);
+        gemv_q6k_dp4a_kfixed_kernel<float, 16, 16><<<grid, 16 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N);
+        return;
+    } else if (K == 2048 && wpb == 16) {
         dim3 grid((N + 15) / 16);
         gemv_q6k_dp4a_kfixed_kernel<float, 16, 8><<<grid, 16 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N);

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -840,29 +840,21 @@ template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 8, 8>(const si_block
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 16, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 16, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
 
-// pack2 LM head: two vocab rows per block (K=4096, NSUPER=16).
+// pack2 LM head: two vocab rows per block (K=4096, NSUPER=16). Matches the default
+// gemv_q6k_dp4a_kfixed_kernel math (one warp/row, lane walks all superblocks) — only
+// the grid is halved by packing two rows per CTA.
 template <int NSUPER>
 __global__ void gemv_q6k_dp4a_kfixed_pack2_kernel(const si_block_q8_1* __restrict__ vy,
                                                    const unsigned char* __restrict__ W,
                                                    float* __restrict__ y, int N) {
-    constexpr int NW = 4, WS = 32;
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
-    const int group = warp >> 2, group_warp = warp & 3;
-    const int row = blockIdx.x * 2 + group;
+    const int row = (int)blockIdx.x * 2 + warp;
     if (row >= N) return;
     const unsigned char* x_row = W + (size_t)row * NSUPER * 210;
-    const int tid4 = group_warp * WS + lane;
-    const int kbx0 = tid4 >> 4;
-    const int iqs = 2 * (tid4 & 15);
     float acc = 0.f;
-    for (int kbx = kbx0; kbx < NSUPER; kbx += 8)
-        acc += si_vec_dot_q6_K(x_row + (size_t)kbx * 210, vy + (size_t)kbx * 8, iqs);
-    __shared__ float sg[2][NW - 1][WS];
-    if (group_warp > 0) sg[group][group_warp - 1][lane] = acc;
-    __syncthreads();
-    if (group_warp > 0) return;
     #pragma unroll
-    for (int l = 0; l < NW - 1; l++) acc += sg[group][l][lane];
+    for (int kbx = 0; kbx < NSUPER; kbx++)
+        acc += si_vec_dot_q6_K(x_row + (size_t)kbx * 210, vy + (size_t)kbx * 8, lane);
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
     if (lane == 0) y[row] = acc;
@@ -872,6 +864,7 @@ template __global__ void gemv_q6k_dp4a_kfixed_pack2_kernel<16>(const si_block_q8
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/gemm.h"
 #include <cstdlib>
+void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32, cudaStream_t stream);
 
 // int8 dp4a for Q4_K GEMVs (faithful to llama.cpp's mul_mat_vec_q). Default ON —
 // ~27% faster decode than the fp32-dequant path and still clears the accuracy gate
@@ -892,37 +885,6 @@ static bool gemv_mmvq() {
 // occupancy lever main already uses for the f32 router GEMV (gemv_f32_sk_kernel), extended to the
 // bf16 projections. Only the fp32 reduction order changes, so it is self-consistent with the
 // one-warp path (no top-1 regression). SPARKINFER_GEMV_SK=0 restores the one-warp kernel. K % 8 == 0.
-
-// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). One warp dots
-// x @ W directly from L2 (no smem staging — 1 row doesn't repay it) and
-// lane 0 applies sigmoid, eliminating the separate sigmoid_scalar_kernel.
-__global__ void gemv_sigmoid_kernel(const __nv_bfloat16* __restrict__ x,
-                                     const __nv_bfloat16* __restrict__ W,
-                                     float* __restrict__ y, int K) {
-    float acc = 0.f;
-    const uint4* x4 = reinterpret_cast<const uint4*>(x);
-    const uint4* row4 = reinterpret_cast<const uint4*>(W);
-    const int n4 = K / 8;
-    for (int i = threadIdx.x; i < n4; i += 32) {
-        uint4 xv = x4[i], wv = row4[i];
-        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
-        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
-        #pragma unroll
-        for (int j = 0; j < 4; j++) {
-            float2 wf = __bfloat1622float2(wh[j]), xf = __bfloat1622float2(xh[j]);
-            acc += wf.x * xf.x + wf.y * xf.y;
-        }
-    }
-    #pragma unroll
-    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
-    if (threadIdx.x == 0) y[0] = 1.f / (1.f + __expf(-acc));
-}
-
-void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K, cudaStream_t stream) {
-    gemv_sigmoid_kernel<<<1, 32, 0, stream>>>(
-        reinterpret_cast<const __nv_bfloat16*>(x),
-        reinterpret_cast<const __nv_bfloat16*>(W), y, K);
-}
 
 static int gemv_bf16_splitk() {
     static int v = -1;
@@ -953,6 +915,17 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K, cudaStream
     gemv_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W),
         reinterpret_cast<__nv_bfloat16*>(y), N, K);
+}
+
+// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). Delegates to the
+// faithful split-k launch_gemv + bf16-rounded sigmoid_scalar path — the single-warp
+// uint4 kernel diverged ~5pp on Qwen3.6 vs the split-k GEMV it was meant to replace.
+void launch_gemv_sigmoid(const void* x, const void* W, void* scratch_bf16, float* y, int K,
+                         cudaStream_t stream) {
+    launch_gemv(x, W, scratch_bf16, 1, K, stream);
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+    launch_qwen36_sigmoid_scalar(scratch_bf16, y, stream);
+#endif
 }
 
 // split-K occupancy for the f32-output bf16 GEMV. Default ON: at decode this path serves the
@@ -1165,10 +1138,10 @@ void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, i
     static int lm_pack2 = -1;
     if (lm_pack2 < 0) {
         const char* e = getenv("SPARKINFER_LM_PACK2");
-        lm_pack2 = (e && e[0] == '1') ? 1 : 0;   // opt-in: pack2 LM head needs parity proof on each model
+        lm_pack2 = (e && e[0] == '1') ? 1 : 0;   // opt-in: correct but slower than WPB=16 @ huge N
     }
     if (K == 4096 && lm_pack2) {
-        gemv_q6k_dp4a_kfixed_pack2_kernel<16><<<(N + 1) / 2, 8 * 32, 0, stream>>>(
+        gemv_q6k_dp4a_kfixed_pack2_kernel<16><<<(N + 1) / 2, 2 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N);
         return;
     }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -655,8 +655,8 @@ template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<__nv_bfloat16, 16>(cons
 template __global__ void si_mmvq_q4k_kfixed_pack2_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
 
 // Fused GDN input projections: qkv[N_qkv,K] and z[N_z,K] share one Q8_1 activation.
-// One block does pack2 rows for qkv (warps 0-3) and pack2 rows for z (warps 4-7), keeping
-// vy hot in L2 across both. Grid = max(ceil(N_qkv/2), ceil(N_z/2)).
+// One block per row index: warps 0-3 -> qkv[row], warps 4-7 -> z[row], keeping vy hot
+// in L2 across both when row < min(n_qkv, n_z). Grid = max(n_qkv, n_z).
 template <int NSUPER>
 __global__ void si_mmvq_gdn_qkv_z_pack2_kernel(const si_block_q8_1* __restrict__ vy,
                                                const unsigned char* __restrict__ qkv_w,
@@ -666,8 +666,8 @@ __global__ void si_mmvq_gdn_qkv_z_pack2_kernel(const si_block_q8_1* __restrict__
                                                int n_qkv, int n_z) {
     constexpr int NW = 4, WS = 32;
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
-    const int half = warp >> 2, sub = warp & 3;
-    const int row = blockIdx.x * 2 + half;
+    const int sub = warp & 3;
+    const int row = blockIdx.x;
     const int tid4 = sub * WS + lane;
     const int kbx0 = tid4 >> 4;
     const int kqs = 2 * (tid4 & 15);
@@ -678,12 +678,12 @@ __global__ void si_mmvq_gdn_qkv_z_pack2_kernel(const si_block_q8_1* __restrict__
         #pragma unroll
         for (int kbx = kbx0; kbx < NSUPER; kbx += 8)
             tmp += si_vec_dot_q4_K(x_row + kbx, vy + (size_t)kbx * 8, kqs);
-        __shared__ float tq[2][NW - 1][WS];
-        if (sub > 0) tq[half][sub - 1][lane] = tmp;
+        __shared__ float tq[NW - 1][WS];
+        if (sub > 0) tq[sub - 1][lane] = tmp;
         __syncthreads();
         if (sub > 0) return;
         #pragma unroll
-        for (int l = 0; l < NW - 1; l++) tmp += tq[half][l][lane];
+        for (int l = 0; l < NW - 1; l++) tmp += tq[l][lane];
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
         if (lane == 0) gemv_write(qkv_out + row, tmp);
@@ -693,18 +693,21 @@ __global__ void si_mmvq_gdn_qkv_z_pack2_kernel(const si_block_q8_1* __restrict__
         #pragma unroll
         for (int kbx = kbx0; kbx < NSUPER; kbx += 8)
             tmp += si_vec_dot_q4_K(x_row + kbx, vy + (size_t)kbx * 8, kqs);
-        __shared__ float tz[2][NW - 1][WS];
-        if (sub > 0) tz[half][sub - 1][lane] = tmp;
+        __shared__ float tz[NW - 1][WS];
+        if (sub > 0) tz[sub - 1][lane] = tmp;
         __syncthreads();
         if (sub > 0) return;
         #pragma unroll
-        for (int l = 0; l < NW - 1; l++) tmp += tz[half][l][lane];
+        for (int l = 0; l < NW - 1; l++) tmp += tz[l][lane];
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
         if (lane == 0) gemv_write(z_out + row, tmp);
     }
 }
 
+template __global__ void si_mmvq_gdn_qkv_z_pack2_kernel<8>(const si_block_q8_1*, const unsigned char*,
+                                                          const unsigned char*, __nv_bfloat16*,
+                                                          __nv_bfloat16*, int, int);
 template __global__ void si_mmvq_gdn_qkv_z_pack2_kernel<16>(const si_block_q8_1*, const unsigned char*,
                                                           const unsigned char*, __nv_bfloat16*,
                                                           __nv_bfloat16*, int, int);
@@ -1086,17 +1089,27 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
     else                       si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
 void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void* z_w,
-                                 void* qkv_out, void* z_out, int n_qkv, int n_z,
+                                 void* qkv_out, void* z_out, int n_qkv, int n_z, int K,
                                  cudaStream_t stream) {
-    const int grid = (n_qkv + 1) / 2 > (n_z + 1) / 2 ? (n_qkv + 1) / 2 : (n_z + 1) / 2;
+    const int grid = n_qkv > n_z ? n_qkv : n_z;
     if (grid <= 0) return;
-    si_mmvq_gdn_qkv_z_pack2_kernel<16><<<grid, 8 * 32, 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81),
-        reinterpret_cast<const unsigned char*>(qkv_w),
-        reinterpret_cast<const unsigned char*>(z_w),
-        reinterpret_cast<__nv_bfloat16*>(qkv_out),
-        reinterpret_cast<__nv_bfloat16*>(z_out),
-        n_qkv, n_z);
+    if (K == 4096) {
+        si_mmvq_gdn_qkv_z_pack2_kernel<16><<<grid, 8 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(qkv_w),
+            reinterpret_cast<const unsigned char*>(z_w),
+            reinterpret_cast<__nv_bfloat16*>(qkv_out),
+            reinterpret_cast<__nv_bfloat16*>(z_out),
+            n_qkv, n_z);
+    } else {
+        si_mmvq_gdn_qkv_z_pack2_kernel<8><<<grid, 8 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(qkv_w),
+            reinterpret_cast<const unsigned char*>(z_w),
+            reinterpret_cast<__nv_bfloat16*>(qkv_out),
+            reinterpret_cast<__nv_bfloat16*>(z_out),
+            n_qkv, n_z);
+    }
 }
 void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -569,7 +569,7 @@ __global__ void shared_gate_up_q8_mmvq_kernel(
     }
 }
 
-template <int H, int F>
+template <int H, int F, bool ACCUM>
 __global__ void shared_down_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
     __nv_bfloat16* __restrict__ out) {
@@ -581,7 +581,10 @@ __global__ void shared_down_q8_mmvq_kernel(
     for (int b = lane; b < nblk; b += 32)
         acc += si_vec_dot_q8_0(dbase + (size_t)b * 34, hq8 + b);
     acc = q4kf_wsum(acc);
-    if (lane == 0) out[h] = __float2bfloat16(acc);
+    if (lane == 0) {
+        if constexpr (ACCUM) acc += __bfloat162float(out[h]);
+        out[h] = __float2bfloat16(acc);
+    }
 }
 
 template <int H, int F, int TOPK>
@@ -1276,7 +1279,7 @@ void launch_shared_expert_q8_mmvq(
     const void* input, const void* input_q8,
     const void* gate_q, const void* up_q, const void* down_q,
     const float* dw, void* output, float* h_scratch, void* h_q8_buf,
-    int hidden, int ffn, cudaStream_t stream) {
+    int hidden, int ffn, cudaStream_t stream, bool accum = false) {
     const si_block_q8_1* vy;
     si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(h_q8_buf);
     if (input_q8) {
@@ -1293,9 +1296,15 @@ void launch_shared_expert_q8_mmvq(
     quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
         h_scratch, qbuf, nqb, 0);
     dim3 dn((hidden + WPB - 1) / WPB);
-    shared_down_q8_mmvq_kernel<2048, 512><<<dn, WPB * 32, 0, stream>>>(
-        qbuf, reinterpret_cast<const unsigned char*>(down_q),
-        reinterpret_cast<__nv_bfloat16*>(output));
+    if (accum) {
+        shared_down_q8_mmvq_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
+            qbuf, reinterpret_cast<const unsigned char*>(down_q),
+            reinterpret_cast<__nv_bfloat16*>(output));
+    } else {
+        shared_down_q8_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
+            qbuf, reinterpret_cast<const unsigned char*>(down_q),
+            reinterpret_cast<__nv_bfloat16*>(output));
+    }
 }
 #endif
 

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -598,13 +598,17 @@ __global__ void gate_up_mmvq2_qwen_kernel(
     const int row = blockIdx.x, ts = row / F, f = row - ts * F, tok = ts / TOPK;
     const int e = expert_ids[ts];
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
-    const int kbx = tid >> 4;
+    const int kbx0 = tid >> 4;
     const int kqs = 2 * (tid & 15);
     const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
     const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 144);
     const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 144);
-    float tg = si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
-    float tu = si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    constexpr int NB = H >> 8;
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = kbx0; kbx < NB; kbx += 8) {
+        tg += si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
+        tu += si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    }
     __shared__ float sg[NW - 1][WS], su[NW - 1][WS];
     if (warp > 0) { sg[warp - 1][lane] = tg; su[warp - 1][lane] = tu; }
     __syncthreads();
@@ -631,13 +635,17 @@ __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     const int ts = row / F, f = row - ts * F, tok = ts / TOPK;
     const int e = expert_ids[ts];
     const int tid4 = group_warp * WS + lane;
-    const int kbx = tid4 >> 4;
+    const int kbx0 = tid4 >> 4;
     const int kqs = 2 * (tid4 & 15);
     const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
     const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 144);
     const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 144);
-    float tg = si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
-    float tu = si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    constexpr int NB = H >> 8;
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = kbx0; kbx < NB; kbx += 8) {
+        tg += si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
+        tu += si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    }
     __shared__ float sg[2][NW - 1][WS], su[2][NW - 1][WS];
     if (group_warp > 0) { sg[group][group_warp - 1][lane] = tg; su[group][group_warp - 1][lane] = tu; }
     __syncthreads();
@@ -647,6 +655,76 @@ __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+}
+
+template <int H, int F, int TOPK>
+__global__ void gate_up_mmvq2_pack4_qwen_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch, int n_rows
+) {
+    si_pdl_lc();
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int row = blockIdx.x * 4 + group;
+    if (row >= n_rows) return;
+    const int ts = row / F, f = row - ts * F, tok = ts / TOPK;
+    const int e = expert_ids[ts];
+    const int tid4 = group_warp * WS + lane;
+    const int kbx0 = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
+    const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 144);
+    const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 144);
+    constexpr int NB = H >> 8;
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = kbx0; kbx < NB; kbx += 8) {
+        tg += si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
+        tu += si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    }
+    __shared__ float sg[4][NW - 1][WS], su[4][NW - 1][WS];
+    if (group_warp > 0) { sg[group][group_warp - 1][lane] = tg; su[group][group_warp - 1][lane] = tu; }
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[group][l][lane]; tu += su[group][l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+}
+
+// Dense hybrid gate/up (Qwythos): same pack2 math as gate_up_mmvq2_pack2_qwen_kernel but
+// without expert_ids indirection (single expert 0 baked into the weight layout).
+template <int H, int F>
+__global__ void dense_gate_up_q4k_pack2_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, float* __restrict__ h_scratch) {
+    si_pdl_lc();
+    constexpr int NW = 4, WS = 32, NB = H >> 8;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int f = blockIdx.x * 2 + group;
+    if (f >= F) return;
+    const int tid4 = group_warp * WS + lane;
+    const int kbx0 = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + (size_t)f * NB * 144);
+    const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + (size_t)f * NB * 144);
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = kbx0; kbx < NB; kbx += 8) {
+        tg += si_vec_dot_q4_K(g_row + kbx, vy + (size_t)kbx * 8, kqs);
+        tu += si_vec_dot_q4_K(u_row + kbx, vy + (size_t)kbx * 8, kqs);
+    }
+    __shared__ float sg[2][NW - 1][WS], su[2][NW - 1][WS];
+    if (group_warp > 0) { sg[group][group_warp - 1][lane] = tg; su[group][group_warp - 1][lane] = tu; }
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[group][l][lane]; tu += su[group][l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[f] = q4kf_silu(tg) * tu;
 }
 
 // int8 dp4a MMVQ down (Q4_K). The Q4_K-quantized down rows in Q4_K_M were the last MoE GEMV
@@ -961,6 +1039,20 @@ static inline int down_splitk_s_q6() {
     return s;
 }
 
+// Shape-tuned Q6_K down split count. Dense hybrid Qwythos (4096,12288,top-1): S=8 wins on 5090.
+static inline int down_splitk_s_q6_ffn(int hidden, int ffn, int top_k) {
+    if (const char* v = getenv("SPARKINFER_DOWN_SPLITK_S_Q6")) {
+        int s = atoi(v);
+        if (s == 0 || s == 1 || s == 2 || s == 4 || s == 8) return s;
+    }
+    if (const char* v = getenv("SPARKINFER_DOWN_SPLITK_S")) {
+        int s = atoi(v);
+        if (s == 0 || s == 1 || s == 2 || s == 4 || s == 8) return s;
+    }
+    if (hidden == 4096 && ffn == 12288 && top_k == 1) return 8;
+    return down_splitk_s_q6();
+}
+
 static inline int down_splitk_s_q4() {
     static int s = -2;
     if (s == -2) {
@@ -1040,6 +1132,23 @@ static inline bool launch_down_q6k_mmvq_splitk(
             down_q, expert_ids, expert_weights, hq8, output, H, pdl);
         return true;
     }
+    if (spec && top_k == 1 && F == 12288) {
+        if (S == 8) {
+            launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_qwen_kernel<8, 48, 1>,
+                down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+            return true;
+        }
+        if (S == 4) {
+            launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_qwen_kernel<4, 48, 1>,
+                down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+            return true;
+        }
+        if (S == 2) {
+            launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_qwen_kernel<2, 48, 1>,
+                down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+            return true;
+        }
+    }
     switch (S) {
         case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q6k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
@@ -1093,6 +1202,48 @@ void launch_moe_expert_ffn_q4k(
     float* h_scratch, float* out_scratch,
     int num_tokens, int top_k, int hidden, int ffn, const void* input_q8, cudaStream_t stream
 ) {
+    // Qwythos dense hybrid fast path: pack2 gate/up without expert lookup + PDL-chained
+    // quant/down. SPARKINFER_DENSE_FFN_FUSE=0 restores the generic MoE dispatch below.
+    static int dense_fuse = -1;
+    if (dense_fuse < 0) {
+        const char* e = getenv("SPARKINFER_DENSE_FFN_FUSE");
+        dense_fuse = (e && e[0] == '0') ? 0 : 1;
+    }
+    if (dense_fuse && num_tokens == 1 && top_k == 1 && hidden == 4096 && ffn == 12288
+        && gate_type == 12 && up_type == 12 && down_type == 14) {
+        constexpr int H = 4096, F = 12288;
+        const si_block_q8_1* vy;
+        si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(out_scratch);
+        if (input_q8) {
+            vy = reinterpret_cast<const si_block_q8_1*>(input_q8);
+        } else {
+            si_quant_bf16_q8_1<<<(H >> 5), 32, 0, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(input), qbuf, H);
+            vy = qbuf;
+        }
+        dense_gate_up_q4k_pack2_kernel<H, F><<<(F + 1) / 2, 8 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), h_scratch);
+        const int nqb = F >> 5;
+        const int pdl = down_mmvq_pdl();
+        quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
+            h_scratch, qbuf, nqb, pdl);
+        const int S = down_splitk_s_q6_ffn(H, F, 1);
+        if (S > 1) {
+            const int RPB = WPB / S;
+            dim3 dns(1, (H + RPB - 1) / RPB);
+            if (launch_down_q6k_mmvq_splitk(S, pdl, dns,
+                    reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
+                    reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, stream))
+                return;
+        }
+        dim3 dnm(1, (H + WPB - 1) / WPB);
+        launch_mmvq_down_kernel(pdl, dnm, dim3(WPB * 32), stream, down_q6k_mmvq_kernel,
+            reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
+            reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, pdl);
+        return;
+    }
+
     // int8 dp4a path for Q4_K gate/up (decode parity with llama.cpp's MMVQ). Default
     // ON — the largest single decode cost; down stays on the fp path (Q6_K). Set
     // SPARKINFER_MMVQ=0 to fall back to the bf16 dequant-GEMV.
@@ -1131,6 +1282,14 @@ void launch_moe_expert_ffn_q4k(
                 reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, num_tokens * top_k * ffn);
         else if (gu_spec && hidden == 2048 && ffn == 768 && top_k == 8)
             gate_up_mmvq2_qwen_kernel<2048, 768, 8><<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
+        else if (gu_pack2 && gu_spec && hidden == 4096 && ffn == 12288 && top_k == 1)
+            gate_up_mmvq2_pack2_qwen_kernel<4096, 12288, 1><<<(num_tokens * top_k * ffn + 1) / 2, 8 * 32, 0, stream>>>(
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, num_tokens * top_k * ffn);
+        else if (gu_spec && hidden == 4096 && ffn == 12288 && top_k == 1)
+            gate_up_mmvq2_qwen_kernel<4096, 12288, 1><<<num_tokens * top_k * ffn, 4 * 32, 0, stream>>>(
                 q, reinterpret_cast<const unsigned char*>(gate_q),
                 reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
         else

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1207,7 +1207,7 @@ void launch_moe_expert_ffn_q4k(
     static int dense_fuse = -1;
     if (dense_fuse < 0) {
         const char* e = getenv("SPARKINFER_DENSE_FFN_FUSE");
-        dense_fuse = (e && e[0] == '1') ? 1 : 0;   // opt-in until dense pack2 path is parity-checked
+        dense_fuse = (e && e[0] == '0') ? 0 : 1;   // default on for Qwythos dense 4096x12288
     }
     if (dense_fuse && num_tokens == 1 && top_k == 1 && hidden == 4096 && ffn == 12288
         && gate_type == 12 && up_type == 12 && down_type == 14) {

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1064,6 +1064,20 @@ static inline int down_splitk_s_q4() {
     return s;
 }
 
+// Shape-tuned Q4_K down split count. Dense hybrid Qwythos after #323 requant: S=8 on 5090.
+static inline int down_splitk_s_q4_ffn(int hidden, int ffn, int top_k) {
+    if (const char* v = getenv("SPARKINFER_DOWN_SPLITK_S_Q4")) {
+        int s = atoi(v);
+        if (s == 0 || s == 1 || s == 2 || s == 4 || s == 8) return s;
+    }
+    if (const char* v = getenv("SPARKINFER_DOWN_SPLITK_S")) {
+        int s = atoi(v);
+        if (s == 0 || s == 1 || s == 2 || s == 4 || s == 8) return s;
+    }
+    if (hidden == 4096 && ffn == 12288 && top_k == 1) return 8;
+    return down_splitk_s_q4();
+}
+
 static inline int down_splitk_s_q5() {
     static int s = -2;
     if (s == -2) {
@@ -1174,6 +1188,23 @@ static inline bool launch_down_q4k_mmvq_splitk(
             down_q, expert_ids, expert_weights, hq8, output, H, pdl);
         return true;
     }
+    if (spec && top_k == 1 && F == 12288) {
+        if (S == 8) {
+            launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_qwen_kernel<8, 48, 1>,
+                down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+            return true;
+        }
+        if (S == 4) {
+            launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_qwen_kernel<4, 48, 1>,
+                down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+            return true;
+        }
+        if (S == 2) {
+            launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_qwen_kernel<2, 48, 1>,
+                down_q, expert_ids, expert_weights, hq8, output, H, pdl);
+            return true;
+        }
+    }
     switch (S) {
         case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
@@ -1210,7 +1241,7 @@ void launch_moe_expert_ffn_q4k(
         dense_fuse = (e && e[0] == '0') ? 0 : 1;   // default on for Qwythos dense 4096x12288
     }
     if (dense_fuse && num_tokens == 1 && top_k == 1 && hidden == 4096 && ffn == 12288
-        && gate_type == 12 && up_type == 12 && down_type == 14) {
+        && gate_type == 12 && up_type == 12 && (down_type == 12 || down_type == 14)) {
         constexpr int H = 4096, F = 12288;
         const si_block_q8_1* vy;
         si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(out_scratch);
@@ -1228,19 +1259,31 @@ void launch_moe_expert_ffn_q4k(
         const int pdl = down_mmvq_pdl();
         quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
             h_scratch, qbuf, nqb, pdl);
-        const int S = down_splitk_s_q6_ffn(H, F, 1);
+        const int S = (down_type == 14) ? down_splitk_s_q6_ffn(H, F, 1)
+                                        : down_splitk_s_q4_ffn(H, F, 1);
         if (S > 1) {
             const int RPB = WPB / S;
             dim3 dns(1, (H + RPB - 1) / RPB);
-            if (launch_down_q6k_mmvq_splitk(S, pdl, dns,
-                    reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
-                    reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, stream))
+            if (down_type == 14) {
+                if (launch_down_q6k_mmvq_splitk(S, pdl, dns,
+                        reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
+                        reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, stream))
+                    return;
+            } else if (launch_down_q4k_mmvq_splitk(S, pdl, dns,
+                        reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
+                        reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, stream))
                 return;
         }
         dim3 dnm(1, (H + WPB - 1) / WPB);
-        launch_mmvq_down_kernel(pdl, dnm, dim3(WPB * 32), stream, down_q6k_mmvq_kernel,
-            reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
-            reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, pdl);
+        if (down_type == 14) {
+            launch_mmvq_down_kernel(pdl, dnm, dim3(WPB * 32), stream, down_q6k_mmvq_kernel,
+                reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
+                reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, pdl);
+        } else {
+            launch_mmvq_down_kernel(pdl, dnm, dim3(WPB * 32), stream, down_q4k_mmvq_kernel,
+                reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, qbuf,
+                reinterpret_cast<__nv_bfloat16*>(output), H, F, 1, pdl);
+        }
         return;
     }
 

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1207,7 +1207,7 @@ void launch_moe_expert_ffn_q4k(
     static int dense_fuse = -1;
     if (dense_fuse < 0) {
         const char* e = getenv("SPARKINFER_DENSE_FFN_FUSE");
-        dense_fuse = (e && e[0] == '0') ? 0 : 1;
+        dense_fuse = (e && e[0] == '1') ? 1 : 0;   // opt-in until dense pack2 path is parity-checked
     }
     if (dense_fuse && num_tokens == 1 && top_k == 1 && hidden == 4096 && ffn == 12288
         && gate_type == 12 && up_type == 12 && down_type == 14) {

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -70,6 +70,14 @@ void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
                                  void* v_bf16, int q_heads, int v_heads, int head_dim,
                                  int conv_kernel, float eps, cudaStream_t stream = nullptr);
 
+// Fused conv_split + per-head l2_norm: one block per head, head_dim threads.
+// Eliminates the two standalone l2_norm_heads kernel launches per GDN layer.
+// SPARKINFER_GDN_FUSE=0 restores the split path for A/B.
+void launch_qwen36_conv_split_l2norm_fused(const void* qkv_bf16, const void* conv_w_bf16,
+                                 void* conv_state_bf16, void* q_bf16, void* k_bf16,
+                                 void* v_bf16, int q_heads, int v_heads, int head_dim,
+                                 int conv_kernel, float eps, cudaStream_t stream = nullptr);
+
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -46,6 +46,11 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K,
 void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K,
                      cudaStream_t stream = nullptr);
 
+// Fused GEMV + sigmoid for the shared-expert gate scalar (N=1). One warp dots
+// x @ W and applies sigmoid. SPARKINFER_GEMV_SIGMOID=0 restores the split path.
+void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K,
+                         cudaStream_t stream = nullptr);
+
 // Quantized on-read GEMV: same as launch_gemv but W is GGUF-native Q4_K/Q6_K/Q8_0
 // [N,K] (wtype = ggml type id, 12=Q4_K / 14=Q6_K / 8=Q8_0). Dequantizes each block in
 // registers with a full-precision (fp32) activation dot — reads the quantized

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -76,6 +76,10 @@ size_t llama_q8_1_bytes(int K);
 void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
+// Fused GDN qkv+z Q4_K MMVQ (shared Q8_1 activation). K must be 4096 (NSUPER=16).
+void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void* z_w,
+                                 void* qkv_out, void* z_out, int n_qkv, int n_z,
+                                 cudaStream_t stream = nullptr);
 // Same, for Q6_K weights (attn-V upgrades + LM head). q81 = block_q8_1(activation).
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -76,9 +76,9 @@ size_t llama_q8_1_bytes(int K);
 void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
-// Fused GDN qkv+z Q4_K MMVQ (shared Q8_1 activation). K must be 4096 (NSUPER=16).
+// Fused GDN qkv+z Q4_K MMVQ (shared Q8_1 activation). K is hidden (2048 -> NSUPER=8, 4096 -> 16).
 void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void* z_w,
-                                 void* qkv_out, void* z_out, int n_qkv, int n_z,
+                                 void* qkv_out, void* z_out, int n_qkv, int n_z, int K,
                                  cudaStream_t stream = nullptr);
 // Same, for Q6_K weights (attn-V upgrades + LM head). q81 = block_q8_1(activation).
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -46,9 +46,9 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K,
 void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K,
                      cudaStream_t stream = nullptr);
 
-// Fused GEMV + sigmoid for the shared-expert gate scalar (N=1). One warp dots
-// x @ W and applies sigmoid. SPARKINFER_GEMV_SIGMOID=0 restores the split path.
-void launch_gemv_sigmoid(const void* x, const void* W, float* y, int K,
+// Fused GEMV + sigmoid for the shared-expert gate scalar (N=1). Uses scratch_bf16
+// for the bf16 dot (same as launch_gemv) then sigmoid_scalar. SPARKINFER_GEMV_SIGMOID=1 enables.
+void launch_gemv_sigmoid(const void* x, const void* W, void* scratch_bf16, float* y, int K,
                          cudaStream_t stream = nullptr);
 
 // Quantized on-read GEMV: same as launch_gemv but W is GGUF-native Q4_K/Q6_K/Q8_0

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -83,6 +83,7 @@ void launch_shared_expert_q8_mmvq(
     const void* input, const void* input_q8,
     const void* gate_q, const void* up_q, const void* down_q,
     const float* dw, void* output, float* h_scratch, void* h_q8_buf,
-    int hidden, int ffn, cudaStream_t stream = nullptr);
+    int hidden, int ffn, cudaStream_t stream = nullptr,
+    bool accum = false);
 
 }} // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -23,6 +23,7 @@ struct Qwen35LayerWeights {
     const void* k_norm = nullptr;        // [head_dim]
     const void* post_attn_norm = nullptr;// [hidden]
     const void* router_w = nullptr;      // [hidden, n_experts]
+    int router_w_type = 0;              // ggml_type when router_w is kept quantized (0 = bf16 dense)
     const void* gate = nullptr;          // [n_experts, hidden, moe_ffn]
     const void* up   = nullptr;          // [n_experts, hidden, moe_ffn]
     const void* down = nullptr;          // [n_experts, moe_ffn, hidden]

--- a/runtime/scripts/bisect_qwen36_acc.sh
+++ b/runtime/scripts/bisect_qwen36_acc.sh
@@ -2,8 +2,9 @@
 # Quick Qwen3.6 accuracy bisect: compare teacher-forced argmax top-1 vs a reference dump.
 # Usage: bisect_qwen36_acc.sh <ref_score.txt> <label> [env exports...]
 set -euo pipefail
-HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$HERE/_common.sh"
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+BENCH="$ROOT/bench/scripts"
+source "$BENCH/_common.sh"
 
 REF="${1:?ref score dump}"; LABEL="${2:?label}"; shift 2
 GGUF="${GGUF:-/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
@@ -13,10 +14,9 @@ ensure_tokenizer
 
 SEED="${SPARKINFER_EVAL_SEED:-fixed}"
 IDS_FILE="/tmp/bisect_ids.txt"
-python3 "$HERE/gen_eval_prompt.py" "$SEED" "$MODELS_DIR/tokenizer.json" \
-  "$HERE/eval_corpus.txt" "$HERE/eval_text.txt" > "$IDS_FILE"
+python3 "$BENCH/gen_eval_prompt.py" "$SEED" "$MODELS_DIR/tokenizer.json" \
+  "$BENCH/eval_corpus.txt" "$BENCH/eval_text.txt" > "$IDS_FILE"
 IDS="$(cat "$IDS_FILE")"
-NT=$(echo "$IDS" | wc -w)
 
 OUT="/tmp/bisect_${LABEL}.txt"
 env "$@" si_run qwen3_gguf_score "$GGUF" 128 $IDS > "$OUT"
@@ -44,7 +44,6 @@ cm, cn = argmatch(cand_path)
 n = min(rn, cn)
 if n == 0:
     print(f"{label}: ERROR no positions parsed"); sys.exit(1)
-# per-position agreement with reference argmax (not tgt)
 ref_am = []
 for line in open(ref_path):
     m = re.match(r"S i=\d+ tgt=\d+ am=(\d+)", line)

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -471,7 +471,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 cudaEventRecord(s.ev_gdn_ab, s.stream_v);
                 kernels::launch_mmvq_gdn_qkv_z_pack2(s.aq81, w.wqkv, w.wqkv_gate,
                                                        s.lin_qkv, s.lin_z,
-                                                       s.linear_qkvdim, s.linear_vdim, st);
+                                                       s.linear_qkvdim, s.linear_vdim, H, st);
             } else if (gdn_pipelined && !gdn_fused_proj) {
                 cudaEventRecord(s.ev_pipe_fork, st);
                 cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
@@ -485,7 +485,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
             } else if (gdn_fused_proj) {
                 kernels::launch_mmvq_gdn_qkv_z_pack2(s.aq81, w.wqkv, w.wqkv_gate,
                                                        s.lin_qkv, s.lin_z,
-                                                       s.linear_qkvdim, s.linear_vdim, st);
+                                                       s.linear_qkvdim, s.linear_vdim, H, st);
                 proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
                 proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
             } else {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -315,15 +315,16 @@ int Qwen35Model::forward_token(int token_id, int position) {
     s.h_scalars[3] = seqlen;
     cu(cudaMemcpyAsync(s.d_scalars, s.h_scalars, 4 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
 
-    // Depth-adaptive KV-split: keep 32 splits for the short-context sweet spot, then jump to
-    // the 128-split occupancy plateau on RTX 5090. The split grid is num_kv_heads*n_splits CTAs,
-    // so 64 splits still underfills mid-context decode; 128 improves 512/2k/4k. Past the 16k
-    // knee, use MAX_NSPLITS to keep each split's serial KV chunk bounded. Partials are sized for
-    // MAX_NSPLITS, and the online-softmax combine is exact for any split count (accuracy unchanged).
+    // Depth-adaptive KV-split: keep 32 splits for the short-context sweet spot, then
+    // scale to 128/256 splits as context grows. The split grid is num_kv_heads*n_splits
+    // CTAs — Qwen3.6 full-attention has only 2 KV-heads (hd=256), so 128 splits at 4k
+    // is just 256 CTAs; 256 splits at 8k+ doubles that. Per-block chunk stays in the
+    // 32-128 token range for good TILE=14 amortization.
+    // Partials are sized for MAX_NSPLITS; online-softmax combine is exact for any split count.
     if (s.adaptive_splits) {
         int want = 32;
-        if ((long)seqlen > 2L * s.split_chunk) want = 128;
-        if ((long)seqlen > 64L * s.split_chunk) want = Impl::MAX_NSPLITS;
+        if ((long)seqlen > 2L * s.split_chunk)  want = 128;
+        if ((long)seqlen > 32L * s.split_chunk) want = 256;
         if (want > Impl::MAX_NSPLITS) want = Impl::MAX_NSPLITS;
         if (want != s.n_splits) {                       // changed -> invalidate the captured graph
             s.n_splits = want;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -686,11 +686,17 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
             }
             if (qmoe) {
+                // Accumulate shared-expert output directly into routed (skip residual_add).
+                // SPARKINFER_SHEXP_ACCUM=0 restores the split path for A/B.
+                static int shexp_accum = -1;
+                if (shexp_accum < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
+                    shexp_accum = (e && e[0] == '0') ? 0 : 1; }
                 kernels::launch_shared_expert_q8_mmvq(
                     s.hn, fnq ? s.aq81 : nullptr,
                     w.shared_gate_q, w.shared_up_q, w.shared_down_q,
                     w.shared_gate_inp ? s.d_shared_w : nullptr,
-                    s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k);
+                    shexp_accum ? s.routed : s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k,
+                    shexp_accum ? true : false);
             } else {
                 kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, s.stream_k);
                 kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, s.stream_v);
@@ -744,6 +750,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
         if (c.n_shared > 0) {
             if (shexp_pipelined) {
                 cudaStreamWaitEvent(st, s.ev_sx_done, 0);
+                // (residual_add folded into add_rmsnorm3 below — #279)
                 const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
                 if (s.use_addnorm3) {
                     if (fnq)
@@ -793,11 +800,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
             }
             if (s.gguf) {
                 if (qmoe) {
+                    static int shexp_accum3 = -1;
+                    if (shexp_accum3 < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
+                        shexp_accum3 = (e && e[0] == '0') ? 0 : 1; }
                     kernels::launch_shared_expert_q8_mmvq(
                         s.hn, fnq ? s.aq81 : nullptr,
                         w.shared_gate_q, w.shared_up_q, w.shared_down_q,
                         w.shared_gate_inp ? s.d_shared_w : nullptr,
-                        s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st);
+                        shexp_accum3 ? s.routed : s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st,
+                        shexp_accum3 ? true : false);
                 } else {
                     kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, st);
                     kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, st);
@@ -816,12 +827,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
         const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         if (shared_to_fold) {
             if (fnq)
-                kernels::launch_add_rmsnorm3_q8(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+                kernels::launch_add_rmsnorm3_q8(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
             else
-                kernels::launch_add_rmsnorm3(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                kernels::launch_add_rmsnorm3(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
         } else if (fnq)
-            kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
-        else
             kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
     }
     // xn now holds RMSNorm(x_final, final_norm)
@@ -1182,8 +1191,17 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             w.up_q   = dev_quant(b + "ffn_up.weight", w.up_qtype);
             w.down_q = dev_quant_down(b + "ffn_down.weight", w.down_qtype);
         } else {
-        if (!expect_dims(b + "ffn_gate_inp.weight", {H, c.n_experts})) return false;
-        w.router_w = dense(b + "ffn_gate_inp.weight", false);   // native [E,H] for GEMV
+            if (!expect_dims(b + "ffn_gate_inp.weight", {H, c.n_experts})) return false;
+            // Router weight: keep Q8_0 raw if present in the GGUF (half bandwidth, on-read GEMV)
+            {
+                const GGUFTensor* rt = g.tensor(b + "ffn_gate_inp.weight");
+                if (qattn && rt && rt->ggml_type == 8) {
+                    w.router_w = dev_quant(b + "ffn_gate_inp.weight", w.router_w_type);
+                } else {
+                    w.router_w = dense(b + "ffn_gate_inp.weight", false);
+                    w.router_w_type = 0;
+                }
+            }
         w.gate_q = dev_quant(b + "ffn_gate_exps.weight", w.gate_qtype);   // kept quantized
         w.up_q   = dev_quant(b + "ffn_up_exps.weight",   w.up_qtype);
         w.down_q = dev_quant(b + "ffn_down_exps.weight", w.down_qtype);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -698,9 +698,9 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     // restores the split path for A/B.
                     static int gemv_sigmoid = -1;
                     if (gemv_sigmoid < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
-                        gemv_sigmoid = (e && e[0] == '0') ? 0 : 1; }
+                        gemv_sigmoid = (e && e[0] == '1') ? 1 : 0; }   // default off: fused dot != split-k GEMV
                     if (gemv_sigmoid) {
-                        kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.d_shared_w, H, s.stream_k);
+                        kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.shared_gate_tmp, s.d_shared_w, H, s.stream_k);
                     } else {
                         kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
                         kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
@@ -708,17 +708,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
             }
             if (qmoe) {
-                // Accumulate shared-expert output directly into routed (skip residual_add).
-                // SPARKINFER_SHEXP_ACCUM=0 restores the split path for A/B.
-                static int shexp_accum = -1;
-                if (shexp_accum < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
-                    shexp_accum = (e && e[0] == '0') ? 0 : 1; }
+                // Pipelined shared overlaps stream_k with MoE on st — accum into routed here
+                // races MoE (shared finishes first, MoE overwrites routed). Always write s.shared;
+                // fold happens after both complete. SPARKINFER_SHEXP_ACCUM=1 only applies on the
+                // non-pipelined path where MoE has already landed in routed.
                 kernels::launch_shared_expert_q8_mmvq(
                     s.hn, fnq ? s.aq81 : nullptr,
                     w.shared_gate_q, w.shared_up_q, w.shared_down_q,
                     w.shared_gate_inp ? s.d_shared_w : nullptr,
-                    shexp_accum ? s.routed : s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k,
-                    shexp_accum ? true : false);
+                    s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k, false);
             } else {
                 kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, s.stream_k);
                 kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, s.stream_v);
@@ -770,10 +768,10 @@ int Qwen35Model::forward_token(int token_id, int position) {
         }
         const void* shared_to_fold = nullptr;
         if (c.n_shared > 0) {
+            const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
             if (shexp_pipelined) {
                 cudaStreamWaitEvent(st, s.ev_sx_done, 0);
                 // (residual_add folded into add_rmsnorm3 below — #279)
-                const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
                 if (s.use_addnorm3) {
                     if (fnq)
                         kernels::launch_add_rmsnorm3_q8(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
@@ -807,9 +805,9 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     } else {
                         static int gs2 = -1;
                         if (gs2 < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
-                            gs2 = (e && e[0] == '0') ? 0 : 1; }
+                            gs2 = (e && e[0] == '1') ? 1 : 0; }
                         if (gs2) {
-                            kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.d_shared_w, H, st);
+                            kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.shared_gate_tmp, s.d_shared_w, H, st);
                         } else {
                             kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
                             kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
@@ -822,15 +820,24 @@ int Qwen35Model::forward_token(int token_id, int position) {
             }
             if (s.gguf) {
                 if (qmoe) {
-                    static int shexp_accum3 = -1;
-                    if (shexp_accum3 < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
-                        shexp_accum3 = (e && e[0] == '0') ? 0 : 1; }
+                    // MoE already wrote routed; safe to accum shared down into it (opt-in).
+                    static int shexp_accum = -1;
+                    if (shexp_accum < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
+                        shexp_accum = (e && e[0] == '1') ? 1 : 0; }
+                    const bool sx_accum = shexp_accum != 0;
                     kernels::launch_shared_expert_q8_mmvq(
                         s.hn, fnq ? s.aq81 : nullptr,
                         w.shared_gate_q, w.shared_up_q, w.shared_down_q,
                         w.shared_gate_inp ? s.d_shared_w : nullptr,
-                        shexp_accum3 ? s.routed : s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st,
-                        shexp_accum3 ? true : false);
+                        sx_accum ? s.routed : s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st,
+                        sx_accum);
+                    if (sx_accum) {
+                        if (fnq)
+                            kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+                        else
+                            kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                        continue;
+                    }
                 } else {
                     kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, st);
                     kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, st);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -55,7 +55,9 @@ bool ggml_dequant_supported(int ggml_type) {
 
 long qwen_moe_meta_int(const GGUF& g, const std::string& key, long def) {
     const long missing = std::numeric_limits<long>::min();
-    long v = g.meta_int("qwen35moe." + key, missing);
+    long v = g.meta_int("qwen35." + key, missing);
+    if (v != missing) return v;
+    v = g.meta_int("qwen35moe." + key, missing);
     if (v != missing) return v;
     v = g.meta_int("qwen3moe." + key, missing);
     if (v != missing) return v;
@@ -67,6 +69,10 @@ bool is_qwen35_or_qwen36_hybrid_moe(const GGUF& g) {
     const std::string name = g.meta_str("general.name");
     if (name.find("Qwen3.5-35B-A3B") != std::string::npos ||
         name.find("Qwen3.6-35B-A3B") != std::string::npos)
+        return true;
+
+    if (g.tensor("blk.0.attn_qkv.weight") != nullptr &&
+        g.tensor("blk.3.attn_q.weight") != nullptr)
         return true;
 
     const GGUFTensor* emb = g.tensor("token_embd.weight");
@@ -224,13 +230,13 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     // Fused-expert + flash-decoding decode scratch (batch 1). Allocated here so
     // EVERY load path (set_weights / load_weights / load_gguf) has it — not just
     // GGUF. (fa_* NULL here is what crashed flash_decode_split on the non-GGUF path.)
-    p_->mf_logits  = p_->alloc<float>(cfg.n_experts);
-    p_->mf_ids     = p_->alloc<int>(cfg.top_k);
-    p_->mf_weights = p_->alloc<float>(cfg.top_k);
-    p_->mf_counts  = p_->alloc<int>(cfg.n_experts);
+    p_->mf_logits  = p_->alloc<float>(std::max(1, cfg.n_experts));
+    p_->mf_ids     = p_->alloc<int>(std::max(1, cfg.top_k));
+    p_->mf_weights = p_->alloc<float>(std::max(1, cfg.top_k));
+    p_->mf_counts  = p_->alloc<int>(std::max(1, cfg.n_experts));
     p_->mf_rc      = p_->alloc<unsigned int>(1);
     cu(cudaMemset(p_->mf_rc, 0, sizeof(unsigned int)), "mf_rc zero");   // grid-completion counter starts at 0
-    p_->mf_h       = p_->alloc<float>((size_t)cfg.top_k * cfg.moe_ffn);
+    p_->mf_h       = p_->alloc<float>((size_t)std::max(1, cfg.top_k) * cfg.moe_ffn);
     p_->mf_out     = p_->alloc<float>(cfg.hidden);
     if (cfg.dense_ffn && cfg.top_k > 0) {
         cu(cudaMemcpy(p_->mf_ids, &zero, sizeof(int), cudaMemcpyHostToDevice), "dense expert id");
@@ -449,7 +455,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                   w.ssm_alpha_type == 8 || w.ssm_beta_type == 8);
             prepare_xn_quant(any_q4k, any_q6k, any_q80);
             const bool gdn_pipelined = s.gguf && s.use_gdn_pipe;
-            if (gdn_pipelined) {
+            const bool gdn_fused_proj = [&] {
+                static int fuse = -1;
+                if (fuse < 0) { const char* e = getenv("SPARKINFER_GDN_QKVZ_FUSE");
+                    fuse = (e && e[0] == '0') ? 0 : 1; }
+                return fuse && s.gguf && s.use_pq && s.use_llama &&
+                       w.wqkv_type == 12 && w.wqkv_gate_type == 12 &&
+                       H == 4096 && s.linear_qkvdim > 0 && s.linear_vdim > 0;
+            }();
+            if (gdn_pipelined && !gdn_fused_proj) {
                 cudaEventRecord(s.ev_pipe_fork, st);
                 cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
                 cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
@@ -459,6 +473,12 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, s.stream_v);
                 cudaEventRecord(s.ev_gdn_ab, s.stream_v);
                 proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
+            } else if (gdn_fused_proj) {
+                kernels::launch_mmvq_gdn_qkv_z_pack2(s.aq81, w.wqkv, w.wqkv_gate,
+                                                       s.lin_qkv, s.lin_z,
+                                                       s.linear_qkvdim, s.linear_vdim, st);
+                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
+                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
             } else {
                 proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
                 proj_xn(w.wqkv_gate, w.wqkv_gate_type, s.lin_z, s.linear_vdim, st);
@@ -471,7 +491,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
             // Fused conv_split + l2_norm: one kernel instead of three (SPARKINFER_GDN_FUSE=0 restores split).
             static int gdn_fuse = -1;
             if (gdn_fuse < 0) { const char* e = getenv("SPARKINFER_GDN_FUSE"); gdn_fuse = (e && e[0] == '0') ? 0 : 1; }
-            if (gdn_fuse && c.linear_head_dim == 128 && c.linear_q_heads == 16 && c.linear_v_heads == 32) {
+            if (gdn_fuse && c.linear_head_dim == 128 && c.linear_q_heads == 16 &&
+                (c.linear_v_heads == 32 || c.linear_v_heads == 16)) {
                 kernels::launch_qwen36_conv_split_l2norm_fused(s.lin_qkv, w.ssm_conv, conv_state,
                                                  s.lin_q, s.lin_k, s.lin_v,
                                                  c.linear_q_heads, c.linear_v_heads,
@@ -832,6 +853,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
             else
                 kernels::launch_add_rmsnorm3(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
         } else if (fnq)
+            kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+        else
             kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
     }
     // xn now holds RMSNorm(x_final, final_norm)
@@ -997,6 +1020,21 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if (s.cfg.linear_v_heads <= 0) s.cfg.linear_v_heads = 32;
         if (s.cfg.linear_head_dim <= 0) s.cfg.linear_head_dim = 128;
         if (s.cfg.linear_conv_kernel <= 0) s.cfg.linear_conv_kernel = 4;
+    }
+    const bool dense_ffn = g.tensor("blk.0.ffn_gate.weight") != nullptr &&
+                           g.tensor("blk.0.ffn_gate_exps.weight") == nullptr;
+    if (dense_ffn) {
+        s.cfg.dense_ffn = true;
+        s.cfg.n_experts = 1;
+        s.cfg.top_k = 1;
+        s.cfg.n_shared = 0;
+        if (s.cfg.moe_ffn <= 0) {
+            s.cfg.moe_ffn = (int)qwen_moe_meta_int(g, "feed_forward_length", 0);
+            if (s.cfg.moe_ffn <= 0) {
+                if (const GGUFTensor* gate = g.tensor("blk.0.ffn_gate.weight"))
+                    if (gate->n_dims >= 2) s.cfg.moe_ffn = (int)gate->dims[1];
+            }
+        }
     }
     const Qwen35Config& c = s.cfg;
     const int H = c.hidden;
@@ -1203,10 +1241,10 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                     w.router_w_type = 0;
                 }
             }
-        w.gate_q = dev_quant(b + "ffn_gate_exps.weight", w.gate_qtype);   // kept quantized
-        w.up_q   = dev_quant(b + "ffn_up_exps.weight",   w.up_qtype);
-        w.down_q = dev_quant(b + "ffn_down_exps.weight", w.down_qtype);
-        if (s.cfg.n_shared > 0) {
+            w.gate_q = dev_quant(b + "ffn_gate_exps.weight", w.gate_qtype);   // kept quantized
+            w.up_q   = dev_quant(b + "ffn_up_exps.weight",   w.up_qtype);
+            w.down_q = dev_quant(b + "ffn_down_exps.weight", w.down_qtype);
+            if (s.cfg.n_shared > 0) {
             if (!expect_dims(b + "ffn_gate_shexp.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_up_shexp.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_down_shexp.weight", {c.moe_ffn, H}) ||
@@ -1230,7 +1268,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const bool have_shared_q = w.shared_gate_q && w.shared_up_q && w.shared_down_q;
             const bool have_shared_d = w.shared_gate && w.shared_up && w.shared_down;
             if (!have_shared_q && !have_shared_d) return false;
-        }
+            }
         }
         const bool have_attn = w.linear_attn
             ? (w.wqkv && w.wqkv_gate && w.ssm_conv && w.ssm_dt && w.ssm_a &&
@@ -1242,7 +1280,12 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if (!have_attn || !w.input_norm || !w.post_attn_norm || !have_ffn) return false;
         if (i == 0 || i == c.n_layers - 1) fprintf(stderr, "[gguf] layer %d loaded\n", i);
     }
-    // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
+    if (dense_ffn) {
+        const int id0 = 0;
+        const float w0 = 1.f;
+        cudaMemcpy(s.mf_ids, &id0, sizeof(int), cudaMemcpyHostToDevice);
+        cudaMemcpy(s.mf_weights, &w0, sizeof(float), cudaMemcpyHostToDevice);
+    }
     return true;
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -461,9 +461,18 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     fuse = (e && e[0] == '0') ? 0 : 1; }
                 return fuse && s.gguf && s.use_pq && s.use_llama &&
                        w.wqkv_type == 12 && w.wqkv_gate_type == 12 &&
-                       H == 2048 && s.linear_qkvdim > 0 && s.linear_vdim > 0;
+                       (H == 2048 || H == 4096) && s.linear_qkvdim > 0 && s.linear_vdim > 0;
             }();
-            if (gdn_pipelined && !gdn_fused_proj) {
+            if (gdn_fused_proj && gdn_pipelined) {
+                cudaEventRecord(s.ev_pipe_fork, st);
+                cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
+                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, s.stream_v);
+                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, s.stream_v);
+                cudaEventRecord(s.ev_gdn_ab, s.stream_v);
+                kernels::launch_mmvq_gdn_qkv_z_pack2(s.aq81, w.wqkv, w.wqkv_gate,
+                                                       s.lin_qkv, s.lin_z,
+                                                       s.linear_qkvdim, s.linear_vdim, st);
+            } else if (gdn_pipelined && !gdn_fused_proj) {
                 cudaEventRecord(s.ev_pipe_fork, st);
                 cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
                 cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
@@ -513,7 +522,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                                           layer_state, s.lin_gdn,
                                           c.linear_q_heads, c.linear_v_heads,
                                           c.linear_head_dim, st);
-            if (gdn_pipelined) cudaStreamWaitEvent(st, s.ev_gdn_z, 0);
+            if (gdn_pipelined && !gdn_fused_proj) cudaStreamWaitEvent(st, s.ev_gdn_z, 0);
             const bool gdn_gn_q8 = s.gguf && s.use_pq && s.use_llama &&
                                    (w.ssm_out_type == 12 || w.ssm_out_type == 8) &&
                                    c.linear_head_dim == 128;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -461,7 +461,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     fuse = (e && e[0] == '0') ? 0 : 1; }
                 return fuse && s.gguf && s.use_pq && s.use_llama &&
                        w.wqkv_type == 12 && w.wqkv_gate_type == 12 &&
-                       H == 4096 && s.linear_qkvdim > 0 && s.linear_vdim > 0;
+                       H == 2048 && s.linear_qkvdim > 0 && s.linear_vdim > 0;
             }();
             if (gdn_pipelined && !gdn_fused_proj) {
                 cudaEventRecord(s.ev_pipe_fork, st);
@@ -492,7 +492,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
             static int gdn_fuse = -1;
             if (gdn_fuse < 0) { const char* e = getenv("SPARKINFER_GDN_FUSE"); gdn_fuse = (e && e[0] == '0') ? 0 : 1; }
             if (gdn_fuse && c.linear_head_dim == 128 && c.linear_q_heads == 16 &&
-                (c.linear_v_heads == 32 || c.linear_v_heads == 16)) {
+                c.linear_v_heads == 32) {
                 kernels::launch_qwen36_conv_split_l2norm_fused(s.lin_qkv, w.ssm_conv, conv_state,
                                                  s.lin_q, s.lin_k, s.lin_v,
                                                  c.linear_q_heads, c.linear_v_heads,
@@ -849,9 +849,9 @@ int Qwen35Model::forward_token(int token_id, int position) {
         const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         if (shared_to_fold) {
             if (fnq)
-                kernels::launch_add_rmsnorm3_q8(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
+                kernels::launch_add_rmsnorm3_q8(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
             else
-                kernels::launch_add_rmsnorm3(s.h, s.routed, s.shared, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
+                kernels::launch_add_rmsnorm3(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
         } else if (fnq)
             kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
         else
@@ -1280,12 +1280,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if (!have_attn || !w.input_norm || !w.post_attn_norm || !have_ffn) return false;
         if (i == 0 || i == c.n_layers - 1) fprintf(stderr, "[gguf] layer %d loaded\n", i);
     }
-    if (dense_ffn) {
-        const int id0 = 0;
-        const float w0 = 1.f;
-        cudaMemcpy(s.mf_ids, &id0, sizeof(int), cudaMemcpyHostToDevice);
-        cudaMemcpy(s.mf_weights, &w0, sizeof(float), cudaMemcpyHostToDevice);
-    }
+    // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -670,9 +670,20 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     kernels::launch_gemv_q(s.hn, w.shared_gate_inp, w.shared_gate_inp_type,
                                            s.shared_gate_tmp, 1, H, s.stream_k);
                 } else {
-                    kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                    // Fused GEMV + sigmoid for the shared-expert gate scalar:
+                    // writes fp32 sigmoid(gate) directly, eliminating the separate
+                    // 1-thread sigmoid_scalar_kernel launch. SPARKINFER_GEMV_SIGMOID=0
+                    // restores the split path for A/B.
+                    static int gemv_sigmoid = -1;
+                    if (gemv_sigmoid < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
+                        gemv_sigmoid = (e && e[0] == '0') ? 0 : 1; }
+                    if (gemv_sigmoid) {
+                        kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.d_shared_w, H, s.stream_k);
+                    } else {
+                        kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
+                        kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
+                    }
                 }
-                kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
             }
             if (qmoe) {
                 kernels::launch_shared_expert_q8_mmvq(
@@ -765,12 +776,20 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     } else if (w.shared_gate_inp_type) {
                         kernels::launch_gemv_q(s.hn, w.shared_gate_inp, w.shared_gate_inp_type, s.shared_gate_tmp, 1, H, st);
                     } else {
-                        kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                        static int gs2 = -1;
+                        if (gs2 < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
+                            gs2 = (e && e[0] == '0') ? 0 : 1; }
+                        if (gs2) {
+                            kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.d_shared_w, H, st);
+                        } else {
+                            kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
+                            kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
+                        }
                     }
                 } else {
                     kernels::launch_gemm(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, 1, H, 1.f, 0.f, gc, st);
+                    kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
                 }
-                kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
             }
             if (s.gguf) {
                 if (qmoe) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -467,11 +467,22 @@ int Qwen35Model::forward_token(int token_id, int position) {
 
             bf16* conv_state = s.lin_conv_state +
                 (size_t)L * (c.linear_conv_kernel - 1) * s.linear_qkvdim;
-            kernels::launch_qwen36_conv_split_l2(s.lin_qkv, w.ssm_conv, conv_state,
+            // Fused conv_split + l2_norm: one kernel instead of three (SPARKINFER_GDN_FUSE=0 restores split).
+            static int gdn_fuse = -1;
+            if (gdn_fuse < 0) { const char* e = getenv("SPARKINFER_GDN_FUSE"); gdn_fuse = (e && e[0] == '0') ? 0 : 1; }
+            if (gdn_fuse && c.linear_head_dim == 128 && c.linear_q_heads == 16 && c.linear_v_heads == 32) {
+                kernels::launch_qwen36_conv_split_l2norm_fused(s.lin_qkv, w.ssm_conv, conv_state,
                                                  s.lin_q, s.lin_k, s.lin_v,
                                                  c.linear_q_heads, c.linear_v_heads,
                                                  c.linear_head_dim, c.linear_conv_kernel,
                                                  c.rms_eps, st);
+            } else {
+                kernels::launch_qwen36_conv_split_l2(s.lin_qkv, w.ssm_conv, conv_state,
+                                                 s.lin_q, s.lin_k, s.lin_v,
+                                                 c.linear_q_heads, c.linear_v_heads,
+                                                 c.linear_head_dim, c.linear_conv_kernel,
+                                                 c.rms_eps, st);
+            }
             if (gdn_pipelined) cudaStreamWaitEvent(st, s.ev_gdn_ab, 0);
             float* layer_state = s.lin_state +
                 (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;


### PR DESCRIPTION
## Summary

Rebased onto `main` @ `ac4a718` (includes **#323** FFN-down Q6_K→Q4_K load-time requant). End-to-end decode optimizations for **Qwythos** (Qwen3.5-9B dense hybrid, H=4096) and **Qwen3.6** (hybrid MoE + GDN).

### Qwythos / dense hybrid (H=4096)

- **Dense FFN fast path** (`dense_ffn`): routes SwiGLU through `launch_moe_expert_ffn_q4k` — pack2 gate/up, PDL-chained Q8_1 quant + split-K down (S=8 @ 4096×12288)
- **Dense FFN fuse + #323**: fuse path restored for load-time requantized **Q4_K** down (`down_type==12`); Q4_K spec split-K kernels for F=12288
- **GDN H=4096 tuning**: `GDN_QKVZ_FUSE` extended to H=4096; pipelined α/β on side streams while fused qkv+z runs on main
- **GDN qkv+z fuse fix**: warps 0–3 / 4–7 now project the **same row** (was pairing qkv even-rows with z odd-rows → Qwythos PPL blow-up); `NSUPER=8` dispatch for K=2048
- **GDN_FAST** adaptive `COLS` (default 4 for 32 v-heads)
- **Qwythos loader fix**: `dense_ffn` + `top_k>0` hybrid GGUF detection

### GDN (both models)

- Fused **conv_split + l2_norm** per-head kernel (3 launches → 1)
- **GDN_FAST** warp-per-column AR with transposed state; pipelined gate/scalar projections (`GDN_PIPE`)
- Gated-norm q8 + ssm_out MMVQ path for hybrid layers

### Attention (Qwen3.6 long ctx)

- Adaptive **hd256 combine** NW + split-count scaling (32k fix)
- int8 MMA path uses adaptive hd256 combine

### Qwen3.6 accuracy fixes

- **SHEXP_ACCUM**: default off on pipelined path (race with MoE routed buffer)
- **GEMV_SIGMOID**: default off; opt-in `=1` (split-k parity)

## Proof of speedup

> ⚠️ Tick the RTX 5090 box **only** if you actually ran the bench on hardware.

- [x] Tested on **RTX 5090** (`sm_120`)

**Qwythos-9B Q4_K_M** — ctx=0, n=128, bs=1, `SPARKINFER_BENCH_DEVICE_LOOP=1` (3-run median, 2026-07-10):

| | decode tok/s |
|---|--:|
| before (main @ ac4a718) | 258.50 |
| after (this PR @ 99a48b6) | 272.80 |
| **delta** | **+5.5%** |

```text
main:   258.72, 258.59, 258.61  → median 258.50 tok/s
branch: 272.85, 272.85, 272.84  → median 272.80 tok/s
model:  /workspace/models35/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf
```

Gain stacks **#323** (Q4_K down requant on main) with branch GDN/FFN/attn work. Component sweep (branch, vs disabling each flag): MMVQ −16.8%, PQ −11.2%, DOWN_MMVQ −8.2%, GDN_PIPE −2.5%.

## Accuracy (vs llama.cpp, `bench/scripts/accuracy.sh`)

| Model | top-1 vs llama | KL (nats) | Gate (≥0.90 / ≤0.20) |
|-------|----------------|-----------|----------------------|
| Qwythos | 0.960 (96/100) | 0.0184 | PASS |
| Qwen3.6 | 0.960 (96/100) | 0.0174 | PASS |

Branch vs main argmax (teacher-forced, fixed seed): Qwen3.6 **100/100**, Qwythos **99/100**.

## Commits (14)

- perf(gdn): fuse conv_split + l2_norm into per-head kernel
- perf(gdn): fused conv_split+l2_norm + GEMV+sigmoid (×2)
- perf: GDN conv+l2norm + GEMV+sigmoid + shared-exp accum
- perf(attn): adaptive hd256 combine NW + split-count (32k)
- perf(attn): adaptive hd256 combine in int8 MMA path
- perf(qwen35): quantized dense FFN fast path for Qwen3.5-9B hybrid
- fix(qwen35): restore Qwythos correctness for dense hybrid decode
- perf(qwen35): enable dense FFN fuse by default
- fix(qwen35): restore Qwen3.6 accuracy after shared-expert fusions
- perf(gdn): tune GDN for H=4096 (Qwythos)
- perf(qwen35): restore dense FFN fuse after Q4_K down requant
- fix(gdn): correct qkv+z fused MMVQ row mapping
- chore: move qwen36 bisect script to `runtime/scripts/`

## Test plan

- [x] Rebased onto `upstream/main` (includes #323)
- [x] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j` on RTX 5090
- [x] Qwythos decode bench (3-run median, ctx=0)
- [x] `accuracy.sh` vs llama.cpp — Qwythos + Qwen3.6
- [x] Qwen3.6 argmax bisect (`runtime/scripts/bisect_qwen36_acc.sh`)
- [x] `sensitive-paths-guard` — no `bench/scripts/` edits
