### PR TITLE
Fix eval bot infra failures being mislabeled as REJECT

### DIFF
--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -251,6 +251,7 @@ DRAFT_STALE_DAYS   = int(os.environ.get("SPARKINFER_DRAFT_STALE_DAYS", "4"))
 STALE_CLOSE_SKIP_LABELS = {HOLD_LABEL, MERGE_FIRST_LABEL}  # protected from auto-close
 EXHAUSTED_EVAL_MAX = int(os.environ.get("SPARKINFER_EXHAUSTED_EVAL_MAX", "2"))
 FAIL_VERDICT_LABELS = frozenset({"none", "REJECT"})
+INFRA_LABEL = "infra-error"
 CONTEXT_LABELS     = {"128-context", "512-context", "4k-context", "16k-context", "32k-context",
                       "64k-context", "128k-context"}
 REGRESSION_LABELS  = {"regression-128", "regression-512", "regression-4k", "regression-16k",
@@ -577,6 +578,13 @@ def _eval_verdict_from_comment(body):
         return None
     m = re.search(r"\|\s*\*\*label\*\*\s*\|\s*`eval:([^`]+)`", body)
     return m.group(1) if m else None
+
+
+def _public_eval_label(res):
+    """GitHub label tier for a verdict — infra failures are not scored REJECTs."""
+    if res and res.get("infra_error"):
+        return INFRA_LABEL
+    return res.get("label") if res else None
 
 
 def none_reject_eval_count(repo, num):
@@ -1008,7 +1016,11 @@ def _best_prefill_measurement(block):
 
 def render(res, oid):
     label = res.get("label", "?")
-    icon = {"REJECT": "❌", "none": "⚪", "BASELINE": "📊"}.get(label, "✅")
+    display_label = _public_eval_label(res) or label
+    if res.get("infra_error"):
+        icon = "⚠️"
+    else:
+        icon = {"REJECT": "❌", "none": "⚪", "BASELINE": "📊"}.get(label, "✅")
     # A passing speedup (XL/L/M/S/XS) clears the significance gate, so its tps becomes the NEW frontier.
     advanced = label in {"XL", "L", "M", "S", "XS"} and res.get("pass")
     ctx_label = res.get("best_context_label")
@@ -1026,14 +1038,20 @@ def render(res, oid):
     if not short and scored_model:
         short = scored_model.split("-")[0]
     gname = res.get("guard_model", "Qwen3-30B")
-    rows = [f"| **label** | `eval:{label}` |"]
+    rows = [f"| **label** | `eval:{display_label}` |"]
     if bidir:
-        rows.append(f"| Qwen3.5 score | `eval-qwen35:{res.get('label_qwen35', '?')}` "
-                    f"({'pass' if res.get('pass_qwen35') else 'fail'}) |")
-        rows.append(f"| Qwen3.6 score | `eval-qwen36:{res.get('label_qwen36', '?')}` "
-                    f"({'pass' if res.get('pass_qwen36') else 'fail'}) |")
+        if res.get("infra_error"):
+            rows.append("| Qwen3.5 score | infra error (not graded) |")
+            rows.append("| Qwen3.6 score | infra error (not graded) |")
+        else:
+            rows.append(f"| Qwen3.5 score | `eval-qwen35:{res.get('label_qwen35', '?')}` "
+                        f"({'pass' if res.get('pass_qwen35') else 'fail'}) |")
+            rows.append(f"| Qwen3.6 score | `eval-qwen36:{res.get('label_qwen36', '?')}` "
+                        f"({'pass' if res.get('pass_qwen36') else 'fail'}) |")
         for title, block in [("Qwen3.5", res.get("score_qwen35") or {}),
                              ("Qwen3.6", res.get("score_qwen36") or {})]:
+            if res.get("infra_error"):
+                continue
             if not block:
                 continue
             bctx = block.get("best_context_label")
@@ -1121,7 +1139,7 @@ def render(res, oid):
             rows.append(f"| legacy 2k no-regression gate | {res.get('ctx_2048_tps')} tok/s"
                         f"{f' vs main {base} tok/s' if base else ''} · {gate} |")
     # The Qwen3-30B no-regression guard — the check that actually gates a dual verdict.
-    if bidir:
+    if bidir and not res.get("infra_error"):
         for title, block in [("Qwen3.5 optimize", res.get("score_qwen35") or {}),
                              ("Qwen3.6 optimize", res.get("score_qwen36") or {})]:
             if not block:
@@ -1195,7 +1213,9 @@ def render(res, oid):
     if label == "REJECT" and res.get("auto_close") and not res.get("infra_error"):
         note = "No context cleared the 2% significance gate while at least one context regressed. Auto-closing this PR."
     if res.get("infra_error") or str(res.get("reason") or "").startswith("infra error"):
-        note = "Infra failure during eval (not a verified PR regression) — re-run recommended."
+        reason = str(res.get("reason") or "infra error").removeprefix("infra error: ").strip()
+        note = ("Infra failure during eval (not a verified PR regression) — re-run recommended."
+                + (f"\n\n`{reason}`" if reason else ""))
     target_note = ("128/512/4k/16k/32k guarded · Qwen3.5 prefill at 4k/32k/64k/128k · "
                    "Qwen3.6 prefill at 128/512/4k/16k/32k · scored vs same-box main"
                    if res.get("eval_mode") == "longctx" and res.get("mode") == "bidir"
@@ -2611,7 +2631,9 @@ def main():
                     f"— re-run manually.\n\n<details><summary>log tail</summary>\n\n```\n{log}\n```\n</details>")
             res, label = None, None
         else:
-            res = json.loads(line[len("RESULT_JSON "):]); label = res["label"]; body = render(res, oid)
+            res = json.loads(line[len("RESULT_JSON "):])
+            label = _public_eval_label(res)
+            body = render(res, oid)
             print(f"PR #{num}: {json.dumps(res)}")
 
             # --- Polaris: parse unsigned attestation from eval box, attest it, upload with eval log ---
@@ -2643,11 +2665,13 @@ def main():
             for lab in {l for l in cur if l.startswith("eval:") or l.startswith("eval-qwen")}:
                 remove_label(args.repo, num, lab)
             add_label(args.repo, num, f"eval:{label}")
-            if res and res.get("mode") == "bidir":
+            if res and res.get("mode") == "bidir" and not res.get("infra_error"):
                 if res.get("label_qwen35"):
                     add_label(args.repo, num, f"eval-qwen35:{res['label_qwen35']}")
                 if res.get("label_qwen36"):
                     add_label(args.repo, num, f"eval-qwen36:{res['label_qwen36']}")
+            elif res and res.get("infra_error"):
+                add_label(args.repo, num, REEVALUATE_LABEL)
             apply_context_label(args.repo, num, cur, res.get("best_context_label"))
             apply_regression_labels(args.repo, num, cur, res.get("regression_labels"))
             # This was just graded against the CURRENT main, so it's no longer stale: clear

--- a/eval/setup_labels.sh
+++ b/eval/setup_labels.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 REPO="${1:-gittensor-ai-lab/sparkinfer}"
 declare -A C=( [XL]=0E8A16 [L]=1D76DB [M]=5319E7 [S]=FBCA04 [XS]=BFD4F2
-               [none]=C5DEF5 [REJECT]=B60205 [BASELINE]=D4C5F9 )
+               [none]=C5DEF5 [REJECT]=B60205 [BASELINE]=D4C5F9 [infra-error]=F9A825 )
 for k in "${!C[@]}"; do
   gh label create "eval:$k" -R "$REPO" --color "${C[$k]}" \
      --description "sparkinfer auto-eval verdict: $k" --force >/dev/null

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -865,6 +865,33 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         body = bot.render({"label": "S", "pass": True, "tps": 200.0, "top1": 1.0, "kl": 0.0}, "df74674")
         self.assertEqual(bot._evaluated_commit_from_comment(body), "df74674")
 
