### PR TITLE
perf(qwen36): tensor-core router logits + warp top-k + bit-identical GDN scan pipelining (+18% pp @32k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -59,6 +59,7 @@
 
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
+#include <cuda_pipeline.h>
 #include <mma.h>
 
 #include <cstdio>
@@ -205,12 +206,35 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
     }
 
     // ---- W^ = T . (b_m exp(G_m) k_m) ----
-    for (int e = tid; e < C * HD; e += nthr) {
-        const int i = e / HD, d = e - i * HD;
-        float acc = 0.f;
-        for (int m = 0; m <= i; m++)
-            acc += s_A[i * (C + PAD) + m] * (s_b[m] * __expf(s_g[m]) * gc_to_f(s_k[m * (HD + PAD) + d]));
-        w_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] = __float2bfloat16(acc);
+    // m-outermost per-thread form. Each thread owns one column d and the rows
+    // i = tid/HD + 2s, so b_m exp(G_m) k[m][d] is formed ONCE per m instead of once per
+    // (i, m) -- the reference recomputed it (expf included, ~68K expf per block) for
+    // every element. s_A[i][m] and the hoisted gate product are warp-uniform broadcasts.
+    // Every acc_i still receives exactly the same products in the same ascending-m order,
+    // so the result is bit-identical to the reference loop.
+    for (int m = tid; m < C; m += nthr) s_t[m] = s_b[m] * __expf(s_g[m]);
+    __syncthreads();
+    {
+        constexpr int NTHR = 256;                 // launcher blockDim (static_asserted there)
+        constexpr int IPT = (C * HD) / NTHR;      // rows per thread
+        constexpr int ISTR = NTHR / HD;           // row stride between per-thread slots
+        const int d = tid % HD, i0 = tid / HD;
+        float acc[IPT];
+        #pragma unroll
+        for (int si = 0; si < IPT; si++) acc[si] = 0.f;
+        for (int m = 0; m < C; m++) {
+            const float bk = s_t[m] * gc_to_f(s_k[m * (HD + PAD) + d]);
+            #pragma unroll
+            for (int si = 0; si < IPT; si++) {
+                const int i = i0 + si * ISTR;
+                if (m <= i) acc[si] += s_A[i * (C + PAD) + m] * bk;
+            }
+        }
+        #pragma unroll
+        for (int si = 0; si < IPT; si++) {
+            const int i = i0 + si * ISTR;
+            w_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] = __float2bfloat16(acc[si]);
+        }
     }
     __syncthreads();
 
@@ -220,12 +244,29 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
         s_x[i * (HD + PAD) + d] = (i < len) ? v[(size_t)(t0 + i) * v_dim + h * HD + d] : __float2bfloat16(0.f);
     }
     __syncthreads();
-    for (int e = tid; e < C * HD; e += nthr) {
-        const int i = e / HD, d = e - i * HD;
-        float acc = 0.f;
-        for (int m = 0; m <= i; m++)
-            acc += s_A[i * (C + PAD) + m] * (s_b[m] * gc_to_f(s_x[m * (HD + PAD) + d]));
-        u_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] = __float2bfloat16(acc);
+    {
+        // Same m-outermost form as W^ above (b_m v[m][d] formed once per m; ascending-m
+        // order per row preserved -> bit-identical).
+        constexpr int NTHR = 256;
+        constexpr int IPT = (C * HD) / NTHR;
+        constexpr int ISTR = NTHR / HD;
+        const int d = tid % HD, i0 = tid / HD;
+        float acc[IPT];
+        #pragma unroll
+        for (int si = 0; si < IPT; si++) acc[si] = 0.f;
+        for (int m = 0; m < C; m++) {
+            const float bv = s_b[m] * gc_to_f(s_x[m * (HD + PAD) + d]);
+            #pragma unroll
+            for (int si = 0; si < IPT; si++) {
+                const int i = i0 + si * ISTR;
+                if (m <= i) acc[si] += s_A[i * (C + PAD) + m] * bv;
+            }
+        }
+        #pragma unroll
+        for (int si = 0; si < IPT; si++) {
+            const int i = i0 + si * ISTR;
+            u_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] = __float2bfloat16(acc[si]);
+        }
     }
 }
 
@@ -249,7 +290,8 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
     float* s_U = s_S + (size_t)HD * JC;                                        // [C][JC]
     float* s_M = s_U + (size_t)C * JC;                                         // [C][C+PAD]
     float* s_g = s_M + (size_t)C * (C + PAD);                                  // [C]
