### PR TITLE
perf(qwen36): native-Q6_K multi-row DFlash head MMVQ (+5.1% DFLASH_TPS)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1044,6 +1044,37 @@ __global__ void gemv_q6k_dp4a_kfixed_kernel(const si_block_q8_1* __restrict__ vy
     for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
     if (lane == 0) gemv_write(y + row, acc);
 }
+
+// Multi-row (M activations, one shared weight) Q6_K MMVQ. The DFlash draft head projects B block
+// tokens against the SAME lm_head; issuing B separate GEMVs re-read the whole vocab weight B times
+// (~416 MB per read at V=248k,K=2048 — far past L2, so it is real HBM traffic). Here each warp owns
+// one output row and walks its weight superblocks ONCE, accumulating all M dot products, so the
+// weight streams from HBM a single time and the M reuses hit L1. y is [M, N] row-major.
+template <typename OutT, int WPB, int NSUPER, int MMAX>
+__global__ void gemv_q6k_dp4a_multirow_kernel(const si_block_q8_1* __restrict__ vy,
+                                              const unsigned char* __restrict__ W,
+                                              OutT* __restrict__ y, int N, int M) {
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row = blockIdx.x * WPB + warp;
+    if (row >= N) return;
+    const unsigned char* x_row = W + (size_t)row * NSUPER * 210;
+    constexpr int QPR = NSUPER * 8;            // si_block_q8_1 blocks per activation row
+    float acc[MMAX];
+    #pragma unroll
+    for (int m = 0; m < MMAX; m++) acc[m] = 0.f;
+    #pragma unroll
+    for (int kbx = 0; kbx < NSUPER; kbx++) {
+        const unsigned char* wblk = x_row + (size_t)kbx * 210;   // read once, reused by all M
+        for (int m = 0; m < M; m++)
+            acc[m] += si_vec_dot_q6_K(wblk, vy + (size_t)m * QPR + (size_t)kbx * 8, lane);
+    }
+    for (int m = 0; m < M; m++) {
+        float a = acc[m];
+        #pragma unroll
+        for (int s = 16; s > 0; s >>= 1) a += __shfl_xor_sync(0xffffffff, a, s);
+        if (lane == 0) gemv_write(y + (size_t)m * N + row, a);
+    }
+}
 #ifndef _MSC_VER
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 8, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 #endif
@@ -1336,6 +1367,17 @@ void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K,
     else if (K == 4096) si_mmvq_q6k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q6k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
