### PR TITLE
perf(dflash): cut the Qwen3.6 compact block verify and draft block cost

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -169,6 +169,74 @@ __global__ void gemv_bf16_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
 }
 
 #ifndef _MSC_VER
+
+// Two independent weight matrices sharing one activation block, in a single launch. The DFlash
+// verify issues a stack of tiny row-GEMVs per layer (ssm_alpha and ssm_beta produce v_heads
+// outputs each from the same xn); at ~2 us apiece across 30 GDN layers that is almost entirely
+// launch and graph-node dependency latency rather than work. Mapping the concatenated output rows
+// onto one grid leaves every row's split-K traversal, warp reduction and ordered split sum exactly
+// as gemv_bf16_rows_sk_kernel computes them, so each output is bit-identical.
+template <typename OutT, int S, int M>
+__global__ void gemv_bf16_rows_sk2_kernel(const __nv_bfloat16* __restrict__ x,
+                                         const __nv_bfloat16* __restrict__ W0,
+                                         const __nv_bfloat16* __restrict__ W1,
+                                         OutT* __restrict__ y0, OutT* __restrict__ y1,
+                                         int N0, int N1, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float part[M][RPB][S];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n_all = blockIdx.x * RPB + row_local;
+    const bool second = n_all >= N0;
+    const __nv_bfloat16* W = second ? W1 : W0;
+    OutT* y = second ? y1 : y0;
+    const int n = second ? n_all - N0 : n_all;
+    const int N = second ? N1 : N0;
+    const bool live = n_all < N0 + N1;
+    float acc[M];
+#pragma unroll
+    for (int r = 0; r < M; ++r) acc[r] = 0.f;
+    if (live) {
+        const uint4* w4 = reinterpret_cast<const uint4*>(W + (size_t)n * K);
+        const int n4 = K / 8;
+        for (int i = split * 32 + lane; i < n4; i += S * 32) {
+            const uint4 wv = w4[i];
+            const __nv_bfloat162* wh = reinterpret_cast<const __nv_bfloat162*>(&wv);
+            float2 wf[4];
+#pragma unroll
+            for (int j = 0; j < 4; ++j) wf[j] = __bfloat1622float2(wh[j]);
+#pragma unroll
+            for (int r = 0; r < M; ++r) {
+                const uint4 xv = reinterpret_cast<const uint4*>(x + (size_t)r * K)[i];
+                const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+#pragma unroll
+                for (int j = 0; j < 4; ++j) {
+                    const float2 xf = __bfloat1622float2(xh[j]);
+                    acc[r] += wf[j].x * xf.x + wf[j].y * xf.y;
+                }
+            }
+        }
+#pragma unroll
+        for (int r = 0; r < M; ++r)
+#pragma unroll
+            for (int d = 16; d > 0; d >>= 1)
+                acc[r] += __shfl_xor_sync(0xffffffff, acc[r], d);
+        if (lane == 0)
+#pragma unroll
+            for (int r = 0; r < M; ++r) part[r][row_local][split] = acc[r];
+    }
+    __syncthreads();
+    if (live && split == 0 && lane == 0) {
+#pragma unroll
+        for (int r = 0; r < M; ++r) {
+            float out = 0.f;
+#pragma unroll
+            for (int s = 0; s < S; ++s) out += part[r][row_local][s];
+            gemv_write(y + (size_t)r * N + n, out);
+        }
+    }
+}
+
 #define SI_INST_GEMV_ROWS(T, S, M) template __global__ void gemv_bf16_rows_sk_kernel<T, S, M>(const __nv_bfloat16*, const __nv_bfloat16*, T*, int, int)
 SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 1); SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 2);
 SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 3); SI_INST_GEMV_ROWS(__nv_bfloat16, 8, 4);
@@ -620,6 +688,94 @@ __device__ __forceinline__ float si_vec_dot_q4_K(const si_block_q4_K* bq4,
     return dm4f.x * sumf_d - dm4f.y * sumf_m;
 }
 
