### PR TITLE
server: add temperature/top_p/top_k/repetition_penalty sampling (was argmax-only)

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -66,6 +66,19 @@ struct Qwen35Weights {
     std::vector<Qwen35LayerWeights> layers;
 };
 
+// Optional decode-time sampling. temperature <= 0 means "unset" — generate()
+// keeps its default deterministic argmax path untouched (eval/accuracy-gate
+// callers depend on that reproducibility) and none of the rest of this struct
+// is consulted. Only when temperature > 0 does generate() switch to CPU-side
+// temperature -> repetition-penalty -> top-k -> top-p -> multinomial sampling.
+struct SamplingConfig {
+    float temperature = 0.0f;
+    float top_p = 1.0f;              // 1 = no nucleus truncation
+    int top_k = 0;                   // 0 = no top-k truncation (full vocab)
+    float repetition_penalty = 1.0f; // 1 = no penalty
+    uint64_t seed = 0;               // 0 = seed from std::random_device
+};
+
 // Single-sequence (batch=1) greedy decoder for Qwen MoE. Owns scratch buffers and
 // drives embed -> N layers -> final norm -> LM head -> argmax per token.
 class Qwen35Model {
@@ -84,11 +97,14 @@ public:
     // dequantized per-layer at decode time (Q4_K_M-sized resident footprint).
     bool load_gguf(const std::string& path);
 
-    // Greedy generate: prompt token ids -> generated token ids (host). An optional ThermalGovernor
+    // Generate: prompt token ids -> generated token ids (host). An optional ThermalGovernor
     // paces decode under thermal pressure (accuracy-preserving); nullptr = full speed, no overhead.
     // When a prefix cache is installed (cache_prefix), skips re-prefilling the matching prefix.
+    // `sampling` is optional — nullptr (or temperature<=0) keeps the original greedy-argmax
+    // path exactly as before; a non-null config with temperature>0 switches to sampled decode.
     std::vector<int> generate(const std::vector<int>& prompt_ids, int max_new_tokens,
-                              ThermalGovernor* gov = nullptr);
+                              ThermalGovernor* gov = nullptr,
+                              const SamplingConfig* sampling = nullptr);
 
     // Prefill `tokens` and retain KV + hybrid recurrent state for reuse on the next request
     // whose prompt starts with the same token sequence. Returns false on allocation failure.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -22,10 +22,12 @@
 #include "sparkinfer/kernels/proj_requant.h"
 
 #include <cuda_runtime.h>
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
 #include <chrono>
+#include <random>
 #include <vector>
 #include <string>
 #include <fstream>
@@ -1335,7 +1337,74 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
     return prefill_batched_run(ctx, prompt_ids, n);
 }
 