-    float* s_Y = s_g + C;                                                      // [C][JC]  Q S staging
+    float* s_eg = s_g + C;                                                     // [C] hoisted per-row expf
+    float* s_Y = s_eg + C;                                                     // [C][JC]  Q S staging
     __nv_bfloat16* s_W =
         reinterpret_cast<__nv_bfloat16*>(s_Y + (size_t)C * JC);                // [C][HD+PAD]
     __nv_bfloat16* s_K = s_W + (size_t)C * (HD + PAD);                         // [C][HD+PAD]
@@ -271,13 +313,37 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
     const float scale = rsqrtf((float)HD);
 
     for (int e = tid; e < HD * JC; e += nthr) s_S[e] = 0.f;    // fresh prefill: state starts at zero
-    __syncthreads();
+
+    // The chunk loop is the ONE serial stage left in this prefill, and every iteration used
+    // to expose the full global latency of its 25 KB W/K/Q staging before any math could
+    // start. Issue those loads with cp.async at the END of the previous iteration (the
+    // S-update sync is the last read of the old tiles), so they overlap the g/U/M stages
+    // and the loop-carried sync. Same buffers, same staged values, same math -- only WHEN
+    // the loads are issued changes. Tail rows of a short final chunk are zeroed after the
+    // wait (cp.async cannot predicate, and reading past n_tokens would fault).
+    auto stage_wkq = [&](int c2) {
+        const int t0s = c2 * C;
+        const int lens = min(C, n_tokens - t0s);
+        for (int e8 = tid; e8 < (C * HD) / 8; e8 += nthr) {
+            const int i = e8 / (HD / 8), d = (e8 % (HD / 8)) * 8;
+            if (i < lens) {
+                __pipeline_memcpy_async(s_W + i * (HD + PAD) + d,
+                                        w_buf + ((size_t)(t0s + i) * v_heads + h) * HD + d, 16);
+                __pipeline_memcpy_async(s_K + i * (HD + PAD) + d,
+                                        k + (size_t)(t0s + i) * q_dim + qh * HD + d, 16);
+                __pipeline_memcpy_async(s_Q + i * (HD + PAD) + d,
+                                        q + (size_t)(t0s + i) * q_dim + qh * HD + d, 16);
+            }
+        }
+        __pipeline_commit();
+    };
+    if (n_chunks > 0) stage_wkq(0);
 
     for (int c = 0; c < n_chunks; c++) {
         const int t0  = c * C;
         const int len = min(C, n_tokens - t0);
 
-        // ---- stage this chunk ----
+        // ---- stage the small linear tiles; W/K/Q arrive via the early-issued cp.async ----
         for (int i = tid; i < C; i += nthr)
             s_g[i] = (i < len) ? g_buf[(size_t)(t0 + i) * v_heads + h] : 0.f;
         for (int e = tid; e < C * JC; e += nthr) {
@@ -288,12 +354,16 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
             const int i = e / C, j = e - i * C;
             s_M[i * (C + PAD) + j] = m_buf[(size_t)e + ((size_t)c * v_heads + h) * C * C];
         }
-        for (int e = tid; e < C * HD; e += nthr) {
-            const int i = e / HD, d = e - i * HD;
-            const bool live = i < len;
-            s_W[i * (HD + PAD) + d] = live ? w_buf[((size_t)(t0 + i) * v_heads + h) * HD + d] : __float2bfloat16(0.f);
-            s_K[i * (HD + PAD) + d] = live ? k[(size_t)(t0 + i) * q_dim + qh * HD + d] : __float2bfloat16(0.f);
-            s_Q[i * (HD + PAD) + d] = live ? q[(size_t)(t0 + i) * q_dim + qh * HD + d] : __float2bfloat16(0.f);
+        __pipeline_wait_prior(0);
+        if (len < C) {
+            for (int e = tid; e < C * HD; e += nthr) {
+                const int i = e / HD, d = e - i * HD;
+                if (i >= len) {
+                    s_W[i * (HD + PAD) + d] = __float2bfloat16(0.f);
+                    s_K[i * (HD + PAD) + d] = __float2bfloat16(0.f);
+                    s_Q[i * (HD + PAD) + d] = __float2bfloat16(0.f);
+                }
+            }
         }
         __syncthreads();
 
@@ -341,21 +411,47 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         __syncthreads();
 
         // ---- Y = [diag(exp G) Y0 + M U^] * scale ----
-        for (int e = tid; e < C * JC; e += nthr) {
-            const int i = e / JC, jj = e - i * JC;
-            if (t0 + i >= n_tokens) continue;
-            float mu = 0.f;
-            for (int p = 0; p <= i; p++) mu += s_M[i * (C + PAD) + p] * s_U[p * JC + jj];
-            const float y = (__expf(s_g[i]) * s_Y[e] + mu) * scale;
-            out[(size_t)(t0 + i) * v_dim + h * HD + j0 + jj] = __float2bfloat16(y);
+        // p-outermost per-thread form (each thread: one column jj, rows i = tid/JC + 8s):
+        // s_U[p][jj] is read once per p, s_M[i][p] and the hoisted exp(G_i) are warp-
+        // uniform broadcasts, and each output still sums its p-terms in ascending order --
+        // bit-identical to the reference element loop.
+        for (int i = tid; i < C; i += nthr) s_eg[i] = __expf(s_g[i]);
+        __syncthreads();
+        {
+            constexpr int NTHR2 = 256;
+            constexpr int OPT = (C * JC) / NTHR2;
+            constexpr int ISTR2 = NTHR2 / JC;
+            const int jj = tid % JC, i0 = tid / JC;
+            float mu[OPT];
+            #pragma unroll
+            for (int si = 0; si < OPT; si++) mu[si] = 0.f;
+            for (int pp = 0; pp < C; pp++) {
+                const float u = s_U[pp * JC + jj];
+                #pragma unroll
+                for (int si = 0; si < OPT; si++) {
+                    const int i = i0 + si * ISTR2;
+                    if (pp <= i) mu[si] += s_M[i * (C + PAD) + pp] * u;
+                }
+            }
+            #pragma unroll
+            for (int si = 0; si < OPT; si++) {
+                const int i = i0 + si * ISTR2;
+                if (t0 + i >= n_tokens) continue;
+                const float y = (s_eg[i] * s_Y[i * JC + jj] + mu[si]) * scale;
+                out[(size_t)(t0 + i) * v_dim + h * HD + j0 + jj] = __float2bfloat16(y);
+            }
         }
         __syncthreads();
 
         // ---- U~[p] = exp(G_last - G_p) U^[p]  (tail rows already carry U^ = 0) ----
+        // exp(G_last - G_i) is a per-ROW value: computed once per row instead of per
+        // element (same inputs, same op, same downstream multiply -> bit-identical).
         const float g_last = s_g[C - 1];               // == s_g[len-1]: tail log-gates are 0
+        for (int i = tid; i < C; i += nthr) s_eg[i] = __expf(g_last - s_g[i]);
+        __syncthreads();
         for (int e = tid; e < C * JC; e += nthr) {
             const int i = e / JC;
-            s_U[e] *= __expf(g_last - s_g[i]);
+            s_U[e] *= s_eg[i];
         }
         __syncthreads();
 
@@ -396,6 +492,7 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
             }
         }
         __syncthreads();
+        if (c + 1 < n_chunks) stage_wkq(c + 1);   // last read of W/K/Q was above this sync
     }
 
     // ---- final state, in the transposed [v_head][col][row] layout decode expects ----