+// M activation rows against one shared Q6_K weight. q81 is M contiguous llama_q8_1_bytes(K)
+// activation rows; y is [M, N] fp32. Returns false when the shape is unsupported (caller loops).
+bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
+                                       int N, int K, int M, cudaStream_t stream) {
+    if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
+    dim3 grid((N + 15) / 16);
+    gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(
+        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+    return true;
+}
+
 void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
     static int wpb = -1;
     if (wpb < 0) {

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -100,5 +100,10 @@ void launch_attn_qkv_mmvq_q4k(const void* q81,
     int Nq, int Nk, int Nv, int K, cudaStream_t stream = nullptr);
 // 1-warp-per-row Q6_K dp4a GEMV (large-N, e.g. LM head): GEMV_WPB rows/block.
 void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
+// M activation rows vs one shared Q6_K weight (DFlash draft head: B block tokens, same lm_head).
+// The weight streams from HBM once instead of M times. q81 = M contiguous llama_q8_1_bytes(K) rows,
+// y = [M, N] fp32. Returns false if the shape is unsupported so the caller can fall back.
+bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
+                                       int N, int K, int M, cudaStream_t stream = nullptr);
 
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -259,6 +259,7 @@ struct DFlashDraftModel::Impl {
     bf16 *gate = nullptr, *up = nullptr, *down = nullptr;
     bf16 *k_new = nullptr, *v_new = nullptr;  // [ctx+B, n_kv, d]
     float* logits = nullptr;        // [B, vocab]
+    void* head_q8 = nullptr;        // [B] Q8_1 rows of xn for the multi-row head MMVQ
     int *d_ids = nullptr, *d_out = nullptr;
     int *h_out = nullptr;
 
@@ -421,6 +422,7 @@ bool DFlashDraftModel::load(const std::string& dir) {
     s.k_new = s.alloc<bf16>((size_t)max_kv * kvdim);
     s.v_new = s.alloc<bf16>((size_t)max_kv * kvdim);
     s.logits = s.alloc<float>((size_t)B * std::max(s.cfg.vocab, 1));
+    s.head_q8 = s.alloc<char>((size_t)B * kernels::llama_q8_1_bytes(H));
     s.d_ids = s.alloc<int>(B);
     s.d_out = s.alloc<int>(B);
     cu(cudaHostAlloc(&s.h_out, B * sizeof(int), cudaHostAllocDefault), "h_out");
@@ -581,6 +583,24 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // GEMV against the eagerly dequantized bf16 lm_head cache instead of a per-token
     // quantized GEMV loop.
     const int V = s.vocab > 0 ? s.vocab : c.vocab;
+    // The batched bf16 head (#661) still streams the DEQUANTIZED head every step: at V=248k,
+    // K=2048 that is ~1.0 GB per pass versus ~416 MB for the native Q6_K bytes, and it pins ~1 GB
+    // of VRAM for the bf16 cache. Prefer a multi-row Q6_K MMVQ that keeps the head quantized: each
+    // warp owns one output row, walks its superblocks once and accumulates all B dot products, so
+    // the weight streams from HBM a single time in its compact form.
+    // SPARKINFER_DFLASH_HEAD_MULTIROW=0 falls back to the bf16 batched path.
+    static int head_mr = -1;
+    if (head_mr < 0) { const char* e = getenv("SPARKINFER_DFLASH_HEAD_MULTIROW"); head_mr = (e && e[0] == '0') ? 0 : 1; }
+    bool head_done = false;
+    if (head_mr && s.lm_head_type == 14 && s.head_q8) {          // native Q6_K shared head
+        const size_t qrow = kernels::llama_q8_1_bytes(H);
+        for (int t = 0; t < B; t++)
+            kernels::launch_quantize_q8_1_blocks(s.xn + (size_t)t * H,
+                                                 (char*)s.head_q8 + (size_t)t * qrow, H, st);
+        head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(s.head_q8, s.lm_head, s.logits,
+                                                               V, H, B, st);
+    }
+    if (!head_done) {
     if (fast16) {
         dflash_kernels::launch_gemv_batched16_f32(s.xn, s.lm_head_bf16, s.logits, V, H, st);
     } else {
@@ -592,6 +612,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             else
                 kernels::launch_gemv_f32(row, s.lm_head, logit_row, V, H, st);
         }
+    }
     }
     kernels::launch_argmax(s.logits, s.d_out, B, V, st);
     cu(cudaMemcpyAsync(s.h_out, s.d_out, B * sizeof(int), cudaMemcpyDeviceToHost, st), "argmax");


### PR DESCRIPTION
## Summary

Follow-up to #661, which batched the DFlash draft head across the block against an **eagerly
dequantized bf16 `lm_head` cache**. That still streams the *dequantized* head every step: at
V≈248k, K=2048 it is **~1.0 GB per pass** versus **~416 MB** for the native Q6_K bytes, and it pins
~1 GB of VRAM for the cache.

This keeps the head **natively quantized**. `gemv_q6k_dp4a_multirow_kernel`: each warp owns one
output row, walks its weight superblocks **once** and accumulates all M dot products, so the head
streams from HBM a single time in its compact form and the M reuses hit L1. The draft head
quantizes its B rows to Q8_1 and issues one call.

Unsupported shapes return `false` and fall back to #661's bf16 batched path (then the per-token
loop), so nothing regresses. `SPARKINFER_DFLASH_HEAD_MULTIROW=0` selects exactly #661's path,
which makes the env toggle a same-binary A/B.

Draft-only change: the draft merely *proposes* and the target still verifies every token, so
SPEC_AGREE is preserved by construction (verified below).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**DFlash tok/s** (`qwen3_gguf_dflash_bench`, same box, interleaved via
`SPARKINFER_DFLASH_HEAD_MULTIROW`; median of 3 passes):

| | DFlash tok/s |
|---|--:|
| before (current `main`, #661 bf16 head) | 202.56 |
| after (this PR, native Q6_K head) | **212.87** |

**+5.1%**, consistent across all three passes; `mean_accept` unchanged at 3.3333.

This is a **DFlash-path-only** change — AR decode and prefill are untouched, so the decode/prefill
tables above are intentionally left empty.

**Accuracy gate** — `bench/scripts/dflash_accuracy.sh`:

```text
METRIC SPEC_AGREE 32/32 = 1.0000
METRIC MEAN_ACCEPT 3.778 steps=9
VERDICT PASS
```

```text
pass1 MULTIROW=0 -> DFLASH=202.8308  mean_accept=3.3333
pass1 MULTIROW=1 -> DFLASH=212.3749  mean_accept=3.3333
pass2 MULTIROW=0 -> DFLASH=202.4928  mean_accept=3.3333
pass2 MULTIROW=1 -> DFLASH=212.8705  mean_accept=3.3333
pass3 MULTIROW=0 -> DFLASH=202.5635  mean_accept=3.3333
pass3 MULTIROW=1 -> DFLASH=213.9576  mean_accept=3.3333
```
