### PR TITLE
fix(kernels): write the whole Q head vector in the int8 QK-norm+RoPE kernels (Qwen3.6 top-1 0.66 -> 0.83)

### DIFF
--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -492,13 +492,22 @@ __global__ void qknorm_rope_kv_partial_int8_kernel(
         __syncthreads();
         s_h[t] = __bfloat162float(__float2bfloat16(xv * s_warp[0] * __bfloat162float(q_w[t])));
         __syncthreads();
+        // Rotate in place in s_h, then write back the WHOLE head vector. Writing only the
+        // rotated dims (t < rhalf, i.e. 0..rope_dim-1) left dims rope_dim..head_dim-1 holding
+        // the raw wq projection output — missing both the RMS scale and the q_norm weight —
+        // because s_h above norms all head_dim dims but only rope_dim of them were stored.
+        // At hd256/rope_dim=64 that is 192 of 256 dims (75% of Q) un-normalized on every
+        // int8-KV decode step. Mirrors qknorm_rope_kv_partial_kernel (the bf16 path), which
+        // rotates into s_h and then writes all t < head_dim.
         if (t < rhalf) {
             const float freq = __powf(theta, -2.f * (float)t / (float)rotary_dim);
             const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
             const float x0 = s_h[t], x1 = s_h[t + rhalf];
-            q[base + t]         = __float2bfloat16(x0 * c - x1 * s);
-            q[base + t + rhalf] = __float2bfloat16(x1 * c + x0 * s);
+            s_h[t]         = __bfloat162float(__float2bfloat16(x0 * c - x1 * s));
+            s_h[t + rhalf] = __bfloat162float(__float2bfloat16(x1 * c + x0 * s));
         }
+        __syncthreads();
+        if (t < head_dim) q[base + t] = __float2bfloat16(s_h[t]);
         return;
     }
 
@@ -604,13 +613,20 @@ __global__ void qknorm_rope_kv_partial_int8_gated_kernel(
         __syncthreads();
         s_h[t] = __bfloat162float(__float2bfloat16(xv * s_warp[0] * __bfloat162float(q_w[t])));
         __syncthreads();
+        // Same defect as qknorm_rope_kv_partial_int8_kernel, and worse here: this variant reads
+        // qraw[] and writes a DISTINCT q[] buffer, so storing only t < rhalf left q dims
+        // rope_dim..head_dim-1 not merely un-normalized but STALE — never written by this
+        // kernel, retaining whatever the q arena last held (the previous layer's Q, in
+        // forward_token's launch order). Rotate in s_h, then write the whole head vector.
         if (t < rhalf) {
             const float freq = __powf(theta, -2.f * (float)t / (float)rotary_dim);
             const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
             const float x0 = s_h[t], x1 = s_h[t + rhalf];
-            q[qbase + t]         = __float2bfloat16(x0 * c - x1 * s);
-            q[qbase + t + rhalf] = __float2bfloat16(x1 * c + x0 * s);
+            s_h[t]         = __bfloat162float(__float2bfloat16(x0 * c - x1 * s));
+            s_h[t + rhalf] = __bfloat162float(__float2bfloat16(x1 * c + x0 * s));
         }
+        __syncthreads();
+        if (t < head_dim) q[qbase + t] = __float2bfloat16(s_h[t]);
         return;
     }
 

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -439,13 +439,19 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
         __syncthreads();
         s_h[t] = pf_to_f(__float2bfloat16(xv * s_warp[0] * pf_to_f(q_w[t])));
         __syncthreads();
+        // Rotate in s_h, then write the whole head vector — see qknorm_rope_kv_partial_int8_kernel
+        // (rope.cu). Storing only t < rhalf left dims rope_dim..head_dim-1 (192 of 256 at
+        // hd256/rope_dim=64) holding the raw wq output, un-normalized. The K branch below already
+        // does this correctly via its `else { val = s_h[t]; }` arm; Q was asymmetric with it.
         if (t < rhalf) {
             const float freq = __powf(theta, -2.f * (float)t / (float)rotary_dim);
             const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
             const float x0 = s_h[t], x1 = s_h[t + rhalf];
-            q[base + t]         = __float2bfloat16(x0 * c - x1 * s);
-            q[base + t + rhalf] = __float2bfloat16(x1 * c + x0 * s);
+            s_h[t]         = pf_to_f(__float2bfloat16(x0 * c - x1 * s));
+            s_h[t + rhalf] = pf_to_f(__float2bfloat16(x1 * c + x0 * s));
         }
+        __syncthreads();
+        if (t < head_dim) q[base + t] = __float2bfloat16(s_h[t]);
         return;
     }
 


### PR DESCRIPTION
## Summary

Fixes #517. The gated int8 QK-norm + partial-RoPE decode kernel norms all `head_dim` dims into `s_h` but stores only the rotated ones (`t < rhalf`), so Q dims `rope_dim..head_dim-1` are never written — and since it reads `qraw[]` and writes a distinct `q[]`, they are **stale**, not merely un-normalized. At hd256/`rope_dim=64` that is **192 of 256 dims, 75% of every Q vector**.

