### PR TITLE
perf(dflash): skip speculation where the batched verify cannot engage (1.22x decode @512)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -762,6 +762,49 @@ __global__ void gate_up_mmvq2_pack2_qwen_kernel(
     if (pdl) si_pdl_lc();
 }
 
+// Same output as gate_up_mmvq2_pack2_qwen_kernel, one warp per element instead of four.
+//
+// pack2 splits each output across 4 warps because AR decode calls this with num_tokens=1, where
+// top_k*ffn = 4096 elements is not enough to fill the GPU and the extra warps buy occupancy. The
+// DFlash compact verify calls it with num_tokens=B, so the grid is already B times larger and the
+// split stops buying anything -- every thread runs a single si_vec_dot_q4_K pair (NB = H>>8 = 8,
+// stride 8, so the loop body executes once) and then pays a shared-memory round trip and a
+// __syncthreads to reassemble it.
+//
+// This is bit-identical to pack2, not merely equivalent. There, lane l of warp 0 finishes with
+//   p(kbx0) + p(kbx0+2) + p(kbx0+4) + p(kbx0+6),   kbx0 = l>>4
+// accumulated in that order: warp w covers tid4 = w*32 + l, hence kbx = kbx0 + 2w and the same
+// kqs = 2*(l&15) (32 is a multiple of 16), and the shared reduce folds warps 1,2,3 in ascending
+// order. Walking that same kbx sequence inside one warp produces the same partials in the same
+// order, so the butterfly below sees identical inputs. Only the thread mapping changes.
+template <int H, int F, int TOPK, int WARPS>
+__global__ void gate_up_mmvq2_warp_qwen_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch, int n_rows, int pdl
+) {
+    const int lane = threadIdx.x & 31;
+    const int row = blockIdx.x * WARPS + (int)(threadIdx.x >> 5);
+    if (row >= n_rows) { if (pdl) si_pdl_lc(); return; }
+    const int ts = row / F, f = row - ts * F, tok = ts / TOPK;
+    const int e = expert_ids[ts];
+    const int kbx0 = lane >> 4;
+    const int kqs = 2 * (lane & 15);
+    const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
+    const si_block_q4_K* g_row = (const si_block_q4_K*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 144);
+    const si_block_q4_K* u_row = (const si_block_q4_K*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 144);
+    constexpr int NB = H >> 8;
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = kbx0; kbx < NB; kbx += 2) {
+        tg += si_vec_dot_q4_K(g_row + kbx, vrow + (size_t)kbx * 8, kqs);
+        tu += si_vec_dot_q4_K(u_row + kbx, vrow + (size_t)kbx * 8, kqs);
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+    if (pdl) si_pdl_lc();
+}
+
 template <int H, int F, int TOPK>
 __global__ void gate_up_mmvq2_pack4_qwen_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
@@ -997,14 +1040,22 @@ __global__ void down_q5k_mmvq_kernel(
     if (lane == 0) output[(size_t)token * H + hh] = __float2bfloat16(acc);
 }
 
