### PR TITLE
fix(runtime): validate routed-expert tensor dims in load_gguf

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1558,6 +1558,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                     w.router_w_type = 0;
                 }
             }
+            // Expert axis is the slowest dim; the FFN kernels stride by it with
+            // (hidden x moe_ffn) taken from metadata, so a mismatch here reads OOB.
+            if (!expect_dims(b + "ffn_gate_exps.weight", {H, c.moe_ffn, c.n_experts}) ||
+                !expect_dims(b + "ffn_up_exps.weight", {H, c.moe_ffn, c.n_experts}) ||
+                !expect_dims(b + "ffn_down_exps.weight", {c.moe_ffn, H, c.n_experts})) return false;
             w.gate_q = dev_quant(b + "ffn_gate_exps.weight", w.gate_qtype);   // kept quantized
             w.up_q   = dev_quant(b + "ffn_up_exps.weight",   w.up_qtype);
             w.down_q = dev_quant(b + "ffn_down_exps.weight", w.down_qtype);


### PR DESCRIPTION
## Summary

Adds the missing `expect_dims` shape validation on the three routed-expert tensors in
`Qwen35Model::load_gguf`, as described in #291.

`ffn_gate_exps` / `ffn_up_exps` / `ffn_down_exps` were the only weights loaded with just a
null-check. Every sibling is already guarded — the dense FFN (`ffn_gate/up/down`), the router
(`ffn_gate_inp`), the shared experts (`ffn_*_shexp`), attention, and the norms — so this was an
inconsistency rather than a deliberate omission.

## Why it matters

These are the largest weights in the model, and their per-expert stride is **assumed, never
re-derived**: `launch_moe_expert_ffn_q4k` strides by `hidden` / `moe_ffn` taken from GGUF
metadata (`embedding_length` / `expert_feed_forward_length`). A file whose metadata disagrees
with the actual `ffn_*_exps` extent — a repacked/mismatched quant, a truncated file, or a variant
with a different expert-FFN width — passed `load_gguf` cleanly and then read past the quantized
blob: corrupt routed output or a CUDA illegal address, on an entirely file-controlled dimension.

## The fix

Three checks in ggml `ne` order, mirroring the existing `ffn_*_shexp` checks with the expert
axis appended:

```cpp
if (!expect_dims(b + "ffn_gate_exps.weight", {H, c.moe_ffn, c.n_experts}) ||
    !expect_dims(b + "ffn_up_exps.weight", {H, c.moe_ffn, c.n_experts}) ||
    !expect_dims(b + "ffn_down_exps.weight", {c.moe_ffn, H, c.n_experts})) return false;
```

Placed before the `dev_quant` loads, so a bad file is rejected at load with the same
`[gguf] bad shape for ...` diagnostic every other tensor already produces, instead of
faulting later inside the expert FFN.

## Shape derivation

The `ne` order was cross-checked against three independent sources in-tree, all of which agree:

| source | evidence |
|---|---|
| `expert_ffn_q4k.cu:133` | `gbase = gate_q + ((size_t)e * F + f) * nblk * gbb`, `nblk = H/256` → gate/up rows are `H` long, strided by `(e*F + f)` → C-order `[E,F,H]` → ne `[H, F, E]` |
| `expert_ffn_q4k.cu:253` | `dbase = down_q + ((size_t)e * H + hh) * nblk * dbb`, `nblk = F/256` → down rows are `F` long, strided by `(e*H + hh)` → C-order `[E,H,F]` → ne `[F, H, E]` |
| `runtime/tools/convert_gguf.py:95-97` | `deq("ffn_gate_exps.weight").transpose(0,2,1)  # [E,F,H]->[E,H,F]` and `# [E,H,F]->[E,F,H]` for down — same orientation |

This is also consistent with the shared-expert checks directly below (`{H, moe_ffn}` for gate/up,
`{moe_ffn, H}` for down) and with `gguf.cpp:119`, which fills `dims[]` in file order, so
`expect_dims` compares against `ne` order.

## Testing

Behaviour is unchanged for any conforming GGUF: the checks assert exactly the shapes the FFN
kernels already assume, so a file that decodes correctly today still loads. A non-conforming file
now fails fast at load instead of reading OOB.

**I was not able to compile this change.** The machine I prepared it on has no CUDA toolkit and no
host compiler, so `cmake`/`ctest` could not run, and `load_gguf` is not reachable from the CPU-only
tests (it needs `dev_quant`). The change is a 5-line addition using an existing in-scope lambda
with the same argument types as the adjacent calls, but it does need a CI/maintainer build to
confirm. Flagging that plainly rather than implying I ran the suite.

## Notes

Non-speedup correctness fix, so it earns no SN74 emission — filing it because #291 is a real gap,
not for reward. Per CONTRIBUTING and the `rtx5090-required` workflow, the proof-of-speedup section
is **removed** rather than left with an unticked box, since this PR does not need GPU eval. Touches
only `runtime/` — no maintainer-owned paths.

Closes #291
