### PR TITLE
Speed up Polaris eval bot pipeline

### DIFF
--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -19,9 +19,11 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/_common.sh"
 source "$HERE/_qwythos.sh"
 
-REF=""; CEILING=0
+REF=""; CEILING=0; BASELINE_ONLY=0
 while [ $# -gt 0 ]; do case "$1" in
-  --ref) shift; REF="$1" ;; --ceiling) shift; CEILING="$1" ;; *) ;;
+  --ref) shift; REF="$1" ;; --ceiling) shift; CEILING="$1" ;;
+  --baseline-only) BASELINE_ONLY=1 ;;
+  *) ;;
 esac; shift; done
 
 export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"
@@ -31,14 +33,6 @@ if [ -n "$REF" ] && [ -z "${SI_NO_CHECKOUT:-}" ]; then
   git -C "$ROOT" fetch -q origin "$REF" 2>/dev/null || true; git -C "$ROOT" checkout -q "$REF"
 fi
 COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
-
-echo ">> [build] submission ($COMMIT) from source (sm_$ARCH) — shared by both models ..." >&2
-rm -rf "$ROOT/build"
-if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
-  echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
-  printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": 0, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false, "mode": "bidir"}\n' "$COMMIT"
-  exit 0
-fi
 
 P35_FILE="$(qwythos_quant_file)"
 P35_REPO="${QWYTHOS_REPO}"
@@ -53,6 +47,18 @@ P36_DIR="${PRIMARY36_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}36}"
 
 QUANT="${PRIMARY_QUANT:-Q4_K_M}"
 echo ">> bidir: Qwen3.5=$P35_FILE (quant=$QUANT, ctx=128/512/4k) + Qwen3.6=$P36_FILE (ctx=128/512/4k/16k/32k)" >&2
+
+if [ "$BASELINE_ONLY" = 1 ]; then
+  echo ">> bidir baseline-only: ctx speed sweep on origin/main (skip PR build + dual eval)" >&2
+else
+  echo ">> [build] submission ($COMMIT) from source (sm_$ARCH) — shared by both models ..." >&2
+  rm -rf "$ROOT/build"
+  if ! NO_PREBUILT=1 ensure_sparkinfer "$ARCH"; then
+    echo ">> build FAILED — submission does not compile (sm_$ARCH)" >&2
+    printf 'RESULT_JSON {"commit": "%s", "tps": 0, "top1": 0, "kl": 99, "frontier_tps": 0, "label": "REJECT", "reason": "build failed (does not compile)", "pass": false, "mode": "bidir"}\n' "$COMMIT"
+    exit 0
+  fi
+fi
 
 reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
 
@@ -148,6 +154,35 @@ G35_512="${SPARKINFER_G35_GUARD_512_BASELINE:-$B35_512}"
 G35_4K="${SPARKINFER_G35_GUARD_4K_BASELINE:-$B35_4K}"
 
 P_DIFF_REF="${SPARKINFER_DIFFICULTY_REF_OVERRIDE:-365.85}"
