### PR TITLE
perf(qwen36): specialize fixed-shape decode kernels

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -703,12 +703,80 @@ __global__ void conv_split_l2norm_fused_kernel(
     }
 }
 
+// Qwen3.6's GDN convolution is fixed at 16 Q heads, 32 V heads, head_dim 128,
+// and a four-tap depthwise filter. Collapse its runtime shape arithmetic and
+// loop bounds while preserving the generic kernel's accumulation and state-shift
+// order exactly.
+__global__ void conv_split_l2norm_qwen_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ conv_w,
+    __nv_bfloat16* __restrict__ conv_state,
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ v,
+    float eps)
+{
+    constexpr int QH = 16, VH = 32, HD = 128, QDIM = QH * HD, QKVDIM = (2 * QH + VH) * HD;
+    const int h = blockIdx.x;
+    const int t = threadIdx.x;
+    const int d = h * HD + t;
+    const bool do_norm = h < 2 * QH;
+    __nv_bfloat16* out = h < QH ? q + d : h < 2 * QH ? k + d - QDIM : v + d - 2 * QDIM;
+
+    const __nv_bfloat16 x0 = conv_state[d];
+    const __nv_bfloat16 x1 = conv_state[QKVDIM + d];
+    const __nv_bfloat16 x2 = conv_state[2 * QKVDIM + d];
+    const __nv_bfloat16 x3 = qkv[d];
+    const __nv_bfloat16* w = conv_w + (size_t)d * 4;
+    float y = 0.f;
+    y += q36_to_f(x0) * q36_to_f(w[0]);
+    y += q36_to_f(x1) * q36_to_f(w[1]);
+    y += q36_to_f(x2) * q36_to_f(w[2]);
+    y += q36_to_f(x3) * q36_to_f(w[3]);
+
+    conv_state[d] = x1;
+    conv_state[QKVDIM + d] = x2;
+    conv_state[2 * QKVDIM + d] = x3;
+
+    const float oy = q36_silu(y);
+    if (do_norm) {
+        const float ss = q36_wsum(oy * oy);
+        __shared__ float sw[32];
+        if ((t & 31) == 0) sw[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = t < 4 ? sw[t] : 0.f;
+            vv = q36_wsum(vv);
+            if (t == 0) sw[0] = rsqrtf(vv + eps);
+        }
+        __syncthreads();
+        out[0] = __float2bfloat16(oy * sw[0]);
+    } else {
+        out[0] = __float2bfloat16(oy);
+    }
+}
+
 void launch_qwen36_conv_split_l2norm_fused(
     const void* qkv_bf16, const void* conv_w_bf16,
     void* conv_state_bf16, void* q_bf16, void* k_bf16,
     void* v_bf16, int q_heads, int v_heads, int head_dim,
     int conv_kernel, float eps, cudaStream_t stream)
 {
+    static int qwen_special = -1;
+    if (qwen_special < 0) {
+        const char* e = getenv("SPARKINFER_GDN_CONV_SPECIAL");
+        qwen_special = !(e && e[0] == '0');
+    }
+    if (qwen_special && q_heads == 16 && v_heads == 32 && head_dim == 128 && conv_kernel == 4) {
+        conv_split_l2norm_qwen_kernel<<<64, 128, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(qkv_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(conv_w_bf16),
+            reinterpret_cast<__nv_bfloat16*>(conv_state_bf16),
+            reinterpret_cast<__nv_bfloat16*>(q_bf16),
+            reinterpret_cast<__nv_bfloat16*>(k_bf16),
+            reinterpret_cast<__nv_bfloat16*>(v_bf16), eps);
+        return;
+    }
     conv_split_l2norm_fused_kernel<<<2 * q_heads + v_heads, head_dim, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(qkv_bf16),
         reinterpret_cast<const __nv_bfloat16*>(conv_w_bf16),

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -101,6 +101,80 @@ template __global__ void gemv_f32_sk_kernel<__nv_bfloat16, 2>(const __nv_bfloat1
 template __global__ void gemv_f32_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, int);
 template __global__ void gemv_f32_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, int);
 
