### PR TITLE
harden(eval): add a 3-seed long-context int8-KV probe to the accuracy gate

### DIFF
--- a/bench/scripts/accuracy.sh
+++ b/bench/scripts/accuracy.sh
@@ -35,21 +35,144 @@ python3 "$HERE/gen_eval_prompt.py" "$SEED" "$MODELS_DIR/tokenizer.json" "$HERE/e
 IDS="$(cat "$IDS_FILE")"
 echo ">> eval prompt: seed=$SEED tokens=$(echo "$IDS" | wc -w)"
 
+# H2 (long-context probe): the short prompt above is ~200-360 tokens, so qwen3_gguf_score leaves
+# int8 KV OFF and the gate scores the bf16 tile path — while bench.cpp/model_engine.cpp turn int8 KV
+# ON at every ctx >= 4096. The gate therefore never executed the kernels the tok/s numbers and the
+# server come from, and four correctness defects reached main through that gap (#300, #388, #393,
+# #517), all int8-path-specific.
+#
+# This second pass scores the SHIPPED config — int8 KV on, >= LONG_N held-out tokens — against the
+# SAME llama.cpp reference, over the last LONG_TAIL positions (all past the engagement thresholds):
+#   int8-MMA flash-decode : chunk >= 32 at n_splits=160 -> seqlen >= 4961
+#   sparse KV (Qwythos)   : seqlen >= sparse_min_ctx (8192)
+# llama is queried once per scored position, so we score a TAIL window (long prefix kept warm by
+# cache_prompt) rather than all LONG_N positions.
+#
+# This second pass scores the SHIPPED config — int8 KV on, >= LONG_N held-out tokens — against the
+# SAME llama.cpp reference, over the last LONG_TAIL positions (all past the engagement thresholds):
+#   int8-MMA flash-decode : chunk >= 32 at n_splits=160 -> seqlen >= 4961
+#   sparse KV (Qwythos)   : seqlen >= sparse_min_ctx (8192)
+# llama is queried once per scored position, so we score a TAIL window (long prefix kept warm by
+# cache_prompt) rather than all LONG_N positions.
+#
+# It runs LONG_SEEDS independent held-out streams (derived from the eval SEED) and AVERAGES their
+# top-1 and KL, then VETOES on the mean: mean_top1 < LONG_TOP1_BAR OR mean_kl > LONG_KL_BAR. The bars
+# are deliberately NOT the short pass's — int8 KV is lossy by construction, so a CORRECT int8 build
+# diverges from llama more than bf16 does. They come from a 27-seed sweep on RTX 5090 (Qwen3.6, 8k,
+# tail-128), across all 3-seed combinations of 16 correct (#517-fixed) and 11 broken (#517-live)
+# builds:
+#     metric   correct 3-seed range   broken 3-seed range   bar     false-reject / false-accept
+#     top-1     [0.870, 0.974]         [0.568, 0.786]        >=0.85       0/560   /   0/165
+#     KL        [0.215, 1.367]         [1.444, 2.461]        <=1.5        0/560   /   0/165
+# Single-seed the two KL distributions OVERLAP (correct up to 1.66, broken down to 1.25) and no KL
+# bar works — averaging LONG_SEEDS is what opens the gap. The KL bar (1.5) is far looser than the
+# short pass's (0.20) precisely to allow int8's honest quantization loss: reading that loss as
+# "corruption" and tightening the bar is what turned this probe off in #227 and created the blind
+# spot. In this data top-1 alone already separates cleanly (broken tops out at 0.786), so the KL
+# veto is defense-in-depth against a future bug that spares top-1 but wrecks KL. Reject on EITHER.
+# Margins are ~0.08 (top-1) and ~0.13 (KL) from this corpus/model; re-run the sweep before trusting
+# them on a new model. All bars, the seed count, window, and token length are env-overridable.
+LONGCTX="${SPARKINFER_EVAL_LONGCTX:-1}"
+LONG_N="${SPARKINFER_EVAL_LONGCTX_TOKENS:-8448}"
+LONG_TAIL="${SPARKINFER_EVAL_LONGCTX_TAIL:-128}"
+LONG_SEEDS="${SPARKINFER_EVAL_LONGCTX_SEEDS:-3}"
+LONG_TOP1_BAR="${SPARKINFER_EVAL_LONGCTX_TOP1_BAR:-0.85}"
+LONG_KL_BAR="${SPARKINFER_EVAL_LONGCTX_KL_BAR:-1.5}"
+if [ "$LONGCTX" = "1" ]; then
+  for j in $(seq 0 $((LONG_SEEDS - 1))); do
+    python3 "$HERE/gen_eval_prompt.py" "${SEED}:L${j}" "$MODELS_DIR/tokenizer.json" "$HERE/eval_corpus.txt" \
+            --len "$LONG_N" > "/tmp/eval_ids_long_${j}.txt"
+  done
+  echo ">> long-context probe: ${LONG_SEEDS} seeds from '$SEED', ${LONG_N} tokens each, scored_tail=$LONG_TAIL, int8_kv=1 vs llama"
+fi
+
 echo ">> sparkinfer teacher-forced score ..."
 # Dump top-128 (>= the llama top-k queried in accuracy_compare). A shallow dump made the KL a
 # truncation artifact: any llama-tail token outside sparkinfer's dump was floored (exp(-20)) and
 # massively over-penalized, inflating KL to 0.14-0.33 on flat distributions. With the dump covering
 # llama's query, KL reflects the true ~0.01-0.03 divergence. Scoring-only — no decode-speed impact.
