### PR TITLE
fix(qwen36): GDN prefill state is handed to two decode kernels transposed

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -208,19 +208,22 @@ __global__ void gdn_ar_kernel(const __nv_bfloat16* __restrict__ q,
     const __nv_bfloat16* qhptr = q + (size_t)qh * head_dim;
     const __nv_bfloat16* khptr = k + (size_t)qh * head_dim;
     const __nv_bfloat16* vhptr = v + (size_t)vh * head_dim;
-    float* sptr = state + (size_t)vh * head_dim * head_dim;
+    // Transposed state layout [vh][col][row] -- the ONE layout every GDN producer and consumer
+    // uses (both batched-prefill scans write it, gdn_ar_fast_kernel reads it). S[i][j] is at
+    // state[(vh*head_dim + j)*head_dim + i]; this thread owns column j, so its rows are contiguous.
+    float* col = state + ((size_t)vh * head_dim + j) * head_dim;
 
     float sk = 0.f;
     for (int i = 0; i < head_dim; i++) {
-        float s = sptr[(size_t)i * head_dim + j] * g;
-        sptr[(size_t)i * head_dim + j] = s;
+        float s = col[i] * g;
+        col[i] = s;
         sk += s * q36_to_f(khptr[i]);
     }
     const float delta = (q36_to_f(vhptr[j]) - sk) * b;
     float y = 0.f;
     for (int i = 0; i < head_dim; i++) {
-        float s = sptr[(size_t)i * head_dim + j] + q36_to_f(khptr[i]) * delta;
-        sptr[(size_t)i * head_dim + j] = s;
+        float s = col[i] + q36_to_f(khptr[i]) * delta;
+        col[i] = s;
         y += s * q36_to_f(qhptr[i]) * scale;
     }
     out[(size_t)vh * head_dim + j] = __float2bfloat16(y);
@@ -289,8 +292,11 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
     if (lane == 0) out[(size_t)vh * HEAD_DIM + j] = __float2bfloat16(y);
 }
 