+// Qwen3.6's dense decode projections use K=2048. With S=8 every lane owns
+// exactly one uint4 from its row, so specialize away the generic loop and
+// runtime K/row mapping while retaining its per-lane dot and S-way sum order.
+__global__ void gemv_bf16_sk_qwen_2048_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ W,
+    __nv_bfloat16* __restrict__ y, int N
+) {
+    __shared__ float s_part[8];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int n = blockIdx.x;
+    float acc = 0.f;
+    if (n < N) {
+        const int i = warp * 32 + lane;
+        const uint4 wv = reinterpret_cast<const uint4*>(W + (size_t)n * 2048)[i];
+        const uint4 xv = reinterpret_cast<const uint4*>(x)[i];
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const float2 wf = __bfloat1622float2(wh[j]);
+            const float2 xf = __bfloat1622float2(xh[j]);
+            acc += wf.x * xf.x + wf.y * xf.y;
+        }
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+        if (lane == 0) s_part[warp] = acc;
+    }
+    __syncthreads();
+    if (n < N && warp == 0 && lane == 0) {
+        float o = 0.f;
+        #pragma unroll
+        for (int s = 0; s < 8; s++) o += s_part[s];
+        y[n] = __float2bfloat16(o);
+    }
+}
+
+// Exact N=1 companion for Qwen3.6's shared-expert gate scalar. Keep the
+// bf16 rounding boundary from launch_gemv before applying sigmoid so this has
+// the same arithmetic as gemv_bf16_sk_qwen_2048_kernel followed by
+// sigmoid_scalar_kernel, without a second kernel launch.
+__global__ void gemv_bf16_sk_qwen_2048_sigmoid_kernel(
+    const __nv_bfloat16* __restrict__ x,
+    const __nv_bfloat16* __restrict__ W,
+    float* __restrict__ y
+) {
+    __shared__ float s_part[8];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    float acc = 0.f;
+    const int i = warp * 32 + lane;
+    const uint4 wv = reinterpret_cast<const uint4*>(W)[i];
+    const uint4 xv = reinterpret_cast<const uint4*>(x)[i];
+    const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+    const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+    #pragma unroll
+    for (int j = 0; j < 4; j++) {
+        const float2 wf = __bfloat1622float2(wh[j]);
+        const float2 xf = __bfloat1622float2(xh[j]);
+        acc += wf.x * xf.x + wf.y * xf.y;
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) s_part[warp] = acc;
+    __syncthreads();
+    if (warp == 0 && lane == 0) {
+        float o = 0.f;
+        #pragma unroll
+        for (int s = 0; s < 8; s++) o += s_part[s];
+        const __nv_bfloat16 rounded = __float2bfloat16(o);
+        const float v = __bfloat162float(rounded);
+        y[0] = 1.f / (1.f + __expf(-v));
+    }
+}
+
 // ---- quantized on-read GEMV (W = GGUF-native Q4_K/Q6_K [N,K]) -----------------
 // Dequantizes each 256-block in registers and dots with a full-precision (fp32)
 // activation — reads the quantized weight bytes (~4x less than bf16) with NO int8
