### PR TITLE
docs(eval): update dflash cron schedule docs to hourly

### DIFF
--- a/eval/README.md
+++ b/eval/README.md
@@ -200,9 +200,9 @@ eval/setup_labels.sh                                  # creates eval-dflash:* + 
 ./eval/run_dflash_bot.sh --only-prs 636 --reeval       # force one PR
 ```
 
-**Schedule every 2 hours on odd hours** (01:00, 03:00, …; shares `/tmp/sparkinfer_bot.lock` with the AR bot):
+**Schedule every hour, on the hour** (shares `/tmp/sparkinfer_bot.lock` with the AR bot):
 ```bash
-crontab -l 2>/dev/null; echo "0 1-23/2 * * * $PWD/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1" | crontab -
+crontab -l 2>/dev/null; echo "0 * * * * $PWD/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1" | crontab -
 ```
 Pinned GPU only; never rents. If the pin is down → `--labels-only` reconcile.
 

--- a/eval/run_dflash_cron.sh
+++ b/eval/run_dflash_cron.sh
@@ -1,17 +1,17 @@
 #!/usr/bin/env bash
-# Cron wrapper for the sparkinfer DFlash PR eval bot — offset from AR bot:
+# Cron wrapper for the sparkinfer DFlash PR eval bot:
 #
-#   0 1-23/2 * * * /home/autotiny/Desktop/sparkinfer/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1
-#   (odd hours :00 — 01:00, 03:00, …; AR bot stays on even hours)
+#   0 * * * * /home/autotiny/Desktop/sparkinfer/eval/run_dflash_cron.sh >> /tmp/sparkinfer_dflash_bot.log 2>&1
+#   (every hour, on the hour)
 #
 # Policy (same as AR bot):
 #   • Pinned vast.ai GPU only; never rent / never start from cron when down.
 #   • Shares /tmp/sparkinfer_bot.lock with run_bot_cron.sh and the sparkinfer-web dashboard-sync
 #     crons (no overlap). The dashboard sync runs every 15 min (*/15 * * * *), which lands on
-#     this cron's own :00 slot every single tick (odd hours :00) — a bare `flock -n` would race
-#     that fast, low-stakes sync job and could lose the entire 2-hour eval window if it happened
-#     to grab the lock first. Wait a bounded amount instead: long enough to outlast a quick
-#     dashboard git-sync, short enough to still bail if something is genuinely stuck.
+#     this cron's own :00 slot every single tick — a bare `flock -n` would race that fast,
+#     low-stakes sync job and could lose an entire eval window if it happened to grab the lock
+#     first. Wait a bounded amount instead: long enough to outlast a quick dashboard git-sync,
+#     short enough to still bail if something is genuinely stuck.
 #   • GPU up → full dflash eval + auto-merge; GPU down → --labels-only.
 export HOME="${HOME:-/home/autotiny}"
 export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin:$PATH"


### PR DESCRIPTION
## Summary
Crontab changed from every 2 hours (odd hours only) to every hour, on the hour — update `run_dflash_cron.sh`'s header comment and the README setup instructions to match the actual installed schedule.

## Test plan
- [x] `bash -n eval/run_dflash_cron.sh`