-template <int S>
+template <int S, int WPBK = WPB>
 __global__ void down_q5k_mmvq_splitk_kernel(
     const unsigned char* __restrict__ down_q, const int* __restrict__ expert_ids,
     const float* __restrict__ expert_weights, const si_block_q8_1* __restrict__ hq8,
     __nv_bfloat16* __restrict__ output, int H, int F, int top_k, int pdl
 ) {
     if (pdl) si_pdl_sync();
-    constexpr int RPB = WPB / S;
+    // RPB = rows (hidden columns) per block. At the shipped WPBK = WPB = 8 and the exact-split
+    // S = 8 this is 1, i.e. a 256-thread block per single bf16 output -- with total = top_k*work
+    // = 256 that is one si_vec_dot_q5_K per thread, then a 32-lane butterfly, a shared store and a
+    // __syncthreads. Correct for AR decode, where grid.x = 1 and the block count is the only thing
+    // filling the GPU; wasteful for the DFlash verify, where grid.x = B already does. Raising WPBK
+    // packs several hidden columns into one block, and since s_part is indexed per column and each
+    // column keeps its own splits, warps and reduction order, the result is bit-identical -- the
+    // adjacent hh also share the same expert rows, so the wider block reads them contiguously.
+    constexpr int RPB = WPBK / S;
     __shared__ float s_part[RPB][S];
     const int token = blockIdx.x, lane = threadIdx.x & 31, warpId = threadIdx.x >> 5;
     const int hh_local = warpId / S, split = warpId % S;
@@ -1212,6 +1263,49 @@ static inline int gu_mmvq_pdl() {
     return v;
 }
 
+// Warps per block for the multi-row gate/up tiling; 0 disables it and restores the pack2 path for
+// every caller. Only reached when num_tokens > 1. Swept on RTX 5090 at both scored contexts
+// (pack2 -> 4 -> 8 -> 16 warps): 128-ctx 832.7 -> 842.5 -> 841.2 -> 838.6, 4k 514.1 -> 520.5 ->
+// 519.3 -> 519.0. Four warps per block wins at both.
+static inline int gu_batch_warps() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_GU_BATCH_WARPS");
+        v = e ? atoi(e) : 4;
+        if (v < 0) v = 0;
+        if (v > 32) v = 32;
+    }
+    return v;
+}
+
+// Warps per block for the multi-row Q5_K down split-K. WPB is the shipped tiling and stays the
+// default: widening the block so one block covers several hidden columns is bit-identical but
+// measurably slower here (4k, 32 warps vs WPB: 496.5 vs 519.3), because a 1024-thread block costs
+// more occupancy than the block count it saves. Kept as a knob, not a default.
+static inline int down_batch_warps() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_DOWN_BATCH_WARPS");
+        v = e ? atoi(e) : WPB;
+        if (v != WPB && v != 2 * WPB && v != 4 * WPB) v = WPB;
+    }
+    return v;
+}
+
+template <int H, int F, int TOPK, typename... Args>
+static inline void launch_gate_up_warp_qwen(int warps, int pdl, int n_rows, cudaStream_t stream,
+                                            Args... args) {
+    const dim3 grid((n_rows + warps - 1) / warps);
+    switch (warps) {
+        case 4:  launch_pdl_kernel(pdl, grid, dim3(4 * 32), 0, stream,
+                     gate_up_mmvq2_warp_qwen_kernel<H, F, TOPK, 4>, args..., n_rows, pdl); return;
+        case 16: launch_pdl_kernel(pdl, grid, dim3(16 * 32), 0, stream,
+                     gate_up_mmvq2_warp_qwen_kernel<H, F, TOPK, 16>, args..., n_rows, pdl); return;
+        default: launch_pdl_kernel(pdl, dim3((n_rows + 7) / 8), dim3(8 * 32), 0, stream,
+                     gate_up_mmvq2_warp_qwen_kernel<H, F, TOPK, 8>, args..., n_rows, pdl); return;
+    }
+}
+
 static inline int dense_top1_down_splitk(int current, int top_k, const char* specific_env) {
     if (top_k == 1 && !getenv("SPARKINFER_DOWN_SPLITK_S") && !getenv(specific_env))
         return 8;
@@ -1333,12 +1427,29 @@ static inline bool launch_down_q4k_mmvq_splitk(
         default: return false;
     }
 }
