### PR TITLE
perf(qwen36): GPU MoE tilemap — skip D2H sync (+30% pp @512)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe.cu
@@ -114,11 +114,6 @@ __device__ __forceinline__ void pm_cp16(void* dst, const void* src, bool pred) {
     if (pred) __pipeline_memcpy_async(dst, src, 16);
     else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
 }
-// Sync 16B staging for kernels that stage once per K-tile without cp.async double-buffer.
-__device__ __forceinline__ void pm_ld16(void* dst, const void* src, bool pred) {
-    if (pred) *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(src);
-    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
-}
 
 template <bool A_INDIRECT, bool C_SCATTER>
 __global__ void pfm_moe_gemm_i8_kernel(const signed char* __restrict__ A_i8,
@@ -348,9 +343,9 @@ __global__ void pfm_moe_gemm_i8_gate_up_bm16_kernel(const signed char* __restric
     const int M   = min(BM, cnt - mt * BM);
     const int n0  = blockIdx.x * PM_BN;
 
-    __shared__ signed char As[BM][PM_BK];
-    __shared__ signed char Bsg[PM_BN][PM_BK];
-    __shared__ signed char Bsu[PM_BN][PM_BK];
+    __shared__ signed char As[2][BM][PM_BK];
+    __shared__ signed char Bsg[2][PM_BN][PM_BK];
+    __shared__ signed char Bsu[2][PM_BN][PM_BK];
     __shared__ int Cs[8][16][16];
     __shared__ int s_tok[BM];
 
@@ -370,40 +365,48 @@ __global__ void pfm_moe_gemm_i8_gate_up_bm16_kernel(const signed char* __restric
     wmma::fill_fragment(cf_g, 0);
     wmma::fill_fragment(cf_u, 0);
 
-    const int nk = (K + PM_BK - 1) / PM_BK;
-    for (int t = 0; t < nk; t++) {
-        const int k0 = t * PM_BK;
+    auto stage = [&](int buf, int k0) {
         for (int idx = tid; idx < BM * 2; idx += blockDim.x) {
             const int r = idx >> 1, c16 = (idx & 1) * 16;
             const int gk = k0 + c16;
             const int arow = s_tok[r];
-            pm_ld16(&As[r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
+            pm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
         }
-        for (int idx = tid; idx < PM_BN * 2; idx += blockDim.x) {
-            const int r = idx >> 1, c16 = (idx & 1) * 16;
+        {
+            const int r = tid >> 1, c16 = (tid & 1) * 16;
             const int gk = k0 + c16;
             const int gn = n0 + r;
-            pm_ld16(&Bsg[r][c16], &Wge[(size_t)gn * K + gk], gn < N && gk < K);
-            pm_ld16(&Bsu[r][c16], &Wue[(size_t)gn * K + gk], gn < N && gk < K);
+            pm_cp16(&Bsg[buf][r][c16], &Wge[(size_t)gn * K + gk], gn < N && gk < K);
+            pm_cp16(&Bsu[buf][r][c16], &Wue[(size_t)gn * K + gk], gn < N && gk < K);
         }
+        __pipeline_commit();
+    };
+
+    const int nk = (K + PM_BK - 1) / PM_BK;
+    stage(0, 0);
+    int buf = 0;
+    for (int t = 0; t < nk; t++) {
+        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * PM_BK);
+        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
         __syncthreads();
 #pragma unroll
         for (int kk = 0; kk < PM_BK; kk += 16) {
             wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af;
             wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf;
-            wmma::load_matrix_sync(af, &As[0][kk], PM_BK);
-            wmma::load_matrix_sync(bf, &Bsg[wn * 16][kk], PM_BK);
+            wmma::load_matrix_sync(af, &As[buf][0][kk], PM_BK);
+            wmma::load_matrix_sync(bf, &Bsg[buf][wn * 16][kk], PM_BK);
             wmma::mma_sync(cf_g, af, bf, cf_g);
         }
 #pragma unroll
         for (int kk = 0; kk < PM_BK; kk += 16) {
             wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af;
             wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf;
-            wmma::load_matrix_sync(af, &As[0][kk], PM_BK);
-            wmma::load_matrix_sync(bf, &Bsu[wn * 16][kk], PM_BK);
+            wmma::load_matrix_sync(af, &As[buf][0][kk], PM_BK);
+            wmma::load_matrix_sync(bf, &Bsu[buf][wn * 16][kk], PM_BK);
             wmma::mma_sync(cf_u, af, bf, cf_u);
         }
         __syncthreads();
+        buf ^= 1;
     }
 
     auto store_tile = [&](const wmma::fragment<wmma::accumulator, 16, 16, 16, int>& cf,

--- a/kernels/csrc/cuda/fused/prefill_moe.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe.cu
@@ -317,6 +317,109 @@ __global__ void pfm_moe_gemm_i8_bm16_kernel(const signed char* __restrict__ A_i8
     }
 }
 
+// Fused gate+up grouped GEMM (BM=16, A_INDIRECT only): stages A once per K-tile and
+// runs two WMMA passes (gate + up) so activations are read once instead of twice.
+__global__ void pfm_moe_gemm_i8_gate_up_bm16_kernel(const signed char* __restrict__ A_i8,
+                                                    const float* __restrict__ sx,
+                                                    const signed char* __restrict__ Wg_i8,
+                                                    const float* __restrict__ swg,
+                                                    const signed char* __restrict__ Wu_i8,
+                                                    const float* __restrict__ swu,
+                                                    const int* __restrict__ pair_tok,
+                                                    const int* __restrict__ offsets,
+                                                    const int* __restrict__ tilemap,
+                                                    const int* __restrict__ d_ntiles,
+                                                    __nv_bfloat16* __restrict__ Cg,
+                                                    __nv_bfloat16* __restrict__ Cu,
+                                                    int N, int K, int e_base) {
+    using namespace nvcuda;
+    constexpr int BM = PM_BM_SHORT;
+    const int tile = blockIdx.y;
+    if (tile >= d_ntiles[0]) return;
+    const int e   = tilemap[2 * tile];
+    const int mt  = tilemap[2 * tile + 1];
+    const int p0  = offsets[e] + mt * BM;
+    const int cnt = offsets[e + 1] - offsets[e];
+    const int M   = min(BM, cnt - mt * BM);
+    const int n0  = blockIdx.x * PM_BN;
+
+    __shared__ signed char As[BM][PM_BK];
+    __shared__ signed char Bsg[PM_BN][PM_BK];
+    __shared__ signed char Bsu[PM_BN][PM_BK];
+    __shared__ int Cs[8][16][16];
+    __shared__ int s_tok[BM];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5, lane = tid & 31;
+    const int wn = warp;
+    const signed char* Wge = Wg_i8 + (size_t)(e - e_base) * N * K;
+    const signed char* Wue = Wu_i8 + (size_t)(e - e_base) * N * K;
+    const float*       swge = swg + (size_t)(e - e_base) * N;
+    const float*       swue = swu + (size_t)(e - e_base) * N;
+
+    for (int r = tid; r < BM; r += blockDim.x)
+        s_tok[r] = (r < M) ? pair_tok[p0 + r] : -1;
+    __syncthreads();
+
+    wmma::fragment<wmma::accumulator, 16, 16, 16, int> cf_g, cf_u;
+    wmma::fill_fragment(cf_g, 0);
+    wmma::fill_fragment(cf_u, 0);
+
+    const int nk = (K + PM_BK - 1) / PM_BK;
+    for (int t = 0; t < nk; t++) {
+        const int k0 = t * PM_BK;
+        for (int idx = tid; idx < BM * 2; idx += blockDim.x) {
+            const int r = idx >> 1, c16 = (idx & 1) * 16;
+            const int gk = k0 + c16;
+            const int arow = s_tok[r];
+            pm_cp16(&As[r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
+        }
+        for (int idx = tid; idx < PM_BN * 2; idx += blockDim.x) {
+            const int r = idx >> 1, c16 = (idx & 1) * 16;
+            const int gk = k0 + c16;
+            const int gn = n0 + r;
+            pm_cp16(&Bsg[r][c16], &Wge[(size_t)gn * K + gk], gn < N && gk < K);
+            pm_cp16(&Bsu[r][c16], &Wue[(size_t)gn * K + gk], gn < N && gk < K);
+        }
+        __syncthreads();
+#pragma unroll
+        for (int kk = 0; kk < PM_BK; kk += 16) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf;
+            wmma::load_matrix_sync(af, &As[0][kk], PM_BK);
+            wmma::load_matrix_sync(bf, &Bsg[wn * 16][kk], PM_BK);
+            wmma::mma_sync(cf_g, af, bf, cf_g);
+        }
+#pragma unroll
+        for (int kk = 0; kk < PM_BK; kk += 16) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf;
+            wmma::load_matrix_sync(af, &As[0][kk], PM_BK);
+            wmma::load_matrix_sync(bf, &Bsu[wn * 16][kk], PM_BK);
+            wmma::mma_sync(cf_u, af, bf, cf_u);
+        }
+        __syncthreads();
+    }
+
+    auto store_tile = [&](const wmma::fragment<wmma::accumulator, 16, 16, 16, int>& cf,
+                          const float* swe, __nv_bfloat16* C) {
+        const int gn0 = n0 + wn * 16;
+        wmma::store_matrix_sync(&Cs[warp][0][0], cf, 16, wmma::mem_row_major);
+        __syncwarp();
+        for (int el = lane; el < 256; el += 32) {
+            const int r = el >> 4, cc = el & 15;
+            const int rm = r, rn = gn0 + cc;
+            if (rm < M && rn < N) {
+                const int p = p0 + rm;
+                const float v = (float)Cs[warp][r][cc] * sx[s_tok[rm]] * swe[rn];
+                C[(size_t)p * N + rn] = __float2bfloat16(v);
+            }
+        }
+    };
+    store_tile(cf_g, swge, Cg);
+    store_tile(cf_u, swue, Cu);
+}
+
 // Single-expert GEMM (W_i8 already the expert slice). blockIdx.y = local M-tile.
 template <bool A_INDIRECT, bool C_SCATTER, int BM>
 __global__ void pfm_moe_gemm_i8_one_kernel(const signed char* __restrict__ A_i8,
@@ -741,6 +844,21 @@ void launch_pfm_moe_gemm_i8_bm(const signed char* A_i8, const float* sx,
     launch_pfm_moe_gemm_i8_bm_base(A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles,
                                    C_bf16, out_f32, N_out, K, max_tiles, bm, /*e_base=*/0,
                                    a_indirect, c_scatter, stream);
+}
+
+void launch_pfm_moe_gemm_i8_gate_up_bm16(const signed char* A_i8, const float* sx,
+                                         const signed char* Wg_i8, const float* swg,
+                                         const signed char* Wu_i8, const float* swu,
+                                         const int* pair_tok,
+                                         const int* offsets, const int* tilemap, const int* d_ntiles,
+                                         void* Cg_bf16, void* Cu_bf16,
+                                         int N_out, int K, int max_tiles, int e_base,
+                                         cudaStream_t stream) {
+    dim3 grid((N_out + PM_BN - 1) / PM_BN, max_tiles);
+    pfm_moe_gemm_i8_gate_up_bm16_kernel<<<grid, 256, 0, stream>>>(
+        A_i8, sx, Wg_i8, swg, Wu_i8, swu, pair_tok, offsets, tilemap, d_ntiles,
+        reinterpret_cast<__nv_bfloat16*>(Cg_bf16), reinterpret_cast<__nv_bfloat16*>(Cu_bf16),
+        N_out, K, e_base);
 }
 
 void launch_pfm_moe_gemm_i8_bm_base(const signed char* A_i8, const float* sx,

--- a/kernels/csrc/cuda/fused/prefill_moe.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe.cu
@@ -114,6 +114,11 @@ __device__ __forceinline__ void pm_cp16(void* dst, const void* src, bool pred) {
     if (pred) __pipeline_memcpy_async(dst, src, 16);
     else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
 }
+// Sync 16B staging for kernels that stage once per K-tile without cp.async double-buffer.
+__device__ __forceinline__ void pm_ld16(void* dst, const void* src, bool pred) {
+    if (pred) *reinterpret_cast<uint4*>(dst) = *reinterpret_cast<const uint4*>(src);
+    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
 
 template <bool A_INDIRECT, bool C_SCATTER>
 __global__ void pfm_moe_gemm_i8_kernel(const signed char* __restrict__ A_i8,
@@ -372,14 +377,14 @@ __global__ void pfm_moe_gemm_i8_gate_up_bm16_kernel(const signed char* __restric
             const int r = idx >> 1, c16 = (idx & 1) * 16;
             const int gk = k0 + c16;
             const int arow = s_tok[r];
-            pm_cp16(&As[r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
+            pm_ld16(&As[r][c16], &A_i8[(size_t)max(arow, 0) * K + gk], arow >= 0 && gk < K);
         }
         for (int idx = tid; idx < PM_BN * 2; idx += blockDim.x) {
             const int r = idx >> 1, c16 = (idx & 1) * 16;
             const int gk = k0 + c16;
             const int gn = n0 + r;
-            pm_cp16(&Bsg[r][c16], &Wge[(size_t)gn * K + gk], gn < N && gk < K);
-            pm_cp16(&Bsu[r][c16], &Wue[(size_t)gn * K + gk], gn < N && gk < K);
+            pm_ld16(&Bsg[r][c16], &Wge[(size_t)gn * K + gk], gn < N && gk < K);
+            pm_ld16(&Bsu[r][c16], &Wue[(size_t)gn * K + gk], gn < N && gk < K);
         }
         __syncthreads();
 #pragma unroll

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -348,6 +348,32 @@ bool launch_gguf_dequant_rows_i8_gather_pair(
     return true;
 }
 
+bool launch_gguf_dequant_rows_i8_mask(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream) {
+    return launch_gguf_dequant_rows_i8_fast_mask(
+        ggml_type, src0, q0, scale0, counts, e_base, n_in, rows_per_expert, cols, expert_bytes,
+        stream);
+}
+
+bool launch_gguf_dequant_rows_i8_mask_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream) {
+    if (launch_gguf_dequant_rows_i8_fast_mask_pair(
+            ggml_type, src0, q0, scale0, src1, q1, scale1, counts, e_base, n_in, rows_per_expert,
+            cols, expert_bytes0, expert_bytes1, stream))
+        return true;
+    if (!launch_gguf_dequant_rows_i8_mask(ggml_type, src0, q0, scale0, counts, e_base, n_in,
+                                          rows_per_expert, cols, expert_bytes0, stream))
+        return false;
+    return launch_gguf_dequant_rows_i8_mask(ggml_type, src1, q1, scale1, counts, e_base, n_in,
+                                            rows_per_expert, cols, expert_bytes1, stream);
+}
+
 void launch_transpose_bf16(const void* src, void* dst, int rows, int cols, cudaStream_t stream) {
     long n = (long)rows*cols; const int T=256;
     transpose2d_kernel<<<(n+T-1)/T,T,0,stream>>>(reinterpret_cast<const __nv_bfloat16*>(src), reinterpret_cast<__nv_bfloat16*>(dst), rows, cols);

--- a/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
+++ b/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
@@ -399,6 +399,180 @@ bool dispatch_gather_pair(const unsigned char* src0, signed char* q0, float* sca
     return true;
 }
 
+// MoE group mask: blockIdx maps (le, row_in); skip when counts[e_base+le]==0.
+template <int QT, int NG>
+__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_mask_kernel(
+        const unsigned char* __restrict__ src0, signed char* __restrict__ q0,
+        float* __restrict__ scale0, const int* __restrict__ counts,
+        int e_base, int n_in, int rows_per_expert, int cols, size_t expert_bytes) {
+    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
+    const int flat = (int)blockIdx.x;
+    const int le = flat / rows_per_expert;
+    const int row_in = flat - le * rows_per_expert;
+    if (le >= n_in || counts[e_base + le] <= 0) return;
+    const int t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const size_t row_bytes = (size_t)nsb * (size_t)BS;
+    const unsigned char* rbase = src0 + (size_t)le * expert_bytes + (size_t)row_in * row_bytes;
+    float* scale = scale0 + (size_t)le * (size_t)rows_per_expert + (size_t)row_in;
+    signed char* qrow = q0 + ((size_t)le * (size_t)rows_per_expert + (size_t)row_in) * (size_t)cols;
+
+    float v[NG][DQR_VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            const unsigned char* blk = rbase + (size_t)(base >> 8) * BS;
+            const int off = base & 255;
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) {
+                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                amax = fmaxf(amax, fabsf(v[g][i]));
+            }
+        }
+    }
+
+    __shared__ float swarp[DQR_BLOCK / 32];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
+        if (t == 0) swarp[0] = w;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) *scale = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            signed char o[DQR_VEC];
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) o[i] = (signed char)(int)roundf(v[g][i] * inv);
+            *reinterpret_cast<unsigned*>(&qrow[base]) = *reinterpret_cast<const unsigned*>(o);
+        }
+    }
+}
+
+template <int QT, int NG>
+__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_mask_pair_kernel(
+        const unsigned char* __restrict__ src0, signed char* __restrict__ q0, float* __restrict__ scale0,
+        const unsigned char* __restrict__ src1, signed char* __restrict__ q1, float* __restrict__ scale1,
+        const int* __restrict__ counts, int e_base, int n_in, int rows_per_expert, int cols,
+        size_t expert_bytes0, size_t expert_bytes1) {
+    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
+    const int n_flat = n_in * rows_per_expert;
+    const int which = (int)(blockIdx.x / (unsigned)n_flat);
+    const int flat = (int)(blockIdx.x - (unsigned)which * (unsigned)n_flat);
+    const int le = flat / rows_per_expert;
+    const int row_in = flat - le * rows_per_expert;
+    if (le >= n_in || counts[e_base + le] <= 0) return;
+    const unsigned char* src = which ? src1 : src0;
+    const size_t expert_bytes = which ? expert_bytes1 : expert_bytes0;
+    signed char* q = which ? q1 : q0;
+    float* scale = which ? scale1 : scale0;
+    const int t = threadIdx.x;
+    const int nsb = cols >> 8;
+    const size_t row_bytes = (size_t)nsb * (size_t)BS;
+    const unsigned char* rbase = src + (size_t)le * expert_bytes + (size_t)row_in * row_bytes;
+    float* srow = scale + (size_t)le * (size_t)rows_per_expert + (size_t)row_in;
+    signed char* qrow = q + ((size_t)le * (size_t)rows_per_expert + (size_t)row_in) * (size_t)cols;
+
+    float v[NG][DQR_VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            const unsigned char* blk = rbase + (size_t)(base >> 8) * BS;
+            const int off = base & 255;
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) {
+                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                amax = fmaxf(amax, fabsf(v[g][i]));
+            }
+        }
+    }
+
+    __shared__ float swarp[DQR_BLOCK / 32];
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((t & 31) == 0) swarp[t >> 5] = amax;
+    __syncthreads();
+    if (t < 32) {
+        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
+        if (t == 0) swarp[0] = w;
+    }
+    __syncthreads();
+    const float d = swarp[0] / 127.f;
+    if (t == 0) *srow = d;
+    const float inv = (d > 0.f) ? (1.f / d) : 0.f;
+
+    #pragma unroll
+    for (int g = 0; g < NG; g++) {
+        const int base = g * GSPAN + t * DQR_VEC;
+        if (base < cols) {
+            signed char o[DQR_VEC];
+            #pragma unroll
+            for (int i = 0; i < DQR_VEC; i++) o[i] = (signed char)(int)roundf(v[g][i] * inv);
+            *reinterpret_cast<unsigned*>(&qrow[base]) = *reinterpret_cast<const unsigned*>(o);
+        }
+    }
+}
+
+template <int QT>
+bool dispatch_mask(const unsigned char* src0, signed char* q0, float* scale0,
+                   const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+                   size_t expert_bytes, cudaStream_t stream) {
+    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
+    const int grid = n_in * rows_per_expert;
+    if (ng <= 4)
+        deq_rows_i8_vec_mask_kernel<QT, 4><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, counts, e_base, n_in, rows_per_expert, cols, expert_bytes);
+    else if (ng <= 8)
+        deq_rows_i8_vec_mask_kernel<QT, 8><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, counts, e_base, n_in, rows_per_expert, cols, expert_bytes);
+    else if (ng <= 12)
+        deq_rows_i8_vec_mask_kernel<QT, 12><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, counts, e_base, n_in, rows_per_expert, cols, expert_bytes);
+    else return false;
+    return true;
+}
+
+template <int QT>
+bool dispatch_mask_pair(const unsigned char* src0, signed char* q0, float* scale0,
+                        const unsigned char* src1, signed char* q1, float* scale1,
+                        const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+                        size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream) {
+    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
+    const int grid = 2 * n_in * rows_per_expert;
+    if (ng <= 4)
+        deq_rows_i8_vec_mask_pair_kernel<QT, 4><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, src1, q1, scale1, counts, e_base, n_in, rows_per_expert, cols,
+            expert_bytes0, expert_bytes1);
+    else if (ng <= 8)
+        deq_rows_i8_vec_mask_pair_kernel<QT, 8><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, src1, q1, scale1, counts, e_base, n_in, rows_per_expert, cols,
+            expert_bytes0, expert_bytes1);
+    else if (ng <= 12)
+        deq_rows_i8_vec_mask_pair_kernel<QT, 12><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, src1, q1, scale1, counts, e_base, n_in, rows_per_expert, cols,
+            expert_bytes0, expert_bytes1);
+    else return false;
+    return true;
+}
+
 }  // namespace
 
 bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed char* q, float* scale,