+# All sparkinfer scores run BEFORE the llama server starts, so the ~21 GB model isn't resident twice
+# on the 32 GB card (llama + sparkinfer together OOM the load).
 si_run qwen3_gguf_score "$GGUF" 128 $IDS > /tmp/spark_score.txt 2>/dev/null || true
 if ! grep -q "^PPL" /tmp/spark_score.txt; then   # prebuilt incompatible -> rebuild
   fallback_build "$ARCH"
   si_run qwen3_gguf_score "$GGUF" 128 $IDS > /tmp/spark_score.txt 2>/dev/null
 fi
 
+if [ "$LONGCTX" = "1" ]; then
+  for j in $(seq 0 $((LONG_SEEDS - 1))); do
+    echo ">> sparkinfer long-context score — int8 KV, seed L${j} ..."
+    SPARKINFER_KV_INT8=1 SPARKINFER_SCORE_MAX_SEQ=$((LONG_N + 256)) \
+      si_run qwen3_gguf_score "$GGUF" 128 $(cat "/tmp/eval_ids_long_${j}.txt") > "/tmp/spark_long_int8_${j}.txt" 2>/dev/null || true
+    grep -q "^PPL" "/tmp/spark_long_int8_${j}.txt" || { echo "!! long score L${j} produced no PPL — skipping H2 veto"; LONGCTX=0; break; }
+  done
+fi
+
 echo ">> starting llama.cpp server (reference) ..."
-"$LLAMACPP_DIR/build/bin/llama-server" -m "$GGUF" -ngl 99 -c 2048 --port 8081 --no-jinja >/tmp/llama_srv.log 2>&1 &
+# -c covers the long stream (+ margin); the short pass shares this one server.
+LLAMA_CTX=2048
+[ "$LONGCTX" = "1" ] && LLAMA_CTX=$((LONG_N + 256))
+"$LLAMACPP_DIR/build/bin/llama-server" -m "$GGUF" -ngl 99 -c "$LLAMA_CTX" --port 8081 --no-jinja >/tmp/llama_srv.log 2>&1 &
 SRV=$!; trap 'kill $SRV 2>/dev/null; wait $SRV 2>/dev/null || true' EXIT   # reap server (frees VRAM) before exit
 for _ in $(seq 1 120); do curl -s http://localhost:8081/health 2>/dev/null | grep -q '"ok"' && break; sleep 2; done
 
