### PR TITLE
perf(dflash): overlap the independent Qwen3.6 verify branches on a second stream

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -2062,36 +2062,37 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
 bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
     if (M < 1 || M > 8 || N < 1 || (K != 2048 && K != 4096)) return false;
-    if (K == 2048)
-        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 8><<<N, 4 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81),
-            reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N);
-    else
-        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81),
-            reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const auto* w = reinterpret_cast<const unsigned char*>(W);
+    auto* out = reinterpret_cast<__nv_bfloat16*>(y);
+    if (K == 2048) {
+        if (M <= 6) si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 6><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
+        else        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
+    } else {
+        if (M <= 6) si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 6><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
+        else        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
+    }
     return true;
 }
 bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
     if (M < 1 || M > 8 || N < 1 || (K != 512 && K != 2048 && K != 4096)) return false;
-    if (K == 512)
-        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81),
-            reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N);
-    else if (K == 2048)
-        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 64, 8><<<N, 4 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81),
-            reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N);
-    else
-        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, 128, 8><<<N, 4 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81),
-            reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N);
+    // The 6-row instantiations already exist (and the Q4_K launcher below picks them); this one
+    // always asked for the 8-row body, so a 6-row block ran two predicated rows of tmp[]/partial[]
+    // and the reduction over them for nothing.
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const auto* w = reinterpret_cast<const unsigned char*>(W);
+    auto* out = reinterpret_cast<__nv_bfloat16*>(y);
+#define SI_Q80_ROWS(NSUP) do {                                                      \
+        if (M <= 6) si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, NSUP, 6>           \
+                        <<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);                \
+        else        si_mmvq_q80_rows_exact_kernel<__nv_bfloat16, NSUP, 8>           \
+                        <<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);                \
+    } while (0)
+    if (K == 512)       SI_Q80_ROWS(16);
+    else if (K == 2048) SI_Q80_ROWS(64);
+    else                SI_Q80_ROWS(128);
+#undef SI_Q80_ROWS
     return true;
 }
 bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -278,7 +278,6 @@ struct DFlashDraftModel::Impl {
     bf16 *x = nullptr, *xn = nullptr, *h = nullptr, *hn = nullptr;
     bf16 *q = nullptr, *k = nullptr, *v = nullptr, *attn = nullptr, *ao = nullptr;
     bf16 *gate = nullptr, *up = nullptr, *down = nullptr;
-    bf16 *k_new = nullptr, *v_new = nullptr;  // [ctx+B, n_kv, d]
     float* logits = nullptr;        // [B, vocab]
     void* head_q8 = nullptr;        // [B] Q8_1 rows of xn for the multi-row head MMVQ
     int *d_ids = nullptr, *d_out = nullptr;
@@ -487,7 +486,6 @@ bool DFlashDraftModel::load(const std::string& dir) {
 
     // Scratch
     const int max_ctx = max_seq;
-    const int max_kv = max_ctx + B;
     s.noise = s.alloc<bf16>((size_t)B * H);
     s.target_proj = s.alloc<bf16>((size_t)max_ctx * H);
     s.x = s.alloc<bf16>((size_t)B * H);
@@ -500,8 +498,6 @@ bool DFlashDraftModel::load(const std::string& dir) {
     s.gate = s.alloc<bf16>((size_t)B * I);
     s.up = s.alloc<bf16>((size_t)B * I);
     s.down = s.alloc<bf16>((size_t)B * H);
-    s.k_new = s.alloc<bf16>((size_t)max_kv * kvdim);
-    s.v_new = s.alloc<bf16>((size_t)max_kv * kvdim);
     s.logits = s.alloc<float>((size_t)B * std::max(s.cfg.vocab, 1));
     s.head_q8 = s.alloc<char>((size_t)B * kernels::llama_q8_1_bytes(H));
     s.d_ids = s.alloc<int>(B);
@@ -593,8 +589,20 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         return e ? atoi(e) : 0;
     }();
     const int run_layers = active_layers > 0 ? std::min(active_layers, c.n_layers) : c.n_layers;
+    // cat(k_ctx, k_noise) is built at exactly the layout and length the cache slice expects, so
+    // staging it in k_new/v_new and memcpy'ing it in cost two extra D2D launches per layer -- 12 a
+    // block, on a draft that is launch-bound (its kernels are 1-3 us and the gaps between them are
+    // the same size). Project straight into the cache slice instead; the RoPE then runs in place
+    // there. Same values written to the same addresses in the same order.
+    const int new_len_all = ctx_len + BW;
+    if (past + new_len_all > c.max_seq) {
+        fprintf(stderr, "[dflash] KV overflow past=%d new=%d max=%d\n", past, new_len_all, c.max_seq);
+        return false;
+    }
     for (int L = 0; L < run_layers; L++) {
         const LayerWeights& w = s.layers[L];
+        bf16* const kdst = s.k_cache[L] + (size_t)past * kvdim;
+        bf16* const vdst = s.v_cache[L] + (size_t)past * kvdim;
         if (L == 0)
             dflash_kernels::launch_rms(s.x, w.input_norm, s.xn, BW, H, c.rms_eps, st);
 
@@ -603,41 +611,41 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             if (w.q8_wq.q4)
                 dflash_kernels::launch_gemv_batched_q4_fused3(
                     s.xn, w.q8_wq.q4, w.q8_wk.q4, w.q8_wv.q4, w.q8_wq.dm, w.q8_wk.dm, w.q8_wv.dm,
-                    s.q, s.k_new + (size_t)ctx_len * kvdim, s.v_new + (size_t)ctx_len * kvdim,
+                    s.q, kdst + (size_t)ctx_len * kvdim, vdst + (size_t)ctx_len * kvdim,
                     qdim, kvdim, kvdim, H, st, BW);
             else if (w.q8_wq.q)
                 dflash_kernels::launch_gemv_batched_q8_fused3(
                     s.xn, w.q8_wq.q, w.q8_wk.q, w.q8_wv.q, w.q8_wq.s, w.q8_wk.s, w.q8_wv.s,
-                    s.q, s.k_new + (size_t)ctx_len * kvdim, s.v_new + (size_t)ctx_len * kvdim,
+                    s.q, kdst + (size_t)ctx_len * kvdim, vdst + (size_t)ctx_len * kvdim,
                     qdim, kvdim, kvdim, H, st, BW);
             else
                 dflash_kernels::launch_gemv_batched16_fused3(
                     s.xn, w.wq, w.wk, w.wv,
-                    s.q, s.k_new + (size_t)ctx_len * kvdim,
-                    s.v_new + (size_t)ctx_len * kvdim,
+                    s.q, kdst + (size_t)ctx_len * kvdim,
+                    vdst + (size_t)ctx_len * kvdim,
                     qdim, kvdim, kvdim, H, st, BW);
         } else {
             for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
-        // Build k_new / v_new = cat(k_ctx, k_noise)
+        // Context half of cat(k_ctx, k_noise), written ahead of the noise rows.
         if (ctx_len > 1) {
             dflash_kernels::launch_gemv_rows_exact_fused2(
-                s.target_proj, w.wk, w.wv, s.k_new, s.v_new,
+                s.target_proj, w.wk, w.wv, kdst, vdst,
                 ctx_len, kvdim, kvdim, H, st);
         } else if (ctx_len == 1) {
             const int t = 0;
             kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wk,
-                                 s.k_new + (size_t)t * kvdim, kvdim, H, st);
+                                 kdst + (size_t)t * kvdim, kvdim, H, st);
             kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wv,
-                                 s.v_new + (size_t)t * kvdim, kvdim, H, st);
+                                 vdst + (size_t)t * kvdim, kvdim, H, st);
         }
         if (!fast16) {
             for (int t = 0; t < BW; t++) {
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wk,
-                                     s.k_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
+                                     kdst + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wv,
-                                     s.v_new + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
+                                     vdst + (size_t)(ctx_len + t) * kvdim, kvdim, H, st);
             }
         }
 
