### PR TITLE
perf(qwen36): Q4_K requant for shared-expert + lm_head, fused GDN alpha/beta GEMV

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_norm_quant.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_norm_quant.cu
@@ -1,0 +1,249 @@
+// Fused gated RMSNorm + int8 row-quantize for the Gated-DeltaNet prefill o_proj input.
+//
+// The batched GDN prefill layer writes att = gdn_scan(...), runs a standalone gated RMSNorm
+// (out = (att/rms(att)) * weight * silu(z), pf_gated_norm_kernel) into a bf16 scratch buffer
+// lnrm, and then -- whenever the o_proj GEMM takes the residual-fused int8 path -- a separate
+// per-row int8 quantizer re-reads all of lnrm before the GEMM. lnrm exists only to ferry values
+// between those two kernels; fusing them removes its store and its reload, the same DRAM
+// round-trip elimination prefill_swiglu_quant.cu already applies to the FFN down-proj input,
+// applied here to the GDN o_proj input instead.
+//
+// One block per token, HPW heads per warp (v_heads = 8*HPW). Each warp keeps its heads' raw
+// x/z values in registers, computes the per-head RMS norm and the bf16-rounded gated output
+// (same math and rounding order as pf_gated_norm_kernel -> numerically identical) without a
+// second DRAM pass, contributes its local max|.| to a block-wide reduction for the per-row int8
+// scale (same amax/127 scale and roundf as the standalone row quantizer -- max is associative
+// and exact in fp, so this reduction order gives the identical amax), then writes int8 straight
+// from the registers it already holds.
+#include "sparkinfer/kernels/prefill.h"
+#include "sparkinfer/kernels/prefill_fp8.h"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+#include <cstdlib>
+
+namespace sparkinfer {
+namespace kernels {
+
+namespace {
+
+// Matches FP8_TGT in prefill_gemm_fp8.cu -- the fp16-accumulate GEMM's overflow bound depends on
+// activations being scaled to this same target, so it cannot drift from that file's constant.
+constexpr float GNQ_FP8_TGT = 2.0f;
+
+__device__ __forceinline__ float gnq_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ float gnq_silu(float x) { return x / (1.f + __expf(-x)); }
+__device__ __forceinline__ float gnq_wsum(float v) {
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffffu, v, m);
+    return v;
+}
+
+template <int HEAD_DIM, int HPW>
+__global__ __launch_bounds__(256) void pf_gdn_norm_quant_i8_kernel(
+        const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ z,
+        const __nv_bfloat16* __restrict__ weight,
+        signed char* __restrict__ q, float* __restrict__ scale,
+        int n_tokens, int v_heads, float eps) {
+    constexpr int NROW = HEAD_DIM / 32;
+    constexpr int N_WARPS = 256 / 32;
+    const int t = blockIdx.x;
+    if (t >= n_tokens) return;
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+
+    // weight[hd] is the SAME vector for every head and every token -- load once per thread.
+    float wv[NROW];
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) wv[r] = gnq_to_f(weight[lane + r * 32]);
+
+    // Each warp owns HPW contiguous heads; keep the bf16-rounded gated output in registers so
+    // the quantize pass below never re-reads x/z or a materialized norm output from DRAM.
+    float ov[HPW][NROW];
+    float amax = 0.f;
+    #pragma unroll
+    for (int hh = 0; hh < HPW; hh++) {
+        const int h = warp * HPW + hh;
+        const size_t base = ((size_t)t * v_heads + h) * HEAD_DIM;
+        float xv[NROW], zv[NROW], ss = 0.f;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int d = lane + r * 32;
+            xv[r] = gnq_to_f(x[base + d]);
+            zv[r] = gnq_to_f(z[base + d]);
+            ss += xv[r] * xv[r];
+        }
+        const float inv = rsqrtf(gnq_wsum(ss) / HEAD_DIM + eps);
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const float o = xv[r] * inv * wv[r] * gnq_silu(zv[r]);
+            const float ob = __bfloat162float(__float2bfloat16(o));   // matches the bf16 store/reload it replaces
+            ov[hh][r] = ob;
+            amax = fmaxf(amax, fabsf(ob));
+        }
+    }
+
+    // Block-wide (all v_heads of this token) max reduction for the int8 row scale.
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    __shared__ float s_warp[N_WARPS];
+    if (lane == 0) s_warp[warp] = amax;
+    __syncthreads();
+    if (warp == 0) {
+        float v = (lane < N_WARPS) ? s_warp[lane] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (lane == 0) s_warp[0] = v;
+    }
+    __syncthreads();
+    const float row_amax = s_warp[0];
+    const float d = row_amax / 127.0f;
+    if (threadIdx.x == 0) scale[t] = d;
+
+    #pragma unroll
+    for (int hh = 0; hh < HPW; hh++) {
+        const int h = warp * HPW + hh;
+        const size_t base = ((size_t)t * v_heads + h) * HEAD_DIM;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int dd = lane + r * 32;
+            q[base + dd] = (signed char)((row_amax == 0.f) ? 0 : (int)roundf(ov[hh][r] / d));
+        }
+    }
+}
+
+// Same fusion, e4m3 output: for MoE (Qwen3.6) GDN layers, which always run the o_proj GEMM on the
+// fp8 tensor cores (moe_fp8, default on) rather than int8 (use_i8 defaults off for MoE -- the
+// discrete top-k router amplifies int8 activation-quant error). Numerically identical to
+// pf_gated_norm_kernel followed by pf_quantize_rows_fp8_kernel (same amax/FP8_TGT scale, same
+// e4m3 rounding), just without the bf16 lnrm round trip.
+template <int HEAD_DIM, int HPW>
+__global__ __launch_bounds__(256) void pf_gdn_norm_quant_fp8_kernel(
+        const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ z,
+        const __nv_bfloat16* __restrict__ weight,
+        __nv_fp8_e4m3* __restrict__ q, float* __restrict__ scale,
+        int n_tokens, int v_heads, float eps) {
+    constexpr int NROW = HEAD_DIM / 32;
+    constexpr int N_WARPS = 256 / 32;
+    const int t = blockIdx.x;
+    if (t >= n_tokens) return;
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+
+    float wv[NROW];
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) wv[r] = gnq_to_f(weight[lane + r * 32]);
+
+    float ov[HPW][NROW];
+    float amax = 0.f;
+    #pragma unroll
+    for (int hh = 0; hh < HPW; hh++) {
+        const int h = warp * HPW + hh;
+        const size_t base = ((size_t)t * v_heads + h) * HEAD_DIM;
+        float xv[NROW], zv[NROW], ss = 0.f;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int d = lane + r * 32;
+            xv[r] = gnq_to_f(x[base + d]);
+            zv[r] = gnq_to_f(z[base + d]);
+            ss += xv[r] * xv[r];
+        }
+        const float inv = rsqrtf(gnq_wsum(ss) / HEAD_DIM + eps);
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const float o = xv[r] * inv * wv[r] * gnq_silu(zv[r]);
+            const float ob = __bfloat162float(__float2bfloat16(o));
+            ov[hh][r] = ob;
+            amax = fmaxf(amax, fabsf(ob));
+        }
+    }
+
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    __shared__ float s_warp[N_WARPS];
+    if (lane == 0) s_warp[warp] = amax;
+    __syncthreads();
+    if (warp == 0) {
+        float v = (lane < N_WARPS) ? s_warp[lane] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (lane == 0) s_warp[0] = v;
+    }
+    __syncthreads();
+    const float row_amax = s_warp[0];
+    const float d = (row_amax == 0.f) ? 1.f : (row_amax / GNQ_FP8_TGT);
+    if (threadIdx.x == 0) scale[t] = d;
+
+    #pragma unroll
+    for (int hh = 0; hh < HPW; hh++) {
+        const int h = warp * HPW + hh;
+        const size_t base = ((size_t)t * v_heads + h) * HEAD_DIM;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int dd = lane + r * 32;
+            q[base + dd] = __nv_fp8_e4m3(ov[hh][r] / d);
+        }
+    }
+}
+
+}  // namespace
+
+bool launch_prefill_gated_norm_quant_i8(const void* x, const void* z, const void* weight,
+                                        signed char* q, float* scale,
+                                        int n_tokens, int v_heads, int head_dim, float eps,
+                                        cudaStream_t stream) {
+    constexpr int BLOCK = 256, N_WARPS = BLOCK / 32;
+
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_NORM_QUANT");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || head_dim != 128 || n_tokens <= 0 || v_heads <= 0 || (v_heads % N_WARPS) != 0)
+        return false;
+
+    const auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
+    const auto zb = reinterpret_cast<const __nv_bfloat16*>(z);
+    const auto wb = reinterpret_cast<const __nv_bfloat16*>(weight);
+    const int hpw = v_heads / N_WARPS;
+    switch (hpw) {
+        case 1: pf_gdn_norm_quant_i8_kernel<128, 1><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, q, scale, n_tokens, v_heads, eps); break;
+        case 2: pf_gdn_norm_quant_i8_kernel<128, 2><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, q, scale, n_tokens, v_heads, eps); break;
+        case 4: pf_gdn_norm_quant_i8_kernel<128, 4><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, q, scale, n_tokens, v_heads, eps); break;
+        case 8: pf_gdn_norm_quant_i8_kernel<128, 8><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, q, scale, n_tokens, v_heads, eps); break;
+        default: return false;
+    }
+    return true;
+}
+
+bool launch_prefill_gated_norm_quant_fp8(const void* x, const void* z, const void* weight,
+                                         void* q, float* scale,
+                                         int n_tokens, int v_heads, int head_dim, float eps,
+                                         cudaStream_t stream) {
+    constexpr int BLOCK = 256, N_WARPS = BLOCK / 32;
+
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_NORM_QUANT");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || head_dim != 128 || n_tokens <= 0 || v_heads <= 0 || (v_heads % N_WARPS) != 0)
+        return false;
+
+    const auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
+    const auto zb = reinterpret_cast<const __nv_bfloat16*>(z);
+    const auto wb = reinterpret_cast<const __nv_bfloat16*>(weight);
+    const auto qb = reinterpret_cast<__nv_fp8_e4m3*>(q);
+    const int hpw = v_heads / N_WARPS;
+    switch (hpw) {
+        case 1: pf_gdn_norm_quant_fp8_kernel<128, 1><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, qb, scale, n_tokens, v_heads, eps); break;
+        case 2: pf_gdn_norm_quant_fp8_kernel<128, 2><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, qb, scale, n_tokens, v_heads, eps); break;
+        case 4: pf_gdn_norm_quant_fp8_kernel<128, 4><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, qb, scale, n_tokens, v_heads, eps); break;
+        case 8: pf_gdn_norm_quant_fp8_kernel<128, 8><<<n_tokens, BLOCK, 0, stream>>>(xb, zb, wb, qb, scale, n_tokens, v_heads, eps); break;
+        default: return false;
+    }
+    return true;
+}
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -111,6 +111,59 @@ template __global__ void gemv_f32_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloat1
 #ifndef _MSC_VER
 template __global__ void gemv_f32_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, int);
 #endif
