### PR TITLE
perf(qwen35): int8-native prefill GEMM (mma.sync m16n8k32) for Qwythos

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
@@ -1,15 +1,16 @@
 // int8 tensor-core GEMM for Qwythos batched prefill (see prefill_i8.h).
 //
-// C[M,N] = A[M,K] @ W^T, W native GGUF [N,K] row-major. int8 x int8 -> int32 wmma with the dequant
-// (per-token sx[m] * per-channel sw[n]) folded into the store, emitting bf16 C. The tiling mirrors
-// the bf16 batched-prefill GEMM exactly (128x128 tile, 8 warps, 2x4 frags, BK=32, cp.async
-// double-buffer) so this is a drop-in replacement that keeps the rest of the prefill pipeline bf16.
-// On sm_120 int8 tensor cores run ~2x the bf16 kernel at identical output fidelity (GGUF weights are
-// already 4-6 bit, so int8 weight-quant is lossless vs what is stored).
+// C[M,N] = A[M,K] @ W^T, W native GGUF [N,K] row-major. int8 x int8 -> int32 with the dequant
+// (per-token sx[m] * per-channel sw[n]) folded into the store, emitting bf16 C.
+//
+// Shaped for int8 rather than mirroring the bf16 GEMM: mma.sync m16n8k32 (int8's native shape --
+// wmma m16n16k16 can only emit the k16 shape, which caps at half the int8 MAC rate), BK=64 to halve
+// the main-loop barrier count, an XOR-swizzled smem layout so the 4B operand loads spread across
+// banks, and a register->global epilogue that keeps the int32 accumulators out of shared memory.
+// Same int8 quantization scheme and accumulation order as before, so C is bit-identical.
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
 #include <cuda_pipeline.h>