@@ -654,21 +662,10 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         const int q_pos0 = pos0;
         dflash_kernels::launch_rms_heads_rope(s.q, w.q_norm, BW, c.n_q_heads, d, c.rms_eps,
                                              q_pos0, c.rope_theta, st);
-        dflash_kernels::launch_rms_heads_rope(s.k_new, w.k_norm, new_len, c.n_kv_heads, d,
+        dflash_kernels::launch_rms_heads_rope(kdst, w.k_norm, new_len, c.n_kv_heads, d,
                                              c.rms_eps, k_pos0, c.rope_theta, st);
 
-        // Append into cache then attend over full past+new
-        // Cache currently has `past` tokens. New keys start at offset `past`.
-        if (past + new_len > c.max_seq) {
-            fprintf(stderr, "[dflash] KV overflow past=%d new=%d max=%d\n", past, new_len, c.max_seq);
-            return false;
-        }
-        cu(cudaMemcpyAsync(s.k_cache[L] + (size_t)past * kvdim, s.k_new,
-                           (size_t)new_len * kvdim * sizeof(bf16), cudaMemcpyDeviceToDevice, st),
-           "k append");
-        cu(cudaMemcpyAsync(s.v_cache[L] + (size_t)past * kvdim, s.v_new,
-                           (size_t)new_len * kvdim * sizeof(bf16), cudaMemcpyDeviceToDevice, st),
-           "v append");
+        // K/V are already in the cache at offset `past` -- attend over the full past+new.
         const int kv_len = past + new_len;
         const int window = (L < (int)c.sliding_layers.size() && c.sliding_layers[L])
                                ? c.sliding_window : 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1906,8 +1906,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // The target overwrites dflash_hidden while capturing verify row zero. Preserve the
         // accepted suffix before running that target forward concurrently with the independent
         // draft stream. The initial full-context buffer is separate and needs no copy.
+        // Only the token-loop path runs verify row zero concurrently with the draft and so needs
+        // the accepted suffix preserved. The compact path runs the draft to completion first, so
+        // nothing can overwrite dflash_hidden underneath it and the copy plus its full-device
+        // synchronize are pure overhead.
         const void* draft_hidden = target_hidden;
-        if (target_hidden == s.dflash_hidden) {
+        if (!compact_verify && target_hidden == s.dflash_hidden) {
             cu(cudaMemcpyAsync(th_scratch, target_hidden,
                                (size_t)th_len * row_stride * sizeof(bf16),
                                cudaMemcpyDeviceToDevice, s.stream), "dflash overlap stash");

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1241,6 +1241,9 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     float* router_logits = a.alloc<float>((size_t)N * E);
     float* moe_h = a.alloc<float>((size_t)N * topk * ffn);
     float* moe_out = a.alloc<float>((size_t)N * H);
+    // Dedicated hidden scratch for the shared expert. It used to borrow moe_h, which is the one
+    // thing that stopped the shared branch from running concurrently with the routed one.
+    float* shared_h = a.alloc<float>((size_t)N * ffn);
     float* logits = a.alloc<float>((size_t)N * c.vocab);
     int* out_ids = a.alloc<int>(N);
     const size_t q81_stride_max = kernels::llama_q8_1_bytes(std::max(H, lvdim));
@@ -1273,6 +1276,18 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     static thread_local const void* verify_head_key = nullptr;
     static thread_local signed char* verify_head_i8 = nullptr;
     static thread_local float* verify_head_scale = nullptr;
+    static thread_local cudaEvent_t ev_fork = nullptr;
+    static thread_local cudaEvent_t ev_join = nullptr;
+    // Off-critical-path stream for the shared expert. Empty stream_k means no overlap is possible.
+    static const bool shared_stream_on = [] {
+        const char* e = getenv("SPARKINFER_DFLASH_SHARED_STREAM");
+        return !(e && e[0] == '0');
+    }();
+    const bool fork_shared = shared_stream_on && s.stream_k && s.stream_k != s.stream;
+    if (fork_shared && !ev_fork) {
+        pf_cu(cudaEventCreateWithFlags(&ev_fork, cudaEventDisableTiming), "verify fork event");
+        pf_cu(cudaEventCreateWithFlags(&ev_join, cudaEventDisableTiming), "verify join event");
+    }
     if (!ph_ids) {
         pf_cu(cudaHostAlloc(&ph_ids, 16 * sizeof(int), cudaHostAllocDefault), "verify host ids");
         pf_cu(cudaHostAlloc(&ph_pos, 16 * sizeof(int), cudaHostAllocDefault), "verify host pos");
@@ -1322,6 +1337,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         }
         quant_rows(in, k);
         return kernels::launch_mmvq_rows(type, q81, w, out, N, no, k, st);
+    };
+    // proj() on an arbitrary stream. Callers must have `in` already quantized into q81 (checked at
+    // each call site), because quantizing here would write shared scratch off the main stream.
+    auto proj_on = [&](cudaStream_t ps, const bf16* in, const void* w, int type, bf16* out,
+                       int no, int k) -> bool {
+        if (type == 0) return kernels::launch_gemv_rows(in, w, out, N, no, k, ps);
+        if (type != 8 && type != 12 && type != 14) return false;
+        if (q81_src != in || q81_k != k) { quant_rows(in, k); ps = st; }
+        return kernels::launch_mmvq_rows(type, q81, w, out, N, no, k, ps);
     };
     auto capture = [&](int layer) {
         if (!capture_dst || !capture_layers || n_capture <= 0) return;
@@ -1389,14 +1413,30 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             bf16* rv = rec_v + (size_t)L * N * lvdim;
             bf16* ra = rec_a + (size_t)L * N * vh;
             bf16* rb = rec_b + (size_t)L * N * vh;
+            // wqkv, wqkv_gate and alpha/beta are three independent reads of the same xn. wqkv is
+            // the only one big enough to fill the device; wqkv_gate and the fused alpha/beta run
+            // at ~3 and ~0.4 CTAs per SM, so serializing them behind wqkv just adds their latency
+            // to the chain. Push the two small ones onto stream_k. Safe only once q81 already
+            // holds xn -- otherwise proj() would have to quantize, which writes shared scratch.
+            const bool fork_gdn = fork_shared && q81_src == xn && q81_k == H;
+            cudaStream_t gst = fork_gdn ? s.stream_k : st;
+            if (fork_gdn) {
+                pf_cu(cudaEventRecord(ev_fork, st), "verify gdn fork");
+                pf_cu(cudaStreamWaitEvent(s.stream_k, ev_fork, 0), "verify gdn fork wait");
+            }
+            supported = proj(xn, w.wqkv, w.wqkv_type, rq, lqkv, H);
             // alpha and beta are v_heads-wide reads of the same xn — two launches whose cost is
             // almost entirely launch/graph-node latency. One fused launch, same per-row math.
             const bool ab_fused = w.ssm_alpha_type == 0 && w.ssm_beta_type == 0 &&
-                kernels::launch_gemv_rows2(xn, w.ssm_alpha, w.ssm_beta, ra, rb, N, vh, vh, H, st);
-            supported = proj(xn, w.wqkv, w.wqkv_type, rq, lqkv, H) &&
-                        proj(xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H) &&
-                        (ab_fused || (proj(xn, w.ssm_alpha, w.ssm_alpha_type, ra, vh, H) &&
-                                      proj(xn, w.ssm_beta, w.ssm_beta_type, rb, vh, H)));
+                kernels::launch_gemv_rows2(xn, w.ssm_alpha, w.ssm_beta, ra, rb, N, vh, vh, H, gst);
+            supported = supported &&
+                        proj_on(gst, xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H) &&
+                        (ab_fused || (proj_on(gst, xn, w.ssm_alpha, w.ssm_alpha_type, ra, vh, H) &&
+                                      proj_on(gst, xn, w.ssm_beta, w.ssm_beta_type, rb, vh, H)));
+            if (fork_gdn) {
+                pf_cu(cudaEventRecord(ev_join, s.stream_k), "verify gdn join");
+                pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify gdn join wait");
+            }
             if (!supported) break;
             const bf16* conv_live = static_cast<const bf16*>(s.lin_conv_state) +
                 (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
@@ -1409,9 +1449,21 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                                                 c.linear_head_dim, c.rms_eps, st);
             supported = proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
         } else {
+            // Same shape of win as the GDN block: wq is 2*qdim rows and saturates, while wk and wv
+            // are kvdim rows apiece and run at well under one CTA per SM.
+            const bool fork_attn = fork_shared && q81_src == xn && q81_k == H;
+            cudaStream_t ast = fork_attn ? s.stream_k : st;
+            if (fork_attn) {
+                pf_cu(cudaEventRecord(ev_fork, st), "verify attn fork");
+                pf_cu(cudaStreamWaitEvent(s.stream_k, ev_fork, 0), "verify attn fork wait");
+            }
             supported = proj(xn, w.wq, w.wq_type, b8, 2 * qdim, H) &&
-                        proj(xn, w.wk, w.wk_type, kf, kvdim, H) &&
-                        proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+                        proj_on(ast, xn, w.wk, w.wk_type, kf, kvdim, H) &&
+                        proj_on(ast, xn, w.wv, w.wv_type, vf, kvdim, H);
+            if (fork_attn) {
+                pf_cu(cudaEventRecord(ev_join, s.stream_k), "verify attn join");
+                pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify attn join wait");
+            }
             if (!supported || !w.q_has_gate) break;
             char* kp = static_cast<char*>(s.kv->k_pool()) +
                        (size_t)L * s.kv->layer_stride_elems() * kv_elem;
@@ -1459,6 +1511,22 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                     w.shared_gate_qtype, w.shared_up_qtype, w.shared_down_qtype);
             supported = false; break;
         }
+        // The routed and shared experts read the same hn/q81 and write disjoint outputs (routed vs
+        // shared), so they are independent right up to the add_rmsnorm3 that sums them. They were
+        // nonetheless serialized on one stream, which put the shared branch fully on the critical
+        // path: its five launches never exceed ~3 CTAs per SM and cost ~10 us a layer, while the
+        // routed branch it waits behind saturates the device (gate_up and down each launch 12288
+        // CTAs). Fork the shared branch onto stream_k -- the stream AR decode already hides this
+        // same kernel on -- so it fills the routed kernels' gaps instead of extending the chain.
+        // Identical kernels on identical inputs in the same per-branch order: bit-identical output.
+        const bool shared_on_k = fork_shared && w.shared_gate_inp &&
+                                 q81_src == hn && q81_k == H;
+        cudaStream_t sst = shared_on_k ? s.stream_k : st;
+        if (shared_on_k) {
+            pf_cu(cudaEventRecord(ev_fork, st), "verify moe fork");
+            pf_cu(cudaStreamWaitEvent(s.stream_k, ev_fork, 0), "verify moe fork wait");
+        }
+        // Routed branch first so the saturating work is enqueued ahead of the filler.
         supported = kernels::launch_gemv_rows_f32(hn, w.router_w, router_logits,
                                                   N, E, H, st);
         kernels::launch_moe_router(router_logits, expert_ids, expert_w, nullptr,
@@ -1468,14 +1536,24 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             moe_h, moe_out, N, topk, H, ffn, q81, st);
 
         if (w.shared_gate_inp) {
-            supported = proj(hn, w.shared_gate_inp, w.shared_gate_inp_type, gate_raw, 1, H);
-            kernels::launch_qwen36_sigmoid_rows(gate_raw, gate_w, N, st);
+            // q81 already holds hn (the add_rmsnorm2 fusion above wrote it), so this never has to
+            // quantize -- which is what makes it safe to issue off the main stream.
+            supported = supported &&
+                (w.shared_gate_inp_type == 0
+                     ? kernels::launch_gemv_rows(hn, w.shared_gate_inp, gate_raw, N, 1, H, sst)
+                     : kernels::launch_mmvq_rows(w.shared_gate_inp_type, q81, w.shared_gate_inp,
+                                                 gate_raw, N, 1, H, sst));
+            kernels::launch_qwen36_sigmoid_rows(gate_raw, gate_w, N, sst);
         } else {
-            pf_cu(cudaMemsetAsync(gate_w, 0, (size_t)N * sizeof(float), st), "verify shared gate");
+            pf_cu(cudaMemsetAsync(gate_w, 0, (size_t)N * sizeof(float), sst), "verify shared gate");
         }
         kernels::launch_shared_expert_q8_mmvq_rows(
             q81, w.shared_gate_q, w.shared_up_q, w.shared_down_q, gate_w,
-            shared, moe_h, sg, H, ffn, N, st);
+            shared, shared_h, sg, H, ffn, N, sst);
+        if (shared_on_k) {
+            pf_cu(cudaEventRecord(ev_join, s.stream_k), "verify moe join");
+            pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify moe join wait");
+        }
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
         kernels::launch_add_rmsnorm3_q8_rows(h, routed, shared, next_norm, x, xn, q81,
                                              N, H, c.rms_eps, st);


