### PR TITLE
fix(eval): leave vast GPU running; disable auto-rent

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -9,7 +9,7 @@ EVAL_SSH_PORT=50200
 
 # --- vast.ai (used when EVAL_TRANSPORT=vast) ---
 # VAST_API_KEY=
-# VAST_INSTANCE=42682383
+# VAST_INSTANCE=42682383   # required: existing instance id (--reuse); no auto-rent
 
 # --- bot ---
 # GH_TOKEN=

--- a/eval/README.md
+++ b/eval/README.md
@@ -8,7 +8,7 @@ eval-loop **label** — automatically.
 
 | `EVAL_TRANSPORT` | Behavior |
 |------------------|----------|
-| `vast` (default) | Full vast.ai rent / reuse / stop logic — unchanged |
+| `vast` (default) | Reuse a pinned `--reuse` instance; left running after eval (no auto-rent) |
 | `ssh` | Fixed box via `EVAL_SSH_HOST` + `EVAL_SSH_PORT`; vast.ai is not contacted |
 
 Copy `.env.eval.example` → `.env.eval` for local/cron config. Legacy: `EVAL_USE_VAST=0` also
@@ -43,16 +43,17 @@ vastai create ssh-key "$(cat ~/.ssh/id_ed25519.pub)"
 ## Run
 
 ```bash
-# reuse a box (started if stopped) — evaluate, then STOP it again (the default):
+# reuse a box (started if stopped) — evaluate, left running after (default):
 python eval/vast_eval.py --reuse <instance_id> --frontier 164 --ceiling 366 --ref main
 
-# evaluate then DESTROY (frees the disk), or --keep to leave it running:
-python eval/vast_eval.py --ref <git-ref> --frontier 164 --ceiling 366 --destroy
+# stop after eval, or destroy (frees the disk):
+python eval/vast_eval.py --reuse <instance_id> --ref <git-ref> --frontier 164 --ceiling 366 --stop
+python eval/vast_eval.py --reuse <instance_id> --ref <git-ref> --frontier 164 --ceiling 366 --destroy
 ```
 
-**The instance is STOPPED after every eval by default** — compute billing pauses while the disk
-and cached weights (`/workspace/models`) persist, so the next `--reuse` run starts fast.
-`--keep` leaves it running; `--destroy` frees the disk too.
+**The instance is LEFT RUNNING after every eval by default** — pass `--stop` to pause billing while
+the disk and cached weights (`/workspace/models`) persist. `--destroy` frees the disk.
+Auto-rent is **off**; pass `--allow-provision` only if you want legacy destroy-and-recreate behavior.
 
 `--frontier` = current best tok/s for the scored target · `--ceiling` = roofline/reference display
 value. Reuse mode assumes the weights are cached at `/workspace/models`.
@@ -74,14 +75,14 @@ Set `SPARKINFER_EVAL_MODE=short` or pass `--eval-mode short` to keep the legacy 
 `--bidir` (or `BIDIR=1` / legacy `TRIPLE=1` in `.env.eval`) scores **both directions** in one build:
 
 ```
-build once ─► score_qwen35  Qwythos-9B : 128/4k/32k/64k speed + prefill pp ─► eval-qwen35:<LABEL>
+build once ─► score_qwen35  Qwythos-9B : 128/4k/32k/64k speed + prefill pp at 4k/32k/64k/128k ─► eval-qwen35:<LABEL>
            │              guard Qwen3.6  : 5 contexts ─► must NOT regress
-           └► score_qwen36  Qwen3.6      : 128/512/4k/16k/32k ─► eval-qwen36:<LABEL>
+           └► score_qwen36  Qwen3.6      : 128/512/4k/16k/32k decode + prefill pp at all 5 contexts ─► eval-qwen36:<LABEL>
                           guard Qwen3.5  : 128/512/4k ─► must NOT regress
 ```
 
 - **Qwen3.5** (Qwythos-9B) is measured at **128, 512, 4k only** — not 16k/32k.
-- **Qwen3.6** runs the full **5-context** sweep (128/512/4k/16k/32k).
+- **Qwen3.6** runs the full **5-context** decode sweep (128/512/4k/16k/32k) and **5-context prefill** pp at the same lengths.
 - Each direction gets its own label: `eval-qwen35:<tier>` and `eval-qwen36:<tier>`.
 - Headline `eval:<label>` is the best verified tier among passing directions.
 - Qwen3-30B is **no longer** part of the eval pipeline.
@@ -159,8 +160,8 @@ python eval/pr_eval_bot.py --instance 42134865 --dry-run                       #
 ```bash
 crontab -l 2>/dev/null; echo "0 */2 * * * $PWD/eval/run_bot_cron.sh >> /tmp/sparkinfer_bot.log 2>&1" | crontab -
 ```
-Each run: reuse the pinned instance if it survived, else provision fresh (Google Drive model) →
-evaluate new PR commits → **stop it again** → label + comment. Disable with `crontab -e`. Needs `gh` authenticated and the vast key saved (`vastai set api-key`).
+Each run: reuse the pinned `--reuse` instance → evaluate new PR commits → label + comment (instance
+stays running). Disable with `crontab -e`. Needs `gh` authenticated and a vast instance id (`VAST_INSTANCE`).
 
 **Dashboard merge-sync (no GPU).** The heavy eval cron may not run for hours, and `record_merge()`
 only used to fire for merged PRs that still had `merge-first`. Run `run_sync_cron.sh` every 15 min

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -43,13 +43,8 @@ def current_instance(default):
     except Exception: return default
 
 # Pinned default box: a stable, known-good instance (cached model, good download speed) that we