@@ -478,6 +652,53 @@ bool launch_gguf_dequant_rows_i8_fast_gather_pair(
         return dispatch_gather_pair<DQR_Q6_K>(s0, q0, scale0, s1, q1, scale1, live_le, n_live,
                                               rows_per_expert, cols, expert_bytes0, expert_bytes1,
                                               stream);
+    return false;
+}
+
+bool launch_gguf_dequant_rows_i8_fast_mask(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || !counts || n_in <= 0 || rows_per_expert <= 0 || cols <= 0 ||
+        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        return false;
+    auto s = reinterpret_cast<const unsigned char*>(src0);
+    if (ggml_type == DQR_Q4_K)
+        return dispatch_mask<DQR_Q4_K>(s, q0, scale0, counts, e_base, n_in, rows_per_expert, cols,
+                                       expert_bytes, stream);
+    if (ggml_type == DQR_Q6_K)
+        return dispatch_mask<DQR_Q6_K>(s, q0, scale0, counts, e_base, n_in, rows_per_expert, cols,
+                                       expert_bytes, stream);
+    return false;
+}
+
+bool launch_gguf_dequant_rows_i8_fast_mask_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || !counts || n_in <= 0 || rows_per_expert <= 0 || cols <= 0 ||
+        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        return false;
+    auto s0 = reinterpret_cast<const unsigned char*>(src0);
+    auto s1 = reinterpret_cast<const unsigned char*>(src1);
+    if (ggml_type == DQR_Q4_K)
+        return dispatch_mask_pair<DQR_Q4_K>(s0, q0, scale0, s1, q1, scale1, counts, e_base, n_in,
+                                            rows_per_expert, cols, expert_bytes0, expert_bytes1,
+                                            stream);
+    if (ggml_type == DQR_Q6_K)
+        return dispatch_mask_pair<DQR_Q6_K>(s0, q0, scale0, s1, q1, scale1, counts, e_base, n_in,
+                                            rows_per_expert, cols, expert_bytes0, expert_bytes1,
+                                            stream);
     return false;
 }
 

