### PR TITLE
perf(dflash): skip context rows a windowed draft layer can never read (1.02x decode @16k)

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1184,6 +1184,30 @@ int attn_gqa_splits(int kv_len) {
     return s;
 }
 
+static inline int attn_gqa_split_path_ok(int q_len, int kv_len, int n_q, int n_kv, int d) {
+    static const int kSplitAttn = []{ const char* e = getenv("SPARKINFER_DFLASH_SPLIT_ATTN");
+                                      return (e && e[0] == '0') ? 0 : 1; }();
+    return kSplitAttn && d == 128 && n_kv > 0 && (n_q % n_kv) == 0 &&
+           q_len <= kDFlashAttnMaxRows && kv_len >= kDFlashAttnMinKv;
+}
+
+int attn_gqa_kv_lo(int q_len, int kv_len, int n_q, int n_kv, int d,
+                   int q_pos0, int k_pos0, int window) {
+    if (window <= 0 || !attn_gqa_split_path_ok(q_len, kv_len, n_q, n_kv, d)) return 0;
+    static const int kWinSpan = []{ const char* e = getenv("SPARKINFER_DFLASH_WINSPAN");
+                                    return (e && e[0] == '0') ? 0 : 1; }();
+    if (!kWinSpan) return 0;
+    // Narrow only when at least one whole split's worth of keys goes away: while the window still
+    // covers the cache this would trim a handful of keys, and re-partitioning the key range changes
+    // the order the online-softmax partials merge in -- not worth spending the draft's acceptance
+    // on for no traffic saved. The kv_len bound is belt-and-braces; the newest key is always inside
+    // the window, so lo < kv_len holds for any window >= 1.
+    const int n_splits_full = attn_gqa_splits(kv_len);
+    const long lo = (long)q_pos0 - (long)k_pos0 - (long)window + 1;
+    if (lo >= (kv_len + n_splits_full - 1) / n_splits_full && lo < (long)kv_len) return (int)lo;
+    return 0;
+}
+
 void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                      int q_len, int kv_len, int n_q, int n_kv, int d,
                      int q_pos0, int k_pos0, int window, bool causal, float scale,
