### PR TITLE
Annotate prefill speed tiers on correctness REJECT

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -781,14 +781,20 @@ if prefill_raw.startswith("RESULT_JSON "):
     pf = json.loads(prefill_raw[len("RESULT_JSON "):])
     res["prefill_tps"] = pf.get("tps", 0)
     res["prefill_frontier_tps"] = pf.get("frontier_tps", 0)
-    res["prefill_label"] = pf.get("label")
+    # Prefer speed_label when correctness REJECTed the prefill call — overall stays REJECT,
+    # but real prefill gains still get annotated (eval-prefill:XL).
+    res["prefill_label"] = pf.get("speed_label") or pf.get("label")
     res["prefill_delta_tps"] = pf.get("delta_tps")
     res["prefill_pct_over_frontier"] = pf.get("pct_over_frontier")
     res["prefill_pct_of_llama"] = pf.get("pct_of_llama")
     res["prefill_effective_pct"] = pf.get("effective_pct")
     if pf.get("difficulty_mult") is not None:
         res["prefill_difficulty_mult"] = pf["difficulty_mult"]
-    if tier_rank(pf.get("label")) > tier_rank(res.get("label")):
+    # Never promote prefill over a correctness REJECT headline (pass=false stays merge-blocking).
+    pf_pass_label = pf.get("label")
+    if res.get("label") == "REJECT" or pf_pass_label == "REJECT":
+        res["score_metric"] = "decode"
+    elif tier_rank(pf_pass_label) > tier_rank(res.get("label")):
         res["decode_label"] = res.get("label")
         res["decode_tps"] = res.get("tps")
         res["decode_score_context"] = res.get("score_context")

--- a/bench/scripts/label.py
+++ b/bench/scripts/label.py
@@ -73,40 +73,65 @@ def difficulty_mult(frontier):
 res = {"commit": commit, "tps": round(tps, 2), "top1": round(top1, 4),
        "kl": round(kl, 4), "frontier_tps": round(frontier, 2)}
 
-if top1 < TOP1_BAR or kl > KL_BAR:
-    res.update(pass_=False, label="REJECT",
-               reason=f"correctness gate: top1={top1} (need >= {TOP1_BAR}), kl={kl} (need <= {KL_BAR})")
-elif frontier <= 0:
-    res.update(pass_=True, label="BASELINE", note="no frontier set; this submission becomes it")
-else:
+
+def _speed_tier_fields(tps, frontier, ceiling):
+    """Compute speed-tier fields as if correctness already passed. Used for the headline label
+    and, on correctness REJECT, for speed_label so real prefill/decode gains still get annotated."""
+    out = {}
+    if frontier <= 0:
+        out["label"] = "BASELINE"
+        return out
     delta = tps - frontier
     g = delta / frontier                                # relative speedup over the frontier — SIGNIFICANCE basis
     if g <= SIG:
-        res.update(pass_=True, label="none", delta_tps=round(delta, 2),
+        out.update(label="none", delta_tps=round(delta, 2),
                    pct_over_frontier=round(100 * g, 1),
                    note="within significance gate — not a verified improvement")
-    else:
-        # FAIR label tier: size the gain against the llama.cpp reference (DIFF_REF — a constant maturity
-        # anchor for EVERY model), not the possibly-unoptimized frontier. So the same tok/s of real work
-        # earns the same tier whether the model started at 23 or 493 tok/s — an un-optimized model can no
-        # longer mint XLs from low-hanging fruit while a mature one (past llama) can't clear XS. Significance
-        # still gates on raw %-over-frontier above (a gain must beat the current best); only the TIER is
-        # llama-anchored. Past-llama difficulty boost (Option B) is unchanged. DIFF_REF<=0 -> legacy basis.
-        ref = DIFF_REF if DIFF_REF > 0 else frontier
-        g_fair = delta / ref
-        D = difficulty_mult(frontier)                   # hard-gain boost once past the reference
-        g_eff = min(g_fair * D, 2 * g)                  # strict cap: tier credit ≤ 2× measured speedup
-        # A verified improvement over the frontier floors at XS (real but small); the higher tiers
-        # (S/M/L/XL) are earned by the llama-anchored size. So "none" always means "not a verified
-        # improvement", never "real but tiny".
-        label = next((l for thr, l in BUCKETS if g_eff >= thr), "XS")
-        res.update(pass_=True, label=label, delta_tps=round(delta, 2),
-                   pct_over_frontier=round(100 * g, 1),      # RAW measured speedup (honest reporting)
-                   pct_of_llama=round(100 * g_fair, 1),      # gain as a fraction of llama.cpp — the label basis
-                   pct_of_ceiling=round(100 * tps / ceiling, 1) if ceiling > 0 else None)
-        res["effective_pct"] = round(100 * g_eff, 1)
-        if D != 1.0:                                    # transparency: expose the boost in the verdict
-            res["difficulty_mult"] = round(D, 2)
+        return out
+    # FAIR label tier: size the gain against the llama.cpp reference (DIFF_REF — a constant maturity
+    # anchor for EVERY model), not the possibly-unoptimized frontier. So the same tok/s of real work
+    # earns the same tier whether the model started at 23 or 493 tok/s — an un-optimized model can no
+    # longer mint XLs from low-hanging fruit while a mature one (past llama) can't clear XS. Significance
+    # still gates on raw %-over-frontier above (a gain must beat the current best); only the TIER is
+    # llama-anchored. Past-llama difficulty boost (Option B) is unchanged. DIFF_REF<=0 -> legacy basis.
+    ref = DIFF_REF if DIFF_REF > 0 else frontier
+    g_fair = delta / ref
+    D = difficulty_mult(frontier)                       # hard-gain boost once past the reference
+    g_eff = min(g_fair * D, 2 * g)                      # strict cap: tier credit ≤ 2× measured speedup
+    # A verified improvement over the frontier floors at XS (real but small); the higher tiers
+    # (S/M/L/XL) are earned by the llama-anchored size. So "none" always means "not a verified
+    # improvement", never "real but tiny".
+    label = next((l for thr, l in BUCKETS if g_eff >= thr), "XS")
+    out.update(label=label, delta_tps=round(delta, 2),
+               pct_over_frontier=round(100 * g, 1),      # RAW measured speedup (honest reporting)
+               pct_of_llama=round(100 * g_fair, 1),      # gain as a fraction of llama.cpp — the label basis
+               pct_of_ceiling=round(100 * tps / ceiling, 1) if ceiling > 0 else None)
+    out["effective_pct"] = round(100 * g_eff, 1)
+    if D != 1.0:                                        # transparency: expose the boost in the verdict
+        out["difficulty_mult"] = round(D, 2)
+    return out
+
+
+if top1 < TOP1_BAR or kl > KL_BAR:
+    res.update(pass_=False, label="REJECT",
+               reason=f"correctness gate: top1={top1} (need >= {TOP1_BAR}), kl={kl} (need <= {KL_BAR})")
+    # Keep reporting the speed tier that would have been earned — overall stays REJECT / not mergeable,
+    # but prefill (or decode) progress is still labeled (e.g. eval-prefill:XL on PR #403).
+    if frontier > 0 and tps > 0:
+        speed = _speed_tier_fields(tps, frontier, ceiling)
+        res["speed_label"] = speed["label"]
+        for k in ("delta_tps", "pct_over_frontier", "pct_of_llama", "pct_of_ceiling",
+                  "effective_pct", "difficulty_mult", "note"):
+            if k in speed and speed[k] is not None:
+                res[k] = speed[k]
+elif frontier <= 0:
+    res.update(pass_=True, label="BASELINE", note="no frontier set; this submission becomes it")
+    res["speed_label"] = "BASELINE"
+else:
+    speed = _speed_tier_fields(tps, frontier, ceiling)
+    res.update(pass_=True, **{k: v for k, v in speed.items() if k != "label"})
+    res["label"] = speed["label"]
+    res["speed_label"] = speed["label"]
 
 # Soft accuracy flag: passed the gate but above the preferred KL ceiling — accepted, margin is thin.
 if res.get("label") != "REJECT" and kl > KL_PREFER:

--- a/bench/scripts/test_label.py
+++ b/bench/scripts/test_label.py
@@ -32,13 +32,18 @@ def score(tps, frontier=100.0, ceiling=200.0, top1=0.97, kl=0.02, commit="deadbe
 
 class LabelPolicyTest(unittest.TestCase):
     def test_correctness_gate_rejects_bad_accuracy(self):
+        # +30 over frontier=100 clears significance; llama-anchored tier is M (~8% of 365.85).
         low_top1 = score(130, top1=0.89, kl=0.02)
         self.assertEqual(low_top1["label"], "REJECT")
         self.assertFalse(low_top1["pass"])
+        # Speed tier still reported so prefill/decode progress can be annotated.
+        self.assertEqual(low_top1["speed_label"], "M")
+        self.assertEqual(low_top1["pct_over_frontier"], 30.0)
 
         high_kl = score(130, top1=0.97, kl=0.21)
         self.assertEqual(high_kl["label"], "REJECT")
         self.assertFalse(high_kl["pass"])
+        self.assertEqual(high_kl["speed_label"], "M")
 
     def test_significance_gate_is_strictly_above_two_percent(self):
         exact_floor = score(102.0)

--- a/bench/scripts/test_prefill_label_merge.py
+++ b/bench/scripts/test_prefill_label_merge.py
@@ -20,9 +20,12 @@ def tier_rank(label):
 def merge_decode_prefill(decode, prefill):
     res = dict(decode)
     pf = dict(prefill)
-    res["prefill_label"] = pf.get("label")
+    res["prefill_label"] = pf.get("speed_label") or pf.get("label")
     res["prefill_tps"] = pf.get("tps")
-    if tier_rank(pf.get("label")) > tier_rank(res.get("label")):
+    pf_pass_label = pf.get("label")
+    if res.get("label") == "REJECT" or pf_pass_label == "REJECT":
+        res["score_metric"] = "decode"
+    elif tier_rank(pf_pass_label) > tier_rank(res.get("label")):
         res["decode_label"] = res.get("label")
         res["decode_tps"] = res.get("tps")
         res["decode_score_context"] = res.get("score_context")
@@ -68,6 +71,20 @@ class PrefillLabelMergeTest(unittest.TestCase):
         gains = {c["label"]: c["gain"] for c in data["contexts"] if c["tps"] > 0}
         self.assertIn("4k-context", gains)
         self.assertGreater(gains["4k-context"], 10.0)
+
+    def test_correctness_reject_still_reports_prefill_xl_speed_label(self):
+        """PR #403-shaped: top1 fails but Qwen3.6 prefill is a huge gain — keep REJECT headline,
+        annotate eval-prefill from speed_label."""
+        decode = {"label": "REJECT", "pass": False, "tps": 407.54, "frontier_tps": 406.66,
+                  "reason": "correctness gate: top1=0.8549"}
+        prefill = {"label": "REJECT", "pass": False, "tps": 13531.5, "frontier_tps": 484.09,
+                   "speed_label": "XL", "delta_tps": 13047.41, "pct_over_frontier": 2695.2,
+                   "score_prefill_context": 32768, "best_prefill_context_label": "32k-context"}
+        out = merge_decode_prefill(decode, prefill)
+        self.assertEqual(out["label"], "REJECT")
+        self.assertEqual(out["prefill_label"], "XL")
+        self.assertEqual(out["score_metric"], "decode")
+        self.assertEqual(out["prefill_tps"], 13531.5)
 
     def test_prefill_L_beats_decode_none(self):
         out = merge_decode_prefill(

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -133,14 +133,17 @@ def _apply_bidir_ctx_from_bres(bres, q36, q35):
         return True
 
     def _fill_pp(score, store, keys, mapping):
+        """Fill whichever prefill contexts measured >0. Qwen3.6 often has 128_pp=0; requiring
+        every key used to abort the whole fill and leave all baselines at 0 (PR #403)."""
         if not score:
             return False
+        got = False
         for k in keys:
             v = float(score.get(mapping[k]) or 0)
-            if v <= 0:
-                return False
-            store[k] = v
-        return True
+            if v > 0:
+                store[k] = v
+                got = True
+        return got
 
     got36 = _fill(bres.get("score_qwen36"), q36, ("128", "512", "4k", "16k", "32k"))
     got35 = _fill(bres.get("score_qwen35"), q35, ("128", "4k", "32k", "64k"))
@@ -2496,6 +2499,9 @@ def main():
             QWEN36_BASE.update(cache["q36"])
             QWYTHOS_BASE.update(cache["q35"])
         bres = cache["bres"]
+        # Re-derive pp from bres so older caches that zeroed all q36 pp (128_pp=0 abort) self-heal.
+        if args.bidir and bres:
+            _apply_bidir_ctx_from_bres(bres, QWEN36_BASE, QWYTHOS_BASE)
         print(f">> reusing cached same-box baseline from {cache['ts']} ({box_id}, main={main_commit or '?'})")
     elif args.skip_baseline:
         print(f">> --skip-baseline: no valid cache for {box_id} — aborting")
@@ -2679,7 +2685,8 @@ def main():
             print("--- dry-run, not posting ---\n" + body); continue
         if label:
             cur = labels_on(args.repo, num)
-            for lab in {l for l in cur if l.startswith("eval:") or l.startswith("eval-qwen")}:
+            for lab in {l for l in cur if l.startswith("eval:") or l.startswith("eval-qwen")
+                        or l.startswith("eval-prefill:")}:
                 remove_label(args.repo, num, lab)
             add_label(args.repo, num, f"eval:{label}")
             if res and res.get("mode") == "bidir" and not res.get("infra_error"):
@@ -2687,6 +2694,16 @@ def main():
                     add_label(args.repo, num, f"eval-qwen35:{res['label_qwen35']}")
                 if res.get("label_qwen36"):
                     add_label(args.repo, num, f"eval-qwen36:{res['label_qwen36']}")
+                # Annotate verified prefill progress even when headline is REJECT (correctness).
+                prefill_tiers = []
+                for block in (res.get("score_qwen35") or {}, res.get("score_qwen36") or {}, res):
+                    pl = block.get("prefill_label")
+                    if pl in SPEEDUP_LABELS:
+                        prefill_tiers.append(pl)
+                if prefill_tiers:
+                    best_pf = max(prefill_tiers, key=lambda t: (
+                        {"XL": 6, "L": 5, "M": 4, "S": 3, "XS": 2}.get(t, 0)))
+                    add_label(args.repo, num, f"eval-prefill:{best_pf}")
             elif res and res.get("infra_error"):
                 add_label(args.repo, num, REEVALUATE_LABEL)
             apply_context_label(args.repo, num, cur, res.get("best_context_label"))

--- a/eval/setup_labels.sh
+++ b/eval/setup_labels.sh
@@ -8,6 +8,8 @@ declare -A C=( [XL]=0E8A16 [L]=1D76DB [M]=5319E7 [S]=FBCA04 [XS]=BFD4F2
 for k in "${!C[@]}"; do
   gh label create "eval:$k" -R "$REPO" --color "${C[$k]}" \
      --description "sparkinfer auto-eval verdict: $k" --force >/dev/null
+  gh label create "eval-prefill:$k" -R "$REPO" --color "${C[$k]}" \
+     --description "sparkinfer prefill speed tier: $k (may annotate REJECT headlines)" --force >/dev/null
 done
 
 # subsystem / emission-weight labels — assigned deterministically from changed paths (no AI)

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -921,6 +921,34 @@ class OnlyPrsAndBaselineCacheTest(unittest.TestCase):
         self.assertEqual(bot._parse_only_prs(0, "387, 389"), {387, 389})
         self.assertEqual(bot._parse_only_prs(387, "389"), {387, 389})
 
+    def test_fill_pp_allows_partial_q36_when_128_pp_zero(self):
+        """Qwen3.6 baseline often has ctx_128_pp_tps=0; must still keep 512/4k/16k/32k pp."""
+        q36 = {"128_pp": 0.0, "512_pp": 0.0, "4k_pp": 0.0, "16k_pp": 0.0, "32k_pp": 0.0,
+               "128": 0, "512": 0, "4k": 0, "16k": 0, "32k": 0}
+        q35 = {"128": 0, "4k": 0, "32k": 0, "64k": 0,
+               "4k_pp": 0.0, "32k_pp": 0.0, "64k_pp": 0.0, "128k_pp": 0.0}
+        bres = {
+            "score_qwen36": {
+                "ctx_128_tps": 475.97, "ctx_512_tps": 469.85, "ctx_4096_tps": 450.96,
+                "ctx_16384_tps": 434.42, "ctx_32768_tps": 406.66,
+                "ctx_128_pp_tps": 0.0, "ctx_512_pp_tps": 534.53,
+                "ctx_4096_pp_tps": 521.72, "ctx_16384_pp_tps": 504.37,
+                "ctx_32768_pp_tps": 484.09,
+            },
+            "score_qwen35": {
+                "ctx_128_tps": 293.92, "ctx_4096_tps": 283.93,
+                "ctx_32768_tps": 282.28, "ctx_65536_tps": 282.28,
+                "ctx_4096_pp_tps": 15665.6, "ctx_32768_pp_tps": 17280.6,
+                "ctx_65536_pp_tps": 17432.4, "ctx_131072_pp_tps": 287.3,
+            },
+        }
+        self.assertTrue(bot._apply_bidir_ctx_from_bres(bres, q36, q35))
+        self.assertEqual(q36["128_pp"], 0.0)
+        self.assertAlmostEqual(q36["512_pp"], 534.53)
+        self.assertAlmostEqual(q36["4k_pp"], 521.72)
+        self.assertAlmostEqual(q36["32k_pp"], 484.09)
+        self.assertAlmostEqual(q35["4k_pp"], 15665.6)
+
     def test_baseline_cache_roundtrip(self):
         with tempfile.TemporaryDirectory() as td:
             cache_path = os.path.join(td, ".baseline_cache.json")


### PR DESCRIPTION
## Summary
- Fix `_fill_pp` so Qwen3.6 baselines with `128_pp=0` still keep 512/4k/16k/32k prefill baselines (PR #403-shaped miss).
- On correctness REJECT, `label.py` still emits `speed_label` so real prefill gains get `eval-prefill:*` without becoming mergeable.
- Bot posts `eval-prefill:{tier}`; merge never promotes prefill over a REJECT headline.

## Test plan
- [x] `python3 bench/scripts/test_label.py`
- [x] `python3 bench/scripts/test_prefill_label_merge.py`
- [x] `python3 -m unittest test_pr_eval_bot.OnlyPrsAndBaselineCacheTest.test_fill_pp_allows_partial_q36_when_128_pp_zero` (from `eval/`)
- [ ] Confirm next REJECT-with-prefill-gain run posts `eval:REJECT` + `eval-prefill:XL` (or similar)