@@ -473,7 +570,7 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
     const size_t sm_scan = (size_t)HD * JC * sizeof(float)          // s_S (fp32 carrier)
                          + (size_t)C * JC * sizeof(float)            // s_U
                          + (size_t)C * (C + PAD) * sizeof(float)     // s_M
-                         + (size_t)C * sizeof(float)                 // s_g
+                         + (size_t)2 * C * sizeof(float)             // s_g, s_eg
                          + (size_t)C * JC * sizeof(float)            // s_Y
                          + (size_t)3 * C * (HD + PAD) * sizeof(__nv_bfloat16)   // s_W, s_K, s_Q
                          + (size_t)HD * (JC + PAD) * sizeof(__nv_bfloat16)      // s_Sb

--- a/kernels/csrc/cuda/fused/prefill_router_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_router_mma.cu
@@ -1,0 +1,178 @@
+// ============================================================================
+// Tensor-core router-logits GEMM for the Qwen3.6 MoE batched prefill.
+//
+// WHY THIS EXISTS
+// ---------------
+// Every MoE layer of the batched prefill computes router logits [N, E] from the
+// normed hidden states [N, H] and the router weight [E, H] with a warp-per-
+// (token, expert) fp32 dot (pfm_router_logits_kernel). That shape does no
+// operand reuse at all: each warp re-reads one full x row and one full W row per
+// output element. Measured on an RTX 5090 (nsys --cuda-graph-trace=node,
+// ctx=32768, Qwen3.6-35B-A3B): 194.9 ms per prefill across 40 layers — 4.9 ms
+// per layer for N*H*E = 17.2 GMAC, i.e. ~7 TFLOP/s against a >200 TFLOP/s bf16
+// tensor peak, and 10-13% of the whole prefill wall at 4k-32k. The router is a
+// plain [N,H] x [H,E] GEMM; this file runs it on the bf16 tensor cores.
+//
+// NUMERICS
+// --------
+// Inputs are the SAME bf16 values the reference dot reads (x rows and the
+// dequantized router weight), and accumulation is fp32 in both paths. A bf16
+// product is exact in fp32 (8-bit mantissas), so each multiply contributes the
+// identical value in either kernel; the ONLY difference is the order the fp32
+// partial sums are reduced in (lane-strided + shuffle tree there, 16-wide wmma
+// k-groups here). The logits agree to fp32 rounding of a 2048-term sum
+// (|Δ| ~ 1e-6 relative); top-k selection can differ only where two experts'
+// logits tie to that precision. Batched-vs-token fidelity is quantified in the
+// PR with qwen3_gguf_prefill_check; the decode/scoring path never calls this
+// kernel (it uses the fused decode router), so gate accuracy is untouched.
+//
+// SHAPE
+// -----
+// One block owns a 64-token x 128-expert C tile: 8 warps in a 2x4 grid, each
+// warp a 32x32 quadrant held in four fp32 accumulator fragments. K is streamed
+// in 32-wide slices through a cp.async double buffer, so global loads overlap
+// the mma work. E and H are tile-aligned for this model (256, 2048); N is
+// masked in the tail block. Occupancy is 3 blocks/SM (vs 1 for the big bf16
+// projection GEMM) and the grid at 32k is 512x2 = 1024 blocks on 170 SMs.
+// ============================================================================
+#include "sparkinfer/kernels/prefill_router_mma.h"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_pipeline.h>
+#include <mma.h>
+
+#include <cstdlib>
+
+namespace sparkinfer {
+namespace kernels {
+namespace {
+
+constexpr int RT_BM = 64;    // tokens per block
+constexpr int RT_BN = 128;   // experts per block
+constexpr int RT_BK = 32;    // K slice per stage
+constexpr int RT_LD = RT_BK + 8;   // smem row stride (elements): breaks bank conflicts, 16B-aligned
+
+__global__ __launch_bounds__(256) void pfr_logits_mma_kernel(
+    const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ W,
+    float* __restrict__ logits, int n_tokens, int n_experts, int H) {
+    using namespace nvcuda::wmma;
+
+    __shared__ __nv_bfloat16 s_a[2][RT_BM][RT_LD];
+    __shared__ __nv_bfloat16 s_b[2][RT_BN][RT_LD];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5, lane = tid & 31;
+    const int row0 = blockIdx.x * RT_BM;     // first token of this block
+    const int col0 = blockIdx.y * RT_BN;     // first expert of this block
+    const bool tail = row0 + RT_BM > n_tokens;
+
+    // warp (wr, wc) owns rows [wr*32, +32) x cols [wc*32, +32) of the C tile
+    const int wr = warp >> 2, wc = warp & 3;
+
+    fragment<accumulator, 16, 16, 16, float> acc[2][2];
+    #pragma unroll
+    for (int i = 0; i < 2; i++)
+        #pragma unroll
+        for (int j = 0; j < 2; j++) fill_fragment(acc[i][j], 0.f);
+
+    // ---- stage one K slice: A rows via cp.async (8 bf16 = 16B per copy) ----
+    // 64 rows x 32 cols = 256 copies for A (1/thread), 128 x 32 = 512 for B (2/thread).
+    auto stage = [&](int kb, int buf) {
+        {
+            const int r = tid >> 2, c4 = (tid & 3) << 3;          // 4 copies cover a row
+            const int gr = row0 + r;
+            if (!tail || gr < n_tokens) {
+                __pipeline_memcpy_async(&s_a[buf][r][c4],
+                                        x + (size_t)gr * H + kb + c4, 16);
+            } else {
+                *reinterpret_cast<float4*>(&s_a[buf][r][c4]) = float4{0.f, 0.f, 0.f, 0.f};
+            }
+        }
+        #pragma unroll
+        for (int rep = 0; rep < 2; rep++) {
+            const int e = (tid >> 2) + (rep << 6), c4 = (tid & 3) << 3;
+            __pipeline_memcpy_async(&s_b[buf][e][c4],
+                                    W + (size_t)(col0 + e) * H + kb + c4, 16);
+        }
+        __pipeline_commit();
+    };
+
+    stage(0, 0);
+    for (int kb = 0, p = 0; kb < H; kb += RT_BK, p ^= 1) {
+        __pipeline_wait_prior(0);
+        __syncthreads();
+        if (kb + RT_BK < H) stage(kb + RT_BK, p ^ 1);
+
+        #pragma unroll
+        for (int kt = 0; kt < RT_BK; kt += 16) {
+            fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af[2];
+            fragment<matrix_b, 16, 16, 16, __nv_bfloat16, col_major> bf[2];
+            #pragma unroll
+            for (int i = 0; i < 2; i++)
+                load_matrix_sync(af[i], &s_a[p][wr * 32 + i * 16][kt], RT_LD);
+            // col_major over the row-major W tile reads W^T -- [K, E] as mma wants it
+            #pragma unroll
+            for (int j = 0; j < 2; j++)
+                load_matrix_sync(bf[j], &s_b[p][wc * 32 + j * 16][kt], RT_LD);
+            #pragma unroll
+            for (int i = 0; i < 2; i++)
+                #pragma unroll
+                for (int j = 0; j < 2; j++) mma_sync(acc[i][j], af[i], bf[j], acc[i][j]);
+        }
+        __syncthreads();
+    }
+
+    // ---- store: fp32 accumulators straight to the fp32 logits ----
+    if (!tail) {
+        #pragma unroll
+        for (int i = 0; i < 2; i++)
+            #pragma unroll
+            for (int j = 0; j < 2; j++)
+                store_matrix_sync(logits + (size_t)(row0 + wr * 32 + i * 16) * n_experts
+                                         + col0 + wc * 32 + j * 16,
+                                  acc[i][j], n_experts, mem_row_major);
+    } else {
+        // tail block: bounce each fragment through smem and write row-guarded
+        float* s_t = reinterpret_cast<float*>(&s_a[0][0][0]) + warp * 256;
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            #pragma unroll
+            for (int j = 0; j < 2; j++) {
+                store_matrix_sync(s_t, acc[i][j], 16, mem_row_major);
+                __syncwarp();
+                const int gr0 = row0 + wr * 32 + i * 16;
+                for (int e = lane; e < 256; e += 32) {
+                    const int r = e >> 4, c = e & 15;
+                    if (gr0 + r < n_tokens)
+                        logits[(size_t)(gr0 + r) * n_experts + col0 + wc * 32 + j * 16 + c] =
+                            s_t[r * 16 + c];
+                }
+                __syncwarp();
+            }
+        }
+    }
+}
+
+}  // namespace
+
+bool launch_pfm_router_logits_mma(const void* x, const void* W, float* logits,
+                                  int n_tokens, int n_experts, int H,
+                                  cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ROUTER_MMA");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    // Tile-alignment guards (Qwen3.6: E=256, H=2048). Small N stays on the warp
+    // dot -- below ~2 row tiles the GEMV's launch is cheaper than the GEMM's.
+    if (!enabled || n_experts % RT_BN != 0 || H % RT_BK != 0 || n_tokens < 128)
+        return false;
+    dim3 grid((n_tokens + RT_BM - 1) / RT_BM, n_experts / RT_BN);
+    pfr_logits_mma_kernel<<<grid, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(W), logits, n_tokens, n_experts, H);
+    return true;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/csrc/cuda/moe/router.cu
+++ b/kernels/csrc/cuda/moe/router.cu
@@ -267,6 +267,29 @@ __global__ void moe_router_fused_kernel(
 }
 #undef SI_CEXG
 
+// Batched warp-per-token top-k for the prefill router. One warp per token, 8 tokens per
+// block, each warp staging its 256 logits and running the SAME si_warp_bitonic_top8 the
+// fused decode router uses -- selection, output order and softmax weights are byte-
+// identical to moe_router_kernel2 (identical descending order + lower-index tie-break,
+// identical mx / ascending-denom op sequence; counts are order-free integer atomics).
+// Replaces kernel2's two serial 256-iteration rank scans per thread with ~40 warp steps.
+__global__ void moe_router_topk_warp_kernel(
+    const float* __restrict__ logits, int* __restrict__ expert_ids,
+    float* __restrict__ expert_weights, int* __restrict__ tokens_per_expert,
+    int num_tokens, int top_k, int normalize)
+{
+    __shared__ float s_lg[8][256];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int tok = blockIdx.x * 8 + warp;
+    if (tok >= num_tokens) return;
+    const float* rowp = logits + (size_t)tok * 256;
+    for (int e = lane; e < 256; e += 32) s_lg[warp][e] = rowp[e];
+    __syncwarp();
+    si_warp_bitonic_top8(s_lg[warp], lane, top_k, normalize,
+                         expert_ids + (size_t)tok * top_k,
+                         expert_weights + (size_t)tok * top_k, tokens_per_expert);
+}
+
 
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 void launch_moe_router(
@@ -280,6 +303,17 @@ void launch_moe_router(
     // restores the k-pass single-warp kernel. Falls back automatically if num_experts > 1024.
     static int r2 = -1;
     if (r2 < 0) { const char* e = getenv("SPARKINFER_ROUTER2"); r2 = (e && e[0] == '0') ? 0 : 1; }
+    // Batched prefill path: warp-per-token bitonic top-8 (byte-identical output to
+    // kernel2 -- see moe_router_topk_warp_kernel). num_experts==256 is what the warp
+    // staging assumes; decode (num_tokens==1) keeps its existing kernels.
+    static int tw = -1;
+    if (tw < 0) { const char* e = getenv("SPARKINFER_PREFILL_TOPK_WARP"); tw = (e && e[0] == '0') ? 0 : 1; }
+    if (tw && num_tokens >= 64 && num_experts == 256 && top_k <= 8) {
+        moe_router_topk_warp_kernel<<<(num_tokens + 7) / 8, 256, 0, stream>>>(
+            logits, expert_ids, expert_weights, tokens_per_expert,
+            num_tokens, top_k, normalize);
+        return;
+    }
     if (r2 && top_k <= 16 && num_experts <= 1024) {
         const int bd = ((num_experts + 31) / 32) * 32;     // round up to a warp multiple
         moe_router_kernel2<<<num_tokens, bd, smem, stream>>>(

--- a/kernels/include/sparkinfer/kernels/prefill_router_mma.h
+++ b/kernels/include/sparkinfer/kernels/prefill_router_mma.h
@@ -1,0 +1,20 @@
+#pragma once
+// Tensor-core (bf16 wmma, fp32 accumulate) router-logits GEMM for the Qwen3.6
+// MoE batched prefill: logits[N,E] = x[N,H] . W[E,H]^T. Same bf16 inputs and
+// fp32 accumulation as the warp-dot reference in prefill_moe.cu -- only the
+// fp32 summation order differs. See prefill_router_mma.cu for the rationale
+// and measured numbers.
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Returns false (caller falls back to launch_pfm_router_logits) when disabled
+// via SPARKINFER_PREFILL_ROUTER_MMA=0 or the shape is not tile-aligned
+// (E % 128, H % 32, or N < 128).
+bool launch_pfm_router_logits_mma(const void* x, const void* W, float* logits,
+                                  int n_tokens, int n_experts, int H,
+                                  cudaStream_t stream);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -19,6 +19,7 @@
 #include "sparkinfer/kernels/prefill_i8.h"
 #include "sparkinfer/kernels/prefill_fp8.h"
 #include "sparkinfer/kernels/prefill_moe.h"
+#include "sparkinfer/kernels/prefill_router_mma.h"
 #include "sparkinfer/kernels/moe.h"
 
 #include <cuda_runtime.h>
@@ -611,7 +612,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // MoE weight re-read that pinned the token loop). Router logits use the decode-reference
             // gemv_f32-order dot; the router weight may itself be quantized in the UD GGUF. ----
             const void* rw = w.router_w_type ? dq(w.router_w, w.router_w_type, E, H) : w.router_w;
-            kernels::launch_pfm_router_logits(hn, rw, mlogits, N, E, H, st);
+            // Router logits on the bf16 tensor cores (same inputs, fp32 accumulate; only the
+            // fp32 summation order differs from the warp-dot -- see prefill_router_mma.cu).
+            // Falls back to the reference dot when disabled or the shape is not tile-aligned.
+            if (!kernels::launch_pfm_router_logits_mma(hn, rw, mlogits, N, E, H, st))
+                kernels::launch_pfm_router_logits(hn, rw, mlogits, N, E, H, st);
             pf_cu(cudaMemsetAsync(mcounts, 0, E * sizeof(int), st), "moe counts zero");
             kernels::launch_moe_router(mlogits, mids, mweights, mcounts, N, E, topk, 1, st);
             kernels::launch_pfm_bucket_pairs_bm(mids, mweights, mcounts, moffsets, mcursors,
@@ -626,8 +631,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_pfm_moe_gemm_qk(mA_i8, msx, w.up_q, w.up_qtype, pair_tok, pair_w,
                                                 moffsets, tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
                                                 true, false, st);
-                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
-                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 kernels::launch_pfm_moe_gemm_qk(h_i8, sh, w.down_q, w.down_qtype, pair_tok, pair_w,
                                                 moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
@@ -687,8 +691,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                 true, false, st);
                         }
                     }
-                    kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
-                    kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                    kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
                     for (int base = 0; base < E; base += G) {
                         const int n_in = (E - base < G) ? (E - base) : G;
                         kernels::launch_pfm_group_tilemap(
@@ -966,8 +969,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     }
                 }
 
-                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, sa);
-                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, sa);
+                // Fused SwiGLU+quant (numerically identical pair replacement): drops the
+                // P x mffn bf16 intermediate store + reload.
+                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, sa);
 
                 for (int gi = 0; gi < n_active; gi++) {
                     const ActiveGroup& ag = active[(size_t)gi];
@@ -1014,8 +1018,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                        tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm,
                                                        true, false, st);
                 }
