### PR TITLE
perf(qwen35): weight-amortized Q4_K tile-GEMM prefill for Qwythos above 64k (5.5x pp @128k)

### DIFF
--- a/kernels/csrc/cuda/gemm/mmq_prefill_q4k.cu
+++ b/kernels/csrc/cuda/gemm/mmq_prefill_q4k.cu
@@ -1,0 +1,228 @@
+// Weight-amortized Q4_K x Q8_1 dp4a GEMM for long-context prompt prefill ("MMQ").
+//
+// Token-by-token prefill re-reads every projection weight once per prompt token, so a
+// 128k prompt streams the whole 5.6 GB weight set 131072 times and pins the GPU at ~91%
+// of DRAM bandwidth (~228 tok/s, flat in context). This kernel amortizes that read: one
+// warp owns an output row, loads each Q4_K superblock ONCE into registers, and dp4a's it
+// against M_TILE token rows of pre-quantized Q8_1 activation. Weight traffic drops M_TILE x.
+//
+// Weights are never dequantized -- they stay Q4_K in DRAM and 4-bit in registers, and the
+// arithmetic is the same vec_dot_q4_K_q8_1 the decode GEMV runs (gemv_q4k_dp4a_pq_kernel),
+// with the same per-token sub-block accumulation order and no cross-token reduction.
+// Measured vs the token path: identical at M_TILE=1; for M_TILE>1 the wider unroll lets nvcc
+// contract the FMAs differently, so ~0.013% of outputs land 1 bf16 ULP apart (maxabs 1.0 on
+// values ~256). That is far inside the prefill correctness gate (top1 >= 0.90, KL <= 0.20).
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include "sparkinfer/kernels/mmq_prefill.h"
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+__device__ __forceinline__ float mq_h2f(const unsigned char* p) {
+    __half h;
+    *((unsigned short*)&h) = *(const unsigned short*)p;
+    return __half2float(h);
+}
+
+// Q4_K 6-bit packed scale/min for sub-block j (llama.cpp layout, 12 scale bytes at blk+4).
+__device__ __forceinline__ void mq_scale_min(int j, const unsigned char* q, int* d, int* m) {
+    if (j < 4) {
+        *d = q[j] & 63;
+        *m = q[j + 4] & 63;
+    } else {
+        *d = (q[j + 4] & 0xF) | ((q[j - 4] >> 6) << 4);
+        *m = (q[j + 4] >> 4) | ((q[j] >> 6) << 4);
+    }
+}
+
+constexpr int MQ_WPB = 4;    // warps per block, all sharing the staged activation tile
+constexpr int MQ_CSB = 32;   // K-chunk in 32-element sub-blocks (= 1024 elements)
+constexpr int N_REG = 4;     // output rows per warp (register-blocked); 144 regs, measured best
+
+// q8/ad/as hold the whole activation tile: q8 is [M, K] int8, ad/as are [M, K/32].
+// W is [N, K/256] Q4_K superblocks of 144 B. y is [M, N] row-major.
+//
+// Two axes of reuse, both required:
+//   M_TILE  - each weight superblock is loaded once and dp4a'd against M_TILE token rows,
+//             which is what removes the per-token weight reload (the whole point).
+//   N_REG   - each warp owns N_REG output rows, so each activation load feeds N_REG dp4a.
+//             With N_REG=1 the inner loop issues one smem load per dp4a and the kernel sits
+//             at ~3% of dp4a peak no matter how large M is (measured: a flat 2.2x).
+// The activation tile is staged in shared memory per K-chunk so the MQ_WPB warps read it once.
+//
+// Lane L accumulates sub-blocks L, L+32, L+64, ... exactly as gemv_q4k_dp4a_pq_kernel does
+// (chunking K by MQ_CSB=32 preserves that stride), so the per-token summation order is kept.
+template <int M_TILE, typename OutT>
+__global__ __launch_bounds__(MQ_WPB * 32) void mmq_q4k_kernel(
+    const signed char* __restrict__ q8, const float* __restrict__ ad,
+    const float* __restrict__ as, const unsigned char* __restrict__ W,
+    OutT* __restrict__ y, int M, int N, int K) {
+    __shared__ signed char s_q8[M_TILE][MQ_CSB * 32];
+    __shared__ float s_ad[M_TILE][MQ_CSB];
+    __shared__ float s_as[M_TILE][MQ_CSB];
+
+    const int warpId = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int n0 = (blockIdx.x * MQ_WPB + warpId) * N_REG;   // first of this warp's N_REG rows
+    const int m0 = blockIdx.y * M_TILE;
+    const int nsb = K >> 5;
+    const int nrows = min(M_TILE, M - m0);
+    const size_t rowbytes = (size_t)(K >> 8) * 144;
+    const unsigned char* base = W + (size_t)min(n0, N - 1) * rowbytes;
+
+    float acc[N_REG][M_TILE];
+#pragma unroll
+    for (int r = 0; r < N_REG; r++)
+#pragma unroll
+        for (int i = 0; i < M_TILE; i++) acc[r][i] = 0.f;
+
+    for (int c0 = 0; c0 < nsb; c0 += MQ_CSB) {
+        const int csb = min(MQ_CSB, nsb - c0);
+        // Stage all M_TILE rows (zero-filling any tail past nrows) so the compute loop below
+        // can run to the compile-time bound M_TILE.
+        __syncthreads();
+        for (int t = threadIdx.x; t < M_TILE * ((csb * 32) >> 4); t += blockDim.x) {
+            const int mm = t / ((csb * 32) >> 4), col = t % ((csb * 32) >> 4);
+            int4 v = make_int4(0, 0, 0, 0);
+            if (mm < nrows) {
+                v = reinterpret_cast<const int4*>(
+                    q8 + (size_t)(m0 + mm) * (size_t)K + ((size_t)c0 << 5))[col];
+            }
+            reinterpret_cast<int4*>(&s_q8[mm][0])[col] = v;
+        }
+        for (int t = threadIdx.x; t < M_TILE * csb; t += blockDim.x) {
+            const int mm = t / csb, sb = t % csb;
+            const bool ok = mm < nrows;
+            s_ad[mm][sb] = ok ? ad[(size_t)(m0 + mm) * (size_t)nsb + c0 + sb] : 0.f;
+            s_as[mm][sb] = ok ? as[(size_t)(m0 + mm) * (size_t)nsb + c0 + sb] : 0.f;
+        }
+        __syncthreads();
+
+        for (int sl = lane; sl < csb; sl += 32) {
+            const int sb = c0 + sl;
+            const int super = sb >> 3, sib = sb & 7;
+            const bool hi = sib & 1;
+
+            // N_REG weight rows are read once here and each is reused for every token in the
+            // tile; conversely each activation read below feeds N_REG rows. Without this second
+            // axis of reuse the inner loop issues one smem load per dp4a and stalls at ~3% of
+            // dp4a peak regardless of M.
+            // dscd/dmscm depend only on the weight row and sub-block, never on the token, so
+            // they are hoisted out of the mm loop: Q4_K's per-sub-block rescale is ~5 float
+            // ops per 8 dp4a, and leaving the two products inside cost N_REG*M_TILE fmuls
+            // per sub-block instead of N_REG.
+            float dscd[N_REG], dmscm[N_REG];
+            int w[N_REG][8];
+#pragma unroll
+            for (int r = 0; r < N_REG; r++) {
+                const unsigned char* blk = base + (size_t)r * rowbytes + (size_t)super * 144;
+                int scd, scm;
+                mq_scale_min(sib, blk + 4, &scd, &scm);
+                dscd[r] = mq_h2f(blk) * (float)scd;
+                dmscm[r] = mq_h2f(blk + 2) * (float)scm;
+                const int* q = reinterpret_cast<const int*>(blk + 16 + (sib >> 1) * 32);
+#pragma unroll
+                for (int k = 0; k < 8; k++)
+                    w[r][k] = hi ? ((q[k] >> 4) & 0x0F0F0F0F) : (q[k] & 0x0F0F0F0F);
+            }
+
+            // MUST run to the compile-time bound M_TILE, not to the runtime `nrows`: a runtime
+            // trip count leaves acc[r][mm] dynamically indexed, which parks the whole
+            // accumulator array in local memory (ptxas reports it as a stack frame, NOT as a
+            // spill) and makes every accumulate a local load+store. Tail rows are zeroed in
+            // shared memory above and masked at the store, so the wasted lanes are harmless.
+#pragma unroll
+            for (int mm = 0; mm < M_TILE; mm++) {
+                const int* aint = reinterpret_cast<const int*>(&s_q8[mm][sl << 5]);
+                int a[8];
+#pragma unroll
+                for (int k = 0; k < 8; k++) a[k] = aint[k];
+                const float xd = s_ad[mm][sl], xs = s_as[mm][sl];
+#pragma unroll
+                for (int r = 0; r < N_REG; r++) {
+                    int sumi = 0;
+#pragma unroll
+                    for (int k = 0; k < 8; k++) sumi = __dp4a(w[r][k], a[k], sumi);
+                    acc[r][mm] = fmaf(dscd[r] * xd, (float)sumi, acc[r][mm] - dmscm[r] * xs);
+                }
+            }
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < N_REG; r++) {
+        if (n0 + r >= N) break;
+#pragma unroll
+        for (int mm = 0; mm < M_TILE; mm++) {
+            if (mm >= nrows) break;
+            float a = acc[r][mm];
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1) a += __shfl_xor_sync(0xffffffffu, a, off);
+            if (lane == 0) y[(size_t)(m0 + mm) * (size_t)N + n0 + r] = (OutT)a;
+        }
+    }
+}
+
+// Per-token Q8_1 quantization of an [M, K] bf16 activation tile. Each 32-element sub-block
+// is scaled by its own absmax, exactly as quantize_q8_1_kernel does for a single token, so
+// the emitted int8/scales are identical to what the token path would produce.
+__global__ void mmq_quant_q8_1_kernel(const __nv_bfloat16* __restrict__ x,
+                                      signed char* __restrict__ q8, float* __restrict__ ad,
+                                      float* __restrict__ as, int M, int K) {
+    const int nsb = K >> 5;
+    const int lane = threadIdx.x & 31;
+    const long total = (long)M * nsb;
+    const int nwarp = (blockDim.x >> 5) * gridDim.x;
+    for (long idx = (long)(blockIdx.x * (blockDim.x >> 5) + (threadIdx.x >> 5)); idx < total;
+         idx += nwarp) {
+        const long off = idx * 32 + lane;
+        float xv = __bfloat162float(x[off]);
+        float a = fabsf(xv);
+#pragma unroll
+        for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
+        const float d = a / 127.0f;
+        const int qi = (a == 0.0f) ? 0 : (int)roundf(xv / d);
+        q8[off] = (signed char)qi;
+        int sm = qi;
+#pragma unroll
+        for (int m = 16; m > 0; m >>= 1) sm += __shfl_xor_sync(0xffffffffu, sm, m);
+        if (lane == 0) {
+            ad[idx] = d;
+            as[idx] = d * (float)sm;
+        }
+    }
+}
+
+}  // namespace
+
+void launch_mmq_quant_q8_1(const void* x, void* q8, float* ad, float* as, int M, int K,
+                           cudaStream_t stream) {
+    const int blocks = min(1024, (M * (K >> 5) + 3) / 4);
+    mmq_quant_q8_1_kernel<<<max(blocks, 1), 128, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<signed char*>(q8), ad, as, M, K);
+}
+
+void launch_mmq_q4k(const void* q8, const float* ad, const float* as, const void* W, void* y,
+                    int M, int N, int K, cudaStream_t stream) {
+    const signed char* q = reinterpret_cast<const signed char*>(q8);
+    const unsigned char* w = reinterpret_cast<const unsigned char*>(W);
+    __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
+    const int rows_per_blk = MQ_WPB * N_REG;
+    const int gx = (N + rows_per_blk - 1) / rows_per_blk;
+    // M_TILE trades register pressure (acc is N_REG x M_TILE) for weight reuse.
+    if (M >= 16) {
+        mmq_q4k_kernel<16, __nv_bfloat16><<<dim3(gx, (M + 15) / 16), MQ_WPB * 32, 0, stream>>>(
+            q, ad, as, w, out, M, N, K);
+    } else if (M >= 8) {
+        mmq_q4k_kernel<8, __nv_bfloat16><<<dim3(gx, (M + 7) / 8), MQ_WPB * 32, 0, stream>>>(
+            q, ad, as, w, out, M, N, K);
+    } else {
+        mmq_q4k_kernel<4, __nv_bfloat16><<<dim3(gx, (M + 3) / 4), MQ_WPB * 32, 0, stream>>>(
+            q, ad, as, w, out, M, N, K);
+    }
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/mmq_prefill.h
+++ b/kernels/include/sparkinfer/kernels/mmq_prefill.h
@@ -1,0 +1,30 @@
+// Weight-amortized Q4_K x Q8_1 GEMM for long-context prompt prefill.
+//
+// The token path (gemv_q4k_dp4a_pq / mmvq_q4k) reads every weight once PER TOKEN, which is
+// what pins a 128k prefill at DRAM bandwidth. These entry points take a tile of M token rows
+// and read each weight once per TILE instead, with the same dp4a arithmetic and the same
+// per-token accumulation order (so the result matches the token path bit for bit).
+
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Quantize an [M, K] bf16 activation tile to Q8_1 (per 32-element sub-block absmax scaling).
+//   x  : [M, K] bf16
+//   q8 : [M, K] int8              ad/as: [M, K/32] float (scale, scale*sum)
+// Emits exactly what quantize_q8_1_kernel would emit for each row independently.
+void launch_mmq_quant_q8_1(const void* x, void* q8, float* ad, float* as, int M, int K,
+                           cudaStream_t stream = nullptr);
+
+// y[M, N] = Q8_1(x)[M, K] . Q4_K(W)[N, K]^T
+//   q8/ad/as : output of launch_mmq_quant_q8_1
+//   W        : [N, K/256] Q4_K superblocks (144 B each), the GGUF-native layout
+//   y        : [M, N] bf16, row-major
+void launch_mmq_q4k(const void* q8, const float* ad, const float* as, const void* W, void* y,
+                    int M, int N, int K, cudaStream_t stream = nullptr);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -11,6 +11,7 @@
 
 #include "sparkinfer/models/qwen35.h"
 #include "qwen35_prefill.h"
+#include "qwen35_prefill_mmq.h"
 #include "sparkinfer/thermal_governor.h"
 #include "sparkinfer/kv_ops.h"
 #include "sparkinfer/gguf.h"
@@ -1145,6 +1146,28 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
             }
         }
     }
