### PR TITLE
perf(qwen35): skip LM head on prefill + dedicated prefill CUDA graph

### DIFF
--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -152,8 +152,29 @@ static bool init_session(BenchSession& s, const std::string& path, int max_ctx, 
 static int run_single(const std::string& path, int n_tokens, int context_tokens) {
     BenchSession s;
     if (!init_session(s, path, context_tokens, n_tokens)) return 1;
+
+    const int suffix_len = (context_tokens > 0 && getenv("SPARKINFER_BENCH_PREFIX_TTFT"))
+        ? std::max(0, atoi(getenv("SPARKINFER_BENCH_PREFIX_TTFT")))
+        : 0;
+    if (suffix_len > 0 && context_tokens > suffix_len) {
+        std::vector<int> prefix((size_t)(context_tokens - suffix_len), 100);
+        std::vector<int> full((size_t)context_tokens, 100);
+        s.model->clear_prefix_cache();
+        double cold = s.model->bench_ttft(full);
+        if (!s.model->cache_prefix(prefix)) {
+            printf("[FAIL] cache_prefix(%d tokens)\n", (int)prefix.size());
+            return 1;
+        }
+        double warm = s.model->bench_ttft(full);
+        s.model->clear_prefix_cache();
+        printf("prefix_ttft  : cold %.3f s (full %d tok) · warm %.3f s (reuse %d + suffix %d)\n",
+               cold, context_tokens, warm, (int)prefix.size(), suffix_len);
+        if (warm > 0. && cold > 0.)
+            printf("prefix_speedup: %.1fx TTFT on cached prefix\n", cold / warm);
+    }
+
     auto bench = s.model->bench_decode(8, n_tokens, context_tokens);
-  auto gpu = sparkinfer::query_gpu_stats();
+    auto gpu = sparkinfer::query_gpu_stats();
     printf("\n=== sparkinfer bench (%s) ===\n", s.gguf_mode ? "Q4_K_M native" : "bf16");
     printf("model        : %s  (%d layers, %d experts top-%d)\n",
            qwen3_model_label(s.cfg), s.cfg.n_layers, s.cfg.n_experts, s.cfg.top_k);

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -171,6 +171,16 @@ static int run_single(const std::string& path, int n_tokens, int context_tokens)
                cold, context_tokens, warm, (int)prefix.size(), suffix_len);
         if (warm > 0. && cold > 0.)
             printf("prefix_speedup: %.1fx TTFT on cached prefix\n", cold / warm);
+    } else {
+        const bool bench_ttft = context_tokens > 0 &&
+            (getenv("SPARKINFER_BENCH_TTFT") || context_tokens >= 512);
+        if (bench_ttft) {
+            std::vector<int> prompt((size_t)context_tokens, 100);
+            double ttft = model.bench_ttft(prompt);
+            if (ttft > 0.)
+                printf("ttft         : %.3f s  (%.1f tok/s prefill, prompt=%d)\n",
+                       ttft, context_tokens / ttft, context_tokens);
+        }
     }
 
     auto bench = s.model->bench_decode(8, n_tokens, context_tokens);

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -176,7 +176,7 @@ static int run_single(const std::string& path, int n_tokens, int context_tokens)
             (getenv("SPARKINFER_BENCH_TTFT") || context_tokens >= 512);
         if (bench_ttft) {
             std::vector<int> prompt((size_t)context_tokens, 100);
-            double ttft = model.bench_ttft(prompt);
+            double ttft = s.model->bench_ttft(prompt);
             if (ttft > 0.)
                 printf("ttft         : %.3f s  (%.1f tok/s prefill, prompt=%d)\n",
                        ttft, context_tokens / ttft, context_tokens);

--- a/runtime/examples/qwen3_gguf_generate.cpp
+++ b/runtime/examples/qwen3_gguf_generate.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     if (!g.open(path)) { printf("[FAIL] cannot open %s\n", path.c_str()); return 1; }
     sparkinfer::Qwen35Config cfg;
     qwen3_config_from_gguf(g, cfg);
-    cfg.max_seq    = 2048;
+    cfg.max_seq    = std::max(2048, (int)prompt.size() + max_new + 16);
     printf("arch: %s, %d layers, hidden %d, %dQ/%dKV hd%d, %d experts top-%d, ffn %d, vocab %d\n",
            qwen3_model_label(cfg), cfg.n_layers, cfg.hidden, cfg.n_q_heads,
            cfg.n_kv_heads, cfg.head_dim, cfg.n_experts, cfg.top_k, cfg.moe_ffn, cfg.vocab);
@@ -100,6 +100,17 @@ int main(int argc, char** argv) {
     if (tg.enabled)
         printf("thermal: ON (turbo<%d°C, balanced≥%d, safe≥%d, emergency≥%d)\n",
                tg.balanced_c, tg.balanced_c, tg.safe_c, tg.emergency_c);
+
+    if (const char* pl = getenv("SPARKINFER_PREFIX_CACHE_LEN")) {
+        int n = atoi(pl);
+        if (n > 0 && n < (int)prompt.size()) {
+            std::vector<int> prefix(prompt.begin(), prompt.begin() + n);
+            if (!model.cache_prefix(prefix))
+                printf("[FAIL] cache_prefix(%d)\n", n);
+            else
+                printf("prefix_cache: installed %d / %zu prompt tokens\n", n, prompt.size());
+        }
+    }
 
     auto out = model.generate(prompt, max_new, tg.enabled ? &gov : nullptr);
     sampling.store(false, std::memory_order_relaxed);

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -79,7 +79,7 @@ int main(int argc, char** argv) {
     std::vector<int> idx(V);
     double nll = 0.0; int scored = 0, ammatch = 0;
     const int K = std::min(topk, V);
-    const size_t i0 = prefix_len > 0 ? (size_t)prefix_len - 1 : 0;
+    const size_t i0 = prefix_len > 0 ? (size_t)prefix_len : 0;
 
     for (size_t i = i0; i + 1 < toks.size(); i++) {
         int am = model.forward_token(toks[i], (int)i);   // logits predict token i+1

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -65,13 +65,23 @@ int main(int argc, char** argv) {
     // seq_id); generate() allocates it — do the same here before scoring.
     if (!kv.allocate(0, cfg.max_seq)) { printf("[FAIL] KV allocate\n"); return 1; }
 
+    int prefix_len = 0;
+    if (const char* pl = getenv("SPARKINFER_PREFIX_CACHE_LEN")) {
+        prefix_len = atoi(pl);
+        if (prefix_len > 0 && prefix_len < (int)toks.size()) {
+            std::vector<int> prefix(toks.begin(), toks.begin() + prefix_len);
+            if (!model.cache_prefix(prefix)) { printf("[FAIL] cache_prefix(%d)\n", prefix_len); return 1; }
+        } else prefix_len = 0;
+    }
+
     const int V = cfg.vocab;
     std::vector<float> lg(V);
     std::vector<int> idx(V);
     double nll = 0.0; int scored = 0, ammatch = 0;
     const int K = std::min(topk, V);
+    const size_t i0 = prefix_len > 0 ? (size_t)prefix_len - 1 : 0;
 
-    for (size_t i = 0; i + 1 < toks.size(); i++) {
+    for (size_t i = i0; i + 1 < toks.size(); i++) {
         int am = model.forward_token(toks[i], (int)i);   // logits predict token i+1
         model.copy_logits(lg.data());
         float mx = lg[0];

--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -30,8 +30,12 @@ public:
     explicit KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes);
     ~KVCacheManager();
 
-    // Allocate physical blocks for a new sequence; returns false if OOM
+    // Allocate physical blocks for a sequence (grows if already allocated).
+    // Returns false if OOM. Idempotent when num_tokens fits existing allocation.
     bool allocate(uint64_t seq_id, int num_tokens);
+
+    // Tokens already covered by the current block allocation for seq_id (0 if none).
+    int allocated_tokens(uint64_t seq_id) const;
 
     // Free all blocks owned by a sequence
     void free(uint64_t seq_id);

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -86,8 +86,23 @@ public:
 
     // Greedy generate: prompt token ids -> generated token ids (host). An optional ThermalGovernor
     // paces decode under thermal pressure (accuracy-preserving); nullptr = full speed, no overhead.
+    // When a prefix cache is installed (cache_prefix), skips re-prefilling the matching prefix.
     std::vector<int> generate(const std::vector<int>& prompt_ids, int max_new_tokens,
                               ThermalGovernor* gov = nullptr);
+
+    // Prefill `tokens` and retain KV + hybrid recurrent state for reuse on the next request
+    // whose prompt starts with the same token sequence. Returns false on allocation failure.
+    bool cache_prefix(const std::vector<int>& tokens);
+
+    // Drop the installed prefix cache and free its KV blocks.
+    void clear_prefix_cache();
+
+    // Length of the currently cached prefix (0 if none).
+    int prefix_cached_len() const;
+
+    // Time-to-first-token: prefill `prompt` then one sampled step. Reuses cache_prefix when the
+    // prompt starts with the cached tokens (only the suffix is prefilled).
+    double bench_ttft(const std::vector<int>& prompt);
 
     // Run one token at `position`, return the argmax next-token id.
     int forward_token(int token_id, int position);
@@ -106,6 +121,9 @@ public:
     const Qwen35Config& config() const;
 
 private:
+    void invalidate_decode_graph();
+    bool prompt_matches_prefix(const std::vector<int>& prompt) const;
+
     struct Impl;
     Impl* p_;
 };

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -104,8 +104,11 @@ public:
     // prompt starts with the cached tokens (only the suffix is prefilled).
     double bench_ttft(const std::vector<int>& prompt);
 
-    // Run one token at `position`, return the argmax next-token id.
-    int forward_token(int token_id, int position);
+    // Run one token at `position`. When sample=false (prefill), runs embed→layers→final
+    // norm without LM head/argmax and without CUDA-graph capture — teacher-forced ingestion.
+    // When sample=true (decode / last prompt token), runs the full path and may capture/replay
+    // the decode graph. Returns argmax next-token id when sample=true, else token_id.
+    int forward_token(int token_id, int position, bool sample = true);
 
     // Copy the most recent step's logits (vocab floats) to host. Valid after a
     // forward_token() call. Used for teacher-forced scoring (perplexity / KL).
@@ -117,6 +120,10 @@ public:
     };
     // Benchmark at a target KV depth: timed prefill, untimed warmup decode, timed decode.
     BenchDecodeResult bench_decode(int warmup, int n_tokens, int context_tokens = 0);
+
+    // Time-to-first-token: ingest `prompt` with prefill (no LM head on interior tokens),
+    // then one sampled forward for the first output token. Returns seconds (lower = better).
+    double bench_ttft(const std::vector<int>& prompt);
 
     const Qwen35Config& config() const;
 

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -100,8 +100,9 @@ public:
     // Length of the currently cached prefix (0 if none).
     int prefix_cached_len() const;
 
-    // Time-to-first-token: prefill `prompt` then one sampled step. Reuses cache_prefix when the
-    // prompt starts with the cached tokens (only the suffix is prefilled).
+    // Time-to-first-token: ingest `prompt` with prefill (no LM head on interior tokens when
+    // not legacy), then one sampled forward. Reuses cache_prefix when the prompt starts with
+    // the cached tokens (only the suffix is prefilled). Returns seconds.
     double bench_ttft(const std::vector<int>& prompt);
 
     // Run one token at `position`. When sample=false (prefill), runs embed→layers→final
@@ -120,10 +121,6 @@ public:
     };
     // Benchmark at a target KV depth: timed prefill, untimed warmup decode, timed decode.
     BenchDecodeResult bench_decode(int warmup, int n_tokens, int context_tokens = 0);
-
-    // Time-to-first-token: ingest `prompt` with prefill (no LM head on interior tokens),
-    // then one sampled forward for the first output token. Returns seconds (lower = better).
-    double bench_ttft(const std::vector<int>& prompt);
 
     const Qwen35Config& config() const;
 

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -83,20 +83,41 @@ KVCacheManager::~KVCacheManager() {
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
     const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
-    if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
     if (need > kMaxBlocksPerSeq) return false;
 
     auto& blocks = impl_->seq_blocks[seq_id];
-    for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
+    const int have = (int)blocks.size();
+    if (have >= need) {
+        auto it = impl_->seq_slot.find(seq_id);
+        return it != impl_->seq_slot.end();
+    }
+    const int grow = need - have;
+    if ((int)impl_->free_list.size() < grow) return false;
 
     int slot;
     auto it = impl_->seq_slot.find(seq_id);
     if (it != impl_->seq_slot.end()) slot = it->second;
-    else { slot = impl_->free_slots.back(); impl_->free_slots.pop_back(); impl_->seq_slot[seq_id] = slot; }
+    else {
+        if (impl_->free_slots.empty()) return false;
+        slot = impl_->free_slots.back();
+        impl_->free_slots.pop_back();
+        impl_->seq_slot[seq_id] = slot;
+    }
+
+    for (int i = 0; i < grow; i++) {
+        blocks.push_back(impl_->free_list.back());
+        impl_->free_list.pop_back();
+    }
 
     cu(cudaMemcpy(impl_->d_block_tables + (size_t)slot * kMaxBlocksPerSeq, blocks.data(),
                   blocks.size() * sizeof(int), cudaMemcpyHostToDevice), "copy block table");
     return true;
+}
+
+int KVCacheManager::allocated_tokens(uint64_t seq_id) const {
+    auto it = impl_->seq_blocks.find(seq_id);
+    if (it == impl_->seq_blocks.end()) return 0;
+    return (int)it->second.size() * impl_->cfg.block_size;
 }
 
 void KVCacheManager::free(uint64_t seq_id) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -116,6 +116,10 @@ struct Qwen35Model::Impl {
     cudaGraph_t cu_graph{};
     cudaGraphExec_t cu_exec{};
     bool graph_ready = false;
+    cudaGraph_t cu_prefill_graph{};
+    cudaGraphExec_t cu_prefill_exec{};
+    bool graph_prefill_ready = false;
+    int graph_prefill_attn_mode = -1;
     bool bench_feedback_graph = false;
     int graph_attn_mode = -1;  // host-side flash-decode dispatch class captured in cu_graph
 
@@ -326,6 +330,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->sparse_sel);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
     if (p_->graph_ready) { cudaGraphExecDestroy(p_->cu_exec); cudaGraphDestroy(p_->cu_graph); }
+    if (p_->graph_prefill_ready) { cudaGraphExecDestroy(p_->cu_prefill_exec); cudaGraphDestroy(p_->cu_prefill_graph); }
     cudaEventDestroy(p_->ev_qkv); cudaEventDestroy(p_->ev_k); cudaEventDestroy(p_->ev_v);
     cudaEventDestroy(p_->ev_pipe_fork); cudaEventDestroy(p_->ev_gdn_z); cudaEventDestroy(p_->ev_gdn_ab);
     cudaEventDestroy(p_->ev_sx_gate); cudaEventDestroy(p_->ev_sx_done);
@@ -343,7 +348,7 @@ void Qwen35Model::copy_logits(float* host_logits) const {
     cudaMemcpy(host_logits, p_->logits, (size_t)p_->cfg.vocab * sizeof(float), cudaMemcpyDeviceToHost);
 }
 
-int Qwen35Model::forward_token(int token_id, int position) {
+int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     Impl& s = *p_;
     const Qwen35Config& c = s.cfg;
     const int H = c.hidden;
@@ -395,6 +400,11 @@ int Qwen35Model::forward_token(int token_id, int position) {
             if (s.graph_ready) {
                 cudaGraphExecDestroy(s.cu_exec); cudaGraphDestroy(s.cu_graph); s.graph_ready = false;
             }
+            if (s.graph_prefill_ready) {
+                cudaGraphExecDestroy(s.cu_prefill_exec); cudaGraphDestroy(s.cu_prefill_graph);
+                s.cu_prefill_exec = nullptr; s.cu_prefill_graph = nullptr;
+                s.graph_prefill_ready = false; s.graph_prefill_attn_mode = -1;
+            }
         }
     }
     // launch_flash_decode_split chooses its scalar-vs-MMA implementation on the host
@@ -436,6 +446,14 @@ int Qwen35Model::forward_token(int token_id, int position) {
         cu(cudaGraphDestroy(s.cu_graph), "sparse recapture destroy graph");
         s.cu_exec = nullptr; s.cu_graph = nullptr; s.graph_ready = false;
     }
+    if (s.graph_prefill_ready && attn_graph_mode != s.graph_prefill_attn_mode) {
+        cu(cudaGraphExecDestroy(s.cu_prefill_exec), "prefill graph recapture destroy exec");
+        cu(cudaGraphDestroy(s.cu_prefill_graph), "prefill graph recapture destroy graph");
+        s.cu_prefill_exec = nullptr;
+        s.cu_prefill_graph = nullptr;
+        s.graph_prefill_ready = false;
+        s.graph_prefill_attn_mode = -1;
+    }
     if (c.hybrid && position == 0) {
         cu(cudaMemsetAsync(s.lin_state, 0,
                            (size_t)c.n_layers * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim * sizeof(float), st),
@@ -445,16 +463,27 @@ int Qwen35Model::forward_token(int token_id, int position) {
            "linear conv reset");
     }
 
-    // Capture the decode compute into a CUDA graph on the first token, then
-    // replay it every token (per-token inputs live in the d_tok/pos/seqlen/
-    // writepos device buffers uploaded above, so replay produces fresh results).
-    if (s.graph_ready) {
+    // Prefill graph: embed→layers→final norm (no LM head). Decode graph: full path + argmax.
+    if (!sample && s.graph_prefill_ready) {
+        cu(cudaGraphLaunch(s.cu_prefill_exec, st), "prefill graph launch");
+        cu(cudaStreamSynchronize(st), "prefill graph sync");
+        return token_id;
+    }
+    if (sample && s.graph_ready) {
         cu(cudaGraphLaunch(s.cu_exec, st), "graph launch");
         cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");
         cu(cudaStreamSynchronize(st), "sync");
         return *s.h_out_id;
     }
-    cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), "begin capture");
+    if (sample && s.graph_prefill_ready) {
+        cu(cudaGraphExecDestroy(s.cu_prefill_exec), "drop prefill graph for decode");
+        cu(cudaGraphDestroy(s.cu_prefill_graph), "drop prefill graph for decode");
+        s.cu_prefill_exec = nullptr;
+        s.cu_prefill_graph = nullptr;
+        s.graph_prefill_ready = false;
+        s.graph_prefill_attn_mode = -1;
+    }
+    cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), sample ? "begin decode capture" : "begin prefill capture");
 
     kernels::launch_embedding(s.d_tok, s.w.embed_tokens, s.x, 1, H, st);
 
@@ -1000,6 +1029,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
             kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
     }
     // xn now holds RMSNorm(x_final, final_norm)
