### PR TITLE
perf(qwen36): enable sink+sliding-window sparse KV for GQA-8 hd256

### DIFF
--- a/kernels/csrc/cuda/attention/sparse_kv.cu
+++ b/kernels/csrc/cuda/attention/sparse_kv.cu
@@ -1,5 +1,6 @@
-// Sink + sliding-window sparse-KV for Qwythos GQA-4 hd256 full-attention decode.
-// [Paral1995] 2026-07-13. SPARKINFER_SPARSE_KV=0 disables; default ON for Qwythos GQA-4 hd256 int8-KV.
+// Sink + sliding-window sparse-KV for hd256 full-attention decode (GQA-4 and GQA-8).
+// [Paral1995] 2026-07-13. SPARKINFER_SPARSE_KV=0 disables; default ON for Qwythos GQA-4
+// and Qwen3.6 GQA-8 hd256 int8-KV (#559).
 //
 // Per full-attn layer after int8 KV append:
 //   (1) fa_kv_window_select — sink block 0 + last W logical blocks (StreamingLLM-style)
@@ -141,16 +142,24 @@ void launch_flash_decode_split_sparse(
     int n_splits, int n_sel, float scale,
     const void* k_scale_layer, const void* v_scale_layer, cudaStream_t stream
 ) {
-    if (head_dim != 256 || num_q_heads != num_kv_heads * 4) return;
+    if (head_dim != 256 || num_kv_heads <= 0) return;
+    const int gqa = num_q_heads / num_kv_heads;
+    if ((gqa != 4 && gqa != 8) || num_q_heads != num_kv_heads * gqa) return;
     dim3 grid(num_kv_heads * n_splits, 1);
-    fa_split_gqa_sparse<256, 4><<<grid, 4 * 32, 0, stream>>>(
-        reinterpret_cast<const __nv_bfloat16*>(q),
-        reinterpret_cast<const signed char*>(k_pool_layer),
-        reinterpret_cast<const signed char*>(v_pool_layer),
-        block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
-        num_q_heads, num_kv_heads, block_size, max_blocks, n_splits, n_sel,
-        reinterpret_cast<const __half*>(k_scale_layer),
-        reinterpret_cast<const __half*>(v_scale_layer));
+    const __nv_bfloat16* q_bf = reinterpret_cast<const __nv_bfloat16*>(q);
+    const signed char* k_i8 = reinterpret_cast<const signed char*>(k_pool_layer);
+    const signed char* v_i8 = reinterpret_cast<const signed char*>(v_pool_layer);
+    const __half* k_sc = reinterpret_cast<const __half*>(k_scale_layer);
+    const __half* v_sc = reinterpret_cast<const __half*>(v_scale_layer);
+    if (gqa == 4) {
+        fa_split_gqa_sparse<256, 4><<<grid, 4 * 32, 0, stream>>>(
+            q_bf, k_i8, v_i8, block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
+            num_q_heads, num_kv_heads, block_size, max_blocks, n_splits, n_sel, k_sc, v_sc);
+    } else {
+        fa_split_gqa_sparse<256, 8><<<grid, 8 * 32, 0, stream>>>(
+            q_bf, k_i8, v_i8, block_table, seq_lens, sel_blk, part_m, part_l, part_acc, scale,
+            num_q_heads, num_kv_heads, block_size, max_blocks, n_splits, n_sel, k_sc, v_sc);
+    }
 }
 #endif
 

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -153,7 +153,7 @@ void launch_fa_combine_hd256(const float* part_m, const float* part_l, const flo
     void* out, int num_q_heads, int n_splits, void* out_q8, cudaStream_t stream = nullptr,
     const void* attn_gate = nullptr);
 
