### PR TITLE
perf(qwen36): n_splits=160 for hd128/GQA-8 long-context decode (+13% @32k, +7% @16k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -407,6 +407,19 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         // GQA-8 (Qwen3.6): flat 160 through 32k (4k–32k A/B on RTX 5090).
         // GQA-4 (Qwythos): same through 32k; promote splits at 64k/128k so per-split MMA
         // chunks do not outgrow occupancy (64k: 192, 128k: 128 — same-box sweeps).
+        // hd128/GQA-8 (Qwen3-MoE, e.g. Qwen3-30B-A3B): the same over-subscription applies to
+        // the 256 tier on this shape, which the hd256 correction below never covered — the
+        // generic long-context tier is chosen by depth alone, not by achieved occupancy of
+        // fa_split_gqa_mma_i8_kernel<128, 8>. Same-box A/B on an RTX 5090 (interleaved with
+        // main, 3 rounds per point, best-of-run, Q4_K_M): vs the 256 tier at 32k, 160 is the
+        // clear optimum (+12.4% median; 96 +5.6%, 128 +5.1%, 192 +9.1%, 224 -0.2%), and 160
+        // holds at 16k (+8.1%). Only the MAX_NSPLITS tier is corrected: the 128 tier (4k) is
+        // already optimal there and forcing 160 onto it measured -7.1%, so it is left alone.
+        // The online-softmax combine is exact for any split count, so this is speed-only.
+        if (c.head_dim == 128 && c.n_kv_heads > 0 && want >= Impl::MAX_NSPLITS &&
+            c.n_q_heads == c.n_kv_heads * 8) {
+            want = 160;
+        }
         if (c.head_dim == 256 && c.n_kv_heads > 0 && want >= 128) {
             if (c.n_q_heads == c.n_kv_heads * 8)
                 want = 160;


### PR DESCRIPTION
## Summary

Extend the existing `n_splits` occupancy correction to the **hd128 / GQA-8** shape
(Qwen3-MoE, e.g. Qwen3-30B-A3B). The correction already exists for hd256 but is gated on
`c.head_dim == 256`, so hd128 still takes the generic depth tier (`MAX_NSPLITS` = 256) at
long context. On an RTX 5090 that tier over-subscribes the split grid: **160 splits is the
clear optimum (+13% decode @32k, +7% @16k)**, matching the same flat-160 result already
measured for hd256.

Only the `MAX_NSPLITS` tier is corrected. The 128 tier (4k and below) is left untouched —
forcing 160 onto it measured **−7.1%**, so the guard is `want >= Impl::MAX_NSPLITS`.

Speed-only: `n_splits` changes just how the KV sequence is partitioned across blocks, and
the online-softmax combine is exact for any split count (as the adjacent hd256 comment
already notes).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

Interleaved A/B (main vs this branch, alternating rounds so boost-clock drift affects both
equally — the repo's own "warm interleaved" methodology), `Qwen3-30B-A3B-Q4_K_M`, bs=1,
`n=128`, CUDA 12.8 / Ubuntu 22.04, both trees built from source:

**Decode tok/s**

| | decode tok/s |
|---|--:|
| before (main) | 242.79 |
| after (this PR) | 274.52 |

That is the 32k point (+13.07%). Full picture across every scored context, 3 interleaved
rounds each:

| ctx | main | this PR | delta | n_splits changed? |
|---|--:|--:|--:|---|
| 128 (ctx 0) | 447.26 / 453.24 / 456.32 | 457.21 / 464.04 / 462.56 | +2.22 / +2.38 / +1.37% | no (tier 32) |
| 512 | 438.36 / 439.02 / 435.24 | 436.92 / 435.11 / 432.74 | −0.33 / −0.89 / −0.57% | no (tier 128) |
| 4k | 376.15 / 382.18 / 377.46 | 376.36 / 381.52 / 378.05 | +0.06 / −0.17 / +0.16% | no (tier 128) |
| 16k | 304.19 / 304.93 / 305.97 | 328.77 / 324.85 / 326.44 | **+8.08 / +6.53 / +6.69%** | yes (256→160) |
| 32k | 242.79 / 242.72 | 274.52 / 274.58 | **+13.07 / +13.13%** | yes (256→160) |

512 and 4k sit below the `want >= MAX_NSPLITS` guard, so this branch is byte-identical to
main there; their sub-1% deltas are run-to-run noise, which is what makes them a useful
control.

How 160 was chosen — `SPARKINFER_NSPLITS` sweep at 32k, 3 interleaved rounds per point,
median delta vs the default 256 tier:

| n_splits | 96 | 128 | **160** | 192 | 224 |
|---|--:|--:|--:|--:|--:|
| median delta | +5.6% | +5.1% | **+12.4%** | +9.1% | −0.2% |

Clean unimodal peak at 160, decaying to ~0 at 224 (adjacent to the default).

`ctest --test-dir build` → **9/9 passing** on this branch.

```text
=== interleaved main vs patched (build from source, both trees) ===
ctx=0     r1  main=447.26  patched=457.21  delta=+2.22%   gpu=47C
ctx=0     r2  main=453.24  patched=464.04  delta=+2.38%   gpu=43C
ctx=0     r3  main=456.32  patched=462.56  delta=+1.37%   gpu=49C
ctx=512   r1  main=438.36  patched=436.92  delta=-0.33%   gpu=57C
ctx=512   r2  main=439.02  patched=435.11  delta=-0.89%   gpu=57C
ctx=512   r3  main=435.24  patched=432.74  delta=-0.57%   gpu=58C
ctx=4096  r1  main=376.15  patched=376.36  delta=+0.06%   gpu=68C
ctx=4096  r2  main=382.18  patched=381.52  delta=-0.17%   gpu=70C
ctx=4096  r3  main=377.46  patched=378.05  delta=+0.16%   gpu=70C
ctx=16384 r1  main=304.19  patched=328.77  delta=+8.08%   gpu=71C
ctx=16384 r2  main=304.93  patched=324.85  delta=+6.53%   gpu=72C
ctx=16384 r3  main=305.97  patched=326.44  delta=+6.69%   gpu=72C
ctx=32768 r1  main=242.79  patched=274.52  delta=+13.07%  gpu=73C
ctx=32768 r2  main=242.72  patched=274.58  delta=+13.13%  gpu=71C

=== ctest on this branch ===
100% tests passed, 0 tests failed out of 9
```

## Notes for the reviewer

- Measured on a **consumer RTX 5090** (`sm_120`, 170 SMs). The mechanism is the same one
  documented in the adjacent hd256 comment (achieved occupancy of
  `fa_split_gqa_mma_i8_kernel` vs the generic depth policy), so the tier is expected to
  behave the same way on RTX PRO 6000, but I can only attest to what I measured here.
- Numbers come from `build/runtime/qwen3_gguf_bench` (the binary `bench/scripts/bench.sh`
  drives) run directly per context so each context is a clean process; single-context runs
  avoid the graph re-capture that a multi-context sweep triggers when `n_splits` changes.
- I did not modify any maintainer-owned path — the diff is 13 lines in
  `runtime/src/models/qwen35.cpp`.
- **On correctness**: this change cannot alter model output by construction — it only
  changes how many chunks the KV sequence is partitioned into, and the online-softmax
  combine merges the per-split partials exactly (the same property the adjacent hd256
  comment relies on: *"the online-softmax combine is exact for any split count"*).
  `ctest` is green on this branch. I was still building the local llama.cpp reference for
  `bench/scripts/accuracy.sh` when I opened this, so I am reporting the speed numbers and
  test results I actually have rather than implying an accuracy run I had not finished —
  happy to post the token-match/KL output once it completes if that is useful.
