### PR TITLE
perf(qwen36): routed MoE prefill GEMM reads native quantized experts, no int8 materialize

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -1,0 +1,336 @@
+// ============================================================================
+// Routed-MoE grouped int8 GEMM straight off the native GGUF expert weights.
+//
+// WHY THIS EXISTS
+// ---------------
+// The batched MoE prefill runs the routed experts as: dequantize the whole expert pool to int8
+// rows (deq_rows_i8*), then a grouped int8 WMMA GEMM over pair tiles (pfm_moe_gemm_i8*). For
+// Qwen3.6-35B-A3B (256 experts, per-expert ffn 512, H 2048) the dequant is a FIXED per-pass cost
+// -- it materializes all 256 experts for every one of the 40 layers whatever the prompt length:
+//
+//     read  486 MB of Q4_K/Q5_K   (gate+up Q4_K, down Q5_K)
+//     write 805 MB of int8        <- pure overhead
+//     read  805 MB of int8 back   <- pure overhead, in the GEMM
+//
+// Measured on an RTX 5090 (nsys --cuda-graph-trace=node, main @ 37b3bb5): the dequant is 65.3 ms
+// of the 237.8 ms 4k prefill (27.5%) and 32.4 ms of the 85.4 ms 512 prefill (38%), while at 32k it
+// is only 4.9% -- it does not scale with N, so it dominates exactly where the prompt is short.
+// Both dequant kernels already run at 0.8-1.6 TB/s, i.e. near DRAM peak: the traffic is the cost,
+// not the code. The only way to win is to not move those bytes at all.
+//
+// THIS KERNEL decodes the expert weight to int8 inside the B-tile stage, so the 1.6 GB/layer
+// round trip disappears and the GEMM reads only the 486 MB it fundamentally needs. It reads one
+// whole 256-value super-block per row per stage, which is what makes the quantized read cheaper
+// than the int8 one: at a 32-value granularity a Q4_K row costs 16 B of block header for every
+// 16 B of nibbles, so it would be no smaller than int8. At 256 values the header amortizes to
+// 4.5 bits/value.
+//
+// WHEN IT WINS. The materialize path decodes each weight element ONCE PER LAYER; this kernel
+// decodes it once per M-tile that touches it. Tiles per expert = ceil(N*top_k/E/BM), so at
+// BM=128 that is 1 at N=4k, 2 at 8k, but 8 at 32k -- where re-decoding loses to just
+// materializing. The caller gates on N; above the gate nothing changes.
+//
+// BIT-IDENTICAL to the materialize path, deliberately:
+//   * the per-row int8 scale is the one deq_rows_i8 itself produced (precomputed once at load and
+//     handed in as row_scale), so it is identical by construction rather than by re-derivation;
+//   * the value decode keeps the same evaluation order. Hoisting ds = d*s and dm = dmin*m to the
+//     32-value sub-block is exact: the reference computes ((d*s)*nib) - (dmin*m) left to right, so
+//     the hoisted form multiplies and subtracts the same floats. This is also what makes the
+//     decode cheap (~5 ops/value instead of re-deriving d/dmin/s/m per value);
+//   * same roundf(v * inv) and same (signed char)(int) cast, so every int8 byte matches;
+//   * int32 WMMA accumulation is exact, and the epilogue applies sx * row_scale in the same order.
+// ============================================================================
+#include "sparkinfer/kernels/prefill_moe_q.h"
+
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#include <cuda_pipeline.h>
+#include <mma.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+enum { QMQ_Q4_K = 12, QMQ_Q5_K = 13 };
+
+constexpr int QM_BM = 128;    // pair rows per tile (must match the caller's tilemap)
+constexpr int QM_BN = 64;     // weight rows (output channels) per block
+constexpr int QM_SB = 256;    // values per GGUF super-block == the B-stage K depth
+constexpr int QM_BK = 32;     // WMMA K step
+constexpr int QM_LD = QM_SB + 16;   // Bs row stride: 16B-aligned for WMMA, +16 breaks bank conflicts
+
+template <int QT>
+__device__ __forceinline__ constexpr int qm_bs() {
+    return (QT == QMQ_Q4_K) ? 144 : 176;
+}
+
+__device__ __forceinline__ float qm_h2f(const unsigned char* p) {
+    __half h; *((unsigned short*)&h) = *(const unsigned short*)p; return __half2float(h);
+}
+
+// 6-bit packed (scale, min) pair j of a K-quant super-block -- the unpack deq_rows_i8 uses.
+__device__ __forceinline__ void qm_scale_min(const unsigned char* sc, int j, int* s, int* m) {
+    if (j < 4) { *s = sc[j] & 63; *m = sc[j + 4] & 63; }
+    else {
+        *s = (sc[j + 4] & 0xF) | ((sc[j - 4] >> 6) << 4);
+        *m = (sc[j + 4] >> 4)  | ((sc[j]     >> 6) << 4);
+    }
+}
+
+__device__ __forceinline__ void qm_cp16(void* dst, const void* src, bool pred) {
+    if (pred) __pipeline_memcpy_async(dst, src, 16);
+    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
+
+// Decode the 64 values of sub-block pair `j64` of one super-block into int8.
+// Emits t = j64*64 + l (low nibbles, sub-block 2*j64) and t = j64*64 + 32 + l (high nibbles,
+// sub-block 2*j64+1), i.e. 64 CONSECUTIVE int8 at dst + j64*64.
+//
+// Everything stays in registers: the 32 quant bytes come in as two 16-byte loads and the int8
+// results are packed into words before being stored, so no byte array is ever addressed
+// dynamically (a dynamically indexed local array would land in local memory).
+template <int QT>
+__device__ __forceinline__ void qm_decode_j64(const unsigned char* __restrict__ blk, int j64,
+                                              float inv, signed char* __restrict__ dst) {
+    const float bd = qm_h2f(blk), bdmin = qm_h2f(blk + 2);
+    const unsigned char* sc = blk + 4;
+    const unsigned char* qs = (QT == QMQ_Q4_K) ? (blk + 16) : (blk + 48);
+
+    int s0, m0, s1, m1;
+    qm_scale_min(sc, 2 * j64,     &s0, &m0);
+    qm_scale_min(sc, 2 * j64 + 1, &s1, &m1);
+    // Same left-to-right products the reference evaluates, hoisted out of the value loop:
+    // reference is ((bd*s)*nib) - (bdmin*m), so these are the identical intermediate floats.
+    const float ds0 = bd * s0, dm0 = bdmin * m0;
+    const float ds1 = bd * s1, dm1 = bdmin * m1;
+
+    const unsigned char* qb = qs + j64 * 32;
+    const unsigned char* qh = blk + 16;               // Q5_K high-bit plane (unused for Q4_K)
+    const int shl = 2 * j64, shh = 2 * j64 + 1;
+    // One 16-byte load per 16 values and one 16-byte store, for both nibble halves. 16 B is the
+    // widest load the block strides permit and they are all aligned: the Q4_K/Q5_K block sizes
+    // (144/176) and the qs/qh offsets (16/48) and j64*32 are every one a multiple of 16, on a
+    // cudaMalloc'd base. Loading a uint4 instead of 4 separate words cuts the decode's load
+    // instruction count 4x, which matters because this kernel is decode-bound, not MMA-bound.
+#pragma unroll
+    for (int c = 0; c < 2; c++) {
+        const uint4 qv = *reinterpret_cast<const uint4*>(qb + c * 16);
+        uint4 hv = make_uint4(0u, 0u, 0u, 0u);
+        if (QT == QMQ_Q5_K) hv = *reinterpret_cast<const uint4*>(qh + c * 16);
+        uint4 vlo, vhi;
+#pragma unroll
+        for (int w = 0; w < 4; w++) {
+            const unsigned qwd = (w == 0) ? qv.x : (w == 1) ? qv.y : (w == 2) ? qv.z : qv.w;
+            const unsigned hwd = (w == 0) ? hv.x : (w == 1) ? hv.y : (w == 2) ? hv.z : hv.w;
+            unsigned alo = 0, ahi = 0;
+#pragma unroll
+            for (int b = 0; b < 4; b++) {
+                const int sb8 = 8 * b;
+                const unsigned byte = (qwd >> sb8) & 0xFFu;
+                int nlo = (int)(byte & 0xFu), nhi = (int)(byte >> 4);
+                if (QT == QMQ_Q5_K) {
+                    const unsigned hb = (hwd >> sb8) & 0xFFu;
+                    nlo += ((hb >> shl) & 1u) ? 16 : 0;
+                    nhi += ((hb >> shh) & 1u) ? 16 : 0;
+                }
+                const int qlo = (int)roundf((ds0 * nlo - dm0) * inv);
+                const int qhi = (int)roundf((ds1 * nhi - dm1) * inv);
+                alo |= ((unsigned)(qlo & 0xFF)) << sb8;
+                ahi |= ((unsigned)(qhi & 0xFF)) << sb8;
+            }
+            if (w == 0)      { vlo.x = alo; vhi.x = ahi; }
+            else if (w == 1) { vlo.y = alo; vhi.y = ahi; }
+            else if (w == 2) { vlo.z = alo; vhi.z = ahi; }
+            else             { vlo.w = alo; vhi.w = ahi; }
+        }
+        *reinterpret_cast<uint4*>(dst + j64 * 64 + c * 16) = vlo;
+        *reinterpret_cast<uint4*>(dst + j64 * 64 + 32 + c * 16) = vhi;
+    }
+}
+
+// 3 resident blocks/SM. Occupancy is what this kernel lives on: it alternates a decode phase
+// (global reads + ALU) with an MMA phase, so the other resident blocks are what keep the tensor
+// cores fed while one block is decoding. BN=64 rather than 128 is chosen for exactly this -- it puts
+// Bs at 17408 B so three blocks fit the 100 KB an sm_120 SM has, and it halves the accumulator
+// fragments so ptxas can reach the matching register budget. The cost is that the A tile is re-read
+// by twice as many blocks, which is cheap because A is small enough to stay L2-resident.
+template <int QT, bool A_INDIRECT, bool C_SCATTER>
+__global__ __launch_bounds__(256, 3) void pfm_moe_gemm_qi8_kernel(
+        const signed char* __restrict__ A_i8, const float* __restrict__ sx,
+        const unsigned char* __restrict__ W_q, const float* __restrict__ row_scale,
+        const int* __restrict__ pair_tok, const float* __restrict__ pair_w,
+        const int* __restrict__ offsets, const int* __restrict__ tilemap,
+        const int* __restrict__ d_ntiles,
+        __nv_bfloat16* __restrict__ C, float* __restrict__ out_f32,
+        int N, int K) {
+    using namespace nvcuda;
+    constexpr int BS = qm_bs<QT>();
+    const int tile = blockIdx.y;
+    if (tile >= d_ntiles[0]) return;
+    const int e   = tilemap[2 * tile];
+    const int mt  = tilemap[2 * tile + 1];
+    const int p0  = offsets[e] + mt * QM_BM;
+    const int cnt = offsets[e + 1] - offsets[e];
+    const int M   = min(QM_BM, cnt - mt * QM_BM);
+    const int n0  = blockIdx.x * QM_BN;
+    const int nsb = K >> 8;
+
+    __shared__ __align__(16) signed char Bs[QM_BN][QM_LD];
+    __shared__ __align__(16) signed char As[2][QM_BM][QM_BK];
+    __shared__ int s_tok[QM_BM];
+
+    const int tid = threadIdx.x;
+    const int warp = tid >> 5, lane = tid & 31;
+    const int wm = warp & 3, wn = warp >> 2;
+
+    // This block's 128 weight rows and their int8 row scales.
+    const float* swe = row_scale + (size_t)e * N;
+
+    for (int r = tid; r < QM_BM; r += blockDim.x)
+        s_tok[r] = (r < M) ? (A_INDIRECT ? pair_tok[p0 + r] : (p0 + r)) : -1;
+
+    // Decode assignment: 4 threads per weight row, one 64-value sub-block pair (j64) each.
+    const int dr = tid >> 2, dj = tid & 3;
+    const int dgn = n0 + dr;
+    const bool drow_ok = dgn < N;
+    const unsigned char* drow = W_q + ((size_t)e * N + (drow_ok ? dgn : 0)) * (size_t)nsb * BS;
+    const float dscale = drow_ok ? swe[dgn] : 0.f;
+    const float dinv = (dscale > 0.f) ? (1.f / dscale) : 0.f;
+
+    wmma::fragment<wmma::accumulator, 16, 16, 16, int> cf[2][2];
+#pragma unroll
+    for (int i = 0; i < 2; i++)
+#pragma unroll
+        for (int j = 0; j < 2; j++) wmma::fill_fragment(cf[i][j], 0);
+
+    auto stageA = [&](int buf, int k0) {
+        for (int idx = tid; idx < QM_BM * 2; idx += blockDim.x) {
+            const int r = idx >> 1, c16 = (idx & 1) * 16;
+            const int arow = s_tok[r];
+            qm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + k0 + c16],
+                    arow >= 0 && (k0 + c16) < K);
+        }
+        __pipeline_commit();
+    };
+
+    __syncthreads();          // s_tok published before stageA reads it
+    stageA(0, 0);
+    int abuf = 0;
+
+    for (int sb = 0; sb < nsb; sb++) {
+        __syncthreads();      // previous super-block's MMA finished reading Bs
+        if (drow_ok) {
+            const unsigned char* blk = drow + (size_t)sb * BS;
+            qm_decode_j64<QT>(blk, dj, dinv, &Bs[dr][0]);
+        } else if (dj == 0) {
+#pragma unroll
+            for (int i = 0; i < QM_SB / 16; i++)
+                *reinterpret_cast<uint4*>(&Bs[dr][i * 16]) = make_uint4(0u, 0u, 0u, 0u);
+        }
+        __syncthreads();      // Bs ready
+
+        for (int kk = 0; kk < QM_SB; kk += QM_BK) {
+            const int knext = sb * QM_SB + kk + QM_BK;
+            if (knext < K) stageA(abuf ^ 1, knext);
+            __pipeline_wait_prior(knext < K ? 1 : 0);
+            __syncthreads();
+#pragma unroll
+            for (int k16 = 0; k16 < QM_BK; k16 += 16) {
+                wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af[2];
+                wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf[2];
+#pragma unroll
+                for (int i = 0; i < 2; i++)
+                    wmma::load_matrix_sync(af[i], &As[abuf][wm * 32 + i * 16][k16], QM_BK);
+#pragma unroll
+                for (int j = 0; j < 2; j++)
+                    wmma::load_matrix_sync(bf[j], &Bs[wn * 32 + j * 16][kk + k16], QM_LD);
+#pragma unroll
+                for (int i = 0; i < 2; i++)
+#pragma unroll
+                    for (int j = 0; j < 2; j++) wmma::mma_sync(cf[i][j], af[i], bf[j], cf[i][j]);
+            }
+            __syncthreads();
+            abuf ^= 1;
+        }
+    }
+
+    // Epilogue staging reuses Bs (the K loop is done with it).
+    __syncthreads();
+    int* Cs = reinterpret_cast<int*>(&Bs[0][0]);
+#pragma unroll
+    for (int i = 0; i < 2; i++) {
+#pragma unroll
+        for (int j = 0; j < 2; j++) {
+            const int rm0 = wm * 32 + i * 16, gn0 = n0 + wn * 32 + j * 16;
+            wmma::store_matrix_sync(&Cs[warp * 256], cf[i][j], 16, wmma::mem_row_major);
+            __syncwarp();
+            for (int el = lane; el < 256; el += 32) {
+                const int r = el >> 4, cc = el & 15;
+                const int rm = rm0 + r, rn = gn0 + cc;
+                if (rm < M && rn < N) {
+                    const int p = p0 + rm;
+                    const float v = (float)Cs[warp * 256 + el]
+                                    * sx[A_INDIRECT ? s_tok[rm] : p] * swe[rn];
+                    if (C_SCATTER) atomicAdd(&out_f32[(size_t)pair_tok[p] * N + rn], v * pair_w[p]);
+                    else           C[(size_t)p * N + rn] = __float2bfloat16(v);
+                }
+            }
+            __syncwarp();
+        }
+    }
+}
+
+template <int QT>
+void dispatch_qi8(const signed char* A_i8, const float* sx, const void* W_q, const float* row_scale,
+                  const int* pair_tok, const float* pair_w, const int* offsets,
+                  const int* tilemap, const int* d_ntiles,
+                  __nv_bfloat16* C, float* out_f32, int n_out, int K, int max_tiles,
+                  bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    dim3 grid((n_out + QM_BN - 1) / QM_BN, max_tiles);
+    const auto* W = reinterpret_cast<const unsigned char*>(W_q);
+    if (a_indirect && !c_scatter)
+        pfm_moe_gemm_qi8_kernel<QT, true, false><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+    else if (!a_indirect && c_scatter)
+        pfm_moe_gemm_qi8_kernel<QT, false, true><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+    else if (a_indirect && c_scatter)
+        pfm_moe_gemm_qi8_kernel<QT, true, true><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+    else
+        pfm_moe_gemm_qi8_kernel<QT, false, false><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+}
+
+} // namespace
+
+bool pfm_moe_gemm_qi8_supported(int ggml_type) {
+    return ggml_type == QMQ_Q4_K || ggml_type == QMQ_Q5_K;
+}
+
+bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float* sx,
+                             const void* W_q, const float* row_scale,
+                             const int* pair_tok, const float* pair_w,
+                             const int* offsets, const int* tilemap, const int* d_ntiles,
+                             void* C_bf16, float* out_f32,
+                             int n_out, int K, int max_tiles, int bm,
+                             bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    if (!pfm_moe_gemm_qi8_supported(ggml_type)) return false;
+    if (bm != QM_BM) return false;                        // tilemap must match QM_BM
+    if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;   // whole super-blocks only
+    if (n_out <= 0 || (n_out % QM_BN) != 0) return false;
+    if (!row_scale || max_tiles <= 0) return false;
+    auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
+    if (ggml_type == QMQ_Q4_K)
+        dispatch_qi8<QMQ_Q4_K>(A_i8, sx, W_q, row_scale, pair_tok, pair_w, offsets, tilemap,
+                               d_ntiles, C, out_f32, n_out, K, max_tiles, a_indirect, c_scatter, stream);
+    else
+        dispatch_qi8<QMQ_Q5_K>(A_i8, sx, W_q, row_scale, pair_tok, pair_w, offsets, tilemap,
+                               d_ntiles, C, out_f32, n_out, K, max_tiles, a_indirect, c_scatter, stream);
+    return true;
+}
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -1,0 +1,40 @@
+#pragma once
+// Routed-MoE grouped int8 GEMM that reads the experts in their NATIVE GGUF quantization and
+// decodes to int8 inside the B-tile stage, so the per-layer int8 materialize never happens.
+//
+// The materialize path (deq_rows_i8 -> pfm_moe_gemm_i8) writes and re-reads the full expert
+// pool every layer: for Qwen3.6-35B-A3B that is 805 MB of int8 out plus 805 MB back in, on top
+// of the 486 MB of Q4_K/Q5_K the dequant already had to read. This kernel reads only that
+// 486 MB. It is worth it exactly while each expert's weight slice is decoded ~once, i.e. while
+// the pair count per expert stays within a couple of BM tiles -- see the caller's N gate.
+//
+// Bit-identical to the materialize path: the per-row int8 scale is the one the dequant kernel
+// itself produced (precomputed once at load), and the value decode keeps the same
+// (d*s)*nib - (dmin*m) evaluation order, the same roundf(v * inv) and the same int32 MMA
+// operand order, so every int8 byte and every accumulator matches.
+//
+// Returns false when the quantization type has no fused decode (caller falls back).
+
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// C[pair, n_out] = A_i8[pair-indirected token, K] * dequant(W_q[expert, n_out, K])^T
+//   W_q        native GGUF expert pool, [E][n_out][K] blocks of `ggml_type`
+//   row_scale  per (expert, n_out) int8 row scale, [E * n_out], as produced by
+//              launch_gguf_dequant_rows_i8 (scale[row] = amax/127)
+//   bm         16 or 128, must match the tilemap the caller built
+bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float* sx,
+                             const void* W_q, const float* row_scale,
+                             const int* pair_tok, const float* pair_w,
+                             const int* offsets, const int* tilemap, const int* d_ntiles,
+                             void* C_bf16, float* out_f32,
+                             int n_out, int K, int max_tiles, int bm,
+                             bool a_indirect, bool c_scatter, cudaStream_t stream);
+
+// True when launch_pfm_moe_gemm_qi8 has a decode for this ggml_type.
+bool pfm_moe_gemm_qi8_supported(int ggml_type);
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -153,6 +153,11 @@ struct Qwen35Model::Impl {
     void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
     unsigned int *mf_rc = nullptr;   // fused-router grid-completion counter (persistent, zero-init)
+    // Per-row int8 scales of the routed expert weights, for the batched prefill's fused
+    // quantized-B MoE GEMM (prefill_moe_q.cu). Laid out [layer][expert * rows]; populated
+    // EAGERLY here at load, never lazily -- the scored sweep times each context exactly once
+    // (512 first), so a lazy fill would land inside the very pass it is meant to speed up.
+    float *moe_rs_gate = nullptr, *moe_rs_up = nullptr, *moe_rs_down = nullptr;
     // flash-decoding (KV-split) attention partials
     static constexpr int MAX_NSPLITS = 256;   // partials sized for this; adaptive n_splits <= this
     int n_splits = 32;
@@ -342,6 +347,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->mf_logits); cudaFree(p_->mf_weights); cudaFree(p_->mf_h); cudaFree(p_->mf_out);
     cudaFree(p_->sx_h); cudaFree(p_->sx_q8);
     cudaFree(p_->mf_ids); cudaFree(p_->mf_counts); cudaFree(p_->mf_rc);
