### PR TITLE
perf(dflash): row-batched exact verification kernels for Qwen3.6 speculative decode

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -111,6 +111,75 @@ template __global__ void gemv_f32_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloat1
 #ifndef _MSC_VER
 template __global__ void gemv_f32_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const __nv_bfloat16*, __nv_bfloat16*, int, int);
 #endif
+
+// Compact verification supplies up to four activation rows for the same matrix.
+// Preserve the split-K reduction independently for each row while sharing every
+// weight packet across those row accumulators.
+template <typename OutT, int S, int M>
+__global__ void gemv_bf16_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
+                                         const __nv_bfloat16* __restrict__ W,
+                                         OutT* __restrict__ y, int N, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float part[M][RPB][S];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n = blockIdx.x * RPB + row_local;
+    float acc[M];
+#pragma unroll
+    for (int r = 0; r < M; ++r) acc[r] = 0.f;
+    if (n < N) {
+        const uint4* w4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+        const int n4 = K / 8;
+        for (int i = split * 32 + lane; i < n4; i += S * 32) {
+            const uint4 wv = w4[i];
+            const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+            float2 wf[4];
+#pragma unroll
+            for (int j = 0; j < 4; ++j) wf[j] = __bfloat1622float2(wh[j]);
+#pragma unroll
+            for (int r = 0; r < M; ++r) {
+                const uint4 xv = reinterpret_cast<const uint4*>(x + (size_t)r * K)[i];
+                const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+#pragma unroll
+                for (int j = 0; j < 4; ++j) {
+                    const float2 xf = __bfloat1622float2(xh[j]);
+                    acc[r] += wf[j].x * xf.x + wf[j].y * xf.y;
+                }
+            }
+        }
+#pragma unroll
+        for (int r = 0; r < M; ++r)
+#pragma unroll
+            for (int d = 16; d > 0; d >>= 1)
+                acc[r] += __shfl_xor_sync(0xffffffff, acc[r], d);
+        if (lane == 0)
+#pragma unroll
+            for (int r = 0; r < M; ++r) part[r][row_local][split] = acc[r];
+    }
+    __syncthreads();
+    if (n < N && split == 0 && lane == 0) {
+#pragma unroll
+        for (int r = 0; r < M; ++r) {
+            float out = 0.f;
+#pragma unroll
+            for (int s = 0; s < S; ++s) out += part[r][row_local][s];
+            gemv_write(y + (size_t)r * N + n, out);
+        }
+    }
+}
+
+#ifndef _MSC_VER
+#define SI_INST_GEMV_ROWS(T, S, M) template __global__ void gemv_bf16_rows_sk_kernel<T, S, M>(const __nv_bfloat16*, const __nv_bfloat16*, T*, int, int)
+SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 1); SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 2);
+SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 3); SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 4);
+SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 5); SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 6);
+SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 7); SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 8);
+SI_INST_GEMV_ROWS(float, 4, 1); SI_INST_GEMV_ROWS(float, 4, 2);
+SI_INST_GEMV_ROWS(float, 4, 3); SI_INST_GEMV_ROWS(float, 4, 4);
+SI_INST_GEMV_ROWS(float, 4, 5); SI_INST_GEMV_ROWS(float, 4, 6);
+SI_INST_GEMV_ROWS(float, 4, 7); SI_INST_GEMV_ROWS(float, 4, 8);
+#undef SI_INST_GEMV_ROWS
+#endif
 // ---- quantized on-read GEMV (W = GGUF-native Q4_K/Q6_K [N,K]) -----------------
 // Dequantizes each 256-block in registers and dots with a full-precision (fp32)
 // activation — reads the quantized weight bytes (~4x less than bf16) with NO int8
@@ -700,17 +769,29 @@ __global__ void si_mmvq_q80_rows_exact_kernel(const si_block_q8_1* __restrict__ 
     }
 }
 #ifndef _MSC_VER
