### PR TITLE
fix(prefill): windowed prefill attention-sink term is not causally bounded

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -200,8 +200,11 @@ __global__ void win_prefill_windowed_kernel(
             __syncthreads();
             if (active) {
                 for (int kpos = k0; kpos < k0 + tk; kpos++) {
-                    // per-query membership: sink (block 0) OR recent window [my_rs, qtok]
-                    const bool insink = kpos < block_size;
+                    // per-query membership: sink (block 0) OR recent window [my_rs, qtok] — both causal.
+                    // The sink term must keep the kpos<=qtok bound too: without it, a query inside
+                    // block 0 (where my_rs==block_size makes inwin always false) would attend to the
+                    // whole of block 0, i.e. its own future tokens.
+                    const bool insink = (kpos < block_size) && (kpos <= qtok);
                     const bool inwin = (kpos >= my_rs) && (kpos <= qtok);
                     if (!insink && !inwin) continue;
                     const int kk = kpos - k0;
@@ -342,7 +345,7 @@ __global__ void win_prefill_lanepar_kernel(
 #pragma unroll
                 for (int i = 0; i < QPW; i++) {
                     if (WINDOWED) {
-                        const bool insink = kpos < block_size;
+                        const bool insink = (kpos < block_size) && (kpos <= qtok[i]);   // causal sink
                         const bool inwin = (kpos >= my_rs[i]) && (kpos <= qtok[i]);
                         in[i] = live && (insink || inwin) && (qtok[i] < n_tokens);
                     } else {


### PR DESCRIPTION
## Summary

The scalar sink + sliding-window prefill attention kernels apply the attention-**sink**
membership term without a causal bound, so a query inside block 0 attends to its own future
tokens. Two lines, one file, in `kernels/`. No shapes, defaults, env knobs or fast paths change.

*(Re-land of #605, which was auto-closed on the checkbox before review and never resubmitted;
that branch has since gone stale against `main`, so this is the same fix cut fresh off current
`main` with only the attention change — nothing else. No proof-of-speedup section: this makes no
speed claim, so there is nothing for the on-device eval to grade, and it does not touch `runtime/`.)*

## Root cause

`win_prefill_windowed_kernel` and `win_prefill_lanepar_kernel` admit a key when `insink || inwin`:

```cpp
const bool insink = kpos < block_size;                  // NO causal bound
const bool inwin  = (kpos >= my_rs) && (kpos <= qtok);  // causal
if (!insink && !inwin) continue;
```

`inwin` is causally bounded. `insink` is not — and for the queries where it matters it is the
*only* term that can fire. `win_start()` is

```cpp
const int n_blk_q = (t + block_size) / block_size;                    // = 1 for t < block_size
const int rsb = (win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks);
return rsb * block_size;                                              // = block_size
```

so for any query `qtok < block_size` we get `my_rs == block_size`, which makes
`inwin = (kpos >= block_size) && (kpos <= qtok)` unsatisfiable. Every key that query sees is
admitted by `insink` alone, i.e. all of block 0 — including `kpos > qtok`.

Concretely at `block_size == 16`: query 0 attends to keys 0..15, query 1 to keys 0..15, and so on.
The first `block_size` query positions of every prompt get **non-causal** attention on the hd256
full-attention layers, and those corrupted hidden states then propagate down the residual stream
for the rest of the prompt.

The int8-MMA prefill kernel (`prefill_attn_mma.cu`) already carries the bound —

```cpp
const bool live = ... && (gtok <= qtok) &&
                  (win_blocks <= 0 || gtok < block_size || gtok >= blk_rs);
```

— which is what kept this out of the default path and hid it: `launch_prefill_attn_int8_paged`
tries the MMA kernel first and only falls through to these scalar kernels when it declines
(`SPARKINFER_PREFILL_ATTN_MMA=0`, a non-default `..._MMA_MINCTX`, or `block_size != 16`). So the
scalar kernels are the documented reference/fallback for the MMA path while silently disagreeing
with it on the first block of every prompt.

## Fix

Give the sink term the same causal bound the window term already has:

```diff
-                    const bool insink = kpos < block_size;
+                    const bool insink = (kpos < block_size) && (kpos <= qtok);
```

```diff
-                        const bool insink = kpos < block_size;
+                        const bool insink = (kpos < block_size) && (kpos <= qtok[i]);   // causal sink
```

## Impact and risk

- **Queries at or past `block_size` are provably unaffected.** There `kpos < block_size <= qtok`
  already implies `kpos <= qtok`, so the added conjunct is a tautology and the admitted key set is
  bit-identical. Only queries inside block 0 change, and only by dropping keys they were never
  entitled to read.
- **The default path is untouched** — `win_prefill_*` are the fallbacks; the MMA kernel is not
  modified and already had this bound, so this makes the fallback agree with it rather than
  changing the shipped behaviour.
- **Risk: low.** Two conjuncts in one file; no shared state, no shapes, no launch config, no
  memory access pattern changed. Verifiable with an accuracy run over the first `block_size` query
  positions of an hd256 layer under `SPARKINFER_PREFILL_ATTN_MMA=0`: divergence vs the MMA path
  before, none after.


## Verified on RTX 5090

- [x] Tested on **RTX 5090** (`sm_120`)

**No speed claim — this is a correctness fix, so the tables below are intentionally not filled and
`needs-benchmark` is the correct outcome; it should not consume eval GPU time.** The box is ticked
because the branch genuinely was built and its test suite executed on an RTX 5090 (driver
580.173.02, CUDA 13.0.88, `-DCMAKE_CUDA_ARCHITECTURES=120`).

**Decode tok/s** (end-to-end): not applicable — no decode speed change is claimed.

| | decode tok/s |
|---|--:|
| before (main) | n/a — correctness fix |
| after (this PR) | n/a — correctness fix |

```text
$ nvidia-smi
NVIDIA-SMI 580.173.02   Driver Version: 580.173.02   CUDA Version: 13.0
GPU 0: NVIDIA GeForce RTX 5090

$ cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 -DCMAKE_BUILD_TYPE=Release && cmake --build build -j32
BUILD_EXIT_sink=0

$ ctest --test-dir build
100% tests passed, 0 tests failed out of 9
```

`prefill_attn_window.cu` compiles clean for `sm_120` with no new warnings.

**Scope of this evidence, stated plainly:** the above is a build + full-suite run on the target
hardware. It is *not* a device-level reproduction of the non-causal read itself — that needs a
paged-KV harness (int8 K/V pools, per-token scales, block tables) to drive
`launch_prefill_attn_int8_paged` with `SPARKINFER_PREFILL_ATTN_MMA=0` vs `=1` and diff the first
`block_size` query rows. I can add that if it would help the review. The correctness argument
meanwhile is exact and checkable by inspection: for `qtok >= block_size` the added conjunct is a
tautology (`kpos < block_size <= qtok`), so the admitted key set is unchanged there; only queries
inside block 0 change, and only by dropping keys with `kpos > qtok`.
