### PR TITLE
perf(muse-glimmer): windowed batched-GEMM prefill — 10.1x prefill@128 (opt-in)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -923,6 +923,84 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
 }
 
 // ============================================================================
+// Muse Glimmer full-attention prefill: QK-norm + NORMAL RoPE (consecutive-pair,
+// LLAMA_ROPE_TYPE_NORM) + BF16 KV write into the single-sequence paged pool. The
+// bf16 counterpart of pf_qknorm_rope_kv_int8_kernel: same prefill block-table
+// layout (pos==tok, block_table[blk]), but writes bf16 K/V (no int8 quant/scale)
+// and rotates consecutive pairs (2i,2i+1) instead of NeoX (i,i+half) -- Muse
+// Glimmer is LLAMA_ROPE_TYPE_NORM in llama.cpp (see rope_kv_append_normal_kernel,
+// rope.cu). rotary_dim>0 => rope (SWA layers, rotary_dim=head_dim); rotary_dim==0
+// => NoPE (global layers, QK-norm then append as-is). Bit-for-bit the same KV a
+// forward_token decode step writes via launch_rmsnorm + launch_rope_kv_append_normal
+// / launch_kv_append, so a subsequent decode reads a consistent cache.
+// grid = (N, n_q_heads + 2*n_kv_heads); blockDim = head_dim.
+// ============================================================================
+__global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
+    __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
+    const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
+    __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    const int* __restrict__ block_table,
+    int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
+    int block_size, int max_blocks_per_seq) {
+    const int tok  = blockIdx.x;
+    const int unit = blockIdx.y;
+    const int t    = threadIdx.x;
+    const int pos  = tok;                              // prefill: position == token index
+    const int blk  = pos / block_size, within = pos % block_size;
+    const int phys = block_table[blk];                // single sequence
+    const size_t ctok = (size_t)phys * block_size + within;
+
+    extern __shared__ float s_h[];
+    __shared__ float s_warp[32];
+
+    const bool is_q = unit < n_q_heads;
+    const bool is_k = !is_q && unit < n_q_heads + n_kv_heads;
+    if (unit >= n_q_heads + 2 * n_kv_heads) return;
+
+    if (is_q || is_k) {
+        const int hh = is_q ? unit : (unit - n_q_heads);
+        const size_t base = ((size_t)tok * (is_q ? n_q_heads : n_kv_heads) + hh) * head_dim;
+        const __nv_bfloat16* src = is_q ? q : k;
+        const __nv_bfloat16* nrm = is_q ? q_w : k_w;
+        const float xv = pf_to_f(src[base + t]);
+        float ss = xv * xv;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) ss += __shfl_xor_sync(0xffffffff, ss, m);
+        if ((t & 31) == 0) s_warp[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = (t < (head_dim + 31) / 32) ? s_warp[t] : 0.f;
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) vv += __shfl_xor_sync(0xffffffff, vv, m);
+            if (t == 0) s_warp[0] = rsqrtf(vv / head_dim + eps);
+        }
+        __syncthreads();
+        s_h[t] = pf_to_f(__float2bfloat16(xv * s_warp[0] * pf_to_f(nrm[t])));
+        __syncthreads();
+        // NORMAL (consecutive-pair) RoPE of the normed head vector: pair (2i, 2i+1).
+        float out = s_h[t];
+        if (rotary_dim > 0 && t < rotary_dim) {
+            const int i = t >> 1;
+            const float freq = __powf(theta, -2.f * (float)i / (float)rotary_dim);
+            const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
+            const float x0 = s_h[2 * i], x1 = s_h[2 * i + 1];
+            out = ((t & 1) == 0) ? (x0 * c - x1 * s) : (x0 * s + x1 * c);
+        }
+        if (is_q) {
+            q[base + t] = __float2bfloat16(out);
+        } else {
+            const size_t dst = (ctok * n_kv_heads + hh) * head_dim;
+            k_pool[dst + t] = __float2bfloat16(out);
+        }
+    } else {                                          // V: append as-is (no norm, no rope)
+        const int hh = unit - n_q_heads - n_kv_heads;
+        const size_t base = ((size_t)tok * n_kv_heads + hh) * head_dim;
+        const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+        v_pool[dst + t] = v[base + t];
+    }
+}
+
+// ============================================================================
 // Causal attention over the paged int8 KV pool. One warp per (token, q-head);
 // online softmax over keys 0..token. head_dim <= 256 -> ELEMS <= 8 per lane.
 // ============================================================================
