### PR TITLE
fix(runtime): take convert_gguf vocab from token_embd, not a dead branch

### DIFF
--- a/runtime/tools/convert_gguf.py
+++ b/runtime/tools/convert_gguf.py
@@ -23,6 +23,17 @@ def to_bf16(x):
     return ((u + 0x7FFF + ((u >> 16) & 1)) >> 16).astype(np.uint16)
 
 
+def vocab_from_embedding(shape, fallback):
+    """Vocab size from token_embd.weight, matching qwen3_gguf_config.h.
+
+    ReaderTensor.shape is the raw ggml dim order ([n_embd, n_vocab]) — not the
+    reversed numpy order that .data is reshaped into — so vocab is dims[1],
+    exactly what the C++ loader reads as emb->dims[1]. A tensor that isn't 2-D
+    keeps the metadata value.
+    """
+    return int(shape[1]) if len(shape) >= 2 else fallback
+
+
 def main():
     if len(sys.argv) != 3:
         print(__doc__); sys.exit(1)
@@ -54,10 +65,10 @@ def main():
         rms_eps=float(meta(A + "attention.layer_norm_rms_epsilon")),
         eos_id=int(meta("tokenizer.ggml.eos_token_id") or 151645),
     )
-    # vocab from token_embd if metadata missing
+    # vocab from token_embd, preferred over metadata (matches the C++ loader)
     ten = {t.name: t for t in r.tensors}
     if "token_embd.weight" in ten:
-        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
+        cfg["vocab"] = vocab_from_embedding(ten["token_embd.weight"].shape, cfg["vocab"])
 
     with open(os.path.join(out, "config.txt"), "w") as f:
         for k, v in cfg.items():

