### PR TITLE
fix(prefill): correct GDN chunk final-state gate for non-32-multiple prompts

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -352,7 +352,13 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         __syncthreads();
 
         // ---- U~[p] = exp(G_last - G_p) U^[p]  (tail rows already carry U^ = 0) ----
-        const float g_last = s_g[C - 1];               // == s_g[len-1]: tail log-gates are 0
+        // G_last is the chunk's final cumulative log-gate, at the last REAL token (index len-1).
+        // The prep kernel leaves the tail cumulative flat (so there s_g[C-1]==s_g[len-1]), but the
+        // load above stages THIS kernel's s_g tail as 0, so on a short final chunk (len < C) s_g[C-1]
+        // is 0, not G_last — which would set the state-carry decay exp(G_last) to 1 (no forgetting)
+        // and blow up U~ = exp(-G_p)U^ (overflow for the strongly-decaying gates here). Read len-1;
+        // for full chunks len==C so this is identical.
+        const float g_last = s_g[len - 1];
         for (int e = tid; e < C * JC; e += nthr) {
             const int i = e / JC;
             s_U[e] *= __expf(g_last - s_g[i]);


### PR DESCRIPTION
## Summary

Correctness fix for the chunk-parallel Gated-DeltaNet prefill scan (`pf_gdnc_scan_kernel` in `kernels/csrc/cuda/fused/prefill_gdn_chunk.cu`). The final recurrent state it writes for decode is wrong whenever the prompt length is **not a multiple of the chunk size `C` (= 32)** — i.e. for ~97% of prompt lengths. This is a pure correctness fix; it changes no shapes, no defaults, and no fast path.

## Root cause

Per chunk the scan needs `G_last` — the chunk's final cumulative log-gate — for the state update `S_out = exp(G_last)·S_in + Kᵀ·U~` and the tail scaling `U~[p] = exp(G_last − G_p)·U^[p]`.

It reads `g_last = s_g[C - 1]`. But this kernel stages the tail of `s_g` as `0` for a short final chunk:

```cpp
// per-chunk staging
s_g[i] = (i < len) ? g_buf[(t0 + i) * v_heads + h] : 0.f;   // tail -> 0
...
const float g_last = s_g[C - 1];   // == 0 when len < C, NOT G_last
```

The old comment (`== s_g[len-1]: tail log-gates are 0`) describes the **prep** kernel, where the cumulative prefix-sum stays flat across the zero-gate tail so `s_g[C-1] == s_g[len-1]`. That invariant does **not** hold here, because the scan kernel explicitly overwrites the tail of `s_g` with `0`. So on the last chunk of a prompt whose length isn't a multiple of 32, `s_g[C-1]` is `0` instead of the true last-real-token cumulative gate `s_g[len-1]` (a large negative value).

Effect on the state handed to decode (`s.lin_state`, consumed by `launch_qwen36_gdn_ar`):
- `exp(G_last)` becomes `exp(0) = 1` → the pre-chunk state is carried with **no decay** instead of `exp(G_last) ≈ 0`.
- `U~[p] = exp(g_last − G_p)·U^[p]` becomes `exp(−G_p)·U^[p] ≥ 1`, which **overflows to +Inf** for the strongly-decaying gates in this checkpoint (per-token log-gates reach −8 and below), producing NaN/Inf in the recurrent state.

Because only the last chunk can be partial and its output *is* the final prefill state, this silently corrupts the decode starting state for the 24 GDN layers on almost every non-aligned prompt. The sequential fallback scan (`pf_gdn_scan_kernel`) walks token-by-token and is unaffected — so this is a regression the chunk optimization introduced relative to the path it replaced.

## Fix

```diff
-        const float g_last = s_g[C - 1];               // == s_g[len-1]: tail log-gates are 0
+        const float g_last = s_g[len - 1];             // last REAL token's cumulative log-gate
```

`len ∈ [1, C]` for every chunk, so the index is always valid. For full chunks `len == C`, so the value is identical — **only the short final chunk changes behavior**, and it changes from wrong to correct.

## Impact

- Fixes the GDN recurrent state passed to decode for any Qwen3.5 (Qwythos) prompt with length not divisible by 32 and ≥ `SPARKINFER_PREFILL_GDN_CHUNK_MINCTX` (default 256) — the common case. Prevents NaN/garbage decode output on those prompts.
- No effect on prompts whose length is a multiple of 32 (the eval's fixed `--ctx 4096` is one such length), and no effect on the per-token prefill outputs `Y` (which never use `g_last`). The change is confined to the final-state computation.

## Risk / tradeoffs

- One-line functional change, no API/shape/default change, no new allocations. Confined to a single expression on the sequential-scan tail.
- Verified by re-deriving the chunk math and the data flow (`launch_prefill_gdn_scan` → `launch_prefill_gdn_chunk` → `s.lin_state` → `launch_qwen36_gdn_ar`). I was not able to run the on-device benchmark/accuracy harness (no RTX 5090 available to me), so I have deliberately **not** attached any speed claim — this is submitted purely as a correctness fix for maintainer review. An accuracy run that fuzzes prompt length (non-multiples of 32) should show the divergence before this change and none after.
