### PR TITLE
perf(dflash): narrow the draft diffusion block and cut its weight and launch cost

### DIFF
--- a/kernels/csrc/cuda/fused/model_ops.cu
+++ b/kernels/csrc/cuda/fused/model_ops.cu
@@ -92,6 +92,51 @@ __global__ void argmax_p2_kernel(int* __restrict__ out_id) {
     if (t == 0) out_id[0] = s_idx[0];
 }
 
+// Row-parallel form of the two-pass scan. The n_rows>1 path is one block per row: with the DFlash
+// draft's handful of proposal rows that pins a 248k-entry scan to a few of the 5090's 170 SMs.
+// Same split as the single-row decode path, with the row on grid.y and per-row partials.
+// argmax_merge is associative and picks max-value/min-index, so the verdict is identical to
+// argmax_kernel's regardless of how the scan is partitioned.
+static constexpr int ARGMAX_ROWS_MAX = 16;
+__device__ float g_argmax_rpv[ARGMAX_ROWS_MAX * ARGMAX_BLOCKS];
+__device__ int   g_argmax_rpi[ARGMAX_ROWS_MAX * ARGMAX_BLOCKS];
+
+__global__ void argmax_rows_p1_kernel(const float* __restrict__ logits, int vocab) {
+    const int row = blockIdx.y;
+    const float* L = logits + (size_t)row * vocab;
+    const int tid = blockIdx.x * blockDim.x + threadIdx.x;
+    const int stride = blockDim.x * gridDim.x;
+    __shared__ float s_val[256];
+    __shared__ int   s_idx[256];
+    float best = -1e30f; int bi = 0;
+    for (int v = tid; v < vocab; v += stride) if (L[v] > best) { best = L[v]; bi = v; }
+    s_val[threadIdx.x] = best; s_idx[threadIdx.x] = bi;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s)
+            argmax_merge(s_val[threadIdx.x], s_idx[threadIdx.x], s_val[threadIdx.x + s], s_idx[threadIdx.x + s]);
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) {
+        g_argmax_rpv[row * ARGMAX_BLOCKS + blockIdx.x] = s_val[0];
+        g_argmax_rpi[row * ARGMAX_BLOCKS + blockIdx.x] = s_idx[0];
+    }
+}
+
+__global__ void argmax_rows_p2_kernel(int* __restrict__ out_id) {
+    __shared__ float s_val[ARGMAX_BLOCKS];
+    __shared__ int   s_idx[ARGMAX_BLOCKS];
+    const int row = blockIdx.x, t = threadIdx.x;
+    s_val[t] = g_argmax_rpv[row * ARGMAX_BLOCKS + t];
+    s_idx[t] = g_argmax_rpi[row * ARGMAX_BLOCKS + t];
+    __syncthreads();
+    for (int s = ARGMAX_BLOCKS / 2; s > 0; s >>= 1) {
+        if (t < s) argmax_merge(s_val[t], s_idx[t], s_val[t + s], s_idx[t + s]);
+        __syncthreads();
+    }
+    if (t == 0) out_id[row] = s_idx[0];
+}
+
 __global__ void decode_feedback_kernel(int* __restrict__ scalars,
                                        const int* __restrict__ out_id) {
     scalars[0] = out_id[0];
@@ -114,6 +159,9 @@ void launch_argmax(const float* logits, int* out_id, int n_rows, int vocab, cuda
     if (n_rows == 1) {   // decode: parallelize the single-row scan across all SMs
         argmax_p1_kernel<<<ARGMAX_BLOCKS, 256, 0, stream>>>(logits, vocab);
         argmax_p2_kernel<<<1, ARGMAX_BLOCKS, 0, stream>>>(out_id);
+    } else if (n_rows > 1 && n_rows <= ARGMAX_ROWS_MAX) {
+        argmax_rows_p1_kernel<<<dim3(ARGMAX_BLOCKS, n_rows), 256, 0, stream>>>(logits, vocab);
+        argmax_rows_p2_kernel<<<n_rows, ARGMAX_BLOCKS, 0, stream>>>(out_id);
     } else {
         argmax_kernel<<<n_rows, 1024, 0, stream>>>(logits, out_id, vocab);
     }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -497,6 +497,28 @@ __global__ void si_quantize_q8_1_blocks(const __nv_bfloat16* __restrict__ x,
     if (lane == 0) y[ib].ds = __floats2half2_rn(d, d * (float)s);
 }
 
+// Row-batched form: grid.y selects the activation row. The DFlash draft head quantizes its
+// proposal rows before the multi-row MMVQ; as separate launches those are tiny kernels (8 CTAs
+// each) whose launch latency dominates their runtime. Per-row arithmetic is unchanged.
+__global__ void si_quantize_q8_1_rows(const __nv_bfloat16* __restrict__ x,
+                                      si_block_q8_1* __restrict__ y, int K, int x_stride) {
+    const int warpsPB = blockDim.x >> 5, ib = blockIdx.x * warpsPB + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (ib >= (K >> 5)) return;
+    const __nv_bfloat16* xr = x + (size_t)blockIdx.y * x_stride;
+    si_block_q8_1* yr = y + (size_t)blockIdx.y * (K >> 5);
+    float xv = __bfloat162float(xr[ib * 32 + lane]), a = fabsf(xv);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
+    float d = a / 127.0f;
+    int qi = (a == 0.0f) ? 0 : (int)roundf(xv / d);
+    yr[ib].qs[lane] = (signed char)qi;
+    int s = qi;
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+    if (lane == 0) yr[ib].ds = __floats2half2_rn(d, d * (float)s);
+}
+
 __device__ __forceinline__ float si_vec_dot_q4_K(const si_block_q4_K* bq4,
                                                  const si_block_q8_1* bq8_1, int iqs) {
     int v[2], u[4]; float d8[2];
@@ -1050,13 +1072,81 @@ __global__ void gemv_q6k_dp4a_kfixed_kernel(const si_block_q8_1* __restrict__ vy
 // (~416 MB per read at V=248k,K=2048 — far past L2, so it is real HBM traffic). Here each warp owns
 // one output row and walks its weight superblocks ONCE, accumulating all M dot products, so the
 // weight streams from HBM a single time and the M reuses hit L1. y is [M, N] row-major.
+// Multi-row Q4_K MMVQ for the DFlash draft head. Same idea as the Q6_K multi-row kernel below,
+// but against the Q4_K copy of the LM head the target already keeps: 248k x 2048 is ~280 MB in
+// Q4_K versus ~417 MB in Q6_K, and that kernel already runs near HBM peak, so the bytes ARE the
+// runtime. One warp owns an output row and walks its super-blocks once; the weight-side work
+// (nibble extraction, the 6-bit scale/min unpack, and the block dm) is hoisted out of the row
+// loop so each extra activation row costs only its two dp4a's. Draft-only, so the Q4_K rounding
+// can shift proposals but never the emitted tokens.
+template <typename OutT, int WPB, int NSUPER, int MMAX, int MFIXED = 0>
+__global__ void si_mmvq_q4k_multirow_kernel(const si_block_q8_1* __restrict__ vy,
+                                            const unsigned char* __restrict__ W,
+                                            OutT* __restrict__ y, int N, int M) {
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    constexpr int QPR = NSUPER * 8;               // si_block_q8_1 blocks per activation row
+    for (int row = blockIdx.x * WPB + warp; row < N; row += gridDim.x * WPB) {
+        const si_block_q4_K* x_row = (const si_block_q4_K*)(W + (size_t)row * NSUPER * 144);
+        float acc[MMAX];
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) acc[m] = 0.f;
+        // 32 lanes cover the NSUPER*16 (super-block, iqs) pairs.
+        for (int p = lane; p < NSUPER * 16; p += 32) {
+            const int kbx = p >> 4, half = p & 15;
+            const si_block_q4_K* bq4 = x_row + kbx;
+            const int bq8_offset = 2 * (half / 4);
+            const int* q4 = (const int*)(bq4->qs + 16 * bq8_offset + 4 * (half % 4));
+            const int v0 = q4[0], v1 = q4[4];
+            const unsigned short* scales = (const unsigned short*)bq4->scales;
+            unsigned short aux[2]; const int j = bq8_offset / 2;
+            if (j < 2) { aux[0] = scales[j] & 0x3f3f; aux[1] = scales[j + 2] & 0x3f3f; }
+            else { aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+                   aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+            const unsigned char* sc = (const unsigned char*)aux;
+            const unsigned char* mn = sc + 2;
+            const float2 dm4f = __half22float2(bq4->dm);
+            #pragma unroll
+            for (int m = 0; m < (MFIXED ? MFIXED : M); m++) {
+                const si_block_q8_1* b8 = vy + (size_t)m * QPR + kbx * 8 + bq8_offset;
+                float sumf_d = 0.0f, sumf_m = 0.0f;
+                #pragma unroll
+                for (int i = 0; i < 2; i++) {
+                    const float d8 = __low2float(b8[i].ds);
+                    const int* q8 = (const int*)b8[i].qs + (half % 4);
+                    const int u0 = q8[0], u1 = q8[4];
+                    const int v0i = (v0 >> (4 * i)) & 0x0F0F0F0F;
+                    const int v1i = (v1 >> (4 * i)) & 0x0F0F0F0F;
+                    const int dot1 = __dp4a(v1i, u1, __dp4a(v0i, u0, 0));
+                    const int dot2 = __dp4a(0x01010101, u1, __dp4a(0x01010101, u0, 0));
+                    sumf_d += d8 * (dot1 * sc[i]);
+                    sumf_m += d8 * (dot2 * mn[i]);
+                }
+                acc[m] += dm4f.x * sumf_d - dm4f.y * sumf_m;
+            }
+        }
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) {
+            if (MFIXED == 0 && m >= M) break;
+            float a = acc[m];
+            #pragma unroll
+            for (int s = 16; s > 0; s >>= 1) a += __shfl_xor_sync(0xffffffff, a, s);
+            if (lane == 0) gemv_write(y + (size_t)m * N + row, a);
+        }
+    }
+}
+
 template <typename OutT, int WPB, int NSUPER, int MMAX, int MFIXED = 0>
 __global__ void gemv_q6k_dp4a_multirow_kernel(const si_block_q8_1* __restrict__ vy,
                                               const unsigned char* __restrict__ W,
                                               OutT* __restrict__ y, int N, int M) {
     const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
-    const int row = blockIdx.x * WPB + warp;
-    if (row >= N) return;
+    // Grid-stride over output rows so the launcher can CAP the grid. This is the DFlash draft's
+    // largest kernel by far (a 248k-row vocabulary is 15520 CTAs of 512 threads) and it runs
+    // concurrently with a target verify forward on another stream. At full width it occupies the
+    // whole GPU and stalls that forward's long chain of small dependent kernels; the draft has a
+    // ~1.9 ms window to fit ~0.9 ms of work into, so trading draft width for less interference is
+    // free until the draft stops fitting.
+    for (int row = blockIdx.x * WPB + warp; row < N; row += gridDim.x * WPB) {
     const unsigned char* x_row = W + (size_t)row * NSUPER * 210;
     constexpr int QPR = NSUPER * 8;            // si_block_q8_1 blocks per activation row
     float acc[MMAX];
@@ -1104,6 +1194,7 @@ __global__ void gemv_q6k_dp4a_multirow_kernel(const si_block_q8_1* __restrict__ 
         #pragma unroll
         for (int s = 16; s > 0; s >>= 1) a += __shfl_xor_sync(0xffffffff, a, s);
         if (lane == 0) gemv_write(y + (size_t)m * N + row, a);
+    }
     }
 }
 
@@ -1313,6 +1404,14 @@ void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t str
     si_quantize_q8_1_blocks<<<grid, warpsPB * 32, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<si_block_q8_1*>(y), K);
 }
+void launch_quantize_q8_1_rows(const void* x, void* y, int K, int rows, int x_stride,
+                               cudaStream_t stream) {
+    if (rows <= 0) return;
+    const int nb = K >> 5, warpsPB = 8;
+    dim3 grid((nb + warpsPB - 1) / warpsPB, rows);
+    si_quantize_q8_1_rows<<<grid, warpsPB * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<si_block_q8_1*>(y), K, x_stride);
+}
 static int mmvq_dualrow() {
     static int v = -1;
     if (v < 0) { const char* e = getenv("SPARKINFER_MMVQ2"); v = (e && e[0] == '0') ? 0 : 1; }
@@ -1401,10 +1500,47 @@ void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K,
 }
 // M activation rows against one shared Q6_K weight. q81 is M contiguous llama_q8_1_bytes(K)
 // activation rows; y is [M, N] fp32. Returns false when the shape is unsupported (caller loops).
+bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
+                                       int N, int K, int M, cudaStream_t stream) {
+    if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
+    static const int cap = []{
+        if (const char* e = getenv("SPARKINFER_DFLASH_HEAD_CTAS")) return atoi(e);
+        int sm = 0, dev = 0;
+        if (cudaGetDevice(&dev) != cudaSuccess ||
+            cudaDeviceGetAttribute(&sm, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
+            return 0;
+        return sm > 1 ? sm / 2 : 0;
+    }();
+    int nblk = (N + 15) / 16;
+    if (cap > 0 && nblk > cap) nblk = cap;
+    dim3 grid(nblk);
+    auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    auto* w = reinterpret_cast<const unsigned char*>(W);
+    if (M == 3) si_mmvq_q4k_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    else        si_mmvq_q4k_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    return true;
+}
+
 bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream) {
     if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
-    dim3 grid((N + 15) / 16);
+    // Cap the grid so the draft head leaves SM slots for the target verify forward it runs
+    // concurrently with (the kernel grid-strides, so a capped grid still covers every row).
+    // Default: half the SMs. The kernel grid-strides, so a capped grid still covers every row —
+    // it just stops the draft head from occupying the whole GPU while a target verify forward
+    // runs concurrently on another stream. Measured peak on an RTX 5090 (170 SMs) is exactly
+    // SM/2 = 85; both wider (170/340/full) and narrower (56/40/28) are worse.
+    static const int cap = []{
+        if (const char* e = getenv("SPARKINFER_DFLASH_HEAD_CTAS")) return atoi(e);
+        int sm = 0, dev = 0;
+        if (cudaGetDevice(&dev) != cudaSuccess ||
+            cudaDeviceGetAttribute(&sm, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
+            return 0;
+        return sm > 1 ? sm / 2 : 0;
+    }();
+    int nblk = (N + 15) / 16;
+    if (cap > 0 && nblk > cap) nblk = cap;
+    dim3 grid(nblk);
     if (M == 3) {
         gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -74,6 +74,10 @@ void launch_gemv_q_dp4a_pq_f32(const void* q8, const float* ad, const float* as,
 // nwarps=4 cooperate per row. A/B test vs our split-K dp4a (SPARKINFER_LLAMA=1).
 size_t llama_q8_1_bytes(int K);
 void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t stream = nullptr);
+// Row-batched Q8_1 quantize: `rows` activation rows of K values, x row stride `x_stride` elements,
+// y rows contiguous (llama_q8_1_bytes(K) apart). Same per-row math as the single-row launcher.
+void launch_quantize_q8_1_rows(const void* x, void* y, int K, int rows, int x_stride,
+                               cudaStream_t stream = nullptr);
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 // Fused GDN qkv+z Q4_K MMVQ (shared Q8_1 activation). K is hidden (2048 -> NSUPER=8, 4096 -> 16).
@@ -103,6 +107,9 @@ void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, i
 // M activation rows vs one shared Q6_K weight (DFlash draft head: B block tokens, same lm_head).
 // The weight streams from HBM once instead of M times. q81 = M contiguous llama_q8_1_bytes(K) rows,
 // y = [M, N] fp32. Returns false if the shape is unsupported so the caller can fall back.
+// Same, for a Q4_K weight (the LM-head copy the target keeps). ~280 MB vs ~417 MB at V=248k.
+bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
+                                       int N, int K, int M, cudaStream_t stream = nullptr);
 bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream = nullptr);
 

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1,6 +1,7 @@
 // DFlash draft kernels: small-seq GQA attention, RoPE, SwiGLU, RMSNorm.
 #include "sparkinfer/models/dflash_kernels.h"
 #include <cuda_bf16.h>
+#include <cuda_fp16.h>
 #include <cmath>
 #include <cstdio>
 
@@ -33,41 +34,57 @@ __global__ void k_rms(const bf16* x, const bf16* w, bf16* out, int rows, int col
     if (r >= rows) return;
     const bf16* xr = x + (size_t)r * cols;
     bf16* or_ = out + (size_t)r * cols;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int nwarps = blockDim.x >> 5;
+    // uint4 (8 bf16) loads plus a shuffle reduction. The tree reduction this replaces cost
+    // log2(blockDim) block-wide barriers and issued 2-byte scalar loads, which on a 16x2048 block
+    // left these norms latency-bound at ~7 us per launch -- and a draft block runs 14 of them.
     float ss = 0.f;
-    for (int i = threadIdx.x; i < cols; i += blockDim.x) {
-        float v = b2f(xr[i]);
-        ss += v * v;
+    if ((cols & 7) == 0) {
+        const uint4* x4 = (const uint4*)xr;
+        for (int i = threadIdx.x; i < (cols >> 3); i += blockDim.x) {
+            const uint4 p = x4[i];
+            const __nv_bfloat162* h = (const __nv_bfloat162*)&p;
+#pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const float2 f = __bfloat1622float2(h[j]);
+                ss += f.x * f.x + f.y * f.y;
+            }
+        }
+    } else {
+        for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+            float v = b2f(xr[i]);
+            ss += v * v;
+        }
     }
-    __shared__ float buf[256];
-    buf[threadIdx.x] = ss;
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) ss += __shfl_down_sync(0xffffffffu, ss, off);
+    __shared__ float ws[32];
+    if (lane == 0) ws[warp] = ss;
     __syncthreads();
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (threadIdx.x < s) buf[threadIdx.x] += buf[threadIdx.x + s];
-        __syncthreads();
-    }
-    float inv = rsqrtf(buf[0] / (float)cols + eps);
+    float tot = 0.f;
+    for (int i = 0; i < nwarps; i++) tot += ws[i];
+    const float inv = rsqrtf(tot / (float)cols + eps);
     for (int i = threadIdx.x; i < cols; i += blockDim.x)
         or_[i] = f2b(b2f(xr[i]) * inv * b2f(w[i]));
 }
 
 __global__ void k_rms_heads(bf16* x, const bf16* w, int seq, int n_heads, int d, float eps) {
-    int idx = blockIdx.x; // seq * n_heads
+    // One warp per (token, head): d is 128 here, so a head fits a single shuffle reduction and
+    // the per-head block barriers disappear entirely.
+    const int idx = blockIdx.x * (blockDim.x >> 5) + (threadIdx.x >> 5);
     if (idx >= seq * n_heads) return;
     bf16* h = x + (size_t)idx * d;
+    const int lane = threadIdx.x & 31;
     float ss = 0.f;
-    for (int i = threadIdx.x; i < d; i += blockDim.x) {
+    for (int i = lane; i < d; i += 32) {
         float v = b2f(h[i]);
         ss += v * v;
     }
-    __shared__ float buf[128];
-    buf[threadIdx.x] = ss;
-    __syncthreads();
-    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
-        if (threadIdx.x < s) buf[threadIdx.x] += buf[threadIdx.x + s];
-        __syncthreads();
-    }
-    float inv = rsqrtf(buf[0] / (float)d + eps);
-    for (int i = threadIdx.x; i < d; i += blockDim.x)
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) ss += __shfl_xor_sync(0xffffffffu, ss, off);
+    const float inv = rsqrtf(ss / (float)d + eps);
+    for (int i = lane; i < d; i += 32)
         h[i] = f2b(b2f(h[i]) * inv * b2f(w[i]));
 }
 
@@ -287,10 +304,15 @@ __global__ void k_gemv_batched(const bf16* __restrict__ x, const bf16* __restric
     }
 }
 
-// Route several projections that share x through one grid. Each warp still owns exactly one
-// output row and executes the same accumulation loop as k_gemv_batched; only launch boundaries
-// change, so Q/K/V and gate/up keep bit-identical arithmetic.
-template <int BATCH>
+// Route several projections that share x through one grid, ROWS output rows per warp.
+// One row per warp re-reads the whole BATCH-row activation block for EVERY output row: per lane
+// and K-chunk that is BATCH uint4 activation loads and BATCH*8 bf16->float converts to feed only
+// BATCH*8 MACs, and across a layer the activation re-reads (~98 MB) outweigh the weight stream
+// (~50 MB) that the kernel exists to do once. Giving a warp ROWS rows amortizes those loads AND
+// their converts over ROWS weight rows: loads per chunk go from BATCH+1 per BATCH*8 MACs to
+// BATCH+ROWS per ROWS*BATCH*8. The weight rows still stream exactly once. Measured monotone over
+// a 1/2/4/8 sweep on an RTX 5090.
+template <int BATCH, int ROWS>
 __global__ void k_gemv_batched_fused3(
         const bf16* __restrict__ x,
         const bf16* __restrict__ W0, const bf16* __restrict__ W1,
@@ -298,45 +320,68 @@ __global__ void k_gemv_batched_fused3(
         bf16* __restrict__ y0, bf16* __restrict__ y1, bf16* __restrict__ y2,
         int N0, int N1, int N2, int K) {
     const int warps_per_block = blockDim.x / 32;
-    const int global_n = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    const int global_n = (blockIdx.x * warps_per_block + (threadIdx.x / 32)) * ROWS;
     const int total = N0 + N1 + N2;
     if (global_n >= total) return;
     const bf16* W;
     bf16* y;
-    int N, n;
+    int N, n0;
     if (global_n < N0) {
-        W = W0; y = y0; N = N0; n = global_n;
+        W = W0; y = y0; N = N0; n0 = global_n;
     } else if (global_n < N0 + N1) {
-        W = W1; y = y1; N = N1; n = global_n - N0;
+        W = W1; y = y1; N = N1; n0 = global_n - N0;
     } else {
-        W = W2; y = y2; N = N2; n = global_n - N0 - N1;
+        W = W2; y = y2; N = N2; n0 = global_n - N0 - N1;
     }
+    // A warp's ROWS rows never straddle two projections: every N here is a multiple of ROWS.
+    const int nr = (N - n0 < ROWS) ? (N - n0) : ROWS;
     const int lane = threadIdx.x & 31;
-    float acc[BATCH];
+    float acc[ROWS][BATCH];
 #pragma unroll
-    for (int b = 0; b < BATCH; b++) acc[b] = 0.f;
-    const uint4* wrow4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+    for (int r = 0; r < ROWS; r++)
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) acc[r][b] = 0.f;
     const int K8 = K / 8;
     for (int k8 = lane; k8 < K8; k8 += 32) {
-        const uint4 wp = wrow4[k8];
-        const bf16* wv = reinterpret_cast<const bf16*>(&wp);
+        float wf[ROWS][8];
+#pragma unroll
+        for (int r = 0; r < ROWS; r++) {
+            // Clamp the tail rows onto row 0; their results are simply not stored below.
+            const int rr = (r < nr) ? r : 0;
+            const uint4 wp = reinterpret_cast<const uint4*>(W + (size_t)(n0 + rr) * K)[k8];
+            const bf16* wv = reinterpret_cast<const bf16*>(&wp);
+#pragma unroll
+            for (int j = 0; j < 8; j++) wf[r][j] = b2f(wv[j]);
+        }
 #pragma unroll
         for (int b = 0; b < BATCH; b++) {
             const uint4 xp = reinterpret_cast<const uint4*>(x + (size_t)b * K)[k8];
             const bf16* xv = reinterpret_cast<const bf16*>(&xp);
+            float xf[8];
 #pragma unroll
-            for (int j = 0; j < 8; j++) acc[b] += b2f(wv[j]) * b2f(xv[j]);
+            for (int j = 0; j < 8; j++) xf[j] = b2f(xv[j]);
+#pragma unroll
+            for (int r = 0; r < ROWS; r++)
+#pragma unroll
+                for (int j = 0; j < 8; j++) acc[r][b] += wf[r][j] * xf[j];
         }
     }
 #pragma unroll
-    for (int b = 0; b < BATCH; b++) {
+    for (int r = 0; r < ROWS; r++) {
 #pragma unroll
-        for (int off = 16; off > 0; off >>= 1)
-            acc[b] += __shfl_down_sync(0xffffffffu, acc[b], off);
+        for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                acc[r][b] += __shfl_down_sync(0xffffffffu, acc[r][b], off);
+        }
     }
     if (lane == 0) {
 #pragma unroll
-        for (int b = 0; b < BATCH; b++) y[(size_t)b * N + n] = f2b(acc[b]);
+        for (int r = 0; r < ROWS; r++) {
+            if (r >= nr) continue;
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) y[(size_t)b * N + n0 + r] = f2b(acc[r][b]);
+        }
     }
 }
 
