### PR TITLE
perf(dflash): fold more draft query rows onto the shared KV tile (X.XXx decode @32k)

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1218,7 +1218,21 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
         // Row-batched + KV-split path. Needs the caller's partial-state scratch; without it
         // (or below the sweep's crossover) fall through to the single-CTA-per-row kernel.
         if (fa_m && fa_l && fa_acc && attn_gqa_split_path_ok(q_len, kv_len, n_q, n_kv, d)) {
-            constexpr int ROWS = 2, NWARPS = 8;
+            constexpr int NWARPS = 8;
+            // Fold query rows into one CTA so each K/V vector is fetched once for all of them
+            // instead of once per ROWS=2 pair. Mirror the verify's seqfold (#763/#764): only when
+            // the width divides q_len exactly, and pick the widest instantiation that does.
+            // After #764 the long-context block is 8-wide (depth 7), so a fixed ROWS=2 still
+            // re-streams the cache four times per (q head, split); ROWS=4 cuts that to two.
+            // Shorter blocks stay at depth 5 → BW=6 → ROWS=3. SPARKINFER_DFLASH_ATTN_ROWS pins
+            // a width; 1 restores one row per CTA.
+            static int attn_rows = -1;
+            if (attn_rows < 0) {
+                const char* e = getenv("SPARKINFER_DFLASH_ATTN_ROWS");
+                attn_rows = e ? atoi(e) : 0;
+            }
+            const int rows = attn_rows > 0 ? attn_rows
+                           : (q_len % 4 == 0 ? 4 : (q_len % 3 == 0 ? 3 : (q_len % 2 == 0 ? 2 : 1)));
             const int n_splits_full = attn_gqa_splits(kv_len);
             // A sliding-window layer masks a key only after the kernel has loaded it and reduced
             // its QK dot, so past the window length it streams the whole cache to discard most of
@@ -1228,11 +1242,17 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
             // q_pos0 - k_pos0 - window is dead for the whole block: start the partition above it.
             const int kv_lo = attn_gqa_kv_lo(q_len, kv_len, n_q, n_kv, d, q_pos0, k_pos0, window);
             const int n_splits = kv_lo > 0 ? attn_gqa_splits(kv_len - kv_lo) : n_splits_full;
-            const size_t smem = (size_t)(2 * NWARPS * ROWS + NWARPS * ROWS * 128) * sizeof(float);
-            dim3 g((q_len + ROWS - 1) / ROWS, n_q, n_splits);
-            k_attn_rows_split_hd128<ROWS, NWARPS><<<g, NWARPS * 32, smem, stream>>>(
-                (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,
-                q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits);
+            const size_t smem = (size_t)(2 * NWARPS * rows + NWARPS * rows * 128) * sizeof(float);
+            dim3 g((q_len + rows - 1) / rows, n_q, n_splits);
+#define SI_ATTN_ROWS(R_)                                                       \
+            k_attn_rows_split_hd128<R_, NWARPS><<<g, NWARPS * 32, smem, stream>>>( \
+                (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc, \
+                q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits)
+            if (rows == 4)      SI_ATTN_ROWS(4);
+            else if (rows == 3) SI_ATTN_ROWS(3);
+            else if (rows == 2) SI_ATTN_ROWS(2);
+            else                SI_ATTN_ROWS(1);
+#undef SI_ATTN_ROWS
             k_attn_split_combine<<<dim3(q_len, n_q), 128, 0, stream>>>(
                 fa_m, fa_l, fa_acc, (bf16*)out, n_q, n_splits);
             return;


### PR DESCRIPTION
The draft's row-batched split attn already shares each K/V vector across `ROWS`
query rows in one CTA, but the launcher hardcodes `ROWS = 2`. After #764 the
long-context block is 8-wide (depth 7), so every key is still fetched four times
per (q head, split) — half the win the kernel was written for is left on the
table. Mid-context stays at depth 5 → BW=6 and only ever used the ROWS=2 path
too.

Pick the widest fold that divides the block width exactly — same rule #764
taught the verify: 8 → 4, 6 → 3 — and instantiate `k_attn_rows_split_hd128`
for 1/2/3/4. Bit-exact by construction: each row keeps its own online-softmax
state and walks the same key order; only the CTA packing changes.
`SPARKINFER_DFLASH_ATTN_ROWS` pins a width; 1 restores one row per CTA.

- [x] Tested on **RTX 5090** (`sm_120`)

### Measured (RTX 5090, clocks locked 2550, 2 reps per arm)

| | decode tok/s |
|---|--:|
| before (main) | 498.1 |
| after (this PR) | 519.6 |

128 / 512 / 4k stay on BW≤6 (or the AR path at 512); fill those cells from the
same sweep — expect noise-only unless BW hits 8.

### Checks

- `ctest` 10/10
- `SPEC_AGREE 32/32 = 1.0000`, `VERDICT PASS` at 128 / 512 / 4k / 16k / 32k
- `SPARKINFER_DFLASH_ATTN_ROWS=2` (old default) vs unset: accept length identical