-                kernels::launch_prefill_swiglu(hg, hu, hh, (long)P * mffn, st);
-                kernels::launch_prefill_quantize_rows_i8(hh, h_i8, sh, P, mffn, st);
+                kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
                 kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
                                                    tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,


### PR DESCRIPTION
## Summary

Four independent, individually-gated optimizations for the Qwen3.6 MoE batched prefill, all outside the projection/MoE-GEMM lanes the other open PRs are working:

1. **Router logits on the bf16 tensor cores** (`prefill_router_mma.cu`, new file). Every MoE layer computes router logits `[N, 256]` with a warp-per-(token, expert) fp32 dot that does no operand reuse: measured 194.9 ms per 32k prefill = ~7 TFLOP/s against a >200 TFLOP/s bf16 tensor peak, 10–13% of the whole prefill wall at 4k–32k. It is a plain `[N,H] x [H,E]` GEMM; the new kernel runs it as one (64x128 C-tile, 8 warps, cp.async double-buffered K slices, 2 blocks/SM, fp32 accumulate straight to the fp32 logits). Inputs are the same bf16 values the reference dot reads and a bf16 product is exact in fp32, so **only the fp32 summation order differs** — quantified below with `qwen3_gguf_prefill_check`. 194.9 → 12.6 ms. `SPARKINFER_PREFILL_ROUTER_MMA=0` restores the warp dot.

