### PR TITLE
perf(qwen36): grouped int8 tensor-core MoE prefill for Qwen3.6-35B-A3B

### DIFF
--- a/kernels/csrc/cuda/moe/moe_prefill_grouped_i8.cu
+++ b/kernels/csrc/cuda/moe/moe_prefill_grouped_i8.cu
@@ -1,0 +1,338 @@
+// Grouped int8 tensor-core MoE FFN for batched prefill — see moe_prefill_grouped.h.
+//
+// The whole prompt runs through the MoE FFN in one pass: top-k routing permutes tokens into
+// per-expert contiguous groups (block-aligned to the 128-row GEMM tile), so each Q4_K/Q6_K expert
+// weight is requantized to int8 once and streamed once, then reused across every token routed to it.
+// gate/up/down run as int8 mma.sync m16n8k32 GEMMs — the same per-row symmetric int8 scheme and
+// accumulation order the dense prefill projections already use, so the FFN output tracks the decode
+// MoE FFN and a following decode step stays faithful.
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_pipeline.h>
+#include "sparkinfer/kernels/moe_prefill_grouped.h"
+#include "sparkinfer/kernels/quant.h"
+
+namespace sparkinfer { namespace kernels {
+
+namespace {
+constexpr int MBM = 128, MBN = 128, MBK = 64;   // output tile 128x128, K-step 64 (mirrors pf_gemm_i8)
+constexpr int MFRAG = 2, NFRAG = 8;             // 32 rows / 16, 64 cols / 8 per warp
+
+__device__ __forceinline__ void mp_cp16(void* dst, const void* src, bool pred) {
+    if (pred) __pipeline_memcpy_async(dst, src, 16);
+    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
+__device__ __forceinline__ int mp_swz(int k, int row) { return (((k >> 4) ^ (row & 3)) << 4) | (k & 15); }
+__device__ __forceinline__ unsigned mp_lds32(const signed char* p) { return *reinterpret_cast<const unsigned*>(p); }
+
+// ---- routing ---------------------------------------------------------------------------------
+// logits[n,e] = <hn[n], rw[e]>, one warp per (token, expert). rw is bf16 [E,H].
+__global__ void mp_router_logits_kernel(const __nv_bfloat16* __restrict__ hn,
+                                        const __nv_bfloat16* __restrict__ rw,
+                                        float* __restrict__ logits, int N, int H, int E) {
+    const int n = blockIdx.x, e = blockIdx.y * (blockDim.x >> 5) + (threadIdx.x >> 5);
+    if (n >= N || e >= E) return;
+    const int lane = threadIdx.x & 31;
+    const __nv_bfloat16* a = hn + (size_t)n * H;
+    const __nv_bfloat16* w = rw + (size_t)e * H;
+    float acc = 0.f;
+    for (int c = lane; c < H; c += 32) acc += __bfloat162float(a[c]) * __bfloat162float(w[c]);
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, o);
+    if (lane == 0) logits[(size_t)n * E + e] = acc;
+}
+
+// ---- group construction ----------------------------------------------------------------------
+// One block, E threads: block-align the per-expert counts, exclusive-scan into padded row offsets,
+// stamp the (row-tile -> expert) schedule, and clear the per-expert scatter cursors.
+__global__ void mp_build_offsets_kernel(const int* __restrict__ counts, int* __restrict__ offsets,
+                                        int* __restrict__ tile_expert, int* __restrict__ cursor,
+                                        int E, int max_tiles) {
+    extern __shared__ int s_aligned[];   // E padded counts
+    const int e = threadIdx.x;
+    if (e < E) {
+        int c = counts[e];
+        s_aligned[e] = ((c + MBM - 1) / MBM) * MBM;   // round group up to the 128-row tile
+        cursor[e] = 0;
+    }
+    __syncthreads();
+    if (e == 0) {   // serial prefix over E=256 experts (cheap, once per layer)
+        int off = 0;
+        for (int j = 0; j < E; j++) {
+            offsets[j] = off;
+            const int t0 = off / MBM, nt = s_aligned[j] / MBM;
+            for (int t = 0; t < nt; t++) tile_expert[t0 + t] = j;
+            off += s_aligned[j];
+        }
+        offsets[E] = off;
+        for (int t = off / MBM; t < max_tiles; t++) tile_expert[t] = -1;   // beyond real tiles
+    }
+}
+
+// Scatter each (token, slot) assignment into its expert's padded group.
+__global__ void mp_scatter_assign_kernel(const int* __restrict__ ids, const float* __restrict__ weights,
+                                         const int* __restrict__ offsets, int* __restrict__ cursor,
+                                         int* __restrict__ pos_token, float* __restrict__ pos_weight,
+                                         int T) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= T) return;
+    const int e = ids[i];
+    const int p = offsets[e] + atomicAdd(&cursor[e], 1);
+    pos_token[p] = i;            // flat token*top_k+slot index; token recovered as i/top_k downstream
+    pos_weight[p] = weights[i];
+}
+
+// ---- gather + per-row int8 quantize ----------------------------------------------------------
+__global__ void mp_gather_quant_i8_kernel(const __nv_bfloat16* __restrict__ hn,
+                                          const int* __restrict__ pos_token, int top_k,
+                                          signed char* __restrict__ Ai8, float* __restrict__ sA,
+                                          int rows, int H) {
+    const int r = blockIdx.x, lane = threadIdx.x;
+    if (r >= rows) return;
+    const int flat = pos_token[r];
+    signed char* out = Ai8 + (size_t)r * H;
+    if (flat < 0) {   // padding row -> zero
+        for (int c = lane; c < H; c += 32) out[c] = 0;
+        if (lane == 0) sA[r] = 0.f;
+        return;
+    }
+    const __nv_bfloat16* a = hn + (size_t)(flat / top_k) * H;
+    float amax = 0.f;
+    for (int c = lane; c < H; c += 32) amax = fmaxf(amax, fabsf(__bfloat162float(a[c])));
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    const float d = amax / 127.0f;
+    if (lane == 0) sA[r] = d;
+    for (int c = lane; c < H; c += 32)
+        out[c] = (signed char)((amax == 0.f) ? 0 : (int)roundf(__bfloat162float(a[c]) / d));
+}
+
+// ---- grouped int8 GEMM -----------------------------------------------------------------------
+// C[t,Nout] = Ai8[t,K] @ W_i8[e,Nout,K]^T for the expert e = tile_expert[blockIdx.x]. Rows are the
+// 128-row block-aligned group tile; dims are tile-aligned (Nout%128==0, K%64==0) by construction.
+__global__ __launch_bounds__(256, 2) void mp_grouped_gemm_i8_kernel(
+        const signed char* __restrict__ A, const float* __restrict__ sA,
+        const signed char* __restrict__ W, const float* __restrict__ sW,
+        const int* __restrict__ tile_expert, __nv_bfloat16* __restrict__ C, int Nout, int K) {
+    const int e = tile_expert[blockIdx.x];
+    if (e < 0) return;
+    const signed char* We = W + (size_t)e * Nout * K;
+    const float* sWe = sW + (size_t)e * Nout;
+
+    __shared__ signed char As[2][MBM][MBK];
+    __shared__ signed char Bs[2][MBN][MBK];
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int grp = lane >> 2, tig = lane & 3, wm = warp & 3, wn = warp >> 2;
+    const int m0 = blockIdx.x * MBM, n0 = blockIdx.y * MBN;
+    const int nk = (K + MBK - 1) / MBK;
+
+    int acc[MFRAG][NFRAG][4];
+    #pragma unroll
+    for (int i = 0; i < MFRAG; i++)
+        #pragma unroll
+        for (int j = 0; j < NFRAG; j++)
+            #pragma unroll
+            for (int el = 0; el < 4; el++) acc[i][j][el] = 0;
+
+    auto stage = [&](int buf, int k0) {
+        #pragma unroll
+        for (int s = tid; s < 512; s += 256) {
+            const int r = s >> 2, c = s & 3, k = c << 4;
+            const int gk = k0 + k;
+            mp_cp16(&As[buf][r][mp_swz(k, r)], &A[(size_t)(m0 + r) * K + gk], gk < K);
+            mp_cp16(&Bs[buf][r][mp_swz(k, r)], &We[(size_t)(n0 + r) * K + gk], gk < K);
+        }
+        __pipeline_commit();
+    };
+
+    stage(0, 0);
+    int buf = 0;
+    for (int t = 0; t < nk; t++) {
+        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * MBK);
+        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+        __syncthreads();
+        #pragma unroll
+        for (int kk = 0; kk < MBK; kk += 32) {
+            const int ka = kk + tig * 4;
+            unsigned af[MFRAG][4], bf[NFRAG][2];
+            #pragma unroll
+            for (int i = 0; i < MFRAG; i++) {
+                const int rlo = wm * 32 + i * 16 + grp, rhi = rlo + 8;
+                af[i][0] = mp_lds32(&As[buf][rlo][mp_swz(ka,      rlo)]);
+                af[i][1] = mp_lds32(&As[buf][rhi][mp_swz(ka,      rhi)]);
+                af[i][2] = mp_lds32(&As[buf][rlo][mp_swz(ka + 16, rlo)]);
+                af[i][3] = mp_lds32(&As[buf][rhi][mp_swz(ka + 16, rhi)]);
+            }
+            #pragma unroll
+            for (int j = 0; j < NFRAG; j++) {
+                const int col = wn * 64 + j * 8 + grp;
+                bf[j][0] = mp_lds32(&Bs[buf][col][mp_swz(ka,      col)]);
+                bf[j][1] = mp_lds32(&Bs[buf][col][mp_swz(ka + 16, col)]);
+            }
+            #pragma unroll
+            for (int i = 0; i < MFRAG; i++)
+                #pragma unroll
+                for (int j = 0; j < NFRAG; j++)
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                        : "+r"(acc[i][j][0]), "+r"(acc[i][j][1]), "+r"(acc[i][j][2]), "+r"(acc[i][j][3])
+                        : "r"(af[i][0]), "r"(af[i][1]), "r"(af[i][2]), "r"(af[i][3]),
+                          "r"(bf[j][0]), "r"(bf[j][1]));
+        }
+        __syncthreads();
+        buf ^= 1;
+    }
+
+    #pragma unroll
+    for (int i = 0; i < MFRAG; i++) {
+        #pragma unroll
+        for (int j = 0; j < NFRAG; j++) {
+            const int gn = n0 + wn * 64 + j * 8 + tig * 2;
+            const float w0 = sWe[gn], w1 = sWe[gn + 1];
+            #pragma unroll
+            for (int h = 0; h < 2; h++) {
+                const int gm = m0 + wm * 32 + i * 16 + grp + h * 8;
+                const float s = sA[gm];
+                const __nv_bfloat162 v = __floats2bfloat162_rn((float)acc[i][j][h * 2] * s * w0,
+                                                               (float)acc[i][j][h * 2 + 1] * s * w1);
+                *reinterpret_cast<__nv_bfloat162*>(&C[(size_t)gm * Nout + gn]) = v;
+            }
+        }
+    }
+}
+
+// ---- SwiGLU -> int8 --------------------------------------------------------------------------
+__global__ void mp_swiglu_quant_i8_kernel(const __nv_bfloat16* __restrict__ gate,
+                                          const __nv_bfloat16* __restrict__ up,
+                                          signed char* __restrict__ Hi8, float* __restrict__ sH,
+                                          int rows, int F) {
+    const int r = blockIdx.x, lane = threadIdx.x;
+    if (r >= rows) return;
+    const __nv_bfloat16* g = gate + (size_t)r * F;
+    const __nv_bfloat16* u = up   + (size_t)r * F;
+    float amax = 0.f;
+    for (int c = lane; c < F; c += 32) {
+        const float gv = __bfloat162float(g[c]);
+        const float h = (gv / (1.f + __expf(-gv))) * __bfloat162float(u[c]);
+        amax = fmaxf(amax, fabsf(h));
+    }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    const float d = amax / 127.0f;
+    if (lane == 0) sH[r] = d;
+    signed char* out = Hi8 + (size_t)r * F;
+    for (int c = lane; c < F; c += 32) {
+        const float gv = __bfloat162float(g[c]);
+        const float h = (gv / (1.f + __expf(-gv))) * __bfloat162float(u[c]);
+        out[c] = (signed char)((amax == 0.f) ? 0 : (int)roundf(h / d));
+    }
+}
+
+// ---- weighted scatter-back -------------------------------------------------------------------
+__global__ void mp_scatter_weighted_kernel(const __nv_bfloat16* __restrict__ D,
+                                           const int* __restrict__ pos_token, int top_k,
+                                           const float* __restrict__ pos_weight,
+                                           float* __restrict__ routed, int rows, int H) {
+    const int r = blockIdx.x;
+    if (r >= rows) return;
+    const int flat = pos_token[r];
+    if (flat < 0) return;
+    const int n = flat / top_k;
+    const float wgt = pos_weight[r];
+    const __nv_bfloat16* d = D + (size_t)r * H;
+    float* dst = routed + (size_t)n * H;
+    for (int c = threadIdx.x; c < H; c += blockDim.x)
+        atomicAdd(&dst[c], wgt * __bfloat162float(d[c]));
+}
+
+// ---- finalize --------------------------------------------------------------------------------
+__global__ void mp_finalize_kernel(const __nv_bfloat16* __restrict__ h, const float* __restrict__ routed,
+                                   const __nv_bfloat16* __restrict__ shared, const float* __restrict__ gate_logit,
+                                   __nv_bfloat16* __restrict__ out, int N, int H) {
+    const int n = blockIdx.x;
+    if (n >= N) return;
+    const float g = (gate_logit && shared) ? 1.f / (1.f + __expf(-gate_logit[n])) : 0.f;
+    const __nv_bfloat16* hn = h + (size_t)n * H;
+    const float* rn = routed + (size_t)n * H;
+    const __nv_bfloat16* sn = shared ? shared + (size_t)n * H : nullptr;
+    __nv_bfloat16* on = out + (size_t)n * H;
+    for (int c = threadIdx.x; c < H; c += blockDim.x) {
+        float v = __bfloat162float(hn[c]) + rn[c];
+        if (sn) v += g * __bfloat162float(sn[c]);
+        on[c] = __float2bfloat16(v);
+    }
+}
+} // namespace
+
+// ---- host launchers --------------------------------------------------------------------------
+int moe_prefill_max_tiles(int N, int top_k, int E) { return (N * top_k + MBM - 1) / MBM + E; }
+int moe_prefill_padded_rows(int N, int top_k, int E) { return moe_prefill_max_tiles(N, top_k, E) * MBM; }
+
+void launch_moe_prefill_router_logits(const void* hn, const void* router_w, int router_w_type,
+                                      void* rw_bf16, float* logits, int N, int H, int E, cudaStream_t st) {
+    const __nv_bfloat16* rw;
+    if (router_w_type != 0) {
+        launch_gguf_dequant(router_w_type, router_w, rw_bf16, (long)E * H, st);
+        rw = reinterpret_cast<const __nv_bfloat16*>(rw_bf16);
+    } else {
+        rw = reinterpret_cast<const __nv_bfloat16*>(router_w);
+    }
+    const int WPB = 8;
+    dim3 grid(N, (E + WPB - 1) / WPB);
+    mp_router_logits_kernel<<<grid, WPB * 32, 0, st>>>(
+        reinterpret_cast<const __nv_bfloat16*>(hn), rw, logits, N, H, E);
+}
+
+void launch_moe_prefill_build_groups(const int* ids, const float* weights, const int* counts,
+                                     int* offsets, int* pos_token, float* pos_weight, int* tile_expert,
+                                     int* /*d_num_tiles*/, int N, int top_k, int E, cudaStream_t st) {
+    const int T = N * top_k;
+    const int max_tiles = moe_prefill_max_tiles(N, top_k, E);
+    cudaMemsetAsync(pos_token, 0xFF, (size_t)max_tiles * MBM * sizeof(int), st);   // -1 padding sentinel
+    int* cursor = offsets + (E + 1);   // reuse the tail of the offsets scratch as the E cursors
+    mp_build_offsets_kernel<<<1, ((E + 31) / 32) * 32, E * sizeof(int), st>>>(
+        counts, offsets, tile_expert, cursor, E, max_tiles);
+    mp_scatter_assign_kernel<<<(T + 255) / 256, 256, 0, st>>>(
+        ids, weights, offsets, cursor, pos_token, pos_weight, T);
+}
+
+void launch_moe_prefill_gather_quant_i8(const void* hn, const int* pos_token, int top_k,
+                                        signed char* Ai8, float* sA, int rows, int H, cudaStream_t st) {
+    mp_gather_quant_i8_kernel<<<rows, 32, 0, st>>>(
+        reinterpret_cast<const __nv_bfloat16*>(hn), pos_token, top_k, Ai8, sA, rows, H);
+}
+
+void launch_moe_grouped_gemm_i8(const signed char* Ai8, const float* sA, const signed char* W_i8,
+                                const float* sW, const int* /*offsets*/, const int* tile_expert,
+                                int max_tiles, void* C, int Nout, int K, cudaStream_t st) {
+    dim3 grid(max_tiles, (Nout + MBN - 1) / MBN);
+    mp_grouped_gemm_i8_kernel<<<grid, 256, 0, st>>>(
+        Ai8, sA, W_i8, sW, tile_expert, reinterpret_cast<__nv_bfloat16*>(C), Nout, K);
+}
+
+void launch_moe_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* Hi8,
+                                        float* sH, int rows, int F, cudaStream_t st) {
+    mp_swiglu_quant_i8_kernel<<<rows, 32, 0, st>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
+        Hi8, sH, rows, F);
+}
+
+void launch_moe_prefill_scatter_weighted(const void* D, const int* pos_token, int top_k,
+                                         const float* pos_weight, void* routed, int rows, int N,
+                                         int H, cudaStream_t st) {
+    cudaMemsetAsync(routed, 0, (size_t)N * H * sizeof(float), st);
+    mp_scatter_weighted_kernel<<<rows, 256, 0, st>>>(
+        reinterpret_cast<const __nv_bfloat16*>(D), pos_token, top_k, pos_weight,
+        reinterpret_cast<float*>(routed), rows, H);
+}
+
+void launch_moe_prefill_finalize(const void* h, const void* routed, const void* shared,
+                                 const float* gate_scalar, void* out, int N, int H, cudaStream_t st) {
+    mp_finalize_kernel<<<N, 256, 0, st>>>(
+        reinterpret_cast<const __nv_bfloat16*>(h), reinterpret_cast<const float*>(routed),
+        reinterpret_cast<const __nv_bfloat16*>(shared), gate_scalar,
+        reinterpret_cast<__nv_bfloat16*>(out), N, H);
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/moe_prefill_grouped.h
+++ b/kernels/include/sparkinfer/kernels/moe_prefill_grouped.h
@@ -1,0 +1,71 @@
+#pragma once
+// Grouped int8 tensor-core MoE FFN for batched prefill (Qwen3.6-35B-A3B).
+//
+// Decode routes one token at a time, so every prompt token reloads all 8 routed experts' Q4_K/Q6_K
+// weights as bandwidth-bound GEMVs. This path instead runs the whole prompt through the MoE FFN in
+// one pass: tokens are permuted into per-expert contiguous groups so each expert weight is streamed
+// once and reused across all its tokens, and the gate/up/down products run as int8 mma.sync
+// (m16n8k32) tensor-core GEMMs against the same per-row symmetric int8 requant the dense prefill
+// projections already use. Output is numerically consistent with the decode MoE FFN so a subsequent
+// decode step is faithful.
+//
+// The grouped GEMM is a single launch: a device-built tile schedule maps each CTA to (expert,
+// row-tile), and expert groups are padded to the block-row tile so a tile never straddles two
+// experts. No host sync in the per-layer loop.
+#include <cuda_runtime.h>
+
+namespace sparkinfer { namespace kernels {
+
+// Padded row capacity for T = num_tokens * top_k assignments, groups rounded up to MOE_PF_BM (128).
+int  moe_prefill_padded_rows(int num_tokens, int top_k, int num_experts);
+// Upper bound on the number of row-tiles the grouped GEMM can emit (for grid.x sizing).
+int  moe_prefill_max_tiles(int num_tokens, int top_k, int num_experts);
+
+// Batched router logits: logits[N,E] = hn[N,H] @ router_w[E,H]^T. router_w native [E,H]; if
+// router_w_type != 0 it is dequantized into rw_bf16 scratch [E,H] first (Q4_K/Q6_K/Q8_0).
+void launch_moe_prefill_router_logits(
+    const void* hn, const void* router_w, int router_w_type, void* rw_bf16,
+    float* logits, int N, int H, int E, cudaStream_t stream);
+
+// From top-k ids/weights + per-expert counts, build padded per-expert groups: exclusive-scan the
+// counts into block-aligned offsets, scatter each (token,slot) assignment into its expert's group
+// (recording source token + routing weight), and emit the (expert per row-tile) schedule. Padding
+// rows get token = -1 (masked to zero downstream).
+void launch_moe_prefill_build_groups(
+    const int* ids, const float* weights, const int* counts,
+    int* offsets, int* pos_token, float* pos_weight, int* tile_expert,
+    int* d_num_tiles, int N, int top_k, int E, cudaStream_t stream);
+
+// Gather permuted activations and per-row symmetric int8 quantize: for padded row t,
+// Ai8[t,:] = round(hn[pos_token[t]/top_k,:] / sA[t]); pos_token[t] < 0 -> zero row.
+void launch_moe_prefill_gather_quant_i8(
+    const void* hn, const int* pos_token, int top_k, signed char* Ai8, float* sA,
+    int padded_rows, int H, cudaStream_t stream);
+
+// Single-launch grouped int8 GEMM: C[t, Nout] = Ai8[t,K] @ W_i8[e(t), Nout, K]^T, dequant folded as
+// sA[t]*sW[e,n]. Rows are grouped by expert via block-aligned offsets; tile_expert[tile] names the
+// expert for row-tile `tile` (>=0), or -1 to skip. grid = (max_tiles, ceil(Nout/128)).
+void launch_moe_grouped_gemm_i8(
+    const signed char* Ai8, const float* sA, const signed char* W_i8, const float* sW,
+    const int* offsets, const int* tile_expert, int max_tiles,
+    void* C, int Nout, int K, cudaStream_t stream);
+
+// h[t,F] = silu(gate[t,F]) * up[t,F], then per-row symmetric int8 quantize -> Hi8[t,F], sH[t].
+void launch_moe_prefill_swiglu_quant_i8(
+    const void* gate, const void* up, signed char* Hi8, float* sH,
+    int padded_rows, int F, cudaStream_t stream);
+
+// Scatter the weighted down outputs back to per-token rows: routed[pos_token[t]/top_k] +=
+// pos_weight[t] * D[t,:] (fp32 accumulate). routed is zero-initialized by the launcher. Padding
+// rows (token < 0) are skipped.
+void launch_moe_prefill_scatter_weighted(
+    const void* D, const int* pos_token, int top_k, const float* pos_weight,
+    void* routed, int padded_rows, int N, int H, cudaStream_t stream);
+
+// Finalize: out[n,:] = h[n,:] + routed[n,:] + gate_scalar[n] * shared[n,:]. gate_scalar may be null
+// (shared added ungated) or shared may be null (no shared expert).
+void launch_moe_prefill_finalize(
+    const void* h, const void* routed, const void* shared, const float* gate_scalar,
+    void* out, int N, int H, cudaStream_t stream);
+
+}} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1109,15 +1109,20 @@ bool prefill_samples_lmhead() {
 // Qwythos dense-hybrid batched prefill (prefill_batched_run). Default ON; SPARKINFER_PREFILL_BATCHED=0
 // disables. Batched fill runs from position 0 only; suffix-only reuse uses the token loop.
 bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
-    static int want_batched = -1, batched_maxctx = -1;
+    static int want_batched = -1, batched_maxctx = -1, want_moe = -1;
     if (want_batched < 0) {
         const char* e = getenv("SPARKINFER_PREFILL_BATCHED");
         want_batched = (e && e[0] == '0') ? 0 : 1;
         const char* mc = getenv("SPARKINFER_PREFILL_BATCHED_MAXCTX");
         batched_maxctx = mc ? atoi(mc) : 65536;
+        const char* me = getenv("SPARKINFER_PREFILL_MOE");   // grouped int8 MoE prefill (Qwen3.6)
+        want_moe = (me && me[0] == '0') ? 0 : 1;
     }
-    return want_batched && gguf && cfg.hybrid && cfg.dense_ffn && n_tokens > 0 &&
-           n_tokens <= batched_maxctx;
+    // Qwen3.6-35B-A3B MoE hybrid: grouped int8 expert FFN path in prefill_batched_run.
+    const bool moe_ok = want_moe && !cfg.dense_ffn && cfg.n_experts == 256 &&
+                        cfg.top_k == 8 && cfg.moe_ffn == 512 && cfg.hidden == 2048;
+    return want_batched && gguf && cfg.hybrid && n_tokens > 0 && n_tokens <= batched_maxctx &&
+           (cfg.dense_ffn || moe_ok);
 }
 } // namespace
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -17,6 +17,8 @@
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/prefill_i8.h"
+#include "sparkinfer/kernels/moe.h"
+#include "sparkinfer/kernels/moe_prefill_grouped.h"
 
 #include <cuda_runtime.h>
 #include <cmath>
