### PR TITLE
perf(qwen36): coalesce live MoE dequant + fused gate/up (+11% pp @512)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe.cu
@@ -84,6 +84,29 @@ __global__ void pfm_scatter_kernel(const int* __restrict__ expert_ids,
     pair_w[slot]   = expert_weights[p];
 }
 
+// Device-side tilemap for one expert group [e_base, e_base+n_in). Replaces the host
+// D2H counts + H2D tilemap sync in the short-N L2-serial path so dequant can be
+// pipelined on a side stream without stalling the main GEMM stream.
+__global__ void pfm_group_tilemap_kernel(const int* __restrict__ counts,
+                                         int* __restrict__ tilemap, int* __restrict__ d_ntiles,
+                                         int e_base, int n_in, int bm, int max_tiles) {
+    if (threadIdx.x != 0) return;
+    int nt = 0;
+    for (int le = 0; le < n_in; le++) {
+        const int e = e_base + le;
+        const int cnt = counts[e];
+        if (cnt <= 0) continue;
+        const int tiles = (cnt + bm - 1) / bm;
+        for (int mt = 0; mt < tiles; mt++) {
+            if (nt >= max_tiles) break;
+            tilemap[2 * nt] = e;
+            tilemap[2 * nt + 1] = mt;
+            nt++;
+        }
+    }
+    d_ntiles[0] = nt;
+}
+
 // ---- grouped int8 GEMM over expert-partitioned pair tiles ----
 #define PM_BN 128
 #define PM_BK 32
@@ -687,6 +710,13 @@ void launch_pfm_bucket_pairs_bm(const int* expert_ids, const float* expert_weigh
     const int P = n_tokens * top_k;
     pfm_scatter_kernel<<<(P + 255) / 256, 256, 0, stream>>>(
         expert_ids, expert_weights, offsets, cursors, pair_tok, pair_w, P, top_k);
+}
+
+void launch_pfm_group_tilemap(const int* counts, int* tilemap, int* d_ntiles,
+                              int e_base, int n_in, int bm, int max_tiles,
+                              cudaStream_t stream) {
+    pfm_group_tilemap_kernel<<<1, 1, 0, stream>>>(counts, tilemap, d_ntiles,
+                                                  e_base, n_in, bm, max_tiles);
 }
 
 void launch_pfm_moe_gemm_i8(const signed char* A_i8, const float* sx,

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -307,6 +307,47 @@ bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q,
     return true;
 }
 
+bool launch_gguf_dequant_rows_i8_pair(int ggml_type,
+                                      const void* src0, signed char* q0, float* scale0,
+                                      const void* src1, signed char* q1, float* scale1,
+                                      int rows, int cols, cudaStream_t stream) {
+    if (launch_gguf_dequant_rows_i8_fast_pair(ggml_type, src0, q0, scale0, src1, q1, scale1,
+                                              rows, cols, stream))
+        return true;
+    // Fallback: two single launches (still correct).
+    if (!launch_gguf_dequant_rows_i8(ggml_type, src0, q0, scale0, rows, cols, stream)) return false;
+    if (!launch_gguf_dequant_rows_i8(ggml_type, src1, q1, scale1, rows, cols, stream)) return false;
+    return true;
+}
+
+bool launch_gguf_dequant_rows_i8_gather(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream) {
+    return launch_gguf_dequant_rows_i8_fast_gather(
+        ggml_type, src0, q0, scale0, live_le, n_live, rows_per_expert, cols, expert_bytes, stream);
+}
+
+bool launch_gguf_dequant_rows_i8_gather_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream) {
+    if (launch_gguf_dequant_rows_i8_fast_gather_pair(
+            ggml_type, src0, q0, scale0, src1, q1, scale1, live_le, n_live, rows_per_expert, cols,
+            expert_bytes0, expert_bytes1, stream))
+        return true;
+    // Fallback: two single gathers.
+    if (!launch_gguf_dequant_rows_i8_gather(ggml_type, src0, q0, scale0, live_le, n_live,
+                                            rows_per_expert, cols, expert_bytes0, stream))
+        return false;
+    if (!launch_gguf_dequant_rows_i8_gather(ggml_type, src1, q1, scale1, live_le, n_live,
+                                            rows_per_expert, cols, expert_bytes1, stream))
+        return false;
+    return true;
+}
+
 void launch_transpose_bf16(const void* src, void* dst, int rows, int cols, cudaStream_t stream) {
     long n = (long)rows*cols; const int T=256;
     transpose2d_kernel<<<(n+T-1)/T,T,0,stream>>>(reinterpret_cast<const __nv_bfloat16*>(src), reinterpret_cast<__nv_bfloat16*>(dst), rows, cols);

--- a/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
+++ b/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
@@ -147,6 +147,258 @@ bool dispatch(const unsigned char* s, signed char* q, float* scale, int rows, in
     return true;
 }
 
+// Dual-tensor: grid = 2*rows. which = blockIdx.x / rows selects src/dst.
+template <int QT, int NG>
+__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_pair_kernel(
+        const unsigned char* __restrict__ src0, signed char* __restrict__ q0, float* __restrict__ scale0,
+        const unsigned char* __restrict__ src1, signed char* __restrict__ q1, float* __restrict__ scale1,
+        int rows, int cols) {
+    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
+    const int which = (int)(blockIdx.x / (unsigned)rows);
+    const int row = (int)(blockIdx.x - (unsigned)which * (unsigned)rows);
+    const unsigned char* src = which ? src1 : src0;
+    signed char* q = which ? q1 : q0;
+    float* scale = which ? scale1 : scale0;
+
+    const int t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const unsigned char* rbase = src + (size_t)row * nsb * BS;
+
+    float v[NG][DQR_VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            const unsigned char* blk = rbase + (size_t)(base >> 8) * BS;
+            const int off = base & 255;
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) {
+                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                amax = fmaxf(amax, fabsf(v[g][i]));
+            }
+        }
+    }
+
+    __shared__ float swarp[DQR_BLOCK / 32];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
+        if (t == 0) swarp[0] = w;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) scale[row] = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    signed char* qrow = q + (size_t)row * cols;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            signed char o[DQR_VEC];
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) o[i] = (signed char)(int)roundf(v[g][i] * inv);
+            *reinterpret_cast<unsigned*>(&qrow[base]) = *reinterpret_cast<const unsigned*>(o);
+        }
+    }
+}
+
+template <int QT>
+bool dispatch_pair(const unsigned char* s0, signed char* q0, float* sc0,
+                   const unsigned char* s1, signed char* q1, float* sc1,
+                   int rows, int cols, cudaStream_t stream) {
+    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
+    const int grid = 2 * rows;
+    if (ng <= 4)
+        deq_rows_i8_vec_pair_kernel<QT, 4><<<grid, DQR_BLOCK, 0, stream>>>(s0, q0, sc0, s1, q1, sc1, rows, cols);
+    else if (ng <= 8)
+        deq_rows_i8_vec_pair_kernel<QT, 8><<<grid, DQR_BLOCK, 0, stream>>>(s0, q0, sc0, s1, q1, sc1, rows, cols);
+    else if (ng <= 12)
+        deq_rows_i8_vec_pair_kernel<QT, 12><<<grid, DQR_BLOCK, 0, stream>>>(s0, q0, sc0, s1, q1, sc1, rows, cols);
+    else return false;
+    return true;
+}
+
+// Sparse gather: blockIdx.x = live_i * rows_per_expert + row_in_expert.
+template <int QT, int NG>
+__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_gather_kernel(
+        const unsigned char* __restrict__ src0, signed char* __restrict__ q0,
+        float* __restrict__ scale0, const int* __restrict__ live_le,
+        int rows_per_expert, int cols, size_t expert_bytes) {
+    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
+    const int live_i = (int)(blockIdx.x / (unsigned)rows_per_expert);
+    const int row_in = (int)(blockIdx.x - (unsigned)live_i * (unsigned)rows_per_expert);
+    const int le = live_le[live_i];
+    const int t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const size_t row_bytes = (size_t)nsb * (size_t)BS;
+    const unsigned char* rbase = src0 + (size_t)le * expert_bytes + (size_t)row_in * row_bytes;
+    float* scale = scale0 + (size_t)le * (size_t)rows_per_expert + (size_t)row_in;
+    signed char* qrow = q0 + ((size_t)le * (size_t)rows_per_expert + (size_t)row_in) * (size_t)cols;
+
+    float v[NG][DQR_VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            const unsigned char* blk = rbase + (size_t)(base >> 8) * BS;
+            const int off = base & 255;
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) {
+                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                amax = fmaxf(amax, fabsf(v[g][i]));
+            }
+        }
+    }
+
+    __shared__ float swarp[DQR_BLOCK / 32];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
+        if (t == 0) swarp[0] = w;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) *scale = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            signed char o[DQR_VEC];
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) o[i] = (signed char)(int)roundf(v[g][i] * inv);
+            *reinterpret_cast<unsigned*>(&qrow[base]) = *reinterpret_cast<const unsigned*>(o);
+        }
+    }
+}
+
+template <int QT, int NG>
+__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_gather_pair_kernel(
+        const unsigned char* __restrict__ src0, signed char* __restrict__ q0, float* __restrict__ scale0,
+        const unsigned char* __restrict__ src1, signed char* __restrict__ q1, float* __restrict__ scale1,
+        const int* __restrict__ live_le, int n_rows, int rows_per_expert, int cols,
+        size_t expert_bytes0, size_t expert_bytes1) {
+    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
+    const int which = (int)(blockIdx.x / (unsigned)n_rows);
+    const int flat = (int)(blockIdx.x - (unsigned)which * (unsigned)n_rows);
+    const int live_i = flat / rows_per_expert;
+    const int row_in = flat - live_i * rows_per_expert;
+    const int le = live_le[live_i];
+    const int t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const size_t row_bytes = (size_t)nsb * (size_t)BS;
+    const unsigned char* src = which ? src1 : src0;
+    const size_t expert_bytes = which ? expert_bytes1 : expert_bytes0;
+    signed char* q0b = which ? q1 : q0;
+    float* scale0b = which ? scale1 : scale0;
+    const unsigned char* rbase = src + (size_t)le * expert_bytes + (size_t)row_in * row_bytes;
+    float* scale = scale0b + (size_t)le * (size_t)rows_per_expert + (size_t)row_in;
+    signed char* qrow = q0b + ((size_t)le * (size_t)rows_per_expert + (size_t)row_in) * (size_t)cols;
+
+    float v[NG][DQR_VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            const unsigned char* blk = rbase + (size_t)(base >> 8) * BS;
+            const int off = base & 255;
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) {
+                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                amax = fmaxf(amax, fabsf(v[g][i]));
+            }
+        }
+    }
+
+    __shared__ float swarp[DQR_BLOCK / 32];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
+        if (t == 0) swarp[0] = w;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) *scale = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            signed char o[DQR_VEC];
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) o[i] = (signed char)(int)roundf(v[g][i] * inv);
+            *reinterpret_cast<unsigned*>(&qrow[base]) = *reinterpret_cast<const unsigned*>(o);
+        }
+    }
+}
+
+template <int QT>
+bool dispatch_gather(const unsigned char* src0, signed char* q0, float* scale0,
+                     const int* live_le, int n_live, int rows_per_expert, int cols,
+                     size_t expert_bytes, cudaStream_t stream) {
+    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
+    const int grid = n_live * rows_per_expert;
+    if (ng <= 4)
+        deq_rows_i8_vec_gather_kernel<QT, 4><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, live_le, rows_per_expert, cols, expert_bytes);
+    else if (ng <= 8)
+        deq_rows_i8_vec_gather_kernel<QT, 8><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, live_le, rows_per_expert, cols, expert_bytes);
+    else if (ng <= 12)
+        deq_rows_i8_vec_gather_kernel<QT, 12><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, live_le, rows_per_expert, cols, expert_bytes);
+    else return false;
+    return true;
+}
+
+template <int QT>
+bool dispatch_gather_pair(const unsigned char* src0, signed char* q0, float* scale0,
+                          const unsigned char* src1, signed char* q1, float* scale1,
+                          const int* live_le, int n_live, int rows_per_expert, int cols,
+                          size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream) {
+    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
+    const int n_rows = n_live * rows_per_expert;
+    const int grid = 2 * n_rows;
+    if (ng <= 4)
+        deq_rows_i8_vec_gather_pair_kernel<QT, 4><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, src1, q1, scale1, live_le, n_rows, rows_per_expert, cols,
+            expert_bytes0, expert_bytes1);
+    else if (ng <= 8)
+        deq_rows_i8_vec_gather_pair_kernel<QT, 8><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, src1, q1, scale1, live_le, n_rows, rows_per_expert, cols,
+            expert_bytes0, expert_bytes1);
+    else if (ng <= 12)
+        deq_rows_i8_vec_gather_pair_kernel<QT, 12><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, src1, q1, scale1, live_le, n_rows, rows_per_expert, cols,
+            expert_bytes0, expert_bytes1);
+    else return false;
+    return true;
+}
+
 }  // namespace
 
 bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed char* q, float* scale,
