### PR TITLE
feat(eval): Polaris attestation for DFlash evals + non-root SSH box support

### DIFF
--- a/eval/polaris/judge.py
+++ b/eval/polaris/judge.py
@@ -80,8 +80,12 @@ def collect_metadata(args, result_json: dict) -> dict:
 
     # --- Code provenance ---
     repo = os.environ.get("EVAL_REPO", "https://github.com/gittensor-ai-lab/sparkinfer")
-    commit = _git("rev-parse HEAD")
-    scoring_commit = _git("rev-parse origin/main")
+    # Bug (pre-existing): _git()'s cwd defaults to /root/sparkinfer, so without passing
+    # args.sparkinfer_root explicitly this silently returns "" on any other checkout path
+    # (e.g. a bare-metal box with a non-root home dir) — never noticed because every prior
+    # caller happened to run on a vast.ai box at exactly /root/sparkinfer.
+    commit = _git("rev-parse HEAD", cwd=args.sparkinfer_root)
+    scoring_commit = _git("rev-parse origin/main", cwd=args.sparkinfer_root)
     build_hash = compute_build_hash(args.build_dir) if args.build_dir else ""
 
     meta["code_repo"] = repo
@@ -173,6 +177,9 @@ def main():
                     help="Eval script to run (wrapper mode)")
     ap.add_argument("--from-stdin", action="store_true",
                     help="Read RESULT_JSON from stdin instead of running eval")
