### PR TITLE
eval: deduplicate accuracy per GGUF in bidir runs

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -441,12 +441,20 @@ echo ">> [3/3] correctness — token-match / KL vs llama.cpp (held-out prompt) .
 # H1: the accuracy gate scores a held-out / fuzzed prompt chosen by EVAL_SEED (set by the bot to a
 # fresh, unpredictable value each eval), so a submission can't overfit the in-repo prompt. The seed
 # is recorded below so any verifier reproduces the exact token stream.
+# evaluate_bidir.sh may set SPARKINFER_SKIP_ACCURACY=1 when the same GGUF was already scored on this
+# build + seed (primary and guard passes share one model each).
 EVAL_SEED="${SPARKINFER_EVAL_SEED:-fixed}"
-acc=$(SPARKINFER_EVAL_SEED="$EVAL_SEED" "$HERE/accuracy.sh" "$GGUF" 2>/dev/null || true)
-# parse the unambiguous METRIC line (not the human-readable text, which contains "bar >= 0.90")
-TOP1=$(printf '%s\n' "$acc" | sed -n 's/.*METRIC .*top1=\([0-9.][0-9.]*\).*/\1/p' | head -1)
-KL=$(printf   '%s\n' "$acc" | sed -n 's/.*METRIC .*kl=\([0-9.][0-9.]*\).*/\1/p' | head -1)
-TOP1="${TOP1:-0}"; KL="${KL:-99}"
+if [ "${SPARKINFER_SKIP_ACCURACY:-0}" = "1" ] && [ -n "${SPARKINFER_ACCURACY_TOP1:-}" ]; then
+  echo ">> reusing cached accuracy (top1=${SPARKINFER_ACCURACY_TOP1}, kl=${SPARKINFER_ACCURACY_KL:-99})" >&2
+  TOP1="${SPARKINFER_ACCURACY_TOP1}"
+  KL="${SPARKINFER_ACCURACY_KL:-99}"
+else
+  acc=$(SPARKINFER_EVAL_SEED="$EVAL_SEED" "$HERE/accuracy.sh" "$GGUF" 2>/dev/null || true)
+  # parse the unambiguous METRIC line (not the human-readable text, which contains "bar >= 0.90")
+  TOP1=$(printf '%s\n' "$acc" | sed -n 's/.*METRIC .*top1=\([0-9.][0-9.]*\).*/\1/p' | head -1)
+  KL=$(printf   '%s\n' "$acc" | sed -n 's/.*METRIC .*kl=\([0-9.][0-9.]*\).*/\1/p' | head -1)
+  TOP1="${TOP1:-0}"; KL="${KL:-99}"
+fi
 
 # Provenance merged into the verdict (M1 clock, H1 seed, C2 reference pins) — non-scoring, for the log.
 [ "$GPU_CLOCKS_PINNED" = 1 ] && CP=true || CP=false

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -51,6 +51,49 @@ QUANT="${PRIMARY_QUANT:-Q4_K_M}"
 echo ">> bidir: Qwen3.5=$P35_FILE (quant=$QUANT, ctx=128/4k/32k/64k) + Qwen3.6=$P36_FILE (ctx=128/512/4k/16k/32k)" >&2
 
 reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
