### PR TITLE
perf(dflash): verify the proposal tail in one row-batched target forward

### DIFF
--- a/kernels/csrc/cuda/fused/dflash_rows_fused.cu
+++ b/kernels/csrc/cuda/fused/dflash_rows_fused.cu
@@ -1,0 +1,492 @@
+// Row-batched DFlash verify kernels: GDN conv front-end + the fused norms.
+//
+// The verify loop forwards one target token per emitted token, so a window of R proposals
+// streams the whole model R times. These kernels consume the window's R activation rows in
+// one launch. Nothing in this file owns a weight matrix worth amortizing (the norm weight is
+// a single row), so the cheap kernels take rows as an extra GRID dimension: each block still
+// runs the single-row kernel verbatim on its own row, which is why rows=R is bit-identical to
+// R single-row calls by construction. The depthwise conv cannot do that — it reads and then
+// shifts conv_state, so token r depends on the state token r-1 left behind — and instead
+// carries a compile-time-length sequential loop over the window inside the block.
+//
+// EXACTNESS: the DFlash gate asserts speculative output equals autoregressive output token
+// for token, so every accumulation order, reduction tree and rounding step below is copied
+// verbatim from conv_split_l2norm_fused_kernel / gated_norm_q8_warp_kernel /
+// add_rmsnorm{2,3}_q8_kernel / rmsnorm_kernel. Batching only chooses which rows share a CTA.
+//
+// Self-contained by house convention: the small device helpers are duplicated here rather
+// than shared through a header (as expert_ffn_q4k.cu duplicates gemv.cu's Q4_K decoder).
+//
+// Portable CUDA — sm_89 .. sm_120.
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include <cuda_runtime.h>
+// At file scope, not inside the namespace: the launchers below must attach to the
+// declarations in this header (and to kDFlashMaxRows), not to nested copies of them.
+#include "sparkinfer/kernels/dflash_rows.h"
+#include <cassert>
+#endif
+
+namespace sparkinfer {
+namespace kernels {
+
+// ---- device helpers (copies of the qwen36.cu / rmsnorm.cu originals) --------
+
+__device__ __forceinline__ float dfr_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ float dfr_silu(float x) { return x / (1.f + __expf(-x)); }
+__device__ __forceinline__ float dfr_wsum(float v) {
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffffu, v, m);
+    return v;
+}
+
+__device__ __forceinline__ float dfr_warp_sum(float v) {
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffff, v, m);
+    return v;
+}
+
+// 128-bit (uint4 = 8 bf16) coalesced access helpers for the bf16 row scan.
+__device__ __forceinline__ void dfr_unpack8(const uint4& p, float out[8]) {
+    const __nv_bfloat16* h = reinterpret_cast<const __nv_bfloat16*>(&p);
+    #pragma unroll
+    for (int j = 0; j < 8; j++) out[j] = __bfloat162float(h[j]);
+}
+__device__ __forceinline__ uint4 dfr_pack8(const float in[8]) {
+    uint4 p; __nv_bfloat16* h = reinterpret_cast<__nv_bfloat16*>(&p);
+    #pragma unroll
+    for (int j = 0; j < 8; j++) h[j] = __float2bfloat16(in[j]);
+    return p;
+}
+
+// llama mmvq activation block (matches si_block_q8_1 used by the int8 GEMVs/MMVQ).
+struct dfr_blk_q8_1 { __half2 ds; signed char qs[32]; };
+
+// ---- conv + split + L2(q,k) over a window of R tokens -----------------------
+// Mirrors conv_split_l2norm_fused_kernel with the SAME grid — one block per head, one
+// thread per channel — and walks the window inside the block. The rows CANNOT be spread
+// over blocks: the causal conv reads conv_state and then shifts token r into it, so token
+// r+1's convolution consumes what token r wrote. Keeping the window inside one block makes
+// that dependency an ordinary sequential loop; each channel d is owned by exactly one
+// thread in exactly one block, so the state shift needs no cross-block ordering.
+//
+// The block-wide L2 reduction forces two structural details: the per-token __syncthreads()
+// pair must be executed by EVERY thread (hence the out-of-range early return becomes the
+// `active` predicate — a thread that returned would starve the barriers and hang the
+// block), and sw[] is reused across tokens, so the loop closes with one more barrier
+// before the next token overwrites it. Barriers move no arithmetic; each token's operand
+// order, reduction tree and rounding are exactly the single-token kernel's.
+template <int R>
+__global__ void dflash_rows_conv_split_l2norm_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ conv_w,
+    __nv_bfloat16* __restrict__ conv_state,
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ v,
+    int q_heads, int v_heads, int head_dim, int conv_kernel, float eps)
+{
+    const int h  = blockIdx.x;
+    const int t  = threadIdx.x;
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int qkv_dim = 2 * q_dim + v_dim;
+
+    bool do_norm = false;
+    int d;
+    __nv_bfloat16* out;
+    if (h < q_heads) {
+        d = h * head_dim + t;  out = q + d;           do_norm = true;
+    } else if (h < 2 * q_heads) {
+        d = q_dim + (h - q_heads) * head_dim + t;  out = k + d - q_dim;  do_norm = true;
+    } else {
+        d = 2 * q_dim + (h - 2 * q_heads) * head_dim + t;  out = v + d - 2 * q_dim;
+    }
+    const bool active = (d < qkv_dim);
+    // q and k stack q_heads heads per token, v stacks v_heads.
+    const int out_stride = do_norm ? q_dim : v_dim;
+
+    __shared__ float sw[32];
+
+    for (int r = 0; r < R; r++) {
+        const __nv_bfloat16* qkv_r = qkv + (size_t)r * qkv_dim;
+
+        // 1D conv + SiLU
+        float y = 0.f;
+        if (active) {
+            for (int p = 0; p < conv_kernel - 1; p++)
+                y += dfr_to_f(conv_state[(size_t)p * qkv_dim + d]) *
+                     dfr_to_f(conv_w[(size_t)d * conv_kernel + p]);
+            y += dfr_to_f(qkv_r[d]) * dfr_to_f(conv_w[(size_t)d * conv_kernel + (conv_kernel - 1)]);
+
+            for (int p = 0; p < conv_kernel - 2; p++)
+                conv_state[(size_t)p * qkv_dim + d] = conv_state[(size_t)(p + 1) * qkv_dim + d];
+            if (conv_kernel > 1)
+                conv_state[(size_t)(conv_kernel - 2) * qkv_dim + d] = qkv_r[d];
+        }
+
+        const float oy = dfr_silu(y);
+
+        if (do_norm) {
+            const float ss = dfr_wsum(oy * oy);
+            if ((t & 31) == 0) sw[t >> 5] = ss;
+            __syncthreads();
+            if (t < 32) {
+                float vv = (t < (head_dim + 31) / 32) ? sw[t] : 0.f;
+                vv = dfr_wsum(vv);
+                if (t == 0) sw[0] = rsqrtf(vv + eps);
+            }
+            __syncthreads();
+            if (active) out[(size_t)r * out_stride] = __float2bfloat16(oy * sw[0]);
+        } else {
+            if (active) out[(size_t)r * out_stride] = __float2bfloat16(oy);
+        }
+        // Retire this token's readers of sw[0] before the next token rewrites sw[].
+        __syncthreads();
+    }
+}
+
+#ifndef _MSC_VER
+template __global__ void dflash_rows_conv_split_l2norm_kernel<1>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+template __global__ void dflash_rows_conv_split_l2norm_kernel<2>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+template __global__ void dflash_rows_conv_split_l2norm_kernel<3>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+template __global__ void dflash_rows_conv_split_l2norm_kernel<4>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+template __global__ void dflash_rows_conv_split_l2norm_kernel<5>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+template __global__ void dflash_rows_conv_split_l2norm_kernel<6>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+template __global__ void dflash_rows_conv_split_l2norm_kernel<7>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+template __global__ void dflash_rows_conv_split_l2norm_kernel<8>(const __nv_bfloat16*, const __nv_bfloat16*,
+    __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int, int, float);
+#endif
+
+// ---- gated norm -> Q8_1, one warp per (v-head, row) -------------------------
+// Mirrors gated_norm_q8_warp_kernel. grid.y is the window index: the whole reduction is
+// warp-local, so a row is just a base-pointer offset and the per-row math is untouched.
+// The norm weight is shared by every row and is NOT offset.
+template <int HEAD_DIM>
+__global__ void dflash_rows_gated_norm_q8_kernel(const __nv_bfloat16* __restrict__ x,
+                                                 const __nv_bfloat16* __restrict__ z,
+                                                 const __nv_bfloat16* __restrict__ weight,
+                                                 dfr_blk_q8_1* __restrict__ out_q8,
+                                                 int v_heads, float eps) {
+    constexpr int NROW = HEAD_DIM / 32;
+    const int h = blockIdx.x;
+    const int row = blockIdx.y;
+    const int lane = threadIdx.x & 31;
+    if (h >= v_heads) return;
+    const size_t base = (size_t)(row * v_heads + h) * HEAD_DIM;
+    const int qbase = (row * v_heads + h) * NROW;
+    float ss = 0.f;
+    float xv[NROW], zv[NROW], wv[NROW];
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) {
+        const int t = lane + r * 32;
+        xv[r] = dfr_to_f(x[base + t]);
+        zv[r] = dfr_to_f(z[base + t]);
+        wv[r] = dfr_to_f(weight[t]);
+        ss += xv[r] * xv[r];
+    }
+    const float inv = rsqrtf(dfr_wsum(ss) / HEAD_DIM + eps);
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) {
+        const float y = xv[r] * inv * wv[r] * dfr_silu(zv[r]);
+        const float bv = __bfloat162float(__float2bfloat16(y));
+        float amax = fabsf(bv);
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
+        const float d = amax / 127.0f;
+        const int qi = (amax == 0.0f) ? 0 : (int)roundf(bv / d);
+        out_q8[qbase + r].qs[lane] = (signed char)qi;
+        int s = qi;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) s += __shfl_xor_sync(0xffffffffu, s, m);
+        if (lane == 0) out_q8[qbase + r].ds = __floats2half2_rn(d, d * (float)s);
+    }
+}
+
+#ifndef _MSC_VER
+template __global__ void dflash_rows_gated_norm_q8_kernel<128>(const __nv_bfloat16*, const __nv_bfloat16*,
+    const __nv_bfloat16*, dfr_blk_q8_1*, int, float);
+#endif
+
+// ---- residual add + RMSNorm + Q8_1(out_norm), one block per row -------------
+// Mirrors add_rmsnorm2_q8_kernel, whose grid was a single block. blockIdx.x is now the
+// window index; every pointer but `weight` is offset by the row. Still one 8-wide pack per
+// thread, so a Q8_1 block is 4 consecutive threads inside one warp.
+__global__ void dflash_rows_add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
+                                                   const __nv_bfloat16* __restrict__ residual,
+                                                   const __nv_bfloat16* __restrict__ weight,
+                                                   __nv_bfloat16* __restrict__ out_sum,
+                                                   __nv_bfloat16* __restrict__ out_norm,
+                                                   dfr_blk_q8_1* __restrict__ out_q8,
+                                                   int cols, float eps) {
+    const int row = blockIdx.x;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    const int t = threadIdx.x;
+    const uint4* x4 = reinterpret_cast<const uint4*>(x + base);
+    const uint4* r4 = reinterpret_cast<const uint4*>(residual + base);
+    uint4* osum4 = reinterpret_cast<uint4*>(out_sum + base);
+    dfr_blk_q8_1* q8 = out_q8 + (size_t)row * (cols >> 5);
+
+    float xv[8], rv[8]; dfr_unpack8(__ldg(x4 + t), xv); dfr_unpack8(__ldg(r4 + t), rv);
+    float sv[8]; float ss = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) { sv[j] = xv[j] + rv[j]; ss = __fmaf_rn(sv[j], sv[j], ss); }
+    osum4[t] = dfr_pack8(sv);
+    ss = dfr_warp_sum(ss);
+    if ((t & 31) == 0) s_warp[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < (blockDim.x + 31) / 32) ? s_warp[t] : 0.f;
+        v = dfr_warp_sum(v);
+        if (t == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    // Re-read the bf16-rounded residual sum (exactly as add_rmsnorm2_kernel does), so out_norm
+    // is bit-identical to the unfused path; then derive Q8_1 from the bf16-rounded out_norm.
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum + base);
+    float svb[8], wv[8]; dfr_unpack8(__ldg(osum4r + t), svb); dfr_unpack8(__ldg(w4 + t), wv);
+    float ov[8], bv[8];
+    #pragma unroll
+    for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
+    reinterpret_cast<uint4*>(out_norm + base)[t] = dfr_pack8(ov);
+
+    // Q8_1 of the bf16-rounded out_norm. 32-block = 4 consecutive threads (t&~3 .. +3).
+    float amax = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(bv[j]));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+    const float d = amax / 127.0f;
+    const int b = t >> 2, r = t & 3;
+    int s = 0;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
+        q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+    }
+    s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
+    if (r == 0) q8[b].ds = __floats2half2_rn(d, d * (float)s);
+}
+
+// 3-input form: out_sum = x + (res1 + res2), the inner sum rounded to bf16 first.
+__global__ void dflash_rows_add_rmsnorm3_q8_kernel(const __nv_bfloat16* __restrict__ x,
+                                                   const __nv_bfloat16* __restrict__ res1,
+                                                   const __nv_bfloat16* __restrict__ res2,
+                                                   const __nv_bfloat16* __restrict__ weight,
+                                                   __nv_bfloat16* __restrict__ out_sum,
+                                                   __nv_bfloat16* __restrict__ out_norm,
+                                                   dfr_blk_q8_1* __restrict__ out_q8,
+                                                   int cols, float eps) {
+    const int row = blockIdx.x;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    const int t = threadIdx.x;
+    const uint4* x4  = reinterpret_cast<const uint4*>(x + base);
+    const uint4* r14 = reinterpret_cast<const uint4*>(res1 + base);
+    const uint4* r24 = reinterpret_cast<const uint4*>(res2 + base);
+    uint4* osum4 = reinterpret_cast<uint4*>(out_sum + base);
+    dfr_blk_q8_1* q8 = out_q8 + (size_t)row * (cols >> 5);
+
+    float xv[8], r1v[8], r2v[8];
+    dfr_unpack8(__ldg(x4 + t), xv); dfr_unpack8(__ldg(r14 + t), r1v); dfr_unpack8(__ldg(r24 + t), r2v);
+    float sv[8]; float ss = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        float rs = __bfloat162float(__float2bfloat16(r1v[j] + r2v[j]));
+        sv[j] = xv[j] + rs;
+        ss = __fmaf_rn(sv[j], sv[j], ss);
+    }
+    osum4[t] = dfr_pack8(sv);
+    ss = dfr_warp_sum(ss);
+    if ((t & 31) == 0) s_warp[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float v = (t < (blockDim.x + 31) / 32) ? s_warp[t] : 0.f;
+        v = dfr_warp_sum(v);
+        if (t == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum + base);
+    float svb[8], wv[8]; dfr_unpack8(__ldg(osum4r + t), svb); dfr_unpack8(__ldg(w4 + t), wv);
+    float ov[8], bv[8];
+    #pragma unroll
+    for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
+    reinterpret_cast<uint4*>(out_norm + base)[t] = dfr_pack8(ov);
+
+    float amax = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(bv[j]));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+    const float d = amax / 127.0f;
+    const int b = t >> 2, r = t & 3;
+    int s = 0;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
+        q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+    }
+    s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
+    if (r == 0) q8[b].ds = __floats2half2_rn(d, d * (float)s);
+}
+
+// ---- plain RMSNorm ----------------------------------------------------------
+// rmsnorm_kernel<0> with the residual branches constant-folded out (the DFlash prime norm
+// at layer 0 has no residual). Already one block per row, so the window needs nothing but a
+// larger grid.
+__global__ void dflash_rows_rmsnorm_kernel(const __nv_bfloat16* __restrict__ x,
+                                           const __nv_bfloat16* __restrict__ weight,
+                                           __nv_bfloat16* __restrict__ out,
+                                           int rows, int cols, float eps) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+
+    const int npack = cols >> 3;   // cols / 8 (RMSNorm widths here are multiples of 8)
+    const int tail  = npack << 3;  // first scalar column (handles cols % 8 != 0)
+    const uint4* x4 = reinterpret_cast<const uint4*>(x + base);
+
+    float ss = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float xv[8]; dfr_unpack8(__ldg(x4 + p), xv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss = __fmaf_rn(xv[j], xv[j], ss);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+        float v = __bfloat162float(x[base + c]);
+        ss = __fmaf_rn(v, v, ss);
+    }
+    ss = dfr_warp_sum(ss);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = dfr_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    uint4* o4 = reinterpret_cast<uint4*>(out + base);
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float xv[8]; dfr_unpack8(__ldg(x4 + p), xv);
+        float wv[8]; dfr_unpack8(__ldg(w4 + p), wv);
+        float ov[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ov[j] = xv[j] * inv_rms * wv[j];
+        o4[p] = dfr_pack8(ov);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+        float v = __bfloat162float(x[base + c]);
+        out[base + c] = __float2bfloat16(v * inv_rms * __bfloat162float(weight[c]));
+    }
+}
+
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+void launch_dflash_rows_conv_split_l2norm(const void* qkv, const void* conv_w, void* conv_state,
+                                          void* q, void* k, void* v,
+                                          int q_heads, int v_heads, int head_dim,
+                                          int conv_kernel, float eps, int rows,
+                                          cudaStream_t stream) {
+    if (rows < 1 || rows > kDFlashMaxRows) return;
+    const int blocks = 2 * q_heads + v_heads;
+#define SI_DFLASH_ROWS_CONV(R)                                                  \
+    dflash_rows_conv_split_l2norm_kernel<R><<<blocks, head_dim, 0, stream>>>(   \
+        reinterpret_cast<const __nv_bfloat16*>(qkv),                            \
+        reinterpret_cast<const __nv_bfloat16*>(conv_w),                         \
+        reinterpret_cast<__nv_bfloat16*>(conv_state),                           \
+        reinterpret_cast<__nv_bfloat16*>(q),                                    \
+        reinterpret_cast<__nv_bfloat16*>(k),                                    \
+        reinterpret_cast<__nv_bfloat16*>(v),                                    \
+        q_heads, v_heads, head_dim, conv_kernel, eps)
+    switch (rows) {
+        case 1: SI_DFLASH_ROWS_CONV(1); break;
+        case 2: SI_DFLASH_ROWS_CONV(2); break;
+        case 3: SI_DFLASH_ROWS_CONV(3); break;
+        case 4: SI_DFLASH_ROWS_CONV(4); break;
+        case 5: SI_DFLASH_ROWS_CONV(5); break;
+        case 6: SI_DFLASH_ROWS_CONV(6); break;
+        case 7: SI_DFLASH_ROWS_CONV(7); break;
+        case 8: SI_DFLASH_ROWS_CONV(8); break;
+        default: break;
+    }
+#undef SI_DFLASH_ROWS_CONV
+}
+
+void launch_dflash_rows_gated_norm_q8(const void* x, const void* z, const void* weight,
+                                      void* out_q8, int v_heads, int head_dim, float eps,
+                                      int rows, cudaStream_t stream) {
+    (void)head_dim;
+    if (rows < 1 || rows > kDFlashMaxRows) return;
+    dflash_rows_gated_norm_q8_kernel<128><<<dim3(v_heads, rows), 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(z),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<dfr_blk_q8_1*>(out_q8),
+        v_heads, eps);
+}
+
+// One 8-wide pack per thread and a Q8_1 block = 4 consecutive threads: requires
+// cols % 256 == 0 (every warp full, each 32-block within one warp) and cols/8 <= 1024
+// (max block dim). The decode residual width (hidden = 2048) satisfies both.
+void launch_dflash_rows_add_rmsnorm2_q8(const void* x, const void* residual, const void* weight,
+                                        void* out_sum, void* out_norm, void* out_q8,
+                                        int cols, float eps, int rows,
+                                        cudaStream_t stream) {
+    if (rows < 1 || rows > kDFlashMaxRows) return;
+    assert(cols % 256 == 0 && (cols >> 3) <= 1024);
+    dflash_rows_add_rmsnorm2_q8_kernel<<<rows, cols >> 3, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out_sum),
+        reinterpret_cast<__nv_bfloat16*>(out_norm),
+        reinterpret_cast<dfr_blk_q8_1*>(out_q8), cols, eps);
+}
+
+void launch_dflash_rows_add_rmsnorm3_q8(const void* x, const void* res1, const void* res2,
+                                        const void* weight, void* out_sum, void* out_norm,
+                                        void* out_q8, int cols, float eps, int rows,
+                                        cudaStream_t stream) {
+    if (rows < 1 || rows > kDFlashMaxRows) return;
+    assert(cols % 256 == 0 && (cols >> 3) <= 1024);
+    dflash_rows_add_rmsnorm3_q8_kernel<<<rows, cols >> 3, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(res1),
+        reinterpret_cast<const __nv_bfloat16*>(res2),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out_sum),
+        reinterpret_cast<__nv_bfloat16*>(out_norm),
+        reinterpret_cast<dfr_blk_q8_1*>(out_q8), cols, eps);
+}
+
+void launch_dflash_rows_rmsnorm(const void* x, const void* weight, void* out,
+                                int cols, float eps, int rows, cudaStream_t stream) {
+    if (rows < 1 || rows > kDFlashMaxRows) return;
+    dflash_rows_rmsnorm_kernel<<<rows, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x),
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out), rows, cols, eps);
+}
+#endif
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/kernels/csrc/cuda/gemm/dflash_rows_gemv.cu
+++ b/kernels/csrc/cuda/gemm/dflash_rows_gemv.cu
@@ -1,0 +1,446 @@
+// Row-batched Q4_K / Q8_0 MMVQ for the DFlash verify window.
+//
+// The single-row mmvq kernels in gemm/gemv.cu are pure weight bandwidth: one CTA per
+// output row, four warps striding the K super-blocks, ~2 dp4a per weight byte. Decode
+// therefore costs one full read of the projection weights per forward, and the verify
+// loop runs one forward per proposal token — a window of R proposals reads the entire
+// weight stream R times even though every row hits the SAME weights.
+//
+// These kernels keep the one-CTA-per-output-row structure and hold R accumulators
+// instead of one: the CTA loads each weight super-block once and dots it against all R
+// activation rows, so a window costs one weight stream regardless of R. Only the
+// activation side scales with R, and that is L2-resident (rows * K/32 * 36 B).
+//
+// EXACTNESS: the DFlash gate asserts token-for-token equality with the autoregressive
+// path, so nothing about the arithmetic may move. Row r accumulates over the same kbx
+// sequence in the same order, through the same vec_dot, and reduces through the same
+// shared-memory + shuffle tree as the single-row kernel would on row r alone. There is
+// no cross-row reduction anywhere and no reassociation: tmp[r] sees exactly the operands
+// tmp saw before. Batching only decides which rows share a CTA.
+//
+// Self-contained per house convention: the block structs and the vec_dot helpers are
+// copied from gemm/gemv.cu instead of shared through a header, so this TU compiles (and
+// NVRTC-compiles) alone. Those copies must stay byte-identical to the originals —
+// divergence is an accuracy-gate failure, not a style problem.
+//
+// Portable CUDA — sm_89 .. sm_120/sm_121.
+
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include <cuda_runtime.h>
+#include "sparkinfer/kernels/dflash_rows.h"   // at file scope so kDFlashMaxRows is visible
+#endif
+
+namespace sparkinfer {
+namespace kernels {
+
+__device__ __forceinline__ void dfr_write(float* p, float v) { *p = v; }
+__device__ __forceinline__ void dfr_write(__nv_bfloat16* p, float v) { *p = __float2bfloat16(v); }
+
+struct dfr_block_q8_1 { __half2 ds; signed char qs[32]; };               // 36 B / 32 values
+struct dfr_block_q4_K { __half2 dm; unsigned char scales[12]; unsigned char qs[128]; };  // 144 B / 256
+
+__device__ __forceinline__ float dfr_vec_dot_q4_K(const dfr_block_q4_K* bq4,
+                                                 const dfr_block_q8_1* bq8_1, int iqs) {
+    int v[2], u[4]; float d8[2];
+    const int bq8_offset = 2 * ((iqs / 2) / 4);
+    const int* q4 = (const int*)(bq4->qs + 16 * bq8_offset + 4 * ((iqs / 2) % 4));
+    v[0] = q4[0]; v[1] = q4[4];
+    const unsigned short* scales = (const unsigned short*)bq4->scales;
+    unsigned short aux[2]; const int j = bq8_offset / 2;
+    if (j < 2) { aux[0] = scales[j] & 0x3f3f; aux[1] = scales[j + 2] & 0x3f3f; }
+    else { aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+           aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+    const unsigned char* sc = (const unsigned char*)aux; const unsigned char* m = sc + 2;
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const dfr_block_q8_1* bq8i = bq8_1 + bq8_offset + i;
+        d8[i] = __low2float(bq8i->ds);
+        const int* q8 = (const int*)bq8i->qs + ((iqs / 2) % 4);
+        u[2 * i] = q8[0]; u[2 * i + 1] = q8[4];
+    }
+    float sumf_d = 0.0f, sumf_m = 0.0f;
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int v0i = (v[0] >> (4 * i)) & 0x0F0F0F0F, v1i = (v[1] >> (4 * i)) & 0x0F0F0F0F;
+        const int dot1 = __dp4a(v1i, u[2 * i + 1], __dp4a(v0i, u[2 * i], 0));
+        const int dot2 = __dp4a(0x01010101, u[2 * i + 1], __dp4a(0x01010101, u[2 * i], 0));
+        sumf_d += d8[i] * (dot1 * sc[i]);
+        sumf_m += d8[i] * (dot2 * m[i]);
+    }
+    float2 dm4f = __half22float2(bq4->dm);
+    return dm4f.x * sumf_d - dm4f.y * sumf_m;
+}
+
+// Same dot, evaluated for R activation rows against one weight super-block. The two int4
+// weight pulls, the 6-bit scale/min unpack and dm depend only on the weight, so they are
+// done once and reused by every row -- that reuse is the whole point of the window, and the
+// compiler does not find it on its own across R inlined calls (the reason gemv.cu's Q6_K
+// multi-row kernel hoists the unpack by hand too). Every float operation and its order is
+// unchanged from dfr_vec_dot_q4_K, so acc[r] lands bit-identical to calling that helper once
+// per row. bq8_1 points at row 0's block for this super-block; rows are q81_per_row apart.
+template <int R>
+__device__ __forceinline__ void dfr_vec_dot_q4_K_rows(const dfr_block_q4_K* bq4,
+                                                      const dfr_block_q8_1* bq8_1,
+                                                      int q81_per_row, int iqs, float* acc) {
+    const int bq8_offset = 2 * ((iqs / 2) / 4);
+    const int* q4 = (const int*)(bq4->qs + 16 * bq8_offset + 4 * ((iqs / 2) % 4));
+    const int v0 = q4[0], v1 = q4[4];
+    const unsigned short* scales = (const unsigned short*)bq4->scales;
+    unsigned short aux[2]; const int j = bq8_offset / 2;
+    if (j < 2) { aux[0] = scales[j] & 0x3f3f; aux[1] = scales[j + 2] & 0x3f3f; }
+    else { aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+           aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+    const unsigned char* sc = (const unsigned char*)aux; const unsigned char* m = sc + 2;
+    const float2 dm4f = __half22float2(bq4->dm);
+    #pragma unroll
+    for (int r = 0; r < R; r++) {
+        const dfr_block_q8_1* base = bq8_1 + (size_t)r * q81_per_row;
+        int u[4]; float d8[2];
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            const dfr_block_q8_1* bq8i = base + bq8_offset + i;
+            d8[i] = __low2float(bq8i->ds);
+            const int* q8 = (const int*)bq8i->qs + ((iqs / 2) % 4);
+            u[2 * i] = q8[0]; u[2 * i + 1] = q8[4];
+        }
+        float sumf_d = 0.0f, sumf_m = 0.0f;
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            const int v0i = (v0 >> (4 * i)) & 0x0F0F0F0F, v1i = (v1 >> (4 * i)) & 0x0F0F0F0F;
+            const int dot1 = __dp4a(v1i, u[2 * i + 1], __dp4a(v0i, u[2 * i], 0));
+            const int dot2 = __dp4a(0x01010101, u[2 * i + 1], __dp4a(0x01010101, u[2 * i], 0));
+            sumf_d += d8[i] * (dot1 * sc[i]);
+            sumf_m += d8[i] * (dot2 * m[i]);
+        }
+        acc[r] += dm4f.x * sumf_d - dm4f.y * sumf_m;
+    }
+}
+
+// Q8_0 blocks are 34 B (2-byte aligned only); read via explicit byte offsets like Q6_K.
+__device__ __forceinline__ float dfr_q80_h2f(const unsigned char* p) {
+    __half h; *reinterpret_cast<unsigned short*>(&h) = *reinterpret_cast<const unsigned short*>(p);
+    return __half2float(h);
+}
+__device__ __forceinline__ int dfr_q80_get_int_b2(const unsigned char* p, int i32) {
+    const unsigned short* u = reinterpret_cast<const unsigned short*>(p);
+    return (int)u[2 * i32] | ((int)u[2 * i32 + 1] << 16);
+}
+__device__ __forceinline__ float dfr_vec_dot_q8_0_mmvq(const unsigned char* bw, const dfr_block_q8_1* ba) {
+    const float dw = dfr_q80_h2f(bw);
+    const int* a = reinterpret_cast<const int*>(ba->qs);
+    int sumi = 0;
+    #pragma unroll
+    for (int i = 0; i < 8; i++) sumi = __dp4a(dfr_q80_get_int_b2(bw + 2, i), a[i], sumi);
+    return dw * __low2float(ba->ds) * (float)sumi;
+}
+
+// Activation-row stride, in dfr_block_q8_1 units. The caller lays the window out as `rows`
+// contiguous llama_q8_1_bytes(K) = (K >> 5) * sizeof(dfr_block_q8_1) byte rows, so row r
+// begins exactly (K >> 5) BLOCKS in — the stride is only ever expressed in blocks here,
+// never in bytes, because dfr_block_q8_1 is 36 B and a byte/element mix-up would leave row
+// 0 correct while silently corrupting every later row of the window.
+__device__ __forceinline__ int si_q81_blocks_per_row(int K) { return K >> 5; }
+
+// ---- Q4_K MMVQ, R activation rows against one weight matrix ----------------------
+// Mirrors si_mmvq_q4k_kernel: same kbx striding, same kqs, same 4-warp reduction, with the
+// R rows of the verify window sharing one pass over the weight. Each super-block is read and
+// unpacked once (dfr_vec_dot_q4_K_rows) and dotted against all R rows, so the window costs
+// one weight stream instead of R.
+template <typename OutT, int R>
+__global__ void si_dflash_rows_mmvq_q4k_kernel(const dfr_block_q8_1* __restrict__ vy,
+                                               const unsigned char* __restrict__ W,
+                                               OutT* __restrict__ y, int N, int K) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    const dfr_block_q4_K* x_row = (const dfr_block_q4_K*)(W + (size_t)row * (K >> 8) * 144);
+    const int blocks_per_row = K >> 8;                       // 256-weight superblocks
+    const int blocks_per_iter = vdr * NW * WS / qi;          // = 8
+    const int q81_per_row = si_q81_blocks_per_row(K);
+    float tmp[R];
+    #pragma unroll
+    for (int r = 0; r < R; r++) tmp[r] = 0.0f;
+    for (int kbx = tid / (qi / vdr); kbx < blocks_per_row; kbx += blocks_per_iter) {
+        const int kby = kbx * 8;                             // q8_1 blocks per superblock = 8
+        const int kqs = vdr * (tid % (qi / vdr));
+        dfr_vec_dot_q4_K_rows<R>(x_row + kbx, vy + kby, q81_per_row, kqs, tmp);
+    }
+    // Each row owns its own slice, so the R writes are independent and one barrier still
+    // separates every write from every read.
+    __shared__ float tmp_shared[R][NW - 1][WS];
+    if (warp > 0) {
+        #pragma unroll
+        for (int r = 0; r < R; r++) tmp_shared[r][warp - 1][lane] = tmp[r];
+    }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int r = 0; r < R; r++) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tmp[r] += tmp_shared[r][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tmp[r] += __shfl_xor_sync(0xffffffff, tmp[r], m);
+        if (lane == 0) dfr_write(y + (size_t)r * N + row, tmp[r]);
+    }
+}
+
+// The row count is the only template parameter: K stays runtime so one instantiation
+// serves every K % 256 == 0 shape (H=2048 -> 8 superblocks, the GDN 4096 -> 16), and the
+// loop bound is not what this kernel is bound by.
+#ifndef _MSC_VER
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 1>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 2>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 3>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 4>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 5>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 6>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 7>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<__nv_bfloat16, 8>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+#endif
+#ifndef _MSC_VER
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 1>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 2>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 3>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 4>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 5>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 6>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 7>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_dflash_rows_mmvq_q4k_kernel<float, 8>(const dfr_block_q8_1*, const unsigned char*, float*, int, int);
+#endif
+
+// ---- Q8_0 MMVQ, R activation rows against one weight matrix ----------------------
+// Mirrors si_mmvq_q80_kernel: the same flat `kb` stride over the K/32 blocks that the
+// kfixed form fixes at compile time, kept runtime here. Q8_0 blocks are 34 B and only
+// 2-byte aligned, so the weight side stays on the byte-offset helpers; those eight
+// dfr_q80_get_int_b2 loads and the fp16 scale are invariant across the row loop.
+template <typename OutT, int R>
+__global__ void si_dflash_rows_mmvq_q80_kernel(const dfr_block_q8_1* __restrict__ vy,
+                                               const unsigned char* __restrict__ W,
+                                               OutT* __restrict__ y, int N, int K) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int row = blockIdx.x;
+    const int nb = K >> 5;
+    const unsigned char* w_row = W + (size_t)row * nb * 34;
+    // Q8_0 and Q8_1 both hold 32 values per block, so the activation stride is the same
+    // block count the weight walks.
+    const int q81_per_row = si_q81_blocks_per_row(K);
+    float tmp[R];
+    #pragma unroll
+    for (int r = 0; r < R; r++) tmp[r] = 0.0f;
+    for (int kb = tid; kb < nb; kb += NW * WS) {
+        #pragma unroll
+        for (int r = 0; r < R; r++)
+            tmp[r] += dfr_vec_dot_q8_0_mmvq(w_row + (size_t)kb * 34,
+                                           vy + (size_t)r * q81_per_row + kb);
+    }
+    __shared__ float tmp_shared[R][NW - 1][WS];
+    if (warp > 0) {
+        #pragma unroll
+        for (int r = 0; r < R; r++) tmp_shared[r][warp - 1][lane] = tmp[r];
+    }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int r = 0; r < R; r++) {
+        #pragma unroll
+        for (int l = 0; l < NW - 1; l++) tmp[r] += tmp_shared[r][l][lane];
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) tmp[r] += __shfl_xor_sync(0xffffffff, tmp[r], m);
+        if (lane == 0) dfr_write(y + (size_t)r * N + row, tmp[r]);
+    }
+}
+
+#ifndef _MSC_VER
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 1>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 2>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 3>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 4>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 5>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 6>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 7>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_dflash_rows_mmvq_q80_kernel<__nv_bfloat16, 8>(const dfr_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+#endif
+// OutT stays generic to match the single-row pair, but only the bf16 half is instantiated:
+// the verify window has no fp32 Q8_0 consumer, and each row count is a separate kernel body.
+
+// ---- fused GDN qkv + z, R activation rows ---------------------------------------
+// One block per row index: warps 0-3 -> qkv[row], warps 4-7 -> z[row], grid =
+// max(n_qkv, n_z), keeping vy hot in L2 across both when row < min(n_qkv, n_z). The two
+// halves keep separate shared arrays and separate early-outs, exactly as the single-row
+// pack2 kernel: a half whose row index is past its own N leaves before its barrier and
+// the other half completes on its own.
+template <int R>
+__global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel(const dfr_block_q8_1* __restrict__ vy,
+                                                           const unsigned char* __restrict__ qkv_w,
+                                                           const unsigned char* __restrict__ z_w,
+                                                           __nv_bfloat16* __restrict__ qkv_out,
+                                                           __nv_bfloat16* __restrict__ z_out,
+                                                           int n_qkv, int n_z, int K) {
+    constexpr int NW = 4, WS = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int sub = warp & 3;
+    const int row = blockIdx.x;
+    const int tid4 = sub * WS + lane;
+    const int kbx0 = tid4 >> 4;
+    const int kqs = 2 * (tid4 & 15);
+    const int nsuper = K >> 8;
+    const int q81_per_row = si_q81_blocks_per_row(K);
+    float tmp[R];
+    #pragma unroll
+    for (int r = 0; r < R; r++) tmp[r] = 0.f;
+    if (warp < 4) {
+        if (row >= n_qkv) return;
+        const dfr_block_q4_K* x_row = (const dfr_block_q4_K*)(qkv_w + (size_t)row * nsuper * 144);
+        for (int kbx = kbx0; kbx < nsuper; kbx += 8) {
+            dfr_vec_dot_q4_K_rows<R>(x_row + kbx, vy + (size_t)kbx * 8, q81_per_row, kqs, tmp);
+        }
+        __shared__ float tq[R][NW - 1][WS];
+        if (sub > 0) {
+            #pragma unroll
+            for (int r = 0; r < R; r++) tq[r][sub - 1][lane] = tmp[r];
+        }
+        __syncthreads();
+        if (sub > 0) return;
+        #pragma unroll
+        for (int r = 0; r < R; r++) {
+            #pragma unroll
+            for (int l = 0; l < NW - 1; l++) tmp[r] += tq[r][l][lane];
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) tmp[r] += __shfl_xor_sync(0xffffffff, tmp[r], m);
+            if (lane == 0) dfr_write(qkv_out + (size_t)r * n_qkv + row, tmp[r]);
+        }
+    } else {
+        if (row >= n_z) return;
+        const dfr_block_q4_K* x_row = (const dfr_block_q4_K*)(z_w + (size_t)row * nsuper * 144);
+        for (int kbx = kbx0; kbx < nsuper; kbx += 8) {
+            dfr_vec_dot_q4_K_rows<R>(x_row + kbx, vy + (size_t)kbx * 8, q81_per_row, kqs, tmp);
+        }
+        __shared__ float tz[R][NW - 1][WS];
+        if (sub > 0) {
+            #pragma unroll
+            for (int r = 0; r < R; r++) tz[r][sub - 1][lane] = tmp[r];
+        }
+        __syncthreads();
+        if (sub > 0) return;
+        #pragma unroll
+        for (int r = 0; r < R; r++) {
+            #pragma unroll
+            for (int l = 0; l < NW - 1; l++) tmp[r] += tz[r][l][lane];
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) tmp[r] += __shfl_xor_sync(0xffffffff, tmp[r], m);
+            if (lane == 0) dfr_write(z_out + (size_t)r * n_z + row, tmp[r]);
+        }
+    }
+}
+
+#ifndef _MSC_VER
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<1>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<2>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<3>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<4>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<5>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<6>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<7>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+template __global__ void si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<8>(const dfr_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+#endif
+
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+
+namespace {
+
+// Every launcher below screens the window shape once, here. K must split into whole
+// 256-value super-blocks (the Q4_K weight block and the 8-q8_1-blocks-per-super-block
+// activation walk both assume it) and `rows` must be one of the instantiated row counts.
+// A rejected window is a silent no-op: the caller keeps its single-token verify path.
+inline bool dflash_rows_shape_ok(int K, int rows) {
+    return rows >= 1 && rows <= kDFlashMaxRows && K > 0 && (K & 255) == 0;
+}
+
+template <typename OutT>
+inline void dflash_rows_mmvq_q4k_dispatch(const dfr_block_q8_1* q, const unsigned char* w,
+                                          OutT* y, int N, int K, int rows, cudaStream_t stream) {
+    switch (rows) {
+        case 1: si_dflash_rows_mmvq_q4k_kernel<OutT, 1><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 2: si_dflash_rows_mmvq_q4k_kernel<OutT, 2><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 3: si_dflash_rows_mmvq_q4k_kernel<OutT, 3><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 4: si_dflash_rows_mmvq_q4k_kernel<OutT, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 5: si_dflash_rows_mmvq_q4k_kernel<OutT, 5><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 6: si_dflash_rows_mmvq_q4k_kernel<OutT, 6><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 7: si_dflash_rows_mmvq_q4k_kernel<OutT, 7><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 8: si_dflash_rows_mmvq_q4k_kernel<OutT, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        default: break;
+    }
+}
+
+template <typename OutT>
+inline void dflash_rows_mmvq_q80_dispatch(const dfr_block_q8_1* q, const unsigned char* w,
+                                          OutT* y, int N, int K, int rows, cudaStream_t stream) {
+    switch (rows) {
+        case 1: si_dflash_rows_mmvq_q80_kernel<OutT, 1><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 2: si_dflash_rows_mmvq_q80_kernel<OutT, 2><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 3: si_dflash_rows_mmvq_q80_kernel<OutT, 3><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 4: si_dflash_rows_mmvq_q80_kernel<OutT, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 5: si_dflash_rows_mmvq_q80_kernel<OutT, 5><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 6: si_dflash_rows_mmvq_q80_kernel<OutT, 6><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 7: si_dflash_rows_mmvq_q80_kernel<OutT, 7><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        case 8: si_dflash_rows_mmvq_q80_kernel<OutT, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K); break;
+        default: break;
+    }
+}
+
+} // namespace
+
+void launch_dflash_rows_mmvq_q4k(const void* q81, const void* W, void* y,
+                                 int N, int K, int rows, cudaStream_t stream) {
+    if (N <= 0 || !dflash_rows_shape_ok(K, rows)) return;
+    dflash_rows_mmvq_q4k_dispatch(reinterpret_cast<const dfr_block_q8_1*>(q81),
+                                  reinterpret_cast<const unsigned char*>(W),
+                                  reinterpret_cast<__nv_bfloat16*>(y), N, K, rows, stream);
+}
+
+void launch_dflash_rows_mmvq_q4k_f32(const void* q81, const void* W, float* y,
+                                     int N, int K, int rows, cudaStream_t stream) {
+    if (N <= 0 || !dflash_rows_shape_ok(K, rows)) return;
+    dflash_rows_mmvq_q4k_dispatch(reinterpret_cast<const dfr_block_q8_1*>(q81),
+                                  reinterpret_cast<const unsigned char*>(W),
+                                  y, N, K, rows, stream);
+}
+
+void launch_dflash_rows_mmvq_q80(const void* q81, const void* W, void* y,
+                                 int N, int K, int rows, cudaStream_t stream) {
+    if (N <= 0 || !dflash_rows_shape_ok(K, rows)) return;
+    dflash_rows_mmvq_q80_dispatch(reinterpret_cast<const dfr_block_q8_1*>(q81),
+                                  reinterpret_cast<const unsigned char*>(W),
+                                  reinterpret_cast<__nv_bfloat16*>(y), N, K, rows, stream);
+}
+
+void launch_dflash_rows_mmvq_gdn_qkv_z(const void* q81, const void* qkv_w, const void* z_w,
+                                       void* qkv_out, void* z_out,
+                                       int n_qkv, int n_z, int K, int rows,
+                                       cudaStream_t stream) {
+    const int grid = n_qkv > n_z ? n_qkv : n_z;
+    if (grid <= 0 || !dflash_rows_shape_ok(K, rows)) return;
+    const dfr_block_q8_1* q = reinterpret_cast<const dfr_block_q8_1*>(q81);
+    const unsigned char* qw = reinterpret_cast<const unsigned char*>(qkv_w);
+    const unsigned char* zw = reinterpret_cast<const unsigned char*>(z_w);
+    __nv_bfloat16* qo = reinterpret_cast<__nv_bfloat16*>(qkv_out);
+    __nv_bfloat16* zo = reinterpret_cast<__nv_bfloat16*>(z_out);
+    switch (rows) {
+        case 1: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<1><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        case 2: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<2><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        case 3: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<3><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        case 4: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<4><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        case 5: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<5><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        case 6: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<6><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        case 7: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<7><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        case 8: si_dflash_rows_mmvq_gdn_qkv_z_pack2_kernel<8><<<grid, 8 * 32, 0, stream>>>(q, qw, zw, qo, zo, n_qkv, n_z, K); break;
+        default: break;
+    }
+}
+#endif
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/kernels/csrc/cuda/moe/dflash_rows_router.cu
+++ b/kernels/csrc/cuda/moe/dflash_rows_router.cu
@@ -1,0 +1,216 @@
+// Row-batched MoE router for the DFlash verify window.
+//
+// One launch routes all `rows` proposal tokens of a verify window: the split-K GEMV of
+// moe_router_fused_kernel gains a grid dimension over tokens, so the [num_experts, K]
+// router weight is streamed for the whole window instead of once per single-token launch,
+// and the top-8 selection still happens in-kernel (no separate top-k launch, no dependent
+// -load gap) for every token.
+//
+// The arithmetic is the single-token kernel's, unchanged: each token owns its own blocks,
+// its own accumulators and its own shared split-K partials, and each output logit is
+// summed over the same K-stride in the same order and reduced by the same shfl_xor tree.
+// Selection runs the same bitonic top-8 over the same 256 staged logits. A call with
+// rows=R is therefore bit-identical to R calls of launch_router_fused, which is what the
+// DFlash accuracy gate (DFlash output == autoregressive output, token for token) needs:
+// the routed expert set and its softmax weights feed the MoE FFN, so any drift here moves
+// the logits and eventually flips an argmax.
+//
+// Bit-exactness binds the build as well as the source: this TU must carry the same flags as
+// router.cu (-O3 --use_fast_math, as every si_* kernel target does). --use_fast_math makes the
+// `/ denom` of the softmax an approximate divide and flushes denormals, so a target that omits
+// it yields different expert weights from the single-token path even with identical source.
+//
+// Portable CUDA — runs on sm_89 .. sm_120 (RTX 5090).
+
+#include <cuda_fp16.h>
+#include <cuda_bf16.h>
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include <cuda_runtime.h>
+#endif
+
+namespace sparkinfer {
+namespace kernels {
+
+// Per-TU copies of the router.cu selection helpers (house style: small __device__ helpers
+// are duplicated rather than shared through a header). They are reproduced verbatim —
+// the compare-exchange predicate below fixes both the ordering (descending logit) and the
+// tie-break (lower expert index wins), and the softmax op sequence at the end fixes the
+// weights, so neither may be rewritten.
+#define DFR_CEXG(av, ai, bv, bi) do {                                     \
+    bool _ge = ((av) > (bv)) || ((av) == (bv) && (ai) < (bi));          \
+    if (!_ge) { float _t = (av); (av) = (bv); (bv) = _t;                \
+                int _u = (ai); (ai) = (bi); (bi) = _u; }               \
+  } while (0)
+
+// Warp-0 bitonic top-8 over 256 logits staged in shared memory. Lane owns experts {lane,lane+32,...
+// lane+224}; per-lane sort to descending, then a 5-step reduction tree bitonic-merging sorted-8 lists.
+// Writes out_ids[0..top_k) / out_w[0..top_k) (softmax when normalize). Must be entered by all of warp 0.
+__device__ __forceinline__ void dfr_warp_bitonic_top8(
+    const float* __restrict__ s_lg, int lane, int top_k, int normalize,
+    int* __restrict__ out_ids, float* __restrict__ out_w, int* __restrict__ counts)
+{
+    float r[8]; int ri[8];
+    #pragma unroll
+    for (int i = 0; i < 8; i++) { r[i] = s_lg[lane + 32 * i]; ri[i] = lane + 32 * i; }
+    #pragma unroll
+    for (int k = 2; k <= 8; k <<= 1)
+        #pragma unroll
+        for (int j = k >> 1; j > 0; j >>= 1)
+            #pragma unroll
+            for (int i = 0; i < 8; i++) {
+                int l = i ^ j;
+                if (l > i) {
+                    if ((i & k) == 0) DFR_CEXG(r[i], ri[i], r[l], ri[l]);
+                    else              DFR_CEXG(r[l], ri[l], r[i], ri[i]);
+                }
+            }
+    #pragma unroll
+    for (int off = 16; off > 0; off >>= 1) {
+        float pr[8]; int pri[8];
+        #pragma unroll
+        for (int m = 0; m < 8; m++) {
+            pr[m]  = __shfl_down_sync(0xffffffffu, r[m],  off);
+            pri[m] = __shfl_down_sync(0xffffffffu, ri[m], off);
+        }
+        float cv[16]; int cci[16];
+        #pragma unroll
+        for (int m = 0; m < 8; m++) {
+            cv[m] = r[m];          cci[m] = ri[m];
+            cv[8 + m] = pr[7 - m]; cci[8 + m] = pri[7 - m];
+        }
+        #pragma unroll
+        for (int i = 0; i < 8; i++) DFR_CEXG(cv[i], cci[i], cv[i + 8], cci[i + 8]);
+        #pragma unroll
+        for (int stride = 4; stride > 0; stride >>= 1)
+            #pragma unroll
+            for (int i = 0; i < 8; i++) {
+                int l = i ^ stride;
+                if (l > i && l < 8) DFR_CEXG(cv[i], cci[i], cv[l], cci[l]);
+            }
+        #pragma unroll
+        for (int m = 0; m < 8; m++) { r[m] = cv[m]; ri[m] = cci[m]; }
+    }
+    if (lane == 0) {
+        float denom = 1.f, mx = r[0];                   // r sorted descending -> r[0] is the max
+        if (normalize) { denom = 0.f; for (int j = 0; j < top_k; j++) denom += __expf(r[j] - mx); }
+        for (int j = 0; j < top_k; j++) {
+            out_ids[j] = ri[j];
+            out_w[j]   = normalize ? __expf(r[j] - mx) / denom : r[j];
+            if (counts) atomicAdd(&counts[ri[j]], 1);
+        }
+    }
+}
+
+// Row-batched fused router GEMV + top-8. blockIdx.x walks the expert rows exactly as in the
+// single-token kernel (RPB logits per block, SPL warps cooperating per logit); blockIdx.y
+// selects the proposal token, which offsets x / logits / expert_ids / expert_weights but NOT
+// W — the weight is what the window shares.
+//
+// The row count is not a template parameter here: a token's work lives entirely in its own
+// blocks, so there is nothing per-row to keep in registers and no gain from specializing.
+//
+// Grid completion is per token. Each token's gridDim.x blocks increment gridctr[blockIdx.y];
+// a single shared counter would let blocks of different tokens elect each other and the
+// elected block would read logits whose GEMV has not landed. atomicInc(., gridDim.x - 1)
+// wraps to 0 after gridDim.x increments, so every counter is self-clearing for the next
+// CUDA-graph replay. The __threadfence() must precede the atomicInc so this block's logits
+// are visible to whichever block is elected; the __syncthreads() after it holds thread 0
+// back until every thread here has fenced.
+//
+// Requires N == 256 (the s_lg staging array and the lane-owns-8-experts bitonic layout) and
+// K % 8 == 0 (uint4 loads), both of which hold for the Qwen3.6 router.
+template <int SPL>
+__global__ void dflash_rows_router_fused_kernel(
+    const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ W,
+    float* __restrict__ logits, unsigned int* __restrict__ gridctr,
+    int* __restrict__ expert_ids, float* __restrict__ expert_weights,
+    int N, int K, int top_k, int normalize)
+{
+    constexpr int RPB = 8 / SPL;
+    __shared__ float s_part[8 / SPL][SPL];
+    const int tok = blockIdx.y;
+    const __nv_bfloat16* __restrict__ x_t = x + (size_t)tok * K;
+    float* __restrict__ logits_t = logits + (size_t)tok * N;
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / SPL, split = warp % SPL;
+    const int n = blockIdx.x * RPB + row_local;
+    float acc = 0.f;
+    if (n < N) {
+        const uint4* row4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+        const uint4* x4   = reinterpret_cast<const uint4*>(x_t);
+        const int n4 = K / 8;
+        for (int i = split * 32 + lane; i < n4; i += SPL * 32) {
+            uint4 wv = row4[i], xv = x4[i];
+            const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+            const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+            #pragma unroll
+            for (int j = 0; j < 4; j++) {
+                float2 wf = __bfloat1622float2(wh[j]), xf = __bfloat1622float2(xh[j]);
+                acc += wf.x * xf.x + wf.y * xf.y;
+            }
+        }
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+        if (lane == 0) s_part[row_local][split] = acc;
+    }
+    __syncthreads();
+    if (n < N && split == 0 && lane == 0) {
+        float o = 0.f;
+        #pragma unroll
+        for (int s = 0; s < SPL; s++) o += s_part[row_local][s];
+        logits_t[n] = o;
+    }
+    __threadfence();
+    __syncthreads();
+    __shared__ unsigned int s_last;
+    if (threadIdx.x == 0) s_last = atomicInc(&gridctr[tok], gridDim.x - 1);
+    __syncthreads();
+    if (s_last != gridDim.x - 1) return;
+    __shared__ float s_lg[256];
+    for (int e = threadIdx.x; e < N; e += blockDim.x) s_lg[e] = logits_t[e];
+    __syncthreads();
+    if (threadIdx.x < 32)
+        dfr_warp_bitonic_top8(s_lg, threadIdx.x & 31, top_k, normalize,
+                             expert_ids + (size_t)tok * top_k,
+                             expert_weights + (size_t)tok * top_k, nullptr);
+}
+#ifndef _MSC_VER
+template __global__ void dflash_rows_router_fused_kernel<4>(
+    const __nv_bfloat16*, const __nv_bfloat16*, float*, unsigned int*, int*, float*, int, int, int, int);
+#endif
+#undef DFR_CEXG
+
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+// `gridctr` is a persistent unsigned counter array of `rows` entries, zero-initialized once by
+// the caller; atomicInc self-resets each entry every call, so the launch is CUDA-graph-replay
+// safe and needs no memset node.
+//
+// Bails (does nothing, leaving the outputs untouched) on every configuration this kernel does
+// not compute exactly; the caller must then fall back to `rows` single-token launch_router_fused
+// calls. num_experts must be exactly 256, not merely at most 256: the bitonic top-8 reads
+// s_lg[lane + 32*i] for all i < 8 unconditionally, so a shorter row leaves the tail of the
+// staging array uninitialized and lets garbage take a top-k slot. top_k must be <= 8 because the
+// selection carries eight registers per lane and indexes them by j < top_k. K % 8 == 0 is what
+// makes the uint4 loads legal, and here it is harder than in the single-token kernel: x + tok*K
+// is 16B-aligned only when K % 8 == 0, so row 1 of the window would fault outright rather than
+// silently drop a K tail. These are the same conditions the single-token call site already gates
+// launch_router_fused on (n_experts == 256 && hidden % 8 == 0).
+void launch_dflash_rows_router_fused(const void* x, const void* W, float* logits,
+                                     unsigned int* gridctr, int* expert_ids,
+                                     float* expert_weights, int num_experts, int K,
+                                     int top_k, int normalize, int rows,
+                                     cudaStream_t stream) {
+    if (rows < 1 || rows > 8) return;
+    if (num_experts != 256) return;
+    if (top_k < 1 || top_k > 8) return;
+    if (K < 8 || (K % 8) != 0) return;
+    constexpr int SPL = 4, RPB = 8 / SPL;              // GEMV_WPB = 8, matches gemv_f32_sk<float,4>
+    dim3 grid((num_experts + RPB - 1) / RPB, rows);
+    dflash_rows_router_fused_kernel<SPL><<<grid, 8 * 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W),
+        logits, gridctr, expert_ids, expert_weights, num_experts, K, top_k, normalize);
+}
+#endif
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/dflash_rows.h
+++ b/kernels/include/sparkinfer/kernels/dflash_rows.h
@@ -1,0 +1,88 @@
+#pragma once
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Row-batched decode kernels for the DFlash verify window.
+//
+// The DFlash verify loop forwards one target token per emitted token, so the whole
+// weight stream of the model is re-read once per proposal. These kernels take `rows`
+// activation rows at once: the weight superblock is loaded into registers once and
+// dotted against every row, so a window of R proposals reads the weights once instead
+// of R times. Only the routed-expert weights still scale with R (each token routes to
+// its own experts) -- everything else is amortized.
+//
+// EXACTNESS CONTRACT: every launcher below computes each row with the same operand
+// order, the same partial-sum order and the same reduction tree as its single-row
+// counterpart in gemv.cu / qwen36.cu / rmsnorm.cu / router.cu. Batching only changes
+// which rows share a CTA, never the arithmetic, so the output of a call with rows=R is
+// bit-identical to R calls of the single-row kernel. Greedy speculative decoding stays
+// exact and DFlash output stays bit-equal to autoregressive output.
+//
+// rows must be in [1, kDFlashMaxRows].
+constexpr int kDFlashMaxRows = 8;
+
+// ---- Q4_K / Q8_0 MMVQ over `rows` activation rows sharing one weight matrix ----
+// q81 : [rows, llama_q8_1_bytes(K)] (rows contiguous, stride llama_q8_1_bytes(K))
+// W   : GGUF-native quantized [N, K]
+// y   : [rows, N], row stride N
+void launch_dflash_rows_mmvq_q4k(const void* q81, const void* W, void* y,
+                                 int N, int K, int rows, cudaStream_t stream = nullptr);
+void launch_dflash_rows_mmvq_q4k_f32(const void* q81, const void* W, float* y,
+                                     int N, int K, int rows, cudaStream_t stream = nullptr);
+void launch_dflash_rows_mmvq_q80(const void* q81, const void* W, void* y,
+                                 int N, int K, int rows, cudaStream_t stream = nullptr);
+
+// Fused GDN qkv + z projection (mirrors launch_mmvq_gdn_qkv_z_pack2): warps 0-3 produce
+// qkv[row], warps 4-7 produce z[row], for every one of `rows` activation rows.
+// qkv_out : [rows, n_qkv], z_out : [rows, n_z]
+void launch_dflash_rows_mmvq_gdn_qkv_z(const void* q81, const void* qkv_w, const void* z_w,
+                                       void* qkv_out, void* z_out,
+                                       int n_qkv, int n_z, int K, int rows,
+                                       cudaStream_t stream = nullptr);
+
+// ---- fused norms / GDN front-end, row-batched ----
+// Mirrors launch_qwen36_conv_split_l2norm_fused. The depthwise conv is causal over the
+// window, so the `rows` tokens are consumed in order inside the kernel and conv_state is
+// left exactly where `rows` successive single-token calls would leave it.
+// qkv : [rows, qkv_dim]; q/k/v : [rows, *]
+void launch_dflash_rows_conv_split_l2norm(const void* qkv, const void* conv_w, void* conv_state,
+                                          void* q, void* k, void* v,
+                                          int q_heads, int v_heads, int head_dim,
+                                          int conv_kernel, float eps, int rows,
+                                          cudaStream_t stream = nullptr);
+
+// Mirrors launch_qwen36_gated_norm_q8. x/z : [rows, v_heads*head_dim];
+// out_q8 : [rows, v_heads*head_dim/32] blocks.
+void launch_dflash_rows_gated_norm_q8(const void* x, const void* z, const void* weight,
+                                      void* out_q8, int v_heads, int head_dim, float eps,
+                                      int rows, cudaStream_t stream = nullptr);
+
+// Mirror launch_add_rmsnorm2_q8 / launch_add_rmsnorm3_q8 over `rows` rows of `cols`.
+// out_q8 : [rows, cols/32] blocks.
+void launch_dflash_rows_add_rmsnorm2_q8(const void* x, const void* residual, const void* weight,
+                                        void* out_sum, void* out_norm, void* out_q8,
+                                        int cols, float eps, int rows,
+                                        cudaStream_t stream = nullptr);
+void launch_dflash_rows_add_rmsnorm3_q8(const void* x, const void* res1, const void* res2,
+                                        const void* weight, void* out_sum, void* out_norm,
+                                        void* out_q8, int cols, float eps, int rows,
+                                        cudaStream_t stream = nullptr);
+
+// Mirrors launch_rmsnorm for `rows` rows (prime norm at layer 0).
+void launch_dflash_rows_rmsnorm(const void* x, const void* weight, void* out,
+                                int cols, float eps, int rows, cudaStream_t stream = nullptr);
+
+// Mirrors launch_router_fused for `rows` tokens: split-K GEMV then the same in-kernel
+// bitonic top-k, one independent grid-completion counter per token.
+// gridctr : [rows] unsigned, zero-initialized once (atomicInc self-clears per replay).
+// logits  : [rows, num_experts]; expert_ids / expert_weights : [rows, top_k]
+void launch_dflash_rows_router_fused(const void* x, const void* W, float* logits,
+                                     unsigned int* gridctr, int* expert_ids,
+                                     float* expert_weights, int num_experts, int K,
+                                     int top_k, int normalize, int rows,
+                                     cudaStream_t stream = nullptr);
+
+} // namespace kernels
+} // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -193,12 +193,23 @@ public:
     bool batched_forward(const int* token_ids, int n, int start_pos, bool resume_gdn,
                          int* out_argmax, const void* dflash_capture_dst = nullptr);
 