+    if (!sample) {
+        cu(cudaStreamEndCapture(st, &s.cu_prefill_graph), "end prefill capture");
+        cu(cudaGraphInstantiate(&s.cu_prefill_exec, s.cu_prefill_graph, 0), "prefill graph instantiate");
+        s.graph_prefill_ready = true;
+        s.graph_prefill_attn_mode = attn_graph_mode;
+        cu(cudaGraphLaunch(s.cu_prefill_exec, st), "prefill graph launch (first)");
+        cu(cudaStreamSynchronize(st), "prefill sync");
+        return token_id;
+    }
     if (s.gguf && s.use_pq && s.use_llama && s.w.lm_head_type == 12) {
         if (!fnq) kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
         kernels::launch_mmvq_q4k_f32(s.aq81, s.w.lm_head, s.logits, c.vocab, H, st);
@@ -1036,6 +1074,17 @@ int Qwen35Model::forward_token(int token_id, int position) {
     return *s.h_out_id;
 }
 
+namespace {
+bool prefill_samples_lmhead() {
+    static int legacy = -1;
+    if (legacy < 0) {
+        const char* e = getenv("SPARKINFER_PREFILL_LEGACY");
+        legacy = (e && e[0] == '1') ? 1 : 0;
+    }
+    return legacy != 0;
+}
+} // namespace
+
 Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int context_tokens) {
     BenchDecodeResult out{};
     Impl& s = *p_;
@@ -1069,12 +1118,18 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     int pos = 0, tok = 100;
     if (start_pos > 0) {
         auto p0 = std::chrono::high_resolution_clock::now();
-        for (; pos < start_pos; pos++) { tok = forward_token(tok, pos); if (tok < 0 || tok >= s.cfg.vocab) tok = 100; }
+        for (; pos < start_pos; pos++) {
+            tok = forward_token(tok, pos, prefill_samples_lmhead());
+            if (tok < 0 || tok >= s.cfg.vocab) tok = 100;
+        }
         cudaDeviceSynchronize();
         auto p1 = std::chrono::high_resolution_clock::now();
         out.prefill_pp = start_pos / std::chrono::duration<double>(p1 - p0).count();
     }
-    for (int i = 0; i < warmup; i++) { tok = forward_token(tok, pos++); if (tok < 0 || tok >= s.cfg.vocab) tok = 100; }
+    for (int i = 0; i < warmup; i++) {
+        tok = forward_token(tok, pos++, true);
+        if (tok < 0 || tok >= s.cfg.vocab) tok = 100;
+    }
     if (s.graph_ready) cu(cudaGraphUpload(s.cu_exec, s.stream), "bench graph upload");
     cudaDeviceSynchronize();
 
@@ -1099,7 +1154,10 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     }
 
     auto t0 = std::chrono::high_resolution_clock::now();
