### PR TITLE
perf(qwen36): precompute expert int8 row scales at load

### DIFF
--- a/kernels/csrc/cuda/quant/expert_row_scale_i8.cu
+++ b/kernels/csrc/cuda/quant/expert_row_scale_i8.cu
@@ -1,0 +1,153 @@
+// Load-time int8 row scales for the MoE expert stacks + the per-pass quantizer that consumes them.
+// See expert_row_scale_i8.h for why this is split out of the fused dequant.
+//
+// Portable CUDA — runs on sm_89 .. sm_120/sm_121 (RTX 5090 / PRO 6000 / Spark).
+
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+
+#include "sparkinfer/kernels/expert_row_scale_i8.h"
+
+namespace sparkinfer {
+namespace kernels {
+namespace {
+
+enum { ERS_Q4_K = 12, ERS_Q5_K = 13, ERS_Q6_K = 14 };
+
+// Block decoders, kept identical in value to dequant_gguf.cu's (that equality is the whole point:
+// it is what makes the split scale bit-identical to the fused one). They are re-stated here rather
+// than shared through a header so this path stays a self-contained translation unit.
+__device__ __forceinline__ float ers_h2f(const unsigned char* p) {
+    __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
+}
+
+// Sub-block j of a Q4_K/Q5_K super-block, resolved all the way to the affine pair the callers
+// actually want: value = a * quant - b. Folding the super-block scales in here (rather than handing
+// back the raw 6-bit packed s/m) keeps the float op order identical to the fused kernel's
+// `d * s * nib - dmin * m`, which is what the bit-identity guarantee rests on.
+__device__ __forceinline__ void ers_affine(const unsigned char* blk, int j, float* a, float* b) {
+    const unsigned char* p = blk + 4;
+    int s, m;
+    if (j < 4) { s = p[j] & 63; m = p[j + 4] & 63; }
+    else {
+        s = (p[j + 4] & 0xF) | ((p[j - 4] >> 6) << 4);
+        m = (p[j + 4] >> 4)  | ((p[j]     >> 6) << 4);
+    }
+    *a = ers_h2f(blk) * s;
+    *b = ers_h2f(blk + 2) * m;
+}
+
+__device__ __forceinline__ float ers_q4k_val(const unsigned char* blk, int t) {
+    const int j64 = t >> 6, r = t & 63, l = r & 31, hi = r >> 5;
+    const unsigned char byte = blk[16 + j64 * 32 + l];
+    float a, b; ers_affine(blk, 2 * j64 + hi, &a, &b);
+    return a * (hi ? (byte >> 4) : (byte & 0xF)) - b;
+}
+
+__device__ __forceinline__ float ers_q5k_val(const unsigned char* blk, int t) {
+    const int j64 = t >> 6, r = t & 63, l = r & 31, hi = r >> 5;
+    const int sub = 2 * j64 + hi;
+    const unsigned char byte = blk[48 + j64 * 32 + l];
+    const int nib = hi ? (byte >> 4) : (byte & 0xF);
+    const int high = (blk[16 + l] >> sub) & 1;          // 5th bit lives in the qh plane
+    float a, b; ers_affine(blk, sub, &a, &b);
+    return a * (nib + (high ? 16 : 0)) - b;
+}
+
+__device__ __forceinline__ float ers_q6k_val(const unsigned char* blk, int t) {
+    const int half = t >> 7, r = t & 127, quad = r >> 5, l = r & 31;
+    const unsigned char* ql = blk + half * 64;
+    const unsigned char* qh = blk + 128 + half * 32;
+    const signed char* sc = (const signed char*)(blk + 192) + half * 8;
+    const float d = ers_h2f(blk + 208);
+    const int is = l / 16;
+    int qv;
+    if (quad == 0)      qv = (int)((ql[l]      & 0xF) | (((qh[l] >> 0) & 3) << 4)) - 32;
+    else if (quad == 1) qv = (int)((ql[l + 32] & 0xF) | (((qh[l] >> 2) & 3) << 4)) - 32;
+    else if (quad == 2) qv = (int)((ql[l]      >>  4) | (((qh[l] >> 4) & 3) << 4)) - 32;
+    else                qv = (int)((ql[l + 32] >>  4) | (((qh[l] >> 6) & 3) << 4)) - 32;
+    return d * sc[is + 2 * quad] * qv;
+}
+
+template <int QT>
+__device__ __forceinline__ float ers_val(const unsigned char* blk, int t) {
+    return (QT == ERS_Q4_K) ? ers_q4k_val(blk, t)
+         : (QT == ERS_Q5_K) ? ers_q5k_val(blk, t) : ers_q6k_val(blk, t);
+}
+
+template <int QT>
+__device__ __forceinline__ const unsigned char* ers_row(const unsigned char* src, int row, int nsb) {
+    constexpr int BS = (QT == ERS_Q4_K) ? 144 : (QT == ERS_Q5_K) ? 176 : 210;
+    return src + (size_t)row * nsb * BS;
+}
+
+// One block (256 threads) per row; thread t handles value t of each super-block, so a full row is
+// covered in cols/256 steps. Load-time only, so plain scalar accesses are fine here.
+template <int QT>
+__global__ void ers_scale_kernel(const unsigned char* __restrict__ src,
+                                 float* __restrict__ scale, int cols) {
+    const int row = blockIdx.x, t = threadIdx.x, nsb = cols >> 8;
+    constexpr int BS = (QT == ERS_Q4_K) ? 144 : (QT == ERS_Q5_K) ? 176 : 210;
+    const unsigned char* rbase = ers_row<QT>(src, row, nsb);
+
+    float peak = 0.f;
+    for (int sb = 0; sb < nsb; sb++)
+        peak = fmaxf(peak, fabsf(ers_val<QT>(rbase + (size_t)sb * BS, t)));
+
+    // Block-wide max. fmaxf is exact and order-independent, so any reduction order yields the same
+    // scale as the fused kernel's; this runs once at load, so take the plain tree over shared memory
+    // rather than a tuned shuffle ladder.
+    __shared__ float red[256];
+    red[t] = peak;
+    __syncthreads();
+    for (int half = 128; half > 0; half >>= 1) {
+        if (t < half) red[t] = fmaxf(red[t], red[t + half]);
+        __syncthreads();
+    }
+    if (t == 0) scale[row] = red[0] / 127.f;
+}
+
+// The per-pass half: the row's scale is already known, so this is a single decode pass.
+template <int QT>
+__global__ void ers_quant_kernel(const unsigned char* __restrict__ src,
+                                 signed char* __restrict__ q,
+                                 const float* __restrict__ scale, int cols) {
+    const int row = blockIdx.x, t = threadIdx.x, nsb = cols >> 8;
+    constexpr int BS = (QT == ERS_Q4_K) ? 144 : (QT == ERS_Q5_K) ? 176 : 210;
+    const unsigned char* rbase = ers_row<QT>(src, row, nsb);
+    const float d = scale[row];
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    signed char* qrow = q + (size_t)row * cols;
+    for (int sb = 0; sb < nsb; sb++)
+        qrow[sb * 256 + t] = (signed char)(int)roundf(ers_val<QT>(rbase + (size_t)sb * BS, t) * inv);
+}
+
+} // namespace
+
+bool launch_expert_row_scales_i8(int ggml_type, const void* src, float* scale,
+                                 int rows, int cols, cudaStream_t stream) {
+    if ((cols & 255) != 0 || rows <= 0) return false;
+    auto* s = reinterpret_cast<const unsigned char*>(src);
+    switch (ggml_type) {
+        case ERS_Q4_K: ers_scale_kernel<ERS_Q4_K><<<rows, 256, 0, stream>>>(s, scale, cols); return true;
+        case ERS_Q5_K: ers_scale_kernel<ERS_Q5_K><<<rows, 256, 0, stream>>>(s, scale, cols); return true;
+        case ERS_Q6_K: ers_scale_kernel<ERS_Q6_K><<<rows, 256, 0, stream>>>(s, scale, cols); return true;
+        default: return false;
+    }
+}
+
+bool launch_expert_rows_i8_scaled(int ggml_type, const void* src, signed char* q,
+                                  const float* scale, int rows, int cols, cudaStream_t stream) {
+    if ((cols & 255) != 0 || rows <= 0) return false;
+    auto* s = reinterpret_cast<const unsigned char*>(src);
+    switch (ggml_type) {
+        case ERS_Q4_K: ers_quant_kernel<ERS_Q4_K><<<rows, 256, 0, stream>>>(s, q, scale, cols); return true;
+        case ERS_Q5_K: ers_quant_kernel<ERS_Q5_K><<<rows, 256, 0, stream>>>(s, q, scale, cols); return true;
+        case ERS_Q6_K: ers_quant_kernel<ERS_Q6_K><<<rows, 256, 0, stream>>>(s, q, scale, cols); return true;
+        default: return false;
+    }
+}
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/expert_row_scale_i8.h
+++ b/kernels/include/sparkinfer/kernels/expert_row_scale_i8.h
@@ -1,0 +1,36 @@
+#pragma once
+// Load-time int8 row scales for the MoE expert stacks, and the matching per-pass quantizer.
+//
+// launch_gguf_dequant_rows_i8 (quant.h) fuses "GGUF row -> symmetric int8" by decoding each
+// element twice: once for the row amax that fixes the scale, once to quantize against it. For a
+// weight that is re-quantized on every pass — the 256 expert matrices of a Qwen3.6 MoE layer, redone
+// per batched-prefill call — the amax half is repeated work, because scale[r] is a function of the
+// static quantized weight alone.
+//
+// Split it: compute the scales once at load (launch_expert_row_scales_i8), then have the per-pass
+// dequant consume them (launch_expert_rows_i8_scaled) and decode each element exactly once. The max
+// reduction is exact and order-independent, so the scales — and the int8 rows derived from them —
+// are bit-identical to what the fused kernel produces.
+//
+// Kept in its own translation unit rather than folded into dequant_gguf.cu: this is an expert-stack
+// concern with a different lifetime (load vs per-pass) from that file's general dequant helpers.
+//
+// Q4_K (12), Q5_K (13) and Q6_K (14) only; both entry points return false, having launched nothing,
+// for any other ggml type or a cols that is not a multiple of 256.
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// scale[r] = max_c |v[r,c]| / 127 over the exact fp32 dequant of row r. rows x cols elements.
+bool launch_expert_row_scales_i8(int ggml_type, const void* src, float* scale,
+                                 int rows, int cols, cudaStream_t stream = nullptr);
+
+// q[r,c] = round(v[r,c] / scale[r]) using the precomputed scale (never written here).
+bool launch_expert_rows_i8_scaled(int ggml_type, const void* src, signed char* q,
+                                  const float* scale, int rows, int cols,
+                                  cudaStream_t stream = nullptr);
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -19,6 +19,7 @@
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/quant.h"
+#include "sparkinfer/kernels/expert_row_scale_i8.h"
 #include "sparkinfer/kernels/proj_requant.h"
 
 #include <cuda_runtime.h>
@@ -152,6 +153,10 @@ struct Qwen35Model::Impl {
     float *sx_h = nullptr;   // pipelined shared-expert h_scratch (avoids racing routed mf_h)
     void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
+    // Batched-prefill expert int8 row scales, precomputed once at load (see load_gguf). The MoE
+    // prefill re-quantizes all 256 experts of every layer on each pass; caching the scales lets
+    // that pass decode each weight once instead of twice. Layer-major, ~126 MB for Qwen3.6-35B.
+    float *pf_exp_sg = nullptr, *pf_exp_su = nullptr, *pf_exp_sd = nullptr;
     unsigned int *mf_rc = nullptr;   // fused-router grid-completion counter (persistent, zero-init)
     // flash-decoding (KV-split) attention partials
     static constexpr int MAX_NSPLITS = 256;   // partials sized for this; adaptive n_splits <= this
@@ -1367,7 +1372,8 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
     bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
     Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.active_seq_id, lin_state, lin_conv,
                           s.logits, s.d_out_id, s.h_out_id, s.gguf,
-                          s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim };
+                          s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
+                          s.pf_exp_sg, s.pf_exp_su, s.pf_exp_sd };
     return prefill_batched_run(ctx, prompt_ids, n);
 }
 