-// Default GDN path: warp-per-state-column with native [vh][row][col] layout (no transposed
-// state). One warp owns column j; row slices live in registers; grid fills the GPU.
+// Fallback GDN path (SPARKINFER_GDN_FAST=0): warp-per-state-column, row slices in registers,
+// grid fills the GPU. Uses the same transposed [vh][col][row] state layout as gdn_ar_fast_kernel
+// and both batched-prefill scans -- the state is one shared buffer, so the layout is not a
+// per-kernel choice. It differs from gdn_ar_fast_kernel only in keeping the naive kernel's
+// separate decay pass, not in how the state is addressed.
 template <int WARPS_PER_BLK, int HEAD_DIM>
 __global__ void gdn_ar_warpgrid_kernel(const __nv_bfloat16* __restrict__ q,
                                        const __nv_bfloat16* __restrict__ k,
@@ -315,14 +321,14 @@ __global__ void gdn_ar_warpgrid_kernel(const __nv_bfloat16* __restrict__ q,
     const __nv_bfloat16* qhptr = q + (size_t)qh * HEAD_DIM;
     const __nv_bfloat16* khptr = k + (size_t)qh * HEAD_DIM;
     const __nv_bfloat16* vhptr = v + (size_t)vh * HEAD_DIM;
-    float* sptr = state + (size_t)vh * HEAD_DIM * HEAD_DIM;
+    float* col = state + ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;   // transposed [vh][col][row]
 
     float sloc[NROW];
     float part_sk = 0.f;
     #pragma unroll
     for (int r = 0; r < NROW; r++) {
         const int i = lane + r * 32;
-        const float s = sptr[(size_t)i * HEAD_DIM + j];
+        const float s = col[i];
         sloc[r] = s;
         part_sk += s * q36_to_f(khptr[i]);
     }
@@ -333,7 +339,7 @@ __global__ void gdn_ar_warpgrid_kernel(const __nv_bfloat16* __restrict__ q,
     for (int r = 0; r < NROW; r++) {
         const int i = lane + r * 32;
         const float s = sloc[r] * g + q36_to_f(khptr[i]) * delta;
-        sptr[(size_t)i * HEAD_DIM + j] = s;
+        col[i] = s;
         part_y += s * q36_to_f(qhptr[i]) * scale;
     }
     const float y = q36_wsum(part_y);
@@ -519,9 +525,14 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
                           const void* dt_bf16, const void* a_bf16,
                           float* state_f32, void* out_bf16,
                           int q_heads, int v_heads, int head_dim, cudaStream_t stream) {
-    // SPARKINFER_GDN_FAST: warp-per-column, register-cached, transposed-state kernel (fills the GPU +
-    // 2x state traffic). Uses a transposed internal state layout, so it MUST be all-or-nothing for the
-    // run — the static flag guarantees that. Requires head_dim a multiple of 32 (128 -> NROW=4).
+    // STATE LAYOUT. `state_f32` is the SHARED Gated-DeltaNet recurrent buffer: the batched-prefill
+    // scans (pf_gdn_scan_kernel, pf_gdnc_scan_kernel) write the post-prompt state that decode then
+    // continues from. All three kernels below therefore address it in the SAME transposed
+    // [v_head][col][row] layout the prefill scans emit — the layout is a cross-kernel contract, not
+    // a per-kernel choice, so switching paths mid-run (or via the env knobs) stays correct.
+    //
+    // SPARKINFER_GDN_FAST: warp-per-column, register-cached kernel (fills the GPU + 2x state
+    // traffic). Requires head_dim a multiple of 32 (128 -> NROW=4).
     static int fast = -1;
     if (fast < 0) { const char* e = getenv("SPARKINFER_GDN_FAST"); fast = (e && e[0] == '0') ? 0 : 1; }
     if (fast && head_dim == 128) {                            // Qwen3.6/Qwythos linear_head_dim=128


### PR DESCRIPTION
## Summary

The Gated-DeltaNet recurrent state is **one shared buffer** (`s.lin_state`): the batched-prefill
scan writes the post-prompt state and the decode `gdn_ar` kernel continues from it. Its memory
layout is therefore a cross-kernel contract — but only three of the five kernels that touch it
honour the same one. `gdn_ar_warpgrid_kernel` and `gdn_ar_kernel` index the buffer transposed
relative to what prefill writes, so on those paths every linear layer starts decoding from
`S^T` instead of `S`.

This is a pure correctness fix in `kernels/`. No shapes, defaults, env knobs or fast paths change,
and the currently-default configuration is untouched.

*(No proof-of-speedup section: this makes no speed claim, so there is nothing for the on-device
eval to grade. It does not touch `runtime/`.)*

## Root cause

Both prefill writers emit the **transposed `[v_head][col][row]`** layout:

```cpp
// kernels/csrc/cuda/fused/batched_prefill.cu:568   (pf_gdn_scan_kernel)
float* col = state + ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;   // transposed [vh][col][row]

// kernels/csrc/cuda/fused/prefill_gdn_chunk.cu:415 (pf_gdnc_scan_kernel)
state[((size_t)h * HD + (j0 + jj)) * HD + m] = s_S[e];
```

`gdn_ar_fast_kernel` reads that layout and is correct. The other two decode kernels did not:

```cpp
// gdn_ar_warpgrid_kernel — SPARKINFER_GDN_FAST=0
float* sptr = state + (size_t)vh * HEAD_DIM * HEAD_DIM;
const float s = sptr[(size_t)i * HEAD_DIM + j];      // [vh][row][col]  <-- mismatch

// gdn_ar_kernel — head_dim != 128 fallback
float  s    = sptr[(size_t)i * head_dim + j] * g;    // [vh][row][col]  <-- mismatch
```

`S` is not symmetric, so `S^T != S` and the recurrence diverges immediately.

The mismatch was invisible because each kernel is **self-consistent in isolation**: with token-loop
prefill the same kernel both builds and consumes the state, starting from the memset-zero buffer,
and any permutation of zeros is still zeros. It only bites at the **prefill → decode handoff**,
which is exactly the default route for the hybrid models (`batched_prefill_enabled` is on by
default). The stale comment on `gdn_ar_warpgrid_kernel` — *"native `[vh][row][col]` layout (no
transposed state)"* — documented the divergence as if it were a free per-kernel choice, and the
dispatcher's note said only the fast kernel used a transposed layout.

Affected paths:

| path | trigger | before |
|---|---|---|
| `gdn_ar_warpgrid_kernel` | `SPARKINFER_GDN_FAST=0` | transposed state, wrong output |
| `gdn_ar_kernel` | `head_dim != 128` | transposed state, wrong output |
| `gdn_ar_fast_kernel` | default | correct |

`SPARKINFER_GDN_FAST=0` is the shipped opt-out and the code's own designated fallback for the
register-cached kernel — it is documented as the slower-but-equivalent path, and it is the first
thing anyone flips when bisecting a suspected GDN issue. Instead of being equivalent it silently
produces garbage for all linear layers, which sends the bisect the wrong way. `head_dim == 128`
holds for both shipped checkpoints, so that row is latent today but is a live trap for the next
linear-head-dim.

## Fix

Address the state as `[v_head][col][row]` in both kernels, matching the prefill writers and
`gdn_ar_fast_kernel`. Only the index arithmetic changes — the arithmetic, its ordering and its
rounding are byte-for-byte untouched:

```diff
-    float* sptr = state + (size_t)vh * HEAD_DIM * HEAD_DIM;
+    float* col = state + ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;   // transposed [vh][col][row]
-        const float s = sptr[(size_t)i * HEAD_DIM + j];
+        const float s = col[i];
```

The dispatcher comment now states the layout once, as the cross-kernel contract it is, so a future
GDN kernel does not have to rediscover it.

## Verification

A CPU transcription of the prefill scan and all three decode kernels (same arithmetic, same
addressing), run as the runtime does it — batched prefill writes the state, then one decode step
reads it — with a random non-symmetric `S` and `ssm_a < 0`:

```
After batched prefill, first decode step (max |diff| vs GDN_FAST reference):
  main   GDN_FAST=0 (native [vh][row][col]) : 3.226229  <-- WRONG OUTPUT
  patch  GDN_FAST=0 (transposed          ) : 0.000000  OK
  resulting state  main : 8.583288   patch : 0.000000

Token-loop only (zero-init state, no prefill writer) — must be unchanged:
  main vs patch output : 0.000000000  identical
```

So the patched fallback now reproduces the default path exactly, and the configurations that were
already self-consistent are bit-identical.

## Impact and risk

- **Default configuration is unchanged.** `gdn_ar_fast_kernel` is not modified and stays the
  dispatch default, so decode/prefill throughput and the accuracy gate are unaffected.
- **Backward compatible.** The state buffer is scratch — allocated per session and memset to zero
  at `position == 0` — so there is no persisted layout to migrate.
- **Risk: low.** One file, two kernels, index arithmetic only; nothing else reads or writes
  `lin_state`. The only behaviour change is on the two paths that were already producing wrong
  results.
- Minor bonus, not claimed as a speedup: in the warpgrid kernel each warp's `NROW` rows are now
  contiguous, so its state reads and writes coalesce instead of striding by `HEAD_DIM`.