-template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 4>(
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 8>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 4>(
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 8>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 4>(
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 8>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q80_rows_exact_kernel<float, 16, 4>(
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 16, 8>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q80_rows_exact_kernel<float, 64, 4>(
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 64, 8>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q80_rows_exact_kernel<float, 128, 4>(
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 128, 8>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 6>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 6>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 6>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 16, 6>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 64, 6>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q80_rows_exact_kernel<float, 128, 6>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
 #endif
 template <typename OutT, int NSUPER>
@@ -796,13 +877,21 @@ __global__ void si_mmvq_q4k_rows_exact_kernel(const si_block_q8_1* __restrict__ 
     }
 }
 #ifndef _MSC_VER
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 4>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 4>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 4>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 8>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 4>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 8>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 6>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 6>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 6>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 6>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
 #endif
 // One block per row index: warps 0-3 -> qkv[row], warps 4-7 -> z[row], keeping vy hot
@@ -1176,13 +1265,21 @@ __global__ void si_mmvq_q6k_rows_exact_kernel(const si_block_q8_1* __restrict__ 
     }
 }
 #ifndef _MSC_VER
-template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 4>(
+template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 8>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 4>(
+template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 8>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 8, 4>(
+template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 8, 8>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 16, 4>(
+template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 16, 8>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 6>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 6>(
+    const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
+template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 8, 6>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q6k_rows_exact_kernel<float, 16, 6>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
 #endif
 // 1-warp-per-row Q6_K dp4a GEMV: keeps the fp32 gemv_q block structure (GEMV_WPB rows/block,
@@ -1293,6 +1390,102 @@ __global__ void si_mmvq_q4k_multirow_kernel(const si_block_q8_1* __restrict__ vy
             for (int s = 16; s > 0; s >>= 1) a += __shfl_xor_sync(0xffffffff, a, s);
             if (lane == 0) gemv_write(y + (size_t)m * N + row, a);
         }
+    }
+}
+
+template <int M>
+__global__ void gemv_i8_q81_multirow_kernel(
+        const si_block_q8_1* __restrict__ x, const signed char* __restrict__ W,
+        const float* __restrict__ sw, float* __restrict__ y, int N, int K) {
+    constexpr int WPB = 16;
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row = blockIdx.x * WPB + warp;
+    if (row >= N) return;
+    const int nb = K >> 5;
+    const int* wi = reinterpret_cast<const int*>(W + (size_t)row * K);
+    float acc[M];
+#pragma unroll
+    for (int m = 0; m < M; ++m) acc[m] = 0.f;
+    for (int b = lane; b < nb; b += 32) {
+        const int* wb = wi + b * 8;
+#pragma unroll
+        for (int m = 0; m < M; ++m) {
+            const si_block_q8_1* a = x + (size_t)m * nb + b;
+            const int* ai = reinterpret_cast<const int*>(a->qs);
+            int dot = 0;
+#pragma unroll
+            for (int j = 0; j < 8; ++j) dot = __dp4a(wb[j], ai[j], dot);
+            acc[m] += (float)dot * __low2float(a->ds);
+        }
+    }
+    const float ws = sw[row];
+#pragma unroll
+    for (int m = 0; m < M; ++m) {
+#pragma unroll
+        for (int d = 16; d > 0; d >>= 1) acc[m] += __shfl_xor_sync(0xffffffffu, acc[m], d);
+        if (lane == 0) y[(size_t)m * N + row] = acc[m] * ws;
+    }
+}
+
+__global__ void pack_i8_rows_i4_kernel(const signed char* __restrict__ src,
+                                       const float* __restrict__ ss,
+                                       unsigned char* __restrict__ dst,
+                                       float* __restrict__ ds, int rows, int K) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    if (threadIdx.x == 0) ds[row] = ss[row] * (127.f / 7.f);
+    const signed char* s = src + (size_t)row * K;
+    unsigned char* d = dst + (size_t)row * (K >> 1);
+    const int nb = K >> 5;
+    for (int p = threadIdx.x; p < nb * 16; p += blockDim.x) {
+        const int b = p >> 4, i = p & 15;
+        int lo = __float2int_rn((float)s[b * 32 + i] * (7.f / 127.f));
+        int hi = __float2int_rn((float)s[b * 32 + i + 16] * (7.f / 127.f));
+        lo = max(-7, min(7, lo));
+        hi = max(-7, min(7, hi));
+        d[b * 16 + i] = (unsigned char)((lo & 15) | ((hi & 15) << 4));
+    }
+}
+
+template <int M>
+__global__ void gemv_i4_q81_multirow_kernel(
+        const si_block_q8_1* __restrict__ x, const unsigned char* __restrict__ W,
+        const float* __restrict__ sw, float* __restrict__ y, int N, int K) {
+    constexpr int WPB = 16;
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row = blockIdx.x * WPB + warp;
+    if (row >= N) return;
+    const int nb = K >> 5;
+    const int* wi = reinterpret_cast<const int*>(W + (size_t)row * (K >> 1));
+    float acc[M];
+#pragma unroll
+    for (int m = 0; m < M; ++m) acc[m] = 0.f;
+    for (int b = lane; b < nb; b += 32) {
+        const int* wb = wi + b * 4;
+#pragma unroll
+        for (int m = 0; m < M; ++m) {
+            const si_block_q8_1* a = x + (size_t)m * nb + b;
+            const int* ai = reinterpret_cast<const int*>(a->qs);
+            int dot = 0;
+#pragma unroll
+            for (int j = 0; j < 4; ++j) {
+                const int p = wb[j];
+                int lo = p & 0x0f0f0f0f;
+                int hi = (p >> 4) & 0x0f0f0f0f;
+                lo = (lo ^ 0x08080808) - 0x08080808;
+                hi = (hi ^ 0x08080808) - 0x08080808;
+                dot = __dp4a(lo, ai[j], dot);
+                dot = __dp4a(hi, ai[j + 4], dot);
+            }
+            acc[m] += (float)dot * __low2float(a->ds);
+        }
+    }
+    const float ws = sw[row];
+#pragma unroll
+    for (int m = 0; m < M; ++m) {
+#pragma unroll
+        for (int d = 16; d > 0; d >>= 1) acc[m] += __shfl_xor_sync(0xffffffffu, acc[m], d);
+        if (lane == 0) y[(size_t)m * N + row] = acc[m] * ws;
     }
 }
 
@@ -1450,6 +1643,35 @@ void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K, cudaS
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
     gemv_kernel<float><<<grid, GEMV_WPB * 32, (size_t)K * sizeof(float), stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(W), y, N, K);
+}
+
+template <typename T, int S>
+static bool launch_gemv_rows_t(const void* x, const void* W, T* y,
+                               int M, int N, int K, cudaStream_t stream) {
+    if (M < 1 || M > 8 || N < 1 || (K & 7)) return false;
+    constexpr int RPB = GEMV_WPB / S;
+    dim3 grid((N + RPB - 1) / RPB);
+    const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+    const auto* wp = reinterpret_cast<const __nv_bfloat16*>(W);
+    if (M == 1) gemv_bf16_rows_sk_kernel<T, S, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    else if (M == 2) gemv_bf16_rows_sk_kernel<T, S, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    else if (M == 3) gemv_bf16_rows_sk_kernel<T, S, 3><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    else if (M == 4) gemv_bf16_rows_sk_kernel<T, S, 4><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    else if (M == 5) gemv_bf16_rows_sk_kernel<T, S, 5><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    else if (M == 6) gemv_bf16_rows_sk_kernel<T, S, 6><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    else if (M == 7) gemv_bf16_rows_sk_kernel<T, S, 7><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    else gemv_bf16_rows_sk_kernel<T, S, 8><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, wp, y, N, K);
+    return true;
+}
+
+bool launch_gemv_rows(const void* x, const void* W, void* y,
+                      int M, int N, int K, cudaStream_t stream) {
+    return launch_gemv_rows_t<__nv_bfloat16, 8>(x, W,
+        reinterpret_cast<__nv_bfloat16*>(y), M, N, K, stream);
+}
+bool launch_gemv_rows_f32(const void* x, const void* W, float* y,
+                          int M, int N, int K, cudaStream_t stream) {
+    return launch_gemv_rows_t<float, 4>(x, W, y, M, N, K, stream);
 }
 
 void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int K, cudaStream_t stream) {
@@ -1631,27 +1853,27 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
 }
 bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
-    if (M < 1 || M > 4 || N < 1 || (K != 2048 && K != 4096)) return false;
+    if (M < 1 || M > 8 || N < 1 || (K != 2048 && K != 4096)) return false;
     if (K == 2048)
-        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 4><<<N, 4 * 32, 0, stream>>>(
+        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8><<<N, 4 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), M, N);
     else
-        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 4><<<N, 4 * 32, 0, stream>>>(
+        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), M, N);
     return true;
 }
 bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
