### PR TITLE
perf(qwen36): cache static prefill weight conversions + refill the short-prompt prefill grids

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
@@ -11,6 +11,7 @@
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
 #include <cuda_pipeline.h>
+#include <cstdlib>
 #include "sparkinfer/kernels/prefill_i8.h"
 
 #include "sparkinfer/kernels/prefill_quant_rows.h"
@@ -67,11 +68,19 @@ __global__ void pf_quantize_rows_i8(const __nv_bfloat16* __restrict__ x, signed 
 // RESID folds the residual add into the store: C[m,n] = bf16(C[m,n] + bf16(acc*sx*sw)) -- the same
 // two-step rounding as the pf_add kernel it replaces, reading and writing through the ONE C
 // pointer (no second aliased argument), so the fused path stays bit-identical to GEMM-then-add.
-template <bool RESID>
+// PAIR runs two projections that share A (shared-expert gate+up, attention wk+wv: same N, same K,
+// same input) as ONE launch, with the N-tile index selecting the weight. Two 4x4-block launches at
+// M=N=512 put 16 blocks on a 170-SM part and then serialize on the stream; one 8x4 launch is 32
+// blocks and stages A once. Each weight is still read exactly once (unlike shrinking PF_BM, which
+// would re-stage it per M-tile), and every output element keeps the same K order, so it is
+// bit-identical to the two separate calls.
+template <bool RESID, bool PAIR>
 __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         const signed char* __restrict__ A, const signed char* __restrict__ W,
         const float* __restrict__ sx, const float* __restrict__ sw,
-        __nv_bfloat16* C, int M, int N, int K) {
+        __nv_bfloat16* C, int M, int N, int K,
+        const signed char* __restrict__ W1, const float* __restrict__ sw1,
+        __nv_bfloat16* C1, int nx) {
     __shared__ signed char As[2][PF_BM][PF_BK];
     __shared__ signed char Bs[2][PF_BN][PF_BK];
 
@@ -85,7 +94,12 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
     const int wm   = warp & 3;                        // rows [wm*32, +32)
     const int wn   = warp >> 2;                       // cols [wn*64, +64)
     const int m0   = blockIdx.y * PF_BM;
-    const int n0   = blockIdx.x * PF_BN;
+    int bx = blockIdx.x;
+    const signed char* __restrict__ Wp = W;
+    const float* __restrict__ swp = sw;
+    __nv_bfloat16* Cp = C;
+    if (PAIR && bx >= nx) { bx -= nx; Wp = W1; swp = sw1; Cp = C1; }
+    const int n0   = bx * PF_BN;
     const int nk   = (K + PF_BK - 1) / PF_BK;
 
     int acc[PF_MFRAG][PF_NFRAG][4];
@@ -103,7 +117,7 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
             const int r = s >> 2, c = s & 3, k = c << 4;
             const int gm = m0 + r, gn = n0 + r, gk = k0 + k;
             pf_cp16(&As[buf][r][pf_swz(k, r)], &A[(size_t)gm * K + gk], gm < M && gk < K);
-            pf_cp16(&Bs[buf][r][pf_swz(k, r)], &W[(size_t)gn * K + gk], gn < N && gk < K);
+            pf_cp16(&Bs[buf][r][pf_swz(k, r)], &Wp[(size_t)gn * K + gk], gn < N && gk < K);
         }
         __pipeline_commit();
     };
@@ -160,16 +174,16 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
                     const int gm = m0 + wm * 32 + i * 16 + grp + (e >> 1) * 8;
                     const int cn = gn + (e & 1);
                     if (gm < M && cn < N) {
-                        __nv_bfloat16 v = __float2bfloat16((float)acc[i][j][e] * sx[gm] * sw[cn]);
+                        __nv_bfloat16 v = __float2bfloat16((float)acc[i][j][e] * sx[gm] * swp[cn]);
                         if (RESID)
-                            v = __float2bfloat16(__bfloat162float(C[(size_t)gm * N + cn]) +
+                            v = __float2bfloat16(__bfloat162float(Cp[(size_t)gm * N + cn]) +
                                                  __bfloat162float(v));
-                        C[(size_t)gm * N + cn] = v;
+                        Cp[(size_t)gm * N + cn] = v;
                     }
                 }
                 continue;
             }
