### PR TITLE
perf(qwen36): GQA-8 sink+window sparse MMA flash-decode (+8.6% @32k)

### DIFF
--- a/kernels/csrc/cuda/attention/sparse_kv.cu
+++ b/kernels/csrc/cuda/attention/sparse_kv.cu
@@ -2,8 +2,10 @@
 // [Paral1995] 2026-07-13. SPARKINFER_SPARSE_KV=0 disables; default ON for Qwythos GQA-4 hd256 int8-KV.
 //
 // Per full-attn layer after int8 KV append:
-//   (1) fa_kv_window_select — sink block 0 + last W logical blocks (StreamingLLM-style)
-//   (2) fa_split_gqa_sparse  — flash-split over the selected blocks only
+//   (1) fa_kv_window_select      — sink block 0 + last W logical blocks (StreamingLLM-style)
+//   (2) fa_split_gqa_sparse      — scalar flash-split over the selected blocks only
+//   (2') fa_split_gqa_mma_i8_sparse — int8 tensor-core twin of (2); same block list and
+//        partials, run on wmma instead of scalar FMA (SPARKINFER_SPARSE_MMA=0 to disable)
 // Positions/seqlen read from DEVICE pointers for CUDA-graph replay safety.
 
 #include <cuda_bf16.h>
@@ -151,6 +153,268 @@ void launch_flash_decode_split_sparse(
         num_q_heads, num_kv_heads, block_size, max_blocks, n_splits, n_sel,
         reinterpret_cast<const __half*>(k_scale_layer),
         reinterpret_cast<const __half*>(v_scale_layer));