+
+# Bot same-box baseline: one build + ctx speed sweep only (skip 4× evaluate.sh + accuracy).
+if [ "$BASELINE_ONLY" = 1 ]; then
+  echo ">> bidir baseline-only: ctx sweep complete — skipping full dual-model eval" >&2
+  B36_128="${B36_128:-0}"; B36_512="${B36_512:-0}"; B36_4K="${B36_4K:-0}"
+  B36_16K="${B36_16K:-0}"; B36_32K="${B36_32K:-0}"
+  B35_128="${B35_128:-0}"; B35_512="${B35_512:-0}"; B35_4K="${B35_4K:-0}"
+  QUANT="${PRIMARY_QUANT:-Q4_K_M}"
+  python3 - <<PY
+import json
+commit = "$COMMIT"
+quant = "$QUANT"
+def stub(tps, ctx128, ctx512, ctx4k, ctx16k=0, ctx32k=0):
+    return {"pass": True, "label": "BASELINE", "tps": float(tps or ctx128 or 0),
+            "top1": 1.0, "kl": 0.0, "ctx_128_tps": float(ctx128 or 0),
+            "ctx_512_tps": float(ctx512 or 0), "ctx_4096_tps": float(ctx4k or 0),
+            "ctx_16384_tps": float(ctx16k or 0), "ctx_32768_tps": float(ctx32k or 0),
+            "guard_128_pass": True, "guard_512_pass": True, "guard_4k_pass": True,
+            "guard_16k_pass": True, "guard_32k_pass": True}
+s35 = stub("$B35_128", "$B35_128", "$B35_512", "$B35_4K")
+s36 = stub("$B36_128", "$B36_128", "$B36_512", "$B36_4K", "$B36_16K", "$B36_32K")
+out = {"pass": True, "label": "BASELINE", "commit": commit, "mode": "bidir", "model": "bidir",
+       "tps": s36["tps"], "top1": 1.0, "kl": 0.0, "primary_quant": quant,
+       "score_qwen35": s35, "score_qwen36": s36, "pass_qwen35": True, "pass_qwen36": True,
+       "label_qwen35": "BASELINE", "label_qwen36": "BASELINE"}
+print("RESULT_JSON " + json.dumps(out))
+PY
+  exit 0
+fi
 
 # --- Direction A: optimize Qwen3.5, guard Qwen3.6 -----------------------------------------------
 PRIMARY35_JSON="$(run_model primary-qwen35 "$P35_FILE" "$P35_REPO" "$P35_TOK" 0 \

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -71,6 +71,57 @@ def _vast_eval_transport_args(instance_id):
         return ["--ssh", ssh_box_arg()]
     return ["--reuse", str(current_instance(instance_id))]
 
+
+def _bidir_baseline_args(q36, q35):
+    """Guard baseline CLI args for vast_eval.py bidir runs."""
+    return [
+        "--p35-guard-128-baseline", str(q35["128"]),
+        "--p35-guard-512-baseline", str(q35["512"]),
+        "--p35-guard-4k-baseline",  str(q35["4k"]),
+        "--p-guard-128-baseline", str(q36["128"]),
+        "--p-guard-512-baseline", str(q36["512"]),
+        "--p-guard-4k-baseline",  str(q36["4k"]),
+        "--p-guard-16k-baseline", str(q36["16k"]),
+        "--p-guard-32k-baseline", str(q36["32k"]),
+        "--g36-guard-128-baseline", str(q36["128"]),
+        "--g36-guard-512-baseline", str(q36["512"]),
+        "--g36-guard-4k-baseline",  str(q36["4k"]),
+        "--g36-guard-16k-baseline", str(q36["16k"]),
+        "--g36-guard-32k-baseline", str(q36["32k"]),
+        "--g35-guard-128-baseline", str(q35["128"]),
+        "--g35-guard-512-baseline", str(q35["512"]),
+        "--g35-guard-4k-baseline",  str(q35["4k"]),
+        "--p-llama-128-baseline", str(q36["llama128"]),
+        "--p-llama-512-baseline", str(q36["llama512"]),
+        "--p-llama-4k-baseline",  str(q36["llama4k"]),
+    ]
+
+
+def _apply_bidir_ctx_from_bres(bres, q36, q35):
+    """Fill QWEN36_BASE / QWYTHOS_BASE from bidir RESULT_JSON; return True if both models covered."""
+    ctx_map = {
+        "128": "ctx_128_tps", "512": "ctx_512_tps", "4k": "ctx_4096_tps",
+        "16k": "ctx_16384_tps", "32k": "ctx_32768_tps",
+    }
+
+    def _fill(score, store, keys):
+        if not score:
+            return False
+        ok = False
+        for k in keys:
+            v = float(score.get(ctx_map[k]) or 0)
+            if v > 0:
+                store[k] = v
+                ok = True
+        if "128" in keys and float(score.get("tps") or 0) > 0:
+            store["128"] = float(score["tps"])
+            ok = True
+        return ok
+
+    got36 = _fill(bres.get("score_qwen36"), q36, ("128", "512", "4k", "16k", "32k"))
+    got35 = _fill(bres.get("score_qwen35"), q35, ("128", "512", "4k"))
+    return got36 and got35
+
 # Subsystem buckets for the deterministic area:<name> label (from a PR's top-level changed
 # dirs — no AI). Categorization/display only: SN74 scoring is speedup-only (the eval:* tier),
 # NOT a per-subsystem budget.