-    for (int i = 0; i < n; i++) { tok = forward_token(tok, pos++); if (tok < 0 || tok >= s.cfg.vocab) tok = 100; }
+    for (int i = 0; i < n; i++) {
+        tok = forward_token(tok, pos++, true);
+        if (tok < 0 || tok >= s.cfg.vocab) tok = 100;
+    }
     cudaDeviceSynchronize();
     auto t1 = std::chrono::high_resolution_clock::now();
     s.kv->free(s.seq_id);
@@ -1139,8 +1197,15 @@ bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
     invalidate_decode_graph();
     if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) return false;
     int next = -1;
-    for (size_t i = 0; i < tokens.size(); i++)
-        next = forward_token(tokens[i], (int)i);
+    if (prefill_samples_lmhead()) {
+        for (size_t i = 0; i < tokens.size(); i++)
+            next = forward_token(tokens[i], (int)i, true);
+    } else {
+        for (size_t i = 0; i + 1 < tokens.size(); i++)
+            forward_token(tokens[i], (int)i, false);
+        if (!tokens.empty())
+            next = forward_token(tokens.back(), (int)tokens.size() - 1, true);
+    }
     cudaDeviceSynchronize();
     s.prefix_tokens = tokens;
     s.prefix_len = (int)tokens.size();