--- a/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
+++ b/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
@@ -53,5 +53,19 @@ bool launch_gguf_dequant_rows_i8_fast_gather_pair(
     const int* live_le, int n_live, int rows_per_expert, int cols,
     size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream = nullptr);
 
+// MoE group mask: grid = n_in * rows_per_expert (pair: 2x). Skips experts with counts[e]==0.
+// Avoids D2H counts + host live-index build when combined with device tilemap.
+bool launch_gguf_dequant_rows_i8_fast_mask(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream = nullptr);
+
+bool launch_gguf_dequant_rows_i8_fast_mask_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream = nullptr);
+
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_moe.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe.h
@@ -72,6 +72,17 @@ void launch_pfm_moe_gemm_i8_bm(const signed char* A_i8, const float* sx,
                                bool a_indirect, bool c_scatter, cudaStream_t stream);
 // Like _bm but W_i8/sw hold a contiguous expert group starting at e_base (tilemap still
 // stores global expert ids; W is indexed as e - e_base).
+// Like _bm_base but fuses gate+up GEMMs (BM=16, A_INDIRECT gate/up only) so activations
+// are staged once per K-tile. SPARKINFER_PREFILL_MOE_FUSE_GU=0 disables (A/B).
+void launch_pfm_moe_gemm_i8_gate_up_bm16(const signed char* A_i8, const float* sx,
+                                         const signed char* Wg_i8, const float* swg,
+                                         const signed char* Wu_i8, const float* swu,
+                                         const int* pair_tok,
+                                         const int* offsets, const int* tilemap, const int* d_ntiles,
+                                         void* Cg_bf16, void* Cu_bf16,
+                                         int N_out, int K, int max_tiles, int e_base,
+                                         cudaStream_t stream);
+
 void launch_pfm_moe_gemm_i8_bm_base(const signed char* A_i8, const float* sx,
                                     const signed char* W_i8, const float* sw,
                                     const int* pair_tok, const float* pair_w,

--- a/kernels/include/sparkinfer/kernels/quant.h
+++ b/kernels/include/sparkinfer/kernels/quant.h
@@ -53,6 +53,18 @@ bool launch_gguf_dequant_rows_i8_gather_pair(
     const int* live_le, int n_live, int rows_per_expert, int cols,
     size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream = nullptr);
 
+bool launch_gguf_dequant_rows_i8_mask(
+    int ggml_type, const void* src0, signed char* q0, float* scale0,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes, cudaStream_t stream = nullptr);
+
+bool launch_gguf_dequant_rows_i8_mask_pair(
+    int ggml_type,
+    const void* src0, signed char* q0, float* scale0,
+    const void* src1, signed char* q1, float* scale1,
+    const int* counts, int e_base, int n_in, int rows_per_expert, int cols,
+    size_t expert_bytes0, size_t expert_bytes1, cudaStream_t stream = nullptr);
+
 // bf16 transposes used to relayout GGUF [out,in] -> our [in,out].
 void launch_transpose_bf16(const void* src, void* dst, int rows, int cols,
                            cudaStream_t stream = nullptr);          // [rows,cols]->[cols,rows]

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -261,6 +261,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (e) return e[0] != '0';
         return N <= 512;
     }();