2. **Warp-per-token batched top-k** (`router.cu`). `moe_router_kernel2` runs one block per token and rank-counts with two serial 256-iteration smem scans per thread — fine for decode (1 token), but ~2.5% of DRAM roofline at prefill N (30 ms per 32k prefill). The new path stages 8 tokens per block and runs the SAME `si_warp_bitonic_top8` the fused decode router already uses: selection, output order and softmax weights are **byte-identical** to `moe_router_kernel2` (identical descending sort + lower-index tie-break, identical mx/ascending-denom op sequence). Decode (num_tokens==1) keeps its existing kernels. `SPARKINFER_PREFILL_TOPK_WARP=0` restores kernel2.

3. **GDN chunk-scan restructures** (`prefill_gdn_chunk.cu`) — all **bit-identical**, verified end-to-end below:
   - The scan's serial chunk loop exposed the full global-load latency of its 25 KB W/K/Q staging every iteration; the tiles are now issued with `cp.async` at the end of the previous iteration (after their last read), overlapping the loop-carried sync and small stages. Same buffers, same staged values, same math — only *when* the loads are issued changes.
   - The prep kernel's `W^ = T·(b_m e^{G_m} k_m)` / `U0 = T·(b_m v_m)` element loops recomputed the gate product — `expf` included, ~68K expf per block — for every (i, m) pair. m-outermost per-thread form: the product is formed once per m, `s_A[i][m]` becomes a warp-uniform broadcast, and every output row still sums its m-terms in the same ascending order.
   - Same p-outermost form for the scan's `M·U^` pass, and per-row `expf` hoisted out of the Y/U~ element loops.
   - Scan: 250.4 → 161.5 ms per 32k prefill; prep: 72.0 → 65.1 ms. The same kernels serve the Qwythos GDN layers, so **Qwen3.5 prefill gains ~+4–4.9% at every scored context as a side effect** (table below). `SPARKINFER_PREFILL_GDN_CHUNK=0` still disables the chunk path entirely.

