### PR TITLE
fix(eval): REJECT on any failed no-regression gate

### DIFF
--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -158,7 +158,6 @@ if [ "$EVAL_MODE" = "short" ]; then
   SELECTED_TPS="$TPS"; SELECTED_FRONTIER="$FRONTIER"; SELECTED_CTX=128
   SELECTED_CONTEXT_LABEL="128-context"; BEST_CONTEXT_LABEL="128-context"; SELECTED_LLAMA_REF="$LLAMA_128_BASELINE"
   SELECTED_GAIN=0; CONTEXT_GAINS_JSON='{}'; REGRESSION_LABELS_JSON='[]'
-  HAS_VERIFIED_CONTEXT_GAIN=false
   PREFILL_SELECTED_TPS=0; PREFILL_SELECTED_FRONTIER=0; PREFILL_SELECTED_CTX=0
   PREFILL_SELECTED_LABEL=""; PREFILL_SELECTED_LLAMA_REF=0; PREFILL_SELECTED_GAIN=0
   PREFILL_CONTEXT_GAINS_JSON='{}'
@@ -513,12 +512,6 @@ if "$EVAL_PREFILL" == "1":
 print("true" if all(x == "true" for x in decode + pp) else "false")
 PY
 )"
-  HAS_VERIFIED_CONTEXT_GAIN="$(python3 - <<PY
-decode_gain = float("$SELECTED_GAIN")
-pp_gain = float("$PREFILL_SELECTED_GAIN") if "$EVAL_PREFILL" == "1" else 0.0
-print("true" if decode_gain > 0.02 or pp_gain > 0.02 else "false")
-PY
-)"
 fi
 # M1: record the graphics clock the number was produced at — the reproducibility anchor. Equals the
 # pin target where -lgc is permitted (bare-metal/datacenter); on a restricted container (vast lacks
@@ -657,7 +650,9 @@ if "$EVAL_MODE" != "short":
 print(json.dumps(data, separators=(",", ":")))
 PY
 )"
-if [ "$EVAL_MODE" != "short" ] && [ "$ALL_GUARDS_PASS" != "true" ] && [ "$HAS_VERIFIED_CONTEXT_GAIN" != "true" ]; then
+# Any failed no-regression gate rejects — a gain at another context (e.g. +14% @64k pp)
+# must not excuse a collapse elsewhere (PR #562: 128k pp 287 vs main 17020 still scored L).
+if [ "$EVAL_MODE" != "short" ] && [ "$ALL_GUARDS_PASS" != "true" ]; then
   PROV="$PROV" python3 - <<PY
 import json, os
 tps=float("$SELECTED_TPS"); frontier=float("$SELECTED_FRONTIER"); guard=float("$GUARD_TPS")

--- a/bench/scripts/test_guard_reject.py
+++ b/bench/scripts/test_guard_reject.py
@@ -1,0 +1,30 @@
+"""No-regression gates: any failed guard rejects — gains elsewhere do not excuse it.
+
+Mirrors evaluate.sh: reject when EVAL_MODE != short and ALL_GUARDS_PASS != true.
+PR #562 scored eval:L with +13.6% @64k pp while 128k pp collapsed (287 vs 17020)
+because a verified mid-ctx gain previously skipped the REJECT path.
+"""
+import unittest
+
+
+def should_reject_for_guards(all_guards_pass: bool, eval_mode: str = "longctx") -> bool:
+    if eval_mode == "short":
+        return False
+    return not all_guards_pass
+
+
+class GuardRejectTests(unittest.TestCase):
+    def test_pr562_128k_pp_fail_with_64k_gain_rejects(self):
+        # Score path had HAS_VERIFIED_CONTEXT_GAIN from 64k pp +13.6%; 128k pp failed.
+        all_guards_pass = False  # guard_128k_pp_pass == false
+        self.assertTrue(should_reject_for_guards(all_guards_pass))
+
+    def test_all_guards_pass_does_not_reject(self):
+        self.assertFalse(should_reject_for_guards(True))
+
+    def test_short_mode_skips_guard_reject(self):
+        self.assertFalse(should_reject_for_guards(False, eval_mode="short"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/miner-guide.md
+++ b/docs/miner-guide.md
@@ -54,8 +54,9 @@ Do not trade accuracy for speed. Accuracy is part of the benchmark.
 
 ## Regression Labels
 
-A PR can improve one context and regress another. The bot makes this explicit
-with context-specific labels:
+Any guarded context that regresses fails the no-regression gate — a gain at
+another context does **not** excuse it. The bot still annotates which contexts
+regressed:
 
 | label | meaning |
 |---|---|
@@ -64,9 +65,9 @@ with context-specific labels:
 | `regression-4k` | 4k-context decode regressed |
 | `regression-16k` | 16k-context decode regressed |
 | `regression-32k` | 32k-context decode regressed |
+| `regression-*-pp` | prefill pp at that context regressed |
 
-If no context improves by at least 2% and any guarded context regresses, the PR
-is rejected and may be auto-closed.
+If any guarded context regresses, the PR is `eval:REJECT`.
 
 ## Speed Labels
 


### PR DESCRIPTION
## Summary
- Remove the `HAS_VERIFIED_CONTEXT_GAIN` escape hatch in `evaluate.sh` so **any** failed decode/prefill no-regression gate yields `eval:REJECT`.
- Fixes the PR #562 false-positive: +13.6% @64k pp still scored `L` while 128k pp collapsed (287 vs main ~17020).
- Update miner-guide regression policy; add a regression unit test.

## Test plan
- [x] `python3 -m unittest bench.scripts.test_guard_reject -v`
- [x] `bash -n bench/scripts/evaluate.sh`
- [ ] After merge, restart eval bot so the next round uses the hardened harness