### PR TITLE
fix(build): static-link runtime/moe on Windows for attested bench binary

### DIFF
--- a/.github/workflows/build-attested-binaries.yml
+++ b/.github/workflows/build-attested-binaries.yml
@@ -123,10 +123,11 @@ jobs:
           New-Item -ItemType Directory -Force -Path $env:OUT | Out-Null
           Copy-Item build/runtime/Release/qwen3_gguf_bench.exe $env:OUT/
           foreach ($pat in @(
-            "build/runtime/Release/sparkinfer_runtime.dll",
-            "build/moe/Release/sparkinfer_moe.dll"
+            "$env:CUDA_PATH/bin/cudart64_*.dll",
+            "$env:CUDA_PATH/bin/cublas64_*.dll",
+            "$env:CUDA_PATH/bin/cublasLt64_*.dll"
           )) {
-            if (Test-Path $pat) { Copy-Item $pat $env:OUT/ }
+            Get-ChildItem $pat -ErrorAction SilentlyContinue | Copy-Item -Destination $env:OUT/
           }
           Get-ChildItem $env:OUT
 

--- a/moe/CMakeLists.txt
+++ b/moe/CMakeLists.txt
@@ -18,7 +18,11 @@ endif()
 include_directories(include)
 
 file(GLOB_RECURSE MOE_SRC "src/*.cpp")
-add_library(sparkinfer_moe SHARED ${MOE_SRC})
+if(WIN32)
+  add_library(sparkinfer_moe STATIC ${MOE_SRC})
+else()
+  add_library(sparkinfer_moe SHARED ${MOE_SRC})
+endif()
 target_include_directories(sparkinfer_moe PUBLIC include)
 target_link_libraries(sparkinfer_moe PUBLIC sparkinfer_kernels CUDA::cudart)
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -24,7 +24,11 @@ endif()
 include_directories(include)
 
 file(GLOB_RECURSE RUNTIME_SRC "src/*.cpp" "csrc/cuda/*.cu")
-add_library(sparkinfer_runtime SHARED ${RUNTIME_SRC})
+if(WIN32)
+  add_library(sparkinfer_runtime STATIC ${RUNTIME_SRC})
+else()
+  add_library(sparkinfer_runtime SHARED ${RUNTIME_SRC})
+endif()
 target_include_directories(sparkinfer_runtime PUBLIC include)
 target_link_libraries(sparkinfer_runtime PUBLIC sparkinfer_moe sparkinfer_kernels CUDA::cudart Threads::Threads)
 


### PR DESCRIPTION
## Summary
- Build `sparkinfer_moe` and `sparkinfer_runtime` as **static** libs on Windows (MSVC was not generating import libs for the DLLs, breaking the runtime link step)
- Package Windows artifact with `qwen3_gguf_bench.exe` + CUDA runtime DLLs (`cudart`, `cublas`, `cublasLt`)

## Test plan
- [ ] Merge and re-run **build-attested-binaries** on `main`
- [ ] Download `sparkinfer-windows-amd64` artifact