### PR TITLE
fix(runtime): charge only the delta when re-allocating a paged KV sequence

### DIFF
--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -82,16 +82,26 @@ KVCacheManager::~KVCacheManager() {
 }
 
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
-    const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
-    if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
-    if (need > kMaxBlocksPerSeq) return false;
+    // `want` is the TOTAL blocks this sequence needs for num_tokens. A sequence that
+    // already holds blocks (a re-allocate to grow a paged sequence) only needs the delta
+    // topped up. Sizing and bounding off the cumulative count — not the per-call request —
+    // is what keeps a re-allocate from double-allocating blocks and, worse, from pushing
+    // blocks.size() past kMaxBlocksPerSeq and overrunning the fixed device block-table row
+    // into the next sequence's row in the cudaMemcpy below.
+    const int want = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
+    if (want > kMaxBlocksPerSeq) return false;            // bound the TOTAL, not the delta
 
     auto& blocks = impl_->seq_blocks[seq_id];
+    const int have = (int)blocks.size();
+    const int need = (want > have) ? (want - have) : 0;   // only the additional blocks
+    const bool new_seq = impl_->seq_slot.find(seq_id) == impl_->seq_slot.end();
+    if ((int)impl_->free_list.size() < need) return false;
+    if (new_seq && impl_->free_slots.empty()) return false;  // a re-allocate already owns its slot
+
     for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
 
     int slot;
