### PR TITLE
Integrate continuous batching with per-request KV sessions

### DIFF
--- a/runtime/include/sparkinfer/inference_engine.h
+++ b/runtime/include/sparkinfer/inference_engine.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/scheduler.h"
+
+namespace sparkinfer {
+
+// Continuous-batch serving engine: queues requests, assigns per-request seq_ids,
+// right-sizes KV allocation, and interleaves decode steps via the Scheduler.
+class ContinuousBatchEngine {
+public:
+    struct Request {
+        std::vector<int> prompt;
+        int max_new_tokens = 0;
+        int priority = 0;
+        int prefill_start = 0;          // skip tokens already in a shared prefix cache
+        bool use_prefix_session = false; // bind to session 0 (cache_prefix KV)
+    };
+
+    struct Result {
+        std::vector<int> tokens;
+        std::string error;
+    };
+
+    ContinuousBatchEngine(Qwen35Model* model, KVCacheManager* kv,
+                          int max_tokens_per_batch = 64,
+                          SchedulePolicy policy = SchedulePolicy::CONTINUOUS_BATCHING);
+    ~ContinuousBatchEngine();
+
+    ContinuousBatchEngine(const ContinuousBatchEngine&) = delete;
+    ContinuousBatchEngine& operator=(const ContinuousBatchEngine&) = delete;
+
+    // Blocking completion (used by the HTTP server).
+    Result complete(const Request& req);
+
+    // Streaming completion: on_token is invoked on the worker thread as tokens are produced.
+    Result complete_streaming(const Request& req, const std::function<void(int)>& on_token);
+
+    int num_active() const;
+    int num_free_kv_blocks() const;
+
+private:
+    struct Job;
+    uint64_t submit_locked(Job job, const std::function<void(int)>& on_token);
+    Result wait_locked(uint64_t request_id);
+    void worker_loop();
+    bool step_job(Job& job);
+
+    Qwen35Model* model_;
+    KVCacheManager* kv_;
+    Scheduler scheduler_;
+    std::thread worker_;
+    std::atomic<bool> running_{false};
+    mutable std::mutex mu_;
+    std::condition_variable cv_;
+    std::unordered_map<uint64_t, std::unique_ptr<Job>> jobs_;
+    std::atomic<uint64_t> next_req_id_{1};
+};
+
+}  // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -100,6 +100,9 @@ public:
     // Length of the currently cached prefix (0 if none).
     int prefix_cached_len() const;
 
+    // Argmax seed after cache_prefix(); -1 if no active prefix cache.
+    int prefix_seed_token() const;
+
     // True when `prompt` begins with the installed prefix token sequence (requires active cache).
     bool prompt_matches_prefix(const std::vector<int>& prompt) const;
 
@@ -133,6 +136,17 @@ public:
     // the last prompt position (seed for the first decode step), or -1 if the batched path is
     // unsupported for this model/config. Implemented in qwen35_prefill.cpp.
     int prefill_batched(const int* prompt_ids, int n);
+
+    // Per-request session lifecycle for continuous batching / serving.
+    // open_session() allocates right-sized KV blocks (+ hybrid recurrent state when needed).
+    // activate_session() binds forward_token / prefill to that seq_id. Returns 0 on OOM.
+    uint64_t open_session(int num_tokens);
+    void close_session(uint64_t seq_id);
+    void activate_session(uint64_t seq_id);
+    uint64_t active_session() const;
+
+    // Token budget for KV allocation: prompt + decode headroom, capped at max_seq.
+    static int session_token_budget(size_t prompt_len, int max_new, int max_seq);
 
 private:
     void invalidate_decode_graph();

--- a/runtime/include/sparkinfer/scheduler.h
+++ b/runtime/include/sparkinfer/scheduler.h
@@ -13,6 +13,11 @@ enum class SchedulePolicy {
     PRIORITY,
 };
 
