### PR TITLE
fix(eval): bidir headline REJECT beats none when one side fails

### DIFF
--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -473,8 +473,18 @@ def pick_best(a, b):
         return a if ra > rb else b
     return a if float(a.get("tps") or 0) >= float(b.get("tps") or 0) else b
 
-passing = [s for s in (score35, score36) if s.get("pass")]
-best = pick_best(score35, score36) if passing else pick_best(score35, score36)
+def pick_headline(a, b):
+    """Headline verdict: a failing optimize run must not lose to the other's none."""
+    if not a.get("pass") or not b.get("pass"):
+        for s in (a, b):
+            if not s.get("pass") and s.get("label") == "REJECT":
+                return dict(s)
+        for s in (a, b):
+            if not s.get("pass"):
+                return dict(s)
+    return pick_best(a, b)
+
+best = pick_headline(score35, score36)
 
 final = dict(best)
 final["commit"] = commit

--- a/bench/scripts/test_bidir_headline.py
+++ b/bench/scripts/test_bidir_headline.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Bidir headline pick: REJECT must beat none when one optimize fails.
+
+Run from repo root:
+  python3 bench/scripts/test_bidir_headline.py
+"""
+import unittest
+
+TIER_RANK = {"XL": 6, "L": 5, "M": 4, "S": 3, "XS": 2, "none": 1, "BASELINE": 0, "REJECT": -1}
+
+
+def pick_best(a, b):
+    ra, rb = TIER_RANK.get(a.get("label"), -1), TIER_RANK.get(b.get("label"), -1)
+    if ra != rb:
+        return a if ra > rb else b
+    return a if float(a.get("tps") or 0) >= float(b.get("tps") or 0) else b
+
+
+def pick_headline(a, b):
+    if not a.get("pass") or not b.get("pass"):
+        for s in (a, b):
+            if not s.get("pass") and s.get("label") == "REJECT":
+                return dict(s)
+        for s in (a, b):
+            if not s.get("pass"):
+                return dict(s)
+    return pick_best(a, b)
+
+
+class BidirHeadlineTest(unittest.TestCase):
+    def test_reject_beats_none(self):
+        q35 = {"label": "REJECT", "pass": False, "tps": 298.1, "reason": "prefill regressed"}
+        q36 = {"label": "none", "pass": True, "tps": 441.98}
+        out = pick_headline(q35, q36)
+        self.assertEqual(out["label"], "REJECT")
+        self.assertFalse(out["pass"])
+
+    def test_both_pass_picks_best_tier(self):
+        q35 = {"label": "none", "pass": True, "tps": 283.0}
+        q36 = {"label": "L", "pass": True, "tps": 480.0}
+        out = pick_headline(q35, q36)
+        self.assertEqual(out["label"], "L")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `pick_headline()` so a failing optimize run (e.g. Qwen3.5 prefill regression) sets headline `eval:REJECT` instead of the other side's `none`
- Fixes mislabeled PRs like #403 (`eval-qwen35:REJECT` but headline `eval:none`)

## Test plan
- [x] `python3 bench/scripts/test_bidir_headline.py`