### PR TITLE
perf(prefill): fp8 e4m3 GDN projections + fused SwiGLU-quant for Qwen3.5 long-context prefill

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
@@ -1,0 +1,224 @@
+// fp8 (e4m3) tensor-core GEMM for Qwythos batched prefill at long context (see prefill_fp8.h).
+//
+// C[M,N] = A[M,K] @ W^T, W dequantized bf16 [N,K]. fp8 x fp8 -> fp16 accumulate, with a periodic
+// flush of the fp16 partials into an fp32 accumulator, then the dequant (per-row sx[m] * per-channel
+// sw[n]) folded into the bf16 store.
+//
+// Why fp8 here: above ~96k the Gated-DeltaNet recurrence (near-1 decay) amplifies per-row int8
+// activation-quant error across the sequence, so the int8 projection path diverges (128k top1 ~0.31).
+// The dense long-ctx fallback therefore runs the GDN projections in bf16 -- ~half the int8 MAC rate.
+// e4m3 keeps a floating range (uniform *relative* error, unlike int8's uniform absolute step), so it
+// holds the recurrence far closer to bf16 fidelity than int8 while running on the fp8 tensor cores.
+//
+// Rate note (GeForce Blackwell / sm_120): fp8 with *fp32* accumulate is throttled to ~half, but fp8
+// with *fp16* accumulate runs at ~2x bf16 (the same op-bandwidth-bound rate the int8 projections
+// hit). K=4096 overflows a raw fp16 accumulator, so the operands are scaled to amax->FP8_TGT and the
+// fp16 partials are flushed to fp32 every FP8_FLUSH BK-tiles (see below).
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+#include <cuda_fp16.h>
+#include <cuda_pipeline.h>
+#include "sparkinfer/kernels/prefill_fp8.h"
+
+namespace sparkinfer { namespace kernels {
+
+namespace {
+constexpr int FP8_BM = 128;
+constexpr int FP8_BN = 128;
+constexpr int FP8_BK = 64;          // 4 x 16B chunks per row
+constexpr int FP8_MFRAG = 2;        // 32 rows per warp / 16
+constexpr int FP8_NFRAG = 8;        // 64 cols per warp / 8
+// The fp16 partials are flushed to the fp32 accumulator every FP8_FLUSH BK-tiles (not every tile),
+// which keeps the fp32-accumulate precision while bounding how large the fp16 running sum can grow.
+// Overflow bound: 2*FP8_FLUSH k32 mma steps accumulate at most 2*FP8_FLUSH*32*FP8_TGT^2 in fp16,
+// which must stay < 65504. FP8_TGT=2, FP8_FLUSH=8 -> 2*8*32*4 = 2048, huge headroom. (Empirically a
+// larger FP8_TGT loses fidelity here well before that bound; +-2 with periodic fp32 flush tracks the
+// bf16 GDN path most closely.)
+constexpr int FP8_FLUSH = 8;
+// Operand target amax. e4m3 with values in +-2 keeps a 2/2^-9 ~= 1024:1 dynamic range (still ~8x
+// finer than int8's 127:1 for the small activations the recurrence is sensitive to; e4m3's 3-bit
+// mantissa gives the same relative step at any scale, so the target sets range, not per-value error).
+constexpr float FP8_TGT = 2.0f;
+
+__device__ __forceinline__ void fp8_cp16(void* dst, const void* src, bool pred) {
+    if (pred) __pipeline_memcpy_async(dst, src, 16);
+    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
+
+// XOR swizzle at 16B granularity: chunk c of row r lives at chunk (c ^ (r & 3)) -- rows 0..3 (the
+// stride the 4B operand loads walk) land on disjoint banks. Same scheme as the int8 GEMM.
+__device__ __forceinline__ int fp8_swz(int k, int row) {
+    return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
+}
+
+__device__ __forceinline__ unsigned fp8_lds32(const __nv_fp8_e4m3* p) {
+    return *reinterpret_cast<const unsigned*>(p);
+}
+
+// Per-row symmetric fp8 quantize (amax -> FP8_TGT), one warp per row. Input bf16.
+__global__ void pf_quantize_rows_fp8_kernel(const __nv_bfloat16* __restrict__ x,
+                                            __nv_fp8_e4m3* __restrict__ q,
+                                            float* __restrict__ scale, int rows, int cols) {
+    const int r = blockIdx.x, lane = threadIdx.x;
+    if (r >= rows) return;
+    float amax = 0.f;
+    for (int c = lane; c < cols; c += 32) amax = fmaxf(amax, fabsf(__bfloat162float(x[(size_t)r * cols + c])));
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
+    const float d = (amax == 0.f) ? 1.f : (amax / FP8_TGT);
+    if (lane == 0) scale[r] = d;
+    for (int c = lane; c < cols; c += 32)
+        q[(size_t)r * cols + c] = __nv_fp8_e4m3(__bfloat162float(x[(size_t)r * cols + c]) / d);
+}
+
+// The 2 in __launch_bounds__ mirrors the int8 kernel: unbounded, nvcc picks a register count that
+// keeps only one block per SM resident.
+__global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
+        const __nv_fp8_e4m3* __restrict__ A, const __nv_fp8_e4m3* __restrict__ W,
+        const float* __restrict__ sx, const float* __restrict__ sw,
+        __nv_bfloat16* __restrict__ C, int M, int N, int K) {
+    __shared__ __nv_fp8_e4m3 As[2][FP8_BM][FP8_BK];
+    __shared__ __nv_fp8_e4m3 Bs[2][FP8_BN][FP8_BK];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int grp  = lane >> 2;                       // 0..7
+    const int tig  = lane & 3;                        // thread-in-group
+    const int wm   = warp & 3;                        // rows [wm*32, +32)
+    const int wn   = warp >> 2;                       // cols [wn*64, +64)
+    const int m0   = blockIdx.y * FP8_BM;
+    const int n0   = blockIdx.x * FP8_BN;
+    const int nk   = (K + FP8_BK - 1) / FP8_BK;
+
+    float acc[FP8_MFRAG][FP8_NFRAG][4];
+    #pragma unroll
+    for (int i = 0; i < FP8_MFRAG; i++)
+        #pragma unroll
+        for (int j = 0; j < FP8_NFRAG; j++)
+            #pragma unroll
+            for (int e = 0; e < 4; e++) acc[i][j][e] = 0.f;
+
+    // 128 rows x 64B = 512 16B chunks per tile; 256 threads stage 2 A-chunks + 2 B-chunks each.
+    auto stage = [&](int buf, int k0) {
+        #pragma unroll
+        for (int s = tid; s < 512; s += 256) {
+            const int r = s >> 2, c = s & 3, k = c << 4;
+            const int gm = m0 + r, gn = n0 + r, gk = k0 + k;
+            fp8_cp16(&As[buf][r][fp8_swz(k, r)], &A[(size_t)gm * K + gk], gm < M && gk < K);
+            fp8_cp16(&Bs[buf][r][fp8_swz(k, r)], &W[(size_t)gn * K + gk], gn < N && gk < K);
+        }
+        __pipeline_commit();
+    };
+
+    // fp16 partials, reset after each flush (every FP8_FLUSH BK-tiles) to bound the running sum.
+    unsigned h[FP8_MFRAG][FP8_NFRAG][2];
+    #pragma unroll
+    for (int i = 0; i < FP8_MFRAG; i++)
+        #pragma unroll
+        for (int j = 0; j < FP8_NFRAG; j++) { h[i][j][0] = 0u; h[i][j][1] = 0u; }
+
+    stage(0, 0);
+    int buf = 0;
+    for (int t = 0; t < nk; t++) {
+        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * FP8_BK);
+        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+        __syncthreads();
+
+        #pragma unroll
+        for (int kk = 0; kk < FP8_BK; kk += 32) {
+            const int ka = kk + tig * 4;
+            unsigned af[FP8_MFRAG][4], bf[FP8_NFRAG][2];
+            #pragma unroll
+            for (int i = 0; i < FP8_MFRAG; i++) {
+                const int rlo = wm * 32 + i * 16 + grp, rhi = rlo + 8;
+                af[i][0] = fp8_lds32(&As[buf][rlo][fp8_swz(ka,      rlo)]);
+                af[i][1] = fp8_lds32(&As[buf][rhi][fp8_swz(ka,      rhi)]);
+                af[i][2] = fp8_lds32(&As[buf][rlo][fp8_swz(ka + 16, rlo)]);
+                af[i][3] = fp8_lds32(&As[buf][rhi][fp8_swz(ka + 16, rhi)]);
+            }
+            #pragma unroll
+            for (int j = 0; j < FP8_NFRAG; j++) {
+                const int col = wn * 64 + j * 8 + grp;
+                bf[j][0] = fp8_lds32(&Bs[buf][col][fp8_swz(ka,      col)]);
+                bf[j][1] = fp8_lds32(&Bs[buf][col][fp8_swz(ka + 16, col)]);
+            }
+            #pragma unroll
+            for (int i = 0; i < FP8_MFRAG; i++)
+                #pragma unroll
+                for (int j = 0; j < FP8_NFRAG; j++)
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.f16.e4m3.e4m3.f16 "
+                        "{%0,%1}, {%2,%3,%4,%5}, {%6,%7}, {%0,%1};\n"
+                        : "+r"(h[i][j][0]), "+r"(h[i][j][1])
+                        : "r"(af[i][0]), "r"(af[i][1]), "r"(af[i][2]), "r"(af[i][3]),
+                          "r"(bf[j][0]), "r"(bf[j][1]));
+        }
+        // flush fp16 partials into the fp32 accumulator every FP8_FLUSH tiles (and on the last one)
+        if ((t % FP8_FLUSH) == FP8_FLUSH - 1 || t == nk - 1) {
+            #pragma unroll
+            for (int i = 0; i < FP8_MFRAG; i++)
+                #pragma unroll
+                for (int j = 0; j < FP8_NFRAG; j++) {
+                    const __half2 p0 = *reinterpret_cast<__half2*>(&h[i][j][0]);
+                    const __half2 p1 = *reinterpret_cast<__half2*>(&h[i][j][1]);
+                    acc[i][j][0] += __half2float(p0.x);
+                    acc[i][j][1] += __half2float(p0.y);
+                    acc[i][j][2] += __half2float(p1.x);
+                    acc[i][j][3] += __half2float(p1.y);
+                    h[i][j][0] = 0u; h[i][j][1] = 0u;
+                }
+        }
+        __syncthreads();
+        buf ^= 1;
+    }
+
+    // Registers straight to global: c0/c1 (and c2/c3) are adjacent columns -> one bf16x2 store each.
+    #pragma unroll
+    for (int i = 0; i < FP8_MFRAG; i++) {
+        #pragma unroll
+        for (int j = 0; j < FP8_NFRAG; j++) {
+            const int gn = n0 + wn * 64 + j * 8 + tig * 2;
+            if (gn + 1 >= N) {                        // tail: scalar path
+                #pragma unroll
+                for (int e = 0; e < 4; e++) {
+                    const int gm = m0 + wm * 32 + i * 16 + grp + (e >> 1) * 8;
+                    const int cn = gn + (e & 1);
+                    if (gm < M && cn < N)
+                        C[(size_t)gm * N + cn] = __float2bfloat16(acc[i][j][e] * sx[gm] * sw[cn]);
+                }
+                continue;
+            }
+            const float w0 = sw[gn], w1 = sw[gn + 1];
+            #pragma unroll
+            for (int h2 = 0; h2 < 2; h2++) {
+                const int gm = m0 + wm * 32 + i * 16 + grp + h2 * 8;
+                if (gm >= M) continue;
+                const float s = sx[gm];
+                const __nv_bfloat162 v = __floats2bfloat162_rn(acc[i][j][h2 * 2] * s * w0,
+                                                               acc[i][j][h2 * 2 + 1] * s * w1);
+                *reinterpret_cast<__nv_bfloat162*>(&C[(size_t)gm * N + gn]) = v;
+            }
+        }
+    }
+}
+} // namespace
+
+void launch_prefill_quantize_rows_fp8(const void* x_bf16, void* q, float* scale,
+                                      int rows, int cols, cudaStream_t stream) {
+    pf_quantize_rows_fp8_kernel<<<rows, 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x_bf16),
+        reinterpret_cast<__nv_fp8_e4m3*>(q), scale, rows, cols);
+}
+
+void launch_prefill_gemm_fp8(const void* A, const void* W,
+                             const float* sx, const float* sw, void* C,
+                             int M, int N, int K, cudaStream_t stream) {
+    dim3 grid((N + FP8_BN - 1) / FP8_BN, (M + FP8_BM - 1) / FP8_BM);
+    pf_gemm_fp8_kernel<<<grid, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
+        sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
+++ b/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
@@ -1,0 +1,65 @@
+// Fused SwiGLU + per-row int8 quantize for the long-context dense FFN down-projection input.
+//
+// The chunked int8 FFN computes gate/up GEMMs into ffg/ffu, then runs a standalone SwiGLU
+// (silu(gate)*up -> ffg) and a standalone per-row int8 quantize (ffg -> A_i8, sx) before the down
+// GEMM. Both are memory-bound passes over the ffn-wide (12288) intermediate; fusing them removes the
+// ffg store (SwiGLU) and the ffg reload (quantize) -- ~2 x rows*ffn bf16 of DRAM traffic per chunk.
+//
+// One block per row: each thread strides the row computing h = silu(ffg)*ffu, tracking the row amax;
+// a block reduction yields the per-row scale, then a second strided pass writes int8. Numerically
+// identical to launch_prefill_swiglu followed by launch_prefill_quantize_rows_i8 (both round the
+// SwiGLU result to bf16 first, so the int8 quant sees the same bf16 values).
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include "sparkinfer/kernels/prefill_fp8.h"
+
+namespace sparkinfer { namespace kernels {
+
+namespace {
+__device__ __forceinline__ float sq_silu(float x) { return x / (1.f + __expf(-x)); }
+
+__global__ void pf_swiglu_quant_i8_kernel(const __nv_bfloat16* __restrict__ gate,
+                                          const __nv_bfloat16* __restrict__ up,
+                                          signed char* __restrict__ q, float* __restrict__ scale,
+                                          int rows, int cols) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    // pass 1: compute h (bf16-rounded, matching the standalone SwiGLU) + row amax
+    float amax = 0.f;
+    for (int c = threadIdx.x; c < cols; c += blockDim.x) {
+        const float h = __bfloat162float(__float2bfloat16(sq_silu(__bfloat162float(gate[base + c]))
+                                                           * __bfloat162float(up[base + c])));
+        amax = fmaxf(amax, fabsf(h));
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = amax;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, m));
+        if (threadIdx.x == 0) s_warp[0] = v;
+    }
+    __syncthreads();
+    const float d = (s_warp[0] == 0.f) ? 1.f : (s_warp[0] / 127.0f);
+    if (threadIdx.x == 0) scale[row] = d;
+    // pass 2: recompute h (cheap ALU) and store int8
+    for (int c = threadIdx.x; c < cols; c += blockDim.x) {
+        const float h = __bfloat162float(__float2bfloat16(sq_silu(__bfloat162float(gate[base + c]))
+                                                           * __bfloat162float(up[base + c])));
+        q[base + c] = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(h / d));
+    }
+}
+} // namespace
+
+void launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
+                                    int rows, int cols, cudaStream_t stream) {
+    pf_swiglu_quant_i8_kernel<<<rows, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
+        q, scale, rows, cols);
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/prefill_fp8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_fp8.h
@@ -1,0 +1,39 @@
+#pragma once
+#include <cuda_runtime.h>
+
+// fp8 (e4m3) tensor-core GEMM for Qwythos (Qwen3.5) batched prefill at long context.
+//
+// The dense long-context (>96k) fallback keeps the Gated-DeltaNet projections in bf16 because the
+// near-1-decay recurrence amplifies per-row int8 activation-quant error over the sequence (128k
+// top1 ~0.31 for int8 vs ~0.69 for bf16). bf16 runs at half the int8 tensor-core rate, so those
+// projections dominate the 128k prefill. e4m3 keeps a floating range (uniform *relative* error,
+// unlike int8's uniform absolute step), holding the recurrence to bf16-like fidelity while running
+// on the fp8 tensor cores at the full int8 rate (fp16 accumulate; fp32 accumulate is throttled to
+// half on GeForce Blackwell).
+//
+// launch_prefill_gemm_fp8 mirrors launch_prefill_gemm_i8's tiling exactly (128x128 tile, 8 warps,
+// 2x8 fragments, BK=64, cp.async double-buffer) and folds the dequant into the bf16 store epilogue,
+// so it is a drop-in replacement for the bf16 GDN projection GEMM.
+
+namespace sparkinfer { namespace kernels {
+
+// Per-row symmetric fp8 quantization to a fixed target amax (so the fp16-accumulate GEMM cannot
+// overflow K=4096): scale[r] = max_c|x[r,c]| / 16, q[r,c] = e4m3(x[r,c] / scale[r]).
+// x: [rows,cols] bf16 -> q: [rows,cols] e4m3 (1 byte), scale: [rows] fp32. One warp per row.
+void launch_prefill_quantize_rows_fp8(const void* x_bf16, void* q, float* scale,
+                                      int rows, int cols, cudaStream_t stream = nullptr);
+
+// fp8 GEMM: C[M,N] = A[M,K] @ W^T, W dequantized bf16 [N,K] row-major (C[m,n]=sum_k A[m,k]*W[n,k]).
+// A/W e4m3 with per-row scales sx[M] (per token) and sw[N] (per output channel). Output C is bf16
+// with the dequant sx[m]*sw[n] fused into the store. fp16 accumulate with a per-BK-tile fp32 flush.
+void launch_prefill_gemm_fp8(const void* A, const void* W,
+                             const float* sx, const float* sw, void* C,
+                             int M, int N, int K, cudaStream_t stream = nullptr);
+
+// Fused SwiGLU + per-row int8 quantize: q[r,:] = int8(silu(gate[r,:]) * up[r,:]) with
+// scale[r] = amax_c|.| / 127. Replaces launch_prefill_swiglu + launch_prefill_quantize_rows_i8 on
+// the ffn-wide intermediate (one block per row), removing its DRAM round-trip. Bit-identical.
+void launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
+                                    int rows, int cols, cudaStream_t stream = nullptr);
+
+}} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -17,6 +17,7 @@
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/prefill_i8.h"
+#include "sparkinfer/kernels/prefill_fp8.h"
 #include "sparkinfer/kernels/prefill_moe.h"
 #include "sparkinfer/kernels/moe.h"
 
