### PR TITLE
fix(eval): purge stale llama UI build and verify harness sync

### DIFF
--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -87,10 +87,31 @@ _llamacpp_clean() {  # $1=llama-bench  $2=sentinel
   [ -f "$2" ] && [ "$(sha256_of "$1")" = "$(cat "$2" 2>/dev/null)" ]
 }
 
+_llamacpp_binary_ok() {  # headless llama-bench is multi-MB; partial links are ~17KB
+  local f="$1" sz
+  [ -x "$f" ] || return 1
+  sz="$(stat -c%s "$f" 2>/dev/null || wc -c <"$f" 2>/dev/null || echo 0)"
+  [ "${sz:-0}" -gt 500000 ]
+}
+
+_llamacpp_purge_stale_build() {  # $1=bdir — drop UI tree when headless server build is required
+  local bdir="$1"
+  if [ -d "$bdir/tools/ui" ]; then
+    echo ">> llama.cpp purge stale UI build tree (headless server) ..." >&2
+    rm -rf "$bdir"
+    return 0
+  fi
+  if [ -f "$bdir/CMakeCache.txt" ] && ! grep -q 'LLAMA_BUILD_UI:BOOL=OFF' "$bdir/CMakeCache.txt" 2>/dev/null; then
+    echo ">> llama.cpp reconfigure (LLAMA_BUILD_UI=OFF for headless server) ..." >&2
+    rm -rf "$bdir"
+  fi
+}
+
 ensure_llamacpp() {  # $1 = arch ; builds llama-bench + llama-server, pinned + tamper-checked (C2)
   local bench="$LLAMACPP_DIR/build/bin/llama-bench" srv="$LLAMACPP_DIR/build/bin/llama-server"
   local sentinel="$LLAMACPP_DIR/.si_refhash"
   local arch="$1" bdir="$LLAMACPP_DIR/build"
+  [ -x "$bench" ] && ! _llamacpp_binary_ok "$bench" && { echo ">> WARN: llama-bench looks truncated — rebuild" >&2; rm -f "$bench"; }
   [ -x "$bench" ] && [ -x "$srv" ] && _llamacpp_clean "$bench" "$sentinel" && return 0
   echo ">> (re)building llama.cpp reference (CUDA sm_$arch) ..." >&2
   if [ -n "${LLAMACPP_COMMIT:-}" ]; then
@@ -113,10 +134,7 @@ ensure_llamacpp() {  # $1 = arch ; builds llama-bench + llama-server, pinned + t
     echo ">> llama.cpp NOT pinned (warn-only) — HEAD $(git -C "$LLAMACPP_DIR" rev-parse --short HEAD 2>/dev/null); set LLAMACPP_COMMIT in reference.lock" >&2
     rm -rf "$bdir"
   fi
-  if [ -f "$bdir/CMakeCache.txt" ] && ! grep -q 'LLAMA_BUILD_UI:BOOL=OFF' "$bdir/CMakeCache.txt" 2>/dev/null; then
-    echo ">> llama.cpp reconfigure (LLAMA_BUILD_UI=OFF for headless server) ..." >&2
-    rm -f "$bdir/CMakeCache.txt"
-  fi
+  _llamacpp_purge_stale_build "$bdir"
   if [ ! -f "$bdir/CMakeCache.txt" ]; then
     : > /tmp/llama_build.log
     if ! cmake -S "$LLAMACPP_DIR" -B "$bdir" -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES="$arch" \

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -18,7 +18,7 @@ it is stopped and a fresh box is provisioned via the vast API automatically; the
 
 Env: VAST_API_KEY, SSH_KEY, EVAL_TRANSPORT (vast|ssh), EVAL_SSH_HOST, EVAL_SSH_PORT, EVAL_REPO, VAST_INSTANCE_FILE.
 """
-import argparse, json, os, random, shlex, shutil, subprocess, sys, time
+import argparse, json, os, random, shlex, shutil, subprocess, sys, tempfile, time
 
 from ssh_box import ssh_box_arg, ssh_box_enabled
 
@@ -71,6 +71,7 @@ def push_bench_scripts(host, port):
     """Deploy bench/scripts harness to the eval box (prefer origin/main)."""
     tar_data = None
     source = "local checkout"
+    extract_root = "/root/sparkinfer/bench/scripts"
     # Prefer origin/main — local tree may be behind (stale harness skews baseline guards).
     subprocess.run(["git", "fetch", "-q", "origin", "main"], cwd=ROOT, capture_output=True, timeout=120)
     arch = subprocess.run(
@@ -79,7 +80,7 @@ def push_bench_scripts(host, port):
     if arch.returncode == 0 and arch.stdout:
         tar_data = arch.stdout
         source = "origin/main"
-        extract = "mkdir -p /root/sparkinfer && tar -xzf - -C /root/sparkinfer"
+        extract_root = "/root/sparkinfer"
     elif os.path.isdir(BENCH_SCRIPTS):
         tar = subprocess.run(
             ["tar", "-C", BENCH_SCRIPTS, "-czf", "-", "."],
@@ -88,18 +89,46 @@ def push_bench_scripts(host, port):
             print(f">> WARN: could not pack bench/scripts (rc={tar.returncode})")
             return
         tar_data = tar.stdout
-        extract = "mkdir -p /root/sparkinfer/bench/scripts && tar -xzf - -C /root/sparkinfer/bench/scripts"
     else:
         return
+    verify_marker = b"LLAMA_BUILD_UI=OFF"
+    tmp_path = ""
     try:
-        subprocess.run(
-            ["ssh", "-i", SSH_KEY, "-o", "StrictHostKeyChecking=accept-new", "-o", "BatchMode=yes",
-             "-o", "ServerAliveInterval=30", "-o", "ServerAliveCountMax=40",
-             "-p", str(port), f"root@{host}", extract],
-            input=tar_data, timeout=180, check=False)
+        with tempfile.NamedTemporaryFile(suffix=".tgz", delete=False) as tmp:
+            tmp.write(tar_data)
+            tmp_path = tmp.name
+        scp = subprocess.run(
+            ["scp", "-P", str(port), "-i", SSH_KEY, "-o", "StrictHostKeyChecking=accept-new",
+             "-o", "BatchMode=yes", tmp_path, f"root@{host}:/tmp/si_bench_scripts.tgz"],
+            capture_output=True, text=True, timeout=180)
+        if scp.returncode != 0:
+            print(f">> WARN: bench/scripts scp failed (rc={scp.returncode}): {scp.stderr[-500:]}")
+            return
+        extract = (
+            f"mkdir -p {shlex.quote(extract_root)} && "
+            "tar -xzf /tmp/si_bench_scripts.tgz "
+            f"-C {shlex.quote(extract_root)} && rm -f /tmp/si_bench_scripts.tgz"
+        )
+        r = sh(host, port, extract, timeout=120)
+        if r.returncode != 0:
+            print(f">> WARN: bench/scripts extract failed (rc={r.returncode}): {(r.stdout + r.stderr)[-500:]}")
+            return
+        if verify_marker in tar_data:
+            chk = sh(host, port,
+                     "grep -c 'LLAMA_BUILD_UI=OFF' /root/sparkinfer/bench/scripts/_common.sh",
+                     timeout=30)
+            if chk.returncode != 0 or not chk.stdout.strip().isdigit() or int(chk.stdout.strip()) < 1:
+                print(">> WARN: bench/scripts sync verify failed — box may run stale harness")
+                return
         print(f">> bench/scripts synced from {source}")
     except subprocess.TimeoutExpired:
         print(">> WARN: bench/scripts sync timed out — box may run stale harness")
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
 
 def sh(host, port, cmd, timeout=3600):


### PR DESCRIPTION
## Summary
- Switch `push_bench_scripts` from SSH stdin tar to scp+extract with post-sync verification (boxes were still running pre-#416 `_common.sh`)
- Purge `/workspace/.llamacpp/build/tools/ui` when headless `llama-server` is required
- Reject truncated `llama-bench` binaries (~17KB partial links) and force rebuild

## Test plan
- [ ] `./eval/run_bot.sh --skip-baseline` completes llama warm without `loading.html` UI errors
- [ ] Box `/root/sparkinfer/bench/scripts/_common.sh` contains `LLAMA_BUILD_UI=OFF` after sync
- [ ] Both `/workspace/.llamacpp/build/bin/llama-bench` and `llama-server` exist on eval box