+    // Row-batched teacher-forced verify: forwards `rows` consecutive tokens (positions
+    // start_pos..start_pos+rows-1) through the layer stack in ONE pass, so every weight
+    // matrix streams from HBM once per window instead of once per token. Produces exactly
+    // the argmaxes, KV cache, GDN recurrent/conv state and hidden captures of `rows`
+    // successive forward_token(ids[i], start_pos+i, true) calls; rejected-token rollback
+    // stays the caller's job. Returns false — before touching any device state — when the
+    // pinned fast-path preconditions do not hold or rows is out of [1, kDFlashMaxRows];
+    // callers then fall back to the verify_block token loop.
+    bool dflash_verify_rows(const int* token_ids, int rows, int start_pos, int* out_argmax);
+
 private:
     void invalidate_decode_graph();
     // Prefill prompt tokens [start, end) with batched path when start==0, else token loop.
     // Returns argmax seed at end-1 for decode, or -1 on failure.
     int ingest_prompt_range(const int* ids, int start, int end);
     void dflash_maybe_capture_layer(int layer);
+    void dflash_rows_capture_layer(int layer, int rows, int row_base);
 
     struct Impl;
     Impl* p_;

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -500,10 +500,12 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     const int qdim = c.n_q_heads * c.head_dim;
     const int kvdim = c.n_kv_heads * c.head_dim;
     const int d = c.head_dim;
