### PR TITLE
fix(eval): tier batched prefill on frontier; keep speed label on guard accuracy fail

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -615,9 +615,11 @@ frontier=float("${PREFILL_SELECTED_FRONTIER:-0}")
 use_frontier = tps <= 0 or llama <= 0 or llama >= tps * 50
 if not use_frontier and frontier > 0 and llama >= 2 * frontier:
     use_frontier = True
+if not use_frontier and frontier > 0 and tps >= 1000:
+    use_frontier = True  # batched sparkinfer pp — tier on same-box main, not llama anchor
 print(0 if use_frontier else llama)
 PY
-)" SPARKINFER_DIFFICULTY_BOOST="${SPARKINFER_DIFFICULTY_BOOST:-1}" \
+)\" SPARKINFER_DIFFICULTY_BOOST="${SPARKINFER_DIFFICULTY_BOOST:-1}" \
   python3 "$HERE/label.py" "$PREFILL_SELECTED_TPS" "$PREFILL_SELECTED_FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT" "{}")"
 DECODE_LINE="$DECODE_LINE" PREFILL_LINE="$PREFILL_LINE" python3 - <<'PY'
 import json, os

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -445,18 +445,23 @@ def merge_primary(primary, guard, scored_model, guard_model, guard_prefix):
         "guard_64k_pass", "guard_128k_pass") if k in guard}
     out["guard"]["speed_ok"] = speed_ok
     out["guard"]["accuracy_ok"] = acc_ok
-    if not speed_ok or not acc_ok:
+    if not speed_ok:
         reasons = []
         if regressed:
             reasons.append(f"{guard_model} decode regressed at: " + ", ".join(regressed))
-        if not acc_ok and guard:
-            reasons.append(f"{guard_model} accuracy broke (top1={guard.get('top1')}, kl={guard.get('kl')})")
         if not guard:
             reasons.append(f"{guard_model} guard produced no verdict")
         out["label"] = "REJECT"
         out["pass"] = False
         out["reason"] = "no-regression guard: " + "; ".join(reasons or ["guard failed"])
         out["guard_regression_labels"] = [f"regression-{guard_prefix}-" + c for c in regressed]
+    elif not acc_ok:
+        reasons = []
+        if not acc_ok and guard:
+            reasons.append(f"{guard_model} accuracy broke (top1={guard.get('top1')}, kl={guard.get('kl')})")
+        out["pass"] = False
+        out["reason"] = "no-regression guard: " + "; ".join(reasons or ["guard failed"])
+        # Keep primary speed tier (e.g. eval-qwen35:M) — guard accuracy fail is pass=false, not tier REJECT.
     return out
 
 commit = os.environ["COMMIT"]

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -434,7 +434,7 @@ def merge_primary(primary, guard, scored_model, guard_model, guard_prefix):
     if not primary:
         return {"label": "REJECT", "pass": False,
                 "reason": f"primary ({scored_model}) produced no verdict (infra error)"}
-    speed_ok, regressed, _, acc_ok = guard_ok(guard)
+    _, regressed, speed_ok, acc_ok = guard_ok(guard)
     out = dict(primary)
     out["model"] = scored_model
     out["guard_model"] = guard_model

--- a/bench/scripts/test_bidir_headline.py
+++ b/bench/scripts/test_bidir_headline.py
@@ -27,6 +27,30 @@ def pick_headline(a, b):
     return pick_best(a, b)
 
 
+def guard_ok(guard):
+    gctx = ["guard_128_pass", "guard_512_pass", "guard_4k_pass", "guard_16k_pass", "guard_32k_pass",
+            "guard_64k_pass", "guard_128k_pass"]
+    present = [k for k in gctx if k in guard]
+    speed_ok = all(guard.get(k, True) for k in present)
+    acc_ok = float(guard.get("top1", 0)) >= 0.90 and float(guard.get("kl", 99)) <= 0.20
+    regressed = [k.replace("guard_", "").replace("_pass", "") for k in present if not guard.get(k, True)]
+    return bool(guard) and speed_ok and acc_ok, regressed, speed_ok, acc_ok
+
+
+def merge_primary(primary, guard, guard_model="Qwen3.6-35B-A3B"):
+    _, regressed, speed_ok, acc_ok = guard_ok(guard)
+    out = dict(primary)
+    out["guard"] = {"speed_ok": speed_ok, "accuracy_ok": acc_ok}
+    if not speed_ok:
+        out["label"] = "REJECT"
+        out["pass"] = False
+        out["reason"] = "no-regression guard: speed"
+    elif not acc_ok:
+        out["pass"] = False
+        out["reason"] = f"no-regression guard: {guard_model} accuracy broke"
+    return out
+
+
 class BidirHeadlineTest(unittest.TestCase):
     def test_reject_beats_none(self):
         q35 = {"label": "REJECT", "pass": False, "tps": 298.1, "reason": "prefill regressed"}
