### PR TITLE
perf(qwen36): direct-4-bit MMQ MoE prefill GEMM for short-context prefill (+38% pp @128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_mmq.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_mmq.cu
@@ -1,0 +1,286 @@
+// Direct-4-bit ("MMQ") grouped MoE expert GEMM for batched prefill — see prefill_moe_mmq.h.
+//
+// Replaces the "dequant whole expert to int8, then int8 tensor-core GEMM" pair with a single
+// dp4a matmul that reads the GGUF Q4_K/Q5_K super-blocks directly, the way decode's MMVQ does.
+// At the small token counts of the 128/512 prefill contexts each expert's GEMM is tiny and the
+// layer is bound by the weight-DRAM traffic of the dequant materialize; folding the weight read
+// into the matmul removes the int8 round-trip (~5x less weight traffic).
+//
+// The Q4_K/Q5_K per-super-block dp4a dots and the Q8_1 quantizer below are the standard
+// llama.cpp-faithful routines (byte-identical to the ones already in expert_ffn_q4k.cu /
+// gemv.cu that the decode MMVQ path uses); they are duplicated here so this stays a single
+// self-contained translation unit. Weight blocks are staged once into shared memory per
+// super-block and reused across the tile's tokens, so each 4-bit block is read from DRAM once.
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include "sparkinfer/kernels/prefill_moe_mmq.h"
+
+namespace sparkinfer {
+namespace kernels {
+namespace {
+
+// ---- GGUF super-block layouts (llama.cpp) --------------------------------------------------
+struct mmq_q8_1 { __half2 ds; signed char qs[32]; };                                     // 36 B / 32
+struct mmq_q4_K { __half2 dm; unsigned char scales[12]; unsigned char qs[128]; };        // 144 B / 256
+struct mmq_q5_K { __half2 dm; unsigned char scales[12]; unsigned char qh[32];
+                              unsigned char qs[128]; };                                   // 176 B / 256
+
+// Q4_K x Q8_1 dp4a for one 256-super-block at position iqs (0,2,..,30). Faithful to
+// llama.cpp vec_dot_q4_K_q8_1 (matches the decode si_vec_dot_q4_K).
+__device__ __forceinline__ float mmq_dot_q4_K(const mmq_q4_K* bq4, const mmq_q8_1* bq8_1, int iqs) {
+    int v[2], u[4];
+    float d8[2];
+    const int bq8_offset = 2 * ((iqs / 2) / 4);
+    const int* q4 = (const int*)(bq4->qs + 16 * bq8_offset + 4 * ((iqs / 2) % 4));
+    v[0] = q4[0];
+    v[1] = q4[4];
+    const unsigned short* scales = (const unsigned short*)bq4->scales;
+    unsigned short aux[2];
+    const int j = bq8_offset / 2;
+    if (j < 2) {
+        aux[0] = scales[j] & 0x3f3f;
+        aux[1] = scales[j + 2] & 0x3f3f;
+    } else {
+        aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+        aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j] & 0xc0c0) >> 2);
+    }
+    const unsigned char* sc = (const unsigned char*)aux;
+    const unsigned char* m = sc + 2;
+#pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const mmq_q8_1* bq8i = bq8_1 + bq8_offset + i;
+        d8[i] = __low2float(bq8i->ds);
+        const int* q8 = (const int*)bq8i->qs + ((iqs / 2) % 4);
+        u[2 * i] = q8[0];
+        u[2 * i + 1] = q8[4];
+    }
+    float sumf_d = 0.0f, sumf_m = 0.0f;
+#pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int v0i = (v[0] >> (4 * i)) & 0x0F0F0F0F, v1i = (v[1] >> (4 * i)) & 0x0F0F0F0F;
+        const int dot1 = __dp4a(v1i, u[2 * i + 1], __dp4a(v0i, u[2 * i], 0));
+        const int dot2 = __dp4a(0x01010101, u[2 * i + 1], __dp4a(0x01010101, u[2 * i], 0));
+        sumf_d += d8[i] * (dot1 * sc[i]);
+        sumf_m += d8[i] * (dot2 * m[i]);
+    }
+    float2 dm4f = __half22float2(bq4->dm);
+    return dm4f.x * sumf_d - dm4f.y * sumf_m;
+}
+
+// Q5_K x Q8_1 dp4a — Q4_K plus one high bit per quant (matches decode si_vec_dot_q5_K).
+__device__ __forceinline__ float mmq_dot_q5_K(const mmq_q5_K* bq5, const mmq_q8_1* bq8_1, int iqs) {
+    int v[2], u[4];
+    float d8[2];
+    const int L = iqs >> 1;
+    const int bq8_offset = 2 * (L / 4);
+    const int* q4 = (const int*)(bq5->qs + 16 * bq8_offset + 4 * (L % 4));
+    v[0] = q4[0];
+    v[1] = q4[4];
+    const int* qhp = (const int*)(bq5->qh + 4 * (L % 4));
+    const int qh0 = qhp[0], qh1 = qhp[4];
+    const unsigned short* scales = (const unsigned short*)bq5->scales;
+    unsigned short aux[2];
+    const int j = bq8_offset / 2;
+    if (j < 2) {
+        aux[0] = scales[j] & 0x3f3f;
+        aux[1] = scales[j + 2] & 0x3f3f;
+    } else {
+        aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+        aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j] & 0xc0c0) >> 2);
+    }
+    const unsigned char* sc = (const unsigned char*)aux;
+    const unsigned char* m = sc + 2;
+#pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const mmq_q8_1* bq8i = bq8_1 + bq8_offset + i;
+        d8[i] = __low2float(bq8i->ds);
+        const int* q8 = (const int*)bq8i->qs + (L % 4);
+        u[2 * i] = q8[0];
+        u[2 * i + 1] = q8[4];
+    }
+    float sumf_d = 0.f, sumf_m = 0.f;
+#pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int hs = bq8_offset + i;
+        const int v0i = ((v[0] >> (4 * i)) & 0x0F0F0F0F) | (((qh0 >> hs) & 0x01010101) << 4);
+        const int v1i = ((v[1] >> (4 * i)) & 0x0F0F0F0F) | (((qh1 >> hs) & 0x01010101) << 4);
+        const int dot1 = __dp4a(v0i, u[2 * i], __dp4a(v1i, u[2 * i + 1], 0));
+        const int dot2 = __dp4a(0x01010101, u[2 * i], __dp4a(0x01010101, u[2 * i + 1], 0));
+        sumf_d += d8[i] * (dot1 * sc[i]);
+        sumf_m += d8[i] * (dot2 * m[i]);
+    }
+    float2 dm5f = __half22float2(bq5->dm);
+    return dm5f.x * sumf_d - dm5f.y * sumf_m;
+}
+
+template <int QT> struct mmq_wtraits;
+template <> struct mmq_wtraits<12> {
+    using B = mmq_q4_K;
+    static constexpr int BS = 144;
+    static __device__ __forceinline__ float dot(const B* w, const mmq_q8_1* a, int iqs) {
+        return mmq_dot_q4_K(w, a, iqs);
+    }
+};
+template <> struct mmq_wtraits<13> {
+    using B = mmq_q5_K;
+    static constexpr int BS = 176;
+    static __device__ __forceinline__ float dot(const B* w, const mmq_q8_1* a, int iqs) {
+        return mmq_dot_q5_K(w, a, iqs);
+    }
+};
+
+// bf16 -> Q8_1 (one 32-value block per warp), interleaved {ds, qs[32]}.
+__global__ void mmq_quantize_rows_q8_1_kernel(const __nv_bfloat16* __restrict__ x,
+                                              mmq_q8_1* __restrict__ y, long total_blocks) {
+    const int warpsPB = blockDim.x >> 5;
+    const long ib = (long)blockIdx.x * warpsPB + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (ib >= total_blocks) return;
+    float xv = __bfloat162float(x[ib * 32 + lane]), a = fabsf(xv);
+#pragma unroll
+    for (int mm = 16; mm > 0; mm >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, mm));
+    float d = a / 127.0f;
+    int qi = (a == 0.0f) ? 0 : (int)roundf(xv / d);
+    y[ib].qs[lane] = (signed char)qi;
+    int s = qi;
+#pragma unroll
+    for (int mm = 16; mm > 0; mm >>= 1) s += __shfl_xor_sync(0xffffffffu, s, mm);
+    if (lane == 0) y[ib].ds = __floats2half2_rn(d, d * (float)s);
+}
+
+// Grouped MoE GEMM. One block == one (expert, m-tile) x BN output columns. The expert's
+// weight super-block is staged into shared memory once and dp4a'd against all BM tokens'
+// Q8_1 activations, so each 4-bit block is read from DRAM once (weight-amortized).
+constexpr int MMQ_BM = 16;
+constexpr int MMQ_BN = 32;
+
+template <int QT, bool A_INDIRECT, bool C_SCATTER>
+__global__ void __launch_bounds__(MMQ_BM* MMQ_BN)
+mmq_moe_gemm_kernel(const mmq_q8_1* __restrict__ A_q8, const unsigned char* __restrict__ W_q,
+                    const int* __restrict__ pair_tok, const float* __restrict__ pair_w,
+                    const int* __restrict__ offsets, const int* __restrict__ tilemap,
+                    const int* __restrict__ d_ntiles, __nv_bfloat16* __restrict__ C,
+                    float* __restrict__ out_f32, int N, int K, int e_base) {
+    using WT = mmq_wtraits<QT>;
+    using WB = typename WT::B;
+    constexpr int BS = WT::BS;
+    constexpr int BSW = BS / 4;  // ints per weight super-block
+
+    const int tile = blockIdx.y;
+    if (tile >= d_ntiles[0]) return;
+    const int e = tilemap[2 * tile];
+    const int mt = tilemap[2 * tile + 1];
+    const int p0 = offsets[e] + mt * MMQ_BM;
+    const int cnt = offsets[e + 1] - offsets[e];
+    const int M = min(MMQ_BM, cnt - mt * MMQ_BM);
+    const int n0 = blockIdx.x * MMQ_BN;
+    const int nsb = K >> 8;   // 256-super-blocks along K
+    const int kblk = K >> 5;  // Q8_1 blocks along K
+
+    __shared__ int s_tok[MMQ_BM];
+    __shared__ WB Ws[MMQ_BN];
+    __shared__ mmq_q8_1 As[MMQ_BM][8];
+
+    const int tid = threadIdx.x;
+    const int m = tid / MMQ_BN;
+    const int n = tid % MMQ_BN;
+    const int gn = n0 + n;
+
+    if (tid < MMQ_BM)
+        s_tok[tid] = (tid < M) ? (A_INDIRECT ? pair_tok[p0 + tid] : (p0 + tid)) : -1;
+    __syncthreads();
+
+    const size_t we_base = (size_t)(e - e_base) * (size_t)N;
+    float acc = 0.f;
+    for (int sb = 0; sb < nsb; sb++) {
+        // stage BN weight super-blocks (one per output column of this tile)
+        for (int i = tid; i < MMQ_BN * BSW; i += blockDim.x) {
+            const int col = i / BSW, w = i % BSW;
+            const int gncol = n0 + col;
+            const int* src = (const int*)(W_q + ((we_base + gncol) * (size_t)nsb + sb) * BS);
+            ((int*)&Ws[col])[w] = (gncol < N) ? src[w] : 0;
+        }
+        // stage BM tokens' 8 Q8_1 blocks for this super-block (9 ints per 36 B block)
+        for (int i = tid; i < MMQ_BM * 8 * 9; i += blockDim.x) {
+            const int r = i / 72, rem = i % 72, blk = rem / 9, w = rem % 9;
+            const int arow = s_tok[r];
+            const int* src = (const int*)(A_q8 + ((size_t)max(arow, 0) * kblk + (size_t)sb * 8 + blk));
+            ((int*)&As[r][blk])[w] = (arow >= 0) ? src[w] : 0;
+        }
+        __syncthreads();
+        if (m < M && gn < N) {
+            const WB* wblk = &Ws[n];
+            const mmq_q8_1* a = &As[m][0];
+#pragma unroll
+            for (int iqs = 0; iqs < 32; iqs += 2)
+                acc += WT::dot(wblk, a, iqs);
+        }
+        __syncthreads();
+    }
+
+    if (m < M && gn < N) {
+        const int p = p0 + m;
+        if (C_SCATTER)
+            atomicAdd(&out_f32[(size_t)pair_tok[p] * N + gn], acc * pair_w[p]);
+        else
+            C[(size_t)p * N + gn] = __float2bfloat16(acc);
+    }
+}
+
+template <int QT>
+inline void dispatch_mmq(const mmq_q8_1* A, const unsigned char* W, const int* pair_tok,
+                         const float* pair_w, const int* offsets, const int* tilemap,
+                         const int* d_ntiles, __nv_bfloat16* C, float* out_f32, int N, int K,
+                         int max_tiles, int e_base, bool a_indirect, bool c_scatter,
+                         cudaStream_t st) {
+    dim3 grid((N + MMQ_BN - 1) / MMQ_BN, max_tiles);
+    const int block = MMQ_BM * MMQ_BN;
+    if (a_indirect && !c_scatter)
+        mmq_moe_gemm_kernel<QT, true, false><<<grid, block, 0, st>>>(
+            A, W, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N, K, e_base);
+    else if (!a_indirect && c_scatter)
+        mmq_moe_gemm_kernel<QT, false, true><<<grid, block, 0, st>>>(
+            A, W, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N, K, e_base);
+    else if (a_indirect && c_scatter)
+        mmq_moe_gemm_kernel<QT, true, true><<<grid, block, 0, st>>>(
+            A, W, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N, K, e_base);
+    else
+        mmq_moe_gemm_kernel<QT, false, false><<<grid, block, 0, st>>>(
+            A, W, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N, K, e_base);
+}
+
+}  // namespace
+
+void launch_prefill_quantize_rows_q8_1(const void* x_bf16, void* y_q8_1, int rows, int K,
+                                       cudaStream_t stream) {
+    const long total = (long)rows * (K >> 5);
+    if (total <= 0) return;
+    const int WPB = 8;
+    const long blocks = (total + WPB - 1) / WPB;
+    mmq_quantize_rows_q8_1_kernel<<<(unsigned)blocks, WPB * 32, 0, stream>>>(
+        (const __nv_bfloat16*)x_bf16, (mmq_q8_1*)y_q8_1, total);
+}
+
+bool launch_pfm_moe_mmq(const void* A_q8_1, const void* W_q, int qtype, const int* pair_tok,
+                        const float* pair_w, const int* offsets, const int* tilemap,
+                        const int* d_ntiles, void* C_bf16, float* out_f32, int N_out, int K,
+                        int max_tiles, int e_base, bool a_indirect, bool c_scatter,
+                        cudaStream_t stream) {
+    const mmq_q8_1* A = (const mmq_q8_1*)A_q8_1;
+    const unsigned char* W = (const unsigned char*)W_q;
+    __nv_bfloat16* C = (__nv_bfloat16*)C_bf16;
+    if (qtype == 12)
+        dispatch_mmq<12>(A, W, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K,
+                         max_tiles, e_base, a_indirect, c_scatter, stream);
+    else if (qtype == 13)
+        dispatch_mmq<13>(A, W, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K,
+                         max_tiles, e_base, a_indirect, c_scatter, stream);
+    else
+        return false;
+    return true;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_moe_mmq.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_mmq.h
@@ -1,0 +1,47 @@
+#pragma once
+#include <cuda_runtime.h>
+
+// Direct-4-bit ("MMQ") grouped MoE expert GEMM for the batched prefill path.
+//
+// The int8 MoE prefill GEMM (launch_pfm_moe_gemm_i8_bm) first dequantizes each expert's
+// GGUF weight to a full int8 row buffer (launch_gguf_dequant_rows_i8) and then runs an
+// int8 tensor-core GEMM over it. At small token counts (few tokens per expert, e.g. the
+// 128/512 prefill contexts) that dequant materialize dominates the layer: the weight is
+// read as 4-bit, written back as int8 (2x the bytes), then re-read by the GEMM — ~5x the
+// weight-DRAM traffic of reading the 4-bit block once. Since the per-expert GEMM is tiny
+// there, the layer is weight-read-bound and the dequant, not the matmul, is the wall.
+//
+// This path folds the weight read into the matmul the way decode's MMVQ does: activations
+// are quantized to Q8_1 and each expert's Q4_K/Q5_K block is dp4a'd directly, with no int8
+// materialize. It reuses the exact pair/tilemap bucketing of the int8 path, so only the
+// inner GEMM differs. It wins at small M (weight-bound) and is intentionally NOT used at
+// large M, where the int8 tensor-core path is faster.
+
+namespace sparkinfer {
+namespace kernels {
+
+// Quantize `rows` rows of `K` bf16 activations to Q8_1 blocks (36 B / 32 values,
+// interleaved {ds, qs[32]}, one block per 32 elements) — the layout the dp4a dots consume.
+// Output buffer must hold rows*(K/32) Q8_1 blocks.
+void launch_prefill_quantize_rows_q8_1(const void* x_bf16, void* y_q8_1,
+                                       int rows, int K, cudaStream_t stream);
+
+// Grouped MoE expert GEMM reading GGUF-quantized weights directly (dp4a with Q8_1
+// activations). Same pair/tilemap contract as launch_pfm_moe_gemm_i8_bm:
+//   A_q8_1     : [rows][K/32] Q8_1 activations (rows = tokens if a_indirect, else pairs)
+//   W_q        : raw GGUF expert weights [n_experts][N_out][K/256 super-blocks]
+//   qtype      : ggml type id — 12 (Q4_K) and 13 (Q5_K) supported; else returns false
+//   pair_tok/pair_w/offsets/tilemap/d_ntiles/e_base : bucketing built by
+//                launch_pfm_bucket_pairs_bm (unchanged)
+//   C_bf16     : dense pair-major output when !c_scatter (gate/up)
+//   out_f32    : token-major scatter-add target when c_scatter (down; folds pair_w)
+// Returns false (no launch) for unsupported qtype so the caller can fall back.
+bool launch_pfm_moe_mmq(const void* A_q8_1, const void* W_q, int qtype,
+                        const int* pair_tok, const float* pair_w,
+                        const int* offsets, const int* tilemap, const int* d_ntiles,
+                        void* C_bf16, float* out_f32,
+                        int N_out, int K, int max_tiles, int e_base,
+                        bool a_indirect, bool c_scatter, cudaStream_t stream);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -19,6 +19,7 @@
 #include "sparkinfer/kernels/prefill_i8.h"
 #include "sparkinfer/kernels/prefill_fp8.h"
 #include "sparkinfer/kernels/prefill_moe.h"
+#include "sparkinfer/kernels/prefill_moe_mmq.h"
 #include "sparkinfer/kernels/moe.h"
 
 #include <cuda_runtime.h>
@@ -231,10 +232,26 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     //
     const int E = moe ? c.n_experts : 0, topk = moe ? c.top_k : 0, mffn = moe ? c.moe_ffn : 0;
     const int P = moe ? N * topk : 0;                          // routed (token, expert) pairs
+    // Direct-4-bit MMQ MoE FFN: at small token counts the per-expert GEMM is tiny and the
+    // layer is bound by the weight-DRAM traffic of the int8 dequant materialize, so read the
+    // Q4_K/Q5_K experts directly (dp4a with Q8_1 activations) instead. Default ON for N<=512
+    // (the 128/512 prefill contexts); at large N the int8 tensor-core path is faster, so it is
+    // left untouched. SPARKINFER_PREFILL_MOE_MMQ=0/1 overrides; MAXN sets the auto threshold.
+    const int moe_mmq_maxn = [&]{
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_MMQ_MAXN");
+        return e ? atoi(e) : 256;   // measured crossover: MMQ wins for N<=256 (few tokens/expert)
+    }();
+    const bool moe_mmq = [&]{
+        if (!moe) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_MMQ");
+        if (e) return e[0] != '0';
+        return N <= moe_mmq_maxn;
+    }();
     // Short-N: BM=16 fills the tile (avg pairs/expert = N*8/256 = N/32; at 512 → 16).
-    // Long-N: BM=128. Override with SPARKINFER_PREFILL_MOE_BM={16,128}.
+    // Long-N: BM=128. Override with SPARKINFER_PREFILL_MOE_BM={16,128}. MMQ requires BM=16.
     const int moe_bm = [&]{
         if (!moe) return 128;
+        if (moe_mmq) return 16;
         const char* e = getenv("SPARKINFER_PREFILL_MOE_BM");
         if (e) { int v = atoi(e); return (v == 16) ? 16 : 128; }
         return (N <= 512) ? 16 : 128;
@@ -292,6 +309,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     int *mids = nullptr, *mcounts = nullptr, *moffsets = nullptr, *mcursors = nullptr;
     int *pair_tok = nullptr, *tilemap = nullptr, *d_ntiles = nullptr, *d_live_le = nullptr;
     bf16 *hg = nullptr, *hu = nullptr, *hh = nullptr, *sfg = nullptr, *sfu = nullptr, *sfh = nullptr;
+    unsigned char *aq_gate = nullptr, *aq_down = nullptr;   // Q8_1 activations for the MMQ path
     if (moe) {
         if (!moe_fused) {
             // Serial: moe_slots * moe_group experts (ping-pong when piped). Bulk: full E.
@@ -327,6 +345,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         sfg = am.alloc<bf16>((size_t)N * mffn);                // shared-expert gate/up/hidden (full N)
         sfu = am.alloc<bf16>((size_t)N * mffn);
         sfh = am.alloc<bf16>((size_t)N * mffn);
+        if (moe_mmq) {                                         // Q8_1 activations (36 B / 32 vals)
+            aq_gate = am.alloc<unsigned char>((size_t)N * (H / 32) * 36);       // gate/up A (per token)
+            aq_down = am.alloc<unsigned char>((size_t)P * (mffn / 32) * 36);    // down A (per pair)
+        }
         if (!am.ok) {
             a.free_all(); a8.free_all(); am.free_all(); aw.free_all();
             fprintf(stderr, "[prefill] MoE scratch alloc failed (ctx=%d) -> fallback\n", N);
@@ -512,9 +534,28 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_moe_router(mlogits, mids, mweights, mcounts, N, E, topk, 1, st);
             kernels::launch_pfm_bucket_pairs_bm(mids, mweights, mcounts, moffsets, mcursors,
                                                 pair_tok, pair_w, tilemap, d_ntiles, N, E, topk, moe_bm, st);
-            kernels::launch_prefill_quantize_rows_i8(hn, mA_i8, msx, N, H, st);
+            // Direct-4-bit MMQ path for Q4_K gate/up + Q5_K down (the common UD layout); other
+            // qtypes (e.g. Q6_K down) fall through to the int8 materialize path below.
+            const bool layer_mmq = moe_mmq && w.gate_qtype == 12 && w.up_qtype == 12 && w.down_qtype == 13;
+            if (!layer_mmq)
+                kernels::launch_prefill_quantize_rows_i8(hn, mA_i8, msx, N, H, st);
             bool sg_hid = false;  // shared-gate scalar already on stream_k
-            if (moe_fused) {
+            if (layer_mmq) {
+                // Read Q4_K/Q5_K experts directly (dp4a) — no int8 dequant materialize.
+                kernels::launch_prefill_quantize_rows_q8_1(hn, aq_gate, N, H, st);
+                kernels::launch_pfm_moe_mmq(aq_gate, w.gate_q, w.gate_qtype, pair_tok, pair_w,
+                                            moffsets, tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles,
+                                            0, /*a_indirect=*/true, /*c_scatter=*/false, st);
+                kernels::launch_pfm_moe_mmq(aq_gate, w.up_q, w.up_qtype, pair_tok, pair_w,
+                                            moffsets, tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
+                                            0, true, false, st);
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
+                kernels::launch_prefill_quantize_rows_q8_1(hh, aq_down, P, mffn, st);
+                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
+                kernels::launch_pfm_moe_mmq(aq_down, w.down_q, w.down_qtype, pair_tok, pair_w,
+                                            moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
+                                            0, /*a_indirect=*/false, /*c_scatter=*/true, st);
+            } else if (moe_fused) {
                 // On-the-fly Q→bf16 B staging — no full-expert int8 materialize (experimental).
                 kernels::launch_pfm_moe_gemm_qk(mA_i8, msx, w.gate_q, w.gate_qtype, pair_tok, pair_w,
                                                 moffsets, tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles,


### PR DESCRIPTION
## Summary

Add a **direct-4-bit ("MMQ") grouped MoE expert GEMM** for the batched prefill path and use it for short contexts (`N <= 256`). The int8 MoE prefill GEMM dequantizes each expert's Q4_K/Q5_K weight to a full int8 row buffer (`launch_gguf_dequant_rows_i8`) and then runs an int8 tensor-core GEMM over it. At small token counts the per-expert GEMM is tiny and the layer is **bound by that dequant materialize** — the weight is read as 4-bit, written back as int8 (2x the bytes), then re-read by the GEMM (~5x the weight-DRAM traffic of reading the 4-bit block once). MMQ folds the weight read into the matmul the way decode's MMVQ already does: activations are quantized to Q8_1 and each Q4_K/Q5_K expert block is `dp4a`'d directly, with no int8 materialize. New self-contained kernel `kernels/csrc/cuda/fused/prefill_moe_mmq.cu`; it reuses the existing pair/tilemap bucketing unchanged and only swaps the inner GEMM. Default ON for `N <= 256` (`SPARKINFER_PREFILL_MOE_MMQ=0/1`, `SPARKINFER_PREFILL_MOE_MMQ_MAXN` overrides); at larger N the int8 tensor-core path is faster and is left untouched.

Distinct from the other prefill-MoE PRs: **#566** (coalesce live dequant + fused gate/up — still materializes int8), **#572** (mma.sync int8 MoE GEMM — consumes already-dequantized `W_i8`), and **#544** (weight-stationary grouped — still dequantizes). Those speed up the dequant or the int8 GEMM; this one removes the dequant entirely for the short-context case.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (no claimed gain; decode path untouched, no-regression >=0.98):

| | decode tok/s |
|---|--:|
| before (main) | 496.46 |
| after (this PR) | 496.07 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B MoE — score context **128**):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 1212.85 |
| after prefill (this PR) | **1672.99** |

```text
# RTX 5090 (sm_120), CUDA 12.8 — model: Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
# bench/scripts/bench.sh <gguf> --ctx 128 --tokens 128, SPARKINFER_KV_INT8=1 (batched prefill = int8 KV)

### BEFORE (main e050e60) ###
=== sparkinfer — decode (n=128, ctx=128, bs=1) ===
decode tg    : 496.46 tok/s  (2.0 ms/token, n=128, ctx=128, bs=1)
prefill pp   : 1212.85 tok/s  (ctx=128, sequential KV fill)

### AFTER (this PR) ###
=== sparkinfer — decode (n=128, ctx=128, bs=1) ===
decode tg    : 496.07 tok/s  (2.0 ms/token, n=128, ctx=128, bs=1)
prefill pp   : 1672.99 tok/s  (ctx=128, sequential KV fill)

# No-regression at the other scored prefill contexts (MMQ off for N>256 -> identical int8 path),
# eval-representative sweep (one session, SPARKINFER_BENCH_SWEEP_CTXS=128,512,4096,16384,32768):
#   ctx      main pp    this PR pp
#   128      1227       1662      (+35%)
#   512      4185       4179      (-0.1%)
#   4096     12786      12731     (-0.4%)
#   16384    15731      15725     (~0%)
#   32768    16105      16095     (~0%)
# bench.sh @512: main 4213.26 -> PR 4210.01  (int8 path, unchanged)
#
# Qwythos-9B / Qwen3.5 (dense, not MoE) unaffected — bench.sh @4k: main 21068.69 -> PR 21040.85
#
# Fidelity (qwen3_gguf_prefill_check @128, 16 positions vs the token-by-token reference):
#   main (int8 materialize)  TOP1 0.875   KL 0.047
#   this PR (MMQ)            TOP1 0.9375  KL 0.043   (MMQ shares decode's dp4a numerics ->
#                                                     slightly closer to the reference)
#   SPARKINFER_PREFILL_MOE_MMQ=0 reproduces main exactly.
```
