### PR TITLE
dashboard: refresh Qwen3.5 prefill frontier

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -5241,7 +5241,7 @@ window.SPARKINFER = {
     "ref_tps": 220.84,
     "token_match": 0.9326,
     "kl": 0.0274,
-    "note": "same-box baseline 91.224.44.227 (KV cap fix, origin/main 6981821, 2026-07-14)",
+    "note": "same-box baseline 91.224.44.227 · prefill pp refs from reference.lock (2026-07-13, RTX 5090)",
     "ctx": [
       {
         "label": "128",
@@ -5372,6 +5372,14 @@ window.SPARKINFER = {
       "label": "XL",
       "tps": 303.18,
       "raw_tps": 300.43
+    },
+    {
+      "name": "skip LM head on prefill + ",
+      "pr": 387,
+      "date": "2026-07-15",
+      "label": "L",
+      "tps": 294.96,
+      "raw_tps": 320.33
     }
   ],
   "qwen36": {

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -5240,7 +5240,7 @@
     "ref_tps": 220.84,
     "token_match": 0.9326,
     "kl": 0.0274,
-    "note": "same-box baseline 91.224.44.227 (KV cap fix, origin/main 6981821, 2026-07-14)",
+    "note": "same-box baseline 91.224.44.227 · prefill pp refs from reference.lock (2026-07-13, RTX 5090)",
     "ctx": [
       {
         "label": "128",
@@ -5371,6 +5371,14 @@
       "label": "XL",
       "tps": 303.18,
       "raw_tps": 300.43
+    },
+    {
+      "name": "skip LM head on prefill + ",
+      "pr": 387,
+      "date": "2026-07-15",
+      "label": "L",
+      "tps": 294.96,
+      "raw_tps": 320.33
     }
   ],
   "qwen36": {

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1031,11 +1031,12 @@ Q35_CTX_SERIES = {
     65536:  {"label": "64k",  "ref_tps": 220.54},
 }
 # Qwen3.5 prefill pp anchors — pinned in bench/scripts/reference.lock (RTX 5090).
-Q35_PP_ORDER = ("4k", "32k", "64k")
+Q35_PP_ORDER = ("4k", "32k", "64k", "128k")
 Q35_PP_SERIES = {
     4096:   {"label": "4k",   "metric": "ctx_4096_pp_tps",  "ref_pp": 11104.62, "color": "#0E8A16"},
     32768:  {"label": "32k",  "metric": "ctx_32768_pp_tps", "ref_pp": 9772.31,  "color": "#6F42C1"},
     65536:  {"label": "64k",  "metric": "ctx_65536_pp_tps", "ref_pp": 8153.53,  "color": "#E67E22"},
+    131072: {"label": "128k", "metric": "ctx_131072_pp_tps", "ref_pp": 5999.59, "color": "#17A2B8"},
 }
 Q36_CTX_ORDER = ("128", "512", "4k", "16k", "32k")
 # Qwen3.6-35B-A3B llama.cpp decode refs (RTX 5090) — pinned in bench/scripts/reference.lock


### PR DESCRIPTION
## Summary
- Confirm Qwen3.5 prefill dashboard bars from `reference.lock` (290.57 pp XL @ 4k; 32k/64k/128k pp vs llama.cpp refs).
- Add PR #387 to `landed_qwen35` journey.
- Include 128k in `Q35_PP_SERIES` for future merge sync.

## Test plan
- [x] Regenerated `dashboard/data.js` from `data.json`
- [ ] Open `dashboard/index.html` and verify Qwen3.5 prefill section