-echo; echo "=== accuracy: sparkinfer vs llama.cpp ==="
-python3 "$HERE/accuracy_compare.py" /tmp/spark_score.txt "$MODELS_DIR/tokenizer.json" "$IDS_FILE"
+echo; echo "=== accuracy: sparkinfer vs llama.cpp (short, bf16 KV) ==="
+python3 "$HERE/accuracy_compare.py" /tmp/spark_score.txt "$MODELS_DIR/tokenizer.json" "$IDS_FILE" \
+        --metric-label METRIC_SHORT | tee /tmp/acc_short.txt
+
+rm -f /tmp/acc_long.txt
+if [ "$LONGCTX" = "1" ]; then
+  for j in $(seq 0 $((LONG_SEEDS - 1))); do
+    echo; echo "=== accuracy: sparkinfer vs llama.cpp (long-context int8, seed L${j}) ==="
+    python3 "$HERE/accuracy_compare.py" "/tmp/spark_long_int8_${j}.txt" "$MODELS_DIR/tokenizer.json" \
+            "/tmp/eval_ids_long_${j}.txt" http://localhost:8081 64 --tail "$LONG_TAIL" \
+            --metric-label "METRIC_LONG${j}" | tee -a /tmp/acc_long.txt
+  done
+fi
+
+# evaluate.sh parses the single `METRIC ` line (grep 'METRIC ' + head -1; the METRIC_SHORT /
+# METRIC_LONG* diagnostics carry no trailing space so they don't match). The emitted gate is the
+# SHORT vs-llama result — so label.py's existing top1/KL bars are unchanged — but the long pass
+# AVERAGES the LONG_SEEDS runs and VETOES if mean_top1 < LONG_TOP1_BAR OR mean_kl > LONG_KL_BAR.
+# On veto, top1 is forced to 0 (REJECT). The long pass can only reject, never rescue; its bars are
+# long-context/int8-specific and never touch the short pass's bars.
+echo
+LONG_TOP1_BAR="$LONG_TOP1_BAR" LONG_KL_BAR="$LONG_KL_BAR" python3 - /tmp/acc_short.txt /tmp/acc_long.txt <<'PY'
+import re, sys, os
+t1_bar = float(os.environ.get("LONG_TOP1_BAR", "0.85"))
+kl_bar = float(os.environ.get("LONG_KL_BAR", "1.5"))
+def grab_short(path):
+    for line in open(path):
+        m = re.match(r'^METRIC_SHORT top1=([\d.]+) kl=([\d.]+)', line)
+        if m: return float(m.group(1)), float(m.group(2))
+    return None
+def grab_longs(path):
+    out = []
+    if os.path.exists(path):
+        for line in open(path):
+            m = re.match(r'^METRIC_LONG\d+ top1=([\d.]+) kl=([\d.]+)', line)
+            if m: out.append((float(m.group(1)), float(m.group(2))))
+    return out
+short = grab_short(sys.argv[1])
+longs = grab_longs(sys.argv[2]) if len(sys.argv) > 2 else []
+if not short:
+    print("METRIC top1=0 kl=99 ppl_spark=0 ppl_llama=0   (short pass produced nothing)"); sys.exit(1)
+t, k = short
+print(f"  short vs-llama (bf16)  top1={t:.4f} kl={k:.4f}   (gates top1>=0.90, kl<=0.20)")
+if longs:
+    for j, (lt, lk) in enumerate(longs):
+        print(f"  long  L{j} int8-vs-llama  top1={lt:.4f} kl={lk:.4f}")
+    mt = sum(x for x, _ in longs) / len(longs)
+    mk = sum(y for _, y in longs) / len(longs)
+    reasons = []
+    if mt < t1_bar: reasons.append(f"mean top1 {mt:.4f} < {t1_bar:.2f}")
+    if mk > kl_bar: reasons.append(f"mean KL {mk:.4f} > {kl_bar:.2f}")
+    print(f"  long  MEAN of {len(longs)}     top1={mt:.4f} kl={mk:.4f}   (veto if top1<{t1_bar:.2f} or KL>{kl_bar:.2f}){'  -> VETO' if reasons else ''}")
+    if reasons:
+        print(f"=== H2 long-context veto: int8 config diverges from llama ({'; '.join(reasons)}) ===")
+        print(f"METRIC top1=0.000000 kl={mk:.6f} ppl_spark=0 ppl_llama=0"); sys.exit(0)
+else:
+    print("  long  int8-vs-llama  SKIPPED")
+print("=== gate = short vs-llama (long pass did not veto) ===")
+print(f"METRIC top1={t:.6f} kl={k:.6f} ppl_spark=0 ppl_llama=0")
+PY