-#include <mma.h>
 #include "sparkinfer/kernels/prefill_i8.h"
 
 namespace sparkinfer { namespace kernels {
@@ -17,11 +18,23 @@ namespace sparkinfer { namespace kernels {
 namespace {
 constexpr int PF_BM = 128;
 constexpr int PF_BN = 128;
-constexpr int PF_BK = 32;
+constexpr int PF_BK = 64;          // 4 x 16B chunks per row
+constexpr int PF_MFRAG = 2;        // 32 rows per warp / 16
+constexpr int PF_NFRAG = 8;        // 64 cols per warp / 8
 
 __device__ __forceinline__ void pf_cp16(void* dst, const void* src, bool pred) {
     if (pred) __pipeline_memcpy_async(dst, src, 16);
     else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
+
+// XOR swizzle at 16B granularity: chunk c of row r lives at chunk (c ^ (r & 3)). Rows 4 apart still
+// collide (2-way); rows 0..3 -- the stride the 4B operand loads walk -- land on disjoint banks.
+__device__ __forceinline__ int pf_swz(int k, int row) {
+    return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
+}
+
+__device__ __forceinline__ unsigned pf_lds32(const signed char* p) {
+    return *reinterpret_cast<const unsigned*>(p);
 }
 
 // Per-row symmetric int8 quantize, one warp per row.
@@ -39,36 +52,43 @@ __global__ void pf_quantize_rows_i8(const __nv_bfloat16* __restrict__ x, signed 
         q[(size_t)r * cols + c] = (signed char)((amax == 0.f) ? 0 : (int)roundf(__bfloat162float(x[(size_t)r * cols + c]) / d));
 }
 
-__global__ void pf_gemm_i8_kernel(const signed char* __restrict__ A, const signed char* __restrict__ W,
-                                  const float* __restrict__ sx, const float* __restrict__ sw,
-                                  __nv_bfloat16* __restrict__ C, int M, int N, int K) {
-    using namespace nvcuda;
+// The 2 in __launch_bounds__ is required, not decorative: left to itself nvcc picks 131 registers,
+// and 2 * 256 * 131 exceeds the 65536-register file, so only one block per SM would be resident.
+__global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
+        const signed char* __restrict__ A, const signed char* __restrict__ W,
+        const float* __restrict__ sx, const float* __restrict__ sw,
+        __nv_bfloat16* __restrict__ C, int M, int N, int K) {
     __shared__ signed char As[2][PF_BM][PF_BK];
     __shared__ signed char Bs[2][PF_BN][PF_BK];
-    __shared__ int Cs[8][16][16];                    // per-warp int32 fragment staging
 
     const int tid  = threadIdx.x;
     const int warp = tid >> 5;
     const int lane = tid & 31;
+    const int grp  = lane >> 2;                       // 0..7
+    const int tig  = lane & 3;                        // thread-in-group
     const int wm   = warp & 3;                        // rows [wm*32, +32)
     const int wn   = warp >> 2;                       // cols [wn*64, +64)
     const int m0   = blockIdx.y * PF_BM;
     const int n0   = blockIdx.x * PF_BN;
     const int nk   = (K + PF_BK - 1) / PF_BK;
 
-    wmma::fragment<wmma::accumulator, 16, 16, 16, int> cf[2][4];
+    int acc[PF_MFRAG][PF_NFRAG][4];
     #pragma unroll
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < PF_MFRAG; i++)
         #pragma unroll
-        for (int j = 0; j < 4; j++) wmma::fill_fragment(cf[i][j], 0);
+        for (int j = 0; j < PF_NFRAG; j++)
+            #pragma unroll
+            for (int e = 0; e < 4; e++) acc[i][j][e] = 0;
 
-    // int8 tile is 128x32 = 4096 B = 256 x 16B slots; 256 threads stage 1 A-slot + 1 B-slot each.
+    // 128 rows x 64B = 512 16B chunks per tile; 256 threads stage 2 A-chunks + 2 B-chunks each.
     auto stage = [&](int buf, int k0) {
-        const int r = tid >> 1, c16 = (tid & 1) * 16;
-        const int gm = m0 + r, gk = k0 + c16;
-        pf_cp16(&As[buf][r][c16], &A[(size_t)gm * K + gk], gm < M && gk < K);
-        const int gn = n0 + r;
-        pf_cp16(&Bs[buf][r][c16], &W[(size_t)gn * K + gk], gn < N && gk < K);
+        #pragma unroll
+        for (int s = tid; s < 512; s += 256) {
+            const int r = s >> 2, c = s & 3, k = c << 4;
+            const int gm = m0 + r, gn = n0 + r, gk = k0 + k;
+            pf_cp16(&As[buf][r][pf_swz(k, r)], &A[(size_t)gm * K + gk], gm < M && gk < K);
+            pf_cp16(&Bs[buf][r][pf_swz(k, r)], &W[(size_t)gn * K + gk], gn < N && gk < K);
+        }
         __pipeline_commit();
     };
 
@@ -78,37 +98,67 @@ __global__ void pf_gemm_i8_kernel(const signed char* __restrict__ A, const signe
         if (t + 1 < nk) stage(buf ^ 1, (t + 1) * PF_BK);
         __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
         __syncthreads();
+
         #pragma unroll
-        for (int kk = 0; kk < PF_BK; kk += 16) {
-            wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af[2];
-            wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf[4];
+        for (int kk = 0; kk < PF_BK; kk += 32) {
+            const int ka = kk + tig * 4;
+            unsigned af[PF_MFRAG][4], bf[PF_NFRAG][2];
             #pragma unroll
-            for (int i = 0; i < 2; i++) wmma::load_matrix_sync(af[i], &As[buf][wm * 32 + i * 16][kk], PF_BK);
+            for (int i = 0; i < PF_MFRAG; i++) {
+                const int rlo = wm * 32 + i * 16 + grp, rhi = rlo + 8;
+                af[i][0] = pf_lds32(&As[buf][rlo][pf_swz(ka,      rlo)]);
+                af[i][1] = pf_lds32(&As[buf][rhi][pf_swz(ka,      rhi)]);
+                af[i][2] = pf_lds32(&As[buf][rlo][pf_swz(ka + 16, rlo)]);
+                af[i][3] = pf_lds32(&As[buf][rhi][pf_swz(ka + 16, rhi)]);
+            }
             #pragma unroll
-            for (int j = 0; j < 4; j++) wmma::load_matrix_sync(bf[j], &Bs[buf][wn * 64 + j * 16][kk], PF_BK);
+            for (int j = 0; j < PF_NFRAG; j++) {
+                const int col = wn * 64 + j * 8 + grp;
+                bf[j][0] = pf_lds32(&Bs[buf][col][pf_swz(ka,      col)]);
+                bf[j][1] = pf_lds32(&Bs[buf][col][pf_swz(ka + 16, col)]);
+            }
             #pragma unroll
-            for (int i = 0; i < 2; i++)
+            for (int i = 0; i < PF_MFRAG; i++)
                 #pragma unroll
-                for (int j = 0; j < 4; j++) wmma::mma_sync(cf[i][j], af[i], bf[j], cf[i][j]);
+                for (int j = 0; j < PF_NFRAG; j++)
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                        : "+r"(acc[i][j][0]), "+r"(acc[i][j][1]), "+r"(acc[i][j][2]), "+r"(acc[i][j][3])
+                        : "r"(af[i][0]), "r"(af[i][1]), "r"(af[i][2]), "r"(af[i][3]),
+                          "r"(bf[j][0]), "r"(bf[j][1]));
         }
         __syncthreads();
         buf ^= 1;
     }
-    // Store 8 fragments via per-warp int32 staging; fold the dequant sx[m]*sw[n] into the bf16 write.
+
+    // Registers straight to global: c0/c1 (and c2/c3) are adjacent columns, so each pair packs into
+    // one 4B bf16x2 store.
     #pragma unroll
-    for (int i = 0; i < 2; i++) {
+    for (int i = 0; i < PF_MFRAG; i++) {
         #pragma unroll
-        for (int j = 0; j < 4; j++) {
-            const int gm = m0 + wm * 32 + i * 16, gn = n0 + wn * 64 + j * 16;
-            wmma::store_matrix_sync(&Cs[warp][0][0], cf[i][j], 16, wmma::mem_row_major);
-            __syncwarp();
-            for (int e = lane; e < 256; e += 32) {
-                const int r = e >> 4, cc = e & 15;
-                const int rm = gm + r, rn = gn + cc;
-                if (rm < M && rn < N)
-                    C[(size_t)rm * N + rn] = __float2bfloat16((float)Cs[warp][r][cc] * sx[rm] * sw[rn]);
+        for (int j = 0; j < PF_NFRAG; j++) {
+            const int gn = n0 + wn * 64 + j * 8 + tig * 2;
+            if (gn + 1 >= N) {                        // tail: scalar path
+                #pragma unroll
+                for (int e = 0; e < 4; e++) {
+                    const int gm = m0 + wm * 32 + i * 16 + grp + (e >> 1) * 8;
+                    const int cn = gn + (e & 1);
+                    if (gm < M && cn < N)
+                        C[(size_t)gm * N + cn] = __float2bfloat16((float)acc[i][j][e] * sx[gm] * sw[cn]);
+                }
+                continue;
             }
-            __syncwarp();
+            const float w0 = sw[gn], w1 = sw[gn + 1];
+            #pragma unroll
+            for (int h = 0; h < 2; h++) {
+                const int gm = m0 + wm * 32 + i * 16 + grp + h * 8;
+                if (gm >= M) continue;
+                const float s = sx[gm];
+                const __nv_bfloat162 v = __floats2bfloat162_rn((float)acc[i][j][h * 2] * s * w0,
+                                                               (float)acc[i][j][h * 2 + 1] * s * w1);
+                *reinterpret_cast<__nv_bfloat162*>(&C[(size_t)gm * N + gn]) = v;
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Reshape `pf_gemm_i8_kernel` for int8 instead of mirroring the bf16 prefill GEMM's tiling. Since #464 removed the dequant round-trip, this kernel is ~52% of Qwythos 4k prefill wall time, and it was leaving about a third of its throughput on the floor. **+19.6% prefill pp at 4k**, output bit-identical to main.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (Qwythos / Qwen3.5, `--ctx 4096`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 13829.52 |
| after prefill (this PR) | 16537.22 |

Decode table intentionally left empty — this PR does not target decode, and the batched-prefill GEMM is not on the decode path (decode uses MMVQ). The runs below confirm decode is unchanged: 286.77 → 286.55 tok/s (−0.08%, noise).

```text
############ BEFORE (main @ upstream/main) ############
$ bench/scripts/bench.sh Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf --tokens 128 --ctx 4096
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s

=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 7.7 GB
decode tg    : 286.77 tok/s  (3.5 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 13829.52 tok/s  (ctx=4096, sequential KV fill)
GPU          : 29°C · 57 W · 2475 MHz (peak under load)

############ AFTER (this PR) ############
$ bench/scripts/bench.sh Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf --tokens 128 --ctx 4096
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s

=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 7.7 GB
decode tg    : 286.55 tok/s  (3.5 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 16537.22 tok/s  (ctx=4096, sequential KV fill)
GPU          : 32°C · 58 W · 2475 MHz (peak under load)
```

## What changed

`kernels/csrc/cuda/fused/prefill_gemm_i8.cu` only; the launcher signature is unchanged, so it stays a drop-in for the bf16 path.

- **`mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32`** replaces `wmma` m16n16k16. wmma's int8 path can only emit the **k16** shape, capping it at roughly half the int8 MAC rate; m16n8k32 is int8's native shape. A and the native GGUF weight are both k-contiguous ([M,K] and [N,K]) — already the `.row.col` operand layout, so no repacking.
- **BK 32 → 64.** At K=4096 the old tiling ran 128 main-loop iterations, each with two block-wide barriers.
- **XOR-swizzled smem** (chunk `c` of row `r` → `c ^ (r & 3)`). The old `[128][32]` int8 tile has a 32-byte row stride = 8 banks, so the 16-row fragment loads collided 4 ways.
- **Register → global epilogue.** wmma's accumulator layout is opaque, so the old epilogue staged int32 through `Cs[8][16][16]` smem with two `__syncwarp()` per fragment. mma.sync's layout is defined, so c0/c1 are adjacent columns and pack into one bf16x2 store.
- **`__launch_bounds__(256, 2)`.** The second argument is required, not decorative: left alone nvcc picks 131 registers, and `2 × 256 × 131` overflows the 65536-register file, so only one block per SM stays resident — half the occupancy of the kernel it replaces (which lands on 125). Capping at 128 (ptxas settles on 127, zero spills) restores 2 blocks/SM and is worth more than every tiling change above combined.

## Correctness

Output is **bit-identical to main** on every real projection shape — attn q/k/v/o, lin_qkv, ssm_out, ffn gate/up/down, plus an odd/tail shape — checked element-for-element against main and against a CPU int32 reference (0 mismatches out of 100,663,296 on the largest tile). The int8 quantization scheme and accumulation order are unchanged; only tiling, MMA shape, and the epilogue differ, so accuracy is unchanged by construction rather than by measurement.

## Notes

- Extra evidence (not the before/after basis): the GEMM alone goes 154.32 ms → 105.44 ms per 4k prefill (1.46×, nsys, 200 launches), ~330 → ~480 TOPS.
- A BK=128 variant with a fully conflict-free swizzle was tried and rejected — 64KB of smem halves blocks/SM and it measured slower than BK=64 on every shape.
- Builds on #464 rather than competing with it: removing the dequant is what promoted this kernel to the top of the profile.
