### PR TITLE
fix(eval): wait for the shared lock instead of instantly skipping the dflash tick

### DIFF
--- a/eval/run_dflash_cron.sh
+++ b/eval/run_dflash_cron.sh
@@ -6,7 +6,12 @@
 #
 # Policy (same as AR bot):
 #   • Pinned vast.ai GPU only; never rent / never start from cron when down.
-#   • Shares /tmp/sparkinfer_bot.lock with run_bot_cron.sh (no overlap).
+#   • Shares /tmp/sparkinfer_bot.lock with run_bot_cron.sh and the sparkinfer-web dashboard-sync
+#     crons (no overlap). The dashboard sync runs every 15 min (*/15 * * * *), which lands on
+#     this cron's own :00 slot every single tick (odd hours :00) — a bare `flock -n` would race
+#     that fast, low-stakes sync job and could lose the entire 2-hour eval window if it happened
+#     to grab the lock first. Wait a bounded amount instead: long enough to outlast a quick
+#     dashboard git-sync, short enough to still bail if something is genuinely stuck.
 #   • GPU up → full dflash eval + auto-merge; GPU down → --labels-only.
 export HOME="${HOME:-/home/autotiny}"
 export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin:$PATH"
@@ -16,7 +21,7 @@ export SPARKINFER_AUTOMERGE_ADMIN="${SPARKINFER_AUTOMERGE_ADMIN:-1}"
 export VAST_NO_AUTO_PROVISION=1
 
 exec 9>/tmp/sparkinfer_bot.lock
-flock -n 9 || { echo "[$(date -u +%FT%TZ)] previous bot run still active — skipping dflash tick"; exit 0; }
+flock -w 120 9 || { echo "[$(date -u +%FT%TZ)] lock held 120s+ — previous bot run still active, skipping dflash tick"; exit 0; }
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_DIR" || exit 1


### PR DESCRIPTION
## Summary
- `run_dflash_cron.sh` uses `flock -n 9` (non-blocking) on `/tmp/sparkinfer_bot.lock`, which fails instantly if anything else currently holds the lock.
- That same lock is shared with `sparkinfer-web/deploy/sync-sparkinfer-dashboard-cron.sh`, which runs every 15 minutes (`*/15 * * * *`) — landing on this cron's own `:00` slot on **every single tick**, since the DFlash cron only fires at `:00` of odd hours.
- If the (fast, low-stakes, idempotent) dashboard sync happened to grab the lock a moment before the DFlash cron did, `flock -n` would fail immediately and the entire 2-hour eval window was lost, printing a misleading "previous bot run still active" even though the real lock holder was a few-second git sync, not an actual GPU evaluation.
- Observed live today at **01:00, 05:00, and 07:00 UTC** — a real, reproducible race, not a fluke.

## Fix
`flock -n 9` → `flock -w 120 9`: wait up to 120s for the lock instead of bailing instantly. Long enough to outlast a quick dashboard git-sync, short enough to still correctly bail if something is genuinely stuck (e.g. an actual overlapping eval run that's still mid-flight).

## Test plan
- [x] `bash -n eval/run_dflash_cron.sh`
- [ ] Observe the next few odd-hour ticks land cleanly instead of skipping