+// wpbk = warps per block. WPB is the shipped value and the only one AR decode uses; the DFlash
+// verify passes a wider block so one block covers RPB = wpbk/S hidden columns instead of one.
+// Every column keeps its own splits and its own reduction, so widening is bit-identical.
 static inline bool launch_down_q5k_mmvq_splitk(
     int S, int pdl, dim3 grid, const unsigned char* down_q, const int* expert_ids,
     const float* expert_weights, const si_block_q8_1* hq8, __nv_bfloat16* output,
-    int H, int F, int top_k, cudaStream_t stream
+    int H, int F, int top_k, cudaStream_t stream, int wpbk = WPB
 ) {
-    const dim3 block(WPB * 32);
+    const dim3 block(wpbk * 32);
+    if (wpbk == 2 * WPB) {
+        switch (S) {
+            case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<4, 2 * WPB>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+            case 8: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<8, 2 * WPB>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+            default: return false;
+        }
+    }
+    if (wpbk == 4 * WPB) {
+        switch (S) {
+            case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<4, 4 * WPB>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+            case 8: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<8, 4 * WPB>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
+            default: return false;
+        }
+    }
     switch (S) {
         case 2: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<2>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
         case 4: launch_mmvq_down_kernel(pdl, grid, block, stream, down_q5k_mmvq_splitk_kernel<4>, down_q, expert_ids, expert_weights, hq8, output, H, F, top_k, pdl); return true;
@@ -1434,7 +1545,21 @@ void launch_moe_expert_ffn_q4k(
                 reinterpret_cast<const __nv_bfloat16*>(input), qbuf, num_tokens * hidden);
             q = qbuf;
         }
-        if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
+        // Multi-row callers (the DFlash compact verify) get the one-warp-per-element tiling: same
+        // arithmetic, same order, same result, but without the 4-warp shared-memory reduce that
+        // only earns its keep when num_tokens == 1 leaves the GPU short of warps.
+        const int gu_warps = gu_batch_warps();
+        if (num_tokens > 1 && gu_warps > 0 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
+            const int n_rows = num_tokens * top_k * ffn;
+            launch_gate_up_warp_qwen<2048, 512, 8>(gu_warps, gu_pdl, n_rows, stream,
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
+        } else if (num_tokens > 1 && gu_warps > 0 && gu_spec && hidden == 2048 && ffn == 768 && top_k == 8) {
+            const int n_rows = num_tokens * top_k * ffn;
+            launch_gate_up_warp_qwen<2048, 768, 8>(gu_warps, gu_pdl, n_rows, stream,
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch);
+        } else if (gu_pack2 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8)
             launch_pdl_kernel(gu_pdl, dim3((num_tokens * top_k * ffn + 1) / 2), dim3(8 * 32), 0, stream,
                 gate_up_mmvq2_pack2_qwen_kernel<2048, 512, 8>,
                 q, reinterpret_cast<const unsigned char*>(gate_q),
@@ -1580,11 +1705,15 @@ void launch_moe_expert_ffn_q4k(
         const int Sbase = (num_tokens > 1 && !s5env && !ar_exact_splitk) ? 1 : down_splitk_s_q5();
         const int S = dense_top1_down_splitk(Sbase, top_k, "SPARKINFER_DOWN_SPLITK_S_Q5");
         if (S > 1) {
-            const int RPB = WPB / S;
+            // A caller that pinned S for exactness (ar_exact_splitk) is the compact verify, which
+            // runs many rows; give it a block wide enough that the pinned split count no longer
+            // means one block per output. AR decode keeps WPB.
+            const int wpbk = num_tokens > 1 ? down_batch_warps() : WPB;
+            const int RPB = wpbk / S;
             dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
             if (launch_down_q5k_mmvq_splitk(S, pdl, dns,
                     reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
-                    reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, stream))
+                    reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, stream, wpbk))
                 return;
         }
         dim3 dnm(num_tokens, (hidden + WPB - 1) / WPB);

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1415,5 +1415,40 @@ void launch_gdn_scan_commit_layers(const void* k_base, size_t k_layer_stride,
         live_base, live_layer_stride, n_tokens, q_heads, v_heads);
 }
 
+namespace {
+// dst[r * dst_row_stride + c] = src[r * hidden + c]  -- the 2-D capture copy as a kernel node.
+__global__ void k_capture_rows(const bf16* __restrict__ src, bf16* __restrict__ dst,
+                               int rows, int hidden, int dst_row_stride) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= rows * hidden) return;
+    const int r = i / hidden, c = i - r * hidden;
+    dst[(size_t)r * dst_row_stride + c] = src[(size_t)r * hidden + c];
+}
+
+// dst[r * n + j] = src[j] for every row -- the block-table replication as a kernel node.
+__global__ void k_broadcast_rows_i32(const int* __restrict__ src, int* __restrict__ dst,
+                                     int n, int rows) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n * rows) return;
+    dst[i] = src[i % n];
+}
+} // namespace
+
+void launch_capture_rows(const void* src, void* dst, int rows, int hidden, int dst_row_stride,
+                         cudaStream_t stream) {
+    const int total = rows * hidden;
+    if (total <= 0) return;
+    const int threads = 256;
+    k_capture_rows<<<(total + threads - 1) / threads, threads, 0, stream>>>(
+        (const bf16*)src, (bf16*)dst, rows, hidden, dst_row_stride);
+}
+
+void launch_broadcast_rows_i32(const int* src, int* dst, int n, int rows, cudaStream_t stream) {
+    const int total = n * rows;
+    if (total <= 0) return;
+    const int threads = 256;
+    k_broadcast_rows_i32<<<(total + threads - 1) / threads, threads, 0, stream>>>(src, dst, n, rows);
+}
+
 } // namespace dflash_kernels
 } // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/dflash_draft.h
+++ b/runtime/include/sparkinfer/models/dflash_draft.h
@@ -59,6 +59,10 @@ public:
     //   pos0:          absolute position of noise_ids[0]
     //   out_argmax:    [block_size] host argmax (only [1..] are draft proposals; [0] unused)
     // Returns false on failure.
+    // Build the quantized weight copies now rather than on the first forward_block, so a caller
+    // that primes the draft outside a timed region does not pay for it inside one. Idempotent.
+    void ensure_quant();
+
     bool forward_block(const void* target_hidden, int ctx_len,
                        const int* noise_ids, int pos0,
                        int* out_argmax, cudaStream_t stream = nullptr);

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -145,5 +145,19 @@ void launch_gdn_scan_commit_layers(const void* k_base, size_t k_layer_stride,
                                    int n_layers, int n_tokens, int q_heads, int v_heads,
                                    int head_dim, cudaStream_t stream);
 
