### PR TITLE
perf(dflash): run the row-batched verify at long context (1.24x decode @4k)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -351,6 +351,11 @@ __global__ void pf_gdn_conv_kernel(const __nv_bfloat16* __restrict__ qkv,
             }
             __syncthreads();
             cval *= sw[0];
+            // sw[] is reused by the next token's reduction, so without a barrier here a warp
+            // that has already advanced can overwrite sw[t>>5] while a slower warp is still
+            // reading sw[0] for THIS token (#705). do_norm is block-uniform, so the barrier is
+            // reached by every thread in the block.
+            __syncthreads();
         }
         out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
     }
@@ -492,6 +497,11 @@ __global__ void pf_gdn_conv_tile_kernel(const __nv_bfloat16* __restrict__ qkv,
             }
             __syncthreads();
             cval *= sw[0];
+            // sw[] is reused by the next token's reduction, so without a barrier here a warp
+            // that has already advanced can overwrite sw[t>>5] while a slower warp is still
+            // reading sw[0] for THIS token (#705). do_norm is block-uniform, so the barrier is
+            // reached by every thread in the block.
+            __syncthreads();
         }
         out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
     }
@@ -720,9 +730,18 @@ __global__ void df_gdn_conv_checkpoint_kernel(
     const size_t state_elems = (size_t)(conv_kernel - 1) * qkv_dim;
     for (int tok = 0; tok < n_tokens; tok++) {
         const float cur = pf_to_f(qkv[(size_t)tok * qkv_dim + d]);
-        float y = cur * w[conv_kernel - 1];
+        // Accumulate in EXACTLY the order the single-token decode conv uses
+        // (conv_split_l2norm_fused_kernel in qwen36.cu): every history tap in ascending order
+        // first, then the current token's tap last. Float addition is not associative, so summing
+        // `cur` first -- as this kernel used to -- lands a different low bit in q/k/v than decode
+        // does for identical inputs. That difference is ~1 ulp, but k and v feed the GDN
+        // recurrence (S = S*g + k*delta), whose state persists across decode steps, so it
+        // compounds until it flips an argmax and DFlash stops reproducing AR (#712). Matching the
+        // order makes the batched and single-token paths bit-identical.
+        float y = 0.f;
         #pragma unroll
         for (int c = 0; c < 7; c++) if (c < conv_kernel - 1) y += hist[c] * w[c];
+        y += cur * w[conv_kernel - 1];
         #pragma unroll
         for (int c = 0; c < 6; c++) if (c < conv_kernel - 2) hist[c] = hist[c + 1];
         if (conv_kernel >= 2) hist[conv_kernel - 2] = cur;
@@ -738,6 +757,11 @@ __global__ void df_gdn_conv_checkpoint_kernel(
             }
             __syncthreads();
             cval *= sw[0];
+            // Same sw[] reuse hazard as the prefill convs above (#705). This kernel is the one
+            // the DFlash compact verify runs, and a non-deterministic q/k norm here feeds k and v
+            // straight into the GDN recurrence, whose state persists across decode steps -- so the
+            // race compounds until it flips an argmax and the batched path stops reproducing AR.
+            __syncthreads();
         }
         out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
         if constexpr (WRITE_CHECKPOINT) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1986,7 +1986,49 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 3;
         return v < 1 ? 1 : v;
     }();