-std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_new, ThermalGovernor* gov) {
+namespace {
+
+// CPU-side temperature -> repetition-penalty -> top-k -> top-p -> multinomial
+// sample, given one step's full logit vector. Only reached when the caller
+// opted in with SamplingConfig::temperature > 0 (see generate()) — the
+// default argmax path never touches this. `logits` is mutated in place
+// (scratch reused each call from a caller-owned buffer); `recent` is the
+// tokens generated so far this request, used (bounded to the last 64) for
+// the repetition penalty.
+int sample_token_from_logits(std::vector<float>& logits, const SamplingConfig& cfg,
+                              const std::vector<int>& recent, std::mt19937_64& rng) {
+    const int vocab = (int)logits.size();
+
+    // Repetition penalty (llama.cpp/HF convention): positive logits are
+    // divided (pushed toward zero -> less likely), negative logits are
+    // multiplied (pushed more negative -> less likely). Bounded window so
+    // this stays cheap regardless of how long the generation has run.
+    if (cfg.repetition_penalty != 1.0f && !recent.empty()) {
+        constexpr int kRepeatWindow = 64;
+        const int start = (int)recent.size() > kRepeatWindow ? (int)recent.size() - kRepeatWindow : 0;
+        for (int i = start; i < (int)recent.size(); i++) {
+            const int tid = recent[(size_t)i];
+            if (tid < 0 || tid >= vocab) continue;
+            float& v = logits[(size_t)tid];
+            v = v > 0.0f ? v / cfg.repetition_penalty : v * cfg.repetition_penalty;
+        }
+    }
+
+    const float temp = cfg.temperature > 0.0f ? cfg.temperature : 1.0f;
+    for (float& v : logits) v /= temp;
+
+    // Top-k: partial_sort leaves the k highest logits in order[0..k), sorted
+    // descending — exactly the order the nucleus (top-p) pass below needs.
+    std::vector<int> order((size_t)vocab);
+    for (int i = 0; i < vocab; i++) order[(size_t)i] = i;
+    const int k = (cfg.top_k > 0 && cfg.top_k < vocab) ? cfg.top_k : vocab;
+    std::partial_sort(order.begin(), order.begin() + k, order.end(),
+                       [&](int a, int b) { return logits[(size_t)a] > logits[(size_t)b]; });
+
+    // Softmax over the top-k survivors only (numerically stable: subtract max).
+    const float max_logit = logits[(size_t)order[0]];
+    std::vector<float> probs((size_t)k);
+    double sum = 0.0;
+    for (int i = 0; i < k; i++) {
+        probs[(size_t)i] = std::exp(logits[(size_t)order[(size_t)i]] - max_logit);
+        sum += probs[(size_t)i];
+    }
+    for (int i = 0; i < k; i++) probs[(size_t)i] = (float)(probs[(size_t)i] / sum);
+
+    // Top-p (nucleus): probs is already sorted descending, so this is just
+    // "keep the smallest prefix whose cumulative probability >= top_p".
+    int keep = k;
+    if (cfg.top_p > 0.0f && cfg.top_p < 1.0f) {
+        double cum = 0.0;
+        for (int i = 0; i < k; i++) {
+            cum += probs[(size_t)i];
+            if (cum >= (double)cfg.top_p) { keep = i + 1; break; }
+        }
+    }
+
+    std::discrete_distribution<int> dist(probs.begin(), probs.begin() + keep);
+    return order[(size_t)dist(rng)];
+}
+
+}  // namespace
+
+std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_new, ThermalGovernor* gov,
+                                        const SamplingConfig* sampling) {
     Impl& s = *p_;
     std::vector<int> out;
     if (prompt.empty()) return out;
@@ -1361,10 +1430,23 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
         fprintf(stderr, "[qwen35] prompt prefill failed (start=%d n=%zu)\n", start, n);
         return out;
     }
+
+    const bool do_sample = sampling != nullptr && sampling->temperature > 0.0f;
+    std::mt19937_64 rng(do_sample && sampling->seed != 0 ? sampling->seed
+                                                          : std::random_device{}());
+    std::vector<float> logits_host;
+    if (do_sample) logits_host.resize((size_t)s.cfg.vocab);
+
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
         if (next == s.cfg.eos_id) break;
-        next = forward_token(next, (int)prompt.size() + i, true);
+        const int argmax_next = forward_token(next, (int)prompt.size() + i, true);
+        if (do_sample) {
+            copy_logits(logits_host.data());
+            next = sample_token_from_logits(logits_host, *sampling, out, rng);
+        } else {
+            next = argmax_next;
+        }
         if (gov) gov->pace();
     }
 

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "sparkinfer/models/qwen35.h"  // sparkinfer::SamplingConfig
+
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -30,13 +32,17 @@ public:
     void set_prefix_tokens(const std::vector<int>& tokens);
     int prefix_token_len() const;
 
-    // Greedy decode. Returns generated token ids (not including prompt).
+    // Decode. Returns generated token ids (not including prompt). `sampling` is
+    // optional — nullptr (or temperature<=0) is the original greedy-argmax path;
+    // a non-null config with temperature>0 switches to sampled decode.
     // Sets last_error() on failure (empty prompt, context overflow, KV alloc).