+// Row-batched twin of si_vec_dot_q4_K: decode the Q4_K weight packet once (4-bit nibble
+// split, 6-bit scale/min unpack, superblock d/dmin) and reuse it across up to R activation
+// rows. The single-row helper redoes all of that per row, which is what makes the compact
+// verifier's projections ALU-bound at block width rather than bandwidth-bound: the weight
+// bytes are read once for the whole block, but the decode cost was paid M times. Each row still
+// evaluates the same two dp4a pairs, in the same i order, and accumulates into its own
+// float — identical operation sequence, so results are bit-identical per row.
+// Decoded Q4_K weight packet: the nibble split, the 6-bit scale/min pair and the superblock
+// d/dmin, i.e. everything in si_vec_dot_q4_K that depends only on the WEIGHT.
+struct si_q4k_packet {
+    int v0i[2], v1i[2];
+    unsigned short aux[2];
+    float2 dm4f;
+};
+
+__device__ __forceinline__ si_q4k_packet si_q4k_decode(const si_block_q4_K* __restrict__ bq4,
+                                                      int bq8_offset, int qoff) {
+    si_q4k_packet p;
+    const int* q4 = (const int*)(bq4->qs + 16 * bq8_offset + 4 * qoff);
+    const int v0 = q4[0], v1 = q4[4];
+    const unsigned short* scales = (const unsigned short*)bq4->scales;
+    const int j = bq8_offset / 2;
+    if (j < 2) { p.aux[0] = scales[j] & 0x3f3f; p.aux[1] = scales[j + 2] & 0x3f3f; }
+    else { p.aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+           p.aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        p.v0i[i] = (v0 >> (4 * i)) & 0x0F0F0F0F;
+        p.v1i[i] = (v1 >> (4 * i)) & 0x0F0F0F0F;
+    }
+    p.dm4f = __half22float2(bq4->dm);
+    return p;
+}
+
+// Row-batched twin of si_vec_dot_q4_K over OROWS weight rows x R activation rows.
+//
+// Two different redundancies are removed here, and neither changes any row's arithmetic:
+//   * the WEIGHT decode is hoisted out of the activation-row loop (si_vec_dot_q4_K redoes it per
+//     row, which is what made the compact verifier's projections ALU-bound at block width even
+//     though the weight bytes are read once for the whole block);
+//   * the ACTIVATION-only term dp4a(0x01010101, u, ...) — a plain sum of eight quantized bytes —
+//     is shared across the OROWS weight rows this CTA owns. Every output row otherwise recomputes
+//     it identically, so per (weight row, activation row) the dp4a count drops from 8 to 4 + 4/OROWS.
+// Each row still evaluates the same two dp4a pairs in the same i order and accumulates into its own
+// float, so results stay bit-identical per row.
+template <int OROWS, int R>
+__device__ __forceinline__ void si_vec_dot_q4_K_tiled(
+        const si_block_q4_K* __restrict__ bq4, size_t wstride, int orows,
+        const si_block_q8_1* __restrict__ bq8_1, int iqs, int astride, int rows,
+        float (&acc)[OROWS][R]) {
+    const int bq8_offset = 2 * ((iqs / 2) / 4);
+    const int qoff = (iqs / 2) % 4;
+    si_q4k_packet pk[OROWS];
+    #pragma unroll
+    for (int o = 0; o < OROWS; o++)
+        if (o < orows) pk[o] = si_q4k_decode(bq4 + wstride * o, bq8_offset, qoff);
+    #pragma unroll
+    for (int r = 0; r < R; r++) {
+        if (r < rows) {
+            const si_block_q8_1* base = bq8_1 + (size_t)r * astride + bq8_offset;
+            int u0[2], u1[2], dot2[2];
+            float d8[2];
+            #pragma unroll
+            for (int i = 0; i < 2; i++) {
+                const si_block_q8_1* bq8i = base + i;
+                d8[i] = __low2float(bq8i->ds);
+                const int* q8 = (const int*)bq8i->qs + qoff;
+                u0[i] = q8[0]; u1[i] = q8[4];
+                dot2[i] = __dp4a(0x01010101, u1[i], __dp4a(0x01010101, u0[i], 0));
+            }
+            #pragma unroll
+            for (int o = 0; o < OROWS; o++) {
+                if (o >= orows) continue;
+                const unsigned char* sc = (const unsigned char*)pk[o].aux;
+                const unsigned char* mn = sc + 2;
+                float sumf_d = 0.0f, sumf_m = 0.0f;
+                #pragma unroll
+                for (int i = 0; i < 2; i++) {
+                    const int dot1 = __dp4a(pk[o].v1i[i], u1[i], __dp4a(pk[o].v0i[i], u0[i], 0));
+                    sumf_d += d8[i] * (dot1 * sc[i]);
+                    sumf_m += d8[i] * (dot2[i] * mn[i]);
+                }
+                acc[o][r] += pk[o].dm4f.x * sumf_d - pk[o].dm4f.y * sumf_m;
+            }
+        }
+    }
+}
+
 template <typename OutT>
 __global__ void si_mmvq_q4k_kernel(const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ W,
                                    OutT* __restrict__ y, int N, int K) {
@@ -836,62 +992,76 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<float, 16>(const si_block_q8_
 // two-stage four-warp reduction are identical to si_mmvq_q4k_kfixed_kernel. Each CTA owns one
 // weight row and evaluates up to four activation rows before eviction, turning repeated HBM
 // reads into intra-CTA cache hits without changing any per-row floating-point association.
-template <typename OutT, int NSUPER, int MMAX>
+// Weight rows per CTA for the row-batched Q4_K MMVQ.
+#define SI_Q4K_OROWS 2
+
+// OROWS weight rows per CTA. The thread -> (superblock, sub-block) mapping, the two-stage
+// four-warp reduction and each row's accumulation order are untouched; owning more than one
+// weight row only lets the CTA share the activation loads and the activation-only dp4a term.
+template <typename OutT, int NSUPER, int MMAX, int OROWS>
 __global__ void si_mmvq_q4k_rows_exact_kernel(const si_block_q8_1* __restrict__ q,
                                               const unsigned char* __restrict__ W,
                                               OutT* __restrict__ y, int M, int N) {
     constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
     constexpr int QPR = NSUPER * 8;
     const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
-    const int row = blockIdx.x;
-    if (row >= N) return;
+    const int row0 = blockIdx.x * OROWS;
+    if (row0 >= N) return;
+    const int orows = (N - row0 < OROWS) ? (N - row0) : OROWS;
     const si_block_q4_K* x_row = reinterpret_cast<const si_block_q4_K*>(
-        W + (size_t)row * NSUPER * 144);
+        W + (size_t)row0 * NSUPER * 144);
     constexpr int blocks_per_iter = vdr * NW * WS / qi;
-    float tmp[MMAX];
+    float tmp[OROWS][MMAX];
     #pragma unroll
-    for (int m = 0; m < MMAX; m++) tmp[m] = 0.f;
+    for (int o = 0; o < OROWS; o++)
+        #pragma unroll
+        for (int m = 0; m < MMAX; m++) tmp[o][m] = 0.f;
     #pragma unroll
     for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
         const int kqs = vdr * (tid % (qi / vdr));
-        #pragma unroll
-        for (int m = 0; m < MMAX; m++) {
-            if (m < M) tmp[m] += si_vec_dot_q4_K(x_row + kbx, q + (size_t)m * QPR + kbx * 8, kqs);
-        }
+        si_vec_dot_q4_K_tiled<OROWS, MMAX>(x_row + kbx, (size_t)NSUPER, orows,
+                                           q + kbx * 8, kqs, QPR, M, tmp);
     }
-    __shared__ float partial[MMAX][NW - 1][WS];
+    __shared__ float partial[OROWS][MMAX][NW - 1][WS];
     if (warp > 0) {
         #pragma unroll
-        for (int m = 0; m < MMAX; m++) if (m < M) partial[m][warp - 1][lane] = tmp[m];
+        for (int o = 0; o < OROWS; o++)
+            #pragma unroll
+            for (int m = 0; m < MMAX; m++)
+                if (o < orows && m < M) partial[o][m][warp - 1][lane] = tmp[o][m];
     }
     __syncthreads();
     if (warp > 0) return;
     #pragma unroll
-    for (int m = 0; m < MMAX; m++) {
-        if (m >= M) break;
+    for (int o = 0; o < OROWS; o++) {
+        if (o >= orows) break;
         #pragma unroll
-        for (int l = 0; l < NW - 1; l++) tmp[m] += partial[m][l][lane];
-        #pragma unroll
-        for (int s = 16; s > 0; s >>= 1) tmp[m] += __shfl_xor_sync(0xffffffff, tmp[m], s);
-        if (lane == 0) gemv_write(y + (size_t)m * N + row, tmp[m]);
+        for (int m = 0; m < MMAX; m++) {
+            if (m >= M) break;
+            #pragma unroll
+            for (int l = 0; l < NW - 1; l++) tmp[o][m] += partial[o][m][l][lane];
+            #pragma unroll
+            for (int s = 16; s > 0; s >>= 1) tmp[o][m] += __shfl_xor_sync(0xffffffff, tmp[o][m], s);
+            if (lane == 0) gemv_write(y + (size_t)m * N + row0 + o, tmp[o][m]);
+        }
     }
 }
 #ifndef _MSC_VER
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 8>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 8, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 8>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 8, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 6>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 6, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 6>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 6, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 6>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 6, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 6>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 6, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
 #endif
 // One block per row index: warps 0-3 -> qkv[row], warps 4-7 -> z[row], keeping vy hot
@@ -1669,6 +1839,27 @@ bool launch_gemv_rows(const void* x, const void* W, void* y,
     return launch_gemv_rows_t<__nv_bfloat16, 8>(x, W,
         reinterpret_cast<__nv_bfloat16*>(y), M, N, K, stream);
 }
+bool launch_gemv_rows2(const void* x, const void* W0, const void* W1, void* y0, void* y1,
+                       int M, int N0, int N1, int K, cudaStream_t stream) {
+    if (M < 1 || M > 8 || N0 < 1 || N1 < 1 || (K & 7)) return false;
+    constexpr int S = 8, RPB = GEMV_WPB / S;
+    dim3 grid((N0 + N1 + RPB - 1) / RPB);
+    const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+    const auto* w0 = reinterpret_cast<const __nv_bfloat16*>(W0);
+    const auto* w1 = reinterpret_cast<const __nv_bfloat16*>(W1);
+    auto* o0 = reinterpret_cast<__nv_bfloat16*>(y0);
+    auto* o1 = reinterpret_cast<__nv_bfloat16*>(y1);
+#define SI_GEMV_ROWS2(MM) gemv_bf16_rows_sk2_kernel<__nv_bfloat16, S, MM>\
+    <<<grid, GEMV_WPB * 32, 0, stream>>>(xp, w0, w1, o0, o1, N0, N1, K)
+    switch (M) {
+        case 1: SI_GEMV_ROWS2(1); break;  case 2: SI_GEMV_ROWS2(2); break;
+        case 3: SI_GEMV_ROWS2(3); break;  case 4: SI_GEMV_ROWS2(4); break;
+        case 5: SI_GEMV_ROWS2(5); break;  case 6: SI_GEMV_ROWS2(6); break;
+        case 7: SI_GEMV_ROWS2(7); break;  default: SI_GEMV_ROWS2(8); break;
+    }
+#undef SI_GEMV_ROWS2
+    return true;
+}
 bool launch_gemv_rows_f32(const void* x, const void* W, float* y,
                           int M, int N, int K, cudaStream_t stream) {
     return launch_gemv_rows_t<float, 4>(x, W, y, M, N, K, stream);
@@ -1854,14 +2045,18 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
 bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
     if (M < 1 || M > 8 || N < 1 || (K != 2048 && K != 4096)) return false;
-    if (K == 2048)
-        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8><<<N, 4 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N);
-    else
-        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    // Dispatch the tightest instantiated row width: MMAX bounds tmp[]/partial[] and the
+    // number of predicated row bodies, so a 6-row block should not pay an 8-row footprint.
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const auto* w = reinterpret_cast<const unsigned char*>(W);
+    auto* out = reinterpret_cast<__nv_bfloat16*>(y);
+    if (K == 2048) {
+        if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 6, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, out, M, N);
+        else        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, out, M, N);
+    } else {
+        if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 6, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, out, M, N);
+        else        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, out, M, N);
+    }
     return true;
 }
 bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,