--- a/runtime/tools/test_convert_gguf.py
+++ b/runtime/tools/test_convert_gguf.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Regression tests for convert_gguf.py vocab derivation (issue #637).
+
+`config.txt` must take vocab from the token_embd.weight tensor, preferring it
+over `qwen3moe.vocab_size` metadata, so the converter agrees with the C++ loader
+(`emb->dims[1]` in runtime/examples/qwen3_gguf_config.h). A prior revision wrote
+the assignment as `... if False else cfg["vocab"]`, making it a no-op, so a GGUF
+with missing or disagreeing metadata produced a wrong vocab and broke downstream
+load_weights / LM-head sizing.
+
+Axis note: gguf's ReaderTensor.shape is the RAW ggml dim order
+([n_embd, n_vocab]); only `.data` is reshaped into reversed numpy order
+([vocab, hidden]). Vocab is therefore dims[1], not dims[0].
+
+convert_gguf.py imports `gguf` and `numpy` at module scope, which the repo does
+not require for tests, so these tests exec the pure helper out of the source
+rather than importing the module.
+
+Run from the repo root:
+  python3 runtime/tools/test_convert_gguf.py
+"""
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "runtime" / "tools" / "convert_gguf.py"
+
+
+def read_script():
+    return SCRIPT.read_text(encoding="utf-8")
+
+
+def load_vocab_helper():
+    """exec only vocab_from_embedding() so no gguf/numpy import is needed."""
+    src = read_script()
+    m = re.search(r"^def vocab_from_embedding\(.*?(?=^\S|\Z)", src, re.M | re.S)
+    assert m, "vocab_from_embedding() not found in %s" % SCRIPT.name
+    namespace = {}
+    exec(m.group(0), namespace)  # noqa: S102 - pure function, no imports
+    return namespace["vocab_from_embedding"]
+
+
+def vocab_assignment(src):
+    """The line in main() that sets cfg["vocab"] from the embedding tensor."""
+    m = re.search(r'^\s*cfg\["vocab"\]\s*=\s*(.+)$', src, re.M)
+    assert m, 'cfg["vocab"] assignment not found'
+    return m.group(1).strip()
+
+
+class VocabFromEmbeddingTest(unittest.TestCase):
+    """The helper must read ggml dims[1], matching qwen3_gguf_config.h."""
+
+    def setUp(self):
+        self.vocab_from_embedding = load_vocab_helper()
+
+    def test_reads_dims_1_of_ggml_shape(self):
+        # ggml order for token_embd.weight is [n_embd, n_vocab].
+        self.assertEqual(self.vocab_from_embedding((2048, 151936), 0), 151936)
+
+    def test_does_not_read_dims_0(self):
+        """dims[0] is hidden size — returning it would mis-size the LM head."""
+        self.assertNotEqual(self.vocab_from_embedding((2048, 151936), 0), 2048)
+
+    def test_tensor_overrides_disagreeing_metadata(self):
+        """The tensor wins; the metadata value is only a fallback."""
+        self.assertEqual(self.vocab_from_embedding((2048, 151936), 151645), 151936)
+
+    def test_non_2d_tensor_keeps_metadata_fallback(self):
+        """Mirrors the C++ `emb->n_dims >= 2` guard."""
+        self.assertEqual(self.vocab_from_embedding((151936,), 151645), 151645)
+        self.assertEqual(self.vocab_from_embedding((), 151645), 151645)
+
+    def test_returns_int(self):
+        result = self.vocab_from_embedding([2048, 151936], 0)
+        self.assertIsInstance(result, int)
+
+
+class VocabAssignmentIsLiveTest(unittest.TestCase):
+    """The assignment must not be short-circuited back to its own value."""
+
+    def setUp(self):
+        self.src = read_script()
+
+    def test_assignment_is_not_dead_coded(self):
+        rhs = vocab_assignment(self.src)
+        self.assertNotIn("if False", rhs,
+                         "vocab assignment is dead-coded: %s" % rhs)
+        self.assertNotRegex(rhs, r'else\s+cfg\["vocab"\]',
+                            "vocab assignment resolves back to itself: %s" % rhs)
+
+    def test_assignment_uses_the_helper(self):
+        self.assertIn("vocab_from_embedding", vocab_assignment(self.src))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`runtime/tools/convert_gguf.py` documents taking `vocab` from `token_embd.weight`, but the assignment was short-circuited:

```python
# vocab from token_embd if metadata missing
if "token_embd.weight" in ten:
    cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
```

`if False` makes it a no-op — it always re-assigns `cfg["vocab"]` to itself. A GGUF whose `qwen3moe.vocab_size` is absent or disagrees with the tensor therefore writes a wrong `vocab=` into `config.txt`, mis-sizing the LM head for downstream `load_weights` on this tool path.

## Root cause

Dead code, not a logic error: the intent is stated in the comment directly above and implemented correctly on the C++ side, but the Python branch was disabled and the fallback never ran.

The C++ loader is the reference — `runtime/examples/qwen3_gguf_config.h`:

```cpp
cfg.vocab = (int)qwen3_meta_int(g, "vocab_size", cfg.vocab);
const sparkinfer::GGUFTensor* emb = g.tensor("token_embd.weight");
if (emb && emb->n_dims >= 2) cfg.vocab = (int)emb->dims[1];
```

Note it *prefers* the tensor over metadata rather than only using it when metadata is missing, so the comment's "if metadata missing" understated the intent. This PR matches the C++ precedence.

### Axis correctness

Worth stating explicitly, since the two orders are easy to conflate. From `gguf/gguf_reader.py`:

```python
np_dims = tuple(reversed(dims.tolist()))
shape = dims,                 # ReaderTensor.shape = RAW ggml dims
data  = ....reshape(np_dims)  # .data = reversed numpy order
```

So `ReaderTensor.shape` is ggml order `[n_embd, n_vocab]` → vocab is `shape[1]`, exactly the C++ `emb->dims[1]`. Only `.data` is `[vocab, hidden]` (as the existing comment on the `embed_tokens` write notes). The old dead expression used `shape[-1]`, which coincides with `shape[1]` for a 2-D tensor but would read the wrong axis for any higher rank; this PR uses `shape[1]` with an explicit 2-D guard, mirroring the C++ `n_dims >= 2` check.

## Changes made

`runtime/tools/convert_gguf.py` (+15 / −2):

- Adds `vocab_from_embedding(shape, fallback)` — returns `int(shape[1])` for a 2-D tensor, else the metadata fallback.
- The `cfg["vocab"]` assignment now calls it instead of resolving back to itself.
- Comment updated to say the tensor is *preferred over* metadata, matching the C++ precedence.

No behaviour change for a well-formed GGUF whose `vocab_size` metadata already agrees with the tensor — which is the common case, so existing conversions are unaffected.

## Tests

Adds `runtime/tools/test_convert_gguf.py` — 98 lines, stdlib `unittest` only, following the convention in `bench/scripts/test_label.py`.

`convert_gguf.py` imports `gguf` and `numpy` at module scope, and the repo's tests otherwise need no third-party packages, so the tests exec the pure helper out of the source rather than importing the module. That keeps them runnable anywhere.

Coverage:

- reads ggml `dims[1]`, and explicitly asserts it does **not** read `dims[0]` (hidden size)
- the tensor overrides disagreeing metadata
- a non-2-D tensor keeps the metadata fallback (the `n_dims >= 2` guard)
- returns `int`
- the assignment is not dead-coded and does not resolve back to `cfg["vocab"]` — the regression itself

All 7 assertions fail against `main` and pass with this change.

## Validation

| Command | Result |
|---|---|
| `python runtime/tools/test_convert_gguf.py` | `Ran 7 tests — OK`, exit 0 |
| same, with `convert_gguf.py` reverted to `main` | `Ran 7 tests — FAILED (failures=7)`, exit 1 |
| `python -m py_compile` on both changed files | OK |
| `bash -n` on `evaluate.sh`, `warm_llamacpp.sh`, `run_bot_cron.sh`, `setup_labels.sh` | OK |
| `python -m py_compile` on the five `eval-policy` files | OK |
| `test_label.py`, `test_guard_reject.py`, `test_bidir_headline.py`, `test_accuracy_cache.py`, `test_copycat_guard.py` | all OK |

Not run: the C++/CUDA suite (`cmake`/`ctest` unavailable, no CUDA toolkit, no NVIDIA GPU on this machine) and the benchmark/accuracy scripts (require a GPU and model weights). This change is Python-only and touches no build or kernel path, so neither is affected — but they were not executed and are not claimed to have passed.

An end-to-end conversion was also not run, as that needs a multi-GB GGUF; the helper is covered directly by unit tests instead.

## Risks and limitations

- Behaviour changes only for GGUFs whose `vocab_size` metadata is missing or disagrees with `token_embd.weight`. For those the old output was wrong, so this is a correction rather than a compatibility break — but it does mean a previously-produced `config.txt` may differ.
- The tests parse the source to reach the helper. If the function is renamed or reformatted they need updating; that is the cost of not importing `gguf` in the test path.
- `eval-policy.yml` is path-filtered to `bench/scripts/**` and `eval/**`, so CI will not run this test as things stand. It would need `runtime/tools/**` (or a broader glob) added to that workflow.

## A note on the RTX 5090 gate

This is a no-GPU tooling fix with no proof-of-speedup section, but it touches `runtime/`, and `rtx5090-required` closes any non-draft PR under `runtime/` unless the 5090 checkbox is ticked. Ticking it without having run on a 5090 would be false attestation, so this is opened as a **draft** instead — the only exemption available to a contributor.

Could a maintainer add `hold` so it can be marked ready for review? Same question as #654; happy to follow whatever the intended path is for non-GPU `runtime/` fixes.

Fixes #637
