### PR TITLE
perf(muse-glimmer): fill idle bus windows with L2 prefetch and collapse four decode launches per layer (1.03x decode @128)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -452,6 +452,22 @@ template __global__ void fa_combine_kernel<256, FA_COMBINE_DG, 16>(const float*,
 template __global__ void fa_combine_gated_q8_kernel<256, FA_COMBINE_DG, FA_COMBINE_NW>(
     const float*, const float*, const float*, __nv_bfloat16*, const __nv_bfloat16*, int, int, fa_block_q8_1*);
 #endif
+// head_dim=128 gated combine. The kernel is HEAD_DIM-generic (ELEMS = HEAD_DIM/(32*DG) = 1 here);
+// only the hd256 architectures had ever been instantiated, which is what kept Muse Glimmer (128)
+// on the split path -- a separate sigmoid-gate kernel plus a separate output quantize, two extra
+// graph nodes per layer, 104 per step.
+#ifndef _MSC_VER
+template __global__ void fa_combine_gated_q8_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(
+    const float*, const float*, const float*, __nv_bfloat16*, const __nv_bfloat16*, int, int, fa_block_q8_1*);
+#endif
+#ifndef _MSC_VER
+template __global__ void fa_combine_gated_q8_kernel<128, FA_COMBINE_DG, 8>(
+    const float*, const float*, const float*, __nv_bfloat16*, const __nv_bfloat16*, int, int, fa_block_q8_1*);
+#endif
+#ifndef _MSC_VER
+template __global__ void fa_combine_gated_q8_kernel<128, FA_COMBINE_DG, 16>(
+    const float*, const float*, const float*, __nv_bfloat16*, const __nv_bfloat16*, int, int, fa_block_q8_1*);
+#endif
 #ifndef _MSC_VER
 template __global__ void fa_combine_gated_q8_kernel<256, FA_COMBINE_DG, 8>(
     const float*, const float*, const float*, __nv_bfloat16*, const __nv_bfloat16*, int, int, fa_block_q8_1*);
@@ -684,6 +700,27 @@ static inline void fa_launch_combine(
         part_m, part_l, part_acc, out, num_q_heads, n_splits, out_q8);
 }
 
