### PR TITLE
fix(eval): pin TOK_REPO to Qwen3.6 for the dflash accuracy check

### DIFF
--- a/eval/pr_dflash_bot.py
+++ b/eval/pr_dflash_bot.py
@@ -306,6 +306,13 @@ test -x build/runtime/qwen3_gguf_bench
 
 if [ "$DO_ACC" = "1" ]; then
   export MODELS_DIR
+  # dflash_accuracy.sh's ensure_tokenizer needs TOK_REPO for the *target* model (Qwen3.6) —
+  # without it, _common.sh's TOK_REPO default ("Qwen/Qwen3-30B-A3B") silently wins, so
+  # gen_eval_prompt.py tokenizes the scored prompt with the wrong (smaller) vocabulary. The
+  # mismatch is invisible downstream: Qwen3.6's vocab is larger, so every resulting id is
+  # still "valid", just semantically meaningless. That corrupted PROMPT_IDS stream is what
+  # both the accuracy check AND the speed bench below score against.
+  export TOK_REPO="$Q36_GUARD_TOK_REPO"
   bash bench/scripts/dflash_accuracy.sh "$GGUF" "$DRAFT" | tee /tmp/dflash_check_out.txt
   grep -q "^VERDICT PASS" /tmp/dflash_check_out.txt
   if [ -z "${{PROMPT_IDS:-}}" ] && [ -f /tmp/dflash_eval_ids.txt ]; then


### PR DESCRIPTION
## Summary
- `dflash_accuracy.sh`'s `ensure_tokenizer()` downloads `tokenizer.json` for whatever `$TOK_REPO` points to, defaulting to `Qwen/Qwen3-30B-A3B` when unset.
- The DFlash accuracy check's `_remote_script()` branch never exported `TOK_REPO` before calling it — so it silently tokenized the held-out eval prompt (`gen_eval_prompt.py`) with the wrong (smaller) vocabulary instead of the actual target model's (Qwen3.6-35B-A3B) tokenizer.
- The mismatch was invisible downstream: Qwen3.6's vocab is larger, so every resulting token id was still "valid", just semantically meaningless relative to the intended prompt text. That corrupted `PROMPT_IDS` stream is what both the accuracy gate (`SPEC_AGREE`) and the speed bench score against.
- Fix: pin `TOK_REPO` to the same Qwen3.6 tokenizer repo the guard sweep already uses (`Q36_GUARD_TOK_REPO`), right before the accuracy check runs.

## Test plan
- [x] `python3 -m py_compile eval/pr_dflash_bot.py`
- [x] Verified live on the eval box: `tokenizer.json` under `models36` now resolves to `Qwen/Qwen3.6-35B-A3B` (`vocab_size=248070`) instead of silently falling back to the default repo
- [x] Confirmed the fixed-prompt path (`gen_eval_prompt.py fixed ...`) produces a stable token count (101) against the correct tokenizer