### PR TITLE
verify the GQA MMA smem opt-in per device and fail over instead of reporting success

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -522,7 +522,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
 }
 
 template <int HD, int GROUP_BLKS, int RQH>
-static void launch_attn_gqa(const void* q, const signed char* k_pool, const signed char* v_pool,
+static bool launch_attn_gqa(const void* q, const signed char* k_pool, const signed char* v_pool,
                             const void* k_scale, const void* v_scale, const int* block_table,
                             void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
                             int block_size, int max_blocks_per_seq, float scale, int win_blocks,
@@ -533,11 +533,25 @@ static void launch_attn_gqa(const void* q, const signed char* k_pool, const sign
                     + (size_t)(RQH * BM * GN) * sizeof(float)        // s_s
                     + (size_t)(BM * HD) * sizeof(float)              // s_o
                     + (size_t)(2 * GN + 5 * RQH * BM) * sizeof(float);
-    static int cfg = 0;
-    if (!cfg) {
-        cudaFuncSetAttribute(pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH>,
-                             cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm);
-        cfg = 1;
+    // At RQH=4 this is 76,032 B — past the 48 KB default, so the opt-in below is
+    // REQUIRED for the launch to be valid, and both it and the launch itself have to
+    // be checked: a discarded failure here used to report success to the caller, which
+    // then skipped the scalar fallback and consumed whatever `attn` already held —
+    // silently wrong logits, no diagnostic. cudaFuncSetAttribute is also a PER-DEVICE
+    // setting, so the do-once latch is keyed on the device ordinal, not the process
+    // (the old process-wide latch left every device but the first unconfigured, and
+    // the launch then failed with cudaErrorInvalidValue on exactly the path that
+    // needs the raise).
+    constexpr int kMaxDevices = 16;
+    static int cfg[kMaxDevices] = {0};
+    int dev = 0;
+    if (cudaGetDevice(&dev) != cudaSuccess || dev < 0 || dev >= kMaxDevices) return false;
+    if (!cfg[dev]) {
+        const cudaError_t ce = cudaFuncSetAttribute(
+            pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm);
+        if (ce != cudaSuccess && sm > 48u * 1024u) return false;  // opt-in refused where it is required
+        cfg[dev] = 1;
     }
     dim3 grid((n_tokens + BM - 1) / BM, n_q_heads / RQH);
     pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH><<<grid, GROUP_BLKS * 32, sm, stream>>>(
@@ -545,6 +559,9 @@ static void launch_attn_gqa(const void* q, const signed char* k_pool, const sign
         reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),
         block_table, reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
         block_size, max_blocks_per_seq, scale, win_blocks);
+    // A rejected launch (e.g. smem over the device limit) enqueues nothing; peek —
+    // rather than get — so a pre-existing sticky error is not silently cleared here.
+    return cudaPeekAtLastError() == cudaSuccess;
 }
 
 bool launch_prefill_attn_mma(
@@ -578,16 +595,18 @@ bool launch_prefill_attn_mma(
     if (n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0) return false;
 
     const int gqa = n_q_heads / n_kv_heads;
-    if (gqa_rqh == 4 && gqa % 4 == 0) {
+    // Each tier reports whether it actually launched; a refusal (opt-in rejected,
+    // launch invalid) cascades to the next tier — RQH=2 needs 46,720 B, under the
+    // 48 KB default — and finally to the per-q-head kernel below, instead of
+    // returning success over an output buffer nothing wrote.
+    if (gqa_rqh == 4 && gqa % 4 == 0 &&
         launch_attn_gqa<HD, GROUP_BLKS, 4>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
-            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream);
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
         return true;
-    }
-    if (gqa_rqh >= 2 && gqa % 2 == 0) {
+    if (gqa_rqh >= 2 && gqa % 2 == 0 &&
         launch_attn_gqa<HD, GROUP_BLKS, 2>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
-            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream);
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
         return true;
-    }
 
     // Fallback: original per-q-head kernel.
     constexpr int GN = GROUP_BLKS * 16;


### PR DESCRIPTION
## Summary

Hardening fix for the GQA prefill-attention tier added in #664: the `RQH=4` kernel
needs **76,032 B** of dynamic shared memory — the first configuration in this file past
the 48 KB default, so the `cudaFuncSetAttribute` opt-in stopped being advisory and
became load-bearing. The launcher latched it once **per process** (the attribute is
**per device**), discarded both the attribute's and the launch's error status, and
`launch_prefill_attn_mma` returned `true` unconditionally — so on any failure the
scalar windowed fallback was skipped and `attn` kept whatever it already held: stale
logits from the previous call, or garbage on the first. Silent, no diagnostic.

## Failure modes closed

1. **Second CUDA device in a process**: never receives the smem raise → the RQH=4
   launch fails with `cudaErrorInvalidValue` → prior contents of `attn` are consumed
   as this layer's attention output.
2. **Any arch/driver where `sharedMemPerBlockOptin` < 76,032 B**: the attribute call
   itself fails; same silent outcome.

Not a live miscompute on the current single-5090 eval box (99 KB opt-in) — stated
plainly. It is the failure mode the file's own fallback structure exists to prevent,
and #664 was the change that pushed the requirement past the default.

## Fix

`launch_attn_gqa` now returns whether it actually launched:
- latch keyed on the device ordinal (`cfg[dev]`),
- a refused opt-in fails the tier only where the raise is required (`sm > 48 KB`),
- the launch is checked with `cudaPeekAtLastError` (peek, not get — a pre-existing
  sticky error is not silently cleared here),
- a refusal cascades RQH=4 → RQH=2 (46,720 B, under the default) → per-q-head kernel,
  which is exactly the bool-and-fall-through contract `prefill_attn_mma.h` documents:
  `if (launch_prefill_attn_mma(...)) return;   // else fall through to the scalar kernels`

The per-head fallback's own latch is left as-is (32,064 B fits the default; advisory).
Success path unchanged instruction-for-instruction.

## Verification (hardware disclosed: RTX 5070 Ti 16GB, WSL2, CUDA 12.8, sm_120)

- ctest **10/10**.
- `qwen3_gguf_prefill_check` on Qwythos-9B Q4_K_M (hd256 — this exact path): TOP1 8/8,
  KL 0.00617, seed 68 — identical to main.
- `qwen3_gguf_bench` @ctx=4096: decode tg 164.2 tok/s, prefill pp 11,398 tok/s — in
  family with main (success path untouched).
- The multi-device repro needs a second GPU; not reproducible on this box — the fix is
  verified as no-behavior-change on the success path plus by inspection of the failure
  path. `compute-sanitizer` unavailable under WSL/WDDM.