### PR TITLE
perf(qwen35): fused Q4K/Q6K->int8 dequant + token-parallel GDN conv + lane-parallel fallback attention (+78% pp @32k on top of #465)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -16,6 +16,8 @@
 #include <cuda_pipeline.h>
 #include <mma.h>
 
+#include <cstdlib>
+
 #include "sparkinfer/kernels/prefill.h"
 #include "sparkinfer/kernels/prefill_attn_mma.h"
 #include "sparkinfer/kernels/prefill_attn_window.h"
@@ -232,6 +234,70 @@ __global__ void pf_gdn_conv_kernel(const __nv_bfloat16* __restrict__ qkv,
     #pragma unroll
     for (int c = 0; c < 7; c++)
         if (c < conv_kernel - 1) conv_state[(size_t)c * qkv_dim + d] = __float2bfloat16(hist[c]);
+}
+
+// ============================================================================
+// Token-parallel variant of pf_gdn_conv_kernel. The causal conv needs only the
+// conv_kernel-1 previous RAW qkv rows, which are all in the input buffer (the
+// prompt starts at position 0, so the incoming conv state is zero) — the token
+// loop above is a needless serialization. One block per (token, output head);
+// same taps, SiLU, and L2-norm math, same conv_state layout on exit.
+// Token on grid.x (grid.y stays under the 65535 cap at any context).
+// ============================================================================
+__global__ void pf_gdn_conv_par_kernel(const __nv_bfloat16* __restrict__ qkv,
+                                       const __nv_bfloat16* __restrict__ conv_w,
+                                       __nv_bfloat16* __restrict__ conv_state,
+                                       __nv_bfloat16* __restrict__ q,
+                                       __nv_bfloat16* __restrict__ k,
+                                       __nv_bfloat16* __restrict__ v,
+                                       int n_tokens, int q_heads, int v_heads,
+                                       int head_dim, int qkv_dim, int conv_kernel, float eps) {
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int tok = blockIdx.x;
+    const int blk = blockIdx.y;                    // output head
+    const int t   = threadIdx.x;                   // channel within head
+    int d; __nv_bfloat16* out; int out_dim; int hh; bool do_norm;
+    if (blk < q_heads)            { hh = blk;                d = hh * head_dim + t;               out = q; out_dim = q_dim; do_norm = true;  }
+    else if (blk < 2 * q_heads)   { hh = blk - q_heads;      d = q_dim + hh * head_dim + t;       out = k; out_dim = q_dim; do_norm = true;  }
+    else                          { hh = blk - 2 * q_heads;  d = 2 * q_dim + hh * head_dim + t;   out = v; out_dim = v_dim; do_norm = false; }
+
+    float y = 0.f;
+    #pragma unroll
+    for (int c = 0; c < 8; c++) {
+        if (c >= conv_kernel) break;
+        const int src = tok - (conv_kernel - 1) + c;
+        if (src >= 0)
+            y += pf_to_f(conv_w[(size_t)d * conv_kernel + c]) * pf_to_f(qkv[(size_t)src * qkv_dim + d]);
+    }
+
+    float cval = pf_silu(y);
+    if (do_norm) {
+        __shared__ float sw[32];
+        const int nwarp = (blockDim.x + 31) / 32;
+        float ss = pf_wsum(cval * cval);
+        if ((t & 31) == 0) sw[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = (t < nwarp) ? sw[t] : 0.f;
+            vv = pf_wsum(vv);
+            if (t == 0) sw[0] = rsqrtf(vv + eps);
+        }
+        __syncthreads();
+        cval *= sw[0];
+    }
+    out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
+
+    // persist the conv window (last conv_kernel-1 raw qkv) in the decode layout.
+    if (tok == n_tokens - 1) {
+        #pragma unroll
+        for (int c = 0; c < 7; c++) {
+            if (c >= conv_kernel - 1) break;
+            const int src = n_tokens - 1 - (conv_kernel - 2 - c);
+            conv_state[(size_t)c * qkv_dim + d] =
+                (src >= 0) ? qkv[(size_t)src * qkv_dim + d] : __float2bfloat16(0.f);
+        }
+    }
 }
 
 // ============================================================================
@@ -536,6 +602,19 @@ void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_sta
                              int head_dim, int conv_kernel, float eps, cudaStream_t stream) {
     const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
     const int blocks = 2 * q_heads + v_heads;
+    static int seq = [] {   // SPARKINFER_PREFILL_GDN_CONV_SEQ=1 restores the token-loop kernel
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_CONV_SEQ");
+        return (e && e[0] == '1') ? 1 : 0;
+    }();
+    if (!seq) {
+        dim3 grid(n_tokens, blocks);
+        pf_gdn_conv_par_kernel<<<grid, head_dim, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
+            reinterpret_cast<__nv_bfloat16*>(conv_state), reinterpret_cast<__nv_bfloat16*>(q),
+            reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
+            n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps);
+        return;
+    }
     pf_gdn_conv_kernel<<<blocks, head_dim, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
         reinterpret_cast<__nv_bfloat16*>(conv_state), reinterpret_cast<__nv_bfloat16*>(q),

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -238,6 +238,205 @@ __global__ void win_prefill_windowed_kernel(
     }
 }
 