@@ -590,6 +664,65 @@ template __global__ void si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 128>(const si_
 template __global__ void si_mmvq_q80_kfixed_kernel<float, 64>(const si_block_q8_1*, const unsigned char*, float*, int);
 template __global__ void si_mmvq_q80_kfixed_kernel<float, 128>(const si_block_q8_1*, const unsigned char*, float*, int);
 
+// Two independent Q8_0 rows per CTA. Each four-warp subgroup uses the same
+// block-to-lane mapping and reduction sequence as si_mmvq_q80_kfixed_kernel.
+template <typename OutT, int NBLOCKS>
+__global__ void si_mmvq_q80_dualrow_kernel(const si_block_q8_1* __restrict__ vy,
+                                            const unsigned char* __restrict__ W,
+                                            OutT* __restrict__ y, int N) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int half = warp >> 2, wsub = warp & 3;
+    const int row = blockIdx.x * 2 + half;
+    const bool active = row < N;
+    float tmp = 0.0f;
+    if (active) {
+        const unsigned char* w_row = W + (size_t)row * NBLOCKS * 34;
+        const int row_tid = wsub * WS + lane;
+        #pragma unroll
+        for (int kb = row_tid; kb < NBLOCKS; kb += NW * WS)
+            tmp += si_vec_dot_q8_0_mmvq(w_row + (size_t)kb * 34, vy + kb);
+    }
+    __shared__ float s_acc[2][NW - 1][WS];
+    if (active && wsub > 0) s_acc[half][wsub - 1][lane] = tmp;
+    __syncthreads();
+    if (!active || wsub > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += s_acc[half][l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffffu, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+template __global__ void si_mmvq_q80_dualrow_kernel<__nv_bfloat16, 128>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+
+// Qwen3.6 GDN's Q8_0 output projection is always [2048, 4096]. The existing
+// dual-row mapping has one Q8_0 block per lane and no tail rows for this shape,
+// so remove its runtime bounds and one-iteration loop without changing the dot
+// or four-warp reduction order.
+__global__ void si_mmvq_q80_gdn_out_qwen_kernel(
+    const si_block_q8_1* __restrict__ vy,
+    const unsigned char* __restrict__ W,
+    __nv_bfloat16* __restrict__ y
+) {
+    constexpr int NW = 4, WS = 32, NBLOCKS = 128;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int half = warp >> 2, wsub = warp & 3;
+    const int row = blockIdx.x * 2 + half;
+    const int row_tid = wsub * WS + lane;
+    const unsigned char* w_row = W + (size_t)row * NBLOCKS * 34;
+    float tmp = 0.f;
+    tmp += si_vec_dot_q8_0_mmvq(w_row + (size_t)row_tid * 34, vy + row_tid);
+    __shared__ float s_acc[2][NW - 1][WS];
+    if (wsub > 0) s_acc[half][wsub - 1][lane] = tmp;
+    __syncthreads();
+    if (wsub > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += s_acc[half][l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffffu, tmp, m);
+    if (lane == 0) y[row] = __float2bfloat16(tmp);
+}
+
 template <typename OutT, int NSUPER>
 __global__ void si_mmvq_q4k_kfixed_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
                                           OutT* __restrict__ y, int N) {
@@ -677,6 +810,48 @@ template __global__ void si_mmvq_gdn_qkv_z_pack2_kernel<8>(const si_block_q8_1*,
 template __global__ void si_mmvq_gdn_qkv_z_pack2_kernel<16>(const si_block_q8_1*, const unsigned char*,
                                                           const unsigned char*, __nv_bfloat16*,
                                                           __nv_bfloat16*, int, int);
+
+// Qwen3.6 GDN uses K=2048 (eight Q4_K superblocks). Two warps can cover one
+// output row by retaining the four-warp kernel's lane-local accumulation order:
+// warp 0 owns superblocks 0/1 and 4/5, warp 1 owns 2/3 and 6/7.
+__global__ void si_mmvq_gdn_qkv_z_pack2_qwen_2w_kernel(
+    const si_block_q8_1* __restrict__ vy,
+    const unsigned char* __restrict__ qkv_w,
+    const unsigned char* __restrict__ z_w,
+    __nv_bfloat16* __restrict__ qkv_out,
+    __nv_bfloat16* __restrict__ z_out,
+    int n_qkv, int n_z) {
+    constexpr int WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 1, sub = warp & 1, row = blockIdx.x;
+    const bool active = group ? row < n_z : row < n_qkv;
+    const int kbx0 = (sub * WS + lane) >> 4;
+    const int kqs = 2 * ((sub * WS + lane) & 15);
+    float first = 0.f, second = 0.f;
+    if (active) {
+        const unsigned char* W = group ? z_w : qkv_w;
+        const si_block_q4_K* x_row = reinterpret_cast<const si_block_q4_K*>(W + (size_t)row * 8 * 144);
+        first = si_vec_dot_q4_K(x_row + kbx0,     vy + (size_t)kbx0 * 8,     kqs);
+        second = si_vec_dot_q4_K(x_row + kbx0 + 4, vy + (size_t)(kbx0 + 4) * 8, kqs);
+    }
+    __shared__ float s_peer[2][2][WS];
+    if (active && sub) {
+        s_peer[group][0][lane] = first;
+        s_peer[group][1][lane] = second;
+    }
+    __syncthreads();
+    if (!active || sub) return;
+    float tmp = first;
+    tmp += s_peer[group][0][lane];
+    tmp += second;
+    tmp += s_peer[group][1][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) {
+        if (group) gemv_write(z_out + row, tmp);
+        else       gemv_write(qkv_out + row, tmp);
+    }
+}
 
 // Shared-expert gate scalar: Q4_K mmvq (K=2048, N=1) + sigmoid in one launch.
 template <int NSUPER>
@@ -992,6 +1167,14 @@ static int gemv_bf16_splitk() {
     if (v < 0) { const char* e = getenv("SPARKINFER_GEMV_SK"); v = (e && e[0] == '0') ? 0 : 1; }
     return v;
 }
+static int gemv_bf16_splitk_qwen() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_GEMV_SK_QWEN");
+        v = (e && e[0] == '0') ? 0 : 1;
+    }
+    return v;
+}
 void launch_gemv(const void* x, const void* W, void* y, int N, int K, cudaStream_t stream) {
     // pick the smallest split S so N*S ~ 16384 warps fill the SMs (larger S = more reduction
     // overhead). N < 16384 covers every Qwen3.6 launch_gemv site (projections top out at 8192 rows);
@@ -1000,6 +1183,10 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K, cudaStream
         const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
         const auto* Wp = reinterpret_cast<const __nv_bfloat16*>(W);
         auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
+        if (gemv_bf16_splitk_qwen() && K == 2048 && N < 4096) {
+            gemv_bf16_sk_qwen_2048_kernel<<<N, GEMV_WPB * 32, 0, stream>>>(xp, Wp, yp, N);
+            return;
+        }
         if (N >= 8192) {          // S=2  -> up to 16384 warps
             constexpr int S = 2, RPB = GEMV_WPB / S;
             gemv_f32_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, Wp, yp, N, K);
@@ -1018,10 +1205,17 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K, cudaStream
         reinterpret_cast<__nv_bfloat16*>(y), N, K);
 }
 
-// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). Delegates to the
-// faithful split-k launch_gemv + bf16-rounded sigmoid_scalar path.
+// Fused GEMV + sigmoid for the Qwen3.6 N=1 shared-expert gate scalar. The
+// specialized path retains launch_gemv's bf16 rounding before sigmoid; other
+// shapes keep the faithful split-k launch_gemv + sigmoid_scalar sequence.
 void launch_gemv_sigmoid(const void* x, const void* W, void* scratch_bf16, float* y, int K,
                          cudaStream_t stream) {
+    if (gemv_bf16_splitk() && gemv_bf16_splitk_qwen() && K == 2048) {
+        gemv_bf16_sk_qwen_2048_sigmoid_kernel<<<1, GEMV_WPB * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x),
+            reinterpret_cast<const __nv_bfloat16*>(W), y);
+        return;
+    }
     launch_gemv(x, W, scratch_bf16, 1, K, stream);
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
     launch_qwen36_sigmoid_scalar(scratch_bf16, y, stream);
@@ -1167,6 +1361,19 @@ static int mmvq_dualrow() {
     if (v < 0) { const char* e = getenv("SPARKINFER_MMVQ2"); v = (e && e[0] == '0') ? 0 : 1; }
     return v;
 }
+static int mmvq_q80_dualrow() {
+    static int v = -1;
+    if (v < 0) { const char* e = getenv("SPARKINFER_Q80_DUALROW"); v = (e && e[0] == '0') ? 0 : 1; }
+    return v;
+}
+static int mmvq_q80_gdn_qwen() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_Q80_GDN_QWEN");
+        v = (e && e[0] == '0') ? 0 : 1;
+    }
+    return v;
+}
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
@@ -1184,7 +1391,20 @@ void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void*
                                  cudaStream_t stream) {
     const int grid = n_qkv > n_z ? n_qkv : n_z;
     if (grid <= 0) return;
-    if (K == 4096) {
+    static int gdn_warps = -1;
+    if (gdn_warps < 0) {
+        const char* e = getenv("SPARKINFER_GDN_WARPS");
+        gdn_warps = e ? atoi(e) : 2;
+        if (!(gdn_warps == 2 || gdn_warps == 4)) gdn_warps = 2;
+    }
+    if (K == 2048 && gdn_warps == 2) {
+        si_mmvq_gdn_qkv_z_pack2_qwen_2w_kernel<<<grid, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(qkv_w),
+            reinterpret_cast<const unsigned char*>(z_w),
+            reinterpret_cast<__nv_bfloat16*>(qkv_out),
+            reinterpret_cast<__nv_bfloat16*>(z_out), n_qkv, n_z);
+    } else if (K == 4096) {
         si_mmvq_gdn_qkv_z_pack2_kernel<16><<<grid, 8 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81),
             reinterpret_cast<const unsigned char*>(qkv_w),
@@ -1222,7 +1442,11 @@ void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cuda
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
     __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
-    if (K == 2048)      si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 64><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    if (mmvq_q80_dualrow() && mmvq_q80_gdn_qwen() && K == 4096 && N == 2048)
+        si_mmvq_q80_gdn_out_qwen_kernel<<<1024, 8 * 32, 0, stream>>>(q, w, out);
+    else if (mmvq_q80_dualrow() && K == 4096 && N >= 512)
+        si_mmvq_q80_dualrow_kernel<__nv_bfloat16, 128><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 2048) si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 64><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else if (K == 4096) si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 128><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else                si_mmvq_q80_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -463,6 +463,51 @@ __device__ __forceinline__ float si_vec_dot_q4_K(const si_block_q4_K* bq4, const
     return dm4f.x * sumf_d - dm4f.y * sumf_m;
 }
 
