### PR TITLE
perf(qwen35): ldmatrix GEMM staging, register-resident attention O, fused residual/quantize prefill passes

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -425,6 +425,90 @@ __global__ void pf_gdn_conv_par_kernel(const __nv_bfloat16* __restrict__ qkv,
 }
 
 // ============================================================================
+// Token-tiled variant of pf_gdn_conv_par_kernel. That kernel launches one block per (token, head),
+// so every raw qkv row is re-read from DRAM by the conv_kernel overlapping token blocks -- a ~4x
+// read amplification of the largest input (measured at its DRAM roofline *including* that
+// amplification). One block per (16-token tile, head) instead: each thread seeds a register
+// window with its channel's conv_kernel-1 boundary rows and slides it across the tile, so the
+// tile reads 16+conv_kernel-1 rows for 16 outputs (~1.2x). Tap order, SiLU, and the two-stage
+// L2-norm reduction are unchanged, and the boundary "add w*0" equals the parallel kernel's
+// predicated skip exactly -- output is bit-identical.
+// ============================================================================
+constexpr int PF_CONV_TT = 16;                     // tokens per block
+__global__ void pf_gdn_conv_tile_kernel(const __nv_bfloat16* __restrict__ qkv,
+                                        const __nv_bfloat16* __restrict__ conv_w,
+                                        __nv_bfloat16* __restrict__ conv_state,
+                                        __nv_bfloat16* __restrict__ q,
+                                        __nv_bfloat16* __restrict__ k,
+                                        __nv_bfloat16* __restrict__ v,
+                                        int n_tokens, int q_heads, int v_heads,
+                                        int head_dim, int qkv_dim, int conv_kernel, float eps) {
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int tok0 = blockIdx.x * PF_CONV_TT;
+    const int blk = blockIdx.y;                    // output head
+    const int t   = threadIdx.x;                   // channel within head
+    int d; __nv_bfloat16* out; int out_dim; int hh; bool do_norm;
+    if (blk < q_heads)            { hh = blk;                d = hh * head_dim + t;               out = q; out_dim = q_dim; do_norm = true;  }
+    else if (blk < 2 * q_heads)   { hh = blk - q_heads;      d = q_dim + hh * head_dim + t;       out = k; out_dim = q_dim; do_norm = true;  }
+    else                          { hh = blk - 2 * q_heads;  d = 2 * q_dim + hh * head_dim + t;   out = v; out_dim = v_dim; do_norm = false; }
+
+    float w[8];                                    // conv taps (conv_kernel <= 8)
+    #pragma unroll
+    for (int c = 0; c < 8; c++) w[c] = (c < conv_kernel) ? pf_to_f(conv_w[(size_t)d * conv_kernel + c]) : 0.f;
+    float hist[7];                                 // rolling raw-qkv window for this channel (<=7)
+    #pragma unroll
+    for (int c = 0; c < 7; c++) {
+        const int src = tok0 - (conv_kernel - 1) + c;
+        hist[c] = (c < conv_kernel - 1 && src >= 0) ? pf_to_f(qkv[(size_t)src * qkv_dim + d]) : 0.f;
+    }
+
+    __shared__ float sw[32];
+    const int nwarp = (blockDim.x + 31) / 32;
+    #pragma unroll
+    for (int tt = 0; tt < PF_CONV_TT; tt++) {
+        const int tok = tok0 + tt;
+        if (tok >= n_tokens) break;                // uniform across the block
+        const float cur = pf_to_f(qkv[(size_t)tok * qkv_dim + d]);
+        float y = 0.f;
+        #pragma unroll
+        for (int c = 0; c < 7; c++)
+            if (c < conv_kernel - 1) y += w[c] * hist[c];
+        y += w[conv_kernel - 1] * cur;
+        #pragma unroll
+        for (int c = 0; c < 6; c++)
+            if (c < conv_kernel - 2) hist[c] = hist[c + 1];
+        if (conv_kernel >= 2) hist[conv_kernel - 2] = cur;
+
+        float cval = pf_silu(y);
+        if (do_norm) {
+            float ss = pf_wsum(cval * cval);
+            if ((t & 31) == 0) sw[t >> 5] = ss;
+            __syncthreads();
+            if (t < 32) {
+                float vv = (t < nwarp) ? sw[t] : 0.f;
+                vv = pf_wsum(vv);
+                if (t == 0) sw[0] = rsqrtf(vv + eps);
+            }
+            __syncthreads();
+            cval *= sw[0];
+        }
+        out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
+    }
+
+    // persist the conv window (last conv_kernel-1 raw qkv) in the decode layout.
+    if (tok0 <= n_tokens - 1 && n_tokens - 1 < tok0 + PF_CONV_TT) {
+        #pragma unroll
+        for (int c = 0; c < 7; c++) {
+            if (c >= conv_kernel - 1) break;
+            const int src = n_tokens - 1 - (conv_kernel - 2 - c);
+            conv_state[(size_t)c * qkv_dim + d] =
+                (src >= 0) ? qkv[(size_t)src * qkv_dim + d] : __float2bfloat16(0.f);
+        }
+    }
+}
+
+// ============================================================================
 // Gated-DeltaNet sequential recurrence, scanned over N tokens in one launch.
 // Warp-per-state-column, register-cached column, transposed final state layout —
 // bit-identical to running gdn_ar_fast (the SPARKINFER_GDN_FAST default) N times.