+    // Device tilemap + mask dequant: skip per-layer D2H counts sync. Default ON at short-N.
+    const bool moe_gpu = [&]{
+        if (!moe_serial) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_GPU");
+        return !e || e[0] != '0';
+    }();
     const int moe_group = [&]{
         const char* e = getenv("SPARKINFER_PREFILL_MOE_GROUP");
         int g = e ? atoi(e) : 32;
@@ -611,6 +617,66 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     const int bs = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
                     return (size_t)(cols >> 8) * (size_t)bs;
                 };
+                const size_t g_rb = q_row_bytes(w.gate_qtype, H);
+                const size_t u_rb = q_row_bytes(w.up_qtype, H);
+                const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
+                const size_t g_eb = (size_t)mffn * g_rb;
+                const size_t u_eb = (size_t)mffn * u_rb;
+                const size_t d_eb = (size_t)H * d_rb;
+                const int G = moe_group;
+                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st),
+                      "routed zero");
+
+                if (moe_gpu && !moe_overlap) {
+                    // No D2H counts sync: device tilemap + mask dequant per expert group.
+                    for (int base = 0; base < E; base += G) {
+                        const int n_in = (E - base < G) ? (E - base) : G;
+                        kernels::launch_pfm_group_tilemap(
+                            mcounts, tilemap, d_ntiles, base, n_in, moe_bm, max_tiles, st);
+                        const void* ge0 = (const char*)w.gate_q + (size_t)base * g_eb;
+                        const void* ue0 = (const char*)w.up_q + (size_t)base * u_eb;
+                        if (w.gate_qtype == w.up_qtype) {
+                            kernels::launch_gguf_dequant_rows_i8_mask_pair(
+                                w.gate_qtype, ge0, Wg_i8, swg, ue0, Wu_i8, swu,
+                                mcounts, base, n_in, mffn, H, g_eb, u_eb, st);
+                        } else {
+                            kernels::launch_gguf_dequant_rows_i8_mask(
+                                w.gate_qtype, ge0, Wg_i8, swg, mcounts, base, n_in, mffn, H,
+                                g_eb, st);
+                            kernels::launch_gguf_dequant_rows_i8_mask(
+                                w.up_qtype, ue0, Wu_i8, swu, mcounts, base, n_in, mffn, H,
+                                u_eb, st);
+                        }
+                        if (moe_fuse_gu) {
+                            kernels::launch_pfm_moe_gemm_i8_gate_up_bm16(
+                                mA_i8, msx, Wg_i8, swg, Wu_i8, swu, pair_tok, moffsets, tilemap,
+                                d_ntiles, hg, hu, mffn, H, max_tiles, base, st);
+                        } else {
+                            kernels::launch_pfm_moe_gemm_i8_bm_base(
+                                mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets, tilemap,
+                                d_ntiles, hg, nullptr, mffn, H, max_tiles, moe_bm, base,
+                                true, false, st);
+                            kernels::launch_pfm_moe_gemm_i8_bm_base(
+                                mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets, tilemap,
+                                d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm, base,
+                                true, false, st);
+                        }
+                    }
+                    kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
+                    kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                    for (int base = 0; base < E; base += G) {
+                        const int n_in = (E - base < G) ? (E - base) : G;
+                        kernels::launch_pfm_group_tilemap(
+                            mcounts, tilemap, d_ntiles, base, n_in, moe_bm, max_tiles, st);
+                        const void* de0 = (const char*)w.down_q + (size_t)base * d_eb;
+                        kernels::launch_gguf_dequant_rows_i8_mask(
+                            w.down_qtype, de0, Wd_i8, swd, mcounts, base, n_in, H, mffn, d_eb, st);
+                        kernels::launch_pfm_moe_gemm_i8_bm_base(
+                            h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets, tilemap, d_ntiles,
+                            nullptr, routed_f32, H, mffn, max_tiles, moe_bm, base,
+                            false, true, st);
+                    }
+                } else {
                 int h_counts_stack[256];
                 int* h_counts = h_counts_stack;
                 // Pinned counts make the D2H sync cheaper (pageable stalls the GPU).
@@ -623,13 +689,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 pf_cu(cudaMemcpyAsync(h_counts, mcounts, (size_t)E * sizeof(int),
                                       cudaMemcpyDeviceToHost, st), "moe counts D2H");
                 pf_cu(cudaStreamSynchronize(st), "moe serial sync");
-                // Zero routed output while the host builds group tilemaps (overlap).
-                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st),
-                      "routed zero");
-                const size_t g_rb = q_row_bytes(w.gate_qtype, H);
-                const size_t u_rb = q_row_bytes(w.up_qtype, H);
-                const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
-                const int G = moe_group;
 
                 struct ActiveGroup {
                     int base, n_in, ntm, tm_off, n_live, live_off;
@@ -912,6 +971,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     // (cross-stream waits on the decode stream permanently slow graph replay).
                     pf_cu(cudaStreamSynchronize(sa), "moe sa join");
                 }
