### PR TITLE
perf(dflash): optimize Qwen3.6 target shared-expert decode

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -98,6 +98,46 @@ __global__ void gemv_f32_sk_kernel(const __nv_bfloat16* __restrict__ x,
         gemv_write(y + n, o);
     }
 }
+
+// N=1 shared-expert gate. This is the S=8 split-K GEMV above with the existing
+// bf16 rounding point and sigmoid folded into its single writer. Keeping the
+// rounding before expf makes it bit-equivalent to launch_gemv + sigmoid_scalar.
+__global__ void gemv_bf16_sigmoid_sk8_kernel(
+    const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ W,
+    __nv_bfloat16* __restrict__ scratch, float* __restrict__ y, int K) {
+    constexpr int S = 8;
+    __shared__ float s_part[S];
+    const int split = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    float acc = 0.f;
+    const uint4* row4 = reinterpret_cast<const uint4*>(W);
+    const uint4* x4 = reinterpret_cast<const uint4*>(x);
+    const int n4 = K / 8;
+    for (int i = split * 32 + lane; i < n4; i += S * 32) {
+        uint4 wv = row4[i], xv = x4[i];
+        const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+        const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+#pragma unroll
+        for (int j = 0; j < 4; ++j) {
+            const float2 wf = __bfloat1622float2(wh[j]);
+            const float2 xf = __bfloat1622float2(xh[j]);
+            acc += wf.x * xf.x + wf.y * xf.y;
+        }
+    }
+#pragma unroll
+    for (int m = 16; m > 0; m >>= 1)
+        acc += __shfl_xor_sync(0xffffffffu, acc, m);
+    if (lane == 0) s_part[split] = acc;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        float o = 0.f;
+#pragma unroll
+        for (int s = 0; s < S; ++s) o += s_part[s];
+        const __nv_bfloat16 rounded = __float2bfloat16(o);
+        if (scratch) scratch[0] = rounded;
+        const float z = __bfloat162float(rounded);
+        y[0] = 1.f / (1.f + __expf(-z));
+    }
+}
 #ifndef _MSC_VER
 template __global__ void gemv_f32_sk_kernel<float, 4>(const __nv_bfloat16*, const __nv_bfloat16*, float*, int, int);
 #endif
@@ -1260,10 +1300,16 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K, cudaStream
         reinterpret_cast<__nv_bfloat16*>(y), N, K);
 }
 
-// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar). Delegates to the
-// faithful split-k launch_gemv + bf16-rounded sigmoid_scalar path.
+// Fused GEMV + sigmoid for N=1 (shared-expert gate scalar).
 void launch_gemv_sigmoid(const void* x, const void* W, void* scratch_bf16, float* y, int K,
                          cudaStream_t stream) {
+    if ((K & 7) == 0) {
+        gemv_bf16_sigmoid_sk8_kernel<<<1, 8 * 32, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x),
+            reinterpret_cast<const __nv_bfloat16*>(W),
+            reinterpret_cast<__nv_bfloat16*>(scratch_bf16), y, K);
+        return;
+    }
     launch_gemv(x, W, scratch_bf16, 1, K, stream);
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
     launch_qwen36_sigmoid_scalar(scratch_bf16, y, stream);

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -570,6 +570,73 @@ __global__ void shared_gate_up_q8_mmvq_kernel(
     }
 }
 