@@ -749,6 +833,19 @@ void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_sta
         const char* e = getenv("SPARKINFER_PREFILL_GDN_CONV_SEQ");
         return (e && e[0] == '1') ? 1 : 0;
     }();
+    static int tile = [] {  // SPARKINFER_PREFILL_GDN_CONV_TILE=0 restores the token-parallel kernel
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_CONV_TILE");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!seq && tile && conv_kernel <= 8) {
+        dim3 grid((n_tokens + PF_CONV_TT - 1) / PF_CONV_TT, blocks);
+        pf_gdn_conv_tile_kernel<<<grid, head_dim, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
+            reinterpret_cast<__nv_bfloat16*>(conv_state), reinterpret_cast<__nv_bfloat16*>(q),
+            reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
+            n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps);
+        return;
+    }
     if (!seq) {
         dim3 grid(n_tokens, blocks);
         pf_gdn_conv_par_kernel<<<grid, head_dim, 0, stream>>>(

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -82,16 +82,31 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
     signed char* s_qi = reinterpret_cast<signed char*>(mma_smem);   // [BM][HEAD_DIM]
     signed char* s_pi = s_qi + BM * HEAD_DIM;                       // [BM][GN]
     float* s_s  = reinterpret_cast<float*>(s_pi + BM * GN);         // [BM][GN] scores / P'
-    float* s_o  = s_s + BM * GN;                                    // [BM][HEAD_DIM] running O
+    float* s_o  = s_s + BM * GN;                                    // [BM][HEAD_DIM] O (epilogue only)
     float* s_ks = s_o + BM * HEAD_DIM;                              // [GN]
     float* s_vs = s_ks + GN;                                        // [GN]
     float* s_qs = s_vs + GN;                                        // [BM]
     float* s_ps = s_qs + BM;                                        // [BM]
     float* s_m  = s_ps + BM;                                        // [BM]
     float* s_l  = s_m + BM;                                         // [BM]
-    // PV int32 landing zone, one 16x16 tile per warp. Aliases s_s: the scores/P' floats are dead
-    // once P' has been quantized into s_pi, and WARPS*256 ints == BM*GN floats exactly.
-    int* s_pv = reinterpret_cast<int*>(s_s);
+    float* s_corr = s_l + BM;                                       // [BM] per-group rescale
+
+    // The running O lives in per-warp accumulator fragments (warp w owns d-tiles w*DPW..+DPW),
+    // not in shared memory: the old path bounced every PV tile through a smem int landing zone
+    // and rescaled all BM*HEAD_DIM floats of s_o through smem each group, at two extra
+    // __syncthreads per group. Element rows for the rescale come from an index fragment loaded
+    // once from a per-warp smem tile (value (row<<8)|col), so no accumulator-layout assumption
+    // is made. All arithmetic keeps the old per-element op/rounding sequence -> bit-identical.
+    fragment<accumulator, 16, 16, 16, float> ofr[DPW];
+    fragment<accumulator, 16, 16, 16, int> idxf;
+    {
+        int* tile = reinterpret_cast<int*>(s_s) + warp * 256;       // disjoint per warp
+        for (int i = lane; i < 256; i += 32) tile[i] = ((i >> 4) << 8) | (i & 15);
+        __syncwarp();
+        load_matrix_sync(idxf, tile, 16, mem_row_major);
+    }
+    #pragma unroll
+    for (int dd = 0; dd < DPW; dd++) fill_fragment(ofr[dd], 0.f);
 
     // ---- load + quantize Q rows (warp w owns rows 2w, 2w+1 at WARPS=8) ----
     #pragma unroll
@@ -115,7 +130,6 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
             s_qi[r * HEAD_DIM + lane + e * 32] =
                 (signed char)((amax == 0.f) ? 0 : (int)roundf(qv[e] / d));
     }
-    for (int i = tid; i < BM * HEAD_DIM; i += blockDim.x) s_o[i] = 0.f;
     if (tid < BM) { s_m[tid] = -1e30f; s_l[tid] = 0.f; }
     __syncthreads();
 
@@ -199,15 +213,18 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
                     pamax  = fmaxf(pamax, __shfl_xor_sync(0xffffffffu, pamax, o));
                 }
                 const float pd = pamax / 127.0f;
