### PR TITLE
Dashboard hero KPIs: Qwen3.6 512-context decode

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -2,15 +2,15 @@
 window.SPARKINFER = {
   "updated": "2026-07-14",
   "status": {
-    "gpu": "RTX 5090 · sm_120 · CUDA 13",
-    "model": "Qwen3-30B-A3B · Q4_K_M",
+    "gpu": "RTX 5090 \u00b7 sm_120 \u00b7 CUDA 13",
+    "model": "Qwen3-30B-A3B \u00b7 Q4_K_M",
     "frontier_tps": 484.79,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
     "token_match": 0.97,
     "kl": 0.02,
-    "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
+    "ref_note": "128-tok decode rerun on current main, same RTX 5090 \u00b7 Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
@@ -110,27 +110,27 @@ window.SPARKINFER = {
     },
     {
       "l": "L",
-      "d": "10–18% over frontier",
+      "d": "10\u201318% over frontier",
       "c": "#1D76DB"
     },
     {
       "l": "M",
-      "d": "6–10% over frontier",
+      "d": "6\u201310% over frontier",
       "c": "#8250DF"
     },
     {
       "l": "S",
-      "d": "3.5–6% over frontier",
+      "d": "3.5\u20136% over frontier",
       "c": "#B8860B"
     },
     {
       "l": "XS",
-      "d": "2–3.5% over frontier",
+      "d": "2\u20133.5% over frontier",
       "c": "#8A93A0"
     },
     {
       "l": "none",
-      "d": "≤ 2% — within noise, no verified gain",
+      "d": "\u2264 2% \u2014 within noise, no verified gain",
       "c": "#9AA6B2"
     },
     {
@@ -274,7 +274,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.37,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -381,7 +381,7 @@ window.SPARKINFER = {
     },
     {
       "num": 360,
-      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K→Q4_K requant of the MoE FFN stage (+3.1–3.8%)",
+      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K\u2192Q4_K requant of the MoE FFN stage (+3.1\u20133.8%)",
       "areas": [
         "runtime"
       ],
@@ -424,7 +424,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.03,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -607,7 +607,7 @@ window.SPARKINFER = {
     },
     {
       "num": 359,
-      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K→Q4_K requant of the MoE FFN stage (+2.8–3.2%)",
+      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K\u2192Q4_K requant of the MoE FFN stage (+2.8\u20133.2%)",
       "areas": [
         "runtime"
       ],
@@ -652,7 +652,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 0.9,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -835,7 +835,7 @@ window.SPARKINFER = {
     },
     {
       "num": 355,
-      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN ssm_out projections (+2.8% @128)",
+      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN ssm_out projections (+2.8% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -874,7 +874,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.32,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -1176,7 +1176,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.17,
         "pct_over_frontier": -0.0,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1398,7 +1398,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.13,
         "pct_over_frontier": 0.2,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1491,7 +1491,7 @@ window.SPARKINFER = {
     },
     {
       "num": 267,
-      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
+      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -1528,7 +1528,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.16,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -1701,7 +1701,7 @@ window.SPARKINFER = {
     },
     {
       "num": 353,
-      "title": "perf(qwen36): Q8_0→Q4_K requant of full-attention q/o projections",
+      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of full-attention q/o projections",
       "areas": [
         "kernels",
         "runtime"
@@ -1738,7 +1738,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.59,
         "pct_over_frontier": 0.5,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1947,7 +1947,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.21,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2022,7 +2022,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.23,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2152,7 +2152,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 2.02,
         "pct_over_frontier": 0.7,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2322,7 +2322,7 @@ window.SPARKINFER = {
     },
     {
       "num": 350,
-      "title": "perf(qwen36): opt-in Q8→Q4 requant reward profile (~+6.3% @512)",
+      "title": "perf(qwen36): opt-in Q8\u2192Q4 requant reward profile (~+6.3% @512)",
       "areas": [
         "kernels",
         "runtime"
@@ -2365,7 +2365,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.8,
         "pct_over_frontier": 0.6,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2625,7 +2625,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.29,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3116,7 +3116,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3324,7 +3324,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate — not a verified improvement",
+        "note": "within significance gate \u2014 not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3838,7 +3838,7 @@ window.SPARKINFER = {
     },
     {
       "num": 323,
-      "title": "perf(qwen35): requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)",
+      "title": "perf(qwen35): requantize dense FFN down Q6_K\u2192Q4_K at load (~5% Qwythos decode)",
       "areas": [
         "kernels",
         "runtime"
@@ -3908,7 +3908,7 @@ window.SPARKINFER = {
     },
     {
       "num": 239,
-      "title": "perf(qwen3.6): fuse decode kernel launches — shared-expert + GDN conv/L2-norm",
+      "title": "perf(qwen3.6): fuse decode kernel launches \u2014 shared-expert + GDN conv/L2-norm",
       "areas": [
         "kernels",
         "runtime"
@@ -4302,7 +4302,7 @@ window.SPARKINFER = {
     },
     {
       "num": 269,
-      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append — 25% decode",
+      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append \u2014 25% decode",
       "areas": [
         "kernels",
         "runtime"
@@ -4317,7 +4317,7 @@ window.SPARKINFER = {
     },
     {
       "num": 266,
-      "title": "perf(qwen36): +15-20% decode — Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
+      "title": "perf(qwen36): +15-20% decode \u2014 Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
       "areas": [
         "kernels",
         "runtime"
@@ -4583,7 +4583,7 @@ window.SPARKINFER = {
     },
     {
       "num": 229,
-      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit…",
+      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit\u2026",
       "areas": [
         "kernels"
       ],
@@ -4626,7 +4626,7 @@ window.SPARKINFER = {
     },
     {
       "num": 230,
-      "title": "perf(qwen3.6): shared expert as coalesced GEMVs — 7.2× decode (23→167 tok/s)",
+      "title": "perf(qwen3.6): shared expert as coalesced GEMVs \u2014 7.2\u00d7 decode (23\u2192167 tok/s)",
       "areas": [
         "kernels",
         "runtime"
@@ -5059,7 +5059,7 @@ window.SPARKINFER = {
       "date": "2026-06-27"
     },
     {
-      "name": "split-K MMVQ down — +8% Qwen",
+      "name": "split-K MMVQ down \u2014 +8% Qwen",
       "tps": 339.59,
       "pr": 74,
       "date": "2026-06-28"
@@ -5230,11 +5230,11 @@ window.SPARKINFER = {
     ]
   },
   "qwen35": {
-    "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
+    "model": "Qwythos-9B (Qwen3.5-9B) \u00b7 Q4_K_M",
     "hf_repo": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 1985221,
-    "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
+    "arch": "dense hybrid Gated-DeltaNet + full-attn \u00b7 9B \u00b7 hd256",
     "frontier_tps": 298.27,
     "baseline_tps": 298.27,
     "ref_name": "llama.cpp",
@@ -5363,17 +5363,18 @@ window.SPARKINFER = {
     }
   ],
   "qwen36": {
-    "model": "Qwen3.6-35B-A3B · UD-Q4_K_M",
+    "model": "Qwen3.6-35B-A3B \u00b7 UD-Q4_K_M",
     "hf_repo": "unsloth/Qwen3.6-35B-A3B-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 844561,
-    "arch": "hybrid Gated-DeltaNet + full-attn MoE · 256 experts top-8 · hd256",
+    "arch": "hybrid Gated-DeltaNet + full-attn MoE \u00b7 256 experts top-8 \u00b7 hd256",
     "frontier_tps": 473.27,
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
     "ref_tps": 275.81,
     "token_match": 0.9529,
     "kl": 0.031,
+    "vram_gb": 22.1,
     "note": "same-box baseline 91.224.44.227 (origin/main 6981821, 2026-07-14)",
     "ctx": [
       {
@@ -5438,7 +5439,7 @@ window.SPARKINFER = {
       "label": "M"
     },
     {
-      "name": "+15-20% decode — Q8 shared M",
+      "name": "+15-20% decode \u2014 Q8 shared M",
       "tps": 300.16,
       "pr": 266,
       "date": "2026-07-06",
@@ -5487,7 +5488,7 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0→Q4_K requant of full-at",
+      "name": "Q8_0\u2192Q4_K requant of full-at",
       "tps": 427.54,
       "pr": 353,
       "date": "2026-07-12",
@@ -5501,7 +5502,7 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0→Q4_K requant of GDN inp",
+      "name": "Q8_0\u2192Q4_K requant of GDN inp",
       "tps": 463.27,
       "pr": 267,
       "date": "2026-07-13",

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -5373,6 +5373,7 @@
     "ref_tps": 275.81,
     "token_match": 0.9529,
     "kl": 0.031,
+    "vram_gb": 22.1,
     "note": "same-box baseline 91.224.44.227 (origin/main 6981821, 2026-07-14)",
     "ctx": [
       {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -394,6 +394,7 @@
 
   const q36 = D.qwen36 || {};
   const q36ctx128 = (q36.ctx||[]).find(x=>x.label==="128");
+  const q36ctx512 = (q36.ctx||[]).find(x=>x.label==="512");
   const q36Lead = q36ctx128 && q36ctx128.ref_tps ? 100*(q36ctx128.tps - q36ctx128.ref_tps)/q36ctx128.ref_tps : null;
 
   $("hero-meta").innerHTML = `GPU <b>${s.gpu}</b> &nbsp;·&nbsp; SOTA target <b>Qwen3.6-35B-A3B</b> &nbsp;·&nbsp; guard <b>${s.model}</b>`;
@@ -425,14 +426,20 @@
     </div>`;
   }
 
-  const ahead = s.frontier_tps >= s.ref_tps;
-  const pct   = 100*(s.frontier_tps - s.ref_tps)/s.ref_tps;   // +ve when sparkinfer leads
-  const gapx  = (s.ref_tps/s.frontier_tps).toFixed(2);
+  const kpiTps = q36ctx512?.tps || q36.frontier_tps || s.frontier_tps;
+  const kpiRef = q36ctx512?.ref_tps || q36.ref_tps || s.ref_tps;
+  const kpiRefName = q36.ref_name || s.ref_name;
+  const kpiTm = q36.token_match ?? s.token_match;
+  const kpiKl = q36.kl ?? s.kl;
+  const kpiVram = q36.vram_gb ?? s.vram_gb;
+  const ahead = kpiTps >= kpiRef;
+  const pct   = kpiRef > 0 ? 100*(kpiTps - kpiRef)/kpiRef : 0;
+  const gapx  = kpiTps > 0 ? (kpiRef/kpiTps).toFixed(2) : "—";
   $("kpis").innerHTML = [
-    {lab:"Frontier decode", val:s.frontier_tps, unit:"tok/s", note:"single-stream, bs=1 · 128-tok"},
-    {lab:(ahead?"vs ":"Gap to ")+s.ref_name, val:(ahead?"+"+pct.toFixed(1)+"%":gapx+"×"), unit:"", note:`${s.ref_name} ${s.ref_tps} tok/s · 128-tok`},
-    {lab:"Accuracy", val:(s.token_match*100).toFixed(0)+"%", unit:"top-1", note:`KL ${s.kl} vs ${s.ref_name}`},
-    {lab:"VRAM resident", val:s.vram_gb, unit:"GB", note:"experts kept quantized"},
+    {lab:"Frontier decode", val:kpiTps, unit:"tok/s", note:"single-stream, bs=1 · 512-context · 128-tok · Qwen3.6-35B-A3B"},
+    {lab:(ahead?"vs ":"Gap to ")+kpiRefName, val:(ahead?"+"+pct.toFixed(1)+"%":gapx+"×"), unit:"", note:`${kpiRefName} ${kpiRef} tok/s · 512-context`},
+    {lab:"Accuracy", val:(kpiTm*100).toFixed(0)+"%", unit:"top-1", note:`KL ${kpiKl} vs ${kpiRefName}`},
+    {lab:"VRAM resident", val:kpiVram, unit:"GB", note:"experts kept quantized"},
   ].map(k=>`<div class="kpi"><div class="lab">${k.lab}</div><div class="val">${k.val} <span>${k.unit}</span></div><div class="note">${k.note}</div></div>`).join("");
 
   // Optimization-journey chart: recorded passes (history) + live optimizations that have LANDED


### PR DESCRIPTION
## Summary
- Hero KPI row (`#kpis`) now shows **Qwen3.6 @ 512 context** decode throughput vs llama.cpp (+74.5%), not Qwen3-30B status.
- Adds `vram_gb` to `qwen36` in `data.json` and regenerates `data.js`.

## Test plan
- [ ] Open dashboard and confirm top row: ~481 tok/s, +74.5% vs ref, 95% top-1, 22.1 GB VRAM
- [ ] Verify notes line reads `512-context · 128-tok · Qwen3.6-35B-A3B`