### PR TITLE
perf(dflash): decode autoregressively once the batched verify is out of range (1.13x @512/4k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1986,6 +1986,29 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 3;
         return v < 1 ? 1 : v;
     }();
+    // Bound above which the row-batched verify is not used (see the engage comment in the loop).
+    // Hoisted out of the loop because the decision below has to be made before the first draft.
+    static const int kCompactMaxSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_COMPACT_MAX_SEQ");
+        return e ? atoi(e) : 384;
+    }();
+    // Speculation only pays when the row-batched verify runs.
+    //
+    // On the token-loop path the target runs one forward for block[0] plus one per accepted
+    // proposal, and the step emits exactly that many tokens (keep = accept + 1). That is ONE
+    // target forward per emitted token -- precisely what plain AR decode does. The proposals
+    // never collapse a forward there; they only decide when the loop early-exits. So the draft
+    // block is pure additive cost and DFlash decodes strictly SLOWER than not speculating.
+    // Measured, RTX 5090, Qwen3.6-35B-A3B UD-Q4_K_M, 128 generated tokens, bf16 KV:
+    // AR decode 524.2 tok/s at 512-ctx and 499.0 at 4k, against DFlash 459.6 and 440.0 --
+    // a 12.3% and 11.8% loss for running the draft.
+    //
+    // Whether the batched verify can run is `start + B <= kCompactMaxSeq`, and `start` only
+    // grows, so that predicate is MONOTONE: once it is false it is false for the rest of the
+    // generation and no proposal can ever be cashed in again. Detect that and stop drafting --
+    // the tokens emitted afterwards are AR's, produced by the same forward_token() plain
+    // generate() calls, so this trades no accuracy for the speed.
+    bool spec_off = false;
     int compact_score = 0;
     bf16* th_scratch = nullptr;
     const int row_stride = dflash_hidden_row_stride();
@@ -1997,10 +2020,35 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     }
     // Build the verify replay graph before the decode clock starts. Capture records kernels
     // rather than running them, so this changes no state -- it just stops decode step 2 from
-    // paying for graph construction.
-    dflash_warm_verify(kProposalDepth + 1, start);
+    // paying for graph construction. Skip it when the batched verify is already out of range at
+    // the first step, since it can never come back into range and the graph would go unused.
+    if (compact_mode == 1 || (start + B) <= kCompactMaxSeq)
+        dflash_warm_verify(kProposalDepth + 1, start);
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
+        // The batched verify is permanently out of reach from here on, so a proposal can no
+        // longer save a target forward. Decode autoregressively: one forward per token, the
+        // same call plain generate() makes, with no draft block and no capture rows on the
+        // target graph.
+        if (!spec_off && compact_mode != 1 && (start + B) > kCompactMaxSeq) {
+            spec_off = true;
+            // Also drops the per-layer capture-row copies the target graph carries for the
+            // draft -- dead weight once nothing drafts -- and restores the adaptive n_splits
+            // that plain AR decode uses.
+            set_dflash_capture(false, {}, 0);
+        }
+        if (spec_off) {
+            out.push_back(next);
+            if (next == s.cfg.eos_id || (int)out.size() >= max_new) break;
+            const int p = forward_token(next, start, true);
+            if (p < 0) { fprintf(stderr, "[dflash] AR fallback failed at %d\n", start); break; }
+            start += 1;
+            next = p;
+            accept_sum += 1.0;
+            steps++;
+            if (gov) gov->pace();
+            continue;
+        }
         // Second condition: only run the batched path where it is VERIFIED bit-exact against AR.
         // The row-batched pass computes a position as one row of an N-row GEMM where AR computes
         // it as a single-row GEMV; the two reduction orders are not bit-identical, and once the
@@ -2017,10 +2065,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // bound every context runs the token loop, which is byte-exact at any length -- i.e.
         // main's code path, unchanged. Raise SPARKINFER_DFLASH_COMPACT_MAX_SEQ to re-test the
         // long-context path once that numerical gap is closed.
-        static const int kCompactMaxSeq = []{
-            const char* e = getenv("SPARKINFER_DFLASH_COMPACT_MAX_SEQ");
-            return e ? atoi(e) : 384;
-        }();
         const bool compact_ctx_ok = (start + B) <= kCompactMaxSeq;
         const bool compact_verify = compact_mode == 1 ||
             (compact_mode != 0 && compact_ctx_ok && compact_score >= kBlockScore);