+// Fused ssm_alpha + ssm_beta GDN gate GEMV: one launch computes BOTH tiny [K]->[V] projections
+// that share the same input activation xn, instead of two separate gemv_f32_sk_kernel<OutT,8>
+// calls. V (= linear_v_heads, e.g. 32) is tiny, so at decode time each standalone call is
+// launch-overhead bound rather than compute bound (nsys: ~1.8us/call, far above the K/1792GB/s
+// streaming time for K in the thousands). Grid covers both weight matrices' rows in one launch
+// (blockIdx.x < V -> alpha row blockIdx.x, else -> beta row blockIdx.x - V); each row still runs
+// the identical S=8 split-K reduction gemv_f32_sk_kernel<OutT,8> uses (same lane assignment, same
+// shuffle order, same partial-sum order), so alpha and beta are each bit-identical to their
+// standalone launch -- only the launch count changes (2 -> 1).
+template <typename OutT>
+__global__ void gdn_ab_sk8_kernel(const __nv_bfloat16* __restrict__ x,
+                                  const __nv_bfloat16* __restrict__ Wa,
+                                  const __nv_bfloat16* __restrict__ Wb,
+                                  OutT* __restrict__ ya, OutT* __restrict__ yb,
+                                  int V, int K) {
+    constexpr int S = 8;                      // matches GEMV_WPB (8) -> one output row per block
+    const bool is_b = blockIdx.x >= V;
+    const int row = is_b ? blockIdx.x - V : blockIdx.x;
+    if (row >= V) return;
+    const __nv_bfloat16* __restrict__ W = is_b ? Wb : Wa;
+    OutT* __restrict__ y = is_b ? yb : ya;
+
+    const int split = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    __shared__ float s_part[S];
+
+    const uint4* row4 = reinterpret_cast<const uint4*>(W + (size_t)row * K);
+    const uint4* x4 = reinterpret_cast<const uint4*>(x);
+    const int n4 = K / 8;
+    float acc = 0.f;
+    for (int i = split * 32 + lane; i < n4; i += S * 32) {
+        uint4 wv = row4[i], xv = x4[i];
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+        #pragma unroll
+        for (int j = 0; j < 4; j++) {
+            float2 wf = __bfloat1622float2(wh[j]), xf = __bfloat1622float2(xh[j]);
+            acc += wf.x * xf.x + wf.y * xf.y;
+        }
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) s_part[split] = acc;
+    __syncthreads();
+    if (split == 0 && lane == 0) {
+        float o = 0.f;
+        #pragma unroll
+        for (int s = 0; s < S; s++) o += s_part[s];
+        gemv_write(y + row, o);
+    }
+}
+#ifndef _MSC_VER
+template __global__ void gdn_ab_sk8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int);
+#endif
 // ---- quantized on-read GEMV (W = GGUF-native Q4_K/Q6_K [N,K]) -----------------
 // Dequantizes each 256-block in registers and dots with a full-precision (fp32)
 // activation — reads the quantized weight bytes (~4x less than bf16) with NO int8