+template <int NW>
+static inline void fa_launch_combine_gated(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, const __nv_bfloat16* gate, int num_q_heads, int n_splits,
+    fa_block_q8_1* out_q8, int num_seqs, cudaStream_t stream
+) {
+    dim3 g(num_q_heads * FA_COMBINE_DG, num_seqs);
+    fa_combine_gated_q8_kernel<128, FA_COMBINE_DG, NW><<<g, NW * 32, 0, stream>>>(
+        part_m, part_l, part_acc, out, gate, num_q_heads, n_splits, out_q8);
+}
+
+static inline void fa_launch_combine_gated_dispatch(
+    const float* part_m, const float* part_l, const float* part_acc,
+    __nv_bfloat16* out, const __nv_bfloat16* gate, int num_q_heads, int n_splits,
+    fa_block_q8_1* out_q8, int num_seqs, cudaStream_t stream
+) {
+    if (n_splits >= 128)      fa_launch_combine_gated<16>(part_m, part_l, part_acc, out, gate, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else if (n_splits >= 64)  fa_launch_combine_gated<8>(part_m, part_l, part_acc, out, gate, num_q_heads, n_splits, out_q8, num_seqs, stream);
+    else                      fa_launch_combine_gated<FA_COMBINE_NW>(part_m, part_l, part_acc, out, gate, num_q_heads, n_splits, out_q8, num_seqs, stream);
+}
+
 static inline void fa_launch_combine_dispatch(
     const float* part_m, const float* part_l, const float* part_acc,
     __nv_bfloat16* out, int num_q_heads, int n_splits, fa_block_q8_1* out_q8,
@@ -759,9 +796,12 @@ void launch_flash_decode_split(
     int num_seqs, int num_q_heads, int num_kv_heads, int head_dim,
     int block_size, int max_blocks, int n_splits, float scale, cudaStream_t stream,
     void* out_q8, int seqlen, const void* k_scale, const void* v_scale, int int8_kv,
-    const void* attn_gate
+    const void* attn_gate, int gated_combine_hd128
 ) {
     const __nv_bfloat16* gate = reinterpret_cast<const __nv_bfloat16*>(attn_gate);
+    // hd256 already had a gated combine; hd128 only gets one when the caller explicitly opts in,
+    // so every pre-existing model keeps byte-for-byte the dispatch it had before.
+    const bool gate128 = gated_combine_hd128 && gate && out_q8;
     auto combine_hd256 = [&](void* oq8) {
         if (gate && oq8)
             fa_launch_combine_gated_dispatch_hd256(part_m, part_l, part_acc,
@@ -950,8 +990,13 @@ void launch_flash_decode_split(
                     part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                     ksc, vsc);
         }
-        fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
-                                   num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
+        if (gate128)
+            fa_launch_combine_gated_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                                             gate, num_q_heads, n_splits,
+                                             reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
+        else
+            fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                                       num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
         (void)head_dim;
         return;
     }
@@ -960,8 +1005,13 @@ void launch_flash_decode_split(
         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
         ksc, vsc, int8_kv);
-    fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
-                               num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
+    if (gate128)
+        fa_launch_combine_gated_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                                         gate, num_q_heads, n_splits,
+                                         reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
+    else
+        fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                                   num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
     (void)head_dim;
 }
 #endif

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -551,10 +551,104 @@ __global__ void rmsnorm_qk_kernel(__nv_bfloat16* __restrict__ q, __nv_bfloat16* 
     if (t < head_dim) x[base + t] = __float2bfloat16(v * s_warp[0] * __bfloat162float(w[t]));
 }
 
+
+// Fused QK-norm + (optional NORM-convention RoPE) + K/V cache append, for Muse Glimmer.
+// Collapses launch_rmsnorm_qk followed by launch_rope_kv_append_normal (sliding-window layers) or
+// launch_kv_append (NoPE layers) into ONE kernel: 2 decode-graph nodes per layer become 1, 52 per
+// 128-token step.
+//
+// Bit-identical to the split pair, by construction:
+//   * the per-head RMS reduction keeps rmsnorm_qk_kernel's exact warp -> shared -> warp grouping
+//     and the same blockDim (head_dim), so the fp32 summation order is unchanged;
+//   * the normed value is rounded to bf16 BEFORE the rotation reads it, which is precisely what
+//     the split path does implicitly when rmsnorm_qk stores bf16 to global and the rope kernel
+//     loads it back;
+//   * q/k are still written back in their normed (unrotated) form, so anything reading s.q/s.k
+//     afterwards sees exactly what it saw before.
+// `pos_angle` supplies the RoPE position and `pos_slot` the cache slot; the split path used d_pos
+// for both on the rope layers and d_writepos for the slot on the NoPE layers, so they are passed
+// separately rather than assumed equal.
+__global__ void muse_qknorm_rope_kv_kernel(
+    __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k,
+    const __nv_bfloat16* __restrict__ v,
+    const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
+    __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    const int* __restrict__ block_table, const int* __restrict__ pos_angle,
+    const int* __restrict__ pos_slot, int n_q_heads, int n_kv_heads, int head_dim,
+    float theta, int block_size, float eps, int do_rope
+) {
+    const int hh = blockIdx.x, t = threadIdx.x;
+    const int slot = pos_slot[0];
+    const int blk = slot / block_size, within = slot - blk * block_size;
+    const size_t ctok = (size_t)((size_t)block_table[blk] * block_size + within);
+
+    if (hh >= n_q_heads + n_kv_heads) {          // V head: straight copy, no norm, no rope
+        const int h = hh - n_q_heads - n_kv_heads;
+        v_pool[(ctok * n_kv_heads + h) * head_dim + t] = v[(size_t)h * head_dim + t];
+        return;
+    }
+    const bool is_q         = (hh < n_q_heads);
+    __nv_bfloat16* x        = is_q ? q : k;
+    const __nv_bfloat16* w  = is_q ? q_w : k_w;
+    const int head          = is_q ? hh : hh - n_q_heads;
+    const size_t base       = (size_t)head * head_dim;
+
+    __shared__ float s_warp[32];
+    extern __shared__ float s_h[];
+    const float xv = __bfloat162float(x[base + t]);
+    float ss = rn_warp_sum(xv * xv);
+    if ((t & 31) == 0) s_warp[t >> 5] = ss;
+    __syncthreads();
+    if (t < 32) {
+        float vv = (t < (blockDim.x + 31) / 32) ? s_warp[t] : 0.f;
+        vv = rn_warp_sum(vv);
+        if (t == 0) s_warp[0] = rsqrtf(vv / head_dim + eps);
+    }
+    __syncthreads();
+    const __nv_bfloat16 nb = __float2bfloat16(xv * s_warp[0] * __bfloat162float(w[t]));
+    x[base + t] = nb;                 // keep s.q / s.k byte-identical to the split path
+    s_h[t] = __bfloat162float(nb);
+    __syncthreads();
+
+    if (!do_rope) {                   // NoPE layer: append the normed K as-is
+        if (!is_q) k_pool[(ctok * n_kv_heads + head) * head_dim + t] = nb;
+        return;
+    }
+    const int half = head_dim >> 1;
+    if (t < half) {                   // NORM convention: rotate the pair (2i, 2i+1)
+        const float freq = __powf(theta, -2.f * (float)t / (float)head_dim);
+        const float ang = (float)pos_angle[0] * freq, c = __cosf(ang), sn = __sinf(ang);
+        const float x0 = s_h[2 * t], x1 = s_h[2 * t + 1];
+        if (is_q) {
+            q[base + 2 * t]     = __float2bfloat16(x0 * c - x1 * sn);
+            q[base + 2 * t + 1] = __float2bfloat16(x0 * sn + x1 * c);
+        } else {
+            const size_t dst = (ctok * n_kv_heads + head) * head_dim + 2 * t;
+            k_pool[dst]     = __float2bfloat16(x0 * c - x1 * sn);
+            k_pool[dst + 1] = __float2bfloat16(x0 * sn + x1 * c);
+        }
+    }
+}
+
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include "sparkinfer/kernels/fused.h"
 #include <cassert>
 #include <cstdlib>
+
+void launch_muse_qknorm_rope_kv(void* q, void* k, const void* v, const void* q_w, const void* k_w,
+                                void* k_pool, void* v_pool, const int* block_table,
+                                const int* pos_angle, const int* pos_slot,
+                                int n_q_heads, int n_kv_heads, int head_dim, float theta,
+                                int block_size, float eps, bool do_rope, cudaStream_t stream) {
+    const int blocks = n_q_heads + 2 * n_kv_heads;   // q heads, k heads, then the v-copy heads
+    muse_qknorm_rope_kv_kernel<<<blocks, head_dim, head_dim * sizeof(float), stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v),
+        reinterpret_cast<const __nv_bfloat16*>(q_w), reinterpret_cast<const __nv_bfloat16*>(k_w),
+        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        block_table, pos_angle, pos_slot, n_q_heads, n_kv_heads, head_dim, theta,
+        block_size, eps, do_rope ? 1 : 0);
+}
 
 void launch_rmsnorm_qk(void* q, void* k, const void* q_w, const void* k_w,
                        int n_q_heads, int n_kv_heads, int head_dim, float eps, cudaStream_t stream) {

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -976,6 +976,53 @@ __global__ void si_mmvq_q4k_kfixed_kernel(const si_block_q8_1* __restrict__ vy, 
     if (lane == 0) gemv_write(y + row, tmp);
 }
 
+// Two Q4_K matrices against ONE shared Q8_1 activation in a single launch. The body below is
+// character-for-character si_mmvq_q4k_kfixed_kernel's; only which (W, y) a block addresses changes,
+// so every output row is produced by the identical dot/reduction order and the result is
+// bit-identical to two separate launches.
+//
+// Muse Glimmer projects attn_q and attn_gate as two separate Q4_K tensors back-to-back on the SAME
+// stream (they are not interleaved at load, unlike every other arch here), so merging them removes
+// one graph node per layer AND doubles the launch from 9.2 MB to 18.4 MB, which sits meaningfully
+// higher on this card's bandwidth-vs-transfer-size curve. Note this deliberately does NOT touch K/V,
+// which QKVSTREAM runs concurrently on side streams -- folding those in removes real overlap and
+// measured -0.13% when tried.
+template <typename OutT, int NSUPER>
+__global__ void si_mmvq_q4k_kfixed2_kernel(const si_block_q8_1* __restrict__ vy,
+                                           const unsigned char* __restrict__ W0,
+                                           const unsigned char* __restrict__ W1,
+                                           OutT* __restrict__ y0, OutT* __restrict__ y1, int N0) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const bool second = (blockIdx.x >= (unsigned)N0);
+    const int row = second ? (int)blockIdx.x - N0 : (int)blockIdx.x;
+    const unsigned char* W = second ? W1 : W0;
+    OutT* y = second ? y1 : y0;
+    const si_block_q4_K* x_row = (const si_block_q4_K*)(W + (size_t)row * NSUPER * 144);
+    constexpr int blocks_per_iter = vdr * NW * WS / qi;
+    float tmp = 0.0f;
+    #pragma unroll
+    for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+        const int kby = kbx * 8;
+        const int kqs = vdr * (tid % (qi / vdr));
+        tmp += si_vec_dot_q4_K(x_row + kbx, vy + kby, kqs);
+    }
+    __shared__ float tmp_shared[NW - 1][WS];
+    if (warp > 0) tmp_shared[warp - 1][lane] = tmp;
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) tmp += tmp_shared[l][lane];
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) tmp += __shfl_xor_sync(0xffffffff, tmp, m);
+    if (lane == 0) gemv_write(y + row, tmp);
+}
+
+#ifndef _MSC_VER
+template __global__ void si_mmvq_q4k_kfixed2_kernel<__nv_bfloat16, 26>(
+    const si_block_q8_1*, const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, int);
+#endif
+
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 8>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
 #endif
