### PR TITLE
Revert "perf(runtime): requant MoE expert down Q5_K/Q6_K to Q4_K at load (#699)"

### DIFF
--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -31,9 +31,7 @@ int main(int argc, char** argv) {
     // may set SPARKINFER_DOWN_REQUANT_Q4K=1 (and that env also gates Qwythos dense-9B attn/lmhead
     // requant defaults); those paths diverge from the reference and falsely fail the correctness
     // gate (~79-83% top1). overwrite=1 so evaluate_bidir's export cannot leak into scoring.
-    // Same for MoE expert-down requant (Q5_K/Q6_K -> Q4_K).
     setenv("SPARKINFER_DOWN_REQUANT_Q4K", "0", 1);
-    setenv("SPARKINFER_MOE_DOWN_REQUANT_Q4K", "0", 1);
 
     const std::string path = argv[1];
     const int topk = atoi(argv[2]);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -2252,9 +2252,8 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     };
     auto dev_quant_requant_q4k = [&](const std::string& name, int& qtype, bool req) -> const void* {
         const void* q6 = dev_quant(name, qtype);
-        // 14=Q6_K, 13=Q5_K (UD MoE downs), 8=Q8_0 -> Q4_K
-        if (!req || (qtype != 14 && qtype != 13 && qtype != 8) || !q6) return q6;
-        const int src_type = qtype;
+        if (!req || (qtype != 14 && qtype != 8) || !q6) return q6;
+        const int src_type = qtype;            // 14 (Q6_K) or 8 (Q8_0) -> Q4_K
         const GGUFTensor* t = g.tensor(name);
         const long nv = t->n_values;
         if (nv % 256 != 0) return q6;
@@ -2286,18 +2285,6 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     auto dev_quant_down = [&](const std::string& name, int& qtype) -> const void* {
         static int req = -1;
         if (req < 0) { const char* e = getenv("SPARKINFER_DOWN_REQUANT_Q4K"); req = (e && e[0] == '0') ? 0 : 1; }
-        return dev_quant_requant_q4k(name, qtype, req != 0);
-    };
-    // MoE expert downs (ffn_down_exps): Q6_K (Qwen3-MoE) / Q5_K (Qwen3.6 UD) -> Q4_K at load so
-    // decode reads fewer weight bytes on the largest per-token GEMV. Reuses the dense-FFN
-    // affine fitter + existing Q4_K MMVQ down path. Default ON;
-    // SPARKINFER_MOE_DOWN_REQUANT_Q4K=0 keeps native Q5_K/Q6_K.
-    auto dev_quant_moe_down = [&](const std::string& name, int& qtype) -> const void* {
-        static int req = -1;
-        if (req < 0) {
-            const char* e = getenv("SPARKINFER_MOE_DOWN_REQUANT_Q4K");
-            req = (e && e[0] == '0') ? 0 : 1;
-        }
         return dev_quant_requant_q4k(name, qtype, req != 0);
     };
     // dense weight -> bf16 (optionally transpose [out,in] -> [in,out])
@@ -2588,7 +2575,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             }
             w.gate_q = dev_quant(b + "ffn_gate_exps.weight", w.gate_qtype);   // kept quantized
             w.up_q   = dev_quant(b + "ffn_up_exps.weight",   w.up_qtype);
-            w.down_q = dev_quant_moe_down(b + "ffn_down_exps.weight", w.down_qtype);
+            w.down_q = dev_quant(b + "ffn_down_exps.weight", w.down_qtype);
             if (s.cfg.n_shared > 0) {
             if (!expect_dims(b + "ffn_gate_shexp.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_up_shexp.weight", {H, c.moe_ffn}) ||


### PR DESCRIPTION
## Summary
- Reverts #699. Its auto-eval claimed +58.4% (PR=713.8 main=450.6 tok/s, XL tier), which triggered auto-merge.
- That number does not reproduce. A clean, single-commit, adjacent re-measurement (this commit's parent vs #699 itself, same box, same build, nothing else in between) gives: @128 -2.4%, @512 +1.0%, @4k +0.6% — a wash at best, a small regression at 128 by the project's own multi-context scoring rule.
- Both sides `SPEC_AGREE 32/32`, Qwen3.5/3.6 guard OK — not a correctness issue, the original speedup claim itself was wrong (most likely a one-off measurement fluke on the original eval run).
- See PR #699 for the corrective comment with the full re-measurement table.

## Test plan
- [x] Clean revert on top of current main (75a73e5), no conflicts with #717 or later work.
- [x] Re-measured #699 vs its immediate parent on the current eval box (RTX 5090): -2.4%/+1.0%/+0.6% across 128/512/4k, SPEC_AGREE 32/32 both sides.