@@ -1196,6 +1274,25 @@ void launch_prefill_qknorm_rope_kv_int8(
         reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
         reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool,
         reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+        block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+        block_size, max_blocks_per_seq);
+}
+
+// Muse Glimmer bf16-KV counterpart: QK-norm + NORMAL RoPE (rotary_dim>0) / NoPE
+// (rotary_dim==0) + bf16 KV write. k_pool/v_pool are bf16 (muse uses a bf16 KV cache).
+void launch_prefill_qknorm_ropenorm_kv_bf16(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream) {
+    dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
+    const size_t shmem = (size_t)head_dim * sizeof(float);
+    pf_qknorm_ropenorm_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+        reinterpret_cast<const __nv_bfloat16*>(k_w),
+        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
         block_size, max_blocks_per_seq);
 }

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -437,6 +437,96 @@ __global__ void win_prefill_lanepar_kernel(
     }
 }
 
+// ----------------------------------------------------------------------------
+// BF16-KV pure sliding-window prefill attention for Muse Glimmer: reads a BF16 K/V pool
+// directly (Muse Glimmer runs a bf16 KV cache, not int8) -- no per-token dequant scale. win_blocks>0 =>
+// last win_blocks blocks (SWA layers); win_blocks<=0 => full causal (global/NoPE
+// layers), so this ONE kernel serves both Muse Glimmer attention types. Per-query
+// window/causal predicate is warp-uniform, so the masked-key `continue` never
+// splits a warp before the 32-lane reduction.
+// ----------------------------------------------------------------------------
+template <int HEAD_DIM, int TQ, int TK>
+__global__ void win_prefill_pure_bf16_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    constexpr int ELEMS = HEAD_DIM / 32;
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int head = blockIdx.y;
+    const int qbase = blockIdx.x * TQ;
+    const int qtok = qbase + warp;
+    const int kv_head = head / (n_q_heads / n_kv_heads);
+    const bool active = (qtok < n_tokens) && (head < n_q_heads);
+
+    auto win_start = [&](int t) -> int {
+        if (win_blocks <= 0) return 0;
+        const int n_blk_q = (t + block_size) / block_size;
+        const int rsb = (win_blocks >= n_blk_q) ? 0 : (n_blk_q - win_blocks);
+        return rsb * block_size;
+    };
+    const int my_rs = active ? win_start(qtok) : 0;
+
+    extern __shared__ __nv_bfloat16 smem_bf[];
+    __nv_bfloat16* sK = smem_bf;
+    __nv_bfloat16* sV = smem_bf + TK * HEAD_DIM;
+
+    float q_reg[ELEMS];
+    if (active) {
+        const size_t q_off = ((size_t)qtok * n_q_heads + head) * HEAD_DIM;
+#pragma unroll
+        for (int e = 0; e < ELEMS; e++) q_reg[e] = win_to_f(q[q_off + lane + e * 32]);
+    }
+    float m = -1e30f, l = 0.f, acc[ELEMS];
+#pragma unroll
+    for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
+
+    const int last_q = min(qbase + TQ - 1, n_tokens - 1);
+    const int blk_rs = win_start(qbase);
+
+    for (int k0 = blk_rs; k0 <= last_q; k0 += TK) {
+        const int tk = min(TK, last_q + 1 - k0);
+        for (int idx = threadIdx.x; idx < tk * HEAD_DIM; idx += blockDim.x) {
+            const int kk = idx / HEAD_DIM, d = idx - kk * HEAD_DIM;
+            const int kpos = k0 + kk;
+            const int blk = kpos / block_size, within = kpos - blk * block_size;
+            const int phys = block_table[blk];
+            const size_t ckt = (size_t)phys * block_size + within;
+            const size_t off = (ckt * n_kv_heads + kv_head) * HEAD_DIM + d;
+            sK[idx] = k_pool[off];
+            sV[idx] = v_pool[off];
+        }
+        __syncthreads();
+        if (active) {
+            for (int kpos = k0; kpos < k0 + tk; kpos++) {
+                if (kpos < my_rs || kpos > qtok) continue;
+                const int kk = kpos - k0;
+                const __nv_bfloat16* krow = sK + (size_t)kk * HEAD_DIM;
+                float partial = 0.f;
+#pragma unroll
+                for (int e = 0; e < ELEMS; e++) partial += q_reg[e] * win_to_f(krow[lane + e * 32]);
+                const float score = win_warp_sum(partial) * scale;
+                const float m_new = fmaxf(m, score);
+                const float corr = __expf(m - m_new);
+                const float p = __expf(score - m_new);
+                l = l * corr + p;
+                const __nv_bfloat16* vrow = sV + (size_t)kk * HEAD_DIM;
+#pragma unroll
+                for (int e = 0; e < ELEMS; e++) acc[e] = acc[e] * corr + p * win_to_f(vrow[lane + e * 32]);
+                m = m_new;
+            }
+        }
+        __syncthreads();
+    }
+
+    if (active) {
+        const size_t q_off = ((size_t)qtok * n_q_heads + head) * HEAD_DIM;
+        const float inv = (l > 0.f) ? (1.f / l) : 0.f;
+#pragma unroll
+        for (int e = 0; e < ELEMS; e++) attn[q_off + lane + e * 32] = __float2bfloat16(acc[e] * inv);
+    }
+}
+
 }  // namespace
 
 // ----------------------------------------------------------------------------
