### PR TITLE
fix(eval): pin ssh to IdentitiesOnly=yes -- fixes the real dflash cron auth flakiness

### DIFF
--- a/eval/pr_dflash_bot.py
+++ b/eval/pr_dflash_bot.py
@@ -252,6 +252,13 @@ def ssh_run(host, port, cmd, timeout=7200, stdin_data=None):
     return subprocess.run(
         [
             "ssh", "-i", key,
+            # Without this, ssh also offers every identity in a running ssh-agent before the
+            # explicit key above -- fine interactively (agent papers over a missing/wrong -i key)
+            # but under cron there's no agent, so a box that only has the -i key authorized (not
+            # some agent identity) fails outright with "Permission denied", and even when an
+            # agent IS present, extra agent identities can eat into the server's MaxAuthTries
+            # before the right key is ever tried. Pin to exactly the key we mean to use.
+            "-o", "IdentitiesOnly=yes",
             "-o", "StrictHostKeyChecking=accept-new",
             "-o", "BatchMode=yes",
             "-o", "ServerAliveInterval=30",
@@ -642,7 +649,8 @@ def push_eval_polaris(host, port):
             tmp.write(tar_data)
             tmp_path = tmp.name
         scp = subprocess.run(
-            ["scp", "-P", str(port), "-i", key, "-o", "StrictHostKeyChecking=accept-new",
+            ["scp", "-P", str(port), "-i", key, "-o", "IdentitiesOnly=yes",
+             "-o", "StrictHostKeyChecking=accept-new",
              "-o", "BatchMode=yes", tmp_path, f"{user}@{host}:/tmp/si_polaris.tgz"],
             capture_output=True, text=True, timeout=120,
         )

--- a/eval/run_dflash_cron.sh
+++ b/eval/run_dflash_cron.sh
@@ -69,13 +69,18 @@ gpu_ready() {
   if [ "${EVAL_TRANSPORT:-vast}" = "ssh" ]; then
     local host="${EVAL_SSH_HOST:-}" port="${EVAL_SSH_PORT:-22}" user="${EVAL_SSH_USER:-root}"
     [ -n "$host" ] || return 1
-    # ConnectTimeout=20 (was 10): the hourly tick lands at :00 alongside three separate */15
-    # dashboard-sync crons that also fire then, all doing their own network I/O at the same
-    # instant — plausible enough contention to blow a tight 10s budget. Capture+print stderr on
-    # failure (was silently discarded) so a future flaky tick actually leaves a diagnosable
-    # trace in the log instead of just "down — labels only" with no reason.
+    # IdentitiesOnly=yes: without it ssh also offers every identity in a running ssh-agent
+    # before the explicit -i key -- fine interactively (an agent can paper over a box where the
+    # -i key was never actually added to authorized_keys) but cron has no agent, so that gap
+    # surfaces as a flat "Permission denied" with zero indication why. This is what actually
+    # caused six straight silent "down — labels only" ticks on 2026-08-09: the box's
+    # authorized_keys never had SSH_KEY's public half, only the interactive session's agent key
+    # -- fixed by adding SSH_KEY's public key to the box directly, and pinned here so it can't
+    # silently regress (an agent that happens to have a WORKING key can also eat into
+    # MaxAuthTries before the right key is tried, on top of the missing-key case).
+    # ConnectTimeout=20 (was 10): cheap extra headroom, kept even though it wasn't the root cause.
     local err rc
-    err="$(ssh -i "$key" -o BatchMode=yes -o ConnectTimeout=20 \
+    err="$(ssh -i "$key" -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=20 \
         -o StrictHostKeyChecking=accept-new -p "$port" "$user@$host" 'true' 2>&1)"
     rc=$?
     [ "$rc" -eq 0 ] || echo "gpu_ready: ssh to $user@$host:$port failed (exit=$rc): $err" >&2


### PR DESCRIPTION
## Summary
- #739 widened `gpu_ready()`'s timeout and added error logging on a theory (top-of-hour cron contention from other `*/15` crons) that turned out to be wrong — none of those other crons even touch the eval GPU box.
- The real error, once #739's logging surfaced it: `Permission denied (publickey,password)`.
- Root cause: the eval box's `authorized_keys` never had `SSH_KEY`'s (`private_key.pem`) public half — only an interactive desktop session's `ssh-agent` key was authorized there. Manual checks always "worked" because that agent silently supplied a different, valid key ahead of the explicit `-i` one (agent identities are tried before explicit ones by default). Cron has no agent, so it hit the gap directly, every single top-of-hour tick.
- Fixed the box (added the key's public half to `authorized_keys`) and pinned `IdentitiesOnly=yes` on every ssh/scp call in the active dflash path so this can't silently regress — without it, agent identities get tried before the explicit key even when the explicit key is valid, which can also exhaust `MaxAuthTries` on a box with several agent-offered keys before the right one is ever reached.

## Test plan
- [x] `bash -n eval/run_dflash_cron.sh`
- [x] `python3 -m py_compile eval/pr_dflash_bot.py`
- [x] Manually verified `ssh -i private_key.pem -o IdentitiesOnly=yes -o BatchMode=yes ...` now succeeds reliably (3/3) against the box with no agent involved, matching cron's actual environment.