### PR TITLE
docs(server): fix broken PRO 6000 changelog link

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -49,8 +49,8 @@ export SPARKINFER_ROOT="$(pwd)"
 
 ### RTX PRO 6000 deploy (32k / 4k)
 
-See [`changelog-pro6000.md`](../changelog-pro6000.md) for the full 5090→PRO 6000 migration
-notes and benchmark table.
+See [`bench/results/qwen3-30b-a3b_q4km_pro6000.md`](../bench/results/qwen3-30b-a3b_q4km_pro6000.md) for the
+5090→PRO 6000 migration notes and benchmark table.
 
 ```bash
 export CTX=36864          # 32k prompt + 4k completion KV pool


### PR DESCRIPTION
## Summary

`server/README.md` linked to `../changelog-pro6000.md`, which does not exist in the repo, so the PRO 6000 deploy section’s “full migration notes and benchmark table” reference was a dead link. Retarget it to the existing [`bench/results/qwen3-30b-a3b_q4km_pro6000.md`](../blob/main/bench/results/qwen3-30b-a3b_q4km_pro6000.md).

## Kind of change

- [x] Docs fix
- [ ] Perf / scored decode or prefill change

## Verification

Relative link from `server/README.md` resolves to a tracked file. No GPU / no `runtime/`.