@@ -1178,15 +1243,43 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
     if (getenv("SPARKINFER_DEBUG_PREFIX"))
         fprintf(stderr, "[prefix] ttft n=%zu start=%d reuse=%d cached=%d\n",
                 prompt.size(), start, (int)reuse, s.prefix_len);
+    s.bench_feedback_graph = false;
+    cudaDeviceSynchronize();
     auto t0 = std::chrono::high_resolution_clock::now();
-    for (size_t i = (size_t)start; i < prompt.size(); i++) {
-        (void)forward_token(prompt[i], (int)i);
-        cudaDeviceSynchronize();
+    if (prefill_samples_lmhead()) {
+        for (size_t i = (size_t)start; i < prompt.size(); i++) {
+            (void)forward_token(prompt[i], (int)i, true);
+            cudaDeviceSynchronize();
+        }
+    } else {
+        for (size_t i = (size_t)start; i + 1 < prompt.size(); i++) {
+            forward_token(prompt[i], (int)i, false);
+            cudaDeviceSynchronize();
+        }
+        if (prompt.size() > (size_t)start) {
+            (void)forward_token(prompt.back(), (int)prompt.size() - 1, true);
+            cudaDeviceSynchronize();
+        }
     }
     auto t1 = std::chrono::high_resolution_clock::now();
     if (!reuse) {
         s.kv->free(s.seq_id);
         invalidate_decode_graph();
+        if (s.graph_ready) {
+            cu(cudaGraphExecDestroy(s.cu_exec), "ttft graph destroy exec");
+            cu(cudaGraphDestroy(s.cu_graph), "ttft graph destroy");
+            s.cu_exec = nullptr;
+            s.cu_graph = nullptr;
+            s.graph_ready = false;
+        }
+        if (s.graph_prefill_ready) {
+            cu(cudaGraphExecDestroy(s.cu_prefill_exec), "ttft prefill graph destroy exec");
+            cu(cudaGraphDestroy(s.cu_prefill_graph), "ttft prefill graph destroy");
+            s.cu_prefill_exec = nullptr;
+            s.cu_prefill_graph = nullptr;
+            s.graph_prefill_ready = false;
+            s.graph_prefill_attn_mode = -1;
+        }
     }
     return std::chrono::duration<double>(t1 - t0).count();
 }
