### PR TITLE
fix(server/cb): prefix cache skipped after ContinuousBatch frees session 0

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1842,6 +1842,12 @@ bool launch_gemv_rows(const void* x, const void* W, void* y,
 bool launch_gemv_rows2(const void* x, const void* W0, const void* W1, void* y0, void* y1,
                        int M, int N0, int N1, int K, cudaStream_t stream) {
     if (M < 1 || M > 8 || N0 < 1 || N1 < 1 || (K & 7)) return false;
+#ifdef _MSC_VER
+    // gemv_bf16_rows_sk2_kernel is compiled out under MSVC (see #ifndef _MSC_VER above).
+    // Two single-matrix launches are bit-identical to the fused path — just two grids.
+    return launch_gemv_rows(x, W0, y0, M, N0, K, stream) &&
+           launch_gemv_rows(x, W1, y1, M, N1, K, stream);
+#else
     constexpr int S = 8, RPB = GEMV_WPB / S;
     dim3 grid((N0 + N1 + RPB - 1) / RPB);
     const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
@@ -1859,6 +1865,7 @@ bool launch_gemv_rows2(const void* x, const void* W0, const void* W1, void* y0, 
     }
 #undef SI_GEMV_ROWS2
     return true;
+#endif
 }
 bool launch_gemv_rows_f32(const void* x, const void* W, float* y,
                           int M, int N, int K, cudaStream_t stream) {

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -111,6 +111,11 @@ public:
     // Drop the installed prefix cache and free its KV blocks.
     void clear_prefix_cache();
 
+    // Soft-invalidate after session 0's KV was freed (generate / ContinuousBatchEngine).
+    // Keeps prefix_tokens/len so the next cache_prefix() can re-warm; clears prefix_active
+    // so callers do not skip re-warm while the KV is empty.
+    void release_prefix_session();
+
     // Length of the currently cached prefix (0 if none).
     int prefix_cached_len() const;
 

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -79,9 +79,13 @@ ContinuousBatchEngine::~ContinuousBatchEngine() {
     if (worker_.joinable()) worker_.join();
     std::lock_guard<std::mutex> lock(mu_);
     for (auto& kv : jobs_) {
-        if (!kv.second->seq_id) continue;
+        if (!kv.second || kv.second->done) continue;
+        // seq_id 0 is a valid prefix session (cannot use truthiness).
         if (kv.second->seq_id != 0) model_->close_session(kv.second->seq_id);
-        else kv_->free(0);
+        else if (kv.second->req.use_prefix_session) {
+            kv_->free(0);
+            model_->release_prefix_session();
+        }
     }
     jobs_.clear();
 }
@@ -272,7 +276,12 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
         job.error = "prefill produced invalid seed token";
         job.done = true;
         if (job.seq_id != 0) model_->close_session(job.seq_id);
-        else kv_->free(job.seq_id);
+        else {
+            kv_->free(job.seq_id);
+            // Match generate(): KV is gone — soft-invalidate so the server does not
+            // skip cache_prefix() on the next exclusive prefix hit.
+            if (job.req.use_prefix_session) model_->release_prefix_session();
+        }
         job.seq_id = 0;
         return true;
     }
@@ -284,7 +293,10 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
     if (job.next_token == cfg.eos_id || job.decode_emitted >= job.req.max_new_tokens) {
         job.done = true;
         if (job.seq_id != 0) model_->close_session(job.seq_id);
-        else kv_->free(job.seq_id);
+        else {
+            kv_->free(job.seq_id);
+            if (job.req.use_prefix_session) model_->release_prefix_session();
+        }
         job.seq_id = 0;
         return true;
     }

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1554,6 +1554,16 @@ void Qwen35Model::clear_prefix_cache() {
     s.prefix_active = false;
 }
 
+void Qwen35Model::release_prefix_session() {
+    Impl& s = *p_;
+    // Caller already freed session-0 KV. Keep the token fingerprint for matching;
+    // mark inactive so the next request re-runs cache_prefix() instead of
+    // attending against an empty block table.
+    s.prefix_next = -1;
+    s.prefix_active = false;
+    invalidate_decode_graph();
+}
+
 int Qwen35Model::prefix_cached_len() const { return p_->prefix_active ? p_->prefix_len : 0; }
 
 int Qwen35Model::prefix_seed_token() const {
@@ -1727,7 +1737,10 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
                                             : ingest_prompt_range(prompt.data(), start, (int)n);
     if (next < 0 || next >= s.cfg.vocab) {
         if (sid != 0) close_session(sid);
-        else s.kv->free(sid);
+        else {
+            s.kv->free(sid);
+            if (reuse) release_prefix_session();
+        }
         fprintf(stderr, "[qwen35] prompt prefill failed (start=%d n=%zu)\n", start, n);
         return out;
     }
@@ -1739,13 +1752,9 @@ std::vector<int> Qwen35Model::generate(const std::vector<int>& prompt, int max_n
     }
 
     if (sid != 0) close_session(sid);
-    else s.kv->free(sid);
-    if (reuse) {
-        // KV is gone; keep prefix_tokens/len so the next cache_prefix()+generate() pair can
-        // re-warm the shared prefix and only prefill the suffix.
-        s.prefix_next = -1;
-        s.prefix_active = false;
-        invalidate_decode_graph();
+    else {
+        s.kv->free(sid);
+        if (reuse) release_prefix_session();
     }
     return out;
 }


### PR DESCRIPTION
## Summary
- With `SPARKINFER_SERVER_PREFIX_TOKEN_*`, the server warms session 0 via `cache_prefix()` and sets `use_prefix_session`.
- `ContinuousBatchEngine` freed session-0 KV on completion but left `prefix_active == true`.
- The next exclusive prefix hit then saw `prefix_cached_len() == prefix.size()`, **skipped** `cache_prefix()`, and prefilling only the suffix against an empty block table → wrong tokens / missing GDN state.
- `generate()` already soft-invalidates (`prefix_active = false`, keep token fingerprint). CB/server did not.
- Add `Qwen35Model::release_prefix_session()` and call it wherever CB (and `generate`) frees session 0 after a prefix reuse. Also fix the destructor so in-flight `seq_id == 0` jobs are not skipped via truthiness.

## Test plan
- [x] Tested on RTX 5090
- [ ] With `SPARKINFER_SERVER_PREFIX_TOKEN_IDS` set, run two sequential chat completions that share the prefix; second request must re-warm (log / `cache_prefix`) and match first-request quality
- [ ] Without prefix env, CB path unchanged
- [ ] CI policy gates (`cap` / `gate` / `guard`)


Made with [Cursor](https://cursor.com)