+    def test_infra_error_public_label_and_render(self):
+        res = {
+            "label": "REJECT", "pass": False, "infra_error": True, "mode": "bidir",
+            "reason": "infra error: accuracy check produced no METRIC (ModuleNotFoundError: No module named 'tokenizers')",
+            "score_qwen35": {"tps": 0, "top1": 0, "kl": 99, "label": "REJECT", "pass": False, "infra_error": True},
+            "score_qwen36": {"tps": 0, "top1": 0, "kl": 99, "label": "REJECT", "pass": False, "infra_error": True},
+            "label_qwen35": "REJECT", "label_qwen36": "REJECT",
+        }
+        self.assertEqual(bot._public_eval_label(res), "infra-error")
+        body = bot.render(res, "e2d829a")
+        self.assertIn("`eval:infra-error`", body)
+        self.assertIn("infra error (not graded)", body)
+        self.assertNotIn("eval-qwen35:REJECT", body)
+        self.assertNotIn("Qwen3.5 optimize", body)
+        self.assertIn("tokenizers", body)
+
+    def test_none_reject_eval_count_ignores_infra_error(self):
+        infra_body = bot.render({
+            "label": "REJECT", "pass": False, "infra_error": True, "mode": "bidir",
+            "reason": "infra error: missing tokenizers",
+            "score_qwen35": {}, "score_qwen36": {},
+        }, "abc1234")
+        comments = [{"body": infra_body}]
+        gh_mock = mock.Mock(return_value=mock.Mock(stdout=json.dumps({"comments": comments})))
+        with mock.patch.object(bot, "gh", gh_mock):
+            self.assertEqual(bot.none_reject_eval_count("gittensor-ai-lab/sparkinfer", 531), 0)
+
     def test_evaluated_commit_from_comment_rejects_error_marker(self):
         body = ("<!-- sparkinfer-eval:df74674 -->\n"
                 "⚠️ **sparkinfer auto-eval errored** for `df74674` — re-run manually.")

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -128,6 +128,29 @@ def push_bench_scripts(host, port):
                 pass
 
 
