### PR TITLE
perf(qwen36): Q6_K->Q4_K requant of LM head

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1657,7 +1657,13 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             return layer_index(name) >= ssm_out_min_layer;
         return false;
     };
-    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K", q35_dense9b_requant_default);
+    // LM-head (output projection) ships Q6_K on the Qwen3.6-35B-A3B UD build and is the single
+    // largest per-token weight read (vocab 248320 x H 2048 ~= 255 MB HBM/token, ~13% of decode).
+    // Requant it to Q4_K at load so decode routes through the faithful llama Q4_K mmvq GEMV
+    // (~1/3 fewer bytes; the path already exists via use_pq+use_llama). Default ON for the Qwen3.6
+    // fingerprint AND the Qwythos dense fingerprint; SPARKINFER_LMHEAD_REQUANT_Q4K=0 keeps native Q6_K.
+    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K",
+                                       q35_dense9b_requant_default || q36_ud_requant_default);
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
         if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8))


### PR DESCRIPTION
## Summary

Enable the existing Q4_K LM-head requant path for the **Qwen3.6-35B-A3B** fingerprint at
model load. The output projection (LM head) ships **Q6_K** on the Qwen3.6 UD build; it is the
single largest per-token weight read (`vocab 248320 x H 2048 ~= 255 MB` HBM/token) and dominates
a meaningful slice of decode bandwidth. The `SPARKINFER_LMHEAD_REQUANT_Q4K` seam was already
defaulting **on** for the Qwythos dense fingerprint (`q35_dense9b_requant_default`) but stayed
**off** for the Qwen3.6 fingerprint (`q36_ud_requant_default`) — this one-line default fix routes
Qwen3.6 decode through the faithful llama Q4_K `mmvq` GEMV that already exists via `use_pq+use_llama`
(~1/3 fewer bytes for that tensor). Touches only `runtime/` (one file). `SPARKINFER_LMHEAD_REQUANT_Q4K=0`
still forces native Q6_K.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `bench/scripts/bench.sh` sweep, `n=128, bs=1`; order-balanced
interleaved A/B, 3 rounds, per-context median — full log pasted below):

| context | decode tok/s |
|---|--:|
| before (main), ctx 0 | 95.31 |
| after (this PR), ctx 0 | 103.58 |
| before (main), ctx 512 | 93.97 |
| after (this PR), ctx 512 | 101.93 |
| before (main), ctx 4096 | 91.61 |
| after (this PR), ctx 4096 | 98.93 |

End-to-end decode gain: **+8.68%** (ctx 0), **+8.47%** (ctx 512), **+7.99%** (ctx 4096).

**Accuracy gate** (Q4_K LM-head vs Q6_K baseline, `qwen3_gguf_score`, 249 scored positions on the
Qwen3.6-35B natural token stream):
- **top-1 agreement (Q4_K vs Q6_K): 249/249 = 1.0000** — no top-1 token flips.
- **KL(base||new): mean 0.00668, median 0.00415, max 0.03573** — next-token distributions barely move.
- Perplexity (self, vs fed next token): **4.575 -> 4.549** (unchanged within noise).
- `ctest --test-dir build_rel`: **7/7 passed**.

```text
# bench/scripts/bench.sh sweep — order-balanced interleaved A/B (BASE = Q6_K LM-head main,
# Q4K = SPARKINFER_LMHEAD_REQUANT_Q4K=1), 3 rounds, one model load per run, ctx {0,512,4096}
===ROUND 1 BASE===
SWEEP_JSON {"0":{"decode_tps":102.3154},"512":{"decode_tps":98.3332,"prefill_pp":99.8777},"4096":{"decode_tps":93.0378,"prefill_pp":94.4355}}
===ROUND 1 Q4K===
SWEEP_JSON {"0":{"decode_tps":104.1561},"512":{"decode_tps":102.3730,"prefill_pp":103.7673},"4096":{"decode_tps":98.9332,"prefill_pp":100.9406}}
===ROUND 2 BASE===
SWEEP_JSON {"0":{"decode_tps":95.1348},"512":{"decode_tps":93.8532,"prefill_pp":94.8951},"4096":{"decode_tps":91.1062,"prefill_pp":92.6424}}
===ROUND 2 Q4K===
SWEEP_JSON {"0":{"decode_tps":103.0138},"512":{"decode_tps":101.1972,"prefill_pp":102.8500},"4096":{"decode_tps":98.5672,"prefill_pp":100.4379}}
===ROUND 3 BASE===
SWEEP_JSON {"0":{"decode_tps":95.3085},"512":{"decode_tps":93.9685,"prefill_pp":95.1578},"4096":{"decode_tps":91.6108,"prefill_pp":93.0957}}
===ROUND 3 Q4K===
SWEEP_JSON {"0":{"decode_tps":103.5844},"512":{"decode_tps":101.9310,"prefill_pp":103.3376},"4096":{"decode_tps":99.1585,"prefill_pp":100.9149}}

# per-context median across the 3 rounds:
#   ctx 0    BASE 95.31  ->  Q4K 103.58   (+8.68%)
#   ctx 512  BASE 93.97  ->  Q4K 101.93   (+8.47%)
#   ctx 4096 BASE 91.61  ->  Q4K  98.93   (+7.99%)
# GPU: RTX 5090, ~575 W, 615 MHz peak under load.

# accuracy (qwen3_gguf_score, 249 positions):
# BASE: PPL 4.57513   Q4K: PPL 4.54946
# top-1 agree (Q4K vs Q6K): 249/249 = 1.0000
# KL(base||new): mean 0.00668  median 0.00415  max 0.03573
```
