### PR TITLE
eval: load model once and sweep all bench contexts

### DIFF
--- a/bench/scripts/_eval_speed.sh
+++ b/bench/scripts/_eval_speed.sh
@@ -1,6 +1,57 @@
 # Shared decode + prefill speed helpers for evaluate.sh (sourced, not executed).
 # median_bench_metric CTX REPS PATTERN — median tok/s from qwen3_gguf_bench output lines.
 
+_BENCH_SWEEP_JSON=""
+
+bench_sweep_enabled() {
+  [ "${SPARKINFER_BENCH_SWEEP:-1}" != "0" ]
+}
+
+# Read decode_tps or prefill_pp for one context from cached SWEEP_JSON.
+_bench_sweep_get() {
+  local ctx="$1" field="$2"
+  python3 - "$ctx" "$field" "$_BENCH_SWEEP_JSON" <<'PY'
+import json, sys
+ctx, field, raw = sys.argv[1], sys.argv[2], sys.argv[3]
+try:
+    d = json.loads(raw)
+    row = d.get(str(ctx), {})
+    v = row.get(field, 0)
+    print(v if v else 0)
+except Exception:
+    print(0)
+PY
+}
+
+# One model load, many contexts. Args: GGUF N_TOKENS (CTX REPS)+
+bench_sweep_run() {
+  local gguf="$1" n_tokens="$2"
+  shift 2
+  local ctxs=() ctx reps max_reps=1
+  while [ $# -ge 2 ]; do
+    ctx="$1"; reps="$2"; shift 2
+    [ "${reps:-0}" -le 0 ] && continue
+    ctxs+=("$ctx")
+    [ "$reps" -gt "$max_reps" ] && max_reps="$reps"
+  done
+  [ ${#ctxs[@]} -eq 0 ] && { _BENCH_SWEEP_JSON=""; return 1; }
+  local csv
+  csv="$(printf '%s\n' "${ctxs[@]}" | sort -nu | paste -sd,)"
+  local out rc=0
+  export SPARKINFER_BENCH_SWEEP_CTXS="$csv"
+  export SPARKINFER_BENCH_SWEEP_REPS="$max_reps"
+  out="$(si_run qwen3_gguf_bench "$gguf" "$n_tokens" sweep 2>&1)" || rc=$?
+  _BENCH_SWEEP_JSON="$(printf '%s\n' "$out" | sed -n 's/^SWEEP_JSON //p' | tail -1)"
+  if [ "$rc" != 0 ] || [ -z "$_BENCH_SWEEP_JSON" ]; then
+    echo ">> WARN: bench sweep failed (rc=$rc): ${out##*$'\n'}" >&2
+    _BENCH_SWEEP_JSON=""
+    return 1
+  fi
+  gclks+=("$(nvidia-smi --query-gpu=clocks.gr --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')")
+  echo ">> bench sweep ok (${csv})" >&2
+  return 0
+}
+
 median_bench_metric() {
   local ctx="$1" reps="$2" pat="$3"
   local vals=() t rc out

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -141,21 +141,46 @@ else
   else
     echo ">> context policy: ${DECODE_TOKENS}-token decode at 128/512/4k/16k/32k/64k/128k (as configured); all measured contexts guarded; best context scores" >&2
   fi
-  si_run qwen3_gguf_bench "$GGUF" 64 "$GUARD_CTX" >/dev/null 2>&1 || true
-  GUARD_TPS="$(median_ctx "$GUARD_CTX" "$GUARD_REPS")"
-  GUARD_512_TPS="$(median_ctx "$GUARD_512_CTX" "$GUARD_512_REPS")"
-  GUARD_4K_TPS="$(median_ctx "$GUARD_4K_CTX" "$GUARD_4K_REPS")"
-  TPS="$(median_ctx "$SCORE_CTX" "$SCORE_REPS")"
-  GUARD_32K_TPS="$(median_ctx "$GUARD_32K_CTX" "$GUARD_32K_REPS")"
-  GUARD_64K_TPS="$(median_ctx "$GUARD_64K_CTX" "$GUARD_64K_REPS")"
-  GUARD_128K_TPS="$(median_ctx "$GUARD_128K_CTX" "$GUARD_128K_REPS")"
-  if [ "$EVAL_PREFILL" = "1" ]; then
-    GUARD_4K_PP_TPS="$(median_ctx_pp "$GUARD_4K_CTX" "$GUARD_4K_REPS")"
-    GUARD_32K_PP_TPS="$(median_ctx_pp "$GUARD_32K_CTX" "$GUARD_32K_REPS")"
-    GUARD_64K_PP_TPS="$(median_ctx_pp "$GUARD_64K_CTX" "$GUARD_64K_REPS")"
-    GUARD_128K_PP_TPS="$(median_ctx_pp "$GUARD_128K_CTX" "$GUARD_128K_REPS")"
+  if bench_sweep_enabled && bench_sweep_run "$GGUF" "$DECODE_TOKENS" \
+      "$GUARD_CTX" "$GUARD_REPS" \
+      "$GUARD_512_CTX" "$GUARD_512_REPS" \
+      "$GUARD_4K_CTX" "$GUARD_4K_REPS" \
+      "$SCORE_CTX" "$SCORE_REPS" \
+      "$GUARD_32K_CTX" "$GUARD_32K_REPS" \
+      "$GUARD_64K_CTX" "$GUARD_64K_REPS" \
+      "$GUARD_128K_CTX" "$GUARD_128K_REPS"; then
+    GUARD_TPS="$(_bench_sweep_get "$GUARD_CTX" decode_tps)"
+    GUARD_512_TPS="$(_bench_sweep_get "$GUARD_512_CTX" decode_tps)"
+    GUARD_4K_TPS="$(_bench_sweep_get "$GUARD_4K_CTX" decode_tps)"
+    TPS="$(_bench_sweep_get "$SCORE_CTX" decode_tps)"
+    GUARD_32K_TPS="$(_bench_sweep_get "$GUARD_32K_CTX" decode_tps)"
+    GUARD_64K_TPS="$(_bench_sweep_get "$GUARD_64K_CTX" decode_tps)"
+    GUARD_128K_TPS="$(_bench_sweep_get "$GUARD_128K_CTX" decode_tps)"
+    if [ "$EVAL_PREFILL" = "1" ]; then
+      GUARD_4K_PP_TPS="$(_bench_sweep_get "$GUARD_4K_CTX" prefill_pp)"
+      GUARD_32K_PP_TPS="$(_bench_sweep_get "$GUARD_32K_CTX" prefill_pp)"
+      GUARD_64K_PP_TPS="$(_bench_sweep_get "$GUARD_64K_CTX" prefill_pp)"
+      GUARD_128K_PP_TPS="$(_bench_sweep_get "$GUARD_128K_CTX" prefill_pp)"
+    else
+      GUARD_4K_PP_TPS=0; GUARD_32K_PP_TPS=0; GUARD_64K_PP_TPS=0; GUARD_128K_PP_TPS=0
+    fi
   else
-    GUARD_4K_PP_TPS=0; GUARD_32K_PP_TPS=0; GUARD_64K_PP_TPS=0; GUARD_128K_PP_TPS=0
+    si_run qwen3_gguf_bench "$GGUF" 64 "$GUARD_CTX" >/dev/null 2>&1 || true
+    GUARD_TPS="$(median_ctx "$GUARD_CTX" "$GUARD_REPS")"
+    GUARD_512_TPS="$(median_ctx "$GUARD_512_CTX" "$GUARD_512_REPS")"
+    GUARD_4K_TPS="$(median_ctx "$GUARD_4K_CTX" "$GUARD_4K_REPS")"
+    TPS="$(median_ctx "$SCORE_CTX" "$SCORE_REPS")"
+    GUARD_32K_TPS="$(median_ctx "$GUARD_32K_CTX" "$GUARD_32K_REPS")"
+    GUARD_64K_TPS="$(median_ctx "$GUARD_64K_CTX" "$GUARD_64K_REPS")"
+    GUARD_128K_TPS="$(median_ctx "$GUARD_128K_CTX" "$GUARD_128K_REPS")"
+    if [ "$EVAL_PREFILL" = "1" ]; then
+      GUARD_4K_PP_TPS="$(median_ctx_pp "$GUARD_4K_CTX" "$GUARD_4K_REPS")"
+      GUARD_32K_PP_TPS="$(median_ctx_pp "$GUARD_32K_CTX" "$GUARD_32K_REPS")"
+      GUARD_64K_PP_TPS="$(median_ctx_pp "$GUARD_64K_CTX" "$GUARD_64K_REPS")"
+      GUARD_128K_PP_TPS="$(median_ctx_pp "$GUARD_128K_CTX" "$GUARD_128K_REPS")"
+    else
+      GUARD_4K_PP_TPS=0; GUARD_32K_PP_TPS=0; GUARD_64K_PP_TPS=0; GUARD_128K_PP_TPS=0
+    fi
   fi
   GUARD_RATIO="$(python3 - <<PY
 base=float("$GUARD_BASELINE")

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -18,6 +18,7 @@
 set -euo pipefail
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$HERE/_common.sh"
+source "$HERE/_eval_speed.sh"
 source "$HERE/_qwythos.sh"
 
 REF=""; CEILING=0; BASELINE_ONLY=0
@@ -168,50 +169,71 @@ _bench_prefill_pp() {
 }
 
 if [ "${SPARKINFER_P36_GUARD_128_BASELINE:-0}" = "0" ]; then
-  echo ">> measuring Qwen3.6 same-box main (5 contexts) ..." >&2
+  echo ">> measuring Qwen3.6 same-box main (5 contexts, one load) ..." >&2
   P36_GGUF="${P36_DIR}/${P36_FILE}"
-  for ctx in 0 512 4096 16384 32768; do
-    t="$(_bench_decode_tps "$P36_GGUF" "$ctx")"
-    t="${t:-0}"
-    case "$ctx" in
-      0)     B36_128="${t:-0}" ;;
-      512)   B36_512="${t:-0}" ;;
-      4096)  B36_4K="${t:-0}" ;;
-      16384) B36_16K="${t:-0}" ;;
-      32768) B36_32K="${t:-0}" ;;
-    esac
-  done
+  if bench_sweep_enabled && bench_sweep_run "$P36_GGUF" 128 0 1 512 1 4096 1 16384 1 32768 1; then
+    B36_128="$(_bench_sweep_get 0 decode_tps)"
+    B36_512="$(_bench_sweep_get 512 decode_tps)"
+    B36_4K="$(_bench_sweep_get 4096 decode_tps)"
+    B36_16K="$(_bench_sweep_get 16384 decode_tps)"
+    B36_32K="$(_bench_sweep_get 32768 decode_tps)"
+  else
+    for ctx in 0 512 4096 16384 32768; do
+      t="$(_bench_decode_tps "$P36_GGUF" "$ctx")"
+      t="${t:-0}"
+      case "$ctx" in
+        0)     B36_128="${t:-0}" ;;
+        512)   B36_512="${t:-0}" ;;
+        4096)  B36_4K="${t:-0}" ;;
+        16384) B36_16K="${t:-0}" ;;
+        32768) B36_32K="${t:-0}" ;;
+      esac
+    done
+  fi
   echo ">> Qwen3.6 main: 128=${B36_128:-0} 512=${B36_512:-0} 4k=${B36_4K:-0} 16k=${B36_16K:-0} 32k=${B36_32K:-0} tok/s" >&2
 fi
 
