### PR TITLE
perf(dflash): graph exact adaptive block verification

### DIFF
--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -249,6 +249,7 @@ template __global__ void qknorm_rope_kv_kernel<true>(
 #endif
 // Fused QK-norm + partial-RoPE + KV-append for Qwen3.6 (rope_dim < head_dim). One kernel per head
 // replaces launch_rmsnorm_qk + launch_rope_kv_append_partial on the 10 full-attn layers.
+template <bool SINGLE_SEQUENCE>
 __global__ void qknorm_rope_kv_partial_kernel(
     __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
@@ -263,7 +264,8 @@ __global__ void qknorm_rope_kv_partial_kernel(
     const int rhalf = rotary_dim >> 1;
     const int pos  = positions[tok];
     const int blk = pos / block_size, within = pos % block_size;
-    const size_t ctok = (size_t)((size_t)block_table[tok * max_blocks_per_seq + blk] * block_size + within);
+    const int table_row = SINGLE_SEQUENCE ? 0 : tok * max_blocks_per_seq;
+    const size_t ctok = (size_t)((size_t)block_table[table_row + blk] * block_size + within);
 
     const bool is_v = (b >= n_q_heads + n_kv_heads);
     if (is_v) {
@@ -570,6 +572,7 @@ __global__ void qknorm_rope_kv_partial_int8_kernel(
 
 // Gated Qwen3.6 full-attn: read Q from qraw (2*head_dim interleaved), extract gate,
 // RMSNorm + partial RoPE in-place to q, then K/V int8 KV-append (same as int8 variant).
+template <bool SINGLE_SEQUENCE>
 __global__ void qknorm_rope_kv_partial_int8_gated_kernel(
     const __nv_bfloat16* __restrict__ qraw, __nv_bfloat16* __restrict__ q,
     __nv_bfloat16* __restrict__ qgate,
@@ -587,7 +590,7 @@ __global__ void qknorm_rope_kv_partial_int8_gated_kernel(
     const int rhalf = rotary_dim >> 1;
     const int pos    = positions[tok];
     const int blk    = pos / block_size, within = pos % block_size;
-    const int phys   = block_table[tok * max_blocks_per_seq + blk];
+    const int phys   = block_table[(SINGLE_SEQUENCE ? 0 : tok * max_blocks_per_seq) + blk];
     const size_t ctok = (size_t)(phys * block_size + within);
 
     extern __shared__ float s_h[];
@@ -731,7 +734,24 @@ void launch_qknorm_rope_kv_partial(
 ) {
     dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
     const int smem = head_dim * sizeof(float);
-    qknorm_rope_kv_partial_kernel<<<grid, head_dim, smem, stream>>>(
+    qknorm_rope_kv_partial_kernel<false><<<grid, head_dim, smem, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v),
+        reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        block_table, positions, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta,
+        block_size, max_blocks_per_seq, eps);
+}
+
+void launch_dflash_qknorm_rope_kv_partial(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
+    float theta, float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream
+) {
+    dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
+    const int smem = head_dim * sizeof(float);
+    qknorm_rope_kv_partial_kernel<true><<<grid, head_dim, smem, stream>>>(
         reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
         reinterpret_cast<const __nv_bfloat16*>(v),
         reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
@@ -821,7 +841,26 @@ void launch_qknorm_rope_kv_partial_int8_gated(
     float theta, float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream) {
     dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
     const int smem = head_dim * (int)sizeof(float);
-    qknorm_rope_kv_partial_int8_gated_kernel<<<grid, head_dim, smem, stream>>>(
+    qknorm_rope_kv_partial_int8_gated_kernel<false><<<grid, head_dim, smem, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qraw), reinterpret_cast<__nv_bfloat16*>(q),
+        reinterpret_cast<__nv_bfloat16*>(qgate),
+        reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<const __nv_bfloat16*>(v),
+        reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+        reinterpret_cast<signed char*>(k_pool), reinterpret_cast<signed char*>(v_pool),
+        reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+        block_table, positions, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta,
+        block_size, max_blocks_per_seq, eps);
+}
+
+void launch_dflash_qknorm_rope_kv_partial_int8_gated(
+    const void* qraw, void* q, void* qgate, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, void* k_scale, void* v_scale,
+    const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
+    float theta, float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream) {
+    dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
+    const int smem = head_dim * (int)sizeof(float);
+    qknorm_rope_kv_partial_int8_gated_kernel<true><<<grid, head_dim, smem, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(qraw), reinterpret_cast<__nv_bfloat16*>(q),
         reinterpret_cast<__nv_bfloat16*>(qgate),
         reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<const __nv_bfloat16*>(v),

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -570,6 +570,184 @@ __global__ void pf_gdn_scan_kernel(const __nv_bfloat16* __restrict__ q,
     for (int r = 0; r < NROW; r++) col[lane + r * 32] = sloc[r];
 }
 
+// DFlash verification scan. Arithmetic and reduction order match pf_gdn_scan_kernel, but the
+// register state is seeded from decode and each candidate's post-token state is checkpointed.
+// The live state is read-only, so a rejected suffix never needs rollback or replay.
+template <int COLS, int HEAD_DIM, bool WRITE_CHECKPOINT>
+__global__ void df_gdn_scan_checkpoint_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k,
+    const __nv_bfloat16* __restrict__ v, const __nv_bfloat16* __restrict__ alpha,
+    const __nv_bfloat16* __restrict__ beta, const __nv_bfloat16* __restrict__ dt,
+    const __nv_bfloat16* __restrict__ a, const float* __restrict__ live_state,
+    __nv_bfloat16* __restrict__ out, float* __restrict__ checkpoints,
+    int n_tokens, int q_heads, int v_heads) {
+    constexpr int NROW = HEAD_DIM / 32;
+    const int vh = blockIdx.x;
+    const int j = blockIdx.y * COLS + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (vh >= v_heads || j >= HEAD_DIM) return;
+    const int qh = vh % q_heads;
+    const int q_dim = q_heads * HEAD_DIM;
+    const int v_dim = v_heads * HEAD_DIM;
+    const size_t state_elems = (size_t)v_heads * HEAD_DIM * HEAD_DIM;
+    const size_t col_off = ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
+    const float scale = rsqrtf((float)HEAD_DIM);
+    const float a_h = pf_to_f(a[vh]);
+    const float dt_h = pf_to_f(dt[vh]);
+
+    float sloc[NROW];
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) sloc[r] = live_state[col_off + lane + r * 32];
+
+    for (int t = 0; t < n_tokens; t++) {
+        const float bb = pf_sigmoid(pf_to_f(beta[(size_t)t * v_heads + vh]));
+        const float g = __expf(pf_softplus(pf_to_f(alpha[(size_t)t * v_heads + vh]) + dt_h) * a_h);
+        const __nv_bfloat16* qp = q + (size_t)t * q_dim + qh * HEAD_DIM;
+        const __nv_bfloat16* kp = k + (size_t)t * q_dim + qh * HEAD_DIM;
+        const __nv_bfloat16* vp = v + (size_t)t * v_dim + vh * HEAD_DIM;
+        float part_sk = 0.f;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int i = lane + r * 32;
+            part_sk += sloc[r] * pf_to_f(kp[i]);
+        }
+        const float sk = g * pf_wsum(part_sk);
+        const float delta = (pf_to_f(vp[j]) - sk) * bb;
+        float part_y = 0.f;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int i = lane + r * 32;
+            const float s_new = sloc[r] * g + pf_to_f(kp[i]) * delta;
+            sloc[r] = s_new;
+            part_y += s_new * pf_to_f(qp[i]) * scale;
+            if constexpr (WRITE_CHECKPOINT)
+                checkpoints[(size_t)t * state_elems + col_off + i] = s_new;
+        }
+        const float y = pf_wsum(part_y);
+        if (lane == 0) out[(size_t)t * v_dim + vh * HEAD_DIM + j] = __float2bfloat16(y);
+    }
+}
+
+// Commit only the accepted compact recurrence inputs. Verification already retained k/v and the
+// scalar gates for each row, so materializing N full state checkpoints is unnecessary: replay the
+// accepted prefix once into the live state. The update expression and reduction order are the
+// same as df_gdn_scan_checkpoint_kernel; q/output work is intentionally omitted because commit
+// happens after posterior selection.
+template <int COLS, int HEAD_DIM>
+__global__ void df_gdn_scan_commit_kernel(
+    const __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
+    const __nv_bfloat16* __restrict__ alpha, const __nv_bfloat16* __restrict__ beta,
+    const __nv_bfloat16* __restrict__ dt, const __nv_bfloat16* __restrict__ a,
+    float* __restrict__ live_state, int n_tokens, int q_heads, int v_heads) {
+    constexpr int NROW = HEAD_DIM / 32;
+    const int vh = blockIdx.x;
+    const int j = blockIdx.y * COLS + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (vh >= v_heads || j >= HEAD_DIM) return;
+    const int qh = vh % q_heads;
+    const int q_dim = q_heads * HEAD_DIM;
+    const int v_dim = v_heads * HEAD_DIM;
+    const size_t col_off = ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
+    const float a_h = pf_to_f(a[vh]);
+    const float dt_h = pf_to_f(dt[vh]);
+
+    float sloc[NROW];
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) sloc[r] = live_state[col_off + lane + r * 32];
+    for (int t = 0; t < n_tokens; t++) {
+        const float bb = pf_sigmoid(pf_to_f(beta[(size_t)t * v_heads + vh]));
+        const float g = __expf(pf_softplus(pf_to_f(alpha[(size_t)t * v_heads + vh]) + dt_h) * a_h);
+        const __nv_bfloat16* kp = k + (size_t)t * q_dim + qh * HEAD_DIM;
+        const __nv_bfloat16* vp = v + (size_t)t * v_dim + vh * HEAD_DIM;
+        float part_sk = 0.f;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int i = lane + r * 32;
+            part_sk += sloc[r] * pf_to_f(kp[i]);
+        }
+        const float sk = g * pf_wsum(part_sk);
+        const float delta = (pf_to_f(vp[j]) - sk) * bb;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int i = lane + r * 32;
+            sloc[r] = sloc[r] * g + pf_to_f(kp[i]) * delta;
+        }
+    }
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) live_state[col_off + lane + r * 32] = sloc[r];
+}
+
+// The convolution state is only the last conv_kernel-1 raw qkv rows. Commit therefore reduces to
+// a window splice from the original live history and the accepted qkv prefix; no convolution or
+// normalization needs to be repeated.
+__global__ void df_gdn_conv_commit_kernel(const __nv_bfloat16* __restrict__ qkv,
+                                          __nv_bfloat16* __restrict__ live_state,
+                                          int n_tokens, int qkv_dim, int conv_kernel) {
+    const int d = blockIdx.x * blockDim.x + threadIdx.x;
+    if (d >= qkv_dim) return;
+    const int history = conv_kernel - 1;
+    for (int c = 0; c < history; c++) {
+        const int src_tok = n_tokens - history + c;
+        live_state[(size_t)c * qkv_dim + d] = src_tok >= 0
+            ? qkv[(size_t)src_tok * qkv_dim + d]
+            : live_state[(size_t)(c + n_tokens) * qkv_dim + d];
+    }
+}
+
+// DFlash causal-convolution counterpart. A single block owns one output head, seeds its rolling
+// window from decode state, and records the post-token window in decode layout for every row.
+template <bool WRITE_CHECKPOINT>
+__global__ void df_gdn_conv_checkpoint_kernel(
+    const __nv_bfloat16* __restrict__ qkv, const __nv_bfloat16* __restrict__ conv_w,
+    const __nv_bfloat16* __restrict__ live_state, __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ v,
+    __nv_bfloat16* __restrict__ checkpoints, int n_tokens, int q_heads, int v_heads,
+    int head_dim, int qkv_dim, int conv_kernel, float eps) {
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int blk = blockIdx.x, t = threadIdx.x;
+    int d, out_dim, hh; __nv_bfloat16* out; bool do_norm;
+    if (blk < q_heads) { hh = blk; d = hh * head_dim + t; out = q; out_dim = q_dim; do_norm = true; }
+    else if (blk < 2 * q_heads) { hh = blk - q_heads; d = q_dim + hh * head_dim + t; out = k; out_dim = q_dim; do_norm = true; }
+    else { hh = blk - 2 * q_heads; d = 2 * q_dim + hh * head_dim + t; out = v; out_dim = v_dim; do_norm = false; }
+    float w[8], hist[7];
+    #pragma unroll
+    for (int c = 0; c < 8; c++) w[c] = c < conv_kernel ? pf_to_f(conv_w[(size_t)d * conv_kernel + c]) : 0.f;
+    #pragma unroll
+    for (int c = 0; c < 7; c++) hist[c] = c < conv_kernel - 1 ? pf_to_f(live_state[(size_t)c * qkv_dim + d]) : 0.f;
+    __shared__ float sw[32];
+    const int nwarp = (blockDim.x + 31) / 32;
+    const size_t state_elems = (size_t)(conv_kernel - 1) * qkv_dim;
+    for (int tok = 0; tok < n_tokens; tok++) {
+        const float cur = pf_to_f(qkv[(size_t)tok * qkv_dim + d]);
+        float y = cur * w[conv_kernel - 1];
+        #pragma unroll
+        for (int c = 0; c < 7; c++) if (c < conv_kernel - 1) y += hist[c] * w[c];
+        #pragma unroll
+        for (int c = 0; c < 6; c++) if (c < conv_kernel - 2) hist[c] = hist[c + 1];
+        if (conv_kernel >= 2) hist[conv_kernel - 2] = cur;
+        float cval = pf_silu(y);
+        if (do_norm) {
+            float ss = pf_wsum(cval * cval);
+            if ((t & 31) == 0) sw[t >> 5] = ss;
+            __syncthreads();
+            if (t < 32) {
+                float vv = t < nwarp ? sw[t] : 0.f;
+                vv = pf_wsum(vv);
+                if (t == 0) sw[0] = rsqrtf(vv + eps);
+            }
+            __syncthreads();
+            cval *= sw[0];
+        }
+        out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
+        if constexpr (WRITE_CHECKPOINT) {
+            #pragma unroll
+            for (int c = 0; c < 7; c++) if (c < conv_kernel - 1)
+                checkpoints[(size_t)tok * state_elems + (size_t)c * qkv_dim + d] = __float2bfloat16(hist[c]);
+        }
+    }
+}
+
 // ============================================================================
 // Batched gated RMSNorm: out = (x/rms(x)) * weight * silu(z), per (token, v_head).
 // One warp per (token, v_head). Mirrors gated_norm_warp_kernel.
