### PR TITLE
feat(qwen35): batched prefill + full cache_prefix integration for generate/server

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -100,6 +100,9 @@ public:
     // Length of the currently cached prefix (0 if none).
     int prefix_cached_len() const;
 
+    // True when `prompt` begins with the installed prefix token sequence (requires active cache).
+    bool prompt_matches_prefix(const std::vector<int>& prompt) const;
+
     // Time-to-first-token: ingest `prompt` with prefill (no LM head on interior tokens when
     // not legacy), then one sampled forward. Reuses cache_prefix when the prompt starts with
     // the cached tokens (only the suffix is prefilled). Returns seconds.
@@ -133,7 +136,9 @@ public:
 
 private:
     void invalidate_decode_graph();
-    bool prompt_matches_prefix(const std::vector<int>& prompt) const;
+    // Prefill prompt tokens [start, end) with batched path when start==0, else token loop.
+    // Returns argmax seed at end-1 for decode, or -1 on failure.
+    int ingest_prompt_range(const int* ids, int start, int end);
 
     struct Impl;
     Impl* p_;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1086,7 +1086,7 @@ bool prefill_samples_lmhead() {
 }
 
 // Qwythos dense-hybrid batched prefill (prefill_batched_run). Default ON; SPARKINFER_PREFILL_BATCHED=0
-// disables. Prefix-reuse paths still use the token loop (batched kernel fills from pos 0 only).
+// disables. Batched fill runs from position 0 only; suffix-only reuse uses the token loop.
 bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
     static int want_batched = -1, batched_maxctx = -1;
     if (want_batched < 0) {
@@ -1225,6 +1225,27 @@ bool Qwen35Model::prompt_matches_prefix(const std::vector<int>& prompt) const {
     return true;
 }
 
+int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end) {
+    Impl& s = *p_;
+    if (!ids || end <= start) return -1;
+    const int n = end - start;
+    if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, n)) {
+        int seed = prefill_batched(ids, n);
+        if (seed >= 0 && seed < s.cfg.vocab) return seed;
+    }
+    int next = -1;
+    if (prefill_samples_lmhead()) {
+        for (int i = start; i < end; i++)
+            next = forward_token(ids[i], i, true);
+    } else {
+        for (int i = start; i + 1 < end; i++)
+            forward_token(ids[i], i, false);
+        if (end > start)
+            next = forward_token(ids[end - 1], end - 1, true);
+    }
+    return next;
+}
+
 bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
     Impl& s = *p_;
     clear_prefix_cache();
@@ -1232,23 +1253,11 @@ bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
     if (tokens.size() > (size_t)s.cfg.max_seq) return false;
     invalidate_decode_graph();
     if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) return false;
-    int next = -1;
     const int n = (int)tokens.size();
-    bool batched_done = false;
-    if (batched_prefill_enabled(s.gguf, s.cfg, n)) {
-        next = prefill_batched(tokens.data(), n);
-        batched_done = next >= 0 && next < s.cfg.vocab;
-    }
-    if (!batched_done) {
-        if (prefill_samples_lmhead()) {
-            for (size_t i = 0; i < tokens.size(); i++)
-                next = forward_token(tokens[i], (int)i, true);
-        } else {
-            for (size_t i = 0; i + 1 < tokens.size(); i++)
-                forward_token(tokens[i], (int)i, false);
-            if (!tokens.empty())
-                next = forward_token(tokens.back(), (int)tokens.size() - 1, true);
-        }
+    int next = ingest_prompt_range(tokens.data(), 0, n);
+    if (next < 0 || next >= s.cfg.vocab) {
+        s.kv->free(s.seq_id);
+        return false;
     }
     cudaDeviceSynchronize();
     s.prefix_tokens = tokens;
@@ -1290,30 +1299,8 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
     s.bench_feedback_graph = false;
     cudaDeviceSynchronize();
     auto t0 = std::chrono::high_resolution_clock::now();
-    bool batched_done = false;
-    if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, (int)prompt.size())) {
-        const int seed = prefill_batched(prompt.data(), (int)prompt.size());
-        cudaDeviceSynchronize();
-        batched_done = seed >= 0;
-        (void)seed;
-    }
-    if (!batched_done) {
-        if (prefill_samples_lmhead()) {
-            for (size_t i = (size_t)start; i < prompt.size(); i++) {
-                (void)forward_token(prompt[i], (int)i, true);
-                cudaDeviceSynchronize();
-            }
-        } else {
-            for (size_t i = (size_t)start; i + 1 < prompt.size(); i++) {
-                forward_token(prompt[i], (int)i, false);
-                cudaDeviceSynchronize();
-            }
-            if (prompt.size() > (size_t)start) {
-                (void)forward_token(prompt.back(), (int)prompt.size() - 1, true);
-                cudaDeviceSynchronize();
-            }
-        }
-    }
+    (void)ingest_prompt_range(prompt.data(), start, (int)prompt.size());
+    cudaDeviceSynchronize();
     auto t1 = std::chrono::high_resolution_clock::now();
     if (!reuse) {
         s.kv->free(s.seq_id);
@@ -1364,24 +1351,14 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
         return out;
     }
