### PR TITLE
perf(muse-glimmer): emit Q8_1 from the sandwich-norm tail (1.04x decode @128)

### DIFF
--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -430,12 +430,18 @@ __global__ void norm_then_add_kernel(const __nv_bfloat16* __restrict__ residual,
 // the other kernel's exact loop order and warp-reduction tree, and stage 2 re-reads the bf16-
 // rounded out_x back from global rather than reusing the float registers, which is precisely what
 // the separate launch_rmsnorm would have seen.
+//
+// Optional out_q8: also emit Q8_1(out_xn) from the bf16-rounded out_xn, same contract as
+// add_rmsnorm2_q8_kernel, so the next MMVQ (FFN gate/up, next-layer QKV, or LM head) skips its
+// standalone quantize. Requires one pack per thread (blockDim == cols/8); the launcher enforces
+// that when out_q8 is set.
 __global__ void muse_sandwich_tail_kernel(const __nv_bfloat16* __restrict__ residual,
                                           const __nv_bfloat16* __restrict__ branch,
                                           const __nv_bfloat16* __restrict__ post_w,
                                           const __nv_bfloat16* __restrict__ next_w,
                                           __nv_bfloat16* __restrict__ out_x,
                                           __nv_bfloat16* __restrict__ out_xn,
+                                          si_blk_q8_1* __restrict__ out_q8,
                                           int cols, float post_eps, float eps) {
     const size_t base = (size_t)blockIdx.x * cols;
     __shared__ float s_warp[32];
@@ -523,6 +529,32 @@ __global__ void muse_sandwich_tail_kernel(const __nv_bfloat16* __restrict__ resi
             float v = __bfloat162float(out_x[base + c]);
             out_xn[base + c] = __float2bfloat16(v * inv2 * __bfloat162float(next_w[c]));
         }
+    }
+
+    // ---- optional Q8_1(out_xn) from the bf16-rounded write above ----
+    // Same layout as add_rmsnorm2_q8_kernel: one pack per thread, 4 consecutive threads per
+    // 32-element Q8_1 block. out_xn bf16 values are re-read so the quant is bit-identical to a
+    // standalone launch_quantize_q8_1_blocks on out_xn.
+    if (out_q8 && threadIdx.x < npack) {
+        out_q8 += (size_t)blockIdx.x * (cols >> 5);
+        const int t = threadIdx.x;
+        const uint4* on4 = reinterpret_cast<const uint4*>(out_xn + base);
+        float bv[8]; rn_unpack8(__ldg(on4 + t), bv);
+        float amax = 0.f;
+        #pragma unroll
+        for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(bv[j]));
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+        const float d = amax / 127.0f;
+        const int b = t >> 2, r = t & 3;
+        int s = 0;
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
+            out_q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+        }
+        s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
+        if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
     }
 }
 
