### PR TITLE
eval: multi-PR baseline reuse and close exhausted none/REJECT PRs

### DIFF
--- a/.github/workflows/close-stale-prs.yml
+++ b/.github/workflows/close-stale-prs.yml
@@ -1,7 +1,8 @@
 name: close-stale-prs
 
 # Close open PRs with no GitHub activity for 2+ days (commits, comments, reviews, labels).
-# Skips PRs labeled `hold` or `merge-first`. Same policy as eval/pr_eval_bot.py close_stale_prs().
+# Also close PRs with more than 2 completed eval:none / eval:REJECT verdicts.
+# Skips PRs labeled `hold` or `merge-first`. Same policy as eval/pr_eval_bot.py.
 
 on:
   schedule:
@@ -46,4 +47,22 @@ jobs:
           days = int(os.environ.get("SPARKINFER_STALE_PR_DAYS", "2"))
           closed = bot.close_stale_prs(repo, days=days)
           print(f">> close-stale-prs: closed {len(closed)} PR(s): {sorted(closed)}")
+          PY
+
+      - name: Close PRs exhausted by none/REJECT evals
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SPARKINFER_EXHAUSTED_EVAL_MAX: "2"
+          REPO: gittensor-ai-lab/sparkinfer
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import os, sys
+          sys.path.insert(0, "eval")
+          import pr_eval_bot as bot
+
+          repo = os.environ.get("REPO", "gittensor-ai-lab/sparkinfer")
+          limit = int(os.environ.get("SPARKINFER_EXHAUSTED_EVAL_MAX", "2"))
+          closed = bot.close_exhausted_eval_prs(repo, max_none_reject=limit)
+          print(f">> close-exhausted-evals: closed {len(closed)} PR(s): {sorted(closed)}")
           PY

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__/
 dist/
 .claude
 .env.eval
+eval/.baseline_cache.json

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -147,6 +147,53 @@ def _bidir_baseline_sane(q36, q35):
     """Reject dashboard stubs / failed sweeps (Qwen3.6 ~400+, Qwythos ~120+ on 5090)."""
     return q36.get("128", 0) >= 200 and q35.get("128", 0) >= 80
 
+BASELINE_CACHE_FILE = os.path.join(HERE, ".baseline_cache.json")
+
+
+def _baseline_box_id(instance=0):
+    if ssh_box_enabled():
+        h, p = ssh_box_endpoint()
+        return f"ssh:{h}:{p}"
+    return f"vast:{instance or current_instance(0)}"
+
+
+def _save_baseline_cache(box_id, q36, q35, bres):
+    try:
+        with open(BASELINE_CACHE_FILE, "w") as f:
+            json.dump({"box": box_id, "ts": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+                       "q36": q36, "q35": q35, "bres": bres}, f)
+    except OSError:
+        pass
+
+
+def _load_baseline_cache(box_id, max_age_hours=12):
+    try:
+        with open(BASELINE_CACHE_FILE) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+    if data.get("box") != box_id:
+        return None
+    try:
+        ts = datetime.datetime.fromisoformat(data["ts"].replace("Z", "+00:00"))
+        age_h = (datetime.datetime.now(datetime.timezone.utc) - ts).total_seconds() / 3600
+        if age_h > max_age_hours:
+            return None
+    except (TypeError, ValueError):
+        return None
+    return data
+
+
+def _parse_only_prs(only_pr, only_prs):
+    out = set()
+    if only_pr:
+        out.add(int(only_pr))
+    for part in (only_prs or "").split(","):
+        part = part.strip()
+        if part:
+            out.add(int(part))
+    return out
+
 # Subsystem buckets for the deterministic area:<name> label (from a PR's top-level changed
 # dirs — no AI). Categorization/display only: SN74 scoring is speedup-only (the eval:* tier),
 # NOT a per-subsystem budget.
@@ -169,6 +216,8 @@ REEVALUATE_LABEL   = "re-evaluate"    # winner merged → rebase onto new main; 
 HOLD_LABEL         = "hold"           # maintainer override: never auto-merge this PR
 STALE_PR_DAYS      = int(os.environ.get("SPARKINFER_STALE_PR_DAYS", "2"))
 STALE_CLOSE_SKIP_LABELS = {HOLD_LABEL, MERGE_FIRST_LABEL}  # protected from auto-close