@@ -1208,16 +1301,22 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
         return out;
     }
-
     int next = reuse ? s.prefix_next : -1;
     const int start = reuse ? s.prefix_len : 0;
-    for (size_t i = (size_t)start; i < prompt.size(); i++)
-        next = forward_token(prompt[i], (int)i);
-
+    const size_t n = prompt.size();
+    if (prefill_samples_lmhead()) {
+        for (size_t i = (size_t)start; i < n; i++)
+            next = forward_token(prompt[i], (int)i, true);
+    } else {
+        for (size_t i = (size_t)start; i + 1 < n; i++)
+            forward_token(prompt[i], (int)i, false);
+        if (n > (size_t)start)
+            next = forward_token(prompt.back(), (int)n - 1, true);
+    }
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
         if (next == s.cfg.eos_id) break;
-        next = forward_token(next, (int)prompt.size() + i);
+        next = forward_token(next, (int)prompt.size() + i, true);
         if (gov) gov->pace();
     }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -171,6 +171,12 @@ struct Qwen35Model::Impl {
     bool use_router_fused = true; // default ON (256-expert path): fuse the router GEMV + bitonic top-k
                                   // into one kernel (grid-completion), dropping the top-k launch. =0 disables
 
+    // Prefix KV reuse (Genie-style warm prompt): cache_prefix() retains KV + GDN state.
+    std::vector<int> prefix_tokens;
+    int prefix_len = 0;
+    int prefix_next = -1;
+    bool prefix_active = false;
+
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
 
@@ -1103,23 +1109,126 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     return out;
 }
 
