### PR TITLE
perf(qwen35): faithful batched prefill to 128k for Qwythos

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1113,8 +1113,11 @@ bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
     if (want_batched < 0) {
         const char* e = getenv("SPARKINFER_PREFILL_BATCHED");
         want_batched = (e && e[0] == '0') ? 0 : 1;
+        // 128k: the windowed prefill attention (#455) is O(N*window) and the FFN scratch is chunked
+        // (prefill_batched_run), so the batched pass now fits VRAM and stays flat ~18k pp up to 128k
+        // (vs the ~300 pp sequential fallback). Raised from 64k. SPARKINFER_PREFILL_BATCHED_MAXCTX overrides.
         const char* mc = getenv("SPARKINFER_PREFILL_BATCHED_MAXCTX");
-        batched_maxctx = mc ? atoi(mc) : 65536;
+        batched_maxctx = mc ? atoi(mc) : 131072;
     }
     return want_batched && gguf && cfg.hybrid && cfg.dense_ffn && n_tokens > 0 &&
            n_tokens <= batched_maxctx;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -63,21 +63,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const int ffn  = c.moe_ffn;                          // 12288
     const int wide = 2 * qdim;                           // 8192 (qraw); also >= lqkv
     const size_t maxw = (size_t)ffn * H;                 // largest weight (gate/up/down)
+    // The dense FFN is processed in token-chunks so its ffn-wide scratch (ffg/ffu/A_i8) stays O(chunk)
+    // instead of O(N) — at long context those full-width buffers dominate and OOM (~8 GB @128k). The
+    // FFN is per-token independent, so chunking is numerically identical. Env override; default 32768.
+    const int ffn_chunk = []{ const char* e = getenv("SPARKINFER_PREFILL_FFN_CHUNK"); int c = e ? atoi(e) : 32768; return c > 0 ? c : 32768; }();
+    const int FC = (N < ffn_chunk) ? N : ffn_chunk;
     bf16* lin_conv_state = static_cast<bf16*>(s.lin_conv_state);
 
     // ---- scratch ----
     Arena a;
     bf16* x    = a.alloc<bf16>((size_t)N * H);
     bf16* xn   = a.alloc<bf16>((size_t)N * H);
-    bf16* hbuf = a.alloc<bf16>((size_t)N * H);
     bf16* hn   = a.alloc<bf16>((size_t)N * H);
     bf16* ao   = a.alloc<bf16>((size_t)N * H);
     bf16* b8   = a.alloc<bf16>((size_t)N * wide);        // qraw / lin_qkv (8192)
     bf16* lz   = a.alloc<bf16>((size_t)N * lvdim);       // lin_z (4096)
-    bf16* qb   = a.alloc<bf16>((size_t)N * qdim);        // full q (4096)
-    bf16* qg   = a.alloc<bf16>((size_t)N * qdim);        // full q-gate (4096)
-    bf16* kf   = a.alloc<bf16>((size_t)N * kvdim);       // full k (1024)
-    bf16* vf   = a.alloc<bf16>((size_t)N * kvdim);       // full v (1024)
     bf16* gq   = a.alloc<bf16>((size_t)N * s.linear_qdim);   // gdn q (2048)
     bf16* gk   = a.alloc<bf16>((size_t)N * s.linear_qdim);   // gdn k (2048)
     bf16* gv   = a.alloc<bf16>((size_t)N * lvdim);       // gdn v (4096)
@@ -85,9 +85,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* lnrm = a.alloc<bf16>((size_t)N * lvdim);       // lin_norm (4096)
     bf16* la   = a.alloc<bf16>((size_t)N * vh);          // lin_alpha (32)
     bf16* lb   = a.alloc<bf16>((size_t)N * vh);          // lin_beta (32)
