### PR TITLE
fix(attn): flash-decode combine emits no Q8_1 blocks at head_dim 256, O projection reads a stale buffer

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -200,10 +200,11 @@ struct fa_block_q8_1 { __half2 ds; signed char qs[32]; };
 // original (which idled at ~2% occupancy with a serial n_splits loop). DG head-dim
 // groups -> DG x more blocks; NW warps per block each fold a 1/NW stripe of the
 // splits, then a shared-memory log-sum-exp merge across warps. grid=(heads*DG,seqs).
-// When out_q8 != nullptr AND ELEMS==1 (DG*32==HEAD_DIM), each (qh,dg) block's warp 0 also
-// emits the Q8_1 block for attn dims [qh*HEAD_DIM + dg*32, +32) from the bf16-rounded output,
-// so the O-projection MMVQ skips its standalone attn-quantize node (bit-identical to running
-// the quantizer on `out` afterwards). Q8_1 block index = qh*(HEAD_DIM/32) + dg.
+// When out_q8 != nullptr, each (qh,dg) block's warp 0 also emits the ELEMS Q8_1 blocks for
+// attn dims [qh*HEAD_DIM + dg*(HEAD_DIM/DG), +HEAD_DIM/DG) from the bf16-rounded output, so
+// the O-projection MMVQ skips its standalone attn-quantize node (bit-identical to running
+// the quantizer on `out` afterwards). Q8_1 block index = qh*(HEAD_DIM/32) + (doff + e*32)/32,
+// so the DG groups together cover all HEAD_DIM/32 blocks of the head at any ELEMS.
 template <int HEAD_DIM, int DG, int NW>
 __global__ void fa_combine_kernel(
     const float* __restrict__ part_m, const float* __restrict__ part_l,
@@ -254,21 +255,31 @@ __global__ void fa_combine_kernel(
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) op[doff + e * 32] = __float2bfloat16(acc[e] * inv);
 
-    // Fused Q8_1(attn) emit for the O-projection MMVQ (only the DG*32==HEAD_DIM layout, ELEMS==1,
-    // where warp 0's 32 lanes hold exactly the 32 elements of one Q8_1 block).
-    if (out_q8 != nullptr && ELEMS == 1) {
-        const float bv = __bfloat162float(__float2bfloat16(acc[0] * inv));   // bf16-rounded, as `out`
-        float amax = fabsf(bv);
+    // Fused Q8_1(attn) emit for the O-projection MMVQ. Lane `lane` owns head dims
+    // doff + e*32, so for a FIXED e warp 0's 32 lanes hold exactly the 32 elements of
+    // Q8_1 block (doff + e*32)/32 — one whole block per e, ELEMS blocks per (qh,dg).
+    // This used to be gated on ELEMS==1 (DG*32==HEAD_DIM, i.e. hd128), which left the
+    // hd256 instantiation emitting nothing at all while its caller — seeing a non-null
+    // out_q8 — skips the standalone launch_quantize_q8_1_blocks, so the O projection
+    // consumed a stale/uninitialized aq81. Looping over e covers every block and is
+    // bit-identical at ELEMS==1 (di/32 == dg there), matching the gated hd256 combine.
+    if (out_q8 != nullptr) {
         #pragma unroll
-        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
-        const float d = amax / 127.0f;
-        const int qi = (amax == 0.0f) ? 0 : (int)roundf(bv / d);
-        const int blk = (seq * num_q_heads + qh) * (HEAD_DIM / 32) + dg;
-        out_q8[blk].qs[lane] = (signed char)qi;
-        int s = qi;
-        #pragma unroll
-        for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
-        if (lane == 0) out_q8[blk].ds = __floats2half2_rn(d, d * (float)s);
+        for (int e = 0; e < ELEMS; e++) {
+            const int di = doff + e * 32;
+            const float bv = __bfloat162float(__float2bfloat16(acc[e] * inv));   // bf16-rounded, as `out`
+            float amax = fabsf(bv);
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
+            const float d = amax / 127.0f;
+            const int qi = (amax == 0.0f) ? 0 : (int)roundf(bv / d);
+            const int blk = (seq * num_q_heads + qh) * (HEAD_DIM / 32) + di / 32;
+            out_q8[blk].qs[lane] = (signed char)qi;
+            int s = qi;
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+            if (lane == 0) out_q8[blk].ds = __floats2half2_rn(d, d * (float)s);
+        }
     }
 }
 

--- a/kernels/tests/cpu_reference_test.cpp
+++ b/kernels/tests/cpu_reference_test.cpp
@@ -297,6 +297,70 @@ static double test_argmax_twopass(int vocab, int nblocks, bool ties) {
     return (double)std::abs(ri - gi);   // expect 0: same index as serial argmax
 }
 
+// ---------------------------------------------------------------------------
+// 6. Flash-decode combine -> fused Q8_1(attn) emit (fa_combine_kernel).
+//     Whenever out_q8 is non-null the combine must fill EVERY one of the head's
+//     HEAD_DIM/32 Q8_1 blocks, because the caller then skips the standalone
+//     launch_quantize_q8_1_blocks and feeds out_q8 straight to the O-projection
+//     MMVQ. Emission is driven by the (dg, lane, e) -> head-dim mapping
+//     di = dg*(HEAD_DIM/DG) + lane + e*32, one Q8_1 block per (dg, e). This checks
+//     that mapping tiles the head exactly once and that each emitted block equals a
+//     direct Q8_1 quantize of `out`. ELEMS = HEAD_DIM/(32*DG) is 1 at hd128 and 2
+//     at hd256 (DG = 4) — the hd256 case emitted 0 of 8 blocks while the emit was
+//     gated on ELEMS == 1.
+// ---------------------------------------------------------------------------
+static double test_combine_q8_emit(int HEAD_DIM, int DG) {
+    const int ELEMS = HEAD_DIM / (32 * DG);
+    const int NBLK  = HEAD_DIM / 32;
+
+    // `out` for one head, exactly as the combine writes it (bf16-rounded).
+    vector<float> out(HEAD_DIM);
+    for (int d = 0; d < HEAD_DIM; d++) out[d] = to_bf16(frand());
+
+    // Reference: quantize `out` to Q8_1 blocks directly (what the standalone
+    // quantizer the fused emit replaces would produce).
+    vector<int> ref_q(HEAD_DIM); vector<float> ref_d(NBLK), ref_s(NBLK);
+    for (int b = 0; b < NBLK; b++) {
+        float amax = 0.f;
+        for (int i = 0; i < 32; i++) amax = std::max(amax, std::fabs(out[b * 32 + i]));
+        const float d = amax / 127.f;
+        int sum = 0;
+        for (int i = 0; i < 32; i++) {
+            const int qi = (amax == 0.f) ? 0 : (int)std::roundf(out[b * 32 + i] / d);
+            ref_q[b * 32 + i] = qi; sum += qi;
+        }
+        ref_d[b] = d; ref_s[b] = d * (float)sum;
+    }
+
+    // Kernel emit: warp 0 of each (qh, dg) block walks e = 0..ELEMS-1; for a fixed e
+    // its 32 lanes own dims di = doff + e*32 and warp-reduce amax / sum over them.
+    vector<int> got_q(HEAD_DIM, 0); vector<float> got_d(NBLK, -1.f), got_s(NBLK, -1.f);
+    vector<int> writes(NBLK, 0);
+    for (int dg = 0; dg < DG; dg++)
+        for (int e = 0; e < ELEMS; e++) {
+            const int base = dg * (HEAD_DIM / DG) + e * 32;
+            float amax = 0.f;
+            for (int lane = 0; lane < 32; lane++) amax = std::max(amax, std::fabs(out[base + lane]));
+            const float d = amax / 127.f;
+            int sum = 0;
+            for (int lane = 0; lane < 32; lane++) {
+                const int qi = (amax == 0.f) ? 0 : (int)std::roundf(out[base + lane] / d);
+                got_q[base + lane] = qi; sum += qi;
+            }
+            const int blk = base / 32;          // lane < 32, so the 32 lanes share one block
+            got_d[blk] = d; got_s[blk] = d * (float)sum; writes[blk]++;
+        }
+
+    double err = 0;
+    for (int b = 0; b < NBLK; b++) {
+        if (writes[b] != 1) return 1.0;         // block missed (or written twice) by the emit
+        err = std::max(err, (double)std::fabs(got_d[b] - ref_d[b]));
+        err = std::max(err, (double)std::fabs(got_s[b] - ref_s[b]));
+    }
+    for (int i = 0; i < HEAD_DIM; i++) err = std::max(err, (double)std::abs(got_q[i] - ref_q[i]));
+    return err;                                  // expect 0: identical to the standalone quantize
+}
+
 int main() {
     printf("sparkinfer kernel algorithm correctness (CPU reference)\n");
     check("attention hd128 kv1",   test_attention(128, 1),    1e-4);
@@ -317,6 +381,8 @@ int main() {
     check("argmax 2pass qwen vocab",test_argmax_twopass(151936, 512, false), 0.0);
     check("argmax 2pass gemma vocab",test_argmax_twopass(262144, 512, false), 0.0);
     check("argmax 2pass tie-break",  test_argmax_twopass(151936, 512, true),  0.0);
+    check("combine q8 emit hd128 dg4", test_combine_q8_emit(128, 4),          0.0);
+    check("combine q8 emit hd256 dg4", test_combine_q8_emit(256, 4),          0.0);
     printf("%s (%d failures)\n", g_fail ? "FAILED" : "ALL PASSED", g_fail);
     return g_fail ? 1 : 0;
 }


### PR DESCRIPTION
## Summary

`fa_combine_kernel` silently emits **no** Q8_1 attention blocks at `head_dim == 256`, while its
caller — seeing a non-null `out_q8` — skips the standalone quantize and hands that buffer straight
to the O-projection MMVQ. This is a correctness-only fix (no speed claim, so no GPU eval requested).

## Root cause

`kernels/csrc/cuda/attention/flash_decode_split.cu` — the fused emit at the tail of
`fa_combine_kernel` was guarded by `ELEMS == 1`:

```cpp
if (out_q8 != nullptr && ELEMS == 1) {
    ...
    const int blk = (seq * num_q_heads + qh) * (HEAD_DIM / 32) + dg;
```

`ELEMS = HEAD_DIM / (32 * DG)`. With `FA_COMBINE_DG == 4` that is `1` at `head_dim 128` but `2` at
`head_dim 256`, so for every hd256 instantiation the entire block is compiled out and all
`HEAD_DIM / 32 == 8` Q8_1 blocks per head are left untouched.

The contract the kernel documents — *"the O-projection MMVQ skips its standalone attn-quantize node
(bit-identical to running the quantizer on `out` afterwards)"* — is what the caller acts on. In
`runtime/src/models/qwen35.cpp` the standalone quantize is skipped precisely when the fused emit was
requested:

```cpp
if (!emit_attn_q8 && !attn_gate_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
kernels::launch_mmvq_q4k(s.aq81, w.wo, s.ao, H, s.qdim, st);
```

So on the hd256 + non-gated path the O projection consumes a stale/uninitialized `aq81` — the
attention output for those layers is wrong, with no error surfaced anywhere.

**Reachability, stated honestly:** the two hd256 models on `main` today take other branches — the
gated hd256 combine (`fa_combine_gated_q8_kernel`) already loops over `e` and handles `ELEMS == 2`
correctly, and `emit_attn_q8` requires `!w.q_has_gate` (i.e. `!cfg.hybrid`), which no current hd256
config sets. So this is a live defect on a reachable code path rather than an observed regression:
the guard is wrong today, it is silent, and it arms the moment a non-hybrid hd256 model or a
`SPARKINFER_*` toggle routes through the non-gated hd256 combine with `out_q8` set. Both the
`launch_flash_decode_split` and the sparse-KV `launch_fa_combine_hd256` entry points reach it.

## Fix

Loop the emit over `e` instead of gating it out (2 files, +95 / -18):

- Lane `lane` owns head dims `doff + e*32`, so for a **fixed** `e` warp 0's 32 lanes hold exactly
  the 32 elements of Q8_1 block `(doff + e*32) / 32` — one whole block per `e`, `ELEMS` blocks per
  `(qh, dg)`, and the `DG` groups together tile all `HEAD_DIM / 32` blocks of the head at any `ELEMS`.
- This is the same construction `fa_combine_gated_q8_kernel` already uses in production for the
  gated hd256 combine, so the two hd256 paths now agree.

**Backward compatible:** at `ELEMS == 1`, `di / 32 == dg` (lane < 32), so the emitted block index,
`qs[lane]`, `d` and `d*sum` are unchanged — the hd128 path is bit-identical, not merely equivalent.
No launcher, header, signature or default changed; nothing outside `kernels/` is touched.

## Validation

`kernels/tests/cpu_reference_test.cpp` gains a test that models the `(dg, lane, e) -> head-dim`
mapping and asserts (a) it tiles the head's Q8_1 blocks **exactly once** and (b) each emitted block
equals a direct Q8_1 quantize of `out`. It discriminates the bug:

| emit rule | hd128 DG4 (ELEMS=1) | hd256 DG4 (ELEMS=2) |
|---|---|---|
| before (`ELEMS == 1` gate) | PASS | **FAIL** — 0 of 8 blocks emitted |
| after (loop over `e`) | PASS | PASS |

```
$ g++ -O2 -Wall -Wextra -std=c++17 kernels/tests/cpu_reference_test.cpp -o t && ./t
  [PASS] argmax 2pass tie-break             max_err=0.000e+00 (tol=0e+00)
  [PASS] combine q8 emit hd128 dg4          max_err=0.000e+00 (tol=0e+00)
  [PASS] combine q8 emit hd256 dg4          max_err=0.000e+00 (tol=0e+00)
ALL PASSED (0 failures)
```

20/20 green, warning-clean. The edited kernel was additionally type-checked host-side for the
`<128,4,4>`, `<256,4,4>` and `<256,4,16>` instantiations (no CUDA toolkit in my environment, so I am
not claiming an on-device run — `build-attested-binaries` is the real compile signal here, subject
to #612 on fork PRs).

## Risk / tradeoffs

Low. The hd128 decode path is byte-for-byte unchanged; the only behavioural difference is that the
hd256 combine now writes the Q8_1 blocks it already claimed to write. The emit adds `ELEMS - 1`
extra warp reductions in warp 0 of the combine (i.e. nothing at hd128, one extra at hd256), which is
off the measured decode critical path for the shapes that use it today. Nothing depended on the
previous no-op, since consuming an unwritten `aq81` was never valid.

## Why there is no RTX 5090 attestation

This is a correctness-only change and makes **no speed claim**, so there is deliberately no
proof-of-speedup section here and the "Tested on RTX 5090" box is **not** ticked. I do not have an
RTX 5090, and ticking that box without a real on-device run would be false attestation, which
CONTRIBUTING.md rightly treats as gaming. Per the auto-close notice on this PR, the
proof-of-speedup section was removed rather than left with an unchecked box.

The eval bot's greenlight gate (`greenlight_status` in `eval/pr_eval_bot.py`) closes any PR whose
box is unticked, regardless of whether the section was removed — so removing it, as the notice
advises, is not by itself enough to keep a non-speed PR open. A maintainer `hold` label is what
keeps this reviewable. #604 merged on exactly this basis: an outside contributor's correctness fix
with no speed claim and no 5090 access.

@ai-hpc @skyrocket2026 — please apply `hold` if this is worth reviewing. If you judge the hd256
non-gated path not worth guarding, say so and I will close it myself rather than leave it open.
