### PR TITLE
perf(qwen35): chunk-parallel GDN scan + vector-store int8 dequant + single-pass row quantize + skinny GEMM (+23% prefill pp)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -21,6 +21,8 @@
 #include "sparkinfer/kernels/prefill.h"
 #include "sparkinfer/kernels/prefill_attn_mma.h"
 #include "sparkinfer/kernels/prefill_attn_window.h"
+#include "sparkinfer/kernels/prefill_gdn_chunk.h"
+#include "sparkinfer/kernels/prefill_gemm_skinny.h"
 
 namespace sparkinfer {
 namespace kernels {
@@ -571,6 +573,9 @@ __global__ void pf_attn_int8_paged_kernel(
 // ============================================================================
 void launch_prefill_gemm(const void* A, const void* W, void* C,
                          int M, int N, int K, cudaStream_t stream) {
+    // Narrow n_out (the GDN gate projections) wastes most of a 128-wide tile and grids to only
+    // 32 blocks; hand those to a tensor-core kernel with a full grid. =0 restores the tiled GEMM.
+    if (launch_prefill_gemm_skinny(A, W, C, M, N, K, stream)) return;
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
     pf_gemm_kernel<<<grid, 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(A), reinterpret_cast<const __nv_bfloat16*>(W),
@@ -632,6 +637,10 @@ void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
                              const void* alpha, const void* beta, const void* dt, const void* a,
                              float* state, void* out, int n_tokens, int q_heads, int v_heads,
                              int head_dim, cudaStream_t stream) {
+    // Chunk-parallel (WY/UT transform) scan: shortens the serial chain N -> N/C. Falls through to
+    // the sequential scan below when disabled (SPARKINFER_PREFILL_GDN_CHUNK=0) or shape-unsupported.
+    if (launch_prefill_gdn_chunk(q, k, v, alpha, beta, dt, a, state, out,
+                                 n_tokens, q_heads, v_heads, head_dim, stream)) return;
     constexpr int COLS = 4;
     dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
     auto qb = reinterpret_cast<const __nv_bfloat16*>(q);

--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -1,0 +1,519 @@
+// ============================================================================
+// Chunk-parallel (WY / UT transform) Gated-DeltaNet prefill scan for Qwythos (Qwen3.5).
+//
+// WHY THIS EXISTS
+// ---------------
+// The batched prompt prefill (#398) runs the gated delta rule as ONE sequential scan over all N
+// prompt tokens (pf_gdn_scan_kernel, batched_prefill.cu): one warp per state column, one rank-1
+// state update per token, two 5-shuffle warp reductions per token on the dependency chain. It is
+// the last sequential stage left in the batched prefill.
+//
+// Measured on an RTX 5090 (nsys --cuda-graph-trace=node, main @ cb34dc1, ctx=4096, and confirmed
+// per-prefill by a reps=1-vs-2 instance diff: 24 -> 48 instances, 59.31 -> 118.64 ms): 59.3 ms per
+// prefill = 20.7% of the 286.1 ms prefill, sustaining ~5.3 TFLOP/s — about 5% of the fp32 peak.
+// After #464 (fused Q4K->int8 dequant + token-parallel GDN conv) took the prefill from 8526 to
+// 14314 pp, this is the largest remaining slice that is not already at hardware peak: pf_gemm_i8 is
+// 52% of the wall but runs at 379 TOPS = 90% of the int8 tensor peak, so it has no headroom.
+//
+// The scan is NOT DRAM-bound: q/k/v/out for one layer need only ~10.5 ms at 1792 GB/s. The cost is
+// L1/L2 bandwidth and serial latency — the grid is (v_heads=32, head_dim/4=32) x 4 warps, so all
+// 128 column-warps of a v-head re-load the same k_t and q_t vector on every one of the N steps
+// (~200x read amplification, ~101 GB/layer of L2 traffic, which alone accounts for the time).
+//
+// THE RECURRENCE AND ITS CHUNK FORM
+// ---------------------------------
+// Per v-head, with S in [d_k=128, d_v=128] (the same S[row][col] the sequential kernel keeps):
+//     S_t = g_t (I - b_t k_t k_t^T) S_{t-1} + b_t k_t v_t^T,   y_t = S_t^T q_t * scale
+//     g_t = exp(softplus(alpha_t + dt) * a),  b_t = sigmoid(beta_t)
+//
+// Substituting S~_t = S_t / Gamma_t with Gamma_t = prod_{s<=t} g_s cancels the gate and leaves a
+// pure delta rule, whose rank-1 chain collapses into a triangular solve (the WY / UT transform):
+//     u~_t = b_t (v~_t - S~_{t-1}^T k_t)   =>   S~_t = S~_{t-1} + k_t u~_t^T
+// Writing u^_t = Gamma_t u~_t keeps every coefficient a RATIO exp(G_t - G_s) with s <= t (G =
+// log Gamma), which is bounded by 1 — the naive form would need v_t / Gamma_t, which overflows.
+// Per chunk of C tokens, with G_i the cumulative log-gate inside the chunk:
+//     (I + A) U^ = B (V - diag(exp G) K S_in),   A[i][j] = b_i (k_i.k_j) exp(G_i - G_j), j < i
+//     Y         = [ diag(exp G) (Q S_in) + M U^ ] * scale,  M[i][j] = (q_i.k_j) exp(G_i-G_j), j<=i
+//     S_out     = exp(G_last) S_in + K^T U~,     U~[j] = exp(G_last - G_j) U^[j]
+// (I + A) is unit lower triangular, so T = (I+A)^-1 is too and costs C^3/6 MACs by forward
+// substitution. The serial chain shortens from N to N/C and the inner work becomes dense matmuls
+// over shared-memory tiles that every state column reuses.
+//
+// NUMERICS. ssm_a is negative for all 24 linear layers x 32 v-heads of this checkpoint (read from
+// the GGUF: min -76.996, max -0.0089), so log g = softplus(alpha+dt)*a <= 0 and G decreases
+// monotonically => every exp(G_i - G_j) with j <= i is in (0, 1]. Per-token log-gates reach -8 and
+// below, so Gamma UNDERFLOWS to zero over a chunk; G is therefore kept in LOG space and only ever
+// exponentiated after a subtraction (never as a ratio exp(G_last)/exp(G_i), which would be 0/0).
+// A zero decay is the correct answer there — the state is simply fully forgotten.
+//
+// STRUCTURE. The state columns are independent: T, A and M depend only on k, q and the gates, and
+// U^[:,j], Y[:,j], S[:,j] each depend only on S_in[:,j]. So the work splits into
+//   1. pf_gdnc_prep_kernel  — grid (N/C, v_heads), FULLY parallel: builds T, then
+//      W^ = T B diag(exp G) K and U0 = T B V and M. No dependence on S_in.
+//   2. pf_gdnc_scan_kernel  — grid (v_heads, head_dim/JC), sequential over chunks only: applies
+//      U^ = U0 - W^ S_in, Y, and the state update. Two matmuls and a triangular apply per chunk.
+// The state stays fp32 and is written back in the SAME transposed [v_head][col][row] layout the
+// decode gdn_ar_fast kernel expects, so this is a drop-in replacement and decode is untouched.
+// ============================================================================
+#include "sparkinfer/kernels/prefill_gdn_chunk.h"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <mma.h>
+
+#include <cstdio>
+#include <cstdlib>
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+__device__ __forceinline__ float gc_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ float gc_sigmoid(float x) { return 1.f / (1.f + __expf(-x)); }
+__device__ __forceinline__ float gc_softplus(float x) { return x > 20.f ? x : __logf(1.f + __expf(x)); }
+
+// Shared-memory row padding (in elements) to break the power-of-two bank stride.
+constexpr int PAD = 8;
+
+// ---------------------------------------------------------------------------
+// Kernel 1: per-chunk prep. grid = (n_chunks, v_heads), fully parallel.
+//
+// Emits, for chunk c of v-head h:
+//   g_buf[t][h]        = G_i, the cumulative log-gate inside the chunk (log space)
+//   w_buf[t][h][:]     = W^ = T B diag(exp G) K      [C, HD]
+//   u_buf[t][h][:]     = U0 = T B V                  [C, HD]
+//   m_buf[c][h][i][j]  = M  = (q_i.k_j) exp(G_i-G_j) for j <= i, else 0   [C, C]
+// Rows past the end of a short final chunk get b = 0 and log-gate 0, which makes W^, U0 and M
+// vanish there, so the scan kernel needs no tail special-casing beyond bounds-checking its writes.
+// ---------------------------------------------------------------------------
+template <int C, int HD>
+__global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
+                                    const __nv_bfloat16* __restrict__ k,
+                                    const __nv_bfloat16* __restrict__ v,
+                                    const __nv_bfloat16* __restrict__ alpha,
+                                    const __nv_bfloat16* __restrict__ beta,
+                                    const __nv_bfloat16* __restrict__ dt,
+                                    const __nv_bfloat16* __restrict__ a,
+                                    float* __restrict__ g_buf,
+                                    __nv_bfloat16* __restrict__ w_buf,
+                                    __nv_bfloat16* __restrict__ u_buf,
+                                    float* __restrict__ m_buf,
+                                    int n_tokens, int q_heads, int v_heads) {
+    extern __shared__ char s_raw[];
+    __nv_bfloat16* s_k = reinterpret_cast<__nv_bfloat16*>(s_raw);              // [C][HD+PAD]
+    __nv_bfloat16* s_x = s_k + (size_t)C * (HD + PAD);                         // [C][HD+PAD] q then v
+    float* s_A = reinterpret_cast<float*>(s_x + (size_t)C * (HD + PAD));       // [C][C+PAD]
+    float* s_g = s_A + (size_t)C * (C + PAD);                                  // [C]
+    float* s_b = s_g + C;                                                      // [C]
+    float* s_t = s_b + C;                                                      // [C] scratch row
+
+    const int c    = blockIdx.x;
+    const int h    = blockIdx.y;
+    const int tid  = threadIdx.x;
+    const int nthr = blockDim.x;
+    const int t0   = c * C;
+    const int len  = min(C, n_tokens - t0);
+    if (len <= 0) return;
+
+    const int qh    = h % q_heads;
+    const int q_dim = q_heads * HD;
+    const int v_dim = v_heads * HD;
+    const float a_h  = gc_to_f(a[h]);
+    const float dt_h = gc_to_f(dt[h]);
+
+    // ---- gates: per-token log-gate and b, then an inclusive prefix sum over the chunk ----
+    for (int i = tid; i < C; i += nthr) {
+        if (i < len) {
+            const float al = gc_to_f(alpha[(size_t)(t0 + i) * v_heads + h]);
+            s_t[i] = gc_softplus(al + dt_h) * a_h;                       // log g_i  (<= 0)
+            s_b[i] = gc_sigmoid(gc_to_f(beta[(size_t)(t0 + i) * v_heads + h]));
+        } else {
+            s_t[i] = 0.f;                                                // tail: no decay, no update
+            s_b[i] = 0.f;
+        }
+    }
+    __syncthreads();
+    if (tid == 0) {                                  // C=64 serial adds, once per block
+        float acc = 0.f;
+        for (int i = 0; i < C; i++) { acc += s_t[i]; s_g[i] = acc; }
+    }
+    __syncthreads();
+    for (int i = tid; i < len; i += nthr) g_buf[(size_t)(t0 + i) * v_heads + h] = s_g[i];
+
+    // ---- stage K and Q ----
+    for (int e = tid; e < C * HD; e += nthr) {
+        const int i = e / HD, d = e - i * HD;
+        const bool live = i < len;
+        s_k[i * (HD + PAD) + d] = live ? k[(size_t)(t0 + i) * q_dim + qh * HD + d] : __float2bfloat16(0.f);
+        s_x[i * (HD + PAD) + d] = live ? q[(size_t)(t0 + i) * q_dim + qh * HD + d] : __float2bfloat16(0.f);
+    }
+    __syncthreads();
+
+    // ---- A[i][j] = b_i (k_i.k_j) exp(G_i-G_j) for j<i (unit diagonal), and M = tril(Q K^T . decay) ----
+    // K K^T and Q K^T are 80% of this kernel's MACs and both contract over HD against the same
+    // K tile, so they run on tensor cores: 8 warps, 8 output tiles of 16x16 (4 for K K^T, 4 for
+    // Q K^T). K and Q are already bf16 (they are the raw conv outputs), so nothing is narrowed here
+    // — only the decay/b scaling and the triangular mask stay scalar, applied to the fp32 results.
+    {
+        using namespace nvcuda;
+        const int warp = tid >> 5;
+        const bool isKK = warp < 4;
+        const int t = warp & 3;
+        const int ti = (t >> 1) * 16, tj = (t & 1) * 16;
+        const __nv_bfloat16* Aop = isKK ? s_k : s_x;      // s_x holds Q at this point
+        wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
+        wmma::fill_fragment(cf, 0.f);
+        #pragma unroll
+        for (int d = 0; d < HD; d += 16) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, __nv_bfloat16, wmma::row_major> af;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, __nv_bfloat16, wmma::col_major> bf;
+            wmma::load_matrix_sync(af, Aop + (size_t)ti * (HD + PAD) + d, HD + PAD);
+            wmma::load_matrix_sync(bf, s_k + (size_t)tj * (HD + PAD) + d, HD + PAD);  // col_major => K^T
+            wmma::mma_sync(cf, af, bf, cf);
+        }
+        __shared__ float sD[8][16][16];
+        wmma::store_matrix_sync(&sD[warp][0][0], cf, 16, wmma::mem_row_major);
+        __syncthreads();
+
+        const size_t mbase = ((size_t)c * v_heads + h) * C * C;
+        for (int e = tid; e < C * C; e += nthr) {
+            const int i = e / C, j = e - i * C;
+            const int w = ((i >> 4) << 1) | (j >> 4);
+            if (j > i) { s_A[i * (C + PAD) + j] = 0.f; m_buf[mbase + e] = 0.f; continue; }
+            const float decay = __expf(s_g[i] - s_g[j]);                 // <= 1 (G is decreasing)
+            const float kk = sD[w][i & 15][j & 15];
+            const float qk = sD[4 + w][i & 15][j & 15];
+            s_A[i * (C + PAD) + j] = (j < i) ? s_b[i] * kk * decay : 1.f;
+            m_buf[mbase + e] = qk * decay;
+        }
+    }
+    __syncthreads();
+
+    // ---- T = (I + A)^-1 in place, by forward substitution over rows ----
+    //   T[i][j] = -A[i][j] - sum_{m=j+1}^{i-1} A[i][m] T[m][j]      (T[j][j] = 1)
+    // Row i still holds A while it is being read; rows m < i already hold T.
+    for (int i = 1; i < C; i++) {
+        for (int j = tid; j < i; j += nthr) {
+            float acc = s_A[i * (C + PAD) + j];
+            for (int m = j + 1; m < i; m++) acc += s_A[i * (C + PAD) + m] * s_A[m * (C + PAD) + j];
+            s_t[j] = -acc;
+        }
+        __syncthreads();
+        for (int j = tid; j < i; j += nthr) s_A[i * (C + PAD) + j] = s_t[j];
+        __syncthreads();
+    }
+
+    // ---- W^ = T . (b_m exp(G_m) k_m) ----
+    for (int e = tid; e < C * HD; e += nthr) {
+        const int i = e / HD, d = e - i * HD;
+        float acc = 0.f;
+        for (int m = 0; m <= i; m++)
+            acc += s_A[i * (C + PAD) + m] * (s_b[m] * __expf(s_g[m]) * gc_to_f(s_k[m * (HD + PAD) + d]));
+        w_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] = __float2bfloat16(acc);
+    }
+    __syncthreads();
+
+    // ---- reuse the Q tile for V, then U0 = T . (b_m v_m) ----
+    for (int e = tid; e < C * HD; e += nthr) {
+        const int i = e / HD, d = e - i * HD;
+        s_x[i * (HD + PAD) + d] = (i < len) ? v[(size_t)(t0 + i) * v_dim + h * HD + d] : __float2bfloat16(0.f);
+    }
+    __syncthreads();
+    for (int e = tid; e < C * HD; e += nthr) {
+        const int i = e / HD, d = e - i * HD;
+        float acc = 0.f;
+        for (int m = 0; m <= i; m++)
+            acc += s_A[i * (C + PAD) + m] * (s_b[m] * gc_to_f(s_x[m * (HD + PAD) + d]));
+        u_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] = __float2bfloat16(acc);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Kernel 2: the (now C-times shorter) sequential scan over chunks.
+// grid = (v_heads, HD/JC); each block owns JC state columns of one v-head and walks the chunks.
+// Per chunk: U^ = U0 - W^ S ; Y = [diag(exp G)(Q S) + M U^] * scale ; S = exp(G_last) S + K^T U~.
+// ---------------------------------------------------------------------------
+template <int C, int HD, int JC>
+__global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
+                                    const __nv_bfloat16* __restrict__ k,
+                                    const float* __restrict__ g_buf,
+                                    const __nv_bfloat16* __restrict__ w_buf,
+                                    const __nv_bfloat16* __restrict__ u_buf,
+                                    const float* __restrict__ m_buf,
+                                    float* __restrict__ state,
+                                    __nv_bfloat16* __restrict__ out,
+                                    int n_tokens, int q_heads, int v_heads, int n_chunks) {
+    extern __shared__ char s_raw[];
+    float* s_S = reinterpret_cast<float*>(s_raw);                              // [HD][JC]  fp32 carrier
+    float* s_U = s_S + (size_t)HD * JC;                                        // [C][JC]
+    float* s_M = s_U + (size_t)C * JC;                                         // [C][C+PAD]
+    float* s_g = s_M + (size_t)C * (C + PAD);                                  // [C]
+    float* s_Y = s_g + C;                                                      // [C][JC]  Q S staging
+    __nv_bfloat16* s_W =
+        reinterpret_cast<__nv_bfloat16*>(s_Y + (size_t)C * JC);                // [C][HD+PAD]
+    __nv_bfloat16* s_K = s_W + (size_t)C * (HD + PAD);                         // [C][HD+PAD]
+    __nv_bfloat16* s_Q = s_K + (size_t)C * (HD + PAD);                         // [C][HD+PAD]
+    // bf16 operand mirrors. S stays fp32 across chunks (it is the recurrent carrier); it is
+    // narrowed to bf16 ONCE per chunk to feed the tensor cores, which is the only precision the
+    // wmma path costs over the fp32 register-tiled one — W^, K and Q are already bf16.
+    __nv_bfloat16* s_Sb = s_Q + (size_t)C * (HD + PAD);                        // [HD][JC+PAD]
+    __nv_bfloat16* s_Ub = s_Sb + (size_t)HD * (JC + PAD);                      // [C][JC+PAD]
+
+    const int h    = blockIdx.x;
+    const int j0   = blockIdx.y * JC;
+    const int tid  = threadIdx.x;
+    const int nthr = blockDim.x;
+
+    const int qh    = h % q_heads;
+    const int q_dim = q_heads * HD;
+    const int v_dim = v_heads * HD;
+    const float scale = rsqrtf((float)HD);
+
+    for (int e = tid; e < HD * JC; e += nthr) s_S[e] = 0.f;    // fresh prefill: state starts at zero
+    __syncthreads();
+
+    for (int c = 0; c < n_chunks; c++) {
+        const int t0  = c * C;
+        const int len = min(C, n_tokens - t0);
+
+        // ---- stage this chunk ----
+        for (int i = tid; i < C; i += nthr)
+            s_g[i] = (i < len) ? g_buf[(size_t)(t0 + i) * v_heads + h] : 0.f;
+        for (int e = tid; e < C * JC; e += nthr) {
+            const int i = e / JC, jj = e - i * JC;
+            s_U[e] = (i < len) ? gc_to_f(u_buf[((size_t)(t0 + i) * v_heads + h) * HD + j0 + jj]) : 0.f;
+        }
+        for (int e = tid; e < C * C; e += nthr) {
+            const int i = e / C, j = e - i * C;
+            s_M[i * (C + PAD) + j] = m_buf[(size_t)e + ((size_t)c * v_heads + h) * C * C];
+        }
+        for (int e = tid; e < C * HD; e += nthr) {
+            const int i = e / HD, d = e - i * HD;
+            const bool live = i < len;
+            s_W[i * (HD + PAD) + d] = live ? w_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] : __float2bfloat16(0.f);
+            s_K[i * (HD + PAD) + d] = live ? k[(size_t)(t0 + i) * q_dim + qh * HD + d] : __float2bfloat16(0.f);
+            s_Q[i * (HD + PAD) + d] = live ? q[(size_t)(t0 + i) * q_dim + qh * HD + d] : __float2bfloat16(0.f);
+        }
+        __syncthreads();
+
+        // ---- U^ = U0 - W^ S   [C,HD] x [HD,JC] ----
+        // REGISTER-TILED 2x2. A scalar `acc += A[m]*B[m]` matmul reads TWO shared-memory operands per
+        // FMA, which caps it at ~16 FMA/cycle/SM against a 128 FMA/cycle peak — that (not the serial
+        // chain) is why the naive chunk kernel only matched the sequential scan. A 2x2 tile reuses
+        // each loaded value twice: 4 loads per 4 FMAs, and 4 independent accumulators to hide latency.
+        // [C=32,JC=32] outputs / 256 threads = exactly 4 each, so the tiling divides evenly.
+        // ---- narrow S to bf16 once, then run U^ = U0 - W^ S and Y0 = Q S on tensor cores ----
+        for (int e = tid; e < HD * JC; e += nthr) {
+            const int m = e / JC, jj = e - m * JC;
+            s_Sb[m * (JC + PAD) + jj] = __float2bfloat16(s_S[e]);
+        }
+        __syncthreads();
+        {
+            using namespace nvcuda;
+            // 8 warps, 8 output tiles of 16x16: warps 0-3 own U^ = W^ S, warps 4-7 own Y0 = Q S.
+            // Both contract over HD against the same s_Sb, so the two matmuls share its fragments.
+            const int warp = tid >> 5;
+            const bool isU = warp < 4;
+            const int t    = warp & 3;                       // 2x2 tile grid over [C=32, JC=32]
+            const int ti = (t >> 1) * 16, tj = (t & 1) * 16;
+            const __nv_bfloat16* Aop = isU ? s_W : s_Q;
+            wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
+            wmma::fill_fragment(cf, 0.f);
+            #pragma unroll
+            for (int kk = 0; kk < HD; kk += 16) {
+                wmma::fragment<wmma::matrix_a, 16, 16, 16, __nv_bfloat16, wmma::row_major> af;
+                wmma::fragment<wmma::matrix_b, 16, 16, 16, __nv_bfloat16, wmma::row_major> bf;
+                wmma::load_matrix_sync(af, Aop + (size_t)ti * (HD + PAD) + kk, HD + PAD);
+                wmma::load_matrix_sync(bf, s_Sb + (size_t)kk * (JC + PAD) + tj, JC + PAD);
+                wmma::mma_sync(cf, af, bf, cf);
+            }
+            __shared__ float sC[8][16][16];
+            wmma::store_matrix_sync(&sC[warp][0][0], cf, 16, wmma::mem_row_major);
+            __syncthreads();
+            for (int e = tid; e < C * JC; e += nthr) {
+                const int i = e / JC, jj = e - i * JC;
+                const int w = ((i >> 4) << 1) | (jj >> 4);
+                s_U[e] -= sC[w][i & 15][jj & 15];             // U^ = U0 - W^ S
+                s_Y[e]  = sC[4 + w][i & 15][jj & 15];         // Y0 = Q S
+            }
+        }
+        __syncthreads();
+
+        // ---- Y = [diag(exp G) Y0 + M U^] * scale ----
+        for (int e = tid; e < C * JC; e += nthr) {
+            const int i = e / JC, jj = e - i * JC;
+            if (t0 + i >= n_tokens) continue;
+            float mu = 0.f;
+            for (int p = 0; p <= i; p++) mu += s_M[i * (C + PAD) + p] * s_U[p * JC + jj];
+            const float y = (__expf(s_g[i]) * s_Y[e] + mu) * scale;
+            out[(size_t)(t0 + i) * v_dim + h * HD + j0 + jj] = __float2bfloat16(y);
+        }
+        __syncthreads();
+
+        // ---- U~[p] = exp(G_last - G_p) U^[p]  (tail rows already carry U^ = 0) ----
+        const float g_last = s_g[C - 1];               // == s_g[len-1]: tail log-gates are 0
+        for (int e = tid; e < C * JC; e += nthr) {
+            const int i = e / JC;
+            s_U[e] *= __expf(g_last - s_g[i]);
+        }
+        __syncthreads();
+
+        // ---- S = exp(G_last) S + K^T U~   [HD,C] x [C,JC], on tensor cores ----
+        for (int e = tid; e < C * JC; e += nthr) {
+            const int i = e / JC, jj = e - i * JC;
+            s_Ub[i * (JC + PAD) + jj] = __float2bfloat16(s_U[e]);
+        }
+        __syncthreads();
+        {
+            using namespace nvcuda;
+            const float gl = __expf(g_last);
+            const int warp = tid >> 5;                       // 8 warps x 2 tiles = 16 tiles [128,32]
+            __shared__ float sC2[8][16][16];
+            #pragma unroll
+            for (int rep = 0; rep < 2; rep++) {
+                const int tile = warp * 2 + rep;             // 0..15
+                const int ti = (tile >> 1) * 16, tj = (tile & 1) * 16;
+                wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
+                wmma::fill_fragment(cf, 0.f);
+                #pragma unroll
+                for (int kk = 0; kk < C; kk += 16) {
+                    // K^T: A[m][p] = s_K[p][m] -> col_major over s_K gives the transpose for free
+                    wmma::fragment<wmma::matrix_a, 16, 16, 16, __nv_bfloat16, wmma::col_major> af;
+                    wmma::fragment<wmma::matrix_b, 16, 16, 16, __nv_bfloat16, wmma::row_major> bf;
+                    wmma::load_matrix_sync(af, s_K + (size_t)kk * (HD + PAD) + ti, HD + PAD);
+                    wmma::load_matrix_sync(bf, s_Ub + (size_t)kk * (JC + PAD) + tj, JC + PAD);
+                    wmma::mma_sync(cf, af, bf, cf);
+                }
+                wmma::store_matrix_sync(&sC2[warp][0][0], cf, 16, wmma::mem_row_major);
+                __syncwarp();
+                for (int e = (tid & 31); e < 256; e += 32) {
+                    const int r = e >> 4, cc = e & 15;
+                    const int m = ti + r, jj = tj + cc;
+                    s_S[m * JC + jj] = gl * s_S[m * JC + jj] + sC2[warp][r][cc];
+                }
+                __syncwarp();
+            }
+        }
+        __syncthreads();
+    }
+
+    // ---- final state, in the transposed [v_head][col][row] layout decode expects ----
+    for (int e = tid; e < HD * JC; e += nthr) {
+        const int m = e / JC, jj = e - m * JC;
+        state[((size_t)h * HD + (j0 + jj)) * HD + m] = s_S[e];
+    }
+}
+
+// Workspace cache. The scan is called once per linear layer with the same N, so one allocation is
+// reused across all 24 layers and every subsequent prefill; it only ever grows.
+void* g_ws = nullptr;
+size_t g_ws_bytes = 0;
+
+bool ws_reserve(size_t bytes) {
+    if (bytes <= g_ws_bytes) return true;
+    if (g_ws) cudaFree(g_ws);
+    g_ws = nullptr;
+    g_ws_bytes = 0;
+    if (cudaMalloc(&g_ws, bytes) != cudaSuccess) { g_ws = nullptr; return false; }
+    g_ws_bytes = bytes;
+    return true;
+}
+
+}  // namespace
+
+bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
+                              const void* alpha, const void* beta,
+                              const void* dt, const void* a,
+                              float* state, void* out,
+                              int n_tokens, int q_heads, int v_heads, int head_dim,
+                              cudaStream_t stream) {
+    constexpr int C = 32, HD = 128, JC = 32, SCAN_THREADS = 256, PREP_THREADS = 256;
+
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_CHUNK");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    static const int minctx = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_CHUNK_MINCTX");
+        return e ? atoi(e) : 256;
+    }();
+
+    if (!enabled || head_dim != HD || n_tokens < minctx) return false;
+    if (q_heads <= 0 || v_heads <= 0 || (HD % JC) != 0) return false;
+
+    const int n_chunks = (n_tokens + C - 1) / C;
+
+    // Workspace: G and M in fp32, W^ and U0 in bf16. W^ is the scan's largest read — every one of
+    // the HD/JC column groups re-reads all of it each chunk — so bf16 there is worth ~1 pp of
+    // end-to-end prefill. It does cost a little accuracy, because the scan forms U^ = U0 - W^ S and
+    // that subtraction cancels: measured at ctx=4096 over 512 positions, top-1 0.9336 (fp32) ->
+    // 0.9277 (bf16), KL 0.01069 -> 0.01096. Both stay well clear of the 0.90 / 0.20 gates and the
+    // KL is still below the sequential scan's own 0.01136, so the trade is taken. M stays fp32: it
+    // is only C*C per chunk, so shrinking it buys little.
+    const size_t n_g = (size_t)n_tokens * v_heads;
+    const size_t n_w = (size_t)n_tokens * v_heads * HD;
+    const size_t n_m = (size_t)n_chunks * v_heads * C * C;
+    const size_t off_g = 0;
+    const size_t off_m = off_g + n_g * sizeof(float);
+    const size_t off_w = off_m + n_m * sizeof(float);
+    const size_t off_u = off_w + n_w * sizeof(__nv_bfloat16);
+    const size_t total = off_u + n_w * sizeof(__nv_bfloat16);
+    if (!ws_reserve(total)) return false;
+
+    char* base  = reinterpret_cast<char*>(g_ws);
+    float* g_buf = reinterpret_cast<float*>(base + off_g);
+    float* m_buf = reinterpret_cast<float*>(base + off_m);
+    __nv_bfloat16* w_buf = reinterpret_cast<__nv_bfloat16*>(base + off_w);
+    __nv_bfloat16* u_buf = reinterpret_cast<__nv_bfloat16*>(base + off_u);
+
+    const size_t sm_prep = (size_t)2 * C * (HD + PAD) * sizeof(__nv_bfloat16)
+                         + (size_t)C * (C + PAD) * sizeof(float)
+                         + (size_t)3 * C * sizeof(float);
+    const size_t sm_scan = (size_t)HD * JC * sizeof(float)          // s_S (fp32 carrier)
+                         + (size_t)C * JC * sizeof(float)            // s_U
+                         + (size_t)C * (C + PAD) * sizeof(float)     // s_M
+                         + (size_t)C * sizeof(float)                 // s_g
+                         + (size_t)C * JC * sizeof(float)            // s_Y
+                         + (size_t)3 * C * (HD + PAD) * sizeof(__nv_bfloat16)   // s_W, s_K, s_Q
+                         + (size_t)HD * (JC + PAD) * sizeof(__nv_bfloat16)      // s_Sb
+                         + (size_t)C * (JC + PAD) * sizeof(__nv_bfloat16);      // s_Ub
+
+    static int cfg = 0;
+    if (!cfg) {
+        if (cudaFuncSetAttribute(pf_gdnc_prep_kernel<C, HD>,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_prep) != cudaSuccess)
+            return false;
+        if (cudaFuncSetAttribute(pf_gdnc_scan_kernel<C, HD, JC>,
+                                 cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_scan) != cudaSuccess)
+            return false;
+        cfg = 1;
+    }
+
+    auto qb = reinterpret_cast<const __nv_bfloat16*>(q);
+    auto kb = reinterpret_cast<const __nv_bfloat16*>(k);
+    auto vb = reinterpret_cast<const __nv_bfloat16*>(v);
+    auto ab = reinterpret_cast<const __nv_bfloat16*>(alpha);
+    auto bb = reinterpret_cast<const __nv_bfloat16*>(beta);
+    auto db = reinterpret_cast<const __nv_bfloat16*>(dt);
+    auto aa = reinterpret_cast<const __nv_bfloat16*>(a);
+    auto ob = reinterpret_cast<__nv_bfloat16*>(out);
+
+    // PREP_THREADS is fixed by the 2x2 (i,j) tiling in the A/M pass: C*C == 4*PREP_THREADS.
+    static_assert(C * C == PREP_THREADS * 4, "2x2 A/M tiling requires C*C == 4*PREP_THREADS");
+    dim3 gprep(n_chunks, v_heads);
+    pf_gdnc_prep_kernel<C, HD><<<gprep, PREP_THREADS, sm_prep, stream>>>(
+        qb, kb, vb, ab, bb, db, aa, g_buf, w_buf, u_buf, m_buf, n_tokens, q_heads, v_heads);
+
+    // SCAN_THREADS is not free tuning: the register tiling below partitions the [C,JC] and [HD,JC]
+    // outputs across exactly this many threads (2x2 and 4x4 tiles respectively).
+    static_assert(C * JC == SCAN_THREADS * 4, "2x2 tiling requires C*JC == 4*SCAN_THREADS");
+    static_assert(HD * JC == SCAN_THREADS * 16, "4x4 tiling requires HD*JC == 16*SCAN_THREADS");
+    dim3 gscan(v_heads, HD / JC);
+    pf_gdnc_scan_kernel<C, HD, JC><<<gscan, SCAN_THREADS, sm_scan, stream>>>(
+        qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob, n_tokens, q_heads, v_heads, n_chunks);
+    return true;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
@@ -13,6 +13,8 @@
 #include <cuda_pipeline.h>
 #include "sparkinfer/kernels/prefill_i8.h"
 
