### PR TITLE
feat(eval): Qwen3.6 CB mixed-load TTFT scoring

### DIFF
--- a/bench/scripts/README.md
+++ b/bench/scripts/README.md
@@ -94,8 +94,8 @@ build/runtime/qwen3_gguf_score model.gguf 20 <token-ids...>   # compare argmax +
 `evaluate.sh` grades one submission (build → correctness → 128/512/4k/16k/32k speed → `label.py`).
 Prefill `eval-prefill:{tier}` is sized by **TTFT reduction %** vs same-box main at the winning
 context (`TTFT ≈ ctx / pp_tps`; `SPARKINFER_LABEL_LOWER_IS_BETTER=1`), not raw pp %-over-frontier.
-For Qwen3.5, the headline is the **max tier** of single-seq TTFT and CB mixed-load `long_ttft_s`
-(`qwen3_gguf_cb_bench`: 4×decode + 8k interrupt). Dashboards still get `prefill_tps` as pp tok/s.
+For Qwen3.5 and Qwen3.6, the headline is the **max tier** of single-seq TTFT and CB mixed-load
+`long_ttft_s` (`qwen3_gguf_cb_bench`: 4×decode + 8k interrupt). Dashboards still get `prefill_tps` as pp tok/s.
 `evaluate_dual.sh` wraps it for **dual-model scoring**: it builds once, then scores **Qwen3.6-35B-A3B**
 (the primary target, 128/512/4k for now) and guards **Qwen3-30B-A3B** against regression (full sweep +
 accuracy) — any Qwen3 speed drop <98% of its main or broken llama.cpp parity REJECTs the submission.

--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -59,7 +59,7 @@ ensure_prefill_check() {  # $1 = arch
   [ -x "$ROOT/build/runtime/qwen3_gguf_prefill_check" ]
 }
 
