### PR TITLE
fix(eval): bidir headline REJECT must beat a passing XL

### DIFF
--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -542,11 +542,7 @@ def pick_best(a, b):
     return a if float(a.get("tps") or 0) >= float(b.get("tps") or 0) else b
 
 def pick_headline(a, b):
-    """Headline verdict: a failing optimize run must not lose to the other's none."""
-    if a.get("pass") and not b.get("pass"):
-        return dict(a)
-    if b.get("pass") and not a.get("pass"):
-        return dict(b)
+    """Headline verdict: either-side fail blocks merge; REJECT beats a passing XL/L/… from the other model."""
     if not a.get("pass") or not b.get("pass"):
         for s in (a, b):
             if s.get("infra_error"):

--- a/bench/scripts/test_bidir_headline.py
+++ b/bench/scripts/test_bidir_headline.py
@@ -59,6 +59,17 @@ class BidirHeadlineTest(unittest.TestCase):
         self.assertEqual(out["label"], "REJECT")
         self.assertFalse(out["pass"])
 
+    def test_reject_beats_passing_xl(self):
+        """PR #555-shaped: Qwen3.6 XL must not headline over Qwen3.5 REJECT (128k-pp regression)."""
+        q35 = {"label": "REJECT", "pass": False, "tps": 283.06,
+               "reason": "128k-context prefill no-regression gate"}
+        q36 = {"label": "XL", "pass": True, "tps": 3388.88}
+        out = pick_headline(q35, q36)
+        self.assertEqual(out["label"], "REJECT")
+        self.assertFalse(out["pass"])
+        out_swap = pick_headline(q36, q35)
+        self.assertEqual(out_swap["label"], "REJECT")
+
     def test_both_pass_picks_best_tier(self):
         q35 = {"label": "none", "pass": True, "tps": 283.0}
         q36 = {"label": "L", "pass": True, "tps": 480.0}

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -598,10 +598,28 @@ def _eval_verdict_from_comment(body):
 
 
 def _public_eval_label(res):
-    """GitHub label tier for a verdict — infra failures are not scored REJECTs."""
-    if res and res.get("infra_error"):
+    """GitHub label tier for a verdict — infra failures are not scored REJECTs.
+
+    Bidir: either-side fail headlines from the failing side (REJECT preferred), so a passing
+    Qwen3.6 XL cannot paper over a Qwen3.5 regression (PR #555).
+    """
+    if not res:
+        return None
+    if res.get("infra_error"):
         return INFRA_LABEL
-    return res.get("label") if res else None
+    if res.get("mode") == "bidir" or res.get("score_qwen35") or res.get("score_qwen36"):
+        sides = (
+            res.get("score_qwen35") or {"label": res.get("label_qwen35"), "pass": res.get("pass_qwen35")},
+            res.get("score_qwen36") or {"label": res.get("label_qwen36"), "pass": res.get("pass_qwen36")},
+        )
+        if any(s.get("pass") is False for s in sides):
+            for s in sides:
+                if s.get("pass") is False and s.get("label") == "REJECT":
+                    return "REJECT"
+            for s in sides:
+                if s.get("pass") is False and s.get("label"):
+                    return s["label"]
+    return res.get("label")
 
 
 def none_reject_eval_count(repo, num):
@@ -2723,6 +2741,11 @@ def main():
         else:
             res = json.loads(line[len("RESULT_JSON "):])
             label = _public_eval_label(res)
+            # Keep RESULT_JSON fields consistent with the public headline (bidir either-side REJECT).
+            if label and res.get("label") != label:
+                res["label"] = label
+                if label == "REJECT":
+                    res["pass"] = False
             body = render(res, oid)
             print(f"PR #{num}: {json.dumps(res)}")
 

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -881,6 +881,21 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertNotIn("Qwen3.5 optimize", body)
         self.assertIn("tokenizers", body)
 
+    def test_bidir_public_label_reject_beats_passing_xl(self):
+        """PR #555: Qwen3.5 REJECT must headline over Qwen3.6 XL."""
+        res = {
+            "mode": "bidir", "label": "XL", "pass": True,
+            "label_qwen35": "REJECT", "pass_qwen35": False,
+            "label_qwen36": "XL", "pass_qwen36": True,
+            "score_qwen35": {"label": "REJECT", "pass": False, "tps": 283.06},
+            "score_qwen36": {"label": "XL", "pass": True, "tps": 3388.88},
+        }
+        self.assertEqual(bot._public_eval_label(res), "REJECT")
+        body = bot.render(res, "dc22645")
+        self.assertIn("`eval:REJECT`", body)
+        self.assertIn("eval-qwen35:REJECT", body)
+        self.assertIn("eval-qwen36:XL", body)
+
     def test_none_reject_eval_count_ignores_infra_error(self):
         infra_body = bot.render({
             "label": "REJECT", "pass": False, "infra_error": True, "mode": "bidir",


### PR DESCRIPTION
## Summary
- Fix `pick_headline` in `evaluate_bidir.sh`: when either optimize side fails, prefer `REJECT` (or the failing side) instead of the other model's passing XL/L.
- Harden `_public_eval_label` so posted GitHub `eval:*` labels match that rule even if RESULT_JSON still has the old headline.
- Add regression tests for the PR #555 shape (Qwen3.5 REJECT + Qwen3.6 XL → headline REJECT).

## Test plan
- [x] `python3 bench/scripts/test_bidir_headline.py`
- [x] `python3 -m unittest test_pr_eval_bot.PrEvalBotPolicyTest.test_bidir_public_label_reject_beats_passing_xl`
- [ ] After merge, restart eval bot so it picks up the harness from `origin/main`
- [x] PR #555 labels already corrected to `eval:REJECT` (removed mistaken `eval:XL` / `merge-first`)