### PR TITLE
fix(runtime): fall back to tied embedding when lm_head.weight is absent

### DIFF
--- a/runtime/tools/convert_qwen35.py
+++ b/runtime/tools/convert_qwen35.py
@@ -60,7 +60,10 @@ def main():
     # globals
     write("embed_tokens", get("model.embed_tokens.weight"))          # [vocab, H]
     write("final_norm",   get("model.norm.weight"))                  # [H]
-    write("lm_head",      get("lm_head.weight").T)                   # [vocab,H] -> [H,vocab]
+    # Tied-embedding checkpoints ship no lm_head.weight; fall back to the input
+    # embedding, which has the same [vocab, H] layout (as convert_gguf.py does).
+    lm = "lm_head.weight" if "lm_head.weight" in tensors else "model.embed_tokens.weight"
+    write("lm_head",      get(lm).T)                                 # [vocab,H] -> [H,vocab]
 
     for i in range(n_layers):
         p = f"model.layers.{i}."


### PR DESCRIPTION
## Summary

Fixes #219. `convert_qwen35.py` read `lm_head.weight` unconditionally:

```python
write("lm_head", get("lm_head.weight").T)
```

`get()` is a bare `tensors[name]` lookup, so a Qwen checkpoint that **ties** its input and output
embeddings — and therefore ships no `lm_head.weight` — aborts conversion with a `KeyError`.

## The fix

Mirror the tied fallback `convert_gguf.py` already implements at line 80
(`output.weight` → `token_embd.weight`): when `lm_head.weight` is absent, read
`model.embed_tokens.weight`, which has the identical `[vocab, H]` layout, so the existing `.T` to
`[H, vocab]` is still correct.

```python
lm = "lm_head.weight" if "lm_head.weight" in tensors else "model.embed_tokens.weight"
write("lm_head",      get(lm).T)
```

## Verification

Ran locally — `python3 -m py_compile` passes, and simulating the tensor index for both checkpoint
shapes:

| checkpoint | old | new |
|---|---|---|
| untied (has `lm_head.weight`) | ok | ok — reads `lm_head.weight` |
| tied (no `lm_head.weight`) | **KeyError('lm_head.weight')** | ok — reads `model.embed_tokens.weight` |

The untied path is unchanged; only the previously-crashing case now resolves.

## Notes

Non-speedup correctness fix — earns no SN74 emission, filed because #219 is a real gap. Proof-of-
speedup section removed per CONTRIBUTING (no GPU eval needed). Touches only `runtime/tools/`.

Closes #219