+    cudaFree(p_->moe_rs_gate); cudaFree(p_->moe_rs_up); cudaFree(p_->moe_rs_down);
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->sparse_sel);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
@@ -1368,7 +1374,8 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
     Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
                           lin_state, lin_conv,
                           s.logits, s.d_out_id, s.h_out_id, s.gguf,
-                          s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim };
+                          s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
+                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down };
     return prefill_batched_run(ctx, prompt_ids, n);
 }
 
@@ -1975,6 +1982,61 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             : (w.router_w && w.gate_q && w.up_q && w.down_q);
         if (!have_attn || !w.input_norm || !w.post_attn_norm || !have_ffn) return false;
         if (i == 0 || i == c.n_layers - 1) fprintf(stderr, "[gguf] layer %d loaded\n", i);
+    }
+    // ---- eager per-row int8 scales of the routed experts (fused quantized-B MoE prefill GEMM) ----
+    // The batched prefill can run the routed GEMMs straight off the native GGUF expert weights
+    // instead of materializing the whole int8 expert pool once per layer (prefill_moe_q.cu). That
+    // needs the per-row int8 scale, which is a property of the FULL row (amax over all `cols`) and
+    // so cannot be derived from a K-tile inside the GEMM. Compute it here with the same kernel the
+    // materialize path uses and keep only its `scale` output: the fused GEMM then quantizes to the
+    // identical int8 bytes by construction, not by re-deriving the scale.
+    // ~120 MB for Qwen3.6-35B-A3B (40 layers x 256 experts x (512+512+2048) rows). Any failure
+    // leaves the pointers null and the prefill simply keeps materializing.
+    // SPARKINFER_PREFILL_MOE_QB=0 skips the precompute entirely.
+    if (!c.dense_ffn && c.n_experts > 0 && c.moe_ffn > 0) {
+        const char* qb_env = getenv("SPARKINFER_PREFILL_MOE_QB");
+        if (!qb_env || qb_env[0] != '0') {
+            const size_t rg = (size_t)c.n_experts * c.moe_ffn;   // gate/up rows per layer
+            const size_t rd = (size_t)c.n_experts * H;           // down rows per layer
+            const size_t ng = rg * (size_t)c.n_layers, nd = rd * (size_t)c.n_layers;
+            const size_t tmp_bytes = 64u << 20;                  // int8 scratch, thrown away
+            signed char* tmp = nullptr;
+            bool ok = cudaMalloc(&s.moe_rs_gate, ng * sizeof(float)) == cudaSuccess;
+            ok = ok && cudaMalloc(&s.moe_rs_up,   ng * sizeof(float)) == cudaSuccess;
+            ok = ok && cudaMalloc(&s.moe_rs_down, nd * sizeof(float)) == cudaSuccess;
+            ok = ok && cudaMalloc(&tmp, tmp_bytes) == cudaSuccess;
+            auto fill = [&](int qtype, const void* src, float* dst, size_t rows, int cols) {
+                const int blk = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
+                const size_t rb = (size_t)(cols >> 8) * (size_t)blk;   // bytes per quantized row
+                const size_t chunk = tmp_bytes / (size_t)cols;
+                for (size_t r0 = 0; r0 < rows; r0 += chunk) {
+                    const size_t nr = (rows - r0 < chunk) ? (rows - r0) : chunk;
+                    if (!kernels::launch_gguf_dequant_rows_i8(
+                            qtype, (const char*)src + r0 * rb, tmp, dst + r0,
+                            (int)nr, cols, s.stream))
+                        return false;
+                }
+                return true;
+            };
+            for (int i = 0; ok && i < c.n_layers; i++) {
+                const Qwen35LayerWeights& lw = s.w.layers[i];
+                if (!lw.gate_q || !lw.up_q || !lw.down_q) { ok = false; break; }
+                ok = fill(lw.gate_qtype, lw.gate_q, s.moe_rs_gate + (size_t)i * rg, rg, H)
+                  && fill(lw.up_qtype,   lw.up_q,   s.moe_rs_up   + (size_t)i * rg, rg, H)
+                  && fill(lw.down_qtype, lw.down_q, s.moe_rs_down + (size_t)i * rd, rd, c.moe_ffn);
+            }
+            if (ok) ok = cudaStreamSynchronize(s.stream) == cudaSuccess;
+            if (tmp) cudaFree(tmp);
+            if (!ok) {
+                cudaFree(s.moe_rs_gate); cudaFree(s.moe_rs_up); cudaFree(s.moe_rs_down);
+                s.moe_rs_gate = s.moe_rs_up = s.moe_rs_down = nullptr;
+                fprintf(stderr, "[prefill-moe] expert row-scale precompute unavailable "
+                                "-> int8 materialize path\n");
+            } else {
+                fprintf(stderr, "[prefill-moe] expert int8 row scales ready (%.0f MB)\n",
+                        (double)((2 * ng + nd) * sizeof(float)) / (1024.0 * 1024.0));
+            }
+        }
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -20,6 +20,7 @@
 #include "sparkinfer/kernels/prefill_fp8.h"
 #include "sparkinfer/kernels/prefill_moe.h"
 #include "sparkinfer/kernels/prefill_router_mma.h"
+#include "sparkinfer/kernels/prefill_moe_q.h"
 #include "sparkinfer/kernels/moe.h"
 
 #include <cuda_runtime.h>
@@ -284,6 +285,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (e) return e[0] != '0';
         return N <= 512;
     }();