@@ -1224,7 +1275,8 @@ def main():
             "--ref", "origin/main", "--frontier", "0", "--ceiling", str(args.ceiling),
             "--eval-mode", "longctx", "--keep"]
     if args.bidir:
-        bcmd += ["--bidir", "--primary-quant", args.primary_quant]
+        bcmd += ["--bidir", "--primary-quant", args.primary_quant, "--baseline-only"]
+        bcmd += _bidir_baseline_args(QWEN36_BASE, QWYTHOS_BASE)
     if PINNED_INSTANCE and not ssh_box_enabled() and str(base_iid) == PINNED_INSTANCE:
         bcmd.append("--pinned")
     box_label = ssh_box_arg() if ssh_box_enabled() else f"instance {base_iid}"
@@ -1292,59 +1344,65 @@ def main():
               f"Aborting; NO PRs graded. Re-run on a warm, stable box.")
         return
 
-    # Bidir mode: bench both model mains on the box (Qwen3.5 at 128/512/4k only).
-    if args.bidir and _vast_sh:
-        ssh_ep = ssh_box_endpoint()
-        if ssh_ep:
-            host, port = ssh_ep
-        elif _vast_endpoint and _vast_info_of:
-            import vastai
-            v = vastai.VastAI()
-            info = _vast_info_of(v, base_iid)
-            host, port = _vast_endpoint(info) if info else (None, None)
-        else:
-            host = port = None
-
-        def _ctx_sweep(host, port, gguf, label, store, ctx_list=None):
-            B = "/root/sparkinfer/build/runtime/qwen3_gguf_bench"
-            tps = {}
-            sweep = ctx_list or [("128", 0), ("512", 512), ("4k", 4096),
-                                 ("16k", 16384), ("32k", 32768)]
-            for lbl, ctx in sweep:
-                cmd = f"export PATH=/usr/local/cuda/bin:$PATH; {B} '{gguf}' 128 {ctx}"
-                r = _vast_sh(host, port, cmd, timeout=600)
-                m = re.search(r"decode\s+tg\s*:\s*([0-9.]+)", r.stdout + r.stderr)
-                tps[lbl] = float(m.group(1)) if m else 0.0
-                print(f"    [{label}] ctx={lbl} tps={tps[lbl]}")
-            if tps.get("128", 0) > 0:
-                store["128"] = tps["128"]
-                if "512" in tps:
-                    store["512"] = tps["512"] if tps["512"] > 0 else round(tps["128"] * 0.98, 2)
-                if "4k" in tps:
-                    store["4k"]  = tps["4k"]  if tps["4k"]  > 0 else round(tps["128"] * 0.93, 2)
-                if "16k" in tps:
-                    store["16k"] = tps["16k"] if tps["16k"] > 0 else store.get("16k", 0)
-                if "32k" in tps:
-                    store["32k"] = tps["32k"] if tps["32k"] > 0 else store.get("32k", 0)
-                parts = " ".join(f"{k}={store[k]}" for k in ("128", "512", "4k", "16k", "32k") if k in store)
-                print(f"  {label} same-box main: {parts} tok/s")
+    # Bidir: reuse ctx speeds from the baseline RESULT_JSON (no duplicate SSH sweeps).
+    if args.bidir:
+        if _apply_bidir_ctx_from_bres(bres, QWEN36_BASE, QWYTHOS_BASE):
+            print(f"  Qwen3.6 same-box main: 128={QWEN36_BASE['128']} 512={QWEN36_BASE['512']} "
+                  f"4k={QWEN36_BASE['4k']} 16k={QWEN36_BASE['16k']} 32k={QWEN36_BASE['32k']} tok/s")
+            print(f"  Qwythos ({args.primary_quant}) same-box main: "
+                  f"128={QWYTHOS_BASE['128']} 512={QWYTHOS_BASE['512']} 4k={QWYTHOS_BASE['4k']} tok/s")
+        elif _vast_sh:
+            ssh_ep = ssh_box_endpoint()
+            if ssh_ep:
+                host, port = ssh_ep
+            elif _vast_endpoint and _vast_info_of:
+                import vastai
+                v = vastai.VastAI()
+                info = _vast_info_of(v, base_iid)
+                host, port = _vast_endpoint(info) if info else (None, None)
             else:
