### PR TITLE
int4 draft-head unpack borrows across byte lanes, off-by-one on negative weights

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1642,8 +1642,17 @@ __global__ void gemv_i4_q81_multirow_kernel(
                 const int p = wb[j];
                 int lo = p & 0x0f0f0f0f;
                 int hi = (p >> 4) & 0x0f0f0f0f;
-                lo = (lo ^ 0x08080808) - 0x08080808;
-                hi = (hi ^ 0x08080808) - 0x08080808;
+                // Per-byte 4-bit sign extension: (n ^ 8) - 8 must be evaluated in each
+                // byte lane INDEPENDENTLY. A scalar 32-bit subtract is not that: every
+                // byte holding a negative weight has (n ^ 8) < 8, so the lane
+                // underflows and BORROWS from the next-higher byte, silently
+                // decrementing its neighbour's decoded weight (and chaining when the
+                // neighbour goes negative too). __vsubss4 subtracts per byte with
+                // saturation — which never engages here, since (n ^ 8) - 8 is always
+                // in [-8, 7] — the same idiom the Q6_K reconstructions in this file
+                // already use.
+                lo = __vsubss4(lo ^ 0x08080808, 0x08080808);
+                hi = __vsubss4(hi ^ 0x08080808, 0x08080808);
                 dot = __dp4a(lo, ai[j], dot);
                 dot = __dp4a(hi, ai[j + 4], dot);
             }


### PR DESCRIPTION
## Summary

`gemv_i4_q81_multirow_kernel` — the DFlash draft head's int4 GEMV — reconstructs packed
4-bit weights with a **scalar 32-bit subtract** where a **per-byte** subtract is
required. Every byte lane holding a negative weight underflows and borrows from the
next-higher lane, silently decrementing its neighbour's decoded weight by one
quantization step. With the pack clamped to [-7, 7], ~half of all nibbles are negative,
so ~half of all decoded weights are wrong before the `__dp4a`. Two-line fix using the
same `__vsubss4` idiom this file already uses for both Q6_K reconstructions.

## The defect

`pack_i8_rows_i4_kernel` stores two's-complement nibbles: `(lo & 15) | ((hi & 15) << 4)`
with `lo, hi ∈ [-7, 7]`. The reader must therefore compute, independently per byte,
`n < 8 ? n : n - 16`, i.e. `(n ^ 8) - 8`. The kernel instead does:

```cpp
lo = (lo ^ 0x08080808) - 0x08080808;   // ONE 32-bit subtract — lanes not independent
```

After the XOR, a negative weight's byte holds `c = n ^ 8 < 8`, so `c - 8` borrows into
the next-higher byte. Host replication of the exact expression mismatches the per-byte
decode on **886 of 1000 random words**; concrete example: packed nibbles for weights
`[-6, 2, 3, -2]` decode as `[-6, 1, 3, -2]` — the `2` became `1` because the `-6`
below it borrowed.

## Where it bites (the scored path)

For the Qwen3.6-35B **UD** model the DFlash draft head defaults through
Q4_K requant → i8 prepack → **i4 prepack** (`hidden == 2048`,
`SPARKINFER_DFLASH_HEAD_I4` default on), so every draft block scores its proposals
against these corrupted logits. **Emitted tokens are unaffected by construction** —
every accepted token is still the target's argmax — but draft ranking quality, and
with it acceptance length and DFLASH_TPS, is silently degraded. Qwythos-9B
(`hidden == 4096`) takes the `K != 2048` early-out and never runs this kernel.

## Fix

```cpp
lo = __vsubss4(lo ^ 0x08080808, 0x08080808);
hi = __vsubss4(hi ^ 0x08080808, 0x08080808);
```

Per-byte saturating subtract; saturation never engages (`(n ^ 8) - 8 ∈ [-8, 7]`).
Identical idiom to `si_vec_dot_q6_K` and `gemv_q6k_dp4a_multirow_kernel` in the same
file. Packed words containing no negative nibble decode byte-identically before and
after. No signature, launcher, header, or runtime change; `pack_i8_rows_i4_kernel` is
the only producer and this kernel the only consumer of the layout.

## Verification (hardware disclosed: RTX 5070 Ti 16GB, WSL2, CUDA 12.8, sm_120)

- Synthetic device harness (N=64, K=2048, M=3): random int8 weights →
  `launch_pack_i8_rows_i4` → `launch_gemv_i4_q81_multirow_f32` with device-quantized
  Q8_1 activations, compared against a host reference computed from the ACTUAL packed
  bytes with correct per-nibble decoding, all 192 outputs: unfixed kernel deviates
  **mean 81% relative, max 53x**; this branch matches to **max_rel 1.5e-05**.
- ctest **10/10**; Qwythos-9B prefill_check identical to main (TOP1 8/8, KL 0.00713,
  seed 82) and bench in family (path not engaged at hidden 4096).
- The 22 GB Qwen3.6 UD target does not fit this box — the end-to-end
  acceptance-length effect is stated, not measured. On a 5090:
  `SPARKINFER_DFLASH_HEAD_I4=1` vs `0` A/B before/after should show i4 tracking i8
  after the fix (today it deviates and is biased negative).