### PR TITLE
fix(eval): reject CB mixed TTFT regressions and harden harness

### DIFF
--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -42,11 +42,19 @@ CUDA_HOST_FLAG=""
 
 ensure_sparkinfer() {  # $1 = arch
   [ -x "$ROOT/build/runtime/qwen3_gguf_bench" ] && [ -x "$ROOT/build/runtime/qwen3_gguf_score" ] \
-    && [ -x "$ROOT/build/runtime/qwen3_gguf_prefill_check" ] && return
+    && [ -x "$ROOT/build/runtime/qwen3_gguf_prefill_check" ] && return 0
   echo ">> building sparkinfer (sm_$1) ..." >&2
   cmake -S "$ROOT" -B "$ROOT/build" -DCMAKE_CUDA_ARCHITECTURES="$1" -DCMAKE_BUILD_TYPE=Release $CUDA_HOST_FLAG >/dev/null
   # Cap at 2 parallel jobs — cc1plus for sm_120 uses ~2-3 GB RAM each; -j4 OOMs on 64GB eval boxes.
-  cmake --build "$ROOT/build" -j2 >/dev/null
+  if ! cmake --build "$ROOT/build" -j2 >/dev/null; then
+    echo ">> sparkinfer build FAILED (sm_$1)" >&2
+    return 1
+  fi
+  [ -x "$ROOT/build/runtime/qwen3_gguf_bench" ] && [ -x "$ROOT/build/runtime/qwen3_gguf_score" ] \
+    && [ -x "$ROOT/build/runtime/qwen3_gguf_prefill_check" ] || {
+    echo ">> sparkinfer build incomplete — missing runtime binaries (sm_$1)" >&2
+    return 1
+  }
 }
 
 # H3: batched-vs-token prefill fidelity binary (not always in release tarballs).