@@ -1135,6 +1188,14 @@ void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K, cudaS
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
     gemv_kernel<float><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W), y, N, K);
+}
+
+void launch_gdn_alpha_beta(const void* x, const void* Wa, const void* Wb, void* ya, void* yb,
+                           int V, int K, cudaStream_t stream) {
+    gdn_ab_sk8_kernel<__nv_bfloat16><<<2 * V, GEMV_WPB * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(Wa), reinterpret_cast<const __nv_bfloat16*>(Wb),
+        reinterpret_cast<__nv_bfloat16*>(ya), reinterpret_cast<__nv_bfloat16*>(yb), V, K);
 }
 
 void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int K, cudaStream_t stream) {

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -728,6 +728,71 @@ __global__ void dense_gate_up_q4k_pack2_kernel(
     if (lane == 0) h_scratch[f] = q4kf_silu(tg) * tu;
 }
 
+// Qwen3.6 shared expert, Q4_K weights: same row/reduction math as dense_gate_up_q4k_pack2_kernel
+// (Q4_K si_vec_dot, pack2 rows/block) with the dw gate-scalar multiply from
+// shared_gate_up_q8_mmvq_kernel folded into the store -- the shared expert ships Q8_0 by default
+// (~2x the bytes/weight of Q4_K); requantizing it at load (see launch_proj_requant_q4k_lloyd,
+// already used for attention/GDN weights) and reading it here cuts the two biggest single decode
+// kernels (shared gate/up + down GEMV) roughly in half on the memory-bound read.
+template <int H, int F>
+__global__ void shared_gate_up_q4k_pack2_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
+    float* __restrict__ h_scratch) {
+    constexpr int NW = 4, WS = 32, NB = H >> 8;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int group = warp >> 2, group_warp = warp & 3;
+    const int f = blockIdx.x * 2 + group;
+    if (f >= F) return;
+    const int tid4 = group_warp * WS + lane;
+    const int kbx0 = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + (size_t)f * NB * 144);
+    const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + (size_t)f * NB * 144);
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = kbx0; kbx < NB; kbx += 8) {
+        tg += si_vec_dot_q4_K(g_row + kbx, vy + (size_t)kbx * 8, kqs);
+        tu += si_vec_dot_q4_K(u_row + kbx, vy + (size_t)kbx * 8, kqs);
+    }
+    __shared__ float sg[2][NW - 1][WS], su[2][NW - 1][WS];
+    if (group_warp > 0) { sg[group][group_warp - 1][lane] = tg; su[group][group_warp - 1][lane] = tu; }
+    __syncthreads();
+    if (group_warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[group][l][lane]; tu += su[group][l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) {
+        float w = dw ? __ldg(dw) : 1.f;
+        h_scratch[f] = w * q4kf_silu(tg) * tu;
+    }
+}
+
+// Shared-expert down, Q4_K weights: same per-row math as down_q4k_mmvq_kernel with the top_k
+// expert loop removed (the shared expert is always exactly one contribution, weight already
+// folded into h_scratch above) and the ACCUM/output convention from shared_down_q8_mmvq_kernel.
+template <int H, int F, bool ACCUM>
+__global__ void shared_down_q4k_mmvq_kernel(
+    const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
+    __nv_bfloat16* __restrict__ out) {
+    const int h = blockIdx.x * WPB + (threadIdx.x >> 5), lane = threadIdx.x & 31;
+    if (h >= H) return;
+    constexpr int NB = F >> 8;                 // 256-superblocks per row
+    constexpr int WORK = NB * 16;               // vdr=2 positions per superblock
+    const si_block_q4_K* drow = (const si_block_q4_K*)(down_q + (size_t)h * NB * 144);
+    float acc = 0.f;
+    for (int wi = lane; wi < WORK; wi += 32) {
+        const int kbx = wi >> 4, kqs = (wi & 15) << 1;
+        acc += si_vec_dot_q4_K(drow + kbx, hq8 + (size_t)kbx * 8, kqs);
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+    if (lane == 0) {
+        if constexpr (ACCUM) acc += __bfloat162float(out[h]);
+        out[h] = __float2bfloat16(acc);
+    }
+}
+
 // int8 dp4a MMVQ down (Q4_K). The Q4_K-quantized down rows in Q4_K_M were the last MoE GEMV
 // still on the fp register-dequant path (Q6_K down + gate/up + attention already run int8).
 // Reuses the Q8_1-quantized activation and the faithful vec_dot_q4_K_q8_1, one warp per
@@ -1536,6 +1601,41 @@ void launch_shared_expert_q8_mmvq(
             reinterpret_cast<__nv_bfloat16*>(output));
     } else {
         shared_down_q8_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
+            qbuf, reinterpret_cast<const unsigned char*>(down_q),
+            reinterpret_cast<__nv_bfloat16*>(output));
+    }
+}
+
+// Same as launch_shared_expert_q8_mmvq but for Q4_K-requantized shared-expert weights (see
+// shared_gate_up_q4k_pack2_kernel / shared_down_q4k_mmvq_kernel above). Activation stays Q8_1
+// either way -- only the weight read narrows from 8.5 to 4.5 bits/element.
+void launch_shared_expert_q4k_mmvq(
+    const void* input, const void* input_q8,
+    const void* gate_q, const void* up_q, const void* down_q,
+    const float* dw, void* output, float* h_scratch, void* h_q8_buf,
+    int hidden, int ffn, cudaStream_t stream, bool accum = false) {
+    const si_block_q8_1* vy;
+    si_block_q8_1* qbuf = reinterpret_cast<si_block_q8_1*>(h_q8_buf);
+    if (input_q8) {
+        vy = reinterpret_cast<const si_block_q8_1*>(input_q8);
+    } else {
+        si_quant_bf16_q8_1<<<(hidden >> 5), 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(input), qbuf, hidden);
+        vy = qbuf;
+    }
+    shared_gate_up_q4k_pack2_kernel<2048, 512><<<(ffn + 1) / 2, 8 * 32, 0, stream>>>(
+        vy, reinterpret_cast<const unsigned char*>(gate_q),
+        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    const int nqb = ffn >> 5;
+    quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
+        h_scratch, qbuf, nqb, 0);
+    dim3 dn((hidden + WPB - 1) / WPB);
+    if (accum) {
+        shared_down_q4k_mmvq_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
+            qbuf, reinterpret_cast<const unsigned char*>(down_q),
+            reinterpret_cast<__nv_bfloat16*>(output));
+    } else {
+        shared_down_q4k_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
             qbuf, reinterpret_cast<const unsigned char*>(down_q),
             reinterpret_cast<__nv_bfloat16*>(output));
     }

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -46,6 +46,15 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K,
 void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K,
                      cudaStream_t stream = nullptr);
 
