### PR TITLE
fix(server): valid completions rejected with another request's error under concurrency

### DIFF
--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -38,13 +38,19 @@ public:
     std::vector<int> complete_streaming(const std::vector<int>& prompt_ids, int max_new_tokens,
                                         const std::function<void(int)>& on_token);
 
+    // Failure from the calling thread's most recent complete()/complete_streaming().
+    // Per-thread by design: the HTTP server serves requests from a thread pool and the
+    // continuous-batch engine keeps several of them in flight at once, so a shared slot
+    // would let one request clear or observe another request's error.
     const std::string& last_error() const;
 
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
     mutable std::mutex mu_;
-    std::string last_error_;
+
+    // Per-thread failure slot backing last_error().
+    static std::string& error_slot();
 };
 
 }  // namespace sparkinfer_server

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -172,9 +172,18 @@ int ModelEngine::prefix_token_len() const {
     return (int)impl_->prefix_tokens.size();
 }
 
+std::string& ModelEngine::error_slot() {
+    // Thread-local: complete_streaming() releases mu_ while the continuous-batch engine runs,
+    // so several requests are in flight at once. One shared string would let them clear each
+    // other's error, report a foreign one, and hand last_error() a reference that another
+    // thread reallocates underneath the caller. cudaGetLastError() is already per host thread,
+    // so this keeps the whole failure path consistently per-request.
+    static thread_local std::string err;
+    return err;
+}
+
 const std::string& ModelEngine::last_error() const {
-    std::lock_guard<std::mutex> lock(mu_);
-    return last_error_;
+    return error_slot();
 }
 
 std::vector<int> ModelEngine::complete(const std::vector<int>& prompt_ids, int max_new_tokens) {
@@ -190,22 +199,22 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
 
     {
         std::lock_guard<std::mutex> lock(mu_);
-        last_error_.clear();
+        error_slot().clear();
         if (!impl_->ready || !impl_->model || !impl_->batch_engine) {
-            last_error_ = "model not loaded";
+            error_slot() = "model not loaded";
             return {};
         }
         if (prompt_ids.empty()) {
-            last_error_ = "empty prompt";
+            error_slot() = "empty prompt";
             return {};
         }
         if (max_new_tokens <= 0) {
-            last_error_ = "max_new_tokens must be positive";
+            error_slot() = "max_new_tokens must be positive";
             return {};
         }
         if ((int)prompt_ids.size() + max_new_tokens > impl_->cfg.max_seq) {
-            last_error_ = "prompt + max_tokens exceeds context limit (" +
-                          std::to_string(impl_->cfg.max_seq) + ")";
+            error_slot() = "prompt + max_tokens exceeds context limit (" +
+                           std::to_string(impl_->cfg.max_seq) + ")";
             fprintf(stderr, "[sparkinfer-server] context overflow: prompt=%zu max_new=%d max_seq=%d\n",
                     prompt_ids.size(), max_new_tokens, impl_->cfg.max_seq);
             return {};
@@ -218,8 +227,8 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
         if (prefix_match && prefix_exclusive) {
             if (impl_->model->prefix_cached_len() != (int)impl_->prefix_tokens.size()) {
                 if (!impl_->model->cache_prefix(impl_->prefix_tokens)) {
-                    last_error_ = "cache_prefix failed (KV alloc or batched prefill)";
-                    fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
+                    error_slot() = "cache_prefix failed (KV alloc or batched prefill)";
+                    fprintf(stderr, "[sparkinfer-server] %s\n", error_slot().c_str());
                     return {};
                 }
             }
@@ -236,19 +245,19 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
 
     std::lock_guard<std::mutex> lock(mu_);
     if (!result.error.empty()) {
-        last_error_ = result.error;
-        fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
+        error_slot() = result.error;
+        fprintf(stderr, "[sparkinfer-server] %s\n", error_slot().c_str());
         return {};
     }
 
     cudaError_t e = cudaGetLastError();
     if (e != cudaSuccess) {
-        last_error_ = std::string("cuda error after decode: ") + cudaGetErrorString(e);
-        fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
+        error_slot() = std::string("cuda error after decode: ") + cudaGetErrorString(e);
+        fprintf(stderr, "[sparkinfer-server] %s\n", error_slot().c_str());
         return {};
     }
     if (result.tokens.empty() && max_new_tokens > 0)
-        last_error_ = "generate returned no tokens (KV alloc failure?)";
+        error_slot() = "generate returned no tokens (KV alloc failure?)";
     return result.tokens;
 }
 


### PR DESCRIPTION
## Summary

`sparkinfer_server` can answer a **valid** completion with `HTTP 400` and someone else's
error message whenever two requests are in flight. `ModelEngine` keeps one shared
`last_error_` string, but continuous batching made concurrent requests the normal case.

*(No proof-of-speedup section: this is a correctness fix in `server/`, it does not touch
`kernels/`, `runtime/` or `moe/` and makes no speed claim, so there is nothing for the
on-device eval to grade.)*

## Root cause

`ModelEngine::complete_streaming()` used to hold `mu_` for the whole generation, which
serialized requests and made a single shared error slot safe. Commit `0b47334`
("Integrate continuous batching with per-request KV sessions for serving") deliberately
**releases `mu_` around `ContinuousBatchEngine::complete_streaming()`** so several
requests decode at once — but `last_error_` stayed a single shared member.

`httplib::Server` dispatches from a thread pool (`CPPHTTPLIB_THREAD_POOL_COUNT`), so the
interleaving below is routine:

| thread A (valid request) | thread B (e.g. context overflow) |
|---|---|
| `error_slot().clear()`, unlock | |
| *…decoding, `mu_` released…* | `last_error_ = "prompt + max_tokens exceeds context limit (…)"` |
| generation finishes, no error | returns 400 (correct for B) |
| `if (!engine.last_error().empty())` → **sees B's error** | |
| **returns 400 and discards A's tokens** | |

Two distinct defects fall out of the shared slot:

1. **Cross-request corruption** — `server/src/sparkinfer_server.cpp:355` (and `:327` on the
   SSE path) reads `engine.last_error()` after its *own* completion, so a good response is
   dropped and replaced with another request's failure. The reverse also happens: A's
   `clear()` wipes B's error, and B then reports success or the generic
   "generate returned no tokens" instead of the real cause. The leaked message also carries
   another caller's prompt/`max_tokens` sizes.
2. **Reference escaping the lock** — `last_error()` took `mu_`, returned
   `const std::string&`, then released `mu_` before the caller touched the string. A
   concurrent assignment reallocates that buffer (SSO → heap), so `json_escape(...)` can read
   freed memory. Undefined behaviour, not just a wrong message.

Files: `server/include/model_engine.hpp`, `server/src/model_engine.cpp`.

## Fix

Make the failure slot **thread-local** — the smallest change that makes the error state
per-request:

```cpp
std::string& ModelEngine::error_slot() {
    static thread_local std::string err;
    return err;
}
const std::string& ModelEngine::last_error() const { return error_slot(); }
```

Each request writes and reads only its own slot, and the reference `last_error()` hands back
is mutated solely by the thread reading it. This matches how the rest of the failure path
already behaves — `cudaGetLastError()` is per host thread — and it fits the ownership model:
a request runs `complete()`/`complete_streaming()` and reads `last_error()` on the same
httplib worker thread (the chunked content provider runs on that thread too).

`last_error()` no longer needs `mu_`, so an error read also stops contending with an
in-flight generation.

## Reproduction

Standalone harness mirroring `complete_streaming()`'s lock/unlock/lock control flow and the
handler's `if (!engine.last_error().empty())` check — 4 valid + 4 failing requests in flight,
200 rounds:

```
BEFORE   valid completions rejected with a foreign error: 800 / 800
AFTER    valid completions rejected with a foreign error: 0 / 800
```

## Impact & risk

- **Impact:** under any concurrency — exactly what continuous batching exists for — valid
  completions stop being dropped with a foreign 400, real errors stop being swallowed, one
  caller's error text stops leaking to another, and the use-after-free window is closed.
- **Risk:** low. Two files, no behaviour change for a single-threaded client, public API and
  every call site unchanged (`last_error()` keeps its signature). No new dependency, no
  allocation on the hot path, and nothing here can move decode/prefill throughput.
- **Tradeoff:** the error is now scoped to the calling thread rather than the process. That is
  the intended semantics for a per-request API; a caller wanting the *server's* last error
  regardless of thread would need a different accessor, and none exists today.
