### PR TITLE
perf(dflash): overlap seed verification with fixed-depth draft

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1050,7 +1050,7 @@ __global__ void gemv_q6k_dp4a_kfixed_kernel(const si_block_q8_1* __restrict__ vy
 // (~416 MB per read at V=248k,K=2048 — far past L2, so it is real HBM traffic). Here each warp owns
 // one output row and walks its weight superblocks ONCE, accumulating all M dot products, so the
 // weight streams from HBM a single time and the M reuses hit L1. y is [M, N] row-major.
-template <typename OutT, int WPB, int NSUPER, int MMAX>
+template <typename OutT, int WPB, int NSUPER, int MMAX, int MFIXED = 0>
 __global__ void gemv_q6k_dp4a_multirow_kernel(const si_block_q8_1* __restrict__ vy,
                                               const unsigned char* __restrict__ W,
                                               OutT* __restrict__ y, int N, int M) {
@@ -1085,7 +1085,8 @@ __global__ void gemv_q6k_dp4a_multirow_kernel(const si_block_q8_1* __restrict__ 
             scv[i] = (int)sc[4 * i];
         }
         const si_block_q8_1* a0 = vy + (size_t)kbx * 8;
-        for (int m = 0; m < M; m++) {
+        #pragma unroll
+        for (int m = 0; m < (MFIXED ? MFIXED : M); m++) {
             const si_block_q8_1* row = a0 + (size_t)m * QPR;
             float sumf = 0.f;
             #pragma unroll
@@ -1097,13 +1098,15 @@ __global__ void gemv_q6k_dp4a_multirow_kernel(const si_block_q8_1* __restrict__ 
             acc[m] += wd * sumf;
         }
     }
-    for (int m = 0; m < M; m++) {
+    #pragma unroll
+    for (int m = 0; m < (MFIXED ? MFIXED : M); m++) {
         float a = acc[m];
         #pragma unroll
         for (int s = 16; s > 0; s >>= 1) a += __shfl_xor_sync(0xffffffff, a, s);
         if (lane == 0) gemv_write(y + (size_t)m * N + row, a);
     }
 }
+
 #ifndef _MSC_VER
 template __global__ void gemv_q6k_dp4a_kfixed_kernel<float, 8, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 #endif
@@ -1402,8 +1405,13 @@ bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream) {
     if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
     dim3 grid((N + 15) / 16);
-    gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+    if (M == 15) {
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16, 15><<<grid, 16 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+    } else {
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+    }
     return true;
 }
 

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1405,7 +1405,10 @@ bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream) {
     if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
     dim3 grid((N + 15) / 16);
-    if (M == 15) {
+    if (M == 3) {
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+    } else if (M == 15) {
         gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16, 15><<<grid, 16 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
     } else {

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -287,6 +287,59 @@ __global__ void k_gemv_batched(const bf16* __restrict__ x, const bf16* __restric
     }
 }
 
+// Route several projections that share x through one grid. Each warp still owns exactly one
+// output row and executes the same accumulation loop as k_gemv_batched; only launch boundaries
+// change, so Q/K/V and gate/up keep bit-identical arithmetic.
+template <int BATCH>
+__global__ void k_gemv_batched_fused3(
+        const bf16* __restrict__ x,
+        const bf16* __restrict__ W0, const bf16* __restrict__ W1,
+        const bf16* __restrict__ W2,
+        bf16* __restrict__ y0, bf16* __restrict__ y1, bf16* __restrict__ y2,
+        int N0, int N1, int N2, int K) {
+    const int warps_per_block = blockDim.x / 32;
+    const int global_n = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    const int total = N0 + N1 + N2;
+    if (global_n >= total) return;
+    const bf16* W;
+    bf16* y;
+    int N, n;
+    if (global_n < N0) {
+        W = W0; y = y0; N = N0; n = global_n;
+    } else if (global_n < N0 + N1) {
+        W = W1; y = y1; N = N1; n = global_n - N0;
+    } else {
+        W = W2; y = y2; N = N2; n = global_n - N0 - N1;
+    }
+    const int lane = threadIdx.x & 31;
+    float acc[BATCH];
+#pragma unroll
+    for (int b = 0; b < BATCH; b++) acc[b] = 0.f;
+    const uint4* wrow4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+    const int K8 = K / 8;
+    for (int k8 = lane; k8 < K8; k8 += 32) {
+        const uint4 wp = wrow4[k8];
+        const bf16* wv = reinterpret_cast<const bf16*>(&wp);
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) {
+            const uint4 xp = reinterpret_cast<const uint4*>(x + (size_t)b * K)[k8];
+            const bf16* xv = reinterpret_cast<const bf16*>(&xp);
+#pragma unroll
+            for (int j = 0; j < 8; j++) acc[b] += b2f(wv[j]) * b2f(xv[j]);
+        }
+    }
+#pragma unroll
+    for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1)
+            acc[b] += __shfl_down_sync(0xffffffffu, acc[b], off);
+    }
+    if (lane == 0) {
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) y[(size_t)b * N + n] = f2b(acc[b]);
+    }
+}
+
 // Same batched-GEMV shape as k_gemv_batched, but for the LM head: fp32 accumulate/output
 // (matching the precision the original per-row launch_gemv_q_f32/launch_gemv_f32 path used
 // for logits) and no BATCH-sized register cap on N (vocab is large, only grid.x scales).