+// Fused ssm_alpha + ssm_beta GDN gate GEMV: y_a[V] = x[K]@Wa^T, y_b[V] = x[K]@Wb^T in one launch.
+// Bit-identical to two launch_gemv(x, Wa, y_a, V, K) / launch_gemv(x, Wb, y_b, V, K) calls when
+// those would each take the split-K S=8 path (V < 4096, K % 8 == 0) -- only the launch count
+// drops from 2 to 1, which is what these tiny (V = linear_v_heads) decode-time GEMVs are bound by.
+// Caller must check V < 4096 && (K % 8) == 0 (true for every current GDN config); falls outside
+// that, use two separate launch_gemv calls instead.
+void launch_gdn_alpha_beta(const void* x, const void* Wa, const void* Wb, void* ya, void* yb,
+                           int V, int K, cudaStream_t stream = nullptr);
+
 // Fused GEMV + sigmoid for the shared-expert gate scalar (N=1). Uses scratch_bf16
 // for the bf16 dot (same as launch_gemv) then sigmoid_scalar. SPARKINFER_GEMV_SIGMOID=1 enables.
 void launch_gemv_sigmoid(const void* x, const void* W, void* scratch_bf16, float* y, int K,

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -86,4 +86,14 @@ void launch_shared_expert_q8_mmvq(
     int hidden, int ffn, cudaStream_t stream = nullptr,
     bool accum = false);
 
+// Same as launch_shared_expert_q8_mmvq but reads Q4_K-requantized shared-expert weights
+// (gate_q/up_q/down_q must be native Q4_K, not Q8_0). hidden must be 2048, ffn must be 512
+// (the only shape instantiated). Activation quantization (Q8_1) is unchanged.
+void launch_shared_expert_q4k_mmvq(
+    const void* input, const void* input_q8,
+    const void* gate_q, const void* up_q, const void* down_q,
+    const float* dw, void* output, float* h_scratch, void* h_q8_buf,
+    int hidden, int ffn, cudaStream_t stream = nullptr,
+    bool accum = false);
+
 }} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -70,6 +70,19 @@ void launch_prefill_gated_norm(const void* x, const void* z, const void* weight,
                                int n_tokens, int v_heads, int head_dim, float eps,
                                cudaStream_t stream = nullptr);
 