@@ -167,16 +168,25 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // unless SPARKINFER_PREFILL_I8_ATTN=0. GDN projections always stay bf16 above bf16_minctx.
     const char* _pi8attn = getenv("SPARKINFER_PREFILL_I8_ATTN");
     bool use_i8_attn = long_bf16 && (!_pi8attn || _pi8attn[0] != '0');
+    // GDN projections (wqkv/wqkv_gate/ssm_out) at long ctx: run them on the fp8 (e4m3) tensor cores
+    // instead of bf16. int8 is off here because the near-1-decay recurrence amplifies per-row int8
+    // activation-quant error (128k top1 ~0.31); e4m3's floating range holds it to bf16-like fidelity
+    // (~0.69) at the full int8 rate. The int8 activation scratch (A_i8/W_i8, 1 byte) doubles as the
+    // e4m3 buffer -- fp8 GDN and int8 FFN/attn never run at the same instant within a layer.
+    // SPARKINFER_PREFILL_FP8_GDN=0 restores the bf16 GDN projections (A/B).
+    const char* _pfp8 = getenv("SPARKINFER_PREFILL_FP8_GDN");
+    bool use_fp8_gdn = long_bf16 && (!_pfp8 || _pfp8[0] != '0');
     Arena a8;
     // A_i8 holds the quantized activation. Dense full-i8: non-FFN projs quantize N rows x K(<=H);
