### PR TITLE
perf(muse-glimmer): selective 3.5-bit FFN gate/up weights (+5.69% decode)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -19,6 +19,7 @@
 #include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
+#include "sparkinfer/kernels/qtype.h"   // SI_QTYPE_Q3A (moe.h below is included from *inside* the namespace)
 #endif
 
 namespace sparkinfer {
@@ -526,6 +527,86 @@ __device__ __forceinline__ float si_vec_dot_q5_K(const si_block_q5_K* bq5, const
     float2 dm5f = __half22float2(bq5->dm);
     return dm5f.x * sumf_d - dm5f.y * sumf_m;
 }
+// ---- Q3_A: sparkinfer's internal 3.5 bits/weight super-block ------------------------------
+// Q4_K with the 4-bit quant plane replaced by a 3-bit one, keeping Q4_K's asymmetric per-32 scale
+// AND min and Q4_K's exact 6-bit scale/min packing -- 112 B per 256 weights against Q4_K's 144 B,
+// so a converted matrix is read 22.2% smaller on every decode token. Produced only by
+// launch_ffn_requant_q3a at model load; never read from or written to a GGUF, so the layout is
+// picked to keep this vec-dot as cheap as si_vec_dot_q4_K rather than to match any ggml type.
+//
+// Same iqs = 2*L convention as si_vec_dot_q4_K (L = 0..15): j = L/4 selects the sub-block pair
+// {2j, 2j+1}, m = L%4 selects positions 8m..8m+7. qs holds the low 2 bits as one int per (j,m) at
+// byte 16*j + 4*m, whose byte lane b = p%4 packs four 2-bit fields f = (s%2) | ((p%8)/4 << 1);
+// qh[p] holds the high bit of every sub-block at position p in bit s, so one int load covers four
+// positions for all eight sub-blocks. Both planes extract with one shift + one mask per four
+// weights, exactly like Q4_K's nibble plane.
+struct si_block_q3_A { __half2 dm; unsigned char scales[12]; unsigned char qs[64]; unsigned char qh[32]; };  // 112 B
+__device__ __forceinline__ float si_vec_dot_q3_A(const si_block_q3_A* bq3, const si_block_q8_1* bq8_1, int iqs) {
+    const int L = iqs >> 1;
+    const int j = L >> 2, m = L & 3;
+    const int vl  = *(const int*)(bq3->qs + 16 * j + 4 * m);
+    const int hlo = *(const int*)(bq3->qh + 8 * m);
+    const int hhi = *(const int*)(bq3->qh + 8 * m + 4);
+    // 6-bit scales/mins: identical packing and identical unpack to si_vec_dot_q4_K, with
+    // bq8_offset == 2*j so the aux index j is the same one that function uses.
+    const unsigned short* scales = (const unsigned short*)bq3->scales;
+    unsigned short aux[2];
+    if (j < 2) { aux[0] = scales[j] & 0x3f3f; aux[1] = scales[j + 2] & 0x3f3f; }
+    else { aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+           aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+    const unsigned char* sc = (const unsigned char*)aux; const unsigned char* mn = sc + 2;
+    float sumf_d = 0.f, sumf_m = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int s = 2 * j + i;                             // sub-block == q8_1 block index
+        const si_block_q8_1* bq8i = bq8_1 + s;
+        const float d8 = __low2float(bq8i->ds);
+        const int* q8 = (const int*)bq8i->qs;
+        const int u0 = q8[2 * m], u1 = q8[2 * m + 1];
+        const int v0 = ((vl >> (2 * i))     & 0x03030303) | (((hlo >> s) & 0x01010101) << 2);
+        const int v1 = ((vl >> (2 * i + 4)) & 0x03030303) | (((hhi >> s) & 0x01010101) << 2);
+        const int dot1 = __dp4a(v0, u0, __dp4a(v1, u1, 0));
+        const int dot2 = __dp4a(0x01010101, u0, __dp4a(0x01010101, u1, 0));
+        sumf_d += d8 * (dot1 * sc[i]);
+        sumf_m += d8 * (dot2 * mn[i]);
+    }
+    float2 dm3f = __half22float2(bq3->dm);
+    return dm3f.x * sumf_d - dm3f.y * sumf_m;
+}
+
+// One CTA per output row, weights read as Q3_A. Same tiling, same accumulation order and same
+// 4-warp reduction as gate_up_mmvq2_kernel below -- only the block format differs.
+__global__ void gate_up_q3a_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch, int H, int F, int top_k, int pdl
+) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    const int row = blockIdx.x, ts = row / F, f = row % F, tok = ts / top_k;
+    const int e = expert_ids[ts];
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
+    const si_block_q3_A* g_row = (const si_block_q3_A*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 112);
+    const si_block_q3_A* u_row = (const si_block_q3_A*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 112);
+    const int blocks_per_row = H >> 8, blocks_per_iter = vdr * NW * WS / qi;   // = 8
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = tid / (qi / vdr); kbx < blocks_per_row; kbx += blocks_per_iter) {
+        const int kby = kbx * 8, kqs = vdr * (tid % (qi / vdr));
+        tg += si_vec_dot_q3_A(g_row + kbx, vrow + kby, kqs);
+        tu += si_vec_dot_q3_A(u_row + kbx, vrow + kby, kqs);
+    }
+    __shared__ float sg[NW - 1][WS], su[NW - 1][WS];
+    if (warp > 0) { sg[warp - 1][lane] = tg; su[warp - 1][lane] = tu; }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[l][lane]; tu += su[l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+    if (pdl) si_pdl_lc();
+}
+
 __global__ void gate_up_mmvq2_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
