### PR TITLE
feat(runtime): add downgrade hysteresis to the thermal governor

### DIFF
--- a/runtime/include/sparkinfer/thermal_governor.h
+++ b/runtime/include/sparkinfer/thermal_governor.h
@@ -40,6 +40,14 @@ public:
         // tier on the projection, so we throttle BEFORE crossing a threshold. 0 = pure reactive.
         int predict_horizon_ms = 1500;
 
+        // Downgrade hysteresis (°C): stepping UP a tier (getting hotter) is always immediate —
+        // safety-first. Stepping DOWN a tier (cooling off) requires the effective temperature to
+        // fall this many degrees below the CURRENT tier's entry threshold first. Without this, a
+        // temperature hovering right at a boundary (e.g. 69.6 <-> 70.1 °C around `safe_c=70`)
+        // flips the mode — and the inter-token pace — every sample, producing visibly jittery
+        // tok/s with no thermal benefit. 0 = legacy behavior (immediate, symmetric up/down).
+        int hysteresis_c = 3;
+
         bool log_transitions = false;   // print a line on each mode change (observability)
 
         // Testing/benchmark override: when `forced` is set, apply `forced_mode` every token and
@@ -56,7 +64,9 @@ public:
     double pace();
 
     // Pure temperature→mode mapping (no hardware, no sleep) — the tiering policy, unit-testable.
-    static Mode classify(const Config& cfg, int temp_c);
+    // `prev_mode` is the mode in effect before this reading; it only matters for downgrade
+    // hysteresis (see Config::hysteresis_c above). Omit it for the plain, state-free mapping.
+    static Mode classify(const Config& cfg, int temp_c, Mode prev_mode = Mode::Turbo);
     static const char* mode_name(Mode m);
 
     Mode   mode()          const { return mode_; }

--- a/runtime/src/thermal_governor.cpp
+++ b/runtime/src/thermal_governor.cpp
@@ -8,6 +8,7 @@
 #include <chrono>
 #include <thread>
 #include <cstdio>
