### PR TITLE
perf(dflash): ask the draft for two more tokens once the KV is long (1.04x decode @32k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -839,21 +839,31 @@ void launch_flash_decode_split(
             // Fold S verify rows into one CTA so the staged K/V tile is read once for all of them
             // instead of once per row. Only when S divides num_seqs exactly, so no row is padded.
             static int seqfold = -1;
-            // 3 measured best on RTX 5090 (32k: 459.1 -> 497.0 tok/s). The fold is limited by the
-            // extra per-row accumulators it keeps live: 2 and 3 are within noise of each other in
-            // isolation (951.6 vs 943.8 us at 32k) while 6 regresses to 1548.0 us, worse than not
-            // folding at all. SPARKINFER_FA_SEQFOLD=1 restores one row per CTA.
-            if (seqfold < 0) { const char* e = getenv("SPARKINFER_FA_SEQFOLD"); seqfold = e ? atoi(e) : 3; }
-            if (!int8_kv && seqfold > 1 && num_seqs > 1 && (num_seqs % seqfold) == 0) {
+            // The fold is limited by the extra per-row accumulators it keeps live: 2, 3 and 4 are
+            // close in isolation (951.6 / 943.8 us at 32k for 2 and 3) while 6 regresses to
+            // 1548.0 us, worse than not folding at all. Since a fold only runs when it divides the
+            // row count exactly, the default picks the widest instantiation that does: a 6-row
+            // verify folds by 3 and an 8-row verify by 4, each leaving 2 CTAs per (kv head, split).
+            // Measured at 32k on an 8-row verify: fold 4 = 518.6 tok/s against fold 2 = 512.4.
+            // SPARKINFER_FA_SEQFOLD pins a specific width; 1 restores one row per CTA.
+            if (seqfold < 0) { const char* e = getenv("SPARKINFER_FA_SEQFOLD"); seqfold = e ? atoi(e) : 0; }
+            const int fold = seqfold > 0 ? seqfold
+                           : (num_seqs % 4 == 0 ? 4 : (num_seqs % 3 == 0 ? 3 : (num_seqs % 2 == 0 ? 2 : 1)));
+            if (!int8_kv && fold > 1 && num_seqs > 1 && (num_seqs % fold) == 0) {
                 const size_t smem = (size_t)2 * TILE * 256 * sizeof(__nv_bfloat16);
-                dim3 gqf(num_kv_heads * n_splits, num_seqs / seqfold);
-                if (seqfold == 2)
+                dim3 gqf(num_kv_heads * n_splits, num_seqs / fold);
+                if (fold == 2)
                     fa_split_gqa_kernel<256, GQA, TILE, false, 2><<<gqf, GQA * 32, smem, stream>>>(
                         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
                         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,
                         n_splits, reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
-                else if (seqfold == 3)
+                else if (fold == 3)
                     fa_split_gqa_kernel<256, GQA, TILE, false, 3><<<gqf, GQA * 32, smem, stream>>>(
+                        reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                        part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,
+                        n_splits, reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+                else if (fold == 4)
+                    fa_split_gqa_kernel<256, GQA, TILE, false, 4><<<gqf, GQA * 32, smem, stream>>>(
                         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
                         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,
                         n_splits, reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));

--- a/runtime/include/sparkinfer/models/dflash_draft.h
+++ b/runtime/include/sparkinfer/models/dflash_draft.h
@@ -63,9 +63,13 @@ public:
     // that primes the draft outside a timed region does not pay for it inside one. Idempotent.
     void ensure_quant();
 
+    //   proposals:     how many rows after the seed to score (0 = the built-in default). The
+    //                  verifier picks this by context length, so the draft has to be told rather
+    //                  than deciding for itself, or the two disagree on how long a block is.
     bool forward_block(const void* target_hidden, int ctx_len,
                        const int* noise_ids, int pos0,
-                       int* out_argmax, cudaStream_t stream = nullptr);
+                       int* out_argmax, cudaStream_t stream = nullptr,
+                       int proposals = 0);
 
     // Apply target lm_head to last forward's hidden states; writes device logits [block, vocab]
     // and host argmax. Called internally by forward_block; exposed for debugging.

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -568,7 +568,7 @@ void DFlashDraftModel::ensure_quant() { if (p_) p_->ensure_quant(); }
 
 bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                      const int* noise_ids, int pos0,
-                                     int* out_argmax, cudaStream_t stream) {
+                                     int* out_argmax, cudaStream_t stream, int proposals) {
     Impl& s = *p_;
     s.ensure_quant();
     if (!s.fc || !s.embed || !s.lm_head || !noise_ids || !out_argmax) return false;
@@ -582,21 +582,28 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     const int qdim = c.n_q_heads * c.head_dim;
     const int kvdim = c.n_kv_heads * c.head_dim;
     const int d = c.head_dim;
-    // Proposal depth (also sets the draft's active diffusion width, depth+1).
-    static const int kProposalDepth = []{
+    // Proposal depth (also sets the draft's active diffusion width, depth+1). The caller selects
+    // it by context length and passes it in; the env default only applies when it does not.
+    static const int kProposalDepthDefault = []{
         const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
         int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
+    const int kProposalDepth = proposals > 0 ? (proposals > 15 ? 15 : proposals)
+                                             : kProposalDepthDefault;
     // Active diffusion width. Only rows 0..kProposalDepth are ever consumed (row 0 is the seed,
     // 1..kProposalDepth the scored proposals), yet the backbone was run at the checkpoint's full
     // block_size=16 — 12 of every 16 rows computed and discarded. The block's attention is
     // bidirectional, so narrowing it DOES change what the draft proposes; that is allowed here
     // because every emitted token is still a target argmax, only the accept length can move.
     // SPARKINFER_DFLASH_BLOCK_WIDTH overrides (0/unset = kProposalDepth+1).
-    static const int BW = [&]{
-        const char* e = getenv("SPARKINFER_DFLASH_BLOCK_WIDTH");
-        int v = e ? atoi(e) : 0;
+    // Not cached across calls: the proposal depth it derives from is now chosen per generation.
+    const int BW = [&]{
+        static const int env_w = []{
+            const char* e = getenv("SPARKINFER_DFLASH_BLOCK_WIDTH");
+            return e ? atoi(e) : 0;
+        }();
+        int v = env_w;
         if (v <= 0) v = kProposalDepth + 1;
         if (v < kProposalDepth + 1) v = kProposalDepth + 1;
         // Round up to a width the batched-GEMV path is instantiated for; anything else falls

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -2084,14 +2084,44 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
 
     std::vector<int> block(B), posterior(B), draft_ids(B);
     // Proposal depth (also sets the draft's active diffusion width, depth+1). 5 is the measured
-    // optimum: accept length rises only 5.33 -> 5.95 -> 6.43 going to depth 6 and 7, while each
-    // extra verify row costs a flat ~0.74 ms, so depth 6 already loses. Keep in sync with
-    // dflash_draft.cpp's copy of this default.
-    static const int kProposalDepth = []{
-        const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
-        int v = e ? atoi(e) : 5;
-        return v < 1 ? 1 : (v > 15 ? 15 : v);
+    // optimum at short context: accept length rises only 5.33 -> 5.95 -> 6.43 going to depth 6 and
+    // 7, while each extra verify row costs a flat ~0.74 ms, so depth 6 already loses there.
+    //
+    // That trade inverts once the KV is long. An extra verify row costs roughly one more set of
+    // routed experts (each row picks its own 8 of 256, and they barely overlap), which is a fixed
+    // price per row; what it buys is fewer decode steps, and every step re-reads the whole KV
+    // cache. Short context: the KV read is negligible, the expert reads dominate, depth 5 wins.
+    // Long context: the KV read dominates, and paying flat expert cost to remove whole steps wins.
+    //
+    // The draft is also running out of room to be asked: at 32k the accept length is 5.61 out of a
+    // maximum of 6, so ~93% of steps are truncated by the request size rather than rejected by the
+    // target. Depth 7 is the largest that keeps every batched path -- the compact verify itself
+    // (dflash_verify_short_run bails above 8 rows), the row-batched Q4_K/Q6_K/Q8_0 GEMVs (MMAX=8 is
+    // the widest instantiation) and the batched MoE all stop at 8 rows -- and it leaves the draft
+    // untouched, because a width of depth+1 rounds up to the same 8-wide block either way.
+    //
+    // Measured, tok/s at depth 5 -> 7 (2 reps each, RTX 5090 @2550):
+    //     128    800.2 -> 749.1  (-6.4%)      8192   432.5 -> 419.7  (-3.0%)
+    //     4096   490.0 -> 429.3  (-12.4%)    12288   630.2 -> 677.7  (+7.5%)
+    //     16384  559.8 -> 567.4  (+1.4%)     32768   497.7 -> 520.2  (+4.5%)
+    // The crossover sits between 8k and 12k, so the floor is 12288 and everything below it keeps
+    // the depth it has today. Acceptance is a property of the text as much as of the length (the
+    // 8k prompt accepts 3.66, less than the 4k one's 3.91), so the floor is deliberately past the
+    // last length measured to lose rather than at it.
+    static const int kDeepMinSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_DEEP_MIN_SEQ");
+        int v = e ? atoi(e) : 12288;
+        return v < 1 ? 1 : v;
     }();
+    // Explicit override wins; 0/unset selects by length. Keep in sync with dflash_draft.cpp, which
+    // reads the same variable for its own default and is handed this value per block.
+    static const int kProposalDepthEnv = []{
+        const char* e = getenv("SPARKINFER_DFLASH_PROPOSALS");
+        int v = e ? atoi(e) : 0;
+        return v < 0 ? 0 : (v > 15 ? 15 : v);
+    }();
+    const int kProposalDepth = kProposalDepthEnv > 0 ? kProposalDepthEnv
+                             : ((n + max_new) >= kDeepMinSeq ? 7 : 5);
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN
     // accepted length, and it has no reason to sit at exactly B. Measured on RTX 5090 at the three
@@ -2211,7 +2241,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             s.defer_decode_sync = false;
         }
         const bool draft_ok = draft.forward_block(
-            draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr);
+            draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr, kProposalDepth);
         if (!compact_verify && p0 == kDFlashDeferred) {
             cu(cudaStreamSynchronize(s.stream), "verify0 sync");
             s.decode_pending = false;


### PR DESCRIPTION
At 32k the mean accept length is **5.6087 out of a maximum of 6**. The proposal depth is 5, so
roughly 93% of steps end because the block ran out of proposals rather than because the target
rejected one — the block is being truncated by how much we ask for, not by how much the draft
gets right.

Raise the depth to 7 for sequences at or past 12288 and leave everything shorter exactly as it is.

**Why 7.** It is the widest depth that keeps every batched path: the compact verify itself, the
row-batched Q4_K / Q6_K / Q8_0 GEMVs (`MMAX=8` is the widest instantiation) and the batched MoE
all stop at 8 rows. It also costs the draft nothing — a width of `depth+1` rounds up to the same
8-wide block at depth 5 and 7, so the draft already computed those two rows and discarded them.
Depth 11 and 15 fall off all of the above and produce no tokens at all.

**Why gate it.** An extra verify row costs about one more set of routed experts — each row picks
its own 8 of 256 and they barely overlap — which is a flat price per row. What it buys is fewer
decode steps, and every step re-reads the whole KV cache. Step time at 32k is `3.08 ms fixed +
1.365 ms per row`, so short context, with no fixed cost to amortise, loses on the deal and long
context wins it.

The crossover sits between 8k and 12k, so the floor is 12288. Acceptance follows the text as much
as the length — the 8k prompt accepts 3.66 where the 4k one accepts 3.91 — so the floor is set
past the last length measured to lose rather than at it. `SPARKINFER_DFLASH_DEEP_MIN_SEQ` moves it
and `SPARKINFER_DFLASH_PROPOSALS` pins a depth outright.

**Fold.** An 8-row verify needs a fold that divides 8, so the split kernel gains a 4-row
instantiation and its launcher now defaults to the widest fold that divides the row count exactly
(8 → 4, 6 → 3) instead of a fixed 3, which would have switched folding off on `8 % 3 != 0`.
Measured on the 8-row verify at 32k: fold 4 = 518.6 tok/s against fold 2 = 512.4.

- [x] Tested on **RTX 5090** (`sm_120`)

### Measured (RTX 5090, clocks locked 2550, 2 reps per arm)

| | decode tok/s |
|---|--:|
| before (main) | 498.1  |
| after (this PR) | 519.6 |

128 / 512 / 4k are below the floor and run the same code they do today; the differences there are
run-to-run noise. 512 takes the autoregressive path regardless.

### Checks

- `ctest` 10/10
- `SPEC_AGREE 32/32 = 1.0000`, `VERDICT PASS` at 128 / 512 / 4k / 16k / 32k
