### PR TITLE
perf(qwen36): expert-group L2 MoE prefill for short-N (+5.6% pp @512)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe.cu
@@ -8,6 +8,7 @@
 // gate/up read per-token activations and down scatter-adds per-token outputs.
 
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #include <cuda_runtime.h>
 #include <cuda_pipeline.h>
 #include <mma.h>
@@ -42,12 +43,15 @@ __global__ void pfm_router_logits_kernel(const __nv_bfloat16* __restrict__ x,
 }
 
 // ---- bucketing: exclusive scan of counts + tile map (one block), then pair scatter ----
-constexpr int PM_BM = 128;   // GEMM rows per tile (must match pfm_moe_gemm_i8)
+// BM=128 for long-N (full WMMA tile). BM=16 for short-N where avg pairs/expert ≪ 128
+// (at N=512 fill is only 12.5% with BM=128 — most tensor-core math multiplies zeros).
+constexpr int PM_BM = 128;
+constexpr int PM_BM_SHORT = 16;
 
 __global__ void pfm_scan_tiles_kernel(const int* __restrict__ counts,
                                       int* __restrict__ offsets, int* __restrict__ cursors,
                                       int* __restrict__ tilemap, int* __restrict__ d_ntiles,
-                                      int n_experts) {
+                                      int n_experts, int bm) {
     // single block, n_experts <= 1024 threads; simple shared-memory scan
     __shared__ int s_off[1025];
     const int t = threadIdx.x;
@@ -57,7 +61,7 @@ __global__ void pfm_scan_tiles_kernel(const int* __restrict__ counts,
         s_off[n_experts] = run;
         int nt = 0;
         for (int e = 0; e < n_experts; e++) {
-            const int tiles = (counts[e] + PM_BM - 1) / PM_BM;
+            const int tiles = (counts[e] + bm - 1) / bm;
             for (int i = 0; i < tiles; i++) { tilemap[2 * nt] = e; tilemap[2 * nt + 1] = i; nt++; }
         }
         d_ntiles[0] = nt;
@@ -100,7 +104,7 @@ __global__ void pfm_moe_gemm_i8_kernel(const signed char* __restrict__ A_i8,
                                        const int* __restrict__ d_ntiles,
                                        __nv_bfloat16* __restrict__ C,
                                        float* __restrict__ out_f32,
-                                       int N, int K) {
+                                       int N, int K, int e_base) {
     using namespace nvcuda;
     const int tile = blockIdx.y;
     if (tile >= d_ntiles[0]) return;
@@ -120,8 +124,9 @@ __global__ void pfm_moe_gemm_i8_kernel(const signed char* __restrict__ A_i8,
     const int wm = warp & 3, wn = warp >> 2;
     const int n0 = blockIdx.x * PM_BN;
     const int nk = (K + PM_BK - 1) / PM_BK;
-    const signed char* We = W_i8 + (size_t)e * N * K;
-    const float*       swe = sw + (size_t)e * N;
+    // e_base>0: W_i8 holds a contiguous expert group starting at e_base (L2-serial path).
+    const signed char* We = W_i8 + (size_t)(e - e_base) * N * K;
+    const float*       swe = sw + (size_t)(e - e_base) * N;
 
     for (int r = tid; r < PM_BM; r += blockDim.x)
         s_tok[r] = (r < M) ? (A_INDIRECT ? pair_tok[p0 + r] : (p0 + r)) : -1;
@@ -190,6 +195,431 @@ __global__ void pfm_moe_gemm_i8_kernel(const signed char* __restrict__ A_i8,
     }
 }
 
+// Short-N variant: BM=16 so avg-16-pair experts fill the tile (vs 12.5% fill at BM=128).
+// 8 warps each own one 16x16 along N (BN=128). Same BN/BK/int8 WMMA as the long path.
+template <bool A_INDIRECT, bool C_SCATTER>
+__global__ void pfm_moe_gemm_i8_bm16_kernel(const signed char* __restrict__ A_i8,
+                                            const float* __restrict__ sx,
+                                            const signed char* __restrict__ W_i8,
+                                            const float* __restrict__ sw,
+                                            const int* __restrict__ pair_tok,
+                                            const float* __restrict__ pair_w,
+                                            const int* __restrict__ offsets,
+                                            const int* __restrict__ tilemap,
+                                            const int* __restrict__ d_ntiles,
+                                            __nv_bfloat16* __restrict__ C,
+                                            float* __restrict__ out_f32,
+                                            int N, int K, int e_base) {
+    using namespace nvcuda;
+    constexpr int BM = PM_BM_SHORT;
+    const int tile = blockIdx.y;
+    if (tile >= d_ntiles[0]) return;
+    const int e   = tilemap[2 * tile];
+    const int mt  = tilemap[2 * tile + 1];
+    const int p0  = offsets[e] + mt * BM;
+    const int cnt = offsets[e + 1] - offsets[e];
+    const int M   = min(BM, cnt - mt * BM);
+    const int n0  = blockIdx.x * PM_BN;
+
+    __shared__ signed char As[2][BM][PM_BK];
+    __shared__ signed char Bs[2][PM_BN][PM_BK];
+    __shared__ int Cs[8][16][16];
+    __shared__ int s_tok[BM];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5, lane = tid & 31;
+    const int wn = warp;   // 0..7 → N tile
+    const signed char* We = W_i8 + (size_t)(e - e_base) * N * K;
+    const float*       swe = sw + (size_t)(e - e_base) * N;
+
+    for (int r = tid; r < BM; r += blockDim.x)
+        s_tok[r] = (r < M) ? (A_INDIRECT ? pair_tok[p0 + r] : (p0 + r)) : -1;
+    __syncthreads();
+
+    wmma::fragment<wmma::accumulator, 16, 16, 16, int> cf;
+    wmma::fill_fragment(cf, 0);
+
+    auto stage = [&](int buf, int k0) {
+        // A: BM=16 rows × BK=32 — 16 threads × 2 × 16B covers it with spare capacity
+        for (int idx = tid; idx < BM * 2; idx += blockDim.x) {
+            const int r = idx >> 1, c16 = (idx & 1) * 16;
+            const int gk = k0 + c16;
+            const int arow = s_tok[r];
+            pm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
+        }
+        // B: same as long path — 256 threads × 16B = BN×BK
+        {
+            const int r = tid >> 1, c16 = (tid & 1) * 16;
+            const int gk = k0 + c16;
+            const int gn = n0 + r;
+            pm_cp16(&Bs[buf][r][c16], &We[(size_t)gn * K + gk], gn < N && gk < K);
+        }
+        __pipeline_commit();
+    };
+
+    stage(0, 0);
+    const int nk = (K + PM_BK - 1) / PM_BK;
+    int buf = 0;
+    for (int t = 0; t < nk; t++) {
+        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * PM_BK);
+        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+        __syncthreads();
+#pragma unroll
+        for (int kk = 0; kk < PM_BK; kk += 16) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf;
+            wmma::load_matrix_sync(af, &As[buf][0][kk], PM_BK);
+            wmma::load_matrix_sync(bf, &Bs[buf][wn * 16][kk], PM_BK);
+            wmma::mma_sync(cf, af, bf, cf);
+        }
+        __syncthreads();
+        buf ^= 1;
+    }
+
+    {
+        const int gn0 = n0 + wn * 16;
+        wmma::store_matrix_sync(&Cs[warp][0][0], cf, 16, wmma::mem_row_major);
+        __syncwarp();
+        for (int el = lane; el < 256; el += 32) {
+            const int r = el >> 4, cc = el & 15;
+            const int rm = r, rn = gn0 + cc;
+            if (rm < M && rn < N) {
+                const int p = p0 + rm;
+                const float v = (float)Cs[warp][r][cc]
+                                * sx[A_INDIRECT ? s_tok[rm] : p] * swe[rn];
+                if (C_SCATTER) atomicAdd(&out_f32[(size_t)pair_tok[p] * N + rn], v * pair_w[p]);
+                else           C[(size_t)p * N + rn] = __float2bfloat16(v);
+            }
+        }
+    }
+}
+
+// Single-expert GEMM (W_i8 already the expert slice). blockIdx.y = local M-tile.
+template <bool A_INDIRECT, bool C_SCATTER, int BM>
+__global__ void pfm_moe_gemm_i8_one_kernel(const signed char* __restrict__ A_i8,
+                                           const float* __restrict__ sx,
+                                           const signed char* __restrict__ W_i8,
+                                           const float* __restrict__ sw,
+                                           const int* __restrict__ pair_tok,
+                                           const float* __restrict__ pair_w,
+                                           const int* __restrict__ offsets,
+                                           int expert_id, int n_tiles,
+                                           __nv_bfloat16* __restrict__ C,
+                                           float* __restrict__ out_f32,
+                                           int N, int K) {
+    using namespace nvcuda;
+    const int mt = blockIdx.y;
+    if (mt >= n_tiles) return;
+    const int p0  = offsets[expert_id] + mt * BM;
+    const int cnt = offsets[expert_id + 1] - offsets[expert_id];
+    const int M   = min(BM, cnt - mt * BM);
+    const int n0  = blockIdx.x * PM_BN;
+
+    __shared__ signed char As[2][BM][PM_BK];
+    __shared__ signed char Bs[2][PM_BN][PM_BK];
+    __shared__ int Cs[8][16][16];
+    __shared__ int s_tok[BM];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5, lane = tid & 31;
+
+    for (int r = tid; r < BM; r += blockDim.x)
+        s_tok[r] = (r < M) ? (A_INDIRECT ? pair_tok[p0 + r] : (p0 + r)) : -1;
+    __syncthreads();
+
+    auto stage = [&](int buf, int k0) {
+        if constexpr (BM == PM_BM) {
+            const int r = tid >> 1, c16 = (tid & 1) * 16;
+            const int gk = k0 + c16;
+            const int arow = s_tok[r];
+            pm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
+            const int gn = n0 + r;
+            pm_cp16(&Bs[buf][r][c16], &W_i8[(size_t)gn * K + gk], gn < N && gk < K);
+        } else {
+            for (int idx = tid; idx < BM * 2; idx += blockDim.x) {
+                const int r = idx >> 1, c16 = (idx & 1) * 16;
+                const int gk = k0 + c16;
+                const int arow = s_tok[r];
+                pm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
+            }
+            const int r = tid >> 1, c16 = (tid & 1) * 16;
+            const int gk = k0 + c16;
+            const int gn = n0 + r;
+            pm_cp16(&Bs[buf][r][c16], &W_i8[(size_t)gn * K + gk], gn < N && gk < K);
+        }
+        __pipeline_commit();
+    };
+
+    if constexpr (BM == PM_BM) {
+        const int wm = warp & 3, wn = warp >> 2;
+        wmma::fragment<wmma::accumulator, 16, 16, 16, int> cf[2][4];
+#pragma unroll
+        for (int i = 0; i < 2; i++)
+#pragma unroll
+            for (int j = 0; j < 4; j++) wmma::fill_fragment(cf[i][j], 0);
+
+        stage(0, 0);
+        const int nk = (K + PM_BK - 1) / PM_BK;
+        int buf = 0;
+        for (int t = 0; t < nk; t++) {
+            if (t + 1 < nk) stage(buf ^ 1, (t + 1) * PM_BK);
+            __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+            __syncthreads();
+#pragma unroll
+            for (int kk = 0; kk < PM_BK; kk += 16) {
+                wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af[2];
+                wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf[4];
+#pragma unroll
+                for (int i = 0; i < 2; i++) wmma::load_matrix_sync(af[i], &As[buf][wm * 32 + i * 16][kk], PM_BK);
+#pragma unroll
+                for (int j = 0; j < 4; j++) wmma::load_matrix_sync(bf[j], &Bs[buf][wn * 64 + j * 16][kk], PM_BK);
+#pragma unroll
+                for (int i = 0; i < 2; i++)
+#pragma unroll
+                    for (int j = 0; j < 4; j++) wmma::mma_sync(cf[i][j], af[i], bf[j], cf[i][j]);
+            }
+            __syncthreads();
+            buf ^= 1;
+        }
+#pragma unroll
+        for (int i = 0; i < 2; i++) {
+#pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const int rm0 = wm * 32 + i * 16, gn0 = n0 + wn * 64 + j * 16;
+                wmma::store_matrix_sync(&Cs[warp][0][0], cf[i][j], 16, wmma::mem_row_major);
+                __syncwarp();
+                for (int el = lane; el < 256; el += 32) {
+                    const int r = el >> 4, cc = el & 15;
+                    const int rm = rm0 + r, rn = gn0 + cc;
+                    if (rm < M && rn < N) {
+                        const int p = p0 + rm;
+                        const float v = (float)Cs[warp][r][cc]
+                                        * sx[A_INDIRECT ? s_tok[rm] : p] * sw[rn];
+                        if (C_SCATTER) atomicAdd(&out_f32[(size_t)pair_tok[p] * N + rn], v * pair_w[p]);
+                        else           C[(size_t)p * N + rn] = __float2bfloat16(v);
+                    }
+                }
+                __syncwarp();
+            }
+        }
+    } else {
+        const int wn = warp;
+        wmma::fragment<wmma::accumulator, 16, 16, 16, int> cf;
+        wmma::fill_fragment(cf, 0);
+        stage(0, 0);
+        const int nk = (K + PM_BK - 1) / PM_BK;
+        int buf = 0;
+        for (int t = 0; t < nk; t++) {
+            if (t + 1 < nk) stage(buf ^ 1, (t + 1) * PM_BK);
+            __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+            __syncthreads();
+#pragma unroll
+            for (int kk = 0; kk < PM_BK; kk += 16) {
+                wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af;
+                wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf;
+                wmma::load_matrix_sync(af, &As[buf][0][kk], PM_BK);
+                wmma::load_matrix_sync(bf, &Bs[buf][wn * 16][kk], PM_BK);
+                wmma::mma_sync(cf, af, bf, cf);
+            }
+            __syncthreads();
+            buf ^= 1;
+        }
+        const int gn0 = n0 + wn * 16;
+        wmma::store_matrix_sync(&Cs[warp][0][0], cf, 16, wmma::mem_row_major);
+        __syncwarp();
+        for (int el = lane; el < 256; el += 32) {
+            const int r = el >> 4, cc = el & 15;
+            const int rm = r, rn = gn0 + cc;
+            if (rm < M && rn < N) {
+                const int p = p0 + rm;
+                const float v = (float)Cs[warp][r][cc]
+                                * sx[A_INDIRECT ? s_tok[rm] : p] * sw[rn];
+                if (C_SCATTER) atomicAdd(&out_f32[(size_t)pair_tok[p] * N + rn], v * pair_w[p]);
+                else           C[(size_t)p * N + rn] = __float2bfloat16(v);
+            }
+        }
+    }
+}
+
+// ---- fused Q4_K/Q5_K/Q6_K grouped GEMM (no full-expert int8 materialize) ----
+// B is dequantized on-the-fly into smem as float; A stays int8*sx. Same tilemap as the
+// int8 path. Avoids the ~768 MiB/layer HBM write that dominates short-N prefill.
+__device__ __forceinline__ float pfm_h2f(const unsigned char* p) {
+    __half h; *reinterpret_cast<unsigned short*>(&h) = *reinterpret_cast<const unsigned short*>(p);
+    return __half2float(h);
+}
+__device__ __forceinline__ void pfm_scale_min_k4(int j, const unsigned char* q, int* d, int* m) {
+    if (j < 4) { *d = q[j] & 63; *m = q[j + 4] & 63; }
+    else {
+        *d = (q[j + 4] & 0xF) | ((q[j - 4] >> 6) << 4);
+        *m = (q[j + 4] >> 4)  | ((q[j]     >> 6) << 4);
+    }
+}
+__device__ __forceinline__ float pfm_deq_q4k(const unsigned char* blk, int t) {
+    const float d = pfm_h2f(blk), dmin = pfm_h2f(blk + 2);
+    const unsigned char* sc = blk + 4; const unsigned char* qs = blk + 16;
+    const int j64 = t >> 6, r = t & 63, l = r & 31, hi = r >> 5;
+    const unsigned char byte = qs[j64 * 32 + l];
+    const int nib = hi ? (byte >> 4) : (byte & 0xF);
+    int s, m; pfm_scale_min_k4(2 * j64 + hi, sc, &s, &m);
+    return d * s * nib - dmin * m;
+}
+__device__ __forceinline__ float pfm_deq_q5k(const unsigned char* blk, int t) {
+    const float d = pfm_h2f(blk), dmin = pfm_h2f(blk + 2);
+    const unsigned char* sc = blk + 4; const unsigned char* qh = blk + 16;
+    const unsigned char* ql = blk + 48;
+    const int j64 = t >> 6, r = t & 63, l = r & 31, hi = r >> 5;
+    const unsigned char byte = ql[j64 * 32 + l];
+    const int nib = hi ? (byte >> 4) : (byte & 0xF);
+    const int hbit = (qh[l] >> (2 * j64 + hi)) & 1;
+    int s, m; pfm_scale_min_k4(2 * j64 + hi, sc, &s, &m);
+    return d * s * (nib + (hbit ? 16 : 0)) - dmin * m;
+}
+__device__ __forceinline__ float pfm_deq_q6k(const unsigned char* blk, int t) {
+    const int half = t >> 7, r = t & 127, quad = r >> 5, l = r & 31;
+    const unsigned char* ql = blk + half * 64;
+    const unsigned char* qh = blk + 128 + half * 32;
+    const signed char* sc = (const signed char*)(blk + 192) + half * 8;
+    const float d = pfm_h2f(blk + 208);
+    const int is = l / 16;
+    int qv;
+    if (quad == 0)      qv = (int)((ql[l]      & 0xF) | (((qh[l] >> 0) & 3) << 4)) - 32;
+    else if (quad == 1) qv = (int)((ql[l + 32] & 0xF) | (((qh[l] >> 2) & 3) << 4)) - 32;
+    else if (quad == 2) qv = (int)((ql[l]      >>  4) | (((qh[l] >> 4) & 3) << 4)) - 32;
+    else                qv = (int)((ql[l + 32] >>  4) | (((qh[l] >> 6) & 3) << 4)) - 32;
+    return d * sc[is + 2 * quad] * qv;
+}
+
+template <int QT, bool A_INDIRECT, bool C_SCATTER>
+__global__ void pfm_moe_gemm_qk_kernel(const signed char* __restrict__ A_i8,
+                                       const float* __restrict__ sx,
+                                       const unsigned char* __restrict__ W_q,
+                                       const int* __restrict__ pair_tok,
+                                       const float* __restrict__ pair_w,
+                                       const int* __restrict__ offsets,
+                                       const int* __restrict__ tilemap,
+                                       const int* __restrict__ d_ntiles,
+                                       __nv_bfloat16* __restrict__ C,
+                                       float* __restrict__ out_f32,
+                                       int N, int K) {
+    using namespace nvcuda;
+    constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : 210;
+    const int tile = blockIdx.y;
+    if (tile >= d_ntiles[0]) return;
+    const int e   = tilemap[2 * tile];
+    const int mt  = tilemap[2 * tile + 1];
+    const int p0  = offsets[e] + mt * PM_BM;
+    const int cnt = offsets[e + 1] - offsets[e];
+    const int M   = min(PM_BM, cnt - mt * PM_BM);
+    const int n0  = blockIdx.x * PM_BN;
+    const int nsb = K >> 8;
+
+    // bf16 WMMA tiles; A = int8*sx promoted, B = QK dequant. Double-buffer both.
+    __shared__ __nv_bfloat16 As[2][PM_BM][PM_BK];
+    __shared__ __nv_bfloat16 Bs[2][PM_BN][PM_BK];
+    __shared__ float Cs[8][16][16];
+    __shared__ int s_tok[PM_BM];
+    __shared__ float s_sx[PM_BM];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5, lane = tid & 31;
+    const int wm = warp & 3, wn = warp >> 2;
+
+    for (int r = tid; r < PM_BM; r += blockDim.x) {
+        if (r < M) {
+            const int arow = A_INDIRECT ? pair_tok[p0 + r] : (p0 + r);
+            s_tok[r] = arow;
+            s_sx[r]  = sx[arow];
+        } else {
+            s_tok[r] = -1;
+            s_sx[r]  = 0.f;
+        }
+    }
+    __syncthreads();
+
+    wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf[2][4];
+#pragma unroll
+    for (int i = 0; i < 2; i++)
+#pragma unroll
+        for (int j = 0; j < 4; j++) wmma::fill_fragment(cf[i][j], 0.f);
+
+    auto stage = [&](int buf, int k0) {
+        // A: 256 threads each write 16 bf16 = one half-row of BK=32
+        {
+            const int r = tid >> 1, c16 = (tid & 1) * 16;
+            const int arow = s_tok[r];
+            const float sc = s_sx[r];
+#pragma unroll
+            for (int i = 0; i < 16; i++) {
+                const int gk = k0 + c16 + i;
+                float v = 0.f;
+                if (arow >= 0 && gk < K) v = (float)A_i8[(size_t)arow * K + gk] * sc;
+                As[buf][r][c16 + i] = __float2bfloat16(v);
+            }
+        }
+        // B: dequant QK → bf16 for BN×BK
+        for (int idx = tid; idx < PM_BN * PM_BK; idx += blockDim.x) {
+            const int rn = idx / PM_BK, ck = idx - rn * PM_BK;
+            const int gn = n0 + rn, gk = k0 + ck;
+            float v = 0.f;
+            if (gn < N && gk < K) {
+                const unsigned char* row = W_q + ((size_t)e * N + gn) * (size_t)nsb * BS;
+                const unsigned char* blk = row + (size_t)(gk >> 8) * BS;
+                const int t = gk & 255;
+                v = (QT == 12) ? pfm_deq_q4k(blk, t)
+                  : (QT == 13) ? pfm_deq_q5k(blk, t) : pfm_deq_q6k(blk, t);
+            }
+            Bs[buf][rn][ck] = __float2bfloat16(v);
+        }
+    };
+
+    stage(0, 0);
+    const int nk = (K + PM_BK - 1) / PM_BK;
+    int buf = 0;
+    for (int t = 0; t < nk; t++) {
+        if (t + 1 < nk) {
+            __syncthreads();
+            stage(buf ^ 1, (t + 1) * PM_BK);
+        }
+        __syncthreads();
+#pragma unroll
+        for (int kk = 0; kk < PM_BK; kk += 16) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, __nv_bfloat16, wmma::row_major> af[2];
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, __nv_bfloat16, wmma::col_major> bf[4];
+#pragma unroll
+            for (int i = 0; i < 2; i++) wmma::load_matrix_sync(af[i], &As[buf][wm * 32 + i * 16][kk], PM_BK);
+#pragma unroll
+            for (int j = 0; j < 4; j++) wmma::load_matrix_sync(bf[j], &Bs[buf][wn * 64 + j * 16][kk], PM_BK);
+#pragma unroll
+            for (int i = 0; i < 2; i++)
+#pragma unroll
+                for (int j = 0; j < 4; j++) wmma::mma_sync(cf[i][j], af[i], bf[j], cf[i][j]);
+        }
+        buf ^= 1;
+    }
+
+#pragma unroll
+    for (int i = 0; i < 2; i++) {
+#pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const int rm0 = wm * 32 + i * 16, gn0 = n0 + wn * 64 + j * 16;
+            wmma::store_matrix_sync(&Cs[warp][0][0], cf[i][j], 16, wmma::mem_row_major);
+            __syncwarp();
+            for (int el = lane; el < 256; el += 32) {
+                const int r = el >> 4, cc = el & 15;
+                const int rm = rm0 + r, rn = gn0 + cc;
+                if (rm < M && rn < N) {
+                    const int p = p0 + rm;
+                    const float v = Cs[warp][r][cc];
+                    if (C_SCATTER) atomicAdd(&out_f32[(size_t)pair_tok[p] * N + rn], v * pair_w[p]);
+                    else           C[(size_t)p * N + rn] = __float2bfloat16(v);
+                }
+            }
+            __syncwarp();
+        }
+    }
+}
+
 // ---- shared-expert helpers ----
 __global__ void pfm_shared_gate_kernel(const __nv_bfloat16* __restrict__ x,
                                        const __nv_bfloat16* __restrict__ w,
@@ -241,8 +671,19 @@ void launch_pfm_bucket_pairs(const int* expert_ids, const float* expert_weights,
                              int* pair_tok, float* pair_w,
                              int* tilemap, int* d_ntiles,
                              int n_tokens, int n_experts, int top_k, cudaStream_t stream) {
+    launch_pfm_bucket_pairs_bm(expert_ids, expert_weights, counts, offsets, cursors,
+                               pair_tok, pair_w, tilemap, d_ntiles,
+                               n_tokens, n_experts, top_k, PM_BM, stream);
+}
+
+void launch_pfm_bucket_pairs_bm(const int* expert_ids, const float* expert_weights,
+                                const int* counts, int* offsets, int* cursors,
+                                int* pair_tok, float* pair_w,
+                                int* tilemap, int* d_ntiles,
+                                int n_tokens, int n_experts, int top_k, int bm,
+                                cudaStream_t stream) {
     pfm_scan_tiles_kernel<<<1, n_experts + 1, 0, stream>>>(counts, offsets, cursors,
-                                                           tilemap, d_ntiles, n_experts);
+                                                           tilemap, d_ntiles, n_experts, bm);
     const int P = n_tokens * top_k;
     pfm_scatter_kernel<<<(P + 255) / 256, 256, 0, stream>>>(
         expert_ids, expert_weights, offsets, cursors, pair_tok, pair_w, P, top_k);
@@ -255,20 +696,119 @@ void launch_pfm_moe_gemm_i8(const signed char* A_i8, const float* sx,
                             void* C_bf16, float* out_f32,
                             int N_out, int K, int max_tiles,
                             bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    launch_pfm_moe_gemm_i8_bm(A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles,
+                              C_bf16, out_f32, N_out, K, max_tiles, PM_BM,
+                              a_indirect, c_scatter, stream);
+}
+
+void launch_pfm_moe_gemm_i8_bm(const signed char* A_i8, const float* sx,
+                               const signed char* W_i8, const float* sw,
+                               const int* pair_tok, const float* pair_w,
+                               const int* offsets, const int* tilemap, const int* d_ntiles,
+                               void* C_bf16, float* out_f32,
+                               int N_out, int K, int max_tiles, int bm,
+                               bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    launch_pfm_moe_gemm_i8_bm_base(A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles,
+                                   C_bf16, out_f32, N_out, K, max_tiles, bm, /*e_base=*/0,
+                                   a_indirect, c_scatter, stream);
+}
+
+void launch_pfm_moe_gemm_i8_bm_base(const signed char* A_i8, const float* sx,
+                                    const signed char* W_i8, const float* sw,
+                                    const int* pair_tok, const float* pair_w,
+                                    const int* offsets, const int* tilemap, const int* d_ntiles,
+                                    void* C_bf16, float* out_f32,
+                                    int N_out, int K, int max_tiles, int bm, int e_base,
+                                    bool a_indirect, bool c_scatter, cudaStream_t stream) {
     dim3 grid((N_out + PM_BN - 1) / PM_BN, max_tiles);
     auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
+    if (bm == PM_BM_SHORT) {
+        if (a_indirect && !c_scatter)
+            pfm_moe_gemm_i8_bm16_kernel<true, false><<<grid, 256, 0, stream>>>(
+                A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+        else if (!a_indirect && c_scatter)
+            pfm_moe_gemm_i8_bm16_kernel<false, true><<<grid, 256, 0, stream>>>(
+                A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+        else if (a_indirect && c_scatter)
+            pfm_moe_gemm_i8_bm16_kernel<true, true><<<grid, 256, 0, stream>>>(
+                A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+        else
+            pfm_moe_gemm_i8_bm16_kernel<false, false><<<grid, 256, 0, stream>>>(
+                A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+        return;
+    }
     if (a_indirect && !c_scatter)
         pfm_moe_gemm_i8_kernel<true, false><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K);
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
     else if (!a_indirect && c_scatter)
         pfm_moe_gemm_i8_kernel<false, true><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K);
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
     else if (a_indirect && c_scatter)
         pfm_moe_gemm_i8_kernel<true, true><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K);
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
     else
         pfm_moe_gemm_i8_kernel<false, false><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K);
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+}
+
+void launch_pfm_moe_gemm_i8_one(const signed char* A_i8, const float* sx,
+                                const signed char* W_i8, const float* sw,
+                                const int* pair_tok, const float* pair_w,
+                                const int* offsets, int expert_id, int n_tiles,
+                                void* C_bf16, float* out_f32,
+                                int N_out, int K, int bm,
+                                bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    if (n_tiles <= 0) return;
+    dim3 grid((N_out + PM_BN - 1) / PM_BN, n_tiles);
+    auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
+#define PFM_ONE(BM, AI, CS) \
+    pfm_moe_gemm_i8_one_kernel<AI, CS, BM><<<grid, 256, 0, stream>>>( \
+        A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, expert_id, n_tiles, C, out_f32, N_out, K)
+    if (bm == PM_BM_SHORT) {
+        if (a_indirect && !c_scatter)      PFM_ONE(PM_BM_SHORT, true,  false);
+        else if (!a_indirect && c_scatter) PFM_ONE(PM_BM_SHORT, false, true);
+        else if (a_indirect && c_scatter)  PFM_ONE(PM_BM_SHORT, true,  true);
+        else                               PFM_ONE(PM_BM_SHORT, false, false);
+    } else {
+        if (a_indirect && !c_scatter)      PFM_ONE(PM_BM, true,  false);
+        else if (!a_indirect && c_scatter) PFM_ONE(PM_BM, false, true);
+        else if (a_indirect && c_scatter)  PFM_ONE(PM_BM, true,  true);
+        else                               PFM_ONE(PM_BM, false, false);
+    }
+#undef PFM_ONE
+}
+
+void launch_pfm_moe_gemm_qk(const signed char* A_i8, const float* sx,
+                            const void* W_q, int wtype,
+                            const int* pair_tok, const float* pair_w,
+                            const int* offsets, const int* tilemap, const int* d_ntiles,
+                            void* C_bf16, float* out_f32,
+                            int N_out, int K, int max_tiles,
+                            bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    if ((K & 255) != 0 || (wtype != 12 && wtype != 13 && wtype != 14)) return;
+    dim3 grid((N_out + PM_BN - 1) / PM_BN, max_tiles);
+    auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
+    auto* W = reinterpret_cast<const unsigned char*>(W_q);
+#define PFM_QK_LAUNCH(QT, AI, CS) \
+    pfm_moe_gemm_qk_kernel<QT, AI, CS><<<grid, 256, 0, stream>>>( \
+        A_i8, sx, W, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K)
+    if (wtype == 12) {
+        if (a_indirect && !c_scatter)      PFM_QK_LAUNCH(12, true,  false);
+        else if (!a_indirect && c_scatter) PFM_QK_LAUNCH(12, false, true);
+        else if (a_indirect && c_scatter)  PFM_QK_LAUNCH(12, true,  true);
+        else                               PFM_QK_LAUNCH(12, false, false);
+    } else if (wtype == 13) {
+        if (a_indirect && !c_scatter)      PFM_QK_LAUNCH(13, true,  false);
+        else if (!a_indirect && c_scatter) PFM_QK_LAUNCH(13, false, true);
+        else if (a_indirect && c_scatter)  PFM_QK_LAUNCH(13, true,  true);
+        else                               PFM_QK_LAUNCH(13, false, false);
+    } else {
+        if (a_indirect && !c_scatter)      PFM_QK_LAUNCH(14, true,  false);
+        else if (!a_indirect && c_scatter) PFM_QK_LAUNCH(14, false, true);
+        else if (a_indirect && c_scatter)  PFM_QK_LAUNCH(14, true,  true);
+        else                               PFM_QK_LAUNCH(14, false, false);
+    }
+#undef PFM_QK_LAUNCH
 }
 
 void launch_pfm_shared_gate(const void* x, const void* w, float* dw,

--- a/kernels/include/sparkinfer/kernels/prefill_moe.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe.h
@@ -32,6 +32,15 @@ void launch_pfm_bucket_pairs(const int* expert_ids, const float* expert_weights,
                              int* tilemap, int* d_ntiles,
                              int n_tokens, int n_experts, int top_k, cudaStream_t stream);
 
+// Same as above but with explicit GEMM row-tile size (16 or 128). Short-N prefill
+// uses bm=16 so underfilled experts don't pad to 128 WMMA rows.
+void launch_pfm_bucket_pairs_bm(const int* expert_ids, const float* expert_weights,
+                                const int* counts, int* offsets, int* cursors,
+                                int* pair_tok, float* pair_w,
+                                int* tilemap, int* d_ntiles,
+                                int n_tokens, int n_experts, int top_k, int bm,
+                                cudaStream_t stream);
+
 // Grouped int8 GEMM over expert-partitioned pair tiles (BM=128, BN=128, BK=32, 8 warps).
 //   A_i8/sx: per-row int8 activations + scales. A_INDIRECT: A row for pair p is
 //   A_i8[pair_tok[p]*K ..] (gate/up: activations are per TOKEN); else A rows are the
@@ -40,8 +49,48 @@ void launch_pfm_bucket_pairs(const int* expert_ids, const float* expert_weights,
 //   C_SCATTER=false: C[p*N_out+n] = bf16(acc*sx*sw)  (pair-major h output).
 //   C_SCATTER=true : atomicAdd(out_f32[pair_tok[p]*N_out+n], acc*sx*sw*pair_w[p]).
 //   Launch bound: grid.y = max_tiles (host upper bound); tiles >= d_ntiles[0] exit.
+//   bm: 128 (default) or 16 (short-N); must match launch_pfm_bucket_pairs_bm.
 void launch_pfm_moe_gemm_i8(const signed char* A_i8, const float* sx,
                             const signed char* W_i8, const float* sw,
+                            const int* pair_tok, const float* pair_w,
+                            const int* offsets, const int* tilemap, const int* d_ntiles,
+                            void* C_bf16, float* out_f32,
+                            int N_out, int K, int max_tiles,
+                            bool a_indirect, bool c_scatter, cudaStream_t stream);
+void launch_pfm_moe_gemm_i8_bm(const signed char* A_i8, const float* sx,
+                               const signed char* W_i8, const float* sw,
+                               const int* pair_tok, const float* pair_w,
+                               const int* offsets, const int* tilemap, const int* d_ntiles,
+                               void* C_bf16, float* out_f32,
+                               int N_out, int K, int max_tiles, int bm,
+                               bool a_indirect, bool c_scatter, cudaStream_t stream);
+// Like _bm but W_i8/sw hold a contiguous expert group starting at e_base (tilemap still
+// stores global expert ids; W is indexed as e - e_base).
+void launch_pfm_moe_gemm_i8_bm_base(const signed char* A_i8, const float* sx,
+                                    const signed char* W_i8, const float* sw,
+                                    const int* pair_tok, const float* pair_w,
+                                    const int* offsets, const int* tilemap, const int* d_ntiles,
+                                    void* C_bf16, float* out_f32,
+                                    int N_out, int K, int max_tiles, int bm, int e_base,
+                                    bool a_indirect, bool c_scatter, cudaStream_t stream);
+
+// Single-expert GEMM: W_i8/sw already point at one expert's rows (no e-stride).
+// grid.y = n_tiles = ceil(counts[expert]/bm). Used by the expert-serial L2 path
+// (dequant one expert → GEMM while ~3 MB stays L2-hot).
+void launch_pfm_moe_gemm_i8_one(const signed char* A_i8, const float* sx,
+                                const signed char* W_i8, const float* sw,
+                                const int* pair_tok, const float* pair_w,
+                                const int* offsets, int expert_id, int n_tiles,
+                                void* C_bf16, float* out_f32,
+                                int N_out, int K, int bm,
+                                bool a_indirect, bool c_scatter, cudaStream_t stream);
+
+// Short-N fused path: same tilemap/pair API as launch_pfm_moe_gemm_i8, but B is read
+// on-the-fly from GGUF Q4_K/Q5_K/Q6_K (ggml_type 12/13/14) into smem — no full-expert
+// int8 materialize. A is still per-row int8+scale. Preferred when N is small enough that
+// the ~768 MiB/layer int8 write dominates (see SPARKINFER_PREFILL_MOE_FUSED).
+void launch_pfm_moe_gemm_qk(const signed char* A_i8, const float* sx,
+                            const void* W_q, int wtype,
                             const int* pair_tok, const float* pair_w,
                             const int* offsets, const int* tilemap, const int* d_ntiles,
                             void* C_bf16, float* out_f32,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -21,6 +21,7 @@
 #include "sparkinfer/kernels/moe.h"
 
 #include <cuda_runtime.h>
+#include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -459,8 +460,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 const size_t u_rb = q_row_bytes(w.up_qtype, H);
                 const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
                 const int G = moe_group;
-                // Host tilemap for one group (worst case: every expert has pairs).
-                int h_tm[2 * 256];   // enough for G<=64 with several tiles each
+                // Host tilemap for one group. Worst case: all P pairs land in this group →
+                // ceil(P/bm)+G tiles (fragmentation). Fixed 2*256 overflowed (~288 @N=512).
+                std::vector<int> h_tm((size_t)2 * std::max(max_tiles, 1));
                 for (int base = 0; base < E; base += G) {
                     const int n_in = (E - base < G) ? (E - base) : G;
                     int ntm = 0, any = 0;
@@ -471,8 +473,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         any = 1;
                         const int nt = (cnt + moe_bm - 1) / moe_bm;
                         for (int mt = 0; mt < nt; mt++) {
-                            h_tm[2 * ntm] = e;
-                            h_tm[2 * ntm + 1] = mt;
+                            if (ntm >= max_tiles) break;
+                            h_tm[(size_t)2 * ntm] = e;
+                            h_tm[(size_t)2 * ntm + 1] = mt;
                             ntm++;
                         }
                     }
@@ -481,7 +484,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     const void* ue = (const char*)w.up_q   + (size_t)base * (size_t)mffn * u_rb;
                     kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, ge, Wg_i8, swg, n_in * mffn, H, st);
                     kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   ue, Wu_i8, swu, n_in * mffn, H, st);
-                    pf_cu(cudaMemcpyAsync(tilemap, h_tm, (size_t)2 * ntm * sizeof(int),
+                    pf_cu(cudaMemcpyAsync(tilemap, h_tm.data(), (size_t)2 * ntm * sizeof(int),
                                           cudaMemcpyHostToDevice, st), "moe group tilemap");
                     pf_cu(cudaMemcpyAsync(d_ntiles, &ntm, sizeof(int),
                                           cudaMemcpyHostToDevice, st), "moe group ntiles");
@@ -506,15 +509,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         any = 1;
                         const int nt = (cnt + moe_bm - 1) / moe_bm;
                         for (int mt = 0; mt < nt; mt++) {
-                            h_tm[2 * ntm] = e;
-                            h_tm[2 * ntm + 1] = mt;
+                            if (ntm >= max_tiles) break;
+                            h_tm[(size_t)2 * ntm] = e;
+                            h_tm[(size_t)2 * ntm + 1] = mt;
                             ntm++;
                         }
                     }
                     if (!any) continue;
                     const void* de = (const char*)w.down_q + (size_t)base * (size_t)H * d_rb;
                     kernels::launch_gguf_dequant_rows_i8(w.down_qtype, de, Wd_i8, swd, n_in * H, mffn, st);
-                    pf_cu(cudaMemcpyAsync(tilemap, h_tm, (size_t)2 * ntm * sizeof(int),
+                    pf_cu(cudaMemcpyAsync(tilemap, h_tm.data(), (size_t)2 * ntm * sizeof(int),
                                           cudaMemcpyHostToDevice, st), "moe down tilemap");
                     pf_cu(cudaMemcpyAsync(d_ntiles, &ntm, sizeof(int),
                                           cudaMemcpyHostToDevice, st), "moe down ntiles");

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -207,9 +207,40 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // `use_i8` flag, which upstream defaults OFF for MoE (it governs only the bf16-vs-int8 choice of
     // the attention/GDN/shared projections routed through `proj`). Full-N shared-expert buffers
     // (sfg/sfu/sfh) are dedicated here because the outer ffg/ffu are FC-chunked (dense path only).
+    //
     const int E = moe ? c.n_experts : 0, topk = moe ? c.top_k : 0, mffn = moe ? c.moe_ffn : 0;
     const int P = moe ? N * topk : 0;                          // routed (token, expert) pairs
-    const int max_tiles = moe ? (P + 127) / 128 + E : 0;       // per-expert 128-row GEMM tiles
+    // Short-N: BM=16 fills the tile (avg pairs/expert = N*8/256 = N/32; at 512 → 16).
+    // Long-N: BM=128. Override with SPARKINFER_PREFILL_MOE_BM={16,128}.
+    const int moe_bm = [&]{
+        if (!moe) return 128;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_BM");
+        if (e) { int v = atoi(e); return (v == 16) ? 16 : 128; }
+        return (N <= 512) ? 16 : 128;
+    }();
+    const int max_tiles = moe ? (P + moe_bm - 1) / moe_bm + E : 0;
+    // Opt-in fused QK path (experimental; currently slower than int8 materialize).
+    const bool moe_fused = [&]{
+        if (!moe) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_FUSED");
+        return e && e[0] == '1';
+    }();
+    // Expert-group L2 path: dequant G experts (~G*3 MB) then GEMM that group while hot in
+    // L2. Wins at short-N (N<=512, G=32 → +5% @512); bulk is faster once tiles fill. Default
+    // ON for N<=512. SPARKINFER_PREFILL_MOE_SERIAL=0/1 overrides; GROUP default 32.
+    const bool moe_serial = [&]{
+        if (!moe || moe_fused) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_SERIAL");
+        if (e) return e[0] != '0';
+        return N <= 512;
+    }();
+    const int moe_group = [&]{
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_GROUP");
+        int g = e ? atoi(e) : 32;
+        if (g < 1) g = 1;
+        if (g > 64) g = 64;
+        return g;
+    }();
     Arena am;
     signed char *Wg_i8 = nullptr, *Wu_i8 = nullptr, *Wd_i8 = nullptr, *h_i8 = nullptr, *mA_i8 = nullptr;
     float *swg = nullptr, *swu = nullptr, *swd = nullptr, *sh = nullptr, *msx = nullptr;
@@ -218,12 +249,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     int *pair_tok = nullptr, *tilemap = nullptr, *d_ntiles = nullptr;
     bf16 *hg = nullptr, *hu = nullptr, *hh = nullptr, *sfg = nullptr, *sfu = nullptr, *sfh = nullptr;
     if (moe) {
-        Wg_i8 = am.alloc<signed char>((size_t)E * mffn * H);
-        Wu_i8 = am.alloc<signed char>((size_t)E * mffn * H);
-        Wd_i8 = am.alloc<signed char>((size_t)E * H * mffn);
-        swg = am.alloc<float>((size_t)E * mffn);
-        swu = am.alloc<float>((size_t)E * mffn);
-        swd = am.alloc<float>((size_t)E * H);
+        if (!moe_fused) {
+            // Serial groups: scratch for moe_group experts. Bulk: full E stack.
+            const int ew = moe_serial ? moe_group : E;
+            Wg_i8 = am.alloc<signed char>((size_t)ew * mffn * H);
+            Wu_i8 = am.alloc<signed char>((size_t)ew * mffn * H);
+            Wd_i8 = am.alloc<signed char>((size_t)ew * H * mffn);
+            swg = am.alloc<float>((size_t)ew * mffn);
+            swu = am.alloc<float>((size_t)ew * mffn);
+            swd = am.alloc<float>((size_t)ew * H);
+        }
         mlogits = am.alloc<float>((size_t)N * E);
         mids = am.alloc<int>((size_t)P);
         mweights = am.alloc<float>((size_t)P);
@@ -391,25 +426,121 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_pfm_router_logits(hn, rw, mlogits, N, E, H, st);
             pf_cu(cudaMemsetAsync(mcounts, 0, E * sizeof(int), st), "moe counts zero");
             kernels::launch_moe_router(mlogits, mids, mweights, mcounts, N, E, topk, 1, st);
-            kernels::launch_pfm_bucket_pairs(mids, mweights, mcounts, moffsets, mcursors,
-                                             pair_tok, pair_w, tilemap, d_ntiles, N, E, topk, st);
-            // Expert weights -> int8 rows ONCE per layer (one launch covers all 256 experts).
-            kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
-            kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   w.up_q,   Wu_i8, swu, E * mffn, H, st);
-            kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
+            kernels::launch_pfm_bucket_pairs_bm(mids, mweights, mcounts, moffsets, mcursors,
+                                                pair_tok, pair_w, tilemap, d_ntiles, N, E, topk, moe_bm, st);
             kernels::launch_prefill_quantize_rows_i8(hn, mA_i8, msx, N, H, st);
-            kernels::launch_pfm_moe_gemm_i8(mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets,
-                                            tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles,
-                                            /*a_indirect=*/true, /*c_scatter=*/false, st);
-            kernels::launch_pfm_moe_gemm_i8(mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets,
-                                            tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
-                                            true, false, st);
-            kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
-            kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
-            pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
-            kernels::launch_pfm_moe_gemm_i8(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
-                                            tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
-                                            /*a_indirect=*/false, /*c_scatter=*/true, st);
+            if (moe_fused) {
+                // On-the-fly Q→bf16 B staging — no full-expert int8 materialize (experimental).
+                kernels::launch_pfm_moe_gemm_qk(mA_i8, msx, w.gate_q, w.gate_qtype, pair_tok, pair_w,
+                                                moffsets, tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles,
+                                                /*a_indirect=*/true, /*c_scatter=*/false, st);
+                kernels::launch_pfm_moe_gemm_qk(mA_i8, msx, w.up_q, w.up_qtype, pair_tok, pair_w,
+                                                moffsets, tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
+                                                true, false, st);
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
+                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
+                kernels::launch_pfm_moe_gemm_qk(h_i8, sh, w.down_q, w.down_qtype, pair_tok, pair_w,
+                                                moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
+                                                /*a_indirect=*/false, /*c_scatter=*/true, st);
+            } else if (moe_serial) {
+                // Expert-group L2 path: dequant G experts into scratch, one grouped GEMM per
+                // stage so the ~G*3 MB working set stays L2-hot (5090 L2 ≈ 96 MB).
+                auto q_row_bytes = [](int qtype, int cols) -> size_t {
+                    const int bs = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
+                    return (size_t)(cols >> 8) * (size_t)bs;
+                };
+                int h_counts[256];
+                pf_cu(cudaMemcpyAsync(h_counts, mcounts, (size_t)E * sizeof(int),
+                                      cudaMemcpyDeviceToHost, st), "moe counts D2H");
+                pf_cu(cudaStreamSynchronize(st), "moe serial sync");
+                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
+                const size_t g_rb = q_row_bytes(w.gate_qtype, H);
+                const size_t u_rb = q_row_bytes(w.up_qtype, H);
+                const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
+                const int G = moe_group;
+                // Host tilemap for one group (worst case: every expert has pairs).
+                int h_tm[2 * 256];   // enough for G<=64 with several tiles each
+                for (int base = 0; base < E; base += G) {
+                    const int n_in = (E - base < G) ? (E - base) : G;
+                    int ntm = 0, any = 0;
+                    for (int le = 0; le < n_in; le++) {
+                        const int e = base + le;
+                        const int cnt = h_counts[e];
+                        if (cnt <= 0) continue;
+                        any = 1;
+                        const int nt = (cnt + moe_bm - 1) / moe_bm;
+                        for (int mt = 0; mt < nt; mt++) {
+                            h_tm[2 * ntm] = e;
+                            h_tm[2 * ntm + 1] = mt;
+                            ntm++;
+                        }
+                    }
+                    if (!any) continue;
+                    const void* ge = (const char*)w.gate_q + (size_t)base * (size_t)mffn * g_rb;
+                    const void* ue = (const char*)w.up_q   + (size_t)base * (size_t)mffn * u_rb;
+                    kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, ge, Wg_i8, swg, n_in * mffn, H, st);
+                    kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   ue, Wu_i8, swu, n_in * mffn, H, st);
+                    pf_cu(cudaMemcpyAsync(tilemap, h_tm, (size_t)2 * ntm * sizeof(int),
+                                          cudaMemcpyHostToDevice, st), "moe group tilemap");
+                    pf_cu(cudaMemcpyAsync(d_ntiles, &ntm, sizeof(int),
+                                          cudaMemcpyHostToDevice, st), "moe group ntiles");
+                    kernels::launch_pfm_moe_gemm_i8_bm_base(
+                        mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets, tilemap, d_ntiles,
+                        hg, nullptr, mffn, H, ntm, moe_bm, base,
+                        /*a_indirect=*/true, /*c_scatter=*/false, st);
+                    kernels::launch_pfm_moe_gemm_i8_bm_base(
+                        mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets, tilemap, d_ntiles,
+                        hu, nullptr, mffn, H, ntm, moe_bm, base, true, false, st);
+                }
+                // One SwiGLU over all pairs, then group-serial down GEMM (L2-resident).
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
+                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                for (int base = 0; base < E; base += G) {
+                    const int n_in = (E - base < G) ? (E - base) : G;
+                    int ntm = 0, any = 0;
+                    for (int le = 0; le < n_in; le++) {
+                        const int e = base + le;
+                        const int cnt = h_counts[e];
+                        if (cnt <= 0) continue;
+                        any = 1;
+                        const int nt = (cnt + moe_bm - 1) / moe_bm;
+                        for (int mt = 0; mt < nt; mt++) {
+                            h_tm[2 * ntm] = e;
+                            h_tm[2 * ntm + 1] = mt;
+                            ntm++;
+                        }
+                    }
+                    if (!any) continue;
+                    const void* de = (const char*)w.down_q + (size_t)base * (size_t)H * d_rb;
+                    kernels::launch_gguf_dequant_rows_i8(w.down_qtype, de, Wd_i8, swd, n_in * H, mffn, st);
+                    pf_cu(cudaMemcpyAsync(tilemap, h_tm, (size_t)2 * ntm * sizeof(int),
+                                          cudaMemcpyHostToDevice, st), "moe down tilemap");
+                    pf_cu(cudaMemcpyAsync(d_ntiles, &ntm, sizeof(int),
+                                          cudaMemcpyHostToDevice, st), "moe down ntiles");
+                    kernels::launch_pfm_moe_gemm_i8_bm_base(
+                        h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets, tilemap, d_ntiles,
+                        nullptr, routed_f32, H, mffn, ntm, moe_bm, base,
+                        /*a_indirect=*/false, /*c_scatter=*/true, st);
+                }
+            } else {
+                // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts).
+                kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
+                kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   w.up_q,   Wu_i8, swu, E * mffn, H, st);
+                kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
+                kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets,
+                                                   tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles, moe_bm,
+                                                   /*a_indirect=*/true, /*c_scatter=*/false, st);
+                kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets,
+                                                   tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm,
+                                                   true, false, st);
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
+                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
+                kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
+                                                   tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,
+                                                   /*a_indirect=*/false, /*c_scatter=*/true, st);
+            }
             // Shared expert (Qwen3.6 UD): out scaled by sigmoid(hn . gate_inp) per token.
             bf16* shared_out = nullptr;
             const void* sg = w.shared_gate_q ? w.shared_gate_q : w.shared_gate;


