### PR TITLE
policy: compare copycats against open PRs only

### DIFF
--- a/.github/COPYCATS.md
+++ b/.github/COPYCATS.md
@@ -12,8 +12,8 @@ Shared thresholds live in `eval/copycat_policy.py`.
 
 - PRs are compared **oldest-first** (ascending PR number), so the original is always seen before any copy.
 - Fingerprint = (changed files, normalized non-comment added lines).
-- Compared against **every earlier PR** by a **different author** that touches the same file(s)
-  (open + merged; eval bot also includes closed).
+- Compared against **every earlier open PR** by a **different author** that touches the same file(s)
+  (closed and merged PRs are **not** used as copycat references).
 - **Self-resubmissions** (same author iterating on their own earlier PR) are **not** copycats.
 
 ### Tiered policy

--- a/eval/copycat_guard.py
+++ b/eval/copycat_guard.py
@@ -21,6 +21,7 @@ from copycat_policy import (
     COPYCAT_BLOCK, COPYCAT_WARN, COPYCAT_CONTAINMENT, MAX_WARNINGS,
     MIN_ADDED_LINES, LITERAL_BLOCK, FUNC_BLOCK_WARN,
     STRUCTURAL_ENABLED, LLM_ENABLED, skip_copycat_scoring,
+    COPYCAT_REFERENCE_STATE,
 )
 
 REPO = os.environ.get("EVAL_REPO", "gittensor-ai-lab/sparkinfer")
@@ -455,6 +456,13 @@ def pr_author_login(repo, num):
     return (info.get("author") or {}).get("login", "")
 
 
+def list_reference_prs(repo, limit=300):
+    """PRs eligible as copycat originals — open non-draft only (not closed/merged)."""
+    raw = json.loads(gh(["pr", "list", "-R", repo, "--state", COPYCAT_REFERENCE_STATE,
+                         "--json", "number,author,isDraft", "--limit", str(limit)]).stdout or "[]")
+    return [p for p in raw if not p.get("isDraft")]
+
+
 # ---- main ----
 
 def main():
@@ -474,20 +482,15 @@ def main():
     if not added:
         print("  no added lines to scan — not a copycat"); return
 
-    open_prs = json.loads(gh(["pr", "list", "-R", REPO, "--state", "all",
-                               "--json", "number,author,isDraft,state", "--limit", "300"]).stdout or "[]")
+    open_prs = list_reference_prs(REPO)
     log = load_copycat_log()
     blocked_prs = {e["pr"] for e in log if e.get("blocked", True)}
     cleared_prs = {e["pr"] for e in log if e.get("blocked") is False}
     if pr_num in cleared_prs:
         print("  cleared in copycats.json — skip"); return
     pr_author = {p["number"]: p["author"]["login"] for p in open_prs}
-    earlier_nums = sorted(
-        p["number"] for p in open_prs
-        if p["number"] < pr_num and not p.get("isDraft")
-        and p.get("state") in ("OPEN", "MERGED")
-    )
-    print(f"  {len(earlier_nums)} earlier open/merged non-draft PRs to check")
+    earlier_nums = sorted(p["number"] for p in open_prs if p["number"] < pr_num)
+    print(f"  {len(earlier_nums)} earlier open non-draft PRs to check")
 
     original = None; orig_author = None; best_containment = 0.0
     pr_level_containment = 0.0

--- a/eval/copycat_policy.py
+++ b/eval/copycat_policy.py
@@ -23,6 +23,9 @@ LLM_ENABLED = False
 # Back-compat alias
 COPYCAT_CONTAINMENT = COPYCAT_BLOCK
 
+# Copycat reference pool: only still-open PRs (excludes closed and merged).
+COPYCAT_REFERENCE_STATE = "open"
+
 
 def skip_copycat_scoring(added_lines, containment):
     """Skip borderline scoring on tiny PRs unless near-literal copy."""

--- a/eval/copycat_sweep.py
+++ b/eval/copycat_sweep.py
@@ -17,9 +17,7 @@ REPO = os.environ.get("EVAL_REPO", "gittensor-ai-lab/sparkinfer")
 
 def sweep(apply=False):
     """Run full copycat detection across all open non-draft PRs."""