-    int next = reuse ? s.prefix_next : -1;
     const int start = reuse ? s.prefix_len : 0;
     const size_t n = prompt.size();
-    bool batched_done = false;
-    if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, (int)n)) {
-        next = prefill_batched(prompt.data(), (int)n);
-        batched_done = next >= 0 && next < s.cfg.vocab;
-    }
-    if (!batched_done) {
-        if (prefill_samples_lmhead()) {
-            for (size_t i = (size_t)start; i < n; i++)
-                next = forward_token(prompt[i], (int)i, true);
-        } else {
-            for (size_t i = (size_t)start; i + 1 < n; i++)
-                forward_token(prompt[i], (int)i, false);
-            if (n > (size_t)start)
-                next = forward_token(prompt.back(), (int)n - 1, true);
-        }
+    int next = (start >= (int)n && reuse) ? s.prefix_next
+                                            : ingest_prompt_range(prompt.data(), start, (int)n);
+    if (next < 0 || next >= s.cfg.vocab) {
+        s.kv->free(s.seq_id);
+        fprintf(stderr, "[qwen35] prompt prefill failed (start=%d n=%zu)\n", start, n);
+        return out;
     }
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
@@ -1392,8 +1369,8 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
 
     s.kv->free(s.seq_id);
     if (reuse) {
-        s.prefix_tokens.clear();
-        s.prefix_len = 0;
+        // KV is gone; keep prefix_tokens/len so the next cache_prefix()+generate() pair can
+        // re-warm the shared prefix and only prefill the suffix.
         s.prefix_next = -1;
         s.prefix_active = false;
         invalidate_decode_graph();

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1084,6 +1084,20 @@ bool prefill_samples_lmhead() {
     }
     return legacy != 0;
 }
+
+// Qwythos dense-hybrid batched prefill (prefill_batched_run). Default ON; SPARKINFER_PREFILL_BATCHED=0
+// disables. Prefix-reuse paths still use the token loop (batched kernel fills from pos 0 only).
+bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
+    static int want_batched = -1, batched_maxctx = -1;
+    if (want_batched < 0) {
+        const char* e = getenv("SPARKINFER_PREFILL_BATCHED");
+        want_batched = (e && e[0] == '0') ? 0 : 1;
+        const char* mc = getenv("SPARKINFER_PREFILL_BATCHED_MAXCTX");
+        batched_maxctx = mc ? atoi(mc) : 65536;
+    }
+    return want_batched && gguf && cfg.hybrid && cfg.dense_ffn && n_tokens > 0 &&
+           n_tokens <= batched_maxctx;
+}
 } // namespace
 
 Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int context_tokens) {
@@ -1123,14 +1137,7 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     // naive) falls back to the token loop below, which is left byte-identical to main on purpose.
     bool batched_done = false;
     if (start_pos > 0) {
-        static int want_batched = -1, batched_maxctx = -1;
-        if (want_batched < 0) {
-            const char* e = getenv("SPARKINFER_PREFILL_BATCHED");
-            want_batched = (e && e[0] == '0') ? 0 : 1;
-            const char* mc = getenv("SPARKINFER_PREFILL_BATCHED_MAXCTX");
-            batched_maxctx = mc ? atoi(mc) : 65536;
-        }
-        if (want_batched && s.gguf && s.cfg.hybrid && s.cfg.dense_ffn && start_pos <= batched_maxctx) {
+        if (batched_prefill_enabled(s.gguf, s.cfg, start_pos)) {
             std::vector<int> ids(start_pos);
             for (int i = 0; i < start_pos; i++) ids[i] = 100 + (i % 20000);   // deterministic pseudo-prompt
             auto pb0 = std::chrono::high_resolution_clock::now();
@@ -1226,14 +1233,22 @@ bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
     invalidate_decode_graph();
     if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) return false;
     int next = -1;
-    if (prefill_samples_lmhead()) {
-        for (size_t i = 0; i < tokens.size(); i++)
-            next = forward_token(tokens[i], (int)i, true);
-    } else {
-        for (size_t i = 0; i + 1 < tokens.size(); i++)
-            forward_token(tokens[i], (int)i, false);
-        if (!tokens.empty())
-            next = forward_token(tokens.back(), (int)tokens.size() - 1, true);
+    const int n = (int)tokens.size();
+    bool batched_done = false;
+    if (batched_prefill_enabled(s.gguf, s.cfg, n)) {
+        next = prefill_batched(tokens.data(), n);
+        batched_done = next >= 0 && next < s.cfg.vocab;
+    }
+    if (!batched_done) {
+        if (prefill_samples_lmhead()) {
+            for (size_t i = 0; i < tokens.size(); i++)
+                next = forward_token(tokens[i], (int)i, true);
+        } else {
+            for (size_t i = 0; i + 1 < tokens.size(); i++)
+                forward_token(tokens[i], (int)i, false);
+            if (!tokens.empty())
+                next = forward_token(tokens.back(), (int)tokens.size() - 1, true);
+        }
     }
     cudaDeviceSynchronize();
     s.prefix_tokens = tokens;
@@ -1275,19 +1290,28 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
     s.bench_feedback_graph = false;
     cudaDeviceSynchronize();
     auto t0 = std::chrono::high_resolution_clock::now();
-    if (prefill_samples_lmhead()) {
-        for (size_t i = (size_t)start; i < prompt.size(); i++) {
-            (void)forward_token(prompt[i], (int)i, true);
-            cudaDeviceSynchronize();
-        }
-    } else {
-        for (size_t i = (size_t)start; i + 1 < prompt.size(); i++) {
-            forward_token(prompt[i], (int)i, false);
-            cudaDeviceSynchronize();
-        }
-        if (prompt.size() > (size_t)start) {
-            (void)forward_token(prompt.back(), (int)prompt.size() - 1, true);
-            cudaDeviceSynchronize();
+    bool batched_done = false;
+    if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, (int)prompt.size())) {
+        const int seed = prefill_batched(prompt.data(), (int)prompt.size());
+        cudaDeviceSynchronize();
+        batched_done = seed >= 0;
+        (void)seed;
+    }
+    if (!batched_done) {
+        if (prefill_samples_lmhead()) {
+            for (size_t i = (size_t)start; i < prompt.size(); i++) {
+                (void)forward_token(prompt[i], (int)i, true);
+                cudaDeviceSynchronize();
+            }
+        } else {
+            for (size_t i = (size_t)start; i + 1 < prompt.size(); i++) {
+                forward_token(prompt[i], (int)i, false);
+                cudaDeviceSynchronize();
+            }
+            if (prompt.size() > (size_t)start) {
+                (void)forward_token(prompt.back(), (int)prompt.size() - 1, true);
+                cudaDeviceSynchronize();
+            }
         }
     }
     auto t1 = std::chrono::high_resolution_clock::now();
@@ -1343,14 +1367,21 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
     int next = reuse ? s.prefix_next : -1;
     const int start = reuse ? s.prefix_len : 0;
     const size_t n = prompt.size();
-    if (prefill_samples_lmhead()) {
-        for (size_t i = (size_t)start; i < n; i++)
-            next = forward_token(prompt[i], (int)i, true);
-    } else {
-        for (size_t i = (size_t)start; i + 1 < n; i++)
-            forward_token(prompt[i], (int)i, false);
-        if (n > (size_t)start)
-            next = forward_token(prompt.back(), (int)n - 1, true);
+    bool batched_done = false;
+    if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, (int)n)) {
+        next = prefill_batched(prompt.data(), (int)n);
+        batched_done = next >= 0 && next < s.cfg.vocab;
+    }
+    if (!batched_done) {
+        if (prefill_samples_lmhead()) {
+            for (size_t i = (size_t)start; i < n; i++)
+                next = forward_token(prompt[i], (int)i, true);
+        } else {
+            for (size_t i = (size_t)start; i + 1 < n; i++)
+                forward_token(prompt[i], (int)i, false);
+            if (n > (size_t)start)
+                next = forward_token(prompt.back(), (int)n - 1, true);
+        }
     }
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);

--- a/server/README.md
+++ b/server/README.md
@@ -83,26 +83,15 @@ curl ... -H 'Authorization: Bearer secret'
 
 Each `/v1/chat/completions` call runs through `Qwen35Model::generate()`:
 
-- Fresh KV cache allocation per request (`kv->allocate` / `kv->free`)
-- Hybrid Gated-DeltaNet recurrent state reset at position 0
+- Fresh KV allocation per request (`kv->allocate` / `kv->free` inside `generate()`)
+- Hybrid Gated-DeltaNet recurrent state reset at position 0 on cold prompts
 - Correct prefill path (interior prompt tokens skip LM head unless `SPARKINFER_PREFILL_LEGACY=1`)
+- Optional **shared prefix cache**: set `SPARKINFER_SERVER_PREFIX_TOKEN_FILE` (JSON array of token ids)
+  or `SPARKINFER_SERVER_PREFIX_TOKEN_IDS` (comma-separated). When the chat prompt starts with those
+  tokens, the server calls `cache_prefix()` (batched prefill) before `generate()`, which only
+  token-loops the suffix.
 
-Prior requests cannot leak context into later ones.
-
-## Jan integration (next)
-
-This server mirrors what Jan's `llamacpp-extension` expects from `llama-server`:
-
-- OpenAI `/v1/chat/completions` (+ SSE `stream: true`)
-- Local bind (`127.0.0.1`)
-- Optional Bearer auth
-
-Next steps on this branch or follow-up PRs:
-
-1. `POST /tokenize` for RAG
-2. Native tokenizer (drop Python helper)
-3. Multi-model load/unload router
-4. Jan `sparkinfer-extension` packaging
+Prior requests cannot leak decode context into later ones (KV is freed after each `generate()`).
 
 ## Env
 
@@ -112,3 +101,6 @@ Next steps on this branch or follow-up PRs:
 | `CTX` | `36864` (PRO 6000) / `0` (5090) | KV pool size passed as `--ctx` |
 | `SPARKINFER_KV_INT8` | model-dependent | Same as `qwen3_gguf_generate` |
 | `SPARKINFER_TOKENIZER_URL` | Qwen3-30B tokenizer | Override tokenizer download |
+| `SPARKINFER_SERVER_PREFIX_TOKEN_FILE` | — | JSON `[id,...]` warmed via `cache_prefix` each request |
+| `SPARKINFER_SERVER_PREFIX_TOKEN_IDS` | — | Comma-separated token ids (same as above) |
+| `SPARKINFER_PREFILL_BATCHED` | `1` | Batched prefill in `cache_prefix` / cold `generate` |

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -25,6 +25,11 @@ public:
     int vocab() const;
     int max_seq() const;
 
+    // Optional shared prompt prefix (e.g. system message tokens). When set, each request whose
+    // prompt starts with these ids calls cache_prefix() (batched prefill) before generate().
+    void set_prefix_tokens(const std::vector<int>& tokens);
+    int prefix_token_len() const;
+
     // Greedy decode. Returns generated token ids (not including prompt).
     // Sets last_error() on failure (empty prompt, context overflow, KV alloc).
     std::vector<int> complete(const std::vector<int>& prompt_ids, int max_new_tokens);

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -10,8 +10,18 @@
 
 #include <cstdio>
 #include <cuda_runtime.h>
+#include <algorithm>
 
 namespace sparkinfer_server {
+
+namespace {
+
+bool prompt_starts_with(const std::vector<int>& prompt, const std::vector<int>& prefix) {
+    if (prefix.empty() || prompt.size() < prefix.size()) return false;
+    return std::equal(prefix.begin(), prefix.end(), prompt.begin());
+}
+
+}  // namespace
 
 struct ModelEngine::Impl {
     std::string path;
@@ -20,6 +30,7 @@ struct ModelEngine::Impl {
     std::unique_ptr<sparkinfer::KVCacheManager> kv;
     std::unique_ptr<sparkinfer::moe::MoEEngine> engine;
     std::unique_ptr<sparkinfer::Qwen35Model> model;
+    std::vector<int> prefix_tokens;
     bool ready = false;
 };
 
@@ -126,6 +137,16 @@ int ModelEngine::max_seq() const {
     return impl_->ready ? impl_->cfg.max_seq : 0;
 }
 
+void ModelEngine::set_prefix_tokens(const std::vector<int>& tokens) {
+    std::lock_guard<std::mutex> lock(mu_);
+    impl_->prefix_tokens = tokens;
+}
+
+int ModelEngine::prefix_token_len() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return (int)impl_->prefix_tokens.size();
+}
+
 const std::string& ModelEngine::last_error() const {
     std::lock_guard<std::mutex> lock(mu_);
     return last_error_;
@@ -160,10 +181,21 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
         return {};
     }
 
-    // Use generate() so each request gets a fresh KV allocation, correct prefill
-    // (interior tokens skip LM head), hybrid recurrent-state reset at position 0,
-    // and kv->free() before the next request.
-    impl_->model->clear_prefix_cache();
+    // Warm a shared prefix with batched prefill when configured; generate() reuses it for the
+    // matching leading tokens and only token-loops the suffix.
+    if (!impl_->prefix_tokens.empty()) {
+        if (prompt_starts_with(prompt_ids, impl_->prefix_tokens)) {
+            if (!impl_->model->cache_prefix(impl_->prefix_tokens)) {
+                last_error_ = "cache_prefix failed (KV alloc or batched prefill)";
+                fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
+                return {};
+            }
+        } else {
+            impl_->model->clear_prefix_cache();
+        }
+    } else {
+        impl_->model->clear_prefix_cache();
+    }
     std::vector<int> out = impl_->model->generate(prompt_ids, max_new_tokens, nullptr);
     if (on_token) {
         for (int t : out) on_token(t);

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -7,6 +7,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <fstream>
 #include <iomanip>
 #include <random>
 #include <sstream>
@@ -131,6 +132,37 @@ bool decode_ids(const std::vector<int>& ids, std::string& text, std::string& err
     return true;
 }
 
+std::vector<int> load_prefix_token_ids() {
+    std::vector<int> out;
+    if (const char* csv = getenv("SPARKINFER_SERVER_PREFIX_TOKEN_IDS")) {
+        const char* p = csv;
+        while (*p) {
+            char* end = nullptr;
+            long v = strtol(p, &end, 10);
+            if (end == p) break;
+            out.push_back((int)v);
+            p = end;
+            while (*p == ',' || *p == ' ') p++;
+        }
+        return out;
+    }
+    const char* path = getenv("SPARKINFER_SERVER_PREFIX_TOKEN_FILE");
+    if (!path || !*path) return out;
+    std::ifstream f(path);
+    if (!f) {
+        fprintf(stderr, "[sparkinfer-server] WARN: cannot open prefix token file %s\n", path);
+        return out;
+    }
+    std::string s((std::istreambuf_iterator<char>(f)), std::istreambuf_iterator<char>());
+    for (size_t i = 0; i < s.size();) {
+        i = s.find_first_of("0123456789", i);
+        if (i == std::string::npos) break;
+        out.push_back(atoi(s.c_str() + i));
+        i = s.find_first_not_of("0123456789", i);
+    }
+    return out;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -174,6 +206,13 @@ int main(int argc, char** argv) {
 
     sparkinfer_server::ModelEngine engine;
     if (!engine.load(model_path, ctx > 0 ? ctx : 0)) return 1;
+
+    const std::vector<int> prefix_ids = load_prefix_token_ids();
+    if (!prefix_ids.empty()) {
+        engine.set_prefix_tokens(prefix_ids);
+        fprintf(stderr, "[sparkinfer-server] prefix cache: %zu tokens (batched prefill per request)\n",
+                prefix_ids.size());
+    }
 
     httplib::Server svr;
 


### PR DESCRIPTION
## Summary

- Routes Qwythos `generate()`, `bench_ttft()`, and `cache_prefix()` through batched prefill when `SPARKINFER_PREFILL_BATCHED=1` (default) and the ingest range starts at position 0.
- Adds `ingest_prompt_range()` so prefix warm (`cache_prefix`), cold prompts, and suffix-only reuse share one prefill path (batched from zero; token loop for suffix).
- Fixes `generate()` to preserve `prefix_tokens`/`prefix_len` after prefix reuse so the server can re-warm the shared prefix on the next request.
- Wires the HTTP server: optional `SPARKINFER_SERVER_PREFIX_TOKEN_FILE` or `SPARKINFER_SERVER_PREFIX_TOKEN_IDS` loads a shared system prefix; matching requests call `cache_prefix()` (batched) before `generate()` (suffix token loop only).

Supersedes #490 (includes its commit `060ad8a` plus server/prefix-cache wiring).

## Test plan

- [ ] `cmake --build build --target sparkinfer_server qwen3_gguf_generate`
- [ ] `qwen3_gguf_prefill_check` on Qwythos 9B (batched prefill parity)
- [ ] Server smoke: set `SPARKINFER_SERVER_PREFIX_TOKEN_IDS`, send chat prompts with/without matching prefix; verify TTFT improvement on suffix-only path
- [ ] `bench/quality/accuracy.sh` Qwythos greedy vs reference