@@ -161,6 +413,71 @@ bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed cha
     auto s = reinterpret_cast<const unsigned char*>(src);
     if (ggml_type == DQR_Q4_K) return dispatch<DQR_Q4_K>(s, q, scale, rows, cols, stream);
     if (ggml_type == DQR_Q6_K) return dispatch<DQR_Q6_K>(s, q, scale, rows, cols, stream);
+    return false;
+}
+
+bool launch_gguf_dequant_rows_i8_fast_pair(int ggml_type,
+                                           const void* src0, signed char* q0, float* scale0,
+                                           const void* src1, signed char* q1, float* scale1,
+                                           int rows, int cols, cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || rows <= 0 || cols <= 0 || (cols % (DQR_BLOCK * DQR_VEC)) != 0) return false;
+    auto s0 = reinterpret_cast<const unsigned char*>(src0);
+    auto s1 = reinterpret_cast<const unsigned char*>(src1);
+    if (ggml_type == DQR_Q4_K)
+        return dispatch_pair<DQR_Q4_K>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
+    if (ggml_type == DQR_Q6_K)
+        return dispatch_pair<DQR_Q6_K>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
+    return false;
+}
+
+bool launch_gguf_dequant_rows_i8_fast_gather(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || !live_le || n_live <= 0 || rows_per_expert <= 0 || cols <= 0 ||
+        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        return false;
+    auto s = reinterpret_cast<const unsigned char*>(src0);
+    if (ggml_type == DQR_Q4_K)
+        return dispatch_gather<DQR_Q4_K>(s, q0, scale0, live_le, n_live, rows_per_expert, cols,
+                                         expert_bytes, stream);
+    if (ggml_type == DQR_Q6_K)
+        return dispatch_gather<DQR_Q6_K>(s, q0, scale0, live_le, n_live, rows_per_expert, cols,
+                                         expert_bytes, stream);
+    return false;
+}
+
+bool launch_gguf_dequant_rows_i8_fast_gather_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || !live_le || n_live <= 0 || rows_per_expert <= 0 || cols <= 0 ||
+        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        return false;
+    auto s0 = reinterpret_cast<const unsigned char*>(src0);
+    auto s1 = reinterpret_cast<const unsigned char*>(src1);
+    if (ggml_type == DQR_Q4_K)
+        return dispatch_gather_pair<DQR_Q4_K>(s0, q0, scale0, s1, q1, scale1, live_le, n_live,
+                                              rows_per_expert, cols, expert_bytes0, expert_bytes1,
+                                              stream);
+    if (ggml_type == DQR_Q6_K)
+        return dispatch_gather_pair<DQR_Q6_K>(s0, q0, scale0, s1, q1, scale1, live_le, n_live,
+                                              rows_per_expert, cols, expert_bytes0, expert_bytes1,
+                                              stream);
     return false;
 }
 

--- a/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
+++ b/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
@@ -30,5 +30,28 @@ namespace kernels {
 bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed char* q, float* scale,
                                       int rows, int cols, cudaStream_t stream = nullptr);
 
+// One-grid gate+up (or any two same-type tensors): blockIdx.x < rows → tensor0, else tensor1.
+// Same bit-identical decode as the single-tensor fast path. Used to fill SMs on one stream
+// without a second CUDA stream (multi-stream MoE prefill poisons decode graphs on this runtime).
+bool launch_gguf_dequant_rows_i8_fast_pair(int ggml_type,
+                                           const void* src0, signed char* q0, float* scale0,
+                                           const void* src1, signed char* q1, float* scale1,
+                                           int rows, int cols, cudaStream_t stream = nullptr);
+
+// Sparse MoE: dequant only live experts listed in live_le[n_live] (group-local indices).
+// src0/q0/scale0 are group bases (expert 0 of the group). expert_bytes = rows_per_expert * row_bytes.
+// One grid of n_live * rows_per_expert blocks — avoids thousands of tiny contiguous launches.
+bool launch_gguf_dequant_rows_i8_fast_gather(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream = nullptr);
+
+bool launch_gguf_dequant_rows_i8_fast_gather_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream = nullptr);
+
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_moe.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe.h
@@ -41,6 +41,12 @@ void launch_pfm_bucket_pairs_bm(const int* expert_ids, const float* expert_weigh
                                 int n_tokens, int n_experts, int top_k, int bm,
                                 cudaStream_t stream);
 
+// Build tilemap + d_ntiles for experts [e_base, e_base+n_in) from device counts.
+// Used by the short-N L2-serial / dual-stream path to avoid D2H counts sync.
+void launch_pfm_group_tilemap(const int* counts, int* tilemap, int* d_ntiles,
+                              int e_base, int n_in, int bm, int max_tiles,
+                              cudaStream_t stream);
+
 // Grouped int8 GEMM over expert-partitioned pair tiles (BM=128, BN=128, BK=32, 8 warps).
 //   A_i8/sx: per-row int8 activations + scales. A_INDIRECT: A row for pair p is
 //   A_i8[pair_tok[p]*K ..] (gate/up: activations are per TOKEN); else A rows are the

--- a/kernels/include/sparkinfer/kernels/quant.h
+++ b/kernels/include/sparkinfer/kernels/quant.h
@@ -34,6 +34,25 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
 bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q, float* scale,
                                  int rows, int cols, cudaStream_t stream = nullptr);
 
+// Dual-tensor variant (same ggml_type). Falls back to two single launches if unsupported.
+bool launch_gguf_dequant_rows_i8_pair(int ggml_type,
+                                      const void* src0, signed char* q0, float* scale0,
+                                      const void* src1, signed char* q1, float* scale1,
+                                      int rows, int cols, cudaStream_t stream = nullptr);
+
+// Live-expert gather (see dequant_rows_i8_fast.h). Returns false if unsupported.
+bool launch_gguf_dequant_rows_i8_gather(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream = nullptr);
+
+bool launch_gguf_dequant_rows_i8_gather_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* live_le, int n_live, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream = nullptr);
+
 // bf16 transposes used to relayout GGUF [out,in] -> our [in,out].
 void launch_transpose_bf16(const void* src, void* dst, int rows, int cols,
                            cudaStream_t stream = nullptr);          // [rows,cols]->[cols,rows]

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1365,7 +1365,8 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
     auto it = s.sessions.find(s.active_seq_id);
     float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
     bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
-    Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.active_seq_id, lin_state, lin_conv,
+    Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
+                          lin_state, lin_conv,
                           s.logits, s.d_out_id, s.h_out_id, s.gguf,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim };
     return prefill_batched_run(ctx, prompt_ids, n);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -262,22 +262,35 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (g > 64) g = 64;
         return g;
     }();
-    // Dual-stream MoE aids (created when serial path is live):
-    //   - aux stream: H2D tilemap || dequant overlap (always on for serial)
-    //   - PIPE=1: also ping-pong dequant of group i+1 while GEMMing i (2 weight slots).
-    // SPARKINFER_PREFILL_MOE_PIPE=1 enables weight ping-pong. Default OFF until decode-safe.
+    // Optional dual-stream weight ping-pong (env). Default OFF.
     const bool moe_pipe = [&]{
         if (!moe_serial) return false;
         const char* e = getenv("SPARKINFER_PREFILL_MOE_PIPE");
         return e && e[0] == '1';
     }();
     const int moe_slots = (moe_serial && moe_pipe) ? 2 : 1;
+    // Opt-in MoE dequant overlap on stream_k/v. Default OFF: side-stream ops that write
+    // ≳8KB permanently regress subsequent decode (~0.92×). SPARKINFER_PREFILL_MOE_OVERLAP=1
+    // for experiments only.
+    const bool moe_overlap = [&]{
+        if (!moe_serial || !s.stream_k || !s.stream_v) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_OVERLAP");
+        return e && e[0] == '1';
+    }();
+    // Hide shared-gate scalar behind MoE on stream_k. Default OFF: even a tiny side-stream
+    // write + WaitEvent onto s.stream permanently slows decode graph replay (~0.92×).
+    // SPARKINFER_PREFILL_HIDE_SG=1 for experiments only.
+    const bool moe_hide_sg = [&]{
+        if (!moe_serial || moe_overlap || !s.stream_k) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_HIDE_SG");
+        return e && e[0] == '1';
+    }();
     Arena am;
     signed char *Wg_i8 = nullptr, *Wu_i8 = nullptr, *Wd_i8 = nullptr, *h_i8 = nullptr, *mA_i8 = nullptr;
     float *swg = nullptr, *swu = nullptr, *swd = nullptr, *sh = nullptr, *msx = nullptr;
     float *mlogits = nullptr, *mweights = nullptr, *pair_w = nullptr, *routed_f32 = nullptr, *dw = nullptr;
     int *mids = nullptr, *mcounts = nullptr, *moffsets = nullptr, *mcursors = nullptr;