+#include <climits>
 
 namespace sparkinfer {
 
@@ -27,11 +28,34 @@ const char* ThermalGovernor::mode_name(Mode m) {
     return "?";
 }
 
-ThermalGovernor::Mode ThermalGovernor::classify(const Config& c, int temp_c) {
-    if (temp_c >= c.emergency_c) return Mode::Emergency;
-    if (temp_c >= c.safe_c)      return Mode::Safe;
-    if (temp_c >= c.balanced_c)  return Mode::Balanced;
-    return Mode::Turbo;
+namespace {
+// Tier rank for ordering comparisons (Turbo < Balanced < Safe < Emergency); matches enum order.
+inline int mode_rank(ThermalGovernor::Mode m) { return static_cast<int>(m); }
+
+// The temperature a mode was entered at (its lower threshold); Turbo has none (bottom tier).
+int mode_entry_threshold(const ThermalGovernor::Config& c, ThermalGovernor::Mode m) {
+    switch (m) {
+        case ThermalGovernor::Mode::Balanced:  return c.balanced_c;
+        case ThermalGovernor::Mode::Safe:      return c.safe_c;
+        case ThermalGovernor::Mode::Emergency: return c.emergency_c;
+        default:                               return INT_MIN;
+    }
+}
+}  // namespace
+
+ThermalGovernor::Mode ThermalGovernor::classify(const Config& c, int temp_c, Mode prev_mode) {
+    Mode natural = Mode::Turbo;
+    if (temp_c >= c.emergency_c) natural = Mode::Emergency;
+    else if (temp_c >= c.safe_c) natural = Mode::Safe;
+    else if (temp_c >= c.balanced_c) natural = Mode::Balanced;
+
+    // Heating (or unchanged) always applies immediately — never delay a safety upgrade.
+    if (c.hysteresis_c <= 0 || mode_rank(natural) >= mode_rank(prev_mode)) return natural;
+
+    // Cooling: stay in the current (hotter) tier until temp drops hysteresis_c below the tier's
+    // own entry threshold, so a brief dip right at the boundary doesn't flap the pace back up.
+    if (temp_c < mode_entry_threshold(c, prev_mode) - c.hysteresis_c) return natural;
+    return prev_mode;
 }
 
 static double pace_ms_for(const ThermalGovernor::Config& c, ThermalGovernor::Mode m) {
@@ -73,7 +97,7 @@ double ThermalGovernor::pace() {
         // Predictive: tier on max(measured, projected) so a fast rise throttles before crossing.
         if (cfg_.predict_horizon_ms > 0 && slope_ > 0.0)
             eff = last_temp_ + (int)(slope_ * cfg_.predict_horizon_ms / 1000.0);
-        mode_ = classify(cfg_, eff);
+        mode_ = classify(cfg_, eff, mode_);
     }
     const double ms = pace_ms_for(cfg_, mode_);
 

--- a/runtime/tests/thermal_governor_cpu_test.cpp
+++ b/runtime/tests/thermal_governor_cpu_test.cpp
@@ -38,6 +38,34 @@ int main() {
     CHECK(std::string(G::mode_name(G::Mode::Turbo))     == "turbo");
     CHECK(std::string(G::mode_name(G::Mode::Emergency)) == "emergency");
 
+    // Downgrade hysteresis: default config has hysteresis_c=3 (balanced=65, safe=70, emergency=80).
+    {
+        // Heating up is always immediate, regardless of the previous mode or hysteresis.
+        CHECK(G::classify(c, 70, G::Mode::Turbo)    == G::Mode::Safe);
+        CHECK(G::classify(c, 80, G::Mode::Balanced) == G::Mode::Emergency);
+
+        // Cooling from Safe (entry 70): must drop below 70-3=67 to downgrade. A dip to 68 or 69
+        // (still >= 67) stays in Safe instead of flapping back to Balanced.
+        CHECK(G::classify(c, 69, G::Mode::Safe) == G::Mode::Safe);
+        CHECK(G::classify(c, 68, G::Mode::Safe) == G::Mode::Safe);
+        CHECK(G::classify(c, 67, G::Mode::Safe) == G::Mode::Safe);   // boundary: not yet below
+        CHECK(G::classify(c, 66, G::Mode::Safe) == G::Mode::Balanced);
+
+        // Cooling from Emergency (entry 80): stays Emergency until below 80-3=77, then jumps
+        // straight to whatever tier the temperature naturally lands in.
+        CHECK(G::classify(c, 78, G::Mode::Emergency) == G::Mode::Emergency);
+        CHECK(G::classify(c, 76, G::Mode::Emergency) == G::Mode::Safe);
+        CHECK(G::classify(c, 50, G::Mode::Emergency) == G::Mode::Turbo);
+
+        // Unchanged temperature (natural == prev) is a no-op, not treated as heating or cooling.
+        CHECK(G::classify(c, 72, G::Mode::Safe) == G::Mode::Safe);
+
+        // hysteresis_c = 0 restores the legacy, state-free, symmetric behavior.
+        G::Config c0 = c; c0.hysteresis_c = 0;
+        CHECK(G::classify(c0, 69, G::Mode::Safe) == G::Mode::Balanced);
+        CHECK(G::classify(c0, 66, G::Mode::Safe) == G::Mode::Balanced);
+    }
+
     printf("thermal_governor_cpu_test: OK\n");
     return 0;
 }


### PR DESCRIPTION
## Summary

Adds downgrade hysteresis to `ThermalGovernor::classify()`: mode upgrades (hotter) still apply
immediately, but downgrades (cooler) now require the temperature to drop `hysteresis_c` (default
3°C) below the current tier's entry threshold before stepping down. This is a non-speedup,
`runtime/` host-side reliability fix, not a kernel/decode-path optimization.

**Problem:** a temperature hovering right at a tier boundary (e.g. 69.6 ↔ 70.1°C around
`safe_c=70`) currently flips `mode_` — and therefore the inter-token sleep — on every sample,
producing visibly jittery tok/s with no real thermal benefit. This PR adds a Schmitt-trigger-style
dead zone on the cooling side only; `hysteresis_c=0` restores the exact previous behavior.

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

I do **not** have access to an RTX 5090 (or any GPU) in this environment, so I have not run
`bench/scripts/bench.sh` and am leaving this box unchecked rather than falsely attesting to it —
per `CONTRIBUTING.md`, ticking it without actually testing is treated as gaming. This change is
also not a decode/prefill speedup (the governor is disabled by default and off the benchmark path
entirely — see the file header), so it isn't expected to move the decode tok/s or prefill pp
tables either way; I'm leaving those blank rather than filling them with fabricated numbers.

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | not run — no RTX 5090 available in this environment |
| after (this PR) | not run — no RTX 5090 available in this environment |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not run — no RTX 5090 available in this environment |
| after prefill (this PR) | not run — no RTX 5090 available in this environment |

```text
Not run: no GPU/RTX 5090 available in this development environment. This PR does not target
decode or prefill throughput (see Summary) — happy for a maintainer or the eval bot to confirm
on real hardware.
```

## What I verified instead (no GPU/C++ toolchain available here)

- Extended `runtime/tests/thermal_governor_cpu_test.cpp` (pure logic, no GPU) with cases for:
  immediate upgrade regardless of hysteresis, staying in a tier while cooling within the dead
  zone, crossing the dead zone and dropping straight to the correct natural tier (including a
  multi-tier drop from Emergency), and `hysteresis_c=0` reproducing the old symmetric behavior
  exactly.
- This sandbox has no `nvcc`/`cmake`/C++ compiler, so I could not run `ctest` myself. I
  cross-checked the new `classify()` control flow with an equivalent standalone Python
  reimplementation against all the C++ assertions (old + new) — all pass. Please run
  `ctest --test-dir build -R thermal_governor_cpu_test` in CI to confirm on real hardware.

## Notes

- `classify()` gained a third `prev_mode` parameter (defaulted to `Mode::Turbo`), so all existing
  call sites compile unchanged; only `pace()` now threads its own current mode through.
- No change to weights, precision, sampling, or KV handling — the governor still only ever sleeps
  between tokens (see the existing file-header contract in `thermal_governor.h`).
