### PR TITLE
fix(server): streaming decode_delta re-emits the full string on BPE/UTF-8 rewrite

### DIFF
--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -446,9 +446,17 @@ std::string ChatTokenizer::decode_delta(std::vector<int>& acc, int new_id) const
     const std::string full = decode(acc);
     if (acc.size() == 1) return full;
     const std::string prev = decode(std::vector<int>(acc.begin(), acc.end() - 1));
-    if (full.size() >= prev.size() && full.compare(0, prev.size(), prev) == 0)
-        return full.substr(prev.size());
-    return full;
+    // HF-style Decode is not always prefix-stable: incomplete UTF-8 / BPE merges can
+    // rewrite the tail (often via U+FFFD). Returning `full` on mismatch re-sends the
+    // entire so-far string into the SSE stream. Emit only the bytes after the longest
+    // common prefix so clients append a true delta.
+    size_t i = 0;
+    const size_t n = std::min(full.size(), prev.size());
+    while (i < n && full[i] == prev[i]) ++i;
+    while (i > 0 && i < full.size() &&
+           (static_cast<unsigned char>(full[i]) & 0xC0) == 0x80)
+        --i;
+    return full.substr(i);
 }
 
 }  // namespace sparkinfer_server


### PR DESCRIPTION
## Summary
- `ChatTokenizer::decode_delta` assumed each decode was a strict prefix of the next.
- HF-style `Decode` is often not prefix-stable (incomplete UTF-8 → U+FFFD, BPE merges rewrite the tail).
- On mismatch the old path returned **`full`**, so SSE chat chunks re-sent the entire so-far string → duplicated / garbled streamed text (especially CJK / multi-byte).
- Emit only the bytes after the longest common prefix with the previous decode (UTF-8-safe cut).

## Test plan
- [ ] Stream a chat completion with CJK / multi-byte output; chunks must append, not replay the whole answer
- [ ] ASCII-only stream still emits per-token suffixes as before
- [ ] CI policy gates (`cap` / `gate` / `guard`)


Made with [Cursor](https://cursor.com)