### PR TITLE
fix(dashboard): bind KPI Frontier decode to scored 128-tok frontier

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -537,7 +537,6 @@
 
   const q36 = D.qwen36 || {};
   const q36ctx128 = (q36.ctx||[]).find(x=>x.label==="128");
-  const q36ctx512 = (q36.ctx||[]).find(x=>x.label==="512");
   const q36Lead = q36ctx128 && q36ctx128.ref_tps ? 100*(q36ctx128.tps - q36ctx128.ref_tps)/q36ctx128.ref_tps : null;
 
   const q35 = D.qwen35 || {};
@@ -588,8 +587,8 @@
     </div>` : "");
   }
 
-  const kpiTps = q36ctx512?.tps || q36.frontier_tps || s.frontier_tps;
-  const kpiRef = q36ctx512?.ref_tps || q36.ref_tps || s.ref_tps;
+  const kpiTps = q36.frontier_tps || s.frontier_tps;
+  const kpiRef = q36.ref_tps || s.ref_tps;
   const kpiRefName = q36.ref_name || s.ref_name;
   const kpiTm = q36.token_match ?? s.token_match;
   const kpiKl = q36.kl ?? s.kl;
@@ -598,8 +597,8 @@
   const pct   = kpiRef > 0 ? 100*(kpiTps - kpiRef)/kpiRef : 0;
   const gapx  = kpiTps > 0 ? (kpiRef/kpiTps).toFixed(2) : "—";
   $("kpis").innerHTML = [
-    {lab:"Frontier decode", val:kpiTps, unit:"tok/s", note:"single-stream, bs=1 · 512-context · 128-tok · Qwen3.6-35B-A3B"},
-    {lab:(ahead?"vs ":"Gap to ")+kpiRefName, val:(ahead?"+"+pct.toFixed(1)+"%":gapx+"×"), unit:"", note:`${kpiRefName} ${kpiRef} tok/s · 512-context`},
+    {lab:"Frontier decode", val:kpiTps, unit:"tok/s", note:"single-stream, bs=1 · 128-tok · Qwen3.6-35B-A3B"},
+    {lab:(ahead?"vs ":"Gap to ")+kpiRefName, val:(ahead?"+"+pct.toFixed(1)+"%":gapx+"×"), unit:"", note:`${kpiRefName} ${kpiRef} tok/s · 128-tok`},
     {lab:"Accuracy", val:(kpiTm*100).toFixed(0)+"%", unit:"top-1", note:`KL ${kpiKl} vs ${kpiRefName}`},
     {lab:"VRAM resident", val:kpiVram, unit:"GB", note:"experts kept quantized"},
   ].map(k=>`<div class="kpi"><div class="lab">${k.lab}</div><div class="val">${k.val} <span>${k.unit}</span></div><div class="note">${k.note}</div></div>`).join("");

--- a/dashboard/test_kpi_binding.py
+++ b/dashboard/test_kpi_binding.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Regression tests for the dashboard KPI strip binding (issue #646).
+
+The KPI strip's "Frontier decode" tile and the SOTA card must publish the SAME
+decode number: the scored 128-tok competition frontier (`qwen36.frontier_tps`).
+A prior revision bound the KPI to the 512-context entry, so the page showed two
+disagreeing "frontier decode" figures and computed the vs-llama.cpp lead off the
+wrong context.
+
+`frontier_tps` is the 128-context field by the eval bot's own schema --
+see CTX_SERIES in eval/pr_eval_bot.py, where 128 maps to status "frontier_tps"
+while 512 maps to "longctx_512_tps".
+
+The dashboard is a no-build static page (index.html + data.js), so these tests
+assert on the binding expressions in the source plus the data invariant they
+rely on, rather than driving a browser.
+
+Run from the repo root:
+  python3 dashboard/test_kpi_binding.py
+"""
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "dashboard" / "index.html"
+DATA = ROOT / "dashboard" / "data.json"
+
+
+def read_index():
+    return INDEX.read_text(encoding="utf-8")
+
+
+def const_rhs(html, name):
+    """Right-hand side of `const <name> = ...;` as written in index.html."""
+    m = re.search(r"^[ \t]*const[ \t]+" + re.escape(name) + r"[ \t]*=[ \t]*(.+?);[ \t]*$",
+                  html, re.M)
+    assert m, "const %s assignment not found in %s" % (name, INDEX.name)
+    return m.group(1).strip()
+
+
+def kpi_block(html):
+    """The `$("kpis").innerHTML = [ ... ]` array literal, including tile notes."""
+    start = html.index('$("kpis").innerHTML')
+    end = html.index("].map(", start)
+    return html[start:end]
+
+
+def ctx_entry(model, label):
+    for row in model.get("ctx", []):
+        if row.get("label") == label:
+            return row
+    raise AssertionError("no ctx entry labelled %r" % label)
+
+
+# `const q36ctx128 = (q36.ctx||[]).find(x=>x.label==="128");` and friends.
+CTX_CONST_RE = re.compile(
+    r'const[ \t]+(q3\dctx\w+)[ \t]*=[ \t]*\((q3\d)\.ctx\|\|\[\]\)\.find\(x=>x\.label==="([^"]+)"\)')
+
+
+def binding_namespace(html, data):
+    """The names a KPI expression may reference, resolved as index.html defines them.
+
+    Reads the per-context consts out of the page rather than assuming which ones
+    exist, so the same helper resolves the expression before and after a rebind.
+    """
+    models = {"q36": data.get("qwen36") or {}, "q35": data.get("qwen35") or {}}
+    ns = dict(models, s=data.get("status") or {})
+    for name, model, label in CTX_CONST_RE.findall(html):
+        rows = models.get(model, {}).get("ctx") or []
+        ns[name] = next((r for r in rows if r.get("label") == label), None)
+    return ns
+
+
+def resolve_or_chain(expr, ns):
+    """Evaluate a `a.b || c.d` fallback chain (optional chaining allowed) against ns.
+
+    Mirrors JS `||` semantics: the first truthy operand wins, so a 0 or missing
+    value falls through exactly as the page would.
+    """
+    for operand in expr.split("||"):
+        parts = operand.strip().replace("?.", ".").split(".")
+        value = ns.get(parts[0])
+        for part in parts[1:]:
+            value = value.get(part) if isinstance(value, dict) else None
+        if value:
+            return value
+    return None
+
+
+class KpiBindingTest(unittest.TestCase):
+    """The KPI tiles must read the scored frontier, not a per-context row."""
+
+    def setUp(self):
+        self.html = read_index()
+
+    def test_kpi_tps_binds_to_scored_frontier(self):
+        rhs = const_rhs(self.html, "kpiTps")
+        self.assertTrue(rhs.startswith("q36.frontier_tps"),
+                        "kpiTps must bind to the scored 128-tok frontier, got: %s" % rhs)
+
+    def test_kpi_ref_binds_to_scored_frontier_reference(self):
+        rhs = const_rhs(self.html, "kpiRef")
+        self.assertTrue(rhs.startswith("q36.ref_tps"),
+                        "kpiRef must bind to the 128-tok llama.cpp reference, got: %s" % rhs)
+
+    def test_kpi_keeps_status_fallback(self):
+        """Backward compatibility: the page still renders when D.qwen36 is absent."""
+        self.assertIn("s.frontier_tps", const_rhs(self.html, "kpiTps"))
+        self.assertIn("s.ref_tps", const_rhs(self.html, "kpiRef"))
+
+    def test_no_per_context_row_feeds_the_kpi(self):
+        """A ctx-row lookup in the KPI is the exact defect from #646."""
+        for expr in (const_rhs(self.html, "kpiTps"), const_rhs(self.html, "kpiRef")):
+            self.assertNotRegex(expr, r"q3\dctx\d",
+                                "KPI must not bind to a per-context row: %s" % expr)
+
+    def test_kpi_notes_do_not_claim_512_context(self):
+        block = kpi_block(self.html)
+        self.assertNotIn("512-context", block,
+                         "KPI tile notes still advertise 512-context")
+        self.assertIn("128-tok", block,
+                      "KPI tile notes should state the 128-tok context")
+
+
+class FrontierIdentityTest(unittest.TestCase):
+    """The data invariant that makes the KPI and the SOTA card agree."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = read_index()
+        cls.data = json.loads(DATA.read_text(encoding="utf-8"))
+        cls.q36 = cls.data["qwen36"]
+
+    def test_fixture_discriminates_128_from_512(self):
+        """Guard: if the two rows ever held equal tok/s these tests would pass vacuously."""
+        self.assertNotEqual(ctx_entry(self.q36, "128")["tps"],
+                            ctx_entry(self.q36, "512")["tps"],
+                            "fixture no longer distinguishes the 128 and 512 rows")
+
+    def test_frontier_tps_is_the_128_tok_row(self):
+        self.assertEqual(self.q36["frontier_tps"], ctx_entry(self.q36, "128")["tps"])
+
+    def test_frontier_reference_is_the_128_tok_reference(self):
+        """The vs-llama.cpp percentage must be computed off the 128-tok reference."""
+        self.assertEqual(self.q36["ref_tps"], ctx_entry(self.q36, "128")["ref_tps"])
+
+    def test_kpi_and_sota_resolve_to_one_decode_number(self):
+        """One 'frontier decode' number on the page, not two (#646).
+
+        Resolves the expression as written in index.html against the live data,
+        so a rebind to any other context fails here and not just on the source
+        assertions above.
+        """
+        ns = binding_namespace(self.html, self.data)
+        kpi_tps = resolve_or_chain(const_rhs(self.html, "kpiTps"), ns)
+        kpi_ref = resolve_or_chain(const_rhs(self.html, "kpiRef"), ns)
+        sota_tps = self.q36["frontier_tps"]          # rendered as "128-tok decode"
+
+        self.assertEqual(kpi_tps, sota_tps,
+                         "KPI decode number disagrees with the SOTA card")
+        self.assertEqual(kpi_ref, ctx_entry(self.q36, "128")["ref_tps"],
+                         "vs-llama.cpp %% is computed off the wrong context")
+        self.assertNotEqual(kpi_tps, ctx_entry(self.q36, "512")["tps"],
+                            "KPI still resolves to the 512-context row")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

The dashboard KPI strip labels a tile "Frontier decode" but resolved it from the Qwen3.6 **512-context** row, while the SOTA card below renders `frontier_tps` (**128-tok**). The page therefore published two disagreeing "frontier decode" numbers, and the vs-llama.cpp percentage next to the KPI was computed against the wrong context.

Against current `dashboard/data.json`:

| surface | decode | vs llama.cpp |
|---|---:|---:|
| KPI strip (before) | 480.91 tok/s | +74.5% |
| SOTA card | 476.54 tok/s | +73% |
| KPI strip (after) | **476.54 tok/s** | **+72.8%** |

## Root cause

Not a `||` precedence bug — the chain behaved as written. The 512 binding was introduced deliberately:

```
c5febb9  skyrocket2026  2026-07-14  (branch dashboard/q36-512-kpis, PR #395)
  Dashboard hero KPIs: Qwen3.6 512-context decode vs llama.cpp.
  Wire the top stat row to qwen36 @ 512 ctx (480.91 tok/s) ...
```

That commit also rewrote the tile note to read `512-context`, leaving it self-contradictory (`bs=1 · 512-context · 128-tok`). So this PR reverts a presentational choice rather than repairing a defect — flagging that explicitly, since it lowers the public headline from 480.91 to 476.54.

The case for pinning to 128-tok: `CTX_SERIES[128]["status"] == "frontier_tps"` in `eval/pr_eval_bot.py` (512 maps to `longctx_512_tps`), `dashboard/README.md` describes the frontier as "@ 128 ctx", and the adjacent in-file comment reads "on the 128-token frontier". The counter-argument is that eval records carry `decode_score_context: 512` for Qwen3.6, so a maintainer may prefer the KPI to track the scored context dynamically. Happy to close this if that is the preference.

## Changes made

`dashboard/index.html` (+4 / −5):

- `kpiTps` / `kpiRef` now bind to `q36.frontier_tps` / `q36.ref_tps`. The `s.frontier_tps` / `s.ref_tps` fallback is preserved, so the page still renders when `D.qwen36` is absent.
- Both KPI tile notes now read `128-tok` instead of claiming `512-context` and `128-tok` simultaneously.
- Removed the `q36ctx512` const, which had no remaining references after the rebind.

No changes to `data.js` or `data.json`.

## Tests

Adds `dashboard/test_kpi_binding.py` — 171 lines, stdlib `unittest` only, no new dependencies, following the convention in `bench/scripts/test_label.py`.

It parses the `kpiTps` / `kpiRef` expressions out of `index.html`, discovers the per-context consts the page defines, resolves the chain against `data.json` with JS truthiness semantics, and asserts the KPI and SOTA card agree. It also guards the data contract (`frontier_tps` is the 128 row) and includes an anti-vacuity check so the suite cannot pass trivially if the 128 and 512 rows ever converge.

Five of its nine assertions fail without the source change; the rest are data-contract and backward-compatibility guards that hold either way.

The dashboard is a no-build static page with no JS test runner in-tree, so the test asserts on the binding expression and data rather than driving a browser. Note that `eval-policy.yml` only triggers on `bench/scripts/**` and `eval/**`, so CI will not run this test as things stand — it would need `dashboard/**` added to that workflow.

## Validation

Run on Windows with Python 3.14. Results as observed:

| Command | Result |
|---|---|
| `python dashboard/test_kpi_binding.py` | `Ran 9 tests — OK`, exit 0 |
| same, with `index.html` reverted to `main` | `Ran 9 tests — FAILED (failures=5)`, exit 1 |
| `bash -n` on `evaluate.sh`, `warm_llamacpp.sh`, `run_bot_cron.sh`, `setup_labels.sh` | all OK |
| `python -m py_compile` on the five `eval-policy` files plus the new test | OK |
| 10 existing Python suites, vs a stashed pristine-`main` baseline | identical results — no new failures |

Five existing suites fail on this machine both with and without the change: `test_label_ttft.py`, `test_cb_prefill_score.py` (hardcode `python3`, which resolves to a Windows stub), `test_prefill_label_merge.py`, `test_bench_sweep.py` (shell out to `bash`), and `test_pr_eval_bot.py` (missing `cryptography`). All are pre-existing and environmental; baselines were captured with the working tree stashed.

Not run: the C++/CUDA suite (`cmake`/`ctest` unavailable, no CUDA toolkit, no NVIDIA GPU on this machine) and the benchmark/accuracy scripts (require a GPU and model weights). This change touches only HTML and Python, so neither is affected — but they were not executed and are not claimed to have passed.

Rendered output was additionally checked by evaluating the real `kpiTps` / `kpiRef` expressions against the real `data.json` in Node, confirming 476.54 / +72.8% after the change and 480.91 / +74.5% before. That harness was a local scratch script and is not included in this PR.

## Risks and limitations

- Reverts an intentional decision (`c5febb9`) and lowers the advertised headline. This needs a maintainer product call, not just a code review.
- The test asserts on source text via regex and would need updating if `index.html` is reformatted. Unavoidable without a JS test runner.
- CI does not currently exercise the test (see Tests above).
- In degenerate data shapes — `frontier_tps` falsy, or `ref_tps` missing — `kpiTps` and `kpiRef` can resolve from different sources, yielding a cross-model percentage. This hazard is pre-existing in the independent `||` chains rather than introduced here, does not occur in current data, and when `frontier_tps` is falsy the SOTA card is suppressed entirely so no disagreement is shown. Left alone to keep this change scoped; happy to harden it separately if wanted.
- Related prior art: PR #654 targets the same issue and is still open as a draft. Deferring to it if maintainers prefer that one — this PR additionally carries the regression test.

Fixes #646