+// ----------------------------------------------------------------------------
+// LANE-PARALLEL tiled prefill attention (windowed and full in one template).
+//
+// The kernels above walk keys one at a time per query-warp: every key pays a
+// 5-shuffle warp reduction plus two dependent expf's inside the online-softmax
+// carry chain, so the warp is latency-bound (~50 cycles/key) and the fp32 units
+// sit idle. Here each of the 32 lanes owns ONE key of the TK=32 tile:
+//   - scoring: lane j computes the full 256-dim dot q.K[j] from smem (K rows
+//     padded to 260 floats -> lane-strided reads hit 32 distinct banks, float4
+//     aligned), so 32 keys score in parallel with zero shuffles;
+//   - softmax: ONE max-reduce + ONE sum-reduce per tile (amortized 10 shuffles
+//     per 32 keys instead of 160), one expf per lane per tile;
+//   - AV: each lane owns 8 contiguous output dims (float4-friendly sV reads,
+//     coalesced attn writes); p_j broadcast by __shfl_sync is warp-uniform, so
+//     all-masked keys are skipped without divergence.
+// The sink+window selection, causal mask, and paged int8-KV dequant are
+// identical to the kernels above; only the schedule (and thus fp32 rounding
+// order) changes. SPARKINFER_PREFILL_ATTN_LANEPAR=0 restores the old kernels.
+// ----------------------------------------------------------------------------
+template <int HEAD_DIM, int QPW, int TK, bool WINDOWED>
+__global__ void win_prefill_lanepar_kernel(
+    const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
+    const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
+    const __half* __restrict__ v_scale, const int* __restrict__ block_table,
+    __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    constexpr int ELEMS = HEAD_DIM / 32;
+    constexpr int KSTRIDE = HEAD_DIM + 4;   // +4 floats: lane-strided rows hit 32 banks, 16B-aligned
+    constexpr int NWARP = 16;
+    constexpr int TQ = NWARP * QPW;         // queries per block
+    static_assert(TK == 32, "one key per lane");
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int head = blockIdx.y;
+    const int qbase = blockIdx.x * TQ;
+    const int q0 = qbase + warp * QPW;      // this warp's first query
+    const int kv_head = head / (n_q_heads / n_kv_heads);
+    const bool active = (q0 < n_tokens) && (head < n_q_heads);
+
+    auto win_start = [&](int t) -> int {
+        const int n_blk_q = (t + block_size) / block_size;
+        const int rsb = (win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks);
+        return rsb * block_size;
+    };
+
+    extern __shared__ float smem_lp[];   // distinct name: the kernels above declare __half smem[]
+    float* sK = smem_lp;                                           // [TK][KSTRIDE] fp32
+    float* sV = sK + TK * KSTRIDE;                                 // [TK][HEAD_DIM] fp32
+    __nv_bfloat16* sQ = reinterpret_cast<__nv_bfloat16*>(sV + TK * HEAD_DIM);  // [TQ][HEAD_DIM] bf16
+
+    // stage the block's query rows verbatim (q is bf16 in global -> no precision change)
+    for (int idx = threadIdx.x; idx < TQ * (HEAD_DIM / 2); idx += blockDim.x) {
+        const int qq = idx / (HEAD_DIM / 2), d2 = idx - qq * (HEAD_DIM / 2);
+        const int qt = qbase + qq;
+        __nv_bfloat162 v2 = {__float2bfloat16(0.f), __float2bfloat16(0.f)};
+        if (qt < n_tokens && head < n_q_heads) {
+            const size_t q_off = ((size_t)qt * n_q_heads + head) * HEAD_DIM;
+            v2 = *reinterpret_cast<const __nv_bfloat162*>(q + q_off + d2 * 2);
+        }
+        *reinterpret_cast<__nv_bfloat162*>(sQ + (size_t)qq * HEAD_DIM + d2 * 2) = v2;
+    }
+
+    int qtok[QPW], my_rs[QPW];
+    float m[QPW], l[QPW], acc[QPW][ELEMS];
+#pragma unroll
+    for (int i = 0; i < QPW; i++) {
+        qtok[i] = q0 + i;
+        my_rs[i] = (WINDOWED && active) ? win_start(min(qtok[i], n_tokens - 1)) : 0;
+        m[i] = -1e30f; l[i] = 0.f;
+#pragma unroll
+        for (int e = 0; e < ELEMS; e++) acc[i][e] = 0.f;
+    }
+
+    const int last_q = min(qbase + TQ - 1, n_tokens - 1);
+    const int blk_rs = WINDOWED ? win_start(qbase) : 0;
+
+    auto run_range = [&](int lo, int hi) {
+        for (int k0 = lo; k0 < hi; k0 += TK) {
+            const int tk = min(TK, hi - k0);
+            // cooperative dequant KV load, char4 global reads -> float4 smem writes
+            for (int idx = threadIdx.x; idx < tk * (HEAD_DIM / 4); idx += blockDim.x) {
+                const int kk = idx / (HEAD_DIM / 4), d4 = idx - kk * (HEAD_DIM / 4);
+                const int kpos = k0 + kk;
+                const int blk = kpos / block_size, within = kpos - blk * block_size;
+                const int phys = block_table[blk];
+                const size_t ckt = (size_t)phys * block_size + within;
+                const size_t off = (ckt * n_kv_heads + kv_head) * HEAD_DIM + (size_t)d4 * 4;
+                const float ksc = __half2float(k_scale[ckt * n_kv_heads + kv_head]);
+                const float vsc = __half2float(v_scale[ckt * n_kv_heads + kv_head]);
+                const char4 k4 = *reinterpret_cast<const char4*>(k_pool + off);
+                const char4 v4 = *reinterpret_cast<const char4*>(v_pool + off);
+                *reinterpret_cast<float4*>(sK + kk * KSTRIDE + d4 * 4) =
+                    make_float4(k4.x * ksc, k4.y * ksc, k4.z * ksc, k4.w * ksc);
+                *reinterpret_cast<float4*>(sV + kk * HEAD_DIM + d4 * 4) =
+                    make_float4(v4.x * vsc, v4.y * vsc, v4.z * vsc, v4.w * vsc);
+            }
+            __syncthreads();
+            if (active && k0 <= qtok[QPW - 1]) {
+                // one key per lane; each K row read feeds all QPW query dots
+                const int kpos = k0 + lane;
+                bool live = lane < tk;
+                bool in[QPW];
+#pragma unroll
+                for (int i = 0; i < QPW; i++) {
+                    if (WINDOWED) {
+                        const bool insink = kpos < block_size;
+                        const bool inwin = (kpos >= my_rs[i]) && (kpos <= qtok[i]);
+                        in[i] = live && (insink || inwin) && (qtok[i] < n_tokens);
+                    } else {
+                        in[i] = live && (kpos <= qtok[i]) && (qtok[i] < n_tokens);
+                    }
+                }
+                float s[QPW];
+                {
+                    const float* krow = sK + lane * KSTRIDE;
+                    const __nv_bfloat16* qrow = sQ + (size_t)(warp * QPW) * HEAD_DIM;
+                    float sa[QPW], sb[QPW];
+#pragma unroll
+                    for (int i = 0; i < QPW; i++) { sa[i] = 0.f; sb[i] = 0.f; }
+#pragma unroll
+                    for (int d = 0; d < HEAD_DIM; d += 4) {
+                        const float4 kv = *reinterpret_cast<const float4*>(krow + d);  // conflict-free (phase-split)
+#pragma unroll
+                        for (int i = 0; i < QPW; i++) {
+                            const __nv_bfloat162 qa = *reinterpret_cast<const __nv_bfloat162*>(
+                                qrow + (size_t)i * HEAD_DIM + d);           // broadcast reads
+                            const __nv_bfloat162 qb = *reinterpret_cast<const __nv_bfloat162*>(
+                                qrow + (size_t)i * HEAD_DIM + d + 2);
+                            sa[i] += __bfloat162float(qa.x) * kv.x + __bfloat162float(qa.y) * kv.y;
+                            sb[i] += __bfloat162float(qb.x) * kv.z + __bfloat162float(qb.y) * kv.w;
+                        }
+                    }
+#pragma unroll
+                    for (int i = 0; i < QPW; i++) s[i] = in[i] ? (sa[i] + sb[i]) * scale : -1e30f;
+                }
+#pragma unroll
+                for (int i = 0; i < QPW; i++) {
+                    float tmax = s[i];
+#pragma unroll
+                    for (int o = 16; o > 0; o >>= 1)
+                        tmax = fmaxf(tmax, __shfl_xor_sync(0xffffffffu, tmax, o));
+                    if (tmax <= -1e29f) { s[i] = 0.f; continue; }   // no live key for query i
+                    const float m_new = fmaxf(m[i], tmax);
+                    const float corr = __expf(m[i] - m_new);
+                    const float p = in[i] ? __expf(s[i] - m_new) : 0.f;
+                    float tl = p;
+#pragma unroll
+                    for (int o = 16; o > 0; o >>= 1)
+                        tl += __shfl_xor_sync(0xffffffffu, tl, o);
+                    l[i] = l[i] * corr + tl;
+                    m[i] = m_new;
+#pragma unroll
+                    for (int e = 0; e < ELEMS; e++) acc[i][e] *= corr;
+                    s[i] = p;                                       // reuse s[] as this tile's p
+                }
+                // dim-parallel AV: lane owns dims {lane, lane+32, ...}; one sV read
+                // (32 consecutive floats, bank-conflict-free) feeds all QPW queries
+                for (int j = 0; j < tk; j++) {
+                    float pj[QPW]; float any = 0.f;
+#pragma unroll
+                    for (int i = 0; i < QPW; i++) {
+                        pj[i] = __shfl_sync(0xffffffffu, s[i], j);
+                        any += pj[i];
+                    }
+                    if (any != 0.f) {             // warp-uniform: fully-masked keys skip whole warp
+                        const float* vrow = sV + j * HEAD_DIM + lane;
+#pragma unroll
+                        for (int e = 0; e < ELEMS; e++) {
+                            const float vv = vrow[e * 32];
+#pragma unroll
+                            for (int i = 0; i < QPW; i++) acc[i][e] += pj[i] * vv;
+                        }
+                    }
+                }
+            }
+            __syncthreads();
+        }
+    };
+
+    if (WINDOWED) {
+        if (blk_rs > block_size) run_range(0, block_size);
+        const int wlo = (blk_rs > block_size) ? blk_rs : 0;
+        run_range(wlo, last_q + 1);
+    } else {
+        run_range(0, last_q + 1);
+    }
+
+    if (active) {
+#pragma unroll
+        for (int i = 0; i < QPW; i++) {
+            if (qtok[i] >= n_tokens) break;
+            const size_t q_off = ((size_t)qtok[i] * n_q_heads + head) * HEAD_DIM;
+            const float inv = (l[i] > 0.f) ? (1.f / l[i]) : 0.f;
+#pragma unroll
+            for (int e = 0; e < ELEMS; e++)
+                attn[q_off + lane + e * 32] = __float2bfloat16(acc[i][e] * inv);
+        }
+    }
+}
+
 }  // namespace
 
 // ----------------------------------------------------------------------------
