### PR TITLE
feat(eval): cron every 2h — labels-only when GPU down, never rent

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -20,6 +20,7 @@ EVAL_SSH_PORT=50200
 # PRIMARY_QUANT=Q4_K_M   # Qwen3.5 quant: Q4_K_M | Q8_0 | BF16
 # SPARKINFER_AUTOMERGE=1       # auto-merge merge-first winner after each poll (0 to disable)
 # SPARKINFER_AUTOMERGE_ADMIN=1 # retry with gh --admin when branch policy blocks squash
+# VAST_NO_AUTO_PROVISION=1     # never rent a new GPU (pinned instance only; cron respects this)
 # POLARIS=1         # Polaris TDX verifiable receipts (default; set 0 to disable)
 # POLARIS_API_KEY=  # TDX attest (https://polaris.computer); preferred when available
 # SPARKINFER_POLARIS_PRIVATE_KEY=  # base64 Ed25519 fallback when TDX is down

--- a/eval/README.md
+++ b/eval/README.md
@@ -160,8 +160,10 @@ python eval/pr_eval_bot.py --instance 42134865 --dry-run                       #
 ```bash
 crontab -l 2>/dev/null; echo "0 */2 * * * $PWD/eval/run_bot_cron.sh >> /tmp/sparkinfer_bot.log 2>&1" | crontab -
 ```