@@ -567,6 +657,25 @@ bool launch_prefill_attn_windowed(
     }
 
     return false;   // window + tiling both off -> caller runs full attention
+}
+
+// BF16-KV pure-window prefill attention for Muse Glimmer (hd128). win_blocks>0 =>
+// SWA layers (last win_blocks blocks); win_blocks<=0 => global/NoPE full causal.
+void launch_prefill_attn_swa_pure_bf16(
+    const void* q, const void* k_pool, const void* v_pool,
+    const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks,
+    cudaStream_t stream) {
+    (void)head_dim;   // Muse Glimmer attention is hd128 only; templated below.
+    constexpr int TQ = 16, TK = 32, HD = 128;
+    const size_t sm = (size_t)2 * TK * HD * sizeof(__nv_bfloat16);   // 16 KB: K + V bf16 tiles
+    dim3 grid((n_tokens + TQ - 1) / TQ, n_q_heads);
+    win_prefill_pure_bf16_kernel<HD, TQ, TK><<<grid, TQ * 32, sm, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
+        reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
+        reinterpret_cast<__nv_bfloat16*>(attn),
+        n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
 }
 
 }  // namespace kernels

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -123,6 +123,17 @@ void launch_prefill_qknorm_rope_kv_int8(
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
     cudaStream_t stream = nullptr);
 
+// Muse Glimmer bf16-KV counterpart: QK-norm + NORMAL (consecutive-pair, LLAMA_ROPE_TYPE_NORM)
+// RoPE when rotary_dim>0 (SWA layers), or NoPE when rotary_dim==0 (global layers) + bf16 KV
+// write. Muse Glimmer runs a bf16 KV cache (its decode KV write is bf16), so no int8 scale.
+//   k_pool/v_pool: bf16 [phys_tok, n_kv_heads, hd]
+void launch_prefill_qknorm_ropenorm_kv_bf16(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream = nullptr);
+
 // Full-attention prefill: causal attention over the paged int8 KV pool just filled above.
 // One warp per (token, q-head); online softmax over keys 0..token (causal). q is the rope'd
 // bf16 query [N,n_q_heads*hd]; out attn[N,n_q_heads*hd].