@@ -1624,7 +1705,8 @@ void launch_moe_expert_ffn_q4k(
     if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '0') ? 0 : 1; }
     const int gu_pdl = gu_mmvq_pdl();
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
-    if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
+    if (mmvq && gu2 && ((gate_type == 12 && up_type == 12) ||
+                       (gate_type == SI_QTYPE_Q3A && up_type == SI_QTYPE_Q3A))) {   // faithful 4-warp mmvq gate/up
         const si_block_q8_1* q;
         if (input_q8) {   // pre-quantized Q8_1(hn) from the fused norm: skip the quantize node
             q = reinterpret_cast<const si_block_q8_1*>(input_q8);
@@ -1639,7 +1721,15 @@ void launch_moe_expert_ffn_q4k(
         // arithmetic, same order, same result, but without the 4-warp shared-memory reduce that
         // only earns its keep when num_tokens == 1 leaves the GPU short of warps.
         const int gu_warps = gu_batch_warps();
-        if (num_tokens > 1 && gu_warps > 0 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
+        // Q3_A gate/up first: every arm below hard-codes the 144-byte Q4_K super-block, so a
+        // converted tensor reaching one of them would read the wrong stride.
+        if (gate_type == SI_QTYPE_Q3A) {
+            launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream,
+                gate_up_q3a_kernel,
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch,
+                hidden, ffn, top_k, gu_pdl);
+        } else if (num_tokens > 1 && gu_warps > 0 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
             const int n_rows = num_tokens * top_k * ffn;
             launch_gate_up_warp_qwen<2048, 512, 8>(gu_warps, gu_pdl, n_rows, stream,
                 q, reinterpret_cast<const unsigned char*>(gate_q),

--- a/kernels/csrc/cuda/quant/ffn_q3a_requant.cu
+++ b/kernels/csrc/cuda/quant/ffn_q3a_requant.cu
@@ -1,0 +1,255 @@
+// Requantize a weight matrix from bf16 to Q3_A once at model load, then decode it on-read via
+// the int8 dp4a Q3_A MMVQ (si_vec_dot_q3_A in moe/expert_ffn_q4k.cu).
+//
+// Q3_A is a sparkinfer-internal 3.5 bits/weight super-block: Q4_K with the 4-bit quant plane
+// replaced by a 3-bit one (a 2-bit plane + a 1-bit plane), keeping Q4_K's asymmetric per-32 scale
+// AND min and Q4_K's exact 6-bit scale/min packing. 112 B per 256 weights against Q4_K's 144 B,
+// so a converted tensor is read 22.2% smaller on every decode token. It is never read from or
+// written to a GGUF file -- it exists only between this load-time fitter and the matching
+// vec-dot, so the layout is chosen to make that vec-dot cheap rather than to match any ggml type.
+//
+// Layout (per 256-weight super-block; s = sub-block 0..7, p = position 0..31 inside it):
+//   dm        : {d, dmin} fp16, exactly Q4_K's
+//   scales[12]: 8x 6-bit scale + 8x 6-bit min, exactly Q4_K's get_scale_min_k4 packing
+//   qs[64]    : low 2 bits. Indexed by (j = s/2, m = p/8) as one int at byte 16*j + 4*m;
+//               inside it byte lane b = p%4 holds four 2-bit fields, field
+//               f = (s%2) | ((p%8)/4 << 1) at bit 2*f.
+//   qh[32]    : high 1 bit. Byte p holds the high bits of all 8 sub-blocks at position p,
+//               bit s -- so one int load covers four positions for every sub-block at once.
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstdio>
+#include <cstdlib>
+
+namespace sparkinfer { namespace kernels {
+
+struct sq3a_block { __half2 dm; unsigned char sc[12]; unsigned char qs[64]; unsigned char qh[32]; };  // 112 B
+
+__device__ __forceinline__ int sq3a_round(float v) { return (int)floorf(v + 0.5f); }
+
+// Fit one 32-value group to y ~= s*q + o with q in [0,7]. Q3_A reconstructs as
+// y = d*sc*q - dmin*m, so the offset o = -negmin is constrained <= 0.
+//
+// This is ggml's make_qkx2_quants search (the one quantize_row_q4_K_impl uses), at nmax=7
+// instead of 15 and with the same importance weights w = av_x + |x|: seed from min/max, then
+// sweep 21 candidate scales around that seed, and for each one refit BOTH scale and offset by
+// weighted least squares, keeping whichever candidate minimises the weighted squared error.
+//
+// A cheaper min/max-plus-two-LS-passes fit (what the Q4_K down requantizer uses) is not good
+// enough at 8 levels: measured top1 0.758 / KL 0.497 against this fit's 0.798 / 0.376 on the
+// same arm. At 16 levels one outlier stretching the group range wastes one level; at 8 it
+// wastes a quarter of the resolution.
+__device__ void sq3a_fit_group(const float* v, float* out_scale, float* out_negmin,
+                               unsigned char* code) {
+    constexpr int NMAX = 7;
+    float sum_x2 = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) sum_x2 += v[i] * v[i];
+    const float av_x = sqrtf(sum_x2 / 32.f);
+
+    float lo = v[0], hi = v[0], sum_w = 0.f, sum_x = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) {
+        lo = fminf(lo, v[i]); hi = fmaxf(hi, v[i]);
+        const float w = av_x + fabsf(v[i]);
+        sum_w += w; sum_x += w * v[i];
+    }
+    if (lo > 0.f) lo = 0.f;                       // offset must be <= 0
+    if (hi == lo) {                               // degenerate (constant / all-zero) group
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) code[i] = 0;
+        *out_scale = 0.f; *out_negmin = -lo; return;
+    }
+
+    float iscale = (float)NMAX / (hi - lo);
+    float scale = 1.f / iscale, best_min = lo, best_mad = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) {
+        int l = sq3a_round(iscale * (v[i] - lo));
+        l = l < 0 ? 0 : (l > NMAX ? NMAX : l);
+        code[i] = (unsigned char)l;
+        const float diff = scale * (float)l + lo - v[i];
+        best_mad += (av_x + fabsf(v[i])) * diff * diff;
+    }
+
+    unsigned char aux[32];
+    for (int is = 0; is <= 20; ++is) {
+        const float isc = (-1.f + 0.1f * (float)is + (float)NMAX) / (hi - lo);
+        float sum_l = 0.f, sum_l2 = 0.f, sum_xl = 0.f;
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) {
+            int l = sq3a_round(isc * (v[i] - lo));
+            l = l < 0 ? 0 : (l > NMAX ? NMAX : l);
+            aux[i] = (unsigned char)l;
+            const float w = av_x + fabsf(v[i]), lf = (float)l;
+            sum_l += w * lf; sum_l2 += w * lf * lf; sum_xl += w * lf * v[i];
+        }
+        const float D = sum_w * sum_l2 - sum_l * sum_l;
+        if (!(D > 0.f)) continue;
+        float this_scale = (sum_w * sum_xl - sum_x * sum_l) / D;
+        float this_min   = (sum_l2 * sum_x - sum_l * sum_xl) / D;
+        if (this_min > 0.f) {                     // offset clamped to 0: refit the scale alone
+            this_min = 0.f;
+            this_scale = (sum_l2 > 0.f) ? (sum_xl / sum_l2) : this_scale;
+        }
+        float mad = 0.f;
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) {
+            const float diff = this_scale * (float)aux[i] + this_min - v[i];
+            mad += (av_x + fabsf(v[i])) * diff * diff;
+        }
+        if (mad < best_mad) {
+            #pragma unroll
+            for (int i = 0; i < 32; ++i) code[i] = aux[i];
+            best_mad = mad; scale = this_scale; best_min = this_min;
+        }
+    }
+    if (!(scale > 0.f)) scale = 0.f;              // 6-bit scales are unsigned; never encode < 0
+    *out_scale = scale; *out_negmin = -best_min;
+}
+
+// Re-derive the codes with error feedback: quantize (v[i] + carried residual) instead of v[i],
+// then carry (target - reconstruction) forward. This does not shrink the per-weight error, it
+// shifts it so that a RUN of consecutive weights sums to roughly the right total -- which is what
+// a dot product against a smooth activation actually integrates. Scale/offset are already fixed
+// by the fit above, so this only changes which of the 8 levels each weight lands on.
+// OFF by default: measured, it makes things WORSE here -- relative RMS reconstruction error
+// against the Q4_K source goes 13.88% -> 23.18%, and the scored top1/KL follow it down
+// (0.929/0.179 -> 0.727/0.705). Kept behind SPARKINFER_Q3A_EFB=1 only so the result is
+// reproducible; do not turn it on.
+__device__ void sq3a_error_feedback(const float* v, float scale, float negmin,
+                                    unsigned char* code) {
+    if (!(scale > 0.f)) return;
+    const float inv = 1.f / scale, o = -negmin;
+    float e = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) {
+        const float target = v[i] + e;
+        int l = sq3a_round(inv * (target - o));
+        l = l < 0 ? 0 : (l > 7 ? 7 : l);
+        code[i] = (unsigned char)l;
+        e = target - (scale * (float)l + o);
+        // Do not let the residual run away on a clipped outlier.
+        e = fmaxf(-scale, fminf(scale, e));
+    }
+}
+
+// One thread per 256-value super-block (8 groups of 32).
+__global__ void sq3a_requant_kernel(const __nv_bfloat16* __restrict__ src,
+                                    sq3a_block* __restrict__ dst, long n_super,
+                                    int efb, float* __restrict__ err_acc) {
+    const long sb = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (sb >= n_super) return;
+    const __nv_bfloat16* base = src + sb * 256;
+    float grpS[8], grpM[8];
+    unsigned char q[256];
+    float vbuf[256];
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) {
+        float buf[32];
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) { buf[i] = __bfloat162float(base[g * 32 + i]); vbuf[g * 32 + i] = buf[i]; }
+        sq3a_fit_group(buf, &grpS[g], &grpM[g], q + g * 32);
+        if (efb) sq3a_error_feedback(buf, grpS[g], grpM[g], q + g * 32);
+    }
+    float topS = 0.f, topM = 0.f;
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) { topS = fmaxf(topS, grpS[g]); topM = fmaxf(topM, grpM[g]); }
+    const float d = topS / 63.f, dmin = topM / 63.f;
+    unsigned char s6[8], m6[8];
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) {
+        int a = d > 0.f ? sq3a_round(grpS[g] / d) : 0;       a = a < 0 ? 0 : (a > 63 ? 63 : a);
+        int b = dmin > 0.f ? sq3a_round(grpM[g] / dmin) : 0; b = b < 0 ? 0 : (b > 63 ? 63 : b);
+        s6[g] = (unsigned char)a; m6[g] = (unsigned char)b;
+    }
+    sq3a_block blk;
+    blk.dm = __floats2half2_rn(d, dmin);
+    // ggml get_scale_min_k4 inverse packing -- byte-identical to the Q4_K requantizer's, because
+    // si_vec_dot_q3_A reuses si_vec_dot_q4_K's scale/min unpack verbatim.
+    #pragma unroll
+    for (int i = 0; i < 12; ++i) blk.sc[i] = 0;
+    #pragma unroll
+    for (int g = 0; g < 4; ++g) { blk.sc[g] = s6[g]; blk.sc[g + 4] = m6[g]; }
+    #pragma unroll
+    for (int g = 4; g < 8; ++g) {
+        blk.sc[g + 4] = (unsigned char)((s6[g] & 0xF) | ((m6[g] & 0xF) << 4));
+        blk.sc[g - 4] |= (unsigned char)(((s6[g] >> 4) & 3) << 6);
+        blk.sc[g]     |= (unsigned char)(((m6[g] >> 4) & 3) << 6);
+    }
+    #pragma unroll
+    for (int i = 0; i < 64; ++i) blk.qs[i] = 0;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) blk.qh[i] = 0;
+    #pragma unroll
+    for (int s = 0; s < 8; ++s)
+        #pragma unroll
+        for (int p = 0; p < 32; ++p) {
+            const int val = q[s * 32 + p];
+            const int j = s >> 1, m = p >> 3, r = p & 7;
+            const int f = (s & 1) | ((r >> 2) << 1);       // 2-bit field inside the byte
+            blk.qs[16 * j + 4 * m + (r & 3)] |= (unsigned char)((val & 3) << (2 * f));
+            blk.qh[p] |= (unsigned char)(((val >> 2) & 1) << s);
+        }
+    dst[sb] = blk;
+
+    // Self-check: reconstruct straight out of the PACKED block (not out of q[]), so a
+    // pack/unpack mismatch shows up here rather than hiding until the vec-dot. Accumulates
+    // sum((w-w_hat)^2) and sum(w^2) so the caller can report a relative RMS and compare it
+    // against the theoretical 3.5-bit figure. Diagnostic only.
+    if (err_acc) {
+        float se = 0.f, sx = 0.f;
+        const float d_f = __low2float(blk.dm), dmin_f = __high2float(blk.dm);
+        for (int s = 0; s < 8; ++s) {
+            // unpack the 6-bit scale/min pair exactly as si_vec_dot_q4_K does
+            int sc6, m6u;
+            if (s < 4) { sc6 = blk.sc[s] & 63; m6u = blk.sc[s + 4] & 63; }
+            else {
+                sc6 = (blk.sc[s + 4] & 0xF) | (((blk.sc[s - 4] >> 6) & 3) << 4);
+                m6u = (blk.sc[s + 4] >> 4)  | (((blk.sc[s]     >> 6) & 3) << 4);
+            }
+            for (int p = 0; p < 32; ++p) {
+                const int j = s >> 1, m = p >> 3, r = p & 7;
+                const int f = (s & 1) | ((r >> 2) << 1);
+                const int lo2 = (blk.qs[16 * j + 4 * m + (r & 3)] >> (2 * f)) & 3;
+                const int hi1 = (blk.qh[p] >> s) & 1;
+                const float w_hat = d_f * (float)sc6 * (float)(lo2 | (hi1 << 2)) - dmin_f * (float)m6u;
+                const float w = vbuf[s * 32 + p];
+                se += (w - w_hat) * (w - w_hat); sx += w * w;
+            }
+        }
+        atomicAdd(err_acc + 0, se);
+        atomicAdd(err_acc + 1, sx);
+    }
+}
+
+// n_values must be a multiple of 256. dst must hold n_values/256 * 112 bytes.
+void launch_ffn_requant_q3a(const void* src_bf16, void* dst_q3a, long n_values,
+                            cudaStream_t stream) {
+    static int efb = -1;
+    if (efb < 0) { const char* e = getenv("SPARKINFER_Q3A_EFB"); efb = (e && e[0] == '1') ? 1 : 0; }
+    static int selfcheck = -1;
+    if (selfcheck < 0) { const char* e = getenv("SPARKINFER_Q3A_SELFCHECK"); selfcheck = (e && e[0] == '1') ? 1 : 0; }
+
+    const long n_super = n_values / 256;
+    const int threads = 128;
+    const long blocks = (n_super + threads - 1) / threads;
+    float* err = nullptr;
+    if (selfcheck && cudaMalloc(&err, 2 * sizeof(float)) == cudaSuccess)
+        cudaMemsetAsync(err, 0, 2 * sizeof(float), stream);
+    sq3a_requant_kernel<<<(unsigned)blocks, threads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(src_bf16),
+        reinterpret_cast<sq3a_block*>(dst_q3a), n_super, efb, err);
+    if (err) {
+        float h[2] = {0.f, 0.f};
+        cudaStreamSynchronize(stream);
+        cudaMemcpy(h, err, sizeof(h), cudaMemcpyDeviceToHost);
+        cudaFree(err);
+        if (h[1] > 0.f)
+            fprintf(stderr, "[q3a] n=%ld relative RMS reconstruction error = %.4f%% (efb=%d)\n",
+                    n_values, 100.0 * sqrt((double)h[0] / (double)h[1]), efb);
+    }
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <cuda_runtime.h>
 
