### PR TITLE
ci: close PRs with no activity for 2+ days

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,0 +1,49 @@
+name: close-stale-prs
+
+# Close open PRs with no GitHub activity for 2+ days (commits, comments, reviews, labels).
+# Skips PRs labeled `hold` or `merge-first`. Same policy as eval/pr_eval_bot.py close_stale_prs().
+
+on:
+  schedule:
+    - cron: "0 6 * * *"   # daily 06:00 UTC
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Inactive days before auto-close"
+        default: "2"
+        required: false
+
+permissions:
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: close-stale-prs
+  cancel-in-progress: false
+
+jobs:
+  close:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - name: Close stale open PRs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPARKINFER_STALE_PR_DAYS: ${{ github.event.inputs.days || '2' }}
+          REPO: gittensor-ai-lab/sparkinfer
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, sys
+          sys.path.insert(0, "eval")
+          import pr_eval_bot as bot
+
+          repo = os.environ.get("REPO", "gittensor-ai-lab/sparkinfer")
+          days = int(os.environ.get("SPARKINFER_STALE_PR_DAYS", "2"))
+          closed = bot.close_stale_prs(repo, days=days)
+          print(f">> close-stale-prs: closed {len(closed)} PR(s): {sorted(closed)}")
+          PY

--- a/.github/workflows/eval-policy.yml
+++ b/.github/workflows/eval-policy.yml
@@ -7,6 +7,7 @@ on:
       - "eval/**"
       - ".github/workflows/eval-policy.yml"
       - ".github/workflows/rtx5090-required.yml"
+      - ".github/workflows/close-stale-prs.yml"
   push:
     branches: [main]
     paths:
@@ -14,6 +15,7 @@ on:
       - "eval/**"
       - ".github/workflows/eval-policy.yml"
       - ".github/workflows/rtx5090-required.yml"
+      - ".github/workflows/close-stale-prs.yml"
 
 permissions:
   contents: read

--- a/eval/run_stale_pr_cron.sh
+++ b/eval/run_stale_pr_cron.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Close open PRs with no GitHub activity for 2+ days (same policy as close-stale-prs.yml).
+#
+# Schedule daily alongside the eval bot:
+#   0 6 * * * /path/to/sparkinfer/eval/run_stale_pr_cron.sh >> /tmp/sparkinfer_stale.log 2>&1
+set -euo pipefail
+export HOME="${HOME:-/home/speedy}"
+export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin:$PATH"
+export PYTHONUNBUFFERED=1
+
+exec 9>/tmp/sparkinfer_bot.lock
+flock -n 9 || { echo "[$(date -u +%FT%TZ)] bot lock held — skip stale PR sweep"; exit 0; }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR" || exit 1
+git pull -q origin main 2>/dev/null || true
+
+echo "[$(date -u +%FT%TZ)] close stale PRs (threshold=${SPARKINFER_STALE_PR_DAYS:-2}d)"
+python3 -c "
+import os, sys
+sys.path.insert(0, 'eval')
+import pr_eval_bot as bot
+repo = os.environ.get('REPO', 'gittensor-ai-lab/sparkinfer')
+days = int(os.environ.get('SPARKINFER_STALE_PR_DAYS', '2'))
+closed = bot.close_stale_prs(repo, days=days)
+print('closed:', sorted(closed))
+"


### PR DESCRIPTION
## Summary
- Add `close-stale-prs` workflow: daily cron (06:00 UTC) + manual dispatch
- Reuses existing `close_stale_prs()` from `pr_eval_bot.py` (same 2-day threshold, skips `hold` / `merge-first`)
- Add `eval/run_stale_pr_cron.sh` for optional server-side cron

## Test plan
- [x] Existing `test_close_stale_prs_*` unit tests
- [ ] Run workflow_dispatch after merge to sweep open PRs