### PR TITLE
Cap eval tier credit at 2× measured speedup

### DIFF
--- a/bench/scripts/label.py
+++ b/bench/scripts/label.py
@@ -16,8 +16,9 @@ Emits one line:  RESULT_JSON {...}
   delta/frontier: over an un-optimized frontier (e.g. Qwen3.6 at 23 tok/s) a small absolute gain used
   to explode to XL, while a mature model (past llama) couldn't clear XS for equal effort. The
   past-llama difficulty boost (Option B) still multiplies the *tier* once the frontier is beyond the
-  reference. Significance still gates on raw %-over-frontier (a gain must beat the current best);
-  pct_over_frontier reports the honest measured speedup; pct_of_llama is the tier basis.
+  reference, then caps tier credit at 2× the measured %-over-frontier. Significance still gates on raw
+  %-over-frontier (a gain must beat the current best); pct_over_frontier reports the honest measured
+  speedup; pct_of_llama is the tier basis.
   llama_ref (SPARKINFER_DIFFICULTY_REF) <= 0 falls back to the legacy delta/frontier basis.
   Thresholds are governance-tunable.
 """
@@ -54,13 +55,15 @@ BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
 # As the frontier pulls past a mature reference (llama.cpp), each further % gain is harder; scale the
 # LABEL up so a late-game hard PR scores like the effort it took. D = 1 for a frontier at/below the
 # reference (the cold-start era is untouched — no retroactive inflation), grows with distance past it,
-# and is bounded by DIFF_MAX so nothing runs away to XL. Crucially the boost multiplies the *label*
-# only: the significance gate stays on the RAW delta (so noise is never boosted) and pct_over_frontier
-# still reports the true measured speedup. OFF by default.
+# and is bounded by DIFF_MAX so nothing runs away to XL. Tier credit is then capped at 2× the measured
+# %-over-frontier (g) so a low per-context llama ref cannot inflate the label past twice the real
+# speedup. Crucially the boost multiplies the *label* only: the significance gate stays on the RAW
+# delta (so noise is never boosted) and pct_over_frontier reports the true measured speedup. OFF by
+# default.
 DIFF_BOOST = os.environ.get("SPARKINFER_DIFFICULTY_BOOST", "0") == "1"
 DIFF_K     = float(os.environ.get("SPARKINFER_DIFFICULTY_K",   "8"))
 DIFF_REF   = float(os.environ.get("SPARKINFER_DIFFICULTY_REF", "365.85"))  # llama.cpp 128-tok tok/s
-DIFF_MAX   = float(os.environ.get("SPARKINFER_DIFFICULTY_MAX", "2"))
+DIFF_MAX   = float(os.environ.get("SPARKINFER_DIFFICULTY_MAX", "1.5"))
 
 def difficulty_mult(frontier):
     if not DIFF_BOOST or DIFF_REF <= 0:
@@ -92,7 +95,7 @@ else:
         ref = DIFF_REF if DIFF_REF > 0 else frontier
         g_fair = delta / ref
         D = difficulty_mult(frontier)                   # hard-gain boost once past the reference
-        g_eff = g_fair * D
+        g_eff = min(g_fair * D, 2 * g)                  # strict cap: tier credit ≤ 2× measured speedup
         # A verified improvement over the frontier floors at XS (real but small); the higher tiers
         # (S/M/L/XL) are earned by the llama-anchored size. So "none" always means "not a verified
         # improvement", never "real but tiny".

--- a/bench/scripts/test_label.py
+++ b/bench/scripts/test_label.py
@@ -69,28 +69,41 @@ class LabelPolicyTest(unittest.TestCase):
         self.assertEqual(score(28.0, frontier=23.0, env=env)["label"], "XS")   # +5 (+22% over frontier) but 2.6% of llama
         self.assertEqual(score(171.0, frontier=23.0, env=env)["label"], "XL")  # a real 7x IS an XL (78% of llama)
 
-    def test_difficulty_boost_changes_label_but_not_raw_percent(self):
+    def test_difficulty_boost_high_cap_still_capped_at_twice_raw_speedup(self):
+        # Even with a generous DIFF_MAX, g_eff cannot exceed 2× pct_over_frontier.
         res = score(484.79, frontier=469.13, ceiling=366.0, top1=0.9612, kl=0.0175,
                     commit="c30bf58",
                     env={"SPARKINFER_DIFFICULTY_BOOST": "1",
                          "SPARKINFER_DIFFICULTY_REF": "365.85",
                          "SPARKINFER_DIFFICULTY_K": "8",
                          "SPARKINFER_DIFFICULTY_MAX": "4"})
-        self.assertEqual(res["label"], "L")
+        self.assertEqual(res["label"], "M")
         self.assertEqual(res["pct_over_frontier"], 3.3)
-        self.assertGreaterEqual(res["effective_pct"], 10.0)
-        self.assertLess(res["effective_pct"], 18.0)
+        self.assertGreaterEqual(res["effective_pct"], 6.0)
+        self.assertLess(res["effective_pct"], 10.0)
 
-    def test_difficulty_boost_default_cap_is_two_x(self):
-        # Default SPARKINFER_DIFFICULTY_MAX=2: same raw gain as above, but capped boost -> lower tier.
+    def test_difficulty_boost_default_cap_is_one_point_five_x(self):
+        # Default SPARKINFER_DIFFICULTY_MAX=1.5 with strict 2× raw cap.
         res = score(484.79, frontier=469.13, ceiling=366.0, top1=0.9612, kl=0.0175,
                     commit="c30bf58",
                     env={"SPARKINFER_DIFFICULTY_BOOST": "1",
                          "SPARKINFER_DIFFICULTY_REF": "365.85",
                          "SPARKINFER_DIFFICULTY_K": "8"})
         self.assertEqual(res["label"], "M")
-        self.assertEqual(res["difficulty_mult"], 2.0)
+        self.assertEqual(res["difficulty_mult"], 1.5)
         self.assertEqual(res["pct_over_frontier"], 3.3)
+        self.assertGreaterEqual(res["effective_pct"], 6.0)
+        self.assertLess(res["effective_pct"], 10.0)
+
+    def test_strict_cap_limits_per_context_llama_ref_inflation(self):
+        # Qwen3.6 @ 128: a low per-context llama ref must not push a ~3% raw gain to L.
+        res = score(479.96, frontier=465.41, ceiling=366.0, top1=0.967, kl=0.0281,
+                    commit="d12766f",
+                    env={"SPARKINFER_DIFFICULTY_BOOST": "1",
+                         "SPARKINFER_DIFFICULTY_REF": "275.81",
+                         "SPARKINFER_DIFFICULTY_K": "8"})
+        self.assertEqual(res["label"], "M")
+        self.assertEqual(res["pct_over_frontier"], 3.1)
         self.assertGreaterEqual(res["effective_pct"], 6.0)
         self.assertLess(res["effective_pct"], 10.0)
 


### PR DESCRIPTION
## Summary
- Lower default `SPARKINFER_DIFFICULTY_MAX` from 2.0 to 1.5.
- Cap tiering input at `min(g_fair * D, 2 * pct_over_frontier)` so a low per-context llama ref cannot inflate labels past twice the measured speedup (e.g. ~3.1% raw gain → M, not L).

## Test plan
- [x] `python3 bench/scripts/test_label.py` (9 tests pass)
- [ ] Re-run bidir eval on a PR with ~3% Qwen3.6 gain to confirm headline label is M