### PR TITLE
fix(eval): fail closed when a failing bidir side carries no label

### DIFF
--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -638,6 +638,11 @@ def _public_eval_label(res):
             for s in sides:
                 if s.get("pass") is False and s.get("label"):
                     return s["label"]
+            # A side failed but carried no label of its own (partial record).
+            # Falling through here would headline the top-level label, which on
+            # a bidir run is the passing side — the exact papering-over this
+            # function exists to prevent. Fail closed instead.
+            return "REJECT"
     return res.get("label")
 
 

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -896,6 +896,38 @@ class PrEvalBotPolicyTest(unittest.TestCase):
         self.assertIn("eval-qwen35:REJECT", body)
         self.assertIn("eval-qwen36:XL", body)
 
+    def test_bidir_failing_side_without_label_does_not_headline_as_passing(self):
+        """A failed side with no label of its own must not fall through to the
+        top-level label — on a bidir run that is the passing side, which is the
+        papering-over #555 established this function must prevent.
+
+        Reward-visible: `eval:XL` is x4.0 in the registry, `eval:REJECT` is x0.0.
+        """
+        res = {
+            "mode": "bidir", "label": "XL", "pass": True,
+            "score_qwen35": {"label": None, "pass": False, "tps": 0},
+            "score_qwen36": {"label": "XL", "pass": True, "tps": 3388.88},
+        }
+        self.assertEqual(bot._public_eval_label(res), "REJECT")
+
+    def test_bidir_failing_side_with_label_still_headlines_that_label(self):
+        """The fail-closed fallback must not swallow a real non-REJECT verdict."""
+        res = {
+            "mode": "bidir", "label": "XL", "pass": True,
+            "score_qwen35": {"label": "none", "pass": False},
+            "score_qwen36": {"label": "XL", "pass": True},
+        }
+        self.assertEqual(bot._public_eval_label(res), "none")
+
+    def test_bidir_all_sides_passing_keeps_the_top_level_label(self):
+        """No side failed, so the headline is unchanged."""
+        res = {
+            "mode": "bidir", "label": "XL", "pass": True,
+            "score_qwen35": {"label": "S", "pass": True},
+            "score_qwen36": {"label": "XL", "pass": True},
+        }
+        self.assertEqual(bot._public_eval_label(res), "XL")
+
     def test_none_reject_eval_count_ignores_infra_error(self):
         infra_body = bot.render({
             "label": "REJECT", "pass": False, "infra_error": True, "mode": "bidir",


### PR DESCRIPTION
## Summary

`_public_eval_label` exists so a passing Qwen3.6 XL cannot paper over a Qwen3.5 regression (#555). Both of its selection loops require the failing side to *carry a label*, so a side with `pass: False` and no label of its own falls past them to `return res.get("label")` — which on a bidir run is the passing side's headline. Not a kernel change and claims no speedup.


> **No GPU eval needed.** Per the auto-close bot's own guidance, the proof-of-speedup
> section is removed rather than left with an unticked box: this PR touches only `eval/`
> Python (the harness that grades PRs), changes no kernel and no runtime path, and cannot
> move decode or prefill. I have no Blackwell GPU, so I did not run `bench.sh`,
> `accuracy.sh` or `ctest`, and I claim no speedup. I am not ticking the RTX 5090 box,
> because that attestation would be false.

## The bug

```python
if any(s.get("pass") is False for s in sides):
    for s in sides:
        if s.get("pass") is False and s.get("label") == "REJECT":
            return "REJECT"
    for s in sides:
        if s.get("pass") is False and s.get("label"):   # <- needs a label
            return s["label"]
return res.get("label")                                 # <- the passing headline
```

Running the current `_public_eval_label` over the bidir matrix:

| `score_qwen35` | `score_qwen36` | headline |
|---|---|---|
| `S` / pass | `XL` / pass | `XL` |
| `REJECT` / fail | `XL` / pass | `REJECT` |
| `none` / fail | `XL` / pass | `none` |
| **`None` / fail** | **`XL` / pass** | **`XL`** |

The last row is the papering-over the docstring names. It is reward-visible rather than cosmetic: in the SN74 registry `eval:XL` is ×4.0 and `eval:REJECT` is ×0.0, so a bidir run whose failing side lost its label pays four times instead of nothing.

`pass: False` with no label is the shape a partial record produces — the side failed before a verdict tier was assigned. That is the same class as the fail-open in the enclave scorer (#670): a stated guard defeated by incomplete evidence rather than by wrong evidence.

## The change

A failed side now falls back to `REJECT` instead of to the headline.

The existing preference order is untouched — a side carrying `REJECT` still wins, and a side carrying a real non-REJECT verdict (`none`) still headlines as that verdict — so the fallback only covers the case where no side offered one.

## Tests

Added next to the existing `test_bidir_public_label_reject_beats_passing_xl`:

- `test_bidir_failing_side_without_label_does_not_headline_as_passing` — the bug. Fails on `main`:
  ```
  AssertionError: 'XL' != 'REJECT'
  ```
- `test_bidir_failing_side_with_label_still_headlines_that_label` — pins that the fallback does not swallow a real `none` verdict
- `test_bidir_all_sides_passing_keeps_the_top_level_label` — pins that an all-passing run is unaffected

The last two pass before and after, on purpose: they bound the change rather than demonstrate it.

## Verification

```
python3 -m pytest eval/ -q     103 passed        (100 before, +3 new)
```

No new dependencies.
