### PR TITLE
fix(quality): add llama-server backend and Qwen3.6 orchestrator

### DIFF
--- a/bench/quality/README.md
+++ b/bench/quality/README.md
@@ -39,6 +39,7 @@ seed_hand_authored/    the original hand-written seed (offline fallback / refere
 python3 scorers.py                     # 10/10 scorer self-tests
 python3 run_quality.py --backend oracle  # gold/scorer sanity for answer-derivable tasks
 python3 run_quality.py --backend mock    # ~0%  - floor
+python3 run_quality.py --self-test-llama-server  # llama-server wiring, against a stub
 
 # 2. score sparkinfer on a GPU box:
 python3 run_quality.py --backend sparkinfer \

--- a/bench/quality/run_quality.py
+++ b/bench/quality/run_quality.py
@@ -27,7 +27,7 @@ Usage:
   python3 run_quality.py --backend sparkinfer --tier development ...  # ~10%, 78 items
   python3 run_quality.py --backend sparkinfer --tier benchmark ...    # ~25%, 196 items
 """
-import argparse, json, os, subprocess, sys, glob
+import argparse, json, os, subprocess, sys, glob, urllib.error, urllib.request
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import scorers
 
@@ -112,6 +112,41 @@ class LlamaBackend:
         return r.stdout
 
 
+class LlamaServerBackend:
+    """llama.cpp `llama-server` over HTTP - keeps the model resident across items.
+
+    `--backend llama` reloads the GGUF per item via llama-cli, which is impractical
+    for the benchmark tier; this talks to an already-running server instead. Prefers
+    the native `/completion` route and falls back to the OpenAI-compatible
+    `/v1/completions` when a build doesn't expose it. Greedy (temperature 0) so the
+    reference matches the other backends.
+    """
+    def __init__(self, url, timeout=600):
+        self.base = url.rstrip("/")
+        self.timeout = timeout
+        self.openai_route = False   # latched after one fallback, so we don't re-probe per item
+
+    def _post(self, path, payload):
+        req = urllib.request.Request(self.base + path, data=json.dumps(payload).encode(),
+                                     headers={"Content-Type": "application/json"})
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            return json.loads(resp.read().decode())
+
+    def gen_for(self, item):
+        n = MAXNEW.get(item["benchmark"], 200)
+        prompt = CHAT.format(p=build_prompt(item))
+        if not self.openai_route:
+            try:
+                return self._post("/completion", {"prompt": prompt, "n_predict": n,
+                                                  "temperature": 0.0})["content"]
+            except urllib.error.HTTPError as e:
+                if e.code not in (404, 405, 501):
+                    raise
+                self.openai_route = True
+        d = self._post("/v1/completions", {"prompt": prompt, "max_tokens": n, "temperature": 0.0})
+        return d["choices"][0]["text"]
+
+
 def make_backend(args, items):
     if args.backend == "oracle": return OracleBackend(items)
     if args.backend == "mock":   return MockBackend()
@@ -119,6 +154,10 @@ def make_backend(args, items):
         return SparkinferBackend(args.model, args.bin, args.tokenizer)
     if args.backend == "llama":
         return LlamaBackend(args.model, args.llama_cli)
+    if args.backend == "llama-server":
+        if not args.llama_url:
+            raise SystemExit("--backend llama-server requires --llama-url")
+        return LlamaServerBackend(args.llama_url)
     raise SystemExit("unknown backend " + args.backend)
 
 
@@ -136,17 +175,91 @@ def load(benchmarks, limit, tier=""):
     return items
 
 
+def self_test_llama_server():
+    """Drive LlamaServerBackend against a stub server - no GPU, no model, no llama.cpp.
+
+    Checks the request shape both endpoints receive, that the native route is used when
+    present, that a 404 latches the OpenAI fallback, and that what comes back still
+    scores through scorers.SCORERS. Returns a process exit code.
+    """
+    import http.server, threading
+
+    seen = []
+
+    def make_server(native_ok):
+        class H(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *a): pass          # keep the harness output clean
+            def do_POST(self):
+                body = json.loads(self.rfile.read(int(self.headers["Content-Length"])))
+                seen.append((self.path, body))
+                if self.path == "/completion":
+                    if not native_ok:
+                        self.send_response(404); self.end_headers(); return
+                    payload = {"content": "... #### 42"}
+                elif self.path == "/v1/completions":
+                    payload = {"choices": [{"text": "... #### 42"}]}
+                else:
+                    self.send_response(404); self.end_headers(); return
+                raw = json.dumps(payload).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        return srv
+
+    item = {"benchmark": "gsm8k", "id": "selftest", "prompt": "2+2?", "target": "42"}
+    failures = []
+
+    def check(label, cond):
+        print(f"  {'ok  ' if cond else 'FAIL'}  {label}")
+        if not cond: failures.append(label)
+
+    print("self-test: llama-server backend")
+    for native_ok, want_path, want_key in ((True, "/completion", "n_predict"),
+                                           (False, "/v1/completions", "max_tokens")):
+        seen.clear()
+        srv = make_server(native_ok)
+        try:
+            be = LlamaServerBackend(f"http://127.0.0.1:{srv.server_address[1]}")
+            out = be.gen_for(item)
+        finally:
+            srv.shutdown()
+        tag = "native" if native_ok else "fallback"
+        check(f"{tag}: request reached {want_path}", seen[-1][0] == want_path)
+        check(f"{tag}: sent {want_key}", want_key in seen[-1][1])
+        check(f"{tag}: greedy (temperature 0)", seen[-1][1].get("temperature") == 0.0)
+        check(f"{tag}: prompt uses the chat template", "<|im_start|>" in seen[-1][1]["prompt"])
+        check(f"{tag}: generation returned", out.strip().endswith("42"))
+        check(f"{tag}: scorer accepts the output", scorers.SCORERS["gsm8k"](item, out)["pass"])
+        if not native_ok:
+            check("fallback: probed /completion first", seen[0][0] == "/completion")
+
+    print("\nself-test: %s" % ("PASS" if not failures else "FAIL (%d)" % len(failures)))
+    return 1 if failures else 0
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--backend", required=True, choices=["oracle", "mock", "sparkinfer", "llama"])
+    ap.add_argument("--backend", choices=["oracle", "mock", "sparkinfer", "llama", "llama-server"])
     ap.add_argument("--model"); ap.add_argument("--bin"); ap.add_argument("--tokenizer")
     ap.add_argument("--llama-cli")
+    ap.add_argument("--llama-url", help="base URL of a running llama-server, e.g. http://localhost:8082")
+    ap.add_argument("--self-test-llama-server", action="store_true",
+                    help="verify the llama-server wiring against a stub (no GPU/model)")
     ap.add_argument("--benchmarks", default="", help="comma list; default all")
     ap.add_argument("--limit", type=int, default=0, help="items per benchmark (0=all)")
     ap.add_argument("--tier", choices=sorted(TIERS),
-                    help="named per-suite sample: development ~=10%, benchmark ~=25%")
+                    help="named per-suite sample: development ~=10%%, benchmark ~=25%%")
     ap.add_argument("--out", default="", help="write per-item JSONL results here")
     args = ap.parse_args()
+
+    if args.self_test_llama_server:
+        sys.exit(self_test_llama_server())
+    if not args.backend:
+        ap.error("--backend is required (or use --self-test-llama-server)")
 
     benchmarks = set(b for b in args.benchmarks.split(",") if b)
     items = load(benchmarks, args.limit, args.tier or "")

--- a/bench/quality/run_qwen36_benchmark.sh
+++ b/bench/quality/run_qwen36_benchmark.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Qwen3.6-35B-A3B quality-parity orchestrator: score sparkinfer, then llama.cpp, on the
+# same GGUF and the same box — one engine on the GPU at a time, so neither run is
+# perturbed by the other's memory or SM contention.
+#
+#   bench/quality/run_qwen36_benchmark.sh /path/to/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf
+#
+# Writes <OUT_DIR>/{sparkinfer,llama}.jsonl and prints both reports; diff the
+# per-benchmark percentages to confirm an optimization is quality-neutral.
+#
+# Env knobs (all optional):
+#   TIER=benchmark            development | benchmark
+#   OUT_DIR=./qwen36_quality  results directory
+#   PORT=8082                 llama-server port
+#   SPARK_BIN=...             sparkinfer generate binary
+#   TOKENIZER=...             tokenizer.json for the sparkinfer backend
+#   LLAMA_SERVER=...          llama-server binary
+#   NGL=99                    layers offloaded to GPU for llama-server
+#   BENCHMARKS=               comma list, e.g. gsm8k,ifeval (default: all)
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MODEL="${1:-${MODEL:-}}"
+if [ -z "$MODEL" ]; then
+  echo "usage: $0 <model.gguf>   (or MODEL=... $0)" >&2
+  exit 1
+fi
+if [ ! -f "$MODEL" ]; then echo "no such model: $MODEL" >&2; exit 1; fi
+
+TIER="${TIER:-benchmark}"
+OUT_DIR="${OUT_DIR:-./qwen36_quality}"
+PORT="${PORT:-8082}"
+SPARK_BIN="${SPARK_BIN:-$HERE/../../build/runtime/qwen3_gguf_generate}"
+TOKENIZER="${TOKENIZER:-$(dirname "$MODEL")/tokenizer.json}"
+LLAMA_SERVER="${LLAMA_SERVER:-$HERE/../../.llamacpp/build/bin/llama-server}"
+NGL="${NGL:-99}"
+BENCH_ARG=()
+[ -n "${BENCHMARKS:-}" ] && BENCH_ARG=(--benchmarks "$BENCHMARKS")
+
+mkdir -p "$OUT_DIR"
+echo "model     : $MODEL"
+echo "tier      : $TIER"
+echo "out       : $OUT_DIR"
+
+# ---- 1. sparkinfer (exclusive GPU) ----
+echo
+echo "=== [1/2] sparkinfer ==="
+for f in "$SPARK_BIN" "$TOKENIZER"; do
+  [ -e "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+python3 "$HERE/run_quality.py" --backend sparkinfer --tier "$TIER" "${BENCH_ARG[@]}" \
+  --model "$MODEL" --bin "$SPARK_BIN" --tokenizer "$TOKENIZER" \
+  --out "$OUT_DIR/sparkinfer.jsonl"
+
+# ---- 2. llama.cpp via llama-server (exclusive GPU, started only now) ----
+echo
+echo "=== [2/2] llama.cpp (llama-server) ==="
+[ -x "$LLAMA_SERVER" ] || { echo "missing llama-server: $LLAMA_SERVER" >&2; exit 1; }
+
+SERVER_PID=""
+cleanup() {
+  if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+"$LLAMA_SERVER" -m "$MODEL" --port "$PORT" -ngl "$NGL" --host 127.0.0.1 \
+  > "$OUT_DIR/llama-server.log" 2>&1 &
+SERVER_PID=$!
+
+printf 'waiting for llama-server on :%s' "$PORT"
+for _ in $(seq 1 120); do
+  if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 \
+     || curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
+    echo " up"; break
+  fi
+  kill -0 "$SERVER_PID" 2>/dev/null || { echo; echo "llama-server died — see $OUT_DIR/llama-server.log" >&2; exit 1; }
+  printf '.'; sleep 1
+done
+
+python3 "$HERE/run_quality.py" --backend llama-server --tier "$TIER" "${BENCH_ARG[@]}" \
+  --llama-url "http://127.0.0.1:$PORT" --model "$MODEL" \
+  --out "$OUT_DIR/llama.jsonl"
+
+cleanup; SERVER_PID=""
+
+echo
+echo "=== done ==="
+echo "sparkinfer : $OUT_DIR/sparkinfer.jsonl"
+echo "llama.cpp  : $OUT_DIR/llama.jsonl"
+echo "Compare the per-benchmark percentages above; equal scores mean quality parity."


### PR DESCRIPTION
## Summary

`bench/quality/README.md` documents the quality-parity A/B path as

```bash
python3 run_quality.py --backend llama-server --llama-url http://localhost:8082 ...
```

with orchestrator `bench/quality/run_qwen36_benchmark.sh`. Neither existed: argparse only accepted `oracle|mock|sparkinfer|llama`, and the script was absent. The remaining `--backend llama` path reloads the GGUF per item through `llama-cli`, which is impractical at benchmark tier — so there was no workable way to score the llama.cpp reference and prove quality parity.

This implements the three items from the issue's **Expected** section.

## Changes made

**1. `--backend llama-server` + `--llama-url`** — `LlamaServerBackend` talks to an already-running `llama-server` over HTTP, keeping the model resident across items. It prefers the native `/completion` route and latches onto the OpenAI-compatible `/v1/completions` on 404/405/501, so it works across llama.cpp builds without re-probing every item. Greedy (`temperature: 0`), matching the other backends. Stdlib `urllib` only — no new dependency.

**2. `run_qwen36_benchmark.sh`** — scores sparkinfer first, then starts `llama-server`, scores it, and stops it on exit. One engine on the GPU at a time, so neither run is perturbed by the other's memory or SM contention. Writes `sparkinfer.jsonl` and `llama.jsonl` for diffing. Env knobs: `TIER`, `OUT_DIR`, `PORT`, `SPARK_BIN`, `TOKENIZER`, `LLAMA_SERVER`, `NGL`, `BENCHMARKS`. Guards for a missing model/binary and a `trap`-based server cleanup.

**3. `--self-test-llama-server`** — drives the backend against a stub HTTP server on a loopback port. Verifies which route each request lands on, that `n_predict`/`max_tokens` are sent per route, `temperature: 0`, that the chat template is applied, that the native route is probed before the fallback, and that the returned text scores through `scorers.SCORERS`. 13 assertions, no GPU, no model, no llama.cpp.

`README.md` gains one line listing the self-test alongside the other no-GPU checks. The rest of the README already described this workflow correctly — the code simply didn't match it.

## One incidental fix, flagged explicitly

The `--tier` help string contained two unescaped `%` characters. `argparse` in Python 3.14 validates help strings eagerly, so **every** `run_quality.py` invocation aborted with `ValueError: badly formed help string` — including `--backend mock`. This reproduces on unmodified `main`:

```
$ git stash && python bench/quality/run_quality.py --backend mock --limit 1 --benchmarks gsm8k
ValueError: badly formed help string
```

It is pre-existing and unrelated to this issue, but nothing here (or in the existing backends) is runnable on 3.14 without it, so the two `%` are escaped to `%%`. Happy to split it into its own PR if preferred — it is a one-line change on line 147.

## Tests

`--self-test-llama-server` is the regression test, chosen over a separate file because it exercises the real backend class against a real socket rather than a mocked transport, and it belongs with the tool it tests.

```
self-test: llama-server backend
  ok    native: request reached /completion
  ok    native: sent n_predict
  ok    native: greedy (temperature 0)
  ok    native: prompt uses the chat template
  ok    native: generation returned
  ok    native: scorer accepts the output
  ok    fallback: request reached /v1/completions
  ok    fallback: sent max_tokens
  ok    fallback: greedy (temperature 0)
  ok    fallback: prompt uses the chat template
  ok    fallback: generation returned
  ok    fallback: scorer accepts the output
  ok    fallback: probed /completion first

self-test: PASS
```

## Validation

Run on Windows with Python 3.14.

| Command | Result |
|---|---|
| `python3 run_quality.py --self-test-llama-server` | 13/13 ok, exit 0 |
| `bash -n bench/quality/run_qwen36_benchmark.sh` | OK |
| orchestrator usage / missing-model guards | both exit cleanly with a message |
| `python3 bench/quality/scorers.py` | 10/10 scorer self-tests passed |
| `run_quality.py --backend mock --limit 1 --benchmarks gsm8k` | 0.0% (floor) — unchanged |
| `run_quality.py --backend oracle --limit 1 --benchmarks gsm8k` | 100.0% — unchanged |
| `bash -n` on `evaluate.sh`, `warm_llamacpp.sh`, `run_bot_cron.sh`, `setup_labels.sh` | OK |
| `py_compile` on the five `eval-policy` files | OK |
| `test_label.py`, `test_guard_reject.py`, `test_bidir_headline.py`, `test_accuracy_cache.py`, `test_copycat_guard.py` | all OK |

Not run: an end-to-end scoring pass against a real `llama-server` and a real GGUF — that needs a GPU and multi-GB weights, which this machine does not have. The self-test covers the HTTP contract and scorer compatibility; the live path is unverified and is not claimed to have been. The orchestrator was syntax-checked and its guard paths exercised, but never executed against real binaries.

## Risks and limitations

- The `/completion` response shape is assumed to be `{"content": ...}` and `/v1/completions` `{"choices": [{"text": ...}]}`. Both are stable llama.cpp contracts, but only the stub has been exercised here, not a real server.
- The fallback latch triggers on 404/405/501. A build that fails differently (e.g. 400 on an unknown field) would surface as an error rather than falling back.
- The orchestrator polls `/health`, then `/v1/models`, for up to 120s. A slow load on a large GGUF could exceed that; raise it if needed.
- `--self-test-llama-server` binds a loopback port, so it needs local socket permission.
- Related: PR #655 targets #650, the near-duplicate issue, and covers the same three items. I implemented from the issue text and the existing code and have not read that diff. If #655 lands first, close this one — no objection.

Fixes #643
