### PR TITLE
perf(qwen35): requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)

### DIFF
--- a/kernels/csrc/cuda/quant/ffn_down_requant.cu
+++ b/kernels/csrc/cuda/quant/ffn_down_requant.cu
@@ -1,0 +1,117 @@
+// Requantize a dense-FFN down projection from Q6_K to Q4_K once at model load, then
+// decode it on-read via the existing int8 dp4a Q4_K MMVQ. On Qwythos (32 dense layers,
+// down = [4096,12288] Q6_K) the down weights are ~1.3 GB of the per-token weight read;
+// dropping them from 6.5625 to 4.5 bits/weight trims ~31% of that read (a load-time-only
+// cost). Gated by SPARKINFER_DOWN_REQUANT_Q4K in the runtime; the down projection is
+// accuracy-sensitive, so the fit below is validated against the KL/top-1 gate.
+//
+// The per-group fit is a min/max seed followed by a fixed-offset least-squares scale
+// refinement — a standard affine-quantizer construction, packed into the ggml Q4_K
+// super-block layout that si_vec_dot_q4_K consumes (y = d*sc*q - dmin*m).
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+
+namespace sparkinfer { namespace kernels {
+
+// Matches si_block_q4_K: {d,dmin fp16}{8x 6-bit scale + 8x 6-bit min, packed}{256x 4-bit}.
+struct sdq_q4k_block { __half2 dm; unsigned char sc[12]; unsigned char nib[128]; };
+
+__device__ __forceinline__ int sdq_round(float v) { return (int)floorf(v + 0.5f); }
+
+// Fit one 32-value group to y ~= s*q + o with q in [0,15]. The Q4_K reconstruction is
+// y = d*sc*q - dmin*m, so the group offset o = -negmin is constrained <= 0. Seeds from
+// min/max, then refines the scale in closed form against the fixed offset (two passes).
+__device__ void sdq_fit_group(const float* v, float* out_scale, float* out_negmin,
+                              unsigned char* code) {
+    float lo = v[0], hi = v[0];
+    #pragma unroll
+    for (int i = 1; i < 32; ++i) { lo = fminf(lo, v[i]); hi = fmaxf(hi, v[i]); }
+    if (lo > 0.f) lo = 0.f;                       // offset must be <= 0
+    if (hi <= lo) {                               // degenerate (constant / all-zero) group
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) code[i] = 0;
+        *out_scale = 0.f; *out_negmin = -lo; return;
+    }
+    float s = (hi - lo) / 15.f;
+    #pragma unroll
+    for (int pass = 0; pass < 2; ++pass) {
+        const float inv = 1.f / s;
+        float num = 0.f, den = 0.f;               // least-squares: s = sum(q*(v-lo)) / sum(q*q)
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) {
+            int q = sdq_round(inv * (v[i] - lo));
+            q = q < 0 ? 0 : (q > 15 ? 15 : q);
+            code[i] = (unsigned char)q;
+            num += (float)q * (v[i] - lo);
+            den += (float)q * (float)q;
+        }
+        if (den > 0.f) s = num / den;             // refine scale, keep offset (lo) fixed
+    }
+    *out_scale = s; *out_negmin = -lo;
+}
+
+// One thread per 256-value super-block (8 groups of 32).
+__global__ void sdq_requant_kernel(const __nv_bfloat16* __restrict__ src,
+                                   sdq_q4k_block* __restrict__ dst, long n_super) {
+    const long sb = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (sb >= n_super) return;
+    const __nv_bfloat16* base = src + sb * 256;
+    float grpS[8], grpM[8];
+    unsigned char q[256];
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) {
+        float buf[32];
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) buf[i] = __bfloat162float(base[g * 32 + i]);
+        sdq_fit_group(buf, &grpS[g], &grpM[g], q + g * 32);
+    }
+    float topS = 0.f, topM = 0.f;
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) { topS = fmaxf(topS, grpS[g]); topM = fmaxf(topM, grpM[g]); }
+    const float d = topS / 63.f, dmin = topM / 63.f;
+    unsigned char s6[8], m6[8];
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) {
+        int a = d > 0.f ? sdq_round(grpS[g] / d) : 0;    a = a < 0 ? 0 : (a > 63 ? 63 : a);
+        int b = dmin > 0.f ? sdq_round(grpM[g] / dmin) : 0; b = b < 0 ? 0 : (b > 63 ? 63 : b);
+        s6[g] = (unsigned char)a; m6[g] = (unsigned char)b;
+    }
+    sdq_q4k_block blk;
+    blk.dm = __floats2half2_rn(d, dmin);
+    // ggml get_scale_min_k4 inverse packing (the single valid layout for si_vec_dot_q4_K).
+    #pragma unroll
+    for (int i = 0; i < 12; ++i) blk.sc[i] = 0;
+    #pragma unroll
+    for (int g = 0; g < 4; ++g) { blk.sc[g] = s6[g]; blk.sc[g + 4] = m6[g]; }
+    #pragma unroll
+    for (int g = 4; g < 8; ++g) {
+        blk.sc[g + 4] = (unsigned char)((s6[g] & 0xF) | ((m6[g] & 0xF) << 4));
+        blk.sc[g - 4] |= (unsigned char)(((s6[g] >> 4) & 3) << 6);
+        blk.sc[g]     |= (unsigned char)(((m6[g] >> 4) & 3) << 6);
+    }
+    #pragma unroll
+    for (int i = 0; i < 128; ++i) blk.nib[i] = 0;
+    #pragma unroll
+    for (int g = 0; g < 8; ++g)
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) {
+            const int byte = (g >> 1) * 32 + i;
+            if (g & 1) blk.nib[byte] |= (unsigned char)(q[g * 32 + i] << 4);
+            else       blk.nib[byte] |= (unsigned char)(q[g * 32 + i] & 0xF);
+        }
+    dst[sb] = blk;
+}
+
+// n_values must be a multiple of 256.
+void launch_ffn_down_requant_q4k(const void* src_bf16, void* dst_q4k, long n_values,
+                                 cudaStream_t stream) {
+    const long n_super = n_values / 256;
+    const int threads = 128;
+    const long blocks = (n_super + threads - 1) / threads;
+    sdq_requant_kernel<<<(unsigned)blocks, threads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(src_bf16),
+        reinterpret_cast<sdq_q4k_block*>(dst_q4k), n_super);
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/quant.h
+++ b/kernels/include/sparkinfer/kernels/quant.h
@@ -33,4 +33,9 @@ void launch_transpose_bf16(const void* src, void* dst, int rows, int cols,
 void launch_transpose3d_bf16(const void* src, void* dst, int E, int A, int B,
                              cudaStream_t stream = nullptr);        // [E,A,B]->[E,B,A]
 
+// Requantize a dense-FFN down projection bf16 -> Q4_K (ggml super-block layout consumed
+// by si_vec_dot_q4_K). Load-time only; n_values must be a multiple of 256.
+void launch_ffn_down_requant_q4k(const void* src_bf16, void* dst_q4k, long n_values,
+                                 cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -972,6 +972,30 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         s.owned.push_back(d);
         return d;
     };
+    // Dense-FFN down: keep GGUF Q6_K by default, or (SPARKINFER_DOWN_REQUANT_Q4K=1)
+    // dequant->requant to Q4_K at load so decode reads 4.5 vs 6.5 bits/weight. The
+    // Q6_K upload is freed after the requant; qtype flips to 12 on success.
+    auto dev_quant_down = [&](const std::string& name, int& qtype) -> const void* {
+        const void* q6 = dev_quant(name, qtype);
+        static int req = -1;
+        if (req < 0) { const char* e = getenv("SPARKINFER_DOWN_REQUANT_Q4K"); req = (e && e[0] == '1') ? 1 : 0; }
+        if (!req || qtype != 14 || !q6) return q6;
+        const GGUFTensor* t = g.tensor(name);
+        const long nv = t->n_values;
+        if (nv % 256 != 0) return q6;
+        void* deq = nullptr;
+        if (cudaMalloc(&deq, (size_t)nv * 2) != cudaSuccess) return q6;
+        kernels::launch_gguf_dequant(14, q6, deq, nv, s.stream);
+        void* q4 = nullptr;
+        if (cudaMalloc(&q4, (size_t)(nv / 256) * 144) != cudaSuccess) { cudaFree(deq); return q6; }
+        kernels::launch_ffn_down_requant_q4k(deq, q4, nv, s.stream);
+        cudaStreamSynchronize(s.stream);
+        cudaFree(deq);
+        if (!s.owned.empty() && s.owned.back() == q6) { s.owned.pop_back(); cudaFree((void*)q6); }
+        s.owned.push_back(q4);
+        qtype = 12;
+        return q4;
+    };
     // dense weight -> bf16 (optionally transpose [out,in] -> [in,out])
     auto dense = [&](const std::string& name, bool transpose) -> const void* {
         const GGUFTensor* t = g.tensor(name);
@@ -1102,7 +1126,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 !expect_dims(b + "ffn_down.weight", {c.moe_ffn, H})) return false;
             w.gate_q = dev_quant(b + "ffn_gate.weight", w.gate_qtype);
             w.up_q   = dev_quant(b + "ffn_up.weight", w.up_qtype);
-            w.down_q = dev_quant(b + "ffn_down.weight", w.down_qtype);
+            w.down_q = dev_quant_down(b + "ffn_down.weight", w.down_qtype);
         } else {
         if (!expect_dims(b + "ffn_gate_inp.weight", {H, c.n_experts})) return false;
         w.router_w = dense(b + "ffn_gate_inp.weight", false);   // native [E,H] for GEMV


### PR DESCRIPTION
## Summary

Load-time requantize of Qwen3.5 dense-hybrid FFN down weights Q6_K→Q4_K (gated by `SPARKINFER_DOWN_REQUANT_Q4K=1`) so decode uses the existing Q4_K MMVQ path and reads ~31% less down-projection bandwidth; default path unchanged.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) the **decode tok/s** table shows a **real end-to-end improvement** (`after > before`,
> filled from `bench/scripts/bench.sh` — *not* an isolated-kernel microbenchmark). A ticked box
> with an empty/placeholder table gets `needs-benchmark` and is **not** evaluated (no point spending
> a GPU when there's no claimed decode gain).
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 249.25 |
| after (this PR) | 261.52 |

```text
# Qwythos-9B Q4_K_M — RTX 5090, cb939a9 baseline + this PR, ctx=128, n=128, bs=1
# Model: /workspace/models9/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf
# Median of 3 runs per config (qwen3_gguf_bench)

=== before (main @ cb939a9, SPARKINFER_DOWN_REQUANT_Q4K=0) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
decode tg    : 249.25 tok/s  (median, n=128, ctx=128, bs=1)  # runs: 249.43 249.25 248.91
decode tg    : 253.05 tok/s  (median, n=128, ctx=0,   bs=1)  # runs: 253.05 253.12 253.01

=== after (this PR, SPARKINFER_DOWN_REQUANT_Q4K=1) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
decode tg    : 261.52 tok/s  (median, n=128, ctx=128, bs=1)  # runs: 260.52 261.52 262.14
decode tg    : 265.60 tok/s  (median, n=128, ctx=0,   bs=1)

# Additional contexts (after, median x3):
# ctx=512:  260.52 tok/s (before 248.05)
# ctx=4096: 248.51 tok/s (before 235.86)
```

## Test plan

- [x] Build `qwen3_gguf_bench` / `qwen3_gguf_score` on RTX 5090 (`sm_120`)
- [x] Qwythos decode sweep ctx 0/128/512/4096 with `SPARKINFER_DOWN_REQUANT_Q4K=0` vs `=1`
- [x] `accuracy_compare.py` vs llama.cpp (seed=42, 271 positions): top-1 94.8% → 93.0%, KL 0.026 → 0.029 (both pass ≥90% gate)
- [ ] Eval-bot triple sweep on merge (Qwythos primary guard)