### PR TITLE
eval: let prefill gains drive Qwen3.5 headline label

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -606,13 +606,36 @@ PY
   echo "$DECODE_LINE"
   exit 0
 fi
-PREFILL_LINE="$(SPARKINFER_DIFFICULTY_REF="$PREFILL_SELECTED_LLAMA_REF" python3 "$HERE/label.py" "$PREFILL_SELECTED_TPS" "$PREFILL_SELECTED_FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT" "{}")"
+PREFILL_LINE="$(SPARKINFER_DIFFICULTY_REF="$(python3 - <<PY
+# llama-batched pp refs (~11k) are not comparable to sparkinfer sequential pp (~300).
+# Tier on same-box frontier when the llama ref is the wrong scale (label.py uses frontier if DIFF_REF<=0).
+tps=float("${PREFILL_SELECTED_TPS:-0}")
+llama=float("${PREFILL_SELECTED_LLAMA_REF:-0}")
+print(llama if llama > 0 and tps > 0 and llama < tps * 50 else 0)
+PY
+)" SPARKINFER_DIFFICULTY_BOOST="${SPARKINFER_DIFFICULTY_BOOST:-1}" \
+  python3 "$HERE/label.py" "$PREFILL_SELECTED_TPS" "$PREFILL_SELECTED_FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT" "{}")"
 DECODE_LINE="$DECODE_LINE" PREFILL_LINE="$PREFILL_LINE" python3 - <<'PY'
 import json, os
+
+TIER_RANK = {"XL": 6, "L": 5, "M": 4, "S": 3, "XS": 2, "none": 1, "BASELINE": 0, "REJECT": -1}
+
+def tier_rank(label):
+    return TIER_RANK.get(label or "none", -1)
+
+def copy_scoring_fields(dst, src):
+    for key in ("label", "tps", "frontier_tps", "delta_tps", "pct_over_frontier",
+                "pct_of_llama", "effective_pct", "note"):
+        if key in src and src[key] is not None:
+            dst[key] = src[key]
+    if src.get("difficulty_mult") is not None:
+        dst["difficulty_mult"] = src["difficulty_mult"]
+
 decode_line = os.environ.get("DECODE_LINE", "").strip()
 prefill_raw = os.environ.get("PREFILL_LINE", "").strip()
 if not decode_line.startswith("RESULT_JSON "):
-    print(decode_line); raise SystemExit(0)
+    print(decode_line)
+    raise SystemExit(0)
 res = json.loads(decode_line[len("RESULT_JSON "):])
 if prefill_raw.startswith("RESULT_JSON "):
     pf = json.loads(prefill_raw[len("RESULT_JSON "):])
@@ -625,5 +648,11 @@ if prefill_raw.startswith("RESULT_JSON "):
     res["prefill_effective_pct"] = pf.get("effective_pct")
     if pf.get("difficulty_mult") is not None:
         res["prefill_difficulty_mult"] = pf["difficulty_mult"]
+    if tier_rank(pf.get("label")) > tier_rank(res.get("label")):
+        res["decode_label"] = res.get("label")
+        copy_scoring_fields(res, pf)
+        res["score_metric"] = "prefill"
+    else:
+        res["score_metric"] = "decode"
 print("RESULT_JSON " + json.dumps(res))
 PY

--- a/bench/scripts/test_label.py
+++ b/bench/scripts/test_label.py
@@ -156,6 +156,13 @@ class LabelPolicyTest(unittest.TestCase):
         self.assertEqual(res["label"], "BASELINE")
         self.assertTrue(res["pass"])
 
+    def test_prefill_frontier_scale_scores_L_at_eleven_pct(self):
+        # PR #387-shaped: ~11% sequential prefill pp over same-box main; llama-batched ref is wrong scale.
+        res = score(320.28, frontier=288.21, top1=0.94, kl=0.03,
+                    env={"SPARKINFER_DIFFICULTY_REF": "0", "SPARKINFER_DIFFICULTY_BOOST": "1"})
+        self.assertEqual(res["label"], "L")
+        self.assertGreater(res["pct_over_frontier"], 10.0)
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/bench/scripts/test_prefill_label_merge.py
+++ b/bench/scripts/test_prefill_label_merge.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Tests for decode/prefill headline label merge in evaluate.sh.
+
+Run from the repo root:
+  python3 bench/scripts/test_prefill_label_merge.py
+"""
+import json
+import unittest
+
+TIER_RANK = {"XL": 6, "L": 5, "M": 4, "S": 3, "XS": 2, "none": 1, "BASELINE": 0, "REJECT": -1}
+
+
+def tier_rank(label):
+    return TIER_RANK.get(label or "none", -1)
+
+
+def merge_decode_prefill(decode, prefill):
+    res = dict(decode)
+    pf = dict(prefill)
+    res["prefill_label"] = pf.get("label")
+    res["prefill_tps"] = pf.get("tps")
+    if tier_rank(pf.get("label")) > tier_rank(res.get("label")):
+        res["decode_label"] = res.get("label")
+        for key in ("label", "tps", "frontier_tps", "delta_tps", "pct_over_frontier"):
+            if key in pf:
+                res[key] = pf[key]
+        res["score_metric"] = "prefill"
+    else:
+        res["score_metric"] = "decode"
+    return res
+
+
+class PrefillLabelMergeTest(unittest.TestCase):
+    def test_prefill_L_beats_decode_none(self):
+        out = merge_decode_prefill(
+            {"label": "none", "tps": 283.16, "frontier_tps": 283.28},
+            {"label": "L", "tps": 320.28, "frontier_tps": 288.21,
+             "delta_tps": 32.07, "pct_over_frontier": 11.1},
+        )
+        self.assertEqual(out["label"], "L")
+        self.assertEqual(out["decode_label"], "none")
+        self.assertEqual(out["score_metric"], "prefill")
+        self.assertEqual(out["prefill_label"], "L")
+
+    def test_decode_XS_beats_prefill_none(self):
+        out = merge_decode_prefill(
+            {"label": "XS", "tps": 300.0, "frontier_tps": 290.0},
+            {"label": "none", "tps": 291.0, "frontier_tps": 290.0},
+        )
+        self.assertEqual(out["label"], "XS")
+        self.assertEqual(out["score_metric"], "decode")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Promote prefill label to headline `label` when it beats decode tier on Qwen3.5 bidir evals
- Tier sequential prefill vs same-box frontier when llama-batched pp refs are wrong scale
- Add tests for label tiering and decode/prefill merge

## Test plan
- [x] `python3 bench/scripts/test_label.py`
- [x] `python3 bench/scripts/test_prefill_label_merge.py`
- [ ] Re-run PR #387 — expect `eval:L` from ~11% 4k prefill gain