@@ -1989,6 +2036,59 @@ void launch_gemv_q_dp4a_pq_f32(const void* q8, const float* ad, const float* as,
         reinterpret_cast<const signed char*>(q8), ad, as, reinterpret_cast<const unsigned char*>(W), y, N, K);
 }
 
+// ---- L2 weight prefetch ----
+// Decode is DRAM-bound (~86% bus utilization measured on a 5090), and the missing ~14% is time
+// the bus sits idle while a latency-bound kernel runs. The worst offender is the Muse Glimmer
+// sandwich-norm tail: two single-CTA reductions per layer, ~3.4 us each, during which 169 of 170
+// SMs and the entire memory bus do nothing. This kernel fills that window by pulling the leading
+// slice of the weight matrix the NEXT big GEMV will stream into L2, so those bytes are already
+// resident when it starts. Pure `prefetch.global.L2` -- no data reaches registers, nothing is
+// written, so it cannot perturb any result. The arithmetic downstream is bit-identical; only
+// where a byte is served from changes.
+__global__ void si_l2_prefetch_kernel(const char* __restrict__ p, size_t bytes) {
+    size_t i = ((size_t)blockIdx.x * blockDim.x + threadIdx.x) << 7;   // one 128 B line per thread
+    const size_t stride = (size_t)gridDim.x * blockDim.x << 7;
+    for (; i < bytes; i += stride)
+        asm volatile("prefetch.global.L2 [%0];" :: "l"(p + i));
+}
+
+// `prefetch.global.L2` is only a hint and the hardware may drop it under memory pressure -- which
+// is exactly the regime this runs in. This variant issues real 16 B loads instead, so the fill is
+// guaranteed; the accumulator is sunk behind a condition that never holds, which keeps the loads
+// from being dead-code-eliminated without ever storing anything.
+__device__ unsigned si_l2_pf_sink;
+__global__ void si_l2_load_kernel(const uint4* __restrict__ p, size_t n16) {
+    size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    const size_t stride = (size_t)gridDim.x * blockDim.x;
+    unsigned acc = 0;
+    for (; i < n16; i += stride) {
+        const uint4 v = __ldg(p + i);
+        acc ^= v.x ^ v.y ^ v.z ^ v.w;
+    }
+    if (acc == 0xFFFFFFFFu && n16 == 0) si_l2_pf_sink = acc;   // never taken
+}
+
+void launch_l2_prefetch(const void* p, size_t bytes, cudaStream_t stream) {
+    if (!p || !bytes) return;
+    static int mode = -1;
+    if (mode < 0) { const char* e = getenv("SPARKINFER_MG_L2PF_MODE"); mode = e ? atoi(e) : 0; }
+    if (mode == 1) {
+        const size_t n16 = bytes >> 4;
+        const int threads = 256;
+        const int blocks = (int)((n16 + threads - 1) / threads < 512 ? (n16 + threads - 1) / threads : 512);
+        si_l2_load_kernel<<<blocks, threads, 0, stream>>>(
+            reinterpret_cast<const uint4*>(p), n16);
+        return;
+    }
+    const size_t lines = (bytes + 127) >> 7;
+    const int threads = 256;
+    // Cap the grid so the prefetch never crowds out the latency-bound kernel it overlaps: 512 CTAs
+    // is already ~3x what it takes to saturate the bus, and leaves the single-CTA tail its SM.
+    const int blocks = (int)((lines + threads - 1) / threads < 512 ? (lines + threads - 1) / threads : 512);
+    si_l2_prefetch_kernel<<<blocks, threads, 0, stream>>>(
+        reinterpret_cast<const char*>(p), bytes);
+}
+
 // ---- faithful llama.cpp Q4_K mmvq launchers ----
 size_t llama_q8_1_bytes(int K) { return (size_t)(K >> 5) * sizeof(si_block_q8_1); }  // 36 B / 32 vals
 void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t stream) {
@@ -2010,6 +2110,16 @@ static int mmvq_dualrow() {
     if (v < 0) { const char* e = getenv("SPARKINFER_MMVQ2"); v = (e && e[0] == '0') ? 0 : 1; }
     return v;
 }
+bool launch_mmvq_q4k_kfixed2(const void* q81, const void* W0, const void* W1,
+                             void* y0, void* y1, int N0, int N1, int K, cudaStream_t stream) {
+    if (K != 6656 || N0 <= 0 || N1 <= 0) return false;   // Muse Glimmer's hidden size only
+    si_mmvq_q4k_kfixed2_kernel<__nv_bfloat16, 26><<<N0 + N1, 4 * 32, 0, stream>>>(
+        reinterpret_cast<const si_block_q8_1*>(q81),
+        reinterpret_cast<const unsigned char*>(W0), reinterpret_cast<const unsigned char*>(W1),
+        reinterpret_cast<__nv_bfloat16*>(y0), reinterpret_cast<__nv_bfloat16*>(y1), N0);
+    return true;
+}
+
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream) {
     const si_block_q8_1* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const unsigned char* w = reinterpret_cast<const unsigned char*>(W);

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -163,7 +163,10 @@ void launch_flash_decode_split(
     int block_size, int max_blocks, int n_splits, float scale,
     cudaStream_t stream = nullptr, void* out_q8 = nullptr, int seqlen = -1,
     const void* k_scale = nullptr, const void* v_scale = nullptr, int int8_kv = 0,
-    const void* attn_gate = nullptr);
+    const void* attn_gate = nullptr,
+    // Opt-in for the head_dim=128 gated combine. Defaults OFF so no existing caller can change
+    // behaviour: only Muse Glimmer, whose hd128 gated kernel this PR instantiates, passes 1.
+    int gated_combine_hd128 = 0);
 
 // Flash decode for GLOBAL layers: full context, head_dim=512, GQA 8:1.
 // Two-phase dot product splits 512-dim head into two 256-dim halves.

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -42,6 +42,14 @@ void launch_norm_then_add(const void* residual_bf16, const void* block_out_bf16,
 //   out_xn = RMSNorm(out_x, next_w, eps)                    (what the following launch_rmsnorm does)
 // Bit-identical to that pair: same 256-thread block, same per-stage loop order and reduction tree,
 // and stage 2 re-reads the bf16-rounded out_x from memory exactly as the separate kernel would.
+// Fused QK-norm + optional NORM-convention RoPE + K/V append (Muse Glimmer). One kernel in place
+// of launch_rmsnorm_qk + launch_rope_kv_append_normal / launch_kv_append. Bit-identical.
+void launch_muse_qknorm_rope_kv(void* q, void* k, const void* v, const void* q_w, const void* k_w,
+                                void* k_pool, void* v_pool, const int* block_table,
+                                const int* pos_angle, const int* pos_slot,
+                                int n_q_heads, int n_kv_heads, int head_dim, float theta,
+                                int block_size, float eps, bool do_rope, cudaStream_t stream = nullptr);
+
 void launch_muse_sandwich_tail(const void* residual_bf16, const void* branch_bf16,
                                const void* post_w_bf16, const void* next_w_bf16,
                                void* out_x_bf16, void* out_xn_bf16,

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -78,11 +78,20 @@ void launch_gemv_q_dp4a_pq_f32(const void* q8, const float* ad, const float* as,
 // nwarps=4 cooperate per row. A/B test vs our split-K dp4a (SPARKINFER_LLAMA=1).
 size_t llama_q8_1_bytes(int K);
 void launch_quantize_q8_1_blocks(const void* x, void* y, int K, cudaStream_t stream = nullptr);
+
+// Pull `bytes` of `p` into L2 (prefetch.global.L2 only -- no loads, no stores, no side effects).
+// Intended to run on a side stream during a latency-bound kernel, so the next weight-streaming
+// GEMV finds its leading slice already resident. Never changes a computed value.
+void launch_l2_prefetch(const void* p, size_t bytes, cudaStream_t stream = nullptr);
 // Row-batched Q8_1 quantize: `rows` activation rows of K values, x row stride `x_stride` elements,
 // y rows contiguous (llama_q8_1_bytes(K) apart). Same per-row math as the single-row launcher.
 void launch_quantize_q8_1_rows(const void* x, void* y, int K, int rows, int x_stride,
                                cudaStream_t stream = nullptr);
 void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cudaStream_t stream = nullptr);
+// Two Q4_K matrices, one shared Q8_1 activation, one launch. Per-row results are bit-identical to
+// two launch_mmvq_q4k calls. Returns false if the shape is unsupported.
+bool launch_mmvq_q4k_kfixed2(const void* q81, const void* W0, const void* W1, void* y0, void* y1,
+                             int N0, int N1, int K, cudaStream_t stream = nullptr);
 void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream = nullptr);
 
 // Exact short-row target verifier: M contiguous Q8_1 activations against one Q4_K matrix.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -132,6 +132,8 @@ struct Qwen35Model::Impl {
     Qwen35Weights w;
     cudaStream_t stream{};
     cudaStream_t stream_k{}, stream_v{};         // side streams for concurrent K/V projection
+    cudaStream_t stream_pf{};                    // side stream for the L2 weight prefetch
+    cudaEvent_t ev_pf_fork{}, ev_pf_done{};      // prefetch fork/join (kept inside the decode graph)
     cudaEvent_t ev_qkv{}, ev_k{}, ev_v{};        // fork/join events (captured into the decode graph)
     cudaEvent_t ev_pipe_fork{}, ev_gdn_z{}, ev_gdn_ab{};
     cudaEvent_t ev_sx_gate{}, ev_sx_done{};
@@ -292,6 +294,13 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->linear_qkvdim = 2 * p_->linear_qdim + p_->linear_vdim;
     cudaStreamCreate(&p_->stream);
     cudaStreamCreate(&p_->stream_k); cudaStreamCreate(&p_->stream_v);
+    // Prefetch stream/events exist ONLY for Muse Glimmer, so every other architecture keeps
+    // byte-for-byte the stream and event set it had before this change.
+    if (cfg.muse_glimmer) {
+        cudaStreamCreate(&p_->stream_pf);
+        cudaEventCreateWithFlags(&p_->ev_pf_fork, cudaEventDisableTiming);
+        cudaEventCreateWithFlags(&p_->ev_pf_done, cudaEventDisableTiming);
+    }
     cudaEventCreateWithFlags(&p_->ev_qkv, cudaEventDisableTiming);
     cudaEventCreateWithFlags(&p_->ev_k, cudaEventDisableTiming);
     cudaEventCreateWithFlags(&p_->ev_v, cudaEventDisableTiming);
@@ -480,9 +489,12 @@ Qwen35Model::~Qwen35Model() {
     if (p_->graph_ready) { cudaGraphExecDestroy(p_->cu_exec); cudaGraphDestroy(p_->cu_graph); }
     if (p_->graph_prefill_ready) { cudaGraphExecDestroy(p_->cu_prefill_exec); cudaGraphDestroy(p_->cu_prefill_graph); }
     if (p_->dflash_graph_ready) { cudaGraphExecDestroy(p_->cu_dflash_exec); cudaGraphDestroy(p_->cu_dflash_graph); }
+    if (p_->ev_pf_fork) cudaEventDestroy(p_->ev_pf_fork);
+    if (p_->ev_pf_done) cudaEventDestroy(p_->ev_pf_done);
     cudaEventDestroy(p_->ev_qkv); cudaEventDestroy(p_->ev_k); cudaEventDestroy(p_->ev_v);
     cudaEventDestroy(p_->ev_pipe_fork); cudaEventDestroy(p_->ev_gdn_z); cudaEventDestroy(p_->ev_gdn_ab);
     cudaEventDestroy(p_->ev_sx_gate); cudaEventDestroy(p_->ev_sx_done);
+    if (p_->stream_pf) cudaStreamDestroy(p_->stream_pf);
     cudaStreamDestroy(p_->stream_v); cudaStreamDestroy(p_->stream_k);
     cudaStreamDestroy(p_->stream);
     delete p_;
@@ -804,8 +816,76 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
     // are already done. Only the prime norm above still needs the standalone quant (layer 0).
     const bool fnq = s.gguf && s.use_fnq && s.use_pq && s.use_llama;
 
+    // ---- L2 weight prefetch into the sandwich-norm tail's idle window ----
+    // Decode is DRAM-bound but only ~86% bus-utilized; the gap is time the bus idles inside a
+    // latency-bound kernel. Muse Glimmer's two single-CTA sandwich tails per layer are the largest
+    // such window (~3.4 us each on one of 170 SMs). Fork a prefetch of the weight matrix the next
+    // big GEMV will stream, so it overlaps the tail instead of leaving the bus idle. Each join sits
+    // a full block after its fork (FFN between fork1/join1, attention between fork2/join2), so the
+    // prefetch never serializes against the main stream. Prefetch has no side effects, so this is
+    // bit-identical -- only where a byte is served from changes.
+    // SPARKINFER_MG_L2PF_MB=0 disables (one-binary A/B control).
+    static int l2pf_mb = -1;
+    if (l2pf_mb < 0) {
+        const char* e = getenv("SPARKINFER_MG_L2PF_MB");
+        l2pf_mb = e ? atoi(e) : 5;   // flat optimum over 3-5 MB
+        if (l2pf_mb < 0) l2pf_mb = 0;
+    }
+    // Each window is forked immediately before a latency-bound stretch and joined immediately
+    // before the matrix it prefetched is streamed, so the prefetch always has the full window to
+    // land and never stalls the main stream. Forking earlier than this is WORSE, not better: a
+    // variant that spanned the whole attention block measured +0.54% against this schedule's
+    // +0.99%, because attention streams ~47 MB through a 96 MB L2 and evicts the prefetch before
+    // the FFN reads it. Sizing is a flat optimum over 3-6 MB; past ~24 MB the prefetch outruns its
+    // window and the join serializes, which costs more than half the step.
+    // Window 1 gets its own size: its runway is the whole attention block (~35 us), an order of
+    // magnitude longer than the two ~4 us sandwich-tail windows, so it can absorb far more of
+    // w.wo than they can of gate/up. Sizing them together undershoots window 1 and overshoots 2/3.
+    static int l2pf_wo_mb = -1;
+    if (l2pf_wo_mb < 0) {
+        const char* e = getenv("SPARKINFER_MG_L2PF_WO_MB");
+        l2pf_wo_mb = e ? atoi(e) : 8;   // swept 8/12/16: 101.57 / 101.55 / 101.46 tok/s
+        if (l2pf_wo_mb < 0) l2pf_wo_mb = 0;
+    }
+    const bool l2pf = c.muse_glimmer && s.gguf && l2pf_mb > 0 && s.stream_pf != nullptr;
+    const size_t pf_bytes = (size_t)l2pf_mb << 20;
+    const size_t pf_wo_bytes = (size_t)l2pf_wo_mb << 20;
+    bool pf_outstanding = false;
+    auto pf_join = [&]() {
+        if (!pf_outstanding) return;
+        cu(cudaStreamWaitEvent(st, s.ev_pf_done, 0), "l2 prefetch join");
+        pf_outstanding = false;
+    };
+    auto pf_fork_n = [&](const void* a, const void* b, size_t nbytes) {
+        if (!l2pf || !nbytes || (!a && !b)) return;
+        cu(cudaEventRecord(s.ev_pf_fork, st), "l2 prefetch fork");
+        cu(cudaStreamWaitEvent(s.stream_pf, s.ev_pf_fork, 0), "l2 prefetch fork wait");
+        if (a) kernels::launch_l2_prefetch(a, nbytes, s.stream_pf);
+        if (b) kernels::launch_l2_prefetch(b, nbytes, s.stream_pf);
+        cu(cudaEventRecord(s.ev_pf_done, s.stream_pf), "l2 prefetch done");
+        pf_outstanding = true;
+    };
+    auto pf_fork = [&](const void* a, const void* b) { pf_fork_n(a, b, pf_bytes); };
+    // A single fork per layer issuing every prefetch back-to-back was tried and is WORSE than
+    // doing nothing (98.37 vs 99.44 tok/s): the side stream then hammers DRAM through the QKV
+    // projections it is supposed to hide behind, and gate/up is evicted long before the FFN reads
+    // it. Each window must be forked immediately before the stretch it covers.
+    // Window mask: 1 = w.wo across the attention block, 2 = gate/up across the post-attn tail,
+    // 4 = next layer's wq across the post-FFN tail. A window only earns its place if it beats the
+    // ~0.89%/step its own fork+join event nodes cost.
+    static int pf_win = -1;
+    if (pf_win < 0) { const char* e = getenv("SPARKINFER_MG_L2PF_WIN"); pf_win = e ? atoi(e) : 7; }
+
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
+        // Window 3 lands: the previous layer's post-FFN prefetch covered its sandwich tail.
+        pf_join();
+        // Window 1: the QKV projections are latency-bound, not bandwidth-bound (~32 MB over ~29 us
+        // = ~1.1 TB/s of a ~1.66 TB/s bus), so the whole attention block has spare bandwidth. w.wo
+        // is streamed at the end of it and only has to survive QKV's ~32 MB through a 96 MB L2, so
+        // it is prefetchable across that entire runway -- unlike gate/up, which would have to
+        // survive attention's full ~47 MB and measured worse when tried that way.
+        if (pf_win & 1) pf_fork_n(w.wo, nullptr, pf_wo_bytes);
         dbg_bf16(s.xn, H, 10, L);   // tag 10: pre-attn-norm output (this layer's normed input)
         dbg_xn_snapshot(s.xn, L);
         // xn_q8_ready assumes the PREVIOUS layer's tail already emitted Q8_1(this layer's xn)
@@ -991,6 +1071,22 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                 const bool sep_gate = (w.wgate != nullptr);
                 void* q_dst = (w.q_has_gate && !sep_gate) ? s.qraw : s.q;
                 const int nq = (w.q_has_gate && !sep_gate) ? s.qdim * 2 : s.qdim;
+                // Muse Glimmer's Q and attn-gate are two separate Q4_K tensors projected
+                // back-to-back on the SAME stream. Merge them into one launch: one fewer graph
+                // node per layer, and the launch doubles to 18.4 MB which reads faster per byte.
+                // K/V are untouched -- QKVSTREAM overlaps them on side streams and folding those
+                // in measured -0.13%. SPARKINFER_MG_QG_FUSE=0 restores the split pair.
+                static int mg_qg = -1;
+                if (mg_qg < 0) { const char* e = getenv("SPARKINFER_MG_QG_FUSE"); mg_qg = (e && e[0] == '0') ? 0 : 1; }
+                auto proj_q_gate = [&](cudaStream_t qs) {
+                    if (mg_qg && c.muse_glimmer && sep_gate && s.use_pq && s.use_llama &&
+                        w.wq_type == 12 && w.wgate_type == 12 && H == 6656 &&
+                        kernels::launch_mmvq_q4k_kfixed2(s.aq81, w.wq, w.wgate, q_dst, s.qgate,
+                                                         nq, s.qdim, H, qs))
+                        return;
+                    proj_xn(w.wq, w.wq_type, q_dst, nq, qs);
+                    if (sep_gate) proj_xn(w.wgate, w.wgate_type, s.qgate, s.qdim, qs);
+                };
                 // The fused QKV kernel writes one contiguous q of width nq and knows nothing about
                 // a separate gate tensor, so it cannot serve this path.
                 const bool attn_qkv = !sep_gate && s.use_attn_qkv && s.use_pq && s.use_llama
@@ -1003,8 +1099,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                     cudaEventRecord(s.ev_qkv, st);
                     cudaStreamWaitEvent(s.stream_k, s.ev_qkv, 0);
                     cudaStreamWaitEvent(s.stream_v, s.ev_qkv, 0);
-                    proj_xn(w.wq, w.wq_type, q_dst, nq, st);
-                    if (sep_gate) proj_xn(w.wgate, w.wgate_type, s.qgate, s.qdim, st);
+                    proj_q_gate(st);
                     proj_xn(w.wk, w.wk_type, s.k, s.kvdim, s.stream_k);
                     proj_xn(w.wv, w.wv_type, s.v, s.kvdim, s.stream_v);
                     cudaEventRecord(s.ev_k, s.stream_k);
@@ -1012,8 +1107,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                     cudaStreamWaitEvent(st, s.ev_k, 0);
                     cudaStreamWaitEvent(st, s.ev_v, 0);
                 } else {
-                    proj_xn(w.wq, w.wq_type, q_dst, nq, st);
-                    if (sep_gate) proj_xn(w.wgate, w.wgate_type, s.qgate, s.qdim, st);
+                    proj_q_gate(st);
                     proj_xn(w.wk, w.wk_type, s.k, s.kvdim, st);
                     proj_xn(w.wv, w.wv_type, s.v, s.kvdim, st);
                 }
@@ -1080,7 +1174,19 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                         c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim,
                         c.rope_theta, c.rms_eps, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
                 } else {
-                    if (s.use_qkfuse)
+                    // Muse Glimmer: QK-norm + RoPE/append are two dependent graph nodes per layer
+                    // (104/step) doing tiny work. Fuse them into one; bit-identical, see
+                    // launch_muse_qknorm_rope_kv. SPARKINFER_MG_QKR_FUSE=0 restores the pair.
+                    static int mg_qkr = -1;
+                    if (mg_qkr < 0) { const char* e = getenv("SPARKINFER_MG_QKR_FUSE"); mg_qkr = (e && e[0] == '0') ? 0 : 1; }
+                    const bool mg_qkr_fuse = mg_qkr && c.muse_glimmer && s.use_qkfuse && !partial_rope && !kv8;
+                    if (mg_qkr_fuse) {
+                        kernels::launch_muse_qknorm_rope_kv(
+                            s.q, s.k, s.v, w.q_norm, w.k_norm, (bf16*)kpool, (bf16*)vpool, btable,
+                            s.d_pos, w.swa ? s.d_pos : s.d_writepos,
+                            c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta,
+                            s.kv->block_size(), c.rms_eps, /*do_rope=*/w.swa != 0, st);
+                    } else if (s.use_qkfuse)
                         kernels::launch_rmsnorm_qk(s.q, s.k, w.q_norm, w.k_norm, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rms_eps, st);
                     else {
                         kernels::launch_rmsnorm(s.q, w.q_norm, s.q, c.n_q_heads,  c.head_dim, c.rms_eps, st);
@@ -1088,7 +1194,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                     }
                     dbg_bf16(s.q, s.qdim, 20, L);   // tag 20: Q, post QK-norm, pre-RoPE
                     dbg_bf16(s.k, s.kvdim, 21, L);  // tag 21: K, post QK-norm, pre-RoPE
-                    if (c.muse_glimmer && !w.swa) {
+                    if (mg_qkr_fuse) {
+                        // already done in one kernel above
+                    } else if (c.muse_glimmer && !w.swa) {
                         // Global/NoPE layer: no rotation at all (Q/K are already QK-normed
                         // above) -- append K/V as-is. Every 4th layer per sliding_window_pattern.
                         launch_kv_append((bf16*)kpool, (bf16*)vpool, s.k, s.v, btable, s.d_writepos, 1,
@@ -1133,8 +1241,17 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // ---- attention (Q8-emit only when output is not gated: the gate mutates attn after decode) ----
             static int attn_gq8 = -1;
             if (attn_gq8 < 0) { const char* e = getenv("SPARKINFER_ATTN_GQ8"); attn_gq8 = (e && e[0] == '0') ? 0 : 1; }
+            // The H test is not a hidden-size requirement -- it is a proxy for "a gated combine has
+            // been instantiated for this architecture's head_dim", and only the hd256 models ever
+            // had one. fa_combine_gated_q8_kernel is HEAD_DIM-generic, so instantiating it at 128
+            // lets Muse Glimmer (H=6656, head_dim=128) qualify too, folding the sigmoid gate and
+            // the output quantize into the combine and deleting 2 graph nodes per layer (104/step).
+            // SPARKINFER_MG_ATTN_GQ8=0 restores the split path for A/B.
+            static int mg_gq8 = -1;
+            if (mg_gq8 < 0) { const char* e = getenv("SPARKINFER_MG_ATTN_GQ8"); mg_gq8 = (e && e[0] == '0') ? 0 : 1; }
+            const bool mg_gate_ok = c.muse_glimmer && mg_gq8 && c.head_dim == 128;
             const bool attn_gate_q8 = attn_gq8 && w.q_has_gate && s.gguf && s.use_pq && s.use_llama
-                                      && (H == 2048 || H == 4096)
+                                      && (H == 2048 || H == 4096 || mg_gate_ok)
                                       && (w.wo_type == 12 || w.wo_type == 8) && (s.qdim % 32 == 0);
             const bool emit_attn_q8 = !w.q_has_gate && s.use_attnin && s.gguf && s.use_pq && s.use_llama && w.wo_type == 12;
             if (c.muse_glimmer && w.swa && s.swa_vtbl) {
@@ -1151,7 +1268,8 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                                                    (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr,
                                                    s.swa_budget * s.kv->block_size(),
                                                    kscale, vscale, kv8 ? 1 : 0,
-                                                   attn_gate_q8 ? s.qgate : nullptr);
+                                                   attn_gate_q8 ? s.qgate : nullptr,
+                                                   mg_gate_ok ? 1 : 0);
             } else if (sparse_on && s.sparse_vtbl) {
                 // GQA-8 (Qwen3.6): the same dense flash-decode entry point, pointed at the
                 // per-step compact view — sink + last-window blocks, view seq_len carrying
@@ -1186,7 +1304,8 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
                                                1.f / sqrtf((float)c.head_dim), st,
                                                (emit_attn_q8 || attn_gate_q8) ? s.aq81 : nullptr, seqlen,
                                                kscale, vscale, kv8 ? 1 : 0,
-                                               attn_gate_q8 ? s.qgate : nullptr);
+                                               attn_gate_q8 ? s.qgate : nullptr,
+                                               mg_gate_ok ? 1 : 0);
             }
             dbg_bf16(s.attn, s.qdim, 30, L);   // tag 30: SDPA output, pre-gate
             if (w.q_has_gate && !attn_gate_q8)
@@ -1194,6 +1313,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             dbg_bf16(s.attn, s.qdim, 31, L);   // tag 31: SDPA output, post sigmoid-gate
 
             // ---- O projection (main's int8 mmvq path) ----
+            if (pf_win & 1) pf_join();   // window 1 lands here: w.wo is read next
             if (s.gguf && s.use_pq && w.wo_type == 12) {
                 if (s.use_llama) {
                     if (!emit_attn_q8 && !attn_gate_q8) kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
@@ -1225,6 +1345,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // c.rms_eps here silently gives wrong post-attn/post-ffn norms.
             // Both halves of the sandwich tail are single-CTA kernels over 6656 elements, so each
             // costs ~3.2 us of launch/reduction latency for 13 KB of traffic. Fuse them.
+            // Window 2: the post-attn sandwich tail is a single CTA on a 170-SM device for ~3.4 us.
+            // Cover it with the FFN gate/up matrices, which are streamed immediately after it.
+            if (pf_win & 2) pf_fork(w.gate_q, w.up_q);
             if (muse_fuse_tail())
                 kernels::launch_muse_sandwich_tail(s.x, s.ao, w.post_attn_norm, w.ffn_norm,
                                                    s.h, s.hn, 1, H, 1e-8f, c.rms_eps, st);
@@ -1464,6 +1587,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             // always null here. xn = RMSNorm(x, nextnorm) is the next layer's ordinary
             // pre-attn norm (or final_norm on the last layer), unaffected by the sandwich.
             // Same 1e-8 post_norm_eps as the post-attn sandwich norm above -- see that comment.
+            // Window 2 lands (the whole FFN has run since it was forked). Window 3: cover the
+            // post-FFN sandwich tail with the next layer's attention projections.
+            {
+                if (pf_win & 2) pf_join();
+                if (pf_win & 4) {
+                    const Qwen35LayerWeights* nx = (L + 1 < c.n_layers) ? &s.w.layers[L + 1] : nullptr;
+                    if (nx) pf_fork(nx->wq, nx->wgate ? nx->wgate : nx->wk);
+                    else    pf_fork(s.w.lm_head, nullptr);
+                }
+            }
             if (muse_fuse_tail())
                 kernels::launch_muse_sandwich_tail(s.h, s.routed, w.post_ffn_norm, nextnorm,
                                                    s.x, s.xn, 1, H, 1e-8f, c.rms_eps, st);
@@ -1483,6 +1616,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample) {
             kernels::launch_add_rmsnorm2(s.h, s.routed, nextnorm, s.x, s.xn, 1, H, c.rms_eps, st);
         dflash_maybe_capture_layer(L);
     }
+    pf_join();   // last layer's prefetch: must be joined before the capture ends or the graph is malformed
     // xn now holds RMSNorm(x_final, final_norm)
     dbg_bf16(s.xn, H, 80, -2);   // tag 80: final-norm output (lm_head input)
     dbg_xn_snapshot(s.xn, c.n_layers);   // extra slot: final-norm output, for lm_head cross-check


### PR DESCRIPTION
## Summary

Muse Glimmer decode is memory-bound, but only **86% bus-utilized**: 14.43 GB of weights per token over a 10.06 ms step is 1.435 TB/s against a ~1.66 TB/s sustained ceiling on this card. Every byte-bound kernel is already at 96–99% of its *size-matched* roofline, so this PR does not try to make them faster. It attacks the other 14% — idle bus time and launch count. Four changes, all **bit-identical**:

Nothing computed changes — only where a byte is served from and how many launches carry it.

Each lever is independently switchable in one binary: `SPARKINFER_MG_L2PF_MB=0 SPARKINFER_MG_ATTN_GQ8=0 SPARKINFER_MG_QKR_FUSE=0 SPARKINFER_MG_QG_FUSE=0` restores main's path.

## Scope: zero footprint outside Muse Glimmer

Every change is inert for other architectures **by construction**, not merely by a runtime branch:

- The prefetch stream and its two events are created only `if (cfg.muse_glimmer)`, and the prefetch additionally requires `s.stream_pf != nullptr` to arm — other models keep byte-for-byte the stream and event set they had before.
- `launch_flash_decode_split` takes a new `gated_combine_hd128` argument that **defaults to 0**; only the two Muse call sites pass 1. No other caller can reach the new hd128 path.
- The QK/RoPE and q+gate fusions and the prefetch all name `c.muse_glimmer` explicitly in their guards rather than inferring it from `H == 6656`.
- `launch_mmvq_q4k_kfixed2` returns false for any `K != 6656`.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, 3 reps alternating against a real `origin/main` build):

| | decode tok/s |
|---|--:|
| before (main) | 99.42 |
| after (this PR) | 102.89 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
Three-way A/B — a real origin/main build (b97ebb4) vs this PR's binary, alternating, GPU confirmed clear between every run.

rep1  real-main: 99.39   PR: 102.95
rep2  real-main: 99.45   PR: 102.87
rep3  real-main: 99.41   PR: 102.84
mean  real-main: 99.42   PR: 102.89          -> +3.49%

$ build/runtime/qwen3_gguf_bench muse-glimmer-30B-kquant-17gb.gguf 128 0
=== sparkinfer bench (Q4_K_M native) ===
model        : Muse Glimmer 30B  (52 layers, 1 experts top-1)
VRAM used    : 19.0 GB
max seq      : 2048
decode tg    : 102.89 tok/s  (9.7 ms/token, n=128, ctx=0, bs=1)

Per-lever, same binary (control = all four disabled):
  all four disabled        :  99.44 tok/s   (== main, confirms the one-binary control)
  gated combine only       : 100.15 tok/s   (+0.70%)
  q+gate fusion only       : 100.17 tok/s   (+0.73%)
  L2 prefetch only         : 100.78 tok/s   (+1.34%)
  prefetch + gated combine : 101.49 tok/s   (+2.07%)
  + QK-norm/RoPE fusion    : 101.83 tok/s   (+2.43%)
  + q+gate fusion (all)    : 102.89 tok/s   (+3.49%)

Accuracy gate — teacher-forced vs a live llama-server reference on the same GGUF,
bench/scripts/eval_text.txt, 99 positions, TOPK=128:
  this PR : METRIC top1=0.939394 kl=0.036192 ppl_spark=2.6930 ppl_llama=3.0876
  main    : METRIC top1=0.939394 kl=0.036192 ppl_spark=2.6930 ppl_llama=3.0876
  $ cmp score_pr.txt score_main.txt   -> identical (byte for byte)
```

## Qwen3.6 guard — re-verified across all five contexts

Run with the guard's exact call (`SPARKINFER_BENCH_SWEEP_CTXS=0,512,4096,16384,32768`, `SPARKINFER_BENCH_SWEEP_REPS=1`, `qwen3_gguf_bench $Q36 128 sweep`), 2 reps of each arm, alternating:

```text
MAIN1: {"0":{"decode_tps":514.68},"512":{"decode_tps":514.25,"prefill_pp":7992.14},"4096":{"decode_tps":499.41,"prefill_pp":24552.52},"16384":{"decode_tps":503.67,"prefill_pp":27125.22},"32768":{"decode_tps":503.80,"prefill_pp":28420.49}}
PR1  : {"0":{"decode_tps":513.50},"512":{"decode_tps":514.43,"prefill_pp":8018.73},"4096":{"decode_tps":498.82,"prefill_pp":24425.25},"16384":{"decode_tps":503.97,"prefill_pp":26894.35},"32768":{"decode_tps":504.07,"prefill_pp":28404.58}}
MAIN2: {"0":{"decode_tps":516.62},"512":{"decode_tps":514.63,"prefill_pp":8007.27},"4096":{"decode_tps":500.37,"prefill_pp":25000.60},"16384":{"decode_tps":503.94,"prefill_pp":27120.94},"32768":{"decode_tps":503.99,"prefill_pp":28337.61}}
PR2  : {"0":{"decode_tps":516.86},"512":{"decode_tps":515.60,"prefill_pp":8004.76},"4096":{"decode_tps":502.29,"prefill_pp":24967.91},"16384":{"decode_tps":504.12,"prefill_pp":27089.15},"32768":{"decode_tps":503.54,"prefill_pp":28351.04}}

                  main       PR        delta
decode@0          515.65     515.18    -0.09%
decode@512        514.44     515.02    +0.11%
prefill@512      7999.7     8011.7     +0.15%
decode@4096       499.89     500.56    +0.13%
prefill@4096    24776.6    24696.6     -0.32%
decode@16384      503.81     504.05    +0.05%
prefill@16384   27123.1    26991.8     -0.48%
decode@32768      503.90     503.81    -0.02%
prefill@32768   28379.1    28377.8     -0.005%
```

All nine measurements land within ±0.5%, against the guard's 2% floor.