+// The fixed Qwen3.6 gate/up mapping provides L directly in [0, 15]. Keep the
+// generic Q4_K helper's dot and floating-point accumulation order while
+// removing its temporary arrays and iqs reconstruction.
+__device__ __forceinline__ float si_vec_dot_q4_K_qwen(
+    const si_block_q4_K* bq4, const si_block_q8_1* bq8_1, int L
+) {
+    const int bq8_offset = (L >> 2) << 1;
+    const int qpos = L & 3;
+    const int* q4 = reinterpret_cast<const int*>(bq4->qs + 16 * bq8_offset + 4 * qpos);
+    const int v0 = q4[0], v1 = q4[4];
+    const unsigned short* scales = reinterpret_cast<const unsigned short*>(bq4->scales);
+    const int j = L >> 2;
+    unsigned short aux0, aux1;
+    if (j < 2) {
+        aux0 = scales[j] & 0x3f3f;
+        aux1 = scales[j + 2] & 0x3f3f;
+    } else {
+        aux0 = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+        aux1 = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2);
+    }
+
+    const si_block_q8_1* bq80 = bq8_1 + bq8_offset;
+    const si_block_q8_1* bq81 = bq80 + 1;
+    const int* q80 = reinterpret_cast<const int*>(bq80->qs) + qpos;
+    const int* q81 = reinterpret_cast<const int*>(bq81->qs) + qpos;
+    const int u00 = q80[0], u01 = q80[4];
+    const int u10 = q81[0], u11 = q81[4];
+    const float d0 = __low2float(bq80->ds), d1 = __low2float(bq81->ds);
+
+    const int v00 = v0 & 0x0F0F0F0F, v10 = v1 & 0x0F0F0F0F;
+    const int dot10 = __dp4a(v10, u01, __dp4a(v00, u00, 0));
+    const int dot20 = __dp4a(0x01010101, u01, __dp4a(0x01010101, u00, 0));
+    float sumf_d = 0.f, sumf_m = 0.f;
+    sumf_d += d0 * (dot10 * (aux0 & 0xff));
+    sumf_m += d0 * (dot20 * (aux1 & 0xff));
+
+    const int v01 = (v0 >> 4) & 0x0F0F0F0F, v11 = (v1 >> 4) & 0x0F0F0F0F;
+    const int dot11 = __dp4a(v11, u11, __dp4a(v01, u10, 0));
+    const int dot21 = __dp4a(0x01010101, u11, __dp4a(0x01010101, u10, 0));
+    sumf_d += d1 * (dot11 * ((aux0 >> 8) & 0xff));
+    sumf_m += d1 * (dot21 * ((aux1 >> 8) & 0xff));
+    const float2 dm4f = __half22float2(bq4->dm);
+    return dm4f.x * sumf_d - dm4f.y * sumf_m;
+}
+
 // Q5_K int8 dp4a vec-dot for the MoE down. Q5_K is Q4_K plus one high bit per quant (qh[32]), so
 // this reuses the faithful Q4_K vec_dot structure (same qs / scales / activation indexing, same
 // iqs = 2*L convention as si_vec_dot_q4_K) and only widens each 4-bit weight to 5 bits. The qh bit
@@ -506,6 +551,57 @@ __device__ __forceinline__ float si_vec_dot_q5_K(const si_block_q5_K* bq5, const
     float2 dm5f = __half22float2(bq5->dm);
     return dm5f.x * sumf_d - dm5f.y * sumf_m;
 }
