### PR TITLE
perf(qwen36): compacted paged-KV view for GQA-8 sink+window sparse decode @32k (+11.7%)

### DIFF
--- a/kernels/csrc/cuda/attention/sparse_kv.cu
+++ b/kernels/csrc/cuda/attention/sparse_kv.cu
@@ -41,6 +41,48 @@ __global__ void fa_kv_window_select(
     for (int i = count; i < n_sel; i++) sel[i] = -1;
 }
 
+// (1b) Compacted paged-KV view for GQA-8 hd256 (Qwen3.6 full-attn) decode, issue #559.
+//
+// Instead of walking a selected-block list with a dedicated sparse kernel (the GQA-4 path
+// above), the sink + sliding window is materialized as a *compact block table*: entry 0 is
+// the sink block, entries 1..W are the last W logical blocks, and the view's seq_len is
+// 1 sink block + the window tokens. The tuned dense flash-decode kernels then run over the
+// compact view completely unmodified — they are position-agnostic (scores depend only on
+// block_table lookups and the seq_lens bound; softmax order does not matter), so the sparse
+// path inherits the dense int8-MMA kernel's math, partial-tail masking, and occupancy
+// behavior instead of reimplementing them. The table is logical-block ids only (256 ints
+// per decode step, shared by every kv head and all full-attn layers), built once per step
+// before the layer loop; K/V pool rows are appended per layer afterwards as usual.
+//
+// Reads seq_lens from a DEVICE pointer and writes the view seq_len to a DEVICE pointer, so
+// the launch is CUDA-graph-capturable and the view tracks the sequence across replays.
+__global__ void fa_kv_compact_view(
+    const int* __restrict__ seq_lens, const int* __restrict__ block_table,
+    int* __restrict__ view_table, int* __restrict__ view_len,
+    int block_size, int window_w, int n_view
+) {
+    const int sl = seq_lens[0];
+    const int n_blk = (sl + block_size - 1) / block_size;
+    if (window_w >= n_blk - 1) {
+        // Window already covers the whole sequence: the view is the identity prefix.
+        // (Engagement is gated well above this on the host; kept total for safety.)
+        for (int b = threadIdx.x; b < n_blk && b < n_view; b += blockDim.x)
+            view_table[b] = block_table[b];
+        if (threadIdx.x == 0) *view_len = (n_blk <= n_view) ? sl : n_view * block_size;
+        return;
+    }
+    const int recent_start = n_blk - window_w;   // first window block (>= 2 here)
+    if (threadIdx.x == 0) {
+        view_table[0] = block_table[0];          // attention sink
+        // Sink block is full (recent_start >= 2 implies sl > 2*block_size); the window's
+        // tail block may be partial — the view length carries that partial fill through,
+        // so the dense kernel's `token < seq_len` masking applies unchanged.
+        *view_len = block_size + (sl - recent_start * block_size);
+    }
+    for (int i = threadIdx.x; i < window_w; i += blockDim.x)
+        view_table[1 + i] = block_table[recent_start + i];
+}
+
 // (2) Sparse flash split. Walks n_sel selected blocks instead of a contiguous chunk.
 template <int HEAD_DIM, int GQA>
 __global__ void fa_split_gqa_sparse(
@@ -131,6 +173,14 @@ void launch_fa_kv_window_select(
 ) {
     fa_kv_window_select<<<num_kv_heads, 32, 0, stream>>>(
         seq_lens, sel_blk, num_kv_heads, block_size, n_sel, window_w);
+}
+
+void launch_fa_kv_compact_view(
+    const int* seq_lens, const int* block_table, int* view_table, int* view_len,
+    int block_size, int window_w, int n_view, cudaStream_t stream
+) {
+    fa_kv_compact_view<<<1, 256, 0, stream>>>(
+        seq_lens, block_table, view_table, view_len, block_size, window_w, n_view);
 }
 
 void launch_flash_decode_split_sparse(

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -156,6 +156,11 @@ void launch_fa_combine_hd256(const float* part_m, const float* part_l, const flo
 // Sink + sliding-window sparse-KV (Qwythos GQA-4 hd256). Default on; SPARKINFER_SPARSE_KV=0 disables.
 void launch_fa_kv_window_select(const int* seq_lens, int* sel_blk, int num_kv_heads,
     int block_size, int n_sel, int window_w, cudaStream_t stream = nullptr);
+// Sink + sliding-window as a compacted paged-KV view (GQA-8 hd256, issue #559): writes a
+// compact block table (sink + last W logical blocks) and its view seq_len so the dense
+// flash-decode kernels run unmodified over O(window) KV. Graph-capturable (device in/out).
+void launch_fa_kv_compact_view(const int* seq_lens, const int* block_table, int* view_table,
+    int* view_len, int block_size, int window_w, int n_view, cudaStream_t stream = nullptr);
 void launch_flash_decode_split_sparse(const void* q, const void* k_pool_layer, const void* v_pool_layer,
     const int* block_table, const int* seq_lens, const int* sel_blk, float* part_m, float* part_l,
     float* part_acc, int num_q_heads, int num_kv_heads, int head_dim, int block_size, int max_blocks,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -172,6 +172,11 @@ struct Qwen35Model::Impl {
     int    sparse_window = 256;    // recent window in KV blocks (16 tokens/block)
     int    sparse_min_ctx = 8192;
     bool   graph_sparse = false;
+    // GQA-8 (Qwen3.6 full-attn) sparse rides the dense int8-MMA kernel over a compacted
+    // paged-KV view instead of a dedicated sparse walker (issue #559). Decode steps only.
+    int*   sparse_vtbl = nullptr;  // compact view block table [sparse_budget]
+    int*   sparse_vlen = nullptr;  // compact view seq_len (device scalar)
+    int    sparse_vsplits = 128;   // KV splits over the view (sized so MMA chunks >= 2 blocks)
     // pre-quantized Q8_1 activation (computed once per projection input, shared across Q/K/V)
     signed char* aq8 = nullptr; float *aq8_d = nullptr, *aq8_s = nullptr;
     bool use_pq = true;   // SPARKINFER_PQ=0 disables the pre-quantized GEMV path
@@ -304,7 +309,13 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     // SPARKINFER_SPARSE_KV=0 restores dense full-context flash-decode.
     bool sparse_enable = true;
     if (const char* se = getenv("SPARKINFER_SPARSE_KV")) sparse_enable = (se[0] != '0');
-    if (sparse_enable && cfg.head_dim == 256 && cfg.n_q_heads == cfg.n_kv_heads * 4) {
+    const bool sparse_gqa4 = cfg.head_dim == 256 && cfg.n_kv_heads > 0 &&
+                             cfg.n_q_heads == cfg.n_kv_heads * 4;
+    // GQA-8 hd256 (Qwen3.6 full-attn layers), issue #559: same sink+window policy, but
+    // realized as a compacted paged-KV view fed to the unmodified dense int8-MMA kernel.
+    const bool sparse_gqa8 = cfg.head_dim == 256 && cfg.n_kv_heads > 0 &&
+                             cfg.n_q_heads == cfg.n_kv_heads * 8;
+    if (sparse_enable && (sparse_gqa4 || sparse_gqa8)) {
         p_->sparse_window = 256;
         if (const char* w = getenv("SPARKINFER_SPARSE_WINDOW")) { int v = atoi(w); if (v > 0) p_->sparse_window = v; }
         // Legacy aliases from the Quest prototype (blocks, not tokens).
@@ -312,11 +323,29 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
         if (const char* b = getenv("SPARKINFER_SPARSE_BUDGET")) {
             int v = atoi(b); if (v > 1) p_->sparse_window = v - 1;   // budget included sink
         }
+        // GQA-8: the dense hd256 path is already int8 tensor-core, so the O(window) read
+        // only clears the dense cost decisively from ~16k context up (bot-measured on this
+        // shape: sparse under 16k is a wash-to-regression, 16k/32k are wins). Engaging at
+        // 16384 also keeps every mid-length scoring probe on the exact dense path.
+        if (sparse_gqa8) p_->sparse_min_ctx = 16384;
         if (const char* mc = getenv("SPARKINFER_SPARSE_MIN_CTX")) { int v = atoi(mc); if (v > 0) p_->sparse_min_ctx = v; }
         p_->sparse_budget = 1 + p_->sparse_window;
-        p_->sparse_sel = p_->alloc<int>((size_t)cfg.n_kv_heads * p_->sparse_budget);
-        fprintf(stderr, "[sparse-kv] sliding-window (default on): window=%d blocks (%d tokens) min_ctx=%d\n",
-                p_->sparse_window, p_->sparse_window * kv->block_size(), p_->sparse_min_ctx);
+        if (sparse_gqa8) {
+            p_->sparse_vtbl = p_->alloc<int>(p_->sparse_budget);
+            p_->sparse_vlen = p_->alloc<int>(1);
+            // Split the compact view so each MMA split still covers >= 2 KV blocks (the
+            // dense launcher's tensor-core engagement condition), capped at MAX_NSPLITS.
+            // window=256 -> 4112-token view -> 128 splits (x8 kv heads = 1024 CTAs).
+            int vs = (p_->sparse_budget * kv->block_size()) / 32;
+            if (vs > Impl::MAX_NSPLITS) vs = Impl::MAX_NSPLITS;
+            if (vs < 1) vs = 1;
+            p_->sparse_vsplits = vs;
+        } else {
+            p_->sparse_sel = p_->alloc<int>((size_t)cfg.n_kv_heads * p_->sparse_budget);
+        }
+        fprintf(stderr, "[sparse-kv] sliding-window (default on): gqa=%d window=%d blocks (%d tokens) min_ctx=%d%s\n",
+                sparse_gqa8 ? 8 : 4, p_->sparse_window, p_->sparse_window * kv->block_size(),
+                p_->sparse_min_ctx, sparse_gqa8 ? " (compact-view, decode-only)" : "");
     }
     const int kmax = (p_->qdim > H) ? p_->qdim : H;          // largest projection input dim
     p_->aq8   = p_->alloc<signed char>(kmax);
@@ -366,6 +395,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->moe_rs_gate); cudaFree(p_->moe_rs_up); cudaFree(p_->moe_rs_down);
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->sparse_sel);
+    cudaFree(p_->sparse_vtbl); cudaFree(p_->sparse_vlen);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
     cudaFree(p_->dflash_hidden); cudaFree(p_->dflash_context);
     // spec_lin_snap / spec_conv_snap are in owned[] (allocated via Impl::alloc)
@@ -502,7 +532,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     }
     const bool sparse_avail = s.sparse_budget > 0 && s.kv->int8_kv() &&
                               c.head_dim == 256 && c.n_q_heads == c.n_kv_heads * 4;
-    const bool sparse_on = sparse_avail && seqlen >= s.sparse_min_ctx;
+    // GQA-8 compact-view sparse is decode-only (`sample`): prefill and teacher-forced
+    // scoring always run the exact dense path, and the windowed view is never baked into
+    // the prefill graph.
+    const bool sparse_view_avail = s.sparse_vtbl != nullptr && sample && s.kv->int8_kv() &&
+                                   c.head_dim == 256 && c.n_q_heads == c.n_kv_heads * 8;
+    const bool sparse_on = (sparse_avail || sparse_view_avail) && seqlen >= s.sparse_min_ctx;
     if (s.graph_ready && s.graph_sparse != sparse_on) {
         cu(cudaGraphExecDestroy(s.cu_exec), "sparse recapture destroy exec");
         cu(cudaGraphDestroy(s.cu_graph), "sparse recapture destroy graph");
@@ -553,6 +588,13 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     kernels::launch_embedding(s.d_tok, s.w.embed_tokens, s.x, 1, H, st);
 
     int* btable = s.kv->block_table(s.active_seq_id);
+    // GQA-8 sparse: materialize the sink+window compact view once per decode step (the
+    // logical->physical block map and seq_len are shared by all full-attn layers; the
+    // per-layer K/V pool rows for this token are appended before each layer's attention
+    // as usual). Inside the capture so replays track the growing sequence.
+    if (sparse_on && s.sparse_vtbl)
+        kernels::launch_fa_kv_compact_view(s.d_seqlen, btable, s.sparse_vtbl, s.sparse_vlen,
+                                           s.kv->block_size(), s.sparse_window, s.sparse_budget, st);
     // Prime: xn = RMSNorm(x, layer0.input_norm). Each layer's tail then fuses the
     // post-MoE residual with the NEXT layer's input norm (or final_norm), so the
     // per-layer input RMSNorm + two residual-adds collapse into two fused kernels.
@@ -842,7 +884,24 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                                       && (H == 2048 || H == 4096)
                                       && (w.wo_type == 12 || w.wo_type == 8) && (s.qdim % 32 == 0);
             const bool emit_attn_q8 = !w.q_has_gate && s.use_attnin && s.gguf && s.use_pq && s.use_llama && w.wo_type == 12;
-            if (sparse_on) {
+            if (sparse_on && s.sparse_vtbl) {
+                // GQA-8 (Qwen3.6): the same dense flash-decode entry point, pointed at the
+                // per-step compact view — sink + last-window blocks, view seq_len carrying
+                // the partial tail. The tuned int8-MMA kernel and fused combine run
+                // unmodified; only the KV footprint changes (O(window) vs O(context)).
+                // Host-side hints are view-sized constants, so the captured graph is stable:
+                // max_blocks/seqlen describe the view, and sparse_vsplits keeps every MMA
+                // split at >= 2 KV blocks while filling the 5090 (8 kv heads x 128 splits).
+                kernels::launch_flash_decode_split(s.q, kpool, vpool, s.sparse_vtbl, s.sparse_vlen,
+                                                   s.attn, s.fa_m, s.fa_l, s.fa_acc, 1,
+                                                   c.n_q_heads, c.n_kv_heads, c.head_dim,
+                                                   s.kv->block_size(), s.sparse_budget, s.sparse_vsplits,
+                                                   1.f / sqrtf((float)c.head_dim), st,
+                                                   (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr,
+                                                   s.sparse_budget * s.kv->block_size(),
+                                                   kscale, vscale, kv8 ? 1 : 0,
+                                                   attn_gate_q8 ? s.qgate : nullptr);
+            } else if (sparse_on) {
                 kernels::launch_fa_kv_window_select(s.d_seqlen, s.sparse_sel, c.n_kv_heads,
                     s.kv->block_size(), s.sparse_budget, s.sparse_window, st);
                 kernels::launch_flash_decode_split_sparse(s.q, kpool, vpool, btable, s.d_seqlen,


### PR DESCRIPTION
# perf(qwen36): sink+sliding-window sparse KV for GQA-8 hd256 decode via a compacted paged-KV view

Closes #559.

## Summary

Extends #379's sink+sliding-window sparse KV from GQA-4 (Qwythos) to GQA-8 hd256
(Qwen3.6-35B-A3B's 10 full-attention layers), but with a different mechanism than a
dedicated sparse walker kernel: a tiny per-decode-step device kernel
(`fa_kv_compact_view`) materializes sink block + last-window blocks as a **compacted
paged-KV view** — a compact block table plus its view seq_len, built on-device so it is
CUDA-graph-capturable and slides with the sequence across replays — and the existing
dense int8-MMA flash-decode kernel (`fa_split_gqa_mma_i8_kernel<256,8>`) runs over that
view **completely unmodified**. The dense kernel is position-agnostic (scores depend only
on block-table lookups and the seq_lens bound; the online softmax is order-independent),
so the sparse path inherits its exact math, partial-tail masking, tensor-core throughput,
and occupancy behavior instead of reimplementing them. Only the KV read changes:
O(window) instead of O(context) — at 32k that skips ~87% of the int8 KV traffic on a
kernel that profiles at the bandwidth roofline (11.7% of decode busy time).

Engagement policy:
- **Decode steps only** (`sample`): prefill, the prefill CUDA graph, and teacher-forced
  scoring always run the byte-identical dense path.
- `min_ctx = 16384` for GQA-8 (the dense hd256 path is already int8 tensor-core, so the
  window's read advantage clears it decisively only from ~16k up), window 256 blocks
  (4096 tokens) + sink block, int8 KV only.
- KV splits over the view are sized so every MMA split keeps >= 2 KV blocks
  (128 splits x 8 kv heads = 1024 CTAs — keeps the 5090's SMs fed; the view-sized
  host constants keep the captured decode graph stable).
- Qwythos GQA-4 keeps its existing scalar sparse path and 8192 engagement, untouched.
- `SPARKINFER_SPARSE_KV=0` fully restores dense; `_WINDOW` / `_MIN_CTX` apply as before.

Files: `kernels/csrc/cuda/attention/sparse_kv.cu` (+50),
`kernels/include/sparkinfer/kernels/attention.h` (+5),
`runtime/src/models/qwen35.cpp` (+71/-6). No changes to any attention math kernel.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `bench/scripts/bench.sh` binary `qwen3_gguf_bench`,
Qwen3.6-35B-A3B-UD-Q4_K_M, n=128, bs=1, scored 32k context):

| | decode tok/s |
|---|--:|
| before (main `37b3bb5`) | 412.10 |
| after (this PR) | 460.38 |

**Interleaved A/B, same session, same box** (BASE/C1 alternating, warm start; driver 580.97):

| ctx | main (rounds) | this PR (rounds) | mean delta | per-round delta |
|--:|---|---|--:|---|
| 32768 | 411.6 / 412.7 / 412.1 / 412.0 | 461.5 / 460.1 / 456.8 / 463.0 | **+11.7%** | +12.1 / +11.5 / +10.8 / +12.4% |
| 16384 | 436.6 / 433.4 / 440.0 / 439.8 | 455.5 / 460.2 / 457.1 / 456.7 | **+4.6%** | +4.3 / +6.2 / +3.9 / +3.8% |
| 4096 | 453.5 / 455.3 / 459.8 | 457.0 / 459.4 / 453.5 | +0.1% | noise (sparse disengaged) |
| 512 | 460.1 / 463.6 / 458.4 / 458.3 | 460.4 / 461.0 / 463.5 / 456.0 | +0.0% | noise (sparse disengaged) |
| 128 | 466.5 / 469.0 / 468.7 / 467.5 | 464.2 / 471.4 / 462.4 / 465.4 | -0.4% | noise (sparse disengaged) |

No-regression guards (same interleaved protocol):

| guard | main | this PR | delta |
|---|--:|--:|--:|
| Qwen3.6 prefill pp @4k | 17147 | 17160 | +0.1% |
| Qwen3.6 prefill pp @16k | 23536 | 23622 | +0.4% |
| Qwen3.6 prefill pp @32k | 24645 | 24606 | -0.2% |
| Qwythos decode @128 | 287.8 | 288.5 | +0.2% |
| Qwythos decode @32k | 275.8 | 278.5 | +1.0% |
| Qwythos prefill pp @32k | 22739 | 22885 | +0.6% |

Qwythos runs the exact same code as main (the GQA-4 sparse path is untouched); Qwen3.6
below 16k runs the byte-identical dense path (the compact-view kernel is not even
launched).

```text
# bench/scripts/bench.sh — Qwen3.6-35B-A3B-UD-Q4_K_M, n=128, ctx=32768 (round 1 of 4)
# before (main 37b3bb5):
ttft         : 1.337 s  (24507.5 tok/s prefill, prompt=32768)
decode tg    : 411.59 tok/s  (2.4 ms/token, n=128, ctx=32768, bs=1)
prefill pp   : 24669.90 tok/s  (ctx=32768, sequential KV fill)

# after (this PR):
[sparse-kv] sliding-window (default on): gqa=8 window=256 blocks (4096 tokens) min_ctx=16384 (compact-view, decode-only)
ttft         : 1.322 s  (24796.0 tok/s prefill, prompt=32768)
decode tg    : 461.54 tok/s  (2.2 ms/token, n=128, ctx=32768, bs=1)
prefill pp   : 24735.47 tok/s  (ctx=32768, sequential KV fill)
```

## Correctness

- `ctest`: **9/9 passed** on the PR build.
- `bench/scripts/accuracy.sh` (Qwen3.6, pinned model sha `ac0e2c11...`, llama.cpp
  reference at the pinned commit), full gate on the PR build — **exit 0, all passes**:
  - short vs llama (bf16): **top1 = 0.9100, KL = 0.0749** (gates: top1 >= 0.90, KL <= 0.20)
  - long-context int8 probe (3 seeds x 8448 tok, tail 128):
    **mean top1 = 0.9609, KL = 0.3977** (veto if top1 < 0.875 or KL > 1.0)
  - H3 batched-prefill fidelity: **top1 = 1.0000, KL = 0.00736** (veto if top1 < 0.80 or KL > 0.05)
- Teacher-forced scoring and all probes run the dense path by construction (decode-only
  engagement + min_ctx 16384) — the accuracy surface of this PR is identical to main.
  Windowed decode beyond a 4k+sink horizon is the same StreamingLLM approximation the
  repo already ships by default for Qwythos (#379), extended to the shape #559 asks for.
- Mid-generation boundary crossing (ctx 16300 -> across 16384, per-token loop): decode
  graph recaptures into sparse mode cleanly, no fault, output stream continues.
- `SPARKINFER_SPARSE_KV=0` on this build restores dense numbers at 32k.

## Why this differs from earlier attempts on #559

Prior PRs (#560, #580) implemented a ~200-line dedicated wmma sparse-walker kernel
(indirect `sel_blk[]` group staging, per-token validity masks, its own Q/P quantization
pipeline) and died on process gates, not the concept. This PR adds **no new attention
kernel at all** — a 40-line block-id compaction pre-pass reuses the already-merged,
already-tuned dense int8-MMA kernel, so there is no duplicated attention math to keep
correct, and the perf-critical inner loops are exactly the ones main already ships.