-    bf16* ffg  = a.alloc<bf16>((size_t)N * ffn);         // ffn gate (12288)
-    bf16* ffu  = a.alloc<bf16>((size_t)N * ffn);         // ffn up
-    bf16* ffh  = a.alloc<bf16>((size_t)N * ffn);         // ffn silu(gate)*up
+    // Full-attention scratch ALIASES the GDN scratch: a layer is either linear-attn (GDN) or full
+    // softmax-attn, never both, and qb/qg/kf/vf are pairwise-distinct within a full-attn layer while
+    // the GDN buffers they map onto are unused there (and vice-versa). Saves ~10K bf16/token of peak
+    // scratch at long context (each is <= its GDN host: qdim/kvdim <= lvdim/linear_qdim).
+    bf16* qb   = gv;                                     // full q      (4096) <- gdn v    (4096)
+    bf16* qg   = lnrm;                                   // full q-gate (4096) <- lin_norm (4096)
+    bf16* kf   = gq;                                     // full k      (1024) <- gdn q    (2048)
+    bf16* vf   = gk;                                     // full v      (1024) <- gdn k    (2048)
+    bf16* ffg  = a.alloc<bf16>((size_t)FC * ffn);        // ffn gate (12288), bounded to FC tokens
+    bf16* ffu  = a.alloc<bf16>((size_t)FC * ffn);        // ffn up,          bounded to FC tokens
+    bf16* ffh  = ffg;                                    // SwiGLU computed in-place into ffg (down reads it)
     bf16* wbuf = a.alloc<bf16>(maxw);                    // dequantized-weight scratch (reused)
     int*  d_ids = a.alloc<int>((size_t)N);
     if (!a.ok) { a.free_all(); fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
@@ -97,8 +105,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // its own arena so an alloc failure at huge N degrades to the bf16 GEMMs, not to the token loop.
     const char* _pi8 = getenv("SPARKINFER_PREFILL_I8");
     bool use_i8 = !(_pi8 && _pi8[0] == '0');
+    // Long-context fidelity: the near-1-decay GDN recurrence amplifies the per-row int8
+    // activation-quant error across the sequence, so int8 prefill diverges from the token-by-token
+    // path past ~96k (128k: top1 0.31 / KL 0.18). Above bf16_minctx (default 96k) fall back to bf16
+    // projections, which stay faithful (128k: top1 0.69 / KL 0.04) at ~half the prefill throughput —
+    // still ~26x the sequential token loop. Short/mid contexts keep int8 (full speed, unchanged).
+    // SPARKINFER_PREFILL_BF16_MINCTX overrides the threshold.
+    static int bf16_minctx = []{ const char* e = getenv("SPARKINFER_PREFILL_BF16_MINCTX"); return e ? atoi(e) : 98304; }();
+    if (N > bf16_minctx) use_i8 = false;
     Arena a8;
-    signed char* A_i8 = use_i8 ? a8.alloc<signed char>((size_t)N * ffn) : nullptr;
+    // A_i8 holds the quantized activation: non-FFN projs quantize N rows x K(<=H); the chunked FFN
+    // quantizes at most FC rows x ffn. Size to the max of the two (N*H dominates at the default chunk).
+    const size_t a_i8_sz = ((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn;
+    signed char* A_i8 = use_i8 ? a8.alloc<signed char>(a_i8_sz) : nullptr;
     signed char* W_i8 = use_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = use_i8 ? a8.alloc<float>((size_t)N) : nullptr;
     float* sw = use_i8 ? a8.alloc<float>((size_t)ffn) : nullptr;
@@ -113,21 +132,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         return wbuf;
     };
     // C[N,n_out] = A[N,K] @ W^T  (W native quantized [n_out,K]).
-    auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K) {
+    auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K, int rows = 0) {
+        const int R = rows > 0 ? rows : N;   // rows (M) to process; chunked FFN passes a sub-N count
         // int8 only for the big weight-bound projections; keep the tiny per-v-head gate
         // projections (ssm_alpha/ssm_beta, n_out == v_heads) in bf16 — they feed the GDN
         // sigmoid gates, where per-row int8 quant of a 32-wide weight costs more accuracy
         // than the negligible time it saves.
         if (use_i8 && n_out >= 128) {
-            kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, N, K, st);
+            kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st);
             // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
             if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
                 const void* wb = dq(W, wtype, n_out, K);
                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
             }
-            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, N, n_out, K, st);
+            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, R, n_out, K, st);
         } else {
-            kernels::launch_prefill_gemm(A, dq(W, wtype, n_out, K), C, N, n_out, K, st);
+            kernels::launch_prefill_gemm(A, dq(W, wtype, n_out, K), C, R, n_out, K, st);
         }
     };
 
@@ -180,18 +200,23 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             proj(att, w.wo, w.wo_type, ao, H, qdim);
         }
 
-        // h = x + ao ; hn = RMSNorm(h, post_attn_norm)
-        kernels::launch_prefill_add(x, ao, hbuf, (long)N * H, st);
-        kernels::launch_rmsnorm(hbuf, w.post_attn_norm, hn, N, H, eps, st);
+        // x += ao (post-attn residual, in-place: hbuf folded into x) ; hn = RMSNorm(x, post_attn_norm)
+        kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+        kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
 
