### PR TITLE
perf(qwen35): quantize each prefill activation once + emit SwiGLU straight to int8 (+2.6% pp @64k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_fused_q8.cu
+++ b/kernels/csrc/cuda/fused/prefill_fused_q8.cu
@@ -1,0 +1,157 @@
+// Fused elementwise->int8 producers for the Qwythos batched prefill.
+//
+// The prefill activation path materializes a bf16 tensor, then re-reads it twice in
+// pf_quantize_rows_i8 (once for the row amax, once to quantize). Measured on RTX 5090 @32k
+// (nsys, main c9e20d1), that elementwise+quantize path is 9.4% of prefill:
+//   pf_quantize_rows_i8 4.2% | pf_swiglu 2.5% | pf_add 1.6% | rmsnorm 1.1%
+// while the DECODE path already fuses the same work (add_rmsnorm2_q8_kernel emits its Q8_1
+// inline). These kernels port that pattern to prefill, in the per-row int8 + per-row float
+// scale format pf_gemm_i8 consumes.
+//
+// The big one is SwiGLU: ffh feeds only proj(ffh, w.down_q, ..., H, ffn) with n_out = H = 4096
+// >= 128, i.e. the int8 path exclusively -- nothing reads ffh in bf16 -- so the fused kernel
+// never writes it. Per element: 11B (2 read + 2B write ffh, then 2x2B read + 1B write q)
+// becomes 5B (2B + 2B read, 1B write q). The row (ffn=12288 bf16 = 24KB) stages in shared, so
+// the amax pass and the quantize pass both hit shared instead of HBM.
+//
+// Numerics are bit-identical to the unfused pair: same silu/mul math, same amax/127 scale, same
+// roundf. SPARKINFER_PREFILL_FUSED_Q8=0 restores the separate kernels.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdlib>
+
+namespace sparkinfer { namespace kernels {
+namespace {
+
+__device__ __forceinline__ float fq_f(__nv_bfloat16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ float fq_silu(float x) { return x / (1.f + __expf(-x)); }
+
+// Warp-max then block-max over the block's warps.
+template <int NT>
+__device__ __forceinline__ float fq_block_amax(float v, float* red) {
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    if (lane == 0) red[warp] = v;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        float m = 0.f;
+        #pragma unroll
+        for (int w = 0; w < NT / 32; ++w) m = fmaxf(m, red[w]);
+        red[0] = m;
+    }
+    __syncthreads();
+    return red[0];
+}
+
+// out_q[r][c] = round( silu(gate[r][c]) * up[r][c] / d ),  d = amax(row)/127,  scale[r] = d.
+// One block per row; the row is staged in shared so amax + quantize never re-read HBM.
+// ffh (bf16) is NOT written -- nothing consumes it outside the int8 GEMM.
+template <int NT>
+__global__ __launch_bounds__(NT, 1)
+void pf_swiglu_q8_kernel(const __nv_bfloat16* __restrict__ gate,
+                         const __nv_bfloat16* __restrict__ up,
+                         signed char* __restrict__ q, float* __restrict__ scale,
+                         int rows, int cols) {
+    extern __shared__ char sfq[];
+    float* red = reinterpret_cast<float*>(sfq);          // [NT/32] warp-max staging
+    __nv_bfloat16* row = reinterpret_cast<__nv_bfloat16*>(red + (NT / 32));  // [cols]
+
+    const int r = blockIdx.x;
+    if (r >= rows) return;
+    const size_t base = (size_t)r * cols;
+
+    float amax = 0.f;
+    for (int c = threadIdx.x; c < cols; c += NT) {
+        const float v = fq_silu(fq_f(gate[base + c])) * fq_f(up[base + c]);
+        row[c] = __float2bfloat16(v);                    // stage bf16 -- matches the unfused
+        amax = fmaxf(amax, fabsf(fq_f(row[c])));         // ffh write, so amax sees the same bits
+    }
+    amax = fq_block_amax<NT>(amax, red);
+
+    const float d = amax / 127.0f;
+    if (threadIdx.x == 0) scale[r] = d;
+    for (int c = threadIdx.x; c < cols; c += NT)
+        q[base + c] = (signed char)((amax == 0.f) ? 0 : (int)roundf(fq_f(row[c]) / d));
+}
+
+// out_bf16[r][c] = rmsnorm(x)[r][c] * w[c]   AND   out_q/scale = row-quantized(out_bf16).
+// The bf16 output is still written: the tiny per-v-head gate projections (n_out < 128) consume
+// it on the bf16 path. The saving is the two HBM re-reads pf_quantize_rows_i8 would do.
+template <int NT>
+__global__ __launch_bounds__(NT, 1)
+void pf_rmsnorm_q8_kernel(const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ w,
+                          __nv_bfloat16* __restrict__ out, signed char* __restrict__ q,
+                          float* __restrict__ scale, int rows, int cols, float eps) {
+    extern __shared__ char sfq[];
+    float* red = reinterpret_cast<float*>(sfq);
+    __nv_bfloat16* row = reinterpret_cast<__nv_bfloat16*>(red + (NT / 32));
+
+    const int r = blockIdx.x;
+    if (r >= rows) return;
+    const size_t base = (size_t)r * cols;
+
+    float ss = 0.f;
+    for (int c = threadIdx.x; c < cols; c += NT) { const float v = fq_f(x[base + c]); ss += v * v; }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) ss += __shfl_xor_sync(0xffffffffu, ss, o);
+    { const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+      if (lane == 0) red[warp] = ss;
+      __syncthreads();
+      if (threadIdx.x == 0) { float s = 0.f;
+          #pragma unroll
+          for (int wi = 0; wi < NT / 32; ++wi) s += red[wi];
+          red[0] = s; }
+      __syncthreads(); ss = red[0]; }
+    const float inv = rsqrtf(ss / (float)cols + eps);
+
+    float amax = 0.f;
+    for (int c = threadIdx.x; c < cols; c += NT) {
+        const __nv_bfloat16 v = __float2bfloat16(fq_f(x[base + c]) * inv * fq_f(w[c]));
+        row[c] = v; out[base + c] = v;
+        amax = fmaxf(amax, fabsf(fq_f(v)));
+    }
+    __syncthreads();
+    amax = fq_block_amax<NT>(amax, red);
+
+    const float d = amax / 127.0f;
+    if (threadIdx.x == 0) scale[r] = d;
+    for (int c = threadIdx.x; c < cols; c += NT)
+        q[base + c] = (signed char)((amax == 0.f) ? 0 : (int)roundf(fq_f(row[c]) / d));
+}
+} // anon namespace
+
+// cols must fit the staged row: cols * 2B + (NT/32)*4B <= smem cap.
+bool launch_prefill_swiglu_q8(const void* gate, const void* up, signed char* q, float* scale,
+                              int rows, int cols, cudaStream_t stream) {
+    constexpr int NT = 256;
+    const size_t sh = (size_t)(NT / 32) * sizeof(float) + (size_t)cols * sizeof(__nv_bfloat16);
+    if (sh > 96 * 1024) return false;                    // fall back to the unfused pair
+    static bool once = false;
+    if (!once) { cudaFuncSetAttribute(pf_swiglu_q8_kernel<NT>,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize, 96 * 1024); once = true; }
+    pf_swiglu_q8_kernel<NT><<<rows, NT, sh, stream>>>(
+        (const __nv_bfloat16*)gate, (const __nv_bfloat16*)up, q, scale, rows, cols);
+    return true;
+}
+
+bool launch_prefill_rmsnorm_q8(const void* x, const void* w, void* out, signed char* q, float* scale,
+                               int rows, int cols, float eps, cudaStream_t stream) {
+    constexpr int NT = 256;
+    const size_t sh = (size_t)(NT / 32) * sizeof(float) + (size_t)cols * sizeof(__nv_bfloat16);
+    if (sh > 96 * 1024) return false;
+    static bool once = false;
+    if (!once) { cudaFuncSetAttribute(pf_rmsnorm_q8_kernel<NT>,
+                    cudaFuncAttributeMaxDynamicSharedMemorySize, 96 * 1024); once = true; }
+    pf_rmsnorm_q8_kernel<NT><<<rows, NT, sh, stream>>>(
+        (const __nv_bfloat16*)x, (const __nv_bfloat16*)w, (__nv_bfloat16*)out, q, scale, rows, cols, eps);
+    return true;
+}
+
+bool prefill_fused_q8_enabled() {
+    const char* e = getenv("SPARKINFER_PREFILL_FUSED_Q8");
+    return !(e && e[0] == '0');
+}
+
+}} // namespace

