### PR TITLE
perf(qwen35): resident fragment-order prefill weights and packed int8 prefill GEMM

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -183,6 +183,11 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
                 for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffffu, mx, o));
                 const float m_old = s_m[r], m_new = fmaxf(m_old, mx), corr = __expf(m_old - m_new);
                 float sum = 0.f, pamax = 0.f;
+                // P' stays in registers. The quantize below walks exactly the t this lane owns here
+                // (t = lane + u*32), so bouncing P' through s_s and reading it straight back was a
+                // round trip to shared memory for a value the thread already holds. sc[] is dead
+                // once its P' is formed, so it doubles as the register buffer and costs nothing --
+                // which matters, the kernel is at its register cap.
                 #pragma unroll
                 for (int u = 0; u < GN / 32; u++) {
                     const int t = lane + u * 32;
@@ -191,7 +196,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
                         const float p = __expf(sc[u] - m_new);
                         sum += p; pv = p * s_vs[t]; pamax = fmaxf(pamax, fabsf(pv));
                     }
-                    s_s[r * GN + t] = pv;
+                    sc[u] = pv;
                 }
                 #pragma unroll
                 for (int o = 16; o > 0; o >>= 1) {
@@ -200,10 +205,21 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
                 }
                 const float pd = pamax / 127.0f;
                 if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; s_ps[r] = pd; }
-                for (int t = lane; t < gblk * 16; t += 32)
-                    s_pi[r * GN + t] =
-                        (signed char)((pamax == 0.f) ? 0 : (int)roundf(s_s[r * GN + t] / pd));
-                for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
+                // Columns past gblk*16 are never read by the PV mma (it walks ks < gblk), exactly as
+                // before -- the old loop bounded t the same way.
+                #pragma unroll
+                for (int u = 0; u < GN / 32; u++) {
+                    const int t = lane + u * 32;
+                    if (t < gblk * 16)
+                        s_pi[r * GN + t] =
+                            (signed char)((pamax == 0.f) ? 0 : (int)roundf(sc[u] / pd));
+                }
+                // Rescaling the running O is HEAD_DIM smem read-modify-writes per row per group, and
+                // it is a no-op whenever the row's running max did not move -- corr is then exactly
+                // 1.0f and x * 1.0f == x for every float. Scanning keys causally, the max settles
+                // early, so most groups skip this entirely. Bit-identical either way.
+                if (corr != 1.0f)
+                    for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
             }
             __syncthreads();
 
@@ -224,15 +240,19 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
                     mma_sync(cf, af, bf, cf);
                 }
                 // s_pv aliases s_s, which is dead once P' is quantized into s_pi. Each warp owns a
-                // disjoint 256-int slice, so the store needs only a warp fence; the __syncthreads
-                // below is what lets the next d-tile (and the next group's QK) reuse the buffer.
+                // disjoint 256-int slice, so reusing it across d-tiles is a warp-local hazard and a
+                // warp fence covers it; only the next group's QK -- which overwrites the whole
+                // aliased buffer -- needs the block-wide barrier, so that one is hoisted out of this
+                // loop. Each warp also owns a disjoint column range of s_o (d-tiles w*DPW..), so the
+                // accumulate below needs no cross-warp ordering either.
+                __syncwarp();
                 store_matrix_sync(s_pv + warp * 256, cf, 16, mem_row_major);
                 __syncwarp();
                 for (int i = lane; i < 256; i += 32)
                     s_o[(i >> 4) * HEAD_DIM + dt * 16 + (i & 15)] +=
                         (float)s_pv[warp * 256 + i] * s_ps[i >> 4];
-                __syncthreads();
             }
+            __syncthreads();
         }
     };
 