@@ -337,6 +390,51 @@ __global__ void k_gemv_rows_exact_s8(const bf16* __restrict__ x,
     const int split = threadIdx.x >> 5;
     const int lane = threadIdx.x & 31;
     if (n >= N || batch >= rows) return;
+    const uint4* w4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+    const uint4* x4 = reinterpret_cast<const uint4*>(x + (size_t)batch * K);
+    const int K8 = K / 8;
+    float acc = 0.f;
+    for (int i = split * 32 + lane; i < K8; i += 8 * 32) {
+        const uint4 wp = w4[i];
+        const uint4 xp = x4[i];
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wp);
+        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xp);
+#pragma unroll
+        for (int j = 0; j < 4; j++) {
+            const float2 wf = __bfloat1622float2(wh[j]);
+            const float2 xf = __bfloat1622float2(xh[j]);
+            acc += wf.x * xf.x + wf.y * xf.y;
+        }
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1)
+        acc += __shfl_xor_sync(0xffffffffu, acc, off);
+    __shared__ float partial[8];
+    if (lane == 0) partial[split] = acc;
+    __syncthreads();
+    if (split == 0 && lane == 0) {
+        float result = 0.f;
+#pragma unroll
+        for (int s = 0; s < 8; s++) result += partial[s];
+        y[(size_t)batch * N + n] = f2b(result);
+    }
+}
+
+__global__ void k_gemv_rows_exact_s8_fused2(
+        const bf16* __restrict__ x,
+        const bf16* __restrict__ W0, const bf16* __restrict__ W1,
+        bf16* __restrict__ y0, bf16* __restrict__ y1,
+        int rows, int N0, int N1, int K) {
+    const int global_n = blockIdx.x;
+    const int batch = blockIdx.y;
+    if (global_n >= N0 + N1 || batch >= rows) return;
+    const bool second = global_n >= N0;
+    const int n = second ? global_n - N0 : global_n;
+    const int N = second ? N1 : N0;
+    const bf16* W = second ? W1 : W0;
+    bf16* y = second ? y1 : y0;
+    const int split = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
     const uint4* w4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
     const uint4* x4 = reinterpret_cast<const uint4*>(x + (size_t)batch * K);
     const int K8 = K / 8;
@@ -429,12 +527,45 @@ void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
         (const bf16*)x, (const bf16*)W, (bf16*)y, N, K);
 }
 
