### PR TITLE
feat(eval): tier prefill by TTFT reduction vs main

### DIFF
--- a/bench/scripts/README.md
+++ b/bench/scripts/README.md
@@ -92,6 +92,9 @@ build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...>   # compare argmax +
 ## Automatic PR evaluation
 
 `evaluate.sh` grades one submission (build → correctness → 128/512/4k/16k/32k speed → `label.py`).
+Prefill `eval-prefill:{tier}` is sized by **TTFT reduction %** vs same-box main at the winning
+context (`TTFT ≈ ctx / pp_tps`; `SPARKINFER_LABEL_LOWER_IS_BETTER=1`), not raw pp %-over-frontier.
+Dashboards still get `prefill_tps` / `prefill_frontier_tps` as pp tok/s.
 `evaluate_dual.sh` wraps it for **dual-model scoring**: it builds once, then scores **Qwen3.6-35B-A3B**
 (the primary target, 128/512/4k for now) and guards **Qwen3-30B-A3B** against regression (full sweep +
 accuracy) — any Qwen3 speed drop <98% of its main or broken llama.cpp parity REJECTs the submission.

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -735,21 +735,44 @@ PY
   echo "$DECODE_LINE"
   exit 0
 fi
-PREFILL_LINE="$(SPARKINFER_DIFFICULTY_REF="$(python3 - <<PY
+PREFILL_LINE="$(python3 - <<PY
+# Derive TTFT from selected prefill pp (TTFT ≈ ctx / pp_tps) and tier by TTFT reduction vs main.
 # llama-batched pp refs (~11k) are not comparable to sparkinfer sequential pp (~300) or
 # batched sparkinfer pp (~4k-6k) vs same-box main — tier on frontier when DIFF_REF<=0.
-tps=float("${PREFILL_SELECTED_TPS:-0}")
-llama=float("${PREFILL_SELECTED_LLAMA_REF:-0}")
-frontier=float("${PREFILL_SELECTED_FRONTIER:-0}")
-use_frontier = tps <= 0 or llama <= 0 or llama >= tps * 50
-if not use_frontier and frontier > 0 and llama >= 2 * frontier:
+import json, os, subprocess
+tps = float("${PREFILL_SELECTED_TPS:-0}")
+llama_pp = float("${PREFILL_SELECTED_LLAMA_REF:-0}")
+frontier = float("${PREFILL_SELECTED_FRONTIER:-0}")
+ctx = float("${PREFILL_SELECTED_CTX:-0}")
+use_frontier = tps <= 0 or llama_pp <= 0 or llama_pp >= tps * 50
+if not use_frontier and frontier > 0 and llama_pp >= 2 * frontier:
     use_frontier = True
 if not use_frontier and frontier > 0 and tps >= 1000:
     use_frontier = True  # batched sparkinfer pp — tier on same-box main, not llama anchor
-print(0 if use_frontier else llama)
+ttft = ctx / tps if tps > 0 and ctx > 0 else 0.0
+frontier_ttft = ctx / frontier if frontier > 0 and ctx > 0 else 0.0
+llama_ttft = 0.0 if use_frontier or llama_pp <= 0 or ctx <= 0 else ctx / llama_pp
+env = os.environ.copy()
+env["SPARKINFER_LABEL_LOWER_IS_BETTER"] = "1"
+env["SPARKINFER_DIFFICULTY_REF"] = str(llama_ttft)
+env["SPARKINFER_DIFFICULTY_BOOST"] = os.environ.get("SPARKINFER_DIFFICULTY_BOOST", "1")
+# ceiling unused for latency (pass 0)
+cmd = ["python3", "${HERE}/label.py", str(ttft), str(frontier_ttft), "0",
+       "${TOP1}", "${KL}", "${COMMIT}", "{}"]
+out = subprocess.check_output(cmd, env=env, text=True).strip()
+# Rewrite display fields: keep label/pct from TTFT path; expose pp tok/s for dashboards.
+if out.startswith("RESULT_JSON "):
+    pf = json.loads(out[len("RESULT_JSON "):])
+    pf["prefill_ttft_s"] = round(ttft, 6)
+    pf["prefill_frontier_ttft_s"] = round(frontier_ttft, 6)
+    pf["tps"] = round(tps, 2)
+    pf["frontier_tps"] = round(frontier, 2)
+    pf["delta_tps"] = round(tps - frontier, 2) if frontier > 0 else None
+    # pct_over_frontier / effective_pct / speed_label stay TTFT-reduction based
+    out = "RESULT_JSON " + json.dumps(pf)
+print(out)
 PY
-)" SPARKINFER_DIFFICULTY_BOOST="${SPARKINFER_DIFFICULTY_BOOST:-1}" \
-  python3 "$HERE/label.py" "$PREFILL_SELECTED_TPS" "$PREFILL_SELECTED_FRONTIER" "$CEILING" "$TOP1" "$KL" "$COMMIT" "{}")"
+)"
 DECODE_LINE="$DECODE_LINE" PREFILL_LINE="$PREFILL_LINE" python3 - <<'PY'
 import json, os
 