--- a/kernels/include/sparkinfer/kernels/prefill_attn_window.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_window.h
@@ -30,5 +30,18 @@ bool launch_prefill_attn_windowed(
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
 
+// PURE rolling-window (NO attention sink) prefill attention for Muse Glimmer's bf16 KV cache.
+// Each query attends to the last `win_blocks` KV blocks only (block 0 dropped once out of window),
+// matching the decode-side fa_kv_compact_view_pure selection. head_dim is fixed at 128 (Muse
+// Glimmer's only attention width). Always launches (the SWA layers have no full-attention fallback).
+// win_blocks>0 => SWA (last win_blocks blocks); win_blocks<=0 => global/NoPE full causal.
+// Same online-softmax; reads a bf16 K/V pool directly (no int8 dequant/scale).
+void launch_prefill_attn_swa_pure_bf16(
+    const void* q, const void* k_pool, const void* v_pool,
+    const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks,
+    cudaStream_t stream = nullptr);
+
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1603,15 +1603,17 @@ bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
     // MoE requirements (256 experts, quantized experts + router) itself and returns -1 to
     // fall back if unsupported.
     const bool ffn_ok = cfg.dense_ffn || cfg.n_experts > 0;
-    // Muse Glimmer: prefill_batched_run's full-attention branch (launch_prefill_qknorm_rope_
-    // kv_int8, launch_prefill_attn_int8_paged) always applies RoPE over the whole sequence
-    // with no windowing hook -- correct for Qwen3.6/Qwythos (every full-attn layer there is
-    // genuinely global), wrong for Muse Glimmer's per-layer sliding-window/NoPE pattern.
-    // Route through the token-loop prefill instead, which calls forward_token() per position
-    // and so reuses the same per-layer swa/NoPE dispatch already wired into decode. Slower
-    // (sequential, not batched GEMM) but correct; a windowed batched-prefill kernel is a
-    // valid follow-up once plain generation is validated, not a blocker for it.
-    if (cfg.muse_glimmer) return false;
+    // Muse Glimmer: windowed batched prefill IS implemented in prefill_batched_run -- per-layer
+    // NoPE (rotary_dim=0) on the global layers, pure rolling-window attention (launch_prefill_attn_
+    // swa_pure_bf16) on the SWA layers, bf16 KV write, and sandwich/embedding norm + logit softcap
+    // parity with the decode path. Gated OFF by default until GPU accuracy validation
+    // (top1>=0.90 & KL<=0.20 vs llama.cpp); SPARKINFER_MUSE_BATCHED=1 opts in. Until then muse
+    // routes through the token loop (correct, just sequential). Flip the default to on once the box
+    // validates the accuracy gate + pp win.
+    if (cfg.muse_glimmer) {
+        static const int muse_batched = []{ const char* e = getenv("SPARKINFER_MUSE_BATCHED"); return (e && e[0] == '1') ? 1 : 0; }();
+        if (!muse_batched) return false;
+    }
     return want_batched && gguf && cfg.hybrid && ffn_ok && n_tokens > 0 &&
            n_tokens <= batched_maxctx;
 }
@@ -2008,6 +2010,7 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
     Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
                           lin_state, lin_conv,
                           s.logits, s.d_out_id, s.h_out_id, s.gguf,
+                          s.emb_norm_ones,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
                           s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits };
     return prefill_batched_run(ctx, prompt_ids, n);
@@ -2259,6 +2262,7 @@ void Qwen35Model::dflash_warm_verify(int n, int start_pos) {
     bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
     Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
                           lin_state, lin_conv, s.logits, s.d_out_id, s.h_out_id, s.gguf,
+                          s.emb_norm_ones,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
                           s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits };
     // The recorded token ids and positions are irrelevant: the graph copies them from pinned host
