### PR TITLE
fix(eval): score vs llama with native GGUF quants, not down-requant

### DIFF
--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -27,6 +27,12 @@ int main(int argc, char** argv) {
     int ndev = 0;
     if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) { printf("[SKIP] no GPU\n"); return 0; }
 
+    // Teacher-forced scoring compares vs llama.cpp reading native GGUF quants. Speed benches
+    // may set SPARKINFER_DOWN_REQUANT_Q4K=1 (and that env also gates Qwythos dense-9B attn/lmhead
+    // requant defaults); those paths diverge from the reference and falsely fail the correctness
+    // gate (~79-83% top1). overwrite=1 so evaluate_bidir's export cannot leak into scoring.
+    setenv("SPARKINFER_DOWN_REQUANT_Q4K", "0", 1);
+
     const std::string path = argv[1];
     const int topk = atoi(argv[2]);
     std::vector<int> toks;


### PR DESCRIPTION
## Summary
- Force `SPARKINFER_DOWN_REQUANT_Q4K=0` in `qwen3_gguf_score` before model load so teacher-forced accuracy compares against llama.cpp's native GGUF weights.
- Leaves decode speed benches unchanged (`qwen3_gguf_bench` still runs with requant ON from `evaluate_bidir.sh`).

Without this, bidir eval's exported `DOWN_REQUANT=1` (also the C++ default) re-packs Qwythos weights and systematically fails the correctness gate at ~79–83% top1 even when `forward_token` matches `origin/main` (e.g. PR #593).

## Test plan
- [ ] Rebuild `qwen3_gguf_score` with parent env `SPARKINFER_DOWN_REQUANT_Q4K=1`
- [ ] Confirm score dumps match a run with `DOWN_REQUANT=0` (byte-identical)
- [ ] Re-eval a known false-fail (e.g. #593): Qwythos top1 should leave the 79–83% band
- [ ] Confirm `qwen3_gguf_bench` tok/s still reflects requant-ON shipped decode path