### PR TITLE
fix(gguf): prevent integer overflow in rd_str bounds check

### DIFF
--- a/runtime/src/gguf.cpp
+++ b/runtime/src/gguf.cpp
@@ -27,7 +27,7 @@ int scalar_size(uint32_t t) {
 struct Cursor {
     const uint8_t* p; size_t off, size; bool ok = true;
     template <class T> T rd() { T v{}; if (off + sizeof(T) > size) { ok=false; return v; } memcpy(&v, p+off, sizeof(T)); off += sizeof(T); return v; }
-    std::string rd_str() { uint64_t n = rd<uint64_t>(); if (!ok || off+n>size) { ok=false; return {}; } std::string s((const char*)(p+off), n); off += n; return s; }
+    std::string rd_str() { uint64_t n = rd<uint64_t>(); if (!ok || n>size-off) { ok=false; return {}; } std::string s((const char*)(p+off), n); off += n; return s; }
     void skip(size_t n) { off += n; if (off > size) ok = false; }
 };
 


### PR DESCRIPTION
## Summary

Fix an integer-overflow in the GGUF metadata string reader (`Cursor::rd_str`) that lets a
malformed/hostile GGUF header trigger an out-of-bounds read. One-line change to the bounds check,
matching the overflow-safe subtraction form already used elsewhere in the same file.

## The bug

`runtime/src/gguf.cpp`, `Cursor::rd_str()`:

```cpp
std::string rd_str() { uint64_t n = rd<uint64_t>(); if (!ok || off+n>size) { ok=false; return {}; }
                       std::string s((const char*)(p+off), n); off += n; return s; }
```

`n` is a 64-bit length read straight from the file, and `off` is a `size_t`. The guard `off + n > size`
is an unsigned 64-bit addition that **wraps**: a crafted string length `n` near `UINT64_MAX` makes
`off + n` overflow to a small value `<= size`, so the check passes and
`std::string(p + off, n)` then constructs a multi-exabyte string, reading far past the end of the
mmap'd file → segfault / OOB read.

`rd_str()` is called on every metadata key and every string value (metadata loop, string-array
elements, and each tensor name), so the length is fully attacker-controlled header data.

## The fix

```diff
-    std::string rd_str() { uint64_t n = rd<uint64_t>(); if (!ok || off+n>size) { ok=false; return {}; } ...
+    std::string rd_str() { uint64_t n = rd<uint64_t>(); if (!ok || n>size-off) { ok=false; return {}; } ...
```

`size - off` cannot underflow: the guard is only reached when `ok` is true after `rd<uint64_t>()`,
which guarantees `off <= size`. The rewrite is the same overflow-safe idiom the file already uses:

- array payload guard (line ~88): `n > (c.size - c.off) / (size_t)es`
- tensor data-region guard (lines ~136–138): *"Written with subtraction so the address arithmetic
  itself cannot overflow."*

`rd_str` was simply the one call site that wasn't converted.

## Testing

Reasoned correctness only (no behavior change on any valid file; identical accept/reject decision for
every in-bounds length). No functional/runtime change to decode — this is a header-parse safety fix.

---

---
_Correctness / memory-safety fix — not a speedup, so no RTX-5090 benchmark applies (expected `eval:none`). Submitting per CONTRIBUTING's welcome of bug fixes; happy for a maintainer to keep it open for review._