+// H=2048 has exactly 64 Q8 blocks per shared-expert gate/up row. Two warps cover a
+// row without the two idle warps in the generic kernel; four rows share one 8-warp CTA.
+template <int H, int F>
+__global__ void shared_gate_up_q8_pack4_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
+    float* __restrict__ h_scratch) {
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int group = warp >> 1, sub = warp & 1;
+    const int f = blockIdx.x * 4 + group;
+    if (f >= F) return;
+    constexpr int NBLK = H >> 5;
+    const int b = sub * 32 + lane;
+    const unsigned char* gbase = gate_q + (size_t)f * NBLK * 34;
+    const unsigned char* ubase = up_q   + (size_t)f * NBLK * 34;
+    float tg = 0.f, tu = 0.f;
+    if (b < NBLK) {
+        tg = si_vec_dot_q8_0(gbase + (size_t)b * 34, vy + b);
+        tu = si_vec_dot_q8_0(ubase + (size_t)b * 34, vy + b);
+    }
+    __shared__ float sg[4][32], su[4][32];
+    if (sub) { sg[group][lane] = tg; su[group][lane] = tu; }
+    __syncthreads();
+    if (sub) return;
+    tg += sg[group][lane]; tu += su[group][lane];
+#pragma unroll
+    for (int m = 16; m > 0; m >>= 1) {
+        tg += __shfl_xor_sync(0xffffffffu, tg, m);
+        tu += __shfl_xor_sync(0xffffffffu, tu, m);
+    }
+    if (lane == 0) {
+        const float w = dw ? __ldg(dw) : 1.f;
+        h_scratch[f] = w * q4kf_silu(tg) * tu;
+    }
+}
+
+// One warp can cover all 64 Q8 blocks by processing two blocks per lane. Packing
+// independent rows per CTA removes the cross-warp exchange and its block-wide barrier.
+template <int H, int F, int ROWS>
+__global__ void shared_gate_up_q8_warp_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
+    float* __restrict__ h_scratch) {
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int f = blockIdx.x * ROWS + warp;
+    if (f >= F) return;
+    constexpr int NBLK = H >> 5;
+    const unsigned char* gbase = gate_q + (size_t)f * NBLK * 34;
+    const unsigned char* ubase = up_q   + (size_t)f * NBLK * 34;
+    float tg = si_vec_dot_q8_0(gbase + (size_t)lane * 34, vy + lane);
+    float tu = si_vec_dot_q8_0(ubase + (size_t)lane * 34, vy + lane);
+#pragma unroll
+    for (int b = 32 + lane; b < NBLK; b += 32) {
+        tg += si_vec_dot_q8_0(gbase + (size_t)b * 34, vy + b);
+        tu += si_vec_dot_q8_0(ubase + (size_t)b * 34, vy + b);
+    }
+#pragma unroll
+    for (int m = 16; m > 0; m >>= 1) {
+        tg += __shfl_xor_sync(0xffffffffu, tg, m);
+        tu += __shfl_xor_sync(0xffffffffu, tu, m);
+    }
+    if (lane == 0) {
+        const float w = dw ? __ldg(dw) : 1.f;
+        h_scratch[f] = w * q4kf_silu(tg) * tu;
+    }
+}
+
 template <int H, int F, bool ACCUM>
 __global__ void shared_down_q8_mmvq_kernel(
     const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
@@ -583,6 +650,29 @@ __global__ void shared_down_q8_mmvq_kernel(
         acc += si_vec_dot_q8_0(dbase + (size_t)b * 34, hq8 + b);
     acc = q4kf_wsum(acc);
     if (lane == 0) {
+        if constexpr (ACCUM) acc += __bfloat162float(out[h]);
+        out[h] = __float2bfloat16(acc);
+    }
+}
+
+// F=512 has 16 Q8 blocks per down row. Each half warp owns one output row, so all
+// lanes issue useful loads and an 8-warp CTA produces 16 rows instead of eight.
+template <int H, int F, bool ACCUM>
+__global__ void shared_down_q8_halfwarp_kernel(
+    const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
+    __nv_bfloat16* __restrict__ out) {
+    const int warp = threadIdx.x >> 5, lane16 = threadIdx.x & 15;
+    const int half = (threadIdx.x >> 4) & 1;
+    const int h = blockIdx.x * 16 + warp * 2 + half;
+    if (h >= H) return;
+    constexpr int NBLK = F >> 5;
+    const unsigned char* dbase = down_q + (size_t)h * NBLK * 34;
+    float acc = lane16 < NBLK
+        ? si_vec_dot_q8_0(dbase + (size_t)lane16 * 34, hq8 + lane16) : 0.f;
+#pragma unroll
+    for (int m = 8; m > 0; m >>= 1)
+        acc += __shfl_xor_sync(0xffffffffu, acc, m);
+    if (lane16 == 0) {
         if constexpr (ACCUM) acc += __bfloat162float(out[h]);
         out[h] = __float2bfloat16(acc);
     }
@@ -1316,6 +1406,8 @@ void launch_moe_expert_ffn_q4k(
     if (gu_spec < 0) { const char* gs = getenv("SPARKINFER_GU_SPEC"); gu_spec = (gs && gs[0] == '0') ? 0 : 1; }
     static int gu_pack2 = -1;
     if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '0') ? 0 : 1; }
+    static int gu_pack4 = -1;
+    if (gu_pack4 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK4"); gu_pack4 = (gp && gp[0] == '1') ? 1 : 0; }
     const int gu_pdl = gu_mmvq_pdl();
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
     if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
@@ -1329,7 +1421,13 @@ void launch_moe_expert_ffn_q4k(
                 reinterpret_cast<const __nv_bfloat16*>(input), qbuf, num_tokens * hidden);
             q = qbuf;
         }
-        if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
+        if (gu_pack4 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
+            launch_pdl_kernel(gu_pdl, dim3((num_tokens * top_k * ffn + 3) / 4), dim3(16 * 32), 0, stream,
+                gate_up_mmvq2_pack4_qwen_kernel<2048, 512, 8>,
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch,
+                num_tokens * top_k * ffn);
+        else if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
             launch_pdl_kernel(gu_pdl, dim3((num_tokens * top_k * ffn + 1) / 2), dim3(8 * 32), 0, stream,
                 gate_up_mmvq2_pack2_qwen_kernel<2048, 512, 8>,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
@@ -1523,21 +1621,53 @@ void launch_shared_expert_q8_mmvq(
             reinterpret_cast<const __nv_bfloat16*>(input), qbuf, hidden);
         vy = qbuf;
     }
-    shared_gate_up_q8_mmvq_kernel<2048, 512><<<ffn, 4 * 32, 0, stream>>>(
-        vy, reinterpret_cast<const unsigned char*>(gate_q),
-        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    static int packed = -1;
+    if (packed < 0) {
+        const char* e = getenv("SPARKINFER_SHEXP_PACKED");
+        // The four-row warp kernel gives enough CTAs to cover the 5090 while keeping
+        // every lane useful. Explicit 0 restores the original kernels for A/B.
+        packed = !e ? 3 : ((e[0] >= '0' && e[0] <= '3') ? e[0] - '0' : 3);
+    }
+    if (packed == 3) {
+        shared_gate_up_q8_warp_kernel<2048, 512, 4><<<(ffn + 3) / 4, 4 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    } else if (packed == 2) {
+        shared_gate_up_q8_warp_kernel<2048, 512, 8><<<(ffn + 7) / 8, 8 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    } else if (packed == 1) {
+        shared_gate_up_q8_pack4_kernel<2048, 512><<<(ffn + 3) / 4, 8 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    } else {
+        shared_gate_up_q8_mmvq_kernel<2048, 512><<<ffn, 4 * 32, 0, stream>>>(
+            vy, reinterpret_cast<const unsigned char*>(gate_q),
+            reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch);
+    }
     const int nqb = ffn >> 5;
     quant_h_q8_1_kernel<<<(nqb + 7) / 8, 8 * 32, 0, stream>>>(
         h_scratch, qbuf, nqb, 0);
-    dim3 dn((hidden + WPB - 1) / WPB);
-    if (accum) {
-        shared_down_q8_mmvq_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
-            qbuf, reinterpret_cast<const unsigned char*>(down_q),
-            reinterpret_cast<__nv_bfloat16*>(output));
+    if (packed) {
+        dim3 dn((hidden + 15) / 16);
+        if (accum)
+            shared_down_q8_halfwarp_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
+                qbuf, reinterpret_cast<const unsigned char*>(down_q),
+                reinterpret_cast<__nv_bfloat16*>(output));
+        else
+            shared_down_q8_halfwarp_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
+                qbuf, reinterpret_cast<const unsigned char*>(down_q),
+                reinterpret_cast<__nv_bfloat16*>(output));
     } else {
-        shared_down_q8_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
-            qbuf, reinterpret_cast<const unsigned char*>(down_q),
-            reinterpret_cast<__nv_bfloat16*>(output));
+        dim3 dn((hidden + WPB - 1) / WPB);
+        if (accum)
+            shared_down_q8_mmvq_kernel<2048, 512, true><<<dn, WPB * 32, 0, stream>>>(
+                qbuf, reinterpret_cast<const unsigned char*>(down_q),
+                reinterpret_cast<__nv_bfloat16*>(output));
+        else
+            shared_down_q8_mmvq_kernel<2048, 512, false><<<dn, WPB * 32, 0, stream>>>(
+                qbuf, reinterpret_cast<const unsigned char*>(down_q),
+                reinterpret_cast<__nv_bfloat16*>(output));
     }
 }
 #endif

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -723,6 +723,21 @@ __global__ void k_gemv_batched_fused3_q4(
     }
 }
 