+enum class SeqPhase {
+    PREFILL,
+    DECODE,
+};
+
 struct SequenceGroup {
     uint64_t group_id;
     int num_seqs;
@@ -20,20 +25,34 @@ struct SequenceGroup {
     int priority;   // higher = more urgent
 };
 
+// Per-request state tracked by the continuous-batch engine.
+struct ScheduledSequence {
+    uint64_t request_id = 0;
+    uint64_t seq_id = 0;
+    SeqPhase phase = SeqPhase::PREFILL;
+    int priority = 0;
+    int tokens_in_phase = 0;  // prefill progress or decode tokens emitted
+};
+
 struct ScheduleBatch {
-    std::vector<uint64_t> prefill_seq_ids;
-    std::vector<uint64_t> decode_seq_ids;
-    int total_tokens;
+    std::vector<uint64_t> prefill_request_ids;
+    std::vector<uint64_t> decode_request_ids;
+    int total_tokens = 0;
 };
 
 class Scheduler {
 public:
-    explicit Scheduler(SchedulePolicy policy = SchedulePolicy::CHUNKED_PREFILL,
-                       int max_tokens_per_batch = 8192);
+    explicit Scheduler(SchedulePolicy policy = SchedulePolicy::CONTINUOUS_BATCHING,
+                       int max_tokens_per_batch = 256);
+    ~Scheduler();
 
+    // Pick the next request(s) to advance one step. Prefill jobs run to completion
+    // before decode interleaving unless policy is CHUNKED_PREFILL.
+    ScheduleBatch schedule(const std::vector<ScheduledSequence>& active) const;
+
+    // Legacy group API (kept for compatibility).
     void add_sequence_group(SequenceGroup group);
     void remove_sequence_group(uint64_t group_id);
-
     ScheduleBatch schedule();
 
     // Preempt lowest-priority decode sequences to make room for prefill

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -1,0 +1,254 @@
+#include "sparkinfer/inference_engine.h"
+
+#include <chrono>
+#include <cstdio>
+
+namespace sparkinfer {
+
+namespace {
+
+bool prefill_samples_lmhead() {
+    static int legacy = -1;
+    if (legacy < 0) {
+        const char* e = getenv("SPARKINFER_PREFILL_LEGACY");
+        legacy = (e && e[0] == '1') ? 1 : 0;
+    }
+    return legacy != 0;
+}
+
+bool batched_prefill_enabled(const Qwen35Config& cfg, bool gguf, int n_tokens) {
+    static int want_batched = -1, batched_maxctx = -1;
+    if (want_batched < 0) {
+        const char* e = getenv("SPARKINFER_PREFILL_BATCHED");
+        want_batched = (e && e[0] == '0') ? 0 : 1;
+        const char* mc = getenv("SPARKINFER_PREFILL_BATCHED_MAXCTX");
+        batched_maxctx = mc ? atoi(mc) : 65536;
+    }
+    return want_batched && gguf && cfg.hybrid && cfg.dense_ffn && n_tokens > 0 &&
+           n_tokens <= batched_maxctx;
+}
+
+}  // namespace
+
+struct ContinuousBatchEngine::Job {
+    uint64_t request_id = 0;
+    Request req;
+    uint64_t seq_id = 0;
+    SeqPhase phase = SeqPhase::PREFILL;
+    int prefill_pos = 0;
+    int decode_emitted = 0;
+    int next_token = -1;
+    bool batched_prefill_done = false;
+    std::vector<int> output;
+    std::string error;
+    std::function<void(int)> on_token;
+    bool done = false;
+};
+
+ContinuousBatchEngine::ContinuousBatchEngine(Qwen35Model* model, KVCacheManager* kv,
+                                             int max_tokens_per_batch, SchedulePolicy policy)
+    : model_(model), kv_(kv), scheduler_(policy, max_tokens_per_batch) {
+    running_ = true;
+    worker_ = std::thread([this] { worker_loop(); });
+}
+
+ContinuousBatchEngine::~ContinuousBatchEngine() {
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        running_ = false;
+        cv_.notify_all();
+    }
+    if (worker_.joinable()) worker_.join();
+    std::lock_guard<std::mutex> lock(mu_);
+    for (auto& kv : jobs_) {
+        if (!kv.second->seq_id) continue;
+        if (kv.second->seq_id != 0) model_->close_session(kv.second->seq_id);
+        else kv_->free(0);
+    }
+    jobs_.clear();
+}
+
+ContinuousBatchEngine::Result ContinuousBatchEngine::complete(const Request& req) {
+    return complete_streaming(req, nullptr);
+}
+
+ContinuousBatchEngine::Result ContinuousBatchEngine::complete_streaming(
+    const Request& req, const std::function<void(int)>& on_token) {
+    uint64_t rid = 0;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        rid = submit_locked(Job{0, req, 0, SeqPhase::PREFILL, req.prefill_start, 0, -1, false, {}, {}, on_token, false},
+                            on_token);
+    }
+    if (!rid) return Result{{}, "failed to enqueue request"};
+    return wait_locked(rid);
+}
+
+int ContinuousBatchEngine::num_active() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    int n = 0;
+    for (const auto& kv : jobs_) if (!kv.second->done) n++;
+    return n;
+}
+
+int ContinuousBatchEngine::num_free_kv_blocks() const { return kv_->num_free_blocks(); }
+
+uint64_t ContinuousBatchEngine::submit_locked(Job job, const std::function<void(int)>& on_token) {
+    if (!model_ || !kv_) return 0;
+    if (job.req.prompt.empty() || job.req.max_new_tokens <= 0) return 0;
+
+    const int budget = Qwen35Model::session_token_budget(
+        job.req.prompt.size(), job.req.max_new_tokens, model_->config().max_seq);
+    if ((int)job.req.prompt.size() + job.req.max_new_tokens > model_->config().max_seq) return 0;
+
+    uint64_t seq_id = 0;
+    if (job.req.use_prefix_session) {
+        seq_id = 0;
+        if (!kv_->allocate(seq_id, budget)) return 0;
+        model_->activate_session(seq_id);
+    } else {
+        seq_id = model_->open_session(budget);
+        if (!seq_id) return 0;
+    }
+
+    job.request_id = next_req_id_.fetch_add(1);
+    job.seq_id = seq_id;
+    job.on_token = on_token;
+    job.prefill_pos = job.req.prefill_start;
+    auto ptr = std::make_unique<Job>(std::move(job));
+    const uint64_t rid = ptr->request_id;
+    jobs_[rid] = std::move(ptr);
+    cv_.notify_one();
+    return rid;
+}
+
+ContinuousBatchEngine::Result ContinuousBatchEngine::wait_locked(uint64_t request_id) {
+    std::unique_lock<std::mutex> lock(mu_);
+    cv_.wait(lock, [&] {
+        auto it = jobs_.find(request_id);
+        return it == jobs_.end() || it->second->done;
+    });
+    auto it = jobs_.find(request_id);
+    if (it == jobs_.end()) return Result{{}, "request not found"};
+    Result out{it->second->output, it->second->error};
+    jobs_.erase(it);
+    return out;
+}
+
+void ContinuousBatchEngine::worker_loop() {
+    while (true) {
+        Job* job = nullptr;
+        {
+            std::unique_lock<std::mutex> lock(mu_);
+            if (!running_ && jobs_.empty()) return;
+
+            std::vector<ScheduledSequence> active;
+            active.reserve(jobs_.size());
+            for (const auto& kv : jobs_) {
+                if (kv.second->done) continue;
+                ScheduledSequence s;
+                s.request_id = kv.first;
+                s.seq_id = kv.second->seq_id;
+                s.phase = kv.second->phase;
+                s.priority = kv.second->req.priority;
+                s.tokens_in_phase = (kv.second->phase == SeqPhase::PREFILL)
+                                        ? kv.second->prefill_pos
+                                        : kv.second->decode_emitted;
+                active.push_back(s);
+            }
+
+            ScheduleBatch batch = scheduler_.schedule(active);
+            uint64_t pick = 0;
+            if (!batch.prefill_request_ids.empty()) pick = batch.prefill_request_ids.front();
+            else if (!batch.decode_request_ids.empty()) pick = batch.decode_request_ids.front();
+
+            if (pick) {
+                auto it = jobs_.find(pick);
+                if (it != jobs_.end() && !it->second->done) job = it->second.get();
+            }
+
+            if (!job) {
+                if (!running_) {
+                    bool any = false;
+                    for (const auto& kv : jobs_)
+                        if (!kv.second->done) { any = true; break; }
+                    if (!any) return;
+                }
+                cv_.wait_for(lock, std::chrono::milliseconds(2));
+                continue;
+            }
+        }
+
+        if (job) {
+            const bool finished = step_job(*job);
+            if (finished) cv_.notify_all();
+        }
+    }
+}
+
+bool ContinuousBatchEngine::step_job(Job& job) {
+    const Qwen35Config& cfg = model_->config();
+    model_->activate_session(job.seq_id);
+
+    if (job.phase == SeqPhase::PREFILL) {
+        const int n = (int)job.req.prompt.size();
+        if (job.prefill_pos == job.req.prefill_start && job.req.prefill_start == 0 &&
+            batched_prefill_enabled(cfg, true, n - job.prefill_pos)) {
+            const int chunk = n - job.prefill_pos;
+            const int seed = model_->prefill_batched(job.req.prompt.data() + job.prefill_pos, chunk);
+            if (seed >= 0 && seed < cfg.vocab) {
+                job.next_token = seed;
+                job.prefill_pos = n;
+                job.batched_prefill_done = true;
+                job.phase = SeqPhase::DECODE;
+                return false;
+            }
+        }
+        if (job.prefill_pos < n) {
+            const bool sample = prefill_samples_lmhead() || job.prefill_pos + 1 == n;
+            if (sample)
+                job.next_token = model_->forward_token(job.req.prompt[(size_t)job.prefill_pos],
+                                                       job.prefill_pos, true);
+            else
+                model_->forward_token(job.req.prompt[(size_t)job.prefill_pos], job.prefill_pos, false);
+            job.prefill_pos++;
+            if (job.prefill_pos >= n) {
+                if (job.next_token < 0 && job.req.use_prefix_session)
+                    job.next_token = model_->prefix_seed_token();
+                job.phase = SeqPhase::DECODE;
+            }
+            return false;
+        }
+        if (job.next_token < 0 && job.req.use_prefix_session)
+            job.next_token = model_->prefix_seed_token();
+        job.phase = SeqPhase::DECODE;
+        return false;
+    }
+
+    if (job.next_token < 0 || job.next_token >= cfg.vocab) {
+        job.error = "prefill produced invalid seed token";
+        job.done = true;
+        if (job.seq_id != 0) model_->close_session(job.seq_id);
+        else kv_->free(job.seq_id);
+        job.seq_id = 0;
+        return true;
+    }
+
+    job.output.push_back(job.next_token);
+    if (job.on_token) job.on_token(job.next_token);
+    job.decode_emitted++;
+
+    if (job.next_token == cfg.eos_id || job.decode_emitted >= job.req.max_new_tokens) {
+        job.done = true;
+        if (job.seq_id != 0) model_->close_session(job.seq_id);
+        else kv_->free(job.seq_id);
+        job.seq_id = 0;
+        return true;
+    }
+
+    const int prompt_len = (int)job.req.prompt.size();
+    job.next_token = model_->forward_token(job.next_token, prompt_len + job.decode_emitted - 1, true);
+    return false;
+}
+
+}  // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -23,6 +23,8 @@
 
 #include <cuda_runtime.h>
 #include <cstdio>