4. **Fused SwiGLU+quant on the routed-expert path** (`qwen35_prefill.cpp`). The routed h path still ran the standalone `launch_prefill_swiglu` + `launch_prefill_quantize_rows_i8` pair; the merged fused kernel (#573, "numerically identical to launch_prefill_swiglu followed by launch_prefill_quantize_rows_i8") replaces the pair at all three MoE call sites, dropping the P x mffn bf16 intermediate store + reload per layer.

Decode is untouched at every context (all changed code is prefill-only; the decode router keeps its fused kernel). No new VRAM: no weight caches, no new workspaces (the scan reuses its existing buffers; +256 B of smem for the hoisted expf row).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (Qwen3.6-35B-A3B UD-Q4_K_M, eval sweep `SPARKINFER_BENCH_SWEEP`, REPS=1, interleaved main<->PR, median of 3, main @c2d0926; best context = 32768):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 16429.4 |
| after prefill (this PR) | 19432.9 |

```text
# Qwen3.6-35B-A3B (UD-Q4_K_M), RTX 5090, one model load per sweep, ctxs 0,512,4k,16k,32k
                prefill pp tok/s               decode tok/s
ctx        main      this PR      gain       main   this PR
 512     4955.4      5105.6     +3.0%      492.6     491.1
4096    12923.5     14620.6    +13.1%      473.7     473.4
16384   16013.6     18779.2    +17.3%      454.1     455.3
32768   16429.4     19432.9    +18.3%      426.9     426.8
ctx0 (decode-only): main 499.0, PR 499.6
```

**Qwen3.5 / Qwythos side** (same GDN chunk kernels; everything else in this PR is MoE-gated). Same methodology, ctxs 4k/32k/64k/128k:

```text
                prefill pp tok/s               decode tok/s
ctx        main      this PR      gain       main   this PR
4096    23188.0     24324.8     +4.9%      290.8     290.9
32768   23535.4     24502.8     +4.1%      289.3     289.3
65536   23350.3     24281.2     +4.0%      289.3     289.3
131072  22834.3     23674.0     +3.7%      288.5     288.4
```

All eight scored prefill contexts improve on both models; decode is inside noise everywhere (including the 128k Qwythos no-regression guard, which gains +3.7%).

## Correctness

- **Qwen3.5 (exercises the GDN restructures alone): byte-identical.** `qwen3_gguf_prefill_check 8320 64` output is deterministic on this model and **identical to the digit** between main and this PR (TOP1, KL, per-position logits) — the bit-identity argument for every GDN change, verified end-to-end.
- **Qwen3.6 batched-vs-token fidelity** (`qwen3_gguf_prefill_check`, 64 tail positions; this model's down-scatter uses float atomicAdd, so main itself varies run to run — 3 reps each):

```text
prefix    main (3 reps)                    this PR (3 reps)
4096      top1 56/62/60 of 64              top1 58/57/58 of 64
          KL .00539/.00513/.00537          KL .00560/.00491/.00509
8320      top1 55/56/53 of 64              top1 50/56/50 of 64
          KL .01275/.01341/.01015          KL .01458/.01282/.01538
32768     top1 64/64                       top1 64/64
          KL .09630                        KL .09611
```

At 4096 and 32768 the PR sits inside main's own band (at 32768 both are 64/64 and the PR's KL is marginally lower). At 8320 the bands overlap (both contain 56/64) with a mean KL excess of ~+0.002 -- for scale, a fifth of the +0.010 excess #573's accepted fp8 tables carry at the same prefix: the only numerics change on this model is the router GEMM's fp32 summation order (bf16 products are exact in fp32 in both paths), which can flip expert selection only where two experts' logits tie to ~1e-6 relative. The accuracy-gate/scoring path (`qwen3_gguf_score`) teacher-forces through the decode path and never calls these kernels — decode numerics are byte-unchanged.

- `ctest`: 100% tests passed (9/9).

## Relation to open PRs

Orthogonal to the whole open Qwen3.6 pool: #582 (fp8 attn/GDN projections — this PR does not touch `proj()` or the projection GEMMs), #581 (bf16 projection GEMM occupancy), #574/#572/#578 (routed-expert GEMM/dequant — untouched here; only the SwiGLU+quant epilogue call sites change, to main's own #573 kernel), #555 (bf16 projection weight cache). No shared kernels or hunks with any of them.

Composition measured, not assumed: applying this diff onto #582's head (clean apply, disjoint hunks) and sweeping the same way gives 5741 / 19082 / 25551 / 26368 pp at 512/4k/16k/32k vs 5575 / 16299 / 20769 / 21222 for #582 alone — the marginal gain grows to +17.1% @4k / +23.0% @16k / +24.2% @32k on that base, because the milliseconds this PR removes are a larger share of the smaller wall. The two PRs compose in either merge order.