### PR TITLE
perf(muse-glimmer): stop dequantizing the Q5_K LM head, and stop running hot decode kernels on one CTA (1.14x decode @128)

### DIFF
--- a/kernels/csrc/cuda/fused/model_ops.cu
+++ b/kernels/csrc/cuda/fused/model_ops.cu
@@ -148,11 +148,15 @@ __global__ void decode_feedback_kernel(int* __restrict__ scalars,
 
 // Gemma2-style final-logit softcap, in place: logits[v] = tanh(logits[v] * scale / cap) * cap.
 // One block per row, grid-stride over vocab.
+// One CTA per row left a 202k-element vocab to a single 256-thread block at decode (n_rows == 1),
+// i.e. one SM of the device: 283 us to touch 1.6 MB, about 5.7 GB/s. Spread the vocab across
+// blockIdx.x and keep the row on blockIdx.y. Every element is still computed by exactly the same
+// expression, so the result is bit-identical -- only which thread evaluates it changes.
 __global__ void logit_softcap_kernel(float* __restrict__ logits, int vocab,
                                      float scale, float cap) {
-    float* L = logits + (size_t)blockIdx.x * vocab;
+    float* L = logits + (size_t)blockIdx.y * vocab;
     const float inv_cap = 1.f / cap;
-    for (int v = threadIdx.x; v < vocab; v += blockDim.x)
+    for (int v = blockIdx.x * blockDim.x + threadIdx.x; v < vocab; v += gridDim.x * blockDim.x)
         L[v] = tanhf(L[v] * scale * inv_cap) * cap;
 }
 
@@ -241,7 +245,10 @@ void launch_decode_feedback(int* scalars, const int* out_id, cudaStream_t stream
 
 void launch_logit_softcap(float* logits, int n_rows, int vocab, float scale, float cap,
                           cudaStream_t stream) {
-    logit_softcap_kernel<<<n_rows, 256, 0, stream>>>(logits, vocab, scale, cap);
+    // Cap the x-grid so a huge vocab does not spawn more blocks than the device can use; the
+    // kernel's grid-stride loop covers whatever is left over.
+    const int bx = (vocab + 255) / 256 > 1024 ? 1024 : (vocab + 255) / 256;
+    logit_softcap_kernel<<<dim3(bx < 1 ? 1 : bx, n_rows), 256, 0, stream>>>(logits, vocab, scale, cap);
 }
 #endif
 

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -420,6 +420,112 @@ __global__ void norm_then_add_kernel(const __nv_bfloat16* __restrict__ residual,
     }
 }
 
+// Muse Glimmer's sandwich-norm tail, fused. The architecture runs it twice per layer:
+//   out_x  = residual + RMSNorm(branch, post_w, post_eps)      (launch_norm_then_add)
+//   out_xn = RMSNorm(out_x, next_w, eps)                       (launch_rmsnorm)
+// Both are single-CTA kernels over 6656 elements -- ~3.2 us each for 13 KB, i.e. one SM of 170
+// and almost pure launch/reduction latency -- and there are 4 of them per layer, 208 per token.
+//
+// Bit-identical to the pair by construction: the block is the same 256 threads, each stage keeps
+// the other kernel's exact loop order and warp-reduction tree, and stage 2 re-reads the bf16-
+// rounded out_x back from global rather than reusing the float registers, which is precisely what
+// the separate launch_rmsnorm would have seen.
+__global__ void muse_sandwich_tail_kernel(const __nv_bfloat16* __restrict__ residual,
+                                          const __nv_bfloat16* __restrict__ branch,
+                                          const __nv_bfloat16* __restrict__ post_w,
+                                          const __nv_bfloat16* __restrict__ next_w,
+                                          __nv_bfloat16* __restrict__ out_x,
+                                          __nv_bfloat16* __restrict__ out_xn,
+                                          int cols, float post_eps, float eps) {
+    const size_t base = (size_t)blockIdx.x * cols;
+    __shared__ float s_warp[32];
+    const int npack = cols >> 3;
+    const int tail = npack << 3;
+
+    // ---- stage 1: norm_then_add over `branch` ----
+    const uint4* b4 = reinterpret_cast<const uint4*>(branch + base);
+    float ss = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float bv[8]; rn_unpack8(__ldg(b4 + p), bv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss = __fmaf_rn(bv[j], bv[j], ss);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+        float v = __bfloat162float(branch[base + c]);
+        ss = __fmaf_rn(v, v, ss);
+    }
+    ss = rn_warp_sum(ss);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + post_eps);
+    }
+    __syncthreads();
+    const float inv1 = s_warp[0];
+    {
+        const uint4* pw4 = reinterpret_cast<const uint4*>(post_w);
+        const uint4* r4 = reinterpret_cast<const uint4*>(residual + base);
+        uint4* ox4 = reinterpret_cast<uint4*>(out_x + base);
+        for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+            float bv[8]; rn_unpack8(__ldg(b4 + p), bv);
+            float rv[8]; rn_unpack8(__ldg(r4 + p), rv);
+            float wv[8]; rn_unpack8(__ldg(pw4 + p), wv);
+            float ov[8];
+            #pragma unroll
+            for (int j = 0; j < 8; j++) ov[j] = rv[j] + bv[j] * inv1 * wv[j];
+            ox4[p] = rn_pack8(ov);
+        }
+        for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+            float bv = __bfloat162float(branch[base + c]);
+            float rv = __bfloat162float(residual[base + c]);
+            float wv = __bfloat162float(post_w[c]);
+            out_x[base + c] = __float2bfloat16(rv + bv * inv1 * wv);
+        }
+    }
+    __syncthreads();   // out_x visible to the whole block, and s_warp free to reuse
+
+    // ---- stage 2: rmsnorm over the bf16-rounded out_x ----
+    const uint4* x4 = reinterpret_cast<const uint4*>(out_x + base);
+    float ss2 = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float xv[8]; rn_unpack8(__ldg(x4 + p), xv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss2 = __fmaf_rn(xv[j], xv[j], ss2);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+        float v = __bfloat162float(out_x[base + c]);
+        ss2 = __fmaf_rn(v, v, ss2);
+    }
+    ss2 = rn_warp_sum(ss2);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss2;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv2 = s_warp[0];
+    {
+        const uint4* nw4 = reinterpret_cast<const uint4*>(next_w);
+        uint4* on4 = reinterpret_cast<uint4*>(out_xn + base);
+        for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+            float xv[8]; rn_unpack8(__ldg(x4 + p), xv);
+            float wv[8]; rn_unpack8(__ldg(nw4 + p), wv);
+            float ov[8];
+            #pragma unroll
+            for (int j = 0; j < 8; j++) ov[j] = xv[j] * inv2 * wv[j];
+            on4[p] = rn_pack8(ov);
+        }
+        for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+            float v = __bfloat162float(out_x[base + c]);
+            out_xn[base + c] = __float2bfloat16(v * inv2 * __bfloat162float(next_w[c]));
+        }
+    }
+}
+
 // Fused per-head Q-norm + K-norm: ONE kernel over (n_q_heads + n_kv_heads) heads
 // (each block normalizes one head), vs two launch_rmsnorm calls. 1 graph node saved.
 __global__ void rmsnorm_qk_kernel(__nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k,
@@ -536,6 +642,18 @@ void launch_add_rmsnorm3_q8_rows(const void* x, const void* res1, const void* re
         reinterpret_cast<const __nv_bfloat16*>(res2), reinterpret_cast<const __nv_bfloat16*>(weight),
         reinterpret_cast<__nv_bfloat16*>(out_sum), reinterpret_cast<__nv_bfloat16*>(out_norm),
         reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
+}
+
+void launch_muse_sandwich_tail(const void* residual, const void* branch, const void* post_w,
+                               const void* next_w, void* out_x, void* out_xn,
+                               int rows, int cols, float post_eps, float eps, cudaStream_t stream) {
+    muse_sandwich_tail_kernel<<<rows, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(branch),
+        reinterpret_cast<const __nv_bfloat16*>(post_w),
+        reinterpret_cast<const __nv_bfloat16*>(next_w),
+        reinterpret_cast<__nv_bfloat16*>(out_x),
+        reinterpret_cast<__nv_bfloat16*>(out_xn), cols, post_eps, eps);
 }
 
 void launch_norm_then_add(const void* residual, const void* block_out, const void* weight,

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -981,6 +981,9 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8>(const si_bl
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+// Muse Glimmer hidden = 6656 -> 26 superblocks. Same loop and same reduction as the generic
+// kernel, so the result is bit-identical; only the trip count becomes a compile-time constant.
+template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 26>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
@@ -2017,6 +2020,10 @@ void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cuda
         si_mmvq_q4k_dualrow_kernel<__nv_bfloat16, 8><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, out, N);
     else if (K == 2048) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    // Muse Glimmer's hidden size. Its q/gate/k/v projections were the only hot GEMVs left on the
+    // runtime-K kernel, measured at 1042 GB/s against 1374 GB/s for the K=4096 kfixed o_proj
+    // sitting next to them in the same layer.
+    else if (K == 6656) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 26><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else                si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }
 void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void* z_w,

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -37,6 +37,17 @@ void launch_norm_then_add(const void* residual_bf16, const void* block_out_bf16,
                           const void* weight_bf16, void* out_bf16,
                           int rows, int cols, float eps, cudaStream_t stream = nullptr);
 
