### PR TITLE
feat(eval): auto-close open PRs inactive for 2+ days

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -143,6 +143,10 @@ applies an `eval:<LABEL>` label, and posts the result as a PR comment. **It neve
 manually after review. Idempotent: each commit is evaluated once (tracked by a hidden marker in the
 bot's comment), so it only spins the GPU when there's new work.
 
+Each bot run also **closes open PRs with no GitHub activity for 2+ days** (`updatedAt` — commits,
+comments, reviews, label changes). PRs labeled `hold` or `merge-first` are skipped. Override with
+`SPARKINFER_STALE_PR_DAYS=0` to disable, or set a different threshold.
+
 ```bash
 eval/setup_labels.sh                                   # one-time: create the eval:* labels
 python eval/pr_eval_bot.py --instance 42134865 --frontier 164 --ceiling 366   # one poll

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -148,6 +148,8 @@ MERGE_FIRST_LABEL  = "merge-first"    # the round's biggest verified speedup —
 NEEDS_REBASE_LABEL = "needs-rebase"   # also a verified speedup, but not the round winner
 REEVALUATE_LABEL   = "re-evaluate"    # winner merged → rebase onto new main; bot re-evals on push
 HOLD_LABEL         = "hold"           # maintainer override: never auto-merge this PR
+STALE_PR_DAYS      = int(os.environ.get("SPARKINFER_STALE_PR_DAYS", "2"))
+STALE_CLOSE_SKIP_LABELS = {HOLD_LABEL, MERGE_FIRST_LABEL}  # protected from auto-close
 CONTEXT_LABELS     = {"128-context", "512-context", "4k-context", "16k-context", "32k-context",
                       "64k-context", "128k-context"}
 REGRESSION_LABELS  = {"regression-128", "regression-512", "regression-4k", "regression-16k",
@@ -206,6 +208,66 @@ def pr_involved_logins(repo, num):
     for l in (out.stdout or "").splitlines():
         if l.strip(): logins.add(l.strip().lower())
     return logins
+
+def _parse_github_time(ts):
+    """Parse GitHub ISO-8601 timestamp to UTC datetime."""
+    if not ts:
+        return None
+    if ts.endswith("Z"):
+        ts = ts[:-1] + "+00:00"
+    return datetime.datetime.fromisoformat(ts)
+
+
+def pr_inactive_days(pr, now=None):
+    """Days since the PR's last activity (updatedAt), or None if unknown."""
+    updated = _parse_github_time(pr.get("updatedAt"))
+    if not updated:
+        return None
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    if updated.tzinfo is None:
+        updated = updated.replace(tzinfo=datetime.timezone.utc)
+    return (now - updated).total_seconds() / 86400.0
+
+
+def close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=False):
+    """Close open PRs with no GitHub activity for more than `days` days.
+
+    Uses PR updatedAt (commits, comments, reviews, label changes). Skips PRs labeled
+    `hold` or `merge-first`. Returns the set of PR numbers closed (or would-close in dry-run).
+  """
+    if days <= 0:
+        return set()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    prs = json.loads(gh(["pr", "list", "-R", repo, "--state", "open",
+                         "--json", "number,title,updatedAt,labels"]).stdout or "[]")
+    closed = set()
+    for pr in prs:
+        num = pr["number"]
+        labels = {l["name"] for l in pr.get("labels", [])}
+        if labels & STALE_CLOSE_SKIP_LABELS:
+            continue
+        inactive = pr_inactive_days(pr, now)
+        if inactive is None or inactive <= days:
+            continue
+        days_idle = int(inactive)
+        print(f"PR #{num}: stale — no activity for {days_idle}d (limit {days}d)"
+              f"{' — would close' if dry_run else ' — closing'}")
+        if dry_run:
+            closed.add(num)
+            continue
+        body = ("<!-- sparkinfer-stale -->\n"
+                f"## Closed: no activity for {days}+ days\n\n"
+                f"This PR has had no updates (commits, comments, reviews, or label changes) "
+                f"for **{days_idle} days** (threshold: {days} days).\n\n"
+                "Reopen this PR or open a fresh one when you're ready to continue.")
+        gh(["pr", "comment", str(num), "-R", repo, "--body", body])
+        if gh(["pr", "close", str(num), "-R", repo]).returncode == 0:
+            closed.add(num)
+    if closed:
+        print(f">> close_stale_prs: {'would close' if dry_run else 'closed'} {len(closed)} PR(s): "
+              f"{sorted(closed)}")
+    return closed
+
 
 def close_blocked_pr(repo, num, hits):
     """Label flagged:gaming, comment with the reason, and close the PR. Returns True on close."""
@@ -1373,8 +1435,12 @@ def main():
     # OLDEST-FIRST: evaluate ascending by PR number so the original of any duplicate is seen before
     # its copy, and the earliest submitter is graded first (fairness + copycat attribution).
     prs = json.loads(gh(["pr", "list", "-R", args.repo, "--state", "open",
-                         "--json", "number,headRefName,headRefOid,title,isCrossRepository,labels,isDraft,mergeable"]).stdout or "[]")
+                         "--json", "number,headRefName,headRefOid,title,isCrossRepository,labels,isDraft,mergeable,updatedAt"]).stdout or "[]")
     prs.sort(key=lambda p: p["number"])
+    if not args.only_pr:
+        stale_closed = close_stale_prs(args.repo, days=STALE_PR_DAYS, dry_run=args.dry_run)
+        if stale_closed:
+            prs = [p for p in prs if p["number"] not in stale_closed]
     if args.only_pr:
         prs = [p for p in prs if p["number"] == args.only_pr]
         if not prs:

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -7,6 +7,7 @@ Run from the repo root:
 import unittest
 import json
 import os
+import datetime
 import tempfile
 from unittest import mock
 
@@ -298,6 +299,58 @@ class PrEvalBotPolicyTest(unittest.TestCase):
              mock.patch.object(bot, "record_merge") as rm:
             bot.sync_merged_dashboard("gittensor-ai-lab/sparkinfer")
         rm.assert_not_called()
+
+    def test_pr_inactive_days_from_updated_at(self):
+        now = datetime.datetime(2026, 7, 13, 12, 0, tzinfo=datetime.timezone.utc)
+        pr = {"updatedAt": "2026-07-10T12:00:00Z"}
+        self.assertAlmostEqual(bot.pr_inactive_days(pr, now), 3.0, places=5)
+
+    def test_close_stale_prs_closes_inactive(self):
+        stale = {
+            "number": 42,
+            "title": "old PR",
+            "updatedAt": "2026-07-01T00:00:00Z",
+            "labels": [{"name": "not-tested"}],
+        }
+        fresh = {
+            "number": 43,
+            "title": "active PR",
+            "updatedAt": "2026-07-12T00:00:00Z",
+            "labels": [],
+        }
+        gh_calls = []
+
+        def fake_gh(args):
+            gh_calls.append(args)
+            if args[:3] == ["pr", "list", "-R"]:
+                return mock.Mock(stdout=json.dumps([stale, fresh]))
+            return mock.Mock(returncode=0)
+
+        now = datetime.datetime(2026, 7, 13, 0, 0, tzinfo=datetime.timezone.utc)
+        with mock.patch.object(bot, "gh", side_effect=fake_gh), \
+             mock.patch.object(bot, "pr_inactive_days", side_effect=lambda pr, _now=None: 5.0 if pr["number"] == 42 else 1.0):
+            closed = bot.close_stale_prs("gittensor-ai-lab/sparkinfer", days=2, dry_run=False)
+        self.assertEqual(closed, {42})
+        self.assertTrue(any(c[:3] == ["pr", "close", "42"] for c in gh_calls))
+
+    def test_close_stale_prs_skips_hold_and_merge_first(self):
+        prs = [
+            {"number": 1, "updatedAt": "2026-01-01T00:00:00Z", "labels": [{"name": "hold"}]},
+            {"number": 2, "updatedAt": "2026-01-01T00:00:00Z", "labels": [{"name": "merge-first"}]},
+        ]
+        with mock.patch.object(bot, "gh", return_value=mock.Mock(stdout=json.dumps(prs))), \
+             mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
+            closed = bot.close_stale_prs("gittensor-ai-lab/sparkinfer", days=2)
+        self.assertEqual(closed, set())
+
+    def test_close_stale_prs_dry_run(self):
+        prs = [{"number": 99, "updatedAt": "2026-01-01T00:00:00Z", "labels": []}]
+        gh_mock = mock.Mock(return_value=mock.Mock(stdout=json.dumps(prs)))
+        with mock.patch.object(bot, "gh", gh_mock), \
+             mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
+            closed = bot.close_stale_prs("gittensor-ai-lab/sparkinfer", days=2, dry_run=True)
+        self.assertEqual(closed, {99})
+        gh_mock.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Each `pr_eval_bot.py` poll closes open PRs with no GitHub activity for 2+ days (`updatedAt`)
- Skips PRs labeled `hold` or `merge-first`; posts an explanatory comment before closing
- Configurable via `SPARKINFER_STALE_PR_DAYS` (set `0` to disable)

## Test plan
- [x] `python3 -m unittest test_pr_eval_bot -v` from `eval/` (16 tests pass)
- [ ] After merge: next bot cron run will close any qualifying stale PRs