-                if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; s_ps[r] = pd; }
+                if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum;
+                                 s_ps[r] = pd; s_corr[r] = corr; }
                 for (int t = lane; t < gblk * 16; t += 32)
                     s_pi[r * GN + t] =
                         (signed char)((pamax == 0.f) ? 0 : (int)roundf(s_s[r * GN + t] / pd));
-                for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
             }
             __syncthreads();
 
-            // ---- PV: int8 mma -> int32, O += int32 * per-row P' scale ----
+            // ---- PV: int8 mma -> int32, O = O*corr + int32 * per-row P' scale, in registers ----
+            // No smem landing zone and no trailing barriers: the next group's after-QK barrier
+            // already orders every cross-warp reuse (softmax g+1 writes s_pi/s_ps/s_corr only
+            // after all warps passed it, i.e. after they finished this PV).
             #pragma unroll
             for (int dd = 0; dd < DPW; dd++) {
                 const int dt = warp * DPW + dd;
@@ -223,21 +240,28 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
                     load_matrix_sync(bf, vb, KVLD);
                     mma_sync(cf, af, bf, cf);
                 }
-                // s_pv aliases s_s, which is dead once P' is quantized into s_pi. Each warp owns a
-                // disjoint 256-int slice, so the store needs only a warp fence; the __syncthreads
-                // below is what lets the next d-tile (and the next group's QK) reuse the buffer.
-                store_matrix_sync(s_pv + warp * 256, cf, 16, mem_row_major);
-                __syncwarp();
-                for (int i = lane; i < 256; i += 32)
-                    s_o[(i >> 4) * HEAD_DIM + dt * 16 + (i & 15)] +=
-                        (float)s_pv[warp * 256 + i] * s_ps[i >> 4];
-                __syncthreads();
+                // Rounding matches the old smem path exactly: the *= corr rescale was a separate
+                // rounded multiply, while the += pv*ps accumulate compiled to an FMA -- so it is
+                // __fmaf_rn over a rounded product here (verified bit-exact against the old
+                // kernel; a plain mul+add differs).
+                #pragma unroll
+                for (int e = 0; e < 8; e++) {
+                    const int r = idxf.x[e] >> 8;
+                    ofr[dd].x[e] = __fmaf_rn((float)cf.x[e], s_ps[r],
+                                             __fmul_rn(ofr[dd].x[e], s_corr[r]));
+                }
             }
         }
     };
 
     if (split_sink) run_range(0, block_size);
     run_range(split_sink ? blk_rs : 0, last_q + 1);
