### PR TITLE
fix(eval): close drafts by draft age, not activity

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -144,8 +144,9 @@ manually after review. Idempotent: each commit is evaluated once (tracked by a h
 bot's comment), so it only spins the GPU when there's new work.
 
 Each bot run also **closes open PRs with no GitHub activity for 2+ days** (`updatedAt` — commits,
-comments, reviews, label changes). **Draft PRs** use a separate **4-day** threshold (still skipped
-for evaluation). PRs labeled `hold` or `merge-first` are skipped. Override with
+comments, reviews, label changes). **Draft PRs** are closed after **4+ days in draft status**
+(`createdAt` or latest `converted_to_draft`; activity does not reset the clock). PRs labeled
+`hold` or `merge-first` are skipped. Override with
 `SPARKINFER_STALE_PR_DAYS=0` / `SPARKINFER_DRAFT_STALE_DAYS=0` to disable, or set different thresholds.
 
 ```bash

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -325,6 +325,39 @@ def pr_inactive_days(pr, now=None):
     return (now - updated).total_seconds() / 86400.0
 
 
+def pr_draft_since(repo, pr):
+    """When the PR's current draft period began.
+
+    Uses the latest ``converted_to_draft`` timeline event when present; otherwise
+    ``createdAt`` for PRs opened as draft.
+    """
+    owner, r = _owner_repo(repo)
+    num = pr["number"]
+    latest_convert = None
+    out = gh(["api", f"repos/{owner}/{r}/issues/{num}/timeline"])
+    if out.returncode == 0:
+        for e in json.loads(out.stdout or "[]"):
+            if e.get("event") != "converted_to_draft":
+                continue
+            ts = _parse_github_time(e.get("created_at"))
+            if ts and (latest_convert is None or ts > latest_convert):
+                latest_convert = ts
+    if latest_convert:
+        return latest_convert
+    return _parse_github_time(pr.get("createdAt"))
+
+
+def pr_draft_days(repo, pr, now=None, *, draft_since=None):
+    """Days the PR has been in draft status (activity ignored), or None if unknown."""
+    since = draft_since if draft_since is not None else pr_draft_since(repo, pr)
+    if not since:
+        return None
+    now = now or datetime.datetime.now(datetime.timezone.utc)
+    if since.tzinfo is None:
+        since = since.replace(tzinfo=datetime.timezone.utc)
+    return (now - since).total_seconds() / 86400.0
+
+
 def close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=False, *, drafts_only=None):
     """Close open PRs with no GitHub activity for more than `days` days.
 
@@ -383,8 +416,45 @@ def close_stale_prs(repo, days=STALE_PR_DAYS, dry_run=False, *, drafts_only=None
 
 
 def close_stale_draft_prs(repo, days=DRAFT_STALE_DAYS, dry_run=False):
-    """Close draft PRs with no GitHub activity for more than `days` days (default 4)."""
-    return close_stale_prs(repo, days=days, dry_run=dry_run, drafts_only=True)
+    """Close draft PRs that have remained in draft status for more than `days` days.
+
+    Uses draft duration (createdAt or latest converted_to_draft), not updatedAt —
+    activity does not reset the clock. Skips `hold` and `merge-first`.
+    """
+    if days <= 0:
+        return set()
+    now = datetime.datetime.now(datetime.timezone.utc)
+    prs = json.loads(gh(["pr", "list", "-R", repo, "--state", "open", "--draft",
+                         "--json", "number,title,createdAt,labels,isDraft"]).stdout or "[]")
+    closed = set()
+    for pr in prs:
+        if not pr.get("isDraft"):
+            continue
+        num = pr["number"]
+        labels = {l["name"] for l in pr.get("labels", [])}
+        if labels & STALE_CLOSE_SKIP_LABELS:
+            continue
+        drafted = pr_draft_days(repo, pr, now)
+        if drafted is None or drafted <= days:
+            continue
+        days_drafted = int(drafted)
+        print(f"PR #{num}: draft age — in draft for {days_drafted}d (limit {days}d)"
+              f"{' — would close' if dry_run else ' — closing'}")
+        if dry_run:
+            closed.add(num)
+            continue
+        body = ("<!-- sparkinfer-stale-draft -->\n"
+                f"## Closed: draft open for {days}+ days\n\n"
+                f"This PR has remained a **draft** for **{days_drafted} days** "
+                f"(threshold: {days} days). Recent commits or comments do not reset this timer.\n\n"
+                "Mark ready for review or reopen when you're ready to continue.")
+        gh(["pr", "comment", str(num), "-R", repo, "--body", body])
+        if gh(["pr", "close", str(num), "-R", repo]).returncode == 0:
+            closed.add(num)
+    if closed:
+        print(f">> close_stale_draft_prs: {'would close' if dry_run else 'closed'} "
+              f"{len(closed)} PR(s): {sorted(closed)}")
+    return closed
 
 
 def rtx5090_close_exempt(pr):

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -690,11 +690,25 @@ class PrEvalBotPolicyTest(unittest.TestCase):
                                          dry_run=True, drafts_only=False)
         self.assertEqual(closed, {51})
 
-    def test_close_stale_draft_prs_closes_inactive_drafts(self):
-        prs = [
-            {"number": 60, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": True},
-            {"number": 61, "updatedAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": False},
-        ]
+    def test_pr_draft_days_from_created_at(self):
+        now = datetime.datetime(2026, 7, 16, 12, 0, tzinfo=datetime.timezone.utc)
+        pr = {"number": 1, "createdAt": "2026-07-10T12:00:00Z", "isDraft": True}
+        with mock.patch.object(bot, "pr_draft_since", return_value=bot._parse_github_time("2026-07-10T12:00:00Z")):
+            self.assertAlmostEqual(bot.pr_draft_days("r/o", pr, now), 6.0, places=5)
+
+    def test_pr_draft_since_uses_latest_convert(self):
+        pr = {"number": 2, "createdAt": "2026-07-01T00:00:00Z", "isDraft": True}
+        timeline = json.dumps([
+            {"event": "converted_to_draft", "created_at": "2026-07-10T00:00:00Z"},
+            {"event": "ready_for_review", "created_at": "2026-07-12T00:00:00Z"},
+            {"event": "converted_to_draft", "created_at": "2026-07-14T00:00:00Z"},
+        ])
+        with mock.patch.object(bot, "gh", return_value=mock.Mock(returncode=0, stdout=timeline)):
+            since = bot.pr_draft_since("gittensor-ai-lab/sparkinfer", pr)
+        self.assertEqual(since.isoformat(), "2026-07-14T00:00:00+00:00")
+
+    def test_close_stale_draft_prs_closes_old_drafts(self):
+        prs = [{"number": 60, "createdAt": "2026-01-01T00:00:00Z", "labels": [], "isDraft": True}]
         gh_calls = []
 
         def fake_gh(args):
@@ -704,16 +718,25 @@ class PrEvalBotPolicyTest(unittest.TestCase):
             return mock.Mock(returncode=0)
 
         with mock.patch.object(bot, "gh", side_effect=fake_gh), \
-             mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
+             mock.patch.object(bot, "pr_draft_days", return_value=10.0):
             closed = bot.close_stale_draft_prs("gittensor-ai-lab/sparkinfer", days=4, dry_run=False)
         self.assertEqual(closed, {60})
         self.assertTrue(any(c[:3] == ["pr", "close", "60"] for c in gh_calls))
 
+    def test_close_stale_draft_prs_ignores_recent_activity(self):
+        """Draft age is not reset by updatedAt — only time in draft status matters."""
+        prs = [{"number": 61, "createdAt": "2026-01-01T00:00:00Z",
+                "updatedAt": "2026-07-16T00:00:00Z", "labels": [], "isDraft": True}]
+        with mock.patch.object(bot, "gh", return_value=mock.Mock(stdout=json.dumps(prs))), \
+             mock.patch.object(bot, "pr_draft_days", return_value=10.0):
+            closed = bot.close_stale_draft_prs("gittensor-ai-lab/sparkinfer", days=4, dry_run=True)
+        self.assertEqual(closed, {61})
+
     def test_close_stale_draft_prs_skips_hold(self):
-        prs = [{"number": 70, "updatedAt": "2026-01-01T00:00:00Z",
+        prs = [{"number": 70, "createdAt": "2026-01-01T00:00:00Z",
                 "labels": [{"name": "hold"}], "isDraft": True}]
         with mock.patch.object(bot, "gh", return_value=mock.Mock(stdout=json.dumps(prs))), \
-             mock.patch.object(bot, "pr_inactive_days", return_value=10.0):
+             mock.patch.object(bot, "pr_draft_days", return_value=10.0):
             closed = bot.close_stale_draft_prs("gittensor-ai-lab/sparkinfer", days=4)
         self.assertEqual(closed, set())
 


### PR DESCRIPTION
## Summary
- Draft auto-close now measures **time in draft status** (4+ days), not `updatedAt` inactivity
- Clock starts at `createdAt` for PRs opened as draft, or the latest `converted_to_draft` timeline event
- Recent commits/comments do **not** reset the timer

## Test plan
- [x] `python3 -m unittest test_pr_eval_bot.PrEvalBotPolicyTest.test_pr_draft_since_uses_latest_convert test_pr_eval_bot.PrEvalBotPolicyTest.test_close_stale_draft_prs_ignores_recent_activity -v`