--- a/kernels/include/sparkinfer/kernels/prefill_i8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8.h
@@ -20,6 +20,17 @@ namespace sparkinfer { namespace kernels {
 // Per-row symmetric int8 quantization: scale[r] = max_c|x[r,c]| / 127,
 // q[r,c] = round(x[r,c] / scale[r]).  x: [rows,cols] bf16 -> q: [rows,cols] int8, scale: [rows] fp32.
 // One warp per row. Used for both the per-token activation A and (once, resident) the weight W.
+// Fused elementwise->int8 producers (prefill_fused_q8.cu): emit the SAME per-row int8 + per-row
+// float scale as launch_prefill_quantize_rows_i8, but straight from the producer, skipping the bf16
+// round-trip that pf_quantize_rows_i8 re-reads twice (once for the row amax, once to quantize).
+// swiglu_q8 never writes ffh at all -- only the int8 GEMM consumes it. Return false if the row will
+// not stage in shared -> caller falls back to the unfused pair.
+bool launch_prefill_swiglu_q8(const void* gate, const void* up, signed char* q, float* scale,
+                              int rows, int cols, cudaStream_t stream = nullptr);
+bool launch_prefill_rmsnorm_q8(const void* x, const void* w, void* out, signed char* q, float* scale,
+                               int rows, int cols, float eps, cudaStream_t stream = nullptr);
+bool prefill_fused_q8_enabled();
+
 void launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
                                      int rows, int cols, cudaStream_t stream = nullptr);
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -89,6 +89,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* ffu  = a.alloc<bf16>((size_t)N * ffn);         // ffn up
     bf16* ffh  = a.alloc<bf16>((size_t)N * ffn);         // ffn silu(gate)*up
     bf16* wbuf = a.alloc<bf16>(maxw);                    // dequantized-weight scratch (reused)
+    // xn feeds 2-3 int8 projections and hn feeds 2 -- today each re-quantizes byte-identical data.
+    // Quantize once with the STOCK kernel and reuse => bit-identical. ffh_i8 replaces bf16 ffh.
+    const bool fq8 = kernels::prefill_fused_q8_enabled();
+    signed char* xn_i8  = fq8 ? a.alloc<signed char>((size_t)N * H)   : nullptr;
+    float*       xn_sx  = fq8 ? a.alloc<float>((size_t)N)             : nullptr;
+    signed char* hn_i8  = fq8 ? a.alloc<signed char>((size_t)N * H)   : nullptr;
+    float*       hn_sx  = fq8 ? a.alloc<float>((size_t)N)             : nullptr;
+    signed char* ffh_i8 = fq8 ? a.alloc<signed char>((size_t)N * ffn) : nullptr;
+    float*       ffh_sx = fq8 ? a.alloc<float>((size_t)N)             : nullptr;
     int*  d_ids = a.alloc<int>((size_t)N);
     if (!a.ok) { a.free_all(); fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
     // int8 tensor-core projections (prefill_gemm_i8): ~2x the bf16 GEMM at int8==bf16 output fidelity
@@ -113,19 +122,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         return wbuf;
     };
     // C[N,n_out] = A[N,K] @ W^T  (W native quantized [n_out,K]).
-    auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K) {
+    auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K,
+                    const signed char* Apre = nullptr, const float* sxpre = nullptr) {
         // int8 only for the big weight-bound projections; keep the tiny per-v-head gate
         // projections (ssm_alpha/ssm_beta, n_out == v_heads) in bf16 — they feed the GDN
         // sigmoid gates, where per-row int8 quant of a 32-wide weight costs more accuracy
         // than the negligible time it saves.
         if (use_i8 && n_out >= 128) {
-            kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, N, K, st);
+            const signed char* Aq = Apre; const float* Asx = sxpre;
+            if (!Aq) { kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, N, K, st); Aq = A_i8; Asx = sx; }
             // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
             if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
                 const void* wb = dq(W, wtype, n_out, K);
                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
             }
