### PR TITLE
fix(server): one chat request can hang the server forever; multimodal prompts reach the model as "text"

### DIFF
--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -229,15 +229,21 @@ bool parse_chat_messages(const std::string& request_json, std::vector<ChatMessag
                     // Multimodal: concatenate text parts only (images skipped for now).
                     size_t j = c;
                     while (j < obj.size()) {
-                        size_t text_key = obj.find("\"text\"", j);
-                        if (text_key == std::string::npos || text_key >= obj.size()) break;
-                        size_t dummy = 0;
+                        const size_t text_key = obj.find("\"text\"", j);
+                        if (text_key == std::string::npos) break;
+                        // Always past the match we just found, so the scan cannot rewind.
+                        j = text_key + 6;
+                        // Only a "text" KEY carries a part's payload; the "text" in
+                        // {"type":"text",...} is a value and must not be read as one.
+                        size_t v = j;
+                        while (v < obj.size() && (obj[v] == ':' || obj[v] == ' ')) v++;
+                        if (v == j || v >= obj.size() || obj[v] != '"') continue;
+                        size_t part_end = 0;
                         std::string piece;
-                        if (extract_json_string(obj, text_key + 6, dummy, piece)) {
-                            if (!msg.content.empty()) msg.content.push_back(' ');
-                            msg.content += piece;
-                        }
-                        j = dummy;
+                        if (!extract_json_string(obj, v, part_end, piece)) break;
+                        if (!msg.content.empty()) msg.content.push_back(' ');
+                        msg.content += piece;
+                        j = part_end;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

One `POST /v1/chat/completions` body hangs a `sparkinfer_server` worker thread forever and
grows a `std::string` until the process is OOM-killed. The same 12-line loop also feeds the
model the literal word `text` instead of the user's message on **every** OpenAI
content-parts request.

*(No proof-of-speedup section: this is a correctness fix in `server/`, it does not touch
`kernels/`, `runtime/` or `moe/` and makes no speed claim, so there is nothing for the
on-device eval to grade.)*

## Root cause

`parse_chat_messages()` — `server/src/chat_tokenizer.cpp:228-242` — walks a message object
looking for `"text"` parts with a bare substring search:

```cpp
size_t j = c;
while (j < obj.size()) {
    size_t text_key = obj.find("\"text\"", j);
    if (text_key == std::string::npos || text_key >= obj.size()) break;
    size_t dummy = 0;                                   // reset every iteration
    std::string piece;
    if (extract_json_string(obj, text_key + 6, dummy, piece)) {
        if (!msg.content.empty()) msg.content.push_back(' ');
        msg.content += piece;
    }
    j = dummy;                                          // written only on success
}
```

**1. Unbounded loop (remote DoS).** `dummy` is only assigned when `extract_json_string()`
succeeds, but `j = dummy` runs unconditionally. If the last `"text"` occurrence in the object
has no string value after it, extraction fails, `dummy` is still `0`, and the scan **rewinds
to offset 0**. `obj.find` then returns the same earlier match, which parses fine, and the loop
runs forever — appending to `msg.content` on every pass. One request pins an httplib worker
thread at 100% CPU and grows the string until the process is OOM-killed; repeat it once per
pool thread and the server is gone. It is reached before any inference work, on both
`/v1/chat/completions` and `/v1/tokenize`, and needs no API key when the server runs without
`--api-key` (the default in `server/run.sh`).

A body that triggers it — a sibling key whose *value* is `text`:

```json
{"messages":[{"role":"user","content":[{"type":"text","text":"a"}],"k":"text"}]}
```

**2. Dropped user text.** `find("\"text\"")` matches the **value** in `{"type":"text",…}`
before it ever reaches the `"text"` key. Extraction then starts just past that value and picks
up the *following* `"text"` key as its payload — so `msg.content` becomes the literal string
`text`. Every request using OpenAI's content-parts format (what the OpenAI SDKs emit as soon
as a message has more than plain text) silently sends the model `text` instead of the prompt.

## Fix

Match a `"text"` **key** — an occurrence followed by `:` and a string — instead of any
occurrence, and advance `j` past every match on all paths so the scan is strictly monotonic
and always terminates. This mirrors how the plain-`"content"` branch directly above already
skips `:` and spaces before reading its value.

## Validation

Test harness driving the real `parse_chat_messages()` from this file (the rest of
`chat_tokenizer.cpp` is compiled as-is; only the `tokenizers_cpp` dependency is stubbed, and
it is not on this path), with a `SIGALRM` watchdog:

```
BEFORE (main)                                  AFTER (this PR)
  [ok]   plain string content   "hi"             [ok] plain string content   "hi"
  [FAIL] one text part          "text"           [ok] one text part          "hi"
  [FAIL] two text parts         "text text"      [ok] two text parts         "one two"
  [FAIL] image part skipped     "text"           [ok] image part skipped     "describe"
  [FAIL] escaped quotes         "text"           [ok] escaped quotes         "say \"hi\" now"
  -> HUNG (watchdog fired)                       [ok] trailing bare "text"   "a"
                                                 [ok] no text part           ""
                                                 [ok] empty content array    ""
                                                 [ok] truncation fuzz — 107 prefixes, none hung
```

The fuzz row feeds every prefix of a valid multimodal body through the parser to confirm no
truncation reaches a non-terminating path. Compiles clean under `-Wall -Wextra`.

## Impact & risk

- **Impact:** removes an unauthenticated single-request hang/OOM of the whole server, and
  restores the actual user prompt for content-parts requests, which today reach the model as
  the word `text`.
- **Risk:** low. One file, one loop, no signature or API change. Plain-string `content` is
  untouched. The only behaviour change for existing multimodal callers is that they now get
  their real text — output for those requests will change, because it was wrong.
- **Tradeoff:** this keeps the file's hand-rolled scanner rather than introducing a JSON
  dependency, matching the "avoid extra deps on this branch" note in
  `server/src/sparkinfer_server.cpp`. The scanner remains best-effort for other malformed
  shapes; the guarantee added here is that it always terminates and never rewinds.
