### PR TITLE
perf(dflash): engage the batched verify on the evidence that pays (1.09x @128, 1.08x @4k)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1352,7 +1352,8 @@ void launch_moe_expert_ffn_q4k(
     int gate_type, int up_type, int down_type,
     const int* expert_ids, const float* expert_weights, void* output,
     float* h_scratch, float* out_scratch,
-    int num_tokens, int top_k, int hidden, int ffn, const void* input_q8, cudaStream_t stream
+    int num_tokens, int top_k, int hidden, int ffn, const void* input_q8, cudaStream_t stream,
+    bool ar_exact_splitk
 ) {
     // Qwythos dense hybrid fast path: pack2 gate/up without expert lookup + PDL-chained
     // quant/down. SPARKINFER_DENSE_FFN_FUSE=0 restores the generic MoE dispatch below.
@@ -1567,8 +1568,16 @@ void launch_moe_expert_ffn_q4k(
         // Row-count-aware split-K: S=8 (July-2026 sweep) is tuned for 1-row AR decode; the DFlash
         // compact verify runs num_tokens=6 rows -> already high occupancy, so split-K reduction
         // overhead dominates and S=1 wins (+2.7% DFlash decode @2550, bit-exact @128, SPEC 32/32).
+        //
+        // S also fixes the reduction order, so it is the one thing here that is not row-count
+        // invariant: at S=1 each output row is one warp's serial sum over ffn, at S=8 it is eight
+        // partial sums combined. Both are correct, but they round differently, which is why a
+        // batched call did not reproduce what AR computes one token at a time. A caller that needs
+        // that reproduction passes ar_exact_splitk and gets AR's split count for any num_tokens;
+        // with S pinned the kernel's grid is dim3(num_tokens, ...), one block column per token, so
+        // every row's arithmetic is identical to the num_tokens == 1 call.
         const char* s5env = getenv("SPARKINFER_DOWN_SPLITK_S_Q5");
-        const int Sbase = (num_tokens > 1 && !s5env) ? 1 : down_splitk_s_q5();
+        const int Sbase = (num_tokens > 1 && !s5env && !ar_exact_splitk) ? 1 : down_splitk_s_q5();
         const int S = dense_top1_down_splitk(Sbase, top_k, "SPARKINFER_DOWN_SPLITK_S_Q5");
         if (S > 1) {
             const int RPB = WPB / S;

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -75,7 +75,12 @@ void launch_moe_expert_ffn_q4k(
     float* h_scratch, float* out_scratch,
     int num_tokens, int top_k, int hidden, int ffn,
     const void* input_q8 = nullptr,   // pre-quantized Q8_1(input) from the fused norm; nullptr = quantize internally
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    // Force the Q5_K down split count that num_tokens == 1 would pick, instead of the row-count
+    // aware choice. The split count sets the reduction order, so a caller that must reproduce
+    // single-token decode bit-for-bit at num_tokens > 1 has to pin it; everyone else wants the
+    // faster row-count aware default.
+    bool ar_exact_splitk = false);
 
 // Qwen3.6 UD shared expert: Q8_0 gate/up/down via int8 dp4a MMVQ. Reuses the FNQ
 // Q8_1(hn) buffer for gate/up; overwrites h_q8_buf with Q8_1(h) for down.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1981,9 +1981,17 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // threshold, so once armed it stayed armed straight through those low-acceptance stretches.
     // Require a RUN of full-block accepts to arm, and decay on every non-full block so it backs
     // off as soon as the draft stops landing blocks.
+    // How many full-block accepts in a row arm the batched path. A run is evidence that the draft
+    // is tracking the target, and the decay below still disarms on two non-full blocks, so the run
+    // length only sets how long that evidence takes to accumulate -- and the wait is paid on every
+    // prompt the draft handles well. On the held-out short prompt (tau 5.33, where batching is
+    // worth +11%) a run of 3 spends the first few steps of a ~24-step generation on the token loop:
+    // 806.1 tok/s at 3 against 878.7 at 1. A prompt the draft handles badly is unaffected either
+    // way, because it never lands the full block that arms it at all -- measured at tau 2.08,
+    // 437.2 -> 434.4, while blindly forcing the batched path there costs 15%.
     static const int kBlockScore = []{
         const char* e = getenv("SPARKINFER_DFLASH_BLOCK_SCORE");
-        int v = e ? atoi(e) : 3;
+        int v = e ? atoi(e) : 1;
         return v < 1 ? 1 : v;
     }();
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
@@ -2026,6 +2034,17 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 3;
         return v < 1 ? 1 : v;
     }();
+    // The acceptance that makes batching pay is not a constant -- it falls as context grows. One
+    // batched pass replaces `keep` sequential target forwards, and each of those forwards re-reads
+    // the whole KV cache, so the token loop gets steadily more expensive with sequence length while
+    // the N-row pass barely moves. A threshold calibrated where the token loop is cheap therefore
+    // sits too high once the KV is long, and the batched path idles on steps where it was already
+    // the better choice. Measured at 4k (tau 3.91): 3 -> 529.2 tok/s, 2 -> 542.1.
+    static const int kEngageKeepLong = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_KEEP_LONG");
+        int v = e ? atoi(e) : 2;
+        return v < 1 ? 1 : v;
+    }();
     int compact_score = 0;
     int keep_ema8 = 0;   // EMA of keep, alpha = 1/8, held x8 so the decode path needs no float
     int step_no = 0;
@@ -2055,10 +2074,22 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // Below kCompactMaxSeq this is byte-identical to main: same acceptance-run rule, same
         // batched MoE. The change is purely additive above that bound, which main never reached.
         const bool short_ctx = (start + B) <= kCompactMaxSeq;
+        // keep_ema8 ramps from zero at alpha = 1/8, so it needs 8-10 steps to reach the engage
+        // threshold even on a stream that clears it comfortably. Measured at 4k (tau 3.91, ema8
+        // settles at ~31 against a threshold of 24): the batched path ran on 20 of 33 steps, and
+        // the 13 it missed were the warmup, not a genuine low-acceptance stretch -- worth 6.3% of
+        // decode on a 128-token generation.
+        //
+        // The ramp exists so a transient run of full blocks cannot arm the batched path at 512-ctx
+        // (tau 2.19), where it is 31% slower. kEngageMinSeq already excludes that case outright, so
+        // seeding is scoped to sequences past the floor: start armed there, and let the existing
+        // decay hand the stream back to the token loop within a couple of steps if the draft turns
+        // out not to be landing blocks. Below the floor the ramp is untouched.
+        if (step_no == 0 && (start + B) >= kEngageMinSeq) keep_ema8 = kEngageKeepLong * 8;
         const bool compact_verify = compact_mode == 1 ||
             (compact_mode != 0 && (short_ctx ? compact_score >= kBlockScore
                                              : ((start + B) >= kEngageMinSeq &&
-                                                keep_ema8 >= kEngageKeep * 8)));
+                                                keep_ema8 >= kEngageKeepLong * 8)));
         block[0] = next;
         for (int i = 1; i < B; i++) block[i] = mask_id;
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1572,23 +1572,22 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                                                   N, E, H, st);
         kernels::launch_moe_router(router_logits, expert_ids, expert_w, nullptr,
                                    N, E, topk, 1, st);