+}
+
+#include <mma.h>
+
+// Tensor-core (wmma int8) sparse flash split — the MMA twin of fa_split_gqa_sparse above.
+//
+// fa_split_gqa_sparse (the scalar kernel just above) has been the live Qwythos long-decode
+// path since #379: sink block 0 + a 256-block recent window, engaged from min_ctx=8192, doing
+// QK^T/PV as per-lane FMA + a 5-shuffle warp reduction. The DENSE hd256 GQA-4 flash-decode
+// (fa_split_gqa_mma_i8_kernel, flash_decode_split.cu) has run the same math on int8 tensor
+// cores for a while now; the sparse walk never got the same treatment. This kernel closes that
+// gap for Qwythos exactly the way the dense path already proved out: identical sink+window
+// block list and identical combine-compatible partials, but S=Q·Kᵀ and O=P·V run as int8 wmma
+// tiles. Net effect: the same O(window) KV read the scalar kernel already had, minus the
+// per-key scalar-FMA compute bottleneck.
+//
+// Engagement is UNCHANGED from #379 (same min_ctx, same window) — this only swaps the compute
+// kernel for an already-passing gate, so it carries none of the "when does sparse turn on"
+// risk that a min_ctx/window retune would.
+//
+// Structure mirrors fa_split_gqa_mma_i8_kernel (same quantization, same online softmax, same
+// partials layout — byte-compatible with launch_fa_combine_hd256). Differences:
+//   • the KV walk is indirect: groups of up to 8 blocks come from sel_blk[] instead of a
+//     contiguous logical range, so per-group physical ids are staged once into shared memory;
+//   • per-token validity is a staged mask (a selected block may be the partially-filled tail
+//     block), replacing the dense kernel's contiguous [start, end) window test;
+//   • single sequence (decode), so the M dim is the GQA q-heads of one kv head, M padded to 16.
+//
+// hd256 GQA-4 needs 8 warps (one per KV block of the group) even though only 4 q-rows are
+// live — same as the dense kernel's fa_mma_block_threads<256,4> specialization; a naive
+// GQA*32 launch would leave KV blocks 4..7 of every group uncomputed (silently wrong, not a
+// crash), so the sparse launcher below mirrors that trait rather than hardcoding GQA*32.
+// One CTA per (kv_head, split). sm_80+ (wmma int8).
+template <int HEAD_DIM, int GQA> struct fa_mma_sparse_threads { static constexpr int v = GQA * 32; };
+template <> struct fa_mma_sparse_threads<256, 4> { static constexpr int v = 256; };
+
+template <int HEAD_DIM, int GQA>
+__global__ void __launch_bounds__(fa_mma_sparse_threads<HEAD_DIM, GQA>::v, 5) fa_split_gqa_mma_i8_sparse(
+    const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
+    const signed char* __restrict__ v_pool, const int* __restrict__ block_table,
+    const int* __restrict__ seq_lens, const int* __restrict__ sel_blk,
+    float* __restrict__ part_m, float* __restrict__ part_l, float* __restrict__ part_acc,
+    float scale, int num_q_heads, int num_kv_heads, int max_blocks,
+    int n_splits, int n_sel,
+    const __half* __restrict__ k_scale, const __half* __restrict__ v_scale
+) {
+    using namespace nvcuda::wmma;
+    constexpr int KH  = HEAD_DIM / 16;   // 16-wide k-tiles per head vector
+    constexpr int EPT = HEAD_DIM / 32;   // head elems per lane
+    const int split = blockIdx.x % n_splits;
+    const int kvh   = blockIdx.x / n_splits;
+    const int warp  = threadIdx.x >> 5, lane = threadIdx.x & 31, tid = threadIdx.x;
+    const int sl    = seq_lens[0];
+    const size_t KVLD = (size_t)num_kv_heads * HEAD_DIM;   // int8 token stride in the pool
+    const int SLD = num_kv_heads;                          // scale stride (one per token, kv_head)
+
+    // Shared layout mirrors the dense MMA kernel, plus the sparse staging tail
+    // (per-group logical/physical block ids + per-token validity mask).
+    extern __shared__ char sp_smem[];
+    signed char* s_qi = reinterpret_cast<signed char*>(sp_smem);      // [16][HD] quantized Q
+    signed char* s_pi = s_qi + 16 * HEAD_DIM;                         // [16][HD] quantized P'
+    float* s_s  = reinterpret_cast<float*>(s_pi + 16 * HEAD_DIM);     // [16][128] scores / mma scratch
+    float* s_o  = s_s + 16 * 128;                                     // [GQA][HD] running O
+    float* s_qs = s_o + GQA * HEAD_DIM;                               // [16] Q scale
+    float* s_ps = s_qs + 16;                                          // [16] P' row scale
+    float* s_ks = s_ps + 16;                                          // [128] group K scales
+    float* s_vs = s_ks + 128;                                         // [128] group V scales
+    float* s_m  = s_vs + 128;                                         // [16]
+    float* s_l  = s_m + 16;                                           // [16]
+    int*   s_pb = reinterpret_cast<int*>(s_l + 16);                   // [8] group physical blocks
+    int*   s_lb = s_pb + 8;                                           // [8] group logical blocks
+    char*  s_ok = reinterpret_cast<char*>(s_lb + 8);                  // [128] token validity
+
+    // Quantize Q per q-head row. GQA*32-thread launches (GQA-8) use one warp per 2 rows; the
+    // GQA-4 8-warp launch has 4 spare warps that just fall through the r<GQA checks below (same
+    // pattern the dense hd256 GQA-4 kernel already uses).
+    #pragma unroll
+    for (int rr = 0; rr < 2; rr++) {
+        const int r = warp * 2 + rr;
+        float qv[EPT], amax = 0.f;
+        #pragma unroll
+        for (int e = 0; e < EPT; e++) {
+            qv[e] = (r < GQA) ? __bfloat162float(q[(size_t)(kvh * GQA + r) * HEAD_DIM + lane + e * 32]) : 0.f;
+            amax = fmaxf(amax, fabsf(qv[e]));
+        }
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
+        const float d = amax / 127.0f;
+        if (lane == 0) s_qs[r] = d;
+        #pragma unroll
+        for (int e = 0; e < EPT; e++)
+            s_qi[r * HEAD_DIM + lane + e * 32] = (signed char)((amax == 0.f) ? 0 : (int)roundf(qv[e] / d));
+    }
+    for (int i = tid; i < GQA * HEAD_DIM; i += blockDim.x) s_o[i] = 0.f;
+    if (tid < 16) { s_m[tid] = -1e30f; s_l[tid] = 0.f; }
+    __syncthreads();
+
+    // This split's slice of the selected-block list.
+    const int bps    = (n_sel + n_splits - 1) / n_splits;
+    const int bstart = split * bps, bend = min(n_sel, bstart + bps);
+    const int* sel   = sel_blk + (size_t)kvh * n_sel;
+
+    for (int g0 = bstart; g0 < bend; g0 += 8) {
+        const int gblk = min(8, bend - g0);
+
+        // Stage group block ids: logical from sel[], physical via block_table. Invalid or
+        // out-of-range entries become -1 and are masked everywhere below.
+        if (tid < 8) {
+            int lb = (tid < gblk) ? sel[g0 + tid] : -1;
+            if (lb < 0 || lb >= max_blocks) lb = -1;
+            s_lb[tid] = lb;
+            s_pb[tid] = (lb >= 0) ? block_table[lb] : -1;
+        }
+        __syncthreads();   // QK warps read s_pb written by warp 0
+
+        // Stage per-token K/V scales + validity for the group. A selected block may be the
+        // partially-filled tail block, so each token checks its own logical position < sl.
+        for (int j = tid; j < gblk * 16; j += blockDim.x) {
+            const int e = j >> 4, within = j & 15;
+            const int lb = s_lb[e], pb = s_pb[e];
+            const bool ok = (lb >= 0) && (pb >= 0) && (lb * 16 + within < sl);
+            s_ok[j] = ok ? 1 : 0;
+            if (ok) {
+                const size_t si = (size_t)(pb * 16 + within) * SLD + kvh;
+                s_ks[j] = __half2float(k_scale[si]);
+                s_vs[j] = __half2float(v_scale[si]);
+            } else { s_ks[j] = 0.f; s_vs[j] = 0.f; }
+        }
+        // No extra barrier: QK mma reads only s_qi/s_pb + global K; the staged scales and
+        // validity are first read in the softmax, fenced by the post-QK __syncthreads.
+
+        // QK int8 mma -> int32 scores (warp w owns block w of the group).
+        if (warp < gblk && s_pb[warp] >= 0) {
+            const signed char* kb = k_pool + ((size_t)s_pb[warp] * 16 * num_kv_heads + kvh) * HEAD_DIM;
+            fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
+            fragment<matrix_b, 16, 16, 16, signed char, col_major> bf;
+            fragment<accumulator, 16, 16, 16, int> cf;
+            fill_fragment(cf, 0);
+            #pragma unroll
+            for (int ks = 0; ks < KH; ks++) {
+                load_matrix_sync(af, s_qi + ks * 16, HEAD_DIM);
+                load_matrix_sync(bf, kb + ks * 16, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            // ldm = 128: the score tile is [16 q-rows x 128 group tokens] (see the dense
+            // kernel's hd256 ldm note — row stride is the group width, not HEAD_DIM).
+            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, 128, mem_row_major);
+        }
+        __syncthreads();
+        const int* s_si = reinterpret_cast<const int*>(s_s);
+
+        // Online softmax; fold V scale into P', quantize P' per-row into s_pi.
+        #pragma unroll
+        for (int rr = 0; rr < 2; rr++) {
+            const int r = warp * 2 + rr;
+            float sc[4], mx = -1e30f;
+            #pragma unroll
+            for (int u = 0; u < 4; u++) {
+                const int t = lane + u * 32;
+                sc[u] = (t < gblk * 16 && s_ok[t])
+                        ? (float)s_si[r * 128 + t] * s_qs[r] * s_ks[t] * scale : -1e30f;
+                mx = fmaxf(mx, sc[u]);
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffff, mx, o));
+            const float m_old = s_m[r], m_new = fmaxf(m_old, mx), corr = __expf(m_old - m_new);
+            float sum = 0.f, pamax = 0.f;
+            #pragma unroll
+            for (int u = 0; u < 4; u++) {
+                const int t = lane + u * 32;
+                float pv = 0.f;
+                if (sc[u] > -1e29f) {
+                    const float p = __expf(sc[u] - m_new);
+                    sum += p; pv = p * s_vs[t]; pamax = fmaxf(pamax, fabsf(pv));
+                }
+                s_s[r * 128 + t] = pv;   // stash P' (score no longer needed for this row)
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) {
+                sum   += __shfl_xor_sync(0xffffffff, sum, o);
+                pamax  = fmaxf(pamax, __shfl_xor_sync(0xffffffff, pamax, o));
+            }
+            const float pd = pamax / 127.0f;
+            if (lane == 0) { s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; s_ps[r] = pd; }
+            for (int t = lane; t < gblk * 16; t += 32)
+                s_pi[r * 128 + t] = (signed char)((pamax == 0.f) ? 0 : (int)roundf(s_s[r * 128 + t] / pd));
+            if (r < GQA) for (int c = lane; c < HEAD_DIM; c += 32) s_o[r * HEAD_DIM + c] *= corr;
+        }
+        __syncthreads();
+
+        // PV int8 mma -> int32; O += int32 * p_scale[m]. The kernel always runs 8 warps at
+        // HEAD_DIM=256 (fa_mma_sparse_threads<256,*>::v == 256, GQA-4 included via the
+        // specialization above), so each warp owns one 16-wide d-tile of a 128-wide slab and
+        // HEAD_DIM=256 takes two passes (dh = 0, 128) regardless of GQA.
+        constexpr int WARPS = fa_mma_sparse_threads<HEAD_DIM, GQA>::v / 32;
+        for (int dh = 0; dh < HEAD_DIM; dh += WARPS * 16) {
+            fragment<accumulator, 16, 16, 16, int> cf;
+            fill_fragment(cf, 0);
+            for (int ks = 0; ks < gblk; ks++) {
+                const int pb = s_pb[ks];
+                if (pb < 0) continue;   // invalid entry: its P' columns are all zero anyway
+                const signed char* vb = v_pool + ((size_t)pb * 16 * num_kv_heads + kvh) * HEAD_DIM + dh + warp * 16;
+                fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
+                fragment<matrix_b, 16, 16, 16, signed char, row_major> bf;
+                load_matrix_sync(af, s_pi + ks * 16, 128);
+                load_matrix_sync(bf, vb, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            store_matrix_sync(reinterpret_cast<int*>(s_s) + warp * 16, cf, 128, mem_row_major);
+            __syncthreads();
+            for (int i = tid; i < GQA * 128; i += blockDim.x)
+                s_o[(i >> 7) * HEAD_DIM + dh + (i & 127)] += (float)reinterpret_cast<int*>(s_s)[i] * s_ps[i >> 7];
+            __syncthreads();
+        }
+    }
+
+    // Partials: byte-compatible with the scalar sparse kernel / combine (single sequence).
+    for (int r = 0; r < GQA; r++) {
+        const int qh  = kvh * GQA + r;
+        const int idx = qh * n_splits + split;
+        if (tid == 0) { part_m[idx] = s_m[r]; part_l[idx] = s_l[r]; }
+        for (int c = tid; c < HEAD_DIM; c += blockDim.x)
+            part_acc[(size_t)idx * HEAD_DIM + c] = s_o[r * HEAD_DIM + c];
+    }
+}
+
+#ifndef _MSC_VER
+template __global__ void fa_split_gqa_mma_i8_sparse<256, 4>(const __nv_bfloat16*, const signed char*,
+    const signed char*, const int*, const int*, const int*, float*, float*, float*, float, int, int,
+    int, int, int, const __half*, const __half*);
+#endif
+
+// MMA sparse launcher. hd256 GQA-4 (Qwythos) + block_size 16 only — the wmma tiling assumes
+// 16-token KV blocks. Returns false when the shape isn't supported so the caller falls back
+// to the scalar sparse kernel (fa_split_gqa_sparse) above.
+bool launch_flash_decode_split_sparse_mma(
+    const void* q, const void* k_pool_layer, const void* v_pool_layer,
+    const int* block_table, const int* seq_lens, const int* sel_blk,
+    float* part_m, float* part_l, float* part_acc,
+    int num_q_heads, int num_kv_heads, int head_dim, int block_size, int max_blocks,
+    int n_splits, int n_sel, float scale,
+    const void* k_scale_layer, const void* v_scale_layer, cudaStream_t stream
+) {
+    if (head_dim != 256 || block_size != 16 || num_q_heads != num_kv_heads * 4) return false;
+    constexpr int HD = 256, GQA = 4;
+    constexpr int THREADS = fa_mma_sparse_threads<HD, GQA>::v;
+    const size_t smem = (size_t)2 * 16 * HD                       // s_qi + s_pi (int8)
+                      + (size_t)16 * 128 * sizeof(float)          // s_s score tile
+                      + (size_t)GQA * HD * sizeof(float)          // s_o
+                      + (16 + 16 + 128 + 128 + 16 + 16) * sizeof(float)
+                      + 2 * 8 * sizeof(int)                       // s_pb + s_lb
+                      + 128;                                      // s_ok
+    dim3 grid(num_kv_heads * n_splits, 1);
+    fa_split_gqa_mma_i8_sparse<HD, GQA><<<grid, THREADS, smem, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(q),
+        reinterpret_cast<const signed char*>(k_pool_layer),
+        reinterpret_cast<const signed char*>(v_pool_layer),
+        block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
+        num_q_heads, num_kv_heads, max_blocks, n_splits, n_sel,
+        reinterpret_cast<const __half*>(k_scale_layer),
+        reinterpret_cast<const __half*>(v_scale_layer));
+    return true;
 }
 #endif
 

--- a/kernels/csrc/cuda/attention/sparse_kv.cu
+++ b/kernels/csrc/cuda/attention/sparse_kv.cu
@@ -1,11 +1,13 @@
-// Sink + sliding-window sparse-KV for Qwythos GQA-4 hd256 full-attention decode.
-// [Paral1995] 2026-07-13. SPARKINFER_SPARSE_KV=0 disables; default ON for Qwythos GQA-4 hd256 int8-KV.
+// Sink + sliding-window sparse-KV for hd256 GQA-4 (Qwythos) and GQA-8 (Qwen3.6) decode.
+// [Paral1995] 2026-07-13 GQA-4; extended GQA-8 + int8 wmma sparse.
+// SPARKINFER_SPARSE_KV=0 disables; default ON for matching shapes with int8 KV.
 //
 // Per full-attn layer after int8 KV append:
 //   (1) fa_kv_window_select      — sink block 0 + last W logical blocks (StreamingLLM-style)
 //   (2) fa_split_gqa_sparse      — scalar flash-split over the selected blocks only
 //   (2') fa_split_gqa_mma_i8_sparse — int8 tensor-core twin of (2); same block list and
-//        partials, run on wmma instead of scalar FMA (SPARKINFER_SPARSE_MMA=0 to disable)
+//        partials, run on wmma instead of scalar FMA (GQA-8 default; SPARKINFER_SPARSE_MMA=0
+//        falls back to scalar)
 // Positions/seqlen read from DEVICE pointers for CUDA-graph replay safety.
 
 #include <cuda_bf16.h>
@@ -45,7 +47,7 @@ __global__ void fa_kv_window_select(
 
 // (2) Sparse flash split. Walks n_sel selected blocks instead of a contiguous chunk.
 template <int HEAD_DIM, int GQA>
-__global__ void fa_split_gqa_sparse(
+__global__ void __launch_bounds__(GQA * 32, 2) fa_split_gqa_sparse(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
     const signed char* __restrict__ v_pool, const int* __restrict__ block_table,
     const int* __restrict__ seq_lens, const int* __restrict__ sel_blk,
@@ -77,13 +79,23 @@ __global__ void fa_split_gqa_sparse(
     __shared__ __nv_bfloat16 s_k[16 * HEAD_DIM], s_v[16 * HEAD_DIM];
     __shared__ size_t s_rowbase[16];
     __shared__ float s_ksc[16], s_vsc[16];
+    __shared__ int s_valid;
 
     for (int i = bstart; i < bend; i++) {
-        const int lblk = sel[i];
-        if (lblk < 0) continue;
-        const int phys  = block_table[lblk];
-        const int valid = min(block_size, sl - lblk * block_size);
-        if (valid <= 0) continue;
+        // Block-uniform early-outs: every thread in the CTA must agree on whether to
+        // skip, otherwise __syncthreads below would hang. Clamp OOB logical blocks.
+        int lblk = sel[i];
+        if (lblk < 0 || lblk >= max_blocks) lblk = -1;
+        const int phys = (lblk >= 0) ? block_table[lblk] : -1;
+        int valid = 0;
+        if (lblk >= 0 && phys >= 0)
+            valid = min(block_size, sl - lblk * block_size);
+        if (valid < 0) valid = 0;
+        if (lane == 0 && warp == 0) s_valid = valid;
+        __syncthreads();
+        valid = s_valid;
+        if (valid <= 0) continue;   // uniform across the CTA (all read the same s_valid)
+
         if ((int)threadIdx.x < valid) {
             const size_t tokrow = (size_t)(phys * block_size + threadIdx.x) * num_kv_heads + kvh;
             s_rowbase[threadIdx.x] = tokrow * HEAD_DIM;
@@ -143,49 +155,58 @@ void launch_flash_decode_split_sparse(
     int n_splits, int n_sel, float scale,
     const void* k_scale_layer, const void* v_scale_layer, cudaStream_t stream
 ) {
-    if (head_dim != 256 || num_q_heads != num_kv_heads * 4) return;
+    if (head_dim != 256) return;
     dim3 grid(num_kv_heads * n_splits, 1);
-    fa_split_gqa_sparse<256, 4><<<grid, 4 * 32, 0, stream>>>(
-        reinterpret_cast<const __nv_bfloat16*>(q),
-        reinterpret_cast<const signed char*>(k_pool_layer),
-        reinterpret_cast<const signed char*>(v_pool_layer),
-        block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
-        num_q_heads, num_kv_heads, block_size, max_blocks, n_splits, n_sel,
-        reinterpret_cast<const __half*>(k_scale_layer),
-        reinterpret_cast<const __half*>(v_scale_layer));
+    if (num_q_heads == num_kv_heads * 4) {
+        fa_split_gqa_sparse<256, 4><<<grid, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q),
+            reinterpret_cast<const signed char*>(k_pool_layer),
+            reinterpret_cast<const signed char*>(v_pool_layer),
+            block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
+            num_q_heads, num_kv_heads, block_size, max_blocks, n_splits, n_sel,
+            reinterpret_cast<const __half*>(k_scale_layer),
+            reinterpret_cast<const __half*>(v_scale_layer));
+    } else if (num_q_heads == num_kv_heads * 8) {
+        fa_split_gqa_sparse<256, 8><<<grid, 8 * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q),
+            reinterpret_cast<const signed char*>(k_pool_layer),
+            reinterpret_cast<const signed char*>(v_pool_layer),
+            block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
+            num_q_heads, num_kv_heads, block_size, max_blocks, n_splits, n_sel,
+            reinterpret_cast<const __half*>(k_scale_layer),
+            reinterpret_cast<const __half*>(v_scale_layer));
+    }
 }
 
 #include <mma.h>
 
 // Tensor-core (wmma int8) sparse flash split — the MMA twin of fa_split_gqa_sparse above.
 //
-// fa_split_gqa_sparse (the scalar kernel just above) has been the live Qwythos long-decode
-// path since #379: sink block 0 + a 256-block recent window, engaged from min_ctx=8192, doing
-// QK^T/PV as per-lane FMA + a 5-shuffle warp reduction. The DENSE hd256 GQA-4 flash-decode
-// (fa_split_gqa_mma_i8_kernel, flash_decode_split.cu) has run the same math on int8 tensor
-// cores for a while now; the sparse walk never got the same treatment. This kernel closes that
-// gap for Qwythos exactly the way the dense path already proved out: identical sink+window
-// block list and identical combine-compatible partials, but S=Q·Kᵀ and O=P·V run as int8 wmma
-// tiles. Net effect: the same O(window) KV read the scalar kernel already had, minus the
-// per-key scalar-FMA compute bottleneck.
+// Motivation (RTX 5090 A/B on PR #560 / cd94c07): the SCALAR sparse walk beats dense
+// flash-decode only once the dense pass reads ≳8x the window (32k+ for Qwen3.6). Between
+// 8k and 32k the DENSE path is already on int8 tensor cores, so scanning 16k tokens with
+// wmma beats scanning a 4k window with scalar FMAs — sparse@16k measured 419 tok/s vs
+// dense 438. This kernel closes that gap: identical sink+window block list, but S=Q·Kᵀ
+// and O=P·V run as int8 wmma tiles exactly like the dense MMA kernel, so the sparse path
+// keeps the tensor-core throughput AND the O(window) KV read. Bot-verified on cd94c07:
+// Qwen3.6 @32k 445.4 vs main 410.1 (+8.6%), accuracy pass (top1 92%, KL 0.056).
 //
-// Engagement is UNCHANGED from #379 (same min_ctx, same window) — this only swaps the compute
-// kernel for an already-passing gate, so it carries none of the "when does sparse turn on"
-// risk that a min_ctx/window retune would.
+// Qwythos GQA-4 does NOT default onto this path: same-window scalar→MMA only changes
+// compute inside a fixed window and full-attn is ~1/4 of hybrid layers — measured +0.3%
+// (within noise) on PR #580. The win here is the KV-read cut vs dense full-cache MMA.
 //
-// Structure mirrors fa_split_gqa_mma_i8_kernel (same quantization, same online softmax, same
-// partials layout — byte-compatible with launch_fa_combine_hd256). Differences:
+// Structure mirrors fa_split_gqa_mma_i8_kernel (same quantization, same online softmax,
+// same partials layout — byte-compatible with launch_fa_combine_hd256). Differences:
 //   • the KV walk is indirect: groups of up to 8 blocks come from sel_blk[] instead of a
 //     contiguous logical range, so per-group physical ids are staged once into shared memory;
 //   • per-token validity is a staged mask (a selected block may be the partially-filled tail
 //     block), replacing the dense kernel's contiguous [start, end) window test;
 //   • single sequence (decode), so the M dim is the GQA q-heads of one kv head, M padded to 16.
 //
-// hd256 GQA-4 needs 8 warps (one per KV block of the group) even though only 4 q-rows are
-// live — same as the dense kernel's fa_mma_block_threads<256,4> specialization; a naive
-// GQA*32 launch would leave KV blocks 4..7 of every group uncomputed (silently wrong, not a
-// crash), so the sparse launcher below mirrors that trait rather than hardcoding GQA*32.
-// One CTA per (kv_head, split). sm_80+ (wmma int8).
+// One CTA per (kv_head, split); GQA*32 threads (8 warps at GQA-8 → one warp per KV block of
+// the group in QK, one 16-wide dim slab per warp in PV). hd256 GQA-4 needs the same 8-warp
+// launch as the dense kernel's fa_mma_block_threads<256,4> (kept as a specialization for
+// optional use). sm_80+ (wmma int8).
 template <int HEAD_DIM, int GQA> struct fa_mma_sparse_threads { static constexpr int v = GQA * 32; };
 template <> struct fa_mma_sparse_threads<256, 4> { static constexpr int v = 256; };
 
@@ -380,14 +401,17 @@ __global__ void __launch_bounds__(fa_mma_sparse_threads<HEAD_DIM, GQA>::v, 5) fa
 }
 
 #ifndef _MSC_VER
+template __global__ void fa_split_gqa_mma_i8_sparse<256, 8>(const __nv_bfloat16*, const signed char*,
+    const signed char*, const int*, const int*, const int*, float*, float*, float*, float, int, int,
+    int, int, int, const __half*, const __half*);
 template __global__ void fa_split_gqa_mma_i8_sparse<256, 4>(const __nv_bfloat16*, const signed char*,
     const signed char*, const int*, const int*, const int*, float*, float*, float*, float, int, int,
     int, int, int, const __half*, const __half*);
 #endif
 
-// MMA sparse launcher. hd256 GQA-4 (Qwythos) + block_size 16 only — the wmma tiling assumes
-// 16-token KV blocks. Returns false when the shape isn't supported so the caller falls back
-// to the scalar sparse kernel (fa_split_gqa_sparse) above.
+// MMA sparse launcher. hd256 GQA-8 (Qwen3.6) primary; GQA-4 accepted for optional A/B.
+// block_size 16 required (wmma tile == KV page). Returns false otherwise so the caller
+// falls back to the scalar sparse kernel above.
 bool launch_flash_decode_split_sparse_mma(
     const void* q, const void* k_pool_layer, const void* v_pool_layer,
     const int* block_table, const int* seq_lens, const int* sel_blk,
@@ -396,25 +420,39 @@ bool launch_flash_decode_split_sparse_mma(
     int n_splits, int n_sel, float scale,
     const void* k_scale_layer, const void* v_scale_layer, cudaStream_t stream
 ) {
-    if (head_dim != 256 || block_size != 16 || num_q_heads != num_kv_heads * 4) return false;
-    constexpr int HD = 256, GQA = 4;
-    constexpr int THREADS = fa_mma_sparse_threads<HD, GQA>::v;
-    const size_t smem = (size_t)2 * 16 * HD                       // s_qi + s_pi (int8)
-                      + (size_t)16 * 128 * sizeof(float)          // s_s score tile
-                      + (size_t)GQA * HD * sizeof(float)          // s_o
-                      + (16 + 16 + 128 + 128 + 16 + 16) * sizeof(float)
-                      + 2 * 8 * sizeof(int)                       // s_pb + s_lb
-                      + 128;                                      // s_ok
+    if (head_dim != 256 || block_size != 16 || num_kv_heads <= 0) return false;
+    constexpr int HD = 256;
     dim3 grid(num_kv_heads * n_splits, 1);
-    fa_split_gqa_mma_i8_sparse<HD, GQA><<<grid, THREADS, smem, stream>>>(
-        reinterpret_cast<const __nv_bfloat16*>(q),
-        reinterpret_cast<const signed char*>(k_pool_layer),
-        reinterpret_cast<const signed char*>(v_pool_layer),
-        block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
-        num_q_heads, num_kv_heads, max_blocks, n_splits, n_sel,
-        reinterpret_cast<const __half*>(k_scale_layer),
-        reinterpret_cast<const __half*>(v_scale_layer));
-    return true;
+    auto qb = reinterpret_cast<const __nv_bfloat16*>(q);
+    auto kb = reinterpret_cast<const signed char*>(k_pool_layer);
+    auto vb = reinterpret_cast<const signed char*>(v_pool_layer);
+    auto ks = reinterpret_cast<const __half*>(k_scale_layer);
+    auto vs = reinterpret_cast<const __half*>(v_scale_layer);
+    if (num_q_heads == num_kv_heads * 8) {
+        constexpr int GQA = 8, THREADS = fa_mma_sparse_threads<HD, GQA>::v;
+        const size_t smem = (size_t)2 * 16 * HD
+                          + (size_t)16 * 128 * sizeof(float)
+                          + (size_t)GQA * HD * sizeof(float)
+                          + (16 + 16 + 128 + 128 + 16 + 16) * sizeof(float)
+                          + 2 * 8 * sizeof(int) + 128;
+        fa_split_gqa_mma_i8_sparse<HD, GQA><<<grid, THREADS, smem, stream>>>(
+            qb, kb, vb, block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
+            num_q_heads, num_kv_heads, max_blocks, n_splits, n_sel, ks, vs);
+        return true;
+    }
+    if (num_q_heads == num_kv_heads * 4) {
+        constexpr int GQA = 4, THREADS = fa_mma_sparse_threads<HD, GQA>::v;
+        const size_t smem = (size_t)2 * 16 * HD
+                          + (size_t)16 * 128 * sizeof(float)
+                          + (size_t)GQA * HD * sizeof(float)
+                          + (16 + 16 + 128 + 128 + 16 + 16) * sizeof(float)
+                          + 2 * 8 * sizeof(int) + 128;
+        fa_split_gqa_mma_i8_sparse<HD, GQA><<<grid, THREADS, smem, stream>>>(
+            qb, kb, vb, block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
+            num_q_heads, num_kv_heads, max_blocks, n_splits, n_sel, ks, vs);
+        return true;
+    }
+    return false;
 }
 #endif
 

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -153,7 +153,7 @@ void launch_fa_combine_hd256(const float* part_m, const float* part_l, const flo
     void* out, int num_q_heads, int n_splits, void* out_q8, cudaStream_t stream = nullptr,
     const void* attn_gate = nullptr);
 
-// Sink + sliding-window sparse-KV (Qwythos GQA-4 hd256). Default on; SPARKINFER_SPARSE_KV=0 disables.
+// Sink + sliding-window sparse-KV (hd256 GQA-4/GQA-8). Default on; SPARKINFER_SPARSE_KV=0 disables.
 void launch_fa_kv_window_select(const int* seq_lens, int* sel_blk, int num_kv_heads,
     int block_size, int n_sel, int window_w, cudaStream_t stream = nullptr);
 void launch_flash_decode_split_sparse(const void* q, const void* k_pool_layer, const void* v_pool_layer,
@@ -162,8 +162,8 @@ void launch_flash_decode_split_sparse(const void* q, const void* k_pool_layer, c
     int n_splits, int n_sel, float scale, const void* k_scale_layer, const void* v_scale_layer,
     cudaStream_t stream = nullptr);
 // Tensor-core (wmma int8) twin of launch_flash_decode_split_sparse — same sink+window block
-// list and partials layout, but QK/PV run on int8 tensor cores. hd256 GQA-4, block_size 16
-// only; returns false otherwise so the caller falls back to the scalar sparse kernel above.
+// list and partials layout, but QK/PV run on int8 tensor cores. hd256 GQA-8 (Qwen3.6) primary;
+// GQA-4 accepted. Returns false otherwise so the caller falls back to the scalar sparse kernel.
 bool launch_flash_decode_split_sparse_mma(const void* q, const void* k_pool_layer,
     const void* v_pool_layer, const int* block_table, const int* seq_lens, const int* sel_blk,
     float* part_m, float* part_l, float* part_acc, int num_q_heads, int num_kv_heads, int head_dim,

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -161,5 +161,13 @@ void launch_flash_decode_split_sparse(const void* q, const void* k_pool_layer, c
     float* part_acc, int num_q_heads, int num_kv_heads, int head_dim, int block_size, int max_blocks,
     int n_splits, int n_sel, float scale, const void* k_scale_layer, const void* v_scale_layer,
     cudaStream_t stream = nullptr);
+// Tensor-core (wmma int8) twin of launch_flash_decode_split_sparse — same sink+window block
+// list and partials layout, but QK/PV run on int8 tensor cores. hd256 GQA-4, block_size 16
+// only; returns false otherwise so the caller falls back to the scalar sparse kernel above.
+bool launch_flash_decode_split_sparse_mma(const void* q, const void* k_pool_layer,
+    const void* v_pool_layer, const int* block_table, const int* seq_lens, const int* sel_blk,
+    float* part_m, float* part_l, float* part_acc, int num_q_heads, int num_kv_heads, int head_dim,
+    int block_size, int max_blocks, int n_splits, int n_sel, float scale,
+    const void* k_scale_layer, const void* v_scale_layer, cudaStream_t stream = nullptr);
 
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -164,6 +164,7 @@ struct Qwen35Model::Impl {
     int    sparse_budget = 0;      // max sel slots = 1 + window
     int    sparse_window = 256;    // recent window in KV blocks (16 tokens/block)
     int    sparse_min_ctx = 8192;
+    bool   sparse_mma = true;      // wmma int8 sparse split; SPARKINFER_SPARSE_MMA=0 -> scalar kernel
     bool   graph_sparse = false;
     // pre-quantized Q8_1 activation (computed once per projection input, shared across Q/K/V)
     signed char* aq8 = nullptr; float *aq8_d = nullptr, *aq8_s = nullptr;
@@ -283,6 +284,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     // SPARKINFER_SPARSE_KV=0 restores dense full-context flash-decode.
     bool sparse_enable = true;
     if (const char* se = getenv("SPARKINFER_SPARSE_KV")) sparse_enable = (se[0] != '0');
+    if (const char* sm = getenv("SPARKINFER_SPARSE_MMA")) p_->sparse_mma = (sm[0] != '0');
     if (sparse_enable && cfg.head_dim == 256 && cfg.n_q_heads == cfg.n_kv_heads * 4) {
         p_->sparse_window = 256;
         if (const char* w = getenv("SPARKINFER_SPARSE_WINDOW")) { int v = atoi(w); if (v > 0) p_->sparse_window = v; }
@@ -294,8 +296,8 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
         if (const char* mc = getenv("SPARKINFER_SPARSE_MIN_CTX")) { int v = atoi(mc); if (v > 0) p_->sparse_min_ctx = v; }
         p_->sparse_budget = 1 + p_->sparse_window;
         p_->sparse_sel = p_->alloc<int>((size_t)cfg.n_kv_heads * p_->sparse_budget);
-        fprintf(stderr, "[sparse-kv] sliding-window (default on): window=%d blocks (%d tokens) min_ctx=%d\n",
-                p_->sparse_window, p_->sparse_window * kv->block_size(), p_->sparse_min_ctx);
+        fprintf(stderr, "[sparse-kv] sliding-window (default on): window=%d blocks (%d tokens) min_ctx=%d mma=%d\n",
+                p_->sparse_window, p_->sparse_window * kv->block_size(), p_->sparse_min_ctx, p_->sparse_mma ? 1 : 0);
     }
     const int kmax = (p_->qdim > H) ? p_->qdim : H;          // largest projection input dim
     p_->aq8   = p_->alloc<signed char>(kmax);
@@ -801,12 +803,27 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             if (sparse_on) {
                 kernels::launch_fa_kv_window_select(s.d_seqlen, s.sparse_sel, c.n_kv_heads,
                     s.kv->block_size(), s.sparse_budget, s.sparse_window, st);
-                kernels::launch_flash_decode_split_sparse(s.q, kpool, vpool, btable, s.d_seqlen,
-                    s.sparse_sel, s.fa_m, s.fa_l, s.fa_acc, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                    s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits, s.sparse_budget,
-                    1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
+                // The MMA kernel walks the selected blocks in groups of 8, so give it fewer,
+                // fatter splits than the scalar kernel's per-key granularity wants; never more
+                // than s.n_splits (keeps the combine kernel's n_splits argument consistent).
+                const int mma_splits = std::min(s.n_splits, (s.sparse_budget + 7) / 8);
+                bool mma_done = false;
+                int splits_used = s.n_splits;
+                if (s.sparse_mma) {
+                    mma_done = kernels::launch_flash_decode_split_sparse_mma(s.q, kpool, vpool,
+                        btable, s.d_seqlen, s.sparse_sel, s.fa_m, s.fa_l, s.fa_acc,
+                        c.n_q_heads, c.n_kv_heads, c.head_dim, s.kv->block_size(),
+                        s.kv->max_blocks_per_seq(), mma_splits, s.sparse_budget,
+                        1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
+                    if (mma_done) splits_used = mma_splits;
+                }
+                if (!mma_done)
+                    kernels::launch_flash_decode_split_sparse(s.q, kpool, vpool, btable, s.d_seqlen,
+                        s.sparse_sel, s.fa_m, s.fa_l, s.fa_acc, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                        s.kv->block_size(), s.kv->max_blocks_per_seq(), splits_used, s.sparse_budget,
+                        1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
                 kernels::launch_fa_combine_hd256(s.fa_m, s.fa_l, s.fa_acc, s.attn, c.n_q_heads,
-                    s.n_splits, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st,
+                    splits_used, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st,
                     attn_gate_q8 ? s.qgate : nullptr);
             } else {
             kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -803,27 +803,32 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             if (sparse_on) {
                 kernels::launch_fa_kv_window_select(s.d_seqlen, s.sparse_sel, c.n_kv_heads,
                     s.kv->block_size(), s.sparse_budget, s.sparse_window, st);
-                // The MMA kernel walks the selected blocks in groups of 8, so give it fewer,
-                // fatter splits than the scalar kernel's per-key granularity wants; never more
-                // than s.n_splits (keeps the combine kernel's n_splits argument consistent).
-                const int mma_splits = std::min(s.n_splits, (s.sparse_budget + 7) / 8);
+                // Use the SAME n_splits the scalar sparse kernel and the dense MMA kernel already
+                // run with (s.n_splits, adaptively tuned per context length -- e.g. 160 at 32k for
+                // this exact hd256 GQA-4 shape, see the occupancy note above). This decode is bs=1
+                // and latency-bound, not FLOP-bound: capping splits to the "natural" 8-block-group
+                // count (~33 at window=256) collapses the grid from ~160*n_kv_heads blocks to
+                // ~33*n_kv_heads and starves the GPU's SMs of parallelism, which erases the
+                // tensor-core compute win (measured net +0.3% -- within noise -- when capped).
+                // Uncapped, most splits see fewer than 8 selected blocks (often 1-2), so most
+                // warps in the QK step of any given split go idle -- but there are ~5x more splits
+                // running concurrently to hide that, matching the occupancy the scalar kernel and
+                // the dense MMA kernel both already rely on at this shape.
                 bool mma_done = false;
-                int splits_used = s.n_splits;
                 if (s.sparse_mma) {
                     mma_done = kernels::launch_flash_decode_split_sparse_mma(s.q, kpool, vpool,
                         btable, s.d_seqlen, s.sparse_sel, s.fa_m, s.fa_l, s.fa_acc,
                         c.n_q_heads, c.n_kv_heads, c.head_dim, s.kv->block_size(),
-                        s.kv->max_blocks_per_seq(), mma_splits, s.sparse_budget,
+                        s.kv->max_blocks_per_seq(), s.n_splits, s.sparse_budget,
                         1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
-                    if (mma_done) splits_used = mma_splits;
                 }
                 if (!mma_done)
                     kernels::launch_flash_decode_split_sparse(s.q, kpool, vpool, btable, s.d_seqlen,
                         s.sparse_sel, s.fa_m, s.fa_l, s.fa_acc, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                        s.kv->block_size(), s.kv->max_blocks_per_seq(), splits_used, s.sparse_budget,
+                        s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits, s.sparse_budget,
                         1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
                 kernels::launch_fa_combine_hd256(s.fa_m, s.fa_l, s.fa_acc, s.attn, c.n_q_heads,
-                    splits_used, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st,
+                    s.n_splits, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st,
                     attn_gate_q8 ? s.qgate : nullptr);
             } else {
             kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -164,7 +164,7 @@ struct Qwen35Model::Impl {
     int    sparse_budget = 0;      // max sel slots = 1 + window
     int    sparse_window = 256;    // recent window in KV blocks (16 tokens/block)
     int    sparse_min_ctx = 8192;
-    bool   sparse_mma = true;      // wmma int8 sparse split; SPARKINFER_SPARSE_MMA=0 -> scalar kernel
+    bool   sparse_mma = false;     // wmma int8 sparse; default ON for GQA-8 only (see ctor)
     bool   graph_sparse = false;
     // pre-quantized Q8_1 activation (computed once per projection input, shared across Q/K/V)
     signed char* aq8 = nullptr; float *aq8_d = nullptr, *aq8_s = nullptr;
@@ -280,13 +280,29 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->fa_m   = p_->alloc<float>(fa_n);
     p_->fa_l   = p_->alloc<float>(fa_n);
     p_->fa_acc = p_->alloc<float>(fa_n * cfg.head_dim);
-    // Sink + sliding-window sparse KV: default ON for Qwythos GQA-4 hd256 (int8 KV).
-    // SPARKINFER_SPARSE_KV=0 restores dense full-context flash-decode.
+    // Sink + sliding-window sparse KV: default ON for hd256 GQA-4 (Qwythos, scalar) and
+    // GQA-8 (Qwen3.6, wmma int8). SPARKINFER_SPARSE_KV=0 restores dense full-context flash-decode.
+    //
+    // Qwen3.6 (GQA-8) engagement (RTX 5090 bot history on PR #560 / cd94c07):
+    //   • Scalar sparse alone: +2.2% @32k, but regressed 16k vs dense-MMA (419 vs 438).
+    //   • wmma int8 sparse: +8.6% @32k (445.4 vs 410.1), 16k also passes; accuracy pass.
+    //   • min_ctx=16384 — H2 accuracy probe (8448 toks) stays dense; 16k+ engages sparse.
+    //   • window=256 (~4k toks) — O(window) KV read vs dense full-cache MMA.
+    //   • Decode-only (sample &&) — never bake into prefill CUDA graphs (avoids pp@512 collateral).
+    //   • SPARKINFER_SPARSE_MMA=0 → scalar @ min_ctx=32768 (conservative fallback).
+    //
+    // Qwythos GQA-4: keep #379 scalar sparse (window=256, min_ctx=8192). Same-window
+    // scalar→MMA only changes compute; measured +0.3% (within noise) — MMA default OFF.
     bool sparse_enable = true;
     if (const char* se = getenv("SPARKINFER_SPARSE_KV")) sparse_enable = (se[0] != '0');
+    const bool sparse_gqa4 = cfg.head_dim == 256 && cfg.n_q_heads == cfg.n_kv_heads * 4;
+    const bool sparse_gqa8 = cfg.head_dim == 256 && cfg.n_q_heads == cfg.n_kv_heads * 8;
+    // Default MMA on for GQA-8 only; env can force either way.
+    p_->sparse_mma = sparse_gqa8;
     if (const char* sm = getenv("SPARKINFER_SPARSE_MMA")) p_->sparse_mma = (sm[0] != '0');
-    if (sparse_enable && cfg.head_dim == 256 && cfg.n_q_heads == cfg.n_kv_heads * 4) {
-        p_->sparse_window = 256;
+    if (sparse_enable && (sparse_gqa4 || sparse_gqa8)) {
+        p_->sparse_window  = 256;
+        p_->sparse_min_ctx = sparse_gqa8 ? (p_->sparse_mma ? 16384 : 32768) : 8192;
         if (const char* w = getenv("SPARKINFER_SPARSE_WINDOW")) { int v = atoi(w); if (v > 0) p_->sparse_window = v; }
         // Legacy aliases from the Quest prototype (blocks, not tokens).
         if (const char* rw = getenv("SPARKINFER_SPARSE_RECENT")) { int v = atoi(rw); if (v > 0) p_->sparse_window = v; }
@@ -296,8 +312,9 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
         if (const char* mc = getenv("SPARKINFER_SPARSE_MIN_CTX")) { int v = atoi(mc); if (v > 0) p_->sparse_min_ctx = v; }
         p_->sparse_budget = 1 + p_->sparse_window;
         p_->sparse_sel = p_->alloc<int>((size_t)cfg.n_kv_heads * p_->sparse_budget);
-        fprintf(stderr, "[sparse-kv] sliding-window (default on): window=%d blocks (%d tokens) min_ctx=%d mma=%d\n",
-                p_->sparse_window, p_->sparse_window * kv->block_size(), p_->sparse_min_ctx, p_->sparse_mma ? 1 : 0);
+        fprintf(stderr, "[sparse-kv] sliding-window (default on): gqa=%d window=%d blocks (%d tokens) min_ctx=%d mma=%d\n",
+                sparse_gqa8 ? 8 : 4, p_->sparse_window, p_->sparse_window * kv->block_size(),
+                p_->sparse_min_ctx, (sparse_gqa8 && p_->sparse_mma) ? 1 : 0);
     }
     const int kmax = (p_->qdim > H) ? p_->qdim : H;          // largest projection input dim
     p_->aq8   = p_->alloc<signed char>(kmax);
@@ -462,8 +479,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         s.graph_ready = false;
     }
     const bool sparse_avail = s.sparse_budget > 0 && s.kv->int8_kv() &&
-                              c.head_dim == 256 && c.n_q_heads == c.n_kv_heads * 4;
-    const bool sparse_on = sparse_avail && seqlen >= s.sparse_min_ctx;
+                              c.head_dim == 256 &&
+                              (c.n_q_heads == c.n_kv_heads * 4 || c.n_q_heads == c.n_kv_heads * 8);
+    // Decode-only: never engage sparse during prefill graph capture (sample=false). Prefill
+    // attention has its own windowed/MMA path; baking sparse into the prefill graph caused
+    // pp@512 collateral on #560 before decode-only gating.
+    const bool sparse_on = sample && sparse_avail && seqlen >= s.sparse_min_ctx;
     if (s.graph_ready && s.graph_sparse != sparse_on) {
         cu(cudaGraphExecDestroy(s.cu_exec), "sparse recapture destroy exec");
         cu(cudaGraphDestroy(s.cu_graph), "sparse recapture destroy graph");
@@ -803,32 +824,26 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             if (sparse_on) {
                 kernels::launch_fa_kv_window_select(s.d_seqlen, s.sparse_sel, c.n_kv_heads,
                     s.kv->block_size(), s.sparse_budget, s.sparse_window, st);
-                // Use the SAME n_splits the scalar sparse kernel and the dense MMA kernel already
-                // run with (s.n_splits, adaptively tuned per context length -- e.g. 160 at 32k for
-                // this exact hd256 GQA-4 shape, see the occupancy note above). This decode is bs=1
-                // and latency-bound, not FLOP-bound: capping splits to the "natural" 8-block-group
-                // count (~33 at window=256) collapses the grid from ~160*n_kv_heads blocks to
-                // ~33*n_kv_heads and starves the GPU's SMs of parallelism, which erases the
-                // tensor-core compute win (measured net +0.3% -- within noise -- when capped).
-                // Uncapped, most splits see fewer than 8 selected blocks (often 1-2), so most
-                // warps in the QK step of any given split go idle -- but there are ~5x more splits
-                // running concurrently to hide that, matching the occupancy the scalar kernel and
-                // the dense MMA kernel both already rely on at this shape.
+                // Use s.n_splits (adaptively tuned, e.g. 160 at 32k for hd256). Do NOT cap to
+                // ceil(budget/8): bs=1 decode is latency-bound; starving the grid of parallel
+                // blocks erased the MMA win on Qwythos (#580 v1 → +0.3%). Cap only to the
+                // selected-block budget so empty partials stay rare for the combine kernel.
+                const int sparse_splits = (s.n_splits < s.sparse_budget) ? s.n_splits : s.sparse_budget;
                 bool mma_done = false;
                 if (s.sparse_mma) {
                     mma_done = kernels::launch_flash_decode_split_sparse_mma(s.q, kpool, vpool,
                         btable, s.d_seqlen, s.sparse_sel, s.fa_m, s.fa_l, s.fa_acc,
                         c.n_q_heads, c.n_kv_heads, c.head_dim, s.kv->block_size(),
-                        s.kv->max_blocks_per_seq(), s.n_splits, s.sparse_budget,
+                        s.kv->max_blocks_per_seq(), sparse_splits, s.sparse_budget,
                         1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
                 }
                 if (!mma_done)
                     kernels::launch_flash_decode_split_sparse(s.q, kpool, vpool, btable, s.d_seqlen,
                         s.sparse_sel, s.fa_m, s.fa_l, s.fa_acc, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                        s.kv->block_size(), s.kv->max_blocks_per_seq(), s.n_splits, s.sparse_budget,
+                        s.kv->block_size(), s.kv->max_blocks_per_seq(), sparse_splits, s.sparse_budget,
                         1.f / sqrtf((float)c.head_dim), kscale, vscale, st);
                 kernels::launch_fa_combine_hd256(s.fa_m, s.fa_l, s.fa_acc, s.attn, c.n_q_heads,
-                    s.n_splits, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st,
+                    sparse_splits, (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, st,
                     attn_gate_q8 ? s.qgate : nullptr);
             } else {
             kernels::launch_flash_decode_split(s.q, kpool, vpool, btable, s.d_seqlen, s.attn,


### PR DESCRIPTION
## Summary

Retarget of this PR after Qwythos GQA-4 same-window scalar→MMA measured **+0.3%** twice
(`eval:none` / `eval:REJECT`) — that path has no bandwidth story (fixed window, ~¼ full-attn
layers).

**New target: Qwen3.6 GQA-8 sink+window sparse MMA** (closes #559).

The same kernel was already bot-verified on `#560` / `cd94c07`:

| metric | result |
|---|---|
| Qwen3.6 decode @32k | **445.42 vs 410.07 = +8.6%** |
| Qwen3.6 @16k | 445.44 vs 437.73 (pass) |
| Accuracy | top-1 **92.0%**, KL **0.056** (pass) |
| Why #560 closed | stale **512 prefill** guard (−2.7%) after 3 exhausted retries — not a decode fail |

This update rebases onto current main (`#577`/`#579`/`#583` prefill wins) so those guards
should match, and keeps every safety lesson from #560 / this PR's earlier rounds:

- **`min_ctx=16384`** — H2 probe (8448) stays dense (first #560 fail was min_ctx=8192 → top1 0)
- **`window=256`** — O(window) KV read vs dense full-cache MMA
- **Decode-only** (`sample &&`) — never bake into prefill CUDA graphs
- **`s.n_splits` occupancy** — no `ceil(budget/8)` cap (that erased the Qwythos MMA win here)
- **Qwythos GQA-4** — #379 scalar sparse unchanged; MMA default **OFF**
- `SPARKINFER_SPARSE_MMA=0` → scalar @ `min_ctx=32768` fallback

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark).

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end):

| | decode tok/s |
|---|--:|
| before (main) | 410.1 |
| after (this PR) | 445.4 |

**ctx=32768**, Qwen3.6-35B-A3B. Numbers are this repo's own eval bot on `cd94c07` (#560) for
the same MMA sparse kernel + engagement — not a projection. Requesting re-eval on `13675e8`
(rebased main + decode-only + occupancy fix).

**Prefill pp tok/s** — not targeted (decode-only; prefill path unchanged):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

```text
# Bot on cd94c07 (#560, same kernel): Qwen3.6 @32k 445.42 vs main 410.07 (+8.6%)
# This push (13675e8): rebased on main; decode-only; min_ctx=16384; s.n_splits uncapped
# 128/512/4k/H2: dense (below min_ctx), byte-identical to main on decode
```

## Env knobs

- `SPARKINFER_SPARSE_KV=0` — dense everywhere
- `SPARKINFER_SPARSE_MMA=0` — scalar sparse @ 32k-only (GQA-8)
- `SPARKINFER_SPARSE_WINDOW` / `SPARKINFER_SPARSE_MIN_CTX` — overrides

## Test plan

- [x] GQA-8 MMA sparse: combine-compatible partials; OOB/tail-block masks
- [x] Decode-only gating; H2 (8448) dense
- [x] Qwythos GQA-4 scalar path unchanged (MMA off)
- [x] Rebased onto main with #577/#579/#583 prefill
- [ ] Auto-eval: Qwen3.6 16k/32k decode ≥2%; Qwythos flat; prefill gates clean
