### PR TITLE
fix(dflash): don't freeze n_splits at a stale pre-transition value

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -526,7 +526,18 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     // dflash_graph_ready specifically lets prefill keep adapting exactly like the non-DFlash path,
     // and only starts freezing once there is a live graph that a change would actually corrupt.
     if (s.adaptive_splits && !(s.dflash_capture && s.dflash_graph_ready)) {
-        const int want = adaptive_nsplits_for(seqlen);
+        // DFlash's decode graph freezes n_splits the instant it is captured (below). If THIS call
+        // is the one about to freeze it (dflash_cap, not yet ready) and the tier is about to turn
+        // over on the very next position, bake in the post-transition value now instead of the
+        // current one -- otherwise the freeze locks in the stale pre-transition n_splits forever
+        // (AR keeps adapting unfrozen and ends up permanently mismatched, not just off by rounding).
+        // Elsewhere (AR calls, and DFlash prefill positions far from a boundary) seqlen+1 falls in
+        // the same tier as seqlen, so this is a no-op.
+        int want = adaptive_nsplits_for(seqlen);
+        if (s.dflash_capture && !s.dflash_graph_ready) {
+            const int want_next = adaptive_nsplits_for(seqlen + 1);
+            if (want_next > want) want = want_next;
+        }
         if (want != s.n_splits) {                       // changed -> invalidate the captured graph
             s.n_splits = want;
             if (s.graph_ready) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1273,6 +1273,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     static thread_local const void* graph_conv_key = nullptr;
     static thread_local const void* graph_capture_key = nullptr;
     static thread_local const void* graph_btable_key = nullptr;
+    static thread_local int graph_ns_key = -1;
     static thread_local const void* verify_head_key = nullptr;
     static thread_local signed char* verify_head_i8 = nullptr;
     static thread_local float* verify_head_scale = nullptr;
@@ -1375,7 +1376,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     bool head_ok = false;
     if (graph_model_key != s.w.lm_head || graph_state_key != s.lin_state ||
         graph_conv_key != s.lin_conv_state || graph_capture_key != capture_dst ||
-        graph_btable_key != btable) {
+        graph_btable_key != btable || graph_ns_key != ns) {
         if (verify_exec) cudaGraphExecDestroy(verify_exec);
         if (verify_graph) cudaGraphDestroy(verify_graph);
         verify_exec = nullptr; verify_graph = nullptr;
@@ -1385,6 +1386,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         graph_conv_key = s.lin_conv_state;
         graph_capture_key = capture_dst;
         graph_btable_key = btable;
+        graph_ns_key = ns;
     }
     if (graph_ready && capture_only) return 0;   // already built
     if (graph_ready) {


### PR DESCRIPTION
## Summary

#714 freezes n_splits the instant a DFlash decode graph is captured, to stop a live graph from being invalidated mid-replay. But for a prompt whose length lands the adaptive-split tier transition (seqlen>512) right at the prefill/decode boundary, that freeze can fire one call too early: the graph gets captured — and frozen — at the short-context n_splits=32 the instant before the transition would have applied, while AR (unfrozen) keeps adapting and moves on to n_splits=160 as normal. DFlash then decodes its entire run with half the intended split count — a permanent split-count mismatch, not a rounding artifact.

Verified via trace on a 512-token prompt: under current main, DFlash's n_splits sits at 32 for the whole decode while AR transitions to 160 at seqlen=513 and stays there.

## Fix

When a forward_token call is about to freeze DFlash's decode graph for the first time, also peek at what the very next position would want and bake that in if it's larger. Everywhere else (AR calls, and DFlash prefill positions away from a tier boundary) `seqlen+1` falls in the same tier as `seqlen`, so this is a no-op — confirmed no regression on a 4096-ctx run, which exercises the normal transition happening mid-prefill (thousands of tokens before decode starts, nowhere near this edge case).

Also adds `n_splits` to `dflash_verify_short_run`'s own graph-invalidation key (`qwen35_prefill.cpp`) — that compact-verify graph is independent of the decode graph above and its cache-key check was missing `n_splits` entirely, so it would keep replaying whatever it was captured with regardless of a later n_splits change.

## What this does *not* fix

I want to be upfront: this fixes a real, independently-reproducible bug (confirmed via direct n_splits tracing), but a 512-ctx SPEC_AGREE check still shows DFlash diverging from AR partway through decode even with n_splits now correctly matched throughout the whole run. That's the separate, still-open issue #712 — this PR does not claim to resolve it, only to fix the split-count mismatch found while investigating it.

## Verification (RTX 5090, CUDA 12.8)

- `ctest`: 10/10.
- `qwen3_gguf_dflash_check` 4096-ctx @ 80gen: SPEC_AGREE 80/80 = 1.0000, PASS (no regression vs current main).
- `qwen3_gguf_dflash_check` 512-ctx @ 32gen, traced: n_splits now correctly reaches and stays at 160 for the whole decode (matching AR) instead of being stuck at 32 — but SPEC_AGREE is still not 1.0 for this case, confirming #712 needs further work independent of this fix.