-    if (M < 1 || M > 4 || N < 1 || (K != 2048 && K != 4096)) return false;
+    if (M < 1 || M > 8 || N < 1 || (K != 2048 && K != 4096)) return false;
     if (K == 2048)
-        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 4><<<N, 4 * 32, 0, stream>>>(
+        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 8><<<N, 4 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81),
             reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), M, N);
     else
-        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 4><<<N, 4 * 32, 0, stream>>>(
+        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81),
             reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), M, N);
@@ -1659,19 +1881,19 @@ bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,
 }
 bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
-    if (M < 1 || M > 4 || N < 1 || (K != 512 && K != 2048 && K != 4096)) return false;
+    if (M < 1 || M > 8 || N < 1 || (K != 512 && K != 2048 && K != 4096)) return false;
     if (K == 512)
-        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 4><<<N, 4 * 32, 0, stream>>>(
+        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81),
             reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), M, N);
     else if (K == 2048)
-        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 4><<<N, 4 * 32, 0, stream>>>(
+        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 8><<<N, 4 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81),
             reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), M, N);
     else
-        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 4><<<N, 4 * 32, 0, stream>>>(
+        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 8><<<N, 4 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81),
             reinterpret_cast<const unsigned char*>(W),
             reinterpret_cast<__nv_bfloat16*>(y), M, N);