@@ -246,6 +445,8 @@ __global__ void win_prefill_windowed_kernel(
 // and tiling are both disabled). Env knobs:
 //   SPARKINFER_PREFILL_ATTN_WINDOW  (default 256) : window size in KV blocks; 0 disables.
 //   SPARKINFER_PREFILL_ATTN_TILED   (default 0)   : use the smem-tiled full kernel when window off.
+//   SPARKINFER_PREFILL_ATTN_LANEPAR (default 1)   : lane-parallel kernel; 0 = the older
+//                                                   one-key-at-a-time warp kernels.
 // ----------------------------------------------------------------------------
 bool launch_prefill_attn_windowed(
     const void* q, const signed char* k_pool, const signed char* v_pool,
@@ -260,12 +461,33 @@ bool launch_prefill_attn_windowed(
     if (head_dim != 256) return false;   // only the hd256 full-attention layers are windowed
     constexpr int TQ = 16, TK = 32, HD = 256;
     const size_t sm = (size_t)2 * TK * HD * sizeof(__half);  // 32 KB smem: K + V tiles (half)
+    // lane-parallel kernel: fp32 K tile (rows padded +4) + fp32 V tile + bf16 query tile
+    constexpr int QPW = 4, TQ_LP = 16 * QPW;
+    const size_t sm_lp = ((size_t)TK * (HD + 4) + (size_t)TK * HD) * sizeof(float)
+                       + (size_t)TQ_LP * HD * sizeof(__nv_bfloat16);
 
+    static int lanepar = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_LANEPAR");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
     static int win_blocks = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_WINDOW");
         return e ? atoi(e) : 256;
     }();
     if (win_blocks > 0) {
+        if (lanepar) {
+            static int cfglw = 0;
+            if (!cfglw) {
+                cudaFuncSetAttribute(win_prefill_lanepar_kernel<HD, QPW, TK, true>,
+                                     cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_lp);
+                cfglw = 1;
+            }
+            dim3 gridw((n_tokens + TQ_LP - 1) / TQ_LP, n_q_heads);
+            win_prefill_lanepar_kernel<HD, QPW, TK, true><<<gridw, 16 * 32, sm_lp, stream>>>(
+                qb, k_pool, v_pool, ks, vs, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
+                block_size, max_blocks_per_seq, scale, win_blocks);
+            return true;
+        }
         static int cfgw = 0;
         if (!cfgw) {
             cudaFuncSetAttribute(win_prefill_windowed_kernel<HD, TQ, TK>,
@@ -276,6 +498,20 @@ bool launch_prefill_attn_windowed(
         win_prefill_windowed_kernel<HD, TQ, TK><<<gridw, TQ * 32, sm, stream>>>(
             qb, k_pool, v_pool, ks, vs, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
             block_size, max_blocks_per_seq, scale, win_blocks);
+        return true;
+    }
+
+    if (lanepar) {
+        static int cfglf = 0;
+        if (!cfglf) {
+            cudaFuncSetAttribute(win_prefill_lanepar_kernel<HD, QPW, TK, false>,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_lp);
+            cfglf = 1;
+        }
+        dim3 grid((n_tokens + TQ_LP - 1) / TQ_LP, n_q_heads);
+        win_prefill_lanepar_kernel<HD, QPW, TK, false><<<grid, 16 * 32, sm_lp, stream>>>(
+            qb, k_pool, v_pool, ks, vs, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
+            block_size, max_blocks_per_seq, scale, 0);
         return true;
     }
 

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -89,6 +89,78 @@ __global__ void deq_q6k_kernel(const unsigned char* __restrict__ src, __nv_bfloa
     }
 }
 
+// ---------------------------------------------------------------------------
+// Fused GGUF -> per-row-int8 dequant for the int8 prefill GEMM. Replaces the
+// dequant-to-bf16 + pf_quantize_rows_i8 round trip (write 2B + read 2B per
+// value) with one pass that decodes the superblocks twice (rows are L2-hot:
+// a 12288-wide Q4_K row is ~7 KB) and writes 1B per value:
+//   pass 1: block-wide amax of the exactly-dequantized row
+//   pass 2: q = round(v / (amax/127)), matching pf_quantize_rows_i8
+// One block (256 threads) per row; thread t decodes value t of each superblock.
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ float deq_q4k_val(const unsigned char* blk, int t) {
+    const float d = gg_h2f(blk), dmin = gg_h2f(blk + 2);
+    const unsigned char* sc = blk + 4; const unsigned char* qs = blk + 16;
+    const int j64 = t >> 6, r = t & 63, l = r & 31, hi = r >> 5;
+    const unsigned char byte = qs[j64 * 32 + l];
+    const int nib = hi ? (byte >> 4) : (byte & 0xF);
+    int s, m; gg_scale_min_k4(2 * j64 + hi, sc, &s, &m);
+    return d * s * nib - dmin * m;
+}
+__device__ __forceinline__ float deq_q6k_val(const unsigned char* blk, int t) {
+    const int half = t >> 7, r = t & 127, quad = r >> 5, l = r & 31;
+    const unsigned char* ql = blk + half * 64;
+    const unsigned char* qh = blk + 128 + half * 32;
+    const signed char* sc = (const signed char*)(blk + 192) + half * 8;
+    const float d = gg_h2f(blk + 208);
+    const int is = l / 16;
+    int qv;
+    if (quad == 0)      qv = (int)((ql[l]      & 0xF) | (((qh[l] >> 0) & 3) << 4)) - 32;
+    else if (quad == 1) qv = (int)((ql[l + 32] & 0xF) | (((qh[l] >> 2) & 3) << 4)) - 32;
+    else if (quad == 2) qv = (int)((ql[l]      >>  4) | (((qh[l] >> 4) & 3) << 4)) - 32;
+    else                qv = (int)((ql[l + 32] >>  4) | (((qh[l] >> 6) & 3) << 4)) - 32;
+    return d * sc[is + 2 * quad] * qv;
+}
+
+template <int QT>   // 12 = Q4_K (144B/superblock), 14 = Q6_K (210B/superblock)
+__global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
+                                   signed char* __restrict__ q, float* __restrict__ scale,
+                                   int cols) {
+    constexpr int BS = (QT == 12) ? 144 : 210;
+    const int row = blockIdx.x, t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const unsigned char* rbase = src + (size_t)row * nsb * BS;
+
+    float amax = 0.f;
+    for (int sb = 0; sb < nsb; sb++) {
+        const unsigned char* blk = rbase + (size_t)sb * BS;
+        const float v = (QT == 12) ? deq_q4k_val(blk, t) : deq_q6k_val(blk, t);
+        amax = fmaxf(amax, fabsf(v));
+    }
+    __shared__ float swarp[8];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < 8) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 4; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (t == 0) swarp[0] = v;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) scale[row] = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    signed char* qrow = q + (size_t)row * cols;
+    for (int sb = 0; sb < nsb; sb++) {
+        const unsigned char* blk = rbase + (size_t)sb * BS;
+        const float v = (QT == 12) ? deq_q4k_val(blk, t) : deq_q6k_val(blk, t);
+        qrow[sb * 256 + t] = (signed char)(int)roundf(v * inv);
+    }
+}
+
 __global__ void deq_q8_0_kernel(const unsigned char* __restrict__ src, __nv_bfloat16* __restrict__ y, long nblocks) {
     long b = (long)blockIdx.x * blockDim.x + threadIdx.x; if (b >= nblocks) return;
     const unsigned char* blk = src + b * 34; float d = gg_h2f(blk);
@@ -129,6 +201,16 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
     else if (ggml_type == GGML_Q8_0) { long nb = n_values/32;  deq_q8_0_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_F16)  { deq_f16_kernel<<<(n_values+T-1)/T,T,0,stream>>>(s,d,n_values); }
     else /* F32 */                   { deq_f32_kernel<<<(n_values+T-1)/T,T,0,stream>>>(reinterpret_cast<const float*>(src),d,n_values); }
+}
+
+bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q, float* scale,
+                                 int rows, int cols, cudaStream_t stream) {
+    if ((cols & 255) != 0) return false;
+    auto* s = reinterpret_cast<const unsigned char*>(src);
+    if (ggml_type == GGML_Q4_K)      deq_rows_i8_kernel<12><<<rows, 256, 0, stream>>>(s, q, scale, cols);
+    else if (ggml_type == GGML_Q6_K) deq_rows_i8_kernel<14><<<rows, 256, 0, stream>>>(s, q, scale, cols);
+    else return false;
+    return true;
 }
 
 void launch_transpose_bf16(const void* src, void* dst, int rows, int cols, cudaStream_t stream) {

--- a/kernels/include/sparkinfer/kernels/quant.h
+++ b/kernels/include/sparkinfer/kernels/quant.h
@@ -27,6 +27,13 @@ void launch_dequant_int4_block(const unsigned char* packed, const void* scales_b
 void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_values,
                          cudaStream_t stream = nullptr);
 
+// Fused GGUF dequant -> per-row symmetric int8 (for launch_prefill_gemm_i8):
+// q[r,c] = round(v[r,c] / scale[r]), scale[r] = max_c|v[r,c]| / 127, with v the
+// exact fp32 dequant. Skips the bf16 scratch round-trip of dequant + row-quantize.
+// Q4_K/Q6_K only; returns false (nothing launched) for other types.
+bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q, float* scale,
+                                 int rows, int cols, cudaStream_t stream = nullptr);
+
 // bf16 transposes used to relayout GGUF [out,in] -> our [in,out].
 void launch_transpose_bf16(const void* src, void* dst, int rows, int cols,
                            cudaStream_t stream = nullptr);          // [rows,cols]->[cols,rows]

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -90,17 +90,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* ffh  = a.alloc<bf16>((size_t)N * ffn);         // ffn silu(gate)*up
     bf16* wbuf = a.alloc<bf16>(maxw);                    // dequantized-weight scratch (reused)
     int*  d_ids = a.alloc<int>((size_t)N);
