### PR TITLE
fix(runtime): don't let `or` swallow a legitimate eos_token_id of 0

### DIFF
--- a/runtime/tools/convert_gguf.py
+++ b/runtime/tools/convert_gguf.py
@@ -36,11 +36,17 @@ def main():
         if f.types[0] == GT.STRING: return bytes(f.parts[f.data[0]]).decode()
         return f.parts[f.data[-1]][0]
 
+    def meta_or(k, default):
+        # `or` would swallow a legitimate 0 (eos_token_id 0 is a valid token id);
+        # only a missing key falls back.
+        v = meta(k)
+        return default if v is None else v
+
     A = "qwen3moe."
     arch = meta("general.architecture")
     assert arch == "qwen3moe", f"expected qwen3moe arch, got {arch}"
     cfg = dict(
-        vocab=int(meta(A + "vocab_size") or 151936),
+        vocab=int(meta_or(A + "vocab_size", 151936)),
         hidden=int(meta(A + "embedding_length")),
         n_layers=int(meta(A + "block_count")),
         n_q_heads=int(meta(A + "attention.head_count")),
@@ -52,7 +58,7 @@ def main():
         moe_ffn=int(meta(A + "expert_feed_forward_length")),
         rope_theta=float(meta(A + "rope.freq_base")),
         rms_eps=float(meta(A + "attention.layer_norm_rms_epsilon")),
-        eos_id=int(meta("tokenizer.ggml.eos_token_id") or 151645),
+        eos_id=int(meta_or("tokenizer.ggml.eos_token_id", 151645)),
     )
     # vocab from token_embd if metadata missing
     ten = {t.name: t for t in r.tensors}


### PR DESCRIPTION
## Summary

Fixes #399. `convert_gguf.py` used `meta(k) or default` as a "use this if present" idiom, but
`meta()` returns `None` **only** when the key is absent — when the key is present it returns the
real value, and `0` is falsy. So a checkpoint whose GGUF legitimately sets `eos_token_id` to
token id `0` had it silently replaced with the hardcoded Qwen `<|im_end|>` id (151645).

## Why it matters

`config.txt`'s `eos_id` becomes `Qwen35Config::eos_id`, which is the *only* stop condition
`Qwen35Model::generate()` checks. A wrong value means the model never matches EOS and generation
runs to `max_new` on every call. It fails silently, and the accuracy gate wouldn't catch it —
`accuracy.sh` scores token-agreement/KL over a fixed decode window, not stop-token behaviour.

## The fix

A `meta_or(k, default)` helper that falls back only on a missing key, used for `eos_id` and for
the `vocab_size` line that has the same shape (lower risk in practice, but the same latent bug).
The helper matches the file's existing nested-helper idiom (`meta`, `deq`, `write`).

## Verification

Ran locally — `python3 -m py_compile` passes, and the old vs new expression over the cases that
matter:

| case | want | old | new |
|---|--:|--:|--:|
| key absent (fallback intended) | 151645 | 151645 | 151645 |
| `eos_token_id = 0` (the bug) | 0 | **151645** | **0** |
| `eos_token_id = 151645` (normal) | 151645 | 151645 | 151645 |
| `eos_token_id = 2` | 2 | 2 | 2 |

Only the falsy-`0` case changes; every other path is byte-identical.

## Notes

Non-speedup correctness fix — earns no SN74 emission, filed because #399 is a real gap. Proof-of-
speedup section removed per CONTRIBUTING (no GPU eval needed). Touches only `runtime/tools/`.

Closes #399
