### PR TITLE
perf(dflash): accelerate mixed-layout draft attention

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -240,10 +240,14 @@ __global__ void k_gemv_batched(const bf16* __restrict__ x, const bf16* __restric
     const uint4* wrow4 = (const uint4*)(W + (size_t)n * K);
     const int K8 = K / 8;
     for (int k8 = lane; k8 < K8; k8 += 32) {
-        const bf16* wv = (const bf16*)&wrow4[k8];
+        // Materialize the wide packets in registers. Merely taking a bf16 pointer
+        // into wrow4 lets ptxas scalarize every unrolled element access.
+        const uint4 wp = wrow4[k8];
+        const bf16* wv = (const bf16*)&wp;
 #pragma unroll
         for (int b = 0; b < BATCH; b++) {
-            const bf16* xv = (const bf16*)&(((const uint4*)(x + (size_t)b * K))[k8]);
+            const uint4 xp = ((const uint4*)(x + (size_t)b * K))[k8];
+            const bf16* xv = (const bf16*)&xp;
 #pragma unroll
             for (int j = 0; j < 8; j++) acc[b] += b2f(wv[j]) * b2f(xv[j]);
         }
@@ -276,10 +280,12 @@ __global__ void k_gemv_batched_f32(const bf16* __restrict__ x, const bf16* __res
     const uint4* wrow4 = (const uint4*)(W + (size_t)n * K);
     const int K8 = K / 8;
     for (int k8 = lane; k8 < K8; k8 += 32) {
-        const bf16* wv = (const bf16*)&wrow4[k8];
+        const uint4 wp = wrow4[k8];
+        const bf16* wv = (const bf16*)&wp;
 #pragma unroll
         for (int b = 0; b < BATCH; b++) {
-            const bf16* xv = (const bf16*)&(((const uint4*)(x + (size_t)b * K))[k8]);
+            const uint4 xp = ((const uint4*)(x + (size_t)b * K))[k8];
+            const bf16* xv = (const bf16*)&xp;
 #pragma unroll
             for (int j = 0; j < 8; j++) acc[b] += b2f(wv[j]) * b2f(xv[j]);
         }

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -155,64 +155,85 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
         ov[i] = f2b(acc[i] * inv);
 }
 
-// DFlash's shipped Qwen3.6 draft shape is hd128 with a 16-token query block. Follow
-// the warp-per-query organization used by FlashAttention paths in llama.cpp/vLLM:
-// keep Q and the online-softmax output in registers and use shuffles for QK, avoiding
-// block-wide synchronization for every key. The four products are paired in the same
-// +64, +32 order as k_attn's 128-thread reduction before the +16..+1 shuffle tree.
-__global__ void k_attn_warp_hd128(
+// Split the key sequence across the warps of one CTA, then merge their online-
+// softmax states once. This keeps the hd128 Q/output state in registers and exposes
+// parallelism across KV tokens as the sequence grows.
+__global__ void k_attn_multiwarp_hd128(
     const bf16* __restrict__ q, const bf16* __restrict__ k,
     const bf16* __restrict__ v, bf16* __restrict__ out,
     int q_len, int kv_len, int n_q, int n_kv,
     int q_pos0, int k_pos0, int window, float scale) {
     const int qt = blockIdx.x;
     const int qh = blockIdx.y;
-    const int lane = threadIdx.x;
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    const int nwarps = blockDim.x >> 5;
     if (qt >= q_len || qh >= n_q) return;
 
     constexpr int D = 128;
     constexpr int E = D / 32;
+    const int base = lane * E;
     const int kv_h = qh / (n_q / n_kv);
-    const bf16* qv = q + ((size_t)qt * n_q + qh) * D;
-    bf16* ov = out + ((size_t)qt * n_q + qh) * D;
+    const bf16* qv = q + ((size_t)qt * n_q + qh) * D + base;
+    bf16* ov = out + ((size_t)qt * n_q + qh) * D + base;
     float qr[E], acc[E];
 #pragma unroll
     for (int e = 0; e < E; e++) {
-        qr[e] = b2f(qv[lane + e * 32]);
+        qr[e] = b2f(qv[e]);
         acc[e] = 0.f;
     }
 
     float max_s = -1e30f;
     float sum = 0.f;
     const int q_pos = q_pos0 + qt;
-    for (int t = 0; t < kv_len; t++) {
+    for (int t = warp; t < kv_len; t += nwarps) {
         const int k_pos = k_pos0 + t;
         if (window > 0 && (q_pos - k_pos) >= window) continue;
-        const bf16* kv = k + ((size_t)t * n_kv + kv_h) * D;
-        const float p0 = qr[0] * b2f(kv[lane]);
-        const float p1 = qr[1] * b2f(kv[lane + 32]);
-        const float p2 = qr[2] * b2f(kv[lane + 64]);
-        const float p3 = qr[3] * b2f(kv[lane + 96]);
-        float dot = __fadd_rn(__fadd_rn(p0, p2), __fadd_rn(p1, p3));
+        const bf16* kv = k + ((size_t)t * n_kv + kv_h) * D + base;
+        float dot = 0.f;
+#pragma unroll
+        for (int e = 0; e < E; e++) dot += qr[e] * b2f(kv[e]);
 #pragma unroll
         for (int off = 16; off > 0; off >>= 1)
             dot += __shfl_down_sync(0xffffffffu, dot, off);
-        dot = __shfl_sync(0xffffffffu, dot, 0);
-
-        const float score = dot * scale;
+        const float score = __shfl_sync(0xffffffffu, dot, 0) * scale;
         const float new_max = fmaxf(max_s, score);
         const float e1 = expf(max_s - new_max);
         const float e2 = expf(score - new_max);
         sum = sum * e1 + e2;
-        const bf16* vv = v + ((size_t)t * n_kv + kv_h) * D;
+        const bf16* vv = v + ((size_t)t * n_kv + kv_h) * D + base;
 #pragma unroll
-        for (int e = 0; e < E; e++)
-            acc[e] = acc[e] * e1 + e2 * b2f(vv[lane + e * 32]);
+        for (int e = 0; e < E; e++) acc[e] = acc[e] * e1 + e2 * b2f(vv[e]);
         max_s = new_max;
     }
-    const float inv = (sum > 0.f) ? (1.f / sum) : 0.f;
+
+    extern __shared__ float sm[];
+    float* s_max = sm;
+    float* s_sum = sm + nwarps;
+    float* s_acc = sm + 2 * nwarps;
+    if (lane == 0) {
+        s_max[warp] = max_s;
+        s_sum[warp] = sum;
+    }
 #pragma unroll
-    for (int e = 0; e < E; e++) ov[lane + e * 32] = f2b(acc[e] * inv);
+    for (int e = 0; e < E; e++) s_acc[(size_t)warp * D + base + e] = acc[e];
+    __syncthreads();
+    if (warp != 0) return;
+
+    float global_max = -1e30f;
+    for (int w = 0; w < nwarps; w++) global_max = fmaxf(global_max, s_max[w]);
+    float global_sum = 0.f;
+    float result[E] = {0.f, 0.f, 0.f, 0.f};
+    for (int w = 0; w < nwarps; w++) {
+        const float correction = expf(s_max[w] - global_max);
+        global_sum += s_sum[w] * correction;
+#pragma unroll
+        for (int e = 0; e < E; e++)
+            result[e] += s_acc[(size_t)w * D + base + e] * correction;
+    }
+    const float inv = global_sum > 0.f ? 1.f / global_sum : 0.f;
+#pragma unroll
+    for (int e = 0; e < E; e++) ov[e] = f2b(result[e] * inv);
 }
 
 // One warp per output row `n`, computing y[b][n] = sum_k x[b][k] * W[n][k] for all b in
@@ -302,6 +323,48 @@ __global__ void k_gemv_batched_f32(const bf16* __restrict__ x, const bf16* __res
     }
 }
 
+// Arithmetic-identical to kernels::gemv_f32_sk_kernel<bf16,8> for N<4096,
+// extended with grid.y for independent activation rows. Each CTA still maps to
+// one (batch, output) pair and uses the same per-lane K traversal, XOR warp
+// reduction, and ordered eight-way split sum as the individual launches.
+__global__ void k_gemv_rows_exact_s8(const bf16* __restrict__ x,
+                                     const bf16* __restrict__ W,
+                                     bf16* __restrict__ y, int rows, int N, int K) {
+    const int n = blockIdx.x;
+    const int batch = blockIdx.y;
+    const int split = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    if (n >= N || batch >= rows) return;
+    const uint4* w4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+    const uint4* x4 = reinterpret_cast<const uint4*>(x + (size_t)batch * K);
+    const int K8 = K / 8;
+    float acc = 0.f;
+    for (int i = split * 32 + lane; i < K8; i += 8 * 32) {
+        const uint4 wp = w4[i];
+        const uint4 xp = x4[i];
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wp);
+        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xp);
+#pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const float2 wf = __bfloat1622float2(wh[j]);
+            const float2 xf = __bfloat1622float2(xh[j]);
+            acc += wf.x * xf.x + wf.y * xf.y;
+        }
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1)
+        acc += __shfl_xor_sync(0xffffffffu, acc, off);
+    __shared__ float partial[8];
+    if (lane == 0) partial[split] = acc;
+    __syncthreads();
+    if (split == 0 && lane == 0) {
+        float result = 0.f;
+#pragma unroll
+        for (int s = 0; s < 8; s++) result += partial[s];
+        y[(size_t)batch * N + n] = f2b(result);
+    }
+}
+
 } // namespace
 
 void launch_add(const void* x, const void* y, void* out, int n, cudaStream_t stream) {
@@ -341,7 +404,10 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
     if (q_len <= 0 || kv_len <= 0) return;
     dim3 grid(q_len, n_q);
     if (d == 128) {
-        k_attn_warp_hd128<<<grid, 32, 0, stream>>>(
+        constexpr int THREADS = 512;
+        constexpr int NWARPS = THREADS / 32;
+        constexpr int SMEM = (2 * NWARPS + NWARPS * 128) * sizeof(float);
+        k_attn_multiwarp_hd128<<<grid, THREADS, SMEM, stream>>>(
             (const bf16*)q, (const bf16*)k, (const bf16*)v, (bf16*)out,
             q_len, kv_len, n_q, n_kv, q_pos0, k_pos0, window, scale);
         return;
@@ -359,6 +425,14 @@ void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
     dim3 grid((N + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
     k_gemv_batched<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
         (const bf16*)x, (const bf16*)W, (bf16*)y, N, K);
+}
+
+void launch_gemv_rows_exact(const void* x, const void* W, void* y,
+                            int rows, int N, int K, cudaStream_t stream) {
+    if (rows <= 0 || N <= 0) return;
+    dim3 grid(N, rows);
+    k_gemv_rows_exact_s8<<<grid, 8 * 32, 0, stream>>>(
+        (const bf16*)x, (const bf16*)W, (bf16*)y, rows, N, K);
 }
 
 void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -122,10 +122,22 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
             dot += q_s[i] * b2f(kv[i]);
         red[threadIdx.x] = dot;
         __syncthreads();
-        for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-            if (threadIdx.x < s) red[threadIdx.x] += red[threadIdx.x + s];
-            __syncthreads();
+        // Preserve the original 128-way reduction tree, but stop using block-wide
+        // barriers once only warp 0 remains. The +64 and +32 stages still go through
+        // shared memory; +16..+1 use the equivalent shuffle-down tree. This removes
+        // four barriers per KV token without perturbing draft logits / acceptance.
+        if (threadIdx.x < 64) red[threadIdx.x] += red[threadIdx.x + 64];
+        __syncthreads();
+        if (threadIdx.x < 32) red[threadIdx.x] += red[threadIdx.x + 32];
+        __syncthreads();
+        if (threadIdx.x < 32) {
+            float warp_sum = red[threadIdx.x];
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                warp_sum += __shfl_down_sync(0xffffffffu, warp_sum, off);
+            if (threadIdx.x == 0) red[0] = warp_sum;
         }
+        __syncthreads();
         float score = red[0] * scale;
         float new_max = fmaxf(max_s, score);
         float e1 = expf(max_s - new_max);
@@ -141,6 +153,66 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
     float inv = (sum > 0.f) ? (1.f / sum) : 0.f;
     for (int i = threadIdx.x; i < d; i += blockDim.x)
         ov[i] = f2b(acc[i] * inv);
+}
+
+// DFlash's shipped Qwen3.6 draft shape is hd128 with a 16-token query block. Follow
+// the warp-per-query organization used by FlashAttention paths in llama.cpp/vLLM:
+// keep Q and the online-softmax output in registers and use shuffles for QK, avoiding
+// block-wide synchronization for every key. The four products are paired in the same
+// +64, +32 order as k_attn's 128-thread reduction before the +16..+1 shuffle tree.
+__global__ void k_attn_warp_hd128(
+    const bf16* __restrict__ q, const bf16* __restrict__ k,
+    const bf16* __restrict__ v, bf16* __restrict__ out,
+    int q_len, int kv_len, int n_q, int n_kv,
+    int q_pos0, int k_pos0, int window, float scale) {
+    const int qt = blockIdx.x;
+    const int qh = blockIdx.y;
+    const int lane = threadIdx.x;
+    if (qt >= q_len || qh >= n_q) return;
+
+    constexpr int D = 128;
+    constexpr int E = D / 32;
+    const int kv_h = qh / (n_q / n_kv);
+    const bf16* qv = q + ((size_t)qt * n_q + qh) * D;
+    bf16* ov = out + ((size_t)qt * n_q + qh) * D;
+    float qr[E], acc[E];
+#pragma unroll
+    for (int e = 0; e < E; e++) {
+        qr[e] = b2f(qv[lane + e * 32]);
+        acc[e] = 0.f;
+    }
+
+    float max_s = -1e30f;
+    float sum = 0.f;
+    const int q_pos = q_pos0 + qt;
+    for (int t = 0; t < kv_len; t++) {
+        const int k_pos = k_pos0 + t;
+        if (window > 0 && (q_pos - k_pos) >= window) continue;
+        const bf16* kv = k + ((size_t)t * n_kv + kv_h) * D;
+        const float p0 = qr[0] * b2f(kv[lane]);
+        const float p1 = qr[1] * b2f(kv[lane + 32]);
+        const float p2 = qr[2] * b2f(kv[lane + 64]);
+        const float p3 = qr[3] * b2f(kv[lane + 96]);
+        float dot = __fadd_rn(__fadd_rn(p0, p2), __fadd_rn(p1, p3));
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1)
+            dot += __shfl_down_sync(0xffffffffu, dot, off);
+        dot = __shfl_sync(0xffffffffu, dot, 0);
+
+        const float score = dot * scale;
+        const float new_max = fmaxf(max_s, score);
+        const float e1 = expf(max_s - new_max);
+        const float e2 = expf(score - new_max);
+        sum = sum * e1 + e2;
+        const bf16* vv = v + ((size_t)t * n_kv + kv_h) * D;
+#pragma unroll
+        for (int e = 0; e < E; e++)
+            acc[e] = acc[e] * e1 + e2 * b2f(vv[lane + e * 32]);
+        max_s = new_max;
+    }
+    const float inv = (sum > 0.f) ? (1.f / sum) : 0.f;
+#pragma unroll
+    for (int e = 0; e < E; e++) ov[lane + e * 32] = f2b(acc[e] * inv);
 }
 
 // One warp per output row `n`, computing y[b][n] = sum_k x[b][k] * W[n][k] for all b in
@@ -262,6 +334,12 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                      cudaStream_t stream) {
     if (q_len <= 0 || kv_len <= 0) return;
     dim3 grid(q_len, n_q);
+    if (d == 128) {
+        k_attn_warp_hd128<<<grid, 32, 0, stream>>>(
+            (const bf16*)q, (const bf16*)k, (const bf16*)v, (bf16*)out,
+            q_len, kv_len, n_q, n_kv, q_pos0, k_pos0, window, scale);
+        return;
+    }
     int smem = (2 * d + 128) * (int)sizeof(float);
     k_attn<<<grid, 128, smem, stream>>>((const bf16*)q, (const bf16*)k, (const bf16*)v,
                                         (bf16*)out, q_len, kv_len, n_q, n_kv, d,

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -91,7 +91,7 @@ __global__ void k_rope(bf16* x, int seq, int n_heads, int d, int pos0, float the
 // One block per (q_token, q_head). Online softmax over kv_len.
 __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
                        int q_len, int kv_len, int n_q, int n_kv, int d,
-                       int q_pos0, int k_pos0, int window, float scale) {
+                       int q_pos0, int k_pos0, int window, bool causal, float scale) {
     int qt = blockIdx.x;
     int qh = blockIdx.y;
     if (qt >= q_len || qh >= n_q) return;
@@ -115,6 +115,7 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
 
     for (int t = 0; t < kv_len; t++) {
         const int k_pos = k_pos0 + t;
+        if (causal && k_pos > q_pos) continue;
         if (window > 0 && (q_pos - k_pos) >= window) continue;
         const bf16* kv = k + ((size_t)t * n_kv + kv_h) * d;
         float dot = 0.f;
@@ -162,7 +163,7 @@ __global__ void k_attn_multiwarp_hd128(
     const bf16* __restrict__ q, const bf16* __restrict__ k,
     const bf16* __restrict__ v, bf16* __restrict__ out,
     int q_len, int kv_len, int n_q, int n_kv,
-    int q_pos0, int k_pos0, int window, float scale) {
+    int q_pos0, int k_pos0, int window, bool causal, float scale) {
     const int qt = blockIdx.x;
     const int qh = blockIdx.y;
     const int lane = threadIdx.x & 31;
@@ -188,6 +189,7 @@ __global__ void k_attn_multiwarp_hd128(
     const int q_pos = q_pos0 + qt;
     for (int t = warp; t < kv_len; t += nwarps) {
         const int k_pos = k_pos0 + t;
+        if (causal && k_pos > q_pos) continue;
         if (window > 0 && (q_pos - k_pos) >= window) continue;
         const bf16* kv = k + ((size_t)t * n_kv + kv_h) * D + base;
         float dot = 0.f;
@@ -399,7 +401,7 @@ void launch_rope_seq(void* x, int seq, int n_heads, int d, int pos0, float theta
 
 void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                      int q_len, int kv_len, int n_q, int n_kv, int d,
-                     int q_pos0, int k_pos0, int window, float scale,
+                     int q_pos0, int k_pos0, int window, bool causal, float scale,
                      cudaStream_t stream) {
     if (q_len <= 0 || kv_len <= 0) return;
     dim3 grid(q_len, n_q);
@@ -409,13 +411,13 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
         constexpr int SMEM = (2 * NWARPS + NWARPS * 128) * sizeof(float);
         k_attn_multiwarp_hd128<<<grid, THREADS, SMEM, stream>>>(
             (const bf16*)q, (const bf16*)k, (const bf16*)v, (bf16*)out,
-            q_len, kv_len, n_q, n_kv, q_pos0, k_pos0, window, scale);
+            q_len, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale);
         return;
     }
     int smem = (2 * d + 128) * (int)sizeof(float);
     k_attn<<<grid, 128, smem, stream>>>((const bf16*)q, (const bf16*)k, (const bf16*)v,
                                         (bf16*)out, q_len, kv_len, n_q, n_kv, d,
-                                        q_pos0, k_pos0, window, scale);
+                                        q_pos0, k_pos0, window, causal, scale);
 }
 
 void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -35,6 +35,11 @@ void launch_rms(const void* x, const void* w, void* out, int rows, int cols,
 void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
                            cudaStream_t stream);
 
+// Exact batched form of the small-N S=8 split-K BF16 GEMV used by launch_gemv.
+// Collapses multiple row launches into grid.y without changing arithmetic order.
+void launch_gemv_rows_exact(const void* x, const void* W, void* y,
+                            int rows, int N, int K, cudaStream_t stream);
+
 // Same, with fp32 output/accumulate (for the LM head's logits).
 void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,
                                cudaStream_t stream);

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -6,12 +6,12 @@
 namespace sparkinfer {
 namespace dflash_kernels {
 
-// Non-causal GQA attention. q: [q_len, n_q, d], k/v: [kv_len, n_kv, d], out: [q_len, n_q, d] bf16.
+// GQA attention. q: [q_len, n_q, d], k/v: [kv_len, n_kv, d], out: [q_len, n_q, d] bf16.
 // q_pos0 / k_pos0 are absolute positions of index 0. If window > 0, mask keys with
 // (q_pos - k_pos) >= window (sliding window). scale = 1/sqrt(d).
 void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                      int q_len, int kv_len, int n_q, int n_kv, int d,
-                     int q_pos0, int k_pos0, int window, float scale,
+                     int q_pos0, int k_pos0, int window, bool causal, float scale,
                      cudaStream_t stream);
 
 // In-place RoPE on [seq, n_heads, d] bf16. positions[i] = pos0 + i.

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -471,9 +471,11 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // fc.weight is [H, n_cap*H] (out, in). Loop gemv per row.
     if (ctx_len > 0) {
         const bf16* th = (const bf16*)target_hidden;
-        for (int t = 0; t < ctx_len; t++) {
-            kernels::launch_gemv(th + (size_t)t * n_cap * H, s.fc,
-                                 s.target_proj + (size_t)t * H, H, n_cap * H, st);
+        if (ctx_len > 1) {
+            dflash_kernels::launch_gemv_rows_exact(th, s.fc, s.target_proj,
+                                                   ctx_len, H, n_cap * H, st);
+        } else {
+            kernels::launch_gemv(th, s.fc, s.target_proj, H, n_cap * H, st);
         }
         dflash_kernels::launch_rms(s.target_proj, s.hidden_norm, s.target_proj,
                                    ctx_len, H, c.rms_eps, st);
@@ -495,7 +497,13 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
         // Build k_new / v_new = cat(k_ctx, k_noise)
-        for (int t = 0; t < ctx_len; t++) {
+        if (ctx_len > 1) {
+            dflash_kernels::launch_gemv_rows_exact(s.target_proj, w.wk, s.k_new,
+                                                   ctx_len, kvdim, H, st);
+            dflash_kernels::launch_gemv_rows_exact(s.target_proj, w.wv, s.v_new,
+                                                   ctx_len, kvdim, H, st);
+        } else if (ctx_len == 1) {
+            const int t = 0;
             kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wk,
                                  s.k_new + (size_t)t * kvdim, kvdim, H, st);
             kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wv,
@@ -594,11 +602,13 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     bool head_done = false;
     if (head_mr && s.lm_head_type == 14 && s.head_q8) {          // native Q6_K shared head
         const size_t qrow = kernels::llama_q8_1_bytes(H);
-        for (int t = 0; t < B; t++)
+        // Row 0 is the already-known seed token; only rows 1..B-1 become draft
+        // proposals, so avoid quantizing and scoring the unused head row.
+        for (int t = 1; t < B; t++)
             kernels::launch_quantize_q8_1_blocks(s.xn + (size_t)t * H,
-                                                 (char*)s.head_q8 + (size_t)t * qrow, H, st);
-        head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(s.head_q8, s.lm_head, s.logits,
-                                                               V, H, B, st);
+                                                 (char*)s.head_q8 + (size_t)(t - 1) * qrow, H, st);
+        head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(
+            s.head_q8, s.lm_head, s.logits + V, V, H, B - 1, st);
     }
     if (!head_done) {
     if (fast16) {
@@ -614,7 +624,9 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         }
     }
     }
-    kernels::launch_argmax(s.logits, s.d_out, B, V, st);
+    kernels::launch_argmax(s.logits + (head_done ? V : 0),
+                           s.d_out + (head_done ? 1 : 0),
+                           head_done ? B - 1 : B, V, st);
     cu(cudaMemcpyAsync(s.h_out, s.d_out, B * sizeof(int), cudaMemcpyDeviceToHost, st), "argmax");
     cu(cudaStreamSynchronize(st), "draft sync");
     for (int t = 0; t < B; t++) out_argmax[t] = s.h_out[t];

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -553,9 +553,15 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         const int kv_len = past + new_len;
         const int window = (L < (int)c.sliding_layers.size() && c.sliding_layers[L])
                                ? c.sliding_window : 0;
+        static int mixed_causal = [] {
+            const char* e = getenv("SPARKINFER_DFLASH_MIXED_CAUSAL");
+            return (!e || e[0] != '0') ? 1 : 0;
+        }();
+        const bool causal = mixed_causal && L < (int)c.sliding_layers.size() &&
+                            c.sliding_layers[L];
         dflash_kernels::launch_attn_gqa(s.q, s.k_cache[L], s.v_cache[L], s.attn,
                                         B, kv_len, c.n_q_heads, c.n_kv_heads, d,
-                                        q_pos0, /*k_pos0_cache=*/0, window, scale, st);
+                                        q_pos0, /*k_pos0_cache=*/0, window, causal, scale, st);
 
         if (fast16) {
             dflash_kernels::launch_gemv_batched16(s.attn, w.wo, s.ao, H, qdim, st);


### PR DESCRIPTION
## Summary

Specialize DFlash draft attention for the model's mixed sliding/full-attention layout. Sliding layers apply causal masking while the full-attention layer remains bidirectional.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 298.37 |
| after (this PR) | 351.34 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
RTX 5090, sm_120, three interleaved 128-token runs, fixed evaluation prompt
main: 298.19, 298.37, 298.82 DFlash tok/s
this PR: 350.99, 351.69, 351.34 DFlash tok/s
median: 298.37 -> 351.34 tok/s (+17.75%)
SPEC_AGREE 64/64 = 1.0000
VERDICT PASS
```
