### PR TITLE
fix(server): concurrent requests can return another request's error; multimodal content hangs forever

### DIFF
--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -8,6 +8,13 @@
 
 namespace sparkinfer_server {
 
+// Outcome of one complete()/complete_streaming() call. Returned by value so concurrent
+// HTTP worker threads cannot observe or clear each other's failure state.
+struct CompletionResult {
+    std::vector<int> tokens;
+    std::string error;  // empty on success
+};
+
 // Thread-safe wrapper around sparkinfer::Qwen35Model + GGUF load.
 class ModelEngine {
 public:
@@ -30,21 +37,17 @@ public:
     void set_prefix_tokens(const std::vector<int>& tokens);
     int prefix_token_len() const;
 
-    // Greedy decode. Returns generated token ids (not including prompt).
-    // Sets last_error() on failure (empty prompt, context overflow, KV alloc).
-    std::vector<int> complete(const std::vector<int>& prompt_ids, int max_new_tokens);
+    // Greedy decode. Tokens are in .tokens; on failure .tokens is empty and .error is set.
+    CompletionResult complete(const std::vector<int>& prompt_ids, int max_new_tokens);
 
     // Same, but invokes cb after each generated token (for SSE streaming).
-    std::vector<int> complete_streaming(const std::vector<int>& prompt_ids, int max_new_tokens,
+    CompletionResult complete_streaming(const std::vector<int>& prompt_ids, int max_new_tokens,
                                         const std::function<void(int)>& on_token);
-
-    const std::string& last_error() const;
 
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;
     mutable std::mutex mu_;
-    std::string last_error_;
 };
 
 }  // namespace sparkinfer_server

--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -226,18 +226,24 @@ bool parse_chat_messages(const std::string& request_json, std::vector<ChatMessag
                     size_t dummy = 0;
                     extract_json_string(obj, c, dummy, msg.content);
                 } else if (c < obj.size() && obj[c] == '[') {
-                    // Multimodal: concatenate text parts only (images skipped for now).
+                    // Multimodal content parts: only concatenate "text" KEY values.
+                    // A naive find("\"text\"") also matches the type VALUE {"type":"text"},
+                    // and when extract fails `j` never advances → infinite loop / OOM.
                     size_t j = c;
-                    while (j < obj.size()) {
-                        size_t text_key = obj.find("\"text\"", j);
-                        if (text_key == std::string::npos || text_key >= obj.size()) break;
-                        size_t dummy = 0;
+                    const size_t lim = obj.size();
+                    while (j < lim) {
+                        const size_t text_key = obj.find("\"text\"", j);
+                        if (text_key == std::string::npos) break;
+                        j = text_key + 6;  // always past this match — scan cannot rewind
+                        size_t v = j;
+                        while (v < lim && (obj[v] == ':' || obj[v] == ' ')) ++v;
+                        if (v == j || v >= lim || obj[v] != '"') continue;  // type value, not a key
+                        size_t part_end = 0;
                         std::string piece;
-                        if (extract_json_string(obj, text_key + 6, dummy, piece)) {
-                            if (!msg.content.empty()) msg.content.push_back(' ');
-                            msg.content += piece;
-                        }
-                        j = dummy;
+                        if (!extract_json_string(obj, v, part_end, piece)) break;
+                        if (!msg.content.empty()) msg.content.push_back(' ');
+                        msg.content += piece;
+                        j = part_end;
                     }
                 }
             }

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -172,43 +172,38 @@ int ModelEngine::prefix_token_len() const {
     return (int)impl_->prefix_tokens.size();
 }
 
-const std::string& ModelEngine::last_error() const {
-    std::lock_guard<std::mutex> lock(mu_);
-    return last_error_;
-}
-
-std::vector<int> ModelEngine::complete(const std::vector<int>& prompt_ids, int max_new_tokens) {
+CompletionResult ModelEngine::complete(const std::vector<int>& prompt_ids, int max_new_tokens) {
     return complete_streaming(prompt_ids, max_new_tokens, nullptr);
 }
 
-std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_ids,
+CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_ids,
                                                  int max_new_tokens,
                                                  const std::function<void(int)>& on_token) {
+    CompletionResult out;
     sparkinfer::ContinuousBatchEngine::Request req;
     req.prompt = prompt_ids;
     req.max_new_tokens = max_new_tokens;
 
     {
         std::lock_guard<std::mutex> lock(mu_);
-        last_error_.clear();
         if (!impl_->ready || !impl_->model || !impl_->batch_engine) {
-            last_error_ = "model not loaded";
-            return {};
+            out.error = "model not loaded";
+            return out;
         }
         if (prompt_ids.empty()) {
-            last_error_ = "empty prompt";
-            return {};
+            out.error = "empty prompt";
+            return out;
         }
         if (max_new_tokens <= 0) {
-            last_error_ = "max_new_tokens must be positive";
-            return {};
+            out.error = "max_new_tokens must be positive";
+            return out;
         }
         if ((int)prompt_ids.size() + max_new_tokens > impl_->cfg.max_seq) {
-            last_error_ = "prompt + max_tokens exceeds context limit (" +
-                          std::to_string(impl_->cfg.max_seq) + ")";
+            out.error = "prompt + max_tokens exceeds context limit (" +
+                        std::to_string(impl_->cfg.max_seq) + ")";
             fprintf(stderr, "[sparkinfer-server] context overflow: prompt=%zu max_new=%d max_seq=%d\n",
                     prompt_ids.size(), max_new_tokens, impl_->cfg.max_seq);
-            return {};
+            return out;
         }
 
         // Shared prefix KV (session 0) is only safe when no other request is in-flight.
@@ -218,9 +213,9 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
         if (prefix_match && prefix_exclusive) {
             if (impl_->model->prefix_cached_len() != (int)impl_->prefix_tokens.size()) {
                 if (!impl_->model->cache_prefix(impl_->prefix_tokens)) {
-                    last_error_ = "cache_prefix failed (KV alloc or batched prefill)";
-                    fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
-                    return {};
+                    out.error = "cache_prefix failed (KV alloc or batched prefill)";
+                    fprintf(stderr, "[sparkinfer-server] %s\n", out.error.c_str());
+                    return out;
                 }
             }
             req.prefill_start = (int)impl_->prefix_tokens.size();
@@ -232,24 +227,28 @@ std::vector<int> ModelEngine::complete_streaming(const std::vector<int>& prompt_
         }
     }
 
+    // complete_streaming releases the engine mutex above so other HTTP workers can enqueue.
+    // Errors must travel with this stack frame — a shared last_error_ slot would let one
+    // request clear or observe another request's failure under concurrency.
     auto result = impl_->batch_engine->complete_streaming(req, on_token);
 
     std::lock_guard<std::mutex> lock(mu_);
     if (!result.error.empty()) {
-        last_error_ = result.error;
-        fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
-        return {};
+        out.error = result.error;
+        fprintf(stderr, "[sparkinfer-server] %s\n", out.error.c_str());
+        return out;
     }
 
     cudaError_t e = cudaGetLastError();
     if (e != cudaSuccess) {
-        last_error_ = std::string("cuda error after decode: ") + cudaGetErrorString(e);
-        fprintf(stderr, "[sparkinfer-server] %s\n", last_error_.c_str());
-        return {};
+        out.error = std::string("cuda error after decode: ") + cudaGetErrorString(e);
+        fprintf(stderr, "[sparkinfer-server] %s\n", out.error.c_str());
+        return out;
     }
     if (result.tokens.empty() && max_new_tokens > 0)
-        last_error_ = "generate returned no tokens (KV alloc failure?)";
-    return result.tokens;
+        out.error = "generate returned no tokens (KV alloc failure?)";
+    out.tokens = std::move(result.tokens);
+    return out;
 }
 
 }  // namespace sparkinfer_server

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -319,14 +319,14 @@ int main(int argc, char** argv) {
                                  write_stream_delta(sink, cid, created, "reasoning_content", delta.reasoning_content);
                                  write_stream_delta(sink, cid, created, "content", delta.content);
                              };
-                             engine.complete_streaming(prompt_ids, max_tokens, on_tok);
+                             const auto outcome = engine.complete_streaming(prompt_ids, max_tokens, on_tok);
                              sparkinfer_server::ThinkingStreamSplitter::Delta flush;
                              splitter.finish(flush);
                              write_stream_delta(sink, cid, created, "reasoning_content", flush.reasoning_content);
                              write_stream_delta(sink, cid, created, "content", flush.content);
-                             if (!engine.last_error().empty()) {
+                             if (!outcome.error.empty()) {
                                  std::ostringstream err_chunk;
-                                 err_chunk << "data: {\"error\":{\"message\":\"" << json_escape(engine.last_error())
+                                 err_chunk << "data: {\"error\":{\"message\":\"" << json_escape(outcome.error)
                                            << "\"}}\n\n";
                                  sink.write(err_chunk.str().c_str(), (size_t)err_chunk.str().size());
                              }
@@ -350,15 +350,15 @@ int main(int argc, char** argv) {
                      return;
                  }
 
-                 std::vector<int> gen = engine.complete(prompt_ids, max_tokens);
+                 const auto outcome = engine.complete(prompt_ids, max_tokens);
                  std::string text;
-                 if (!engine.last_error().empty()) {
+                 if (!outcome.error.empty()) {
                      res.status = 400;
-                     res.set_content("{\"error\":{\"message\":\"" + json_escape(engine.last_error()) + "\"}}",
+                     res.set_content("{\"error\":{\"message\":\"" + json_escape(outcome.error) + "\"}}",
                                      "application/json");
                      return;
                  }
-                 if (!decode_ids(gen, text, err)) {
+                 if (!decode_ids(outcome.tokens, text, err)) {
                      res.status = 500;
                      res.set_content("{\"error\":{\"message\":\"" + json_escape(err) + "\"}}",
                                      "application/json");
@@ -375,7 +375,7 @@ int main(int argc, char** argv) {
                      body << ",\"reasoning_content\":\"" << json_escape(parsed.reasoning_content) << "\"";
                  body << ",\"content\":\"" << json_escape(parsed.content) << "\""
                       << "},\"finish_reason\":\"stop\"}],"
-                      << usage_json((int)prompt_ids.size(), (int)gen.size()) << "}";
+                      << usage_json((int)prompt_ids.size(), (int)outcome.tokens.size()) << "}";
                  res.set_content(body.str(), "application/json");
              });
 


### PR DESCRIPTION
## Summary

Two production correctness bugs in `sparkinfer_server`:

1. **Concurrent error bleed** — `ModelEngine` kept one shared `last_error_` string, but continuous batching runs multiple HTTP workers at once. A valid completion can get `HTTP 400` with another request's message (or a dangling reference after another thread clears/reallocates the slot).
2. **Multimodal hang / OOM** — content-parts parsing treats every `"text"` substring as a key. On `{"type":"text",...}` the extract fails and `j` never advances, so one chat request loops forever growing a string until OOM.

## Root cause

- Error state was process-global while the request path is concurrent by design (`complete_streaming` releases `mu_` while the batch engine runs).
- The multimodal scanner did not distinguish a `"text"` **key** from the `"text"` **value** of `"type"`, and did not guarantee forward progress on extract failure.

## Fix approach

- Replace shared `last_error_` with a **`CompletionResult { tokens, error }` returned by value**; update `/v1/chat/completions` to use `outcome.error`. Failures travel with the calling stack frame.
- In multimodal parsing, only accept `"text"` when followed by `:` + a string, always advance past each match, and stop if extract fails.

Touches only `server/` (no `runtime/` / kernels / eval harness). Not a speedup claim — no RTX 5090 eval requested.

## Impact

- Concurrent completions report the correct per-request error (or success).
- OpenAI-style multimodal `content` arrays no longer hang the server worker.
- Backward compatible at the HTTP API; C++ callers of `ModelEngine` must use `CompletionResult` instead of `last_error()`.

## Risk / tradeoffs

- Small C++ API change for `ModelEngine` (`complete` / `complete_streaming` return type). HTTP JSON API unchanged.
- Images in multimodal parts remain skipped (same as before); only text parts are concatenated.

## Test plan

- [x] `cmake -B build -DBUILD_SERVER=ON && cmake --build build -j --target sparkinfer_server` succeeds
- [x] `ctest --test-dir build` — 10/10 passed
- [ ] Manual: two overlapping `/v1/chat/completions` where one fails validation — the other must not receive its error
- [ ] Manual: `content: [{"type":"text","text":"hello"}]` completes without hanging


Made with [Cursor](https://cursor.com)