@@ -48,6 +72,19 @@ class BidirHeadlineTest(unittest.TestCase):
         q36 = {"label": "REJECT", "pass": False, "tps": 482.53}
         out = pick_headline(q35, q36)
         self.assertEqual(out["label"], "REJECT")
+
+    def test_merge_primary_guard_accuracy_fail_keeps_speed_tier(self):
+        """PR #463: all decode guards pass but Qwen3.6 guard accuracy fails — keep M, pass=false."""
+        primary = {"label": "M", "pass": True, "tps": 5511.53, "prefill_label": "M"}
+        guard = {"top1": 0.8549, "kl": 0.0523,
+                 "guard_128_pass": True, "guard_512_pass": True, "guard_4k_pass": True,
+                 "guard_16k_pass": True, "guard_32k_pass": True, "guard_64k_pass": True,
+                 "guard_128k_pass": True}
+        out = merge_primary(primary, guard)
+        self.assertEqual(out["label"], "M")
+        self.assertFalse(out["pass"])
+        self.assertTrue(out["guard"]["speed_ok"])
+        self.assertFalse(out["guard"]["accuracy_ok"])
 
 
 if __name__ == "__main__":

--- a/bench/scripts/test_bidir_headline.py
+++ b/bench/scripts/test_bidir_headline.py
@@ -41,6 +41,14 @@ class BidirHeadlineTest(unittest.TestCase):
         out = pick_headline(q35, q36)
         self.assertEqual(out["label"], "L")
 
+    def test_headline_reject_when_other_side_rejects(self):
+        """Qwen3.5 keeps speed tier M but pass=false; headline follows Qwen3.6 REJECT."""
+        q35 = {"label": "M", "pass": False, "tps": 5511.53,
+               "reason": "no-regression guard: Qwen3.6 accuracy broke"}
+        q36 = {"label": "REJECT", "pass": False, "tps": 482.53}
+        out = pick_headline(q35, q36)
+        self.assertEqual(out["label"], "REJECT")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/bench/scripts/test_prefill_label_merge.py
+++ b/bench/scripts/test_prefill_label_merge.py
@@ -100,6 +100,8 @@ class PrefillDifficultyRefTest(unittest.TestCase):
         use_frontier = tps <= 0 or llama <= 0 or llama >= tps * 50
         if not use_frontier and frontier > 0 and llama >= 2 * frontier:
             use_frontier = True
+        if not use_frontier and frontier > 0 and tps >= 1000:
+            use_frontier = True
         return 0 if use_frontier else llama
 
     def test_sequential_pp_uses_frontier(self):
@@ -107,6 +109,10 @@ class PrefillDifficultyRefTest(unittest.TestCase):
 
     def test_batched_pp_uses_frontier(self):
         self.assertEqual(self.prefill_diff_ref(6062.59, 11104.62, 4151.38), 0)
+
+    def test_batched_pp_uses_frontier_when_main_caught_up(self):
+        """64k batched pp ~5.5k vs main ~5.1k: llama < 2×frontier but still tier on main."""
+        self.assertEqual(self.prefill_diff_ref(5511.53, 8153.53, 5127.34), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Tier batched sparkinfer prefill (~4k–6k tok/s) on same-box main when llama anchor is stale (main past 2×frontier), fixing PR #463 +7.5% prefill being scored as S instead of M.
- In bidirectional eval, guard-model accuracy failure sets `pass=false` but preserves the primary speed tier (e.g. `eval-qwen35:M`) instead of overwriting to REJECT.

## Test plan
- [x] `python3 -m unittest bench.scripts.test_prefill_label_merge bench.scripts.test_bidir_headline -v`
- [ ] Rescore PR #463 → `eval-qwen35:M` (pass=false), headline stays `eval:REJECT` from Qwen3.6 correctness