### PR TITLE
perf(dflash): skip the draft's out-of-window keys at long context (1.08x decode @16k)

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -257,7 +257,7 @@ template <int ROWS, int NWARPS>
 __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
     const bf16* __restrict__ q, const bf16* __restrict__ k, const bf16* __restrict__ v,
     float* __restrict__ p_m, float* __restrict__ p_l, float* __restrict__ p_acc,
-    int q_len, int kv_len, int n_q, int n_kv,
+    int q_len, int kv_lo, int kv_len, int n_q, int n_kv,
     int q_pos0, int k_pos0, int window, bool causal, float scale, int n_splits) {
     constexpr int D = 128, E = D / 32;
     const int rg = blockIdx.x, qh = blockIdx.y, sp = blockIdx.z;
@@ -277,8 +277,11 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
         sum[r] = 0.f;
     }
 
-    const int chunk = (kv_len + n_splits - 1) / n_splits;
-    const int t0 = sp * chunk;
+    // Partition [kv_lo, kv_len) rather than [0, kv_len): keys below kv_lo are masked out for every
+    // row of the block (the caller derives kv_lo from the same window predicate this loop applies),
+    // so covering them only buys a K load and a QK dot that are thrown away.
+    const int chunk = (kv_len - kv_lo + n_splits - 1) / n_splits;
+    const int t0 = kv_lo + sp * chunk;
     const int t1 = min(kv_len, t0 + chunk);
 
     for (int t = t0 + warp; t < t1; t += NWARPS) {
@@ -1195,12 +1198,32 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
         if (kSplitAttn && fa_m && fa_l && fa_acc && n_kv > 0 && (n_q % n_kv) == 0 &&
             q_len <= kDFlashAttnMaxRows && kv_len >= kDFlashAttnMinKv) {
             constexpr int ROWS = 2, NWARPS = 8;
-            const int n_splits = attn_gqa_splits(kv_len);
+            const int n_splits_full = attn_gqa_splits(kv_len);
+            // A sliding-window layer masks a key only after the kernel has loaded it and reduced
+            // its QK dot, so past the window length it streams the whole cache to discard most of
+            // it -- at a 16k context with a 4096 window that is 3/4 of the traffic on every
+            // windowed layer. The kernel's own predicate is (q_pos - k_pos) >= window, and the
+            // block's smallest query position is q_pos0, so every key at or below
+            // q_pos0 - k_pos0 - window is dead for the whole block: start the partition above it.
+            static const int kWinSpan = []{ const char* e = getenv("SPARKINFER_DFLASH_WINSPAN");
+                                            return (e && e[0] == '0') ? 0 : 1; }();
+            // Narrow only when at least one whole split's worth of keys goes away: while the window
+            // still covers the cache this would trim a handful of keys, and re-partitioning the key
+            // range changes the order the online-softmax partials merge in -- not worth spending
+            // the draft's acceptance on for no traffic saved. The kv_len bound is belt-and-braces;
+            // the newest key is always inside the window, so lo < kv_len holds for any window >= 1.
+            int kv_lo = 0;
+            if (kWinSpan && window > 0) {
+                const long lo = (long)q_pos0 - (long)k_pos0 - (long)window + 1;
+                if (lo >= (kv_len + n_splits_full - 1) / n_splits_full && lo < (long)kv_len)
+                    kv_lo = (int)lo;
+            }
+            const int n_splits = kv_lo > 0 ? attn_gqa_splits(kv_len - kv_lo) : n_splits_full;
             const size_t smem = (size_t)(2 * NWARPS * ROWS + NWARPS * ROWS * 128) * sizeof(float);
             dim3 g((q_len + ROWS - 1) / ROWS, n_q, n_splits);
             k_attn_rows_split_hd128<ROWS, NWARPS><<<g, NWARPS * 32, smem, stream>>>(
                 (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,
-                q_len, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits);
+                q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits);
             k_attn_split_combine<<<dim3(q_len, n_q), 128, 0, stream>>>(
                 fa_m, fa_l, fa_acc, (bf16*)out, n_q, n_splits);
             return;


### PR DESCRIPTION
## Summary

The DFlash draft is 6 layers and its `config.json` marks 5 of them `sliding_attention` with
`sliding_window: 4096`; `dflash_draft.cpp` passes that window through per layer. But
`k_attn_rows_split_hd128` evaluates the window predicate only *after* it has loaded the key and
reduced its QK dot — it skips just the V load. Past the window length a windowed layer therefore
streams the entire KV cache to keep a 4096-key slice of it, and the waste grows with context: at a
16k context it read ~16392 keys per layer to use ~4104.

Every key at or below `q_pos0 - k_pos0 - window` is masked for every row of the block, so the split
partition can start there instead of at 0. The bound is derived from the same predicate the kernel
applies, so it drops exactly the dead prefix rather than approximating it. Narrowing is taken only
when it removes at least one whole split's worth of keys — while the window still covers the cache
it would re-partition the online-softmax merge for no traffic saved — so 128/512/4k are untouched
by construction and measure flat below.

Emitted tokens are target argmaxes either way and the accept length is identical at every context,
so this is latency only, not an accuracy trade.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end `DFLASH_TPS`, 128 tokens, held-out `gen_eval_prompt.py fixed` prompt at
16384 tokens — verified byte-identical to the one the eval generates):

| | decode tok/s |
|---|--:|
| before (main) | 548.30 |
| after (this PR) | 594.29 |

Medians of 3 alternating pairs. Both arms come from **one binary**, switched by
`SPARKINFER_DFLASH_WINSPAN`, so the comparison cannot be contaminated by a stale build.

```text
=== 16k, alternating, one build (RTX 5090, sm_120, CUDA 12.8) ===
  before    after    delta   tau(before/after)
  549.81   594.75   +8.17%   5.3750 / 5.3750
  548.30   594.29   +8.39%   5.3750 / 5.3750
  548.10   594.22   +8.41%   5.3750 / 5.3750
  median   +8.39%

=== every scored context, 3 pairs each (24 runs) ===
   ctx   before    after    delta   tau(before/after)
 16384   548.30   594.29   +8.39%   5.3750 / 5.3750
  4096   554.10   554.33   +0.04%   3.9091 / 3.9091
   512   522.08   522.10   +0.00%   1.0000 / 1.0000
   128   897.51   893.74   -0.42%   5.3333 / 5.3333
```

The 128 figure is run-to-run noise: below `kDFlashAttnMinKv` (1024) the KV-split path is not
dispatched at all, so this code cannot execute there. The three before-reps spread 0.7%
(899.43 / 897.51 / 893.21) while the after-reps sit within 0.03% of each other.

### Where the time went

Two capture-ranged nsys profiles of the 16k decode loop (`--cuda-graph-trace=node`), same 144
draft-attention calls over 24 steps:

| | before | after |
|---|--:|--:|
| `k_attn_rows_split_hd128` | 37.60 ms (261.13 us/call) | **19.78 ms (137.35 us/call)** |
| draft stream | 71.2 ms | 53.3 ms |
| total kernel time | 248.77 ms | 230.43 ms |

The kernel gives up 17.82 ms and the draft stream falls by 17.9 ms. Everything else is unchanged —
`si_mmvq_q4k_rows_exact` 42.26 -> 42.17, `fa_split_gqa` 38.05 -> 37.92,
`gate_up_mmvq2_warp_qwen` 25.28 -> 25.28, verify stream 142.9 -> 142.6 ms.
`dflash_kernels::launch_attn_gqa` has exactly one caller, the draft's `forward_block`.

### Accuracy gate

```text
>> DFlash check: seed=fixed prompt_tokens=101 max_new=32
METRIC SPEC_AGREE 32/32 = 1.0000
VERDICT PASS

per-context (build/runtime/qwen3_gguf_dflash_check <gguf> <draft> 32 <ids>):
  ctx=16384  SPEC_AGREE=1.0000  VERDICT=PASS
  ctx=4096   SPEC_AGREE=1.0000  VERDICT=PASS
  ctx=512    SPEC_AGREE=1.0000  VERDICT=PASS
  ctx=128    SPEC_AGREE=1.0000  VERDICT=PASS
```

### Scope

`dflash_kernels::launch_attn_gqa` has exactly one caller — `DFlashDraftModel::forward_block` — so
nothing outside DFlash speculation can reach this code, and `qwen3_gguf_bench` never constructs a
draft. The 16k profile above is consistent with that: the verify stream and every non-draft kernel
are unchanged.