@@ -1974,6 +1980,39 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             : (w.router_w && w.gate_q && w.up_q && w.down_q);
         if (!have_attn || !w.input_norm || !w.post_attn_norm || !have_ffn) return false;
         if (i == 0 || i == c.n_layers - 1) fprintf(stderr, "[gguf] layer %d loaded\n", i);
+    }
+    // ---- Precompute the batched-prefill expert int8 row scales (static weights -> static scales).
+    // Skipped silently on alloc failure or an unsupported expert qtype; prefill then falls back to
+    // the self-contained two-pass dequant, so this is a pure fast path.
+    if (!c.dense_ffn && c.n_experts > 0 && c.moe_ffn > 0) {
+        const size_t ng = (size_t)c.n_layers * c.n_experts * c.moe_ffn;   // gate/up rows, all layers
+        const size_t nd = (size_t)c.n_layers * c.n_experts * H;           // down rows, all layers
+        void *pg = nullptr, *pu = nullptr, *pd = nullptr;
+        const bool alloc_ok =
+            cudaMalloc(&pg, ng * sizeof(float)) == cudaSuccess &&
+            cudaMalloc(&pu, ng * sizeof(float)) == cudaSuccess &&
+            cudaMalloc(&pd, nd * sizeof(float)) == cudaSuccess;
+        bool ok = alloc_ok;
+        if (ok) {
+            for (int i = 0; i < c.n_layers && ok; i++) {
+                const Qwen35LayerWeights& w = s.w.layers[i];
+                const size_t og = (size_t)i * c.n_experts * c.moe_ffn, od = (size_t)i * c.n_experts * H;
+                ok = kernels::launch_expert_row_scales_i8(w.gate_qtype, w.gate_q, (float*)pg + og,
+                                                        c.n_experts * c.moe_ffn, H, s.stream)
+                  && kernels::launch_expert_row_scales_i8(w.up_qtype, w.up_q, (float*)pu + og,
+                                                        c.n_experts * c.moe_ffn, H, s.stream)
+                  && kernels::launch_expert_row_scales_i8(w.down_qtype, w.down_q, (float*)pd + od,
+                                                        c.n_experts * H, c.moe_ffn, s.stream);
+            }
+            if (ok) ok = cudaStreamSynchronize(s.stream) == cudaSuccess;
+        }
+        if (ok) {
+            s.pf_exp_sg = (float*)pg; s.pf_exp_su = (float*)pu; s.pf_exp_sd = (float*)pd;
+            s.owned.push_back(pg); s.owned.push_back(pu); s.owned.push_back(pd);
+        } else {
+            cudaFree(pg); cudaFree(pu); cudaFree(pd);
+            fprintf(stderr, "[gguf] expert row-scale precompute unavailable -> prefill uses the two-pass dequant\n");
+        }
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -15,6 +15,7 @@
 #include "sparkinfer/kernels/prefill.h"
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/quant.h"
+#include "sparkinfer/kernels/expert_row_scale_i8.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/prefill_i8.h"
 #include "sparkinfer/kernels/prefill_moe.h"
@@ -320,20 +321,32 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_pfm_bucket_pairs(mids, mweights, mcounts, moffsets, mcursors,
                                              pair_tok, pair_w, tilemap, d_ntiles, N, E, topk, st);
             // Expert weights -> int8 rows ONCE per layer (one launch covers all 256 experts).
-            kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
-            kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   w.up_q,   Wu_i8, swu, E * mffn, H, st);
-            kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
+            // With load-time scales the row amax is already known, so each weight element is
+            // decoded once here instead of twice; the emitted int8 rows are identical either way.
+            const float* csg = s.exp_scale_gate ? s.exp_scale_gate + (size_t)L * E * mffn : nullptr;
+            const float* csu = s.exp_scale_up   ? s.exp_scale_up   + (size_t)L * E * mffn : nullptr;
+            const float* csd = s.exp_scale_down ? s.exp_scale_down + (size_t)L * E * H    : nullptr;
+            if (csg && csu && csd) {
+                kernels::launch_expert_rows_i8_scaled(w.gate_qtype, w.gate_q, Wg_i8, csg, E * mffn, H, st);
+                kernels::launch_expert_rows_i8_scaled(w.up_qtype,   w.up_q,   Wu_i8, csu, E * mffn, H, st);
+                kernels::launch_expert_rows_i8_scaled(w.down_qtype, w.down_q, Wd_i8, csd, E * H, mffn, st);
+            } else {
+                kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
+                kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   w.up_q,   Wu_i8, swu, E * mffn, H, st);
+                kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
+                csg = swg; csu = swu; csd = swd;
+            }
             kernels::launch_prefill_quantize_rows_i8(hn, mA_i8, msx, N, H, st);