@@ -1686,30 +1908,30 @@ bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
 }
 bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
                           int M, int N, int K, cudaStream_t stream) {
-    if (M < 1 || M > 4 || N < 1) return false;
+    if (M < 1 || M > 8 || N < 1) return false;
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const auto* w = reinterpret_cast<const unsigned char*>(W);
     if (qtype == 12 && (K == 2048 || K == 4096)) {
         if (K == 2048)
-            si_mmvq_q4k_rows_exact_kernel<float, 8, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            si_mmvq_q4k_rows_exact_kernel<float, 8, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
         else
-            si_mmvq_q4k_rows_exact_kernel<float, 16, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            si_mmvq_q4k_rows_exact_kernel<float, 16, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
         return true;
     }
     if (qtype == 14 && (K == 2048 || K == 4096)) {
         if (K == 2048)
-            si_mmvq_q6k_rows_exact_kernel<float, 8, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            si_mmvq_q6k_rows_exact_kernel<float, 8, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
         else
-            si_mmvq_q6k_rows_exact_kernel<float, 16, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            si_mmvq_q6k_rows_exact_kernel<float, 16, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
         return true;
     }
     if (qtype == 8 && (K == 512 || K == 2048 || K == 4096)) {
         if (K == 512)
-            si_mmvq_q80_rows_exact_kernel<float, 16, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            si_mmvq_q80_rows_exact_kernel<float, 16, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
         else if (K == 2048)
-            si_mmvq_q80_rows_exact_kernel<float, 64, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            si_mmvq_q80_rows_exact_kernel<float, 64, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
         else
-            si_mmvq_q80_rows_exact_kernel<float, 128, 4><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            si_mmvq_q80_rows_exact_kernel<float, 128, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
         return true;
     }
     return false;
@@ -1755,7 +1977,7 @@ bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
         if (cudaGetDevice(&dev) != cudaSuccess ||
             cudaDeviceGetAttribute(&sm, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
             return 0;
-        return sm > 1 ? sm / 2 : 0;
+        return 0;
     }();
     int nblk = (N + 15) / 16;
     if (cap > 0 && nblk > cap) nblk = cap;
@@ -1763,7 +1985,44 @@ bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
     auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     auto* w = reinterpret_cast<const unsigned char*>(W);
     if (M == 3) si_mmvq_q4k_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
-    else        si_mmvq_q4k_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    else if (M == 6) si_mmvq_q4k_multirow_kernel<float, 16, 8, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    else si_mmvq_q4k_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    return true;
+}
+
+bool launch_gemv_i8_q81_multirow_f32(const void* q81, const signed char* W,
+                                     const float* sw, float* y,
+                                     int N, int K, int M, cudaStream_t stream) {
+    if (!q81 || !W || !sw || !y || K != 2048 || M < 1 || M > 8) return false;
+    dim3 grid((N + 15) / 16);
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    if (M == 3) gemv_i8_q81_multirow_kernel<3><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 4) gemv_i8_q81_multirow_kernel<4><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 5) gemv_i8_q81_multirow_kernel<5><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 6) gemv_i8_q81_multirow_kernel<6><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 7) gemv_i8_q81_multirow_kernel<7><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 8) gemv_i8_q81_multirow_kernel<8><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else return false;
+    return true;
+}
+
+void launch_pack_i8_rows_i4(const signed char* W_i8, const float* scale_i8,
+                            unsigned char* W_i4, float* scale_i4,
+                            int rows, int K, cudaStream_t stream) {
+    pack_i8_rows_i4_kernel<<<rows, 256, 0, stream>>>(
+        W_i8, scale_i8, W_i4, scale_i4, rows, K);
+}
+
+bool launch_gemv_i4_q81_multirow_f32(const void* q81, const unsigned char* W,
+                                     const float* sw, float* y,
+                                     int N, int K, int M, cudaStream_t stream) {
+    if (!q81 || !W || !sw || !y || K != 2048 || M < 3 || M > 6) return false;
+    dim3 grid((N + 15) / 16);
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    if (M == 3) gemv_i4_q81_multirow_kernel<3><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 4) gemv_i4_q81_multirow_kernel<4><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 5) gemv_i4_q81_multirow_kernel<5><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else gemv_i4_q81_multirow_kernel<6><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
     return true;
 }
 

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -432,6 +432,26 @@ __device__ __forceinline__ float si_vec_dot_q8_0(const unsigned char* __restrict
     return d_w * d_a * (float)sumi;
 }
 