-    // chunked FFN quantizes at most FC rows x ffn. Long-ctx selective: N*H if attn-i8 else FC*ffn.
+    // chunked FFN quantizes at most FC rows x ffn. Long-ctx selective: N*H if attn-i8/fp8-gdn else FC*ffn.
     // MoE: no chunked FFN; projections quantize N rows x maxAK.
-    const bool need_i8 = use_i8 || use_i8_ffn || use_i8_attn || moe_shared_i8;
+    const bool wide_a = use_i8 || use_i8_attn || use_fp8_gdn;
+    const bool need_i8 = use_i8 || use_i8_ffn || use_i8_attn || use_fp8_gdn || moe_shared_i8;
     const size_t a_i8_sz = moe ? (size_t)N * maxAK
-                               : ((use_i8 || use_i8_attn)
+                               : (wide_a
                                   ? (((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn)
                                   : (size_t)FC * ffn);
-    const size_t sx_n = (use_i8 || use_i8_attn || moe_shared_i8) ? (size_t)N : (size_t)FC;
+    const size_t sx_n = (wide_a || moe_shared_i8) ? (size_t)N : (size_t)FC;
     signed char* A_i8 = need_i8 ? a8.alloc<signed char>(a_i8_sz) : nullptr;
     signed char* W_i8 = need_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = need_i8 ? a8.alloc<float>(sx_n) : nullptr;
@@ -187,6 +197,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         use_i8_ffn = false;
         use_i8_attn = false;
         moe_shared_i8 = false;
+        use_fp8_gdn = false;
         A_i8 = W_i8 = nullptr;
         sx = sw = nullptr;
     }
@@ -321,6 +332,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
             }
             kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, R, n_out, K, st);
