### PR TITLE
fix(kv): give paged-KV storage only to layers that use it (unbreak DFlash at 64k)

### DIFF
--- a/runtime/examples/qwen35_generate.cpp
+++ b/runtime/examples/qwen35_generate.cpp
@@ -38,7 +38,7 @@ int main(int argc, char** argv) {
     cfg.max_seq = 2048;
 
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(cfg); kvc.num_kv_heads = cfg.n_kv_heads;
     kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
     sparkinfer::KVCacheManager kv(kvc, 512ull * 1024 * 1024);
 

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -122,7 +122,7 @@ static bool init_session(BenchSession& s, const std::string& path, int max_ctx, 
     s.rt = sparkinfer::Runtime::create({});
     s.rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = s.cfg.n_layers;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(s.cfg);
     kvc.num_kv_heads = s.cfg.n_kv_heads;
     kvc.head_dim = s.cfg.head_dim;
     kvc.block_size = 16;
@@ -131,7 +131,7 @@ static bool init_session(BenchSession& s, const std::string& path, int max_ctx, 
     const size_t epb = (size_t)16 * s.cfg.n_kv_heads * s.cfg.head_dim;
     const size_t blocks = (s.cfg.max_seq + 15) / 16 + 8;
     s.kv = std::make_unique<sparkinfer::KVCacheManager>(
-        kvc, (size_t)s.cfg.n_layers * 2 * epb * 2 * blocks);
+        kvc, (size_t)sparkinfer::qwen35_kv_layer_count(s.cfg) * 2 * epb * 2 * blocks);
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = s.cfg.n_experts; mc.top_k = s.cfg.top_k;
     mc.hidden_dim = s.cfg.hidden; mc.ffn_dim = s.cfg.moe_ffn;

--- a/runtime/examples/qwen3_gguf_cb_bench.cpp
+++ b/runtime/examples/qwen3_gguf_cb_bench.cpp
@@ -81,7 +81,7 @@ int main(int argc, char** argv) {
     rt->initialize();
 
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(cfg);
     kvc.num_kv_heads = cfg.n_kv_heads;
     kvc.head_dim = cfg.head_dim;
     kvc.block_size = 16;
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     // Pool for concurrency streams + one long prefill.
     const size_t blocks = (size_t)(concurrency + 1) * ((cfg.max_seq + 15) / 16 + 4);
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)sparkinfer::qwen35_kv_layer_count(cfg) * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts;

--- a/runtime/examples/qwen3_gguf_dflash_bench.cpp
+++ b/runtime/examples/qwen3_gguf_dflash_bench.cpp
@@ -52,14 +52,14 @@ int main(int argc, char** argv) {
     rt->initialize();
 
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(cfg);
     kvc.num_kv_heads = cfg.n_kv_heads;
     kvc.head_dim = cfg.head_dim;
     kvc.block_size = 16;
     kvc.int8_kv = false;
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)sparkinfer::qwen35_kv_layer_count(cfg) * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts;

--- a/runtime/examples/qwen3_gguf_dflash_check.cpp
+++ b/runtime/examples/qwen3_gguf_dflash_check.cpp
@@ -47,14 +47,14 @@ int main(int argc, char** argv) {
     rt->initialize();
 
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(cfg);
     kvc.num_kv_heads = cfg.n_kv_heads;
     kvc.head_dim = cfg.head_dim;
     kvc.block_size = 16;
     kvc.int8_kv = false;
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)sparkinfer::qwen35_kv_layer_count(cfg) * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts;

--- a/runtime/examples/qwen3_gguf_generate.cpp
+++ b/runtime/examples/qwen3_gguf_generate.cpp
@@ -46,13 +46,13 @@ int main(int argc, char** argv) {
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
 
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(cfg); kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
     // int8 KV is the Qwen3-MoE head_dim=128 tensor-core path; Qwen3.6 attention (gated, head_dim=256) writes bf16 KV.
     { const char* e = getenv("SPARKINFER_KV_INT8");   // hybrid: int8 KV when prompt length >= 4k
       kvc.int8_kv = e ? (e[0] != '0') : (cfg.hybrid ? ((argc - 3) >= 4096) : true); }
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)sparkinfer::qwen35_kv_layer_count(cfg) * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts; mc.top_k = cfg.top_k; mc.hidden_dim = cfg.hidden;

--- a/runtime/examples/qwen3_gguf_prefill_check.cpp
+++ b/runtime/examples/qwen3_gguf_prefill_check.cpp
@@ -61,11 +61,11 @@ int main(int argc, char** argv) {
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(cfg); kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
     { const char* e = getenv("SPARKINFER_KV_INT8"); kvc.int8_kv = e ? (e[0] != '0') : true; }  // batched prefill uses int8 KV
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)sparkinfer::qwen35_kv_layer_count(cfg) * 2 * epb * 2 * blocks);
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts; mc.top_k = cfg.top_k; mc.hidden_dim = cfg.hidden;
     mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -51,7 +51,7 @@ int main(int argc, char** argv) {
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
-    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    kvc.num_layers = sparkinfer::qwen35_kv_layer_count(cfg); kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
     // int8 KV default mirrors the SHIPPED config, so scoring reflects what actually runs:
     //   non-hybrid (Qwen3-MoE, hd128) always ships int8 KV -> default int8.
     //   hybrid (Qwen3.6/Qwythos, hd256) ships int8 KV at ctx >= 4096 (bench.cpp:130,
@@ -70,7 +70,7 @@ int main(int argc, char** argv) {
       kvc.int8_kv = e ? (e[0] != '0') : (cfg.hybrid ? ((argc - 3) >= 4096) : true); }
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)sparkinfer::qwen35_kv_layer_count(cfg) * 2 * epb * 2 * blocks);
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts; mc.top_k = cfg.top_k; mc.hidden_dim = cfg.hidden;
     mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;

