### PR TITLE
fix(eval): always target pinned GPU for cron/bot (never rent)

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -1,15 +1,20 @@
 # Copy to .env.eval and fill in secrets. Not committed to git.
 
 # --- transport ---
-# vast  = rent/reuse vast.ai GPUs (default; all vast_eval.py logic active)
+# vast  = reuse pinned vast.ai GPU (default for production bot)
 # ssh   = fixed bare-metal box (EVAL_SSH_HOST); vast.ai not contacted
-EVAL_TRANSPORT=ssh
-EVAL_SSH_HOST=91.224.44.227
-EVAL_SSH_PORT=50200
+EVAL_TRANSPORT=vast
 
 # --- vast.ai (used when EVAL_TRANSPORT=vast) ---
 # VAST_API_KEY=
-# VAST_INSTANCE=42682383   # required: existing instance id (--reuse); no auto-rent
+# VAST_INSTANCE=46074104          # pinned box id (--reuse); cron + bot always use this
+# VAST_DEFAULT_INSTANCE=46074104  # same pin (written to ~/.sparkinfer_pinned_instance)
+# VAST_NO_AUTO_PROVISION=1        # never rent a new GPU
+# SSH_KEY=~/.ssh/speedy
+# Optional bare-metal override:
+# EVAL_TRANSPORT=ssh
+# EVAL_SSH_HOST=
+# EVAL_SSH_PORT=22
 
 # --- bot ---
 # GH_TOKEN=

--- a/eval/README.md
+++ b/eval/README.md
@@ -160,10 +160,12 @@ python eval/pr_eval_bot.py --instance 42134865 --dry-run                       #
 ```bash
 crontab -l 2>/dev/null; echo "0 */2 * * * $PWD/eval/run_bot_cron.sh >> /tmp/sparkinfer_bot.log 2>&1" | crontab -
 ```
-Each run: **never rents a GPU**. If the pinned instance is already running and SSH works → full
-eval of new PR commits. If the GPU is stopped/unreachable → `--labels-only` (greenlight /
-needs-benchmark / merge-first reconcile, no GPU). Disable with `crontab -e`. Needs `gh`
-authenticated and `VAST_INSTANCE` in `.env.eval` (`VAST_NO_AUTO_PROVISION=1`).
+Each run: **always uses the pinned GPU** (`VAST_DEFAULT_INSTANCE` /
+`~/.sparkinfer_pinned_instance`). **Never rents** a new one. If the pin is already running and
+SSH works → full eval of new PR commits. If the pin is stopped/unreachable → `--labels-only`
+(greenlight / needs-benchmark / merge-first reconcile, no GPU). Disable with `crontab -e`. Needs
+`gh` authenticated and `VAST_INSTANCE` / `VAST_DEFAULT_INSTANCE` in `.env.eval`
+(`VAST_NO_AUTO_PROVISION=1`).
 
 **Dashboard.** Eval verdicts and frontier updates are committed to
 [`gittensor-ai-lab/sparkinfer-web`](https://github.com/gittensor-ai-lab/sparkinfer-web)

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -51,7 +51,8 @@ def _read_pin():
         v = open(PIN_FILE).read().strip()
         if v: return v
     except Exception: pass
-    return os.environ.get("VAST_DEFAULT_INSTANCE", "44206573").strip()
+    return os.environ.get("VAST_DEFAULT_INSTANCE",
+                          os.environ.get("VAST_INSTANCE", "46074104")).strip()
 def _write_pin(iid):
     try:
         with open(PIN_FILE, "w") as f: f.write(str(iid))

--- a/eval/run_bot.sh
+++ b/eval/run_bot.sh
@@ -42,7 +42,7 @@ BOT_ARGS=(
   --repo     "${REPO:-gittensor-ai-lab/sparkinfer}"
 )
 if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
-  BOT_ARGS+=(--instance "${VAST_INSTANCE:-42682383}")
+  BOT_ARGS+=(--instance "${VAST_INSTANCE:-${VAST_DEFAULT_INSTANCE:-0}}")
 fi
 if printf '%s\n' "$@" | grep -qx -- '--bidir' || \
    [ -n "${BIDIR:-${TRIPLE:-1}}" ] && [ "${BIDIR:-${TRIPLE:-1}}" != "0" ] || \

--- a/eval/run_bot_cron.sh
+++ b/eval/run_bot_cron.sh
@@ -4,10 +4,10 @@
 #   0 */2 * * * /home/autotiny/Desktop/sparkinfer/eval/run_bot_cron.sh >> /tmp/sparkinfer_bot.log 2>&1
 #
 # Policy:
-#   • Never rent a new vast.ai GPU (pinned instance only; VAST_NO_AUTO_PROVISION=1).
+#   • Always target the pinned vast.ai GPU (VAST_DEFAULT_INSTANCE / ~/.sparkinfer_pinned_instance).
+#   • Never rent a new GPU (VAST_NO_AUTO_PROVISION=1). Never destroy the pin.
 #   • If the pinned box is running AND SSH-reachable → full eval + auto-merge.
-#   • If the box is down/stopped/unreachable → labels only (greenlight / needs-benchmark /
-#     merge-first reconcile). No start_instance, no provision.
+#   • If the pin is stopped/unreachable → labels only (no start_instance, no provision).
 #
 # Transport (set in .env.eval or env):
 #   EVAL_TRANSPORT=vast  — reuse pinned vast.ai instance (default)
@@ -40,13 +40,35 @@ unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY all_proxy
 
 git pull -q origin main 2>/dev/null || true
 
+# Resolve the pinned GPU id (file wins, then env). Sync pin + instance files so the bot
+# always --reuse's this box and never drifts to a self-healed rental id.
+PIN_FILE="${VAST_PIN_FILE:-$HOME/.sparkinfer_pinned_instance}"
+INSTANCE_FILE="${VAST_INSTANCE_FILE:-$HOME/.sparkinfer_vast_instance}"
+resolve_pin() {
+  local v=""
+  if [ -f "$PIN_FILE" ]; then
+    v="$(tr -d '[:space:]' <"$PIN_FILE" 2>/dev/null || true)"
+  fi
+  if [ -z "$v" ] || [ "$v" = "0" ]; then
+    v="${VAST_DEFAULT_INSTANCE:-${VAST_INSTANCE:-}}"
+  fi
+  printf '%s' "$v"
+}
+PINNED_ID="$(resolve_pin)"
+if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ] && [ -n "$PINNED_ID" ] && [ "$PINNED_ID" != "0" ]; then
+  export VAST_INSTANCE="$PINNED_ID"
+  export VAST_DEFAULT_INSTANCE="$PINNED_ID"
+  printf '%s\n' "$PINNED_ID" >"$PIN_FILE"
+  printf '%s\n' "$PINNED_ID" >"$INSTANCE_FILE"
+fi
+
 BOT_ARGS=(
   --frontier "${FRONTIER:-285}"
   --ceiling  "${CEILING:-366}"
   --repo     "${REPO:-gittensor-ai-lab/sparkinfer}"
 )
 if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