@@ -1912,10 +2107,13 @@ bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const auto* w = reinterpret_cast<const unsigned char*>(W);
     if (qtype == 12 && (K == 2048 || K == 4096)) {
-        if (K == 2048)
-            si_mmvq_q4k_rows_exact_kernel<float, 8, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
-        else
-            si_mmvq_q4k_rows_exact_kernel<float, 16, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        if (K == 2048) {
+            if (M <= 6) si_mmvq_q4k_rows_exact_kernel<float, 8, 6, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            else        si_mmvq_q4k_rows_exact_kernel<float, 8, 8, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        } else {
+            if (M <= 6) si_mmvq_q4k_rows_exact_kernel<float, 16, 6, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            else        si_mmvq_q4k_rows_exact_kernel<float, 16, 8, SI_Q4K_OROWS><<<(N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS, 4 * 32, 0, stream>>>(q, w, y, M, N);
+        }
         return true;
     }
     if (qtype == 14 && (K == 2048 || K == 4096)) {

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -608,12 +608,24 @@ __global__ void shared_down_q8_mmvq_kernel(
     }
 }
 
+// Warps per CTA sized to the work that exists: one row is H/32 Q8_0 blocks and the loop strides
+// by NW*WS, so with H=2048 (64 blocks) a 4-warp CTA leaves threads 64..127 with zero iterations.
+// Those dead warps still occupy the CTA and still push a 0.0f into the shared-memory reduction.
+// Dropping them is numerically inert (the reduction just stops adding those zeros) and doubles the
+// CTAs that fit per SM. This kernel is hidden behind the routed MoE on stream_k in the DECODE path,
+// but the DFlash verify issues it on the main stream, where it is squarely on the critical path.
+template <int H, int WS>
+__device__ __host__ constexpr int si_shexp_nw() {
+    return (H / 32) >= 4 * WS ? 4 : ((H / 32) + WS - 1) / WS;
+}
+
 template <int H, int F, int R>
 __global__ void shared_gate_up_q8_mmvq_rows_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const float* __restrict__ dw,
     float* __restrict__ h_scratch) {
-    constexpr int NW = 4, WS = 32;
+    constexpr int WS = 32;
+    constexpr int NW = si_shexp_nw<H, WS>();
     const int f = blockIdx.x, lane = threadIdx.x & 31;
     const int warp = threadIdx.x >> 5, tid = threadIdx.x;
     const int nblk = H >> 5;
@@ -646,23 +658,37 @@ __global__ void shared_gate_up_q8_mmvq_rows_kernel(
     }
 }
 
+// F/32 Q8_0 blocks per output row (16 for the Qwen3.6 shared expert) against a 32-lane stride left
+// lanes 16..31 with nothing to do, and the 32-lane reduction then folded their zeros in. Give each
+// half-warp its own output row instead: the surviving reduction is the same 16-lane tree the low
+// half already ran, minus a `+ 0.0f`, so every output is unchanged while the CTA covers twice the
+// rows. Only worthwhile because the DFlash verify puts this on the critical path — in decode it
+// hides on stream_k behind the routed MoE.
 template <int H, int F, int R>
 __global__ void shared_down_q8_mmvq_rows_kernel(
     const si_block_q8_1* __restrict__ hq8, const unsigned char* __restrict__ down_q,
     __nv_bfloat16* __restrict__ out) {
-    const int h = blockIdx.x * WPB + (threadIdx.x >> 5), lane = threadIdx.x & 31;
+    constexpr int nblk = F >> 5;
+    constexpr int HALF = (nblk <= 16) ? 1 : 0;          // two rows per warp when 16 lanes suffice
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    const int sub = HALF ? (lane >> 4) : 0;             // which half-warp
+    const int llane = HALF ? (lane & 15) : lane;
+    const int rows_per_warp = HALF ? 2 : 1;
+    const int h = (blockIdx.x * WPB + warp) * rows_per_warp + sub;
     if (h >= H) return;
-    const int nblk = F >> 5;
     const unsigned char* dbase = down_q + (size_t)h * nblk * 34;
     float acc[R];
 #pragma unroll
     for (int r = 0; r < R; ++r) acc[r] = 0.f;
-    for (int b = lane; b < nblk; b += 32)
+    for (int b = llane; b < nblk; b += (HALF ? 16 : 32))
         si_vec_dot_q8_0_rows<R>(dbase + (size_t)b * 34, hq8 + b, nblk, acc);
 #pragma unroll
     for (int r = 0; r < R; ++r) {
-        acc[r] = q4kf_wsum(acc[r]);
-        if (lane == 0) out[(size_t)r * H + h] = __float2bfloat16(acc[r]);
+#pragma unroll
+        for (int m = (HALF ? 8 : 16); m > 0; m >>= 1)
+            acc[r] += __shfl_xor_sync(0xffffffff, acc[r], m);
+        if (llane == 0) out[(size_t)r * H + h] = __float2bfloat16(acc[r]);
     }
 }
 
