### PR TITLE
fix(eval): always reconfigure cmake, surface build errors on failure

### DIFF
--- a/eval/pr_dflash_bot.py
+++ b/eval/pr_dflash_bot.py
@@ -312,12 +312,20 @@ if [ ! -f "$DRAFT/model.safetensors" ] && [ ! -f "$DRAFT/model.safetensors.index
 fi
 test -f "$GGUF" || {{ echo "FAIL missing GGUF $GGUF"; exit 1; }}
 
-# Build dflash tools + qwen3_gguf_bench (incremental) — the latter drives the Qwen3.5/3.6 guard below.
+# Build dflash tools + qwen3_gguf_bench (incremental build — the latter drives the Qwen3.5/3.6
+# guard below — but ALWAYS reconfigure). build/ is gitignored so it survives every checkout on
+# this box; skipping `cmake -S . -B build` whenever CMakeCache.txt already exists left stale
+# generated Makefiles pointing at source files from a *different* PR's branch that added them —
+# switching checkout to main (or another PR without those files) then failed with
+# "No such file or directory" for files main never even references (#693, #694). cmake's own
+# configure step is cheap and idempotent on an existing cache, so there's no reason to skip it.
 mkdir -p build
-if [ ! -f build/CMakeCache.txt ]; then
-  cmake -S . -B build -DCMAKE_BUILD_TYPE=Release >/tmp/dflash_cmake.log 2>&1
-fi
-cmake --build build --target qwen3_gguf_dflash_check qwen3_gguf_dflash_bench qwen3_gguf_bench -j"$(nproc)" >/tmp/dflash_build.log 2>&1
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release >/tmp/dflash_cmake.log 2>&1
+cmake --build build --target qwen3_gguf_dflash_check qwen3_gguf_dflash_bench qwen3_gguf_bench -j"$(nproc)" >/tmp/dflash_build.log 2>&1 || {{
+  echo "BUILD_FAILED — tail of /tmp/dflash_build.log:" >&2
+  tail -80 /tmp/dflash_build.log >&2
+  exit 1
+}}
 test -x build/runtime/qwen3_gguf_dflash_bench
 test -x build/runtime/qwen3_gguf_bench
 


### PR DESCRIPTION
## Summary
`build/` is gitignored, so it survives every git checkout on the eval box across PR/main evaluations. The build step only ran `cmake -S . -B build` when `CMakeCache.txt` was missing — meaning once any PR's branch added new source files (and matching `CMakeLists.txt` entries), the generated Makefiles kept referencing those files even after switching checkout to `main` or a different PR that never had them, failing with `No such file or directory` for files the checked-out tree doesn't reference at all.

Root-caused **#693** (failed evaluating *main* itself) and **#694** (failed evaluating its own branch) today — both hit stale Makefiles left over from a different PR's earlier build/configure on the shared box. Not a GPU/OOM issue at all, unlike #684/#690 (fixed in #692) — this one is fully deterministic once the build directory gets poisoned by a checkout that added-then-removed source files.

## Fix
- Always reconfigure with `cmake -S . -B build` — cmake's own configure step is cheap and idempotent on an existing cache, so there's no reason to skip it.
- On a build failure, dump the last 80 lines of `/tmp/dflash_build.log` to stderr, so a REJECT from a real compile error shows the actual compiler diagnostic instead of a bare `Error 2` with no context (this is what let me actually root-cause #693/#694 by SSHing in manually — now it'll be visible directly in the PR comment).

## Test plan
- [x] `python3 -m py_compile eval/pr_dflash_bot.py`
- [x] `bash -n` on the generated remote script
- [ ] Observe the next eval round on a PR that previously hit this (#693/#694 rebased, or any new dflash PR) build and score cleanly