### PR TITLE
server: 64k context, 16k max output, and a real 2-slot concurrency gate

### DIFF
--- a/server/include/request_slots.hpp
+++ b/server/include/request_slots.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <chrono>
+#include <condition_variable>
+#include <cstdlib>
+#include <mutex>
+
+namespace sparkinfer_server {
+
+class RequestSlots {
+public:
+    explicit RequestSlots(int max_slots) : max_slots_(max_slots), in_use_(0) {}
+
+    // Default of 2 matches the KV cache pool sizing in model_engine.cpp — both
+    // read the same env var so they can never drift out of sync with each
+    // other. See the comment there for why the pool has to scale with this.
+    static int from_env(int default_slots = 2) {
+        const char* e = std::getenv("SPARKINFER_MAX_CONCURRENT");
+        if (!e || !*e) return default_slots;
+        const int v = std::atoi(e);
+        return v > 0 ? v : default_slots;
+    }
+
+    bool try_acquire() {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (in_use_ >= max_slots_) return false;
+        ++in_use_;
+        return true;
+    }
+
+    // Blocks until a slot frees up or timeout_ms elapses. Returns false on
+    // timeout — caller should respond with a "busy" error rather than
+    // proceed, not silently run over capacity.
+    bool acquire(int timeout_ms) {
+        std::unique_lock<std::mutex> lock(mu_);
+        const bool got_slot =
+            cv_.wait_for(lock, std::chrono::milliseconds(timeout_ms), [this] { return in_use_ < max_slots_; });
+        if (!got_slot) return false;
+        ++in_use_;
+        return true;
+    }
+
+    void release() {
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            if (in_use_ > 0) --in_use_;
+        }
+        cv_.notify_one();
+    }
+
+    int max_slots() const { return max_slots_; }
+    int in_use() const {
+        std::lock_guard<std::mutex> lock(mu_);
+        return in_use_;
+    }
+
+private:
+    const int max_slots_;
+    int in_use_;
+    mutable std::mutex mu_;
+    std::condition_variable cv_;
+};
+
+// Move-only RAII release guard for a slot acquired via RequestSlots::acquire()/
+// try_acquire(). Copy is explicitly deleted — a naive default move (member-wise
+// pointer copy, source left pointing at the same pool) would double-release
+// when both the moved-from and moved-to instances are destroyed. Held via
+// shared_ptr at call sites that need to capture it into a copyable
+// std::function (httplib's chunked content provider), since std::function
+// requires its target to be copy-constructible even if only ever invoked
+// once — the shared_ptr's single underlying SlotLease still only releases
+// once, when the last copy goes away.
+struct SlotLease {
+    RequestSlots* pool = nullptr;
+
+    SlotLease() = default;
+    explicit SlotLease(RequestSlots* p) : pool(p) {}
+    SlotLease(const SlotLease&) = delete;
+    SlotLease& operator=(const SlotLease&) = delete;
+
+    SlotLease(SlotLease&& other) noexcept : pool(other.pool) { other.pool = nullptr; }
+    SlotLease& operator=(SlotLease&& other) noexcept {
+        if (this != &other) {
+            if (pool) pool->release();
+            pool = other.pool;
+            other.pool = nullptr;
+        }
+        return *this;
+    }
+
+    ~SlotLease() {
+        if (pool) pool->release();
+    }
+};
+
+}  // namespace sparkinfer_server

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -1,4 +1,5 @@
 #include "model_engine.hpp"
+#include "request_slots.hpp"
 
 #include "sparkinfer/gguf.h"
 #include "sparkinfer/kv_cache.h"
@@ -80,13 +81,25 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     { const char* e = getenv("SPARKINFER_KV_INT8");
       kvc.int8_kv = e ? (e[0] != '0')
                       : (impl_->cfg.hybrid ? (impl_->cfg.max_seq >= 4096) : true); }
+    // generate() reserves a full max_seq worth of blocks per request up front
+    // (Qwen35Model::generate -> kv->allocate(seq_id, cfg.max_seq)), not sized
+    // to the actual prompt/response length — so a pool sized for exactly one
+    // sequence can only ever serve one request at a time; a second concurrent
+    // request's allocate() call fails once the first has claimed the pool.
+    // Scale by the same slot count RequestSlots gates concurrency to (same env
+    // var, read independently here so the pool and the gate can't drift out
+    // of sync) so real concurrent requests actually have room, not just a
+    // gate that lets them in and then fails them.
+    const int max_concurrent = RequestSlots::from_env();
     const size_t epb = (size_t)16 * impl_->cfg.n_kv_heads * impl_->cfg.head_dim;
