### PR TITLE
Skip Qwen3.5 128k context eval for now

### DIFF
--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -2,16 +2,16 @@
 # Bidirectional evaluation: Qwen3.5-9B (Qwythos) and Qwen3.6-35B-A3B — one build, one box.
 #
 # Runs BOTH scoring directions in one submission:
-#   • score_qwen35 — optimize Qwen3.5 (128/4k/32k/64k/128k), guard Qwen3.6 (5 contexts)
-#   • score_qwen36 — optimize Qwen3.6 (5 contexts), guard Qwen3.5 (128/4k/32k/64k/128k)
+#   • score_qwen35 — optimize Qwen3.5 (128/4k/32k/64k), guard Qwen3.6 (5 contexts)
+#   • score_qwen36 — optimize Qwen3.6 (5 contexts), guard Qwen3.5 (128/4k/32k/64k)
 #
 #   bench/scripts/evaluate_bidir.sh [--ref GIT_REF] [--ceiling TPS]
 #
 # PRIMARY_QUANT: Q4_K_M (default) | Q8_0 | BF16
 #
 # Env (optional):
-#   SPARKINFER_P35_GUARD_*     Qwen3.5 same-box main decode tok/s (128/4k/32k/64k/128k)
-#   SPARKINFER_P35_GUARD_*_PP  Qwen3.5 same-box main prefill pp tok/s (4k/32k/64k/128k)
+#   SPARKINFER_P35_GUARD_*     Qwen3.5 same-box main decode tok/s (128/4k/32k/64k)
+#   SPARKINFER_P35_GUARD_*_PP  Qwen3.5 same-box main prefill pp tok/s (4k/32k/64k)
 #   SPARKINFER_P36_GUARD_*     Qwen3.6 same-box main tok/s (128/512/4k/16k/32k)
 #   SPARKINFER_G36_GUARD_*   Qwen3.6 guard baselines (for score_qwen35)
 #   SPARKINFER_G35_GUARD_*   Qwen3.5 guard baselines (for score_qwen36)
@@ -47,7 +47,7 @@ P36_TOK="${PRIMARY36_TOK_REPO:-Qwen/Qwen3.6-35B-A3B}"
 P36_DIR="${PRIMARY36_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}36}"
 
 QUANT="${PRIMARY_QUANT:-Q4_K_M}"
-echo ">> bidir: Qwen3.5=$P35_FILE (quant=$QUANT, ctx=128/4k/32k/64k/128k) + Qwen3.6=$P36_FILE (ctx=128/512/4k/16k/32k)" >&2
+echo ">> bidir: Qwen3.5=$P35_FILE (quant=$QUANT, ctx=128/4k/32k/64k) + Qwen3.6=$P36_FILE (ctx=128/512/4k/16k/32k)" >&2
 
 reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
 
@@ -115,7 +115,7 @@ run_model() {
     | sed -n 's/^RESULT_JSON //p' | tail -1
 }
 
-# Qwen3.5: score/guard at 128/4k/32k/64k/128k (skip 512 and 16k).
+# Qwen3.5: score/guard at 128/4k/32k/64k (skip 512, 16k, and 128k for now).
 Q35_CTX_ENVS=(
   SPARKINFER_SCORE_REPS=0
   SPARKINFER_GUARD_512_REPS=0
@@ -124,9 +124,11 @@ Q35_CTX_ENVS=(
   SPARKINFER_GUARD_4K_REPS=1
   SPARKINFER_GUARD_32K_REPS=1
   SPARKINFER_GUARD_64K_REPS=1
-  SPARKINFER_GUARD_128K_REPS=1
+  SPARKINFER_GUARD_128K_REPS=0
   SPARKINFER_GUARD_16K_BASELINE=0
   SPARKINFER_GUARD_512_BASELINE=0
+  SPARKINFER_GUARD_128K_BASELINE=0
+  SPARKINFER_GUARD_128K_PP_BASELINE=0
 )
 
 # Qwen3.6: full 5-context sweep.
@@ -183,9 +185,9 @@ if [ "${SPARKINFER_P36_GUARD_128_BASELINE:-0}" = "0" ]; then
 fi
 
 if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ]; then
