### PR TITLE
governance: cap difficulty boost at 2× (was 4×)

### DIFF
--- a/bench/scripts/label.py
+++ b/bench/scripts/label.py
@@ -60,7 +60,7 @@ BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
 DIFF_BOOST = os.environ.get("SPARKINFER_DIFFICULTY_BOOST", "0") == "1"
 DIFF_K     = float(os.environ.get("SPARKINFER_DIFFICULTY_K",   "8"))
 DIFF_REF   = float(os.environ.get("SPARKINFER_DIFFICULTY_REF", "365.85"))  # llama.cpp 128-tok tok/s
-DIFF_MAX   = float(os.environ.get("SPARKINFER_DIFFICULTY_MAX", "4"))
+DIFF_MAX   = float(os.environ.get("SPARKINFER_DIFFICULTY_MAX", "2"))
 
 def difficulty_mult(frontier):
     if not DIFF_BOOST or DIFF_REF <= 0:

--- a/bench/scripts/test_label.py
+++ b/bench/scripts/test_label.py
@@ -81,6 +81,19 @@ class LabelPolicyTest(unittest.TestCase):
         self.assertGreaterEqual(res["effective_pct"], 10.0)
         self.assertLess(res["effective_pct"], 18.0)
 
+    def test_difficulty_boost_default_cap_is_two_x(self):
+        # Default SPARKINFER_DIFFICULTY_MAX=2: same raw gain as above, but capped boost -> lower tier.
+        res = score(484.79, frontier=469.13, ceiling=366.0, top1=0.9612, kl=0.0175,
+                    commit="c30bf58",
+                    env={"SPARKINFER_DIFFICULTY_BOOST": "1",
+                         "SPARKINFER_DIFFICULTY_REF": "365.85",
+                         "SPARKINFER_DIFFICULTY_K": "8"})
+        self.assertEqual(res["label"], "M")
+        self.assertEqual(res["difficulty_mult"], 2.0)
+        self.assertEqual(res["pct_over_frontier"], 3.3)
+        self.assertGreaterEqual(res["effective_pct"], 6.0)
+        self.assertLess(res["effective_pct"], 10.0)
+
     def test_long_context_metadata_is_preserved_in_verdict(self):
         prov = {
             "eval_mode": "longctx",

--- a/eval/sim_difficulty.py
+++ b/eval/sim_difficulty.py
@@ -11,7 +11,7 @@ journey from origin/main's dashboard/data.json.
 import json, subprocess, sys
 
 REF = 365.85          # llama.cpp 128-tok reference (SPARKINFER_DIFFICULTY_REF)
-DIFF_MAX = 4.0        # cap (SPARKINFER_DIFFICULTY_MAX)
+DIFF_MAX = 2.0        # cap (SPARKINFER_DIFFICULTY_MAX)
 SIG = 0.02
 BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
 


### PR DESCRIPTION
## Summary
- Lower default `SPARKINFER_DIFFICULTY_MAX` from 4 to 2 in `label.py` and `sim_difficulty.py`
- Late-game label tiers were inflating too aggressively once the frontier passed llama.cpp
- Raw `pct_over_frontier` is unchanged — only the difficulty multiplier cap affects eval labels
- Add unit test asserting the new 2× default cap behavior

## Test plan
- [x] `python3 bench/scripts/test_label.py` — all 8 tests pass
- [ ] Next eval bot run uses the new cap for fresh PR scoring