+    if (!a.ok) { a.free_all(); fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
     // int8 tensor-core projections (prefill_gemm_i8): ~2x the bf16 GEMM at int8==bf16 output fidelity
     // (GGUF weights are already Q4_K/Q6_K -> int8 weight-quant is lossless vs what's stored). Default
-    // ON; SPARKINFER_PREFILL_I8=0 disables (A/B). Gated to low context: the extra int8 scratch is only
-    // spent where prefill_pp is highest (best-context scored); larger contexts fall through to bf16.
+    // ON at every batched context; SPARKINFER_PREFILL_I8=0 disables (A/B). The int8 scratch lives in
+    // its own arena so an alloc failure at huge N degrades to the bf16 GEMMs, not to the token loop.
     const char* _pi8 = getenv("SPARKINFER_PREFILL_I8");
-    const bool use_i8 = !(_pi8 && _pi8[0] == '0') && (N <= 8192);
-    signed char* A_i8 = use_i8 ? a.alloc<signed char>((size_t)N * ffn) : nullptr;
-    signed char* W_i8 = use_i8 ? a.alloc<signed char>(maxw) : nullptr;
-    float* sx = use_i8 ? a.alloc<float>((size_t)N) : nullptr;
-    float* sw = use_i8 ? a.alloc<float>((size_t)ffn) : nullptr;
-    if (!a.ok) { a.free_all(); fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
+    bool use_i8 = !(_pi8 && _pi8[0] == '0');
+    Arena a8;
+    signed char* A_i8 = use_i8 ? a8.alloc<signed char>((size_t)N * ffn) : nullptr;
+    signed char* W_i8 = use_i8 ? a8.alloc<signed char>(maxw) : nullptr;
+    float* sx = use_i8 ? a8.alloc<float>((size_t)N) : nullptr;
+    float* sw = use_i8 ? a8.alloc<float>((size_t)ffn) : nullptr;
+    if (use_i8 && !a8.ok) { a8.free_all(); use_i8 = false; }
 
     pf_cu(cudaMemcpyAsync(d_ids, prompt_ids, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "prefill ids");
 
@@ -112,17 +114,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     };
     // C[N,n_out] = A[N,K] @ W^T  (W native quantized [n_out,K]).
     auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K) {
-        const void* wb = dq(W, wtype, n_out, K);
         // int8 only for the big weight-bound projections; keep the tiny per-v-head gate
         // projections (ssm_alpha/ssm_beta, n_out == v_heads) in bf16 — they feed the GDN
         // sigmoid gates, where per-row int8 quant of a 32-wide weight costs more accuracy
         // than the negligible time it saves.
         if (use_i8 && n_out >= 128) {
             kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, N, K, st);
-            kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
+            // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
+            if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
+                const void* wb = dq(W, wtype, n_out, K);
+                kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
+            }
             kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, N, n_out, K, st);
         } else {
-            kernels::launch_prefill_gemm(A, wb, C, N, n_out, K, st);
+            kernels::launch_prefill_gemm(A, dq(W, wtype, n_out, K), C, N, n_out, K, st);
         }
     };
 
