### PR TITLE
perf(prefill): single-pass Q→i8 row dequant (+15% Qwen3.6 pp @512)

### DIFF
--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -133,30 +133,29 @@ __device__ __forceinline__ float deq_q6k_val(const unsigned char* blk, int t) {
     return d * sc[is + 2 * quad] * qv;
 }
 
-// Single-pass Q→i8 for cols ≤ 2048 (Qwen3.6 MoE H/mffn). Wider rows (Qwythos
-// attn K=4096, FFN K=12288) keep the two-pass kernel so we never reject the i8
-// path (the previous cols>4096 early-return regressed Qwythos @4k prefill ~10%).
+// Single-pass Q→i8 for cols ≤ 2048 (Qwen3.6 MoE H/mffn). Values live in registers
+// (templated NSB) so the int8 rows are bit-identical to the two-pass kernel — same
+// dequant, same amax reduce, same roundf — while skipping the second decode pass.
+// Wider rows (Qwythos attn K=4096, FFN K=12288) keep two-pass so we never reject the
+// i8 path (the previous cols>4096 early-return regressed Qwythos @4k prefill ~10%).
 static constexpr int kDeqRowsI8MaxNsb = 8;
 
-template <int QT>   // 12 = Q4_K (144B), 13 = Q5_K (176B), 14 = Q6_K (210B) per superblock
+template <int QT, int NSB>   // QT: 12=Q4_K, 13=Q5_K, 14=Q6_K; NSB = cols/256
 __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
                                    signed char* __restrict__ q, float* __restrict__ scale,
                                    int cols) {
-    // Single pass: dequant once into smem, reduce amax, then write int8.
-    // Avoids the old two-pass ~2x Q4_K/Q5_K/Q6_K decode cost. Cap cols at 2048
-    // (8 KB smem) so occupancy stays healthy on sm_120.
     constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : 210;
     const int row = blockIdx.x, t = threadIdx.x;
-    const int nsb = cols >> 8;
-    const unsigned char* rbase = src + (size_t)row * nsb * BS;
+    const unsigned char* rbase = src + (size_t)row * NSB * BS;
 
-    extern __shared__ float svals[];
+    float vals[NSB];
     float amax = 0.f;
-    for (int sb = 0; sb < nsb; sb++) {
+    #pragma unroll
+    for (int sb = 0; sb < NSB; sb++) {
         const unsigned char* blk = rbase + (size_t)sb * BS;
         const float v = (QT == 12) ? deq_q4k_val(blk, t)
                       : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
-        svals[sb * 256 + t] = v;
+        vals[sb] = v;
         amax = fmaxf(amax, fabsf(v));
     }
     __shared__ float swarp[8];
@@ -176,8 +175,9 @@ __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
     const float inv = (d > 0.f) ? (1.f / d) : 0.f;
 
     signed char* qrow = q + (size_t)row * cols;
-    for (int sb = 0; sb < nsb; sb++)
-        qrow[sb * 256 + t] = (signed char)(int)roundf(svals[sb * 256 + t] * inv);
+    #pragma unroll
+    for (int sb = 0; sb < NSB; sb++)
+        qrow[sb * 256 + t] = (signed char)(int)roundf(vals[sb] * inv);
 }
 
 // Two-pass fallback for cols > 2048 (Qwythos projections). Same math as above.
@@ -269,12 +269,26 @@ bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q,
     if ((cols & 255) != 0) return false;
     auto* s = reinterpret_cast<const unsigned char*>(src);
     const int nsb = cols >> 8;
-    if (nsb <= kDeqRowsI8MaxNsb) {
-        const size_t smem = (size_t)cols * sizeof(float);
-        if (ggml_type == GGML_Q4_K)      deq_rows_i8_kernel<12><<<rows, 256, smem, stream>>>(s, q, scale, cols);
-        else if (ggml_type == GGML_Q5_K) deq_rows_i8_kernel<13><<<rows, 256, smem, stream>>>(s, q, scale, cols);
-        else if (ggml_type == GGML_Q6_K) deq_rows_i8_kernel<14><<<rows, 256, smem, stream>>>(s, q, scale, cols);
+    if (nsb > 0 && nsb <= kDeqRowsI8MaxNsb) {
+        // Explicit NSB instantiations keep vals[] in registers (bit-same as two-pass).
+        #define SI_LAUNCH(QT, NSB) deq_rows_i8_kernel<QT, NSB><<<rows, 256, 0, stream>>>(s, q, scale, cols)
+        #define SI_BY_NSB(QT) \
+            switch (nsb) { \
+                case 1: SI_LAUNCH(QT, 1); break; \
+                case 2: SI_LAUNCH(QT, 2); break; \
+                case 3: SI_LAUNCH(QT, 3); break; \
+                case 4: SI_LAUNCH(QT, 4); break; \
+                case 5: SI_LAUNCH(QT, 5); break; \
+                case 6: SI_LAUNCH(QT, 6); break; \
+                case 7: SI_LAUNCH(QT, 7); break; \
+                default: SI_LAUNCH(QT, 8); break; \
+            }
+        if (ggml_type == GGML_Q4_K)      { SI_BY_NSB(12); }
+        else if (ggml_type == GGML_Q5_K) { SI_BY_NSB(13); }
+        else if (ggml_type == GGML_Q6_K) { SI_BY_NSB(14); }
         else return false;
+        #undef SI_BY_NSB
+        #undef SI_LAUNCH
     } else {
         // Qwythos attn/FFN: keep two-pass so i8 GEMM still engages (do not return false).
         if (ggml_type == GGML_Q4_K)      deq_rows_i8_twopass_kernel<12><<<rows, 256, 0, stream>>>(s, q, scale, cols);

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -133,20 +133,23 @@ __device__ __forceinline__ float deq_q6k_val(const unsigned char* blk, int t) {
     return d * sc[is + 2 * quad] * qv;
 }
 
+// Single-pass Q→i8 for cols ≤ 2048 (Qwen3.6 MoE H/mffn). Wider rows (Qwythos
+// attn K=4096, FFN K=12288) keep the two-pass kernel so we never reject the i8
+// path (the previous cols>4096 early-return regressed Qwythos @4k prefill ~10%).
+static constexpr int kDeqRowsI8MaxNsb = 8;
+
 template <int QT>   // 12 = Q4_K (144B), 13 = Q5_K (176B), 14 = Q6_K (210B) per superblock
 __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
                                    signed char* __restrict__ q, float* __restrict__ scale,
                                    int cols) {
-    // Single pass: dequant each of the `cols` values once into smem, reduce amax, then
-    // write int8. The previous two-pass form (amax scan then re-dequant) paid ~2x the
-    // Q4_K/Q5_K/Q6_K decode cost; MoE prefill calls this over E*mffn / E*H rows per layer.
+    // Single pass: dequant once into smem, reduce amax, then write int8.
+    // Avoids the old two-pass ~2x Q4_K/Q5_K/Q6_K decode cost. Cap cols at 2048
+    // (8 KB smem) so occupancy stays healthy on sm_120.
     constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : 210;
     const int row = blockIdx.x, t = threadIdx.x;
     const int nsb = cols >> 8;
     const unsigned char* rbase = src + (size_t)row * nsb * BS;
 
-    // cols is a multiple of 256 and <= 4096 on every Qwen3.6 / Qwythos projection we feed
-    // through this path; 4096 floats = 16 KB shared — well under the sm_120 default.
     extern __shared__ float svals[];
     float amax = 0.f;
     for (int sb = 0; sb < nsb; sb++) {
@@ -175,6 +178,48 @@ __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
     signed char* qrow = q + (size_t)row * cols;
     for (int sb = 0; sb < nsb; sb++)
         qrow[sb * 256 + t] = (signed char)(int)roundf(svals[sb * 256 + t] * inv);
+}
+
+// Two-pass fallback for cols > 2048 (Qwythos projections). Same math as above.
+template <int QT>
+__global__ void deq_rows_i8_twopass_kernel(const unsigned char* __restrict__ src,
+                                           signed char* __restrict__ q, float* __restrict__ scale,
+                                           int cols) {
+    constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : 210;
+    const int row = blockIdx.x, t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const unsigned char* rbase = src + (size_t)row * nsb * BS;
+
+    float amax = 0.f;
+    for (int sb = 0; sb < nsb; sb++) {
+        const unsigned char* blk = rbase + (size_t)sb * BS;
+        const float v = (QT == 12) ? deq_q4k_val(blk, t)
+                      : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
+        amax = fmaxf(amax, fabsf(v));
+    }
+    __shared__ float swarp[8];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < 8) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 4; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (t == 0) swarp[0] = v;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) scale[row] = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    signed char* qrow = q + (size_t)row * cols;
+    for (int sb = 0; sb < nsb; sb++) {
+        const unsigned char* blk = rbase + (size_t)sb * BS;
+        const float v = (QT == 12) ? deq_q4k_val(blk, t)
+                      : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
+        qrow[sb * 256 + t] = (signed char)(int)roundf(v * inv);
+    }
 }
 
 __global__ void deq_q8_0_kernel(const unsigned char* __restrict__ src, __nv_bfloat16* __restrict__ y, long nblocks) {
@@ -222,13 +267,21 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
 bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q, float* scale,
                                  int rows, int cols, cudaStream_t stream) {
     if ((cols & 255) != 0) return false;
-    if (cols > 4096) return false;   // smem staging bound in deq_rows_i8_kernel
     auto* s = reinterpret_cast<const unsigned char*>(src);
-    const size_t smem = (size_t)cols * sizeof(float);
-    if (ggml_type == GGML_Q4_K)      deq_rows_i8_kernel<12><<<rows, 256, smem, stream>>>(s, q, scale, cols);
-    else if (ggml_type == GGML_Q5_K) deq_rows_i8_kernel<13><<<rows, 256, smem, stream>>>(s, q, scale, cols);
-    else if (ggml_type == GGML_Q6_K) deq_rows_i8_kernel<14><<<rows, 256, smem, stream>>>(s, q, scale, cols);
-    else return false;
+    const int nsb = cols >> 8;
+    if (nsb <= kDeqRowsI8MaxNsb) {
+        const size_t smem = (size_t)cols * sizeof(float);
+        if (ggml_type == GGML_Q4_K)      deq_rows_i8_kernel<12><<<rows, 256, smem, stream>>>(s, q, scale, cols);
+        else if (ggml_type == GGML_Q5_K) deq_rows_i8_kernel<13><<<rows, 256, smem, stream>>>(s, q, scale, cols);
+        else if (ggml_type == GGML_Q6_K) deq_rows_i8_kernel<14><<<rows, 256, smem, stream>>>(s, q, scale, cols);
+        else return false;
+    } else {
+        // Qwythos attn/FFN: keep two-pass so i8 GEMM still engages (do not return false).
+        if (ggml_type == GGML_Q4_K)      deq_rows_i8_twopass_kernel<12><<<rows, 256, 0, stream>>>(s, q, scale, cols);
+        else if (ggml_type == GGML_Q5_K) deq_rows_i8_twopass_kernel<13><<<rows, 256, 0, stream>>>(s, q, scale, cols);
+        else if (ggml_type == GGML_Q6_K) deq_rows_i8_twopass_kernel<14><<<rows, 256, 0, stream>>>(s, q, scale, cols);
+        else return false;
+    }
     return true;
 }
 

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -137,16 +137,23 @@ template <int QT>   // 12 = Q4_K (144B), 13 = Q5_K (176B), 14 = Q6_K (210B) per 
 __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
                                    signed char* __restrict__ q, float* __restrict__ scale,
                                    int cols) {
+    // Single pass: dequant each of the `cols` values once into smem, reduce amax, then
+    // write int8. The previous two-pass form (amax scan then re-dequant) paid ~2x the
+    // Q4_K/Q5_K/Q6_K decode cost; MoE prefill calls this over E*mffn / E*H rows per layer.
     constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : 210;
     const int row = blockIdx.x, t = threadIdx.x;
     const int nsb = cols >> 8;
     const unsigned char* rbase = src + (size_t)row * nsb * BS;
 
+    // cols is a multiple of 256 and <= 4096 on every Qwen3.6 / Qwythos projection we feed
+    // through this path; 4096 floats = 16 KB shared — well under the sm_120 default.
+    extern __shared__ float svals[];
     float amax = 0.f;
     for (int sb = 0; sb < nsb; sb++) {
         const unsigned char* blk = rbase + (size_t)sb * BS;
         const float v = (QT == 12) ? deq_q4k_val(blk, t)
                       : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
+        svals[sb * 256 + t] = v;
         amax = fmaxf(amax, fabsf(v));
     }
     __shared__ float swarp[8];
@@ -166,12 +173,8 @@ __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
     const float inv = (d > 0.f) ? (1.f / d) : 0.f;
 
     signed char* qrow = q + (size_t)row * cols;
-    for (int sb = 0; sb < nsb; sb++) {
-        const unsigned char* blk = rbase + (size_t)sb * BS;
-        const float v = (QT == 12) ? deq_q4k_val(blk, t)
-                      : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
-        qrow[sb * 256 + t] = (signed char)(int)roundf(v * inv);
-    }
+    for (int sb = 0; sb < nsb; sb++)
+        qrow[sb * 256 + t] = (signed char)(int)roundf(svals[sb * 256 + t] * inv);
 }
 
 __global__ void deq_q8_0_kernel(const unsigned char* __restrict__ src, __nv_bfloat16* __restrict__ y, long nblocks) {
@@ -219,10 +222,12 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
 bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q, float* scale,
                                  int rows, int cols, cudaStream_t stream) {
     if ((cols & 255) != 0) return false;
+    if (cols > 4096) return false;   // smem staging bound in deq_rows_i8_kernel
     auto* s = reinterpret_cast<const unsigned char*>(src);
-    if (ggml_type == GGML_Q4_K)      deq_rows_i8_kernel<12><<<rows, 256, 0, stream>>>(s, q, scale, cols);
-    else if (ggml_type == GGML_Q5_K) deq_rows_i8_kernel<13><<<rows, 256, 0, stream>>>(s, q, scale, cols);
-    else if (ggml_type == GGML_Q6_K) deq_rows_i8_kernel<14><<<rows, 256, 0, stream>>>(s, q, scale, cols);
+    const size_t smem = (size_t)cols * sizeof(float);
+    if (ggml_type == GGML_Q4_K)      deq_rows_i8_kernel<12><<<rows, 256, smem, stream>>>(s, q, scale, cols);
+    else if (ggml_type == GGML_Q5_K) deq_rows_i8_kernel<13><<<rows, 256, smem, stream>>>(s, q, scale, cols);
+    else if (ggml_type == GGML_Q6_K) deq_rows_i8_kernel<14><<<rows, 256, smem, stream>>>(s, q, scale, cols);
     else return false;
     return true;
 }