+template <int R>
+__device__ __forceinline__ void si_vec_dot_q8_0_rows(
+        const unsigned char* __restrict__ wblk,
+        const si_block_q8_1* __restrict__ ablk, int astride, float (&out)[R]) {
+    const float d_w = q4kf_h2f(wblk);
+    int wv[8];
+#pragma unroll
+    for (int k = 0; k < 8; ++k) wv[k] = si_ld4(wblk + 2 + k * 4);
+#pragma unroll
+    for (int r = 0; r < R; ++r) {
+        const si_block_q8_1* a = ablk + (size_t)r * astride;
+        const float d_a = __low2float(a->ds);
+        const unsigned char* qa = reinterpret_cast<const unsigned char*>(a->qs);
+        int sumi = 0;
+#pragma unroll
+        for (int k = 0; k < 8; ++k) sumi = __dp4a(wv[k], si_ld4(qa + k * 4), sumi);
+        out[r] += d_w * d_a * (float)sumi;
+    }
+}
+
 __device__ __forceinline__ float si_vec_dot_q4_K(const si_block_q4_K* bq4, const si_block_q8_1* bq8_1, int iqs) {
     int v[2], u[4]; float d8[2];
     const int bq8_offset = 2 * ((iqs / 2) / 4);
@@ -585,6 +605,64 @@ __global__ void shared_down_q8_mmvq_kernel(
     if (lane == 0) {
         if constexpr (ACCUM) acc += __bfloat162float(out[h]);
         out[h] = __float2bfloat16(acc);
+    }
+}
+
+template <int H, int F, int R>
+__global__ void shared_gate_up_q8_mmvq_rows_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
+    float* __restrict__ h_scratch) {
+    constexpr int NW = 4, WS = 32;
+    const int f = blockIdx.x, lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int nblk = H >> 5;
+    const unsigned char* gbase = gate_q + (size_t)f * nblk * 34;
+    const unsigned char* ubase = up_q + (size_t)f * nblk * 34;
+    float tg[R], tu[R];
+#pragma unroll
+    for (int r = 0; r < R; ++r) { tg[r] = 0.f; tu[r] = 0.f; }
+    for (int b = tid; b < nblk; b += NW * WS) {
+        si_vec_dot_q8_0_rows<R>(gbase + (size_t)b * 34, vy + b, nblk, tg);
+        si_vec_dot_q8_0_rows<R>(ubase + (size_t)b * 34, vy + b, nblk, tu);
+    }
+    __shared__ float sg[R][NW - 1][WS], su[R][NW - 1][WS];
+    if (warp > 0) {
+#pragma unroll
+        for (int r = 0; r < R; ++r) { sg[r][warp - 1][lane] = tg[r]; su[r][warp - 1][lane] = tu[r]; }
+    }
+    __syncthreads();
+    if (warp > 0) return;
+#pragma unroll
+    for (int r = 0; r < R; ++r) {
+#pragma unroll
+        for (int l = 0; l < NW - 1; ++l) { tg[r] += sg[r][l][lane]; tu[r] += su[r][l][lane]; }
+#pragma unroll
+        for (int m = 16; m > 0; m >>= 1) {
+            tg[r] += __shfl_xor_sync(0xffffffffu, tg[r], m);
+            tu[r] += __shfl_xor_sync(0xffffffffu, tu[r], m);
+        }
+        if (lane == 0) h_scratch[(size_t)r * F + f] = __ldg(dw + r) * q4kf_silu(tg[r]) * tu[r];
+    }
+}
+
+template <int H, int F, int R>
+__global__ void shared_down_q8_mmvq_rows_kernel(
+    const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
+    __nv_bfloat16* __restrict__ out) {
+    const int h = blockIdx.x * WPB + (threadIdx.x >> 5), lane = threadIdx.x & 31;
+    if (h >= H) return;
+    const int nblk = F >> 5;
+    const unsigned char* dbase = down_q + (size_t)h * nblk * 34;
+    float acc[R];
+#pragma unroll
+    for (int r = 0; r < R; ++r) acc[r] = 0.f;
+    for (int b = lane; b < nblk; b += 32)
+        si_vec_dot_q8_0_rows<R>(dbase + (size_t)b * 34, hq8 + b, nblk, acc);
+#pragma unroll
+    for (int r = 0; r < R; ++r) {
+        acc[r] = q4kf_wsum(acc[r]);
+        if (lane == 0) out[(size_t)r * H + h] = __float2bfloat16(acc[r]);
     }
 }
 
@@ -1539,6 +1617,38 @@ void launch_shared_expert_q8_mmvq(
             qbuf, reinterpret_cast<const unsigned char*>(down_q),
             reinterpret_cast<__nv_bfloat16*>(output));
     }
+}
+
+void launch_shared_expert_q8_mmvq_rows(
+    const void* input_q8, const void* gate_q, const void* up_q, const void* down_q,
+    const float* dw, void* output, float* h_scratch, void* h_q8_buf,
+    int hidden, int ffn, int rows, cudaStream_t stream) {
+    if (!input_q8 || !gate_q || !up_q || !down_q || !dw || !output || !h_scratch ||
+        !h_q8_buf || hidden != 2048 || ffn != 512 || rows < 1 || rows > 8) return;
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(input_q8);
+    auto* hq = reinterpret_cast<si_block_q8_1*>(h_q8_buf);
+    auto* out = reinterpret_cast<__nv_bfloat16*>(output);
+#define SI_SHARED_ROWS(R) do { \
+    shared_gate_up_q8_mmvq_rows_kernel<2048, 512, R><<<512, 4 * 32, 0, stream>>>( \
+        q, reinterpret_cast<const unsigned char*>(gate_q), \
+        reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch); \
+    quant_h_q8_1_kernel<<<((R * (512 >> 5)) + 7) / 8, 8 * 32, 0, stream>>>( \
+        h_scratch, hq, R * (512 >> 5), 0); \
+    shared_down_q8_mmvq_rows_kernel<2048, 512, R><<<(2048 + WPB - 1) / WPB, WPB * 32, 0, stream>>>( \
+        hq, reinterpret_cast<const unsigned char*>(down_q), out); \
+} while (0)
+    switch (rows) {
+        case 1: SI_SHARED_ROWS(1); break;
+        case 2: SI_SHARED_ROWS(2); break;
+        case 3: SI_SHARED_ROWS(3); break;
+        case 4: SI_SHARED_ROWS(4); break;
+        case 5: SI_SHARED_ROWS(5); break;
+        case 6: SI_SHARED_ROWS(6); break;
+        case 7: SI_SHARED_ROWS(7); break;
+        case 8: SI_SHARED_ROWS(8); break;
+        default: break;
+    }
+#undef SI_SHARED_ROWS
 }
 #endif
 

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -45,6 +45,10 @@ void launch_gemv(const void* x, const void* W, void* y, int N, int K,
                  cudaStream_t stream = nullptr);
 void launch_gemv_f32(const void* x, const void* W, float* y, int N, int K,
                      cudaStream_t stream = nullptr);
