### PR TITLE
governance: block jimcody1995 (#436 copycat of #403)

### DIFF
--- a/.github/FLAGGED.md
+++ b/.github/FLAGGED.md
@@ -133,3 +133,7 @@ removed `g2`; added lines matched #318's existing call-site pattern at 100% (tin
 literal rule). Independent convergent fix with #336 (merged ~14 min earlier).
 Maintainer cleared: label `copycat-cleared`, #338 reopened. Account was not on
 `blocked-contributors.txt`.
+
+## 2026-07-15 — `jimcody1995` (auto-blocked)
+
+#436 ≥85% copycat of #403 (90%). Maintainer confirmed block on 2026-07-16.

--- a/.github/blocked-contributors.txt
+++ b/.github/blocked-contributors.txt
@@ -24,3 +24,5 @@ Daedalus-Icarus
 devmixa702
 
 jony376
+
+jimcody1995

--- a/.github/copycats.json
+++ b/.github/copycats.json
@@ -88,5 +88,13 @@
     "strike": 0,
     "containment": 0.07,
     "note": "false positive cleared: per-function skv_wsum warp-shuffle matched #223 boilerplate at 94%; PR-level overlap 7%. Independent sparse-KV feature (sparse_kv.cu)."
+  },
+  {
+    "pr": 436,
+    "author": "jimcody1995",
+    "original": 403,
+    "date": "2026-07-15",
+    "blocked": true,
+    "containment": 0.90
   }
 ]


### PR DESCRIPTION
## Summary
- Add `jimcody1995` to `.github/blocked-contributors.txt`
- Record copycat strike for PR #436 (90% containment vs #403) in `copycats.json`
- Document in `FLAGGED.md`

The bot closed #436 on 2026-07-15 but the block commit never landed on protected `main`.

## Test plan
- [x] Verify `jimcody1995` appears in blocked-contributors.txt
- [ ] Bot will auto-close/flag any future PRs from this account