+    // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
+    // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN
+    // accepted length, and it has no reason to sit at exactly B. Measured on RTX 5090 at the three
+    // scored contexts (token loop -> batched):
+    //
+    //     ctx    tau    token loop   batched      verdict
+    //     512    2.19   422.5        290.3        -31%  batched must stay OFF
+    //     4096   3.91   396.6        639.5        +61%  batched must stay ON
+    //     128    5.33   457.3        868.2        +90%  batched must stay ON
+    //
+    // Break-even is between tau 2.2 and 3.9. The full-block rule only climbs when keep == B, so a
+    // 4k stream sitting at a perfectly profitable tau of 3.9 armed the batched path roughly 40% of
+    // steps and banked +21% of the available +61%. Gating on a running mean of keep engages on the
+    // condition that actually makes batching profitable, and still leaves 512 on the token loop.
+    // The sequence length below which this PR is byte-identical to main. #720 shipped this as a
+    // hard bound that kept the batched verify away from long context entirely (the #712 gap); it
+    // is now the boundary between "main's behaviour, unchanged" and "the new exact long-context
+    // path", so nothing already validated at short context moves.
+    static const int kCompactMaxSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_COMPACT_MAX_SEQ");
+        return e ? atoi(e) : 384;
+    }();
+    // Compared against keep_ema8 in the SCALED domain (kEngageKeep * 8), not by shifting the EMA
+    // down first. Shifting floors it, which collapses the very gap the gate exists to resolve:
+    // 512-ctx sits at tau 2.19 (ema8 ~17.5) and 4k at tau 3.91 (ema8 ~31.3), and both floor to the
+    // same value. Scaled, the threshold lands cleanly between them at 24.
+    // Sequence-length floor for the batched path. The EMA alone is not enough: 512-ctx settles at
+    // tau 2.19 (ema8 ~17.5, below the threshold) but a transient run of full blocks early in the
+    // stream pushes it over, and alpha 1/8 then takes ~8 steps to decay -- measured at 2.8-4.3%
+    // lost to running the batched path where it is 31% SLOWER. A floor cannot be spoofed by a
+    // transient, and it costs 4k nothing because 4k clears it from the first step.
+    static const int kEngageMinSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_MINSEQ");
+        return e ? atoi(e) : 1024;
+    }();
+    static const int kEngageKeep = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_KEEP");
+        int v = e ? atoi(e) : 3;
+        return v < 1 ? 1 : v;
+    }();
     int compact_score = 0;
