### PR TITLE
fix(prefill): causal bound on attention-sink keys in windowed prefill fallback

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -200,8 +200,11 @@ __global__ void win_prefill_windowed_kernel(
             __syncthreads();
             if (active) {
                 for (int kpos = k0; kpos < k0 + tk; kpos++) {
-                    // per-query membership: sink (block 0) OR recent window [my_rs, qtok]
-                    const bool insink = kpos < block_size;
+                    // per-query membership: sink (block 0) OR recent window [my_rs, qtok] — both causal.
+                    // The sink term must keep the kpos<=qtok bound too: without it, a query inside
+                    // block 0 (where my_rs==block_size makes inwin always false) would attend to the
+                    // whole of block 0, i.e. its own future tokens.
+                    const bool insink = (kpos < block_size) && (kpos <= qtok);
                     const bool inwin = (kpos >= my_rs) && (kpos <= qtok);
                     if (!insink && !inwin) continue;
                     const int kk = kpos - k0;
@@ -342,7 +345,7 @@ __global__ void win_prefill_lanepar_kernel(
 #pragma unroll
                 for (int i = 0; i < QPW; i++) {
                     if (WINDOWED) {
-                        const bool insink = kpos < block_size;
+                        const bool insink = (kpos < block_size) && (kpos <= qtok[i]);   // causal sink
                         const bool inwin = (kpos >= my_rs[i]) && (kpos <= qtok[i]);
                         in[i] = live && (insink || inwin) && (qtok[i] < n_tokens);
                     } else {


### PR DESCRIPTION
## Summary

Correctness fix for the sink + sliding-window prefill attention kernels in `kernels/csrc/cuda/fused/prefill_attn_window.cu`. The attention-**sink** membership term was applied without a causal bound, so a query inside block 0 attended to its own future tokens. This is a pure correctness fix — no shapes, defaults, or fast paths change.

## Root cause

Both windowed kernels admit a key when `insink || inwin`:

```cpp
const bool insink = kpos < block_size;                 // NO causal bound
const bool inwin  = (kpos >= my_rs) && (kpos <= qtok); // causal
if (!insink && !inwin) continue;
```

The window term is causal (`kpos <= qtok`), but the sink term is only `kpos < block_size`. For a query **inside block 0**, `win_start(qtok)` returns `block_size` (`n_blk_q == 1 → rsb == 1`), so `inwin` is *always false* for that query — causality then rests entirely on `insink`, which has no `kpos <= qtok` bound. Result: every query at position `p < block_size` attends to **all** of block 0 (keys `0..block_size-1`), i.e. its own future tokens. Query 0, which should see only key 0, instead gets a softmax blend over keys `0..15` (with `block_size == 16`). This corrupts the first `block_size` tokens (including BOS) at every hd256 full-attention layer, and the error propagates downstream.

Affected kernels:
- `win_prefill_windowed_kernel` (line ~204)
- `win_prefill_lanepar_kernel`, `WINDOWED` arm (line ~345)

(The non-windowed arm, `in[i] = live && (kpos <= qtok[i]) && …`, and the `win_prefill_tiled_kernel` (`klim = min(k0+tk, qtok+1)`) are already causal and unaffected.)

## Fix

Add the causal bound to the sink term in both kernels, so the mask is `causal AND (sink OR window)` — exactly what the default MMA path (`pf_attn_mma_i8_kernel`) already does:

```diff
- const bool insink = kpos < block_size;
+ const bool insink = (kpos < block_size) && (kpos <= qtok);      // windowed kernel
```
```diff
- const bool insink = kpos < block_size;
+ const bool insink = (kpos < block_size) && (kpos <= qtok[i]);   // lanepar kernel
```

For any query past block 0, `kpos < block_size` already implies `kpos <= qtok`, so this changes **only** block-0 queries — from non-causal to causal.

## Scope / severity (honest)

This affects the **fallback** windowed kernels, not the default path. With the default KV `block_size == 16`, the int8 tensor-core MMA path (`launch_prefill_attn_mma`, default on, `MINCTX == 0`) handles hd256 prefill and is causally correct, so `launch_prefill_attn_windowed` is reached only when the MMA path is disabled (`SPARKINFER_PREFILL_ATTN_MMA=0`) or the block size isn't 16. It's still a real causality violation in these kernels, and the fallbacks should match the MMA path's correctness — so this hardens them to be safe whenever they are selected.

## Risk / tradeoffs

- Two-line functional change; no API/shape/default change, no new allocations. Purely tightens a mask condition.
- Verified by re-deriving `win_start` for block-0 queries and confirming the fix is a no-op for all queries at position ≥ `block_size`.
- I did not have an RTX 5090 to run the on-device harness, so I've attached **no** speed claim — submitted purely as a correctness fix for maintainer review. An accuracy run that includes the first `block_size` query positions on an hd256 layer with `SPARKINFER_PREFILL_ATTN_MMA=0` should show the divergence before this change and none after.