+// Muse Glimmer's sandwich-norm tail in one launch instead of two:
+//   out_x  = residual + RMSNorm(branch, post_w, post_eps)   (what launch_norm_then_add does)
+//   out_xn = RMSNorm(out_x, next_w, eps)                    (what the following launch_rmsnorm does)
+// Bit-identical to that pair: same 256-thread block, same per-stage loop order and reduction tree,
+// and stage 2 re-reads the bf16-rounded out_x from memory exactly as the separate kernel would.
+void launch_muse_sandwich_tail(const void* residual_bf16, const void* branch_bf16,
+                               const void* post_w_bf16, const void* next_w_bf16,
+                               void* out_x_bf16, void* out_xn_bf16,
+                               int rows, int cols, float post_eps, float eps,
+                               cudaStream_t stream = nullptr);
+
 // Fold residual_add(res1,res2) into add_rmsnorm2: out_sum = x + (res1 + res2).
 void launch_add_rmsnorm3(const void* x_bf16, const void* res1_bf16, const void* res2_bf16,
                          const void* weight_bf16, void* out_sum_bf16, void* out_norm_bf16,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -2696,10 +2696,15 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                name.find(".attn_v.weight") != std::string::npos ||
                name.find(".attn_output.weight") != std::string::npos;
     };
