### PR TITLE
Fix Qwen3.5 optimization journey chart

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -2,15 +2,15 @@
 window.SPARKINFER = {
   "updated": "2026-07-14",
   "status": {
-    "gpu": "RTX 5090 \u00b7 sm_120 \u00b7 CUDA 13",
-    "model": "Qwen3-30B-A3B \u00b7 Q4_K_M",
+    "gpu": "RTX 5090 · sm_120 · CUDA 13",
+    "model": "Qwen3-30B-A3B · Q4_K_M",
     "frontier_tps": 484.79,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
     "token_match": 0.97,
     "kl": 0.02,
-    "ref_note": "128-tok decode rerun on current main, same RTX 5090 \u00b7 Q4_K_M GGUF",
+    "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
@@ -110,27 +110,27 @@ window.SPARKINFER = {
     },
     {
       "l": "L",
-      "d": "10\u201318% over frontier",
+      "d": "10–18% over frontier",
       "c": "#1D76DB"
     },
     {
       "l": "M",
-      "d": "6\u201310% over frontier",
+      "d": "6–10% over frontier",
       "c": "#8250DF"
     },
     {
       "l": "S",
-      "d": "3.5\u20136% over frontier",
+      "d": "3.5–6% over frontier",
       "c": "#B8860B"
     },
     {
       "l": "XS",
-      "d": "2\u20133.5% over frontier",
+      "d": "2–3.5% over frontier",
       "c": "#8A93A0"
     },
     {
       "l": "none",
-      "d": "\u2264 2% \u2014 within noise, no verified gain",
+      "d": "≤ 2% — within noise, no verified gain",
       "c": "#9AA6B2"
     },
     {
@@ -274,7 +274,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.37,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -381,7 +381,7 @@ window.SPARKINFER = {
     },
     {
       "num": 360,
-      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K\u2192Q4_K requant of the MoE FFN stage (+3.1\u20133.8%)",
+      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K→Q4_K requant of the MoE FFN stage (+3.1–3.8%)",
       "areas": [
         "runtime"
       ],
@@ -424,7 +424,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.03,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -607,7 +607,7 @@ window.SPARKINFER = {
     },
     {
       "num": 359,
-      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K\u2192Q4_K requant of the MoE FFN stage (+2.8\u20133.2%)",
+      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K→Q4_K requant of the MoE FFN stage (+2.8–3.2%)",
       "areas": [
         "runtime"
       ],
@@ -652,7 +652,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 0.9,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -835,7 +835,7 @@ window.SPARKINFER = {
     },
     {
       "num": 355,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN ssm_out projections (+2.8% @128)",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN ssm_out projections (+2.8% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -874,7 +874,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.32,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -1176,7 +1176,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.17,
         "pct_over_frontier": -0.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1398,7 +1398,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.13,
         "pct_over_frontier": 0.2,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1491,7 +1491,7 @@ window.SPARKINFER = {
     },
     {
       "num": 267,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -1528,7 +1528,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.16,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -1701,7 +1701,7 @@ window.SPARKINFER = {
     },
     {
       "num": 353,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of full-attention q/o projections",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of full-attention q/o projections",
       "areas": [
         "kernels",
         "runtime"
@@ -1738,7 +1738,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.59,
         "pct_over_frontier": 0.5,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -1947,7 +1947,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.21,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2022,7 +2022,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.23,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2152,7 +2152,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 2.02,
         "pct_over_frontier": 0.7,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2322,7 +2322,7 @@ window.SPARKINFER = {
     },
     {
       "num": 350,
-      "title": "perf(qwen36): opt-in Q8\u2192Q4 requant reward profile (~+6.3% @512)",
+      "title": "perf(qwen36): opt-in Q8→Q4 requant reward profile (~+6.3% @512)",
       "areas": [
         "kernels",
         "runtime"
@@ -2365,7 +2365,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.8,
         "pct_over_frontier": 0.6,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -2625,7 +2625,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.29,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3116,7 +3116,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3324,7 +3324,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3838,7 +3838,7 @@ window.SPARKINFER = {
     },
     {
       "num": 323,
-      "title": "perf(qwen35): requantize dense FFN down Q6_K\u2192Q4_K at load (~5% Qwythos decode)",
+      "title": "perf(qwen35): requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)",
       "areas": [
         "kernels",
         "runtime"
@@ -3908,7 +3908,7 @@ window.SPARKINFER = {
     },
     {
       "num": 239,
-      "title": "perf(qwen3.6): fuse decode kernel launches \u2014 shared-expert + GDN conv/L2-norm",
+      "title": "perf(qwen3.6): fuse decode kernel launches — shared-expert + GDN conv/L2-norm",
       "areas": [
         "kernels",
         "runtime"
@@ -4302,7 +4302,7 @@ window.SPARKINFER = {
     },
     {
       "num": 269,
-      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append \u2014 25% decode",
+      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append — 25% decode",
       "areas": [
         "kernels",
         "runtime"
@@ -4317,7 +4317,7 @@ window.SPARKINFER = {
     },
     {
       "num": 266,
-      "title": "perf(qwen36): +15-20% decode \u2014 Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
+      "title": "perf(qwen36): +15-20% decode — Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
       "areas": [
         "kernels",
         "runtime"
@@ -4583,7 +4583,7 @@ window.SPARKINFER = {
     },
     {
       "num": 229,
-      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit\u2026",
+      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit…",
       "areas": [
         "kernels"
       ],
@@ -4626,7 +4626,7 @@ window.SPARKINFER = {
     },
     {
       "num": 230,
-      "title": "perf(qwen3.6): shared expert as coalesced GEMVs \u2014 7.2\u00d7 decode (23\u2192167 tok/s)",
+      "title": "perf(qwen3.6): shared expert as coalesced GEMVs — 7.2× decode (23→167 tok/s)",
       "areas": [
         "kernels",
         "runtime"
@@ -5059,7 +5059,7 @@ window.SPARKINFER = {
       "date": "2026-06-27"
     },
     {
-      "name": "split-K MMVQ down \u2014 +8% Qwen",
+      "name": "split-K MMVQ down — +8% Qwen",
       "tps": 339.59,
       "pr": 74,
       "date": "2026-06-28"
@@ -5230,13 +5230,13 @@ window.SPARKINFER = {
     ]
   },
   "qwen35": {
-    "model": "Qwythos-9B (Qwen3.5-9B) \u00b7 Q4_K_M",
+    "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
     "hf_repo": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 1985221,
-    "arch": "dense hybrid Gated-DeltaNet + full-attn \u00b7 9B \u00b7 hd256",
-    "frontier_tps": 298.27,
-    "baseline_tps": 298.27,
+    "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
+    "frontier_tps": 303.18,
+    "baseline_tps": 256.95,
     "ref_name": "llama.cpp",
     "ref_tps": 220.84,
     "token_match": 0.9326,
@@ -5320,54 +5320,60 @@ window.SPARKINFER = {
     },
     {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 281.63,
+      "tps": 272.63,
       "pr": 326,
       "date": "2026-07-10",
-      "label": "XS",
-      "attribution": "maintainer #334"
-    },
-    {
-      "name": "complete gate_up->quant_h->d",
-      "tps": 298.27,
-      "pr": 331,
-      "date": "2026-07-13",
       "label": "XS"
     },
     {
+      "name": "Q4_K requant for Qwythos Q6 ",
+      "tps": 303.18,
+      "pr": 329,
+      "date": "2026-07-11",
+      "label": "M"
+    },
+    {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 298.27,
+      "tps": 272.63,
       "pr": 327,
       "date": "2026-07-13",
       "label": "XS"
     },
     {
+      "name": "complete gate_up->quant_h->d",
+      "tps": 281.88,
+      "pr": 331,
+      "date": "2026-07-13",
+      "label": "XS"
+    },
+    {
       "name": "GQA-4 int8 MMA flash-decode ",
-      "tps": 298.27,
+      "tps": 301.07,
       "pr": 366,
       "date": "2026-07-13",
       "label": "L"
     },
     {
+      "name": "tune hd256 combine for 160-s",
+      "tps": 301.24,
+      "pr": 363,
+      "date": "2026-07-14",
+      "label": "S"
+    },
+    {
       "name": "sink + sliding-window sparse",
-      "tps": 298.27,
+      "tps": 300.43,
       "pr": 379,
       "date": "2026-07-14",
       "label": "XL"
-    },
-    {
-      "name": "Q4_K requant for Qwythos Q6",
-      "tps": 303.18,
-      "pr": 329,
-      "date": "2026-07-11",
-      "label": "M"
     }
   ],
   "qwen36": {
-    "model": "Qwen3.6-35B-A3B \u00b7 UD-Q4_K_M",
+    "model": "Qwen3.6-35B-A3B · UD-Q4_K_M",
     "hf_repo": "unsloth/Qwen3.6-35B-A3B-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 844561,
-    "arch": "hybrid Gated-DeltaNet + full-attn MoE \u00b7 256 experts top-8 \u00b7 hd256",
+    "arch": "hybrid Gated-DeltaNet + full-attn MoE · 256 experts top-8 · hd256",
     "frontier_tps": 473.27,
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
@@ -5439,7 +5445,7 @@ window.SPARKINFER = {
       "label": "M"
     },
     {
-      "name": "+15-20% decode \u2014 Q8 shared M",
+      "name": "+15-20% decode — Q8 shared M",
       "tps": 300.16,
       "pr": 266,
       "date": "2026-07-06",
@@ -5488,7 +5494,7 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of full-at",
+      "name": "Q8_0→Q4_K requant of full-at",
       "tps": 427.54,
       "pr": 353,
       "date": "2026-07-12",
@@ -5502,7 +5508,7 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of GDN inp",
+      "name": "Q8_0→Q4_K requant of GDN inp",
       "tps": 463.27,
       "pr": 267,
       "date": "2026-07-13",

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -5234,8 +5234,8 @@
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 1985221,
     "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
-    "frontier_tps": 298.27,
-    "baseline_tps": 298.27,
+    "frontier_tps": 303.18,
+    "baseline_tps": 256.95,
     "ref_name": "llama.cpp",
     "ref_tps": 220.84,
     "token_match": 0.9326,
@@ -5319,46 +5319,52 @@
     },
     {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 281.63,
+      "tps": 272.63,
       "pr": 326,
       "date": "2026-07-10",
-      "label": "XS",
-      "attribution": "maintainer #334"
-    },
-    {
-      "name": "complete gate_up->quant_h->d",
-      "tps": 298.27,
-      "pr": 331,
-      "date": "2026-07-13",
       "label": "XS"
     },
     {
+      "name": "Q4_K requant for Qwythos Q6 ",
+      "tps": 303.18,
+      "pr": 329,
+      "date": "2026-07-11",
+      "label": "M"
+    },
+    {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 298.27,
+      "tps": 272.63,
       "pr": 327,
       "date": "2026-07-13",
       "label": "XS"
     },
     {
+      "name": "complete gate_up->quant_h->d",
+      "tps": 281.88,
+      "pr": 331,
+      "date": "2026-07-13",
+      "label": "XS"
+    },
+    {
       "name": "GQA-4 int8 MMA flash-decode ",
-      "tps": 298.27,
+      "tps": 301.07,
       "pr": 366,
       "date": "2026-07-13",
       "label": "L"
     },
     {
+      "name": "tune hd256 combine for 160-s",
+      "tps": 301.24,
+      "pr": 363,
+      "date": "2026-07-14",
+      "label": "S"
+    },
+    {
       "name": "sink + sliding-window sparse",
-      "tps": 298.27,
+      "tps": 300.43,
       "pr": 379,
       "date": "2026-07-14",
       "label": "XL"
-    },
-    {
-      "name": "Q4_K requant for Qwythos Q6",
-      "tps": 303.18,
-      "pr": 329,
-      "date": "2026-07-11",
-      "label": "M"
     }
   ],
   "qwen36": {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -488,22 +488,21 @@
       legItem("#D14D72","ai-hpc v0.3.3 long-context POC")+
       legItem("#B8860B","landed on context frontier")));
   })();
-  // Qwen3.5 journey — Qwythos-9B frontier (128/512/4k only).
+  // Qwen3.5 journey — Qwythos-9B 128-tok decode frontier (merge-chronological).
   (function(){
-    const q = D.qwen35 || {}; const L = D.landed_qwen35 || [];
+    const q = D.qwen35 || {};
+    const L = [...(D.landed_qwen35 || [])].sort((a,b)=>(a.date||"").localeCompare(b.date||"")||(a.pr||0)-(b.pr||0));
     const pts = [];
-    const base = q.baseline_tps || q.guard_128_baseline;
-    if (base) pts.push({name:"origin/main", sub:"same-box baseline · RTX 5090", tps:base, baseline:true});
+    const base = q.baseline_tps;
+    if (base) pts.push({name:"origin/main", sub:"same-box baseline · 128-tok decode", tps:base, baseline:true});
     pts.push(...L.filter(l=>!l.baseline).map(l=>({name:l.name, sub:(l.pr?"PR #"+l.pr+" · ":"")+l.date+(l.label?" · eval:"+l.label:""), tps:l.tps, live:true})));
     const h = $("passes35-hint");
     if (h) {
-      const f = q.frontier_tps || (pts.length ? pts[pts.length-1].tps : 0);
-      const b = base || f;
+      const f = q.frontier_tps || Math.max(0, ...L.map(l=>l.tps), base||0);
+      const b = base || (pts.length ? pts[0].tps : f);
       if (b && f) {
-      let t = `${b} → ${f} tok/s · ${q.ref_tps?((f/q.ref_tps)*100).toFixed(0)+'% of '+q.ref_name+' '+q.ref_tps:'—'}`;
-      if (q.prefill_frontier_pp) t += ` · prefill ${q.prefill_frontier_pp} pp tok/s${q.prefill_label?' (eval-prefill:'+q.prefill_label+')':''}`;
-      h.textContent = t;
-    }
+        h.textContent = `${b} → ${f} tok/s · 128-tok decode · ${q.ref_tps?((f/q.ref_tps)*100).toFixed(0)+'% of '+q.ref_name+' '+q.ref_tps:'—'}`;
+      }
     }
     if (!pts.length && q.ref_tps) {
       pts.push({name:"llama.cpp", sub:"reference · 128-tok decode", tps:q.ref_tps, llama:true, fixed:true});

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1009,6 +1009,15 @@ def sync_merged_dashboard(repo, limit=40):
         by_num = {p["num"]: p for p in data.get("prs", [])}
     if synced:
         print(f">> sync_merged_dashboard: applied {synced} merge(s)")
+    # Repair Qwen3.5 journey from prs rows (fixes stale cumulative-bar plateau / wrong sort).
+    data = load_dash()
+    if data is not None:
+        before = json.dumps(data.get("landed_qwen35", []), sort_keys=True)
+        _rebuild_qwen35_journey(data)
+        if json.dumps(data.get("landed_qwen35", []), sort_keys=True) != before:
+            data["updated"] = datetime.date.today().isoformat()
+            write_dash(data)
+            push_dash("dashboard: repair Qwen3.5 optimization journey")
 
 def _scaled_context_tps(old_tps, measured_tps, guard_tps):
     if measured_tps is None:
@@ -1221,6 +1230,53 @@ def _qwen36_journey_tps(sub):
     """128-token headline for Qwen3.6 journey steps (matches chart hint + landed history)."""
     return float(sub.get("ctx_128_tps") or sub.get("tps") or 0)
 
+def _qwen35_journey_tps(sub):
+    """128-token decode headline for Qwen3.5 journey (not longctx best-context tps)."""
+    return float(sub.get("ctx_128_tps") or sub.get("tps") or 0)
+
+def _qwen35_baseline_from_prs(data):
+    """Same-box origin/main 128-tok speed before the first landed Qwen3.5 optimization."""
+    earliest_num, guard = None, None
+    for e in data.get("prs", []):
+        if not (e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS):
+            continue
+        num = e.get("num")
+        if num is None:
+            continue
+        sub = e.get("score_qwen35") or e
+        g = sub.get("guard_128_baseline")
+        if g is None:
+            continue
+        if earliest_num is None or num < earliest_num:
+            earliest_num, guard = num, float(g)
+    return round(guard, 2) if guard is not None else None
+
+def _rebuild_qwen35_journey(data):
+    """Recompute landed_qwen35 + baseline/frontier from stored prs rows (merge-chronological)."""
+    existing_dates = {m["pr"]: m.get("date") for m in data.get("landed_qwen35", []) if m.get("pr")}
+    landed = []
+    for e in data.get("prs", []):
+        if not (e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS):
+            continue
+        num = e["num"]
+        sub = e.get("score_qwen35") or e
+        step = round(_qwen35_journey_tps(sub), 2)
+        short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
+        landed.append({
+            "name": short or f"PR #{num}",
+            "tps": step,
+            "pr": num,
+            "date": existing_dates.get(num) or datetime.date.today().isoformat(),
+            "label": e.get("label_qwen35"),
+        })
+    landed.sort(key=lambda m: (m.get("date", ""), m.get("pr", 0)))
+    data["landed_qwen35"] = landed
+    q35 = data.setdefault("qwen35", {})
+    bl = _qwen35_baseline_from_prs(data)
+    if bl is not None:
+        q35["baseline_tps"] = bl
+    if landed:
+        q35["frontier_tps"] = round(max(m["tps"] for m in landed), 2)
 
 def record_merge(repo, num):
     """A frontier-advancing PR was MERGED → advance the displayed frontier by its verified same-box
@@ -1257,20 +1313,11 @@ def record_merge(repo, num):
         if e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS:
             sub = e.get("score_qwen35") or e
             q35 = data.setdefault("qwen35", {})
-            old_f = round(q35.get("frontier_tps") or q35.get("baseline_tps") or 0, 2)
-            new_f = round(max(old_f, sub.get("tps") or 0), 2)
-            q35["frontier_tps"] = new_f
-            if not q35.get("baseline_tps") and sub.get("guard_128_baseline"):
-                q35["baseline_tps"] = round(float(sub["guard_128_baseline"]), 2)
             if sub.get("top1") is not None: q35["token_match"] = round(sub["top1"], 4)
             if sub.get("kl") is not None:   q35["kl"] = round(sub["kl"], 4)
             _upsert_qwen35_ctx(data, sub)
             _upsert_qwen35_pp(data, sub)
-            short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
-            landed = [m for m in data.get("landed_qwen35", []) if m.get("pr") != num]
-            landed.append({"name": short or f"PR #{num}", "tps": new_f, "pr": num,
-                           "date": datetime.date.today().isoformat(), "label": e.get("label_qwen35")})
-            data["landed_qwen35"] = sorted(landed, key=lambda m: m["tps"])
+            _rebuild_qwen35_journey(data)
             changed = True
         if changed:
             data["updated"] = datetime.date.today().isoformat()

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -342,6 +342,25 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         by2 = {r["label"]: r["pp"] for r in data["qwen35"]["pp"]}
         self.assertEqual(by2, by)
 
+    def test_qwen35_journey_tps_prefers_ctx_128(self):
+        self.assertEqual(bot._qwen35_journey_tps({"tps": 283.28, "ctx_128_tps": 300.43}), 300.43)
+
+    def test_rebuild_qwen35_journey(self):
+        data = {
+            "prs": [
+                {"num": 323, "title": "perf(qwen35): first", "pass_qwen35": True, "label_qwen35": "S",
+                 "score_qwen35": {"ctx_128_tps": 271.85, "guard_128_baseline": 256.95, "tps": 271.85}},
+                {"num": 379, "title": "perf(attn): long", "pass_qwen35": True, "label_qwen35": "XL",
+                 "score_qwen35": {"ctx_128_tps": 300.43, "tps": 283.28, "guard_128_baseline": 301.01}},
+            ],
+            "landed_qwen35": [{"pr": 379, "tps": 298.27, "name": "wrong", "date": "2026-07-14"}],
+            "qwen35": {"frontier_tps": 298.27, "baseline_tps": 298.27},
+        }
+        bot._rebuild_qwen35_journey(data)
+        self.assertEqual(data["qwen35"]["baseline_tps"], 256.95)
+        self.assertEqual(data["qwen35"]["frontier_tps"], 300.43)
+        self.assertEqual([m["tps"] for m in data["landed_qwen35"]], [271.85, 300.43])
+
     def test_qwen36_ctx_uses_measured_tps_without_scaling(self):
         data = {
             "qwen36": {


### PR DESCRIPTION
## Summary
- Journey bars now use each PR's **128-tok decode** (`ctx_128_tps`), not cumulative frontier max or long-context best tps.
- `landed_qwen35` is rebuilt merge-chronologically from `prs`; baseline comes from the earliest PR's same-box guard.
- Dashboard hint is decode-only (removes misleading prefill XL line from the journey header).

## Test plan
- [ ] Open dashboard Qwen3.5 journey: baseline ~257 tok/s, peak ~303 tok/s (PR #329), bars in merge order
- [ ] Hint reads `256.95 → 303.18 tok/s · 128-tok decode · 137% of llama.cpp`
- [ ] `python3 -m unittest test_pr_eval_bot.PrEvalBotPolicyTest.test_rebuild_qwen35_journey` passes