### PR TITLE
fix(eval): fail closed when the no-regression guard measured no context

### DIFF
--- a/eval/polaris/scoring.py
+++ b/eval/polaris/scoring.py
@@ -87,8 +87,15 @@ def score(result: dict) -> dict:
 
     # ---- No-regression guard ----
     # Every measured context must hold >= tolerance vs main branch baseline.
+    #
+    # `all([])` is vacuously true, so an empty measurement set must not read as
+    # a pass: a guard carrying accuracy fields but no per-context speed flags is
+    # a partial infra failure, and this script fails closed on those (see the
+    # empty-primary branch above and the `bool(guard)` term below). Requiring at
+    # least one measured context keeps "no regression" a claim about evidence
+    # rather than about its absence.
     present = [k for k in GUARD_CTX_KEYS if k in guard]
-    speed_ok = all(guard.get(k, True) for k in present)
+    speed_ok = bool(present) and all(guard[k] for k in present)
     g_top1 = float(guard.get("top1", 0))
     g_kl = float(guard.get("kl", 99))
     g_acc_ok = g_top1 >= TOP1_BAR and g_kl <= KL_BAR
@@ -125,6 +132,10 @@ def score(result: dict) -> dict:
             )
         if not bool(guard):
             reasons.append("Qwen3-30B guard produced no verdict (infra error)")
+        elif not present:
+            reasons.append(
+                "Qwen3-30B guard measured no decode context (infra error)"
+            )
         if not reasons:
             reasons.append("Qwen3-30B no-regression guard failed")
         final["label"] = "REJECT"