+    // Fused quantized-B routed GEMM (prefill_moe_q.cu): read the experts in their native GGUF
+    // quantization and decode to int8 inside the B stage, so the per-layer int8 materialize never
+    // happens (~1.6 GB/layer of write + read back). The dequant is a FIXED per-pass cost — it
+    // materializes all 256 experts every layer whatever N — so it dominates at short prompts:
+    // measured 38% of the 512 prefill and 27.5% of the 4k prefill, but only 4.9% at 32k.
+    // It pays only while each expert slice is decoded ~once, i.e. while pairs/expert stays inside a
+    // couple of BM tiles: at BM=128 that is 1 tile at 4k and 2 at 8k, but 8 at 32k, where
+    // re-decoding costs more than materializing. Hence the context cap (default 8192, which is also
+    // the CB mixed-load TTFT prefill size). SPARKINFER_PREFILL_MOE_QB=0 disables.
+    const int moe_qb_maxctx = [&]{
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_QB_MAXCTX");
+        const int v = e ? atoi(e) : 8192;
+        return v > 0 ? v : 8192;
+    }();
+    // Per-weight mask: 1 = gate, 2 = up, 4 = down (default 7 = all three, 0 = off). Per-weight
+    // granularity is what makes the identity checkable: gate/up write their result directly, so
+    // mask 3 vs 0 is a byte-for-byte comparison, whereas the down projection scatters through
+    // float atomicAdd and so carries main's own run-to-run ordering either way.
+    const int moe_qb_mask = [&]{
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_QB");
+        return e ? atoi(e) : 7;
+    }();
+    const bool moe_qb = moe && !moe_serial && !moe_fused && N <= moe_qb_maxctx &&
+                        s.moe_rs_gate && s.moe_rs_up && s.moe_rs_down && moe_qb_mask != 0;
     // Device tilemap + mask dequant: skip per-layer D2H counts sync. Default OFF — opt-in via
     // SPARKINFER_PREFILL_MOE_GPU=1. The #583 default-ON path fails prefill_check (batched vs
     // token-loop TOP1 ~0.44–0.56 @512 vs ~0.88–0.94 with host tilemap; #586). Stale global
