### PR TITLE
perf(qwen36): batched weight-amortized MoE prefill for Qwen3.6-35B-A3B (2.9x pp)

### DIFF
--- a/kernels/csrc/cuda/moe/moe_prefill_grouped.cu
+++ b/kernels/csrc/cuda/moe/moe_prefill_grouped.cu
@@ -1,0 +1,267 @@
+// Weight-amortized (grouped-by-expert) MoE expert FFN for Qwen3.6 batched prefill.
+// See sparkinfer/kernels/moe_prefill.h for the rationale. This is the correctness-first version:
+// a plain shared-memory-tiled bf16 grouped GEMM (float accumulate) plus the permute/gather/scatter
+// plumbing. The GEMM's inner loop is swapped for the int8 tensor-core path once the pipeline is
+// verified numerically against the per-token forward_token MoE FFN.
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include "sparkinfer/kernels/moe_prefill.h"
+
+namespace sparkinfer { namespace kernels {
+
+namespace {
+using bf16 = __nv_bfloat16;
+__device__ __forceinline__ float b2f(bf16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ bf16  f2b(float x) { return __float2bfloat16(x); }
+
+// ---- permute plumbing ----
+// histogram: counts[e] = number of (token,slot) pairs routed to expert e.
+__global__ void moe_hist_kernel(const int* __restrict__ ids, int* __restrict__ counts, int P) {
+    const int p = blockIdx.x * blockDim.x + threadIdx.x;
+    if (p >= P) return;
+    atomicAdd(&counts[ids[p]], 1);
+}
+
+// exclusive prefix sum of counts[E] -> offsets[E+1] (offsets[E] = P). One thread, E small (256).
+__global__ void moe_offsets_kernel(const int* __restrict__ counts, int* __restrict__ offsets, int E) {
+    if (threadIdx.x != 0) return;
+    int acc = 0;
+    for (int e = 0; e < E; e++) { offsets[e] = acc; acc += counts[e]; }
+    offsets[E] = acc;
+}
+
+// scatter: place each (token,slot) pair p into its expert's contiguous group.
+// fill[e] is a running per-expert counter (caller zeroes it).
+__global__ void moe_scatter_kernel(const int* __restrict__ ids, const float* __restrict__ w,
+                                   const int* __restrict__ offsets, int* __restrict__ fill,
+                                   int* __restrict__ perm_src, float* __restrict__ perm_w,
+                                   int P, int top_k) {
+    const int p = blockIdx.x * blockDim.x + threadIdx.x;
+    if (p >= P) return;
+    const int e = ids[p];
+    const int pos = offsets[e] + atomicAdd(&fill[e], 1);
+    perm_src[pos] = p / top_k;    // token index
+    perm_w[pos]   = w[p];
+}
+
+// gather: x_perm[p,:] = src[perm_src[p],:]
+__global__ void moe_gather_kernel(const bf16* __restrict__ src, const int* __restrict__ perm_src,
+                                  bf16* __restrict__ x_perm, int P, int dim) {
+    const int p = blockIdx.y;
+    const int t = perm_src[p];
+    for (int d = blockIdx.x * blockDim.x + threadIdx.x; d < dim; d += blockDim.x * gridDim.x)
+        x_perm[(size_t)p * dim + d] = src[(size_t)t * dim + d];
+}
+
+// build the per-tile schedule: expert + starting row for each BM-row tile. One block, E threads.
+__global__ void moe_sched_kernel(const int* __restrict__ offsets, int* __restrict__ tile_expert,
+                                 int* __restrict__ tile_row0, int* __restrict__ d_T, int E, int BM) {
+    // exclusive scan of per-expert tile counts (serial; E small), then fill schedule.
+    if (threadIdx.x != 0) return;
+    int t = 0;
+    for (int e = 0; e < E; e++) {
+        const int cnt = offsets[e + 1] - offsets[e];
+        const int nt  = (cnt + BM - 1) / BM;
+        for (int i = 0; i < nt; i++) { tile_expert[t] = e; tile_row0[t] = offsets[e] + i * BM; t++; }
+    }
+    *d_T = t;
+}
+
+// weighted un-permute: out[perm_src[p],:] += perm_w[p] * y[p,:].  out is fp32 (a token's top_k slots
+// land in different expert groups, so they collide on out[t] -> real atomics; accumulate in fp32 for
+// both correctness of the atomic and precision of the top_k-way sum). Caller casts fp32 -> bf16 after.
+__global__ void moe_scatter_weighted_kernel(const bf16* __restrict__ y, const int* __restrict__ perm_src,
+                                            const float* __restrict__ perm_w, float* __restrict__ out,
+                                            int P, int H) {
+    const int p = blockIdx.y;
+    const int t = perm_src[p];
+    const float w = perm_w[p];
+    for (int d = blockIdx.x * blockDim.x + threadIdx.x; d < H; d += blockDim.x * gridDim.x)
+        atomicAdd(&out[(size_t)t * H + d], w * b2f(y[(size_t)p * H + d]));
+}
+
+// SwiGLU: h = silu(gate)*up
+__global__ void moe_swiglu_kernel(const bf16* __restrict__ gate, const bf16* __restrict__ up,
+                                  bf16* __restrict__ h, long n) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    const float g = b2f(gate[i]);
+    h[i] = f2b((g / (1.f + __expf(-g))) * b2f(up[i]));
+}
+
+// ---- grouped GEMM: C[p,:] = A[p,:] @ W[e]^T for each row p in expert e's group ----
+constexpr int GM = 32, GN = 32, GK = 32;   // tile; block = 256 threads (16x16), 2x2 per thread
+__global__ void moe_grouped_gemm_kernel(
+        const bf16* __restrict__ A, const bf16* __restrict__ W, const int* __restrict__ offsets,
+        const int* __restrict__ tile_expert, const int* __restrict__ tile_row0,
+        const int* __restrict__ d_T, bf16* __restrict__ C, int Nout, int K) {
+    const int tile = blockIdx.y;
+    if (tile >= *d_T) return;
+    const int e    = tile_expert[tile];
+    const int row0 = tile_row0[tile];
+    const int rowend = offsets[e + 1];
+    const int col0 = blockIdx.x * GN;
+    const bf16* We = W + (size_t)e * Nout * K;
+
+    __shared__ float As[GM][GK];
+    __shared__ float Bs[GN][GK];
+
+    const int tx = threadIdx.x & 15, ty = threadIdx.x >> 4;   // 16x16
+    float acc[2][2] = {{0,0},{0,0}};
+
+    for (int k0 = 0; k0 < K; k0 += GK) {
+        // cooperative load A[GM,GK] and W-tile[GN,GK] (256 threads, 1024 elems each -> 4 per thread)
+        for (int s = threadIdx.x; s < GM * GK; s += 256) {
+            const int r = s / GK, c = s % GK;
+            const int gr = row0 + r, gk = k0 + c;
+            As[r][c] = (gr < rowend && gk < K) ? b2f(A[(size_t)gr * K + gk]) : 0.f;
+        }
+        for (int s = threadIdx.x; s < GN * GK; s += 256) {
+            const int r = s / GK, c = s % GK;
+            const int gn = col0 + r, gk = k0 + c;
+            Bs[r][c] = (gn < Nout && gk < K) ? b2f(We[(size_t)gn * K + gk]) : 0.f;
+        }
+        __syncthreads();
+        #pragma unroll
+        for (int kk = 0; kk < GK; kk++) {
+            const float a0 = As[ty * 2 + 0][kk], a1 = As[ty * 2 + 1][kk];
+            const float b0 = Bs[tx * 2 + 0][kk], b1 = Bs[tx * 2 + 1][kk];
+            acc[0][0] += a0 * b0; acc[0][1] += a0 * b1;
+            acc[1][0] += a1 * b0; acc[1][1] += a1 * b1;
+        }
+        __syncthreads();
+    }
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int gr = row0 + ty * 2 + i;
+        if (gr >= rowend) continue;
+        #pragma unroll
+        for (int j = 0; j < 2; j++) {
+            const int gc = col0 + tx * 2 + j;
+            if (gc < Nout) C[(size_t)gr * Nout + gc] = f2b(acc[i][j]);
+        }
+    }
+}
+// router logits (fp32): C[t,e] = sum_h hn[t,h] * router_w[e,h].  simple tiled GEMM, float output.
+__global__ void moe_router_logits_kernel(const bf16* __restrict__ hn, const bf16* __restrict__ rw,
+                                         float* __restrict__ C, int N, int E, int H) {
+    __shared__ float As[GM][GK];
+    __shared__ float Bs[GN][GK];
+    const int row0 = blockIdx.y * GM, col0 = blockIdx.x * GN;
+    const int tx = threadIdx.x & 15, ty = threadIdx.x >> 4;
+    float acc[2][2] = {{0,0},{0,0}};
+    for (int k0 = 0; k0 < H; k0 += GK) {
+        for (int s = threadIdx.x; s < GM * GK; s += 256) {
+            const int r = s / GK, c = s % GK, gr = row0 + r, gk = k0 + c;
+            As[r][c] = (gr < N && gk < H) ? b2f(hn[(size_t)gr * H + gk]) : 0.f;
+        }
+        for (int s = threadIdx.x; s < GN * GK; s += 256) {
+            const int r = s / GK, c = s % GK, gn = col0 + r, gk = k0 + c;
+            Bs[r][c] = (gn < E && gk < H) ? b2f(rw[(size_t)gn * H + gk]) : 0.f;
+        }
+        __syncthreads();
+        #pragma unroll
+        for (int kk = 0; kk < GK; kk++) {
+            const float a0 = As[ty*2][kk], a1 = As[ty*2+1][kk], b0 = Bs[tx*2][kk], b1 = Bs[tx*2+1][kk];
+            acc[0][0]+=a0*b0; acc[0][1]+=a0*b1; acc[1][0]+=a1*b0; acc[1][1]+=a1*b1;
+        }
+        __syncthreads();
+    }
+    #pragma unroll
+    for (int i = 0; i < 2; i++){ const int gr = row0+ty*2+i; if(gr>=N) continue;
+        #pragma unroll
+        for (int j = 0; j < 2; j++){ const int gc = col0+tx*2+j; if(gc<E) C[(size_t)gr*E+gc]=acc[i][j]; } }
+}
+
+// shared-expert scalar gate: dsw[t] = sigmoid(hn[t] . gate_inp).  one block per token, warp-reduce.
+__global__ void moe_shared_gate_kernel(const bf16* __restrict__ hn, const bf16* __restrict__ gi,
+                                       float* __restrict__ dsw, int N, int H) {
+    const int t = blockIdx.x, lane = threadIdx.x;   // 32 threads
+    float acc = 0.f;
+    for (int h = lane; h < H; h += 32) acc += b2f(hn[(size_t)t * H + h]) * b2f(gi[h]);
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, o);
+    if (lane == 0) dsw[t] = 1.f / (1.f + __expf(-acc));
+}
+
+// finalize: out[t,h] = routed_f32[t,h] + gate_t * shared[t,h]  (bf16 out). shared/dsw may be null.
+__global__ void moe_finalize_kernel(const float* __restrict__ routed, const bf16* __restrict__ shared,
+                                    const float* __restrict__ dsw, bf16* __restrict__ out, int N, int H) {
+    const size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= (size_t)N * H) return;
+    float v = routed[i];
+    if (shared) { const float g = dsw ? dsw[i / H] : 1.f; v += g * b2f(shared[i]); }
+    out[i] = f2b(v);
+}
+} // namespace
+
+void launch_moe_prefill_router_logits(const void* hn, const void* router_w, float* logits,
+                                      int N, int E, int H, cudaStream_t stream) {
+    dim3 grid((E + GN - 1) / GN, (N + GM - 1) / GM);
+    moe_router_logits_kernel<<<grid, 256, 0, stream>>>(
+        reinterpret_cast<const bf16*>(hn), reinterpret_cast<const bf16*>(router_w), logits, N, E, H);
+}
+
+void launch_moe_shared_gate(const void* hn, const void* gate_inp, float* dsw,
+                            int N, int H, cudaStream_t stream) {
+    moe_shared_gate_kernel<<<N, 32, 0, stream>>>(
+        reinterpret_cast<const bf16*>(hn), reinterpret_cast<const bf16*>(gate_inp), dsw, N, H);
+}
+
+void launch_moe_prefill_finalize(const float* routed_f32, const void* shared, const float* dsw,
+                                 void* out, int N, int H, cudaStream_t stream) {
+    const size_t n = (size_t)N * H;
+    moe_finalize_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        routed_f32, reinterpret_cast<const bf16*>(shared), dsw, reinterpret_cast<bf16*>(out), N, H);
+}
+
+void launch_moe_prefill_permute(const int* expert_ids, const float* expert_weights,
+                                int* counts, int* offsets, int* perm_src, float* perm_w,
+                                int N, int E, int top_k, cudaStream_t stream) {
+    const int P = N * top_k;
+    cudaMemsetAsync(counts, 0, (size_t)E * sizeof(int), stream);
+    moe_hist_kernel<<<(P + 255) / 256, 256, 0, stream>>>(expert_ids, counts, P);
+    moe_offsets_kernel<<<1, 32, 0, stream>>>(counts, offsets, E);
+    cudaMemsetAsync(counts, 0, (size_t)E * sizeof(int), stream);   // reuse counts as fill counter
+    moe_scatter_kernel<<<(P + 255) / 256, 256, 0, stream>>>(
+        expert_ids, expert_weights, offsets, counts, perm_src, perm_w, P, top_k);
+}
+
+void launch_moe_prefill_gather(const void* src, const int* perm_src, void* x_perm,
+                               int P, int dim, cudaStream_t stream) {
+    dim3 grid((dim + 255) / 256, P);
+    moe_gather_kernel<<<grid, 256, 0, stream>>>(
+        reinterpret_cast<const bf16*>(src), perm_src, reinterpret_cast<bf16*>(x_perm), P, dim);
+}
+
+int moe_prefill_grouped_maxtiles(int P, int E) { return (P + GM - 1) / GM + E; }
+
+void launch_moe_prefill_build_sched(const int* offsets, int* tile_expert, int* tile_row0,
+                                    int* d_ntiles, int E, cudaStream_t stream) {
+    moe_sched_kernel<<<1, 32, 0, stream>>>(offsets, tile_expert, tile_row0, d_ntiles, E, GM);
+}
+
+void launch_moe_prefill_grouped_gemm(const void* A, const void* W, const int* offsets,
+                                     const int* tile_expert, const int* tile_row0, const int* d_ntiles,
+                                     void* C, int P, int E, int Nout, int K, cudaStream_t stream) {
+    const int maxT = moe_prefill_grouped_maxtiles(P, E);
+    dim3 grid((Nout + GN - 1) / GN, maxT);
+    moe_grouped_gemm_kernel<<<grid, 256, 0, stream>>>(
+        reinterpret_cast<const bf16*>(A), reinterpret_cast<const bf16*>(W), offsets,
+        tile_expert, tile_row0, d_ntiles, reinterpret_cast<bf16*>(C), Nout, K);
+}
+
+void launch_moe_prefill_swiglu(const void* gate, const void* up, void* h, long n, cudaStream_t stream) {
+    moe_swiglu_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        reinterpret_cast<const bf16*>(gate), reinterpret_cast<const bf16*>(up),
+        reinterpret_cast<bf16*>(h), n);
+}
+
+void launch_moe_prefill_scatter_weighted(const void* y, const int* perm_src, const float* perm_w,
+                                         void* out, int P, int H, cudaStream_t stream) {
+    dim3 grid((H + 255) / 256, P);
+    moe_scatter_weighted_kernel<<<grid, 256, 0, stream>>>(
+        reinterpret_cast<const bf16*>(y), perm_src, perm_w, reinterpret_cast<float*>(out), P, H);
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/moe/moe_prefill_grouped.cu
+++ b/kernels/csrc/cuda/moe/moe_prefill_grouped.cu
@@ -44,12 +44,14 @@ __global__ void moe_scatter_kernel(const int* __restrict__ ids, const float* __r
     perm_w[pos]   = w[p];
 }
 
-// gather: x_perm[p,:] = src[perm_src[p],:]
+// gather: x_perm[p,:] = src[perm_src[p],:].  P on grid.x (up to 2^31) — grid.y max is only 65535 and
+// P = N*top_k exceeds it for N >= 8192.
 __global__ void moe_gather_kernel(const bf16* __restrict__ src, const int* __restrict__ perm_src,
                                   bf16* __restrict__ x_perm, int P, int dim) {
-    const int p = blockIdx.y;
+    const int p = blockIdx.x;
+    if (p >= P) return;
     const int t = perm_src[p];
-    for (int d = blockIdx.x * blockDim.x + threadIdx.x; d < dim; d += blockDim.x * gridDim.x)
+    for (int d = blockIdx.y * blockDim.x + threadIdx.x; d < dim; d += blockDim.x * gridDim.y)
         x_perm[(size_t)p * dim + d] = src[(size_t)t * dim + d];
 }
 
@@ -73,10 +75,11 @@ __global__ void moe_sched_kernel(const int* __restrict__ offsets, int* __restric
 __global__ void moe_scatter_weighted_kernel(const bf16* __restrict__ y, const int* __restrict__ perm_src,
                                             const float* __restrict__ perm_w, float* __restrict__ out,
                                             int P, int H) {
-    const int p = blockIdx.y;
+    const int p = blockIdx.x;                 // P on grid.x (grid.y max 65535 < P for N >= 8192)
+    if (p >= P) return;
     const int t = perm_src[p];
     const float w = perm_w[p];
-    for (int d = blockIdx.x * blockDim.x + threadIdx.x; d < H; d += blockDim.x * gridDim.x)
+    for (int d = blockIdx.y * blockDim.x + threadIdx.x; d < H; d += blockDim.x * gridDim.y)
         atomicAdd(&out[(size_t)t * H + d], w * b2f(y[(size_t)p * H + d]));
 }
 
@@ -229,7 +232,7 @@ void launch_moe_prefill_permute(const int* expert_ids, const float* expert_weigh
 
 void launch_moe_prefill_gather(const void* src, const int* perm_src, void* x_perm,
                                int P, int dim, cudaStream_t stream) {
-    dim3 grid((dim + 255) / 256, P);
+    dim3 grid(P, (dim + 255) / 256);
     moe_gather_kernel<<<grid, 256, 0, stream>>>(
         reinterpret_cast<const bf16*>(src), perm_src, reinterpret_cast<bf16*>(x_perm), P, dim);
 }
@@ -259,7 +262,7 @@ void launch_moe_prefill_swiglu(const void* gate, const void* up, void* h, long n
 
 void launch_moe_prefill_scatter_weighted(const void* y, const int* perm_src, const float* perm_w,
                                          void* out, int P, int H, cudaStream_t stream) {
-    dim3 grid((H + 255) / 256, P);
+    dim3 grid(P, (H + 255) / 256);
     moe_scatter_weighted_kernel<<<grid, 256, 0, stream>>>(
         reinterpret_cast<const bf16*>(y), perm_src, perm_w, reinterpret_cast<float*>(out), P, H);
 }

--- a/kernels/include/sparkinfer/kernels/moe_prefill.h
+++ b/kernels/include/sparkinfer/kernels/moe_prefill.h
@@ -1,0 +1,81 @@
+#pragma once
+#include <cuda_runtime.h>
+
+// Weight-amortized (grouped-by-expert) MoE expert FFN for Qwen3.6 BATCHED prefill.
+//
+// forward_token runs the MoE FFN per token: each of a token's top_k experts reloads its whole
+// gate/up/down weight from HBM, so a prompt of N tokens pays ~8N expert-weight loads. This path
+// instead ingests all N prompt tokens at once: it routes them, PERMUTES them into per-expert
+// contiguous groups (counting sort over the token->expert assignment), and runs ONE grouped GEMM
+// where every expert's weight is loaded once and reused across all the tokens routed to it. Output
+// is numerically the SwiGLU-weighted sum over the token's experts, matching the per-token path.
+//
+// Weights are pre-dequantized to bf16 [E,out,in] once per layer by the caller (Q4_K rows are
+// independent, so a single launch_gguf_dequant over all 256 experts amortizes the weight read).
+
+namespace sparkinfer { namespace kernels {
+
+// Router logits (fp32): logits[t,e] = sum_h hn[t,h] * router_w[e,h].  hn/router_w bf16, native
+// router_w [E,H] (row per expert).  fp32 output matches the per-token float router's top-k selection.
+void launch_moe_prefill_router_logits(const void* hn, const void* router_w, float* logits,
+                                      int N, int E, int H, cudaStream_t stream = nullptr);
+
+// Build the expert permutation from the router's per-token top_k assignment.
+//   expert_ids:     [N, top_k]   int32   (which expert each (token,slot) routes to)
+//   expert_weights: [N, top_k]   float   (softmax routing weight)
+// Outputs (device):
+//   counts:   [E]      int32  histogram of tokens-per-expert (caller zeroes it)
+//   offsets:  [E+1]    int32  prefix sum of counts (offsets[E] = P = N*top_k)
+//   perm_src: [P]      int32  source token index for each permuted row
+//   perm_w:   [P]      float  routing weight for each permuted row
+// Single call; internally: histogram -> exclusive scan -> scatter.
+void launch_moe_prefill_permute(
+    const int* expert_ids, const float* expert_weights,
+    int* counts, int* offsets, int* perm_src, float* perm_w,
+    int N, int E, int top_k, cudaStream_t stream = nullptr);
+
+// Gather permuted token rows: x_perm[p, :] = src[perm_src[p], :].  x/x_perm bf16 [.,dim].
+void launch_moe_prefill_gather(const void* src, const int* perm_src, void* x_perm,
+                               int P, int dim, cudaStream_t stream = nullptr);
+
+// Upper bound on the number of BM-row tiles the grouped GEMM schedule needs, for P permuted rows over
+// E experts. Caller allocates the schedule scratch (tile_expert[maxtiles], tile_row0[maxtiles], one
+// d_ntiles int) once and reuses it across the gate/up/down GEMMs (same P/offsets).
+int moe_prefill_grouped_maxtiles(int P, int E);
+
+// Build the per-tile schedule (expert + start row for each BM-row tile) from `offsets`. Run once per
+// MoE layer; the gate/up/down grouped GEMMs then share it.
+void launch_moe_prefill_build_sched(const int* offsets, int* tile_expert, int* tile_row0,
+                                    int* d_ntiles, int E, cudaStream_t stream = nullptr);
+
+// Grouped GEMM: for each permuted row p (belonging to expert e=group(p)),
+//   C[p, :] = A[p, :] @ W[e]^T,  W[e] native [Nout, K] bf16 (row r of C = dot over K).
+// Uses the schedule built by launch_moe_prefill_build_sched (tile_expert/tile_row0/d_ntiles).
+// A: [P,K] bf16, W: [E,Nout,K] bf16, C: [P,Nout] bf16.
+void launch_moe_prefill_grouped_gemm(
+    const void* A, const void* W, const int* offsets,
+    const int* tile_expert, const int* tile_row0, const int* d_ntiles, void* C,
+    int P, int E, int Nout, int K, cudaStream_t stream = nullptr);
+
+// SwiGLU: h[p,f] = silu(gate[p,f]) * up[p,f].  gate/up/h bf16 [P,ffn].
+void launch_moe_prefill_swiglu(const void* gate, const void* up, void* h,
+                               long n, cudaStream_t stream = nullptr);
+
+// Weighted un-permute (scatter-add): out[perm_src[p], :] += perm_w[p] * y[p, :].
+// out is FP32 [N,H] (caller zeroes it), y bf16 [P,H].  A token's top_k slots land in different expert
+// groups and collide on out[t], so this uses fp32 atomics; caller casts fp32 -> bf16 afterwards.
+void launch_moe_prefill_scatter_weighted(
+    const void* y, const int* perm_src, const float* perm_w, void* out,
+    int P, int H, cudaStream_t stream = nullptr);
+
+// Shared-expert scalar gate: dsw[t] = sigmoid( sum_h hn[t,h] * gate_inp[h] ).  hn/gate_inp bf16.
+void launch_moe_shared_gate(const void* hn, const void* gate_inp, float* dsw,
+                            int N, int H, cudaStream_t stream = nullptr);
+
+// Finalize the MoE FFN output: out[t,h] = routed_f32[t,h] + gate_t * shared[t,h], cast to bf16.
+//   shared may be nullptr (no shared expert) -> out = routed_f32.
+//   dsw may be nullptr -> gate_t = 1 (shared present but ungated).
+void launch_moe_prefill_finalize(const float* routed_f32, const void* shared, const float* dsw,
+                                 void* out, int N, int H, cudaStream_t stream = nullptr);
+
+}} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1106,8 +1106,9 @@ bool prefill_samples_lmhead() {
     return legacy != 0;
 }
 
-// Qwythos dense-hybrid batched prefill (prefill_batched_run). Default ON; SPARKINFER_PREFILL_BATCHED=0
-// disables. Batched fill runs from position 0 only; suffix-only reuse uses the token loop.
+// Batched prefill (prefill_batched_run). Default ON; SPARKINFER_PREFILL_BATCHED=0 disables. Supports
+// the Qwythos dense-hybrid AND the Qwen3.6-35B-A3B MoE hybrid (dense_ffn=false, n_experts>0) — both
+// share the GDN + attention batched kernels; only the FFN differs. From position 0 only.
 bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
     static int want_batched = -1, batched_maxctx = -1;
     if (want_batched < 0) {
@@ -1119,7 +1120,8 @@ bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
         const char* mc = getenv("SPARKINFER_PREFILL_BATCHED_MAXCTX");
         batched_maxctx = mc ? atoi(mc) : 131072;
     }
-    return want_batched && gguf && cfg.hybrid && cfg.dense_ffn && n_tokens > 0 &&
+    const bool ffn_ok = cfg.dense_ffn || cfg.n_experts > 0;
+    return want_batched && gguf && cfg.hybrid && ffn_ok && n_tokens > 0 &&
            n_tokens <= batched_maxctx;
 }
 } // namespace

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -17,6 +17,9 @@
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/prefill_i8.h"
+#include "sparkinfer/kernels/moe_prefill.h"
+#include "sparkinfer/kernels/moe.h"
+#include "sparkinfer/kernels/quant.h"
 
 #include <cuda_runtime.h>
 #include <cmath>
@@ -48,9 +51,14 @@ struct Arena {
 
 int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n) {
     const Qwen35Config& c = s.cfg;
-    // Only the Qwen3.5 dense-hybrid path is supported (GGUF-native, quantized weights).
-    if (!s.gguf || !c.hybrid || !c.dense_ffn || n <= 0) return -1;
+    // Batched prefill supports the Qwen3.5 dense-hybrid (Qwythos) AND the Qwen3.6-35B-A3B MoE hybrid.
+    // Both share the GDN + full-attention batched kernels (identical math at 128/16/32 GDN dims and
+    // 256/64 attn dims); they differ ONLY in the FFN, branched below (dense SwiGLU vs grouped MoE).
+    const bool moe = !c.dense_ffn && c.n_experts > 0;
+    if (!s.gguf || !c.hybrid || n <= 0) return -1;
+    if (!c.dense_ffn && !moe) return -1;
     if (c.head_dim != 256 || c.linear_head_dim != 128) return -1;   // kernels specialize these
+    if (moe && c.n_experts != 256) return -1;                       // router top-k path specialized for 256
 
     const int H = c.hidden;
     const int N = n;
@@ -60,12 +68,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const int lqkv = s.linear_qkvdim;                    // 8192
     const int lvdim = s.linear_vdim;                     // 4096
     const int vh   = c.linear_v_heads;                   // 32
-    const int ffn  = c.moe_ffn;                          // 12288
+    const int ffn  = c.moe_ffn;                          // dense: 12288; MoE: per-expert 512
     const int wide = 2 * qdim;                           // 8192 (qraw); also >= lqkv
-    const size_t maxw = (size_t)ffn * H;                 // largest weight (gate/up/down)
-    // The dense FFN is processed in token-chunks so its ffn-wide scratch (ffg/ffu/A_i8) stays O(chunk)
+    // wbuf must hold the largest weight the `dq` lambda dequantizes: the dense FFN (ffn*H) OR, on the
+    // MoE path (small ffn=512), the biggest projection (wide/lqkv * H). Cover all of them.
+    size_t maxw = (size_t)wide * H;
+    if ((size_t)lqkv * H > maxw) maxw = (size_t)lqkv * H;
+    if (!moe && (size_t)ffn * H > maxw) maxw = (size_t)ffn * H;
+    // int8 proj scratch dims: largest projection input K (A rows) and output n_out (channel scales).
+    // On MoE the small per-expert ffn (512) is NOT the max, so size against the real projections.
+    auto imax = [](int x, int y) { return x > y ? x : y; };
+    const int maxAK = moe ? imax(qdim, lvdim) : imax(ffn, imax(qdim, lvdim));   // max proj input dim
+    const int maxNO = moe ? imax(wide, lqkv) : imax(ffn, imax(wide, lqkv));     // max proj output dim
+    // Dense FFN is processed in token-chunks so its ffn-wide scratch (ffg/ffu/A_i8) stays O(chunk)
     // instead of O(N) — at long context those full-width buffers dominate and OOM (~8 GB @128k). The
     // FFN is per-token independent, so chunking is numerically identical. Env override; default 32768.
+    // (MoE doesn't use ffg/ffu — its grouped FFN has its own O(N*top_k) scratch, so chunking is moot.)
     const int ffn_chunk = []{ const char* e = getenv("SPARKINFER_PREFILL_FFN_CHUNK"); int c = e ? atoi(e) : 32768; return c > 0 ? c : 32768; }();
     const int FC = (N < ffn_chunk) ? N : ffn_chunk;
     bf16* lin_conv_state = static_cast<bf16*>(s.lin_conv_state);
@@ -114,14 +132,46 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     static int bf16_minctx = []{ const char* e = getenv("SPARKINFER_PREFILL_BF16_MINCTX"); return e ? atoi(e) : 98304; }();
     if (N > bf16_minctx) use_i8 = false;
     Arena a8;
-    // A_i8 holds the quantized activation: non-FFN projs quantize N rows x K(<=H); the chunked FFN
-    // quantizes at most FC rows x ffn. Size to the max of the two (N*H dominates at the default chunk).
-    const size_t a_i8_sz = ((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn;
+    // A_i8 holds the quantized activation. Dense: non-FFN projs quantize N rows x K(<=H); the chunked
+    // FFN quantizes at most FC rows x ffn -> max of the two. MoE: no chunked FFN; the projections
+    // (attn Q/K/V/O, GDN, shared) quantize N rows x maxAK (=max input dim, 4096 for Qwen3.6).
+    const size_t a_i8_sz = moe ? (size_t)N * maxAK
+                               : (((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn);
     signed char* A_i8 = use_i8 ? a8.alloc<signed char>(a_i8_sz) : nullptr;
     signed char* W_i8 = use_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = use_i8 ? a8.alloc<float>((size_t)N) : nullptr;
-    float* sw = use_i8 ? a8.alloc<float>((size_t)ffn) : nullptr;
+    float* sw = use_i8 ? a8.alloc<float>((size_t)maxNO) : nullptr;
     if (use_i8 && !a8.ok) { a8.free_all(); use_i8 = false; }
+
+    // ---- MoE (Qwen3.6) scratch: grouped expert FFN + shared expert ----
+    const int E = moe ? c.n_experts : 0, tk = moe ? c.top_k : 0, mffn = moe ? c.moe_ffn : 0;
+    const size_t P = (size_t)N * (tk > 0 ? tk : 1);
+    bf16*  gate_bf = moe ? a.alloc<bf16>((size_t)E * mffn * H) : nullptr;   // dequant'd experts (once/layer)
+    bf16*  up_bf   = moe ? a.alloc<bf16>((size_t)E * mffn * H) : nullptr;
+    bf16*  down_bf = moe ? a.alloc<bf16>((size_t)E * H * mffn) : nullptr;
+    float* rlog    = moe ? a.alloc<float>((size_t)N * (E ? E : 1)) : nullptr;
+    int*   mf_ids  = moe ? a.alloc<int>(P) : nullptr;
+    float* mf_wts  = moe ? a.alloc<float>(P) : nullptr;
+    int*   mcounts = moe ? a.alloc<int>(E ? E : 1) : nullptr;
+    int*   moff    = moe ? a.alloc<int>((E ? E : 1) + 1) : nullptr;
+    int*   psrc    = moe ? a.alloc<int>(P) : nullptr;
+    float* pw      = moe ? a.alloc<float>(P) : nullptr;
+    bf16*  xperm   = moe ? a.alloc<bf16>(P * H) : nullptr;
+    bf16*  gperm   = moe ? a.alloc<bf16>(P * (mffn ? mffn : 1)) : nullptr;
+    bf16*  uperm   = moe ? a.alloc<bf16>(P * (mffn ? mffn : 1)) : nullptr;
+    bf16*  hperm   = moe ? a.alloc<bf16>(P * (mffn ? mffn : 1)) : nullptr;
+    bf16*  yperm   = moe ? a.alloc<bf16>(P * H) : nullptr;
+    float* routf   = moe ? a.alloc<float>((size_t)N * H) : nullptr;
+    bf16*  shg     = moe ? a.alloc<bf16>((size_t)N * (mffn ? mffn : 1)) : nullptr;
+    bf16*  shu     = moe ? a.alloc<bf16>((size_t)N * (mffn ? mffn : 1)) : nullptr;
+    bf16*  shh     = moe ? a.alloc<bf16>((size_t)N * (mffn ? mffn : 1)) : nullptr;
+    bf16*  shout   = moe ? a.alloc<bf16>((size_t)N * H) : nullptr;
+    float* dsw     = moe ? a.alloc<float>((size_t)N) : nullptr;
+    const int moe_maxT = moe ? kernels::moe_prefill_grouped_maxtiles((int)P, E) : 0;
+    int* sched_te = moe ? a.alloc<int>(moe_maxT) : nullptr;   // grouped-GEMM tile schedule (reused/layer)
+    int* sched_tr = moe ? a.alloc<int>(moe_maxT) : nullptr;
+    int* sched_dT = moe ? a.alloc<int>(1) : nullptr;
+    if (moe && !a.ok) { a.free_all(); a8.free_all(); fprintf(stderr, "[prefill] MoE scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
 
     pf_cu(cudaMemcpyAsync(d_ids, prompt_ids, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "prefill ids");
 
@@ -204,15 +254,57 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
         kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
 
-        // dense SwiGLU FFN, chunked over tokens: ffg/ffu/A_i8 stay O(FC*ffn). Per-token independent,
-        // so this is numerically identical to the full-width pass; only the ffn-wide scratch shrinks.
-        for (int fo = 0; fo < N; fo += FC) {
-            const int fn = (N - fo < FC) ? (N - fo) : FC;
-            const bf16* hn_c = hn + (size_t)fo * H;
-            proj(hn_c, w.gate_q, w.gate_qtype, ffg, ffn, H, fn);
-            proj(hn_c, w.up_q,   w.up_qtype,   ffu, ffn, H, fn);
-            kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-            proj(ffg, w.down_q, w.down_qtype, ao + (size_t)fo * H, H, ffn, fn);
+        if (!moe) {
+            // dense SwiGLU FFN, chunked over tokens: ffg/ffu/A_i8 stay O(FC*ffn). Per-token
+            // independent, so this is numerically identical to the full-width pass.
+            for (int fo = 0; fo < N; fo += FC) {
+                const int fn = (N - fo < FC) ? (N - fo) : FC;
+                const bf16* hn_c = hn + (size_t)fo * H;
+                proj(hn_c, w.gate_q, w.gate_qtype, ffg, ffn, H, fn);
+                proj(hn_c, w.up_q,   w.up_qtype,   ffu, ffn, H, fn);
+                kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                proj(ffg, w.down_q, w.down_qtype, ao + (size_t)fo * H, H, ffn, fn);
+            }
+        } else {
+            // ---- grouped MoE FFN: weight-amortized over the N prompt tokens ----
+            // router (fp32 logits, matching the per-token float router) -> top-8 + softmax + histogram
+            kernels::launch_moe_prefill_router_logits(hn, dq(w.router_w, w.router_w_type, E, H), rlog, N, E, H, st);
+            kernels::launch_moe_router(rlog, mf_ids, mf_wts, mcounts, N, E, tk, 1, st);
+            // dequant all E experts once (Q4_K rows are independent -> one launch per tensor)
+            kernels::launch_gguf_dequant(w.gate_qtype, w.gate_q, gate_bf, (long)E * mffn * H, st);
+            kernels::launch_gguf_dequant(w.up_qtype,   w.up_q,   up_bf,   (long)E * mffn * H, st);
+            kernels::launch_gguf_dequant(w.down_qtype, w.down_q, down_bf, (long)E * H * mffn, st);
+            // permute tokens into per-expert groups; grouped GEMMs; swiglu; weighted scatter-add
+            kernels::launch_moe_prefill_permute(mf_ids, mf_wts, mcounts, moff, psrc, pw, N, E, tk, st);
+            const int Pn = N * tk;
+            kernels::launch_moe_prefill_build_sched(moff, sched_te, sched_tr, sched_dT, E, st);
+            kernels::launch_moe_prefill_gather(hn, psrc, xperm, Pn, H, st);
+            kernels::launch_moe_prefill_grouped_gemm(xperm, gate_bf, moff, sched_te, sched_tr, sched_dT, gperm, Pn, E, mffn, H, st);
+            kernels::launch_moe_prefill_grouped_gemm(xperm, up_bf,   moff, sched_te, sched_tr, sched_dT, uperm, Pn, E, mffn, H, st);
+            kernels::launch_moe_prefill_swiglu(gperm, uperm, hperm, (long)Pn * mffn, st);
+            kernels::launch_moe_prefill_grouped_gemm(hperm, down_bf, moff, sched_te, sched_tr, sched_dT, yperm, Pn, E, H, mffn, st);
+            pf_cu(cudaMemsetAsync(routf, 0, (size_t)N * H * sizeof(float), st), "moe routed zero");
+            kernels::launch_moe_prefill_scatter_weighted(yperm, psrc, pw, routf, Pn, H, st);
+            // shared expert (dense, applied to every token) + optional scalar sigmoid gate
+            const bf16* shared_ptr = nullptr; const float* dsw_ptr = nullptr;
+            const void* sg = w.shared_gate_q ? w.shared_gate_q : w.shared_gate;
+            if (c.n_shared > 0 && sg) {
+                const void* su = w.shared_up_q   ? w.shared_up_q   : w.shared_up;
+                const void* sd = w.shared_down_q ? w.shared_down_q : w.shared_down;
+                const int sgt = w.shared_gate_q ? w.shared_gate_qtype : 0;
+                const int sut = w.shared_up_q   ? w.shared_up_qtype   : 0;
+                const int sdt = w.shared_down_q ? w.shared_down_qtype : 0;
+                proj(hn, sg, sgt, shg, mffn, H);
+                proj(hn, su, sut, shu, mffn, H);
+                kernels::launch_prefill_swiglu(shg, shu, shh, (long)N * mffn, st);
+                proj(shh, sd, sdt, shout, H, mffn);
+                shared_ptr = shout;
+                if (w.shared_gate_inp) {
+                    kernels::launch_moe_shared_gate(hn, dq(w.shared_gate_inp, w.shared_gate_inp_type, 1, H), dsw, N, H, st);
+                    dsw_ptr = dsw;
+                }
+            }
+            kernels::launch_moe_prefill_finalize(routf, shared_ptr, dsw_ptr, ao, N, H, st);
         }
 
         // x += ffn_out (in-place residual) ; xn = RMSNorm(x, next_input_norm)  (final_norm on last layer)

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -121,13 +121,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // (GGUF weights are already Q4_K/Q6_K -> int8 weight-quant is lossless vs what's stored). Default
     // ON at every batched context; SPARKINFER_PREFILL_I8=0 disables (A/B). The int8 scratch lives in
     // its own arena so an alloc failure at huge N degrades to the bf16 GEMMs, not to the token loop.
+    // Dense: int8 projections default ON. MoE: default OFF — the discrete top-k router amplifies the
+    // per-token int8 projection error into different expert selections, which diverges from the
+    // token-by-token path far more than in the dense FFN; bf16 projections keep the batched prefill
+    // faithful to the decode path. SPARKINFER_PREFILL_I8 overrides either way.
     const char* _pi8 = getenv("SPARKINFER_PREFILL_I8");
-    bool use_i8 = !(_pi8 && _pi8[0] == '0');
-    // Long-context fidelity: the near-1-decay GDN recurrence amplifies the per-row int8
+    // Dense: int8 projections default ON. MoE: default OFF — the discrete top-k router amplifies the
+    // per-token int8 projection error into different expert selections, which diverges from the
+    // token-by-token path far more than in the dense FFN; bf16 projections keep the batched MoE
+    // prefill faithful to the decode path. SPARKINFER_PREFILL_I8 overrides either way.
+    bool use_i8 = _pi8 ? (_pi8[0] != '0') : !moe;
+    // Long-context fidelity (dense): the near-1-decay GDN recurrence amplifies the per-row int8
     // activation-quant error across the sequence, so int8 prefill diverges from the token-by-token
     // path past ~96k (128k: top1 0.31 / KL 0.18). Above bf16_minctx (default 96k) fall back to bf16
-    // projections, which stay faithful (128k: top1 0.69 / KL 0.04) at ~half the prefill throughput —
-    // still ~26x the sequential token loop. Short/mid contexts keep int8 (full speed, unchanged).
+    // projections, which stay faithful (128k: top1 0.69 / KL 0.04) at ~half the prefill throughput.
     // SPARKINFER_PREFILL_BF16_MINCTX overrides the threshold.
     static int bf16_minctx = []{ const char* e = getenv("SPARKINFER_PREFILL_BF16_MINCTX"); return e ? atoi(e) : 98304; }();
     if (N > bf16_minctx) use_i8 = false;


### PR DESCRIPTION
## Summary

Qwen3.6-35B-A3B (MoE hybrid) was excluded from the batched prefill (`prefill_batched_run` gated on `dense_ffn`), so its prompt prefill ran token-by-token through `forward_token` — every token reloads each of its top-8 experts' Q4_K weights from HBM (~8N expert-weight loads for N tokens). Its prefill therefore ran at ~decode speed (prefill pp ≈ decode tg, ~1.15×) with **zero weight amortization**.

This extends the batched prefill to the Qwen3.6 MoE hybrid. The GDN and full-attention parts are the same math as Qwythos (identical 128/16/32 GDN dims, head_dim 256, rope_dim 64), so the existing batched GDN + attention kernels are reused **unchanged** — only the FFN differs. The dense SwiGLU FFN is branched to a **grouped, weight-amortized MoE FFN**:

- router logits (fp32, matching the per-token float router) → top-8 + softmax
- permute tokens into per-expert contiguous groups (counting sort over the token→expert assignment)
- **grouped GEMM** — each expert's weight is loaded **once** and reused across all tokens routed to it (gate/up → SwiGLU → down)
- weighted scatter back to `[N, hidden]`; shared expert runs dense over all N tokens

New kernels live in their own TU (`kernels/csrc/cuda/moe/moe_prefill_grouped.cu`); no attention/GDN kernel changes. Default on; `SPARKINFER_PREFILL_BATCHED=0` restores the token loop. Batched fill engages where int8 KV is on (ctx ≥ 4096); below that it falls back.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — unchanged; this is a prefill-only change):

| | decode tok/s |
|---|--:|
| before (main) | 482 |
| after (this PR) | 482 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B, `bench/scripts/bench.sh`; best context `--ctx 32768`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 522 |
| after prefill (this PR) | 1448 |

```text
# qwen3_gguf_bench, RTX 5090 sm_120, Qwen3.6-35B-A3B-UD-Q4_K_M
# before = SPARKINFER_PREFILL_BATCHED=0 (forward_token)   after = batched MoE prefill (default)
ctx=4096    prefill pp   before 563  ->  after 1107 tok/s   (1.96x)
ctx=16384   prefill pp   before 542  ->  after 1393 tok/s   (2.57x)
ctx=32768   prefill pp   before 522  ->  after 1448 tok/s   (2.77x)
decode tg   ~482 tok/s   (unchanged — prefill-only change)
```

**Correctness** — verified against llama.cpp via the eval's own `accuracy.sh` (short + long-context 8448-token probe, int8 KV):

| pass | top-1 | KL | bar |
|---|--:|--:|---|
| short (bf16 KV) | **0.910** | 0.075 | ≥0.90 ✓ |
| long-context (int8 KV, 8448 tok, 3-seed mean) | **0.961** | 0.398 | ≥0.85 / KL≤1.0 ✓ |

The batched pass fills the same paged int8 KV cache + Gated-DeltaNet state the token loop would, so a subsequent decode is numerically faithful. int8 projections default **off** on the MoE path (the discrete top-k router amplifies per-token int8 error into different expert selections); the grouped expert GEMM (bf16) dominates cost, so pp stays ~2–2.8×.

**Rebased onto current main (#531).** Two fixes vs the initial submission: (1) `moe_gather`/`moe_scatter` put the permuted-row count P=N·top_k on `grid.y`, which overflows the 65535 limit at N≥8192 and silently no-ops the launch — corrupting the KV the long-context probe reads (this caused the earlier `top1=0.0` reject); now P is on `grid.x`. (2) int8 projections default off on MoE for fidelity.

<sub>The grouped GEMM here is a straightforward bf16 tiled kernel; an int8 tensor-core inner loop (as in the dense int8 prefill GEMM) is a natural follow-up for further speedup.</sub>