+
+    // Land the register O tiles in s_o once, so the epilogue below stays coalesced + unchanged.
+    #pragma unroll
+    for (int dd = 0; dd < DPW; dd++)
+        store_matrix_sync(s_o + (warp * DPW + dd) * 16, ofr[dd], HEAD_DIM, mem_row_major);
+    __syncthreads();
 
     // ---- epilogue ----
     for (int r = 0; r < BM; r++) {
@@ -281,8 +305,8 @@ bool launch_prefill_attn_mma(
     const size_t sm = (size_t)BM * HD                 // s_qi (int8)
                     + (size_t)BM * GN                 // s_pi (int8)
                     + (size_t)(BM * GN) * sizeof(float)      // s_s
-                    + (size_t)(BM * HD) * sizeof(float)      // s_o
-                    + (size_t)(2 * GN + 4 * BM) * sizeof(float);  // scales + m/l
+                    + (size_t)(BM * HD) * sizeof(float)      // s_o (epilogue landing)
+                    + (size_t)(2 * GN + 5 * BM) * sizeof(float);  // scales + m/l/corr
 
     static int cfg = 0;
     if (!cfg) {

--- a/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
@@ -52,8 +52,14 @@ __device__ __forceinline__ int fp8_swz(int k, int row) {
     return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
 }
 
-__device__ __forceinline__ unsigned fp8_lds32(const __nv_fp8_e4m3* p) {
-    return *reinterpret_cast<const unsigned*>(p);
+// ldmatrix.x4 operand staging, same as the int8 GEMM: one instruction per four 8x8 tiles instead
+// of four scalar lds.32, so fragment loads stop competing with the mma issue rate. e4m3 and s8 are
+// both 1-byte k32 operand types, so the m16n8k32 fragment layout (and this mapping) is identical.
+__device__ __forceinline__ void fp8_ldm_x4(unsigned& r0, unsigned& r1, unsigned& r2, unsigned& r3,
+                                           const __nv_fp8_e4m3* p) {
+    const unsigned a = (unsigned)__cvta_generic_to_shared(p);
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+                 : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3) : "r"(a));
 }
 
 // Per-row symmetric fp8 quantize (amax -> FP8_TGT), one warp per row. Input bf16.
@@ -86,6 +92,8 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
     const int lane = tid & 31;
     const int grp  = lane >> 2;                       // 0..7
     const int tig  = lane & 3;                        // thread-in-group
+    const int sub  = lane >> 3;                       // ldmatrix tile this thread addresses (0..3)
+    const int lrow = lane & 7;                        // row within that tile
     const int wm   = warp & 3;                        // rows [wm*32, +32)
     const int wn   = warp >> 2;                       // cols [wn*64, +64)
     const int m0   = blockIdx.y * FP8_BM;
@@ -128,21 +136,20 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
 
         #pragma unroll
         for (int kk = 0; kk < FP8_BK; kk += 32) {
-            const int ka = kk + tig * 4;
             unsigned af[FP8_MFRAG][4], bf[FP8_NFRAG][2];
+            // A fragment i: tiles {rows lo,k0} {rows hi,k0} {rows lo,k16} {rows hi,k16} -> af[i][0..3]
             #pragma unroll
             for (int i = 0; i < FP8_MFRAG; i++) {
-                const int rlo = wm * 32 + i * 16 + grp, rhi = rlo + 8;
-                af[i][0] = fp8_lds32(&As[buf][rlo][fp8_swz(ka,      rlo)]);
-                af[i][1] = fp8_lds32(&As[buf][rhi][fp8_swz(ka,      rhi)]);
-                af[i][2] = fp8_lds32(&As[buf][rlo][fp8_swz(ka + 16, rlo)]);
-                af[i][3] = fp8_lds32(&As[buf][rhi][fp8_swz(ka + 16, rhi)]);
+                const int row = wm * 32 + i * 16 + (sub & 1) * 8 + lrow;
+                fp8_ldm_x4(af[i][0], af[i][1], af[i][2], af[i][3],
+                           &As[buf][row][fp8_swz(kk + (sub >> 1) * 16, row)]);
             }
+            // B pair (j, j+1): tiles {cols j,k0} {cols j,k16} {cols j+1,k0} {cols j+1,k16}
             #pragma unroll
-            for (int j = 0; j < FP8_NFRAG; j++) {
-                const int col = wn * 64 + j * 8 + grp;
-                bf[j][0] = fp8_lds32(&Bs[buf][col][fp8_swz(ka,      col)]);
-                bf[j][1] = fp8_lds32(&Bs[buf][col][fp8_swz(ka + 16, col)]);
+            for (int jp = 0; jp < FP8_NFRAG; jp += 2) {
+                const int col = wn * 64 + (jp + (sub >> 1)) * 8 + lrow;
+                fp8_ldm_x4(bf[jp][0], bf[jp][1], bf[jp + 1][0], bf[jp + 1][1],
+                           &Bs[buf][col][fp8_swz(kk + (sub & 1) * 16, col)]);
             }
             #pragma unroll
             for (int i = 0; i < FP8_MFRAG; i++)

--- a/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
@@ -35,8 +35,16 @@ __device__ __forceinline__ int pf_swz(int k, int row) {
     return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
 }
 
-__device__ __forceinline__ unsigned pf_lds32(const signed char* p) {
-    return *reinterpret_cast<const unsigned*>(p);
+// ldmatrix.x4: one instruction moves all four 8x8 operand tiles of an mma fragment through the
+// LDS pipe (the four scalar lds.32 it replaces issued 1:1 against the mma pipe and were the
+// staging bottleneck). Thread t supplies the shared-memory address of row (t&7) of tile (t>>3);
+// the XOR swizzle still applies per row address, so the smem layout is unchanged and the loaded
+// registers are identical to the lds.32 path.
+__device__ __forceinline__ void pf_ldm_x4(unsigned& r0, unsigned& r1, unsigned& r2, unsigned& r3,
+                                          const signed char* p) {
+    const unsigned a = (unsigned)__cvta_generic_to_shared(p);
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+                 : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3) : "r"(a));
 }
 
 // Per-row symmetric int8 quantize, one warp per row.
@@ -56,10 +64,14 @@ __global__ void pf_quantize_rows_i8(const __nv_bfloat16* __restrict__ x, signed 
 
 // The 2 in __launch_bounds__ is required, not decorative: left to itself nvcc picks 131 registers,
 // and 2 * 256 * 131 exceeds the 65536-register file, so only one block per SM would be resident.
+// RESID folds the residual add into the store: C[m,n] = bf16(C[m,n] + bf16(acc*sx*sw)) -- the same
+// two-step rounding as the pf_add kernel it replaces, reading and writing through the ONE C
+// pointer (no second aliased argument), so the fused path stays bit-identical to GEMM-then-add.
+template <bool RESID>
 __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         const signed char* __restrict__ A, const signed char* __restrict__ W,
         const float* __restrict__ sx, const float* __restrict__ sw,
-        __nv_bfloat16* __restrict__ C, int M, int N, int K) {
+        __nv_bfloat16* C, int M, int N, int K) {
     __shared__ signed char As[2][PF_BM][PF_BK];
     __shared__ signed char Bs[2][PF_BN][PF_BK];
 
@@ -68,6 +80,8 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
     const int lane = tid & 31;
     const int grp  = lane >> 2;                       // 0..7
     const int tig  = lane & 3;                        // thread-in-group
+    const int sub  = lane >> 3;                       // ldmatrix tile this thread addresses (0..3)
+    const int lrow = lane & 7;                        // row within that tile
     const int wm   = warp & 3;                        // rows [wm*32, +32)
     const int wn   = warp >> 2;                       // cols [wn*64, +64)
     const int m0   = blockIdx.y * PF_BM;
@@ -103,21 +117,20 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
 
         #pragma unroll
         for (int kk = 0; kk < PF_BK; kk += 32) {
-            const int ka = kk + tig * 4;
             unsigned af[PF_MFRAG][4], bf[PF_NFRAG][2];
+            // A fragment i: tiles {rows lo,k0} {rows hi,k0} {rows lo,k16} {rows hi,k16} -> af[i][0..3]
             #pragma unroll
             for (int i = 0; i < PF_MFRAG; i++) {
-                const int rlo = wm * 32 + i * 16 + grp, rhi = rlo + 8;
-                af[i][0] = pf_lds32(&As[buf][rlo][pf_swz(ka,      rlo)]);
-                af[i][1] = pf_lds32(&As[buf][rhi][pf_swz(ka,      rhi)]);
-                af[i][2] = pf_lds32(&As[buf][rlo][pf_swz(ka + 16, rlo)]);
-                af[i][3] = pf_lds32(&As[buf][rhi][pf_swz(ka + 16, rhi)]);
+                const int row = wm * 32 + i * 16 + (sub & 1) * 8 + lrow;
+                pf_ldm_x4(af[i][0], af[i][1], af[i][2], af[i][3],
+                          &As[buf][row][pf_swz(kk + (sub >> 1) * 16, row)]);
             }
+            // B pair (j, j+1): tiles {cols j,k0} {cols j,k16} {cols j+1,k0} {cols j+1,k16}
             #pragma unroll
-            for (int j = 0; j < PF_NFRAG; j++) {
-                const int col = wn * 64 + j * 8 + grp;
-                bf[j][0] = pf_lds32(&Bs[buf][col][pf_swz(ka,      col)]);
-                bf[j][1] = pf_lds32(&Bs[buf][col][pf_swz(ka + 16, col)]);
+            for (int jp = 0; jp < PF_NFRAG; jp += 2) {
+                const int col = wn * 64 + (jp + (sub >> 1)) * 8 + lrow;
+                pf_ldm_x4(bf[jp][0], bf[jp][1], bf[jp + 1][0], bf[jp + 1][1],
+                          &Bs[buf][col][pf_swz(kk + (sub & 1) * 16, col)]);
             }
             #pragma unroll
             for (int i = 0; i < PF_MFRAG; i++)
@@ -146,8 +159,13 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
                 for (int e = 0; e < 4; e++) {
                     const int gm = m0 + wm * 32 + i * 16 + grp + (e >> 1) * 8;
                     const int cn = gn + (e & 1);
-                    if (gm < M && cn < N)
-                        C[(size_t)gm * N + cn] = __float2bfloat16((float)acc[i][j][e] * sx[gm] * sw[cn]);
+                    if (gm < M && cn < N) {
+                        __nv_bfloat16 v = __float2bfloat16((float)acc[i][j][e] * sx[gm] * sw[cn]);
+                        if (RESID)
+                            v = __float2bfloat16(__bfloat162float(C[(size_t)gm * N + cn]) +
+                                                 __bfloat162float(v));
+                        C[(size_t)gm * N + cn] = v;
+                    }
                 }
                 continue;
             }
@@ -157,9 +175,15 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
                 const int gm = m0 + wm * 32 + i * 16 + grp + h * 8;
                 if (gm >= M) continue;
                 const float s = sx[gm];
-                const __nv_bfloat162 v = __floats2bfloat162_rn((float)acc[i][j][h * 2] * s * w0,
-                                                               (float)acc[i][j][h * 2 + 1] * s * w1);
-                *reinterpret_cast<__nv_bfloat162*>(&C[(size_t)gm * N + gn]) = v;
+                __nv_bfloat162 v = __floats2bfloat162_rn((float)acc[i][j][h * 2] * s * w0,
+                                                         (float)acc[i][j][h * 2 + 1] * s * w1);
+                __nv_bfloat162* cp = reinterpret_cast<__nv_bfloat162*>(&C[(size_t)gm * N + gn]);
+                if (RESID) {
+                    const __nv_bfloat162 r = *cp;
+                    v = __floats2bfloat162_rn(__bfloat162float(r.x) + __bfloat162float(v.x),
+                                              __bfloat162float(r.y) + __bfloat162float(v.y));
+                }
+                *cp = v;
             }
         }
     }
@@ -179,7 +203,17 @@ void launch_prefill_gemm_i8(const signed char* A, const signed char* W,
                             const float* sx, const float* sw, void* C,
                             int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
-    pf_gemm_i8_kernel<<<grid, 256, 0, stream>>>(
+    pf_gemm_i8_kernel<false><<<grid, 256, 0, stream>>>(
+        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+}
+
+// Residual-fused variant: C[m,n] += bf16(acc*sx*sw) with pf_add's rounding. Passing the residual
+// tensor AS C removes the ao scratch round-trip and the separate full-tensor add launch.
+void launch_prefill_gemm_i8_resid(const signed char* A, const signed char* W,
+                                  const float* sx, const float* sw, void* C,
+                                  int M, int N, int K, cudaStream_t stream) {
+    dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
+    pf_gemm_i8_kernel<true><<<grid, 256, 0, stream>>>(
         A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
 }
 

--- a/kernels/include/sparkinfer/kernels/prefill_i8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8.h
@@ -30,4 +30,11 @@ void launch_prefill_gemm_i8(const signed char* A, const signed char* W,
                             const float* sx, const float* sw, void* C,
                             int M, int N, int K, cudaStream_t stream = nullptr);
 
+// Residual-fused int8 GEMM: C[m,n] = bf16(C[m,n] + bf16(acc*sx*sw)) -- pass the residual tensor as
+// C to fold the post-projection "x += out" into the store (same two-step rounding as the separate
+// add kernel, so the result is bit-identical while skipping the ao scratch round-trip + add pass).
+void launch_prefill_gemm_i8_resid(const signed char* A, const signed char* W,
+                                  const float* sx, const float* sw, void* C,
+                                  int M, int N, int K, cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -342,6 +342,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::launch_gguf_dequant(wtype, W, wbuf, (long)n_out * K, st);
         return wbuf;
     };
+    // int8 activation memo: consecutive int8 projections of the SAME input (wq/wk/wv on xn,
+    // wqkv/wqkv_gate on xn, FFN gate/up on the same chunk) re-quantize identical values into
+    // A_i8/sx each call. Remember what A_i8 currently holds and skip the repeat quantize --
+    // bit-identical, it reuses the exact bytes the first call produced. The memo is reset at
+    // every layer top (xn/hn refresh in place) and wherever A_i8 is written outside proj().
+    const bf16* a_q = nullptr; int a_qR = 0, a_qK = 0;
+    auto quant_a_i8 = [&](const bf16* A, int R, int K) {
+        if (a_q == A && a_qR == R && a_qK == K) return;
+        kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st);
+        a_q = A; a_qR = R; a_qK = K;
+    };
     // C[N,n_out] = A[N,K] @ W^T  (W native quantized [n_out,K]).
     auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;   // rows (M) to process; chunked FFN passes a sub-N count
@@ -350,7 +361,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         // sigmoid gates, where per-row int8 quant of a 32-wide weight costs more accuracy
         // than the negligible time it saves.
         if (use_i8 && n_out >= 128) {
-            kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st);
+            quant_a_i8(A, R, K);
             // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
             if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
                 const void* wb = dq(W, wtype, n_out, K);
@@ -360,6 +371,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         } else if (use_fp8_gdn && n_out >= 128) {
             // fp8 (e4m3) tensor-core path for the long-ctx GDN projections. A_i8/W_i8 (1 byte) hold
             // the e4m3 operands; dequant the weight to bf16 scratch, then row/channel fp8-quantize.
+            a_q = nullptr;                              // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, R, K, st);
             const void* wb = dq(W, wtype, n_out, K);
             kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, n_out, K, st);
@@ -375,6 +387,26 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         }
     };
 
+    // Residual-fused output projection: when the projection takes the int8 tensor-core path, run
+    // it with the residual-fused GEMM straight into x (C[m,n] += dequant, pf_add's rounding), so
+    // the ao scratch write + full-tensor add pass disappear. Returns false when the int8 path
+    // would not be taken -- the caller falls back to proj() + launch_prefill_add, unchanged.
+    // Bit-identical to the two-step path. SPARKINFER_PREFILL_RESID_FUSE=0 disables (A/B).
+    const char* _prfuse = getenv("SPARKINFER_PREFILL_RESID_FUSE");
+    const bool resid_fuse = !_prfuse || _prfuse[0] != '0';
+    auto proj_resid = [&](const bf16* A, const void* W, int wtype, bf16* Cx, int n_out, int K,
+                          int rows = 0) -> bool {
+        if (!resid_fuse || !use_i8 || n_out < 128) return false;
+        const int R = rows > 0 ? rows : N;
+        quant_a_i8(A, R, K);
+        if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
+            const void* wb = dq(W, wtype, n_out, K);
+            kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
+        }
+        kernels::launch_prefill_gemm_i8_resid(A_i8, W_i8, sx, sw, Cx, R, n_out, K, st);
+        return true;
+    };
+
     // GDN wqkv + wqkv_gate both project the same input xn, so on the fp8 path quantize xn to e4m3
     // ONCE and share it across both GEMMs (proj() would otherwise re-quantize xn per projection --
     // a full redundant read of xn and rewrite of the e4m3 activation each layer). Bit-identical to