@@ -420,52 +465,336 @@ __global__ void k_gemv_rows_exact_s8(const bf16* __restrict__ x,
     }
 }
 
-__global__ void k_gemv_rows_exact_s8_fused2(
+// Row-batched form of the context projection. The exact split-K kernel maps one CTA to each
+// (context row, output) pair, so it re-reads the whole weight once PER CONTEXT ROW. Here one warp
+// owns an output row and accumulates a tile of RMAX context rows from a SINGLE weight pass, so the
+// weight streams ceil(rows/RMAX) times instead of `rows` times. Draft-only: these feed the
+// proposals, and every emitted token is still a target argmax, so accumulation order is free.
+template <int RMAX>
+__global__ void k_gemv_rows_batched_fused2(
         const bf16* __restrict__ x,
         const bf16* __restrict__ W0, const bf16* __restrict__ W1,
         bf16* __restrict__ y0, bf16* __restrict__ y1,
         int rows, int N0, int N1, int K) {
-    const int global_n = blockIdx.x;
-    const int batch = blockIdx.y;
-    if (global_n >= N0 + N1 || batch >= rows) return;
+    const int warps_per_block = blockDim.x / 32;
+    const int global_n = blockIdx.x * warps_per_block + (threadIdx.x / 32);
+    if (global_n >= N0 + N1) return;
     const bool second = global_n >= N0;
     const int n = second ? global_n - N0 : global_n;
     const int N = second ? N1 : N0;
-    const bf16* W = second ? W1 : W0;
-    bf16* y = second ? y1 : y0;
-    const int split = threadIdx.x >> 5;
+    const bf16* __restrict__ W = second ? W1 : W0;
+    bf16* __restrict__ y = second ? y1 : y0;
+    const int r0 = blockIdx.y * RMAX;
+    const int nr = (rows - r0 < RMAX) ? (rows - r0) : RMAX;
+    if (nr <= 0) return;
     const int lane = threadIdx.x & 31;
-    const uint4* w4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
-    const uint4* x4 = reinterpret_cast<const uint4*>(x + (size_t)batch * K);
-    const int K8 = K / 8;
-    float acc = 0.f;
-    for (int i = split * 32 + lane; i < K8; i += 8 * 32) {
-        const uint4 wp = w4[i];
-        const uint4 xp = x4[i];
-        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wp);
-        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xp);
+    float acc[RMAX];
 #pragma unroll
-        for (int j = 0; j < 4; j++) {
-            const float2 wf = __bfloat1622float2(wh[j]);
-            const float2 xf = __bfloat1622float2(xh[j]);
-            acc += wf.x * xf.x + wf.y * xf.y;
+    for (int r = 0; r < RMAX; r++) acc[r] = 0.f;
+    const uint4* w4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+    const int K8 = K / 8;
+    for (int k8 = lane; k8 < K8; k8 += 32) {
+        const uint4 wp = w4[k8];
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wp);
+#pragma unroll
+        for (int r = 0; r < RMAX; r++) {
+            const int rr = r0 + ((r < nr) ? r : 0);
+            const uint4 xp = reinterpret_cast<const uint4*>(x + (size_t)rr * K)[k8];
+            const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xp);
+#pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const float2 wf = __bfloat1622float2(wh[j]);
+                const float2 xf = __bfloat1622float2(xh[j]);
+                acc[r] += wf.x * xf.x + wf.y * xf.y;
+            }
         }
     }
 #pragma unroll