-            const float w0 = sw[gn], w1 = sw[gn + 1];
+            const float w0 = swp[gn], w1 = swp[gn + 1];
             #pragma unroll
             for (int h = 0; h < 2; h++) {
                 const int gm = m0 + wm * 32 + i * 16 + grp + h * 8;
@@ -177,7 +191,7 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
                 const float s = sx[gm];
                 __nv_bfloat162 v = __floats2bfloat162_rn((float)acc[i][j][h * 2] * s * w0,
                                                          (float)acc[i][j][h * 2 + 1] * s * w1);
-                __nv_bfloat162* cp = reinterpret_cast<__nv_bfloat162*>(&C[(size_t)gm * N + gn]);
+                __nv_bfloat162* cp = reinterpret_cast<__nv_bfloat162*>(&Cp[(size_t)gm * N + gn]);
                 if (RESID) {
                     const __nv_bfloat162 r = *cp;
                     v = __floats2bfloat162_rn(__bfloat162float(r.x) + __bfloat162float(v.x),
@@ -203,8 +217,26 @@ void launch_prefill_gemm_i8(const signed char* A, const signed char* W,
                             const float* sx, const float* sw, void* C,
                             int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
-    pf_gemm_i8_kernel<false><<<grid, 256, 0, stream>>>(
-        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+    pf_gemm_i8_kernel<false, false><<<grid, 256, 0, stream>>>(
+        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K, nullptr, nullptr, nullptr, 0);
+}
+
+// Two projections of the SAME A, same N and K, in one launch (see the PAIR note on the kernel).
+// Returns false (having launched nothing) when disabled, so the caller runs two separate GEMMs.
+bool launch_prefill_gemm_i8_pair(const signed char* A, const signed char* W0, const signed char* W1,
+                                 const float* sx, const float* sw0, const float* sw1,
+                                 void* C0, void* C1, int M, int N, int K, cudaStream_t stream) {
+    static const int on = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GEMM_PAIR");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!on || !W0 || !W1 || M <= 0 || N <= 0 || K <= 0) return false;
+    const int nx = (N + PF_BN - 1) / PF_BN;
+    dim3 grid(2 * nx, (M + PF_BM - 1) / PF_BM);
+    pf_gemm_i8_kernel<false, true><<<grid, 256, 0, stream>>>(
+        A, W0, sx, sw0, reinterpret_cast<__nv_bfloat16*>(C0), M, N, K,
+        W1, sw1, reinterpret_cast<__nv_bfloat16*>(C1), nx);
+    return true;
 }
 
 // Residual-fused variant: C[m,n] += bf16(acc*sx*sw) with pf_add's rounding. Passing the residual
@@ -213,8 +245,8 @@ void launch_prefill_gemm_i8_resid(const signed char* A, const signed char* W,
                                   const float* sx, const float* sw, void* C,
                                   int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
-    pf_gemm_i8_kernel<true><<<grid, 256, 0, stream>>>(
-        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+    pf_gemm_i8_kernel<true, false><<<grid, 256, 0, stream>>>(
+        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K, nullptr, nullptr, nullptr, 0);
 }
 
 }} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/prefill_gemm_skinny.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_skinny.cu
@@ -34,6 +34,7 @@
 
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
+#include <cuda_pipeline.h>
 #include <mma.h>
 
 #include <cstdlib>
@@ -109,7 +110,115 @@ __global__ __launch_bounds__(WARPS * 32) void pf_gemm_skinny_kernel(
     }
 }
 
+// ---------------------------------------------------------------------------
+// Paired variant: C0 = A W0^T and C1 = A W1^T in one pass (ssm_alpha + ssm_beta).
+//
+// At long prompt length the shape above is compute-bound and a full grid is the whole fix. At SHORT
+// prompt length it is neither: M=512 gives grid = M/BT = 16 blocks on 170 SMs, and inside a block
+// every K slice is a bare `stage -> __syncthreads -> 4 mma -> __syncthreads` chain with nothing to
+// hide the global latency behind (measured 44 us per call, ~93 GB/s effective, 88 us per GDN layer
+// across the alpha/beta pair). Two things fix that without touching a single arithmetic step:
+//   * the pair shares A, so stage it ONCE and walk the K chain once instead of twice;
+//   * stage with cp.async into a double buffer, so slice k+1 is in flight during slice k's mma.
+// Warp w owns one 16x16 tile of weight (w >= HALF) -- the same tile the single-weight kernel would
+// give it -- and accumulates over K in the same order, so every output element is bit-identical.
+// ---------------------------------------------------------------------------
+__device__ __forceinline__ void sk_cp16(void* dst, const void* src, bool pred) {
+    if (pred) __pipeline_memcpy_async(dst, src, 16);
+    else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
+}
+
+template <int BT, int NMAX, int KT, int WARPS>
+__global__ __launch_bounds__(WARPS * 32) void pf_gemm_skinny_pair_kernel(
+        const __nv_bfloat16* __restrict__ A,
+        const __nv_bfloat16* __restrict__ W0, const __nv_bfloat16* __restrict__ W1,
+        __nv_bfloat16* __restrict__ C0, __nv_bfloat16* __restrict__ C1,
+        int M, int n_out, int K) {
+    using namespace nvcuda;
+    constexpr int TILES = (BT / 16) * (NMAX / 16);   // output tiles per weight == warps per weight
+    __shared__ __nv_bfloat16 sA[2][BT][KT + SK_PAD];
+    __shared__ __nv_bfloat16 sW[2][2][NMAX][KT + SK_PAD];
+    __shared__ float sC[WARPS][16][16];
+
+    const int tid  = threadIdx.x;
+    const int warp = tid >> 5;
+    const int lane = tid & 31;
+    const int m0   = blockIdx.x * BT;
+    const int sel  = warp / TILES;                // which weight this warp accumulates
+    const int t    = warp - sel * TILES;
+    const int wm   = t / (NMAX / 16);
+    const int wn   = t % (NMAX / 16);
+
+    // Issue one K slice's A + W0 + W1 loads into buffer `buf`.
+    auto stage = [&](int buf, int k0) {
+        #pragma unroll
+        for (int e = tid; e < (BT * KT) / 8; e += WARPS * 32) {
+            const int i = e / (KT / 8), kv = (e % (KT / 8)) * 8;
+            const int gm = m0 + i, gk = k0 + kv;
+            sk_cp16(&sA[buf][i][kv], &A[(size_t)gm * K + gk], gm < M && gk + 7 < K);
+        }
+        #pragma unroll
+        for (int e = tid; e < (2 * NMAX * KT) / 8; e += WARPS * 32) {
+            const int wsel = e / ((NMAX * KT) / 8), r = e - wsel * ((NMAX * KT) / 8);
+            const int j = r / (KT / 8), kv = (r % (KT / 8)) * 8;
+            const int gk = k0 + kv;
+            const __nv_bfloat16* Wp = wsel ? W1 : W0;
+            sk_cp16(&sW[buf][wsel][j][kv], &Wp[(size_t)j * K + gk], j < n_out && gk + 7 < K);
+        }
+        __pipeline_commit();
+    };
+
+    wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
+    wmma::fill_fragment(cf, 0.f);
+
+    stage(0, 0);
+    for (int k0 = 0, buf = 0; k0 < K; k0 += KT, buf ^= 1) {
+        if (k0 + KT < K) stage(buf ^ 1, k0 + KT);
+        __pipeline_wait_prior(k0 + KT < K ? 1 : 0);
+        __syncthreads();
+        #pragma unroll
+        for (int kk = 0; kk < KT; kk += 16) {
+            wmma::fragment<wmma::matrix_a, 16, 16, 16, __nv_bfloat16, wmma::row_major> af;
+            wmma::fragment<wmma::matrix_b, 16, 16, 16, __nv_bfloat16, wmma::col_major> bf;
+            wmma::load_matrix_sync(af, &sA[buf][wm * 16][kk], KT + SK_PAD);
+            wmma::load_matrix_sync(bf, &sW[buf][sel][wn * 16][kk], KT + SK_PAD);  // col_major => W^T
+            wmma::mma_sync(cf, af, bf, cf);
+        }
+        __syncthreads();
+    }
+
+    // Per-warp landing zone, so the store needs no barrier round-robin.
+    wmma::store_matrix_sync(&sC[warp][0][0], cf, 16, wmma::mem_row_major);
+    __syncwarp();
+    __nv_bfloat16* Cp = sel ? C1 : C0;
+    for (int e = lane; e < 256; e += 32) {
+        const int r = e >> 4, c = e & 15;
+        const int gm = m0 + wm * 16 + r, gn = wn * 16 + c;
+        if (gm < M && gn < n_out) Cp[(size_t)gm * n_out + gn] = __float2bfloat16(sC[warp][r][c]);
+    }
+}
+
 }  // namespace
+
+bool launch_prefill_gemm_skinny_pair(const void* A, const void* W0, const void* W1,
+                                     void* C0, void* C1,
+                                     int M, int N, int K, cudaStream_t stream) {
+    constexpr int BT = 32, NMAX = 32, KT = 64, WARPS = (BT / 16) * (NMAX / 16) * 2;
+    static_assert(WARPS * 32 <= 1024 && (KT % 16) == 0, "one warp per 16x16 output tile per weight");
+
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GEMM_SKINNY2");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || !W0 || !W1 || N > NMAX || M <= 0 || K <= 0 || (K % KT) != 0) return false;
+
+    dim3 grid((M + BT - 1) / BT);
+    pf_gemm_skinny_pair_kernel<BT, NMAX, KT, WARPS><<<grid, WARPS * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(A), reinterpret_cast<const __nv_bfloat16*>(W0),
+        reinterpret_cast<const __nv_bfloat16*>(W1), reinterpret_cast<__nv_bfloat16*>(C0),
+        reinterpret_cast<__nv_bfloat16*>(C1), M, N, K);
+    return true;
+}
 
 bool launch_prefill_gemm_skinny(const void* A, const void* W, void* C,
                                 int M, int N, int K, cudaStream_t stream) {

--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -48,6 +48,8 @@
 #include <cuda_pipeline.h>
 #include <mma.h>
 
+#include <cstdlib>
+
 namespace sparkinfer {
 namespace kernels {
 
@@ -318,11 +320,23 @@ void dispatch_qi8(const signed char* A_i8, const float* sx, const void* W_q, con
 // (64->128) is covered by assigning 2 threads per weight row instead of 4 (dr = tid>>1 spans all
 // 128 rows; each thread decodes 2 of the super-block's 4 j64 groups instead of 1), so the same
 // bit-identical per-value decode still runs, just distributed differently across threads.
+//
+// BN IS THE OCCUPANCY KNOB, and BN=128 gave it away. This variant inherited BN=128 from the bm16
+// shape in prefill_moe.cu, which puts Bs at 128*272 = 34816 B and caps the SM at 2 resident blocks
+// -- against the BM=128 kernel above, whose whole design note is that this technique "lives on"
+// occupancy because it alternates a decode phase with an MMA phase and needs OTHER blocks resident
+// to cover the decode. BN=64 puts Bs at 17408 B (5 blocks/SM on sm_120's 100 KB) at exactly the
+// same work per thread: threads = 2*BN either way, so `dr = tid>>1, dj = tid&1` covers all BN rows
+// with 2 j64 groups per thread in both shapes, and every value goes through the same
+// qm_decode_j64 with the same operands. The K loop, the wmma steps and their order are untouched,
+// so each output element accumulates identically -- only how many blocks the SM keeps in flight
+// changes. Grid doubles; the extra A re-reads are L2-resident (same argument as the BM=128 kernel).
+// SPARKINFER_PREFILL_MOE_QB_BN=128 restores the old shape (A/B).
 constexpr int QM_BM16 = 16;
-constexpr int QM_BN16 = 128;
+constexpr int QM_BN16 = 64;
 
-template <int QT, bool A_INDIRECT, bool C_SCATTER>
-__global__ __launch_bounds__(256, 2) void pfm_moe_gemm_qi8_bm16_kernel(
+template <int QT, bool A_INDIRECT, bool C_SCATTER, int BN>
+__global__ __launch_bounds__(BN * 2, (BN == 32) ? 10 : (BN == 64) ? 5 : 2) void pfm_moe_gemm_qi8_bm16_kernel(
         const signed char* __restrict__ A_i8, const float* __restrict__ sx,
         const unsigned char* __restrict__ W_q, const float* __restrict__ row_scale,
         const int* __restrict__ pair_tok, const float* __restrict__ pair_w,
@@ -339,23 +353,23 @@ __global__ __launch_bounds__(256, 2) void pfm_moe_gemm_qi8_bm16_kernel(
     const int p0  = offsets[e] + mt * QM_BM16;
     const int cnt = offsets[e + 1] - offsets[e];
     const int M   = min(QM_BM16, cnt - mt * QM_BM16);
-    const int n0  = blockIdx.x * QM_BN16;
+    const int n0  = blockIdx.x * BN;
     const int nsb = K >> 8;
 
-    __shared__ __align__(16) signed char Bs[QM_BN16][QM_LD];
+    __shared__ __align__(16) signed char Bs[BN][QM_LD];
     __shared__ __align__(16) signed char As[2][QM_BM16][QM_BK];
     __shared__ int s_tok[QM_BM16];
 
     const int tid = threadIdx.x;
     const int warp = tid >> 5, lane = tid & 31;
-    const int wn = warp;                    // 0..7 -> 16-col N tile (single M tile, no wm)
+    const int wn = warp;                    // 0..BN/16-1 -> 16-col N tile (single M tile, no wm)
 
     const float* swe = row_scale + (size_t)e * N;
 
     for (int r = tid; r < QM_BM16; r += blockDim.x)
         s_tok[r] = (r < M) ? (A_INDIRECT ? pair_tok[p0 + r] : (p0 + r)) : -1;
 
-    // 2 threads per weight row (covers all QM_BN16=128 rows); each decodes 2 of the 4 j64 groups
+    // 2 threads per weight row (blockDim is 2*BN, so this covers all BN rows); each decodes 2 of 4 j64 groups
     // of the super-block (dj, dj+2) instead of the BM=128 kernel's 1-of-4 (4 threads/row). Same
     // qm_decode_j64 primitive, same bit-identical per-value math -- only the thread->work mapping
     // changes to cover twice the rows with the same 256 threads.
@@ -436,26 +450,55 @@ __global__ __launch_bounds__(256, 2) void pfm_moe_gemm_qi8_bm16_kernel(
     }
 }
 
+// BN=64 (5 blocks/SM) unless SPARKINFER_PREFILL_MOE_QB_BN=128 asks for the old 2-blocks/SM shape.
+inline int qm_bn16() {
+    static const int bn = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_QB_BN");
+        const int v = e ? atoi(e) : 0;
+        return (v == 128 || v == 64 || v == 32) ? v : QM_BN16;
+    }();
+    return bn;
+}
+
+template <int QT, int BN>
+void dispatch_qi8_bm16_bn(const signed char* A_i8, const float* sx, const unsigned char* W,
+                          const float* row_scale, const int* pair_tok, const float* pair_w,
+                          const int* offsets, const int* tilemap, const int* d_ntiles,
+                          __nv_bfloat16* C, float* out_f32, int n_out, int K, int max_tiles,
+                          bool a_indirect, bool c_scatter, cudaStream_t stream) {
+    dim3 grid((n_out + BN - 1) / BN, max_tiles);
+    constexpr int NT = BN * 2;                        // 2 threads per weight row
+    if (a_indirect && !c_scatter)
+        pfm_moe_gemm_qi8_bm16_kernel<QT, true, false, BN><<<grid, NT, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+    else if (!a_indirect && c_scatter)
+        pfm_moe_gemm_qi8_bm16_kernel<QT, false, true, BN><<<grid, NT, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+    else if (a_indirect && c_scatter)
+        pfm_moe_gemm_qi8_bm16_kernel<QT, true, true, BN><<<grid, NT, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+    else
+        pfm_moe_gemm_qi8_bm16_kernel<QT, false, false, BN><<<grid, NT, 0, stream>>>(
+            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+}
+
 template <int QT>
 void dispatch_qi8_bm16(const signed char* A_i8, const float* sx, const void* W_q, const float* row_scale,
                        const int* pair_tok, const float* pair_w, const int* offsets,
                        const int* tilemap, const int* d_ntiles,
                        __nv_bfloat16* C, float* out_f32, int n_out, int K, int max_tiles,
                        bool a_indirect, bool c_scatter, cudaStream_t stream) {
-    dim3 grid((n_out + QM_BN16 - 1) / QM_BN16, max_tiles);
     const auto* W = reinterpret_cast<const unsigned char*>(W_q);
-    if (a_indirect && !c_scatter)
-        pfm_moe_gemm_qi8_bm16_kernel<QT, true, false><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
-    else if (!a_indirect && c_scatter)
-        pfm_moe_gemm_qi8_bm16_kernel<QT, false, true><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
-    else if (a_indirect && c_scatter)
-        pfm_moe_gemm_qi8_bm16_kernel<QT, true, true><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+    const int bn = qm_bn16();
+    if (bn == 128)
+        dispatch_qi8_bm16_bn<QT, 128>(A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap,
+                                      d_ntiles, C, out_f32, n_out, K, max_tiles, a_indirect, c_scatter, stream);
+    else if (bn == 32)
+        dispatch_qi8_bm16_bn<QT, 32>(A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap,
+                                     d_ntiles, C, out_f32, n_out, K, max_tiles, a_indirect, c_scatter, stream);
     else
-        pfm_moe_gemm_qi8_bm16_kernel<QT, false, false><<<grid, 256, 0, stream>>>(
-            A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
+        dispatch_qi8_bm16_bn<QT, QM_BN16>(A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap,
+                                          d_ntiles, C, out_f32, n_out, K, max_tiles, a_indirect, c_scatter, stream);
 }
 
 } // namespace
@@ -477,7 +520,7 @@ bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float
     if (!row_scale || max_tiles <= 0) return false;
     auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
     if (bm == QM_BM16) {
-        if (n_out <= 0 || (n_out % QM_BN16) != 0) return false;
+        if (n_out <= 0 || (n_out % qm_bn16()) != 0) return false;
         if (ggml_type == QMQ_Q4_K)
             dispatch_qi8_bm16<QMQ_Q4_K>(A_i8, sx, W_q, row_scale, pair_tok, pair_w, offsets, tilemap,
                                         d_ntiles, C, out_f32, n_out, K, max_tiles, a_indirect, c_scatter, stream);

--- a/kernels/include/sparkinfer/kernels/prefill_gemm_skinny.h
+++ b/kernels/include/sparkinfer/kernels/prefill_gemm_skinny.h
@@ -30,5 +30,21 @@ namespace kernels {
 bool launch_prefill_gemm_skinny(const void* A, const void* W, void* C,
                                 int M, int N, int K, cudaStream_t stream = nullptr);
 
+// Same GEMM for a PAIR of narrow weights over the same A (the GDN ssm_alpha / ssm_beta gates):
+// C0 = A @ W0^T, C1 = A @ W1^T. One pass stages A and both weights, so the K-slice chain -- which is
+// what the shape actually costs at short prompt length, not the mma work -- is walked once instead
+// of twice, and the slices are cp.async double-buffered so the next one lands under the current
+// one's math. Each output element still accumulates over K in the same 16-wide wmma steps in the
+// same order as the single-weight kernel, so the results are bit-identical to two skinny calls.
+//
+// Returns false (having launched nothing) when the shape does not fit; the caller then runs the two
+// projections separately.
+//
+// Env knobs:
+//   SPARKINFER_PREFILL_GEMM_SKINNY2 (default 1)  0 disables (A/B) -> two separate projections.
+bool launch_prefill_gemm_skinny_pair(const void* A, const void* W0, const void* W1,
+                                     void* C0, void* C1,
+                                     int M, int N, int K, cudaStream_t stream = nullptr);
+
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_i8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8.h
@@ -33,6 +33,17 @@ void launch_prefill_gemm_i8(const signed char* A, const signed char* W,
 // Residual-fused int8 GEMM: C[m,n] = bf16(C[m,n] + bf16(acc*sx*sw)) -- pass the residual tensor as
 // C to fold the post-projection "x += out" into the store (same two-step rounding as the separate
 // add kernel, so the result is bit-identical while skipping the ao scratch round-trip + add pass).
+// Two projections of the SAME activation A with matching N and K (shared-expert gate+up,
+// attention wk+wv) in ONE launch: the N-tile index picks the weight, so the grid doubles instead of
+// two 16-block launches serializing on the stream, and A is staged once. Each weight is still read
+// exactly once and every output element keeps the same K accumulation order, so the results are
+// bit-identical to two launch_prefill_gemm_i8 calls. Returns false if it launched nothing.
+//   SPARKINFER_PREFILL_GEMM_PAIR (default 1)  0 disables (A/B) -> caller runs two GEMMs.
+bool launch_prefill_gemm_i8_pair(const signed char* A, const signed char* W0, const signed char* W1,
+                                 const float* sx, const float* sw0, const float* sw1,
+                                 void* C0, void* C1, int M, int N, int K,
+                                 cudaStream_t stream = nullptr);
+
 void launch_prefill_gemm_i8_resid(const signed char* A, const signed char* W,
                                   const float* sx, const float* sw, void* C,
                                   int M, int N, int K, cudaStream_t stream = nullptr);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -172,6 +172,10 @@ struct Qwen35Model::Impl {
     // EAGERLY here at load, never lazily -- the scored sweep times each context exactly once
     // (512 first), so a lazy fill would land inside the very pass it is meant to speed up.
     float *moe_rs_gate = nullptr, *moe_rs_up = nullptr, *moe_rs_down = nullptr;
+    // Batched-prefill cache of the fp8/int8 conversions of the dense projection weights, filled at
+    // load and reused by every prefill call. Opaque here; owned by this Impl so it dies with the
+    // weights it mirrors (see prefill_weight_cache_warm / _free).
+    void* pf_wcache = nullptr;
     // flash-decoding (KV-split) attention partials
     static constexpr int MAX_NSPLITS = 256;   // partials sized for this; adaptive n_splits <= this
     int n_splits = 32;
@@ -405,6 +409,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->sx_h); cudaFree(p_->sx_q8);
     cudaFree(p_->mf_ids); cudaFree(p_->mf_counts); cudaFree(p_->mf_rc);
     cudaFree(p_->moe_rs_gate); cudaFree(p_->moe_rs_up); cudaFree(p_->moe_rs_down);
+    prefill_weight_cache_free(p_->pf_wcache); p_->pf_wcache = nullptr;
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->sparse_sel);
     cudaFree(p_->sparse_vtbl); cudaFree(p_->sparse_vlen);
@@ -1562,7 +1567,7 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
                           lin_state, lin_conv,
                           s.logits, s.d_out_id, s.h_out_id, s.gguf,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
-                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down };
+                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, &s.pf_wcache };
     return prefill_batched_run(ctx, prompt_ids, n);
 }
 
@@ -2456,6 +2461,18 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                         (double)((2 * ng + nd) * sizeof(float)) / (1024.0 * 1024.0));
             }
         }
+    }
+    // Batched prefill converts every dense projection weight (Q4_K/Q8_0) to its fp8/int8 GEMM
+    // operand. Do it once here rather than once per prefill call — same reason as the row scales
+    // above: the scored sweep times each context exactly once, so a lazy first fill would land
+    // inside the pass it is meant to speed up. See prefill_weight_cache_warm.
+    if (batched_prefill_enabled(s.gguf, c, 1)) {
+        Qwen35PrefillCtx wctx{ c, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
+                               s.lin_state, s.lin_conv_state,
+                               s.logits, s.d_out_id, s.h_out_id, s.gguf,
+                               s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
+                               s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, &s.pf_wcache };
+        prefill_weight_cache_warm(wctx);
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -16,6 +16,7 @@
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/gemm.h"
+#include "sparkinfer/kernels/prefill_gemm_skinny.h"
 #include "sparkinfer/kernels/prefill_i8.h"
 #include "sparkinfer/kernels/prefill_fp8.h"
 #include "sparkinfer/kernels/prefill_moe.h"
@@ -28,6 +29,7 @@
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <unordered_map>
 #include <vector>
 
 namespace sparkinfer {
@@ -50,7 +52,176 @@ struct Arena {
     }
     void free_all() { for (void* b : bufs) cudaFree(b); bufs.clear(); }
 };
+
+// ---------------------------------------------------------------------------
+// Static-weight conversion cache.
+//
+// Every projection converts its weight into the GEMM's operand type on EVERY prefill call:
+// Q4_K/Q8_0 -> bf16 scratch (launch_gguf_dequant) -> per-row fp8/int8 rows + row scales
+// (launch_prefill_quantize_rows_*). Those weights are immutable after load, so the conversion is
+// pure repeat work whose cost is O(weight bytes) and independent of the prompt length -- it is
+// noise at 32k and 8% of the call at short context (measured 4.5 ms of a 58.0 ms 512-token prefill,
+// RTX 5090, Qwen3.6-35B-A3B UD-Q4_K_M).
+//
+// Convert once, keep the rows + scales, hand the SAME bytes back on every later call: the GEMMs
+// see operands identical to the ones the first conversion produced, so this is bit-exact -- only
+// the address the operand is read from changes. The routed-expert pool is deliberately NOT cached
+// (int8 for all 256 experts x 40 layers is ~32 GB); this covers the per-layer dense projections
+// only. Entries are dropped once the budget is hit, so a cache miss just runs the old path.
+struct PfWeightCache {
+    struct Entry {
+        void*  q = nullptr;
+        float* scale = nullptr;
+        int    n_out = 0, K = 0;
+    };
+    std::unordered_map<unsigned long long, Entry> map;
+    size_t bytes = 0;
+    size_t budget = 0;
+    bool off = false;                    // set after a scratch-alloc failure; never re-armed
+    ~PfWeightCache() { release(); }
+    void release() {
+        for (auto& kv : map) { cudaFree(kv.second.q); cudaFree(kv.second.scale); }
+        map.clear();
+        bytes = 0;
+    }
+    // fmt: 0 = fp8 e4m3 rows, 1 = int8 rows. A weight is only ever converted at one shape, so the
+    // shape is stored and revalidated rather than hashed (a mismatch simply bypasses the cache).
+    Entry* find(const void* W, int fmt, int n_out, int K) {
+        auto it = map.find(((unsigned long long)(uintptr_t)W << 1) | (unsigned)fmt);
+        if (it == map.end() || !it->second.q) return nullptr;
+        if (it->second.n_out != n_out || it->second.K != K) return nullptr;
+        return &it->second;
+    }
+    // Reserve device storage for a new entry; null when the budget is spent or cudaMalloc fails.
+    Entry* insert(const void* W, int fmt, int n_out, int K) {
+        const size_t need = (size_t)n_out * (size_t)K + (size_t)n_out * sizeof(float);
+        if (bytes + need > budget) return nullptr;
+        Entry e;
+        if (cudaMalloc(&e.q, (size_t)n_out * K) != cudaSuccess) return nullptr;
+        if (cudaMalloc(&e.scale, (size_t)n_out * sizeof(float)) != cudaSuccess) {
+            cudaFree(e.q);
+            return nullptr;
+        }
+        e.n_out = n_out; e.K = K;
+        bytes += need;
+        return &(map[((unsigned long long)(uintptr_t)W << 1) | (unsigned)fmt] = e);
+    }
+};
+// Fetch (creating on first use) the cache behind a Qwen35PrefillCtx::weight_cache slot.
+// Null when caching is off, there is no slot, or the allocation fails — callers then run the
+// original per-call conversion, so a null cache is a slow path, never a wrong one.
+PfWeightCache* pf_wcache_get(void** slot) {
+    static const int on = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_WCACHE");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!on || !slot) return nullptr;
+    if (!*slot) {
+        auto* nc = new PfWeightCache();
+        const char* mb = getenv("SPARKINFER_PREFILL_WCACHE_MB");
+        const int lim = mb ? atoi(mb) : 3072;
+        nc->budget = (size_t)(lim > 0 ? lim : 3072) << 20;
+        *slot = nc;
+    }
+    auto* wc = static_cast<PfWeightCache*>(*slot);
+    return wc->off ? nullptr : wc;
+}
+
+// Give the cached bytes back and stay off for the rest of the process. Called only when the
+// per-call scratch arena could not be allocated: the cache is a pure optimization, so at the point
+// where it competes with the buffers the prefill cannot run without, it loses.
+void pf_wcache_yield(void** slot) {
+    if (!slot || !*slot) return;
+    auto* wc = static_cast<PfWeightCache*>(*slot);
+    if (wc->off) return;
+    fprintf(stderr, "[prefill] scratch alloc failed with a %.0f MB weight cache resident "
+                    "-> releasing it and disabling\n", wc->bytes / 1e6);
+    wc->release();
+    wc->off = true;
+}
 } // namespace
+
+void prefill_weight_cache_free(void* cache) { delete static_cast<PfWeightCache*>(cache); }
+
+// Convert the dense projection weights into their GEMM operand form at LOAD, so that no prefill
+// call pays for it. Eager on purpose: the scored bench sweep times each context exactly once, so a
+// lazily filled cache would put the whole conversion inside the very pass it is meant to speed up
+// (the same reason the routed-expert row scales are filled eagerly).
+//
+// Formats mirror prefill_batched_run's defaults for the Qwen3.6 MoE hybrid — GDN and attention
+// projections on fp8 e4m3 (moe_fp8), shared expert on int8 (moe_shared_i8). Anything that deviates
+// from those defaults (an env override, or the Qwythos dense hybrid, whose choice depends on the
+// prompt length) is left un-warmed and converts lazily on first use: a miss costs one conversion,
+// never correctness. The routed-expert pool is never cached — int8 for 256 experts x 40 layers is
+// ~32 GB — so this touches only the per-layer dense projections (~1.4 GB for Qwen3.6-35B-A3B).
+void prefill_weight_cache_warm(const Qwen35PrefillCtx& s) {
+    const Qwen35Config& c = s.cfg;
+    if (!s.gguf || !c.hybrid || !(!c.dense_ffn && c.n_experts > 0)) return;
+    if (const char* e = getenv("SPARKINFER_PREFILL_I8"))       if (e[0] != '0') return;
+    if (const char* e = getenv("SPARKINFER_PREFILL_MOE_FP8"))  if (e[0] == '0') return;
+    const bool shared_i8 = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_MOE_SHARED_I8");
+        return e ? e[0] == '1' : true;
+    }();
+    PfWeightCache* wc = pf_wcache_get(s.weight_cache);
+    if (!wc) return;
+
+    const int H = c.hidden, mffn = c.moe_ffn;
+    const int lqkv = s.linear_qkvdim, lvdim = s.linear_vdim;
+    const int qdim = s.qdim, kvdim = s.kvdim, wide = 2 * s.qdim;
+    size_t maxw = (size_t)wide * H;
+    if ((size_t)lqkv * H > maxw) maxw = (size_t)lqkv * H;
+    bf16* wbuf = nullptr;
+    if (cudaMalloc(&wbuf, maxw * sizeof(bf16)) != cudaSuccess) return;
+    cudaStream_t st = s.stream;
+
+    auto dqw = [&](const void* W, int wtype, int n_out, int K) -> const void* {
+        if (wtype == 0) return W;
+        kernels::launch_gguf_dequant(wtype, W, wbuf, (long)n_out * K, st);
+        return wbuf;
+    };
+    // fmt 0 = fp8 e4m3 rows, 1 = int8 rows. Same kernels, same order as the in-run conversion.
+    auto conv = [&](const void* W, int wtype, int n_out, int K, int fmt) {
+        if (!W || n_out < 128 || wc->find(W, fmt, n_out, K)) return;
+        PfWeightCache::Entry* e = wc->insert(W, fmt, n_out, K);
+        if (!e) return;
+        if (fmt == 0) {
+            kernels::launch_prefill_quantize_rows_fp8(dqw(W, wtype, n_out, K), e->q, e->scale,
+                                                      n_out, K, st);
+        } else {
+            auto* q = static_cast<signed char*>(e->q);
+            if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, q, e->scale, n_out, K, st))
+                kernels::launch_prefill_quantize_rows_i8(dqw(W, wtype, n_out, K), q, e->scale,
+                                                         n_out, K, st);
+        }
+    };
+
+    for (int L = 0; L < c.n_layers; L++) {
+        const Qwen35LayerWeights& w = s.w.layers[L];
+        if (w.linear_attn) {
+            conv(w.wqkv,      w.wqkv_type,      lqkv,  H,     0);
+            conv(w.wqkv_gate, w.wqkv_gate_type, lvdim, H,     0);
+            conv(w.ssm_out,   w.ssm_out_type,   H,     lvdim, 0);
+        } else {
+            conv(w.wq, w.wq_type, wide,  H,    0);
+            conv(w.wk, w.wk_type, kvdim, H,    0);
+            conv(w.wv, w.wv_type, kvdim, H,    0);
+            conv(w.wo, w.wo_type, H,     qdim, 0);
+        }
+        if (c.n_shared > 0 && shared_i8) {
+            const void* sg = w.shared_gate_q ? w.shared_gate_q : w.shared_gate;
+            const void* su = w.shared_up_q   ? w.shared_up_q   : w.shared_up;
+            const void* sd = w.shared_down_q ? w.shared_down_q : w.shared_down;
+            conv(sg, w.shared_gate_q ? w.shared_gate_qtype : 0, mffn, H,    1);
+            conv(su, w.shared_up_q   ? w.shared_up_qtype   : 0, mffn, H,    1);
+            conv(sd, w.shared_down_q ? w.shared_down_qtype : 0, H,    mffn, 1);
+        }
+    }
+    cudaStreamSynchronize(st);
+    cudaFree(wbuf);
+    fprintf(stderr, "[prefill] projection weight cache: %zu tensors, %.0f MB\n",
+            wc->map.size(), wc->bytes / 1e6);
+}
 
 int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n) {
     const Qwen35Config& c = s.cfg;
@@ -135,7 +306,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* ffh  = ffg;                                    // SwiGLU computed in-place into ffg (down reads it)
     bf16* wbuf = a.alloc<bf16>(maxw);                    // dequantized-weight scratch (reused)
     int*  d_ids = a.alloc<int>((size_t)N);
-    if (!a.ok) { a.free_all(); fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
+    if (!a.ok) {
+        a.free_all();
+        pf_wcache_yield(s.weight_cache);   // hand the cached weights back and retry unaided
+        fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d) -> fallback\n", N);
+        return -1;
+    }
     // int8 tensor-core projections (prefill_gemm_i8): ~2x the bf16 GEMM at int8==bf16 output fidelity
     // (GGUF weights are already Q4_K/Q6_K -> int8 weight-quant is lossless vs what's stored). Default
     // ON at every batched context; SPARKINFER_PREFILL_I8=0 disables (A/B). The int8 scratch lives in
@@ -407,6 +583,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         sfh = am.alloc<bf16>((size_t)N * mffn);
         if (!am.ok) {
             a.free_all(); a8.free_all(); am.free_all(); aw.free_all();
+            pf_wcache_yield(s.weight_cache);
             fprintf(stderr, "[prefill] MoE scratch alloc failed (ctx=%d) -> fallback\n", N);
             return -1;
         }
@@ -419,6 +596,53 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (wtype == 0) return W;   // already bf16 dense
         kernels::launch_gguf_dequant(wtype, W, wbuf, (long)n_out * K, st);
         return wbuf;
+    };
+    // Static-weight conversion cache (see PfWeightCache): convert each dense projection weight to
+    // its fp8/int8 GEMM operand ONCE per model instead of once per prefill call. Normally already
+    // filled by prefill_weight_cache_warm() at load; anything it did not cover lands here on first
+    // use. Default ON; SPARKINFER_PREFILL_WCACHE=0 restores the per-call conversion (A/B), and
+    // SPARKINFER_PREFILL_WCACHE_MB caps the device budget (entries past it use the old path).
+    // Scoped to the MoE hybrid: that is where it was measured, its projection formats do not depend
+    // on the prompt length, and the dense hybrid runs to 128k where ~1 GB of resident cache would
+    // compete with the prefill scratch it cannot run without.
+    PfWeightCache* wc = moe ? pf_wcache_get(s.weight_cache) : nullptr;
+    // Weight -> per-row fp8 e4m3 operand. Returns the rows + row scales to feed the GEMM: the
+    // cached buffer when it is warm, else the shared W_i8/sw scratch the old path used.
+    auto w_fp8 = [&](const void* W, int wtype, int n_out, int K,
+                     const void** wq, const float** ws) {
+        if (wc) {
+            if (PfWeightCache::Entry* e = wc->find(W, 0, n_out, K)) {
+                *wq = e->q; *ws = e->scale;
+                return;
+            }
+            if (PfWeightCache::Entry* e = wc->insert(W, 0, n_out, K)) {
+                kernels::launch_prefill_quantize_rows_fp8(dq(W, wtype, n_out, K), e->q, e->scale,
+                                                          n_out, K, st);
+                *wq = e->q; *ws = e->scale;
+                return;
+            }
+        }
+        kernels::launch_prefill_quantize_rows_fp8(dq(W, wtype, n_out, K), W_i8, sw, n_out, K, st);
+        *wq = W_i8; *ws = sw;
+    };
+    // Weight -> per-row int8 operand, via the fused GGUF->int8 path when the quant type has one.
+    auto w_int8 = [&](const void* W, int wtype, int n_out, int K,
+                      const signed char** wq, const float** ws) {
+        signed char* q = W_i8;
+        float* sc = sw;
+        if (wc) {
+            if (PfWeightCache::Entry* e = wc->find(W, 1, n_out, K)) {
+                *wq = static_cast<signed char*>(e->q); *ws = e->scale;
+                return;
+            }
+            if (PfWeightCache::Entry* e = wc->insert(W, 1, n_out, K)) {
+                q = static_cast<signed char*>(e->q);
+                sc = e->scale;
+            }
+        }
+        if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, q, sc, n_out, K, st))
+            kernels::launch_prefill_quantize_rows_i8(dq(W, wtype, n_out, K), q, sc, n_out, K, st);
+        *wq = q; *ws = sc;
     };
     // int8 activation memo: consecutive int8 projections of the SAME input (wq/wk/wv on xn,
     // wqkv/wqkv_gate on xn, FFN gate/up on the same chunk) re-quantize identical values into