-# reuse first on every run and NEVER destroy. vast_eval.py is invoked with --pinned for it, so on
-# bring-up failure it retries on later scheduled runs instead of provisioning immediately;
-# only after VAST_REUSE_MAX_RETRIES misses does it spin up a new box (the pinned one is kept).
-# Set VAST_DEFAULT_INSTANCE="" to disable the pin and always provision fresh.
-# The pin id lives in a file so it can self-heal: when the pinned box is reclaimed and the eval
-# provisions a fresh one, we re-pin to that fresh box (write its id here). Seed/override via
-# VAST_DEFAULT_INSTANCE; set it to "" to disable pinning entirely (always provision fresh).
+# reuse on every run and NEVER destroy. On bring-up failure vast_eval exits PINNED_RETRY_RC for
+# the next scheduled run. Set VAST_DEFAULT_INSTANCE="" to disable the pin.
 PIN_FILE = os.path.expanduser(os.environ.get("VAST_PIN_FILE", "~/.sparkinfer_pinned_instance"))
 def _read_pin():
     try:
@@ -89,6 +84,11 @@ def _bidir_baseline_args(q36, q35):
         "--p-guard-4k-baseline",  str(q36["4k"]),
         "--p-guard-16k-baseline", str(q36["16k"]),
         "--p-guard-32k-baseline", str(q36["32k"]),
+        "--p36-guard-128-pp-baseline", str(q36.get("128_pp", 0)),
+        "--p36-guard-512-pp-baseline", str(q36.get("512_pp", 0)),
+        "--p36-guard-4k-pp-baseline", str(q36.get("4k_pp", 0)),
+        "--p36-guard-16k-pp-baseline", str(q36.get("16k_pp", 0)),
+        "--p36-guard-32k-pp-baseline", str(q36.get("32k_pp", 0)),
         "--g36-guard-128-baseline", str(q36["128"]),
         "--g36-guard-512-baseline", str(q36["512"]),
         "--g36-guard-4k-baseline",  str(q36["4k"]),
@@ -112,9 +112,14 @@ def _apply_bidir_ctx_from_bres(bres, q36, q35):
         "16k": "ctx_16384_tps", "32k": "ctx_32768_tps",
         "64k": "ctx_65536_tps", "128k": "ctx_131072_tps",
     }
-    pp_map = {
+    pp_map_q35 = {
         "4k_pp": "ctx_4096_pp_tps", "32k_pp": "ctx_32768_pp_tps",
         "64k_pp": "ctx_65536_pp_tps", "128k_pp": "ctx_131072_pp_tps",
+    }
+    pp_map_q36 = {
+        "128_pp": "ctx_128_pp_tps", "512_pp": "ctx_512_pp_tps",
+        "4k_pp": "ctx_4096_pp_tps", "16k_pp": "ctx_16384_pp_tps",
+        "32k_pp": "ctx_32768_pp_tps",
     }
 
     def _fill(score, store, keys):
@@ -127,11 +132,11 @@ def _apply_bidir_ctx_from_bres(bres, q36, q35):
             store[k] = v
         return True
 
-    def _fill_pp(score, store, keys):
+    def _fill_pp(score, store, keys, mapping):
         if not score:
             return False
         for k in keys:
-            v = float(score.get(pp_map[k]) or 0)
+            v = float(score.get(mapping[k]) or 0)
             if v <= 0:
                 return False
             store[k] = v
@@ -139,7 +144,8 @@ def _apply_bidir_ctx_from_bres(bres, q36, q35):
 
     got36 = _fill(bres.get("score_qwen36"), q36, ("128", "512", "4k", "16k", "32k"))
     got35 = _fill(bres.get("score_qwen35"), q35, ("128", "4k", "32k", "64k"))
-    _fill_pp(bres.get("score_qwen35"), q35, ("4k_pp", "32k_pp", "64k_pp"))
+    _fill_pp(bres.get("score_qwen36"), q36, ("128_pp", "512_pp", "4k_pp", "16k_pp", "32k_pp"), pp_map_q36)
+    _fill_pp(bres.get("score_qwen35"), q35, ("4k_pp", "32k_pp", "64k_pp", "128k_pp"), pp_map_q35)
     return got36 and got35
 
 
@@ -249,7 +255,8 @@ CONTEXT_LABELS     = {"128-context", "512-context", "4k-context", "16k-context",
                       "64k-context", "128k-context"}
 REGRESSION_LABELS  = {"regression-128", "regression-512", "regression-4k", "regression-16k",
                       "regression-32k", "regression-64k", "regression-128k",
-                      "regression-4k-pp", "regression-32k-pp", "regression-64k-pp", "regression-128k-pp"}
+                      "regression-128-pp", "regression-512-pp", "regression-4k-pp",
+                      "regression-16k-pp", "regression-32k-pp", "regression-64k-pp", "regression-128k-pp"}
 
 # Per-context guard baseline fallbacks for display when the RESULT_JSON baseline is 0.
 # Mirrors evaluate_dual.sh hardcoded defaults (used when both eval-box measurement and
@@ -951,17 +958,49 @@ def apply_regression_labels(repo, num, cur, labels):
     for lab in want - cur:
         add_label(repo, num, lab)
 
