### PR TITLE
ci: close PRs with unticked RTX 5090 template checkbox

### DIFF
--- a/.github/workflows/rtx5090-required.yml
+++ b/.github/workflows/rtx5090-required.yml
@@ -1,18 +1,18 @@
 name: rtx5090-required
 
-# Close PRs that do not tick the template's "Tested on RTX 5090" checkbox.
-# Evaluation is opt-in — unchecked PRs are not kept in the open review queue.
+# Close PRs that leave the template "Tested on RTX 5090" checkbox unticked (`- [ ]`).
+# PRs that remove the proof section entirely (e.g. docs-only) are not auto-closed.
 #
 # Contributor flow after auto-close:
-#   1. Edit the PR description on the closed PR: tick the box + fill benchmark tables.
+#   1. Edit the PR description: tick `- [x] Tested on RTX 5090` + fill benchmark tables.
 #   2. Reopen the PR.
 #
 # Safe by design: pull_request_target never checks out or runs PR code — GitHub API only.
-# Draft PRs, bots, maintainers, and PRs labeled `hold` are exempt.
+# Draft PRs, bots, maintainers, and PRs labeled `hold` are exempt while draft/exempt.
 
 on:
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -27,7 +27,7 @@ jobs:
   gate:
     runs-on: ubuntu-latest
     steps:
-      - name: Close PRs without RTX 5090 attestation
+      - name: Close PRs with unticked RTX 5090 checkbox
         uses: actions/github-script@v7
         with:
           script: |
@@ -35,11 +35,23 @@ jobs:
             const EXEMPT_LOGIN = new Set(['ai-hpc']);
             const SKIP_LABELS = new Set(['hold']);
 
+            function rtx5090HasCheckbox(body) {
+              if (!body) return false;
+              return body.split('\n').some(ln => {
+                if (!ln.includes('5090')) return false;
+                return /-\s*\[\s*[xX]\s*\]/.test(ln) || /-\s*\[\s*\]/.test(ln);
+              });
+            }
+
             function rtx5090Checked(body) {
               if (!body) return false;
               return body.split('\n').some(ln =>
-                /\[\s*[xX]\s*\]/.test(ln) && ln.includes('5090')
+                ln.includes('5090') && /-\s*\[\s*[xX]\s*\]/.test(ln)
               );
+            }
+
+            function rtx5090ShouldClose(body) {
+              return rtx5090HasCheckbox(body) && !rtx5090Checked(body);
             }
 
             function exempt(pr) {
@@ -58,8 +70,8 @@ jobs:
                 core.info(`#${pr.number}: exempt — skip rtx5090 gate`);
                 return false;
               }
-              if (rtx5090Checked(pr.body)) {
-                core.info(`#${pr.number}: RTX 5090 box checked — ok`);
+              if (!rtx5090ShouldClose(pr.body)) {
+                core.info(`#${pr.number}: no unticked RTX 5090 checkbox — ok`);
                 return false;
               }
 
@@ -68,23 +80,25 @@ jobs:
                 owner, repo, issue_number: pr.number,
                 body:
                   '<!-- sparkinfer-rtx5090-required -->\n' +
-                  '## Closed — RTX 5090 attestation required\n\n' +
-                  'This PR was auto-closed because the **Tested on RTX 5090** checkbox in the ' +
-                  'PR template is not ticked.\n\n' +
-                  'Evaluation is opt-in and proof-gated. To submit for review:\n\n' +
-                  '1. **Edit this PR description** (you can edit while closed): tick ' +
-                  '`- [x] Tested on RTX 5090` — only if you actually ran on a 5090\n' +
+                  '## Closed — RTX 5090 checkbox not ticked\n\n' +
+                  'This PR was auto-closed because the template includes **Tested on RTX 5090** ' +
+                  'as `- [ ]` (unchecked). Evaluation is opt-in — tick the box only after a real ' +
+                  '5090 run.\n\n' +
+                  'To submit for review:\n\n' +
+                  '1. **Edit this PR description** (you can edit while closed): change to ' +
+                  '`- [x] Tested on RTX 5090`\n' +
                   '2. Fill the decode and/or prefill **before → after** tables with real ' +
                   '`bench/scripts/bench.sh` numbers showing improvement\n' +
                   '3. **Reopen** this PR\n\n' +
-                  'Unchecked PRs stay out of the RTX 5090 eval queue. See ' +
-                  `[CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md).\n\n` +
+                  'If this PR does not need GPU eval (e.g. docs-only), remove the proof-of-speedup ' +
+                  'section from the description instead of leaving an unchecked box.\n\n' +
+                  `[CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md)\n\n` +
                   '<sub>Automated by rtx5090-required CI. Maintainers and `hold` PRs are exempt.</sub>',
               });
               await github.rest.pulls.update({
                 owner, repo, pull_number: pr.number, state: 'closed',
               });