-    // Proposal depth (also sets the draft's active diffusion width, depth+1).
+    // Proposal depth (also sets the draft's active diffusion width, depth+1). Must match the
+    // verifier's default in qwen35.cpp: the verifier sizes its window from its own copy, so a
+    // disagreement makes it verify rows the draft never proposed.
     static const int kProposalDepth = []{
         const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
-        int v = e ? atoi(e) : 3;
+        int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
     // Active diffusion width. Only rows 0..kProposalDepth are ever consumed (row 0 is the seed,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -22,6 +22,7 @@
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/proj_requant.h"
+#include "sparkinfer/kernels/dflash_rows.h"
 
 #include <cuda_runtime.h>
 #include <cstdio>
@@ -241,6 +242,40 @@ struct Qwen35Model::Impl {
     float* spec_lin_snap = nullptr;
     bf16* spec_conv_snap = nullptr;
 
+    // DFlash row-batched verify scratch (dflash_verify_rows): kDFlashMaxRows-row twins of the
+    // single-row decode buffers above, allocated lazily on the first supported verify window
+    // (rb_cap guards it) and freed in the destructor. The single-row buffers are never resized
+    // or aliased by the rows path -- the autoregressive decode path and its captured CUDA
+    // graphs depend on them staying byte-identical.
+    int rb_cap = 0;                   // allocated row capacity (0 = not yet allocated)
+    bf16 *rb_x = nullptr, *rb_xn = nullptr, *rb_h = nullptr, *rb_hn = nullptr;
+    bf16 *rb_routed = nullptr, *rb_shared = nullptr, *rb_ao = nullptr;
+    bf16 *rb_q = nullptr, *rb_k = nullptr, *rb_v = nullptr, *rb_attn = nullptr;
+    bf16 *rb_qraw = nullptr, *rb_qgate = nullptr;
+    bf16 *rb_lin_qkv = nullptr, *rb_lin_q = nullptr, *rb_lin_k = nullptr, *rb_lin_v = nullptr;
+    bf16 *rb_lin_z = nullptr, *rb_lin_alpha = nullptr, *rb_lin_beta = nullptr, *rb_lin_gdn = nullptr;
+    bf16 *rb_shared_gate_tmp = nullptr;   // [rows] shared-expert gate dot (pre-sigmoid)
+    // Q8_1 activation rows. Sized for the LARGEST K quantized on this path (qdim /
+    // linear_vdim = 4096 > hidden = 2048); each op packs its rows contiguously at
+    // llama_q8_1_bytes(K) for ITS K, which is the layout the rows-MMVQ kernels expect.
+    void *rb_aq81 = nullptr;
+    float *rb_logits = nullptr;           // [rows, vocab]
+    float *rb_mf_logits = nullptr, *rb_mf_weights = nullptr, *rb_mf_h = nullptr, *rb_mf_out = nullptr;
+    int   *rb_mf_ids = nullptr;
+    unsigned int *rb_rc = nullptr;        // per-row fused-router grid-completion counters (zeroed once;
+                                          // atomicInc self-clears them across calls)
+    float *rb_sx_h = nullptr;             // [rows, moe_ffn] shared-expert h scratch
+    void  *rb_sx_q8 = nullptr;            // [rows, llama_q8_1_bytes(moe_ffn)] shared-expert Q8_1(h)
+    float *rb_shared_w = nullptr;         // [rows] shared-expert sigmoid(gate) scalars
+    float *rb_fa_m = nullptr, *rb_fa_l = nullptr, *rb_fa_acc = nullptr;   // per-row flash-decode partials
+    int *rb_scalars = nullptr;            // [rows][5] {token,pos,writepos,seqlen,cap_row} + [rows] token ids
+    int *rb_out_id = nullptr;             // [rows] greedy argmax per row
+    int *rb_h_scalars = nullptr;          // pinned staging for rb_scalars (+ token ids)
+    int *rb_h_out_id = nullptr;           // pinned rows argmax readback
+    bool rb_alloc();
+    void rb_release();
+    bool dflash_rows_supported() const;
+
     template <class T> T* alloc(size_t n) { void* p=nullptr; cu(cudaMalloc(&p, n*sizeof(T)), "malloc"); return (T*)p; }
 };
 
@@ -423,6 +458,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->sparse_vtbl); cudaFree(p_->sparse_vlen);
     cudaFree(p_->aq8); cudaFree(p_->aq8_d); cudaFree(p_->aq8_s); cudaFree(p_->aq81);
     cudaFree(p_->dflash_hidden); cudaFree(p_->dflash_context);
