### PR TITLE
fix(runtime): take convert_gguf vocab from token_embd.weight

### DIFF
--- a/runtime/tools/convert_gguf.py
+++ b/runtime/tools/convert_gguf.py
@@ -54,10 +54,12 @@ def main():
         rms_eps=float(meta(A + "attention.layer_norm_rms_epsilon")),
         eos_id=int(meta("tokenizer.ggml.eos_token_id") or 151645),
     )
-    # vocab from token_embd if metadata missing
+    # Prefer embedding-tensor vocab over metadata (matches C++ emb->dims[1]).
     ten = {t.name: t for t in r.tensors}
     if "token_embd.weight" in ten:
-        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
+        shape = ten["token_embd.weight"].shape
+        if len(shape) >= 2:
+            cfg["vocab"] = int(shape[1])
 
     with open(os.path.join(out, "config.txt"), "w") as f:
         for k, v in cfg.items():

--- a/runtime/tools/test_convert_gguf.py
+++ b/runtime/tools/test_convert_gguf.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+"""Regression tests for convert_gguf vocab derivation (issue #637)."""
+import re
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().with_name("convert_gguf.py")
+
+
+class TestConvertGgufVocab(unittest.TestCase):
+    def test_shortcircuit_gone_and_dims1_used(self):
+        src = SCRIPT.read_text(encoding="utf-8")
+        self.assertNotRegex(src, r"if\s+False\s+else")
+        self.assertRegex(src, r'cfg\["vocab"\]\s*=\s*int\(\s*shape\[1\]\s*\)')
+
+    def test_logic_matches_cpp_dims1(self):
+        def vocab(shape, fallback):
+            return int(shape[1]) if len(shape) >= 2 else int(fallback)
+        self.assertEqual(vocab((4096, 151936), 1), 151936)
+        self.assertEqual(vocab((2048, 248320), 151936), 248320)
+        self.assertEqual(vocab((151936,), 42), 42)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`runtime/tools/convert_gguf.py` short-circuited the `token_embd.weight` vocab assignment with `if False`. Restore `shape[1]` (ggml `dims[1]`) to match the C++ loader, with a CPU unit test.

Fixes #637

## Proof of speedup

> Tools-only correctness fix - no GPU / no speedup claim. Box left unticked on purpose.
> Non-speed `runtime/` PRs need maintainer **`hold`** before leaving draft.

- [ ] Tested on **RTX 5090** (`sm_120`)

## CI status

| Check | Result | Notes |
|---|---|---|
| cap / guard / gate | pass | |
| build-linux / build-windows **Build + Package** | **success** | CUDA build of `qwen3_gguf_bench` is green |
| Generate artifact attestation | **fail** | fork PR `id-token` limitation - [#612](https://github.com/gittensor-ai-lab/sparkinfer/issues/612) |

Same attestation red on every fork PR that touches `runtime/**` (including already-merged ones). Not a compile failure from this diff.

## Note for maintainers

Opened as a **draft** so `rtx5090-required` does not auto-close. Please:

1. Add label **`hold`**
2. Mark ready for review (or tell me to)

## Kind of change

- [x] Bug fix (converter tooling)
- [ ] Perf / scored decode or prefill change

## Verification

```text
$ python3 runtime/tools/test_convert_gguf.py -v
OK
```