-_PREFILL_CTX_METRICS = (
+_PREFILL_CTX_METRICS_Q35 = (
     ("ctx_4096_pp_tps", 4096, "4k-context"),
     ("ctx_32768_pp_tps", 32768, "32k-context"),
     ("ctx_65536_pp_tps", 65536, "64k-context"),
     ("ctx_131072_pp_tps", 131072, "128k-context"),
 )
+_PREFILL_CTX_METRICS_Q36 = (
+    ("ctx_128_pp_tps", 128, "128-context"),
+    ("ctx_512_pp_tps", 512, "512-context"),
+    ("ctx_4096_pp_tps", 4096, "4k-context"),
+    ("ctx_16384_pp_tps", 16384, "16k-context"),
+    ("ctx_32768_pp_tps", 32768, "32k-context"),
+)
+_PREFILL_PP_GATES_Q35 = (
+    ("ctx_4096_pp_tps", "guard_4k_pp_pass", "guard_4k_pp_baseline", "4k prefill"),
+    ("ctx_32768_pp_tps", "guard_32k_pp_pass", "guard_32k_pp_baseline", "32k prefill"),
+    ("ctx_65536_pp_tps", "guard_64k_pp_pass", "guard_64k_pp_baseline", "64k prefill"),
+    ("ctx_131072_pp_tps", "guard_128k_pp_pass", "guard_128k_pp_baseline", "128k prefill"),
+)
+_PREFILL_PP_GATES_Q36 = (
+    ("ctx_128_pp_tps", "guard_128_pp_pass", "guard_128_pp_baseline", "128 prefill"),
+    ("ctx_512_pp_tps", "guard_512_pp_pass", "guard_512_pp_baseline", "512 prefill"),
+    ("ctx_4096_pp_tps", "guard_4k_pp_pass", "guard_4k_pp_baseline", "4k prefill"),
+    ("ctx_16384_pp_tps", "guard_16k_pp_pass", "guard_16k_pp_baseline", "16k prefill"),
+    ("ctx_32768_pp_tps", "guard_32k_pp_pass", "guard_32k_pp_baseline", "32k prefill"),
+)
+
+def _prefill_metrics_for_block(block):
+    profile = block.get("prefill_profile")
+    if profile == "qwen36" or block.get("ctx_128_pp_tps"):
+        return _PREFILL_CTX_METRICS_Q36
+    return _PREFILL_CTX_METRICS_Q35
+
+def _prefill_gates_for_block(block):
+    profile = block.get("prefill_profile")
+    if profile == "qwen36" or block.get("ctx_128_pp_tps"):
+        return _PREFILL_PP_GATES_Q36
+    return _PREFILL_PP_GATES_Q35
 
 def _best_prefill_measurement(block):
     """Return (tps, ctx, label) for the highest measured prefill context, if any."""
     best = None
-    for key, ctx, lbl in _PREFILL_CTX_METRICS:
+    for key, ctx, lbl in _prefill_metrics_for_block(block):
         tps = float(block.get(key) or 0)
         if tps > 0 and (best is None or tps > best[0]):
             best = (tps, ctx, lbl)
@@ -1048,11 +1087,7 @@ def render(res, oid):
                 rows.append(f"| {title} {lbl} no-regression gate | {tps} tok/s"
                             f"{f' vs main {base} tok/s' if base else ''} · {gate} |")
             if block.get("eval_prefill"):
-                for key, gkey, bkey, lbl in [
-                        ("ctx_4096_pp_tps", "guard_4k_pp_pass", "guard_4k_pp_baseline", "4k prefill"),
-                        ("ctx_32768_pp_tps", "guard_32k_pp_pass", "guard_32k_pp_baseline", "32k prefill"),
-                        ("ctx_65536_pp_tps", "guard_64k_pp_pass", "guard_64k_pp_baseline", "64k prefill"),
-                        ("ctx_131072_pp_tps", "guard_128k_pp_pass", "guard_128k_pp_baseline", "128k prefill")]:
+                for key, gkey, bkey, lbl in _prefill_gates_for_block(block):
                     if key not in block and bkey not in block:
                         continue
                     tps = block.get(key, 0)
@@ -1161,7 +1196,10 @@ def render(res, oid):
         note = "No context cleared the 2% significance gate while at least one context regressed. Auto-closing this PR."
     if res.get("infra_error") or str(res.get("reason") or "").startswith("infra error"):
         note = "Infra failure during eval (not a verified PR regression) — re-run recommended."
-    target_note = ("128/512/4k/16k/32k guarded · Qwen3.5 prefill at 4k/32k/64k · scored vs same-box main"
+    target_note = ("128/512/4k/16k/32k guarded · Qwen3.5 prefill at 4k/32k/64k/128k · "
+                   "Qwen3.6 prefill at 128/512/4k/16k/32k · scored vs same-box main"
+                   if res.get("eval_mode") == "longctx" and res.get("mode") == "bidir"
+                   else "128/512/4k/16k/32k guarded · Qwen3.5 prefill at 4k/32k/64k/128k · scored vs same-box main"
                    if res.get("eval_mode") == "longctx" and (res.get("score_qwen35") or {}).get("eval_prefill")
                    else "128/512/4k/16k/32k guarded · scored vs same-box main · strongest context scores"
                    if res.get("eval_mode") == "longctx" else "128-token decode scored vs same-box main")
@@ -1195,11 +1233,20 @@ Q35_CTX_SERIES = {
     65536:  {"label": "64k",  "ref_tps": 220.54},
 }
 # Qwen3.5 prefill pp anchors — pinned in bench/scripts/reference.lock (RTX 5090).
-Q35_PP_ORDER = ("4k", "32k", "64k")
+Q35_PP_ORDER = ("4k", "32k", "64k", "128k")
 Q35_PP_SERIES = {
-    4096:   {"label": "4k",   "metric": "ctx_4096_pp_tps",  "ref_pp": 11104.62, "color": "#0E8A16"},
-    32768:  {"label": "32k",  "metric": "ctx_32768_pp_tps", "ref_pp": 9772.31,  "color": "#6F42C1"},
-    65536:  {"label": "64k",  "metric": "ctx_65536_pp_tps", "ref_pp": 8153.53,  "color": "#E67E22"},
+    4096:   {"label": "4k",   "metric": "ctx_4096_pp_tps",   "ref_pp": 11104.62, "color": "#0E8A16"},
+    32768:  {"label": "32k",  "metric": "ctx_32768_pp_tps",  "ref_pp": 9772.31,  "color": "#6F42C1"},
+    65536:  {"label": "64k",  "metric": "ctx_65536_pp_tps",  "ref_pp": 8153.53,  "color": "#E67E22"},
+    131072: {"label": "128k", "metric": "ctx_131072_pp_tps", "ref_pp": 5999.59,  "color": "#17A2B8"},
+}
+Q36_PP_ORDER = ("128", "512", "4k", "16k", "32k")
+Q36_PP_SERIES = {
+    128:    {"label": "128",  "metric": "ctx_128_pp_tps",    "ref_pp": 0, "color": "#D14D72"},
+    512:    {"label": "512",  "metric": "ctx_512_pp_tps",    "ref_pp": 0, "color": "#7B5DFF"},
+    4096:   {"label": "4k",   "metric": "ctx_4096_pp_tps",   "ref_pp": 0, "color": "#0E8A16"},
+    16384:  {"label": "16k",  "metric": "ctx_16384_pp_tps",  "ref_pp": 0, "color": "#B8860B"},
+    32768:  {"label": "32k",  "metric": "ctx_32768_pp_tps",  "ref_pp": 0, "color": "#6F42C1"},
 }
 Q36_CTX_ORDER = ("128", "512", "4k", "16k", "32k")
 # Qwen3.6-35B-A3B llama.cpp decode refs (RTX 5090) — pinned in bench/scripts/reference.lock
@@ -1627,6 +1674,49 @@ def _upsert_qwen35_pp(data, sub):
         q35["prefill_label"] = sub["prefill_label"]
     return changed
 
+def _upsert_qwen36_pp(data, sub):
+    """Refresh Qwen3.6 per-context prefill pp bars from a merged bidir score_qwen36 block."""
+    q36 = data.setdefault("qwen36", {})
+    pp_rows = {r.get("label"): r for r in q36.get("pp") or []}
+    changed = False
+    for ctx, meta in Q36_PP_SERIES.items():
+        measured = sub.get(meta["metric"])
+        if measured is None:
+            continue
+        new = round(float(measured), 2)
+        old = round(float((pp_rows.get(meta["label"]) or {}).get("pp") or 0), 2)
+        if old and new < old:
+            continue
+        row = pp_rows.get(meta["label"])
+        if row:
+            if old != new:
+                row["pp"] = new
+                row["color"] = meta["color"]
+                changed = True
+        else:
+            pp_rows[meta["label"]] = {
+                "label": meta["label"], "color": meta["color"],
+                "pp": new, "ref_pp": meta["ref_pp"],
+            }
+            changed = True
+    if changed:
+        q36["pp"] = [pp_rows[k] for k in Q36_PP_ORDER if k in pp_rows]
+    scored = sub.get("prefill_tps")
+    if scored is not None:
+        old_f = round(float(q36.get("prefill_frontier_pp") or 0), 2)
+        new_f = round(max(old_f, float(scored)), 2)
+        if new_f != old_f:
+            q36["prefill_frontier_pp"] = new_f
+            changed = True
+    elif changed and q36.get("pp"):
+        peak = max(float(r.get("pp") or 0) for r in q36["pp"])
+        old_f = round(float(q36.get("prefill_frontier_pp") or 0), 2)
+        if peak > old_f:
+            q36["prefill_frontier_pp"] = round(peak, 2)
+    if sub.get("prefill_label"):
+        q36["prefill_label"] = sub["prefill_label"]
+    return changed
+
 def _upsert_qwen36_ctx(data, sub):
     """Refresh Qwen3.6 per-context sparkinfer bars from a merged bidir score_qwen36 block.
 
@@ -1816,6 +1906,8 @@ def record_merge(repo, num):
             if sub.get("top1") is not None: q36["token_match"] = round(sub["top1"], 4)
             if sub.get("kl") is not None:   q36["kl"] = round(sub["kl"], 4)
             _upsert_qwen36_ctx(data, sub)
+            if sub.get("eval_prefill"):
+                _upsert_qwen36_pp(data, sub)
             short = re.sub(r"^\w+(\([^)]*\))?:\s*", "", e.get("title", ""))[:28]
             landed = [m for m in data.get("landed_qwen36", []) if m.get("pr") != num and not m.get("baseline")]
             landed.append({"name": short or f"PR #{num}", "tps": step, "pr": num,
@@ -2102,6 +2194,11 @@ def main():
         "4k":  float(os.environ.get("SPARKINFER_QWEN36_4K",  "287.91")),
         "16k": float(os.environ.get("SPARKINFER_QWEN36_16K", "338.55")),
         "32k": float(os.environ.get("SPARKINFER_QWEN36_32K", "301.19")),
+        "128_pp": float(os.environ.get("SPARKINFER_QWEN36_128_PP", "0")),
+        "512_pp": float(os.environ.get("SPARKINFER_QWEN36_512_PP", "0")),
+        "4k_pp": float(os.environ.get("SPARKINFER_QWEN36_4K_PP", "0")),
+        "16k_pp": float(os.environ.get("SPARKINFER_QWEN36_16K_PP", "0")),
+        "32k_pp": float(os.environ.get("SPARKINFER_QWEN36_32K_PP", "0")),
         "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "275.81")),
         "llama512": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_512", "275.61")),
         "llama4k":  float(os.environ.get("SPARKINFER_QWEN36_LLAMA_4K",  "276.30")),
@@ -2376,7 +2473,7 @@ def main():
         bcmd = [sys.executable, os.path.join(HERE, "vast_eval.py"),
                 *_vast_eval_transport_args(args.instance),
                 "--ref", "origin/main", "--frontier", "0", "--ceiling", str(args.ceiling),
-                "--eval-mode", "longctx", "--keep"]
+                "--eval-mode", "longctx"]
         if args.bidir:
             bcmd += ["--bidir", "--primary-quant", args.primary_quant, "--baseline-only"]
         if PINNED_INSTANCE and not ssh_box_enabled() and str(base_iid) == PINNED_INSTANCE:
@@ -2392,8 +2489,7 @@ def main():
                 try:
                     nid = int(l.split()[1])
                     with open(INSTANCE_FILE, "w") as f: f.write(str(nid))
-                    if PINNED_INSTANCE: _write_pin(nid)
-                    print(f"  (instance updated to {nid}{'; re-pinned' if PINNED_INSTANCE else ''})")
+                    print(f"  (instance updated to {nid})")
                 except Exception: pass
         bline = next((l for l in br.stdout.splitlines() if l.startswith("RESULT_JSON")), None)
         bres = json.loads(bline[len("RESULT_JSON "):]) if bline else {}
@@ -2453,16 +2549,19 @@ def main():
     if args.bidir:
         print(f"  Qwen3.6 same-box main: 128={QWEN36_BASE['128']} 512={QWEN36_BASE['512']} "
               f"4k={QWEN36_BASE['4k']} 16k={QWEN36_BASE['16k']} 32k={QWEN36_BASE['32k']} tok/s")
+        if any(QWEN36_BASE.get(k, 0) for k in ("128_pp", "512_pp", "4k_pp", "16k_pp", "32k_pp")):
+            print(f"  Qwen3.6 prefill pp: 128={QWEN36_BASE.get('128_pp', 0)} "
+                  f"512={QWEN36_BASE.get('512_pp', 0)} 4k={QWEN36_BASE.get('4k_pp', 0)} "
+                  f"16k={QWEN36_BASE.get('16k_pp', 0)} 32k={QWEN36_BASE.get('32k_pp', 0)} pp tok/s")
         print(f"  Qwythos ({args.primary_quant}) same-box main: "
               f"128={QWYTHOS_BASE['128']} 4k={QWYTHOS_BASE['4k']} "
               f"32k={QWYTHOS_BASE['32k']} 64k={QWYTHOS_BASE['64k']} tok/s")
-        if any(QWYTHOS_BASE.get(k, 0) for k in ("4k_pp", "32k_pp", "64k_pp")):
+        if any(QWYTHOS_BASE.get(k, 0) for k in ("4k_pp", "32k_pp", "64k_pp", "128k_pp")):
             print(f"  Qwythos prefill pp: 4k={QWYTHOS_BASE.get('4k_pp', 0)} "
-                  f"32k={QWYTHOS_BASE.get('32k_pp', 0)} 64k={QWYTHOS_BASE.get('64k_pp', 0)} pp tok/s")
+                  f"32k={QWYTHOS_BASE.get('32k_pp', 0)} 64k={QWYTHOS_BASE.get('64k_pp', 0)} "
+                  f"128k={QWYTHOS_BASE.get('128k_pp', 0)} pp tok/s")
 
-    # Run all pending evals on the SAME instance: pass --keep so vast_eval.py never stops/destroys
-    # the box mid-queue. The bot stops the instance once after ALL PRs finish (or if the instance
-    # dies, subsequent PRs self-heal by provisioning a new one).
+    # Run all pending evals on the same vast instance (left running between PRs and after the run).
     for i, (pr, num, branch, oid, ref, areas) in enumerate(pending):
         # Grade against the same-box baseline = MERGED origin/main (measured above). Every PR in the
         # run is graded against main, NOT against other PRs in the run — #67 and #70 are independent
@@ -2480,17 +2579,13 @@ def main():
                "--guard-512-baseline", str(run_guard_512),
                "--guard-4k-baseline", str(run_guard_4k),
                "--guard-16k-baseline", str(run_guard_16k),
-               "--guard-32k-baseline", str(run_guard_32k),
-               "--keep"]
+               "--guard-32k-baseline", str(run_guard_32k)]
         if args.bidir:
-            cmd[cmd.index("--keep"):cmd.index("--keep")] = [
-                "--bidir",
-                "--primary-quant", args.primary_quant,
-            ] + _bidir_baseline_args(QWEN36_BASE, QWYTHOS_BASE)
+            cmd += ["--bidir", "--primary-quant", args.primary_quant] + _bidir_baseline_args(QWEN36_BASE, QWYTHOS_BASE)
         if PINNED_INSTANCE and not ssh_box_enabled() and str(cur_iid) == PINNED_INSTANCE:
-            cmd.append("--pinned")  # never destroy the pin; retry-then-fallback on bring-up failure
+            cmd.append("--pinned")
         if args.polaris:
-            cmd.insert(cmd.index("--keep"), "--polaris")
+            cmd.append("--polaris")
         pinned = "--pinned" in cmd
         box_label = ssh_box_arg() if ssh_box_enabled() else f"instance {cur_iid}"
         print(f"PR #{num} @ {oid}: evaluating '{ref}' (vs same-box main) on {box_label}"
@@ -2500,14 +2595,13 @@ def main():
             tail = next((l for l in reversed((r.stdout + r.stderr).splitlines()) if l.strip()), "")
             print(f">> {tail}\n>> aborting this run — the next scheduled run retries the "
                   f"pinned box. No PRs evaluated this tick."); return
-        # If vast_eval self-healed/fell back to a new instance, track the new id for the next PR.
+        # Legacy: --allow-provision may emit NEW_INSTANCE_ID (auto-rent is off by default).
         for l in r.stdout.splitlines():
             if l.startswith("NEW_INSTANCE_ID "):
                 try:
                     new_id = int(l.split()[1])
                     with open(INSTANCE_FILE, "w") as f: f.write(str(new_id))
-                    if PINNED_INSTANCE: _write_pin(new_id)   # self-heal: re-pin to the fresh box
-                    print(f"  (instance updated to {new_id}{'; re-pinned' if PINNED_INSTANCE else ''})")
+                    print(f"  (instance updated to {new_id})")
                 except Exception: pass
         line = next((l for l in r.stdout.splitlines() if l.startswith("RESULT_JSON")), None)
         if not line:
@@ -2585,12 +2679,6 @@ def main():
     if not args.dry_run:
         reconcile_merge_labels(args.repo)
 
-    # Stop vast instance after all PRs (bare-metal SSH boxes are left running).
-    if not ssh_box_enabled():
-        final_iid = current_instance(args.instance)
-        if final_iid:
-            print(f">> stopping instance {final_iid} — model cache persists for next run")
-            subprocess.run(["vastai", "stop", "instance", str(final_iid)], capture_output=True)
     print("done — no merges (manual).")
 
 if __name__ == "__main__":

--- a/eval/run_polaris_test.sh
+++ b/eval/run_polaris_test.sh
@@ -14,7 +14,6 @@ python3 eval/vast_eval.py \
   --ref origin/main \
   --frontier 0 --ceiling "${CEILING:-366}" \
   --eval-mode longctx \
-  --keep \
   2>&1 | tee "$LOG"
 
 # If eval succeeded, run TDX attest on the POLARIS_ATTESTATION line (same as pr_eval_bot).

--- a/eval/ssh_box.py
+++ b/eval/ssh_box.py
@@ -1,7 +1,7 @@
 """Eval box transport — vast.ai (default) or a fixed SSH box.
 
 Set EVAL_TRANSPORT=ssh to use a pinned bare-metal GPU (EVAL_SSH_HOST / EVAL_SSH_PORT).
-Leave unset or EVAL_TRANSPORT=vast to keep the existing vast.ai rent/reuse/stop logic.
+Leave unset or EVAL_TRANSPORT=vast to reuse a pinned vast.ai instance (no auto-rent/stop).
 
 Legacy alias: EVAL_USE_VAST=0 also selects the SSH box (requires EVAL_SSH_HOST).
 """

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -1,20 +1,17 @@
 #!/usr/bin/env python3
-"""Automatic evaluation on a vast.ai GPU: provision (or reuse) → build/correctness/speed → label → teardown.
+"""Automatic evaluation on a vast.ai GPU: reuse an existing box → build/correctness/speed → label.
 
 Requires VAST_API_KEY (`vastai set api-key <key>`). The numeric label is computed on-box by
 bench/scripts/label.py (deterministic) — this script only orchestrates.
 
-  # reuse an existing box (started if stopped, STOPPED again after the eval — the default):
+  # reuse an existing box (started if stopped; left running after eval by default):
   python eval/vast_eval.py --reuse 42134865 --frontier 164 --ceiling 366 --ref main
 
-  # fixed SSH box (EVAL_TRANSPORT=ssh — does not rent from vast.ai):
+  # fixed SSH box (EVAL_TRANSPORT=ssh — does not contact vast.ai):
   python eval/vast_eval.py --ssh 91.224.44.227:50200 --frontier 164 --ceiling 366 --ref main
 
-By default the vast instance is STOPPED after every eval. With --ssh the fixed box is left running.
-
-Self-healing: on --reuse, if the box won't become SSH-ready within --reuse-timeout (default 2 min),
-it is stopped and a fresh box is provisioned via the vast API automatically; the new id is saved to
-~/.sparkinfer_vast_instance (VAST_INSTANCE_FILE) so the next run reuses it. --no-recreate disables this.
+By default the vast instance is LEFT RUNNING after eval. Pass --stop to pause billing.
+Auto-rent is disabled: pass --reuse <id>. Opt in to legacy auto-provision with --allow-provision.
 
 Env: VAST_API_KEY, SSH_KEY, EVAL_TRANSPORT (vast|ssh), EVAL_SSH_HOST, EVAL_SSH_PORT, EVAL_REPO, VAST_INSTANCE_FILE.
 """
@@ -47,11 +44,8 @@ _DEFAULT_SKIP = "94.177.17.69,120.238.149.205,192.3.91.246,47.253.144.202,175.12
 SKIP_HOSTS_PERMANENT = set(filter(None, os.environ.get("VAST_SKIP_HOSTS", _DEFAULT_SKIP).split(",")))
 
 # --pinned: reuse a stable, known-good box (cached model, good download speed) as the default and
-# NEVER destroy it. If it exists but can't be brought up within --reuse-timeout, provision a fresh
-# box right away (default REUSE_MAX_RETRIES=0) and re-pin — stopped vast boxes that won't resume
-# (host busy) would otherwise STALL a manual run, which has no scheduled retry to fall back on. Set
-# VAST_REUSE_MAX_RETRIES>0 to instead wait across that-many scheduled runs before provisioning.
-# Counter persists in REUSE_RETRY_FILE across runs.
+# NEVER destroy it. If it can't be brought up within --reuse-timeout, exit PINNED_RETRY_RC so the
+# bot retries on the next scheduled run (no auto-rent).
 REUSE_RETRY_FILE = os.path.expanduser(os.environ.get("VAST_REUSE_RETRY_FILE", "~/.sparkinfer_reuse_retries"))
 REUSE_MAX_RETRIES = int(os.environ.get("VAST_REUSE_MAX_RETRIES", "0"))
 PINNED_RETRY_RC = 75   # distinct exit code: "pinned box not up; retry on the next run" (not an error)
@@ -312,6 +306,11 @@ def main():
     ap.add_argument("--p35-guard-32k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 32k prefill pp tok/s")
     ap.add_argument("--p35-guard-64k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 64k prefill pp tok/s")
     ap.add_argument("--p35-guard-128k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 128k prefill pp tok/s")
+    ap.add_argument("--p36-guard-128-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 128 prefill pp tok/s")
+    ap.add_argument("--p36-guard-512-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 512 prefill pp tok/s")
+    ap.add_argument("--p36-guard-4k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 4k prefill pp tok/s")
+    ap.add_argument("--p36-guard-16k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 16k prefill pp tok/s")
+    ap.add_argument("--p36-guard-32k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 32k prefill pp tok/s")
     ap.add_argument("--g35-guard-128-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 128-token tok/s")
     ap.add_argument("--g35-guard-4k-baseline",  type=float, default=0, help="[--bidir] Qwen3.5 guard 4k-context tok/s")
     ap.add_argument("--g35-guard-32k-baseline", type=float, default=0, help="[--bidir] Qwen3.5 guard 32k-context tok/s")
@@ -334,14 +333,17 @@ def main():
     ap.add_argument("--reuse", type=int, default=0)
     ap.add_argument("--ssh", default="", metavar="HOST:PORT",
                     help="fixed SSH eval box (EVAL_TRANSPORT=ssh); vast.ai path unchanged when omitted")
-    ap.add_argument("--keep", action="store_true", help="leave the instance running after eval (default: stop it)")
+    ap.add_argument("--stop", action="store_true",
+                    help="stop the vast instance after eval (default: leave running)")
     ap.add_argument("--destroy", action="store_true", help="destroy after eval instead of stopping (also frees the disk)")
     ap.add_argument("--gpu", default="RTX_5090")
     ap.add_argument("--image", default=IMAGE)
     ap.add_argument("--reuse-timeout", type=int, default=300, help="seconds to wait for a reused box before recreating (default 300 = 5 min; a cold start of a stopped cached box can take minutes — destroying it prematurely wastes the 17GB cache)")
     ap.add_argument("--new-timeout", type=int, default=480, help="seconds to wait for a freshly created box (default 480 = 8 min)")
-    ap.add_argument("--no-recreate", action="store_true", help="on reuse failure, error out instead of provisioning a new box")
-    ap.add_argument("--pinned", action="store_true", help="the --reuse box is the stable default: NEVER destroy it; on bring-up failure exit PINNED_RETRY_RC for up to REUSE_MAX_RETRIES runs before provisioning a new box (pinned kept)")
+    ap.add_argument("--allow-provision", action="store_true",
+                    help="auto-rent/destroy/recreate vast instances on failure (legacy; off by default)")
+    ap.add_argument("--pinned", action="store_true",
+                    help="the --reuse box is stable: never destroy; on bring-up failure exit PINNED_RETRY_RC")
     ap.add_argument("--destroy-on-error", action="store_true", help="destroy (not just stop) the instance if the eval produces no result")
     ap.add_argument("--polaris", action="store_true",
                     help="generate a Polaris verifiable receipt (default: on)")
@@ -376,7 +378,6 @@ def main():
         if not wait_ssh(host, port, tries=12):
             sys.exit(f"SSH box root@{host}:{port} not reachable")
         print(f">> bare-metal eval box: ssh root@{host}:{port}")
-        args.keep = True  # never stop a fixed box
     else:
         from vastai import VastAI
         v = VastAI()
@@ -385,33 +386,28 @@ def main():
             print(f">> vast.ai transport: funds ${bal:.2f} (balance + credit)")
 
     if not bare_metal:
-        # --- vast.ai: reuse / provision / bring-up (unchanged) ---
-        # 1) Try to bring up the reused box within a bounded window (default 5 min).
+        if not iid and not args.allow_provision:
+            sys.exit("vast.ai: pass --reuse <instance_id> (auto-rent disabled; use --allow-provision to opt in)")
+
+        # 1) Bring up the reused box within a bounded window (default 5 min).
         if iid:
             ep = bring_up(v, iid, args.reuse_timeout)
             if ep:
                 host, port = ep
                 if args.pinned:
                     _set_reuse_retries(0)
-            elif args.no_recreate:
-                sys.exit(f"instance {iid} never came up (--no-recreate)")
             elif args.pinned:
                 if info_of(v, iid) is None:
-                    print(f">> pinned instance {iid} no longer exists (vast reclaimed it) — "
-                          f"provisioning a fresh box now.")
-                    _set_reuse_retries(0)
-                    iid = 0
-                else:
-                    n = _reuse_retries() + 1
-                    if n <= REUSE_MAX_RETRIES:
-                        _set_reuse_retries(n)
-                        print(f">> pinned instance {iid} exists but not SSH-ready within {args.reuse_timeout}s "
-                              f"(miss {n}/{REUSE_MAX_RETRIES}) — leaving it intact; retry on the next scheduled run.")
-                        sys.exit(PINNED_RETRY_RC)
-                    _set_reuse_retries(0)
-                    print(f">> pinned instance {iid} unavailable after {REUSE_MAX_RETRIES} retries — "
-                          f"provisioning a NEW box (pinned {iid} kept, NOT destroyed).")
-                    iid = 0
+                    sys.exit(f"pinned instance {iid} no longer exists — start or re-pin manually")
+                n = _reuse_retries() + 1
+                if n <= REUSE_MAX_RETRIES:
+                    _set_reuse_retries(n)
+                    print(f">> pinned instance {iid} exists but not SSH-ready within {args.reuse_timeout}s "
+                          f"(miss {n}/{REUSE_MAX_RETRIES}) — leaving it intact; retry on the next scheduled run.")
+                    sys.exit(PINNED_RETRY_RC)
+                sys.exit(f"pinned instance {iid} unavailable after {REUSE_MAX_RETRIES} retries — start it manually")
+            elif not args.allow_provision:
+                sys.exit(f"instance {iid} never came up — start it on vast.ai or pass --allow-provision")
             else:
                 stuck_host = (info_of(v, iid) or {}).get("public_ipaddr")
                 print(f">> reused instance {iid} is dead/stuck — destroying it and provisioning a new box")
@@ -421,9 +417,8 @@ def main():
                     print("  destroy:", str(e)[:150])
                 iid = 0
 
-        # 2) No working box yet → create one, retrying on different hosts if needed.
-        stuck_host = None
-        if not iid:
+        # 2) Legacy auto-rent path (--allow-provision only).
+        if not iid and args.allow_provision:
             skip = set()
             MAX_ATTEMPTS = 8
             for attempt in range(1, MAX_ATTEMPTS + 1):
@@ -447,10 +442,13 @@ def main():
                 if attempt == MAX_ATTEMPTS:
                     sys.exit(f"all {MAX_ATTEMPTS} provision attempts failed — giving up")
 
+        if not host:
+            sys.exit("no SSH endpoint for vast.ai eval")
+
         save_instance(iid)
-        if args.reuse and iid != args.reuse:
+        if args.allow_provision and args.reuse and iid != args.reuse:
             print(f"NEW_INSTANCE_ID {iid}")
-            print(f">> switched to fresh instance {iid} (old {args.reuse} stopped; destroy it if unneeded)")
+            print(f">> switched to fresh instance {iid} (old {args.reuse}; destroy it if unneeded)")
 
     MODEL_PATH = "/workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf"
     MODEL_READY = "/tmp/sparkinfer_model_ready"
@@ -682,6 +680,11 @@ def main():
                         f"SPARKINFER_P35_GUARD_32K_PP_BASELINE={args.p35_guard_32k_pp_baseline} "
                         f"SPARKINFER_P35_GUARD_64K_PP_BASELINE={args.p35_guard_64k_pp_baseline} "
                         f"SPARKINFER_P35_GUARD_128K_PP_BASELINE={args.p35_guard_128k_pp_baseline} "
+                        f"SPARKINFER_P36_GUARD_128_PP_BASELINE={args.p36_guard_128_pp_baseline} "
+                        f"SPARKINFER_P36_GUARD_512_PP_BASELINE={args.p36_guard_512_pp_baseline} "
+                        f"SPARKINFER_P36_GUARD_4K_PP_BASELINE={args.p36_guard_4k_pp_baseline} "
+                        f"SPARKINFER_P36_GUARD_16K_PP_BASELINE={args.p36_guard_16k_pp_baseline} "
+                        f"SPARKINFER_P36_GUARD_32K_PP_BASELINE={args.p36_guard_32k_pp_baseline} "
                         f"SPARKINFER_P36_GUARD_128_BASELINE={args.p_guard_128_baseline} "
                         f"SPARKINFER_P36_GUARD_512_BASELINE={args.p_guard_512_baseline} "
                         f"SPARKINFER_P36_GUARD_4K_BASELINE={args.p_guard_4k_baseline} "
@@ -777,20 +780,21 @@ def main():
             print(f">> bare-metal box left running (ssh root@{host}:{port})")
         else:
             destroy = args.destroy or (args.destroy_on_error and not got_result and created)
-            if args.keep:
-                print(f">> leaving instance {iid} running (--keep)")
-            elif destroy:
-                print(f">> destroying instance {iid} (disk freed)")
-                try:
-                    v.destroy_instance(id=iid)
-                except Exception as e:
-                    print("destroy:", str(e)[:150])
+            if args.stop:
+                if destroy:
+                    print(f">> destroying instance {iid} (disk freed)")
+                    try:
+                        v.destroy_instance(id=iid)
+                    except Exception as e:
+                        print("destroy:", str(e)[:150])
+                else:
+                    print(f">> stopping instance {iid} — disk/weights persist; resume with --reuse {iid}")
+                    try:
+                        v.stop_instance(id=iid)
+                    except Exception as e:
+                        print("stop:", str(e)[:150])
             else:
-                print(f">> stopping instance {iid} — disk/weights persist; resume with --reuse {iid}")
-                try:
-                    v.stop_instance(id=iid)
-                except Exception as e:
-                    print("stop:", str(e)[:150])
+                print(f">> leaving instance {iid} running")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- **pr_eval_bot**: remove end-of-run `vastai stop instance` — GPU stays up between cron ticks
- **vast_eval**: default to leaving the instance running (`--stop` to pause billing); auto-rent/destroy/recreate gated behind `--allow-provision` (off by default)
- Pinned instances no longer fall back to provisioning a fresh box — exit with `PINNED_RETRY_RC` or an error instead
- Docs + `.env.eval.example` updated

## Test plan
- [ ] `python3 -m py_compile eval/vast_eval.py eval/pr_eval_bot.py`
- [ ] Bot run with `EVAL_TRANSPORT=vast` + `--reuse <id>` leaves instance running after completion
- [ ] `vast_eval.py` without `--reuse` errors unless `--allow-provision` is passed