-                print(f"  {label} bench failed — using config defaults")
+                host = port = None
 
-        if host and port:
-            _ctx_sweep(host, port, "/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
-                       "Qwen3.6", QWEN36_BASE)
-            qmap = {
-                "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
-                "Q8_0":   "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
-                "BF16":   "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf",
-            }
-            qfile = qmap[args.primary_quant]
-            _ctx_sweep(host, port, f"/workspace/models35/{qfile}",
-                       f"Qwythos ({args.primary_quant})", QWYTHOS_BASE,
-                       ctx_list=[("128", 0), ("512", 512), ("4k", 4096)])
-        else:
-            print(f"  could not reach eval box for model bench — using config defaults")
+            def _ctx_sweep(host, port, gguf, label, store, ctx_list=None):
+                B = "/root/sparkinfer/build/runtime/qwen3_gguf_bench"
+                tps = {}
+                sweep = ctx_list or [("128", 0), ("512", 512), ("4k", 4096),
+                                     ("16k", 16384), ("32k", 32768)]
+                for lbl, ctx in sweep:
+                    cmd = f"export PATH=/usr/local/cuda/bin:$PATH; {B} '{gguf}' 128 {ctx}"
+                    r = _vast_sh(host, port, cmd, timeout=600)
+                    m = re.search(r"decode\s+tg\s*:\s*([0-9.]+)", r.stdout + r.stderr)
+                    tps[lbl] = float(m.group(1)) if m else 0.0
+                    print(f"    [{label}] ctx={lbl} tps={tps[lbl]}")
+                if tps.get("128", 0) > 0:
+                    store["128"] = tps["128"]
+                    if "512" in tps:
+                        store["512"] = tps["512"] if tps["512"] > 0 else round(tps["128"] * 0.98, 2)
+                    if "4k" in tps:
+                        store["4k"]  = tps["4k"]  if tps["4k"]  > 0 else round(tps["128"] * 0.93, 2)
+                    if "16k" in tps:
+                        store["16k"] = tps["16k"] if tps["16k"] > 0 else store.get("16k", 0)
+                    if "32k" in tps:
+                        store["32k"] = tps["32k"] if tps["32k"] > 0 else store.get("32k", 0)
+                    parts = " ".join(f"{k}={store[k]}" for k in ("128", "512", "4k", "16k", "32k") if k in store)
+                    print(f"  {label} same-box main: {parts} tok/s")
+                else:
+                    print(f"  {label} bench failed — using config defaults")
+
+            if host and port:
+                _ctx_sweep(host, port, "/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf",
+                           "Qwen3.6", QWEN36_BASE)
+                qmap = {
+                    "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
+                    "Q8_0":   "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
+                    "BF16":   "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf",
+                }
+                qfile = qmap[args.primary_quant]
+                _ctx_sweep(host, port, f"/workspace/models35/{qfile}",
+                           f"Qwythos ({args.primary_quant})", QWYTHOS_BASE,
+                           ctx_list=[("128", 0), ("512", 512), ("4k", 4096)])
+            else:
+                print(f"  could not reach eval box for model bench — using config defaults")
 
     # Run all pending evals on the SAME instance: pass --keep so vast_eval.py never stops/destroys
     # the box mid-queue. The bot stops the instance once after ALL PRs finish (or if the instance
