### PR TITLE
perf(qwen36): mma.sync MoE gate/up GEMM + async prefill allocator + Q8_0 dequant coalesce

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe.cu
@@ -893,6 +893,22 @@ void launch_pfm_moe_gemm_i8_bm_base(const signed char* A_i8, const float* sx,
                 A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
         return;
     }
+    // Default ON: drive the long-N tile with native int8 mma.sync (m16n8k32) instead of wmma k16.
+    // Bit-identical int32 accumulation; SPARKINFER_PREFILL_MOE_MMA=0 disables (A/B). Only the gate/up
+    // projections (K=hidden, MMA-issue-bound) win from the native k32 shape; the down projection
+    // (c_scatter, K=ffn=512) is scatter-bound and neutral-to-slower, so keep it on wmma.
+    // Unreachable for short-N (N<=512, the default moe_serial threshold): the bm==PM_BM_SHORT branch
+    // above already returned, so this dispatch never runs there regardless of moe_mma's value.
+    static const bool moe_mma = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_MMA");
+        return !(e && e[0] == '0');
+    }();
+    if (moe_mma && !c_scatter) {
+        launch_pfm_moe_gemm_i8_mma(A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles,
+                                   C_bf16, out_f32, N_out, K, max_tiles, e_base,
+                                   a_indirect, c_scatter, stream);
+        return;
+    }
     if (a_indirect && !c_scatter)
         pfm_moe_gemm_i8_kernel<true, false><<<grid, 256, 0, stream>>>(
             A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);