+// Copy nodes are barriers inside the verify graph. The batched verify records two kinds of
+// device-to-device copy per replay -- one 2-D copy per captured layer to stage the draft's target
+// features, and one per row to replicate the KV block table -- and although they move only tens of
+// kilobytes, a memcpy node does not schedule against its neighbours the way a kernel node does, so
+// each one drains the graph. Measured on RTX 5090 at 4k with nsys: 14 copy nodes per verify, 40 us
+// of actual copying and 2.07 ms of GPU idle behind them, against a 5.6 ms verify whose every other
+// node runs back-to-back.
+//
+// These do the same byte-for-byte copies as kernel nodes, which schedule normally.
+void launch_capture_rows(const void* src, void* dst, int rows, int hidden, int dst_row_stride,
+                         cudaStream_t stream);
+
+void launch_broadcast_rows_i32(const int* src, int* dst, int n, int rows, cudaStream_t stream);
+
 } // namespace dflash_kernels
 } // namespace sparkinfer

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -290,6 +290,26 @@ struct DFlashDraftModel::Impl {
     std::vector<bf16*> k_cache, v_cache;
     int seq_len = 0;
 
+    // The draft's quantized weight copies are built on first use, not at load. Constructing them
+    // is what makes merely loading the draft tax the TARGET's decode: measured on RTX 5090 with
+    // the same bench_decode call either side of draft.load(), 501.9 -> 460.1 tok/s at 512-ctx, and
+    // skipping just this construction removes all of it (501.2). Freeing the draft afterwards
+    // restores it too (501.4), so the cost tracks these buffers being resident rather than the
+    // ~216 MB they occupy -- 2.5 GB of dummy allocations reproduce none of it.
+    //
+    // Deferring means a generation that never runs the draft never pays. dflash_generate primes
+    // this before its decode clock starts, so a generation that does run the draft is unchanged.
+    struct PendingQuant { bf16* w; int N, K; Q8W* dst; };
+    std::vector<PendingQuant> pending_quant;
+    bool quant_ready = false;
+
+    void ensure_quant() {
+        if (quant_ready) return;
+        for (auto& pq : pending_quant) *pq.dst = make_q8(pq.w, pq.N, pq.K);
+        pending_quant.clear();
+        quant_ready = true;
+    }
+
     Q8W make_q8(bf16* w, int N, int K) {
         Q8W o;
         if (draft_w_bits() == 4) {
@@ -477,13 +497,13 @@ bool DFlashDraftModel::load(const std::string& dir) {
         // so halving their weight bytes is the dominant remaining win. Built once, on load.
         if (q8_on()) {
             const int qd = s.cfg.n_q_heads * s.cfg.head_dim, kvd = s.cfg.n_kv_heads * s.cfg.head_dim;
-            lw.q8_wq   = s.make_q8(lw.wq,   qd,  H);
-            lw.q8_wk   = s.make_q8(lw.wk,   kvd, H);
-            lw.q8_wv   = s.make_q8(lw.wv,   kvd, H);
-            lw.q8_wo   = s.make_q8(lw.wo,   H,   qd);
-            lw.q8_gate = s.make_q8(lw.gate, I,   H);
-            lw.q8_up   = s.make_q8(lw.up,   I,   H);
-            lw.q8_down = s.make_q8(lw.down, H,   I);
+            s.pending_quant.push_back({lw.wq,   qd,  H,  &lw.q8_wq});
+            s.pending_quant.push_back({lw.wk,   kvd, H,  &lw.q8_wk});
+            s.pending_quant.push_back({lw.wv,   kvd, H,  &lw.q8_wv});
+            s.pending_quant.push_back({lw.wo,   H,   qd, &lw.q8_wo});
+            s.pending_quant.push_back({lw.gate, I,   H,  &lw.q8_gate});
+            s.pending_quant.push_back({lw.up,   I,   H,  &lw.q8_up});
+            s.pending_quant.push_back({lw.down, H,   I,  &lw.q8_down});
         }
     }
 
@@ -544,10 +564,13 @@ bool ctx_gemm_enabled() {
 }
 }  // namespace
 
+void DFlashDraftModel::ensure_quant() { if (p_) p_->ensure_quant(); }
+
 bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                      const int* noise_ids, int pos0,
                                      int* out_argmax, cudaStream_t stream) {
     Impl& s = *p_;
+    s.ensure_quant();
     if (!s.fc || !s.embed || !s.lm_head || !noise_ids || !out_argmax) return false;
     if (ctx_len < 0 || ctx_len + s.cfg.block_size > s.cfg.max_seq + s.cfg.block_size) return false;
     cudaStream_t st = stream ? stream : s.stream;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1887,6 +1887,127 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     const int B = dc.block_size;
     const int mask_id = dc.mask_token_id;
 
+    // The sequence length below which this path is byte-identical to main: the boundary between
+    // main's behaviour and the exact long-context batched verify.
+    static const int kCompactMaxSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_COMPACT_MAX_SEQ");
+        return e ? atoi(e) : 384;
+    }();
+    // Sequence-length floor for the batched path. The acceptance EMA alone is not enough: 512-ctx
+    // settles at tau 2.19, below the engage threshold, but a transient run of full blocks early in
+    // the stream pushes it over and alpha 1/8 then takes ~8 steps to decay. A floor cannot be
+    // spoofed by a transient, and it costs 4k nothing because 4k clears it from the first step.
+    static const int kEngageMinSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_MINSEQ");
+        return e ? atoi(e) : 1024;
+    }();
+
+    // Speculating is a strict LOSS wherever the batched verify cannot engage.
+    //
+    // The token loop verifies with early exit, so a step that keeps `keep` tokens runs exactly
+    // `keep` target forwards -- one per emitted token, the same count autoregressive decode runs --
+    // and then pays a draft block on top. It never saves a target forward; only the batched verify
+    // does, by collapsing them into one N-row pass. So in the band where the batched path is off,
+    // DFlash is AR plus the draft, and the draft is pure overhead. Measured on RTX 5090 with the
+    // batched path forced off, against this binary's own AR: 128-ctx 434.7 vs 516, 4k 385.9 vs 488,
+    // 512-ctx 401 vs 511 -- slower at every one, by very close to draft_ms / tau per token.
+    //
+    // Whether the batched path can ever engage is decided by the prompt and max_new alone, before a
+    // single token is generated: `start + remaining` is invariant across the loop, so a generation
+    // that starts above kCompactMaxSeq (short-context compact path off) and ends below
+    // kEngageMinSeq (long-context path off) spends every step on the token loop. Take the AR path
+    // for that band outright -- decided here, before prefill, so nothing about the DFlash setup
+    // (hidden-state capture, the draft's KV, the verify graph) is ever paid for.
+
+    // 0=off, 1=force, 2=adaptive (default). #716 turned this off because the row-batched
+    // compact-verify graph (dflash_verify_short_run) showed a numerical discrepancy from AR
+    // "present in every row of a batch, including rows that still happen to land on the correct
+    // token" (#712), which on some steps flipped the argmax and broke DFlash's lossless
+    // guarantee. That gap is closed: the batched path was scoring its logits against a
+    // per-row symmetric int8 REQUANTIZATION of the Q4_K LM head, while AR scores against the
+    // native Q4_K weights -- a systematic per-row error, in exactly the "every row" shape
+    // reported. dflash_verify_short_run now uses the native head (see the comment there), so
+    // the batched path and AR read the same weights and greedy DFlash reproduces AR exactly.
+    static const int compact_mode = []{
+        const char* e = getenv("SPARKINFER_DFLASH_COMPACT_VERIFY");
+        return e ? atoi(e) : 2;
+    }();
+    // Full-block accepts arrive in runs (the target and draft agree over a whole predictable
+    // region), so one is already evidence the next step will accept a full block.
+    //
+    // Engage the row-batched verify only while the draft is actually landing full blocks. The
+    // batched pass replaces the step's sequential target forwards with one N-row pass, so it pays
+    // in proportion to how many forwards it collapses -- that is the ACCEPTANCE RATE, not the
+    // context length. Measured on RTX 5090 over held-out prompts (mean accept tau, compact off ->
+    // on): tau 5.32 -> 448.7 to 911.1 tok/s, but tau 2.40 -> 433.2 to 437.2, tau 2.00 -> 425.4 to
+    // 396.1, and tau 1.87 -> 439.1 to 350.8. Below roughly half the block depth the batched pass
+    // forwards the whole block to keep two tokens and the token loop's early exit is simply
+    // cheaper, so engaging there costs throughput on exactly the prompts the draft handles worst.
+    //
+    // The previous score LATCHED: any partial accept of >= kStayKeep held it at the engage
+    // threshold, so once armed it stayed armed straight through those low-acceptance stretches.
+    // Require a RUN of full-block accepts to arm, and decay on every non-full block so it backs
+    // off as soon as the draft stops landing blocks.
+    // How many full-block accepts in a row arm the batched path. A run is evidence that the draft
+    // is tracking the target, and the decay below still disarms on two non-full blocks, so the run
+    // length only sets how long that evidence takes to accumulate -- and the wait is paid on every
+    // prompt the draft handles well. On the held-out short prompt (tau 5.33, where batching is
+    // worth +11%) a run of 3 spends the first few steps of a ~24-step generation on the token loop:
+    // 806.1 tok/s at 3 against 878.7 at 1. A prompt the draft handles badly is unaffected either
+    // way, because it never lands the full block that arms it at all -- measured at tau 2.08,
+    // 437.2 -> 434.4, while blindly forcing the batched path there costs 15%.
+    static const int kBlockScore = []{
+        const char* e = getenv("SPARKINFER_DFLASH_BLOCK_SCORE");
+        int v = e ? atoi(e) : 1;
+        return v < 1 ? 1 : v;
+    }();
+
+    const int n_prompt = (int)prompt.size();
+    const bool spec_never_pays = (n_prompt + B) > kCompactMaxSeq &&
+                                 (n_prompt + max_new + B) < kEngageMinSeq &&
+                                 compact_mode != 1;
+    if (spec_never_pays) {
+        // Plain autoregressive decode, set up the way generate() sets it up: no hidden-state
+        // capture, no draft KV, no verify graph. Deciding before prefill rather than falling back
+        // mid-stream is what makes this reach AR's own throughput instead of approaching it -- a
+        // fallback still pays for the DFlash prefill it already ran.
+        set_dflash_capture(false, {}, 0);
+        const int ar_budget = session_token_budget(prompt.size(), max_new + B, s.cfg.max_seq);
+        clear_prefix_cache();
+        invalidate_decode_graph();
+        const uint64_t ar_sid = open_session(ar_budget);
+        if (!ar_sid) {
+            fprintf(stderr, "[dflash] KV allocate failed (need %d)\n", ar_budget);
+            return out;
+        }
+        activate_session(ar_sid);
+        s.final_seqlen_hint = n_prompt + max_new;
+        const auto ar_t0 = std::chrono::steady_clock::now();
+        int ar_next = ingest_prompt_range(prompt.data(), 0, n_prompt);
+        const auto ar_t1 = std::chrono::steady_clock::now();
+        if (ar_next < 0 || ar_next >= s.cfg.vocab) {
+            close_session(ar_sid);
+            fprintf(stderr, "[dflash] prompt prefill failed (n=%d)\n", n_prompt);
+            return out;
+        }
+        for (int i = 0; i < max_new; i++) {
+            out.push_back(ar_next);
+            if (ar_next == s.cfg.eos_id) break;
+            ar_next = forward_token(ar_next, n_prompt + i, true);
+            if (ar_next < 0) break;
+            if (gov) gov->pace();
+        }
+        const auto ar_t2 = std::chrono::steady_clock::now();
+        if (stats) {
+            stats->steps = (int)out.size();
+            stats->mean_accept = 1.0;   // one target forward per token, by definition
+            stats->ttft_s = std::chrono::duration<double>(ar_t1 - ar_t0).count();
+            stats->decode_s = std::chrono::duration<double>(ar_t2 - ar_t1).count();
+        }
+        close_session(ar_sid);
+        return out;
+    }
+
     // Head for the draft. The dual-head path keeps a native Q6_K copy so the draft's multi-row
     // MMVQ has something to chew on, but that kernel runs near HBM peak, so its runtime is just
     // its weight bytes -- and the target's own Q4_K copy is ~280 MB against the Q6_K's ~417 MB.