+        } else if (use_fp8_gdn && n_out >= 128) {
+            // fp8 (e4m3) tensor-core path for the long-ctx GDN projections. A_i8/W_i8 (1 byte) hold
+            // the e4m3 operands; dequant the weight to bf16 scratch, then row/channel fp8-quantize.
+            kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, R, K, st);
+            const void* wb = dq(W, wtype, n_out, K);
+            kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, n_out, K, st);
+            kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, C, R, n_out, K, st);
         } else {
             // mma.sync bf16 GEMM only for dense-hybrid long prefill (the >96k int8→bf16 fallback).
             // MoE always stays on wmma: its top-k router turns tiny GEMM differences into expert
@@ -329,6 +347,28 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // VRAM, so R<=FC would otherwise keep the dominant gate/up/down GEMMs on wmma forever.
             const bool prefer_mma = !moe && N > bf16_minctx;
             kernels::launch_prefill_gemm(A, dq(W, wtype, n_out, K), C, R, n_out, K, st, prefer_mma);
+        }
+    };
+
+    // GDN wqkv + wqkv_gate both project the same input xn, so on the fp8 path quantize xn to e4m3
+    // ONCE and share it across both GEMMs (proj() would otherwise re-quantize xn per projection --
+    // a full redundant read of xn and rewrite of the e4m3 activation each layer). Bit-identical to
+    // the two independent proj() calls. Default on with the fp8 GDN path;
+    // SPARKINFER_PREFILL_FP8_GDN_SHAREQ=0 restores the per-projection quantize (A/B).
+    const char* _pshareq = getenv("SPARKINFER_PREFILL_FP8_GDN_SHAREQ");
+    const bool fp8_shareq = use_fp8_gdn && (!_pshareq || _pshareq[0] != '0');
+    auto gdn_qkv_z = [&](const bf16* A, const Qwen35LayerWeights& w) {
+        if (fp8_shareq) {
+            kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);   // xn -> e4m3 once
+            const void* wb = dq(w.wqkv, w.wqkv_type, lqkv, H);
+            kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lqkv, H, st);
+            kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, b8, N, lqkv, H, st);
+            wb = dq(w.wqkv_gate, w.wqkv_gate_type, lvdim, H);
+            kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lvdim, H, st);
+            kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, lz, N, lvdim, H, st);
+        } else {
+            proj(A, w.wqkv,      w.wqkv_type,      b8, lqkv,  H);   // qkv
+            proj(A, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H);   // z gate
         }
     };
 