-  echo ">> measuring Qwen3.5 same-box main (128/4k/32k/64k/128k) ..." >&2
+  echo ">> measuring Qwen3.5 same-box main (128/4k/32k/64k) ..." >&2
   P35_GGUF="${P35_DIR}/${P35_FILE}"
-  for ctx in 0 4096 32768 65536 131072; do
+  for ctx in 0 4096 32768 65536; do
     t="$(_bench_decode_tps "$P35_GGUF" "$ctx")"
     t="${t:-0}"
     case "$ctx" in
@@ -193,26 +195,24 @@ if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ]; then
       4096)   B35_4K="${t:-0}" ;;
       32768)  B35_32K="${t:-0}" ;;
       65536)  B35_64K="${t:-0}" ;;
-      131072) B35_128K="${t:-0}" ;;
     esac
   done
-  echo ">> Qwen3.5 main: 128=${B35_128:-0} 4k=${B35_4K:-0} 32k=${B35_32K:-0} 64k=${B35_64K:-0} 128k=${B35_128K:-0} tok/s" >&2
+  echo ">> Qwen3.5 main: 128=${B35_128:-0} 4k=${B35_4K:-0} 32k=${B35_32K:-0} 64k=${B35_64K:-0} tok/s" >&2
 fi
 
 if [ "${SPARKINFER_P35_GUARD_4K_PP_BASELINE:-0}" = "0" ]; then
-  echo ">> measuring Qwen3.5 same-box main prefill pp (4k/32k/64k/128k) ..." >&2
+  echo ">> measuring Qwen3.5 same-box main prefill pp (4k/32k/64k) ..." >&2
   P35_GGUF="${P35_DIR}/${P35_FILE}"
-  for ctx in 4096 32768 65536 131072; do
+  for ctx in 4096 32768 65536; do
     t="$(_bench_prefill_pp "$P35_GGUF" "$ctx")"
     t="${t:-0}"
     case "$ctx" in
       4096)   B35_4K_PP="${t:-0}" ;;
       32768)  B35_32K_PP="${t:-0}" ;;
       65536)  B35_64K_PP="${t:-0}" ;;
-      131072) B35_128K_PP="${t:-0}" ;;
     esac
   done
-  echo ">> Qwen3.5 prefill: 4k=${B35_4K_PP:-0} 32k=${B35_32K_PP:-0} 64k=${B35_64K_PP:-0} 128k=${B35_128K_PP:-0} pp tok/s" >&2
+  echo ">> Qwen3.5 prefill: 4k=${B35_4K_PP:-0} 32k=${B35_32K_PP:-0} 64k=${B35_64K_PP:-0} pp tok/s" >&2
 fi
 
 B36_128="${B36_128:-${SPARKINFER_P36_GUARD_128_BASELINE:-0}}"
@@ -279,8 +279,8 @@ def stub(tps, ctx128, ctx4k, ctx32k=0, ctx64k=0, ctx128k=0, ctx512=0, ctx16k=0,
             "guard_4k_pp_pass": True, "guard_32k_pp_pass": True,
             "guard_64k_pp_pass": True, "guard_128k_pp_pass": True,
             "eval_prefill": bool(float(pp4k or pp32k or pp64k or pp128k or 0) > 0)}