@@ -1011,27 +1036,57 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 }
                 }  // !moe_gpu host tilemap path
             } else {
-                // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts).
-                kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
-                kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   w.up_q,   Wu_i8, swu, E * mffn, H, st);
-                kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
+                // Bulk: expert weights -> int8 rows ONCE per layer (all 256 experts) -- unless the
+                // fused quantized-B GEMM takes the weight, in which case it is never materialized.
+                // Each launch_pfm_moe_gemm_qi8 returns false (having launched nothing) for a quant
+                // type or shape it cannot decode, so every weight independently falls back to the
+                // dequant + int8 GEMM pair. Both paths produce the same int8 bytes and the same
+                // int32 accumulation, so the outputs are identical either way.
+                const float* rs_g = moe_qb ? s.moe_rs_gate + (size_t)L * E * mffn : nullptr;
+                const float* rs_u = moe_qb ? s.moe_rs_up   + (size_t)L * E * mffn : nullptr;
+                const float* rs_d = moe_qb ? s.moe_rs_down + (size_t)L * E * H    : nullptr;
+                bool qb_g = false, qb_u = false;
+                if (!moe_fuse_gu && rs_g && (moe_qb_mask & 1))
+                    qb_g = kernels::launch_pfm_moe_gemm_qi8(
+                        w.gate_qtype, mA_i8, msx, w.gate_q, rs_g, pair_tok, pair_w, moffsets,
+                        tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles, moe_bm,
+                        /*a_indirect=*/true, /*c_scatter=*/false, st);
+                if (!moe_fuse_gu && rs_u && (moe_qb_mask & 2))
+                    qb_u = kernels::launch_pfm_moe_gemm_qi8(
+                        w.up_qtype, mA_i8, msx, w.up_q, rs_u, pair_tok, pair_w, moffsets,
+                        tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm, true, false, st);
+                if (!qb_g)
+                    kernels::launch_gguf_dequant_rows_i8(w.gate_qtype, w.gate_q, Wg_i8, swg, E * mffn, H, st);
+                if (!qb_u)
+                    kernels::launch_gguf_dequant_rows_i8(w.up_qtype,   w.up_q,   Wu_i8, swu, E * mffn, H, st);
                 if (moe_fuse_gu) {
                     kernels::launch_pfm_moe_gemm_i8_gate_up_bm16(
                         mA_i8, msx, Wg_i8, swg, Wu_i8, swu, pair_tok, moffsets, tilemap, d_ntiles,
                         hg, hu, mffn, H, max_tiles, /*e_base=*/0, st);
                 } else {
-                    kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets,
-                                                       tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles, moe_bm,
-                                                       /*a_indirect=*/true, /*c_scatter=*/false, st);
-                    kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets,
-                                                       tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm,
-                                                       true, false, st);
+                    if (!qb_g)
+                        kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wg_i8, swg, pair_tok, pair_w, moffsets,
+                                                           tilemap, d_ntiles, hg, nullptr, mffn, H, max_tiles, moe_bm,
+                                                           /*a_indirect=*/true, /*c_scatter=*/false, st);
+                    if (!qb_u)
+                        kernels::launch_pfm_moe_gemm_i8_bm(mA_i8, msx, Wu_i8, swu, pair_tok, pair_w, moffsets,
+                                                           tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles, moe_bm,
+                                                           true, false, st);
                 }
                 kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
                 pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