-if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ]; then
-  echo ">> measuring Qwen3.5 same-box main (128/4k/32k/64k) ..." >&2
+if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ] || [ "${SPARKINFER_P35_GUARD_4K_PP_BASELINE:-0}" = "0" ]; then
+  echo ">> measuring Qwen3.5 same-box main (decode + prefill, one load) ..." >&2
   P35_GGUF="${P35_DIR}/${P35_FILE}"
-  for ctx in 0 4096 32768 65536; do
-    t="$(_bench_decode_tps "$P35_GGUF" "$ctx")"
-    t="${t:-0}"
-    case "$ctx" in
-      0)      B35_128="${t:-0}" ;;
-      4096)   B35_4K="${t:-0}" ;;
-      32768)  B35_32K="${t:-0}" ;;
-      65536)  B35_64K="${t:-0}" ;;
-    esac
-  done
+  if bench_sweep_enabled && bench_sweep_run "$P35_GGUF" 128 0 1 4096 1 32768 1 65536 1; then
+    if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ]; then
+      B35_128="$(_bench_sweep_get 0 decode_tps)"
+      B35_4K="$(_bench_sweep_get 4096 decode_tps)"
+      B35_32K="$(_bench_sweep_get 32768 decode_tps)"
+      B35_64K="$(_bench_sweep_get 65536 decode_tps)"
+    fi
+    if [ "${SPARKINFER_P35_GUARD_4K_PP_BASELINE:-0}" = "0" ]; then
+      B35_4K_PP="$(_bench_sweep_get 4096 prefill_pp)"
+      B35_32K_PP="$(_bench_sweep_get 32768 prefill_pp)"
+      B35_64K_PP="$(_bench_sweep_get 65536 prefill_pp)"
+    fi
+  else
+    if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ]; then
+      for ctx in 0 4096 32768 65536; do
+        t="$(_bench_decode_tps "$P35_GGUF" "$ctx")"
+        t="${t:-0}"
+        case "$ctx" in
+          0)      B35_128="${t:-0}" ;;
+          4096)   B35_4K="${t:-0}" ;;
+          32768)  B35_32K="${t:-0}" ;;
+          65536)  B35_64K="${t:-0}" ;;
+        esac
+      done
+    fi
+    if [ "${SPARKINFER_P35_GUARD_4K_PP_BASELINE:-0}" = "0" ]; then
+      for ctx in 4096 32768 65536; do
+        t="$(_bench_prefill_pp "$P35_GGUF" "$ctx")"
+        t="${t:-0}"
+        case "$ctx" in
+          4096)   B35_4K_PP="${t:-0}" ;;
+          32768)  B35_32K_PP="${t:-0}" ;;
+          65536)  B35_64K_PP="${t:-0}" ;;
+        esac
+      done
+    fi
+  fi
   echo ">> Qwen3.5 main: 128=${B35_128:-0} 4k=${B35_4K:-0} 32k=${B35_32K:-0} 64k=${B35_64K:-0} tok/s" >&2