--- a/runtime/include/sparkinfer/models/qwen_config.h
+++ b/runtime/include/sparkinfer/models/qwen_config.h
@@ -52,4 +52,34 @@ struct Qwen35Config {
     float logit_scale = 1.f;              // 1 = no-op
 };
 
+// ---- paged-KV layer mapping ----
+//
+// Only full-attention layers own paged-KV storage. The hybrid stack interleaves Gated-DeltaNet
+// layers, which carry their history in the recurrent state (lin_state / lin_conv_state) and never
+// read or write the KV pool -- every k_pool()/v_pool() dereference in the decode and prefill paths
+// sits inside the full-attention branch. Indexing the pool by the FULL layer index therefore
+// reserves a sub-pool for each GDN layer that nothing ever touches: at full_attn_interval = 4 that
+// is three quarters of the allocation. On a 40-layer Qwen3.6 at a 32k context it is 10.81 GB where
+// 2.70 GB is used, which together with the ~21 GB of weights overruns a 32 GB card and fails the
+// KV allocation outright.
+//
+// These map a model layer to a compact KV slot. For a non-hybrid stack every layer owns KV, so the
+// mapping is the identity and nothing changes.
+inline bool qwen35_layer_uses_kv(const Qwen35Config& c, int layer) {
+    return !(c.hybrid && c.full_attn_interval > 0 && ((layer + 1) % c.full_attn_interval) != 0);
+}
+
+// Compact pool index for a full-attention layer (undefined for GDN layers, which never index it).
+inline int qwen35_kv_slot(const Qwen35Config& c, int layer) {
+    if (!(c.hybrid && c.full_attn_interval > 0)) return layer;
+    return (layer + 1) / c.full_attn_interval - 1;
+}
+
+// Number of layers that need a KV sub-pool. Callers size KVCacheConfig::num_layers and the pool
+// budget with this rather than n_layers.
+inline int qwen35_kv_layer_count(const Qwen35Config& c) {
+    if (!(c.hybrid && c.full_attn_interval > 0)) return c.n_layers;
+    return c.n_layers / c.full_attn_interval;
+}
+
 } // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -948,10 +948,10 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // ---- QK-norm + RoPE + KV-append ----
             const bool kv8 = s.kv->int8_kv();
             const int kv_elem = kv8 ? 1 : 2;