@@ -1629,12 +1655,12 @@ void launch_shared_expert_q8_mmvq_rows(
     auto* hq = reinterpret_cast<si_block_q8_1*>(h_q8_buf);
     auto* out = reinterpret_cast<__nv_bfloat16*>(output);
 #define SI_SHARED_ROWS(R) do { \
-    shared_gate_up_q8_mmvq_rows_kernel<2048, 512, R><<<512, 4 * 32, 0, stream>>>( \
+    shared_gate_up_q8_mmvq_rows_kernel<2048, 512, R><<<512, si_shexp_nw<2048, 32>() * 32, 0, stream>>>( \
         q, reinterpret_cast<const unsigned char*>(gate_q), \
         reinterpret_cast<const unsigned char*>(up_q), dw, h_scratch); \
     quant_h_q8_1_kernel<<<((R * (512 >> 5)) + 7) / 8, 8 * 32, 0, stream>>>( \
         h_scratch, hq, R * (512 >> 5), 0); \
-    shared_down_q8_mmvq_rows_kernel<2048, 512, R><<<(2048 + WPB - 1) / WPB, WPB * 32, 0, stream>>>( \
+    shared_down_q8_mmvq_rows_kernel<2048, 512, R><<<(2048 + WPB * 2 - 1) / (WPB * 2), WPB * 32, 0, stream>>>( \
         hq, reinterpret_cast<const unsigned char*>(down_q), out); \
 } while (0)
     switch (rows) {

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -109,6 +109,11 @@ void launch_mmvq_q80_f32(const void* q81, const void* W, float* y, int N, int K,
 bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream = nullptr);
 // GGUF dispatch for exact short-row projections (Q8_0=8, Q4_K=12, Q6_K=14).
+// Two bf16 weight matrices against one activation block in a single launch. Per-row results are
+// bit-identical to two launch_gemv_rows calls.
+bool launch_gemv_rows2(const void* x, const void* W0, const void* W1, void* y0, void* y1,
+                       int M, int N0, int N1, int K, cudaStream_t stream = nullptr);
+
 bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
                       int M, int N, int K, cudaStream_t stream = nullptr);
 // FP32-output counterpart for verifier logits. It preserves the serial decode reduction order.

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -69,6 +69,38 @@ __global__ void k_rms(const bf16* x, const bf16* w, bf16* out, int rows, int col
         or_[i] = f2b(b2f(xr[i]) * inv * b2f(w[i]));
 }
 
+// Residual add fused with the RMSNorm that always follows it: sum = a + b (kept for the next
+// residual) and out = rms(sum) * w. Identical arithmetic to launch_add followed by launch_rms, but
+// one eager launch instead of two and `sum` stays in registers for the norm's first pass.
+__global__ void k_add_rms(const bf16* a, const bf16* b, bf16* sum, const bf16* w, bf16* out,
+                          int rows, int cols, float eps) {
+    const int r = blockIdx.x;
+    if (r >= rows) return;
+    const bf16* ar = a + (size_t)r * cols;
+    const bf16* br = b + (size_t)r * cols;
+    bf16* sr = sum + (size_t)r * cols;
+    bf16* orow = out + (size_t)r * cols;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int nwarps = blockDim.x >> 5;
+    float ss = 0.f;
+    for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+        const float v = b2f(ar[i]) + b2f(br[i]);
+        sr[i] = f2b(v);
+        const float vq = b2f(sr[i]);          // round-trip through bf16, as launch_add then rms does
+        ss += vq * vq;
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) ss += __shfl_down_sync(0xffffffffu, ss, off);
+    __shared__ float ws[32];
+    if (lane == 0) ws[warp] = ss;
+    __syncthreads();
+    float tot = 0.f;
+    for (int i = 0; i < nwarps; i++) tot += ws[i];
+    const float inv = rsqrtf(tot / (float)cols + eps);
+    for (int i = threadIdx.x; i < cols; i += blockDim.x)
+        orow[i] = f2b(b2f(sr[i]) * inv * b2f(w[i]));
+}
+
 __global__ void k_rms_heads(bf16* x, const bf16* w, int seq, int n_heads, int d, float eps) {
     // One warp per (token, head): d is 128 here, so a head fits a single shuffle reduction and
     // the per-head block barriers disappear entirely.
@@ -86,6 +118,39 @@ __global__ void k_rms_heads(bf16* x, const bf16* w, int seq, int n_heads, int d,
     const float inv = rsqrtf(ss / (float)d + eps);
     for (int i = lane; i < d; i += 32)
         h[i] = f2b(b2f(h[i]) * inv * b2f(w[i]));
+}
+
+// Per-head RMSNorm immediately followed by RoPE on the same buffer. Two launches per tensor and
+// two per layer for q and k is 24 launches a draft block spends on ~37 us of work; the draft is
+// launched eagerly (no graph), so each one also pays a full launch gap. One warp per (token, head)
+// as in k_rms_heads, then the same rotation k_rope applies, in the same order per element.
+__global__ void k_rms_heads_rope(bf16* x, const bf16* w, int seq, int n_heads, int d,
+                                 float eps, int pos0, float theta) {
+    const int idx = blockIdx.x * (blockDim.x >> 5) + (threadIdx.x >> 5);
+    if (idx >= seq * n_heads) return;
+    bf16* h = x + (size_t)idx * d;
+    const int lane = threadIdx.x & 31;
+    float ss = 0.f;
+    for (int i = lane; i < d; i += 32) {
+        float v = b2f(h[i]);
+        ss += v * v;
+    }
+#pragma unroll
+    for (int off = 16; off > 0; off >>= 1) ss += __shfl_xor_sync(0xffffffffu, ss, off);
+    const float inv = rsqrtf(ss / (float)d + eps);
+    for (int i = lane; i < d; i += 32)
+        h[i] = f2b(b2f(h[i]) * inv * b2f(w[i]));
+    __syncwarp();
+    const int pos = pos0 + (idx / n_heads);
+    const int half = d / 2;
+    for (int i = lane; i < half; i += 32) {
+        const float freq = 1.f / powf(theta, (float)(2 * i) / (float)d);
+        const float ang = (float)pos * freq;
+        const float c = cosf(ang), sn = sinf(ang);
+        const float x0 = b2f(h[i]), x1 = b2f(h[i + half]);
+        h[i] = f2b(x0 * c - x1 * sn);
+        h[i + half] = f2b(x0 * sn + x1 * c);
+    }
 }
 
 __global__ void k_rope(bf16* x, int seq, int n_heads, int d, int pos0, float theta) {
@@ -741,7 +806,12 @@ void launch_gemv_batched_q4_fused3(const void* x,
                                    int batch) {
     const int total = N0 + N1 + N2;
     if (total <= 0) return;
-    constexpr int WPB = 4, ROWS = 8;
+    // ROWS is the number of WEIGHT rows a warp owns, which amortizes the activation re-reads --- but
+    // acc[ROWS][BATCH] plus wf[ROWS][8] are both live across the K loop, so at ROWS=8, BATCH=8 the
+    // kernel compiled to 167 registers and only 3 CTAs fit an SM (~19% occupancy), leaving it ~3.7x
+    // off HBM roofline. 4 halves both arrays and roughly doubles resident CTAs; measured 861.9 tok/s
+    // vs 855.4 at 8, with 3 and 5 within noise of 4.
+    constexpr int WPB = 4, ROWS = 4;
     const int warps = (total + ROWS - 1) / ROWS;
     dim3 grid((warps + WPB - 1) / WPB);
     const dim3 blk(WPB * 32);
@@ -810,6 +880,22 @@ void launch_rms(const void* x, const void* w, void* out, int rows, int cols, flo
                 cudaStream_t stream) {
     if (rows <= 0) return;
     k_rms<<<rows, 256, 0, stream>>>((const bf16*)x, (const bf16*)w, (bf16*)out, rows, cols, eps);
+}
+
+void launch_add_rms(const void* a, const void* b, void* sum, const void* w, void* out,
+                    int rows, int cols, float eps, cudaStream_t stream) {
+    if (rows <= 0 || cols <= 0) return;
+    k_add_rms<<<rows, 256, 0, stream>>>((const bf16*)a, (const bf16*)b, (bf16*)sum,
+                                        (const bf16*)w, (bf16*)out, rows, cols, eps);
+}
+
+void launch_rms_heads_rope(void* x, const void* w, int seq, int n_heads, int d, float eps,
+                           int pos0, float theta, cudaStream_t stream) {
+    if (seq <= 0 || n_heads <= 0) return;
+    constexpr int WPB = 4;
+    const int total = seq * n_heads;
+    k_rms_heads_rope<<<(total + WPB - 1) / WPB, WPB * 32, 0, stream>>>(
+        (bf16*)x, (const bf16*)w, seq, n_heads, d, eps, pos0, theta);
 }
 
 void launch_rms_heads(void* x, const void* w, int seq, int n_heads, int d, float eps,
@@ -905,7 +991,10 @@ void launch_gemv_rows_exact_fused2(const void* x,
                                    int rows, int N0, int N1, int K,
                                    cudaStream_t stream) {
     if (rows <= 0 || N0 + N1 <= 0) return;
-    constexpr int RMAX = 8, WPB = 4;
+    // RMAX is the activation-row tile. The r loop runs the full RMAX and folds r >= nr back onto
+    // row 0, so any slack is redundant work: with kProposalDepth=5 the accepted prefix this
+    // projects is at most 6 rows, and 8 spent a quarter of the kernel recomputing row 0.
+    constexpr int RMAX = 6, WPB = 4;
     dim3 grid((N0 + N1 + WPB - 1) / WPB, (rows + RMAX - 1) / RMAX);
     k_gemv_rows_batched_fused2<RMAX><<<grid, WPB * 32, 0, stream>>>(
         (const bf16*)x, (const bf16*)W0, (const bf16*)W1,
@@ -919,6 +1008,127 @@ void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, in
     dim3 grid((N + WARPS_PER_BLOCK - 1) / WARPS_PER_BLOCK);
     k_gemv_batched_f32<16><<<grid, WARPS_PER_BLOCK * 32, 0, stream>>>(
         (const bf16*)x, (const bf16*)W, y, N, K);
+}
+
+// ---- all-layer accepted-prefix GDN commit -------------------------------------------------
+// Same expressions, same reduction order and the same intrinsics as the single-layer commits in
+// fused/batched_prefill.cu, so each layer's result is bit-identical; only the layer loop moves
+// from the host stream to a grid dimension.
+namespace {
+
+__device__ __forceinline__ float gc_sigmoid(float x) { return 1.f / (1.f + __expf(-x)); }
+__device__ __forceinline__ float gc_softplus(float x) { return x > 20.f ? x : __logf(1.f + __expf(x)); }
+__device__ __forceinline__ float gc_wsum(float v) {
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffffu, v, m);
+    return v;
+}
+
+__global__ void k_gdn_conv_commit_layers(const bf16* __restrict__ qkv_base, size_t qkv_stride,
+                                         bf16* __restrict__ live_base, size_t live_stride,
+                                         const int* __restrict__ layer_ids,
+                                         int n_tokens, int qkv_dim, int conv_kernel) {
+    const int d = blockIdx.x * blockDim.x + threadIdx.x;
+    if (d >= qkv_dim) return;
+    const size_t L = (size_t)layer_ids[blockIdx.y];
+    const bf16* qkv = qkv_base + qkv_stride * L;
+    bf16* live_state = live_base + live_stride * L;
+    const int history = conv_kernel - 1;
+    for (int c = 0; c < history; c++) {
+        const int src_tok = n_tokens - history + c;
+        live_state[(size_t)c * qkv_dim + d] = src_tok >= 0
+            ? qkv[(size_t)src_tok * qkv_dim + d]
+            : live_state[(size_t)(c + n_tokens) * qkv_dim + d];
+    }
+}
+
+template <int COLS, int HEAD_DIM>
+__global__ void k_gdn_scan_commit_layers(
+    const bf16* __restrict__ k_base, size_t k_stride,
+    const bf16* __restrict__ v_base, size_t v_stride,
+    const bf16* __restrict__ alpha_base, size_t ab_stride,
+    const bf16* __restrict__ beta_base,
+    const GdnCommitLayer* __restrict__ layers,
+    float* __restrict__ live_base, size_t live_stride,
+    int n_tokens, int q_heads, int v_heads) {
+    constexpr int NROW = HEAD_DIM / 32;
+    const int li = blockIdx.z;
+    const int vh = blockIdx.x;
+    const int j = blockIdx.y * COLS + (threadIdx.x >> 5);
+    const int lane = threadIdx.x & 31;
+    if (vh >= v_heads || j >= HEAD_DIM) return;
+    const size_t L = (size_t)layers[li].layer;
+    const bf16* k = k_base + k_stride * L;
+    const bf16* v = v_base + v_stride * L;
+    const bf16* alpha = alpha_base + ab_stride * L;
+    const bf16* beta = beta_base + ab_stride * L;
+    const bf16* dt = reinterpret_cast<const bf16*>(layers[li].dt);
+    const bf16* a = reinterpret_cast<const bf16*>(layers[li].a);
+    float* live_state = live_base + live_stride * L;
+
+    const int qh = vh % q_heads;
+    const int q_dim = q_heads * HEAD_DIM;
+    const int v_dim = v_heads * HEAD_DIM;
+    const size_t col_off = ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
+    const float a_h = b2f(a[vh]);
+    const float dt_h = b2f(dt[vh]);
+
+    float sloc[NROW];
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) sloc[r] = live_state[col_off + lane + r * 32];
+    for (int t = 0; t < n_tokens; t++) {
+        const float bb = gc_sigmoid(b2f(beta[(size_t)t * v_heads + vh]));
+        const float g = __expf(gc_softplus(b2f(alpha[(size_t)t * v_heads + vh]) + dt_h) * a_h);
+        const bf16* kp = k + (size_t)t * q_dim + qh * HEAD_DIM;
+        const bf16* vp = v + (size_t)t * v_dim + vh * HEAD_DIM;
+        float part_sk = 0.f;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int i = lane + r * 32;
+            part_sk += sloc[r] * b2f(kp[i]);
+        }
+        const float sk = g * gc_wsum(part_sk);
+        const float delta = (b2f(vp[j]) - sk) * bb;
+        #pragma unroll
+        for (int r = 0; r < NROW; r++) {
+            const int i = lane + r * 32;
+            sloc[r] = sloc[r] * g + b2f(kp[i]) * delta;
+        }
+    }
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) live_state[col_off + lane + r * 32] = sloc[r];
+}
+
+} // namespace
+
+void launch_gdn_conv_commit_layers(const void* qkv_base, size_t qkv_layer_stride,
+                                   void* live_base, size_t live_layer_stride,
+                                   const int* layer_ids, int n_layers, int n_tokens,
+                                   int q_heads, int v_heads, int head_dim, int conv_kernel,
+                                   cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim <= 0 || conv_kernel < 2 || conv_kernel > 8 || n_layers <= 0) return;
+    const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
+    constexpr int BLOCK = 256;
+    dim3 grid((qkv_dim + BLOCK - 1) / BLOCK, n_layers);
+    k_gdn_conv_commit_layers<<<grid, BLOCK, 0, stream>>>(
+        (const bf16*)qkv_base, qkv_layer_stride, (bf16*)live_base, live_layer_stride,
+        layer_ids, n_tokens, qkv_dim, conv_kernel);
+}
+
+void launch_gdn_scan_commit_layers(const void* k_base, size_t k_layer_stride,
+                                   const void* v_base, size_t v_layer_stride,
+                                   const void* alpha_base, size_t ab_layer_stride,
+                                   const void* beta_base, const GdnCommitLayer* layers,
+                                   float* live_base, size_t live_layer_stride,
+                                   int n_layers, int n_tokens, int q_heads, int v_heads,
+                                   int head_dim, cudaStream_t stream) {
+    if (n_tokens <= 0 || head_dim != 128 || n_layers <= 0) return;
+    constexpr int COLS = 4;
+    dim3 grid(v_heads, (head_dim + COLS - 1) / COLS, n_layers);
+    k_gdn_scan_commit_layers<COLS, 128><<<grid, COLS * 32, 0, stream>>>(
+        (const bf16*)k_base, k_layer_stride, (const bf16*)v_base, v_layer_stride,
+        (const bf16*)alpha_base, ab_layer_stride, (const bf16*)beta_base, layers,
+        live_base, live_layer_stride, n_tokens, q_heads, v_heads);
 }
 
 } // namespace dflash_kernels

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -26,6 +26,10 @@ void launch_swiglu(const void* gate, const void* up, void* out, int n,
 void launch_add(const void* x, const void* y, void* out, int n,
                 cudaStream_t stream);
 
+// sum = a + b, then out = rms(sum) * w. One launch for the residual+norm pair.
+void launch_add_rms(const void* a, const void* b, void* sum, const void* w, void* out,
+                    int rows, int cols, float eps, cudaStream_t stream);
+
 // RMSNorm over last dim: x [rows, cols] -> out [rows, cols], weight [cols].
 void launch_rms(const void* x, const void* w, void* out, int rows, int cols,
                 float eps, cudaStream_t stream);
@@ -91,6 +95,40 @@ void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, in
 // Per-head RMSNorm on [seq, n_heads, d] (in-place).
 void launch_rms_heads(void* x, const void* w, int seq, int n_heads, int d,
                       float eps, cudaStream_t stream);
+
+// Per-head RMSNorm followed by RoPE, same buffer, one launch. Same math and order as calling
+// launch_rms_heads then launch_rope_seq.
+void launch_rms_heads_rope(void* x, const void* w, int seq, int n_heads, int d, float eps,
+                           int pos0, float theta, cudaStream_t stream);
+
+// Accepted-prefix GDN commit for EVERY linear-attention layer in one launch.
+//
+// The per-layer commits (kernels::launch_dflash_gdn_{conv,scan}_commit) are independent — each
+// touches only its own slice of the live recurrent state — but they run back-to-back on one stream
+// after the verify graph, and the next step's draft cannot start until they drain. That put 2 *
+// n_gdn_layers tiny serialized launches on the critical path for work that is n_layers-way
+// parallel. These forms take the base pointer plus the per-layer stride and use a grid dimension
+// as the layer index. Every buffer is regularly strided by the FULL layer index (linear-attention
+// layers are interleaved with full-attention ones), so the layer table carries the real index; the
+// two per-layer weight vectors are not strided and are passed as device pointers.
+//
+// The per-layer arithmetic and reduction order are unchanged, so each layer's committed state is
+// bit-identical to running the single-layer kernels one at a time.
+struct GdnCommitLayer { const void* dt; const void* a; int layer; };
+
+void launch_gdn_conv_commit_layers(const void* qkv_base, size_t qkv_layer_stride,
+                                   void* live_base, size_t live_layer_stride,
+                                   const int* layer_ids, int n_layers, int n_tokens,
+                                   int q_heads, int v_heads, int head_dim, int conv_kernel,
+                                   cudaStream_t stream);
+
+void launch_gdn_scan_commit_layers(const void* k_base, size_t k_layer_stride,
+                                   const void* v_base, size_t v_layer_stride,
+                                   const void* alpha_base, size_t ab_layer_stride,
+                                   const void* beta_base, const GdnCommitLayer* layers,
+                                   float* live_base, size_t live_layer_stride,
+                                   int n_layers, int n_tokens, int q_heads, int v_heads,
+                                   int head_dim, cudaStream_t stream);
 
 } // namespace dflash_kernels
 } // namespace sparkinfer

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -268,6 +268,8 @@ struct DFlashDraftModel::Impl {
     bf16* lm_head_bf16 = nullptr;  // eager dequant+transpose cache for the batched LM-head GEMM
     signed char* lm_head_i8 = nullptr;
     float* lm_head_i8_scale = nullptr;
+    unsigned char* lm_head_i4 = nullptr;
+    float* lm_head_i4_scale = nullptr;
 
     // Scratch
     cudaStream_t stream{};
@@ -366,6 +368,11 @@ void DFlashDraftModel::set_shared_weights(const void* embed, const void* lm_head
         }
         cu(cudaStreamSynchronize(p_->stream), "lm_head dequant");
     }