+// Fused gated RMSNorm + per-row int8 quantize, for GDN layers whose o_proj takes the residual-
+// fused int8 GEMM path: numerically identical to launch_prefill_gated_norm followed by the int8
+// row quantizer (both round the gated-norm result to bf16 first), but skips materializing the
+// bf16 intermediate in DRAM. q/scale are the same A_i8/sx buffers the int8 GEMM reads.
+//   x/z: [N, v_heads*hd]   weight: [hd]   q: [N, v_heads*hd] int8   scale: [N]
+// Returns false (nothing launched) when head_dim != 128 or v_heads is not a multiple of 8 -- the
+// caller should fall back to launch_prefill_gated_norm + the standalone row quantizer.
+// Env SPARKINFER_PREFILL_GDN_NORM_QUANT (default 1): 0 disables (A/B).
+bool launch_prefill_gated_norm_quant_i8(const void* x, const void* z, const void* weight,
+                                        signed char* q, float* scale,
+                                        int n_tokens, int v_heads, int head_dim, float eps,
+                                        cudaStream_t stream = nullptr);
+
 // Full-attention prefill: batched QK-norm + partial-RoPE (q,k in place, bf16) + int8 KV write
 // into the single-sequence paged pool at positions 0..N-1. Matches the decode int8 layout
 // (per-(token,kv_head) max-abs fp16 scale). block_table maps logical block -> physical block.

--- a/kernels/include/sparkinfer/kernels/prefill_fp8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_fp8.h
@@ -36,4 +36,15 @@ void launch_prefill_gemm_fp8(const void* A, const void* W,
 void launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
                                     int rows, int cols, cudaStream_t stream = nullptr);
 
+// Fused gated RMSNorm + per-row fp8 (e4m3) quantize, for MoE (Qwen3.6) GDN layers whose o_proj
+// always takes the fp8 tensor-core path (moe_fp8). Numerically identical to
+// launch_prefill_gated_norm followed by launch_prefill_quantize_rows_fp8, but skips materializing
+// the bf16 intermediate in DRAM. See prefill.h for the int8 counterpart (dense/Qwythos GDN).
+//   x/z: [N, v_heads*hd]   weight: [hd]   q: [N, v_heads*hd] e4m3   scale: [N]
+// Returns false when head_dim != 128 or v_heads is not a multiple of 8.
+bool launch_prefill_gated_norm_quant_fp8(const void* x, const void* z, const void* weight,
+                                         void* q, float* scale,
+                                         int n_tokens, int v_heads, int head_dim, float eps,
+                                         cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -656,6 +656,27 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                 kernels::launch_gemm(x, W, y, 1, N, K, 1.f, 0.f, gc, st);
             }
         };