-    int *pair_tok = nullptr, *tilemap = nullptr, *d_ntiles = nullptr;
+    int *pair_tok = nullptr, *tilemap = nullptr, *d_ntiles = nullptr, *d_live_le = nullptr;
     bf16 *hg = nullptr, *hu = nullptr, *hh = nullptr, *sfg = nullptr, *sfu = nullptr, *sfh = nullptr;
     if (moe) {
         if (!moe_fused) {
@@ -298,9 +311,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         mcursors = am.alloc<int>(E);
         pair_tok = am.alloc<int>((size_t)P);
         pair_w = am.alloc<float>((size_t)P);
-        // Serial: dual tilemap buffers so H2D of group i+1 overlaps GEMM of i.
+        // Serial: packed tilemaps for all groups live in this buffer ([tm...][ntiles...]).
         tilemap = am.alloc<int>((size_t)2 * 2 * max_tiles);
         d_ntiles = am.alloc<int>(2);
+        if (moe_serial) d_live_le = am.alloc<int>(E > 0 ? E : 256);
         hg = am.alloc<bf16>((size_t)P * mffn);
         hu = am.alloc<bf16>((size_t)P * mffn);
         hh = am.alloc<bf16>((size_t)P * mffn);
@@ -396,23 +410,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     kernels::launch_embedding(d_ids, s.w.embed_tokens, x, N, H, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, eps, st);
 
-    // MoE aux stream: H2D tilemap overlaps dequant; optional ping-pong when PIPE=1.
-    // Created once for all layers. Full device sync before destroy so decode isn't poisoned.
-    cudaStream_t moe_st_aux = nullptr;
-    cudaEvent_t moe_ev_h2d{}, moe_ev_gemm[2]{}, moe_ev_dq[2]{}, moe_ev_done[2]{}, moe_ev_ready{};
-    if (moe_serial) {
-        pf_cu(cudaStreamCreateWithFlags(&moe_st_aux, cudaStreamNonBlocking), "moe aux stream");
-        pf_cu(cudaEventCreateWithFlags(&moe_ev_h2d, cudaEventDisableTiming), "moe ev_h2d");
-        pf_cu(cudaEventCreateWithFlags(&moe_ev_gemm[0], cudaEventDisableTiming), "moe ev_gemm0");
-        pf_cu(cudaEventCreateWithFlags(&moe_ev_gemm[1], cudaEventDisableTiming), "moe ev_gemm1");
+    // MoE aux events: overlap path and/or tiny shared-gate hide on stream_k.
+    cudaEvent_t moe_ev_up{}, moe_ev_down0{}, moe_ev_ready{}, moe_ev_sg{};
+    if (moe_overlap) {
+        pf_cu(cudaEventCreateWithFlags(&moe_ev_up, cudaEventDisableTiming), "moe ev_up");
+        pf_cu(cudaEventCreateWithFlags(&moe_ev_down0, cudaEventDisableTiming), "moe ev_down0");
         pf_cu(cudaEventCreateWithFlags(&moe_ev_ready, cudaEventDisableTiming), "moe ev_ready");
-        if (moe_pipe) {
-            for (int sidx = 0; sidx < moe_slots; sidx++) {
-                pf_cu(cudaEventCreateWithFlags(&moe_ev_dq[sidx], cudaEventDisableTiming), "moe ev_dq");
-                pf_cu(cudaEventCreateWithFlags(&moe_ev_done[sidx], cudaEventDisableTiming), "moe ev_done");
-            }
-        }
     }
+    if (moe_hide_sg)
+        pf_cu(cudaEventCreateWithFlags(&moe_ev_sg, cudaEventDisableTiming), "moe ev_sg");
 
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
@@ -507,6 +513,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_pfm_bucket_pairs_bm(mids, mweights, mcounts, moffsets, mcursors,
                                                 pair_tok, pair_w, tilemap, d_ntiles, N, E, topk, moe_bm, st);
             kernels::launch_prefill_quantize_rows_i8(hn, mA_i8, msx, N, H, st);
+            bool sg_hid = false;  // shared-gate scalar already on stream_k
             if (moe_fused) {
                 // On-the-fly Q→bf16 B staging — no full-expert int8 materialize (experimental).
                 kernels::launch_pfm_moe_gemm_qk(mA_i8, msx, w.gate_q, w.gate_qtype, pair_tok, pair_w,
@@ -522,43 +529,58 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                 moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
                                                 /*a_indirect=*/false, /*c_scatter=*/true, st);
             } else if (moe_serial) {
-                // Expert-group L2 path on top of main(#561):
+                // Expert-group L2 path on top of main(#561), tuned for N≈512:
                 //   - D2H counts, skip empty groups, exact-ntm GEMM grids
-                //   - hybrid sparse dequant when ≤50% of a group is live (big @128 win)
-                //   - dual tilemap buffers: H2D overlaps prior GEMM; tilemaps reused for down
-                //   - optional PIPE=1 weight ping-pong (usually slower — leave off)
+                //   - coalesce live-expert dequant runs (skip empty weight rows)
+                //   - one-shot packed tilemap H2D
+                //   - optional gate∥up on private streams (decode-unsafe; env)
                 auto q_row_bytes = [](int qtype, int cols) -> size_t {
                     const int bs = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
                     return (size_t)(cols >> 8) * (size_t)bs;
                 };
-                int h_counts[256];
+                int h_counts_stack[256];
+                int* h_counts = h_counts_stack;
+                // Pinned counts make the D2H sync cheaper (pageable stalls the GPU).
+                static thread_local int* pinned_counts = nullptr;
+                if (!pinned_counts) {
+                    if (cudaMallocHost(&pinned_counts, 256 * sizeof(int)) != cudaSuccess)
+                        pinned_counts = nullptr;
+                }
+                if (pinned_counts) h_counts = pinned_counts;
                 pf_cu(cudaMemcpyAsync(h_counts, mcounts, (size_t)E * sizeof(int),
                                       cudaMemcpyDeviceToHost, st), "moe counts D2H");
                 pf_cu(cudaStreamSynchronize(st), "moe serial sync");
-                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 const size_t g_rb = q_row_bytes(w.gate_qtype, H);
                 const size_t u_rb = q_row_bytes(w.up_qtype, H);
                 const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
                 const int G = moe_group;
-                const size_t slot_g = (size_t)G * (size_t)mffn * (size_t)H;
-                const size_t slot_gs = (size_t)G * (size_t)mffn;
-                const size_t slot_d = (size_t)G * (size_t)H * (size_t)mffn;
-                const size_t slot_ds = (size_t)G * (size_t)H;
 
-                struct ActiveGroup { int base, n_in, ntm; std::vector<int> tm; };
+                struct ActiveGroup {
+                    int base, n_in, ntm, tm_off, n_live, live_off;
+                    std::vector<int> tm;
+                    std::vector<int> live;
+                };
                 std::vector<ActiveGroup> active;
                 active.reserve((size_t)((E + G - 1) / G));
+                int tm_total = 0;
+                int live_total = 0;
                 for (int base = 0; base < E; base += G) {
                     const int n_in = (E - base < G) ? (E - base) : G;
                     ActiveGroup ag;
                     ag.base = base;
                     ag.n_in = n_in;
                     ag.ntm = 0;
+                    ag.tm_off = tm_total;
+                    ag.n_live = 0;
+                    ag.live_off = live_total;
                     ag.tm.reserve((size_t)2 * 64);
+                    ag.live.reserve((size_t)n_in);
                     for (int le = 0; le < n_in; le++) {
                         const int e = base + le;
                         const int cnt = h_counts[e];
                         if (cnt <= 0) continue;
+                        ag.live.push_back(le);
+                        ag.n_live++;
                         const int nt = (cnt + moe_bm - 1) / moe_bm;
                         for (int mt = 0; mt < nt; mt++) {
                             if (ag.ntm >= max_tiles) break;
@@ -567,185 +589,246 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                             ag.ntm++;
                         }
                     }
-                    if (ag.ntm > 0) active.push_back(std::move(ag));
+                    if (ag.ntm > 0) {
+                        tm_total += ag.ntm;
+                        live_total += ag.n_live;
+                        active.push_back(std::move(ag));
+                    }
                 }
                 const int n_active = (int)active.size();
 
-                auto slot_w = [&](int slot, signed char*& g, signed char*& u, signed char*& d,
-                                  float*& sg, float*& su, float*& sd) {
-                    g = Wg_i8 + (size_t)slot * slot_g;
-                    u = Wu_i8 + (size_t)slot * slot_g;
-                    d = Wd_i8 + (size_t)slot * slot_d;
-                    sg = swg + (size_t)slot * slot_gs;
-                    su = swu + (size_t)slot * slot_gs;
-                    sd = swd + (size_t)slot * slot_ds;
+                std::vector<int> h_tm_all((size_t)2 * std::max(tm_total, 1));
+                std::vector<int> h_nt_all((size_t)std::max(n_active, 1));
+                std::vector<int> h_live_all((size_t)std::max(live_total, 1));
+                for (int gi = 0; gi < n_active; gi++) {
+                    const ActiveGroup& ag = active[(size_t)gi];
+                    h_nt_all[(size_t)gi] = ag.ntm;
+                    for (int t = 0; t < ag.ntm; t++) {
+                        h_tm_all[(size_t)2 * (ag.tm_off + t)]     = ag.tm[(size_t)2 * t];
+                        h_tm_all[(size_t)2 * (ag.tm_off + t) + 1] = ag.tm[(size_t)2 * t + 1];
+                    }
+                    for (int i = 0; i < ag.n_live; i++)
+                        h_live_all[(size_t)ag.live_off + i] = ag.live[(size_t)i];
+                }
+                const bool pack_fit = (tm_total <= 2 * max_tiles) && (n_active <= 64) &&
+                                     (2 * tm_total + n_active <= 4 * max_tiles);
+
+                // Reuse decode stream_k (=sa) / stream_v (=sb) for MoE; host-join so s.stream
+                // never accumulates cross-stream WaitEvents from the group loop.
+                cudaStream_t sa = moe_overlap ? s.stream_k : st;
+                cudaStream_t sb = moe_overlap ? s.stream_v : st;
+                if (moe_overlap) {
+                    pf_cu(cudaEventRecord(moe_ev_ready, st), "moe fork");
+                    pf_cu(cudaStreamWaitEvent(sa, moe_ev_ready, 0), "moe sa wait");
+                    pf_cu(cudaStreamWaitEvent(sb, moe_ev_ready, 0), "moe sb wait");
+                }
+                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), sa), "routed zero");
+
+                int* d_nt_pack = nullptr;
+                if (pack_fit && n_active > 0) {
+                    d_nt_pack = tilemap + 2 * tm_total;
+                    pf_cu(cudaMemcpyAsync(tilemap, h_tm_all.data(),
+                                          (size_t)2 * tm_total * sizeof(int),
+                                          cudaMemcpyHostToDevice, sa), "moe all tm H2D");
+                    pf_cu(cudaMemcpyAsync(d_nt_pack, h_nt_all.data(),
+                                          (size_t)n_active * sizeof(int),
+                                          cudaMemcpyHostToDevice, sa), "moe all nt H2D");
+                }
+                // One-shot live-expert index upload (stable for all group gathers — no per-group race).
+                if (d_live_le && live_total > 0) {
+                    pf_cu(cudaMemcpyAsync(d_live_le, h_live_all.data(),
+                                          (size_t)live_total * sizeof(int),
+                                          cudaMemcpyHostToDevice, sa), "moe all live H2D");
+                }
+
+                auto dq_gateup = [&](const ActiveGroup& ag) {
+                    const int n_live = ag.n_live;
+                    if (n_live <= 0) return;
+                    const void* ge0 = (const char*)w.gate_q +
+                        (size_t)ag.base * (size_t)mffn * g_rb;
+                    const void* ue0 = (const char*)w.up_q +
+                        (size_t)ag.base * (size_t)mffn * u_rb;
+                    const size_t g_eb = (size_t)mffn * g_rb;
+                    const size_t u_eb = (size_t)mffn * u_rb;
+                    // Full group live + same type: one fused contiguous pair launch.
+                    if (n_live == ag.n_in && !moe_overlap && w.gate_qtype == w.up_qtype) {
+                        if (kernels::launch_gguf_dequant_rows_i8_pair(
+                                w.gate_qtype, ge0, Wg_i8, swg, ue0, Wu_i8, swu,
+                                ag.n_in * mffn, H, sa))
+                            return;
+                    }
+                    if (n_live == ag.n_in && !moe_overlap) {
+                        kernels::launch_gguf_dequant_rows_i8(
+                            w.gate_qtype, ge0, Wg_i8, swg, ag.n_in * mffn, H, sa);
+                        kernels::launch_gguf_dequant_rows_i8(
+                            w.up_qtype, ue0, Wu_i8, swu, ag.n_in * mffn, H, sa);
+                        return;
+                    }
+                    // Sparse: optional one-shot gather (SPARKINFER_PREFILL_MOE_GATHER=1).
+                    // Default OFF: gather still needs accuracy bake-off; coalesce+pair is the win.
+                    static const int use_gather = [] {
+                        const char* e = getenv("SPARKINFER_PREFILL_MOE_GATHER");
+                        return (e && e[0] == '1') ? 1 : 0;
+                    }();
+                    const int* d_live = d_live_le + ag.live_off;
+                    const int* h_live = ag.live.data();
+                    if (use_gather && !moe_overlap && w.gate_qtype == w.up_qtype && d_live_le &&
+                        kernels::launch_gguf_dequant_rows_i8_gather_pair(
+                            w.gate_qtype, ge0, Wg_i8, swg, ue0, Wu_i8, swu,
+                            d_live, n_live, mffn, H, g_eb, u_eb, sa))
+                        return;
+                    // Pair each contiguous live run (same-type gate+up) — big @512 win vs serial.
+                    if (!moe_overlap && w.gate_qtype == w.up_qtype) {
+                        int i = 0;
+                        while (i < n_live) {
+                            int le0 = h_live[i], run = 1;
+                            while (i + run < n_live && h_live[i + run] == le0 + run) run++;
+                            const void* ge = (const char*)ge0 + (size_t)le0 * g_eb;
+                            const void* ue = (const char*)ue0 + (size_t)le0 * u_eb;
+                            if (!kernels::launch_gguf_dequant_rows_i8_pair(
+                                    w.gate_qtype, ge, Wg_i8 + (size_t)le0 * mffn * H,
+                                    swg + (size_t)le0 * mffn,
+                                    ue, Wu_i8 + (size_t)le0 * mffn * H,
+                                    swu + (size_t)le0 * mffn, run * mffn, H, sa)) {
+                                kernels::launch_gguf_dequant_rows_i8(
+                                    w.gate_qtype, ge, Wg_i8 + (size_t)le0 * mffn * H,
+                                    swg + (size_t)le0 * mffn, run * mffn, H, sa);
+                                kernels::launch_gguf_dequant_rows_i8(
+                                    w.up_qtype, ue, Wu_i8 + (size_t)le0 * mffn * H,
+                                    swu + (size_t)le0 * mffn, run * mffn, H, sa);
+                            }
+                            i += run;
+                        }
+                        return;
+                    }
+                    auto dq_g = [&](int qtype, const void* src0, signed char* dst, float* sc,
+                                    size_t eb, cudaStream_t ds) {
+                        if (use_gather && d_live_le &&
+                            kernels::launch_gguf_dequant_rows_i8_gather(
+                                qtype, src0, dst, sc, d_live, n_live, mffn, H, eb, ds))
+                            return;
+                        int i = 0;
+                        while (i < n_live) {
+                            int le0 = h_live[i], run = 1;
+                            while (i + run < n_live && h_live[i + run] == le0 + run) run++;
+                            const void* src = (const char*)src0 + (size_t)le0 * eb;
+                            kernels::launch_gguf_dequant_rows_i8(
+                                qtype, src, dst + (size_t)le0 * mffn * H,
+                                sc + (size_t)le0 * mffn, run * mffn, H, ds);
+                            i += run;
+                        }
+                    };
+                    dq_g(w.gate_qtype, ge0, Wg_i8, swg, g_eb, sa);
+                    if (moe_overlap) {
+                        dq_g(w.up_qtype, ue0, Wu_i8, swu, u_eb, sb);
+                        pf_cu(cudaEventRecord(moe_ev_up, sb), "moe up done");
+                        pf_cu(cudaStreamWaitEvent(sa, moe_ev_up, 0), "moe sa wait up");
+                    } else {
+                        dq_g(w.up_qtype, ue0, Wu_i8, swu, u_eb, sa);
+                    }
+                };
+                auto dq_down = [&](const ActiveGroup& ag, cudaStream_t ds) {
+                    const int n_live = ag.n_live;
+                    if (n_live <= 0) return;
+                    const void* de0 = (const char*)w.down_q +
+                        (size_t)ag.base * (size_t)H * d_rb;
+                    const size_t d_eb = (size_t)H * d_rb;
+                    if (n_live == ag.n_in) {
+                        kernels::launch_gguf_dequant_rows_i8(
+                            w.down_qtype, de0, Wd_i8, swd, ag.n_in * H, mffn, ds);
+                        return;
+                    }
+                    const int* d_live = d_live_le + ag.live_off;
+                    const int* h_live = ag.live.data();
+                    static const int use_gather_dn = [] {
+                        const char* e = getenv("SPARKINFER_PREFILL_MOE_GATHER");
+                        return (e && e[0] == '1') ? 1 : 0;
+                    }();
+                    if (use_gather_dn && d_live_le &&
+                        kernels::launch_gguf_dequant_rows_i8_gather(
+                            w.down_qtype, de0, Wd_i8, swd, d_live, n_live, H, mffn, d_eb, ds))
+                        return;
+                    int i = 0;
+                    while (i < n_live) {
+                        int le0 = h_live[i], run = 1;
+                        while (i + run < n_live && h_live[i + run] == le0 + run) run++;
+                        const void* de = (const char*)de0 + (size_t)le0 * d_eb;
+                        kernels::launch_gguf_dequant_rows_i8(
+                            w.down_qtype, de, Wd_i8 + (size_t)le0 * H * mffn,
+                            swd + (size_t)le0 * H, run * H, mffn, ds);
+                        i += run;
+                    }
                 };
 
-                // Dual tilemap buffers: H2D into free buf while GEMM reads the other.
-                int tm_buf = 0;
-                bool tm_used[2] = {false, false};
-                auto upload_tm = [&](const ActiveGroup& ag) {
-                    if (tm_used[tm_buf])
-                        pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_gemm[tm_buf], 0),
-                              "moe h2d wait old buf");
-                    int* tm = tilemap + (size_t)tm_buf * 2 * max_tiles;
-                    int* nt = d_ntiles + tm_buf;
-                    pf_cu(cudaMemcpyAsync(tm, ag.tm.data(), (size_t)2 * ag.ntm * sizeof(int),
-                                          cudaMemcpyHostToDevice, moe_st_aux), "moe tm H2D");
-                    pf_cu(cudaMemcpyAsync(nt, &ag.ntm, sizeof(int),
-                                          cudaMemcpyHostToDevice, moe_st_aux), "moe ntm H2D");
-                    pf_cu(cudaEventRecord(moe_ev_h2d, moe_st_aux), "moe h2d done");
-                };
-                auto dequant_gateup = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
-                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
-                    (void)Wd_s; (void)swd_s;
-                    int n_live = 0;
-                    for (int le = 0; le < ag.n_in; le++)
-                        if (h_counts[ag.base + le] > 0) n_live++;
-                    // Sparse only when enough empties to beat one contiguous launch.
-                    if (n_live > 0 && n_live * 2 <= ag.n_in) {
-                        for (int le = 0; le < ag.n_in; le++) {
-                            const int e = ag.base + le;
-                            if (h_counts[e] <= 0) continue;
-                            const void* ge = (const char*)w.gate_q + (size_t)e * (size_t)mffn * g_rb;
-                            const void* ue = (const char*)w.up_q   + (size_t)e * (size_t)mffn * u_rb;
-                            kernels::launch_gguf_dequant_rows_i8(
-                                w.gate_qtype, ge, Wg_s + (size_t)le * mffn * H,
-                                swg_s + (size_t)le * mffn, mffn, H, s);
-                            kernels::launch_gguf_dequant_rows_i8(
-                                w.up_qtype, ue, Wu_s + (size_t)le * mffn * H,
-                                swu_s + (size_t)le * mffn, mffn, H, s);
-                        }
+                // Kick tiny shared-gate scalar on stream_k (≈2KB write) behind MoE.
+                // Only when gate_inp is already float — quantized dq() would trash MoE scratch.
+                if (moe_hide_sg && c.n_shared > 0 && w.shared_gate_inp &&
+                    !w.shared_gate_inp_type &&
+                    (w.shared_gate_q || w.shared_gate)) {
+                    kernels::launch_pfm_shared_gate(
+                        hn, w.shared_gate_inp, dw, N, H, s.stream_k);
+                    pf_cu(cudaEventRecord(moe_ev_sg, s.stream_k), "moe sg done");
+                    sg_hid = true;
+                }
+
+                for (int gi = 0; gi < n_active; gi++) {
+                    const ActiveGroup& ag = active[(size_t)gi];
+                    int* tm;
+                    int* nt;
+                    if (pack_fit) {
+                        tm = tilemap + 2 * ag.tm_off;
+                        nt = d_nt_pack + gi;
                     } else {
-                        const void* ge = (const char*)w.gate_q + (size_t)ag.base * (size_t)mffn * g_rb;
-                        const void* ue = (const char*)w.up_q   + (size_t)ag.base * (size_t)mffn * u_rb;
-                        kernels::launch_gguf_dequant_rows_i8(
-                            w.gate_qtype, ge, Wg_s, swg_s, ag.n_in * mffn, H, s);
-                        kernels::launch_gguf_dequant_rows_i8(
-                            w.up_qtype, ue, Wu_s, swu_s, ag.n_in * mffn, H, s);
+                        tm = tilemap;
+                        nt = d_ntiles;
+                        pf_cu(cudaMemcpyAsync(tm, ag.tm.data(),
+                                              (size_t)2 * ag.ntm * sizeof(int),
+                                              cudaMemcpyHostToDevice, sa), "moe tm H2D");
+                        pf_cu(cudaMemcpyAsync(nt, &ag.ntm, sizeof(int),
+                                              cudaMemcpyHostToDevice, sa), "moe ntm H2D");
                     }
-                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe gateup dq");
-                };
-                auto gemm_gateup = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
-                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
-                    (void)Wd_s; (void)swd_s;
-                    int* tm = tilemap + (size_t)tm_buf * 2 * max_tiles;
-                    int* nt = d_ntiles + tm_buf;
-                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, moe_ev_dq[slot], 0), "moe wait dq");
-                    pf_cu(cudaStreamWaitEvent(s, moe_ev_h2d, 0), "moe wait h2d");
+                    dq_gateup(ag);
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        mA_i8, msx, Wg_s, swg_s, pair_tok, pair_w, moffsets, tm, nt,
+                        mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets, tm, nt,
                         hg, nullptr, mffn, H, ag.ntm, moe_bm, ag.base,