@@ -883,6 +1061,91 @@ void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
     if (head_dim == 128)
         pf_gdn_scan_kernel<COLS, 128><<<grid, COLS * 32, 0, stream>>>(
             qb, kb, vb, ab, bb, db, aa, state, ob, n_tokens, q_heads, v_heads);
+}
+
+void launch_dflash_gdn_conv(const void* qkv, const void* conv_w, const void* live_state,
+                            void* q, void* k, void* v, void* checkpoints,
+                            int n_tokens, int q_heads, int v_heads, int head_dim,
+                            int conv_kernel, float eps, cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim <= 0 || conv_kernel < 2 || conv_kernel > 8) return;
+    const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
+    df_gdn_conv_checkpoint_kernel<true><<<2 * q_heads + v_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
+        reinterpret_cast<const __nv_bfloat16*>(live_state), reinterpret_cast<__nv_bfloat16*>(q),
+        reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
+        reinterpret_cast<__nv_bfloat16*>(checkpoints), n_tokens, q_heads, v_heads,
+        head_dim, qkv_dim, conv_kernel, eps);
+}
+
+void launch_dflash_gdn_scan(const void* q, const void* k, const void* v,
+                            const void* alpha, const void* beta, const void* dt, const void* a,
+                            const float* live_state, void* out, float* checkpoints,
+                            int n_tokens, int q_heads, int v_heads, int head_dim,
+                            cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim != 128) return;
+    constexpr int COLS = 4;
+    dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
+    df_gdn_scan_checkpoint_kernel<COLS, 128, true><<<grid, COLS * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(alpha),
+        reinterpret_cast<const __nv_bfloat16*>(beta), reinterpret_cast<const __nv_bfloat16*>(dt),
+        reinterpret_cast<const __nv_bfloat16*>(a), live_state,
+        reinterpret_cast<__nv_bfloat16*>(out), checkpoints, n_tokens, q_heads, v_heads);
+}
+
+void launch_dflash_gdn_conv_compact(const void* qkv, const void* conv_w,
+                                    const void* live_state, void* q, void* k, void* v,
+                                    int n_tokens, int q_heads, int v_heads, int head_dim,
+                                    int conv_kernel, float eps, cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim <= 0 || conv_kernel < 2 || conv_kernel > 8) return;
+    const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
+    df_gdn_conv_checkpoint_kernel<false><<<2 * q_heads + v_heads, head_dim, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
+        reinterpret_cast<const __nv_bfloat16*>(live_state), reinterpret_cast<__nv_bfloat16*>(q),
+        reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v), nullptr,
+        n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps);
+}
+
+void launch_dflash_gdn_scan_compact(const void* q, const void* k, const void* v,
+                                    const void* alpha, const void* beta,
+                                    const void* dt, const void* a, const float* live_state,
+                                    void* out, int n_tokens, int q_heads, int v_heads,
+                                    int head_dim, cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim != 128) return;
+    constexpr int COLS = 4;
+    dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
+    df_gdn_scan_checkpoint_kernel<COLS, 128, false><<<grid, COLS * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(alpha),
+        reinterpret_cast<const __nv_bfloat16*>(beta), reinterpret_cast<const __nv_bfloat16*>(dt),
+        reinterpret_cast<const __nv_bfloat16*>(a), live_state,
+        reinterpret_cast<__nv_bfloat16*>(out), nullptr, n_tokens, q_heads, v_heads);
+}
+
+void launch_dflash_gdn_conv_commit(const void* qkv, void* live_state, int n_tokens,
+                                   int q_heads, int v_heads, int head_dim, int conv_kernel,
+                                   cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim <= 0 || conv_kernel < 2 || conv_kernel > 8) return;
+    const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
+    constexpr int BLOCK = 256;
+    df_gdn_conv_commit_kernel<<<(qkv_dim + BLOCK - 1) / BLOCK, BLOCK, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv),
+        reinterpret_cast<__nv_bfloat16*>(live_state), n_tokens, qkv_dim, conv_kernel);
+}
+
+void launch_dflash_gdn_scan_commit(const void* k, const void* v,
+                                   const void* alpha, const void* beta,
+                                   const void* dt, const void* a, float* live_state,
+                                   int n_tokens, int q_heads, int v_heads, int head_dim,
+                                   cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim != 128) return;
+    constexpr int COLS = 4;
+    dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
+    df_gdn_scan_commit_kernel<COLS, 128><<<grid, COLS * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(k), reinterpret_cast<const __nv_bfloat16*>(v),
+        reinterpret_cast<const __nv_bfloat16*>(alpha), reinterpret_cast<const __nv_bfloat16*>(beta),
+        reinterpret_cast<const __nv_bfloat16*>(dt), reinterpret_cast<const __nv_bfloat16*>(a),
+        live_state, n_tokens, q_heads, v_heads);
 }
 
 void launch_prefill_gated_norm(const void* x, const void* z, const void* weight, void* out,

--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -53,6 +53,12 @@ __global__ void sigmoid_scalar_kernel(const __nv_bfloat16* __restrict__ x,
     out[0] = q36_sigmoid(q36_to_f(x[0]));
 }
 
+__global__ void sigmoid_rows_kernel(const __nv_bfloat16* __restrict__ x,
+                                    float* __restrict__ out, int rows) {
+    const int r = blockIdx.x * blockDim.x + threadIdx.x;
+    if (r < rows) out[r] = q36_sigmoid(q36_to_f(x[r]));
+}
+
 // Shared-expert SwiGLU: out[i] = dw * SiLU(gate[i]) * up[i]. The shared-expert
 // gate scalar dw folds in here (down is linear, so scaling the intermediate is
 // identical to scaling the output), letting the caller finish with a plain add.
@@ -63,6 +69,19 @@ __global__ void shared_swiglu_kernel(const __nv_bfloat16* __restrict__ gate,
     const int i = blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
     out[i] = __float2bfloat16((*dw) * q36_silu(q36_to_f(gate[i])) * q36_to_f(up[i]));
+}
+
+
+__global__ void shared_swiglu_rows_kernel(const __nv_bfloat16* __restrict__ gate,
+                                          const __nv_bfloat16* __restrict__ up,
+                                          const float* __restrict__ dw,
+                                          __nv_bfloat16* __restrict__ out,
+                                          int rows, int ffn) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    const int n = rows * ffn;
+    if (i >= n) return;
+    const int row = i / ffn;
+    out[i] = __float2bfloat16(dw[row] * q36_silu(q36_to_f(gate[i])) * q36_to_f(up[i]));
 }
 
 __global__ void conv_split_kernel(const __nv_bfloat16* __restrict__ qkv,
@@ -458,6 +477,16 @@ void launch_qwen36_shared_swiglu(const void* gate_bf16, const void* up_bf16,
         dw_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16), n);
 }
 
+void launch_qwen36_shared_swiglu_rows(const void* gate_bf16, const void* up_bf16,
+                                      const float* dw_f32, void* out_bf16,
+                                      int rows, int ffn, cudaStream_t stream) {
+    const int n = rows * ffn;
+    shared_swiglu_rows_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gate_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(up_bf16), dw_f32,
+        reinterpret_cast<__nv_bfloat16*>(out_bf16), rows, ffn);
+}
+
 void launch_qwen36_split_q_gate(const void* qg_bf16, void* q_bf16, void* gate_bf16,
                                 int n_heads, int head_dim, cudaStream_t stream) {
     const int n = n_heads * head_dim;
@@ -478,6 +507,14 @@ void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32,
                                   cudaStream_t stream) {
     sigmoid_scalar_kernel<<<1, 1, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x_bf16), out_f32);