+                }  // !moe_gpu host tilemap path
             } else {
                 // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts).
                 kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -595,7 +595,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_pfm_moe_gemm_qk(mA_i8, msx, w.up_q, w.up_qtype, pair_tok, pair_w,
                                                 moffsets, tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
                                                 true, false, st);
-                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
+                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 kernels::launch_pfm_moe_gemm_qk(h_i8, sh, w.down_q, w.down_qtype, pair_tok, pair_w,
                                                 moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
@@ -881,7 +882,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     }
                 }
 
-                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, sa);
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, sa);
+                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, sa);
 
                 for (int gi = 0; gi < n_active; gi++) {
                     const ActiveGroup& ag = active[(size_t)gi];
@@ -927,7 +929,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                        tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm,
                                                        true, false, st);
                 }
-                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
+                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
+                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
                                                    tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -246,6 +246,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         const char* e = getenv("SPARKINFER_PREFILL_MOE_FUSED");
         return e && e[0] == '1';
     }();
+    // Fused gate+up GEMM (BM=16): one A staging pass per K-tile. Default ON at short-N.
+    const bool moe_fuse_gu = [&]{
+        if (!moe || moe_bm != 16) return false;
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_FUSE_GU");
+        return !e || e[0] != '0';
+    }();
     // Expert-group L2 path: dequant G experts (~G*3 MB) then GEMM that group while hot in
     // L2. Wins at short-N (N<=512, G=32 → +5% @512); bulk is faster once tiles fill. Default
     // ON for N<=512. SPARKINFER_PREFILL_MOE_SERIAL=0/1 overrides; GROUP default 32.
