### PR TITLE
perf(qwen36): batch DFlash draft model projections and LM head across the block

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -143,6 +143,87 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
         ov[i] = f2b(acc[i] * inv);
 }
 
+// One warp per output row `n`, computing y[b][n] = sum_k x[b][k] * W[n][k] for all b in
+// [0,BATCH) at once. W stays in its native [N,K] "out,in" row-major layout (the same layout
+// the single-row GEMV path reads) -- unlike a tiled A@B GEMM, this needs no relayout. Each
+// warp reads its weight row from DRAM once and reuses it across the whole BATCH instead of
+// once per row, so BATCH separate GEMV launches collapse into one launch with ~BATCH-times
+// less weight traffic. Register cost is O(BATCH), so this is only used for the draft's
+// fixed block_size batch (16), never for the variable, potentially-large context length.
+// K is always a multiple of 8 for every weight this is used on (H=2048, qdim=4096,
+// kvdim=1024, I=6144), and cudaMalloc'd row bases land on >=16-byte boundaries, so every
+// lane's 8-element (16-byte) chunk is safely loadable as one uint4 -- this is the kernel's
+// dominant cost (each lane otherwise issues K/32 separate 2-byte loads per weight row), same
+// lesson as the fused prefill dequant-GEMM kernels: load width, not FLOPs, is the limiter here.
+template <int BATCH>
+__global__ void k_gemv_batched(const bf16* __restrict__ x, const bf16* __restrict__ W,
+                               bf16* __restrict__ y, int N, int K) {
+    const int warps_per_block = blockDim.x / 32;
+    const int n = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    if (n >= N) return;
+    const int lane = threadIdx.x & 31;
+    float acc[BATCH];
+#pragma unroll
+    for (int b = 0; b < BATCH; b++) acc[b] = 0.f;
+    const uint4* wrow4 = (const uint4*)(W + (size_t)n * K);
+    const int K8 = K / 8;
+    for (int k8 = lane; k8 < K8; k8 += 32) {
+        const bf16* wv = (const bf16*)&wrow4[k8];
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) {
+            const bf16* xv = (const bf16*)&(((const uint4*)(x + (size_t)b * K))[k8]);
+#pragma unroll
+            for (int j = 0; j < 8; j++) acc[b] += b2f(wv[j]) * b2f(xv[j]);
+        }
+    }
+#pragma unroll
+    for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1)
+            acc[b] += __shfl_down_sync(0xffffffffu, acc[b], off);
+    }
+    if (lane == 0) {
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) y[(size_t)b * N + n] = f2b(acc[b]);
+    }
+}
+
+// Same batched-GEMV shape as k_gemv_batched, but for the LM head: fp32 accumulate/output
+// (matching the precision the original per-row launch_gemv_q_f32/launch_gemv_f32 path used
+// for logits) and no BATCH-sized register cap on N (vocab is large, only grid.x scales).
+template <int BATCH>
+__global__ void k_gemv_batched_f32(const bf16* __restrict__ x, const bf16* __restrict__ W,
+                                   float* __restrict__ y, int N, int K) {
+    const int warps_per_block = blockDim.x / 32;
+    const int n = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    if (n >= N) return;
+    const int lane = threadIdx.x & 31;
+    float acc[BATCH];
+#pragma unroll
+    for (int b = 0; b < BATCH; b++) acc[b] = 0.f;
+    const uint4* wrow4 = (const uint4*)(W + (size_t)n * K);
+    const int K8 = K / 8;
+    for (int k8 = lane; k8 < K8; k8 += 32) {
+        const bf16* wv = (const bf16*)&wrow4[k8];
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) {
+            const bf16* xv = (const bf16*)&(((const uint4*)(x + (size_t)b * K))[k8]);
+#pragma unroll
+            for (int j = 0; j < 8; j++) acc[b] += b2f(wv[j]) * b2f(xv[j]);
+        }
+    }
+#pragma unroll
+    for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1)
+            acc[b] += __shfl_down_sync(0xffffffffu, acc[b], off);
+    }
+    if (lane == 0) {
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) y[(size_t)b * N + n] = acc[b];
+    }
+}
+
 } // namespace
 
 void launch_add(const void* x, const void* y, void* out, int n, cudaStream_t stream) {
@@ -185,6 +266,24 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
     k_attn<<<grid, 128, smem, stream>>>((const bf16*)q, (const bf16*)k, (const bf16*)v,
                                         (bf16*)out, q_len, kv_len, n_q, n_kv, d,
                                         q_pos0, k_pos0, window, scale);
+}
+
+void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
+                           cudaStream_t stream) {
+    if (N <= 0) return;
+    constexpr int WARPS_PER_BLOCK = 4;
+    dim3 grid((N + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
+    k_gemv_batched<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
+        (const bf16*)x, (const bf16*)W, (bf16*)y, N, K);
+}
+
+void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,
+                               cudaStream_t stream) {
+    if (N <= 0) return;
+    constexpr int WARPS_PER_BLOCK = 4;
+    dim3 grid((N + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
+    k_gemv_batched_f32<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
+        (const bf16*)x, (const bf16*)W, y, N, K);
 }
 
 } // namespace dflash_kernels

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -30,6 +30,15 @@ void launch_add(const void* x, const void* y, void* out, int n,
 void launch_rms(const void* x, const void* w, void* out, int rows, int cols,
                 float eps, cudaStream_t stream);
 
+// Batched GEMV: y[b,:] = x[b,:] @ W^T for a fixed batch of 16 rows in one launch.
+// x: [16,K] bf16, W: [N,K] bf16 (native "out,in" layout, same as a single-row GEMV), y: [16,N] bf16.
+void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
+                           cudaStream_t stream);
+
+// Same, with fp32 output/accumulate (for the LM head's logits).
+void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,
+                               cudaStream_t stream);
+
 // Per-head RMSNorm on [seq, n_heads, d] (in-place).
 void launch_rms_heads(void* x, const void* w, int seq, int n_heads, int d,
                       float eps, cudaStream_t stream);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -3,6 +3,7 @@
 #include "sparkinfer/models/dflash_kernels.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/fused.h"
