### PR TITLE
perf(qwen36): hoist the Q6_K unpack out of the DFlash head multi-row loop (+3.9% DFLASH_TPS)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1064,9 +1064,38 @@ __global__ void gemv_q6k_dp4a_multirow_kernel(const si_block_q8_1* __restrict__ 
     for (int m = 0; m < MMAX; m++) acc[m] = 0.f;
     #pragma unroll
     for (int kbx = 0; kbx < NSUPER; kbx++) {
-        const unsigned char* wblk = x_row + (size_t)kbx * 210;   // read once, reused by all M
-        for (int m = 0; m < M; m++)
-            acc[m] += si_vec_dot_q6_K(wblk, vy + (size_t)m * QPR + (size_t)kbx * 8, lane);
+        const unsigned char* wblk = x_row + (size_t)kbx * 210;
+        // Hoist the weight-side work out of the M loop: the 6-bit unpack, the super-block scale
+        // and d depend only on the weight, so calling si_vec_dot_q6_K per activation row redid
+        // all of it M times. Unpack once here, then each row costs just two dp4a's.
+        const signed char* scales = reinterpret_cast<const signed char*>(wblk + 192);
+        const float wd = gq_h2f(wblk + 208);
+        const int bq8_offset   = 4 * (lane / 16) + (lane % 16) / 8;
+        const int scale_offset = 8 * (lane / 16) + (lane % 16) / 4;
+        const int vh_shift     = 2 * ((lane % 16) / 8);
+        const int vl = si_get_int_b2(wblk, lane);
+        const int vh = si_get_int_b2(wblk + 128, 8 * (lane / 16) + (lane % 8)) >> vh_shift;
+        const signed char* sc = scales + scale_offset;
+        int vi[2], scv[2];
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            const int vil = (vl >> (4 * i)) & 0x0F0F0F0F;
+            const int vih = ((vh >> (4 * i)) << 4) & 0x30303030;
+            vi[i]  = __vsubss4((vil | vih), 0x20202020);
+            scv[i] = (int)sc[4 * i];
+        }
+        const si_block_q8_1* a0 = vy + (size_t)kbx * 8;
+        for (int m = 0; m < M; m++) {
+            const si_block_q8_1* row = a0 + (size_t)m * QPR;
+            float sumf = 0.f;
+            #pragma unroll
+            for (int i = 0; i < 2; i++) {
+                const si_block_q8_1* b8 = row + bq8_offset + 2 * i;
+                const int u = reinterpret_cast<const int*>(b8->qs)[lane % 8];
+                sumf += __low2float(b8->ds) * (__dp4a(vi[i], u, 0) * scv[i]);
+            }
+            acc[m] += wd * sumf;
+        }
     }
     for (int m = 0; m < M; m++) {
         float a = acc[m];


### PR DESCRIPTION
## Summary

Follow-up to #662. The multi-row head MMVQ called `si_vec_dot_q6_K` once per activation row, so
the **weight-side** work — the `vl`/`vh` loads, the super-block scale and `d`, and the 6-bit → int8
unpack (`vil | vih` → `__vsubss4`) — was redone M=16 times per super-block even though it depends
only on the weight. Only `u`/`d8` vary per row.

Profiling on an RTX 5090 showed the kernel at **1.498 ms** per call against a **~232 µs** roofline
for its 416 MB read (6.5× off) — i.e. unpack-bound, not bandwidth-bound.

Unpack each super-block once, then each activation row costs just its two `__dp4a`
accumulations. Same operands and same per-row accumulation order, so results are unchanged.

Kernel time drops **1.498 ms → 0.960 ms** per call (−36%; 5.0% → 3.3% of profiled GPU time).

<sub>Also tried staging the activations in shared memory (they are re-read by every output-row
block) — measured slightly *worse* (36 KB of shared costs more occupancy than the L1 traffic it
saves), so it is deliberately not included.</sub>

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**DFlash tok/s** (`qwen3_gguf_dflash_bench`, same box, interleaved, median of 5 passes):

| | DFlash tok/s |
|---|--:|
| before (current `main`) | 200.00 |
| after (this PR) | **207.75** |

**+3.9%**; `mean_accept` unchanged at 3.3333.

DFlash-path-only change — AR decode and prefill are untouched, so the decode/prefill tables above
are intentionally left empty.

**Accuracy gate** — `bench/scripts/dflash_accuracy.sh`:

```text
METRIC SPEC_AGREE 32/32 = 1.0000
VERDICT PASS
```

```text
pass1 MAIN=196.9257 NEW=207.4859
pass2 MAIN=200.0384 NEW=208.6138
pass3 MAIN=199.9963 NEW=207.5422
pass4 MAIN=200.3892 NEW=207.7464
pass5 MAIN=199.9725 NEW=207.8551
```