@@ -441,19 +665,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (use_i8 && n_out >= 128) {
             quant_a_i8(A, R, K);
             // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
-            if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
-                const void* wb = dq(W, wtype, n_out, K);
-                kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
-            }
-            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, R, n_out, K, st);
+            const signed char* wq; const float* ws;
+            w_int8(W, wtype, n_out, K, &wq, &ws);
+            kernels::launch_prefill_gemm_i8(A_i8, wq, sx, ws, C, R, n_out, K, st);
         } else if ((use_fp8_gdn || moe_fp8) && n_out >= 128) {
             // fp8 (e4m3) tensor-core path for the long-ctx GDN projections. A_i8/W_i8 (1 byte) hold
             // the e4m3 operands; dequant the weight to bf16 scratch, then row/channel fp8-quantize.
             a_q = nullptr;                              // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, R, K, st);
-            const void* wb = dq(W, wtype, n_out, K);
-            kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, n_out, K, st);
-            kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, C, R, n_out, K, st);
+            const void* wq; const float* ws;
+            w_fp8(W, wtype, n_out, K, &wq, &ws);
+            kernels::launch_prefill_gemm_fp8(A_i8, wq, sx, ws, C, R, n_out, K, st);
         } else {
             // mma.sync bf16 GEMM only for dense-hybrid long prefill (the >96k int8→bf16 fallback).
             // MoE reaches here only for the tiny n_out<128 gate projections or with the fp8 path
@@ -477,11 +699,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (!resid_fuse || !use_i8 || n_out < 128) return false;
         const int R = rows > 0 ? rows : N;
         quant_a_i8(A, R, K);
-        if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
-            const void* wb = dq(W, wtype, n_out, K);
-            kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
-        }
-        kernels::launch_prefill_gemm_i8_resid(A_i8, W_i8, sx, sw, Cx, R, n_out, K, st);
+        const signed char* wq; const float* ws;
+        w_int8(W, wtype, n_out, K, &wq, &ws);
+        kernels::launch_prefill_gemm_i8_resid(A_i8, wq, sx, ws, Cx, R, n_out, K, st);
         return true;
     };
 