-            kernels::launch_pfm_moe_gemm_i8(mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets,
+            kernels::launch_pfm_moe_gemm_i8(mA_i8, msx, Wg_i8, csg, pair_tok, pair_w, moffsets,
                                             tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles,
                                             /*a_indirect=*/true, /*c_scatter=*/false, st);
-            kernels::launch_pfm_moe_gemm_i8(mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets,
+            kernels::launch_pfm_moe_gemm_i8(mA_i8, msx, Wu_i8, csu, pair_tok, pair_w, moffsets,
                                             tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
                                             true, false, st);
             kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
             kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
             pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
-            kernels::launch_pfm_moe_gemm_i8(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
+            kernels::launch_pfm_moe_gemm_i8(h_i8, sh, Wd_i8, csd, pair_tok, pair_w, moffsets,
                                             tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
                                             /*a_indirect=*/false, /*c_scatter=*/true, st);
             // Shared expert (Qwen3.6 UD): out scaled by sigmoid(hn . gate_inp) per token.

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -26,6 +26,11 @@ struct Qwen35PrefillCtx {
     bool                 gguf;             // native GGUF load (quantized weights)
     int                  qdim, kvdim;                       // full-attn q / kv dims
     int                  linear_qdim, linear_vdim, linear_qkvdim;  // GDN dims
+    // Expert int8 row scales precomputed at load, layer-major (gate/up: [n_layers,E*moe_ffn],
+    // down: [n_layers,E*hidden]). Null when unavailable -> the two-pass dequant is used instead.
+    const float*         exp_scale_gate;
+    const float*         exp_scale_up;
+    const float*         exp_scale_down;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.


### PR DESCRIPTION
## Summary

The Qwen3.6-35B-A3B batched MoE prefill re-quantizes all 256 experts of every layer to int8 on each pass, and that kernel decodes every weight element **twice** — once for the row `amax` (which fixes the int8 scale), once to quantize against it. The scale is a pure function of the *static* quantized weight, so this PR computes the expert row scales once at load and lets the per-pass dequant decode each element exactly once. The emitted int8 rows are bit-identical.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — this PR does **not** target decode; filled as a no-regression check, not a claimed gain):

| | decode tok/s |
|---|--:|
| before (main) | 499.29 |
| after (this PR) | 498.67 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B-UD-Q4_K_M, best context = 512):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2539.04 |
| after prefill (this PR) | 2964.14 |

All scored contexts, median of 3 interleaved runs:

| ctx | frontier (`82cd167`) | this PR | marginal |
|---|--:|--:|--:|
| 512 | 2539.04 | **2964.14** | **+16.74%** |
| 4096 | 9649.39 | **10388.15** | **+7.66%** |
| 16384 | 12905.68 | 13213.55 | +2.39% |
| 32768 | 13485.17 | 13672.47 | +1.39% |

Decode at every scored context (uniformly ~-0.15%, i.e. noise, nowhere near the 2% guard):

| ctx | 128 | 512 | 4096 | 16384 | 32768 |
|---|--:|--:|--:|--:|--:|
| frontier | 499.29 | 491.51 | 473.08 | 455.27 | 426.61 |
| this PR | 498.67 | 490.73 | 472.39 | 454.54 | 425.91 |
| delta | -0.12% | -0.16% | -0.15% | -0.16% | -0.16% |

The gain is largest at short context because the expert dequant is **N-independent**: profiled on `main`, nsys puts it at 93.7 ms at ctx 512 and 93.3 ms at ctx 4096 — 46% and 22% of the respective prefill. VRAM cost is ~126 MB of scales (24.5 -> 24.7 GB measured).

```text
# interleaved on one idle box, separate build trees, raw SWEEP_JSON:
MAIN1 {"512":{"prefill_pp":2555.3021},"4096":{"prefill_pp":9649.3941},"16384":{"prefill_pp":12878.9090},"32768":{"prefill_pp":13485.1720}}
PR1   {"512":{"prefill_pp":2964.1379},"4096":{"prefill_pp":10396.0724},"16384":{"prefill_pp":13213.5454},"32768":{"prefill_pp":13676.5535}}
MAIN2 {"512":{"prefill_pp":2539.0359},"4096":{"prefill_pp":9661.6890},"16384":{"prefill_pp":12905.6792},"32768":{"prefill_pp":13453.6396}}
PR2   {"512":{"prefill_pp":2975.3840},"4096":{"prefill_pp":10363.0202},"16384":{"prefill_pp":13187.4417},"32768":{"prefill_pp":13650.5393}}
MAIN3 {"512":{"prefill_pp":2509.7173},"4096":{"prefill_pp":9643.1090},"16384":{"prefill_pp":12919.2963},"32768":{"prefill_pp":13493.6922}}
PR3   {"512":{"prefill_pp":2960.8761},"4096":{"prefill_pp":10388.1520},"16384":{"prefill_pp":13222.9002},"32768":{"prefill_pp":13672.4738}}
```

## Correctness

Bit-identity is verified directly, not inferred — a standalone harness ran both the in-tree two-pass `launch_gguf_dequant_rows_i8` and this split path over randomized Q4_K/Q5_K/Q6_K payloads at the real expert shapes and compared every output byte:

```text
Q4_K gate/up (E=16)   rows=8192   cols=2048  int8 diffs=0/16777216  scale diffs=0/8192   IDENTICAL
Q5_K down    (E=16)   rows=32768  cols=512   int8 diffs=0/16777216  scale diffs=0/32768  IDENTICAL
Q6_K down    (E=16)   rows=32768  cols=512   int8 diffs=0/16777216  scale diffs=0/32768  IDENTICAL
Q4_K odd width 768    rows=1024   cols=768   int8 diffs=0/786432    scale diffs=0/1024   IDENTICAL
Q4_K narrow 256       rows=1024   cols=256   int8 diffs=0/262144    scale diffs=0/1024   IDENTICAL
RESULT: ALL IDENTICAL
```

The accuracy gate returns **identical metrics** on both builds, same box, same seeds:

```text
# main @82cd167 AND this PR, both:
short vs-llama (bf16)   top1=0.9100 kl=0.0749   (gates top1>=0.90, kl<=0.20)
long  MEAN of 3         top1=0.9609 kl=0.3977   (veto if top1<0.85 or KL>1.00)
METRIC top1=0.910000 kl=0.074893
```

`ctest`: 9/9 pass. `qwen3_gguf_prefill_check 8320 128` (batched vs token-loop reference) puts this PR at top-1 0.9219 / KL 0.0090-0.0108, inside main's own run-to-run band of 0.8906-0.9297 / KL 0.0092-0.0096 — the down-projection scatter uses float `atomicAdd`, so that metric is non-deterministic on both builds.