### PR TITLE
feat(eval): apply eval:* labels on dflash PRs alongside eval-dflash:*

### DIFF
--- a/eval/pr_dflash_bot.py
+++ b/eval/pr_dflash_bot.py
@@ -991,6 +991,12 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
         return
     strip_dflash_eval_labels(repo, num)
     arb.add_label(repo, num, f"{EVAL_PREFIX}{label}")
+    # Also apply the AR bot's eval:* convention (same tier value) — SN74 scoring reads eval:*
+    # tiers, not eval-dflash:*, and the AR bot no longer runs on cron to post them itself. Without
+    # this a DFlash-verified speedup would be invisible to anything that only looks at eval:*.
+    for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
+        arb.remove_label(repo, num, lab)
+    arb.add_label(repo, num, f"eval:{label}")
     arb.gh(["pr", "comment", str(num), "-R", repo, "--body", body])
     if res.get("ok"):
         upload_dflash_eval_log(repo, num, title, commit, res)


### PR DESCRIPTION
## Summary
- SN74 scoring reads `eval:*` tier labels, not `eval-dflash:*`.
- The AR bot used to be the only thing posting `eval:*` labels, but it's retired from cron now that DFlash is the sole active scoring path — meaning a DFlash-verified speedup currently gets `eval-dflash:XL/L/M/S/XS` but never the `eval:*` label anything reading the old convention expects, so it's invisible to that scoring path entirely.
- Mirrors the AR bot's own label lifecycle: strip any stale `eval:*` label before applying the current tier value, same as `strip_dflash_eval_labels()` already does for `eval-dflash:*`.
- All `eval:*` label values already exist in the repo (`XL`/`L`/`M`/`S`/`XS`/`none`/`REJECT`/...), created for the AR bot originally — no new labels need creating.

## Test plan
- [x] `python3 -m py_compile eval/pr_dflash_bot.py`
- [x] Confirmed `eval:*` labels already exist via `gh label list`
- [ ] Observe the next dflash eval round apply both `eval-dflash:X` and `eval:X` to a PR