-                        /*a_indirect=*/true, /*c_scatter=*/false, s);
+                        /*a_indirect=*/true, /*c_scatter=*/false, sa);
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        mA_i8, msx, Wu_s, swu_s, pair_tok, pair_w, moffsets, tm, nt,
-                        hu, nullptr, mffn, H, ag.ntm, moe_bm, ag.base, true, false, s);
-                    pf_cu(cudaEventRecord(moe_ev_gemm[tm_buf], s), "moe gemm done");
-                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_done[slot], s), "moe gateup done");
-                    tm_used[tm_buf] = true;
-                    tm_buf ^= 1;
-                };
-
-                if (moe_pipe && n_active > 0) {
-                    pf_cu(cudaEventRecord(moe_ev_ready, st), "moe ready");
-                    pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_ready, 0), "moe aux wait ready");
-                    dequant_gateup(0, active[0], moe_st_aux);
+                        mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets, tm, nt,
+                        hu, nullptr, mffn, H, ag.ntm, moe_bm, ag.base, true, false, sa);
                 }
+
+                // down0∥SwiGLU disabled: full-group down dequant on a side stream exceeds the
+                // ~4KB/op decode-poison threshold.
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, sa);
+                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, sa);
+
                 for (int gi = 0; gi < n_active; gi++) {
-                    const int slot = moe_pipe ? (gi & 1) : 0;
                     const ActiveGroup& ag = active[(size_t)gi];
-                    if (!moe_pipe) {
-                        upload_tm(ag);
-                        dequant_gateup(slot, ag, st);
-                        gemm_gateup(slot, ag, st);
+                    int* tm;
+                    int* nt;
+                    if (pack_fit) {
+                        tm = tilemap + 2 * ag.tm_off;
+                        nt = d_nt_pack + gi;
                     } else {
-                        upload_tm(ag);
-                        if (gi + 1 < n_active) {
-                            const int ns = (gi + 1) & 1;
-                            if (gi >= 1)
-                                pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_done[ns], 0),
-                                      "moe dq wait slot");
-                            dequant_gateup(ns, active[(size_t)gi + 1], moe_st_aux);
-                        }
-                        gemm_gateup(slot, ag, st);
+                        tm = tilemap;
+                        nt = d_ntiles;
+                        pf_cu(cudaMemcpyAsync(tm, ag.tm.data(),
+                                              (size_t)2 * ag.ntm * sizeof(int),
+                                              cudaMemcpyHostToDevice, sa), "moe down tm");
+                        pf_cu(cudaMemcpyAsync(nt, &ag.ntm, sizeof(int),
+                                              cudaMemcpyHostToDevice, sa), "moe down ntm");
                     }
-                }
-                if (moe_pipe && n_active > 0)
-                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_active - 1) & 1], 0), "moe gateup join");
-
-                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
-                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
-
-                auto dequant_down = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
-                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
-                    (void)Wg_s; (void)Wu_s; (void)swg_s; (void)swu_s;
-                    int n_live = 0;
-                    for (int le = 0; le < ag.n_in; le++)
-                        if (h_counts[ag.base + le] > 0) n_live++;
-                    if (n_live > 0 && n_live * 2 <= ag.n_in) {
-                        for (int le = 0; le < ag.n_in; le++) {
-                            const int e = ag.base + le;
-                            if (h_counts[e] <= 0) continue;
-                            const void* de = (const char*)w.down_q + (size_t)e * (size_t)H * d_rb;
-                            kernels::launch_gguf_dequant_rows_i8(
-                                w.down_qtype, de, Wd_s + (size_t)le * H * mffn,
-                                swd_s + (size_t)le * H, H, mffn, s);
-                        }
-                    } else {
-                        const void* de = (const char*)w.down_q + (size_t)ag.base * (size_t)H * d_rb;
-                        kernels::launch_gguf_dequant_rows_i8(
-                            w.down_qtype, de, Wd_s, swd_s, ag.n_in * H, mffn, s);
-                    }
-                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe down dq");
-                };
-                auto gemm_down = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
-                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
-                    (void)Wg_s; (void)Wu_s; (void)swg_s; (void)swu_s;
-                    int* tm = tilemap + (size_t)tm_buf * 2 * max_tiles;
-                    int* nt = d_ntiles + tm_buf;
-                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, moe_ev_dq[slot], 0), "moe down wait dq");
-                    pf_cu(cudaStreamWaitEvent(s, moe_ev_h2d, 0), "moe down wait h2d");
+                    dq_down(ag, sa);
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        h_i8, sh, Wd_s, swd_s, pair_tok, pair_w, moffsets, tm, nt,
+                        h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets, tm, nt,
                         nullptr, routed_f32, H, mffn, ag.ntm, moe_bm, ag.base,
-                        /*a_indirect=*/false, /*c_scatter=*/true, s);
-                    pf_cu(cudaEventRecord(moe_ev_gemm[tm_buf], s), "moe down gemm done");
-                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_done[slot], s), "moe down done");
-                    tm_used[tm_buf] = true;
-                    tm_buf ^= 1;
-                };
-
-                if (moe_pipe && n_active > 0) {
-                    pf_cu(cudaEventRecord(moe_ev_ready, st), "moe down ready");
-                    pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_ready, 0), "moe aux down ready");
-                    if (n_active > 1)
-                        pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_done[0], 0), "moe down slot0");
-                    dequant_down(0, active[0], moe_st_aux);
+                        /*a_indirect=*/false, /*c_scatter=*/true, sa);
                 }
-                for (int gi = 0; gi < n_active; gi++) {
-                    const int slot = moe_pipe ? (gi & 1) : 0;
-                    const ActiveGroup& ag = active[(size_t)gi];
-                    if (!moe_pipe) {
-                        upload_tm(ag);
-                        dequant_down(slot, ag, st);
-                        gemm_down(slot, ag, st);
-                    } else {
-                        upload_tm(ag);
-                        if (gi + 1 < n_active) {
-                            const int ns = (gi + 1) & 1;
-                            pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_done[ns], 0),
-                                  "moe down dq wait");
-                            dequant_down(ns, active[(size_t)gi + 1], moe_st_aux);
-                        }
-                        gemm_down(slot, ag, st);
-                    }
+                if (moe_overlap) {
+                    // Host-join private streams — do NOT cudaStreamWaitEvent onto s.stream
+                    // (cross-stream waits on the decode stream permanently slow graph replay).
+                    pf_cu(cudaStreamSynchronize(sa), "moe sa join");
                 }
-                if (moe_pipe && n_active > 0)
-                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_active - 1) & 1], 0), "moe down join");
             } else {
                 // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts).
                 kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
@@ -775,9 +858,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 const int sdt = w.shared_down_q ? w.shared_down_qtype : 0;
                 const bool has_gi = w.shared_gate_inp != nullptr;
                 if (has_gi) {
-                    const void* gi = w.shared_gate_inp_type
-                        ? dq(w.shared_gate_inp, w.shared_gate_inp_type, 1, H) : w.shared_gate_inp;
-                    kernels::launch_pfm_shared_gate(hn, gi, dw, N, H, st);
+                    if (sg_hid) {
+                        // Join tiny stream_k write before dw is consumed on st.
+                        pf_cu(cudaStreamWaitEvent(st, moe_ev_sg, 0), "moe wait sg");
+                    } else {
+                        const void* gi = w.shared_gate_inp_type
+                            ? dq(w.shared_gate_inp, w.shared_gate_inp_type, 1, H)
+                            : w.shared_gate_inp;
+                        kernels::launch_pfm_shared_gate(hn, gi, dw, N, H, st);
+                    }
                 }
                 const bool restore_i8_sh = use_i8;
                 if (moe_shared_i8) use_i8 = true;
@@ -797,21 +886,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
     }
 