@@ -1372,25 +1430,7 @@ def main():
             cmd[cmd.index("--keep"):cmd.index("--keep")] = [
                 "--bidir",
                 "--primary-quant", args.primary_quant,
-                "--p35-guard-128-baseline", str(QWYTHOS_BASE["128"]),
-                "--p35-guard-512-baseline", str(QWYTHOS_BASE["512"]),
-                "--p35-guard-4k-baseline",  str(QWYTHOS_BASE["4k"]),
-                "--p-guard-128-baseline", str(QWEN36_BASE["128"]),
-                "--p-guard-512-baseline", str(QWEN36_BASE["512"]),
-                "--p-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
-                "--p-guard-16k-baseline", str(QWEN36_BASE["16k"]),
-                "--p-guard-32k-baseline", str(QWEN36_BASE["32k"]),
-                "--g36-guard-128-baseline", str(QWEN36_BASE["128"]),
-                "--g36-guard-512-baseline", str(QWEN36_BASE["512"]),
-                "--g36-guard-4k-baseline",  str(QWEN36_BASE["4k"]),
-                "--g36-guard-16k-baseline", str(QWEN36_BASE["16k"]),
-                "--g36-guard-32k-baseline", str(QWEN36_BASE["32k"]),
-                "--g35-guard-128-baseline", str(QWYTHOS_BASE["128"]),
-                "--g35-guard-512-baseline", str(QWYTHOS_BASE["512"]),
-                "--g35-guard-4k-baseline",  str(QWYTHOS_BASE["4k"]),
-                "--p-llama-128-baseline", str(QWEN36_BASE["llama128"]),
-                "--p-llama-512-baseline", str(QWEN36_BASE["llama512"]),
-                "--p-llama-4k-baseline",  str(QWEN36_BASE["llama4k"])]
+            ] + _bidir_baseline_args(QWEN36_BASE, QWYTHOS_BASE)
         if PINNED_INSTANCE and not ssh_box_enabled() and str(cur_iid) == PINNED_INSTANCE:
             cmd.append("--pinned")  # never destroy the pin; retry-then-fallback on bring-up failure
         if args.polaris:

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -268,6 +268,8 @@ def main():
                     help="generate a Polaris verifiable receipt (default: on)")
     ap.add_argument("--no-polaris", action="store_true",
                     help="disable Polaris TDX receipts (overrides POLARIS=1)")
+    ap.add_argument("--baseline-only", action="store_true",
+                    help="bidir: measure same-box ctx speeds only (bot baseline; skip full dual eval)")
     args = ap.parse_args()
     if args.triple or args.dual:
         args.bidir = True
@@ -588,50 +590,69 @@ def main():
         # Difficulty compensation ON (Option B): as the frontier pulls past llama.cpp each further %
         # gain is harder, so label.py scales the label tier up (raw % + significance gate unchanged).
         # Governance-tunable via SPARKINFER_DIFFICULTY_{K,REF,MAX}; applies from new evals onward.
+        baseline_flag = " --baseline-only" if args.baseline_only else ""
         if args.bidir:
-            ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
-                  f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
-                  f"SPARKINFER_EVAL_MODE={args.eval_mode} PRIMARY_QUANT={args.primary_quant} "
-                  f"SPARKINFER_P35_GUARD_128_BASELINE={args.p35_guard_128_baseline} "
-                  f"SPARKINFER_P35_GUARD_512_BASELINE={args.p35_guard_512_baseline} "
-                  f"SPARKINFER_P35_GUARD_4K_BASELINE={args.p35_guard_4k_baseline} "
-                  f"SPARKINFER_P36_GUARD_128_BASELINE={args.p_guard_128_baseline} "
-                  f"SPARKINFER_P36_GUARD_512_BASELINE={args.p_guard_512_baseline} "
-                  f"SPARKINFER_P36_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
-                  f"SPARKINFER_P36_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
-                  f"SPARKINFER_P36_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
-                  f"SPARKINFER_G36_GUARD_128_BASELINE={args.g36_guard_128_baseline} "
-                  f"SPARKINFER_G36_GUARD_512_BASELINE={args.g36_guard_512_baseline} "
-                  f"SPARKINFER_G36_GUARD_4K_BASELINE={args.g36_guard_4k_baseline} "
-                  f"SPARKINFER_G36_GUARD_16K_BASELINE={args.g36_guard_16k_baseline} "
-                  f"SPARKINFER_G36_GUARD_32K_BASELINE={args.g36_guard_32k_baseline} "
-                  f"SPARKINFER_G35_GUARD_128_BASELINE={args.g35_guard_128_baseline} "
-                  f"SPARKINFER_G35_GUARD_512_BASELINE={args.g35_guard_512_baseline} "
-                  f"SPARKINFER_G35_GUARD_4K_BASELINE={args.g35_guard_4k_baseline} "
-                  f"SPARKINFER_P35_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
-                  f"SPARKINFER_P35_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
-                  f"SPARKINFER_P35_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
-                  f"SPARKINFER_P36_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
-                  f"SPARKINFER_P36_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
-                  f"SPARKINFER_P36_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
-                  f"SPARKINFER_P36_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
-                  f"SPARKINFER_P36_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
-                  f"MODELS_DIR=/workspace/models36 QWYTHOS_MODELS_DIR=/workspace/models35 "
-                  f"PRIMARY36_MODELS_DIR=/workspace/models36 "
-                  f"LLAMACPP_DIR={LLAMACPP_DIR} "
-                  f"bench/scripts/evaluate_bidir.sh --ref {args.ref} "
-                  f"--ceiling {args.ceiling}")
+            eval_cmd = (f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
+                        f"SPARKINFER_EVAL_MODE={args.eval_mode} PRIMARY_QUANT={args.primary_quant} "
+                        f"SPARKINFER_P35_GUARD_128_BASELINE={args.p35_guard_128_baseline} "
+                        f"SPARKINFER_P35_GUARD_512_BASELINE={args.p35_guard_512_baseline} "
+                        f"SPARKINFER_P35_GUARD_4K_BASELINE={args.p35_guard_4k_baseline} "
+                        f"SPARKINFER_P36_GUARD_128_BASELINE={args.p_guard_128_baseline} "
+                        f"SPARKINFER_P36_GUARD_512_BASELINE={args.p_guard_512_baseline} "
+                        f"SPARKINFER_P36_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
+                        f"SPARKINFER_P36_GUARD_16K_BASELINE={args.p_guard_16k_baseline} "
+                        f"SPARKINFER_P36_GUARD_32K_BASELINE={args.p_guard_32k_baseline} "
+                        f"SPARKINFER_G36_GUARD_128_BASELINE={args.g36_guard_128_baseline} "
+                        f"SPARKINFER_G36_GUARD_512_BASELINE={args.g36_guard_512_baseline} "
+                        f"SPARKINFER_G36_GUARD_4K_BASELINE={args.g36_guard_4k_baseline} "
+                        f"SPARKINFER_G36_GUARD_16K_BASELINE={args.g36_guard_16k_baseline} "
+                        f"SPARKINFER_G36_GUARD_32K_BASELINE={args.g36_guard_32k_baseline} "
+                        f"SPARKINFER_G35_GUARD_128_BASELINE={args.g35_guard_128_baseline} "
+                        f"SPARKINFER_G35_GUARD_512_BASELINE={args.g35_guard_512_baseline} "
+                        f"SPARKINFER_G35_GUARD_4K_BASELINE={args.g35_guard_4k_baseline} "
+                        f"SPARKINFER_P35_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
+                        f"SPARKINFER_P35_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
+                        f"SPARKINFER_P35_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
+                        f"SPARKINFER_P36_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
+                        f"SPARKINFER_P36_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
+                        f"SPARKINFER_P36_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "
+                        f"SPARKINFER_P36_LLAMA_16K_BASELINE={args.p_llama_16k_baseline} "
+                        f"SPARKINFER_P36_LLAMA_32K_BASELINE={args.p_llama_32k_baseline} "
+                        f"MODELS_DIR=/workspace/models36 QWYTHOS_MODELS_DIR=/workspace/models35 "
+                        f"PRIMARY36_MODELS_DIR=/workspace/models36 "
+                        f"LLAMACPP_DIR={LLAMACPP_DIR} "
+                        f"bench/scripts/evaluate_bidir.sh --ref {args.ref} "
+                        f"--ceiling {args.ceiling}{baseline_flag}")
+            p36_gguf = "/workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf"
+            qmap = {"Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
+                    "Q8_0": "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
+                    "BF16": "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf"}
+            p35_gguf = f"/workspace/models35/{qmap[args.primary_quant]}"
         else:
