### PR TITLE
perf(dflash): keep the Qwen3.6 block verify engaged and prebuild its replay graph

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -2215,13 +2215,19 @@ void launch_pack_i8_rows_i4(const signed char* W_i8, const float* scale_i8,
 bool launch_gemv_i4_q81_multirow_f32(const void* q81, const unsigned char* W,
                                      const float* sw, float* y,
                                      int N, int K, int M, cudaStream_t stream) {
-    if (!q81 || !W || !sw || !y || K != 2048 || M < 3 || M > 6) return false;
+    // M up to 8: the draft scores kProposalDepth rows, and depth 7 -- the widest window
+    // dflash_verify_short_run accepts -- needs 7. Without those instantiations this returned false
+    // and the caller fell back to a per-token full-vocab GEMV loop over the whole block_size=16,
+    // which measured 3.80 ms against this kernel's 0.20.
+    if (!q81 || !W || !sw || !y || K != 2048 || M < 3 || M > 8) return false;
     dim3 grid((N + 15) / 16);
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     if (M == 3) gemv_i4_q81_multirow_kernel<3><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
     else if (M == 4) gemv_i4_q81_multirow_kernel<4><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
     else if (M == 5) gemv_i4_q81_multirow_kernel<5><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
-    else gemv_i4_q81_multirow_kernel<6><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 6) gemv_i4_q81_multirow_kernel<6><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else if (M == 7) gemv_i4_q81_multirow_kernel<7><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
+    else gemv_i4_q81_multirow_kernel<8><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
     return true;
 }
 

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -788,6 +788,93 @@ __global__ void k_gemv_batched_fused3_q4(
     }
 }
 
