### PR TITLE
fix(dflash): size draft KV to the requested context (unbreak DFlash at 16k)

### DIFF
--- a/runtime/examples/qwen3_gguf_dflash_bench.cpp
+++ b/runtime/examples/qwen3_gguf_dflash_bench.cpp
@@ -73,6 +73,11 @@ int main(int argc, char** argv) {
     if (!model.load_gguf(gguf)) { printf("[FAIL] load_gguf\n"); return 1; }
 
     sparkinfer::DFlashDraftConfig dcfg;
+    // Size the draft KV cache to the requested context. Without this the draft keeps its default
+    // max_seq=8192, so draft.forward_block() bails out past 8k and DFlash silently degrades to a
+    // lossy/zero-throughput fallback at longer contexts (e.g. the 16k eval sweep). The draft model
+    // itself supports up to max_position_embeddings (262144); the target is sized the same way above.
+    dcfg.max_seq = cfg.max_seq;
     sparkinfer::DFlashDraftModel draft(dcfg);
     if (!draft.load(draft_dir)) { printf("[FAIL] draft load\n"); return 1; }
     model.set_dflash_draft(&draft);

--- a/runtime/examples/qwen3_gguf_dflash_check.cpp
+++ b/runtime/examples/qwen3_gguf_dflash_check.cpp
@@ -68,6 +68,10 @@ int main(int argc, char** argv) {
     if (!model.load_gguf(gguf)) { printf("[FAIL] load_gguf\n"); return 1; }
 
     sparkinfer::DFlashDraftConfig dcfg;
+    // Size the draft KV cache to the requested context (see qwen3_gguf_dflash_bench.cpp): the
+    // default max_seq=8192 otherwise makes draft.forward_block() bail out past 8k, so the accuracy
+    // check at longer contexts (16k sweep) sees a lossy/zero-throughput result instead of a match.
+    dcfg.max_seq = cfg.max_seq;
     sparkinfer::DFlashDraftModel draft(dcfg);
     if (!draft.load(draft_dir)) { printf("[FAIL] load draft %s\n", draft_dir.c_str()); return 1; }
     model.set_dflash_draft(&draft);


### PR DESCRIPTION
## Summary

DFlash is structurally broken above the draft model's `max_seq` at the **16k** context that
`fbda5ed` just added to the eval sweep: the draft keeps its default `max_seq=8192`, so
`draft.forward_block()` bails out past 8k and DFlash silently degrades to a lossy / zero-throughput
fallback (`DFLASH_TPS=0`, `SPEC_AGREE=0`, `VERDICT=FAIL`). This sizes the draft KV cache to the
requested context — exactly as the target model is already sized one line above — restoring
**lossless** DFlash at 16k (**0 → 537.5 tok/s**, `SPEC_AGREE=1.0000`). The draft model itself
supports `max_position_embeddings=262144`; only the runtime cap was in the way. Short contexts
(128 / 512 / 4k) are **bit-identical** — this is a correctness/capability fix at the newly-added
16k sweep context, not a change to any already-working path.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — at the **16k** sweep context this PR fixes (128/512/4k are unchanged, listed below):

| | decode tok/s |
|---|--:|
| before (main) | **0** — DFlash bails past 8k (`DFLASH_TPS=0`, `VERDICT=FAIL`, lossy) |
| after (this PR) | **537.5** — `τ=5.375`, `SPEC_AGREE=1.0000`, `VERDICT=PASS` (lossless) |

Scored short contexts are unchanged (bit-identical, no regression):

| ctx | main decode tok/s | this PR | SPEC_AGREE |
|---|--:|--:|:--:|
| 128 | 866.1 | 866.1 | 1.0000 |
| 512 | 504.1 | 504.1 | 1.0000 |
| 4k | 537.6 | 537.6 | 1.0000 |
| **16k** | **0 (FAIL)** | **537.5** | **1.0000** |

**Prefill pp tok/s**: N/A — this PR targets the DFlash decode path, not prefill.

<!-- Measured with the repo's own end-to-end DFlash bench (`qwen3_gguf_dflash_bench` — the same
     binary the eval harness runs) + `qwen3_gguf_dflash_check` for SPEC_AGREE. `bench/scripts/bench.sh`
     covers only plain-AR decode, not the DFlash path, so it cannot show this. These are full
     model-generation runs, not isolated-kernel microbenchmarks. RTX 5090, Qwen3.6-35B-A3B Q4_K_M,
     z-lab DFlash draft, NTOK=128, fixed eval prompt (gen_eval_prompt.py fixed ... --len 16384). -->

```text
# ---- BEFORE (main, draft max_seq=8192) @ 16k ----
CTX=16384  AR_TPS=3.8988  DFLASH_TPS=0.0000  TAU=0.0000  SPEC_AGREE=0.0000  VERDICT=FAIL

# ---- AFTER (this PR) @ 16k ----
=== sparkinfer DFlash bench ===
gen_tokens    : AR=128 DFlash=128
AR            : 3.90 tok/s  (wall 32.847s)          # AR wall includes the 16k prefill
DFlash        : 537.52 tok/s  (decode 0.238s)       # decode-only
mean_accept τ : 5.375  (steps=24)
METRIC DFLASH_TPS 537.5590
METRIC MEAN_ACCEPT 5.3750
SPEC_AGREE 1.0000  VERDICT PASS

# ---- Scored contexts AFTER (this PR) — unchanged vs main ----
CTX=128(primary)  DFLASH_TPS=866.1211  TAU=5.3333  SPEC_AGREE=1.0000  VERDICT=PASS
CTX=512           DFLASH_TPS=504.1264  TAU=1.0000  SPEC_AGREE=1.0000  VERDICT=PASS
CTX=4096          DFLASH_TPS=537.6373  TAU=3.9091  SPEC_AGREE=1.0000  VERDICT=PASS
```