--- a/bench/scripts/accuracy_compare.py
+++ b/bench/scripts/accuracy_compare.py
@@ -20,7 +20,7 @@ int8-MMA and sparse-KV engagement thresholds — which is the whole point of the
 --metric-label NAME renames the machine-readable METRIC line (e.g. METRIC_LONG), so accuracy.sh
 can emit several passes and still hand evaluate.sh exactly one unambiguous `METRIC ` line.
 """
-import sys, json, math, urllib.request
+import sys, json, math, time, urllib.error, urllib.request
 from tokenizers import Tokenizer
 
 argv = sys.argv[1:]
@@ -48,12 +48,41 @@ if _toks and all(t.lstrip("-").isdigit() for t in _toks):
 else:
     ids = Tokenizer.from_file(tok_path).encode(_raw).ids
 
-def llama_dist(prefix):
-    req = {"prompt": prefix, "n_predict": 1, "n_probs": TOPK, "temperature": 0, "cache_prompt": True}
+def _completion(req):
     r = urllib.request.urlopen(urllib.request.Request(
         URL + "/completion", data=json.dumps(req).encode(),
         headers={"Content-Type": "application/json"}), timeout=120)
-    tl = json.load(r)["completion_probabilities"][0]["top_logprobs"]
+    return json.load(r)
+
+def llama_dist(prefix):
+    # temperature=0 + n_probs: top_logprobs come from pre-sampling logits
+    # (post_sampling_probs=false). When the greedy token is incomplete UTF-8,
+    # llama-server (n_predict=1) skips add_token and omits completion_probabilities
+    # entirely — KeyError / infra error. Retry forcing an ASCII sample so the
+    # response includes probs; the distribution itself is unchanged.
+    # Also retry on transient HTTP 5xx (same grammar force, then one plain retry).
+    req = {"prompt": prefix, "n_predict": 1, "n_probs": TOPK, "temperature": 0, "cache_prompt": True}
+    data = None
+    last_err = None
+    for attempt, extra in enumerate(({}, {"grammar": 'root ::= "a"'}, {})):
+        try:
+            data = _completion({**req, **extra})
+            if data.get("completion_probabilities"):
+                break
+            last_err = f"omitted completion_probabilities (content={data.get('content')!r})"
+        except urllib.error.HTTPError as e:
+            last_err = f"HTTP {e.code}: {e.reason}"
+            if e.code < 500 or attempt == 2:
+                raise
+            time.sleep(0.5)
+        except (TimeoutError, urllib.error.URLError) as e:
+            last_err = str(e)
+            if attempt == 2:
+                raise
+            time.sleep(0.5)
+    if not data or not data.get("completion_probabilities"):
+        raise RuntimeError(f"llama-server /completion failed after retries: {last_err}")
+    tl = data["completion_probabilities"][0]["top_logprobs"]
     return {e["id"]: e["logprob"] for e in tl}
 
 spark = {}

--- a/bench/scripts/evaluate.sh
+++ b/bench/scripts/evaluate.sh
@@ -829,7 +829,8 @@ if cb_ttft > 0 and cb_frontier > 0:
 print("RESULT_JSON " + json.dumps(pf))
 PY
 )"
-DECODE_LINE="$DECODE_LINE" PREFILL_LINE="$PREFILL_LINE" python3 - <<'PY'
+DECODE_LINE="$DECODE_LINE" PREFILL_LINE="$PREFILL_LINE" \
+EVAL_MODE="$EVAL_MODE" GUARD_TOL="$GUARD_TOL" python3 - <<'PY'
 import json, os
 
 TIER_RANK = {"XL": 6, "L": 5, "M": 4, "S": 3, "XS": 2, "none": 1, "BASELINE": 0, "REJECT": -1}
@@ -903,5 +904,31 @@ if prefill_raw.startswith("RESULT_JSON "):
         res["score_metric"] = "prefill"
     else:
         res["score_metric"] = "decode"
+
+# CB mixed-load TTFT no-regression gate (latency: lower is better).
+# Single-seq pp gains must not excuse a serving-path TTFT regression (same 2% tol as decode/pp).
+tol = float(os.environ.get("GUARD_TOL", "0.98") or 0.98)
+cb_ttft = float(res.get("cb_ttft_s") or 0)
+cb_base = float(res.get("cb_frontier_ttft_s") or 0)
+cb_pass = True
+if cb_ttft > 0 and cb_base > 0:
+    cb_pass = cb_ttft <= (cb_base / tol)
+res["guard_cb_ttft_pass"] = cb_pass
+res["guard_cb_ttft_baseline"] = round(cb_base, 6) if cb_base > 0 else 0.0
+res["guard_cb_ttft_tol"] = tol
+if (not cb_pass) and os.environ.get("EVAL_MODE", "longctx") != "short":
+    labels = list(res.get("regression_labels") or [])
+    if "regression-cb-ttft" not in labels:
+        labels.append("regression-cb-ttft")
+    res["regression_labels"] = labels
+    limit = cb_base / tol
+    reason = (f"CB mixed-load TTFT no-regression gate: {cb_ttft:.3f}s > "
+              f"{100 * tol:.0f}% of main {cb_base:.3f}s (limit {limit:.3f}s)")
+    # Keep speed annotations for the comment; overall stays merge-blocking REJECT.
+    res["pass"] = False
+    res["label"] = "REJECT"
+    res["reason"] = reason
+    res["auto_close"] = True
+
 print("RESULT_JSON " + json.dumps(res))
 PY

--- a/bench/scripts/evaluate_bidir.sh
+++ b/bench/scripts/evaluate_bidir.sh
@@ -604,7 +604,10 @@ final["pass_qwen36"] = bool(score36.get("pass"))
 final["model"] = "bidir"
 final["primary_quant"] = quant
 final["regression_labels"] = list(dict.fromkeys(
-    (score35.get("guard_regression_labels") or []) + (score36.get("guard_regression_labels") or [])))
+    (score35.get("guard_regression_labels") or [])
+    + (score36.get("guard_regression_labels") or [])
+    + (score35.get("regression_labels") or [])
+    + (score36.get("regression_labels") or [])))
 
 print("RESULT_JSON " + json.dumps(final))
 PY

--- a/bench/scripts/test_guard_reject.py
+++ b/bench/scripts/test_guard_reject.py
@@ -3,6 +3,9 @@
 Mirrors evaluate.sh: reject when EVAL_MODE != short and ALL_GUARDS_PASS != true.
 PR #562 scored eval:L with +13.6% @64k pp while 128k pp collapsed (287 vs 17020)
 because a verified mid-ctx gain previously skipped the REJECT path.
+
+CB mixed-load TTFT (latency, lower-is-better) uses the same tol: fail when
+ttft > frontier / tol. Single-seq pp gains must not excuse a serving-path regression.
 """
 import unittest
 
@@ -11,6 +14,13 @@ def should_reject_for_guards(all_guards_pass: bool, eval_mode: str = "longctx") 
     if eval_mode == "short":
         return False
     return not all_guards_pass
+
+
+def cb_ttft_guard_pass(ttft: float, frontier: float, tol: float = 0.98) -> bool:
+    """Latency no-regression: allow up to ~(1/tol - 1) worse TTFT vs main."""
+    if ttft <= 0 or frontier <= 0:
+        return True  # skip when unmeasured (same as missing decode baselines)
+    return ttft <= frontier / tol
 
 
 class GuardRejectTests(unittest.TestCase):
@@ -24,6 +34,22 @@ class GuardRejectTests(unittest.TestCase):
 
     def test_short_mode_skips_guard_reject(self):
         self.assertFalse(should_reject_for_guards(False, eval_mode="short"))
