### PR TITLE
perf(dflash): row-batched KV-split draft attention and tensor-core context ingestion

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -4,6 +4,7 @@
 #include <cuda_fp16.h>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 
 namespace sparkinfer {
 namespace dflash_kernels {
@@ -236,6 +237,146 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
     float inv = (sum > 0.f) ? (1.f / sum) : 0.f;
     for (int i = threadIdx.x; i < d; i += blockDim.x)
         ov[i] = f2b(acc[i] * inv);
+}
+
+// Row-batched, KV-split hd128 GQA attention for long draft contexts.
+//
+// k_attn_multiwarp_hd128 gives one CTA to each (query row, q head) and walks the whole
+// key sequence inside it. The per-warp online-softmax update is loop-carried, so the CTA's
+// runtime grows with kv_len while the CTA count stays fixed at q_len*n_q -- at a 4k draft
+// context that serial chain, not the KV bytes, is what the kernel is waiting on (measured:
+// 1 query row costs the same as 4, so the short-grid case is latency-bound, and the 16-row
+// case then re-reads the same K/V once per row).
+//
+// This kernel fixes both: ROWS query rows share a CTA (each K/V vector is fetched once per
+// ROWS rows instead of once per row) and the key range is cut into n_splits chunks so the
+// serial chain shortens and the grid grows with context. Per-split partial (m, l, acc)
+// states are merged by k_attn_split_combine, which is the same online-softmax merge the
+// in-CTA warp reduction already does -- exact for any split count.
+template <int ROWS, int NWARPS>
+__global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
+    const bf16* __restrict__ q, const bf16* __restrict__ k, const bf16* __restrict__ v,
+    float* __restrict__ p_m, float* __restrict__ p_l, float* __restrict__ p_acc,
+    int q_len, int kv_len, int n_q, int n_kv,
+    int q_pos0, int k_pos0, int window, bool causal, float scale, int n_splits) {
+    constexpr int D = 128, E = D / 32;
+    const int rg = blockIdx.x, qh = blockIdx.y, sp = blockIdx.z;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int base = lane * E;
+    const int kv_h = qh / (n_q / n_kv);
+    const int qt0 = rg * ROWS;
+
+    float qr[ROWS][E], acc[ROWS][E], max_s[ROWS], sum[ROWS];
+#pragma unroll
+    for (int r = 0; r < ROWS; r++) {
+        const int qt = qt0 + r;
+        const bf16* qv = q + ((size_t)qt * n_q + qh) * D + base;
+#pragma unroll
+        for (int e = 0; e < E; e++) { qr[r][e] = (qt < q_len) ? b2f(qv[e]) : 0.f; acc[r][e] = 0.f; }
+        max_s[r] = -1e30f;
+        sum[r] = 0.f;
+    }
+
+    const int chunk = (kv_len + n_splits - 1) / n_splits;
+    const int t0 = sp * chunk;
+    const int t1 = min(kv_len, t0 + chunk);
+
+    for (int t = t0 + warp; t < t1; t += NWARPS) {
+        const int k_pos = k_pos0 + t;
+        const bf16* kp = k + ((size_t)t * n_kv + kv_h) * D + base;
+        float kreg[E];
+#pragma unroll
+        for (int e = 0; e < E; e++) kreg[e] = b2f(kp[e]);
+        float dots[ROWS];
+#pragma unroll
+        for (int r = 0; r < ROWS; r++) {
+            float d = 0.f;
+#pragma unroll
+            for (int e = 0; e < E; e++) d += qr[r][e] * kreg[e];
+            dots[r] = d;
+        }
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1)
+#pragma unroll
+            for (int r = 0; r < ROWS; r++) dots[r] += __shfl_down_sync(0xffffffffu, dots[r], off);
+        float vreg[E];
+        bool vloaded = false;
+#pragma unroll
+        for (int r = 0; r < ROWS; r++) {
+            const int qt = qt0 + r;
+            if (qt >= q_len) continue;
+            const int q_pos = q_pos0 + qt;
+            if (causal && k_pos > q_pos) continue;
+            if (window > 0 && (q_pos - k_pos) >= window) continue;
+            if (!vloaded) {
+                const bf16* vp = v + ((size_t)t * n_kv + kv_h) * D + base;
+#pragma unroll
+                for (int e = 0; e < E; e++) vreg[e] = b2f(vp[e]);
+                vloaded = true;
+            }
+            const float score = __shfl_sync(0xffffffffu, dots[r], 0) * scale;
+            const float new_max = fmaxf(max_s[r], score);
+            const float e1 = __expf(max_s[r] - new_max);
+            const float e2 = __expf(score - new_max);
+            sum[r] = sum[r] * e1 + e2;
+#pragma unroll
+            for (int e = 0; e < E; e++) acc[r][e] = acc[r][e] * e1 + e2 * vreg[e];
+            max_s[r] = new_max;
+        }
+    }
+
+    extern __shared__ float sm[];
+    float* s_max = sm;                            // NWARPS * ROWS
+    float* s_sum = s_max + NWARPS * ROWS;         // NWARPS * ROWS
+    float* s_acc = s_sum + NWARPS * ROWS;         // NWARPS * ROWS * D
+#pragma unroll
+    for (int r = 0; r < ROWS; r++) {
+        if (lane == 0) { s_max[warp * ROWS + r] = max_s[r]; s_sum[warp * ROWS + r] = sum[r]; }
+#pragma unroll
+        for (int e = 0; e < E; e++)
+            s_acc[((size_t)warp * ROWS + r) * D + base + e] = acc[r][e];
+    }
+    __syncthreads();
+    if (warp != 0) return;
+#pragma unroll
+    for (int r = 0; r < ROWS; r++) {
+        const int qt = qt0 + r;
+        if (qt >= q_len) continue;
+        float gmax = -1e30f;
+        for (int w = 0; w < NWARPS; w++) gmax = fmaxf(gmax, s_max[w * ROWS + r]);
+        float gsum = 0.f;
+        float result[E] = {0.f, 0.f, 0.f, 0.f};
+        for (int w = 0; w < NWARPS; w++) {
+            const float c = __expf(s_max[w * ROWS + r] - gmax);
+            gsum += s_sum[w * ROWS + r] * c;
+#pragma unroll
+            for (int e = 0; e < E; e++)
+                result[e] += s_acc[((size_t)w * ROWS + r) * D + base + e] * c;
+        }
+        const size_t o = ((size_t)qt * n_q + qh) * n_splits + sp;
+#pragma unroll
+        for (int e = 0; e < E; e++) p_acc[o * D + base + e] = result[e];
+        if (lane == 0) { p_m[o] = gmax; p_l[o] = gsum; }
+    }
+}
+
+// Merge the per-split online-softmax partials into the bf16 output.
+__global__ void k_attn_split_combine(const float* __restrict__ p_m, const float* __restrict__ p_l,
+                                     const float* __restrict__ p_acc, bf16* __restrict__ out,
+                                     int n_q, int n_splits) {
+    constexpr int D = 128;
+    const int qt = blockIdx.x, qh = blockIdx.y, d = threadIdx.x;
+    const size_t b = ((size_t)qt * n_q + qh) * n_splits;
+    float gmax = -1e30f;
+    for (int s = 0; s < n_splits; s++) gmax = fmaxf(gmax, p_m[b + s]);
+    float gsum = 0.f, acc = 0.f;
+    for (int s = 0; s < n_splits; s++) {
+        const float c = __expf(p_m[b + s] - gmax);
+        gsum += p_l[b + s] * c;
+        acc += p_acc[(b + s) * D + d] * c;
+    }
+    const float inv = gsum > 0.f ? 1.f / gsum : 0.f;
+    out[((size_t)qt * n_q + qh) * D + d] = f2b(acc * inv);
 }
 
 // Split the key sequence across the warps of one CTA, then merge their online-
