### PR TITLE
perf(qwen36): shared-expert Q8 pack2 + PDL chain for MoE decode

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -545,7 +545,7 @@ template <int H, int F>
 __global__ void shared_gate_up_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
-    float* __restrict__ h_scratch) {
+    float* __restrict__ h_scratch, int pdl) {
     constexpr int NW = 4, WS = 32;
     const int f = blockIdx.x, lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
     const int nblk = H >> 5;
@@ -568,12 +568,51 @@ __global__ void shared_gate_up_q8_mmvq_kernel(
         float w = dw ? __ldg(dw) : 1.f;
         h_scratch[f] = w * q4kf_silu(tg) * tu;
     }
+    if (pdl) si_pdl_lc();
+}
+
+// Pack2 shared-expert gate/up: one 8-warp CTA owns two F rows (same layout as routed
+// gate_up_mmvq2_pack2). Halves the grid vs shared_gate_up_q8_mmvq_kernel and emits
+// si_pdl_lc so quant_h / down can overlap via programmatic stream serialization.
+template <int H, int F>
+__global__ void shared_gate_up_q8_pack2_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
+    float* __restrict__ h_scratch, int pdl) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int f = blockIdx.x * 2 + group;
+    if (f >= F) return;
+    const int nblk = H >> 5;
+    const int tid4 = group_warp * WS + lane;
+    const unsigned char* gbase = gate_q + (size_t)f * nblk * 34;
+    const unsigned char* ubase = up_q   + (size_t)f * nblk * 34;
+    float tg = 0.f, tu = 0.f;
+    for (int b = tid4; b < nblk; b += NW * WS) {
+        tg += si_vec_dot_q8_0(gbase + (size_t)b * 34, vy + b);
+        tu += si_vec_dot_q8_0(ubase + (size_t)b * 34, vy + b);
+    }
+    __shared__ float sg[2][NW - 1][WS], su[2][NW - 1][WS];
+    if (group_warp > 0) { sg[group][group_warp - 1][lane] = tg; su[group][group_warp - 1][lane] = tu; }
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[group][l][lane]; tu += su[group][l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) {
+        float w = dw ? __ldg(dw) : 1.f;
+        h_scratch[f] = w * q4kf_silu(tg) * tu;
+    }
+    if (pdl) si_pdl_lc();
 }
 
 template <int H, int F, bool ACCUM>
 __global__ void shared_down_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