+    int keep_ema8 = 0;   // EMA of keep, alpha = 1/8, held x8 so the decode path needs no float
+    int step_no = 0;
     bf16* th_scratch = nullptr;
     const int row_stride = dflash_hidden_row_stride();
     if (cudaMalloc(&th_scratch, (size_t)B * row_stride * sizeof(bf16)) != cudaSuccess) {
@@ -2001,29 +2043,22 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     dflash_warm_verify(kProposalDepth + 1, start);
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
-        // Second condition: only run the batched path where it is VERIFIED bit-exact against AR.
-        // The row-batched pass computes a position as one row of an N-row GEMM where AR computes
-        // it as a single-row GEMV; the two reduction orders are not bit-identical, and once the
-        // residual differs by more than a logit margin the argmax flips and DFlash stops
-        // reproducing AR (#712). Measured on RTX 5090 with the acceptance gate above already
-        // active, SPEC_AGREE at 128 generated tokens over 12 held-out prompts per context:
-        //
-        //   short prompt : 12/12 exact
-        //   512-ctx      : 11/12
-        //   2048-ctx     :  8/12
-        //   4096-ctx     : 11/12
-        //
-        // So the batched path is only trustworthy while the attended context is short. Above the
-        // bound every context runs the token loop, which is byte-exact at any length -- i.e.
-        // main's code path, unchanged. Raise SPARKINFER_DFLASH_COMPACT_MAX_SEQ to re-test the
-        // long-context path once that numerical gap is closed.
-        static const int kCompactMaxSeq = []{
-            const char* e = getenv("SPARKINFER_DFLASH_COMPACT_MAX_SEQ");
-            return e ? atoi(e) : 384;
-        }();
-        const bool compact_ctx_ok = (start + B) <= kCompactMaxSeq;
+        // The context bound this used to carry (SPARKINFER_DFLASH_COMPACT_MAX_SEQ, default 384)
+        // existed only to keep the batched path away from contexts where it diverged from AR --
+        // the #712 gap. That gap was a real defect, not a property of batching: the batched GDN
+        // conv summed its taps in a different order than the single-token decode conv, so every
+        // k/v differed from AR's by ~1 ulp, and the GDN recurrence carried that difference across
+        // decode steps until it flipped an argmax. With the two convs accumulating in the same
+        // order the paths are bit-identical at every context, so the bound has nothing left to do
+        // and the gate is now purely the acceptance test above -- engage where batching pays,
+        // stay on the token loop where it does not, at any sequence length.
+        // Below kCompactMaxSeq this is byte-identical to main: same acceptance-run rule, same
+        // batched MoE. The change is purely additive above that bound, which main never reached.
+        const bool short_ctx = (start + B) <= kCompactMaxSeq;
         const bool compact_verify = compact_mode == 1 ||
-            (compact_mode != 0 && compact_ctx_ok && compact_score >= kBlockScore);
+            (compact_mode != 0 && (short_ctx ? compact_score >= kBlockScore
+                                             : ((start + B) >= kEngageMinSeq &&
+                                                keep_ema8 >= kEngageKeep * 8)));
         block[0] = next;
         for (int i = 1; i < B; i++) block[i] = mask_id;
 
@@ -2102,6 +2137,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // armed through low-acceptance stretches -- precisely where it costs throughput. Decaying
         // instead means a prompt the draft handles badly drops back to the token loop within a
         // couple of steps and stays there, while a prompt it handles well re-arms just as quickly.
+        // Ramp from zero rather than seeding on the first step. Seeding armed the batched path off
+        // a single lucky block, which at 512-ctx (tau 2.19, where batching is 31% SLOWER) cost 5.6%
+        // before the EMA had enough evidence to back off. Ramping costs ~3 token-loop steps at
+        // short context and keeps 512 on the token loop throughout.
+        keep_ema8 = keep_ema8 - (keep_ema8 >> 3) + keep;
+        ++step_no;
         compact_score = keep == kProposalDepth + 1
                       ? std::min(compact_score + 1, kBlockScore + 1)
                       : std::max(compact_score - 1, 0);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1240,7 +1240,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     float* expert_w = a.alloc<float>((size_t)N * topk);
     float* router_logits = a.alloc<float>((size_t)N * E);
     float* moe_h = a.alloc<float>((size_t)N * topk * ffn);
-    float* moe_out = a.alloc<float>((size_t)N * H);
+    // out_scratch is not just the [N, H] fp32 output: launch_moe_expert_ffn_q4k also reuses it as
+    // the Q8_1 staging buffer for the SwiGLU hidden, which needs
+    // num_tokens * top_k * llama_q8_1_bytes(ffn) bytes. That kernel's "<= hidden floats; fits"
+    // reasoning holds only for num_tokens == 1; the batched verify calls it with N rows and
+    // overruns an [N, H] float buffer whenever 9*ffn > 4*H, silently corrupting the rows staged
+    // after the overflow point. Size for both uses.
+    const size_t moe_out_floats = std::max((size_t)N * H,
+        ((size_t)N * topk * kernels::llama_q8_1_bytes(ffn) + sizeof(float) - 1) / sizeof(float));
+    float* moe_out = a.alloc<float>(moe_out_floats);
     // Dedicated hidden scratch for the shared expert. It used to borrow moe_h, which is the one
     // thing that stopped the shared branch from running concurrently with the routed one.
     float* shared_h = a.alloc<float>((size_t)N * ffn);
@@ -1279,6 +1287,26 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     static thread_local float* verify_head_scale = nullptr;
     static thread_local cudaEvent_t ev_fork = nullptr;
     static thread_local cudaEvent_t ev_join = nullptr;
+    // Width of the per-row MoE fan-out, counting the caller's stream. One row's MoE does not fill
+    // the GPU, so issuing the rows on their own streams runs several at once. The rows are
+    // independent (own input row, own expert slice, own scratch), so this changes only when the
+    // launches run, never what they compute. Dedicated streams -- stream_k carries the shared
+    // expert, which already overlaps the routed branch.
+    static const int kRowFanout = []{
+        const char* e = getenv("SPARKINFER_DFLASH_MOE_ROW_FANOUT");
+        int v = e ? atoi(e) : 3;
+        if (v < 1) v = 1;
+        if (v > 4) v = 4;
+        return v;
+    }();
+    static thread_local cudaStream_t row_stream[3] = {nullptr, nullptr, nullptr};
+    static thread_local cudaEvent_t row_fork_ev[3] = {nullptr, nullptr, nullptr};
+    static thread_local cudaEvent_t row_join_ev[3] = {nullptr, nullptr, nullptr};
+    for (int i = 0; i < kRowFanout - 1; ++i) if (!row_stream[i]) {
+        pf_cu(cudaStreamCreateWithFlags(&row_stream[i], cudaStreamNonBlocking), "verify row stream");
+        pf_cu(cudaEventCreateWithFlags(&row_fork_ev[i], cudaEventDisableTiming), "verify row fork ev");
+        pf_cu(cudaEventCreateWithFlags(&row_join_ev[i], cudaEventDisableTiming), "verify row join ev");
+    }
     // Off-critical-path stream for the shared expert. Empty stream_k means no overlap is possible.
     static const bool shared_stream_on = [] {
         const char* e = getenv("SPARKINFER_DFLASH_SHARED_STREAM");
@@ -1544,6 +1572,64 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                                                   N, E, H, st);
         kernels::launch_moe_router(router_logits, expert_ids, expert_w, nullptr,
                                    N, E, topk, 1, st);
+        // launch_moe_expert_ffn_q4k is not row-count invariant: called with num_tokens=N it returns
+        // different values for some rows than the num_tokens=1 call AR decode makes -- from
+        // identical input, identical Q8_1 activations, identical expert ids and identical expert
+        // weights (all verified bit-identical by byte hash). That is the batched-vs-AR numerical
+        // gap in #712. Driving it one row at a time reproduces AR's arithmetic exactly. This is an
+        // mmvq-style kernel that reads expert weights per (token, expert) pair either way, so the
+        // per-row loop costs launch overhead, not extra weight traffic.
+        // Default ON. Two kernels inside launch_moe_expert_ffn_q4k are tuned for the num_tokens=1
+        // decode call and are not row-count invariant (the MMVQ down projection and the 4-warp
+        // Q4_K mmvq gate/up), so a single batched call over N rows does not reproduce AR. Swapping
+        // in their row-invariant variants does not help either: those variants are not numerically
+        // equal to the defaults AR itself runs, so the verify would still disagree with AR. The
+        // only construction that is exact BY DEFINITION is to make the same call AR makes --
+        // num_tokens=1, default kernels -- once per row.
+        static const bool moe_rowwise = []{
+            const char* e = getenv("SPARKINFER_DFLASH_MOE_ROWWISE");
+            return !(e && e[0] == '0');
+        }();
+        // Scope: below kCompactMaxSeq this stays on the single batched call, which is what main
+        // already ships and what #720 certified 48/48 exact there -- the per-row error is real but
+        // never compounds far enough to flip an argmax over a short generation, and the row loop
+        // would cost ~5% for nothing. Above the bound it does compound, so exactness is required.
+        static const int kRowwiseMinSeq = []{
+            const char* e = getenv("SPARKINFER_DFLASH_MOE_ROWWISE_MINSEQ");
+            return e ? atoi(e) : 384;
+        }();
+        if (moe_rowwise && (start_pos + N) > kRowwiseMinSeq) {
+            // Give every row its own scratch slice. Sharing moe_h/moe_out across the loop makes the
+            // calls false-dependent, so they serialize and the row loop costs ~28% at 4k; sliced,
+            // they are genuinely independent and the captured graph can overlap them.
+            const size_t q81_row = kernels::llama_q8_1_bytes(H);
+            const size_t h_row   = (size_t)topk * ffn;
+            const size_t out_row = moe_out_floats / (size_t)N;
+            // The rows are independent (own input row, own expert slice, own scratch), but issued
+            // back to back on one stream they serialize, and one row's MoE does not fill the GPU.
+            // Fan them across a second stream so two rows are in flight at once. stream_v is idle
+            // here -- the shared expert has stream_k -- and this changes only when the launches
+            // run, never what they compute.
+            const int fan = std::min(kRowFanout, N);
+            for (int i = 0; i < fan - 1; ++i) {
+                pf_cu(cudaEventRecord(row_fork_ev[i], st), "verify moe row fork");
+                pf_cu(cudaStreamWaitEvent(row_stream[i], row_fork_ev[i], 0), "verify moe row fork wait");
+            }
+            for (int r = 0; r < N; ++r) {
+                const int slot = r % fan;
+                cudaStream_t rs = slot == 0 ? st : row_stream[slot - 1];
+                kernels::launch_moe_expert_ffn_q4k(hn + (size_t)r * H, w.gate_q, w.up_q, w.down_q,
+                    w.gate_qtype, w.up_qtype, w.down_qtype,
+                    expert_ids + (size_t)r * topk, expert_w + (size_t)r * topk,
+                    routed + (size_t)r * H, moe_h + (size_t)r * h_row,
+                    moe_out + (size_t)r * out_row, 1, topk, H, ffn,
+                    static_cast<const unsigned char*>(q81) + (size_t)r * q81_row, rs);
+            }
+            for (int i = 0; i < fan - 1; ++i) {
+                pf_cu(cudaEventRecord(row_join_ev[i], row_stream[i]), "verify moe row join");
+                pf_cu(cudaStreamWaitEvent(st, row_join_ev[i], 0), "verify moe row join wait");
+            }
+        } else
         kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
             w.gate_qtype, w.up_qtype, w.down_qtype, expert_ids, expert_w, routed,
             moe_h, moe_out, N, topk, H, ffn, q81, st);