-    if (moe_serial) {
-        // Drain aux work so a subsequent decode bench isn't scheduled against leftover cmds.
-        pf_cu(cudaStreamSynchronize(moe_st_aux), "moe aux sync");
-        if (moe_pipe) {
-            for (int sidx = 0; sidx < moe_slots; sidx++) {
-                cudaEventDestroy(moe_ev_dq[sidx]);
-                cudaEventDestroy(moe_ev_done[sidx]);
-            }
-        }
-        cudaEventDestroy(moe_ev_h2d);
-        cudaEventDestroy(moe_ev_gemm[0]);
-        cudaEventDestroy(moe_ev_gemm[1]);
+    if (moe_overlap) {
+        pf_cu(cudaStreamSynchronize(s.stream_k), "moe sk sync");
+        pf_cu(cudaStreamSynchronize(s.stream_v), "moe sv sync");
+        cudaEventDestroy(moe_ev_up);
+        cudaEventDestroy(moe_ev_down0);
         cudaEventDestroy(moe_ev_ready);
-        cudaStreamDestroy(moe_st_aux);
     }
+    if (moe_hide_sg)
+        cudaEventDestroy(moe_ev_sg);
 
     // Seed for the first decode step: argmax at the last prompt position (xn already = final norm).
     const bf16* xn_last = xn + (size_t)(N - 1) * H;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -262,6 +262,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (g > 64) g = 64;
         return g;
     }();
+    // Dual-stream: dequant group i+1 on a side stream while GEMMing group i (default ON
+    // with serial). SPARKINFER_PREFILL_MOE_PIPE=0 disables (single-stream + device tilemap).
+    const bool moe_pipe = [&]{
+        if (!moe_serial) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_PIPE");
+        if (e) return e[0] != '0';
+        return true;
+    }();
+    const int moe_slots = (moe_serial && moe_pipe) ? 2 : 1;
     Arena am;
     signed char *Wg_i8 = nullptr, *Wu_i8 = nullptr, *Wd_i8 = nullptr, *h_i8 = nullptr, *mA_i8 = nullptr;
     float *swg = nullptr, *swu = nullptr, *swd = nullptr, *sh = nullptr, *msx = nullptr;
@@ -271,8 +280,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16 *hg = nullptr, *hu = nullptr, *hh = nullptr, *sfg = nullptr, *sfu = nullptr, *sfh = nullptr;
     if (moe) {
         if (!moe_fused) {
-            // Serial groups: scratch for moe_group experts. Bulk: full E stack.
-            const int ew = moe_serial ? moe_group : E;
+            // Serial: moe_slots * moe_group experts (ping-pong when piped). Bulk: full E.
+            const int ew = moe_serial ? (moe_slots * moe_group) : E;
             Wg_i8 = am.alloc<signed char>((size_t)ew * mffn * H);
             Wu_i8 = am.alloc<signed char>((size_t)ew * mffn * H);
             Wd_i8 = am.alloc<signed char>((size_t)ew * H * mffn);
@@ -288,8 +297,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         mcursors = am.alloc<int>(E);
         pair_tok = am.alloc<int>((size_t)P);
         pair_w = am.alloc<float>((size_t)P);
-        tilemap = am.alloc<int>((size_t)2 * max_tiles);
-        d_ntiles = am.alloc<int>(1);
+        // Serial needs per-slot tilemaps for dual-stream; bulk uses one full map.
+        const int tm_cap = moe_serial
+            ? moe_slots * std::max((P + moe_bm - 1) / moe_bm + moe_group, 1)
+            : max_tiles;
+        tilemap = am.alloc<int>((size_t)2 * tm_cap);
+        d_ntiles = am.alloc<int>(moe_serial ? moe_slots : 1);
         hg = am.alloc<bf16>((size_t)P * mffn);
         hu = am.alloc<bf16>((size_t)P * mffn);
         hh = am.alloc<bf16>((size_t)P * mffn);
@@ -493,87 +506,141 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                 moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
                                                 /*a_indirect=*/false, /*c_scatter=*/true, st);
             } else if (moe_serial) {
-                // Expert-group L2 path: dequant G experts into scratch, one grouped GEMM per
-                // stage so the ~G*3 MB working set stays L2-hot (5090 L2 ≈ 96 MB).
+                // Expert-group L2 path + optional dual-stream pipe:
+                //   - device group tilemap (no D2H counts sync)
+                //   - PIPE=1: dequant group i+1 on side stream while GEMMing i
                 auto q_row_bytes = [](int qtype, int cols) -> size_t {
                     const int bs = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
                     return (size_t)(cols >> 8) * (size_t)bs;
                 };
-                int h_counts[256];
-                pf_cu(cudaMemcpyAsync(h_counts, mcounts, (size_t)E * sizeof(int),
-                                      cudaMemcpyDeviceToHost, st), "moe counts D2H");
-                pf_cu(cudaStreamSynchronize(st), "moe serial sync");
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 const size_t g_rb = q_row_bytes(w.gate_qtype, H);
                 const size_t u_rb = q_row_bytes(w.up_qtype, H);
                 const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
                 const int G = moe_group;
-                // Host tilemap for one group. Worst case: all P pairs land in this group →
-                // ceil(P/bm)+G tiles (fragmentation). Fixed 2*256 overflowed (~288 @N=512).
-                std::vector<int> h_tm((size_t)2 * std::max(max_tiles, 1));
-                for (int base = 0; base < E; base += G) {
-                    const int n_in = (E - base < G) ? (E - base) : G;
-                    int ntm = 0, any = 0;
-                    for (int le = 0; le < n_in; le++) {
-                        const int e = base + le;
-                        const int cnt = h_counts[e];
-                        if (cnt <= 0) continue;
-                        any = 1;
-                        const int nt = (cnt + moe_bm - 1) / moe_bm;
-                        for (int mt = 0; mt < nt; mt++) {
-                            if (ntm >= max_tiles) break;
-                            h_tm[(size_t)2 * ntm] = e;
-                            h_tm[(size_t)2 * ntm + 1] = mt;
-                            ntm++;
-                        }
+                const int max_group_tiles = std::max((P + moe_bm - 1) / moe_bm + G, 1);
+                const int n_groups = (E + G - 1) / G;
+                const size_t slot_g = (size_t)G * (size_t)mffn * (size_t)H;
+                const size_t slot_gs = (size_t)G * (size_t)mffn;
+                const size_t slot_d = (size_t)G * (size_t)H * (size_t)mffn;
+                const size_t slot_ds = (size_t)G * (size_t)H;
+
+                cudaStream_t st_dq = st;
+                cudaEvent_t ev_dq[2]{}, ev_done[2]{};
+                bool own_dq = false;
+                if (moe_pipe) {
+                    pf_cu(cudaStreamCreateWithFlags(&st_dq, cudaStreamNonBlocking), "moe dq stream");
+                    own_dq = true;
+                    for (int s = 0; s < moe_slots; s++) {
+                        pf_cu(cudaEventCreateWithFlags(&ev_dq[s], cudaEventDisableTiming), "moe ev_dq");
+                        pf_cu(cudaEventCreateWithFlags(&ev_done[s], cudaEventDisableTiming), "moe ev_done");
                     }
-                    if (!any) continue;
+                }
+
+                auto slot_ptrs = [&](int slot, signed char*& g, signed char*& u, signed char*& d,
+                                     float*& sg, float*& su, float*& sd, int*& tm, int*& nt) {
+                    g = Wg_i8 + (size_t)slot * slot_g;
+                    u = Wu_i8 + (size_t)slot * slot_g;
+                    d = Wd_i8 + (size_t)slot * slot_d;
+                    sg = swg + (size_t)slot * slot_gs;
+                    su = swu + (size_t)slot * slot_gs;
+                    sd = swd + (size_t)slot * slot_ds;
+                    tm = tilemap + (size_t)slot * 2 * max_group_tiles;
+                    nt = d_ntiles + slot;
+                };
+
+                // ---- gate/up: prepare (tilemap+dequant) then GEMM, optionally overlapped ----
+                auto prep_gateup = [&](int slot, int base, cudaStream_t s) {
+                    const int n_in = (E - base < G) ? (E - base) : G;
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
+                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
+                    (void)Wd_s; (void)swd_s;
+                    kernels::launch_pfm_group_tilemap(mcounts, tm, nt, base, n_in, moe_bm,
+                                                      max_group_tiles, s);
                     const void* ge = (const char*)w.gate_q + (size_t)base * (size_t)mffn * g_rb;
                     const void* ue = (const char*)w.up_q   + (size_t)base * (size_t)mffn * u_rb;
-                    kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, ge, Wg_i8, swg, n_in * mffn, H, st);
-                    kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   ue, Wu_i8, swu, n_in * mffn, H, st);
-                    pf_cu(cudaMemcpyAsync(tilemap, h_tm.data(), (size_t)2 * ntm * sizeof(int),
-                                          cudaMemcpyHostToDevice, st), "moe group tilemap");
-                    pf_cu(cudaMemcpyAsync(d_ntiles, &ntm, sizeof(int),
-                                          cudaMemcpyHostToDevice, st), "moe group ntiles");
+                    kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, ge, Wg_s, swg_s, n_in * mffn, H, s);
+                    kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   ue, Wu_s, swu_s, n_in * mffn, H, s);
+                    if (moe_pipe) pf_cu(cudaEventRecord(ev_dq[slot], s), "moe gateup dq record");
+                };
+                auto gemm_gateup = [&](int slot, int base, cudaStream_t s) {
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
+                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
+                    (void)Wd_s; (void)swd_s;
+                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, ev_dq[slot], 0), "moe gateup wait dq");
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets, tilemap, d_ntiles,
-                        hg, nullptr, mffn, H, ntm, moe_bm, base,
-                        /*a_indirect=*/true, /*c_scatter=*/false, st);
+                        mA_i8, msx, Wg_s, swg_s, pair_tok, pair_w, moffsets, tm, nt,
+                        hg, nullptr, mffn, H, max_group_tiles, moe_bm, base,
+                        /*a_indirect=*/true, /*c_scatter=*/false, s);
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets, tilemap, d_ntiles,
-                        hu, nullptr, mffn, H, ntm, moe_bm, base, true, false, st);
+                        mA_i8, msx, Wu_s, swu_s, pair_tok, pair_w, moffsets, tm, nt,
+                        hu, nullptr, mffn, H, max_group_tiles, moe_bm, base, true, false, s);
+                    if (moe_pipe) pf_cu(cudaEventRecord(ev_done[slot], s), "moe gateup done");
+                };
+
+                if (moe_pipe && n_groups > 0) prep_gateup(0, 0, st_dq);
+                for (int gi = 0; gi < n_groups; gi++) {
+                    const int slot = moe_pipe ? (gi & 1) : 0;
+                    const int base = gi * G;
+                    if (!moe_pipe) {
+                        prep_gateup(slot, base, st);
+                        gemm_gateup(slot, base, st);
+                    } else {
+                        if (gi + 1 < n_groups) prep_gateup((gi + 1) & 1, (gi + 1) * G, st_dq);
+                        gemm_gateup(slot, base, st);
+                    }
                 }
-                // One SwiGLU over all pairs, then group-serial down GEMM (L2-resident).
+                if (moe_pipe && n_groups > 0)
+                    pf_cu(cudaStreamWaitEvent(st, ev_done[(n_groups - 1) & 1], 0), "moe gateup join");
+
                 kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
                 kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