+
+// The fixed Qwen3.6 Q5_K path uses one 32-lane dot per selected expert.
+// This retains the generic helper's arithmetic order while avoiding its small
+// temporary arrays and loop-index reconstruction.
+__device__ __forceinline__ float si_vec_dot_q5_K_qwen(
+    const si_block_q5_K* bq5, const si_block_q8_1* bq8_1, int L
+) {
+    const int bq8_offset = (L >> 2) << 1;
+    const int qpos = L & 3;
+    const int* q4 = reinterpret_cast<const int*>(bq5->qs + 16 * bq8_offset + 4 * qpos);
+    const int v0 = q4[0], v1 = q4[4];
+    const int* qhp = reinterpret_cast<const int*>(bq5->qh + 4 * qpos);
+    const int qh0 = qhp[0], qh1 = qhp[4];
+    const unsigned short* scales = reinterpret_cast<const unsigned short*>(bq5->scales);
+    const int j = L >> 2;
+    unsigned short aux0, aux1;
+    if (j < 2) {
+        aux0 = scales[j] & 0x3f3f;
+        aux1 = scales[j + 2] & 0x3f3f;
+    } else {
+        aux0 = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+        aux1 = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2);
+    }
+
+    const si_block_q8_1* bq80 = bq8_1 + bq8_offset;
+    const si_block_q8_1* bq81 = bq80 + 1;
+    const int* q80 = reinterpret_cast<const int*>(bq80->qs) + qpos;
+    const int* q81 = reinterpret_cast<const int*>(bq81->qs) + qpos;
+    const int u00 = q80[0], u01 = q80[4];
+    const int u10 = q81[0], u11 = q81[4];
+    const float d0 = __low2float(bq80->ds), d1 = __low2float(bq81->ds);
+    const int hs0 = bq8_offset;
+    const int v00 = (v0 & 0x0F0F0F0F) | (((qh0 >> hs0) & 0x01010101) << 4);
+    const int v10 = (v1 & 0x0F0F0F0F) | (((qh1 >> hs0) & 0x01010101) << 4);
+    const int dot10 = __dp4a(v00, u00, __dp4a(v10, u01, 0));
+    const int dot20 = __dp4a(0x01010101, u00, __dp4a(0x01010101, u01, 0));
+    float sumf_d = 0.f, sumf_m = 0.f;
+    sumf_d += d0 * (dot10 * (aux0 & 0xff));
+    sumf_m += d0 * (dot20 * (aux1 & 0xff));
+
+    const int hs1 = bq8_offset + 1;
+    const int v01 = ((v0 >> 4) & 0x0F0F0F0F) | (((qh0 >> hs1) & 0x01010101) << 4);
+    const int v11 = ((v1 >> 4) & 0x0F0F0F0F) | (((qh1 >> hs1) & 0x01010101) << 4);
+    const int dot11 = __dp4a(v01, u10, __dp4a(v11, u11, 0));
+    const int dot21 = __dp4a(0x01010101, u10, __dp4a(0x01010101, u11, 0));
+    sumf_d += d1 * (dot11 * ((aux0 >> 8) & 0xff));
+    sumf_m += d1 * (dot21 * ((aux1 >> 8) & 0xff));
+    float2 dm5f = __half22float2(bq5->dm);
+    return dm5f.x * sumf_d - dm5f.y * sumf_m;
+}
+
 __global__ void gate_up_mmvq2_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
@@ -539,14 +635,14 @@ __global__ void gate_up_mmvq2_kernel(
 
 // ---- Qwen3.6 shared expert (Q8_0 gate/up/down, F=512) -------------------------
 // Reuses the FNQ Q8_1(hn) buffer for gate/up dp4a (same trick as routed MoE mmvq),
-// then overwrites that scratch with Q8_1(h) for the down dp4a. One 4-warp block/row
-// for gate/up (64 Q8_0 blocks/row); one warp/row for down (2048 rows, K=512).
-template <int H, int F>
+// then overwrites that scratch with Q8_1(h) for the down dp4a. Qwen3.6 has 64 Q8_0
+// blocks/row, so the specialized two-warp launch keeps every lane productive.
+template <int H, int F, int NW>
 __global__ void shared_gate_up_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
     float* __restrict__ h_scratch) {
-    constexpr int NW = 4, WS = 32;
+    constexpr int WS = 32;
     const int f = blockIdx.x, lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
     const int nblk = H >> 5;
     const unsigned char* gbase = gate_q + (size_t)f * nblk * 34;
@@ -627,6 +723,7 @@ __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
     float* __restrict__ h_scratch, int n_rows, int pdl
 ) {
+    if (pdl) si_pdl_lc();
     constexpr int NW = 4, WS = 32;
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
     const int group = warp >> 2, group_warp = warp & 3;
@@ -655,7 +752,48 @@ __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     #pragma unroll
     for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
     if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+}
+
+// Qwen3.6's routed FFN is always H=2048, F=512, TOPK=8. Its pack-two
+// grid has exactly 2048 CTAs per token, so every subgroup maps to a valid
+// row. Keep the same lane-to-Q4_K mapping and reduction order as pack2 while
+// removing its dynamic row tail and shape arithmetic.
+template <bool QWEN_DOT>
+__global__ void gate_up_mmvq2_pack2_qwen_2048_512_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch, int pdl
+) {
     if (pdl) si_pdl_lc();
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int row = blockIdx.x * 2 + group;
+    const int ts = row >> 9, f = row & 511, tok = ts >> 3;
+    const int e = expert_ids[ts];
+    const int tid4 = group_warp * WS + lane;
+    const int kbx = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const si_block_q8_1* vrow = vy + (size_t)tok * 64;
+    const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + ((size_t)e * 512 + f) * 8 * 144);
+    const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + ((size_t)e * 512 + f) * 8 * 144);
+    float tg, tu;
+    if constexpr (QWEN_DOT) {
+        tg = si_vec_dot_q4_K_qwen(g_row + kbx, vrow + (size_t)kbx * 8, kqs >> 1);
+        tu = si_vec_dot_q4_K_qwen(u_row + kbx, vrow + (size_t)kbx * 8, kqs >> 1);
+    } else {
+        tg = si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
+        tu = si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    }
+    __shared__ float sg[2][NW - 1][WS], su[2][NW - 1][WS];
+    if (group_warp > 0) { sg[group][group_warp - 1][lane] = tg; su[group][group_warp - 1][lane] = tu; }
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[group][l][lane]; tu += su[group][l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[(size_t)ts * 512 + f] = q4kf_silu(tg) * tu;
 }
 
 template <int H, int F, int TOPK>