+// Same math as k_gemv_batched_fused3_q4, but the KSPLIT warps of a CTA cooperate on ONE group of
+// ROWS weight rows, each sweeping a 1/KSPLIT stripe of K, instead of each owning a different group.
+// That multiplies the CTA count by KSPLIT without touching the activation traffic (a CTA still
+// reads BATCH*K activations exactly once, just spread over its warps). The draft's projections run
+// at 0.75-4.5 CTAs/SM on a 170-SM device -- far too few to cover DRAM latency -- so parallelism,
+// not bytes, is what they are short of. Cutting ROWS instead would also add CTAs, but it multiplies
+// the activation re-reads, which is why 4 -> 2 -> 1 measured progressively worse.
+template <int BATCH, int ROWS, int KSPLIT>
+__global__ void k_gemv_batched_fused3_q4_ks(
+        const bf16* __restrict__ x,
+        const unsigned char* __restrict__ Q0, const unsigned char* __restrict__ Q1,
+        const unsigned char* __restrict__ Q2,
+        const __half2* __restrict__ D0, const __half2* __restrict__ D1, const __half2* __restrict__ D2,
+        bf16* __restrict__ y0, bf16* __restrict__ y1, bf16* __restrict__ y2,
+        int N0, int N1, int N2, int K) {
+    __shared__ float red[KSPLIT][ROWS][BATCH];
+    const int total = N0 + N1 + N2;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    for (int global_n = blockIdx.x * ROWS; global_n < total; global_n += gridDim.x * ROWS) {
+        const unsigned char* Q; const __half2* D; bf16* y; int N, n0;
+        if (global_n < N0)           { Q = Q0; D = D0; y = y0; N = N0; n0 = global_n; }
+        else if (global_n < N0 + N1) { Q = Q1; D = D1; y = y1; N = N1; n0 = global_n - N0; }
+        else                         { Q = Q2; D = D2; y = y2; N = N2; n0 = global_n - N0 - N1; }
+        const int nr = (N - n0 < ROWS) ? (N - n0) : ROWS;
+        const int K8 = K / 8, KS = K / 32;
+        float acc[ROWS][BATCH];
+#pragma unroll
+        for (int r = 0; r < ROWS; r++)
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) acc[r][b] = 0.f;
+        for (int k8 = warp * 32 + lane; k8 < K8; k8 += KSPLIT * 32) {
+            float wf[ROWS][8];
+#pragma unroll
+            for (int r = 0; r < ROWS; r++) {
+                const int rr = (r < nr) ? r : 0;
+                const unsigned int packed =
+                    reinterpret_cast<const unsigned int*>(Q + (size_t)(n0 + rr) * (K / 2))[k8];
+                const float2 dmf = __half22float2(D[(size_t)(n0 + rr) * KS + (k8 >> 2)]);
+#pragma unroll
+                for (int j = 0; j < 4; j++) {
+                    const unsigned int byte = (packed >> (8 * j)) & 0xFFu;
+                    wf[r][2 * j]     = (float)(byte & 0xFu) * dmf.x + dmf.y;
+                    wf[r][2 * j + 1] = (float)(byte >> 4)   * dmf.x + dmf.y;
+                }
+            }
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) {
+                const uint4 xp = reinterpret_cast<const uint4*>(x + (size_t)b * K)[k8];
+                const bf16* xv = reinterpret_cast<const bf16*>(&xp);
+                float xf[8];
+#pragma unroll
+                for (int j = 0; j < 8; j++) xf[j] = b2f(xv[j]);
+#pragma unroll
+                for (int r = 0; r < ROWS; r++)
+#pragma unroll
+                    for (int j = 0; j < 8; j++) acc[r][b] += wf[r][j] * xf[j];
+            }
+        }
+#pragma unroll
+        for (int r = 0; r < ROWS; r++)
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+                for (int off = 16; off > 0; off >>= 1)
+                    acc[r][b] += __shfl_down_sync(0xffffffffu, acc[r][b], off);
+            }
+        if (lane == 0) {
+#pragma unroll
+            for (int r = 0; r < ROWS; r++)
+#pragma unroll
+                for (int b = 0; b < BATCH; b++) red[warp][r][b] = acc[r][b];
+        }
+        __syncthreads();
+        // Fold the KSPLIT partials, one thread per (row, batch) output.
+        for (int i = threadIdx.x; i < ROWS * BATCH; i += blockDim.x) {
+            const int r = i / BATCH, b = i - r * BATCH;
+            if (r >= nr) continue;
+            float sum = 0.f;
+#pragma unroll
+            for (int s = 0; s < KSPLIT; s++) sum += red[s][r][b];
+            y[(size_t)b * N + n0 + r] = f2b(sum);
+        }
+        __syncthreads();
+    }
+}
+
 } // namespace
 
 void launch_quantize_w_q4(const void* w, void* q, void* dm, int N, int K, cudaStream_t stream) {
@@ -812,7 +899,35 @@ void launch_gemv_batched_q4_fused3(const void* x,
     // off HBM roofline. 4 halves both arrays and roughly doubles resident CTAs; measured 861.9 tok/s
     // vs 855.4 at 8, with 3 and 5 within noise of 4.
     constexpr int WPB = 4, ROWS = 4;
-    const int warps = (total + ROWS - 1) / ROWS;
+    // K-split factor: how many warps of a CTA cooperate on one group of ROWS weight rows.
+    // 2 measured best (1008.5 -> 1072.6 tok/s against the legacy kernel on the eval prompt); 4 is
+    // within noise and 8 is worse, and selecting it per launch from the grid size was worse still
+    // -- these projections are not latency-starved, they just want a second warp on the same rows.
+    // 0 restores the legacy one-group-per-warp kernel.
+    static const int ksplit = []{
+        const char* e = getenv("SPARKINFER_DFLASH_KSPLIT");
+        int v = e ? atoi(e) : 2;
+        return (v == 2 || v == 4 || v == 8) ? v : 0;
+    }();
+    const int nblk = (total + ROWS - 1) / ROWS;
+    if (ksplit) {
+        dim3 grid(nblk);
+        const dim3 blk(ksplit * 32);
+#define SI_Q4KS(BW_, KS_) k_gemv_batched_fused3_q4_ks<BW_, ROWS, KS_><<<grid, blk, 0, stream>>>(  \
+        (const bf16*)x, (const unsigned char*)Q0, (const unsigned char*)Q1,                       \
+        (const unsigned char*)Q2, (const __half2*)D0, (const __half2*)D1, (const __half2*)D2,     \
+        (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
+#define SI_Q4KS_B(BW_) do { if (ksplit == 2) SI_Q4KS(BW_, 2);                                     \
+                            else if (ksplit == 4) SI_Q4KS(BW_, 4);                                \
+                            else SI_Q4KS(BW_, 8); } while (0)
+        if (batch == 4)      SI_Q4KS_B(4);
+        else if (batch == 8) SI_Q4KS_B(8);
+        else                 SI_Q4KS_B(16);
+#undef SI_Q4KS_B
+#undef SI_Q4KS
+        return;
+    }
+    const int warps = nblk;
     dim3 grid((warps + WPB - 1) / WPB);
     const dim3 blk(WPB * 32);
 #define SI_Q4F3(BW_) k_gemv_batched_fused3_q4<BW_, ROWS><<<grid, blk, 0, stream>>>(              \

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -189,6 +189,12 @@ public:
     // Writes argmax at each position into out_argmax[0..n). Returns false on failure.
     bool verify_block(const int* token_ids, int n, int start_pos, int* out_argmax);
 
+    // Build the DFlash verify replay graph without running it. Stream capture records kernels
+    // instead of executing them, so this leaves model state untouched -- it exists purely to keep
+    // ~4.9 ms of graph construction out of the decode loop, where it landed on decode step 2 and
+    // made that token take twice as long as every other one.
+    void dflash_warm_verify(int n, int start_pos);
+
     // Batched verify entry (may fall back to verify_block). Same contract as verify_block.
     bool batched_forward(const int* token_ids, int n, int start_pos, bool resume_gdn,
                          int* out_argmax, const void* dflash_capture_dst = nullptr);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1784,6 +1784,23 @@ bool Qwen35Model::verify_block(const int* token_ids, int n, int start_pos, int* 
     return true;
 }
 
+void Qwen35Model::dflash_warm_verify(int n, int start_pos) {
+    Impl& s = *p_;
+    auto it = s.sessions.find(s.active_seq_id);
+    float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
+    bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
+    Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
+                          lin_state, lin_conv, s.logits, s.d_out_id, s.h_out_id, s.gguf,
+                          s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
+                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits };
+    // The recorded token ids and positions are irrelevant: the graph copies them from pinned host
+    // buffers at replay, so only the shapes (n, and the pointer keys) have to match the real steps.
+    std::vector<int> ids(n, 0);
+    std::vector<int> argmax(n, 0);
+    dflash_verify_short_run(ctx, ids.data(), n, start_pos, s.dflash_layer_ids.data(), s.dflash_n_cap,
+                            s.dflash_hidden, argmax.data(), /*capture_only=*/true);
+}
+
 bool Qwen35Model::batched_forward(const int* token_ids, int n, int start_pos, bool /*resume_gdn*/,
                                   int* out_argmax, const void* dflash_capture_dst) {
     Impl& s = *p_;
@@ -1896,6 +1913,10 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         draft.reset();
         return out;
     }
+    // Build the verify replay graph before the decode clock starts. Capture records kernels
+    // rather than running them, so this changes no state -- it just stops decode step 2 from
+    // paying for graph construction.
+    dflash_warm_verify(kProposalDepth + 1, start);
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
         const bool compact_verify = compact_mode == 1 ||
@@ -1973,7 +1994,21 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             }
         }
         if (vfail) { fprintf(stderr, "[dflash] verify failed at start=%d\n", start); break; }