@@ -1193,10 +1217,7 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
     if (d == 128) {
         // Row-batched + KV-split path. Needs the caller's partial-state scratch; without it
         // (or below the sweep's crossover) fall through to the single-CTA-per-row kernel.
-        static const int kSplitAttn = []{ const char* e = getenv("SPARKINFER_DFLASH_SPLIT_ATTN");
-                                          return (e && e[0] == '0') ? 0 : 1; }();
-        if (kSplitAttn && fa_m && fa_l && fa_acc && n_kv > 0 && (n_q % n_kv) == 0 &&
-            q_len <= kDFlashAttnMaxRows && kv_len >= kDFlashAttnMinKv) {
+        if (fa_m && fa_l && fa_acc && attn_gqa_split_path_ok(q_len, kv_len, n_q, n_kv, d)) {
             constexpr int ROWS = 2, NWARPS = 8;
             const int n_splits_full = attn_gqa_splits(kv_len);
             // A sliding-window layer masks a key only after the kernel has loaded it and reduced
@@ -1205,19 +1226,7 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
             // windowed layer. The kernel's own predicate is (q_pos - k_pos) >= window, and the
             // block's smallest query position is q_pos0, so every key at or below
             // q_pos0 - k_pos0 - window is dead for the whole block: start the partition above it.
-            static const int kWinSpan = []{ const char* e = getenv("SPARKINFER_DFLASH_WINSPAN");
-                                            return (e && e[0] == '0') ? 0 : 1; }();
-            // Narrow only when at least one whole split's worth of keys goes away: while the window
-            // still covers the cache this would trim a handful of keys, and re-partitioning the key
-            // range changes the order the online-softmax partials merge in -- not worth spending
-            // the draft's acceptance on for no traffic saved. The kv_len bound is belt-and-braces;
-            // the newest key is always inside the window, so lo < kv_len holds for any window >= 1.
-            int kv_lo = 0;
-            if (kWinSpan && window > 0) {
-                const long lo = (long)q_pos0 - (long)k_pos0 - (long)window + 1;
-                if (lo >= (kv_len + n_splits_full - 1) / n_splits_full && lo < (long)kv_len)
-                    kv_lo = (int)lo;
-            }
+            const int kv_lo = attn_gqa_kv_lo(q_len, kv_len, n_q, n_kv, d, q_pos0, k_pos0, window);
             const int n_splits = kv_lo > 0 ? attn_gqa_splits(kv_len - kv_lo) : n_splits_full;
             const size_t smem = (size_t)(2 * NWARPS * ROWS + NWARPS * ROWS * 128) * sizeof(float);
             dim3 g((q_len + ROWS - 1) / ROWS, n_q, n_splits);

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -29,6 +29,15 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                      cudaStream_t stream, float* fa_m = nullptr, float* fa_l = nullptr,
                      float* fa_acc = nullptr);
 
+// First key index launch_attn_gqa will actually read for a windowed layer, given a block whose
+// smallest query position is q_pos0; 0 when it will read from the start. Everything below the
+// return value is masked for every row of the block AND excluded from the split partition, so a
+// caller that fills the KV cache may leave those rows unwritten. Exposed rather than left inline in
+// the launcher so producer and consumer derive the bound from one place and cannot disagree -- a
+// row the producer skipped but the kernel still read would be uninitialized memory.
+int attn_gqa_kv_lo(int q_len, int kv_len, int n_q, int n_kv, int d,
+                   int q_pos0, int k_pos0, int window);
+
 // In-place RoPE on [seq, n_heads, d] bf16. positions[i] = pos0 + i.
 void launch_rope_seq(void* x, int seq, int n_heads, int d, int pos0,
                      float theta, cudaStream_t stream);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -659,8 +659,14 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         fprintf(stderr, "[dflash] KV overflow past=%d new=%d max=%d\n", past, new_len_all, c.max_seq);
         return false;
     }
+    // Attention geometry for this block, hoisted: the context ingestion below needs the layer's
+    // window and the block's key span to know which context rows the attention can still reach.
+    const int kv_len_for_block = past + new_len_all;
+    const int q_pos0_for_block = pos0;
     for (int L = 0; L < run_layers; L++) {
         const LayerWeights& w = s.layers[L];
+        const int window_of_layer = (L < (int)c.sliding_layers.size() && c.sliding_layers[L])
+                                        ? c.sliding_window : 0;
         bf16* const kdst = s.k_cache[L] + (size_t)past * kvdim;
         bf16* const vdst = s.v_cache[L] + (size_t)past * kvdim;
         if (L == 0)
@@ -689,19 +695,38 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
         // Context half of cat(k_ctx, k_noise), written ahead of the noise rows.
-        if (ctx_gemm) {
-            kernels::launch_prefill_gemm(s.target_proj, w.wk, kdst, ctx_len, kvdim, H, st);
-            kernels::launch_prefill_gemm(s.target_proj, w.wv, vdst, ctx_len, kvdim, H, st);
-        } else if (ctx_len > 1) {
+        //
+        // A windowed layer never reads a key older than `window` before the query, and
+        // launch_attn_gqa now starts its partition above that bound rather than masking it inside
+        // the loop -- so on a long prompt the leading context rows are projected into the cache and
+        // then never touched. Skip producing them. The bound comes from attn_gqa_kv_lo, the same
+        // function the launcher uses, evaluated at THIS block: q_pos0 only grows as the generation
+        // proceeds, and the one-split-worth guard it applies gets easier to satisfy as it does
+        // (the bound climbs a key per token while a split's width climbs a fraction of one), so a
+        // row dead for this block is dead for every later block too. Full-attention layers and
+        // every steady-state block (where the window still covers the cache) get skip == 0 and are
+        // byte-for-byte unchanged.
+        static const int kCtxTrim = []{ const char* e = getenv("SPARKINFER_DFLASH_CTX_TRIM");
+                                        return (e && e[0] == '0') ? 0 : 1; }();
+        const int ctx_kv_lo = (ctx_len > 0 && kCtxTrim)
+            ? dflash_kernels::attn_gqa_kv_lo(BW, kv_len_for_block, c.n_q_heads, c.n_kv_heads, d,
+                                             q_pos0_for_block, /*k_pos0=*/0, window_of_layer)
+            : 0;
+        const int ctx_skip = ctx_kv_lo > past ? std::min(ctx_kv_lo - past, ctx_len) : 0;
+        const int ctx_rows = ctx_len - ctx_skip;
+        const bf16* const ctx_src = s.target_proj + (size_t)ctx_skip * H;
+        bf16* const kdst_ctx = kdst + (size_t)ctx_skip * kvdim;
+        bf16* const vdst_ctx = vdst + (size_t)ctx_skip * kvdim;
+        if (ctx_rows > 0 && ctx_gemm) {
+            kernels::launch_prefill_gemm(ctx_src, w.wk, kdst_ctx, ctx_rows, kvdim, H, st);
+            kernels::launch_prefill_gemm(ctx_src, w.wv, vdst_ctx, ctx_rows, kvdim, H, st);
+        } else if (ctx_rows > 1) {
             dflash_kernels::launch_gemv_rows_exact_fused2(
-                s.target_proj, w.wk, w.wv, kdst, vdst,
-                ctx_len, kvdim, kvdim, H, st);
-        } else if (ctx_len == 1) {
-            const int t = 0;
-            kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wk,
-                                 kdst + (size_t)t * kvdim, kvdim, H, st);
-            kernels::launch_gemv(s.target_proj + (size_t)t * H, w.wv,
-                                 vdst + (size_t)t * kvdim, kvdim, H, st);
+                ctx_src, w.wk, w.wv, kdst_ctx, vdst_ctx,
+                ctx_rows, kvdim, kvdim, H, st);
+        } else if (ctx_rows == 1) {
+            kernels::launch_gemv(ctx_src, w.wk, kdst_ctx, kvdim, H, st);
+            kernels::launch_gemv(ctx_src, w.wv, vdst_ctx, kvdim, H, st);
         }
         if (!fast16) {
             for (int t = 0; t < BW; t++) {
@@ -725,13 +750,16 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         const int q_pos0 = pos0;
         dflash_kernels::launch_rms_heads_rope(s.q, w.q_norm, BW, c.n_q_heads, d, c.rms_eps,
                                              q_pos0, c.rope_theta, st);
-        dflash_kernels::launch_rms_heads_rope(kdst, w.k_norm, new_len, c.n_kv_heads, d,
-                                             c.rms_eps, k_pos0, c.rope_theta, st);
+        // Norm+RoPE only the rows that were actually produced above; the skipped context prefix
+        // holds no K to normalise. Row i of this slice keeps its own absolute position, so the
+        // surviving rows get exactly the angles they got before.
+        dflash_kernels::launch_rms_heads_rope(kdst + (size_t)ctx_skip * kvdim, w.k_norm,
+                                             new_len - ctx_skip, c.n_kv_heads, d,
+                                             c.rms_eps, k_pos0 + ctx_skip, c.rope_theta, st);
 
         // K/V are already in the cache at offset `past` -- attend over the full past+new.
         const int kv_len = past + new_len;
-        const int window = (L < (int)c.sliding_layers.size() && c.sliding_layers[L])
-                               ? c.sliding_window : 0;
+        const int window = window_of_layer;
         static int mixed_causal = [] {
             const char* e = getenv("SPARKINFER_DFLASH_MIXED_CAUSAL");
             return (!e || e[0] != '0') ? 1 : 0;


### PR DESCRIPTION
## Summary

The draft ingests the whole prompt on the first block of a generation, projecting every context row
into K/V for all six of its layers. Five of those layers are `sliding_attention` with
`sliding_window=4096`, and the split attention path now starts its key partition above the window
rather than masking inside the loop — so on a long prompt those leading rows are computed, written,
and then never read by anything. Skip producing them.

The bound is not recomputed here: it comes from the same function the launcher narrows with, so the
rows the producer skips are exactly the rows the consumer skips. Full-attention layers, and every
steady-state block (where the window still covers the cache), get a skip of zero and are unchanged.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_dflash_bench`, held-out 16k prompt, 128 new tokens):

| | decode tok/s |
|---|--:|
| before (main) | 580.11 |
| after (this PR) | 592.25 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | |
| after prefill (this PR) | |

Every scored DFlash context, one binary, three alternating pairs each, medians reported. Mean
accepted length is identical in all twelve pairs, so these are step-cost changes and not a
different continuation:

| context | main | this PR | change | τ | SPEC_AGREE |
|---|--:|--:|--:|--:|---|
| held-out primary (101 tok) | 865.23 | 865.44 | +0.02% | 5.3333 | 32/32 PASS |
| 512 | 503.56 | 503.63 | +0.01% | 1.0000 | 32/32 PASS |
| 4096 | 534.95 | 534.32 | −0.12% | 3.9091 | 32/32 PASS |
| 16384 | 580.11 | 592.25 | **+2.09%** | 5.3750 | 32/32 PASS |

### What changed

**Skip the context rows a windowed layer can never read.** A host-timed split of the decode loop at
a 16k context shows the first block costs the draft 17.28 ms against a 1.83 ms steady state — that
one block is 6.9% of a 128-token decode (at 4k the same block is 1.9%, which is why this is a
long-context effect and not a general one). An `nsys` profile of the decode loop attributes it to 13
`pf_gemm` launches: one `fc` projection over the whole prompt, then a K and a V projection per layer.
Ten of those twelve per-layer projections belong to windowed layers, and three quarters of each was
dead on arrival.

The window predicate is `(q_pos - k_pos) >= window`, and the smallest query position in a block is
`q_pos0`, so nothing at or below `q_pos0 - k_pos0 - window` can contribute for any row. That is the
bound the split path already applies, so this factors it out of the launcher into
`dflash_kernels::attn_gqa_kv_lo` and calls it from the ingestion. Deriving it in one place is the
point: a row the ingestion skipped but the kernel still read would be uninitialized memory, and the
two must agree by construction rather than by matching two copies of a predicate. The launcher's
behaviour is unchanged — same value, same call site, same guards.

Evaluating the bound at the current block is sufficient for the whole generation. `q_pos0` grows by a
token per step while the one-split-worth guard the bound is subject to grows by a fraction of one, so
a row that is dead for this block stays dead for every later block.

The norm+RoPE over the K slice follows the same range. Row `i` of the surviving slice keeps its own
absolute position, so the rows that remain get exactly the angles they got before.

Result at 16k: the first block's draft cost falls 17.28 → 12.94 ms, the steady-state block is
unchanged at 1.83 ms, and mean accepted length is identical. `SPARKINFER_DFLASH_CTX_TRIM=0` restores
the previous behaviour.

```text
--- BEFORE (main) 16384 ---
DFlash        : 580.11 tok/s
METRIC DFLASH_TPS 580.1050
METRIC MEAN_ACCEPT 5.3750
[step split] step0 draft=17.28ms | steady draft=1.84ms/step verify=6.83ms/step

--- AFTER (this PR) 16384 ---
DFlash        : 592.25 tok/s
METRIC DFLASH_TPS 592.2451
METRIC MEAN_ACCEPT 5.3750
[step split] step0 draft=12.94ms | steady draft=1.83ms/step verify=6.82ms/step

--- alternating pairs, one binary (SPARKINFER_DFLASH_CTX_TRIM=0/1) ---
ctx=0      rep1 off 865.4444  on 864.2438   tau 5.3333 / 5.3333
ctx=0      rep2 off 865.2343  on 865.5351   tau 5.3333 / 5.3333
ctx=0      rep3 off 865.0554  on 865.4401   tau 5.3333 / 5.3333
ctx=512    rep1 off 503.9168  on 504.4901   tau 1.0000 / 1.0000
ctx=512    rep2 off 503.4232  on 503.1110   tau 1.0000 / 1.0000
ctx=512    rep3 off 503.5648  on 503.6300   tau 1.0000 / 1.0000
ctx=4096   rep1 off 535.2444  on 534.9691   tau 3.9091 / 3.9091
ctx=4096   rep2 off 533.3651  on 534.3174   tau 3.9091 / 3.9091
ctx=4096   rep3 off 534.9508  on 534.1508   tau 3.9091 / 3.9091
ctx=16384  rep1 off 580.9451  on 590.9113   tau 5.3750 / 5.3750
ctx=16384  rep2 off 580.1050  on 592.3017   tau 5.3750 / 5.3750
ctx=16384  rep3 off 579.3410  on 592.2451   tau 5.3750 / 5.3750

--- accuracy gate, this PR (qwen3_gguf_dflash_check, 32 new tokens) ---
primary : METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
512     : METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
4096    : METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
16384   : METRIC SPEC_AGREE 32/32 = 1.0000   VERDICT PASS
```