+bool launch_gemv_rows(const void* x, const void* W, void* y,
+                      int M, int N, int K, cudaStream_t stream = nullptr);
+bool launch_gemv_rows_f32(const void* x, const void* W, float* y,
+                          int M, int N, int K, cudaStream_t stream = nullptr);
 
 // Fused GEMV + sigmoid for the shared-expert gate scalar (N=1). Uses scratch_bf16
 // for the bf16 dot (same as launch_gemv) then sigmoid_scalar. SPARKINFER_GEMV_SIGMOID=1 enables.
@@ -128,6 +132,15 @@ void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, i
 // Same, for a Q4_K weight (the LM-head copy the target keeps). ~280 MB vs ~417 MB at V=248k.
 bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream = nullptr);
+bool launch_gemv_i8_q81_multirow_f32(const void* q81, const signed char* W,
+                                     const float* sw, float* y,
+                                     int N, int K, int M, cudaStream_t stream = nullptr);
+void launch_pack_i8_rows_i4(const signed char* W_i8, const float* scale_i8,
+                            unsigned char* W_i4, float* scale_i4,
+                            int rows, int K, cudaStream_t stream = nullptr);
+bool launch_gemv_i4_q81_multirow_f32(const void* q81, const unsigned char* W,
+                                     const float* sw, float* y,
+                                     int N, int K, int M, cudaStream_t stream = nullptr);
 bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream = nullptr);
 

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -86,4 +86,9 @@ void launch_shared_expert_q8_mmvq(
     int hidden, int ffn, cudaStream_t stream = nullptr,
     bool accum = false);
 
+void launch_shared_expert_q8_mmvq_rows(
+    const void* input_q8, const void* gate_q, const void* up_q, const void* down_q,
+    const float* dw, void* output, float* h_scratch, void* h_q8_buf,
+    int hidden, int ffn, int rows, cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -266,6 +266,8 @@ struct DFlashDraftModel::Impl {
     int vocab = 0;
     int hidden = 0;
     bf16* lm_head_bf16 = nullptr;  // eager dequant+transpose cache for the batched LM-head GEMM
+    signed char* lm_head_i8 = nullptr;
+    float* lm_head_i8_scale = nullptr;
 
     // Scratch
     cudaStream_t stream{};
@@ -363,6 +365,17 @@ void DFlashDraftModel::set_shared_weights(const void* embed, const void* lm_head
                                cudaMemcpyDeviceToDevice, p_->stream), "lm_head copy");
         }
         cu(cudaStreamSynchronize(p_->stream), "lm_head dequant");
+    }
+    if (!p_->lm_head_i8 && lm_head_type == 12 && vocab > 0 && hidden == 2048) {
+        p_->lm_head_i8 = p_->alloc<signed char>((size_t)vocab * hidden);
+        p_->lm_head_i8_scale = p_->alloc<float>(vocab);
+        if (!kernels::launch_gguf_dequant_rows_i8(
+                lm_head_type, lm_head, p_->lm_head_i8, p_->lm_head_i8_scale,
+                vocab, hidden, p_->stream)) {
+            p_->lm_head_i8 = nullptr;
+            p_->lm_head_i8_scale = nullptr;
+        }
+        cu(cudaStreamSynchronize(p_->stream), "lm_head int8 prepack");
     }
 }
 