-            void* kpool = (char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* vpool = (char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            void* kpool = (char*)s.kv->k_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->layer_stride_elems() * kv_elem;
+            void* vpool = (char*)s.kv->v_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->layer_stride_elems() * kv_elem;
+            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->scale_layer_stride_elems() * 2 : nullptr;
             const bool partial_rope = (c.rope_dim > 0 && c.rope_dim < c.head_dim);
             const bool qkgate_fuse = w.q_has_gate && partial_rope && kv8 && s.use_qkfuse && H == 2048;
             if (w.q_has_gate && !qkgate_fuse)

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -580,10 +580,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             proj(xn, w.wk, w.wk_type, kf, kvdim, H);
             proj(xn, w.wv, w.wv_type, vf, kvdim, H);
             kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
-            signed char* kpool = (signed char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            signed char* kpool = (signed char*)s.kv->k_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->layer_stride_elems() * kv_elem;
+            signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->layer_stride_elems() * kv_elem;
+            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)qwen35_kv_slot(c, L) * s.kv->scale_layer_stride_elems() * 2 : nullptr;
             if (!kv8) { a.free_all(); a8.free_all(); am.free_all(); aw.free_all(); fprintf(stderr, "[prefill] batched prefill requires int8 KV\n"); return -1; }
             kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
                 kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
@@ -1498,13 +1498,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             }
             if (!supported || !w.q_has_gate) break;
             char* kp = static_cast<char*>(s.kv->k_pool()) +
-                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                       (size_t)qwen35_kv_slot(c, L) * s.kv->layer_stride_elems() * kv_elem;
             char* vp = static_cast<char*>(s.kv->v_pool()) +
-                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                       (size_t)qwen35_kv_slot(c, L) * s.kv->layer_stride_elems() * kv_elem;
             char* ks = kv8 ? static_cast<char*>(s.kv->k_scale_pool()) +
-                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                             (size_t)qwen35_kv_slot(c, L) * s.kv->scale_layer_stride_elems() * 2 : nullptr;
             char* vs = kv8 ? static_cast<char*>(s.kv->v_scale_pool()) +
-                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                             (size_t)qwen35_kv_slot(c, L) * s.kv->scale_layer_stride_elems() * 2 : nullptr;
             if (kv8) {
                 kernels::launch_dflash_qknorm_rope_kv_partial_int8_gated(
                     b8, qb, qg, kf, vf, w.q_norm, w.k_norm, kp, vp, ks, vs, btable, pos,


### PR DESCRIPTION
Closes #765

## Summary

Only the 10 full-attention layers of this 40-layer hybrid stack use paged KV — the 30 Gated-DeltaNet
layers carry history in recurrent state and never touch the pool — but the pool is indexed by the
full layer index, so three quarters of it is reserved and never read. At 64k that over-allocation
overruns a 32 GB card and DFlash fails to start (`[kv] malloc k_pool: out of memory`,
`DFLASH_TPS=0`). This maps model layers to compact KV slots, restoring DFlash at 64k
(**0 → 508.97 tok/s**). For a non-hybrid stack the mapping is the identity and nothing changes.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`qwen3_gguf_dflash_bench`, 128 generated tokens, seed `fixed`):

| | decode tok/s |
|---|--:|
| before (main) | **0** — OOM during `load_gguf`; DFlash cannot run at 64k |
| after (this PR) | **508.97** |

**Prefill pp tok/s**: N/A — this targets the DFlash decode path, not prefill.

Already-working contexts are unchanged, with **bit-identical mean accepted length** on both arms
(this changes allocation only, never what any kernel computes):

| ctx | main | this PR | τ (both arms) | SPEC_AGREE (both arms) |
|---|--:|--:|--:|:--:|
| 128 | 846.42 | 856.15 | 5.3333 | 32/32 PASS |
| 512 | 500.65 | 504.34 | 1.0000 | 32/32 PASS |
| 4k | 539.45 | 541.24 | 3.9091 | 32/32 PASS |
| 16k | 615.51 | 619.96 | 6.4286 | 32/32 PASS |
| 32k | 563.90 | 564.98 | 7.2778 | 32/32 PASS |
| **64k** | **0 (OOM)** | **508.97** | 7.7647 | **32/32 PASS** |

The +0.3% to +1.2% on the scored contexts is run-to-run noise, not a claimed speedup — an
allocation change should be free, not faster.

64k is **lossless**: `qwen3_gguf_dflash_check` at 64k returns `METRIC SPEC_AGREE 32/32 = 1.0000`,
`VERDICT PASS` — DFlash reproduces greedy AR exactly at the restored context.

## Limits (measured, not assumed)

- **Headroom at 64k is ~2 GB.** Peak VRAM is 30360 MiB of 32607 for the accuracy check and
  30362 MiB for the bench, so 64k fits but not comfortably; anything else resident on the card
  will still push it over. Below 64k there is ample room.
- **64k only.** 98304 still fails on both arms (OOM plus an illegal access); any throughput printed
  there is garbage and is not claimed.
- Verified on one 32 GB RTX 5090. The threshold where this binds is card-dependent.

## Credit / prior art

- **#750** (@James-CUDA) is the same class of fix one level up — it sized the **draft's** KV to the
  requested context and unblocked 16k. That fix is in `main` here and is necessary but not
  sufficient at 64k; this addresses the **target's** paged-KV pool, a separate allocation binding at
  a different length. The framing of this PR follows theirs.
- #762 / #751 / #752 (@inference2026) trim the draft's long-context reads — orthogonal to pool
  sizing, and unaffected: τ is bit-identical at 16k and 32k on both arms.

## Build / test status

Verified on current `main` (`ad9d76e`, includes the seven `muse-glimmer` commits), RTX 5090,
CUDA 12.8:

- `cmake --build build` — **all targets compile** (not just the two used for measurement).
- `ctest` — **10/10 pass** with this change, twice, and 10/10 on clean `main` for comparison.
- The change is a no-op for non-hybrid stacks: `qwen35_layer_uses_kv()` returns true for every
  layer when `hybrid` is false, so Muse Glimmer (dense GQA) maps identically to before.