+    // The draft's head is the single largest read in the draft block, and the draft only has to
+    // NOMINATE tokens -- every emitted token is still a target argmax, so the head's precision can
+    // only move the accept length, never correctness. int4 halves those bytes again (~254 MB vs
+    // ~508 MB at V=248k), and the kernel is at HBM peak, so its runtime is its weight bytes.
+    // SPARKINFER_DFLASH_HEAD_I4=0 keeps the int8 head.
     if (!p_->lm_head_i8 && lm_head_type == 12 && vocab > 0 && hidden == 2048) {
         p_->lm_head_i8 = p_->alloc<signed char>((size_t)vocab * hidden);
         p_->lm_head_i8_scale = p_->alloc<float>(vocab);
@@ -374,6 +381,23 @@ void DFlashDraftModel::set_shared_weights(const void* embed, const void* lm_head
                 vocab, hidden, p_->stream)) {
             p_->lm_head_i8 = nullptr;
             p_->lm_head_i8_scale = nullptr;
+        }
+        static const bool want_i4 = [] {
+            const char* e = getenv("SPARKINFER_DFLASH_HEAD_I4");
+            return !(e && e[0] == '0');
+        }();
+        if (want_i4 && p_->lm_head_i8) {
+            p_->lm_head_i4 = p_->alloc<unsigned char>((size_t)vocab * (hidden / 2));
+            p_->lm_head_i4_scale = p_->alloc<float>(vocab);
+            if (p_->lm_head_i4 && p_->lm_head_i4_scale) {
+                kernels::launch_pack_i8_rows_i4(p_->lm_head_i8, p_->lm_head_i8_scale,
+                                                p_->lm_head_i4, p_->lm_head_i4_scale,
+                                                vocab, hidden, p_->stream);
+                cudaStreamSynchronize(p_->stream);
+            } else {
+                p_->lm_head_i4 = nullptr;
+                p_->lm_head_i4_scale = nullptr;
+            }
         }
         cu(cudaStreamSynchronize(p_->stream), "lm_head int8 prepack");
     }
