### PR TITLE
fix(eval): disable same-box baseline cache by default — always remeasure

### DIFF
--- a/.env.eval.example
+++ b/.env.eval.example
@@ -25,6 +25,7 @@ EVAL_TRANSPORT=vast
 # PRIMARY_QUANT=Q4_K_M   # Qwen3.5 quant: Q4_K_M | Q8_0 | BF16
 # SPARKINFER_AUTOMERGE=1       # auto-merge merge-first winner after each poll (0 to disable)
 # SPARKINFER_AUTOMERGE_ADMIN=1 # retry with gh --admin when branch policy blocks squash
+# SPARKINFER_BASELINE_CACHE=0  # 0=always remeasure same-box main baseline (default); 1=reuse ≤12h cache
 # VAST_NO_AUTO_PROVISION=1     # never rent a new GPU (pinned instance only; cron respects this)
 # POLARIS=1         # Polaris TDX verifiable receipts (default; set 0 to disable)
 # POLARIS_API_KEY=  # TDX attest (https://polaris.computer); preferred when available

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -173,6 +173,9 @@ def _bidir_baseline_sane(q36, q35):
     return q36.get("128", 0) >= 200 and q35.get("128", 0) >= 80
 
 BASELINE_CACHE_FILE = os.path.join(HERE, ".baseline_cache.json")
+# Same-box main baseline cache is OFF by default — each eval run remeasures origin/main.
+# Set SPARKINFER_BASELINE_CACHE=1 to reuse a ≤12h cache (faster cron ticks, less precise).
+USE_BASELINE_CACHE = os.environ.get("SPARKINFER_BASELINE_CACHE", "0") == "1"
 
 
 def _baseline_box_id(instance=0):
@@ -2344,9 +2347,13 @@ def main():
                     help="comma-separated PR numbers — one baseline, then eval each (e.g. 387,389)")
     ap.add_argument("--skip-baseline", action="store_true",
                     help="require cached same-box baseline (≤12h, same box, same origin/main); abort if missing")
+    ap.add_argument("--baseline-cache", action="store_true",
+                    help="reuse ≤12h same-box baseline cache (default: always remeasure; "
+                         "or set SPARKINFER_BASELINE_CACHE=1)")
     ap.add_argument("--reeval", action="store_true",
                     help="re-run eval even if this commit was already graded (use with --only-pr)")
     args = ap.parse_args()
+    use_baseline_cache = USE_BASELINE_CACHE or args.baseline_cache
     if args.triple or args.dual:
         args.bidir = True
     if os.environ.get("BIDIR", "1") != "0" and not any(
@@ -2645,8 +2652,8 @@ def main():
     box_id = _baseline_box_id(base_iid)
     main_commit = _origin_main_short()
     bres = {}
-    cache = _load_baseline_cache(box_id)
-    cache_ok = cache and _baseline_cache_valid(cache, args.bidir, QWEN36_BASE, QWYTHOS_BASE, main_commit)
+    cache = _load_baseline_cache(box_id) if use_baseline_cache else None
+    cache_ok = bool(cache and _baseline_cache_valid(cache, args.bidir, QWEN36_BASE, QWYTHOS_BASE, main_commit))
     if cache_ok:
         if args.bidir:
             QWEN36_BASE.update(cache["q36"])
@@ -2660,6 +2667,8 @@ def main():
         print(f">> --skip-baseline: no valid cache for {box_id} — aborting")
         return
     else:
+        if not use_baseline_cache:
+            print(">> baseline cache disabled — measuring fresh same-box origin/main")
         if cache and main_commit:
             cached_commit = (cache.get("bres") or {}).get("commit")
             if (cached_commit and cached_commit != main_commit
@@ -2703,7 +2712,8 @@ def main():
         if not args.bidir and (not bres.get("pass") or not bres.get("tps")):
             log = (br.stdout + br.stderr)[-1200:]
             print(f">> same-box baseline (origin/main) failed — aborting; no PRs graded.\n{log}"); return
-        _save_baseline_cache(box_id, dict(QWEN36_BASE), dict(QWYTHOS_BASE), bres)
+        if use_baseline_cache:
+            _save_baseline_cache(box_id, dict(QWEN36_BASE), dict(QWYTHOS_BASE), bres)
     if args.bidir:
         run_baseline = float(QWEN36_BASE["128"])
         run_guard_128 = float(QWEN36_BASE["128"])

--- a/eval/run_bot.sh
+++ b/eval/run_bot.sh
@@ -35,6 +35,7 @@ export PATH="/usr/local/bin:/usr/bin:/bin:${HOME}/.local/bin:$PATH"
 export PYTHONUNBUFFERED=1
 # Auto-merge the round's merge-first winner (guarded). Override with SPARKINFER_AUTOMERGE=0.
 export SPARKINFER_AUTOMERGE="${SPARKINFER_AUTOMERGE:-1}"
+export SPARKINFER_BASELINE_CACHE="${SPARKINFER_BASELINE_CACHE:-0}"
 
 BOT_ARGS=(
   --frontier "${FRONTIER:-285}"

--- a/eval/run_bot_cron.sh
+++ b/eval/run_bot_cron.sh
@@ -18,6 +18,7 @@ export PYTHONUNBUFFERED=1
 export SPARKINFER_AUTOMERGE="${SPARKINFER_AUTOMERGE:-1}"
 export SPARKINFER_AUTOMERGE_ADMIN="${SPARKINFER_AUTOMERGE_ADMIN:-1}"
 export VAST_NO_AUTO_PROVISION=1
+export SPARKINFER_BASELINE_CACHE="${SPARKINFER_BASELINE_CACHE:-0}"
 
 exec 9>/tmp/sparkinfer_bot.lock
 flock -n 9 || { echo "[$(date -u +%FT%TZ)] previous bot run still active — skipping this tick"; exit 0; }
@@ -36,6 +37,7 @@ fi
 export SPARKINFER_AUTOMERGE="${SPARKINFER_AUTOMERGE:-1}"
 export SPARKINFER_AUTOMERGE_ADMIN="${SPARKINFER_AUTOMERGE_ADMIN:-1}"
 export VAST_NO_AUTO_PROVISION=1
+export SPARKINFER_BASELINE_CACHE="${SPARKINFER_BASELINE_CACHE:-0}"
 unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY all_proxy
 
 git pull -q origin main 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Default `SPARKINFER_BASELINE_CACHE=0` so each eval run remeasures same-box `origin/main` instead of reusing a ≤12h cache
- Opt in via env `SPARKINFER_BASELINE_CACHE=1` or `--baseline-cache`
- Document the flag in `.env.eval.example` and export the default in bot/cron wrappers

## Test plan
- [ ] Confirm bot/cron start without baseline cache reuse unless explicitly enabled
- [ ] With cache off, fresh same-box baseline is measured each run
- [ ] With `SPARKINFER_BASELINE_CACHE=1` or `--baseline-cache`, ≤12h cache still works