@@ -589,8 +595,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_pfm_moe_gemm_qk(mA_i8, msx, w.up_q, w.up_qtype, pair_tok, pair_w,
                                                 moffsets, tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
                                                 true, false, st);
-                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
-                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 kernels::launch_pfm_moe_gemm_qk(h_i8, sh, w.down_q, w.down_qtype, pair_tok, pair_w,
                                                 moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
@@ -617,6 +622,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 pf_cu(cudaMemcpyAsync(h_counts, mcounts, (size_t)E * sizeof(int),
                                       cudaMemcpyDeviceToHost, st), "moe counts D2H");
                 pf_cu(cudaStreamSynchronize(st), "moe serial sync");
+                // Zero routed output while the host builds group tilemaps (overlap).
+                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st),
+                      "routed zero");
                 const size_t g_rb = q_row_bytes(w.gate_qtype, H);
                 const size_t u_rb = q_row_bytes(w.up_qtype, H);
                 const size_t d_rb = q_row_bytes(w.down_qtype, mffn);
@@ -627,7 +635,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     std::vector<int> tm;
                     std::vector<int> live;
                 };
-                std::vector<ActiveGroup> active;
+                static thread_local std::vector<ActiveGroup> active;
+                static thread_local std::vector<int> h_tm_all, h_nt_all, h_live_all;
+                active.clear();
                 active.reserve((size_t)((E + G - 1) / G));
                 int tm_total = 0;
                 int live_total = 0;
