### PR TITLE
eval: restore protected harness sync

### DIFF
--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -91,7 +91,8 @@ def push_bench_scripts(host, port):
             print(f">> WARN: could not pack bench/scripts (rc={tar.returncode})")
             return
         tar_data = tar.stdout
-    else:
+    if tar_data is None:
+        print(">> WARN: no bench/scripts archive — box may run stale harness")
         return
     verify_marker = b"LLAMA_BUILD_UI=OFF"
     tmp_path = ""


### PR DESCRIPTION
## Summary
- allow successful `origin/main` bench-script archives to continue into the SCP deployment path
- fail with an explicit warning only when no harness archive can be created
- prevent PR checkouts from retaining stale `reference.lock` pins during evaluation

## Test plan
- verified `git archive origin/main bench/scripts` succeeds and now continues to upload
- reproduce PR #355 checkout and confirm the protected harness restores the current Qwythos SHA pin