+def ensure_box_deps(host, port):
+    """Install build + accuracy deps on the eval box; fail closed if verification fails."""
+    setup = (
+        "export DEBIAN_FRONTEND=noninteractive; "
+        "git config --global --add safe.directory /root/sparkinfer 2>/dev/null || true; "
+        "apt-get update -q; "
+        "apt-get install -y -q git curl cmake build-essential libisl23 python3-pip gcc-12 g++-12; "
+        "if ! command -v nvcc >/dev/null 2>&1; then "
+        "  apt-get install -y -q cuda-nvcc-12-8 cuda-cudart-dev-12-8 libcublas-dev-12-8 cuda-nvml-dev-12-8; "
+        "fi; "
+        "python3 -m pip install -q --break-system-packages -U pip; "
+        "python3 -m pip install -q --break-system-packages "
+        "huggingface_hub 'huggingface-hub[cli]' tokenizers; "
+        "python3 -c 'import tokenizers; print(\"tokenizers ok\")'; "
+        "command -v cmake; command -v g++-12; nvcc --version | head -1"
+    )
+    r = sh(host, port, setup, timeout=1800)
+    if r.returncode != 0:
+        tail = ((r.stdout or "") + (r.stderr or ""))[-1500:]
+        sys.exit(f"box setup failed (missing cmake/tokenizers/build deps):\n{tail}")
+    print(">> box deps verified (cmake, g++-12, nvcc, tokenizers)")
+
+
 def sh(host, port, cmd, timeout=3600):
     try:
         return subprocess.run(
@@ -502,14 +525,10 @@ def main():
                 f"git fetch -q origin '{branch}' && git checkout -qf FETCH_HEAD; "
                 f"fi"
             )
+        ensure_box_deps(host, port)
         # g++-12: nvcc 12.8 breaks against Ubuntu 24.04's GCC 13.3 libstdc++ (cstdio /__gnu_cxx
         # errors). The build pins CMAKE_CUDA_HOST_COMPILER=g++-12, so it must be present.
-        setup = ("export DEBIAN_FRONTEND=noninteractive; "
-                 "git config --global --add safe.directory /root/sparkinfer 2>/dev/null || true; "
-                 "(command -v git >/dev/null && command -v cmake >/dev/null && dpkg -s libisl23 >/dev/null 2>&1 && dpkg -s python3-pip >/dev/null 2>&1 && dpkg -s g++-12 >/dev/null 2>&1) "
-                 "|| (apt-get update -q && apt-get install -y -q git curl cmake build-essential libisl23 python3-pip gcc-12 g++-12); "
-                 "python3 -m pip install -q --break-system-packages huggingface_hub 'huggingface-hub[cli]' tokenizers >/dev/null 2>&1 || true; "
-                 f"if [ -d /root/sparkinfer/.git ]; then cd /root/sparkinfer && {checkout}; "
+        setup = (f"if [ -d /root/sparkinfer/.git ]; then cd /root/sparkinfer && {checkout}; "
                  f"else git clone -q {REPO} /root/sparkinfer && cd /root/sparkinfer && {checkout}; fi")
         sr = sh(host, port, setup, timeout=1800)
         if sr.returncode:


### PR DESCRIPTION
## Summary
- Add `ensure_box_deps()` in `vast_eval.py` to install cmake, CUDA nvcc/NVML, and tokenizers on eval boxes before running
- Map harness `infra_error` verdicts to `eval:infra-error` instead of misleading `eval:REJECT` comments/labels
- Skip bogus 0 tok/s bidir sub-scores on infra failure; add `re-evaluate` label and exclude from exhausted-eval auto-close
- Add `eval:infra-error` GitHub label and unit tests

## Test plan
- [x] `python3 -m unittest eval.test_pr_eval_bot` (61 tests pass)
- [ ] Re-run eval bot on box 45230745 with `--reeval --only-pr 531,511,530` after baseline completes