### PR TITLE
perf(qwen35): tune dense split-K and int8 graph capture

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -989,6 +989,12 @@ static inline int down_mmvq_pdl() {
     return v;
 }
 
+static inline int dense_top1_down_splitk(int current, int top_k, const char* specific_env) {
+    if (top_k == 1 && !getenv("SPARKINFER_DOWN_SPLITK_S") && !getenv(specific_env))
+        return 8;
+    return current;
+}
+
 template <typename Kernel, typename... Args>
 static inline void launch_mmvq_down_kernel(
     int pdl, dim3 grid, dim3 block, cudaStream_t stream, Kernel kernel, Args... args
@@ -1158,9 +1164,10 @@ void launch_moe_expert_ffn_q4k(
         const int pdl = down_mmvq_pdl();
         quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
             h_scratch, hq8, nqb, pdl);
-        // split-K MMVQ down (default S=4): S warps/row -> S*H warps in flight, hiding
-        // the bs=1 occupancy stall the one-warp kernel hits. Falls back to one-warp if disabled.
-        const int S = down_splitk_s_q6();
+        // split-K MMVQ down: S warps/row -> S*H warps in flight, hiding the bs=1
+        // occupancy stall the one-warp kernel hits. Dense top-1 defaults to S=8 unless
+        // an explicit split-K env override is set; routed MoE keeps its existing default.
+        const int S = dense_top1_down_splitk(down_splitk_s_q6(), top_k, "SPARKINFER_DOWN_SPLITK_S_Q6");
         if (S > 1) {
             const int RPB = WPB / S;
             dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
@@ -1187,7 +1194,7 @@ void launch_moe_expert_ffn_q4k(
         const int pdl = down_mmvq_pdl();
         quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
             h_scratch, hq8, nqb, pdl);
-        const int S = down_splitk_s_q4();
+        const int S = dense_top1_down_splitk(down_splitk_s_q4(), top_k, "SPARKINFER_DOWN_SPLITK_S_Q4");
         if (S > 1) {
             const int RPB = WPB / S;
             dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
@@ -1216,7 +1223,7 @@ void launch_moe_expert_ffn_q4k(
         const int pdl = down_mmvq_pdl();
         quant_h_q8_1_kernel<<<(nqb + (qthreads >> 5) - 1) / (qthreads >> 5), qthreads, 0, stream>>>(
             h_scratch, hq8, nqb, pdl);
-        const int S = down_splitk_s_q5();
+        const int S = dense_top1_down_splitk(down_splitk_s_q5(), top_k, "SPARKINFER_DOWN_SPLITK_S_Q5");
         if (S > 1) {
             const int RPB = WPB / S;
             dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -110,6 +110,7 @@ struct Qwen35Model::Impl {
     cudaGraphExec_t cu_exec{};
     bool graph_ready = false;
     bool bench_feedback_graph = false;
+    int graph_attn_mode = -1;  // host-side flash-decode dispatch class captured in cu_graph
 
     // scratch (bf16)
     bf16 *x, *xn, *q, *k, *v, *attn, *ao, *h, *hn, *routed, *shared;
@@ -330,6 +331,28 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 cudaGraphExecDestroy(s.cu_exec); cudaGraphDestroy(s.cu_graph); s.graph_ready = false;
             }
         }
+    }
+    // launch_flash_decode_split chooses its scalar-vs-MMA implementation on the host
+    // while the graph is captured. If int8 KV is enabled for a long-context run, a graph
+    // captured at a short seqlen would otherwise keep replaying the scalar int8 path after
+    // the sequence is large enough for the tensor-core path. Recapture at that mode change.
+    static int famma_graph = -1;
+    if (famma_graph < 0) {
+        const char* e = getenv("SPARKINFER_FAMMA");
+        famma_graph = (e && e[0] == '0') ? 0 : 1;
+    }
+    int attn_graph_mode = 0;
+    if (famma_graph && s.kv->int8_kv() && s.kv->block_size() == 16 &&
+        c.n_kv_heads > 0 && c.n_q_heads == c.n_kv_heads * 8) {
+        const int mma_chunk = (s.n_splits > 0) ? (seqlen + s.n_splits - 1) / s.n_splits : 0;
+        attn_graph_mode = (seqlen > 512 && mma_chunk >= 32) ? 2 : 1;
+    }
+    if (s.graph_ready && attn_graph_mode != s.graph_attn_mode) {
+        cu(cudaGraphExecDestroy(s.cu_exec), "graph recapture destroy exec");
+        cu(cudaGraphDestroy(s.cu_graph), "graph recapture destroy graph");
+        s.cu_exec = nullptr;
+        s.cu_graph = nullptr;
+        s.graph_ready = false;
     }
     if (c.hybrid && position == 0) {
         cu(cudaMemsetAsync(s.lin_state, 0,
@@ -785,6 +808,7 @@ int Qwen35Model::forward_token(int token_id, int position) {
     cu(cudaStreamEndCapture(st, &s.cu_graph), "end capture");
     cu(cudaGraphInstantiate(&s.cu_exec, s.cu_graph, 0), "graph instantiate");
     s.graph_ready = true;
+    s.graph_attn_mode = attn_graph_mode;
     cu(cudaGraphLaunch(s.cu_exec, st), "graph launch (first)");
 
     cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");


### PR DESCRIPTION
## Summary

Retunes dense top-1 MMVQ down split-K to use the existing S=8 path when no split-K override is set, while leaving routed MoE defaults unchanged. Also recaptures the CUDA graph when int8-KV flash decode crosses from the scalar host-dispatch path to the tensor-core/MMA path at long context.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) the **decode tok/s** table shows a **real end-to-end improvement** (`after > before`,
> filled from `bench/scripts/bench.sh` — *not* an isolated-kernel microbenchmark). A ticked box
> with an empty/placeholder table gets `needs-benchmark` and is **not** evaluated (no point spending
> a GPU when there's no claimed decode gain).
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main) | 259.80 |
| after (this PR) | 272.63 |

```text
# before: origin/main 966ad99
# note: current base ac4a718 only differs by dashboard/index.html from this measured runtime/kernel baseline
# command: NO_PREBUILT=1 ./bench/scripts/bench.sh /workspace/models35/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf --tokens 128 --ctx 0
>> GPU arch: sm_120

=== sparkinfer — decode (n=128, ctx=0, bs=1) ===
>> using local build
[gguf] layer 0 loaded
[gguf] layer 31 loaded
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
loading /workspace/models35/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf (native GGUF, experts quantized) ...

=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 8.2 GB
max seq      : 2048
decode tg    : 259.80 tok/s  (3.8 ms/token, n=128, ctx=0, bs=1)
GPU          : 47°C · 294 W · 2655 MHz (peak under load)

# after: ecad70b
# command: NO_PREBUILT=1 ./bench/scripts/bench.sh /workspace/models35/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf --tokens 128 --ctx 0
>> GPU arch: sm_120

=== sparkinfer — decode (n=128, ctx=0, bs=1) ===
[gguf] layer 0 loaded
[gguf] layer 31 loaded
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
loading /workspace/models35/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf (native GGUF, experts quantized) ...

=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 8.2 GB
max seq      : 2048
decode tg    : 272.63 tok/s  (3.7 ms/token, n=128, ctx=0, bs=1)
GPU          : 48°C · 297 W · 2805 MHz (peak under load)

# additional long-context evidence for the int8-KV graph recapture path
# before: origin/main 966ad99
# note: current base ac4a718 only differs by dashboard/index.html from this measured runtime/kernel baseline
# command: NO_PREBUILT=1 ./bench/scripts/bench.sh /workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --tokens 128 --ctx 8192
decode tg    : 384.40 tok/s  (2.6 ms/token, n=128, ctx=8192, bs=1)

# after: ecad70b
# command: NO_PREBUILT=1 ./bench/scripts/bench.sh /workspace/models36/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf --tokens 128 --ctx 8192
decode tg    : 402.65 tok/s  (2.5 ms/token, n=128, ctx=8192, bs=1)
```