@@ -349,8 +389,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         const Qwen35LayerWeights& w = s.w.layers[L];
         if (w.linear_attn) {
             // ---- Gated DeltaNet linear-attention layer ----
-            proj(xn, w.wqkv,      w.wqkv_type,      b8, lqkv,  H);   // qkv
-            proj(xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H);   // z gate
+            gdn_qkv_z(xn, w);                                       // qkv + z gate (fp8: fused)
             proj(xn, w.ssm_alpha, w.ssm_alpha_type, la, vh,    H);
             proj(xn, w.ssm_beta,  w.ssm_beta_type,  lb, vh,    H);
             bf16* conv_state = lin_conv_state + (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
@@ -413,8 +452,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_quantize_rows_i8(hn_c, A_i8, sx, fn, H, st);
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wg_i8, sx, ffn_swg, ffg, fn, ffn, H, st);
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wu_i8, sx, ffn_swu, ffu, fn, ffn, H, st);
-                    kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                    kernels::launch_prefill_quantize_rows_i8(ffg, A_i8, sx, fn, ffn, st);
+                    // fused SwiGLU + int8 quantize for the down input (skips the ffg DRAM round-trip)
+                    kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st);
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wd_i8, sx, ffn_swd,
                                                     ao + (size_t)fo * H, fn, H, ffn, st);
                 } else {


### PR DESCRIPTION
## Summary

Run the Qwythos (Qwen3.5) Gated-DeltaNet projections on the **fp8 (e4m3) tensor cores** at long context, fuse the dense FFN's **SwiGLU + down-input int8 quantize** into one kernel, and **share the `xn → e4m3` quantize** across the two GDN projections that read it. Above `bf16_minctx` (128k) the GDN projections were forced to bf16 (int8 activation-quant diverges on the near-1-decay recurrence), which left those GEMMs at ~half the int8 rate and dominating the 128k prefill; e4m3's floating range holds the recurrence far closer to bf16 while running at the int8 rate.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`) — unchanged (prefill-only PR):

| | decode tok/s |
|---|--:|
| before (main) | 288.09 |
| after (this PR) | 287.98 |

**Prefill pp tok/s** (Qwythos / Qwen3.5, `--ctx 131072`, best context; 4k/32k/64k are byte-identical to main so they are unchanged):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 17,890.12 |
| after prefill (this PR) | 21,045.60 |

```text
# main @772f042
$ bench/scripts/bench.sh Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf --ctx 131072 --tokens 128
>> GPU arch: sm_120
ttft         : 7.278 s  (18010.6 tok/s prefill, prompt=131072)
decode tg    : 288.09 tok/s  (3.5 ms/token, n=128, ctx=131072, bs=1)
prefill pp   : 17890.12 tok/s  (ctx=131072, sequential KV fill)

# this PR
$ bench/scripts/bench.sh Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf --ctx 131072 --tokens 128
>> GPU arch: sm_120
ttft         : 6.179 s  (21213.7 tok/s prefill, prompt=131072)
decode tg    : 287.98 tok/s  (3.5 ms/token, n=128, ctx=131072, bs=1)
prefill pp   : 21045.60 tok/s  (ctx=131072, sequential KV fill)
```

## What changed

1. **`prefill_gemm_fp8.cu` (new)** — e4m3 × e4m3 GEMM mirroring the int8 prefill GEMM's tiling (128×128 tile, 8 warps, 2×8 fragments, BK=64, cp.async double-buffer). fp8 with **fp16 accumulate** runs at ~2× bf16 on GeForce Blackwell (fp32 accumulate is throttled to half); K=4096 would overflow a raw fp16 accumulator, so operands are scaled to a fixed amax and the fp16 partials are flushed to an fp32 accumulator every 8 BK-tiles. Dequant `sx[m]·sw[n]` folded into the bf16 store. Gated on `SPARKINFER_PREFILL_FP8_GDN` (default on above `bf16_minctx`); the existing int8 activation scratch doubles as the e4m3 buffer.
2. **`prefill_swiglu_quant.cu` (new)** — fuses the long-ctx FFN's SwiGLU + per-row int8 quantize of the down-projection input, removing the ffn-wide (12288) intermediate's DRAM round-trip. One block per row; numerically equivalent to the two standalone kernels it replaces.
3. **`qwen35_prefill.cpp`** — routes the GDN projections (wqkv / wqkv_gate / ssm_out) through the fp8 path above `bf16_minctx`, calls the fused SwiGLU-quantize in the int8 FFN chunk loop, and **shares one `xn → e4m3` quantize across the wqkv + wqkv_gate projections** (both read the same activation; the generic path re-quantized `xn` for each — a full redundant `xn` read + e4m3 rewrite every GDN layer). The share is bit-identical to the two independent projections.

## Correctness / quality

- **Decode-neutral & no-regression:** every change is confined to `prefill_batched_run` and gated to the long-context path. The accuracy gates score `forward_token` (decode), which is untouched; 4k/32k/64k prefill and decode are **byte-for-byte identical to main** (batched-prefill seed + KL match to 5 decimals at 4096/32768/65536), and the fp8/fusion code never runs below `bf16_minctx` / outside the int8 FFN.
- **fp8 vs int8 vs bf16 at 128k** (batched prefill → greedy free-run): bf16 GDN is a clean ramp, **fp8 GDN tracks it closely** (~1 differing token in 24), and forced-int8 GDN produces incoherent output — the intended result: e4m3 holds the recurrence int8 collapses. Batched-vs-token-reference at 128k (synthetic-ramp prompt, so even bf16 scores low there): bf16 top1 0.333 / KL 0.208, fp8 top1 0.250 / KL 0.218 — fp8 tracks bf16 (KL Δ +0.010), int8 diverges.

## Relation to open PRs

`qwen35_prefill.cpp` is the shared Qwen3.5 + Qwen3.6 prefill translation unit, so open PRs that add **Qwen3.6 MoE** prefill paths also touch it — but this PR adds a **Qwythos (dense) fp8 GDN** path plus a dense-FFN SwiGLU fusion, on disjoint code paths. The new `.cu`/`.h` files are unique to this PR; no shared kernels, no overlapping added lines.