-    auto dev_quant_requant_q4k = [&](const std::string& name, int& qtype, bool req) -> const void* {
+    // allow_q5k is opt-in per call site, NOT a widening of the default set: dev_quant_down() also
+    // routes through here with requant on by default, so accepting Q5_K unconditionally would
+    // silently requantize the dense-FFN down tensor of any model that ships one.
+    auto dev_quant_requant_q4k = [&](const std::string& name, int& qtype, bool req,
+                                     bool allow_q5k = false) -> const void* {
         const void* q6 = dev_quant(name, qtype);
-        if (!req || (qtype != 14 && qtype != 8) || !q6) return q6;
-        const int src_type = qtype;            // 14 (Q6_K) or 8 (Q8_0) -> Q4_K
+        const bool src_ok = (qtype == 14 || qtype == 8 || (allow_q5k && qtype == 13));
+        if (!req || !src_ok || !q6) return q6;
+        const int src_type = qtype;            // 14 (Q6_K), 8 (Q8_0) or 13 (Q5_K) -> Q4_K
         const GGUFTensor* t = g.tensor(name);
         const long nv = t->n_values;
         if (nv % 256 != 0) return q6;
@@ -2909,10 +2914,20 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             return dev_quant_requant_q4k(name, type, req_attn_q4(name, t->ggml_type));
         type = 0; return dense(name, false);
     };
+    // Muse Glimmer ships output.weight as Q5_K -- the only Q5_K tensor in the file -- and Q5_K was
+    // not on this list, so the head fell through to `dense()` and was dequantized to bf16. The
+    // decode LM head then read 2.69 GB every token (gemv_f32_sk) instead of 0.76 GB through the
+    // Q4_K MMVQ path: 1.60 ms of a 12.4 ms step. Requanting it to Q4_K at load is the same
+    // mechanism this codebase already applies to other models' heads (SPARKINFER_LMHEAD_REQUANT_Q4K).
+    static const bool mg_lm_q5k = [] {
+        const char* e = getenv("SPARKINFER_MUSE_LMHEAD_Q5K");
+        return !(e && e[0] == '0');
+    }();
     auto lm_w = [&](const std::string& name, int& type) -> const void* {
         const GGUFTensor* t = g.tensor(name);
-        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8))
-            return dev_quant_requant_q4k(name, type, req_lm_q4);
+        const bool q5k_ok = mg_lm_q5k && s.cfg.muse_glimmer && t && t->ggml_type == 13;
+        if (qattn && t && (t->ggml_type == 12 || t->ggml_type == 14 || t->ggml_type == 8 || q5k_ok))
+            return dev_quant_requant_q4k(name, type, req_lm_q4 || q5k_ok, q5k_ok);
         type = 0; return dense(name, false);
     };
     auto dense_opt = [&](const std::string& name, bool transpose) -> const void* {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -43,6 +43,15 @@ namespace {
 inline void cu(cudaError_t e, const char* what) {
     if (e != cudaSuccess) fprintf(stderr, "[qwen35] %s: %s\n", what, cudaGetErrorString(e));
 }
+// SPARKINFER_MUSE_FUSE_TAIL=0 splits Muse Glimmer's sandwich-norm tail back into the original
+// launch_norm_then_add + launch_rmsnorm pair (the two produce bit-identical output).
+inline bool muse_fuse_tail() {
+    static const bool on = [] {
+        const char* e = getenv("SPARKINFER_MUSE_FUSE_TAIL");
+        return !(e && e[0] == '0');
+    }();
+    return on;
+}
 using bf16 = unsigned short;
 
 // forward_token() sentinel: the decode graph was enqueued but not yet collected. Never a valid
@@ -1206,9 +1215,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // upstream's `post_norm_eps` in muse-glimmer.cpp), distinct from the model's
             // normal rms_eps (1e-5, used for attn_norm/ffn_norm/q_norm/k_norm) -- reusing
             // c.rms_eps here silently gives wrong post-attn/post-ffn norms.
+            // Both halves of the sandwich tail are single-CTA kernels over 6656 elements, so each
+            // costs ~3.2 us of launch/reduction latency for 13 KB of traffic. Fuse them.
+            if (muse_fuse_tail())
+                kernels::launch_muse_sandwich_tail(s.x, s.ao, w.post_attn_norm, w.ffn_norm,
+                                                   s.h, s.hn, 1, H, 1e-8f, c.rms_eps, st);
+            else {
             kernels::launch_norm_then_add(s.x, s.ao, w.post_attn_norm, s.h, 1, H, 1e-8f, st);
             dbg_bf16(s.h, H, 50, L);   // tag 50: h = x + sandwich_norm(ao)  (post-attn residual)
             kernels::launch_rmsnorm(s.h, w.ffn_norm, s.hn, 1, H, c.rms_eps, st);
+            }
             dbg_bf16(s.hn, H, 51, L);  // tag 51: hn = pre-FFN norm(h)
         } else if (fnq) {
             // fused: h = x + ao ; hn = RMSNorm(h, post_attn_norm). When fnq, also emit
@@ -1440,9 +1456,14 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // always null here. xn = RMSNorm(x, nextnorm) is the next layer's ordinary
             // pre-attn norm (or final_norm on the last layer), unaffected by the sandwich.
             // Same 1e-8 post_norm_eps as the post-attn sandwich norm above -- see that comment.
+            if (muse_fuse_tail())
+                kernels::launch_muse_sandwich_tail(s.h, s.routed, w.post_ffn_norm, nextnorm,
+                                                   s.x, s.xn, 1, H, 1e-8f, c.rms_eps, st);
+            else {
             kernels::launch_norm_then_add(s.h, s.routed, w.post_ffn_norm, s.x, 1, H, 1e-8f, st);
             dbg_bf16(s.x, H, 70, L);   // tag 70: x = h + sandwich_norm(routed)  (layer output)
             kernels::launch_rmsnorm(s.x, nextnorm, s.xn, 1, H, c.rms_eps, st);
+            }
         } else if (shared_to_fold) {
             if (fnq)
                 kernels::launch_add_rmsnorm3_q8(s.h, s.routed, shared_to_fold, nextnorm, s.x, s.xn, s.aq81, H, c.rms_eps, st);


### PR DESCRIPTION
## Summary

Four independent wins on the 128-token decode path. The big one: `output.weight` is the **only
Q5_K tensor in the file**, and `lm_w()` kept a head quantized only for ggml types 12/14/8 — so
Q5_K fell through to `dense()` and the LM head was dequantized to bf16 at load, making decode read
**2.69 GB of head every token** through `gemv_f32_sk`. The rest are launch-latency: three of the
hot kernels here run as a *single CTA* (one SM of 170) because `rows == 1` at decode.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`qwen3_gguf_bench <gguf> 128 0` — the configuration the Muse Glimmer bot scores):

| | decode tok/s |
|---|--:|
| before (main) | 78.97 |
| after (this PR) | 90.21 |

```text
=== BEFORE (main f7877a8) ===
main rep=1 decode tg    : 78.98 tok/s  (12.7 ms/token, n=128, ctx=0, bs=1)
main rep=2 decode tg    : 78.96 tok/s  (12.7 ms/token, n=128, ctx=0, bs=1)

=== AFTER (main + this PR) ===
patched rep=1 decode tg    : 90.19 tok/s  (11.1 ms/token, n=128, ctx=0, bs=1)
patched rep=2 decode tg    : 90.23 tok/s  (11.1 ms/token, n=128, ctx=0, bs=1)

+14.24% decode, VRAM 20.7 -> 18.8 GB
```

Two **separate builds**, clocks locked at 2550, 2 reps each and deterministic to the second decimal.

### What changed, largest first

**1. LM head Q5_K → Q4_K at load (+10.3%).** The head was the largest single kernel left on the
step at 1.60 ms of 12.4 ms. Requantized at load it reads 0.76 GB instead of 2.69 GB and runs on the
existing Q4_K MMVQ path. Accepting Q5_K is **opt-in per call site** (`allow_q5k`) rather than a
widening of `dev_quant_requant_q4k`'s accepted set — `dev_quant_down()` also routes through that
helper with requant on by default, and would otherwise start requantizing any other model's Q5_K
dense-FFN down tensor. `SPARKINFER_MUSE_LMHEAD_Q5K=0` restores the previous load path.

**2. Logit softcap grid (+2.32%, bit-identical).** `launch_logit_softcap` launched
`<<<n_rows, 256>>>`; at decode `n_rows == 1`, so a single 256-thread block walked all 202048
logits — one SM out of 170, 283 µs to touch 1.6 MB (5.7 GB/s). The vocab now spreads across
`blockIdx.x` with the row on `blockIdx.y`. Each element is computed by the same expression, so the
result is unchanged bit for bit.

**3. `si_mmvq_q4k_kfixed<26>` for K=6656 (+0.19%, bit-identical).** There were K-specialized
kernels for 2048 and 4096 and a runtime-K kernel otherwise, so Muse Glimmer's 6656 projections took
the generic path. Same loop and same reduction, only the trip count becomes constant. Small,
because that q/gate/k/v mix turns out to be launch-bound rather than instruction-bound — k and v
are only 256 rows.

**4. Fused sandwich-norm tail (+1.03%, byte-identical output).** Muse runs
`launch_norm_then_add` + `launch_rmsnorm` twice per layer; both are `<<<1, 256>>>` at decode, so
each is one CTA touching 13 KB in ~3.2 µs — 208 launches per token of pure latency. Fused into one
kernel per pair, keeping each stage's exact loop order and reduction tree and re-reading the
bf16-rounded intermediate from memory. The `qwen3_gguf_score` dump is byte-for-byte identical with
the fusion on and off. `SPARKINFER_MUSE_FUSE_TAIL=0` restores the pair.

**Measured and deliberately not shipped:** pairing `attn_q` + `attn_gate` into one 8192-CTA launch
is worth nothing (90.21 → 90.22, noise) — those 4096-CTA launches are not latency-starved and k/v
already ride separate streams.

**Deliberately not touched:** `gate_up_mmvq2` (5.07 ms/token) and `down_q4k_mmvq_splitk`
(2.49 ms/token) already run at 1534 and 1562 GB/s. They are bandwidth-saturated and shape-
specializing them wins nothing.

### Accuracy

`ctest` 11/11. Teacher-forced over 98 positions, both arms from one binary
(`SPARKINFER_MUSE_LMHEAD_Q5K`):

```text
PPL              2.70678  ->  2.71124   (+0.16%)
argmax agreement 97/98 = 0.9898
mean |dlogprob|  0.029414   max 0.234658
```

Bit-identical output is not possible for change 1 — requantizing the head changes dequant rounding.
The baseline arm here is the path validated at top1 0.980 / KL 0.0029 against llama.cpp in
`6d911d4`, and the distribution barely moves off it.

### Scope

Changes 1 and 3 are reachable only for Muse Glimmer (`c.muse_glimmer` + a Q5_K head; K=6656 is this
model's hidden size). Change 2 is shared but computes the same values for every caller.
