### PR TITLE
fix(runtime): admit the top group when it alone exceeds the batch budget

### DIFF
--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -28,7 +28,11 @@ ScheduleBatch Scheduler::schedule() {
     std::sort(ordered.begin(), ordered.end(),
               [](const SequenceGroup* a, const SequenceGroup* b) { return a->priority > b->priority; });
     for (auto* g : ordered) {
-        if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
+        // The budget is a soft cap: admit the highest-priority group unconditionally,
+        // else a group with num_seqs > max_tokens_per_batch overflows on the first
+        // iteration, yields an empty batch, and never makes progress.
+        if (!batch.decode_seq_ids.empty() &&
+            batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
         for (int i = 0; i < g->num_seqs; i++) batch.decode_seq_ids.push_back(g->group_id);
         batch.total_tokens += g->num_seqs;
     }


### PR DESCRIPTION
## Summary

Fixes #217. `Scheduler::schedule()` breaks out of the packing loop on the first group that exceeds
the remaining token budget:

```cpp
for (auto* g : ordered) {
    if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
    ...
}
```

When the highest-priority group's `num_seqs` is greater than `max_tokens_per_batch`, this breaks on
the **first** iteration and returns an empty `ScheduleBatch` — so that group never makes forward
progress, even when it is the only runnable work. It can never shrink, so it starves permanently.

## The fix

`max_tokens_per_batch` is a soft cap, so admit the highest-priority group unconditionally and apply
the cap only to subsequent groups:

```cpp
if (!batch.decode_seq_ids.empty() &&
    batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
```

This restores the invariant the issue asks for — `schedule()` never returns an empty batch while a
runnable group exists — while leaving packing for groups that fit byte-identical. I kept the
`break` (rather than switching to `continue` to pack smaller groups behind a big one), since
changing the packing policy is beyond this issue.

## Verification

`scheduler.cpp` is host-only, but **I could not compile it** — the machine I prepared this on has no
CUDA toolkit and no host compiler, so `cmake`/`ctest` could not run. Flagging that plainly rather
than implying I ran the suite.

What I did do is model the packing loop exactly (same ordering, same comparison, same `break`) and
run the old and new forms over the relevant cases:

| case | old | new | |
|---|--:|--:|---|
| all groups fit | 5 seqs | 5 seqs | unchanged |
| second group overflows | 6 seqs | 6 seqs | unchanged |
| top group alone > budget | **0 seqs** | **10 seqs** | starved → fixed |
| single oversized group | **0 seqs** | **99 seqs** | starved → fixed |
| exact fit | 8 seqs | 8 seqs | unchanged |

Only the previously-starving cases change.

## On test coverage

The issue notes "No test currently covers the scheduler." I agree one is warranted and the class is
a good fit for a `*_cpu_test.cpp` in `runtime/tests/` (host-only, no CUDA, no device needed). I
deliberately did **not** add one here: without a local compiler I can't run it, and shipping an
unverified test seemed worse than shipping none. Happy to add it in a follow-up if you'd like —
or if you prefer it in this PR, say so and I'll write it against the existing
`decode_layer_cpu_test` pattern.

## Notes

Non-speedup correctness fix — earns no SN74 emission, filed because #217 is a real gap. Proof-of-
speedup section removed per CONTRIBUTING (no GPU eval needed). Touches only `runtime/`.

Closes #217