-fi
-
-if [ "${SPARKINFER_P35_GUARD_4K_PP_BASELINE:-0}" = "0" ]; then
-  echo ">> measuring Qwen3.5 same-box main prefill pp (4k/32k/64k) ..." >&2
-  P35_GGUF="${P35_DIR}/${P35_FILE}"
-  for ctx in 4096 32768 65536; do
-    t="$(_bench_prefill_pp "$P35_GGUF" "$ctx")"
-    t="${t:-0}"
-    case "$ctx" in
-      4096)   B35_4K_PP="${t:-0}" ;;
-      32768)  B35_32K_PP="${t:-0}" ;;
-      65536)  B35_64K_PP="${t:-0}" ;;
-    esac
-  done
   echo ">> Qwen3.5 prefill: 4k=${B35_4K_PP:-0} 32k=${B35_32K_PP:-0} 64k=${B35_64K_PP:-0} pp tok/s" >&2
 fi
 

--- a/bench/scripts/test_bench_sweep.py
+++ b/bench/scripts/test_bench_sweep.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Unit tests for bench sweep JSON parsing (_eval_speed.sh helper logic).
+
+Run from the repo root:
+  python3 bench/scripts/test_bench_sweep.py
+"""
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EVAL_SPEED = ROOT / "bench" / "scripts" / "_eval_speed.sh"
+
+
+def sweep_get(ctx: int, field: str, raw: str) -> float:
+    cmd = [
+        "bash", "-c",
+        f'source "{EVAL_SPEED}"; _BENCH_SWEEP_JSON="$1"; _bench_sweep_get "$2" "$3"',
+        "_",
+        raw,
+        str(ctx),
+        field,
+    ]
+    out = subprocess.check_output(cmd, text=True).strip()
+    return float(out)
+
+
+class BenchSweepParseTest(unittest.TestCase):
+    def test_decode_and_prefill(self):
+        raw = json.dumps({
+            "0": {"decode_tps": 350.5, "prefill_pp": 0.0},
+            "4096": {"decode_tps": 290.1, "prefill_pp": 1200.3},
+            "32768": {"decode_tps": 192.0, "prefill_pp": 450.7},
+        }, separators=(",", ":"))
+        self.assertAlmostEqual(sweep_get(0, "decode_tps", raw), 350.5)
+        self.assertAlmostEqual(sweep_get(4096, "prefill_pp", raw), 1200.3)
+        self.assertAlmostEqual(sweep_get(99999, "decode_tps", raw), 0.0)
+
+    def test_malformed_json(self):
+        self.assertEqual(sweep_get(0, "decode_tps", "not-json"), 0.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -2,9 +2,14 @@
 // Reports steady-state single-stream generation tokens/sec, to compare against
 // llama.cpp's `llama-bench` tg number on the same model + GPU.
 //
-// Usage: qwen3_gguf_bench <model.gguf | weight_dir> [n_tokens] [context_tokens]
-//   *.gguf  -> native load (experts kept quantized, Q4_K_M-sized)
-//   dir     -> bf16 weights from convert_gguf.py (reads config.txt)
+// Single context:
+//   qwen3_gguf_bench <model.gguf | weight_dir> [n_tokens] [context_tokens]
+//
+// Multi-context sweep (one load, many contexts) — set SPARKINFER_BENCH_SWEEP_CTXS:
+//   qwen3_gguf_bench <model> [n_tokens] sweep
+//   SPARKINFER_BENCH_SWEEP_CTXS=0,4096,32768,65536
+//
+// Sweep prints human-readable lines per context plus a final SWEEP_JSON line.
 
 #include "sparkinfer/runtime.h"
 #include "sparkinfer/kv_cache.h"
@@ -17,83 +22,231 @@
 #include <cstdio>
 #include <cstdlib>
 #include <string>
+#include <vector>
 #include <fstream>
 #include <unordered_map>
 #include <algorithm>
+#include <memory>
 
 static bool ends_with(const std::string& s, const std::string& suf) {
     return s.size() >= suf.size() && s.compare(s.size() - suf.size(), suf.size(), suf) == 0;
 }
 
-int main(int argc, char** argv) {
-    if (argc < 2) { printf("usage: %s <model.gguf|weight_dir> [n_tokens] [context_tokens]\n", argv[0]); return 2; }
-    int ndev = 0;
-    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) { printf("[SKIP] no GPU\n"); return 0; }
-    const std::string path = argv[1];
-    const int n_tokens = argc > 2 ? atoi(argv[2]) : 64;
-    const int context_tokens = argc > 3 ? atoi(argv[3]) : 0;
-    const bool gguf_mode = ends_with(path, ".gguf");
-
-    sparkinfer::Qwen35Config cfg;
-    if (gguf_mode) {
-        sparkinfer::GGUF g; if (!g.open(path)) { printf("[FAIL] open gguf\n"); return 1; }
-        qwen3_config_from_gguf(g, cfg);
-    } else {
-        std::ifstream f(path + "/config.txt"); std::string line;
-        std::unordered_map<std::string,std::string> m;
-        while (std::getline(f, line)) { auto p=line.find('='); if(p!=std::string::npos) m[line.substr(0,p)]=line.substr(p+1); }
-        auto gi=[&](const char*k,int d){auto it=m.find(k);return it==m.end()?d:atoi(it->second.c_str());};
-        auto gf=[&](const char*k,float d){auto it=m.find(k);return it==m.end()?d:(float)atof(it->second.c_str());};
-        cfg.vocab=gi("vocab",151936); cfg.hidden=gi("hidden",2048); cfg.n_layers=gi("n_layers",48);
-        cfg.n_q_heads=gi("n_q_heads",32); cfg.n_kv_heads=gi("n_kv_heads",4); cfg.head_dim=gi("head_dim",128);
-        cfg.n_experts=gi("n_experts",128); cfg.top_k=gi("top_k",8); cfg.n_shared=gi("n_shared",0);
-        cfg.moe_ffn=gi("moe_ffn",768); cfg.rope_theta=gf("rope_theta",1e6f); cfg.rms_eps=gf("rms_eps",1e-6f);
+static std::vector<int> parse_ctx_list(const char* csv) {
+    std::vector<int> out;
+    if (!csv || !*csv) return out;
+    const char* p = csv;
+    while (*p) {
+        char* end = nullptr;
+        long v = strtol(p, &end, 10);
+        if (end == p) break;
+        out.push_back((int)v);
+        p = end;
+        while (*p == ',' || *p == ' ') p++;
     }
-    cfg.max_seq = std::max(2048, context_tokens + n_tokens + 16);
+    std::sort(out.begin(), out.end());
+    out.erase(std::unique(out.begin(), out.end()), out.end());
+    return out;
+}
+
+struct SweepRow {
+    int ctx = 0;
+    double decode_tps = 0.0;
+    double prefill_pp = 0.0;
+};
+
+static double median_val(std::vector<double> v) {
+    if (v.empty()) return 0.0;
+    std::sort(v.begin(), v.end());
+    return v[(v.size() - 1) / 2];
+}
+
+static void print_bench_block(const sparkinfer::Qwen35Config& cfg, bool gguf_mode,
+                              size_t vram_used, int n_tokens, const SweepRow& row) {
+    printf("\n=== sparkinfer bench (%s) sweep ctx=%d ===\n",
+           gguf_mode ? "Q4_K_M native" : "bf16", row.ctx);
+    printf("model        : %d layers, %d experts top-%d\n",
+           cfg.n_layers, cfg.n_experts, cfg.top_k);
+    printf("VRAM used    : %.1f GB\n", vram_used / 1e9);
+    printf("max seq      : %d\n", cfg.max_seq);
+    printf("decode tg    : %.2f tok/s  (n=%d, ctx=%d, bs=1)\n",
+           row.decode_tps, n_tokens, row.ctx);
+    if (row.ctx > 0)
+        printf("prefill pp   : %.2f tok/s  (ctx=%d, sequential KV fill)\n",
+               row.prefill_pp, row.ctx);
+}
+
+struct BenchSession {
+    sparkinfer::Qwen35Config cfg{};
+    bool gguf_mode = false;
+    std::unique_ptr<sparkinfer::Runtime> rt;
+    std::unique_ptr<sparkinfer::KVCacheManager> kv;
+    std::unique_ptr<sparkinfer::moe::MoEEngine> engine;
+    std::unique_ptr<sparkinfer::Qwen35Model> model;
+    size_t vram_used = 0;
+};
+
+static bool init_session(BenchSession& s, const std::string& path, int max_ctx, int n_tokens) {
+    s.gguf_mode = ends_with(path, ".gguf");
+    if (s.gguf_mode) {
+        sparkinfer::GGUF g;
+        if (!g.open(path)) { printf("[FAIL] open gguf\n"); return false; }
+        qwen3_config_from_gguf(g, s.cfg);
+    } else {
+        std::ifstream f(path + "/config.txt");
+        std::string line;
+        std::unordered_map<std::string, std::string> m;
+        while (std::getline(f, line)) {
+            auto p = line.find('=');
+            if (p != std::string::npos) m[line.substr(0, p)] = line.substr(p + 1);
+        }
+        auto gi = [&](const char* k, int d) {
+            auto it = m.find(k); return it == m.end() ? d : atoi(it->second.c_str());
+        };
+        auto gf = [&](const char* k, float d) {
+            auto it = m.find(k); return it == m.end() ? d : (float)atof(it->second.c_str());
+        };
+        s.cfg.vocab = gi("vocab", 151936); s.cfg.hidden = gi("hidden", 2048);
+        s.cfg.n_layers = gi("n_layers", 48); s.cfg.n_q_heads = gi("n_q_heads", 32);
+        s.cfg.n_kv_heads = gi("n_kv_heads", 4); s.cfg.head_dim = gi("head_dim", 128);
+        s.cfg.n_experts = gi("n_experts", 128); s.cfg.top_k = gi("top_k", 8);
+        s.cfg.n_shared = gi("n_shared", 0); s.cfg.moe_ffn = gi("moe_ffn", 768);
+        s.cfg.rope_theta = gf("rope_theta", 1e6f); s.cfg.rms_eps = gf("rms_eps", 1e-6f);
+    }
+    s.cfg.max_seq = std::max(2048, max_ctx + n_tokens + 16);
     if (const char* e = getenv("SPARKINFER_BENCH_MAX_SEQ")) {
         int v = atoi(e);
-        if (v > cfg.max_seq) cfg.max_seq = v;
+        if (v > s.cfg.max_seq) s.cfg.max_seq = v;
     }
 
-    auto rt = sparkinfer::Runtime::create({}); rt->initialize();
+    s.rt = sparkinfer::Runtime::create({});
+    s.rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers=cfg.n_layers; kvc.num_kv_heads=cfg.n_kv_heads; kvc.head_dim=cfg.head_dim; kvc.block_size=16;
-    // int8 KV pays off once the halved long-context KV read outweighs per-token write cost.
-    // Enable context-adaptively (>= 4k) by default; 128/512 stay bf16 (no short-ctx regression).
-    // SPARKINFER_KV_INT8=1/0 forces it on/off regardless.
-    // Context-adaptive int8 KV (>= 4k) for hybrid hd256 full-attn (int8 flash-decode + partial-RoPE).
-    { const char* e8 = getenv("SPARKINFER_KV_INT8");
-      kvc.int8_kv = e8 ? (e8[0] != '0') : (context_tokens >= 4096); }
-    const size_t epb=(size_t)16*cfg.n_kv_heads*cfg.head_dim, blocks=(cfg.max_seq+15)/16+8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers*2*epb*2*blocks);
+    kvc.num_layers = s.cfg.n_layers;
+    kvc.num_kv_heads = s.cfg.n_kv_heads;
+    kvc.head_dim = s.cfg.head_dim;
+    kvc.block_size = 16;
+    const char* e8 = getenv("SPARKINFER_KV_INT8");
+    kvc.int8_kv = e8 ? (e8[0] != '0') : (max_ctx >= 4096);
+    const size_t epb = (size_t)16 * s.cfg.n_kv_heads * s.cfg.head_dim;
+    const size_t blocks = (s.cfg.max_seq + 15) / 16 + 8;
+    s.kv = std::make_unique<sparkinfer::KVCacheManager>(
+        kvc, (size_t)s.cfg.n_layers * 2 * epb * 2 * blocks);
     sparkinfer::moe::MoEConfig mc;
-    mc.num_experts=cfg.n_experts; mc.top_k=cfg.top_k; mc.hidden_dim=cfg.hidden; mc.ffn_dim=cfg.moe_ffn; mc.num_layers=cfg.n_layers;
-    auto engine = sparkinfer::moe::MoEEngine::create(mc);
+    mc.num_experts = s.cfg.n_experts; mc.top_k = s.cfg.top_k;
+    mc.hidden_dim = s.cfg.hidden; mc.ffn_dim = s.cfg.moe_ffn;
+    mc.num_layers = s.cfg.n_layers;
+    s.engine = sparkinfer::moe::MoEEngine::create(mc);
+    s.model = std::make_unique<sparkinfer::Qwen35Model>(s.cfg, s.kv.get(), s.engine.get());
 
-    sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
-    printf("loading %s (%s) ...\n", path.c_str(), gguf_mode ? "native GGUF, experts quantized" : "bf16");
-    bool ok = gguf_mode ? model.load_gguf(path) : model.load_weights(path);
-    if (!ok) { printf("[FAIL] load\n"); return 1; }
-    size_t freeb=0, totb=0; cudaMemGetInfo(&freeb,&totb);
+    printf("loading %s (%s) ...\n", path.c_str(),
+           s.gguf_mode ? "native GGUF, experts quantized" : "bf16");
+    bool ok = s.gguf_mode ? s.model->load_gguf(path) : s.model->load_weights(path);
+    if (!ok) { printf("[FAIL] load\n"); return false; }
+    size_t freeb = 0, totb = 0;
+    cudaMemGetInfo(&freeb, &totb);
+    s.vram_used = totb - freeb;
+    return true;
+}
 
-    auto bench = model.bench_decode(8, n_tokens, context_tokens);
-    double toks = bench.decode_tps;
-    auto gpu = sparkinfer::query_gpu_stats();   // sampled right after the decode loop — near peak heat
-    printf("\n=== sparkinfer bench (%s) ===\n", gguf_mode ? "Q4_K_M native" : "bf16");
+static int run_single(const std::string& path, int n_tokens, int context_tokens) {
+    BenchSession s;
+    if (!init_session(s, path, context_tokens, n_tokens)) return 1;
+    auto bench = s.model->bench_decode(8, n_tokens, context_tokens);
+  auto gpu = sparkinfer::query_gpu_stats();
+    printf("\n=== sparkinfer bench (%s) ===\n", s.gguf_mode ? "Q4_K_M native" : "bf16");
     printf("model        : %s  (%d layers, %d experts top-%d)\n",
-           qwen3_model_label(cfg), cfg.n_layers, cfg.n_experts, cfg.top_k);
-    printf("VRAM used    : %.1f GB\n", (totb - freeb) / 1e9);
-    printf("max seq      : %d\n", cfg.max_seq);
+           qwen3_model_label(s.cfg), s.cfg.n_layers, s.cfg.n_experts, s.cfg.top_k);
+    printf("VRAM used    : %.1f GB\n", s.vram_used / 1e9);
+    printf("max seq      : %d\n", s.cfg.max_seq);
     printf("decode tg    : %.2f tok/s  (%.1f ms/token, n=%d, ctx=%d, bs=1)\n",
-           toks, toks > 0 ? 1000.0 / toks : 0.0, n_tokens, context_tokens);
+           bench.decode_tps, bench.decode_tps > 0 ? 1000.0 / bench.decode_tps : 0.0,
+           n_tokens, context_tokens);
     if (context_tokens > 0)
         printf("prefill pp   : %.2f tok/s  (ctx=%d, sequential KV fill)\n",
                bench.prefill_pp, context_tokens);
     if (gpu.valid && gpu.temp_c >= 0) {
         printf("GPU          : %d°C", gpu.temp_c);
-        if (gpu.power_w      >= 0) printf(" · %d W", gpu.power_w);
+        if (gpu.power_w >= 0) printf(" · %d W", gpu.power_w);
         if (gpu.sm_clock_mhz >= 0) printf(" · %d MHz", gpu.sm_clock_mhz);
         printf(" (peak under load)\n");
     }
     return 0;
+}
+
+static int run_sweep(const std::string& path, int n_tokens, const std::vector<int>& ctxs) {
+    if (ctxs.empty()) { fprintf(stderr, "[FAIL] empty sweep ctx list\n"); return 1; }
+    const int max_ctx = *std::max_element(ctxs.begin(), ctxs.end());
+    BenchSession s;
+    if (!init_session(s, path, max_ctx, n_tokens)) return 1;
+
+    int reps = 1;
+    if (const char* er = getenv("SPARKINFER_BENCH_SWEEP_REPS")) reps = std::max(1, atoi(er));
+
+    printf(">> sweep: %zu contexts, one model load (max_ctx=%d, n=%d, reps=%d)\n",
+           ctxs.size(), max_ctx, n_tokens, reps);
+
+    // Clock / cache warmup (not scored).
+    s.model->bench_decode(8, 64, 0);
+
+    std::vector<SweepRow> rows;
+    rows.reserve(ctxs.size());
+    for (int ctx : ctxs) {
+        std::vector<double> dec, pp;
+        for (int r = 0; r < reps; r++) {
+            auto b = s.model->bench_decode(8, n_tokens, ctx);
+            dec.push_back(b.decode_tps);
+            pp.push_back(b.prefill_pp);
+        }
+        SweepRow row;
+        row.ctx = ctx;
+        row.decode_tps = median_val(dec);
+        row.prefill_pp = ctx > 0 ? median_val(pp) : 0.0;
+        rows.push_back(row);
+        print_bench_block(s.cfg, s.gguf_mode, s.vram_used, n_tokens, row);
+    }
+
+    auto gpu = sparkinfer::query_gpu_stats();
+    if (gpu.valid && gpu.temp_c >= 0) {
+        printf("GPU          : %d°C", gpu.temp_c);
+        if (gpu.power_w >= 0) printf(" · %d W", gpu.power_w);
+        if (gpu.sm_clock_mhz >= 0) printf(" · %d MHz", gpu.sm_clock_mhz);
+        printf(" (peak under load)\n");
+    }
+
+    printf("SWEEP_JSON {");
+    for (size_t i = 0; i < rows.size(); i++) {
+        if (i) printf(",");
+        printf("\"%d\":{\"decode_tps\":%.4f,\"prefill_pp\":%.4f}",
+               rows[i].ctx, rows[i].decode_tps, rows[i].prefill_pp);
+    }
+    printf("}\n");
+    return 0;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        printf("usage: %s <model.gguf|weight_dir> [n_tokens] [context_tokens|sweep]\n", argv[0]);
+        printf("  sweep: SPARKINFER_BENCH_SWEEP_CTXS=0,4096,... %s <model> [n_tokens] sweep\n", argv[0]);
+        return 2;
+    }
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no GPU\n");
+        return 0;
+    }
+    const std::string path = argv[1];
+    const int n_tokens = argc > 2 ? atoi(argv[2]) : 64;
+    const bool sweep_mode = (argc > 3 && std::string(argv[3]) == "sweep") ||
+                            (getenv("SPARKINFER_BENCH_SWEEP_CTXS") && argc <= 3);
+    if (sweep_mode) {
+        const char* csv = getenv("SPARKINFER_BENCH_SWEEP_CTXS");
+        if (!csv || !*csv) {
+            fprintf(stderr, "[FAIL] sweep requires SPARKINFER_BENCH_SWEEP_CTXS\n");
+            return 1;
+        }
+        return run_sweep(path, n_tokens, parse_ctx_list(csv));
+    }
+    const int context_tokens = argc > 3 ? atoi(argv[3]) : 0;
+    return run_single(path, n_tokens, context_tokens);
 }

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1033,6 +1033,15 @@ int Qwen35Model::forward_token(int token_id, int position) {
 Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int context_tokens) {
     BenchDecodeResult out{};
     Impl& s = *p_;
+    static int last_bench_ctx = -1;
+    if (context_tokens != last_bench_ctx && s.graph_ready) {
+        cudaGraphExecDestroy(s.cu_exec);
+        cudaGraphDestroy(s.cu_graph);
+        s.cu_exec = nullptr;
+        s.cu_graph = nullptr;
+        s.graph_ready = false;
+    }
+    last_bench_ctx = context_tokens;
     if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) { fprintf(stderr, "[bench] kv allocate failed\n"); return out; }
     int start_pos = context_tokens;
     if (const char* e = getenv("SPARKINFER_BENCH_START_POS")) {


### PR DESCRIPTION
## Summary
- Add multi-context sweep mode to `qwen3_gguf_bench` (one GGUF load, ascending ctx sweep, `SWEEP_JSON` output)
- Wire `evaluate.sh` and `evaluate_bidir.sh` to use sweep by default (`SPARKINFER_BENCH_SWEEP=0` restores legacy per-context runs)
- Invalidate CUDA graphs in `bench_decode` when context changes so sweep measurements stay correct
- Add `test_bench_sweep.py` for SWEEP_JSON parsing

## Test plan
- [x] `python3 bench/scripts/test_bench_sweep.py`
- [ ] GPU eval box: verify `evaluate.sh` / `evaluate_bidir.sh` emit same tok/s ordering as before
- [ ] Confirm bidir PR eval bench phase is ~3–5× faster end-to-end