### PR TITLE
fix(muse-glimmer): decode() strips harmony-format markers, breaking content routing

### DIFF
--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -166,9 +166,12 @@ std::string filter_answer_chunk(std::string& carry, const std::string& piece) {
 struct ChatTokenizer::Impl {
     std::unique_ptr<tokenizers::Tokenizer> tok;
     bool museglimmer = false;
-    // Muse Glimmer harmony-format marker token ids, resolved lazily on first decode() once
-    // `tok` is loaded and `museglimmer` is set -- see decode()'s comment for why these need
-    // special handling.
+    // Muse Glimmer harmony-format marker token ids, resolved once in set_museglimmer() (single
+    // -threaded server startup, after `tok` is loaded) -- see decode()'s comment for why these
+    // need special handling. Deliberately NOT lazily resolved on first decode(): decode() runs
+    // on the shared g_tokenizer from every /v1/chat/completions request, and cpp-httplib
+    // dispatches those across a real thread pool by default -- a lazy first-call init here
+    // would race across concurrently-arriving requests.
     int32_t mg_start_id = -1, mg_message_id = -1, mg_eom_id = -1, mg_eot_id = -1;
 };
 
@@ -196,7 +199,20 @@ bool ChatTokenizer::load(const std::string& tokenizer_json_path, std::string& er
     return true;
 }
 
-void ChatTokenizer::set_museglimmer(bool on) { impl_->museglimmer = on; }
+void ChatTokenizer::set_museglimmer(bool on) {
+    impl_->museglimmer = on;
+    // Resolve the harmony-format marker ids here (single-threaded startup, `tok` already
+    // loaded by this point) rather than lazily in decode() -- see the Impl::mg_start_id
+    // comment for why. TokenToId returns -1 for an unknown token, which decode()'s
+    // marker_str() already treats as "never matches", so a missing marker degrades
+    // gracefully instead of crashing.
+    if (on && impl_->tok) {
+        impl_->mg_start_id = impl_->tok->TokenToId(kMgStart);
+        impl_->mg_message_id = impl_->tok->TokenToId(kMgMessage);
+        impl_->mg_eom_id = impl_->tok->TokenToId(kMgEom);
+        impl_->mg_eot_id = impl_->tok->TokenToId(kMgEot);
+    }
+}
 
 bool parse_chat_messages(const std::string& request_json, std::vector<ChatMessage>& messages, std::string& err) {
     messages.clear();
@@ -629,13 +645,8 @@ std::string ChatTokenizer::decode(const std::vector<int>& ids) const {
         // kMgStart/kMgMessage/kMgEom/kMgEot constants the parser already searches for,
         // rather than relying on the library's special-token handling. Non-museglimmer
         // models (Qwen3.6 et al, whose <think> tags are ordinary text tokens, not special
-        // ones) are unaffected -- this whole branch is gated on impl_->museglimmer.
-        if (impl_->mg_start_id < 0) {
-            impl_->mg_start_id = impl_->tok->TokenToId(kMgStart);
-            impl_->mg_message_id = impl_->tok->TokenToId(kMgMessage);
-            impl_->mg_eom_id = impl_->tok->TokenToId(kMgEom);
-            impl_->mg_eot_id = impl_->tok->TokenToId(kMgEot);
-        }
+        // ones) are unaffected -- this whole branch is gated on impl_->museglimmer. Marker
+        // ids are resolved once in set_museglimmer(), not lazily here -- see Impl::mg_start_id.
         auto marker_str = [&](int32_t id) -> const char* {
             if (id == impl_->mg_start_id) return kMgStart;
             if (id == impl_->mg_message_id) return kMgMessage;

--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -166,6 +166,10 @@ std::string filter_answer_chunk(std::string& carry, const std::string& piece) {
 struct ChatTokenizer::Impl {
     std::unique_ptr<tokenizers::Tokenizer> tok;
     bool museglimmer = false;
+    // Muse Glimmer harmony-format marker token ids, resolved lazily on first decode() once
+    // `tok` is loaded and `museglimmer` is set -- see decode()'s comment for why these need
+    // special handling.
+    int32_t mg_start_id = -1, mg_message_id = -1, mg_eom_id = -1, mg_eot_id = -1;
 };
 
 ChatTokenizer::ChatTokenizer() : impl_(std::make_unique<Impl>()) {}
@@ -608,6 +612,57 @@ bool ChatTokenizer::encode_chat_request(const std::string& request_json, std::ve
 std::string ChatTokenizer::decode(const std::vector<int>& ids) const {
     if (!impl_->tok || ids.empty()) return {};
     std::vector<int32_t> v(ids.begin(), ids.end());
+
+    if (impl_->museglimmer) {
+        // Muse Glimmer's harmony-format structural tokens (<|start|>, <|message|>, <|eom|>,
+        // <|eot|>) are registered as special tokens in its tokenizer.json, so the underlying
+        // tokenizers-cpp Decode() silently drops them from the output text (standard
+        // skip-special-tokens decode behavior, confirmed empirically: decoding any of these
+        // four ids alone returns ""). But parse_museglimmer_output/ThinkingStreamSplitter
+        // both scan the DECODED TEXT for those literal marker strings to find segment
+        // boundaries -- with them stripped, the scan never finds a match and both content
+        // and reasoning_content come back empty regardless of what the model generated.
+        //
+        // Fix: decode body/header text in non-marker runs (so BPE merging/spacing across
+        // ordinary tokens stays correct -- ordinary Decode() semantics, unchanged) and
+        // splice the literal marker string back in at each split point using the same
+        // kMgStart/kMgMessage/kMgEom/kMgEot constants the parser already searches for,
+        // rather than relying on the library's special-token handling. Non-museglimmer
+        // models (Qwen3.6 et al, whose <think> tags are ordinary text tokens, not special
+        // ones) are unaffected -- this whole branch is gated on impl_->museglimmer.
+        if (impl_->mg_start_id < 0) {
+            impl_->mg_start_id = impl_->tok->TokenToId(kMgStart);
+            impl_->mg_message_id = impl_->tok->TokenToId(kMgMessage);
+            impl_->mg_eom_id = impl_->tok->TokenToId(kMgEom);
+            impl_->mg_eot_id = impl_->tok->TokenToId(kMgEot);
+        }
+        auto marker_str = [&](int32_t id) -> const char* {
+            if (id == impl_->mg_start_id) return kMgStart;
+            if (id == impl_->mg_message_id) return kMgMessage;
+            if (id == impl_->mg_eom_id) return kMgEom;
+            if (id == impl_->mg_eot_id) return kMgEot;
+            return nullptr;
+        };
+        std::string out;
+        std::vector<int32_t> run;
+        auto flush_run = [&]() {
+            if (!run.empty()) {
+                out += impl_->tok->Decode(run);
+                run.clear();
+            }
+        };
+        for (int32_t id : v) {
+            if (const char* m = marker_str(id)) {
+                flush_run();
+                out += m;
+            } else {
+                run.push_back(id);
+            }
+        }
+        flush_run();
+        return out;
+    }
+
     return impl_->tok->Decode(v);
 }
 


### PR DESCRIPTION
## Summary

`ChatTokenizer::decode()` calls `tokenizers-cpp`'s `Decode()`, which skips special tokens by default. Muse Glimmer's harmony-format structural tokens (`<|start|>`, `<|message|>`, `<|eom|>`, `<|eot|>`) are registered as special tokens in its `tokenizer.json`, so they get silently stripped from the decoded text.

`parse_museglimmer_output()` and `ThinkingStreamSplitter` both scan the decoded text for those literal marker strings to find segment boundaries and route `to=self` vs `to=user` content. With the markers stripped, the scan never finds a match, and both `content` and `reasoning_content` come back empty — regardless of `enable_thinking`, regardless of `max_tokens`, regardless of whether the model generated anything coherent.

## Repro

Plain `"Say hi"` request against `Muse-Glimmer-30B-UD-Q4_K_XL.gguf`: every `/v1/chat/completions` response returns `content:""` with `finish_reason:"stop"`, despite `completion_tokens` being fully consumed and real GPU decode time elapsed (confirmed via `nvidia-smi` telemetry during generation — temp/power climbed as expected).

Confirmed directly with the tokenizer that decoding any of the four marker ids alone (e.g. id `200023` for `<|message|>`) returns an empty string:
```python
tok.decode([200023], skip_special_tokens=True)  # -> ''
tok.decode([200023], skip_special_tokens=False)  # -> '<|message|>'
```

## Fix

In `decode()`, when museglimmer mode is active, split the id sequence at marker-token boundaries (resolved once via `TokenToId`, not hardcoded), decode each non-marker run through the normal `Decode()` path (preserving correct BPE merging/spacing for ordinary content), and splice the literal marker string back in at each split point using the same `kMgStart`/`kMgMessage`/`kMgEom`/`kMgEot` constants the parser already searches for.

Non-museglimmer models are unaffected — gated entirely on `impl_->museglimmer`, and Qwen3.6's `<think>` tags are ordinary text tokens (not special ones) so they were never affected by this in the first place.

## Note: separate deeper issue found while testing this

While verifying this fix I found the server's continuous-batching/int8-KV-cache generation path produces entirely different (incoherent) token sequences than the plain CLI generate path (`qwen3_gguf_generate`) given the *identical* prompt, for this model. That's a distinct bug in generation itself, not decoding — filing it as a separate issue rather than bundling it here, since this PR's fix is real and correct on its own regardless of that deeper issue.

## Test plan

- [x] Built clean (`cmake --build build --target sparkinfer_server`)
- [x] Verified marker ids resolve correctly via `TokenToId` (`start=200022 message=200023 eom=200007 eot=200008`)
- [x] Confirmed non-museglimmer path (Qwen3.6) untouched — fix is gated on `impl_->museglimmer`
- [ ] Full accuracy-gate run (`eval/pr_museglimmer_bot.py`) — left to the repo's own CI, since I don't have access to the pinned eval GPU and the reference corpus this bot uses

🤖 Generated with [Claude Code](https://claude.com/claude-code)