+
+// Compare a linear speculative candidate chain entirely on device. predictions[i] is the
+// target argmax after candidates[i]; each match accepts candidates[i + 1].
+__global__ void k_accept_linear(const int* candidates, const int* predictions, int n,
+                                int* out_accept, int* out_bonus) {
+    if (threadIdx.x != 0 || blockIdx.x != 0) return;
+    int accept = 0;
+    for (int i = 0; i + 1 < n; ++i) {
+        if (predictions[i] != candidates[i + 1]) break;
+        ++accept;
+    }
+    *out_accept = accept;
+    *out_bonus = predictions[accept];
+}
+
 } // namespace
 
 void launch_quantize_w_q4(const void* w, void* q, void* dm, int N, int K, cudaStream_t stream) {
@@ -919,6 +934,12 @@ void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, in
     dim3 grid((N + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
     k_gemv_batched_f32<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
         (const bf16*)x, (const bf16*)W, y, N, K);
+}
+
+void launch_accept_linear(const int* candidates, const int* predictions, int n,
+                          int* out_accept, int* out_bonus, cudaStream_t stream) {
+    if (!candidates || !predictions || !out_accept || !out_bonus || n <= 0) return;
+    k_accept_linear<<<1, 1, 0, stream>>>(candidates, predictions, n, out_accept, out_bonus);
 }
 
 } // namespace dflash_kernels

