### PR TITLE
fix(build): set CMAKE_CUDA_ARCHITECTURES before project(... CUDA), drop unsupported sm_121

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,19 @@
 cmake_minimum_required(VERSION 3.20)
+
+# Blackwell consumer/edge: sm_120 (RTX 5090, RTX PRO 6000). sm_121 (RTX Spark, Jetson
+# Thor) is intentionally excluded — CUDA 12.8's nvcc (currently in use) hard-errors with
+# "Unsupported gpu architecture 'compute_121'" during compiler identification, since that
+# target requires CUDA 12.9+.
+# Must be set BEFORE project(... CUDA) — project()/enable_language(CUDA) reads
+# CMAKE_CUDA_ARCHITECTURES at that call and caches its own (environment-dependent,
+# sometimes ancient e.g. "52") default if it isn't already set. A set() after
+# project() is a CACHE no-op once that's happened, silently building tensor-core/wmma
+# kernels for a target that can't support them.
+set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120" CACHE STRING "CUDA architectures")
 project(sparkinfer LANGUAGES CXX CUDA)
 
-# Blackwell consumer/edge: sm_120 (RTX 5090, RTX PRO 6000), sm_121 (RTX Spark, Jetson Thor).
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
-set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120;121" CACHE STRING "CUDA architectures")
 
 option(BUILD_TESTS    "Build unit / integration tests" ON)
 option(BUILD_EXAMPLES "Build example programs"          ON)

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -1,14 +1,16 @@
 cmake_minimum_required(VERSION 3.20)
-project(sparkinfer_kernels LANGUAGES CXX CUDA)
-
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CUDA_STANDARD 17)
 
 # Primary target: sm_120 = consumer Blackwell (RTX 5090).
 # Also: sm_100 = datacenter Blackwell (B200/GB200), sm_90 = Hopper, sm_89 = Ada.
 # NOTE: RTX 5090 is compute capability 12.0 (sm_120), NOT sm_100. sm_100 is
 # datacenter Blackwell (B200) and is binary-incompatible with the 5090.
-set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120;121" CACHE STRING "CUDA architectures")
+# Must be set BEFORE project(... CUDA) — see root CMakeLists.txt for why.
+# sm_121 excluded — unsupported by the CUDA 12.8 toolkit currently in use.
+set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120" CACHE STRING "CUDA architectures")
+project(sparkinfer_kernels LANGUAGES CXX CUDA)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CUDA_STANDARD 17)
 
 option(BUILD_TESTS         "Build unit tests"            ON)
 option(BUILD_BENCHMARKS    "Build benchmarks"            OFF)

--- a/moe/CMakeLists.txt
+++ b/moe/CMakeLists.txt
@@ -1,9 +1,12 @@
 cmake_minimum_required(VERSION 3.20)
+
+# Must be set BEFORE project(... CUDA) — see root CMakeLists.txt for why.
+# sm_121 excluded — unsupported by the CUDA 12.8 toolkit currently in use.
+set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120" CACHE STRING "CUDA architectures")
 project(sparkinfer_moe LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
-set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120;121" CACHE STRING "CUDA architectures")
 
 option(BUILD_TESTS "Build unit tests" ON)
 

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -1,10 +1,13 @@
 cmake_minimum_required(VERSION 3.20)
+
+# Primary target sm_120 (RTX 5090). Also Ada/Hopper/datacenter-Blackwell.
+# Must be set BEFORE project(... CUDA) — see root CMakeLists.txt for why.
+# sm_121 excluded — unsupported by the CUDA 12.8 toolkit currently in use.
+set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120" CACHE STRING "CUDA architectures")
 project(sparkinfer_runtime LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CUDA_STANDARD 17)
-# Primary target sm_120 (RTX 5090). Also Ada/Hopper/datacenter-Blackwell.
-set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120;121" CACHE STRING "CUDA architectures")
 
 option(BUILD_TESTS    "Build unit / integration tests" ON)
 option(BUILD_EXAMPLES "Build example programs"          ON)


### PR DESCRIPTION
## Summary
- `set(CMAKE_CUDA_ARCHITECTURES ...)` in all 4 CMakeLists.txt (root, kernels/, runtime/, moe/) ran *after* `project(... LANGUAGES CUDA)`. `project()`/`enable_language(CUDA)` reads `CMAKE_CUDA_ARCHITECTURES` at that call and, if unset, caches its own environment-dependent default — observed falling back to the ancient arch `52` on a fresh configure of a new box. Once that cache entry exists, the later `set()` is a no-op, so the build silently produces tensor-core/wmma kernels for a target that can't run them (compile fails once `__CUDA_ARCH__`-gated code hits a virtual architecture below sm_70).
- Fixed by moving each `set()` before its `project()` call, so the intended architecture list is honored deterministically instead of depending on CMake's own detection.
- Also dropped `sm_121` (RTX Spark, Jetson Thor) from the list — CUDA 12.8's nvcc hard-errors with `Unsupported gpu architecture 'compute_121'` during compiler identification; that target needs CUDA 12.9+, which isn't what's actually installed on the current eval box.

## Test plan
- [x] Fresh `rm -rf build && cmake -S . -B build` on an RTX 5090 (sm_120) box with CUDA 12.8 — cache now correctly shows `89;90;100;120` on the first configure (previously defaulted to `52`).
- [x] Full build of `qwen3_gguf_dflash_check`, `qwen3_gguf_dflash_bench`, `qwen3_gguf_bench` completes cleanly, all three binaries present and executable.