+EXHAUSTED_EVAL_MAX = int(os.environ.get("SPARKINFER_EXHAUSTED_EVAL_MAX", "2"))
+FAIL_VERDICT_LABELS = frozenset({"none", "REJECT"})
 CONTEXT_LABELS     = {"128-context", "512-context", "4k-context", "16k-context", "32k-context",
                       "64k-context", "128k-context"}
 REGRESSION_LABELS  = {"regression-128", "regression-512", "regression-4k", "regression-16k",
@@ -286,6 +335,64 @@ def close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=False):
     if closed:
         print(f">> close_stale_prs: {'would close' if dry_run else 'closed'} {len(closed)} PR(s): "
               f"{sorted(closed)}")
+    return closed
+
+
+def _eval_verdict_from_comment(body):
+    """Return eval tier label from a completed auto-eval comment, or None."""
+    if _evaluated_commit_from_comment(body) is None:
+        return None
+    m = re.search(r"\|\s*\*\*label\*\*\s*\|\s*`eval:([^`]+)`", body)
+    return m.group(1) if m else None
+
+
+def none_reject_eval_count(repo, num):
+    """Count completed auto-eval comments whose verdict is none or REJECT."""
+    r = gh(["pr", "view", str(num), "-R", repo, "--json", "comments"])
+    n = 0
+    for c in json.loads(r.stdout or "{}").get("comments", []):
+        if _eval_verdict_from_comment(c.get("body", "")) in FAIL_VERDICT_LABELS:
+            n += 1
+    return n
+
+
+def close_exhausted_eval_prs(repo, max_none_reject=EXHAUSTED_EVAL_MAX, dry_run=False):
+    """Close open PRs with more than `max_none_reject` completed none/REJECT evals.
+
+    Default max is 2 — a third none or REJECT triggers auto-close. Skips `hold`, `merge-first`,
+    and draft PRs. Returns PR numbers closed (or would-close in dry-run).
+    """
+    if max_none_reject < 0:
+        return set()
+    prs = json.loads(gh(["pr", "list", "-R", repo, "--state", "open",
+                         "--json", "number,title,labels,isDraft"]).stdout or "[]")
+    closed = set()
+    for pr in prs:
+        num = pr["number"]
+        if pr.get("isDraft"):
+            continue
+        labels = {l["name"] for l in pr.get("labels", [])}
+        if labels & STALE_CLOSE_SKIP_LABELS:
+            continue
+        count = none_reject_eval_count(repo, num)
+        if count <= max_none_reject:
+            continue
+        print(f"PR #{num}: {count} none/REJECT eval(s) (limit >{max_none_reject})"
+              f"{' — would close' if dry_run else ' — closing'}")
+        if dry_run:
+            closed.add(num)
+            continue
+        body = ("<!-- sparkinfer-exhausted -->\n"
+                f"## Closed: {count} evaluations with no verified speedup or rejection\n\n"
+                f"This PR received **{count}** completed sparkinfer auto-evaluations labeled "
+                f"`eval:none` or `eval:REJECT` (limit: more than {max_none_reject}).\n\n"
+                "Open a fresh PR if you have a new optimization to try.")
+        gh(["pr", "comment", str(num), "-R", repo, "--body", body])
+        if gh(["pr", "close", str(num), "-R", repo]).returncode == 0:
+            closed.add(num)
+    if closed:
+        print(f">> close_exhausted_eval_prs: {'would close' if dry_run else 'closed'} "
+              f"{len(closed)} PR(s): {sorted(closed)}")
     return closed
 
 
@@ -1596,6 +1703,10 @@ def main():
                     help="disable Polaris TDX receipts (overrides POLARIS=1)")
     ap.add_argument("--only-pr", type=int, default=0,
                     help="evaluate only this PR number (must be open)")
