### PR TITLE
perf(dflash): overlap the GDN commit with the next draft block; pin the draft id staging

### DIFF
--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -285,6 +285,7 @@ struct DFlashDraftModel::Impl {
     void* head_q8 = nullptr;        // [B] Q8_1 rows of xn for the multi-row head MMVQ
     int *d_ids = nullptr, *d_out = nullptr;
     int *h_out = nullptr;
+    int *h_ids = nullptr;   // pinned staging for the block's noise ids
 
     // Per-layer contiguous KV cache: [max_seq, n_kv, d]
     std::vector<bf16*> k_cache, v_cache;
@@ -341,6 +342,7 @@ DFlashDraftModel::~DFlashDraftModel() {
     if (!p_) return;
     for (void* p : p_->owned) cudaFree(p);
     if (p_->h_out) cudaFreeHost(p_->h_out);
+    if (p_->h_ids) cudaFreeHost(p_->h_ids);
     if (p_->stream) cudaStreamDestroy(p_->stream);
     delete p_;
     p_ = nullptr;
@@ -513,6 +515,7 @@ bool DFlashDraftModel::load(const std::string& dir) {
     s.d_ids = s.alloc<int>(B);
     s.d_out = s.alloc<int>(B);
     cu(cudaHostAlloc(&s.h_out, B * sizeof(int), cudaHostAllocDefault), "h_out");
+    cu(cudaHostAlloc(&s.h_ids, B * sizeof(int), cudaHostAllocDefault), "h_ids");
 
     s.k_cache.resize(s.cfg.n_layers);
     s.v_cache.resize(s.cfg.n_layers);
@@ -589,7 +592,20 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // for the current checkpoint); any other block_size falls back to the per-token GEMV loop.
     const bool fast16 = (BW == 16 || BW == 8 || BW == 4);
 
-    cu(cudaMemcpyAsync(s.d_ids, noise_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
+    // Stage the ids through pinned memory: an async H2D from the caller's pageable buffer
+    // makes the driver bounce it through an internal staging area, stalling this thread while
+    // the stream still has the previous step's tail in flight. The memcpy into the pinned
+    // buffer is nanoseconds; the async copy out of it is a true fire-and-forget.
+    static const bool pinned_ids = [] {
+        const char* e = getenv("SPARKINFER_DFLASH_PINNED_IDS");
+        return !(e && e[0] == '0');
+    }();
+    if (pinned_ids && s.h_ids) {
+        memcpy(s.h_ids, noise_ids, (size_t)BW * sizeof(int));
+        cu(cudaMemcpyAsync(s.d_ids, s.h_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
+    } else {
+        cu(cudaMemcpyAsync(s.d_ids, noise_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
+    }
     kernels::launch_embedding(s.d_ids, s.embed, s.noise, BW, H, st);
 
     // target_hidden [ctx, n_cap*H] -> fc -> hidden_norm -> target_proj [ctx, H]

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1685,7 +1685,16 @@ verify_forward_done:
                 s.w.layers[L].ssm_a, state, keep, c.linear_q_heads, vh, c.linear_head_dim, st);
         }
     }
-    pf_cu(cudaStreamSynchronize(st), "verify commit");
+    // No barrier after the commit: the host reads nothing the commit kernels produce, and every
+    // consumer of the GDN state they update (the next verify/prefill pass) runs on this same
+    // stream, so stream order already protects it. Syncing here serialized the next step's draft
+    // launch ramp behind the commit for no correctness benefit; letting them overlap hides the
+    // commit entirely. SPARKINFER_DFLASH_COMMIT_SYNC=1 restores the old barrier (A/B).
+    static const bool commit_sync = [] {
+        const char* e = getenv("SPARKINFER_DFLASH_COMMIT_SYNC");
+        return e && e[0] == '1';
+    }();
+    if (commit_sync) pf_cu(cudaStreamSynchronize(st), "verify commit");
     return keep;
 }
 


### PR DESCRIPTION
# Summary

  Two small host-side changes to the DFlash decode loop:

  1. `dflash_verify_short_run` no longer issues a `cudaStreamSynchronize` after launching the
     post-verification GDN commit kernels. The host reads nothing those kernels produce, and every
     GPU-side consumer of the state they update (the next verify/prefill pass) runs on the same
     stream, so stream order already guarantees correctness. The barrier only serialized the next
     step's draft launch ramp behind the commit. `SPARKINFER_DFLASH_COMMIT_SYNC=1` restores the old
     barrier for A/B.

  2. `DFlashDraftModel::forward_block` stages the block's noise ids through a pinned host buffer
     before the async H2D copy, instead of an async copy from the caller's pageable `std::vector`
     (which bounces through a driver staging area and stalls the launching thread).
     `SPARKINFER_DFLASH_PINNED_IDS=0` restores the old path.

  DFlash output is unchanged: greedy DFlash still reproduces AR exactly —
  `qwen3_gguf_dflash_check` (32 new tokens): `SPEC_AGREE 1.0000`, `VERDICT PASS` at primary, 512,
  and 4096 contexts with the new defaults.

  Scope note: the measured effect is small (+0.28% decode at the primary context, noise-level at
  512/4k). Node-level nsys profiling shows the decode loop is ~94% GPU-busy inside the verify
  graph's MoE GEMVs, so no larger launch/sync win was available on this path; this removes a host
  barrier that served no correctness purpose.

  # Proof of Speedup

  - [x] Tested on **RTX 5090** (`sm_120`)

  Setup: RTX 5090 32 GB (Vast.ai), CUDA 13.2 toolkit / 570.211.01 driver, upstream main @ 922fff0.
  Held-out prompts from `bench/scripts/gen_eval_prompt.py` (seed `fixed`), 128 generated tokens,
  5 alternating same-binary A/B pairs per context (old behavior restored via the env switches
  above), separate process per run. Values below are medians of 5.

  ## Decode tok/s (DFlash, Qwen3.6-35B-A3B UD-Q4_K_M + z-lab DFlash draft)

  | metric | before (main) | after (this PR) |
  |---|---|---|
  | DFLASH_TPS @ primary (~128) | 924.44 | 926.99 |
  | DFLASH_TPS @ 512 | 466.98 | 466.83 |
  | DFLASH_TPS @ 4096 | 445.03 | 444.98 |

  MEAN_ACCEPT identical in every pair (5.3333 / 2.1864 / 3.9091 at primary/512/4096).

  after (this PR), primary context, representative run

  METRIC AR_TPS 299.2676
  METRIC DFLASH_TPS 927.5865
  METRIC MEAN_ACCEPT 5.3333
  before (env-restored old behavior), same binary, same box

  METRIC AR_TPS 299.1298
  METRIC DFLASH_TPS 924.4861
  METRIC MEAN_ACCEPT 5.3333
  correctness, new defaults

  METRIC SPEC_AGREE 1.0000
  VERDICT PASS   (primary, 512, and 4096)
  
  