@@ -931,6 +1069,47 @@ __global__ void down_q5k_mmvq_splitk_kernel(
         #pragma unroll
         for (int s = 0; s < S; s++) o += s_part[hh_local][s];
         output[(size_t)token * H + hh] = __float2bfloat16(o);
+    }
+}
+
+// Qwen3.6 UD's routed down path is always H=2048, F=512, top_k=8. At its
+// measured S=8 split each warp owns one selected expert and its 32 Q5_K dot
+// lanes (two superblocks). Specializing that mapping removes the generic
+// flattened-work divide/modulo and shape-dependent address math without
+// changing the dot or reduction order.
+template <int H>
+__global__ void down_q5k_mmvq_splitk_qwen_s8_kernel(
+    const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
+    const float* __restrict__ expert_weights, const si_block_q8_1* __restrict__ hq8,
+    __nv_bfloat16* __restrict__ output, int pdl
+) {
+    if (pdl) si_pdl_sync();
+    constexpr int S = 8, NBLK = 2, Q8PB = NBLK * 8;
+    __shared__ float s_part[S];
+    const int token = blockIdx.x, lane = threadIdx.x & 31;
+    const int split = threadIdx.x >> 5;
+    const int hh = blockIdx.y;
+    float acc = 0.f;
+    if (hh < H) {
+        const int ts = token * 8 + split;
+        const int e = expert_ids[ts];
+        const int kbx = lane >> 4;
+        const int L = lane & 15;
+        const si_block_q5_K* drow = reinterpret_cast<const si_block_q5_K*>(
+            down_q + ((size_t)e * H + hh) * NBLK * 176);
+        const si_block_q8_1* h8 = hq8 + (size_t)ts * Q8PB;
+        acc = expert_weights[ts] * si_vec_dot_q5_K_qwen(drow + kbx, h8 + (size_t)kbx * 8, L);
+
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+        if (lane == 0) s_part[split] = acc;
+    }
+    __syncthreads();
+    if (hh < H && split == 0 && lane == 0) {
+        float out = 0.f;
+        #pragma unroll
+        for (int s = 0; s < S; s++) out += s_part[s];
+        output[(size_t)token * H + hh] = __float2bfloat16(out);
     }
 }
 
@@ -1235,6 +1414,11 @@ static inline bool launch_down_q5k_mmvq_splitk(
     int H, int F, int top_k, cudaStream_t stream
 ) {
     const dim3 block(WPB * 32);
+    if (S == 8 && H == 2048 && F == 512 && top_k == 8) {
+        launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_qwen_s8_kernel<2048>,
+            down_q, expert_ids, expert_weights, hq8, output, pdl);
+        return true;
+    }
     switch (S) {
         case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
@@ -1316,6 +1500,10 @@ void launch_moe_expert_ffn_q4k(
     if (gu_spec < 0) { const char* gs = getenv("SPARKINFER_GU_SPEC"); gu_spec = (gs && gs[0] == '0') ? 0 : 1; }
     static int gu_pack2 = -1;
     if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '0') ? 0 : 1; }
+    static int gu_qwen_static = -1;
+    if (gu_qwen_static < 0) { const char* gqs = getenv("SPARKINFER_GU_QWEN_STATIC"); gu_qwen_static = (gqs && gqs[0] == '0') ? 0 : 1; }
+    static int gu_q4dot_qwen = -1;
+    if (gu_q4dot_qwen < 0) { const char* gqd = getenv("SPARKINFER_GU_Q4DOT_QWEN"); gu_q4dot_qwen = (gqd && gqd[0] == '0') ? 0 : 1; }
     const int gu_pdl = gu_mmvq_pdl();
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
     if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
@@ -1329,7 +1517,19 @@ void launch_moe_expert_ffn_q4k(
                 reinterpret_cast<const __nv_bfloat16*>(input), qbuf, num_tokens * hidden);
             q = qbuf;
         }
-        if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
+        if (gu_pack2 && gu_spec && gu_qwen_static && hidden == 2048 && ffn == 512 && top_k == 8) {
+            if (gu_q4dot_qwen)
+                launch_pdl_kernel(gu_pdl, dim3(num_tokens * 2048), dim3(8 * 32), 0, stream,
+                    gate_up_mmvq2_pack2_qwen_2048_512_kernel<true>,
+                    q, reinterpret_cast<const unsigned char*>(gate_q),
+                    reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, gu_pdl);
+            else
+                launch_pdl_kernel(gu_pdl, dim3(num_tokens * 2048), dim3(8 * 32), 0, stream,
+                    gate_up_mmvq2_pack2_qwen_2048_512_kernel<false>,
+                    q, reinterpret_cast<const unsigned char*>(gate_q),
+                    reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, gu_pdl);
+        }
+        else if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
             launch_pdl_kernel(gu_pdl, dim3((num_tokens * top_k * ffn + 1) / 2), dim3(8 * 32), 0, stream,
                 gate_up_mmvq2_pack2_qwen_kernel<2048, 512, 8>,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
@@ -1523,9 +1723,21 @@ void launch_shared_expert_q8_mmvq(
             reinterpret_cast<const __nv_bfloat16*>(input), qbuf, hidden);
         vy = qbuf;
     }