@@ -1901,6 +2022,11 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
                               : (s.dflash_lm_head ? s.dflash_lm_head_type : lm_head_quant_type());
     draft.set_shared_weights(embed_weights(), draft_head, draft_head_type,
                              s.cfg.vocab, s.cfg.hidden);
+    // Build the draft's quantized weights here, before prefill and well before the decode clock,
+    // so this generation pays exactly what it did when load() built them eagerly. The point of
+    // deferring them is the branch above: a generation that takes the autoregressive path returns
+    // before this line and never materialises them at all.
+    draft.ensure_quant();
     set_dflash_capture(true, dc.target_layer_ids, B);
 
     const int budget = session_token_budget(prompt.size(), max_new + B, s.cfg.max_seq);
@@ -1952,48 +2078,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
-    // 0=off, 1=force, 2=adaptive (default). #716 turned this off because the row-batched
-    // compact-verify graph (dflash_verify_short_run) showed a numerical discrepancy from AR
-    // "present in every row of a batch, including rows that still happen to land on the correct
-    // token" (#712), which on some steps flipped the argmax and broke DFlash's lossless
-    // guarantee. That gap is closed: the batched path was scoring its logits against a
-    // per-row symmetric int8 REQUANTIZATION of the Q4_K LM head, while AR scores against the
-    // native Q4_K weights -- a systematic per-row error, in exactly the "every row" shape
-    // reported. dflash_verify_short_run now uses the native head (see the comment there), so
-    // the batched path and AR read the same weights and greedy DFlash reproduces AR exactly.
-    static const int compact_mode = []{
-        const char* e = getenv("SPARKINFER_DFLASH_COMPACT_VERIFY");
-        return e ? atoi(e) : 2;
-    }();
-    // Full-block accepts arrive in runs (the target and draft agree over a whole predictable
-    // region), so one is already evidence the next step will accept a full block.
-    //
-    // Engage the row-batched verify only while the draft is actually landing full blocks. The
-    // batched pass replaces the step's sequential target forwards with one N-row pass, so it pays
-    // in proportion to how many forwards it collapses -- that is the ACCEPTANCE RATE, not the
-    // context length. Measured on RTX 5090 over held-out prompts (mean accept tau, compact off ->
-    // on): tau 5.32 -> 448.7 to 911.1 tok/s, but tau 2.40 -> 433.2 to 437.2, tau 2.00 -> 425.4 to
-    // 396.1, and tau 1.87 -> 439.1 to 350.8. Below roughly half the block depth the batched pass
-    // forwards the whole block to keep two tokens and the token loop's early exit is simply
-    // cheaper, so engaging there costs throughput on exactly the prompts the draft handles worst.
-    //
-    // The previous score LATCHED: any partial accept of >= kStayKeep held it at the engage
-    // threshold, so once armed it stayed armed straight through those low-acceptance stretches.
-    // Require a RUN of full-block accepts to arm, and decay on every non-full block so it backs
-    // off as soon as the draft stops landing blocks.
-    // How many full-block accepts in a row arm the batched path. A run is evidence that the draft
-    // is tracking the target, and the decay below still disarms on two non-full blocks, so the run
-    // length only sets how long that evidence takes to accumulate -- and the wait is paid on every
-    // prompt the draft handles well. On the held-out short prompt (tau 5.33, where batching is
-    // worth +11%) a run of 3 spends the first few steps of a ~24-step generation on the token loop:
-    // 806.1 tok/s at 3 against 878.7 at 1. A prompt the draft handles badly is unaffected either
-    // way, because it never lands the full block that arms it at all -- measured at tau 2.08,
-    // 437.2 -> 434.4, while blindly forcing the batched path there costs 15%.
-    static const int kBlockScore = []{
-        const char* e = getenv("SPARKINFER_DFLASH_BLOCK_SCORE");
-        int v = e ? atoi(e) : 1;
-        return v < 1 ? 1 : v;
-    }();
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN
     // accepted length, and it has no reason to sit at exactly B. Measured on RTX 5090 at the three