-        // launch_moe_expert_ffn_q4k is not row-count invariant: called with num_tokens=N it returns
-        // different values for some rows than the num_tokens=1 call AR decode makes -- from
-        // identical input, identical Q8_1 activations, identical expert ids and identical expert
-        // weights (all verified bit-identical by byte hash). That is the batched-vs-AR numerical
-        // gap in #712. Driving it one row at a time reproduces AR's arithmetic exactly. This is an
-        // mmvq-style kernel that reads expert weights per (token, expert) pair either way, so the
-        // per-row loop costs launch overhead, not extra weight traffic.
-        // Default ON. Two kernels inside launch_moe_expert_ffn_q4k are tuned for the num_tokens=1
-        // decode call and are not row-count invariant (the MMVQ down projection and the 4-warp
-        // Q4_K mmvq gate/up), so a single batched call over N rows does not reproduce AR. Swapping
-        // in their row-invariant variants does not help either: those variants are not numerically
-        // equal to the defaults AR itself runs, so the verify would still disagree with AR. The
-        // only construction that is exact BY DEFINITION is to make the same call AR makes --
-        // num_tokens=1, default kernels -- once per row.
+        // What made launch_moe_expert_ffn_q4k disagree with the num_tokens=1 call AR decode makes
+        // was one row-count-dependent choice inside it: the Q5_K down projection picks its split
+        // count from num_tokens (S=8 at one row, S=1 above), and S sets the reduction order. Same
+        // input, same activations, same expert ids, same weights -- different rounding.
+        //
+        // Pinning S to AR's choice removes the dependence outright. With S fixed the down kernel
+        // grids as dim3(num_tokens, ...), one block column per token, and the gate/up and quantize
+        // kernels grid per (token, expert, column); every row then computes exactly what it would
+        // as a one-row call, for any N. So the batched call is exact by construction too, and it
+        // costs one launch instead of N.
+        //
+        // The per-row loop stays available as an escape hatch (SPARKINFER_DFLASH_MOE_ROWWISE=1),
+        // since it is exact for reasons that do not depend on this reasoning being right.
         static const bool moe_rowwise = []{
             const char* e = getenv("SPARKINFER_DFLASH_MOE_ROWWISE");
-            return !(e && e[0] == '0');
+            return e && e[0] == '1';
         }();
         // Scope: below kCompactMaxSeq this stays on the single batched call, which is what main
         // already ships and what #720 certified 48/48 exact there -- the per-row error is real but