+
+    def test_cb_ttft_regression_fails_gate(self):
+        # PR #591-shaped: 0.505s vs main 0.463s (−9.1%) must fail at 2% tol.
+        self.assertFalse(cb_ttft_guard_pass(0.505, 0.463, tol=0.98))
+
+    def test_cb_ttft_within_tol_passes(self):
+        # 1% worse latency is within 2% tol.
+        self.assertTrue(cb_ttft_guard_pass(0.4676, 0.463, tol=0.98))
+
+    def test_cb_ttft_improvement_passes(self):
+        # PR #584-shaped latest: 0.468s vs main 0.542s.
+        self.assertTrue(cb_ttft_guard_pass(0.468, 0.542, tol=0.98))
+
+    def test_cb_ttft_unmeasured_skips(self):
+        self.assertTrue(cb_ttft_guard_pass(0.0, 0.542))
+        self.assertTrue(cb_ttft_guard_pass(0.468, 0.0))
 
 
 if __name__ == "__main__":

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1130,9 +1130,25 @@ def render(res, oid):
                             f"{f' · {plbl}' if plbl else ''}) | {block.get('prefill_tps', '?')} pp tok/s"
                             f"{ttft_note}{src_note} · "
                             f"`eval-prefill:{block.get('prefill_label')}` |")
-                if block.get("cb_ttft_s") is not None and src != "cb":
+                if block.get("cb_ttft_s") is not None and block.get("cb_frontier_ttft_s") is not None:
                     cb_pct = block.get("cb_pct_over_frontier")
-                    cb_note = f" · TTFT −{cb_pct}%" if cb_pct is not None else ""
+                    if cb_pct is None:
+                        cb_note = ""
+                    elif cb_pct >= 0:
+                        cb_note = f" · TTFT −{cb_pct}%"
+                    else:
+                        cb_note = f" · TTFT +{abs(cb_pct)}% (regress)"
+                    gate = "pass" if block.get("guard_cb_ttft_pass", True) else "fail"
+                    rows.append(f"| {title} CB mixed TTFT no-regression gate | {block.get('cb_ttft_s')}s"
+                                f" vs main {block.get('cb_frontier_ttft_s')}s{cb_note} · {gate} |")
+                elif block.get("cb_ttft_s") is not None and src != "cb":
+                    cb_pct = block.get("cb_pct_over_frontier")
+                    if cb_pct is None:
+                        cb_note = ""
+                    elif cb_pct >= 0:
+                        cb_note = f" · TTFT −{cb_pct}%"
+                    else:
+                        cb_note = f" · TTFT +{abs(cb_pct)}% (regress)"
                     rows.append(f"| {title} CB mixed TTFT | {block.get('cb_ttft_s')}s"
                                 f" vs main {block.get('cb_frontier_ttft_s', '?')}s{cb_note} |")
             elif block.get("eval_prefill"):

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -34,7 +34,9 @@ IMAGE   = os.environ.get("EVAL_IMAGE", "nvidia/cuda:12.8.0-devel-ubuntu24.04")  
 TEMPLATE_HASH = os.environ.get("EVAL_TEMPLATE_HASH", "7f806603ccd0de9b7370266673c0a32d")
 SSH_KEY = os.path.expanduser(os.environ.get("SSH_KEY", "~/.ssh/id_ed25519"))
 # Bare-metal SSH boxes often have nvcc outside default PATH (non-interactive ssh).
-BOX_CUDA_ENV = "export PATH=/usr/local/cuda-12.8/bin:/usr/local/cuda/bin:$PATH; "
+# Prefer newest CUDA first (13.0 on current vast base images; 12.8 still common).
+BOX_CUDA_ENV = ("export PATH=/usr/local/cuda-13.0/bin:/usr/local/cuda-12.8/bin:"
+                "/usr/local/cuda/bin:$PATH; ")
 LLAMACPP_DIR = os.environ.get("LLAMACPP_DIR", "/workspace/.llamacpp")            # persists across stop/start
 INSTANCE_FILE = os.path.expanduser(os.environ.get("VAST_INSTANCE_FILE", "~/.sparkinfer_vast_instance"))  # self-healed id
 # IPs of hosts that repeatedly hang on image pull or never expose direct SSH, despite high vast


### PR DESCRIPTION
## Summary
- Add a CB mixed-load TTFT no-regression gate (same 2% tol as decode/pp): `cb_ttft > main/tol` → `eval:REJECT` + `regression-cb-ttft`, so single-seq pp gains cannot excuse a serving-path TTFT regression.
- Show CB TTFT as a pass/fail gate in eval comments; render latency regressions clearly.
- Harden eval infra: accuracy `/completion` retries on missing probs / HTTP 5xx, `ensure_sparkinfer` verifies runtime binaries after build, prefer CUDA 13.0 on boxes.

## Test plan
- [x] `python3 bench/scripts/test_guard_reject.py` (CB TTFT gate cases)
- [x] `python3 bench/scripts/test_cb_prefill_score.py`
- [ ] Re-eval a PR with CB TTFT regression → `eval:REJECT` + gate row `fail`
- [ ] Re-eval a PR with CB TTFT improvement (e.g. #584-shaped) → gate `pass`, prior label unchanged