### PR TITLE
perf(attn): grid-target KV-split cap for int8-MMA long-context decode

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -334,6 +334,22 @@ int Qwen35Model::forward_token(int token_id, int position) {
         if ((long)seqlen > 28L * s.split_chunk && (long)seqlen <= 48L * s.split_chunk)
             want = Impl::MAX_NSPLITS;
         if ((long)seqlen > 64L * s.split_chunk) want = Impl::MAX_NSPLITS;
+        // int8-MMA split cap. The tensor-core flash-decode (fa_split_gqa_mma_i8_kernel) runs 5
+        // CTAs/SM; a num_kv_heads*256 grid (the MAX_NSPLITS tier above) spills a partial 2nd wave
+        // (tail) and shrinks the per-split chunk until the QK warps idle (gblk<8). The optimum is a
+        // grid that fills ~3/4 of one occupancy wave and is INDEPENDENT of seqlen — on RTX 5090
+        // (170 SMs) both 16k and 32k decode peak at the same grid (~640, i.e. n_splits 159 at 4 KV
+        // heads). The cap only bites for higher KV-head counts: hd128 Qwen3-MoE (4 KV) -> 159; hd256
+        // (2 KV -> cap 318, above the 256 tier) and short context stay unchanged. Composes with the
+        // banded policy above (it only lowers the MAX_NSPLITS long-context tier for hd128). The
+        // online-softmax combine is exact for any split count, so this is correctness-neutral.
+        if (s.kv->int8_kv() && s.kv->block_size() == 16 && c.head_dim == 128
+            && c.n_kv_heads > 0 && c.n_q_heads == c.n_kv_heads * 8) {
+            static int famma_on = [](){ const char* e = getenv("SPARKINFER_FAMMA"); return (e && e[0] == '0') ? 0 : 1; }();
+            static int nsm = [](){ int n = 0; cudaDeviceGetAttribute(&n, cudaDevAttrMultiProcessorCount, 0); return n > 0 ? n : 132; }();
+            const int cap = (nsm * 5 * 3 / 4) / c.n_kv_heads;   // ~3/4 of a 5-CTA/SM occupancy wave
+            if (famma_on && cap >= 32 && want > cap) want = cap;
+        }
         if (want > Impl::MAX_NSPLITS) want = Impl::MAX_NSPLITS;
         // hd256/GQA-8 occupancy correction (Qwen3.6 full-attention shape specifically): the
         // generic 128/256 thresholds above were tuned around the split kernel's assumed


### PR DESCRIPTION
## Summary

One decode scheduling fix for the int8 tensor-core flash-decode at long context, output-neutral to main (only the KV-work partition changes).

**Grid-target n_splits cap.** The depth-adaptive KV-split count jumps to 256 at >8k context — a value tuned for the older bf16 tile kernel. For the int8-MMA flash-decode (`fa_split_gqa_mma_i8_kernel`, 5 CTAs/SM), 256 over-splits: the `num_kv_heads*256` grid spills a partial 2nd occupancy wave (tail), and the per-split chunk shrinks until the QK warps idle (`gblk<8`). On an nsys node trace the split kernel is ~27% of the 32k-context token and already runs at ~89% of memory bandwidth — so the win is the schedule, not the kernel.

This caps `n_splits` to a grid that fills ~3/4 of one occupancy wave: `(num_sms*5*3/4)/num_kv_heads`. The optimal grid is independent of seqlen — on the RTX 5090 (170 SMs) both 16k and 32k decode peak at grid ~640 (n_splits 159 at 4 KV heads). The cap only bites for higher KV-head counts: hd128 Qwen3-MoE (4 KV) -> 159; hd256 (2 KV -> cap 318, above the 256 tier) and short context (<8k, n_splits 32/128) are unchanged. The online-softmax combine is exact for any split count, so this is correctness-neutral.

A/B toggle: `SPARKINFER_NSPLITS=256` restores the pre-cap fixed split count for the comparison below.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `bench/scripts/bench.sh`, `Qwen3-30B-A3B-Q4_K_M.gguf`, 128 decode tokens):

| | decode tok/s (32k) |
|---|--:|
| before (main) | 257.4 |
| after (this PR) | 287.1 |

Same-box A/B, both built on current main (v0.4.0), 2 reps each:

```text
# ctx=16384: before 324.4 -> after 350.6  (+8.1%)
# ctx=32768: before 257.4 -> after 287.1  (+11.5%)

-- ctx=16384 (before / after) --
324.83 350.74
324.02 350.52
-- ctx=32768 --
257.47 287.65
257.34 286.64
```

128 / 512 / 4k are unchanged — the cap does not engage below 8k (int8 KV + the MMA path start at ctx>=8192). Correctness: the split count is a KV-work partition; the log-sum-exp combine is exact for any n_splits (main already ships 128 at 4k, 256 at 16k), so the attention output is unchanged up to float reduction order.

## Relation to open PRs

The n_splits grid-target cap is original — no open PR does it. The only file touched is `runtime/src/models/qwen35.cpp`, shared with several open PRs (#329, #308, #294, #285, #283, #272, #267), but the change is a small self-contained addition to the depth-adaptive split block. Added-line containment against every one of those (and every merged/closed PR on this file) is <=14.3% — a single shared `}`. No kernel changes.