@@ -664,9 +674,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 }
                 const int n_active = (int)active.size();
 
-                std::vector<int> h_tm_all((size_t)2 * std::max(tm_total, 1));
-                std::vector<int> h_nt_all((size_t)std::max(n_active, 1));
-                std::vector<int> h_live_all((size_t)std::max(live_total, 1));
+                h_tm_all.resize((size_t)2 * std::max(tm_total, 1));
+                h_nt_all.resize((size_t)std::max(n_active, 1));
+                h_live_all.resize((size_t)std::max(live_total, 1));
                 for (int gi = 0; gi < n_active; gi++) {
                     const ActiveGroup& ag = active[(size_t)gi];
                     h_nt_all[(size_t)gi] = ag.ntm;
@@ -688,8 +698,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     pf_cu(cudaEventRecord(moe_ev_ready, st), "moe fork");
                     pf_cu(cudaStreamWaitEvent(sa, moe_ev_ready, 0), "moe sa wait");
                     pf_cu(cudaStreamWaitEvent(sb, moe_ev_ready, 0), "moe sb wait");
+                    pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), sa),
+                          "routed zero");
                 }
-                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), sa), "routed zero");
 
                 int* d_nt_pack = nullptr;
                 if (pack_fit && n_active > 0) {
@@ -855,19 +866,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                               cudaMemcpyHostToDevice, sa), "moe ntm H2D");
                     }
                     dq_gateup(ag);