### PR DESCRIPTION
## Summary

Where the row-batched compact verify cannot run, DFlash performs **one target forward per emitted token — exactly what plain AR decode does** — so the draft block buys nothing and costs its own forward. That condition is monotone, so this detects it and stops drafting: **+13.4% decode at both 512-ctx and 4k**, with the 128-ctx compact path untouched.

## Why the draft cannot pay there

In the token-loop path (`compact_verify == false`) the target runs one forward for `block[0]` plus one per accepted proposal, and the step emits exactly that many tokens (`keep = accept + 1`). The proposals never collapse a forward; they only decide when the loop early-exits. Only the batched verify converts proposals into saved forwards. So on that path DFlash decodes *strictly slower* than not speculating at all:

| ctx | AR decode (`qwen3_gguf_bench`, bf16 KV) | DFlash (main) | |
|---|--:|--:|--|
| 512 | 524.2 | 459.6 | **−12.3%** |
| 4k | 499.0 | 440.0 | **−11.8%** |

Whether the batched verify can run is `start + B <= kCompactMaxSeq`, and `start` only grows — the predicate is **monotone**. Once false it is false for the rest of the generation and no proposal can ever be cashed in again. This PR detects exactly that point and switches to autoregressive decode using the same `forward_token()` calls plain `generate()` makes, also detaching the capture rows the target graph carries for the draft and skipping the verify-graph warm-up that would go unused.

Tokens emitted after the switch are AR's by construction, so this trades no accuracy for the speed. `τ → 1.0` at 512/4k is the intended consequence of not speculating, not a changed token stream — SPEC_AGREE stays 128/128 at every context tested.

Behaviour at short context is bit-for-bit unchanged: at 128-ctx the bound is never exceeded, the compact path engages exactly as on main, and τ stays 5.3333 over 24 steps.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, 4k-ctx — the best of the three scored contexts):

| | decode tok/s |
|---|--:|
| before (main) | 440.31 |
| after (this PR) | 499.44 |

**Prefill pp tok/s** — not applicable; this PR changes only the DFlash decode loop (`dflash_generate`) and touches no prefill path.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

```text
Qwen3.6-35B-A3B UD-Q4_K_M + DFlash draft, RTX 5090, NTOK=128, 2-rep alternating A/B
main = 922fff0 (#720)

                                     DFLASH_TPS       tau    steps
main    128-ctx  rep1                  911.2985    5.3333       24
PR      128-ctx  rep1                  910.0484    5.3333       24
main    512-ctx  rep1                  459.7510    2.1864       59
PR      512-ctx  rep1                  521.4045    1.0000      127
main    4k-ctx   rep1                  440.6651    3.9091       33
PR      4k-ctx   rep1                  499.2211    1.0000      127
main    128-ctx  rep2                  905.8867    5.3333       24
PR      128-ctx  rep2                  906.7573    5.3333       24
main    512-ctx  rep2                  459.2876    2.1864       59
PR      512-ctx  rep2                  521.0271    1.0000      127
main    4k-ctx   rep2                  439.9533    3.9091       33
PR      4k-ctx   rep2                  499.6582    1.0000      127

                 main        PR       delta
128-ctx        908.59    908.40      -0.02%   (compact path untouched, tau/steps identical)
512-ctx        459.52    521.22     +13.42%
4k-ctx         440.31    499.44     +13.43%

Correctness — qwen3_gguf_dflash_check, 128 generated tokens (not the 32-token default):
  fixed  ctx505  ctx511  ctx512  ctx1024  ctx2048  ctx3072  ctx4096  s2  s5  dflash-a  dflash-b
  all 128/128 = 1.0000, VERDICT PASS

  bench/scripts/dflash_accuracy.sh ................ VERDICT PASS (SPEC_AGREE 32/32)
  dflash_gdn_checkpoint_gpu_test .................. PASS

No Qwen3.5/3.6 decode regression (qwen3_gguf_bench <gguf> 64, 2 reps alternating):
  main  533.53, 533.38 tok/s
  PR    533.46, 533.32 tok/s        -0.01%
```