--- a/kernels/csrc/cuda/fused/prefill_gemm_i8_packed.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8_packed.cu
@@ -1,0 +1,431 @@
+// int8 prefill GEMM over a pre-packed weight (see prefill_i8_packed.h).
+//
+// Same math as prefill_gemm_i8.cu -- C[M,N] = A[M,K] @ W^T, int8 x int8 -> int32 with the
+// sx[m]*sw[n] dequant folded into the store -- but the weight is staged in tensor-core fragment
+// order instead of [N,K] row-major.
+//
+// The row-major kernel pays for that layout twice in its inner loop: each mma B operand is two
+// scalar 4B smem loads at a swizzled address, and the XOR swizzle only spreads rows 0..3 (rows 4
+// apart still collide 2-way). Because the prefill weights are constant, the runtime can hold them
+// resident and pay the reshuffle once at cache-build time, so a lane's mma operand becomes a single
+// contiguous load with no address math.
+//
+// Packing (N%16==0, K%64==0). For column group cg = n/8, k-block k32 = k/32 and lane = 0..31 with
+// grp = lane>>2 (the mma B operand's n index) and tig = lane&3, one lane's 8 operand bytes are
+//   [0..3] = W[cg*8+grp][k32*32 +      tig*4 .. +4]
+//   [4..7] = W[cg*8+grp][k32*32 + 16 + tig*4 .. +4]
+// and column groups are stored in INTERLEAVED PAIRS (pk_bdst): cg and cg+1 land adjacent for the
+// same lane, so one 16B load feeds two mma B operands. With the activation packed the same way
+// (prefill_i8_packed.h), the inner loop issues 6 loads per 16 mma -- 2 for A, 4 for B -- all
+// conflict-free, where the row-major kernel issues 32.
+//
+// Bit-identical to the row-major kernel: int8 products accumulate in int32 and never overflow
+// (|sum| <= 127*127*12288 ~ 1.98e8 < 2^31), so integer accumulation is exact and order-independent;
+// the epilogue is unchanged. Every pack is a pure permutation of the same bytes.
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_pipeline.h>
+#include <cstdlib>
+#include "sparkinfer/kernels/prefill_i8_packed.h"
+
+namespace sparkinfer { namespace kernels {
+
+namespace {
+constexpr int PK_BM = 128;
+constexpr int PK_BN = 128;
+constexpr int PK_BK = 64;          // 2 k32 blocks per stage
+constexpr int PK_MFRAG = 2;        // 32 rows per warp / 16
+constexpr int PK_NFRAG = 8;        // 64 cols per warp / 8
+constexpr int PK_CGP = PK_BN / 16; // 8 column-group PAIRS per block tile (see the pack note)
+constexpr int PK_CGB = 1024;       // bytes per pair per BK tile: 2 k32 * 32 lanes * 16B
+constexpr int PK_MT = PK_BM / 16;  // 8 mma row-tiles per block tile
+constexpr int PK_MTB = 1024;       // bytes per row-tile per BK tile: 2 k32 * 32 lanes * 16B
+constexpr int PK_QP_THREADS = 512; // quantize+pack block: 16 warps, one per row of the mma tile
+// cp.async depth. 2 stages = 32 KB, which keeps 2 blocks/SM at 124 registers. A 3-stage variant
+// measured +0.4% (inside run-to-run noise) while needing exactly 49152 B of static smem -- the
+// per-block limit, with no headroom left for anything else -- so the extra prefetch depth is not
+// worth the fragility.
+constexpr int PK_STAGES = 2;
+// Row-blocks per rasterization group. Blocks issue in blockIdx.x-major order, so the natural
+// (m,n) = (blockIdx.y, blockIdx.x) mapping puts every block resident at one time on a *different*
+// weight column block, and a wave's weight working set becomes the whole [N,K] weight. Walking
+// PK_GROUP row-blocks down M before stepping along N bounds it to ~wave/PK_GROUP column blocks.
+// This is worth +3% on the interleaved gate|up GEMM, whose 100 MB weight is the one that does not
+// fit L2 -- without it the SwiGLU fusion below is a net *loss*, its saved elementwise pass paid
+// straight back in re-streamed weight. Neutral on the smaller projections, which fit either way, so
+// it is applied uniformly rather than special-cased.
+//
+// 8 is measured, not derived: swept 1/2/4/8/16/32 at ctx=4096, and only the step off 1 matters --
+// past 8 the sweep is flat. The tempting extrapolation ("taller stripes -> fewer passes over the
+// weight -> keep growing it") does not hold.
+constexpr int PK_GROUP = 8;
+
+// Stripe height for a shape: PK_GROUP, but never more row-blocks than exist.
+// SPARKINFER_PREFILL_PK_GROUP overrides it (A/B); 1 gives the natural rasterization.
+int pk_group(int M) {
+    static const int env_g = []() {
+        const char* e = getenv("SPARKINFER_PREFILL_PK_GROUP");
+        return e ? atoi(e) : 0;
+    }();
+    const int nblk_m = (M + PK_BM - 1) / PK_BM;
+    const int g = env_g > 0 ? env_g : PK_GROUP;
+    return g > nblk_m ? (nblk_m < 1 ? 1 : nblk_m) : (g < 1 ? 1 : g);
+}
+
+// Where column group cg's fragment for (k32, lane) lives. Pairs of column groups are interleaved:
+// a lane's 8 bytes for cg and its 8 for cg+1 sit adjacent, so the GEMM fetches both mma B operands
+// in ONE 16B load instead of two 8B ones. Pair p = cg>>1 occupies 512 B per k32 (32 lanes x 16 B).
+__device__ __forceinline__ signed char* pk_bdst(signed char* Wp, int cg, int k32, int lane,
+                                                int nk32) {
+    return Wp + ((size_t)((cg >> 1) * nk32 + k32) * 32 + lane) * 16 + (cg & 1) * 8;
+}
+
+__device__ __forceinline__ void pk_cp16(void* dst, const void* src, bool pred) {
+    if (pred) __pipeline_memcpy_async(dst, src, 16);
+    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
+// Must match pf_silu/pf_to_f in batched_prefill.cu -- the fused epilogue reproduces
+// pf_swiglu_kernel exactly, including the bf16 rounding of both operands before the silu.
+__device__ __forceinline__ float pk_silu(float x) { return x / (1.f + __expf(-x)); }
+
+// Map this block to its (row, col) tile in `g`-row-block-tall stripes (see PK_GROUP). Pure
+// scheduling: every block still computes exactly one tile, so results are unchanged. g == 1 is
+// exactly the natural (blockIdx.y, blockIdx.x) mapping.
+__device__ __forceinline__ void pk_tile(int nblk_n, int nblk_m, int g, int& m_blk, int& n_blk) {
+    const int bid       = blockIdx.y * nblk_n + blockIdx.x;
+    const int per_group = g * nblk_n;
+    const int gid       = bid / per_group;
+    const int first_m   = gid * g;
+    const int rows      = min(nblk_m - first_m, g);          // last group may be short
+    const int idx       = bid - gid * per_group;
+    m_blk = first_m + idx % rows;
+    n_blk = idx / rows;
+}
+
+// One block per (column group, k32 block); 32 threads = the 32 lanes of the target fragment.
+__global__ void pk_pack_weight_kernel(const signed char* __restrict__ W, signed char* __restrict__ Wp,
+                                      int N, int K) {
+    const int nk32 = K >> 5;
+    const int cg   = blockIdx.x;
+    const int k32  = blockIdx.y;
+    const int lane = threadIdx.x;
+    const int grp = lane >> 2, tig = lane & 3;
+    const int n = cg * 8 + grp;
+    signed char* dst = pk_bdst(Wp, cg, k32, lane, nk32);
+    if (n >= N) { *reinterpret_cast<uint2*>(dst) = make_uint2(0u, 0u); return; }
+    const signed char* src = W + (size_t)n * K + k32 * 32;
+    uint2 v;
+    v.x = *reinterpret_cast<const unsigned*>(src + tig * 4);
+    v.y = *reinterpret_cast<const unsigned*>(src + 16 + tig * 4);
+    *reinterpret_cast<uint2*>(dst) = v;
+}
+
+// Interleaved gate/up pack: dst row 2j = gate row j, dst row 2j+1 = up row j. `parity` selects which
+// half this call fills, so the caller only needs a staging buffer for one [n_half,K] weight. Within a
+// fragment the dst row is cg*8 + grp, and cg*8 is even, so a lane's parity is just grp&1 -- the two
+// calls write disjoint lanes.
+__global__ void pk_pack_gate_up_kernel(const signed char* __restrict__ W, signed char* __restrict__ Wp,
+                                       int parity, int n_half, int K) {
+    const int nk32 = K >> 5;
+    const int cg   = blockIdx.x;
+    const int k32  = blockIdx.y;
+    const int lane = threadIdx.x;
+    const int grp = lane >> 2, tig = lane & 3;
+    if ((grp & 1) != parity) return;
+    const int n_src = (cg * 8 + grp) >> 1;
+    signed char* dst = pk_bdst(Wp, cg, k32, lane, nk32);
+    if (n_src >= n_half) { *reinterpret_cast<uint2*>(dst) = make_uint2(0u, 0u); return; }
+    const signed char* src = W + (size_t)n_src * K + k32 * 32;
+    uint2 v;
+    v.x = *reinterpret_cast<const unsigned*>(src + tig * 4);
+    v.y = *reinterpret_cast<const unsigned*>(src + 16 + tig * 4);
+    *reinterpret_cast<uint2*>(dst) = v;
+}
+
+__global__ void pk_interleave_scales_kernel(const float* __restrict__ s, float* __restrict__ dst,
+                                            int parity, int n_half) {
+    const int j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j < n_half) dst[2 * j + parity] = s[j];
+}
+
+// Fused per-row int8 quantize + mma A-operand pack. One block per 16-row mma tile: warp w reduces
+// row w's amax, then the whole block writes the tile in fragment order. Same scheme as the row-major
+// quantize (d = amax/127, q = round(x/d), zero row -> zero), and amax is an fmaxf reduction, so it is
+// order-independent and every byte matches regardless of how the rows are split across threads.
+__global__ __launch_bounds__(PK_QP_THREADS) void pk_quant_pack_a_kernel(
+        const __nv_bfloat16* __restrict__ x, signed char* __restrict__ Ap,
+        float* __restrict__ scale, int rows, int cols) {
+    __shared__ float sd[16];
+    const int mt = blockIdx.x, tid = threadIdx.x;
+    const int w = tid >> 5, lane = tid & 31;
+
+    if (w < 16) {
+        const int r = mt * 16 + w;
+        float amax = 0.f;
+        if (r < rows) {
+            // 8 bf16 per lane per step: K is a multiple of 64, so the row base is 16B-aligned.
+            const uint4* xv = reinterpret_cast<const uint4*>(x + (size_t)r * cols);
+            for (int v = lane; v < (cols >> 3); v += 32) {
+                const uint4 raw = xv[v];
+                const __nv_bfloat16* h = reinterpret_cast<const __nv_bfloat16*>(&raw);
+                #pragma unroll
+                for (int e = 0; e < 8; e++) amax = fmaxf(amax, fabsf(__bfloat162float(h[e])));
+            }
+        }
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
+        if (lane == 0) {
+            const float d = amax / 127.0f;
+            sd[w] = d;
+            if (r < rows) scale[r] = d;
+        }
+    }
+    __syncthreads();
+
+    // One 16B fragment per (k32, lane): the 4 chunks a lane feeds to mma as {a0,a1,a2,a3} are rows
+    // grp / grp+8 at k-offsets tig*4 and 16+tig*4 -- exactly the operands the GEMM reads back.
+    const int nk32 = cols >> 5;
+    for (int u = tid; u < nk32 * 32; u += PK_QP_THREADS) {
+        const int k32 = u >> 5, l = u & 31;
+        const int grp = l >> 2, tig = l & 3;
+        signed char out[16];
+        #pragma unroll
+        for (int p = 0; p < 4; p++) {
+            const int rr = grp + (p & 1) * 8;
+            const int cc = k32 * 32 + (p >> 1) * 16 + tig * 4;
+            const int gr = mt * 16 + rr;
+            const float d = sd[rr];
+            // cc is a multiple of 4, so the 4 bf16 this chunk needs are one aligned 8B load.
+            uint2 raw = make_uint2(0u, 0u);
+            if (gr < rows) raw = *reinterpret_cast<const uint2*>(x + (size_t)gr * cols + cc);
+            const __nv_bfloat16* h = reinterpret_cast<const __nv_bfloat16*>(&raw);
+            #pragma unroll
+            for (int e = 0; e < 4; e++)
+                out[p * 4 + e] = (signed char)((d == 0.f) ? 0 : (int)roundf(__bfloat162float(h[e]) / d));
+        }
+        *reinterpret_cast<uint4*>(Ap + ((size_t)mt * nk32 + k32) * 512 + l * 16) =
+            *reinterpret_cast<const uint4*>(out);
+    }
+}
+
+// SWIGLU=false: C[M,N] = dequant(A @ Wp^T), the plain packed GEMM.
+// SWIGLU=true:  Wp is the interleaved gate/up weight, so a lane's c0/c1 hold gate_j/up_j for the same
+//               output column j = gn>>1; the epilogue folds SwiGLU in and writes C[M,N/2].
+template <bool SWIGLU>
+__global__ __launch_bounds__(256, 2) void pk_gemm_i8_packed_kernel(
+        const signed char* __restrict__ A, const signed char* __restrict__ Wp,
+        const float* __restrict__ sx, const float* __restrict__ sw,
+        __nv_bfloat16* __restrict__ C, int M, int N, int K, int g) {
+    __shared__ signed char As[PK_STAGES][PK_MT][PK_MTB];
+    __shared__ signed char Bs[PK_STAGES][PK_CGP][PK_CGB];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int grp  = lane >> 2;
+    const int tig  = lane & 3;
+    const int wm   = warp & 3;
+    const int wn   = warp >> 2;
+    int m_blk, n_blk;
+    pk_tile(gridDim.x, gridDim.y, g, m_blk, n_blk);
+    const int m0   = m_blk * PK_BM;
+    const int n0   = n_blk * PK_BN;
+    const int cgp0 = n0 >> 4;          // first column-group pair of this block tile
+    const int mt0  = m_blk * PK_MT;
+    const int mtiles = (M + 15) >> 4;
+    const int nk32 = K >> 5;
+    const int nk   = (K + PK_BK - 1) / PK_BK;
+
+    int acc[PK_MFRAG][PK_NFRAG][4];
+    #pragma unroll
+    for (int i = 0; i < PK_MFRAG; i++)
+        #pragma unroll
+        for (int j = 0; j < PK_NFRAG; j++)
+            #pragma unroll
+            for (int e = 0; e < 4; e++) acc[i][j][e] = 0;
+
+    // Both operands are already in fragment order, so each stage is two straight contiguous copies
+    // with no swizzle: A is 8 row-tiles x 1024B (the tile's two k32 blocks are adjacent by
+    // construction), B is 16 column groups x 512B.
+    auto stage = [&](int buf, int k0) {
+        const int k320 = k0 >> 5;
+        #pragma unroll
+        for (int s = tid; s < 512; s += 256) {
+            const int mtl = s >> 6, aoff = (s & 63) << 4;
+            const int gmt = mt0 + mtl;
+            pk_cp16(&As[buf][mtl][aoff],
+                    A + ((size_t)gmt * nk32 + k320) * 512 + aoff,
+                    gmt < mtiles);
+
+            const int cgpl = s >> 6, boff = (s & 63) << 4;
+            const int gcgp = cgp0 + cgpl;
+            pk_cp16(&Bs[buf][cgpl][boff],
+                    Wp + ((size_t)gcgp * nk32 + k320) * 512 + boff,
+                    gcgp * 16 < N && k0 < K);
+        }
+        __pipeline_commit();
+    };
+
+    stage(0, 0);
+    int buf = 0;
+    for (int t = 0; t < nk; t++) {
+        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * PK_BK);
+        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+        __syncthreads();
+
+        #pragma unroll
+        for (int kk = 0; kk < PK_BK; kk += 32) {
+            const int k32l = kk >> 5;
+            uint4 af[PK_MFRAG];
+            unsigned bf[PK_NFRAG][2];
+            // One 16B load per fragment: {a0,a1,a2,a3} are this lane's four operand registers, laid
+            // out adjacently by the pack. Lanes read consecutive 16B, so it is conflict-free.
+            #pragma unroll
+            for (int i = 0; i < PK_MFRAG; i++)
+                af[i] = *reinterpret_cast<const uint4*>(
+                    &As[buf][wm * 2 + i][k32l * 512 + lane * 16]);
+            // One 16B load per column-group PAIR: the lane's four operand registers for fragments
+            // 2*jp and 2*jp+1 are adjacent by construction, so B costs 4 loads per k-step, not 8.
+            #pragma unroll
+            for (int jp = 0; jp < PK_NFRAG / 2; jp++) {
+                const uint4 v = *reinterpret_cast<const uint4*>(
+                    &Bs[buf][wn * 4 + jp][k32l * 512 + lane * 16]);
+                bf[2 * jp][0]     = v.x; bf[2 * jp][1]     = v.y;
+                bf[2 * jp + 1][0] = v.z; bf[2 * jp + 1][1] = v.w;
+            }
+            #pragma unroll
+            for (int i = 0; i < PK_MFRAG; i++)
+                #pragma unroll
+                for (int j = 0; j < PK_NFRAG; j++)
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                        : "+r"(acc[i][j][0]), "+r"(acc[i][j][1]), "+r"(acc[i][j][2]), "+r"(acc[i][j][3])
+                        : "r"(af[i].x), "r"(af[i].y), "r"(af[i].z), "r"(af[i].w),
+                          "r"(bf[j][0]), "r"(bf[j][1]));
+        }
+        __syncthreads();
+        buf ^= 1;
+    }
+
+    // Fused SwiGLU epilogue. gn is always even (n0 is a multiple of PK_BN, plus wn*64 + j*8 + tig*2),
+    // so with the interleaved weight this lane's c0 is gate column gn>>1 and c1 is up column gn>>1 --
+    // the pair meets in registers and never goes to memory. Rounding both to bf16 *before* the silu is
+    // what keeps this bit-identical: the unfused path materializes ffg/ffu as bf16, and pf_swiglu
+    // reads them back. prefill_gate_up_fusion_supported() guarantees the pair is in range.
+    if constexpr (SWIGLU) {
+        const int Nout = N >> 1;
+        #pragma unroll
+        for (int i = 0; i < PK_MFRAG; i++) {
+            #pragma unroll
+            for (int j = 0; j < PK_NFRAG; j++) {
+                const int gn = n0 + wn * 64 + j * 8 + tig * 2;
+                const float w0 = sw[gn], w1 = sw[gn + 1];
+                #pragma unroll
+                for (int h = 0; h < 2; h++) {
+                    const int gm = m0 + wm * 32 + i * 16 + grp + h * 8;
+                    if (gm >= M) continue;
+                    const float s = sx[gm];
+                    const float g = __bfloat162float(__float2bfloat16((float)acc[i][j][h * 2]     * s * w0));
+                    const float u = __bfloat162float(__float2bfloat16((float)acc[i][j][h * 2 + 1] * s * w1));
+                    C[(size_t)gm * Nout + (gn >> 1)] = __float2bfloat16(pk_silu(g) * u);
+                }
+            }
+        }
+        return;
+    }
+
+    // Identical epilogue to the row-major kernel.
+    #pragma unroll
+    for (int i = 0; i < PK_MFRAG; i++) {
+        #pragma unroll
+        for (int j = 0; j < PK_NFRAG; j++) {
+            const int gn = n0 + wn * 64 + j * 8 + tig * 2;
+            if (gn + 1 >= N) {
+                #pragma unroll
+                for (int e = 0; e < 4; e++) {
+                    const int gm = m0 + wm * 32 + i * 16 + grp + (e >> 1) * 8;
+                    const int cn = gn + (e & 1);
+                    if (gm < M && cn < N)
+                        C[(size_t)gm * N + cn] = __float2bfloat16((float)acc[i][j][e] * sx[gm] * sw[cn]);
+                }
+                continue;
+            }
+            const float w0 = sw[gn], w1 = sw[gn + 1];
+            #pragma unroll
+            for (int h = 0; h < 2; h++) {
+                const int gm = m0 + wm * 32 + i * 16 + grp + h * 8;
+                if (gm >= M) continue;
+                const float s = sx[gm];
+                const __nv_bfloat162 v = __floats2bfloat162_rn((float)acc[i][j][h * 2] * s * w0,
+                                                               (float)acc[i][j][h * 2 + 1] * s * w1);
+                *reinterpret_cast<__nv_bfloat162*>(&C[(size_t)gm * N + gn]) = v;
+            }
+        }
+    }
+}
+} // namespace
+
+bool prefill_pack_weight_i8_supported(int N, int K) {
+    // N % 16: column groups are packed in interleaved pairs (see pk_bdst), so N must tile whole
+    // pairs. K % 64: the packed path stages a whole BK=64 tile (both k32 blocks of a row-tile) per
+    // copy, so a partial trailing tile has no packed representation. Every Qwythos projection
+    // satisfies both; anything else keeps the row-major kernel.
+    return (N & 15) == 0 && (K & 63) == 0;
+}
+
+size_t prefill_packed_activation_bytes(int M, int K) {
+    return (size_t)((M + 15) / 16) * 16 * (size_t)K;
+}
+
+void launch_prefill_quantize_pack_a_i8(const void* x_bf16, signed char* Ap, float* scale,
+                                       int rows, int cols, cudaStream_t stream) {
+    pk_quant_pack_a_kernel<<<(rows + 15) / 16, PK_QP_THREADS, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x_bf16), Ap, scale, rows, cols);
+}
+
+size_t prefill_packed_weight_bytes(int N, int K) {
+    return (size_t)((N + 7) / 8) * 8 * (size_t)K;
+}
+
+void launch_prefill_pack_weight_i8(const signed char* W, signed char* Wp,
+                                   int N, int K, cudaStream_t stream) {
+    dim3 grid((N + 7) / 8, K >> 5);
+    pk_pack_weight_kernel<<<grid, 32, 0, stream>>>(W, Wp, N, K);
+}
+
+void launch_prefill_gemm_i8_packed(const signed char* A, const signed char* Wp,
+                                   const float* sx, const float* sw, void* C,
+                                   int M, int N, int K, cudaStream_t stream) {
+    dim3 grid((N + PK_BN - 1) / PK_BN, (M + PK_BM - 1) / PK_BM);
+    pk_gemm_i8_packed_kernel<false><<<grid, 256, 0, stream>>>(
+        A, Wp, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K, pk_group(M));
+}
+
+bool prefill_gate_up_fusion_supported(int n_half, int K) {
+    // The fused epilogue reads the (gn, gn+1) pair unconditionally, so the interleaved weight must
+    // tile PK_BN exactly -- no partial column block, no padded rows.
+    return prefill_pack_weight_i8_supported(2 * n_half, K) && ((2 * n_half) % PK_BN) == 0;
+}
+
+void launch_prefill_pack_gate_up_i8(const signed char* W, signed char* Wp,
+                                    int parity, int n_half, int K, cudaStream_t stream) {
+    dim3 grid((2 * n_half + 7) / 8, K >> 5);
+    pk_pack_gate_up_kernel<<<grid, 32, 0, stream>>>(W, Wp, parity, n_half, K);
+}
+
+void launch_prefill_interleave_scales(const float* s, float* dst,
+                                      int parity, int n_half, cudaStream_t stream) {
+    pk_interleave_scales_kernel<<<(n_half + 255) / 256, 256, 0, stream>>>(s, dst, parity, n_half);
+}
+
+void launch_prefill_gemm_i8_packed_swiglu(const signed char* A, const signed char* Wp,
+                                          const float* sx, const float* sw, void* C,
+                                          int M, int n_half, int K, cudaStream_t stream) {
+    const int N = 2 * n_half;
+    dim3 grid(N / PK_BN, (M + PK_BM - 1) / PK_BM);
+    pk_gemm_i8_packed_kernel<true><<<grid, 256, 0, stream>>>(
+        A, Wp, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K, pk_group(M));
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/prefill_i8_packed.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8_packed.h
@@ -1,0 +1,95 @@
+#pragma once
+#include <cuda_runtime.h>
+#include <cstddef>
+
+// Pre-packed-weight variant of the int8 prefill GEMM (prefill_i8.h).
+//
+// The row-major kernel reads each mma B operand as two scalar 4B smem loads at an XOR-swizzled
+// address, and that swizzle only separates rows 0..3 -- rows 4 apart still collide 2-way. Prefill
+// weights are constant, so the runtime can hold them resident and pay one reshuffle at cache-build
+// time; afterwards the 8 bytes a lane feeds to mma.sync.m16n8k32 are contiguous, so the B path
+// becomes one conflict-free 8B load per fragment with no address math.
+//
+// Results are bit-identical to launch_prefill_gemm_i8: the int8 products accumulate in int32 and
+// cannot overflow at these shapes (|sum| <= 127*127*12288 ~ 1.98e8 < 2^31), so integer accumulation
+// is exact and independent of order, and the dequant epilogue is unchanged. Callers that cannot pack
+// (unsupported shape, no spare VRAM) keep using the row-major kernel.
+
+namespace sparkinfer { namespace kernels {
+
+// Packing needs N a multiple of 8 (the mma B operand's n extent) and K a multiple of 64 (two k32
+// blocks, the kernel's BK step -- the activation pack below stages a whole BK tile per mtile).
+bool prefill_pack_weight_i8_supported(int N, int K);
+
+// ---------------------------------------------------------------------------
+// Packed activation.
+//
+// The weight pack above fixes the mma *B* operand; the *A* operand is still four swizzled scalar 4B
+// smem loads per fragment. Activations change every pass, so they cannot be held resident -- but they
+// are already rewritten once per pass by the row quantize, and that pass is free to emit fragment
+// order instead of row-major at no extra cost. The GEMM's four LDS.32 then become one conflict-free
+// LDS.128 with no address math, taking the inner loop from 16 loads per 16 mmas to 10.
+//
+// Bit-identical to launch_prefill_quantize_rows_i8: the same symmetric per-row scheme (d = amax/127,
+// q = round(x/d)), and amax is an fmaxf reduction, which is order-independent -- so re-parallelizing
+// it cannot change a byte.
+// ---------------------------------------------------------------------------
+
+// Bytes launch_prefill_quantize_pack_a_i8 writes for an [M,K] activation (M padded to the 16-row
+// mma tile).
+size_t prefill_packed_activation_bytes(int M, int K);
+
+// Quantize x_bf16[M,K] to int8 in mma.sync.m16n8k32 A-operand order -> Ap, per-row scales -> scale.
+// Rows past M in the final tile are zero-filled, so the GEMM needs no row predicate.
+void launch_prefill_quantize_pack_a_i8(const void* x_bf16, signed char* Ap, float* scale,
+                                       int rows, int cols, cudaStream_t stream = nullptr);
+
+// Bytes launch_prefill_pack_weight_i8 writes for a [N,K] int8 weight.
+size_t prefill_packed_weight_bytes(int N, int K);
+
+// Reshuffle a row-major int8 weight [N,K] into tensor-core fragment order. One-time, per weight.
+void launch_prefill_pack_weight_i8(const signed char* W, signed char* Wp,
+                                   int N, int K, cudaStream_t stream = nullptr);
+
+// C[M,N] = A[M,K] @ W^T with Wp produced by launch_prefill_pack_weight_i8. A, sx, sw, C as in
+// launch_prefill_gemm_i8.
+void launch_prefill_gemm_i8_packed(const signed char* A, const signed char* Wp,
+                                   const float* sx, const float* sw, void* C,
+                                   int M, int N, int K, cudaStream_t stream = nullptr);
+
+// ---------------------------------------------------------------------------
+// Fused SwiGLU FFN variant.
+//
+// The dense FFN runs gate and up as two [n_half,K] projections over the same activation, then a
+// separate elementwise pass reads both back to form silu(gate)*up. Packing lets the two weights be
+// interleaved row-wise -- dst row 2j = gate row j, dst row 2j+1 = up row j -- into one [2*n_half,K]
+// weight. mma.sync.m16n8k32's accumulator then lands columns n and n+1 in the *same lane's* c0/c1
+// (the epilogue's column index n0 + wn*64 + j*8 + tig*2 is always even), so gate_j and up_j meet in
+// registers and SwiGLU collapses into the epilogue: one GEMM, no elementwise pass, and the two
+// full-size gate/up writes become one.
+//
+// Bit-identical to gemm_i8_packed + launch_prefill_swiglu: both operands are rounded to bf16 before
+// the silu, exactly as materializing them to memory would.
+// ---------------------------------------------------------------------------
+
+// The fused GEMM tiles 128 weight rows (= 64 outputs) per block, so the interleaved weight needs
+// 2*n_half a multiple of 128, on top of the plain packing constraints.
+bool prefill_gate_up_fusion_supported(int n_half, int K);
+
+// Pack one parity of the interleaved gate/up weight: parity 0 takes W = gate into the even dst rows,
+// parity 1 takes W = up into the odd ones. Two calls with the same Wp build the whole weight, so the
+// row-major staging buffer only ever has to hold one [n_half,K] weight at a time.
+void launch_prefill_pack_gate_up_i8(const signed char* W, signed char* Wp,
+                                    int parity, int n_half, int K, cudaStream_t stream = nullptr);
+
+// Scatter one parity's row scales to match: dst[2*j + parity] = s[j].
+void launch_prefill_interleave_scales(const float* s, float* dst,
+                                      int parity, int n_half, cudaStream_t stream = nullptr);
+
+// C[M,n_half] = silu(A[M,K] @ Wgate^T) * (A[M,K] @ Wup^T), with Wp the interleaved packed weight.
+// sw holds the interleaved row scales (2*n_half of them); sx, A as in launch_prefill_gemm_i8.
+void launch_prefill_gemm_i8_packed_swiglu(const signed char* A, const signed char* Wp,
+                                          const float* sx, const float* sw, void* C,
+                                          int M, int n_half, int K, cudaStream_t stream = nullptr);
+
+}} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -17,6 +17,7 @@
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/prefill_i8.h"
+#include "sparkinfer/kernels/prefill_i8_packed.h"
 #include "sparkinfer/kernels/prefill_moe.h"
 #include "sparkinfer/kernels/moe.h"
 
@@ -24,6 +25,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <unordered_map>
 #include <vector>
 
 namespace sparkinfer {
@@ -46,6 +48,163 @@ struct Arena {
     }
     void free_all() { for (void* b : bufs) cudaFree(b); bufs.clear(); }
 };
+
+// ---------------------------------------------------------------------------
+// Resident weight cache.
+//
+// proj() re-derives the int8 form of every weight (and the bf16 dequant of the tiny gate
+// projections) on *every* prefill call: ~200 weight conversions per 4k dense prefill. The GGUF
+// weights are constant for the model's lifetime, so this caches each weight's converted form on
+// first use and keeps it resident. prefill_i8.h already specifies the intent -- "the per-output-row
+// weight scales are computed once and kept resident, the per-token activation scales are computed
+// per prefill pass" -- and this makes the resident half of that contract true; the activation quant
+// stays per-pass. The cached bytes are exactly what the per-call path would have produced (same
+// kernels, same inputs), so every GEMM sees bit-identical operands. Budget-capped with free-VRAM
+// headroom; keyed by weight pointer; a build failure caches a null so it is not retried. A different
+// model in the process drops the cache. Disabled with SPARKINFER_PREFILL_WCACHE=0.
+// ---------------------------------------------------------------------------
+// q: resident int8 weight -- tensor-core fragment order when `packed`, else [n_out,K] row-major.
+struct CachedI8 { signed char* q; float* s; bool packed; };
+
+std::unordered_map<const void*, CachedI8> g_wc_i8;   // weight -> resident int8 rows + row scales
+std::unordered_map<const void*, CachedI8> g_wc_gu;   // gate weight -> resident interleaved gate|up
+std::unordered_map<const void*, void*>    g_wc_bf16; // weight -> resident bf16 dequant (small gates)
+size_t      g_wc_bytes = 0;
+const void* g_wc_model = nullptr;   // model tag; a different model drops the cache
+
+void wcache_reset() {
+    for (auto& kv : g_wc_i8) { cudaFree(kv.second.q); cudaFree(kv.second.s); }
+    for (auto& kv : g_wc_gu) { cudaFree(kv.second.q); cudaFree(kv.second.s); }
+    for (auto& kv : g_wc_bf16) cudaFree(kv.second);
+    g_wc_i8.clear();
+    g_wc_gu.clear();
+    g_wc_bf16.clear();
+    g_wc_bytes = 0;
+}
+
+size_t wcache_budget() {
+    static const long mb = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_WCACHE_MB");
+        return e ? atol(e) : 10240L;
+    }();
+    return (size_t)mb << 20;
+}
+// Take the allocation only if it fits the budget and leaves the device comfortable headroom -- the
+// scratch arena for a long context is many GB, and starving it drops the whole prefill back to the
+// per-token loop, far slower than any dequant this cache removes.
+bool wcache_can_alloc(size_t bytes) {
+    if (g_wc_bytes + bytes > wcache_budget()) return false;
+    size_t freeb = 0, totalb = 0;
+    if (cudaMemGetInfo(&freeb, &totalb) != cudaSuccess) return false;
+    return bytes + (3ull << 30) < freeb;
+}
+
+// Row-major int8 form of a native GGUF weight [n_out,K] -> dst, row scales -> s. Exactly the kernels
+// the per-call path runs, in the same order, so the bytes are identical to what it would produce.
+// `bfs` is staging for weight types the fused GGUF->int8 path does not cover.
+void build_i8_rows(const void* W, int wtype, signed char* dst, float* s, int n_out, int K,
+                   bf16* bfs, cudaStream_t st) {
+    if (kernels::launch_gguf_dequant_rows_i8(wtype, W, dst, s, n_out, K, st)) return;
+    const void* wb = W;
+    if (wtype != 0) {
+        kernels::launch_gguf_dequant(wtype, W, bfs, (long)n_out * K, st);
+        wb = bfs;
+    }
+    kernels::launch_prefill_quantize_rows_i8(wb, dst, s, n_out, K, st);
+}
+
+// Finish a cache entry: commit its bytes, or free it and leave it null if the build failed.
+void wcache_commit(CachedI8& c, size_t bytes, cudaStream_t st) {
+    if (cudaStreamSynchronize(st) == cudaSuccess) {
+        g_wc_bytes += bytes;
+    } else {
+        cudaFree(c.q); cudaFree(c.s);
+        c.q = nullptr; c.s = nullptr;
+    }
+}
+
+// Reserve a cache entry's device buffers. False (and c left null) if it does not fit.
+bool wcache_alloc(CachedI8& c, size_t qbytes, size_t sbytes) {
+    if (wcache_can_alloc(qbytes + sbytes) &&
+        cudaMalloc((void**)&c.q, qbytes) == cudaSuccess &&
+        cudaMalloc((void**)&c.s, sbytes) == cudaSuccess) return true;
+    cudaFree(c.q);              // no-op on null; the scale alloc may have been the one that failed
+    c.q = nullptr; c.s = nullptr;
+    return false;
+}
+
+// Resident int8 form of weight W, built on first use. Returns null if uncacheable (the caller then
+// converts into per-call scratch exactly as before). `bfs`/`i8s` are shared per-call staging: bfs
+// for weight types the fused GGUF->int8 path does not cover, i8s to hold the row-major int8 while it
+// is reshuffled into the resident fragment-order copy.
+const CachedI8* wcache_i8_get(const void* W, int wtype, int n_out, int K, bf16* bfs,
+                              signed char* i8s, cudaStream_t st) {
+    auto it = g_wc_i8.find(W);
+    if (it != g_wc_i8.end()) return it->second.q ? &it->second : nullptr;
+
+    const bool pack = i8s && kernels::prefill_pack_weight_i8_supported(n_out, K);
+    const size_t qbytes = pack ? kernels::prefill_packed_weight_bytes(n_out, K)
+                               : (size_t)n_out * K;
+    const size_t sbytes = (size_t)n_out * sizeof(float);
+    CachedI8 c{nullptr, nullptr, pack};
+    if (wcache_alloc(c, qbytes, sbytes)) {
+        // The pack is a pure reshuffle on top of the same row-major bytes.
+        signed char* dst = pack ? i8s : c.q;
+        build_i8_rows(W, wtype, dst, c.s, n_out, K, bfs, st);
+        if (pack) kernels::launch_prefill_pack_weight_i8(dst, c.q, n_out, K, st);
+        wcache_commit(c, qbytes + sbytes, st);
+    }
+    auto ins = g_wc_i8.emplace(W, c);   // cache the failure too, so it is not retried every call
+    return ins.first->second.q ? &ins.first->second : nullptr;
+}
+
+// Resident interleaved gate|up weight (dst row 2j = gate row j, 2j+1 = up row j) in fragment order,
+// so one GEMM can produce silu(gate)*up with the pair meeting in registers. Keyed by the gate
+// pointer. Built one parity at a time, which keeps the row-major staging at one weight's worth.
+// Returns null if it does not fit; the caller then runs the two separate projections as before.
+const CachedI8* wcache_gate_up_get(const void* Wg, int gtype, const void* Wu, int utype,
+                                   int n_half, int K, bf16* bfs, signed char* i8s, float* ss,
+                                   cudaStream_t st) {
+    auto it = g_wc_gu.find(Wg);
+    if (it != g_wc_gu.end()) return it->second.q ? &it->second : nullptr;
+
+    const size_t qbytes = kernels::prefill_packed_weight_bytes(2 * n_half, K);
+    const size_t sbytes = (size_t)2 * n_half * sizeof(float);
+    CachedI8 c{nullptr, nullptr, true};
+    if (wcache_alloc(c, qbytes, sbytes)) {
+        const void* W[2] = {Wg, Wu};
+        const int   t[2] = {gtype, utype};
+        for (int p = 0; p < 2; p++) {
+            build_i8_rows(W[p], t[p], i8s, ss, n_half, K, bfs, st);
+            kernels::launch_prefill_pack_gate_up_i8(i8s, c.q, p, n_half, K, st);
+            kernels::launch_prefill_interleave_scales(ss, c.s, p, n_half, st);
+        }
+        wcache_commit(c, qbytes + sbytes, st);
+    }
+    auto ins = g_wc_gu.emplace(Wg, c);
+    return ins.first->second.q ? &ins.first->second : nullptr;
+}
+
+// Resident bf16 dequant, for the tiny per-v-head gate weights (ssm_alpha/ssm_beta) that stay on the
+// bf16 path. Each is only n_out*K values, but dequantizing them per call launches a single-block deq
+// kernel dozens of times per prefill.
+const void* wcache_bf16_get(const void* W, int wtype, int n_out, int K, cudaStream_t st) {
+    if (wtype == 0) return W;   // already bf16 dense (e.g. Qwen3.6 ssm_alpha/beta) -- W is resident
+    auto it = g_wc_bf16.find(W);
+    if (it != g_wc_bf16.end()) return it->second;
+
+    const size_t bytes = (size_t)n_out * K * sizeof(bf16);
+    void* p = nullptr;
+    if (!wcache_can_alloc(bytes) || cudaMalloc(&p, bytes) != cudaSuccess) {
+        p = nullptr;
+    } else {
+        kernels::launch_gguf_dequant(wtype, W, p, (long)n_out * K, st);
+        if (cudaStreamSynchronize(st) == cudaSuccess) g_wc_bytes += bytes;
+        else { cudaFree(p); p = nullptr; }
+    }
+    g_wc_bf16.emplace(W, p);
+    return p;
+}
 } // namespace
 
 int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n) {
@@ -158,15 +317,32 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // unless SPARKINFER_PREFILL_I8_ATTN=0. GDN projections always stay bf16 above bf16_minctx.
     const char* _pi8attn = getenv("SPARKINFER_PREFILL_I8_ATTN");
     bool use_i8_attn = long_bf16 && (!_pi8attn || _pi8attn[0] != '0');
+    // Resident weight cache (see wcache_* above): keep each weight's converted int8/bf16 form across
+    // calls instead of re-deriving it every prefill. Packed entries also emit tensor-core fragment
+    // order. Enabled by default; SPARKINFER_PREFILL_WCACHE=0 restores the per-call path. Only the
+    // int8 projections (use_i8, the <=96k dense regime) take the packed path.
+    static const int wcache = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_WCACHE");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
     Arena a8;
     // A_i8 holds the quantized activation. Dense full-i8: non-FFN projs quantize N rows x K(<=H);
     // chunked FFN quantizes at most FC rows x ffn. Long-ctx selective: N*H if attn-i8 else FC*ffn.
     // MoE: no chunked FFN; projections quantize N rows x maxAK.
     const bool need_i8 = use_i8 || use_i8_ffn || use_i8_attn;
-    const size_t a_i8_sz = moe ? (size_t)N * maxAK
-                               : ((use_i8 || use_i8_attn)
-                                  ? (((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn)
-                                  : (size_t)FC * ffn);
+    size_t a_i8_sz = moe ? (size_t)N * maxAK
+                         : ((use_i8 || use_i8_attn)
+                            ? (((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn)
+                            : (size_t)FC * ffn);
+    // The packed activation quantizer rounds the row count up to the mma tile, so its buffer is a
+    // touch larger; prefill_packed_activation_bytes(N, maxAK) upper-bounds every packed projection
+    // (maxAK is the widest proj input and N >= any chunk row count). The packed path can run on any
+    // int8 projection -- including the long-ctx full-attn Q/K/V/O that use_i8_attn re-enables -- so
+    // size for it whenever either int8 mode is live.
+    if ((use_i8 || use_i8_attn) && wcache) {
+        const size_t pk = kernels::prefill_packed_activation_bytes(N, maxAK);
+        if (pk > a_i8_sz) a_i8_sz = pk;
+    }
     const size_t sx_n = (use_i8 || use_i8_attn) ? (size_t)N : (size_t)FC;
     signed char* A_i8 = need_i8 ? a8.alloc<signed char>(a_i8_sz) : nullptr;
     signed char* W_i8 = need_i8 ? a8.alloc<signed char>(maxw) : nullptr;
@@ -255,11 +431,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
     pf_cu(cudaMemcpyAsync(d_ids, prompt_ids, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "prefill ids");
 
+    // Weights are constant, so their converted form is cached across calls (see wcache_* above). A
+    // different model in the same process drops the cache: weight pointers are only unique per model.
+    if (g_wc_model != s.w.embed_tokens) { wcache_reset(); g_wc_model = s.w.embed_tokens; }
+
     // Dequantize a native GGUF weight [n_out,K] to bf16 scratch; return a bf16 [n_out,K] ptr.
     auto dq = [&](const void* W, int wtype, int n_out, int K) -> const void* {
         if (wtype == 0) return W;   // already bf16 dense
         kernels::launch_gguf_dequant(wtype, W, wbuf, (long)n_out * K, st);
         return wbuf;
+    };
+    // int8 activation for a projection. The packed form emits mma A-operand order so the GEMM's A
+    // fragment is one contiguous load per mma; the row-major form feeds the stock int8 GEMM.
+    auto quant_act = [&](const bf16* A, int K, bool packed, int R) {
+        if (packed) kernels::launch_prefill_quantize_pack_a_i8(A, A_i8, sx, R, K, st);
+        else        kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st);
     };
     // C[N,n_out] = A[N,K] @ W^T  (W native quantized [n_out,K]).
     auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K, int rows = 0) {
@@ -269,13 +455,25 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         // sigmoid gates, where per-row int8 quant of a 32-wide weight costs more accuracy
         // than the negligible time it saves.
         if (use_i8 && n_out >= 128) {
-            kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st);
-            // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
-            if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
+            // Resident weight (fragment-packed when supported, else row-major); null -> per-call.
+            const CachedI8* cc = wcache ? wcache_i8_get(W, wtype, n_out, K, wbuf, W_i8, st) : nullptr;
+            if (cc && cc->packed) {
+                // Packed weight -> packed activation: both operands reach the mma as one load each.
+                quant_act(A, K, true, R);
+                kernels::launch_prefill_gemm_i8_packed(A_i8, cc->q, sx, cc->s, C, R, n_out, K, st);
+                return;
+            }
+            quant_act(A, K, false, R);
+            const signed char* Wq = W_i8;
+            const float*       Ws = sw;
+            if (cc) {                       // resident row-major weight (unpackable shape)
+                Wq = cc->q; Ws = cc->s;
+            } else if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
+                // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
                 const void* wb = dq(W, wtype, n_out, K);
                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
             }
-            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, R, n_out, K, st);
+            kernels::launch_prefill_gemm_i8(A_i8, Wq, sx, Ws, C, R, n_out, K, st);
         } else {
             // mma.sync bf16 GEMM only for dense-hybrid long prefill (the >96k int8→bf16 fallback).
             // MoE always stays on wmma: its top-k router turns tiny GEMM differences into expert
@@ -283,8 +481,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // Gate on full prompt length N (not chunk rows R): FFN is token-chunked to FC=32k for
             // VRAM, so R<=FC would otherwise keep the dominant gate/up/down GEMMs on wmma forever.
             const bool prefer_mma = !moe && N > bf16_minctx;
-            kernels::launch_prefill_gemm(A, dq(W, wtype, n_out, K), C, R, n_out, K, st, prefer_mma);
+            // Tiny gate weights (n_out < 128) stay on bf16; hold them resident to avoid a per-call
+            // single-block dequant. Larger bf16 GEMMs (the >96k fallback) use per-call scratch.
+            const void* Wb = nullptr;
+            if (wcache && n_out < 128) Wb = wcache_bf16_get(W, wtype, n_out, K, st);
+            if (!Wb) Wb = dq(W, wtype, n_out, K);
+            kernels::launch_prefill_gemm(A, Wb, C, R, n_out, K, st, prefer_mma);
         }
+    };
+
+    // Fused dense-FFN gate|up: H_out[rows,ffn] = silu(A @ Wgate^T) * (A @ Wup^T) in ONE GEMM off the
+    // resident interleaved gate|up weight -- gate_j and up_j land in the same lane's accumulator, so
+    // the elementwise SwiGLU pass and one of the two full-size gate/up writes both disappear.
+    // Bit-identical: both operands are rounded to bf16 before the silu, exactly as materializing
+    // ffg/ffu would. False when unavailable (MoE, or an unsupported shape) -> caller runs the
+    // gate/up/swiglu sequence. Dense only.
+    const bool gu_fuse = use_i8 && wcache && !moe && kernels::prefill_gate_up_fusion_supported(ffn, H);
+    auto ffn_fused = [&](const Qwen35LayerWeights& w, const bf16* A, bf16* H_out, int rows) -> bool {
+        if (!gu_fuse) return false;
+        const CachedI8* cc = wcache_gate_up_get(w.gate_q, w.gate_qtype, w.up_q, w.up_qtype,
+                                                ffn, H, wbuf, W_i8, sw, st);
+        if (!cc) return false;
+        kernels::launch_prefill_quantize_pack_a_i8(A, A_i8, sx, rows, H, st);
+        kernels::launch_prefill_gemm_i8_packed_swiglu(A_i8, cc->q, sx, cc->s, H_out, rows, ffn, H, st);
+        return true;
     };
 
     const int* btable = s.kv->block_table(s.seq_id);
@@ -373,9 +593,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wd_i8, sx, ffn_swd,
                                                     ao + (size_t)fo * H, fn, H, ffn, st);
                 } else {
-                    proj(hn_c, w.gate_q, w.gate_qtype, ffg, ffn, H, fn);
-                    proj(hn_c, w.up_q,   w.up_qtype,   ffu, ffn, H, fn);
-                    kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                    // One fused GEMM emits silu(gate)*up straight into ffg; fall back to the two
+                    // projections + elementwise SwiGLU when the interleaved weight is unavailable.
+                    if (!ffn_fused(w, hn_c, ffg, fn)) {
+                        proj(hn_c, w.gate_q, w.gate_qtype, ffg, ffn, H, fn);
+                        proj(hn_c, w.up_q,   w.up_qtype,   ffu, ffn, H, fn);
+                        kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                    }
                     proj(ffg, w.down_q, w.down_qtype, ao + (size_t)fo * H, H, ffn, fn);
                 }
             }