--- a/eval/polaris/test_scoring.py
+++ b/eval/polaris/test_scoring.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Unit tests for the enclave scoring script.
+
+`scoring.py` is what the TDX enclave runs to turn a merged RESULT_JSON into the
+signed verdict, so its gates decide every PR's reward. These pin the gate matrix
+— correctness bar, no-regression guard, and the fail-closed posture on partial
+or missing evidence.
+
+Run:  python3 -m pytest eval/polaris/test_scoring.py -v
+  or:  python3 eval/polaris/test_scoring.py
+"""
+
+import os
+import sys
+import unittest
+
+# Ensure we can import from eval/polaris/
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from eval.polaris.scoring import KL_BAR, TOP1_BAR, score
+
+
+def _primary(**over):
+    base = {"top1": 0.99, "kl": 0.01, "label": "M", "pass": True, "delta_pct": 3.2}
+    base.update(over)
+    return base
+
+
+def _guard(**over):
+    base = {
+        "top1": 0.99,
+        "kl": 0.01,
+        "guard_128_pass": True,
+        "guard_512_pass": True,
+        "guard_4k_pass": True,
+        "guard_16k_pass": True,
+        "guard_32k_pass": True,
+    }
+    base.update(over)
+    return base
+
+
+class TestCorrectnessGate(unittest.TestCase):
+    def test_accepts_a_clean_run(self):
+        out = score({"primary": _primary(), "guard": _guard()})
+        self.assertEqual(out["label"], "M")
+        self.assertTrue(out["pass"])
+        self.assertTrue(out["guard"]["speed_ok"])
+        self.assertTrue(out["guard"]["accuracy_ok"])
+
+    def test_empty_primary_fails_closed(self):
+        out = score({"primary": {}, "guard": _guard()})
+        self.assertEqual(out["label"], "REJECT")
+        self.assertIn("infra error", out["reason"])
+
+    def test_top1_below_bar_is_rejected(self):
+        out = score({"primary": _primary(top1=TOP1_BAR - 0.01), "guard": _guard()})
+        self.assertEqual(out["label"], "REJECT")
+        self.assertIn("top1=", out["reason"])
+
+    def test_kl_above_bar_is_rejected(self):
+        out = score({"primary": _primary(kl=KL_BAR + 0.01), "guard": _guard()})
+        self.assertEqual(out["label"], "REJECT")
+        self.assertIn("kl=", out["reason"])
+
+
+class TestNoRegressionGuard(unittest.TestCase):
+    def test_regressed_context_is_rejected_and_named(self):
+        out = score({"primary": _primary(), "guard": _guard(guard_4k_pass=False)})
+        self.assertEqual(out["label"], "REJECT")
+        self.assertIn("4k", out["reason"])
+        self.assertIn("regression-qwen3-4k", out["guard_regression_labels"])
+
+    def test_missing_guard_fails_closed(self):
+        out = score({"primary": _primary(), "guard": {}})
+        self.assertEqual(out["label"], "REJECT")
+
+    def test_guard_accuracy_break_is_rejected(self):
+        out = score({"primary": _primary(), "guard": _guard(top1=0.10)})
+        self.assertEqual(out["label"], "REJECT")
+        self.assertIn("accuracy broke", out["reason"])
+
+    def test_zero_measured_contexts_fails_closed(self):
+        """A guard with accuracy but no per-context speed flags proves nothing.
+
+        `all([])` is vacuously true, so this used to report speed_ok=True and
+        pass the no-regression guard on zero speed evidence — inside the enclave
+        that signs the receipt.
+        """
+        guard = {"top1": 0.99, "kl": 0.01}  # accuracy pass ran, speed pass did not
+
+        out = score({"primary": _primary(), "guard": guard})
+
+        self.assertFalse(out["guard"]["speed_ok"])
+        self.assertEqual(out["label"], "REJECT")
+        self.assertFalse(out["pass"])
+        self.assertIn("measured no decode context", out["reason"])
+
+    def test_a_single_measured_context_is_enough(self):
+        """The fix must not require all five contexts — only that one was measured."""
+        guard = {"top1": 0.99, "kl": 0.01, "guard_4k_pass": True}
+
+        out = score({"primary": _primary(), "guard": guard})
+
+        self.assertTrue(out["guard"]["speed_ok"])
+        self.assertEqual(out["label"], "M")
+
+
+class TestVerdictShape(unittest.TestCase):
+    def test_primary_metrics_are_carried_verbatim(self):
+        out = score({"primary": _primary(delta_pct=7.5), "guard": _guard()})
+        self.assertEqual(out["delta_pct"], 7.5)
+
+    def test_flat_result_without_primary_key_is_accepted(self):
+        # `primary = result.get("primary", result)` — a bare verdict still scores.
+        out = score(dict(_primary(), guard=_guard()))
+        self.assertEqual(out["label"], "M")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The enclave scoring script's no-regression guard reduces its per-context flags with `all()`, and `all([])` is vacuously true — so a guard that measured **no** decode context reported `speed_ok: true` and passed. This is not a kernel change and claims no speedup; it is a correctness fix in the code that issues the verdict.


> **No GPU eval needed.** Per the auto-close bot's own guidance, the proof-of-speedup
> section is removed rather than left with an unticked box: this PR touches only `eval/`
> Python (the harness that grades PRs), changes no kernel and no runtime path, and cannot
> move decode or prefill. I have no Blackwell GPU, so I did not run `bench.sh`,
> `accuracy.sh` or `ctest`, and I claim no speedup. I am not ticking the RTX 5090 box,
> because that attestation would be false.

## The bug

`score()` fails closed in two places — an empty `primary` ("infra error") and an entirely empty `guard` via `bool(guard)`. A guard that is *present but measured nothing* fell between them:

```python
present = [k for k in GUARD_CTX_KEYS if k in guard]
speed_ok = all(guard.get(k, True) for k in present)   # all([]) is True
```

Running the current `scoring.py` over the gate matrix:

| input | verdict |
|---|---|
| empty `primary` | REJECT — fail-closed |
| empty `guard` | REJECT — fail-closed |
| `guard_4k_pass: false` | REJECT — names the context |
| **`{"top1": 0.99, "kl": 0.01}`** — accuracy ran, speed did not | **label `M`, `pass: true`, `speed_ok: true`** |

That last shape is what a partial infra failure produces: the accuracy pass completed, the speed pass did not, so the `guard_*_pass` keys are simply absent. The comment above the block says *"Every measured context must hold >= tolerance vs main branch baseline"* — with nothing measured, "every" is satisfied by an empty set.

It matters more here than in an ordinary script because this is the code the enclave runs: per `EVAL-TRUST.md`, *"The DCAP quote proves this exact script, with these exact inputs, produced this exact output."* A hardware-signed receipt would attest a "no regression" verdict backed by zero speed evidence.

## The change

```python
speed_ok = bool(present) and all(guard[k] for k in present)
```

One measured context is still enough — a run that measured only `guard_4k_pass` passes on that context. The only behaviour that changes is that the empty set stops counting as a pass, and the rejection reason distinguishes "guard produced no verdict" from "guard measured no decode context".

(The `guard.get(k, True)` default was already unreachable, since `present` only contains keys that are in `guard`.)

## Tests

`eval/polaris/scoring.py` was the one module under `eval/polaris/` with no test file, and it is the one that decides rewards — so this adds `eval/polaris/test_scoring.py` alongside `test_receipt.py`, in the same `unittest` + `sys.path` style.

Eleven tests covering the correctness bar (top-1, KL), the guard matrix (regressed context, accuracy break, missing guard), the fail-closed paths, and the verdict shape (primary metrics carried verbatim, bare-verdict input).

**Ten of the eleven pass against the previous `scoring.py`** — the file characterizes existing behaviour rather than rewriting it. The eleventh is the bug:

```
FAILED eval/polaris/test_scoring.py::TestNoRegressionGuard::test_zero_measured_contexts_fails_closed
    self.assertFalse(out["guard"]["speed_ok"])
E   AssertionError: True is not false
```

`test_a_single_measured_context_is_enough` guards the other direction, so a future change cannot quietly start demanding all five contexts.

## Verification

```
python3 -m pytest eval/ -q     111 passed          (100 before, +11 new)
```

Stdlib-only, as `scoring.py` requires — the tests add no runtime dependency.
