### PR TITLE
fix(quality): restore llama-server backend and Qwen3.6 orchestrator

### DIFF
--- a/bench/quality/README.md
+++ b/bench/quality/README.md
@@ -39,11 +39,12 @@ seed_hand_authored/    the original hand-written seed (offline fallback / refere
 python3 scorers.py                     # 10/10 scorer self-tests
 python3 run_quality.py --backend oracle  # gold/scorer sanity for answer-derivable tasks
 python3 run_quality.py --backend mock    # ~0%  - floor
+python3 run_quality.py --self-test-llama-server  # HTTP backend wiring (stdlib stub)
 
 # 2. score sparkinfer on a GPU box:
 python3 run_quality.py --backend sparkinfer \
     --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf \
-    --bin ./build/qwen3_gguf_generate \
+    --bin ./build/runtime/qwen3_gguf_generate \
     --tokenizer /workspace/models/tokenizer.json
 
 # 3. score the llama.cpp reference (start llama-server first, then):

--- a/bench/quality/run_quality.py
+++ b/bench/quality/run_quality.py
@@ -14,11 +14,17 @@ Usage:
   # sparkinfer:
   python3 run_quality.py --backend sparkinfer \
       --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf \
-      --bin ./build/qwen3_gguf_generate --tokenizer /workspace/models/tokenizer.json
+      --bin ./build/runtime/qwen3_gguf_generate --tokenizer /workspace/models/tokenizer.json
 
-  # llama.cpp reference:
+  # llama.cpp reference (one-shot CLI — reloads weights per item):
   python3 run_quality.py --backend llama --llama-cli /workspace/.llamacpp/build/bin/llama-cli \
       --model /workspace/models/Qwen3-30B-A3B-Q4_K_M.gguf
+
+  # llama.cpp via a running llama-server (resident weights — preferred for tiers):
+  python3 run_quality.py --backend llama-server --llama-url http://localhost:8082
+
+  # CPU-only wiring check for the HTTP backend (stdlib mock, no GPU/model):
+  python3 run_quality.py --self-test-llama-server
 
   # only some benchmarks / fewer items:
   python3 run_quality.py --backend sparkinfer --benchmarks gsm8k,humaneval --limit 20 ...
@@ -27,7 +33,7 @@ Usage:
   python3 run_quality.py --backend sparkinfer --tier development ...  # ~10%, 78 items
   python3 run_quality.py --backend sparkinfer --tier benchmark ...    # ~25%, 196 items
 """
-import argparse, json, os, subprocess, sys, glob
+import argparse, json, os, subprocess, sys, glob, urllib.error, urllib.request
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import scorers
 
@@ -112,6 +118,49 @@ class LlamaBackend:
         return r.stdout
 
 
+
+class LlamaServerBackend:
+    """Score against a running llama.cpp `llama-server`.
+
+    Keeps the GGUF resident across items (unlike `--backend llama`, which shells
+    `llama-cli` once per prompt). Tries the native `/completion` route first and
+    falls back to OpenAI-compatible `/v1/completions` when that path is absent.
+    Always greedy (`temperature=0`) so the reference matches the other backends.
+    """
+
+    def __init__(self, url, timeout=600):
+        self.base = url.rstrip("/")
+        self.timeout = timeout
+        self._use_openai = False
+
+    def _post(self, path, payload):
+        req = urllib.request.Request(
+            self.base + path,
+            data=json.dumps(payload).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+            return json.loads(resp.read().decode())
+
+    def gen_for(self, item):
+        n = MAXNEW.get(item["benchmark"], 200)
+        prompt = CHAT.format(p=build_prompt(item))
+        if not self._use_openai:
+            try:
+                body = self._post("/completion", {
+                    "prompt": prompt, "n_predict": n, "temperature": 0.0,
+                })
+                return body["content"]
+            except urllib.error.HTTPError as exc:
+                if exc.code not in (404, 405, 501):
+                    raise
+                self._use_openai = True
+        body = self._post("/v1/completions", {
+            "prompt": prompt, "max_tokens": n, "temperature": 0.0,
+        })
+        return body["choices"][0]["text"]
+
+
 def make_backend(args, items):
     if args.backend == "oracle": return OracleBackend(items)
     if args.backend == "mock":   return MockBackend()
@@ -119,6 +168,10 @@ def make_backend(args, items):
         return SparkinferBackend(args.model, args.bin, args.tokenizer)
     if args.backend == "llama":
         return LlamaBackend(args.model, args.llama_cli)
+    if args.backend == "llama-server":
+        if not args.llama_url:
+            raise SystemExit("--backend llama-server requires --llama-url")
+        return LlamaServerBackend(args.llama_url)
     raise SystemExit("unknown backend " + args.backend)
 
 
@@ -136,17 +189,100 @@ def load(benchmarks, limit, tier=""):
     return items
 
 
+
+def self_test_llama_server():
+    """Exercise LlamaServerBackend against an in-process stub (no GPU / no weights)."""
+    import http.server
+    import threading
+
+    seen = []
+
+    def start(native_ok):
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *_):
+                return
+
+            def do_POST(self):
+                n = int(self.headers.get("Content-Length", "0"))
+                payload = json.loads(self.rfile.read(n))
+                seen.append((self.path, payload))
+                if self.path == "/completion":
+                    if not native_ok:
+                        self.send_response(404)
+                        self.end_headers()
+                        return
+                    out = {"content": "... #### 42"}
+                elif self.path == "/v1/completions":
+                    out = {"choices": [{"text": "... #### 42"}]}
+                else:
+                    self.send_response(404)
+                    self.end_headers()
+                    return
+                raw = json.dumps(out).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+        srv = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=srv.serve_forever, daemon=True).start()
+        return srv
+
+    item = {"benchmark": "gsm8k", "id": "selftest", "prompt": "2+2?", "target": "42"}
+    failed = []
+
+    def check(name, ok):
+        print(f"  {'ok' if ok else 'FAIL':4s}  {name}")
+        if not ok:
+            failed.append(name)
+
+    print("self-test: llama-server backend")
+    cases = (
+        (True, "/completion", "n_predict"),
+        (False, "/v1/completions", "max_tokens"),
+    )
+    for native_ok, expect_path, expect_key in cases:
+        seen.clear()
+        srv = start(native_ok)
+        try:
+            be = LlamaServerBackend(f"http://127.0.0.1:{srv.server_address[1]}")
+            text_out = be.gen_for(item)
+        finally:
+            srv.shutdown()
+        tag = "native" if native_ok else "openai-fallback"
+        check(f"{tag}: hit {expect_path}", seen[-1][0] == expect_path)
+        check(f"{tag}: body has {expect_key}", expect_key in seen[-1][1])
+        check(f"{tag}: temperature 0", seen[-1][1].get("temperature") == 0.0)
+        check(f"{tag}: chat template in prompt", "<|im_start|>" in seen[-1][1]["prompt"])
+        check(f"{tag}: returned generation", text_out.strip().endswith("42"))
+        check(f"{tag}: gsm8k scorer passes", scorers.SCORERS["gsm8k"](item, text_out)["pass"])
+        if not native_ok:
+            check("openai-fallback: probed /completion first", seen[0][0] == "/completion")
+
+    print("self-test:", "PASS" if not failed else f"FAIL ({len(failed)})")
+    return 1 if failed else 0
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument("--backend", required=True, choices=["oracle", "mock", "sparkinfer", "llama"])
+    ap.add_argument("--backend", choices=["oracle", "mock", "sparkinfer", "llama", "llama-server"])
     ap.add_argument("--model"); ap.add_argument("--bin"); ap.add_argument("--tokenizer")
     ap.add_argument("--llama-cli")
+    ap.add_argument("--llama-url", help="base URL of a running llama-server")
+    ap.add_argument("--self-test-llama-server", action="store_true",
+                    help="verify llama-server HTTP wiring against a local stub")
     ap.add_argument("--benchmarks", default="", help="comma list; default all")
     ap.add_argument("--limit", type=int, default=0, help="items per benchmark (0=all)")
     ap.add_argument("--tier", choices=sorted(TIERS),
                     help="named per-suite sample: development ~=10%, benchmark ~=25%")
     ap.add_argument("--out", default="", help="write per-item JSONL results here")
     args = ap.parse_args()
+
+    if args.self_test_llama_server:
+        sys.exit(self_test_llama_server())
+    if not args.backend:
+        ap.error("--backend is required (or pass --self-test-llama-server)")
 
     benchmarks = set(b for b in args.benchmarks.split(",") if b)
     items = load(benchmarks, args.limit, args.tier or "")

--- a/bench/quality/run_qwen36_benchmark.sh
+++ b/bench/quality/run_qwen36_benchmark.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Quality-parity A/B for Qwen3.6: sparkinfer first (exclusive GPU), then llama-server.
+#
+#   bench/quality/run_qwen36_benchmark.sh /path/to/model.gguf
+#
+# Env (optional): TIER OUT_DIR PORT SPARK_BIN TOKENIZER LLAMA_SERVER NGL BENCHMARKS
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+MODEL="${1:-${MODEL:-}}"
+if [ -z "$MODEL" ]; then
+  echo "usage: $0 <model.gguf>   (or MODEL=... $0)" >&2
+  exit 1
+fi
+[ -f "$MODEL" ] || { echo "no such model: $MODEL" >&2; exit 1; }
+
+TIER="${TIER:-benchmark}"
+OUT_DIR="${OUT_DIR:-./qwen36_quality}"
+PORT="${PORT:-8082}"
+SPARK_BIN="${SPARK_BIN:-$HERE/../../build/qwen3_gguf_generate}"
+TOKENIZER="${TOKENIZER:-$(dirname "$MODEL")/tokenizer.json}"
+LLAMA_SERVER="${LLAMA_SERVER:-$HERE/../../.llamacpp/build/bin/llama-server}"
+NGL="${NGL:-99}"
+BENCH_ARG=()
+[ -n "${BENCHMARKS:-}" ] && BENCH_ARG=(--benchmarks "$BENCHMARKS")
+
+mkdir -p "$OUT_DIR"
+echo "model : $MODEL"
+echo "tier  : $TIER"
+echo "out   : $OUT_DIR"
+
+echo
+echo "=== [1/2] sparkinfer ==="
+for f in "$SPARK_BIN" "$TOKENIZER"; do
+  [ -e "$f" ] || { echo "missing: $f" >&2; exit 1; }
+done
+python3 "$HERE/run_quality.py" --backend sparkinfer --tier "$TIER" "${BENCH_ARG[@]}" \
+  --model "$MODEL" --bin "$SPARK_BIN" --tokenizer "$TOKENIZER" \
+  --out "$OUT_DIR/sparkinfer.jsonl"
+
+echo
+echo "=== [2/2] llama-server ==="
+[ -x "$LLAMA_SERVER" ] || { echo "missing llama-server: $LLAMA_SERVER" >&2; exit 1; }
+
+SERVER_PID=""
+cleanup() {
+  if [ -n "${SERVER_PID:-}" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+    kill "$SERVER_PID" 2>/dev/null || true
+    wait "$SERVER_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+"$LLAMA_SERVER" -m "$MODEL" --port "$PORT" -ngl "$NGL" --host 127.0.0.1 \
+  >"$OUT_DIR/llama-server.log" 2>&1 &
+SERVER_PID=$!
+
+printf 'waiting for llama-server on :%s' "$PORT"
+for _ in $(seq 1 120); do
+  if curl -sf "http://127.0.0.1:$PORT/health" >/dev/null 2>&1 \
+     || curl -sf "http://127.0.0.1:$PORT/v1/models" >/dev/null 2>&1; then
+    echo " up"
+    break
+  fi
+  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+    echo
+    echo "llama-server died — see $OUT_DIR/llama-server.log" >&2
+    exit 1
+  fi
+  printf '.'
+  sleep 1
+done
+
+python3 "$HERE/run_quality.py" --backend llama-server --tier "$TIER" "${BENCH_ARG[@]}" \
+  --llama-url "http://127.0.0.1:$PORT" --model "$MODEL" \
+  --out "$OUT_DIR/llama.jsonl"
+
+cleanup
+SERVER_PID=""
+
+echo
+echo "=== done ==="
+echo "sparkinfer : $OUT_DIR/sparkinfer.jsonl"
+echo "llama.cpp  : $OUT_DIR/llama.jsonl"


### PR DESCRIPTION
## Summary

`bench/quality/README.md` documents `--backend llama-server` and `run_qwen36_benchmark.sh`, but the backend was missing from argparse and the orchestrator script did not exist. Restore both, plus correct the sparkinfer `--bin` example to `./build/runtime/qwen3_gguf_generate`.

Fixes #643
Fixes #650

## Proof of speedup

> Docs/tooling only — no GPU / no speedup claim.

- [ ] Tested on **RTX 5090** (`sm_120`)

## Kind of change

- [x] Bug fix (quality tooling)
- [ ] Perf / scored decode or prefill change

## Verification

```text
$ python3 bench/quality/run_quality.py --self-test-llama-server
self-test: PASS
```

No GPU required. Does not touch `bench/scripts/` or other maintainer-owned paths.
