### PR TITLE
dashboard: emphasize Qwen3.6-35B-A3B as primary SOTA target

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -57,6 +57,24 @@
   .tcard .spec{font-family:"Sora";font-size:11.5px;color:var(--muted);margin-top:10px}
   .tcard a{font-size:12.5px;font-weight:600;margin-top:10px;display:inline-block}
   .arch{margin-left:auto;font-family:"Sora";font-size:10.5px;font-weight:700;color:var(--theme);background:rgba(123,93,255,.12);border:1px solid rgba(123,93,255,.35);border-radius:6px;padding:2px 7px;letter-spacing:.02em;white-space:nowrap}
+  .badge-sota{display:inline-block;font-family:"Sora";font-size:10.5px;font-weight:800;letter-spacing:.1em;text-transform:uppercase;color:#1a1500;background:linear-gradient(135deg,var(--theme2),#e8ff6a);border:1px solid rgba(212,255,18,.55);border-radius:6px;padding:3px 9px;vertical-align:middle}
+  .sota-spotlight{position:relative;overflow:hidden;background:linear-gradient(135deg,#0c0a18 0%,#1a1238 55%,#241653 100%);border:1px solid rgba(123,93,255,.35);border-radius:18px;padding:26px 28px;color:#e8e4f7;box-shadow:0 14px 40px rgba(123,93,255,.18);margin-top:28px}
+  .sota-spotlight::before{content:"";position:absolute;inset:0;background:radial-gradient(520px 220px at 88% 0%,rgba(212,255,18,.14),transparent 60%),radial-gradient(420px 200px at 8% 100%,rgba(123,93,255,.28),transparent 55%);pointer-events:none}
+  .sota-spotlight .inner{position:relative;z-index:1;display:grid;grid-template-columns:1.35fr 1fr;gap:24px;align-items:center}
+  .sota-eyebrow{font-size:11px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--theme2)}
+  .sota-spotlight h3{color:#fff;font-size:28px;font-weight:800;line-height:1.15;margin-top:8px}
+  .sota-spotlight h3 .hl{color:var(--theme2)}
+  .sota-spotlight p{font-size:14.5px;color:#b9b2d6;margin-top:10px;max-width:560px}
+  .sota-stats{display:grid;grid-template-columns:repeat(3,1fr);gap:12px}
+  .sota-stat{background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.12);border-radius:12px;padding:14px}
+  .sota-stat .n{font-family:"Sora";font-weight:800;font-size:24px;color:#fff;line-height:1}
+  .sota-stat .n span{font-size:12px;color:#9a93bd;font-weight:600}
+  .sota-stat .l{font-size:11.5px;color:#9a93bd;margin-top:6px;text-transform:uppercase;letter-spacing:.05em;font-weight:600}
+  .tcard.sota{border-color:rgba(212,255,18,.35);box-shadow:0 10px 32px rgba(123,93,255,.12)}
+  .tcard.sota::before{background:linear-gradient(90deg,var(--theme2),var(--theme))}
+  .cmp-card.sota{border-color:rgba(212,255,18,.45);background:linear-gradient(180deg,#fffef5 0%,#fbfbfd 100%);box-shadow:0 8px 24px rgba(184,134,11,.08)}
+  .sec-sota .sec-title-row h2{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+  @media(max-width:820px){.sota-spotlight .inner{grid-template-columns:1fr}.sota-stats{grid-template-columns:1fr 1fr}}
   /* hero image + card thumbnails (NVIDIA / MediaTek product imagery) */
   .hero-grid{display:grid;grid-template-columns:1.25fr 1fr;gap:34px;align-items:center;margin-top:26px}
   .hero-text .eyebrow{margin-top:0}
@@ -192,6 +210,7 @@
 
 <div class="wrap">
   <div class="kpis" id="kpis"></div>
+  <div class="sota-spotlight" id="sota-spotlight" aria-label="Primary SOTA model"></div>
 
   <section>
     <div class="sec-h"><h2>Target GPUs</h2><span class="hint">NVIDIA Blackwell, on-device — consumer <code>sm_120</code> + edge <code>sm_121</code> (not datacenter sm_100)</span></div>
@@ -220,17 +239,42 @@
   </section>
 
   <section>
-    <div class="sec-h"><h2>Target models</h2><span class="hint">two architecturally distinct MoEs — a win must hold on <b>both</b>, or it's overfitting</span></div>
+    <div class="sec-h"><h2>Target models</h2><span class="hint">primary SOTA target <b>Qwen3.6-35B-A3B</b> + architecturally distinct guards — a win must generalize, not overfit</span></div>
     <div class="grid2">
+      <div class="tcard sota"><img class="tcard-img tall" src="assets/img/qwen.jpg" alt="Qwen3.6-35B-A3B" loading="lazy"><h4>Qwen3.6-35B-A3B<span class="badge-sota">SOTA</span></h4>
+        <div class="role">primary model · state-of-the-art MoE</div>
+        <p>Hybrid <b>Gated-DeltaNet + full attention</b> MoE — 256 experts top-8, head_dim 256. The frontier model sparkinfer is built for: <b><span id="q36-frontier">—</span> tok/s</b> decode with <b><span id="q36-acc">—</span> top-1</b> vs llama.cpp on RTX 5090.</p>
+        <div class="spec" id="q36-arch-spec">UD-Q4_K_M · bidirectional eval guard on every PR</div></div>
       <div class="tcard"><img class="tcard-img tall" src="assets/img/qwen.jpg" alt="Qwen3-MoE" loading="lazy"><h4>Qwen3-MoE<span class="arch" style="color:var(--ok);background:rgba(14,138,22,.14);border-color:rgba(14,138,22,.3)">proven</span></h4>
-        <div class="role">model #1 · today's frontier</div>
-        <p>Qwen3-30B-A3B / 35B-A3B — 128–256 experts, top-8, GQA head_dim 128, uniform full attention. Runs end-to-end at the current frontier with <b><span id="hero-acc">—</span> token-match</b> vs llama.cpp.</p>
+        <div class="role">guard model #1 · legacy frontier</div>
+        <p>Qwen3-30B-A3B — 128 experts top-8, GQA head_dim 128, uniform full attention. Long-running optimization baseline with <b><span id="hero-acc">—</span> token-match</b> vs llama.cpp.</p>
         <div class="spec">Q4_K_M · experts kept quantized · verified on RTX 5090 + PRO 6000</div></div>
+    </div>
+    <div class="grid2" style="margin-top:18px">
       <div class="tcard"><img class="tcard-img tall" src="assets/img/gemma-4.jpg" alt="Gemma 4" loading="lazy"><h4>Gemma 4<span class="arch" style="color:var(--warn);background:rgba(184,134,11,.14);border-color:rgba(184,134,11,.35)">wiring</span></h4>
-        <div class="role">model #2 · the generality test</div>
+        <div class="role">guard model #2 · the generality test</div>
         <p>Gemma 4 26B-A4B — 128 experts top-8 + shared, interleaved local-SWA / global attention, <b>head_dim 512</b>, dual RoPE. Deliberately unlike Qwen, so an optimization can't overfit one architecture.</p>
         <div class="spec">distinct attention + routing → the anti-overfit guard for the basket</div></div>
+      <div class="tcard" style="display:flex;flex-direction:column;justify-content:center;background:linear-gradient(135deg,#fbfbfd 0%,#f3f0ff 100%)">
+        <div class="role">why Qwen3.6?</div>
+        <p style="margin-top:10px">Latest-generation open MoE with hybrid linear + full attention — the class of models agentic on-device stacks are racing to ship. sparkinfer tracks it as the <b>SOTA reference</b>: every PR is scored bidirectionally against Qwen3.6 with no-regression guards at 128/512/4k/16k/32k.</p>
+        <a class="hf-model" id="target-q36-hf" href="https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF" target="_blank" rel="noopener" style="margin-top:14px">
+          <img src="assets/img/huggingface.svg" alt="Hugging Face" width="22" height="22" loading="lazy">
+          <span class="hf-model-name">unsloth/Qwen3.6-35B-A3B-GGUF</span>
+          <span class="hf-dl" id="target-q36-dl"></span>
+        </a>
+      </div>
     </div>
+  </section>
+
+  <section class="sec-sota">
+    <div class="sec-h">
+      <div class="sec-title-row">
+        <h2>Qwen3.6-35B-A3B <span class="badge-sota">SOTA</span> · optimization journey</h2>
+      </div>
+      <span class="hint" id="passes36-hint"></span>
+    </div>
+    <div class="card"><div id="passes36"></div></div>
   </section>
 
   <section>
@@ -244,13 +288,23 @@
   </section>
 
   <section>
-    <div class="sec-h"><h2>Qwen3.6 · optimization journey</h2><span class="hint" id="passes36-hint"></span></div>
-    <div class="card"><div id="passes36"></div></div>
-  </section>
-
-  <section>
     <div class="sec-h"><h2>sparkinfer vs llama.cpp</h2><span class="hint">same GPU · same GGUF · 128-token decode</span></div>
     <div class="card" id="vsllama"></div>
+  </section>
+
+  <section class="sec-sota">
+    <div class="sec-h">
+      <div class="sec-title-row">
+        <h2>Qwen3.6-35B-A3B <span class="badge-sota">SOTA</span> · per-context</h2>
+        <a class="hf-model" id="detail-q36-hf" href="https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF" target="_blank" rel="noopener" title="unsloth/Qwen3.6-35B-A3B-GGUF">
+          <img src="assets/img/huggingface.svg" alt="Hugging Face" width="22" height="22" loading="eager" decoding="async">
+          <span class="hf-model-name">unsloth/Qwen3.6-35B-A3B-GGUF</span>
+          <span class="hf-dl" id="detail-q36-dl"></span>
+        </a>
+      </div>
+      <span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k / 16k / 32k</span>
+    </div>
+    <div class="card" id="detail-q36"></div>
   </section>
 
   <section>
@@ -281,21 +335,6 @@
       <span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k</span>
     </div>
     <div class="card" id="detail-q35"></div>
-  </section>
-
-  <section>
-    <div class="sec-h">
-      <div class="sec-title-row">
-        <h2>Qwen3.6 · per-context</h2>
-        <a class="hf-model" id="detail-q36-hf" href="https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF" target="_blank" rel="noopener" title="unsloth/Qwen3.6-35B-A3B-GGUF">
-          <img src="assets/img/huggingface.svg" alt="Hugging Face" width="22" height="22" loading="eager" decoding="async">
-          <span class="hf-model-name">unsloth/Qwen3.6-35B-A3B-GGUF</span>
-          <span class="hf-dl" id="detail-q36-dl"></span>
-        </a>
-      </div>
-      <span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k / 16k / 32k</span>
-    </div>
-    <div class="card" id="detail-q36"></div>
   </section>
 
   <section>
@@ -353,10 +392,41 @@
   wireHfModel("detail-q3-hf", "detail-q3-dl", D.status, "Qwen/Qwen3-30B-A3B-GGUF");
   wireHfModel("detail-q35-hf", "detail-q35-dl", D.qwen35, "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF");
   wireHfModel("detail-q36-hf", "detail-q36-dl", D.qwen36, "unsloth/Qwen3.6-35B-A3B-GGUF");
+  wireHfModel("target-q36-hf", "target-q36-dl", D.qwen36, "unsloth/Qwen3.6-35B-A3B-GGUF");
 
-  $("hero-meta").innerHTML = `GPU <b>${s.gpu}</b> &nbsp;·&nbsp; model <b>${s.model}</b>`;
+  const q36 = D.qwen36 || {};
+  const q36ctx128 = (q36.ctx||[]).find(x=>x.label==="128");
+  const q36Lead = q36ctx128 && q36ctx128.ref_tps ? 100*(q36ctx128.tps - q36ctx128.ref_tps)/q36ctx128.ref_tps : null;
+
+  $("hero-meta").innerHTML = `GPU <b>${s.gpu}</b> &nbsp;·&nbsp; SOTA target <b>Qwen3.6-35B-A3B</b> &nbsp;·&nbsp; guard <b>${s.model}</b>`;
   $("updated").textContent = "updated " + D.updated;
   $("hero-acc").textContent = (s.token_match*100).toFixed(0)+"%";   // live frontier accuracy, not hardcoded
+  if ($("q36-frontier")) $("q36-frontier").textContent = q36.frontier_tps || q36ctx128?.tps || "—";
+  if ($("q36-acc")) $("q36-acc").textContent = q36.token_match ? (q36.token_match*100).toFixed(1)+"%" : "—";
+  if ($("q36-arch-spec") && q36.arch) $("q36-arch-spec").textContent = q36.arch + " · UD-Q4_K_M · bidirectional eval guard on every PR";
+
+  const sotaEl = $("sota-spotlight");
+  if (sotaEl && q36.frontier_tps) {
+    const pctLlama = q36Lead != null ? (q36Lead>=0?"+":"")+q36Lead.toFixed(0)+"%" : "—";
+    const pctAll = q36.ref_tps ? ((q36.frontier_tps/q36.ref_tps)*100).toFixed(0)+"%" : "—";
+    sotaEl.innerHTML = `<div class="inner">
+      <div>
+        <div class="sota-eyebrow">Primary eval target</div>
+        <h3><span class="badge-sota">SOTA</span> Qwen3.6-35B-A3B</h3>
+        <p>${q36.arch || "Hybrid Gated-DeltaNet + full-attention MoE"}. sparkinfer optimizes for this state-of-the-art open model — every merged PR is verified on the same RTX 5090 box with Polaris-attested logs and no-regression guards across 128→32k context.</p>
+        <a class="hf-model" href="https://huggingface.co/${q36.hf_repo||"unsloth/Qwen3.6-35B-A3B-GGUF"}" target="_blank" rel="noopener" style="margin-top:14px;color:#e8e4f7">
+          <img src="${q36.hf_avatar||"assets/img/huggingface.svg"}" alt="Hugging Face" width="22" height="22">
+          <span class="hf-model-name" style="color:#fff">${q36.hf_repo||"unsloth/Qwen3.6-35B-A3B-GGUF"}</span>
+          ${q36.hf_downloads ? `<span class="hf-dl" style="color:#9a93bd">· ${fmtDl(q36.hf_downloads)} downloads</span>` : ""}
+        </a>
+      </div>
+      <div class="sota-stats">
+        <div class="sota-stat"><div class="n">${q36.frontier_tps} <span>tok/s</span></div><div class="l">128-tok frontier</div></div>
+        <div class="sota-stat"><div class="n">${pctLlama}</div><div class="l">vs ${q36.ref_name||"llama.cpp"} @128</div></div>
+        <div class="sota-stat"><div class="n">${pctAll}</div><div class="l">of ${q36.ref_name||"llama.cpp"} speed</div></div>
+      </div>
+    </div>`;
+  }
 
   const ahead = s.frontier_tps >= s.ref_tps;
   const pct   = 100*(s.frontier_tps - s.ref_tps)/s.ref_tps;   // +ve when sparkinfer leads
@@ -449,15 +519,15 @@
   (function(){
     const C128 = ctxColor(128);
     const models = [
+      {key:"q36", title:"Qwen3.6-35B-A3B", sub:"SOTA · UD-Q4_K_M · 128-tok decode", sota:true,
+       sp:(D.qwen36?.ctx||[]).find(x=>x.label==="128")?.tps||0,
+       ll:(D.qwen36?.ctx||[]).find(x=>x.label==="128")?.ref_tps||0},
       {key:"q3", title:"Qwen3-MoE 30B-A3B", sub:"Q4_K_M · 128-tok decode",
        sp:(D.context_baselines||[]).find(x=>x.ctx===128)?.sparkinfer_tps||0,
        ll:(D.context_baselines||[]).find(x=>x.ctx===128)?.llamacpp_decode_tps||0},
       {key:"q35", title:"Qwen3.5 9B", sub:"Qwythos · Q4_K_M · 128-tok decode",
        sp:(D.qwen35?.ctx||[]).find(x=>x.label==="128")?.tps||0,
        ll:(D.qwen35?.ctx||[]).find(x=>x.label==="128")?.ref_tps||0},
-      {key:"q36", title:"Qwen3.6 35B-A3B", sub:"UD-Q4_K_M · 128-tok decode",
-       sp:(D.qwen36?.ctx||[]).find(x=>x.label==="128")?.tps||0,
-       ll:(D.qwen36?.ctx||[]).find(x=>x.label==="128")?.ref_tps||0},
     ].filter(m=>m.sp>0||m.ll>0);
     if (!models.length) return;
     const pct = (sp,ll)=> ll>0 && sp>0 ? 100*(sp-ll)/ll : null;
@@ -465,10 +535,10 @@
       const d=pct(m.sp,m.ll), max=Math.max(m.sp,m.ll,1);
       const bar=v=>Math.max(4,100*v/max);
       const fmt=v=>v>0?v.toFixed(2):"—";
-      return `<div class="cmp-card">
+      return `<div class="cmp-card${m.sota?" sota":""}">
         <div class="cmp-top">
           <div>
-            <div class="cmp-title"><span class="cmp-dot" style="background:${C128}"></span>${m.title}</div>
+            <div class="cmp-title"><span class="cmp-dot" style="background:${C128}"></span>${m.title}${m.sota?` <span class="badge-sota">SOTA</span>`:""}</div>
             <div class="cmp-sub">${m.sub}</div>
           </div>
           ${d!=null?`<div class="cmp-delta${d<0?' neg':''}">${d>=0?'+':''}${d.toFixed(1)}%</div>`:''}


### PR DESCRIPTION
## Summary
- Add SOTA spotlight banner with live Qwen3.6 frontier stats (+71% vs llama.cpp @128)
- Restructure Target models section: Qwen3.6-35B-A3B featured first with SOTA badge
- Reorder Qwen3.6 journey/per-context sections above other models
- Highlight Qwen3.6 card in sparkinfer vs llama.cpp comparison

## Test plan
- [ ] Open dashboard locally — SOTA spotlight shows below KPIs with 473 tok/s frontier
- [ ] Target models card shows SOTA badge on Qwen3.6
- [ ] Qwen3.6 sections appear first in journey and per-context blocks