### PR TITLE
chore(eval): schedule DFlash bot on odd hours

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -181,9 +181,9 @@ eval/setup_labels.sh                                  # creates eval-dflash:* + 
 ./eval/run_dflash_bot.sh --only-prs 636 --reeval       # force one PR
 ```
 
-**Schedule every 2 hours, :30 past the hour** (shares `/tmp/sparkinfer_bot.lock` with the AR bot):
+**Schedule every 2 hours on odd hours** (01:00, 03:00, …; shares `/tmp/sparkinfer_bot.lock` with the AR bot):
 ```bash
-crontab -l 2>/dev/null; echo "30 */2 * * * $PWD/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1" | crontab -
+crontab -l 2>/dev/null; echo "0 1-23/2 * * * $PWD/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1" | crontab -
 ```
 Pinned GPU only; never rents. If the pin is down → `--labels-only` reconcile.
 

--- a/eval/run_dflash_cron.sh
+++ b/eval/run_dflash_cron.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 # Cron wrapper for the sparkinfer DFlash PR eval bot — offset from AR bot:
 #
-#   30 */2 * * * /home/autotiny/Desktop/sparkinfer/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1
+#   0 1-23/2 * * * /home/autotiny/Desktop/sparkinfer/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1
+#   (odd hours :00 — 01:00, 03:00, …; AR bot stays on even hours)
 #
 # Policy (same as AR bot):
 #   • Pinned vast.ai GPU only; never rent / never start from cron when down.


### PR DESCRIPTION
## Summary
- Document DFlash cron on odd hours at minute 0 (`0 1-23/2`) so it does not collide with the AR bot on even hours.
- Update comment in `eval/run_dflash_cron.sh` to match the live crontab.

## Test plan
- [x] Confirm local crontab lists AR at `0 */2` and DFlash at `0 1-23/2`
- [ ] Spot-check next odd-hour tick in `/tmp/sparkinfer_dflash_bot.log`