### PR TITLE
dashboard: show Qwen3.5 prefill pp state

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -4454,6 +4454,34 @@ window.SPARKINFER = {
         "tps": 159.19,
         "ref_tps": 220.58
       }
+    ],
+    "prefill_frontier_pp": 290.57,
+    "prefill_label": "XL",
+    "pp": [
+      {
+        "label": "4k",
+        "color": "#0E8A16",
+        "pp": 290.57,
+        "ref_pp": 11104.62
+      },
+      {
+        "label": "32k",
+        "color": "#6F42C1",
+        "pp": 272.07,
+        "ref_pp": 9772.31
+      },
+      {
+        "label": "64k",
+        "color": "#E67E22",
+        "pp": 256.23,
+        "ref_pp": 8153.53
+      },
+      {
+        "label": "128k",
+        "color": "#17A2B8",
+        "pp": 227.87,
+        "ref_pp": 5999.59
+      }
     ]
   },
   "landed_qwen35": [

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -4453,6 +4453,34 @@
         "tps": 159.19,
         "ref_tps": 220.58
       }
+    ],
+    "prefill_frontier_pp": 290.57,
+    "prefill_label": "XL",
+    "pp": [
+      {
+        "label": "4k",
+        "color": "#0E8A16",
+        "pp": 290.57,
+        "ref_pp": 11104.62
+      },
+      {
+        "label": "32k",
+        "color": "#6F42C1",
+        "pp": 272.07,
+        "ref_pp": 9772.31
+      },
+      {
+        "label": "64k",
+        "color": "#E67E22",
+        "pp": 256.23,
+        "ref_pp": 8153.53
+      },
+      {
+        "label": "128k",
+        "color": "#17A2B8",
+        "pp": 227.87,
+        "ref_pp": 5999.59
+      }
     ]
   },
   "landed_qwen35": [

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -322,9 +322,17 @@
           <span class="hf-dl" id="detail-q35-dl"></span>
         </a>
       </div>
-      <span class="hint">sparkinfer vs llama.cpp · 128 / 512 / 4k</span>
+      <span class="hint">sparkinfer vs llama.cpp · 128 / 4k / 32k / 64k / 128k decode</span>
     </div>
     <div class="card" id="detail-q35"></div>
+  </section>
+
+  <section>
+    <div class="sec-h">
+      <h2>Qwen3.5 <span class="model-eq">(Qwythos)</span> · prefill</h2>
+      <span class="hint" id="detail-q35-pp-hint">sparkinfer vs llama.cpp · 4k / 32k / 64k / 128k context</span>
+    </div>
+    <div class="card" id="detail-q35-pp"></div>
   </section>
 
   <section>
@@ -484,7 +492,11 @@
     if (h) {
       const f = q.frontier_tps || (pts.length ? pts[pts.length-1].tps : 0);
       const b = base || f;
-      if (b && f) h.textContent = `${b} → ${f} tok/s · ${q.ref_tps?((f/q.ref_tps)*100).toFixed(0)+'% of '+q.ref_name+' '+q.ref_tps:'—'}`;
+      if (b && f) {
+      let t = `${b} → ${f} tok/s · ${q.ref_tps?((f/q.ref_tps)*100).toFixed(0)+'% of '+q.ref_name+' '+q.ref_tps:'—'}`;
+      if (q.prefill_frontier_pp) t += ` · prefill ${q.prefill_frontier_pp} pp tok/s${q.prefill_label?' (eval-prefill:'+q.prefill_label+')':''}`;
+      h.textContent = t;
+    }
     }
     if (!pts.length && q.ref_tps) {
       pts.push({name:"llama.cpp", sub:"reference · 128-tok decode", tps:q.ref_tps, llama:true, fixed:true});
@@ -594,7 +606,39 @@
         <div class="v" style="font-size:12px;color:var(--body);margin-left:8px">${fmt(x.ref_tps)}${d!=null?` <span style="color:${d>=0?'var(--ok)':'var(--bad)'};font-weight:700;font-size:13px">${d>=0?'+':''}${d.toFixed(1)}%</span>`:''}</div>
       </div>`
     }).join("");
-    $("detail-q35").innerHTML = `${detailRows}<div class="ctx-note" style="margin-top:12px">sparkinfer vs llama.cpp · same GPU · Qwythos-9B Q4_K_M GGUF</div>`;
+    $("detail-q35").innerHTML = `${detailRows}<div class="ctx-note" style="margin-top:12px">sparkinfer vs llama.cpp · same GPU · Qwythos-9B Q4_K_M GGUF · decode</div>`;
+  })();
+
+  // Qwen3.5 prefill detail: 4k / 32k / 64k / 128k pp vs llama.cpp
+  (function(){
+    const q = D.qwen35 || {};
+    const rows = (q.pp||[]).filter(x=>x.ref_pp);
+    const hint = $("detail-q35-pp-hint");
+    if (hint && q.prefill_frontier_pp) {
+      hint.textContent = `frontier ${q.prefill_frontier_pp} pp tok/s${q.prefill_label?' · eval-prefill:'+q.prefill_label:''} · 4k / 32k / 64k / 128k context`;
+    }
+    if (!rows.length) {
+      if ($("detail-q35-pp")) $("detail-q35-pp").innerHTML = `<div class="ctx-note">Prefill baselines pending — bidir eval with SPARKINFER_EVAL_PREFILL=1 populates this chart.</div>`;
+      return;
+    }
+    const maxT = Math.max(...rows.flatMap(x=>[x.pp||0, x.ref_pp]));
+    const fmt=v=>v>0?v.toFixed(2):"pending"; const bar=v=>Math.max(3, 100*v/maxT);
+    const ppColor = lbl => ({4k:"#0E8A16", "32k":"#6F42C1", "64k":"#E67E22", "128k":"#17A2B8"}[lbl]||"#7B5DFF");
+    const detailRows = rows.map(x=>{
+      const d=x.pp>0?100*(x.pp-x.ref_pp)/x.ref_pp:null;
+      const col=x.color||ppColor(x.label);
+      return `<div class="bar-row">
+        <div class="nm">${x.label}<small>prefill pp</small></div>
+        <div class="track"><div class="fill" style="width:${x.pp>0?bar(x.pp):0}%;background:linear-gradient(90deg,${col},${col}88)"></div></div>
+        <div class="v" style="font-size:12px;color:var(--body);margin-left:8px">${fmt(x.pp)}</div>
+      </div>
+      <div class="bar-row">
+        <div class="nm">llama.cpp</div>
+        <div class="track"><div class="fill them" style="width:${bar(x.ref_pp)}%;background:${LLAMA_FILL}"></div></div>
+        <div class="v" style="font-size:12px;color:var(--body);margin-left:8px">${fmt(x.ref_pp)}${d!=null?` <span style="color:${d>=0?'var(--ok)':'var(--bad)'};font-weight:700;font-size:13px">${d>=0?'+':''}${d.toFixed(1)}%</span>`:''}</div>
+      </div>`
+    }).join("");
+    $("detail-q35-pp").innerHTML = `${detailRows}<div class="ctx-note" style="margin-top:12px">sparkinfer vs llama.cpp · same GPU · Qwythos-9B Q4_K_M GGUF · prefill throughput (pp tok/s)</div>`;
   })();
 
   // Qwen3.6 per-context detail: 128 / 512 / 4k bars vs llama.cpp

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -713,6 +713,14 @@ Q35_CTX_SERIES = {
     65536:  {"label": "64k",  "ref_tps": 220.54},
     131072: {"label": "128k", "ref_tps": 220.58},
 }
+# Qwen3.5 prefill pp anchors — pinned in bench/scripts/reference.lock (RTX 5090).
+Q35_PP_ORDER = ("4k", "32k", "64k", "128k")
+Q35_PP_SERIES = {
+    4096:   {"label": "4k",   "metric": "ctx_4096_pp_tps",  "ref_pp": 11104.62, "color": "#0E8A16"},
+    32768:  {"label": "32k",  "metric": "ctx_32768_pp_tps", "ref_pp": 9772.31,  "color": "#6F42C1"},
+    65536:  {"label": "64k",  "metric": "ctx_65536_pp_tps", "ref_pp": 8153.53,  "color": "#E67E22"},
+    131072: {"label": "128k", "metric": "ctx_131072_pp_tps", "ref_pp": 5999.59, "color": "#17A2B8"},
+}
 Q36_CTX_ORDER = ("128", "512", "4k", "16k", "32k")
 # Qwen3.6-35B-A3B llama.cpp decode refs (RTX 5090) — pinned in bench/scripts/reference.lock
 Q36_LLAMA_REF = {128: 275.81, 512: 275.61, 4096: 276.3, 16384: 280.66, 32768: 279.83}
@@ -1084,6 +1092,49 @@ def _upsert_qwen35_ctx(data, sub):
         q35["ctx"] = [ctx_rows[k] for k in Q35_CTX_ORDER if k in ctx_rows]
     return changed
 
+def _upsert_qwen35_pp(data, sub):
+    """Refresh Qwen3.5 per-context prefill pp bars from a merged bidir score_qwen35 block."""
+    q35 = data.setdefault("qwen35", {})
+    pp_rows = {r.get("label"): r for r in q35.get("pp") or []}
+    changed = False
+    for ctx, meta in Q35_PP_SERIES.items():
+        measured = sub.get(meta["metric"])
+        if measured is None:
+            continue
+        new = round(float(measured), 2)
+        old = round(float((pp_rows.get(meta["label"]) or {}).get("pp") or 0), 2)
+        if old and new < old:
+            continue
+        row = pp_rows.get(meta["label"])
+        if row:
+            if old != new:
+                row["pp"] = new
+                row["color"] = meta["color"]
+                changed = True
+        else:
+            pp_rows[meta["label"]] = {
+                "label": meta["label"], "color": meta["color"],
+                "pp": new, "ref_pp": meta["ref_pp"],
+            }
+            changed = True
+    if changed:
+        q35["pp"] = [pp_rows[k] for k in Q35_PP_ORDER if k in pp_rows]
+    scored = sub.get("prefill_tps")
+    if scored is not None:
+        old_f = round(float(q35.get("prefill_frontier_pp") or 0), 2)
+        new_f = round(max(old_f, float(scored)), 2)
+        if new_f != old_f:
+            q35["prefill_frontier_pp"] = new_f
+            changed = True
+    elif changed and q35.get("pp"):
+        peak = max(float(r.get("pp") or 0) for r in q35["pp"])
+        old_f = round(float(q35.get("prefill_frontier_pp") or 0), 2)
+        if peak > old_f:
+            q35["prefill_frontier_pp"] = round(peak, 2)
+    if sub.get("prefill_label"):
+        q35["prefill_label"] = sub["prefill_label"]
+    return changed
+
 def _upsert_qwen36_ctx(data, sub):
     """Refresh Qwen3.6 per-context sparkinfer bars from a merged bidir score_qwen36 block.
 
@@ -1166,6 +1217,7 @@ def record_merge(repo, num):
             if sub.get("top1") is not None: q35["token_match"] = round(sub["top1"], 4)
             if sub.get("kl") is not None:   q35["kl"] = round(sub["kl"], 4)
             _upsert_qwen35_ctx(data, sub)
+            _upsert_qwen35_pp(data, sub)
             short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
             landed = [m for m in data.get("landed_qwen35", []) if m.get("pr") != num]
             landed.append({"name": short or f"PR #{num}", "tps": new_f, "pr": num,

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -215,6 +215,36 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         by2 = {r["label"]: r["tps"] for r in data["qwen35"]["ctx"]}
         self.assertEqual(by2, by)
 
+    def test_qwen35_pp_uses_measured_pp_without_scaling(self):
+        data = {
+            "qwen35": {
+                "prefill_frontier_pp": 290.57,
+                "pp": [
+                    {"label": "4k", "pp": 290.57, "ref_pp": 11104.62},
+                    {"label": "32k", "pp": 272.07, "ref_pp": 9772.31},
+                ],
+            }
+        }
+        sub = {
+            "ctx_4096_pp_tps": 295.0,
+            "ctx_32768_pp_tps": 278.5,
+            "ctx_65536_pp_tps": 260.0,
+            "ctx_131072_pp_tps": 230.0,
+            "prefill_tps": 295.0,
+            "prefill_label": "M",
+        }
+        bot._upsert_qwen35_pp(data, sub)
+        by = {r["label"]: r["pp"] for r in data["qwen35"]["pp"]}
+        self.assertEqual(by["4k"], 295.0)
+        self.assertEqual(by["32k"], 278.5)
+        self.assertEqual(by["64k"], 260.0)
+        self.assertEqual(by["128k"], 230.0)
+        self.assertEqual(data["qwen35"]["prefill_frontier_pp"], 295.0)
+        self.assertEqual(data["qwen35"]["prefill_label"], "M")
+        bot._upsert_qwen35_pp(data, sub)
+        by2 = {r["label"]: r["pp"] for r in data["qwen35"]["pp"]}
+        self.assertEqual(by2, by)
+
     def test_qwen36_ctx_uses_measured_tps_without_scaling(self):
         data = {
             "qwen36": {


### PR DESCRIPTION
## Summary
- Seed Qwythos prefill baselines (4k/32k/64k/128k pp tok/s) in dashboard data
- Upsert prefill bars on Qwen3.5 PR merge via `_upsert_qwen35_pp`
- Add dedicated prefill section to the public dashboard and show frontier in journey hint

## Test plan
- [x] `python3 -m unittest test_pr_eval_bot.PrEvalBotPolicyTest.test_qwen35_pp_uses_measured_pp_without_scaling`
- [ ] Open dashboard locally and confirm prefill bars render for all four contexts