+    ap.add_argument("--dflash", action="store_true",
+                    help="DFlash mode: stdin is a plain JSON dict (pr_dflash_bot.py's "
+                         "eval_dflash_on_box() result), not a RESULT_JSON-prefixed AR verdict")
     ap.add_argument("--model-file", default="",
                     help="Path to primary model GGUF (for SHA256)")
     ap.add_argument("--guard-model-file", default="",
@@ -185,6 +192,53 @@ def main():
 
     # Allow --build-dir to override the git working directory
     git_root = args.sparkinfer_root
+
+    if args.dflash:
+        try:
+            dflash_result = json.loads(sys.stdin.read())
+        except json.JSONDecodeError as e:
+            print(f">> [polaris-judge] ERROR: invalid --dflash JSON on stdin: {e}", file=sys.stderr)
+            sys.exit(1)
+        meta = collect_metadata(args, {})
+        builder = AttestationBuilder()
+        builder.set_code(
+            repo=meta["code_repo"], commit=meta["code_commit"],
+            build_hash=meta["code_build_hash"],
+            scoring_scripts_commit=meta["code_scoring_scripts_commit"],
+        )
+        builder.set_references(
+            model_sha256=meta["model_sha256"], model_file=meta["model_file"],
+            guard_model_sha256=meta["guard_model_sha256"], guard_model_file=meta["guard_model_file"],
+            llamacpp_commit=meta["llamacpp_commit"], eval_seed=meta["eval_seed"],
+        )
+        builder.set_environment(
+            eval_mode="dflash", decode_tokens=meta["decode_tokens"],
+            gpu_name=meta["gpu_name"], gpu_arch=meta["gpu_arch"],
+            clocks_pinned=meta["clocks_pinned"], clock_mhz=meta["clock_mhz"],
+            clock_spread_mhz=meta["clock_spread_mhz"], pin_target_mhz=meta["pin_target_mhz"],
+            cuda_version=meta["cuda_version"], driver_version=meta["driver_version"],
+        )
+        builder.set_dflash_measurements(dflash_result)
+        pr_tps = dflash_result.get("pr_dflash_tps") or 0
+        main_tps = dflash_result.get("main_dflash_tps") or 0
+        builder.set_verdict({
+            "model": "dflash",
+            "label": dflash_result.get("label", "?"),
+            "pass": dflash_result.get("pass", False),
+            "tps": pr_tps,
+            "delta_tps": pr_tps - main_tps,
+            "pct_over_frontier": dflash_result.get("delta_pct"),
+            "reason": dflash_result.get("reason"),
+        })
+        builder.set_timestamp()
+        attestation = builder.build()
+        print(f"POLARIS_ATTESTATION {json.dumps(attestation, separators=(',', ':'))}")
+        try:
+            with open("/tmp/polaris_attestation.json", "w") as f:
+                json.dump(attestation, f, indent=2)
+        except Exception:
+            pass
+        return
 
     # ---- Get RESULT_JSON ----
     if args.from_stdin:

--- a/eval/polaris/receipt.py
+++ b/eval/polaris/receipt.py
@@ -29,6 +29,7 @@ import datetime
 import hashlib
 import json
 import os
+import re
 from typing import Any, Dict, List, Optional, Tuple
 
 # ---- Ed25519 via cryptography (already installed on bot + eval boxes) ----
@@ -345,6 +346,33 @@ class AttestationBuilder:
         if guard_data:
             self._measurements["guard"] = guard_data
 
+    def set_dflash_measurements(self, dflash_result: dict):
+        """Extract DFlash + Qwen3.5/3.6 no-regression guard measurements
+        (pr_dflash_bot.py's eval_dflash_on_box() result dict), not a RESULT_JSON verdict —
+        the DFlash bot scores same-box PR-vs-main directly rather than against a frontier."""
+        guard36 = dflash_result.get("guard36") or {}
+        guard35 = dflash_result.get("guard35") or {}
+        self._measurements = {
+            "dflash": {
+                "pr_dflash_tps": _f(dflash_result.get("pr_dflash_tps")),
+                "main_dflash_tps": _f(dflash_result.get("main_dflash_tps")),
+                "pr_ar_tps": _f(dflash_result.get("pr_ar_tps")),
+                "main_ar_tps": _f(dflash_result.get("main_ar_tps")),
+                "mean_accept": _f(dflash_result.get("mean_accept")),
+                "spec_agree": dflash_result.get("spec_agree", ""),
+                "speedup_vs_main": _f(dflash_result.get("speedup_vs_main")),
+                "speedup_vs_ar": _f(dflash_result.get("speedup_vs_ar")),
+            },
+            "qwen_guard": {
+                "ok": bool(dflash_result.get("guard_ok", True)),
+                "problems": dflash_result.get("guard_problems") or [],
+                "qwen36": {str(k): {kk: _f(vv) for kk, vv in v.items()}
+                           for k, v in guard36.items()},
+                "qwen35": {str(k): {kk: _f(vv) for kk, vv in v.items()}
+                           for k, v in guard35.items()},
+            },
+        }
+
     def set_verdict(self, result_json: dict):
         """Extract verdict fields from RESULT_JSON."""
         self._verdict = {
@@ -434,10 +462,18 @@ class ReceiptValidator:
             if k not in a.get("environment", {}):
                 issues.append(f"missing attestation.environment.{k}")
 
-        # Measurements
+        # Measurements — two shapes: AR/bidir bot (measurements.primary, ctx sweep + top1/kl)
+        # or DFlash bot (measurements.dflash + measurements.qwen_guard, no frontier ctx sweep).
         meas = a.get("measurements", {})
-        if "primary" not in meas:
-            issues.append("missing attestation.measurements.primary")
+        if "dflash" in meas:
+            d = meas["dflash"]
+            for k in ["pr_dflash_tps", "main_dflash_tps", "spec_agree"]:
+                if k not in d:
+                    issues.append(f"missing attestation.measurements.dflash.{k}")
+            if "qwen_guard" not in meas:
+                issues.append("missing attestation.measurements.qwen_guard")
+        elif "primary" not in meas:
+            issues.append("missing attestation.measurements.primary or .dflash")
         else:
             p = meas["primary"]
             for k in ["ctx_128_tps", "ctx_512_tps", "ctx_4096_tps", "top1", "kl"]:
@@ -478,6 +514,12 @@ class ReceiptValidator:
             val = primary.get(key)
             if val is not None and isinstance(val, (int, float)) and val < 0:
                 issues.append(f"measurements.primary.{key} is negative: {val}")
+
+        dflash = meas.get("dflash", {})
+        for key in ["pr_dflash_tps", "main_dflash_tps", "pr_ar_tps", "main_ar_tps"]:
+            val = dflash.get(key)
+            if val is not None and isinstance(val, (int, float)) and val < 0:
+                issues.append(f"measurements.dflash.{key} is negative: {val}")
 
         # If clocks_pinned is true, pin_target_mhz should be > 0
         if e.get("clocks_pinned") and not e.get("pin_target_mhz", 0):
@@ -703,7 +745,8 @@ class ReceiptValidator:
         still produces a valid attestation receipt.
         """
         reject = self.attestation.get("verdict", {}).get("pass") is False
-        gate_markers = ("correctness gate", "primary guard", "guard model")
+        gate_markers = ("correctness gate", "primary guard", "guard model",
+                        "DFlash accuracy", "qwen3.5/3.6 guard")
         relevant = [
             line for line in results
             if not (reject and any(m in line for m in gate_markers))
@@ -712,8 +755,11 @@ class ReceiptValidator:
 
     def _recheck_gates(self) -> List[str]:
         """Re-check correctness gates from attested measurements."""
+        meas = self.attestation.get("measurements", {})
+        if "dflash" in meas:
+            return self._recheck_dflash_gates(meas)
         results = []
-        primary = self.attestation.get("measurements", {}).get("primary", {})
+        primary = meas.get("primary", {})
         top1 = primary.get("top1", 0)
         kl = primary.get("kl", 99)
 
@@ -749,6 +795,33 @@ class ReceiptValidator:
                 results.append("✓ guard model: accuracy OK")
             else:
                 results.append("✗ guard model: accuracy REGRESSION")
+
+        return results
+
+    def _recheck_dflash_gates(self, meas: dict) -> List[str]:
+        """DFlash bot's gates: SPEC_AGREE accuracy (dflash_accuracy.sh's own VERDICT PASS
+        already enforces this before the eval proceeds — this is a consistency recheck, not
+        an independent gate) and the Qwen3.5/3.6 no-regression guard."""
+        results = []
+        spec_agree = (meas.get("dflash", {}) or {}).get("spec_agree", "") or ""
+        m = re.search(r"=\s*([0-9.]+)\s*$", spec_agree.strip())
+        if m:
+            ratio = float(m.group(1))
+            if ratio >= 0.999:
+                results.append(f"✓ DFlash accuracy: SPEC_AGREE={ratio:.4f}")
+            else:
+                results.append(f"✗ DFlash accuracy: SPEC_AGREE={ratio:.4f} (<1.0)")
+        else:
+            results.append(f"⚠ DFlash accuracy: could not parse SPEC_AGREE ('{spec_agree}')")
+
+        guard = meas.get("qwen_guard") or {}
+        if guard.get("ok", True):
+            results.append("✓ qwen3.5/3.6 guard: no regression (decode + prefill)")
+        else:
+            for p in guard.get("problems") or []:
+                results.append(f"✗ qwen3.5/3.6 guard: {p}")
+            if not guard.get("problems"):
+                results.append("✗ qwen3.5/3.6 guard: FAILED")
 
         return results
 

--- a/eval/polaris/scoring.py
+++ b/eval/polaris/scoring.py
@@ -12,6 +12,7 @@ this exact output — hardware-attested scoring.
 """
 
 import json
+import re
 import sys
 
 TOP1_BAR = 0.90
@@ -137,9 +138,56 @@ def score(result: dict) -> dict:
     return final
 
 
+def score_dflash(result: dict) -> dict:
+    """Score a DFlash bot result (measurements.dflash / measurements.qwen_guard shape, from
+    pr_dflash_bot.py's eval_dflash_on_box()) — distinct schema from the AR bot's primary/guard
+    RESULT_JSON, so score() above (which reads primary.top1/kl) can't handle it: those fields
+    don't exist in this shape, silently default to 0/99, and score() falls through to an
+    identical REJECT regardless of the real input — which is exactly what produced a constant
+    result_sha256 across genuinely different DFlash evals before this function existed.
+
+    Gate: DFlash accuracy (SPEC_AGREE must be exact) + the Qwen3.5/3.6 no-regression guard.
+    """
+    dflash = result.get("dflash") or {}
+    guard = result.get("qwen_guard") or {}
+
+    if not dflash:
+        return {
+            "label": "REJECT",
+            "pass": False,
+            "reason": "dflash measurements missing (infra error)",
+        }
+
+    spec_agree = str(dflash.get("spec_agree", ""))
+    m = re.search(r"=\s*([0-9.]+)\s*$", spec_agree.strip())
+    ratio = float(m.group(1)) if m else 0.0
+    acc_ok = ratio >= 0.999
+    guard_ok = bool(guard) and bool(guard.get("ok", False))
+
+    final = dict(dflash)
+    final["guard"] = guard
+
+    if not acc_ok:
+        final["label"] = "REJECT"
+        final["pass"] = False
+        final["reason"] = f"DFlash accuracy gate failed: SPEC_AGREE={ratio:.4f} (need >= 0.999)"
+        return final
+    if not guard_ok:
+        reasons = guard.get("problems") or ["qwen3.5/3.6 guard produced no verdict (infra error)"]
+        final["label"] = "REJECT"
+        final["pass"] = False
+        final["reason"] = "qwen3.5/qwen3.6 no-regression guard failed: " + "; ".join(reasons[:6])
+        return final
+
+    final["label"] = "ok"
+    final["pass"] = True
+    final["reason"] = f"DFlash accuracy (SPEC_AGREE={ratio:.4f}) + qwen3.5/3.6 guard both pass"
+    return final
+
+
 def main():
     result = load_result()
-    verdict = score(result)
+    verdict = score_dflash(result) if "dflash" in result else score(result)
     print(json.dumps(verdict))
 
 

--- a/eval/pr_dflash_bot.py
+++ b/eval/pr_dflash_bot.py
@@ -19,6 +19,7 @@ import re
 import shlex
 import subprocess
 import sys
+import tempfile
 import time
 
 HERE = os.path.dirname(os.path.abspath(__file__))
@@ -28,7 +29,7 @@ if HERE not in sys.path:
 if ROOT not in sys.path:
     sys.path.insert(0, ROOT)
 
-from ssh_box import ssh_box_enabled, ssh_box_endpoint  # noqa: E402
+from ssh_box import ssh_box_enabled, ssh_box_endpoint, ssh_box_user  # noqa: E402
 
 # Reuse shared helpers from the AR bot (labels, greenlight, denylist, …).
 import pr_eval_bot as arb  # noqa: E402
@@ -71,6 +72,14 @@ Q36_GUARD_MODELS_DIR = os.path.dirname(DEFAULT_GGUF) or DEFAULT_MODELS_DIR
 Q36_GUARD_MODEL_REPO = os.environ.get("PRIMARY36_MODEL_REPO", "unsloth/Qwen3.6-35B-A3B-GGUF")
 Q36_GUARD_TOK_REPO = os.environ.get("PRIMARY36_TOK_REPO", "Qwen/Qwen3.6-35B-A3B")
 Q35_GUARD_MODELS_DIR = os.environ.get("QWYTHOS_MODELS_DIR", "/workspace/models35")
+_Q35_QUANT_FILES = {
+    "Q4_K_M": "Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf",
+    "Q8_0": "Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf",
+    "BF16": "Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf",
+}
+Q35_GUARD_MODEL_FILE = _Q35_QUANT_FILES.get(
+    os.environ.get("PRIMARY_QUANT", "Q4_K_M").upper(), _Q35_QUANT_FILES["Q4_K_M"]
+)
 GUARD_CTX_LABEL = {0: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k",
                    65536: "64k", 131072: "128k"}
 
@@ -83,6 +92,24 @@ AUTOMERGE_BLOCK = {
 SCORES_FILE = os.path.expanduser(
     os.environ.get("DFLASH_SCORES_FILE", "~/.sparkinfer_dflash_scores.json")
 )
+
+# Polaris verifiable-compute receipts — same policy as the AR bot (on by default; TDX via
+# POLARIS_API_KEY when configured, else Ed25519 fallback via SPARKINFER_POLARIS_PRIVATE_KEY).
+POLARIS_ENABLED = os.environ.get("POLARIS", "1") != "0"
+POLARIS_API_KEY = os.environ.get("POLARIS_API_KEY", "")
+_POLARIS_PUBKEY_FILE = os.path.join(HERE, "polaris", "sparkinfer_eval.pub")
+
+
+def _load_polaris_pubkey():
+    try:
+        with open(_POLARIS_PUBKEY_FILE) as f:
+            for line in f:
+                line = line.strip()
+                if line and not line.startswith("#"):
+                    return line
+    except Exception:
+        pass
+    return ""
 
 
 def _load_scores():
@@ -174,8 +201,11 @@ def resolve_ssh(instance_id: int):
     return ip, port
 
 
-def ssh_run(host, port, cmd, timeout=7200):
+def ssh_run(host, port, cmd, timeout=7200, stdin_data=None):
     key = os.environ.get("SSH_KEY", os.path.expanduser("~/.ssh/speedy"))
+    # vast.ai images run as root; a bare-metal SSH box (EVAL_TRANSPORT=ssh) may have a
+    # non-root default account instead — EVAL_SSH_USER overrides (defaults to root).
+    user = ssh_box_user() if ssh_box_enabled() else "root"
     return subprocess.run(
         [
             "ssh", "-i", key,
@@ -183,9 +213,9 @@ def ssh_run(host, port, cmd, timeout=7200):
             "-o", "BatchMode=yes",
             "-o", "ServerAliveInterval=30",
             "-o", "ServerAliveCountMax=40",
-            "-p", str(port), f"root@{host}", cmd,
+            "-p", str(port), f"{user}@{host}", cmd,
         ],
-        capture_output=True, text=True, timeout=timeout,
+        capture_output=True, text=True, timeout=timeout, input=stdin_data,
     )
 
 
@@ -395,6 +425,159 @@ def check_qwen_guard(pr: dict, main: dict, tol: float = REGRESS_TOL):
     return (len(problems) == 0, problems)
 
 
+def push_eval_polaris(host, port):
+    """Sync eval/polaris/ (judge.py + receipt.py) to the box from a TRUSTED source before
+    running attestation — mirrors vast_eval.py's push_bench_scripts() protection of the
+    scoring harness. The box's git checkout is whatever ref is being evaluated (the PR's own
+    branch, or main); letting a PR's own commits supply the code that produces its own
+    attestation would let it fake a clean receipt, defeating the entire point of an
+    independently-verifiable one. Prefers origin/main (fetched fresh — a stale local dev tree
+    would be just as untrustworthy a source of truth as the PR itself); set
+    SPARKINFER_USE_LOCAL_POLARIS=1 to force the local working tree instead, for testing
+    eval/polaris changes before they're merged. Returns True on success."""
+    use_local = os.environ.get("SPARKINFER_USE_LOCAL_POLARIS", "").strip().lower() in ("1", "true", "yes")
+    tar_data = None
+    source = "local checkout"
+    extract_root = os.path.join(REMOTE_REPO, "eval")
+    if not use_local:
+        subprocess.run(["git", "fetch", "-q", "origin", "main"], cwd=ROOT, capture_output=True, timeout=120)
+        arch = subprocess.run(
+            ["git", "archive", "--format=tar.gz", "origin/main", "eval/polaris"],
+            cwd=ROOT, capture_output=True, timeout=120,
+        )
+        if arch.returncode == 0 and arch.stdout:
+            tar_data = arch.stdout
+            source = "origin/main"
+            extract_root = REMOTE_REPO
+    if tar_data is None:
+        polaris_dir = os.path.join(HERE, "polaris")
+        if os.path.isdir(polaris_dir):
+            tar = subprocess.run(["tar", "-C", HERE, "-czf", "-", "polaris"],
+                                  capture_output=True, timeout=120)
+            if tar.returncode == 0 and tar.stdout:
+                tar_data = tar.stdout
+                source = "local checkout"
+                extract_root = os.path.join(REMOTE_REPO, "eval")
+    if tar_data is None:
+        print(">> WARN: no eval/polaris archive — attestation unavailable this run")
+        return False
+    key = os.environ.get("SSH_KEY", os.path.expanduser("~/.ssh/speedy"))
+    user = ssh_box_user() if ssh_box_enabled() else "root"
+    tmp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(suffix=".tgz", delete=False) as tmp:
+            tmp.write(tar_data)
+            tmp_path = tmp.name
+        scp = subprocess.run(
+            ["scp", "-P", str(port), "-i", key, "-o", "StrictHostKeyChecking=accept-new",
+             "-o", "BatchMode=yes", tmp_path, f"{user}@{host}:/tmp/si_polaris.tgz"],
+            capture_output=True, text=True, timeout=120,
+        )
+        if scp.returncode != 0:
+            print(f">> WARN: eval/polaris scp failed (rc={scp.returncode}): {scp.stderr[-500:]}")
+            return False
+        extract = (
+            f"mkdir -p {shlex.quote(extract_root)} && "
+            f"tar -xzf /tmp/si_polaris.tgz -C {shlex.quote(extract_root)} && "
+            "rm -f /tmp/si_polaris.tgz"
+        )
+        r = ssh_run(host, port, extract, timeout=60)
+        if r.returncode != 0:
+            print(f">> WARN: eval/polaris extract failed (rc={r.returncode}): {(r.stdout + r.stderr)[-500:]}")
+            return False
+        print(f">> eval/polaris synced from {source} (trusted attestation code)")
+        return True
+    except subprocess.TimeoutExpired:
+        print(">> WARN: eval/polaris sync timed out — attestation unavailable this run")
+        return False
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def collect_polaris_attestation(host, port, res: dict, pr_ref: str):
+    """Run judge.py --dflash on the box to assemble an unsigned attestation from the eval
+    result, then sign it (TDX via POLARIS_API_KEY, else Ed25519 fallback) — same policy as the
+    AR bot. Returns {"attestation":..., "receipt":...} (receipt omitted if unsigned), or None
+    if Polaris is disabled. Never raises — a Polaris failure must not block the DFlash verdict
+    itself, only omit its receipt.
+
+    Two correctness fixes baked in here:
+    - eval_dflash_on_box() evaluates the PR ref first, then main second, and leaves the box
+      checked out on whichever ran last (main) — so judge.py's `git rev-parse HEAD` would
+      silently attest to the BASELINE commit, not the PR commit the verdict is actually about.
+      Re-checkout pr_ref explicitly before invoking judge.py.
+    - build_polaris_receipt_from_attestation()'s nonce is sha256(commit + model_sha256 +
+      eval_seed); with eval_seed empty (the default), re-evaluating the same commit+model
+      combo — which DFlash re-evals routinely do — produces an IDENTICAL nonce every time.
+      Observed in testing: two attestations with genuinely different measurements came back
+      with the same tdx.result_sha256, consistent with Polaris treating a repeated nonce as
+      a dedup/idempotency key and replaying a cached quote rather than a fresh one. Force a
+      unique eval_seed per call so the nonce — and therefore the quote — can never repeat.
+    """
+    if not POLARIS_ENABLED:
+        return None
+    # Order matters: checkout pr_ref FIRST (so git HEAD is the commit being attested), THEN
+    # sync the trusted judge.py on top of it (so the PR's own — possibly stale or, if malicious,
+    # deliberately broken — copy of eval/polaris/ never runs). Reversed, the checkout would
+    # clobber the just-synced trusted files right back to whatever the PR ref itself carries.
+    checkout_cmd = (
+        f"cd {shlex.quote(REMOTE_REPO)} && "
+        f"git fetch -q origin {shlex.quote(pr_ref)} && git checkout -qf FETCH_HEAD"
+    )
+    r0 = ssh_run(host, port, checkout_cmd, timeout=60)
+    if r0.returncode != 0:
+        print(f">> Polaris: could not checkout {pr_ref} for attestation (rc={r0.returncode}): "
+              f"{(r0.stderr or '')[-300:]}")
+        return None
+    if not push_eval_polaris(host, port):
+        return None
+    q35_gguf = f"{Q35_GUARD_MODELS_DIR}/{Q35_GUARD_MODEL_FILE}"
+    q36_gguf = f"{Q36_GUARD_MODELS_DIR}/{Q36_GUARD_MODEL_FILE}"
+    eval_seed = f"dflash-{int(time.time() * 1000)}"
+    cmd = (
+        f"cd {shlex.quote(REMOTE_REPO)} && "
+        f"SPARKINFER_EVAL_SEED={shlex.quote(eval_seed)} python3 eval/polaris/judge.py --dflash "
+        f"--sparkinfer-root {shlex.quote(REMOTE_REPO)} "
+        f"--build-dir {shlex.quote(REMOTE_REPO)}/build/runtime "
+        f"--model-file {shlex.quote(q36_gguf)} "
+        f"--guard-model-file {shlex.quote(q35_gguf)}"
+    )
+    try:
+        r = ssh_run(host, port, cmd, timeout=120, stdin_data=json.dumps(res))
+    except Exception as e:
+        print(f">> Polaris judge SSH failed: {e}")
+        return None
+    if r.returncode != 0:
+        print(f">> Polaris judge failed (rc={r.returncode}): {(r.stderr or '')[-500:]}")
+        return None
+    polaris_line = next((l for l in (r.stdout or "").splitlines()
+                         if l.startswith("POLARIS_ATTESTATION ")), None)
+    if not polaris_line:
+        print(">> Polaris judge produced no attestation")
+        return None
+    try:
+        attestation = json.loads(polaris_line[len("POLARIS_ATTESTATION "):])
+    except json.JSONDecodeError as e:
+        print(f">> Polaris attestation JSON parse failed: {e}")
+        return None
+    privkey = arb._load_polaris_privkey()
+    if not POLARIS_API_KEY and not privkey:
+        print(">> Polaris: attestation collected but NOT signed (no key configured)")
+        return {"attestation": attestation}
+    try:
+        receipt = arb.build_polaris_receipt_from_attestation(
+            attestation, api_key=POLARIS_API_KEY, privkey=privkey, pubkey=_load_polaris_pubkey(),
+        )
+        return {"attestation": attestation, "receipt": receipt}
+    except Exception as e:
+        print(f">> Polaris signing failed: {e}")
+        return {"attestation": attestation}
+
+
 def eval_dflash_on_box(host, port, pr_ref: str):
     """Run PR accuracy+bench then main bench with same prompt ids. Returns result dict."""
     print(f">> DFlash eval on box: PR ref={pr_ref}")
@@ -425,7 +608,7 @@ def eval_dflash_on_box(host, port, pr_ref: str):
         label = "REJECT"
         passed = False
         reason = "qwen3.5/qwen3.6 no-regression guard failed: " + "; ".join(guard_problems[:6])
-    return {
+    res = {
         "ok": True,
         "label": label,
         "pass": passed and label != "REJECT",
@@ -442,7 +625,13 @@ def eval_dflash_on_box(host, port, pr_ref: str):
         "speedup_vs_ar": round(pr["dflash_tps"] / pr["ar_tps"], 3) if pr.get("ar_tps") else 0,
         "guard_ok": guard_ok,
         "guard_problems": guard_problems,
+        "guard36": pr.get("guard36"),
+        "guard35": pr.get("guard35"),
     }
+    polaris = collect_polaris_attestation(host, port, res, pr_ref)
+    if polaris:
+        res["polaris"] = polaris
+    return res
 
 
 def format_comment(commit: str, res: dict) -> str:
@@ -473,6 +662,18 @@ def format_comment(commit: str, res: dict) -> str:
         problems = res.get("guard_problems") or []
         guard_row = "| Qwen3.5/3.6 guard | ❌ **REGRESSED** — DFlash score voided |\n"
         guard_row += "".join(f"| &nbsp;&nbsp;↳ | `{p}` |\n" for p in problems[:8])
+    polaris = res.get("polaris") or {}
+    receipt = polaris.get("receipt")
+    if receipt:
+        rtype = "TDX (Intel hardware attestation)" if receipt.get("attestation_type") == "tdx-quote" \
+            else "Ed25519 (SparkInfer key)"
+        polaris_row = (
+            f"| Polaris receipt | `{receipt.get('receipt_id', '?')[:16]}…` — {rtype} |\n"
+        )
+    elif polaris.get("attestation"):
+        polaris_row = "| Polaris receipt | collected, not signed (no key configured) |\n"
+    else:
+        polaris_row = ""
     return (
         f"{marker}\n## sparkinfer dflash auto-eval — `eval-dflash:{lab}`\n\n"
         f"| metric | value |\n|---|---|\n"
@@ -485,6 +686,7 @@ def format_comment(commit: str, res: dict) -> str:
         f"| mean accept τ | {res.get('mean_accept') or 0:.3f} |\n"
         f"| accuracy | {res.get('spec_agree') or 'VERDICT PASS'} |\n"
         f"{guard_row}"
+        f"{polaris_row}"
         f"| commit | `{commit[:9]}` |\n\n"
         f"{res.get('reason') or ''}\n\n"
         "<sub>Scored on pinned RTX 5090 vs same-box `origin/main` DFlash, gated by a "
@@ -597,7 +799,72 @@ def reconcile_dflash_merge_labels(repo, dry_run=False):
         try_auto_merge_dflash(repo, winner)
 
 
-def apply_result(repo, num, commit, res, dry_run=False):
+def upload_dflash_eval_log(repo, num, title, oid, res):
+    """Commit the DFlash eval result (+ Polaris receipt/attestation) to sparkinfer-log — the
+    same public ledger the AR bot writes to (gittensor-ai-lab/sparkinfer-log), just under a
+    dflash-prefixed run id so it can't collide with an AR-bot entry for the same PR number.
+    Best-effort: never blocks or raises — a log-upload failure must not affect the verdict
+    already posted to the PR."""
+    try:
+        rid = f"dflash-{int(num):04d}-{oid[:7]}"
+        arb._ensure_log_repo()
+        rundir = os.path.join(arb.LOG_DIR, "runs", rid)
+        os.makedirs(rundir, exist_ok=True)
+        polaris = res.get("polaris") or {}
+        receipt = polaris.get("receipt")
+        result = {
+            "id": rid, "pr": int(num), "title": title,
+            "url": f"https://github.com/{repo}/pull/{num}", "commit": oid[:7],
+            "eval_mode": "dflash",
+            "label": res.get("label"), "pass": res.get("pass"), "reason": res.get("reason"),
+            "delta_pct": res.get("delta_pct"),
+            "pr_dflash_tps": res.get("pr_dflash_tps"), "main_dflash_tps": res.get("main_dflash_tps"),
+            "pr_ar_tps": res.get("pr_ar_tps"), "main_ar_tps": res.get("main_ar_tps"),
+            "speedup_vs_main": res.get("speedup_vs_main"), "speedup_vs_ar": res.get("speedup_vs_ar"),
+            "mean_accept": res.get("mean_accept"), "spec_agree": res.get("spec_agree"),
+            "guard_ok": res.get("guard_ok"), "guard_problems": res.get("guard_problems"),
+            "gpu": "RTX 5090 (sm_120)", "date": arb.datetime.date.today().isoformat(),
+        }
+        if receipt:
+            result["polaris"] = True
+            result["polaris_receipt_id"] = receipt.get("receipt_id")
+        json.dump(result, open(os.path.join(rundir, "result.json"), "w"), indent=2)
+        if polaris.get("attestation"):
+            json.dump(polaris["attestation"], open(os.path.join(rundir, "attestation.json"), "w"), indent=2)
+        if receipt:
+            json.dump(receipt, open(os.path.join(rundir, "receipt.json"), "w"), indent=2)
+        ipath = os.path.join(arb.LOG_DIR, "index.json")
+        idx = json.load(open(ipath)) if os.path.exists(ipath) else []
+        idx = [e for e in idx if e.get("id") != rid]
+        idx_entry = {"id": rid, "pr": int(num), "title": title, "label": res.get("label"),
+                     "delta_pct": res.get("delta_pct"), "eval_mode": "dflash", "date": result["date"]}
+        if receipt:
+            idx_entry["polaris"] = True
+            idx_entry["polaris_receipt_id"] = receipt.get("receipt_id", "")[:16]
+        idx.append(idx_entry)
+        idx.sort(key=lambda x: x["id"])
+        json.dump(idx, open(ipath, "w"), indent=2)
+        subprocess.run(["git", "-C", arb.LOG_DIR, "add", "-A"], check=True)
+        msg = f"dflash-eval: #{num} {oid[:7]} -> eval-dflash:{res.get('label')}"
+        if receipt:
+            msg += f" + polaris {receipt.get('receipt_id', '?')[:16]}"
+        commit = subprocess.run(["git", "-C", arb.LOG_DIR, "commit", "-q", "-m", msg], check=False)
+        if commit.returncode != 0:
+            print(">> dflash eval-log upload skipped: nothing to commit")
+            return None
+        push = subprocess.run(["git", "-C", arb.LOG_DIR, "push", "-q"], check=False)
+        if push.returncode != 0:
+            print(f">> dflash eval-log push failed (rc={push.returncode})")
+            return None
+        url = arb.LOG_PAGE + rid
+        print(f">> dflash eval log: {url}")
+        return url
+    except Exception as e:
+        print(f">> dflash eval-log upload failed: {e}")
+        return None
+
+
+def apply_result(repo, num, commit, res, title="", dry_run=False):
     body = format_comment(commit, res)
     label = res.get("label") if res.get("ok") else "REJECT"
     if not res.get("ok"):
@@ -611,6 +878,8 @@ def apply_result(repo, num, commit, res, dry_run=False):
     strip_dflash_eval_labels(repo, num)
     arb.add_label(repo, num, f"{EVAL_PREFIX}{label}")
     arb.gh(["pr", "comment", str(num), "-R", repo, "--body", body])
+    if res.get("ok"):
+        upload_dflash_eval_log(repo, num, title, commit, res)
     if res.get("ok") and res.get("delta_pct") is not None:
         scores = _load_scores()
         scores[str(num)] = {
@@ -699,7 +968,7 @@ def main():
 
         ref = f"pull/{num}/head"
         # Same-repo branches can use headRefName; pull/N/head always works.
-        pending.append((num, head, short, ref))
+        pending.append((num, head, short, ref, pr.get("title", "")))
 
     if not pending:
         reconcile_dflash_merge_labels(args.repo, dry_run=args.dry_run)
@@ -724,15 +993,16 @@ def main():
         print("done — dflash labels only (GPU down).")
         return
 
-    print(f">> SSH root@{host}:{port}")
+    _ssh_user = ssh_box_user() if ssh_box_enabled() else "root"
+    print(f">> SSH {_ssh_user}@{host}:{port}")
 
-    for num, head, short, ref in pending:
+    for num, head, short, ref, title in pending:
         print(f"PR #{num} @ {short}: evaluating DFlash '{ref}' …")
         try:
             res = eval_dflash_on_box(host, port, ref)
         except Exception as e:
             res = {"ok": False, "reason": f"exception: {e}"}
-        apply_result(args.repo, num, head or short, res, dry_run=False)
+        apply_result(args.repo, num, head or short, res, title=title, dry_run=False)
 
     reconcile_dflash_merge_labels(args.repo, dry_run=False)
     print("done — dflash eval pass complete.")

--- a/eval/run_dflash_cron.sh
+++ b/eval/run_dflash_cron.sh
@@ -62,10 +62,10 @@ fi
 gpu_ready() {
   local key="${SSH_KEY:-$HOME/.ssh/speedy}"
   if [ "${EVAL_TRANSPORT:-vast}" = "ssh" ]; then
-    local host="${EVAL_SSH_HOST:-}" port="${EVAL_SSH_PORT:-22}"
+    local host="${EVAL_SSH_HOST:-}" port="${EVAL_SSH_PORT:-22}" user="${EVAL_SSH_USER:-root}"
     [ -n "$host" ] || return 1
     ssh -i "$key" -o BatchMode=yes -o ConnectTimeout=10 \
-        -o StrictHostKeyChecking=accept-new -p "$port" "root@$host" 'true' 2>/dev/null
+        -o StrictHostKeyChecking=accept-new -p "$port" "$user@$host" 'true' 2>/dev/null
     return $?
   fi
   local iid="${VAST_INSTANCE:-}"

--- a/eval/ssh_box.py
+++ b/eval/ssh_box.py
@@ -51,3 +51,10 @@ def ssh_box_enabled():
     if vast_enabled():
         return False
     return ssh_box_endpoint() is not None
+
+
+def ssh_box_user():
+    """Remote SSH user for the fixed box. vast.ai images run as root, so that's the
+    default; a bare-metal box with a non-root account (e.g. cloud-init default users)
+    overrides via EVAL_SSH_USER. Only meaningful when ssh_box_enabled()."""
+    return os.environ.get("EVAL_SSH_USER", "root").strip() or "root"


### PR DESCRIPTION
## Summary
- DFlash evaluations now get a Polaris receipt (TDX hardware attestation via `POLARIS_API_KEY`, Ed25519 fallback otherwise) — same policy as the AR/bidir bot, gated by the Qwen3.5/3.6 no-regression guard from #680. Shown in the PR comment and pushed to `sparkinfer-log`.
- Adds `EVAL_SSH_USER` (defaults to `root`, existing vast.ai configs unaffected) so `EVAL_TRANSPORT=ssh` works against a bare-metal box with a non-root default account, not just vast.ai's always-root images.

## Three real bugs found and fixed getting this working end-to-end against live hardware
All three reproduced and confirmed fixed against a real GPU box + the real Polaris service — not hypothetical.

1. **`judge.py` ran whatever was checked out on the box** — a PR's own branch, or main — never local files. Added `push_eval_polaris()` to sync the trusted `eval/polaris/` from `origin/main` before every attestation, mirroring `vast_eval.py`'s existing `bench/scripts` protection: a PR must never be able to supply the code that produces its own receipt.
2. **Wrong-commit binding + reused nonce.** The sync above initially ran in the wrong order and clobbered itself. Separately, the attestation was binding to the *baseline* commit being compared against, not the PR commit actually being scored, because `judge.py`'s `git rev-parse HEAD` ran after `eval_dflash_on_box()` had already left the box checked out on main. Also found the signing nonce (`sha256(commit+model_sha+eval_seed)`) was identical across re-evaluations of the same commit — forced a unique `eval_seed` per attestation call.
3. **The big one: Polaris's enclave-side `scoring.py` didn't understand the DFlash measurement shape.** It only knew the AR bot's `primary`/`guard` schema; for DFlash's `dflash`/`qwen_guard` shape it silently defaulted `top1=0, kl=99` and always emitted the exact same fixed REJECT string regardless of input. Every DFlash TDX attestation was cryptographically valid but semantically meaningless — a real quote, hardware-attesting to a canned constant. Added a DFlash-aware scoring path; confirmed live that `result_sha256` now actually varies with content.

## Proof
PR #681's re-evaluation produced a correctly commit-bound, content-bound, Intel DCAP-verified receipt:
- [PR comment](https://github.com/gittensor-ai-lab/sparkinfer/pull/681#issuecomment-5209624985)
- [sparkinfer-log entry](https://gittensor-ai-lab.github.io/sparkinfer-log/?run=dflash-0681-caeb013)

## Test plan
- [x] `py_compile` on all changed files, `bash -n` on `run_dflash_cron.sh`
- [x] Unit-tested `AttestationBuilder.set_dflash_measurements()` + `ReceiptValidator` round-trip (build → sign → verify) for both a clean pass and a REJECTed/guard-failed case
- [x] Live end-to-end against a real box (SSH+stdin+judge.py) and the real Polaris TDX service, iterated until all three bugs above were found and fixed
- [x] Verified `push_eval_polaris()`'s extraction path for both the `origin/main` (git archive) and local-override (`SPARKINFER_USE_LOCAL_POLARIS=1`) sources
- [ ] Not yet exercised through a full cron/`main()` run with `AUTOMERGE=1` (only tested via direct function calls, deliberately avoiding GitHub side effects during iteration)
