### PR TITLE
Qwen3.5 journey: monotonic frontier ratchet

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -5306,66 +5306,72 @@ window.SPARKINFER = {
   "landed_qwen35": [
     {
       "name": "requantize dense FFN down Q6",
-      "tps": 271.85,
       "pr": 323,
       "date": "2026-07-10",
-      "label": "S"
+      "label": "S",
+      "tps": 271.85
     },
     {
       "name": "tune dense split-K and int8 ",
-      "tps": 281.63,
       "pr": 324,
       "date": "2026-07-10",
-      "label": "M"
+      "label": "M",
+      "tps": 281.63
     },
     {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 272.63,
       "pr": 326,
       "date": "2026-07-10",
-      "label": "XS"
+      "label": "XS",
+      "tps": 281.63,
+      "raw_tps": 272.63
     },
     {
       "name": "Q4_K requant for Qwythos Q6 ",
-      "tps": 303.18,
       "pr": 329,
       "date": "2026-07-11",
-      "label": "M"
+      "label": "M",
+      "tps": 303.18
     },
     {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 272.63,
       "pr": 327,
       "date": "2026-07-13",
-      "label": "XS"
+      "label": "XS",
+      "tps": 303.18,
+      "raw_tps": 272.63
     },
     {
       "name": "complete gate_up->quant_h->d",
-      "tps": 281.88,
       "pr": 331,
       "date": "2026-07-13",
-      "label": "XS"
+      "label": "XS",
+      "tps": 303.18,
+      "raw_tps": 281.88
     },
     {
       "name": "GQA-4 int8 MMA flash-decode ",
-      "tps": 301.07,
       "pr": 366,
       "date": "2026-07-13",
-      "label": "L"
+      "label": "L",
+      "tps": 303.18,
+      "raw_tps": 301.07
     },
     {
       "name": "tune hd256 combine for 160-s",
-      "tps": 301.24,
       "pr": 363,
       "date": "2026-07-14",
-      "label": "S"
+      "label": "S",
+      "tps": 303.18,
+      "raw_tps": 301.24
     },
     {
       "name": "sink + sliding-window sparse",
-      "tps": 300.43,
       "pr": 379,
       "date": "2026-07-14",
-      "label": "XL"
+      "label": "XL",
+      "tps": 303.18,
+      "raw_tps": 300.43
     }
   ],
   "qwen36": {

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -5305,66 +5305,72 @@
   "landed_qwen35": [
     {
       "name": "requantize dense FFN down Q6",
-      "tps": 271.85,
       "pr": 323,
       "date": "2026-07-10",
-      "label": "S"
+      "label": "S",
+      "tps": 271.85
     },
     {
       "name": "tune dense split-K and int8 ",
-      "tps": 281.63,
       "pr": 324,
       "date": "2026-07-10",
-      "label": "M"
+      "label": "M",
+      "tps": 281.63
     },
     {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 272.63,
       "pr": 326,
       "date": "2026-07-10",
-      "label": "XS"
+      "label": "XS",
+      "tps": 281.63,
+      "raw_tps": 272.63
     },
     {
       "name": "Q4_K requant for Qwythos Q6 ",
-      "tps": 303.18,
       "pr": 329,
       "date": "2026-07-11",
-      "label": "M"
+      "label": "M",
+      "tps": 303.18
     },
     {
       "name": "GQA-4 shared-KV tile for Qwy",
-      "tps": 272.63,
       "pr": 327,
       "date": "2026-07-13",
-      "label": "XS"
+      "label": "XS",
+      "tps": 303.18,
+      "raw_tps": 272.63
     },
     {
       "name": "complete gate_up->quant_h->d",
-      "tps": 281.88,
       "pr": 331,
       "date": "2026-07-13",
-      "label": "XS"
+      "label": "XS",
+      "tps": 303.18,
+      "raw_tps": 281.88
     },
     {
       "name": "GQA-4 int8 MMA flash-decode ",
-      "tps": 301.07,
       "pr": 366,
       "date": "2026-07-13",
-      "label": "L"
+      "label": "L",
+      "tps": 303.18,
+      "raw_tps": 301.07
     },
     {
       "name": "tune hd256 combine for 160-s",
-      "tps": 301.24,
       "pr": 363,
       "date": "2026-07-14",
-      "label": "S"
+      "label": "S",
+      "tps": 303.18,
+      "raw_tps": 301.24
     },
     {
       "name": "sink + sliding-window sparse",
-      "tps": 300.43,
       "pr": 379,
       "date": "2026-07-14",
-      "label": "XL"
+      "label": "XL",
+      "tps": 303.18,
+      "raw_tps": 300.43
     }
   ],
   "qwen36": {

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -495,7 +495,11 @@
     const pts = [];
     const base = q.baseline_tps;
     if (base) pts.push({name:"origin/main", sub:"same-box baseline · 128-tok decode", tps:base, baseline:true});
-    pts.push(...L.filter(l=>!l.baseline).map(l=>({name:l.name, sub:(l.pr?"PR #"+l.pr+" · ":"")+l.date+(l.label?" · eval:"+l.label:""), tps:l.tps, live:true})));
+    pts.push(...L.filter(l=>!l.baseline).map(l=>{
+      let sub=(l.pr?"PR #"+l.pr+" · ":"")+l.date+(l.label?" · eval:"+l.label:"");
+      if(l.raw_tps && l.raw_tps!==l.tps) sub+=" · measured "+l.raw_tps;
+      return {name:l.name, sub, tps:l.tps, live:true};
+    }));
     const h = $("passes35-hint");
     if (h) {
       const f = q.frontier_tps || Math.max(0, ...L.map(l=>l.tps), base||0);

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1252,31 +1252,45 @@ def _qwen35_baseline_from_prs(data):
     return round(guard, 2) if guard is not None else None
 
 def _rebuild_qwen35_journey(data):
-    """Recompute landed_qwen35 + baseline/frontier from stored prs rows (merge-chronological)."""
+    """Recompute landed_qwen35 + baseline/frontier from stored prs rows (merge-chronological).
+
+    Each bar is the running 128-tok frontier after that merge (monotonic ratchet), not the raw
+    same-box measurement for that PR. Raw tok/s zig-zags with box state and with PRs that target
+    long-context only; the ratchet matches Qwen3-MoE journey semantics and the headline frontier.
+    """
     existing_dates = {m["pr"]: m.get("date") for m in data.get("landed_qwen35", []) if m.get("pr")}
-    landed = []
+    pending = []
     for e in data.get("prs", []):
         if not (e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS):
             continue
         num = e["num"]
         sub = e.get("score_qwen35") or e
-        step = round(_qwen35_journey_tps(sub), 2)
+        raw = round(_qwen35_journey_tps(sub), 2)
         short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
-        landed.append({
+        pending.append({
             "name": short or f"PR #{num}",
-            "tps": step,
+            "raw_tps": raw,
             "pr": num,
             "date": existing_dates.get(num) or datetime.date.today().isoformat(),
             "label": e.get("label_qwen35"),
         })
-    landed.sort(key=lambda m: (m.get("date", ""), m.get("pr", 0)))
-    data["landed_qwen35"] = landed
+    pending.sort(key=lambda m: (m.get("date", ""), m.get("pr", 0)))
     q35 = data.setdefault("qwen35", {})
     bl = _qwen35_baseline_from_prs(data)
     if bl is not None:
         q35["baseline_tps"] = bl
+    running = round(float(bl or 0), 2)
+    landed = []
+    for ent in pending:
+        raw = ent.pop("raw_tps")
+        running = round(max(running, raw), 2)
+        ent["tps"] = running
+        if raw != running:
+            ent["raw_tps"] = raw
+        landed.append(ent)
+    data["landed_qwen35"] = landed
     if landed:
-        q35["frontier_tps"] = round(max(m["tps"] for m in landed), 2)
+        q35["frontier_tps"] = running
 
 def record_merge(repo, num):
     """A frontier-advancing PR was MERGED → advance the displayed frontier by its verified same-box

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -361,6 +361,23 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual(data["qwen35"]["frontier_tps"], 300.43)
         self.assertEqual([m["tps"] for m in data["landed_qwen35"]], [271.85, 300.43])
 
+    def test_rebuild_qwen35_journey_ratchet_monotonic(self):
+        data = {
+            "prs": [
+                {"num": 324, "title": "perf(qwen35): b", "pass_qwen35": True, "label_qwen35": "M",
+                 "score_qwen35": {"ctx_128_tps": 281.63, "guard_128_baseline": 257.47}},
+                {"num": 326, "title": "perf(qwen35): c", "pass_qwen35": True, "label_qwen35": "XS",
+                 "score_qwen35": {"ctx_128_tps": 272.63, "guard_128_baseline": 268.84}},
+                {"num": 329, "title": "perf(qwen35): d", "pass_qwen35": True, "label_qwen35": "M",
+                 "score_qwen35": {"ctx_128_tps": 303.18, "guard_128_baseline": 283.18}},
+            ],
+            "landed_qwen35": [],
+            "qwen35": {},
+        }
+        bot._rebuild_qwen35_journey(data)
+        self.assertEqual([m["tps"] for m in data["landed_qwen35"]], [281.63, 281.63, 303.18])
+        self.assertEqual(data["landed_qwen35"][1].get("raw_tps"), 272.63)
+
     def test_qwen36_ctx_uses_measured_tps_without_scaling(self):
         data = {
             "qwen36": {


### PR DESCRIPTION
## Summary
- Journey bars now show the **running 128-tok frontier** after each merge (monotonic ratchet), not raw same-box measurements that zig-zag with box variance and long-context-only PRs.
- Tooltips include `measured X` when raw tok/s differs from the ratcheted bar.
- Aligns with Qwen3-MoE journey semantics (`record_merge` gain stacking policy).

## Test plan
- [ ] Qwen3.5 journey: `257 → 272 → 282 → 282 → 303 → 303 …` (no dips)
- [ ] Hover PR #326: shows measured 272.63 while bar stays at 282
- [ ] `python3 -m unittest test_pr_eval_bot.PrEvalBotPolicyTest.test_rebuild_qwen35_journey_ratchet_monotonic`