### PR TITLE
dashboard: Qwen3.5 prefill optimization journey

### DIFF
--- a/dashboard/data.js
+++ b/dashboard/data.js
@@ -1,15 +1,15 @@
 window.SPARKINFER = {
   "updated": "2026-07-16",
   "status": {
-    "gpu": "RTX 5090 \u00b7 sm_120 \u00b7 CUDA 13",
-    "model": "Qwen3-30B-A3B \u00b7 Q4_K_M",
+    "gpu": "RTX 5090 · sm_120 · CUDA 13",
+    "model": "Qwen3-30B-A3B · Q4_K_M",
     "frontier_tps": 484.79,
     "ref_name": "llama.cpp",
     "ref_tps": 365.85,
     "vram_gb": 21.4,
     "token_match": 0.97,
     "kl": 0.02,
-    "ref_note": "128-tok decode rerun on current main, same RTX 5090 \u00b7 Q4_K_M GGUF",
+    "ref_note": "128-tok decode rerun on current main, same RTX 5090 · Q4_K_M GGUF",
     "longctx_16k_tps": 330.2,
     "longctx_2k_tps": 277.78,
     "longctx_token_match": 0.9426,
@@ -109,27 +109,27 @@ window.SPARKINFER = {
     },
     {
       "l": "L",
-      "d": "10\u201318% over frontier",
+      "d": "10–18% over frontier",
       "c": "#1D76DB"
     },
     {
       "l": "M",
-      "d": "6\u201310% over frontier",
+      "d": "6–10% over frontier",
       "c": "#8250DF"
     },
     {
       "l": "S",
-      "d": "3.5\u20136% over frontier",
+      "d": "3.5–6% over frontier",
       "c": "#B8860B"
     },
     {
       "l": "XS",
-      "d": "2\u20133.5% over frontier",
+      "d": "2–3.5% over frontier",
       "c": "#8A93A0"
     },
     {
       "l": "none",
-      "d": "\u2264 2% \u2014 within noise, no verified gain",
+      "d": "≤ 2% — within noise, no verified gain",
       "c": "#9AA6B2"
     },
     {
@@ -177,7 +177,7 @@ window.SPARKINFER = {
         "label": "XL",
         "delta_tps": 6395.15,
         "pct_over_frontier": 83.5,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2535",
@@ -301,7 +301,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.7,
         "pct_over_frontier": 0.2,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2535",
@@ -446,7 +446,7 @@ window.SPARKINFER = {
         "label": "XL",
         "delta_tps": 2318.58,
         "pct_over_frontier": 42.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2535",
@@ -570,7 +570,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.69,
         "pct_over_frontier": 0.2,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2542",
@@ -677,7 +677,7 @@ window.SPARKINFER = {
     },
     {
       "num": 463,
-      "title": "perf(qwen35): fp16 shared-memory tiles for windowed prefill attention (+3\u20135% pp)",
+      "title": "perf(qwen35): fp16 shared-memory tiles for windowed prefill attention (+3–5% pp)",
       "areas": [
         "kernels",
         "runtime"
@@ -713,7 +713,7 @@ window.SPARKINFER = {
         "label": "M",
         "delta_tps": 381.06,
         "pct_over_frontier": 7.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2535",
@@ -837,7 +837,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.03,
         "pct_over_frontier": 0.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2527",
@@ -1202,7 +1202,7 @@ window.SPARKINFER = {
     },
     {
       "num": 458,
-      "title": "perf(qwen36): Q6\u2192Q4 LM-head via loader + specialize GDN AR",
+      "title": "perf(qwen36): Q6→Q4 LM-head via loader + specialize GDN AR",
       "areas": [
         "kernels",
         "runtime"
@@ -1501,7 +1501,7 @@ window.SPARKINFER = {
         "label": "XL",
         "delta_tps": 3128.35,
         "pct_over_frontier": 247.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2527",
@@ -1625,7 +1625,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.5,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2497",
@@ -1732,7 +1732,7 @@ window.SPARKINFER = {
     },
     {
       "num": 422,
-      "title": "perf(qwen35): int8 tensor-core prefill GEMM for Qwythos [DRAFT \u2014 awaits #398]",
+      "title": "perf(qwen35): int8 tensor-core prefill GEMM for Qwythos [DRAFT — awaits #398]",
       "areas": [
         "kernels",
         "runtime"
@@ -1768,7 +1768,7 @@ window.SPARKINFER = {
         "label": "XL",
         "delta_tps": 1916.72,
         "pct_over_frontier": 45.9,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2512",
@@ -1892,7 +1892,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.2,
         "pct_over_frontier": 0.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2542",
@@ -2036,7 +2036,7 @@ window.SPARKINFER = {
         "label": "XL",
         "delta_tps": 3829.97,
         "pct_over_frontier": 1195.2,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2527",
@@ -2157,7 +2157,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.19,
         "pct_over_frontier": 0.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2527",
@@ -2411,7 +2411,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 8.6,
         "pct_over_frontier": 2.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -2554,7 +2554,7 @@ window.SPARKINFER = {
         "label": "L",
         "delta_tps": 32.17,
         "pct_over_frontier": 11.2,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2520",
@@ -2669,7 +2669,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.19,
         "pct_over_frontier": 0.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "2490",
@@ -2908,7 +2908,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.37,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3015,7 +3015,7 @@ window.SPARKINFER = {
     },
     {
       "num": 360,
-      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K\u2192Q4_K requant of the MoE FFN stage (+3.1\u20133.8%)",
+      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K→Q4_K requant of the MoE FFN stage (+3.1–3.8%)",
       "areas": [
         "runtime"
       ],
@@ -3058,7 +3058,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.03,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3241,7 +3241,7 @@ window.SPARKINFER = {
     },
     {
       "num": 359,
-      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K\u2192Q4_K requant of the MoE FFN stage (+2.8\u20133.2%)",
+      "title": "perf(qwen36): Q4_K shared-expert FFN kernels + Q8_0/Q5_K→Q4_K requant of the MoE FFN stage (+2.8–3.2%)",
       "areas": [
         "runtime"
       ],
@@ -3286,7 +3286,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 0.9,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -3469,7 +3469,7 @@ window.SPARKINFER = {
     },
     {
       "num": 355,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN ssm_out projections (+2.8% @128)",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN ssm_out projections (+2.8% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -3508,7 +3508,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.32,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -3810,7 +3810,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.17,
         "pct_over_frontier": -0.0,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -4032,7 +4032,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.13,
         "pct_over_frontier": 0.2,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -4125,7 +4125,7 @@ window.SPARKINFER = {
     },
     {
       "num": 267,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of GDN input projections (attn_qkv + attn_gate) (+11.5% @128)",
       "areas": [
         "kernels",
         "runtime"
@@ -4162,7 +4162,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.16,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": true,
         "clock_mhz": "0",
@@ -4335,7 +4335,7 @@ window.SPARKINFER = {
     },
     {
       "num": 353,
-      "title": "perf(qwen36): Q8_0\u2192Q4_K requant of full-attention q/o projections",
+      "title": "perf(qwen36): Q8_0→Q4_K requant of full-attention q/o projections",
       "areas": [
         "kernels",
         "runtime"
@@ -4372,7 +4372,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.59,
         "pct_over_frontier": 0.5,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -4581,7 +4581,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.21,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -4656,7 +4656,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 0.23,
         "pct_over_frontier": 0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -4786,7 +4786,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 2.02,
         "pct_over_frontier": 0.7,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -4956,7 +4956,7 @@ window.SPARKINFER = {
     },
     {
       "num": 350,
-      "title": "perf(qwen36): opt-in Q8\u2192Q4 requant reward profile (~+6.3% @512)",
+      "title": "perf(qwen36): opt-in Q8→Q4 requant reward profile (~+6.3% @512)",
       "areas": [
         "kernels",
         "runtime"
@@ -4999,7 +4999,7 @@ window.SPARKINFER = {
         "label": "REJECT",
         "delta_tps": 1.8,
         "pct_over_frontier": 0.6,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": false,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -5259,7 +5259,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": 1.29,
         "pct_over_frontier": 0.4,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -5750,7 +5750,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -5958,7 +5958,7 @@ window.SPARKINFER = {
         "label": "none",
         "delta_tps": -0.45,
         "pct_over_frontier": -0.1,
-        "note": "within significance gate \u2014 not a verified improvement",
+        "note": "within significance gate — not a verified improvement",
         "pass": true,
         "clocks_pinned": false,
         "clock_mhz": "0",
@@ -6472,7 +6472,7 @@ window.SPARKINFER = {
     },
     {
       "num": 323,
-      "title": "perf(qwen35): requantize dense FFN down Q6_K\u2192Q4_K at load (~5% Qwythos decode)",
+      "title": "perf(qwen35): requantize dense FFN down Q6_K→Q4_K at load (~5% Qwythos decode)",
       "areas": [
         "kernels",
         "runtime"
@@ -6542,7 +6542,7 @@ window.SPARKINFER = {
     },
     {
       "num": 239,
-      "title": "perf(qwen3.6): fuse decode kernel launches \u2014 shared-expert + GDN conv/L2-norm",
+      "title": "perf(qwen3.6): fuse decode kernel launches — shared-expert + GDN conv/L2-norm",
       "areas": [
         "kernels",
         "runtime"
@@ -6936,7 +6936,7 @@ window.SPARKINFER = {
     },
     {
       "num": 269,
-      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append \u2014 25% decode",
+      "title": "perf(qwen3.6): shared-expert MMVQ + QK-norm+RoPE+KV-append — 25% decode",
       "areas": [
         "kernels",
         "runtime"
@@ -6951,7 +6951,7 @@ window.SPARKINFER = {
     },
     {
       "num": 266,
-      "title": "perf(qwen36): +15-20% decode \u2014 Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
+      "title": "perf(qwen36): +15-20% decode — Q8 shared MMVQ, pipelining, F=512 MoE, hd256 FA",
       "areas": [
         "kernels",
         "runtime"
@@ -7217,7 +7217,7 @@ window.SPARKINFER = {
     },
     {
       "num": 229,
-      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit\u2026",
+      "title": "feat(qwen36): add optimized Gated-DeltaNet AR state update kernel wit…",
       "areas": [
         "kernels"
       ],
@@ -7315,7 +7315,7 @@ window.SPARKINFER = {
       "date": "2026-06-27"
     },
     {
-      "name": "split-K MMVQ down \u2014 +8% Qwen",
+      "name": "split-K MMVQ down — +8% Qwen",
       "tps": 339.59,
       "pr": 74,
       "date": "2026-06-28"
@@ -7486,18 +7486,18 @@ window.SPARKINFER = {
     ]
   },
   "qwen35": {
-    "model": "Qwythos-9B (Qwen3.5-9B) \u00b7 Q4_K_M",
+    "model": "Qwythos-9B (Qwen3.5-9B) · Q4_K_M",
     "hf_repo": "empero-ai/Qwythos-9B-Claude-Mythos-5-1M-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 1985221,
-    "arch": "dense hybrid Gated-DeltaNet + full-attn \u00b7 9B \u00b7 hd256",
+    "arch": "dense hybrid Gated-DeltaNet + full-attn · 9B · hd256",
     "frontier_tps": 303.18,
     "baseline_tps": 256.95,
     "ref_name": "llama.cpp",
     "ref_tps": 220.84,
     "token_match": 0.9573,
     "kl": 0.0274,
-    "note": "same-box baseline 91.224.44.227 \u00b7 prefill pp refs from reference.lock (2026-07-13, RTX 5090)",
+    "note": "same-box baseline 91.224.44.227 · prefill pp refs from reference.lock (2026-07-13, RTX 5090)",
     "ctx": [
       {
         "label": "128",
@@ -7545,7 +7545,8 @@ window.SPARKINFER = {
         "pp": 14149.94,
         "ref_pp": 8153.53
       }
-    ]
+    ],
+    "baseline_pp": 288.16
   },
   "landed_qwen35": [
     {
@@ -7675,11 +7676,11 @@ window.SPARKINFER = {
     }
   ],
   "qwen36": {
-    "model": "Qwen3.6-35B-A3B \u00b7 UD-Q4_K_M",
+    "model": "Qwen3.6-35B-A3B · UD-Q4_K_M",
     "hf_repo": "unsloth/Qwen3.6-35B-A3B-GGUF",
     "hf_avatar": "assets/img/huggingface.svg",
     "hf_downloads": 844561,
-    "arch": "hybrid Gated-DeltaNet + full-attn MoE \u00b7 256 experts top-8 \u00b7 hd256",
+    "arch": "hybrid Gated-DeltaNet + full-attn MoE · 256 experts top-8 · hd256",
     "frontier_tps": 473.27,
     "baseline_tps": 427.54,
     "ref_name": "llama.cpp",
@@ -7751,7 +7752,7 @@ window.SPARKINFER = {
       "label": "M"
     },
     {
-      "name": "+15-20% decode \u2014 Q8 shared M",
+      "name": "+15-20% decode — Q8 shared M",
       "tps": 300.16,
       "pr": 266,
       "date": "2026-07-06",
@@ -7800,7 +7801,7 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of full-at",
+      "name": "Q8_0→Q4_K requant of full-at",
       "tps": 427.54,
       "pr": 353,
       "date": "2026-07-12",
@@ -7814,11 +7815,65 @@ window.SPARKINFER = {
       "label": "S"
     },
     {
-      "name": "Q8_0\u2192Q4_K requant of GDN inp",
+      "name": "Q8_0→Q4_K requant of GDN inp",
       "tps": 463.27,
       "pr": 267,
       "date": "2026-07-13",
       "label": "XL"
+    }
+  ],
+  "landed_qwen35_pp": [
+    {
+      "name": "skip LM head on prefill + de",
+      "pr": 387,
+      "date": "2026-07-15",
+      "label": "L",
+      "tps": 320.33
+    },
+    {
+      "name": "batched prompt prefill for Q",
+      "pr": 398,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 4150.42
+    },
+    {
+      "name": "int8 tensor-core prefill GEM",
+      "pr": 422,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 6096.4
+    },
+    {
+      "name": "windowed prefill attention f",
+      "pr": 455,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 6096.4,
+      "raw_tps": 4394.9
+    },
+    {
+      "name": "fp16 shared-memory tiles for",
+      "pr": 463,
+      "date": "2026-07-16",
+      "label": "M",
+      "tps": 6096.4,
+      "raw_tps": 5509.41
+    },
+    {
+      "name": "fused Q4K/Q6K->int8 dequant ",
+      "pr": 464,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 14057.87
+    },
+    {
+      "name": "int8 tensor-core prefill att",
+      "pr": 465,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 14057.87,
+      "raw_tps": 7828.06
     }
   ]
 };

--- a/dashboard/data.json
+++ b/dashboard/data.json
@@ -7545,7 +7545,8 @@
         "pp": 14149.94,
         "ref_pp": 8153.53
       }
-    ]
+    ],
+    "baseline_pp": 288.16
   },
   "landed_qwen35": [
     {
@@ -7819,6 +7820,60 @@
       "pr": 267,
       "date": "2026-07-13",
       "label": "XL"
+    }
+  ],
+  "landed_qwen35_pp": [
+    {
+      "name": "skip LM head on prefill + de",
+      "pr": 387,
+      "date": "2026-07-15",
+      "label": "L",
+      "tps": 320.33
+    },
+    {
+      "name": "batched prompt prefill for Q",
+      "pr": 398,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 4150.42
+    },
+    {
+      "name": "int8 tensor-core prefill GEM",
+      "pr": 422,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 6096.4
+    },
+    {
+      "name": "windowed prefill attention f",
+      "pr": 455,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 6096.4,
+      "raw_tps": 4394.9
+    },
+    {
+      "name": "fp16 shared-memory tiles for",
+      "pr": 463,
+      "date": "2026-07-16",
+      "label": "M",
+      "tps": 6096.4,
+      "raw_tps": 5509.41
+    },
+    {
+      "name": "fused Q4K/Q6K->int8 dequant ",
+      "pr": 464,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 14057.87
+    },
+    {
+      "name": "int8 tensor-core prefill att",
+      "pr": 465,
+      "date": "2026-07-16",
+      "label": "XL",
+      "tps": 14057.87,
+      "raw_tps": 7828.06
     }
   ]
 }

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -254,7 +254,7 @@
   </section>
 
   <section>
-    <div class="sec-h"><h2>Qwen3.5 · optimization journey</h2><span class="hint" id="passes35-hint"></span></div>
+    <div class="sec-h"><h2>Qwen3.5 · prefill optimization journey</h2><span class="hint" id="passes35-hint"></span></div>
     <div class="card"><div id="passes35"></div></div>
   </section>
 
@@ -424,7 +424,7 @@
   // Reusable optimization-journey bar chart — each scored model (Qwen3-MoE, Qwen3.6) gets its own.
   const legItem=(c,t)=>`<span style="display:flex;align-items:center;gap:6px"><span style="width:11px;height:11px;border-radius:3px;background:${c}"></span>${t}</span>`;
   const legWrap=items=>`<div style="display:flex;gap:18px;justify-content:center;margin-top:12px;font-size:12px;color:var(--body);flex-wrap:wrap">${items}</div>`;
-  function drawJourney(elId, pts, legendHtml){
+  function drawJourney(elId, pts, legendHtml, unit="tok/s"){
     if(!pts.length){ return; }
     const W=760,H=336,padL=12,padR=12,padT=30,padB=106, cw=W-padL-padR, ch=H-padT-padB;
     const maxT=Math.max(...pts.map(p=>p.tps)), slot=cw/pts.length, bw=Math.min(slot*0.56,60);
@@ -433,7 +433,7 @@
     const bars=pts.map((p,i)=>{
       const cx=padL+slot*i+slot/2, bh=Math.max(2,p.tps/maxT*ch), y=padT+ch-bh;
       const fill=p.fixed?"url(#gFixed)":(p.llama?"url(#gLlama)":(p.baseline?"url(#gPoc)":(p.long?"url(#gLong)":(p.live?"url(#gLive)":"url(#gHist)"))));
-      return `<g><title>${esc(p.name)} — ${esc(p.sub)} · ${p.tps} tok/s</title>`+
+      return `<g><title>${esc(p.name)} — ${esc(p.sub)} · ${p.tps} ${unit}</title>`+
         `<rect x="${(cx-bw/2).toFixed(1)}" y="${y.toFixed(1)}" width="${bw.toFixed(1)}" height="${bh.toFixed(1)}" rx="4" fill="${fill}"/>`+
         `<text x="${cx.toFixed(1)}" y="${(y-7).toFixed(1)}" text-anchor="middle" font-size="12" font-weight="700" fill="#06050B">${p.tps<1?p.tps:Math.round(p.tps)}</text>`+
         `<text x="${cx.toFixed(1)}" y="${(padT+ch+14).toFixed(1)}" text-anchor="end" transform="rotate(-45 ${cx.toFixed(1)} ${(padT+ch+14).toFixed(1)})" font-size="10.5" fill="#5b5b66">${esc(trunc(p.name))}</text></g>`;
@@ -465,13 +465,14 @@
       legItem("#D14D72","ai-hpc v0.3.3 long-context POC")+
       legItem("#B8860B","landed on context frontier")));
   })();
-  // Qwen3.5 journey — Qwythos-9B 128-tok decode frontier (merge-chronological).
+  // Qwen3.5 prefill journey — scored prefill pp tok/s (merge-chronological ratchet).
   (function(){
     const q = D.qwen35 || {};
-    const L = [...(D.landed_qwen35 || [])].sort((a,b)=>(a.date||"").localeCompare(b.date||"")||(a.pr||0)-(b.pr||0));
+    const L = [...(D.landed_qwen35_pp || [])].sort((a,b)=>(a.date||"").localeCompare(b.date||"")||(a.pr||0)-(b.pr||0));
+    const refPp = (q.pp||[]).find(x=>x.label==="32k")?.ref_pp || 0;
     const pts = [];
-    const base = q.baseline_tps;
-    if (base) pts.push({name:"origin/main", sub:"same-box baseline · 128-tok decode", tps:base, baseline:true});
+    const base = q.baseline_pp;
+    if (base) pts.push({name:"origin/main", sub:"same-box baseline · scored prefill", tps:base, baseline:true});
     pts.push(...L.filter(l=>!l.baseline).map(l=>{
       let sub=(l.pr?"PR #"+l.pr+" · ":"")+l.date+(l.label?" · eval:"+l.label:"");
       if(l.raw_tps && l.raw_tps!==l.tps) sub+=" · measured "+l.raw_tps;
@@ -479,18 +480,19 @@
     }));
     const h = $("passes35-hint");
     if (h) {
-      const f = q.frontier_tps || Math.max(0, ...L.map(l=>l.tps), base||0);
+      const f = q.prefill_frontier_pp || Math.max(0, ...L.map(l=>l.tps), base||0);
       const b = base || (pts.length ? pts[0].tps : f);
       if (b && f) {
-        h.textContent = `${b} → ${f} tok/s · 128-tok decode · ${q.ref_tps?((f/q.ref_tps)*100).toFixed(0)+'% of '+q.ref_name+' '+q.ref_tps:'—'}`;
+        h.textContent = `${b} → ${f} pp tok/s · 32k prefill · ${refPp?((f/refPp)*100).toFixed(0)+'% of '+q.ref_name+' '+refPp:'—'}`;
       }
     }
-    if (!pts.length && q.ref_tps) {
-      pts.push({name:"llama.cpp", sub:"reference · 128-tok decode", tps:q.ref_tps, llama:true, fixed:true});
+    if (!pts.length && refPp) {
+      pts.push({name:"llama.cpp", sub:"reference · 32k prefill", tps:refPp, llama:true, fixed:true});
     }
     drawJourney("passes35", pts,
       legWrap(legItem("#D14D72","origin/main baseline")+
-              legItem("#0E8A16","landed / eval frontier · RTX 5090")));
+              legItem("#0E8A16","landed / eval frontier · RTX 5090")),
+      "pp tok/s");
   })();
   // Qwen3.6 journey — its own frontier (hybrid Gated-DeltaNet MoE, scored 128/512/4k).
   (function(){

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1445,8 +1445,11 @@ def sync_merged_dashboard(repo, limit=40):
     data = load_dash()
     if data is not None:
         before = json.dumps(data.get("landed_qwen35", []), sort_keys=True)
+        before_pp = json.dumps(data.get("landed_qwen35_pp", []), sort_keys=True)
         _rebuild_qwen35_journey(data)
-        if json.dumps(data.get("landed_qwen35", []), sort_keys=True) != before:
+        _rebuild_qwen35_pp_journey(data)
+        if (json.dumps(data.get("landed_qwen35", []), sort_keys=True) != before
+                or json.dumps(data.get("landed_qwen35_pp", []), sort_keys=True) != before_pp):
             data["updated"] = datetime.date.today().isoformat()
             write_dash(data)
             push_dash("dashboard: repair Qwen3.5 optimization journey")
@@ -1666,6 +1669,10 @@ def _qwen35_journey_tps(sub):
     """128-token decode headline for Qwen3.5 journey (not longctx best-context tps)."""
     return float(sub.get("ctx_128_tps") or sub.get("tps") or 0)
 
+def _qwen35_journey_pp(sub):
+    """Scored prefill headline for Qwen3.5 prefill optimization journey."""
+    return float(sub.get("prefill_tps") or 0)
+
 def _qwen35_baseline_from_prs(data):
     """Same-box origin/main 128-tok speed before the first landed Qwen3.5 optimization."""
     earliest_num, guard = None, None
@@ -1682,6 +1689,25 @@ def _qwen35_baseline_from_prs(data):
         if earliest_num is None or num < earliest_num:
             earliest_num, guard = num, float(g)
     return round(guard, 2) if guard is not None else None
+
+def _qwen35_pp_baseline_from_prs(data):
+    """Same-box origin/main prefill speed before the first landed Qwen3.5 prefill win."""
+    earliest_num, baseline = None, None
+    for e in data.get("prs", []):
+        if not (e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS):
+            continue
+        num = e.get("num")
+        if num is None:
+            continue
+        sub = e.get("score_qwen35") or e
+        if _qwen35_journey_pp(sub) <= 0:
+            continue
+        bl = sub.get("frontier_tps")
+        if bl is None or float(bl) <= 0:
+            continue
+        if earliest_num is None or num < earliest_num:
+            earliest_num, baseline = num, float(bl)
+    return round(baseline, 2) if baseline is not None else None
 
 def _rebuild_qwen35_journey(data):
     """Recompute landed_qwen35 + baseline/frontier from stored prs rows (merge-chronological).
@@ -1724,6 +1750,46 @@ def _rebuild_qwen35_journey(data):
     if landed:
         q35["frontier_tps"] = running
 
+def _rebuild_qwen35_pp_journey(data):
+    """Recompute landed_qwen35_pp + prefill baseline/frontier from stored prs rows."""
+    decode_dates = {m["pr"]: m.get("date") for m in data.get("landed_qwen35", []) if m.get("pr")}
+    existing_dates = {m["pr"]: m.get("date") for m in data.get("landed_qwen35_pp", []) if m.get("pr")}
+    existing_dates = {**decode_dates, **existing_dates}
+    pending = []
+    for e in data.get("prs", []):
+        if not (e.get("pass_qwen35") and e.get("label_qwen35") in SPEEDUP_LABELS):
+            continue
+        num = e["num"]
+        sub = e.get("score_qwen35") or e
+        raw = round(_qwen35_journey_pp(sub), 2)
+        if raw <= 0:
+            continue
+        short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
+        pending.append({
+            "name": short or f"PR #{num}",
+            "raw_tps": raw,
+            "pr": num,
+            "date": existing_dates.get(num) or datetime.date.today().isoformat(),
+            "label": e.get("label_qwen35") or sub.get("prefill_label"),
+        })
+    pending.sort(key=lambda m: (m.get("date", ""), m.get("pr", 0)))
+    q35 = data.setdefault("qwen35", {})
+    bl = _qwen35_pp_baseline_from_prs(data)
+    if bl is not None:
+        q35["baseline_pp"] = bl
+    running = round(float(bl or 0), 2)
+    landed = []
+    for ent in pending:
+        raw = ent.pop("raw_tps")
+        running = round(max(running, raw), 2)
+        ent["tps"] = running
+        if raw != running:
+            ent["raw_tps"] = raw
+        landed.append(ent)
+    data["landed_qwen35_pp"] = landed
+    if landed:
+        q35["prefill_frontier_pp"] = running
+
 def record_merge(repo, num):
     """A frontier-advancing PR was MERGED → advance the displayed frontier by its verified same-box
     relative gain and add it to the journey (`landed`). Hardware-independent and merged-only;
@@ -1764,6 +1830,7 @@ def record_merge(repo, num):
             _upsert_qwen35_ctx(data, sub)
             _upsert_qwen35_pp(data, sub)
             _rebuild_qwen35_journey(data)
+            _rebuild_qwen35_pp_journey(data)
             changed = True
         if changed:
             data["updated"] = datetime.date.today().isoformat()

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -497,6 +497,24 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertEqual([m["tps"] for m in data["landed_qwen35"]], [281.63, 281.63, 303.18])
         self.assertEqual(data["landed_qwen35"][1].get("raw_tps"), 272.63)
 
+    def test_rebuild_qwen35_pp_journey(self):
+        data = {
+            "prs": [
+                {"num": 387, "title": "perf(qwen35): prefill graph", "pass_qwen35": True, "label_qwen35": "L",
+                 "score_qwen35": {"prefill_tps": 320.33, "frontier_tps": 288.16, "eval_prefill": True}},
+                {"num": 398, "title": "perf(qwen35): batched prefill", "pass_qwen35": True, "label_qwen35": "XL",
+                 "score_qwen35": {"prefill_tps": 4150.42, "frontier_tps": 320.45, "eval_prefill": True}},
+                {"num": 422, "title": "perf(qwen35): int8 GEMM", "pass_qwen35": True, "label_qwen35": "XL",
+                 "score_qwen35": {"prefill_tps": 6096.4, "frontier_tps": 4179.68, "eval_prefill": True}},
+            ],
+            "landed_qwen35_pp": [],
+            "qwen35": {},
+        }
+        bot._rebuild_qwen35_pp_journey(data)
+        self.assertEqual(data["qwen35"]["baseline_pp"], 288.16)
+        self.assertEqual(data["qwen35"]["prefill_frontier_pp"], 6096.4)
+        self.assertEqual([m["tps"] for m in data["landed_qwen35_pp"]], [320.33, 4150.42, 6096.4])
+
     def test_qwen36_ctx_uses_measured_tps_without_scaling(self):
         data = {
             "qwen36": {


### PR DESCRIPTION
## Summary
- Replace Qwen3.5 optimization journey chart with **prefill** progression (pp tok/s ratchet)
- Add `landed_qwen35_pp` + `baseline_pp`; rebuild from eval `prefill_tps` on merge/sync
- Journey now shows 288 → **14058** pp tok/s across prefill PRs (#387–#464), not the decode plateau at 303 tok/s

## Test plan
- [x] `test_rebuild_qwen35_pp_journey` passes
- [ ] Chart shows prefill bars with meaningful growth after merge