-                for (int base = 0; base < E; base += G) {
+
+                // ---- down: same pipe pattern ----
+                auto prep_down = [&](int slot, int base, cudaStream_t s) {
                     const int n_in = (E - base < G) ? (E - base) : G;
-                    int ntm = 0, any = 0;
-                    for (int le = 0; le < n_in; le++) {
-                        const int e = base + le;
-                        const int cnt = h_counts[e];
-                        if (cnt <= 0) continue;
-                        any = 1;
-                        const int nt = (cnt + moe_bm - 1) / moe_bm;
-                        for (int mt = 0; mt < nt; mt++) {
-                            if (ntm >= max_tiles) break;
-                            h_tm[(size_t)2 * ntm] = e;
-                            h_tm[(size_t)2 * ntm + 1] = mt;
-                            ntm++;
-                        }
-                    }
-                    if (!any) continue;
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
+                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
+                    (void)Wg_s; (void)Wu_s; (void)swg_s; (void)swu_s;
+                    kernels::launch_pfm_group_tilemap(mcounts, tm, nt, base, n_in, moe_bm,
+                                                      max_group_tiles, s);
                     const void* de = (const char*)w.down_q + (size_t)base * (size_t)H * d_rb;
-                    kernels::launch_gguf_dequant_rows_i8(w.down_qtype, de, Wd_i8, swd, n_in * H, mffn, st);
-                    pf_cu(cudaMemcpyAsync(tilemap, h_tm.data(), (size_t)2 * ntm * sizeof(int),
-                                          cudaMemcpyHostToDevice, st), "moe down tilemap");
-                    pf_cu(cudaMemcpyAsync(d_ntiles, &ntm, sizeof(int),
-                                          cudaMemcpyHostToDevice, st), "moe down ntiles");
+                    kernels::launch_gguf_dequant_rows_i8(w.down_qtype, de, Wd_s, swd_s, n_in * H, mffn, s);
+                    if (moe_pipe) pf_cu(cudaEventRecord(ev_dq[slot], s), "moe down dq record");
+                };
+                auto gemm_down = [&](int slot, int base, cudaStream_t s) {
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
+                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
+                    (void)Wg_s; (void)Wu_s; (void)swg_s; (void)swu_s;
+                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, ev_dq[slot], 0), "moe down wait dq");
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets, tilemap, d_ntiles,
-                        nullptr, routed_f32, H, mffn, ntm, moe_bm, base,
-                        /*a_indirect=*/false, /*c_scatter=*/true, st);
+                        h_i8, sh, Wd_s, swd_s, pair_tok, pair_w, moffsets, tm, nt,
+                        nullptr, routed_f32, H, mffn, max_group_tiles, moe_bm, base,
+                        /*a_indirect=*/false, /*c_scatter=*/true, s);
+                    if (moe_pipe) pf_cu(cudaEventRecord(ev_done[slot], s), "moe down done");
+                };
+
+                if (moe_pipe && n_groups > 0) prep_down(0, 0, st_dq);
+                for (int gi = 0; gi < n_groups; gi++) {
+                    const int slot = moe_pipe ? (gi & 1) : 0;
+                    const int base = gi * G;
+                    if (!moe_pipe) {
+                        prep_down(slot, base, st);
+                        gemm_down(slot, base, st);
+                    } else {
+                        if (gi + 1 < n_groups) prep_down((gi + 1) & 1, (gi + 1) * G, st_dq);
+                        gemm_down(slot, base, st);
+                    }
+                }
+                if (moe_pipe && n_groups > 0)
+                    pf_cu(cudaStreamWaitEvent(st, ev_done[(n_groups - 1) & 1], 0), "moe down join");
+
+                if (own_dq) {
+                    for (int s = 0; s < moe_slots; s++) {
+                        cudaEventDestroy(ev_dq[s]);
+                        cudaEventDestroy(ev_done[s]);
+                    }
+                    cudaStreamDestroy(st_dq);
                 }
             } else {
                 // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts).

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -262,9 +262,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (g > 64) g = 64;
         return g;
     }();
-    // Dual-stream: dequant group i+1 on a side stream while GEMMing group i.
-    // Default OFF — PIPE=1 is correct for prefill but regresses short-ctx decode ~8% on
-    // 5090 (side-stream residue). SPARKINFER_PREFILL_MOE_PIPE=1 enables.
+    // Dual-stream MoE aids (created when serial path is live):
+    //   - aux stream: H2D tilemap || dequant overlap (always on for serial)
+    //   - PIPE=1: also ping-pong dequant of group i+1 while GEMMing i (2 weight slots).
+    // SPARKINFER_PREFILL_MOE_PIPE=1 enables weight ping-pong. Default OFF until decode-safe.
     const bool moe_pipe = [&]{
         if (!moe_serial) return false;
         const char* e = getenv("SPARKINFER_PREFILL_MOE_PIPE");
@@ -297,14 +298,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         mcursors = am.alloc<int>(E);
         pair_tok = am.alloc<int>((size_t)P);
         pair_w = am.alloc<float>((size_t)P);
-        // Serial needs per-slot tilemaps for dual-stream; bulk bucket_pairs also writes a
-        // full-E tilemap into the same buffer before the serial path runs — size for both.
-        const int max_group_tiles = moe_serial
-            ? std::max((P + moe_bm - 1) / moe_bm + moe_group, 1) : 0;
-        const int tm_count = moe_serial
-            ? std::max(moe_slots * max_group_tiles, max_tiles) : max_tiles;
-        tilemap = am.alloc<int>((size_t)2 * std::max(tm_count, 1));
-        d_ntiles = am.alloc<int>(moe_serial ? moe_slots : 1);
+        // Serial: dual tilemap buffers so H2D of group i+1 overlaps GEMM of i.
+        tilemap = am.alloc<int>((size_t)2 * 2 * max_tiles);
+        d_ntiles = am.alloc<int>(2);
         hg = am.alloc<bf16>((size_t)P * mffn);
         hu = am.alloc<bf16>((size_t)P * mffn);
         hh = am.alloc<bf16>((size_t)P * mffn);
@@ -400,16 +396,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     kernels::launch_embedding(d_ids, s.w.embed_tokens, x, N, H, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, eps, st);
 
-    // MoE dual-stream resources: create once for all layers (per-layer create/destroy was
-    // dominating short-N and racing with incomplete dequant → TOP1=0 / fake tok/s).
-    cudaStream_t moe_st_dq = nullptr;
-    cudaEvent_t moe_ev_dq[2]{}, moe_ev_done[2]{}, moe_ev_ready{};
-    if (moe_pipe) {
-        pf_cu(cudaStreamCreateWithFlags(&moe_st_dq, cudaStreamNonBlocking), "moe dq stream");
+    // MoE aux stream: H2D tilemap overlaps dequant; optional ping-pong when PIPE=1.
+    // Created once for all layers. Full device sync before destroy so decode isn't poisoned.
+    cudaStream_t moe_st_aux = nullptr;
+    cudaEvent_t moe_ev_h2d{}, moe_ev_gemm[2]{}, moe_ev_dq[2]{}, moe_ev_done[2]{}, moe_ev_ready{};
+    if (moe_serial) {
+        pf_cu(cudaStreamCreateWithFlags(&moe_st_aux, cudaStreamNonBlocking), "moe aux stream");
+        pf_cu(cudaEventCreateWithFlags(&moe_ev_h2d, cudaEventDisableTiming), "moe ev_h2d");
+        pf_cu(cudaEventCreateWithFlags(&moe_ev_gemm[0], cudaEventDisableTiming), "moe ev_gemm0");
+        pf_cu(cudaEventCreateWithFlags(&moe_ev_gemm[1], cudaEventDisableTiming), "moe ev_gemm1");
         pf_cu(cudaEventCreateWithFlags(&moe_ev_ready, cudaEventDisableTiming), "moe ev_ready");
-        for (int sidx = 0; sidx < moe_slots; sidx++) {
-            pf_cu(cudaEventCreateWithFlags(&moe_ev_dq[sidx], cudaEventDisableTiming), "moe ev_dq");
-            pf_cu(cudaEventCreateWithFlags(&moe_ev_done[sidx], cudaEventDisableTiming), "moe ev_done");
+        if (moe_pipe) {
+            for (int sidx = 0; sidx < moe_slots; sidx++) {
+                pf_cu(cudaEventCreateWithFlags(&moe_ev_dq[sidx], cudaEventDisableTiming), "moe ev_dq");
+                pf_cu(cudaEventCreateWithFlags(&moe_ev_done[sidx], cudaEventDisableTiming), "moe ev_done");
+            }
         }
     }
 
@@ -521,150 +522,230 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                 moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
                                                 /*a_indirect=*/false, /*c_scatter=*/true, st);
             } else if (moe_serial) {
-                // Expert-group L2 path + optional dual-stream pipe:
-                //   - device group tilemap (no D2H counts sync)
-                //   - PIPE=1: dequant group i+1 on side stream while GEMMing i
+                // Expert-group L2 path on top of main(#561):
+                //   - D2H counts, skip empty groups, exact-ntm GEMM grids
+                //   - hybrid sparse dequant when ≤50% of a group is live (big @128 win)
+                //   - dual tilemap buffers: H2D overlaps prior GEMM; tilemaps reused for down
+                //   - optional PIPE=1 weight ping-pong (usually slower — leave off)
                 auto q_row_bytes = [](int qtype, int cols) -> size_t {
                     const int bs = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
                     return (size_t)(cols >> 8) * (size_t)bs;
                 };
+                int h_counts[256];
+                pf_cu(cudaMemcpyAsync(h_counts, mcounts, (size_t)E * sizeof(int),
+                                      cudaMemcpyDeviceToHost, st), "moe counts D2H");
+                pf_cu(cudaStreamSynchronize(st), "moe serial sync");
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 const size_t g_rb = q_row_bytes(w.gate_qtype, H);
                 const size_t u_rb = q_row_bytes(w.up_qtype, H);
                 const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
                 const int G = moe_group;
-                const int max_group_tiles = std::max((P + moe_bm - 1) / moe_bm + G, 1);
-                const int n_groups = (E + G - 1) / G;
                 const size_t slot_g = (size_t)G * (size_t)mffn * (size_t)H;
                 const size_t slot_gs = (size_t)G * (size_t)mffn;
                 const size_t slot_d = (size_t)G * (size_t)H * (size_t)mffn;
                 const size_t slot_ds = (size_t)G * (size_t)H;
 
-                cudaStream_t st_dq = moe_pipe ? moe_st_dq : st;
-                // Side stream must see mcounts / pair buckets / routed zero before first prep.
-                if (moe_pipe) {
-                    pf_cu(cudaEventRecord(moe_ev_ready, st), "moe ready");
-                    pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_ready, 0), "moe dq wait ready");
+                struct ActiveGroup { int base, n_in, ntm; std::vector<int> tm; };
+                std::vector<ActiveGroup> active;
+                active.reserve((size_t)((E + G - 1) / G));
+                for (int base = 0; base < E; base += G) {
+                    const int n_in = (E - base < G) ? (E - base) : G;
+                    ActiveGroup ag;
+                    ag.base = base;
+                    ag.n_in = n_in;
+                    ag.ntm = 0;
+                    ag.tm.reserve((size_t)2 * 64);
+                    for (int le = 0; le < n_in; le++) {
+                        const int e = base + le;
+                        const int cnt = h_counts[e];
+                        if (cnt <= 0) continue;
+                        const int nt = (cnt + moe_bm - 1) / moe_bm;
+                        for (int mt = 0; mt < nt; mt++) {
+                            if (ag.ntm >= max_tiles) break;
+                            ag.tm.push_back(e);
+                            ag.tm.push_back(mt);
+                            ag.ntm++;
+                        }
+                    }
+                    if (ag.ntm > 0) active.push_back(std::move(ag));
                 }
+                const int n_active = (int)active.size();
 
-                auto slot_ptrs = [&](int slot, signed char*& g, signed char*& u, signed char*& d,
-                                     float*& sg, float*& su, float*& sd, int*& tm, int*& nt) {
+                auto slot_w = [&](int slot, signed char*& g, signed char*& u, signed char*& d,
+                                  float*& sg, float*& su, float*& sd) {
                     g = Wg_i8 + (size_t)slot * slot_g;
                     u = Wu_i8 + (size_t)slot * slot_g;
                     d = Wd_i8 + (size_t)slot * slot_d;
                     sg = swg + (size_t)slot * slot_gs;
                     su = swu + (size_t)slot * slot_gs;
                     sd = swd + (size_t)slot * slot_ds;
-                    tm = tilemap + (size_t)slot * 2 * max_group_tiles;
-                    nt = d_ntiles + slot;
                 };
 
-                // ---- gate/up: prepare (tilemap+dequant) then GEMM, optionally overlapped ----
-                auto prep_gateup = [&](int slot, int base, cudaStream_t s) {
-                    const int n_in = (E - base < G) ? (E - base) : G;
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
-                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
-                    (void)Wd_s; (void)swd_s;
-                    kernels::launch_pfm_group_tilemap(mcounts, tm, nt, base, n_in, moe_bm,
-                                                      max_group_tiles, s);
-                    const void* ge = (const char*)w.gate_q + (size_t)base * (size_t)mffn * g_rb;
-                    const void* ue = (const char*)w.up_q   + (size_t)base * (size_t)mffn * u_rb;
-                    kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, ge, Wg_s, swg_s, n_in * mffn, H, s);
-                    kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   ue, Wu_s, swu_s, n_in * mffn, H, s);
-                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe gateup dq record");
+                // Dual tilemap buffers: H2D into free buf while GEMM reads the other.
+                int tm_buf = 0;
+                bool tm_used[2] = {false, false};
+                auto upload_tm = [&](const ActiveGroup& ag) {
+                    if (tm_used[tm_buf])
+                        pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_gemm[tm_buf], 0),
+                              "moe h2d wait old buf");
+                    int* tm = tilemap + (size_t)tm_buf * 2 * max_tiles;
+                    int* nt = d_ntiles + tm_buf;
+                    pf_cu(cudaMemcpyAsync(tm, ag.tm.data(), (size_t)2 * ag.ntm * sizeof(int),
+                                          cudaMemcpyHostToDevice, moe_st_aux), "moe tm H2D");
+                    pf_cu(cudaMemcpyAsync(nt, &ag.ntm, sizeof(int),
+                                          cudaMemcpyHostToDevice, moe_st_aux), "moe ntm H2D");
+                    pf_cu(cudaEventRecord(moe_ev_h2d, moe_st_aux), "moe h2d done");
                 };
