### PR TITLE
fix(eval): disable llama.cpp embedded Web UI for headless server

### DIFF
--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -113,10 +113,15 @@ ensure_llamacpp() {  # $1 = arch ; builds llama-bench + llama-server, pinned + t
     echo ">> llama.cpp NOT pinned (warn-only) — HEAD $(git -C "$LLAMACPP_DIR" rev-parse --short HEAD 2>/dev/null); set LLAMACPP_COMMIT in reference.lock" >&2
     rm -rf "$bdir"
   fi
+  if [ -f "$bdir/CMakeCache.txt" ] && ! grep -q 'LLAMA_BUILD_UI:BOOL=OFF' "$bdir/CMakeCache.txt" 2>/dev/null; then
+    echo ">> llama.cpp reconfigure (LLAMA_BUILD_UI=OFF for headless server) ..." >&2
+    rm -f "$bdir/CMakeCache.txt"
+  fi
   if [ ! -f "$bdir/CMakeCache.txt" ]; then
     : > /tmp/llama_build.log
     if ! cmake -S "$LLAMACPP_DIR" -B "$bdir" -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="$arch" \
-          -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DLLAMA_BUILD_SERVER=ON $CUDA_HOST_FLAG >&2; then
+          -DCMAKE_BUILD_TYPE=Release -DLLAMA_CURL=OFF -DLLAMA_BUILD_SERVER=ON -DLLAMA_BUILD_UI=OFF \
+          $CUDA_HOST_FLAG >&2; then
       echo ">> FATAL: llama.cpp cmake configure failed" >&2; return 1
     fi
   fi


### PR DESCRIPTION
## Summary
- Set `LLAMA_BUILD_UI=OFF` when building pinned llama.cpp on eval boxes
- Reconfigure when an old cache has UI enabled
- Fixes `llama-server` build failure: `UI: llama-ui-embed failed — missing loading.html`

## Test plan
- [ ] `warm_llamacpp.sh` on eval box produces both `llama-bench` and `llama-server`
- [ ] Re-run eval bot with `--skip-baseline`