### PR TITLE
fix(dflash): freeze n_splits only once a dflash graph is actually live

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -205,6 +205,10 @@ private:
     // Returns argmax seed at end-1 for decode, or -1 on failure.
     int ingest_prompt_range(const int* ids, int start, int end);
     void dflash_maybe_capture_layer(int layer);
+    // Depth-adaptive KV-split count for a given seqlen (32/128/160/256 tiers, GQA-8/hd256
+    // occupancy correction). Shared by forward_token()'s normal per-token adaptation and
+    // dflash_generate()'s one-time pre-capture initialization (see qwen35.cpp).
+    int adaptive_nsplits_for(int seqlen) const;
 
     struct Impl;
     Impl* p_;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -466,6 +466,34 @@ void Qwen35Model::dflash_maybe_capture_layer(int layer) {
                                        s.dflash_n_cap * H, s.dflash_max_rows, s.stream);
 }
 
+// Depth-adaptive KV-split count for a given seqlen: 32 (short) -> 128 (mid) -> 256 (long), plus
+// the hd256/GQA occupancy correction. Extracted so both forward_token()'s per-token adaptation
+// and dflash_generate()'s one-time pre-capture initialization compute the exact same value —
+// see forward_token() below for why dflash_generate needs its own call to this.
+int Qwen35Model::adaptive_nsplits_for(int seqlen) const {
+    const Impl& s = *p_;
+    const Qwen35Config& c = s.cfg;
+    int want = 32;
+    if ((long)seqlen > 2L * s.split_chunk) want = 128;
+    if ((long)seqlen > 28L * s.split_chunk && (long)seqlen <= 48L * s.split_chunk)
+        want = Impl::MAX_NSPLITS;
+    if ((long)seqlen > 64L * s.split_chunk) want = Impl::MAX_NSPLITS;
+    if (want > Impl::MAX_NSPLITS) want = Impl::MAX_NSPLITS;
+    // hd256/GQA-8 occupancy correction (Qwen3.6 full-attention shape specifically) — see the
+    // #707-era measurement notes this replaces for the exact tuning rationale (flat 160 through
+    // 32k for GQA-8; GQA-4 promotes further at 64k/128k).
+    if (c.head_dim == 256 && c.n_kv_heads > 0 && want >= 128) {
+        if (c.n_q_heads == c.n_kv_heads * 8)
+            want = 160;
+        else if (c.n_q_heads == c.n_kv_heads * 4) {
+            if ((long)seqlen > 98304L)           want = 128;  // 128k decode (seqlen ~131k)
+            else if ((long)seqlen > 65536L)      want = 192;  // 64k decode band
+            else                                 want = 160;
+        }
+    }
+    return want;
+}
+
 int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     Impl& s = *p_;
     const Qwen35Config& c = s.cfg;