-    open_prs = json.loads(gh(["pr", "list", "-R", REPO, "--state", "open",
-                               "--json", "number,author,isDraft,title", "--limit", "100"]).stdout or "[]")
-    open_prs = [p for p in open_prs if not p["isDraft"]]
+    open_prs = list_reference_prs(REPO, limit=100)
     all_nums = sorted(p["number"] for p in open_prs)
     pr_author = {p["number"]: p["author"]["login"] for p in open_prs}
     pr_title  = {p["number"]: p["title"] for p in open_prs}

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -315,7 +315,7 @@ def block_account(login, reason):
 # Tiered policy (shared with eval/copycat_policy.py + copycat_guard.py):
 #   ≥85% containment → block + close; 75–84% → copycat-warn; 3 warns → block.
 from copycat_policy import COPYCAT_BLOCK, COPYCAT_WARN, MAX_WARNINGS, skip_copycat_scoring
-from copycat_guard import warn_copycat
+from copycat_guard import warn_copycat, list_reference_prs
 
 FLAG_FILE = os.path.join(ROOT, ".github", "FLAGGED.md")
 COPYCAT_LABEL = "copycat"
@@ -1699,12 +1699,11 @@ def main():
     if not prs:
         print("no open PRs"); return
 
-    # Fingerprint EVERY PR (open + closed + merged) so an open PR can be compared against any earlier
-    # one — copies often target already-merged originals. Built once, ascending by number.
-    all_prs = json.loads(gh(["pr", "list", "-R", args.repo, "--state", "all",
-                             "--json", "number,author", "-L", "300"]).stdout or "[]")
-    all_nums = sorted(p["number"] for p in all_prs)
-    pr_author = {p["number"]: (p.get("author") or {}).get("login", "?") for p in all_prs}
+    # Fingerprint open PRs only — copycat comparison is against still-open earlier PRs
+    # (closed/merged are excluded; see eval/copycat_policy.py COPYCAT_REFERENCE_STATE).
+    ref_prs = list_reference_prs(args.repo)
+    all_nums = sorted(p["number"] for p in ref_prs)
+    pr_author = {p["number"]: (p.get("author") or {}).get("login", "?") for p in ref_prs}
     fps = {n: pr_fingerprint(args.repo, n) for n in all_nums}
     copy_log = load_copycat_log()
     logged_blocked = {e["pr"] for e in copy_log if e.get("blocked", True)}
@@ -1756,7 +1755,7 @@ def main():
             print(f"PR #{num}: BLOCKED (denylisted: {', '.join(sorted(hits))}) — flag + close, no eval")
             if not args.dry_run: close_blocked_pr(args.repo, num, hits)
             continue
-        # Gate 2 — copycat: tiered containment vs earlier PRs (open/closed/merged).
+        # Gate 2 — copycat: tiered containment vs earlier open PRs (not closed/merged).
         pr_labels = {l["name"] for l in pr.get("labels", [])}
         if COPYCAT_CLEARED_LABEL in pr_labels or num in cleared_copycats:
             print(f"PR #{num}: copycat-cleared — skip copycat gate")

--- a/eval/test_copycat_guard.py
+++ b/eval/test_copycat_guard.py
@@ -1,0 +1,35 @@
+"""Unit tests for copycat reference PR selection."""
+
+import copycat_guard as cg
+
+
+def test_list_reference_prs_filters_drafts(monkeypatch):
+    payload = [
+        {"number": 10, "author": {"login": "alice"}, "isDraft": False},
+        {"number": 11, "author": {"login": "bob"}, "isDraft": True},
+        {"number": 12, "author": {"login": "carol"}, "isDraft": False},
+    ]
+
+    def fake_gh(args):
+        class R:
+            stdout = __import__("json").dumps(payload)
+        return R
+
+    monkeypatch.setattr(cg, "gh", fake_gh)
+    out = cg.list_reference_prs("owner/repo", limit=50)
+    assert [p["number"] for p in out] == [10, 12]
+
+
+def test_list_reference_prs_uses_open_state(monkeypatch):
+    seen = {}
+
+    def fake_gh(args):
+        seen["args"] = args
+        class R:
+            stdout = "[]"
+        return R
+
+    monkeypatch.setattr(cg, "gh", fake_gh)
+    cg.list_reference_prs("owner/repo")
+    assert "--state" in seen["args"]
+    assert seen["args"][seen["args"].index("--state") + 1] == "open"


### PR DESCRIPTION
## Summary
- Copycat guard, eval bot, and sweep now compare new PRs only against earlier **open** PRs.
- Closed and merged PRs are excluded from the reference pool to reduce false positives.

## Test plan
- [x] `python3 -c` smoke test for `list_reference_prs` draft filtering
- [ ] copycat-guard workflow on next opened PR