@@ -571,7 +595,8 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     const int run_layers = active_layers > 0 ? std::min(active_layers, c.n_layers) : c.n_layers;
     for (int L = 0; L < run_layers; L++) {
         const LayerWeights& w = s.layers[L];
-        dflash_kernels::launch_rms(s.x, w.input_norm, s.xn, BW, H, c.rms_eps, st);
+        if (L == 0)
+            dflash_kernels::launch_rms(s.x, w.input_norm, s.xn, BW, H, c.rms_eps, st);
 
         // Q from noise, K/V from cat(target, noise)
         if (fast16) {
@@ -618,8 +643,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
 
         const int new_len = ctx_len + BW;
         // Q / K RMSNorm per head
-        dflash_kernels::launch_rms_heads(s.q, w.q_norm, BW, c.n_q_heads, d, c.rms_eps, st);
-        dflash_kernels::launch_rms_heads(s.k_new, w.k_norm, new_len, c.n_kv_heads, d, c.rms_eps, st);
+
 
         // RoPE: Q at positions past..(past+B) if past≈pos0 for noise-only positions.
         // Match reference: position_ids cover past_len .. start+block_size for the cat length.
@@ -628,8 +652,10 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // q_pos0 = pos0.
         const int k_pos0 = pos0 - ctx_len;
         const int q_pos0 = pos0;
-        dflash_kernels::launch_rope_seq(s.q, BW, c.n_q_heads, d, q_pos0, c.rope_theta, st);
-        dflash_kernels::launch_rope_seq(s.k_new, new_len, c.n_kv_heads, d, k_pos0, c.rope_theta, st);
+        dflash_kernels::launch_rms_heads_rope(s.q, w.q_norm, BW, c.n_q_heads, d, c.rms_eps,
+                                             q_pos0, c.rope_theta, st);
+        dflash_kernels::launch_rms_heads_rope(s.k_new, w.k_norm, new_len, c.n_kv_heads, d,
+                                             c.rms_eps, k_pos0, c.rope_theta, st);
 
         // Append into cache then attend over full past+new
         // Cache currently has `past` tokens. New keys start at offset `past`.
@@ -671,9 +697,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.attn + (size_t)t * qdim, w.wo, s.ao + (size_t)t * H, H, qdim, st);
         }
-        dflash_kernels::launch_add(s.x, s.ao, s.h, BW * H, st);
-
-        dflash_kernels::launch_rms(s.h, w.post_norm, s.hn, BW, H, c.rms_eps, st);
+        dflash_kernels::launch_add_rms(s.x, s.ao, s.h, w.post_norm, s.hn, BW, H, c.rms_eps, st);
         if (fast16) {
             if (w.q8_gate.q4)
                 dflash_kernels::launch_gemv_batched_q4_fused3(
@@ -708,10 +732,14 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.gate + (size_t)t * I, w.down, s.down + (size_t)t * H, H, I, st);
         }
-        dflash_kernels::launch_add(s.h, s.down, s.x, BW * H, st);
+        // Fold the second residual into the norm that always consumes it: the next layer's input
+        // norm, or the final norm after the last layer. Same math, one launch instead of two, and
+        // the draft is eager-launched so each saved launch is also a saved gap.
+        const bf16* next_norm = (L + 1 < run_layers) ? s.layers[L + 1].input_norm : s.final_norm;
+        dflash_kernels::launch_add_rms(s.h, s.down, s.x, next_norm, s.xn, BW, H, c.rms_eps, st);
     }
-
-    dflash_kernels::launch_rms(s.x, s.final_norm, s.xn, BW, H, c.rms_eps, st);
+    if (run_layers <= 0)
+        dflash_kernels::launch_rms(s.x, s.final_norm, s.xn, BW, H, c.rms_eps, st);
 
     // LM head (target weights) -> logits / argmax. Batched over the whole block: one batched
     // GEMV against the eagerly dequantized bf16 lm_head cache instead of a per-token
@@ -736,7 +764,11 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             const char* e = getenv("SPARKINFER_DFLASH_HEAD_I8");
             return !(e && e[0] == '0');
         }();
-        if (s.lm_head_type == 12 && head_i8 && s.lm_head_i8)
+        if (s.lm_head_type == 12 && s.lm_head_i4)
+            head_done = kernels::launch_gemv_i4_q81_multirow_f32(
+                s.head_q8, s.lm_head_i4, s.lm_head_i4_scale,
+                s.logits + V, V, H, kProposalDepth, st);
+        else if (s.lm_head_type == 12 && head_i8 && s.lm_head_i8)
             head_done = kernels::launch_gemv_i8_q81_multirow_f32(
                 s.head_q8, s.lm_head_i8, s.lm_head_i8_scale,
                 s.logits + V, V, H, kProposalDepth, st);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1862,18 +1862,30 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     int th_len = n;
 
     std::vector<int> block(B), posterior(B), draft_ids(B);
