### PR TITLE
fix(runtime): bound-check two latent out-of-bounds paths in moe/kv-cache

### DIFF
--- a/moe/src/engine.cpp
+++ b/moe/src/engine.cpp
@@ -53,6 +53,14 @@ public:
                     num_tokens, max_tokens_);
             return;
         }
+        if (layer < 0 || layer >= (int)weights_.size()) {
+            // weights_ is sized to num_layers; set_layer_weights() already bounds this same
+            // index, so guard forward() symmetrically — an out-of-range layer would be a
+            // std::vector OOB read yielding garbage device pointers passed to the kernels.
+            fprintf(stderr, "[moe] forward: layer %d out of range [0, %d) — skipping\n",
+                    layer, (int)weights_.size());
+            return;
+        }
         const LayerWeights& w = weights_[layer];
         const int E = cfg_.num_experts, K = cfg_.top_k;
         const int H = cfg_.hidden_dim, F = cfg_.ffn_dim;

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -84,9 +84,14 @@ KVCacheManager::~KVCacheManager() {
 bool KVCacheManager::allocate(uint64_t seq_id, int num_tokens) {
     const int need = (num_tokens + impl_->cfg.block_size - 1) / impl_->cfg.block_size;
     if ((int)impl_->free_list.size() < need || impl_->free_slots.empty()) return false;
-    if (need > kMaxBlocksPerSeq) return false;
 
     auto& blocks = impl_->seq_blocks[seq_id];
+    // allocate() is additive — it extends the sequence — so the cap must bound the
+    // CUMULATIVE block count, not just this call's `need`. Checking only `need` let a
+    // second allocate() for the same seq_id grow `blocks` past kMaxBlocksPerSeq and
+    // memcpy past its block-table row into the next sequence's row (cudaMemcpy below).
+    if ((int)blocks.size() + need > kMaxBlocksPerSeq) return false;
+
     for (int i = 0; i < need; i++) { blocks.push_back(impl_->free_list.back()); impl_->free_list.pop_back(); }
 
     int slot;


### PR DESCRIPTION
## Summary

Add bounds guards to two latent out-of-bounds paths in the runtime, each matching a check the
surrounding code already applies to a sibling parameter. No behavior change on any valid input.

## 1. `moe/src/engine.cpp` — `MoEEngineImpl::forward()` unchecked `layer`

`forward()` did `const LayerWeights& w = weights_[layer];` with no range check, even though
`set_layer_weights()` guards the *same* index (`if (layer >= 0 && layer < weights_.size())`). An
out-of-range `layer` is a `std::vector::operator[]` OOB read → a garbage `LayerWeights` whose
device pointers (`router_w`, `gate_w`, `up_w`, `down_w`) are passed straight into
`launch_moe_router_gemm` / `launch_moe_expert_ffn` → illegal memory access instead of a clean
diagnostic. Added a symmetric early-return guard identical in style to the `num_tokens` guard
already in the same function.

## 2. `runtime/src/kv_cache.cpp` — `KVCacheManager::allocate()` per-call vs cumulative cap

`allocate()` **extends** a sequence: it appends `need` blocks to `seq_blocks[seq_id]` and then
`cudaMemcpy`s `blocks.size()` block ids into a fixed `kMaxBlocksPerSeq`-wide row of
`d_block_tables`. The cap checked only this call's `need > kMaxBlocksPerSeq`, not the cumulative
size. Calling `allocate()` a second time for the same `seq_id` (the natural paged-KV grow
operation) can push `blocks.size()` past `kMaxBlocksPerSeq`, and the `cudaMemcpy` then writes past
the sequence's row into the **next** sequence's block table — silent device-side corruption.
Changed the cap to bound the cumulative count (`blocks.size() + need > kMaxBlocksPerSeq`).

## Impact

Both are **latent** in the current tree — callers pass valid layer indices, and the sequences are
allocated once rather than grown — so this is hardening, not a live-crash fix. But both are silent
memory corruption the moment those preconditions change (e.g. a decode loop that grows the KV cache
incrementally, or a model wired with a mismatched layer count). The guards make each fail loudly /
refuse instead.

## Testing

Reasoned correctness only — no valid-path behavior change (identical accept/reject for every in-range
input). No runtime/decode change to observe.

## Notes

- Could be split into two PRs if you'd prefer them separate; kept together as one "bound-check the
  latent OOBs" change since both are the same class of one-file defensive guard.
- Not a speedup → expected `eval:none`; needs a maintainer merge (RTX-5090 box left unticked, as
  this makes no speed claim).