--- a/runtime/include/sparkinfer/models/dflash_draft.h
+++ b/runtime/include/sparkinfer/models/dflash_draft.h
@@ -61,7 +61,8 @@ public:
     // Returns false on failure.
     bool forward_block(const void* target_hidden, int ctx_len,
                        const int* noise_ids, int pos0,
-                       int* out_argmax, cudaStream_t stream = nullptr);
+                       int* out_argmax, cudaStream_t stream = nullptr,
+                       cudaEvent_t wait_event = nullptr);
 
     // Apply target lm_head to last forward's hidden states; writes device logits [block, vocab]
     // and host argmax. Called internally by forward_block; exposed for debugging.

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -88,6 +88,11 @@ void launch_gemv_rows_exact_fused2(const void* x,
 void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,
                                cudaStream_t stream);
 
+// Device-side acceptance for a linear candidate chain. Writes accepted proposal count and
+// the target bonus token, requiring only one final host collection for the whole verify window.
+void launch_accept_linear(const int* candidates, const int* predictions, int n,
+                          int* out_accept, int* out_bonus, cudaStream_t stream);
+
 // Per-head RMSNorm on [seq, n_heads, d] (in-place).
 void launch_rms_heads(void* x, const void* w, int seq, int n_heads, int d,
                       float eps, cudaStream_t stream);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -487,11 +487,14 @@ bool DFlashDraftModel::load(const std::string& dir) {
 
 bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                      const int* noise_ids, int pos0,
-                                     int* out_argmax, cudaStream_t stream) {
+                                     int* out_argmax, cudaStream_t stream,
+                                     cudaEvent_t wait_event) {
     Impl& s = *p_;
     if (!s.fc || !s.embed || !s.lm_head || !noise_ids || !out_argmax) return false;
     if (ctx_len < 0 || ctx_len + s.cfg.block_size > s.cfg.max_seq + s.cfg.block_size) return false;
     cudaStream_t st = stream ? stream : s.stream;
+    if (wait_event)
+        cu(cudaStreamWaitEvent(st, wait_event, 0), "draft input wait");
     const auto& c = s.cfg;
     const int H = c.hidden;
     const int I = c.intermediate;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1043,12 +1043,14 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             cudaStreamWaitEvent(s.stream_k, s.ev_pipe_fork, 0);
             cudaStreamWaitEvent(s.stream_v, s.ev_pipe_fork, 0);
             if (w.shared_gate_inp) {
+                bool gate_sigmoid_done = false;
                 if (s.use_pq && w.shared_gate_inp_type == 12) {
                     if (s.use_llama) {
                         if (!fnq) kernels::launch_quantize_q8_1_blocks(s.hn, s.aq81, H, s.stream_k);
-                        if (H == 2048)
+                        if (H == 2048) {
                             kernels::launch_mmvq_q4k_sigmoid(s.aq81, w.shared_gate_inp, s.d_shared_w, H, s.stream_k);
-                        else
+                            gate_sigmoid_done = true;
+                        } else
                             kernels::launch_mmvq_q4k(s.aq81, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
                     } else {
                         kernels::launch_quantize_q8_1(s.hn, s.aq8, s.aq8_d, s.aq8_s, H, s.stream_k);
@@ -1071,12 +1073,14 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                         gemv_sigmoid = (e && e[0] == '1') ? 1 : 0; }   // default off: fused dot != split-k GEMV
                     if (gemv_sigmoid) {
                         kernels::launch_gemv_sigmoid(s.hn, w.shared_gate_inp, s.shared_gate_tmp, s.d_shared_w, H, s.stream_k);
+                        gate_sigmoid_done = true;
                     } else {
                         kernels::launch_gemv(s.hn, w.shared_gate_inp, s.shared_gate_tmp, 1, H, s.stream_k);
-                        kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
                     }
                 }
-                if (w.shared_gate_inp && !(s.use_pq && s.use_llama && w.shared_gate_inp_type == 12 && H == 2048))
+                // All non-Q4_K paths above leave the gate logit in shared_gate_tmp. Apply the
+                // sigmoid exactly once here; the BF16 path previously launched this twice.
+                if (!gate_sigmoid_done)
                     kernels::launch_qwen36_sigmoid_scalar(s.shared_gate_tmp, s.d_shared_w, s.stream_k);
             }
             if (qmoe) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -238,6 +238,16 @@ struct Qwen35Model::Impl {
     int dflash_ctx_cap = 0;
     bf16* dflash_hidden = nullptr;    // [max_rows, n_cap * H]
     bf16* dflash_context = nullptr;   // [ctx_cap, n_cap * H]
+    // Tail-window verification keeps row scalars, target argmaxes and acceptance metadata on
+    // device until one final collect. The target graph still replays sequentially because GDN
+    // state is recurrent; this removes only the intermediate host gates.
+    int* dflash_batch_ids = nullptr;
+    int* dflash_batch_candidates = nullptr;
+    int* dflash_batch_result = nullptr;
+    int* h_dflash_batch_result = nullptr;
+    int* h_dflash_batch_scalars = nullptr;  // pinned [max_rows, 5]
+    bool dflash_batch_async = false;
+    int dflash_batch_row = 0;
     float* spec_lin_snap = nullptr;
     bf16* spec_conv_snap = nullptr;
 
@@ -423,6 +433,9 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->sparse_vtbl); cudaFree(p_->sparse_vlen);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
     cudaFree(p_->dflash_hidden); cudaFree(p_->dflash_context);
+    cudaFree(p_->dflash_batch_ids); cudaFree(p_->dflash_batch_candidates);
+    cudaFree(p_->dflash_batch_result); cudaFreeHost(p_->h_dflash_batch_result);
+    cudaFreeHost(p_->h_dflash_batch_scalars);
     // spec_lin_snap / spec_conv_snap are in owned[] (allocated via Impl::alloc)
     for (auto& kv : p_->sessions) {
         if (kv.first == 0) continue;
@@ -474,12 +487,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     int seqlen = position + 1;
     cudaStream_t st = s.stream;
     const bool dflash_cap = s.dflash_capture;
-    s.h_scalars[0] = token_id;
-    s.h_scalars[1] = position;
-    s.h_scalars[2] = position;
-    s.h_scalars[3] = seqlen;
-    s.h_scalars[4] = s.dflash_cap_row;
-    cu(cudaMemcpyAsync(s.d_scalars, s.h_scalars, 5 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
+    int* host_scalars = s.h_scalars;
+    if (s.dflash_batch_async && s.h_dflash_batch_scalars &&
+        s.dflash_batch_row >= 0 && s.dflash_batch_row < s.dflash_max_rows)
+        host_scalars = s.h_dflash_batch_scalars + (size_t)s.dflash_batch_row * 5;
+    host_scalars[0] = token_id;
+    host_scalars[1] = position;
+    host_scalars[2] = position;
+    host_scalars[3] = seqlen;
+    host_scalars[4] = s.dflash_cap_row;
+    cu(cudaMemcpyAsync(s.d_scalars, host_scalars, 5 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
 
     // Depth-adaptive KV-split: 32 (short) -> 128 (mid) -> 256 (long). The 8k-12k band
     // (28*split_chunk < seqlen <= 48*split_chunk) is roofline-bound on 128 splits; promote
@@ -623,6 +640,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     }
     if (sample && dflash_cap && s.dflash_graph_ready) {
         cu(cudaGraphLaunch(s.cu_dflash_exec, st), "dflash graph launch");
+        if (s.dflash_batch_async && s.dflash_batch_ids &&
+            s.dflash_batch_row >= 0 && s.dflash_batch_row < s.dflash_max_rows) {
+            cu(cudaMemcpyAsync(s.dflash_batch_ids + s.dflash_batch_row, s.d_out_id,
+                               sizeof(int), cudaMemcpyDeviceToDevice, st), "dflash tail argmax");
+            return token_id;
+        }
         cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");
         // Deferred collect (DFlash verify token 0 only): return without blocking so the caller
         // can issue the draft block behind it. The target forward is then already running on the
@@ -1271,6 +1294,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         cu(cudaGraphLaunch(s.cu_exec, st), "graph launch (first)");
     }
 
+    if (s.dflash_batch_async && s.dflash_batch_ids &&
+        s.dflash_batch_row >= 0 && s.dflash_batch_row < s.dflash_max_rows) {
+        cu(cudaMemcpyAsync(s.dflash_batch_ids + s.dflash_batch_row, s.d_out_id,
+                           sizeof(int), cudaMemcpyDeviceToDevice, st), "dflash tail argmax");
+        return token_id;
+    }
     cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "out_id");
     cu(cudaStreamSynchronize(st), "sync");
     return *s.h_out_id;
@@ -1707,9 +1736,22 @@ void Qwen35Model::set_dflash_capture(bool on, const std::vector<int>& target_lay
     const size_t hidden_bytes = (size_t)s.dflash_max_rows * row_elems * sizeof(bf16);
     if (s.dflash_hidden) { cudaFree(s.dflash_hidden); s.dflash_hidden = nullptr; }
     if (s.dflash_context) { cudaFree(s.dflash_context); s.dflash_context = nullptr; }
+    if (s.dflash_batch_ids) { cudaFree(s.dflash_batch_ids); s.dflash_batch_ids = nullptr; }
+    if (s.dflash_batch_candidates) { cudaFree(s.dflash_batch_candidates); s.dflash_batch_candidates = nullptr; }
+    if (s.dflash_batch_result) { cudaFree(s.dflash_batch_result); s.dflash_batch_result = nullptr; }
+    if (s.h_dflash_batch_result) { cudaFreeHost(s.h_dflash_batch_result); s.h_dflash_batch_result = nullptr; }
+    if (s.h_dflash_batch_scalars) { cudaFreeHost(s.h_dflash_batch_scalars); s.h_dflash_batch_scalars = nullptr; }
+    s.dflash_batch_async = false;
+    s.dflash_batch_row = 0;
     s.dflash_ctx_cap = s.cfg.max_seq;
     cu(cudaMalloc(&s.dflash_hidden, hidden_bytes), "dflash hidden");
     cu(cudaMalloc(&s.dflash_context, (size_t)s.dflash_ctx_cap * row_elems * sizeof(bf16)), "dflash ctx");
+    cu(cudaMalloc(&s.dflash_batch_ids, (size_t)s.dflash_max_rows * sizeof(int)), "dflash tail ids");
+    cu(cudaMalloc(&s.dflash_batch_candidates, (size_t)s.dflash_max_rows * sizeof(int)), "dflash tail candidates");
+    cu(cudaMalloc(&s.dflash_batch_result, 2 * sizeof(int)), "dflash tail result");
+    cu(cudaMallocHost(&s.h_dflash_batch_result, 2 * sizeof(int)), "dflash tail host result");
+    cu(cudaMallocHost(&s.h_dflash_batch_scalars, (size_t)s.dflash_max_rows * 5 * sizeof(int)),
+       "dflash tail host scalars");
     if (s.cfg.hybrid && !s.spec_lin_snap) {
         const size_t ls = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
                           s.cfg.linear_head_dim * s.cfg.linear_head_dim;
@@ -1753,7 +1795,6 @@ void Qwen35Model::save_spec_snapshot() {
        "spec snap lin");
     cu(cudaMemcpyAsync(s.spec_conv_snap, s.lin_conv_state, cs * sizeof(bf16), cudaMemcpyDeviceToDevice, s.stream),
        "spec snap conv");
-    cu(cudaStreamSynchronize(s.stream), "spec snap sync");
 }
 
 void Qwen35Model::restore_spec_snapshot() {
@@ -1766,8 +1807,6 @@ void Qwen35Model::restore_spec_snapshot() {
        "spec restore lin");
     cu(cudaMemcpyAsync(s.lin_conv_state, s.spec_conv_snap, cs * sizeof(bf16), cudaMemcpyDeviceToDevice, s.stream),
        "spec restore conv");
-    cu(cudaStreamSynchronize(s.stream), "spec restore sync");
-    invalidate_decode_graph();
 }
 
 bool Qwen35Model::verify_block(const int* token_ids, int n, int start_pos, int* out_argmax) {
@@ -1864,6 +1903,9 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         draft.reset();
         return out;
     }
+    cudaEvent_t th_scratch_ready = nullptr;
+    cu(cudaEventCreateWithFlags(&th_scratch_ready, cudaEventDisableTiming),
+       "dflash overlap event");
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
         block[0] = next;
@@ -1873,11 +1915,17 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // accepted suffix before running that target forward concurrently with the independent
         // draft stream. The initial full-context buffer is separate and needs no copy.
         const void* draft_hidden = target_hidden;
+        cudaEvent_t draft_wait = nullptr;
         if (target_hidden == s.dflash_hidden) {
             cu(cudaMemcpyAsync(th_scratch, target_hidden,
                                (size_t)th_len * row_stride * sizeof(bf16),
                                cudaMemcpyDeviceToDevice, s.stream), "dflash overlap stash");
-            cu(cudaStreamSynchronize(s.stream), "dflash overlap stash sync");
+            if (th_scratch_ready) {
+                cu(cudaEventRecord(th_scratch_ready, s.stream), "dflash overlap event record");
+                draft_wait = th_scratch_ready;
+            } else {
+                cu(cudaStreamSynchronize(s.stream), "dflash overlap stash sync");
+            }
             draft_hidden = th_scratch;
         }
 
@@ -1890,7 +1938,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int p0 = forward_token(block[0], start, true);
         s.defer_decode_sync = false;
         const bool draft_ok = draft.forward_block(
-            draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr);
+            draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr, draft_wait);
         if (p0 == kDFlashDeferred) {
             cu(cudaStreamSynchronize(s.stream), "verify0 sync");
             s.decode_pending = false;
@@ -1902,15 +1950,69 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         }
         for (int i = 1; i <= kProposalDepth; i++) block[i] = draft_ids[i];
 
+        static const int batch_verify = [] {
+            const char* e = getenv("SPARKINFER_DFLASH_BATCH_VERIFY");
+            return (e && e[0] == '1') ? 1 : 0;
+        }();
+        const bool use_batch_verify = batch_verify && s.cfg.hybrid &&
+            kProposalDepth >= 1 && kProposalDepth < B &&
+            s.dflash_batch_ids && s.dflash_batch_candidates && s.dflash_batch_result &&
+            s.h_dflash_batch_result && s.h_dflash_batch_scalars &&
+            s.spec_lin_snap && s.spec_conv_snap;
+
         // Incremental verify with early-exit: forward only the accepted prefix, stopping at the
         // first rejected proposal. forward_token advances GDN state + KV per token, so after
         // block[0..keep-1] the recurrent state and KV sit exactly at start+keep -- no snapshot /
         // restore / KV-truncate / replay needed (greedy speculative decoding is exact). Rejected
         // proposals (block[keep..B-1]) are never forwarded, saving ~B-keep target forwards/step.
         int accept = 0, keep = 1;
+        int bonus = p0;
         bool vfail = p0 < 0;
         posterior[0] = p0;
-        if (!vfail && block[1] == p0) {
+        if (!vfail && block[1] == p0 && use_batch_verify) {
+            // SGLang-style hybrid verify/commit: retain the exact post-seed recurrent state,
+            // queue the tail graph replays without host gates, then commit the live full-tail
+            // state or restore and replay only the accepted prefix after a rejection.
+            save_spec_snapshot();
+            const int tail_n = kProposalDepth;
+            cu(cudaMemcpyAsync(s.dflash_batch_candidates, block.data() + 1,
+                               (size_t)tail_n * sizeof(int), cudaMemcpyHostToDevice, s.stream),
+               "dflash tail candidates");
+            s.dflash_batch_async = true;
+            for (int i = 1; i <= kProposalDepth; ++i) {
+                set_dflash_capture_row(i);
+                s.dflash_batch_row = i;
+                forward_token(block[i], start + i, true);
+            }
+            s.dflash_batch_async = false;
+            dflash_kernels::launch_accept_linear(s.dflash_batch_candidates,
+                                                 s.dflash_batch_ids + 1, tail_n,
+                                                 s.dflash_batch_result,
+                                                 s.dflash_batch_result + 1, s.stream);
+            cu(cudaMemcpyAsync(s.h_dflash_batch_result, s.dflash_batch_result,
+                               2 * sizeof(int), cudaMemcpyDeviceToHost, s.stream),
+               "dflash tail accept");
+            cu(cudaStreamSynchronize(s.stream), "dflash tail verify sync");
+            const int tail_accept = s.h_dflash_batch_result[0];
+            accept = 1 + tail_accept;
+            bonus = s.h_dflash_batch_result[1];
+            if (tail_accept < 0 || tail_accept >= tail_n ||
+                accept > kProposalDepth || bonus < 0 || bonus >= s.cfg.vocab) {
+                vfail = true;
+            } else {
+                keep = accept + 1;
+                if (accept < kProposalDepth) {
+                    restore_spec_snapshot();
+                    s.dflash_batch_async = true;
+                    for (int i = 1; i <= accept; ++i) {
+                        set_dflash_capture_row(i);
+                        s.dflash_batch_row = i;
+                        forward_token(block[i], start + i, true);
+                    }
+                    s.dflash_batch_async = false;
+                }
+            }
+        } else if (!vfail && block[1] == p0) {
             for (int i = 1; i <= kProposalDepth; i++) {
                 set_dflash_capture_row(i);
                 const int p = forward_token(block[i], start + i, true);
@@ -1920,6 +2022,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
                 keep = i + 1;
                 if (i < kProposalDepth && block[i + 1] != p) break;
             }
+            bonus = posterior[accept];
         }
         if (vfail) { fprintf(stderr, "[dflash] verify failed at start=%d\n", start); break; }
         // forward_token() synchronizes after sampling, so the accepted capture rows are already
@@ -1934,7 +2037,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         }
         if (stop) break;
         // Bonus token becomes the next block seed (emitted on the following iteration).
-        next = posterior[accept];
+        next = bonus;
         if (next == s.cfg.eos_id) {
             if ((int)out.size() < max_new) out.push_back(next);
             break;
@@ -1955,6 +2058,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         stats->decode_s = std::chrono::duration<double>(t_end - t_decode0).count();
     }
     close_session(sid);
+    if (th_scratch_ready) cudaEventDestroy(th_scratch_ready);
     if (th_scratch) cudaFree(th_scratch);
     set_dflash_capture(false, {}, 0);
     draft.reset();


### PR DESCRIPTION
## Summary

Optimizes Qwen3.6 DFlash target decode with packed shared-expert Q8 kernels, an exact fused BF16 shared-gate sigmoid path, and removal of a duplicate sigmoid launch. The existing batch-gated hybrid verification experiment remains opt-in.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end DFlash decode, 128 generated tokens, fixed 102-token prompt, alternating same-box A/B):

| | decode tok/s |
|---|--:|
| before (`main` at `b0261a5`) | 478.66 |
| after (this PR at `383563e`) | 498.09 |

The measured end-to-end DFlash decode improvement is **+4.06%**.

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
GPU: NVIDIA GeForce RTX 5090, sm_120, CUDA 12.8
Model: Qwen3.6-35B-A3B-UD-Q4_K_M + DFlash draft
Benchmark: max_new=128, fixed 102-token prompt, SPARKINFER_PREFILL_MOE_QB=0

alternating same-box A/B means:
  main  METRIC DFLASH_TPS 478.6587
  PR    METRIC DFLASH_TPS 498.0922
  delta: +4.0600%

correctness, max_new=128:
METRIC SPEC_AGREE 128/128 = 1.0000
METRIC MEAN_ACCEPT 3.743 steps=35
VERDICT PASS
```

### Accuracy gate

Greedy DFlash output agrees exactly with the autoregressive reference. The packed Q8 kernels preserve the original per-row floating-point reduction order; no weights or quantization parameters are changed. `SPARKINFER_SHEXP_PACKED=0` restores the original shared-expert kernels for A/B.