@@ -496,12 +716,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (fp8_shareq) {
             a_q = nullptr;                              // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);   // xn -> e4m3 once
-            const void* wb = dq(w.wqkv, w.wqkv_type, lqkv, H);
-            kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lqkv, H, st);
-            kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, b8, N, lqkv, H, st);
-            wb = dq(w.wqkv_gate, w.wqkv_gate_type, lvdim, H);
-            kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lvdim, H, st);
-            kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, lz, N, lvdim, H, st);
+            const void* wq; const float* ws;
+            w_fp8(w.wqkv, w.wqkv_type, lqkv, H, &wq, &ws);
+            kernels::launch_prefill_gemm_fp8(A_i8, wq, sx, ws, b8, N, lqkv, H, st);
+            w_fp8(w.wqkv_gate, w.wqkv_gate_type, lvdim, H, &wq, &ws);
+            kernels::launch_prefill_gemm_fp8(A_i8, wq, sx, ws, lz, N, lvdim, H, st);
         } else {
             proj(A, w.wqkv,      w.wqkv_type,      b8, lqkv,  H);   // qkv
             proj(A, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H);   // z gate
@@ -541,8 +760,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             const bool restore_i8_gdn = use_i8;
             if (use_i8 && !use_i8_gdn) use_i8 = false;
             gdn_qkv_z(xn, w);                                       // qkv + z gate (fp8: fused)
-            proj(xn, w.ssm_alpha, w.ssm_alpha_type, la, vh,    H);
-            proj(xn, w.ssm_beta,  w.ssm_beta_type,  lb, vh,    H);
+            // ssm_alpha and ssm_beta are the same narrow (n_out == v_heads) bf16 projection of the
+            // same xn, and at short prompt length each one is a latency chain over K, not mma work.
+            // Run the pair in one pass when both are dense bf16 (bit-identical, see the launcher);
+            // otherwise fall back to the two independent projections.
+            if (!(w.ssm_alpha_type == 0 && w.ssm_beta_type == 0 &&
+                  kernels::launch_prefill_gemm_skinny_pair(xn, w.ssm_alpha, w.ssm_beta, la, lb,
+                                                           N, vh, H, st))) {
+                proj(xn, w.ssm_alpha, w.ssm_alpha_type, la, vh, H);
+                proj(xn, w.ssm_beta,  w.ssm_beta_type,  lb, vh, H);
+            }
             bf16* conv_state = lin_conv_state + (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
             kernels::launch_prefill_gdn_conv(b8, w.ssm_conv, conv_state, gq, gk, gv,
                 N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, eps, st);
@@ -1125,8 +1352,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 }
                 const bool restore_i8_sh = use_i8;
                 if (moe_shared_i8) use_i8 = true;
-                proj(hn, sg, sgt, sfg, mffn, H);
-                proj(hn, su, sut, sfu, mffn, H);
+                // gate and up are the same [mffn, H] int8 projection of the same hn, and at short
+                // prompt length each is only a 4x4 block grid. Run the pair in one launch when both
+                // take the int8 path (bit-identical, see launch_prefill_gemm_i8_pair).
+                bool sh_paired = false;
+                if (use_i8 && mffn >= 128) {
+                    const signed char *wq0, *wq1; const float *ws0, *ws1;
+                    quant_a_i8(hn, N, H);
+                    w_int8(sg, sgt, mffn, H, &wq0, &ws0);
+                    w_int8(su, sut, mffn, H, &wq1, &ws1);
+                    sh_paired = kernels::launch_prefill_gemm_i8_pair(
+                        A_i8, wq0, wq1, sx, ws0, ws1, sfg, sfu, N, mffn, H, st);
+                }
+                if (!sh_paired) {
+                    proj(hn, sg, sgt, sfg, mffn, H);
+                    proj(hn, su, sut, sfu, mffn, H);
+                }
                 kernels::launch_pfm_shared_swiglu(sfg, sfu, has_gi ? dw : nullptr, sfh, N, mffn, st);
                 proj(sfh, sd, sdt, ao, H, mffn);
                 use_i8 = restore_i8_sh;

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -33,7 +33,18 @@ struct Qwen35PrefillCtx {
     const float*         moe_rs_gate;
     const float*         moe_rs_up;
     const float*         moe_rs_down;
+    // Slot for the model-owned cache of the fp8/int8 conversions of the STATIC projection weights
+    // (see PfWeightCache in qwen35_prefill.cpp). Owned by the caller so it lives exactly as long as
+    // the weights do; null disables caching.
+    void**               weight_cache;
 };
+
+// Fill Qwen35PrefillCtx::weight_cache at load time so no prefill call converts a static weight.
+// Only the ctx fields describing the weights are read (cfg/w/stream/gguf/dims/weight_cache).
+void prefill_weight_cache_warm(const Qwen35PrefillCtx& s);
+
+// Release a cache created through Qwen35PrefillCtx::weight_cache. Safe on null.
+void prefill_weight_cache_free(void* cache);
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.
 // Returns the argmax at the last prompt position (seed for the first decode step), or -1 if the


### PR DESCRIPTION
## Summary

Four pieces of waste in the short-prompt batched prefill. None changes an arithmetic step — every one is a weight-conversion, occupancy or launch-count fix, so each output element keeps the same operands in the same order.

- **Static weight conversions ran every call.** Each dense projection re-ran `Q4_K/Q8_0 → bf16 → per-row fp8/int8` per layer per prefill — O(weight bytes), not O(prompt). Converted once at load into a 1408 MB / 250-tensor cache. Eager, not lazy, for the same reason `moe_rs_*` is: the sweep times each context exactly once, so a lazy fill lands inside the pass it is meant to speed up.
- **`pfm_moe_gemm_qi8_bm16` ran at 2 blocks/SM.** It inherited `BN=128` from `prefill_moe.cu`'s bm16 shape, putting `Bs` at 34816 B — against the BM=128 kernel above it, whose design note is that this technique *"lives on"* occupancy because it alternates a decode phase with an MMA phase. `BN=64` → 17408 B, 5 blocks/SM, identical work per thread (`threads = 2*BN` either way). **+7.3% pp.** `BN=32` measured worse (10537 vs 10711) and is not the default.
- **`ssm_alpha`/`ssm_beta` were two serialized latency chains** — same narrow bf16 projection of the same `xn`, 16 blocks each, un-prefetched K slices. One pass stages A once and cp.async double-buffers: **88.0 → 16.7 µs** per GDN layer.
- **Shared-expert gate+up were two 16-block launches** serializing on the stream. One `2·nx`-wide launch stages A once; each weight is still read exactly once, unlike shrinking `PF_BM`. **+2.1% pp.**

All default ON behind `SPARKINFER_PREFILL_WCACHE` / `_GEMM_SKINNY2` / `_MOE_QB_BN` / `_GEMM_PAIR` — one binary, A/B interleaved below. Scoped to the Qwen3.6 MoE hybrid; the cache releases its memory and disables itself if the prefill scratch arena ever fails.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 496.33 |
| after (this PR) | 495.62 |

Decode is untouched; −0.14% is session drift (every context lands ≥ 99.8% of main, guard is 98%).

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 8611.02 |
| after prefill (this PR) | 10844.64 |

```text
qwen3_gguf_bench <gguf> 128 sweep, ctxs 128/512/4k/16k/32k, medians of 5 interleaved runs, same box

ctx     pp before     pp after      pp        TTFT cut    decode before → after
512      8611.02      10844.64    +25.9%      -20.6%       496.33 → 495.62
4096    24725.92      25917.11     +4.8%       -4.6%       476.25 → 475.83
16384   26194.95      26517.15     +1.2%       -1.2%       478.78 → 478.52
32768   27411.72      27625.94     +0.8%       -0.8%       479.19 → 478.86

512-token TTFT 59.46 -> 47.21 ms.  Scored context is 512 (best gain).
```

`ctest` 9/9. `accuracy.sh` vs llama.cpp with the flags OFF and ON is **identical to every digit** (long passes top-1 1.0000 / 0.9922 / 0.9922, KL 0.00138 / 0.04776 / 0.16069) — it scores `qwen3_gguf_score`, the token loop, which this PR does not touch. The batched-prefill H3 veto (`qwen3_gguf_prefill_check` 512/16, bars 0.80 / 0.05) reads top-1 0.875–1.000 / KL ≤ 0.0075 over 6 flags-ON runs against 0.875–0.9375 / KL ≤ 0.0072 on main over 4 — the same range (the MoE down projection scatters through float `atomicAdd`, so neither side is run-to-run reproducible).