### PR DESCRIPTION
## Summary

`deq_rows_i8` decoded every Q4_K/Q5_K/Q6_K value twice (amax then re-dequant). For MoE-width rows (`cols ≤ 2048`) stage once in registers (NSB-templated), reduce amax, then quantize — **bit-identical** to the two-pass kernel, ~half the dequant cost on Qwen3.6 expert projections.

**Fix vs prior eval reject:** `cols > 4096` used to return false, dropping Qwythos FFN (`K=12288`) off the i8 path (~−10% `@4k` pp). Wide rows keep two-pass. Short accuracy is decode-path and matches main seed-for-seed.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — decode unchanged):

| | decode tok/s |
|---|--:|
| before (main) | 502.3 |
| after (this PR) | 502.3 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B `@512`; Qwythos `@4k` flat):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2632.2 |
| after prefill (this PR) | 3175.8 |

```text
# RTX 5090 sm_120, same-box A/B (main 90925ff vs this PR)
# SPARKINFER_KV_INT8=1  qwen3_gguf_bench
#
# Qwen3.6 @512:  2632.23 -> 3175.82 pp  (+20.7%)
# Qwen3.6 @4k:   10023.98 -> 10893.64 pp (+8.7%)
# Qwythos @4k:   17477.75 -> 17433.33 pp (~flat, no regression)
#
# Accuracy vs llama (short gate, SPARKINFER_EVAL_LONGCTX=0):
#   Qwythos 10/10 seeds: PR == main, all >= 0.90
#   Qwen3.6 seed=fixed/a: PR == main (0.910 / 0.921), pass
#   Qwen3.6 seed=c: PR == main at 0.893 (both below bar — seed flake on main too)
```