+void launch_gemv_batched16_fused3(const void* x,
+                                  const void* W0, const void* W1, const void* W2,
+                                  void* y0, void* y1, void* y2,
+                                  int N0, int N1, int N2, int K, cudaStream_t stream) {
+    const int total = N0 + N1 + N2;
+    if (total <= 0) return;
+    constexpr int WARPS_PER_BLOCK = 4;
+    dim3 grid((total + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
+    k_gemv_batched_fused3<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
+        (const bf16*)x, (const bf16*)W0, (const bf16*)W1, (const bf16*)W2,
+        (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K);
+}
+
+void launch_gemv_batched16_fused2(const void* x,
+                                  const void* W0, const void* W1,
+                                  void* y0, void* y1,
+                                  int N0, int N1, int K, cudaStream_t stream) {
+    launch_gemv_batched16_fused3(x, W0, W1, nullptr, y0, y1, nullptr,
+                                 N0, N1, 0, K, stream);
+}
+
 void launch_gemv_rows_exact(const void* x, const void* W, void* y,
                             int rows, int N, int K, cudaStream_t stream) {
     if (rows <= 0 || N <= 0) return;
     dim3 grid(N, rows);
     k_gemv_rows_exact_s8<<<grid, 8 * 32, 0, stream>>>(
         (const bf16*)x, (const bf16*)W, (bf16*)y, rows, N, K);
+}
+
+void launch_gemv_rows_exact_fused2(const void* x,
+                                   const void* W0, const void* W1,
+                                   void* y0, void* y1,
+                                   int rows, int N0, int N1, int K,
+                                   cudaStream_t stream) {
+    if (rows <= 0 || N0 + N1 <= 0) return;
+    dim3 grid(N0 + N1, rows);
+    k_gemv_rows_exact_s8_fused2<<<grid, 8 * 32, 0, stream>>>(
+        (const bf16*)x, (const bf16*)W0, (const bf16*)W1,
+        (bf16*)y0, (bf16*)y1, rows, N0, N1, K);
 }
 
 void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -34,11 +34,24 @@ void launch_rms(const void* x, const void* w, void* out, int rows, int cols,
 // x: [16,K] bf16, W: [N,K] bf16 (native "out,in" layout, same as a single-row GEMV), y: [16,N] bf16.
 void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
                            cudaStream_t stream);
+void launch_gemv_batched16_fused2(const void* x,
+                                  const void* W0, const void* W1,
+                                  void* y0, void* y1,
+                                  int N0, int N1, int K, cudaStream_t stream);
+void launch_gemv_batched16_fused3(const void* x,
+                                  const void* W0, const void* W1, const void* W2,
+                                  void* y0, void* y1, void* y2,
+                                  int N0, int N1, int N2, int K, cudaStream_t stream);
 
 // Exact batched form of the small-N S=8 split-K BF16 GEMV used by launch_gemv.
 // Collapses multiple row launches into grid.y without changing arithmetic order.
 void launch_gemv_rows_exact(const void* x, const void* W, void* y,
                             int rows, int N, int K, cudaStream_t stream);
+void launch_gemv_rows_exact_fused2(const void* x,
+                                   const void* W0, const void* W1,
+                                   void* y0, void* y1,
+                                   int rows, int N0, int N1, int K,
+                                   cudaStream_t stream);
 
 // Same, with fp32 output/accumulate (for the LM head's logits).
 void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -491,17 +491,20 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
 
         // Q from noise, K/V from cat(target, noise)
         if (fast16) {
-            dflash_kernels::launch_gemv_batched16(s.xn, w.wq, s.q, qdim, H, st);
+            dflash_kernels::launch_gemv_batched16_fused3(
+                s.xn, w.wq, w.wk, w.wv,
+                s.q, s.k_new + (size_t)ctx_len * kvdim,
+                s.v_new + (size_t)ctx_len * kvdim,
+                qdim, kvdim, kvdim, H, st);
         } else {
             for (int t = 0; t < B; t++)
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
         // Build k_new / v_new = cat(k_ctx, k_noise)
         if (ctx_len > 1) {
-            dflash_kernels::launch_gemv_rows_exact(s.target_proj, w.wk, s.k_new,
-                                                   ctx_len, kvdim, H, st);
-            dflash_kernels::launch_gemv_rows_exact(s.target_proj, w.wv, s.v_new,
-                                                   ctx_len, kvdim, H, st);
+            dflash_kernels::launch_gemv_rows_exact_fused2(
+                s.target_proj, w.wk, w.wv, s.k_new, s.v_new,
+                ctx_len, kvdim, kvdim, H, st);
         } else if (ctx_len == 1) {
             const int t = 0;
             kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wk,
@@ -509,12 +512,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wv,
                                  s.v_new + (size_t)t * kvdim, kvdim, H, st);
         }
-        if (fast16) {
-            dflash_kernels::launch_gemv_batched16(s.xn, w.wk, s.k_new + (size_t)ctx_len * kvdim,
-                                                  kvdim, H, st);
-            dflash_kernels::launch_gemv_batched16(s.xn, w.wv, s.v_new + (size_t)ctx_len * kvdim,
-                                                  kvdim, H, st);
-        } else {
+        if (!fast16) {
             for (int t = 0; t < B; t++) {
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wk,
                                      s.k_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
@@ -573,8 +571,8 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
 
         dflash_kernels::launch_rms(s.h, w.post_norm, s.hn, B, H, c.rms_eps, st);
         if (fast16) {
-            dflash_kernels::launch_gemv_batched16(s.hn, w.gate, s.gate, I, H, st);
-            dflash_kernels::launch_gemv_batched16(s.hn, w.up, s.up, I, H, st);
+            dflash_kernels::launch_gemv_batched16_fused2(
+                s.hn, w.gate, w.up, s.gate, s.up, I, I, H, st);
         } else {
             for (int t = 0; t < B; t++) {
                 kernels::launch_gemv(s.hn + (size_t)t * H, w.gate, s.gate + (size_t)t * I, I, H, st);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -456,6 +456,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     const int qdim = c.n_q_heads * c.head_dim;
     const int kvdim = c.n_kv_heads * c.head_dim;
     const int d = c.head_dim;
+    constexpr int kProposalDepth = 3;
     const float scale = 1.f / sqrtf((float)d);
     const int past = s.seq_len;
     // The fixed-size (block_size) projections below can use a batched-GEMV kernel that reads
@@ -606,13 +607,14 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     bool head_done = false;
     if (head_mr && s.lm_head_type == 14 && s.head_q8) {          // native Q6_K shared head
         const size_t qrow = kernels::llama_q8_1_bytes(H);
-        // Row 0 is the already-known seed token; only rows 1..B-1 become draft
-        // proposals, so avoid quantizing and scoring the unused head row.
-        for (int t = 1; t < B; t++)
+        // Score only the proposal rows the verifier can consume. The remaining diffusion rows
+        // still participate in the backbone, but streaming the 248k-row Q6_K head for them is
+        // wasted once verification is capped below the full block.
+        for (int t = 1; t <= kProposalDepth; t++)
             kernels::launch_quantize_q8_1_blocks(s.xn + (size_t)t * H,
                                                  (char*)s.head_q8 + (size_t)(t - 1) * qrow, H, st);
         head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(
-            s.head_q8, s.lm_head, s.logits + V, V, H, B - 1, st);
+            s.head_q8, s.lm_head, s.logits + V, V, H, kProposalDepth, st);
     }
     if (!head_done) {
     if (fast16) {
@@ -630,10 +632,12 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     }
     kernels::launch_argmax(s.logits + (head_done ? V : 0),
                            s.d_out + (head_done ? 1 : 0),
-                           head_done ? B - 1 : B, V, st);
-    cu(cudaMemcpyAsync(s.h_out, s.d_out, B * sizeof(int), cudaMemcpyDeviceToHost, st), "argmax");
+                           head_done ? kProposalDepth : B, V, st);
+    cu(cudaMemcpyAsync(s.h_out, s.d_out,
+                       (head_done ? kProposalDepth + 1 : B) * sizeof(int),
+                       cudaMemcpyDeviceToHost, st), "argmax");
     cu(cudaStreamSynchronize(st), "draft sync");
-    for (int t = 0; t < B; t++) out_argmax[t] = s.h_out[t];
+    for (int t = 0; t <= kProposalDepth; t++) out_argmax[t] = s.h_out[t];
 
     // Advance past the just-appended ctx+noise, then crop to `pos0` (= block start).
     // Matches z-lab dflash: past_key_values_draft.update(...) then .crop(start).

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -34,6 +34,7 @@
 #include <fstream>
 #include <limits>
 #include <algorithm>
+#include <thread>
 
 namespace sparkinfer {
 
@@ -1850,32 +1851,62 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     int th_len = n;
 
     std::vector<int> block(B), posterior(B), draft_ids(B);
+    constexpr int kProposalDepth = 3;
+    bf16* th_scratch = nullptr;
+    const int row_stride = dflash_hidden_row_stride();
+    if (cudaMalloc(&th_scratch, (size_t)B * row_stride * sizeof(bf16)) != cudaSuccess) {
+        close_session(sid);
+        set_dflash_capture(false, {}, 0);
+        draft.reset();
+        return out;
+    }
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
         block[0] = next;
         for (int i = 1; i < B; i++) block[i] = mask_id;
 
-        if (!draft.forward_block(target_hidden, th_len, block.data(), start, draft_ids.data(), s.stream)) {
+        // The target overwrites dflash_hidden while capturing verify row zero. Preserve the
+        // accepted suffix before running that target forward concurrently with the independent
+        // draft stream. The initial full-context buffer is separate and needs no copy.
+        const void* draft_hidden = target_hidden;
+        if (target_hidden == s.dflash_hidden) {
+            cu(cudaMemcpyAsync(th_scratch, target_hidden,
+                               (size_t)th_len * row_stride * sizeof(bf16),
+                               cudaMemcpyDeviceToDevice, s.stream), "dflash overlap stash");
+            cu(cudaStreamSynchronize(s.stream), "dflash overlap stash sync");
+            draft_hidden = th_scratch;
+        }
+
+        int p0 = -1;
+        set_dflash_capture_row(0);
+        std::thread verify0([&] { p0 = forward_token(block[0], start, true); });
+        const bool draft_ok = draft.forward_block(
+            draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr);
+        verify0.join();
+        if (!draft_ok) {
             fprintf(stderr, "[dflash] draft forward failed at start=%d\n", start);
             break;
         }
-        for (int i = 1; i < B; i++) block[i] = draft_ids[i];
+        for (int i = 1; i <= kProposalDepth; i++) block[i] = draft_ids[i];
 
         // Incremental verify with early-exit: forward only the accepted prefix, stopping at the
         // first rejected proposal. forward_token advances GDN state + KV per token, so after
         // block[0..keep-1] the recurrent state and KV sit exactly at start+keep -- no snapshot /
         // restore / KV-truncate / replay needed (greedy speculative decoding is exact). Rejected
         // proposals (block[keep..B-1]) are never forwarded, saving ~B-keep target forwards/step.
-        int accept = 0, keep = 0;
-        bool vfail = false;
-        for (int i = 0; i < B; i++) {
-            set_dflash_capture_row(i);
-            const int p = forward_token(block[i], start + i, true);
-            if (p < 0) { vfail = true; break; }
-            posterior[i] = p;
-            accept = i;
-            keep = i + 1;
-            if (i + 1 < B && block[i + 1] != p) break;   // first mismatch -> reject the rest
+        int accept = 0, keep = 1;
+        bool vfail = p0 < 0;
+        posterior[0] = p0;
+        if (!vfail && block[1] == p0) {
+            for (int i = 1; i <= kProposalDepth; i++) {
+                set_dflash_capture_row(i);
+                const int p = forward_token(block[i], start + i, true);
+                if (p < 0) { vfail = true; break; }
+                posterior[i] = p;
+                accept = i;
+                keep = i + 1;
+                if (i < kProposalDepth && block[i + 1] != p) break;
+            }
         }
         if (vfail) { fprintf(stderr, "[dflash] verify failed at start=%d\n", start); break; }
         // forward_token() synchronizes after sampling, so the accepted capture rows are already
@@ -1911,6 +1942,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         stats->decode_s = std::chrono::duration<double>(t_end - t_decode0).count();
     }
     close_session(sid);
+    if (th_scratch) cudaFree(th_scratch);
     set_dflash_capture(false, {}, 0);
     draft.reset();
     return out;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1850,10 +1850,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     int th_len = n;
 
     std::vector<int> block(B), posterior(B), draft_ids(B);
-    bf16* th_scratch = nullptr;
-    const int row_stride = dflash_hidden_row_stride();
-    cu(cudaMalloc(&th_scratch, (size_t)B * row_stride * sizeof(bf16)), "th scratch");
-
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
         block[0] = next;
@@ -1882,13 +1878,10 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             if (i + 1 < B && block[i + 1] != p) break;   // first mismatch -> reject the rest
         }
         if (vfail) { fprintf(stderr, "[dflash] verify failed at start=%d\n", start); break; }
-        // Accepted hiddens are in dflash_hidden rows 0..keep-1 (captured above); hand them to the
-        // next draft block via th_scratch and stash into the context buffer by global position.
-        cu(cudaMemcpyAsync(th_scratch, s.dflash_hidden,
-                           (size_t)keep * row_stride * sizeof(bf16),
-                           cudaMemcpyDeviceToDevice, s.stream), "th keep");
-        for (int i = 0; i < keep; i++) dflash_stash_capture(start + i);
-        cu(cudaStreamSynchronize(s.stream), "th sync");
+        // forward_token() synchronizes after sampling, so the accepted capture rows are already
+        // stable. The draft consumes only this newly accepted suffix; its KV cache retains all
+        // earlier context. Hand the capture buffer over directly instead of copying it to a second
+        // scratch allocation, stashing another unused full-context copy, and synchronizing again.
 
         bool stop = false;
         for (int i = 0; i < keep && (int)out.size() < max_new; i++) {
@@ -1906,7 +1899,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         start += keep;
         accept_sum += (double)keep;
         steps++;
-        target_hidden = th_scratch;
+        target_hidden = s.dflash_hidden;
         th_len = keep;
         if (gov) gov->pace();
     }
@@ -1917,7 +1910,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         stats->ttft_s = std::chrono::duration<double>(t1 - t0).count();
         stats->decode_s = std::chrono::duration<double>(t_end - t_decode0).count();
     }
-    cudaFree(th_scratch);
     close_session(sid);
     set_dflash_capture(false, {}, 0);
     draft.reset();

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -217,6 +217,10 @@ struct Qwen35Model::Impl {
 
     // DFlash speculative decoding (target-side primitives).
     DFlashDraftModel* dflash_draft = nullptr;
+    // Preserve the native Q6_K head for the draft's multi-row MMVQ while the
+    // target uses its faster, narrower Q4_K requantized copy.
+    const void* dflash_lm_head = nullptr;
+    int dflash_lm_head_type = 0;
     bool dflash_capture = false;
     std::vector<int> dflash_layer_ids;
     int dflash_n_cap = 0;
@@ -1804,7 +1808,9 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     const int B = dc.block_size;
     const int mask_id = dc.mask_token_id;
 
-    draft.set_shared_weights(embed_weights(), lm_head_weights(), lm_head_quant_type(),
+    draft.set_shared_weights(embed_weights(),
+                             s.dflash_lm_head ? s.dflash_lm_head : lm_head_weights(),
+                             s.dflash_lm_head ? s.dflash_lm_head_type : lm_head_quant_type(),
                              s.cfg.vocab, s.cfg.hidden);
     set_dflash_capture(true, dc.target_layer_ids, B);
 
@@ -2244,7 +2250,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             return layer_index(name) >= ssm_out_min_layer;
         return false;
     };
-    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K", q35_dense9b_requant_default);
+    const bool dual_dflash_lm_head = env_enabled(
+        "SPARKINFER_DFLASH_DUAL_LMHEAD",
+        q36_ud_requant_default && !q35_dense9b_requant_default);
+    const bool req_lm_q4 = env_enabled("SPARKINFER_LMHEAD_REQUANT_Q4K",
+                                       q35_dense9b_requant_default || dual_dflash_lm_head);
     auto attn_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
         if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8))
@@ -2293,6 +2303,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     s.w.embed_tokens = dense("token_embd.weight", false);     // [vocab,hidden] as-is
     s.w.final_norm   = dense("output_norm.weight", false);
     const char* lm = g.tensor("output.weight") ? "output.weight" : "token_embd.weight";  // tied fallback
+    const GGUFTensor* lm_tensor = g.tensor(lm);
+    if (dual_dflash_lm_head && req_lm_q4 && lm_tensor &&
+        (lm_tensor->ggml_type == 14 || lm_tensor->ggml_type == 8)) {
+        s.dflash_lm_head = dev_quant(lm, s.dflash_lm_head_type);
+    }
     s.w.lm_head = lm_w(lm, s.w.lm_head_type);                 // native [vocab,hidden] for GEMV
     if (!s.w.embed_tokens || !s.w.final_norm || !s.w.lm_head) return false;
 


### PR DESCRIPTION
## Summary

Run seed-token verification concurrently with the fixed-depth draft on independent CUDA streams. Preserve accepted capture rows in a scratch buffer, score only three proposal rows, and specialize the native Q6_K head for that exact depth.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 321.62 |
| after (this PR) | 391.14 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
RTX 5090, sm_120, 64-token held-out DFlash run, identical prompt
main: 321.7222, 321.6221, 322.3202 DFlash tok/s
this PR: 391.7939, 391.1441, 391.0544 DFlash tok/s
median: 321.62 -> 391.14 tok/s (+21.61%)
held-out exactness: 99/99 across four seeds
Qwen3.5 decode/prefill guard: PASS
```
