### PR TITLE
Require RTX 5090 greenlight for runtime PRs

### DIFF
--- a/.github/workflows/rtx5090-required.yml
+++ b/.github/workflows/rtx5090-required.yml
@@ -1,7 +1,8 @@
 name: rtx5090-required
 
 # Close PRs that leave the template "Tested on RTX 5090" checkbox unticked (`- [ ]`).
-# PRs that remove the proof section entirely (e.g. docs-only) are not auto-closed.
+# PRs touching runtime/ are also closed when the box is not ticked, even if the proof
+# section was removed. Docs-only PRs outside runtime/ without the checkbox are not closed.
 #
 # Contributor flow after auto-close:
 #   1. Edit the PR description: tick `- [x] Tested on RTX 5090` + fill benchmark tables.
@@ -50,8 +51,10 @@ jobs:
               );
             }
 
-            function rtx5090ShouldClose(body) {
-              return rtx5090HasCheckbox(body) && !rtx5090Checked(body);
+            function rtx5090ShouldClose(body, touchesRuntime) {
+              if (rtx5090Checked(body)) return false;
+              if (touchesRuntime) return true;
+              return rtx5090HasCheckbox(body);
             }
 
             function exempt(pr) {
@@ -64,20 +67,28 @@ jobs:
               return false;
             }
 
+            async function touchesRuntime(owner, repo, pull_number) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner, repo, pull_number, per_page: 100,
+              });
+              return files.some(f => f.filename.startsWith('runtime/'));
+            }
+
             async function maybeClose(pr) {
               if (!pr || pr.state !== 'open') return false;
               if (exempt(pr)) {
                 core.info(`#${pr.number}: exempt — skip rtx5090 gate`);
                 return false;
               }
+              const { owner, repo } = context.repo;
               const labels = (pr.labels || []).map(l => l.name);
               const legacyNotTested = labels.includes('not-tested');
-              if (!legacyNotTested && !rtx5090ShouldClose(pr.body)) {
-                core.info(`#${pr.number}: no unticked RTX 5090 checkbox — ok`);
+              const runtime = await touchesRuntime(owner, repo, pr.number);
+              if (!legacyNotTested && !rtx5090ShouldClose(pr.body, runtime)) {
+                core.info(`#${pr.number}: rtx5090 gate ok`);
                 return false;
               }
 
-              const { owner, repo } = context.repo;
               if (legacyNotTested) {
                 for (const lab of ['test-on-5090', 'not-tested', 'needs-benchmark']) {
                   if (labels.includes(lab)) {
@@ -87,29 +98,42 @@ jobs:
                   }
                 }
               }
-              await github.rest.issues.createComment({
-                owner, repo, issue_number: pr.number,
-                body:
-                  '<!-- sparkinfer-rtx5090-required -->\n' +
-                  '## Closed — RTX 5090 checkbox not ticked\n\n' +
-                  'This PR was auto-closed because the template includes **Tested on RTX 5090** ' +
+              const runtimeNote = runtime && !legacyNotTested
+                ? 'This PR touches **`runtime/`** and was auto-closed because **Tested on RTX 5090** ' +
+                  'is not ticked (`- [x]`). Runtime changes must show a real 5090 before/after benchmark ' +
+                  'to enter the eval queue.\n\n'
+                : 'This PR was auto-closed because the template includes **Tested on RTX 5090** ' +
                   'as `- [ ]` (unchecked). Evaluation is opt-in — tick the box only after a real ' +
-                  '5090 run.\n\n' +
-                  'To submit for review:\n\n' +
-                  '1. **Edit this PR description** (you can edit while closed): change to ' +
+                  '5090 run.\n\n';
+              const reopenNote = runtime && !legacyNotTested
+                ? '1. **Edit this PR description** (you can edit while closed): add or restore the ' +
+                  'proof-of-speedup section and tick `- [x] Tested on RTX 5090`\n' +
+                  '2. Fill the decode and/or prefill **before → after** tables with real ' +
+                  '`bench/scripts/bench.sh` numbers\n' +
+                  '3. **Reopen** this PR\n\n' +
+                  'Non-speed runtime fixes that should not be evaluated need a maintainer `hold` label.\n\n'
+                : '1. **Edit this PR description** (you can edit while closed): change to ' +
                   '`- [x] Tested on RTX 5090`\n' +
                   '2. Fill the decode and/or prefill **before → after** tables with real ' +
                   '`bench/scripts/bench.sh` numbers showing improvement\n' +
                   '3. **Reopen** this PR\n\n' +
                   'If this PR does not need GPU eval (e.g. docs-only), remove the proof-of-speedup ' +
-                  'section from the description instead of leaving an unchecked box.\n\n' +
+                  'section from the description instead of leaving an unchecked box.\n\n';
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: pr.number,
+                body:
+                  '<!-- sparkinfer-rtx5090-required -->\n' +
+                  '## Closed — RTX 5090 checkbox not ticked\n\n' +
+                  runtimeNote +
+                  'To submit for review:\n\n' +
+                  reopenNote +
                   `[CONTRIBUTING.md](https://github.com/${owner}/${repo}/blob/main/CONTRIBUTING.md)\n\n` +
                   '<sub>Automated by rtx5090-required CI. Maintainers and `hold` PRs are exempt.</sub>',
               });
               await github.rest.pulls.update({
                 owner, repo, pull_number: pr.number, state: 'closed',
               });
-              core.notice(`closed #${pr.number}: RTX 5090 checkbox unticked`);
+              core.notice(`closed #${pr.number}: RTX 5090 gate (${runtime ? 'runtime' : 'unchecked'})`);
               return true;
             }
 

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -227,7 +227,8 @@ AREAS = {"kernels", "runtime", "moe", "bench"}
 # box alone is not enough (it wasted GPU on PRs whose tables were still placeholder). States:
 # greenlit -> test-on-5090 (eval); box ticked but no valid before<after gain ->
 # needs-benchmark (skip + ask for numbers); box unticked -> auto-close (rtx5090-required).
-# There is NO manual override — every eval must pass the gate on real RTX 5090 before/after numbers.
+# PRs touching runtime/ must tick the box even when the proof section was removed — non-speed
+# runtime fixes stay out of the open queue until greenlit or exempted via hold/maintainer.
 EVAL_GATE_LABEL  = "test-on-5090"     # bot-set marker: greenlit, will be evaluated
 NOT_TESTED_LABEL = "not-tested"       # legacy label — removed on close; no longer applied
 NEEDS_BENCH_LABEL = "needs-benchmark" # box ticked but decode/prefill tables missing/invalid/no-gain
@@ -378,44 +379,67 @@ def rtx5090_close_exempt(pr):
     return False
 
 
-def post_rtx5090_unchecked_comment(repo, num):
+def post_rtx5090_unchecked_comment(repo, num, runtime=False):
     owner, r = _owner_repo(repo)
+    if runtime:
+        reason = (
+            "This PR touches **`runtime/`** and was auto-closed because **Tested on RTX 5090** "
+            "is not ticked (`- [x]`). Runtime changes must show a real 5090 before/after benchmark "
+            "to enter the eval queue."
+        )
+        reopen = (
+            "1. **Edit this PR description** (you can edit while closed): add or restore the "
+            "proof-of-speedup section and tick `- [x] Tested on RTX 5090`\n"
+            "2. Fill the decode and/or prefill **before → after** tables with real "
+            "`bench/scripts/bench.sh` numbers\n"
+            "3. **Reopen** this PR\n\n"
+            "Non-speed runtime fixes that should not be evaluated need a maintainer `hold` label."
+        )
+    else:
+        reason = (
+            "This PR was auto-closed because the template includes **Tested on RTX 5090** "
+            "as `- [ ]` (unchecked). Evaluation is opt-in — tick the box only after a real "
+            "5090 run."
+        )
+        reopen = (
+            "1. **Edit this PR description** (you can edit while closed): change to "
+            "`- [x] Tested on RTX 5090`\n"
+            "2. Fill the decode and/or prefill **before → after** tables with real "
+            "`bench/scripts/bench.sh` numbers showing improvement\n"
+            "3. **Reopen** this PR\n\n"
+            "If this PR does not need GPU eval (e.g. docs-only), remove the proof-of-speedup "
+            "section from the description instead of leaving an unchecked box."
+        )
     body = (
         "<!-- sparkinfer-rtx5090-required -->\n"
-        "## Closed — RTX 5090 checkbox not ticked\n\n"
-        "This PR was auto-closed because the template includes **Tested on RTX 5090** "
-        "as `- [ ]` (unchecked). Evaluation is opt-in — tick the box only after a real "
-        "5090 run.\n\n"
+        f"## Closed — RTX 5090 checkbox not ticked\n\n"
+        f"{reason}\n\n"
         "To submit for review:\n\n"
-        "1. **Edit this PR description** (you can edit while closed): change to "
-        "`- [x] Tested on RTX 5090`\n"
-        "2. Fill the decode and/or prefill **before → after** tables with real "
-        "`bench/scripts/bench.sh` numbers showing improvement\n"
-        "3. **Reopen** this PR\n\n"
-        "If this PR does not need GPU eval (e.g. docs-only), remove the proof-of-speedup "
-        "section from the description instead of leaving an unchecked box.\n\n"
+        f"{reopen}\n\n"
         f"[CONTRIBUTING.md](https://github.com/{owner}/{r}/blob/main/CONTRIBUTING.md)\n\n"
         "<sub>Automated by eval bot / rtx5090-required CI.</sub>"
     )
     gh(["pr", "comment", str(num), "-R", repo, "--body", body])
 
 
-def close_rtx5090_unchecked_pr(repo, num, dry_run=False):
+def close_rtx5090_unchecked_pr(repo, num, dry_run=False, runtime=False):
     """Close one PR with unticked RTX 5090 checkbox (or legacy not-tested label)."""
     if dry_run:
         return True
     for lab in (EVAL_GATE_LABEL, NOT_TESTED_LABEL, NEEDS_BENCH_LABEL):
         if lab in labels_on(repo, num):
             remove_label(repo, num, lab)
-    post_rtx5090_unchecked_comment(repo, num)
+    post_rtx5090_unchecked_comment(repo, num, runtime=runtime)
     gh(["pr", "close", str(num), "-R", repo, "-c", "closed"])
     return True
 
 
 def close_unchecked_rtx5090_prs(repo, dry_run=False):
-    """Close open PRs with unticked RTX 5090 checkbox or legacy not-tested label.
+    """Close open PRs with unticked RTX 5090 checkbox, legacy not-tested label, or runtime/
+    changes without a ticked box.
 
-    Docs-only PRs without the template checkbox are left open. Returns PR numbers closed.
+    Docs-only PRs outside runtime/ without the template checkbox are left open.
+    Returns PR numbers closed.
     """
     prs = json.loads(gh(["pr", "list", "-R", repo, "--state", "open",
                          "--json", "number,title,labels,isDraft,author,authorAssociation"]).stdout or "[]")
@@ -428,14 +452,18 @@ def close_unchecked_rtx5090_prs(repo, dry_run=False):
         legacy = NOT_TESTED_LABEL in labels
         body = (json.loads(gh(["pr", "view", str(num), "-R", repo, "--json", "body"]).stdout or "{}")
                 .get("body") or "")
-        if not legacy and not rtx5090_should_close(body):
+        areas = areas_for_pr(repo, num)
+        runtime_gate = "runtime" in areas
+        if not legacy and not rtx5090_should_close(body, areas):
             continue
-        print(f"PR #{num}: RTX 5090 unchecked{' (legacy not-tested)' if legacy else ''}"
+        why = "legacy not-tested" if legacy else ("runtime without ticked box" if runtime_gate
+                                                    else "unchecked checkbox")
+        print(f"PR #{num}: RTX 5090 gate ({why})"
               f"{' — would close' if dry_run else ' — closing'}")
         if dry_run:
             closed.add(num)
             continue
-        close_rtx5090_unchecked_pr(repo, num)
+        close_rtx5090_unchecked_pr(repo, num, runtime=runtime_gate and not legacy)
         closed.add(num)
     if closed:
         print(f">> close_unchecked_rtx5090: {'would close' if dry_run else 'closed'} "
@@ -679,9 +707,15 @@ def rtx5090_box_checked(body):
         for ln in (body or "").splitlines()
     )
 
-def rtx5090_should_close(body):
-    """True when the 5090 checkbox is present in the PR body but not ticked."""
-    return rtx5090_has_checkbox(body) and not rtx5090_box_checked(body)
+def rtx5090_should_close(body, areas=None):
+    """True when the 5090 box is not ticked and either the template checkbox is present
+    unchecked, or the PR touches runtime/ (runtime changes require greenlight)."""
+    if rtx5090_box_checked(body):
+        return False
+    areas = areas or set()
+    if "runtime" in areas:
+        return True
+    return rtx5090_has_checkbox(body)
 
 def greenlight_status(repo, num, pr_labels):
     """Decide whether a PR may be evaluated. Returns (status, reason):
@@ -1912,6 +1946,9 @@ def main():
         unchecked_closed = close_unchecked_rtx5090_prs(args.repo, dry_run=args.dry_run)
         if unchecked_closed:
             prs = [p for p in prs if p["number"] not in unchecked_closed]
+        exhausted_closed = close_exhausted_eval_prs(args.repo, dry_run=args.dry_run)
+        if exhausted_closed:
+            prs = [p for p in prs if p["number"] not in exhausted_closed]
     if only_set:
         prs = [p for p in prs if p["number"] in only_set]
         if not prs:

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -672,10 +672,11 @@ class PrEvalBotPolicyTest(unittest.TestCase):
             return mock.Mock(returncode=0)
 
         with mock.patch.object(bot, "gh", side_effect=fake_gh), \
+             mock.patch.object(bot, "areas_for_pr", return_value=set()), \
              mock.patch.object(bot, "close_rtx5090_unchecked_pr") as close_one:
             closed = bot.close_unchecked_rtx5090_prs("gittensor-ai-lab/sparkinfer")
         self.assertEqual(closed, {10})
-        close_one.assert_called_once_with("gittensor-ai-lab/sparkinfer", 10)
+        close_one.assert_called_once_with("gittensor-ai-lab/sparkinfer", 10, runtime=False)
 
     def test_close_unchecked_legacy_not_tested_label(self):
         ticked = self._TEMPLATE_DECODE.format(db=300, da=320)
@@ -689,10 +690,33 @@ class PrEvalBotPolicyTest(unittest.TestCase):
             return mock.Mock(returncode=0)
 
         with mock.patch.object(bot, "gh", side_effect=fake_gh), \
+             mock.patch.object(bot, "areas_for_pr", return_value=set()), \
              mock.patch.object(bot, "close_rtx5090_unchecked_pr") as close_one:
             closed = bot.close_unchecked_rtx5090_prs("gittensor-ai-lab/sparkinfer")
         self.assertEqual(closed, {11})
-        close_one.assert_called_once_with("gittensor-ai-lab/sparkinfer", 11)
+        close_one.assert_called_once_with("gittensor-ai-lab/sparkinfer", 11, runtime=False)
+
+    def test_close_unchecked_closes_runtime_without_checkbox(self):
+        pr, body = self._unchecked_pr(30, body="runtime correctness fix — no proof section")
+
+        def fake_gh(args):
+            if args[:3] == ["pr", "list", "-R"]:
+                return mock.Mock(stdout=json.dumps([pr]))
+            if args[:4] == ["pr", "view", "30", "-R"]:
+                return mock.Mock(stdout=json.dumps({"body": body}))
+            return mock.Mock(returncode=0)
+
+        with mock.patch.object(bot, "gh", side_effect=fake_gh), \
+             mock.patch.object(bot, "areas_for_pr", return_value={"runtime"}), \
+             mock.patch.object(bot, "close_rtx5090_unchecked_pr") as close_one:
+            closed = bot.close_unchecked_rtx5090_prs("gittensor-ai-lab/sparkinfer")
+        self.assertEqual(closed, {30})
+        close_one.assert_called_once_with("gittensor-ai-lab/sparkinfer", 30, runtime=True)
+
+    def test_rtx5090_should_close_runtime_without_checkbox(self):
+        self.assertTrue(bot.rtx5090_should_close("no checkbox", {"runtime"}))
+        self.assertFalse(bot.rtx5090_should_close("no checkbox", {"kernels"}))
+        self.assertFalse(bot.rtx5090_should_close("docs only", set()))
 
     def test_close_unchecked_skips_exempt_and_no_checkbox(self):
         unchecked_body = self._TEMPLATE_DECODE.format(db=300, da=320).replace("[x]", "[ ]")
@@ -716,6 +740,7 @@ class PrEvalBotPolicyTest(unittest.TestCase):
             return mock.Mock(returncode=0)
 
         with mock.patch.object(bot, "gh", side_effect=fake_gh), \
+             mock.patch.object(bot, "areas_for_pr", return_value=set()), \
              mock.patch.object(bot, "close_rtx5090_unchecked_pr") as close_one:
             closed = bot.close_unchecked_rtx5090_prs("gittensor-ai-lab/sparkinfer", dry_run=True)
         self.assertEqual(closed, {25})


### PR DESCRIPTION
## Summary
- Auto-close open `runtime/` PRs when the RTX 5090 box is not ticked, even if the proof section was removed.
- Mirror the same rule in `rtx5090-required` CI (checks changed files).
- Run `close_exhausted_eval_prs` on each eval-bot poll (not only the daily cron).

## Test plan
- [x] `python3 -m unittest test_pr_eval_bot.PrEvalBotPolicyTest.test_close_unchecked_* test_pr_eval_bot.PrEvalBotPolicyTest.test_rtx5090_should_close_runtime_without_checkbox`
- [ ] Next bot poll / `close-stale-prs` sweep should close runtime PRs #438–#442 without ticked boxes