### PR TITLE
fix(quality): point sparkinfer --bin at build/runtime/

### DIFF
--- a/bench/quality/README.md
+++ b/bench/quality/README.md
@@ -43,7 +43,7 @@ python3 run_quality.py --backend mock    # ~0%  - floor
 # 2. score sparkinfer on a GPU box:
 python3 run_quality.py --backend sparkinfer \
     --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf \
-    --bin ./build/qwen3_gguf_generate \
+    --bin ./build/runtime/qwen3_gguf_generate \
     --tokenizer /workspace/models/tokenizer.json
 
 # 3. score the llama.cpp reference (start llama-server first, then):

--- a/bench/quality/run_quality.py
+++ b/bench/quality/run_quality.py
@@ -14,7 +14,7 @@ Usage:
   # sparkinfer:
   python3 run_quality.py --backend sparkinfer \
       --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf \
-      --bin ./build/qwen3_gguf_generate --tokenizer /workspace/models/tokenizer.json
+      --bin ./build/runtime/qwen3_gguf_generate --tokenizer /workspace/models/tokenizer.json
 
   # llama.cpp reference:
   python3 run_quality.py --backend llama --llama-cli /workspace/.llamacpp/build/bin/llama-cli \


### PR DESCRIPTION
## Summary

The quality harness docs still told users to pass `--bin ./build/qwen3_gguf_generate`. The superbuild installs that binary under `build/runtime/` (same path `bench/scripts/_common.sh` uses), so copy-paste runs failed with a missing binary.

Replaces #734 (auto-closed by the 5-PR author cap during a burst open).

## Kind of change

- [x] Bug fix (docs / quality tooling)
- [ ] Perf / scored decode or prefill change

## Verification

```bash
grep -n 'build/runtime/qwen3_gguf_generate' bench/quality/README.md bench/quality/run_quality.py
```

No GPU required. Does not touch `bench/scripts/`.