+}
+
+
+void launch_qwen36_sigmoid_rows(const void* x_bf16, float* out_f32, int rows,
+                                cudaStream_t stream) {
+    if (rows <= 0) return;
+    sigmoid_rows_kernel<<<(rows + 31) / 32, 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x_bf16), out_f32, rows);
 }
 
 void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -184,12 +184,13 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
                                        __nv_bfloat16* __restrict__ out_norm,
                                        si_blk_q8_1* __restrict__ out_q8,
                                        int cols, float eps) {
-    const size_t base = 0;
+    const size_t base = (size_t)blockIdx.x * cols;
     __shared__ float s_warp[32];
     const int t = threadIdx.x;
-    const uint4* x4 = reinterpret_cast<const uint4*>(x);
-    const uint4* r4 = reinterpret_cast<const uint4*>(residual);
-    uint4* osum4 = reinterpret_cast<uint4*>(out_sum);
+    const uint4* x4 = reinterpret_cast<const uint4*>(x + base);
+    const uint4* r4 = reinterpret_cast<const uint4*>(residual + base);
+    uint4* osum4 = reinterpret_cast<uint4*>(out_sum + base);
+    out_q8 += (size_t)blockIdx.x * (cols >> 5);
 
     float xv[8], rv[8]; rn_unpack8(__ldg(x4 + t), xv); rn_unpack8(__ldg(r4 + t), rv);
     float sv[8]; float ss = 0.f;
@@ -210,12 +211,12 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     // Re-read the bf16-rounded residual sum (exactly as add_rmsnorm2_kernel does), so out_norm
     // is bit-identical to the unfused path; then derive Q8_1 from the bf16-rounded out_norm.
     const uint4* w4 = reinterpret_cast<const uint4*>(weight);
-    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum);
+    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum + base);
     float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
     float ov[8], bv[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
-    reinterpret_cast<uint4*>(out_norm)[t] = rn_pack8(ov);
+    reinterpret_cast<uint4*>(out_norm + base)[t] = rn_pack8(ov);
 
     // Q8_1 of the bf16-rounded out_norm. 32-block = 4 consecutive threads (t&~3 .. +3).
     float amax = 0.f;
@@ -246,10 +247,12 @@ __global__ void add_rmsnorm3_q8_kernel(const __nv_bfloat16* __restrict__ x,
                                        int cols, float eps) {
     __shared__ float s_warp[32];
     const int t = threadIdx.x;
-    const uint4* x4  = reinterpret_cast<const uint4*>(x);
-    const uint4* r14 = reinterpret_cast<const uint4*>(res1);
-    const uint4* r24 = reinterpret_cast<const uint4*>(res2);
-    uint4* osum4 = reinterpret_cast<uint4*>(out_sum);
+    const size_t base = (size_t)blockIdx.x * cols;
+    const uint4* x4  = reinterpret_cast<const uint4*>(x + base);
+    const uint4* r14 = reinterpret_cast<const uint4*>(res1 + base);
+    const uint4* r24 = reinterpret_cast<const uint4*>(res2 + base);
+    uint4* osum4 = reinterpret_cast<uint4*>(out_sum + base);
+    out_q8 += (size_t)blockIdx.x * (cols >> 5);
 
     float xv[8], r1v[8], r2v[8];
     rn_unpack8(__ldg(x4 + t), xv); rn_unpack8(__ldg(r14 + t), r1v); rn_unpack8(__ldg(r24 + t), r2v);
@@ -273,12 +276,12 @@ __global__ void add_rmsnorm3_q8_kernel(const __nv_bfloat16* __restrict__ x,
     const float inv_rms = s_warp[0];
 
     const uint4* w4 = reinterpret_cast<const uint4*>(weight);
-    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum);
+    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum + base);
     float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
     float ov[8], bv[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
-    reinterpret_cast<uint4*>(out_norm)[t] = rn_pack8(ov);
+    reinterpret_cast<uint4*>(out_norm + base)[t] = rn_pack8(ov);
 
     float amax = 0.f;
     #pragma unroll
@@ -450,6 +453,27 @@ void launch_add_rmsnorm3_q8(const void* x, const void* res1, const void* res2, c
         reinterpret_cast<const __nv_bfloat16*>(weight),
         reinterpret_cast<__nv_bfloat16*>(out_sum),
         reinterpret_cast<__nv_bfloat16*>(out_norm),
+        reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
+}
+
+void launch_add_rmsnorm2_q8_rows(const void* x, const void* residual, const void* weight,
+                                 void* out_sum, void* out_norm, void* out_q8,
+                                 int rows, int cols, float eps, cudaStream_t stream) {
+    assert(rows > 0 && cols % 256 == 0 && (cols >> 3) <= 1024);
+    add_rmsnorm2_q8_kernel<<<rows, cols >> 3, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(weight), reinterpret_cast<__nv_bfloat16*>(out_sum),
+        reinterpret_cast<__nv_bfloat16*>(out_norm), reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
+}
+
+void launch_add_rmsnorm3_q8_rows(const void* x, const void* res1, const void* res2,
+                                 const void* weight, void* out_sum, void* out_norm, void* out_q8,
+                                 int rows, int cols, float eps, cudaStream_t stream) {
+    assert(rows > 0 && cols % 256 == 0 && (cols >> 3) <= 1024);
+    add_rmsnorm3_q8_kernel<<<rows, cols >> 3, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(res1),
+        reinterpret_cast<const __nv_bfloat16*>(res2), reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out_sum), reinterpret_cast<__nv_bfloat16*>(out_norm),
         reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
 }
 

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -661,6 +661,58 @@ template __global__ void si_mmvq_q80_kfixed_kernel<float, 64>(const si_block_q8_
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q80_kfixed_kernel<float, 128>(const si_block_q8_1*, const unsigned char*, float*, int);
 #endif
+template <typename OutT, int NBLOCKS, int MMAX>
+__global__ void si_mmvq_q80_rows_exact_kernel(const si_block_q8_1* __restrict__ q,
+                                              const unsigned char* __restrict__ W,
+                                              OutT* __restrict__ y, int M, int N) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    if (row >= N) return;
+    const unsigned char* w_row = W + (size_t)row * NBLOCKS * 34;
+    float tmp[MMAX];
+    #pragma unroll
+    for (int m = 0; m < MMAX; m++) tmp[m] = 0.f;
+    #pragma unroll
+    for (int kb = tid; kb < NBLOCKS; kb += NW * WS) {
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) {
+            if (m < M)
+                tmp[m] += si_vec_dot_q8_0_mmvq(w_row + (size_t)kb * 34,
+                                               q + (size_t)m * NBLOCKS + kb);
+        }
+    }
+    __shared__ float partial[MMAX][NW - 1][WS];
+    if (warp > 0) {
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) if (m < M) partial[m][warp - 1][lane] = tmp[m];
+    }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int m = 0; m < MMAX; m++) {
+        if (m >= M) break;
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tmp[m] += partial[m][l][lane];
+        #pragma unroll
+        for (int s = 16; s > 0; s >>= 1) tmp[m] += __shfl_xor_sync(0xffffffff, tmp[m], s);
+        if (lane == 0) gemv_write(y + (size_t)m * N + row, tmp[m]);
+    }
+}
+#ifndef _MSC_VER
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 4>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 4>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 4>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 16, 4>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 64, 4>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 128, 4>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+#endif
 template <typename OutT, int NSUPER>
 __global__ void si_mmvq_q4k_kfixed_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
                                           OutT* __restrict__ y, int N) {
@@ -698,6 +750,60 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<float, 8>(const si_block_q8_1
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+#endif
+// Short-row Q4_K MMVQ for exact target verification. The thread-to-fragment mapping and the
+// two-stage four-warp reduction are identical to si_mmvq_q4k_kfixed_kernel. Each CTA owns one
+// weight row and evaluates up to four activation rows before eviction, turning repeated HBM
+// reads into intra-CTA cache hits without changing any per-row floating-point association.
+template <typename OutT, int NSUPER, int MMAX>
+__global__ void si_mmvq_q4k_rows_exact_kernel(const si_block_q8_1* __restrict__ q,
+                                              const unsigned char* __restrict__ W,
+                                              OutT* __restrict__ y, int M, int N) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    constexpr int QPR = NSUPER * 8;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    if (row >= N) return;
+    const si_block_q4_K* x_row = reinterpret_cast<const si_block_q4_K*>(
+        W + (size_t)row * NSUPER * 144);
+    constexpr int blocks_per_iter = vdr * NW * WS / qi;
+    float tmp[MMAX];
+    #pragma unroll
+    for (int m = 0; m < MMAX; m++) tmp[m] = 0.f;
+    #pragma unroll
+    for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+        const int kqs = vdr * (tid % (qi / vdr));
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) {
+            if (m < M) tmp[m] += si_vec_dot_q4_K(x_row + kbx, q + (size_t)m * QPR + kbx * 8, kqs);
+        }
+    }
+    __shared__ float partial[MMAX][NW - 1][WS];
+    if (warp > 0) {
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) if (m < M) partial[m][warp - 1][lane] = tmp[m];
+    }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int m = 0; m < MMAX; m++) {
+        if (m >= M) break;
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tmp[m] += partial[m][l][lane];
+        #pragma unroll
+        for (int s = 16; s > 0; s >>= 1) tmp[m] += __shfl_xor_sync(0xffffffff, tmp[m], s);
+        if (lane == 0) gemv_write(y + (size_t)m * N + row, tmp[m]);
+    }
+}
+#ifndef _MSC_VER
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 4>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 4>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 4>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 4>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
 #endif
 // One block per row index: warps 0-3 -> qkv[row], warps 4-7 -> z[row], keeping vy hot
 // in L2 across both when row < min(n_qkv, n_z). Grid = max(n_qkv, n_z).
@@ -1023,6 +1129,61 @@ template __global__ void si_mmvq_q6k_kfixed_kernel<float, 8>(const si_block_q8_1
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q6k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+#endif
+
+// Exact short-row Q6_K counterpart to si_mmvq_q4k_rows_exact_kernel. Four warps retain the
+// decode kernel's fragment ownership and two-stage reduction for every activation row, while the
+// CTA keeps the shared weight row hot across up to four verifier candidates.
+template <typename OutT, int NSUPER, int MMAX>
+__global__ void si_mmvq_q6k_rows_exact_kernel(const si_block_q8_1* __restrict__ q,
+                                              const unsigned char* __restrict__ W,
+                                              OutT* __restrict__ y, int M, int N) {
+    constexpr int NW = 4, WS = 32, vdr = 1, qi = 32;
+    constexpr int QPR = NSUPER * 8;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    if (row >= N) return;
+    const unsigned char* x_row = W + (size_t)row * NSUPER * 210;
+    constexpr int blocks_per_iter = vdr * NW * WS / qi;
+    float tmp[MMAX];
+    #pragma unroll
+    for (int m = 0; m < MMAX; m++) tmp[m] = 0.f;
+    #pragma unroll
+    for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+        const int kqs = vdr * (tid % (qi / vdr));
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) {
+            if (m < M)
+                tmp[m] += si_vec_dot_q6_K(x_row + (size_t)kbx * 210,
+                                           q + (size_t)m * QPR + kbx * 8, kqs);
+        }
+    }
+    __shared__ float partial[MMAX][NW - 1][WS];
+    if (warp > 0) {
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) if (m < M) partial[m][warp - 1][lane] = tmp[m];
+    }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int m = 0; m < MMAX; m++) {
+        if (m >= M) break;
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tmp[m] += partial[m][l][lane];
+        #pragma unroll
+        for (int s = 16; s > 0; s >>= 1) tmp[m] += __shfl_xor_sync(0xffffffff, tmp[m], s);
+        if (lane == 0) gemv_write(y + (size_t)m * N + row, tmp[m]);
+    }
+}
+#ifndef _MSC_VER
+template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 4>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 4>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 8, 4>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 16, 4>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
 #endif
 // 1-warp-per-row Q6_K dp4a GEMV: keeps the fp32 gemv_q block structure (GEMV_WPB rows/block,
 // well-occupied for large N like the LM head's 151936 rows) but dp4a instead of fp32 dequant.
@@ -1467,6 +1628,91 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
     else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
+}
+bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
+                          int M, int N, int K, cudaStream_t stream) {
+    if (M < 1 || M > 4 || N < 1 || (K != 2048 && K != 4096)) return false;
+    if (K == 2048)
+        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 4><<<N, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    else
+        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 4><<<N, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    return true;
+}
+bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,
+                          int M, int N, int K, cudaStream_t stream) {
+    if (M < 1 || M > 4 || N < 1 || (K != 2048 && K != 4096)) return false;
+    if (K == 2048)
+        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 4><<<N, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    else
+        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 4><<<N, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    return true;
+}
+bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
+                          int M, int N, int K, cudaStream_t stream) {
+    if (M < 1 || M > 4 || N < 1 || (K != 512 && K != 2048 && K != 4096)) return false;
+    if (K == 512)
+        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 4><<<N, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    else if (K == 2048)
+        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 4><<<N, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    else
+        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 4><<<N, 4 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(W),
+            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    return true;
+}
+bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
+                      int M, int N, int K, cudaStream_t stream) {
+    if (qtype == 12) return launch_mmvq_q4k_rows(q81, W, y, M, N, K, stream);
+    if (qtype == 14) return launch_mmvq_q6k_rows(q81, W, y, M, N, K, stream);
+    if (qtype == 8)  return launch_mmvq_q80_rows(q81, W, y, M, N, K, stream);
+    return false;
+}
+bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
+                          int M, int N, int K, cudaStream_t stream) {
+    if (M < 1 || M > 4 || N < 1) return false;
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const auto* w = reinterpret_cast<const unsigned char*>(W);
+    if (qtype == 12 && (K == 2048 || K == 4096)) {
+        if (K == 2048)
+            si_mmvq_q4k_rows_exact_kernel<float, 8, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        else
+            si_mmvq_q4k_rows_exact_kernel<float, 16, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        return true;
+    }
+    if (qtype == 14 && (K == 2048 || K == 4096)) {
+        if (K == 2048)
+            si_mmvq_q6k_rows_exact_kernel<float, 8, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        else
+            si_mmvq_q6k_rows_exact_kernel<float, 16, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        return true;
+    }
+    if (qtype == 8 && (K == 512 || K == 2048 || K == 4096)) {
+        if (K == 512)
+            si_mmvq_q80_rows_exact_kernel<float, 16, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        else if (K == 2048)
+            si_mmvq_q80_rows_exact_kernel<float, 64, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        else
+            si_mmvq_q80_rows_exact_kernel<float, 128, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        return true;
+    }
+    return false;
 }
 void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -52,6 +52,16 @@ void launch_qknorm_rope_kv_partial(
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
     float theta, float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr);
 