+#include "sparkinfer/kernels/qtype.h"   // SI_QTYPE_Q3A
+
 namespace sparkinfer { namespace kernels {
 
 // Router projection: logits = input @ router_w  (bf16 x bf16 -> fp32).

--- a/kernels/include/sparkinfer/kernels/qtype.h
+++ b/kernels/include/sparkinfer/kernels/qtype.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace sparkinfer { namespace kernels {
+
+// sparkinfer-internal weight type ids, carried through the same `*_qtype` ints as ggml type ids
+// (12 = Q4_K, 13 = Q5_K, 14 = Q6_K, 8 = Q8_0). Deliberately far above every ggml type id: a
+// dispatch that does not explicitly know one of these simply misses it and falls through to a
+// safe path, instead of silently reading a block of the wrong size. None of these ever appear
+// in a GGUF file -- they are produced at model load and consumed by a matching vec-dot.
+//
+//   Q3_A -- 3.5 bits/weight. Q4_K's asymmetric per-32 scale AND min and Q4_K's exact 6-bit
+//           scale/min packing, with the 4-bit quant plane replaced by a 3-bit one (a 2-bit
+//           plane plus a 1-bit plane). 112 B per 256 weights against Q4_K's 144 B.
+//           Produced by launch_ffn_requant_q3a (quant.h), consumed by si_vec_dot_q3_A
+//           (moe/expert_ffn_q4k.cu).
+//
+// Lives in its own header because expert_ffn_q4k.cu includes moe.h from *inside*
+// namespace sparkinfer::kernels, so anything declared there is not reachable by its
+// unqualified name from that file's kernels.
+static constexpr int SI_QTYPE_Q3A = 112;   // == the block size in bytes, per 256 weights
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/quant.h
+++ b/kernels/include/sparkinfer/kernels/quant.h
@@ -86,4 +86,11 @@ void launch_interleave_qgate_rows(const void* q, const void* gate, void* out,
 void launch_ffn_down_requant_q4k(const void* src_bf16, void* dst_q4k, long n_values,
                                  cudaStream_t stream = nullptr);
 
+// Requantize a weight matrix bf16 -> Q3_A, sparkinfer's internal 3.5 bits/weight super-block
+// (Q4_K's asymmetric per-32 scale and min and its 6-bit scale packing, with a 3-bit quant plane;
+// 112 B per 256 weights against Q4_K's 144 B) consumed by si_vec_dot_q3_A. Load-time only; never
+// read from or written to a GGUF. n_values must be a multiple of 256.
+void launch_ffn_requant_q3a(const void* src_bf16, void* dst_q3a, long n_values,
+                            cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3049,6 +3049,31 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if (req < 0) { const char* e = getenv("SPARKINFER_DOWN_REQUANT_Q4K"); req = (e && e[0] == '0') ? 0 : 1; }
         return dev_quant_requant_q4k(name, qtype, req != 0);
     };
+    // Requantize a weight matrix to Q3_A (3.5 bits/weight -- Q4_K's asymmetric per-32 scale and
+    // min, 3-bit quant plane, 112 B per 256 weights) at load, then decode it on-read through
+    // si_vec_dot_q3_A, so the matrix is read 22.2% smaller on every decode token. Sources
+    // Q4_K/Q5_K/Q6_K straight to Q3_A (one dequant, one fit). Falls back to the untouched source
+    // on any failure.
+    auto dev_quant_q3a = [&](const std::string& name, int& qtype) -> const void* {
+        const void* src = dev_quant(name, qtype);
+        if (!src) return src;
+        if (qtype != 12 && qtype != 13 && qtype != 14) return src;   // Q4_K / Q5_K / Q6_K
+        const GGUFTensor* t = g.tensor(name);
+        const long nv = t->n_values;
+        if (nv % 256 != 0) return src;
+        void* deq = nullptr;
+        if (cudaMalloc(&deq, (size_t)nv * 2) != cudaSuccess) return src;
+        kernels::launch_gguf_dequant(qtype, src, deq, nv, s.stream);
+        void* q3 = nullptr;
+        if (cudaMalloc(&q3, (size_t)(nv / 256) * 112) != cudaSuccess) { cudaFree(deq); return src; }
+        kernels::launch_ffn_requant_q3a(deq, q3, nv, s.stream);
+        cudaStreamSynchronize(s.stream);
+        cudaFree(deq);
+        if (!s.owned.empty() && s.owned.back() == src) { s.owned.pop_back(); cudaFree((void*)src); }
+        s.owned.push_back(q3);
+        qtype = kernels::SI_QTYPE_Q3A;
+        return q3;
+    };
     // dense weight -> bf16 (optionally transpose [out,in] -> [in,out])
     auto dense = [&](const std::string& name, bool transpose) -> const void* {
         const GGUFTensor* t = g.tensor(name);
@@ -3107,6 +3132,37 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                  : (q35_dense9b_requant_default ? std::string("qkv,v")
                     : (q36_ud_requant_default ? std::string("attn_q,attn_output,qkv,attn_gate,ssm_out")
                                               : std::string()));
+    // Muse Glimmer dense FFN gate/up -> Q3_A on the 42 layers selected by calibration.
+    // The ten sensitive layers remain native Q4_K; this passes the production distribution gate
+    // (top1 >= 0.90 and KL <= 0.10 against llama.cpp) while reducing decode weight traffic.
+    // Architecture-scoped because no other model served by this shared loader was calibrated.
+    // SPARKINFER_MUSE_FFN_Q3A=0 restores the Q4_K load path exactly, so both arms of an A/B come
+    // out of one binary.
+    const char* ffn_q3a_layers_env = getenv("SPARKINFER_MUSE_FFN_Q3A_LAYERS");
+    const std::string ffn_q3a_layers = ffn_q3a_layers_env
+        ? std::string(ffn_q3a_layers_env)
+        : (c.muse_glimmer ? std::string("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,33,34,39,40,41,42,43,44,45,46,47,48,49,50,51") : std::string());
+    const char* ffn_q3a_env = getenv("SPARKINFER_MUSE_FFN_Q3A");
+    const std::string ffn_q3a_mode =
+        ffn_q3a_env ? std::string(ffn_q3a_env)
+                    : (c.muse_glimmer ? std::string("ffn_gate,ffn_up") : std::string());
+    auto list_token = [](const std::string& list, const char* want) {
+        const std::string w(want);
+        size_t p = 0;
+        while (p < list.size()) {
+            while (p < list.size() && (list[p] == ',' || list[p] == '+' || list[p] == ':' || list[p] == ' ')) ++p;
+            size_t e = p;
+            while (e < list.size() && list[e] != ',' && list[e] != '+' && list[e] != ':' && list[e] != ' ') ++e;
+            if (e > p && list.compare(p, e - p, w) == 0) return true;
+            p = e + 1;
+        }
+        return false;
+    };
+    auto ffn_q3a_on = [&](const char* which) {
+        if (mode_is_off(ffn_q3a_mode)) return false;
+        if (ffn_q3a_mode == "1" || list_token(ffn_q3a_mode, "all")) return true;
+        return list_token(ffn_q3a_mode, which);
+    };
     auto mode_token = [&](const char* want) {
         const std::string w(want);
         size_t p = 0;
@@ -3400,8 +3456,14 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             if (!expect_dims(b + "ffn_gate.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_up.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_down.weight", {c.moe_ffn, H})) return false;
-            w.gate_q = dev_quant(b + "ffn_gate.weight", w.gate_qtype);
-            w.up_q   = dev_quant(b + "ffn_up.weight", w.up_qtype);
+            // Gate and up convert together or not at all because the compact MMVQ kernel
+            // consumes equal-stride pairs; unselected layers retain the native Q4_K path.
+            const bool gu3 = ffn_q3a_on("ffn_gate") && ffn_q3a_on("ffn_up") &&
+                             int_list_has(ffn_q3a_layers, i);
+            w.gate_q = gu3 ? dev_quant_q3a(b + "ffn_gate.weight", w.gate_qtype)
+                           : dev_quant(b + "ffn_gate.weight", w.gate_qtype);
+            w.up_q   = gu3 ? dev_quant_q3a(b + "ffn_up.weight", w.up_qtype)
+                           : dev_quant(b + "ffn_up.weight", w.up_qtype);
             w.down_q = dev_quant_down(b + "ffn_down.weight", w.down_qtype);
         } else {
             if (!expect_dims(b + "ffn_gate_inp.weight", {H, c.n_experts})) return false;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -2910,6 +2910,31 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if (req < 0) { const char* e = getenv("SPARKINFER_DOWN_REQUANT_Q4K"); req = (e && e[0] == '0') ? 0 : 1; }
         return dev_quant_requant_q4k(name, qtype, req != 0);
     };
+    // Requantize a weight matrix to Q3_A (3.5 bits/weight -- Q4_K's asymmetric per-32 scale and
+    // min, 3-bit quant plane, 112 B per 256 weights) at load, then decode it on-read through
+    // si_vec_dot_q3_A, so the matrix is read 22.2% smaller on every decode token. Sources
+    // Q4_K/Q5_K/Q6_K straight to Q3_A (one dequant, one fit). Falls back to the untouched source
+    // on any failure.
+    auto dev_quant_q3a = [&](const std::string& name, int& qtype) -> const void* {
+        const void* src = dev_quant(name, qtype);
+        if (!src) return src;
+        if (qtype != 12 && qtype != 13 && qtype != 14) return src;   // Q4_K / Q5_K / Q6_K
+        const GGUFTensor* t = g.tensor(name);
+        const long nv = t->n_values;
+        if (nv % 256 != 0) return src;
+        void* deq = nullptr;
+        if (cudaMalloc(&deq, (size_t)nv * 2) != cudaSuccess) return src;
+        kernels::launch_gguf_dequant(qtype, src, deq, nv, s.stream);
+        void* q3 = nullptr;
+        if (cudaMalloc(&q3, (size_t)(nv / 256) * 112) != cudaSuccess) { cudaFree(deq); return src; }
+        kernels::launch_ffn_requant_q3a(deq, q3, nv, s.stream);
+        cudaStreamSynchronize(s.stream);
+        cudaFree(deq);
+        if (!s.owned.empty() && s.owned.back() == src) { s.owned.pop_back(); cudaFree((void*)src); }
+        s.owned.push_back(q3);
+        qtype = kernels::SI_QTYPE_Q3A;
+        return q3;
+    };
     // dense weight -> bf16 (optionally transpose [out,in] -> [in,out])
     auto dense = [&](const std::string& name, bool transpose) -> const void* {
         const GGUFTensor* t = g.tensor(name);
@@ -2968,6 +2993,37 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                  : (q35_dense9b_requant_default ? std::string("qkv,v")
                     : (q36_ud_requant_default ? std::string("attn_q,attn_output,qkv,attn_gate,ssm_out")
                                               : std::string()));
+    // Muse Glimmer dense FFN gate/up -> Q3_A on the 42 layers selected by calibration.
+    // The ten sensitive layers remain native Q4_K; this passes the production distribution gate
+    // (top1 >= 0.90 and KL <= 0.10 against llama.cpp) while reducing decode weight traffic.
+    // Architecture-scoped because no other model served by this shared loader was calibrated.
+    // SPARKINFER_MUSE_FFN_Q3A=0 restores the Q4_K load path exactly, so both arms of an A/B come
+    // out of one binary.
+    const char* ffn_q3a_layers_env = getenv("SPARKINFER_MUSE_FFN_Q3A_LAYERS");
+    const std::string ffn_q3a_layers = ffn_q3a_layers_env
+        ? std::string(ffn_q3a_layers_env)
+        : (c.muse_glimmer ? std::string("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,33,34,39,40,41,42,43,44,45,46,47,48,49,50,51") : std::string());
+    const char* ffn_q3a_env = getenv("SPARKINFER_MUSE_FFN_Q3A");
+    const std::string ffn_q3a_mode =
+        ffn_q3a_env ? std::string(ffn_q3a_env)
+                    : (c.muse_glimmer ? std::string("ffn_gate,ffn_up") : std::string());
+    auto list_token = [](const std::string& list, const char* want) {
+        const std::string w(want);
+        size_t p = 0;
+        while (p < list.size()) {
+            while (p < list.size() && (list[p] == ',' || list[p] == '+' || list[p] == ':' || list[p] == ' ')) ++p;
+            size_t e = p;
+            while (e < list.size() && list[e] != ',' && list[e] != '+' && list[e] != ':' && list[e] != ' ') ++e;
+            if (e > p && list.compare(p, e - p, w) == 0) return true;
+            p = e + 1;
+        }
+        return false;
+    };
+    auto ffn_q3a_on = [&](const char* which) {
+        if (mode_is_off(ffn_q3a_mode)) return false;
+        if (ffn_q3a_mode == "1" || list_token(ffn_q3a_mode, "all")) return true;
+        return list_token(ffn_q3a_mode, which);
+    };
     auto mode_token = [&](const char* want) {
         const std::string w(want);
         size_t p = 0;
@@ -3261,8 +3317,14 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             if (!expect_dims(b + "ffn_gate.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_up.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_down.weight", {c.moe_ffn, H})) return false;
-            w.gate_q = dev_quant(b + "ffn_gate.weight", w.gate_qtype);
-            w.up_q   = dev_quant(b + "ffn_up.weight", w.up_qtype);
+            // Gate and up convert together or not at all because the compact MMVQ kernel
+            // consumes equal-stride pairs; unselected layers retain the native Q4_K path.
+            const bool gu3 = ffn_q3a_on("ffn_gate") && ffn_q3a_on("ffn_up") &&
+                             int_list_has(ffn_q3a_layers, i);
+            w.gate_q = gu3 ? dev_quant_q3a(b + "ffn_gate.weight", w.gate_qtype)
+                           : dev_quant(b + "ffn_gate.weight", w.gate_qtype);
+            w.up_q   = gu3 ? dev_quant_q3a(b + "ffn_up.weight", w.up_qtype)
+                           : dev_quant(b + "ffn_up.weight", w.up_qtype);
             w.down_q = dev_quant_down(b + "ffn_down.weight", w.down_qtype);
         } else {
             if (!expect_dims(b + "ffn_gate_inp.weight", {H, c.n_experts})) return false;


### PR DESCRIPTION
## Summary

Adds a Muse Glimmer-specific, calibration-selected 3.5-bit representation for dense-FFN gate and up projections. Forty-two accuracy-tolerant layers use the compact format while ten sensitive layers remain native Q4_K. The branch includes the decode optimizations merged in #782 and improves 128-token autoregressive decode from 104.36 to 110.66 tok/s (+6.04%) on an RTX 5090 while passing the production llama.cpp distribution gate.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, three alternating same-binary runs):

| | decode tok/s |
|---|--:|
| before (main after #782; Q3_A disabled) | 104.36 |
| after (this PR; Q3_A enabled) | 110.66 |

```text
# RTX 5090, official 17 GB Muse Glimmer GGUF, 128-token autoregressive decode
# Branch: 235d6f7 (includes #782); only SPARKINFER_MUSE_FFN_Q3A changes between arms.

run      control    this PR
1        104.34     110.61 tok/s
2        104.38     110.70 tok/s
3        104.36     110.68 tok/s
mean     104.36     110.66 tok/s
delta               +6.04%
```

## Design

At model load, selected Q4_K gate/up tensors are dequantized once and fitted into an internal Q3_A super-block. Q3_A keeps Q4_K's asymmetric per-32 scale/min metadata while replacing the 4-bit value plane with a 3-bit plane, reducing each 256-weight block from 144 to 112 bytes.

- Selected layers: 0-26, 33-34, and 39-51.
- Sensitive layers 27-32 and 35-38 remain Q4_K.
- A dedicated dp4a MMVQ kernel consumes equal-stride Q3_A gate/up pairs.
- `SPARKINFER_MUSE_FFN_Q3A=0` restores native Q4_K for same-binary A/B testing.

The format is internal only and is never read from or written to GGUF files. Other architectures retain their existing load and dispatch paths.

## Benchmark details

After merging #782 into this branch, three alternating same-binary runs were performed with the official 17 GB Muse Glimmer GGUF on an RTX 5090. Disabling only Q3_A preserves all #782 optimizations and provides the current-frontier control. The stable means were 104.36 tok/s for control and 110.66 tok/s for selective Q3_A (+6.04%).

```bash
SPARKINFER_MUSE_FFN_Q3A=0 build/runtime/qwen3_gguf_bench model.gguf 128 0
build/runtime/qwen3_gguf_bench model.gguf 128 0
```

## Accuracy

Teacher-forced scoring used the evaluator's 99-position corpus and top-128 logits against a live llama.cpp server using the same GGUF.

| Metric | Result | Required |
|---|---:|---:|
| Top-1 agreement | 0.969697 | >= 0.90 |
| Mean KL | 0.088731 | <= 0.10 |
| SparkInfer PPL | 2.7561 | informational |

## Validation

- Release build for CUDA `sm_120` at combined commit `235d6f7`: passed.
- `ctest --test-dir build --output-on-failure`: 13/13 passed.
- Muse Glimmer accuracy gate: passed.
- `git diff --check`: passed.

## Scope

- Muse Glimmer dense FFN only.
- Gate/up projections only; down projection is unchanged.
- No evaluation, workflow, or protected-path changes.
- No changes to other model architectures.

## Fallback

Set `SPARKINFER_MUSE_FFN_Q3A=0` to disable conversion entirely. `SPARKINFER_MUSE_FFN_Q3A_LAYERS` can override the calibrated layer list for diagnostics.
