### PR TITLE
fix(runtime): take convert_gguf vocab from token_embd.weight

### DIFF
--- a/runtime/tools/convert_gguf.py
+++ b/runtime/tools/convert_gguf.py
@@ -54,10 +54,12 @@ def main():
         rms_eps=float(meta(A + "attention.layer_norm_rms_epsilon")),
         eos_id=int(meta("tokenizer.ggml.eos_token_id") or 151645),
     )
-    # vocab from token_embd if metadata missing
+    # Prefer embedding-tensor vocab over metadata (matches C++ emb->dims[1]).
     ten = {t.name: t for t in r.tensors}
     if "token_embd.weight" in ten:
-        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
+        shape = ten["token_embd.weight"].shape
+        if len(shape) >= 2:
+            cfg["vocab"] = int(shape[1])
 
     with open(os.path.join(out, "config.txt"), "w") as f:
         for k, v in cfg.items():

--- a/runtime/tools/test_convert_gguf.py
+++ b/runtime/tools/test_convert_gguf.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Regression tests for convert_gguf vocab derivation (issue #637).
+
+  python3 runtime/tools/test_convert_gguf.py
+"""
+import re
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().with_name("convert_gguf.py")
+
+
+class TestConvertGgufVocab(unittest.TestCase):
+    def test_shortcircuit_gone_and_dims1_used(self):
+        src = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotRegex(src, r"if\s+False\s+else")
+        self.assertRegex(
+            src,
+            r'cfg\["vocab"\]\s*=\s*int\(\s*shape\[1\]\s*\)',
+        )
+        self.assertIn("token_embd.weight", src)
+
+    def test_logic_matches_cpp_dims1(self):
+        # Mirror the inlined rule for a few shapes.
+        def vocab(shape, fallback):
+            return int(shape[1]) if len(shape) >= 2 else int(fallback)
+
+        self.assertEqual(vocab((4096, 151936), 1), 151936)
+        self.assertEqual(vocab((2048, 248320), 151936), 248320)
+        self.assertEqual(vocab((151936,), 42), 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`runtime/tools/convert_gguf.py` claimed to prefer `token_embd.weight` for `vocab=` in `config.txt`, but the assignment was permanently short-circuited:

```python
cfg["vocab"] = int(...shape[-1]) if False else cfg["vocab"]
```

The C++ GGUF path always prefers `emb->dims[1]`. This restores that rule (`shape[1]` for 2D ggml `[n_embd, n_vocab]`) and adds a CPU unit test.

Fixes #637

## Proof of speedup

> Tools-only correctness fix - no GPU / no speedup claim. Box left unticked on purpose.
> Non-speed `runtime/` PRs need maintainer **`hold`** (see #638 / #660).

- [ ] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (N/A):

| | decode tok/s |
|---|--:|
| before (main) |  |
| after (this PR) |  |

**Prefill pp tok/s** (N/A):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
$ python3 runtime/tools/test_convert_gguf.py -v
OK
```

## Note for maintainers

Please add **`hold`**, then this can stay ready without a false 5090 attestation.

`build-linux` / `build-windows` attestation fails on every fork PR (`id-token`) - #612. CUDA build itself completes; this diff is Python tooling only.

## Kind of change

- [x] Bug fix (converter tooling)
- [ ] Perf / scored decode or prefill change
