### PR TITLE
ci: auto-close PRs without RTX 5090 template attestation

### DIFF
--- a/.github/workflows/eval-policy.yml
+++ b/.github/workflows/eval-policy.yml
@@ -6,12 +6,14 @@ on:
       - "bench/scripts/**"
       - "eval/**"
       - ".github/workflows/eval-policy.yml"
+      - ".github/workflows/rtx5090-required.yml"
   push:
     branches: [main]
     paths:
       - "bench/scripts/**"
       - "eval/**"
       - ".github/workflows/eval-policy.yml"
+      - ".github/workflows/rtx5090-required.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/rtx5090-required.yml
+++ b/.github/workflows/rtx5090-required.yml
@@ -1,0 +1,111 @@
+name: rtx5090-required
+
+# Close PRs that do not tick the template's "Tested on RTX 5090" checkbox.
+# Evaluation is opt-in — unchecked PRs are not kept in the open review queue.
+#
+# Contributor flow after auto-close:
+#   1. Edit the PR description on the closed PR: tick the box + fill benchmark tables.
+#   2. Reopen the PR.
+#
+# Safe by design: pull_request_target never checks out or runs PR code — GitHub API only.
+# Draft PRs, bots, maintainers, and PRs labeled `hold` are exempt.
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: rtx5090-required-${{ github.event.pull_request.number || 'sweep' }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PRs without RTX 5090 attestation
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const EXEMPT_ASSOC = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const EXEMPT_LOGIN = new Set(['ai-hpc']);
+            const SKIP_LABELS = new Set(['hold']);
+
+            function rtx5090Checked(body) {
+              if (!body) return false;
+              return body.split('\n').some(ln =>
+                /\[\s*[xX]\s*\]/.test(ln) && ln.includes('5090')
+              );
+            }
+
+            function exempt(pr) {
+              if (!pr || pr.draft) return true;
+              if (pr.user?.type === 'Bot') return true;
+              if (EXEMPT_LOGIN.has(pr.user?.login)) return true;
+              if (EXEMPT_ASSOC.has(pr.author_association)) return true;
+              const labels = (pr.labels || []).map(l => l.name);
+              if (labels.some(n => SKIP_LABELS.has(n))) return true;
+              return false;
+            }
+
+            async function maybeClose(pr) {
+              if (!pr || pr.state !== 'open') return false;
+              if (exempt(pr)) {
+                core.info(`#${pr.number}: exempt — skip rtx5090 gate`);
+                return false;
+              }
+              if (rtx5090Checked(pr.body)) {
+                core.info(`#${pr.number}: RTX 5090 box checked — ok`);
+                return false;
+              }
+
+              const { owner, repo } = context.repo;
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number,
+                body:
+                  '<!-- sparkinfer-rtx5090-required -->\n' +
+                  '## Closed — RTX 5090 attestation required\n\n' +
+                  'This PR was auto-closed because the **Tested on RTX 5090** checkbox in the ' +
+                  'PR template is not ticked.\n\n' +
+                  'Evaluation is opt-in and proof-gated. To submit for review:\n\n' +
+                  '1. **Edit this PR description** (you can edit while closed): tick ' +
+                  '`- [x] Tested on RTX 5090` — only if you actually ran on a 5090\n' +
+                  '2. Fill the decode and/or prefill **before → after** tables with real ' +
+                  '`bench/scripts/bench.sh` numbers showing improvement\n' +
+                  '3. **Reopen** this PR\n\n' +
+                  'Unchecked PRs stay out of the RTX 5090 eval queue. See ' +
+                  `[CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md).\n\n` +
+                  '<sub>Automated by rtx5090-required CI. Maintainers and `hold` PRs are exempt.</sub>',
+              });
+              await github.rest.pulls.update({
+                owner, repo, pull_number: pr.number, state: 'closed',
+              });
+              core.notice(`closed #${pr.number}: RTX 5090 box not checked`);
+              return true;
+            }
+
+            const { owner, repo } = context.repo;
+            const isSweep = context.eventName === 'workflow_dispatch';
+            let closed = 0;
+
+            if (isSweep) {
+              const all = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+              for (const pr of all) {
+                const full = await github.rest.pulls.get({
+                  owner, repo, pull_number: pr.number,
+                });
+                if (await maybeClose(full.data)) closed++;
+              }
+            } else {
+              const num = context.payload.pull_request.number;
+              const full = await github.rest.pulls.get({ owner, repo, pull_number: num });
+              if (await maybeClose(full.data)) closed = 1;
+            }
+
+            core.notice(`rtx5090-required: closed ${closed} PR(s).`);

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -448,6 +448,10 @@ def _claimed_gain(before, after):
     """True when both numbers are present and after > before."""
     return before is not None and after is not None and after > before
 
+def rtx5090_box_checked(body):
+    """True when the PR template's 'Tested on RTX 5090' checkbox is ticked."""
+    return any(re.search(r"\[\s*[xX]\s*\]", ln) and "5090" in ln for ln in (body or "").splitlines())
+
 def greenlight_status(repo, num, pr_labels):
     """Decide whether a PR may be evaluated. Returns (status, reason):
       'ok'        — greenlit: box ticked + real decode and/or prefill before<after gain
@@ -456,7 +460,7 @@ def greenlight_status(repo, num, pr_labels):
     Checking the box is necessary but NOT sufficient — decode or prefill gain must be claimed."""
     body = (json.loads(gh(["pr", "view", str(num), "-R", repo, "--json", "body"]).stdout or "{}")
             .get("body") or "")
-    if not any(re.search(r"\[\s*[xX]\s*\]", ln) and "5090" in ln for ln in body.splitlines()):
+    if not rtx5090_box_checked(body):
         return "unchecked", "RTX-5090 box unchecked"
     d_before, d_after = _decode_val(body, "before"), _decode_val(body, "after")
     p_before, p_after = _prefill_val(body, "before"), _prefill_val(body, "after")

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -78,6 +78,13 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual(status, "unchecked")
         self.assertIn("unchecked", reason)
 
+    def test_rtx5090_box_checked(self):
+        ticked = self._TEMPLATE_DECODE.format(db=300, da=320)
+        self.assertTrue(bot.rtx5090_box_checked(ticked))
+        self.assertFalse(bot.rtx5090_box_checked(ticked.replace("[x]", "[ ]")))
+        self.assertFalse(bot.rtx5090_box_checked("- [x] Tested on RTX 4090"))
+        self.assertFalse(bot.rtx5090_box_checked(""))
+
     def test_decode_val_ignores_prefill_rows(self):
         body = self._TEMPLATE_BOTH.format(db=301, da=310, pb=250, pa=260)
         self.assertEqual(bot._decode_val(body, "before"), 301.0)


### PR DESCRIPTION
## Summary
- Add `rtx5090-required` GitHub Actions workflow: closes open PRs when the template **Tested on RTX 5090** checkbox is not ticked
- Exempt drafts, bots, maintainers, and `hold` label
- Extract `rtx5090_box_checked()` in `pr_eval_bot.py` so CI and the eval bot use the same rule
- `workflow_dispatch` sweeps existing open unchecked PRs

## Test plan
- [x] `python3 eval/test_pr_eval_bot.py -k rtx5090`
- [ ] After merge: open a test PR without ticking the box → should auto-close with instructions