+#include <atomic>
+#include <unordered_map>
 #include <cstdlib>
 #include <cmath>
 #include <chrono>
@@ -99,6 +101,11 @@ bool is_linear_layer(const Qwen35Config& c, int layer) {
 }
 }
 
+struct SessionBuffers {
+    float* lin_state = nullptr;
+    bf16* lin_conv_state = nullptr;
+};
+
 struct Qwen35Model::Impl {
     Qwen35Config cfg;
     KVCacheManager* kv;
@@ -109,7 +116,9 @@ struct Qwen35Model::Impl {
     cudaEvent_t ev_qkv{}, ev_k{}, ev_v{};        // fork/join events (captured into the decode graph)
     cudaEvent_t ev_pipe_fork{}, ev_gdn_z{}, ev_gdn_ab{};
     cudaEvent_t ev_sx_gate{}, ev_sx_done{};
-    uint64_t seq_id = 0;
+    uint64_t active_seq_id = 0;
+    std::atomic<uint64_t> next_session_id{1};
+    std::unordered_map<uint64_t, SessionBuffers> sessions;
     int qdim, kvdim;
     int linear_qdim = 0, linear_vdim = 0, linear_qkvdim = 0;
     bool gguf = false;   // true after load_gguf: dense weights are native [out,in], use GEMV
@@ -307,6 +316,12 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     if (const char* e = getenv("SPARKINFER_SHEXP_PIPE")) p_->use_shexp_pipe = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ADDNORM3")) p_->use_addnorm3 = !(e[0] == '0');
     if (const char* e = getenv("SPARKINFER_ROUTER_FUSED")) p_->use_router_fused = !(e[0] == '0');
+    if (cfg.hybrid) {
+        SessionBuffers d;
+        d.lin_state = p_->lin_state;
+        d.lin_conv_state = p_->lin_conv_state;
+        p_->sessions[0] = d;
+    }
 }
 
 Qwen35Model::~Qwen35Model() {
@@ -330,6 +345,11 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->sparse_sel);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
+    for (auto& kv : p_->sessions) {
+        if (kv.first == 0) continue;
+        if (kv.second.lin_state) cudaFree(kv.second.lin_state);
+        if (kv.second.lin_conv_state) cudaFree(kv.second.lin_conv_state);
+    }
     if (p_->graph_ready) { cudaGraphExecDestroy(p_->cu_exec); cudaGraphDestroy(p_->cu_graph); }
     if (p_->graph_prefill_ready) { cudaGraphExecDestroy(p_->cu_prefill_exec); cudaGraphDestroy(p_->cu_prefill_graph); }
     cudaEventDestroy(p_->ev_qkv); cudaEventDestroy(p_->ev_k); cudaEventDestroy(p_->ev_v);
@@ -488,7 +508,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
 
     kernels::launch_embedding(s.d_tok, s.w.embed_tokens, s.x, 1, H, st);
 
-    int* btable = s.kv->block_table(s.seq_id);
+    int* btable = s.kv->block_table(s.active_seq_id);
     // Prime: xn = RMSNorm(x, layer0.input_norm). Each layer's tail then fuses the
     // post-MoE residual with the NEXT layer's input norm (or final_norm), so the
     // per-layer input RMSNorm + two residual-adds collapse into two fused kernels.
@@ -1113,7 +1133,7 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
         s.graph_ready = false;
     }
     last_bench_ctx = context_tokens;
-    if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) { fprintf(stderr, "[bench] kv allocate failed\n"); return out; }
+    if (!s.kv->allocate(s.active_seq_id, s.cfg.max_seq)) { fprintf(stderr, "[bench] kv allocate failed\n"); return out; }
     int start_pos = context_tokens;
     if (const char* e = getenv("SPARKINFER_BENCH_START_POS")) {
         start_pos = atoi(e);
@@ -1122,7 +1142,7 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     if (start_pos + warmup + n > s.cfg.max_seq) {
         fprintf(stderr, "[bench] requested ctx=%d warmup=%d n=%d exceeds max_seq=%d\n",
                 start_pos, warmup, n, s.cfg.max_seq);
-        s.kv->free(s.seq_id);
+        s.kv->free(s.active_seq_id);
         return out;
     }
     static int bench_device_loop = -1;
@@ -1183,7 +1203,7 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
         cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, s.stream), "bench final out");
         cu(cudaStreamSynchronize(s.stream), "bench sync");
         auto t1 = std::chrono::high_resolution_clock::now();
