### PR TITLE
fix(attn): sparse-KV combine drops the attention output gate (Qwythos >= 8k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -637,13 +637,22 @@ static inline void fa_launch_combine_gated_dispatch_hd256(
 }
 
 // Standalone hd256 combine (sparse-KV path: split then combine). num_seqs=1 (decode).
+// attn_gate: optional per-element sigmoid output gate — same contract as the gated combine
+// inside launch_flash_decode_split (gate && out_q8 selects the gated kernel).
 void launch_fa_combine_hd256(
     const float* part_m, const float* part_l, const float* part_acc, void* out,
-    int num_q_heads, int n_splits, void* out_q8, cudaStream_t stream
+    int num_q_heads, int n_splits, void* out_q8, cudaStream_t stream,
+    const void* attn_gate
 ) {
-    fa_launch_combine_dispatch_hd256(part_m, part_l, part_acc,
-        reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
-        reinterpret_cast<fa_block_q8_1*>(out_q8), 1, stream);
+    const __nv_bfloat16* gate = reinterpret_cast<const __nv_bfloat16*>(attn_gate);
+    if (gate && out_q8)
+        fa_launch_combine_gated_dispatch_hd256(part_m, part_l, part_acc,
+            reinterpret_cast<__nv_bfloat16*>(out), gate, num_q_heads, n_splits,
+            reinterpret_cast<fa_block_q8_1*>(out_q8), 1, stream);
+    else
+        fa_launch_combine_dispatch_hd256(part_m, part_l, part_acc,
+            reinterpret_cast<__nv_bfloat16*>(out), num_q_heads, n_splits,
+            reinterpret_cast<fa_block_q8_1*>(out_q8), 1, stream);
 }
 
 void launch_flash_decode_split(

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -150,7 +150,8 @@ void launch_flash_decode_global_hd512(
 );
 
 void launch_fa_combine_hd256(const float* part_m, const float* part_l, const float* part_acc,
-    void* out, int num_q_heads, int n_splits, void* out_q8, cudaStream_t stream = nullptr);
+    void* out, int num_q_heads, int n_splits, void* out_q8, cudaStream_t stream = nullptr,
+    const void* attn_gate = nullptr);
 
 // Sink + sliding-window sparse-KV (Qwythos GQA-4 hd256). Default on; SPARKINFER_SPARSE_KV=0 disables.
 void launch_fa_kv_window_select(const int* seq_lens, int* sel_blk, int num_kv_heads,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -750,7 +750,8 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits, s.sparse_budget,
                     1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
                 kernels::launch_fa_combine_hd256(s.fa_m, s.fa_l, s.fa_acc, s.attn, c.n_q_heads,
-                    s.n_splits, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st);
+                    s.n_splits, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st,
+                    attn_gate_q8 ? s.qgate : nullptr);
             } else {
             kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,
                                                s.fa_m, s.fa_l, s.fa_acc, 1, c.n_q_heads, c.n_kv_heads, c.head_dim,


### PR DESCRIPTION
Fixes the sparse-path gate drop documented in #388 (third defect in the comment thread there — full code-path analysis included).

## What breaks

#379 wired its sparse attention as split → standalone combine (`launch_fa_combine_hd256`), and that standalone wrapper unconditionally dispatches the **ungated** `fa_combine_kernel`. For gated-attention models the output gate is normally applied in one of exactly two places: inside the gated combine (the `attn_gate_q8` configuration — which is Qwythos') or by a separate `mul_sigmoid` launch that `qwen35.cpp` deliberately skips when `attn_gate_q8` is set.

Net effect on current main: for Qwythos, `sigmoid(q_gate)` is never applied at any position with seqlen ≥ 8192 (`sparse_min_ctx`). The O-projection consumes ungated attention output (both the bf16 buffer and the emitted Q8 activations) on all 8 full-attention layers — decode and prefill both. Positions < 8192 and `SPARKINFER_SPARSE_KV=0` runs are unaffected, which is exactly why the ≤4k accuracy gate cannot see it.

## Fix

Give the standalone combine the same optional-gate contract the in-launcher combine already has (`gate && out_q8` → gated dispatch), and pass `attn_gate_q8 ? s.qgate : nullptr` at the sparse call site — the identical dispatch decision the dense branch makes a few lines below. +17/−6 across three files. With no gate supplied the wrapper compiles to the exact pre-PR dispatch, and non-gated models take the unchanged path.

## Validation (RTX 5090, sm_120)

- Static path symmetry: the diff makes the sparse branch's gating decision byte-for-byte identical to the dense branch's.
- Builds clean for `sm_120` (CUDA 13).
- **Verified on an RTX 5090 since filing** (the box I mentioned was down at filing time came back up): a teacher-forced bitwise parity harness at the sparse boundary shows the fix restores correct attention output past position 8192 — and, at a window set to cover all blocks (where sparse ≡ dense mathematically), the fixed sparse path becomes **bitwise-equal to the dense path**, which it is not on `main`. This also exposed that the ungated hd256 combine's fused Q8 emit is compile-time dead (`ELEMS==1` guard vs hd256's ELEMS==2), so this PR additionally fixes a stale-scratch O-projection on the sparse path — details and the md5-exact replication of `main`'s corrupted logits are in the comment thread above and in #388.
- No speed claim: the gated combine differs from the plain one by an elementwise multiply, so the decode/prefill no-regression floors are unaffected. The before/after tables are intentionally empty — this is a correctness fix, not an optimization.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`) — box ticked to attest the RTX 5090 correctness validation above. This is a **correctness fix with no throughput claim**, so the before/after speed tables are deliberately left empty (expected routing: `needs-benchmark`).