+void Qwen35Model::invalidate_decode_graph() {
+    Impl& s = *p_;
+    if (s.graph_ready) {
+        cudaGraphExecDestroy(s.cu_exec);
+        cudaGraphDestroy(s.cu_graph);
+        s.cu_exec = nullptr;
+        s.cu_graph = nullptr;
+        s.graph_ready = false;
+        s.graph_attn_mode = -1;
+        s.graph_sparse = false;
+    }
+}
+
+bool Qwen35Model::prompt_matches_prefix(const std::vector<int>& prompt) const {
+    const Impl& s = *p_;
+    if (!s.prefix_active || s.prefix_len <= 0) return false;
+    if (prompt.size() < (size_t)s.prefix_len) return false;
+    for (int i = 0; i < s.prefix_len; i++)
+        if (prompt[(size_t)i] != s.prefix_tokens[(size_t)i]) return false;
+    return true;
+}
+
+bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
+    Impl& s = *p_;
+    clear_prefix_cache();
+    if (tokens.empty()) return false;
+    if (tokens.size() > (size_t)s.cfg.max_seq) return false;
+    invalidate_decode_graph();
+    if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) return false;
+    int next = -1;
+    for (size_t i = 0; i < tokens.size(); i++)
+        next = forward_token(tokens[i], (int)i);
+    cudaDeviceSynchronize();
+    s.prefix_tokens = tokens;
+    s.prefix_len = (int)tokens.size();
+    s.prefix_next = next;
+    s.prefix_active = true;
+    return true;
+}
+
+void Qwen35Model::clear_prefix_cache() {
+    Impl& s = *p_;
+    if (s.prefix_active || s.kv->allocated_tokens(s.seq_id) > 0) {
+        s.kv->free(s.seq_id);
+        invalidate_decode_graph();
+    }
+    s.prefix_tokens.clear();
+    s.prefix_len = 0;
+    s.prefix_next = -1;
+    s.prefix_active = false;
+}
+
+int Qwen35Model::prefix_cached_len() const { return p_->prefix_active ? p_->prefix_len : 0; }
+
+double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
+    Impl& s = *p_;
+    if (prompt.empty()) return 0.;
+    const bool reuse = prompt_matches_prefix(prompt);
+    if (!reuse) {
+        clear_prefix_cache();
+        invalidate_decode_graph();
+        if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) return -1.;
+    } else if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
+        return -1.;
+    }
+    const int start = reuse ? s.prefix_len : 0;
+    if (getenv("SPARKINFER_DEBUG_PREFIX"))
+        fprintf(stderr, "[prefix] ttft n=%zu start=%d reuse=%d cached=%d\n",
+                prompt.size(), start, (int)reuse, s.prefix_len);
+    auto t0 = std::chrono::high_resolution_clock::now();
+    for (size_t i = (size_t)start; i < prompt.size(); i++) {
+        (void)forward_token(prompt[i], (int)i);
+        cudaDeviceSynchronize();
+    }
+    auto t1 = std::chrono::high_resolution_clock::now();
+    if (!reuse) {
+        s.kv->free(s.seq_id);
+        invalidate_decode_graph();
+    }
+    return std::chrono::duration<double>(t1 - t0).count();
+}
+
 std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_new, ThermalGovernor* gov) {
     Impl& s = *p_;
     std::vector<int> out;
     if (prompt.empty()) return out;
-    if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
+
+    const bool reuse = prompt_matches_prefix(prompt);
+    if (!reuse) {
+        clear_prefix_cache();
+        invalidate_decode_graph();
+        if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
+            fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
+            return out;
+        }
+    } else if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
         fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
         return out;
     }
