### PR TITLE
dashboard: HF model links for Qwen3-MoE and Qwen3.6

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -2,22 +2,25 @@
 window.SPARKINFER = {
   "updated": "2026-07-13",
   "status": {
-    "gpu": "RTX 5090 · sm_120 · CUDA 13",
-    "model": "Qwen3-30B-A3B · Q4_K_M",
+    "gpu": "RTX 5090 \u00b7 sm_120 \u00b7 CUDA 13",
+    "model": "Qwen3-30B-A3B \u00b7 Q4_K_M",
     "frontier_tps": 484.79,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
     "token_match": 0.97,
     "kl": 0.02,
-    "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
+    "ref_note": "128-tok decode rerun on current main, same RTX 5090 \u00b7 Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
     "longctx_kl": 0.0368,
     "longctx_512_tps": 469.58,
     "longctx_4k_tps": 392.65,
-    "longctx_32k_tps": 260.3
+    "longctx_32k_tps": 260.3,
+    "hf_repo": "Qwen/Qwen3-30B-A3B-GGUF",
+    "hf_avatar": "assets/img/huggingface.svg",
+    "hf_downloads": 85521
   },
   "context_baselines": [
     {
@@ -107,27 +110,27 @@ window.SPARKINFER = {
     },
     {
       "l": "L",
-      "d": "10–18% over frontier",
+      "d": "10\u201318% over frontier",
       "c": "#1D76DB"
     },
     {
       "l": "M",
-      "d": "6–10% over frontier",
+      "d": "6\u201310% over frontier",
       "c": "#8250DF"
     },
     {
       "l": "S",
-      "d": "3.5–6% over frontier",
+      "d": "3.5\u20136% over frontier",
       "c": "#B8860B"
     },
     {
       "l": "XS",
-      "d": "2–3.5% over frontier",
+      "d": "2\u20133.5% over frontier",
       "c": "#8A93A0"
     },
     {
       "l": "none",
-      "d": "≤ 2% — within noise, no verified gain",
+      "d": "\u2264 2% \u2014 within noise, no verified gain",
       "c": "#9AA6B2"
     },
     {
@@ -139,7 +142,7 @@ window.SPARKINFER = {
   "prs": [
     {
       "num": 267,
-      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
+      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -176,7 +179,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.16,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -349,7 +352,7 @@ window.SPARKINFER = {
     },
     {
       "num": 353,
-      "title": "perf(qwen36): Q8_0→Q4_K requant of full-attention q/o projections",
+      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of full-attention q/o projections",
       "areas": [
         "kernels",
         "runtime"
@@ -386,7 +389,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.59,
         "pct_over_frontier": 0.5,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -595,7 +598,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.21,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -670,7 +673,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.23,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -800,7 +803,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 2.02,
         "pct_over_frontier": 0.7,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -970,7 +973,7 @@ window.SPARKINFER = {
     },
     {
       "num": 350,
-      "title": "perf(qwen36): opt-in Q8→Q4 requant reward profile (~+6.3% @512)",
+      "title": "perf(qwen36): opt-in Q8\u2192Q4 requant reward profile (~+6.3% @512)",
       "areas": [
         "kernels",
         "runtime"
@@ -1013,7 +1016,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.8,
         "pct_over_frontier": 0.6,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1273,7 +1276,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.29,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1764,7 +1767,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1972,7 +1975,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2486,7 +2489,7 @@ window.SPARKINFER = {
     },
     {
       "num": 323,
-      "title": "perf(qwen35): requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)",
+      "title": "perf(qwen35): requantize dense FFN down Q6_K\u2192Q4_K at load (~5% Qwythos decode)",
       "areas": [
         "kernels",
         "runtime"
@@ -2556,7 +2559,7 @@ window.SPARKINFER = {
     },
     {
       "num": 239,
-      "title": "perf(qwen3.6): fuse decode kernel launches — shared-expert + GDN conv/L2-norm",
+      "title": "perf(qwen3.6): fuse decode kernel launches \u2014 shared-expert + GDN conv/L2-norm",
       "areas": [
         "kernels",
         "runtime"
@@ -2950,7 +2953,7 @@ window.SPARKINFER = {
     },
     {
       "num": 269,
-      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append — 25% decode",
+      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append \u2014 25% decode",
       "areas": [
         "kernels",
         "runtime"
@@ -2965,7 +2968,7 @@ window.SPARKINFER = {
     },
     {
       "num": 266,
-      "title": "perf(qwen36): +15-20% decode — Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
+      "title": "perf(qwen36): +15-20% decode \u2014 Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
       "areas": [
         "kernels",
         "runtime"
@@ -3231,7 +3234,7 @@ window.SPARKINFER = {
     },
     {
       "num": 229,
-      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit…",
+      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit\u2026",
       "areas": [
         "kernels"
       ],
@@ -3274,7 +3277,7 @@ window.SPARKINFER = {
     },
     {
       "num": 230,
-      "title": "perf(qwen3.6): shared expert as coalesced GEMVs — 7.2× decode (23→167 tok/s)",
+      "title": "perf(qwen3.6): shared expert as coalesced GEMVs \u2014 7.2\u00d7 decode (23\u2192167 tok/s)",
       "areas": [
         "kernels",
         "runtime"
@@ -3835,7 +3838,7 @@ window.SPARKINFER = {
       "date": "2026-06-27"
     },
     {
-      "name": "split-K MMVQ down — +8% Qwen",
+      "name": "split-K MMVQ down \u2014 +8% Qwen",
       "tps": 339.59,
       "pr": 74,
       "date": "2026-06-28"
@@ -4006,11 +4009,11 @@ window.SPARKINFER = {
     ]
   },
   "qwen35": {
-    "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
+    "model": "Qwythos-9B (Qwen3.5-9B) \u00b7 Q4_K_M",
     "hf_repo": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 1967677,
-    "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
+    "arch": "dense hybrid Gated-DeltaNet + full-attn \u00b7 9B \u00b7 hd256",
     "frontier_tps": 298.27,
     "baseline_tps": 298.27,
     "ref_name": "llama.cpp",
@@ -4097,8 +4100,11 @@ window.SPARKINFER = {
     }
   ],
   "qwen36": {
-    "model": "Qwen3.6-35B-A3B · UD-Q4_K_M",
-    "arch": "hybrid Gated-DeltaNet + full-attn MoE · 256 experts top-8 · hd256",
+    "model": "Qwen3.6-35B-A3B \u00b7 UD-Q4_K_M",
+    "hf_repo": "unsloth/Qwen3.6-35B-A3B-GGUF",
+    "hf_avatar": "assets/img/huggingface.svg",
+    "hf_downloads": 854407,
+    "arch": "hybrid Gated-DeltaNet + full-attn MoE \u00b7 256 experts top-8 \u00b7 hd256",
     "frontier_tps": 473.27,
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
@@ -4169,7 +4175,7 @@ window.SPARKINFER = {
       "label": "M"
     },
     {
-      "name": "+15-20% decode — Q8 shared M",
+      "name": "+15-20% decode \u2014 Q8 shared M",
       "tps": 300.16,
       "pr": 266,
       "date": "2026-07-06",
@@ -4218,7 +4224,7 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0→Q4_K requant of full-at",
+      "name": "Q8_0\u2192Q4_K requant of full-at",
       "tps": 427.54,
       "pr": 353,
       "date": "2026-07-12",
@@ -4232,7 +4238,7 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0→Q4_K requant of GDN inp",
+      "name": "Q8_0\u2192Q4_K requant of GDN inp",
       "tps": 463.27,
       "pr": 267,
       "date": "2026-07-13",

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -16,7 +16,10 @@
     "longctx_kl": 0.0368,
     "longctx_512_tps": 469.58,
     "longctx_4k_tps": 392.65,
-    "longctx_32k_tps": 260.3
+    "longctx_32k_tps": 260.3,
+    "hf_repo": "Qwen/Qwen3-30B-A3B-GGUF",
+    "hf_avatar": "assets/img/huggingface.svg",
+    "hf_downloads": 85521
   },
   "context_baselines": [
     {
@@ -4097,6 +4100,9 @@
   ],
   "qwen36": {
     "model": "Qwen3.6-35B-A3B · UD-Q4_K_M",
+    "hf_repo": "unsloth/Qwen3.6-35B-A3B-GGUF",
+    "hf_avatar": "assets/img/huggingface.svg",
+    "hf_downloads": 854407,
     "arch": "hybrid Gated-DeltaNet + full-attn MoE · 256 experts top-8 · hd256",
     "frontier_tps": 473.27,
     "baseline_tps": 427.54,

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -254,7 +254,17 @@
   </section>
 
   <section>
-    <div class="sec-h"><h2>Qwen3-MoE · per-context</h2><span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k / 16k / 32k</span></div>
+    <div class="sec-h">
+      <div class="sec-title-row">
+        <h2>Qwen3-MoE · per-context</h2>
+        <a class="hf-model" id="detail-q3-hf" href="https://huggingface.co/Qwen/Qwen3-30B-A3B-GGUF" target="_blank" rel="noopener" title="Qwen/Qwen3-30B-A3B-GGUF">
+          <img src="assets/img/huggingface.svg" alt="Hugging Face" width="22" height="22" loading="eager" decoding="async">
+          <span class="hf-model-name">Qwen/Qwen3-30B-A3B-GGUF</span>
+          <span class="hf-dl" id="detail-q3-dl"></span>
+        </a>
+      </div>
+      <span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k / 16k / 32k</span>
+    </div>
     <div class="card" id="detail-q3"></div>
   </section>
 
@@ -274,7 +284,17 @@
   </section>
 
   <section>
-    <div class="sec-h"><h2>Qwen3.6 · per-context</h2><span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k / 16k / 32k</span></div>
+    <div class="sec-h">
+      <div class="sec-title-row">
+        <h2>Qwen3.6 · per-context</h2>
+        <a class="hf-model" id="detail-q36-hf" href="https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF" target="_blank" rel="noopener" title="unsloth/Qwen3.6-35B-A3B-GGUF">
+          <img src="assets/img/huggingface.svg" alt="Hugging Face" width="22" height="22" loading="eager" decoding="async">
+          <span class="hf-model-name">unsloth/Qwen3.6-35B-A3B-GGUF</span>
+          <span class="hf-dl" id="detail-q36-dl"></span>
+        </a>
+      </div>
+      <span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k / 16k / 32k</span>
+    </div>
     <div class="card" id="detail-q36"></div>
   </section>
 
@@ -309,26 +329,30 @@
   const ctxColor = ctx => CTX_COLOR[ctx] || "#7B5DFF";
   const LLAMA_FILL = "linear-gradient(90deg,#A9A9B4,#C8C8D4)";
 
-  (function(){
-    const q = D.qwen35 || {};
-    const repo = q.hf_repo || "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF";
-    const el = $("detail-q35-hf");
-    if (!el) return;
+  const fmtDl = n => {
+    if (!n) return "";
+    if (n >= 1e6) return (n / 1e6).toFixed(2).replace(/\.?0+$/, "") + "M";
+    if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
+    return String(n);
+  };
+  const wireHfModel = (elId, dlId, cfg, fallbackRepo) => {
+    const q = cfg || {};
+    const repo = q.hf_repo || fallbackRepo;
+    const el = $(elId);
+    if (!el || !repo) return;
     el.href = `https://huggingface.co/${repo}`;
     el.title = repo;
     const name = el.querySelector(".hf-model-name");
     if (name) name.textContent = repo;
     const img = el.querySelector("img");
     if (img) img.src = q.hf_avatar || "assets/img/huggingface.svg";
-    const fmtDl = n => {
-      if (!n) return "";
-      if (n >= 1e6) return (n / 1e6).toFixed(2).replace(/\.?0+$/, "") + "M";
-      if (n >= 1e3) return (n / 1e3).toFixed(1).replace(/\.0$/, "") + "k";
-      return String(n);
-    };
-    const dl = $("detail-q35-dl");
+    const dl = dlId ? $(dlId) : null;
     if (dl && q.hf_downloads) dl.textContent = `· ${fmtDl(q.hf_downloads)} downloads`;
-  })();
+  };
+
+  wireHfModel("detail-q3-hf", "detail-q3-dl", D.status, "Qwen/Qwen3-30B-A3B-GGUF");
+  wireHfModel("detail-q35-hf", "detail-q35-dl", D.qwen35, "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF");
+  wireHfModel("detail-q36-hf", "detail-q36-dl", D.qwen36, "unsloth/Qwen3.6-35B-A3B-GGUF");
 
   $("hero-meta").innerHTML = `GPU <b>${s.gpu}</b> &nbsp;·&nbsp; model <b>${s.model}</b>`;
   $("updated").textContent = "updated " + D.updated;


### PR DESCRIPTION
## Summary
- Add Hugging Face repo links + 🤗 avatar to Qwen3-MoE and Qwen3.6 per-context sections
- `Qwen/Qwen3-30B-A3B-GGUF` and `unsloth/Qwen3.6-35B-A3B-GGUF` with download counts
- Shared `wireHfModel()` helper for Qwen3 / Qwen3.5 / Qwen3.6

## Test plan
- [x] `data.json` has `hf_repo` on `status` and `qwen36`
- [ ] Live dashboard shows HF links on all three per-context sections