+#include "sparkinfer/kernels/prefill_quant_rows.h"
+
 namespace sparkinfer { namespace kernels {
 
 namespace {
@@ -166,6 +168,9 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
 
 void launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
                                      int rows, int cols, cudaStream_t stream) {
+    // Block-parallel single-pass path (one block per row, row held in registers; bit-identical).
+    // SPARKINFER_PREFILL_QUANT_ROWS=0 restores the warp-per-row kernel below.
+    if (launch_prefill_quant_rows_fast(x_bf16, q, scale, rows, cols, stream)) return;
     pf_quantize_rows_i8<<<rows, 32, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x_bf16), q, scale, rows, cols);
 }

--- a/kernels/csrc/cuda/fused/prefill_gemm_skinny.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_skinny.cu
@@ -1,0 +1,135 @@
+// ============================================================================
+// Skinny bf16 prefill GEMM: C[M,n_out] = A[M,K] @ W^T for narrow n_out.
+//
+// WHY THIS EXISTS
+// ---------------
+// pf_gemm_kernel (batched_prefill.cu, #398) tiles the output 128x128 with cp.async double buffering
+// — the right shape for the big projections, which are where prefill's arithmetic lives. The Gated-
+// DeltaNet gate projections are the opposite shape: ssm_alpha and ssm_beta are [n_out=32, K=4096],
+// deliberately left in bf16 (per-row int8 quant of a 32-wide weight costs more accuracy than the
+// time it saves), so they fall through to pf_gemm and get:
+//
+//     grid = ((32 + 127)/128, (4096 + 127)/128) = 1 x 32 = 32 blocks   on a 170-SM part
+//
+// 32 blocks use 19% of the GPU, and 96 of every 128 output columns are padding — so ~75% of the
+// tensor-core work is multiplying zeros. Measured on an RTX 5090 (nsys, main @ cb34dc1, ctx=4096):
+// 7.5 ms per prefill across 48 calls (24 linear layers x {alpha, beta}).
+//
+// It is COMPUTE-bound, not bandwidth-bound — worth stating because the shape invites the opposite
+// guess. A is [4096,4096] bf16 = 33.5 MB per call, but it is the same `xn` for alpha and beta (and
+// for the qkv/gate projections beside them), so it is L2-resident and real DRAM traffic is ~0.45 ms
+// across all 48 calls. The work is 4096*32*4096 = 537 MMAC per call (51.5 GFLOP over 48), and the
+// existing path sustains ~6.9 TFLOP/s against a ~255 TFLOP/s bf16 tensor peak. An fp32 register-
+// tiled rewrite was tried first and changed nothing (7.49 vs 7.50 ms): staging was never the issue.
+//
+// THE SHAPE THIS WANTS. One block per BT-row strip of A, all n_out columns held at once, K streamed
+// in KT-wide tiles through shared memory, and the math on tensor cores:
+//   * grid = M/BT = 128 blocks (vs 32) — 4x the SMs, and every block does useful work.
+//   * one warp per 16x16 wmma output tile; no padding — n_out is masked, never rounded to a tile.
+//   * 16-byte vector staging, so a warp moves 512 contiguous bytes per slot.
+// Accumulation is fp32 and the store is bf16, matching pf_gemm_kernel; only the blocking and the
+// mma shape differ. Measured: 7.5 -> 3.54 ms.
+// ============================================================================
+#include "sparkinfer/kernels/prefill_gemm_skinny.h"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <mma.h>
+
+#include <cstdlib>
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+constexpr int SK_PAD = 8;    // break the power-of-two smem row stride
+
+// One block per BT-row strip; NMAX output columns held at once; K streamed KT at a time.
+// WARPS warps, each owning one 16x16 wmma accumulator tile of the [BT, NMAX] output.
+template <int BT, int NMAX, int KT, int WARPS>
+__global__ __launch_bounds__(WARPS * 32) void pf_gemm_skinny_kernel(
+        const __nv_bfloat16* __restrict__ A, const __nv_bfloat16* __restrict__ W,
+        __nv_bfloat16* __restrict__ C, int M, int n_out, int K) {
+    using namespace nvcuda;
+    __shared__ __nv_bfloat16 sA[BT][KT + SK_PAD];
+    __shared__ __nv_bfloat16 sW[NMAX][KT + SK_PAD];
+    __shared__ float sC[16][16];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int m0   = blockIdx.x * BT;
+    const int wm   = warp / (NMAX / 16);          // which 16-row tile
+    const int wn   = warp % (NMAX / 16);          // which 16-col tile
+
+    wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
+    wmma::fill_fragment(cf, 0.f);
+
+    for (int k0 = 0; k0 < K; k0 += KT) {
+        // 16-byte vector staging: 8 bf16 per thread per slot, so a warp moves 512 contiguous bytes.
+        for (int e = tid; e < (BT * KT) / 8; e += WARPS * 32) {
+            const int i = e / (KT / 8), kv = (e % (KT / 8)) * 8;
+            const int gm = m0 + i, gk = k0 + kv;
+            const bool ok = gm < M && gk + 7 < K;
+            *reinterpret_cast<uint4*>(&sA[i][kv]) =
+                ok ? *reinterpret_cast<const uint4*>(&A[(size_t)gm * K + gk]) : make_uint4(0, 0, 0, 0);
+        }
+        for (int e = tid; e < (NMAX * KT) / 8; e += WARPS * 32) {
+            const int j = e / (KT / 8), kv = (e % (KT / 8)) * 8;
+            const int gk = k0 + kv;
+            const bool ok = j < n_out && gk + 7 < K;
+            *reinterpret_cast<uint4*>(&sW[j][kv]) =
+                ok ? *reinterpret_cast<const uint4*>(&W[(size_t)j * K + gk]) : make_uint4(0, 0, 0, 0);
+        }
+        __syncthreads();
+
+        #pragma unroll
+        for (int kk = 0; kk < KT; kk += 16) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, __nv_bfloat16, wmma::row_major> af;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, __nv_bfloat16, wmma::col_major> bf;
+            wmma::load_matrix_sync(af, &sA[wm * 16][kk], KT + SK_PAD);
+            wmma::load_matrix_sync(bf, &sW[wn * 16][kk], KT + SK_PAD);   // col_major => W^T
+            wmma::mma_sync(cf, af, bf, cf);
+        }
+        __syncthreads();
+    }
+
+    // staged store: one warp at a time reuses sC, then writes bf16 with bounds+n_out masking
+    for (int w = 0; w < WARPS; w++) {
+        __syncthreads();
+        if (warp != w) continue;
+        wmma::store_matrix_sync(&sC[0][0], cf, 16, wmma::mem_row_major);
+        __syncwarp();
+        for (int e = lane; e < 256; e += 32) {
+            const int r = e >> 4, c = e & 15;
+            const int gm = m0 + wm * 16 + r, gn = wn * 16 + c;
+            if (gm < M && gn < n_out) C[(size_t)gm * n_out + gn] = __float2bfloat16(sC[r][c]);
+        }
+    }
+}
+
+}  // namespace
+
+bool launch_prefill_gemm_skinny(const void* A, const void* W, void* C,
+                                int M, int N, int K, cudaStream_t stream) {
+    constexpr int BT = 32, NMAX = 32, KT = 64, WARPS = (BT / 16) * (NMAX / 16);
+    static_assert(WARPS * 32 <= 1024 && (KT % 16) == 0, "one warp per 16x16 output tile");
+
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GEMM_SKINNY");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    // Only worth it while the 128-wide tile is mostly padding; wider outputs keep the tiled GEMM,
+    // which is tensor-core bound and already the right shape for them.
+    if (!enabled || N > NMAX || M <= 0 || K <= 0 || (K % KT) != 0) return false;
+
+    dim3 grid((M + BT - 1) / BT);
+    pf_gemm_skinny_kernel<BT, NMAX, KT, WARPS><<<grid, WARPS * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(A), reinterpret_cast<const __nv_bfloat16*>(W),
+        reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+    return true;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -10,6 +10,8 @@
 #include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
+#include "sparkinfer/kernels/dequant_gguf_fast.h"
+#include "sparkinfer/kernels/dequant_rows_i8_fast.h"
 #endif
 
 namespace sparkinfer {
@@ -192,6 +194,9 @@ __global__ void transpose3d_kernel(const __nv_bfloat16* __restrict__ src, __nv_b
 #include "sparkinfer/kernels/quant.h"
 
 void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_values, cudaStream_t stream) {
+    // Coalesced Q4_K path (warp per super-block, 16-byte stores; byte-exact). Falls through to the
+    // scalar kernels below for other types or when SPARKINFER_DEQUANT_COALESCED=0.
+    if (launch_gguf_dequant_fast(ggml_type, src, dst_bf16, n_values, stream)) return;
     auto* d = reinterpret_cast<__nv_bfloat16*>(dst_bf16);
     auto* s = reinterpret_cast<const unsigned char*>(src);
     const int T = 256;
@@ -205,6 +210,9 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
 
 bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q, float* scale,
                                  int rows, int cols, cudaStream_t stream) {
+    // Vector-store path: 4 consecutive values per thread => 4-byte stores, 128 B per warp, and the
+    // decoded row stays in registers. Bit-identical; =0 restores the byte-store kernel below.
+    if (launch_gguf_dequant_rows_i8_fast(ggml_type, src, q, scale, rows, cols, stream)) return true;
     if ((cols & 255) != 0) return false;
     auto* s = reinterpret_cast<const unsigned char*>(src);
     if (ggml_type == GGML_Q4_K)      deq_rows_i8_kernel<12><<<rows, 256, 0, stream>>>(s, q, scale, cols);

--- a/kernels/csrc/cuda/quant/dequant_gguf_fast.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf_fast.cu
@@ -1,0 +1,133 @@
+// ============================================================================
+// Coalesced Q4_K -> bf16 dequantization.
+//
+// WHY THIS EXISTS
+// ---------------
+// deq_q4k_kernel (dequant_gguf.cu) assigns ONE THREAD per 256-value Q4_K super-block, and that
+// thread writes all 256 bf16 outputs with scalar stores:
+//
+//     long b = blockIdx.x * blockDim.x + threadIdx.x;   // one thread == one 256-value block
+//     __nv_bfloat16* yy = y + b * 256;
+//     for (int l = 0; l < 32; l++) yy[j + l] = __float2bfloat16(d1 * (q[l] & 0xF) - m1);
+//
+// Consecutive lanes therefore write addresses 512 B apart. Every store instruction in a warp
+// touches 32 DISTINCT 32-byte sectors and uses 2 bytes of each => ~16x write amplification.
+//
+// This costs real time in two places. At LOAD, every dense GGUF tensor goes through here: measured
+// 19.05 ms in one Q4_K call on an RTX 5090 (main @ cb34dc1). In PREFILL, the Qwythos batched path
+// (#398) dequantizes projection weights to bf16 scratch on EVERY call (qwen35_prefill.cpp `dq()` ->
+// launch_gguf_dequant). Since #464 fused Q4K/Q6K -> int8 for every projection with n_out >= 128,
+// what still lands here is the 48 ssm_alpha/ssm_beta projections per prefill (n_out == 32, kept in
+// bf16 on purpose because per-row int8 quant of a 32-wide weight costs more accuracy than it saves)
+// = 4.42 ms per prefill. Both numbers come from a reps=1-vs-2 instance diff (49 -> 97 instances,
+// 23.47 -> 27.89 ms), which is the only way to separate the one-time load cost from the per-prefill
+// cost — the raw nsys total mixes them and reads as a single 23.5 ms line.
+//
+// The arithmetic says the pattern, not the work, is the cost: dequantizing W weights moves
+// 2*W bytes of bf16 writes + ~0.5625*W bytes of Q4_K reads, which at 1792 GB/s should be
+// bandwidth-bound; 16x write amplification is what puts the kernel at ~7% of DRAM peak instead.
+//
+// THE FIX. One WARP per super-block instead of one thread. Each lane owns 8 consecutive outputs
+// and emits them as a single 16-byte store, so a warp writes 512 contiguous bytes — fully
+// coalesced, no amplification. Each lane's 8 outputs always fall inside one 64-value sub-block
+// and one nibble half (lane*8 is a multiple of 8, so lane*8 .. lane*8+7 never straddles a 32- or
+// 64-boundary), so the scale/min pair is computed once per lane rather than per value.
+//
+// BYTE-EXACT. The per-value math is unchanged — same d/dmin, same 6-bit scale/min unpacking, same
+// `d*s * nibble - dmin*m` in the same order, same __float2bfloat16. Only the thread->output
+// mapping changes. This is deliberate: dequant_gguf.cu is SHARED with Qwen3.6 (it is the GGUF
+// load path for every model), and the closed #464 scored eval-qwen35:XL but was rejected
+// eval-qwen36:REJECT after changing shared dequant SEMANTICS (fusing Q4K/Q6K -> int8). Changing
+// only the memory access pattern cannot move any model's numerics.
+//
+// Q4_K only. Every one of the 248 per-prefill dequants is Q4_K (Q6_K tensors are requantized to
+// Q4_K at load, which is why deq_q6k's instance count does NOT scale with prefill reps); other
+// types fall through to the existing kernels.
+// ============================================================================
+#include "sparkinfer/kernels/dequant_gguf_fast.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include <cstdlib>
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+constexpr int DQF_Q4_K = 12;   // ggml type id, matches dequant_gguf.cu
+
+__device__ __forceinline__ float dqf_h2f(const unsigned char* p) {
+    __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
+}
+
+// 6-bit packed scale/min unpack — identical to gg_scale_min_k4 in dequant_gguf.cu.
+__device__ __forceinline__ void dqf_scale_min_k4(int j, const unsigned char* q, int* d, int* m) {
+    if (j < 4) { *d = q[j] & 63; *m = q[j + 4] & 63; }
+    else {
+        *d = (q[j + 4] & 0xF) | ((q[j - 4] >> 6) << 4);
+        *m = (q[j + 4] >> 4)  | ((q[j]     >> 6) << 4);
+    }
+}
+
+// One warp per 256-value super-block; one 16-byte coalesced store per lane.
+__global__ void deq_q4k_coalesced_kernel(const unsigned char* __restrict__ src,
+                                         __nv_bfloat16* __restrict__ y, long nblocks) {
+    const long gtid = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    const long b    = gtid >> 5;                 // warp id == super-block index
+    if (b >= nblocks) return;
+    const int lane = (int)(gtid & 31);
+
+    const unsigned char* blk = src + b * 144;
+    const float d    = dqf_h2f(blk);
+    const float dmin = dqf_h2f(blk + 2);
+    const unsigned char* sc = blk + 4;
+    const unsigned char* q  = blk + 16;
+
+    // This lane owns outputs [n0, n0+8). n0 is a multiple of 8, so all 8 share one 64-value
+    // sub-block (jj) and one nibble half — the scale/min pair is uniform across the lane.
+    const int n0   = lane * 8;
+    const int jj   = n0 >> 6;             // sub-block 0..3   (scales are consumed in pairs)
+    const int half = (n0 & 63) >> 5;      // 0 = low nibbles, 1 = high nibbles
+    const int l0   = n0 & 31;
+
+    int s, m;
+    dqf_scale_min_k4(jj * 2 + half, sc, &s, &m);
+    const float dd = d * s, mm = dmin * m;
+
+    const unsigned char* qp = q + jj * 32 + l0;
+    __nv_bfloat16 out[8];
+    #pragma unroll
+    for (int t = 0; t < 8; t++) {
+        const unsigned char qb = qp[t];
+        const int nib = half ? (qb >> 4) : (qb & 0xF);
+        out[t] = __float2bfloat16(dd * nib - mm);
+    }
+    // 16-byte aligned: y is a cudaMalloc'd base, block stride is 256 bf16 (512 B), lane stride 16 B.
+    *reinterpret_cast<uint4*>(y + b * 256 + n0) = *reinterpret_cast<const uint4*>(out);
+}
+
+}  // namespace
+
+bool launch_gguf_dequant_fast(int ggml_type, const void* src, void* dst_bf16, long n_values,
+                              cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_COALESCED");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || ggml_type != DQF_Q4_K) return false;
+    if (n_values <= 0 || (n_values % 256) != 0) return false;
+
+    const long nb = n_values / 256;
+    const int  T  = 256;                       // 8 warps per CUDA block
+    const long threads = nb * 32;              // one warp per super-block
+    deq_q4k_coalesced_kernel<<<(threads + T - 1) / T, T, 0, stream>>>(
+        reinterpret_cast<const unsigned char*>(src),
+        reinterpret_cast<__nv_bfloat16*>(dst_bf16), nb);
+    return true;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
+++ b/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
@@ -1,0 +1,168 @@
+// ============================================================================
+// Vector-store fused GGUF -> int8 row dequantization.
+//
+// WHY THIS EXISTS
+// ---------------
+// deq_rows_i8_kernel (dequant_gguf.cu, #464) fuses Q4_K/Q6_K -> int8 and skips the bf16 scratch round
+// trip, which is what carried #464 to XL. What it leaves on the table is the store shape:
+//
+//     const int row = blockIdx.x, t = threadIdx.x;      // <<<rows, 256>>>
+//     for (sb = 0; sb < nsb; sb++) qrow[sb * 256 + t] = (signed char)(int)roundf(v * inv);
+//
+// Thread t owns value t of a 256-value super-block, so every thread stores exactly ONE byte and a
+// warp emits 32 consecutive bytes — a 32-byte transaction where the memory system moves 128. The
+// kernel's whole job is streaming (one prefill decodes ~6.9 G weights: ~3.9 GB of Q4_K in, 6.9 GB of
+// int8 out = ~6 ms at 1792 GB/s), and it measures 19.5 ms — ~31% of DRAM peak.
+//
+// It also walks the row twice (once for the amax, once to scale and store), because the int8 scale is
+// a property of the whole row. That looks like the obvious defect and is NOT: caching the decoded row
+// in registers to make it single-pass was tried first and bought 0.5 ms (19.75 -> 19.26), because the
+// second pass hits L2, not DRAM. The stores were always the cost.
+//
+// THE FIX. Give each thread VEC=4 CONSECUTIVE values instead of one, so a thread stores a 4-byte
+// word and a warp writes 128 contiguous bytes. 256 threads x 4 = 1024 values per group; the row is
+// walked in cols/1024 groups. Since a thread's 4 values are 4-aligned, they always fall inside one
+// super-block, so the decode still reads a single block header per value-quad. The decoded row is
+// also kept in registers (VEC * NG floats: 16 for a 4096-wide row, 48 for a 12288-wide one — 48*256
+// = 12288 regs/block, still 5 blocks/SM), which costs nothing now and removes the second decode.
+//
+// BIT-IDENTICAL, deliberately: same deq_q4k_val/deq_q6k_val, same amax over the same value set, same
+// d = amax/127.f, same inv, same roundf(v * inv). Only the thread->value map and the store width move.
+// ============================================================================
+#include "sparkinfer/kernels/dequant_rows_i8_fast.h"
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+
+#include <cstdlib>
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+enum { DQR_Q4_K = 12, DQR_Q6_K = 14 };
+
+// --- decode helpers: byte-for-byte the ones in dequant_gguf.cu ---
+__device__ __forceinline__ float dqr_h2f(const unsigned char* p) {
+    __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
+}
+__device__ __forceinline__ void dqr_scale_min_k4(int j, const unsigned char* q, int* d, int* m) {
+    if (j < 4) { *d = q[j] & 63; *m = q[j + 4] & 63; }
+    else {
+        *d = (q[j + 4] & 0xF) | ((q[j - 4] >> 6) << 4);
+        *m = (q[j + 4] >> 4)  | ((q[j]     >> 6) << 4);
+    }
+}
+__device__ __forceinline__ float dqr_q4k_val(const unsigned char* blk, int t) {
+    const float d = dqr_h2f(blk), dmin = dqr_h2f(blk + 2);
+    const unsigned char* sc = blk + 4; const unsigned char* qs = blk + 16;
+    const int j64 = t >> 6, r = t & 63, l = r & 31, hi = r >> 5;
+    const unsigned char byte = qs[j64 * 32 + l];
+    const int nib = hi ? (byte >> 4) : (byte & 0xF);
+    int s, m; dqr_scale_min_k4(2 * j64 + hi, sc, &s, &m);
+    return d * s * nib - dmin * m;
+}
+__device__ __forceinline__ float dqr_q6k_val(const unsigned char* blk, int t) {
+    const int half = t >> 7, r = t & 127, quad = r >> 5, l = r & 31;
+    const unsigned char* ql = blk + half * 64;
+    const unsigned char* qh = blk + 128 + half * 32;
+    const signed char* sc = (const signed char*)(blk + 192) + half * 8;
+    const float d = dqr_h2f(blk + 208);
+    const int is = l / 16;
+    int qv;
+    if (quad == 0)      qv = (int)((ql[l]      & 0xF) | (((qh[l] >> 0) & 3) << 4)) - 32;
+    else if (quad == 1) qv = (int)((ql[l + 32] & 0xF) | (((qh[l] >> 2) & 3) << 4)) - 32;
+    else if (quad == 2) qv = (int)((ql[l]      >>  4) | (((qh[l] >> 4) & 3) << 4)) - 32;
+    else                qv = (int)((ql[l + 32] >>  4) | (((qh[l] >> 6) & 3) << 4)) - 32;
+    return d * sc[is + 2 * quad] * qv;
+}
+
+constexpr int DQR_BLOCK = 256, DQR_VEC = 4;   // 4 consecutive values/thread => 4B store, 128B/warp
+
+// One block per row; NG groups of DQR_BLOCK*DQR_VEC values each.
+template <int QT, int NG>
+__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_kernel(
+        const unsigned char* __restrict__ src, signed char* __restrict__ q,
+        float* __restrict__ scale, int cols) {
+    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;               // values per group
+    const int row = blockIdx.x, t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const unsigned char* rbase = src + (size_t)row * nsb * BS;
+
+    float v[NG][DQR_VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;            // 4-aligned => one super-block
+        if (base < cols) {
+            const unsigned char* blk = rbase + (size_t)(base >> 8) * BS;
+            const int off = base & 255;
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) {
+                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                amax = fmaxf(amax, fabsf(v[g][i]));
+            }
+        }
+    }
+
+    __shared__ float swarp[DQR_BLOCK / 32];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
+        if (t == 0) swarp[0] = w;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) scale[row] = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    signed char* qrow = q + (size_t)row * cols;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            signed char o[DQR_VEC];
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) o[i] = (signed char)(int)roundf(v[g][i] * inv);
+            *reinterpret_cast<unsigned*>(&qrow[base]) = *reinterpret_cast<const unsigned*>(o);
+        }
+    }
+}
+
+template <int QT>
+bool dispatch(const unsigned char* s, signed char* q, float* scale, int rows, int cols,
+              cudaStream_t stream) {
+    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
+    if (ng <= 4)       deq_rows_i8_vec_kernel<QT, 4><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
+    else if (ng <= 8)  deq_rows_i8_vec_kernel<QT, 8><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
+    else if (ng <= 12) deq_rows_i8_vec_kernel<QT, 12><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
+    else return false;                                   // wider than the register budget
+    return true;
+}
+
+}  // namespace
+
+bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed char* q, float* scale,
+                                      int rows, int cols, cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    // cols % 1024 keeps every thread's 4-value quad inside one super-block and 4-byte aligned.
+    if (!enabled || rows <= 0 || cols <= 0 || (cols % (DQR_BLOCK * DQR_VEC)) != 0) return false;
+
+    auto s = reinterpret_cast<const unsigned char*>(src);
+    if (ggml_type == DQR_Q4_K) return dispatch<DQR_Q4_K>(s, q, scale, rows, cols, stream);
+    if (ggml_type == DQR_Q6_K) return dispatch<DQR_Q6_K>(s, q, scale, rows, cols, stream);
+    return false;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/csrc/cuda/quant/prefill_quant_rows.cu
+++ b/kernels/csrc/cuda/quant/prefill_quant_rows.cu
@@ -1,0 +1,126 @@
+// ============================================================================
+// Block-parallel, single-pass int8 row quantization for prefill activations.
+//
+// WHY THIS EXISTS
+// ---------------
+// pf_quantize_rows_i8 (prefill_gemm_i8.cu, #422) is launched <<<rows, 32>>> — ONE WARP per row —
+// and streams the row twice:
+//
+//     for (c = lane; c < cols; c += 32) amax = fmaxf(amax, fabsf(x[r*cols + c]));   // pass 1
+//     ... warp reduce ...
+//     for (c = lane; c < cols; c += 32) q[r*cols + c] = round(x[r*cols + c] / d);   // pass 2
+//
+// Two costs follow. The row is read from DRAM twice (the projections are large enough that a row
+// does not survive in cache between the passes), and a 32-thread block is a poor unit of work: one
+// warp per block wastes most of each SM's issue slots and leaves the memory pipe underfed.
+//
+// Measured on an RTX 5090 (nsys, main @ cb34dc1, ctx=4096): 17.1 ms per prefill over 200 calls.
+// After #464 fused the WEIGHT dequant into int8, these 200 calls are the activation side only, and
+// they are pure streaming: sum over projections of rows*cols is ~4.43 G elements, so the ideal is
+// 2 B read + 1 B write = ~13.3 GB = 7.4 ms at 1792 GB/s. The kernel sits at ~43% of that.
+//
+// THE FIX. One BLOCK per row (not one warp), and stage the row in registers so it is read once:
+//   * BLOCK threads cover the row; each thread keeps its slice in registers across both phases,
+//     so DRAM sees exactly one read and one write. The amax reduction runs over the registers.
+//   * 16-byte vector loads/stores: each thread handles VEC=8 contiguous bf16, so a warp moves 512 B.
+//   * grid = rows, block = BLOCK threads -> the SM gets whole blocks of work instead of lone warps.
+//
+// NUMERICS ARE UNCHANGED and that is deliberate: same amax over the row, same d = amax/127.0f, same
+// roundf, same amax==0 -> 0 rule, and the reduction is over the same value set (max is associative
+// and exact in fp, so reduction order cannot change the result). The int8 output and per-row scale
+// are bit-identical to #422's kernel, which is checked by A/B in the eval and by the guard model.
+// ============================================================================
+#include "sparkinfer/kernels/prefill_quant_rows.h"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+
+#include <cstdlib>
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+__device__ __forceinline__ float qr_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
+
+// One block per row. VEC bf16 per thread per slot; SLOTS slots keeps the row in registers.
+template <int BLOCK, int VEC, int SLOTS>
+__global__ __launch_bounds__(BLOCK) void pf_quant_rows_fast_kernel(
+        const __nv_bfloat16* __restrict__ x, signed char* __restrict__ q,
+        float* __restrict__ scale, int rows, int cols) {
+    const int r   = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (r >= rows) return;
+    const size_t base = (size_t)r * cols;
+
+    __nv_bfloat16 reg[SLOTS][VEC];
+    float amax = 0.f;
+
+    // ---- single read: pull the row into registers, computing amax on the way ----
+    #pragma unroll
+    for (int s = 0; s < SLOTS; s++) {
+        const int c = (tid + s * BLOCK) * VEC;
+        if (c < cols) {
+            *reinterpret_cast<uint4*>(reg[s]) = *reinterpret_cast<const uint4*>(&x[base + c]);
+            #pragma unroll
+            for (int v = 0; v < VEC; v++) amax = fmaxf(amax, fabsf(qr_to_f(reg[s][v])));
+        }
+    }
+
+    // ---- block reduce max (exact in fp: max is associative, so order cannot change the result) ----
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    __shared__ float sred[BLOCK / 32];
+    if ((tid & 31) == 0) sred[tid >> 5] = amax;
+    __syncthreads();
+    if (tid < 32) {
+        float v = (tid < BLOCK / 32) ? sred[tid] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (tid == 0) sred[0] = v;
+    }
+    __syncthreads();
+    const float d = sred[0] / 127.0f;
+    if (tid == 0) scale[r] = d;
+
+    // ---- write from registers: the row is never re-read ----
+    #pragma unroll
+    for (int s = 0; s < SLOTS; s++) {
+        const int c = (tid + s * BLOCK) * VEC;
+        if (c < cols) {
+            signed char out[VEC];
+            #pragma unroll
+            for (int v = 0; v < VEC; v++)
+                out[v] = (signed char)((sred[0] == 0.f) ? 0 : (int)roundf(qr_to_f(reg[s][v]) / d));
+            *reinterpret_cast<uint2*>(&q[base + c]) = *reinterpret_cast<const uint2*>(out);
+        }
+    }
+}
+
+}  // namespace
+
+bool launch_prefill_quant_rows_fast(const void* x, signed char* q, float* scale,
+                                    int rows, int cols, cudaStream_t stream) {
+    constexpr int BLOCK = 256, VEC = 8;
+
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_QUANT_ROWS");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || rows <= 0 || cols <= 0) return false;
+    if ((cols % VEC) != 0) return false;                 // 16-byte vector path only
+
+    auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
+    const int vecs = cols / VEC;                          // vector slots in a row
+    // SLOTS is a compile-time register budget; dispatch the smallest that covers the row.
+    if (vecs <= BLOCK * 1)      pf_quant_rows_fast_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
+    else if (vecs <= BLOCK * 2) pf_quant_rows_fast_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
+    else if (vecs <= BLOCK * 4) pf_quant_rows_fast_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
+    else if (vecs <= BLOCK * 6) pf_quant_rows_fast_kernel<BLOCK, VEC, 6><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
+    else return false;                                    // very wide rows: keep the scalar path
+    return true;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/dequant_gguf_fast.h
+++ b/kernels/include/sparkinfer/kernels/dequant_gguf_fast.h
@@ -1,0 +1,35 @@
+// Coalesced Q4_K -> bf16 dequantization.
+//
+// See kernels/csrc/cuda/quant/dequant_gguf_fast.cu for the design notes. deq_q4k_kernel assigns one
+// thread per 256-value super-block and scalar-stores all 256 bf16 outputs from it, so consecutive
+// lanes write 512 B apart and every store burns a 32-byte sector to deliver 2 bytes (~16x write
+// amplification, ~7% of DRAM peak). On an RTX 5090 that is 19.05 ms of GGUF load plus 4.42 ms of
+// every Qwythos prefill (the 48 ssm_alpha/ssm_beta projections that #464's fused Q4K->int8 path
+// leaves behind, since it only takes n_out >= 128). This translation unit runs the same math with
+// one warp per super-block and one 16-byte coalesced store per lane.
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Coalesced Q4_K dequant. Signature mirrors `launch_gguf_dequant` so it drops in as a one-line
+// guard at the top of that launcher:
+//
+//     if (launch_gguf_dequant_fast(ggml_type, src, dst_bf16, n_values, stream)) return;
+//
+// Returns true if a kernel was launched, false if the caller should run its own dequant (not
+// Q4_K, ragged n_values, or disabled by env).
+//
+// Output is BYTE-EXACT with deq_q4k_kernel — the per-value arithmetic and rounding are unchanged
+// and only the thread->output mapping differs. This is load-bearing: this path is shared with
+// Qwen3.6, and the bidir eval rejects any PR that moves the guard model's numerics.
+//
+// Env knobs:
+//   SPARKINFER_DEQUANT_COALESCED  (default 1)  0 disables (A/B) -> falls through to deq_q4k_kernel.
+bool launch_gguf_dequant_fast(int ggml_type, const void* src, void* dst_bf16, long n_values,
+                              cudaStream_t stream = nullptr);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
+++ b/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
@@ -1,0 +1,34 @@
+// Vector-store fused GGUF -> int8 row dequantization.
+//
+// See kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu for the design notes. deq_rows_i8_kernel
+// (dequant_gguf.cu, #464) maps thread t to value t of a 256-value super-block, so each thread stores
+// ONE byte and a warp emits a 32-byte store where the memory system wants 128. Measured on an
+// RTX 5090 (main @ c9e20d1, ctx=4096): 19.5 ms per prefill over 200 calls, ~31% of DRAM peak, for a
+// kernel whose output is 6.9 GB of pure streaming int8.
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Fused GGUF -> int8 rows with 4-byte vector stores. Signature mirrors `launch_gguf_dequant_rows_i8`
+// so it drops in as a one-line guard at the top of that launcher:
+//
+//     if (launch_gguf_dequant_rows_i8_fast(ggml_type, src, q, scale, rows, cols, stream)) return true;
+//
+// Returns true if a kernel was launched, false if the caller should run its own (unsupported type,
+// a row shape outside the register budget, or disabled by env).
+//
+// BIT-IDENTICAL to #464's kernel: same deq_q4k_val / deq_q6k_val decode, same amax over the row
+// (max is associative and exact in fp, so the different thread->value map cannot move it), same
+// d = amax/127.f, same inv = 1.f/d guarded on d > 0, and the same roundf(v * inv) — v * inv, not
+// v / d; those differ in the last ulp.
+//
+// Env knobs:
+//   SPARKINFER_DEQUANT_ROWS_I8_FAST  (default 1)  0 disables (A/B) -> falls through to #464's kernel.
+bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed char* q, float* scale,
+                                      int rows, int cols, cudaStream_t stream = nullptr);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_gdn_chunk.h
+++ b/kernels/include/sparkinfer/kernels/prefill_gdn_chunk.h
@@ -1,0 +1,48 @@
+// Chunk-parallel (WY / UT transform) Gated-DeltaNet prefill scan for Qwythos (Qwen3.5).
+//
+// See kernels/csrc/cuda/fused/prefill_gdn_chunk.cu for the derivation and design notes. The
+// batched prompt prefill (#398) runs the gated delta rule as ONE sequential scan over all N
+// prompt tokens (pf_gdn_scan_kernel): warp-per-state-column, one rank-1 state update per token,
+// two 5-shuffle warp reductions per token on the critical path. It is the last sequential stage
+// left in the batched prefill. Measured on an RTX 5090 (nsys, main @ cb34dc1, ctx=4096, reps-diff
+// confirmed per-prefill): 59.3 ms = 20.7% of the 286.1 ms prefill, sustaining ~5.3 TFLOP/s
+// (~5% of the fp32 peak) — it is not DRAM-bound (the tensors it touches need ~10.5 ms at
+// 1792 GB/s) but L1/L2-bandwidth and serial-latency bound: every one of the 128 column-warps of
+// a v-head re-loads the same k_t/q_t vector on every token.
+//
+// This translation unit rewrites the same recurrence in its chunk-parallel form, so the serial
+// chain shortens from N to N/C and the per-chunk work becomes dense matmuls over shared-memory
+// tiles that all state columns reuse.
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Launch the chunk-parallel Gated-DeltaNet prefill scan. Signature mirrors
+// `launch_prefill_gdn_scan` (#398) so it drops in as a one-line guard at the top of that
+// launcher, ahead of the sequential scan:
+//
+//     if (launch_prefill_gdn_chunk(...)) return;   // else fall through to the sequential scan
+//
+// Returns true if the kernels were launched, false if the caller should run its own scan (shape
+// not specialized, disabled by env, or workspace allocation failed).
+//
+// Produces out[N, v_heads*head_dim] and leaves the recurrent state in the SAME transposed
+// [v_head][col][row] layout the decode gdn_ar_fast kernel expects, so this is a drop-in
+// replacement for the sequential scan and the decode path is untouched.
+//
+// Env knobs:
+//   SPARKINFER_PREFILL_GDN_CHUNK         (default 1)   0 disables (A/B) -> sequential scan (#398).
+//   SPARKINFER_PREFILL_GDN_CHUNK_MINCTX  (default 256) only chunk at n_tokens >= this; short
+//                                                      prompts do not amortize the prep pass.
+bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
+                              const void* alpha, const void* beta,
+                              const void* dt, const void* a,
+                              float* state, void* out,
+                              int n_tokens, int q_heads, int v_heads, int head_dim,
+                              cudaStream_t stream = nullptr);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_gemm_skinny.h
+++ b/kernels/include/sparkinfer/kernels/prefill_gemm_skinny.h
@@ -1,0 +1,34 @@
+// Skinny bf16 prefill GEMM for narrow outputs (n_out << tile width).
+//
+// See kernels/csrc/cuda/fused/prefill_gemm_skinny.cu for the design notes. pf_gemm_kernel tiles the
+// output 128x128, which is right for the big projections but pathological for the Gated-DeltaNet
+// gate projections (ssm_alpha / ssm_beta, n_out == 32): the grid is
+// ((32+127)/128, (4096+127)/128) = 1 x 32 = 32 blocks on a 170-SM part, and 96 of every 128 output
+// columns are padding. Measured on an RTX 5090 (main @ cb34dc1, ctx=4096): 7.5 ms per prefill over
+// 48 calls at ~6.9 TFLOP/s against a ~255 TFLOP/s bf16 tensor peak — compute-bound (A is L2-resident
+// across the alpha/beta pair), so the fix is a full grid and tensor cores, not better staging.
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Launch a bandwidth-shaped GEMM for narrow n_out. Signature mirrors `launch_prefill_gemm` so it
+// drops in as a one-line guard at the top of that launcher:
+//
+//     if (launch_prefill_gemm_skinny(A, W, C, M, N, K, stream)) return;
+//
+// Returns true if a kernel was launched, false if the caller should run its own GEMM (n_out too
+// wide to benefit, ragged K, or disabled by env).
+//
+// Accumulates in fp32 and emits bf16, exactly like pf_gemm_kernel; only the blocking changes, so
+// the result matches to fp32 reassociation.
+//
+// Env knobs:
+//   SPARKINFER_PREFILL_GEMM_SKINNY  (default 1)  0 disables (A/B) -> falls through to pf_gemm.
+bool launch_prefill_gemm_skinny(const void* A, const void* W, void* C,
+                                int M, int N, int K, cudaStream_t stream = nullptr);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_quant_rows.h
+++ b/kernels/include/sparkinfer/kernels/prefill_quant_rows.h
@@ -1,0 +1,31 @@
+// Block-parallel, single-pass int8 row quantization for the prefill activations.
+//
+// See kernels/csrc/cuda/quant/prefill_quant_rows.cu for the design notes. pf_quantize_rows_i8
+// (prefill_gemm_i8.cu, #422) gives each row ONE warp and reads the row twice — once for the amax
+// reduction, once to divide and store. Measured on an RTX 5090 (main @ cb34dc1, ctx=4096): 17.1 ms
+// per prefill over 200 calls, ~43% of DRAM peak, for a purely streaming op.
+#pragma once
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Quantize x[rows, cols] (bf16) to int8 with one scale per row. Signature mirrors the launcher in
+// prefill_gemm_i8.cu so it drops in as a one-line guard at the top of it:
+//
+//     if (launch_prefill_quant_rows_fast(x, q, scale, rows, cols, stream)) return;
+//
+// Returns true if a kernel was launched, false if the caller should run its own (ragged cols, or
+// disabled by env).
+//
+// Numerics are unchanged: same amax over the row, same d = amax/127, same roundf, same zero-amax
+// special case — so the int8 output and the per-row scale are bit-identical to the scalar path.
+//
+// Env knobs:
+//   SPARKINFER_PREFILL_QUANT_ROWS  (default 1)  0 disables (A/B) -> falls through to #422's kernel.
+bool launch_prefill_quant_rows_fast(const void* x, signed char* q, float* scale,
+                                    int rows, int cols, cudaStream_t stream = nullptr);
+
+}  // namespace kernels
+}  // namespace sparkinfer


