### PR TITLE
fix(server): match ModelEngine to Qwen35Model::generate API

### DIFF
--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -164,8 +164,10 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
     // (interior tokens skip LM head), hybrid recurrent-state reset at position 0,
     // and kv->free() before the next request.
     impl_->model->clear_prefix_cache();
-    std::vector<int> out =
-        impl_->model->generate(prompt_ids, max_new_tokens, nullptr, on_token);
+    std::vector<int> out = impl_->model->generate(prompt_ids, max_new_tokens, nullptr);
+    if (on_token) {
+        for (int t : out) on_token(t);
+    }
 
     cudaError_t e = cudaGetLastError();
     if (e != cudaSuccess) {


### PR DESCRIPTION
## Summary
Follow-up to #475 — `sparkinfer_server` failed to compile on `main` because `ModelEngine::complete_streaming` called a non-existent 4-arg `Qwen35Model::generate(..., callback)`.

- Call the runtime's 3-arg `generate(prompt, max_new, governor)`
- Invoke the optional `on_token` callback over the returned token vector (SSE still works; tokens are emitted after decode completes)

## Verification
- [x] GPU-tested on RTX 5090 eval box (Qwythos-9B): build, `/health`, non-stream + stream `/v1/chat/completions`

## Test plan
- [ ] `cmake -DBUILD_SERVER=ON && cmake --build build --target sparkinfer_server` on CUDA box
- [ ] Smoke `GET /health` + `POST /v1/chat/completions`