-    shared_gate_up_q8_mmvq_kernel<2048, 512><<<ffn, 4 * 32, 0, stream>>>(
-        vy, reinterpret_cast<const unsigned char*>(gate_q),
-        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    static int gu_warps = -1;
+    if (gu_warps < 0) {
+        const char* e = getenv("SPARKINFER_SHEXP_GU_WARPS");
+        gu_warps = e ? atoi(e) : 2;
+        if (!(gu_warps == 2 || gu_warps == 4)) gu_warps = 2;
+    }
+    if (gu_warps == 4) {
+        shared_gate_up_q8_mmvq_kernel<2048, 512, 4><<<ffn, 4 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    } else {
+        shared_gate_up_q8_mmvq_kernel<2048, 512, 2><<<ffn, 2 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    }
     const int nqb = ffn >> 5;
     quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
         h_scratch, qbuf, nqb, 0);

--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -213,15 +213,15 @@ __device__ __forceinline__ void si_warp_bitonic_top8(
 // CUDA-graph replay); the last block to arrive reads all 256 logits and runs the same bitonic top-8
 // in-kernel. Removes the separate top-k launch and its dependent-load gap from the decode critical
 // path. Byte-identical logits + selection to gemv_f32 + kernel6. Requires num_experts==256, K%8==0.
-template <int SPL>
+template <int SPL, int RPB>
 __global__ void moe_router_fused_kernel(
     const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ W,
     float* __restrict__ logits, unsigned int* __restrict__ gridctr,
     int* __restrict__ expert_ids, float* __restrict__ expert_weights,
     int N, int K, int top_k, int normalize)
 {
-    constexpr int RPB = 8 / SPL;
-    __shared__ float s_part[8 / SPL][SPL];
+    static_assert(RPB > 0 && RPB * SPL <= 32, "invalid router block shape");
+    __shared__ float s_part[RPB][SPL];
     const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
     const int row_local = warp / SPL, split = warp % SPL;
     const int n = blockIdx.x * RPB + row_local;
@@ -299,11 +299,29 @@ void launch_moe_router(
 void launch_router_fused(const void* x, const void* W, float* logits, unsigned int* gridctr,
                          int* expert_ids, float* expert_weights,
                          int num_experts, int K, int top_k, int normalize, cudaStream_t stream) {
-    constexpr int SPL = 4, RPB = 8 / SPL;              // GEMV_WPB = 8, matches gemv_f32_sk<float,4>
-    dim3 grid((num_experts + RPB - 1) / RPB);
-    moe_router_fused_kernel<SPL><<<grid, 8 * 32, 0, stream>>>(
-        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W),
-        logits, gridctr, expert_ids, expert_weights, num_experts, K, top_k, normalize);
+    constexpr int SPL = 4;
+    static int rpb = -1;
+    if (rpb < 0) {
+        const char* e = getenv("SPARKINFER_ROUTER_RPB");
+        rpb = e ? atoi(e) : 4;
+        if (!(rpb == 1 || rpb == 2 || rpb == 4)) rpb = 4;
+    }
+    if (rpb == 1) {
+        dim3 grid(num_experts);
+        moe_router_fused_kernel<SPL, 1><<<grid, SPL * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W),
+            logits, gridctr, expert_ids, expert_weights, num_experts, K, top_k, normalize);
+    } else if (rpb == 4) {
+        dim3 grid((num_experts + 3) / 4);
+        moe_router_fused_kernel<SPL, 4><<<grid, 4 * SPL * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W),
+            logits, gridctr, expert_ids, expert_weights, num_experts, K, top_k, normalize);
+    } else {
+        dim3 grid((num_experts + 1) / 2);
+        moe_router_fused_kernel<SPL, 2><<<grid, 2 * SPL * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W),
+            logits, gridctr, expert_ids, expert_weights, num_experts, K, top_k, normalize);
+    }
 }
 #endif
 

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -46,8 +46,8 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K,
 void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K,
                      cudaStream_t stream = nullptr);
 