@@ -1029,13 +1170,41 @@ void launch_rope_seq(void* x, int seq, int n_heads, int d, int pos0, float theta
     k_rope<<<grid, 64, 0, stream>>>((bf16*)x, seq, n_heads, d, pos0, theta);
 }
 
+int attn_gqa_splits(int kv_len) {
+    // Chosen from a same-box sweep of the draft shape (16 rows, 32 q / 8 kv heads, hd128):
+    // kv_len 128 -> 2, 512 -> 8, 4096 -> 16 splits were each at or within ~2% of the best
+    // (splits, rows) pair, and every point beat the unsplit kernel. Splitting past 16 starts
+    // losing to the per-split combine and the shrinking per-CTA key count.
+    int s = kv_len / 64;
+    if (s < 2) s = 2;
+    if (s > kDFlashAttnMaxSplits) s = kDFlashAttnMaxSplits;
+    return s;
+}
+
 void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                      int q_len, int kv_len, int n_q, int n_kv, int d,
                      int q_pos0, int k_pos0, int window, bool causal, float scale,
-                     cudaStream_t stream) {
+                     cudaStream_t stream, float* fa_m, float* fa_l, float* fa_acc) {
     if (q_len <= 0 || kv_len <= 0) return;
     dim3 grid(q_len, n_q);
     if (d == 128) {
+        // Row-batched + KV-split path. Needs the caller's partial-state scratch; without it
+        // (or below the sweep's crossover) fall through to the single-CTA-per-row kernel.
+        static const int kSplitAttn = []{ const char* e = getenv("SPARKINFER_DFLASH_SPLIT_ATTN");
+                                          return (e && e[0] == '0') ? 0 : 1; }();
+        if (kSplitAttn && fa_m && fa_l && fa_acc && n_kv > 0 && (n_q % n_kv) == 0 &&
+            q_len <= kDFlashAttnMaxRows && kv_len >= kDFlashAttnMinKv) {
+            constexpr int ROWS = 2, NWARPS = 8;
+            const int n_splits = attn_gqa_splits(kv_len);
+            const size_t smem = (size_t)(2 * NWARPS * ROWS + NWARPS * ROWS * 128) * sizeof(float);
+            dim3 g((q_len + ROWS - 1) / ROWS, n_q, n_splits);
+            k_attn_rows_split_hd128<ROWS, NWARPS><<<g, NWARPS * 32, smem, stream>>>(
+                (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,
+                q_len, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits);
+            k_attn_split_combine<<<dim3(q_len, n_q), 128, 0, stream>>>(
+                fa_m, fa_l, fa_acc, (bf16*)out, n_q, n_splits);
+            return;
+        }
         constexpr int THREADS = 512;
         constexpr int NWARPS = THREADS / 32;
         constexpr int SMEM = (2 * NWARPS + NWARPS * 128) * sizeof(float);

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -6,13 +6,28 @@
 namespace sparkinfer {
 namespace dflash_kernels {
 
+// Upper bounds for the hd128 row-batched KV-split attention path, so the caller can size
+// its per-split partial-state scratch once at load instead of per call.
+constexpr int kDFlashAttnMaxSplits = 16;
+constexpr int kDFlashAttnMaxRows = 16;
+// Below this key count the split path is not worth taking: the unsplit kernel is already short
+// enough that the extra combine pass eats the gain, and re-associating the reduction perturbs the
+// draft's proposals -- at a 512-token context that cost more mean acceptance than the kernel saved
+// (2.0317 -> 2.0000, net -0.7%). Long contexts, where the unsplit kernel is ~25x off roofline, are
+// the case this exists for; everything shorter stays bit-for-bit on the original kernel.
+constexpr int kDFlashAttnMinKv = 1024;
+
 // GQA attention. q: [q_len, n_q, d], k/v: [kv_len, n_kv, d], out: [q_len, n_q, d] bf16.
 // q_pos0 / k_pos0 are absolute positions of index 0. If window > 0, mask keys with
 // (q_pos - k_pos) >= window (sliding window). scale = 1/sqrt(d).
+// fa_m / fa_l / fa_acc: optional partial-state scratch for the hd128 KV-split path, sized
+// [kDFlashAttnMaxRows * n_q * kDFlashAttnMaxSplits] (and * 128 for fa_acc). Pass nullptr to
+// force the single-CTA-per-row kernel.
 void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                      int q_len, int kv_len, int n_q, int n_kv, int d,
                      int q_pos0, int k_pos0, int window, bool causal, float scale,
-                     cudaStream_t stream);
+                     cudaStream_t stream, float* fa_m = nullptr, float* fa_l = nullptr,
+                     float* fa_acc = nullptr);
 
 // In-place RoPE on [seq, n_heads, d] bf16. positions[i] = pos0 + i.
 void launch_rope_seq(void* x, int seq, int n_heads, int d, int pos0,

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -4,6 +4,7 @@
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/quant.h"
+#include "sparkinfer/kernels/prefill.h"
 
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
@@ -278,6 +279,8 @@ struct DFlashDraftModel::Impl {
     bf16 *x = nullptr, *xn = nullptr, *h = nullptr, *hn = nullptr;
     bf16 *q = nullptr, *k = nullptr, *v = nullptr, *attn = nullptr, *ao = nullptr;
     bf16 *gate = nullptr, *up = nullptr, *down = nullptr;
+    // Per-split online-softmax partials for the row-batched KV-split draft attention.
+    float *fa_m = nullptr, *fa_l = nullptr, *fa_acc = nullptr;
     float* logits = nullptr;        // [B, vocab]
     void* head_q8 = nullptr;        // [B] Q8_1 rows of xn for the multi-row head MMVQ
     int *d_ids = nullptr, *d_out = nullptr;
@@ -495,6 +498,13 @@ bool DFlashDraftModel::load(const std::string& dir) {
     s.q = s.alloc<bf16>((size_t)B * qdim);
     s.attn = s.alloc<bf16>((size_t)B * qdim);
     s.ao = s.alloc<bf16>((size_t)B * H);
+    {
+        const size_t parts = (size_t)dflash_kernels::kDFlashAttnMaxRows * s.cfg.n_q_heads *
+                             dflash_kernels::kDFlashAttnMaxSplits;
+        s.fa_m = s.alloc<float>(parts);
+        s.fa_l = s.alloc<float>(parts);
+        s.fa_acc = s.alloc<float>(parts * 128);
+    }
     s.gate = s.alloc<bf16>((size_t)B * I);
     s.up = s.alloc<bf16>((size_t)B * I);
     s.down = s.alloc<bf16>((size_t)B * H);
@@ -517,6 +527,22 @@ bool DFlashDraftModel::load(const std::string& dir) {
     (void)I; (void)n_cap;
     return true;
 }
+
+namespace {
+// Rows below this keep the bit-exact row-batched GEMV path. Two reasons for a high bar. The
+// prefill GEMM tiles its output 128x128, so a narrow block leaves most of the tile idle and the
+// GEMV shape still wins outright. And re-associating this projection perturbs the draft's
+// proposals, which at a short context costs more acceptance than the kernel saves (measured at
+// 512: mean accept 2.0317 -> 2.0000, a net -0.65% even though the kernel itself got faster).
+// Only a genuinely long context ingestion, where the GEMV shape is an order of magnitude off,
+// takes the GEMM -- every shorter block stays bit-for-bit what it was.
+constexpr int kCtxGemmMinRows = 1024;
+bool ctx_gemm_enabled() {
+    static const int on = []{ const char* e = getenv("SPARKINFER_DFLASH_CTX_GEMM");
+                              return (e && e[0] == '0') ? 0 : 1; }();
+    return on != 0;
+}
+}  // namespace
 
 bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                      const int* noise_ids, int pos0,
@@ -568,9 +594,20 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
 
     // target_hidden [ctx, n_cap*H] -> fc -> hidden_norm -> target_proj [ctx, H]
     // fc.weight is [H, n_cap*H] (out, in). Loop gemv per row.
+    // Context ingestion (the first block of a generation) runs these projections over the whole
+    // prompt: at a 4k context that one step is [4096, n_cap*H] -> [4096, H] here plus [4096, H] ->
+    // K/V per layer below. The row-batched GEMV kernels these used give one CTA per (output, row)
+    // and reduce K per CTA, so at 4k they hit ~13 TFLOPS -- fine for the 1-6 row steady-state
+    // blocks they were written for, an order of magnitude off for a 4096-row one. Route just the
+    // wide case to the tensor-core bf16 prefill GEMM (same C[M,N] = A[M,K] @ W^T with the native
+    // [N,K] weight, fp32 accumulate); anything at or below kCtxGemmMinRows keeps the existing
+    // exact GEMV path bit-for-bit, so every steady-state block is untouched.
+    const bool ctx_gemm = ctx_len >= kCtxGemmMinRows && ctx_gemm_enabled();
     if (ctx_len > 0) {
         const bf16* th = (const bf16*)target_hidden;
-        if (ctx_len > 1) {
+        if (ctx_gemm) {
+            kernels::launch_prefill_gemm(th, s.fc, s.target_proj, ctx_len, H, n_cap * H, st);
+        } else if (ctx_len > 1) {
             dflash_kernels::launch_gemv_rows_batched(th, s.fc, s.target_proj,
                                                    ctx_len, H, n_cap * H, st);
         } else {
@@ -629,7 +666,10 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
         // Context half of cat(k_ctx, k_noise), written ahead of the noise rows.
-        if (ctx_len > 1) {
+        if (ctx_gemm) {
+            kernels::launch_prefill_gemm(s.target_proj, w.wk, kdst, ctx_len, kvdim, H, st);
+            kernels::launch_prefill_gemm(s.target_proj, w.wv, vdst, ctx_len, kvdim, H, st);
+        } else if (ctx_len > 1) {
             dflash_kernels::launch_gemv_rows_exact_fused2(
                 s.target_proj, w.wk, w.wv, kdst, vdst,
                 ctx_len, kvdim, kvdim, H, st);
@@ -677,7 +717,8 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                             c.sliding_layers[L];
         dflash_kernels::launch_attn_gqa(s.q, s.k_cache[L], s.v_cache[L], s.attn,
                                         BW, kv_len, c.n_q_heads, c.n_kv_heads, d,
-                                        q_pos0, /*k_pos0_cache=*/0, window, causal, scale, st);
+                                        q_pos0, /*k_pos0_cache=*/0, window, causal, scale, st,
+                                        s.fa_m, s.fa_l, s.fa_acc);
 
         if (fast16) {
             if (w.q8_wo.q4)


### PR DESCRIPTION
## Summary

DFlash decode at a long context is dominated by the **draft**, not the target verify: host-timed
step split at 4k gives 2.96 ms/step in the draft against 0.87 ms at 128 ctx, while the compact
verify is nearly flat (5.23 vs 4.88 ms). This speeds up the two draft paths that scale with context.

**Draft attention.** `k_attn_multiwarp_hd128` gives one CTA to each (query row, q head) and walks the
whole key sequence inside it, so the CTA count is fixed at `q_len*n_q` regardless of context and the
online-softmax update is loop-carried — 240 us/launch at kv_len 4096 against 9.4 us of K/V bytes. A
row sweep separates the two causes: 1/2/4 query rows all cost ~100 us (short grid, latency-bound),
then 8 → 16 doubles it (each row re-reads the same K/V). `k_attn_rows_split_hd128` shares a CTA
across ROWS query rows and cuts the key range into `n_splits` chunks, keeping the existing 32-lane
dot inner loop (a shared-memory-tiled rewrite of it measured 2x slower). Kernel: 4096 **248 → 134 us**,
1024 62.6 → 38.5, 512 33.7 → 21.9.

**Context ingestion.** The first block projects the whole prompt (`[ctx, n_cap*H] → [ctx, H]`, then
`[ctx, H] → K/V` per layer) on the row-batched GEMV kernels — one CTA per (output, row), right for
the 1-6 row steady-state blocks they were written for, an order of magnitude off for a 4096-row one
(grid 2048 x 4096 = 8.4M CTAs, ~13 TFLOPS on a 275 GFLOP product). Routed to the tensor-core bf16
prefill GEMM, which already takes the native `[N,K]` weight. First block at 4k: **33.9 → 5.8 ms**.

Both paths are gated to long context (`kv_len` / `ctx_len` >= 1024); below the gate the original
kernels run bit for bit. Re-associating either reduction perturbs the draft's proposals, and at 512
that cost more mean acceptance than the kernels saved (2.0317 → 2.0000, net -0.7% even though both
kernels got faster there). `SPARKINFER_DFLASH_SPLIT_ATTN=0` / `SPARKINFER_DFLASH_CTX_GEMM=0` restore
the old paths for A/B.

Mean acceptance is **identical at every context**, so the 4k gain is a per-step cost reduction and
not a different token stream — worth stating because at this 4k prompt the greedy argmax at one
early generated position is nearly tied, so a change that only perturbs rounding can flip the whole
continuation and move throughput ~40% without making anything faster.

`SPEC_AGREE` is unchanged versus the base build at all three contexts, and
`dflash_gdn_checkpoint_gpu_test` passes.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 355.41 |
| after (this PR) | 395.43 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

DFlash decode against same-box `origin/main`, per context:

| context | main | this PR | change | accuracy |
|---|--:|--:|--:|--:|
| 4096 | 355.41 | 395.43 | **+11.3%** | SPEC_AGREE 1.0000 |
| 512 | 412.22 | 412.98 | +0.2% | SPEC_AGREE 1.0000 |
| 128 | 449.23 | 449.44 | +0.0% | pass |

Isolated-kernel and step-breakdown figures quoted above were taken on an earlier base of this
branch; the code is unchanged since, and the per-context table here is the current same-box
comparison. The earlier alternating A/B is kept below as supporting evidence for the mechanism --
it ran on a single binary through the two kill-switches, so both legs shared one build and one
thermal state (OFF = the pre-change code paths):

```text
ctx=4096 iter=1 OFF DFLASH_TPS=460.8146 ACCEPT=3.9091
ctx=4096 iter=1 ON  DFLASH_TPS=552.8364 ACCEPT=3.9091
ctx=4096 iter=2 OFF DFLASH_TPS=459.2520 ACCEPT=3.9091
ctx=4096 iter=2 ON  DFLASH_TPS=551.9366 ACCEPT=3.9091

ctx=512  iter=1 OFF DFLASH_TPS=398.9796 ACCEPT=2.0317
ctx=512  iter=1 ON  DFLASH_TPS=398.9126 ACCEPT=2.0317
ctx=512  iter=2 OFF DFLASH_TPS=398.8519 ACCEPT=2.0317
ctx=512  iter=2 ON  DFLASH_TPS=398.9499 ACCEPT=2.0317

ctx=128  iter=1 OFF DFLASH_TPS=987.1833 ACCEPT=5.3333
ctx=128  iter=1 ON  DFLASH_TPS=986.9738 ACCEPT=5.3333
ctx=128  iter=2 OFF DFLASH_TPS=987.4692 ACCEPT=5.3333
ctx=128  iter=2 ON  DFLASH_TPS=987.2436 ACCEPT=5.3333
```

Isolated draft-attention kernel sweep (extra evidence, not the before/after above), us per launch at
the draft shape (16 rows, 32 q / 8 kv heads, hd128), validated against the existing kernel's output:

```text
kv_len=  128   unsplit  10.26   rows-split   8.45
kv_len=  256   unsplit  17.85   rows-split  13.51
kv_len=  512   unsplit  33.73   rows-split  21.89
kv_len= 1024   unsplit  62.56   rows-split  38.53
kv_len= 4096   unsplit 248.22   rows-split 134.51
```