@@ -765,6 +788,10 @@ def copy_scoring_fields(dst, src):
             dst[key] = src[key]
     if src.get("difficulty_mult") is not None:
         dst["difficulty_mult"] = src["difficulty_mult"]
+    if src.get("prefill_ttft_s") is not None:
+        dst["prefill_ttft_s"] = src["prefill_ttft_s"]
+    if src.get("prefill_frontier_ttft_s") is not None:
+        dst["prefill_frontier_ttft_s"] = src["prefill_frontier_ttft_s"]
 
 decode_line = os.environ.get("DECODE_LINE", "").strip()
 prefill_raw = os.environ.get("PREFILL_LINE", "").strip()
@@ -780,9 +807,13 @@ if prefill_raw.startswith("RESULT_JSON "):
     # but real prefill gains still get annotated (eval-prefill:XL).
     res["prefill_label"] = pf.get("speed_label") or pf.get("label")
     res["prefill_delta_tps"] = pf.get("delta_tps")
-    res["prefill_pct_over_frontier"] = pf.get("pct_over_frontier")
+    res["prefill_pct_over_frontier"] = pf.get("pct_over_frontier")  # TTFT reduction %
     res["prefill_pct_of_llama"] = pf.get("pct_of_llama")
     res["prefill_effective_pct"] = pf.get("effective_pct")
+    if pf.get("prefill_ttft_s") is not None:
+        res["prefill_ttft_s"] = pf["prefill_ttft_s"]
+    if pf.get("prefill_frontier_ttft_s") is not None:
+        res["prefill_frontier_ttft_s"] = pf["prefill_frontier_ttft_s"]
     if pf.get("difficulty_mult") is not None:
         res["prefill_difficulty_mult"] = pf["difficulty_mult"]
     # Never promote prefill over a correctness REJECT headline (pass=false stays merge-blocking).

--- a/bench/scripts/label.py
+++ b/bench/scripts/label.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Eval-loop label = deterministic function of measurements (so validators converge).
 
-  label.py <tps> <frontier_tps> <ceiling_tps> <top1> <kl> <commit>
+  label.py <value> <frontier> <ceiling> <top1> <kl> <commit> [prov_json]
 
 Emits one line:  RESULT_JSON {...}
 
@@ -20,13 +20,16 @@ Emits one line:  RESULT_JSON {...}
   %-over-frontier (a gain must beat the current best); pct_over_frontier reports the honest measured
   speedup; pct_of_llama is the tier basis.
   llama_ref (SPARKINFER_DIFFICULTY_REF) <= 0 falls back to the legacy delta/frontier basis.
