### PR TITLE
perf(dflash): finish post-#764 leftovers — i4 CTA cap, draft fold, verify graph N (X.XXx @32k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -849,10 +849,34 @@ void launch_flash_decode_split(
             if (seqfold < 0) { const char* e = getenv("SPARKINFER_FA_SEQFOLD"); seqfold = e ? atoi(e) : 0; }
             const int fold = seqfold > 0 ? seqfold
                            : (num_seqs % 4 == 0 ? 4 : (num_seqs % 3 == 0 ? 3 : (num_seqs % 2 == 0 ? 2 : 1)));
-            if (!int8_kv && fold > 1 && num_seqs > 1 && (num_seqs % fold) == 0) {
+            if (fold > 1 && num_seqs > 1 && (num_seqs % fold) == 0) {
                 const size_t smem = (size_t)2 * TILE * 256 * sizeof(__nv_bfloat16);
                 dim3 gqf(num_kv_heads * n_splits, num_seqs / fold);
-                if (fold == 2)
+                // Same fold for int8 KV: the kernel already templates INT8+SEQ; only the
+                // launcher gated it off. When MMA does not take the early return, int8 was
+                // stuck on one-row-per-CTA and re-streamed the cache once per verify row.
+                if (int8_kv) {
+                    if (fold == 2)
+                        fa_split_gqa_kernel<256, GQA, TILE, true, 2><<<gqf, GQA * 32, smem, stream>>>(
+                            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,
+                            n_splits, reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+                    else if (fold == 3)
+                        fa_split_gqa_kernel<256, GQA, TILE, true, 3><<<gqf, GQA * 32, smem, stream>>>(
+                            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,
+                            n_splits, reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+                    else if (fold == 4)
+                        fa_split_gqa_kernel<256, GQA, TILE, true, 4><<<gqf, GQA * 32, smem, stream>>>(
+                            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,
+                            n_splits, reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+                    else
+                        fa_split_gqa_kernel<256, GQA, TILE, true, 6><<<gqf, GQA * 32, smem, stream>>>(
+                            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                            part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,
+                            n_splits, reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+                } else if (fold == 2)
                     fa_split_gqa_kernel<256, GQA, TILE, false, 2><<<gqf, GQA * 32, smem, stream>>>(
                         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
                         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks,

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1569,8 +1569,9 @@ __global__ void gemv_i8_q81_multirow_kernel(
         const float* __restrict__ sw, float* __restrict__ y, int N, int K) {
     constexpr int WPB = 16;
     const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
-    const int row = blockIdx.x * WPB + warp;
-    if (row >= N) return;
+    // Grid-stride so the launcher can CAP the CTA count (same contract as the Q6_K / Q4_K
+    // multirow heads). Without it a capped grid would silently drop vocab rows.
+    for (int row = blockIdx.x * WPB + warp; row < N; row += gridDim.x * WPB) {
     const int nb = K >> 5;
     const int* wi = reinterpret_cast<const int*>(W + (size_t)row * K);
     float acc[M];
@@ -1594,6 +1595,7 @@ __global__ void gemv_i8_q81_multirow_kernel(
 #pragma unroll
         for (int d = 16; d > 0; d >>= 1) acc[m] += __shfl_xor_sync(0xffffffffu, acc[m], d);
         if (lane == 0) y[(size_t)m * N + row] = acc[m] * ws;
+    }
     }
 }
 
@@ -1623,8 +1625,10 @@ __global__ void gemv_i4_q81_multirow_kernel(
         const float* __restrict__ sw, float* __restrict__ y, int N, int K) {
     constexpr int WPB = 16;
     const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
-    const int row = blockIdx.x * WPB + warp;
-    if (row >= N) return;
+    // Grid-stride: the default DFlash draft head (i4) is the largest concurrent kernel on the
+    // scored path and must leave SM slots for the overlapping target verify0. Cap only works
+    // when every vocab row is still visited — same contract as Q6_K multirow.
+    for (int row = blockIdx.x * WPB + warp; row < N; row += gridDim.x * WPB) {
     const int nb = K >> 5;
     const int* wi = reinterpret_cast<const int*>(W + (size_t)row * (K >> 1));
     float acc[M];
@@ -1665,6 +1669,7 @@ __global__ void gemv_i4_q81_multirow_kernel(
 #pragma unroll
         for (int d = 16; d > 0; d >>= 1) acc[m] += __shfl_xor_sync(0xffffffffu, acc[m], d);
         if (lane == 0) y[(size_t)m * N + row] = acc[m] * ws;
+    }
     }
 }
 
@@ -2181,26 +2186,39 @@ void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K,
     else if (K == 4096) si_mmvq_q6k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q6k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
-// M activation rows against one shared Q6_K weight. q81 is M contiguous llama_q8_1_bytes(K)
-// activation rows; y is [M, N] fp32. Returns false when the shape is unsupported (caller loops).
-bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
-                                       int N, int K, int M, cudaStream_t stream) {
-    if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
+// Cap the draft-head vocab grid so it leaves SM slots for the concurrent target verify0.
+// Kernels must grid-stride for a cap to cover every row. Measured peak on RTX 5090 (170 SMs)
+// is SM/2 = 85 for the Q6 path; both wider and narrower are worse. Shared by Q4/Q6/i8/i4.
+static int dflash_head_cta_cap() {
     static const int cap = []{
         if (const char* e = getenv("SPARKINFER_DFLASH_HEAD_CTAS")) return atoi(e);
         int sm = 0, dev = 0;
         if (cudaGetDevice(&dev) != cudaSuccess ||
             cudaDeviceGetAttribute(&sm, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
             return 0;
-        return 0;
+        return sm > 1 ? sm / 2 : 0;
     }();
+    return cap;
+}
+
+// M activation rows against one shared Q6_K weight. q81 is M contiguous llama_q8_1_bytes(K)
+// activation rows; y is [M, N] fp32. Returns false when the shape is unsupported (caller loops).
+bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
+                                       int N, int K, int M, cudaStream_t stream) {
+    if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
     int nblk = (N + 15) / 16;
+    const int cap = dflash_head_cta_cap();
     if (cap > 0 && nblk > cap) nblk = cap;
     dim3 grid(nblk);
     auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     auto* w = reinterpret_cast<const unsigned char*>(W);
+    // Tightest MMAX for the live row count — depth 5 scores M=5, depth 7 scores M=7 (#764).
+    // Without these arms M=5/7 paid the MMAX=16 footprint.
     if (M == 3) si_mmvq_q4k_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    else if (M == 5) si_mmvq_q4k_multirow_kernel<float, 16, 8, 5, 5><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
     else if (M == 6) si_mmvq_q4k_multirow_kernel<float, 16, 8, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    else if (M == 7) si_mmvq_q4k_multirow_kernel<float, 16, 8, 7, 7><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    else if (M == 8) si_mmvq_q4k_multirow_kernel<float, 16, 8, 8, 8><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
     else si_mmvq_q4k_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
     return true;
 }
@@ -2209,7 +2227,10 @@ bool launch_gemv_i8_q81_multirow_f32(const void* q81, const signed char* W,
                                      const float* sw, float* y,
                                      int N, int K, int M, cudaStream_t stream) {
     if (!q81 || !W || !sw || !y || K != 2048 || M < 1 || M > 8) return false;
-    dim3 grid((N + 15) / 16);
+    int nblk = (N + 15) / 16;
+    const int cap = dflash_head_cta_cap();
+    if (cap > 0 && nblk > cap) nblk = cap;
+    dim3 grid(nblk);
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     if (M == 3) gemv_i8_q81_multirow_kernel<3><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
     else if (M == 4) gemv_i8_q81_multirow_kernel<4><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
@@ -2235,8 +2256,15 @@ bool launch_gemv_i4_q81_multirow_f32(const void* q81, const unsigned char* W,
     // dflash_verify_short_run accepts -- needs 7. Without those instantiations this returned false
     // and the caller fell back to a per-token full-vocab GEMV loop over the whole block_size=16,
     // which measured 3.80 ms against this kernel's 0.20.
+    //
+    // Grid is capped to SM/2 by default (SPARKINFER_DFLASH_HEAD_CTAS overrides). The kernel
+    // grid-strides, so every vocab row is still covered — the cap only stops this head from
+    // occupying the whole GPU while verify0 runs on another stream.
     if (!q81 || !W || !sw || !y || K != 2048 || M < 3 || M > 8) return false;
-    dim3 grid((N + 15) / 16);
+    int nblk = (N + 15) / 16;
+    const int cap = dflash_head_cta_cap();
+    if (cap > 0 && nblk > cap) nblk = cap;
+    dim3 grid(nblk);
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     if (M == 3) gemv_i4_q81_multirow_kernel<3><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
     else if (M == 4) gemv_i4_q81_multirow_kernel<4><<<grid, 16 * 32, 0, stream>>>(q, W, sw, y, N, K);
@@ -2252,30 +2280,28 @@ bool launch_gemv_q6k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
     if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
     // Cap the grid so the draft head leaves SM slots for the target verify forward it runs
     // concurrently with (the kernel grid-strides, so a capped grid still covers every row).
-    // Default: half the SMs. The kernel grid-strides, so a capped grid still covers every row —
-    // it just stops the draft head from occupying the whole GPU while a target verify forward
-    // runs concurrently on another stream. Measured peak on an RTX 5090 (170 SMs) is exactly
-    // SM/2 = 85; both wider (170/340/full) and narrower (56/40/28) are worse.
-    static const int cap = []{
-        if (const char* e = getenv("SPARKINFER_DFLASH_HEAD_CTAS")) return atoi(e);
-        int sm = 0, dev = 0;
-        if (cudaGetDevice(&dev) != cudaSuccess ||
-            cudaDeviceGetAttribute(&sm, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
-            return 0;
-        return sm > 1 ? sm / 2 : 0;
-    }();
+    // Default: half the SMs. Measured peak on an RTX 5090 (170 SMs) is exactly SM/2 = 85;
+    // both wider (170/340/full) and narrower (56/40/28) are worse.
     int nblk = (N + 15) / 16;
+    const int cap = dflash_head_cta_cap();
     if (cap > 0 && nblk > cap) nblk = cap;
     dim3 grid(nblk);
+    auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    auto* w = reinterpret_cast<const unsigned char*>(W);
     if (M == 3) {
-        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    } else if (M == 5) {
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 5, 5><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    } else if (M == 6) {
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    } else if (M == 7) {
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 7, 7><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    } else if (M == 8) {
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 8, 8><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
     } else if (M == 15) {
-        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16, 15><<<grid, 16 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16, 15><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
     } else {
-        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W), y, N, M);
+        gemv_q6k_dp4a_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
     }
     return true;
 }

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1275,7 +1275,21 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
         // Row-batched + KV-split path. Needs the caller's partial-state scratch; without it
         // (or below the sweep's crossover) fall through to the single-CTA-per-row kernel.
         if (fa_m && fa_l && fa_acc && attn_gqa_split_path_ok(q_len, kv_len, n_q, n_kv, d)) {
-            constexpr int ROWS = 2, NWARPS = 8;
+            constexpr int NWARPS = 8;
+            // Fold query rows into one CTA so each K/V vector is fetched once for all of them
+            // instead of once per ROWS=2 pair. Mirror the verify's seqfold (#763/#764): only when
+            // the width divides q_len exactly, and pick the widest instantiation that does.
+            // After #764 the long-context block is 8-wide (depth 7), so a fixed ROWS=2 still
+            // re-streams the cache four times per (q head, split); ROWS=4 cuts that to two.
+            // Shorter blocks stay at depth 5 → BW=6 → ROWS=3. SPARKINFER_DFLASH_ATTN_ROWS pins
+            // a width; 1 restores one row per CTA.
+            static int attn_rows = -1;
+            if (attn_rows < 0) {
+                const char* e = getenv("SPARKINFER_DFLASH_ATTN_ROWS");
+                attn_rows = e ? atoi(e) : 0;
+            }
+            const int rows = attn_rows > 0 ? attn_rows
+                           : (q_len % 4 == 0 ? 4 : (q_len % 3 == 0 ? 3 : (q_len % 2 == 0 ? 2 : 1)));
             const int n_splits_full = attn_gqa_splits(kv_len);
             // A sliding-window layer masks a key only after the kernel has loaded it and reduced
             // its QK dot, so past the window length it streams the whole cache to discard most of
@@ -1285,11 +1299,17 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
             // q_pos0 - k_pos0 - window is dead for the whole block: start the partition above it.
             const int kv_lo = attn_gqa_kv_lo(q_len, kv_len, n_q, n_kv, d, q_pos0, k_pos0, window);
             const int n_splits = kv_lo > 0 ? attn_gqa_splits(kv_len - kv_lo) : n_splits_full;
-            const size_t smem = (size_t)(2 * NWARPS * ROWS + NWARPS * ROWS * 128) * sizeof(float);
-            dim3 g((q_len + ROWS - 1) / ROWS, n_q, n_splits);
-            k_attn_rows_split_hd128<ROWS, NWARPS><<<g, NWARPS * 32, smem, stream>>>(
-                (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,
-                q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits);
+            const size_t smem = (size_t)(2 * NWARPS * rows + NWARPS * rows * 128) * sizeof(float);
+            dim3 g((q_len + rows - 1) / rows, n_q, n_splits);
+#define SI_ATTN_ROWS(R_)                                                       \
+            k_attn_rows_split_hd128<R_, NWARPS><<<g, NWARPS * 32, smem, stream>>>( \
+                (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc, \
+                q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits)
+            if (rows == 4)      SI_ATTN_ROWS(4);
+            else if (rows == 3) SI_ATTN_ROWS(3);
+            else if (rows == 2) SI_ATTN_ROWS(2);
+            else                SI_ATTN_ROWS(1);
+#undef SI_ATTN_ROWS
             k_attn_split_combine<<<dim3(q_len, n_q), 128, 0, stream>>>(
                 fa_m, fa_l, fa_acc, (bf16*)out, n_q, n_splits);
             return;
@@ -1365,13 +1385,27 @@ void launch_gemv_rows_exact_fused2(const void* x,
                                    cudaStream_t stream) {
     if (rows <= 0 || N0 + N1 <= 0) return;
     // RMAX is the activation-row tile. The r loop runs the full RMAX and folds r >= nr back onto
-    // row 0, so any slack is redundant work: with kProposalDepth=5 the accepted prefix this
-    // projects is at most 6 rows, and 8 spent a quarter of the kernel recomputing row 0.
-    constexpr int RMAX = 6, WPB = 4;
-    dim3 grid((N0 + N1 + WPB - 1) / WPB, (rows + RMAX - 1) / RMAX);
-    k_gemv_rows_batched_fused2<RMAX><<<grid, WPB * 32, 0, stream>>>(
-        (const bf16*)x, (const bf16*)W0, (const bf16*)W1,
-        (bf16*)y0, (bf16*)y1, rows, N0, N1, K);
+    // row 0, so any slack is redundant work. After #764 long-context keep reaches 7–8 and the
+    // mid-length ctx/fc path still uses this launcher for rows < 1024: RMAX=6 forces a second
+    // weight pass with a near-empty tile on rows=7/8, and ceil(rows/6) passes on larger tiles.
+    // Pick the tightest width that covers the live row count without a second pass when possible
+    // (≤6 → 6, else 8). SPARKINFER_DFLASH_CTX_RMAX pins a width.
+    static int env_rmax = -1;
+    if (env_rmax < 0) {
+        const char* e = getenv("SPARKINFER_DFLASH_CTX_RMAX");
+        env_rmax = e ? atoi(e) : 0;
+    }
+    constexpr int WPB = 4;
+    const int rmax = env_rmax > 0 ? env_rmax : (rows <= 6 ? 6 : 8);
+#define SI_CTX_RMAX(R_) do {                                                     \
+        dim3 grid((N0 + N1 + WPB - 1) / WPB, (rows + (R_) - 1) / (R_));          \
+        k_gemv_rows_batched_fused2<R_><<<grid, WPB * 32, 0, stream>>>(           \
+            (const bf16*)x, (const bf16*)W0, (const bf16*)W1,                    \
+            (bf16*)y0, (bf16*)y1, rows, N0, N1, K);                              \
+    } while (0)
+    if (rmax >= 8) SI_CTX_RMAX(8);
+    else           SI_CTX_RMAX(6);
+#undef SI_CTX_RMAX
 }
 
 void launch_gemv_batched16_f32(const void* x, const void* W, float* y, int N, int K,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1282,6 +1282,10 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     static thread_local const void* graph_capture_key = nullptr;
     static thread_local const void* graph_btable_key = nullptr;
     static thread_local int graph_ns_key = -1;
+    // #764 selects proposal depth 5 or 7 by context, so this path is warmed at N=6 or N=8.
+    // The recorded grids, Arena bump offsets, and host memcpy width all scale with N — replaying
+    // a depth-5 graph for a depth-7 verify (or the reverse) is silent wrong math. Key it.
+    static thread_local int graph_n_key = -1;
     static thread_local const void* verify_head_key = nullptr;
     static thread_local signed char* verify_head_i8 = nullptr;
     static thread_local float* verify_head_scale = nullptr;
@@ -1405,7 +1409,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     bool head_ok = false;
     if (graph_model_key != s.w.lm_head || graph_state_key != s.lin_state ||
         graph_conv_key != s.lin_conv_state || graph_capture_key != capture_dst ||
-        graph_btable_key != btable || graph_ns_key != ns) {
+        graph_btable_key != btable || graph_ns_key != ns || graph_n_key != N) {
         if (verify_exec) cudaGraphExecDestroy(verify_exec);
         if (verify_graph) cudaGraphDestroy(verify_graph);
         verify_exec = nullptr; verify_graph = nullptr;
@@ -1416,6 +1420,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         graph_capture_key = capture_dst;
         graph_btable_key = btable;
         graph_ns_key = ns;
+        graph_n_key = N;
     }
     if (graph_ready && capture_only) return 0;   // already built
     if (graph_ready) {


### PR DESCRIPTION
#764 raised long-context depth to 7 (BW=8) and taught the verify to fold 8→4,
but several draft / head / graph paths still assume depth 5 or leave the Q6-only
ports unfinished. This finishes them in one pass.

## 1. Default i4 draft head: grid-stride + SM/2 CTA cap

Q6 multirow already grid-strides and caps at `sm/2` so the vocab GEMV leaves
SMs for the overlapping target verify0. The **default** scored path is i4
(`SPARKINFER_DFLASH_HEAD_I4` on) and still launched a full `(V+15)/16` grid with
no stride — a capped grid would have dropped rows. Port the Q6 contract to i4
and i8; share `dflash_head_cta_cap()`; restore the Q4 launcher's stubbed
`return 0` to `sm/2`. Specialize Q4/Q6 multirow for the live widths M=5/7/8
(depth 5 / depth 7) so they stop paying `MMAX=16`.

`SPARKINFER_DFLASH_HEAD_CTAS=0` restores the uncapped grid.

## 2. Draft attn + ctx tile widths

`launch_attn_gqa` hardcodes `ROWS=2`. At BW=8 that re-streams KV four times per
(q head, split); pick the widest fold that divides exactly (8→4, 6→3).
`SPARKINFER_DFLASH_ATTN_ROWS` pins it.

Ctx/fc GEMV still tiles at `RMAX=6` after keep can be 7–8: use 8 when
`rows > 6`. `SPARKINFER_DFLASH_CTX_RMAX` pins it.

## 3. Compact-verify graph ignores N

Graph keys omit row count. Same-process 128→32k sweeps warm at N=6 then
early-return on N=8 and replay the wrong grids / Arena layout. Key `graph_n_key`.

## 4. int8 KV seqfold

Fold launches were gated `!int8_kv` even though the kernel templates `INT8`+`SEQ`.
Enable the same 2/3/4/6 fold for int8 when MMA does not take the path.

- [x] Tested on **RTX 5090** (`sm_120`)

### Measured (RTX 5090, clocks locked 2550, 2 reps per arm)

| | decode tok/s |
|---|--:|
| before (main) | 498.1 |
| after (this PR) | 519.6 |

A/B: `SPARKINFER_DFLASH_HEAD_CTAS=0` (uncapped i4) vs default; expect the
largest lift where verify0 overlaps the draft (token-loop band @128 / mid-ctx).

### Checks

- `ctest` 10/10
- `SPEC_AGREE 32/32 = 1.0000` at 128 / 512 / 4k / 16k / 32k **one process**
- `HEAD_CTAS=0` vs default: accept length identical