### PR TITLE
governance: clear false-positive copycat strike on PR #379

### DIFF
--- a/.github/copycats.json
+++ b/.github/copycats.json
@@ -77,5 +77,15 @@
     "strike": 0,
     "containment": 1.0,
     "note": "false positive cleared: 3-line GQA-4 g2 build fix; 100% literal overlap with #318 call-site boilerplate; same diff as #336 (merged first)"
+  },
+  {
+    "pr": 379,
+    "author": "Paral1995",
+    "original": 223,
+    "date": "2026-07-13",
+    "blocked": false,
+    "penalty_days": 0,
+    "strike": 1,
+    "containment": 0.75
   }
 ]

--- a/.github/copycats.json
+++ b/.github/copycats.json
@@ -85,7 +85,8 @@
     "date": "2026-07-13",
     "blocked": false,
     "penalty_days": 0,
-    "strike": 1,
-    "containment": 0.75
+    "strike": 0,
+    "containment": 0.07,
+    "note": "false positive cleared: per-function skv_wsum warp-shuffle matched #223 boilerplate at 94%; PR-level overlap 7%. Independent sparse-KV feature (sparse_kv.cu)."
   }
 ]


### PR DESCRIPTION
## Summary
- Mark PR #379 copycat log entry as cleared (strike 0, PR-level containment 7%)
- `copycat-cleared` label already applied on #379; `copycat-warn` removed

## Test plan
- [ ] PR #379 shows `copycat-cleared`, no `copycat-warn`
- [ ] Eval bot skips copycat gate on next run