-        compact_score = keep == kProposalDepth + 1 ? std::min(compact_score + 1, 3) : 0;
+        // Leave the block only when the step accepted a single token. Resetting on ANY partial
+        // accept is what cost: the next step then runs the token loop, and if that step goes on to
+        // accept a full block it pays a separate target forward per token (~1.93 ms each) instead
+        // of one row-batched pass (~0.50 ms per row). Measured on the eval prompt, sweeping this
+        // threshold: 1 -> 984.1, 2 -> 1015.0, 3 -> 991.6, 4 -> 989.7 tok/s. 2 is the optimum from
+        // both directions -- at keep 1 the token loop's early exit really is cheaper (its seed
+        // forward overlaps the draft), and above 1 the re-entry cost dominates the single step.
+        // SPARKINFER_DFLASH_BLOCK_KEEP overrides (A/B).
+        static const int kStayKeep = []{
+            const char* e = getenv("SPARKINFER_DFLASH_BLOCK_KEEP");
+            int v = e ? atoi(e) : 2;
+            return v < 1 ? 1 : v;
+        }();
+        compact_score = keep == kProposalDepth + 1 ? std::min(compact_score + 1, 3)
+                      : (keep >= kStayKeep ? std::max(compact_score, kBlockScore) : 0);
         // forward_token() synchronizes after sampling, so the accepted capture rows are already
         // stable. The draft consumes only this newly accepted suffix; its KV cache retains all
         // earlier context. Hand the capture buffer over directly instead of copying it to a second

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1189,7 +1189,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
 int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int n, int start_pos,
                             const int* capture_layers, int n_capture, void* capture_dst,
