### PR TITLE
fix(eval): surface infra failures instead of false PR rejects

### DIFF
--- a/bench/scripts/_eval_speed.sh
+++ b/bench/scripts/_eval_speed.sh
@@ -41,12 +41,14 @@ bench_sweep_run() {
   export SPARKINFER_BENCH_SWEEP_CTXS="$csv"
   export SPARKINFER_BENCH_SWEEP_REPS="$max_reps"
   out="$(si_run qwen3_gguf_bench "$gguf" "$n_tokens" sweep 2>&1)" || rc=$?
+  _BENCH_SWEEP_ERR="${out##*$'\n'}"
   _BENCH_SWEEP_JSON="$(printf '%s\n' "$out" | sed -n 's/^SWEEP_JSON //p' | tail -1)"
   if [ "$rc" != 0 ] || [ -z "$_BENCH_SWEEP_JSON" ]; then
-    echo ">> WARN: bench sweep failed (rc=$rc): ${out##*$'\n'}" >&2
+    echo ">> WARN: bench sweep failed (rc=$rc): ${_BENCH_SWEEP_ERR}" >&2
     _BENCH_SWEEP_JSON=""
     return 1
   fi
+  _BENCH_SWEEP_ERR=""
   gclks+=("$(nvidia-smi --query-gpu=clocks.gr --format=csv,noheader,nounits 2>/dev/null | head -1 | tr -d ' ')")
   echo ">> bench sweep ok (${csv})" >&2
   return 0

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -37,6 +37,21 @@ if [ -n "$REF" ] && [ -z "${SI_NO_CHECKOUT:-}" ]; then
 fi
 COMMIT="$(git -C "$ROOT" rev-parse --short HEAD)"
 
+emit_infra_verdict() {
+  COMMIT="$COMMIT" FRONTIER="$FRONTIER" INFRA_MSG="$1" python3 - <<'PY'
+import json, os
+print("RESULT_JSON " + json.dumps({
+    "commit": os.environ["COMMIT"],
+    "tps": 0, "top1": 0, "kl": 99,
+    "frontier_tps": float(os.environ.get("FRONTIER", "0") or 0),
+    "label": "REJECT", "pass": False,
+    "reason": "infra error: " + os.environ["INFRA_MSG"],
+    "infra_error": True,
+}))
+PY
+  exit 0
+}
+
 # SI_SKIP_BUILD=1: the caller (evaluate_dual.sh) already built this exact tree from source and is
 # now scoring a second model against the same binaries — skip the rebuild so a two-model eval pays
 # the (model-agnostic) compile cost once, not twice.
@@ -165,6 +180,9 @@ else
       GUARD_4K_PP_TPS=0; GUARD_32K_PP_TPS=0; GUARD_64K_PP_TPS=0; GUARD_128K_PP_TPS=0
     fi
   else
+    if [[ "${_BENCH_SWEEP_ERR:-}" == *"[FAIL] load"* ]]; then
+      emit_infra_verdict "model load failed during bench sweep: ${_BENCH_SWEEP_ERR}"
+    fi
     si_run qwen3_gguf_bench "$GGUF" 64 "$GUARD_CTX" >/dev/null 2>&1 || true
     GUARD_TPS="$(median_ctx "$GUARD_CTX" "$GUARD_REPS")"
     GUARD_512_TPS="$(median_ctx "$GUARD_512_CTX" "$GUARD_512_REPS")"
@@ -449,11 +467,21 @@ if [ "${SPARKINFER_SKIP_ACCURACY:-0}" = "1" ] && [ -n "${SPARKINFER_ACCURACY_TOP
   TOP1="${SPARKINFER_ACCURACY_TOP1}"
   KL="${SPARKINFER_ACCURACY_KL:-99}"
 else
-  acc=$(SPARKINFER_EVAL_SEED="$EVAL_SEED" "$HERE/accuracy.sh" "$GGUF" 2>/dev/null || true)
+  _acc_err="$(mktemp)"
+  acc=$(SPARKINFER_EVAL_SEED="$EVAL_SEED" "$HERE/accuracy.sh" "$GGUF" 2>"$_acc_err" || true)
+  if ! printf '%s\n' "$acc" | grep -q 'METRIC '; then
+    _errtail="$(tail -1 "$_acc_err" 2>/dev/null | tr -d '\n' | head -c 200)"
+    rm -f "$_acc_err"
+    emit_infra_verdict "accuracy check produced no METRIC (${_errtail:-empty})"
+  fi
+  rm -f "$_acc_err"
   # parse the unambiguous METRIC line (not the human-readable text, which contains "bar >= 0.90")
   TOP1=$(printf '%s\n' "$acc" | sed -n 's/.*METRIC .*top1=\([0-9.][0-9.]*\).*/\1/p' | head -1)
   KL=$(printf   '%s\n' "$acc" | sed -n 's/.*METRIC .*kl=\([0-9.][0-9.]*\).*/\1/p' | head -1)
   TOP1="${TOP1:-0}"; KL="${KL:-99}"
+  if [ "$TOP1" = "0" ] && [ "$KL" = "99" ]; then
+    emit_infra_verdict "accuracy METRIC parsed as top1=0 kl=99 (likely failed run)"
+  fi
 fi
 
 # Provenance merged into the verdict (M1 clock, H1 seed, C2 reference pins) — non-scoring, for the log.

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -50,8 +50,19 @@ P36_DIR="${PRIMARY36_MODELS_DIR:-${MODELS_DIR:-$ROOT/models}36}"
 QUANT="${PRIMARY_QUANT:-Q4_K_M}"
 echo ">> bidir: Qwen3.5=$P35_FILE (quant=$QUANT, ctx=128/4k/32k/64k) + Qwen3.6=$P36_FILE (ctx=128/512/4k/16k/32k)" >&2
 
-reap() { pkill -f llama-server 2>/dev/null || true; pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
-reap_bench() { pkill -f qwen3_gguf 2>/dev/null || true; sleep 1; true; }
+reap() {
+  pkill -f llama-server 2>/dev/null || true
+  pkill -f qwen3_gguf_bench 2>/dev/null || true
+  pkill -f qwen3_gguf 2>/dev/null || true
+  sleep 3
+  true
+}
+reap_bench() {
+  pkill -f qwen3_gguf_bench 2>/dev/null || true
+  pkill -f qwen3_gguf 2>/dev/null || true
+  sleep 3
+  true
+}
 
 declare -A _ACC_TOP1 _ACC_KL
 _LAST_GGUF=""
@@ -416,6 +427,8 @@ def load(name):
         return {}
 
 def guard_ok(guard):
+    if guard.get("infra_error"):
+        return True, [], True, True
     gctx = ["guard_128_pass", "guard_512_pass", "guard_4k_pass", "guard_16k_pass", "guard_32k_pass",
             "guard_64k_pass", "guard_128k_pass"]
     present = [k for k in gctx if k in guard]
@@ -434,6 +447,8 @@ def merge_primary(primary, guard, scored_model, guard_model, guard_prefix):
     if not primary:
         return {"label": "REJECT", "pass": False,
                 "reason": f"primary ({scored_model}) produced no verdict (infra error)"}
+    if primary.get("infra_error"):
+        return dict(primary)
     _, regressed, speed_ok, acc_ok = guard_ok(guard)
     out = dict(primary)
     out["model"] = scored_model
@@ -480,11 +495,19 @@ def pick_best(a, b):
 
 def pick_headline(a, b):
     """Headline verdict: a failing optimize run must not lose to the other's none."""
+    if a.get("pass") and not b.get("pass"):
+        return dict(a)
+    if b.get("pass") and not a.get("pass"):
+        return dict(b)
     if not a.get("pass") or not b.get("pass"):
         for s in (a, b):
+            if s.get("infra_error"):
+                continue
             if not s.get("pass") and s.get("label") == "REJECT":
                 return dict(s)
         for s in (a, b):
+            if s.get("infra_error"):
+                continue
             if not s.get("pass"):
                 return dict(s)
     return pick_best(a, b)

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1157,8 +1157,10 @@ def render(res, oid):
             "BASELINE": "No same-box main baseline was set; this run establishes one."
             }.get(label, f"Verified speedup over same-box origin/main — "
                          f"{res.get('tps')} tok/s (main was {res.get('frontier_tps','?')} tok/s).")
-    if label == "REJECT" and res.get("auto_close"):
+    if label == "REJECT" and res.get("auto_close") and not res.get("infra_error"):
         note = "No context cleared the 2% significance gate while at least one context regressed. Auto-closing this PR."
+    if res.get("infra_error") or str(res.get("reason") or "").startswith("infra error"):
+        note = "Infra failure during eval (not a verified PR regression) — re-run recommended."
     target_note = ("128/512/4k/16k/32k guarded · Qwen3.5 prefill at 4k/32k/64k · scored vs same-box main"
                    if res.get("eval_mode") == "longctx" and (res.get("score_qwen35") or {}).get("eval_prefill")
                    else "128/512/4k/16k/32k guarded · scored vs same-box main · strongest context scores"


### PR DESCRIPTION
## Summary
- Emit explicit `infra_error` verdicts when bench sweep hits `[FAIL] load` or accuracy produces no METRIC / default top1=0 kl=99
- Teach bidir merge to skip guard penalties and prefer passing runs when the other side infra-failed
- Stop the eval bot from auto-closing PRs on infra failures; show a re-run note instead

Follows #469 (evaluate.sh syntax fix). Fixes false "primary produced no verdict" / accuracy REJECTs on PRs like #464 when the box OOMs on guard models.

## Test plan
- [x] Local diff reviewed against origin/main (accuracy cache preserved)
- [ ] Re-run eval bot on a PR after merge without `SPARKINFER_USE_LOCAL_BENCH=1`