+// DFlash short-block continuation for one sequence. `positions` has n_tokens absolute positions,
+// while `block_table` is a single sequence row (not n_tokens repeated rows). Math and bf16 KV
+// layout are identical to launch_qknorm_rope_kv_partial.
+void launch_dflash_qknorm_rope_kv_partial(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
+    float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream = nullptr);
+
 // Fused QK-norm + partial-RoPE + int8 KV-append for Qwen3.6 hd256 full-attn layers.
 void launch_qknorm_rope_kv_partial_int8(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
@@ -67,6 +77,15 @@ void launch_qknorm_rope_kv_partial_int8_gated(
     const int* block_table, const int* positions,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
     float theta, float eps, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr);
+
+// Exact DFlash continuation variant: all candidate positions share one sequence block-table row.
+void launch_dflash_qknorm_rope_kv_partial_int8_gated(
+    const void* qraw, void* q, void* qgate, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, void* k_scale, void* v_scale,
+    const int* block_table, const int* positions,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
+    float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream = nullptr);
 
 // Variant for models with partial rotary embeddings (e.g. Qwen3.6: 64 of 256
 // dimensions rotate, the remaining per-head dimensions are copied unchanged).

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -24,6 +24,10 @@ void launch_add_rmsnorm2(const void* x_bf16, const void* residual_bf16, const vo
 void launch_add_rmsnorm2_q8(const void* x_bf16, const void* residual_bf16, const void* weight_bf16,
                             void* out_sum_bf16, void* out_norm_bf16, void* out_q8,
                             int cols, float eps, cudaStream_t stream = nullptr);
+void launch_add_rmsnorm2_q8_rows(const void* x_bf16, const void* residual_bf16,
+                                 const void* weight_bf16, void* out_sum_bf16,
+                                 void* out_norm_bf16, void* out_q8, int rows, int cols,
+                                 float eps, cudaStream_t stream = nullptr);
 
 // Fold residual_add(res1,res2) into add_rmsnorm2: out_sum = x + (res1 + res2).
 void launch_add_rmsnorm3(const void* x_bf16, const void* res1_bf16, const void* res2_bf16,
@@ -32,6 +36,10 @@ void launch_add_rmsnorm3(const void* x_bf16, const void* res1_bf16, const void* 
 void launch_add_rmsnorm3_q8(const void* x_bf16, const void* res1_bf16, const void* res2_bf16,
                             const void* weight_bf16, void* out_sum_bf16, void* out_norm_bf16,
                             void* out_q8, int cols, float eps, cudaStream_t stream = nullptr);
+void launch_add_rmsnorm3_q8_rows(const void* x_bf16, const void* res1_bf16,
+                                 const void* res2_bf16, const void* weight_bf16,
+                                 void* out_sum_bf16, void* out_norm_bf16, void* out_q8,
+                                 int rows, int cols, float eps, cudaStream_t stream = nullptr);
 
 // Fused per-head Q-norm + K-norm in one kernel (1 graph node vs 2). In-place on q/k.
 void launch_rmsnorm_qk(void* q, void* k, const void* q_w, const void* k_w,
@@ -59,11 +67,16 @@ void launch_qwen36_mul_sigmoid(void* x_bf16, const void* gate_bf16, int n,
 
 void launch_qwen36_sigmoid_scalar(const void* x_bf16, float* out_f32,
                                   cudaStream_t stream = nullptr);
+void launch_qwen36_sigmoid_rows(const void* x_bf16, float* out_f32, int rows,
+                                cudaStream_t stream = nullptr);
 
 // Shared-expert SwiGLU with folded gate scalar: out[i] = dw * SiLU(gate[i]) * up[i].
 void launch_qwen36_shared_swiglu(const void* gate_bf16, const void* up_bf16,
                                  const float* dw_f32, void* out_bf16, int n,
                                  cudaStream_t stream = nullptr);
+void launch_qwen36_shared_swiglu_rows(const void* gate_bf16, const void* up_bf16,
+                                      const float* dw_f32, void* out_bf16,
+                                      int rows, int ffn, cudaStream_t stream = nullptr);
 
 void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
                                  void* conv_state_bf16, void* q_bf16, void* k_bf16,

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -80,6 +80,12 @@ void launch_quantize_q8_1_rows(const void* x, void* y, int K, int rows, int x_st
                                cudaStream_t stream = nullptr);
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
+
+// Exact short-row target verifier: M contiguous Q8_1 activations against one Q4_K matrix.
+// Preserves launch_mmvq_q4k's four-warp dot/reduction order independently for every row while
+// sharing the weight traffic within a CTA. y is row-major [M,N]. Returns false if unsupported.
+bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
+                          int M, int N, int K, cudaStream_t stream = nullptr);
 // Fused GDN qkv+z Q4_K MMVQ (shared Q8_1 activation). K is hidden (2048 -> NSUPER=8, 4096 -> 16).
 void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void* z_w,
                                  void* qkv_out, void* z_out, int n_qkv, int n_z, int K,
@@ -89,9 +95,21 @@ void launch_mmvq_q4k_sigmoid(const void* q81, const void* W, float* out, int K, 
 // Same, for Q6_K weights (attn-V upgrades + LM head). q81 = block_q8_1(activation).
 void launch_mmvq_q6k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
+// Exact short-row Q6_K target projection, matching the four-warp decode association per row.
+bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,
+                          int M, int N, int K, cudaStream_t stream = nullptr);
 // Q8_0 x Q8_1 dp4a mmvq (Qwen3.6 UD attention/GDN projections kept int8 on device)
 void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q80_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
+// Exact short-row Q8_0 target projection, matching the four-warp decode association per row.
+bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
+                          int M, int N, int K, cudaStream_t stream = nullptr);
+// GGUF dispatch for exact short-row projections (Q8_0=8, Q4_K=12, Q6_K=14).
+bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
+                      int M, int N, int K, cudaStream_t stream = nullptr);
+// FP32-output counterpart for verifier logits. It preserves the serial decode reduction order.
+bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
+                          int M, int N, int K, cudaStream_t stream = nullptr);
 // GDN: four Q4_K projections from one block_q8_1 activation in a single grid (K=2048).
 void launch_gdn_quad_mmvq_q4k(const void* q81,
     const void* W0, const void* W1, const void* W2, const void* W3,

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -64,6 +64,47 @@ void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
                              int n_tokens, int q_heads, int v_heads, int head_dim,
                              cudaStream_t stream = nullptr);
 
+// DFlash short-block variants. They start from the live decode state but leave it untouched,
+// writing a complete post-token checkpoint for every candidate row. checkpoint[t] uses the same
+// layout as live_state, so committing the accepted prefix is one device-to-device row copy.
+void launch_dflash_gdn_conv(const void* qkv, const void* conv_w, const void* live_state,
+                            void* q, void* k, void* v, void* checkpoints,
+                            int n_tokens, int q_heads, int v_heads, int head_dim,
+                            int conv_kernel, float eps, cudaStream_t stream = nullptr);
+
+void launch_dflash_gdn_scan(const void* q, const void* k, const void* v,
+                            const void* alpha, const void* beta,
+                            const void* dt, const void* a, const float* live_state,
+                            void* out, float* checkpoints,
+                            int n_tokens, int q_heads, int v_heads, int head_dim,
+                            cudaStream_t stream = nullptr);
+
+// Verification-only forms: produce every candidate activation from the live state without
+// mutating it or writing O(N * state_size) checkpoints. The compact inputs are committed later.
+void launch_dflash_gdn_conv_compact(const void* qkv, const void* conv_w,
+                                    const void* live_state, void* q, void* k, void* v,
+                                    int n_tokens, int q_heads, int v_heads, int head_dim,
+                                    int conv_kernel, float eps, cudaStream_t stream = nullptr);
+
+void launch_dflash_gdn_scan_compact(const void* q, const void* k, const void* v,
+                                    const void* alpha, const void* beta,
+                                    const void* dt, const void* a, const float* live_state,
+                                    void* out, int n_tokens, int q_heads, int v_heads,
+                                    int head_dim, cudaStream_t stream = nullptr);
+
+// Compact accepted-prefix commit. Verification retains qkv plus k/v/alpha/beta per GDN layer;
+// these launchers update the live decode state once after posterior selection, avoiding both
+// per-candidate full-state checkpoints and target-token replay.
+void launch_dflash_gdn_conv_commit(const void* qkv, void* live_state, int n_tokens,
+                                   int q_heads, int v_heads, int head_dim, int conv_kernel,
+                                   cudaStream_t stream = nullptr);
+
+void launch_dflash_gdn_scan_commit(const void* k, const void* v,
+                                   const void* alpha, const void* beta,
+                                   const void* dt, const void* a, float* live_state,
+                                   int n_tokens, int q_heads, int v_heads, int head_dim,
+                                   cudaStream_t stream = nullptr);
+
 // Batched gated RMSNorm: out[t,h,:] = (x/rms(x)) * weight * silu(z), per (token, v_head).
 //   x/z: [N, v_heads*hd]   weight: [hd]   out: [N, v_heads*hd]
 void launch_prefill_gated_norm(const void* x, const void* z, const void* weight, void* out,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1562,7 +1562,7 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
                           lin_state, lin_conv,
                           s.logits, s.d_out_id, s.h_out_id, s.gguf,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
-                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down };
+                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits };
     return prefill_batched_run(ctx, prompt_ids, n);
 }
 
@@ -1785,11 +1785,19 @@ bool Qwen35Model::verify_block(const int* token_ids, int n, int start_pos, int* 
 }
 
 bool Qwen35Model::batched_forward(const int* token_ids, int n, int start_pos, bool /*resume_gdn*/,
-                                  int* out_argmax, const void* /*dflash_capture_dst*/) {
-    // Phase 3 gate: true batched hybrid verify (multi-token GDN+MoE) lands only after
-    // SPEC_AGREE + single-stream speedup. Token-loop verify is correct for GDN advance.
-    // Full-block accept in dflash_generate already skips rollback when accept==B-1.
-    return verify_block(token_ids, n, start_pos, out_argmax);
+                                  int* out_argmax, const void* dflash_capture_dst) {
+    Impl& s = *p_;
+    auto it = s.sessions.find(s.active_seq_id);
+    float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
+    bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
+    Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
+                          lin_state, lin_conv, s.logits, s.d_out_id, s.h_out_id, s.gguf,
+                          s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
+                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits };
+    const int consumed = dflash_verify_short_run(ctx, token_ids, n, start_pos,
+                                                  s.dflash_layer_ids.data(), s.dflash_n_cap,
+                                                  const_cast<void*>(dflash_capture_dst), out_argmax);
+    return consumed > 0;
 }
 
 std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, int max_new,
@@ -1860,6 +1868,14 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 3;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
+    // 0=off, 1=force, 2=adaptive (default). Adaptive preserves early-exit verification on
+    // low-acceptance workloads and switches to the weight-reusing four-row graph only after two
+    // consecutive full-block accepts.
+    static const int compact_mode = []{
+        const char* e = getenv("SPARKINFER_DFLASH_COMPACT_VERIFY");
+        return e ? atoi(e) : 2;
+    }();
+    int compact_score = 0;
     bf16* th_scratch = nullptr;
     const int row_stride = dflash_hidden_row_stride();
     if (cudaMalloc(&th_scratch, (size_t)B * row_stride * sizeof(bf16)) != cudaSuccess) {
@@ -1870,6 +1886,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     }
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
+        const bool compact_verify = compact_mode == 1 || (compact_mode != 0 && compact_score >= 2);
         block[0] = next;
         for (int i = 1; i < B; i++) block[i] = mask_id;
 
@@ -1889,13 +1906,16 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // draft block on its own stream. Ordering matters: the target must be in flight before
         // the draft's launches start, or the draft queues ahead of it. A deferred collect also
         // avoids spawning and joining a std::thread on every decode step.
-        set_dflash_capture_row(0);
-        s.defer_decode_sync = true;
-        int p0 = forward_token(block[0], start, true);
-        s.defer_decode_sync = false;
+        int p0 = -1;
+        if (!compact_verify) {
+            set_dflash_capture_row(0);
+            s.defer_decode_sync = true;
+            p0 = forward_token(block[0], start, true);
+            s.defer_decode_sync = false;
+        }
         const bool draft_ok = draft.forward_block(
             draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr);