-                    kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets, tm, nt,
-                        hg, nullptr, mffn, H, ag.ntm, moe_bm, ag.base,
-                        /*a_indirect=*/true, /*c_scatter=*/false, sa);
-                    kernels::launch_pfm_moe_gemm_i8_bm_base(
-                        mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets, tm, nt,
-                        hu, nullptr, mffn, H, ag.ntm, moe_bm, ag.base, true, false, sa);
+                    if (moe_fuse_gu) {
+                        kernels::launch_pfm_moe_gemm_i8_gate_up_bm16(
+                            mA_i8, msx, Wg_i8, swg, Wu_i8, swu, pair_tok, moffsets, tm, nt,
+                            hg, hu, mffn, H, ag.ntm, ag.base, sa);
+                    } else {
+                        kernels::launch_pfm_moe_gemm_i8_bm_base(
+                            mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets, tm, nt,
+                            hg, nullptr, mffn, H, ag.ntm, moe_bm, ag.base,
+                            /*a_indirect=*/true, /*c_scatter=*/false, sa);
+                        kernels::launch_pfm_moe_gemm_i8_bm_base(
+                            mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets, tm, nt,
+                            hu, nullptr, mffn, H, ag.ntm, moe_bm, ag.base, true, false, sa);
+                    }
                 }
 
-                // down0∥SwiGLU disabled: full-group down dequant on a side stream exceeds the
-                // ~4KB/op decode-poison threshold.
-                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, sa);
-                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, sa);
+                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, sa);
 
                 for (int gi = 0; gi < n_active; gi++) {
                     const ActiveGroup& ag = active[(size_t)gi];
@@ -901,14 +915,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
                 kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   w.up_q,   Wu_i8, swu, E * mffn, H, st);
                 kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
-                kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets,
-                                                   tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles, moe_bm,
-                                                   /*a_indirect=*/true, /*c_scatter=*/false, st);
-                kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets,
-                                                   tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm,
-                                                   true, false, st);
-                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
-                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                if (moe_fuse_gu) {
+                    kernels::launch_pfm_moe_gemm_i8_gate_up_bm16(
+                        mA_i8, msx, Wg_i8, swg, Wu_i8, swu, pair_tok, moffsets, tilemap, d_ntiles,
+                        hg, hu, mffn, H, max_tiles, /*e_base=*/0, st);
+                } else {
+                    kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets,
+                                                       tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles, moe_bm,
+                                                       /*a_indirect=*/true, /*c_scatter=*/false, st);
+                    kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets,
+                                                       tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm,
+                                                       true, false, st);
+                }
+                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
                                                    tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,


### PR DESCRIPTION
## Summary

Eliminate the per-layer MoE D2H expert-count sync on short-N prefill (N≤512) by wiring device-side group tilemaps and counts-mask dequant, plus a cp.async double-buffered fused gate+up BM=16 GEMM. ~+30% end-to-end prefill pp @512 on RTX 5090 with flat decode.


- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 502.6 |
| after (this PR) | 503.5 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 5010 |
| after prefill (this PR) | 6550 |

```text
# Qwen3.6-35B-A3B-UD-Q4_K_M, SPARKINFER_KV_INT8=1, ctx=512, n=128
# build/runtime/qwen3_gguf_bench <gguf> 128 512

=== before (main, host tilemap path) ===
decode tg    : 502.64 tok/s  (2.0 ms/token, n=128, ctx=512, bs=1)
prefill pp   : 5010.4 tok/s  (ctx=512, sequential KV fill)

=== after (this PR, GPU tilemap default) ===
decode tg    : 503.52 tok/s  (2.0 ms/token, n=128, ctx=512, bs=1)
prefill pp   : 6549.3 tok/s  (ctx=512, sequential KV fill)
```

<!-- More checklist items will be added here later. -->