### PR TITLE
feat(lmcache): integrate LMCache OSS as an opt-in CPU-RAM KV cache tier

### DIFF
--- a/bridge/README.md
+++ b/bridge/README.md
@@ -1,0 +1,66 @@
+# sparkinfer LMCache bridge sidecar
+
+A small Python process that embeds the real [LMCache](https://github.com/LMCache/LMCache)
+library via its documented in-process API and speaks a sparkinfer-owned wire protocol
+(`../docs/lmcache_bridge_protocol.md`) back to sparkinfer's C++ server. See that doc for the
+"why" (LMCache has no stable non-Python integration surface) and the full protocol spec, and
+`/home/autotiny/.claude/plans/fuzzy-riding-taco.md` for the overall design.
+
+Not started automatically by anything in this directory -- `sparkinfer_server` spawns it when
+`SPARKINFER_LMCACHE_ENABLE=1` is set (see the server's startup code). This README is for running
+it standalone, e.g. to debug the sidecar in isolation from the C++ side.
+
+## Setup
+
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+`torch` is a real ~500MB dependency, pulled in transitively by `lmcache` even for CPU-only KV
+offload -- there is no way around it while using LMCache's real API (see `requirements.txt`'s
+comment).
+
+## Run standalone
+
+```bash
+python3 lmcache_bridge.py \
+  --socket /tmp/sparkinfer_lmcache.sock \
+  --num-layers 52 --num-kv-heads 2 --head-dim 128 --block-size 16 \
+  --elem-bytes 1 --int8-kv \
+  --model-name muse-glimmer-30B \
+  --log-level DEBUG
+```
+
+The KV layout flags must match whatever the C++ side's `BridgeKVLayout` actually is (see
+`runtime/include/sparkinfer/lmcache_bridge_client.h`) -- a mismatched HELLO from the C++ side is
+rejected (see the protocol doc's HELLO_ACK semantics), not silently coerced.
+
+Engine construction (first-time `torch`/`lmcache` import + `LMCacheEngineBuilder.get_or_create()`
++ `post_init()`) takes on the order of 10 seconds and happens *before* the socket is even bound --
+this is deliberate, not a bug (see `BridgeServer`'s docstring in `lmcache_bridge.py`): it keeps
+that cost out of any timeout-bound request path on the C++ side.
+
+Useful env vars (see the protocol doc / `lmcache_bridge.py` for the full list):
+- `SPARKINFER_LMCACHE_CHUNK_SIZE` (default 256) -- must be a multiple of `--block-size`.
+- `SPARKINFER_LMCACHE_MAX_CPU_GB` (default 4.0) -- CPU-RAM backend size cap.
+- `LMCACHE_TRACK_USAGE=false` / `DO_NOT_TRACK=1` -- set automatically by `lmcache_bridge.py`
+  itself before importing `lmcache` (it phones home to `stats.lmcache.ai:8080` otherwise, found
+  during development to hang indefinitely in a restricted-network sandbox). Override only if you
+  specifically want telemetry back on.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s tests -v
+```
+
+`tests/test_protocol.py` is pure unit tests, no dependencies beyond the standard library.
+`tests/test_bridge_e2e.py` spawns a real sidecar subprocess against the real `lmcache` CPU-RAM
+backend and round-trips actual bytes through it (skipped automatically if `lmcache` isn't
+installed) -- slow (~15-30s, dominated by the cold engine-construction cost above), but this is
+the test that actually caught a real bug during development: an early version's `LMCacheMetadata`
+`kv_shape` silently under-sized LMCache's internal buffer by exactly `elem_bytes`, corrupting the
+back half of every retrieved chunk. Don't skip re-running it after touching `ShmConnector` or
+`build_engine()`'s shape/dtype math in `lmcache_bridge.py`.

--- a/bridge/lmcache_bridge.py
+++ b/bridge/lmcache_bridge.py
@@ -1,0 +1,479 @@
+#!/usr/bin/env python3
+"""sparkinfer <-> LMCache sidecar. Embeds the real `lmcache` package via its documented
+in-process API and speaks ../docs/lmcache_bridge_protocol.md back to sparkinfer's C++ server.
+
+Run standalone for debugging: see bridge/README.md.
+"""
+from __future__ import annotations
+
+# LMCache phones home to stats.lmcache.ai:8080 for usage telemetry by default, with no fast
+# timeout observed in a restricted-network environment during development (see the Stage 1 spike
+# notes in the protocol doc) -- these MUST be set before `import lmcache` anywhere below, or
+# engine construction can hang.
+import os
+
+os.environ.setdefault("LMCACHE_TRACK_USAGE", "false")
+os.environ.setdefault("DO_NOT_TRACK", "1")
+
+import argparse
+import logging
+import socket
+import sys
+import threading
+from dataclasses import dataclass, field
+from typing import Optional
+
+import torch
+
+import protocol as proto
+import shm_transfer as shm
+
+logger = logging.getLogger("lmcache_bridge")
+
+
+# --- the connector: LMCache's real integration point (lmcache.v1.gpu_connector.GPUConnectorInterface) ---
+#
+# Confirmed via the Stage 1 spike: this is what a non-vLLM/non-SGLang caller implements. Instead
+# of a real GPU, to_gpu/from_gpu read/write a POSIX shm region this sidecar creates per request.
+# Addressing is deterministic from token position (chunk_index = (tok - base) // chunk_size),
+# not from call order, since LMCache's internal chunk splitting order isn't part of its public
+# contract -- this lets the connector stay correct regardless of what order to_gpu/from_gpu fire.
+
+
+class ShmConnector:
+    """One instance shared by the whole sidecar process (LMCacheEngine is a singleton per
+    instance_id). begin_request()/end_request() scope chunk_size/base_tok/mmap for the duration
+    of one store()/retrieve() call -- LMCacheEngine calls back into to_gpu/from_gpu synchronously
+    within that call, never concurrently with another request on this connector (EngineHandle.lock
+    in _handle_lookup/_handle_store serializes engine access across connections/threads).
+    """
+
+    def __init__(self, num_layers: int, kv_heads: int, head_dim: int, block_size: int,
+                elem_bytes: int, int8_kv: bool, chunk_size: int) -> None:
+        self.num_layers = num_layers
+        self.kv_heads = kv_heads
+        self.head_dim = head_dim
+        self.block_size = block_size
+        self.elem_bytes = elem_bytes
+        self.int8_kv = int8_kv
+        self.chunk_size = chunk_size
+        self.kvcaches = None  # required by GPUConnectorInterface's base initializer, unused here
+
+        self._active_mmap = None
+        self._active_base_tok = 0
+        self._touched_chunks: list[tuple[int, int]] = []  # (start_tok, end_tok) actually copied
+
+    # -- bytes-per-chunk layout, matching docs/lmcache_bridge_protocol.md's "shm region layout" --
+
+    def block_bytes(self) -> int:
+        return self.block_size * self.kv_heads * self.head_dim * self.elem_bytes
+
+    def scale_bytes_per_chunk(self, n_tok: int) -> int:
+        if not self.int8_kv:
+            return 0
+        # one fp16 (2-byte) scale per (token, kv_head), per layer -- see kv_cache.cpp's
+        # scale_layer_stride convention on the C++ side.
+        return self.num_layers * n_tok * self.kv_heads * 2
+
+    def chunk_byte_size(self, n_tok: int) -> int:
+        n_blocks = n_tok // self.block_size
+        kv_bytes = self.num_layers * 2 * n_blocks * self.block_bytes()  # K then V
+        return kv_bytes + 2 * self.scale_bytes_per_chunk(n_tok)  # K scale + V scale
+
+    def begin_request(self, mm, base_tok: int) -> None:
+        """Called by the sidecar before invoking store()/retrieve() -- `mm` is this request's
+        shm mmap, `base_tok` is the token position that chunk index 0 corresponds to."""
+        self._active_mmap = mm
+        self._active_base_tok = base_tok
+        self._touched_chunks = []
+
+    def end_request(self) -> list[tuple[int, int]]:
+        touched = self._touched_chunks
+        self._active_mmap = None
+        self._touched_chunks = []
+        return touched
+
+    def _offset_for(self, start_tok: int, n_tok: int) -> int:
+        # Deterministic from token position, not call order -- see the module docstring.
+        chunk_index = (start_tok - self._active_base_tok) // self.chunk_size
+        return chunk_index * self.chunk_byte_size(self.chunk_size) if n_tok == self.chunk_size \
+            else chunk_index * self.chunk_byte_size(self.chunk_size)  # only full chunks in v1
+
+    # -- GPUConnectorInterface --
+
+    def get_shape(self, num_tokens: Optional[int] = None):
+        n = num_tokens if num_tokens is not None else self.chunk_size
+        # Opaque byte layout -- shape is informational for LMCache's own bookkeeping, not used to
+        # interpret the bytes (kv_dtype=torch.uint8 makes every element 1 byte, see
+        # LMCacheMetadata in lmcache_bridge.py's build_engine()).
+        return torch.Size([self.chunk_byte_size(n)])
+
+    def from_gpu(self, memory_obj, start: int, end: int, **kwargs) -> None:
+        """STORE path: copy from our shm (the "GPU") into memory_obj (LMCache's own storage)."""
+        assert self._active_mmap is not None, "from_gpu called outside begin_request/end_request"
+        n_tok = end - start
+        off = self._offset_for(start, n_tok)
+        size = self.chunk_byte_size(n_tok)
+        dst = memory_obj.byte_array.cast("B")
+        n = min(len(dst), size)
+        dst[:n] = self._active_mmap[off : off + n]
+        self._touched_chunks.append((start, end))
+
+    def to_gpu(self, memory_obj, start: int, end: int, **kwargs) -> None:
+        """RETRIEVE path: copy from memory_obj (LMCache's own storage) into our shm."""
+        assert self._active_mmap is not None, "to_gpu called outside begin_request/end_request"
+        n_tok = end - start
+        off = self._offset_for(start, n_tok)
+        size = self.chunk_byte_size(n_tok)
+        src = bytes(memory_obj.byte_array.cast("B"))
+        n = min(len(src), size)
+        self._active_mmap[off : off + n] = src[:n]
+        self._touched_chunks.append((start, end))
+
+    def batched_from_gpu(self, memory_objs, starts, ends, **kwargs) -> None:
+        for mo, s, e in zip(memory_objs, starts, ends):
+            self.from_gpu(mo, s, e, **kwargs)
+
+    def batched_to_gpu(self, memory_objs, starts, ends, **kwargs) -> None:
+        for mo, s, e in zip(memory_objs, starts, ends):
+            self.to_gpu(mo, s, e, **kwargs)
+
+
+@dataclass
+class EngineHandle:
+    engine: object
+    connector: ShmConnector
+    layout: proto.HelloRequest
+    chunk_size: int
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+def build_engine(layout: proto.HelloRequest, instance_id: str) -> EngineHandle:
+    # Imported here (not at module scope) so --help / argument errors don't pay LMCache's import
+    # cost, and so the LMCACHE_TRACK_USAGE env vars above are guaranteed set first regardless of
+    # how this module is invoked.
+    from lmcache.v1.cache_engine import LMCacheEngineBuilder
+    from lmcache.v1.config import LMCacheEngineConfig
+    from lmcache.v1.metadata import LMCacheMetadata
+
+    chunk_size = int(os.environ.get("SPARKINFER_LMCACHE_CHUNK_SIZE", "256"))
+    max_local_cpu_gb = float(os.environ.get("SPARKINFER_LMCACHE_MAX_CPU_GB", "4.0"))
+
+    config = LMCacheEngineConfig.from_defaults(
+        chunk_size=chunk_size,
+        local_cpu=True,
+        max_local_cpu_size=max_local_cpu_gb,
+        remote_url=None,
+    )
+    connector = ShmConnector(
+        num_layers=layout.num_layers,
+        kv_heads=layout.num_kv_heads,
+        head_dim=layout.head_dim,
+        block_size=layout.block_size,
+        elem_bytes=layout.elem_bytes,
+        int8_kv=layout.int8_kv,
+        chunk_size=chunk_size,
+    )
+    # LMCacheMetadata.get_shapes(num_tokens) allocates MemoryObj as
+    # [kv_shape[1], kv_shape[0], num_tokens, kv_shape[3]*kv_shape[4]] elements of kv_dtype
+    # (verified by reading lmcache/v1/metadata.py -- not documented). With kv_dtype=torch.uint8
+    # (1 byte/element), that total must equal ShmConnector.chunk_byte_size(chunk_size) exactly,
+    # or store()/retrieve() allocate a MemoryObj smaller than what the connector actually
+    # writes/reads, silently truncating (found via the Stage 1 E2E test: a naive
+    # kv_shape=(layers,2,chunk_size,kv_heads,head_dim) under-sized the buffer by exactly
+    # elem_bytes, corrupting exactly the back half of every retrieved chunk). Folding
+    # elem_bytes and the int8 scale contribution into kv_shape[4] (with kv_shape[3]=1) makes
+    # the two sides agree regardless of int8_kv -- see ShmConnector.chunk_byte_size for the
+    # matching derivation.
+    per_token_bytes = layout.num_kv_heads * layout.head_dim * layout.elem_bytes
+    if layout.int8_kv:
+        per_token_bytes += layout.num_kv_heads * 2  # one fp16 scale per (token, kv_head)
+    metadata = LMCacheMetadata(
+        model_name=layout.model_name,
+        world_size=1,
+        local_world_size=1,
+        worker_id=0,
+        local_worker_id=0,
+        kv_dtype=torch.uint8,  # opaque bytes -- confirmed accepted in the Stage 1 spike
+        kv_shape=(layout.num_layers, 2, chunk_size, 1, per_token_bytes),
+        chunk_size=chunk_size,
+    )
+    engine = LMCacheEngineBuilder.get_or_create(
+        instance_id,
+        config,
+        metadata,
+        connector,
+        lambda t, r: t,  # single-worker: broadcast is a no-op
+        lambda o, r: o,
+    )
+    engine.post_init()  # required -- store()/retrieve() assert on storage_manager without it
+    return EngineHandle(engine=engine, connector=connector, layout=layout, chunk_size=chunk_size)
+
+
+class BridgeServer:
+    """Accepts multiple concurrent AF_UNIX SOCK_SEQPACKET connections (the C++ side opens two:
+    one for LOOKUP/PING, one for STORE -- see the protocol doc's "Transport" section) and serves
+    each on its own thread.
+
+    The LMCacheEngine is built once, eagerly, before serve_forever() ever accepts a connection --
+    NOT lazily from the first HELLO. That was the original design (avoids duplicating the KV
+    layout as both CLI args and a HELLO payload) but real testing found engine construction
+    (first-time `import torch`/`lmcache` plus LMCacheEngineBuilder + post_init()) takes on the
+    order of 10 seconds, which blows straight through the tight timeout budget the C++ side's
+    ctrl-connection handshake uses (SPARKINFER_LMCACHE_LOOKUP_TIMEOUT_MS, default 5ms) -- a lazy
+    build would make the sidecar's very first real handshake fail (safely, but for tens of
+    seconds after every server restart, during which the cache silently does nothing). So the KV
+    layout is CLI args here, duplicating HELLO's payload fields -- HELLO becomes a cheap
+    layout-match check against the already-built engine, not a trigger for building it.
+    """
+
+    def __init__(self, socket_path: str, engine: EngineHandle) -> None:
+        self.socket_path = socket_path
+        self._engine = engine
+
+    def sweep_orphans(self) -> None:
+        """Removes any /sparkinfer_kv_* shm regions left behind by a prior sidecar process that
+        crashed or was killed before it could unlink them (e.g. a LOOKUP hit the C++ side never
+        got around to reading). Only meaningful at startup, before any request could have
+        created a legitimate one of these -- never called mid-run."""
+        try:
+            for name in os.listdir(shm._SHM_DIR):
+                if name.startswith("sparkinfer_kv_"):
+                    shm.unlink("/" + name)
+                    logger.info("swept orphaned shm region from a prior run: %s", name)
+        except OSError:
+            pass  # /dev/shm not listable for some reason -- not fatal, just skip the sweep
+
+    def serve_forever(self) -> None:
+        self.sweep_orphans()
+        if os.path.exists(self.socket_path):
+            os.unlink(self.socket_path)
+        srv = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)
+        srv.bind(self.socket_path)
+        srv.listen(8)
+        logger.info("listening on %s", self.socket_path)
+        try:
+            while True:
+                conn, _ = srv.accept()
+                t = threading.Thread(target=self._serve_connection, args=(conn,), daemon=True)
+                t.start()
+        finally:
+            srv.close()
+            shm_path = self.socket_path
+            if os.path.exists(shm_path):
+                os.unlink(shm_path)
+
+    def _serve_connection(self, conn: socket.socket) -> None:
+        peer_layout: Optional[proto.HelloRequest] = None
+        try:
+            while True:
+                raw = conn.recv(proto.MAX_FRAME_BYTES)
+                if not raw:
+                    return  # peer closed
+                try:
+                    frame = proto.decode_frame(raw)
+                except proto.ProtocolError:
+                    logger.warning("malformed frame, dropping connection")
+                    return
+
+                if frame.msg_type == proto.HELLO:
+                    peer_layout = proto.HelloRequest.decode(frame.payload)
+                    if peer_layout != self._engine.layout:
+                        conn.send(proto.encode_frame(
+                            proto.HELLO_ACK, frame.request_id,
+                            proto.encode_hello_ack(False, "", 0, "layout mismatch: sidecar was "
+                                                   "started with a different KV layout")))
+                        return
+                    conn.send(proto.encode_frame(
+                        proto.HELLO_ACK, frame.request_id,
+                        proto.encode_hello_ack(True, _lmcache_version(), self._engine.chunk_size)))
+                elif frame.msg_type == proto.PING:
+                    conn.send(proto.encode_frame(proto.PONG, frame.request_id, b""))
+                elif frame.msg_type == proto.LOOKUP:
+                    self._handle_lookup(conn, frame, peer_layout)
+                elif frame.msg_type == proto.STORE:
+                    self._handle_store(conn, frame, peer_layout)
+                else:
+                    conn.send(proto.encode_frame(
+                        proto.ERROR_MSG, frame.request_id,
+                        proto.encode_error(f"unexpected msg_type {frame.msg_type}")))
+        except (ConnectionError, OSError):
+            pass  # peer went away -- nothing to clean up beyond closing our end
+        finally:
+            conn.close()
+
+    def _handle_lookup(self, conn: socket.socket, frame: proto.Frame,
+                       layout: Optional[proto.HelloRequest]) -> None:
+        if layout is None:
+            conn.send(proto.encode_frame(proto.ERROR_MSG, frame.request_id,
+                                         proto.encode_error("LOOKUP before HELLO")))
+            return
+        try:
+            req = proto.LookupRequest.decode(frame.payload)
+        except proto.ProtocolError as e:
+            conn.send(proto.encode_frame(proto.ERROR_MSG, frame.request_id, proto.encode_error(str(e))))
+            return
+
+        handle = self._engine
+        n_tok_aligned = (len(req.token_ids) // handle.chunk_size) * handle.chunk_size
+        if n_tok_aligned == 0:
+            conn.send(proto.encode_frame(proto.LOOKUP_RESP, frame.request_id,
+                                         proto.encode_lookup_resp(0, "", [])))
+            return
+
+        region_name = f"/sparkinfer_kv_{frame.request_id}_p"
+        n_chunks_possible = n_tok_aligned // handle.chunk_size
+        region_size = n_chunks_possible * handle.connector.chunk_byte_size(handle.chunk_size)
+        mm = shm.create(region_name, max(region_size, 1))
+        matched_tokens = 0  # set below on success; stays 0 if an exception fires first, so the
+                            # finally block below knows there is nothing for the C++ side to read
+        try:
+            with handle.lock:
+                handle.connector.begin_request(mm, base_tok=0)
+                tokens = torch.tensor(req.token_ids[:n_tok_aligned], dtype=torch.int64)
+                try:
+                    mask = handle.engine.retrieve(tokens=tokens, shm_name=region_name)
+                finally:
+                    touched = handle.connector.end_request()
+
+            # Only leading contiguous hits count -- a gap would mean decode has to recompute
+            # the missing middle anyway, so nothing after the first miss is usable as a prefix.
+            leading = 0
+            for i in range(0, n_tok_aligned, handle.chunk_size):
+                if bool(mask[i]):
+                    leading = i + handle.chunk_size
+                else:
+                    break
+            matched_tokens = leading
+
+            chunks = [
+                proto.LookupChunk(
+                    start_tok=s, len_tok=e - s,
+                    shm_offset_bytes=handle.connector._offset_for(s, e - s),
+                )
+                for (s, e) in touched
+                if s < matched_tokens
+            ]
+            conn.send(proto.encode_frame(
+                proto.LOOKUP_RESP, frame.request_id,
+                proto.encode_lookup_resp(matched_tokens, region_name if matched_tokens else "", chunks)))
+        except Exception as e:  # noqa: BLE001 -- report as ERROR, never crash the connection
+            logger.exception("LOOKUP failed")
+            conn.send(proto.encode_frame(proto.ERROR_MSG, frame.request_id, proto.encode_error(str(e))))
+        finally:
+            mm.close()
+            if matched_tokens == 0:
+                shm.unlink(region_name)
+            # else: a hit -- left for the C++ side to shm_open by name and read (protocol doc's
+            # shm lifecycle). Orphaned if the C++ side crashes before consuming it; swept on the
+            # next sidecar startup by sweep_orphans() rather than tracked/timed here.
+
+    def _handle_store(self, conn: socket.socket, frame: proto.Frame,
+                      layout: Optional[proto.HelloRequest]) -> None:
+        if layout is None:
+            conn.send(proto.encode_frame(proto.ERROR_MSG, frame.request_id,
+                                         proto.encode_error("STORE before HELLO")))
+            return
+        try:
+            req = proto.StoreRequest.decode(frame.payload)
+        except proto.ProtocolError as e:
+            conn.send(proto.encode_frame(proto.ERROR_MSG, frame.request_id, proto.encode_error(str(e))))
+            return
+
+        handle = self._engine
+        try:
+            mm = shm.attach(req.shm_name)
+        except FileNotFoundError as e:
+            conn.send(proto.encode_frame(proto.STORE_ACK, frame.request_id,
+                                         proto.encode_store_ack(False, str(e))))
+            return
+
+        try:
+            n_new = req.new_end_tok - req.new_start_tok
+            if n_new <= 0 or n_new % handle.chunk_size != 0:
+                conn.send(proto.encode_frame(
+                    proto.STORE_ACK, frame.request_id,
+                    proto.encode_store_ack(False, "store range not chunk-aligned")))
+                return
+
+            mask = torch.zeros(len(req.token_ids), dtype=torch.bool)
+            mask[req.new_start_tok : req.new_end_tok] = True
+            tokens = torch.tensor(req.token_ids, dtype=torch.int64)
+
+            with handle.lock:
+                handle.connector.begin_request(mm, base_tok=req.new_start_tok)
+                try:
+                    handle.engine.store(tokens=tokens, mask=mask)
+                finally:
+                    handle.connector.end_request()
+
+            conn.send(proto.encode_frame(proto.STORE_ACK, frame.request_id, proto.encode_store_ack(True)))
+        except Exception as e:  # noqa: BLE001
+            logger.exception("STORE failed")
+            conn.send(proto.encode_frame(proto.STORE_ACK, frame.request_id, proto.encode_store_ack(False, str(e))))
+        finally:
+            mm.close()
+            # STORE's shm region was created by the C++ side; per the protocol doc it owns
+            # unlinking (does so once it receives this STORE_ACK), not us.
+
+
+def _lmcache_version() -> str:
+    try:
+        import importlib.metadata
+
+        return importlib.metadata.version("lmcache")
+    except Exception:  # noqa: BLE001 -- informational only, never fatal
+        return "unknown"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--socket", required=True, help="AF_UNIX SOCK_SEQPACKET path to listen on")
+    parser.add_argument("--instance-id", default="sparkinfer-lmcache")
+    parser.add_argument("--log-level", default="INFO")
+    # KV layout, duplicating what HELLO also carries -- see BridgeServer's docstring for why this
+    # is CLI args and not deferred to the first HELLO (engine construction is ~10s of first-time
+    # import + setup cost that must happen before any connection is accepted, not inside one).
+    parser.add_argument("--num-layers", type=int, required=True)
+    parser.add_argument("--num-kv-heads", type=int, required=True)
+    parser.add_argument("--head-dim", type=int, required=True)
+    parser.add_argument("--block-size", type=int, required=True)
+    parser.add_argument("--int8-kv", action="store_true")
+    parser.add_argument("--elem-bytes", type=int, required=True)
+    parser.add_argument("--model-name", required=True)
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level.upper(), logging.INFO),
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+
+    layout = proto.HelloRequest(
+        num_layers=args.num_layers,
+        num_kv_heads=args.num_kv_heads,
+        head_dim=args.head_dim,
+        block_size=args.block_size,
+        int8_kv=args.int8_kv,
+        elem_bytes=args.elem_bytes,
+        model_name=args.model_name,
+    )
+    logger.info("building LMCacheEngine for layout=%s ...", layout)
+    handle = build_engine(layout, args.instance_id)
+    logger.info("LMCacheEngine ready (chunk_size=%d)", handle.chunk_size)
+
+    server = BridgeServer(args.socket, handle)
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        try:
+            from lmcache.v1.cache_engine import LMCacheEngineBuilder
+
+            LMCacheEngineBuilder.destroy(args.instance_id)
+        except Exception:  # noqa: BLE001 -- best-effort shutdown
+            pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bridge/lmcache_bridge.py
+++ b/bridge/lmcache_bridge.py
@@ -396,14 +396,32 @@ class BridgeServer:
                     proto.encode_store_ack(False, "store range not chunk-aligned")))
                 return
 
-            mask = torch.zeros(len(req.token_ids), dtype=torch.bool)
-            mask[req.new_start_tok : req.new_end_tok] = True
-            tokens = torch.tensor(req.token_ids, dtype=torch.int64)
+            # LMCache's mask contract (confirmed against the real store() docstring during the
+            # Stage 1 spike) is "FFFF...TTTT": Falses are an already-cached PREFIX to skip, Trues
+            # a SUFFIX extending to the end of `tokens` to store -- and it requires the False
+            # count to be a chunk_size multiple. That shape doesn't fit what sparkinfer actually
+            # sends: new_end_tok is often less than len(token_ids) (a trailing partial chunk
+            # beyond the chunk-aligned range genuinely isn't being stored at all, not "already
+            # cached elsewhere"), which isn't a prefix-skip/suffix-store split LMCache's mask can
+            # express. Found via the live E2E test (runtime/tests/lmcache_e2e_gpu_test.cpp):
+            # engine.store() raised "number of Falses ... not a multiple of the chunk size."
+            #
+            # Every current caller (Qwen35Model::lmcache_maybe_store in qwen35.cpp) always stores
+            # from position 0, so the fix for now is simpler than a general mask: truncate to the
+            # aligned range and pass no mask at all (mask=None means "store all of `tokens`", per
+            # store()'s own docstring). This assumes new_start_tok == 0; a future caller wanting a
+            # nonzero start would need real mask support, not implemented here.
+            if req.new_start_tok != 0:
+                conn.send(proto.encode_frame(
+                    proto.STORE_ACK, frame.request_id,
+                    proto.encode_store_ack(False, "nonzero new_start_tok not yet supported")))
+                return
+            tokens = torch.tensor(req.token_ids[: req.new_end_tok], dtype=torch.int64)
 
             with handle.lock:
                 handle.connector.begin_request(mm, base_tok=req.new_start_tok)
                 try:
-                    handle.engine.store(tokens=tokens, mask=mask)
+                    handle.engine.store(tokens=tokens)
                 finally:
                     handle.connector.end_request()
 

--- a/bridge/protocol.py
+++ b/bridge/protocol.py
@@ -1,0 +1,249 @@
+"""Wire format for the sparkinfer <-> LMCache-sidecar bridge.
+
+Python twin of runtime/src/lmcache_bridge_client.cpp's frame (de)serialization. Both sides must
+track ../docs/lmcache_bridge_protocol.md by hand -- there is no IDL/codegen in this design. If you
+change one side, update the doc and the other side's constants in the same change.
+"""
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass, field
+
+MAGIC = 0x53494B56  # 'SIKV' little-endian on the wire
+PROTOCOL_VERSION = 1
+MAX_FRAME_BYTES = 2 * 1024 * 1024  # see the protocol doc's "Framing note"
+
+# msg_type values
+HELLO = 1
+HELLO_ACK = 2
+LOOKUP = 3
+LOOKUP_RESP = 4
+STORE = 5
+STORE_ACK = 6
+PING = 7
+PONG = 8
+ERROR_MSG = 9
+
+# FrameHeader: magic(u32) version(u16) msg_type(u16) payload_len(u32) request_id(u32), 16 bytes.
+_HEADER_FMT = "<IHHII"
+HEADER_SIZE = struct.calcsize(_HEADER_FMT)
+assert HEADER_SIZE == 16
+
+
+class ProtocolError(Exception):
+    """A frame was malformed or failed a sanity check. Callers treat this exactly like a
+    transport failure -- log it, tear down the connection, never crash the sidecar process."""
+
+
+@dataclass
+class Frame:
+    msg_type: int
+    request_id: int
+    payload: bytes
+    version: int = PROTOCOL_VERSION
+
+
+def encode_frame(msg_type: int, request_id: int, payload: bytes) -> bytes:
+    """One bytes object carrying header+payload, meant for a single send() call -- SOCK_SEQPACKET
+    preserves message boundaries only if the whole frame goes out in one write."""
+    if len(payload) > MAX_FRAME_BYTES:
+        raise ProtocolError(f"payload too large: {len(payload)} bytes")
+    header = struct.pack(_HEADER_FMT, MAGIC, PROTOCOL_VERSION, msg_type, len(payload), request_id)
+    return header + payload
+
+
+def decode_frame(raw: bytes) -> Frame:
+    """Decodes exactly one message (the result of one recv() call). Raises ProtocolError on any
+    malformed input -- never silently accepts a truncated or corrupt frame."""
+    if len(raw) < HEADER_SIZE:
+        raise ProtocolError(f"frame too short: {len(raw)} bytes")
+    magic, version, msg_type, payload_len, request_id = struct.unpack(
+        _HEADER_FMT, raw[:HEADER_SIZE]
+    )
+    if magic != MAGIC:
+        raise ProtocolError(f"bad magic: {magic:#x}")
+    if HEADER_SIZE + payload_len != len(raw):
+        raise ProtocolError(
+            f"payload_len mismatch: header says {payload_len}, got {len(raw) - HEADER_SIZE}"
+        )
+    return Frame(msg_type=msg_type, request_id=request_id, payload=raw[HEADER_SIZE:], version=version)
+
+
+class Writer:
+    """Accumulates a payload matching BridgeClient's put_* helpers byte-for-byte."""
+
+    def __init__(self) -> None:
+        self._parts: list[bytes] = []
+
+    def u8(self, v: int) -> "Writer":
+        self._parts.append(struct.pack("<B", v))
+        return self
+
+    def u32(self, v: int) -> "Writer":
+        self._parts.append(struct.pack("<I", v))
+        return self
+
+    def u64(self, v: int) -> "Writer":
+        self._parts.append(struct.pack("<Q", v))
+        return self
+
+    def i32(self, v: int) -> "Writer":
+        self._parts.append(struct.pack("<i", v))
+        return self
+
+    def str(self, s: str) -> "Writer":
+        b = s.encode("utf-8")
+        self._parts.append(struct.pack("<I", len(b)))
+        self._parts.append(b)
+        return self
+
+    def bytes(self) -> bytes:
+        return b"".join(self._parts)
+
+
+@dataclass
+class Reader:
+    """Cursor-based reader mirroring BridgeClient's Reader: every getter raises ProtocolError on
+    underflow instead of letting struct.unpack throw a raw exception, so callers get one
+    consistent error type to catch."""
+
+    data: bytes
+    offset: int = field(default=0)
+
+    def _need(self, n: int) -> None:
+        if self.offset + n > len(self.data):
+            raise ProtocolError(
+                f"read past end: need {n} bytes at offset {self.offset}, have {len(self.data)}"
+            )
+
+    def u8(self) -> int:
+        self._need(1)
+        v = self.data[self.offset]
+        self.offset += 1
+        return v
+
+    def u32(self) -> int:
+        self._need(4)
+        v = struct.unpack_from("<I", self.data, self.offset)[0]
+        self.offset += 4
+        return v
+
+    def u64(self) -> int:
+        self._need(8)
+        v = struct.unpack_from("<Q", self.data, self.offset)[0]
+        self.offset += 8
+        return v
+
+    def i32(self) -> int:
+        self._need(4)
+        v = struct.unpack_from("<i", self.data, self.offset)[0]
+        self.offset += 4
+        return v
+
+    def str(self) -> str:
+        n = self.u32()
+        self._need(n)
+        s = self.data[self.offset : self.offset + n].decode("utf-8")
+        self.offset += n
+        return s
+
+    def i32_array(self, n: int) -> list[int]:
+        self._need(4 * n)
+        vals = list(struct.unpack_from(f"<{n}i", self.data, self.offset))
+        self.offset += 4 * n
+        return vals
+
+
+# --- message-specific helpers ---------------------------------------------------------------
+#
+# These encode/decode the payload bodies described in the protocol doc. Kept here (not spread
+# across lmcache_bridge.py) so the wire format has one home on the Python side, matching how the
+# C++ side keeps put_*/Reader next to the frame helpers rather than in the caller.
+
+
+@dataclass
+class HelloRequest:
+    num_layers: int
+    num_kv_heads: int
+    head_dim: int
+    block_size: int
+    int8_kv: bool
+    elem_bytes: int
+    model_name: str
+
+    @staticmethod
+    def decode(payload: bytes) -> "HelloRequest":
+        r = Reader(payload)
+        return HelloRequest(
+            num_layers=r.u32(),
+            num_kv_heads=r.u32(),
+            head_dim=r.u32(),
+            block_size=r.u32(),
+            int8_kv=bool(r.u8()),
+            elem_bytes=r.u32(),
+            model_name=r.str(),
+        )
+
+
+def encode_hello_ack(ok: bool, lmcache_version: str, chunk_size_tokens: int, error: str = "") -> bytes:
+    return (
+        Writer()
+        .u8(1 if ok else 0)
+        .str(lmcache_version)
+        .u32(chunk_size_tokens)
+        .str(error)
+        .bytes()
+    )
+
+
+@dataclass
+class LookupRequest:
+    token_ids: list[int]
+
+    @staticmethod
+    def decode(payload: bytes) -> "LookupRequest":
+        r = Reader(payload)
+        n = r.u32()
+        return LookupRequest(token_ids=r.i32_array(n))
+
+
+@dataclass
+class LookupChunk:
+    start_tok: int
+    len_tok: int
+    shm_offset_bytes: int
+
+
+def encode_lookup_resp(matched_tokens: int, shm_name: str, chunks: list[LookupChunk]) -> bytes:
+    w = Writer().i32(matched_tokens).str(shm_name).u32(len(chunks))
+    for c in chunks:
+        w.i32(c.start_tok).i32(c.len_tok).u64(c.shm_offset_bytes)
+    return w.bytes()
+
+
+@dataclass
+class StoreRequest:
+    token_ids: list[int]
+    new_start_tok: int
+    new_end_tok: int
+    shm_name: str
+
+    @staticmethod
+    def decode(payload: bytes) -> "StoreRequest":
+        r = Reader(payload)
+        n = r.u32()
+        token_ids = r.i32_array(n)
+        new_start = r.u32()
+        new_end = r.u32()
+        shm_name = r.str()
+        return StoreRequest(
+            token_ids=token_ids, new_start_tok=new_start, new_end_tok=new_end, shm_name=shm_name
+        )
+
+
+def encode_store_ack(ok: bool, error: str = "") -> bytes:
+    return Writer().u8(1 if ok else 0).str(error).bytes()
+
+
+def encode_error(message: str) -> bytes:
+    return Writer().str(message).bytes()

--- a/bridge/requirements.txt
+++ b/bridge/requirements.txt
@@ -1,0 +1,17 @@
+# Pinned exact -- lmcache's real store()/retrieve() API surface used here
+# (lmcache.v1.cache_engine.LMCacheEngineBuilder, lmcache.v1.gpu_connector.GPUConnectorInterface,
+# lmcache.v1.metadata.LMCacheMetadata) is not lmcache's actively-promoted integration path (that's
+# MP-mode's standalone server, see docs/lmcache_bridge_protocol.md), so its signatures are not
+# guaranteed stable release to release. Bump deliberately, re-run bridge/tests/ (especially
+# test_bridge_e2e.py's byte-identical round-trip check) before trusting a newer version, not as a
+# routine dependency bump.
+lmcache==0.5.3
+
+# Pulled in transitively by lmcache even for CPU-only KV offload (it represents KV cache data as
+# torch tensors regardless of backend) -- a real, sizeable dependency (~500MB wheel), not optional.
+# CPU-only build is sufficient; the sidecar never touches a GPU itself (see ShmConnector in
+# lmcache_bridge.py -- it stands in for what would otherwise be real device memory).
+torch==2.13.0
+
+# Python >= 3.10 required (lmcache's own floor as of 0.5.3; this bridge's code uses no
+# newer-than-3.10 syntax itself).

--- a/bridge/shm_transfer.py
+++ b/bridge/shm_transfer.py
@@ -1,0 +1,65 @@
+"""POSIX shared-memory helpers for the LMCache sidecar.
+
+Deliberately does NOT use multiprocessing.shared_memory: its naming/permission behavior isn't
+guaranteed to interoperate with the C++ side's raw shm_open()/mmap() calls, and verifying that
+interop was flagged as an open question in the original design. Sidestepping it entirely: POSIX
+shm_open()-created objects are plain files under /dev/shm (that's the standard Linux
+implementation, not an implementation detail this code is gambling on), so both sides just treat
+shm as "a file under /dev/shm" via plain open()+mmap. The C++ side's shm_open("/name", ...) and
+this module's open("/dev/shm/name", ...) address the exact same object.
+"""
+from __future__ import annotations
+
+import mmap
+import os
+
+_SHM_DIR = "/dev/shm"
+
+
+def _path_for(name: str) -> str:
+    """name is a POSIX shm name (as passed on the wire, e.g. "/sparkinfer_kv_7_p") -- strip the
+    leading slash sparkinfer's protocol always includes, since /dev/shm/<name> is not itself
+    slash-prefixed."""
+    return os.path.join(_SHM_DIR, name.lstrip("/"))
+
+
+def create(name: str, size: int) -> mmap.mmap:
+    """Creates a new shm region of exactly `size` bytes and returns it mapped read/write. Raises
+    FileExistsError if name is already in use -- callers should pick unique names (the protocol
+    doc's convention is /sparkinfer_kv_<request_id>_<side>, which request_id already makes
+    unique) rather than this module silently overwriting something.
+    """
+    path = _path_for(name)
+    fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600)
+    try:
+        os.ftruncate(fd, size)
+        return mmap.mmap(fd, size)
+    finally:
+        os.close(fd)  # the mapping keeps the underlying object alive; the fd itself is not needed
+
+
+def attach(name: str) -> mmap.mmap:
+    """Maps an existing shm region (created by the peer) read/write, sized to whatever it
+    actually is. Raises FileNotFoundError if the region doesn't exist -- callers should treat
+    that as a protocol-level error (the peer's shm_name was stale or never created), not retry
+    silently.
+    """
+    path = _path_for(name)
+    fd = os.open(path, os.O_RDWR)
+    try:
+        size = os.fstat(fd).st_size
+        return mmap.mmap(fd, size)
+    finally:
+        os.close(fd)
+
+
+def unlink(name: str) -> None:
+    """Removes the name from /dev/shm. Safe to call even if already removed (e.g. by the peer) --
+    matches the C++ side's shm_unlink() being a similarly best-effort cleanup call. Existing
+    mappings stay valid after unlink (standard POSIX shm semantics); this only removes the name
+    other opens would use to find it.
+    """
+    try:
+        os.unlink(_path_for(name))
+    except FileNotFoundError:
+        pass

--- a/bridge/tests/test_bridge_e2e.py
+++ b/bridge/tests/test_bridge_e2e.py
@@ -1,0 +1,167 @@
+"""Integration test for bridge/lmcache_bridge.py: a real sidecar subprocess, the real `lmcache`
+CPU-RAM backend, and a raw-socket test client following protocol.py (standing in for the C++
+BridgeClient, which this repo has no Python bindings to exercise from here).
+
+Skipped automatically if `lmcache` isn't installed (see bridge/requirements.txt) -- this is a
+heavy, real dependency (torch included), not something every CI environment running the rest of
+sparkinfer's tests is expected to have.
+
+Slow: real engine construction (first-time torch/lmcache import + LMCacheEngineBuilder +
+post_init()) takes on the order of 10 seconds. That cost is why lmcache_bridge.py builds the
+engine eagerly at startup rather than lazily on first HELLO -- see BridgeServer's docstring.
+"""
+import importlib.util
+import os
+import socket
+import subprocess
+import sys
+import time
+import unittest
+
+_BRIDGE_DIR = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, _BRIDGE_DIR)
+
+import protocol as proto  # noqa: E402
+import shm_transfer as shm  # noqa: E402
+
+_HAVE_LMCACHE = importlib.util.find_spec("lmcache") is not None
+
+NUM_LAYERS, KV_HEADS, HEAD_DIM, BLOCK_SIZE = 4, 2, 8, 16
+CHUNK_SIZE = 256
+
+
+def _recv_frame(conn: socket.socket) -> proto.Frame:
+    return proto.decode_frame(conn.recv(proto.MAX_FRAME_BYTES))
+
+
+def _hello(conn: socket.socket, req_id: int) -> int:
+    payload = (
+        proto.Writer()
+        .u32(NUM_LAYERS).u32(KV_HEADS).u32(HEAD_DIM).u32(BLOCK_SIZE)
+        .u8(0).u32(2).str("e2e-test-model").bytes()
+    )
+    conn.send(proto.encode_frame(proto.HELLO, req_id, payload))
+    f = _recv_frame(conn)
+    assert f.msg_type == proto.HELLO_ACK, f
+    r = proto.Reader(f.payload)
+    ok = r.u8()
+    r.str()  # lmcache_version, unchecked
+    chunk_size = r.u32()
+    err = r.str()
+    assert ok == 1, err
+    return chunk_size
+
+
+@unittest.skipUnless(_HAVE_LMCACHE, "lmcache not installed (see bridge/requirements.txt)")
+class BridgeE2ETest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.sock_path = f"/tmp/sparkinfer_lmcache_e2e_{os.getpid()}.sock"
+        if os.path.exists(self.sock_path):
+            os.unlink(self.sock_path)
+
+        env = dict(os.environ)
+        env["LMCACHE_TRACK_USAGE"] = "false"
+        env["DO_NOT_TRACK"] = "1"
+        env["SPARKINFER_LMCACHE_CHUNK_SIZE"] = str(CHUNK_SIZE)
+        self.proc = subprocess.Popen(
+            [sys.executable, os.path.join(_BRIDGE_DIR, "lmcache_bridge.py"),
+             "--socket", self.sock_path, "--instance-id", f"e2e-{os.getpid()}",
+             "--log-level", "WARNING",
+             "--num-layers", str(NUM_LAYERS), "--num-kv-heads", str(KV_HEADS),
+             "--head-dim", str(HEAD_DIM), "--block-size", str(BLOCK_SIZE),
+             "--elem-bytes", "2", "--model-name", "e2e-test-model"],
+            env=env, cwd=_BRIDGE_DIR,
+        )
+        for _ in range(300):  # up to 30s for cold engine construction
+            if os.path.exists(self.sock_path):
+                break
+            time.sleep(0.1)
+        else:
+            self.proc.kill()
+            raise RuntimeError("sidecar never created its socket within 30s")
+        time.sleep(0.5)  # let listen() actually start accepting
+
+    def tearDown(self) -> None:
+        self.proc.terminate()
+        try:
+            self.proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            self.proc.kill()
+        if os.path.exists(self.sock_path):
+            os.unlink(self.sock_path)
+
+    def test_lookup_miss_store_lookup_hit_byte_identical(self):
+        ctrl = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)
+        self.addCleanup(ctrl.close)
+        ctrl.settimeout(10)
+        ctrl.connect(self.sock_path)
+        self.assertEqual(_hello(ctrl, 1), CHUNK_SIZE)
+
+        token_ids = list(range(1000, 1000 + CHUNK_SIZE))
+        lookup_payload = proto.Writer().u32(len(token_ids))
+        for t in token_ids:
+            lookup_payload.i32(t)
+
+        # miss before anything is stored
+        ctrl.send(proto.encode_frame(proto.LOOKUP, 2, lookup_payload.bytes()))
+        f = _recv_frame(ctrl)
+        r = proto.Reader(f.payload)
+        matched = r.i32()
+        self.assertEqual(matched, 0, "expected a miss before any STORE")
+
+        # store on a second connection (mirrors BridgeClient's separate STORE connection)
+        store_conn = socket.socket(socket.AF_UNIX, socket.SOCK_SEQPACKET)
+        self.addCleanup(store_conn.close)
+        store_conn.settimeout(10)
+        store_conn.connect(self.sock_path)
+        self.assertEqual(_hello(store_conn, 3), CHUNK_SIZE)
+
+        block_bytes = BLOCK_SIZE * KV_HEADS * HEAD_DIM * 2
+        n_blocks = CHUNK_SIZE // BLOCK_SIZE
+        chunk_bytes = NUM_LAYERS * 2 * n_blocks * block_bytes
+        fake_kv = bytearray((i * 37 + 11) % 256 for i in range(chunk_bytes))
+
+        store_region = f"/sparkinfer_kv_{os.getpid()}_c"
+        mm = shm.create(store_region, len(fake_kv))
+        mm[:] = fake_kv
+        mm.close()
+
+        store_payload = proto.Writer().u32(len(token_ids))
+        for t in token_ids:
+            store_payload.i32(t)
+        store_payload.u32(0).u32(CHUNK_SIZE).str(store_region)
+        store_conn.send(proto.encode_frame(proto.STORE, 4, store_payload.bytes()))
+        f = _recv_frame(store_conn)
+        self.assertEqual(f.msg_type, proto.STORE_ACK)
+        r = proto.Reader(f.payload)
+        ok = r.u8()
+        err = r.str()
+        self.assertEqual(ok, 1, err)
+        # STORE's shm region is created (and unlinked) by the creator, per the protocol doc --
+        # this test stands in for the C++ side, which unlinks after receiving the ack.
+        shm.unlink(store_region)
+
+        # hit after storing
+        ctrl.send(proto.encode_frame(proto.LOOKUP, 5, lookup_payload.bytes()))
+        f = _recv_frame(ctrl)
+        r = proto.Reader(f.payload)
+        matched = r.i32()
+        shm_name = r.str()
+        n_chunks = r.u32()
+        chunks = [(r.i32(), r.i32(), r.u64()) for _ in range(n_chunks)]
+        self.assertEqual(matched, CHUNK_SIZE)
+        self.assertEqual(chunks, [(0, CHUNK_SIZE, 0)])
+
+        got = shm.attach(shm_name)
+        got_bytes = bytes(got[chunks[0][2]: chunks[0][2] + chunk_bytes])
+        got.close()
+        shm.unlink(shm_name)
+        self.assertEqual(got_bytes, bytes(fake_kv), "retrieved KV bytes must be byte-identical to what was stored")
+
+        ctrl.send(proto.encode_frame(proto.PING, 6, b""))
+        f = _recv_frame(ctrl)
+        self.assertEqual(f.msg_type, proto.PONG)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bridge/tests/test_protocol.py
+++ b/bridge/tests/test_protocol.py
@@ -1,0 +1,135 @@
+"""Unit tests for bridge/protocol.py's frame + payload (de)serialization."""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import protocol as proto  # noqa: E402
+
+
+class FrameTests(unittest.TestCase):
+    def test_round_trip(self):
+        frame = proto.encode_frame(proto.LOOKUP, request_id=42, payload=b"hello")
+        f = proto.decode_frame(frame)
+        self.assertEqual(f.msg_type, proto.LOOKUP)
+        self.assertEqual(f.request_id, 42)
+        self.assertEqual(f.payload, b"hello")
+        self.assertEqual(f.version, proto.PROTOCOL_VERSION)
+
+    def test_empty_payload(self):
+        f = proto.decode_frame(proto.encode_frame(proto.PING, 1, b""))
+        self.assertEqual(f.payload, b"")
+
+    def test_too_short_raises(self):
+        with self.assertRaises(proto.ProtocolError):
+            proto.decode_frame(b"\x00" * 4)
+
+    def test_bad_magic_raises(self):
+        raw = bytearray(proto.encode_frame(proto.PING, 1, b""))
+        raw[0] ^= 0xFF
+        with self.assertRaises(proto.ProtocolError):
+            proto.decode_frame(bytes(raw))
+
+    def test_payload_len_mismatch_raises(self):
+        raw = proto.encode_frame(proto.PING, 1, b"") + b"\x00"  # trailing garbage byte
+        with self.assertRaises(proto.ProtocolError):
+            proto.decode_frame(raw)
+
+    def test_oversized_payload_rejected_at_encode(self):
+        with self.assertRaises(proto.ProtocolError):
+            proto.encode_frame(proto.STORE, 1, b"\x00" * (proto.MAX_FRAME_BYTES + 1))
+
+
+class ReaderWriterTests(unittest.TestCase):
+    def test_all_field_types_round_trip(self):
+        w = proto.Writer().u8(200).u32(0xDEADBEEF).u64(0x0123456789ABCDEF).i32(-12345).str("héllo")
+        r = proto.Reader(w.bytes())
+        self.assertEqual(r.u8(), 200)
+        self.assertEqual(r.u32(), 0xDEADBEEF)
+        self.assertEqual(r.u64(), 0x0123456789ABCDEF)
+        self.assertEqual(r.i32(), -12345)
+        self.assertEqual(r.str(), "héllo")
+
+    def test_i32_array(self):
+        w = proto.Writer()
+        for v in (-5, 0, 100, 99999):
+            w.i32(v)
+        r = proto.Reader(w.bytes())
+        self.assertEqual(r.i32_array(4), [-5, 0, 100, 99999])
+
+    def test_underflow_raises_not_crashes(self):
+        r = proto.Reader(b"\x01\x02")
+        with self.assertRaises(proto.ProtocolError):
+            r.u32()
+
+    def test_truncated_string_raises(self):
+        # length prefix claims more bytes than are actually present
+        raw = proto.Writer().u32(100).bytes()  # no string bytes follow
+        r = proto.Reader(raw)
+        with self.assertRaises(proto.ProtocolError):
+            r.str()
+
+
+class MessageHelperTests(unittest.TestCase):
+    def test_hello_request_round_trip(self):
+        payload = (
+            proto.Writer()
+            .u32(52).u32(2).u32(128).u32(16).u8(1).u32(1).str("muse-glimmer-30B")
+            .bytes()
+        )
+        req = proto.HelloRequest.decode(payload)
+        self.assertEqual(req.num_layers, 52)
+        self.assertEqual(req.num_kv_heads, 2)
+        self.assertEqual(req.head_dim, 128)
+        self.assertEqual(req.block_size, 16)
+        self.assertTrue(req.int8_kv)
+        self.assertEqual(req.elem_bytes, 1)
+        self.assertEqual(req.model_name, "muse-glimmer-30B")
+
+    def test_hello_ack_round_trip(self):
+        payload = proto.encode_hello_ack(True, "0.5.3", 256)
+        r = proto.Reader(payload)
+        self.assertEqual(r.u8(), 1)
+        self.assertEqual(r.str(), "0.5.3")
+        self.assertEqual(r.u32(), 256)
+        self.assertEqual(r.str(), "")
+
+    def test_lookup_request_round_trip(self):
+        payload = proto.Writer().u32(3).i32(1).i32(2).i32(3).bytes()
+        req = proto.LookupRequest.decode(payload)
+        self.assertEqual(req.token_ids, [1, 2, 3])
+
+    def test_lookup_resp_round_trip(self):
+        chunks = [proto.LookupChunk(0, 256, 0), proto.LookupChunk(256, 256, 65536)]
+        payload = proto.encode_lookup_resp(512, "/sparkinfer_kv_1_p", chunks)
+        r = proto.Reader(payload)
+        self.assertEqual(r.i32(), 512)
+        self.assertEqual(r.str(), "/sparkinfer_kv_1_p")
+        n = r.u32()
+        self.assertEqual(n, 2)
+        got = [(r.i32(), r.i32(), r.u64()) for _ in range(n)]
+        self.assertEqual(got, [(0, 256, 0), (256, 256, 65536)])
+
+    def test_store_request_round_trip(self):
+        payload = (
+            proto.Writer().u32(4).i32(10).i32(11).i32(12).i32(13)
+            .u32(0).u32(4).str("/sparkinfer_kv_2_c")
+            .bytes()
+        )
+        req = proto.StoreRequest.decode(payload)
+        self.assertEqual(req.token_ids, [10, 11, 12, 13])
+        self.assertEqual(req.new_start_tok, 0)
+        self.assertEqual(req.new_end_tok, 4)
+        self.assertEqual(req.shm_name, "/sparkinfer_kv_2_c")
+
+    def test_store_ack_round_trip(self):
+        payload = proto.encode_store_ack(False, "layout mismatch")
+        r = proto.Reader(payload)
+        self.assertEqual(r.u8(), 0)
+        self.assertEqual(r.str(), "layout mismatch")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/lmcache_bridge_protocol.md
+++ b/docs/lmcache_bridge_protocol.md
@@ -1,0 +1,249 @@
+# sparkinfer &lt;-&gt; LMCache bridge wire protocol
+
+Authoritative spec for the protocol between sparkinfer's C++ server (`runtime/src/lmcache_bridge_client.cpp`)
+and the Python sidecar (`bridge/lmcache_bridge.py`) that embeds the real `lmcache` package. Both sides'
+constants must track this document by hand — there is no IDL/codegen in this design (deliberately, to avoid
+a gRPC/protobuf dependency neither side otherwise needs). If you change one side, update this doc and the
+other side's constants in the same change; the HELLO handshake's version check refuses to talk on any
+mismatch rather than guessing.
+
+See `/home/autotiny/.claude/plans/fuzzy-riding-taco.md` for the overall design this protocol serves.
+
+## Why this exists
+
+LMCache's only stable, documented integration surface is a Python in-process API
+(`lmcache.v1.cache_engine.LMCacheEngineBuilder`/`LMCacheEngine`, driving a caller-supplied
+`GPUConnectorInterface` subclass — confirmed by reading the installed package source and round-tripping
+`store()`/`retrieve()` against it, see the Stage 1 spike notes below). sparkinfer is pure C++/CUDA with no
+Python serving layer. Rather than embed CPython in sparkinfer's tuned single-worker-thread hot path, or
+reverse-engineer LMCache's undocumented, pickle-based standalone-server wire protocol, a small sidecar
+process embeds LMCache the way it's actually meant to be used, and speaks this protocol — designed and
+owned by sparkinfer — back to the C++ server.
+
+## Transport
+
+`AF_UNIX` `SOCK_SEQPACKET` — message-based, so neither side hand-rolls stream reassembly. One socket path
+per sparkinfer server instance, passed to the sidecar at spawn time (`--socket <path>`). Fall back to
+`SOCK_STREAM` + the length prefix below only if `SOCK_SEQPACKET` proves awkward from Python's `socket`
+module during implementation (not expected, but not load-bearing either way since the frame already carries
+its own length).
+
+## Frame format
+
+Fixed 16-byte header, little-endian, followed by `payload_len` bytes of payload:
+
+```c
+struct FrameHeader {
+    uint32_t magic;        // 0x53494B56 ('SIKV', ASCII "SIKV" byte-swapped by LE encoding)
+    uint16_t version;      // protocol version -- see "Versioning" below
+    uint16_t msg_type;     // one of the MsgType values below
+    uint32_t payload_len;  // bytes following this header
+    uint32_t request_id;   // caller-assigned, echoed back in the matching response
+};
+```
+
+`MsgType`:
+
+| value | name           | direction       |
+|-------|----------------|-----------------|
+| 1     | HELLO          | C++ -> sidecar  |
+| 2     | HELLO_ACK      | sidecar -> C++  |
+| 3     | LOOKUP         | C++ -> sidecar  |
+| 4     | LOOKUP_RESP    | sidecar -> C++  |
+| 5     | STORE          | C++ -> sidecar  |
+| 6     | STORE_ACK      | sidecar -> C++  |
+| 7     | PING           | C++ -> sidecar  |
+| 8     | PONG           | sidecar -> C++  |
+| 9     | ERROR          | sidecar -> C++  |
+
+All multi-byte payload fields are little-endian. Strings are length-prefixed (`uint32` byte length,
+followed by raw UTF-8 bytes, no NUL terminator).
+
+## Versioning
+
+`version` starts at `1`. HELLO carries the sender's version; HELLO_ACK carries the sidecar's. Any mismatch
+is an ERROR + connection close — the C++ side treats this exactly like "sidecar unavailable" (see
+Degradation below), never a fatal server error. Bump `version` on any wire-format change to any message
+(new/removed/reordered field, changed type) and update both sides in the same change.
+
+## Messages
+
+### HELLO (C++ -> sidecar)
+
+Sent once, immediately after connect, before any LOOKUP/STORE. Payload:
+
+```
+uint32 num_layers
+uint32 num_kv_heads
+uint32 head_dim
+uint32 block_size          // sparkinfer's KVCacheManager block_size (tokens/block)
+uint8  int8_kv             // 0 = bf16 KV, 1 = int8 K/V + fp16 per-(token,kv_head) scale
+uint32 elem_bytes          // bytes per K or V element (2 for bf16, 1 for int8)
+str    model_name          // metadata.model_name for the sidecar's LMCacheMetadata
+```
+
+### HELLO_ACK (sidecar -> C++)
+
+```
+uint8  ok                  // 0 = reject (layout unsupported / config error), 1 = accept
+str    lmcache_version     // str(importlib.metadata.version("lmcache")), informational
+uint32 chunk_size_tokens   // LMCache's configured chunk_size (sparkinfer default: 256)
+str    error                // present (possibly empty) even when ok=1; human-readable on ok=0
+```
+
+If `ok=0`, the sidecar closes the connection after sending this frame. The C++ side must not retry the
+handshake on the same connection; the reconnect/cooldown logic (see Degradation) applies as if the
+connection had failed outright.
+
+### LOOKUP (C++ -> sidecar)
+
+Sent once per eligible prefill (see the gating rule below), before starting the token-loop/batched dispatch
+for the range about to be (re)computed.
+
+```
+uint32    n_tokens
+int32[n]  token_ids
+```
+
+Gating rule (enforced on the C++ side, not the sidecar): only sent when the range about to be recomputed is
+`>= chunk_size_tokens` (one LMCache chunk, 256 by default) — below that, sparkinfer always recomputes
+locally without asking. This bounds the IPC round trip to cases where it can plausibly pay off.
+
+### LOOKUP_RESP (sidecar -> C++)
+
+```
+uint32 matched_tokens       // 0 = miss; otherwise the longest matched prefix length, a multiple of
+                             // chunk_size_tokens
+str    shm_name             // POSIX shm object name holding the matched KV bytes (empty if matched_tokens==0)
+uint32 n_chunks
+repeated n_chunks:
+    uint32 chunk_start_tok
+    uint32 chunk_len_tok
+    uint64 shm_offset_bytes  // byte offset of this chunk's data within shm_name (K region; see
+                              // "shm region layout" below for how V and int8 scales are located)
+```
+
+The sidecar has already copied the matched bytes into a freshly created shm region by the time this
+response is sent (see Stage 3 in the plan: contiguous staging buffer, not per-block zero-copy, for v1). The
+C++ side is responsible for `shm_unlink`-ing (harmless if the sidecar already did) once it has finished
+`mmap`-reading, per the "one short-lived shm region per in-flight request" rule below.
+
+### STORE (C++ -> sidecar)
+
+Sent on `clear_prefix_cache()` (about to free an active prefix's blocks for a different one) and
+`close_session()` (session ending, prompt was `>= chunk_size_tokens`) -- never on every request.
+
+```
+uint32    n_tokens          // full token-ID context needed for LMCache's chunk hashing
+int32[n]  token_ids
+uint32    new_start_tok     // sub-range actually being stored: [new_start_tok, new_end_tok)
+uint32    new_end_tok
+str       shm_name          // shm region the C++ side already staged the KV bytes into
+```
+
+### STORE_ACK (sidecar -> C++)
+
+```
+uint8 ok
+str   error   // empty when ok=1
+```
+
+STORE is fire-and-forget from the worker thread's perspective (see "Threading" below) — the ack is
+consumed by the dedicated background STORE thread, not the worker thread that triggered the store.
+
+### PING / PONG
+
+Empty payload on both. C++ sends PING on a fixed low-frequency timer (~2s), independent of request
+traffic, so a hung-but-connected sidecar is detected even with no active requests. Three consecutive missed
+PONGs (or one failed `send`/`recv`) marks the bridge dead.
+
+### ERROR (sidecar -> C++)
+
+```
+str message
+```
+
+Sent for any request the sidecar cannot fulfill for a reason other than a normal cache miss (malformed
+frame, internal LMCache exception, etc.). The C++ side treats this identically to a timeout for that one
+request (miss / no-op) — it does not tear down the connection unless it's an ERROR sent in place of
+HELLO_ACK.
+
+## shm region layout
+
+One short-lived POSIX shm object per in-flight LOOKUP or STORE, not a long-lived pool (simpler correctness
+story for the first landable increment; a fixed ring buffer is a reasonable later optimization once traffic
+volume is measured). Naming: `/sparkinfer_kv_<request_id>_<side>` where `<side>` is `c` (created by C++, for
+STORE) or `p` (created by the sidecar/Python side, for LOOKUP's response) — the creator always
+`shm_open(O_CREAT | O_EXCL, ...)`, `ftruncate`s to the exact needed size, `mmap`s, and `shm_unlink`s
+*immediately* after mapping (safe, standard POSIX idiom — the unlink only removes the name, not the mapping,
+so the peer can still open-then-immediately-fail only if it tries to open by name after the creator unlinks;
+to avoid that race, the creator does not unlink until it has confirmed the peer no longer needs the name --
+in practice this means: STORE's creator (C++) unlinks only after receiving STORE_ACK; LOOKUP's creator
+(sidecar) unlinks only after including a `Content-Length`-equivalent (`n_chunks`/offsets) in LOOKUP_RESP,
+which the C++ side uses to `shm_open` *by name* one time within the same round trip before the sidecar
+would ever unlink -- the sidecar unlinks only after the C++ side's *next* frame (e.g. the following PING)
+confirms liveness, giving a generous window; if this ordering proves fragile in implementation, fall back to
+never unlinking proactively and instead sweeping `/dev/shm/sparkinfer_kv_*` for orphans older than a few
+seconds on sidecar startup).
+
+Layout within one region, contiguous, no padding beyond natural alignment:
+
+```
+[K bytes: num_layers * chunk_blocks * block_bytes]
+[V bytes: num_layers * chunk_blocks * block_bytes]
+[K scale bytes: num_layers * chunk_blocks * block_size * num_kv_heads * 2  -- only when int8_kv]
+[V scale bytes: num_layers * chunk_blocks * block_size * num_kv_heads * 2  -- only when int8_kv]
+```
+
+where `block_bytes = block_size * num_kv_heads * head_dim * elem_bytes` and `chunk_blocks = chunk_len_tok /
+block_size`. All of this is opaque `uint8` as far as the sidecar/LMCache is concerned (see the Stage 1 spike
+note on `LMCacheMetadata.kv_dtype = torch.uint8`) -- sparkinfer is the only side that interprets these bytes
+as bf16 or int8+scale.
+
+## Threading / must-not-block-worker-thread rule
+
+sparkinfer has exactly one worker thread driving all GPU work (`ContinuousBatchEngine::worker_loop`). It
+must never block on the sidecar indefinitely:
+
+- LOOKUP is synchronous-with-timeout: `SO_RCVTIMEO` set to `SPARKINFER_LMCACHE_LOOKUP_TIMEOUT_MS`
+  (default 5) on the socket. A timeout is treated as a miss and execution falls through to normal recompute
+  -- never an error surfaced to the request.
+- STORE is fire-and-forget from the worker thread's perspective: the worker thread hands the store
+  descriptor (already-staged shm region + token range) to one dedicated background STORE thread, which owns
+  the actual frame send + STORE_ACK wait + shm unlink. A slow or absent STORE_ACK never stalls `step_job`.
+- On any socket error, malformed frame, or ERROR-in-place-of-HELLO_ACK: mark the bridge dead, apply an
+  exponential-backoff cooldown (start 5s, cap at some reasonable ceiling e.g. 60s) before the next reconnect
+  attempt, which happens lazily on the next eligible LOOKUP/STORE rather than on a separate timer thread.
+  While dead: every LOOKUP silently returns a miss, every STORE silently no-ops. The model server never
+  refuses to serve, never surfaces a bridge-down condition as a request-visible error.
+
+## Degradation is always safe
+
+Every failure mode above (sidecar never started, sidecar crashed, HELLO layout mismatch, timeout, malformed
+frame) degrades to exactly today's behavior: no cross-request cache, full recompute. This is the single
+invariant every implementation change to this protocol must preserve.
+
+## Stage 1 spike notes (informing this spec)
+
+Confirmed against `lmcache==0.5.3` (see `/home/autotiny/.claude/plans/fuzzy-riding-taco.md` Stage 1):
+
+- `LMCacheEngineBuilder.get_or_create(instance_id, config, metadata, gpu_connector, broadcast_fn,
+  broadcast_object_fn)` then an explicit `engine.post_init()` call -- easy to miss, `store()`/`retrieve()`
+  raise `AssertionError` on `storage_manager` without it.
+- `LMCacheMetadata.kv_dtype = torch.uint8` works -- LMCache does not require an interpretable float dtype,
+  confirming the "opaque bytes" design above needs no int8-to-bf16 conversion.
+- The integration point is `lmcache.v1.gpu_connector.GPUConnectorInterface`: `to_gpu`/`from_gpu`/
+  `batched_to_gpu`/`batched_from_gpu`/`get_shape`, given a `MemoryObj` LMCache owns (its `.byte_array`
+  gives raw byte access). `bridge/lmcache_bridge.py`'s connector subclass implements these against the
+  POSIX shm regions this protocol describes, in place of a real GPU.
+- `MemoryObj.byte_array` is a ctypes-backed `memoryview` reporting an explicit-byte-order format (`<B`) --
+  CPython's memoryview slice-assignment rejects that outright (`NotImplementedError: unsupported format`).
+  Call `.cast("B")` before any slice-assignment into it.
+- LMCache phones home to `stats.lmcache.ai:8080` for usage telemetry by default, with no fast timeout in a
+  restricted-network environment -- the sidecar process **must** set `LMCACHE_TRACK_USAGE=false` and
+  `DO_NOT_TRACK=1` in its environment before importing `lmcache`, or a slow/blocked network path can hang
+  engine construction.
+- LMCache starts non-daemon background periodic threads (e.g. `PinMonitor-thread`) that keep the process
+  alive after `main()` logic completes -- the sidecar's shutdown path must call
+  `LMCacheEngineBuilder.destroy(instance_id)` (or find whatever the maintained equivalent is at
+  implementation time) rather than relying on the process exiting on its own.

--- a/docs/lmcache_bridge_protocol.md
+++ b/docs/lmcache_bridge_protocol.md
@@ -28,6 +28,14 @@ per sparkinfer server instance, passed to the sidecar at spawn time (`--socket <
 module during implementation (not expected, but not load-bearing either way since the frame already carries
 its own length).
 
+**The C++ side opens two independent connections to the same socket path, each with its own HELLO
+handshake**: a "control" connection used for LOOKUP + PING (and the initial HELLO), and a separate
+connection used only by the dedicated STORE background thread. This is deliberate, not an accident of
+implementation: LOOKUP and STORE share nothing (not even a mutex) so a slow STORE_ACK can never delay a
+LOOKUP the worker thread is waiting on within its tight timeout budget. The sidecar must accept multiple
+concurrent client connections (each gets its own `LMCacheEngine` interaction through the one underlying
+engine instance -- the engine itself is process-wide, only the socket is per-connection).
+
 ## Frame format
 
 Fixed 16-byte header, little-endian, followed by `payload_len` bytes of payload:
@@ -58,6 +66,13 @@ struct FrameHeader {
 
 All multi-byte payload fields are little-endian. Strings are length-prefixed (`uint32` byte length,
 followed by raw UTF-8 bytes, no NUL terminator).
+
+**Framing note**: `SOCK_SEQPACKET` preserves message boundaries but only if each frame (header + payload)
+is written with a single `send()`/`sendmsg()` call and read with a single `recv()` into a buffer large
+enough for the whole message -- two separate `send()` calls for header then payload would arrive as two
+separate messages, not one. Size receive buffers for the worst case: `token_ids` bounded by sparkinfer's
+max context (~163840 tokens, `kMaxBlocksPerSeq * block_size` in `kv_cache.cpp`) means a LOOKUP/STORE
+payload can approach ~640KB; implementations should size around 1-2MiB to have headroom.
 
 ## Versioning
 
@@ -104,6 +119,12 @@ for the range about to be (re)computed.
 uint32    n_tokens
 int32[n]  token_ids
 ```
+
+`token_ids` is the full prompt prefix from position 0 up to (and including) the range about to be
+recomputed -- not just the new range -- matching what STORE sends and what LMCache's own chunk hashing
+needs (chunk hashes chain off preceding chunks, per `lmcache.v1.cache_engine.LMCacheEngine.store()`'s own
+`tokens`/`mask` contract found during the Stage 1 spike). The sidecar computes matched-length and chunk
+boundaries itself; sparkinfer never computes a hash.
 
 Gating rule (enforced on the C++ side, not the sidecar): only sent when the range about to be recomputed is
 `>= chunk_size_tokens` (one LMCache chunk, 256 by default) — below that, sparkinfer always recomputes
@@ -186,7 +207,13 @@ confirms liveness, giving a generous window; if this ordering proves fragile in 
 never unlinking proactively and instead sweeping `/dev/shm/sparkinfer_kv_*` for orphans older than a few
 seconds on sidecar startup).
 
-Layout within one region, contiguous, no padding beyond natural alignment:
+Layout is per-chunk: each `LOOKUP_RESP` chunk entry's `shm_offset_bytes` points to the start of
+that chunk's own self-contained block below (sized from that chunk's own `chunk_len_tok`), not a
+single layout shared across all `n_chunks`. A multi-chunk match is `n_chunks` independent blocks
+back-to-back in the same region, each addressed by its own offset -- a reader must not assume
+chunk N+1 immediately follows chunk N's computed size; always use the offset given.
+
+Contiguous, no padding beyond natural alignment, within one chunk's block:
 
 ```
 [K bytes: num_layers * chunk_blocks * block_bytes]

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -16,7 +16,7 @@ Scoring, same-box PR-vs-main on a single pinned GPU:
               SAME GGUF, exactly the methodology validated by hand this session (commit
               6d911d4's message): qwen3_gguf_score dumps sparkinfer's per-position distribution,
               llama-server answers /completion (n_probs + cache_prompt + temperature=0) for the
-              same positions, accuracy_compare.py reports top1/KL. Bar: top1 >= 0.90, KL <= 0.20
+              same positions, accuracy_compare.py reports top1/KL. Bar: top1 >= 0.90, KL <= 0.10
               (this session achieved 0.980 / 0.0029 on the exact eval_text.txt corpus reused
               here). A PR that fails this bar is REJECTed regardless of speed — speed is
               meaningless if a PR silently breaks a still-fragile architecture's correctness.
@@ -73,7 +73,7 @@ BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
 # on the 99-token eval_text.txt corpus; bars themselves are the short-pass bars this codebase
 # already uses elsewhere, see accuracy_compare.py's own docstring bar for top-1).
 ACC_TOP1_BAR = float(os.environ.get("MUSEGLIMMER_ACC_TOP1_BAR", "0.90"))
-ACC_KL_BAR = float(os.environ.get("MUSEGLIMMER_ACC_KL_BAR", "0.20"))
+ACC_KL_BAR = float(os.environ.get("MUSEGLIMMER_ACC_KL_BAR", "0.10"))
 
 EVAL_PREFIX = "eval-museglimmer:"
 MUSEGLIMMER_MERGE_FIRST = "museglimmer-merge-first"

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -70,6 +70,12 @@ if(BUILD_EXAMPLES)
     add_executable(qwen3_gguf_bench examples/qwen3_gguf_bench.cpp)
     target_include_directories(qwen3_gguf_bench PRIVATE include)
     target_link_libraries(qwen3_gguf_bench PRIVATE sparkinfer_runtime CUDA::cudart)
+    # TTFT benchmark: LMCache cache-hit vs. full-recompute baseline on a synthetic model (see
+    # lmcache_bench.cpp's header comment for why a real GGUF isn't needed). Requires a real
+    # sidecar venv at runtime (SPARKINFER_LMCACHE_PYTHON/_BRIDGE_SCRIPT), not build time.
+    add_executable(lmcache_bench examples/lmcache_bench.cpp)
+    target_include_directories(lmcache_bench PRIVATE include)
+    target_link_libraries(lmcache_bench PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(qwen3_gguf_cb_bench examples/qwen3_gguf_cb_bench.cpp)
     target_include_directories(qwen3_gguf_cb_bench PRIVATE include)
     find_package(Threads REQUIRED)

--- a/runtime/examples/lmcache_bench.cpp
+++ b/runtime/examples/lmcache_bench.cpp
@@ -1,0 +1,268 @@
+// TTFT benchmark: LMCache-enabled (cache hit, repeated prefix) vs. baseline (full recompute) on
+// the same prompt. Uses a synthetic random-weight model, same construction as
+// runtime/tests/batch_engine_gpu_test.cpp / lmcache_e2e_gpu_test.cpp, sized larger here to give
+// prefill a realistic compute cost -- benchmark timing depends on model *shape* (layers, hidden
+// size, head counts), not trained weight *values*, so a same-shaped random model gives a
+// meaningful TTFT comparison without needing a multi-GB real GGUF download.
+//
+// Requires SPARKINFER_LMCACHE_PYTHON / SPARKINFER_LMCACHE_BRIDGE_SCRIPT pointing at a real
+// lmcache+torch venv (see bridge/README.md) -- exits early with a clear message if unset, same
+// convention as lmcache_e2e_gpu_test.cpp's skip behavior.
+#include "sparkinfer/inference_engine.h"
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/lmcache_bridge_client.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/moe/engine.h"
+#include "sparkinfer/runtime.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cuda_runtime.h>
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+void* rand_bf16(size_t n, float s) {
+    std::vector<uint16_t> h(n);
+    for (size_t i = 0; i < n; i++) {
+        float f = s * (2.f * ((i * 2654435761u + 40503u) % 1000) / 1000.f - 1.f);
+        uint32_t b;
+        __builtin_memcpy(&b, &f, 4);
+        h[i] = (uint16_t)(b >> 16);
+    }
+    void* d = nullptr;
+    cudaMalloc(&d, n * sizeof(uint16_t));
+    cudaMemcpy(d, h.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    return d;
+}
+
+void fill_weights(sparkinfer::Qwen35Weights& w, const sparkinfer::Qwen35Config& cfg) {
+    const int H = cfg.hidden, Q = cfg.n_q_heads * cfg.head_dim, KV = cfg.n_kv_heads * cfg.head_dim;
+    const int E = cfg.n_experts, F = cfg.moe_ffn;
+    w.embed_tokens = rand_bf16((size_t)cfg.vocab * H, 1.f);
+    w.final_norm = rand_bf16(H, 0.5f);
+    w.lm_head = rand_bf16((size_t)H * cfg.vocab, 0.05f);
+    w.layers.resize(cfg.n_layers);
+    for (int l = 0; l < cfg.n_layers; l++) {
+        auto& lw = w.layers[l];
+        lw.input_norm = rand_bf16(H, 0.5f);
+        lw.wq = rand_bf16((size_t)H * Q, 0.04f);
+        lw.wk = rand_bf16((size_t)H * KV, 0.04f);
+        lw.wv = rand_bf16((size_t)H * KV, 0.04f);
+        lw.wo = rand_bf16((size_t)Q * H, 0.04f);
+        lw.q_norm = rand_bf16(cfg.head_dim, 0.5f);
+        lw.k_norm = rand_bf16(cfg.head_dim, 0.5f);
+        lw.post_attn_norm = rand_bf16(H, 0.5f);
+        lw.router_w = rand_bf16((size_t)H * E, 0.1f);
+        lw.gate = rand_bf16((size_t)E * H * F, 0.04f);
+        lw.up = rand_bf16((size_t)E * H * F, 0.04f);
+        lw.down = rand_bf16((size_t)E * F * H, 0.04f);
+        lw.shared_gate = rand_bf16((size_t)H * F, 0.04f);
+        lw.shared_up = rand_bf16((size_t)H * F, 0.04f);
+        lw.shared_down = rand_bf16((size_t)F * H, 0.04f);
+    }
+}
+
+pid_t spawn_sidecar(const std::string& python, const std::string& script,
+                    const std::string& socket_path, const sparkinfer::Qwen35Config& cfg,
+                    const sparkinfer::KVCacheManager& kv) {
+    std::vector<std::string> args = {
+        python, script,
+        "--socket", socket_path,
+        "--instance-id", "lmcache-bench",
+        "--num-layers", std::to_string(cfg.n_layers),
+        "--num-kv-heads", std::to_string(cfg.n_kv_heads),
+        "--head-dim", std::to_string(cfg.head_dim),
+        "--block-size", std::to_string(kv.block_size()),
+        "--elem-bytes", std::to_string(kv.int8_kv() ? 1 : 2),
+        "--model-name", "lmcache-bench-model",
+        "--log-level", "WARNING",
+    };
+    if (kv.int8_kv()) args.push_back("--int8-kv");
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (auto& a : args) argv.push_back(const_cast<char*>(a.c_str()));
+    argv.push_back(nullptr);
+
+    const pid_t pid = fork();
+    if (pid < 0) return -1;
+    if (pid == 0) {
+        execvp(python.c_str(), argv.data());
+        fprintf(stderr, "[lmcache_bench] exec failed: %s\n", strerror(errno));
+        _exit(127);
+    }
+    return pid;
+}
+
+void terminate_sidecar(pid_t pid) {
+    if (pid <= 0) return;
+    kill(pid, SIGTERM);
+    for (int i = 0; i < 100; i++) {
+        int status = 0;
+        if (waitpid(pid, &status, WNOHANG) == pid) return;
+        usleep(100000);
+    }
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+}
+
+}  // namespace
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("no CUDA device\n");
+        return 1;
+    }
+    const char* python_env = getenv("SPARKINFER_LMCACHE_PYTHON");
+    const char* script_env = getenv("SPARKINFER_LMCACHE_BRIDGE_SCRIPT");
+    if (!python_env || !python_env[0] || !script_env || !script_env[0]) {
+        printf("SPARKINFER_LMCACHE_PYTHON / SPARKINFER_LMCACHE_BRIDGE_SCRIPT not set -- see "
+               "bridge/README.md\n");
+        return 1;
+    }
+    const int prompt_len = getenv("LMCACHE_BENCH_PROMPT_LEN") ? atoi(getenv("LMCACHE_BENCH_PROMPT_LEN")) : 4096;
+
+    auto rt = sparkinfer::Runtime::create({});
+    rt->initialize();
+
+    // Larger than the correctness test's tiny model -- realistic-enough shape for prefill
+    // compute cost to be meaningful (this is a mid-size dense-ish MoE config, not tuned to match
+    // any specific real model, just big enough that a multi-thousand-token prefill takes a
+    // measurable amount of wall-clock time).
+    sparkinfer::Qwen35Config cfg;
+    cfg.vocab = 32000;
+    cfg.hidden = 4096;
+    cfg.n_layers = 8;
+    cfg.n_q_heads = 32;
+    cfg.n_kv_heads = 4;
+    cfg.head_dim = 128;
+    cfg.n_experts = 8;
+    cfg.top_k = 2;
+    cfg.n_shared = 1;
+    cfg.moe_ffn = 1024;
+    cfg.max_seq = prompt_len + 256;
+    cfg.eos_id = -1;
+
+    sparkinfer::KVCacheConfig kvc;
+    kvc.num_layers = cfg.n_layers;
+    kvc.num_kv_heads = cfg.n_kv_heads;
+    kvc.head_dim = cfg.head_dim;
+    kvc.block_size = 16;
+    sparkinfer::KVCacheManager kv(kvc, 4ull * 1024 * 1024 * 1024);
+
+    sparkinfer::moe::MoEConfig mc;
+    mc.num_experts = cfg.n_experts;
+    mc.top_k = cfg.top_k;
+    mc.hidden_dim = cfg.hidden;
+    mc.ffn_dim = cfg.moe_ffn;
+    mc.num_layers = cfg.n_layers;
+    auto engine = sparkinfer::moe::MoEEngine::create(mc);
+
+    sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
+    sparkinfer::Qwen35Weights w;
+    printf("[lmcache_bench] building synthetic model (hidden=%d layers=%d) ...\n", cfg.hidden, cfg.n_layers);
+    fill_weights(w, cfg);
+    model.set_weights(w);
+
+    const std::string socket_path = "/tmp/sparkinfer_lmcache_bench.sock";
+    unlink(socket_path.c_str());
+    const pid_t sidecar_pid = spawn_sidecar(python_env, script_env, socket_path, cfg, kv);
+    if (sidecar_pid <= 0) {
+        printf("could not spawn sidecar\n");
+        return 1;
+    }
+    printf("[lmcache_bench] sidecar spawned (pid=%d), waiting for cold engine construction ...\n",
+           (int)sidecar_pid);
+    for (int i = 0; i < 300 && access(socket_path.c_str(), F_OK) != 0; i++)
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (access(socket_path.c_str(), F_OK) != 0) {
+        printf("sidecar never came up within 30s\n");
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
+    sparkinfer::BridgeKVLayout layout;
+    layout.num_layers = cfg.n_layers;
+    layout.num_kv_heads = cfg.n_kv_heads;
+    layout.head_dim = cfg.head_dim;
+    layout.block_size = kv.block_size();
+    layout.int8_kv = kv.int8_kv();
+    layout.elem_bytes = kv.int8_kv() ? 1 : 2;
+    layout.model_name = "lmcache-bench-model";
+    sparkinfer::BridgeClient bridge(socket_path, layout);
+    model.set_lmcache_bridge(&bridge);
+
+    sparkinfer::ContinuousBatchEngine batch(&model, &kv, prompt_len + 64);
+
+    std::vector<int> prompt;
+    prompt.reserve(prompt_len);
+    for (int i = 0; i < prompt_len; i++) prompt.push_back(1 + (i * 37) % (cfg.vocab - 1));
+
+    // Request 1: cold, populates the cache (MISS). Not itself part of the comparison -- this is
+    // the one-time cost of warming the cache, same as the plan's "session-close eviction"
+    // trigger firing for the first time.
+    sparkinfer::ContinuousBatchEngine::Request warm;
+    warm.prompt = prompt;
+    warm.max_new_tokens = 4;
+    auto rw = batch.complete(warm);
+    if (!rw.error.empty()) {
+        printf("warm-up request failed: %s\n", rw.error.c_str());
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    printf("[lmcache_bench] warm-up (cache miss) TTFT: %.2f ms\n", rw.ttft_ms);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2000));  // let the async STORE land
+
+    // Request 2: same prompt, LMCache attached -- should hit.
+    sparkinfer::ContinuousBatchEngine::Request cached;
+    cached.prompt = prompt;
+    cached.max_new_tokens = 4;
+    auto rc = batch.complete(cached);
+    if (!rc.error.empty()) {
+        printf("cached request failed: %s\n", rc.error.c_str());
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    const uint64_t hits_after_cached = bridge.lookup_hit_count();
+    printf("[lmcache_bench] cache-hit TTFT: %.2f ms (lookup hits=%llu)\n", rc.ttft_ms,
+           (unsigned long long)hits_after_cached);
+
+    // Request 3: same prompt again, LMCache DETACHED -- forces full recompute, isolating what
+    // the cache actually saves (rather than comparing against the warm-up request, which paid
+    // for the LOOKUP miss + STORE stage cost the baseline never pays either).
+    model.set_lmcache_bridge(nullptr);
+    sparkinfer::ContinuousBatchEngine::Request baseline;
+    baseline.prompt = prompt;
+    baseline.max_new_tokens = 4;
+    auto rb = batch.complete(baseline);
+    if (!rb.error.empty()) {
+        printf("baseline request failed: %s\n", rb.error.c_str());
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    printf("[lmcache_bench] baseline (no cache, full recompute) TTFT: %.2f ms\n", rb.ttft_ms);
+
+    terminate_sidecar(sidecar_pid);
+    unlink(socket_path.c_str());
+
+    printf("\n=== summary (prompt_len=%d tokens) ===\n", prompt_len);
+    printf("baseline (full recompute):   %8.2f ms\n", rb.ttft_ms);
+    printf("LMCache (cache hit):         %8.2f ms\n", rc.ttft_ms);
+    if (rc.ttft_ms > 0.0)
+        printf("speedup:                      %8.2fx\n", rb.ttft_ms / rc.ttft_ms);
+    if (hits_after_cached < 1)
+        printf("WARNING: no LOOKUP hit was recorded -- the \"cache hit\" number above did not "
+               "actually hit the cache, treat it as invalid\n");
+    return 0;
+}

--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <vector>
 #include <cuda_runtime.h>
 
 namespace sparkinfer {
@@ -50,6 +51,14 @@ public:
     // Returns device pointer to the block table for seq_id
     // Shape: [num_layers, max_blocks_per_seq]
     int* block_table(uint64_t seq_id) const;
+
+    // Physical block ids owned by seq_id, in logical order (index 0 = the sequence's first
+    // block). Empty if seq_id is unknown. Physical blocks are free-list allocated and not
+    // guaranteed contiguous, so a caller walking (layer, physical_block) byte ranges for bulk
+    // copy-out/copy-in (e.g. an external KV cache tier) needs this rather than assuming a
+    // contiguous span. Returns a reference into internal state -- valid only until the next
+    // allocate()/free()/truncate_blocks() call for this seq_id.
+    const std::vector<int>& physical_block_ids(uint64_t seq_id) const;
 
     // Device pointers to K and V storage pools (base = layer 0).
     // Per-layer pointer = (bf16*)k_pool() + layer * layer_stride_elems().

--- a/runtime/include/sparkinfer/lmcache_bridge_client.h
+++ b/runtime/include/sparkinfer/lmcache_bridge_client.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace sparkinfer {
+
+// Layout the bridge needs to describe sparkinfer's KV to the sidecar in HELLO. Mirrors
+// KVCacheConfig (kv_cache.h) plus the element size, which KVCacheConfig itself doesn't carry
+// (int8_kv implies 1 byte, bf16 implies 2 -- BridgeClient wants it explicit rather than
+// re-deriving the rule).
+struct BridgeKVLayout {
+    int num_layers = 0;
+    int num_kv_heads = 0;
+    int head_dim = 0;
+    int block_size = 0;
+    bool int8_kv = false;
+    int elem_bytes = 2;
+    std::string model_name;
+};
+
+// One matched chunk from a LOOKUP hit. shm_offset_bytes is this chunk's own offset into the
+// shm region named by LookupResult::shm_name -- see docs/lmcache_bridge_protocol.md's "shm
+// region layout" section. Each chunk is self-contained; chunks are not assumed contiguous.
+struct BridgeKVChunk {
+    int start_tok = 0;
+    int len_tok = 0;
+    uint64_t shm_offset_bytes = 0;
+};
+
+struct LookupResult {
+    bool ok = false;   // false = miss, timeout, or bridge unavailable -- caller always falls
+                       // back to normal recompute, this never distinguishes "why" to the caller
+    int matched_tokens = 0;
+    std::string shm_name;  // empty when matched_tokens == 0
+    std::vector<BridgeKVChunk> chunks;
+};
+
+// C++ side of the sparkinfer <-> LMCache-sidecar bridge (docs/lmcache_bridge_protocol.md).
+// Owns one AF_UNIX SOCK_SEQPACKET connection to the Python sidecar plus one dedicated background
+// thread for STORE (so a slow STORE_ACK never stalls the caller). LOOKUP is synchronous with a
+// short fixed timeout, called from ContinuousBatchEngine's single worker thread.
+//
+// Every method degrades safely: if the sidecar was never started, crashed, times out, or sends a
+// malformed frame, LOOKUP returns a miss and STORE silently no-ops. Nothing here ever surfaces a
+// bridge-down condition as a request-visible error -- see the "Degradation is always safe"
+// invariant in the protocol doc.
+class BridgeClient {
+public:
+    // socket_path: where the sidecar is listening (or will listen -- BridgeClient retries
+    // connecting lazily, it does not require the sidecar to already be up at construction time).
+    BridgeClient(std::string socket_path, BridgeKVLayout layout);
+    ~BridgeClient();
+
+    BridgeClient(const BridgeClient&) = delete;
+    BridgeClient& operator=(const BridgeClient&) = delete;
+
+    // True once HELLO/HELLO_ACK has succeeded and no failure has been observed since. Cheap
+    // (atomic read) -- callers should check this before bothering to build a LOOKUP payload,
+    // though lookup()/store_async() are themselves safe to call regardless.
+    bool is_alive() const;
+
+    // Synchronous, bounded by SPARKINFER_LMCACHE_LOOKUP_TIMEOUT_MS (default 5ms). Lazily
+    // (re)connects/handshakes if the bridge isn't currently alive and the reconnect cooldown has
+    // elapsed; a connect attempt that can't complete within the same budget also counts as a
+    // miss for this call, it does not block the caller waiting for a slow connect.
+    LookupResult lookup(const std::vector<int>& token_ids);
+
+    // Fire-and-forget from the caller's perspective: hands the descriptor to the background
+    // STORE thread and returns immediately. shm_name must already contain the staged KV bytes
+    // (written by the caller before calling this) at the layout described in the protocol doc;
+    // ownership of unlinking shm_name passes to the background thread once queued.
+    void store_async(const std::vector<int>& token_ids, int new_start_tok, int new_end_tok,
+                     std::string shm_name);
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> impl_;
+};
+
+} // namespace sparkinfer

--- a/runtime/include/sparkinfer/lmcache_bridge_client.h
+++ b/runtime/include/sparkinfer/lmcache_bridge_client.h
@@ -77,6 +77,14 @@ public:
     void store_async(const std::vector<int>& token_ids, int new_start_tok, int new_end_tok,
                      std::string shm_name);
 
+    // Cumulative counts across every lookup() call this instance has made, for the
+    // sparkinfer_lmcache_lookup_{hits,misses}_total /metrics counters. A "hit" is
+    // res.ok && res.matched_tokens > 0; everything else (genuine miss, timeout, bridge down,
+    // malformed response) counts as a miss -- these deliberately do not distinguish "why" any
+    // more than LookupResult itself does, matching its own doc comment.
+    uint64_t lookup_hit_count() const;
+    uint64_t lookup_miss_count() const;
+
 private:
     struct Impl;
     std::unique_ptr<Impl> impl_;

--- a/runtime/include/sparkinfer/lmcache_staging.h
+++ b/runtime/include/sparkinfer/lmcache_staging.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+#include <cuda_runtime.h>
+
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/lmcache_bridge_client.h"
+
+namespace sparkinfer {
+
+// Bytes needed for one chunk of `n_tok` tokens under `layout`, matching
+// docs/lmcache_bridge_protocol.md's shm region layout (K bytes, V bytes, then K/V scale bytes
+// only when layout.int8_kv). Both sides of the bridge derive this the same way -- see
+// bridge/lmcache_bridge.py's ShmConnector.chunk_byte_size for the Python twin (which computes it
+// purely to size an opaque byte buffer; it never interprets the internal (layer, block)
+// sub-layout the way this side's stage_kv_to_shm/restore_kv_from_shm do).
+size_t lmcache_chunk_byte_size(const BridgeKVLayout& layout, int n_tok);
+
+// Copies seq_id's KV bytes for token range [start_tok, end_tok) into a freshly created shm
+// region named shm_name (O_CREAT|O_EXCL -- fails if it already exists, callers pick unique
+// names). end_tok - start_tok must be a positive multiple of layout.block_size; start_tok must
+// also be block-aligned. Physical blocks are walked via kv.physical_block_ids() rather than
+// assumed contiguous (sparkinfer's paging is free-list allocated). Blocking: synchronizes
+// `stream` before returning so the region is fully populated by the time this returns.
+//
+// Returns false on any failure (bad range, shm create, cudaMemcpy) -- callers must treat that as
+// "skip this store," never a crash; any partially-created shm region is cleaned up before
+// returning false.
+bool stage_kv_to_shm(KVCacheManager& kv, const BridgeKVLayout& layout, uint64_t seq_id,
+                     int start_tok, int end_tok, const std::string& shm_name, cudaStream_t stream);
+
+// Reverse of stage_kv_to_shm: copies bytes already sitting in shm_name at shm_offset_bytes (as
+// reported by a LookupResult chunk) into seq_id's KV blocks for [start_tok, start_tok+len_tok).
+// Caller must have already kv.allocate()'d enough blocks for seq_id to cover this range -- this
+// function only fills bytes into blocks that already exist. Blocking: synchronizes `stream`
+// before returning.
+//
+// Returns false on any failure (shm attach, out-of-range offset, cudaMemcpy) -- callers must
+// treat a restore failure as a cache miss for this chunk (fall back to recompute), never a crash
+// or corrupted-but-unreported KV state.
+bool restore_kv_from_shm(KVCacheManager& kv, const BridgeKVLayout& layout, uint64_t seq_id,
+                         const std::string& shm_name, uint64_t shm_offset_bytes, int start_tok,
+                         int len_tok, cudaStream_t stream);
+
+} // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -9,6 +9,7 @@
 namespace sparkinfer {
 
 class ThermalGovernor;   // optional decode-time thermal pacing (thermal_governor.h)
+class BridgeClient;      // optional external KV cache tier (lmcache_bridge_client.h)
 
 // Device (bf16) weight pointers for one layer.
 struct Qwen35LayerWeights {
@@ -193,16 +194,26 @@ public:
     // the argmax seed for decode once out_pos == end, or -1 while there is remaining work (or on
     // failure). The single funnel both cache_prefix()'s exclusive-session path and
     // ContinuousBatchEngine::step_job()'s continuous-batch path dispatch prefill through, so
-    // batched-vs-token-loop routing and (later) any external KV cache lookup/store only need to
-    // be implemented once.
+    // batched-vs-token-loop routing and external KV cache lookup/store (when a bridge is
+    // attached via set_lmcache_bridge()) only need to be implemented once.
     int ingest_prompt_range(const int* ids, int start, int end, int chunk_limit = 0,
                             int* out_pos = nullptr);
+
+    // Attaches an optional external KV cache tier (docs/lmcache_bridge_protocol.md). Null (the
+    // default) leaves every lookup/store call site a no-op -- existing behavior is unchanged
+    // unless a caller explicitly opts in. Does not take ownership; the caller (ModelEngine) is
+    // responsible for the BridgeClient's lifetime, which must outlive this model.
+    void set_lmcache_bridge(BridgeClient* bridge);
 
     // Per-request session lifecycle for continuous batching / serving.
     // open_session() allocates right-sized KV blocks (+ hybrid recurrent state when needed).
     // activate_session() binds forward_token / prefill to that seq_id. Returns 0 on OOM.
     uint64_t open_session(int num_tokens);
-    void close_session(uint64_t seq_id);
+    // store_tokens, when non-null and an LMCache bridge is attached, stores this session's KV
+    // for [0, store_tokens->size()) to the bridge (chunk-aligned, see lmcache_maybe_store in
+    // qwen35.cpp) before freeing it -- the "session close" eviction point. Most callers don't
+    // have the original prompt at this call site and pass nullptr, which is a pure no-op.
+    void close_session(uint64_t seq_id, const std::vector<int>* store_tokens = nullptr);
     void activate_session(uint64_t seq_id);
     uint64_t active_session() const;
 

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -184,6 +184,20 @@ public:
     // unsupported for this model/config. Implemented in qwen35_prefill.cpp.
     int prefill_batched(const int* prompt_ids, int n);
 
+    // Prefill prompt tokens [start, end) with the batched path when start==0 and eligible, else
+    // the token loop. chunk_limit > 0 caps the token-loop path to at most chunk_limit tokens per
+    // call (the batched path never chunks — it always covers the full range in one pass, so a
+    // chunk_limit smaller than end-start forces the token-loop fallback); pass 0 for unlimited
+    // (single call covers the whole range). out_pos, if non-null, receives the position reached
+    // (== end once the whole range is consumed, < end if chunk_limit stopped it early). Returns
+    // the argmax seed for decode once out_pos == end, or -1 while there is remaining work (or on
+    // failure). The single funnel both cache_prefix()'s exclusive-session path and
+    // ContinuousBatchEngine::step_job()'s continuous-batch path dispatch prefill through, so
+    // batched-vs-token-loop routing and (later) any external KV cache lookup/store only need to
+    // be implemented once.
+    int ingest_prompt_range(const int* ids, int start, int end, int chunk_limit = 0,
+                            int* out_pos = nullptr);
+
     // Per-request session lifecycle for continuous batching / serving.
     // open_session() allocates right-sized KV blocks (+ hybrid recurrent state when needed).
     // activate_session() binds forward_token / prefill to that seq_id. Returns 0 on OOM.
@@ -234,9 +248,6 @@ public:
 
 private:
     void invalidate_decode_graph();
-    // Prefill prompt tokens [start, end) with batched path when start==0, else token loop.
-    // Returns argmax seed at end-1 for decode, or -1 on failure.
-    int ingest_prompt_range(const int* ids, int start, int end);
     void dflash_maybe_capture_layer(int layer);
     // Depth-adaptive KV-split count for a given seqlen (32/128/160/256 tiers, GQA-8/hd256
     // occupancy correction). Shared by forward_token()'s normal per-token adaptation and

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -276,8 +276,15 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
     // name it.
     auto finish_job = [this](Job& j) {
         j.done = true;
-        if (j.seq_id != 0) model_->close_session(j.seq_id);
-        else {
+        if (j.seq_id != 0) {
+            // Offer this session's KV to the external cache tier (docs/lmcache_bridge_protocol.md)
+            // only once the full prompt has actually been ingested -- j.phase only advances past
+            // PREFILL once prefill_pos reaches the prompt's end (see step_job). A job
+            // cancelled/timed-out mid-prefill has KV for only part of its prompt range (possibly
+            // garbage past prefill_pos), so store_tokens must stay null in that case; passing the
+            // full prompt would tell close_session a longer range is valid than actually is.
+            model_->close_session(j.seq_id, j.phase != SeqPhase::PREFILL ? &j.req.prompt : nullptr);
+        } else {
             kv_->free(j.seq_id);
             if (j.req.use_prefix_session) model_->release_prefix_session();
         }

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -9,36 +9,6 @@ namespace sparkinfer {
 
 namespace {
 
-bool prefill_samples_lmhead() {
-    static int legacy = -1;
-    if (legacy < 0) {
-        const char* e = getenv("SPARKINFER_PREFILL_LEGACY");
-        legacy = (e && e[0] == '1') ? 1 : 0;
-    }
-    return legacy != 0;
-}
-
-// Match Qwen35Model::batched_prefill_enabled: dense hybrid (Qwythos) OR MoE hybrid
-// (Qwen3.6). The old dense_ffn-only gate forced MoE CB onto the token loop (~300 pp),
-// which is why scored Qwen3.6 CB mixed TTFT sat at ~17s on main.
-bool batched_prefill_enabled(const Qwen35Config& cfg, bool gguf, int n_tokens) {
-    static int want_batched = -1, batched_maxctx = -1;
-    if (want_batched < 0) {
-        const char* e = getenv("SPARKINFER_PREFILL_BATCHED");
-        want_batched = (e && e[0] == '0') ? 0 : 1;
-        const char* mc = getenv("SPARKINFER_PREFILL_BATCHED_MAXCTX");
-        batched_maxctx = mc ? atoi(mc) : 131072;
-    }
-    const bool ffn_ok = cfg.dense_ffn || cfg.n_experts > 0;
-    // Muse Glimmer: the batched-prefill full-attention kernels have no per-layer sliding-
-    // window/NoPE hook yet (see the matching note in Qwen35Model::batched_prefill_enabled,
-    // qwen35.cpp) -- force the token-loop path, which reuses forward_token()'s correct
-    // per-layer dispatch, until a windowed batched-prefill kernel exists.
-    if (cfg.muse_glimmer) return false;
-    return want_batched && gguf && cfg.hybrid && ffn_ok && n_tokens > 0 &&
-           n_tokens <= batched_maxctx;
-}
-
 // Chunked-prefill budget (vLLM-style): when decode requests are waiting, only
 // advance this many prefill tokens before yielding. 0 = unlimited (full prompt).
 int prefill_chunk_tokens() {
@@ -83,7 +53,6 @@ struct ContinuousBatchEngine::Job {
     int prefill_pos = 0;
     int decode_emitted = 0;
     int next_token = -1;
-    bool batched_prefill_done = false;
     std::vector<int> output;
     std::string error;
     std::function<bool(int)> on_token;  // false return = cancel
@@ -331,39 +300,20 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
     if (job.phase == SeqPhase::PREFILL) {
         const int n = (int)job.req.prompt.size();
         const int chunk = prefill_chunk_tokens();
-        const int remain = n - job.prefill_pos;
-        // Batched GEMM prefill (Qwythos / Qwen3.6 hybrid) is ~100× faster than the
-        // token loop. Never demote it to token-loop "chunks" — that destroys ITPS under
-        // mixed load. True mid-prompt chunked batched prefill needs start_pos support
-        // in prefill_batched_run; until then, decode-first scheduling already advances
-        // waiting decodes once before this full batched pass runs.
-        if (job.prefill_pos == job.req.prefill_start && job.req.prefill_start == 0 &&
-            batched_prefill_enabled(cfg, true, remain)) {
-            const int seed = model_->prefill_batched(job.req.prompt.data() + job.prefill_pos, remain);
-            if (seed >= 0 && seed < cfg.vocab) {
-                job.next_token = seed;
-                job.prefill_pos = n;
-                job.batched_prefill_done = true;
-                job.phase = SeqPhase::DECODE;
-                return false;
-            }
-        }
-        // Token-loop (or chunked) prefill: used when batched is unavailable (non-hybrid /
-        // disabled). Advance up to `limit` tokens then yield so decode can run.
-        int limit = remain;
-        if (chunked && chunk > 0 && remain > chunk) limit = chunk;
-        int advanced = 0;
-        while (advanced < limit && job.prefill_pos < n) {
-            const bool sample = prefill_samples_lmhead() || job.prefill_pos + 1 == n;
-            if (sample)
-                job.next_token = model_->forward_token(job.req.prompt[(size_t)job.prefill_pos],
-                                                       job.prefill_pos, true);
-            else
-                model_->forward_token(job.req.prompt[(size_t)job.prefill_pos], job.prefill_pos, false);
-            job.prefill_pos++;
-            advanced++;
-        }
+        // Qwen35Model::ingest_prompt_range() is the single funnel both this continuous-batch
+        // path and cache_prefix()'s exclusive-session path dispatch prefill through: it picks
+        // batched GEMM prefill (Qwythos / Qwen3.6 hybrid, ~100x faster than the token loop, only
+        // eligible from position 0) vs. the token-loop fallback itself, and the batched path
+        // never chunks (no start_pos support in prefill_batched_run yet) regardless of the
+        // chunk_limit passed here -- decode-first scheduling already advances waiting decodes
+        // once before a full batched pass runs, so that never hurts ITPS under mixed load.
+        const int chunk_limit = chunked ? chunk : 0;
+        int out_pos = job.prefill_pos;
+        const int seed = model_->ingest_prompt_range(job.req.prompt.data(), job.prefill_pos, n,
+                                                      chunk_limit, &out_pos);
+        job.prefill_pos = out_pos;
         if (job.prefill_pos >= n) {
+            job.next_token = seed;
             if (job.next_token < 0 && job.req.use_prefix_session)
                 job.next_token = model_->prefix_seed_token();
             job.phase = SeqPhase::DECODE;

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -158,6 +158,12 @@ int* KVCacheManager::block_table(uint64_t seq_id) const {
     return impl_->d_block_tables + (size_t)it->second * kMaxBlocksPerSeq;
 }
 
+const std::vector<int>& KVCacheManager::physical_block_ids(uint64_t seq_id) const {
+    static const std::vector<int> kEmpty;
+    auto it = impl_->seq_blocks.find(seq_id);
+    return it == impl_->seq_blocks.end() ? kEmpty : it->second;
+}
+
 void*  KVCacheManager::k_pool() const { return impl_->k_pool; }
 void*  KVCacheManager::v_pool() const { return impl_->v_pool; }
 size_t KVCacheManager::layer_stride_elems() const { return impl_->layer_stride; }

--- a/runtime/src/lmcache_bridge_client.cpp
+++ b/runtime/src/lmcache_bridge_client.cpp
@@ -142,6 +142,8 @@ struct BridgeClient::Impl {
     Connection store_conn;
 
     std::atomic<uint32_t> next_request_id{1};
+    std::atomic<uint64_t> lookup_hits{0};
+    std::atomic<uint64_t> lookup_misses{0};
 
     std::atomic<bool> running{true};
     std::thread ping_thread;
@@ -406,6 +408,18 @@ bool BridgeClient::is_alive() const {
 
 LookupResult BridgeClient::lookup(const std::vector<int>& token_ids) {
     LookupResult out;
+    // Fires on every exit path (there are several early returns below) rather than requiring
+    // each one to remember to increment the right counter -- classifies purely on `out`'s final
+    // state, which every return path already sets correctly for its own outcome.
+    struct CounterGuard {
+        Impl* impl;
+        const LookupResult* out;
+        ~CounterGuard() {
+            auto& counter = (out->ok && out->matched_tokens > 0) ? impl->lookup_hits : impl->lookup_misses;
+            counter.fetch_add(1, std::memory_order_relaxed);
+        }
+    } counter_guard{impl_.get(), &out};
+
     const int timeout_ms = lookup_timeout_ms_config();
 
     std::lock_guard<std::mutex> lock(impl_->ctrl.mu);
@@ -463,6 +477,14 @@ void BridgeClient::store_async(const std::vector<int>& token_ids, int new_start_
     impl_->store_queue.push_back(
         Impl::StoreItem{token_ids, new_start_tok, new_end_tok, std::move(shm_name)});
     impl_->store_cv.notify_one();
+}
+
+uint64_t BridgeClient::lookup_hit_count() const {
+    return impl_->lookup_hits.load(std::memory_order_relaxed);
+}
+
+uint64_t BridgeClient::lookup_miss_count() const {
+    return impl_->lookup_misses.load(std::memory_order_relaxed);
 }
 
 } // namespace sparkinfer

--- a/runtime/src/lmcache_bridge_client.cpp
+++ b/runtime/src/lmcache_bridge_client.cpp
@@ -156,6 +156,18 @@ struct BridgeClient::Impl {
     std::mutex store_mu;
     std::condition_variable store_cv;
     std::deque<StoreItem> store_queue;
+
+    // Dedicated to the ping thread's interruptible sleep -- deliberately NOT store_cv/store_mu.
+    // An earlier version shared them (as a ready-made shutdown signal, since both threads just
+    // needed "wake up when running goes false"), but std::condition_variable::notify_one() wakes
+    // an arbitrary one of ALL current waiters, not a specific one: store_async()'s notify_one()
+    // could wake the ping thread instead of the store thread, leaving a queued STORE stuck until
+    // something else happened to wake the right thread (found via this file's own unit test
+    // flaking -- a queued store sometimes never got sent within a many-second window, not just a
+    // slow one). Two independent condition variables makes that class of bug structurally
+    // impossible rather than relying on both predicates happening to be safe under notify_all.
+    std::mutex shutdown_mu;
+    std::condition_variable shutdown_cv;
 };
 
 namespace {
@@ -293,13 +305,14 @@ BridgeClient::BridgeClient(std::string socket_path, BridgeKVLayout layout) : imp
 
     impl_->ping_thread = std::thread([this] {
         while (impl_->running.load(std::memory_order_relaxed)) {
-            // Interruptible sleep (shares store_mu/store_cv with the STORE thread purely as a
-            // ready-made shutdown signal -- no queue semantics implied here) so ~BridgeClient()
-            // doesn't block for up to 2s waiting on a plain sleep_for() to notice running=false.
+            // Interruptible sleep on its own dedicated condition variable (not store_cv -- see
+            // Impl::shutdown_cv's comment for why sharing one with the STORE thread is a real
+            // bug, not just a style choice) so ~BridgeClient() doesn't block for up to 2s waiting
+            // on a plain sleep_for() to notice running=false.
             {
-                std::unique_lock<std::mutex> wait_lock(impl_->store_mu);
-                impl_->store_cv.wait_for(wait_lock, std::chrono::milliseconds(2000),
-                                         [this] { return !impl_->running.load(std::memory_order_relaxed); });
+                std::unique_lock<std::mutex> wait_lock(impl_->shutdown_mu);
+                impl_->shutdown_cv.wait_for(wait_lock, std::chrono::milliseconds(2000),
+                                            [this] { return !impl_->running.load(std::memory_order_relaxed); });
             }
             if (!impl_->running.load(std::memory_order_relaxed)) break;
             std::lock_guard<std::mutex> lock(impl_->ctrl.mu);
@@ -374,6 +387,7 @@ BridgeClient::BridgeClient(std::string socket_path, BridgeKVLayout layout) : imp
 BridgeClient::~BridgeClient() {
     impl_->running.store(false, std::memory_order_relaxed);
     impl_->store_cv.notify_all();
+    impl_->shutdown_cv.notify_all();
     if (impl_->ping_thread.joinable()) impl_->ping_thread.join();
     if (impl_->store_thread.joinable()) impl_->store_thread.join();
     {

--- a/runtime/src/lmcache_bridge_client.cpp
+++ b/runtime/src/lmcache_bridge_client.cpp
@@ -1,0 +1,454 @@
+// C++ side of the sparkinfer <-> LMCache-sidecar bridge. Wire format is
+// docs/lmcache_bridge_protocol.md -- keep both in sync by hand, there is no codegen here.
+#include "sparkinfer/lmcache_bridge_client.h"
+
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <algorithm>
+#include <cerrno>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <condition_variable>
+#include <deque>
+#include <mutex>
+
+namespace sparkinfer {
+
+namespace {
+
+constexpr uint32_t kMagic = 0x53494B56;  // 'SIKV' little-endian on the wire
+constexpr uint16_t kProtocolVersion = 1;
+constexpr size_t kMaxFrameBytes = 2 * 1024 * 1024;  // see protocol doc's "Framing note"
+
+enum MsgType : uint16_t {
+    HELLO = 1,
+    HELLO_ACK = 2,
+    LOOKUP = 3,
+    LOOKUP_RESP = 4,
+    STORE = 5,
+    STORE_ACK = 6,
+    PING = 7,
+    PONG = 8,
+    ERROR_MSG = 9,
+};
+
+#pragma pack(push, 1)
+struct FrameHeader {
+    uint32_t magic;
+    uint16_t version;
+    uint16_t msg_type;
+    uint32_t payload_len;
+    uint32_t request_id;
+};
+#pragma pack(pop)
+static_assert(sizeof(FrameHeader) == 16, "FrameHeader must match the 16-byte wire layout");
+
+int lookup_timeout_ms_config() {
+    static int ms = [] {
+        const char* e = getenv("SPARKINFER_LMCACHE_LOOKUP_TIMEOUT_MS");
+        int v = e ? atoi(e) : 5;
+        return v > 0 ? v : 5;
+    }();
+    return ms;
+}
+
+// --- payload (de)serialization -------------------------------------------------------------
+
+void put_u8(std::vector<uint8_t>& b, uint8_t v) { b.push_back(v); }
+void put_u32(std::vector<uint8_t>& b, uint32_t v) {
+    for (int i = 0; i < 4; i++) b.push_back((uint8_t)(v >> (8 * i)));
+}
+void put_i32(std::vector<uint8_t>& b, int32_t v) { put_u32(b, (uint32_t)v); }
+void put_str(std::vector<uint8_t>& b, const std::string& s) {
+    put_u32(b, (uint32_t)s.size());
+    b.insert(b.end(), s.begin(), s.end());
+}
+
+// Cursor-based reader over a received payload. Every getter bounds-checks and sets `ok=false`
+// (sticky) on underflow instead of throwing -- a malformed frame degrades to "treat as failure",
+// never a crash, matching the protocol doc's degradation invariant.
+struct Reader {
+    const uint8_t* p;
+    size_t len;
+    size_t off = 0;
+    bool ok = true;
+
+    bool need(size_t n) {
+        if (!ok || off + n > len) { ok = false; return false; }
+        return true;
+    }
+    uint8_t get_u8() {
+        if (!need(1)) return 0;
+        return p[off++];
+    }
+    uint32_t get_u32() {
+        if (!need(4)) return 0;
+        uint32_t v = 0;
+        for (int i = 0; i < 4; i++) v |= (uint32_t)p[off + i] << (8 * i);
+        off += 4;
+        return v;
+    }
+    uint64_t get_u64() {
+        if (!need(8)) return 0;
+        uint64_t v = 0;
+        for (int i = 0; i < 8; i++) v |= (uint64_t)p[off + i] << (8 * i);
+        off += 8;
+        return v;
+    }
+    int32_t get_i32() { return (int32_t)get_u32(); }
+    std::string get_str() {
+        uint32_t n = get_u32();
+        if (!ok || !need(n)) return {};
+        std::string s((const char*)p + off, n);
+        off += n;
+        return s;
+    }
+};
+
+// One AF_UNIX SOCK_SEQPACKET connection with its own liveness/reconnect state. ctrl (HELLO +
+// LOOKUP + PING) and store_conn (HELLO + STORE) are deliberately separate instances -- see the
+// "Transport" section of the protocol doc for why a slow STORE must never delay a LOOKUP.
+// Namespace-scoped (not nested in BridgeClient) purely so it can be defined here without also
+// forward-declaring it in the public header alongside Impl.
+struct Connection {
+    std::mutex mu;
+    int fd = -1;
+    std::atomic<bool> alive{false};
+    std::chrono::steady_clock::time_point next_attempt{};  // cooldown gate, epoch = never waited
+    int backoff_ms = 5000;
+    static constexpr int kMaxBackoffMs = 60000;
+    // Reused across every recv on this connection so LOOKUP's tight timeout budget never pays
+    // for a fresh 2MiB allocation + zero-fill on every call -- sized lazily on first use, then
+    // kept for the connection's lifetime (reconnects don't need to resize it).
+    std::vector<uint8_t> recv_buf;
+
+    void close_locked() {
+        if (fd >= 0) { ::close(fd); fd = -1; }
+        alive.store(false, std::memory_order_relaxed);
+    }
+};
+
+}  // namespace
+
+struct BridgeClient::Impl {
+    std::string socket_path;
+    BridgeKVLayout layout;
+
+    Connection ctrl;
+    Connection store_conn;
+
+    std::atomic<uint32_t> next_request_id{1};
+
+    std::atomic<bool> running{true};
+    std::thread ping_thread;
+    std::thread store_thread;
+
+    struct StoreItem {
+        std::vector<int> token_ids;
+        int new_start = 0;
+        int new_end = 0;
+        std::string shm_name;
+    };
+    std::mutex store_mu;
+    std::condition_variable store_cv;
+    std::deque<StoreItem> store_queue;
+};
+
+namespace {
+
+bool set_timeout(int fd, int ms) {
+    struct timeval tv;
+    tv.tv_sec = ms / 1000;
+    tv.tv_usec = (ms % 1000) * 1000;
+    bool ok = setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv)) == 0;
+    ok = setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv)) == 0 && ok;
+    return ok;
+}
+
+// Connects a fresh fd for `conn` (closing any prior one), honoring the cooldown -- returns false
+// without touching the socket at all if still in cooldown. Does not send HELLO; caller does that
+// so it can use its own timeout budget for the handshake round trip.
+bool dial_locked(Connection& conn, const std::string& path, int timeout_ms) {
+    const auto now = std::chrono::steady_clock::now();
+    if (now < conn.next_attempt) return false;
+
+    conn.close_locked();
+
+    int fd = ::socket(AF_UNIX, SOCK_SEQPACKET, 0);
+    if (fd < 0) {
+        conn.next_attempt = now + std::chrono::milliseconds(conn.backoff_ms);
+        conn.backoff_ms = std::min(conn.backoff_ms * 2, Connection::kMaxBackoffMs);
+        return false;
+    }
+    set_timeout(fd, timeout_ms);
+
+    struct sockaddr_un addr;
+    memset(&addr, 0, sizeof(addr));
+    addr.sun_family = AF_UNIX;
+    if (path.size() >= sizeof(addr.sun_path)) {
+        ::close(fd);
+        return false;
+    }
+    memcpy(addr.sun_path, path.c_str(), path.size() + 1);
+
+    if (::connect(fd, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+        ::close(fd);
+        conn.next_attempt = now + std::chrono::milliseconds(conn.backoff_ms);
+        conn.backoff_ms = std::min(conn.backoff_ms * 2, Connection::kMaxBackoffMs);
+        return false;
+    }
+
+    conn.fd = fd;
+    return true;
+}
+
+// One send() call carrying header+payload as a single SOCK_SEQPACKET message -- see the
+// protocol doc's "Framing note": splitting this into two send()s would arrive as two messages.
+bool send_frame_locked(Connection& conn, uint16_t msg_type, uint32_t request_id,
+                       const std::vector<uint8_t>& payload) {
+    if (conn.fd < 0) return false;
+    std::vector<uint8_t> buf;
+    buf.reserve(sizeof(FrameHeader) + payload.size());
+    FrameHeader h{kMagic, kProtocolVersion, msg_type, (uint32_t)payload.size(), request_id};
+    buf.insert(buf.end(), (const uint8_t*)&h, (const uint8_t*)&h + sizeof(h));
+    buf.insert(buf.end(), payload.begin(), payload.end());
+    const ssize_t n = ::send(conn.fd, buf.data(), buf.size(), 0);
+    return n == (ssize_t)buf.size();
+}
+
+// One recv() call retrieving exactly one message. Returns false on timeout, short read, bad
+// magic, or a truncated (oversized) message -- any of these is treated as a failed request by
+// the caller, never a crash.
+bool recv_frame_locked(Connection& conn, FrameHeader* out_header,
+                       std::vector<uint8_t>* out_payload) {
+    if (conn.fd < 0) return false;
+    if (conn.recv_buf.empty()) conn.recv_buf.resize(kMaxFrameBytes);
+    const ssize_t n = ::recv(conn.fd, conn.recv_buf.data(), conn.recv_buf.size(), 0);
+    if (n < (ssize_t)sizeof(FrameHeader)) return false;
+    FrameHeader h;
+    memcpy(&h, conn.recv_buf.data(), sizeof(h));
+    if (h.magic != kMagic) return false;
+    if (sizeof(FrameHeader) + h.payload_len != (size_t)n) return false;  // short/truncated msg
+    *out_header = h;
+    out_payload->assign(conn.recv_buf.begin() + sizeof(FrameHeader), conn.recv_buf.begin() + n);
+    return true;
+}
+
+std::vector<uint8_t> build_hello_payload(const BridgeKVLayout& layout) {
+    std::vector<uint8_t> p;
+    put_u32(p, (uint32_t)layout.num_layers);
+    put_u32(p, (uint32_t)layout.num_kv_heads);
+    put_u32(p, (uint32_t)layout.head_dim);
+    put_u32(p, (uint32_t)layout.block_size);
+    put_u8(p, layout.int8_kv ? 1 : 0);
+    put_u32(p, (uint32_t)layout.elem_bytes);
+    put_str(p, layout.model_name);
+    return p;
+}
+
+// Connect (respecting cooldown) + HELLO/HELLO_ACK, all within `timeout_ms`. On any failure the
+// connection is left closed and the cooldown/backoff from dial_locked applies; a version
+// mismatch or ok=0 ack is treated identically to a transport failure -- callers never retry the
+// handshake on the same fd, per the protocol doc.
+bool handshake_locked(Connection& conn, const std::string& path,
+                      const BridgeKVLayout& layout, uint32_t request_id, int timeout_ms) {
+    if (conn.alive.load(std::memory_order_relaxed)) return true;
+    if (!dial_locked(conn, path, timeout_ms)) return false;
+
+    if (!send_frame_locked(conn, HELLO, request_id, build_hello_payload(layout))) {
+        conn.close_locked();
+        return false;
+    }
+    FrameHeader h{};
+    std::vector<uint8_t> payload;
+    if (!recv_frame_locked(conn, &h, &payload) || h.msg_type != HELLO_ACK ||
+        h.version != kProtocolVersion) {
+        conn.close_locked();
+        return false;
+    }
+    Reader r{payload.data(), payload.size()};
+    const uint8_t ok = r.get_u8();
+    (void)r.get_str();  // lmcache_version, informational only
+    (void)r.get_u32();  // chunk_size_tokens, informational only for the C++ side (the sidecar is
+                        // the one that enforces chunk alignment)
+    (void)r.get_str();  // error, only meaningful when ok==0
+    if (!r.ok || !ok) {
+        conn.close_locked();
+        return false;
+    }
+    conn.alive.store(true, std::memory_order_relaxed);
+    conn.backoff_ms = 5000;  // reset backoff on a successful handshake
+    return true;
+}
+
+}  // namespace
+
+BridgeClient::BridgeClient(std::string socket_path, BridgeKVLayout layout) : impl_(new Impl()) {
+    impl_->socket_path = std::move(socket_path);
+    impl_->layout = std::move(layout);
+
+    impl_->ping_thread = std::thread([this] {
+        while (impl_->running.load(std::memory_order_relaxed)) {
+            // Interruptible sleep (shares store_mu/store_cv with the STORE thread purely as a
+            // ready-made shutdown signal -- no queue semantics implied here) so ~BridgeClient()
+            // doesn't block for up to 2s waiting on a plain sleep_for() to notice running=false.
+            {
+                std::unique_lock<std::mutex> wait_lock(impl_->store_mu);
+                impl_->store_cv.wait_for(wait_lock, std::chrono::milliseconds(2000),
+                                         [this] { return !impl_->running.load(std::memory_order_relaxed); });
+            }
+            if (!impl_->running.load(std::memory_order_relaxed)) break;
+            std::lock_guard<std::mutex> lock(impl_->ctrl.mu);
+            const uint32_t rid = impl_->next_request_id.fetch_add(1);
+            // Short budget: a hung PING must not tie up ctrl for long, since LOOKUP shares it.
+            if (!handshake_locked(impl_->ctrl, impl_->socket_path, impl_->layout, rid, 50))
+                continue;
+            if (!send_frame_locked(impl_->ctrl, PING, rid, {})) {
+                impl_->ctrl.close_locked();
+                continue;
+            }
+            FrameHeader h{};
+            std::vector<uint8_t> payload;
+            if (!recv_frame_locked(impl_->ctrl, &h, &payload) || h.msg_type != PONG)
+                impl_->ctrl.close_locked();
+        }
+    });
+
+    impl_->store_thread = std::thread([this] {
+        while (true) {
+            Impl::StoreItem item;
+            {
+                std::unique_lock<std::mutex> lock(impl_->store_mu);
+                impl_->store_cv.wait(lock, [this] {
+                    return !impl_->store_queue.empty() ||
+                           !impl_->running.load(std::memory_order_relaxed);
+                });
+                if (impl_->store_queue.empty()) {
+                    if (!impl_->running.load(std::memory_order_relaxed)) return;
+                    continue;
+                }
+                item = std::move(impl_->store_queue.front());
+                impl_->store_queue.pop_front();
+            }
+
+            std::vector<uint8_t> payload;
+            put_u32(payload, (uint32_t)item.token_ids.size());
+            for (int t : item.token_ids) put_i32(payload, t);
+            put_u32(payload, (uint32_t)item.new_start);
+            put_u32(payload, (uint32_t)item.new_end);
+            put_str(payload, item.shm_name);
+
+            bool acked = false;
+            {
+                std::lock_guard<std::mutex> lock(impl_->store_conn.mu);
+                const uint32_t rid = impl_->next_request_id.fetch_add(1);
+                // STORE is off the hot path; a generous budget is fine here, unlike LOOKUP/PING.
+                if (handshake_locked(impl_->store_conn, impl_->socket_path, impl_->layout, rid,
+                                     2000) &&
+                    send_frame_locked(impl_->store_conn, STORE, rid, payload)) {
+                    FrameHeader h{};
+                    std::vector<uint8_t> resp;
+                    if (recv_frame_locked(impl_->store_conn, &h, &resp) && h.msg_type == STORE_ACK) {
+                        Reader r{resp.data(), resp.size()};
+                        acked = r.get_u8() != 0;
+                    } else {
+                        impl_->store_conn.close_locked();
+                    }
+                }
+            }
+            // The C++ side created shm_name for this STORE (per the protocol doc's shm
+            // lifecycle) -- unlink it now regardless of ack outcome. On a failed/timed-out
+            // STORE the sidecar never mapped it, so this is just cleaning up our own staging
+            // buffer; on success the sidecar has already copied out of it by the time STORE_ACK
+            // arrives (synchronous within its own handler).
+            if (!item.shm_name.empty()) shm_unlink(item.shm_name.c_str());
+            (void)acked;  // no caller to report to -- store_async() is fire-and-forget by design
+        }
+    });
+}
+
+BridgeClient::~BridgeClient() {
+    impl_->running.store(false, std::memory_order_relaxed);
+    impl_->store_cv.notify_all();
+    if (impl_->ping_thread.joinable()) impl_->ping_thread.join();
+    if (impl_->store_thread.joinable()) impl_->store_thread.join();
+    {
+        std::lock_guard<std::mutex> lock(impl_->ctrl.mu);
+        impl_->ctrl.close_locked();
+    }
+    {
+        std::lock_guard<std::mutex> lock(impl_->store_conn.mu);
+        impl_->store_conn.close_locked();
+    }
+}
+
+bool BridgeClient::is_alive() const {
+    return impl_->ctrl.alive.load(std::memory_order_relaxed);
+}
+
+LookupResult BridgeClient::lookup(const std::vector<int>& token_ids) {
+    LookupResult out;
+    const int timeout_ms = lookup_timeout_ms_config();
+
+    std::lock_guard<std::mutex> lock(impl_->ctrl.mu);
+    const uint32_t rid = impl_->next_request_id.fetch_add(1);
+    if (!handshake_locked(impl_->ctrl, impl_->socket_path, impl_->layout, rid, timeout_ms))
+        return out;  // ok=false: bridge unavailable, caller recomputes -- never blocks longer
+                     // than one handshake attempt at `timeout_ms`
+
+    std::vector<uint8_t> payload;
+    put_u32(payload, (uint32_t)token_ids.size());
+    for (int t : token_ids) put_i32(payload, t);
+
+    if (!send_frame_locked(impl_->ctrl, LOOKUP, rid, payload)) {
+        impl_->ctrl.close_locked();
+        return out;
+    }
+    FrameHeader h{};
+    std::vector<uint8_t> resp;
+    if (!recv_frame_locked(impl_->ctrl, &h, &resp)) {
+        // Timeout or malformed response: leave the connection open (this is not necessarily a
+        // dead bridge, just a slow one this time) but return a miss for this call -- the
+        // worker thread's budget is what matters, not whether the sidecar eventually replies.
+        return out;
+    }
+    if (h.msg_type == ERROR_MSG) return out;  // sidecar-reported failure: miss, not a crash
+    if (h.msg_type != LOOKUP_RESP) {
+        impl_->ctrl.close_locked();  // genuinely unexpected framing: treat as connection-broken
+        return out;
+    }
+
+    Reader r{resp.data(), resp.size()};
+    out.matched_tokens = (int)r.get_i32();
+    out.shm_name = r.get_str();
+    // Not reserve()'d against n_chunks: it comes straight off the wire, unvalidated, and a
+    // malformed/corrupt frame could claim an enormous count -- push_back's incremental growth
+    // is bounded by how many chunks actually fit in the payload (r.ok flips false the moment a
+    // read runs past the buffer), reserve() would not be.
+    const uint32_t n_chunks = r.get_u32();
+    for (uint32_t i = 0; i < n_chunks && r.ok; i++) {
+        BridgeKVChunk c;
+        c.start_tok = (int)r.get_i32();
+        c.len_tok = (int)r.get_i32();
+        c.shm_offset_bytes = r.get_u64();
+        out.chunks.push_back(c);
+    }
+    if (!r.ok) return LookupResult{};  // malformed payload: treat the whole response as a miss
+
+    out.ok = true;
+    return out;
+}
+
+void BridgeClient::store_async(const std::vector<int>& token_ids, int new_start_tok,
+                               int new_end_tok, std::string shm_name) {
+    std::lock_guard<std::mutex> lock(impl_->store_mu);
+    impl_->store_queue.push_back(
+        Impl::StoreItem{token_ids, new_start_tok, new_end_tok, std::move(shm_name)});
+    impl_->store_cv.notify_one();
+}
+
+} // namespace sparkinfer

--- a/runtime/src/lmcache_staging.cpp
+++ b/runtime/src/lmcache_staging.cpp
@@ -1,0 +1,205 @@
+// Bulk KV <-> shm staging for the LMCache bridge. Physical KV blocks are free-list allocated
+// (see kv_cache.cpp) and not guaranteed contiguous per sequence, so both directions walk
+// (layer, physical_block) pairs individually rather than assuming one contiguous device range.
+//
+// Layout convention chosen here (layer-major, block-minor within each of K/V/K-scale/V-scale
+// regions) is a purely internal agreement between stage_kv_to_shm and restore_kv_from_shm -- the
+// Python sidecar never interprets these bytes (see bridge/lmcache_bridge.py's ShmConnector,
+// which treats a chunk as an opaque blob of lmcache_chunk_byte_size() bytes), so nothing outside
+// this file needs to agree with the ordering, only stage_kv_to_shm and restore_kv_from_shm need
+// to agree with each other.
+#include "sparkinfer/lmcache_staging.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <cstring>
+
+namespace sparkinfer {
+
+namespace {
+
+size_t elems_per_block(const BridgeKVLayout& layout) {
+    return (size_t)layout.block_size * layout.num_kv_heads * layout.head_dim;
+}
+size_t scale_elems_per_block(const BridgeKVLayout& layout) {
+    return (size_t)layout.block_size * layout.num_kv_heads;
+}
+
+}  // namespace
+
+size_t lmcache_chunk_byte_size(const BridgeKVLayout& layout, int n_tok) {
+    if (n_tok <= 0 || layout.block_size <= 0) return 0;
+    const int n_blocks = n_tok / layout.block_size;
+    const size_t block_bytes = elems_per_block(layout) * (size_t)layout.elem_bytes;
+    size_t total = (size_t)layout.num_layers * 2 * (size_t)n_blocks * block_bytes;  // K + V
+    if (layout.int8_kv) {
+        const size_t scale_block_bytes = scale_elems_per_block(layout) * sizeof(uint16_t);
+        total += (size_t)layout.num_layers * 2 * (size_t)n_blocks * scale_block_bytes;  // K+V scale
+    }
+    return total;
+}
+
+namespace {
+
+// Copies one (K, V, or scale) region between a pinned host staging buffer and the device KV
+// pool for n_blocks logical blocks starting at first_block, walking physical block ids so
+// non-contiguous paging is handled correctly. `host_to_device` picks the copy direction; `off`
+// (in/out) is the running byte offset within the staging buffer, advanced by this region's size
+// regardless of success so the caller's next region starts at the right place even after a
+// failure (the caller bails out on `ok=false` before that matters).
+bool copy_region(void* pool, size_t layer_stride_elems, size_t region_elems_per_block,
+                 int elem_bytes, const std::vector<int>& phys, int first_block, int n_blocks,
+                 int num_layers, uint8_t* host_buf, size_t& off, bool host_to_device,
+                 cudaStream_t stream) {
+    const size_t nbytes = region_elems_per_block * (size_t)elem_bytes;
+    for (int L = 0; L < num_layers; L++) {
+        for (int b = 0; b < n_blocks; b++) {
+            const int phys_block = phys[(size_t)(first_block + b)];
+            const size_t dev_elem_off =
+                (size_t)L * layer_stride_elems + (size_t)phys_block * region_elems_per_block;
+            uint8_t* dev_ptr = (uint8_t*)pool + dev_elem_off * (size_t)elem_bytes;
+            uint8_t* host_ptr = host_buf + off;
+            off += nbytes;
+            const cudaError_t err =
+                host_to_device ? cudaMemcpyAsync(dev_ptr, host_ptr, nbytes, cudaMemcpyHostToDevice, stream)
+                               : cudaMemcpyAsync(host_ptr, dev_ptr, nbytes, cudaMemcpyDeviceToHost, stream);
+            if (err != cudaSuccess) return false;
+        }
+    }
+    return true;
+}
+
+}  // namespace
+
+bool stage_kv_to_shm(KVCacheManager& kv, const BridgeKVLayout& layout, uint64_t seq_id,
+                     int start_tok, int end_tok, const std::string& shm_name, cudaStream_t stream) {
+    if (end_tok <= start_tok) return false;
+    const int n_tok = end_tok - start_tok;
+    if (layout.block_size <= 0 || start_tok % layout.block_size != 0 ||
+        n_tok % layout.block_size != 0)
+        return false;
+    const int first_block = start_tok / layout.block_size;
+    const int n_blocks = n_tok / layout.block_size;
+
+    const std::vector<int>& phys = kv.physical_block_ids(seq_id);
+    if ((int)phys.size() < first_block + n_blocks) return false;
+
+    const size_t total_bytes = lmcache_chunk_byte_size(layout, n_tok);
+    if (total_bytes == 0) return false;
+
+    void* h_staging = nullptr;
+    if (cudaHostAlloc(&h_staging, total_bytes, cudaHostAllocDefault) != cudaSuccess) return false;
+    uint8_t* host_buf = (uint8_t*)h_staging;
+    size_t off = 0;
+    bool ok = true;
+
+    ok = ok && copy_region(kv.k_pool(), kv.layer_stride_elems(), elems_per_block(layout),
+                           layout.elem_bytes, phys, first_block, n_blocks, layout.num_layers,
+                           host_buf, off, /*host_to_device=*/false, stream);
+    ok = ok && copy_region(kv.v_pool(), kv.layer_stride_elems(), elems_per_block(layout),
+                           layout.elem_bytes, phys, first_block, n_blocks, layout.num_layers,
+                           host_buf, off, false, stream);
+    if (ok && layout.int8_kv) {
+        ok = ok && copy_region(kv.k_scale_pool(), kv.scale_layer_stride_elems(),
+                               scale_elems_per_block(layout), (int)sizeof(uint16_t), phys,
+                               first_block, n_blocks, layout.num_layers, host_buf, off, false,
+                               stream);
+        ok = ok && copy_region(kv.v_scale_pool(), kv.scale_layer_stride_elems(),
+                               scale_elems_per_block(layout), (int)sizeof(uint16_t), phys,
+                               first_block, n_blocks, layout.num_layers, host_buf, off, false,
+                               stream);
+    }
+    if (ok) ok = (cudaStreamSynchronize(stream) == cudaSuccess);
+    if (!ok) {
+        cudaFreeHost(h_staging);
+        return false;
+    }
+
+    const int fd = shm_open(shm_name.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    if (fd < 0) {
+        cudaFreeHost(h_staging);
+        return false;
+    }
+    if (ftruncate(fd, (off_t)total_bytes) != 0) {
+        close(fd);
+        shm_unlink(shm_name.c_str());
+        cudaFreeHost(h_staging);
+        return false;
+    }
+    void* mapped = mmap(nullptr, total_bytes, PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (mapped == MAP_FAILED) {
+        shm_unlink(shm_name.c_str());
+        cudaFreeHost(h_staging);
+        return false;
+    }
+    memcpy(mapped, h_staging, total_bytes);
+    munmap(mapped, total_bytes);
+    cudaFreeHost(h_staging);
+    return true;
+}
+
+bool restore_kv_from_shm(KVCacheManager& kv, const BridgeKVLayout& layout, uint64_t seq_id,
+                         const std::string& shm_name, uint64_t shm_offset_bytes, int start_tok,
+                         int len_tok, cudaStream_t stream) {
+    if (len_tok <= 0 || layout.block_size <= 0 || start_tok % layout.block_size != 0 ||
+        len_tok % layout.block_size != 0)
+        return false;
+    const int first_block = start_tok / layout.block_size;
+    const int n_blocks = len_tok / layout.block_size;
+
+    const std::vector<int>& phys = kv.physical_block_ids(seq_id);
+    if ((int)phys.size() < first_block + n_blocks) return false;
+
+    const size_t total_bytes = lmcache_chunk_byte_size(layout, len_tok);
+    if (total_bytes == 0) return false;
+
+    const int fd = shm_open(shm_name.c_str(), O_RDONLY, 0);
+    if (fd < 0) return false;
+    struct stat st;
+    if (fstat(fd, &st) != 0 || st.st_size < 0 ||
+        shm_offset_bytes + total_bytes > (uint64_t)st.st_size) {
+        close(fd);
+        return false;
+    }
+    void* mapped = mmap(nullptr, (size_t)st.st_size, PROT_READ, MAP_SHARED, fd, 0);
+    close(fd);
+    if (mapped == MAP_FAILED) return false;
+
+    void* h_staging = nullptr;
+    if (cudaHostAlloc(&h_staging, total_bytes, cudaHostAllocDefault) != cudaSuccess) {
+        munmap(mapped, (size_t)st.st_size);
+        return false;
+    }
+    memcpy(h_staging, (const uint8_t*)mapped + shm_offset_bytes, total_bytes);
+    munmap(mapped, (size_t)st.st_size);
+
+    uint8_t* host_buf = (uint8_t*)h_staging;
+    size_t off = 0;
+    bool ok = true;
+
+    ok = ok && copy_region(kv.k_pool(), kv.layer_stride_elems(), elems_per_block(layout),
+                           layout.elem_bytes, phys, first_block, n_blocks, layout.num_layers,
+                           host_buf, off, /*host_to_device=*/true, stream);
+    ok = ok && copy_region(kv.v_pool(), kv.layer_stride_elems(), elems_per_block(layout),
+                           layout.elem_bytes, phys, first_block, n_blocks, layout.num_layers,
+                           host_buf, off, true, stream);
+    if (ok && layout.int8_kv) {
+        ok = ok && copy_region(kv.k_scale_pool(), kv.scale_layer_stride_elems(),
+                               scale_elems_per_block(layout), (int)sizeof(uint16_t), phys,
+                               first_block, n_blocks, layout.num_layers, host_buf, off, true,
+                               stream);
+        ok = ok && copy_region(kv.v_scale_pool(), kv.scale_layer_stride_elems(),
+                               scale_elems_per_block(layout), (int)sizeof(uint16_t), phys,
+                               first_block, n_blocks, layout.num_layers, host_buf, off, true,
+                               stream);
+    }
+    if (ok) ok = (cudaStreamSynchronize(stream) == cudaSuccess);
+
+    cudaFreeHost(h_staging);
+    return ok;
+}
+
+} // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1654,9 +1654,15 @@ BridgeKVLayout lmcache_layout_from_cfg(const Qwen35Config& cfg, const KVCacheMan
 // bridge is currently unreachable, or nothing chunk-aligned remains. Fire-and-forget: the actual
 // network round trip happens on BridgeClient's own background thread, this call only blocks for
 // the (synchronous, on-stream) cudaMemcpy staging into shm.
-void lmcache_maybe_store(Qwen35Model::Impl& s, uint64_t seq_id, const std::vector<int>& tokens,
+//
+// Takes individual fields rather than Impl& -- Impl is a private nested type, so a free function
+// outside the class can't name it in a signature even from within the same translation unit
+// (only member functions, which is why every call site below reads `s.<field>` from inside an
+// actual Qwen35Model member function's `Impl& s = *p_;`).
+void lmcache_maybe_store(BridgeClient* bridge, const Qwen35Config& cfg, KVCacheManager& kv,
+                         cudaStream_t stream, uint64_t seq_id, const std::vector<int>& tokens,
                          int start, int end) {
-    if (!s.lmcache_bridge || !s.lmcache_bridge->is_alive()) return;
+    if (!bridge || !bridge->is_alive()) return;
     const int chunk = lmcache_chunk_size_tokens();
     const int aligned_end = (end / chunk) * chunk;
     if (aligned_end <= start) return;
@@ -1664,9 +1670,9 @@ void lmcache_maybe_store(Qwen35Model::Impl& s, uint64_t seq_id, const std::vecto
     static std::atomic<uint64_t> counter{0};
     const std::string shm_name = "/sparkinfer_kv_store_" + std::to_string(seq_id) + "_" +
                                  std::to_string(counter.fetch_add(1));
-    const BridgeKVLayout layout = lmcache_layout_from_cfg(s.cfg, *s.kv);
-    if (!stage_kv_to_shm(*s.kv, layout, seq_id, start, aligned_end, shm_name, s.stream)) return;
-    s.lmcache_bridge->store_async(tokens, start, aligned_end, shm_name);
+    const BridgeKVLayout layout = lmcache_layout_from_cfg(cfg, kv);
+    if (!stage_kv_to_shm(kv, layout, seq_id, start, aligned_end, shm_name, stream)) return;
+    bridge->store_async(tokens, start, aligned_end, shm_name);
 }
 } // namespace
 
@@ -1898,7 +1904,8 @@ void Qwen35Model::clear_prefix_cache() {
         // is the "prefix cache overwrite" eviction point (docs/lmcache_bridge_protocol.md's
         // STORE trigger list): the active prefix is about to be dropped for a different one.
         if (s.prefix_active)
-            lmcache_maybe_store(s, s.active_seq_id, s.prefix_tokens, 0, s.prefix_len);
+            lmcache_maybe_store(s.lmcache_bridge, s.cfg, *s.kv, s.stream, s.active_seq_id,
+                               s.prefix_tokens, 0, s.prefix_len);
         s.kv->free(s.active_seq_id);
         invalidate_decode_graph();
     }
@@ -2023,7 +2030,8 @@ void Qwen35Model::close_session(uint64_t seq_id, const std::vector<int>* store_t
     // original prompt; only ContinuousBatchEngine::finish_job has that context) -- a null
     // pointer is a pure no-op here, not a degraded path.
     if (store_tokens && !store_tokens->empty())
-        lmcache_maybe_store(s, seq_id, *store_tokens, 0, (int)store_tokens->size());
+        lmcache_maybe_store(s.lmcache_bridge, s.cfg, *s.kv, s.stream, seq_id, *store_tokens, 0,
+                           (int)store_tokens->size());
     s.kv->free(seq_id);
     auto it = s.sessions.find(seq_id);
     if (it != s.sessions.end()) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1743,25 +1743,39 @@ bool Qwen35Model::prompt_matches_prefix(const std::vector<int>& prompt) const {
     return true;
 }
 
-int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end) {
+int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chunk_limit,
+                                     int* out_pos) {
     Impl& s = *p_;
-    if (!ids || end <= start) return -1;
+    if (!ids || end <= start) {
+        if (out_pos) *out_pos = start;
+        return -1;
+    }
     const int n = end - start;
+    // Batched GEMM prefill never chunks (no start_pos support in prefill_batched_run yet) --
+    // only eligible on the very first call for this range (start==0) and always covers the
+    // whole [0,end) in one pass regardless of chunk_limit.
     if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, n)) {
         int seed = prefill_batched(ids, n);
-        if (seed >= 0 && seed < s.cfg.vocab) return seed;
+        if (seed >= 0 && seed < s.cfg.vocab) {
+            if (out_pos) *out_pos = end;
+            return seed;
+        }
     }
+    int limit = n;
+    if (chunk_limit > 0 && n > chunk_limit) limit = chunk_limit;
+    const int stop = start + limit;
     int next = -1;
-    if (prefill_samples_lmhead()) {
-        for (int i = start; i < end; i++)
-            next = forward_token(ids[i], i, true);
-    } else {
-        for (int i = start; i + 1 < end; i++)
-            forward_token(ids[i], i, false);
-        if (end > start)
-            next = forward_token(ids[end - 1], end - 1, true);
+    for (int i = start; i < stop; i++) {
+        // Only sample (compute logits/argmax) at the true end of the whole range, not at a
+        // chunk boundary -- decode doesn't start until the full prompt is ingested, so
+        // intermediate chunk-final tokens never need a logits pass (unless the legacy
+        // every-step flag is set).
+        const bool sample = prefill_samples_lmhead() || i + 1 == end;
+        int r = forward_token(ids[i], i, sample);
+        if (sample) next = r;
     }
-    return next;
+    if (out_pos) *out_pos = stop;
+    return (stop >= end) ? next : -1;
 }
 
 bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1662,7 +1662,15 @@ BridgeKVLayout lmcache_layout_from_cfg(const Qwen35Config& cfg, const KVCacheMan
 void lmcache_maybe_store(BridgeClient* bridge, const Qwen35Config& cfg, KVCacheManager& kv,
                          cudaStream_t stream, uint64_t seq_id, const std::vector<int>& tokens,
                          int start, int end) {
-    if (!bridge || !bridge->is_alive()) return;
+    // Deliberately not gated on bridge->is_alive(): that only becomes true as a side effect of
+    // a prior successful handshake, so gating on it here would mean the very first store in a
+    // freshly started process never fires (nothing has ever connected yet to make it true) --
+    // found via the live E2E test (lmcache_e2e_gpu_test.cpp), which is exactly the class of bug
+    // that kind of test exists to catch. store_async() (and the LOOKUP call in
+    // ingest_prompt_range, same reasoning) already handle "is the bridge actually reachable"
+    // internally via their own lazy-connect + cooldown/backoff -- that's what their docstrings
+    // mean by "safe to call regardless."
+    if (!bridge) return;
     const int chunk = lmcache_chunk_size_tokens();
     const int aligned_end = (end / chunk) * chunk;
     if (aligned_end <= start) return;
@@ -1837,9 +1845,14 @@ int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chu
     // into a slower one for the remainder -- it's a strict win, never a trade-off. Only on the
     // very first call for this range (start==0); a chunked resumption call (start>0, continuing
     // a previous partial token-loop advance) never re-queries -- one round trip per prefill.
+    // Deliberately not gated on lmcache_bridge->is_alive(): that only becomes true as a side
+    // effect of a prior successful handshake, so gating on it here would mean the very first
+    // lookup in a freshly started process never fires (found via the live E2E test,
+    // lmcache_e2e_gpu_test.cpp -- exactly the class of bug that test exists to catch).
+    // lookup() already handles "is the bridge actually reachable" internally via its own
+    // lazy-connect + cooldown/backoff, bounded by the 5ms default timeout either way.
     int actual_start = start;
-    if (start == 0 && s.lmcache_bridge && s.lmcache_bridge->is_alive() &&
-        n >= lmcache_chunk_size_tokens()) {
+    if (start == 0 && s.lmcache_bridge && n >= lmcache_chunk_size_tokens()) {
         LookupResult res = s.lmcache_bridge->lookup(std::vector<int>(ids, ids + end));
         if (res.ok && res.matched_tokens > 0) {
             const BridgeKVLayout layout = lmcache_layout_from_cfg(s.cfg, *s.kv);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1868,7 +1868,17 @@ int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chu
             // garbage KV -- never resume the token loop past whatever was verified fully
             // restored, and never resume past a failure point at all: fall back to recomputing
             // the entire range from 0 rather than risk attending against corrupted KV.
-            if (restored) actual_start = res.matched_tokens;
+            //
+            // Clamped to end-1, never end itself: a full hit (matched_tokens == end) would
+            // otherwise skip the token loop entirely, and the token loop is what produces the
+            // decode seed (the LM-head logits at the last prompt position) -- the KV cache lets
+            // attention skip recomputing *past* positions, it doesn't let this function skip
+            // computing the *current*/last position's own forward pass, which is what next's
+            // value actually comes from. Found via lmcache_bench.cpp's benchmark, whose prompt
+            // length happened to land on an exact chunk boundary (matched_tokens == end) --
+            // earlier tests never hit this because their prompts weren't exact chunk multiples,
+            // so the token loop always had at least one real remaining token regardless.
+            if (restored) actual_start = std::min(res.matched_tokens, end - 1);
         }
     }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -22,6 +22,8 @@
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/proj_requant.h"
+#include "sparkinfer/lmcache_bridge_client.h"
+#include "sparkinfer/lmcache_staging.h"
 
 #include <cuda_runtime.h>
 #include <cstdio>
@@ -236,6 +238,12 @@ struct Qwen35Model::Impl {
     int prefix_len = 0;
     int prefix_next = -1;
     bool prefix_active = false;
+
+    // Optional external KV cache tier (docs/lmcache_bridge_protocol.md). Null = disabled (the
+    // default) -- every lookup/store call site below is a no-op when this is null, so nothing
+    // about existing behavior changes unless a caller explicitly opts in via
+    // set_lmcache_bridge().
+    BridgeClient* lmcache_bridge = nullptr;
 
     // DFlash speculative decoding (target-side primitives).
     DFlashDraftModel* dflash_draft = nullptr;
@@ -1607,6 +1615,59 @@ bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
     return want_batched && gguf && cfg.hybrid && ffn_ok && n_tokens > 0 &&
            n_tokens <= batched_maxctx;
 }
+
+// LMCache chunk size, tokens. Doubles as both the LOOKUP eligibility threshold (below this many
+// tokens, always recompute locally rather than pay an IPC round trip) and the STORE alignment
+// unit (a store range is rounded down to the nearest multiple, matching what the sidecar's own
+// LMCache instance is configured with -- see bridge/lmcache_bridge.py's identically-named env
+// var). Not negotiated from the sidecar's HELLO_ACK at runtime (that field exists on the wire
+// but is currently informational-only on this side, see lmcache_bridge_client.cpp) -- both sides
+// must be configured to agree; a mismatch degrades safely (misaligned STOREs are rejected by the
+// sidecar, not corrupted) rather than crashing, so this is a real but non-catastrophic
+// simplification, not a hidden correctness trap.
+int lmcache_chunk_size_tokens() {
+    static int chunk = [] {
+        const char* e = getenv("SPARKINFER_LMCACHE_CHUNK_SIZE");
+        const int v = e ? atoi(e) : 256;
+        return v > 0 ? v : 256;
+    }();
+    return chunk;
+}
+
+BridgeKVLayout lmcache_layout_from_cfg(const Qwen35Config& cfg, const KVCacheManager& kv) {
+    BridgeKVLayout layout;
+    layout.num_layers = cfg.n_layers;
+    layout.num_kv_heads = cfg.n_kv_heads;
+    layout.head_dim = cfg.head_dim;
+    layout.block_size = kv.block_size();
+    layout.int8_kv = kv.int8_kv();
+    layout.elem_bytes = kv.int8_kv() ? 1 : 2;
+    // model_name is unused for the staging byte-math this layout feeds (stage_kv_to_shm /
+    // restore_kv_from_shm never read it) -- the BridgeClient's own layout, fixed at construction
+    // and used for HELLO, is what actually needs to match the sidecar's.
+    return layout;
+}
+
+// Stores tokens[start, end) (rounded down to the nearest lmcache_chunk_size_tokens() boundary --
+// a trailing partial chunk is silently dropped, not sent, since the sidecar would reject it as
+// misaligned anyway) for seq_id to the external cache tier. No-op if no bridge is attached, the
+// bridge is currently unreachable, or nothing chunk-aligned remains. Fire-and-forget: the actual
+// network round trip happens on BridgeClient's own background thread, this call only blocks for
+// the (synchronous, on-stream) cudaMemcpy staging into shm.
+void lmcache_maybe_store(Qwen35Model::Impl& s, uint64_t seq_id, const std::vector<int>& tokens,
+                         int start, int end) {
+    if (!s.lmcache_bridge || !s.lmcache_bridge->is_alive()) return;
+    const int chunk = lmcache_chunk_size_tokens();
+    const int aligned_end = (end / chunk) * chunk;
+    if (aligned_end <= start) return;
+
+    static std::atomic<uint64_t> counter{0};
+    const std::string shm_name = "/sparkinfer_kv_store_" + std::to_string(seq_id) + "_" +
+                                 std::to_string(counter.fetch_add(1));
+    const BridgeKVLayout layout = lmcache_layout_from_cfg(s.cfg, *s.kv);
+    if (!stage_kv_to_shm(*s.kv, layout, seq_id, start, aligned_end, shm_name, s.stream)) return;
+    s.lmcache_bridge->store_async(tokens, start, aligned_end, shm_name);
+}
 } // namespace
 
 Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int context_tokens) {
@@ -1761,11 +1822,42 @@ int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chu
             return seed;
         }
     }
-    int limit = n;
-    if (chunk_limit > 0 && n > chunk_limit) limit = chunk_limit;
-    const int stop = start + limit;
+
+    // External KV cache lookup (docs/lmcache_bridge_protocol.md). Deliberately gated on
+    // batched_prefill_enabled() having already been tried-and-failed (or never eligible) above:
+    // the batched path is ~100x faster than the token loop and only ever eligible from position
+    // 0, so restoring a prefix from the bridge only when we were headed for the token loop
+    // anyway means a partial hit can never downgrade what would otherwise be a fast batched pass
+    // into a slower one for the remainder -- it's a strict win, never a trade-off. Only on the
+    // very first call for this range (start==0); a chunked resumption call (start>0, continuing
+    // a previous partial token-loop advance) never re-queries -- one round trip per prefill.
+    int actual_start = start;
+    if (start == 0 && s.lmcache_bridge && s.lmcache_bridge->is_alive() &&
+        n >= lmcache_chunk_size_tokens()) {
+        LookupResult res = s.lmcache_bridge->lookup(std::vector<int>(ids, ids + end));
+        if (res.ok && res.matched_tokens > 0) {
+            const BridgeKVLayout layout = lmcache_layout_from_cfg(s.cfg, *s.kv);
+            bool restored = true;
+            for (const BridgeKVChunk& c : res.chunks) {
+                if (!restore_kv_from_shm(*s.kv, layout, s.active_seq_id, res.shm_name,
+                                         c.shm_offset_bytes, c.start_tok, c.len_tok, s.stream)) {
+                    restored = false;
+                    break;
+                }
+            }
+            // A partial restore failure means some positions in [0, matched_tokens) may hold
+            // garbage KV -- never resume the token loop past whatever was verified fully
+            // restored, and never resume past a failure point at all: fall back to recomputing
+            // the entire range from 0 rather than risk attending against corrupted KV.
+            if (restored) actual_start = res.matched_tokens;
+        }
+    }
+
+    int limit = end - actual_start;
+    if (chunk_limit > 0 && limit > chunk_limit) limit = chunk_limit;
+    const int stop = actual_start + limit;
     int next = -1;
-    for (int i = start; i < stop; i++) {
+    for (int i = actual_start; i < stop; i++) {
         // Only sample (compute logits/argmax) at the true end of the whole range, not at a
         // chunk boundary -- decode doesn't start until the full prompt is ingested, so
         // intermediate chunk-final tokens never need a logits pass (unless the legacy
@@ -1802,6 +1894,11 @@ bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
 void Qwen35Model::clear_prefix_cache() {
     Impl& s = *p_;
     if (s.prefix_active || s.kv->allocated_tokens(s.active_seq_id) > 0) {
+        // Store to the external cache tier before the blocks it reads are freed below -- this
+        // is the "prefix cache overwrite" eviction point (docs/lmcache_bridge_protocol.md's
+        // STORE trigger list): the active prefix is about to be dropped for a different one.
+        if (s.prefix_active)
+            lmcache_maybe_store(s, s.active_seq_id, s.prefix_tokens, 0, s.prefix_len);
         s.kv->free(s.active_seq_id);
         invalidate_decode_graph();
     }
@@ -1915,9 +2012,18 @@ uint64_t Qwen35Model::open_session(int num_tokens) {
     return seq_id;
 }
 
-void Qwen35Model::close_session(uint64_t seq_id) {
+void Qwen35Model::set_lmcache_bridge(BridgeClient* bridge) { p_->lmcache_bridge = bridge; }
+
+void Qwen35Model::close_session(uint64_t seq_id, const std::vector<int>* store_tokens) {
     Impl& s = *p_;
     if (seq_id == 0) return;
+    // Store to the external cache tier before freeing the blocks it reads -- this is the
+    // "session close" eviction point (docs/lmcache_bridge_protocol.md's STORE trigger list).
+    // store_tokens is null for most callers (this model class doesn't itself track a session's
+    // original prompt; only ContinuousBatchEngine::finish_job has that context) -- a null
+    // pointer is a pure no-op here, not a degraded path.
+    if (store_tokens && !store_tokens->empty())
+        lmcache_maybe_store(s, seq_id, *store_tokens, 0, (int)store_tokens->size());
     s.kv->free(seq_id);
     auto it = s.sessions.find(seq_id);
     if (it != s.sessions.end()) {

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -47,6 +47,15 @@ add_executable(batch_engine_gpu_test batch_engine_gpu_test.cpp)
 target_link_libraries(batch_engine_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME batch_engine_gpu_test COMMAND batch_engine_gpu_test)
 
+# Real sidecar subprocess + real KV cache + a small synthetic model on real hardware -- the one
+# place both halves of the LMCache bridge run together against the real model code path. Skips
+# (not fails) unless SPARKINFER_LMCACHE_PYTHON/_BRIDGE_SCRIPT point at a real lmcache+torch venv
+# (see bridge/README.md) -- most environments running the rest of this suite won't have that
+# ~1.5GB, CPU-only-torch-is-enough dependency installed.
+add_executable(lmcache_e2e_gpu_test lmcache_e2e_gpu_test.cpp)
+target_link_libraries(lmcache_e2e_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
+add_test(NAME lmcache_e2e_gpu_test COMMAND lmcache_e2e_gpu_test)
+
 # GPU integration tests — run the real device path; skip without a device.
 add_executable(decode_runner_gpu_test decode_runner_gpu_test.cpp)
 target_link_libraries(decode_runner_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -33,6 +33,16 @@ target_link_libraries(scheduler_cpu_test PRIVATE sparkinfer_runtime)
 set_target_properties(scheduler_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME scheduler_cpu_test COMMAND scheduler_cpu_test)
 
+# BridgeClient (docs/lmcache_bridge_protocol.md) against a from-scratch fake AF_UNIX peer --
+# no GPU, no real lmcache/Python, no shm KV staging (that's bridge/tests/test_bridge_e2e.py's
+# job). Only needs lmcache_bridge_client.cpp, not the full sparkinfer_runtime -- it has zero CUDA
+# dependencies (confirmed: compiles standalone with plain g++, no CUDA headers needed).
+add_executable(lmcache_bridge_client_cpu_test lmcache_bridge_client_cpu_test.cpp
+               ../src/lmcache_bridge_client.cpp)
+target_link_libraries(lmcache_bridge_client_cpu_test PRIVATE Threads::Threads)
+set_target_properties(lmcache_bridge_client_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME lmcache_bridge_client_cpu_test COMMAND lmcache_bridge_client_cpu_test)
+
 add_executable(batch_engine_gpu_test batch_engine_gpu_test.cpp)
 target_link_libraries(batch_engine_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME batch_engine_gpu_test COMMAND batch_engine_gpu_test)

--- a/runtime/tests/lmcache_bridge_client_cpu_test.cpp
+++ b/runtime/tests/lmcache_bridge_client_cpu_test.cpp
@@ -181,6 +181,8 @@ int main() {
         assert(res.chunks.size() == 1);
         assert(res.chunks[0].start_tok == 0 && res.chunks[0].len_tok == 256);
         assert(client.is_alive());
+        assert(client.lookup_hit_count() == 1);
+        assert(client.lookup_miss_count() == 0);
         printf("[ok] handshake + LOOKUP hit\n");
     }
 
@@ -205,6 +207,10 @@ int main() {
         LookupResult res = client.lookup(std::vector<int>(256, 1));
         assert(res.ok);
         assert(res.matched_tokens == 0);
+        // res.ok is true (a well-formed response was parsed) but matched_tokens==0 is still a
+        // miss for counting purposes -- "ok" only means "the round trip succeeded," not "found."
+        assert(client.lookup_hit_count() == 0);
+        assert(client.lookup_miss_count() == 1);
         printf("[ok] LOOKUP miss\n");
     }
 

--- a/runtime/tests/lmcache_bridge_client_cpu_test.cpp
+++ b/runtime/tests/lmcache_bridge_client_cpu_test.cpp
@@ -1,0 +1,339 @@
+// Exercises BridgeClient against a from-scratch fake peer implementing just enough of
+// docs/lmcache_bridge_protocol.md's wire format to stand in for the real Python sidecar -- no
+// GPU, no real lmcache, no shm KV staging (that's covered separately: shm_transfer.py/protocol.py
+// by bridge/tests/, and the real round trip by bridge/tests/test_bridge_e2e.py). This test's job
+// is BridgeClient's own socket/timeout/degradation behavior: does it handshake correctly, time
+// out within budget instead of hanging, and survive a dead/absent/misbehaving peer without ever
+// crashing or blocking indefinitely.
+//
+// The frame (de)serialization here is a deliberately independent, minimal reimplementation of
+// the wire format (not a reuse of lmcache_bridge_client.cpp's private helpers) -- the point is to
+// verify BridgeClient's actual on-the-wire behavior against a spec-compliant peer, not to share
+// code with the thing being tested.
+#include "sparkinfer/lmcache_bridge_client.h"
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <atomic>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <chrono>
+#include <cstdlib>
+#include <functional>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+using sparkinfer::BridgeClient;
+using sparkinfer::BridgeKVLayout;
+using sparkinfer::LookupResult;
+
+constexpr uint32_t kMagic = 0x53494B56;
+constexpr uint16_t kVersion = 1;
+enum : uint16_t { HELLO = 1, HELLO_ACK = 2, LOOKUP = 3, LOOKUP_RESP = 4,
+                  STORE = 5, STORE_ACK = 6, PING = 7, PONG = 8, ERROR_MSG = 9 };
+
+#pragma pack(push, 1)
+struct Header { uint32_t magic; uint16_t version; uint16_t msg_type; uint32_t payload_len; uint32_t request_id; };
+#pragma pack(pop)
+static_assert(sizeof(Header) == 16, "header size must match the protocol");
+
+void put_u8(std::vector<uint8_t>& b, uint8_t v) { b.push_back(v); }
+void put_u32(std::vector<uint8_t>& b, uint32_t v) { for (int i = 0; i < 4; i++) b.push_back((uint8_t)(v >> (8 * i))); }
+void put_str(std::vector<uint8_t>& b, const std::string& s) { put_u32(b, (uint32_t)s.size()); b.insert(b.end(), s.begin(), s.end()); }
+
+std::vector<uint8_t> frame(uint16_t msg_type, uint32_t request_id, const std::vector<uint8_t>& payload) {
+    Header h{kMagic, kVersion, msg_type, (uint32_t)payload.size(), request_id};
+    std::vector<uint8_t> out((const uint8_t*)&h, (const uint8_t*)&h + sizeof(h));
+    out.insert(out.end(), payload.begin(), payload.end());
+    return out;
+}
+
+// Minimal fake sidecar: accepts connections on `path`, and for each connection runs `handler`
+// once per received frame (handler returns the raw response bytes to send back, or an empty
+// vector to send nothing at all -- used to simulate a hung/non-responsive peer).
+class FakePeer {
+public:
+    using Handler = std::function<std::vector<uint8_t>(uint16_t msg_type, uint32_t request_id,
+                                                        const std::vector<uint8_t>& payload)>;
+
+    FakePeer(std::string path, Handler handler) : path_(std::move(path)), handler_(std::move(handler)) {
+        unlink(path_.c_str());
+        fd_ = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+        assert(fd_ >= 0);
+        struct sockaddr_un addr;
+        memset(&addr, 0, sizeof(addr));
+        addr.sun_family = AF_UNIX;
+        strncpy(addr.sun_path, path_.c_str(), sizeof(addr.sun_path) - 1);
+        assert(bind(fd_, (struct sockaddr*)&addr, sizeof(addr)) == 0);
+        assert(listen(fd_, 4) == 0);
+        thread_ = std::thread([this] { run(); });
+    }
+
+    ~FakePeer() {
+        running_ = false;
+        shutdown(fd_, SHUT_RDWR);
+        close(fd_);
+        if (thread_.joinable()) thread_.join();
+        unlink(path_.c_str());
+    }
+
+private:
+    void run() {
+        while (running_) {
+            const int conn = accept(fd_, nullptr, nullptr);
+            if (conn < 0) return;  // fd_ closed (destructor) or real error -- either way, stop
+            std::thread([this, conn] {
+                std::vector<uint8_t> buf(1 << 20);
+                while (running_) {
+                    const ssize_t n = recv(conn, buf.data(), buf.size(), 0);
+                    if (n < (ssize_t)sizeof(Header)) break;
+                    Header h;
+                    memcpy(&h, buf.data(), sizeof(h));
+                    std::vector<uint8_t> payload(buf.begin() + sizeof(Header), buf.begin() + n);
+                    std::vector<uint8_t> resp = handler_(h.msg_type, h.request_id, payload);
+                    if (!resp.empty()) send(conn, resp.data(), resp.size(), 0);
+                }
+                close(conn);
+            }).detach();
+        }
+    }
+
+    std::string path_;
+    Handler handler_;
+    int fd_ = -1;
+    std::thread thread_;
+    volatile bool running_ = true;
+};
+
+BridgeKVLayout test_layout() {
+    BridgeKVLayout l;
+    l.num_layers = 4;
+    l.num_kv_heads = 2;
+    l.head_dim = 8;
+    l.block_size = 16;
+    l.int8_kv = false;
+    l.elem_bytes = 2;
+    l.model_name = "test-model";
+    return l;
+}
+
+std::string unique_socket_path(const char* tag) {
+    return "/tmp/sparkinfer_lmcache_test_" + std::string(tag) + "_" + std::to_string(getpid()) + ".sock";
+}
+
+double elapsed_ms(std::chrono::steady_clock::time_point t0) {
+    return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+}
+
+}  // namespace
+
+int main() {
+    // lookup_timeout_ms_config() (lmcache_bridge_client.cpp) caches its env-var read in a
+    // function-local static on first call -- a deliberate hot-path optimization for production
+    // (read once, not per-lookup), but it means this test must set the value ONCE here, before
+    // any BridgeClient::lookup() call anywhere below, rather than varying it per test case.
+    // 500ms is generous enough that this from-scratch thread-per-connection fake peer (real
+    // thread spawns + real socket round trips, no warm-path tuning) doesn't flake the happy-path
+    // assertions below the way the production default (5ms, tuned for a warm same-host sidecar)
+    // did during development of this test -- while still keeping the deliberately-hung-peer test
+    // fast enough to run routinely.
+    setenv("SPARKINFER_LMCACHE_LOOKUP_TIMEOUT_MS", "500", 1);
+
+    // --- successful handshake + LOOKUP hit ---
+    {
+        const std::string path = unique_socket_path("hit");
+        FakePeer peer(path, [](uint16_t msg_type, uint32_t rid, const std::vector<uint8_t>&) -> std::vector<uint8_t> {
+            if (msg_type == HELLO) {
+                std::vector<uint8_t> p;
+                put_u8(p, 1);
+                put_str(p, "0.0.0-fake");
+                put_u32(p, 256);
+                put_str(p, "");
+                return frame(HELLO_ACK, rid, p);
+            }
+            if (msg_type == LOOKUP) {
+                std::vector<uint8_t> p;
+                put_u32(p, 256);       // matched_tokens (i32, but positive so byte layout is the same)
+                put_str(p, "/sparkinfer_kv_test_hit");
+                put_u32(p, 1);          // n_chunks
+                put_u32(p, 0);          // start_tok
+                put_u32(p, 256);        // len_tok
+                for (int i = 0; i < 8; i++) p.push_back(0);  // shm_offset_bytes (u64) = 0
+                return frame(LOOKUP_RESP, rid, p);
+            }
+            return {};
+        });
+
+        BridgeClient client(path, test_layout());
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));  // let the peer start accepting
+        std::vector<int> tokens(256, 42);
+        LookupResult res = client.lookup(tokens);
+        assert(res.ok);
+        assert(res.matched_tokens == 256);
+        assert(res.shm_name == "/sparkinfer_kv_test_hit");
+        assert(res.chunks.size() == 1);
+        assert(res.chunks[0].start_tok == 0 && res.chunks[0].len_tok == 256);
+        assert(client.is_alive());
+        printf("[ok] handshake + LOOKUP hit\n");
+    }
+
+    // --- LOOKUP miss ---
+    {
+        const std::string path = unique_socket_path("miss");
+        FakePeer peer(path, [](uint16_t msg_type, uint32_t rid, const std::vector<uint8_t>&) -> std::vector<uint8_t> {
+            if (msg_type == HELLO) {
+                std::vector<uint8_t> p;
+                put_u8(p, 1); put_str(p, "0.0.0-fake"); put_u32(p, 256); put_str(p, "");
+                return frame(HELLO_ACK, rid, p);
+            }
+            if (msg_type == LOOKUP) {
+                std::vector<uint8_t> p;
+                put_u32(p, 0); put_str(p, ""); put_u32(p, 0);
+                return frame(LOOKUP_RESP, rid, p);
+            }
+            return {};
+        });
+        BridgeClient client(path, test_layout());
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        LookupResult res = client.lookup(std::vector<int>(256, 1));
+        assert(res.ok);
+        assert(res.matched_tokens == 0);
+        printf("[ok] LOOKUP miss\n");
+    }
+
+    // --- HELLO rejected (layout mismatch simulated by the fake peer) ---
+    {
+        const std::string path = unique_socket_path("reject");
+        FakePeer peer(path, [](uint16_t msg_type, uint32_t rid, const std::vector<uint8_t>&) -> std::vector<uint8_t> {
+            if (msg_type == HELLO) {
+                std::vector<uint8_t> p;
+                put_u8(p, 0); put_str(p, ""); put_u32(p, 0); put_str(p, "layout mismatch");
+                return frame(HELLO_ACK, rid, p);
+            }
+            return {};
+        });
+        BridgeClient client(path, test_layout());
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        LookupResult res = client.lookup(std::vector<int>(256, 1));
+        assert(!res.ok);  // rejected handshake must degrade to a miss, not a crash or hang
+        assert(!client.is_alive());
+        printf("[ok] rejected HELLO degrades to miss\n");
+    }
+
+    // --- no peer listening at all: fast fail, must not block ---
+    {
+        const std::string path = unique_socket_path("nopeer");
+        unlink(path.c_str());  // guarantee nothing is there
+        BridgeClient client(path, test_layout());
+        const auto t0 = std::chrono::steady_clock::now();
+        LookupResult res = client.lookup(std::vector<int>(256, 1));
+        const double ms = elapsed_ms(t0);
+        assert(!res.ok);
+        assert(ms < 200.0);  // connect() to a nonexistent AF_UNIX path fails immediately (ECONNREFUSED
+                              // / ENOENT), not a timeout wait -- generous bound to absorb CI jitter
+        printf("[ok] no peer listening -> fast fail (%.1fms)\n", ms);
+    }
+
+    // --- peer accepts but never responds to LOOKUP: must time out within budget, not hang ---
+    {
+        const std::string path = unique_socket_path("hang");
+        FakePeer peer(path, [](uint16_t msg_type, uint32_t rid, const std::vector<uint8_t>&) -> std::vector<uint8_t> {
+            if (msg_type == HELLO) {
+                std::vector<uint8_t> p;
+                put_u8(p, 1); put_str(p, "0.0.0-fake"); put_u32(p, 256); put_str(p, "");
+                return frame(HELLO_ACK, rid, p);
+            }
+            return {};  // LOOKUP: silently swallowed, simulating a hung sidecar
+        });
+        // Reusing the 500ms budget set at the top of main() -- see the comment there for why
+        // this can't be varied per test case (the timeout is read once and cached).
+        BridgeClient client(path, test_layout());
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        const auto t0 = std::chrono::steady_clock::now();
+        LookupResult res = client.lookup(std::vector<int>(256, 1));
+        const double ms = elapsed_ms(t0);
+        assert(!res.ok);
+        assert(ms < 2000.0);  // bounded by the 500ms timeout (+ generous scheduling slack), never hangs
+        printf("[ok] hung peer times out instead of hanging (%.1fms)\n", ms);
+    }
+
+    // --- malformed response: must degrade to a miss, not crash ---
+    {
+        const std::string path = unique_socket_path("malformed");
+        FakePeer peer(path, [](uint16_t msg_type, uint32_t rid, const std::vector<uint8_t>&) -> std::vector<uint8_t> {
+            if (msg_type == HELLO) {
+                std::vector<uint8_t> p;
+                put_u8(p, 1); put_str(p, "0.0.0-fake"); put_u32(p, 256); put_str(p, "");
+                return frame(HELLO_ACK, rid, p);
+            }
+            if (msg_type == LOOKUP) {
+                // Claims a LOOKUP_RESP with a huge payload_len but sends far fewer bytes --
+                // BridgeClient's recv_frame_locked must reject this as truncated, not read OOB.
+                std::vector<uint8_t> p;
+                put_u32(p, 999999);  // matched_tokens: nonsensical, but that's not even reached --
+                                     // the frame itself is short, caught before payload parsing
+                Header h{kMagic, kVersion, LOOKUP_RESP, 999999, rid};  // payload_len lies
+                std::vector<uint8_t> out((const uint8_t*)&h, (const uint8_t*)&h + sizeof(h));
+                out.insert(out.end(), p.begin(), p.end());  // actual bytes sent: far short of 999999
+                return out;
+            }
+            return {};
+        });
+        BridgeClient client(path, test_layout());
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        LookupResult res = client.lookup(std::vector<int>(256, 1));
+        assert(!res.ok);  // malformed frame -> miss, and critically: no crash getting here
+        printf("[ok] malformed frame degrades to miss, no crash\n");
+    }
+
+    // --- STORE ack ---
+    {
+        const std::string path = unique_socket_path("store");
+        std::atomic<bool> got_store{false};
+        FakePeer peer(path, [&got_store](uint16_t msg_type, uint32_t rid, const std::vector<uint8_t>&) -> std::vector<uint8_t> {
+            if (msg_type == HELLO) {
+                std::vector<uint8_t> p;
+                put_u8(p, 1); put_str(p, "0.0.0-fake"); put_u32(p, 256); put_str(p, "");
+                return frame(HELLO_ACK, rid, p);
+            }
+            if (msg_type == STORE) {
+                got_store = true;
+                std::vector<uint8_t> p;
+                put_u8(p, 1); put_str(p, "");
+                return frame(STORE_ACK, rid, p);
+            }
+            return {};
+        });
+        // BridgeClient's store thread unlinks this shm name after the ack -- give it something
+        // real to unlink so that codepath is exercised, not just skipped on ENOENT.
+        const std::string shm_name = "/sparkinfer_kv_test_store_" + std::to_string(getpid());
+        const int shm_fd = shm_open(shm_name.c_str(), O_CREAT | O_RDWR, 0600);
+        assert(shm_fd >= 0);
+        close(shm_fd);
+
+        BridgeClient client(path, test_layout());
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        client.store_async(std::vector<int>(256, 7), 0, 256, shm_name);
+        // The STORE background thread does its own fresh handshake on a separate connection
+        // (store_conn) with a 2000ms budget (hardcoded in lmcache_bridge_client.cpp -- STORE is
+        // off the hot path, so it gets a more generous timeout than LOOKUP) before it can even
+        // send the STORE frame -- poll comfortably past that worst case rather than the tighter
+        // budget an earlier version of this test used, which flaked under scheduling jitter.
+        for (int i = 0; i < 150 && !got_store; i++) std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        assert(got_store.load());
+        // Give the background thread a moment to process the ack and unlink.
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        assert(shm_open(shm_name.c_str(), O_RDONLY, 0) < 0);  // unlinked by BridgeClient's store thread
+        printf("[ok] STORE round trip + shm unlink\n");
+    }
+
+    printf("ALL PASSED\n");
+    return 0;
+}

--- a/runtime/tests/lmcache_e2e_gpu_test.cpp
+++ b/runtime/tests/lmcache_e2e_gpu_test.cpp
@@ -1,0 +1,298 @@
+// Live end-to-end test: a real sidecar subprocess (embedding the real `lmcache` package) +
+// ContinuousBatchEngine + a small synthetic model on real hardware. Unlike
+// lmcache_bridge_client_cpu_test.cpp (BridgeClient's own protocol/timeout behavior against a
+// fake peer) and bridge/tests/test_bridge_e2e.py (the sidecar's own protocol handling against a
+// raw socket client standing in for BridgeClient), this test is the one place both halves of the
+// bridge run together against the real model/KV-cache code path -- proving the whole feature
+// actually works, not just its two halves independently.
+//
+// A synthetic random-weight model (same pattern as batch_engine_gpu_test.cpp) is deliberately
+// used instead of a real GGUF: this test verifies the CACHING MECHANISM's correctness (does a
+// stored-then-restored KV chunk reproduce identical generation), which needs a real KV cache and
+// a real deterministic decode loop, not real model quality -- avoiding a multi-GB model download
+// keeps this test fast and independent of any specific model being available on the box.
+//
+// Skipped (not failed) when the sidecar's prerequisites aren't configured, matching the
+// no-CUDA-device skip convention elsewhere in this test suite: this needs Python + a real
+// lmcache/torch install (~1.5GB, CPU-only build), which most environments running the rest of
+// this test suite won't have.
+#include "sparkinfer/inference_engine.h"
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/lmcache_bridge_client.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/moe/engine.h"
+#include "sparkinfer/runtime.h"
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cuda_runtime.h>
+#include <cerrno>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+void* rand_bf16(size_t n, float s) {
+    std::vector<uint16_t> h(n);
+    for (size_t i = 0; i < n; i++) {
+        float f = s * (2.f * ((i * 2654435761u + 40503u) % 1000) / 1000.f - 1.f);
+        uint32_t b;
+        __builtin_memcpy(&b, &f, 4);
+        h[i] = (uint16_t)(b >> 16);
+    }
+    void* d = nullptr;
+    cudaMalloc(&d, n * sizeof(uint16_t));
+    cudaMemcpy(d, h.data(), n * sizeof(uint16_t), cudaMemcpyHostToDevice);
+    return d;
+}
+
+void fill_weights(sparkinfer::Qwen35Weights& w, const sparkinfer::Qwen35Config& cfg) {
+    const int H = cfg.hidden, Q = cfg.n_q_heads * cfg.head_dim, KV = cfg.n_kv_heads * cfg.head_dim;
+    const int E = cfg.n_experts, F = cfg.moe_ffn;
+    w.embed_tokens = rand_bf16((size_t)cfg.vocab * H, 1.f);
+    w.final_norm = rand_bf16(H, 0.5f);
+    w.lm_head = rand_bf16((size_t)H * cfg.vocab, 0.05f);
+    w.layers.resize(cfg.n_layers);
+    for (int l = 0; l < cfg.n_layers; l++) {
+        auto& lw = w.layers[l];
+        lw.input_norm = rand_bf16(H, 0.5f);
+        lw.wq = rand_bf16((size_t)H * Q, 0.04f);
+        lw.wk = rand_bf16((size_t)H * KV, 0.04f);
+        lw.wv = rand_bf16((size_t)H * KV, 0.04f);
+        lw.wo = rand_bf16((size_t)Q * H, 0.04f);
+        lw.q_norm = rand_bf16(cfg.head_dim, 0.5f);
+        lw.k_norm = rand_bf16(cfg.head_dim, 0.5f);
+        lw.post_attn_norm = rand_bf16(H, 0.5f);
+        lw.router_w = rand_bf16((size_t)H * E, 0.1f);
+        lw.gate = rand_bf16((size_t)E * H * F, 0.04f);
+        lw.up = rand_bf16((size_t)E * H * F, 0.04f);
+        lw.down = rand_bf16((size_t)E * F * H, 0.04f);
+        lw.shared_gate = rand_bf16((size_t)H * F, 0.04f);
+        lw.shared_up = rand_bf16((size_t)H * F, 0.04f);
+        lw.shared_down = rand_bf16((size_t)F * H, 0.04f);
+    }
+}
+
+// Mirrors model_engine.cpp's spawn_lmcache_sidecar -- deliberately not shared code (this test
+// wants to exercise the same CLI-args contract sparkinfer_server actually uses, independent of
+// whether that function itself has a bug).
+pid_t spawn_sidecar(const std::string& python, const std::string& script,
+                    const std::string& socket_path, const sparkinfer::Qwen35Config& cfg,
+                    const sparkinfer::KVCacheManager& kv) {
+    std::vector<std::string> args = {
+        python, script,
+        "--socket", socket_path,
+        "--instance-id", "lmcache-e2e-gpu-test",
+        "--num-layers", std::to_string(cfg.n_layers),
+        "--num-kv-heads", std::to_string(cfg.n_kv_heads),
+        "--head-dim", std::to_string(cfg.head_dim),
+        "--block-size", std::to_string(kv.block_size()),
+        "--elem-bytes", std::to_string(kv.int8_kv() ? 1 : 2),
+        "--model-name", "lmcache-e2e-gpu-test-model",
+        "--log-level", "WARNING",
+    };
+    if (kv.int8_kv()) args.push_back("--int8-kv");
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (auto& a : args) argv.push_back(const_cast<char*>(a.c_str()));
+    argv.push_back(nullptr);
+
+    const pid_t pid = fork();
+    if (pid < 0) return -1;
+    if (pid == 0) {
+        execvp(python.c_str(), argv.data());
+        fprintf(stderr, "[lmcache_e2e_gpu_test] exec failed: %s\n", strerror(errno));
+        _exit(127);
+    }
+    return pid;
+}
+
+void terminate_sidecar(pid_t pid) {
+    if (pid <= 0) return;
+    kill(pid, SIGTERM);
+    for (int i = 0; i < 100; i++) {  // up to 10s -- cold sidecar teardown includes an LMCache
+                                     // engine destroy, give it real room before SIGKILL
+        int status = 0;
+        if (waitpid(pid, &status, WNOHANG) == pid) return;
+        usleep(100000);
+    }
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+}
+
+}  // namespace
+
+int main() {
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no CUDA device\n");
+        return 0;
+    }
+    const char* python_env = getenv("SPARKINFER_LMCACHE_PYTHON");
+    const char* script_env = getenv("SPARKINFER_LMCACHE_BRIDGE_SCRIPT");
+    if (!python_env || !python_env[0] || !script_env || !script_env[0]) {
+        printf("[SKIP] SPARKINFER_LMCACHE_PYTHON / SPARKINFER_LMCACHE_BRIDGE_SCRIPT not set "
+               "(needs a real lmcache+torch venv -- see bridge/README.md)\n");
+        return 0;
+    }
+
+    auto rt = sparkinfer::Runtime::create({});
+    rt->initialize();
+
+    sparkinfer::Qwen35Config cfg;
+    cfg.vocab = 4000;
+    cfg.hidden = 2048;
+    cfg.n_layers = 2;
+    cfg.n_q_heads = 16;
+    cfg.n_kv_heads = 2;
+    cfg.head_dim = 128;
+    cfg.n_experts = 8;
+    cfg.top_k = 2;
+    cfg.n_shared = 1;
+    cfg.moe_ffn = 64;
+    cfg.max_seq = 1024;  // must comfortably exceed the 256+ token prompt below
+    cfg.eos_id = -1;
+
+    sparkinfer::KVCacheConfig kvc;
+    kvc.num_layers = cfg.n_layers;
+    kvc.num_kv_heads = cfg.n_kv_heads;
+    kvc.head_dim = cfg.head_dim;
+    kvc.block_size = 16;
+    sparkinfer::KVCacheManager kv(kvc, 512ull * 1024 * 1024);
+
+    sparkinfer::moe::MoEConfig mc;
+    mc.num_experts = cfg.n_experts;
+    mc.top_k = cfg.top_k;
+    mc.hidden_dim = cfg.hidden;
+    mc.ffn_dim = cfg.moe_ffn;
+    mc.num_layers = cfg.n_layers;
+    auto engine = sparkinfer::moe::MoEEngine::create(mc);
+
+    sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
+    sparkinfer::Qwen35Weights w;
+    fill_weights(w, cfg);
+    model.set_weights(w);
+
+    const std::string socket_path = "/tmp/sparkinfer_lmcache_e2e_gpu_test.sock";
+    unlink(socket_path.c_str());
+    const pid_t sidecar_pid = spawn_sidecar(python_env, script_env, socket_path, cfg, kv);
+    if (sidecar_pid <= 0) {
+        printf("[FAIL] could not spawn sidecar\n");
+        return 1;
+    }
+    printf("[lmcache_e2e_gpu_test] sidecar spawned (pid=%d), waiting for it to come up "
+           "(cold engine construction takes ~10s) ...\n", (int)sidecar_pid);
+    for (int i = 0; i < 300 && access(socket_path.c_str(), F_OK) != 0; i++)
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    if (access(socket_path.c_str(), F_OK) != 0) {
+        printf("[FAIL] sidecar never created its socket within 30s\n");
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));  // let listen() start accepting
+
+    sparkinfer::BridgeKVLayout layout;
+    layout.num_layers = cfg.n_layers;
+    layout.num_kv_heads = cfg.n_kv_heads;
+    layout.head_dim = cfg.head_dim;
+    layout.block_size = kv.block_size();
+    layout.int8_kv = kv.int8_kv();
+    layout.elem_bytes = kv.int8_kv() ? 1 : 2;
+    layout.model_name = "lmcache-e2e-gpu-test-model";
+    sparkinfer::BridgeClient bridge(socket_path, layout);
+    model.set_lmcache_bridge(&bridge);
+
+    sparkinfer::ContinuousBatchEngine batch(&model, &kv, 512);
+
+    // 300 tokens: >= one 256-token LMCache chunk, so the LOOKUP gate in ingest_prompt_range
+    // actually fires (see lmcache_chunk_size_tokens() in qwen35.cpp).
+    std::vector<int> prompt;
+    prompt.reserve(300);
+    for (int i = 0; i < 300; i++) prompt.push_back(1 + (i * 37) % (cfg.vocab - 1));
+
+    sparkinfer::ContinuousBatchEngine::Request req1;
+    req1.prompt = prompt;
+    req1.max_new_tokens = 8;
+    auto r1 = batch.complete(req1);
+    if (!r1.error.empty()) {
+        printf("[FAIL] request 1: %s\n", r1.error.c_str());
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    printf("[lmcache_e2e_gpu_test] request 1 done: %zu tokens, lookup hits=%llu misses=%llu\n",
+           r1.tokens.size(), (unsigned long long)bridge.lookup_hit_count(),
+           (unsigned long long)bridge.lookup_miss_count());
+    if (bridge.lookup_miss_count() < 1) {
+        printf("[FAIL] expected at least 1 LOOKUP miss on the first request (nothing cached yet)\n");
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    if (bridge.lookup_hit_count() != 0) {
+        printf("[FAIL] expected 0 LOOKUP hits on the first request, got %llu\n",
+               (unsigned long long)bridge.lookup_hit_count());
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+
+    // The STORE this session's close triggers is fire-and-forget (BridgeClient's background
+    // thread, plus the sidecar's own store() call) -- give it real time to land before the
+    // second request's LOOKUP would otherwise race it.
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+
+    sparkinfer::ContinuousBatchEngine::Request req2;
+    req2.prompt = prompt;  // identical prompt -- should now hit the stored chunk
+    req2.max_new_tokens = 8;
+    auto r2 = batch.complete(req2);
+    if (!r2.error.empty()) {
+        printf("[FAIL] request 2: %s\n", r2.error.c_str());
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+    printf("[lmcache_e2e_gpu_test] request 2 done: %zu tokens, lookup hits=%llu misses=%llu\n",
+           r2.tokens.size(), (unsigned long long)bridge.lookup_hit_count(),
+           (unsigned long long)bridge.lookup_miss_count());
+    if (bridge.lookup_hit_count() < 1) {
+        printf("[FAIL] expected at least 1 LOOKUP hit on the second (repeated-prompt) request -- "
+               "the stored chunk from request 1 should have been found\n");
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+
+    // The actual correctness bar: a cache hit must reproduce byte-identical generation.
+    // Greedy/deterministic decoding throughout this codebase makes this a strict, meaningful
+    // assertion, not a "numerically close" one -- any mismatch means the restored KV bytes are
+    // wrong (a corrupted scale, a block miscopy, a chunk-boundary/offset bug), not just "close
+    // enough."
+    if (r1.tokens != r2.tokens) {
+        printf("[FAIL] generation mismatch between cache-miss and cache-hit runs of the same "
+               "prompt -- restored KV must reproduce identical output. run1=[");
+        for (int t : r1.tokens) printf("%d ", t);
+        printf("] run2=[");
+        for (int t : r2.tokens) printf("%d ", t);
+        printf("]\n");
+        terminate_sidecar(sidecar_pid);
+        return 1;
+    }
+
+    terminate_sidecar(sidecar_pid);
+    unlink(socket_path.c_str());
+
+    cudaError_t err = cudaGetLastError();
+    if (err != cudaSuccess) {
+        printf("[FAIL] cuda error: %s\n", cudaGetErrorString(err));
+        return 1;
+    }
+
+    printf("[PASS] lmcache_e2e_gpu_test: cache-miss and cache-hit runs byte-identical "
+           "(%zu tokens), hits=%llu misses=%llu\n",
+           r1.tokens.size(), (unsigned long long)bridge.lookup_hit_count(),
+           (unsigned long long)bridge.lookup_miss_count());
+    return 0;
+}

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -57,6 +58,17 @@ public:
     int active_requests() const;
     int free_kv_blocks() const;
     int max_queue_depth() const;
+
+    // LMCache bridge counters (docs/lmcache_bridge_protocol.md), for GET /metrics'
+    // sparkinfer_lmcache_lookup_{hits,misses}_total. enabled=false (both counts 0) when
+    // SPARKINFER_LMCACHE_ENABLE wasn't set or the sidecar never came up -- distinct from
+    // "enabled but 0 lookups happened yet," which also reports zero counts but enabled=true.
+    struct LMCacheStats {
+        bool enabled = false;
+        uint64_t lookup_hits = 0;
+        uint64_t lookup_misses = 0;
+    };
+    LMCacheStats lmcache_stats() const;
 
 private:
     struct Impl;

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -341,6 +341,16 @@ int ModelEngine::max_queue_depth() const {
     return (impl_->ready && impl_->batch_engine) ? impl_->batch_engine->max_queue_depth() : 0;
 }
 
+ModelEngine::LMCacheStats ModelEngine::lmcache_stats() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    LMCacheStats stats;
+    if (!impl_->lmcache_bridge) return stats;  // enabled=false, both counts 0
+    stats.enabled = true;
+    stats.lookup_hits = impl_->lmcache_bridge->lookup_hit_count();
+    stats.lookup_misses = impl_->lmcache_bridge->lookup_miss_count();
+    return stats;
+}
+
 CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_ids,
                                                  int max_new_tokens,
                                                  const std::function<bool(int)>& on_token) {

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -3,12 +3,17 @@
 #include "sparkinfer/gguf.h"
 #include "sparkinfer/inference_engine.h"
 #include "sparkinfer/kv_cache.h"
+#include "sparkinfer/lmcache_bridge_client.h"
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/moe/engine.h"
 #include "sparkinfer/runtime.h"
 
 #include "../../runtime/examples/qwen3_gguf_config.h"
 
+#include <sys/wait.h>
+#include <unistd.h>
+#include <cerrno>
+#include <csignal>
 #include <cstdio>
 #include <cstring>
 #include <cuda_runtime.h>
@@ -32,6 +37,98 @@ int batch_tokens_per_step() {
     return v;
 }
 
+// LMCache bridge sidecar lifecycle (docs/lmcache_bridge_protocol.md). Off by default -- gated on
+// SPARKINFER_LMCACHE_ENABLE=1 -- so this feature ships with zero risk to existing behavior until
+// explicitly turned on. All the actual cache logic lives behind Qwen35Model's BridgeClient*
+// (null unless attached); this section only owns the sidecar subprocess and the socket path.
+
+bool lmcache_enabled() {
+    const char* e = getenv("SPARKINFER_LMCACHE_ENABLE");
+    return e && e[0] == '1';
+}
+
+std::string lmcache_socket_path() {
+    const char* e = getenv("SPARKINFER_LMCACHE_SOCKET");
+    return e ? e : "/tmp/sparkinfer_lmcache.sock";
+}
+
+// fork+exec the sidecar (python3 bridge/lmcache_bridge.py --socket ... --num-layers ... ...),
+// passing the KV layout as CLI args -- see bridge/lmcache_bridge.py's BridgeServer docstring for
+// why this is CLI args and not deferred to the first HELLO (engine construction there is ~10s of
+// first-time import + setup cost that must happen before any connection is accepted). Returns
+// the child pid, or -1 on failure (missing SPARKINFER_LMCACHE_BRIDGE_SCRIPT, fork()/exec()
+// failure) -- callers must treat -1 as "sidecar unavailable," never a fatal server error, matching
+// the protocol doc's degradation invariant.
+pid_t spawn_lmcache_sidecar(const std::string& socket_path, const sparkinfer::Qwen35Config& cfg,
+                            const sparkinfer::KVCacheManager& kv, const std::string& model_name) {
+    const char* script = getenv("SPARKINFER_LMCACHE_BRIDGE_SCRIPT");
+    if (!script || !script[0]) {
+        fprintf(stderr, "[sparkinfer-server] SPARKINFER_LMCACHE_ENABLE=1 but "
+                        "SPARKINFER_LMCACHE_BRIDGE_SCRIPT is unset -- lmcache disabled\n");
+        return -1;
+    }
+    const char* python_env = getenv("SPARKINFER_LMCACHE_PYTHON");
+    const std::string python = python_env && python_env[0] ? python_env : "python3";
+    const int elem_bytes = kv.int8_kv() ? 1 : 2;
+
+    std::vector<std::string> args = {
+        python,
+        script,
+        "--socket", socket_path,
+        "--instance-id", "sparkinfer",
+        "--num-layers", std::to_string(cfg.n_layers),
+        "--num-kv-heads", std::to_string(cfg.n_kv_heads),
+        "--head-dim", std::to_string(cfg.head_dim),
+        "--block-size", std::to_string(kv.block_size()),
+        "--elem-bytes", std::to_string(elem_bytes),
+        "--model-name", model_name,
+    };
+    if (kv.int8_kv()) args.push_back("--int8-kv");
+
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (auto& a : args) argv.push_back(const_cast<char*>(a.c_str()));
+    argv.push_back(nullptr);
+
+    const pid_t pid = fork();
+    if (pid < 0) {
+        fprintf(stderr, "[sparkinfer-server] lmcache sidecar fork() failed: %s\n", strerror(errno));
+        return -1;
+    }
+    if (pid == 0) {
+        // Child: stdout/stderr inherited from the parent (both point at the same stderr the
+        // server itself logs to, per the doc -- no extra log plumbing needed to see sidecar
+        // output). This spawn happens before sparkinfer_server ever binds its HTTP listener
+        // (load() runs ahead of svr.listen() in main()), so there's no listening socket fd to
+        // worry about leaking into the child; the CUDA context/device fds already open by this
+        // point (weights are already loaded onto the GPU) are never touched by the child since
+        // execvp runs immediately below with no CUDA calls in between, and NVIDIA's driver has
+        // set O_CLOEXEC on its own device fds for years specifically to make this pattern safe.
+        // execvp only returns on failure.
+        execvp(python.c_str(), argv.data());
+        fprintf(stderr, "[sparkinfer-server] lmcache sidecar exec failed: %s\n", strerror(errno));
+        _exit(127);
+    }
+    fprintf(stderr, "[sparkinfer-server] lmcache sidecar spawned (pid=%d, socket=%s)\n",
+            (int)pid, socket_path.c_str());
+    return pid;
+}
+
+// SIGTERM + bounded wait (5s) before SIGKILL -- mirrors the HTTP listener's own graceful-
+// shutdown grace period so a wedged sidecar never blocks server exit indefinitely.
+void terminate_lmcache_sidecar(pid_t pid) {
+    if (pid <= 0) return;
+    kill(pid, SIGTERM);
+    for (int i = 0; i < 50; i++) {
+        int status = 0;
+        if (waitpid(pid, &status, WNOHANG) == pid) return;
+        usleep(100000);
+    }
+    fprintf(stderr, "[sparkinfer-server] lmcache sidecar did not exit within 5s, sending SIGKILL\n");
+    kill(pid, SIGKILL);
+    waitpid(pid, nullptr, 0);
+}
+
 }  // namespace
 
 struct ModelEngine::Impl {
@@ -44,6 +141,22 @@ struct ModelEngine::Impl {
     std::unique_ptr<sparkinfer::ContinuousBatchEngine> batch_engine;
     std::vector<int> prefix_tokens;
     bool ready = false;
+
+    // LMCache bridge (docs/lmcache_bridge_protocol.md): the C++ socket client is owned here
+    // (BridgeClient itself is declared in lmcache_bridge_client.h; Qwen35Model only holds a
+    // non-owning pointer to it via set_lmcache_bridge()) alongside the sidecar subprocess this
+    // ModelEngine spawned for it. Both null/-1 when the feature is disabled or unavailable.
+    std::unique_ptr<sparkinfer::BridgeClient> lmcache_bridge;
+    pid_t lmcache_sidecar_pid = -1;
+
+    // Explicit teardown order: destroy the BridgeClient first (joins its ping/store threads,
+    // which may otherwise be mid-handshake against the sidecar) before killing the sidecar out
+    // from under it -- tearing them down in the other order risks those threads observing a
+    // closed socket mid-operation instead of a clean, already-stopped state.
+    ~Impl() {
+        lmcache_bridge.reset();
+        terminate_lmcache_sidecar(lmcache_sidecar_pid);
+    }
 };
 
 ModelEngine::ModelEngine() : impl_(std::make_unique<Impl>()) {}
@@ -58,6 +171,11 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     impl_->kv.reset();
     impl_->rt.reset();
     impl_->path.clear();
+    // A reload (load() called again on an already-loaded engine) must not leak the previous
+    // sidecar process or leave a BridgeClient pointing at a model that no longer exists.
+    impl_->lmcache_bridge.reset();
+    terminate_lmcache_sidecar(impl_->lmcache_sidecar_pid);
+    impl_->lmcache_sidecar_pid = -1;
 
     int ndev = 0;
     if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
@@ -115,6 +233,33 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     if (!impl_->model->load_gguf(gguf_path)) {
         fprintf(stderr, "[sparkinfer-server] load_gguf failed\n");
         return false;
+    }
+
+    if (lmcache_enabled()) {
+        const std::string socket_path = lmcache_socket_path();
+        impl_->lmcache_sidecar_pid =
+            spawn_lmcache_sidecar(socket_path, impl_->cfg, *impl_->kv, gguf_path);
+        if (impl_->lmcache_sidecar_pid > 0) {
+            sparkinfer::BridgeKVLayout layout;
+            layout.num_layers = impl_->cfg.n_layers;
+            layout.num_kv_heads = impl_->cfg.n_kv_heads;
+            layout.head_dim = impl_->cfg.head_dim;
+            layout.block_size = impl_->kv->block_size();
+            layout.int8_kv = impl_->kv->int8_kv();
+            layout.elem_bytes = impl_->kv->int8_kv() ? 1 : 2;
+            layout.model_name = gguf_path;
+            // Constructing BridgeClient does not block on the sidecar being ready yet (it
+            // connects/handshakes lazily on first use, respecting its own timeout budget) --
+            // safe to do immediately after fork() even though the sidecar's own ~10s cold-start
+            // engine build is still running in the background.
+            impl_->lmcache_bridge =
+                std::make_unique<sparkinfer::BridgeClient>(socket_path, layout);
+            impl_->model->set_lmcache_bridge(impl_->lmcache_bridge.get());
+        }
+        // lmcache_sidecar_pid <= 0 (spawn failure, e.g. missing SPARKINFER_LMCACHE_BRIDGE_SCRIPT)
+        // leaves lmcache_bridge null -- the model's every lookup/store call site treats that as
+        // "no cache tier," never a load failure. lmcache_enabled() being on with a broken sidecar
+        // config is a misconfiguration worth the stderr line above, not a reason to refuse to serve.
     }
 
     sparkinfer::SchedulePolicy policy = sparkinfer::SchedulePolicy::CONTINUOUS_BATCHING;

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -323,6 +323,22 @@ int main(int argc, char** argv) {
                 "# HELP sparkinfer_free_kv_blocks Free KV cache blocks\n"
                 "# TYPE sparkinfer_free_kv_blocks gauge\n"
              << "sparkinfer_free_kv_blocks " << engine.free_kv_blocks() << "\n";
+        // Only emitted when the LMCache bridge is actually enabled (docs/lmcache_bridge_protocol.md)
+        // -- omitting the metric entirely when disabled, rather than always emitting zeros, makes
+        // "is this feature even on" visible from /metrics itself, not just server startup logs.
+        const auto lmc = engine.lmcache_stats();
+        if (lmc.enabled) {
+            body << "# HELP sparkinfer_lmcache_lookup_hits_total External KV cache tier lookups "
+                    "that restored a matched prefix\n"
+                    "# TYPE sparkinfer_lmcache_lookup_hits_total counter\n"
+                 << "sparkinfer_lmcache_lookup_hits_total " << lmc.lookup_hits << "\n"
+                    "# HELP sparkinfer_lmcache_lookup_misses_total External KV cache tier lookups "
+                    "that found nothing usable (includes a genuine miss, a timed-out sidecar, and "
+                    "the sidecar being unreachable -- see docs/lmcache_bridge_protocol.md's "
+                    "degradation invariant, all three fall back to the same recompute path)\n"
+                    "# TYPE sparkinfer_lmcache_lookup_misses_total counter\n"
+                 << "sparkinfer_lmcache_lookup_misses_total " << lmc.lookup_misses << "\n";
+        }
         res.set_content(body.str(), "text/plain; version=0.0.4");
     });
 


### PR DESCRIPTION
## Summary
- Adds LMCache OSS (`lmcache==0.5.3`) as a secondary, CPU-RAM-backed KV cache tier, reached via a new sparkinfer-owned binary protocol (`AF_UNIX SOCK_SEQPACKET` + POSIX shm) to a Python sidecar process that embeds the real `lmcache` library.
- Off by default (`SPARKINFER_LMCACHE_ENABLE=1` to enable); zero behavior change when disabled.
- Primarily benefits Muse Glimmer, whose SWA/NoPE layer pattern has no batched prefill kernel (`batched_prefill_enabled()` always returns false) and so always pays full token-loop prefill today — LMCache lets a repeated/session-churned prefix skip that. For Qwythos/Qwen3.6 (`hybrid=true`, batched prefill available) it's an edge-case fallback only.
- 6 real bugs found and fixed via live testing against a real sidecar + real GPU (see individual commits): condvar sharing in `BridgeClient`, LMCache KV shape/dtype mismatch, a private-nested-type compile error, an `is_alive()` chicken-and-egg deadlock, a STORE mask-contract mismatch, and a full-cache-hit decode-seed loss.

## Test plan
- [x] `runtime/tests/lmcache_bridge_client_cpu_test.cpp` — fake AF_UNIX peer, no GPU/Python needed (30+ clean local runs)
- [x] `bridge/tests/test_protocol.py` — 16 pure-stdlib protocol round-trip tests
- [x] `bridge/tests/test_bridge_e2e.py` — real sidecar + real CPU-RAM `lmcache`, shape round-trip
- [x] `runtime/tests/lmcache_e2e_gpu_test.cpp` — real sidecar + real `ContinuousBatchEngine` + real GPU: LOOKUP miss then hit, byte-identical generated tokens between cache-miss and cache-hit runs
- [x] `runtime/examples/lmcache_bench.cpp` — TTFT: baseline 36798.35ms vs cache-hit 158.77ms (231.77x, synthetic model)
- [x] Decode-speed regression check (LMCache disabled, default) on real production GGUFs, 3 runs each, on `main` vs this branch:
  - Muse Glimmer 30B: ~96.6 tok/s both sides (no delta beyond noise)
  - Qwythos/Qwen3.6-35B-A3B: ~529.8-530.0 tok/s both sides (no delta beyond noise)