@@ -384,6 +416,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool fp8_shareq = use_fp8_gdn && (!_pshareq || _pshareq[0] != '0');
     auto gdn_qkv_z = [&](const bf16* A, const Qwen35LayerWeights& w) {
         if (fp8_shareq) {
+            a_q = nullptr;                              // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);   // xn -> e4m3 once
             const void* wb = dq(w.wqkv, w.wqkv_type, lqkv, H);
             kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lqkv, H, st);
@@ -422,6 +455,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
+        a_q = nullptr;                                 // xn/hn are refreshed in place each layer
+        bool attn_fused = false;                       // post-attn residual folded into the proj?
         if (w.linear_attn) {
             // ---- Gated DeltaNet linear-attention layer ----
             gdn_qkv_z(xn, w);                                       // qkv + z gate (fp8: fused)
@@ -434,7 +469,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_prefill_gdn_scan(gq, gk, gv, la, lb, w.ssm_dt, w.ssm_a,
                 layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim, st);
             kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
-            proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
+            if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
         } else {
             // ---- full softmax-attention layer (q_has_gate, partial RoPE, int8 KV) ----
             // Long-ctx: optionally keep Q/K/V/O on int8 (no GDN recurrence here).
@@ -455,12 +491,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_prefill_attn_int8_paged(qb, kpool, vpool, kscale, vscale, btable, att,
                 N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
             kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
-            proj(att, w.wo, w.wo_type, ao, H, qdim);
+            attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
+            if (!attn_fused) proj(att, w.wo, w.wo_type, ao, H, qdim);
             use_i8 = restore_i8;
         }
 
-        // x += ao (post-attn residual, in-place) ; hn = RMSNorm(x, post_attn_norm)
-        kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+        // x += ao (post-attn residual, in-place; skipped when folded into the output proj)
+        // hn = RMSNorm(x, post_attn_norm)
+        if (!attn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
         kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
 
         if (!moe) {
@@ -480,26 +518,55 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 dequant_w_i8(w.up_qtype,   w.up_q,   ffn_Wu_i8, ffn_swu, ffn, H);
                 dequant_w_i8(w.down_qtype, w.down_q, ffn_Wd_i8, ffn_swd, H, ffn);
             }
+            // The down projection takes the int8 path on both branches whenever ffn_i8 or use_i8,
+            // so the FFN residual can ride the residual-fused GEMM straight into x per chunk.
+            const bool ffn_fused = resid_fuse && (ffn_i8 || use_i8);
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
                 if (ffn_i8) {
+                    a_q = nullptr;                     // this branch writes A_i8/sx directly
                     kernels::launch_prefill_quantize_rows_i8(hn_c, A_i8, sx, fn, H, st);
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wg_i8, sx, ffn_swg, ffg, fn, ffn, H, st);
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wu_i8, sx, ffn_swu, ffu, fn, ffn, H, st);
                     // fused SwiGLU + int8 quantize for the down input (skips the ffg DRAM round-trip)
                     kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st);
-                    kernels::launch_prefill_gemm_i8(A_i8, ffn_Wd_i8, sx, ffn_swd,
-                                                    ao + (size_t)fo * H, fn, H, ffn, st);
+                    if (ffn_fused)
+                        kernels::launch_prefill_gemm_i8_resid(A_i8, ffn_Wd_i8, sx, ffn_swd,
+                                                              x + (size_t)fo * H, fn, H, ffn, st);
+                    else
+                        kernels::launch_prefill_gemm_i8(A_i8, ffn_Wd_i8, sx, ffn_swd,
+                                                        ao + (size_t)fo * H, fn, H, ffn, st);
                 } else {
                     proj(hn_c, w.gate_q, w.gate_qtype, ffg, ffn, H, fn);
                     proj(hn_c, w.up_q,   w.up_qtype,   ffu, ffn, H, fn);
-                    kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                    proj(ffg, w.down_q, w.down_qtype, ao + (size_t)fo * H, H, ffn, fn);
+                    if (use_i8) {
+                        // Same fused SwiGLU + per-row int8 quantize the long-ctx ffn_i8 branch
+                        // runs (bit-identical to swiglu-then-quantize; both bf16-round first) --
+                        // skips the ffg store + reload that proj()'s internal quantize would pay.
+                        a_q = nullptr;                 // swiglu_quant writes A_i8/sx directly
+                        kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st);
+                        if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,
+                                                                  W_i8, sw, H, ffn, st)) {
+                            const void* wb = dq(w.down_q, w.down_qtype, H, ffn);
+                            kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, ffn, st);
+                        }
+                        if (ffn_fused)
+                            kernels::launch_prefill_gemm_i8_resid(A_i8, W_i8, sx, sw,
+                                                                  x + (size_t)fo * H, fn, H, ffn, st);
+                        else
+                            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw,
+                                                            ao + (size_t)fo * H, fn, H, ffn, st);
+                    } else {
+                        kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                        if (!ffn_fused || !proj_resid(ffg, w.down_q, w.down_qtype,
+                                                      x + (size_t)fo * H, H, ffn, fn))
+                            proj(ffg, w.down_q, w.down_qtype, ao + (size_t)fo * H, H, ffn, fn);
+                    }
                 }
             }