-// Fused GEMV + sigmoid for the shared-expert gate scalar (N=1). Uses scratch_bf16
-// for the bf16 dot (same as launch_gemv) then sigmoid_scalar. SPARKINFER_GEMV_SIGMOID=1 enables.
+// Fused GEMV + sigmoid for the Qwen3.6 shared-expert gate scalar (N=1). The exact
+// K=2048 path preserves launch_gemv's bf16 rounding before sigmoid.
 void launch_gemv_sigmoid(const void* x, const void* W, void* scratch_bf16, float* y, int K,
                          cudaStream_t stream = nullptr);
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -796,13 +796,20 @@ int Qwen35Model::forward_token(int token_id, int position) {
             cudaEventRecord(s.ev_pipe_fork, st);
             cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
             cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
+            static int single_shared_gate_sigmoid = -1;
+            if (single_shared_gate_sigmoid < 0) {
+                const char* e = getenv("SPARKINFER_SHEXP_SINGLE_SIGMOID");
+                single_shared_gate_sigmoid = (e && e[0] == '0') ? 0 : 1;
+            }
+            bool shared_gate_sigmoid_ready = false;
             if (w.shared_gate_inp) {
                 if (s.use_pq && w.shared_gate_inp_type == 12) {
                     if (s.use_llama) {
                         if (!fnq) kernels::launch_quantize_q8_1_blocks(s.hn, s.aq81, H, s.stream_k);
-                        if (H == 2048)
+                        if (H == 2048) {
                             kernels::launch_mmvq_q4k_sigmoid(s.aq81, w.shared_gate_inp, s.d_shared_w, H, s.stream_k);
-                        else
+                            shared_gate_sigmoid_ready = true;
+                        } else
                             kernels::launch_mmvq_q4k(s.aq81, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
                     } else {
                         kernels::launch_quantize_q8_1(s.hn, s.aq8, s.aq8_d, s.aq8_s, H, s.stream_k);
@@ -816,21 +823,23 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     kernels::launch_gemv_q(s.hn, w.shared_gate_inp, w.shared_gate_inp_type,
                                            s.shared_gate_tmp, 1, H, s.stream_k);
                 } else {
-                    // Fused GEMV + sigmoid for the shared-expert gate scalar:
-                    // writes fp32 sigmoid(gate) directly, eliminating the separate
-                    // 1-thread sigmoid_scalar_kernel launch. SPARKINFER_GEMV_SIGMOID=0
-                    // restores the split path for A/B.
+                    // Qwen3.6's K=2048 scalar gate can retain the GEMV bf16
+                    // rounding and apply sigmoid in its reduction kernel.
+                    // SPARKINFER_GEMV_SIGMOID=0 restores the separate launch.
                     static int gemv_sigmoid = -1;
                     if (gemv_sigmoid < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
-                        gemv_sigmoid = (e && e[0] == '1') ? 1 : 0; }   // default off: fused dot != split-k GEMV
-                    if (gemv_sigmoid) {
+                        gemv_sigmoid = (e && e[0] == '0') ? 0 : 1; }
+                    if (gemv_sigmoid && qmoe && single_shared_gate_sigmoid) {
                         kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.shared_gate_tmp, s.d_shared_w, H, s.stream_k);
+                        shared_gate_sigmoid_ready = true;
                     } else {
                         kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
-                        kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
                     }
                 }
-                if (w.shared_gate_inp && !(s.use_pq && s.use_llama && w.shared_gate_inp_type == 12 && H == 2048))
+                if (!shared_gate_sigmoid_ready)
+                    kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
+                if (!single_shared_gate_sigmoid &&
+                    !(s.use_pq && s.use_llama && w.shared_gate_inp_type == 12 && H == 2048))
                     kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
             }
             if (qmoe) {
@@ -912,14 +921,16 @@ int Qwen35Model::forward_token(int token_id, int position) {
                 }
                 continue;
             }
+            bool shared_gate_sigmoid_ready = false;
             if (w.shared_gate_inp) {
                 if (s.gguf) {
                     if (s.use_pq && w.shared_gate_inp_type == 12) {
                         if (s.use_llama) {
                             if (!fnq) kernels::launch_quantize_q8_1_blocks(s.hn, s.aq81, H, st);
-                            if (H == 2048)
+                            if (H == 2048) {
                                 kernels::launch_mmvq_q4k_sigmoid(s.aq81, w.shared_gate_inp, s.d_shared_w, H, st);
-                            else
+                                shared_gate_sigmoid_ready = true;
+                            } else
                                 kernels::launch_mmvq_q4k(s.aq81, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
                         } else {
                             kernels::launch_quantize_q8_1(s.hn, s.aq8, s.aq8_d, s.aq8_s, H, st);
@@ -934,18 +945,19 @@ int Qwen35Model::forward_token(int token_id, int position) {
                     } else {
                         static int gs2 = -1;
                         if (gs2 < 0) { const char* e = getenv("SPARKINFER_GEMV_SIGMOID");
-                            gs2 = (e && e[0] == '1') ? 1 : 0; }
-                        if (gs2) {
+                            gs2 = (e && e[0] == '0') ? 0 : 1; }
+                        if (gs2 && qmoe) {
                             kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.shared_gate_tmp, s.d_shared_w, H, st);
+                            shared_gate_sigmoid_ready = true;
                         } else {
                             kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, st);
-                            kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
                         }
                     }
                 } else {
                     kernels::launch_gemm(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, 1, H, 1.f, 0.f, gc, st);
-                    kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
                 }
+                if (!shared_gate_sigmoid_ready)
+                    kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, st);
             }
             if (s.gguf) {
                 if (qmoe) {


### PR DESCRIPTION
## Summary

Specializes fixed Qwen3.6-35B-A3B UD decode shapes in the GDN, dense BF16 projections, native-Q8 shared expert, Q4_K/Q5_K MoE kernels, and router. Generic paths remain available through the existing or added runtime fallbacks; this PR does not load-time requantize weights or alter attention algorithms.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end; the same `qwen3_gguf_bench` runner invoked by `bench/scripts/bench.sh`, single stream, `n=128`, `ctx=128`):

| | decode tok/s |
|---|--:|
| before (main) | 474.53 |
| after (this PR) | 491.55 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
GPU: NVIDIA RTX 5090 (sm_120), CUDA 12.8.1
Model: Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
Model SHA256: ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61
Runner: qwen3_gguf_bench MODEL 128 128
Environment: SPARKINFER_BENCH_DEVICE_LOOP=0

main runs:      473.61, 473.74, 476.24 tok/s; mean 474.53 tok/s
candidate runs: 492.45, 488.19, 494.00 tok/s; mean 491.55 tok/s
Delta: +3.59%

Additional interleaved decode means:
ctx=512: main 478.27 tok/s, candidate 496.09 tok/s (+3.73%)
ctx=4k:  main 460.53 tok/s, candidate 478.31 tok/s (+3.86%)

Candidate build validation: ctest --output-on-failure: 7/7 passed
```

The post-benchmark remote endpoint became unavailable before the full llama.cpp score comparison could be repeated. The normal evaluator accuracy gate should run against this commit; no quality result is claimed here beyond the completed build/test and end-to-end decode measurements.
