### PR TITLE
fix(dashboard): show TDX shield for PR #267 eval proof

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -343,7 +343,9 @@ window.SPARKINFER = {
       "guard_32k_ratio": 1.0982,
       "guard_32k_pass": true,
       "proof_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0267-ca7028c",
-      "proof_run": "0267-ca7028c"
+      "proof_run": "0267-ca7028c",
+      "polaris_receipt_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0267-ca7028c",
+      "polaris_receipt_hash": "f6e61cd0534f2779"
     },
     {
       "num": 353,

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -342,7 +342,9 @@
       "guard_32k_ratio": 1.0982,
       "guard_32k_pass": true,
       "proof_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0267-ca7028c",
-      "proof_run": "0267-ca7028c"
+      "proof_run": "0267-ca7028c",
+      "polaris_receipt_url": "https://gittensor-ai-lab.github.io/sparkinfer-log/?run=0267-ca7028c",
+      "polaris_receipt_hash": "f6e61cd0534f2779"
     },
     {
       "num": 353,

--- a/eval/backfill_dashboard.py
+++ b/eval/backfill_dashboard.py
@@ -30,6 +30,24 @@ def _parse_result_log(text: str) -> dict:
     raise ValueError("RESULT_JSON not found in log")
 
 
+def _polaris_fields(run: str | None) -> dict:
+    """Attach dashboard polaris receipt links when sparkinfer-log has a TDX receipt."""
+    if not run:
+        return {}
+    try:
+        with urllib.request.urlopen(f"{LOG_BASE}/{run}/receipt.json", timeout=60) as resp:
+            receipt = json.load(resp)
+    except Exception:
+        return {}
+    if not (receipt.get("tdx") or receipt.get("attestation_type") == "tdx-quote"):
+        return {}
+    rid = receipt.get("receipt_id") or ""
+    return {
+        "polaris_receipt_url": f"https://gittensor-ai-lab.github.io/sparkinfer-log/?run={run}",
+        "polaris_receipt_hash": rid[:16] if rid else None,
+    }
+
+
 def _load_result(run: str | None, result_path: str | None) -> dict:
     if result_path:
         with open(result_path) as f:
@@ -69,6 +87,7 @@ def apply(pr_num: int, res: dict, *, merge: bool, proof_run: str | None, title: 
         proof = f"https://gittensor-ai-lab.github.io/sparkinfer-log/?run={res['id']}"
 
     bot.push_dash = lambda _msg: None  # noqa: ARG005 — local backfill only
+    res = {**res, **{k: v for k, v in _polaris_fields(proof_run or res.get("id")).items() if v}}
     bot.update_dashboard(repo, pr, areas, res, proof_url=proof)
     if merge:
         bot.record_merge(repo, pr_num)


### PR DESCRIPTION
## Summary
- Add `polaris_receipt_url` / `polaris_receipt_hash` for PR #267 (`0267-ca7028c` TDX receipt)
- Dashboard proof column now shows 🛡️ (Polaris TDX) instead of 📋
- `backfill_dashboard.py` auto-attaches polaris fields from `receipt.json` when present

## Test plan
- [x] PR #267 row in dashboard shows 🛡️ `0267-ca7028c`
- [ ] sparkinfer-log run page still shows Polaris TDX receipt card