-            ev = (f"cd /root/sparkinfer && git fetch -q origin main && git checkout -q origin/main -- bench/scripts && "
-                  f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} SPARKINFER_DIFFICULTY_BOOST=1 "
-                  f"SPARKINFER_EVAL_MODE={args.eval_mode} "
-                  f"SPARKINFER_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
-                  f"SPARKINFER_GUARD_512_BASELINE={args.guard_512_baseline} "
-                  f"SPARKINFER_GUARD_4K_BASELINE={args.guard_4k_baseline} "
-                  f"SPARKINFER_GUARD_16K_BASELINE={args.guard_16k_baseline} "
-                  f"SPARKINFER_GUARD_32K_BASELINE={args.guard_32k_baseline} "
-                  f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
-                  f"bench/scripts/evaluate.sh --ref {args.ref} --frontier {args.frontier} --ceiling {args.ceiling}")
+            eval_cmd = (f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} SPARKINFER_DIFFICULTY_BOOST=1 "
+                        f"SPARKINFER_EVAL_MODE={args.eval_mode} "
+                        f"SPARKINFER_GUARD_128_BASELINE={args.guard_128_baseline or args.guard_2k_baseline} "
+                        f"SPARKINFER_GUARD_512_BASELINE={args.guard_512_baseline} "
+                        f"SPARKINFER_GUARD_4K_BASELINE={args.guard_4k_baseline} "
+                        f"SPARKINFER_GUARD_16K_BASELINE={args.guard_16k_baseline} "
+                        f"SPARKINFER_GUARD_32K_BASELINE={args.guard_32k_baseline} "
+                        f"MODELS_DIR=/workspace/models LLAMACPP_DIR={LLAMACPP_DIR} "
+                        f"bench/scripts/evaluate.sh --ref {args.ref} --frontier {args.frontier} --ceiling {args.ceiling}")
+            p36_gguf = f"{MODEL_PATH}"
+            p35_gguf = ""
+        harness = ("cd /root/sparkinfer && git fetch -q origin main && "
+                   "git checkout -q origin/main -- bench/scripts && ")
+        if args.polaris and not args.baseline_only:
+            guard_arg = f" --guard-model-file {p35_gguf}" if p35_gguf else ""
+            ev = (f"{harness}({eval_cmd}) > /tmp/spark_eval.log 2>&1; "
+                  f"cat /tmp/spark_eval.log; "
+                  f"python3 eval/polaris/judge.py --from-stdin "
+                  f"--model-file {p36_gguf}{guard_arg} "
+                  f"--build-dir /root/sparkinfer/build/runtime "
+                  f"--sparkinfer-root /root/sparkinfer "
+                  f"< /tmp/spark_eval.log")
+        else:
+            ev = harness + eval_cmd
         got_result = False
         if bare_metal:
             ev = BOX_CUDA_ENV + ev


### PR DESCRIPTION
## Summary
- Wire `judge.py --from-stdin` in `vast_eval.py` when `--polaris` (post-hoc; no second GPU eval pass)
- Add `evaluate_bidir.sh --baseline-only` for bot same-box baseline (ctx sweep only, no 4× full eval)
- Drop duplicate `_ctx_sweep` when baseline `RESULT_JSON` already has per-context speeds
- Pass measured guard baselines into PR evals so `evaluate_bidir` skips auto-measure

## Root cause
Polaris was not breaking batching — `judge.py` was never called. Slowness came from running full bidir eval on `origin/main` for baseline, then re-benchmarking 8 contexts via SSH `_ctx_sweep`.

## Test plan
- [ ] `./eval/run_bot.sh --dry-run` still polls PRs
- [ ] Baseline phase completes in ~5 min (not ~30+ min)
- [ ] PR eval emits `POLARIS_ATTESTATION` line
- [ ] Per-PR eval still produces `RESULT_JSON` with bidir scores


Made with [Cursor](https://cursor.com)