### PR DESCRIPTION
## Summary

The DFlash compact block verify ran its entire ~810-node graph on a single stream, so three sets of mutually independent projections were serialized behind each other. The largest is the shared expert: it reads the same `hn`/`q81` as the routed expert, writes a disjoint output, and the two only meet at the `add_rmsnorm3` that sums them — yet it sat on the critical path costing ~10 us a layer while the routed branch it waited behind saturates the device. AR decode already hides this same kernel on `stream_k`; the verify now does too. The one thing that had blocked it was that both branches used `moe_h` as scratch, so the shared branch gets its own. The same fork is applied to the two smaller independent projection groups (GDN `wqkv_gate` + fused alpha/beta behind `wqkv`, and attention `wk`/`wv` behind `wq`).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 895.22 |
| after (this PR) | 940.50 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

```text
# qwen3_gguf_dflash_bench, Qwen3.6-35B-A3B UD-Q4_K_M + Qwen3.6-35B-A3B-DFlash,
# 128 new tokens, bench/scripts/eval_text.txt prompt ids (101 tokens), RTX 5090.
# Two trees on one box, alternating runs.

===== main (3dde0bc) =====
prompt_tokens : 101
gen_tokens    : AR=128 DFlash=128
AR            : 298.61 tok/s  (wall 0.429s)
DFlash        : 895.22 tok/s  (decode 0.143s, ttft 0.195s, wall 0.342s)
mean_accept t : 5.333  (steps=24)
METRIC AR_TPS 298.6142
METRIC DFLASH_TPS 895.2224
METRIC MEAN_ACCEPT 5.3333

===== this PR =====
prompt_tokens : 101
gen_tokens    : AR=128 DFlash=128
AR            : 298.42 tok/s  (wall 0.429s)
DFlash        : 940.50 tok/s  (decode 0.136s, ttft 0.196s, wall 0.335s)
mean_accept t : 5.333  (steps=24)
METRIC AR_TPS 298.4230
METRIC DFLASH_TPS 940.4995
METRIC MEAN_ACCEPT 5.3333

# Host-side phase timers, mean over the 24 decode steps:
#   main    step 5.968 ms = draft 1.156 + verify 4.803
#   this PR step 5.658 ms = draft 1.147 + verify 4.491

# Gates
bench/scripts/dflash_accuracy.sh   METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
dflash_gdn_checkpoint_gpu_test     [PASS] DFlash GDN checkpoints and compact commits equal serial state
qwen3_gguf_bench Qwen3.6 decode    main 532.85 -> PR 532.78 tok/s (-0.01%)
```