+reap_bench() { pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
+
+declare -A _ACC_TOP1 _ACC_KL
+_LAST_GGUF=""
+
+_models_dir_from_args() {
+  local file="$1"; shift
+  local mdir="${MODELS_DIR:-$ROOT/models}"
+  local a
+  for a in "$@"; do
+    case "$a" in MODELS_DIR=*) mdir="${a#MODELS_DIR=}" ;; esac
+  done
+  echo "${mdir}/${file}"
+}
+
+run_model() {
+  local role="$1" file="$2" repo="$3" tok="$4" frontier="$5"; shift 5
+  local gguf skip_env=() json
+  gguf="$(_models_dir_from_args "$file" "$@")"
+  if [ -n "${_ACC_TOP1[$gguf]:-}" ]; then
+    skip_env=(SPARKINFER_SKIP_ACCURACY=1
+              SPARKINFER_ACCURACY_TOP1="${_ACC_TOP1[$gguf]}"
+              SPARKINFER_ACCURACY_KL="${_ACC_KL[$gguf]}")
+    echo ">> [$role] reusing cached accuracy for $file (top1=${_ACC_TOP1[$gguf]}, kl=${_ACC_KL[$gguf]})" >&2
+    if [ "$gguf" = "$_LAST_GGUF" ]; then reap_bench; else reap; fi
+  else
+    reap
+  fi
+  echo ">> [$role] model $file ..." >&2
+  json="$(env SI_SKIP_BUILD=1 SI_NO_CHECKOUT=1 \
+      MODEL_FILE="$file" MODEL_REPO="$repo" TOK_REPO="$tok" \
+      "${skip_env[@]}" \
+      "$@" \
+      "$HERE/evaluate.sh" --ref "$REF" --frontier "$frontier" --ceiling "$CEILING" \
+    | sed -n 's/^RESULT_JSON //p' | tail -1)"
+  if [ -z "${_ACC_TOP1[$gguf]:-}" ] && [ -n "$json" ]; then
+    read -r _t _k < <(python3 -c 'import json,sys; d=json.loads(sys.argv[1]); print(d.get("top1",0), d.get("kl",99))' "$json")
+    _ACC_TOP1[$gguf]="$_t"
+    _ACC_KL[$gguf]="$_k"
+  fi
+  _LAST_GGUF="$gguf"
+  echo "$json"
+}
 
 if [ "$BASELINE_ONLY" = 1 ]; then
   echo ">> bidir baseline-only: ctx speed sweep on origin/main (skip PR build + dual eval)" >&2
@@ -104,17 +147,6 @@ else
   fi
   export SPARKINFER_DOWN_REQUANT_Q4K=1
 fi
-
-run_model() {
-  local role="$1" file="$2" repo="$3" tok="$4" frontier="$5"; shift 5
-  reap
-  echo ">> [$role] model $file ..." >&2
-  env SI_SKIP_BUILD=1 SI_NO_CHECKOUT=1 \
-      MODEL_FILE="$file" MODEL_REPO="$repo" TOK_REPO="$tok" \
-      "$@" \
-      "$HERE/evaluate.sh" --ref "$REF" --frontier "$frontier" --ceiling "$CEILING" \
-    | sed -n 's/^RESULT_JSON //p' | tail -1
-}
 
 # Qwen3.5: score/guard at 128/4k/32k/64k (skip 512, 16k, and 128k for now).
 Q35_CTX_ENVS=(

--- a/bench/scripts/test_accuracy_cache.py
+++ b/bench/scripts/test_accuracy_cache.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Unit tests for bidir per-GGUF accuracy cache key logic.
+
+Run from the repo root:
+  python3 bench/scripts/test_accuracy_cache.py
+"""
+import json
+import unittest
+
+
+def cache_key(models_dir: str, model_file: str) -> str:
+    return f"{models_dir}/{model_file}"
+
+
+def should_reuse(cached: dict, gguf: str, last_gguf: str) -> bool:
+    return gguf in cached and gguf == last_gguf
+
+
+class AccuracyCacheTest(unittest.TestCase):
+    def test_bidir_pass_order(self):
+        p35 = cache_key("/models35", "Qwythos-Q4_K_M.gguf")
+        p36 = cache_key("/models36", "Qwen3.6-Q4_K_M.gguf")
+        cached = {}
+        order = [
+            ("primary35", p35),
+            ("guard36", p36),
+            ("primary36", p36),
+            ("guard35", p35),
+        ]
+        last = ""
+        hits = []
+        for _role, gguf in order:
+            if gguf in cached:
+                hits.append(gguf)
+            else:
+                cached[gguf] = {"top1": 0.97, "kl": 0.02}
+            last = gguf
+        self.assertEqual(hits, [p36, p35])
+        self.assertEqual(len(cached), 2)
+
+    def test_same_gguf_reap_bench(self):
+        p36 = cache_key("/m36", "a.gguf")
+        self.assertTrue(should_reuse({p36: 1}, p36, p36))
+        self.assertFalse(should_reuse({p36: 1}, p36, "/other/a.gguf"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Cache top1/KL per GGUF in `evaluate_bidir.sh` after the first pass on each model
- Skip `accuracy.sh` on the second pass (`primary36`, `guard35`) via `SPARKINFER_SKIP_ACCURACY`
- Use `reap_bench` when reusing cache on the same GGUF back-to-back

## Test plan
- [x] `bash -n bench/scripts/evaluate_bidir.sh`
- [x] `python3 bench/scripts/test_accuracy_cache.py`
- [ ] GPU bidir eval: confirm guard accuracy_ok unchanged vs full 4× accuracy runs