This is live on **Qwen3.6-35B-A3B**, the primary SOTA target (`qkgate_fuse` requires `hidden==2048`, `qwen35.cpp:708`; Qwen3.6 is hidden=2048/GQA-8). int8 KV auto-enables at ctx >= 4096 (`qwen3_gguf_bench.cpp:130`, `server/src/model_engine.cpp:80`), so **every benched context >= 4k and every server request past 4k** is affected, at every position. Qwythos (hidden=4096) takes the `rmsnorm_qk` + `rope_kv_append_partial_int8` branch and is unaffected on decode.

The same truncation is in the batched-prefill kernel, which is **not** gated on `hidden` and so is live for **Qwythos prefill** — scored since #383. Its own K branch already writes the full vector; Q was asymmetric with it.

All three hunks mirror the bf16 reference `qknorm_rope_kv_partial_kernel` (`rope.cu:302-312`): rotate in `s_h`, then write all `t < head_dim`. hd128 and every bf16 path are untouched.

## ⚠️ This is a correctness fix with NO speedup — it will need a manual merge

Being explicit so nobody's time is wasted: the decode table below shows **parity, not a gain**, so per the template this earns `needs-benchmark` and the on-device eval will not run. That is correct behaviour, not something to work around. It is the same dynamic that closed #393 and #389 (both since merged manually), and #300 before them.

The box is ticked because it was genuinely run on an RTX 5090 — not to claim a speedup.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — Qwen3.6-35B-A3B UD-Q4_K_M, same box, `qwen3_gguf_bench <gguf> 128 <ctx>`:

| | decode tok/s |
|---|--:|
| before (main `a739958`) | 484.68 @4k · 465.19 @16k · 435.88 @32k |
| after (this PR) | 484.72 @4k · 465.78 @16k · 436.23 @32k |

100.0% / 100.1% / 100.1% — free. The kernel already computed the discarded dims; writing them back is a few stores against a memory-bound step.

**Prefill pp tok/s**: not targeted; unchanged.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a — not a prefill perf change |
| after prefill (this PR) | n/a |

## Correctness evidence (the actual point of this PR)

Qwen3.6-35B-A3B UD-Q4_K_M, 12k-token teacher-forced feed, int8 KV (the benched/served config) vs the exact bf16 KV path. Clean configures, binaries confirmed to differ.

| build | PPL | top-1 |
|---|---:|---:|
| int8 KV, main `a739958` | 3.591 | **0.6631** |
| int8 KV, **this PR** | 5.876 | **0.8302** |
| bf16 KV (exact reference) | 5.400 | 0.8377 |

**+16.7 points of top-1**, landing beside the exact path; the residual 0.75 pt is ordinary int8 KV loss.

The signature is the tell. On main, int8 has *better* PPL (3.591 vs 5.400) but *far worse* argmax (0.663 vs 0.838) — a flattened, corrupted distribution, not a lossy-but-sane one. With this PR, int8 is slightly worse than bf16 on **both** metrics: the physically correct direction. The feed is a tiled corpus, so a healthy model should reach ~90% top-1 by copying from earlier tiles — bf16 does exactly that (68.5% -> 91.0% after the first tile) while main's int8 stays flat at ~65% and never learns to copy.

Qwythos batched-prefill vs token-loop (`qwen3_gguf_prefill_check`), mean KL over the continuation:

| prefix | main | this PR |
|---|---:|---:|
| 4096 | 0.01643 | **0.00525** |
| 6144 | 0.01749 | **0.00717** |

## Scope

| hunk | status |
|---|---|
| `qknorm_rope_kv_partial_int8_gated_kernel` (`rope.cu`) | **live on Qwen3.6 decode** — the substantive fix |
| `pf_qknorm_rope_kv_int8_kernel` (`batched_prefill.cu`) | **live on Qwythos prefill** |
| `qknorm_rope_kv_partial_int8_kernel` (`rope.cu`) | dead today (needs `hidden==2048 && !q_has_gate`, which no model configures); fixed for symmetry so it cannot become live later. Claims nothing. |

## Context

#227 observed this exact divergence on 2026-07-04 (its own table: top-1 **0.75** int8 vs **0.930** bf16), read it as the score tool taking a wrong path, and disabled int8 KV **in the accuracy gate** — while bench and server kept int8 KV on at >= 4k. Full write-up in #517. The consequence is that the published Qwen3.6 quality figures (top-1 0.953 / KL 0.031, and the `bench/quality` tables) are all measured with int8 KV off, i.e. not the shipped configuration, and will need re-measurement once this lands.

Related: this is the fourth defect to reach `main` through the same blind spot (#299 -> #300, #388, #393, this). The `>= 8192` scored probe @reyanthony062001-ops proposes in #388 would have caught all of them; given #227 the stronger form is that **the accuracy gate should run the same KV configuration the benchmark runs**.