-s35 = stub("$B35_128", "$B35_128", "$B35_4K", "$B35_32K", "$B35_64K", "$B35_128K",
-           pp4k="$B35_4K_PP", pp32k="$B35_32K_PP", pp64k="$B35_64K_PP", pp128k="$B35_128K_PP")
+s35 = stub("$B35_128", "$B35_128", "$B35_4K", "$B35_32K", "$B35_64K",
+           pp4k="$B35_4K_PP", pp32k="$B35_32K_PP", pp64k="$B35_64K_PP")
 s36 = stub("$B36_128", "$B36_128", "$B36_4K", "$B36_32K", ctx512="$B36_512", ctx16k="$B36_16K")
 out = {"pass": True, "label": "BASELINE", "commit": commit, "mode": "bidir", "model": "bidir",
        "tps": s36["tps"], "top1": 1.0, "kl": 0.0, "primary_quant": quant,
@@ -300,20 +300,16 @@ PRIMARY35_JSON="$(run_model primary-qwen35 "$P35_FILE" "$P35_REPO" "$P35_TOK" 0 
   SPARKINFER_GUARD_4K_BASELINE="${B35_4K}" \
   SPARKINFER_GUARD_32K_BASELINE="${B35_32K}" \
   SPARKINFER_GUARD_64K_BASELINE="${B35_64K}" \
-  SPARKINFER_GUARD_128K_BASELINE="${B35_128K}" \
   SPARKINFER_GUARD_4K_PP_BASELINE="${B35_4K_PP}" \
   SPARKINFER_GUARD_32K_PP_BASELINE="${B35_32K_PP}" \
   SPARKINFER_GUARD_64K_PP_BASELINE="${B35_64K_PP}" \
-  SPARKINFER_GUARD_128K_PP_BASELINE="${B35_128K_PP}" \
   SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P35_LLAMA_128_BASELINE:-${QWEN35_9B_LLAMA_128:-0}}" \
   SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P35_LLAMA_4K_BASELINE:-${QWEN35_9B_LLAMA_4K:-0}}" \
   SPARKINFER_LLAMA_32K_BASELINE="${SPARKINFER_P35_LLAMA_32K_BASELINE:-${QWEN35_9B_LLAMA_32K:-0}}" \
   SPARKINFER_LLAMA_64K_BASELINE="${SPARKINFER_P35_LLAMA_64K_BASELINE:-${QWEN35_9B_LLAMA_64K:-0}}" \
-  SPARKINFER_LLAMA_128K_BASELINE="${SPARKINFER_P35_LLAMA_128K_BASELINE:-${QWEN35_9B_LLAMA_128K:-0}}" \
   SPARKINFER_LLAMA_4K_PP_BASELINE="${SPARKINFER_P35_LLAMA_4K_PP_BASELINE:-${QWEN35_9B_LLAMA_4K_PP:-0}}" \
   SPARKINFER_LLAMA_32K_PP_BASELINE="${SPARKINFER_P35_LLAMA_32K_PP_BASELINE:-${QWEN35_9B_LLAMA_32K_PP:-0}}" \
-  SPARKINFER_LLAMA_64K_PP_BASELINE="${SPARKINFER_P35_LLAMA_64K_PP_BASELINE:-${QWEN35_9B_LLAMA_64K_PP:-0}}" \
-  SPARKINFER_LLAMA_128K_PP_BASELINE="${SPARKINFER_P35_LLAMA_128K_PP_BASELINE:-${QWEN35_9B_LLAMA_128K_PP:-0}}")"
+  SPARKINFER_LLAMA_64K_PP_BASELINE="${SPARKINFER_P35_LLAMA_64K_PP_BASELINE:-${QWEN35_9B_LLAMA_64K_PP:-0}}")"
 
 GUARD36_JSON="$(run_model guard36 "$P36_FILE" "$P36_REPO" "$P36_TOK" 0 \
   MODELS_DIR="$P36_DIR" MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" \
@@ -348,8 +344,7 @@ GUARD35_JSON="$(run_model guard35 "$P35_FILE" "$P35_REPO" "$P35_TOK" 0 \
   SPARKINFER_GUARD_128_BASELINE="${G35_128}" \
   SPARKINFER_GUARD_4K_BASELINE="${G35_4K}" \
   SPARKINFER_GUARD_32K_BASELINE="${G35_32K}" \
-  SPARKINFER_GUARD_64K_BASELINE="${G35_64K}" \
-  SPARKINFER_GUARD_128K_BASELINE="${G35_128K}")"
+  SPARKINFER_GUARD_64K_BASELINE="${G35_64K}")"
 reap
 
 PRIMARY35_JSON="$PRIMARY35_JSON" GUARD36_JSON="$GUARD36_JSON" \

