### PR TITLE
docs: align MoE stack layout and CONTRIBUTING ctest guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ source of the incentive loop is clear: SPARKINFER is built through **SN74 on Git
 ## Before you open a PR
 
 ```bash
-# 1. build + tests (must be 5/5)
+# 1. build + tests (all ctest targets must pass)
 cmake -B build -DCMAKE_CUDA_ARCHITECTURES=120 && cmake --build build -j && ctest --test-dir build
 
 # 2. speed — does it actually go faster?

--- a/moe/README.md
+++ b/moe/README.md
@@ -12,7 +12,7 @@ The MoE dispatch and routing layer that sits between sparkinfer-runtime and spar
 
 - **Expert routing** — top-k selection with softmax, per-expert sigmoid (DeepSeek-V2 style), or expert-choice
 - **Sync-free token dispatch** — token counts tracked in GPU memory only, no CPU readback, enabling end-to-end CUDA graph capture
-- **Expert cache management** — async prefetch of next-layer experts while current layer executes; eviction for models where experts exceed VRAM
+- **Expert residency** — YAML `expert_cache:` knobs document intended eviction/prefetch policy; the current engine keeps layered weights resident once `set_layer_weights` runs
 
 ---
 
@@ -52,12 +52,11 @@ include/sparkinfer/moe/
 └── router.h   # Router, RouterType, RouterConfig
 
 src/
-├── router/    # routing kernel dispatch
-├── expert/    # expert weight cache, prefetch logic
-└── dispatcher/# token-to-expert assignment, GroupGEMM dispatch
+├── engine.cpp # MoEEngine::create / forward
+└── router.cpp # routing kernel dispatch
 ```
 
-Kernel implementation lives in [sparkinfer-kernels](https://github.com/gittensor-ai-lab/sparkinfer-kernels) (`csrc/cute/moe_swiglu/`, `csrc/cute/moe_gemm/`).
+Kernel implementation lives in-tree under [`kernels/`](../kernels/) (`csrc/cute/moe_swiglu/`, `csrc/cute/moe_gemm/`).
 
 ---
 

--- a/moe/configs/qwen35_35b_a3b.yaml
+++ b/moe/configs/qwen35_35b_a3b.yaml
@@ -1,5 +1,5 @@
 # MoE engine configuration for Qwen3.5-35B-A3B
-# Load with: MoEEngine::create(MoEConfig::from_yaml("configs/qwen35_35b_a3b.yaml"))
+# Reference shape for MoEConfig fields (no MoEConfig::from_yaml in-tree — fill MoEConfig in C++).
 
 num_experts: 256
 top_k: 8


### PR DESCRIPTION
## Summary

`moe/README.md` documented a phantom `src/{router,expert,dispatcher}/` tree and linked a separate `sparkinfer-kernels` repo that 404s. Document the real two-file layout and in-tree `kernels/`. Also drop the stale `MoEConfig::from_yaml` comment and the outdated CONTRIBUTING "ctest 5/5" note.

## Kind of change

- [x] Docs fix
- [ ] Perf / scored decode or prefill change

## Verification

Docs match `moe/src/` / `moe/include/`. No GPU required. Does not touch `runtime/`.