-            // x += ffn_out (post-attn residual already folded into x above)
-            kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+            // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk)
+            if (!ffn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
         } else {
             // ---- expert-grouped 256-expert int8 MoE FFN (this PR): route -> bucket routed
             // (token, expert) pairs by expert -> per-expert int8 tensor-core GEMMs, so each expert's


### PR DESCRIPTION
## Summary

Six bit-identical prefill optimizations for Qwythos (Qwen3.5): `ldmatrix.x4` operand staging for the int8 and fp8 prefill GEMMs, a register-resident running O for the MMA prefill attention, a residual-fused int8 GEMM epilogue, the fused SwiGLU+quant extended to the short-context dense FFN, an activation-quantize memo for repeated projections of the same input, and a token-tiled GDN conv that removes its 4x qkv read amplification. Every change preserves main's exact numerics (integer accumulation order and float rounding sequences unchanged), verified end-to-end: the batched-prefill output seeds match main at 4k/32k/64k and the 128k fp8 path reproduces main's output token-for-token. Prefill pp improves ~10.4-10.8% at 4k/32k/64k and ~7.7% at 128k; decode is untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (Qwythos / Qwen3.5, best context `--ctx 32768`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 21041.37 |
| after prefill (this PR) | 23308.69 |

```text
################ BEFORE (main @5f5ac8e) ################
>> GPU arch: sm_120
>> using local build
=== sparkinfer — decode (n=32, ctx=32768, bs=1) ===
[sparse-kv] sliding-window (default on): window=256 blocks (4096 tokens) min_ctx=8192
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
ttft         : 1.547 s  (21175.6 tok/s prefill, prompt=32768)
=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 9.8 GB
max seq      : 32816
decode tg    : 286.36 tok/s  (3.5 ms/token, n=32, ctx=32768, bs=1)
prefill pp   : 21041.37 tok/s  (ctx=32768, sequential KV fill)
GPU          : 68°C · 575 W · 2685 MHz (peak under load)
################ AFTER (this PR) ################
>> GPU arch: sm_120
>> using local build
=== sparkinfer — decode (n=32, ctx=32768, bs=1) ===
[sparse-kv] sliding-window (default on): window=256 blocks (4096 tokens) min_ctx=8192
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
ttft         : 1.387 s  (23617.0 tok/s prefill, prompt=32768)
=== sparkinfer bench (Q4_K_M native) ===
model        : Qwen3.5-9B dense hybrid  (32 layers, 1 experts top-1)
VRAM used    : 9.8 GB
max seq      : 32816
decode tg    : 289.31 tok/s  (3.5 ms/token, n=32, ctx=32768, bs=1)
prefill pp   : 23308.69 tok/s  (ctx=32768, sequential KV fill)
GPU          : 69°C · 574 W · 2587 MHz (peak under load)
```

Interleaved A/B (median of 3 main/PR pairs per context, same box, idle GPU, main @5f5ac8e): 4k +10.4%, 32k +10.8%, 64k +10.6%, 128k +7.7%. Decode within noise at every context.

## Correctness

All changes are numerically inert by construction (int8/int32 arithmetic is exact under these restructures; float sequences keep the same ops in the same order), and verified end-to-end on the current main (5f5ac8e):

- `qwen3_gguf_prefill_check` batched seeds vs main: 4k **290==290**, 32k **198==198**, 64k **82==82** (TOP1/KL identical to main at every context), re-run after every lever landed and again after rebasing onto #577.
- 128k (fp8 GDN + int8 FFN/attn + residual fusion + conv tile all active): the batched-prefill output seed and a 24-token greedy continuation reproduce main token-for-token.
- Kernel microbenches (GEMM variants, attention variants) checked bit-exact against the production kernels on randomized inputs before integration.

## Relation to other work

Builds directly on main's int8 prefill GEMM (#464), MMA prefill attention (#465), batched GDN conv (#398), selective long-context int8 (#557), and the fp8 GDN projections + fused SwiGLU-quant (#573). Rebased on #577 (touches only the MoE branch of the shared prefill TU — hunks are disjoint). No overlap with the open Qwen3.6 MoE prefill PRs (#544/#555/#572/#574/#578): this PR touches only the dense Qwythos prefill path and its kernels.