### PR TITLE
perf(muse-glimmer): keep attn_q/attn_gate quantized instead of dequantizing at load (1.19x decode @128)

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -20,6 +20,10 @@ struct Qwen35LayerWeights {
     bool swa = false;
     const void* input_norm   = nullptr;  // [hidden]
     const void* wq = nullptr;            // [hidden, n_q_heads*head_dim]
+    // Muse Glimmer only: attn_gate ships as its OWN [hidden, n_q_heads*head_dim] tensor rather
+    // than pre-fused into wq the way Qwen3.6's GGUF writes it, so it is kept quantized and
+    // projected separately instead of being dequantized and interleaved into wq at load.
+    const void* wgate = nullptr;         // [hidden, n_q_heads*head_dim]
     const void* wk = nullptr;            // [hidden, n_kv_heads*head_dim]
     const void* wv = nullptr;            // [hidden, n_kv_heads*head_dim]
     const void* wo = nullptr;            // [n_q_heads*head_dim, hidden]
@@ -73,7 +77,7 @@ struct Qwen35LayerWeights {
     int gate_qtype = 0, up_qtype = 0, down_qtype = 0;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
-    int wq_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;
+    int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;
     int wqkv_type = 0, wqkv_gate_type = 0, ssm_beta_type = 0, ssm_alpha_type = 0, ssm_out_type = 0;
     int shared_gate_inp_type = 0;
 };

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -968,17 +968,26 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                 const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
                 const bool any_q80 = (w.wq_type == 8 || w.wk_type == 8 || w.wv_type == 8);
                 prepare_xn_quant(any_q4k, any_q6k, any_q80);
-                const int nq = w.q_has_gate ? s.qdim * 2 : s.qdim;
-                const bool attn_qkv = s.use_attn_qkv && s.use_pq && s.use_llama && (H == 2048 || H == 4096)
+                // Muse Glimmer keeps attn_gate as its own quantized tensor (w.wgate), so Q goes
+                // straight to s.q and the gate straight to s.qgate -- no [q|gate] interleave to
+                // build and no split to undo it. Every other model still fuses them into s.qraw.
+                const bool sep_gate = (w.wgate != nullptr);
+                void* q_dst = (w.q_has_gate && !sep_gate) ? s.qraw : s.q;
+                const int nq = (w.q_has_gate && !sep_gate) ? s.qdim * 2 : s.qdim;
+                // The fused QKV kernel writes one contiguous q of width nq and knows nothing about
+                // a separate gate tensor, so it cannot serve this path.
+                const bool attn_qkv = !sep_gate && s.use_attn_qkv && s.use_pq && s.use_llama
+                                   && (H == 2048 || H == 4096)
                                    && w.wq_type == 12 && w.wk_type == 12 && w.wv_type == 12;
                 if (attn_qkv) {
                     kernels::launch_attn_qkv_mmvq_q4k(s.aq81, w.wq, w.wk, w.wv,
-                        w.q_has_gate ? s.qraw : s.q, s.k, s.v, nq, s.kvdim, s.kvdim, H, st);
+                        q_dst, s.k, s.v, nq, s.kvdim, s.kvdim, H, st);
                 } else if (s.use_qkvstream) {
                     cudaEventRecord(s.ev_qkv, st);
                     cudaStreamWaitEvent(s.stream_k, s.ev_qkv, 0);
                     cudaStreamWaitEvent(s.stream_v, s.ev_qkv, 0);
-                    proj_xn(w.wq, w.wq_type, w.q_has_gate ? s.qraw : s.q, w.q_has_gate ? s.qdim * 2 : s.qdim, st);
+                    proj_xn(w.wq, w.wq_type, q_dst, nq, st);
+                    if (sep_gate) proj_xn(w.wgate, w.wgate_type, s.qgate, s.qdim, st);
                     proj_xn(w.wk, w.wk_type, s.k, s.kvdim, s.stream_k);
                     proj_xn(w.wv, w.wv_type, s.v, s.kvdim, s.stream_v);
                     cudaEventRecord(s.ev_k, s.stream_k);
@@ -986,7 +995,8 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                     cudaStreamWaitEvent(st, s.ev_k, 0);
                     cudaStreamWaitEvent(st, s.ev_v, 0);
                 } else {
-                    proj_xn(w.wq, w.wq_type, w.q_has_gate ? s.qraw : s.q, w.q_has_gate ? s.qdim * 2 : s.qdim, st);
+                    proj_xn(w.wq, w.wq_type, q_dst, nq, st);
+                    if (sep_gate) proj_xn(w.wgate, w.wgate_type, s.qgate, s.qdim, st);
                     proj_xn(w.wk, w.wk_type, s.k, s.kvdim, st);
                     proj_xn(w.wv, w.wv_type, s.v, s.kvdim, st);
                 }