+- SPARKINFER_LABEL_LOWER_IS_BETTER=1: value/frontier are latencies (e.g. TTFT seconds). Gain is the
+  reduction fraction (frontier - value) / frontier; pct_over_frontier is % reduced. Prefill scoring
+  uses this so tiers reflect time-to-first-token cuts vs same-box main.
   Thresholds are governance-tunable.
 """
 import sys, json, os
 
-tps      = float(sys.argv[1])   # measured median tok/s of the submission
-frontier = float(sys.argv[2])   # current best verified tok/s (0 = none yet)
-ceiling  = float(sys.argv[3])   # roofline / strong-reference cap (display only)
+tps      = float(sys.argv[1])   # measured median tok/s (or TTFT seconds when lower-is-better)
+frontier = float(sys.argv[2])   # current best verified tok/s / TTFT (0 = none yet)
+ceiling  = float(sys.argv[3])   # roofline / strong-reference cap (display only; unused if 0)
 top1     = float(sys.argv[4])   # token-match vs reference, 0..1
 kl       = float(sys.argv[5])   # mean KL vs reference (nats)
 commit   = sys.argv[6]
@@ -50,6 +53,8 @@ KL_PREFER = float(os.environ.get("SPARKINFER_KL_PREFER", "0.15"))
 SIG = 0.02                                              # noise floor: gain must beat 2% of frontier
 # min relative speedup (delta/frontier) for each tier; XS starts at the noise floor SIG.
 BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
+# Prefill / TTFT: score latency reduction instead of throughput increase.
+LOWER_IS_BETTER = os.environ.get("SPARKINFER_LABEL_LOWER_IS_BETTER", "0") == "1"
 
 # ---- Optional difficulty compensation (Option B — opt-in, governance-tunable) ----
 # As the frontier pulls past a mature reference (llama.cpp), each further % gain is harder; scale the
@@ -66,12 +71,18 @@ DIFF_REF   = float(os.environ.get("SPARKINFER_DIFFICULTY_REF", "365.85"))  # lla
 DIFF_MAX   = float(os.environ.get("SPARKINFER_DIFFICULTY_MAX", "1.5"))
 
 def difficulty_mult(frontier):
-    if not DIFF_BOOST or DIFF_REF <= 0:
+    if not DIFF_BOOST or DIFF_REF <= 0 or frontier <= 0:
         return 1.0
+    if LOWER_IS_BETTER:
+        # Latency: past-llama when frontier TTFT is *below* llama TTFT (faster).
+        return min(1.0 + DIFF_K * max(0.0, DIFF_REF / frontier - 1.0), DIFF_MAX)
     return min(1.0 + DIFF_K * max(0.0, frontier / DIFF_REF - 1.0), DIFF_MAX)
 
-res = {"commit": commit, "tps": round(tps, 2), "top1": round(top1, 4),
-       "kl": round(kl, 4), "frontier_tps": round(frontier, 2)}
+res = {"commit": commit, "tps": round(tps, 6 if LOWER_IS_BETTER else 2),
+       "top1": round(top1, 4), "kl": round(kl, 4),
+       "frontier_tps": round(frontier, 6 if LOWER_IS_BETTER else 2)}
+if LOWER_IS_BETTER:
+    res["lower_is_better"] = True
 
 
 def _speed_tier_fields(tps, frontier, ceiling):
@@ -81,12 +92,18 @@ def _speed_tier_fields(tps, frontier, ceiling):
     if frontier <= 0:
         out["label"] = "BASELINE"
         return out
-    delta = tps - frontier
-    g = delta / frontier                                # relative speedup over the frontier — SIGNIFICANCE basis
+    if LOWER_IS_BETTER:
+        delta = frontier - tps                          # seconds saved (positive when faster)
+        g = delta / frontier                            # TTFT reduction fraction
+    else:
+        delta = tps - frontier
+        g = delta / frontier                            # relative speedup — SIGNIFICANCE basis
     if g <= SIG:
-        out.update(label="none", delta_tps=round(delta, 2),
+        out.update(label="none", delta_tps=round(delta, 6 if LOWER_IS_BETTER else 2),
                    pct_over_frontier=round(100 * g, 1),
-                   note="within significance gate — not a verified improvement")
+                   note=("within significance gate — not a verified TTFT reduction"
+                         if LOWER_IS_BETTER else
+                         "within significance gate — not a verified improvement"))
         return out
     # FAIR label tier: size the gain against the llama.cpp reference (DIFF_REF — a constant maturity
     # anchor for EVERY model), not the possibly-unoptimized frontier. So the same tok/s of real work
@@ -95,17 +112,21 @@ def _speed_tier_fields(tps, frontier, ceiling):
     # still gates on raw %-over-frontier above (a gain must beat the current best); only the TIER is
     # llama-anchored. Past-llama difficulty boost (Option B) is unchanged. DIFF_REF<=0 -> legacy basis.
     ref = DIFF_REF if DIFF_REF > 0 else frontier
-    g_fair = delta / ref
+    if LOWER_IS_BETTER:
+        # Latency: fair gain = how much of llama's TTFT we cut vs llama (ref - value) / ref.
+        g_fair = (ref - tps) / ref if ref > 0 else g
+    else:
+        g_fair = delta / ref
     D = difficulty_mult(frontier)                       # hard-gain boost once past the reference
     g_eff = min(g_fair * D, 2 * g)                      # strict cap: tier credit ≤ 2× measured speedup
     # A verified improvement over the frontier floors at XS (real but small); the higher tiers
     # (S/M/L/XL) are earned by the llama-anchored size. So "none" always means "not a verified
     # improvement", never "real but tiny".
     label = next((l for thr, l in BUCKETS if g_eff >= thr), "XS")
-    out.update(label=label, delta_tps=round(delta, 2),
-               pct_over_frontier=round(100 * g, 1),      # RAW measured speedup (honest reporting)
-               pct_of_llama=round(100 * g_fair, 1),      # gain as a fraction of llama.cpp — the label basis
-               pct_of_ceiling=round(100 * tps / ceiling, 1) if ceiling > 0 else None)
+    out.update(label=label, delta_tps=round(delta, 6 if LOWER_IS_BETTER else 2),
+               pct_over_frontier=round(100 * g, 1),      # RAW measured speedup / TTFT reduction
+               pct_of_llama=round(100 * g_fair, 1),      # gain vs llama — the label basis
+               pct_of_ceiling=round(100 * tps / ceiling, 1) if ceiling > 0 and not LOWER_IS_BETTER else None)
     out["effective_pct"] = round(100 * g_eff, 1)
     if D != 1.0:                                        # transparency: expose the boost in the verdict
         out["difficulty_mult"] = round(D, 2)

--- a/bench/scripts/test_label_ttft.py
+++ b/bench/scripts/test_label_ttft.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""TTFT reduction scoring via SPARKINFER_LABEL_LOWER_IS_BETTER (prefill tiers).
+
+Run from the repo root:
+  python3 bench/scripts/test_label_ttft.py
+"""
+import json
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+LABEL = HERE / "label.py"
+
+
+def run_label(value, frontier, *, top1=0.95, kl=0.01, lower=True, diff_ref=0.0, boost="0"):
+    env = os.environ.copy()
+    env["SPARKINFER_LABEL_LOWER_IS_BETTER"] = "1" if lower else "0"
+    env["SPARKINFER_DIFFICULTY_REF"] = str(diff_ref)
+    env["SPARKINFER_DIFFICULTY_BOOST"] = boost
+    out = subprocess.check_output(
+        ["python3", str(LABEL), str(value), str(frontier), "0",
+         str(top1), str(kl), "deadbeef", "{}"],
+        env=env, text=True,
+    ).strip()
+    assert out.startswith("RESULT_JSON "), out
+    return json.loads(out[len("RESULT_JSON "):])
+
+
+class LabelTtftTest(unittest.TestCase):
+    def test_20pct_pp_gain_is_ttft_reduction_L(self):
+        """20% pp gain → TTFT reduction ≈ 16.7% → L (same mid-gain family as pp path)."""
+        # ctx cancel: ttft_main=1.0, ttft_pr = 1/1.2 ≈ 0.833 → g = 16.67%
+        res = run_label(1.0 / 1.2, 1.0, diff_ref=0.0)
+        self.assertTrue(res["pass"])
+        self.assertAlmostEqual(res["pct_over_frontier"], 16.7, places=0)
+        self.assertEqual(res["label"], "L")
+        self.assertTrue(res.get("lower_is_better"))
+
+    def test_small_ttft_cut_below_sig_is_none(self):
+        """g < 2% → none (noise / not verified)."""
+        res = run_label(0.99, 1.0, diff_ref=0.0)  # 1% reduction
+        self.assertEqual(res["label"], "none")
+        self.assertAlmostEqual(res["pct_over_frontier"], 1.0, places=0)
+
+    def test_correctness_reject_exposes_speed_label_from_ttft(self):
+        """Correctness REJECT still annotates speed_label from the TTFT path."""
+        # Huge TTFT cut (half latency) with failing top1
+        res = run_label(0.5, 1.0, top1=0.5, kl=0.5, diff_ref=0.0)
+        self.assertEqual(res["label"], "REJECT")
+        self.assertFalse(res["pass"])
+        self.assertEqual(res["speed_label"], "XL")
+        self.assertGreater(res["pct_over_frontier"], 18.0)
+
+    def test_pp_equivalence_formula(self):
+        """g = 1 - pp_main/pp_PR matches TTFT reduction from ctx/pp."""
+        ctx, pp_main, pp_pr = 4096.0, 1000.0, 1200.0
+        ttft_main = ctx / pp_main
+        ttft_pr = ctx / pp_pr
+        g_pp = 1.0 - pp_main / pp_pr
+        g_ttft = (ttft_main - ttft_pr) / ttft_main
+        self.assertAlmostEqual(g_pp, g_ttft, places=9)
+        res = run_label(ttft_pr, ttft_main, diff_ref=0.0)
+        self.assertAlmostEqual(res["pct_over_frontier"] / 100.0, g_ttft, places=2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1107,8 +1107,11 @@ def render(res, oid):
             if block.get("prefill_label"):
                 pctx = block.get("score_prefill_context", 0)
                 plbl = block.get("best_prefill_context_label", "")
+                ttft_pct = block.get("prefill_pct_over_frontier")
+                ttft_note = (f" · TTFT −{ttft_pct}%" if ttft_pct is not None else "")
                 rows.append(f"| {title} scored prefill ({pctx} ctx"
-                            f"{f' · {plbl}' if plbl else ''}) | {block.get('prefill_tps', '?')} pp tok/s · "
+                            f"{f' · {plbl}' if plbl else ''}) | {block.get('prefill_tps', '?')} pp tok/s"
+                            f"{ttft_note} · "
                             f"`eval-prefill:{block.get('prefill_label')}` |")
             elif block.get("eval_prefill"):
                 best_pp = _best_prefill_measurement(block)


### PR DESCRIPTION
## Summary
- Prefill `eval-prefill:{tier}` is sized by **TTFT reduction %** vs same-box main (`TTFT ≈ ctx / pp_tps`), via `SPARKINFER_LABEL_LOWER_IS_BETTER=1` in `label.py`.
- `evaluate.sh` keeps `prefill_tps` as pp tok/s for dashboards; adds `prefill_ttft_s` / `prefill_frontier_ttft_s`; `prefill_pct_over_frontier` is the reduction rate.
- No new `eval-ttft` track (same physical win as pp). Unit tests + README note; bot comment shows TTFT −%.

## Test plan
- [x] `python3 bench/scripts/test_label_ttft.py`
- [x] `python3 bench/scripts/test_prefill_label_merge.py`
- [x] Dry-run: 20% pp → ~16.7% TTFT → L; 30% pp → ~23% TTFT → XL
- [ ] Confirm next dual eval PR comment shows TTFT −% next to `eval-prefill:*`