### PR TITLE
dashboard: correct Qwen3.5 ctx bars after scaling bug

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -2849,30 +2849,30 @@ window.SPARKINFER = {
   "qwen35": {
     "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
     "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
-    "frontier_tps": 281.63,
+    "frontier_tps": 272.36,
     "baseline_tps": 256.95,
     "ref_name": "llama.cpp",
     "ref_tps": 224.91,
     "token_match": 0.9613,
     "kl": 0.0141,
-    "note": "PR #323 merged · same-box main baseline + eval:S @128 ctx · RTX 5090",
+    "note": "post-main rebench 2026-07-10 (RTX 5090, 3-rep median); ctx bars corrected from inflated _scaled_context_tps compounding",
     "ctx": [
       {
         "label": "128",
         "color": "#D14D72",
-        "tps": 348.97,
+        "tps": 272.36,
         "ref_tps": 224.91
       },
       {
         "label": "512",
         "color": "#7B5DFF",
-        "tps": 343.25,
+        "tps": 270.59,
         "ref_tps": 225.1
       },
       {
         "label": "4k",
         "color": "#0E8A16",
-        "tps": 331.66,
+        "tps": 262.91,
         "ref_tps": 224.68
       }
     ]

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -2848,30 +2848,30 @@
   "qwen35": {
     "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
     "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
-    "frontier_tps": 281.63,
+    "frontier_tps": 272.36,
     "baseline_tps": 256.95,
     "ref_name": "llama.cpp",
     "ref_tps": 224.91,
     "token_match": 0.9613,
     "kl": 0.0141,
-    "note": "PR #323 merged · same-box main baseline + eval:S @128 ctx · RTX 5090",
+    "note": "post-main rebench 2026-07-10 (RTX 5090, 3-rep median); ctx bars corrected from inflated _scaled_context_tps compounding",
     "ctx": [
       {
         "label": "128",
         "color": "#D14D72",
-        "tps": 348.97,
+        "tps": 272.36,
         "ref_tps": 224.91
       },
       {
         "label": "512",
         "color": "#7B5DFF",
-        "tps": 343.25,
+        "tps": 270.59,
         "ref_tps": 225.1
       },
       {
         "label": "4k",
         "color": "#0E8A16",
-        "tps": 331.66,
+        "tps": 262.91,
         "ref_tps": 224.68
       }
     ]

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -794,7 +794,12 @@ def _upsert_context_baselines(data, e):
     return changed
 
 def _upsert_qwen35_ctx(data, sub):
-    """Refresh Qwen3.5 per-context sparkinfer bars from a merged bidir score_qwen35 block."""
+    """Refresh Qwen3.5 per-context sparkinfer bars from a merged bidir score_qwen35 block.
+
+    Uses same-box measured tok/s directly (vs llama.cpp ref anchors). Unlike Qwen3.6
+    context_baselines, do not apply _scaled_context_tps — that compounded merge ratios and
+    inflated ctx bars above frontier_tps.
+    """
     q35 = data.setdefault("qwen35", {})
     ctx_rows = {r.get("label"): r for r in q35.get("ctx") or []}
     changed = False
@@ -802,12 +807,13 @@ def _upsert_qwen35_ctx(data, sub):
         measured = sub.get(CTX_SERIES[ctx]["metric"])
         if measured is None:
             continue
-        guard = sub.get(CTX_SERIES[ctx]["guard"])
-        old = (ctx_rows.get(meta["label"]) or {}).get("tps") or q35.get("frontier_tps") or 0
-        new = _scaled_context_tps(old, measured, guard) or round(float(measured), 2)
+        new = round(float(measured), 2)
+        old = round(float((ctx_rows.get(meta["label"]) or {}).get("tps") or 0), 2)
+        if old and new < old:
+            continue
         row = ctx_rows.get(meta["label"])
         if row:
-            if round(float(row.get("tps") or 0), 2) < new:
+            if old != new:
                 row["tps"] = new
                 row["color"] = CTX_SERIES[ctx]["color"]
                 changed = True

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -138,6 +138,35 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual(out["landed_longctx"][0]["ctx"], 4096)
         self.assertFalse(out["landed"])
 
+    def test_qwen35_ctx_uses_measured_tps_without_scaling(self):
+        data = {
+            "qwen35": {
+                "frontier_tps": 281.63,
+                "ctx": [
+                    {"label": "128", "tps": 281.63, "ref_tps": 224.91},
+                    {"label": "512", "tps": 277.69, "ref_tps": 225.1},
+                    {"label": "4k", "tps": 264.06, "ref_tps": 224.68},
+                ],
+            }
+        }
+        sub = {
+            "ctx_128_tps": 284.47,
+            "ctx_512_tps": 281.34,
+            "ctx_4096_tps": 267.66,
+            "guard_128_baseline": 257.47,
+            "guard_512_baseline": 254.27,
+            "guard_4k_baseline": 242.49,
+        }
+        bot._upsert_qwen35_ctx(data, sub)
+        by = {r["label"]: r["tps"] for r in data["qwen35"]["ctx"]}
+        self.assertEqual(by["128"], 284.47)
+        self.assertEqual(by["512"], 281.34)
+        self.assertEqual(by["4k"], 267.66)
+        # Second merge with same measured must not compound ratios.
+        bot._upsert_qwen35_ctx(data, sub)
+        by2 = {r["label"]: r["tps"] for r in data["qwen35"]["ctx"]}
+        self.assertEqual(by2, by)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Corrects inflated `qwen35.ctx` bars (349/343/332 → 272/271/263 tok/s) from RTX 5090 3-rep median rebench on current main
- Fixes `_upsert_qwen35_ctx` to store same-box measured tok/s directly instead of compounding `_scaled_context_tps` ratios on every merge
- Adds unit test ensuring repeated merges do not inflate ctx bars

## Test plan
- [x] `python3 eval/test_pr_eval_bot.py`
- [ ] Merge and verify dashboard Qwen3.5 vs-llama card shows ~272 tok/s @128 ctx


Made with [Cursor](https://cursor.com)