### PR TITLE
fix: restore convert_gguf vocab fallback and align auto-merge docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ source of the incentive loop is clear: SPARKINFER is built through **SN74 on Git
 ## Before you open a PR
 
 ```bash
-# 1. build + tests (must be 5/5)
+# 1. build + tests (all registered tests must pass; GPU tests self-skip without a device)
 cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j && ctest --test-dir build
 
 # 2. speed — does it actually go faster?

--- a/README.md
+++ b/README.md
@@ -191,8 +191,12 @@ aggregated across contexts.
 The label is a **deterministic function of the measurements**, so it's reproducible across
 validators. The bot also tags the PR's **subsystem** — `area:kernels` / `runtime` / `moe` /
 `bench` — from its changed paths (categorization only — scoring is speedup-only; deterministic, no AI).
-The bot **never merges** — merging is manual after review. Runs the same evaluator you can run
-yourself: [`eval/`](eval) (`vast_eval.py`, `pr_eval_bot.py`).
+The bot labels each round's biggest verified win [`merge-first`](https://github.com/gittensor-ai-lab/sparkinfer/labels/merge-first)
+and can **auto-merge** that winner once it clears the guards in [CONTRIBUTING.md](CONTRIBUTING.md)
+(verified speedup, clean CI, no conflicts, author in good standing, only `kernels`/`runtime`/`moe`);
+a maintainer can stop that with `hold`. Other scored PRs stay [`needs-rebase`](https://github.com/gittensor-ai-lab/sparkinfer/labels/needs-rebase)
+until they rebase onto the new `main`. Runs the same evaluator you can run yourself:
+[`eval/`](eval) (`vast_eval.py`, `pr_eval_bot.py`).
 
 ### Trust & verifiability
 

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -341,7 +341,7 @@
   </section>
 
   <section>
-    <div class="sec-h"><h2>Evaluated PRs</h2><span class="hint">bot labels + comments · never auto-merges</span></div>
+    <div class="sec-h"><h2>Evaluated PRs</h2><span class="hint">bot labels + comments · merge-first can auto-merge</span></div>
     <div class="card"><table><thead><tr><th>PR</th><th>area</th><th>label</th><th>decode</th><th>vs frontier</th><th>proof</th></tr></thead><tbody id="prs"></tbody></table></div>
   </section>
 

--- a/docs/miner-guide.md
+++ b/docs/miner-guide.md
@@ -133,7 +133,8 @@ merge than a broad rewrite.
 
 ## Current Target
 
-The current frontier is Qwen3-MoE Q4_K_M decode on RTX 5090 / consumer Blackwell.
+The current primary frontier is **Qwen3.6-35B-A3B** Q4_K_M decode on RTX 5090 /
+consumer Blackwell (with Qwen3-MoE / Qwen3.5 as additional scored or guard targets).
 The project is especially interested in:
 
 - Long-context flash decode at 16k and beyond.

--- a/runtime/tools/convert_gguf.py
+++ b/runtime/tools/convert_gguf.py
@@ -54,10 +54,13 @@ def main():
         rms_eps=float(meta(A + "attention.layer_norm_rms_epsilon")),
         eos_id=int(meta("tokenizer.ggml.eos_token_id") or 151645),
     )
-    # vocab from token_embd if metadata missing
+    # Prefer vocab from token_embd (matches qwen3_config_from_gguf: emb->dims[1]).
     ten = {t.name: t for t in r.tensors}
-    if "token_embd.weight" in ten:
-        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
+    emb = ten.get("token_embd.weight")
+    if emb is not None and len(emb.shape) >= 2:
+        cfg["vocab"] = int(emb.shape[1])
+    elif emb is not None and len(emb.shape) == 1:
+        cfg["vocab"] = int(emb.shape[0])
 
     with open(os.path.join(out, "config.txt"), "w") as f:
         for k, v in cfg.items():


### PR DESCRIPTION
## Summary

- Restore `convert_gguf.py` vocab fallback from `token_embd.weight` (was dead-coded with `if False`), matching the C++ GGUF config path (`emb->dims[1]`).
- Align README + dashboard with CONTRIBUTING: guarded `merge-first` auto-merge is real; drop the incorrect "bot never merges" wording.
- Update miner-guide current target to Qwen3.6 and CONTRIBUTING ctest guidance so contributors are not pointed at stale targets / a fake "5/5" gate.

Fixes #637

## Notes

Docs/tooling only — no GPU eval requested. Proof-of-speedup section intentionally omitted so the RTX 5090 opt-in CI does not auto-close this PR.