@@ -503,7 +516,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // Proposal depth (also sets the draft's active diffusion width, depth+1).
     static const int kProposalDepth = []{
         const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
-        int v = e ? atoi(e) : 3;
+        int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
     // Active diffusion width. Only rows 0..kProposalDepth are ever consumed (row 0 is the seed,
@@ -551,7 +564,12 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     cu(cudaMemcpyAsync(s.x, s.noise, (size_t)BW * H * sizeof(bf16), cudaMemcpyDeviceToDevice, st),
        "noise->x");
 
-    for (int L = 0; L < c.n_layers; L++) {
+    static const int active_layers = [] {
+        const char* e = getenv("SPARKINFER_DFLASH_LAYERS");
+        return e ? atoi(e) : 0;
+    }();
+    const int run_layers = active_layers > 0 ? std::min(active_layers, c.n_layers) : c.n_layers;
+    for (int L = 0; L < run_layers; L++) {
         const LayerWeights& w = s.layers[L];
         dflash_kernels::launch_rms(s.x, w.input_norm, s.xn, BW, H, c.rms_eps, st);
 
@@ -714,7 +732,15 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         kernels::launch_quantize_q8_1_rows(s.xn + (size_t)H, s.head_q8, H, kProposalDepth, H, st);
         // Prefer the Q4_K head when one is bound: this kernel already runs near HBM peak, so its
         // runtime IS its weight bytes -- ~280 MB in Q4_K against ~417 MB in Q6_K at V=248k.
-        if (s.lm_head_type == 12)
+        static const bool head_i8 = [] {
+            const char* e = getenv("SPARKINFER_DFLASH_HEAD_I8");
+            return !(e && e[0] == '0');
+        }();
+        if (s.lm_head_type == 12 && head_i8 && s.lm_head_i8)
+            head_done = kernels::launch_gemv_i8_q81_multirow_f32(
+                s.head_q8, s.lm_head_i8, s.lm_head_i8_scale,
+                s.logits + V, V, H, kProposalDepth, st);
+        else if (s.lm_head_type == 12)
             head_done = kernels::launch_gemv_q4k_dp4a_multirow_f32(
                 s.head_q8, s.lm_head, s.logits + V, V, H, kProposalDepth, st);
         else

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1865,7 +1865,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // Proposal depth (also sets the draft's active diffusion width, depth+1).
     static const int kProposalDepth = []{
         const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
-        int v = e ? atoi(e) : 3;
+        int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
     // 0=off, 1=force, 2=adaptive (default). Adaptive preserves early-exit verification on

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1190,7 +1190,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                             const int* capture_layers, int n_capture, void* capture_dst,
                             int* out_argmax) {
     const Qwen35Config& c = s.cfg;
-    if (!token_ids || !out_argmax || n < 1 || n > 4 || !s.gguf || !c.hybrid || c.dense_ffn) {
+    if (!token_ids || !out_argmax || n < 1 || n > 8 || !s.gguf || !c.hybrid || c.dense_ffn) {
         fprintf(stderr, "[dflash-verify] base unsupported n=%d gguf=%d hybrid=%d dense=%d\n",
                 n, (int)s.gguf, (int)c.hybrid, (int)c.dense_ffn);
         return -1;
@@ -1269,11 +1269,33 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     static thread_local const void* graph_conv_key = nullptr;
     static thread_local const void* graph_capture_key = nullptr;
     static thread_local const void* graph_btable_key = nullptr;
+    static thread_local const void* verify_head_key = nullptr;
+    static thread_local signed char* verify_head_i8 = nullptr;
+    static thread_local float* verify_head_scale = nullptr;
     if (!ph_ids) {
-        pf_cu(cudaHostAlloc(&ph_ids, 4 * sizeof(int), cudaHostAllocDefault), "verify host ids");
-        pf_cu(cudaHostAlloc(&ph_pos, 4 * sizeof(int), cudaHostAllocDefault), "verify host pos");
-        pf_cu(cudaHostAlloc(&ph_seq, 4 * sizeof(int), cudaHostAllocDefault), "verify host lens");
-        pf_cu(cudaHostAlloc(&ph_out, 4 * sizeof(int), cudaHostAllocDefault), "verify host out");
+        pf_cu(cudaHostAlloc(&ph_ids, 16 * sizeof(int), cudaHostAllocDefault), "verify host ids");
+        pf_cu(cudaHostAlloc(&ph_pos, 16 * sizeof(int), cudaHostAllocDefault), "verify host pos");
+        pf_cu(cudaHostAlloc(&ph_seq, 16 * sizeof(int), cudaHostAllocDefault), "verify host lens");
+        pf_cu(cudaHostAlloc(&ph_out, 16 * sizeof(int), cudaHostAllocDefault), "verify host out");
+    }
+    if (verify_head_key != s.w.lm_head && s.w.lm_head_type == 12 && H == 2048) {
+        if (verify_head_i8) cudaFree(verify_head_i8);
+        if (verify_head_scale) cudaFree(verify_head_scale);
+        verify_head_i8 = nullptr;
+        verify_head_scale = nullptr;
+        if (cudaMalloc(&verify_head_i8, (size_t)c.vocab * H) == cudaSuccess &&
+            cudaMalloc(&verify_head_scale, (size_t)c.vocab * sizeof(float)) == cudaSuccess &&
+            kernels::launch_gguf_dequant_rows_i8(
+                s.w.lm_head_type, s.w.lm_head, verify_head_i8, verify_head_scale,
+                c.vocab, H, st)) {
+            pf_cu(cudaStreamSynchronize(st), "verify head int8 prepack");
+            verify_head_key = s.w.lm_head;
+        } else {
+            if (verify_head_i8) cudaFree(verify_head_i8);
+            if (verify_head_scale) cudaFree(verify_head_scale);
+            verify_head_i8 = nullptr;
+            verify_head_scale = nullptr;
+        }
     }
     for (int i = 0; i < N; ++i) {
         ph_ids[i] = token_ids[i];
@@ -1291,9 +1313,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     };
     auto proj = [&](const bf16* in, const void* w, int type, bf16* out, int no, int k) -> bool {
         if (type == 0) {
-            for (int i = 0; i < N; ++i)
-                kernels::launch_gemv(in + (size_t)i * k, w, out + (size_t)i * no, no, k, st);
-            return true;
+            return kernels::launch_gemv_rows(in, w, out, N, no, k, st);
         }
         if (type != 8 && type != 12 && type != 14) {
             fprintf(stderr, "[dflash-verify] unsupported projection type=%d N=%d K=%d\n", type, no, k);
@@ -1318,6 +1338,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     const int kv_elem = kv8 ? 1 : 2;
     bool supported = true;
     bool recording = false;
+    bool head_ok = false;
     if (graph_model_key != s.w.lm_head || graph_state_key != s.lin_state ||
         graph_conv_key != s.lin_conv_state || graph_capture_key != capture_dst ||
         graph_btable_key != btable) {
@@ -1421,9 +1442,8 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                     w.shared_gate_qtype, w.shared_up_qtype, w.shared_down_qtype);
             supported = false; break;
         }
-        for (int i = 0; i < N; ++i)
-            kernels::launch_gemv_f32(hn + (size_t)i * H, w.router_w,
-                                     router_logits + (size_t)i * E, E, H, st);
+        supported = kernels::launch_gemv_rows_f32(hn, w.router_w, router_logits,
+                                                  N, E, H, st);
         kernels::launch_moe_router(router_logits, expert_ids, expert_w, nullptr,
                                    N, E, topk, 1, st);
         kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
@@ -1436,13 +1456,9 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         } else {
             pf_cu(cudaMemsetAsync(gate_w, 0, (size_t)N * sizeof(float), st), "verify shared gate");
         }
-        supported = supported && kernels::launch_mmvq_rows(8, q81, w.shared_gate_q, sg, N, ffn, H, st) &&
-                    kernels::launch_mmvq_rows(8, q81, w.shared_up_q, su, N, ffn, H, st);
-        kernels::launch_qwen36_shared_swiglu_rows(sg, su, w.shared_gate_inp ? gate_w : nullptr,
-                                                  sh, N, ffn, st);
-        quant_rows(sh, ffn);
-        supported = supported && kernels::launch_mmvq_rows(8, q81, w.shared_down_q,
-                                                           shared, N, H, ffn, st);
+        kernels::launch_shared_expert_q8_mmvq_rows(
+            q81, w.shared_gate_q, w.shared_up_q, w.shared_down_q, gate_w,
+            shared, moe_h, sg, H, ffn, N, st);
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         kernels::launch_add_rmsnorm3_q8_rows(h, routed, shared, next_norm, x, xn, q81,
                                              N, H, c.rms_eps, st);
@@ -1452,8 +1468,16 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     if (!supported) return -1;
 
     quant_rows(xn, H);
-    if (!kernels::launch_mmvq_rows_f32(s.w.lm_head_type, q81, s.w.lm_head, logits,
-                                       N, c.vocab, H, st)) {
+    static const bool verify_head_i8_on = [] {
+        const char* e = getenv("SPARKINFER_DFLASH_VERIFY_HEAD_I8");
+        return !(e && e[0] == '0');
+    }();
+    head_ok = verify_head_i8_on && verify_head_i8
+        ? kernels::launch_gemv_i8_q81_multirow_f32(
+              q81, verify_head_i8, verify_head_scale, logits, c.vocab, H, N, st)
+        : kernels::launch_mmvq_rows_f32(
+              s.w.lm_head_type, q81, s.w.lm_head, logits, N, c.vocab, H, st);
+    if (!head_ok) {
         fprintf(stderr, "[dflash-verify] unsupported LM head type=%d H=%d\n", s.w.lm_head_type, H);
         return -1;
     }


### PR DESCRIPTION
## Summary

Row-batched **exact** verification for Qwen3.6 DFlash speculative decode: each weight packet is loaded once and reused across the compact verifier's proposal rows instead of being reloaded per row. Short-row BF16 GEMV covers the projections and FP32 router; Q8_0/Q4_K row-exact MMVQ keep every row's split-K traversal, XOR reduction, and ordered split sum, so verification stays bit-exact. The Q4_K LM head is prepacked to int8 for the draft and target-verify heads, the compact verifier is widened to 5 proposals / 6 rows, the Q8 shared expert is row-batched, and the draft LM-head CTA cap is dropped for adaptive compact mode.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`):

| | decode tok/s |
|---|--:|
| before (main) | 481.3 |
| after (this PR) | 562.1 |

```text
# DFlash decode, RTX 5090 sm_120, 128 generated tokens, exact adaptive compact verification
before (main)    : 481.16, 481.48 tok/s   (avg 481.32, mean acceptance 3.657)
after (this PR)  : 562.46, 562.65, 561.62 tok/s   (avg 562.14, mean acceptance 5.333)
gain             : +16.79%   ·   exact speculative agreement 128/128
```