### PR DESCRIPTION
## Summary

Closes the Qwen3.6 short-N prefill gap vs the bulk expert-grouped MoE path by dequanting experts in L2-resident groups (default G=32, BM=16 for N≤512) so the ~G×3 MB working set stays hot instead of materializing all 256 experts (~768 MB/layer) every time. Bulk path unchanged for N>512; experimental fused QK path behind `SPARKINFER_PREFILL_MOE_FUSED=1`.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 501.20 |
| after (this PR) | 501.45 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 3889.3 |
| after prefill (this PR) | 4105.8 |

```text
# Qwen3.6-35B-A3B-UD-Q4_K_M, RTX 5090 (sm_120), same-box A/B via qwen3_gguf_bench
# Target context: --ctx 512 (short-N MoE group path)

# before (main / SPARKINFER_PREFILL_MOE_SERIAL=0 bulk):
#   prefill pp 3889.3 tok/s     decode tg 501.20 tok/s @512
# after  (this PR, default G=32 BM=16 @N<=512):
#   prefill pp 4105.8 tok/s  (+5.6%)     decode tg 501.45 tok/s @512

# Decode guards (no regression, tol 0.98):
#   ctx=128    bulk_tg=507.12  def_tg=506.31  ratio=0.9984
#   ctx=512    bulk_tg=501.20  def_tg=501.45  ratio=1.0005
#   ctx=4096   bulk_tg=483.55  def_tg=483.74  ratio=1.0004
#   ctx=16384  bulk_tg=466.14  def_tg=466.17  ratio=1.0001
#   ctx=32768  bulk_tg=436.04  def_tg=436.24  ratio=1.0005

# Prefill guards vs bulk (tol 0.98; group path only engages N<=512):
#   ctx=128    bulk_pp=1175.6  def_pp=1174.5  ratio=0.9990
#   ctx=512    bulk_pp=3889.3  def_pp=4105.8  ratio=1.0557
#   ctx=1024   bulk_pp=6539.3  def_pp=6527.1  ratio=0.9981
#   ctx=4096   bulk_pp=12869.5 def_pp=12904.9 ratio=1.0028

# Correctness — qwen3_gguf_prefill_check prefix=512 cont=32:
#   TOP1 ~0.875  KL ~0.005  (matches bulk within run noise)
# vs-llama accuracy.sh (seed=fixed): short top1=0.910 kl=0.075 PASS
# long H2 mean (3 seeds, int8): top1=0.961 kl=0.398 PASS (no veto)
# self_consistency bulk vs G=32 score dump: agree=1.000 selfkl=0
```