### PR TITLE
fix(eval): purge llama build when server missing

### DIFF
--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -112,6 +112,12 @@ ensure_llamacpp() {  # $1 = arch ; builds llama-bench + llama-server, pinned + t
   local sentinel="$LLAMACPP_DIR/.si_refhash"
   local arch="$1" bdir="$LLAMACPP_DIR/build"
   [ -x "$bench" ] && ! _llamacpp_binary_ok "$bench" && { echo ">> WARN: llama-bench looks truncated — rebuild" >&2; rm -f "$bench"; }
+  # Stale partial trees (UI assets, old CMakeCache) leave llama-server broken while llama-bench exists.
+  if [ ! -x "$srv" ] && { [ -d "$bdir/tools/ui" ] || [ -f "$bdir/CMakeCache.txt" ]; }; then
+    echo ">> llama.cpp llama-server missing — purging stale build tree ..." >&2
+    rm -rf "$bdir"
+    rm -f "$sentinel"
+  fi
   [ -x "$bench" ] && [ -x "$srv" ] && _llamacpp_clean "$bench" "$sentinel" && return 0
   echo ">> (re)building llama.cpp reference (CUDA sm_$arch) ..." >&2
   if [ -n "${LLAMACPP_COMMIT:-}" ]; then

--- a/bench/scripts/warm_llamacpp.sh
+++ b/bench/scripts/warm_llamacpp.sh
@@ -7,6 +7,6 @@ source "$HERE/_common.sh"
 export LLAMACPP_DIR="${LLAMACPP_DIR:-/workspace/.llamacpp}"
 ARCH="$(detect_arch)"
 exec 9>/tmp/llamacpp_build.lock
-flock -n 9 || { echo ">> warm_llamacpp: another build holds /tmp/llamacpp_build.lock — skip" >&2; exit 0; }
+flock -n 9 || { echo ">> warm_llamacpp: another build holds /tmp/llamacpp_build.lock — abort" >&2; exit 1; }
 ensure_llamacpp "$ARCH"
 echo ">> warm_llamacpp: ready (sm_$ARCH)"


### PR DESCRIPTION
## Summary
- Purge `/workspace/.llamacpp/build` when `llama-server` is missing but a stale CMake/UI tree remains
- Make `warm_llamacpp.sh` exit non-zero when the flock is held (stop vast_eval proceeding with a broken reference)

## Test plan
- [ ] Warm on eval box produces both `llama-bench` and `llama-server` without `loading.html` UI errors
- [ ] PR #387 bidir eval completes with `RESULT_JSON`