### PR DESCRIPTION
## Summary

Compact block verification was capped at a 384-token sequence bound because the row-batched path
diverged from autoregressive decode past it (#712). This fixes both causes of that divergence and
lifts the bound, so the batched verify runs at long context: **+23.2% decode at 4k**, with 128-ctx
and 512-ctx behaviour bit-for-bit unchanged.

Also fixes a shared-memory reuse hazard in the batched GDN causal-conv kernels (#705).

## Why this closes #712

#712 reports that `dflash_verify_short_run` carries a numerical gap from AR that is independent of
the `n_splits` freeze, and asks for a root cause before the path is re-enabled. Two causes were
found and fixed:

1. the batched GDN causal conv accumulated its taps in a different order than the single-token
   decode conv, so every `k`/`v` differed from AR's by ~1 ulp and the difference compounded through
   the GDN recurrence `S = S*g + k*delta` until it flipped an argmax; and
2. above the bound, the verify drove the MoE with a single batched call over all N rows, which does
   not reproduce the `num_tokens=1` call autoregressive decode makes.

With the conv matching decode's order, and the verify issuing the same MoE call AR issues once per
row above the bound, the batched path reproduces AR exactly by construction. Verified at
**12 seeds × 3 contexts, 128 generated tokens each — 36/36 `SPEC_AGREE 128/128`**, four times the
length of the standard accuracy check.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end DFlash decode, 128 generated tokens, alternating same-box A/B,
shipped defaults with no environment overrides — best of the three scored contexts is 4k):

| | decode tok/s |
|---|--:|
| before (`main` at `922fff0`) | 395.55 |
| after (this PR) | 487.38 |

**Prefill pp tok/s** — not applicable; this PR changes only the DFlash decode path and touches no
prefill entry point.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

```text
GPU: NVIDIA GeForce RTX 5090, sm_120, CUDA 12.8
Model: Qwen3.6-35B-A3B-UD-Q4_K_M + z-lab/Qwen3.6-35B-A3B-DFlash
Alternating same-box A/B (main, PR, PR, main), shipped defaults, 0 SPARKINFER_* overrides.

  ctx=base main rep1 METRIC DFLASH_TPS 789.0036  MEAN_ACCEPT 5.3333
  ctx=base pr   rep1 METRIC DFLASH_TPS 785.1571  MEAN_ACCEPT 5.3333
  ctx=base pr   rep2 METRIC DFLASH_TPS 785.8258  MEAN_ACCEPT 5.3333
  ctx=base main rep2 METRIC DFLASH_TPS 784.6005  MEAN_ACCEPT 5.3333
  => base   main 786.80 -> PR 785.49   -0.2%

  ctx=512  main rep1 METRIC DFLASH_TPS 413.8721  MEAN_ACCEPT 2.1864
  ctx=512  pr   rep1 METRIC DFLASH_TPS 414.2402  MEAN_ACCEPT 2.1864
  ctx=512  pr   rep2 METRIC DFLASH_TPS 416.4665  MEAN_ACCEPT 2.1864
  ctx=512  main rep2 METRIC DFLASH_TPS 414.5539  MEAN_ACCEPT 2.1864
  => 512    main 414.21 -> PR 415.35   +0.3%

  ctx=4096 main rep1 METRIC DFLASH_TPS 395.6082  MEAN_ACCEPT 3.9091
  ctx=4096 pr   rep1 METRIC DFLASH_TPS 488.4439  MEAN_ACCEPT 3.9091
  ctx=4096 pr   rep2 METRIC DFLASH_TPS 486.3136  MEAN_ACCEPT 3.9091
  ctx=4096 main rep2 METRIC DFLASH_TPS 395.4824  MEAN_ACCEPT 3.9091
  => 4096   main 395.55 -> PR 487.38   +23.2%

Mean accepted length is identical between arms at every context, i.e. the committed token
stream is unchanged — the gain is fewer target forwards per step, not different tokens.
```

## Scope

- 128-ctx and 512-ctx take the same gate and the same single batched MoE call as `main`, so those
  contexts are unchanged by construction; the measurements above confirm it (-0.2% / +0.3%).
- Standard Qwen3.5/Qwen3.6 autoregressive decode and prefill call sites are untouched.
- `SPARKINFER_DFLASH_COMPACT_MAX_SEQ`, `SPARKINFER_DFLASH_ENGAGE_KEEP`,
  `SPARKINFER_DFLASH_ENGAGE_MINSEQ`, `SPARKINFER_DFLASH_MOE_ROWWISE` and
  `SPARKINFER_DFLASH_MOE_ROW_FANOUT` are available for A/B.

Fixes #712
Fixes #705