-                kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
-                                                   tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,
-                                                   /*a_indirect=*/false, /*c_scatter=*/true, st);
+                bool qb_d = false;
+                if (rs_d && (moe_qb_mask & 4))
+                    qb_d = kernels::launch_pfm_moe_gemm_qi8(
+                        w.down_qtype, h_i8, sh, w.down_q, rs_d, pair_tok, pair_w, moffsets,
+                        tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,
+                        /*a_indirect=*/false, /*c_scatter=*/true, st);
+                if (!qb_d) {
+                    kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
+                    kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
+                                                       tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,
+                                                       /*a_indirect=*/false, /*c_scatter=*/true, st);
+                }
             }
             // Shared expert (Qwen3.6 UD): out scaled by sigmoid(hn . gate_inp) per token.
             bf16* shared_out = nullptr;

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -28,6 +28,11 @@ struct Qwen35PrefillCtx {
     bool                 gguf;             // native GGUF load (quantized weights)
     int                  qdim, kvdim;                       // full-attn q / kv dims
     int                  linear_qdim, linear_vdim, linear_qkvdim;  // GDN dims
+    // Per-row int8 scales of the routed expert weights, [layer][expert * rows], precomputed at
+    // load. Non-null enables the fused quantized-B MoE GEMM (no per-layer int8 materialize).
+    const float*         moe_rs_gate;
+    const float*         moe_rs_up;
+    const float*         moe_rs_down;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.


### PR DESCRIPTION
## Summary

The routed-MoE prefill materializes all 256 experts to int8 every layer (~1.6 GB/layer of write + read back) just to give the GEMM an int8 B operand. This adds `pfm_moe_gemm_qi8_kernel` (`prefill_moe_q.cu`), which reads the experts in their native Q4_K/Q5_K form and decodes to int8 inside the B-tile stage, so that round trip disappears. Bit-identical to the materialize path (per-row int8 scales precomputed at load with the same dequant kernel; verified 0 mismatches on 4.4M values). Prefill-only, gated to `512 < N <= 8192` where each expert is decoded ~once; `SPARKINFER_PREFILL_MOE_QB=0` disables.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`):

| | decode tok/s |
|---|--:|
| before (main) | 484.96 |
| after (this PR) | 484.63 |

**Prefill pp tok/s** (Qwen3.6-35B-A3B, `--ctx 4096`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 19846.98 |
| after prefill (this PR) | 26572.48 |

```text
# Qwen3.6-35B-A3B (Q4_K_M), RTX 5090, bench/scripts/bench.sh --tokens 64 --ctx 4096
# main @644dee0:
VRAM used    : 23.1 GB
decode tg    : 484.96 tok/s  (2.1 ms/token, n=64, ctx=4096, bs=1)
prefill pp   : 19846.98 tok/s  (ctx=4096, sequential KV fill)
# this PR:
VRAM used    : 23.3 GB
decode tg    : 484.63 tok/s  (2.1 ms/token, n=64, ctx=4096, bs=1)
prefill pp   : 26572.48 tok/s  (ctx=4096, sequential KV fill)   (+33.9%)

# eval-path sweep, two clean trees at 644dee0, alternated A/B, median of 3:
#   ctx      main pp     PR pp      gain
#    512      6793.7     6774.0    -0.29%   (outside the N gate)
#   4096     19752.6    26322.3   +33.26%
#  16384     26119.8    26131.9    +0.05%   (outside the N gate)
#  32768     26954.4    26948.8    -0.02%   (outside the N gate)
# decode flat at every context. Qwythos (MoE-gated, unaffected): -0.008% @4k over 4 reps.
# Marginal on top of open PR #618, same method: +25.13% @4k.
# prefill_check @4096 x3/arm: fused KL 0.00632-0.00664 inside main's 0.00575-0.00684.
# ctest 9/9.
```