-        // dense SwiGLU FFN
-        proj(hn, w.gate_q, w.gate_qtype, ffg, ffn, H);
-        proj(hn, w.up_q,   w.up_qtype,   ffu, ffn, H);
-        kernels::launch_prefill_swiglu(ffg, ffu, ffh, (long)N * ffn, st);
-        proj(ffh, w.down_q, w.down_qtype, ao, H, ffn);
+        // dense SwiGLU FFN, chunked over tokens: ffg/ffu/A_i8 stay O(FC*ffn). Per-token independent,
+        // so this is numerically identical to the full-width pass; only the ffn-wide scratch shrinks.
+        for (int fo = 0; fo < N; fo += FC) {
+            const int fn = (N - fo < FC) ? (N - fo) : FC;
+            const bf16* hn_c = hn + (size_t)fo * H;
+            proj(hn_c, w.gate_q, w.gate_qtype, ffg, ffn, H, fn);
+            proj(hn_c, w.up_q,   w.up_qtype,   ffu, ffn, H, fn);
+            kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+            proj(ffg, w.down_q, w.down_qtype, ao + (size_t)fo * H, H, ffn, fn);
+        }
 
-        // x = h + ffn_out ; xn = RMSNorm(x, next_input_norm)  (final_norm on the last layer)
-        kernels::launch_prefill_add(hbuf, ao, x, (long)N * H, st);
+        // x += ffn_out (in-place residual) ; xn = RMSNorm(x, next_input_norm)  (final_norm on last layer)
+        kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
     }


### PR DESCRIPTION
## Summary

Qwythos batched prompt-prefill was capped at 64k — above that it fell back to the ~300 pp sequential token loop, because the batched pass allocated **O(N) scratch** (OOM past ~64k) and its int8 projections lose fidelity at extreme length. This makes the batched pass run **faithfully up to 128k**:

- **Memory** — `prefill_batched_run` now chunks the dense FFN over tokens (the ffn-wide `ffg`/`ffu` and the int8 activation scratch are bounded to `O(chunk·ffn)` instead of `O(N·ffn)`), computes SwiGLU in-place, aliases the mutually-exclusive full-attention scratch onto the GDN scratch, and folds the post-attn residual into `x`. Peak scratch **~24 GB → ~12 GB @128k**. The FFN is per-token independent, so chunking is **numerically exact** (top1/KL byte-identical across chunk counts).
- **Fidelity** — the near-1-decay Gated-DeltaNet recurrence amplifies the per-row int8 activation-quant error across the sequence, so int8 prefill diverges past ~96k. Above `bf16_minctx` (default 96k) the projections fall back to **bf16** (faithful) at ~half prefill throughput; **≤96k keeps int8 at full speed, unchanged**. `SPARKINFER_PREFILL_BF16_MINCTX` overrides.
- `qwen35.cpp`: raise the batched-prefill cap **64k → 128k**.

Builds on the merged windowed prefill attention (#455). Prefill-only — the decode path is untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (from `bench.sh`; prefill-only change → expected unchanged, shown to confirm no regression):

| | decode tok/s |
|---|--:|
| before (main) | 292.7 |
| after (this PR) | 292.6 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — headline context `--ctx 131072`; batched vs the sequential fallback):

| | prefill pp tok/s |
|---|--:|
| before prefill (main, seq fallback >64k) | 298 |
| after prefill (this PR, batched+bf16) | 7652 |

<!-- Full curve (default config): 4k 17199 / 32k 18418 / 64k 18332 (int8, unchanged);
     96k 18286 (int8, was ~300 seq); 128k 7652 (bf16, was 298 seq). decode ~292 at all ctx. -->

```text
# bench/scripts/bench.sh style (qwen3_gguf_bench), RTX 5090, Qwythos-9B Q4_K_M, default config:
ctx=4096    prefill pp 17199   decode 292.7    (int8, unchanged)
ctx=32768   prefill pp 18418   decode 292.9    (int8, unchanged)
ctx=65536   prefill pp 18333   decode 292.6    (int8, unchanged)
ctx=98304   prefill pp 18286   decode 291.6    (int8; was ~300 sequential -> batched)
ctx=131072  prefill pp  7652   decode 291.2    (bf16; was 298 sequential -> ~26x)
```

**Correctness** (`qwen3_gguf_prefill_check`, batched vs token-by-token, mean KL over the continuation):

| prefix | top1 | KL |
|---:|--:|--:|
| 4096 | 0.9375 | 0.0053 |
| 65536 | 0.75 | 0.0077 |
| 98304 | 0.75 | 0.032 |
| 131072 | 0.6875 | 0.0414 |

128k KL 0.041 is inside the accuracy gate (≤0.20) and the long-context KL veto (≤1.0, #522). FFN chunking verified numerically exact (1-chunk vs 4-chunk byte-identical). No regression: prefill ≤64k and decode at all contexts are unchanged.

> Scope note: this is a **long-context capability** win (65k–128k prefill), not a change to the 4k headline metric (4k is untouched). Above 96k it trades ~2× prefill throughput for faithful state (still ~26× the sequential fallback); a fast-but-degraded int8 128k is available via `SPARKINFER_PREFILL_BF16_MINCTX=999999` but is intentionally **not** the default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