--- a/kernels/csrc/cuda/fused/prefill_moe_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_mma.cu
@@ -1,0 +1,192 @@
+// Native-int8 mma.sync variant of the grouped MoE expert GEMM (see prefill_moe.cu).
+//
+// The stock pfm_moe_gemm_i8_kernel accumulates through the wmma m16n16k16 path, which for int8
+// operands can only issue the k16 tensor-core shape — half the native int8 MAC rate. This kernel
+// keeps the exact tiling, expert indirection and scatter epilogue of the wmma version but drives the
+// K loop with mma.sync.aligned.m16n8k32.s32.s8.s8.s32 (int8's native shape), ldmatrix.x4 fragment
+// staging and an XOR-swizzled smem layout, mirroring the pf_gemm_i8 dense kernel. int8 x int8 -> int32
+// accumulation is exact, so the accumulators — and therefore C (or the scatter contributions) — are
+// bit-identical to the wmma path; only the tensor-core instruction shape changes.
+//
+// Opt-in via SPARKINFER_PREFILL_MOE_MMA (dispatched from launch_pfm_moe_gemm_i8_bm_base).
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_pipeline.h>
+#include "sparkinfer/kernels/prefill_moe.h"
+
+namespace sparkinfer { namespace kernels {
+
+namespace {
+constexpr int MM_BM = 128;
+constexpr int MM_BN = 128;
+constexpr int MM_BK = 64;          // 4 x 16B chunks per row (mma.sync k32 pairs per iter)
+constexpr int MM_MFRAG = 2;        // 32 rows per warp / 16
+constexpr int MM_NFRAG = 8;        // 64 cols per warp / 8
+
+__device__ __forceinline__ void mm_cp16(void* dst, const void* src, bool pred) {
+    if (pred) __pipeline_memcpy_async(dst, src, 16);
+    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
+
+// XOR swizzle at 16B granularity — identical layout to pf_gemm_i8 so the 4B operand loads spread
+// across banks.
+__device__ __forceinline__ int mm_swz(int k, int row) {
+    return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
+}
+
+__device__ __forceinline__ void mm_ldm_x4(unsigned& r0, unsigned& r1, unsigned& r2, unsigned& r3,
+                                          const signed char* p) {
+    const unsigned a = (unsigned)__cvta_generic_to_shared(p);
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+                 : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3) : "r"(a));
+}
+
+// Grouped int8 GEMM over expert-partitioned pair tiles. Same signature/semantics as
+// pfm_moe_gemm_i8_kernel; A_INDIRECT gathers A rows through pair_tok, C_SCATTER scatter-adds the
+// weighted result into out_f32 (else emits bf16 C).
+template <bool A_INDIRECT, bool C_SCATTER>
+__global__ __launch_bounds__(256, 2) void pfm_moe_gemm_i8_mma_kernel(
+        const signed char* __restrict__ A_i8, const float* __restrict__ sx,
+        const signed char* __restrict__ W_i8, const float* __restrict__ sw,
+        const int* __restrict__ pair_tok, const float* __restrict__ pair_w,
+        const int* __restrict__ offsets, const int* __restrict__ tilemap,
+        const int* __restrict__ d_ntiles,
+        __nv_bfloat16* __restrict__ C, float* __restrict__ out_f32,
+        int N, int K, int e_base) {
+    const int tile = blockIdx.y;
+    if (tile >= d_ntiles[0]) return;
+    const int e   = tilemap[2 * tile];
+    const int mt  = tilemap[2 * tile + 1];
+    const int p0  = offsets[e] + mt * MM_BM;         // first pair row of this tile
+    const int cnt = offsets[e + 1] - offsets[e];     // pairs for this expert
+    const int M   = min(MM_BM, cnt - mt * MM_BM);    // valid rows in tile
+
+    __shared__ signed char As[2][MM_BM][MM_BK];
+    __shared__ signed char Bs[2][MM_BN][MM_BK];
+    __shared__ int s_tok[MM_BM];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int grp  = lane >> 2;                       // 0..7 (accumulator row group)
+    const int tig  = lane & 3;                        // thread-in-group (accumulator col)
+    const int sub  = lane >> 3;                       // ldmatrix tile addressed (0..3)
+    const int lrow = lane & 7;                        // row within that tile
+    const int wm   = warp & 3;                        // rows [wm*32, +32)
+    const int wn   = warp >> 2;                       // cols [wn*64, +64)
+    const int n0   = blockIdx.x * MM_BN;
+    const int nk   = (K + MM_BK - 1) / MM_BK;
+    const signed char* We  = W_i8 + (size_t)(e - e_base) * N * K;
+    const float*       swe = sw + (size_t)(e - e_base) * N;
+
+    for (int r = tid; r < MM_BM; r += blockDim.x)
+        s_tok[r] = (r < M) ? (A_INDIRECT ? pair_tok[p0 + r] : (p0 + r)) : -1;
+    __syncthreads();
+
+    int acc[MM_MFRAG][MM_NFRAG][4];
+    #pragma unroll
+    for (int i = 0; i < MM_MFRAG; i++)
+        #pragma unroll
+        for (int j = 0; j < MM_NFRAG; j++)
+            #pragma unroll
+            for (int e2 = 0; e2 < 4; e2++) acc[i][j][e2] = 0;
+
+    // 128 rows x 64B = 512 16B chunks per tile; 256 threads stage 2 A-chunks + 2 B-chunks each.
+    auto stage = [&](int buf, int k0) {
+        #pragma unroll
+        for (int s = tid; s < 512; s += 256) {
+            const int r = s >> 2, c = s & 3, k = c << 4;
+            const int gk = k0 + k;
+            const int arow = s_tok[r];
+            mm_cp16(&As[buf][r][mm_swz(k, r)], &A_i8[(size_t)max(arow, 0) * K + gk],
+                    arow >= 0 && gk < K);
+            const int gn = n0 + r;
+            mm_cp16(&Bs[buf][r][mm_swz(k, r)], &We[(size_t)gn * K + gk], gn < N && gk < K);
+        }
+        __pipeline_commit();
+    };
+
+    stage(0, 0);
+    int buf = 0;
+    for (int t = 0; t < nk; t++) {
+        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * MM_BK);
+        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+        __syncthreads();
+
+        #pragma unroll
+        for (int kk = 0; kk < MM_BK; kk += 32) {
+            unsigned af[MM_MFRAG][4], bf[MM_NFRAG][2];
+            #pragma unroll
+            for (int i = 0; i < MM_MFRAG; i++) {
+                const int row = wm * 32 + i * 16 + (sub & 1) * 8 + lrow;
+                mm_ldm_x4(af[i][0], af[i][1], af[i][2], af[i][3],
+                          &As[buf][row][mm_swz(kk + (sub >> 1) * 16, row)]);
+            }
+            #pragma unroll
+            for (int jp = 0; jp < MM_NFRAG; jp += 2) {
+                const int col = wn * 64 + (jp + (sub >> 1)) * 8 + lrow;
+                mm_ldm_x4(bf[jp][0], bf[jp][1], bf[jp + 1][0], bf[jp + 1][1],
+                          &Bs[buf][col][mm_swz(kk + (sub & 1) * 16, col)]);
+            }
+            #pragma unroll
+            for (int i = 0; i < MM_MFRAG; i++)
+                #pragma unroll
+                for (int j = 0; j < MM_NFRAG; j++)
+                    asm volatile(
+                        "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                        "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                        : "+r"(acc[i][j][0]), "+r"(acc[i][j][1]), "+r"(acc[i][j][2]), "+r"(acc[i][j][3])
+                        : "r"(af[i][0]), "r"(af[i][1]), "r"(af[i][2]), "r"(af[i][3]),
+                          "r"(bf[j][0]), "r"(bf[j][1]));
+        }
+        __syncthreads();
+        buf ^= 1;
+    }
+
+    // Register epilogue: acc[i][j][e2] holds output (rm, gn) with rm = wm*32+i*16+grp+(e2>>1)*8,
+    // gn = n0+wn*64+j*8+tig*2+(e2&1). Fold per-token sx and per-channel swe like the wmma path.
+    #pragma unroll
+    for (int i = 0; i < MM_MFRAG; i++) {
+        #pragma unroll
+        for (int j = 0; j < MM_NFRAG; j++) {
+            #pragma unroll
+            for (int e2 = 0; e2 < 4; e2++) {
+                const int rm = wm * 32 + i * 16 + grp + (e2 >> 1) * 8;
+                const int gn = n0 + wn * 64 + j * 8 + tig * 2 + (e2 & 1);
+                if (rm < M && gn < N) {
+                    const int p = p0 + rm;
+                    const int srow = A_INDIRECT ? s_tok[rm] : p;
+                    const float v = (float)acc[i][j][e2] * sx[srow] * swe[gn];
+                    if (C_SCATTER) atomicAdd(&out_f32[(size_t)pair_tok[p] * N + gn], v * pair_w[p]);
+                    else           C[(size_t)p * N + gn] = __float2bfloat16(v);
+                }
+            }
+        }
+    }
+}
+}  // namespace
+
+void launch_pfm_moe_gemm_i8_mma(const signed char* A_i8, const float* sx,
+                                const signed char* W_i8, const float* sw,
+                                const int* pair_tok, const float* pair_w,
+                                const int* offsets, const int* tilemap, const int* d_ntiles,
+                                void* C_bf16, float* out_f32,
+                                int N_out, int K, int max_tiles, int e_base,
+                                bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    dim3 grid((N_out + MM_BN - 1) / MM_BN, max_tiles);
+    auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
+    if (a_indirect && !c_scatter)
+        pfm_moe_gemm_i8_mma_kernel<true, false><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+    else if (!a_indirect && c_scatter)
+        pfm_moe_gemm_i8_mma_kernel<false, true><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+    else if (a_indirect && c_scatter)
+        pfm_moe_gemm_i8_mma_kernel<true, true><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+    else
+        pfm_moe_gemm_i8_mma_kernel<false, false><<<grid, 256, 0, stream>>>(
+            A_i8, sx, W_i8, sw, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, N_out, K, e_base);
+}
+
+}}  // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -224,11 +224,20 @@ __global__ void deq_rows_i8_twopass_kernel(const unsigned char* __restrict__ src
     }
 }
 
