### PR TITLE
Reuse baseline cache when main only changes eval tooling

### DIFF
--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -179,6 +179,16 @@ def _origin_main_short():
     return (r.stdout or "").strip() or None
 
 
+def _bench_harness_changed_between(old_commit, new_commit):
+    """True when bench/scripts differs between two main commits (needs fresh baseline)."""
+    if not old_commit or not new_commit or old_commit == new_commit:
+        return False
+    r = subprocess.run(
+        ["git", "-C", ROOT, "diff", "--quiet", f"{old_commit}..{new_commit}", "--", "bench/scripts"],
+        capture_output=True, text=True)
+    return r.returncode != 0
+
+
 def _baseline_cache_valid(cache, bidir, q36, q35, main_commit=None):
     """Return True when a loaded baseline cache entry is safe to reuse."""
     if not cache:
@@ -186,7 +196,8 @@ def _baseline_cache_valid(cache, bidir, q36, q35, main_commit=None):
     bres = cache.get("bres") or {}
     cached_commit = bres.get("commit")
     if main_commit and cached_commit and cached_commit != main_commit:
-        return False
+        if _bench_harness_changed_between(cached_commit, main_commit):
+            return False
     if bidir:
         probe36, probe35 = dict(q36), dict(q35)
         return (_apply_bidir_ctx_from_bres(bres, probe36, probe35)
@@ -2490,9 +2501,12 @@ def main():
         print(f">> --skip-baseline: no valid cache for {box_id} — aborting")
         return
     else:
-        if cache and main_commit and (cache.get("bres") or {}).get("commit") not in (None, main_commit):
-            print(f">> baseline cache stale (cached main={(cache.get('bres') or {}).get('commit')} "
-                  f"!= origin/main={main_commit}) — remeasuring")
+        if cache and main_commit:
+            cached_commit = (cache.get("bres") or {}).get("commit")
+            if (cached_commit and cached_commit != main_commit
+                    and _bench_harness_changed_between(cached_commit, main_commit)):
+                print(f">> baseline cache stale (bench/scripts changed {cached_commit}..{main_commit}) "
+                      f"— remeasuring")
         bcmd = [sys.executable, os.path.join(HERE, "vast_eval.py"),
                 *_vast_eval_transport_args(args.instance),
                 "--ref", "origin/main", "--frontier", "0", "--ceiling", str(args.ceiling),

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -944,7 +944,21 @@ class OnlyPrsAndBaselineCacheTest(unittest.TestCase):
                           "score_qwen35": {"ctx_128_tps": 200, "ctx_4096_tps": 190,
                                            "ctx_32768_tps": 180, "ctx_65536_tps": 170}}}
         q36, q35 = {"128": 0}, {"128": 0}
-        self.assertFalse(bot._baseline_cache_valid(cache, True, q36, q35, "def5678"))
+        with mock.patch.object(bot, "_bench_harness_changed_between", return_value=True):
+            self.assertFalse(bot._baseline_cache_valid(cache, True, q36, q35, "def5678"))
+
+    def test_baseline_cache_valid_keeps_cache_when_only_eval_changed(self):
+        cache = {"bres": {"commit": "abc1234", "pass": True, "tps": 300.0,
+                          "score_qwen36": {"ctx_128_tps": 300, "ctx_512_tps": 290,
+                                           "ctx_4096_tps": 280, "ctx_16384_tps": 270,
+                                           "ctx_32768_tps": 260},
+                          "score_qwen35": {"ctx_128_tps": 200, "ctx_4096_tps": 190,
+                                           "ctx_32768_tps": 180, "ctx_65536_tps": 170,
+                                           "ctx_4096_pp_tps": 100, "ctx_32768_pp_tps": 90,
+                                           "ctx_65536_pp_tps": 80}}}
+        q36, q35 = {"128": 0}, {"128": 0}
+        with mock.patch.object(bot, "_bench_harness_changed_between", return_value=False):
+            self.assertTrue(bot._baseline_cache_valid(cache, True, q36, q35, "def5678"))
 
     def test_baseline_cache_valid_accepts_matching_main(self):
         bres = {

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -137,6 +137,8 @@ def ensure_box_deps(host, port):
         "apt-get install -y -q git curl cmake build-essential libisl23 python3-pip gcc-12 g++-12; "
         "if ! command -v nvcc >/dev/null 2>&1; then "
         "  apt-get install -y -q cuda-nvcc-12-8 cuda-cudart-dev-12-8 libcublas-dev-12-8 cuda-nvml-dev-12-8; "
+        "elif [ ! -f /usr/local/cuda/include/nvml.h ] && [ ! -f /usr/local/cuda-12.8/include/nvml.h ]; then "
+        "  apt-get install -y -q cuda-nvml-dev-12-8; "
         "fi; "
         "python3 -m pip install -q --break-system-packages -U pip; "
         "python3 -m pip install -q --break-system-packages "


### PR DESCRIPTION
## Summary
- Only invalidate the same-box baseline cache when `bench/scripts` changes between the cached main commit and current `origin/main`
- Eval-only main merges (e.g. argparse fixes) no longer trigger a full baseline rebuild
- Ensure `cuda-nvml-dev` is installed even when nvcc is already present

## Test plan
- [x] `python3 -m unittest eval.test_pr_eval_bot.OnlyPrsAndBaselineCacheTest`