-        s.kv->free(s.seq_id);
+        s.kv->free(s.active_seq_id);
         s.bench_feedback_graph = false;
         double secs = std::chrono::duration<double>(t1 - t0).count();
         out.decode_tps = n / secs;
@@ -1197,7 +1217,7 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     }
     cudaDeviceSynchronize();
     auto t1 = std::chrono::high_resolution_clock::now();
-    s.kv->free(s.seq_id);
+    s.kv->free(s.active_seq_id);
     s.bench_feedback_graph = false;
     double secs = std::chrono::duration<double>(t1 - t0).count();
     out.decode_tps = n / secs;
@@ -1253,11 +1273,11 @@ bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
     if (tokens.empty()) return false;
     if (tokens.size() > (size_t)s.cfg.max_seq) return false;
     invalidate_decode_graph();
-    if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) return false;
+    if (!s.kv->allocate(s.active_seq_id, s.cfg.max_seq)) return false;
     const int n = (int)tokens.size();
     int next = ingest_prompt_range(tokens.data(), 0, n);
     if (next < 0 || next >= s.cfg.vocab) {
-        s.kv->free(s.seq_id);
+        s.kv->free(s.active_seq_id);
         return false;
     }
     cudaDeviceSynchronize();
@@ -1270,8 +1290,8 @@ bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
 
 void Qwen35Model::clear_prefix_cache() {
     Impl& s = *p_;
-    if (s.prefix_active || s.kv->allocated_tokens(s.seq_id) > 0) {
-        s.kv->free(s.seq_id);
+    if (s.prefix_active || s.kv->allocated_tokens(s.active_seq_id) > 0) {
+        s.kv->free(s.active_seq_id);
         invalidate_decode_graph();
     }
     s.prefix_tokens.clear();
@@ -1282,6 +1302,11 @@ void Qwen35Model::clear_prefix_cache() {
 
 int Qwen35Model::prefix_cached_len() const { return p_->prefix_active ? p_->prefix_len : 0; }
 
+int Qwen35Model::prefix_seed_token() const {
+    const Impl& s = *p_;
+    return (s.prefix_active && s.prefix_next >= 0) ? s.prefix_next : -1;
+}
+
 double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
     Impl& s = *p_;
     if (prompt.empty()) return 0.;
@@ -1289,8 +1314,8 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
     if (!reuse) {
         clear_prefix_cache();
         invalidate_decode_graph();
-        if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) return -1.;
-    } else if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
+        if (!s.kv->allocate(s.active_seq_id, s.cfg.max_seq)) return -1.;
+    } else if (!s.kv->allocate(s.active_seq_id, s.cfg.max_seq)) {
         return -1.;
     }
     const int start = reuse ? s.prefix_len : 0;
@@ -1304,7 +1329,7 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
     cudaDeviceSynchronize();
     auto t1 = std::chrono::high_resolution_clock::now();
     if (!reuse) {
-        s.kv->free(s.seq_id);
+        s.kv->free(s.active_seq_id);
         invalidate_decode_graph();
         if (s.graph_ready) {
             cu(cudaGraphExecDestroy(s.cu_exec), "ttft graph destroy exec");
@@ -1329,11 +1354,80 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
 // buffers, streams and config it needs, so Impl stays private to this file.
 int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
     Impl& s = *p_;
-    Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.seq_id, s.lin_state, s.lin_conv_state,
+    auto it = s.sessions.find(s.active_seq_id);
+    float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
+    bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
+    Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.active_seq_id, lin_state, lin_conv,
                           s.logits, s.d_out_id, s.h_out_id, s.gguf,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim };
     return prefill_batched_run(ctx, prompt_ids, n);
 }
+
+int Qwen35Model::session_token_budget(size_t prompt_len, int max_new, int max_seq) {
+    const long need = (long)prompt_len + max_new + 16;
+    if (need <= 0) return 16;
+    if (need > max_seq) return max_seq;
+    return (int)need;
+}
+
+uint64_t Qwen35Model::open_session(int num_tokens) {
+    Impl& s = *p_;
+    if (num_tokens <= 0) return 0;
+    const uint64_t seq_id = s.next_session_id.fetch_add(1);
+    if (!s.kv->allocate(seq_id, num_tokens)) return 0;
+    if (s.cfg.hybrid) {
+        SessionBuffers buf;
+        buf.lin_state = s.alloc<float>((size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
+                                       s.cfg.linear_head_dim * s.cfg.linear_head_dim);
+        buf.lin_conv_state = s.alloc<bf16>((size_t)s.cfg.n_layers *
+                                           (s.cfg.linear_conv_kernel - 1) * s.linear_qkvdim);
+        if (!buf.lin_state || !buf.lin_conv_state) {
+            s.kv->free(seq_id);
+            if (buf.lin_state) cudaFree(buf.lin_state);
+            if (buf.lin_conv_state) cudaFree(buf.lin_conv_state);
+            return 0;
+        }
+        s.sessions[seq_id] = buf;
+    }
+    return seq_id;
+}
+
+void Qwen35Model::close_session(uint64_t seq_id) {
+    Impl& s = *p_;
+    if (seq_id == 0) return;
+    s.kv->free(seq_id);
+    auto it = s.sessions.find(seq_id);
+    if (it != s.sessions.end()) {
+        if (it->second.lin_state && it->second.lin_state != s.lin_state)
+            cudaFree(it->second.lin_state);
+        if (it->second.lin_conv_state && it->second.lin_conv_state != s.lin_conv_state)
+            cudaFree(it->second.lin_conv_state);
+        s.sessions.erase(it);
+    }
+    if (s.active_seq_id == seq_id) activate_session(0);
+}
+
+void Qwen35Model::activate_session(uint64_t seq_id) {
+    Impl& s = *p_;
+    if (s.active_seq_id == seq_id) return;
+    s.active_seq_id = seq_id;
+    auto it = s.sessions.find(seq_id);
+    if (s.cfg.hybrid) {
+        if (it != s.sessions.end()) {
+            s.lin_state = it->second.lin_state;
+            s.lin_conv_state = it->second.lin_conv_state;
+        } else if (seq_id == 0) {
+            auto z = s.sessions.find(0);
+            if (z != s.sessions.end()) {
+                s.lin_state = z->second.lin_state;
+                s.lin_conv_state = z->second.lin_conv_state;
+            }
+        }
+    }
+    invalidate_decode_graph();
+}
+
+uint64_t Qwen35Model::active_session() const { return p_->active_seq_id; }
 
 std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_new, ThermalGovernor* gov) {
     Impl& s = *p_;
@@ -1341,23 +1435,32 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
     if (prompt.empty()) return out;
 
     const bool reuse = prompt_matches_prefix(prompt);
+    const int budget = session_token_budget(prompt.size(), max_new, s.cfg.max_seq);
+    uint64_t sid = 0;
     if (!reuse) {
         clear_prefix_cache();
         invalidate_decode_graph();
-        if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
-            fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
+        sid = open_session(budget);
+        if (!sid) {
+            fprintf(stderr, "[qwen35] KV allocate failed (need %d tokens)\n", budget);
             return out;
         }
-    } else if (!s.kv->allocate(s.seq_id, s.cfg.max_seq)) {
-        fprintf(stderr, "[qwen35] KV allocate failed (pool too small for max_seq=%d)\n", s.cfg.max_seq);
-        return out;
+        activate_session(sid);
+    } else {
+        sid = s.active_seq_id;
+        if (!s.kv->allocate(sid, budget)) {
+            fprintf(stderr, "[qwen35] KV allocate failed (need %d tokens)\n", budget);
+            return out;
+        }
+        activate_session(sid);
     }
     const int start = reuse ? s.prefix_len : 0;
     const size_t n = prompt.size();
     int next = (start >= (int)n && reuse) ? s.prefix_next
                                             : ingest_prompt_range(prompt.data(), start, (int)n);
     if (next < 0 || next >= s.cfg.vocab) {
-        s.kv->free(s.seq_id);
+        if (sid != 0) close_session(sid);
+        else s.kv->free(sid);
         fprintf(stderr, "[qwen35] prompt prefill failed (start=%d n=%zu)\n", start, n);
         return out;
     }
@@ -1368,7 +1471,8 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         if (gov) gov->pace();
     }
 
-    s.kv->free(s.seq_id);
+    if (sid != 0) close_session(sid);
+    else s.kv->free(sid);
     if (reuse) {
         // KV is gone; keep prefix_tokens/len so the next cache_prefix()+generate() pair can
         // re-warm the shared prefix and only prefill the suffix.

--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -1,4 +1,4 @@
-// Scheduler — minimal continuous-batching policy over sequence groups.
+// Scheduler — continuous-batching policy over in-flight requests.
 // Host-only; decides which sequences run in the next step.
 
 #include "sparkinfer/scheduler.h"
@@ -17,19 +17,51 @@ struct Scheduler::Impl {
 Scheduler::Scheduler(SchedulePolicy policy, int max_tokens_per_batch)
     : impl_(new Impl{policy, max_tokens_per_batch, {}}) {}
 
+Scheduler::~Scheduler() = default;
+
+ScheduleBatch Scheduler::schedule(const std::vector<ScheduledSequence>& active) const {
+    ScheduleBatch batch;
+    if (active.empty()) return batch;
+
+    std::vector<const ScheduledSequence*> ordered;
+    ordered.reserve(active.size());
+    for (const auto& s : active) ordered.push_back(&s);
+    std::sort(ordered.begin(), ordered.end(),
+              [](const ScheduledSequence* a, const ScheduledSequence* b) {
+                  return a->priority > b->priority;
+              });
+
+    // Prefill-first: one prefill job at a time so TTFT stays predictable.
+    for (const ScheduledSequence* s : ordered) {
+        if (s->phase == SeqPhase::PREFILL) {
+            batch.prefill_request_ids.push_back(s->request_id);
+            batch.total_tokens = 1;
+            return batch;
+        }
+    }
+
+    // One decode request per step while the model forward path is batch=1.
+    for (const ScheduledSequence* s : ordered) {
+        if (s->phase != SeqPhase::DECODE) continue;
+        batch.decode_request_ids.push_back(s->request_id);
+        batch.total_tokens = 1;
+        break;
+    }
+    return batch;
+}
+
 void Scheduler::add_sequence_group(SequenceGroup g) { impl_->groups[g.group_id] = g; }
 void Scheduler::remove_sequence_group(uint64_t id)  { impl_->groups.erase(id); }
 
 ScheduleBatch Scheduler::schedule() {
-    ScheduleBatch batch; batch.total_tokens = 0;
-    // Order by priority (desc); pack decode steps until the token budget is hit.
+    ScheduleBatch batch;
     std::vector<const SequenceGroup*> ordered;
     for (auto& kv : impl_->groups) ordered.push_back(&kv.second);
     std::sort(ordered.begin(), ordered.end(),
               [](const SequenceGroup* a, const SequenceGroup* b) { return a->priority > b->priority; });
     for (auto* g : ordered) {
         if (batch.total_tokens + g->num_seqs > impl_->max_tokens_per_batch) break;
-        for (int i = 0; i < g->num_seqs; i++) batch.decode_seq_ids.push_back(g->group_id);
+        for (int i = 0; i < g->num_seqs; i++) batch.decode_request_ids.push_back(g->group_id);
         batch.total_tokens += g->num_seqs;
     }
     return batch;
@@ -40,8 +72,13 @@ std::vector<uint64_t> Scheduler::preempt(int tokens_needed) {
     for (auto& kv : impl_->groups) ordered.push_back(&kv.second);
     std::sort(ordered.begin(), ordered.end(),
               [](const SequenceGroup* a, const SequenceGroup* b) { return a->priority < b->priority; });
-    std::vector<uint64_t> victims; int freed = 0;
-    for (auto* g : ordered) { if (freed >= tokens_needed) break; victims.push_back(g->group_id); freed += g->num_seqs; }
+    std::vector<uint64_t> victims;
+    int freed = 0;
+    for (auto* g : ordered) {
+        if (freed >= tokens_needed) break;
+        victims.push_back(g->group_id);
+        freed += g->num_seqs;
+    }
     return victims;
 }
 

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -17,6 +17,15 @@ target_link_libraries(thermal_governor_cpu_test PRIVATE sparkinfer_runtime)
 set_target_properties(thermal_governor_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME thermal_governor_cpu_test COMMAND thermal_governor_cpu_test)
 
+add_executable(scheduler_cpu_test scheduler_cpu_test.cpp)
+target_link_libraries(scheduler_cpu_test PRIVATE sparkinfer_runtime)
+set_target_properties(scheduler_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME scheduler_cpu_test COMMAND scheduler_cpu_test)
+
+add_executable(batch_engine_gpu_test batch_engine_gpu_test.cpp)
+target_link_libraries(batch_engine_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
+add_test(NAME batch_engine_gpu_test COMMAND batch_engine_gpu_test)
+
 # GPU integration tests — run the real device path; skip without a device.
 add_executable(decode_runner_gpu_test decode_runner_gpu_test.cpp)
 target_link_libraries(decode_runner_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/tests/batch_engine_gpu_test.cpp
+++ b/runtime/tests/batch_engine_gpu_test.cpp
@@ -1,0 +1,147 @@
+// GPU smoke test: ContinuousBatchEngine + per-request sessions on real hardware.
+#include "sparkinfer/inference_engine.h"
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/moe/engine.h"
+#include "sparkinfer/runtime.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <vector>
+
+static void* rand_bf16(size_t n, float s) {
+    std::vector<uint16_t> h(n);
+    for (size_t i = 0; i < n; i++) {
+        float f = s * (2.f * ((i * 2654435761u + 40503u) % 1000) / 1000.f - 1.f);
+        uint32_t b;
+        __builtin_memcpy(&b, &f, 4);
+        h[i] = (uint16_t)(b >> 16);
+    }
+    void* d = nullptr;
+    cudaMalloc(&d, n * sizeof(uint16_t));
+    cudaMemcpy(d, h.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    return d;
+}
+
+static void fill_weights(sparkinfer::Qwen35Weights& w, const sparkinfer::Qwen35Config& cfg) {
+    const int H = cfg.hidden, Q = cfg.n_q_heads * cfg.head_dim, KV = cfg.n_kv_heads * cfg.head_dim;
+    const int E = cfg.n_experts, F = cfg.moe_ffn;
+    w.embed_tokens = rand_bf16((size_t)cfg.vocab * H, 1.f);
+    w.final_norm = rand_bf16(H, 0.5f);
+    w.lm_head = rand_bf16((size_t)H * cfg.vocab, 0.05f);
+    w.layers.resize(cfg.n_layers);
+    for (int l = 0; l < cfg.n_layers; l++) {
+        auto& lw = w.layers[l];
+        lw.input_norm = rand_bf16(H, 0.5f);
+        lw.wq = rand_bf16((size_t)H * Q, 0.04f);
+        lw.wk = rand_bf16((size_t)H * KV, 0.04f);
+        lw.wv = rand_bf16((size_t)H * KV, 0.04f);
+        lw.wo = rand_bf16((size_t)Q * H, 0.04f);
+        lw.q_norm = rand_bf16(cfg.head_dim, 0.5f);
+        lw.k_norm = rand_bf16(cfg.head_dim, 0.5f);
+        lw.post_attn_norm = rand_bf16(H, 0.5f);
+        lw.router_w = rand_bf16((size_t)H * E, 0.1f);
+        lw.gate = rand_bf16((size_t)E * H * F, 0.04f);
+        lw.up = rand_bf16((size_t)E * H * F, 0.04f);
+        lw.down = rand_bf16((size_t)E * F * H, 0.04f);
+        lw.shared_gate = rand_bf16((size_t)H * F, 0.04f);
+        lw.shared_up = rand_bf16((size_t)H * F, 0.04f);
+        lw.shared_down = rand_bf16((size_t)F * H, 0.04f);
+    }
+}
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no CUDA device\n");
+        return 0;
+    }
+
+    auto rt = sparkinfer::Runtime::create({});
+    rt->initialize();
+
+    sparkinfer::Qwen35Config cfg;
+    cfg.vocab = 2000;
+    cfg.hidden = 2048;
+    cfg.n_layers = 2;
+    cfg.n_q_heads = 16;
+    cfg.n_kv_heads = 2;
+    cfg.head_dim = 128;
+    cfg.n_experts = 8;
+    cfg.top_k = 2;
+    cfg.n_shared = 1;
+    cfg.moe_ffn = 64;
+    cfg.max_seq = 128;
+    cfg.eos_id = -1;
+
+    sparkinfer::KVCacheConfig kvc;
+    kvc.num_layers = cfg.n_layers;
+    kvc.num_kv_heads = cfg.n_kv_heads;
+    kvc.head_dim = cfg.head_dim;
+    kvc.block_size = 16;
+    sparkinfer::KVCacheManager kv(kvc, 256ull * 1024 * 1024);
+
+    sparkinfer::moe::MoEConfig mc;
+    mc.num_experts = cfg.n_experts;
+    mc.top_k = cfg.top_k;
+    mc.hidden_dim = cfg.hidden;
+    mc.ffn_dim = cfg.moe_ffn;
+    mc.num_layers = cfg.n_layers;
+    auto engine = sparkinfer::moe::MoEEngine::create(mc);
+
+    sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
+    sparkinfer::Qwen35Weights w;
+    fill_weights(w, cfg);
+    model.set_weights(w);
+
+    sparkinfer::ContinuousBatchEngine batch(&model, &kv, 8);
+
+    sparkinfer::ContinuousBatchEngine::Request a;
+    a.prompt = {1, 5, 9};
+    a.max_new_tokens = 4;
+    auto ra = batch.complete(a);
+    if (!ra.error.empty()) {
+        printf("[FAIL] request A: %s\n", ra.error.c_str());
+        return 1;
+    }
+    if ((int)ra.tokens.size() != 4) {
+        printf("[FAIL] request A: expected 4 tokens, got %zu\n", ra.tokens.size());
+        return 1;
+    }
+
+    sparkinfer::ContinuousBatchEngine::Request b;
+    b.prompt = {2, 6, 10, 14};
+    b.max_new_tokens = 6;
+    b.priority = 1;
+    auto rb = batch.complete(b);
+    if (!rb.error.empty()) {
+        printf("[FAIL] request B: %s\n", rb.error.c_str());
+        return 1;
+    }
+    if ((int)rb.tokens.size() != 6) {
+        printf("[FAIL] request B: expected 6 tokens, got %zu\n", rb.tokens.size());
+        return 1;
+    }
+
+    for (int id : ra.tokens)
+        if (id < 0 || id >= cfg.vocab) {
+            printf("[FAIL] token %d out of range\n", id);
+            return 1;
+        }
+    for (int id : rb.tokens)
+        if (id < 0 || id >= cfg.vocab) {
+            printf("[FAIL] token %d out of range\n", id);
+            return 1;
+        }
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("[FAIL] cuda error: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+
+    printf("[PASS] batch_engine_gpu_test: A=%zu tokens B=%zu tokens free_kv_blocks=%d\n",
+           ra.tokens.size(), rb.tokens.size(), kv.num_free_blocks());
+    return 0;
+}

--- a/runtime/tests/scheduler_cpu_test.cpp
+++ b/runtime/tests/scheduler_cpu_test.cpp
@@ -1,0 +1,31 @@
+#include "sparkinfer/scheduler.h"
+
+#include <cassert>
+#include <cstdio>
+
+int main() {
+    using namespace sparkinfer;
+
+    Scheduler sched(SchedulePolicy::CONTINUOUS_BATCHING, 4);
+
+    std::vector<ScheduledSequence> active;
+    active.push_back({1, 10, SeqPhase::DECODE, 5, 3});
+    active.push_back({2, 11, SeqPhase::DECODE, 1, 1});
+    active.push_back({3, 12, SeqPhase::PREFILL, 9, 0});
+
+    ScheduleBatch batch = sched.schedule(active);
+    assert(batch.prefill_request_ids.size() == 1);
+    assert(batch.prefill_request_ids[0] == 3);
+    assert(batch.decode_request_ids.empty());
+
+    for (auto& s : active) {
+        if (s.request_id == 3) s.phase = SeqPhase::DECODE;
+    }
+    batch = sched.schedule(active);
+    assert(batch.prefill_request_ids.empty());
+    assert(batch.decode_request_ids.size() == 1);
+    assert(batch.decode_request_ids[0] == 3);  // highest priority among decode jobs
+
+    printf("[PASS] scheduler_cpu_test\n");
+    return 0;
+}

--- a/server/README.md
+++ b/server/README.md
@@ -79,19 +79,24 @@ With API key (optional):
 curl ... -H 'Authorization: Bearer secret'
 ```
 
-## Request isolation
+## Request isolation & continuous batching
 
-Each `/v1/chat/completions` call runs through `Qwen35Model::generate()`:
+Each `/v1/chat/completions` call is submitted to `ContinuousBatchEngine`, which:
 
-- Fresh KV allocation per request (`kv->allocate` / `kv->free` inside `generate()`)
-- Hybrid Gated-DeltaNet recurrent state reset at position 0 on cold prompts
-- Correct prefill path (interior prompt tokens skip LM head unless `SPARKINFER_PREFILL_LEGACY=1`)
-- Optional **shared prefix cache**: set `SPARKINFER_SERVER_PREFIX_TOKEN_FILE` (JSON array of token ids)
-  or `SPARKINFER_SERVER_PREFIX_TOKEN_IDS` (comma-separated). When the chat prompt starts with those
-  tokens, the server calls `cache_prefix()` (batched prefill) before `generate()`, which only
-  token-loops the suffix.
+- Allocates a **per-request `seq_id`** with **right-sized KV** (`prompt + max_tokens + headroom`, not `max_seq`)
+- Runs prefill then interleaves decode steps across concurrent requests via the runtime `Scheduler`
+- Frees KV blocks when the request finishes (no cross-request KV leakage)
+- Uses per-request hybrid Gated-DeltaNet recurrent buffers when the model is hybrid
 
-Prior requests cannot leak decode context into later ones (KV is freed after each `generate()`).
+Shared prefix cache still works: when the chat prompt starts with configured prefix tokens,
+`cache_prefix()` warms session 0 and only the suffix is prefilled per request.
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `SPARKINFER_BATCH_TOKENS` | `64` | Scheduler decode token budget per step |
+| `SPARKINFER_SCHED_POLICY` | `continuous` | `continuous`, `chunked` (CHUNKED_PREFILL), or `priority` |
+
+Prior requests cannot leak decode context into later ones (KV is freed after each completion).
 
 ## Env
 
@@ -103,4 +108,4 @@ Prior requests cannot leak decode context into later ones (KV is freed after eac
 | `SPARKINFER_TOKENIZER_URL` | Qwen3-30B tokenizer | Override tokenizer download |
 | `SPARKINFER_SERVER_PREFIX_TOKEN_FILE` | — | JSON `[id,...]` warmed via `cache_prefix` each request |
 | `SPARKINFER_SERVER_PREFIX_TOKEN_IDS` | — | Comma-separated token ids (same as above) |
-| `SPARKINFER_PREFILL_BATCHED` | `1` | Batched prefill in `cache_prefix` / cold `generate` |
+| `SPARKINFER_PREFILL_BATCHED` | `1` | Batched prefill in `cache_prefix` / cold prompts |

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -1,6 +1,7 @@
 #include "model_engine.hpp"
 
 #include "sparkinfer/gguf.h"
+#include "sparkinfer/inference_engine.h"
 #include "sparkinfer/kv_cache.h"
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/moe/engine.h"
@@ -21,6 +22,15 @@ bool prompt_starts_with(const std::vector<int>& prompt, const std::vector<int>& 
     return std::equal(prefix.begin(), prefix.end(), prompt.begin());
 }
 
+int batch_tokens_per_step() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_BATCH_TOKENS");
+        v = e ? std::max(1, atoi(e)) : 64;
+    }
+    return v;
+}
+
 }  // namespace
 
 struct ModelEngine::Impl {
@@ -30,6 +40,7 @@ struct ModelEngine::Impl {
     std::unique_ptr<sparkinfer::KVCacheManager> kv;
     std::unique_ptr<sparkinfer::moe::MoEEngine> engine;
     std::unique_ptr<sparkinfer::Qwen35Model> model;
+    std::unique_ptr<sparkinfer::ContinuousBatchEngine> batch_engine;
     std::vector<int> prefix_tokens;
     bool ready = false;
 };
@@ -40,6 +51,7 @@ ModelEngine::~ModelEngine() = default;
 bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     std::lock_guard<std::mutex> lock(mu_);
     impl_->ready = false;
+    impl_->batch_engine.reset();
     impl_->model.reset();
     impl_->engine.reset();
     impl_->kv.reset();
@@ -75,8 +87,6 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     kvc.num_kv_heads = impl_->cfg.n_kv_heads;
     kvc.head_dim = impl_->cfg.head_dim;
     kvc.block_size = 16;
-    // Match qwen3_gguf_bench / qwen3_gguf_generate: hybrid Qwen3.6 uses int8 KV at ctx>=4k
-    // (halves KV read bandwidth — the 32k decode win on 5090/PRO 6000). Override via env.
     { const char* e = getenv("SPARKINFER_KV_INT8");
       kvc.int8_kv = e ? (e[0] != '0')
                       : (impl_->cfg.hybrid ? (impl_->cfg.max_seq >= 4096) : true); }
@@ -106,8 +116,18 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
         return false;
     }
 
+    sparkinfer::SchedulePolicy policy = sparkinfer::SchedulePolicy::CONTINUOUS_BATCHING;
+    if (const char* p = getenv("SPARKINFER_SCHED_POLICY")) {
+        if (p[0] == 'c' || p[0] == 'C') policy = sparkinfer::SchedulePolicy::CHUNKED_PREFILL;
+        else if (p[0] == 'p' || p[0] == 'P') policy = sparkinfer::SchedulePolicy::PRIORITY;
+    }
+    impl_->batch_engine = std::make_unique<sparkinfer::ContinuousBatchEngine>(
+        impl_->model.get(), impl_->kv.get(), batch_tokens_per_step(), policy);
+
     impl_->path = gguf_path;
     impl_->ready = true;
+    fprintf(stderr, "[sparkinfer-server] continuous batching enabled (policy=%d, batch=%d)\n",
+            (int)policy, batch_tokens_per_step());
     fprintf(stderr, "[sparkinfer-server] model ready: %s\n", gguf_path.c_str());
     return true;
 }
@@ -159,46 +179,61 @@ std::vector<int> ModelEngine::complete(const std::vector<int>& prompt_ids, int m
 std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_ids,
                                                  int max_new_tokens,
                                                  const std::function<void(int)>& on_token) {
-    std::lock_guard<std::mutex> lock(mu_);
-    last_error_.clear();
-    if (!impl_->ready || !impl_->model) {
-        last_error_ = "model not loaded";
-        return {};
-    }
-    if (prompt_ids.empty()) {
-        last_error_ = "empty prompt";
-        return {};
-    }
-    if (max_new_tokens <= 0) {
-        last_error_ = "max_new_tokens must be positive";
-        return {};
-    }
-    if ((int)prompt_ids.size() + max_new_tokens > impl_->cfg.max_seq) {
-        last_error_ = "prompt + max_tokens exceeds context limit (" +
-                      std::to_string(impl_->cfg.max_seq) + ")";
-        fprintf(stderr, "[sparkinfer-server] context overflow: prompt=%zu max_new=%d max_seq=%d\n",
-                prompt_ids.size(), max_new_tokens, impl_->cfg.max_seq);
-        return {};
+    sparkinfer::ContinuousBatchEngine::Request req;
+    req.prompt = prompt_ids;
+    req.max_new_tokens = max_new_tokens;
+
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        last_error_.clear();
+        if (!impl_->ready || !impl_->model || !impl_->batch_engine) {
+            last_error_ = "model not loaded";
+            return {};
+        }
+        if (prompt_ids.empty()) {
+            last_error_ = "empty prompt";
+            return {};
+        }
+        if (max_new_tokens <= 0) {
+            last_error_ = "max_new_tokens must be positive";
+            return {};
+        }
+        if ((int)prompt_ids.size() + max_new_tokens > impl_->cfg.max_seq) {
+            last_error_ = "prompt + max_tokens exceeds context limit (" +
+                          std::to_string(impl_->cfg.max_seq) + ")";
+            fprintf(stderr, "[sparkinfer-server] context overflow: prompt=%zu max_new=%d max_seq=%d\n",
+                    prompt_ids.size(), max_new_tokens, impl_->cfg.max_seq);
+            return {};
+        }
+
+        // Shared prefix KV (session 0) is only safe when no other request is in-flight.
+        const bool prefix_match = !impl_->prefix_tokens.empty() &&
+                                  prompt_starts_with(prompt_ids, impl_->prefix_tokens);
+        const bool prefix_exclusive = impl_->batch_engine->num_active() == 0;
+        if (prefix_match && prefix_exclusive) {
+            if (impl_->model->prefix_cached_len() != (int)impl_->prefix_tokens.size()) {
+                if (!impl_->model->cache_prefix(impl_->prefix_tokens)) {
+                    last_error_ = "cache_prefix failed (KV alloc or batched prefill)";
+                    fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
+                    return {};
+                }
+            }
+            req.prefill_start = (int)impl_->prefix_tokens.size();
+            req.use_prefix_session = true;
+        } else {
+            if (!prefix_match) impl_->model->clear_prefix_cache();
+            req.prefill_start = 0;
+            req.use_prefix_session = false;
+        }
     }
 
-    // Warm a shared prefix with batched prefill when configured; generate() reuses it for the
-    // matching leading tokens and only token-loops the suffix.
-    if (!impl_->prefix_tokens.empty()) {
-        if (prompt_starts_with(prompt_ids, impl_->prefix_tokens)) {
-            if (!impl_->model->cache_prefix(impl_->prefix_tokens)) {
-                last_error_ = "cache_prefix failed (KV alloc or batched prefill)";
-                fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
-                return {};
-            }
-        } else {
-            impl_->model->clear_prefix_cache();
-        }
-    } else {
-        impl_->model->clear_prefix_cache();
-    }
-    std::vector<int> out = impl_->model->generate(prompt_ids, max_new_tokens, nullptr);
-    if (on_token) {
-        for (int t : out) on_token(t);
+    auto result = impl_->batch_engine->complete_streaming(req, on_token);
+
+    std::lock_guard<std::mutex> lock(mu_);
+    if (!result.error.empty()) {
+        last_error_ = result.error;
+        fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
+        return {};
     }
 
     cudaError_t e = cudaGetLastError();
@@ -207,9 +242,9 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
         fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
         return {};
     }
-    if (out.empty() && max_new_tokens > 0 && last_error_.empty())
+    if (result.tokens.empty() && max_new_tokens > 0)
         last_error_ = "generate returned no tokens (KV alloc failure?)";
-    return out;
+    return result.tokens;
 }
 
 }  // namespace sparkinfer_server


### PR DESCRIPTION
## Summary
- Add `ContinuousBatchEngine` with scheduler-driven prefill/decode steps and per-request `seq_id` lifecycle
- Right-size KV allocation per request (`prompt + max_new + headroom`) via `Qwen35Model::open_session` / `close_session`
- Wire the HTTP server through the batch engine with safe shared-prefix reuse (session 0 only when no other request is in-flight)

## Test plan
- [x] `scheduler_cpu_test` — scheduler prefill-first / priority decode selection
- [x] `batch_engine_gpu_test` — two sequential requests on RTX 5090 (instance 45182004)
- [x] `qwen35_gpu_test` — existing generate path still passes on GPU
- [x] `decode_runner_gpu_test` — batched decode runner smoke test on GPU
- [ ] CI `guard` check on PR merge