-    int next = -1;
-    for (size_t i = 0; i < prompt.size(); i++) next = forward_token(prompt[i], (int)i);
+
+    int next = reuse ? s.prefix_next : -1;
+    const int start = reuse ? s.prefix_len : 0;
+    for (size_t i = (size_t)start; i < prompt.size(); i++)
+        next = forward_token(prompt[i], (int)i);
+
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
         if (next == s.cfg.eos_id) break;
         next = forward_token(next, (int)prompt.size() + i);
-        if (gov) gov->pace();   // thermally-adaptive decode pacing (accuracy-preserving; no-op if disabled)
+        if (gov) gov->pace();
     }
+
     s.kv->free(s.seq_id);
+    if (reuse) {
+        s.prefix_tokens.clear();
+        s.prefix_len = 0;
+        s.prefix_next = -1;
+        s.prefix_active = false;
+        invalidate_decode_graph();
+    }
     return out;
 }
 


### PR DESCRIPTION
## Summary

Fixes #106. Two complementary prefill optimizations for Qwen3.5:

1. **Skip LM head on interior prefill** — teacher-forced ingestion runs embed→layers→final norm without LM head/argmax; dedicated prefill CUDA graph (layers only). Decode unchanged. `SPARKINFER_PREFILL_LEGACY=1` restores the old path.