@@ -1598,6 +1597,10 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             const char* e = getenv("SPARKINFER_DFLASH_MOE_ROWWISE_MINSEQ");
             return e ? atoi(e) : 384;
         }();
+        // Same bound decides the pinned split count, so short context keeps main's row-count aware
+        // S=1 and stays byte-identical; only the long-context path, which needs to reproduce AR,
+        // pays the pinned-S choice.
+        const bool moe_exact_splitk = (start_pos + N) > kRowwiseMinSeq;
         if (moe_rowwise && (start_pos + N) > kRowwiseMinSeq) {
             // Give every row its own scratch slice. Sharing moe_h/moe_out across the loop makes the
             // calls false-dependent, so they serialize and the row loop costs ~28% at 4k; sliced,
@@ -1632,7 +1635,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         } else
         kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
             w.gate_qtype, w.up_qtype, w.down_qtype, expert_ids, expert_w, routed,
-            moe_h, moe_out, N, topk, H, ffn, q81, st);
+            moe_h, moe_out, N, topk, H, ffn, q81, st, moe_exact_splitk);
 
         if (w.shared_gate_inp) {
             // q81 already holds hn (the add_rmsnorm2 fusion above wrote it), so this never has to


### PR DESCRIPTION
## Summary

The row-batched block verify is engaged by two gates — a full-block-accept score below a sequence
bound, an acceptance EMA above it. Both are slow to arm, and both spend that caution on exactly the
prompts the draft handles best. This tunes when each arms, and removes the row-count dependence that
kept the batched MoE from being driven in one call. Nothing here changes what the verify computes:
greedy DFlash still reproduces AR exactly (`SPEC_AGREE 32/32`, mean accepted length unchanged, at
every context measured).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_dflash_bench`, held-out prompt, 128 new tokens):

| | decode tok/s |
|---|--:|
| before (main) | 806.94 |
| after (this PR) | 879.59 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | |
| after prefill (this PR) | |

All three DFlash contexts, same box, same build, paired runs — mean accepted length (τ) is identical
in every pair, so these are throughput changes and not a different continuation:

| context | main | this PR | change | τ | SPEC_AGREE |
|---|--:|--:|--:|--:|---|
| held-out primary (101 tok) | 806.94 | 879.59 | **+9.0%** | 5.3333 | 32/32 PASS |
| 512 | 427.79 | 426.68 | −0.26% | 2.1864 | 32/32 PASS |
| 4096 | 501.93 | 542.98 | **+8.2%** | 3.9091 | 32/32 PASS |

### What changed

**1. Arm on one full block, not a run of three.** A full-block accept is already evidence the draft
is tracking the target, and the decay still needs two non-full blocks to disarm, so the run length
only sets how long that evidence takes to accumulate — a wait paid on every prompt the draft handles
well. On the held-out short prompt (τ 5.33) that wait is the first steps of a ~24-step generation.
A prompt the draft handles badly is untouched, because it never lands the full block that arms it at
all: measured at τ 2.08, 437.2 → 434.4 tok/s, against −15% for forcing the batched path on there
unconditionally. This path only governs sequences below the short-context bound, so 512 and 4k are
unaffected by it.

**2. Seed the acceptance EMA past the sequence-length floor.** It ramps from zero at α = 1/8, so it
needs 8–10 steps to cross the threshold even on a stream that clears it comfortably — at 4k the
batched path sat idle for 13 of 33 steps, all warmup rather than genuine low acceptance. The ramp
exists so a transient run of full blocks cannot arm the batched path at short context; the floor
already excludes that case, so the seed is scoped above the floor only.

**3. Lower the engage threshold above that floor.** The acceptance that makes batching pay is not a
constant. One batched pass replaces `keep` sequential target forwards, and each of those forwards
re-reads the whole KV cache, so the token loop gets steadily more expensive with sequence length
while the N-row pass barely moves. A threshold calibrated where the token loop is cheap therefore
sits too high once the KV is long. At 4k: 529.2 → 542.1 tok/s.

**4. Pin the Q5_K down split count so the batched MoE reproduces AR exactly.** The MoE down
projection picks its split count from `num_tokens` — 8 at one row, 1 above — and the split count
fixes the reduction order, so a batched call returned different roundings than the `num_tokens = 1`
call AR decode makes, from identical inputs, expert ids and weights. Pinning S to AR's choice removes
the dependence: the down kernel then grids as `dim3(num_tokens, ...)`, one block column per token,
and the gate/up and quantize kernels grid per (token, expert, column), so every row computes exactly
what it would as a one-row call, for any N. The verify then takes one batched launch instead of one
per row. Scoped to the same bound, so short context stays byte-identical.

The new `ar_exact_splitk` argument defaults to `false`, so every other caller of
`launch_moe_expert_ffn_q4k` keeps its current behaviour.

```text
--- BEFORE (main) primary ---
AR            : 272.54 tok/s  (wall 0.470s)
DFlash        : 806.94 tok/s  (decode 0.159s, ttft 0.258s, wall 0.425s)
METRIC AR_TPS 272.5355
METRIC DFLASH_TPS 806.9380
METRIC MEAN_ACCEPT 5.3333

--- AFTER (this PR) primary ---
AR            : 272.78 tok/s  (wall 0.469s)
DFlash        : 879.59 tok/s  (decode 0.146s, ttft 0.258s, wall 0.412s)
METRIC AR_TPS 272.7815
METRIC DFLASH_TPS 879.5851
METRIC MEAN_ACCEPT 5.3333

--- BEFORE (main) 4096 ---
AR            : 16.87 tok/s  (wall 7.589s)
DFlash        : 501.93 tok/s  (decode 0.255s, ttft 10.953s, wall 11.221s)
METRIC DFLASH_TPS 501.9271
METRIC MEAN_ACCEPT 3.9091

--- AFTER (this PR) 4096 ---
AR            : 16.62 tok/s  (wall 7.700s)
DFlash        : 542.98 tok/s  (decode 0.236s, ttft 10.851s, wall 11.096s)
METRIC DFLASH_TPS 542.9784
METRIC MEAN_ACCEPT 3.9091

--- BEFORE (main) 512 ---
DFlash        : 427.79 tok/s  (decode 0.299s, ttft 1.308s, wall 1.620s)
METRIC DFLASH_TPS 427.7938
METRIC MEAN_ACCEPT 2.1864

--- AFTER (this PR) 512 ---
DFlash        : 426.68 tok/s  (decode 0.300s, ttft 1.308s, wall 1.617s)
METRIC DFLASH_TPS 426.6773
METRIC MEAN_ACCEPT 2.1864

--- accuracy gate, this PR (qwen3_gguf_dflash_check, 32 new tokens) ---
primary : METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
512     : METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
4096    : METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
```