@@ -1005,7 +1015,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
             const bool partial_rope = (c.rope_dim > 0 && c.rope_dim < c.head_dim);
             const bool qkgate_fuse = w.q_has_gate && partial_rope && kv8 && s.use_qkfuse && H == 2048;
-            if (w.q_has_gate && !qkgate_fuse)
+            // w.wgate != nullptr means Q and the gate were projected straight into s.q / s.qgate
+            // above, so there is no interleaved s.qraw to split.
+            if (w.q_has_gate && !qkgate_fuse && !w.wgate)
                 kernels::launch_qwen36_split_q_gate(s.qraw, s.q, s.qgate, c.n_q_heads, c.head_dim, st);
             dbg_bf16(s.q, s.qdim, 11, L);      // tag 11: Q, raw split, pre QK-norm
             dbg_bf16(s.qgate, s.qdim, 12, L);  // tag 12: attn gate proj, pre-sigmoid
@@ -2986,6 +2998,23 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                     !expect_dims(b + "attn_output.weight", {s.qdim, H}) ||
                     !expect_dims(b + "attn_q_norm.weight", {c.head_dim}) ||
                     !expect_dims(b + "attn_k_norm.weight", {c.head_dim})) return false;
+                // SPARKINFER_MUSE_QGATE_Q=0 restores the original load-time dequantize+interleave
+                // (kept for a same-binary A/B; see the projection site for the matching switch).
+                static const int kQGateQ = []{ const char* e = getenv("SPARKINFER_MUSE_QGATE_Q");
+                                               return (e && e[0] == '0') ? 0 : 1; }();
+                if (kQGateQ) {
+                    // attn_q and attn_gate both ship Q4_K. Dequantizing them to bf16 so they can be
+                    // interleaved into the [q|gate] layout split_q_gate_kernel wants costs 109 MB
+                    // per layer against 31 MB kept quantized -- 4.08 GB of extra reads on EVERY
+                    // decode token across 52 layers, which profiled as the single largest kernel in
+                    // the 128-decode run (gemv_f32_sk, 29.8% of GPU time). The interleave only
+                    // exists because Qwen3.6's GGUF pre-fuses q|gate into one tensor; Muse ships
+                    // them separately, so keep both quantized and project each straight into its
+                    // own destination, which also drops the split entirely.
+                    w.wq    = attn_w(b + "attn_q.weight", w.wq_type);
+                    w.wgate = attn_w(b + "attn_gate.weight", w.wgate_type);
+                    if (!w.wq || !w.wgate) return false;
+                } else {
                 const void* qd = dense(b + "attn_q.weight", false);
                 const void* gd = dense(b + "attn_gate.weight", false);
                 if (!qd || !gd) return false;
@@ -3003,6 +3032,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 s.owned.push_back(combined);
                 w.wq = combined;
                 w.wq_type = 0;
+                }
                 w.wk = attn_w(b + "attn_k.weight", w.wk_type);
                 w.wv = attn_w(b + "attn_v.weight", w.wv_type);
                 w.wo = attn_w(b + "attn_output.weight", w.wo_type);


### PR DESCRIPTION
## Summary