### PR DESCRIPTION
## Summary

Batched Qwythos prefill re-derives every weight's int8 form on **every call** and feeds the int8 GEMM row-major (16 bank-conflicted `LDS.32`/k-step). This keeps the converted weights resident, reshapes them once into `mma.sync` fragment order (conflict-free `LDS.64`, one 16 B load feeds two B operands), and folds SwiGLU into the FFN GEMM epilogue — **+19.8% prefill pp @4k, bit-identical, decode untouched**.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 291.51 |
| after (this PR) | 290.36 |

<!-- Decode is not the target; shown only to confirm non-regression (within run-to-run noise). -->

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 21095.48 |
| after prefill (this PR) | 25280.12 |

```text
# bench/scripts/bench.sh <Qwythos-Q4_K_M> --ctx 4096 --tokens 128   (RTX 5090 sm_120, CUDA 12.8)

########## BEFORE (main) ##########
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
decode tg    : 291.51 tok/s  (3.4 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 21095.48 tok/s  (ctx=4096, sequential KV fill)

########## AFTER (this PR) ##########
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
decode tg    : 290.36 tok/s  (3.4 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 25280.12 tok/s  (ctx=4096, sequential KV fill)

# +19.8% prefill pp @4k. Interleaved paired reps (n=14): +20.0% median, worst rep +19.8%.

# Correctness — bit-identical, not merely accurate:
#   qwen3_gguf_prefill_check <Qwythos> 512 32  ->  TOP1 0.7188 / KL 0.01131 / seed 261
#   identical on main and this PR (batched-vs-token-loop prefill parity metric unchanged).
#   ctest --test-dir build : 9/9 passed.
# Guard model (Qwen3.6-35B-A3B) untouched — decode 494->494 @128, 471.8->470.2 @4k;
#   prefill 12567->12571 @4k with byte-identical generation.
```

Scope is the Qwen3.5 dense-hybrid batched prefill. Qwen3.6 (MoE) keeps bf16 projections by default, so its prefill is unaffected (measured above). Escape hatches: `SPARKINFER_PREFILL_WCACHE=0`, `SPARKINFER_PREFILL_I8=0`; `PK_GROUP=1` reduces the rasterization to the identity map.