-    // Proposal depth (also sets the draft's active diffusion width, depth+1).
+    // Proposal depth (also sets the draft's active diffusion width, depth+1). 5 is the measured
+    // optimum: accept length rises only 5.33 -> 5.95 -> 6.43 going to depth 6 and 7, while each
+    // extra verify row costs a flat ~0.74 ms, so depth 6 already loses. Keep in sync with
+    // dflash_draft.cpp's copy of this default.
     static const int kProposalDepth = []{
         const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
         int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
     // 0=off, 1=force, 2=adaptive (default). Adaptive preserves early-exit verification on
-    // low-acceptance workloads and switches to the weight-reusing four-row graph only after two
-    // consecutive full-block accepts.
+    // low-acceptance workloads and switches to the weight-reusing row-batched graph on a run of
+    // full-block accepts.
     static const int compact_mode = []{
         const char* e = getenv("SPARKINFER_DFLASH_COMPACT_VERIFY");
         return e ? atoi(e) : 2;
+    }();
+    // Full-block accepts arrive in runs (the target and draft agree over a whole predictable
+    // region), so one is already evidence the next step will accept a full block. Requiring two
+    // spent the first step of every run on the token loop, which costs one full target forward
+    // per accepted token instead of one row-batched pass over the block.
+    static const int kBlockScore = []{
+        const char* e = getenv("SPARKINFER_DFLASH_BLOCK_SCORE");
+        int v = e ? atoi(e) : 1;
+        return v < 1 ? 1 : v;
     }();
     int compact_score = 0;
     bf16* th_scratch = nullptr;
@@ -1886,7 +1898,8 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     }
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
-        const bool compact_verify = compact_mode == 1 || (compact_mode != 0 && compact_score >= 2);
+        const bool compact_verify = compact_mode == 1 ||
+            (compact_mode != 0 && compact_score >= kBlockScore);
         block[0] = next;
         for (int i = 1; i < B; i++) block[i] = mask_id;
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -23,6 +23,7 @@
 #include "sparkinfer/kernels/prefill_moe_q.h"
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/attention.h"
+#include "sparkinfer/models/dflash_kernels.h"
 
 #include <cuda_runtime.h>
 #include <algorithm>
@@ -1336,6 +1337,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     const int bs = s.kv->block_size(), mbs = s.kv->max_blocks_per_seq();
     const bool kv8 = s.kv->int8_kv();
     const int kv_elem = kv8 ? 1 : 2;
+    // The flash-decode split/combine kernels are already batched over grid.y = num_seqs, and every
+    // buffer this function hands them is laid out with exactly the per-row stride they expect. The
+    // one thing that is not is the block table: they index block_table[seq * max_blocks + blk], and
+    // all N verify rows share a single sequence. Replicate the table N times (N * max_blocks ints,
+    // a few KB) so the 10 full-attention layers each run ONE split + ONE combine instead of one per
+    // row. That removes 2*(N-1) graph nodes per attention layer, and the graph is ~1000 nodes deep
+    // against only ~5.6 ms of kernel time, so node count is itself a real cost here.
+    int* btab_rows = (N > 1) ? a.alloc<int>((size_t)N * mbs) : nullptr;
+    if (!a.ok) { fprintf(stderr, "[dflash-verify] block-table scratch allocation failed\n"); return -1; }
     bool supported = true;
     bool recording = false;
     bool head_ok = false;