+#include "sparkinfer/kernels/quant.h"
 
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
@@ -247,6 +248,7 @@ struct DFlashDraftModel::Impl {
     int lm_head_type = 0;
     int vocab = 0;
     int hidden = 0;
+    bf16* lm_head_bf16 = nullptr;  // eager dequant+transpose cache for the batched LM-head GEMM
 
     // Scratch
     cudaStream_t stream{};
@@ -314,6 +316,21 @@ void DFlashDraftModel::set_shared_weights(const void* embed, const void* lm_head
     p_->lm_head_type = lm_head_type;
     p_->vocab = vocab;
     p_->hidden = hidden;
+    // Eagerly dequantize the (static, resident) lm_head weight to bf16 exactly once, in its
+    // native [vocab,hidden] ("out,in") layout -- dflash_kernels::launch_gemv_batched16_f32
+    // reads W the same way a single-row GEMV does, so no relayout is needed. Lets
+    // forward_block score a whole block with one batched GEMV instead of a per-token loop.
+    if (!p_->lm_head_bf16 && vocab > 0 && hidden > 0) {
+        p_->lm_head_bf16 = p_->alloc<bf16>((size_t)vocab * hidden);
+        if (lm_head_type != 0) {
+            kernels::launch_gguf_dequant(lm_head_type, lm_head, p_->lm_head_bf16,
+                                         (long)vocab * hidden, p_->stream);
+        } else {
+            cu(cudaMemcpyAsync(p_->lm_head_bf16, lm_head, (size_t)vocab * hidden * sizeof(bf16),
+                               cudaMemcpyDeviceToDevice, p_->stream), "lm_head copy");
+        }
+        cu(cudaStreamSynchronize(p_->stream), "lm_head dequant");
+    }
 }
 
 void DFlashDraftModel::reset() { p_->seq_len = 0; }
@@ -439,6 +456,11 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     const int d = c.head_dim;
     const float scale = 1.f / sqrtf((float)d);
     const int past = s.seq_len;
+    // The fixed-size (block_size) projections below can use a batched-GEMV kernel that reads
+    // each weight row from DRAM once instead of once per token (see dflash_kernels.cu). It's
+    // compiled for exactly 16 rows, so it's only used when the draft's block_size is 16 (true
+    // for the current checkpoint); any other block_size falls back to the per-token GEMV loop.
+    const bool fast16 = (B == 16);
 
     cu(cudaMemcpyAsync(s.d_ids, noise_ids, B * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
     kernels::launch_embedding(s.d_ids, s.embed, s.noise, B, H, st);
@@ -464,8 +486,11 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         dflash_kernels::launch_rms(s.x, w.input_norm, s.xn, B, H, c.rms_eps, st);
 
         // Q from noise, K/V from cat(target, noise)
-        for (int t = 0; t < B; t++) {
-            kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
+        if (fast16) {
+            dflash_kernels::launch_gemv_batched16(s.xn, w.wq, s.q, qdim, H, st);
+        } else {
+            for (int t = 0; t < B; t++)
+                kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
         // Build k_new / v_new = cat(k_ctx, k_noise)
         for (int t = 0; t < ctx_len; t++) {
@@ -474,11 +499,18 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wv,
                                  s.v_new + (size_t)t * kvdim, kvdim, H, st);
         }
-        for (int t = 0; t < B; t++) {
-            kernels::launch_gemv(s.xn + (size_t)t * H, w.wk,
-                                 s.k_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
-            kernels::launch_gemv(s.xn + (size_t)t * H, w.wv,
-                                 s.v_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
+        if (fast16) {
+            dflash_kernels::launch_gemv_batched16(s.xn, w.wk, s.k_new + (size_t)ctx_len * kvdim,
+                                                  kvdim, H, st);
+            dflash_kernels::launch_gemv_batched16(s.xn, w.wv, s.v_new + (size_t)ctx_len * kvdim,
+                                                  kvdim, H, st);
+        } else {
+            for (int t = 0; t < B; t++) {
+                kernels::launch_gemv(s.xn + (size_t)t * H, w.wk,
+                                     s.k_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
+                kernels::launch_gemv(s.xn + (size_t)t * H, w.wv,
+                                     s.v_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
+            }
         }
 
         const int new_len = ctx_len + B;
@@ -515,32 +547,51 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                         B, kv_len, c.n_q_heads, c.n_kv_heads, d,
                                         q_pos0, /*k_pos0_cache=*/0, window, scale, st);
 
-        for (int t = 0; t < B; t++)
-            kernels::launch_gemv(s.attn + (size_t)t * qdim, w.wo, s.ao + (size_t)t * H, H, qdim, st);
+        if (fast16) {
+            dflash_kernels::launch_gemv_batched16(s.attn, w.wo, s.ao, H, qdim, st);
+        } else {
+            for (int t = 0; t < B; t++)
+                kernels::launch_gemv(s.attn + (size_t)t * qdim, w.wo, s.ao + (size_t)t * H, H, qdim, st);
+        }
         dflash_kernels::launch_add(s.x, s.ao, s.h, B * H, st);
 
         dflash_kernels::launch_rms(s.h, w.post_norm, s.hn, B, H, c.rms_eps, st);
-        for (int t = 0; t < B; t++) {
-            kernels::launch_gemv(s.hn + (size_t)t * H, w.gate, s.gate + (size_t)t * I, I, H, st);
-            kernels::launch_gemv(s.hn + (size_t)t * H, w.up,   s.up   + (size_t)t * I, I, H, st);
+        if (fast16) {
+            dflash_kernels::launch_gemv_batched16(s.hn, w.gate, s.gate, I, H, st);
+            dflash_kernels::launch_gemv_batched16(s.hn, w.up, s.up, I, H, st);
+        } else {
+            for (int t = 0; t < B; t++) {
+                kernels::launch_gemv(s.hn + (size_t)t * H, w.gate, s.gate + (size_t)t * I, I, H, st);
+                kernels::launch_gemv(s.hn + (size_t)t * H, w.up,   s.up   + (size_t)t * I, I, H, st);
+            }
         }
         dflash_kernels::launch_swiglu(s.gate, s.up, s.gate, B * I, st);
-        for (int t = 0; t < B; t++)
-            kernels::launch_gemv(s.gate + (size_t)t * I, w.down, s.down + (size_t)t * H, H, I, st);
+        if (fast16) {
+            dflash_kernels::launch_gemv_batched16(s.gate, w.down, s.down, H, I, st);
+        } else {
+            for (int t = 0; t < B; t++)
+                kernels::launch_gemv(s.gate + (size_t)t * I, w.down, s.down + (size_t)t * H, H, I, st);
+        }
         dflash_kernels::launch_add(s.h, s.down, s.x, B * H, st);
     }
 
     dflash_kernels::launch_rms(s.x, s.final_norm, s.xn, B, H, c.rms_eps, st);
 
-    // LM head (target weights) -> logits / argmax. Skip row 0 for proposals but still compute.
+    // LM head (target weights) -> logits / argmax. Batched over the whole block: one batched
+    // GEMV against the eagerly dequantized bf16 lm_head cache instead of a per-token
+    // quantized GEMV loop.
     const int V = s.vocab > 0 ? s.vocab : c.vocab;
-    for (int t = 0; t < B; t++) {
-        const bf16* row = s.xn + (size_t)t * H;
-        float* logit_row = s.logits + (size_t)t * V;
-        if (s.lm_head_type)
-            kernels::launch_gemv_q_f32(row, s.lm_head, s.lm_head_type, logit_row, V, H, st);
-        else
-            kernels::launch_gemv_f32(row, s.lm_head, logit_row, V, H, st);
+    if (fast16) {
+        dflash_kernels::launch_gemv_batched16_f32(s.xn, s.lm_head_bf16, s.logits, V, H, st);
+    } else {
+        for (int t = 0; t < B; t++) {
+            const bf16* row = s.xn + (size_t)t * H;
+            float* logit_row = s.logits + (size_t)t * V;
+            if (s.lm_head_type)
+                kernels::launch_gemv_q_f32(row, s.lm_head, s.lm_head_type, logit_row, V, H, st);
+            else
+                kernels::launch_gemv_f32(row, s.lm_head, logit_row, V, H, st);
+        }
     }
     kernels::launch_argmax(s.logits, s.d_out, B, V, st);
     cu(cudaMemcpyAsync(s.h_out, s.d_out, B * sizeof(int), cudaMemcpyDeviceToHost, st), "argmax");


### PR DESCRIPTION
## Summary

The DFlash draft model computed its Q/K/V/O/gate/up/down projections and LM head with one `launch_gemv` call per token in the 16-token block — 16x redundant re-reads of each weight matrix from DRAM. Replaces those loops with a batched-GEMV kernel (one warp per output row, 16-byte vectorized loads, weight read once and reused across the whole block) for every projection whose row count is exactly `block_size` (16), plus the LM head (now scored via a one-time eager bf16 dequant of the lm_head weight instead of a per-token quantized GEMV).
The variable-length context path (`fc`/`wk_ctx`/`wv_ctx`) is untouched — batching it the same way measured net-negative (padding overhead exceeds the win when true context length is well under 16) and was not shipped.

Confined to the draft model's own forward pass (`dflash_draft.cpp`, `dflash_kernels.cu`) — the target-model verify/accept-reject loop is untouched. Correctness is unaffected: SPEC_AGREE=100% speculative-decode exactness comes from the verify loop, which is independent of how the draft computes its proposals.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**DFlash decode tok/s** (`build/runtime/qwen3_gguf_dflash_bench <target.gguf> <draft_dir> 256`, interleaved A/B, 5 reps, median-stable):

| | DFLASH_TPS |
|---|--:|
| before (main) | 311.93 |
| after (this PR) | 347.96 |

+11.55% marginal DFLASH_TPS. `qwen3_gguf_dflash_check`: `SPEC_AGREE 64/64 = 1.0000`, `MEAN_ACCEPT` unchanged vs main on every tested seed. `bench/scripts/dflash_accuracy.sh`: `VERDICT PASS`.

```text
=== rep 1: main ===
METRIC DFLASH_TPS 311.9369
=== rep 1: this PR ===
METRIC DFLASH_TPS 347.8526
=== rep 2: main ===
METRIC DFLASH_TPS 311.8391
=== rep 2: this PR ===
METRIC DFLASH_TPS 348.0370
=== rep 3: main ===
METRIC DFLASH_TPS 311.9138
=== rep 3: this PR ===
METRIC DFLASH_TPS 347.8096
```