--- a/eval/README.md
+++ b/eval/README.md
@@ -74,7 +74,7 @@ Set `SPARKINFER_EVAL_MODE=short` or pass `--eval-mode short` to keep the legacy 
 `--bidir` (or `BIDIR=1` / legacy `TRIPLE=1` in `.env.eval`) scores **both directions** in one build:
 
 ```
-build once ─► score_qwen35  Qwythos-9B : 128/4k/32k/64k/128k speed + accuracy ─► eval-qwen35:<LABEL>
+build once ─► score_qwen35  Qwythos-9B : 128/4k/32k/64k speed + prefill pp ─► eval-qwen35:<LABEL>
            │              guard Qwen3.6  : 5 contexts ─► must NOT regress
            └► score_qwen36  Qwen3.6      : 128/512/4k/16k/32k ─► eval-qwen36:<LABEL>
                           guard Qwen3.5  : 128/512/4k ─► must NOT regress

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -138,8 +138,8 @@ def _apply_bidir_ctx_from_bres(bres, q36, q35):
         return True
 
     got36 = _fill(bres.get("score_qwen36"), q36, ("128", "512", "4k", "16k", "32k"))
-    got35 = _fill(bres.get("score_qwen35"), q35, ("128", "4k", "32k", "64k", "128k"))
-    _fill_pp(bres.get("score_qwen35"), q35, ("4k_pp", "32k_pp", "64k_pp", "128k_pp"))
+    got35 = _fill(bres.get("score_qwen35"), q35, ("128", "4k", "32k", "64k"))
+    _fill_pp(bres.get("score_qwen35"), q35, ("4k_pp", "32k_pp", "64k_pp"))
     return got36 and got35
 
 
@@ -714,7 +714,7 @@ def post_needs_bench_comment(repo, num):
             "until at least one does.\n\n**Decode** (end-to-end, not an isolated-kernel microbench):\n"
             "```bash\nbench/scripts/bench.sh --download            # baseline (before)\n"
             "bench/scripts/bench.sh --download            # your branch (after)\n```\n\n"
-            "**Prefill pp** (Qwythos — report your best of 4k/32k/64k/128k from the `prefill pp` "
+            "**Prefill pp** (Qwythos — report your best of 4k/32k/64k from the `prefill pp` "
             "line in bench output):\n```bash\nbench/scripts/bench.sh --download --ctx 4096   # try "
             "4096 / 32768 / 65536 / 131072\nbench/scripts/bench.sh --download --ctx 4096   # your "
             "branch\n```\n\nThen the bot greenlights it on the next poll and evaluates it on an "
@@ -940,7 +940,7 @@ def render(res, oid):
                          f"{res.get('tps')} tok/s (main was {res.get('frontier_tps','?')} tok/s).")
     if label == "REJECT" and res.get("auto_close"):
         note = "No context cleared the 2% significance gate while at least one context regressed. Auto-closing this PR."