-        if (p0 == kDFlashDeferred) {
+        if (!compact_verify && p0 == kDFlashDeferred) {
             cu(cudaStreamSynchronize(s.stream), "verify0 sync");
             s.decode_pending = false;
             p0 = *s.h_out_id;
@@ -1912,9 +1932,19 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // restore / KV-truncate / replay needed (greedy speculative decoding is exact). Rejected
         // proposals (block[keep..B-1]) are never forwarded, saving ~B-keep target forwards/step.
         int accept = 0, keep = 1;
-        bool vfail = p0 < 0;
-        posterior[0] = p0;
-        if (!vfail && block[1] == p0) {
+        bool vfail = false;
+        if (compact_verify) {
+            const int vn = kProposalDepth + 1;
+            vfail = !batched_forward(block.data(), vn, start, false, posterior.data(), s.dflash_hidden);
+            if (!vfail) {
+                while (accept < kProposalDepth && block[accept + 1] == posterior[accept]) ++accept;
+                keep = accept + 1;
+            }
+        } else {
+            vfail = p0 < 0;
+            posterior[0] = p0;
+        }
+        if (!compact_verify && !vfail && block[1] == p0) {
             for (int i = 1; i <= kProposalDepth; i++) {
                 set_dflash_capture_row(i);
                 const int p = forward_token(block[i], start + i, true);
@@ -1926,6 +1956,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             }
         }
         if (vfail) { fprintf(stderr, "[dflash] verify failed at start=%d\n", start); break; }
+        compact_score = keep == kProposalDepth + 1 ? std::min(compact_score + 1, 3) : 0;
         // forward_token() synchronizes after sampling, so the accepted capture rows are already
         // stable. The draft consumes only this newly accepted suffix; its KV cache retains all
         // earlier context. Hand the capture buffer over directly instead of copying it to a second

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1053,7 +1053,11 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                         kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
                     }
                 }
-                if (w.shared_gate_inp && !(s.use_pq && s.use_llama && w.shared_gate_inp_type == 12 && H == 2048))
+                // The dense gate branch above already applies sigmoid (either fused into
+                // launch_gemv_sigmoid or as its split follow-up). Only quantized projections
+                // that leave a raw scalar in shared_gate_tmp need this common epilogue.
+                if (w.shared_gate_inp && w.shared_gate_inp_type != 0 &&
+                    !(s.use_pq && s.use_llama && w.shared_gate_inp_type == 12 && H == 2048))
                     kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
             }
             if (qmoe) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -22,12 +22,14 @@
 #include "sparkinfer/kernels/prefill_router_mma.h"
 #include "sparkinfer/kernels/prefill_moe_q.h"
 #include "sparkinfer/kernels/moe.h"
+#include "sparkinfer/kernels/attention.h"
 
 #include <cuda_runtime.h>
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <vector>
 
 namespace sparkinfer {
@@ -40,15 +42,30 @@ inline void pf_cu(cudaError_t e, const char* what) {
 // Simple device-buffer arena: all-or-nothing allocation with one free() at the end.
 struct Arena {
     std::vector<void*> bufs;
+    std::vector<size_t> sizes;
+    size_t cursor = 0;
     bool ok = true;
     template <class T> T* alloc(size_t n) {
-        void* p = nullptr;
         if (n == 0) n = 1;
-        if (cudaMalloc(&p, n * sizeof(T)) != cudaSuccess) { ok = false; return nullptr; }
-        bufs.push_back(p);
+        const size_t bytes = n * sizeof(T);
+        void* p = nullptr;
+        if (cursor < bufs.size() && sizes[cursor] >= bytes) {
+            p = bufs[cursor++];
+            return static_cast<T*>(p);
+        }
+        if (cursor < bufs.size()) {
+            cudaFree(bufs[cursor]);
+            bufs.erase(bufs.begin() + cursor);
+            sizes.erase(sizes.begin() + cursor);
+        }
+        if (cudaMalloc(&p, bytes) != cudaSuccess) { ok = false; return nullptr; }
+        bufs.insert(bufs.begin() + cursor, p);
+        sizes.insert(sizes.begin() + cursor, bytes);
+        ++cursor;
         return static_cast<T*>(p);
     }
-    void free_all() { for (void* b : bufs) cudaFree(b); bufs.clear(); }
+    void rewind() { cursor = 0; ok = true; }
+    void free_all() { for (void* b : bufs) cudaFree(b); bufs.clear(); sizes.clear(); cursor = 0; }
 };
 } // namespace
 
@@ -1167,6 +1184,310 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     am.free_all();
     aw.free_all();
     return seed;
+}
+
+int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int n, int start_pos,
+                            const int* capture_layers, int n_capture, void* capture_dst,
+                            int* out_argmax) {
+    const Qwen35Config& c = s.cfg;
+    if (!token_ids || !out_argmax || n < 1 || n > 4 || !s.gguf || !c.hybrid || c.dense_ffn) {
+        fprintf(stderr, "[dflash-verify] base unsupported n=%d gguf=%d hybrid=%d dense=%d\n",
+                n, (int)s.gguf, (int)c.hybrid, (int)c.dense_ffn);
+        return -1;
+    }
+    if (c.head_dim != 256 || c.linear_head_dim != 128 || c.n_experts != 256 || c.top_k <= 0) {
+        fprintf(stderr, "[dflash-verify] shape unsupported hd=%d lhd=%d experts=%d topk=%d\n",
+                c.head_dim, c.linear_head_dim, c.n_experts, c.top_k);
+        return -1;
+    }
+    const int H = c.hidden, N = n, qdim = s.qdim, kvdim = s.kvdim;
+    const int lqkv = s.linear_qkvdim, lvdim = s.linear_vdim, vh = c.linear_v_heads;
+    const int ffn = c.moe_ffn, E = c.n_experts, topk = c.top_k;
+    cudaStream_t st = s.stream;
+    static thread_local Arena verify_arena;
+    verify_arena.rewind();
+    Arena& a = verify_arena;
+    bf16* x = a.alloc<bf16>((size_t)N * H);
+    bf16* xn = a.alloc<bf16>((size_t)N * H);
+    bf16* h = a.alloc<bf16>((size_t)N * H);
+    bf16* hn = a.alloc<bf16>((size_t)N * H);
+    bf16* ao = a.alloc<bf16>((size_t)N * H);
+    bf16* routed = a.alloc<bf16>((size_t)N * H);
+    bf16* shared = a.alloc<bf16>((size_t)N * H);
+    bf16* b8 = a.alloc<bf16>((size_t)N * 2 * qdim);
+    bf16* lz = a.alloc<bf16>((size_t)N * lvdim);
+    bf16* gq = a.alloc<bf16>((size_t)N * s.linear_qdim);
+    bf16* gk = a.alloc<bf16>((size_t)N * s.linear_qdim);
+    bf16* gv = a.alloc<bf16>((size_t)N * lvdim);
+    bf16* att = a.alloc<bf16>((size_t)N * lvdim);
+    bf16* lnrm = a.alloc<bf16>((size_t)N * lvdim);
+    bf16* la = a.alloc<bf16>((size_t)N * vh);
+    bf16* lb = a.alloc<bf16>((size_t)N * vh);
+    bf16* qb = gv;
+    bf16* qg = lnrm;
+    bf16* kf = gq;
+    bf16* vf = gk;
+    bf16* sg = a.alloc<bf16>((size_t)N * ffn);
+    bf16* su = a.alloc<bf16>((size_t)N * ffn);
+    bf16* sh = a.alloc<bf16>((size_t)N * ffn);
+    bf16* gate_raw = a.alloc<bf16>(N);
+    float* gate_w = a.alloc<float>(N);
+    int* ids = a.alloc<int>(N);
+    int* pos = a.alloc<int>(N);
+    int* seq = a.alloc<int>(N);
+    int* expert_ids = a.alloc<int>((size_t)N * topk);
+    float* expert_w = a.alloc<float>((size_t)N * topk);
+    float* router_logits = a.alloc<float>((size_t)N * E);
+    float* moe_h = a.alloc<float>((size_t)N * topk * ffn);
+    float* moe_out = a.alloc<float>((size_t)N * H);
+    float* logits = a.alloc<float>((size_t)N * c.vocab);
+    int* out_ids = a.alloc<int>(N);
+    const size_t q81_stride_max = kernels::llama_q8_1_bytes(std::max(H, lvdim));
+    void* q81 = a.alloc<unsigned char>((size_t)N * q81_stride_max);
+    const int ns = std::max(1, s.n_splits);
+    float* fa_m = a.alloc<float>((size_t)N * c.n_q_heads * ns);
+    float* fa_l = a.alloc<float>((size_t)N * c.n_q_heads * ns);
+    float* fa_acc = a.alloc<float>((size_t)N * c.n_q_heads * ns * c.head_dim);
+    // Compact recurrence records retained until posterior selection.
+    bf16* rec_qkv = a.alloc<bf16>((size_t)c.n_layers * N * lqkv);
+    bf16* rec_k = a.alloc<bf16>((size_t)c.n_layers * N * s.linear_qdim);
+    bf16* rec_v = a.alloc<bf16>((size_t)c.n_layers * N * lvdim);
+    bf16* rec_a = a.alloc<bf16>((size_t)c.n_layers * N * vh);
+    bf16* rec_b = a.alloc<bf16>((size_t)c.n_layers * N * vh);
+    if (!a.ok) { fprintf(stderr, "[dflash-verify] scratch allocation failed\n"); return -1; }
+
+    static thread_local int* ph_ids = nullptr;
+    static thread_local int* ph_pos = nullptr;
+    static thread_local int* ph_seq = nullptr;
+    static thread_local int* ph_out = nullptr;
+    static thread_local cudaGraph_t verify_graph = nullptr;
+    static thread_local cudaGraphExec_t verify_exec = nullptr;
+    static thread_local bool graph_warm = false;
+    static thread_local bool graph_ready = false;
+    static thread_local const void* graph_model_key = nullptr;
+    static thread_local const void* graph_state_key = nullptr;
+    static thread_local const void* graph_conv_key = nullptr;
+    static thread_local const void* graph_capture_key = nullptr;
+    static thread_local const void* graph_btable_key = nullptr;
+    if (!ph_ids) {
+        pf_cu(cudaHostAlloc(&ph_ids, 4 * sizeof(int), cudaHostAllocDefault), "verify host ids");
+        pf_cu(cudaHostAlloc(&ph_pos, 4 * sizeof(int), cudaHostAllocDefault), "verify host pos");
+        pf_cu(cudaHostAlloc(&ph_seq, 4 * sizeof(int), cudaHostAllocDefault), "verify host lens");
+        pf_cu(cudaHostAlloc(&ph_out, 4 * sizeof(int), cudaHostAllocDefault), "verify host out");
+    }
+    for (int i = 0; i < N; ++i) {
+        ph_ids[i] = token_ids[i];
+        ph_pos[i] = start_pos + i;
+        ph_seq[i] = start_pos + i + 1;
+    }
+
+    const bf16* q81_src = nullptr;
+    int q81_k = 0;
+    auto quant_rows = [&](const bf16* in, int k) {
+        if (q81_src == in && q81_k == k) return;
+        kernels::launch_quantize_q8_1_rows(in, q81, k, N, k, st);
+        q81_src = in;
+        q81_k = k;
+    };
+    auto proj = [&](const bf16* in, const void* w, int type, bf16* out, int no, int k) -> bool {
+        if (type == 0) {
+            for (int i = 0; i < N; ++i)
+                kernels::launch_gemv(in + (size_t)i * k, w, out + (size_t)i * no, no, k, st);
+            return true;
+        }
+        if (type != 8 && type != 12 && type != 14) {
+            fprintf(stderr, "[dflash-verify] unsupported projection type=%d N=%d K=%d\n", type, no, k);
+            return false;
+        }
+        quant_rows(in, k);
+        return kernels::launch_mmvq_rows(type, q81, w, out, N, no, k, st);
+    };
+    auto capture = [&](int layer) {
+        if (!capture_dst || !capture_layers || n_capture <= 0) return;
+        for (int slot = 0; slot < n_capture; ++slot) if (capture_layers[slot] == layer) {
+            char* dst = static_cast<char*>(capture_dst) + (size_t)slot * H * sizeof(bf16);
+            pf_cu(cudaMemcpy2DAsync(dst, (size_t)n_capture * H * sizeof(bf16), x,
+                                    (size_t)H * sizeof(bf16), (size_t)H * sizeof(bf16), N,
+                                    cudaMemcpyDeviceToDevice, st), "verify capture");
+        }
+    };
+
+    const int* btable = s.kv->block_table(s.seq_id);
+    const int bs = s.kv->block_size(), mbs = s.kv->max_blocks_per_seq();
+    const bool kv8 = s.kv->int8_kv();
+    const int kv_elem = kv8 ? 1 : 2;
+    bool supported = true;
+    bool recording = false;
+    if (graph_model_key != s.w.lm_head || graph_state_key != s.lin_state ||
+        graph_conv_key != s.lin_conv_state || graph_capture_key != capture_dst ||
+        graph_btable_key != btable) {
+        if (verify_exec) cudaGraphExecDestroy(verify_exec);
+        if (verify_graph) cudaGraphDestroy(verify_graph);
+        verify_exec = nullptr; verify_graph = nullptr;
+        graph_ready = false; graph_warm = false;
+        graph_model_key = s.w.lm_head;
+        graph_state_key = s.lin_state;
+        graph_conv_key = s.lin_conv_state;
+        graph_capture_key = capture_dst;
+        graph_btable_key = btable;
+    }
+    if (graph_ready) {
+        pf_cu(cudaGraphLaunch(verify_exec, st), "verify graph launch");
+        pf_cu(cudaStreamSynchronize(st), "verify graph sync");
+        std::memcpy(out_argmax, ph_out, (size_t)N * sizeof(int));
+        goto verify_forward_done;
+    }
+    recording = graph_warm;
+    if (recording)
+        pf_cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), "verify graph begin");
+    pf_cu(cudaMemcpyAsync(ids, ph_ids, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify ids");
+    pf_cu(cudaMemcpyAsync(pos, ph_pos, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify pos");
+    pf_cu(cudaMemcpyAsync(seq, ph_seq, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify lens");
+    kernels::launch_embedding(ids, s.w.embed_tokens, x, N, H, st);
+    kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, c.rms_eps, st);
+    for (int L = 0; L < c.n_layers && supported; ++L) {
+        const Qwen35LayerWeights& w = s.w.layers[L];
+        if (w.linear_attn) {
+            bf16* rq = rec_qkv + (size_t)L * N * lqkv;
+            bf16* rk = rec_k + (size_t)L * N * s.linear_qdim;
+            bf16* rv = rec_v + (size_t)L * N * lvdim;
+            bf16* ra = rec_a + (size_t)L * N * vh;
+            bf16* rb = rec_b + (size_t)L * N * vh;
+            supported = proj(xn, w.wqkv, w.wqkv_type, rq, lqkv, H) &&
+                        proj(xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H) &&
+                        proj(xn, w.ssm_alpha, w.ssm_alpha_type, ra, vh, H) &&
+                        proj(xn, w.ssm_beta, w.ssm_beta_type, rb, vh, H);
+            if (!supported) break;
+            const bf16* conv_live = static_cast<const bf16*>(s.lin_conv_state) +
+                (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
+            kernels::launch_dflash_gdn_conv_compact(rq, w.ssm_conv, conv_live, gq, rk, rv,
+                N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, c.rms_eps, st);
+            const float* state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
+            kernels::launch_dflash_gdn_scan_compact(gq, rk, rv, ra, rb, w.ssm_dt, w.ssm_a,
+                state, att, N, c.linear_q_heads, vh, c.linear_head_dim, st);
+            kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh,
+                                                c.linear_head_dim, c.rms_eps, st);
+            supported = proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+        } else {
+            supported = proj(xn, w.wq, w.wq_type, b8, 2 * qdim, H) &&
+                        proj(xn, w.wk, w.wk_type, kf, kvdim, H) &&
+                        proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+            if (!supported || !w.q_has_gate) break;
+            char* kp = static_cast<char*>(s.kv->k_pool()) +
+                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+            char* vp = static_cast<char*>(s.kv->v_pool()) +
+                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+            char* ks = kv8 ? static_cast<char*>(s.kv->k_scale_pool()) +
+                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            char* vs = kv8 ? static_cast<char*>(s.kv->v_scale_pool()) +
+                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            if (kv8) {
+                kernels::launch_dflash_qknorm_rope_kv_partial_int8_gated(
+                    b8, qb, qg, kf, vf, w.q_norm, w.k_norm, kp, vp, ks, vs, btable, pos,
+                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta, c.rms_eps,
+                    bs, mbs, st);
+            } else {
+                kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
+                kernels::launch_dflash_qknorm_rope_kv_partial(
+                    qb, kf, vf, w.q_norm, w.k_norm, kp, vp, btable, pos,
+                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta, c.rms_eps,
+                    bs, mbs, st);
+            }
+            for (int i = 0; i < N; ++i)
+                kernels::launch_flash_decode_split(
+                    qb + (size_t)i * qdim, kp, vp, btable, seq + i, att + (size_t)i * qdim,
+                    fa_m + (size_t)i * c.n_q_heads * ns,
+                    fa_l + (size_t)i * c.n_q_heads * ns,
+                    fa_acc + (size_t)i * c.n_q_heads * ns * c.head_dim,
+                    1, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, ns,
+                    1.f / sqrtf((float)c.head_dim), st, nullptr, -1,
+                    ks, vs, kv8 ? 1 : 0, kv8 ? qg + (size_t)i * qdim : nullptr);
+            if (!kv8)
+                for (int i = 0; i < N; ++i)
+                    kernels::launch_qwen36_mul_sigmoid(att + (size_t)i * qdim,
+                                                        qg + (size_t)i * qdim, qdim, st);
+            supported = proj(att, w.wo, w.wo_type, ao, H, qdim);
+        }
+        if (!supported) break;
+        kernels::launch_add_rmsnorm2_q8_rows(x, ao, w.post_attn_norm, h, hn, q81,
+                                             N, H, c.rms_eps, st);
+        q81_src = hn; q81_k = H;
+
+        if (!w.gate_q || !w.router_w ||
+            !w.shared_gate_q || !w.shared_up_q || !w.shared_down_q ||
+            w.shared_gate_qtype != 8 || w.shared_up_qtype != 8 || w.shared_down_qtype != 8) {
+            fprintf(stderr, "[dflash-verify] unsupported MoE layer=%d gate=%p router=%p shared=%p/%p/%p types=%d/%d/%d\n",
+                    L, w.gate_q, w.router_w, w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                    w.shared_gate_qtype, w.shared_up_qtype, w.shared_down_qtype);
+            supported = false; break;
+        }
+        for (int i = 0; i < N; ++i)
+            kernels::launch_gemv_f32(hn + (size_t)i * H, w.router_w,
+                                     router_logits + (size_t)i * E, E, H, st);
+        kernels::launch_moe_router(router_logits, expert_ids, expert_w, nullptr,
+                                   N, E, topk, 1, st);
+        kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
+            w.gate_qtype, w.up_qtype, w.down_qtype, expert_ids, expert_w, routed,
+            moe_h, moe_out, N, topk, H, ffn, q81, st);
+
+        if (w.shared_gate_inp) {
+            supported = proj(hn, w.shared_gate_inp, w.shared_gate_inp_type, gate_raw, 1, H);
+            kernels::launch_qwen36_sigmoid_rows(gate_raw, gate_w, N, st);
+        } else {
+            pf_cu(cudaMemsetAsync(gate_w, 0, (size_t)N * sizeof(float), st), "verify shared gate");
+        }
+        supported = supported && kernels::launch_mmvq_rows(8, q81, w.shared_gate_q, sg, N, ffn, H, st) &&
+                    kernels::launch_mmvq_rows(8, q81, w.shared_up_q, su, N, ffn, H, st);
+        kernels::launch_qwen36_shared_swiglu_rows(sg, su, w.shared_gate_inp ? gate_w : nullptr,
+                                                  sh, N, ffn, st);
+        quant_rows(sh, ffn);
+        supported = supported && kernels::launch_mmvq_rows(8, q81, w.shared_down_q,
+                                                           shared, N, H, ffn, st);
+        const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
+        kernels::launch_add_rmsnorm3_q8_rows(h, routed, shared, next_norm, x, xn, q81,
+                                             N, H, c.rms_eps, st);
+        q81_src = xn; q81_k = H;
+        capture(L);
+    }
+    if (!supported) return -1;
+
+    quant_rows(xn, H);
+    if (!kernels::launch_mmvq_rows_f32(s.w.lm_head_type, q81, s.w.lm_head, logits,
+                                       N, c.vocab, H, st)) {
+        fprintf(stderr, "[dflash-verify] unsupported LM head type=%d H=%d\n", s.w.lm_head_type, H);
+        return -1;
+    }
+    kernels::launch_argmax(logits, out_ids, N, c.vocab, st);
+    pf_cu(cudaMemcpyAsync(ph_out, out_ids, (size_t)N * sizeof(int), cudaMemcpyDeviceToHost, st),
+          "verify argmax");
+    if (recording) {
+        pf_cu(cudaStreamEndCapture(st, &verify_graph), "verify graph end");
+        pf_cu(cudaGraphInstantiate(&verify_exec, verify_graph, 0), "verify graph instantiate");
+        graph_ready = true;
+        pf_cu(cudaGraphLaunch(verify_exec, st), "verify graph first launch");
+    }
+    pf_cu(cudaStreamSynchronize(st), "verify sync");
+    std::memcpy(out_argmax, ph_out, (size_t)N * sizeof(int));
+    graph_warm = true;
+verify_forward_done:
+    int keep = 1;
+    while (keep < N && token_ids[keep] == out_argmax[keep - 1]) ++keep;
+    for (int L = 0; L < c.n_layers; ++L) if (s.w.layers[L].linear_attn) {
+        bf16* rq = rec_qkv + (size_t)L * N * lqkv;
+        bf16* rk = rec_k + (size_t)L * N * s.linear_qdim;
+        bf16* rv = rec_v + (size_t)L * N * lvdim;
+        bf16* ra = rec_a + (size_t)L * N * vh;
+        bf16* rb = rec_b + (size_t)L * N * vh;
+        bf16* conv_live = static_cast<bf16*>(s.lin_conv_state) +
+            (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
+        float* state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
+        kernels::launch_dflash_gdn_conv_commit(rq, conv_live, keep, c.linear_q_heads, vh,
+            c.linear_head_dim, c.linear_conv_kernel, st);
+        kernels::launch_dflash_gdn_scan_commit(rk, rv, ra, rb, s.w.layers[L].ssm_dt,
+            s.w.layers[L].ssm_a, state, keep, c.linear_q_heads, vh, c.linear_head_dim, st);
+    }
+    pf_cu(cudaStreamSynchronize(st), "verify commit");
+    return keep;
 }
 
 } // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -33,11 +33,19 @@ struct Qwen35PrefillCtx {
     const float*         moe_rs_gate;
     const float*         moe_rs_up;
     const float*         moe_rs_down;
+    int                  n_splits;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.
 // Returns the argmax at the last prompt position (seed for the first decode step), or -1 if the
 // batched path is unsupported for this model/config (caller falls back to the token loop).
 int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n);
+
+// Exact short-block DFlash verifier. It evaluates all candidate rows from the live hybrid state,
+// commits only the accepted prefix, and leaves rejected KV rows outside the logical sequence.
+// Returns the number of consumed rows, or -1 when the exact fast path is unsupported.
+int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int n, int start_pos,
+                            const int* capture_layers, int n_capture, void* capture_dst,
+                            int* out_argmax);
 
 } // namespace sparkinfer

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -34,3 +34,7 @@ add_test(NAME decode_runner_gpu_test COMMAND decode_runner_gpu_test)
 add_executable(qwen35_gpu_test qwen35_gpu_test.cpp)
 target_link_libraries(qwen35_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME qwen35_gpu_test COMMAND qwen35_gpu_test)