@@ -648,6 +680,14 @@ void launch_add_rmsnorm3_q8_rows(const void* x, const void* res1, const void* re
 void launch_muse_sandwich_tail(const void* residual, const void* branch, const void* post_w,
                                const void* next_w, void* out_x, void* out_xn,
                                int rows, int cols, float post_eps, float eps, cudaStream_t stream) {
+    launch_muse_sandwich_tail_q8(residual, branch, post_w, next_w, out_x, out_xn, nullptr,
+                                 rows, cols, post_eps, eps, stream);
+}
+
+void launch_muse_sandwich_tail_q8(const void* residual, const void* branch, const void* post_w,
+                                  const void* next_w, void* out_x, void* out_xn, void* out_q8,
+                                  int rows, int cols, float post_eps, float eps,
+                                  cudaStream_t stream) {
     // 256 threads for a 6656-wide row means npack = 832 packs walked 3-4 deep per thread, twice,
     // on a chain of dependent loads -- and the whole thing is one CTA of a 170-SM device. One
     // thread per pack collapses that chain; 1024 is the first width that covers all 832 in a
@@ -660,19 +700,38 @@ void launch_muse_sandwich_tail(const void* residual, const void* branch, const v
     // 2.12623 -> 2.11524 and agreement with the true next token 176/191 -> 175/191, while
     // agreement against the 256-wide arm is 189/191 with mean |dlogprob| 1.1e-2.
     // SPARKINFER_MUSE_TAIL_W overrides the width (256/512/768/1024) for A/B.
+    //
+    // When emitting Q8_1(out_xn), force one pack per thread (cols/8): the Q8 layout mirrors
+    // add_rmsnorm2_q8 (4 consecutive threads per 32-element block). For Muse H=6656 that is
+    // 832 threads — still covers every pack in one pass. SPARKINFER_MUSE_TAIL_Q8=0 disables
+    // the emit even if out_q8 is passed (falls back to bf16-only and the caller's fresh quantize).
     static int tail_w = -1;
     if (tail_w < 0) {
         const char* e = getenv("SPARKINFER_MUSE_TAIL_W");
         tail_w = e ? atoi(e) : 1024;
         if (tail_w != 256 && tail_w != 512 && tail_w != 768 && tail_w != 1024) tail_w = 1024;
     }
-    muse_sandwich_tail_kernel<<<rows, tail_w, 0, stream>>>(
+    static int tail_q8 = -1;
+    if (tail_q8 < 0) {
+        const char* e = getenv("SPARKINFER_MUSE_TAIL_Q8");
+        tail_q8 = (e && e[0] == '0') ? 0 : 1;
+    }
+    si_blk_q8_1* q8 = (out_q8 && tail_q8) ? reinterpret_cast<si_blk_q8_1*>(out_q8) : nullptr;
+    int threads = tail_w;
+    if (q8) {
+        // One pack per thread for the Q8 epilogue; cols must be a multiple of 256 so each
+        // 32-element block sits inside one warp (same assert as launch_add_rmsnorm2_q8).
+        assert(cols % 256 == 0 && (cols >> 3) <= 1024);
+        threads = cols >> 3;
+    }
+    muse_sandwich_tail_kernel<<<rows, threads, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(residual),
         reinterpret_cast<const __nv_bfloat16*>(branch),
         reinterpret_cast<const __nv_bfloat16*>(post_w),
         reinterpret_cast<const __nv_bfloat16*>(next_w),
         reinterpret_cast<__nv_bfloat16*>(out_x),
-        reinterpret_cast<__nv_bfloat16*>(out_xn), cols, post_eps, eps);
+        reinterpret_cast<__nv_bfloat16*>(out_xn),
+        q8, cols, post_eps, eps);
 }
 
 void launch_norm_then_add(const void* residual, const void* block_out, const void* weight,

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -677,13 +677,8 @@ void launch_add_rmsnorm3_q8_rows(const void* x, const void* res1, const void* re
         reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
 }
 
-void launch_muse_sandwich_tail(const void* residual, const void* branch, const void* post_w,
-                               const void* next_w, void* out_x, void* out_xn,
-                               int rows, int cols, float post_eps, float eps, cudaStream_t stream) {
-    launch_muse_sandwich_tail_q8(residual, branch, post_w, next_w, out_x, out_xn, nullptr,
-                                 rows, cols, post_eps, eps, stream);
-}
-
+// Q8 launcher first: bf16 wrapper calls it, and this .cu does not include fused.h
+// (NVCC otherwise errors "identifier undefined" — Muse bot BUILD_FAILED on #777).
 void launch_muse_sandwich_tail_q8(const void* residual, const void* branch, const void* post_w,
                                   const void* next_w, void* out_x, void* out_xn, void* out_q8,
                                   int rows, int cols, float post_eps, float eps,
@@ -732,6 +727,13 @@ void launch_muse_sandwich_tail_q8(const void* residual, const void* branch, cons
         reinterpret_cast<__nv_bfloat16*>(out_x),
         reinterpret_cast<__nv_bfloat16*>(out_xn),
         q8, cols, post_eps, eps);
+}
+
+void launch_muse_sandwich_tail(const void* residual, const void* branch, const void* post_w,
+                               const void* next_w, void* out_x, void* out_xn,
+                               int rows, int cols, float post_eps, float eps, cudaStream_t stream) {
+    launch_muse_sandwich_tail_q8(residual, branch, post_w, next_w, out_x, out_xn, nullptr,
+                                 rows, cols, post_eps, eps, stream);
 }
 
 void launch_norm_then_add(const void* residual, const void* block_out, const void* weight,

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -47,6 +47,14 @@ void launch_muse_sandwich_tail(const void* residual_bf16, const void* branch_bf1
                                void* out_x_bf16, void* out_xn_bf16,
                                int rows, int cols, float post_eps, float eps,
                                cudaStream_t stream = nullptr);
+// Same sandwich tail, also emitting Q8_1(out_xn) into out_q8 (si_block_q8_1 layout) from the
+// bf16-rounded out_xn — the Muse equivalent of launch_add_rmsnorm2_q8. out_q8 may be null to
+// keep the bf16-only path. SPARKINFER_MUSE_TAIL_Q8=0 disables the emit even when out_q8 is set.
+void launch_muse_sandwich_tail_q8(const void* residual_bf16, const void* branch_bf16,
+                                  const void* post_w_bf16, const void* next_w_bf16,
+                                  void* out_x_bf16, void* out_xn_bf16, void* out_q8,
+                                  int rows, int cols, float post_eps, float eps,
+                                  cudaStream_t stream = nullptr);
 
 // Fold residual_add(res1,res2) into add_rmsnorm2: out_sum = x + (res1 + res2).
 void launch_add_rmsnorm3(const void* x_bf16, const void* res1_bf16, const void* res2_bf16,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -54,6 +54,16 @@ inline bool muse_fuse_tail() {
     }();
     return on;
 }
+// Fused sandwich also emits Q8_1(out_xn) into aq81 (Muse's fnq side channel). Off when the
+// fuse itself is off, or when SPARKINFER_MUSE_TAIL_Q8=0 (A/B vs a fresh standalone quantize).
+inline bool muse_tail_q8() {
+    static const bool on = [] {
+        if (!muse_fuse_tail()) return false;
+        const char* e = getenv("SPARKINFER_MUSE_TAIL_Q8");
+        return !(e && e[0] == '0');
+    }();
+    return on;
+}
 using bf16 = unsigned short;
 
 // forward_token() sentinel: the decode graph was enqueued but not yet collected. Never a valid
@@ -809,15 +819,10 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         dbg_bf16(s.xn, H, 10, L);   // tag 10: pre-attn-norm output (this layer's normed input)
         dbg_xn_snapshot(s.xn, L);
         // xn_q8_ready assumes the PREVIOUS layer's tail already emitted Q8_1(this layer's xn)
-        // into s.aq81 as a side effect (true for architectures whose post-MoE tail runs
-        // launch_add_rmsnorm2_q8 / add_rmsnorm3_q8). Muse Glimmer's tail is the sandwich-norm
-        // pair launch_norm_then_add + a plain launch_rmsnorm (see the c.muse_glimmer branch
-        // below) -- neither emits a Q8 side channel. Trusting xn_q8_ready==true here for L>0
-        // left s.aq81 permanently stuck holding layer 0's Q8_1(xn): every K/V projection at
-        // L=1..n_layers-1 (both wk_type=12 Q4_K and wv_type=14 Q6_K route through proj_xn's
-        // mmvq_q4k/mmvq_q6k branches, which read s.aq81 unconditionally) ran against the wrong
-        // layer's quantized activation. Force a fresh quantize every layer for muse_glimmer.
-        bool xn_q8_ready = fnq && L > 0 && !c.muse_glimmer;
+        // into s.aq81 as a side effect. Muse Glimmer's sandwich tail does that via
+        // launch_muse_sandwich_tail_q8 when muse_tail_q8() is on; otherwise force a fresh
+        // quantize (the old muse_glimmer exclusion).
+        bool xn_q8_ready = fnq && L > 0 && (!c.muse_glimmer || muse_tail_q8());
         auto prepare_xn_quant = [&](bool any_q4k, bool any_q6k, bool any_q80) {
             if (!s.gguf || !s.use_pq) return;
             if (xn_q8_ready) return;
@@ -1225,10 +1230,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // c.rms_eps here silently gives wrong post-attn/post-ffn norms.
             // Both halves of the sandwich tail are single-CTA kernels over 6656 elements, so each
             // costs ~3.2 us of launch/reduction latency for 13 KB of traffic. Fuse them.
-            if (muse_fuse_tail())
-                kernels::launch_muse_sandwich_tail(s.x, s.ao, w.post_attn_norm, w.ffn_norm,
-                                                   s.h, s.hn, 1, H, 1e-8f, c.rms_eps, st);
-            else {
+            // When fnq, also emit Q8_1(hn) into aq81 so the dense FFN gate/up MMVQ skips its
+            // standalone quantize — the Muse equivalent of launch_add_rmsnorm2_q8.
+            if (muse_fuse_tail()) {
+                if (fnq)
+                    kernels::launch_muse_sandwich_tail_q8(s.x, s.ao, w.post_attn_norm, w.ffn_norm,
+                                                          s.h, s.hn, s.aq81, 1, H, 1e-8f, c.rms_eps, st);
+                else
+                    kernels::launch_muse_sandwich_tail(s.x, s.ao, w.post_attn_norm, w.ffn_norm,
+                                                      s.h, s.hn, 1, H, 1e-8f, c.rms_eps, st);
+            } else {
             kernels::launch_norm_then_add(s.x, s.ao, w.post_attn_norm, s.h, 1, H, 1e-8f, st);
             dbg_bf16(s.h, H, 50, L);   // tag 50: h = x + sandwich_norm(ao)  (post-attn residual)
             kernels::launch_rmsnorm(s.h, w.ffn_norm, s.hn, 1, H, c.rms_eps, st);
@@ -1318,22 +1329,13 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // expert-FFN path as MoE decode — bf16 dequant+GEMV diverged ~40pp vs llama.cpp.
             //
             // input_q8 must be a valid Q8_1 quantization of s.hn (the FFN's actual input) or
-            // null (letting the kernel quantize s.hn itself). `fnq` only guarantees that for
-            // architectures whose post-attention step runs launch_add_rmsnorm2_q8, which emits
-            // Q8_1(hn) as a side effect of computing hn. Muse Glimmer's sandwich norm does not:
-            // its post-attn step is launch_norm_then_add (writes s.h, no Q8 emission) followed
-            // by a plain launch_rmsnorm into s.hn (see the c.muse_glimmer branch above) -- s.aq81
-            // at this point still holds Q8_1(xn) from this same layer's QKV-input quantize
-            // (prepare_xn_quant, earlier in this iteration), not Q8_1(hn). Passing that stale
-            // buffer here fed the gate/up MMVQ kernel the wrong activation vector entirely:
-            // garbage FFN output that still looked like a confident (but wrong) distribution
-            // downstream, rather than crashing or NaN-ing. Force nullptr for muse_glimmer so
-            // launch_moe_expert_ffn_q4k quantizes s.hn fresh instead of trusting the stale cache.
+            // null (letting the kernel quantize s.hn itself). With muse_tail_q8(), the post-attn
+            // sandwich emits Q8_1(hn) into aq81 via launch_muse_sandwich_tail_q8.
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,
                                                1, c.top_k, H, c.moe_ffn,
-                                               (fnq && !c.muse_glimmer) ? s.aq81 : nullptr, st);
+                                               (fnq && (!c.muse_glimmer || muse_tail_q8())) ? s.aq81 : nullptr, st);
         } else if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
             // The per-expert token counts only feed the batched-dispatch sort; the single-token
             // decode expert FFN reads ids/weights directly and never touches them. Zeroing that
@@ -1464,10 +1466,15 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // always null here. xn = RMSNorm(x, nextnorm) is the next layer's ordinary
             // pre-attn norm (or final_norm on the last layer), unaffected by the sandwich.
             // Same 1e-8 post_norm_eps as the post-attn sandwich norm above -- see that comment.
-            if (muse_fuse_tail())
-                kernels::launch_muse_sandwich_tail(s.h, s.routed, w.post_ffn_norm, nextnorm,
-                                                   s.x, s.xn, 1, H, 1e-8f, c.rms_eps, st);
-            else {
+            // When fnq, emit Q8_1(xn) into aq81 for the next layer's QKV / final LM head.
+            if (muse_fuse_tail()) {
+                if (fnq)
+                    kernels::launch_muse_sandwich_tail_q8(s.h, s.routed, w.post_ffn_norm, nextnorm,
+                                                          s.x, s.xn, s.aq81, 1, H, 1e-8f, c.rms_eps, st);
+                else
+                    kernels::launch_muse_sandwich_tail(s.h, s.routed, w.post_ffn_norm, nextnorm,
+                                                      s.x, s.xn, 1, H, 1e-8f, c.rms_eps, st);
+            } else {
             kernels::launch_norm_then_add(s.h, s.routed, w.post_ffn_norm, s.x, 1, H, 1e-8f, st);
             dbg_bf16(s.x, H, 70, L);   // tag 70: x = h + sandwich_norm(routed)  (layer output)
             kernels::launch_rmsnorm(s.x, nextnorm, s.xn, 1, H, c.rms_eps, st);
@@ -1497,22 +1504,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
         cu(cudaStreamSynchronize(st), "prefill sync");
         return token_id;
     }
-    // Third instance of the same stale-Q8_1-cache pattern as prepare_xn_quant's xn_q8_ready
-    // (L>0) and the dense_ffn gate/up input above: `fnq` only promises aq81==Q8_1(xn) here
-    // because the fnq path's final-layer tail is launch_add_rmsnorm2_q8/add_rmsnorm3_q8,
-    // which writes xn AND emits Q8_1(xn) into aq81 as a side effect. Muse Glimmer's final-
-    // layer tail is the c.muse_glimmer sandwich-norm branch above (launch_norm_then_add then
-    // a plain launch_rmsnorm into s.xn) -- no Q8 side channel. `fnq` itself doesn't check
-    // c.muse_glimmer (it's just s.gguf/use_fnq/use_pq/use_llama), so with fnq true this
-    // silently fed the LM head a stale aq81 left over from the last layer's fresh
-    // prepare_xn_quant(xn) quantize (a *different*, pre-final-norm activation vector) --
-    // wrong logits on every single decode step. Force a fresh quantize for muse_glimmer.
+    // Final LM-head quantize: with muse_tail_q8() the last layer's post-ffn sandwich emits
+    // Q8_1(xn) into aq81 (launch_muse_sandwich_tail_q8), same as add_rmsnorm2_q8 on other models.
     if (s.gguf && s.use_pq && s.use_llama && s.w.lm_head_type == 12) {
-        if (!fnq || c.muse_glimmer) kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
+        if (!fnq || (c.muse_glimmer && !muse_tail_q8()))
+            kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
         kernels::launch_mmvq_q4k_f32(s.aq81, s.w.lm_head, s.logits, c.vocab, H, st);
     }
     else if (s.gguf && s.use_q6mmvq && s.w.lm_head_type == 14) {   // int8 Q6_K dp4a LM head (1 warp/row)
-        if (!fnq || c.muse_glimmer) kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);  // else aq81 = Q8_1(xn) from final norm
+        if (!fnq || (c.muse_glimmer && !muse_tail_q8()))
+            kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);  // else aq81 = Q8_1(xn) from final norm
         kernels::launch_gemv_q6k_dp4a_f32(s.aq81, s.w.lm_head, s.logits, c.vocab, H, st);
     }
     else if (s.gguf && s.w.lm_head_type) kernels::launch_gemv_q_f32(s.xn, s.w.lm_head, s.w.lm_head_type, s.logits, c.vocab, H, st);


### PR DESCRIPTION
## Summary

Every non-Muse architecture's fused-norm path (`launch_add_rmsnorm2_q8` /
`add_rmsnorm3_q8`) writes `out_norm` **and** emits `Q8_1(out_norm)` into `aq81`,
so the next MMVQ skips its standalone quantize. Muse Glimmer's sandwich-norm
tail never grew that side channel — after the correctness fix in `6d911d4`,
decode was forced to re-quantize every layer (`!c.muse_glimmer` guards at the
QKV reuse, dense-FFN input, and LM head). That is ~100 extra quantize graph
nodes per 128-token step on the path the Muse bot scores.

Finish the port: `muse_sandwich_tail` optionally emits `Q8_1(out_xn)` from the
bf16-rounded write (same layout as `add_rmsnorm2_q8_kernel`), wire both
post-attn / post-ffn call sites, and drop the three muse exclusions.

`SPARKINFER_MUSE_TAIL_Q8=0` restores the fresh-quantize path for A/B.
`SPARKINFER_MUSE_FUSE_TAIL=0` still splits the sandwich and keeps the old
quantize behaviour.

- [x] Tested on **RTX 5090** (`sm_120`)

### Measured (RTX 5090, clocks locked 2550, 2 reps per arm)

`qwen3_gguf_bench <muse-glimmer-….gguf> 128 0` — the configuration the Muse
Glimmer bot scores:

| | decode tok/s |
|---|--:|
| before (main) | 96.60 |
| after (this PR) | 99.77 |

A/B on one binary: `SPARKINFER_MUSE_TAIL_Q8=0` (before) vs unset (after).

### Checks

- Muse bot accuracy gate: top1 ≥ 0.90, KL ≤ 0.10 vs live llama.cpp on the same GGUF
- `SPARKINFER_MUSE_TAIL_Q8=0` reproduces main's quantize behaviour
- Qwen3.6 / non-muse paths untouched (`c.muse_glimmer` gated)