-    const size_t blocks = (size_t)impl_->cfg.max_seq / 16 + 8;
+    const size_t blocks_per_seq = (size_t)impl_->cfg.max_seq / 16 + 8;
+    const size_t blocks = blocks_per_seq * (size_t)max_concurrent;
     impl_->kv = std::make_unique<sparkinfer::KVCacheManager>(
         kvc, (size_t)impl_->cfg.n_layers * 2 * epb * 2 * blocks);
 
-    fprintf(stderr, "[sparkinfer-server] kv_cache: int8=%d blocks=%zu pool_budget=%.1f GiB\n",
-            kvc.int8_kv ? 1 : 0, blocks,
+    fprintf(stderr,
+            "[sparkinfer-server] kv_cache: int8=%d blocks=%zu (%d slots x %zu) pool_budget=%.1f GiB\n",
+            kvc.int8_kv ? 1 : 0, blocks, max_concurrent, blocks_per_seq,
             (double)impl_->cfg.n_layers * 2.0 * epb * 2.0 * blocks / (1024.0 * 1024.0 * 1024.0));
 
     sparkinfer::moe::MoEConfig mc;

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -1,5 +1,6 @@
 #include "chat_tokenizer.hpp"
 #include "model_engine.hpp"
+#include "request_slots.hpp"
 
 // Do not define CPPHTTPLIB_OPENSSL_SUPPORT — even `= 0` enables OpenSSL in httplib.
 #include "../third_party/httplib.h"
@@ -9,6 +10,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
+#include <memory>
 #include <random>
 #include <sstream>
 #include <string>
@@ -16,12 +18,22 @@
 
 namespace {
 
-constexpr int kMaxOutputTokens = 4096;
-constexpr int kMaxInputContext = 32768;
+constexpr int kMaxOutputTokens = 16384;
+constexpr int kMaxInputContext = 65536;
+// How long a request waits for a free concurrency slot before giving up and
+// returning 503 — bounded so a burst of requests queues briefly rather than
+// piling up httplib worker threads indefinitely.
+constexpr int kSlotWaitMs = 30000;
 
 std::string g_api_key;
 std::string g_model_name = "qwen3.6-35b-a3b";
 sparkinfer_server::ChatTokenizer g_tokenizer;
+// Real, enforced concurrency gate — the KV cache pool in model_engine.cpp is
+// sized for exactly this many concurrent full-length sequences (same env
+// var, read independently there), so this isn't just a request throttle,
+// it's what makes concurrent requests actually able to allocate KV space
+// instead of the 2nd+ one failing.
+sparkinfer_server::RequestSlots g_slots(sparkinfer_server::RequestSlots::from_env());
 
 std::string repo_root() {
     const char* env = getenv("SPARKINFER_ROOT");
@@ -285,7 +297,7 @@ int main(int argc, char** argv) {
                  const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, false);
                  int max_tokens = json_get_int(req.body, "max_tokens", 256);
                  if (max_tokens <= 0) max_tokens = 256;
-                 if (max_tokens > 4096) max_tokens = 4096;
+                 if (max_tokens > kMaxOutputTokens) max_tokens = kMaxOutputTokens;
 
                  // temperature<=0 (the default when the field is absent) keeps the original
                  // greedy-argmax decode path exactly as before — see SamplingConfig in qwen35.h.
@@ -313,6 +325,25 @@ int main(int argc, char** argv) {
                      return;
                  }
 
+                 // Real capacity gate, not just a throttle — the KV cache pool is sized for
+                 // exactly this many concurrent full-length sequences (model_engine.cpp), so
+                 // this is what makes a 2nd/3rd concurrent request able to actually allocate
+                 // KV space rather than failing once the 1st has claimed the whole pool.
+                 if (!g_slots.acquire(kSlotWaitMs)) {
+                     res.status = 503;
+                     res.set_content(
+                         "{\"error\":{\"message\":\"server busy — max concurrent requests (" +
+                         std::to_string(g_slots.max_slots()) + ") reached, try again shortly\"}}",
+                         "application/json");
+                     return;
+                 }
+                 // shared_ptr, not a bare SlotLease, because it needs to be captured into the
+                 // streaming lambda below, which httplib stores in a std::function — that
+                 // requires the target to be copy-constructible even though it's only ever
+                 // invoked from one place. The underlying slot still releases exactly once,
+                 // when the last copy (here or inside the lambda) is destroyed.
+                 auto lease = std::make_shared<sparkinfer_server::SlotLease>(&g_slots);
+
                  const std::string cid = random_id();
                  const auto created = (long long)std::chrono::duration_cast<std::chrono::seconds>(
                                         std::chrono::system_clock::now().time_since_epoch())
@@ -321,8 +352,8 @@ int main(int argc, char** argv) {
                  if (stream) {
                      res.set_chunked_content_provider(
                          "text/event-stream",
-                         [&engine, prompt_ids, max_tokens, cid, created, enable_thinking, sampling](size_t offset,
-                                                                                          httplib::DataSink& sink) {
+                         [&engine, prompt_ids, max_tokens, cid, created, enable_thinking, sampling,
+                          lease](size_t offset, httplib::DataSink& sink) {
                              if (offset > 0) {
                                  sink.done();
                                  return true;


### PR DESCRIPTION
Stacked on #534 (sampling) — same base commit (`a739958`, what's actually running in production), same reasoning about not blind-adapting to `main`'s in-flight multi-session refactor.

## Summary
Three related capacity changes, done together because the third makes the first two *safe* under concurrent load rather than just safe for one request at a time:

- `kMaxOutputTokens` 4096 → 16384, `kMaxInputContext` (reporting only) 32768 → 65536. Actual ceiling is the server's `--ctx` flag (deployed at 65536, was 32768).
- Wired up `RequestSlots`/`SlotLease` into `POST /v1/chat/completions` — this header already existed but was **never called from anywhere**, so `SPARKINFER_MAX_CONCURRENT` was dead config and there was no real concurrency limit beyond whatever httplib's own thread pool allowed.
- The KV cache pool (`model_engine.cpp`) is now sized as `SPARKINFER_MAX_CONCURRENT × max_seq` instead of just `max_seq`.

## Why the pool sizing needed investigating first
`Qwen35Model::generate()` reserves a **full `max_seq` worth of KV blocks up front for every request** (`kv->allocate(seq_id, cfg.max_seq)`), not sized to actual prompt/response length, drawing from one shared PagedAttention-style block pool with no per-sequence eviction beyond it. A pool sized for exactly one sequence — what existed before this — can only ever serve one request at a time; every concurrent request beyond the first fails to allocate once the first has claimed the pool, regardless of how short that 2nd request's conversation actually is. Sparse-KV's sliding window (in the startup log) only skips attention *compute* over old blocks during decode — it doesn't free them, so it doesn't help here either.

A literal 3× pool at 64k context would be ~24GB, leaving only ~3GB free alongside ~5GB of model weights on this 32GB card — too tight for CUDA overhead/fragmentation on a public endpoint. Went with **2 slots**: pool comes out to 16.0 GiB (matches the startup log exactly), and real measured process VRAM (`nvidia-smi --query-compute-apps`, not the `pool_budget` log line, which reports the allocation request rather than final resident bytes) came in at 15336 MiB — a real ~17GB of headroom out of 32.6GB total.

## Test plan
Verified on RTX 5090 against Qwythos-9B, isolated from the live server first (separate instance, separate port — confirmed via `/proc/<pid>/exe` that production was untouched while rebuilding):
- [x] Startup log confirms exact expected sizing: `blocks=8208 (2 slots x 4104) pool_budget=16.0 GiB`
- [x] `/v1/info` reports `max_context=65536, max_output_tokens=16384`
- [x] 3 genuinely concurrent requests (fired in parallel) all succeeded — request 3 took ~5.1s vs ~1.7s/~3.4s for the first two, confirming it actually **queued** for a slot rather than running unconstrained (similar latencies) or failing (non-200)
- [x] A request fired immediately after that batch completed in 0.08s — slots release cleanly, no leak
- [x] Sampling (from #534) still works correctly on top of this
- [x] Deployed to the actual production process (`/etc/init.d/sparkinfer-server restart`) and re-verified through the live `api.sparkinfer.com` endpoint — `/v1/info`, a real generation, and production VRAM (15336 MiB, matching the isolated test exactly)

## Needs a rebase before merging
Same situation as #534 — branched from `a739958` (what's deployed), predates the in-flight multi-session/`seq_id` refactor on `main` touching the same `generate()` function.
