### PR TITLE
fix(eval): skip RTX 5090 auto-close when PR has hold

### DIFF
--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -2548,6 +2548,9 @@ def main():
             _reconcile(NEEDS_BENCH_LABEL, [EVAL_GATE_LABEL, NOT_TESTED_LABEL])
             if first_time and not args.dry_run: post_needs_bench_comment(args.repo, num)
         else:  # unchecked
+            if HOLD_LABEL in pr_labels:
+                print(f"PR #{num}: not greenlit ({reason}) — hold, skip close")
+                continue
             print(f"PR #{num}: not greenlit ({reason}) — close (RTX 5090 unchecked)")
             if not args.dry_run:
                 close_rtx5090_unchecked_pr(args.repo, num)


### PR DESCRIPTION
## Summary
- In the main eval loop, do not auto-close unchecked RTX 5090 PRs that have the \`hold\` label
- Matches \`close_unchecked_rtx5090_prs\` / \`rtx5090_close_exempt\` behavior

## Test plan
- [ ] \`hold\` + unchecked checkbox → bot logs skip close, PR stays open
- [ ] unchecked without \`hold\` → still auto-closes