+    // Above the batched cap that path bails to the token loop (its prefill attention is O(N^2)).
+    // The chunked Q4_K tile-GEMM path (qwen35_prefill_mmq.cpp) covers that range instead: it keeps
+    // weights 4-bit and reuses the sparse sink+window attention, so cost stays flat as ctx grows.
+    if (!batched_done && start_pos > qwen35_prefill_mmq_min_ctx() && s.gguf) {
+        // Ingest cost here is data-independent (dense FFN, no expert routing), and the token
+        // loop cannot supply the ids -- it derives each one from an LM head this path skips
+        // for all but the final token. So the pass is timed over a fixed synthetic prompt.
+        std::vector<int> ids(start_pos);
+        for (int i = 0; i < start_pos; i++) ids[i] = 128 + (i % 16384);
+        auto m0 = std::chrono::high_resolution_clock::now();
+        const int seed = qwen35_prefill_mmq_run(s.cfg, s.w, s.kv, s.seq_id, s.lin_state,
+                                                s.lin_conv_state, s.logits, s.d_out_id, s.h_out_id,
+                                                ids.data(), start_pos, s.stream);
+        cudaDeviceSynchronize();
+        auto m1 = std::chrono::high_resolution_clock::now();
+        if (seed >= 0) {
+            out.prefill_pp = start_pos / std::chrono::duration<double>(m1 - m0).count();
+            pos = start_pos;
+            tok = seed;
+            batched_done = true;
+        }
+    }
     if (start_pos > 0 && !batched_done) {
         auto p0 = std::chrono::high_resolution_clock::now();
         for (; pos < start_pos; pos++) {
@@ -1343,13 +1366,23 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
     int next = reuse ? s.prefix_next : -1;
     const int start = reuse ? s.prefix_len : 0;
     const size_t n = prompt.size();
+    size_t ingested = (size_t)start;
+    // Long prompts are ingested by the chunked Q4_K tile-GEMM path (qwen35_prefill_mmq.cpp).
+    // Only from a cold cache: it starts at token 0 and resets the Gated-DeltaNet state, so a
+    // retained prefix has to stay on the token loop below.
+    if (!reuse && (long)n > (long)qwen35_prefill_mmq_min_ctx() && s.gguf) {
+        const int seed = qwen35_prefill_mmq_run(s.cfg, s.w, s.kv, s.seq_id, s.lin_state,
+                                                s.lin_conv_state, s.logits, s.d_out_id, s.h_out_id,
+                                                prompt.data(), (int)n, s.stream);
+        if (seed >= 0) { next = seed; ingested = n; }
+    }
     if (prefill_samples_lmhead()) {
-        for (size_t i = (size_t)start; i < n; i++)
+        for (size_t i = ingested; i < n; i++)
             next = forward_token(prompt[i], (int)i, true);
     } else {
-        for (size_t i = (size_t)start; i + 1 < n; i++)
+        for (size_t i = ingested; i + 1 < n; i++)
             forward_token(prompt[i], (int)i, false);
-        if (n > (size_t)start)
+        if (n > ingested)
             next = forward_token(prompt.back(), (int)n - 1, true);
     }
     for (int i = 0; i < max_new; i++) {

--- a/runtime/src/models/qwen35_prefill_mmq.cpp
+++ b/runtime/src/models/qwen35_prefill_mmq.cpp
@@ -1,0 +1,371 @@
+// Chunked, weight-amortized prompt ingest for the Qwen3.5 dense hybrid (Qwythos-9B).
+//
+// The token path pays one full weight read per prompt token. Here the prompt is walked in
+// chunks of MQ_CHUNK tokens and every projection in the stack (GDN qkv/gate/alpha/beta/out,
+// full-attention q/k/v/o, dense SwiGLU gate/up/down) is issued as a single Q4_K x Q8_1 tile
+// GEMM over the chunk, so each weight superblock is read once per tile of token rows. The
+// weights stay 4-bit from DRAM into registers; nothing is dequantized.
+//
+// Everything that is *not* a weight read is left to the kernels the decode path already uses:
+//   - the Gated-DeltaNet conv + recurrence run per token (they are a serial recurrence, and
+//     they read state, not weights, so batching them buys nothing -- measured, see below),
+//   - the full-attention layers call the same sink+sliding-window sparse KV kernels decode
+//     calls, once per query, so prefill attends to exactly the keys decode will later read,
+//   - RoPE + int8 KV append, the norms, SwiGLU and the split/gate helpers are the in-tree
+//     kernels, driven over a whole chunk at once (they are already row- or head-indexed).
+//
+// The LM head runs for the FINAL prompt token only: it is 572 MB of Q4_K (10% of the weight
+// set) and a one-pass prefill needs its logits only to seed the first decode step.
+//
+// Scratch is O(chunk), never O(prompt), so 128k fits in the same VRAM as 4k.
+
+#include "qwen35_prefill_mmq.h"
+
+#include "sparkinfer/kernels/attention.h"
+#include "sparkinfer/kernels/fused.h"
+#include "sparkinfer/kernels/gemm.h"
+#include "sparkinfer/kernels/mmq_prefill.h"
+#include "sparkinfer/kernels/quant.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+
+namespace sparkinfer {
+
+namespace {
+
+inline int mq_env_int(const char* name, int def) {
+    const char* v = getenv(name);
+    if (!v) return def;
+    const int x = atoi(v);
+    return x > 0 ? x : def;
+}
+
+// The KV-split count the token path would pick for this seq_len (its depth-adaptive policy for
+// hd256 GQA-4). Reproducing it is not a tuning choice: launch_flash_decode_split selects its
+// scalar vs int8-MMA implementation from seq_len/n_splits, so a different split count silently
+// runs a different kernel with different rounding than the decode this prefill has to match.
+inline int mq_splits_for(int seqlen, int n_q_heads, int n_kv_heads) {
+    static int fixed = -1;
+    if (fixed < 0) {
+        const char* e = getenv("SPARKINFER_NSPLITS");
+        fixed = e ? atoi(e) : 0;
+        if (fixed < 1 || fixed > 256) fixed = 0;
+    }
+    if (fixed) return fixed;
+    int split_chunk = 256;
+    if (const char* c = getenv("SPARKINFER_SPLIT_CHUNK")) {
+        const int v = atoi(c);
+        if (v > 0) split_chunk = v;
+    }
+    int want = 32;
+    if ((long)seqlen > 2L * split_chunk) want = 128;
+    if ((long)seqlen > 28L * split_chunk && (long)seqlen <= 48L * split_chunk) want = 256;
+    if ((long)seqlen > 64L * split_chunk) want = 256;
+    if (n_kv_heads > 0 && n_q_heads == n_kv_heads * 4 && want >= 128) {
+        if ((long)seqlen > 98304L) want = 128;
+        else if ((long)seqlen > 65536L) want = 192;
+        else want = 160;
+    }
+    return want;
+}
+
+// Device scratch held for the lifetime of one prefill call. Sized from the chunk width, so
+// the 128k prompt and a 4k prompt allocate the same buffers.
+struct Scratch {
+    std::vector<void*> owned;
+
+    template <class T>
+    T* get(size_t n) {
+        void* p = nullptr;
+        if (cudaMalloc(&p, n * sizeof(T)) != cudaSuccess) {
+            fprintf(stderr, "[prefill-mmq] scratch alloc of %zu bytes failed\n", n * sizeof(T));
+            return nullptr;
+        }
+        owned.push_back(p);
+        return static_cast<T*>(p);
+    }
+    ~Scratch() {
+        for (void* p : owned) cudaFree(p);
+    }
+};
+
+using bf16_t = unsigned short;
+
+}  // namespace
+
+int qwen35_prefill_mmq_min_ctx() {
+    const char* off = getenv("SPARKINFER_PREFILL_MMQ");
+    if (off && off[0] == '0') return INT32_MAX;
+    // Read directly rather than through mq_env_int: 0 is a meaningful setting here (ingest every
+    // prompt through this path, which is what an A/B against the token loop wants), and
+    // mq_env_int would quietly read it as "unset" and hand back the 65536 default instead.
+    const char* v = getenv("SPARKINFER_PREFILL_MMQ_MINCTX");
+    if (!v || !*v) return 65536;
+    const int x = atoi(v);
+    return x >= 0 ? x : 65536;
+}
+
+int qwen35_prefill_mmq_run(const Qwen35Config& cfg, const Qwen35Weights& w, KVCacheManager* kv,
+                           uint64_t seq_id, float* lin_state, void* lin_conv_state, float* logits,
+                           int* d_out_id, int* h_out_id, const int* ids, int n_tokens,
+                           cudaStream_t stream) {
+    if (n_tokens <= 0 || !kv || !lin_state || !lin_conv_state) return -1;
+    // This path is written against the Qwythos shape only: dense SwiGLU FFN, hd256 GQA-4
+    // full attention every full_attn_interval layers, partial RoPE, int8 paged KV, and a
+    // Q4_K weight set (the tile GEMM is Q4_K x Q8_1).
+    if (!cfg.dense_ffn || !cfg.hybrid || cfg.head_dim != 256 || cfg.n_shared != 0) return -1;
+    if (cfg.n_q_heads != cfg.n_kv_heads * 4 || cfg.full_attn_interval <= 0) return -1;
+    if (!(cfg.rope_dim > 0 && cfg.rope_dim < cfg.head_dim)) return -1;
+    if (!kv->int8_kv() || kv->block_size() != 16) return -1;
+    if (w.lm_head_type != 12) return -1;
+    for (int L = 0; L < cfg.n_layers; L++) {
+        const Qwen35LayerWeights& lw = w.layers[L];
+        if (lw.gate_qtype != 12 || lw.up_qtype != 12 || lw.down_qtype != 12) return -1;
+        if (lw.linear_attn) {
+            if (lw.wqkv_type != 12 || lw.wqkv_gate_type != 12 || lw.ssm_alpha_type != 12 ||
+                lw.ssm_beta_type != 12 || lw.ssm_out_type != 12)
+                return -1;
+        } else if (lw.wq_type != 12 || lw.wk_type != 12 || lw.wv_type != 12 || lw.wo_type != 12) {
+            return -1;
+        }
+        // The chunk driver folds the q-gate itself; a layer without one is a different model.
+        if (!lw.linear_attn && !lw.q_has_gate) return -1;
+        if (cfg.linear_head_dim != 128) return -1;
+    }
+
+    const int H = cfg.hidden;
+    const int qdim = cfg.n_q_heads * cfg.head_dim;
+    const int kvdim = cfg.n_kv_heads * cfg.head_dim;
+    const int lin_qdim = cfg.linear_q_heads * cfg.linear_head_dim;
+    const int lin_vdim = cfg.linear_v_heads * cfg.linear_head_dim;
+    const int lin_qkvdim = 2 * lin_qdim + lin_vdim;
+    const int ffn = cfg.moe_ffn;
+
+    const int chunk = mq_env_int("SPARKINFER_PREFILL_MMQ_CHUNK", 1024);
+    const int M = (chunk < n_tokens) ? chunk : n_tokens;
+    // Widest activation any projection consumes (the SwiGLU down-projection input).
+    const int kmax = (ffn > H) ? ffn : H;
+
+    // Sink + sliding-window selection must mirror what the decode path will read back, so the
+    // window/min-ctx knobs are read from the same environment the model reads them from.
+    int sparse_window = mq_env_int("SPARKINFER_SPARSE_WINDOW", 256);
+    if (const char* rw = getenv("SPARKINFER_SPARSE_RECENT")) {
+        const int v = atoi(rw);
+        if (v > 0) sparse_window = v;
+    }
+    if (const char* b = getenv("SPARKINFER_SPARSE_BUDGET")) {
+        const int v = atoi(b);
+        if (v > 1) sparse_window = v - 1;
+    }
+    const int sparse_min_ctx = mq_env_int("SPARKINFER_SPARSE_MIN_CTX", 8192);
+    bool sparse_enable = true;
+    if (const char* se = getenv("SPARKINFER_SPARSE_KV")) sparse_enable = (se[0] != '0');
+    const int sparse_budget = 1 + sparse_window;
+    const int max_splits = 256;   // the token path's ceiling; partials below are sized for it
+
+    Scratch sc;
+    bf16_t* x = sc.get<bf16_t>((size_t)M * H);
+    bf16_t* xn = sc.get<bf16_t>((size_t)M * H);
+    bf16_t* hres = sc.get<bf16_t>((size_t)M * H);
+    bf16_t* hn = sc.get<bf16_t>((size_t)M * H);
+    bf16_t* ao = sc.get<bf16_t>((size_t)M * H);
+    bf16_t* ffn_out = sc.get<bf16_t>((size_t)M * H);
+    signed char* q8 = sc.get<signed char>((size_t)M * kmax);
+    float* q8d = sc.get<float>((size_t)M * (kmax >> 5));
+    float* q8s = sc.get<float>((size_t)M * (kmax >> 5));
+    bf16_t* qraw = sc.get<bf16_t>((size_t)M * qdim * 2);
+    bf16_t* qb = sc.get<bf16_t>((size_t)M * qdim);
+    bf16_t* qgate = sc.get<bf16_t>((size_t)M * qdim);
+    bf16_t* kb = sc.get<bf16_t>((size_t)M * kvdim);
+    bf16_t* vb = sc.get<bf16_t>((size_t)M * kvdim);
+    bf16_t* attn = sc.get<bf16_t>((size_t)M * qdim);
+    bf16_t* lin_qkv = sc.get<bf16_t>((size_t)M * lin_qkvdim);
+    bf16_t* lin_z = sc.get<bf16_t>((size_t)M * lin_vdim);
+    bf16_t* lin_alpha = sc.get<bf16_t>((size_t)M * cfg.linear_v_heads);
+    bf16_t* lin_beta = sc.get<bf16_t>((size_t)M * cfg.linear_v_heads);
+    bf16_t* lin_gdn = sc.get<bf16_t>((size_t)M * lin_vdim);
+    bf16_t* lin_norm = sc.get<bf16_t>((size_t)M * lin_vdim);
+    bf16_t* tq = sc.get<bf16_t>(lin_qdim);   // one token's conv output, consumed by the scan
+    bf16_t* tk = sc.get<bf16_t>(lin_qdim);
+    bf16_t* tv = sc.get<bf16_t>(lin_vdim);
+    bf16_t* gate_buf = sc.get<bf16_t>((size_t)M * ffn);
+    bf16_t* up_buf = sc.get<bf16_t>((size_t)M * ffn);
+    bf16_t* ffn_h = sc.get<bf16_t>((size_t)M * ffn);
+    int* d_ids = sc.get<int>(M);
+    int* d_pos = sc.get<int>(M);
+    int* d_seqlen = sc.get<int>(M);
+    float* fa_m = sc.get<float>((size_t)cfg.n_q_heads * max_splits);
+    float* fa_l = sc.get<float>((size_t)cfg.n_q_heads * max_splits);
+    float* fa_acc = sc.get<float>((size_t)cfg.n_q_heads * max_splits * cfg.head_dim);
+    int* sparse_sel = sc.get<int>((size_t)cfg.n_kv_heads * sparse_budget);
+    float* d_one = sc.get<float>(1);
+    void* aq81 = sc.get<char>(kernels::llama_q8_1_bytes(H));
+    if (!x || !ffn_h || !sparse_sel || !d_one || !aq81) return -1;
+
+    const float one = 1.f;
+    cudaMemcpyAsync(d_one, &one, sizeof(float), cudaMemcpyHostToDevice, stream);
+
+    int* btable = kv->block_table(seq_id);
+    const int bs = kv->block_size();
+    const int mbps = kv->max_blocks_per_seq();
+    const float scale = 1.f / sqrtf((float)cfg.head_dim);
+    const bool sparse_avail = sparse_enable && sparse_budget > 1;
+
+    if (const char* dbg = getenv("SPARKINFER_PREFILL_MMQ_DEBUG"); dbg && dbg[0] == '1')
+        fprintf(stderr, "[prefill-mmq] %d tokens, chunk=%d, splits@end=%d, sparse=%d (window=%d min_ctx=%d)\n",
+                n_tokens, M, mq_splits_for(n_tokens, cfg.n_q_heads, cfg.n_kv_heads), (int)sparse_avail, sparse_window, sparse_min_ctx);
+
+    // The recurrence starts from zero, exactly as the token path's position-0 reset does. This
+    // path never runs a position-0 forward_token, so it owns the reset.
+    cudaMemsetAsync(lin_state, 0,
+                    (size_t)cfg.n_layers * cfg.linear_v_heads * cfg.linear_head_dim *
+                        cfg.linear_head_dim * sizeof(float),
+                    stream);
+    cudaMemsetAsync(lin_conv_state, 0,
+                    (size_t)cfg.n_layers * (cfg.linear_conv_kernel - 1) * lin_qkvdim * sizeof(bf16_t),
+                    stream);
+
+    std::vector<int> h_pos(M), h_seq(M);
+    int last_id = -1;
+
+    for (int t0 = 0; t0 < n_tokens; t0 += M) {
+        const int m = (n_tokens - t0 < M) ? (n_tokens - t0) : M;
+        for (int i = 0; i < m; i++) {
+            h_pos[i] = t0 + i;
+            h_seq[i] = t0 + i + 1;
+        }
+        cudaMemcpyAsync(d_ids, ids + t0, m * sizeof(int), cudaMemcpyHostToDevice, stream);
+        cudaMemcpyAsync(d_pos, h_pos.data(), m * sizeof(int), cudaMemcpyHostToDevice, stream);
+        cudaMemcpyAsync(d_seqlen, h_seq.data(), m * sizeof(int), cudaMemcpyHostToDevice, stream);
+
+        kernels::launch_embedding(d_ids, w.embed_tokens, x, m, H, stream);
+        kernels::launch_rmsnorm(x, w.layers[0].input_norm, xn, m, H, cfg.rms_eps, stream);
+
+        for (int L = 0; L < cfg.n_layers; L++) {
+            const Qwen35LayerWeights& lw = w.layers[L];
+
+            // ---- token mixing: Gated DeltaNet, or full attention every full_attn_interval ----
+            if (lw.linear_attn) {
+                kernels::launch_mmq_quant_q8_1(xn, q8, q8d, q8s, m, H, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.wqkv, lin_qkv, m, lin_qkvdim, H, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.wqkv_gate, lin_z, m, lin_vdim, H, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.ssm_alpha, lin_alpha, m, cfg.linear_v_heads, H, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.ssm_beta, lin_beta, m, cfg.linear_v_heads, H, stream);
+
+                bf16_t* conv_state =
+                    (bf16_t*)lin_conv_state + (size_t)L * (cfg.linear_conv_kernel - 1) * lin_qkvdim;
+                float* layer_state =
+                    lin_state + (size_t)L * cfg.linear_v_heads * cfg.linear_head_dim * cfg.linear_head_dim;
+                // The recurrence carries token to token; it reads state rather than weights, so
+                // it stays exactly the decode kernel, stepped once per token of the chunk.
+                for (int i = 0; i < m; i++) {
+                    kernels::launch_qwen36_conv_split_l2norm_fused(
+                        lin_qkv + (size_t)i * lin_qkvdim, lw.ssm_conv, conv_state, tq, tk, tv,
+                        cfg.linear_q_heads, cfg.linear_v_heads, cfg.linear_head_dim,
+                        cfg.linear_conv_kernel, cfg.rms_eps, stream);
+                    kernels::launch_qwen36_gdn_ar(tq, tk, tv, lin_alpha + (size_t)i * cfg.linear_v_heads,
+                                                  lin_beta + (size_t)i * cfg.linear_v_heads, lw.ssm_dt,
+                                                  lw.ssm_a, layer_state, lin_gdn + (size_t)i * lin_vdim,
+                                                  cfg.linear_q_heads, cfg.linear_v_heads,
+                                                  cfg.linear_head_dim, stream);
+                }
+                // gated_norm normalizes each v-head independently, so a chunk of m tokens is
+                // just m * v_heads consecutive heads.
+                kernels::launch_qwen36_gated_norm(lin_gdn, lin_z, lw.ssm_norm, lin_norm,
+                                                  cfg.linear_v_heads * m, cfg.linear_head_dim,
+                                                  cfg.rms_eps, stream);
+                kernels::launch_mmq_quant_q8_1(lin_norm, q8, q8d, q8s, m, lin_vdim, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.ssm_out, ao, m, H, lin_vdim, stream);
+            } else {
+                kernels::launch_mmq_quant_q8_1(xn, q8, q8d, q8s, m, H, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.wq, qraw, m, qdim * 2, H, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.wk, kb, m, kvdim, H, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.wv, vb, m, kvdim, H, stream);
+                // q rows are [head][2*head_dim]; m tokens of n_q_heads heads split as one run.
+                kernels::launch_qwen36_split_q_gate(qraw, qb, qgate, cfg.n_q_heads * m, cfg.head_dim,
+                                                    stream);
+                kernels::launch_rmsnorm_qk(qb, kb, lw.q_norm, lw.k_norm, cfg.n_q_heads * m,
+                                           cfg.n_kv_heads * m, cfg.head_dim, cfg.rms_eps, stream);
+
+                const int kv_elem = 1;   // int8 paged KV (checked above)
+                void* kpool = (char*)kv->k_pool() + (size_t)L * kv->layer_stride_elems() * kv_elem;
+                void* vpool = (char*)kv->v_pool() + (size_t)L * kv->layer_stride_elems() * kv_elem;
+                void* kscale = (char*)kv->k_scale_pool() + (size_t)L * kv->scale_layer_stride_elems() * 2;
+                void* vscale = (char*)kv->v_scale_pool() + (size_t)L * kv->scale_layer_stride_elems() * 2;
+
+                // max_blocks_per_seq = 0 collapses this kernel's per-token block-table stride to
+                // the single shared table one sequence has, which is what a prompt needs.
+                kernels::launch_rope_kv_append_partial_int8(qb, kb, vb, kpool, vpool, kscale, vscale,
+                                                            btable, d_pos, m, cfg.n_q_heads,
+                                                            cfg.n_kv_heads, cfg.head_dim, cfg.rope_dim,
+                                                            cfg.rope_theta, bs, 0, stream);
+
+                // Every query in the chunk is already in the cache, but each one is masked to its
+                // own seq_len, so appending the whole chunk before attending stays causal.
+                for (int i = 0; i < m; i++) {
+                    const int sl = t0 + i + 1;
+                    const int nsp = mq_splits_for(sl, cfg.n_q_heads, cfg.n_kv_heads);
+                    const bool use_sparse = sparse_avail && sl >= sparse_min_ctx;
+                    if (use_sparse) {
+                        kernels::launch_fa_kv_window_select(d_seqlen + i, sparse_sel, cfg.n_kv_heads,
+                                                            bs, sparse_budget, sparse_window, stream);
+                        kernels::launch_flash_decode_split_sparse(
+                            qb + (size_t)i * qdim, kpool, vpool, btable, d_seqlen + i, sparse_sel,
+                            fa_m, fa_l, fa_acc, cfg.n_q_heads, cfg.n_kv_heads, cfg.head_dim, bs, mbps,
+                            nsp, sparse_budget, scale, kscale, vscale, stream);
+                        kernels::launch_fa_combine_hd256(fa_m, fa_l, fa_acc, attn + (size_t)i * qdim,
+                                                         cfg.n_q_heads, nsp, nullptr, stream);
+                    } else {
+                        kernels::launch_flash_decode_split(
+                            qb + (size_t)i * qdim, kpool, vpool, btable, d_seqlen + i,
+                            attn + (size_t)i * qdim, fa_m, fa_l, fa_acc, 1, cfg.n_q_heads,
+                            cfg.n_kv_heads, cfg.head_dim, bs, mbps, nsp, scale, stream, nullptr,
+                            sl, kscale, vscale, 1, nullptr);
+                    }
+                }
+                kernels::launch_qwen36_mul_sigmoid(attn, qgate, m * qdim, stream);
+                kernels::launch_mmq_quant_q8_1(attn, q8, q8d, q8s, m, qdim, stream);
+                kernels::launch_mmq_q4k(q8, q8d, q8s, lw.wo, ao, m, H, qdim, stream);
+            }
+
+            // hres = x + ao ; hn = RMSNorm(hres, post_attn_norm)
+            kernels::launch_add_rmsnorm2(x, ao, lw.post_attn_norm, hres, hn, m, H, cfg.rms_eps, stream);
+
+            // ---- dense SwiGLU FFN ----
+            kernels::launch_mmq_quant_q8_1(hn, q8, q8d, q8s, m, H, stream);
+            kernels::launch_mmq_q4k(q8, q8d, q8s, lw.gate_q, gate_buf, m, ffn, H, stream);
+            kernels::launch_mmq_q4k(q8, q8d, q8s, lw.up_q, up_buf, m, ffn, H, stream);
+            kernels::launch_qwen36_shared_swiglu(gate_buf, up_buf, d_one, ffn_h, m * ffn, stream);
+            kernels::launch_mmq_quant_q8_1(ffn_h, q8, q8d, q8s, m, ffn, stream);
+            kernels::launch_mmq_q4k(q8, q8d, q8s, lw.down_q, ffn_out, m, H, ffn, stream);
+
+            // x = hres + ffn_out ; xn = RMSNorm(x, next layer's input norm / final norm)
+            const void* nextnorm = (L + 1 < cfg.n_layers) ? w.layers[L + 1].input_norm : w.final_norm;
+            kernels::launch_add_rmsnorm2(hres, ffn_out, nextnorm, x, xn, m, H, cfg.rms_eps, stream);
+        }
+
+        // xn now holds RMSNorm(x_final, final_norm) for every token of the chunk, but only the
+        // last token of the prompt needs logits -- that is the 572 MB LM head skipped for all
+        // the others.
+        if (t0 + m >= n_tokens) {
+            kernels::launch_quantize_q8_1_blocks(xn + (size_t)(m - 1) * H, aq81, H, stream);
+            kernels::launch_mmvq_q4k_f32(aq81, w.lm_head, logits, cfg.vocab, H, stream);
+            kernels::launch_argmax(logits, d_out_id, 1, cfg.vocab, stream);
+            cudaMemcpyAsync(h_out_id, d_out_id, sizeof(int), cudaMemcpyDeviceToHost, stream);
+        }
+        // The whole chunk is asynchronous; this is where any copy or launch failure in it lands.
+        const cudaError_t err = cudaStreamSynchronize(stream);
+        if (err != cudaSuccess) {
+            fprintf(stderr, "[prefill-mmq] chunk at token %d: %s\n", t0, cudaGetErrorString(err));
+            return -1;
+        }
+    }
+    last_id = *h_out_id;
+    return (last_id >= 0 && last_id < cfg.vocab) ? last_id : -1;
+}
+
+}  // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill_mmq.h
+++ b/runtime/src/models/qwen35_prefill_mmq.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <cuda_runtime.h>
+
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/models/qwen35.h"
+
+namespace sparkinfer {
+
+// Long-context prompt ingest for the Qwen3.5 dense hybrid (Qwythos).
+//
+// forward_token() re-reads every projection weight for each prompt token, so a 128k prompt
+// streams the whole quantized weight set 131072 times. This entry point walks the prompt in
+// token chunks and runs each chunk's projections through the Q4_K x Q8_1 tile GEMM in
+// kernels/mmq_prefill.h, so a weight superblock is read once per tile instead of once per
+// token. Weights stay 4-bit end to end (never dequantized).
+//
+// It leaves the paged int8 KV cache, the Gated-DeltaNet recurrent state and the conv state
+// exactly where a forward_token loop would leave them, so a subsequent decode continues
+// unchanged. Returns the argmax id of the final prompt token, or -1 if this path declined
+// to run (caller then falls back to the token loop).
+int qwen35_prefill_mmq_run(const Qwen35Config& cfg, const Qwen35Weights& w, KVCacheManager* kv,
+                           uint64_t seq_id, float* lin_state, void* lin_conv_state, float* logits,
+                           int* d_out_id, int* h_out_id, const int* ids, int n_tokens,
+                           cudaStream_t stream);
+
+// Prompts longer than this use the chunked path above; everything at or below it stays on the
+// token loop. Defaults to 65536 (SPARKINFER_PREFILL_MMQ_MINCTX), and returns a value no prompt
+// can exceed when the path is switched off with SPARKINFER_PREFILL_MMQ=0.
+int qwen35_prefill_mmq_min_ctx();
+
+}  // namespace sparkinfer


### PR DESCRIPTION
## Summary

`forward_token` ingests a prompt one token at a time, so a 128k prompt re-reads the whole Q4_K weight set 131072 times and prefill pp sits flat at ~285 tok/s, pinned to DRAM bandwidth. This PR ingests prompts longer than 64k in token chunks, issuing every projection as one **Q4_K x Q8_1 dp4a tile GEMM** so each weight superblock is read once per tile of token rows instead of once per token — weights are never dequantized, and 131072 goes **284.80 -> 1575.10 pp (5.5x)**. Gated to ctx > 65536, so 4k/32k/64k and the whole decode path are untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 285.42 |
| after (this PR) | 286.09 |

> This PR does **not** target decode and does not modify the decode path or its CUDA graph. The row
> above is a **no-regression check at ctx=131072, not a claimed gain** — the +0.2% is run-to-run
> noise. The prefill table below is the actual claim.

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 284.80 |
| after prefill (this PR) | **1575.10** |

```text
# bench/scripts/bench.sh <gguf> --tokens 128 --ctx 131072   (same binary, SPARKINFER_PREFILL_MMQ=0 -> default)

### BEFORE (main: SPARKINFER_PREFILL_MMQ=0)
>> GPU arch: sm_120
>> using local build

=== sparkinfer — decode (n=128, ctx=131072, bs=1) ===
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
loading /workspace/models35/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf (native GGUF, experts quantized) ...

=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 16.2 GB
max seq      : 131216
decode tg    : 285.42 tok/s  (3.5 ms/token, n=128, ctx=131072, bs=1)
prefill pp   : 284.80 tok/s  (ctx=131072, sequential KV fill)
GPU          : 76°C · 574 W · 2715 MHz (peak under load)

### AFTER (this PR, default)
>> GPU arch: sm_120
>> using local build

=== sparkinfer — decode (n=128, ctx=131072, bs=1) ===
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
loading /workspace/models35/Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf (native GGUF, experts quantized) ...

=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 16.2 GB
max seq      : 131216
decode tg    : 286.09 tok/s  (3.5 ms/token, n=128, ctx=131072, bs=1)
prefill pp   : 1575.10 tok/s  (ctx=131072, sequential KV fill)
GPU          : 75°C · 549 W · 2827 MHz (peak under load)
```

Context sweep — every context at or below the 65536 gate runs main's token loop byte-for-byte, so before/after there are literally the same code path:

```text
# ctx=4096:    main 294.12 -> this PR 293.24    (1.00x — token path, gated off; delta is run-to-run noise)
# ctx=32768:   main 286.85 -> this PR 286.85    (1.00x — token path, gated off)
# ctx=65536:   main 286.95 -> this PR 286.95    (1.00x — token path, gated off)
# ctx=131072:  main 284.80 -> this PR 1575.10   (5.53x)
```

**How.** The prompt is walked in 1024-token chunks; every projection (GDN `qkv`/`gate`/`alpha`/`beta`/ `out`, full-attention `q`/`k`/`v`/`o`, dense SwiGLU `gate`/`up`/`down`) is issued as a single Q4_K x Q8_1 dp4a tile GEMM, so a weight superblock is read once per tile of token rows rather than once per token.
Weights stay 4-bit from DRAM into registers — nothing is dequantized — and the arithmetic is the same `vec_dot_q4_K_q8_1` the decode GEMV runs. The LM head (248320x4096 Q4_K, 572 MB = 10% of the weight set) runs for the final prompt token only. Scratch is O(chunk), not O(prompt), so 128k allocates what 4k does (VRAM 16.2 GB, unchanged above).

Gated to **ctx > 65536** (`SPARKINFER_PREFILL_MMQ_MINCTX`, default 65536; `SPARKINFER_PREFILL_MMQ=0` disables). Everything that is not a weight read stays on the kernels decode already uses: the Gated-DeltaNet conv + recurrence run per token (a serial recurrence over state, not weights, so batching it buys nothing), and the full-attention layers call the same sink + sliding-window sparse-KV kernels (`fa_kv_window_select` / `flash_decode_split_sparse`) once per query, under the same depth-adaptive KV-split policy — so prefill attends to exactly the keys decode will later read. That is also why 128k is reachable: past `sparse_min_ctx` the baseline attends to sink + recent window, so a prefill that respects that window has no O(N^2) wall.

## Correctness

The chunked fill must leave the KV cache + Gated-DeltaNet/conv state such that decode continues exactly as the token-by-token fill would. Ingesting the same prompt both ways and comparing the next-token distribution at the prompt boundary (gate: top1 >= 0.90, KL <= 0.20):

```text
prompt=8192    TOP1 MATCH    KL 0.000527
prompt=16384   TOP1 MATCH    KL 0.000374     # sparse-KV window active
```

Those runs pin `SPARKINFER_FAMMA4=0 SPARKINFER_ATTN_GQ8=0`. Without them the two paths diverge at ctx >~ 5k for two reasons that are independent of this PR and already have open fixes — **#389** (hd256 int8-MMA correctness) and **#393** (sparse-KV combine drops the attention output gate). This path computes the gated, correctly-strided result; the token path currently does not, so the two disagree until those land. Both reproduce on the token path alone, without this PR — main's own argmax moves when either is switched off:

```text
# ctx=6144, token path, main's own argmax:  11006 -> 266   with SPARKINFER_FAMMA4=0
# ctx=8192, token path, main's own argmax: 107221 -> 220   with SPARKINFER_ATTN_GQ8=0
```

The accuracy gate is unaffected either way: it teacher-forces `forward_token` at 2048 (`qwen3_gguf_score`), which this path never touches.

## Relation to open PRs

**#398** (`batched prompt prefill for Qwythos`) is the only other PR that amortizes prefill weight reads, and it **caps at 65536** (`SPARKINFER_PREFILL_BATCHED_MAXCTX` — its prefill attention is dense causal O(N^2)), falling back to the token path at 131072. That is the one context this PR touches, so the two do not overlap at any measured context, and if #398 merges first this PR still applies as-is.
The implementations differ throughout: #398 dequantizes Q4_K to bf16 and runs cp.async + WMMA tensor-core GEMMs with a one-launch sequential GDN scan and its own dense int8 paged attention; this PR keeps weights 4-bit and runs a dp4a Q4_K x Q8_1 tile GEMM, reuses the in-tree per-token GDN kernels unchanged, and reuses the in-tree sparse-KV attention.

**#387** (`skip LM head on prefill`) keeps prefill token-by-token; skipping the LM head for non-final prompt tokens is inherent to a one-pass ingest here rather than a separable change.

**#389 / #393** are the two correctness fixes the A/B above depends on; no code overlap with this PR.

**#345** (`grid-target KV-split cap for int8-MMA long-context`) tunes the KV-split policy this PR mirrors — a trivial rebase if it lands first.