-    for (int off = 16; off > 0; off >>= 1)
-        acc += __shfl_xor_sync(0xffffffffu, acc, off);
-    __shared__ float partial[8];
-    if (lane == 0) partial[split] = acc;
-    __syncthreads();
-    if (split == 0 && lane == 0) {
-        float result = 0.f;
+    for (int r = 0; r < RMAX; r++) {
+        float a = acc[r];
 #pragma unroll
-        for (int s = 0; s < 8; s++) result += partial[s];
-        y[(size_t)batch * N + n] = f2b(result);
+        for (int off = 16; off > 0; off >>= 1) a += __shfl_down_sync(0xffffffffu, a, off);
+        if (lane == 0 && r < nr) y[(size_t)(r0 + r) * N + n] = f2b(a);
+    }
+}
+
+// bf16 -> Q8_0-style int8 with one fp32 scale per 32 weights, one warp per 32-weight block.
+// Done once at load: the draft's per-block weight stream is ~705 MB of bf16, and after the
+// diffusion width narrowed to 4 rows these projections are squarely DRAM-bound, so halving the
+// bytes is the only remaining lever. Draft-only, and every emitted token is still a target
+// argmax, so the quantization can only move the accept length, never the output.
+__global__ void k_quantize_w_q8(const bf16* __restrict__ w, signed char* __restrict__ q,
+                                float* __restrict__ sc, long nblocks) {
+    const long blk = (long)blockIdx.x * (blockDim.x >> 5) + (threadIdx.x >> 5);
+    if (blk >= nblocks) return;
+    const int lane = threadIdx.x & 31;
+    const float v = b2f(w[blk * 32 + lane]);
+    float a = fabsf(v);
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, off));
+    const float d = a / 127.0f;
+    q[blk * 32 + lane] = (signed char)(a == 0.f ? 0 : __float2int_rn(v / d));
+    if (lane == 0) sc[blk] = d;
+}
+
+// Q8_0 weights, bf16 activations. Same tiling as k_gemv_batched_fused3: ROWS output rows per
+// warp so the BATCH activation loads amortize; the weight side now reads 8 bytes instead of 16
+// per K-chunk, plus one fp32 block scale per 4 chunks.
+template <int BATCH, int ROWS>
+__global__ void k_gemv_batched_fused3_q8(
+        const bf16* __restrict__ x,
+        const signed char* __restrict__ Q0, const signed char* __restrict__ Q1,
+        const signed char* __restrict__ Q2,
+        const float* __restrict__ S0, const float* __restrict__ S1, const float* __restrict__ S2,
+        bf16* __restrict__ y0, bf16* __restrict__ y1, bf16* __restrict__ y2,
+        int N0, int N1, int N2, int K) {
+    const int warps_per_block = blockDim.x / 32;
+    const int total = N0 + N1 + N2;
+    // Grid-stride over row tiles: the launcher caps the grid so this leaves SM slots for the
+    // concurrent target verify forward (see launch_gemv_batched_q8_fused3).
+    for (int global_n = (blockIdx.x * warps_per_block + (threadIdx.x / 32)) * ROWS;
+         global_n < total; global_n += gridDim.x * warps_per_block * ROWS) {
+    const signed char* Q; const float* S; bf16* y; int N, n0;
+    if (global_n < N0)            { Q = Q0; S = S0; y = y0; N = N0; n0 = global_n; }
+    else if (global_n < N0 + N1)  { Q = Q1; S = S1; y = y1; N = N1; n0 = global_n - N0; }
+    else                          { Q = Q2; S = S2; y = y2; N = N2; n0 = global_n - N0 - N1; }
+    const int nr = (N - n0 < ROWS) ? (N - n0) : ROWS;
+    const int lane = threadIdx.x & 31;
+    const int K8 = K / 8, KS = K / 32;
+    float acc[ROWS][BATCH];
+#pragma unroll
+    for (int r = 0; r < ROWS; r++)
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) acc[r][b] = 0.f;
+    for (int k8 = lane; k8 < K8; k8 += 32) {
+        float wf[ROWS][8];
+#pragma unroll
+        for (int r = 0; r < ROWS; r++) {
+            const int rr = (r < nr) ? r : 0;
+            const uint2 wp = reinterpret_cast<const uint2*>(Q + (size_t)(n0 + rr) * K)[k8];
+            const signed char* wv = reinterpret_cast<const signed char*>(&wp);
+            const float d = S[(size_t)(n0 + rr) * KS + (k8 >> 2)];
+#pragma unroll
+            for (int j = 0; j < 8; j++) wf[r][j] = (float)wv[j] * d;
+        }
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) {
+            const uint4 xp = reinterpret_cast<const uint4*>(x + (size_t)b * K)[k8];
+            const bf16* xv = reinterpret_cast<const bf16*>(&xp);
+            float xf[8];
+#pragma unroll
+            for (int j = 0; j < 8; j++) xf[j] = b2f(xv[j]);
+#pragma unroll
+            for (int r = 0; r < ROWS; r++)
+#pragma unroll
+                for (int j = 0; j < 8; j++) acc[r][b] += wf[r][j] * xf[j];
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < ROWS; r++)
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                acc[r][b] += __shfl_down_sync(0xffffffffu, acc[r][b], off);
+        }
+    if (lane == 0) {
+#pragma unroll
+        for (int r = 0; r < ROWS; r++) {
+            if (r >= nr) continue;
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) y[(size_t)b * N + n0 + r] = f2b(acc[r][b]);
+        }
+    }
+    }
+}
+
+// Copy one captured hidden row into dflash_hidden[row][slot]. `row` is read from DEVICE memory,
+// which is the whole point: the destination row changes on every verify token, but a captured
+// CUDA graph bakes its node arguments, so a host-side destination forced the capture into a
+// row-independent staging buffer that then had to be flushed by a second, out-of-graph memcpy on
+// every verify token. Reading the row on the device lets the capture write its final location
+// from inside the graph, and the per-token flush disappears.
+__global__ void k_capture_row(const bf16* __restrict__ x, bf16* __restrict__ hidden,
+                              const int* __restrict__ cap_row, int slot, int H,
+                              int row_elems, int max_rows) {
+    const int r = *cap_row;
+    if (r < 0 || r >= max_rows) return;
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= H / 8) return;
+    uint4* dst = (uint4*)(hidden + (size_t)r * row_elems + (size_t)slot * H);
+    dst[i] = ((const uint4*)x)[i];
+}
+
+// bf16 -> asymmetric int4: 32 weights per block as packed nibbles plus an fp16 (scale, min) pair.
+// ~5 bits/weight against Q8_0's 9, so the draft's per-block projection stream drops from ~353 MB
+// to ~196 MB. Asymmetric (scale+min, like Q4_K) rather than symmetric: at 4 bits the extra
+// degree of freedom is what keeps the proposals good enough that the accept length holds.
+__global__ void k_quantize_w_q4(const bf16* __restrict__ w, unsigned char* __restrict__ q,
+                                __half2* __restrict__ dm, long nblocks) {
+    const long blk = (long)blockIdx.x * (blockDim.x >> 5) + (threadIdx.x >> 5);
+    if (blk >= nblocks) return;
+    const int lane = threadIdx.x & 31;
+    const float v = b2f(w[blk * 32 + lane]);
+    float mn = v, mx = v;
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        mn = fminf(mn, __shfl_xor_sync(0xffffffffu, mn, off));
+        mx = fmaxf(mx, __shfl_xor_sync(0xffffffffu, mx, off));
+    }
+    const float d = (mx - mn) / 15.0f;
+    const int qi = (d > 0.f) ? __float2int_rn((v - mn) / d) : 0;
+    const unsigned int nib = (unsigned)(qi < 0 ? 0 : (qi > 15 ? 15 : qi));
+    // Two lanes share a byte: even lane -> low nibble, odd lane -> high nibble.
+    const unsigned int other = __shfl_xor_sync(0xffffffffu, nib, 1);
+    if ((lane & 1) == 0) q[blk * 16 + (lane >> 1)] = (unsigned char)(nib | (other << 4));
+    if (lane == 0) dm[blk] = __floats2half2_rn(d, mn);
+}
+
+// int4 weights, bf16 activations; same tiling as the Q8 variant.
+template <int BATCH, int ROWS>
+__global__ void k_gemv_batched_fused3_q4(
+        const bf16* __restrict__ x,
+        const unsigned char* __restrict__ Q0, const unsigned char* __restrict__ Q1,
+        const unsigned char* __restrict__ Q2,
+        const __half2* __restrict__ D0, const __half2* __restrict__ D1, const __half2* __restrict__ D2,
+        bf16* __restrict__ y0, bf16* __restrict__ y1, bf16* __restrict__ y2,
+        int N0, int N1, int N2, int K) {
+    const int warps_per_block = blockDim.x / 32;
+    const int total = N0 + N1 + N2;
+    for (int global_n = (blockIdx.x * warps_per_block + (threadIdx.x / 32)) * ROWS;
+         global_n < total; global_n += gridDim.x * warps_per_block * ROWS) {
+    const unsigned char* Q; const __half2* D; bf16* y; int N, n0;
+    if (global_n < N0)           { Q = Q0; D = D0; y = y0; N = N0; n0 = global_n; }
+    else if (global_n < N0 + N1) { Q = Q1; D = D1; y = y1; N = N1; n0 = global_n - N0; }
+    else                         { Q = Q2; D = D2; y = y2; N = N2; n0 = global_n - N0 - N1; }
+    const int nr = (N - n0 < ROWS) ? (N - n0) : ROWS;
+    const int lane = threadIdx.x & 31;
+    const int K8 = K / 8, KS = K / 32;
+    float acc[ROWS][BATCH];
+#pragma unroll
+    for (int r = 0; r < ROWS; r++)
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) acc[r][b] = 0.f;
+    for (int k8 = lane; k8 < K8; k8 += 32) {
+        float wf[ROWS][8];
+#pragma unroll
+        for (int r = 0; r < ROWS; r++) {
+            const int rr = (r < nr) ? r : 0;
+            const unsigned int packed =
+                reinterpret_cast<const unsigned int*>(Q + (size_t)(n0 + rr) * (K / 2))[k8];
+            const float2 dmf = __half22float2(D[(size_t)(n0 + rr) * KS + (k8 >> 2)]);
+#pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const unsigned int byte = (packed >> (8 * j)) & 0xFFu;
+                wf[r][2 * j]     = (float)(byte & 0xFu) * dmf.x + dmf.y;
+                wf[r][2 * j + 1] = (float)(byte >> 4)   * dmf.x + dmf.y;
+            }
+        }
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) {
+            const uint4 xp = reinterpret_cast<const uint4*>(x + (size_t)b * K)[k8];
+            const bf16* xv = reinterpret_cast<const bf16*>(&xp);
+            float xf[8];
+#pragma unroll
+            for (int j = 0; j < 8; j++) xf[j] = b2f(xv[j]);
+#pragma unroll
+            for (int r = 0; r < ROWS; r++)
+#pragma unroll
+                for (int j = 0; j < 8; j++) acc[r][b] += wf[r][j] * xf[j];
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < ROWS; r++)
+#pragma unroll
+        for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+            for (int off = 16; off > 0; off >>= 1)
+                acc[r][b] += __shfl_down_sync(0xffffffffu, acc[r][b], off);
+        }
+    if (lane == 0) {
+#pragma unroll
+        for (int r = 0; r < ROWS; r++) {
+            if (r >= nr) continue;
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) y[(size_t)b * N + n0 + r] = f2b(acc[r][b]);
+        }
+    }
     }
 }
 
 } // namespace