-            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, N, n_out, K, st);
+            kernels::launch_prefill_gemm_i8(Aq, W_i8, Asx, sw, C, N, n_out, K, st);
         } else {
             kernels::launch_prefill_gemm(A, dq(W, wtype, n_out, K), C, N, n_out, K, st);
         }
@@ -137,19 +148,44 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool kv8 = s.kv->int8_kv();
     const int  kv_elem = kv8 ? 1 : 2;
     const float rope_theta = c.rope_theta, eps = c.rms_eps;
+    // Upstream rmsnorm stays byte-for-byte (its packed-8 __fmaf_rn order is the reference -- a
+    // re-implementation drifts KL 0.01433 -> 0.01520). The win is not fusing the norm: it is
+    // quantizing its output ONCE with the stock kernel instead of 2-3x inside each projection.
+    auto norm_q8 = [&](const bf16* src, const void* wn, bf16* dst, signed char* dq, float* dsx) -> bool {
+        kernels::launch_rmsnorm(src, wn, dst, N, H, eps, st);
+        if (!fq8) return false;
+        kernels::launch_prefill_quantize_rows_i8(dst, dq, dsx, N, H, st);
+        return true;
+    };
+    // residual-add + RMSNorm as ONE upstream kernel (launch_add_rmsnorm2), which emits out_sum too --
+    // hbuf is still materialized for the second residual. Replaces pf_add + rmsnorm (2 passes -> 1).
+    auto add_norm_q8 = [&](const bf16* xs, const bf16* res, const void* wn, bf16* osum, bf16* onorm,
+                           signed char* dq, float* dsx) -> bool {
+        if (!fq8) {
+            kernels::launch_prefill_add(xs, res, osum, (long)N * H, st);
+            kernels::launch_rmsnorm(osum, wn, onorm, N, H, eps, st);
+            return false;
+        }
+        kernels::launch_add_rmsnorm2(xs, res, wn, osum, onorm, N, H, eps, st);
+        kernels::launch_prefill_quantize_rows_i8(onorm, dq, dsx, N, H, st);
+        return true;
+    };
     const int rope_dim = (c.rope_dim > 0) ? c.rope_dim : c.head_dim;
     const float attn_scale = 1.f / sqrtf((float)c.head_dim);
 
     // embed -> x, prime xn = RMSNorm(x, layer0.input_norm)
     kernels::launch_embedding(d_ids, s.w.embed_tokens, x, N, H, st);
