### PR TITLE
fix(eval): warm llama.cpp on box and surface long CUDA builds

### DIFF
--- a/.github/workflows/eval-policy.yml
+++ b/.github/workflows/eval-policy.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           set -euo pipefail
           bash -n bench/scripts/evaluate.sh
+          bash -n bench/scripts/warm_llamacpp.sh
           bash -n eval/run_bot_cron.sh
           bash -n eval/setup_labels.sh
 

--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -90,25 +90,42 @@ _llamacpp_clean() {  # $1=llama-bench  $2=sentinel
 ensure_llamacpp() {  # $1 = arch ; builds llama-bench + llama-server, pinned + tamper-checked (C2)
   local bench="$LLAMACPP_DIR/build/bin/llama-bench" srv="$LLAMACPP_DIR/build/bin/llama-server"
   local sentinel="$LLAMACPP_DIR/.si_refhash"
-  [ -x "$bench" ] && [ -x "$srv" ] && _llamacpp_clean "$bench" "$sentinel" && return
-  echo ">> (re)building llama.cpp reference (CUDA sm_$1) ..." >&2
+  local arch="$1"
+  [ -x "$bench" ] && [ -x "$srv" ] && _llamacpp_clean "$bench" "$sentinel" && return 0
+  echo ">> (re)building llama.cpp reference (CUDA sm_$arch) ..." >&2
   if [ -n "${LLAMACPP_COMMIT:-}" ]; then
-    # Reproducible + tamper-proof: a fresh shallow fetch of EXACTLY the pinned commit, not a drifting
-    # (or possibly-tampered) persisted tree. GitHub serves any reachable sha to `fetch --depth 1`.
-    rm -rf "$LLAMACPP_DIR"; mkdir -p "$LLAMACPP_DIR"
-    git -C "$LLAMACPP_DIR" init -q
-    git -C "$LLAMACPP_DIR" remote add origin "$LLAMACPP_REPO"
-    git -C "$LLAMACPP_DIR" fetch -q --depth 1 origin "$LLAMACPP_COMMIT" >&2 || { echo ">> FATAL: cannot fetch pinned llama commit $LLAMACPP_COMMIT" >&2; return 1; }
-    git -C "$LLAMACPP_DIR" checkout -q FETCH_HEAD
+    local head_ok=0
+    if [ -d "$LLAMACPP_DIR/.git" ]; then
+      [ "$(git -C "$LLAMACPP_DIR" rev-parse HEAD 2>/dev/null)" = \
+        "$(git -C "$LLAMACPP_DIR" rev-parse "$LLAMACPP_COMMIT^{commit}" 2>/dev/null)" ] && head_ok=1
+    fi
+    if [ "$head_ok" != 1 ]; then
+      rm -rf "$LLAMACPP_DIR"; mkdir -p "$LLAMACPP_DIR"
+      git -C "$LLAMACPP_DIR" init -q
+      git -C "$LLAMACPP_DIR" remote add origin "$LLAMACPP_REPO"
+      git -C "$LLAMACPP_DIR" fetch -q --depth 1 origin "$LLAMACPP_COMMIT" >&2 || {
+        echo ">> FATAL: cannot fetch pinned llama commit $LLAMACPP_COMMIT" >&2; return 1; }
+      git -C "$LLAMACPP_DIR" checkout -q FETCH_HEAD
+    fi
   else
     [ -d "$LLAMACPP_DIR/.git" ] || git clone --depth=1 "$LLAMACPP_REPO" "$LLAMACPP_DIR" >&2
     echo ">> llama.cpp NOT pinned (warn-only) — HEAD $(git -C "$LLAMACPP_DIR" rev-parse --short HEAD 2>/dev/null); set LLAMACPP_COMMIT in reference.lock" >&2
   fi
   rm -rf "$LLAMACPP_DIR/build"
-  cmake -S "$LLAMACPP_DIR" -B "$LLAMACPP_DIR/build" -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="$1" \
-        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF $CUDA_HOST_FLAG >/dev/null 2>&1
-  cmake --build "$LLAMACPP_DIR/build" -j4 --target llama-bench llama-server >/dev/null 2>&1
-  sha256_of "$bench" > "$sentinel" 2>/dev/null || true   # record provenance for the reuse tamper-check
+  if ! cmake -S "$LLAMACPP_DIR" -B "$LLAMACPP_DIR/build" -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="$arch" \
+        -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF $CUDA_HOST_FLAG >&2; then
+    echo ">> FATAL: llama.cpp cmake configure failed" >&2; return 1
+  fi
+  # CUDA build is long (~30–45 min). Stream progress (hidden builds look like hung SSH evals).
+  if ! cmake --build "$LLAMACPP_DIR/build" -j2 --target llama-bench llama-server 2>&1 \
+        | tee /tmp/llama_build.log | awk 'NR<=5 || NR%40==0 || /Built target|error:|FAILED|fatal error/' >&2; then
+    echo ">> FATAL: llama.cpp build failed" >&2
+    tail -40 /tmp/llama_build.log >&2 || true
+    return 1
+  fi
+  [ -x "$bench" ] && [ -x "$srv" ] || { echo ">> FATAL: llama binaries missing after build" >&2; return 1; }
+  sha256_of "$bench" > "$sentinel" 2>/dev/null || true
+  echo ">> llama.cpp reference ready ($(git -C "$LLAMACPP_DIR" rev-parse --short HEAD 2>/dev/null))" >&2
 }
 
 # ---- prebuilt binaries (GitHub release) with source-build fallback ----

--- a/bench/scripts/warm_llamacpp.sh
+++ b/bench/scripts/warm_llamacpp.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Pre-build pinned llama.cpp on the eval box (once per session). vast_eval calls this after setup.
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=_common.sh
+source "$HERE/_common.sh"
+export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"
+ARCH="$(detect_arch)"
+ensure_llamacpp "$ARCH"
+echo ">> warm_llamacpp: ready (sm_$ARCH)"

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -696,6 +696,16 @@ def main():
             p36_gguf = f"{MODEL_PATH}"
             p35_gguf = ""
         push_bench_scripts(host, port)
+        if args.bidir:
+            wr = sh(host, port,
+                    "cd /root/sparkinfer && LLAMACPP_DIR=/workspace/.llamacpp "
+                    "bash bench/scripts/warm_llamacpp.sh",
+                    timeout=7200)
+            if wr.returncode:
+                print(">> WARN: warm_llamacpp failed — eval will retry inline")
+                sys.stdout.write((wr.stdout + wr.stderr)[-2000:])
+            else:
+                print(">> llama.cpp reference warm on box")
         harness = "cd /root/sparkinfer && "
         if args.polaris and not args.baseline_only:
             guard_arg = f" --guard-model-file {p35_gguf}" if p35_gguf else ""


### PR DESCRIPTION
## Summary
- Fix `ensure_llamacpp`: keep pinned checkout when possible, `-j2`, show build progress/errors, fail loudly if binaries missing
- Add `warm_llamacpp.sh` and call it from `vast_eval.py` before bidir PR eval (2h budget)
- Fixes PR eval infra failures where llama.cpp CUDA compile ran ~30–45 min with no output

## Test plan
- [x] `bash -n bench/scripts/warm_llamacpp.sh`
- [ ] CI eval-policy passes
- [ ] Re-run `./eval/run_bot.sh --only-prs 387,398 --reeval --skip-baseline`