@@ -165,7 +170,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
             void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
             void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-            if (!kv8) { a.free_all(); fprintf(stderr, "[prefill] batched prefill requires int8 KV\n"); return -1; }
+            if (!kv8) { a.free_all(); a8.free_all(); fprintf(stderr, "[prefill] batched prefill requires int8 KV\n"); return -1; }
             kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
                 kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
                 rope_dim, rope_theta, eps, bs, mbs, st);
@@ -203,6 +208,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     int seed = *s.h_out_id;
 
     a.free_all();
+    a8.free_all();
     return seed;
 }
 


### PR DESCRIPTION
## Summary

Three profiling-guided fixes to the Qwythos (Qwen3.5) batched-prefill path. Rebased on and **composing with** the merged #463 (half-precision smem tiles) and #465 (int8-MMA prefill attention): the two big wins here are in stages #465 doesn't touch, and they stack on top of it.

1. **Fused Q4_K/Q6_K → int8-row dequant** (`dequant_gguf.cu`). Every projection dequantized the weight to a bf16 scratch (2B/value written) then re-read and row-quantized it to int8 for the #422 int8 tensor-core GEMM. `deq_rows_i8_kernel` decodes superblocks in registers and writes int8 + per-row scale directly (1B/value, no bf16 bounce), one block per row instead of one thread per superblock. The `N <= 8192` int8-GEMM gate is also lifted — int8 scratch moves to its own arena, so an alloc failure at huge N degrades to the bf16 GEMMs instead of the token loop (this is why main's pp32k ran bf16 GEMMs until now).
2. **Token-parallel GDN conv** (`batched_prefill.cu`). `pf_gdn_conv_kernel` looped all N tokens sequentially with a `__syncthreads()` per token on only 64 blocks (2.7 ms/layer, ~21 ms/layer at 32k). The causal 4-tap conv reads only in-buffer raw inputs (the prompt starts at position 0), so it is token-parallel: one block per (token, head), ~0.1 ms/layer. Same taps/SiLU/L2-norm math and conv-state layout. `SPARKINFER_PREFILL_GDN_CONV_SEQ=1` restores.
3. **Lane-parallel prefill attention** (`prefill_attn_window.cu`) — written before #465 landed; with #465's MMA kernel default-on this now only upgrades the `SPARKINFER_PREFILL_ATTN_MMA=0` fallback path (the scalar kernels walk keys one per query-warp with a 5-shuffle reduce + two dependent `expf` per key; this one scores 32 keys per warp in parallel, 18.3 → 5.7 ms/layer, exact fp32 math). Kept env-gated (`SPARKINFER_PREFILL_ATTN_LANEPAR=0` restores the scalar kernels); no effect on the default MMA path.

