### PR TITLE
perf(qwen36): fast Q5_K gather dequant for MoE down cols=512 (+8.7% pp @512)

### DIFF
--- a/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
+++ b/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
@@ -21,7 +21,7 @@
 //
 // THE FIX. Give each thread VEC=4 CONSECUTIVE values instead of one, so a thread stores a 4-byte
 // word and a warp writes 128 contiguous bytes. 256 threads x 4 = 1024 values per group; the row is
-// walked in cols/1024 groups. Since a thread's 4 values are 4-aligned, they always fall inside one
+// walked in ceil(cols/1024) groups (cols=512 uses one partial group). Since a thread's 4 values are 4-aligned, they always fall inside one
 // super-block, so the decode still reads a single block header per value-quad. The decoded row is
 // also kept in registers (VEC * NG floats: 16 for a 4096-wide row, 48 for a 12288-wide one — 48*256
 // = 12288 regs/block, still 5 blocks/SM), which costs nothing now and removes the second decode.
@@ -41,7 +41,7 @@ namespace kernels {
 
 namespace {
 
-enum { DQR_Q4_K = 12, DQR_Q6_K = 14 };
+enum { DQR_Q4_K = 12, DQR_Q5_K = 13, DQR_Q6_K = 14 };
 
 // --- decode helpers: byte-for-byte the ones in dequant_gguf.cu ---
 __device__ __forceinline__ float dqr_h2f(const unsigned char* p) {
@@ -63,6 +63,25 @@ __device__ __forceinline__ float dqr_q4k_val(const unsigned char* blk, int t) {
     }
     return d * s * nib - dmin * m;
 }
+
+__device__ __forceinline__ float dqr_q5k_val(const unsigned char* blk, int t) {
+    const float d = dqr_h2f(blk), dmin = dqr_h2f(blk + 2);
+    const unsigned char* sc = blk + 4; const unsigned char* qh = blk + 16;
+    const unsigned char* ql = blk + 48;
+    const int j64 = t >> 6, r = t & 63, l = r & 31, hi = r >> 5;
+    const unsigned char byte = ql[j64 * 32 + l];
+    const int nib = hi ? (byte >> 4) : (byte & 0xF);
+    const int hbit = (qh[l] >> (2 * j64 + hi)) & 1;
+    // 6-bit packed scale/min unpack (same as Q4_K / deq_q5k_val in dequant_gguf.cu).
+    const int j = 2 * j64 + hi;
+    int s, m;
+    if (j < 4) { s = sc[j] & 63; m = sc[j + 4] & 63; }
+    else {
+        s = (sc[j + 4] & 0xF) | ((sc[j - 4] >> 6) << 4);
+        m = (sc[j + 4] >> 4)  | ((sc[j]     >> 6) << 4);
+    }
+    return d * s * (nib + (hbit ? 16 : 0)) - dmin * m;
+}
 __device__ __forceinline__ float dqr_q6k_val(const unsigned char* blk, int t) {
     const int half = t >> 7, r = t & 127, quad = r >> 5, l = r & 31;
     const unsigned char* ql = blk + half * 64;
@@ -78,6 +97,20 @@ __device__ __forceinline__ float dqr_q6k_val(const unsigned char* blk, int t) {
     return d * sc[is + 2 * quad] * qv;
 }
 
+
+template <int QT>
+__device__ __forceinline__ constexpr int dqr_bs() {
+    if constexpr (QT == DQR_Q4_K) return 144;
+    else if constexpr (QT == DQR_Q5_K) return 176;
+    else return 210;
+}
+template <int QT>
+__device__ __forceinline__ float dqr_val(const unsigned char* blk, int t) {
+    if constexpr (QT == DQR_Q4_K) return dqr_q4k_val(blk, t);
+    else if constexpr (QT == DQR_Q5_K) return dqr_q5k_val(blk, t);
+    else return dqr_q6k_val(blk, t);
+}
+
 constexpr int DQR_BLOCK = 256, DQR_VEC = 4;   // 4 consecutive values/thread => 4B store, 128B/warp
 
 // One block per row; NG groups of DQR_BLOCK*DQR_VEC values each.
@@ -85,7 +118,7 @@ template <int QT, int NG>
 __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_kernel(
         const unsigned char* __restrict__ src, signed char* __restrict__ q,
         float* __restrict__ scale, int cols) {
-    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int BS = dqr_bs<QT>();
     constexpr int GSPAN = DQR_BLOCK * DQR_VEC;               // values per group
     const int row = blockIdx.x, t = threadIdx.x;
     const int nsb = cols >> 8;
@@ -101,7 +134,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_kernel(
             const int off = base & 255;
             #pragma unroll
             for (int i = 0; i < DQR_VEC; i++) {
-                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                v[g][i] = dqr_val<QT>(blk, off + i);
                 amax = fmaxf(amax, fabsf(v[g][i]));
             }
         }
@@ -140,7 +173,8 @@ template <int QT>
 bool dispatch(const unsigned char* s, signed char* q, float* scale, int rows, int cols,
               cudaStream_t stream) {
     const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
-    if (ng <= 4)       deq_rows_i8_vec_kernel<QT, 4><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
+    if (ng <= 1)       deq_rows_i8_vec_kernel<QT, 1><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
+    else if (ng <= 4)  deq_rows_i8_vec_kernel<QT, 4><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
     else if (ng <= 8)  deq_rows_i8_vec_kernel<QT, 8><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
     else if (ng <= 12) deq_rows_i8_vec_kernel<QT, 12><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
     else return false;                                   // wider than the register budget
@@ -153,7 +187,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_pair_kernel(
         const unsigned char* __restrict__ src0, signed char* __restrict__ q0, float* __restrict__ scale0,
         const unsigned char* __restrict__ src1, signed char* __restrict__ q1, float* __restrict__ scale1,
         int rows, int cols) {
-    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int BS = dqr_bs<QT>();
     constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
     const int which = (int)(blockIdx.x / (unsigned)rows);
     const int row = (int)(blockIdx.x - (unsigned)which * (unsigned)rows);
@@ -175,7 +209,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_pair_kernel(
             const int off = base & 255;
             #pragma unroll
             for (int i = 0; i < DQR_VEC; i++) {
-                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                v[g][i] = dqr_val<QT>(blk, off + i);
                 amax = fmaxf(amax, fabsf(v[g][i]));
             }
         }
@@ -227,13 +261,14 @@ bool dispatch_pair(const unsigned char* s0, signed char* q0, float* sc0,
 }
 
 // Sparse gather: blockIdx.x = live_i * rows_per_expert + row_in_expert.
-template <int QT, int NG>
-__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_gather_kernel(
+// BLOCK defaults to 256; cols=512 uses BLOCK=128 so 128*4 covers the row with no idle threads.
+template <int QT, int NG, int BLOCK = DQR_BLOCK>
+__global__ __launch_bounds__(BLOCK) void deq_rows_i8_vec_gather_kernel(
         const unsigned char* __restrict__ src0, signed char* __restrict__ q0,
         float* __restrict__ scale0, const int* __restrict__ live_le,
         int rows_per_expert, int cols, size_t expert_bytes) {
-    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
-    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
+    constexpr int BS = dqr_bs<QT>();
+    constexpr int GSPAN = BLOCK * DQR_VEC;
     const int live_i = (int)(blockIdx.x / (unsigned)rows_per_expert);
     const int row_in = (int)(blockIdx.x - (unsigned)live_i * (unsigned)rows_per_expert);
     const int le = live_le[live_i];
@@ -254,19 +289,19 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_gather_kernel(
             const int off = base & 255;
             #pragma unroll
             for (int i = 0; i < DQR_VEC; i++) {
-                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                v[g][i] = dqr_val<QT>(blk, off + i);
                 amax = fmaxf(amax, fabsf(v[g][i]));
             }
         }
     }
 
-    __shared__ float swarp[DQR_BLOCK / 32];
+    __shared__ float swarp[BLOCK / 32];
     #pragma unroll
     for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
     if ((t & 31) == 0) swarp[t >> 5] = amax;
     __syncthreads();
     if (t < 32) {
-        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        float w = (t < BLOCK / 32) ? swarp[t] : 0.f;
         #pragma unroll
         for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
         if (t == 0) swarp[0] = w;
@@ -294,7 +329,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_gather_pair_kernel(
         const unsigned char* __restrict__ src1, signed char* __restrict__ q1, float* __restrict__ scale1,
         const int* __restrict__ live_le, int n_rows, int rows_per_expert, int cols,
         size_t expert_bytes0, size_t expert_bytes1) {
-    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int BS = dqr_bs<QT>();
     constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
     const int which = (int)(blockIdx.x / (unsigned)n_rows);
     const int flat = (int)(blockIdx.x - (unsigned)which * (unsigned)n_rows);
@@ -322,7 +357,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_gather_pair_kernel(
             const int off = base & 255;
             #pragma unroll
             for (int i = 0; i < DQR_VEC; i++) {
-                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                v[g][i] = dqr_val<QT>(blk, off + i);
                 amax = fmaxf(amax, fabsf(v[g][i]));
             }
         }
@@ -360,9 +395,18 @@ template <int QT>
 bool dispatch_gather(const unsigned char* src0, signed char* q0, float* scale0,
                      const int* live_le, int n_live, int rows_per_expert, int cols,
                      size_t expert_bytes, cudaStream_t stream) {
-    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
     const int grid = n_live * rows_per_expert;
-    if (ng <= 4)
+    // MoE down (cols=512): 128 threads x 4 = full row, no idle half-block.
+    if (cols == 512) {
+        deq_rows_i8_vec_gather_kernel<QT, 1, 128><<<grid, 128, 0, stream>>>(
+            src0, q0, scale0, live_le, rows_per_expert, cols, expert_bytes);
+        return true;
+    }
+    const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
+    if (ng <= 1)
+        deq_rows_i8_vec_gather_kernel<QT, 1><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, live_le, rows_per_expert, cols, expert_bytes);
+    else if (ng <= 4)
         deq_rows_i8_vec_gather_kernel<QT, 4><<<grid, DQR_BLOCK, 0, stream>>>(
             src0, q0, scale0, live_le, rows_per_expert, cols, expert_bytes);
     else if (ng <= 8)
@@ -405,7 +449,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_mask_kernel(
         const unsigned char* __restrict__ src0, signed char* __restrict__ q0,
         float* __restrict__ scale0, const int* __restrict__ counts,
         int e_base, int n_in, int rows_per_expert, int cols, size_t expert_bytes) {
-    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int BS = dqr_bs<QT>();
     constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
     const int flat = (int)blockIdx.x;
     const int le = flat / rows_per_expert;
@@ -428,7 +472,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_mask_kernel(
             const int off = base & 255;
             #pragma unroll
             for (int i = 0; i < DQR_VEC; i++) {
-                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                v[g][i] = dqr_val<QT>(blk, off + i);
                 amax = fmaxf(amax, fabsf(v[g][i]));
             }
         }
@@ -468,7 +512,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_mask_pair_kernel(
         const unsigned char* __restrict__ src1, signed char* __restrict__ q1, float* __restrict__ scale1,
         const int* __restrict__ counts, int e_base, int n_in, int rows_per_expert, int cols,
         size_t expert_bytes0, size_t expert_bytes1) {
-    constexpr int BS = (QT == DQR_Q4_K) ? 144 : 210;
+    constexpr int BS = dqr_bs<QT>();
     constexpr int GSPAN = DQR_BLOCK * DQR_VEC;
     const int n_flat = n_in * rows_per_expert;
     const int which = (int)(blockIdx.x / (unsigned)n_flat);
@@ -497,7 +541,7 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_mask_pair_kernel(
             const int off = base & 255;
             #pragma unroll
             for (int i = 0; i < DQR_VEC; i++) {
-                v[g][i] = (QT == DQR_Q4_K) ? dqr_q4k_val(blk, off + i) : dqr_q6k_val(blk, off + i);
+                v[g][i] = dqr_val<QT>(blk, off + i);
                 amax = fmaxf(amax, fabsf(v[g][i]));
             }
         }
@@ -537,7 +581,10 @@ bool dispatch_mask(const unsigned char* src0, signed char* q0, float* scale0,
                    size_t expert_bytes, cudaStream_t stream) {
     const int ng = (cols + DQR_BLOCK * DQR_VEC - 1) / (DQR_BLOCK * DQR_VEC);
     const int grid = n_in * rows_per_expert;
-    if (ng <= 4)
+    if (ng <= 1)
+        deq_rows_i8_vec_mask_kernel<QT, 1><<<grid, DQR_BLOCK, 0, stream>>>(
+            src0, q0, scale0, counts, e_base, n_in, rows_per_expert, cols, expert_bytes);
+    else if (ng <= 4)
         deq_rows_i8_vec_mask_kernel<QT, 4><<<grid, DQR_BLOCK, 0, stream>>>(
             src0, q0, scale0, counts, e_base, n_in, rows_per_expert, cols, expert_bytes);
     else if (ng <= 8)
@@ -581,11 +628,13 @@ bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed cha
         const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
         return (e && e[0] == '0') ? 0 : 1;
     }();
-    // cols % 1024 keeps every thread's 4-value quad inside one super-block and 4-byte aligned.
+    // Full-row / bulk path: require a full 1024-wide group so no threads idle. Partial widths
+    // (MoE down cols=512) use the gather/mask launchers below.
     if (!enabled || rows <= 0 || cols <= 0 || (cols % (DQR_BLOCK * DQR_VEC)) != 0) return false;
 
     auto s = reinterpret_cast<const unsigned char*>(src);
     if (ggml_type == DQR_Q4_K) return dispatch<DQR_Q4_K>(s, q, scale, rows, cols, stream);
+    if (ggml_type == DQR_Q5_K) return dispatch<DQR_Q5_K>(s, q, scale, rows, cols, stream);
     if (ggml_type == DQR_Q6_K) return dispatch<DQR_Q6_K>(s, q, scale, rows, cols, stream);
     return false;
 }
@@ -603,6 +652,8 @@ bool launch_gguf_dequant_rows_i8_fast_pair(int ggml_type,
     auto s1 = reinterpret_cast<const unsigned char*>(src1);
     if (ggml_type == DQR_Q4_K)
         return dispatch_pair<DQR_Q4_K>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
+    if (ggml_type == DQR_Q5_K)
+        return dispatch_pair<DQR_Q5_K>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
     if (ggml_type == DQR_Q6_K)
         return dispatch_pair<DQR_Q6_K>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
     return false;
@@ -616,12 +667,17 @@ bool launch_gguf_dequant_rows_i8_fast_gather(
         const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
         return (e && e[0] == '0') ? 0 : 1;
     }();
+    // Live-expert gather: allow cols=512 (Qwen3.6 MoE down Q5_K). Partial GSPAN is
+    // base<cols-guarded; idle threads only hurt when dequanting the full expert stack.
     if (!enabled || !live_le || n_live <= 0 || rows_per_expert <= 0 || cols <= 0 ||
-        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        (cols & 255) != 0)
         return false;
     auto s = reinterpret_cast<const unsigned char*>(src0);
     if (ggml_type == DQR_Q4_K)
         return dispatch_gather<DQR_Q4_K>(s, q0, scale0, live_le, n_live, rows_per_expert, cols,
+                                         expert_bytes, stream);
+    if (ggml_type == DQR_Q5_K)
+        return dispatch_gather<DQR_Q5_K>(s, q0, scale0, live_le, n_live, rows_per_expert, cols,
                                          expert_bytes, stream);
     if (ggml_type == DQR_Q6_K)
         return dispatch_gather<DQR_Q6_K>(s, q0, scale0, live_le, n_live, rows_per_expert, cols,
@@ -640,12 +696,16 @@ bool launch_gguf_dequant_rows_i8_fast_gather_pair(
         return (e && e[0] == '0') ? 0 : 1;
     }();
     if (!enabled || !live_le || n_live <= 0 || rows_per_expert <= 0 || cols <= 0 ||
-        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        (cols & 255) != 0)
         return false;
     auto s0 = reinterpret_cast<const unsigned char*>(src0);
     auto s1 = reinterpret_cast<const unsigned char*>(src1);
     if (ggml_type == DQR_Q4_K)
         return dispatch_gather_pair<DQR_Q4_K>(s0, q0, scale0, s1, q1, scale1, live_le, n_live,
+                                              rows_per_expert, cols, expert_bytes0, expert_bytes1,
+                                              stream);
+    if (ggml_type == DQR_Q5_K)
+        return dispatch_gather_pair<DQR_Q5_K>(s0, q0, scale0, s1, q1, scale1, live_le, n_live,
                                               rows_per_expert, cols, expert_bytes0, expert_bytes1,
                                               stream);
     if (ggml_type == DQR_Q6_K)
@@ -664,11 +724,14 @@ bool launch_gguf_dequant_rows_i8_fast_mask(
         return (e && e[0] == '0') ? 0 : 1;
     }();
     if (!enabled || !counts || n_in <= 0 || rows_per_expert <= 0 || cols <= 0 ||
-        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        (cols & 255) != 0)
         return false;
     auto s = reinterpret_cast<const unsigned char*>(src0);
     if (ggml_type == DQR_Q4_K)
         return dispatch_mask<DQR_Q4_K>(s, q0, scale0, counts, e_base, n_in, rows_per_expert, cols,
+                                       expert_bytes, stream);
+    if (ggml_type == DQR_Q5_K)
+        return dispatch_mask<DQR_Q5_K>(s, q0, scale0, counts, e_base, n_in, rows_per_expert, cols,
                                        expert_bytes, stream);
     if (ggml_type == DQR_Q6_K)
         return dispatch_mask<DQR_Q6_K>(s, q0, scale0, counts, e_base, n_in, rows_per_expert, cols,
@@ -687,12 +750,16 @@ bool launch_gguf_dequant_rows_i8_fast_mask_pair(
         return (e && e[0] == '0') ? 0 : 1;
     }();
     if (!enabled || !counts || n_in <= 0 || rows_per_expert <= 0 || cols <= 0 ||
-        (cols % (DQR_BLOCK * DQR_VEC)) != 0)
+        (cols & 255) != 0)
         return false;
     auto s0 = reinterpret_cast<const unsigned char*>(src0);
     auto s1 = reinterpret_cast<const unsigned char*>(src1);
     if (ggml_type == DQR_Q4_K)
         return dispatch_mask_pair<DQR_Q4_K>(s0, q0, scale0, s1, q1, scale1, counts, e_base, n_in,
+                                            rows_per_expert, cols, expert_bytes0, expert_bytes1,
+                                            stream);
+    if (ggml_type == DQR_Q5_K)
+        return dispatch_mask_pair<DQR_Q5_K>(s0, q0, scale0, s1, q1, scale1, counts, e_base, n_in,
                                             rows_per_expert, cols, expert_bytes0, expert_bytes1,
                                             stream);
     if (ggml_type == DQR_Q6_K)

--- a/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
+++ b/kernels/include/sparkinfer/kernels/dequant_rows_i8_fast.h
@@ -20,10 +20,11 @@ namespace kernels {
 // Returns true if a kernel was launched, false if the caller should run its own (unsupported type,
 // a row shape outside the register budget, or disabled by env).
 //
-// BIT-IDENTICAL to #464's kernel: same deq_q4k_val / deq_q6k_val decode, same amax over the row
-// (max is associative and exact in fp, so the different thread->value map cannot move it), same
-// d = amax/127.f, same inv = 1.f/d guarded on d > 0, and the same roundf(v * inv) — v * inv, not
-// v / d; those differ in the last ulp.
+// BIT-IDENTICAL to #464's kernel: same deq_q4k_val / deq_q5k_val / deq_q6k_val decode, same amax
+// over the row (max is associative and exact in fp, so the different thread->value map cannot move
+// it), same d = amax/127.f, same inv = 1.f/d guarded on d > 0, and the same roundf(v * inv) — v * inv,
+// not v / d; those differ in the last ulp. Supports Q4_K/Q5_K/Q6_K. Plain/pair launchers require
+// cols % 1024 == 0; gather/mask also accept cols % 256 == 0 (MoE down Q5_K cols=512).
 //
 // Env knobs:
 //   SPARKINFER_DEQUANT_ROWS_I8_FAST  (default 1)  0 disables (A/B) -> falls through to #464's kernel.


### PR DESCRIPTION
## Summary

Extend the vector-store GGUF→int8 fast dequant path to **Q5_K** and MoE-down **cols=512** (gather/mask), so Qwen3.6 live-expert down weights stop falling through to the slow `#464` kernel. Prefill-only; decode graph untouched. Opt-out: `SPARKINFER_DEQUANT_ROWS_I8_FAST=0`.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 485.21 |
| after (this PR) | 485.60 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 5409.10 |
| after prefill (this PR) | 5879.50 |

Primary scored model is **Qwen3.6-35B-A3B** @512 (+8.70%). Qwythos dense path is unchanged (flat @512/4k/32k); mid-ctx Qwen3.6 also flat.

```text
# qwen3_gguf_bench, SPARKINFER_KV_INT8=1, RTX 5090 sm_120, tip 6b62157 -> this PR
# Qwen3.6-35B-A3B-UD-Q4_K_M  (n=64)
# @512  tip med pp 5409.10 / tg 485.21  ->  pat med pp 5879.50 / tg 485.60   (+8.70% pp)
# @4k   tip med pp 16210.9 / tg 469.83  ->  pat med pp 16199.1 / tg 469.72   (~0%)
# @32k  tip med pp 21255.6 / tg 421.72  ->  pat med pp 21226.8 / tg 421.91   (~0%)
#
# Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M
# @512  tip 9933.3 -> pat 9930.2 (~0%)
# @4k   tip 23183  -> pat 23155  (~0%)
# @32k  tip 23362  -> pat 23347  (~0%)
#
# H3 prefill_check @512 cont=16 (5x):
# Qwen3.6 tip TOP1 0.875–1.00 KL~0.007  ->  pat TOP1 0.875–0.9375 KL~0.008  (bar 0.80)
# Qwythos tip/pat TOP1 0.9375 KL 0.00294 identical
```