-Each run: reuse the pinned `--reuse` instance → evaluate new PR commits → label + comment (instance
-stays running). Disable with `crontab -e`. Needs `gh` authenticated and a vast instance id (`VAST_INSTANCE`).
+Each run: **never rents a GPU**. If the pinned instance is already running and SSH works → full
+eval of new PR commits. If the GPU is stopped/unreachable → `--labels-only` (greenlight /
+needs-benchmark / merge-first reconcile, no GPU). Disable with `crontab -e`. Needs `gh`
+authenticated and `VAST_INSTANCE` in `.env.eval` (`VAST_NO_AUTO_PROVISION=1`).
 
 **Dashboard.** Eval verdicts and frontier updates are committed to
 [`gittensor-ai-lab/sparkinfer-web`](https://github.com/gittensor-ai-lab/sparkinfer-web)

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -2318,6 +2318,9 @@ def main():
     ap.add_argument("--ceiling", type=float, default=0)
     ap.add_argument("--repo", default="gittensor-ai-lab/sparkinfer")
     ap.add_argument("--dry-run", action="store_true", help="evaluate + print, but don't label/comment")
+    ap.add_argument("--labels-only", action="store_true",
+                    help="apply greenlight/needs-benchmark/merge labels only — no GPU eval "
+                         "(used by cron when the pinned box is down; never rents)")
     # Dual-model: score Qwen3.6-35B-A3B (primary) and guard Qwen3-30B against no-regression.
     # Each PR is scored directly against the SAME-BOX origin/main baseline (measured once per run),
     # not a passed-in frontier number — so the gain is hardware-independent and always current.
@@ -2622,6 +2625,15 @@ def main():
     if args.dry_run:
         print("--- dry-run: would evaluate (oldest-first): " +
               ", ".join(f"#{n}" for _, n, *_ in pending)); return
+
+    if args.labels_only:
+        # GPU unavailable / cron tick with box down: labels already applied above; still reconcile
+        # merge-first / needs-rebase / auto-merge. Never touch vast.ai rent/start from here.
+        print("--- labels-only: skipping GPU eval for " +
+              ", ".join(f"#{n}" for _, n, *_ in pending))
+        if not args.dry_run:
+            reconcile_merge_labels(args.repo)
+        print("done — labels only (no GPU)."); return
 
     # Reuse the pinned stable box first (cached model, good download speed). Skip when on bare metal.
     if PINNED_INSTANCE and not ssh_box_enabled():

--- a/eval/run_bot_cron.sh
+++ b/eval/run_bot_cron.sh
@@ -1,16 +1,23 @@
 #!/usr/bin/env bash
-# Cron wrapper for the sparkinfer PR auto-eval bot — gives cron a sane env, refreshes the
-# evaluator from main, and runs one poll. Schedule it every 2 hours:
+# Cron wrapper for the sparkinfer PR auto-eval bot — one poll every 2 hours:
 #
-#   0 */2 * * * /home/speedy/gittensor-ai-lab/sparkinfer/eval/run_bot_cron.sh >> /tmp/sparkinfer_bot.log 2>&1
+#   0 */2 * * * /home/autotiny/Desktop/sparkinfer/eval/run_bot_cron.sh >> /tmp/sparkinfer_bot.log 2>&1
+#
+# Policy:
+#   • Never rent a new vast.ai GPU (pinned instance only; VAST_NO_AUTO_PROVISION=1).
+#   • If the pinned box is running AND SSH-reachable → full eval + auto-merge.
+#   • If the box is down/stopped/unreachable → labels only (greenlight / needs-benchmark /
+#     merge-first reconcile). No start_instance, no provision.
 #
 # Transport (set in .env.eval or env):
-#   EVAL_TRANSPORT=vast  — rent/reuse vast.ai (default)
-#   EVAL_TRANSPORT=ssh   — fixed GPU box via EVAL_SSH_HOST / EVAL_SSH_PORT (no vast billing)
-export HOME="${HOME:-/home/speedy}"
+#   EVAL_TRANSPORT=vast  — reuse pinned vast.ai instance (default)
+#   EVAL_TRANSPORT=ssh   — fixed GPU box via EVAL_SSH_HOST / EVAL_SSH_PORT
+export HOME="${HOME:-/home/autotiny}"
 export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin:$PATH"
 export PYTHONUNBUFFERED=1
-export SPARKINFER_AUTOMERGE=1   # auto-merge the round's merge-first winner (guarded). Set 0 to disable.
+export SPARKINFER_AUTOMERGE="${SPARKINFER_AUTOMERGE:-1}"
+export SPARKINFER_AUTOMERGE_ADMIN="${SPARKINFER_AUTOMERGE_ADMIN:-1}"
+export VAST_NO_AUTO_PROVISION=1
 
 exec 9>/tmp/sparkinfer_bot.lock
 flock -n 9 || { echo "[$(date -u +%FT%TZ)] previous bot run still active — skipping this tick"; exit 0; }
@@ -25,18 +32,21 @@ if [ -f "$REPO_DIR/.env.eval" ]; then
   source "$REPO_DIR/.env.eval"
   set +a
 fi
+# Re-assert after .env.eval in case a stale file omitted them.
+export SPARKINFER_AUTOMERGE="${SPARKINFER_AUTOMERGE:-1}"
+export SPARKINFER_AUTOMERGE_ADMIN="${SPARKINFER_AUTOMERGE_ADMIN:-1}"
+export VAST_NO_AUTO_PROVISION=1
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY all_proxy
 
 git pull -q origin main 2>/dev/null || true
-echo "[$(date -u +%FT%TZ)] sparkinfer PR bot run (EVAL_TRANSPORT=${EVAL_TRANSPORT:-vast})"
 
 BOT_ARGS=(
   --frontier "${FRONTIER:-285}"
   --ceiling  "${CEILING:-366}"
   --repo     "${REPO:-gittensor-ai-lab/sparkinfer}"
 )
-# vast.ai path still needs --instance; SSH path ignores it.
 if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
-  BOT_ARGS+=(--instance "${VAST_INSTANCE:-42682383}")
+  BOT_ARGS+=(--instance "${VAST_INSTANCE:-${VAST_DEFAULT_INSTANCE:-0}}")
 fi
 [ "${BIDIR:-${TRIPLE:-1}}" != "0" ] && BOT_ARGS+=(--bidir --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
 if [ "${POLARIS:-1}" = "0" ]; then
@@ -45,4 +55,40 @@ else
   BOT_ARGS+=(--polaris)
 fi
 
-python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}"
+# Returns 0 iff the eval GPU is usable right now (no rent, no start).
+gpu_ready() {
+  local key="${SSH_KEY:-$HOME/.ssh/speedy}"
+  if [ "${EVAL_TRANSPORT:-vast}" = "ssh" ]; then
+    local host="${EVAL_SSH_HOST:-}" port="${EVAL_SSH_PORT:-22}"
+    [ -n "$host" ] || return 1
+    ssh -i "$key" -o BatchMode=yes -o ConnectTimeout=10 \
+        -o StrictHostKeyChecking=accept-new -p "$port" "root@$host" 'true' 2>/dev/null
+    return $?
+  fi
+  local iid="${VAST_INSTANCE:-${VAST_DEFAULT_INSTANCE:-}}"
+  [ -n "$iid" ] && [ "$iid" != "0" ] || return 1
+  command -v vastai >/dev/null 2>&1 || return 1
+  local raw st ip port
+  raw="$(vastai show instance "$iid" --raw 2>/dev/null)" || return 1
+  read -r st ip port < <(python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read() or '{}')
+st = d.get('actual_status') or ''
+ip = d.get('public_ipaddr') or ''
+ports = d.get('ports') or {}
+p = ((ports.get('22/tcp') or [{}])[0] or {}).get('HostPort') or ''
+print(st, ip, p)
+" <<<"$raw")
+  [ "$st" = "running" ] && [ -n "$ip" ] && [ -n "$port" ] || return 1
+  ssh -i "$key" -o BatchMode=yes -o ConnectTimeout=10 \
+      -o StrictHostKeyChecking=accept-new -p "$port" "root@$ip" 'true' 2>/dev/null
+}
+
+TS="$(date -u +%FT%TZ)"
+if gpu_ready; then
+  echo "[$TS] sparkinfer PR bot — GPU up — full eval (AUTOMERGE=${SPARKINFER_AUTOMERGE}, no-rent)"
+  python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}"
+else
+  echo "[$TS] sparkinfer PR bot — GPU down/unreachable — labels only (no rent, no start)"
+  python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}" --labels-only
+fi


### PR DESCRIPTION
## Summary
- Cron wrapper checks pinned GPU is running + SSH-reachable; never rents or starts instances (`VAST_NO_AUTO_PROVISION=1`).
- If GPU is up → full PR eval + auto-merge. If down → `--labels-only` (greenlight / needs-benchmark / merge reconcile).
- Document 2-hour crontab schedule in `eval/README.md`.

## Test plan
- [ ] `bash -n eval/run_bot_cron.sh`
- [ ] `python3 eval/pr_eval_bot.py --help` shows `--labels-only`
- [ ] With GPU stopped: cron path prints labels-only and exits without vast rent
- [ ] With GPU up: full eval runs as before
- [ ] Crontab installed: `0 */2 * * * .../eval/run_bot_cron.sh >> /tmp/sparkinfer_bot.log 2>&1`