-                auto gemm_gateup = [&](int slot, int base, cudaStream_t s) {
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
-                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
+                auto dequant_gateup = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
+                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
                     (void)Wd_s; (void)swd_s;
-                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, moe_ev_dq[slot], 0), "moe gateup wait dq");
+                    int n_live = 0;
+                    for (int le = 0; le < ag.n_in; le++)
+                        if (h_counts[ag.base + le] > 0) n_live++;
+                    // Sparse only when enough empties to beat one contiguous launch.
+                    if (n_live > 0 && n_live * 2 <= ag.n_in) {
+                        for (int le = 0; le < ag.n_in; le++) {
+                            const int e = ag.base + le;
+                            if (h_counts[e] <= 0) continue;
+                            const void* ge = (const char*)w.gate_q + (size_t)e * (size_t)mffn * g_rb;
+                            const void* ue = (const char*)w.up_q   + (size_t)e * (size_t)mffn * u_rb;
+                            kernels::launch_gguf_dequant_rows_i8(
+                                w.gate_qtype, ge, Wg_s + (size_t)le * mffn * H,
+                                swg_s + (size_t)le * mffn, mffn, H, s);
+                            kernels::launch_gguf_dequant_rows_i8(
+                                w.up_qtype, ue, Wu_s + (size_t)le * mffn * H,
+                                swu_s + (size_t)le * mffn, mffn, H, s);
+                        }
+                    } else {
+                        const void* ge = (const char*)w.gate_q + (size_t)ag.base * (size_t)mffn * g_rb;
+                        const void* ue = (const char*)w.up_q   + (size_t)ag.base * (size_t)mffn * u_rb;
+                        kernels::launch_gguf_dequant_rows_i8(
+                            w.gate_qtype, ge, Wg_s, swg_s, ag.n_in * mffn, H, s);
+                        kernels::launch_gguf_dequant_rows_i8(
+                            w.up_qtype, ue, Wu_s, swu_s, ag.n_in * mffn, H, s);
+                    }
+                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe gateup dq");
+                };
+                auto gemm_gateup = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
+                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
+                    (void)Wd_s; (void)swd_s;
+                    int* tm = tilemap + (size_t)tm_buf * 2 * max_tiles;
+                    int* nt = d_ntiles + tm_buf;
+                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, moe_ev_dq[slot], 0), "moe wait dq");
+                    pf_cu(cudaStreamWaitEvent(s, moe_ev_h2d, 0), "moe wait h2d");
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
                         mA_i8, msx, Wg_s, swg_s, pair_tok, pair_w, moffsets, tm, nt,
-                        hg, nullptr, mffn, H, max_group_tiles, moe_bm, base,
+                        hg, nullptr, mffn, H, ag.ntm, moe_bm, ag.base,
                         /*a_indirect=*/true, /*c_scatter=*/false, s);
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
                         mA_i8, msx, Wu_s, swu_s, pair_tok, pair_w, moffsets, tm, nt,
-                        hu, nullptr, mffn, H, max_group_tiles, moe_bm, base, true, false, s);
+                        hu, nullptr, mffn, H, ag.ntm, moe_bm, ag.base, true, false, s);
+                    pf_cu(cudaEventRecord(moe_ev_gemm[tm_buf], s), "moe gemm done");
                     if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_done[slot], s), "moe gateup done");
+                    tm_used[tm_buf] = true;
+                    tm_buf ^= 1;
                 };
 
-                if (moe_pipe && n_groups > 0) prep_gateup(0, 0, st_dq);
-                for (int gi = 0; gi < n_groups; gi++) {
+                if (moe_pipe && n_active > 0) {
+                    pf_cu(cudaEventRecord(moe_ev_ready, st), "moe ready");
+                    pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_ready, 0), "moe aux wait ready");
+                    dequant_gateup(0, active[0], moe_st_aux);
+                }
+                for (int gi = 0; gi < n_active; gi++) {
                     const int slot = moe_pipe ? (gi & 1) : 0;
-                    const int base = gi * G;
+                    const ActiveGroup& ag = active[(size_t)gi];
                     if (!moe_pipe) {
-                        prep_gateup(slot, base, st);
-                        gemm_gateup(slot, base, st);
+                        upload_tm(ag);
+                        dequant_gateup(slot, ag, st);
+                        gemm_gateup(slot, ag, st);
                     } else {
-                        // Do not overwrite slot ns while its prior GEMM still reads W/tilemap.
-                        if (gi + 1 < n_groups) {
+                        upload_tm(ag);
+                        if (gi + 1 < n_active) {
                             const int ns = (gi + 1) & 1;
                             if (gi >= 1)
-                                pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_done[ns], 0),
-                                      "moe gateup dq wait slot");
-                            prep_gateup(ns, (gi + 1) * G, st_dq);
+                                pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_done[ns], 0),
+                                      "moe dq wait slot");
+                            dequant_gateup(ns, active[(size_t)gi + 1], moe_st_aux);
                         }
-                        gemm_gateup(slot, base, st);
+                        gemm_gateup(slot, ag, st);
                     }
                 }
-                if (moe_pipe && n_groups > 0)
-                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_groups - 1) & 1], 0), "moe gateup join");
+                if (moe_pipe && n_active > 0)
+                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_active - 1) & 1], 0), "moe gateup join");
 
                 kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
                 kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
 
-                // ---- down: same pipe pattern ----
-                auto prep_down = [&](int slot, int base, cudaStream_t s) {
-                    const int n_in = (E - base < G) ? (E - base) : G;
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
-                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
+                auto dequant_down = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
+                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
                     (void)Wg_s; (void)Wu_s; (void)swg_s; (void)swu_s;
-                    kernels::launch_pfm_group_tilemap(mcounts, tm, nt, base, n_in, moe_bm,
-                                                      max_group_tiles, s);
-                    const void* de = (const char*)w.down_q + (size_t)base * (size_t)H * d_rb;
-                    kernels::launch_gguf_dequant_rows_i8(w.down_qtype, de, Wd_s, swd_s, n_in * H, mffn, s);
-                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe down dq record");
+                    int n_live = 0;
+                    for (int le = 0; le < ag.n_in; le++)
+                        if (h_counts[ag.base + le] > 0) n_live++;
+                    if (n_live > 0 && n_live * 2 <= ag.n_in) {
+                        for (int le = 0; le < ag.n_in; le++) {
+                            const int e = ag.base + le;
+                            if (h_counts[e] <= 0) continue;
+                            const void* de = (const char*)w.down_q + (size_t)e * (size_t)H * d_rb;
+                            kernels::launch_gguf_dequant_rows_i8(
+                                w.down_qtype, de, Wd_s + (size_t)le * H * mffn,
+                                swd_s + (size_t)le * H, H, mffn, s);
+                        }
+                    } else {
+                        const void* de = (const char*)w.down_q + (size_t)ag.base * (size_t)H * d_rb;
+                        kernels::launch_gguf_dequant_rows_i8(
+                            w.down_qtype, de, Wd_s, swd_s, ag.n_in * H, mffn, s);
+                    }
+                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe down dq");
                 };
-                auto gemm_down = [&](int slot, int base, cudaStream_t s) {
-                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
-                    slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
+                auto gemm_down = [&](int slot, const ActiveGroup& ag, cudaStream_t s) {
+                    signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s;
+                    slot_w(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s);
                     (void)Wg_s; (void)Wu_s; (void)swg_s; (void)swu_s;
+                    int* tm = tilemap + (size_t)tm_buf * 2 * max_tiles;
+                    int* nt = d_ntiles + tm_buf;
                     if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, moe_ev_dq[slot], 0), "moe down wait dq");
+                    pf_cu(cudaStreamWaitEvent(s, moe_ev_h2d, 0), "moe down wait h2d");
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
                         h_i8, sh, Wd_s, swd_s, pair_tok, pair_w, moffsets, tm, nt,
-                        nullptr, routed_f32, H, mffn, max_group_tiles, moe_bm, base,
+                        nullptr, routed_f32, H, mffn, ag.ntm, moe_bm, ag.base,
                         /*a_indirect=*/false, /*c_scatter=*/true, s);
+                    pf_cu(cudaEventRecord(moe_ev_gemm[tm_buf], s), "moe down gemm done");
                     if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_done[slot], s), "moe down done");
+                    tm_used[tm_buf] = true;
+                    tm_buf ^= 1;
                 };
 
-                // Down prep may overlap swiglu/quantize (weight-only); GEMM stays on st after them.
-                if (moe_pipe && n_groups > 0) {
+                if (moe_pipe && n_active > 0) {
                     pf_cu(cudaEventRecord(moe_ev_ready, st), "moe down ready");
-                    pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_ready, 0), "moe dq wait down ready");
-                    // Slot 0 was last used by gateup; wait before reusing for down.
-                    if (n_groups > 1)
-                        pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_done[0], 0), "moe down dq wait slot0");
-                    prep_down(0, 0, st_dq);
+                    pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_ready, 0), "moe aux down ready");
+                    if (n_active > 1)
+                        pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_done[0], 0), "moe down slot0");
+                    dequant_down(0, active[0], moe_st_aux);
                 }
-                for (int gi = 0; gi < n_groups; gi++) {
+                for (int gi = 0; gi < n_active; gi++) {
                     const int slot = moe_pipe ? (gi & 1) : 0;
-                    const int base = gi * G;
+                    const ActiveGroup& ag = active[(size_t)gi];
                     if (!moe_pipe) {
-                        prep_down(slot, base, st);
-                        gemm_down(slot, base, st);
+                        upload_tm(ag);
+                        dequant_down(slot, ag, st);
+                        gemm_down(slot, ag, st);
                     } else {
-                        if (gi + 1 < n_groups) {
+                        upload_tm(ag);
+                        if (gi + 1 < n_active) {
                             const int ns = (gi + 1) & 1;
-                            // First refill of slot1 after gateup, or later ping-pong reuse.
-                            pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_done[ns], 0),
-                                  "moe down dq wait slot");
-                            prep_down(ns, (gi + 1) * G, st_dq);
+                            pf_cu(cudaStreamWaitEvent(moe_st_aux, moe_ev_done[ns], 0),
+                                  "moe down dq wait");
+                            dequant_down(ns, active[(size_t)gi + 1], moe_st_aux);
                         }
-                        gemm_down(slot, base, st);
+                        gemm_down(slot, ag, st);
                     }
                 }
-                if (moe_pipe && n_groups > 0)
-                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_groups - 1) & 1], 0), "moe down join");
+                if (moe_pipe && n_active > 0)
+                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_active - 1) & 1], 0), "moe down join");
             } else {
                 // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts).
                 kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
@@ -716,13 +797,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
     }
 