--- a/bench/scripts/accuracy_compare.py
+++ b/bench/scripts/accuracy_compare.py
@@ -2,6 +2,7 @@
 """Compare sparkinfer vs a running llama.cpp server on the same token sequence.
 
   accuracy_compare.py <spark_score.txt> <tokenizer.json> <text> [server_url] [topk]
+                      [--tail N] [--metric-label NAME]
 
 Reads sparkinfer's teacher-forced score dump (from qwen3_gguf_score) and queries the
 llama.cpp server (/completion, n_probs + cache_prompt) for the same per-position
@@ -9,16 +10,33 @@ distributions, then reports:
   - top-1 token agreement   (argmax_spark == argmax_llama)   -> implementation correctness
   - mean KL(llama || spark) over the top-k union             -> distribution closeness
   - perplexity for each engine (exp(-mean log p(actual next)))
+
+--tail N scores only the LAST N positions of the stream. This is what makes the long-context
+probe affordable: llama is queried once per scored position, so scoring all ~8k positions of a
+long stream would mean ~8k HTTP round-trips. A long prefix with a short scored tail costs N calls
+(cache_prompt keeps the prefix warm) while every scored position sits at a seqlen past the
+int8-MMA and sparse-KV engagement thresholds — which is the whole point of the probe.
+
+--metric-label NAME renames the machine-readable METRIC line (e.g. METRIC_LONG), so accuracy.sh
+can emit several passes and still hand evaluate.sh exactly one unambiguous `METRIC ` line.
 """
 import sys, json, math, urllib.request
 from tokenizers import Tokenizer
 
-score_path, tok_path, text_path = sys.argv[1], sys.argv[2], sys.argv[3]
-URL  = sys.argv[4] if len(sys.argv) > 4 else "http://localhost:8081"
+argv = sys.argv[1:]
+TAIL = 0
+LABEL = "METRIC"
+if "--tail" in argv:
+    i = argv.index("--tail"); TAIL = int(argv[i + 1]); del argv[i:i + 2]
+if "--metric-label" in argv:
+    i = argv.index("--metric-label"); LABEL = argv[i + 1]; del argv[i:i + 2]
+
+score_path, tok_path, text_path = argv[0], argv[1], argv[2]
+URL  = argv[3] if len(argv) > 3 else "http://localhost:8081"
 # llama top-k to query per position. MUST be <= sparkinfer's dump depth (accuracy.sh dumps 128) so
 # every token llama gives mass to is present in sparkinfer's distribution — otherwise it gets FLOOR'd
 # and KL is inflated by a truncation artifact (the metric bug that read 0.14-0.33 instead of ~0.02).
-TOPK = int(sys.argv[5]) if len(sys.argv) > 5 else 64
+TOPK = int(argv[4]) if len(argv) > 4 else 64
 FLOOR = -20.0
 
 # 3rd arg is either a file of space-separated token ids (the EXACT prompt scored — produced by
@@ -46,7 +64,8 @@ for line in open(score_path):
     spark[i] = {"am": am, "lp": lp, "top": top}
 
 match = n = 0; snll = lnll = 0.0; klsum = 0.0
-for i in range(len(ids) - 1):
+lo = max(0, (len(ids) - 1) - TAIL) if TAIL > 0 else 0
+for i in range(lo, len(ids) - 1):
     if i not in spark: continue
     ld = llama_dist(ids[:i + 1]); lam = max(ld, key=ld.get); n += 1
     if spark[i]["am"] == lam: match += 1