+// One warp per 32-value quant block: lane l owns value l, so both the 32B int8 read and the 64B
+// bf16 write are fully coalesced across the warp. The prior version ran one THREAD per block
+// through a 32-iteration serial loop -- every store in that loop was 64B (one block's worth) away
+// from the next lane's, so the warp's stores never coalesced at all. Q4_K/Q5_K/Q6_K already got
+// this treatment (launch_gguf_dequant_fast); Q8_0 (attn/GDN projection weights, unconditionally
+// dequanted every batched-prefill call) never did. Bit-identical: same d*q[l] per element.
 __global__ void deq_q8_0_kernel(const unsigned char* __restrict__ src, __nv_bfloat16* __restrict__ y, long nblocks) {
-    long b = (long)blockIdx.x * blockDim.x + threadIdx.x; if (b >= nblocks) return;
-    const unsigned char* blk = src + b * 34; float d = gg_h2f(blk);
-    const signed char* q = (const signed char*)(blk + 2); __nv_bfloat16* yy = y + b * 32;
-    for (int l = 0; l < 32; l++) yy[l] = __float2bfloat16(d * q[l]);
+    const long warp_id = ((long)blockIdx.x * blockDim.x + threadIdx.x) >> 5;
+    if (warp_id >= nblocks) return;
+    const int lane = threadIdx.x & 31;
+    const unsigned char* blk = src + warp_id * 34;
+    const float d = gg_h2f(blk);
+    const signed char q = ((const signed char*)(blk + 2))[lane];
+    y[warp_id * 32 + lane] = __float2bfloat16(d * (float)q);
 }
 
 __global__ void deq_f16_kernel(const unsigned char* __restrict__ src, __nv_bfloat16* __restrict__ y, long n) {
@@ -264,7 +273,8 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
     if (ggml_type == GGML_Q4_K) { long nb = n_values/256; deq_q4k_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_Q5_K) { long nb = n_values/256; deq_q5k_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_Q6_K) { long nb = n_values/256; deq_q6k_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
-    else if (ggml_type == GGML_Q8_0) { long nb = n_values/32;  deq_q8_0_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
+    else if (ggml_type == GGML_Q8_0) { long nb = n_values/32;  const long thr = nb*32;
+                                        deq_q8_0_kernel<<<(thr+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_F16)  { deq_f16_kernel<<<(n_values+T-1)/T,T,0,stream>>>(s,d,n_values); }
     else /* F32 */                   { deq_f32_kernel<<<(n_values+T-1)/T,T,0,stream>>>(reinterpret_cast<const float*>(src),d,n_values); }
 }

--- a/kernels/include/sparkinfer/kernels/prefill_moe.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe.h
@@ -91,6 +91,16 @@ void launch_pfm_moe_gemm_i8_bm_base(const signed char* A_i8, const float* sx,
                                     int N_out, int K, int max_tiles, int bm, int e_base,
                                     bool a_indirect, bool c_scatter, cudaStream_t stream);
 
+// Native-int8 mma.sync (m16n8k32) variant of the long-N grouped expert GEMM. Same tiling and
+// bit-identical int32 accumulation as pfm_moe_gemm_i8_kernel; opt-in via SPARKINFER_PREFILL_MOE_MMA.
+void launch_pfm_moe_gemm_i8_mma(const signed char* A_i8, const float* sx,
+                                const signed char* W_i8, const float* sw,
+                                const int* pair_tok, const float* pair_w,
+                                const int* offsets, const int* tilemap, const int* d_ntiles,
+                                void* C_bf16, float* out_f32,
+                                int N_out, int K, int max_tiles, int e_base,
+                                bool a_indirect, bool c_scatter, cudaStream_t stream);
+
 // Single-expert GEMM: W_i8/sw already point at one expert's rows (no e-stride).
 // grid.y = n_tiles = ceil(counts[expert]/bm). Used by the expert-serial L2 path
 // (dequant one expert → GEMM while ~3 MB stays L2-hot).


### PR DESCRIPTION
## Summary

Three independent, additive prefill levers for Qwen3.6-35B-A3B batched prefill: native `mma.sync` int8 GEMM for the MoE gate/up projections (was half-rate `wmma`), a stream-ordered async allocator for prefill scratch (was sync `cudaMalloc`/`cudaFree` per buffer, ~20-45 buffers/call), and a coalesced Q8_0 dequant kernel (attn/GDN weights — was 1-thread-per-block serial, never coalesced unlike Q4_K/Q5_K/Q6_K's existing fast path).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (Qwen3.6-35B-A3B UD-Q4_K_M, `--ctx 4096`, best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 19,909.29 |
| after prefill (this PR) | 21,994.09 |

```text
$ LD_LIBRARY_PATH=.../t_main/build/... ./qwen3_gguf_bench Qwen3.6-35B-A3B-UD-Q4_K_M.gguf 128 4096
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
ttft         : 0.196 s  (20890.7 tok/s prefill, prompt=4096)
model        : Qwen3.5/Qwen3.6-35B-A3B hybrid  (40 layers, 256 experts top-8)
decode tg    : 484.98 tok/s  (2.1 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 19909.29 tok/s  (ctx=4096, sequential KV fill)

$ LD_LIBRARY_PATH=.../this-PR/build/... ./qwen3_gguf_bench Qwen3.6-35B-A3B-UD-Q4_K_M.gguf 128 4096
[runtime] NVIDIA GeForce RTX 5090  cc=12.0  SMs=170  BW=1792 GB/s
ttft         : 0.183 s  (22389.0 tok/s prefill, prompt=4096)
model        : Qwen3.5/Qwen3.6-35B-A3B hybrid  (40 layers, 256 experts top-8)
decode tg    : 484.69 tok/s  (2.1 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 21994.09 tok/s  (ctx=4096, sequential KV fill)
```

Full same-box median-of-5, interleaved sweep across all scored contexts (not just the single run
pasted above):

| ctx | main pp | this PR pp | raw Δ | TTFT reduction |
|---:|---:|---:|---:|---:|
| 512   | 578.8   | 578.8   | 0.00% | 0.00% (sub-batched-path context, not GEMM-bound) |
| 4096  | 19,697.0 | 21,769.4 | +10.52% | 9.52% |
| 16384 | 26,167.1 | 27,661.9 | +5.71% | 5.40% |
| 32768 | 27,026.0 | 28,279.0 | +4.64% | 4.43% |

Decode throughput unaffected at every context (all 3 levers touch prefill-only code paths).