+        // ssm_alpha/ssm_beta are both tiny (n_out == linear_v_heads) per-head gate projections of
+        // the SAME input xn, so when both stay in bf16 (the common case -- quantizing a 32-wide
+        // output weight costs more accuracy than it saves) they'd otherwise be two separate
+        // proj_xn(..., t=0) calls into launch_gemv's split-K path. At decode time each such call is
+        // launch-overhead bound (nsys: ~1.8us/call vs a sub-microsecond K-dot at this width), so
+        // fuse them into one launch_gdn_alpha_beta call -- same split-K math per output (bit-
+        // identical), just one kernel instead of two. Falls back to the separate calls whenever
+        // either weight is quantized. SPARKINFER_GDN_AB_FUSE=0 disables (A/B).
+        auto proj_gdn_ab = [&](const Qwen35LayerWeights& w, void* ya, void* yb, cudaStream_t pst) {
+            static int fuse = -1;
+            if (fuse < 0) { const char* e = getenv("SPARKINFER_GDN_AB_FUSE");
+                fuse = (e && e[0] == '0') ? 0 : 1; }
+            if (fuse && s.gguf && w.ssm_alpha_type == 0 && w.ssm_beta_type == 0 &&
+                c.linear_v_heads < 4096 && (H & 7) == 0) {
+                kernels::launch_gdn_alpha_beta(s.xn, w.ssm_alpha, w.ssm_beta, ya, yb,
+                                               c.linear_v_heads, H, pst);
+            } else {
+                proj_xn(w.ssm_alpha, w.ssm_alpha_type, ya, c.linear_v_heads, pst);
+                proj_xn(w.ssm_beta,  w.ssm_beta_type,  yb, c.linear_v_heads, pst);
+            }
+        };
 
         if (w.linear_attn) {
             const bool any_q4k = (w.wqkv_type == 12 || w.wqkv_gate_type == 12 ||
@@ -684,8 +705,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             } else if (gdn_fused_proj && gdn_pipelined) {
                 cudaEventRecord(s.ev_pipe_fork, st);
                 cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
-                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, s.stream_v);
-                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, s.stream_v);
+                proj_gdn_ab(w, s.lin_alpha, s.lin_beta, s.stream_v);
                 cudaEventRecord(s.ev_gdn_ab, s.stream_v);
                 kernels::launch_mmvq_gdn_qkv_z_pack2(s.aq81, w.wqkv, w.wqkv_gate,
                                                        s.lin_qkv, s.lin_z,
@@ -696,21 +716,18 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                 cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
                 proj_xn(w.wqkv_gate, w.wqkv_gate_type, s.lin_z, s.linear_vdim, s.stream_k);
                 cudaEventRecord(s.ev_gdn_z, s.stream_k);
-                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, s.stream_v);
-                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, s.stream_v);
+                proj_gdn_ab(w, s.lin_alpha, s.lin_beta, s.stream_v);
                 cudaEventRecord(s.ev_gdn_ab, s.stream_v);
                 proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
             } else if (gdn_fused_proj) {
                 kernels::launch_mmvq_gdn_qkv_z_pack2(s.aq81, w.wqkv, w.wqkv_gate,
                                                        s.lin_qkv, s.lin_z,
                                                        s.linear_qkvdim, s.linear_vdim, H, st);
-                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
-                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
+                proj_gdn_ab(w, s.lin_alpha, s.lin_beta, st);
             } else {
                 proj_xn(w.wqkv, w.wqkv_type, s.lin_qkv, s.linear_qkvdim, st);
                 proj_xn(w.wqkv_gate, w.wqkv_gate_type, s.lin_z, s.linear_vdim, st);
-                proj_xn(w.ssm_alpha, w.ssm_alpha_type, s.lin_alpha, c.linear_v_heads, st);
-                proj_xn(w.ssm_beta, w.ssm_beta_type, s.lin_beta, c.linear_v_heads, st);
+                proj_gdn_ab(w, s.lin_alpha, s.lin_beta, st);
             }
 
             bf16* conv_state = s.lin_conv_state +
@@ -950,7 +967,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             kernels::launch_add_rmsnorm2(s.x, s.ao, w.post_attn_norm, s.h, s.hn, 1, H, c.rms_eps, st);
 
         const bool qmoe = w.shared_gate_q && w.shared_up_q && w.shared_down_q