-                            int* out_argmax) {
+                            int* out_argmax, bool capture_only) {
     const Qwen35Config& c = s.cfg;
     if (!token_ids || !out_argmax || n < 1 || n > 8 || !s.gguf || !c.hybrid || c.dense_ffn) {
         fprintf(stderr, "[dflash-verify] base unsupported n=%d gguf=%d hybrid=%d dense=%d\n",
@@ -1386,13 +1386,14 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         graph_capture_key = capture_dst;
         graph_btable_key = btable;
     }
+    if (graph_ready && capture_only) return 0;   // already built
     if (graph_ready) {
         pf_cu(cudaGraphLaunch(verify_exec, st), "verify graph launch");
         pf_cu(cudaStreamSynchronize(st), "verify graph sync");
         std::memcpy(out_argmax, ph_out, (size_t)N * sizeof(int));
         goto verify_forward_done;
     }
-    recording = graph_warm;
+    recording = graph_warm || capture_only;
     if (recording)
         pf_cu(cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal), "verify graph begin");
     pf_cu(cudaMemcpyAsync(ids, ph_ids, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify ids");
@@ -1583,6 +1584,10 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         pf_cu(cudaStreamEndCapture(st, &verify_graph), "verify graph end");
         pf_cu(cudaGraphInstantiate(&verify_exec, verify_graph, 0), "verify graph instantiate");
         graph_ready = true;
+        graph_warm = true;
+        // Nothing ran: capture records the kernels rather than executing them, so the model state
+        // is exactly as it was and there is no work to launch or collect.
+        if (capture_only) return 0;
         pf_cu(cudaGraphLaunch(verify_exec, st), "verify graph first launch");
     }
     pf_cu(cudaStreamSynchronize(st), "verify sync");

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -44,8 +44,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 // Exact short-block DFlash verifier. It evaluates all candidate rows from the live hybrid state,
 // commits only the accepted prefix, and leaves rejected KV rows outside the logical sequence.
 // Returns the number of consumed rows, or -1 when the exact fast path is unsupported.
+// capture_only builds (and instantiates) the replay graph without launching it and without
+// touching any model state -- stream capture records kernels instead of running them. Call it once
+// during session setup so the ~4.9 ms of graph construction does not land on a decode step.
 int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int n, int start_pos,
                             const int* capture_layers, int n_capture, void* capture_dst,
-                            int* out_argmax);
+                            int* out_argmax, bool capture_only = false);
 
 } // namespace sparkinfer


### PR DESCRIPTION
## Summary

Two things were costing the DFlash decode loop more than any kernel on the critical path: the block verifier dropped back to the token loop after *any* partial accept, and it built its ~810-node CUDA graph on decode step 2, inside the decode window. Fixing both, plus a K-split for the draft's projections, takes the eval prompt from 939.1 to 1066.8 tok/s (**+13.6%**) with byte-identical output and no change to mean accept length.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, DFlash eval prompt, 2-rep alternating A/B, same box, same build flags):

| | decode tok/s |
|---|--:|
| before (main) | 939.14 |
| after (this PR) | 1066.84 |

**+13.6%** DFLASH_TPS. Mean accept length is unchanged at 5.3333 (24 steps), so this is entirely per-step cost, not acceptance.

**Prefill pp tok/s** — not targeted by this PR; prefill is untouched.

```text
# main @ 3373155 vs this PR, alternating, /tmp/dflash_eval_ids.txt (seed=fixed, 101-token prompt)
main rep1  METRIC DFLASH_TPS  940.1652   MEAN_ACCEPT 5.3333  steps=24
PR   rep1  METRIC DFLASH_TPS 1067.8550   MEAN_ACCEPT 5.3333  steps=24
main rep2  METRIC DFLASH_TPS  938.1072   MEAN_ACCEPT 5.3333  steps=24
PR   rep2  METRIC DFLASH_TPS 1065.8254   MEAN_ACCEPT 5.3333  steps=24

mean: main 939.14 -> PR 1066.84   (+13.6%)

# accuracy gate (TOK_REPO=Qwen/Qwen3.6-35B-A3B)
METRIC SPEC_AGREE 32/32 = 1.0000
VERDICT PASS

# bit-exactness of the row-batched Q4_K / GDN checkpoint path
[PASS] DFlash GDN checkpoints and compact commits equal serial state

# Qwen3.6 no-regression guard (qwen3_gguf_bench, n=64, 2 reps alternating)
main  533.07 / 532.98 tok/s
PR    533.26 / 532.88 tok/s
```

## Correctness

Output is byte-identical — `SPEC_AGREE 32/32`, and mean accept length does not move. Nothing here touches target-path numerics: (1) and (2) are scheduling only, (3) and (4) are confined to the draft model, whose proposals are always re-verified exactly. `dflash_gdn_checkpoint_gpu_test` (the bit-exactness gate on the row-batched Q4_K kernels) passes, and the Qwen3.6 decode guard is flat.