@@ -59,10 +78,14 @@ for i in range(len(ids) - 1):
         if pp > 0: kl += pp * math.log(pp / max(qq, 1e-12))
     klsum += kl
 
-print(f"positions             : {n}")
+if n == 0:
+    print(f"{LABEL} top1=0 kl=99 ppl_spark=0 ppl_llama=0   (NO SCORED POSITIONS)")
+    sys.exit(1)
+print(f"positions             : {n}" + (f"  (tail {TAIL} of {len(ids)})" if TAIL else ""))
+print(f"scored range          : {lo}..{len(ids) - 2}  (seqlen {lo + 1}..{len(ids) - 1})")
 print(f"token-match (top-1)   : {match}/{n} = {match/n:.3f}   (bar >= 0.90)")
 print(f"mean KL(llama||spark) : {klsum/n:.4f} nats  (top-k approx)")
 print(f"PPL sparkinfer        : {math.exp(snll/n):.3f}  (exact, full softmax)")
 print(f"PPL llama.cpp         : {math.exp(lnll/n):.3f}  (top-{TOPK}+floor; inflated)")
 # unambiguous machine-readable line for evaluate.sh (avoid parsing the human text above)
-print(f"METRIC top1={match/n:.6f} kl={klsum/n:.6f} ppl_spark={math.exp(snll/n):.4f} ppl_llama={math.exp(lnll/n):.4f}")
+print(f"{LABEL} top1={match/n:.6f} kl={klsum/n:.6f} ppl_spark={math.exp(snll/n):.4f} ppl_llama={math.exp(lnll/n):.4f}")

--- a/bench/scripts/gen_eval_prompt.py
+++ b/bench/scripts/gen_eval_prompt.py
@@ -8,26 +8,55 @@ run; this picks a random window of a diverse multi-domain corpus and a fuzzed to
 The PR author can't know which slice will be scored, so correctness must generalize. The seed is
 recorded in the eval log, so any third party reproduces the exact token stream and verdict.
 
-Usage:  gen_eval_prompt.py <seed> <tokenizer.json> <corpus.txt> [fixed_text.txt]
+Usage:  gen_eval_prompt.py <seed> <tokenizer.json> <corpus.txt> [fixed_text.txt] [--len N]
 Prints a space-separated list of token ids (the same format accuracy.sh feeds qwen3_gguf_score).
 If <fixed_text.txt> is given AND seed=="fixed", reproduces the legacy fixed prompt (for bench.sh).