@@ -48,9 +50,12 @@ struct Arena {
 
 int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n) {
     const Qwen35Config& c = s.cfg;
-    // Only the Qwen3.5 dense-hybrid path is supported (GGUF-native, quantized weights).
-    if (!s.gguf || !c.hybrid || !c.dense_ffn || n <= 0) return -1;
+    // Qwen3.5 dense-hybrid, or the Qwen3.6-35B-A3B MoE hybrid (grouped int8 expert FFN below).
+    const bool is_moe = !c.dense_ffn;
+    if (!s.gguf || !c.hybrid || n <= 0) return -1;
     if (c.head_dim != 256 || c.linear_head_dim != 128) return -1;   // kernels specialize these
+    if (is_moe && !(c.n_experts == 256 && c.top_k == 8 && c.moe_ffn == 512 && c.hidden == 2048))
+        return -1;   // grouped MoE prefill specialized to the Qwen3.6-35B-A3B shape
 
     const int H = c.hidden;
     const int N = n;
@@ -60,9 +65,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const int lqkv = s.linear_qkvdim;                    // 8192
     const int lvdim = s.linear_vdim;                     // 4096
     const int vh   = c.linear_v_heads;                   // 32
-    const int ffn  = c.moe_ffn;                          // 12288
+    const int ffn  = c.moe_ffn;                          // dense: 12288 · MoE: 512 (per expert)
     const int wide = 2 * qdim;                           // 8192 (qraw); also >= lqkv
-    const size_t maxw = (size_t)ffn * H;                 // largest weight (gate/up/down)
+    // Projection scratch must cover every proj() shape, not just the FFN: on the MoE model ffn=512
+    // is small but the GDN/attn projections (wqkv=lqkv, ssm_out K=lvdim, ...) are wider. Size the
+    // int8/dequant scratch on the true maxima so proj() never overruns on either model.
+    auto umax = [](size_t a, size_t b) { return a > b ? a : b; };
+    const size_t maxw = umax(umax((size_t)ffn * H, (size_t)lqkv * H),
+                             umax((size_t)H * lvdim, (size_t)H * qdim));   // largest weight tile
+    const int max_k   = (int)umax(umax((size_t)H, (size_t)ffn), umax((size_t)lvdim, (size_t)qdim));
+    const int max_out = (int)umax(umax((size_t)ffn, (size_t)lqkv), umax((size_t)H, (size_t)wide));
     bf16* lin_conv_state = static_cast<bf16*>(s.lin_conv_state);
 
     // ---- scratch ----
@@ -98,11 +110,63 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const char* _pi8 = getenv("SPARKINFER_PREFILL_I8");
     bool use_i8 = !(_pi8 && _pi8[0] == '0');
     Arena a8;
-    signed char* A_i8 = use_i8 ? a8.alloc<signed char>((size_t)N * ffn) : nullptr;
+    signed char* A_i8 = use_i8 ? a8.alloc<signed char>((size_t)N * max_k) : nullptr;
     signed char* W_i8 = use_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = use_i8 ? a8.alloc<float>((size_t)N) : nullptr;
-    float* sw = use_i8 ? a8.alloc<float>((size_t)ffn) : nullptr;
+    float* sw = use_i8 ? a8.alloc<float>((size_t)max_out) : nullptr;
     if (use_i8 && !a8.ok) { a8.free_all(); use_i8 = false; }
+
+    // ---- grouped-MoE prefill scratch (Qwen3.6) ----------------------------------------------
+    // One int8 requant of the whole [E,*] expert stack per weight per layer (reused across the
+    // layer's tokens), plus the permuted-assignment activation/output buffers. Its own arena so an
+    // OOM at large N degrades to the token loop instead of the dense-FFN path.
+    const int E = c.n_experts, F = c.moe_ffn, TK = c.top_k;
+    const int max_tiles = is_moe ? kernels::moe_prefill_max_tiles(N, TK, E) : 0;
+    const int prows = max_tiles * 128;                   // padded permuted rows
+    Arena am;
+    float*  m_logits = nullptr; int* m_ids = nullptr; float* m_wts = nullptr; int* m_counts = nullptr;
+    int*    m_off = nullptr; int* m_postok = nullptr; float* m_poswt = nullptr; int* m_tile = nullptr;
+    signed char *m_Ai8 = nullptr, *m_Hi8 = nullptr, *m_Wg = nullptr, *m_Wu = nullptr, *m_Wd = nullptr;
+    float   *m_sA = nullptr, *m_sH = nullptr, *m_sWg = nullptr, *m_sWu = nullptr, *m_sWd = nullptr;
+    bf16    *m_G = nullptr, *m_U = nullptr, *m_D = nullptr, *m_rw = nullptr;
+    float*  m_routed = nullptr;
+    bf16    *m_shared = nullptr, *m_shg = nullptr, *m_shu = nullptr, *m_shh = nullptr;
+    bf16    *m_sgw = nullptr, *m_suw = nullptr, *m_sdw = nullptr, *m_sgiw = nullptr;
+    bf16    *m_wdq = nullptr;
+    float*  m_gate_logit = nullptr;
+    if (is_moe) {
+        m_logits = am.alloc<float>((size_t)N * E);
+        m_ids    = am.alloc<int>((size_t)N * TK);
+        m_wts    = am.alloc<float>((size_t)N * TK);
+        m_counts = am.alloc<int>(E);
+        m_off    = am.alloc<int>(2 * E + 1);             // offsets[E+1] + E scatter cursors
+        m_postok = am.alloc<int>(prows);
+        m_poswt  = am.alloc<float>(prows);
+        m_tile   = am.alloc<int>(max_tiles);
+        m_Ai8    = am.alloc<signed char>((size_t)prows * H);
+        m_sA     = am.alloc<float>(prows);
+        m_Wg     = am.alloc<signed char>((size_t)E * F * H); m_sWg = am.alloc<float>((size_t)E * F);
+        m_Wu     = am.alloc<signed char>((size_t)E * F * H); m_sWu = am.alloc<float>((size_t)E * F);
+        m_Wd     = am.alloc<signed char>((size_t)E * H * F); m_sWd = am.alloc<float>((size_t)E * H);
+        m_G      = am.alloc<bf16>((size_t)prows * F);
+        m_U      = am.alloc<bf16>((size_t)prows * F);
+        m_Hi8    = am.alloc<signed char>((size_t)prows * F); m_sH = am.alloc<float>(prows);
+        m_D      = am.alloc<bf16>((size_t)prows * H);
+        m_rw     = am.alloc<bf16>((size_t)E * H);
+        m_routed = am.alloc<float>((size_t)N * H);
+        m_shared = am.alloc<bf16>((size_t)N * H);
+        m_shg    = am.alloc<bf16>((size_t)N * F);
+        m_shu    = am.alloc<bf16>((size_t)N * F);
+        m_shh    = am.alloc<bf16>((size_t)N * F);
+        m_sgw    = am.alloc<bf16>((size_t)F * H);
+        m_suw    = am.alloc<bf16>((size_t)F * H);
+        m_sdw    = am.alloc<bf16>((size_t)H * F);
+        m_sgiw   = am.alloc<bf16>(H);
+        m_gate_logit = am.alloc<float>(N);
+        m_wdq       = am.alloc<bf16>((size_t)E * F * H);   // bf16 fallback for unsupported quant (UD Q5_K)
+        if (!am.ok) { am.free_all(); a.free_all(); a8.free_all();
+            fprintf(stderr, "[prefill] MoE scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
+    }
 
     pf_cu(cudaMemcpyAsync(d_ids, prompt_ids, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "prefill ids");
 
@@ -139,6 +203,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const float rope_theta = c.rope_theta, eps = c.rms_eps;
     const int rope_dim = (c.rope_dim > 0) ? c.rope_dim : c.head_dim;
     const float attn_scale = 1.f / sqrtf((float)c.head_dim);
+
+    // Return a bf16 [rows,cols] view of a shared-expert weight: pass through the bf16 dense tensor
+    // if present, else dequant the GGUF-quantized tensor (Q8_0/Q4_K) into the provided scratch.
+    auto sh_bf16 = [&](const void* wq, int qtype, const void* wbf, bf16* scratch, long nv) -> const bf16* {
+        if (wbf) return reinterpret_cast<const bf16*>(wbf);
+        if (wq)  { kernels::launch_gguf_dequant(qtype, wq, scratch, nv, st); return scratch; }
+        return nullptr;
+    };
 
     // embed -> x, prime xn = RMSNorm(x, layer0.input_norm)
     kernels::launch_embedding(d_ids, s.w.embed_tokens, x, N, H, st);
@@ -184,14 +256,63 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::launch_prefill_add(x, ao, hbuf, (long)N * H, st);
         kernels::launch_rmsnorm(hbuf, w.post_attn_norm, hn, N, H, eps, st);
 
-        // dense SwiGLU FFN
-        proj(hn, w.gate_q, w.gate_qtype, ffg, ffn, H);
-        proj(hn, w.up_q,   w.up_qtype,   ffu, ffn, H);
-        kernels::launch_prefill_swiglu(ffg, ffu, ffh, (long)N * ffn, st);
-        proj(ffh, w.down_q, w.down_qtype, ao, H, ffn);
+        if (!is_moe) {
+            // dense SwiGLU FFN
+            proj(hn, w.gate_q, w.gate_qtype, ffg, ffn, H);
+            proj(hn, w.up_q,   w.up_qtype,   ffu, ffn, H);
+            kernels::launch_prefill_swiglu(ffg, ffu, ffh, (long)N * ffn, st);
+            proj(ffh, w.down_q, w.down_qtype, ao, H, ffn);
+            // x = h + ffn_out
+            kernels::launch_prefill_add(hbuf, ao, x, (long)N * H, st);
+        } else {
+            // grouped int8 tensor-core MoE FFN: route -> permute into per-expert groups ->
+            // gate/up/down as grouped int8 GEMMs -> weighted scatter + gated shared expert.
+            kernels::launch_moe_prefill_router_logits(hn, w.router_w, w.router_w_type, m_rw,
+                                                      m_logits, N, H, E, st);
+            pf_cu(cudaMemsetAsync(m_counts, 0, (size_t)E * sizeof(int), st), "moe counts zero");
+            kernels::launch_moe_router(m_logits, m_ids, m_wts, m_counts, N, E, TK, 1, st);
+            kernels::launch_moe_prefill_build_groups(m_ids, m_wts, m_counts, m_off, m_postok,
+                                                     m_poswt, m_tile, nullptr, N, TK, E, st);
+            kernels::launch_moe_prefill_gather_quant_i8(hn, m_postok, TK, m_Ai8, m_sA, prows, H, st);
+            // one int8 requant of the whole expert stack, reused across all of this layer's tokens.
+            // Fused Q4_K/Q6_K -> int8; UD mixed quants (e.g. Q5_K down) fall back to dequant->bf16
+            // (the validated GGUF path) then per-row int8, matching the dense proj() fallback.
+            auto requant = [&](int qt, const void* Wq, signed char* Wi8, float* sWi8, int rows, int cols) {
+                if (!kernels::launch_gguf_dequant_rows_i8(qt, Wq, Wi8, sWi8, rows, cols, st)) {
+                    kernels::launch_gguf_dequant(qt, Wq, m_wdq, (long)rows * cols, st);
+                    kernels::launch_prefill_quantize_rows_i8(m_wdq, Wi8, sWi8, rows, cols, st);
+                }
+            };
+            requant(w.gate_qtype, w.gate_q, m_Wg, m_sWg, E * F, H);
+            requant(w.up_qtype,   w.up_q,   m_Wu, m_sWu, E * F, H);
+            requant(w.down_qtype, w.down_q, m_Wd, m_sWd, E * H, F);
+            kernels::launch_moe_grouped_gemm_i8(m_Ai8, m_sA, m_Wg, m_sWg, m_off, m_tile, max_tiles, m_G, F, H, st);
+            kernels::launch_moe_grouped_gemm_i8(m_Ai8, m_sA, m_Wu, m_sWu, m_off, m_tile, max_tiles, m_U, F, H, st);
+            kernels::launch_moe_prefill_swiglu_quant_i8(m_G, m_U, m_Hi8, m_sH, prows, F, st);
+            kernels::launch_moe_grouped_gemm_i8(m_Hi8, m_sH, m_Wd, m_sWd, m_off, m_tile, max_tiles, m_D, H, F, st);
+            kernels::launch_moe_prefill_scatter_weighted(m_D, m_postok, TK, m_poswt, m_routed, prows, N, H, st);
+            // shared expert (Q8_0/Q4_K -> bf16, batched bf16 GEMM) + its sigmoid scalar gate
+            const bf16* sgw = sh_bf16(w.shared_gate_q, w.shared_gate_qtype, w.shared_gate, m_sgw, (long)F * H);
+            const bf16* suw = sh_bf16(w.shared_up_q,   w.shared_up_qtype,   w.shared_up,   m_suw, (long)F * H);
+            const bf16* sdw = sh_bf16(w.shared_down_q, w.shared_down_qtype, w.shared_down, m_sdw, (long)H * F);
+            const bf16* shared_out = nullptr; const float* glogit = nullptr;
+            if (c.n_shared > 0 && sgw && suw && sdw) {
+                kernels::launch_prefill_gemm(hn, sgw, m_shg, N, F, H, st);
+                kernels::launch_prefill_gemm(hn, suw, m_shu, N, F, H, st);
+                kernels::launch_prefill_swiglu(m_shg, m_shu, m_shh, (long)N * F, st);
+                kernels::launch_prefill_gemm(m_shh, sdw, m_shared, N, H, F, st);
+                shared_out = m_shared;
+                if (w.shared_gate_inp) {   // reuse the router-logits kernel as a single-expert dot
+                    kernels::launch_moe_prefill_router_logits(hn, w.shared_gate_inp,
+                        w.shared_gate_inp_type, m_sgiw, m_gate_logit, N, H, 1, st);
+                    glogit = m_gate_logit;
+                }
+            }
+            // x = h + routed + sigmoid(glogit) * shared
+            kernels::launch_moe_prefill_finalize(hbuf, m_routed, shared_out, glogit, x, N, H, st);
+        }
 
-        // x = h + ffn_out ; xn = RMSNorm(x, next_input_norm)  (final_norm on the last layer)
-        kernels::launch_prefill_add(hbuf, ao, x, (long)N * H, st);
+        // xn = RMSNorm(x, next_input_norm)  (final_norm on the last layer)
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
     }
@@ -209,6 +330,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
     a.free_all();
     a8.free_all();
+    am.free_all();
     return seed;
 }
 


### PR DESCRIPTION
## Summary

Batched **grouped int8 tensor-core MoE prefill** for Qwen3.6-35B-A3B. On `main` this model's prefill falls back to the per-token decode loop — every routed expert's Q4_K/Q6_K weight is reloaded once per prompt token — so prompt processing runs at ~520–580 pp. This PR permutes the prompt's tokens into per-expert contiguous groups (block-aligned to the 128-row GEMM tile) so each expert weight is streamed **once** and reused across all of its tokens, and runs gate/up/down as `mma.sync.m16n8k32` int8 tensor-core GEMMs. The batched FFN output tracks the decode MoE FFN (routing reuses `launch_moe_router`; output verified numerically faithful), so a following decode step is unchanged. The dense Qwythos/Qwen3.5 path is untouched (guarded by `!dense_ffn`). Scoped to `kernels/` + `runtime/`.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh`).

- [x] Tested on **RTX 5090** (`sm_120`)

Both `main` and this PR were built from source and benched on the **same RTX 5090**, one model-load per build (sweep mode), so the deltas are same-box.

**Decode tok/s** — unchanged (this PR does not touch the decode path):

| | decode tok/s |
|---|--:|
| before (main) | 481.17 |
| after (this PR) | 481.78 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B, from `bench.sh` / `qwen3_gguf_bench <gguf> 128 <ctx>`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 562.75 |
| after prefill (this PR) | 7412.20 |

Full measured sweep (same box, fresh source builds of both):

| ctx | before (main) | after (this PR) | speedup |
|---|--:|--:|--:|
| 512 | 578.14 | 1399.72 | 2.4× |
| 4096 | 562.75 | 7412.20 | 13.2× |
| 16384 | 543.17 | 12534.54 | 23.1× |
| 32768 | 520.10 | 14026.89 | 27.0× |

`SPARKINFER_PREFILL_MOE=0` restores the token-loop baseline for A/B on the same binary.

```text
# qwen3_gguf_bench 128, SPARKINFER_BENCH_SWEEP_CTXS=512,4096,16384,32768 (one load each)
BASELINE (main):
  {"512":{"decode_tps":500.71,"prefill_pp":578.14},"4096":{"decode_tps":481.17,"prefill_pp":562.75},
   "16384":{"decode_tps":462.36,"prefill_pp":543.17},"32768":{"decode_tps":431.96,"prefill_pp":520.10}}
CANDIDATE (this PR):
  {"512":{"decode_tps":500.90,"prefill_pp":1399.72},"4096":{"decode_tps":481.78,"prefill_pp":7412.20},
   "16384":{"decode_tps":463.03,"prefill_pp":12534.54},"32768":{"decode_tps":433.64,"prefill_pp":14026.89}}
```

### Implementation

- New `kernels/csrc/cuda/moe/moe_prefill_grouped_i8.cu` (+ header): router-logits, block-aligned per-expert permute/gather, the grouped int8 `m16n8k32` GEMM with a device-built (expert → row-tile) schedule, SwiGLU→int8, weighted scatter-back, and the gated shared-expert finalize.
- `runtime/src/models/qwen35_prefill.cpp`: MoE FFN branch; the projection int8/dequant scratch is sized on the true per-projection maxima (unchanged for the dense model, where `moe_ffn` is already the largest dim). UD mixed-quant `down` (Q5_K) uses a bf16 requant fallback.
- `runtime/src/models/qwen35.cpp`: `batched_prefill_enabled` widened to admit the Qwen3.6 MoE hybrid (env `SPARKINFER_PREFILL_MOE`).