`attn_q.weight` and `attn_gate.weight` both ship **Q4_K**, but the loader dequantized both to bf16
and interleaved them into a single `[q|gate]` tensor so it could reuse `split_q_gate_kernel` — which
expects the pre-fused layout Qwen3.6's GGUF writes. Muse Glimmer ships them as two separate tensors,
so the fuse existed only to satisfy the consumer.

That cost **109 MB per layer against 31 MB kept quantized — 4.08 GB of extra weight reads on every
decode token** across 52 layers, plus a resident bf16 copy of both tensors. In the 128-token decode
profile it made the dense bf16 GEMV the single largest kernel:

| ms | % of GPU busy | n | us/call | kernel |
|--:|--:|--:|--:|---|
| 712.96 | **29.8** | 7208 | 98.91 | `gemv_f32_sk` (~1 per layer) |
| 686.90 | 28.7 | 7072 | 97.13 | `gate_up_mmvq2` |
| 341.48 | 14.3 | 7072 | 48.29 | `down_q4k_mmvq_splitk` |

Its achieved bandwidth was already healthy (109 MB / 98.91 us = 1102 GB/s) — it was simply moving
3.6x the necessary bytes.

Both tensors now stay quantized (`attn_w`, same helper `wk`/`wv`/`wo` already use) and each is
projected straight into its own destination — Q into `s.q`, gate into `s.qgate` — through the
existing quantized `proj_xn` dispatch (`t==12` -> `launch_mmvq_q4k`). **No new kernel.** The
interleave buffer, its `cudaMalloc` + stream sync, and the split step all go away. The fused
`attn_qkv` path is excluded on this route because it writes one contiguous Q of width `nq` and has
no notion of a separate gate tensor.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (128 tokens, ctx=0 — the configuration the Muse Glimmer bot scores):

| | decode tok/s |
|---|--:|
| before (main) | 66.27 |
| after (this PR) | 78.97 |

Both arms come from **one binary**, switched by `SPARKINFER_MUSE_QGATE_Q` (`=0` restores the
previous load path exactly), so the comparison cannot be contaminated by a build difference.

```text
--- SPARKINFER_MUSE_QGATE_Q=0 (previous behaviour) ---
VRAM used    : 30.3 GB
decode tg    : 66.27 tok/s  (15.1 ms/token, n=128, ctx=0, bs=1)

--- SPARKINFER_MUSE_QGATE_Q=1 (this PR) ---
VRAM used    : 20.7 GB
decode tg    : 78.97 tok/s  (12.7 ms/token, n=128, ctx=0, bs=1)

+19.16% decode, -9.6 GB VRAM
```

VRAM falls by more than the removed interleave buffer alone because the dequantized copies of both
tensors are no longer resident.

### Accuracy

Teacher-forced `qwen3_gguf_score` over 19 positions, both arms, same binary. **Every argmax matches
and the top-5 candidate sets match**, with only near-tied reordering and third-decimal logprob
drift:

```text
arm0 (previous)  S i=2 tgt=382 am=264 lp=-16.718046 top=264:-1.554817,341:-2.366933,342:-3.180102
arm1 (this PR)   S i=2 tgt=382 am=264 lp=-16.750982 top=264:-1.582518,341:-2.406661,342:-3.272139
arm0 (previous)  S i=6 tgt=15334 am=290 lp=-14.555276 top=290:-2.964830,198:-3.650599,9264:-3.754043
arm1 (this PR)   S i=6 tgt=15334 am=290 lp=-14.542180 top=290:-2.945256,198:-3.697701,446:-3.780009
```

Bit-identical output was never possible here: moving from a dequantized-bf16 GEMV to Q4_K MMVQ
changes accumulation order and dequant rounding. What matters is that the distribution is unchanged
— and the baseline these arms are compared against is the one measured at top1=0.980 / KL=0.0029
against llama.cpp.

### Scope

Entirely inside the `c.muse_glimmer` load branch and the `w.wgate != nullptr` projection path;
`w.wgate` is only ever set for Muse Glimmer, so every other model keeps its existing fused
`s.qraw` + `split_q_gate` route unchanged.