@@ -2012,10 +2096,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // hard bound that kept the batched verify away from long context entirely (the #712 gap); it
     // is now the boundary between "main's behaviour, unchanged" and "the new exact long-context
     // path", so nothing already validated at short context moves.
-    static const int kCompactMaxSeq = []{
-        const char* e = getenv("SPARKINFER_DFLASH_COMPACT_MAX_SEQ");
-        return e ? atoi(e) : 384;
-    }();
     // Compared against keep_ema8 in the SCALED domain (kEngageKeep * 8), not by shifting the EMA
     // down first. Shifting floors it, which collapses the very gap the gate exists to resolve:
     // 512-ctx sits at tau 2.19 (ema8 ~17.5) and 4k at tau 3.91 (ema8 ~31.3), and both floor to the
@@ -2025,10 +2105,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // stream pushes it over, and alpha 1/8 then takes ~8 steps to decay -- measured at 2.8-4.3%
     // lost to running the batched path where it is 31% SLOWER. A floor cannot be spoofed by a
     // transient, and it costs 4k nothing because 4k clears it from the first step.
-    static const int kEngageMinSeq = []{
-        const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_MINSEQ");
-        return e ? atoi(e) : 1024;
-    }();
     static const int kEngageKeep = []{
         const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_KEEP");
         int v = e ? atoi(e) : 3;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1380,9 +1380,10 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         if (!capture_dst || !capture_layers || n_capture <= 0) return;
         for (int slot = 0; slot < n_capture; ++slot) if (capture_layers[slot] == layer) {
             char* dst = static_cast<char*>(capture_dst) + (size_t)slot * H * sizeof(bf16);
-            pf_cu(cudaMemcpy2DAsync(dst, (size_t)n_capture * H * sizeof(bf16), x,
-                                    (size_t)H * sizeof(bf16), (size_t)H * sizeof(bf16), N,
-                                    cudaMemcpyDeviceToDevice, st), "verify capture");
+            // Kernel node, not a 2-D memcpy node: same bytes to the same addresses, but it
+            // schedules against its neighbours instead of draining the graph (see the note on
+            // launch_capture_rows in dflash_kernels.h).
+            dflash_kernels::launch_capture_rows(x, dst, N, H, n_capture * H, st);
         }
     };
 
