### PR TITLE
Harden detect_arch when nvidia-smi NVML is broken

### DIFF
--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -19,8 +19,14 @@ sha256_of() { sha256sum "$1" 2>/dev/null | awk '{print $1}'; }
 
 # compute capability -> CUDA arch (12.0 -> 120). RTX 5090 / PRO 6000 = 120, Spark/Thor = 121.
 detect_arch() {
-  local cc; cc="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '.')"
-  echo "${ARCH:-${cc:-120}}"
+  local cc arch="${ARCH:-}"
+  cc="$(nvidia-smi --query-gpu=compute_cap --format=csv,noheader 2>/dev/null | head -1 | tr -d '[:space:].')"
+  if [[ ! "$cc" =~ ^[0-9]+$ ]]; then cc=120; fi
+  if [[ -n "$arch" && "$arch" =~ ^[0-9]+$ ]]; then
+    echo "$arch"
+  else
+    echo "$cc"
+  fi
 }
 
 # Bare-metal SSH boxes often install nvcc outside default PATH (non-interactive ssh).


### PR DESCRIPTION
## Summary
- Validate `nvidia-smi` compute_cap output is numeric before using it
- Fall back to sm_120 when NVML prints errors to stdout (driver/library mismatch)

## Test plan
- [x] Reproduced on instance 45311451: NVML mismatch produced `compute_` cmake failure
- [x] After reboot + fallback, baseline setup proceeds