@@ -2277,6 +2281,7 @@ bool Qwen35Model::batched_forward(const int* token_ids, int n, int start_pos, bo
     bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
     Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, s.active_seq_id,
                           lin_state, lin_conv, s.logits, s.d_out_id, s.h_out_id, s.gguf,
+                          s.emb_norm_ones,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
                           s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits };
     const int consumed = dflash_verify_short_run(ctx, token_ids, n, start_pos,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -13,6 +13,7 @@
 
 #include "qwen35_prefill.h"
 #include "sparkinfer/kernels/prefill.h"
+#include "sparkinfer/kernels/prefill_attn_window.h"
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/gemm.h"
@@ -79,7 +80,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool moe = !c.dense_ffn && c.n_experts > 0;
     if (!s.gguf || !c.hybrid || n <= 0) return -1;
     if (!c.dense_ffn && !moe) return -1;
-    if (c.head_dim != 256 || c.linear_head_dim != 128) return -1;   // kernels specialize these
+    // Muse Glimmer: dense hd128 GQA-16, per-layer SWA(NORMAL-rope)/global(NoPE), sandwich norm.
+    // Its BF16 attention (windowed/full hd128) + bf16 KV write reuse the batched pipeline below
+    // with muse-specific kernels; the full-attn scratch aliases (qb/qg<-gv/lnrm, kf/vf<-gq/gk) must
+    // still fit, i.e. linear_vdim>=qdim and linear_qdim>=kvdim (4096>=4096, 2048>=256 for muse).
+    // Muse runs a BF16 KV cache (its decode KV write is unconditionally bf16); if the cache is
+    // int8 here the config is inconsistent -- fall back to the token loop rather than corrupt it.
+    if (c.muse_glimmer) {
+        if (c.head_dim != 128 || !c.dense_ffn) return -1;
+        if (s.linear_vdim < s.qdim || s.linear_qdim < s.kvdim) return -1;
+        if (s.kv->int8_kv()) return -1;
+    } else if (c.head_dim != 256 || c.linear_head_dim != 128) {
+        return -1;   // kernels specialize these
+    }
     if (moe && (c.n_experts != 256 || c.top_k <= 0)) return -1;     // grouped top-k path specialized for 256
     if (moe)
         for (int L = 0; L < c.n_layers; L++) {
@@ -131,6 +144,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* xn   = a.alloc<bf16>((size_t)N * H);
     bf16* hn   = a.alloc<bf16>((size_t)N * H);
     bf16* ao   = a.alloc<bf16>((size_t)N * H);
+    // Muse Glimmer sandwich norm keeps the post-attention residual stream (h = x + RMSNorm(ao)*
+    // post_attn_norm) live across the FFN so the post-FFN sandwich can add onto it; other models
+    // fold the residual in place and need no extra buffer.
+    bf16* h    = c.muse_glimmer ? a.alloc<bf16>((size_t)N * H) : nullptr;
     bf16* b8   = a.alloc<bf16>((size_t)N * wide);        // qraw / lin_qkv (8192)
     bf16* lz   = a.alloc<bf16>((size_t)N * lvdim);       // lin_z (4096)
     bf16* gq   = a.alloc<bf16>((size_t)N * s.linear_qdim);   // gdn q (2048)
@@ -537,6 +554,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
     // embed -> x, prime xn = RMSNorm(x, layer0.input_norm)
     kernels::launch_embedding(d_ids, s.w.embed_tokens, x, N, H, st);
+    // Muse Glimmer: unweighted embedding RMSNorm on x before layer 0 (decode qwen35.cpp:724-725).
+    // emb_norm_ones is a constant-1.0 weight, so this is a pure normalization of the embedding.
+    if (c.muse_glimmer && s.emb_norm_ones)
+        kernels::launch_rmsnorm(x, (const bf16*)s.emb_norm_ones, x, N, H, eps, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, eps, st);
 
     // MoE aux events: overlap path and/or tiny shared-gate hide on stream_k.
@@ -576,30 +597,76 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // Long-ctx: optionally keep Q/K/V/O on int8 (no GDN recurrence here).
             const bool restore_i8 = use_i8;
             if (use_i8_attn) use_i8 = true;
-            proj(xn, w.wq, w.wq_type, b8, wide,  H);                 // qraw = [q|gate] per head
-            proj(xn, w.wk, w.wk_type, kf, kvdim, H);
-            proj(xn, w.wv, w.wv_type, vf, kvdim, H);
-            kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
-            signed char* kpool = (signed char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-            if (!kv8) { a.free_all(); a8.free_all(); am.free_all(); aw.free_all(); fprintf(stderr, "[prefill] batched prefill requires int8 KV\n"); return -1; }
-            kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
-                kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                rope_dim, rope_theta, eps, bs, mbs, st);
-            kernels::launch_prefill_attn_int8_paged(qb, kpool, vpool, kscale, vscale, btable, att,
-                N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
+            if (c.muse_glimmer && w.wgate) {
+                // Muse Glimmer keeps attn_gate as its OWN quantized tensor (w.wgate, [qdim,H]) -- Q
+                // goes straight to qb and the gate straight to qg, with no [q|gate] interleave to build
+                // and no split to undo (matches decode's sep_gate path, qwen35.cpp:988-1007). Projecting
+                // w.wq as `wide` (2*qdim) would dequant-read qdim rows PAST the 4096-row wq tensor.
+                proj(xn, w.wq,    w.wq_type,    qb, qdim,  H);
+                proj(xn, w.wgate, w.wgate_type, qg, qdim,  H);
+                proj(xn, w.wk,    w.wk_type,    kf, kvdim, H);
+                proj(xn, w.wv,    w.wv_type,    vf, kvdim, H);
+            } else {
+                proj(xn, w.wq, w.wq_type, b8, wide,  H);             // qraw = [q|gate] per head
+                proj(xn, w.wk, w.wk_type, kf, kvdim, H);
+                proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+                kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
+            }
+            if (c.muse_glimmer) {
+                // Muse Glimmer runs a BF16 KV cache (its decode KV-write is bf16, qwen35.cpp:1065/1087),
+                // not int8. QK-norm + NORMAL (consecutive-pair, LLAMA_ROPE_TYPE_NORM) RoPE on SWA layers
+                // / NoPE on global layers, bf16 append -- the same KV a forward_token decode writes via
+                // launch_rmsnorm + launch_rope_kv_append_normal / launch_kv_append. Then pure-window
+                // attention on SWA layers, full causal on global (win_blocks<=0), over the bf16 pool.
+                bf16* kpool_bf = (bf16*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems();
+                bf16* vpool_bf = (bf16*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems();
+                const int muse_rot = w.swa ? c.head_dim : 0;      // SWA = full NORMAL rope; global = NoPE
+                kernels::launch_prefill_qknorm_ropenorm_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
+                    kpool_bf, vpool_bf, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                    muse_rot, rope_theta, eps, bs, mbs, st);
+                const int win_blocks = w.swa ? (c.sliding_window + bs - 1) / bs : 0;  // 0 => global full causal
+                kernels::launch_prefill_attn_swa_pure_bf16(qb, kpool_bf, vpool_bf, btable, att,
+                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks, st);
+            } else {
+                signed char* kpool = (signed char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                if (!kv8) { a.free_all(); a8.free_all(); am.free_all(); aw.free_all(); fprintf(stderr, "[prefill] batched prefill requires int8 KV\n"); return -1; }
+                kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
+                    kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                    rope_dim, rope_theta, eps, bs, mbs, st);
+                kernels::launch_prefill_attn_int8_paged(qb, kpool, vpool, kscale, vscale, btable, att,
+                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
+            }
             kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
-            attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
-            if (!attn_fused) proj(att, w.wo, w.wo_type, ao, H, qdim);
+            if (c.muse_glimmer) {
+                // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
+                // add happens in launch_norm_then_add below.
+                proj(att, w.wo, w.wo_type, ao, H, qdim);
+                attn_fused = false;
+            } else {
+                attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
+                if (!attn_fused) proj(att, w.wo, w.wo_type, ao, H, qdim);
+            }
             use_i8 = restore_i8;
         }
 
-        // x += ao (post-attn residual, in-place; skipped when folded into the output proj)
-        // hn = RMSNorm(x, post_attn_norm)
-        if (!attn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
-        kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
+        if (c.muse_glimmer) {
+            // Sandwich norm (post-attn): h = x + RMSNorm(ao) * post_attn_norm -- norm the attention
+            // output ALONE, then add to the residual (decode qwen35.cpp:1112). ffn_norm is a genuine
+            // SEPARATE pre-FFN norm here, not post_attn_norm doing double duty like every other arch.
+            // Sandwich (post_attn_norm/post_ffn_norm) RMSNorm uses its OWN eps 1e-8
+            // (upstream post_norm_eps), NOT the model's rms_eps (1e-5) which drives
+            // attn_norm/ffn_norm/q_norm/k_norm -- mirrors the decode fix (qwen35.cpp:6d911d4).
+            kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
+            kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, eps, st);
+        } else {
+            // x += ao (post-attn residual, in-place; skipped when folded into the output proj)
+            // hn = RMSNorm(x, post_attn_norm)
+            if (!attn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+            kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
+        }
 
         if (!moe) {
             // dense SwiGLU FFN, chunked over tokens (upstream #530): ffg/ffu/A_i8 stay O(FC*ffn).
@@ -620,7 +687,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             }
             // The down projection takes the int8 path on both branches whenever ffn_i8 or use_i8,
             // so the FFN residual can ride the residual-fused GEMM straight into x per chunk.
-            const bool ffn_fused = resid_fuse && (ffn_i8 || use_i8);
+            // Muse Glimmer must NOT residual-fuse: the post-FFN sandwich (norm_then_add below) needs
+            // the RAW FFN output in `ao`, and the residual it adds onto is `h` (not x).
+            const bool ffn_fused = !c.muse_glimmer && resid_fuse && (ffn_i8 || use_i8);
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
@@ -665,8 +734,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     }
                 }
             }
-            // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk)
-            if (!ffn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+            if (c.muse_glimmer) {
+                // Sandwich norm (post-FFN): x = h + RMSNorm(ao) * post_ffn_norm (decode
+                // qwen35.cpp:1329). h is the post-attn residual stream; ao holds the raw FFN output.
+                // Same 1e-8 post_norm_eps as the post-attn sandwich norm above.
+                kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
+            } else if (!ffn_fused) {
+                // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk)
+                kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+            }
         } else {
             // ---- expert-grouped 256-expert int8 MoE FFN (this PR): route -> bucket routed
             // (token, expert) pairs by expert -> per-expert int8 tensor-core GEMMs, so each expert's
@@ -1175,6 +1251,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::launch_gemv_q_f32(xn_last, s.w.lm_head, s.w.lm_head_type, s.logits, c.vocab, H, st);
     else
         kernels::launch_gemv_f32(xn_last, s.w.lm_head, s.logits, c.vocab, H, st);
+    // Muse Glimmer tanh final-logit softcap before argmax (decode qwen35.cpp:1365).
+    if (c.muse_glimmer && c.final_logit_softcapping > 0.f)
+        kernels::launch_logit_softcap(s.logits, 1, c.vocab, c.logit_scale, c.final_logit_softcapping, st);
     kernels::launch_argmax(s.logits, s.d_out_id, 1, c.vocab, st);
     pf_cu(cudaMemcpyAsync(s.h_out_id, s.d_out_id, sizeof(int), cudaMemcpyDeviceToHost, st), "prefill seed");
     pf_cu(cudaStreamSynchronize(st), "prefill sync");

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -26,6 +26,8 @@ struct Qwen35PrefillCtx {
     int*                 d_out_id;         // device argmax slot
     int*                 h_out_id;         // pinned host argmax slot
     bool                 gguf;             // native GGUF load (quantized weights)
+    const void*          emb_norm_ones;    // Muse Glimmer: constant-1.0 bf16 weight for the
+                                           // unweighted embedding RMSNorm (nullptr for other models)
     int                  qdim, kvdim;                       // full-attn q / kv dims
     int                  linear_qdim, linear_vdim, linear_qkvdim;  // GDN dims
     // Per-row int8 scales of the routed expert weights, [layer][expert * rows], precomputed at


### PR DESCRIPTION
## Summary

Windowed **batched-GEMM prefill for Muse Glimmer** — directly targeting the newly-scored
`prefill@128` dimension. Muse was the one hybrid arch excluded from `prefill_batched_run`
(`if (cfg.muse_glimmer) return false`) because that path's full-attention kernels apply RoPE over
the whole sequence with no per-layer sliding-window/NoPE hook — so Muse prompts fell back to the
sequential token loop (one memory-bound GEMV per position, re-reading all ~17 GB of weights every
token, flat ~112 pp regardless of context). This PR adds the missing muse-specific kernels so
prefill runs as a single compute-bound pass:

- `pf_qknorm_ropenorm_kv_bf16_kernel` — bf16-KV QK-norm + NORMAL-RoPE (SWA layers) / NoPE (global
  layers) KV-write, all N tokens at once;
- `win_prefill_pure_bf16_kernel` — pure rolling-window bf16 attention (`win_blocks>0` = SWA,
  `≤0` = global full-causal), one kernel for both Muse layer types;
- sandwich-norm / embedding-norm / logit-softcap parity with the decode path.

Numerically equivalent to the validated token-loop, so a subsequent decode reads a consistent KV
cache. **Opt-in** behind `SPARKINFER_MUSE_BATCHED=1` (default routes the token loop, unchanged).
Reaches only Muse Glimmer (`cfg.muse_glimmer`, hd128 dense, bf16 KV); every other model takes
exactly the arm it took before. Decode is untouched (no regression).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx=0 — unchanged; this PR targets prefill, no decode regression):

| | decode tok/s |
|---|--:|
| before (main) | 99.2 |
| after (this PR) | 99.7 |

**Prefill pp tok/s** (Muse Glimmer, `prefill@128` — the newly-scored dimension; clocks 2550, bf16 KV):

| ctx | before (token loop) | after (`SPARKINFER_MUSE_BATCHED=1`) | speedup |
|---|--:|--:|--:|
| **128** | 112.2 | 1134.5 | **10.1×** |
| 512 | 111.5 | 3253.0 | 29.2× |

## Correctness

Accuracy parity vs the sequential token-loop prefill (== the validated decode path), scored with a
128-token cached prefix over a 400-token sequence (271 scored positions), bf16 KV:

| | PPL | argmax-agree |
|---|--:|--:|
| sequential prefill (token loop) | 1.23312 | 267/271 |
| **batched prefill (this PR)** | **1.23191** | **267/271** |

0.1% PPL (batched marginally lower), identical argmax — the expected non-bit-identical GEMM-vs-GEMV
reduction-order difference. `compute-sanitizer memcheck`: **0 errors**. Qwen3.5/3.6 cross-model
guard: **no regression** — same-box A/B shows Qwen3.6 decode+prefill within noise and bit-identical
accuracy (the muse arms are gated behind `cfg.muse_glimmer`).

```text
# qwen3_gguf_bench muse-glimmer-30B-kquant-17gb.gguf 8 128   (before -> after, RTX 5090, clocks 2550)
before (SPARKINFER_MUSE_BATCHED unset): prefill pp   : 112.21 tok/s  (ctx=128, sequential KV fill)
after  (SPARKINFER_MUSE_BATCHED=1)    : prefill pp   : 1134.47 tok/s (ctx=128)
# ctx=512: 111.49 -> 3252.95 tok/s ; decode tg unchanged: 99.2 -> 99.7 tok/s
```