@@ -1430,10 +1431,10 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     pf_cu(cudaMemcpyAsync(pos, ph_pos, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify pos");
     pf_cu(cudaMemcpyAsync(seq, ph_seq, (size_t)N * sizeof(int), cudaMemcpyHostToDevice, st), "verify lens");
     // Device-to-device inside the capture, so each replay re-reads the sequence's live table as it
-    // grows instead of baking in the mapping from capture time.
-    for (int i = 0; btab_rows && i < N; ++i)
-        pf_cu(cudaMemcpyAsync(btab_rows + (size_t)i * mbs, btable, (size_t)mbs * sizeof(int),
-                              cudaMemcpyDeviceToDevice, st), "verify btable row");
+    // grows instead of baking in the mapping from capture time. One kernel node rather than N
+    // memcpy nodes -- same reason as the capture copies above.
+    if (btab_rows)
+        dflash_kernels::launch_broadcast_rows_i32(btable, btab_rows, mbs, N, st);
     kernels::launch_embedding(ids, s.w.embed_tokens, x, N, H, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, c.rms_eps, st);
     for (int L = 0; L < c.n_layers && supported; ++L) {


### PR DESCRIPTION
## Summary

Skips speculation in the band where the batched verify can never engage — there the token loop
runs one target forward per emitted token, the same count AR decode runs, plus a draft block — and
builds the draft's quantized weights on first use so a generation that never runs the draft does
not materialise them. Also tiles the batched expert gate/up one warp per element for the multi-row
caller and issues the verify's device-to-device copies as kernel nodes.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end DFlash decode, 128 generated tokens, best of the three scored
contexts — 512):

| | decode tok/s |
|---|--:|
| before (main) | 407.99 |
| after (this PR) | 496.70 |

**Prefill pp tok/s** — not applicable; this PR changes only the DFlash decode path and touches no
prefill entry point.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

```text
GPU: NVIDIA GeForce RTX 5090, sm_120, CUDA 12.8
Model: Qwen3.6-35B-A3B-UD-Q4_K_M + z-lab/Qwen3.6-35B-A3B-DFlash
Base: origin/main 0a9a1fe. Alternating same-box A/B, 3 reps per arm,
shipped defaults, 0 SPARKINFER_* overrides.

  ctx=base main 844.78 / 844.93 / 841.48   mean 843.73   MEAN_ACCEPT 5.3333
  ctx=base pr   854.30 / 855.65 / 849.49   mean 853.15   MEAN_ACCEPT 5.3333
  => base   843.73 -> 853.15   +1.1%

  ctx=512  main 407.46 / 408.87 / 407.65   mean 407.99   MEAN_ACCEPT 2.1864
  ctx=512  pr   495.77 / 497.74 / 496.58   mean 496.70   MEAN_ACCEPT 1.0000
  => 512    407.99 -> 496.70   +21.7%

  ctx=4096 main 524.42 / 523.35 / 522.93   mean 523.57   MEAN_ACCEPT 3.9091
  ctx=4096 pr   534.55 / 528.19 / 534.27   mean 532.34   MEAN_ACCEPT 3.9091
  => 4096   523.57 -> 532.34   +1.7%
```

**Accuracy** — 12/12 `SPEC_AGREE = 1.0000`, `VERDICT PASS`: 4 seeds (`fixed`, `s1`, `s4`, `s8`)
x 3 contexts (base/512/4k), 128 generated tokens each, four times the standard check length.

At 512 `MEAN_ACCEPT` reads 1.0000 because that band runs the autoregressive path, where one target
forward produces one token by definition; the emitted tokens are AR's own, so the accuracy check is
exact there by construction. 128-ctx and 4k keep `MEAN_ACCEPT` identical to `main` (5.3333 /
3.9091), i.e. their committed token stream is unchanged.

## Scope

- The autoregressive band is entered only when a generation both starts above `kCompactMaxSeq` and
  ends below `kEngageMinSeq`, so 128-ctx and 4k never reach it — confirmed by their unchanged mean
  accept length.
- `dflash_generate` primes the draft's quantized weights before prefill, ahead of its decode clock,
  so any generation that does run the draft is unchanged. `ensure_quant()` is idempotent and
  `forward_block` also calls it, so no path can observe them missing.
- The gate/up tiling is bit-identical to the four-warp path — same `kbx` sequence in the same order,
  same butterfly — and applies only when `num_tokens > 1`, leaving AR decode on its tuned kernel.
- The verify's copy nodes move the same bytes to the same addresses.
- Standard Qwen3.5/Qwen3.6 autoregressive decode and prefill call sites are untouched.
- `SPARKINFER_GU_BATCH_WARPS`, `SPARKINFER_DOWN_BATCH_WARPS`, `SPARKINFER_DFLASH_COMPACT_MAX_SEQ`
  and `SPARKINFER_DFLASH_ENGAGE_MINSEQ` are available for A/B.
