### PR TITLE
fix(eval): vast_eval Qwen3.5 32k/64k/128k guard CLI args

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -4015,8 +4015,8 @@ window.SPARKINFER = {
     "baseline_tps": 298.27,
     "ref_name": "llama.cpp",
     "ref_tps": 224.91,
-    "token_match": 0.9553,
-    "kl": 0.028,
+    "token_match": 0.9613,
+    "kl": 0.0141,
     "note": "same-box baseline 91.224.44.227 (KV cap fix, origin/main + kMaxBlocksPerSeq=10240, 2026-07-13)",
     "ctx": [
       {
@@ -4078,6 +4078,13 @@ window.SPARKINFER = {
       "name": "complete gate_up->quant_h->d",
       "tps": 298.27,
       "pr": 331,
+      "date": "2026-07-13",
+      "label": "XS"
+    },
+    {
+      "name": "GQA-4 shared-KV tile for Qwy",
+      "tps": 298.27,
+      "pr": 327,
       "date": "2026-07-13",
       "label": "XS"
     },

--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -2,15 +2,15 @@
 window.SPARKINFER = {
   "updated": "2026-07-13",
   "status": {
-    "gpu": "RTX 5090 \u00b7 sm_120 \u00b7 CUDA 13",
-    "model": "Qwen3-30B-A3B \u00b7 Q4_K_M",
+    "gpu": "RTX 5090 · sm_120 · CUDA 13",
+    "model": "Qwen3-30B-A3B · Q4_K_M",
     "frontier_tps": 484.79,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
     "token_match": 0.97,
     "kl": 0.02,
-    "ref_note": "128-tok decode rerun on current main, same RTX 5090 \u00b7 Q4_K_M GGUF",
+    "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
@@ -107,27 +107,27 @@ window.SPARKINFER = {
     },
     {
       "l": "L",
-      "d": "10\u201318% over frontier",
+      "d": "10–18% over frontier",
       "c": "#1D76DB"
     },
     {
       "l": "M",
-      "d": "6\u201310% over frontier",
+      "d": "6–10% over frontier",
       "c": "#8250DF"
     },
     {
       "l": "S",
-      "d": "3.5\u20136% over frontier",
+      "d": "3.5–6% over frontier",
       "c": "#B8860B"
     },
     {
       "l": "XS",
-      "d": "2\u20133.5% over frontier",
+      "d": "2–3.5% over frontier",
       "c": "#8A93A0"
     },
     {
       "l": "none",
-      "d": "\u2264 2% \u2014 within noise, no verified gain",
+      "d": "≤ 2% — within noise, no verified gain",
       "c": "#9AA6B2"
     },
     {
@@ -139,7 +139,7 @@ window.SPARKINFER = {
   "prs": [
     {
       "num": 267,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -176,7 +176,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.16,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -349,7 +349,7 @@ window.SPARKINFER = {
     },
     {
       "num": 353,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of full-attention q/o projections",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of full-attention q/o projections",
       "areas": [
         "kernels",
         "runtime"
@@ -386,7 +386,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.59,
         "pct_over_frontier": 0.5,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -595,7 +595,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.21,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -670,7 +670,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.23,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -800,7 +800,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 2.02,
         "pct_over_frontier": 0.7,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -970,7 +970,7 @@ window.SPARKINFER = {
     },
     {
       "num": 350,
-      "title": "perf(qwen36): opt-in Q8\u2192Q4 requant reward profile (~+6.3% @512)",
+      "title": "perf(qwen36): opt-in Q8→Q4 requant reward profile (~+6.3% @512)",
       "areas": [
         "kernels",
         "runtime"
@@ -1013,7 +1013,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.8,
         "pct_over_frontier": 0.6,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1273,7 +1273,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.29,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1764,7 +1764,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1972,7 +1972,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2486,7 +2486,7 @@ window.SPARKINFER = {
     },
     {
       "num": 323,
-      "title": "perf(qwen35): requantize dense FFN down Q6_K\u2192Q4_K at load (~5% Qwythos decode)",
+      "title": "perf(qwen35): requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)",
       "areas": [
         "kernels",
         "runtime"
@@ -2556,7 +2556,7 @@ window.SPARKINFER = {
     },
     {
       "num": 239,
-      "title": "perf(qwen3.6): fuse decode kernel launches \u2014 shared-expert + GDN conv/L2-norm",
+      "title": "perf(qwen3.6): fuse decode kernel launches — shared-expert + GDN conv/L2-norm",
       "areas": [
         "kernels",
         "runtime"
@@ -2950,7 +2950,7 @@ window.SPARKINFER = {
     },
     {
       "num": 269,
-      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append \u2014 25% decode",
+      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append — 25% decode",
       "areas": [
         "kernels",
         "runtime"
@@ -2965,7 +2965,7 @@ window.SPARKINFER = {
     },
     {
       "num": 266,
-      "title": "perf(qwen36): +15-20% decode \u2014 Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
+      "title": "perf(qwen36): +15-20% decode — Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
       "areas": [
         "kernels",
         "runtime"
@@ -3231,7 +3231,7 @@ window.SPARKINFER = {
     },
     {
       "num": 229,
-      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit\u2026",
+      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit…",
       "areas": [
         "kernels"
       ],
@@ -3274,7 +3274,7 @@ window.SPARKINFER = {
     },
     {
       "num": 230,
-      "title": "perf(qwen3.6): shared expert as coalesced GEMVs \u2014 7.2\u00d7 decode (23\u2192167 tok/s)",
+      "title": "perf(qwen3.6): shared expert as coalesced GEMVs — 7.2× decode (23→167 tok/s)",
       "areas": [
         "kernels",
         "runtime"
@@ -3835,7 +3835,7 @@ window.SPARKINFER = {
       "date": "2026-06-27"
     },
     {
-      "name": "split-K MMVQ down \u2014 +8% Qwen",
+      "name": "split-K MMVQ down — +8% Qwen",
       "tps": 339.59,
       "pr": 74,
       "date": "2026-06-28"
@@ -4006,17 +4006,17 @@ window.SPARKINFER = {
     ]
   },
   "qwen35": {
-    "model": "Qwythos-9B (Qwen3.5-9B) \u00b7 Q4_K_M",
+    "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
     "hf_repo": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 1967677,
-    "arch": "dense hybrid Gated-DeltaNet + full-attn \u00b7 9B \u00b7 hd256",
+    "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
     "frontier_tps": 298.27,
     "baseline_tps": 298.27,
     "ref_name": "llama.cpp",
     "ref_tps": 224.91,
-    "token_match": 0.9521,
-    "kl": 0.0301,
+    "token_match": 0.9553,
+    "kl": 0.028,
     "note": "same-box baseline 91.224.44.227 (KV cap fix, origin/main + kMaxBlocksPerSeq=10240, 2026-07-13)",
     "ctx": [
       {
@@ -4075,6 +4075,13 @@ window.SPARKINFER = {
       "attribution": "maintainer #334"
     },
     {
+      "name": "complete gate_up->quant_h->d",
+      "tps": 298.27,
+      "pr": 331,
+      "date": "2026-07-13",
+      "label": "XS"
+    },
+    {
       "name": "Q4_K requant for Qwythos Q6",
       "tps": 303.18,
       "pr": 329,
@@ -4083,14 +4090,14 @@ window.SPARKINFER = {
     }
   ],
   "qwen36": {
-    "model": "Qwen3.6-35B-A3B \u00b7 UD-Q4_K_M",
-    "arch": "hybrid Gated-DeltaNet + full-attn MoE \u00b7 256 experts top-8 \u00b7 hd256",
+    "model": "Qwen3.6-35B-A3B · UD-Q4_K_M",
+    "arch": "hybrid Gated-DeltaNet + full-attn MoE · 256 experts top-8 · hd256",
     "frontier_tps": 473.27,
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
     "ref_tps": 275.81,
-    "token_match": 0.9529,
-    "kl": 0.031,
+    "token_match": 0.9665,
+    "kl": 0.0203,
     "note": "same-box baseline 91.224.44.227 (origin/main 6e963a7, 2026-07-13)",
     "ctx": [
       {
@@ -4155,7 +4162,7 @@ window.SPARKINFER = {
       "label": "M"
     },
     {
-      "name": "+15-20% decode \u2014 Q8 shared M",
+      "name": "+15-20% decode — Q8 shared M",
       "tps": 300.16,
       "pr": 266,
       "date": "2026-07-06",
@@ -4204,14 +4211,21 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of full-at",
+      "name": "Q8_0→Q4_K requant of full-at",
       "tps": 427.54,
       "pr": 353,
       "date": "2026-07-12",
       "label": "XL"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of GDN inp",
+      "name": "complete gate_up->quant_h->d",
+      "tps": 427.92,
+      "pr": 331,
+      "date": "2026-07-13",
+      "label": "S"
+    },
+    {
+      "name": "Q8_0→Q4_K requant of GDN inp",
       "tps": 463.27,
       "pr": 267,
       "date": "2026-07-13",

--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -4103,8 +4103,8 @@ window.SPARKINFER = {
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
     "ref_tps": 275.81,
-    "token_match": 0.9665,
-    "kl": 0.0203,
+    "token_match": 0.9529,
+    "kl": 0.031,
     "note": "same-box baseline 91.224.44.227 (origin/main 6e963a7, 2026-07-13)",
     "ctx": [
       {

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -4014,8 +4014,8 @@
     "baseline_tps": 298.27,
     "ref_name": "llama.cpp",
     "ref_tps": 224.91,
-    "token_match": 0.9553,
-    "kl": 0.028,
+    "token_match": 0.9613,
+    "kl": 0.0141,
     "note": "same-box baseline 91.224.44.227 (KV cap fix, origin/main + kMaxBlocksPerSeq=10240, 2026-07-13)",
     "ctx": [
       {
@@ -4077,6 +4077,13 @@
       "name": "complete gate_up->quant_h->d",
       "tps": 298.27,
       "pr": 331,
+      "date": "2026-07-13",
+      "label": "XS"
+    },
+    {
+      "name": "GQA-4 shared-KV tile for Qwy",
+      "tps": 298.27,
+      "pr": 327,
       "date": "2026-07-13",
       "label": "XS"
     },

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -1,15 +1,15 @@
 {
   "updated": "2026-07-13",
   "status": {
-    "gpu": "RTX 5090 \u00b7 sm_120 \u00b7 CUDA 13",
-    "model": "Qwen3-30B-A3B \u00b7 Q4_K_M",
+    "gpu": "RTX 5090 · sm_120 · CUDA 13",
+    "model": "Qwen3-30B-A3B · Q4_K_M",
     "frontier_tps": 484.79,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
     "token_match": 0.97,
     "kl": 0.02,
-    "ref_note": "128-tok decode rerun on current main, same RTX 5090 \u00b7 Q4_K_M GGUF",
+    "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
@@ -106,27 +106,27 @@
     },
     {
       "l": "L",
-      "d": "10\u201318% over frontier",
+      "d": "10–18% over frontier",
       "c": "#1D76DB"
     },
     {
       "l": "M",
-      "d": "6\u201310% over frontier",
+      "d": "6–10% over frontier",
       "c": "#8250DF"
     },
     {
       "l": "S",
-      "d": "3.5\u20136% over frontier",
+      "d": "3.5–6% over frontier",
       "c": "#B8860B"
     },
     {
       "l": "XS",
-      "d": "2\u20133.5% over frontier",
+      "d": "2–3.5% over frontier",
       "c": "#8A93A0"
     },
     {
       "l": "none",
-      "d": "\u2264 2% \u2014 within noise, no verified gain",
+      "d": "≤ 2% — within noise, no verified gain",
       "c": "#9AA6B2"
     },
     {
@@ -138,7 +138,7 @@
   "prs": [
     {
       "num": 267,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -175,7 +175,7 @@
         "label": "none",
         "delta_tps": 0.16,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -348,7 +348,7 @@
     },
     {
       "num": 353,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of full-attention q/o projections",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of full-attention q/o projections",
       "areas": [
         "kernels",
         "runtime"
@@ -385,7 +385,7 @@
         "label": "none",
         "delta_tps": 1.59,
         "pct_over_frontier": 0.5,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -594,7 +594,7 @@
         "label": "none",
         "delta_tps": 1.21,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -669,7 +669,7 @@
         "label": "none",
         "delta_tps": 0.23,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -799,7 +799,7 @@
         "label": "none",
         "delta_tps": 2.02,
         "pct_over_frontier": 0.7,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -969,7 +969,7 @@
     },
     {
       "num": 350,
-      "title": "perf(qwen36): opt-in Q8\u2192Q4 requant reward profile (~+6.3% @512)",
+      "title": "perf(qwen36): opt-in Q8→Q4 requant reward profile (~+6.3% @512)",
       "areas": [
         "kernels",
         "runtime"
@@ -1012,7 +1012,7 @@
         "label": "REJECT",
         "delta_tps": 1.8,
         "pct_over_frontier": 0.6,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1272,7 +1272,7 @@
         "label": "none",
         "delta_tps": 1.29,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1763,7 +1763,7 @@
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1971,7 +1971,7 @@
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2485,7 +2485,7 @@
     },
     {
       "num": 323,
-      "title": "perf(qwen35): requantize dense FFN down Q6_K\u2192Q4_K at load (~5% Qwythos decode)",
+      "title": "perf(qwen35): requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)",
       "areas": [
         "kernels",
         "runtime"
@@ -2555,7 +2555,7 @@
     },
     {
       "num": 239,
-      "title": "perf(qwen3.6): fuse decode kernel launches \u2014 shared-expert + GDN conv/L2-norm",
+      "title": "perf(qwen3.6): fuse decode kernel launches — shared-expert + GDN conv/L2-norm",
       "areas": [
         "kernels",
         "runtime"
@@ -2949,7 +2949,7 @@
     },
     {
       "num": 269,
-      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append \u2014 25% decode",
+      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append — 25% decode",
       "areas": [
         "kernels",
         "runtime"
@@ -2964,7 +2964,7 @@
     },
     {
       "num": 266,
-      "title": "perf(qwen36): +15-20% decode \u2014 Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
+      "title": "perf(qwen36): +15-20% decode — Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
       "areas": [
         "kernels",
         "runtime"
@@ -3230,7 +3230,7 @@
     },
     {
       "num": 229,
-      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit\u2026",
+      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit…",
       "areas": [
         "kernels"
       ],
@@ -3273,7 +3273,7 @@
     },
     {
       "num": 230,
-      "title": "perf(qwen3.6): shared expert as coalesced GEMVs \u2014 7.2\u00d7 decode (23\u2192167 tok/s)",
+      "title": "perf(qwen3.6): shared expert as coalesced GEMVs — 7.2× decode (23→167 tok/s)",
       "areas": [
         "kernels",
         "runtime"
@@ -3834,7 +3834,7 @@
       "date": "2026-06-27"
     },
     {
-      "name": "split-K MMVQ down \u2014 +8% Qwen",
+      "name": "split-K MMVQ down — +8% Qwen",
       "tps": 339.59,
       "pr": 74,
       "date": "2026-06-28"
@@ -4005,17 +4005,17 @@
     ]
   },
   "qwen35": {
-    "model": "Qwythos-9B (Qwen3.5-9B) \u00b7 Q4_K_M",
+    "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
     "hf_repo": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 1967677,
-    "arch": "dense hybrid Gated-DeltaNet + full-attn \u00b7 9B \u00b7 hd256",
+    "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
     "frontier_tps": 298.27,
     "baseline_tps": 298.27,
     "ref_name": "llama.cpp",
     "ref_tps": 224.91,
-    "token_match": 0.9521,
-    "kl": 0.0301,
+    "token_match": 0.9553,
+    "kl": 0.028,
     "note": "same-box baseline 91.224.44.227 (KV cap fix, origin/main + kMaxBlocksPerSeq=10240, 2026-07-13)",
     "ctx": [
       {
@@ -4074,6 +4074,13 @@
       "attribution": "maintainer #334"
     },
     {
+      "name": "complete gate_up->quant_h->d",
+      "tps": 298.27,
+      "pr": 331,
+      "date": "2026-07-13",
+      "label": "XS"
+    },
+    {
       "name": "Q4_K requant for Qwythos Q6",
       "tps": 303.18,
       "pr": 329,
@@ -4082,14 +4089,14 @@
     }
   ],
   "qwen36": {
-    "model": "Qwen3.6-35B-A3B \u00b7 UD-Q4_K_M",
-    "arch": "hybrid Gated-DeltaNet + full-attn MoE \u00b7 256 experts top-8 \u00b7 hd256",
+    "model": "Qwen3.6-35B-A3B · UD-Q4_K_M",
+    "arch": "hybrid Gated-DeltaNet + full-attn MoE · 256 experts top-8 · hd256",
     "frontier_tps": 473.27,
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
     "ref_tps": 275.81,
-    "token_match": 0.9529,
-    "kl": 0.031,
+    "token_match": 0.9665,
+    "kl": 0.0203,
     "note": "same-box baseline 91.224.44.227 (origin/main 6e963a7, 2026-07-13)",
     "ctx": [
       {
@@ -4154,7 +4161,7 @@
       "label": "M"
     },
     {
-      "name": "+15-20% decode \u2014 Q8 shared M",
+      "name": "+15-20% decode — Q8 shared M",
       "tps": 300.16,
       "pr": 266,
       "date": "2026-07-06",
@@ -4203,14 +4210,21 @@
       "label": "S"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of full-at",
+      "name": "Q8_0→Q4_K requant of full-at",
       "tps": 427.54,
       "pr": 353,
       "date": "2026-07-12",
       "label": "XL"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of GDN inp",
+      "name": "complete gate_up->quant_h->d",
+      "tps": 427.92,
+      "pr": 331,
+      "date": "2026-07-13",
+      "label": "S"
+    },
+    {
+      "name": "Q8_0→Q4_K requant of GDN inp",
       "tps": 463.27,
       "pr": 267,
       "date": "2026-07-13",

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -4102,8 +4102,8 @@
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
     "ref_tps": 275.81,
-    "token_match": 0.9665,
-    "kl": 0.0203,
+    "token_match": 0.9529,
+    "kl": 0.031,
     "note": "same-box baseline 91.224.44.227 (origin/main 6e963a7, 2026-07-13)",
     "ctx": [
       {

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -269,14 +269,18 @@ def main():
     ap.add_argument("--p-llama-32k-baseline", type=float, default=0, help="[--dual] Qwen3.6 llama.cpp 32k-context tok/s")
     # --- bidirectional: Qwen3.5-9B + Qwen3.6-35B (both directions scored) ---
     ap.add_argument("--bidir", action="store_true",
-                    help="bidirectional eval: score Qwen3.5 (128/512/4k) and Qwen3.6 (5 contexts), "
+                    help="bidirectional eval: score Qwen3.5 (128/4k/32k/64k/128k) and Qwen3.6 (5 contexts), "
                          "each guarding the other via evaluate_bidir.sh")
     ap.add_argument("--p35-guard-128-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 128-token tok/s")
-    ap.add_argument("--p35-guard-512-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 512-context tok/s")
     ap.add_argument("--p35-guard-4k-baseline",  type=float, default=0, help="[--bidir] Qwen3.5 main 4k-context tok/s")
+    ap.add_argument("--p35-guard-32k-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 32k-context tok/s")
+    ap.add_argument("--p35-guard-64k-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 64k-context tok/s")
+    ap.add_argument("--p35-guard-128k-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 128k-context tok/s")
     ap.add_argument("--g35-guard-128-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 128-token tok/s")
-    ap.add_argument("--g35-guard-512-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 512-context tok/s")
     ap.add_argument("--g35-guard-4k-baseline",  type=float, default=0, help="[--bidir] Qwen3.5 guard 4k-context tok/s")
+    ap.add_argument("--g35-guard-32k-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 32k-context tok/s")
+    ap.add_argument("--g35-guard-64k-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 64k-context tok/s")
+    ap.add_argument("--g35-guard-128k-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 128k-context tok/s")
     # --- triple-model: legacy alias for --bidir ---
     ap.add_argument("--triple", action="store_true",
                     help="alias for --bidir (Qwen3.5 + Qwen3.6 only; Qwen3-30B removed)")
@@ -634,8 +638,10 @@ def main():
             eval_cmd = (f"SI_NO_CHECKOUT=1 SPARKINFER_EVAL_SEED={eval_seed} "
                         f"SPARKINFER_EVAL_MODE={args.eval_mode} PRIMARY_QUANT={args.primary_quant} "
                         f"SPARKINFER_P35_GUARD_128_BASELINE={args.p35_guard_128_baseline} "
-                        f"SPARKINFER_P35_GUARD_512_BASELINE={args.p35_guard_512_baseline} "
                         f"SPARKINFER_P35_GUARD_4K_BASELINE={args.p35_guard_4k_baseline} "
+                        f"SPARKINFER_P35_GUARD_32K_BASELINE={args.p35_guard_32k_baseline} "
+                        f"SPARKINFER_P35_GUARD_64K_BASELINE={args.p35_guard_64k_baseline} "
+                        f"SPARKINFER_P35_GUARD_128K_BASELINE={args.p35_guard_128k_baseline} "
                         f"SPARKINFER_P36_GUARD_128_BASELINE={args.p_guard_128_baseline} "
                         f"SPARKINFER_P36_GUARD_512_BASELINE={args.p_guard_512_baseline} "
                         f"SPARKINFER_P36_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
@@ -647,8 +653,10 @@ def main():
                         f"SPARKINFER_G36_GUARD_16K_BASELINE={args.g36_guard_16k_baseline} "
                         f"SPARKINFER_G36_GUARD_32K_BASELINE={args.g36_guard_32k_baseline} "
                         f"SPARKINFER_G35_GUARD_128_BASELINE={args.g35_guard_128_baseline} "
-                        f"SPARKINFER_G35_GUARD_512_BASELINE={args.g35_guard_512_baseline} "
                         f"SPARKINFER_G35_GUARD_4K_BASELINE={args.g35_guard_4k_baseline} "
+                        f"SPARKINFER_G35_GUARD_32K_BASELINE={args.g35_guard_32k_baseline} "
+                        f"SPARKINFER_G35_GUARD_64K_BASELINE={args.g35_guard_64k_baseline} "
+                        f"SPARKINFER_G35_GUARD_128K_BASELINE={args.g35_guard_128k_baseline} "
                         f"SPARKINFER_P35_LLAMA_128_BASELINE={args.p_llama_128_baseline} "
                         f"SPARKINFER_P35_LLAMA_512_BASELINE={args.p_llama_512_baseline} "
                         f"SPARKINFER_P35_LLAMA_4K_BASELINE={args.p_llama_4k_baseline} "


### PR DESCRIPTION
## Summary
- Add missing `--p35-guard-*` / `--g35-guard-*` args for 32k/64k/128k.
- Pass through to evaluate_bidir.sh env (unblocks PR grading after #369).

## Test plan
- [ ] Eval bot grades greenlit PRs without argparse error