### PR TITLE
fix(eval): reject mismatched Qwen3-30B tokenizer in models35

### DIFF
--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -108,14 +108,33 @@ verify_model() {
   echo ">> model sha256 OK after re-fetch" >&2
 }
 
+# Download tokenizer.json for TOK_REPO into MODELS_DIR. Refuses to reuse a leftover from a
+# different repo — a Qwen3-30B tokenizer (vocab ~151k) in models35 silently tanks Qwythos
+# teacher-forced accuracy (~0.88 top1 / KL~0.20) while long-context still looks fine.
 ensure_tokenizer() {
-  [ -f "$MODELS_DIR/tokenizer.json" ] && return
-  echo ">> downloading tokenizer.json ..." >&2
+  local marker="$MODELS_DIR/.tokenizer_repo" need=0 vocab=0
   mkdir -p "$MODELS_DIR"
+  [ -f "$MODELS_DIR/tokenizer.json" ] || need=1
+  [ -f "$marker" ] && [ "$(cat "$marker" 2>/dev/null)" = "$TOK_REPO" ] || need=1
+  if [ "$need" = 0 ] && command -v python3 >/dev/null; then
+    vocab="$(python3 -c "from tokenizers import Tokenizer; print(Tokenizer.from_file(r'$MODELS_DIR/tokenizer.json').get_vocab_size())" 2>/dev/null || echo 0)"
+    case "$TOK_REPO" in
+      *Qwen3.5*|*Qwen3.6*|*Qwen3_5*|*Qwen3_6*)
+        # Qwythos / Qwen3.5 / Qwen3.6 GGUFs embed ~248k tokens.
+        [ "${vocab:-0}" -ge 200000 ] || need=1 ;;
+      *Qwen3-30B*|*Qwen3_30B*)
+        [ "${vocab:-0}" -ge 140000 ] && [ "${vocab:-0}" -lt 200000 ] || need=1 ;;
+    esac
+  fi
+  if [ "$need" = 0 ]; then return 0; fi
+  echo ">> downloading tokenizer.json from $TOK_REPO (replacing mismatched/missing) ..." >&2
+  rm -f "$MODELS_DIR/tokenizer.json" "$marker"
   HF_HUB_DISABLE_XET=1 hf download "$TOK_REPO" tokenizer.json --local-dir "$MODELS_DIR" >&2 || \
   python3 -c "from huggingface_hub import hf_hub_download as d; d('$TOK_REPO','tokenizer.json',local_dir='$MODELS_DIR')" >&2 || \
   curl -fL --progress-bar "https://huggingface.co/${TOK_REPO}/resolve/main/tokenizer.json" \
        -o "$MODELS_DIR/tokenizer.json" >&2
+  [ -f "$MODELS_DIR/tokenizer.json" ] || { echo "!! tokenizer download failed for $TOK_REPO" >&2; return 1; }
+  printf '%s\n' "$TOK_REPO" > "$marker"
 }
 
 # Reuse the persisted llama.cpp only if it's the pinned commit, a clean tree, and the binary still

--- a/eval/vast_eval.py
+++ b/eval/vast_eval.py
@@ -684,6 +684,40 @@ def main():
                 else:
                     print("!! Qwythos download slow — evaluate_bidir.sh will retry (may add time)")
 
+            # Qwythos GGUF vocab is ~248k (Qwen3.5). A leftover Qwen3-30B tokenizer (~151k) in
+            # models35 makes teacher-forced accuracy look like a main regression (~0.88 top1).
+            # ensure_tokenizer also guards this; prefetch here so a fresh box is correct before eval.
+            tok35 = (
+                f"mkdir -p {P35_DIR}; "
+                f"need=0; "
+                f"[ -f {P35_DIR}/tokenizer.json ] || need=1; "
+                f"[ -f {P35_DIR}/.tokenizer_repo ] && "
+                f"[ \"$(cat {P35_DIR}/.tokenizer_repo 2>/dev/null)\" = 'Qwen/Qwen3.5-9B' ] || need=1; "
+                f"if [ \"$need\" = 0 ]; then "
+                f"  v=$(python3 -c \"from tokenizers import Tokenizer; "
+                f"print(Tokenizer.from_file('{P35_DIR}/tokenizer.json').get_vocab_size())\" 2>/dev/null || echo 0); "
+                f"  [ \"${{v:-0}}\" -ge 200000 ] || need=1; "
+                f"fi; "
+                f"if [ \"$need\" = 1 ]; then "
+                f"  echo '>> fetching Qwen3.5-9B tokenizer into models35'; "
+                f"  rm -f {P35_DIR}/tokenizer.json {P35_DIR}/.tokenizer_repo; "
+                f"  HF_HUB_DISABLE_XET=1 hf download Qwen/Qwen3.5-9B tokenizer.json "
+                f"    --local-dir {P35_DIR} >/tmp/tok35.log 2>&1 "
+                f"  || python3 -c \"from huggingface_hub import hf_hub_download as d; "
+                f"d('Qwen/Qwen3.5-9B','tokenizer.json',local_dir='{P35_DIR}')\" >>/tmp/tok35.log 2>&1; "
+                f"  printf '%s\\n' 'Qwen/Qwen3.5-9B' > {P35_DIR}/.tokenizer_repo; "
+                f"fi; "
+                f"python3 -c \"from tokenizers import Tokenizer; "
+                f"print('models35 tokenizer vocab', "
+                f"Tokenizer.from_file('{P35_DIR}/tokenizer.json').get_vocab_size())\""
+            )
+            tr = sh(host, port, tok35, timeout=300)
+            if tr.returncode == 0:
+                print(f">> {(tr.stdout or '').strip() or 'Qwythos tokenizer ok'}")
+            else:
+                print(f"!! Qwythos tokenizer prefetch failed (rc={tr.returncode}) — "
+                      f"evaluate_bidir ensure_tokenizer will retry\n{(tr.stderr or '')[-500:]}")
+
         # Reap any leftover reference server / runner from a previous PR on this kept-alive box —
         # a leaked llama-server holding port 8081 would make this PR's accuracy.sh fail to bind.
         sh(host, port, "pkill -f llama-server 2>/dev/null; pkill -f qwen3_gguf 2>/dev/null; sleep 1; true", timeout=30)


### PR DESCRIPTION
## Summary
- `ensure_tokenizer` now refuses a leftover tokenizer from the wrong repo (vocab-size + `.tokenizer_repo` marker).
- `vast_eval` prefetches `Qwen/Qwen3.5-9B` into `/workspace/models35` so a fresh box cannot silently use the Qwen3-30B tokenizer.

A Qwen3-30B tokenizer (~151k) in `models35` made Qwythos short vs-llama look broken (~0.88 top1 / KL ~0.20) while long-context still passed. With the Qwen3.5 tokenizer (~248k), the same seeds recover to ~0.96–0.98 top1 / KL ~0.02.

## Test plan
- [x] On eval box: replace tokenizer, remeasure seeds `dad78ec6…` / `b135645f…` → match prior passing evals
- [x] Confirm GGUF `token_embd` vocab ~248320 vs Qwen3.5 tokenizer 248070
- [ ] Bot round after merge: previously false-rejected PRs no longer fail Qwythos correctness for this reason