-                       && w.shared_gate_qtype == 8 && c.hidden == 2048 && c.moe_ffn == 512;
+                       && (w.shared_gate_qtype == 8 || w.shared_gate_qtype == 12)
+                       && c.hidden == 2048 && c.moe_ffn == 512;
+        const bool shexp_q4k = qmoe && w.shared_gate_qtype == 12;
         const bool shexp_pipelined = (c.n_shared > 0) && s.gguf && s.use_shexp_pipe;
         if (shexp_pipelined) {
             cudaEventRecord(s.ev_pipe_fork, st);
@@ -998,11 +1017,19 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                 // races MoE (shared finishes first, MoE overwrites routed). Always write s.shared;
                 // fold happens after both complete. SPARKINFER_SHEXP_ACCUM=1 only applies on the
                 // non-pipelined path where MoE has already landed in routed.
-                kernels::launch_shared_expert_q8_mmvq(
-                    s.hn, fnq ? s.aq81 : nullptr,
-                    w.shared_gate_q, w.shared_up_q, w.shared_down_q,
-                    w.shared_gate_inp ? s.d_shared_w : nullptr,
-                    s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k, false);
+                if (shexp_q4k) {
+                    kernels::launch_shared_expert_q4k_mmvq(
+                        s.hn, fnq ? s.aq81 : nullptr,
+                        w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                        w.shared_gate_inp ? s.d_shared_w : nullptr,
+                        s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k, false);
+                } else {
+                    kernels::launch_shared_expert_q8_mmvq(
+                        s.hn, fnq ? s.aq81 : nullptr,
+                        w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                        w.shared_gate_inp ? s.d_shared_w : nullptr,
+                        s.shared, s.sx_h, s.sx_q8, H, c.moe_ffn, s.stream_k, false);
+                }
             } else {
                 kernels::launch_gemv(s.hn, w.shared_gate, s.sh_gate, c.moe_ffn, H, s.stream_k);
                 kernels::launch_gemv(s.hn, w.shared_up,   s.sh_up,   c.moe_ffn, H, s.stream_v);
@@ -1115,12 +1142,21 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                     if (shexp_accum < 0) { const char* e = getenv("SPARKINFER_SHEXP_ACCUM");
                         shexp_accum = (e && e[0] == '1') ? 1 : 0; }
                     const bool sx_accum = shexp_accum != 0;
-                    kernels::launch_shared_expert_q8_mmvq(
-                        s.hn, fnq ? s.aq81 : nullptr,
-                        w.shared_gate_q, w.shared_up_q, w.shared_down_q,
-                        w.shared_gate_inp ? s.d_shared_w : nullptr,
-                        sx_accum ? s.routed : s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st,
-                        sx_accum);
+                    if (shexp_q4k) {
+                        kernels::launch_shared_expert_q4k_mmvq(
+                            s.hn, fnq ? s.aq81 : nullptr,
+                            w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                            w.shared_gate_inp ? s.d_shared_w : nullptr,
+                            sx_accum ? s.routed : s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st,
+                            sx_accum);
+                    } else {
+                        kernels::launch_shared_expert_q8_mmvq(
+                            s.hn, fnq ? s.aq81 : nullptr,
+                            w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                            w.shared_gate_inp ? s.d_shared_w : nullptr,
+                            sx_accum ? s.routed : s.shared, s.mf_h, s.aq81, H, c.moe_ffn, st,
+                            sx_accum);
+                    }
                     if (sx_accum) {
                         if (fnq)
                             kernels::launch_add_rmsnorm2_q8(s.h, s.routed, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);
@@ -2159,7 +2195,12 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             return layer_index(name) >= ssm_out_min_layer;
         return false;
     };
-    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K", q35_dense9b_requant_default);
+    // lm_head is a huge one-shot GEMV (whole vocab, every decode token) that stayed native
+    // Q6_K on the Qwen3.6 UD fingerprint -- q35_dense9b_requant_default only fires for the
+    // dense Qwythos shape, so this never defaulted on for the MoE hybrid model. Reuse the
+    // same affine-fit Q6_K->Q4_K requant already proven for FFN down (~31% fewer bytes/weight).
+    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K",
+                                        q35_dense9b_requant_default || q36_ud_requant_default);
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
         if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8))
