### PR TITLE
fix(prefill): stop GDN chunk prep OOB on partial final chunks

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -205,8 +205,12 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
     }
 
     // ---- W^ = T . (b_m exp(G_m) k_m) ----
+    // w_buf/u_buf are sized to n_tokens (not n_chunks*C). On a short final chunk only the live
+    // rows are valid addresses — writing the padded tail (i >= len) overruns into/past u_buf
+    // and faults (IMA at e.g. prompt lengths 289..301). Scan already treats i >= len as zero.
     for (int e = tid; e < C * HD; e += nthr) {
         const int i = e / HD, d = e - i * HD;
+        if (i >= len) continue;
         float acc = 0.f;
         for (int m = 0; m <= i; m++)
             acc += s_A[i * (C + PAD) + m] * (s_b[m] * __expf(s_g[m]) * gc_to_f(s_k[m * (HD + PAD) + d]));
@@ -222,6 +226,7 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
     __syncthreads();
     for (int e = tid; e < C * HD; e += nthr) {
         const int i = e / HD, d = e - i * HD;
+        if (i >= len) continue;
         float acc = 0.f;
         for (int m = 0; m <= i; m++)
             acc += s_A[i * (C + PAD) + m] * (s_b[m] * gc_to_f(s_x[m * (HD + PAD) + d]));


### PR DESCRIPTION
## Summary
- `pf_gdnc_prep_kernel` wrote `W^` / `U0` for all `C=32` rows of every chunk, but `w_buf` / `u_buf` are allocated for `n_tokens` only.
- On a short final chunk (`len < C`), padded rows wrote past the buffers → CUDA IMA and `prefill_check` TOP1 0 (reproduced at prompt lengths ~289–301).
- Skip stores when `i >= len`; the scan already stages those rows as zero. Complements #604 (`g_last` fix), which did not address this overrun.

## Test plan
- [x] RTX 5090 `qwen3_gguf_prefill_check` (Qwythos Q4_K_M, chunk ON, int8 KV):
  - P=289, 296, **300**, 301: was IMA / TOP1 0 → now **16/16**, no IMA
  - P=288, 302, 304, 512, 513, 1031: still healthy (no regression)
- [ ] Eval bot accuracy / H3 on a non-÷32 prefix once merged (optional follow-up: fuzz `PFCHECK_N`)