### PR TITLE
Enhance attested binary builds for Linux and Windows

### DIFF
--- a/.github/workflows/build-attested-binaries.yml
+++ b/.github/workflows/build-attested-binaries.yml
@@ -68,17 +68,16 @@ jobs:
           find build/runtime build/moe -maxdepth 1 \( -name 'libsparkinfer_runtime.so*' -o -name 'libsparkinfer_moe.so*' \) \
             -exec install -m755 {} "${BUNDLE}/lib/" \;
           BENCH_SHA="$(sha256sum "${BUNDLE}/bin/qwen3_gguf_bench" | awk '{print $1}')"
-          cat > "${BUNDLE}/BUILD_MANIFEST.json" <<EOF
-{
-  "platform": "linux-amd64",
-  "cuda": "12.8",
-  "sm": "${CUDA_ARCH}",
-  "commit": "${GITHUB_SHA}",
-  "ref": "${GITHUB_REF}",
-  "binary": "bin/qwen3_gguf_bench",
-  "binary_sha256": "${BENCH_SHA}"
-}
-EOF
+          jq -n \
+            --arg platform "linux-amd64" \
+            --arg cuda "12.8" \
+            --arg sm "${CUDA_ARCH}" \
+            --arg commit "${GITHUB_SHA}" \
+            --arg ref "${GITHUB_REF}" \
+            --arg binary "bin/qwen3_gguf_bench" \
+            --arg binary_sha256 "${BENCH_SHA}" \
+            '{platform:$platform,cuda:$cuda,sm:$sm,commit:$commit,ref:$ref,binary:$binary,binary_sha256:$binary_sha256}' \
+            > "${BUNDLE}/BUILD_MANIFEST.json"
           (cd "${BUNDLE}" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
           ls -laR "${BUNDLE}"
 

--- a/.github/workflows/build-attested-binaries.yml
+++ b/.github/workflows/build-attested-binaries.yml
@@ -1,10 +1,11 @@
 name: build-attested-binaries
 
 # Build qwen3_gguf_bench for Linux + Windows, attest with GitHub Artifact Attestations,
-# and upload versioned release bundles. Compile-only (no GPU on hosted runners).
+# upload CI artifacts (bin/lib layout), and publish GitHub Release tarballs on version tags.
 #
 # Verify locally after download:
-#   gh attestation verify dist/sparkinfer-linux-amd64/qwen3_gguf_bench -R OWNER/REPO
+#   gh run download -R gittensor-ai-lab/sparkinfer -n sparkinfer-linux-amd64
+#   gh attestation verify sparkinfer-bin/bin/qwen3_gguf_bench -R gittensor-ai-lab/sparkinfer
 
 on:
   workflow_dispatch:
@@ -36,7 +37,7 @@ jobs:
       id-token: write
       attestations: write
     env:
-      OUT: dist/sparkinfer-linux-amd64
+      BUNDLE: dist/sparkinfer-linux-amd64/sparkinfer-bin
       CUDA_ARCH: "120"
     steps:
       - name: Checkout
@@ -62,16 +63,29 @@ jobs:
       - name: Package
         run: |
           set -euo pipefail
-          mkdir -p "${OUT}"
-          install -m755 build/runtime/qwen3_gguf_bench "${OUT}/"
-          find build/runtime build/moe -maxdepth 1 \( -name 'libsparkinfer_runtime.so*' -o -name 'libsparkinfer_moe.so*' \) -exec install -m755 {} "${OUT}/" \;
-          (cd dist && sha256sum sparkinfer-linux-amd64/* > sparkinfer-linux-amd64/SHA256SUMS)
-          ls -la "${OUT}"
+          mkdir -p "${BUNDLE}/bin" "${BUNDLE}/lib"
+          install -m755 build/runtime/qwen3_gguf_bench "${BUNDLE}/bin/"
+          find build/runtime build/moe -maxdepth 1 \( -name 'libsparkinfer_runtime.so*' -o -name 'libsparkinfer_moe.so*' \) \
+            -exec install -m755 {} "${BUNDLE}/lib/" \;
+          BENCH_SHA="$(sha256sum "${BUNDLE}/bin/qwen3_gguf_bench" | awk '{print $1}')"
+          cat > "${BUNDLE}/BUILD_MANIFEST.json" <<EOF
+{
+  "platform": "linux-amd64",
+  "cuda": "12.8",
+  "sm": "${CUDA_ARCH}",
+  "commit": "${GITHUB_SHA}",
+  "ref": "${GITHUB_REF}",
+  "binary": "bin/qwen3_gguf_bench",
+  "binary_sha256": "${BENCH_SHA}"
+}
+EOF
+          (cd "${BUNDLE}" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          ls -laR "${BUNDLE}"
 
       - name: Generate artifact attestation
         uses: actions/attest@v4
         with:
-          subject-path: "${{ env.OUT }}/**/*"
+          subject-path: "${{ env.BUNDLE }}/**/*"
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4
@@ -87,7 +101,7 @@ jobs:
       id-token: write
       attestations: write
     env:
-      OUT: dist/sparkinfer-windows-amd64
+      BUNDLE: dist/sparkinfer-windows-amd64/sparkinfer-bin
       CUDA_ARCH: "120"
     steps:
       - name: Checkout
@@ -115,26 +129,46 @@ jobs:
 
       - name: Build
         shell: pwsh
-        run: cmake --build build --config Release -j --target qwen3_gguf_bench
+        run: cmake --build build --config Release -j 2 --target qwen3_gguf_bench
 
       - name: Package
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Force -Path $env:OUT | Out-Null
-          Copy-Item build/runtime/Release/qwen3_gguf_bench.exe $env:OUT/
+          New-Item -ItemType Directory -Force -Path "$env:BUNDLE/bin" | Out-Null
+          Copy-Item build/runtime/Release/qwen3_gguf_bench.exe "$env:BUNDLE/bin/"
           foreach ($pat in @(
             "$env:CUDA_PATH/bin/cudart64_*.dll",
             "$env:CUDA_PATH/bin/cublas64_*.dll",
             "$env:CUDA_PATH/bin/cublasLt64_*.dll"
           )) {
-            Get-ChildItem $pat -ErrorAction SilentlyContinue | Copy-Item -Destination $env:OUT/
+            Get-ChildItem $pat -ErrorAction SilentlyContinue | Copy-Item -Destination "$env:BUNDLE/bin/"
           }
-          Get-ChildItem $env:OUT
+          $bench = "$env:BUNDLE/bin/qwen3_gguf_bench.exe"
+          $hash = (Get-FileHash -Algorithm SHA256 $bench).Hash.ToLower()
+          $manifest = @{
+            platform = "windows-amd64"
+            cuda = "12.8"
+            sm = $env:CUDA_ARCH
+            commit = $env:GITHUB_SHA
+            ref = $env:GITHUB_REF
+            binary = "bin/qwen3_gguf_bench.exe"
+            binary_sha256 = $hash
+          } | ConvertTo-Json -Compress
+          Set-Content -Path "$env:BUNDLE/BUILD_MANIFEST.json" -Value $manifest -Encoding utf8NoBOM
+          Push-Location $env:BUNDLE
+          Get-ChildItem -Recurse -File | Where-Object { $_.Name -ne 'SHA256SUMS' } |
+            Sort-Object FullName |
+            ForEach-Object {
+              $rel = $_.FullName.Substring((Get-Location).Path.Length + 1).Replace('\', '/')
+              "$((Get-FileHash -Algorithm SHA256 $_.FullName).Hash.ToLower())  ./$rel"
+            } | Set-Content -Path SHA256SUMS -Encoding utf8NoBOM
+          Pop-Location
+          Get-ChildItem -Recurse $env:BUNDLE | Select-Object FullName
 
       - name: Generate artifact attestation
         uses: actions/attest@v4
         with:
-          subject-path: "${{ env.OUT }}/**/*"
+          subject-path: "${{ env.BUNDLE }}/**/*"
 
       - name: Upload bundle
         uses: actions/upload-artifact@v4
@@ -142,3 +176,51 @@ jobs:
           name: sparkinfer-windows-amd64
           path: dist/sparkinfer-windows-amd64/
           if-no-files-found: error
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [build-linux, build-windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Download Linux bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: sparkinfer-linux-amd64
+          path: dist/linux
+
+      - name: Download Windows bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: sparkinfer-windows-amd64
+          path: dist/windows
+
+      - name: Create release archives
+        run: |
+          set -euo pipefail
+          TAG="${GITHUB_REF_NAME}"
+          LINUX_TGZ="sparkinfer-${TAG}-linux-x86_64-cuda13-sm120.tar.gz"
+          WIN_ZIP="sparkinfer-${TAG}-windows-amd64-cuda13-sm120.zip"
+          tar -C dist/linux -czf "${LINUX_TGZ}" sparkinfer-bin
+          (cd dist/windows && zip -r "../../${WIN_ZIP}" sparkinfer-bin)
+          sha256sum "${LINUX_TGZ}" "${WIN_ZIP}" > SHA256SUMS
+          ls -la "${LINUX_TGZ}" "${WIN_ZIP}" SHA256SUMS
+
+      - name: Attest release archives
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            sparkinfer-*-linux-*.tar.gz
+            sparkinfer-*-windows-*.zip
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            sparkinfer-*-linux-*.tar.gz
+            sparkinfer-*-windows-*.zip
+            SHA256SUMS
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- Package Linux/Windows CI artifacts as `sparkinfer-bin/{bin,lib}` with `BUILD_MANIFEST.json` and `SHA256SUMS`
- Attest bundled files via GitHub Artifact Attestations
- On `v*` tags, publish GitHub Release archives matching bench prebuilt naming (`sparkinfer-$tag-linux-x86_64-cuda13-sm120.tar.gz`)

## Test plan
- [ ] `build-linux` and `build-windows` jobs pass on this PR
- [ ] Download `sparkinfer-linux-amd64` artifact and verify `sparkinfer-bin/bin/qwen3_gguf_bench` layout
- [ ] `gh attestation verify sparkinfer-bin/bin/qwen3_gguf_bench -R gittensor-ai-lab/sparkinfer`
- [ ] Tag `v*` smoke test for release job (optional)