### PR TITLE
release: v0.4.0 — Qwen3.5 + three models past llama.cpp

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -19,7 +19,8 @@ EVAL_SSH_PORT=50200
 # TRIPLE=1          # legacy alias for BIDIR=1
 # PRIMARY_QUANT=Q4_K_M   # Qwen3.5 quant: Q4_K_M | Q8_0 | BF16
 # POLARIS=1         # Polaris TDX verifiable receipts (default; set 0 to disable)
-# POLARIS_API_KEY=  # required for TDX attest (https://polaris.computer)
+# POLARIS_API_KEY=  # TDX attest (https://polaris.computer); preferred when available
+# SPARKINFER_POLARIS_PRIVATE_KEY=  # base64 Ed25519 fallback when TDX is down
 # POLARIS_API_BASE=https://polaris.computer
 
 # --- Qwythos / Qwen3.5-9B (triple-eval primary) ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,69 @@
 Notable changes to sparkinfer. Format loosely follows [Keep a Changelog](https://keepachangelog.com);
 versions track the GitHub [releases](https://github.com/gittensor-ai-lab/sparkinfer/releases).
 
+## [0.4.0] — 2026-07-11
+
+This release adds **Qwen3.5-9B (Qwythos)** as a first-class target and locks in **three-model** decode:
+**Qwen3-MoE**, **Qwen3.6-35B-A3B**, and **Qwen3.5-9B** — all beating llama.cpp on the same RTX 5090
+box. Qwen3.5 landed in under a day and is already **20%+ faster than llama.cpp** at 128/512/4k context;
+Qwen3.6 holds the **30%+ long-context lead** from v0.3.8 with no regression.
+
+### 🆕 Qwen3.5 (Qwythos-9B) — +24% past llama.cpp in one day
+
+Dense hybrid Gated-DeltaNet + full-attention · 9B · hd256 · Q4_K_M. Same RTX 5090, 128 generated tokens,
+`qwen3_gguf_bench` (3-rep median):
+
+| context | sparkinfer | llama.cpp | delta |
+|---|---:|---:|---:|
+| **128-token decode** | **279.8 tok/s** | 224.91 tok/s | **+24%** |
+| **512-context decode** | **277.9 tok/s** | 225.10 tok/s | **+23%** |
+| **4k-context decode** | **270.1 tok/s** | 224.68 tok/s | **+20%** |
+
+Landed in a single sprint: dense-hybrid loader, FFN down Q6→Q4 requant at load (#323), split-K + int8
+graph capture (#324), GQA-4 shared-KV tiles (#326), and bidirectional eval against Qwen3.6 guards.
+**`SPARKINFER_DOWN_REQUANT_Q4K` now defaults ON** (set `=0` to keep native Q6_K reads).
+
+### 🏁 Three models — all ahead of llama.cpp @128
+
+| model | sparkinfer @128 | llama.cpp | delta |
+|---|---:|---:|---:|
+| **Qwen3-MoE (30B-A3B)** | **480.7 tok/s** | 365.85 tok/s | **+31%** |
+| **Qwen3.6-35B-A3B** | **424.9 tok/s** | 275.81 tok/s | **+54%** |
+| **Qwen3.5-9B (Qwythos)** | **279.8 tok/s** | 224.91 tok/s | **+24%** |
+
+Qwen3.6 long-context ladder unchanged vs v0.3.8 (post-#300 MMA correctness rebench):
+
+| context | sparkinfer | llama.cpp | delta |
+|---|---:|---:|---:|
+| **128-token decode** | **424.9 tok/s** | 275.81 tok/s | **+54%** |
+| **512-context decode** | **420.1 tok/s** | 275.61 tok/s | **+52%** |
+| **4k-context decode** | **403.1 tok/s** | 276.30 tok/s | **+46%** |
+| **16k-context decode** | **386.4 tok/s** | 280.66 tok/s | **+38%** |
+| **32k-context decode** | **364.3 tok/s** | 279.83 tok/s | **+30%** |
+
+### Performance — landed since v0.3.8
+
+- **#318** (`eval:M`) — quantized dense FFN + GDN fusions + hd256 32k combine
+- **#323** (`eval:S`) — requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)
+- **#324** (`eval:M`) — tune dense split-K and int8 graph capture for Qwen3.5
+- **#326** (`eval:XS`) — GQA-4 shared-KV tile for Qwythos dense attention
+- **#331** (`eval:XS`) — complete MoE gate_up→quant_h→down PDL chain for bs=1 decode
+- **#300** — hd256 MMA correctness fix in flash-decode split (no perf regression on release rebench)
+
+### Eval — Polaris Ed25519 fallback
+
+When Intel TDX is unavailable (Polaris API timeout/404), the eval bot falls back to **Ed25519-signed
+receipts** if `SPARKINFER_POLARIS_PRIVATE_KEY` is set — eval logs still ship a verifiable receipt.
+
+### The proof, in four layers
+
+1. **Speed** — three models, each **20–54%** over llama.cpp on the same GPU/GGUF; Qwen3.6 long-context lead held.
+2. **Correctness** — top-1 **≥ 0.95**, KL **≈ 0.01** vs llama.cpp on held-out prompts.
+3. **Same-box baseline** — bidirectional Qwen3.5 + Qwen3.6 eval with per-model no-regression guards.
+4. **Polaris** — TDX receipts when available; Ed25519 fallback when the enclave API is down.
+
+**Verified:** RTX 5090 · Qwen3.5 **280 tok/s** @128 · Qwen3.6 **425 tok/s** @128 · Qwen3-MoE **481 tok/s** @128.
+
 ## [0.3.8] — 2026-07-09
 
 This release adds **hardware-rooted trust** to the eval pipeline and locks in the Qwen3.6 speed story

--- a/eval/README.md
+++ b/eval/README.md
@@ -98,17 +98,21 @@ python eval/vast_eval.py --ssh HOST:PORT --bidir --primary-quant Q4_K_M --ref ma
 
 Eval runs through **Polaris** by default (`POLARIS=1`). The GPU box collects an unsigned
 attestation via `eval/polaris/judge.py`; the bot host submits it to Polaris for Intel TDX
-verification and uploads the signed receipt with the eval log.
+verification and uploads the signed receipt with the eval log. When TDX is unavailable (API
+timeout, 404, etc.), the bot falls back to **Ed25519** signing if
+`SPARKINFER_POLARIS_PRIVATE_KEY` is set.
 
 ```bash
 # .env.eval
 POLARIS=1
 POLARIS_API_KEY=pi_sk_...
+SPARKINFER_POLARIS_PRIVATE_KEY=...   # base64, 32 bytes — Ed25519 fallback
 POLARIS_API_BASE=https://polaris.computer
 
 ./eval/run_bot.sh              # Polaris on (default)
 ./eval/run_bot.sh --no-polaris # legacy unsigned path
 ./eval/run_polaris_test.sh     # end-to-end smoke test
+./eval/run_polaris_smoke.sh    # TDX or Ed25519 smoke from saved attestation
 ```
 
 Set `POLARIS=0` in `.env.eval` or pass `--no-polaris` to disable.

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -755,6 +755,54 @@ def _scaled_context_tps(old_tps, measured_tps, guard_tps):
         return round(old_tps * (measured_tps / guard_tps), 2)
     return round(measured_tps, 2)
 
+def _load_polaris_privkey():
+    """Load SparkInfer Ed25519 signing key from SPARKINFER_POLARIS_PRIVATE_KEY (base64, 32 bytes)."""
+    import base64
+    key_b64 = os.environ.get("SPARKINFER_POLARIS_PRIVATE_KEY", "")
+    if not key_b64:
+        return None
+    try:
+        return base64.b64decode(key_b64)
+    except Exception as e:
+        print(f">> Polaris Ed25519 key load failed: {e}")
+        return None
+
+def build_polaris_receipt_from_attestation(attestation, api_key="", privkey=None, pubkey=""):
+    """Build a Polaris receipt: TDX via API when available, else Ed25519 fallback."""
+    if api_key:
+        try:
+            from eval.polaris.receipt import build_polaris_receipt
+            from eval.polaris.client import PolarisClient
+
+            nonce_input = (
+                attestation.get("code", {}).get("commit", "") +
+                attestation.get("references", {}).get("model_sha256", "") +
+                attestation.get("references", {}).get("eval_seed", "")
+            ).encode("utf-8")
+            nonce = hashlib.sha256(nonce_input).hexdigest()[:64]
+            polaris_resp = PolarisClient(api_key).attest_scoring(
+                attestation.get("measurements", {}),
+                nonce,
+                pubkey,
+            )
+            receipt = build_polaris_receipt(polaris_resp, attestation)
+            tee = polaris_resp.get("tee_attestation", {}) or {}
+            intel = (tee.get("verification", {}) or polaris_resp.get("verification", {}) or {}
+                     ).get("intel_verified")
+            print(f">> Polaris TDX: Intel verified={intel}")
+            return receipt
+        except Exception as e:
+            print(f">> Polaris TDX unavailable: {e}")
+            if not privkey:
+                raise
+            print(">> Polaris: falling back to Ed25519 signing")
+    if privkey:
+        from eval.polaris.receipt import build_receipt
+        receipt = build_receipt(attestation, privkey)
+        print(">> Polaris Ed25519: signed with SparkInfer key")
+        return receipt
+    return None
+
 def _upsert_context_baselines(data, e):
     """Update the displayed per-context live baselines from a merged longctx eval.
 
@@ -1149,11 +1197,10 @@ def main():
     }
 
     # --- Polaris verifiable compute ---
-    # Two modes, auto-selected:
-    #   TDX (preferred):  POLARIS_API_KEY is set → scoring runs inside Intel TDX enclave
-    #   Ed25519 (legacy): SPARKINFER_POLARIS_PRIVATE_KEY is set → bot signs attestations
+    # TDX (preferred): POLARIS_API_KEY → scoring inside Intel TDX enclave.
+    # Ed25519 fallback: SPARKINFER_POLARIS_PRIVATE_KEY when TDX is down or unset.
     # The private key NEVER touches the eval box — the bot signs/submits here on the bot host.
-    POLARIS_PRIVKEY = None
+    POLARIS_PRIVKEY = _load_polaris_privkey() if args.polaris else None
     POLARIS_API_KEY = os.environ.get("POLARIS_API_KEY", "")
     POLARIS_PUBKEY = ""  # SparkInfer's Ed25519 public key (used as e2e_pubkey for TDX)
 
@@ -1173,18 +1220,15 @@ def main():
             pass
 
         if POLARIS_API_KEY:
-            print(f">> Polaris TDX enabled — scoring will run inside Intel TDX enclave")
-        else:
-            _key_b64 = os.environ.get("SPARKINFER_POLARIS_PRIVATE_KEY", "")
-            if _key_b64:
-                try:
-                    POLARIS_PRIVKEY = _b64.b64decode(_key_b64)
-                    print(f">> Polaris Ed25519 enabled — receipts will be signed")
-                except Exception as e:
-                    print(f">> Polaris key load failed: {e} — attestations will NOT be signed")
+            if POLARIS_PRIVKEY:
+                print(">> Polaris TDX enabled (Ed25519 fallback if TDX unavailable)")
             else:
-                print(">> Polaris enabled but no POLARIS_API_KEY or SPARKINFER_POLARIS_PRIVATE_KEY set — "
-                      "attestations will be collected but NOT signed")
+                print(">> Polaris TDX enabled — scoring will run inside Intel TDX enclave")
+        elif POLARIS_PRIVKEY:
+            print(">> Polaris Ed25519 enabled — receipts will be signed")
+        else:
+            print(">> Polaris enabled but no POLARIS_API_KEY or SPARKINFER_POLARIS_PRIVATE_KEY set — "
+                  "attestations will be collected but NOT signed")
 
     dash = load_dash()
     frontier = dash["status"]["frontier_tps"] if dash else args.frontier   # live ledger frontier
@@ -1511,36 +1555,12 @@ def main():
             if polaris_line and res:
                 try:
                     attestation = json.loads(polaris_line[len("POLARIS_ATTESTATION "):])
-                    receipt = None
-
-                    if POLARIS_API_KEY:
-                        # --- TDX path: submit scoring to Polaris Intel TDX enclave ---
-                        from eval.polaris.receipt import build_polaris_receipt
-                        from eval.polaris.client import PolarisClient
-
-                        # Nonce binds the attestation to this specific eval
-                        nonce_input = (
-                            attestation.get("code", {}).get("commit", "") +
-                            attestation.get("references", {}).get("model_sha256", "") +
-                            attestation.get("references", {}).get("eval_seed", "")
-                        ).encode("utf-8")
-                        nonce = hashlib.sha256(nonce_input).hexdigest()[:64]
-
-                        client = PolarisClient(POLARIS_API_KEY)
-                        polaris_resp = client.attest_scoring(
-                            attestation.get("measurements", {}),
-                            nonce,
-                            POLARIS_PUBKEY,
-                        )
-                        receipt = build_polaris_receipt(polaris_resp, attestation)
-                        print(f">> Polaris TDX: Intel verified={polaris_resp.get('tee_attestation', {}).get('verification', {}).get('intel_verified')}")
-
-                    elif POLARIS_PRIVKEY:
-                        # --- Ed25519 path: sign attestation with SparkInfer private key ---
-                        from eval.polaris.receipt import build_receipt
-                        receipt = build_receipt(attestation, POLARIS_PRIVKEY)
-                        print(f">> Polaris Ed25519: signed with SparkInfer key")
-
+                    receipt = build_polaris_receipt_from_attestation(
+                        attestation,
+                        api_key=POLARIS_API_KEY,
+                        privkey=POLARIS_PRIVKEY,
+                        pubkey=POLARIS_PUBKEY,
+                    )
                     if receipt:
                         polaris_bundle = {"receipt": receipt, "attestation": attestation}
                         res["polaris_receipt_hash"] = receipt["receipt_id"][:16]

--- a/eval/run_polaris_smoke.sh
+++ b/eval/run_polaris_smoke.sh
@@ -14,29 +14,24 @@ ssh -i "$SSH_KEY" -o BatchMode=yes -p "$PORT" "root@${HOST}" \
 export POLARIS_SMOKE_ATTEST="$ATTEST"
 
 python3 <<'PY'
-import json, hashlib, os, sys
+import json, os, sys
 sys.path.insert(0, os.getcwd())
 a = json.load(open(os.environ.get("POLARIS_SMOKE_ATTEST", "/tmp/polaris_attestation.json")))
-from eval.polaris.client import PolarisClient
-from eval.polaris.receipt import build_polaris_receipt
 pub = next(l.strip() for l in open("eval/polaris/sparkinfer_eval.pub")
            if l.strip() and not l.startswith("#"))
-nonce = hashlib.sha256((
-    a.get("code", {}).get("commit", "") +
-    a.get("references", {}).get("model_sha256", "") +
-    a.get("references", {}).get("eval_seed", "")
-).encode()).hexdigest()[:64]
 print(f">> endpoint: {os.environ.get('POLARIS_API_BASE', 'https://polaris.computer')}/v1/attest")
-resp = PolarisClient(os.environ["POLARIS_API_KEY"]).attest_scoring(
-    a.get("measurements", {}), nonce, pub)
-receipt = build_polaris_receipt(resp, a)
-intel = resp.get("tee_attestation", {}).get("verification", {}).get("intel_verified")
+from eval.pr_eval_bot import build_polaris_receipt_from_attestation, _load_polaris_privkey
+privkey = _load_polaris_privkey()
+receipt = build_polaris_receipt_from_attestation(
+    a, api_key=os.environ.get("POLARIS_API_KEY", ""), privkey=privkey, pubkey=pub)
+intel = receipt.get("tdx", {}).get("verification", {}).get("intel_verified")
 if intel is None:
-    intel = resp.get("verification", {}).get("intel_verified")
+    intel = receipt.get("verification", {}).get("intel_verified")
+is_ed25519 = bool(receipt.get("signature")) and "tdx" not in receipt
 out = "/tmp/polaris_smoke_receipt.json"
 json.dump(receipt, open(out, "w"), indent=2)
-print(f">> Polaris OK: intel_verified={intel} receipt_id={receipt['receipt_id'][:16]}")
+print(f">> Polaris OK: intel_verified={intel} ed25519={is_ed25519} receipt_id={receipt['receipt_id'][:16]}")
 print(f">> receipt: {out}")
-if not intel:
+if not intel and not is_ed25519:
     sys.exit(1)
 PY

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -167,6 +167,36 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         by2 = {r["label"]: r["tps"] for r in data["qwen35"]["ctx"]}
         self.assertEqual(by2, by)
 
+    def test_polaris_tdx_falls_back_to_ed25519(self):
+        from eval.polaris.receipt import generate_keypair, verify_attestation
+
+        priv, _ = generate_keypair()
+        att = {
+            "code": {"commit": "abc1234"},
+            "references": {"model_sha256": "deadbeef", "eval_seed": "seed1"},
+            "measurements": {"tps": 100, "label": "S"},
+        }
+        with mock.patch("eval.polaris.client.PolarisClient") as mock_client_cls:
+            mock_client_cls.return_value.attest_scoring.side_effect = RuntimeError("HTTP 404")
+            receipt = bot.build_polaris_receipt_from_attestation(
+                att, api_key="pi_sk_test", privkey=priv, pubkey="dGVzdA==")
+        self.assertIsNotNone(receipt.get("signature"))
+        self.assertNotIn("tdx", receipt)
+        self.assertTrue(verify_attestation(att, receipt["signature"], receipt["public_key"]))
+
+    def test_polaris_ed25519_only_when_no_api_key(self):
+        from eval.polaris.receipt import generate_keypair
+
+        priv, _ = generate_keypair()
+        att = {
+            "code": {"commit": "def5678"},
+            "references": {"model_sha256": "cafebabe", "eval_seed": "seed2"},
+            "measurements": {"tps": 200, "label": "M"},
+        }
+        receipt = bot.build_polaris_receipt_from_attestation(att, api_key="", privkey=priv)
+        self.assertIsNotNone(receipt.get("signature"))
+        self.assertNotIn("tdx", receipt)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1090,13 +1090,12 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         s.owned.push_back(d);
         return d;
     };
-    // Dense-FFN down: keep GGUF Q6_K by default, or (SPARKINFER_DOWN_REQUANT_Q4K=1)
-    // dequant->requant to Q4_K at load so decode reads 4.5 vs 6.5 bits/weight. The
-    // Q6_K upload is freed after the requant; qtype flips to 12 on success.
+    // Dense-FFN down: Q6_K in GGUF is requantized to Q4_K at load by default (~5% decode on
+    // Qwythos). Set SPARKINFER_DOWN_REQUANT_Q4K=0 to keep native Q6_K reads.
     auto dev_quant_down = [&](const std::string& name, int& qtype) -> const void* {
         const void* q6 = dev_quant(name, qtype);
         static int req = -1;
-        if (req < 0) { const char* e = getenv("SPARKINFER_DOWN_REQUANT_Q4K"); req = (e && e[0] == '1') ? 1 : 0; }
+        if (req < 0) { const char* e = getenv("SPARKINFER_DOWN_REQUANT_Q4K"); req = (e && e[0] == '0') ? 0 : 1; }
         if (!req || qtype != 14 || !q6) return q6;
         const GGUFTensor* t = g.tensor(name);
         const long nv = t->n_values;


### PR DESCRIPTION
## Summary
- Merges #331 via #341 (MoE PDL chain, `eval:XS`)
- Default `SPARKINFER_DOWN_REQUANT_Q4K=ON` for Qwythos (fixes false regression vs release bench)
- Polaris TDX→Ed25519 fallback in eval bot
- CHANGELOG v0.4.0

## Regression gate (RTX 5090 release rebench)
- Qwen3.6: no regression vs v0.3.8 (425 @128, +30% @32k)
- Qwen3-MoE: 481 @128 (+31% vs llama)
- Qwen3.5: 280 @128 (+24% vs llama) with default requant ON

## Test plan
- [x] `python3 eval/test_pr_eval_bot.py`
- [ ] Merge → tag `v0.4.0` → GitHub release