### PR TITLE
perf(qwen36): double bf16 prefill projection GEMM occupancy to 2 blocks/SM (+12% pp)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -65,7 +65,12 @@ __device__ __forceinline__ int pf_swz_e(int e, int row) {
 __device__ __forceinline__ unsigned pf_lds32b(const __nv_bfloat16* p) {
     return *reinterpret_cast<const unsigned*>(p);   // load 2 contiguous bf16 as one 32b operand
 }
-__global__ void pf_gemm_kernel(const __nv_bfloat16* __restrict__ A,
+// The 2 is load-bearing: left to itself nvcc gives this kernel 130 registers, and 256*130 > 65536,
+// so only ONE block is resident per SM. Capping to 2 blocks/SM forces <=128 registers (ptxas: 128,
+// no spills, same 40 KB smem) and doubles occupancy. The wmma MMA schedule is unchanged, so the
+// output is numerically equivalent to before (accuracy gate untouched). This kernel runs every
+// Qwen3.6 GDN/attention projection at batched prefill, where it is the single largest kernel.
+__global__ __launch_bounds__(256, 2) void pf_gemm_kernel(const __nv_bfloat16* __restrict__ A,
                                const __nv_bfloat16* __restrict__ W,
                                __nv_bfloat16* __restrict__ C, int M, int N, int K) {
     using namespace nvcuda;


### PR DESCRIPTION
## Summary

`pf_gemm_kernel` (the bf16 wmma GEMM that `proj()` runs for every Qwen3.6 GDN/attention projection at batched prefill — the MoE path keeps these bf16 because int8 flips the top-k router) was register-limited to one resident block per SM: nvcc gives it 130 registers and 256*130 > 65536. It is the single largest prefill kernel (27% of the wall at ctx=4k, 31% at 32k). Adding `__launch_bounds__(256, 2)` caps it to 128 registers (ptxas: 128, no spills, same 40 KB smem) so two blocks are resident per SM. The wmma MMA schedule is unchanged, so the output is numerically equivalent (accuracy unaffected) and decode is untouched — it is a one-line, prefill-only occupancy fix.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 492.1 |
| after (this PR) | 491.2 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B — this PR targets prefill; eval sweep contexts, int8-KV on, 5-run interleaved median; best context = 16384):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 15724.8 |
| after prefill (this PR) | 17623.5 |

```text
# 5-run interleaved median, one model load per sweep (SPARKINFER_BENCH_SWEEP), int8-KV on.
# Qwen3.6-35B-A3B-UD-Q4_K_M, RTX 5090 (sm_120), CUDA 12.8.

                 prefill pp tok/s          decode tok/s
ctx        main     this PR     Δ        main    this PR
 512     4909.9     5124.0   +4.4%      492.1     491.2
4096    12782.1    14077.9  +10.1%      474.1     474.0
16384   15724.8    17623.5  +12.1%      453.2     455.9
32768   16116.5    18004.1  +11.7%      426.9     426.9

# ptxas: pf_gemm_kernel 130 -> 128 registers, 0 spills, 40960 B smem (1 -> 2 blocks/SM).
# qwen3_gguf_prefill_check @4096: top1 16/16 = 1.0000 (== main), KL 0.00589 (main 0.00585).
