### PR TITLE
Make Polaris TDX the default eval path

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -18,6 +18,9 @@ EVAL_SSH_PORT=50200
 # BIDIR=1          # Qwen3.5 + Qwen3.6 bidirectional eval (default; set 0 for legacy single-model)
 # TRIPLE=1          # legacy alias for BIDIR=1
 # PRIMARY_QUANT=Q4_K_M   # Qwen3.5 quant: Q4_K_M | Q8_0 | BF16
+# POLARIS=1         # Polaris TDX verifiable receipts (default; set 0 to disable)
+# POLARIS_API_KEY=  # required for TDX attest (https://polaris.computer)
+# POLARIS_API_BASE=https://polaris.computer
 
 # --- Qwythos / Qwen3.5-9B (triple-eval primary) ---
 # QWYTHOS_REPO=empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF
@@ -32,4 +35,3 @@ EVAL_SSH_PORT=50200
 # --- optional ---
 # HF_TOKEN=
 # OPENAI_API_KEY=
-# POLARIS_API_KEY=

--- a/eval/README.md
+++ b/eval/README.md
@@ -94,6 +94,25 @@ python eval/vast_eval.py --ssh HOST:PORT --bidir --primary-quant Q4_K_M --ref ma
 ./eval/run_bot.sh --bidir
 ```
 
+## Polaris TDX receipts (default)
+
+Eval runs through **Polaris** by default (`POLARIS=1`). The GPU box collects an unsigned
+attestation via `eval/polaris/judge.py`; the bot host submits it to Polaris for Intel TDX
+verification and uploads the signed receipt with the eval log.
+
+```bash
+# .env.eval
+POLARIS=1
+POLARIS_API_KEY=pi_sk_...
+POLARIS_API_BASE=https://polaris.computer
+
+./eval/run_bot.sh              # Polaris on (default)
+./eval/run_bot.sh --no-polaris # legacy unsigned path
+./eval/run_polaris_test.sh     # end-to-end smoke test
+```
+
+Set `POLARIS=0` in `.env.eval` or pass `--no-polaris` to disable.
+
 ## Legacy dual/triple modes
 
 `--dual` and `--triple` are aliases for `--bidir`. The old Qwen3-30B guard paths

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -971,7 +971,9 @@ def main():
                     choices=["Q4_K_M", "Q8_0", "BF16"],
                     help="[--triple] Qwythos GGUF quant (default Q4_K_M)")
     ap.add_argument("--polaris", action="store_true",
-                    help="generate a Polaris verifiable receipt for each eval")
+                    help="generate a Polaris verifiable receipt for each eval (default: on)")
+    ap.add_argument("--no-polaris", action="store_true",
+                    help="disable Polaris TDX receipts (overrides POLARIS=1)")
     ap.add_argument("--only-pr", type=int, default=0,
                     help="evaluate only this PR number (must be open)")
     ap.add_argument("--reeval", action="store_true",
@@ -982,6 +984,10 @@ def main():
     if os.environ.get("BIDIR", "1") != "0" and not any(
             a in sys.argv for a in ("--bidir", "--triple", "--dual")):
         args.bidir = True
+    if args.no_polaris:
+        args.polaris = False
+    elif not args.polaris and os.environ.get("POLARIS", "1") != "0":
+        args.polaris = True
     if not ssh_box_enabled() and not args.instance:
         ap.error("--instance is required for vast.ai transport (or set EVAL_TRANSPORT=ssh + EVAL_SSH_HOST)")
     if ssh_box_enabled():

--- a/eval/run_bot.sh
+++ b/eval/run_bot.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # Run the sparkinfer PR eval bot once (interactive). Sources .env.eval for transport + secrets.
 #
-#   ./eval/run_bot.sh              # full run on SSH box (or vast if EVAL_TRANSPORT=vast)
+#   ./eval/run_bot.sh              # full run on SSH box (Polaris TDX on by default)
 #   ./eval/run_bot.sh --dry-run    # poll PRs + print plan, no GPU eval
 #   ./eval/run_bot.sh --bidir      # Qwen3.5 + Qwen3.6 bidirectional eval (default)
-#   ./eval/run_bot.sh --triple     # legacy alias for --bidir
+#   ./eval/run_bot.sh --no-polaris # skip Polaris TDX receipts
 set -euo pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -22,6 +22,7 @@ fi
 
 export SSH_KEY="${SSH_KEY:-$HOME/.ssh/speedy}"
 export PATH="/usr/local/bin:/usr/bin:/bin:${HOME}/.local/bin:$PATH"
+export PYTHONUNBUFFERED=1
 
 BOT_ARGS=(
   --frontier "${FRONTIER:-285}"
@@ -36,9 +37,11 @@ if printf '%s\n' "$@" | grep -qx -- '--bidir' || \
    [ -n "${DUAL:-}" ] || printf '%s\n' "$@" | grep -qxE -- '--triple|--dual'; then
   BOT_ARGS+=(--bidir --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
 fi
-if [ -n "${POLARIS:-}" ] || printf '%s\n' "$@" | grep -qx -- '--polaris'; then
+if printf '%s\n' "$@" | grep -qx -- '--no-polaris' || [ "${POLARIS:-1}" = "0" ]; then
+  BOT_ARGS+=(--no-polaris)
+else
   BOT_ARGS+=(--polaris)
 fi
 
-echo "[$(date -u +%FT%TZ)] eval bot (EVAL_TRANSPORT=${EVAL_TRANSPORT:-vast}, SSH_KEY=$SSH_KEY)"
+echo "[$(date -u +%FT%TZ)] eval bot (EVAL_TRANSPORT=${EVAL_TRANSPORT:-vast}, POLARIS=${POLARIS:-1}, SSH_KEY=$SSH_KEY)"
 exec python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}" "$@"

--- a/eval/run_bot_cron.sh
+++ b/eval/run_bot_cron.sh
@@ -9,6 +9,7 @@
 #   EVAL_TRANSPORT=ssh   — fixed GPU box via EVAL_SSH_HOST / EVAL_SSH_PORT (no vast billing)
 export HOME="${HOME:-/home/speedy}"
 export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin:$PATH"
+export PYTHONUNBUFFERED=1
 export SPARKINFER_AUTOMERGE=1   # auto-merge the round's merge-first winner (guarded). Set 0 to disable.
 
 exec 9>/tmp/sparkinfer_bot.lock
@@ -38,5 +39,10 @@ if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
   BOT_ARGS+=(--instance "${VAST_INSTANCE:-42682383}")
 fi
 [ "${BIDIR:-${TRIPLE:-1}}" != "0" ] && BOT_ARGS+=(--bidir --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
+if [ "${POLARIS:-1}" = "0" ]; then
+  BOT_ARGS+=(--no-polaris)
+else
+  BOT_ARGS+=(--polaris)
+fi
 
 python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}"

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -265,10 +265,16 @@ def main():
     ap.add_argument("--pinned", action="store_true", help="the --reuse box is the stable default: NEVER destroy it; on bring-up failure exit PINNED_RETRY_RC for up to REUSE_MAX_RETRIES runs before provisioning a new box (pinned kept)")
     ap.add_argument("--destroy-on-error", action="store_true", help="destroy (not just stop) the instance if the eval produces no result")
     ap.add_argument("--polaris", action="store_true",
-                    help="generate a Polaris verifiable receipt (unsigned attestation from eval box)")
+                    help="generate a Polaris verifiable receipt (default: on)")
+    ap.add_argument("--no-polaris", action="store_true",
+                    help="disable Polaris TDX receipts (overrides POLARIS=1)")
     args = ap.parse_args()
     if args.triple or args.dual:
         args.bidir = True
+    if args.no_polaris:
+        args.polaris = False
+    elif not args.polaris and os.environ.get("POLARIS", "1") != "0":
+        args.polaris = True
 
     if not args.ssh and ssh_box_enabled():
         args.ssh = ssh_box_arg()


### PR DESCRIPTION
## Summary
- Enable Polaris TDX verifiable receipts by default (`POLARIS=1`) in `pr_eval_bot.py`, `vast_eval.py`, `run_bot.sh`, and `run_bot_cron.sh`.
- Add `--no-polaris` / `POLARIS=0` opt-out.
- Document Polaris flow in `eval/README.md` and `.env.eval.example`.
- Set `PYTHONUNBUFFERED=1` for live bot logs.

## Test plan
- [x] `./eval/run_bot.sh` passes `--polaris` with `POLARIS=1` in `.env.eval`
- [ ] CI guard passes


Made with [Cursor](https://cursor.com)