+
+add_executable(dflash_gdn_checkpoint_gpu_test dflash_gdn_checkpoint_gpu_test.cpp)
+target_link_libraries(dflash_gdn_checkpoint_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
+add_test(NAME dflash_gdn_checkpoint_gpu_test COMMAND dflash_gdn_checkpoint_gpu_test)

--- a/runtime/tests/dflash_gdn_checkpoint_gpu_test.cpp
+++ b/runtime/tests/dflash_gdn_checkpoint_gpu_test.cpp
@@ -1,0 +1,350 @@
+#include "sparkinfer/kernels/prefill.h"
+#include "sparkinfer/kernels/gemm.h"
+#include "sparkinfer/kernels/attention.h"
+#include "sparkinfer/kernels/fused.h"
+
+#include <cuda_runtime.h>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+uint16_t bf16(float x) {
+    uint32_t u;
+    std::memcpy(&u, &x, sizeof(u));
+    return static_cast<uint16_t>(u >> 16);
+}
+
+template <class T> T* device_copy(const std::vector<T>& h) {
+    T* d = nullptr;
+    cudaMalloc(&d, h.size() * sizeof(T));
+    cudaMemcpy(d, h.data(), h.size() * sizeof(T), cudaMemcpyHostToDevice);
+    return d;
+}
+
+template <class T> bool equal_device(const T* a, const T* b, size_t n, const char* what) {
+    std::vector<T> ha(n), hb(n);
+    cudaMemcpy(ha.data(), a, n * sizeof(T), cudaMemcpyDeviceToHost);
+    cudaMemcpy(hb.data(), b, n * sizeof(T), cudaMemcpyDeviceToHost);
+    if (ha == hb) return true;
+    size_t i = 0;
+    while (i < n && ha[i] == hb[i]) i++;
+    std::printf("[FAIL] %s differs at %zu\n", what, i);
+    return false;
+}
+
+} // namespace
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        std::printf("[SKIP] no CUDA device\n");
+        return 0;
+    }
+
+    constexpr int N = 4, QH = 4, VH = 4, HD = 128, CK = 4;
+    constexpr int QD = QH * HD, VD = VH * HD, QKVD = 2 * QD + VD;
+    const size_t conv_state_n = (CK - 1) * QKVD;
+    const size_t scan_state_n = (size_t)VH * HD * HD;
+    auto make_bf16 = [](size_t n, int salt, float scale) {
+        std::vector<uint16_t> h(n);
+        for (size_t i = 0; i < n; i++) {
+            const int v = (int)((i * 1103515245u + 12345u + salt) % 2001u) - 1000;
+            h[i] = bf16(scale * v / 1000.f);
+        }
+        return h;
+    };
+
+    auto hqkv = make_bf16((size_t)N * QKVD, 1, 0.2f);
+    auto hcw = make_bf16((size_t)QKVD * CK, 2, 0.1f);
+    auto hcs = make_bf16(conv_state_n, 3, 0.2f);
+    uint16_t *dqkv = device_copy(hqkv), *dcw = device_copy(hcw), *dcs = device_copy(hcs);
+    uint16_t *bq, *bk, *bv, *bc, *sq, *sk, *sv, *sc, *sc_live;
+    cudaMalloc(&bq, (size_t)N * QD * 2); cudaMalloc(&bk, (size_t)N * QD * 2);
+    cudaMalloc(&bv, (size_t)N * VD * 2); cudaMalloc(&bc, (size_t)N * conv_state_n * 2);
+    cudaMalloc(&sq, (size_t)N * QD * 2); cudaMalloc(&sk, (size_t)N * QD * 2);
+    cudaMalloc(&sv, (size_t)N * VD * 2); cudaMalloc(&sc, conv_state_n * 2);
+    cudaMalloc(&sc_live, conv_state_n * 2); cudaMemcpy(sc_live, dcs, conv_state_n * 2, cudaMemcpyDeviceToDevice);
+    sparkinfer::kernels::launch_dflash_gdn_conv(dqkv, dcw, dcs, bq, bk, bv, bc,
+                                                 N, QH, VH, HD, CK, 1e-6f);
+    uint16_t *cq, *ck, *cv;
+    cudaMalloc(&cq, (size_t)N * QD * 2); cudaMalloc(&ck, (size_t)N * QD * 2);
+    cudaMalloc(&cv, (size_t)N * VD * 2);
+    sparkinfer::kernels::launch_dflash_gdn_conv_compact(
+        dqkv, dcw, dcs, cq, ck, cv, N, QH, VH, HD, CK, 1e-6f);
+    for (int t = 0; t < N; t++) {
+        sparkinfer::kernels::launch_dflash_gdn_conv(
+            dqkv + (size_t)t * QKVD, dcw, sc_live,
+            sq + (size_t)t * QD, sk + (size_t)t * QD, sv + (size_t)t * VD, sc,
+            1, QH, VH, HD, CK, 1e-6f);
+        cudaMemcpy(sc_live, sc, conv_state_n * 2, cudaMemcpyDeviceToDevice);
+    }
+    cudaDeviceSynchronize();
+    bool ok = equal_device(bq, sq, (size_t)N * QD, "conv q") &&
+              equal_device(bk, sk, (size_t)N * QD, "conv k") &&
+              equal_device(bv, sv, (size_t)N * VD, "conv v") &&
+              equal_device(bq, cq, (size_t)N * QD, "compact conv q") &&
+              equal_device(bk, ck, (size_t)N * QD, "compact conv k") &&
+              equal_device(bv, cv, (size_t)N * VD, "compact conv v") &&
+              equal_device(bc + (size_t)(N - 1) * conv_state_n, sc_live,
+                           conv_state_n, "conv checkpoint");
+    for (int accept = 1; accept <= N; accept++) {
+        cudaMemcpy(sc_live, dcs, conv_state_n * 2, cudaMemcpyDeviceToDevice);
+        sparkinfer::kernels::launch_dflash_gdn_conv_commit(
+            dqkv, sc_live, accept, QH, VH, HD, CK);
+        cudaDeviceSynchronize();
+        char what[64];
+        std::snprintf(what, sizeof(what), "compact conv commit %d", accept);
+        ok = equal_device(bc + (size_t)(accept - 1) * conv_state_n, sc_live,
+                          conv_state_n, what) && ok;
+    }
+
+    auto hq = make_bf16((size_t)N * QD, 4, 0.1f);
+    auto hk = make_bf16((size_t)N * QD, 5, 0.1f);
+    auto hv = make_bf16((size_t)N * VD, 6, 0.1f);
+    auto ha = make_bf16((size_t)N * VH, 7, 0.1f);
+    auto hb = make_bf16((size_t)N * VH, 8, 0.1f);
+    auto hdt = make_bf16(VH, 9, 0.05f);
+    auto hdecay = make_bf16(VH, 10, -0.05f);
+    std::vector<float> hstate(scan_state_n);
+    for (size_t i = 0; i < hstate.size(); i++) hstate[i] = ((int)(i % 37) - 18) * 0.0001f;
+    uint16_t *dq = device_copy(hq), *dk = device_copy(hk), *dv = device_copy(hv);
+    uint16_t *da = device_copy(ha), *db = device_copy(hb), *ddt = device_copy(hdt), *ddecay = device_copy(hdecay);
+    float* dstate = device_copy(hstate);
+    uint16_t *bout, *sout; float *bcp, *scp, *sstate;
+    cudaMalloc(&bout, (size_t)N * VD * 2); cudaMalloc(&sout, (size_t)N * VD * 2);
+    cudaMalloc(&bcp, (size_t)N * scan_state_n * 4); cudaMalloc(&scp, scan_state_n * 4);
+    cudaMalloc(&sstate, scan_state_n * 4); cudaMemcpy(sstate, dstate, scan_state_n * 4, cudaMemcpyDeviceToDevice);
+    sparkinfer::kernels::launch_dflash_gdn_scan(dq, dk, dv, da, db, ddt, ddecay,
+                                                 dstate, bout, bcp, N, QH, VH, HD);
+    uint16_t* cout = nullptr;
+    cudaMalloc(&cout, (size_t)N * VD * 2);
+    sparkinfer::kernels::launch_dflash_gdn_scan_compact(
+        dq, dk, dv, da, db, ddt, ddecay, dstate, cout, N, QH, VH, HD);
+    for (int t = 0; t < N; t++) {
+        sparkinfer::kernels::launch_dflash_gdn_scan(
+            dq + (size_t)t * QD, dk + (size_t)t * QD, dv + (size_t)t * VD,
+            da + (size_t)t * VH, db + (size_t)t * VH, ddt, ddecay,
+            sstate, sout + (size_t)t * VD, scp, 1, QH, VH, HD);
+        cudaMemcpy(sstate, scp, scan_state_n * 4, cudaMemcpyDeviceToDevice);
+    }
+    cudaDeviceSynchronize();
+    ok = equal_device(bout, sout, (size_t)N * VD, "scan output") &&
+         equal_device(bout, cout, (size_t)N * VD, "compact scan output") &&
+         equal_device(bcp + (size_t)(N - 1) * scan_state_n, sstate,
+                      scan_state_n, "scan checkpoint") && ok;
+    for (int accept = 1; accept <= N; accept++) {
+        cudaMemcpy(sstate, dstate, scan_state_n * 4, cudaMemcpyDeviceToDevice);
+        sparkinfer::kernels::launch_dflash_gdn_scan_commit(
+            dk, dv, da, db, ddt, ddecay, sstate, accept, QH, VH, HD);
+        cudaDeviceSynchronize();
+        char what[64];
+        std::snprintf(what, sizeof(what), "compact scan commit %d", accept);
+        ok = equal_device(bcp + (size_t)(accept - 1) * scan_state_n, sstate,
+                          scan_state_n, what) && ok;
+    }
+
+    // One-sequence short-block QK-norm/RoPE/KV append must equal N decode-shaped launches.
+    constexpr int AQH = 4, AKH = 2, AHD = 128, ARD = 64, ABS = 16;
+    constexpr int APOS0 = 14, APOOLTOK = 32;
+    auto haqq = make_bf16((size_t)N * AQH * AHD, 21, 0.1f);
+    auto hakk = make_bf16((size_t)N * AKH * AHD, 22, 0.1f);
+    auto havv = make_bf16((size_t)N * AKH * AHD, 23, 0.1f);
+    auto hanw = make_bf16(AHD, 24, 0.05f);
+    std::vector<int> hpos(N), htable = {0, 1};
+    for (int i = 0; i < N; i++) hpos[i] = APOS0 + i;
+    uint16_t *aqq0 = device_copy(haqq), *aqq1 = device_copy(haqq);
+    uint16_t *akk = device_copy(hakk), *avv = device_copy(havv), *anw = device_copy(hanw);
+    int *apos = device_copy(hpos), *atable = device_copy(htable);
+    uint16_t *akp0, *avp0, *akp1, *avp1;
+    const size_t apool_n = (size_t)APOOLTOK * AKH * AHD;
+    cudaMalloc(&akp0, apool_n * 2); cudaMalloc(&avp0, apool_n * 2);
+    cudaMalloc(&akp1, apool_n * 2); cudaMalloc(&avp1, apool_n * 2);
+    cudaMemset(akp0, 0, apool_n * 2); cudaMemset(avp0, 0, apool_n * 2);
+    cudaMemset(akp1, 0, apool_n * 2); cudaMemset(avp1, 0, apool_n * 2);
+    sparkinfer::kernels::launch_dflash_qknorm_rope_kv_partial(
+        aqq0, akk, avv, anw, anw, akp0, avp0, atable, apos,
+        N, AQH, AKH, AHD, ARD, 1000000.f, 1e-6f, ABS, 2);
+    for (int i = 0; i < N; i++)
+        sparkinfer::kernels::launch_qknorm_rope_kv_partial(
+            aqq1 + (size_t)i * AQH * AHD,
+            akk + (size_t)i * AKH * AHD, avv + (size_t)i * AKH * AHD,
+            anw, anw, akp1, avp1, atable, apos + i,
+            1, AQH, AKH, AHD, ARD, 1000000.f, 1e-6f, ABS, 2);
+    cudaDeviceSynchronize();
+    ok = equal_device(aqq0, aqq1, (size_t)N * AQH * AHD, "short-block Q RoPE") &&
+         equal_device(akp0, akp1, apool_n, "short-block K append") &&
+         equal_device(avp0, avp1, apool_n, "short-block V append") && ok;
+
+    auto haqraw = make_bf16((size_t)N * AQH * AHD * 2, 28, 0.1f);
+    uint16_t *aqraw = device_copy(haqraw);
+    uint16_t *aiq0, *aiq1, *aig0, *aig1;
+    uint16_t *aik0 = device_copy(hakk), *aik1 = device_copy(hakk);
+    cudaMalloc(&aiq0, (size_t)N * AQH * AHD * 2); cudaMalloc(&aiq1, (size_t)N * AQH * AHD * 2);
+    cudaMalloc(&aig0, (size_t)N * AQH * AHD * 2); cudaMalloc(&aig1, (size_t)N * AQH * AHD * 2);
+    signed char *aikp0, *aivp0, *aikp1, *aivp1;
+    uint16_t *aiks0, *aivs0, *aiks1, *aivs1;
+    const size_t ascale_n = (size_t)APOOLTOK * AKH;
+    cudaMalloc(&aikp0, apool_n); cudaMalloc(&aivp0, apool_n);
+    cudaMalloc(&aikp1, apool_n); cudaMalloc(&aivp1, apool_n);
+    cudaMalloc(&aiks0, ascale_n * 2); cudaMalloc(&aivs0, ascale_n * 2);
+    cudaMalloc(&aiks1, ascale_n * 2); cudaMalloc(&aivs1, ascale_n * 2);
+    cudaMemset(aikp0, 0, apool_n); cudaMemset(aivp0, 0, apool_n);
+    cudaMemset(aikp1, 0, apool_n); cudaMemset(aivp1, 0, apool_n);
+    cudaMemset(aiks0, 0, ascale_n * 2); cudaMemset(aivs0, 0, ascale_n * 2);
+    cudaMemset(aiks1, 0, ascale_n * 2); cudaMemset(aivs1, 0, ascale_n * 2);
+    sparkinfer::kernels::launch_dflash_qknorm_rope_kv_partial_int8_gated(
+        aqraw, aiq0, aig0, aik0, avv, anw, anw, aikp0, aivp0, aiks0, aivs0, atable, apos,
+        N, AQH, AKH, AHD, ARD, 1000000.f, 1e-6f, ABS, 2);
+    for (int i = 0; i < N; i++)
+        sparkinfer::kernels::launch_qknorm_rope_kv_partial_int8_gated(
+            aqraw + (size_t)i * AQH * AHD * 2,
+            aiq1 + (size_t)i * AQH * AHD, aig1 + (size_t)i * AQH * AHD,
+            aik1 + (size_t)i * AKH * AHD, avv + (size_t)i * AKH * AHD,
+            anw, anw, aikp1, aivp1, aiks1, aivs1, atable, apos + i,
+            1, AQH, AKH, AHD, ARD, 1000000.f, 1e-6f, ABS, 2);
+    cudaDeviceSynchronize();
+    ok = equal_device(aiq0, aiq1, (size_t)N * AQH * AHD, "short-block int8 Q RoPE") &&
+         equal_device(aig0, aig1, (size_t)N * AQH * AHD, "short-block Q gate") &&
+         equal_device(aikp0, aikp1, apool_n, "short-block int8 K append") &&
+         equal_device(aivp0, aivp1, apool_n, "short-block int8 V append") &&
+         equal_device(aiks0, aiks1, ascale_n, "short-block K scales") &&
+         equal_device(aivs0, aivs1, ascale_n, "short-block V scales") && ok;
+
+    constexpr int SFFN = 512;
+    auto hsg = make_bf16((size_t)N * SFFN, 25, 0.2f);
+    auto hsu = make_bf16((size_t)N * SFFN, 26, 0.2f);
+    auto hsw = make_bf16(N, 27, 0.1f);
+    uint16_t *dsg = device_copy(hsg), *dsu = device_copy(hsu), *dsw = device_copy(hsw);
+    float *dfw0, *dfw1; uint16_t *dsh0, *dsh1;
+    cudaMalloc(&dfw0, N * sizeof(float)); cudaMalloc(&dfw1, N * sizeof(float));
+    cudaMalloc(&dsh0, (size_t)N * SFFN * 2); cudaMalloc(&dsh1, (size_t)N * SFFN * 2);
+    sparkinfer::kernels::launch_qwen36_sigmoid_rows(dsw, dfw0, N);
+    for (int i = 0; i < N; i++)
+        sparkinfer::kernels::launch_qwen36_sigmoid_scalar(dsw + i, dfw1 + i);
+    sparkinfer::kernels::launch_qwen36_shared_swiglu_rows(dsg, dsu, dfw0, dsh0, N, SFFN);
+    for (int i = 0; i < N; i++)
+        sparkinfer::kernels::launch_qwen36_shared_swiglu(
+            dsg + (size_t)i * SFFN, dsu + (size_t)i * SFFN, dfw1 + i,
+            dsh1 + (size_t)i * SFFN, SFFN);
+    cudaDeviceSynchronize();
+    ok = equal_device(dfw0, dfw1, N, "shared gate sigmoid rows") &&
+         equal_device(dsh0, dsh1, (size_t)N * SFFN, "shared SwiGLU rows") && ok;
+
+    // Exact multi-row Q4_K projection must be byte-identical to M independent decode MMVQs.
+    constexpr int MH = 2048, MN = 8192;
+    auto hact = make_bf16((size_t)N * MH, 11, 0.2f);
+    uint16_t* dact = device_copy(hact);
+    const size_t q81_row = sparkinfer::kernels::llama_q8_1_bytes(MH);
+    void* dq81 = nullptr;
+    cudaMalloc(&dq81, (size_t)N * q81_row);
+    sparkinfer::kernels::launch_quantize_q8_1_rows(dact, dq81, MH, N, MH);
+    std::vector<unsigned char> hw((size_t)MN * 8 * 144);
+    for (int row = 0; row < MN; row++) for (int sb = 0; sb < 8; sb++) {
+        unsigned char* p = hw.data() + ((size_t)row * 8 + sb) * 144;
+        p[0] = 0x1f; p[1] = 0x21; p[2] = 0x1f; p[3] = 0x21; // finite fp16 dm
+        for (int i = 4; i < 144; i++) p[i] = (unsigned char)((row * 17 + sb * 29 + i * 13) & 255);
+    }
+    unsigned char* dw = device_copy(hw);
+    uint16_t *ym = nullptr, *ys = nullptr;
+    cudaMalloc(&ym, (size_t)N * MN * 2); cudaMalloc(&ys, (size_t)N * MN * 2);
+    ok = sparkinfer::kernels::launch_mmvq_q4k_rows(dq81, dw, ym, N, MN, MH) && ok;
+    for (int m = 0; m < N; m++)
+        sparkinfer::kernels::launch_mmvq_q4k((const char*)dq81 + (size_t)m * q81_row,
+                                              dw, ys + (size_t)m * MN, MN, MH);
+    cudaDeviceSynchronize();
+    ok = equal_device(ym, ys, (size_t)N * MN, "Q4_K exact rows") && ok;
+    float *yfm = nullptr, *yfs = nullptr;
+    cudaMalloc(&yfm, (size_t)N * MN * sizeof(float));
+    cudaMalloc(&yfs, (size_t)N * MN * sizeof(float));
+    ok = sparkinfer::kernels::launch_mmvq_rows_f32(12, dq81, dw, yfm, N, MN, MH) && ok;
+    for (int m = 0; m < N; m++)
+        sparkinfer::kernels::launch_mmvq_q4k_f32((const char*)dq81 + (size_t)m * q81_row,
+                                                 dw, yfs + (size_t)m * MN, MN, MH);
+    cudaDeviceSynchronize();
+    ok = equal_device(yfm, yfs, (size_t)N * MN, "Q4_K exact FP32 rows") && ok;
+    std::vector<unsigned char> hw6((size_t)MN * 8 * 210);
+    for (int row = 0; row < MN; row++) for (int sb = 0; sb < 8; sb++) {
+        unsigned char* p = hw6.data() + ((size_t)row * 8 + sb) * 210;
+        for (int i = 0; i < 208; i++)
+            p[i] = (unsigned char)((row * 11 + sb * 31 + i * 7) & 255);
+        p[208] = 0x00; p[209] = 0x3c; // finite fp16 super-block scale (1.0)
+    }
+    unsigned char* dw6 = device_copy(hw6);
+    ok = sparkinfer::kernels::launch_mmvq_q6k_rows(dq81, dw6, ym, N, MN, MH) && ok;
+    for (int m = 0; m < N; m++)
+        sparkinfer::kernels::launch_mmvq_q6k((const char*)dq81 + (size_t)m * q81_row,
+                                              dw6, ys + (size_t)m * MN, MN, MH);
+    cudaDeviceSynchronize();
+    ok = equal_device(ym, ys, (size_t)N * MN, "Q6_K exact rows") && ok;
+    std::vector<unsigned char> hw8((size_t)MN * (MH / 32) * 34);
+    for (int row = 0; row < MN; row++) for (int kb = 0; kb < MH / 32; kb++) {
+        unsigned char* p = hw8.data() + ((size_t)row * (MH / 32) + kb) * 34;
+        p[0] = 0x00; p[1] = 0x3c; // finite fp16 block scale (1.0)
+        for (int i = 2; i < 34; i++) p[i] = (unsigned char)((row * 5 + kb * 19 + i * 3) & 255);
+    }
+    unsigned char* dw8 = device_copy(hw8);
+    ok = sparkinfer::kernels::launch_mmvq_q80_rows(dq81, dw8, ym, N, MN, MH) && ok;
+    for (int m = 0; m < N; m++)
+        sparkinfer::kernels::launch_mmvq_q80((const char*)dq81 + (size_t)m * q81_row,
+                                              dw8, ys + (size_t)m * MN, MN, MH);
+    cudaDeviceSynchronize();
+    ok = equal_device(ym, ys, (size_t)N * MN, "Q8_0 exact rows") && ok;
+    constexpr int K512 = 512, N512 = 2048;
+    const size_t q815_row = sparkinfer::kernels::llama_q8_1_bytes(K512);
+    void* dq815 = nullptr;
+    cudaMalloc(&dq815, (size_t)N * q815_row);
+    sparkinfer::kernels::launch_quantize_q8_1_rows(dact, dq815, K512, N, MH);
+    std::vector<unsigned char> hw85((size_t)N512 * (K512 / 32) * 34);
+    for (int row = 0; row < N512; row++) for (int kb = 0; kb < K512 / 32; kb++) {
+        unsigned char* p = hw85.data() + ((size_t)row * (K512 / 32) + kb) * 34;
+        p[0] = 0x00; p[1] = 0x3c;
+        for (int i = 2; i < 34; i++) p[i] = (unsigned char)((row * 23 + kb * 3 + i * 5) & 255);
+    }
+    unsigned char* dw85 = device_copy(hw85);
+    ok = sparkinfer::kernels::launch_mmvq_q80_rows(dq815, dw85, ym, N, N512, K512) && ok;
+    for (int m = 0; m < N; m++)
+        sparkinfer::kernels::launch_mmvq_q80((const char*)dq815 + (size_t)m * q815_row,
+                                              dw85, ys + (size_t)m * N512, N512, K512);
+    cudaDeviceSynchronize();
+    ok = equal_device(ym, ys, (size_t)N * N512, "Q8_0 exact rows K512") && ok;
+    cudaEvent_t ev0, ev1;
+    cudaEventCreate(&ev0); cudaEventCreate(&ev1);
+    constexpr int REPS = 40;
+    cudaEventRecord(ev0);
+    for (int r = 0; r < REPS; r++)
+        sparkinfer::kernels::launch_mmvq_q4k_rows(dq81, dw, ym, N, MN, MH);
+    cudaEventRecord(ev1); cudaEventSynchronize(ev1);
+    float batch_ms = 0.f; cudaEventElapsedTime(&batch_ms, ev0, ev1);
+    cudaEventRecord(ev0);
+    for (int r = 0; r < REPS; r++) for (int m = 0; m < N; m++)
+        sparkinfer::kernels::launch_mmvq_q4k((const char*)dq81 + (size_t)m * q81_row,
+                                              dw, ys + (size_t)m * MN, MN, MH);
+    cudaEventRecord(ev1); cudaEventSynchronize(ev1);
+    float serial_ms = 0.f; cudaEventElapsedTime(&serial_ms, ev0, ev1);
+    std::printf("Q4_K rows: batch %.3f ms, four serial %.3f ms, %.2fx\n",
+                batch_ms / REPS, serial_ms / REPS, serial_ms / batch_ms);
+    cudaEventRecord(ev0);
+    for (int r = 0; r < REPS; r++)
+        sparkinfer::kernels::launch_mmvq_rows_f32(12, dq81, dw, yfm, N, MN, MH);
+    cudaEventRecord(ev1); cudaEventSynchronize(ev1);
+    float fbatch_ms = 0.f; cudaEventElapsedTime(&fbatch_ms, ev0, ev1);
+    cudaEventRecord(ev0);
+    for (int r = 0; r < REPS; r++) for (int m = 0; m < N; m++)
+        sparkinfer::kernels::launch_mmvq_q4k_f32((const char*)dq81 + (size_t)m * q81_row,
+                                                 dw, yfs + (size_t)m * MN, MN, MH);
+    cudaEventRecord(ev1); cudaEventSynchronize(ev1);
+    float fserial_ms = 0.f; cudaEventElapsedTime(&fserial_ms, ev0, ev1);
+    std::printf("Q4_K FP32 rows: batch %.3f ms, four serial %.3f ms, %.2fx\n",
+                fbatch_ms / REPS, fserial_ms / REPS, fserial_ms / fbatch_ms);
+    const cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        std::printf("[FAIL] CUDA: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+    std::printf(ok ? "[PASS] DFlash GDN checkpoints and compact commits equal serial state\n"
+                   : "[FAIL] DFlash GDN checkpoint/commit equivalence\n");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Adds exact four-row DFlash target verification with compact GDN state commit, quantized weight reuse, and CUDA graph replay. The adaptive gate retains early-exit verification until two consecutive full blocks are accepted.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s**

| | decode tok/s |
|---|--:|
| before (main) | 428.02 |
| after (this PR) | 474.71 |

**Prefill pp tok/s**

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | |
| after prefill (this PR) | |

```text
Fixed 101-token prompt, 100 generated tokens, three-run medians:
main: 428.02 tok/s
optimized: 474.71 tok/s
delta: +10.91%

SPEC_AGREE 100/100 = 1.0000
MEAN_ACCEPT 3.6429
VERDICT PASS
```