-    kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, eps, st);
+    bool hnq = false;
+    bool xnq = norm_q8(x, s.w.layers[0].input_norm, xn, xn_i8, xn_sx);
+    #define XN_PRE (xnq ? xn_i8 : nullptr), (xnq ? xn_sx : nullptr)
+    #define HN_PRE (hnq ? hn_i8 : nullptr), (hnq ? hn_sx : nullptr)
 
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
         if (w.linear_attn) {
             // ---- Gated DeltaNet linear-attention layer ----
-            proj(xn, w.wqkv,      w.wqkv_type,      b8, lqkv,  H);   // qkv
-            proj(xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H);   // z gate
+            proj(xn, w.wqkv,      w.wqkv_type,      b8, lqkv,  H, XN_PRE);   // qkv
+            proj(xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H, XN_PRE);   // z gate
             proj(xn, w.ssm_alpha, w.ssm_alpha_type, la, vh,    H);
             proj(xn, w.ssm_beta,  w.ssm_beta_type,  lb, vh,    H);
             bf16* conv_state = lin_conv_state + (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
@@ -162,9 +198,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
         } else {
             // ---- full softmax-attention layer (q_has_gate, partial RoPE, int8 KV) ----
-            proj(xn, w.wq, w.wq_type, b8, wide,  H);                 // qraw = [q|gate] per head
-            proj(xn, w.wk, w.wk_type, kf, kvdim, H);
-            proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+            proj(xn, w.wq, w.wq_type, b8, wide,  H, XN_PRE);         // qraw = [q|gate] per head
+            proj(xn, w.wk, w.wk_type, kf, kvdim, H, XN_PRE);
+            proj(xn, w.wv, w.wv_type, vf, kvdim, H, XN_PRE);
             kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
             signed char* kpool = (signed char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
             signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
@@ -182,18 +218,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
         // h = x + ao ; hn = RMSNorm(h, post_attn_norm)
         kernels::launch_prefill_add(x, ao, hbuf, (long)N * H, st);
-        kernels::launch_rmsnorm(hbuf, w.post_attn_norm, hn, N, H, eps, st);
+        hnq = norm_q8(hbuf, w.post_attn_norm, hn, hn_i8, hn_sx);
 
         // dense SwiGLU FFN
-        proj(hn, w.gate_q, w.gate_qtype, ffg, ffn, H);
-        proj(hn, w.up_q,   w.up_qtype,   ffu, ffn, H);
-        kernels::launch_prefill_swiglu(ffg, ffu, ffh, (long)N * ffn, st);
-        proj(ffh, w.down_q, w.down_qtype, ao, H, ffn);
+        proj(hn, w.gate_q, w.gate_qtype, ffg, ffn, H, HN_PRE);
+        proj(hn, w.up_q,   w.up_qtype,   ffu, ffn, H, HN_PRE);
+        // swiglu -> int8 directly: ffh is consumed ONLY by the int8 down-proj (n_out=H>=128), so
+        // its bf16 form is never read. Same silu/mul + bf16 staging => bit-identical.
+        bool fhq = fq8 && kernels::launch_prefill_swiglu_q8(ffg, ffu, ffh_i8, ffh_sx, N, ffn, st);
+        if (!fhq) kernels::launch_prefill_swiglu(ffg, ffu, ffh, (long)N * ffn, st);
+        proj(ffh, w.down_q, w.down_qtype, ao, H, ffn,
+             fhq ? ffh_i8 : nullptr, fhq ? ffh_sx : nullptr);
 
         // x = h + ffn_out ; xn = RMSNorm(x, next_input_norm)  (final_norm on the last layer)
         kernels::launch_prefill_add(hbuf, ao, x, (long)N * H, st);
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        xnq = norm_q8(x, next_norm, xn, xn_i8, xn_sx);
     }
 
     // Seed for the first decode step: argmax at the last prompt position (xn already = final norm).


### PR DESCRIPTION
## Summary

Two redundancies in the Qwythos batched-prefill activation path, both bit-identical to remove.

1. **Each activation is quantized once, not 2–3 times.** `xn` feeds 2–3 int8 projections per layer
   (`wq`/`wk`/`wv` on attention layers, `wqkv`/`wqkv_gate` on linear ones) and `hn` feeds 2
   (`gate`/`up`). Every one of those calls `pf_quantize_rows_i8` over the **same bytes**, and that
   kernel reads its input **twice** (once for the row `amax`, once to quantize). This quantizes once
   after the norm and passes the int8 rows + per-row scales to every consumer. `proj()` takes an
   optional pre-quantized `A`; when it is absent the old path runs unchanged.

2. **SwiGLU emits int8 directly.** `ffh` is consumed only by the int8 down-projection
   (`n_out = H = 4096 >= 128`), so its bf16 form is never read by anything. `pf_swiglu_q8` stages the
   row in shared memory, takes the `amax`, and writes int8 — `ffh` is never materialized. On the
   widest tensor in the model (`ffn = 12288`) that is **11 B/elem → 5 B/elem**: previously
   `swiglu` (2+2 read, 2 write) then `quantize` (2×2 read, 1 write); now 2+2 read, 1 write.

nsys on `c9e20d1` put this elementwise+quantize path at **9.4% of prefill** @32k
(`pf_quantize_rows_i8` 4.2%, `pf_swiglu` 2.5%, `pf_add` 1.6%, `rmsnorm` 1.1%). This removes
`pf_quantize_rows_i8` as a standalone kernel and the `ffh` round-trip with it.

`SPARKINFER_PREFILL_FUSED_Q8=0` restores the previous path exactly. The upstream `rmsnorm` and the
stock row-quantizer are **untouched** — only *how often* and *from where* they run changes.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`, driver 580.159.03)

**Decode tok/s** — this PR does not target decode and does not touch the decode path. Rows are a
**no-regression check, not a claimed gain**; the deltas below are run-to-run noise on an idle box:

| ctx | decode tok/s before | after |
|---|--:|--:|
| 4096 | 290.11 | 288.75 |
| 32768 | 289.17 | 288.16 |
| 65536 | 289.15 | 288.83 |

**Prefill pp tok/s** (Qwythos-9B Q4_K_M) — **median of 5**, same binary, same GPU, same run,
`SPARKINFER_PREFILL_FUSED_Q8=0` vs default, via the eval's own sweep path, on an otherwise **idle**
box (0 compute apps). Best context is 64k:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 16466.22 |
| after prefill (this PR) | **16886.69** |

```text
# RTX 5090 sm_120 · main c9e20d1 · median of 5 · idle box · one model load
# SPARKINFER_EVAL_PREFILL=1 SPARKINFER_BENCH_SWEEP_CTXS=4096,32768,65536 \
#   SPARKINFER_BENCH_SWEEP_REPS=5 ./build/runtime/qwen3_gguf_bench <gguf> 128 sweep

### BEFORE (SPARKINFER_PREFILL_FUSED_Q8=0)
SWEEP_JSON {"4096":{"decode_tps":290.1106,"prefill_pp":15890.6356},
            "32768":{"decode_tps":289.1671,"prefill_pp":16564.4032},
            "65536":{"decode_tps":289.1502,"prefill_pp":16466.2196}}

### AFTER (this PR, default)
SWEEP_JSON {"4096":{"decode_tps":288.7516,"prefill_pp":16076.4622},
            "32768":{"decode_tps":288.1578,"prefill_pp":16929.6697},
            "65536":{"decode_tps":288.8292,"prefill_pp":16886.6895}}

ctx=4096    prefill pp  15890.64 -> 16076.46  (+1.17%)
ctx=32768   prefill pp  16564.40 -> 16929.67  (+2.21%)
ctx=65536   prefill pp  16466.22 -> 16886.69  (+2.55%)
```

Reporting all three contexts rather than only the best: the gain is smallest at 4k, where the
fixed per-layer weight-dequant cost dominates and the elementwise path is a smaller share.

## Correctness

Output is **bit-identical to main**, not merely close. `qwen3_gguf_prefill_check` (batched prefill vs
token-by-token fill), 4k prefix / 128 continuation positions — the context the accuracy gate measures:

| @4k, 128 positions | top-1 | KL | seed |
|---|--:|--:|--:|
| before (`FUSED_Q8=0`) | 118/128 = 0.9219 | 0.01433 | 290 |
| **after (this PR)** | **118/128 = 0.9219** | **0.01433** | **290** |

Identical top-1, identical KL, identical sampled seed. Bit-identity holds by construction:

- The **upstream `rmsnorm` is untouched** — its packed-8 `__fmaf_rn` accumulation order is the
  reference, and re-implementing it drifts (measured: KL 0.01433 → 0.01520). Only the *number of
  times its output is quantized* changes, using the **stock** `pf_quantize_rows_i8`.
- `pf_swiglu_q8` keeps the same `silu`/mul math and **stages the row as bf16 before taking the
  `amax`**, so the `amax` sees exactly the bits the materialized bf16 `ffh` would have had, then
  applies the same `amax/127` scale and the same `roundf`.

`launch_prefill_swiglu_q8` / `launch_prefill_rmsnorm_q8` return `false` if the row will not stage in
shared memory, and the caller falls back to the unfused pair — so a wider model degrades to today's
behaviour rather than failing.

## Relation to open PRs

New logic lives in a new file (`kernels/csrc/cuda/fused/prefill_fused_q8.cu`) that no other PR
touches. The shared files are `runtime/src/models/qwen35_prefill.cpp` and
`kernels/include/sparkinfer/kernels/prefill_i8.h`. Flagging explicitly rather than leaning on the
copycat guard: **#482 (`feat(prefill): Qwen3.6 MoE batched prefill + parity fixes`) also modifies
`qwen35_prefill.cpp`.** It is a different change (Qwen3.6 MoE path); this one only alters where the
Qwythos activation quantization happens. Happy to rebase behind #482 whenever it lands.