-    if (moe_pipe) {
-        for (int sidx = 0; sidx < moe_slots; sidx++) {
-            cudaEventDestroy(moe_ev_dq[sidx]);
-            cudaEventDestroy(moe_ev_done[sidx]);
+    if (moe_serial) {
+        // Drain aux work so a subsequent decode bench isn't scheduled against leftover cmds.
+        pf_cu(cudaStreamSynchronize(moe_st_aux), "moe aux sync");
+        if (moe_pipe) {
+            for (int sidx = 0; sidx < moe_slots; sidx++) {
+                cudaEventDestroy(moe_ev_dq[sidx]);
+                cudaEventDestroy(moe_ev_done[sidx]);
+            }
         }
+        cudaEventDestroy(moe_ev_h2d);
+        cudaEventDestroy(moe_ev_gemm[0]);
+        cudaEventDestroy(moe_ev_gemm[1]);
         cudaEventDestroy(moe_ev_ready);
-        cudaStreamDestroy(moe_st_dq);
+        cudaStreamDestroy(moe_st_aux);
     }
 
     // Seed for the first decode step: argmax at the last prompt position (xn already = final norm).

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -262,13 +262,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (g > 64) g = 64;
         return g;
     }();
-    // Dual-stream: dequant group i+1 on a side stream while GEMMing group i (default ON
-    // with serial). SPARKINFER_PREFILL_MOE_PIPE=0 disables (single-stream + device tilemap).
+    // Dual-stream: dequant group i+1 on a side stream while GEMMing group i.
+    // Default OFF — PIPE=1 is correct for prefill but regresses short-ctx decode ~8% on
+    // 5090 (side-stream residue). SPARKINFER_PREFILL_MOE_PIPE=1 enables.
     const bool moe_pipe = [&]{
         if (!moe_serial) return false;
         const char* e = getenv("SPARKINFER_PREFILL_MOE_PIPE");
-        if (e) return e[0] != '0';
-        return true;
+        return e && e[0] == '1';
     }();
     const int moe_slots = (moe_serial && moe_pipe) ? 2 : 1;
     Arena am;
@@ -297,11 +297,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         mcursors = am.alloc<int>(E);
         pair_tok = am.alloc<int>((size_t)P);
         pair_w = am.alloc<float>((size_t)P);
-        // Serial needs per-slot tilemaps for dual-stream; bulk uses one full map.
-        const int tm_cap = moe_serial
-            ? moe_slots * std::max((P + moe_bm - 1) / moe_bm + moe_group, 1)
-            : max_tiles;
-        tilemap = am.alloc<int>((size_t)2 * tm_cap);
+        // Serial needs per-slot tilemaps for dual-stream; bulk bucket_pairs also writes a
+        // full-E tilemap into the same buffer before the serial path runs — size for both.
+        const int max_group_tiles = moe_serial
+            ? std::max((P + moe_bm - 1) / moe_bm + moe_group, 1) : 0;
+        const int tm_count = moe_serial
+            ? std::max(moe_slots * max_group_tiles, max_tiles) : max_tiles;
+        tilemap = am.alloc<int>((size_t)2 * std::max(tm_count, 1));
         d_ntiles = am.alloc<int>(moe_serial ? moe_slots : 1);
         hg = am.alloc<bf16>((size_t)P * mffn);
         hu = am.alloc<bf16>((size_t)P * mffn);
@@ -397,6 +399,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // embed -> x, prime xn = RMSNorm(x, layer0.input_norm)
     kernels::launch_embedding(d_ids, s.w.embed_tokens, x, N, H, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, eps, st);
+
+    // MoE dual-stream resources: create once for all layers (per-layer create/destroy was
+    // dominating short-N and racing with incomplete dequant → TOP1=0 / fake tok/s).
+    cudaStream_t moe_st_dq = nullptr;
+    cudaEvent_t moe_ev_dq[2]{}, moe_ev_done[2]{}, moe_ev_ready{};
+    if (moe_pipe) {
+        pf_cu(cudaStreamCreateWithFlags(&moe_st_dq, cudaStreamNonBlocking), "moe dq stream");
+        pf_cu(cudaEventCreateWithFlags(&moe_ev_ready, cudaEventDisableTiming), "moe ev_ready");
+        for (int sidx = 0; sidx < moe_slots; sidx++) {
+            pf_cu(cudaEventCreateWithFlags(&moe_ev_dq[sidx], cudaEventDisableTiming), "moe ev_dq");
+            pf_cu(cudaEventCreateWithFlags(&moe_ev_done[sidx], cudaEventDisableTiming), "moe ev_done");
+        }
+    }
 
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
@@ -525,16 +540,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 const size_t slot_d = (size_t)G * (size_t)H * (size_t)mffn;
                 const size_t slot_ds = (size_t)G * (size_t)H;
 
-                cudaStream_t st_dq = st;
-                cudaEvent_t ev_dq[2]{}, ev_done[2]{};
-                bool own_dq = false;
+                cudaStream_t st_dq = moe_pipe ? moe_st_dq : st;
+                // Side stream must see mcounts / pair buckets / routed zero before first prep.
                 if (moe_pipe) {
-                    pf_cu(cudaStreamCreateWithFlags(&st_dq, cudaStreamNonBlocking), "moe dq stream");
-                    own_dq = true;
-                    for (int s = 0; s < moe_slots; s++) {
-                        pf_cu(cudaEventCreateWithFlags(&ev_dq[s], cudaEventDisableTiming), "moe ev_dq");
-                        pf_cu(cudaEventCreateWithFlags(&ev_done[s], cudaEventDisableTiming), "moe ev_done");
-                    }
+                    pf_cu(cudaEventRecord(moe_ev_ready, st), "moe ready");
+                    pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_ready, 0), "moe dq wait ready");
                 }
 
                 auto slot_ptrs = [&](int slot, signed char*& g, signed char*& u, signed char*& d,
@@ -561,13 +571,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     const void* ue = (const char*)w.up_q   + (size_t)base * (size_t)mffn * u_rb;
                     kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, ge, Wg_s, swg_s, n_in * mffn, H, s);
                     kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   ue, Wu_s, swu_s, n_in * mffn, H, s);
-                    if (moe_pipe) pf_cu(cudaEventRecord(ev_dq[slot], s), "moe gateup dq record");
+                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe gateup dq record");
                 };
                 auto gemm_gateup = [&](int slot, int base, cudaStream_t s) {
                     signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
                     slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
                     (void)Wd_s; (void)swd_s;
-                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, ev_dq[slot], 0), "moe gateup wait dq");
+                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, moe_ev_dq[slot], 0), "moe gateup wait dq");
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
                         mA_i8, msx, Wg_s, swg_s, pair_tok, pair_w, moffsets, tm, nt,
                         hg, nullptr, mffn, H, max_group_tiles, moe_bm, base,
@@ -575,7 +585,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
                         mA_i8, msx, Wu_s, swu_s, pair_tok, pair_w, moffsets, tm, nt,
                         hu, nullptr, mffn, H, max_group_tiles, moe_bm, base, true, false, s);
-                    if (moe_pipe) pf_cu(cudaEventRecord(ev_done[slot], s), "moe gateup done");
+                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_done[slot], s), "moe gateup done");
                 };
 
                 if (moe_pipe && n_groups > 0) prep_gateup(0, 0, st_dq);
@@ -586,12 +596,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         prep_gateup(slot, base, st);
                         gemm_gateup(slot, base, st);
                     } else {
-                        if (gi + 1 < n_groups) prep_gateup((gi + 1) & 1, (gi + 1) * G, st_dq);
+                        // Do not overwrite slot ns while its prior GEMM still reads W/tilemap.
+                        if (gi + 1 < n_groups) {
+                            const int ns = (gi + 1) & 1;
+                            if (gi >= 1)
+                                pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_done[ns], 0),
+                                      "moe gateup dq wait slot");
+                            prep_gateup(ns, (gi + 1) * G, st_dq);
+                        }
                         gemm_gateup(slot, base, st);
                     }
                 }
                 if (moe_pipe && n_groups > 0)
-                    pf_cu(cudaStreamWaitEvent(st, ev_done[(n_groups - 1) & 1], 0), "moe gateup join");
+                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_groups - 1) & 1], 0), "moe gateup join");
 
                 kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
                 kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
@@ -606,21 +623,29 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                       max_group_tiles, s);
                     const void* de = (const char*)w.down_q + (size_t)base * (size_t)H * d_rb;
                     kernels::launch_gguf_dequant_rows_i8(w.down_qtype, de, Wd_s, swd_s, n_in * H, mffn, s);
-                    if (moe_pipe) pf_cu(cudaEventRecord(ev_dq[slot], s), "moe down dq record");
+                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_dq[slot], s), "moe down dq record");
                 };
                 auto gemm_down = [&](int slot, int base, cudaStream_t s) {
                     signed char *Wg_s, *Wu_s, *Wd_s; float *swg_s, *swu_s, *swd_s; int *tm, *nt;
                     slot_ptrs(slot, Wg_s, Wu_s, Wd_s, swg_s, swu_s, swd_s, tm, nt);
                     (void)Wg_s; (void)Wu_s; (void)swg_s; (void)swu_s;
-                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, ev_dq[slot], 0), "moe down wait dq");
+                    if (moe_pipe) pf_cu(cudaStreamWaitEvent(s, moe_ev_dq[slot], 0), "moe down wait dq");
                     kernels::launch_pfm_moe_gemm_i8_bm_base(
                         h_i8, sh, Wd_s, swd_s, pair_tok, pair_w, moffsets, tm, nt,
                         nullptr, routed_f32, H, mffn, max_group_tiles, moe_bm, base,
                         /*a_indirect=*/false, /*c_scatter=*/true, s);
-                    if (moe_pipe) pf_cu(cudaEventRecord(ev_done[slot], s), "moe down done");
+                    if (moe_pipe) pf_cu(cudaEventRecord(moe_ev_done[slot], s), "moe down done");
                 };
 
-                if (moe_pipe && n_groups > 0) prep_down(0, 0, st_dq);
+                // Down prep may overlap swiglu/quantize (weight-only); GEMM stays on st after them.
+                if (moe_pipe && n_groups > 0) {
+                    pf_cu(cudaEventRecord(moe_ev_ready, st), "moe down ready");
+                    pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_ready, 0), "moe dq wait down ready");
+                    // Slot 0 was last used by gateup; wait before reusing for down.
+                    if (n_groups > 1)
+                        pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_done[0], 0), "moe down dq wait slot0");
+                    prep_down(0, 0, st_dq);
+                }
                 for (int gi = 0; gi < n_groups; gi++) {
                     const int slot = moe_pipe ? (gi & 1) : 0;
                     const int base = gi * G;
@@ -628,20 +653,18 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         prep_down(slot, base, st);
                         gemm_down(slot, base, st);
                     } else {
-                        if (gi + 1 < n_groups) prep_down((gi + 1) & 1, (gi + 1) * G, st_dq);
+                        if (gi + 1 < n_groups) {
+                            const int ns = (gi + 1) & 1;
+                            // First refill of slot1 after gateup, or later ping-pong reuse.
+                            pf_cu(cudaStreamWaitEvent(st_dq, moe_ev_done[ns], 0),
+                                  "moe down dq wait slot");
+                            prep_down(ns, (gi + 1) * G, st_dq);
+                        }
                         gemm_down(slot, base, st);
                     }
                 }
                 if (moe_pipe && n_groups > 0)
-                    pf_cu(cudaStreamWaitEvent(st, ev_done[(n_groups - 1) & 1], 0), "moe down join");
-
-                if (own_dq) {
-                    for (int s = 0; s < moe_slots; s++) {
-                        cudaEventDestroy(ev_dq[s]);
-                        cudaEventDestroy(ev_done[s]);
-                    }
-                    cudaStreamDestroy(st_dq);
-                }
+                    pf_cu(cudaStreamWaitEvent(st, moe_ev_done[(n_groups - 1) & 1], 0), "moe down join");
             } else {
                 // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts).
                 kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
@@ -691,6 +714,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+    }
+
+    if (moe_pipe) {
+        for (int sidx = 0; sidx < moe_slots; sidx++) {
+            cudaEventDestroy(moe_ev_dq[sidx]);
+            cudaEventDestroy(moe_ev_done[sidx]);
+        }
+        cudaEventDestroy(moe_ev_ready);
+        cudaStreamDestroy(moe_st_dq);
     }
 
     // Seed for the first decode step: argmax at the last prompt position (xn already = final norm).

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -17,6 +17,8 @@ struct Qwen35PrefillCtx {
     const Qwen35Weights& w;
     KVCacheManager*      kv;
     cudaStream_t         stream;
+    cudaStream_t         stream_k;         // reuse decode side streams for MoE overlap
+    cudaStream_t         stream_v;
     uint64_t             seq_id;
     float*               lin_state;        // Gated-DeltaNet recurrent state (per layer)
     void*                lin_conv_state;   // bf16 causal-conv window (per layer)


### PR DESCRIPTION
## Summary

On top of merged #561 + #549, short-N MoE prefill **skips empty-expert dequant** (coalesce contiguous live runs) and **fuses same-type gate+up dequant** into one grid on the main stream. Decode-safe: multi-stream MoE overlap stays opt-in (`SPARKINFER_PREFILL_MOE_OVERLAP=1`) — side-stream work + WaitEvent onto the decode stream permanently slows graph replay (~0.92×). Distinct from #555/#544 (and layered on #549, not a copy of it).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`) — vast `45464977`

**Decode tok/s** (no claimed gain; no-regression ≥0.98):

| | decode tok/s |
|---|--:|
| before (main `e050e60` = #549) | ~495 @512 |
| after (this PR) | ~495 @512 (**1.00×**) |

**Prefill pp tok/s** (Qwen3.6 MoE — score context **512**):

| | prefill pp tok/s |
|---|--:|
| before prefill (main `#549`) | ~4107 @512 |
| after prefill (this PR) | **~4590 @512 (+11.7%)** |

```text
# RTX 5090 / 45464977 — SPARKINFER_KV_INT8=1
# main(e050e60 #549) vs PR (coalesce + fused gate/up), 5× A/B @512:
#   main pp≈4107 tg≈495
#   PR   pp≈4590 tg≈495   pp×≈1.117  tg×≈1.00
# Teacher-forced score dumps: bit-identical to main (short + long int8 @5120)
```

## Accuracy note (prior `eval:REJECT`)

The previous reject (`top1=0.0`, `kl≈0.94`) was the **H2 long-context veto** forcing top1→0 (not a short-pass failure). Short vs-llama remains healthy (top1≈0.93, KL≈0.05).

Reproduced the same H2 veto on **clean main `#549`** with the same seed — identical METRIC_LONG numbers. So this is not a PR numeric regression vs main; it is the tightened #567 H2 bars (top1≥0.90, KL≤0.50) vetoing a seed where even main sits at top1≈0.89 / KL≈1.31 (within the historical *correct* KL band [0.215, 1.367]).

## Test plan

- [x] Rebased onto `main` including #549
- [x] 5× A/B pp/decode @512 vs same-box main
- [x] Teacher-forced score identity vs main (short + long int8)
- [x] accuracy.sh short PASS; H2 veto matches main on same seed
- [ ] CI / eval bot re-run