### PR TITLE
server: enforce a real think/answer token budget split

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -77,6 +77,18 @@ struct SamplingConfig {
     int top_k = 0;                   // 0 = no top-k truncation (full vocab)
     float repetition_penalty = 1.0f; // 1 = no penalty
     uint64_t seed = 0;               // 0 = seed from std::random_device
+
+    // Optional think/answer token budget split. Disabled unless reasoning_budget>0
+    // and both ids are valid (>=0). When enabled, generate() counts tokens emitted
+    // between think_open_id and think_close_id; once that count reaches
+    // reasoning_budget without think_close_id having appeared naturally, it
+    // force-injects think_close_id so the remaining max_new_tokens budget is
+    // guaranteed to be available for the answer instead of being consumed by
+    // reasoning. No effect if the model never emits think_open_id (e.g. thinking
+    // disabled for the request).
+    int reasoning_budget = 0;
+    int think_open_id = -1;
+    int think_close_id = -1;
 };
 
 // Single-sequence (batch=1) greedy decoder for Qwen MoE. Owns scratch buffers and

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1437,15 +1437,37 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
     std::vector<float> logits_host;
     if (do_sample) logits_host.resize((size_t)s.cfg.vocab);
 
+    // Think/answer budget enforcement (see SamplingConfig::reasoning_budget):
+    // tracked purely by token-id comparison against the just-pushed token, no
+    // text decoding needed. seen_open latches once <think> is emitted so a
+    // request with thinking disabled (which never emits it) is untouched.
+    const bool enforce_budget = sampling != nullptr && sampling->reasoning_budget > 0 &&
+                                 sampling->think_open_id >= 0 && sampling->think_close_id >= 0;
+    bool seen_open = false;
+    bool seen_close = false;
+    int reasoning_tokens = 0;
+
     for (int i = 0; i < max_new; i++) {
         out.push_back(next);
         if (next == s.cfg.eos_id) break;
+        if (enforce_budget) {
+            if (next == sampling->think_open_id) seen_open = true;
+            else if (next == sampling->think_close_id) seen_close = true;
+            else if (seen_open && !seen_close) reasoning_tokens++;
+        }
         const int argmax_next = forward_token(next, (int)prompt.size() + i, true);
         if (do_sample) {
             copy_logits(logits_host.data());
             next = sample_token_from_logits(logits_host, *sampling, out, rng);
         } else {
             next = argmax_next;
+        }
+        if (enforce_budget && seen_open && !seen_close && reasoning_tokens >= sampling->reasoning_budget) {
+            // Force-close reasoning: inject </think> in place of the naturally
+            // predicted token so the remaining budget goes to the answer. The
+            // model sees this injected id as its own output on the next step,
+            // same as teacher-forcing any other token.
+            next = sampling->think_close_id;
         }
         if (gov) gov->pace();
     }

--- a/server/include/chat_tokenizer.hpp
+++ b/server/include/chat_tokenizer.hpp
@@ -24,6 +24,9 @@ public:
     std::string decode(const std::vector<int>& ids) const;
     std::string decode_delta(std::vector<int>& acc, int new_id) const;
 
+    // Vocab id for `token`, or -1 if it isn't in the loaded tokenizer.
+    int token_id(const std::string& token) const;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -451,4 +451,9 @@ std::string ChatTokenizer::decode_delta(std::vector<int>& acc, int new_id) const
     return full;
 }
 
+int ChatTokenizer::token_id(const std::string& token) const {
+    if (!impl_->tok) return -1;
+    return impl_->tok->TokenToId(token);
+}
+
 }  // namespace sparkinfer_server

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -28,6 +28,10 @@ constexpr int kSlotWaitMs = 30000;
 std::string g_api_key;
 std::string g_model_name = "qwen3.6-35b-a3b";
 sparkinfer_server::ChatTokenizer g_tokenizer;
+// Looked up once from the loaded tokenizer at startup (see main()); -1 if this
+// tokenizer has no such token, which disables reasoning-budget enforcement.
+int g_think_open_id = -1;
+int g_think_close_id = -1;
 // Real, enforced concurrency gate — the KV cache pool in model_engine.cpp is
 // sized for exactly this many concurrent full-length sequences (same env
 // var, read independently there), so this isn't just a request throttle,
