### PR TITLE
fix(server): include OpenAI usage in chat completion responses

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -45,7 +45,7 @@ export SPARKINFER_ROOT="$(pwd)"
 | `GET /v1/models` | OpenAI model list |
 | `GET /v1/info` | Model limits (`max_context`, `max_output_tokens`) |
 | `POST /v1/tokenize` | Token count for a chat request body |
-| `POST /v1/chat/completions` | Chat (JSON `messages`, optional `stream`, `enable_thinking`) |
+| `POST /v1/chat/completions` | Chat (JSON `messages`, optional `stream`, `enable_thinking`). Responses include OpenAI `usage` (`prompt_tokens`, `completion_tokens`, `total_tokens`). Streaming sends a final chunk with `choices:[]` + `usage` before `[DONE]`. |
 
 ### RTX PRO 6000 deploy (32k / 4k)
 

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -89,6 +89,14 @@ std::string random_id() {
     return ss.str();
 }
 
+std::string usage_json(int prompt_tokens, int completion_tokens) {
+    std::ostringstream o;
+    const int total = prompt_tokens + completion_tokens;
+    o << "\"usage\":{\"prompt_tokens\":" << prompt_tokens << ",\"completion_tokens\":" << completion_tokens
+      << ",\"total_tokens\":" << total << "}";
+    return o.str();
+}
+
 bool auth_ok(const httplib::Request& req) {
     if (g_api_key.empty()) return true;
     auto it = req.headers.find("Authorization");
@@ -283,6 +291,14 @@ int main(int argc, char** argv) {
                                            << "\"}}\n\n";
                                  sink.write(err_chunk.str().c_str(), (size_t)err_chunk.str().size());
                              }
+                             const int prompt_tokens = (int)prompt_ids.size();
+                             const int completion_tokens = (int)stream_ids.size();
+                             std::ostringstream usage_chunk;
+                             usage_chunk << "data: {\"id\":\"" << cid << "\",\"object\":\"chat.completion.chunk\","
+                                         << "\"created\":" << created << ",\"model\":\"" << g_model_name << "\","
+                                         << "\"choices\":[],"
+                                         << usage_json(prompt_tokens, completion_tokens) << "}\n\n";
+                             sink.write(usage_chunk.str().c_str(), (size_t)usage_chunk.str().size());
                              std::string tail =
                                  "data: {\"id\":\"" + cid +
                                  "\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
@@ -319,7 +335,8 @@ int main(int argc, char** argv) {
                  if (!parsed.reasoning_content.empty())
                      body << ",\"reasoning_content\":\"" << json_escape(parsed.reasoning_content) << "\"";
                  body << ",\"content\":\"" << json_escape(parsed.content) << "\""
-                      << "},\"finish_reason\":\"stop\"}]}";
+                      << "},\"finish_reason\":\"stop\"}],"
+                      << usage_json((int)prompt_ids.size(), (int)gen.size()) << "}";
                  res.set_content(body.str(), "application/json");
              });
 


### PR DESCRIPTION
## Summary

- Add OpenAI-compatible `usage` to non-streaming `POST /v1/chat/completions` responses: `prompt_tokens`, `completion_tokens`, and `total_tokens` (sum of prompt + completion).
- For streaming (`stream: true`), emit a final SSE chunk with empty `choices` and the same `usage` object before the terminal `[DONE]` chunk, matching common OpenAI client expectations.

## Test plan

- [ ] Non-streaming chat completion: response JSON includes `usage` with correct token counts.
- [ ] Streaming chat completion: final data chunk before `[DONE]` has `choices: []` and `usage`.
- [ ] Jan / other OpenAI clients that read `usage` for billing or UI display work against `http://127.0.0.1:8080/v1`.