-// Sink + sliding-window sparse-KV (Qwythos GQA-4 hd256). Default on; SPARKINFER_SPARSE_KV=0 disables.
+// Sink + sliding-window sparse-KV (hd256 GQA-4 / GQA-8). Default on; SPARKINFER_SPARSE_KV=0 disables.
 void launch_fa_kv_window_select(const int* seq_lens, int* sel_blk, int num_kv_heads,
     int block_size, int n_sel, int window_w, cudaStream_t stream = nullptr);
 void launch_flash_decode_split_sparse(const void* q, const void* k_pool_layer, const void* v_pool_layer,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -279,11 +279,13 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->fa_m   = p_->alloc<float>(fa_n);
     p_->fa_l   = p_->alloc<float>(fa_n);
     p_->fa_acc = p_->alloc<float>(fa_n * cfg.head_dim);
-    // Sink + sliding-window sparse KV: default ON for Qwythos GQA-4 hd256 (int8 KV).
-    // SPARKINFER_SPARSE_KV=0 restores dense full-context flash-decode.
+    // Sink + sliding-window sparse KV: default ON for hd256 GQA-4 (Qwythos) and GQA-8
+    // (Qwen3.6) int8 KV. SPARKINFER_SPARSE_KV=0 restores dense full-context flash-decode.
     bool sparse_enable = true;
     if (const char* se = getenv("SPARKINFER_SPARSE_KV")) sparse_enable = (se[0] != '0');
-    if (sparse_enable && cfg.head_dim == 256 && cfg.n_q_heads == cfg.n_kv_heads * 4) {
+    const bool sparse_gqa = cfg.n_kv_heads > 0 &&
+        (cfg.n_q_heads == cfg.n_kv_heads * 4 || cfg.n_q_heads == cfg.n_kv_heads * 8);
+    if (sparse_enable && cfg.head_dim == 256 && sparse_gqa) {
         p_->sparse_window = 256;
         if (const char* w = getenv("SPARKINFER_SPARSE_WINDOW")) { int v = atoi(w); if (v > 0) p_->sparse_window = v; }
         // Legacy aliases from the Quest prototype (blocks, not tokens).
@@ -460,7 +462,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         s.graph_ready = false;
     }
     const bool sparse_avail = s.sparse_budget > 0 && s.kv->int8_kv() &&
-                              c.head_dim == 256 && c.n_q_heads == c.n_kv_heads * 4;
+                              c.head_dim == 256 && c.n_kv_heads > 0 &&
+                              (c.n_q_heads == c.n_kv_heads * 4 ||
+                               c.n_q_heads == c.n_kv_heads * 8);
     const bool sparse_on = sparse_avail && seqlen >= s.sparse_min_ctx;
     if (s.graph_ready && s.graph_sparse != sparse_on) {
         cu(cudaGraphExecDestroy(s.cu_exec), "sparse recapture destroy exec");


### PR DESCRIPTION
## Summary

Enable sink + sliding-window sparse KV for **Qwen3.6 hd256 GQA-8** (same path as Qwythos GQA-4 from #379).

Previously `launch_flash_decode_split_sparse` and the runtime fingerprint required `n_q == 4 * n_kv`, so Qwen3.6-35B-A3B stayed on dense flash-decode at 16k/32k. This PR:

1. Instantiates `fa_split_gqa_sparse<256, 8>` (8 warps / CTA)
2. Widens the enable fingerprint in `qwen35.cpp` to GQA-4 **or** GQA-8
3. Leaves the GQA-4 kernel launch bit-identical (`<<<grid, 4*32>>>` + `<256,4>`)

Reuses existing knobs: `SPARKINFER_SPARSE_KV`, `SPARKINFER_SPARSE_WINDOW` (default 256), `SPARKINFER_SPARSE_MIN_CTX` (default 8192).

Fixes #559

## Proof of speedup

> ⚠️ Auto-closed by `rtx5090-required` — this box stays **unticked** until a real RTX 5090 `bench/scripts/bench.sh` run is pasted below. Do **not** tick without hardware (false attestation → denylist).

- [ ] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — required for evaluation):

| | decode tok/s |
|---|--:|
| before (main, GQA-8 dense @32k) | _TBD — run on 5090_ |
| after (this PR, sparse on @32k) | _TBD — must be > before_ |

```bash
# on RTX 5090 box
bench/scripts/bench.sh --download   # main baseline
# checkout this PR branch, rebuild, then:
SPARKINFER_SPARSE_KV=1 SPARKINFER_SPARSE_WINDOW=256 bench/scripts/bench.sh
```

## Test plan

- [ ] Build kernels + runtime on sm_120
- [ ] Qwythos GQA-4: sparse still engages at ctx≥8192; `SPARKINFER_SPARSE_KV=0` dense unchanged
- [ ] Qwen3.6 GQA-8: `[sparse-kv]` at init; sparse path at 16k/32k decode with after > before
- [ ] Short-ctx (< min_ctx) still dense for both shapes