+
+void launch_quantize_w_q4(const void* w, void* q, void* dm, int N, int K, cudaStream_t stream) {
+    if (N <= 0 || (K & 31) != 0) return;
+    const long nblocks = (long)N * (K / 32);
+    constexpr int WPB = 8;
+    k_quantize_w_q4<<<(nblocks + WPB - 1) / WPB, WPB * 32, 0, stream>>>(
+        (const bf16*)w, (unsigned char*)q, (__half2*)dm, nblocks);
+}
+
+void launch_gemv_batched_q4_fused3(const void* x,
+                                   const void* Q0, const void* Q1, const void* Q2,
+                                   const void* D0, const void* D1, const void* D2,
+                                   void* y0, void* y1, void* y2,
+                                   int N0, int N1, int N2, int K, cudaStream_t stream,
+                                   int batch) {
+    const int total = N0 + N1 + N2;
+    if (total <= 0) return;
+    constexpr int WPB = 4, ROWS = 8;
+    const int warps = (total + ROWS - 1) / ROWS;
+    dim3 grid((warps + WPB - 1) / WPB);
+    const dim3 blk(WPB * 32);
+#define SI_Q4F3(BW_) k_gemv_batched_fused3_q4<BW_, ROWS><<<grid, blk, 0, stream>>>(              \
+        (const bf16*)x, (const unsigned char*)Q0, (const unsigned char*)Q1,                     \
+        (const unsigned char*)Q2, (const __half2*)D0, (const __half2*)D1, (const __half2*)D2,   \
+        (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
+    if (batch == 4)      SI_Q4F3(4);
+    else if (batch == 8) SI_Q4F3(8);
+    else                 SI_Q4F3(16);
+#undef SI_Q4F3
+}
+
+void launch_capture_row(const void* x, void* hidden, const int* cap_row, int slot, int H,
+                        int row_elems, int max_rows, cudaStream_t stream) {
+    if (H <= 0 || (H & 7) != 0) return;
+    const int n4 = H / 8;
+    k_capture_row<<<(n4 + 255) / 256, 256, 0, stream>>>(
+        (const bf16*)x, (bf16*)hidden, cap_row, slot, H, row_elems, max_rows);
+}
+
+void launch_quantize_w_q8(const void* w, void* q, float* sc, int N, int K, cudaStream_t stream) {
+    if (N <= 0 || (K & 31) != 0) return;
+    const long nblocks = (long)N * (K / 32);
+    constexpr int WPB = 8;
+    k_quantize_w_q8<<<(nblocks + WPB - 1) / WPB, WPB * 32, 0, stream>>>(
+        (const bf16*)w, (signed char*)q, sc, nblocks);
+}
+
+void launch_gemv_batched_q8_fused3(const void* x,
+                                   const void* Q0, const void* Q1, const void* Q2,
+                                   const float* S0, const float* S1, const float* S2,
+                                   void* y0, void* y1, void* y2,
+                                   int N0, int N1, int N2, int K, cudaStream_t stream,
+                                   int batch) {
+    const int total = N0 + N1 + N2;
+    if (total <= 0) return;
+    constexpr int WPB = 4, ROWS = 8;
+    static const int cap = []{ const char* e = getenv("SPARKINFER_DFLASH_PROJ_CTAS");
+                               return e ? atoi(e) : 0; }();
+    const int warps = (total + ROWS - 1) / ROWS;
+    int nblk = (warps + WPB - 1) / WPB;
+    if (cap > 0 && nblk > cap) nblk = cap;
+    dim3 grid(nblk);
+    const dim3 blk(WPB * 32);
+#define SI_Q8F3(BW_) k_gemv_batched_fused3_q8<BW_, ROWS><<<grid, blk, 0, stream>>>(               \
+        (const bf16*)x, (const signed char*)Q0, (const signed char*)Q1, (const signed char*)Q2,   \
+        S0, S1, S2, (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
+    if (batch == 4)      SI_Q8F3(4);
+    else if (batch == 8) SI_Q8F3(8);
+    else                 SI_Q8F3(16);
+#undef SI_Q8F3
+}
 
 void launch_add(const void* x, const void* y, void* out, int n, cudaStream_t stream) {
     if (n <= 0) return;
@@ -487,7 +816,9 @@ void launch_rms_heads(void* x, const void* w, int seq, int n_heads, int d, float
                       cudaStream_t stream) {
     int n = seq * n_heads;
     if (n <= 0) return;
-    k_rms_heads<<<n, 128, 0, stream>>>((bf16*)x, (const bf16*)w, seq, n_heads, d, eps);
+    constexpr int WPB = 4;                       // one warp per (token, head)
+    k_rms_heads<<<(n + WPB - 1) / WPB, WPB * 32, 0, stream>>>(
+        (bf16*)x, (const bf16*)w, seq, n_heads, d, eps);
 }
 
 void launch_rope_seq(void* x, int seq, int n_heads, int d, int pos0, float theta,
@@ -519,33 +850,45 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
 }
 
 void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
-                           cudaStream_t stream) {
+                           cudaStream_t stream, int batch) {
     if (N <= 0) return;
-    constexpr int WARPS_PER_BLOCK = 4;
-    dim3 grid((N + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
-    k_gemv_batched<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
-        (const bf16*)x, (const bf16*)W, (bf16*)y, N, K);
+    // Single projection = the fused path with one entry, so wo/down get the same
+    // ROWS-per-warp activation amortization as Q/K/V and gate/up.
+    launch_gemv_batched16_fused3(x, W, nullptr, nullptr, y, nullptr, nullptr, N, 0, 0, K, stream, batch);
 }
 
 void launch_gemv_batched16_fused3(const void* x,
                                   const void* W0, const void* W1, const void* W2,
                                   void* y0, void* y1, void* y2,
-                                  int N0, int N1, int N2, int K, cudaStream_t stream) {
+                                  int N0, int N1, int N2, int K, cudaStream_t stream,
+                                  int batch) {
     const int total = N0 + N1 + N2;
     if (total <= 0) return;
-    constexpr int WARPS_PER_BLOCK = 4;
-    dim3 grid((total + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
-    k_gemv_batched_fused3<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
-        (const bf16*)x, (const bf16*)W0, (const bf16*)W1, (const bf16*)W2,
-        (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K);
+    constexpr int WARPS_PER_BLOCK = 4, ROWS = 8;
+    const int warps = (total + ROWS - 1) / ROWS;
+    dim3 grid((warps + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
+    const dim3 blk(WARPS_PER_BLOCK * 32);
+#define SI_FUSED3(BW_) k_gemv_batched_fused3<BW_, ROWS><<<grid, blk, 0, stream>>>(              \
+        (const bf16*)x, (const bf16*)W0, (const bf16*)W1, (const bf16*)W2,                     \
+        (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
+    if (batch == 4)       SI_FUSED3(4);
+    else if (batch == 8)  SI_FUSED3(8);
+    else                  SI_FUSED3(16);
+#undef SI_FUSED3
 }
 
 void launch_gemv_batched16_fused2(const void* x,
                                   const void* W0, const void* W1,
                                   void* y0, void* y1,
-                                  int N0, int N1, int K, cudaStream_t stream) {
+                                  int N0, int N1, int K, cudaStream_t stream, int batch) {
     launch_gemv_batched16_fused3(x, W0, W1, nullptr, y0, y1, nullptr,
-                                 N0, N1, 0, K, stream);
+                                 N0, N1, 0, K, stream, batch);
+}
+
+void launch_gemv_rows_batched(const void* x, const void* W, void* y,
+                              int rows, int N, int K, cudaStream_t stream) {
+    if (rows <= 0 || N <= 0) return;
+    launch_gemv_rows_exact_fused2(x, W, nullptr, y, nullptr, rows, N, 0, K, stream);
 }
 
 void launch_gemv_rows_exact(const void* x, const void* W, void* y,
@@ -562,8 +905,9 @@ void launch_gemv_rows_exact_fused2(const void* x,
                                    int rows, int N0, int N1, int K,
                                    cudaStream_t stream) {
     if (rows <= 0 || N0 + N1 <= 0) return;
-    dim3 grid(N0 + N1, rows);
-    k_gemv_rows_exact_s8_fused2<<<grid, 8 * 32, 0, stream>>>(
+    constexpr int RMAX = 8, WPB = 4;
+    dim3 grid((N0 + N1 + WPB - 1) / WPB, (rows + RMAX - 1) / RMAX);
+    k_gemv_rows_batched_fused2<RMAX><<<grid, WPB * 32, 0, stream>>>(
         (const bf16*)x, (const bf16*)W0, (const bf16*)W1,
         (bf16*)y0, (bf16*)y1, rows, N0, N1, K);
 }

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -32,21 +32,52 @@ void launch_rms(const void* x, const void* w, void* out, int rows, int cols,
 
 // Batched GEMV: y[b,:] = x[b,:] @ W^T for a fixed batch of 16 rows in one launch.
 // x: [16,K] bf16, W: [N,K] bf16 (native "out,in" layout, same as a single-row GEMV), y: [16,N] bf16.
+// `batch` = active activation rows (the draft's diffusion width; 4, 8 or 16).
 void launch_gemv_batched16(const void* x, const void* W, void* y, int N, int K,
-                           cudaStream_t stream);
+                           cudaStream_t stream, int batch = 16);
 void launch_gemv_batched16_fused2(const void* x,
                                   const void* W0, const void* W1,
                                   void* y0, void* y1,
-                                  int N0, int N1, int K, cudaStream_t stream);
+                                  int N0, int N1, int K, cudaStream_t stream, int batch = 16);
 void launch_gemv_batched16_fused3(const void* x,
                                   const void* W0, const void* W1, const void* W2,
                                   void* y0, void* y1, void* y2,
-                                  int N0, int N1, int N2, int K, cudaStream_t stream);
+                                  int N0, int N1, int N2, int K, cudaStream_t stream, int batch = 16);
 
 // Exact batched form of the small-N S=8 split-K BF16 GEMV used by launch_gemv.
 // Collapses multiple row launches into grid.y without changing arithmetic order.
 void launch_gemv_rows_exact(const void* x, const void* W, void* y,
                             int rows, int N, int K, cudaStream_t stream);
+// Copy hidden row `x` [H] into hidden[(*cap_row) * row_elems + slot * H]. The row index lives in
+// device memory so the launch can be captured into the decode graph and still target the right row.
+void launch_capture_row(const void* x, void* hidden, const int* cap_row, int slot, int H,
+                        int row_elems, int max_rows, cudaStream_t stream);
+
+// bf16 -> asymmetric int4 (packed nibbles + fp16 scale/min per 32). Run once at load.
+void launch_quantize_w_q4(const void* w, void* q, void* dm, int N, int K, cudaStream_t stream);
+
+// int4-weight form of launch_gemv_batched16_fused3 (~5 bits/weight vs Q8_0's 9).
+void launch_gemv_batched_q4_fused3(const void* x,
+                                   const void* Q0, const void* Q1, const void* Q2,
+                                   const void* D0, const void* D1, const void* D2,
+                                   void* y0, void* y1, void* y2,
+                                   int N0, int N1, int N2, int K, cudaStream_t stream,
+                                   int batch = 16);
+
+// bf16 -> Q8_0 (int8 + one fp32 scale per 32 values along K). Run once at load.
+void launch_quantize_w_q8(const void* w, void* q, float* sc, int N, int K, cudaStream_t stream);
+
+// Q8_0-weight form of launch_gemv_batched16_fused3 (half the weight bytes).
+void launch_gemv_batched_q8_fused3(const void* x,
+                                   const void* Q0, const void* Q1, const void* Q2,
+                                   const float* S0, const float* S1, const float* S2,
+                                   void* y0, void* y1, void* y2,
+                                   int N0, int N1, int N2, int K, cudaStream_t stream,
+                                   int batch = 16);
+
+// Single-weight form of the row-batched context projection (weight streamed once per 8 rows).
+void launch_gemv_rows_batched(const void* x, const void* W, void* y,
+                              int rows, int N, int K, cudaStream_t stream);
 void launch_gemv_rows_exact_fused2(const void* x,
                                    const void* W0, const void* W1,
                                    void* y0, void* y1,

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -225,12 +225,29 @@ bool parse_config_json(const std::string& path, DFlashDraftConfig& cfg) {
     return true;
 }
 
+struct Q8W { signed char* q = nullptr; float* s = nullptr;
+              unsigned char* q4 = nullptr; void* dm = nullptr; };
+
 struct LayerWeights {
     bf16 *wq = nullptr, *wk = nullptr, *wv = nullptr, *wo = nullptr;
+    // Q8_0 mirrors of the four batched projections (Q/K/V, O, gate/up, down).
+    Q8W q8_wq, q8_wk, q8_wv, q8_wo, q8_gate, q8_up, q8_down;
     bf16 *q_norm = nullptr, *k_norm = nullptr;
     bf16 *input_norm = nullptr, *post_norm = nullptr;
     bf16 *gate = nullptr, *up = nullptr, *down = nullptr;
 };
+
+// Draft projection weight format: 4 = asymmetric int4, 8 = Q8_0, 0 = bf16. Default 4.
+inline int draft_w_bits() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_DFLASH_WBITS");
+        v = e ? atoi(e) : 4;
+        if (v != 0 && v != 4 && v != 8) v = 4;
+    }
+    return v;
+}
+inline bool q8_on() { return draft_w_bits() != 0; }
 
 } // namespace
 
@@ -266,6 +283,21 @@ struct DFlashDraftModel::Impl {
     // Per-layer contiguous KV cache: [max_seq, n_kv, d]
     std::vector<bf16*> k_cache, v_cache;
     int seq_len = 0;
+
+    Q8W make_q8(bf16* w, int N, int K) {
+        Q8W o;
+        if (draft_w_bits() == 4) {
+            o.q4 = alloc<unsigned char>((size_t)N * (K / 2));
+            o.dm = alloc<short>((size_t)N * (K / 32) * 2);   // __half2 per 32-weight block
+            dflash_kernels::launch_quantize_w_q4(w, o.q4, o.dm, N, K, stream);
+        } else {
+            o.q = alloc<signed char>((size_t)N * K);
+            o.s = alloc<float>((size_t)N * (K / 32));
+            dflash_kernels::launch_quantize_w_q8(w, o.q, o.s, N, K, stream);
+        }
+        cudaStreamSynchronize(stream);
+        return o;
+    }
 
     template <class T> T* alloc(size_t n) {
         void* p = nullptr;
@@ -402,6 +434,18 @@ bool DFlashDraftModel::load(const std::string& dir) {
         lw.q_norm = s.upload(*qn); lw.k_norm = s.upload(*kn);
         lw.input_norm = s.upload(*in); lw.post_norm = s.upload(*pn);
         lw.gate = s.upload(*g); lw.up = s.upload(*u); lw.down = s.upload(*d);
+        // Q8_0 mirrors: the batched projections are DRAM-bound at the narrowed diffusion width,
+        // so halving their weight bytes is the dominant remaining win. Built once, on load.
+        if (q8_on()) {
+            const int qd = s.cfg.n_q_heads * s.cfg.head_dim, kvd = s.cfg.n_kv_heads * s.cfg.head_dim;
+            lw.q8_wq   = s.make_q8(lw.wq,   qd,  H);
+            lw.q8_wk   = s.make_q8(lw.wk,   kvd, H);
+            lw.q8_wv   = s.make_q8(lw.wv,   kvd, H);
+            lw.q8_wo   = s.make_q8(lw.wo,   H,   qd);
+            lw.q8_gate = s.make_q8(lw.gate, I,   H);
+            lw.q8_up   = s.make_q8(lw.up,   I,   H);
+            lw.q8_down = s.make_q8(lw.down, H,   I);
+        }
     }
 
     // Scratch
@@ -456,24 +500,45 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     const int qdim = c.n_q_heads * c.head_dim;
     const int kvdim = c.n_kv_heads * c.head_dim;
     const int d = c.head_dim;
-    constexpr int kProposalDepth = 3;
+    // Proposal depth (also sets the draft's active diffusion width, depth+1).
+    static const int kProposalDepth = []{
+        const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
+        int v = e ? atoi(e) : 3;
+        return v < 1 ? 1 : (v > 15 ? 15 : v);
+    }();
+    // Active diffusion width. Only rows 0..kProposalDepth are ever consumed (row 0 is the seed,
+    // 1..kProposalDepth the scored proposals), yet the backbone was run at the checkpoint's full
+    // block_size=16 — 12 of every 16 rows computed and discarded. The block's attention is
+    // bidirectional, so narrowing it DOES change what the draft proposes; that is allowed here
+    // because every emitted token is still a target argmax, only the accept length can move.
+    // SPARKINFER_DFLASH_BLOCK_WIDTH overrides (0/unset = kProposalDepth+1).
+    static const int BW = [&]{
+        const char* e = getenv("SPARKINFER_DFLASH_BLOCK_WIDTH");
+        int v = e ? atoi(e) : 0;
+        if (v <= 0) v = kProposalDepth + 1;
+        if (v < kProposalDepth + 1) v = kProposalDepth + 1;
+        // Round up to a width the batched-GEMV path is instantiated for; anything else falls
+        // back to the per-token GEMV loop, which costs far more than the rows it saves.
+        const int w = v <= 4 ? 4 : (v <= 8 ? 8 : 16);
+        return w > c.block_size ? c.block_size : w;
+    }();
     const float scale = 1.f / sqrtf((float)d);
     const int past = s.seq_len;
     // The fixed-size (block_size) projections below can use a batched-GEMV kernel that reads
     // each weight row from DRAM once instead of once per token (see dflash_kernels.cu). It's
     // compiled for exactly 16 rows, so it's only used when the draft's block_size is 16 (true
     // for the current checkpoint); any other block_size falls back to the per-token GEMV loop.
-    const bool fast16 = (B == 16);
+    const bool fast16 = (BW == 16 || BW == 8 || BW == 4);
 
-    cu(cudaMemcpyAsync(s.d_ids, noise_ids, B * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
-    kernels::launch_embedding(s.d_ids, s.embed, s.noise, B, H, st);
+    cu(cudaMemcpyAsync(s.d_ids, noise_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
+    kernels::launch_embedding(s.d_ids, s.embed, s.noise, BW, H, st);
 
     // target_hidden [ctx, n_cap*H] -> fc -> hidden_norm -> target_proj [ctx, H]
     // fc.weight is [H, n_cap*H] (out, in). Loop gemv per row.
     if (ctx_len > 0) {
         const bf16* th = (const bf16*)target_hidden;
         if (ctx_len > 1) {
-            dflash_kernels::launch_gemv_rows_exact(th, s.fc, s.target_proj,
+            dflash_kernels::launch_gemv_rows_batched(th, s.fc, s.target_proj,
                                                    ctx_len, H, n_cap * H, st);
         } else {
             kernels::launch_gemv(th, s.fc, s.target_proj, H, n_cap * H, st);
@@ -483,22 +548,33 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     }
 
     // x = noise embedding
-    cu(cudaMemcpyAsync(s.x, s.noise, (size_t)B * H * sizeof(bf16), cudaMemcpyDeviceToDevice, st),
+    cu(cudaMemcpyAsync(s.x, s.noise, (size_t)BW * H * sizeof(bf16), cudaMemcpyDeviceToDevice, st),
        "noise->x");
 
     for (int L = 0; L < c.n_layers; L++) {
         const LayerWeights& w = s.layers[L];
-        dflash_kernels::launch_rms(s.x, w.input_norm, s.xn, B, H, c.rms_eps, st);
+        dflash_kernels::launch_rms(s.x, w.input_norm, s.xn, BW, H, c.rms_eps, st);
 
         // Q from noise, K/V from cat(target, noise)
         if (fast16) {
-            dflash_kernels::launch_gemv_batched16_fused3(
-                s.xn, w.wq, w.wk, w.wv,
-                s.q, s.k_new + (size_t)ctx_len * kvdim,
-                s.v_new + (size_t)ctx_len * kvdim,
-                qdim, kvdim, kvdim, H, st);
+            if (w.q8_wq.q4)
+                dflash_kernels::launch_gemv_batched_q4_fused3(
+                    s.xn, w.q8_wq.q4, w.q8_wk.q4, w.q8_wv.q4, w.q8_wq.dm, w.q8_wk.dm, w.q8_wv.dm,
+                    s.q, s.k_new + (size_t)ctx_len * kvdim, s.v_new + (size_t)ctx_len * kvdim,
+                    qdim, kvdim, kvdim, H, st, BW);
+            else if (w.q8_wq.q)
+                dflash_kernels::launch_gemv_batched_q8_fused3(
+                    s.xn, w.q8_wq.q, w.q8_wk.q, w.q8_wv.q, w.q8_wq.s, w.q8_wk.s, w.q8_wv.s,
+                    s.q, s.k_new + (size_t)ctx_len * kvdim, s.v_new + (size_t)ctx_len * kvdim,
+                    qdim, kvdim, kvdim, H, st, BW);
+            else
+                dflash_kernels::launch_gemv_batched16_fused3(
+                    s.xn, w.wq, w.wk, w.wv,
+                    s.q, s.k_new + (size_t)ctx_len * kvdim,
+                    s.v_new + (size_t)ctx_len * kvdim,
+                    qdim, kvdim, kvdim, H, st, BW);
         } else {
-            for (int t = 0; t < B; t++)
+            for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
         // Build k_new / v_new = cat(k_ctx, k_noise)
@@ -514,7 +590,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                  s.v_new + (size_t)t * kvdim, kvdim, H, st);
         }
         if (!fast16) {
-            for (int t = 0; t < B; t++) {
+            for (int t = 0; t < BW; t++) {
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wk,
                                      s.k_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wv,
@@ -522,9 +598,9 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             }
         }
 
-        const int new_len = ctx_len + B;
+        const int new_len = ctx_len + BW;
         // Q / K RMSNorm per head
-        dflash_kernels::launch_rms_heads(s.q, w.q_norm, B, c.n_q_heads, d, c.rms_eps, st);
+        dflash_kernels::launch_rms_heads(s.q, w.q_norm, BW, c.n_q_heads, d, c.rms_eps, st);
         dflash_kernels::launch_rms_heads(s.k_new, w.k_norm, new_len, c.n_kv_heads, d, c.rms_eps, st);
 
         // RoPE: Q at positions past..(past+B) if past≈pos0 for noise-only positions.
@@ -534,7 +610,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // q_pos0 = pos0.
         const int k_pos0 = pos0 - ctx_len;
         const int q_pos0 = pos0;
-        dflash_kernels::launch_rope_seq(s.q, B, c.n_q_heads, d, q_pos0, c.rope_theta, st);
+        dflash_kernels::launch_rope_seq(s.q, BW, c.n_q_heads, d, q_pos0, c.rope_theta, st);
         dflash_kernels::launch_rope_seq(s.k_new, new_len, c.n_kv_heads, d, k_pos0, c.rope_theta, st);
 
         // Append into cache then attend over full past+new
@@ -559,38 +635,65 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         const bool causal = mixed_causal && L < (int)c.sliding_layers.size() &&
                             c.sliding_layers[L];
         dflash_kernels::launch_attn_gqa(s.q, s.k_cache[L], s.v_cache[L], s.attn,
-                                        B, kv_len, c.n_q_heads, c.n_kv_heads, d,
+                                        BW, kv_len, c.n_q_heads, c.n_kv_heads, d,
                                         q_pos0, /*k_pos0_cache=*/0, window, causal, scale, st);
 
         if (fast16) {
-            dflash_kernels::launch_gemv_batched16(s.attn, w.wo, s.ao, H, qdim, st);
+            if (w.q8_wo.q4)
+                dflash_kernels::launch_gemv_batched_q4_fused3(
+                    s.attn, w.q8_wo.q4, nullptr, nullptr, w.q8_wo.dm, nullptr, nullptr,
+                    s.ao, nullptr, nullptr, H, 0, 0, qdim, st, BW);
+            else if (w.q8_wo.q)
+                dflash_kernels::launch_gemv_batched_q8_fused3(
+                    s.attn, w.q8_wo.q, nullptr, nullptr, w.q8_wo.s, nullptr, nullptr,
+                    s.ao, nullptr, nullptr, H, 0, 0, qdim, st, BW);
+            else
+                dflash_kernels::launch_gemv_batched16(s.attn, w.wo, s.ao, H, qdim, st, BW);
         } else {
-            for (int t = 0; t < B; t++)
+            for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.attn + (size_t)t * qdim, w.wo, s.ao + (size_t)t * H, H, qdim, st);
         }
-        dflash_kernels::launch_add(s.x, s.ao, s.h, B * H, st);
+        dflash_kernels::launch_add(s.x, s.ao, s.h, BW * H, st);
 
-        dflash_kernels::launch_rms(s.h, w.post_norm, s.hn, B, H, c.rms_eps, st);
+        dflash_kernels::launch_rms(s.h, w.post_norm, s.hn, BW, H, c.rms_eps, st);
         if (fast16) {
-            dflash_kernels::launch_gemv_batched16_fused2(
-                s.hn, w.gate, w.up, s.gate, s.up, I, I, H, st);
+            if (w.q8_gate.q4)
+                dflash_kernels::launch_gemv_batched_q4_fused3(
+                    s.hn, w.q8_gate.q4, w.q8_up.q4, nullptr, w.q8_gate.dm, w.q8_up.dm, nullptr,
+                    s.gate, s.up, nullptr, I, I, 0, H, st, BW);
+            else if (w.q8_gate.q)
+                dflash_kernels::launch_gemv_batched_q8_fused3(
+                    s.hn, w.q8_gate.q, w.q8_up.q, nullptr, w.q8_gate.s, w.q8_up.s, nullptr,
+                    s.gate, s.up, nullptr, I, I, 0, H, st, BW);
+            else
+                dflash_kernels::launch_gemv_batched16_fused2(
+                    s.hn, w.gate, w.up, s.gate, s.up, I, I, H, st, BW);
         } else {
-            for (int t = 0; t < B; t++) {
+            for (int t = 0; t < BW; t++) {
                 kernels::launch_gemv(s.hn + (size_t)t * H, w.gate, s.gate + (size_t)t * I, I, H, st);
                 kernels::launch_gemv(s.hn + (size_t)t * H, w.up,   s.up   + (size_t)t * I, I, H, st);
             }
         }
-        dflash_kernels::launch_swiglu(s.gate, s.up, s.gate, B * I, st);
+        dflash_kernels::launch_swiglu(s.gate, s.up, s.gate, BW * I, st);
         if (fast16) {
-            dflash_kernels::launch_gemv_batched16(s.gate, w.down, s.down, H, I, st);
+            if (w.q8_down.q4)
+                dflash_kernels::launch_gemv_batched_q4_fused3(
+                    s.gate, w.q8_down.q4, nullptr, nullptr, w.q8_down.dm, nullptr, nullptr,
+                    s.down, nullptr, nullptr, H, 0, 0, I, st, BW);
+            else if (w.q8_down.q)
+                dflash_kernels::launch_gemv_batched_q8_fused3(
+                    s.gate, w.q8_down.q, nullptr, nullptr, w.q8_down.s, nullptr, nullptr,
+                    s.down, nullptr, nullptr, H, 0, 0, I, st, BW);
+            else
+                dflash_kernels::launch_gemv_batched16(s.gate, w.down, s.down, H, I, st, BW);
         } else {
-            for (int t = 0; t < B; t++)
+            for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.gate + (size_t)t * I, w.down, s.down + (size_t)t * H, H, I, st);
         }
-        dflash_kernels::launch_add(s.h, s.down, s.x, B * H, st);
+        dflash_kernels::launch_add(s.h, s.down, s.x, BW * H, st);
     }
 
-    dflash_kernels::launch_rms(s.x, s.final_norm, s.xn, B, H, c.rms_eps, st);
+    dflash_kernels::launch_rms(s.x, s.final_norm, s.xn, BW, H, c.rms_eps, st);
 
     // LM head (target weights) -> logits / argmax. Batched over the whole block: one batched
     // GEMV against the eagerly dequantized bf16 lm_head cache instead of a per-token
@@ -605,19 +708,21 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     static int head_mr = -1;
     if (head_mr < 0) { const char* e = getenv("SPARKINFER_DFLASH_HEAD_MULTIROW"); head_mr = (e && e[0] == '0') ? 0 : 1; }
     bool head_done = false;
-    if (head_mr && s.lm_head_type == 14 && s.head_q8) {          // native Q6_K shared head
-        const size_t qrow = kernels::llama_q8_1_bytes(H);
-        // Score only the proposal rows the verifier can consume. The remaining diffusion rows
-        // still participate in the backbone, but streaming the 248k-row Q6_K head for them is
-        // wasted once verification is capped below the full block.
-        for (int t = 1; t <= kProposalDepth; t++)
-            kernels::launch_quantize_q8_1_blocks(s.xn + (size_t)t * H,
-                                                 (char*)s.head_q8 + (size_t)(t - 1) * qrow, H, st);
-        head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(
-            s.head_q8, s.lm_head, s.logits + V, V, H, kProposalDepth, st);
+    if (head_mr && s.head_q8 && (s.lm_head_type == 14 || s.lm_head_type == 12)) {
+        // Score only the proposal rows the verifier can consume. One row-batched quantize launch
+        // instead of kProposalDepth tiny ones (8 CTAs each, so launch latency dominated them).
+        kernels::launch_quantize_q8_1_rows(s.xn + (size_t)H, s.head_q8, H, kProposalDepth, H, st);
+        // Prefer the Q4_K head when one is bound: this kernel already runs near HBM peak, so its
+        // runtime IS its weight bytes -- ~280 MB in Q4_K against ~417 MB in Q6_K at V=248k.
+        if (s.lm_head_type == 12)
+            head_done = kernels::launch_gemv_q4k_dp4a_multirow_f32(
+                s.head_q8, s.lm_head, s.logits + V, V, H, kProposalDepth, st);
+        else
+            head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(
+                s.head_q8, s.lm_head, s.logits + V, V, H, kProposalDepth, st);
     }
     if (!head_done) {
-    if (fast16) {
+    if (BW == 16) {
         dflash_kernels::launch_gemv_batched16_f32(s.xn, s.lm_head_bf16, s.logits, V, H, st);
     } else {
         for (int t = 0; t < B; t++) {
@@ -643,7 +748,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // Matches z-lab dflash: past_key_values_draft.update(...) then .crop(start).
     // Without this, seq_len stays 0, crop(pos0) clamps to 0, and every step rebuilds
     // from an empty cache — draft quality collapses (τ≈1.x) after the first block.
-    s.seq_len = past + ctx_len + B;
+    s.seq_len = past + ctx_len + BW;
     crop(pos0);
     return true;
 }

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -11,6 +11,7 @@
 
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/models/dflash_draft.h"
+#include "sparkinfer/models/dflash_kernels.h"
 #include "qwen35_prefill.h"
 #include "sparkinfer/thermal_governor.h"
 #include "sparkinfer/kv_ops.h"
@@ -32,9 +33,9 @@
 #include <vector>
 #include <string>
 #include <fstream>
+#include <climits>
 #include <limits>
 #include <algorithm>
-#include <thread>
 
 namespace sparkinfer {
 
@@ -43,6 +44,10 @@ inline void cu(cudaError_t e, const char* what) {
     if (e != cudaSuccess) fprintf(stderr, "[qwen35] %s: %s\n", what, cudaGetErrorString(e));
 }
 using bf16 = unsigned short;
+
+// forward_token() sentinel: the decode graph was enqueued but not yet collected. Never a valid
+// token id, so it cannot be confused with a real argmax.
+constexpr int kDFlashDeferred = INT_MIN;
 
 // launch_gguf_dequant only implements F32/F16/Q8_0/Q4_K/Q6_K. Reject anything
 // else at load time so Q5_K (etc.) cannot silently fall through as F32.
@@ -136,17 +141,14 @@ struct Qwen35Model::Impl {
     bool bench_feedback_graph = false;
     int graph_attn_mode = -1;  // host-side flash-decode dispatch class captured in cu_graph
     // Separate decode graph for DFlash verify (sample=true, dflash_capture=true). The normal
-    // cu_graph/cu_exec can't be reused here because dflash_maybe_capture_layer's destination
-    // (dflash_hidden + cap_row*row_elems) changes every call; this graph instead always
-    // captures into the row-independent dflash_cap_stage buffer, and the caller does one
-    // small follow-up memcpy into the real row after each replay -- same varying-scalar-input
-    // pattern the plain decode graph already relies on for token_id/position.
+    // cu_graph/cu_exec can't be reused here because it carries the extra per-layer hidden
+    // captures. Their destination row varies per call, which is handled the same way the graph
+    // already handles token_id/position: cap_row is packed into d_scalars and read on device.
     cudaGraph_t cu_dflash_graph{};
     cudaGraphExec_t cu_dflash_exec{};
     bool dflash_graph_ready = false;
     int dflash_graph_attn_mode = -1;
     bool dflash_graph_sparse = false;
-    bf16* dflash_cap_stage = nullptr;  // [n_cap, H], row-independent capture target for the graph
 
     // scratch (bf16)
     bf16 *x, *xn, *q, *k, *v, *attn, *ao, *h, *hn, *routed, *shared;
@@ -159,6 +161,7 @@ struct Qwen35Model::Impl {
     float* lin_state = nullptr;
     float* logits;
     int *d_scalars, *d_tok, *d_out_id, *d_pos, *d_seqlen, *d_writepos, *d_shared_ids;
+    int *d_cap_row = nullptr;   // dflash capture row, packed into d_scalars[4]
     int *h_scalars = nullptr, *h_out_id = nullptr;
     float* d_shared_w;
     std::vector<void*> owned;   // device buffers from load_weights / load_gguf
@@ -223,6 +226,10 @@ struct Qwen35Model::Impl {
     const void* dflash_lm_head = nullptr;
     int dflash_lm_head_type = 0;
     bool dflash_capture = false;
+    // DFlash verify token 0: enqueue the captured decode graph and collect it later, so the
+    // draft block can be issued in between (see dflash_generate).
+    bool defer_decode_sync = false;
+    bool decode_pending = false;
     std::vector<int> dflash_layer_ids;
     int dflash_n_cap = 0;
     int dflash_max_rows = 16;
@@ -289,11 +296,12 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
         p_->shared_gate_tmp=p_->alloc<bf16>(1);
     }
     p_->logits=p_->alloc<float>(cfg.vocab);
-    p_->d_scalars=p_->alloc<int>(4);
+    p_->d_scalars=p_->alloc<int>(5);
     p_->d_tok=p_->d_scalars + 0; p_->d_pos=p_->d_scalars + 1;
     p_->d_writepos=p_->d_scalars + 2; p_->d_seqlen=p_->d_scalars + 3;
+    p_->d_cap_row=p_->d_scalars + 4;
     p_->d_out_id=p_->alloc<int>(1);
-    cu(cudaHostAlloc(&p_->h_scalars, 4 * sizeof(int), cudaHostAllocDefault), "host scalars");
+    cu(cudaHostAlloc(&p_->h_scalars, 5 * sizeof(int), cudaHostAllocDefault), "host scalars");
     cu(cudaHostAlloc(&p_->h_out_id, sizeof(int), cudaHostAllocDefault), "host out id");
     p_->d_shared_ids=p_->alloc<int>(1); p_->d_shared_w=p_->alloc<float>(1);
     int zero=0; float one=1.f;
@@ -414,7 +422,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->sparse_sel);
     cudaFree(p_->sparse_vtbl); cudaFree(p_->sparse_vlen);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
-    cudaFree(p_->dflash_hidden); cudaFree(p_->dflash_context); cudaFree(p_->dflash_cap_stage);
+    cudaFree(p_->dflash_hidden); cudaFree(p_->dflash_context);
     // spec_lin_snap / spec_conv_snap are in owned[] (allocated via Impl::alloc)
     for (auto& kv : p_->sessions) {
         if (kv.first == 0) continue;
@@ -443,19 +451,19 @@ void Qwen35Model::copy_logits(float* host_logits) const {
 
 void Qwen35Model::dflash_maybe_capture_layer(int layer) {
     Impl& s = *p_;
-    if (!s.dflash_capture || !s.dflash_cap_stage || s.dflash_n_cap <= 0) return;
+    if (!s.dflash_capture || !s.dflash_hidden || s.dflash_n_cap <= 0) return;
     int slot = -1;
     for (int i = 0; i < s.dflash_n_cap; i++) {
         if (s.dflash_layer_ids[i] == layer) { slot = i; break; }
     }
     if (slot < 0) return;
     const int H = s.cfg.hidden;
-    // Writes to the row-independent staging buffer (not dflash_hidden[cap_row] directly) so
-    // this sequence of memcpys has a FIXED destination and can be captured into the dflash
-    // decode graph below; the caller copies stage -> dflash_hidden[cap_row] once per call.
-    bf16* dst = s.dflash_cap_stage + (size_t)slot * H;
-    cu(cudaMemcpyAsync(dst, s.x, (size_t)H * sizeof(bf16), cudaMemcpyDeviceToDevice, s.stream),
-       "dflash capture");
+    // Writes dflash_hidden[cap_row][slot] directly. cap_row is read from d_scalars[4] on the
+    // device, so this node is graph-capturable even though the row changes every verify token --
+    // which retires the staging buffer and the extra out-of-graph flush memcpy that every DFlash
+    // verify token paid on top of a plain decode forward.
+    dflash_kernels::launch_capture_row(s.x, s.dflash_hidden, s.d_cap_row, slot, H,
+                                       s.dflash_n_cap * H, s.dflash_max_rows, s.stream);
 }
 
 int Qwen35Model::forward_token(int token_id, int position, bool sample) {
@@ -466,25 +474,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     int seqlen = position + 1;
     cudaStream_t st = s.stream;
     const bool dflash_cap = s.dflash_capture;
-    // dflash_maybe_capture_layer always writes into the row-independent dflash_cap_stage
-    // buffer (graph-capturable, unlike dflash_hidden[cap_row] which varies call to call).
-    // Every path that can run it -- eager prefill, dflash decode graph capture, dflash decode
-    // graph replay -- must call this exactly once afterward or dflash_hidden[cap_row] is left
-    // stale/uninitialized for that call.
-    auto dflash_flush_stage = [&s, H]() {
-        if (!s.dflash_hidden || !s.dflash_cap_stage || s.dflash_n_cap <= 0 ||
-            s.dflash_cap_row < 0 || s.dflash_cap_row >= s.dflash_max_rows) return;
-        const size_t row_elems = (size_t)s.dflash_n_cap * H;
-        cu(cudaMemcpyAsync(s.dflash_hidden + (size_t)s.dflash_cap_row * row_elems,
-                           s.dflash_cap_stage, row_elems * sizeof(bf16),
-                           cudaMemcpyDeviceToDevice, s.stream), "dflash stage->hidden");
-    };
-
     s.h_scalars[0] = token_id;
     s.h_scalars[1] = position;
     s.h_scalars[2] = position;
     s.h_scalars[3] = seqlen;
-    cu(cudaMemcpyAsync(s.d_scalars, s.h_scalars, 4 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
+    s.h_scalars[4] = s.dflash_cap_row;
+    cu(cudaMemcpyAsync(s.d_scalars, s.h_scalars, 5 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
 
     // Depth-adaptive KV-split: 32 (short) -> 128 (mid) -> 256 (long). The 8k-12k band
     // (28*split_chunk < seqlen <= 48*split_chunk) is roofline-bound on 128 splits; promote
@@ -612,10 +607,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     // Prefill graph: embed→layers→final norm (no LM head). Decode graph: full path + argmax.
     // DFlash's per-layer hidden capture used to require the eager path entirely (a captured
     // graph bakes fixed destinations, and dflash_hidden[cap_row] varies call to call) -- the
-    // dflash decode graph below instead captures into the row-independent dflash_cap_stage
-    // buffer and the caller does one small follow-up memcpy into the real row, so DFlash
-    // verify tokens (sample=true) get graph replay too. The prefill/prompt path (sample=false)
-    // still falls back to eager under capture; it is not on the scored decode-tps path.
+    // capture kernel reads cap_row from device memory instead, so DFlash verify tokens
+    // (sample=true) get graph replay with no post-replay fixup. The prefill/prompt path
+    // (sample=false) still falls back to eager under capture; not on the scored decode path.
     if (!sample && s.graph_prefill_ready && !dflash_cap) {
         cu(cudaGraphLaunch(s.cu_prefill_exec, st), "prefill graph launch");
         cu(cudaStreamSynchronize(st), "prefill graph sync");
@@ -629,8 +623,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     }
     if (sample && dflash_cap && s.dflash_graph_ready) {
         cu(cudaGraphLaunch(s.cu_dflash_exec, st), "dflash graph launch");
-        dflash_flush_stage();
         cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");
+        // Deferred collect (DFlash verify token 0 only): return without blocking so the caller
+        // can issue the draft block behind it. The target forward is then already running on the
+        // GPU while the host is still issuing the draft's ~100 launches -- and it costs no
+        // std::thread spawn/join per decode step.
+        if (s.defer_decode_sync) { s.decode_pending = true; return kDFlashDeferred; }
         cu(cudaStreamSynchronize(st), "sync");
         return *s.h_out_id;
     }
@@ -1230,12 +1228,6 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             s.graph_prefill_attn_mode = attn_graph_mode;
             cu(cudaGraphLaunch(s.cu_prefill_exec, st), "prefill graph launch (first)");
         }
-        // The prefill/prompt path always runs dflash_maybe_capture_layer eagerly (never
-        // graph-captured, see capturing_graph above), which now writes into the row-independent
-        // dflash_cap_stage instead of dflash_hidden[cap_row] directly (so the SAME helper is
-        // safe to call from inside the dflash decode graph too). Needs the same follow-up copy
-        // the decode-graph branches do, or dflash_hidden[cap_row] is never actually updated here.
-        if (dflash_cap) dflash_flush_stage();
         cu(cudaStreamSynchronize(st), "prefill sync");
         return token_id;
     }
@@ -1260,7 +1252,6 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         s.dflash_graph_attn_mode = attn_graph_mode;
         s.dflash_graph_sparse = sparse_on;
         cu(cudaGraphLaunch(s.cu_dflash_exec, st), "dflash graph launch (first)");
-        dflash_flush_stage();
     } else if (capturing_graph) {
         cu(cudaStreamEndCapture(st, &s.cu_graph), "end capture");
         cu(cudaGraphInstantiate(&s.cu_exec, s.cu_graph, 0), "graph instantiate");
@@ -1716,11 +1707,9 @@ void Qwen35Model::set_dflash_capture(bool on, const std::vector<int>& target_lay
     const size_t hidden_bytes = (size_t)s.dflash_max_rows * row_elems * sizeof(bf16);
     if (s.dflash_hidden) { cudaFree(s.dflash_hidden); s.dflash_hidden = nullptr; }
     if (s.dflash_context) { cudaFree(s.dflash_context); s.dflash_context = nullptr; }
-    if (s.dflash_cap_stage) { cudaFree(s.dflash_cap_stage); s.dflash_cap_stage = nullptr; }
     s.dflash_ctx_cap = s.cfg.max_seq;
     cu(cudaMalloc(&s.dflash_hidden, hidden_bytes), "dflash hidden");
     cu(cudaMalloc(&s.dflash_context, (size_t)s.dflash_ctx_cap * row_elems * sizeof(bf16)), "dflash ctx");
-    cu(cudaMalloc(&s.dflash_cap_stage, row_elems * sizeof(bf16)), "dflash cap stage");
     if (s.cfg.hybrid && !s.spec_lin_snap) {
         const size_t ls = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
                           s.cfg.linear_head_dim * s.cfg.linear_head_dim;
@@ -1809,9 +1798,19 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     const int B = dc.block_size;
     const int mask_id = dc.mask_token_id;
 
-    draft.set_shared_weights(embed_weights(),
-                             s.dflash_lm_head ? s.dflash_lm_head : lm_head_weights(),
-                             s.dflash_lm_head ? s.dflash_lm_head_type : lm_head_quant_type(),
+    // Head for the draft. The dual-head path keeps a native Q6_K copy so the draft's multi-row
+    // MMVQ has something to chew on, but that kernel runs near HBM peak, so its runtime is just
+    // its weight bytes -- and the target's own Q4_K copy is ~280 MB against the Q6_K's ~417 MB.
+    // With a multi-row Q4_K MMVQ the draft prefers the smaller one. SPARKINFER_DFLASH_HEAD_Q4=0
+    // restores the Q6_K copy (A/B).
+    static const int head_q4 = []{ const char* e = getenv("SPARKINFER_DFLASH_HEAD_Q4");
+                                   return (e && e[0] == '0') ? 0 : 1; }();
+    const bool use_q4_head = head_q4 && lm_head_quant_type() == 12 && lm_head_weights();
+    const void* draft_head = use_q4_head ? lm_head_weights()
+                           : (s.dflash_lm_head ? s.dflash_lm_head : lm_head_weights());
+    const int draft_head_type = use_q4_head ? lm_head_quant_type()
+                              : (s.dflash_lm_head ? s.dflash_lm_head_type : lm_head_quant_type());
+    draft.set_shared_weights(embed_weights(), draft_head, draft_head_type,
                              s.cfg.vocab, s.cfg.hidden);
     set_dflash_capture(true, dc.target_layer_ids, B);
 
@@ -1851,7 +1850,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     int th_len = n;
 
     std::vector<int> block(B), posterior(B), draft_ids(B);
-    constexpr int kProposalDepth = 3;
+    // Proposal depth (also sets the draft's active diffusion width, depth+1).
+    static const int kProposalDepth = []{
+        const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
+        int v = e ? atoi(e) : 3;
+        return v < 1 ? 1 : (v > 15 ? 15 : v);
+    }();
     bf16* th_scratch = nullptr;
     const int row_stride = dflash_hidden_row_stride();
     if (cudaMalloc(&th_scratch, (size_t)B * row_stride * sizeof(bf16)) != cudaSuccess) {
@@ -1877,12 +1881,21 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             draft_hidden = th_scratch;
         }
 
-        int p0 = -1;
+        // Enqueue verify token 0 first (one graph launch, ~10 us of host time), then issue the
+        // draft block on its own stream. Ordering matters: the target must be in flight before
+        // the draft's launches start, or the draft queues ahead of it. A deferred collect also
+        // avoids spawning and joining a std::thread on every decode step.
         set_dflash_capture_row(0);
-        std::thread verify0([&] { p0 = forward_token(block[0], start, true); });
+        s.defer_decode_sync = true;
+        int p0 = forward_token(block[0], start, true);
+        s.defer_decode_sync = false;
         const bool draft_ok = draft.forward_block(
             draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr);
-        verify0.join();
+        if (p0 == kDFlashDeferred) {
+            cu(cudaStreamSynchronize(s.stream), "verify0 sync");
+            s.decode_pending = false;
+            p0 = *s.h_out_id;
+        }
         if (!draft_ok) {
             fprintf(stderr, "[dflash] draft forward failed at start=%d\n", start);
             break;


### PR DESCRIPTION
## Summary

Rebased onto #682. That PR overlapped the draft block with the seed verify, which leaves the draft *itself* as the exposed cost — so this one attacks the draft's bytes, its width, and its launch count. Every change is draft-side or capture-side: emitted tokens are still target argmaxes, so `SPEC_AGREE` is unaffected, and the measured accept length τ is unchanged on every prompt below.

Measured on the eval box, the step decomposes as: solo verify token `T` = 1.930 ms, overlap region 2.484 ms, **exposed draft 0.555 ms/step**. Neither stream exceeds ~60% of HBM peak, so the residual is occupancy interference and weight bytes.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end `DFLASH_TPS`, 128 tokens, same-box `origin/main` @1bb584e vs this branch, held-out 215-token prompt, 2 alternating reps):

| | decode tok/s |
|---|--:|
| before (main) | 405.1 |
| after (this PR) | 474.5 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
=== 2-rep alternating A/B vs main @1bb584e (RTX 5090, sm_120, CUDA 12.8) ===
  seed      main      PR     delta    tau(main/PR)
  a2       388.1   469.3    +20.9%   1.8551/1.8551
  a5       419.9   489.3    +16.5%   2.4706/2.4706
  b1       388.5   467.0    +20.2%   1.9545/1.9545
  b3       405.1   474.5    +17.1%   2.0806/2.0476
  mean delta: +18.7%

raw seed b3 (alternating reps):
  main 405.4125  tau 2.0806
  PR   475.4053  tau 2.0476
  main 404.7056  tau 2.0806
  PR   473.6370  tau 2.0476
```

Prompts are held-out `gen_eval_prompt.py` slices (not the fixed `eval_text.txt` one), generated with the Qwen3.6 tokenizer.

### Accuracy gate

```text
>> DFlash check: seed=fixed prompt_tokens=101 max_new=32
METRIC SPEC_AGREE 32/32 = 1.0000
METRIC MEAN_ACCEPT 3.091 steps=11
VERDICT PASS

max_new=64:
METRIC SPEC_AGREE 64/64 = 1.0000
VERDICT PASS
```

### Qwen3.6 no-regression guard (same build, `qwen3_gguf_bench`)

| ctx | main decode | PR decode | main prefill pp | PR prefill pp |
|---|--:|--:|--:|--:|
| 128 | 526.99 | 527.13 | — | — |
| 512 | 516.74 | 516.74 | 575.21 | 575.16 |
| 4096 | 499.02 | 498.78 | 26021.88 | 26042.41 |

Within run-to-run noise. Shared-file additions (`launch_quantize_q8_1_rows`, the multi-row Q4_K MMVQ, the row-parallel argmax path) are reached **only** from the DFlash draft — the target LM head uses `launch_mmvq_q4k_f32` and the decode argmax uses the single-row two-pass path, neither of which is modified.