@@ -481,45 +509,18 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     s.h_scalars[4] = s.dflash_cap_row;
     cu(cudaMemcpyAsync(s.d_scalars, s.h_scalars, 5 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
 
-    // Depth-adaptive KV-split: 32 (short) -> 128 (mid) -> 256 (long). The 8k-12k band
-    // (28*split_chunk < seqlen <= 48*split_chunk) is roofline-bound on 128 splits; promote
-    // to MAX_NSPLITS there only. Past 16k keep the original 64* knee. Math unchanged.
+    // Depth-adaptive KV-split (see adaptive_nsplits_for() above for the tiers/occupancy math).
     // DFlash decode: freeze n_splits while capturing. Adapting it mid-generation (e.g. the
     // 32->160 jump at seqlen>2*split_chunk ~= 512) invalidates + re-captures the separate dflash
     // verify graph mid-stream, which corrupts the compact-verify state and makes DFlash emit a
     // spurious token 0 then repeat (SPEC fails at ctx crossing the boundary; 508-512 etc.). The
     // eval prompt (~128 ctx) never crosses the threshold, so this is free there. Non-dflash decode
-    // keeps adapting.
+    // keeps adapting. dflash_generate() makes its own one-time call to adaptive_nsplits_for()
+    // right before capture begins so this freeze locks in the value correct for the actual
+    // context depth, instead of whatever n_splits happened to be set to beforehand (this block
+    // never runs at all once dflash_capture is set, for the entire generation).
     if (s.adaptive_splits && !s.dflash_capture) {
-        int want = 32;
-        if ((long)seqlen > 2L * s.split_chunk) want = 128;
-        if ((long)seqlen > 28L * s.split_chunk && (long)seqlen <= 48L * s.split_chunk)
-            want = Impl::MAX_NSPLITS;
-        if ((long)seqlen > 64L * s.split_chunk) want = Impl::MAX_NSPLITS;
-        if (want > Impl::MAX_NSPLITS) want = Impl::MAX_NSPLITS;
-        // hd256/GQA-8 occupancy correction (Qwen3.6 full-attention shape specifically): the
-        // generic 128/256 thresholds above were tuned around the split kernel's assumed
-        // occupancy, but fa_split_gqa_mma_i8_kernel<HEAD_DIM,GQA> is a single template shared
-        // by hd128 and hd256 under the SAME __launch_bounds__(GQA*32, 5) hint — hd256's smem
-        // footprint is ~1.9x hd128's (i8_smem ~33KB vs ~17KB for GQA=8), so its REAL achieved
-        // occupancy is lower than the 5 blocks/SM the generic policy assumes, meaning the split
-        // grid is systematically over-subscribed at this shape. Empirically re-measured (RTX
-        // 5090, same-box A/B, 4k/8k/16k/32k): a flat 160 beats both the 128 and 256 tiers at
-        // every measured point (+2.8% @16k, +4.9% @32k, +3.2% @8k, tied @4k), confirmed
-        // byte-safe (online-softmax combine is exact for any split count; verified top-1=100%,
-        // KL~equal to baseline vs a real llama.cpp reference at 120 sampled 8k-32k positions).
-        // GQA-8 (Qwen3.6): flat 160 through 32k (4k–32k A/B on RTX 5090).
-        // GQA-4 (Qwythos): same through 32k; promote splits at 64k/128k so per-split MMA
-        // chunks do not outgrow occupancy (64k: 192, 128k: 128 — same-box sweeps).
-        if (c.head_dim == 256 && c.n_kv_heads > 0 && want >= 128) {
-            if (c.n_q_heads == c.n_kv_heads * 8)
-                want = 160;
-            else if (c.n_q_heads == c.n_kv_heads * 4) {
-                if ((long)seqlen > 98304L)           want = 128;  // 128k decode (seqlen ~131k)
-                else if ((long)seqlen > 65536L)      want = 192;  // 64k decode band
-                else                                 want = 160;
-            }
-        }
+        const int want = adaptive_nsplits_for(seqlen);
         if (want != s.n_splits) {                       // changed -> invalidate the captured graph
             s.n_splits = want;
             if (s.graph_ready) {
@@ -1848,6 +1849,19 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     draft.set_shared_weights(embed_weights(), draft_head, draft_head_type,
                              s.cfg.vocab, s.cfg.hidden);
     set_dflash_capture(true, dc.target_layer_ids, B);
+    // forward_token()'s adaptive-split block never runs once dflash_capture is set (see there) —
+    // n_splits would otherwise stay frozen at whatever it was left at before this call, which for
+    // every real dflash_generate() invocation is just the struct's compile-time default (32),
+    // regardless of the actual prompt length. That's only coincidentally correct for short
+    // contexts; verified broken (SPEC_AGREE far below PASS) at 512 and 4096 tokens before this
+    // fix. Initialize it correctly for THIS context now, once, before any capture happens.
+    if (s.adaptive_splits) {
+        const int want = adaptive_nsplits_for((int)prompt.size());
+        if (want != s.n_splits) {
+            s.n_splits = want;
+            invalidate_decode_graph();
+        }
+    }
 
     const int budget = session_token_budget(prompt.size(), max_new + B, s.cfg.max_seq);
     clear_prefix_cache();

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -510,16 +510,22 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     cu(cudaMemcpyAsync(s.d_scalars, s.h_scalars, 5 * sizeof(int), cudaMemcpyHostToDevice, st), "decode scalars");
 
     // Depth-adaptive KV-split (see adaptive_nsplits_for() above for the tiers/occupancy math).
-    // DFlash decode: freeze n_splits while capturing. Adapting it mid-generation (e.g. the
-    // 32->160 jump at seqlen>2*split_chunk ~= 512) invalidates + re-captures the separate dflash
-    // verify graph mid-stream, which corrupts the compact-verify state and makes DFlash emit a
-    // spurious token 0 then repeat (SPEC fails at ctx crossing the boundary; 508-512 etc.). The
-    // eval prompt (~128 ctx) never crosses the threshold, so this is free there. Non-dflash decode
-    // keeps adapting. dflash_generate() makes its own one-time call to adaptive_nsplits_for()
-    // right before capture begins so this freeze locks in the value correct for the actual
-    // context depth, instead of whatever n_splits happened to be set to beforehand (this block
-    // never runs at all once dflash_capture is set, for the entire generation).
-    if (s.adaptive_splits && !s.dflash_capture) {
+    // DFlash DECODE: freeze n_splits once an actual dflash verify graph is captured. Adapting it
+    // while that graph is live (e.g. the 32->160 jump at seqlen>2*split_chunk ~= 512) invalidates
+    // + re-captures it mid-stream, corrupting the compact-verify state (spurious token 0, then
+    // repeat). Gating on dflash_capture alone (rather than dflash_capture && dflash_graph_ready)
+    // was wrong: dflash_capture is set true before prefill even starts, so that blanket guard also
+    // froze n_splits during PREFILL, where sample=false never captures any graph at all and there
+    // is nothing to protect. Prefill then ran every position (short depths included) at whatever
+    // single value happened to be inherited from framework state predating this call, instead of
+    // ramping 32->128->160 with depth the way the reference (AR / pre-freeze) path does — a small
+    // per-split floating-point rounding difference in the quantized-KV reduction that compounds
+    // over thousands of positions into hidden states the draft model no longer agrees with
+    // (verified: SPEC_AGREE collapses at 4k-ctx even though the final prefill logits/argmax token
+    // are unaffected — only DFlash's own stashed hidden-state capture diverges). Gating on
+    // dflash_graph_ready specifically lets prefill keep adapting exactly like the non-DFlash path,
+    // and only starts freezing once there is a live graph that a change would actually corrupt.
+    if (s.adaptive_splits && !(s.dflash_capture && s.dflash_graph_ready)) {
         const int want = adaptive_nsplits_for(seqlen);
         if (want != s.n_splits) {                       // changed -> invalidate the captured graph
             s.n_splits = want;
@@ -1262,6 +1268,15 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         s.dflash_graph_ready = true;
         s.dflash_graph_attn_mode = attn_graph_mode;
         s.dflash_graph_sparse = sparse_on;
+        {
+            static int dbg = -1;
+            if (dbg < 0) { const char* e = getenv("SPARKINFER_GRAPH_DEBUG"); dbg = (e && e[0]=='1') ? 1 : 0; }
+            if (dbg) {
+                const int mma_chunk = (s.n_splits > 0) ? (seqlen + s.n_splits - 1) / s.n_splits : 0;
+                fprintf(stderr, "[dflash-graph] capture pos=%d seqlen=%d n_splits=%d attn_mode=%d mma_chunk=%d sparse=%d\n",
+                        position, seqlen, s.n_splits, attn_graph_mode, mma_chunk, sparse_on ? 1 : 0);
+            }
+        }
         cu(cudaGraphLaunch(s.cu_dflash_exec, st), "dflash graph launch (first)");
     } else if (capturing_graph) {
         cu(cudaStreamEndCapture(st, &s.cu_graph), "end capture");
@@ -1849,19 +1864,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     draft.set_shared_weights(embed_weights(), draft_head, draft_head_type,
                              s.cfg.vocab, s.cfg.hidden);
     set_dflash_capture(true, dc.target_layer_ids, B);
-    // forward_token()'s adaptive-split block never runs once dflash_capture is set (see there) —
-    // n_splits would otherwise stay frozen at whatever it was left at before this call, which for
-    // every real dflash_generate() invocation is just the struct's compile-time default (32),
-    // regardless of the actual prompt length. That's only coincidentally correct for short
-    // contexts; verified broken (SPEC_AGREE far below PASS) at 512 and 4096 tokens before this
-    // fix. Initialize it correctly for THIS context now, once, before any capture happens.
-    if (s.adaptive_splits) {
-        const int want = adaptive_nsplits_for((int)prompt.size());
-        if (want != s.n_splits) {
-            s.n_splits = want;
-            invalidate_decode_graph();
-        }
-    }
 
     const int budget = session_token_budget(prompt.size(), max_new + B, s.cfg.max_seq);
     clear_prefix_cache();


### PR DESCRIPTION
## Summary
Fixes a real correctness regression introduced by #707 at 4096-token context, while preserving #707's original 512-ctx crash fix.

#707 froze `n_splits` (the depth-adaptive KV-split count) during DFlash decode by gating the adaptive-split block on `!s.dflash_capture`. But `dflash_capture` is set `true` **before prefill even starts** in `dflash_generate()` — so that guard also froze `n_splits` during prefill, where `sample=false` never captures any graph at all and there's nothing to protect from mid-capture corruption (the actual bug #707 was fixing).

## Root cause (verified via isolated bisection + instrumentation)
- #707's freeze change alone (no other #707 changes), applied to a from-scratch pre-#707 base, reproduces the 4k-ctx `SPEC_AGREE` collapse. The `down_splitk` change alone does not — it's completely innocent.
- Traced the *actual* DFlash graph capture (not the regular decode graph, which has a separate, misleadingly-similar debug print I initially misread): `n_splits`/`attn_mode`/`mma_chunk`/`sparse` are byte-identical between the working and broken builds at capture time. Not the value.
- Checksummed the stashed prefill hidden states (`dflash_context`) at the same point in both builds: they differ, even though the final prefill argmax token is identical. Prefill itself diverges.

**Mechanism**: pre-#707, adaptive splits ramp `32 -> 128 -> 160` with depth *during prefill*, matching the non-DFlash reference path position-for-position. Freezing on `dflash_capture` instead pins every prefill position to whatever `n_splits` was inherited from framework state predating the call (e.g. a preceding plain-AR `generate()` on the same model instance) — early positions that should compute at `n_splits=32` compute at `160` instead. Split count doesn't change the *math* (online-softmax combine is exact for any split count) but does change the *rounding* of the quantized-KV reduction, and that small per-position difference compounds over thousands of positions into hidden states the draft model — which requires exact agreement — no longer produces matching predictions from.

## Fix
Gate on `dflash_capture && dflash_graph_ready` instead of `dflash_capture` alone. Prefill (no graph yet) keeps adapting exactly like the reference path; freezing only begins once an actual DFlash verify graph exists that a mid-stream `n_splits` change would corrupt.

## Verified results (isolated worktree, clean rebuild)
| context | before this fix (current `main`) | after this fix |
|---|---|---|
| 512-ctx | no crash, `SPEC_AGREE` 16/80=0.200 (FAIL) | no crash, `SPEC_AGREE` 19/80=0.2375 (FAIL — see note) |
| 4096-ctx | no crash, `SPEC_AGREE` 5/80=0.0625 (FAIL — regressed from pre-#707's clean 1.0) | `SPEC_AGREE` 80/80=1.0000 (**PASS**, matches pre-#707 exactly) |

**Note on 512-ctx**: still not fully correct, but strictly better than both pre-#707 (crashed, 0.075) and current `main` (0.200) — no crash, higher agreement. Since `n_splits=32` there is objectively the correct value for that depth (unaffected by this fix's change), the residual gap is a **separate, pre-existing correctness issue** in the DFlash mechanism itself, not caused by #707 or fixed by this PR. Tracked separately.

## Test plan
- [x] Isolated worktree + from-scratch rebuild (ruled out build-cache contamination from earlier, misleading test runs)
- [x] `qwen3_gguf_dflash_check` at 512-ctx: no crash (regression-fix preserved)
- [x] `qwen3_gguf_dflash_check` at 4096-ctx: `VERDICT PASS`, matches pre-#707 baseline exactly