+    ap.add_argument("--only-prs", default="",
+                    help="comma-separated PR numbers — one baseline, then eval each (e.g. 387,389)")
+    ap.add_argument("--skip-baseline", action="store_true",
+                    help="reuse cached same-box baseline from this run's first measure (≤12h, same box)")
     ap.add_argument("--reeval", action="store_true",
                     help="re-run eval even if this commit was already graded (use with --only-pr)")
     args = ap.parse_args()
@@ -1688,14 +1799,16 @@ def main():
     prs = json.loads(gh(["pr", "list", "-R", args.repo, "--state", "open",
                          "--json", "number,headRefName,headRefOid,title,isCrossRepository,labels,isDraft,mergeable,updatedAt"]).stdout or "[]")
     prs.sort(key=lambda p: p["number"])
-    if not args.only_pr:
+    only_set = _parse_only_prs(args.only_pr, args.only_prs)
+    targeted = bool(only_set)
+    if not targeted:
         stale_closed = close_stale_prs(args.repo, days=STALE_PR_DAYS, dry_run=args.dry_run)
         if stale_closed:
             prs = [p for p in prs if p["number"] not in stale_closed]
-    if args.only_pr:
-        prs = [p for p in prs if p["number"] == args.only_pr]
+    if only_set:
+        prs = [p for p in prs if p["number"] in only_set]
         if not prs:
-            print(f"PR #{args.only_pr} not open"); return
+            print(f"PR(s) {sorted(only_set)} not open"); return
     if not prs:
         print("no open PRs"); return
 
@@ -1834,7 +1947,10 @@ def main():
             for L in drop:
                 if L in pr_labels: remove_label(args.repo, num, L)
         status, reason = greenlight_status(args.repo, num, pr_labels)
-        if status == "ok":
+        if targeted:
+            print(f"PR #{num}: maintainer-targeted eval (greenlight: {status} — {reason})")
+            pending.append((pr, num, branch, oid, ref, areas))
+        elif status == "ok":
             print(f"PR #{num}: greenlit ({reason})")
             _reconcile(EVAL_GATE_LABEL, [NOT_TESTED_LABEL, NEEDS_BENCH_LABEL])
             pending.append((pr, num, branch, oid, ref, areas))
@@ -1866,49 +1982,59 @@ def main():
     if PINNED_INSTANCE and not ssh_box_enabled():
         with open(INSTANCE_FILE, "w") as f: f.write(PINNED_INSTANCE)
 
-    # --- Same-box baseline -------------------------------------------------------------------------
+    # --- Same-box baseline (once per bot run; reused for every PR in pending) ----------------------
     base_iid = current_instance(args.instance) if args.instance else 0