-    __nv_bfloat16* __restrict__ out) {
+    __nv_bfloat16* __restrict__ out, int pdl) {
+    if (pdl) si_pdl_sync();
     const int h = blockIdx.x * WPB + (threadIdx.x >> 5), lane = threadIdx.x & 31;
     if (h >= H) return;
     const int nblk = F >> 5;
@@ -1509,11 +1548,24 @@ void launch_moe_expert_ffn_q4k(
 
 // Qwen3.6 UD shared expert: Q8_0 weights + int8 dp4a MMVQ (reuses FNQ Q8_1(hn)).
 // input_q8 may be overwritten with Q8_1(h) after gate/up. h_scratch: [ffn] fp32.
+// Default: pack2 gate/up (256 CTAs) + PDL-chained quant_h → down (same pattern as
+// routed MoE #331). SPARKINFER_SHEXP_PACK2=0 / SPARKINFER_SHEXP_PDL=0 restore plain launches.
 void launch_shared_expert_q8_mmvq(
     const void* input, const void* input_q8,
     const void* gate_q, const void* up_q, const void* down_q,
     const float* dw, void* output, float* h_scratch, void* h_q8_buf,
     int hidden, int ffn, cudaStream_t stream, bool accum = false) {
+    static int shexp_pack2 = -1;
+    if (shexp_pack2 < 0) {
+        const char* e = getenv("SPARKINFER_SHEXP_PACK2");
+        shexp_pack2 = (e && e[0] == '0') ? 0 : 1;
+    }
+    static int shexp_pdl = -1;
+    if (shexp_pdl < 0) {
+        const char* e = getenv("SPARKINFER_SHEXP_PDL");
+        shexp_pdl = (e && e[0] == '0') ? 0 : 1;
+    }
+    const int pdl = shexp_pdl;
     const si_block_q8_1* vy;
     si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(h_q8_buf);
     if (input_q8) {
@@ -1523,21 +1575,36 @@ void launch_shared_expert_q8_mmvq(
             reinterpret_cast<const __nv_bfloat16*>(input), qbuf, hidden);
         vy = qbuf;
     }
-    shared_gate_up_q8_mmvq_kernel<2048, 512><<<ffn, 4 * 32, 0, stream>>>(
-        vy, reinterpret_cast<const unsigned char*>(gate_q),
-        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    if (shexp_pack2 && hidden == 2048 && ffn == 512) {
+        launch_pdl_kernel(pdl, dim3((ffn + 1) / 2), dim3(8 * 32), 0, stream,
+            shared_gate_up_q8_pack2_kernel<2048, 512>,
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch, pdl);
+    } else if (hidden == 2048 && ffn == 512) {
+        launch_pdl_kernel(pdl, dim3(ffn), dim3(4 * 32), 0, stream,
+            shared_gate_up_q8_mmvq_kernel<2048, 512>,
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch, pdl);
+    } else {
+        // Untuned shapes: keep the historical one-row-per-CTA plain path.
+        shared_gate_up_q8_mmvq_kernel<2048, 512><<<ffn, 4 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch, 0);
+    }
     const int nqb = ffn >> 5;
-    quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
-        h_scratch, qbuf, nqb, 0);
+    launch_pdl_kernel(pdl, dim3((nqb + 7) / 8), dim3(8 * 32), 0, stream,
+        quant_h_q8_1_kernel, h_scratch, qbuf, nqb, pdl);
     dim3 dn((hidden + WPB - 1) / WPB);
     if (accum) {
-        shared_down_q8_mmvq_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
+        launch_pdl_kernel(pdl, dn, dim3(WPB * 32), 0, stream,
+            shared_down_q8_mmvq_kernel<2048, 512, true>,
             qbuf, reinterpret_cast<const unsigned char*>(down_q),
-            reinterpret_cast<__nv_bfloat16*>(output));
+            reinterpret_cast<__nv_bfloat16*>(output), pdl);
     } else {
-        shared_down_q8_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
+        launch_pdl_kernel(pdl, dn, dim3(WPB * 32), 0, stream,
+            shared_down_q8_mmvq_kernel<2048, 512, false>,
             qbuf, reinterpret_cast<const unsigned char*>(down_q),
-            reinterpret_cast<__nv_bfloat16*>(output));
+            reinterpret_cast<__nv_bfloat16*>(output), pdl);
     }
 }
 #endif


### PR DESCRIPTION
## Summary

Implements the shared-expert pack2 + PDL gap left after routed MoE #331: `launch_shared_expert_q8_mmvq` now uses a pack2 gate/up kernel (256 CTAs vs 512) and chains gate_up → quant_h → down through `launch_pdl_kernel` / `si_pdl_lc` / `si_pdl_sync`.

- New `shared_gate_up_q8_pack2_kernel` for H=2048, F=512 (8-warp CTA owns 2 F-rows).
- `SPARKINFER_SHEXP_PACK2=0` / `SPARKINFER_SHEXP_PDL=0` restore the pre-change plain launches.
- No math change; Qwythos dense path (`n_shared=0`) untouched.

Closes #432. Related: #362.

## Proof of speedup

> ⚠️ **Local nvidia-smi reports NVIDIA GeForce RTX 4060 Laptop GPU (`sm_89`), not an RTX 5090.** Per CONTRIBUTING / this template, the RTX 5090 box is left **unchecked** — false attestation is treated as gaming and blocks the account. Before/after decode numbers below stay empty until measured with `bench/scripts/bench.sh` on a real `sm_120` box.

- [ ] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) |  |
| after (this PR) |  |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
# Needs RTX 5090 bench/scripts/bench.sh before -> after
# Local machine: RTX 4060 Laptop (sm_89) — no CUDA toolkit / cannot run sm_120 bench here
```