-    std::vector<int> complete(const std::vector<int>& prompt_ids, int max_new_tokens);
+    std::vector<int> complete(const std::vector<int>& prompt_ids, int max_new_tokens,
+                              const sparkinfer::SamplingConfig* sampling = nullptr);
 
     // Same, but invokes cb after each generated token (for SSE streaming).
     std::vector<int> complete_streaming(const std::vector<int>& prompt_ids, int max_new_tokens,
-                                        const std::function<void(int)>& on_token);
+                                        const std::function<void(int)>& on_token,
+                                        const sparkinfer::SamplingConfig* sampling = nullptr);
 
     const std::string& last_error() const;
 

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -152,13 +152,15 @@ const std::string& ModelEngine::last_error() const {
     return last_error_;
 }
 
-std::vector<int> ModelEngine::complete(const std::vector<int>& prompt_ids, int max_new_tokens) {
-    return complete_streaming(prompt_ids, max_new_tokens, nullptr);
+std::vector<int> ModelEngine::complete(const std::vector<int>& prompt_ids, int max_new_tokens,
+                                       const sparkinfer::SamplingConfig* sampling) {
+    return complete_streaming(prompt_ids, max_new_tokens, nullptr, sampling);
 }
 
 std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_ids,
                                                  int max_new_tokens,
-                                                 const std::function<void(int)>& on_token) {
+                                                 const std::function<void(int)>& on_token,
+                                                 const sparkinfer::SamplingConfig* sampling) {
     std::lock_guard<std::mutex> lock(mu_);
     last_error_.clear();
     if (!impl_->ready || !impl_->model) {
@@ -196,7 +198,7 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
     } else {
         impl_->model->clear_prefix_cache();
     }
-    std::vector<int> out = impl_->model->generate(prompt_ids, max_new_tokens, nullptr);
+    std::vector<int> out = impl_->model->generate(prompt_ids, max_new_tokens, nullptr, sampling);
     if (on_token) {
         for (int t : out) on_token(t);
     }

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -65,6 +65,15 @@ int json_get_int(const std::string& body, const std::string& key, int def) {
     return atoi(body.c_str() + p + 1);
 }
 
+double json_get_double(const std::string& body, const std::string& key, double def) {
+    const std::string needle = "\"" + key + "\"";
+    size_t p = body.find(needle);
+    if (p == std::string::npos) return def;
+    p = body.find(':', p);
+    if (p == std::string::npos) return def;
+    return atof(body.c_str() + p + 1);
+}
+
 std::string json_escape(const std::string& s) {
     std::ostringstream o;
     for (unsigned char c : s) {
@@ -278,6 +287,14 @@ int main(int argc, char** argv) {
                  if (max_tokens <= 0) max_tokens = 256;
                  if (max_tokens > 4096) max_tokens = 4096;
 
+                 // temperature<=0 (the default when the field is absent) keeps the original
+                 // greedy-argmax decode path exactly as before — see SamplingConfig in qwen35.h.
+                 sparkinfer::SamplingConfig sampling;
+                 sampling.temperature = (float)json_get_double(req.body, "temperature", 0.0);
+                 sampling.top_p = (float)json_get_double(req.body, "top_p", 1.0);
+                 sampling.top_k = json_get_int(req.body, "top_k", 0);
+                 sampling.repetition_penalty = (float)json_get_double(req.body, "repetition_penalty", 1.0);
+
                  std::vector<int> prompt_ids;
                  std::string err;
                  if (!encode_messages(req.body, prompt_ids, enable_thinking, err)) {
@@ -304,7 +321,7 @@ int main(int argc, char** argv) {
                  if (stream) {
                      res.set_chunked_content_provider(
                          "text/event-stream",
-                         [&engine, prompt_ids, max_tokens, cid, created, enable_thinking](size_t offset,
+                         [&engine, prompt_ids, max_tokens, cid, created, enable_thinking, sampling](size_t offset,
                                                                                           httplib::DataSink& sink) {
                              if (offset > 0) {
                                  sink.done();
@@ -319,7 +336,7 @@ int main(int argc, char** argv) {
                                  write_stream_delta(sink, cid, created, "reasoning_content", delta.reasoning_content);
                                  write_stream_delta(sink, cid, created, "content", delta.content);
                              };
-                             engine.complete_streaming(prompt_ids, max_tokens, on_tok);
+                             engine.complete_streaming(prompt_ids, max_tokens, on_tok, &sampling);
                              sparkinfer_server::ThinkingStreamSplitter::Delta flush;
                              splitter.finish(flush);
                              write_stream_delta(sink, cid, created, "reasoning_content", flush.reasoning_content);
@@ -350,7 +367,7 @@ int main(int argc, char** argv) {
                      return;
                  }
 
-                 std::vector<int> gen = engine.complete(prompt_ids, max_tokens);
+                 std::vector<int> gen = engine.complete(prompt_ids, max_tokens, &sampling);
                  std::string text;
                  if (!engine.last_error().empty()) {
                      res.status = 400;


### PR DESCRIPTION
Base is `a739958` — the commit actually running in production — **not current `main`**. See the "Needs a rebase" note below before merging.

## Summary
The engine had no sampling path at all: `Qwen35Model::forward_token()` unconditionally ran `launch_argmax` every decode step, and the server accepted no `temperature`/`top_p`/`top_k`/`repetition_penalty` fields. On a public endpoint that matters — greedy decoding is a known repetition-loop trigger on long generations (`sparkinfer-web` already carries client-side detection/truncation for exactly this, as a symptom-level workaround).

Adds real sampling, CPU-side, built on an existing hook rather than touching the CUDA decode path:

- `SamplingConfig` (`qwen35.h`): `temperature`/`top_p`/`top_k`/`repetition_penalty`/`seed`. `temperature<=0` (including the default when absent) means "unset" — `generate()` takes the exact original argmax-only branch, zero behavior change for every existing caller (eval harness, accuracy gate, bench scripts) unless it opts in.
- `generate()`: when sampling is active, after each `forward_token()` it also calls the already-existing `copy_logits()` (previously only used for teacher-forced perplexity/KL scoring) to pull that step's logits to host, then does temperature scale → repetition penalty (bounded 64-token window) → top-k (`std::partial_sort`) → top-p (nucleus, on the sorted survivors) → `std::discrete_distribution` sample, feeding the result in as the next decode step instead of the argmax token. Safe to override because the KV cache only encodes already-committed history by the time `forward_token()` returns.
- Threaded through `ModelEngine::complete`/`complete_streaming` and `/v1/chat/completions`, parsing the four fields OpenAI-style from the request body.

## Test plan
Verified on RTX 5090 against Qwythos-9B, isolated from the live server first (separate instance, separate port — confirmed via `/proc/<pid>/exe` that the running production process kept using its old `(deleted)` binary inode unaffected while I rebuilt in place):

- [x] Default requests (no sampling fields) byte-identical across repeated calls — greedy path provably untouched
- [x] `temperature=0.6, top_p=0.95, top_k=20, repetition_penalty=1.05` (the documented recommended settings) produces different, coherent output across repeated identical requests — confirms real sampling, not still-secretly-greedy
- [x] Both streaming and non-streaming code paths
- [x] Longer (~300 token) generation — no repetition loop, no crash
- [x] Deployed to the actual production process (`/etc/init.d/sparkinfer-server restart`) and re-verified all of the above through the live `api.sparkinfer.com` endpoint over the public tunnel, not just locally

## Needs a rebase before merging
Branched from `a739958` (what's actually deployed), which predates the in-flight multi-session/`seq_id` refactor on `main` (`Impl::seq_id` → `active_seq_id` + a `sessions` map — `feat/continuous-batching-serving` territory) that touches the same `generate()` function this extends. Deliberately not attempting that adaptation blind — I can only really validate this against real GPU hardware, and the production box is still on the pre-refactor architecture.