-    bcmd = [sys.executable, os.path.join(HERE, "vast_eval.py"),
-            *_vast_eval_transport_args(args.instance),
-            "--ref", "origin/main", "--frontier", "0", "--ceiling", str(args.ceiling),
-            "--eval-mode", "longctx", "--keep"]
-    if args.bidir:
-        bcmd += ["--bidir", "--primary-quant", args.primary_quant, "--baseline-only"]
-        # Do NOT pass guard baselines here — evaluate_bidir must measure fresh on-box.
-    if PINNED_INSTANCE and not ssh_box_enabled() and str(base_iid) == PINNED_INSTANCE:
-        bcmd.append("--pinned")
-    box_label = ssh_box_arg() if ssh_box_enabled() else f"instance {base_iid}"
-    print(f">> measuring same-box baseline (origin/main) on {box_label} ...")
-    br = subprocess.run(bcmd, cwd=ROOT, capture_output=True, text=True, timeout=14400)
-    if br.returncode == PINNED_RETRY_RC:
-        tail = next((l for l in reversed((br.stdout + br.stderr).splitlines()) if l.strip()), "")
-        print(f">> {tail}\n>> aborting this run — next scheduled run retries the pinned box."); return
-    for l in br.stdout.splitlines():
-        if l.startswith("NEW_INSTANCE_ID "):
-            try:
-                nid = int(l.split()[1])
-                with open(INSTANCE_FILE, "w") as f: f.write(str(nid))
-                if PINNED_INSTANCE: _write_pin(nid)
-                print(f"  (instance updated to {nid}{'; re-pinned' if PINNED_INSTANCE else ''})")
-            except Exception: pass
-    bline = next((l for l in br.stdout.splitlines() if l.startswith("RESULT_JSON")), None)
-    bres = json.loads(bline[len("RESULT_JSON "):]) if bline else {}
-    if not bres.get("label"):
-        log = (br.stdout + br.stderr)[-1200:]
-        print(f">> same-box baseline (origin/main) failed ({bres.get('label','no result')}) — "
-              f"aborting; no PRs graded.\n{log}"); return
-    if args.bidir and not (bres.get("pass") or bres.get("score_qwen35") or bres.get("score_qwen36")):
-        log = (br.stdout + br.stderr)[-1200:]
-        print(f">> bidir baseline (origin/main) failed — aborting; no PRs graded.\n{log}"); return
-    if args.bidir:
-        if not _apply_bidir_ctx_from_bres(bres, QWEN36_BASE, QWYTHOS_BASE) or not _bidir_baseline_sane(QWEN36_BASE, QWYTHOS_BASE):
+    box_id = _baseline_box_id(base_iid)
+    bres = {}
+    use_baseline_cache = args.skip_baseline or (args.reeval and targeted)
+    cache = _load_baseline_cache(box_id) if use_baseline_cache else None
+    if cache and _apply_bidir_ctx_from_bres(cache.get("bres", {}), QWEN36_BASE, QWYTHOS_BASE):
+        QWEN36_BASE.update(cache["q36"])
+        QWYTHOS_BASE.update(cache["q35"])
+        bres = cache["bres"]
+        print(f">> reusing cached same-box baseline from {cache['ts']} ({box_id})")
+    else:
+        if args.skip_baseline:
+            print(f">> --skip-baseline: no valid cache for {box_id} — measuring fresh baseline")
+        bcmd = [sys.executable, os.path.join(HERE, "vast_eval.py"),
+                *_vast_eval_transport_args(args.instance),
+                "--ref", "origin/main", "--frontier", "0", "--ceiling", str(args.ceiling),
+                "--eval-mode", "longctx", "--keep"]
+        if args.bidir:
+            bcmd += ["--bidir", "--primary-quant", args.primary_quant, "--baseline-only"]
+        if PINNED_INSTANCE and not ssh_box_enabled() and str(base_iid) == PINNED_INSTANCE:
+            bcmd.append("--pinned")
+        box_label = ssh_box_arg() if ssh_box_enabled() else f"instance {base_iid}"
+        print(f">> measuring same-box baseline (origin/main) on {box_label} ...")
+        br = subprocess.run(bcmd, cwd=ROOT, capture_output=True, text=True, timeout=14400)
+        if br.returncode == PINNED_RETRY_RC:
+            tail = next((l for l in reversed((br.stdout + br.stderr).splitlines()) if l.strip()), "")
+            print(f">> {tail}\n>> aborting this run — next scheduled run retries the pinned box."); return
+        for l in br.stdout.splitlines():
+            if l.startswith("NEW_INSTANCE_ID "):
+                try:
+                    nid = int(l.split()[1])
+                    with open(INSTANCE_FILE, "w") as f: f.write(str(nid))
+                    if PINNED_INSTANCE: _write_pin(nid)
+                    print(f"  (instance updated to {nid}{'; re-pinned' if PINNED_INSTANCE else ''})")
+                except Exception: pass
+        bline = next((l for l in br.stdout.splitlines() if l.startswith("RESULT_JSON")), None)
+        bres = json.loads(bline[len("RESULT_JSON "):]) if bline else {}
+        if not bres.get("label"):
             log = (br.stdout + br.stderr)[-1200:]
