### PR TITLE
perf(qwen35): default smem-tiled full prefill attention when window off

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -240,7 +240,7 @@ __global__ void win_prefill_windowed_kernel(
 // the caller should run its own attention (e.g. head_dim != 256, or the window
 // and tiling are both disabled). Env knobs:
 //   SPARKINFER_PREFILL_ATTN_WINDOW  (default 256) : window size in KV blocks; 0 disables.
-//   SPARKINFER_PREFILL_ATTN_TILED   (default 0)   : use the smem-tiled full kernel when window off.
+//   SPARKINFER_PREFILL_ATTN_TILED   (default 1)   : smem-tiled full kernel when window off; 0 = naive.
 // ----------------------------------------------------------------------------
 bool launch_prefill_attn_windowed(
     const void* q, const signed char* k_pool, const signed char* v_pool,
@@ -276,7 +276,8 @@ bool launch_prefill_attn_windowed(
 
     static int tiled = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_TILED");
-        return (e && e[0] == '1') ? 1 : 0;
+        if (!e) return 1;   // default on: ~10% faster full O(N^2) prefill at 32k vs naive fallback
+        return (e[0] == '1' || e[0] == 'y' || e[0] == 'Y') ? 1 : 0;
     }();
     if (tiled) {
         static int cfg = 0;

--- a/kernels/include/sparkinfer/kernels/prefill_attn_window.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_window.h
@@ -23,7 +23,7 @@ namespace kernels {
 //
 // Env knobs:
 //   SPARKINFER_PREFILL_ATTN_WINDOW  (default 256) window size in KV blocks; 0 disables windowing.
-//   SPARKINFER_PREFILL_ATTN_TILED   (default 0)   smem-tiled full attention when windowing is off.
+//   SPARKINFER_PREFILL_ATTN_TILED   (default 1)   smem-tiled full attention when windowing is off.
 bool launch_prefill_attn_windowed(
     const void* q, const signed char* k_pool, const signed char* v_pool,
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,


### PR DESCRIPTION
## Summary

#455 landed `win_prefill_tiled_kernel` (smem KV-tile reuse for full O(N²) prefill attention) behind `SPARKINFER_PREFILL_ATTN_TILED=1` when windowing is disabled. This PR flips that knob to **default on** so `SPARKINFER_PREFILL_ATTN_WINDOW=0` no longer falls through to the naive one-warp-per-query kernel in `batched_prefill.cu`. Same online-softmax math — only memory traffic changes. Default windowed prefill (256 blocks) is untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — unchanged; prefill-only change, default window path):

| | decode tok/s |
|---|--:|
| before (main) | 294.12 |
| after (this PR) | 294.12 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — best context `--ctx 32768`; before = `SPARKINFER_PREFILL_ATTN_WINDOW=0 SPARKINFER_PREFILL_ATTN_TILED=0`, after = `WINDOW=0` with tiled default on):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2342.64 |
| after prefill (this PR) | 2585.28 |

```text
# qwen3_gguf_bench, RTX 5090 sm_120, Qwythos-9B Q4_K_M, SPARKINFER_PREFILL_ATTN_WINDOW=0, 3-rep median
ctx=4096   prefill pp  before 5339.84  ->  after 5356.89 tok/s   (+0.3%, noise)
ctx=32768  prefill pp  before 2342.64  ->  after 2585.28 tok/s   (+10.4%)
decode tg  294.1 tok/s (default window path — unchanged)
```

Set `SPARKINFER_PREFILL_ATTN_TILED=0` to restore the naive full-attention fallback.