### PR TITLE
governance: block jsdevninja and james3773 (missing denylist entries)

### DIFF
--- a/.github/FLAGGED.md
+++ b/.github/FLAGGED.md
@@ -137,3 +137,15 @@ Maintainer cleared: label `copycat-cleared`, #338 reopened. Account was not on
 ## 2026-07-15 — `jimcody1995` (auto-blocked)
 
 #436 ≥85% copycat of #403 (90%). Maintainer confirmed block on 2026-07-16.
+
+## 2026-07-09 — `jsdevninja` (auto-blocked)
+
+Real-time copycat guard closed #298 (≥85% containment vs #121). Block comment posted
+but entry never landed on `main`. Maintainer confirmed block on 2026-07-16.
+
+## 2026-07-04 — `james3773` (rename of blocked `jony376`)
+
+`jony376` was blocked for verbatim copycat of fansilas's #221 via #209. GitHub login
+`jony376` no longer exists (404); flagged PRs #209/#142 are under **`james3773`**. Added
+`james3773` to `blocked-contributors.txt` on 2026-07-16; kept `jony376` for historical
+commit-author matching.

--- a/.github/blocked-contributors.txt
+++ b/.github/blocked-contributors.txt
@@ -24,5 +24,8 @@ Daedalus-Icarus
 devmixa702
 
 jony376
+james3773
 
 jimcody1995
+
+jsdevninja

--- a/.github/copycats.json
+++ b/.github/copycats.json
@@ -44,7 +44,7 @@
     "author": "jony376",
     "original": 221,
     "date": "2026-07-04",
-    "note": "reattributed: #209 is a verbatim copy of fansilas's #221 (fansilas authored the #195 kernel; jony376 commit 11:18 > fansilas 05:23)"
+    "note": "reattributed: #209 is a verbatim copy of fansilas's #221 (fansilas authored the #195 kernel; jony376 commit 11:18 > fansilas 05:23). GitHub login renamed to james3773 (jony376 404 as of 2026-07-16)."
   },
   {
     "pr": 244,
@@ -96,5 +96,13 @@
     "date": "2026-07-15",
     "blocked": true,
     "containment": 0.90
+  },
+  {
+    "pr": 298,
+    "author": "jsdevninja",
+    "original": 121,
+    "date": "2026-07-09",
+    "blocked": true,
+    "note": "real-time copycat guard; ≥85% vs #121. Block persisted 2026-07-16."
   }
 ]


### PR DESCRIPTION
## Summary
- Add **`jsdevninja`** — real-time copycat guard blocked #298 (≥85% vs #121) but entry never persisted to `main`
- Add **`james3773`** — live GitHub login for blocked `jony376` (#209 copycat of #221); `jony376` returns 404
- Record both in `FLAGGED.md`; add #298 to `copycats.json`; note rename on #209 entry

## Test plan
- [x] Cross-check `flagged:gaming` authors vs `blocked-contributors.txt`
- [ ] Bot auto-closes future PRs from either account