-            print(f">> bidir baseline measurement invalid (need live ctx sweep, not dashboard defaults) — "
+            print(f">> same-box baseline (origin/main) failed ({bres.get('label','no result')}) — "
                   f"aborting; no PRs graded.\n{log}"); return
-    if not args.bidir and (not bres.get("pass") or not bres.get("tps")):
-        log = (br.stdout + br.stderr)[-1200:]
-        print(f">> same-box baseline (origin/main) failed ({bres.get('label','no result')}) — "
-              f"aborting; no PRs graded.\n{log}"); return
+        if args.bidir and not (bres.get("pass") or bres.get("score_qwen35") or bres.get("score_qwen36")):
+            log = (br.stdout + br.stderr)[-1200:]
+            print(f">> bidir baseline (origin/main) failed — aborting; no PRs graded.\n{log}"); return
+        if args.bidir:
+            if not _apply_bidir_ctx_from_bres(bres, QWEN36_BASE, QWYTHOS_BASE) or not _bidir_baseline_sane(QWEN36_BASE, QWYTHOS_BASE):
+                log = (br.stdout + br.stderr)[-1200:]
+                print(f">> bidir baseline measurement invalid — aborting; no PRs graded.\n{log}"); return
+        if not args.bidir and (not bres.get("pass") or not bres.get("tps")):
+            log = (br.stdout + br.stderr)[-1200:]
+            print(f">> same-box baseline (origin/main) failed — aborting; no PRs graded.\n{log}"); return
+        _save_baseline_cache(box_id, dict(QWEN36_BASE), dict(QWYTHOS_BASE), bres)
     if args.bidir:
         run_baseline = float(QWEN36_BASE["128"])
         run_guard_128 = float(QWEN36_BASE["128"])

--- a/eval/run_bot.sh
+++ b/eval/run_bot.sh
@@ -11,10 +11,13 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_DIR"
 
 # Harness + eval code must match origin/main (vast_eval syncs bench/scripts from there).
-git fetch -q origin main 2>/dev/null || true
-if git rev-parse --verify origin/main >/dev/null 2>&1; then
-  git checkout -q main 2>/dev/null || true
-  git reset --hard origin/main
+# Set EVAL_SKIP_GIT_SYNC=1 to run local eval/ changes without resetting to origin/main.
+if [ "${EVAL_SKIP_GIT_SYNC:-0}" != "1" ]; then
+  git fetch -q origin main 2>/dev/null || true
+  if git rev-parse --verify origin/main >/dev/null 2>&1; then
+    git checkout -q main 2>/dev/null || true
+    git reset --hard origin/main
+  fi
 fi
 
 if [ -f "$REPO_DIR/.env.eval" ]; then

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -603,5 +603,82 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual(done, {"abc1234"})
 
 
+class OnlyPrsAndBaselineCacheTest(unittest.TestCase):
+    def test_parse_only_prs(self):
+        self.assertEqual(bot._parse_only_prs(387, ""), {387})
+        self.assertEqual(bot._parse_only_prs(0, "387, 389"), {387, 389})
+        self.assertEqual(bot._parse_only_prs(387, "389"), {387, 389})
+
+    def test_baseline_cache_roundtrip(self):
+        with tempfile.TemporaryDirectory() as td:
+            cache_path = os.path.join(td, ".baseline_cache.json")
+            with mock.patch.object(bot, "BASELINE_CACHE_FILE", cache_path):
+                q36 = {"128": 200.0, "512": 195.0}
+                q35 = {"128": 150.0, "4k": 140.0}
+                bres = {"pass": True, "score_qwen36": 200.0}
+                bot._save_baseline_cache("ssh:host:22", q36, q35, bres)
+                loaded = bot._load_baseline_cache("ssh:host:22")
+                self.assertIsNotNone(loaded)
+                self.assertEqual(loaded["q36"], q36)
+                self.assertEqual(loaded["q35"], q35)
+                self.assertEqual(loaded["bres"], bres)
+                self.assertIsNone(bot._load_baseline_cache("ssh:other:22"))
+
+
+class ExhaustedEvalCloseTest(unittest.TestCase):
+    def test_eval_verdict_from_comment(self):
+        none_body = bot.render({"label": "none", "pass": True, "tps": 300.0, "top1": 0.97, "kl": 0.02,
+                                "frontier_tps": 298.0}, "abc1234")
+        self.assertEqual(bot._eval_verdict_from_comment(none_body), "none")
+        reject_body = bot.render({"label": "REJECT", "pass": False, "reason": "regression",
+                                  "tps": 280.0, "top1": 0.97, "kl": 0.02, "frontier_tps": 300.0},
+                                 "def5678")
+        self.assertEqual(bot._eval_verdict_from_comment(reject_body), "REJECT")
+        pass_body = bot.render({"label": "S", "pass": True, "tps": 320.0, "top1": 0.97, "kl": 0.02,
+                                "frontier_tps": 300.0, "pct_over_frontier": 6.7, "delta_tps": 20.0},
+                               "fed9012")
+        self.assertEqual(bot._eval_verdict_from_comment(pass_body), "S")
+        self.assertIsNone(bot._eval_verdict_from_comment("<!-- sparkinfer-eval:abc -->\nno verdict"))
+
+    def test_none_reject_eval_count(self):
+        comments = [
+            {"body": bot.render({"label": "none", "pass": True, "tps": 300.0, "top1": 0.97, "kl": 0.02,
+                                 "frontier_tps": 298.0}, "aaa1111")},
+            {"body": bot.render({"label": "REJECT", "pass": False, "reason": "x", "tps": 0,
+                                 "top1": 0, "kl": 0, "frontier_tps": 300.0}, "bbb2222")},
+            {"body": bot.render({"label": "M", "pass": True, "tps": 330.0, "top1": 0.97, "kl": 0.02,
+                                 "frontier_tps": 300.0, "pct_over_frontier": 10.0, "delta_tps": 30.0},
+                                "ccc3333")},
+        ]
+        gh_mock = mock.Mock(return_value=mock.Mock(stdout=json.dumps({"comments": comments})))
+        with mock.patch.object(bot, "gh", gh_mock):
+            self.assertEqual(bot.none_reject_eval_count("gittensor-ai-lab/sparkinfer", 42), 2)
+
+    def test_close_exhausted_eval_prs(self):
+        prs = [
+            {"number": 10, "title": "ok", "labels": [], "isDraft": False},
+            {"number": 11, "title": "exhausted", "labels": [], "isDraft": False},
+            {"number": 12, "title": "hold", "labels": [{"name": "hold"}], "isDraft": False},
+        ]
+        list_mock = mock.Mock(return_value=mock.Mock(stdout=json.dumps(prs)))
+        close_mock = mock.Mock(return_value=mock.Mock(returncode=0))
+        comment_mock = mock.Mock(return_value=mock.Mock(returncode=0))
+
+        def gh_side_effect(args, *a, **kw):
+            if len(args) >= 2 and args[0] == "pr" and args[1] == "list":
+                return list_mock(*a, **kw)
+            if len(args) >= 2 and args[0] == "pr" and args[1] == "close":
+                return close_mock(*a, **kw)
+            if len(args) >= 2 and args[0] == "pr" and args[1] == "comment":
+                return comment_mock(*a, **kw)
+            return mock.Mock(stdout=json.dumps({"comments": []}))
+
+        with mock.patch.object(bot, "gh", side_effect=gh_side_effect), \
+             mock.patch.object(bot, "none_reject_eval_count", side_effect=lambda _r, n: {10: 2, 11: 3, 12: 5}[n]):
+            closed = bot.close_exhausted_eval_prs("gittensor-ai-lab/sparkinfer", max_none_reject=2)
+        self.assertEqual(closed, {11})
+        close_mock.assert_called_once()
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary
- Add `--only-prs` for maintainer-targeted runs that measure same-box baseline once, then grade each listed PR
- Cache same-box baselines (12h TTL per box) and reuse on `--reeval` / `--skip-baseline`
- Add `EVAL_SKIP_GIT_SYNC=1` so `run_bot.sh` can run local eval-bot changes without resetting to `origin/main`
- Auto-close open PRs with more than two completed `eval:none` or `eval:REJECT` verdicts (daily in `close-stale-prs` workflow)
- Draft PRs remain skipped (no `--include-draft`)

## Test plan
- [x] `python3 eval/test_pr_eval_bot.py ExhaustedEvalCloseTest OnlyPrsAndBaselineCacheTest`
- [ ] CI `eval-policy` workflow passes on this PR
- [ ] `workflow_dispatch` on `close-stale-prs` dry-run in staging (optional)