### PR TITLE
fix(eval): surface prefill pp failures in bench and PR comments

### DIFF
--- a/bench/scripts/_eval_speed.sh
+++ b/bench/scripts/_eval_speed.sh
@@ -3,11 +3,15 @@
 
 median_bench_metric() {
   local ctx="$1" reps="$2" pat="$3"
-  local vals=() t
+  local vals=() t rc out
   [ "${reps:-0}" -le 0 ] && { echo 0; return; }
   for _ in $(seq 1 "$reps"); do
-    t=$(si_run qwen3_gguf_bench "$GGUF" "$DECODE_TOKENS" "$ctx" 2>/dev/null |
-        sed -n "s/.*${pat} *: *\\([0-9.][0-9.]*\\).*/\\1/p" | tail -1 || true)
+    out="$(si_run qwen3_gguf_bench "$GGUF" "$DECODE_TOKENS" "$ctx" 2>&1)" || rc=$?
+    t=$(printf '%s\n' "$out" | sed -n "s/.*${pat} *: *\\([0-9.][0-9.]*\\).*/\\1/p" | tail -1 || true)
+    if [ "${rc:-0}" != 0 ] || [ -z "$t" ]; then
+      echo ">> WARN: bench metric '${pat}' failed (ctx=$ctx rc=${rc:-0}): ${out##*$'\n'}" >&2
+      t=0
+    fi
     vals+=("${t:-0}")
     gclks+=("$(nvidia-smi --query-gpu=clocks.gr --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')")
   done

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -595,6 +595,8 @@ def render(res, oid):
                 rows.append(f"| {title} scored prefill ({pctx} ctx"
                             f"{f' · {plbl}' if plbl else ''}) | {block.get('prefill_tps', '?')} pp tok/s · "
                             f"`eval-prefill:{block.get('prefill_label')}` |")
+            elif block.get("eval_prefill"):
+                rows.append(f"| {title} scored prefill | not measured (0 pp tok/s on all contexts) |")
             rows.append(f"| {title} correctness | top-1 {block.get('top1', 0) * 100:.1f}% · "
                         f"KL {block.get('kl', '?')} |")
             for key, gkey, bkey, lbl in [
@@ -606,24 +608,27 @@ def render(res, oid):
                     ("ctx_65536_tps", "guard_64k_pass", "guard_64k_baseline", "64k-context"),
                     ("ctx_131072_tps", "guard_128k_pass", "guard_128k_baseline", "128k-context")]:
                 tps = block.get(key)
+                if tps is None:
+                    continue
                 if not tps:
                     continue
                 gate = "pass" if block.get(gkey, True) else "fail"
                 base = block.get(bkey) or _GUARD_BASE_FALLBACK.get(bkey, 0)
                 rows.append(f"| {title} {lbl} no-regression gate | {tps} tok/s"
                             f"{f' vs main {base} tok/s' if base else ''} · {gate} |")
-            for key, gkey, bkey, lbl in [
-                    ("ctx_4096_pp_tps", "guard_4k_pp_pass", "guard_4k_pp_baseline", "4k prefill"),
-                    ("ctx_32768_pp_tps", "guard_32k_pp_pass", "guard_32k_pp_baseline", "32k prefill"),
-                    ("ctx_65536_pp_tps", "guard_64k_pp_pass", "guard_64k_pp_baseline", "64k prefill"),
-                    ("ctx_131072_pp_tps", "guard_128k_pp_pass", "guard_128k_pp_baseline", "128k prefill")]:
-                tps = block.get(key)
-                if not tps:
-                    continue
-                gate = "pass" if block.get(gkey, True) else "fail"
-                base = block.get(bkey) or 0
-                rows.append(f"| {title} {lbl} no-regression gate | {tps} pp tok/s"
-                            f"{f' vs main {base} pp tok/s' if base else ''} · {gate} |")
+            if block.get("eval_prefill"):
+                for key, gkey, bkey, lbl in [
+                        ("ctx_4096_pp_tps", "guard_4k_pp_pass", "guard_4k_pp_baseline", "4k prefill"),
+                        ("ctx_32768_pp_tps", "guard_32k_pp_pass", "guard_32k_pp_baseline", "32k prefill"),
+                        ("ctx_65536_pp_tps", "guard_64k_pp_pass", "guard_64k_pp_baseline", "64k prefill"),
+                        ("ctx_131072_pp_tps", "guard_128k_pp_pass", "guard_128k_pp_baseline", "128k prefill")]:
+                    if key not in block and bkey not in block:
+                        continue
+                    tps = block.get(key, 0)
+                    gate = "pass" if block.get(gkey, True) else "fail"
+                    base = block.get(bkey) or 0
+                    rows.append(f"| {title} {lbl} no-regression gate | {tps} pp tok/s"
+                                f"{f' vs main {base} pp tok/s' if base else ''} · {gate} |")
     if not bidir:
         rows += [
             f"| scored decode ({res.get('score_context', 128)} ctx{f' · {ctx_label}' if ctx_label else ''}{f' · {short}' if dual or triple else ''}) | {res.get('tps','?')} tok/s |",

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -131,6 +131,41 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertIn("`eval-prefill:S`", body)
         self.assertIn("4k prefill no-regression gate", body)
 
+    def test_bidir_qwen35_zero_prefill_render(self):
+        res = {
+            "mode": "bidir",
+            "label": "REJECT",
+            "pass": False,
+            "eval_mode": "longctx",
+            "label_qwen35": "REJECT",
+            "label_qwen36": "REJECT",
+            "pass_qwen35": False,
+            "pass_qwen36": False,
+            "score_qwen35": {
+                "label": "REJECT",
+                "pass": False,
+                "tps": 287.55,
+                "frontier_tps": 285.7,
+                "top1": 0.897,
+                "kl": 0.0425,
+                "score_context": 4096,
+                "best_context_label": "4k-context",
+                "eval_prefill": True,
+                "ctx_4096_pp_tps": 0.0,
+                "ctx_32768_pp_tps": 0.0,
+                "ctx_65536_pp_tps": 0.0,
+                "ctx_131072_pp_tps": 0.0,
+                "guard_4k_pp_baseline": 289.26,
+                "guard_4k_pp_pass": False,
+                "guard_32k_pp_baseline": 285.42,
+                "guard_32k_pp_pass": False,
+            },
+            "score_qwen36": {"label": "REJECT", "pass": False, "tps": 488.0, "top1": 0.92, "kl": 0.04},
+        }
+        body = bot.render(res, "943f58a")
+        self.assertIn("not measured (0 pp tok/s on all contexts)", body)
+        self.assertIn("4k prefill no-regression gate | 0.0 pp tok/s vs main 289.26 pp tok/s · fail", body)
+
     def test_mixed_win_render_keeps_eval_label_and_shows_regression(self):
         res = {
             "label": "S",

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -86,7 +86,7 @@ int main(int argc, char** argv) {
     printf("max seq      : %d\n", cfg.max_seq);
     printf("decode tg    : %.2f tok/s  (%.1f ms/token, n=%d, ctx=%d, bs=1)\n",
            toks, toks > 0 ? 1000.0 / toks : 0.0, n_tokens, context_tokens);
-    if (context_tokens > 0 && bench.prefill_pp > 0)
+    if (context_tokens > 0)
         printf("prefill pp   : %.2f tok/s  (ctx=%d, sequential KV fill)\n",
                bench.prefill_pp, context_tokens);
     if (gpu.valid && gpu.temp_c >= 0) {


### PR DESCRIPTION
## Summary
- Always print `prefill pp` from `qwen3_gguf_bench` when context > 0 (including 0.00 failures)
- Stop swallowing bench stderr in `_eval_speed.sh`; WARN when parse yields 0 tok/s
- Show prefill rows in PR eval comments when `eval_prefill` is set (including `0.0 · fail` and "not measured")

## Test plan
- [x] `pytest eval/test_pr_eval_bot.py -k prefill`
- [ ] Re-run eval bot on a Qwen3.5 prefill PR to confirm comment shows prefill rows on failure