+    p_->rb_release();   // DFlash row-batched verify scratch (rb_*)
     // spec_lin_snap / spec_conv_snap are in owned[] (allocated via Impl::alloc)
     for (auto& kv : p_->sessions) {
         if (kv.first == 0) continue;
@@ -1770,6 +1806,419 @@ void Qwen35Model::restore_spec_snapshot() {
     invalidate_decode_graph();
 }
 
+// ---- DFlash row-batched verify ----------------------------------------------------------
+// The verify window's `rows` proposals share ONE pass through the 40 layers: every weight
+// matrix streams from HBM once per window instead of once per proposal (only the routed
+// experts still scale with rows). Bit-exactness with `rows` successive forward_token()
+// calls rests on two invariants: (a) every rows kernel computes each row with the same
+// operand order and reduction tree as its single-row counterpart (the dflash_rows.h
+// contract), and (b) every op with sequential state -- the depthwise conv, the GDN delta
+// rule, the KV append and the attention read -- consumes the rows strictly in position
+// order, so row r sees rows 0..r-1 of the window and nothing later.
+
+// Pins the exact configuration the scored Qwen3.6-35B-A3B Q4_K_M decode runs, kernel for
+// kernel. Every check corresponds to a branch forward_token() takes on that model; if ANY
+// fails, dflash_verify_rows() bails before touching device state and the caller falls back
+// to the token-loop verify. Strictness is the safety net: an unfamiliar model, quant mix or
+// flag override must never reach the rows path.
+bool Qwen35Model::Impl::dflash_rows_supported() const {
+    const Qwen35Config& c = cfg;
+    if (!gguf || !c.hybrid || c.dense_ffn) return false;
+    // Flag defaults the live path relies on (each one selects a kernel the rows path mirrors).
+    if (!(use_pq && use_llama && use_q6mmvq && use_fnq)) return false;         // fnq Q8_1 chain
+    if (!(use_addnorm3 && use_router_fused && use_gdn_pipe && !use_gdn_quad &&
+          use_attn_qkv && use_qkfuse && use_shexp_pipe)) return false;
+    // Env-gated statics inside forward_token / the launchers that pick the live kernels:
+    // fused GDN qkv+z, fused conv+l2norm, gated-norm Q8 emit, gated Q8 attention combine,
+    // dual-row Q4_K MMVQ dispatch, no router counts, split gemv+sigmoid gate scalar.
+    static const bool env_defaults = [] {
+        auto on  = [](const char* n) { const char* e = getenv(n); return !(e && e[0] == '0'); };
+        auto off = [](const char* n) { const char* e = getenv(n); return !(e && e[0] == '1'); };
+        return on("SPARKINFER_GDN_QKVZ_FUSE") && on("SPARKINFER_GDN_FUSE") &&
+               on("SPARKINFER_GDN_GNORM_Q8") && on("SPARKINFER_ATTN_GQ8") &&
+               on("SPARKINFER_MMVQ2") &&
+               off("SPARKINFER_MOE_COUNTS") && off("SPARKINFER_GEMV_SIGMOID");
+    }();
+    if (!env_defaults) return false;
+    // bf16 KV: the rows path mirrors qknorm_rope_kv_partial + the bf16 fa_split_gqa tile,
+    // and with int8 KV off the sink+window sparse view can never engage either.
+    if (kv->int8_kv()) return false;
+    // Model shape (Qwen3.6-35B-A3B).
+    if (c.n_layers != 40 || c.full_attn_interval != 4) return false;
+    if (c.hidden != 2048 || c.moe_ffn != 512 || c.n_experts != 256 || c.top_k != 8) return false;
+    if (c.n_shared <= 0 || c.vocab != 248320) return false;
+    if (c.head_dim != 256 || c.n_q_heads != 16 || c.n_kv_heads != 2 || c.rope_dim != 64) return false;
+    if (c.linear_q_heads != 16 || c.linear_v_heads != 32 || c.linear_head_dim != 128 ||
+        c.linear_conv_kernel != 4) return false;
+    if (linear_qkvdim != 8192 || linear_vdim != 4096 || qdim != 4096 || kvdim != 512) return false;
+    if (!w.embed_tokens || !w.final_norm || !w.lm_head || w.lm_head_type != 12) return false;
+    if ((int)w.layers.size() != c.n_layers) return false;
+    for (int L = 0; L < c.n_layers; L++) {
+        const Qwen35LayerWeights& lw = w.layers[L];
+        if (lw.linear_attn != is_linear_layer(c, L)) return false;
+        if (!lw.input_norm || !lw.post_attn_norm) return false;
+        if (lw.linear_attn) {
+            if (!(lw.wqkv && lw.wqkv_gate && lw.ssm_conv && lw.ssm_dt && lw.ssm_a &&
+                  lw.ssm_alpha && lw.ssm_beta && lw.ssm_norm && lw.ssm_out)) return false;
+            // Q4_K everywhere: si_mmvq_gdn_qkv_z_pack2 + si_mmvq_q4k (alpha/beta/ssm_out).
+            if (lw.wqkv_type != 12 || lw.wqkv_gate_type != 12 || lw.ssm_out_type != 12)
+                return false;
+            // alpha/beta dense bf16 -> plain GEMV per row (see the projection above).
+            if (lw.ssm_alpha_type != 0 || lw.ssm_beta_type != 0) return false;
+        } else {
+            if (!lw.q_has_gate) return false;   // split_q_gate + gated attention combine
+            if (!(lw.wq && lw.wk && lw.wv && lw.wo && lw.q_norm && lw.k_norm)) return false;
+            // Q4_K query, Q8_0 key/value, Q4_K output -- the shapes the rows MMVQs cover.
+            if (lw.wq_type != 12 || lw.wk_type != 8 || lw.wv_type != 8 || lw.wo_type != 12)
+                return false;
+        }
+        // moe_router_fused reads the router as dense bf16; experts stay GGUF-quantized.
+        if (!lw.router_w || lw.router_w_type != 0) return false;
+        if (!(lw.gate_q && lw.up_q && lw.down_q)) return false;
+        // Q8_0 shared expert + dense gate-scalar projection (gemv + sigmoid_scalar).
+        if (!(lw.shared_gate_q && lw.shared_up_q && lw.shared_down_q &&
+              lw.shared_gate_qtype == 8)) return false;
+        if (!lw.shared_gate_inp || lw.shared_gate_inp_type != 0) return false;
+    }
+    return true;
+}
+
+bool Qwen35Model::Impl::rb_alloc() {
+    if (rb_cap > 0) return true;
+    const int R = kernels::kDFlashMaxRows;
+    const Qwen35Config& c = cfg;
+    const int H = c.hidden;
+    const int kmax = std::max(H, std::max(qdim, linear_vdim));
+    const size_t fa_n = (size_t)c.n_q_heads * MAX_NSPLITS;
+    rb_x = alloc<bf16>((size_t)R * H); rb_xn = alloc<bf16>((size_t)R * H);
+    rb_h = alloc<bf16>((size_t)R * H); rb_hn = alloc<bf16>((size_t)R * H);
+    rb_routed = alloc<bf16>((size_t)R * H); rb_shared = alloc<bf16>((size_t)R * H);
+    rb_ao = alloc<bf16>((size_t)R * H);
+    rb_q = alloc<bf16>((size_t)R * qdim); rb_k = alloc<bf16>((size_t)R * kvdim);
+    rb_v = alloc<bf16>((size_t)R * kvdim); rb_attn = alloc<bf16>((size_t)R * qdim);
+    rb_qraw = alloc<bf16>((size_t)R * qdim * 2); rb_qgate = alloc<bf16>((size_t)R * qdim);
+    rb_lin_qkv = alloc<bf16>((size_t)R * linear_qkvdim);
+    rb_lin_q = alloc<bf16>((size_t)R * linear_qdim);
+    rb_lin_k = alloc<bf16>((size_t)R * linear_qdim);
+    rb_lin_v = alloc<bf16>((size_t)R * linear_vdim);
+    rb_lin_z = alloc<bf16>((size_t)R * linear_vdim);
+    rb_lin_alpha = alloc<bf16>((size_t)R * c.linear_v_heads);
+    rb_lin_beta = alloc<bf16>((size_t)R * c.linear_v_heads);
+    rb_lin_gdn = alloc<bf16>((size_t)R * linear_vdim);
+    rb_shared_gate_tmp = alloc<bf16>((size_t)R);
+    rb_aq81 = alloc<char>((size_t)R * kernels::llama_q8_1_bytes(kmax));
+    rb_logits = alloc<float>((size_t)R * c.vocab);
+    rb_mf_logits = alloc<float>((size_t)R * c.n_experts);
+    rb_mf_ids = alloc<int>((size_t)R * c.top_k);
+    rb_mf_weights = alloc<float>((size_t)R * c.top_k);
+    rb_mf_h = alloc<float>((size_t)R * c.top_k * c.moe_ffn);
+    rb_mf_out = alloc<float>((size_t)R * H);
+    rb_rc = alloc<unsigned int>((size_t)R);
+    rb_sx_h = alloc<float>((size_t)R * c.moe_ffn);
+    rb_sx_q8 = alloc<char>((size_t)R * kernels::llama_q8_1_bytes(c.moe_ffn));
+    rb_shared_w = alloc<float>((size_t)R);
+    rb_fa_m = alloc<float>((size_t)R * fa_n);
+    rb_fa_l = alloc<float>((size_t)R * fa_n);
+    rb_fa_acc = alloc<float>((size_t)R * fa_n * c.head_dim);
+    rb_scalars = alloc<int>((size_t)R * 6);   // [R][5] scalars + [R] token ids for the embedding
+    rb_out_id = alloc<int>((size_t)R);
+    cu(cudaHostAlloc(&rb_h_scalars, (size_t)R * 6 * sizeof(int), cudaHostAllocDefault), "rb host scalars");
+    cu(cudaHostAlloc(&rb_h_out_id, (size_t)R * sizeof(int), cudaHostAllocDefault), "rb host out ids");
+    const bool ok = rb_x && rb_xn && rb_h && rb_hn && rb_routed && rb_shared && rb_ao &&
+                    rb_q && rb_k && rb_v && rb_attn && rb_qraw && rb_qgate &&
+                    rb_lin_qkv && rb_lin_q && rb_lin_k && rb_lin_v && rb_lin_z &&
+                    rb_lin_alpha && rb_lin_beta && rb_lin_gdn && rb_shared_gate_tmp &&
+                    rb_aq81 && rb_logits && rb_mf_logits && rb_mf_ids && rb_mf_weights &&
+                    rb_mf_h && rb_mf_out && rb_rc && rb_sx_h && rb_sx_q8 && rb_shared_w &&
+                    rb_fa_m && rb_fa_l && rb_fa_acc && rb_scalars && rb_out_id &&
+                    rb_h_scalars && rb_h_out_id;
+    if (!ok) { rb_release(); return false; }
+    cu(cudaMemset(rb_rc, 0, (size_t)R * sizeof(unsigned int)), "rb_rc zero");
+    rb_cap = R;
+    return true;
+}
+
+void Qwen35Model::Impl::rb_release() {
+    cudaFree(rb_x); cudaFree(rb_xn); cudaFree(rb_h); cudaFree(rb_hn);
+    cudaFree(rb_routed); cudaFree(rb_shared); cudaFree(rb_ao);
+    cudaFree(rb_q); cudaFree(rb_k); cudaFree(rb_v); cudaFree(rb_attn);
+    cudaFree(rb_qraw); cudaFree(rb_qgate);
+    cudaFree(rb_lin_qkv); cudaFree(rb_lin_q); cudaFree(rb_lin_k); cudaFree(rb_lin_v);
+    cudaFree(rb_lin_z); cudaFree(rb_lin_alpha); cudaFree(rb_lin_beta); cudaFree(rb_lin_gdn);
+    cudaFree(rb_shared_gate_tmp); cudaFree(rb_aq81); cudaFree(rb_logits);
+    cudaFree(rb_mf_logits); cudaFree(rb_mf_ids); cudaFree(rb_mf_weights);
+    cudaFree(rb_mf_h); cudaFree(rb_mf_out); cudaFree(rb_rc);
+    cudaFree(rb_sx_h); cudaFree(rb_sx_q8); cudaFree(rb_shared_w);
+    cudaFree(rb_fa_m); cudaFree(rb_fa_l); cudaFree(rb_fa_acc);
+    cudaFree(rb_scalars); cudaFree(rb_out_id);
+    if (rb_h_scalars) cudaFreeHost(rb_h_scalars);
+    if (rb_h_out_id) cudaFreeHost(rb_h_out_id);
+    rb_x = rb_xn = rb_h = rb_hn = rb_routed = rb_shared = rb_ao = nullptr;
+    rb_q = rb_k = rb_v = rb_attn = rb_qraw = rb_qgate = nullptr;
+    rb_lin_qkv = rb_lin_q = rb_lin_k = rb_lin_v = rb_lin_z = nullptr;
+    rb_lin_alpha = rb_lin_beta = rb_lin_gdn = rb_shared_gate_tmp = nullptr;
+    rb_aq81 = rb_sx_q8 = nullptr;
+    rb_logits = rb_mf_logits = rb_mf_weights = rb_mf_h = rb_mf_out = nullptr;
+    rb_sx_h = rb_shared_w = rb_fa_m = rb_fa_l = rb_fa_acc = nullptr;
+    rb_mf_ids = rb_scalars = rb_out_id = nullptr;
+    rb_rc = nullptr;
+    rb_h_scalars = rb_h_out_id = nullptr;
+    rb_cap = 0;
+}
+
+// Rows twin of dflash_maybe_capture_layer: after layer L's tail, rb_x row r is the same
+// post-layer residual sum forward_token leaves in s.x for window token r. One strided D2D
+// copy places all rows into dflash_hidden[(row_base + r)][slot].
+void Qwen35Model::dflash_rows_capture_layer(int layer, int rows, int row_base) {
+    Impl& s = *p_;
+    if (!s.dflash_capture || !s.dflash_hidden || s.dflash_n_cap <= 0) return;
+    int slot = -1;
+    for (int i = 0; i < s.dflash_n_cap; i++) {
+        if (s.dflash_layer_ids[i] == layer) { slot = i; break; }
+    }
+    if (slot < 0) return;
+    const int H = s.cfg.hidden;
+    const size_t row_elems = (size_t)s.dflash_n_cap * H;
+    cu(cudaMemcpy2DAsync(s.dflash_hidden + (size_t)row_base * row_elems + (size_t)slot * H,
+                         row_elems * sizeof(bf16),
+                         s.rb_x, (size_t)H * sizeof(bf16),
+                         (size_t)H * sizeof(bf16), (size_t)rows,
+                         cudaMemcpyDeviceToDevice, s.stream),
+       "dflash rows capture");
+}
+
+bool Qwen35Model::dflash_verify_rows(const int* token_ids, int rows, int start_pos,
+                                     int* out_argmax) {
+    Impl& s = *p_;
+    const Qwen35Config& c = s.cfg;
+    if (!token_ids || !out_argmax || start_pos < 0) return false;
+    if (rows < 1 || rows > kernels::kDFlashMaxRows) return false;
+    if (!s.dflash_rows_supported()) return false;
+    // Capture rows land at dflash_hidden[row_base + r]; row_base is the verify row index of
+    // the window's first token (the caller sets it via set_dflash_capture_row).
+    const int row_base = s.dflash_cap_row;
+    if (s.dflash_capture && (row_base < 0 || row_base + rows > s.dflash_max_rows)) return false;
+    // All bail-outs above precede any device work, so a false return leaves KV / GDN state
+    // untouched and the caller can rerun the same window through the token loop.
+    if (!s.rb_alloc()) return false;
+
+    const int H = c.hidden;
+    cudaStream_t st = s.stream;
+    const int R5 = kernels::kDFlashMaxRows * 5;
+    int* rb_tok = s.rb_scalars + R5;
+    const size_t q8h = kernels::llama_q8_1_bytes(H);          // Q8_1 row stride, K = hidden
+    const size_t q8q = kernels::llama_q8_1_bytes(s.qdim);     // Q8_1 row stride, K = qdim
+    const size_t q8f = kernels::llama_q8_1_bytes(c.moe_ffn);  // Q8_1 row stride, K = moe_ffn
+    for (int r = 0; r < rows; r++) {
+        const int pos = start_pos + r;
+        s.rb_h_scalars[r * 5 + 0] = token_ids[r];
+        s.rb_h_scalars[r * 5 + 1] = pos;
+        s.rb_h_scalars[r * 5 + 2] = pos;
+        s.rb_h_scalars[r * 5 + 3] = pos + 1;
+        s.rb_h_scalars[r * 5 + 4] = row_base + r;
+        s.rb_h_scalars[R5 + r] = token_ids[r];
+    }
+    cu(cudaMemcpyAsync(s.rb_scalars, s.rb_h_scalars, (size_t)rows * 5 * sizeof(int),
+                       cudaMemcpyHostToDevice, st), "rows scalars");
+    cu(cudaMemcpyAsync(rb_tok, s.rb_h_scalars + R5, (size_t)rows * sizeof(int),
+                       cudaMemcpyHostToDevice, st), "rows tokens");
+    if (c.hybrid && start_pos == 0) {
+        cu(cudaMemsetAsync(s.lin_state, 0,
+                           (size_t)c.n_layers * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim * sizeof(float), st),
+           "rows linear state reset");
+        cu(cudaMemsetAsync(s.lin_conv_state, 0,
+                           (size_t)c.n_layers * (c.linear_conv_kernel - 1) * s.linear_qkvdim * sizeof(bf16), st),
+           "rows linear conv reset");
+    }
+    // The KV-split count is a partial-sum boundary in the flash-decode combine, so each row
+    // must use exactly the split count forward_token's depth-adaptive policy picks at that
+    // row's seqlen (mirrors the adaptive block in forward_token; s.n_splits itself is left
+    // alone so the decode-graph bookkeeping never sees this path).
+    auto row_splits = [&](int seqlen) {
+        if (!s.adaptive_splits) return s.n_splits;
+        int want = 32;
+        if ((long)seqlen > 2L * s.split_chunk) want = 128;
+        if ((long)seqlen > 28L * s.split_chunk && (long)seqlen <= 48L * s.split_chunk)
+            want = Impl::MAX_NSPLITS;
+        if ((long)seqlen > 64L * s.split_chunk) want = Impl::MAX_NSPLITS;
+        if (want > Impl::MAX_NSPLITS) want = Impl::MAX_NSPLITS;
+        if (c.head_dim == 256 && c.n_kv_heads > 0 && want >= 128) {
+            if (c.n_q_heads == c.n_kv_heads * 8)
+                want = 160;
+            else if (c.n_q_heads == c.n_kv_heads * 4) {
+                if ((long)seqlen > 98304L)      want = 128;
+                else if ((long)seqlen > 65536L) want = 192;
+                else                            want = 160;
+            }
+        }
+        return want;
+    };
+
+    kernels::launch_embedding(rb_tok, s.w.embed_tokens, s.rb_x, rows, H, st);
+    int* btable = s.kv->block_table(s.active_seq_id);
+    // Prime: xn = RMSNorm(x, layer0.input_norm). Every later layer's Q8_1(xn) is emitted by
+    // the previous layer's fused tail (fnq), so only layer 0 needs the standalone quantize.
+    kernels::launch_dflash_rows_rmsnorm(s.rb_x, s.w.layers[0].input_norm, s.rb_xn, H,
+                                        c.rms_eps, rows, st);
+    kernels::launch_quantize_q8_1_rows(s.rb_xn, s.rb_aq81, H, rows, H, st);
+
+    for (int L = 0; L < c.n_layers; L++) {
+        const Qwen35LayerWeights& w = s.w.layers[L];
+        if (w.linear_attn) {
+            // Live path runs alpha/beta on stream_v behind fork/join events; the rows path
+            // keeps them on the main stream -- correctness-neutral, the kernels' arithmetic
+            // does not depend on which stream issues them.
+            kernels::launch_dflash_rows_mmvq_gdn_qkv_z(s.rb_aq81, w.wqkv, w.wqkv_gate,
+                                                       s.rb_lin_qkv, s.rb_lin_z,
+                                                       s.linear_qkvdim, s.linear_vdim, H, rows, st);
+            // alpha/beta stay dense bf16 in this GGUF, so they take proj_xn's t==0 branch:
+            // a plain bf16 GEMV per row. They project to linear_v_heads (32) values, far too
+            // little weight to be worth a rows kernel, and looping keeps the split-K reduction
+            // identical to the single-token path.
+            for (int r = 0; r < rows; r++) {
+                kernels::launch_gemv(s.rb_xn + (size_t)r * H, w.ssm_alpha,
+                                     s.rb_lin_alpha + (size_t)r * c.linear_v_heads,
+                                     c.linear_v_heads, H, st);
+                kernels::launch_gemv(s.rb_xn + (size_t)r * H, w.ssm_beta,
+                                     s.rb_lin_beta + (size_t)r * c.linear_v_heads,
+                                     c.linear_v_heads, H, st);
+            }
+            bf16* conv_state = s.lin_conv_state +
+                (size_t)L * (c.linear_conv_kernel - 1) * s.linear_qkvdim;
+            // One call for the whole window: the depthwise conv is causal, so the kernel
+            // walks the rows in order internally and leaves conv_state exactly where `rows`
+            // single-token calls would.
+            kernels::launch_dflash_rows_conv_split_l2norm(s.rb_lin_qkv, w.ssm_conv, conv_state,
+                                                          s.rb_lin_q, s.rb_lin_k, s.rb_lin_v,
+                                                          c.linear_q_heads, c.linear_v_heads,
+                                                          c.linear_head_dim, c.linear_conv_kernel,
+                                                          c.rms_eps, rows, st);
+            float* layer_state = s.lin_state +
+                (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;
+            // The delta-rule recurrence is inherently sequential in the token dimension:
+            // one single-token launch per row, in position order, against the same slice of
+            // lin_state -- identical to the token loop by construction.
+            for (int r = 0; r < rows; r++) {
+                kernels::launch_qwen36_gdn_ar(s.rb_lin_q + (size_t)r * s.linear_qdim,
+                                              s.rb_lin_k + (size_t)r * s.linear_qdim,
+                                              s.rb_lin_v + (size_t)r * s.linear_vdim,
+                                              s.rb_lin_alpha + (size_t)r * c.linear_v_heads,
+                                              s.rb_lin_beta + (size_t)r * c.linear_v_heads,
+                                              w.ssm_dt, w.ssm_a,
+                                              layer_state,
+                                              s.rb_lin_gdn + (size_t)r * s.linear_vdim,
+                                              c.linear_q_heads, c.linear_v_heads,
+                                              c.linear_head_dim, st);
+            }
+            kernels::launch_dflash_rows_gated_norm_q8(s.rb_lin_gdn, s.rb_lin_z, w.ssm_norm,
+                                                      s.rb_aq81, c.linear_v_heads,
+                                                      c.linear_head_dim, c.rms_eps, rows, st);
+            kernels::launch_dflash_rows_mmvq_q4k(s.rb_aq81, w.ssm_out, s.rb_ao, H,
+                                                 s.linear_vdim, rows, st);
+        } else {
+            // Q is Q4_K and K/V are Q8_0 in this GGUF, so the single-token path takes the
+            // per-projection use_qkvstream branch (Q on the main stream, K and V on the side
+            // streams) rather than the fused single-grid QKV kernel. The rows path issues the
+            // same three projections on one stream; each row's dot order is unchanged.
+            kernels::launch_dflash_rows_mmvq_q4k(s.rb_aq81, w.wq, s.rb_qraw, s.qdim * 2, H, rows, st);
+            kernels::launch_dflash_rows_mmvq_q80(s.rb_aq81, w.wk, s.rb_k, s.kvdim, H, rows, st);
+            kernels::launch_dflash_rows_mmvq_q80(s.rb_aq81, w.wv, s.rb_v, s.kvdim, H, rows, st);
+            void* kpool = (char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * 2;
+            void* vpool = (char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * 2;
+            for (int r = 0; r < rows; r++)
+                kernels::launch_qwen36_split_q_gate(s.rb_qraw + (size_t)r * s.qdim * 2,
+                                                    s.rb_q + (size_t)r * s.qdim,
+                                                    s.rb_qgate + (size_t)r * s.qdim,
+                                                    c.n_q_heads, c.head_dim, st);
+            // KV append + attention strictly in position order: row r's K/V land in the
+            // cache before row r+1 runs, and row r attends with seqlen = start_pos + r + 1,
+            // so it sees exactly rows 0..r-1 of the window and never r+1 -- the causal
+            // teacher-forced semantics of the token loop.
+            for (int r = 0; r < rows; r++) {
+                const int seqlen_r = start_pos + r + 1;
+                const int* d_pos_r = s.rb_scalars + r * 5 + 1;
+                const int* d_seqlen_r = s.rb_scalars + r * 5 + 3;
+                kernels::launch_qknorm_rope_kv_partial(s.rb_q + (size_t)r * s.qdim,
+                                                       s.rb_k + (size_t)r * s.kvdim,
+                                                       s.rb_v + (size_t)r * s.kvdim,
+                                                       w.q_norm, w.k_norm,
+                                                       (bf16*)kpool, (bf16*)vpool, btable, d_pos_r, 1,
+                                                       c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim,
+                                                       c.rope_theta, c.rms_eps, s.kv->block_size(),
+                                                       s.kv->max_blocks_per_seq(), st);
+                // Gated combine emits Q8_1(sigmoid(gate) * attn) straight into this row's
+                // aq81 slice, same as the single-token attn_gate_q8 path.
+                kernels::launch_flash_decode_split(s.rb_q + (size_t)r * s.qdim, kpool, vpool,
+                                                   btable, d_seqlen_r,
+                                                   s.rb_attn + (size_t)r * s.qdim,
+                                                   s.rb_fa_m + (size_t)r * c.n_q_heads * Impl::MAX_NSPLITS,
+                                                   s.rb_fa_l + (size_t)r * c.n_q_heads * Impl::MAX_NSPLITS,
+                                                   s.rb_fa_acc + (size_t)r * c.n_q_heads * Impl::MAX_NSPLITS * c.head_dim,
+                                                   1, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                                                   s.kv->block_size(), s.kv->max_blocks_per_seq(),
+                                                   row_splits(seqlen_r),
+                                                   1.f / sqrtf((float)c.head_dim), st,
+                                                   (char*)s.rb_aq81 + (size_t)r * q8q, seqlen_r,
+                                                   nullptr, nullptr, 0,
+                                                   s.rb_qgate + (size_t)r * s.qdim);
+            }
+            kernels::launch_dflash_rows_mmvq_q4k(s.rb_aq81, w.wo, s.rb_ao, H, s.qdim, rows, st);
+        }
+
+        // h = x + ao ; hn = RMSNorm(h, post_attn_norm), also emitting Q8_1(hn) for the
+        // shared-expert and routed gate/up MMVQs (fnq).
+        kernels::launch_dflash_rows_add_rmsnorm2_q8(s.rb_x, s.rb_ao, w.post_attn_norm,
+                                                    s.rb_h, s.rb_hn, s.rb_aq81, H, c.rms_eps, rows, st);
+
+        // Shared expert per row (no rows form; the live path overlaps it with the routed MoE
+        // on stream_k, which is correctness-neutral to drop). The gate-scalar gemv + sigmoid
+        // is the exact single-token pair; the live path launches sigmoid_scalar twice on this
+        // branch, but it is a pure function of the gemv output, so once is value-identical.
+        // Each row gets its own h/Q8 scratch so rb_aq81 (still feeding the routed gate/up
+        // below) is never overwritten.
+        for (int r = 0; r < rows; r++) {
+            kernels::launch_gemv(s.rb_hn + (size_t)r * H, w.shared_gate_inp,
+                                 s.rb_shared_gate_tmp + r, 1, H, st);
+            kernels::launch_qwen36_sigmoid_scalar(s.rb_shared_gate_tmp + r, s.rb_shared_w + r, st);
+            kernels::launch_shared_expert_q8_mmvq(
+                s.rb_hn + (size_t)r * H, (char*)s.rb_aq81 + (size_t)r * q8h,
+                w.shared_gate_q, w.shared_up_q, w.shared_down_q,
+                s.rb_shared_w + r,
+                s.rb_shared + (size_t)r * H,
+                s.rb_sx_h + (size_t)r * c.moe_ffn,
+                (char*)s.rb_sx_q8 + (size_t)r * q8f,
+                H, c.moe_ffn, st, false);
+        }
+
+        kernels::launch_dflash_rows_router_fused(s.rb_hn, w.router_w, s.rb_mf_logits, s.rb_rc,
+                                                 s.rb_mf_ids, s.rb_mf_weights,
+                                                 c.n_experts, H, c.top_k, 1, rows, st);
+        kernels::launch_moe_expert_ffn_q4k(s.rb_hn, w.gate_q, w.up_q, w.down_q,
+                                           w.gate_qtype, w.up_qtype, w.down_qtype,
+                                           s.rb_mf_ids, s.rb_mf_weights, s.rb_routed,
+                                           s.rb_mf_h, s.rb_mf_out,
+                                           rows, c.top_k, H, c.moe_ffn,
+                                           s.rb_aq81, st);
+        // x = h + routed + shared ; xn = RMSNorm(x, next input norm) -- final_norm on the
+        // last layer -- plus Q8_1(xn) for the next layer / the LM head (fnq).
+        const void* nextnorm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
+        kernels::launch_dflash_rows_add_rmsnorm3_q8(s.rb_h, s.rb_routed, s.rb_shared, nextnorm,
+                                                    s.rb_x, s.rb_xn, s.rb_aq81, H, c.rms_eps, rows, st);
+        dflash_rows_capture_layer(L, rows, row_base);
+    }
+
+    // The last layer's tail already folded final_norm and emitted Q8_1(xn) (fnq), exactly as
+    // forward_token reaches its LM head -- no separate final rmsnorm / quantize.
+    kernels::launch_dflash_rows_mmvq_q4k_f32(s.rb_aq81, s.w.lm_head, s.rb_logits,
+                                             c.vocab, H, rows, st);
+    kernels::launch_argmax(s.rb_logits, s.rb_out_id, rows, c.vocab, st);
+    cu(cudaMemcpyAsync(s.rb_h_out_id, s.rb_out_id, (size_t)rows * sizeof(int),
+                       cudaMemcpyDeviceToHost, st), "rows out ids");
+    cu(cudaStreamSynchronize(st), "rows verify sync");
+    for (int r = 0; r < rows; r++) out_argmax[r] = s.rb_h_out_id[r];
+    return true;
+}
+
 bool Qwen35Model::verify_block(const int* token_ids, int n, int start_pos, int* out_argmax) {
     if (!token_ids || !out_argmax || n <= 0) return false;
     for (int i = 0; i < n; i++) {
@@ -1782,9 +2231,13 @@ bool Qwen35Model::verify_block(const int* token_ids, int n, int start_pos, int* 
 
 bool Qwen35Model::batched_forward(const int* token_ids, int n, int start_pos, bool /*resume_gdn*/,
                                   int* out_argmax, const void* /*dflash_capture_dst*/) {
-    // Phase 3 gate: true batched hybrid verify (multi-token GDN+MoE) lands only after
-    // SPEC_AGREE + single-stream speedup. Token-loop verify is correct for GDN advance.
-    // Full-block accept in dflash_generate already skips rollback when accept==B-1.
+    // Row-batched verify first: one weight stream for the whole window instead of one per
+    // token. dflash_verify_rows rejects unsupported configs / window sizes before touching
+    // any device state, so the token-loop fallback below never sees a half-advanced KV or
+    // GDN state. Rollback of rejected tokens stays the caller's job on both paths.
+    set_dflash_capture_row(0);   // window rows capture into dflash_hidden[0..n)
+    if (dflash_verify_rows(token_ids, n, start_pos, out_argmax))
+        return true;
     return verify_block(token_ids, n, start_pos, out_argmax);
 }
 
@@ -1850,11 +2303,22 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     int th_len = n;
 
     std::vector<int> block(B), posterior(B), draft_ids(B);
-    // Proposal depth (also sets the draft's active diffusion width, depth+1).
+    // Proposal depth (also sets the draft's active diffusion width, depth+1). The verify
+    // window amortizes the target's weight stream over the whole tail, so a deeper tail is
+    // nearly free on the target side and only pays the draft's extra diffusion width; 5 is
+    // the measured optimum on an RTX 5090 (4 and 6 both lose to it). With the window off the
+    // ordering inverts -- every proposal costs its own full forward again and 3 wins -- so
+    // this default and SPARKINFER_DFLASH_ROWS belong together.
     static const int kProposalDepth = []{
         const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
-        int v = e ? atoi(e) : 3;
+        int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
+    }();
+    // Verify the proposal tail as one row-batched window. SPARKINFER_DFLASH_ROWS=0 restores the
+    // token loop, which is the A/B control and the fallback if a config is unsupported.
+    static const int rows_verify = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ROWS");
+        return (e && e[0] == '0') ? 0 : 1;
     }();
     bf16* th_scratch = nullptr;
     const int row_stride = dflash_hidden_row_stride();
@@ -1902,23 +2366,67 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         }
         for (int i = 1; i <= kProposalDepth; i++) block[i] = draft_ids[i];
 
-        // Incremental verify with early-exit: forward only the accepted prefix, stopping at the
-        // first rejected proposal. forward_token advances GDN state + KV per token, so after
-        // block[0..keep-1] the recurrent state and KV sit exactly at start+keep -- no snapshot /
-        // restore / KV-truncate / replay needed (greedy speculative decoding is exact). Rejected
-        // proposals (block[keep..B-1]) are never forwarded, saving ~B-keep target forwards/step.
+        // Verify the proposal tail. Both paths below are exact; they differ in how many times
+        // the target's weight stream is read.
+        //
+        // Token loop: forward one proposal per call with early exit, stopping at the first
+        // mismatch. forward_token advances GDN state + KV per token, so after block[0..keep-1]
+        // the recurrent state and KV sit exactly at start+keep and nothing has to be undone.
+        // It costs one full target forward -- one read of every weight -- per emitted token,
+        // which is why DFlash decode lands below plain autoregressive decode.
+        //
+        // Window: push the whole tail through one row-batched forward. Weights stream once for
+        // the window instead of once per proposal; only the routed experts still scale with the
+        // window, since each token routes to its own. The trade is that proposals a rejection
+        // will discard are forwarded anyway, so the GDN recurrent + conv state is snapshotted at
+        // the window head and, when the tail is not fully accepted, rolled back and re-advanced
+        // over the accepted prefix only. KV needs no truncation: later steps overwrite the stale
+        // rows and attention only ever reads seqlen entries.
         int accept = 0, keep = 1;
         bool vfail = p0 < 0;
         posterior[0] = p0;
         if (!vfail && block[1] == p0) {
+            bool windowed = false;
+            if (rows_verify && kProposalDepth >= 2) {
+                // Snapshot the window head in place on the decode stream. save_spec_snapshot()
+                // would do the same two copies but also block the host on them, and nothing
+                // here needs the host: the copies are already ordered ahead of the window.
+                const size_t ls = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
+                                  s.cfg.linear_head_dim * s.cfg.linear_head_dim;
+                const size_t cs = (size_t)s.cfg.n_layers * (s.cfg.linear_conv_kernel - 1) * s.linear_qkvdim;
+                cu(cudaMemcpyAsync(s.spec_lin_snap, s.lin_state, ls * sizeof(float),
+                                   cudaMemcpyDeviceToDevice, s.stream), "rows snap lin");
+                cu(cudaMemcpyAsync(s.spec_conv_snap, s.lin_conv_state, cs * sizeof(bf16),
+                                   cudaMemcpyDeviceToDevice, s.stream), "rows snap conv");
+                set_dflash_capture_row(1);
+                windowed = dflash_verify_rows(block.data() + 1, kProposalDepth, start + 1,
+                                              posterior.data() + 1);
+            }
             for (int i = 1; i <= kProposalDepth; i++) {
-                set_dflash_capture_row(i);
-                const int p = forward_token(block[i], start + i, true);
-                if (p < 0) { vfail = true; break; }
-                posterior[i] = p;
+                if (!windowed) {
+                    set_dflash_capture_row(i);
+                    posterior[i] = forward_token(block[i], start + i, true);
+                }
+                if (posterior[i] < 0) { vfail = true; break; }
                 accept = i;
                 keep = i + 1;
-                if (i < kProposalDepth && block[i + 1] != p) break;
+                if (i < kProposalDepth && block[i + 1] != posterior[i]) break;
+            }
+            if (windowed && !vfail && accept < kProposalDepth) {
+                // Rewind the recurrent state to the window head and replay only the accepted
+                // proposals. Restoring in place keeps every captured decode graph valid -- the
+                // graphs bake buffer addresses, not their contents.
+                const size_t rls = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
+                                   s.cfg.linear_head_dim * s.cfg.linear_head_dim;
+                const size_t rcs = (size_t)s.cfg.n_layers * (s.cfg.linear_conv_kernel - 1) * s.linear_qkvdim;
+                cu(cudaMemcpyAsync(s.lin_state, s.spec_lin_snap, rls * sizeof(float),
+                                   cudaMemcpyDeviceToDevice, s.stream), "rows rewind lin");
+                cu(cudaMemcpyAsync(s.lin_conv_state, s.spec_conv_snap, rcs * sizeof(bf16),
+                                   cudaMemcpyDeviceToDevice, s.stream), "rows rewind conv");
+                for (int i = 1; i <= accept; i++) {
+                    set_dflash_capture_row(i);
+                    if (forward_token(block[i], start + i, true) < 0) { vfail = true; break; }
+                }
             }
         }
         if (vfail) { fprintf(stderr, "[dflash] verify failed at start=%d\n", start); break; }


### PR DESCRIPTION
## Summary

The DFlash verify loop forwards one target token per emitted token, so the model's entire weight stream is re-read once per proposal — which is why DFlash decode (498 tok/s) sits *below* plain autoregressive decode (524 tok/s) on this box and speculation currently buys nothing. This pushes the whole proposal tail through the layer stack in one row-batched forward, so the weights stream once per window instead of once per proposal, and raises the default proposal depth to 5 now that a deeper tail is nearly free on the target side.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, DFlash eval prompt, 2-rep alternating A/B, same box, same build flags):

| | decode tok/s |
|---|--:|
| before (main) | 498.63 |
| after (this PR) | 630.66 |

**+26.5%** DFLASH_TPS. Mean accept length rises 3.657 → 5.333.

**Prefill pp tok/s** — not targeted by this PR; prefill is unchanged (see the guard tables below).

```text
# main @ b0261a5 vs this PR, alternating, /tmp/dflash_eval_ids.txt (seed=fixed, 101-token prompt)
main rep1 METRIC DFLASH_TPS 499.0296   MEAN_ACCEPT 3.6571
PR   rep1 METRIC DFLASH_TPS 632.6492   MEAN_ACCEPT 5.3333
main rep2 METRIC DFLASH_TPS 498.2370   MEAN_ACCEPT 3.6571
PR   rep2 METRIC DFLASH_TPS 628.6661   MEAN_ACCEPT 5.3333

mean: main 498.63 -> PR 630.66   (+26.5%)
```

## What the window does

Each layer's projections are re-expressed as row-batched MMVQs: one CTA per output row holding `R` accumulators, loading each Q4_K/Q8_0 super-block once and dotting it against all `R` activation rows. Only the routed experts still scale with the window — each token routes to its own top-8 — so the gate/up/down term is unchanged while the GDN qkv+z, ssm_out, attention projections, router and LM head are each read once for the whole tail.

The parts that cannot batch stay per-row and are documented as such: the delta-rule recurrence (`gdn_ar`) is sequential by construction, and the KV append plus flash-decode run strictly in position order so row `r` sees rows `0..r-1` of the window and never `r+1`.

The window forwards proposals that a rejection will discard, so the GDN recurrent and conv state is snapshotted at the window head and, when the tail is not fully accepted, rewound and re-advanced over the accepted prefix only. KV needs no truncation — later steps overwrite the stale rows and attention only ever reads `seqlen` entries.

## Exactness

Batching changes only which rows share a CTA, never the arithmetic: every row keeps the single-row kernel's operand order, partial-sum order and reduction tree, and there is no cross-row reduction anywhere. Greedy speculative decoding therefore stays exact.

```text
METRIC SPEC_AGREE 32/32 = 1.0000
VERDICT PASS
```

`ctest --test-dir build` — 9/9 passed.

## Why the proposal depth moves 3 -> 5

With the window, a deeper tail costs the target almost nothing extra and only pays the draft's wider diffusion. Measured on the eval prompt, windowed: depth 3 = 575.8, depth 4 = 586.0, **depth 5 = 631.0**, depth 6 = 597.7, depth 7 = 520.8.

The two settings belong together — with the window disabled the ordering inverts, because every proposal costs its own full forward again:

| | depth 3 | depth 5 |
|---|--:|--:|
| token loop (`SPARKINFER_DFLASH_ROWS=0`) | 498.48 | 490.28 |
| row-batched window | 575.80 | **630.97** |

## No-regression guard (same PR build)

Each number is the mean of two sweeps run in opposite orders (main-first and PR-first). A single pass showed every context drifting ~1% in favour of whichever build ran first, so the orders are balanced to cancel it.

**Qwen3.6-35B-A3B**

| ctx | decode before | decode after | ratio | prefill before | prefill after | ratio |
|---|--:|--:|--:|--:|--:|--:|
| 128 | 524.23 | 523.76 | 0.999 | — | — | — |
| 512 | 515.39 | 515.48 | 1.000 | 9080.17 | 9061.85 | 0.998 |
| 4k | 494.52 | 494.23 | 0.999 | 25101.74 | 24993.18 | 0.996 |
| 16k | 497.07 | 497.25 | 1.000 | 26295.53 | 26269.77 | 0.999 |
| 32k | 497.40 | 497.02 | 0.999 | 27418.08 | 27340.56 | 0.997 |

**Qwythos / Qwen3.5-9B**

| ctx | decode before | decode after | ratio | prefill before | prefill after | ratio |
|---|--:|--:|--:|--:|--:|--:|
| 128 | 299.52 | 299.45 | 1.000 | — | — | — |
| 4k | 289.32 | 289.16 | 0.999 | 23278.44 | 23268.97 | 1.000 |
| 32k | 287.86 | 288.24 | 1.001 | 24071.72 | 24047.62 | 0.999 |
| 64k | 288.05 | 287.83 | 0.999 | 23911.68 | 23893.36 | 0.999 |
| 128k | 286.89 | 286.95 | 1.000 | 23116.51 | 23137.44 | 1.001 |

Both models are flat at every context, decode and prefill, well clear of the 0.98 tolerance — as expected, since `forward_token` is not modified and the new code is reachable only from the DFlash verify path. The row-batched buffers are allocated lazily and separately from the single-row ones, and the window is gated behind a predicate that checks the full Qwen3.6-35B-A3B shape and quantization layout (and every relevant env-tunable at its default) before it will engage; anything else falls back to the existing token loop.

## Escape hatches

- `SPARKINFER_DFLASH_ROWS=0` — restore the token-loop verify (this is the A/B control above).
- `SPARKINFER_DFLASH_PROPOSALS=<n>` — proposal depth, as before.
