### PR TITLE
perf(qwen36): PDL-chain shared expert gate/up → quant → down

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -545,7 +545,7 @@ template <int H, int F>
 __global__ void shared_gate_up_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
-    float* __restrict__ h_scratch) {
+    float* __restrict__ h_scratch, int pdl) {
     constexpr int NW = 4, WS = 32;
     const int f = blockIdx.x, lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
     const int nblk = H >> 5;
@@ -568,12 +568,14 @@ __global__ void shared_gate_up_q8_mmvq_kernel(
         float w = dw ? __ldg(dw) : 1.f;
         h_scratch[f] = w * q4kf_silu(tg) * tu;
     }
+    if (pdl) si_pdl_lc();   // PDL: signal quant_h/down after h_scratch is written
 }
 
 template <int H, int F, bool ACCUM>
 __global__ void shared_down_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
-    __nv_bfloat16* __restrict__ out) {
+    __nv_bfloat16* __restrict__ out, int pdl) {
+    if (pdl) si_pdl_sync();   // PDL: wait for quant_h's Q8_1(h) before reading it
     const int h = blockIdx.x * WPB + (threadIdx.x >> 5), lane = threadIdx.x & 31;
     if (h >= H) return;
     const int nblk = F >> 5;
@@ -1523,21 +1525,27 @@ void launch_shared_expert_q8_mmvq(
             reinterpret_cast<const __nv_bfloat16*>(input), qbuf, hidden);
         vy = qbuf;
     }
-    shared_gate_up_q8_mmvq_kernel<2048, 512><<<ffn, 4 * 32, 0, stream>>>(
+    const int gu_pdl = gu_mmvq_pdl();
+    const int down_pdl = down_mmvq_pdl();
+    const int q_pdl = gu_pdl && down_pdl;
+    launch_pdl_kernel(gu_pdl, dim3(ffn), dim3(4 * 32), 0, stream,
+        shared_gate_up_q8_mmvq_kernel<2048, 512>,
         vy, reinterpret_cast<const unsigned char*>(gate_q),
-        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch, gu_pdl);
     const int nqb = ffn >> 5;
-    quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
-        h_scratch, qbuf, nqb, 0);
+    launch_pdl_kernel(q_pdl, dim3((nqb + 7) / 8), dim3(8 * 32), 0, stream,
+        quant_h_q8_1_kernel, h_scratch, qbuf, nqb, q_pdl);
     dim3 dn((hidden + WPB - 1) / WPB);
     if (accum) {
-        shared_down_q8_mmvq_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
+        launch_mmvq_down_kernel(down_pdl, dn, dim3(WPB * 32), stream,
+            shared_down_q8_mmvq_kernel<2048, 512, true>,
             qbuf, reinterpret_cast<const unsigned char*>(down_q),
-            reinterpret_cast<__nv_bfloat16*>(output));
+            reinterpret_cast<__nv_bfloat16*>(output), down_pdl);
     } else {
-        shared_down_q8_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
+        launch_mmvq_down_kernel(down_pdl, dn, dim3(WPB * 32), stream,
+            shared_down_q8_mmvq_kernel<2048, 512, false>,
             qbuf, reinterpret_cast<const unsigned char*>(down_q),
-            reinterpret_cast<__nv_bfloat16*>(output));
+            reinterpret_cast<__nv_bfloat16*>(output), down_pdl);
     }
 }
 #endif


### PR DESCRIPTION
## Summary

Wire programmatic dependent launch (PDL) into the Qwen3.6 shared-expert Q8 MMVQ path (`launch_shared_expert_q8_mmvq`). The routed MoE FFN already chains gate/up → `quant_h_q8_1` → down via PDL to hide bs=1 launch latency; the shared expert fired the same three kernels back-to-back without PDL. This mirrors the existing routed-MoE pattern using `SPARKINFER_GU_PDL` / `SPARKINFER_DOWN_PDL` (both default ON).

**Target:** Qwen3.6-35B-A3B decode @128–512 (shared expert runs every MoE layer).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`) — same-box A/B on **NVIDIA RTX PRO 6000 Blackwell** (sm_120, 188 SMs)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench`, Qwen3.6-35B-A3B-UD-Q4_K_M.gguf, ctx=0, bs=1, 3-run median):

| | decode tok/s @128 | decode tok/s @512 |
|---|--:|--:|
| before (main) | 479.32 | 480.16 |
| after (this PR) | 478.87 | 479.91 |

```text
=== BEFORE (main @465c383) ===
GPU: NVIDIA RTX PRO 6000 Blackwell Workstation Edition  cc=12.0  SMs=188
model: Qwen3.6-35B-A3B-UD-Q4_K_M.gguf

n=128: 479.13 / 479.68 / 479.32 tok/s  (median 479.32)
n=512: 480.54 / 480.13 / 480.16 tok/s  (median 480.16)

=== AFTER (perf/qwen36-shared-expert-pdl) ===
GPU: NVIDIA RTX PRO 6000 Blackwell Workstation Edition  cc=12.0  SMs=188
model: Qwen3.6-35B-A3B-UD-Q4_K_M.gguf

n=128: 478.79 / 478.87 / 480.09 tok/s  (median 478.87)
n=512: 479.56 / 479.91 / 479.91 tok/s  (median 479.91)
```

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A (decode-only change) |
| after prefill (this PR) | N/A |

## Test plan

- [x] `cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j`
- [x] `qwen3_gguf_bench` on `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf` @128 and @512 (3 runs each, same box)
- [ ] `bench/scripts/accuracy.sh --download` — top-1 and KL unchanged vs main
- [ ] Verify `SPARKINFER_GU_PDL=0` / `SPARKINFER_DOWN_PDL=0` still fall back to non-PDL launches
