### PR TITLE
fix(quality): restore llama-server backend + Qwen3.6 orchestrator

### DIFF
--- a/bench/quality/README.md
+++ b/bench/quality/README.md
@@ -27,6 +27,7 @@ optimization preserved capability, not just token agreement. Headline claim it u
 ```
 scorers.py             deterministic, stdlib-only scoring (one fn per benchmark) + self-test
 run_quality.py         driver: prompt-build -> backend generate -> score -> report (+ A/B)
+run_qwen36_benchmark.sh  orchestrator: sparkinfer then llama-server (exclusive GPU)
 fetch.py               pull real datasets from HuggingFace, ~10% stratified dev sample -> data/
 data/*.jsonl           real ~10% dev samples (784 items) - regenerate with fetch.py
 seed_hand_authored/    the original hand-written seed (offline fallback / reference)
@@ -39,6 +40,7 @@ seed_hand_authored/    the original hand-written seed (offline fallback / refere
 python3 scorers.py                     # 10/10 scorer self-tests
 python3 run_quality.py --backend oracle  # gold/scorer sanity for answer-derivable tasks
 python3 run_quality.py --backend mock    # ~0%  - floor
+python3 run_quality.py --self-test-llama-server  # mock HTTP /completion wiring
 
 # 2. score sparkinfer on a GPU box:
 python3 run_quality.py --backend sparkinfer \

--- a/bench/quality/run_quality.py
+++ b/bench/quality/run_quality.py
@@ -10,14 +10,18 @@ Usage:
   # offline pipeline check (no GPU/model needed):
   python3 run_quality.py --backend oracle
   python3 run_quality.py --backend mock
+  python3 run_quality.py --self-test-llama-server   # mock HTTP server, no GPU
 
   # sparkinfer:
-  python3 run_quality.py --backend sparkinfer \
-      --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf \
+  python3 run_quality.py --backend sparkinfer \\
+      --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf \\
       --bin ./build/qwen3_gguf_generate --tokenizer /workspace/models/tokenizer.json
 
-  # llama.cpp reference:
-  python3 run_quality.py --backend llama --llama-cli /workspace/.llamacpp/build/bin/llama-cli \
+  # llama.cpp server (start llama-server first — preferred A/B path):
+  python3 run_quality.py --backend llama-server --llama-url http://127.0.0.1:8082
+
+  # llama.cpp one-shot CLI (reloads model each item — slow):
+  python3 run_quality.py --backend llama --llama-cli /workspace/.llamacpp/build/bin/llama-cli \\
       --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf
 
   # only some benchmarks / fewer items:
@@ -27,7 +31,7 @@ Usage:
   python3 run_quality.py --backend sparkinfer --tier development ...  # ~10%, 78 items
   python3 run_quality.py --backend sparkinfer --tier benchmark ...    # ~25%, 196 items
 """
-import argparse, json, os, subprocess, sys, glob
+import argparse, json, os, subprocess, sys, glob, urllib.error, urllib.request
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import scorers
 
@@ -112,6 +116,69 @@ class LlamaBackend:
         return r.stdout
 
 
+class LlamaServerBackend:
+    """llama.cpp `llama-server` HTTP backend (keeps the model resident — the A/B path).
+
+    Tries native `/completion` first, then OpenAI-compatible `/v1/completions`.
+    """
+
+    def __init__(self, base_url, timeout=600):
+        self.base = base_url.rstrip("/")
+        self.timeout = timeout
+
+    def _post_json(self, path, payload):
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self.base + path,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+
+    @staticmethod
+    def _content_from_completion(body):
+        # llama.cpp /completion: {"content": "..."} or {"content": ["..."]}
+        if isinstance(body.get("content"), str):
+            return body["content"]
+        if isinstance(body.get("content"), list) and body["content"]:
+            return "".join(str(x) for x in body["content"])
+        # OpenAI /v1/completions
+        choices = body.get("choices") or []
+        if choices:
+            c0 = choices[0]
+            if isinstance(c0.get("text"), str):
+                return c0["text"]
+            msg = c0.get("message") or {}
+            if isinstance(msg.get("content"), str):
+                return msg["content"]
+        raise ValueError("llama-server response missing completion text: " + json.dumps(body)[:200])
+
+    def gen_for(self, item):
+        n = MAXNEW.get(item["benchmark"], 200)
+        prompt = CHAT.format(p=build_prompt(item))
+        # Prefer native llama-server /completion (temp 0 = greedy, matches CLI path).
+        try:
+            body = self._post_json("/completion", {
+                "prompt": prompt,
+                "n_predict": n,
+                "temperature": 0.0,
+                "stream": False,
+            })
+            return self._content_from_completion(body)
+        except urllib.error.HTTPError as e:
+            if e.code not in (404, 405):
+                raise
+        body = self._post_json("/v1/completions", {
+            "prompt": prompt,
+            "max_tokens": n,
+            "temperature": 0.0,
+            "stream": False,
+        })
+        return self._content_from_completion(body)
+
+
 def make_backend(args, items):
     if args.backend == "oracle": return OracleBackend(items)
     if args.backend == "mock":   return MockBackend()
@@ -119,6 +186,8 @@ def make_backend(args, items):
         return SparkinferBackend(args.model, args.bin, args.tokenizer)
     if args.backend == "llama":
         return LlamaBackend(args.model, args.llama_cli)
+    if args.backend == "llama-server":
+        return LlamaServerBackend(args.llama_url)
     raise SystemExit("unknown backend " + args.backend)
 
 
@@ -136,17 +205,73 @@ def load(benchmarks, limit, tier=""):
     return items
 
 
+def self_test_llama_server():
+    """Spin a tiny stdlib HTTP mock of llama-server; no GPU required."""
+    import threading
+    from http.server import BaseHTTPRequestHandler, HTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, fmt, *args):  # quiet
+            pass
+
+        def do_POST(self):
+            n = int(self.headers.get("Content-Length", "0"))
+            raw = self.rfile.read(n)
+            payload = json.loads(raw.decode("utf-8") or "{}")
+            prompt = payload.get("prompt", "")
+            text = "mock-ok"
+            if "Solve it step by step" in prompt:
+                text = "reasoning\n#### 42"
+            body = json.dumps({"content": text}).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+    httpd = HTTPServer(("127.0.0.1", 0), Handler)
+    port = httpd.server_address[1]
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        be = LlamaServerBackend(f"http://127.0.0.1:{port}", timeout=5)
+        item = {
+            "id": "self0",
+            "benchmark": "gsm8k",
+            "prompt": "What is 6*7?",
+            "target": "42",
+        }
+        out = be.gen_for(item)
+        r = scorers.SCORERS["gsm8k"](item, out)
+        if not r["pass"]:
+            raise SystemExit(f"self-test failed: out={out!r} detail={r['detail']}")
+        print("llama-server self-test OK  (mock HTTP /completion + gsm8k scorer)")
+    finally:
+        httpd.shutdown()
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--backend", required=True, choices=["oracle", "mock", "sparkinfer", "llama"])
+    ap.add_argument("--backend", choices=["oracle", "mock", "sparkinfer", "llama", "llama-server"],
+                    help="generation backend")
     ap.add_argument("--model"); ap.add_argument("--bin"); ap.add_argument("--tokenizer")
     ap.add_argument("--llama-cli")
+    ap.add_argument("--llama-url", default="http://127.0.0.1:8082",
+                    help="llama-server base URL (for --backend llama-server)")
     ap.add_argument("--benchmarks", default="", help="comma list; default all")
     ap.add_argument("--limit", type=int, default=0, help="items per benchmark (0=all)")
     ap.add_argument("--tier", choices=sorted(TIERS),
                     help="named per-suite sample: development ~=10%, benchmark ~=25%")
     ap.add_argument("--out", default="", help="write per-item JSONL results here")
+    ap.add_argument("--self-test-llama-server", action="store_true",
+                    help="CPU-only mock of llama-server HTTP; verifies the backend wiring")
     args = ap.parse_args()
+
+    if args.self_test_llama_server:
+        self_test_llama_server()
+        return
+    if not args.backend:
+        ap.error("--backend is required (or pass --self-test-llama-server)")
 
     benchmarks = set(b for b in args.benchmarks.split(",") if b)
     items = load(benchmarks, args.limit, args.tier or "")

--- a/bench/quality/run_qwen36_benchmark.sh
+++ b/bench/quality/run_qwen36_benchmark.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Orchestrate Qwen3.6 quality parity: sparkinfer first (exclusive GPU), then llama-server.
+# Matches bench/quality/README.md — do not keep both engines resident on 32 GB cards.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+QUALITY="$ROOT/bench/quality"
+OUT_DIR="${OUT_DIR:-/tmp/qwen36_quality}"
+MODEL="${MODEL:-$ROOT/models/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf}"
+TOKENIZER="${TOKENIZER:-$ROOT/models/tokenizer.json}"
+SPARK_BIN="${SPARK_BIN:-$ROOT/build/runtime/qwen3_gguf_generate}"
+LLAMA_SERVER="${LLAMA_SERVER:-$ROOT/.llamacpp/build/bin/llama-server}"
+LLAMA_URL="${LLAMA_URL:-http://127.0.0.1:8082}"
+LLAMA_PORT="${LLAMA_PORT:-8082}"
+TIER="${TIER:-benchmark}"
+NGL="${NGL:-99}"
+
+mkdir -p "$OUT_DIR"
+
+die() { echo "error: $*" >&2; exit 1; }
+need() { [[ -e "$1" ]] || die "missing $1"; }
+
+need "$MODEL"
+need "$QUALITY/run_quality.py"
+need "$SPARK_BIN"
+need "$LLAMA_SERVER"
+need "$TOKENIZER"
+
+echo "==> [1/3] sparkinfer quality ($TIER) — exclusive GPU"
+python3 "$QUALITY/run_quality.py" \
+  --backend sparkinfer \
+  --model "$MODEL" \
+  --bin "$SPARK_BIN" \
+  --tokenizer "$TOKENIZER" \
+  --tier "$TIER" \
+  --out "$OUT_DIR/sparkinfer_${TIER}.jsonl"
+
+echo "==> [2/3] start llama-server on :$LLAMA_PORT"
+"$LLAMA_SERVER" -m "$MODEL" --port "$LLAMA_PORT" -ngl "$NGL" --host 127.0.0.1 \
+  >"$OUT_DIR/llama-server.log" 2>&1 &
+LLAMA_PID=$!
+cleanup() {
+  if kill -0 "$LLAMA_PID" 2>/dev/null; then
+    echo "==> stopping llama-server pid=$LLAMA_PID"
+    kill "$LLAMA_PID" 2>/dev/null || true
+    wait "$LLAMA_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Wait until /completion answers (or timeout).
+for i in $(seq 1 120); do
+  if curl -sf -o /dev/null -X POST "$LLAMA_URL/completion" \
+      -H 'Content-Type: application/json' \
+      -d '{"prompt":"ping","n_predict":1,"temperature":0}'; then
+    break
+  fi
+  sleep 2
+  if [[ "$i" -eq 120 ]]; then
+    die "llama-server did not become ready; see $OUT_DIR/llama-server.log"
+  fi
+done
+
+echo "==> [3/3] llama-server quality ($TIER)"
+python3 "$QUALITY/run_quality.py" \
+  --backend llama-server \
+  --llama-url "$LLAMA_URL" \
+  --tier "$TIER" \
+  --out "$OUT_DIR/llama_${TIER}.jsonl"
+
+echo "==> done. results in $OUT_DIR"


### PR DESCRIPTION
## Summary

Restore the documented bench/quality A/B path:

- Add a llama-server HTTP backend (--backend llama-server / --llama-url) to bench/quality/run_quality.py.
- Add the missing Qwen3.6 orchestrator script bench/quality/run_qwen36_benchmark.sh.
- Add a --self-test-llama-server CPU-only mock that verifies HTTP wiring and scorer compatibility.

Fixes #650
Supersedes #651

## Scope

bench/quality/ only. Does not touch runtime/, kernels/, or moe/. No speed evaluation requested; proof section omitted on purpose.

## Self-test

Run: python3 bench/quality/run_quality.py --self-test-llama-server