@@ -224,6 +228,8 @@ int main(int argc, char** argv) {
         fprintf(stderr, "[sparkinfer-server] %s\n", tok_err.c_str());
         return 1;
     }
+    g_think_open_id = g_tokenizer.token_id("<think>");
+    g_think_close_id = g_tokenizer.token_id("</think>");
 
     sparkinfer_server::ModelEngine engine;
     if (!engine.load(model_path, ctx > 0 ? ctx : 0)) return 1;
@@ -306,6 +312,23 @@ int main(int argc, char** argv) {
                  sampling.top_p = (float)json_get_double(req.body, "top_p", 1.0);
                  sampling.top_k = json_get_int(req.body, "top_k", 0);
                  sampling.repetition_penalty = (float)json_get_double(req.body, "repetition_penalty", 1.0);
+
+                 // thinking_budget_tokens reserves room for the answer: once this many
+                 // tokens have been generated inside <think>...</think>, force-close
+                 // reasoning so max_tokens - budget is guaranteed available for the
+                 // answer instead of being silently consumed by reasoning (see
+                 // SamplingConfig::reasoning_budget in qwen35.h). No-op when thinking
+                 // is disabled for this request, or when this tokenizer has no
+                 // <think>/</think> tokens.
+                 if (enable_thinking && g_think_open_id >= 0 && g_think_close_id >= 0) {
+                     int budget = json_get_int(req.body, "thinking_budget_tokens", 0);
+                     if (budget > 0) {
+                         if (budget >= max_tokens) budget = max_tokens > 1 ? max_tokens - 1 : 0;
+                         sampling.reasoning_budget = budget;
+                         sampling.think_open_id = g_think_open_id;
+                         sampling.think_close_id = g_think_close_id;
+                     }
+                 }
 
                  std::vector<int> prompt_ids;
                  std::string err;


### PR DESCRIPTION
## Summary
- `thinking_budget_tokens` was accepted in the request body but never enforced — a request could burn its entire `max_tokens` budget on reasoning and leave zero room for the answer (the "Reasoning finished but the answer was cut off" symptom reported from production).
- `SamplingConfig` gains `reasoning_budget`/`think_open_id`/`think_close_id`. `Qwen35Model::generate()` tracks tokens emitted between `<think>` and `</think>` purely by token id (no text decoding in the decode loop) and force-injects `</think>` once the budget is hit, guaranteeing the remaining `max_tokens` is available for the answer.
- `<think>`/`</think>` ids are looked up once at startup via a new `ChatTokenizer::token_id()` (wraps `tokenizers::Tokenizer::TokenToId`) — dynamic, not hardcoded, so it stays correct if the tokenizer changes.
- Server parses `thinking_budget_tokens` from the request and wires it into `sampling` only when thinking is enabled and both ids resolved; clamps it below `max_tokens` so there's always at least one token of headroom.
- Stacked on #535 since it reuses the `sampling` plumbing added there.

## Test plan
- [x] Built clean on the RTX 5090 box (`sparkinfer_server`)
- [x] Isolated test instance (separate port, 1 slot, small ctx) — non-streaming: baseline (no budget) reproduces the cut-off bug (reasoning consumes full 500-token budget, empty answer); with `thinking_budget_tokens=200` reasoning is capped and a real answer is produced, generation finishes naturally before `max_tokens`
- [x] Streaming mode: reasoning force-closes correctly, no `<think>`/`</think>` marker leakage into the `content` SSE stream, `usage` stats (`ttft_ms`, `decode_tps`) intact
- [x] Requests without `thinking_budget_tokens`, and with thinking disabled, are unaffected (enforcement is a no-op)
- [x] Deployed to production (`sparkinfer_server` on the live RTX 5090 box), verified `/health` + `/v1/info`, VRAM footprint unchanged (15336 MiB)
- [x] Companion client-side fix in `sparkinfer-web` unifies the two divergent `thinking_budget_tokens` formulas so the SettingsModal label, the value sent, and the value enforced here all agree