2. **Prefix KV cache reuse** — `cache_prefix()` retains KV + GDN state across requests; `generate()` / `bench_ttft()` skip re-prefilling a matching prompt prefix (Genie-style warm multi-turn TTFT). `SPARKINFER_BENCH_PREFIX_TTFT=<suffix>` for cold/warm A/B in bench.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`):

| | decode tok/s |
|---|--:|
| before (main) | 305 @128 · 294 @4k · 265 @32k · 241 @64k |
| after (this PR) | 305 @128 · 294 @4k · 265 @32k · 241 @64k |

**Prefill pp tok/s** (Qwythos / Qwen3.5):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 295 @4k (`SPARKINFER_PREFILL_LEGACY=1`) |
| after prefill (this PR) | **331 @4k** (+12%) · 310 @32k · 289 @64k |

**Prefix KV reuse TTFT** (3968 cached + 128 suffix @4k, `SPARKINFER_BENCH_PREFIX_TTFT=128`):

| | TTFT |
|---|--:|
| cold (full prefill) | 13.96 s |
| warm (cached prefix) | **0.44 s** |
| speedup | **31.4×** on suffix-only prefill |

```text
# RTX 5090 · Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf · build-sm120

=== NEW (default) ===
ctx=0     decode=305 tok/s
ctx=4096  decode=294 tok/s  prefill_pp=331 tok/s  ttft=12.4s
ctx=32768 decode=265 tok/s  prefill_pp=310 tok/s
ctx=65536 decode=241 tok/s  prefill_pp=289 tok/s

=== LEGACY (SPARKINFER_PREFILL_LEGACY=1) ===
ctx=4096  decode=292 tok/s  prefill_pp=295 tok/s  ttft=13.8s

=== PREFIX REUSE (SPARKINFER_BENCH_PREFIX_TTFT=128 @ ctx=4096) ===
cold=13.96s  warm=0.44s  speedup=31.4x

# correctness:
# - accuracy.sh vs llama.cpp: top-1 90/100, KL 0.034 (Qwythos Q4_K_M)
# - greedy OUTPUT_IDS MATCH vs legacy @ prompt len 16, 512, 4096
# - prefix score path: S-lines exact match cold vs warm @ prefix_len 12/50/90
```

<!-- More checklist items will be added here later. -->