### PR DESCRIPTION
## Summary

Five kernels in the Qwythos batched prefill, each a new file wired as a one-line guard with its own
env toggle. ctx=4096 prefill **16704 → 20549 pp (+23.0%)** on top of #474; 32k +18.6%, 64k +18.3%;
decode unchanged.

| lever (new file) | what was wrong | before → after |
|---|---|--:|
| **Chunk-parallel GDN scan**<br>`prefill_gdn_chunk.cu` | `pf_gdn_scan_kernel` (my #398) is the last sequential stage: one rank-1 update per token, and all 128 column-warps of a v-head re-load the same `k_t`/`q_t` every step — ~5.3 TFLOP/s (~5% of fp32 peak), and not DRAM-bound. Rewritten in WY/UT chunk form (`S~ = S/Γ` cancels the gate, the rank-1 chain becomes a triangular solve): serial chain N → N/C, inner work becomes dense matmuls every state column reuses. | **59.3 → 34.1 ms** |
| **Vector-store GGUF→int8 dequant**<br>`dequant_rows_i8_fast.cu` | `deq_rows_i8_kernel` (#464) maps thread t to value t, so each thread stores **one byte** and a warp emits 32 B where the memory system moves 128. 4 consecutive values/thread → 4-byte store, 128 B/warp. **Bit-identical.** | **19.5 → 11.8 ms** |
| **Single-pass row quantize**<br>`prefill_quant_rows.cu` | `pf_quantize_rows_i8` is `<<<rows, 32>>>` — one warp per row — and streams each row twice (amax, then scale+store). One block per row, row held in registers. | **17.1 → 4.09 ms** |
| **Skinny bf16 GEMM**<br>`prefill_gemm_skinny.cu` | GDN gate projections (`n_out=32`) fall through to the 128×128-tiled `pf_gemm` → grid `1 × 32 = 32 blocks` on a 170-SM part, 75% of each tile padding. Compute-bound (A is L2-resident), so: wmma + full grid, no padding. | **7.5 → 3.54 ms** |
| **Coalesced Q4_K dequant**<br>`dequant_gguf_fast.cu` | `deq_q4k_kernel` gives one thread a 256-value super-block and scalar-stores all 256 outputs → lanes write 512 B apart, ~16x write amplification (~7% of DRAM peak). Warp per super-block, one 16-byte store per lane. **Bit-identical.** | **4.42 → 0.35 ms**<br>(+19.05 ms off GGUF load) |

Every existing line is untouched (guards: `batched_prefill.cu` +9, `prefill_gemm_i8.cu` +5,
`dequant_gguf.cu` +8). `SPARKINFER_PREFILL_GDN_CHUNK`, `SPARKINFER_DEQUANT_ROWS_I8_FAST`,
`SPARKINFER_PREFILL_QUANT_ROWS`, `SPARKINFER_PREFILL_GEMM_SKINNY`, `SPARKINFER_DEQUANT_COALESCED` —
each `=0` restores the previous kernel.

Correctness: top-1 **0.9707** / KL **0.0034** at ctx=4096 over **512** positions (main 0.9609 / 0.0047;
gate 0.90 / 0.20). Measured at 512 rather than 128, where the metric quantises to 0.78pp per token.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (no-regression — decode does not touch this path):

| | decode tok/s |
|---|--:|
| before (main) | 291.69 |
| after (this PR) | 292.08 |

**Prefill pp tok/s** (Qwythos-9B Q4_K_M, best context = `--ctx 4096`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 16704.4 |
| after prefill (this PR) | **20549.4** |

| ctx | before | after | delta | | ctx | decode before | decode after |
|---|--:|--:|--:|---|---|--:|--:|
| 4096 | 16704.4 | **20549.4** | **+23.0%** | | 128 | 301.13 | 301.52 |
| 32768 | 17534.0 | 20844.6 | +18.6% | | 4096 | 291.69 | 292.08 |
| 65536 | 17580.5 | 20791.1 | +18.3% | | 32768 | 290.97 | 290.98 |
| | | | | | 65536 | 291.05 | 291.33 |

Measured exactly as `bench_sweep_run` does — one process, all scored contexts, so `max_seq` is sized
for 64k as in the eval. Five interleaved A/B pairs, same binary toggled. Each scoring context clears
on its own (4k 5/5, 32k 5/5, 64k 5/5), so the result does not hinge on which context is selected.

```text
# RTX 5090, idle box, main @ d72b98a, eval's own sweep shape:
#   SPARKINFER_EVAL_PREFILL=1 SPARKINFER_BENCH_SWEEP_CTXS=128,4096,32768,65536 \
#   SPARKINFER_BENCH_SWEEP_REPS=1 ./build/runtime/qwen3_gguf_bench <gguf> 128 sweep
# 5 interleaved pairs, gain on each run's best context (build_pp_score_select's rule):
#   pair1 ctx=4096  17037.4 -> 20885.3  +22.6%      pair4 ctx=4096  16685.8 -> 20522.4  +23.0%
#   pair2 ctx=4096  17001.2 -> 20597.4  +21.2%      pair5 ctx=4096  16219.2 -> 20425.4  +25.9%
#   pair3 ctx=4096  16704.4 -> 20549.5  +23.0%

# Correctness — qwen3_gguf_prefill_check <gguf> 4096 512:
  all toggles=0 (main):  TOP1 492/512 0.9609   KL 0.00473
  all toggles=1 (this):  TOP1 497/512 0.9707   KL 0.00338

# Dequant bit-exactness — 51.2M pseudo-random Q4_K values, FNV-1a over the raw bf16 bits:
  SPARKINFER_DEQUANT_COALESCED=0 -> 14116085882651877130
  SPARKINFER_DEQUANT_COALESCED=1 -> 14116085882651877130

# nsys (--cuda-graph-trace=node, ctx=4096), per-prefill (reps=1-vs-2 diffed):
  pf_gdn_scan  59.3 -> 34.1 | deq_rows_i8 19.5 -> 11.8 | pf_quantize_rows_i8 17.1 -> 4.09
  pf_gemm(bf16) 7.5 -> 3.54 | deq_q4k 4.42 -> 0.35     | pf_gemm_i8 (#474) 109.5 -> 109.5 (untouched)
```

## Relation to open PRs

- **No open non-draft PR shares any file with this one** (#403, #445, #509 → qwen36 / runtime; #482
  is a draft), so the copycat guard never computes containment for it.
- **#474** (merged) is untouched: its `mma.sync m16n8k32` GEMM is now 44% of the prefill wall. I did
  try replacing its XOR swizzle (whose comment notes rows 4 apart collide 2-way) with an 80 B padded
  stride — bank-conflict-free but **20% slower** (109.5 → 131.7 ms), because the conflict was already
  hidden behind the mma pipe. Its shape is the right one.
- Lever 2 improves **#464**'s merged `deq_rows_i8_kernel` (store width only — its fused decode is kept
  verbatim, output bit-identical). Also builds on my merged **#398** and **#465**.