-  BOT_ARGS+=(--instance "${VAST_INSTANCE:-${VAST_DEFAULT_INSTANCE:-0}}")
+  BOT_ARGS+=(--instance "${VAST_INSTANCE:-0}")
 fi
 [ "${BIDIR:-${TRIPLE:-1}}" != "0" ] && BOT_ARGS+=(--bidir --primary-quant "${PRIMARY_QUANT:-Q4_K_M}")
 if [ "${POLARIS:-1}" = "0" ]; then
@@ -55,7 +77,7 @@ else
   BOT_ARGS+=(--polaris)
 fi
 
-# Returns 0 iff the eval GPU is usable right now (no rent, no start).
+# Returns 0 iff the pinned eval GPU is usable right now (no rent, no start).
 gpu_ready() {
   local key="${SSH_KEY:-$HOME/.ssh/speedy}"
   if [ "${EVAL_TRANSPORT:-vast}" = "ssh" ]; then
@@ -65,7 +87,7 @@ gpu_ready() {
         -o StrictHostKeyChecking=accept-new -p "$port" "root@$host" 'true' 2>/dev/null
     return $?
   fi
-  local iid="${VAST_INSTANCE:-${VAST_DEFAULT_INSTANCE:-}}"
+  local iid="${VAST_INSTANCE:-}"
   [ -n "$iid" ] && [ "$iid" != "0" ] || return 1
   command -v vastai >/dev/null 2>&1 || return 1
   local raw st ip port
@@ -86,9 +108,9 @@ print(st, ip, p)
 
 TS="$(date -u +%FT%TZ)"
 if gpu_ready; then
-  echo "[$TS] sparkinfer PR bot — GPU up — full eval (AUTOMERGE=${SPARKINFER_AUTOMERGE}, no-rent)"
+  echo "[$TS] sparkinfer PR bot — pinned GPU ${VAST_INSTANCE:-ssh} up — full eval (AUTOMERGE=${SPARKINFER_AUTOMERGE}, no-rent)"
   python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}"
 else
-  echo "[$TS] sparkinfer PR bot — GPU down/unreachable — labels only (no rent, no start)"
+  echo "[$TS] sparkinfer PR bot — pinned GPU ${VAST_INSTANCE:-?} down/unreachable — labels only (no rent, no start)"
   python3 eval/pr_eval_bot.py "${BOT_ARGS[@]}" --labels-only
 fi


### PR DESCRIPTION
## Summary
- Always resolve/sync the pinned Vast GPU instance id before the eval bot runs (cron never rents).
- `run_bot.sh` / `pr_eval_bot.py` take instance from `VAST_INSTANCE` / `VAST_DEFAULT_INSTANCE` with pin fallback `46074104`.
- Docs and `.env.eval.example` updated for the pinned-instance workflow.

## Test plan
- [x] `bash -n` on `eval/run_bot_cron.sh` and `eval/run_bot.sh`
- [x] `python3 -m py_compile eval/pr_eval_bot.py`
- [ ] Confirm cron resolves pin files / env to `46074104` before bot start