-    target_note = ("128/512/4k/16k/32k guarded · Qwen3.5 prefill at 4k/32k/64k/128k · scored vs same-box main"
+    target_note = ("128/512/4k/16k/32k guarded · Qwen3.5 prefill at 4k/32k/64k · scored vs same-box main"
                    if res.get("eval_mode") == "longctx" and (res.get("score_qwen35") or {}).get("eval_prefill")
                    else "128/512/4k/16k/32k guarded · scored vs same-box main · strongest context scores"
                    if res.get("eval_mode") == "longctx" else "128-token decode scored vs same-box main")
@@ -966,21 +966,19 @@ CTX_SERIES = {
     131072: {"metric": "ctx_131072_tps", "guard": "guard_128k_baseline", "status": "longctx_128k_tps", "label": "128k", "color": "#17A2B8", "llama": 0, "note": "Qwythos long-context decode at 128k, ntg=128"},
 }
 # Qwen3.5 (Qwythos) per-context llama.cpp anchors — colors match CTX_SERIES.
-Q35_CTX_ORDER = ("128", "4k", "32k", "64k", "128k")
+Q35_CTX_ORDER = ("128", "4k", "32k", "64k")
 Q35_CTX_SERIES = {
     128:    {"label": "128",  "ref_tps": 220.84},
     4096:   {"label": "4k",   "ref_tps": 221.80},
     32768:  {"label": "32k",  "ref_tps": 221.11},
     65536:  {"label": "64k",  "ref_tps": 220.54},
-    131072: {"label": "128k", "ref_tps": 220.58},
 }
 # Qwen3.5 prefill pp anchors — pinned in bench/scripts/reference.lock (RTX 5090).
-Q35_PP_ORDER = ("4k", "32k", "64k", "128k")
+Q35_PP_ORDER = ("4k", "32k", "64k")
 Q35_PP_SERIES = {
     4096:   {"label": "4k",   "metric": "ctx_4096_pp_tps",  "ref_pp": 11104.62, "color": "#0E8A16"},
     32768:  {"label": "32k",  "metric": "ctx_32768_pp_tps", "ref_pp": 9772.31,  "color": "#6F42C1"},
     65536:  {"label": "64k",  "metric": "ctx_65536_pp_tps", "ref_pp": 8153.53,  "color": "#E67E22"},
-    131072: {"label": "128k", "metric": "ctx_131072_pp_tps", "ref_pp": 5999.59, "color": "#17A2B8"},
 }
 Q36_CTX_ORDER = ("128", "512", "4k", "16k", "32k")
 # Qwen3.6-35B-A3B llama.cpp decode refs (RTX 5090) — pinned in bench/scripts/reference.lock
@@ -2166,12 +2164,10 @@ def main():
               f"4k={QWEN36_BASE['4k']} 16k={QWEN36_BASE['16k']} 32k={QWEN36_BASE['32k']} tok/s")
         print(f"  Qwythos ({args.primary_quant}) same-box main: "
               f"128={QWYTHOS_BASE['128']} 4k={QWYTHOS_BASE['4k']} "
-              f"32k={QWYTHOS_BASE['32k']} 64k={QWYTHOS_BASE['64k']} "
-              f"128k={QWYTHOS_BASE['128k']} tok/s")
-        if any(QWYTHOS_BASE.get(k, 0) for k in ("4k_pp", "32k_pp", "64k_pp", "128k_pp")):
+              f"32k={QWYTHOS_BASE['32k']} 64k={QWYTHOS_BASE['64k']} tok/s")
+        if any(QWYTHOS_BASE.get(k, 0) for k in ("4k_pp", "32k_pp", "64k_pp")):
             print(f"  Qwythos prefill pp: 4k={QWYTHOS_BASE.get('4k_pp', 0)} "
-                  f"32k={QWYTHOS_BASE.get('32k_pp', 0)} 64k={QWYTHOS_BASE.get('64k_pp', 0)} "
-                  f"128k={QWYTHOS_BASE.get('128k_pp', 0)} pp tok/s")
+                  f"32k={QWYTHOS_BASE.get('32k_pp', 0)} 64k={QWYTHOS_BASE.get('64k_pp', 0)} pp tok/s")
 
     # Run all pending evals on the SAME instance: pass --keep so vast_eval.py never stops/destroys
     # the box mid-queue. The bot stops the instance once after ALL PRs finish (or if the instance

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -352,7 +352,7 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual(by["4k"], 295.0)
         self.assertEqual(by["32k"], 278.5)
         self.assertEqual(by["64k"], 260.0)
-        self.assertEqual(by["128k"], 230.0)
+        self.assertNotIn("128k", by)
         self.assertEqual(data["qwen35"]["prefill_frontier_pp"], 295.0)
         self.assertEqual(data["qwen35"]["prefill_label"], "M")
         bot._upsert_qwen35_pp(data, sub)


### PR DESCRIPTION
## Summary
- Qwen 3.5 bidir eval no longer benches or guards **128k** decode/prefill (128 / 4k / 32k / 64k unchanged).
- Baseline sweep, scoring envs, bot cache validation, and dashboard ctx/pp series aligned to skip 128k.

## Test plan
- [x] `python3 eval/test_pr_eval_bot.py` (44 tests pass)