### PR TITLE
fix(moe): bounds-check layer and reject unset weights in forward

### DIFF
--- a/moe/src/engine.cpp
+++ b/moe/src/engine.cpp
@@ -53,7 +53,20 @@ public:
                     num_tokens, max_tokens_);
             return;
         }
+        if (layer < 0 || layer >= (int)weights_.size()) {
+            // weights_ is sized to cfg.num_layers; set_layer_weights() already range-checks,
+            // so an out-of-range read here would be UB on the vector.
+            fprintf(stderr, "[moe] forward: layer %d out of range [0, %d) — skipping\n",
+                    layer, (int)weights_.size());
+            return;
+        }
         const LayerWeights& w = weights_[layer];
+        if (!w.router_w || !w.gate_w || !w.up_w || !w.down_w) {
+            // LayerWeights defaults to all-null, so a layer whose set_layer_weights()
+            // was skipped would launch the kernels on null device pointers.
+            fprintf(stderr, "[moe] forward: layer %d weights unset — skipping\n", layer);
+            return;
+        }
         const int E = cfg_.num_experts, K = cfg_.top_k;
         const int H = cfg_.hidden_dim, F = cfg_.ffn_dim;
 


### PR DESCRIPTION
## Summary

Fixes #197 and #204. Both are missing input guards in the same function, `MoEEngineImpl::forward`,
so they're fixed together rather than as two conflicting PRs against adjacent lines — happy to
split if you'd rather.

**#197 — unchecked layer index.** `forward()` did `const LayerWeights& w = weights_[layer];` with no
range check, even though `set_layer_weights()` directly above it already range-checks the same index
(`if (layer >= 0 && layer < (int)weights_.size())`). An out-of-range `layer` is UB on the vector.
The inconsistency between the two functions is the tell.

**#204 — null weight pointers.** `LayerWeights` defaults every pointer to `nullptr`, and the
constructor only does `weights_.resize(cfg.num_layers)`. So any layer whose `set_layer_weights()`
was skipped left an all-null entry, and `forward()` dispatched `launch_moe_router_gemm` /
`launch_moe_expert_ffn` straight onto null device pointers.

## The fix

Two guards alongside the existing `num_tokens > max_tokens_` capacity check, in the same shape
(diagnose on stderr, refuse the launch):

```cpp
if (layer < 0 || layer >= (int)weights_.size()) {
    fprintf(stderr, "[moe] forward: layer %d out of range [0, %d) — skipping\n",
            layer, (int)weights_.size());
    return;
}
const LayerWeights& w = weights_[layer];
if (!w.router_w || !w.gate_w || !w.up_w || !w.down_w) {
    fprintf(stderr, "[moe] forward: layer %d weights unset — skipping\n", layer);
    return;
}
```

Pure input validation — no behaviour change on any correctly-configured call, since a valid layer
with weights set takes neither branch.

## Note on #198

While here I checked #198 ("cap num_tokens in Router::route"): `forward()` **already** has the
`num_tokens > max_tokens_` guard with an explanatory comment about `d_logits_`/`d_ids_`/`d_weights_`
overflow, so that part appears already addressed on `main`. I left it alone rather than fold an
unrelated claim into this PR.

## Verification

**I could not compile this change** — the machine I prepared it on has no CUDA toolkit and no host
compiler, so `cmake`/`ctest` could not run. Flagging that plainly rather than implying otherwise.
The change is additive input validation using only `weights_` (already in scope), the `layer`
parameter, and `fprintf` (already used in this function), so it should be low-risk, but it does
need a CI/maintainer build to confirm.

## Notes

Non-speedup correctness fix — earns no SN74 emission, filed because both issues are real gaps.
Proof-of-speedup section removed per CONTRIBUTING (no GPU eval needed). Touches only `moe/`.

Closes #197
Closes #204
