### PR TITLE
Fix eval bot skip logic for errored PR comments

### DIFF
--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -371,12 +371,24 @@ def flag_copycat(repo, num, original, author):
             f"See [`.github/COPYCATS.md`](../blob/main/.github/COPYCATS.md).")
     gh(["pr", "comment", str(num), "-R", repo, "--body", body])
 
+def _evaluated_commit_from_comment(body):
+    """Return commit oid if a PR comment records a completed eval verdict, else None.
+
+    Error posts reuse the eval marker but lack the verdict header — they must not block re-runs."""
+    if not body or "auto-eval errored" in body:
+        return None
+    m = re.search(r"<!-- sparkinfer-eval:([0-9a-f]+) -->", body)
+    if not m or "sparkinfer auto-eval —" not in body:
+        return None
+    return m.group(1)
+
 def evaluated_commits(repo, num):
     r = gh(["pr", "view", str(num), "-R", repo, "--json", "comments"])
     done = set()
     for c in json.loads(r.stdout or "{}").get("comments", []):
-        for m in re.finditer(r"<!-- sparkinfer-eval:([0-9a-f]+) -->", c.get("body", "")):
-            done.add(m.group(1))
+        oid = _evaluated_commit_from_comment(c.get("body", ""))
+        if oid:
+            done.add(oid)
     return done
 
 def areas_for_pr(repo, num):
@@ -1765,7 +1777,7 @@ def main():
         if not line:
             log = (r.stdout + r.stderr)[-1500:]
             print(f"PR #{num}: eval produced no result\n{log}")
-            body = (f"<!-- sparkinfer-eval:{oid} -->\n⚠️ **sparkinfer auto-eval errored** for `{oid}` "
+            body = (f"<!-- sparkinfer-eval-error:{oid} -->\n⚠️ **sparkinfer auto-eval errored** for `{oid}` "
                     f"— re-run manually.\n\n<details><summary>log tail</summary>\n\n```\n{log}\n```\n</details>")
             res, label = None, None
         else:

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -356,6 +356,31 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual(closed, {99})
         gh_mock.assert_called_once()
 
+    def test_evaluated_commit_from_comment_accepts_verdict(self):
+        body = bot.render({"label": "S", "pass": True, "tps": 200.0, "top1": 1.0, "kl": 0.0}, "df74674")
+        self.assertEqual(bot._evaluated_commit_from_comment(body), "df74674")
+
+    def test_evaluated_commit_from_comment_rejects_error_marker(self):
+        body = ("<!-- sparkinfer-eval:df74674 -->\n"
+                "⚠️ **sparkinfer auto-eval errored** for `df74674` — re-run manually.")
+        self.assertIsNone(bot._evaluated_commit_from_comment(body))
+
+    def test_evaluated_commit_from_comment_rejects_error_marker_v2(self):
+        body = ("<!-- sparkinfer-eval-error:df74674 -->\n"
+                "⚠️ **sparkinfer auto-eval errored** for `df74674` — re-run manually.")
+        self.assertIsNone(bot._evaluated_commit_from_comment(body))
+
+    def test_evaluated_commits_ignores_errored_comments(self):
+        comments = [
+            {"body": "<!-- sparkinfer-eval:df74674 -->\n⚠️ **sparkinfer auto-eval errored**"},
+            {"body": bot.render({"label": "REJECT", "pass": False, "reason": "x",
+                                 "tps": 0, "top1": 0, "kl": 0}, "abc1234")},
+        ]
+        gh_mock = mock.Mock(return_value=mock.Mock(stdout=json.dumps({"comments": comments})))
+        with mock.patch.object(bot, "gh", gh_mock):
+            done = bot.evaluated_commits("gittensor-ai-lab/sparkinfer", 379)
+        self.assertEqual(done, {"abc1234"})
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Only treat PR comments with a completed verdict header as already evaluated
- Use a distinct `sparkinfer-eval-error` marker for failed eval posts so they do not block re-runs
- Add unit tests for the skip logic (including PR #379-style error comments)

## Test plan
- [x] `python3 eval/test_pr_eval_bot.py`
- [ ] Next bot run re-evaluates PR #379 instead of skipping it