-# Mixed-load CB TTFT bench (Qwen3.5 prefill scoring when SPARKINFER_EVAL_PREFILL_CB=1).
+# Mixed-load CB TTFT bench (prefill scoring when SPARKINFER_EVAL_PREFILL_CB=1).
 ensure_cb_bench() {  # $1 = arch
   if [ -x "$ROOT/build/runtime/qwen3_gguf_cb_bench" ]; then return 0; fi
   if [ -n "${SI_BIN:-}" ] && [ -x "$SI_BIN/qwen3_gguf_cb_bench" ]; then return 0; fi

--- a/bench/scripts/_eval_speed.sh
+++ b/bench/scripts/_eval_speed.sh
@@ -160,7 +160,7 @@ print(json.dumps({"chosen": chosen, "contexts": contexts, "metric": "prefill"}, 
 PY
 }
 
-# Mixed-load continuous-batching TTFT (Qwen3.5 / Qwythos serving path).
+# Mixed-load continuous-batching TTFT (Qwen3.5 / Qwen3.6 serving path).
 # Fixed recipe matches PR #585 proof: concurrency=4 prompt=256 max_new=64 long_prefill=8192.
 # Echoes: "<long_ttft_s> <long_prefill_pp>"
 run_cb_ttft() {

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -69,9 +69,8 @@ else
   fi
 fi
 SI_BIN="$ROOT/build/runtime"; SI_LD=""
-# CB mixed-load TTFT bench for Qwen3.5 prefill scoring (skip if binary absent after warn).
-if [ "${SPARKINFER_EVAL_PREFILL:-0}" = "1" ] && [ "${SPARKINFER_PREFILL_PROFILE:-qwen35}" = "qwen35" ] \
-   && [ "${SPARKINFER_EVAL_PREFILL_CB:-1}" = "1" ]; then
+# CB mixed-load TTFT bench for Qwen3.5 / Qwen3.6 prefill scoring.
+if [ "${SPARKINFER_EVAL_PREFILL:-0}" = "1" ] && [ "${SPARKINFER_EVAL_PREFILL_CB:-1}" = "1" ]; then
   ensure_cb_bench "$ARCH" || echo ">> WARN: qwen3_gguf_cb_bench missing — CB TTFT scoring skipped" >&2
 fi
 
@@ -741,11 +740,11 @@ PY
   exit 0
 fi
 
-# Optional CB mixed-load TTFT (Qwen3.5 only): measure long_ttft_s vs same-box main baseline.
+# Optional CB mixed-load TTFT (Qwen3.5 + Qwen3.6): measure long_ttft_s vs same-box main baseline.
 CB_TTFT=0; CB_PP=0; CB_FRONTIER_TTFT="${SPARKINFER_GUARD_CB_TTFT_BASELINE:-0}"
-if [ "$PREFILL_PROFILE" = "qwen35" ] && [ "${SPARKINFER_EVAL_PREFILL_CB:-1}" = "1" ] \
+if [ "${SPARKINFER_EVAL_PREFILL_CB:-1}" = "1" ] \
    && [ -x "$SI_BIN/qwen3_gguf_cb_bench" ]; then
-  echo ">> CB mixed-load TTFT (4×decode + 8k interrupt) ..." >&2
+  echo ">> CB mixed-load TTFT (4×decode + 8k interrupt, profile=$PREFILL_PROFILE) ..." >&2
   CB_PAIR="$(run_cb_ttft "$GGUF" || true)"
   CB_TTFT="$(printf '%s\n' "$CB_PAIR" | awk '{print $1+0}')"
   CB_PP="$(printf '%s\n' "$CB_PAIR" | awk '{print $2+0}')"

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -154,6 +154,7 @@ if [ "$BASELINE_ONLY" = 1 ]; then
   SPARKINFER_P35_GUARD_64K_PP_BASELINE=0
   SPARKINFER_P35_GUARD_128K_PP_BASELINE=0
   SPARKINFER_P35_GUARD_CB_TTFT_BASELINE=0
+  SPARKINFER_P36_GUARD_CB_TTFT_BASELINE=0
 else
   echo ">> [build] submission ($COMMIT) from source (sm_$ARCH) — shared by both models ..." >&2
   rm -rf "$ROOT/build"
@@ -308,20 +309,31 @@ if [ "${SPARKINFER_P35_GUARD_128_BASELINE:-0}" = "0" ] || [ "${SPARKINFER_P35_GU
   echo ">> Qwen3.5 prefill: 4k=${B35_4K_PP:-0} 32k=${B35_32K_PP:-0} 64k=${B35_64K_PP:-0} 128k=${B35_128K_PP:-0} pp tok/s" >&2
 fi
 
-# CB mixed-load TTFT baseline (Qwen3.5 / Qwythos) — same fixed recipe as evaluate.sh.
+# CB mixed-load TTFT baselines (Qwen3.5 + Qwen3.6) — same fixed recipe as evaluate.sh.
 B35_CB_TTFT="${SPARKINFER_P35_GUARD_CB_TTFT_BASELINE:-0}"
-if [ "${B35_CB_TTFT}" = "0" ] && [ "${SPARKINFER_EVAL_PREFILL_CB:-1}" = "1" ]; then
+B36_CB_TTFT="${SPARKINFER_P36_GUARD_CB_TTFT_BASELINE:-0}"
+if [ "${SPARKINFER_EVAL_PREFILL_CB:-1}" = "1" ]; then
   if ensure_cb_bench "$ARCH"; then
-    echo ">> measuring Qwen3.5 CB mixed-load TTFT (4×decode + 8k interrupt) ..." >&2
-    P35_GGUF="${P35_DIR}/${P35_FILE}"
-    CB_PAIR="$(run_cb_ttft "$P35_GGUF" || true)"
-    B35_CB_TTFT="$(printf '%s\n' "$CB_PAIR" | awk '{print $1+0}')"
-    echo ">> Qwen3.5 CB TTFT main: ${B35_CB_TTFT}s" >&2
+    if [ "${B35_CB_TTFT}" = "0" ]; then
+      echo ">> measuring Qwen3.5 CB mixed-load TTFT (4×decode + 8k interrupt) ..." >&2
+      P35_GGUF="${P35_DIR}/${P35_FILE}"
+      CB_PAIR="$(run_cb_ttft "$P35_GGUF" || true)"
+      B35_CB_TTFT="$(printf '%s\n' "$CB_PAIR" | awk '{print $1+0}')"
+      echo ">> Qwen3.5 CB TTFT main: ${B35_CB_TTFT}s" >&2
+    fi
+    if [ "${B36_CB_TTFT}" = "0" ]; then
+      echo ">> measuring Qwen3.6 CB mixed-load TTFT (4×decode + 8k interrupt) ..." >&2
+      P36_GGUF="${P36_DIR}/${P36_FILE}"
+      CB_PAIR="$(run_cb_ttft "$P36_GGUF" || true)"
+      B36_CB_TTFT="$(printf '%s\n' "$CB_PAIR" | awk '{print $1+0}')"
+      echo ">> Qwen3.6 CB TTFT main: ${B36_CB_TTFT}s" >&2
+    fi
   else
-    echo ">> WARN: qwen3_gguf_cb_bench unavailable — CB TTFT baseline skipped" >&2
+    echo ">> WARN: qwen3_gguf_cb_bench unavailable — CB TTFT baselines skipped" >&2
   fi
 fi
 B35_CB_TTFT="${B35_CB_TTFT:-0}"
+B36_CB_TTFT="${B36_CB_TTFT:-0}"
 
 B36_128="${B36_128:-${SPARKINFER_P36_GUARD_128_BASELINE:-0}}"
 B36_512="${B36_512:-${SPARKINFER_P36_GUARD_512_BASELINE:-0}}"
@@ -400,11 +412,13 @@ s35 = stub("$B35_128", "$B35_128", "$B35_4K", "$B35_32K", "$B35_64K",
 s35["cb_ttft_s"] = float("${B35_CB_TTFT:-0}" or 0)
 s36 = stub("$B36_128", "$B36_128", "$B36_4K", "$B36_32K", ctx512="$B36_512", ctx16k="$B36_16K",
            pp128="$B36_128_PP", pp512="$B36_512_PP", pp4k="$B36_4K_PP", pp16k="$B36_16K_PP", pp32k="$B36_32K_PP")
+s36["cb_ttft_s"] = float("${B36_CB_TTFT:-0}" or 0)
 out = {"pass": True, "label": "BASELINE", "commit": commit, "mode": "bidir", "model": "bidir",
        "tps": s36["tps"], "top1": 1.0, "kl": 0.0, "primary_quant": quant,
        "score_qwen35": s35, "score_qwen36": s36, "pass_qwen35": True, "pass_qwen36": True,
        "label_qwen35": "BASELINE", "label_qwen36": "BASELINE",
-       "cb_ttft_s": float("${B35_CB_TTFT:-0}" or 0)}
+       "cb_ttft_s": float("${B35_CB_TTFT:-0}" or 0),
+       "cb_ttft_s_qwen36": float("${B36_CB_TTFT:-0}" or 0)}
 print("RESULT_JSON " + json.dumps(out))
 PY
   exit 0
@@ -458,6 +472,7 @@ PRIMARY36_JSON="$(run_model primary-qwen36 "$P36_FILE" "$P36_REPO" "$P36_TOK" 0 
   SPARKINFER_GUARD_4K_PP_BASELINE="${B36_4K_PP}" \
   SPARKINFER_GUARD_16K_PP_BASELINE="${B36_16K_PP}" \
   SPARKINFER_GUARD_32K_PP_BASELINE="${B36_32K_PP}" \
+  SPARKINFER_GUARD_CB_TTFT_BASELINE="${B36_CB_TTFT}" \
   SPARKINFER_LLAMA_128_BASELINE="${SPARKINFER_P36_LLAMA_128_BASELINE:-275.81}" \
   SPARKINFER_LLAMA_512_BASELINE="${SPARKINFER_P36_LLAMA_512_BASELINE:-275.61}" \
   SPARKINFER_LLAMA_4K_BASELINE="${SPARKINFER_P36_LLAMA_4K_BASELINE:-276.30}" \

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -80,6 +80,7 @@ def _bidir_baseline_args(q36, q35):
         "--p35-guard-64k-pp-baseline", str(q35.get("64k_pp", 0)),
         "--p35-guard-128k-pp-baseline", str(q35.get("128k_pp", 0)),
         "--p35-guard-cb-ttft-baseline", str(q35.get("cb_ttft", 0)),
+        "--p36-guard-cb-ttft-baseline", str(q36.get("cb_ttft", 0)),
         "--p-guard-128-baseline", str(q36["128"]),
         "--p-guard-512-baseline", str(q36["512"]),
         "--p-guard-4k-baseline",  str(q36["4k"]),
@@ -150,13 +151,19 @@ def _apply_bidir_ctx_from_bres(bres, q36, q35):
     got35 = _fill(bres.get("score_qwen35"), q35, ("128", "4k", "32k", "64k"))
     _fill_pp(bres.get("score_qwen36"), q36, ("128_pp", "512_pp", "4k_pp", "16k_pp", "32k_pp"), pp_map_q36)
     _fill_pp(bres.get("score_qwen35"), q35, ("4k_pp", "32k_pp", "64k_pp", "128k_pp"), pp_map_q35)
-    # CB mixed-load TTFT (seconds) — top-level or nested under score_qwen35.
-    cb = float(bres.get("cb_ttft_s") or 0)
-    if cb <= 0:
+    # CB mixed-load TTFT (seconds) — per model from nested scores or top-level.
+    cb35 = float(bres.get("cb_ttft_s") or 0)
+    if cb35 <= 0:
         s35 = bres.get("score_qwen35") or {}
-        cb = float(s35.get("cb_ttft_s") or 0)
-    if cb > 0:
-        q35["cb_ttft"] = cb
+        cb35 = float(s35.get("cb_ttft_s") or 0)
+    if cb35 > 0:
+        q35["cb_ttft"] = cb35
+    cb36 = float(bres.get("cb_ttft_s_qwen36") or 0)
+    if cb36 <= 0:
+        s36 = bres.get("score_qwen36") or {}
+        cb36 = float(s36.get("cb_ttft_s") or 0)
+    if cb36 > 0:
+        q36["cb_ttft"] = cb36
     return got36 and got35
 
 
@@ -2342,6 +2349,7 @@ def main():
         "llama128": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_128", "275.81")),
         "llama512": float(os.environ.get("SPARKINFER_QWEN36_LLAMA_512", "275.61")),
         "llama4k":  float(os.environ.get("SPARKINFER_QWEN36_LLAMA_4K",  "276.30")),
+        "cb_ttft": float(os.environ.get("SPARKINFER_QWEN36_CB_TTFT", "0")),
     }
     QWYTHOS_BASE = {
         "128": float(os.environ.get("SPARKINFER_QWYTHOS_128", "0")),
@@ -2712,6 +2720,8 @@ def main():
                   f"128k={QWYTHOS_BASE.get('128k_pp', 0)} pp tok/s")
         if QWYTHOS_BASE.get("cb_ttft", 0) > 0:
             print(f"  Qwythos CB mixed TTFT: {QWYTHOS_BASE.get('cb_ttft')}s")
+        if QWEN36_BASE.get("cb_ttft", 0) > 0:
+            print(f"  Qwen3.6 CB mixed TTFT: {QWEN36_BASE.get('cb_ttft')}s")
 
     # Run all pending evals on the same vast instance (left running between PRs and after the run).
     for i, (pr, num, branch, oid, ref, areas) in enumerate(pending):

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -337,6 +337,8 @@ def main():
     ap.add_argument("--p35-guard-128k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.5 main 128k prefill pp tok/s")
     ap.add_argument("--p35-guard-cb-ttft-baseline", type=float, default=0,
                     help="[--bidir] Qwen3.5 main CB mixed-load long_ttft_s (seconds)")
+    ap.add_argument("--p36-guard-cb-ttft-baseline", type=float, default=0,
+                    help="[--bidir] Qwen3.6 main CB mixed-load long_ttft_s (seconds)")
     ap.add_argument("--p36-guard-128-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 128 prefill pp tok/s")
     ap.add_argument("--p36-guard-512-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 512 prefill pp tok/s")
     ap.add_argument("--p36-guard-4k-pp-baseline", type=float, default=0, help="[--bidir] Qwen3.6 main 4k prefill pp tok/s")
@@ -708,6 +710,7 @@ def main():
                         f"SPARKINFER_P35_GUARD_64K_PP_BASELINE={args.p35_guard_64k_pp_baseline} "
                         f"SPARKINFER_P35_GUARD_128K_PP_BASELINE={args.p35_guard_128k_pp_baseline} "
                         f"SPARKINFER_P35_GUARD_CB_TTFT_BASELINE={args.p35_guard_cb_ttft_baseline} "
+                        f"SPARKINFER_P36_GUARD_CB_TTFT_BASELINE={args.p36_guard_cb_ttft_baseline} "
                         f"SPARKINFER_P36_GUARD_128_PP_BASELINE={args.p36_guard_128_pp_baseline} "
                         f"SPARKINFER_P36_GUARD_512_PP_BASELINE={args.p36_guard_512_pp_baseline} "
                         f"SPARKINFER_P36_GUARD_4K_PP_BASELINE={args.p36_guard_4k_pp_baseline} "


### PR DESCRIPTION
## Summary
- Enable CB mixed-load TTFT for **Qwen3.6** as well as Qwen3.5 (same `qwen3_gguf_cb_bench` recipe).
- Bidir measures/passes `SPARKINFER_P36_GUARD_CB_TTFT_BASELINE`; bot/vast cache `cb_ttft` for both models.

## Test plan
- [x] `python3 bench/scripts/test_cb_prefill_score.py`
- [x] bash -n evaluate scripts
- [ ] Next bidir eval shows CB TTFT lines for both Qwen3.5 and Qwen3.6