### PR TITLE
Fix #197: bounds-check layer index in MoEEngine::forward

### DIFF
--- a/moe/src/engine.cpp
+++ b/moe/src/engine.cpp
@@ -46,6 +46,11 @@ public:
     void forward(const void* input, void* output, int num_tokens, int layer,
                  cudaStream_t stream) override {
         if (num_tokens <= 0) return;
+        if (layer < 0 || layer >= (int)weights_.size()) {
+            fprintf(stderr, "[moe] forward: layer index %d out of range (num_layers=%zu) — skipping\n",
+                    layer, weights_.size());
+            return;
+        }
         if (num_tokens > max_tokens_) {
             // Router/top-k scratch is sized for max_tokens_; a larger batch would
             // overflow d_logits_/d_ids_/d_weights_ (OOB device writes). Refuse instead.


### PR DESCRIPTION
## Summary
- Validate `layer` against `weights_.size()` before indexing in `MoEEngine::forward`.

Host-side bounds check in `moe/` only — no `runtime/` changes. No RTX 5090 section (not a speedup PR).

Fixes #197
