### PR TITLE
fix(prefill): missing __syncthreads() on sw[] reuse in the GDN conv L2-norm loops (incl. DFlash draft conv)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -351,6 +351,10 @@ __global__ void pf_gdn_conv_kernel(const __nv_bfloat16* __restrict__ qkv,
             }
             __syncthreads();
             cval *= sw[0];
+            // WAR guard: the next token's `sw[t >> 5] = ss` store must not begin
+            // until every warp has read this token's sw[0] — without this barrier a
+            // lagging warp can pick up token tok+1's partial sums as its normalizer.
+            __syncthreads();
         }
         out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
     }
@@ -492,6 +496,11 @@ __global__ void pf_gdn_conv_tile_kernel(const __nv_bfloat16* __restrict__ qkv,
             }
             __syncthreads();
             cval *= sw[0];
+            // WAR guard (same as pf_gdn_conv_kernel): keep the next tt iteration's
+            // `sw[t >> 5] = ss` store from racing this iteration's sw[0] read in
+            // lagging warps — #pragma unroll makes the next store eligible to issue
+            // as soon as the barrier above releases.
+            __syncthreads();
         }
         out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
     }
@@ -738,6 +747,11 @@ __global__ void df_gdn_conv_checkpoint_kernel(
             }
             __syncthreads();
             cval *= sw[0];
+            // WAR guard (same as pf_gdn_conv_kernel / pf_gdn_conv_tile_kernel): the
+            // next tok's `sw[t >> 5] = ss` store is unordered against lagging warps'
+            // read of this tok's sw[0] without a trailing barrier — a warp that loses
+            // the race normalizes with the NEXT token's partial sum.
+            __syncthreads();
         }
         out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
         if constexpr (WRITE_CHECKPOINT) {


### PR DESCRIPTION
## Summary

Correctness fix: three GDN causal-conv kernels in
`kernels/csrc/cuda/fused/batched_prefill.cu` reduce the per-token q/k L2 normalizer
through shared `sw[]` with no barrier between one token's *read* of `sw[0]` and the
next token's *write* of `sw[t >> 5]` — a loop-carried write-after-read hazard on shared
memory. Since this was first filed (#665), the merged #689 **copied the same pattern
into the DFlash draft conv** (`df_gdn_conv_checkpoint_kernel`, both instantiations), so
the hazard now also sits in the scored speculative-decode path. This adds the missing
`__syncthreads()` after the `cval *= sw[0]` read in all three kernels (the new
`pf_gdn_conv_par_kernel` is one token per block — no loop reuse, not affected). No
shapes, defaults, or arithmetic change.

## The race

Per token, `do_norm` blocks (all q/k heads):

```cpp
if ((t & 31) == 0) sw[t >> 5] = ss;   // (1) warp partial sums
__syncthreads();
if (t < 32) { ... if (t == 0) sw[0] = rsqrtf(vv + eps); }  // (2) normalizer
__syncthreads();
cval *= sw[0];                        // (3) all warps read
// no barrier: next iteration's (1) can overwrite sw[0] while lagging warps sit at (3)
```

A lagging warp normalizes token `t` with a partial sum of token `t+1` — a wrong q/k
normalizer feeding the GDN recurrence. `#pragma unroll` on the tile/token loops lets
the next store issue the moment the barrier before (3) releases. Nothing in the
independent-thread-scheduling model orders it; current numbers are scheduling luck,
same class as the merged #604/#608 boundary fixes.

Reachability: every hybrid batched prefill (Qwythos-9B: 24 GDN layers x ceil(N/16)
tiles x 32 q/k head-blocks per prompt) plus, since #689, every DFlash draft
conv pass.

## Verification (hardware disclosed: RTX 5070 Ti 16GB, WSL2, CUDA 12.8, sm_120 build)

This is a correctness PR, not a perf PR — no speedup is claimed and the proof section
is intentionally omitted.

- ctest **10/10** (md5-distinct binaries vs the main build).
- `qwen3_gguf_prefill_check`, scored Qwythos-9B Q4_K_M, main vs patched — identical at
  every length: P=96 (8/8, KL 0.03939, seed 196), P=320 (8/8, 0.00713, 82),
  P=513 (7/8, 0.01330, 82), P=1031 (8/8, 0.00617, 68).
- Perf-neutral: interleaved `qwen3_gguf_bench` @ctx=4096 — decode tg 161.9–166.5 and
  prefill pp 11245–11266 tok/s, main vs patched within 0.1%; CB mixed-load
  `long_ttft_s` 2.209/2.214/2.223 vs 2.188/2.208/2.218 (noise).
- compute-sanitizer cannot run under WSL/WDDM ("Failed to initialize WDDM debugger
  interface"); on a bare-metal Linux box racecheck should flag main and pass this
  branch: `compute-sanitizer --tool racecheck ./build/runtime/qwen3_gguf_prefill_check <qwythos.gguf> 96 4`