@@ -2291,12 +2332,19 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const bool qmoe = []{ const char* a = getenv("SPARKINFER_QMOE");
                                    return !(a && a[0] == '0'); }();
             if (qmoe) {
-                w.shared_gate_q = dev_quant(b + "ffn_gate_shexp.weight", w.shared_gate_qtype);
-                w.shared_up_q   = dev_quant(b + "ffn_up_shexp.weight",   w.shared_up_qtype);
-                w.shared_down_q = dev_quant(b + "ffn_down_shexp.weight", w.shared_down_qtype);
+                // Shared expert ships Q8_0 (8.5 bits/weight) and is always active every token
+                // (unlike the routed top-k experts, already native Q4_K/Q5_K) -- requant to Q4_K
+                // at load, same Lloyd-max fit already used for attn_gate/ssm_out
+                // (dev_quant_requant_q4k dispatches on src_type==8 regardless of tensor name).
+                static int shexp_req = -1;
+                if (shexp_req < 0) { const char* e = getenv("SPARKINFER_SHEXP_REQUANT_Q4K");
+                    shexp_req = (e && e[0] == '0') ? 0 : 1; }
+                w.shared_gate_q = dev_quant_requant_q4k(b + "ffn_gate_shexp.weight", w.shared_gate_qtype, shexp_req != 0);
+                w.shared_up_q   = dev_quant_requant_q4k(b + "ffn_up_shexp.weight",   w.shared_up_qtype,   shexp_req != 0);
+                w.shared_down_q = dev_quant_requant_q4k(b + "ffn_down_shexp.weight", w.shared_down_qtype, shexp_req != 0);
             }
             if (!qmoe || !w.shared_gate_q || !w.shared_up_q || !w.shared_down_q ||
-                w.shared_gate_qtype != 8) {
+                (w.shared_gate_qtype != 8 && w.shared_gate_qtype != 12)) {
                 w.shared_gate = dense(b + "ffn_gate_shexp.weight", false);
                 w.shared_up   = dense(b + "ffn_up_shexp.weight", false);
                 w.shared_down = dense(b + "ffn_down_shexp.weight", false);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -549,9 +549,42 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             float* layer_state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
             kernels::launch_prefill_gdn_scan(gq, gk, gv, la, lb, w.ssm_dt, w.ssm_a,
                 layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim, st);
-            kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
-            attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
-            if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            // Fuse the gated-norm epilogue with whichever per-row quantize the o_proj GEMM would
+            // otherwise run as a second pass over lnrm: write straight into A_i8/sx and skip
+            // materializing lnrm at all (see prefill_gdn_norm_quant.cu). Two variants, matching
+            // proj()'s own int8-then-fp8 precedence: the residual-fused int8 GEMM (dense/Qwythos
+            // GDN with resid_fuse on) and the fp8 GEMM (MoE/Qwen3.6, which always runs GDN o_proj
+            // on fp8 -- moe_fp8 defaults on since use_i8 defaults off for MoE). fp8 has no
+            // residual-fused GEMM yet, so that branch still falls through to the plain add below.
+            bool gdn_fused_norm_quant = false;
+            if (resid_fuse && use_i8) {
+                gdn_fused_norm_quant = kernels::launch_prefill_gated_norm_quant_i8(
+                    att, lz, w.ssm_norm, A_i8, sx, N, vh, c.linear_head_dim, eps, st);
+                if (gdn_fused_norm_quant) {
+                    a_q = nullptr; a_qR = 0; a_qK = 0;   // A_i8 now holds fresh data outside quant_a_i8's memo
+                    if (!kernels::launch_gguf_dequant_rows_i8(w.ssm_out_type, w.ssm_out, W_i8, sw, H, lvdim, st)) {
+                        const void* wb = dq(w.ssm_out, w.ssm_out_type, H, lvdim);
+                        kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, lvdim, st);
+                    }
+                    kernels::launch_prefill_gemm_i8_resid(A_i8, W_i8, sx, sw, x, N, H, lvdim, st);
+                    attn_fused = true;
+                }
+            } else if (!use_i8 && (use_fp8_gdn || moe_fp8)) {
+                gdn_fused_norm_quant = kernels::launch_prefill_gated_norm_quant_fp8(
+                    att, lz, w.ssm_norm, A_i8, sx, N, vh, c.linear_head_dim, eps, st);
+                if (gdn_fused_norm_quant) {
+                    a_q = nullptr; a_qR = 0; a_qK = 0;
+                    const void* wb = dq(w.ssm_out, w.ssm_out_type, H, lvdim);
+                    kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, H, lvdim, st);
+                    kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, ao, N, H, lvdim, st);
+                    attn_fused = false;   // no fp8 residual-fused GEMM yet -- fall to the add below
+                }
+            }
+            if (!gdn_fused_norm_quant) {
+                kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
+                attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
+                if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            }
             use_i8 = restore_i8_gdn;
         } else {
             // ---- full softmax-attention layer (q_has_gate, partial RoPE, int8 KV) ----


### PR DESCRIPTION
## Summary

Q4_K-requant Qwen3.6's shared-expert and lm_head weights (previously stuck on native Q8_0/Q6_K), fuse the GDN alpha/beta GEMVs into one launch, and fold the prefill GDN norm+quantize into one kernel. Q4_K requants verified within the accuracy gate (self-KL 0.023 nats on held-out text); the two fusions are bit-identical. No regression on Qwythos.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`, interleaved A/B, medians of 5 runs, ctx=128 — best-scored context):

| | decode tok/s |
|---|--:|
| before (main) | 507.95 |
| after (this PR) | 539.10 |

**Prefill pp tok/s** (Qwythos / Qwen3.5, ctx=4096 — best of 4096/32768/65536 tried, median of 3 runs):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 25257.91 |
| after prefill (this PR) | 25388.46 |

```text
# RTX 5090 (sm_120), n=128, bs=1
### decode Qwen3.6-35B-A3B-UD-Q4_K_M ctx128, before ###
decode tg    : 506.97 tok/s  (2.0 ms/token, n=128, ctx=128, bs=1)
### decode Qwen3.6-35B-A3B-UD-Q4_K_M ctx128, after ###
decode tg    : 538.55 tok/s  (1.9 ms/token, n=128, ctx=128, bs=1)

### prefill Qwythos-9B ctx4096, before ###
prefill pp   : 25215.38 tok/s  (ctx=4096, sequential KV fill)
### prefill Qwythos-9B ctx4096, after ###
prefill pp   : 25340.73 tok/s  (ctx=4096, sequential KV fill)
```