+
+--len N emits a LONG stream of exactly N ids for the long-context probe (accuracy.sh's second
+pass). The corpus is ~1.3k tokens, far short of the >= 8k needed to engage the int8-MMA and
+sparse-KV kernels, so the stream is built by tiling seed-shuffled paragraph orders: every tile is
+a fresh shuffle, so the result is long, non-degenerate, and still unpredictable to a submission —
+the same H1 held-out property as the short prompt. --len is a no-op under seed=="fixed"+fixed_text,
+which must stay byte-reproducible for bench.sh.
 """
 import sys, random
 from tokenizers import Tokenizer
 
 
+def build_long(rng, tok, paras, n_target):
+    """Tile seed-shuffled paragraph orders until n_target ids, then truncate exactly."""
+    ids, tile = [], 0
+    while len(ids) < n_target:
+        order = list(paras)
+        rng.shuffle(order)
+        ids.extend(tok.encode(f"\n\n[section {tile}]\n\n" + "\n\n".join(order)).ids)
+        tile += 1
+    return ids[:n_target]
+
+
 def main():
-    seed, tok_path, corpus_path = sys.argv[1], sys.argv[2], sys.argv[3]
-    fixed = sys.argv[4] if len(sys.argv) > 4 else ""
+    argv = [a for a in sys.argv[1:]]
+    n_long = 0
+    if "--len" in argv:
+        i = argv.index("--len")
+        n_long = int(argv[i + 1])
+        del argv[i:i + 2]
+    seed, tok_path, corpus_path = argv[0], argv[1], argv[2]
+    fixed = argv[3] if len(argv) > 3 else ""
     tok = Tokenizer.from_file(tok_path)
 
-    if seed == "fixed" and fixed:
+    if seed == "fixed" and fixed and not n_long:
         ids = tok.encode(open(fixed).read().strip()).ids
         print(" ".join(map(str, ids)))
         return
 
     rng = random.Random(seed)            # seed is a string; Random hashes it deterministically
     paras = [p.strip() for p in open(corpus_path).read().split("\n\n") if p.strip()]
+
+    if n_long:
+        print(" ".join(map(str, build_long(rng, tok, paras, n_long))))
+        return
+
     # pick a random run of 2..5 adjacent paragraphs (held-out: which slice is unknown to the PR)
     k = rng.randint(2, min(5, len(paras)))
     start = rng.randint(0, max(0, len(paras) - k))

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -46,10 +46,20 @@ int main(int argc, char** argv) {
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
     kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
-    // int8 KV is the Qwen3-MoE head_dim=128 tensor-core path; Qwen3.6 (hybrid, gated head_dim=256)
-    // writes bf16 KV. Scoring with int8 KV on the hybrid model corrupts attention -> false accuracy
-    // divergence vs llama.cpp. Mirror generate.cpp: bf16 KV for hybrid.
-    // Context-adaptive int8 KV for hybrid (>= 4k fed length) so accuracy gate matches bench at 4k.
+    // int8 KV default mirrors the SHIPPED config, so scoring reflects what actually runs:
+    //   non-hybrid (Qwen3-MoE, hd128) always ships int8 KV -> default int8.
+    //   hybrid (Qwen3.6/Qwythos, hd256) ships int8 KV at ctx >= 4096 (bench.cpp:130,
+    //     server/model_engine.cpp:80) -> context-adaptive on fed length.
+    // SPARKINFER_KV_INT8 forces it either way, which is how accuracy.sh drives its two passes:
+    // the short prompt (< 4096) scores the hybrid bf16 path, the long probe forces int8 on.
+    //
+    // History: this comment used to claim "Qwen3.6 (hybrid, gated head_dim=256) writes bf16 KV ...
+    // scoring with int8 KV corrupts attention -> FALSE accuracy divergence" (#227). The divergence
+    // was REAL, not false — the gated int8 QK-norm+RoPE kernel left 75% of every Q vector stale
+    // (#517). The gate feeding only ~101 tokens meant hybrid always landed on the bf16 side of this
+    // ternary, hiding that bug for two weeks and creating the blind spot #388 and #393 also shipped
+    // through. Do NOT narrow this to dodge a divergence: if the int8 path disagrees with llama.cpp,
+    // that is the gate working — see the long-context probe in accuracy.sh.
     { const char* e = getenv("SPARKINFER_KV_INT8");
       kvc.int8_kv = e ? (e[0] != '0') : (cfg.hybrid ? ((argc - 3) >= 4096) : true); }
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;


### PR DESCRIPTION
## Summary

Closes the blind spot behind four correctness defects (#300, #388, #393, #517): the accuracy gate scored a ~200-360 token prompt, which leaves int8 KV **off** on hybrid models, so it only ever exercised the bf16 tile path. `bench.cpp:130` and `server/model_engine.cpp:80` turn int8 KV **on** at every ctx >= 4096 — so the gate never executed the kernels the tok/s numbers and the server come from. Every one of those four bugs was int8/long-context specific, and each was found by a contributor doing unrelated work rather than by the gate.

Root cause of the blind spot: **#227** (2026-07-04) observed the int8 divergence (top-1 0.75 int8 vs 0.930 bf16), read int8 KV's honest quantization loss as a tool misconfiguration, and disabled int8 KV in the gate — while bench and server kept it on. That divergence was a **real bug** (#517: the gated int8 QK-norm+RoPE kernel left 75% of every Q vector stale).

## What it adds

A long-context pass, scoring the **shipped** config against the **same** llama.cpp reference:

- **short pass** — sparkinfer bf16 vs llama, ~256 tokens. **Unchanged.** Emits the `METRIC` line `label.py` already reads (top1 >= 0.90, KL <= 0.20).
- **long pass** — sparkinfer **int8 KV** vs llama over `LONG_SEEDS` (default 3) held-out >= 8448-token streams derived from the eval seed, scored on the last 128 positions of each (all past the int8-MMA `seqlen>=4961` and sparse `seqlen>=8192` thresholds), then **averaged**. Vetoes if `mean top-1 < 0.85` OR `mean KL > 1.5`. On veto the emitted `METRIC` is forced to `top1=0` (REJECT). The long pass can only reject, never rescue.

`label.py` and `evaluate.sh` are untouched — the single `METRIC ` line they parse now reflects both passes (the `METRIC_SHORT` / `METRIC_LONG*` diagnostics carry no trailing space, so the existing `grep 'METRIC '` ignores them).

## Bars are calibrated, not guessed

From a **27-seed sweep** on RTX 5090 (Qwen3.6-35B-A3B UD-Q4_K_M, 8k, tail-128), over **all** 3-seed combinations of 16 correct (#517-fixed) and 11 broken (#517-live) builds:

| metric | correct 3-seed range | broken 3-seed range | bar | false-reject | false-accept |
|---|---|---|---|---|---|
| top-1 | [0.870, 0.974] | [0.568, 0.786] | >= 0.85 | 0/560 | 0/165 |
| KL | [0.215, 1.367] | [1.444, 2.461] | <= 1.5 | 0/560 | 0/165 |

Two findings the sweep forced (single-seed calibration was misleading and I do not recommend trusting it):

1. **The KL bar must be loose (1.5, vs the short pass's 0.20).** int8 KV is lossy by construction — a correct build's int8-vs-llama KL centers at **0.66** and reaches **1.37** on hard content. A KL bar of 0.5 false-rejects **72%** of correct builds; 0.3 rejects 96%. Tightening it is precisely the #227 mistake. (bf16 KV can't serve as a tighter reference here — it **OOMs at 8k** on a 32 GB card, which is *why* the shipped long-context config is int8 in the first place.)
2. **Averaging is what makes any KL gate viable.** Single-seed, the correct and broken KL distributions **overlap** (correct up to 1.66, broken down to 1.25) — no KL bar works. 3-seed averaging tightens both and opens the `[1.367, 1.444]` gap that 1.5 sits above.

In this data **top-1 alone already separates** (broken tops out at 0.786), so the KL veto is **defense-in-depth** against a future bug that spares top-1 but wrecks KL. Reject on EITHER.

## End-to-end validation

Seed `harden-517`, 3-seed, on the two commits around #517 (`a739958` without the fix, `e7c2014` with):

| arm | mean top-1 | mean KL | gate |
|---|---|---|---|
| #517 **live** | 0.664 | 1.93 | **VETO** (both) -> REJECT |
| #517 **fixed** | 0.919 | 0.78 | passes both -> short result flows through |

## Cost & knobs

The long pass adds 3 int8 scores + ~384 cache-warm llama calls per eval (a few minutes). All bars, seed count, window, and token length are env-overridable: `SPARKINFER_EVAL_LONGCTX_TOP1_BAR` (0.85), `_KL_BAR` (1.5), `_SEEDS` (3), `_TAIL` (128), `_TOKENS` (8448); `SPARKINFER_EVAL_LONGCTX=0` disables the pass entirely.

## Caveats for the reviewer

- **The bars are corpus- and model-specific.** Calibrated on Qwen3.6 + the current eval corpus. Qwythos or a new target needs its own sweep before these bars are trusted — flagged in the code and commit.
- **`qwen3_gguf_score.cpp`:** default `int8_kv` logic is **unchanged** (still `hybrid ? fed_len>=4096 : true`, so Qwen3-MoE still scores its shipped int8 path); only the misleading #227 comment is corrected.
- This touches a **maintainer-owned path** (`bench/scripts/`). Opening as a PR for review/discussion per CONTRIBUTING.md; not to be self-merged without a second look at the bar calibration.