-    auto it = impl_->seq_slot.find(seq_id);
-    if (it != impl_->seq_slot.end()) slot = it->second;
+    if (!new_seq) slot = impl_->seq_slot[seq_id];
     else { slot = impl_->free_slots.back(); impl_->free_slots.pop_back(); impl_->seq_slot[seq_id] = slot; }
 
     cu(cudaMemcpy(impl_->d_block_tables + (size_t)slot * kMaxBlocksPerSeq, blocks.data(),

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -25,3 +25,7 @@ add_test(NAME decode_runner_gpu_test COMMAND decode_runner_gpu_test)
 add_executable(qwen35_gpu_test qwen35_gpu_test.cpp)
 target_link_libraries(qwen35_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME qwen35_gpu_test COMMAND qwen35_gpu_test)
+
+add_executable(kv_cache_gpu_test kv_cache_gpu_test.cpp)
+target_link_libraries(kv_cache_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
+add_test(NAME kv_cache_gpu_test COMMAND kv_cache_gpu_test)

--- a/runtime/tests/kv_cache_gpu_test.cpp
+++ b/runtime/tests/kv_cache_gpu_test.cpp
@@ -1,0 +1,88 @@
+// GPU test for grow-aware KV block allocation (issue #110).
+// Re-allocating an existing seq_id — the natural way to grow a paged sequence —
+// must top up by the delta only: no block leak, and the cumulative block count
+// must stay bounded by max_blocks_per_seq so the device block-table row never
+// overruns. Skips when no CUDA device is present.
+
+#include "sparkinfer/kv_cache.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+
+using sparkinfer::KVCacheConfig;
+using sparkinfer::KVCacheManager;
+
+static int blocks_for(int tokens, int block_size) {
+    return (tokens + block_size - 1) / block_size;
+}
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no CUDA device — kv_cache_gpu_test requires a GPU\n");
+        return 0;
+    }
+
+    // Small per-block footprint so the pool holds more blocks than max_blocks_per_seq,
+    // making the cumulative-bound path below reachable on a modest device allocation.
+    KVCacheConfig cfg;
+    cfg.num_layers = 1;
+    cfg.num_kv_heads = 1;
+    cfg.head_dim = 16;
+    cfg.block_size = 16;
+    KVCacheManager kv(cfg, 64ull * 1024 * 1024);
+
+    const int cap = kv.max_blocks_per_seq();
+    if (kv.num_total_blocks() <= cap) {
+        printf("[FAIL] test needs a pool larger than max_blocks_per_seq (%d blocks)\n", cap);
+        return 1;
+    }
+
+    const int free0 = kv.num_free_blocks();
+    const uint64_t seq = 42;
+
+    // Initial allocate charges exactly the blocks for 32 tokens.
+    if (!kv.allocate(seq, 32)) { printf("[FAIL] initial allocate(32)\n"); return 1; }
+    const int b32 = blocks_for(32, cfg.block_size);
+    if (free0 - kv.num_free_blocks() != b32) {
+        printf("[FAIL] expected %d blocks for 32 tokens, got %d\n", b32, free0 - kv.num_free_blocks());
+        return 1;
+    }
+
+    // Re-allocate the same token count — must not consume additional blocks (no leak).
+    const int free1 = kv.num_free_blocks();
+    if (!kv.allocate(seq, 32)) { printf("[FAIL] re-allocate(32)\n"); return 1; }
+    if (kv.num_free_blocks() != free1) {
+        printf("[FAIL] re-allocate(32) leaked blocks: free %d -> %d\n", free1, kv.num_free_blocks());
+        return 1;
+    }
+
+    // Grow to 48 tokens — only the delta should be charged.
+    if (!kv.allocate(seq, 48)) { printf("[FAIL] grow allocate(48)\n"); return 1; }
+    const int b48 = blocks_for(48, cfg.block_size);
+    if (free1 - kv.num_free_blocks() != b48 - b32) {
+        printf("[FAIL] grow to 48: expected delta %d, got %d\n", b48 - b32, free1 - kv.num_free_blocks());
+        return 1;
+    }
+
+    // Cumulative bound: two calls that each individually pass the per-seq cap but together
+    // would exceed it must be rejected on the total — never allowed to grow the row past cap
+    // (the buggy code appended blindly and overran the device block-table row).
+    const uint64_t big = 7;
+    const int near = (cap - 1) * cfg.block_size;               // ceil(near/bs) == cap-1 <= cap
+    if (!kv.allocate(big, near)) { printf("[FAIL] allocate(near-cap)\n"); return 1; }
+    if (kv.allocate(big, near + 2 * cfg.block_size)) {         // total would be cap+1 blocks
+        printf("[FAIL] grow past max_blocks_per_seq was not rejected\n");
+        return 1;
+    }
+
+    kv.free(seq);
+    kv.free(big);
+    if (kv.num_free_blocks() != free0) {
+        printf("[FAIL] free did not return all blocks: %d vs %d\n", kv.num_free_blocks(), free0);
+        return 1;
+    }
+
+    printf("[PASS] kv_cache grow-aware allocate\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

`KVCacheManager::allocate()` derived `need` from the total `num_tokens` but appended those blocks to whatever the sequence already held, so calling it again for the same `seq_id` — the normal way to grow a paged sequence past its initial reservation — added a full fresh `need` each time instead of topping up to that total. The guard checked only the incremental `need` against `kMaxBlocksPerSeq`, never the cumulative count, so after a re-allocate `blocks.size()` could exceed the row width and the `cudaMemcpy` wrote past the fixed device block-table row into the next sequence's row.

This sizes and bounds off the total instead. `want` is the total blocks for `num_tokens` and is checked against `kMaxBlocksPerSeq`; only the delta (`want - have`) is charged to the free list, keyed off whether the `seq_id` already owns a slot. Growing charges the delta, a re-allocate of equal size is a no-op, and a grow that would push the total past the row width is rejected before any block or slot state is mutated.

## Verification

Added `runtime/tests/kv_cache_gpu_test.cpp`, wired into the existing `ctest` suite. It allocates a sequence, re-allocates it at the same token count and asserts no blocks are consumed, grows it and asserts only the delta is charged, and asserts a grow whose total would exceed `max_blocks_per_seq` is rejected. The re-allocate leak assertion fails on the pre-fix code. It skips cleanly when no CUDA device is present.

## Notes

The existing callers (qwen35 generate/bench and the example) allocate `max_seq` once and then `free`, so they take the unchanged new-sequence path; only the grow-by-re-allocate case is affected.

Fixes #110

<details><summary>Notes I made while reviewing this</summary>

- **minor** `runtime/src/kv_cache.cpp:94` — `auto& blocks = impl_->seq_blocks[seq_id];` now runs before the `free_list.size() < need` check (it was after in the original). A failed grow for a brand-new seq_id therefore leaves a dangling empty vector in seq_blocks with no matching seq_slot entry.
- **minor** `runtime/src/kv_cache.cpp:96` — Grow-only semantics: when num_tokens shrinks (want < have), need is clamped to 0 and no blocks are returned to the free list. This is a deliberate and reasonable choice for a paged-grow API and matches the issue's framing, but the sequence keeps its peak footprint until free(). Worth a one-line comment if shrink-to-fit is ever expected.
- **minor** `runtime/src/kv_cache.cpp:94` — `auto& blocks = impl_->seq_blocks[seq_id];` now executes before the `free_list.size() < need` guard (the pre-fix code ran the free-list check first). A failed allocate due to block exhaustion therefore leaves an empty phantom vector in seq_blocks for that seq_id. It's benign — block_table()/free() key off seq_slot, not seq_blocks, and a later retry sees have=0 and works — but it is a slight behavior change on the failure path.

</details>

No GPU eval is requested: this is a correctness fix in the paged KV-cache allocator and makes no performance claim, so per CONTRIBUTING.md the proof-of-speedup section is omitted rather than left with an unticked box.
