### PR TITLE
fix(eval): repair prefill tiering bash syntax in evaluate.sh

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -619,7 +619,7 @@ if not use_frontier and frontier > 0 and tps >= 1000:
     use_frontier = True  # batched sparkinfer pp — tier on same-box main, not llama anchor
 print(0 if use_frontier else llama)
 PY
-)\" SPARKINFER_DIFFICULTY_BOOST="${SPARKINFER_DIFFICULTY_BOOST:-1}" \
+)" SPARKINFER_DIFFICULTY_BOOST="${SPARKINFER_DIFFICULTY_BOOST:-1}" \
   python3 "$HERE/label.py" "$PREFILL_SELECTED_TPS" "$PREFILL_SELECTED_FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT" "{}")"
 DECODE_LINE="$DECODE_LINE" PREFILL_LINE="$PREFILL_LINE" python3 - <<'PY'
 import json, os


### PR DESCRIPTION
## Summary
- Fix a one-character bash syntax error in `bench/scripts/evaluate.sh` (`)\""` → `)"`) introduced in #466
- Restores the Qwen3.5 prefill tiering path (`PREFILL_LINE=...`) so bidir primary evals emit `RESULT_JSON` instead of crashing with `unexpected EOF while looking for matching ')'`

## Context
Without this fix, PRs whose Qwythos primary passes the prefill gate get false **infra error** rejects (`primary produced no verdict`) on the default harness synced from `origin/main`.

## Test plan
- [x] `bash -n bench/scripts/evaluate.sh`
- [ ] Merge and re-run eval bot without `SPARKINFER_USE_LOCAL_BENCH=1`