Decode paths, CUDA graphs, and the Qwen3.6 model are untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 295.54 |
| after (this PR) | 295.34 |

> This PR does **not** target decode and does not modify the decode path. The row above is a
> **no-regression check at ctx=4096, not a claimed gain** (-0.07% is run noise). The prefill
> table below is the actual claim.

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 8419.18 |
| after prefill (this PR) | **14951.55** |

```text
# qwen3_gguf_bench (the binary bench/scripts/bench.sh wraps), RTX 5090 sm_120,
# Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M, default path, post-warmup, 3-rep median.
# before = clean clone of main @ 9fdf68a (includes #463 + #465), same box, same build flags.

### BEFORE (main @ 9fdf68a)
SWEEP_JSON {"4096":{"decode_tps":295.5379,"prefill_pp":8457.7366},
            "32768":{"decode_tps":294.1757,"prefill_pp":8419.1842}}

### AFTER (this PR, rebased on 9fdf68a)
SWEEP_JSON {"4096":{"decode_tps":295.3402,"prefill_pp":13987.3013},
            "32768":{"decode_tps":293.9429,"prefill_pp":14951.5538}}

ctx=4096   prefill pp   8457.74 -> 13987.30  (+65%;  llama.cpp same box: 11741.24)
ctx=32768  prefill pp   8419.18 -> 14951.55  (+78%;  llama.cpp same box: 10413.76)
```

**Correctness.** `qwen3_gguf_prefill_check` (batched prefill vs token-by-token fill, prefix 4096,
cont 16), same box, same build flags, both on top of the merged int8-MMA attention:
this PR **top-1 13/16 · KL 0.0164 · seed 290** vs main @ 9fdf68a **top-1 13/16 · KL 0.0152 ·
seed 290** — identical top-1 and seed, KL at the same level. (The fused dequant quantizes from
the exact fp32 dequant instead of the bf16-rounded scratch — pre-#465 it measured *tighter* than
the then-main: KL 0.0164 vs 0.0191.) `ctest` 7/7 pass.