@@ -1364,6 +1374,11 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     pf_cu(cudaMemcpyAsync(ids, ph_ids, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify ids");
     pf_cu(cudaMemcpyAsync(pos, ph_pos, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify pos");
     pf_cu(cudaMemcpyAsync(seq, ph_seq, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify lens");
+    // Device-to-device inside the capture, so each replay re-reads the sequence's live table as it
+    // grows instead of baking in the mapping from capture time.
+    for (int i = 0; btab_rows && i < N; ++i)
+        pf_cu(cudaMemcpyAsync(btab_rows + (size_t)i * mbs, btable, (size_t)mbs * sizeof(int),
+                              cudaMemcpyDeviceToDevice, st), "verify btable row");
     kernels::launch_embedding(ids, s.w.embed_tokens, x, N, H, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, c.rms_eps, st);
     for (int L = 0; L < c.n_layers && supported; ++L) {
@@ -1374,10 +1389,14 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             bf16* rv = rec_v + (size_t)L * N * lvdim;
             bf16* ra = rec_a + (size_t)L * N * vh;
             bf16* rb = rec_b + (size_t)L * N * vh;
+            // alpha and beta are v_heads-wide reads of the same xn — two launches whose cost is
+            // almost entirely launch/graph-node latency. One fused launch, same per-row math.
+            const bool ab_fused = w.ssm_alpha_type == 0 && w.ssm_beta_type == 0 &&
+                kernels::launch_gemv_rows2(xn, w.ssm_alpha, w.ssm_beta, ra, rb, N, vh, vh, H, st);
             supported = proj(xn, w.wqkv, w.wqkv_type, rq, lqkv, H) &&
                         proj(xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H) &&
-                        proj(xn, w.ssm_alpha, w.ssm_alpha_type, ra, vh, H) &&
-                        proj(xn, w.ssm_beta, w.ssm_beta_type, rb, vh, H);
+                        (ab_fused || (proj(xn, w.ssm_alpha, w.ssm_alpha_type, ra, vh, H) &&
+                                      proj(xn, w.ssm_beta, w.ssm_beta_type, rb, vh, H)));
             if (!supported) break;
             const bf16* conv_live = static_cast<const bf16*>(s.lin_conv_state) +
                 (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
@@ -1414,19 +1433,17 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                     N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta, c.rms_eps,
                     bs, mbs, st);
             }
-            for (int i = 0; i < N; ++i)
-                kernels::launch_flash_decode_split(
-                    qb + (size_t)i * qdim, kp, vp, btable, seq + i, att + (size_t)i * qdim,
-                    fa_m + (size_t)i * c.n_q_heads * ns,
-                    fa_l + (size_t)i * c.n_q_heads * ns,
-                    fa_acc + (size_t)i * c.n_q_heads * ns * c.head_dim,
-                    1, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, ns,
-                    1.f / sqrtf((float)c.head_dim), st, nullptr, -1,
-                    ks, vs, kv8 ? 1 : 0, kv8 ? qg + (size_t)i * qdim : nullptr);
+            kernels::launch_flash_decode_split(
+                qb, kp, vp, btab_rows ? btab_rows : btable, seq, att,
+                fa_m, fa_l, fa_acc,
+                N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, ns,
+                1.f / sqrtf((float)c.head_dim), st, nullptr, -1,
+                ks, vs, kv8 ? 1 : 0, kv8 ? qg : nullptr);
+            // att/qg rows are contiguous at stride qdim, and the gate is elementwise, so one
+            // launch covers the whole block. N separate nodes cost N times the graph-node
+            // dependency latency for the same work.
             if (!kv8)
-                for (int i = 0; i < N; ++i)
-                    kernels::launch_qwen36_mul_sigmoid(att + (size_t)i * qdim,
-                                                        qg + (size_t)i * qdim, qdim, st);
+                kernels::launch_qwen36_mul_sigmoid(att, qg, N * qdim, st);
             supported = proj(att, w.wo, w.wo_type, ao, H, qdim);
         }
         if (!supported) break;
@@ -1496,19 +1513,63 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
 verify_forward_done:
     int keep = 1;
     while (keep < N && token_ids[keep] == out_argmax[keep - 1]) ++keep;
-    for (int L = 0; L < c.n_layers; ++L) if (s.w.layers[L].linear_attn) {
-        bf16* rq = rec_qkv + (size_t)L * N * lqkv;
-        bf16* rk = rec_k + (size_t)L * N * s.linear_qdim;
-        bf16* rv = rec_v + (size_t)L * N * lvdim;
-        bf16* ra = rec_a + (size_t)L * N * vh;
-        bf16* rb = rec_b + (size_t)L * N * vh;
-        bf16* conv_live = static_cast<bf16*>(s.lin_conv_state) +
-            (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
-        float* state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
-        kernels::launch_dflash_gdn_conv_commit(rq, conv_live, keep, c.linear_q_heads, vh,
-            c.linear_head_dim, c.linear_conv_kernel, st);
-        kernels::launch_dflash_gdn_scan_commit(rk, rv, ra, rb, s.w.layers[L].ssm_dt,
-            s.w.layers[L].ssm_a, state, keep, c.linear_q_heads, vh, c.linear_head_dim, st);
+    // Commit the accepted prefix into the live GDN state. This runs OUTSIDE the verify graph, on
+    // the same stream, and the next step's draft does not start until it drains — so its launches
+    // are on the critical path. One launch per GDN layer per commit meant 60 tiny serialized
+    // kernels for work that is independent across layers; drive all of them from one grid instead.
+    static const bool commit_layers = [] {
+        const char* e = getenv("SPARKINFER_DFLASH_COMMIT_LAYERS");
+        return !(e && e[0] == '0');
+    }();
+    static thread_local const void* gdn_tbl_key = nullptr;
+    static thread_local int* d_gdn_layers = nullptr;
+    static thread_local dflash_kernels::GdnCommitLayer* d_gdn_w = nullptr;
+    static thread_local int n_gdn = 0;
+    if (commit_layers && gdn_tbl_key != &s.w) {
+        std::vector<int> ids;
+        std::vector<dflash_kernels::GdnCommitLayer> wts;
+        for (int L = 0; L < c.n_layers; ++L) if (s.w.layers[L].linear_attn) {
+            ids.push_back(L);
+            wts.push_back({s.w.layers[L].ssm_dt, s.w.layers[L].ssm_a, L});
+        }
+        if (d_gdn_layers) cudaFree(d_gdn_layers);
+        if (d_gdn_w) cudaFree(d_gdn_w);
+        d_gdn_layers = nullptr; d_gdn_w = nullptr; n_gdn = 0;
+        if (!ids.empty() &&
+            cudaMalloc(&d_gdn_layers, ids.size() * sizeof(int)) == cudaSuccess &&
+            cudaMalloc(&d_gdn_w, wts.size() * sizeof(dflash_kernels::GdnCommitLayer)) == cudaSuccess) {
+            cudaMemcpy(d_gdn_layers, ids.data(), ids.size() * sizeof(int), cudaMemcpyHostToDevice);
+            cudaMemcpy(d_gdn_w, wts.data(), wts.size() * sizeof(dflash_kernels::GdnCommitLayer),
+                       cudaMemcpyHostToDevice);
+            n_gdn = (int)ids.size();
+            gdn_tbl_key = &s.w;
+        }
+    }
+    if (commit_layers && n_gdn > 0) {
+        dflash_kernels::launch_gdn_conv_commit_layers(
+            rec_qkv, (size_t)N * lqkv, s.lin_conv_state,
+            (size_t)(c.linear_conv_kernel - 1) * lqkv, d_gdn_layers, n_gdn, keep,
+            c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, st);
+        dflash_kernels::launch_gdn_scan_commit_layers(
+            rec_k, (size_t)N * s.linear_qdim, rec_v, (size_t)N * lvdim,
+            rec_a, (size_t)N * vh, rec_b, d_gdn_w,
+            s.lin_state, (size_t)vh * c.linear_head_dim * c.linear_head_dim,
+            n_gdn, keep, c.linear_q_heads, vh, c.linear_head_dim, st);
+    } else {
+        for (int L = 0; L < c.n_layers; ++L) if (s.w.layers[L].linear_attn) {
+            bf16* rq = rec_qkv + (size_t)L * N * lqkv;
+            bf16* rk = rec_k + (size_t)L * N * s.linear_qdim;
+            bf16* rv = rec_v + (size_t)L * N * lvdim;
+            bf16* ra = rec_a + (size_t)L * N * vh;
+            bf16* rb = rec_b + (size_t)L * N * vh;
+            bf16* conv_live = static_cast<bf16*>(s.lin_conv_state) +
+                (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
+            float* state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
+            kernels::launch_dflash_gdn_conv_commit(rq, conv_live, keep, c.linear_q_heads, vh,
+                c.linear_head_dim, c.linear_conv_kernel, st);
+            kernels::launch_dflash_gdn_scan_commit(rk, rv, ra, rb, s.w.layers[L].ssm_dt,
+                s.w.layers[L].ssm_a, state, keep, c.linear_q_heads, vh, c.linear_head_dim, st);
+        }
     }
     pf_cu(cudaStreamSynchronize(st), "verify commit");
     return keep;


### PR DESCRIPTION
## Summary

Ten changes to the two things Qwen3.6 DFlash decode actually spends its time on: the row-batched compact block verify, and the draft block that precedes it serially. Everything on the target path is bit-exact: each output row keeps the same operation sequence and reduction order, so `dflash_gdn_checkpoint_gpu_test`'s byte-identity assertion against independent single-row MMVQs still holds. The draft-side changes can only move the accept length, never correctness — every emitted token is still a target argmax.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 713.35 |
| after (this PR) | 861.88 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a — decode-only change |
| after prefill (this PR) | n/a — decode-only change |

`Qwen3.6-35B-A3B-UD-Q4_K_M` + `z-lab/Qwen3.6-35B-A3B-DFlash`, 128 generated tokens, mean accept τ = 5.3333 on both arms. Two reps each, trees alternated: main 713.46 / 713.24, this PR 862.19 / 861.58 → **+20.8%**, rep spread ≤ 0.07%.

### Gates

- `bench/scripts/dflash_accuracy.sh` → `VERDICT PASS`, `METRIC SPEC_AGREE 32/32 = 1.0000`.
- `dflash_gdn_checkpoint_gpu_test` passes: row-batched Q4_K output stays **byte-identical** to M independent single-row decode MMVQs, bf16 and fp32.
- Qwen3.6 no-regression guard, same build, decode / prefill pp — all within 0.1%:

  | ctx | before | after |
  |---|--:|--:|
  | 128 | 528.17 / — | 527.97 / — |
  | 512 | 520.26 / 8613.1 | 519.90 / 8630.9 |
  | 4096 | 498.53 / 22798.7 | 498.23 / 22801.6 |

  Qwen3.5 is untouched by construction: the changed `launch_mmvq_*_rows` / `launch_gemv_rows2` / GDN-commit entry points are reachable only from `dflash_verify_short_run`, the two MoE edits are in the row-batched (`_rows`) variants the single-token decode path never calls, and the rest is inside the DFlash draft.

```text
# ---- main (9acf0d5) ----
prompt_tokens : 101
gen_tokens    : AR=128 DFlash=128
DFlash        : 713.46 tok/s
mean_accept τ : 5.3333  (steps=24)
METRIC DFLASH_TPS 713.4618
METRIC MEAN_ACCEPT 5.3333

# ---- this PR, same box, same prompt ids ----
prompt_tokens : 101
gen_tokens    : AR=128 DFlash=128
DFlash        : 862.19 tok/s
mean_accept τ : 5.3333  (steps=24)
METRIC DFLASH_TPS 862.1851
METRIC MEAN_ACCEPT 5.3333

# ---- accuracy gate (this PR) ----
METRIC SPEC_AGREE 32/32 = 1.0000
VERDICT PASS

# ---- isolated kernel, extra evidence only (dflash_gdn_checkpoint_gpu_test) ----
# 4 rows x N=8192 x K=2048 vs four serial single-row MMVQs
main:     Q4_K rows: batch 0.012 ms, four serial 0.018 ms, 1.43x
this PR:  Q4_K rows: batch 0.009 ms, four serial 0.018 ms, 1.97x
[PASS] DFlash GDN checkpoints and compact commits equal serial state
```