### PR TITLE
feat(eval): auto-close draft PRs inactive for 4+ days

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -144,8 +144,9 @@ manually after review. Idempotent: each commit is evaluated once (tracked by a h
 bot's comment), so it only spins the GPU when there's new work.
 
 Each bot run also **closes open PRs with no GitHub activity for 2+ days** (`updatedAt` — commits,
-comments, reviews, label changes). PRs labeled `hold` or `merge-first` are skipped. Override with
-`SPARKINFER_STALE_PR_DAYS=0` to disable, or set a different threshold.
+comments, reviews, label changes). **Draft PRs** use a separate **4-day** threshold (still skipped
+for evaluation). PRs labeled `hold` or `merge-first` are skipped. Override with
+`SPARKINFER_STALE_PR_DAYS=0` / `SPARKINFER_DRAFT_STALE_DAYS=0` to disable, or set different thresholds.
 
 ```bash
 eval/setup_labels.sh                                   # one-time: create the eval:* labels

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -241,6 +241,7 @@ RTX5090_CLOSE_SKIP_LABELS = {HOLD_LABEL}
 RTX5090_EXEMPT_LOGINS = {"ai-hpc"}
 RTX5090_EXEMPT_ASSOC = frozenset({"OWNER", "MEMBER", "COLLABORATOR"})
 STALE_PR_DAYS      = int(os.environ.get("SPARKINFER_STALE_PR_DAYS", "2"))
+DRAFT_STALE_DAYS   = int(os.environ.get("SPARKINFER_DRAFT_STALE_DAYS", "4"))
 STALE_CLOSE_SKIP_LABELS = {HOLD_LABEL, MERGE_FIRST_LABEL}  # protected from auto-close
 EXHAUSTED_EVAL_MAX = int(os.environ.get("SPARKINFER_EXHAUSTED_EVAL_MAX", "2"))
 FAIL_VERDICT_LABELS = frozenset({"none", "REJECT"})
@@ -324,20 +325,27 @@ def pr_inactive_days(pr, now=None):
     return (now - updated).total_seconds() / 86400.0
 
 
-def close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=False):
+def close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=False, *, drafts_only=None):
     """Close open PRs with no GitHub activity for more than `days` days.
 
     Uses PR updatedAt (commits, comments, reviews, label changes). Skips PRs labeled
-    `hold` or `merge-first`. Returns the set of PR numbers closed (or would-close in dry-run).
-  """
+    `hold` or `merge-first`. When `drafts_only` is False, draft PRs are skipped (they are
+    handled by close_stale_draft_prs). Returns the set of PR numbers closed (or would-close
+    in dry-run).
+    """
     if days <= 0:
         return set()
     now = datetime.datetime.now(datetime.timezone.utc)
     prs = json.loads(gh(["pr", "list", "-R", repo, "--state", "open",
-                         "--json", "number,title,updatedAt,labels"]).stdout or "[]")
+                         "--json", "number,title,updatedAt,labels,isDraft"]).stdout or "[]")
     closed = set()
     for pr in prs:
         num = pr["number"]
+        is_draft = bool(pr.get("isDraft"))
+        if drafts_only is True and not is_draft:
+            continue
+        if drafts_only is False and is_draft:
+            continue
         labels = {l["name"] for l in pr.get("labels", [])}
         if labels & STALE_CLOSE_SKIP_LABELS:
             continue
@@ -345,23 +353,38 @@ def close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=False):
         if inactive is None or inactive <= days:
             continue
         days_idle = int(inactive)
-        print(f"PR #{num}: stale — no activity for {days_idle}d (limit {days}d)"
+        kind = "draft stale" if is_draft else "stale"
+        print(f"PR #{num}: {kind} — no activity for {days_idle}d (limit {days}d)"
               f"{' — would close' if dry_run else ' — closing'}")
         if dry_run:
             closed.add(num)
             continue
-        body = ("<!-- sparkinfer-stale -->\n"
-                f"## Closed: no activity for {days}+ days\n\n"
-                f"This PR has had no updates (commits, comments, reviews, or label changes) "
-                f"for **{days_idle} days** (threshold: {days} days).\n\n"
-                "Reopen this PR or open a fresh one when you're ready to continue.")
+        marker = "<!-- sparkinfer-stale-draft -->" if is_draft else "<!-- sparkinfer-stale -->"
+        if is_draft:
+            body = (f"{marker}\n"
+                    f"## Closed: draft inactive for {days}+ days\n\n"
+                    f"This **draft** PR has had no updates (commits, comments, reviews, or label "
+                    f"changes) for **{days_idle} days** (draft threshold: {days} days).\n\n"
+                    "Mark ready for review or reopen when you're ready to continue.")
+        else:
+            body = (f"{marker}\n"
+                    f"## Closed: no activity for {days}+ days\n\n"
+                    f"This PR has had no updates (commits, comments, reviews, or label changes) "
+                    f"for **{days_idle} days** (threshold: {days} days).\n\n"
+                    "Reopen this PR or open a fresh one when you're ready to continue.")
         gh(["pr", "comment", str(num), "-R", repo, "--body", body])
         if gh(["pr", "close", str(num), "-R", repo]).returncode == 0:
             closed.add(num)
     if closed:
-        print(f">> close_stale_prs: {'would close' if dry_run else 'closed'} {len(closed)} PR(s): "
+        tag = "close_stale_draft_prs" if drafts_only else "close_stale_prs"
+        print(f">> {tag}: {'would close' if dry_run else 'closed'} {len(closed)} PR(s): "
               f"{sorted(closed)}")
     return closed
+
+
+def close_stale_draft_prs(repo, days=DRAFT_STALE_DAYS, dry_run=False):
+    """Close draft PRs with no GitHub activity for more than `days` days (default 4)."""
+    return close_stale_prs(repo, days=days, dry_run=dry_run, drafts_only=True)
 
 
 def rtx5090_close_exempt(pr):
@@ -530,10 +553,11 @@ def close_exhausted_eval_prs(repo, max_none_reject=EXHAUSTED_EVAL_MAX, dry_run=F
 
 
 def run_poll_auto_closes(repo, dry_run=False):
-    """Stale / unchecked-5090 / exhausted-eval sweeps — run at each bot poll tick."""
+    """Stale / draft-stale / unchecked-5090 / exhausted-eval sweeps — run at each bot poll tick."""
     closed = set()
     for got in (
-        close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=dry_run),
+        close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=dry_run, drafts_only=False),
+        close_stale_draft_prs(repo, dry_run=dry_run),
         close_unchecked_rtx5090_prs(repo, dry_run=dry_run),
         close_exhausted_eval_prs(repo, dry_run=dry_run),
     ):

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -671,13 +671,51 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual(closed, set())
 
     def test_close_stale_prs_dry_run(self):
-        prs = [{"number": 99, "updatedAt": "2026-01-01T00:00:00Z", "labels": []}]
+        prs = [{"number": 99, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": False}]
         gh_mock = mock.Mock(return_value=mock.Mock(stdout=json.dumps(prs)))
         with mock.patch.object(bot, "gh", gh_mock), \
              mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
             closed = bot.close_stale_prs("gittensor-ai-lab/sparkinfer", days=2, dry_run=True)
         self.assertEqual(closed, {99})
         gh_mock.assert_called_once()
+
+    def test_close_stale_prs_skips_drafts_when_non_draft_only(self):
+        prs = [
+            {"number": 50, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": True},
+            {"number": 51, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": False},
+        ]
+        with mock.patch.object(bot, "gh", return_value=mock.Mock(stdout=json.dumps(prs))), \
+             mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
+            closed = bot.close_stale_prs("gittensor-ai-lab/sparkinfer", days=2,
+                                         dry_run=True, drafts_only=False)
+        self.assertEqual(closed, {51})
+
+    def test_close_stale_draft_prs_closes_inactive_drafts(self):
+        prs = [
+            {"number": 60, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": True},
+            {"number": 61, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": False},
+        ]
+        gh_calls = []
+
+        def fake_gh(args):
+            gh_calls.append(args)
+            if args[:3] == ["pr", "list", "-R"]:
+                return mock.Mock(stdout=json.dumps(prs))
+            return mock.Mock(returncode=0)
+
+        with mock.patch.object(bot, "gh", side_effect=fake_gh), \
+             mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
+            closed = bot.close_stale_draft_prs("gittensor-ai-lab/sparkinfer", days=4, dry_run=False)
+        self.assertEqual(closed, {60})
+        self.assertTrue(any(c[:3] == ["pr", "close", "60"] for c in gh_calls))
+
+    def test_close_stale_draft_prs_skips_hold(self):
+        prs = [{"number": 70, "updatedAt": "2026-01-01T00:00:00Z",
+                "labels": [{"name": "hold"}], "isDraft": True}]
+        with mock.patch.object(bot, "gh", return_value=mock.Mock(stdout=json.dumps(prs))), \
+             mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
+            closed = bot.close_stale_draft_prs("gittensor-ai-lab/sparkinfer", days=4)
+        self.assertEqual(closed, set())
 
     def _unchecked_pr(self, num, body=None, labels=None, **extra):
         body = body or self._TEMPLATE_DECODE.format(db=300, da=320).replace("[x]", "[ ]")
@@ -909,10 +947,11 @@ class ExhaustedEvalCloseTest(unittest.TestCase):
 
     def test_run_poll_auto_closes(self):
         with mock.patch.object(bot, "close_stale_prs", return_value={1}), \
+             mock.patch.object(bot, "close_stale_draft_prs", return_value={4}), \
              mock.patch.object(bot, "close_unchecked_rtx5090_prs", return_value={2}), \
              mock.patch.object(bot, "close_exhausted_eval_prs", return_value={3}):
             closed = bot.run_poll_auto_closes("gittensor-ai-lab/sparkinfer")
-        self.assertEqual(closed, {1, 2, 3})
+        self.assertEqual(closed, {1, 2, 3, 4})
 
     def test_maybe_close_exhausted_pr(self):
         view_mock = mock.Mock(return_value=mock.Mock(


### PR DESCRIPTION
## Summary
- On each eval bot poll, close **draft** PRs with no GitHub activity for **4+ days** (`updatedAt`)
- Non-draft PRs keep the existing **2-day** stale close; drafts are excluded from that sweep
- Skips `hold` and `merge-first` labels; override with `SPARKINFER_DRAFT_STALE_DAYS=0`

## Test plan
- [x] `python3 -m unittest test_pr_eval_bot.PrEvalBotPolicyTest.test_close_stale_draft_prs_closes_inactive_drafts test_pr_eval_bot.PrEvalBotPolicyTest.test_close_stale_prs_skips_drafts_when_non_draft_only test_pr_eval_bot.ExhaustedEvalCloseTest.test_run_poll_auto_closes -v`