-              core.notice(`closed #${pr.number}: RTX 5090 box not checked`);
+              core.notice(`closed #${pr.number}: RTX 5090 checkbox unticked`);
               return true;
             }
 
@@ -100,11 +114,19 @@ jobs:
                 const full = await github.rest.pulls.get({
                   owner, repo, pull_number: pr.number,
                 });
+                const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+                  owner, repo, issue_number: pr.number, per_page: 100,
+                });
+                full.data.labels = labels;
                 if (await maybeClose(full.data)) closed++;
               }
             } else {
               const num = context.payload.pull_request.number;
               const full = await github.rest.pulls.get({ owner, repo, pull_number: num });
+              const labels = await github.paginate(github.rest.issues.listLabelsOnIssue, {
+                owner, repo, issue_number: num, per_page: 100,
+              });
+              full.data.labels = labels;
               if (await maybeClose(full.data)) closed = 1;
             }
 

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -448,9 +448,28 @@ def _claimed_gain(before, after):
     """True when both numbers are present and after > before."""
     return before is not None and after is not None and after > before
 
+def _rtx5090_line(ln):
+    return "5090" in ln
+
+def rtx5090_has_checkbox(body):
+    """True when the PR body still has the template RTX 5090 markdown checkbox line."""
+    for ln in (body or "").splitlines():
+        if not _rtx5090_line(ln):
+            continue
+        if re.search(r"-\s*\[\s*[xX]\s*\]", ln) or re.search(r"-\s*\[\s*\]", ln):
+            return True
+    return False
+
 def rtx5090_box_checked(body):
     """True when the PR template's 'Tested on RTX 5090' checkbox is ticked."""
-    return any(re.search(r"\[\s*[xX]\s*\]", ln) and "5090" in ln for ln in (body or "").splitlines())
+    return any(
+        _rtx5090_line(ln) and re.search(r"-\s*\[\s*[xX]\s*\]", ln)
+        for ln in (body or "").splitlines()
+    )
+
+def rtx5090_should_close(body):
+    """True when the 5090 checkbox is present in the PR body but not ticked."""
+    return rtx5090_has_checkbox(body) and not rtx5090_box_checked(body)
 
 def greenlight_status(repo, num, pr_labels):
     """Decide whether a PR may be evaluated. Returns (status, reason):

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -85,6 +85,16 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertFalse(bot.rtx5090_box_checked("- [x] Tested on RTX 4090"))
         self.assertFalse(bot.rtx5090_box_checked(""))
 
+    def test_rtx5090_has_checkbox_and_should_close(self):
+        ticked = self._TEMPLATE_DECODE.format(db=300, da=320)
+        unchecked = ticked.replace("[x]", "[ ]")
+        self.assertTrue(bot.rtx5090_has_checkbox(unchecked))
+        self.assertTrue(bot.rtx5090_has_checkbox(ticked))
+        self.assertFalse(bot.rtx5090_has_checkbox("docs-only change, no proof section"))
+        self.assertTrue(bot.rtx5090_should_close(unchecked))
+        self.assertFalse(bot.rtx5090_should_close(ticked))
+        self.assertFalse(bot.rtx5090_should_close("no template checkbox here"))
+
     def test_decode_val_ignores_prefill_rows(self):
         body = self._TEMPLATE_BOTH.format(db=301, da=310, pb=250, pa=260)
         self.assertEqual(bot._decode_val(body, "before"), 301.0)


### PR DESCRIPTION
## Summary
- Auto-close only when the PR body still has the template `- [ ] Tested on RTX 5090` line (unchecked)
- Docs-only PRs that remove the proof section are left open
- Add `ready_for_review` trigger so draft→ready PRs with an unticked box get closed
- Fetch issue labels on sweep for correct `hold` exemption

## Test plan
- [x] `python3 eval/test_pr_eval_bot.py -k rtx5090`
- [ ] Run workflow_dispatch sweep to close existing open PRs with `- [ ]` still in body