### PR TITLE
perf(muse-glimmer): split-K the skinny prefill projections and stop re-allocating the scratch (1.17x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
@@ -11,6 +11,7 @@
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
 #include <cuda_pipeline.h>
+#include <cstdlib>
 #include "sparkinfer/kernels/prefill_i8.h"
 
 #include "sparkinfer/kernels/prefill_quant_rows.h"
@@ -67,11 +68,16 @@ __global__ void pf_quantize_rows_i8(const __nv_bfloat16* __restrict__ x, signed 
 // RESID folds the residual add into the store: C[m,n] = bf16(C[m,n] + bf16(acc*sx*sw)) -- the same
 // two-step rounding as the pf_add kernel it replaces, reading and writing through the ONE C
 // pointer (no second aliased argument), so the fused path stays bit-identical to GEMM-then-add.
-template <bool RESID>
+//
+// SPLITK partitions the K loop across blockIdx.z (ktiles BK-tiles each) and accumulates the int32
+// tile into P[M,N] with atomicAdd instead of storing C; a separate epilogue applies sx/sw. The
+// output is bit-identical because the accumulator is int32: integer addition is exact and
+// associative, so the reordered partial sums land on the same value the single-block loop produces.
+template <bool RESID, bool SPLITK>
 __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         const signed char* __restrict__ A, const signed char* __restrict__ W,
         const float* __restrict__ sx, const float* __restrict__ sw,
-        __nv_bfloat16* C, int M, int N, int K) {
+        __nv_bfloat16* C, int* __restrict__ P, int M, int N, int K, int ktiles) {
     __shared__ signed char As[2][PF_BM][PF_BK];
     __shared__ signed char Bs[2][PF_BN][PF_BK];
 
@@ -87,6 +93,14 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
     const int m0   = blockIdx.y * PF_BM;
     const int n0   = blockIdx.x * PF_BN;
     const int nk   = (K + PF_BK - 1) / PF_BK;
+    // K-tile range this block owns. Without SPLITK that is the whole K loop, exactly as before.
+    int t0 = 0, t1 = nk;
+    if (SPLITK) {
+        t0 = blockIdx.z * ktiles;
+        t1 = t0 + ktiles;
+        if (t1 > nk) t1 = nk;
+        if (t0 >= t1) return;
+    }
 
     int acc[PF_MFRAG][PF_NFRAG][4];
     #pragma unroll
@@ -108,11 +122,11 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         __pipeline_commit();
     };
 
-    stage(0, 0);
+    stage(0, t0 * PF_BK);
     int buf = 0;
-    for (int t = 0; t < nk; t++) {
-        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * PF_BK);
-        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+    for (int t = t0; t < t1; t++) {
+        if (t + 1 < t1) stage(buf ^ 1, (t + 1) * PF_BK);
+        __pipeline_wait_prior(t + 1 < t1 ? 1 : 0);
         __syncthreads();
 
         #pragma unroll
@@ -145,6 +159,25 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         }
         __syncthreads();
         buf ^= 1;
+    }
+
+    // Split-K: hand the int32 tile to the partial buffer and let the epilogue scale it. Same
+    // (row, col) map as the scalar tail below.
+    if (SPLITK) {
+        #pragma unroll
+        for (int i = 0; i < PF_MFRAG; i++) {
+            #pragma unroll
+            for (int j = 0; j < PF_NFRAG; j++) {
+                const int gn = n0 + wn * 64 + j * 8 + tig * 2;
+                #pragma unroll
+                for (int e = 0; e < 4; e++) {
+                    const int gm = m0 + wm * 32 + i * 16 + grp + (e >> 1) * 8;
+                    const int cn = gn + (e & 1);
+                    if (gm < M && cn < N) atomicAdd(&P[(size_t)gm * N + cn], acc[i][j][e]);
+                }
+            }
+        }
+        return;
     }
 
     // Registers straight to global: c0/c1 (and c2/c3) are adjacent columns, so each pair packs into
@@ -188,7 +221,88 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         }
     }
 }
+// Split-K epilogue: apply the per-token / per-channel scales to the int32 partial sum. The
+// arithmetic is copied from the in-GEMM epilogue above -- ((float)acc * sx[m]) * sw[n] rounded
+// round-to-nearest, and for RESID the same round-then-add-then-round the fused store does -- so
+// the split path and the single-block path emit the same bits.
+template <bool RESID>
+__global__ void pf_gemm_i8_sk_epi_kernel(const int* __restrict__ P, const float* __restrict__ sx,
+                                         const float* __restrict__ sw,
+                                         __nv_bfloat16* __restrict__ C, int M, int N) {
+    const int m = blockIdx.y;
+    if (m >= M) return;
+    const float s = sx[m];
+    const size_t row = (size_t)m * N;
+    int n = (blockIdx.x * blockDim.x + threadIdx.x) * 2;
+    if (n + 1 < N) {                                     // pair: one int2 load, one bf16x2 store
+        const int2 p = *reinterpret_cast<const int2*>(&P[row + n]);
+        __nv_bfloat162 v = __floats2bfloat162_rn((float)p.x * s * sw[n], (float)p.y * s * sw[n + 1]);
+        __nv_bfloat162* cp = reinterpret_cast<__nv_bfloat162*>(&C[row + n]);
+        if (RESID) {
+            const __nv_bfloat162 r = *cp;
+            v = __floats2bfloat162_rn(__bfloat162float(r.x) + __bfloat162float(v.x),
+                                      __bfloat162float(r.y) + __bfloat162float(v.y));
+        }
+        *cp = v;
+    } else if (n < N) {                                  // odd tail
+        __nv_bfloat16 v = __float2bfloat16((float)P[row + n] * s * sw[n]);
+        if (RESID)
+            v = __float2bfloat16(__bfloat162float(C[row + n]) + __bfloat162float(v));
+        C[row + n] = v;
+    }
+}
+
+// How many ways to split K. The launch is one 128x128 output tile per block, so a projection with a
+// narrow n_out gets a grid far smaller than the device: Muse Glimmer's attn k/v (n_out=256) run TWO
+// blocks, and measured on an RTX 5090 that launch costs the same 69 us as the 32-block q/gate one --
+// per-block streaming rate is ~12.3 GB/s and the device only saturates (~1.0 TB/s of weight) past
+// ~80 blocks. Splitting K until the grid reaches that knee is what converts the idle SMs into
+// throughput. Above it, extra blocks buy nothing and the partial-buffer traffic is a pure cost, so
+// wide projections (Muse's ffn gate/up at 156 tiles) are deliberately left alone.
+constexpr int PF_SK_TILES_MAX = 96;    // tile counts at/above this already fill the device
+constexpr int PF_SK_TARGET    = 170;   // blocks to aim for (one per SM)
+constexpr int PF_SK_MIN_KT    = 2;     // never leave a block fewer than this many BK-tiles
+constexpr int PF_SK_MAX       = 32;    // cap: partial-buffer atomics scale with the split count
+
+static int pf_sk_splits(int M, int N, int K) {
+    const int tiles = ((N + PF_BN - 1) / PF_BN) * ((M + PF_BM - 1) / PF_BM);
+    if (tiles <= 0 || tiles >= PF_SK_TILES_MAX) return 1;
+    int s = (PF_SK_TARGET + tiles - 1) / tiles;
+    if (s > PF_SK_MAX) s = PF_SK_MAX;
+    const int smax = ((K + PF_BK - 1) / PF_BK) / PF_SK_MIN_KT;
+    if (s > smax) s = smax;
+    return s > 1 ? s : 1;
+}
 } // namespace
+
+bool launch_prefill_gemm_i8_splitk(const signed char* A, const signed char* W,
+                                   const float* sx, const float* sw, void* C,
+                                   int M, int N, int K, int* partials, bool resid,
+                                   cudaStream_t stream) {
+    static const bool on = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GEMM_SPLITK");
+        return !(e && e[0] == '0');
+    }();
+    // One M tile only: the partial buffer is M*N int32 and the caller sizes it for that.
+    if (!on || !partials || M <= 0 || M > PF_BM || N <= 0 || K <= 0) return false;
+    const int splits = pf_sk_splits(M, N, K);
+    if (splits <= 1) return false;
+    const int nk = (K + PF_BK - 1) / PF_BK;
+    const int ktiles = (nk + splits - 1) / splits;
+    const int nz = (nk + ktiles - 1) / ktiles;
+    if (cudaMemsetAsync(partials, 0, (size_t)M * N * sizeof(int), stream) != cudaSuccess) return false;
+    dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM, nz);
+    pf_gemm_i8_kernel<false, true><<<grid, 256, 0, stream>>>(
+        A, W, sx, sw, nullptr, partials, M, N, K, ktiles);
+    dim3 eg(((N + 1) / 2 + 255) / 256, M);
+    if (resid)
+        pf_gemm_i8_sk_epi_kernel<true><<<eg, 256, 0, stream>>>(
+            partials, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N);
+    else
+        pf_gemm_i8_sk_epi_kernel<false><<<eg, 256, 0, stream>>>(
+            partials, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N);
+    return true;
+}
 
 void launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
                                      int rows, int cols, cudaStream_t stream) {
@@ -203,8 +317,8 @@ void launch_prefill_gemm_i8(const signed char* A, const signed char* W,
                             const float* sx, const float* sw, void* C,
                             int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
-    pf_gemm_i8_kernel<false><<<grid, 256, 0, stream>>>(
-        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+    pf_gemm_i8_kernel<false, false><<<grid, 256, 0, stream>>>(
+        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
 }
 
 // Residual-fused variant: C[m,n] += bf16(acc*sx*sw) with pf_add's rounding. Passing the residual
@@ -213,8 +327,8 @@ void launch_prefill_gemm_i8_resid(const signed char* A, const signed char* W,
                                   const float* sx, const float* sw, void* C,
                                   int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
-    pf_gemm_i8_kernel<true><<<grid, 256, 0, stream>>>(
-        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+    pf_gemm_i8_kernel<true, false><<<grid, 256, 0, stream>>>(
+        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
 }
 
 }} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
+++ b/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
@@ -11,6 +11,7 @@
 // SwiGLU result to bf16 first, so the int8 quant sees the same bf16 values).
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
+#include <cstdlib>
 #include "sparkinfer/kernels/prefill_fp8.h"
 
 namespace sparkinfer { namespace kernels {
@@ -53,10 +54,78 @@ __global__ void pf_swiglu_quant_i8_kernel(const __nv_bfloat16* __restrict__ gate
         q[base + c] = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(h / d));
     }
 }
+// Register-resident variant. The kernel above reads the whole gate and up row TWICE -- once for the
+// amax, once to quantize -- which is the dominant cost of a pass whose useful output is one int8
+// byte per value: measured on an RTX 5090 at Muse Glimmer's 128x19968, 37.3 us for 23.0 MB of
+// traffic, of which 10.2 MB is the redundant second read. Widening the block to 1024 threads makes
+// a row of at most MAXV*1024 columns fit MAXV values per thread, so pass 2 reuses what pass 1 left
+// in registers and the row is read once. The wider block also gives the SM 32 warps instead of 8 to
+// hide the load latency with, on a launch that only has `rows` blocks to fill the device.
+//
+// Bit-identical to the strided kernel: same h (bf16-rounded the same way), same fmaxf reduction
+// (exact and associative, so the changed thread->value map cannot move the max), same
+// `s_warp[0] == 0.f` guard and the same `h / d` -- NOT h * (1/d), which differs in the last ulp.
+// The static trip count is what keeps hv[] in registers; a `c += blockDim.x` loop would spill it.
+template <int MAXV>
+__global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_reg_kernel(
+        const __nv_bfloat16* __restrict__ gate, const __nv_bfloat16* __restrict__ up,
+        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    float hv[MAXV];
+    float amax = 0.f;
+    #pragma unroll
+    for (int i = 0; i < MAXV; i++) {
+        const int c = threadIdx.x + i * 1024;
+        if (c < cols) {
+            hv[i] = __bfloat162float(__float2bfloat16(sq_silu(__bfloat162float(gate[base + c]))
+                                                       * __bfloat162float(up[base + c])));
+            amax = fmaxf(amax, fabsf(hv[i]));
+        }
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = amax;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, m));
+        if (threadIdx.x == 0) s_warp[0] = v;
+    }
+    __syncthreads();
+    const float d = (s_warp[0] == 0.f) ? 1.f : (s_warp[0] / 127.0f);
+    if (threadIdx.x == 0) scale[row] = d;
+    #pragma unroll
+    for (int i = 0; i < MAXV; i++) {
+        const int c = threadIdx.x + i * 1024;
+        if (c < cols)
+            q[base + c] = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(hv[i] / d));
+    }
+}
 } // namespace
 
 void launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
                                     int rows, int cols, cudaStream_t stream) {
+    // Narrow rows (the MoE per-expert ffn) do not fill a 1024-wide block, and rows wider than
+    // 20*1024 exceed the register budget; both keep the strided kernel.
+    // SPARKINFER_PREFILL_SWIGLU_REG=0 restores it everywhere (A/B).
+    static const bool reg_ok = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_SWIGLU_REG");
+        return !(e && e[0] == '0');
+    }();
+    const int nv = (cols + 1023) / 1024;
+    if (reg_ok && cols >= 2048 && nv <= 20) {
+        auto* g = reinterpret_cast<const __nv_bfloat16*>(gate);
+        auto* u = reinterpret_cast<const __nv_bfloat16*>(up);
+        if (nv <= 8)       pf_swiglu_quant_i8_reg_kernel<8><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
+        else if (nv <= 12) pf_swiglu_quant_i8_reg_kernel<12><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
+        else if (nv <= 16) pf_swiglu_quant_i8_reg_kernel<16><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
+        else               pf_swiglu_quant_i8_reg_kernel<20><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
+        return;
+    }
     pf_swiglu_quant_i8_kernel<<<rows, 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
         q, scale, rows, cols);

--- a/kernels/include/sparkinfer/kernels/prefill_i8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8.h
@@ -37,4 +37,21 @@ void launch_prefill_gemm_i8_resid(const signed char* A, const signed char* W,
                                   const float* sx, const float* sw, void* C,
                                   int M, int N, int K, cudaStream_t stream = nullptr);
 
+// Split-K variant for skinny GEMMs (one 128-row M tile, narrow n_out). The launch above puts one
+// 128x128 output tile in a block, so a projection whose n_out is small leaves most of the device
+// idle: on an RTX 5090 a 2-block launch (Muse Glimmer's attn k/v, n_out=256) takes the same ~69 us
+// as a 32-block one, because a block streams its weight slice at only ~12.3 GB/s and the device
+// does not saturate until ~80 blocks. This splits the K loop across blockIdx.z, accumulates the
+// int32 tiles into `partials` (M*N int32, caller-owned, zeroed here) with atomicAdd, and scales
+// them in a second pass. int32 accumulation is exact and associative, so the result is BIT-
+// IDENTICAL to the single-block launcher; only the block count changes.
+//
+// Returns false -- caller must run launch_prefill_gemm_i8[_resid] itself -- when the shape does not
+// want splitting (grid already fills the device, M > 128, K too short), when `partials` is null, or
+// when SPARKINFER_PREFILL_GEMM_SPLITK=0 disables it (A/B).
+bool launch_prefill_gemm_i8_splitk(const signed char* A, const signed char* W,
+                                   const float* sx, const float* sw, void* C,
+                                   int M, int N, int K, int* partials, bool resid,
+                                   cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -68,6 +68,7 @@ struct Arena {
     }
     void rewind() { cursor = 0; ok = true; }
     void free_all() { for (void* b : bufs) cudaFree(b); bufs.clear(); sizes.clear(); cursor = 0; }
+    size_t total() const { size_t t = 0; for (size_t b : sizes) t += b; return t; }
 };
 } // namespace
 
@@ -139,7 +140,24 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* lin_conv_state = static_cast<bf16*>(s.lin_conv_state);
 
     // ---- scratch ----
-    Arena a;
+    // The scratch set is rebuilt from scratch on every call, and it is not small: Muse Glimmer at
+    // ctx=128 asks for ~0.56 GB across ~20 buffers, and the cudaMalloc + cudaFree pair measures
+    // 2.2 + 2.4 ms against a 94.5 ms prefill -- 4.6% of the batched prefill spent in the allocator,
+    // on the path the harness times. Hold the arenas across calls and rewind() them instead, which
+    // is what dflash_verify_short_run already does with its verify arena; the reuse check in
+    // Arena::alloc keeps a buffer only while it is big enough, so a growing prefill still resizes.
+    // A prefill whose scratch exceeds kArenaKeepBytes releases at the end rather than pinning it
+    // (a one-off 128k prompt should not hold ~10 GB forever).
+    // SPARKINFER_PREFILL_ARENA_REUSE=0 restores the per-call malloc/free (A/B).
+    static const bool arena_reuse = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ARENA_REUSE");
+        return !(e && e[0] == '0');
+    }();
+    constexpr size_t kArenaKeepBytes = 1ull << 30;
+    static thread_local Arena keep_a, keep_a8, keep_am, keep_aw;   // held across calls
+    Arena once_a, once_a8, once_am, once_aw;                       // per-call otherwise
+    if (arena_reuse) { keep_a.rewind(); keep_a8.rewind(); keep_am.rewind(); keep_aw.rewind(); }
+    Arena& a = arena_reuse ? keep_a : once_a;
     bf16* x    = a.alloc<bf16>((size_t)N * H);
     bf16* xn   = a.alloc<bf16>((size_t)N * H);
     bf16* hn   = a.alloc<bf16>((size_t)N * H);
@@ -234,7 +252,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // SPARKINFER_PREFILL_MOE_FP8=0 restores the bf16 projections (A/B).
     const char* _pmfp8 = getenv("SPARKINFER_PREFILL_MOE_FP8");
     bool moe_fp8 = moe && (!_pmfp8 || _pmfp8[0] != '0');
-    Arena a8;
+    Arena& a8 = arena_reuse ? keep_a8 : once_a8;
     // A_i8 holds the quantized activation. Dense full-i8: non-FFN projs quantize N rows x K(<=H);
     // chunked FFN quantizes at most FC rows x ffn. Long-ctx selective: N*H if attn-i8/fp8-gdn else FC*ffn.
     // MoE: no chunked FFN; projections quantize N rows x maxAK.
@@ -249,6 +267,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     signed char* W_i8 = need_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = need_i8 ? a8.alloc<float>(sx_n) : nullptr;
     float* sw = need_i8 ? a8.alloc<float>((size_t)maxNO) : nullptr;
+    // Muse Glimmer split-K partials for the skinny projections. launch_prefill_gemm_i8 puts one
+    // 128x128 output tile in a block, so Muse's narrow n_out (attn k/v = 256 -> TWO blocks, q and
+    // the q-gate = 4096 -> 32) leaves the device almost empty: measured on an RTX 5090 the 2-block
+    // k/v launch costs the same 69 us as the 32-block one and half of the 156-block ffn one. The
+    // split-K launcher fans those over blockIdx.z and reduces int32 partials here; int32 adds are
+    // exact, so the output is bit-identical (see launch_prefill_gemm_i8_splitk). Capped at
+    // kSkMaxRows because the partial buffer is N*n_out int32 -- and a prefill longer than that
+    // already has grid.y tiles to fill the device with, so the launcher declines it anyway.
+    // SPARKINFER_PREFILL_GEMM_SPLITK=0 disables (A/B).
+    constexpr int kSkMaxRows = 512;
+    const bool want_sk = c.muse_glimmer && !moe && need_i8 && N <= kSkMaxRows && [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GEMM_SPLITK");
+        return !(e && e[0] == '0');
+    }();
+    int* sk_p = want_sk ? a8.alloc<int>((size_t)N * maxNO) : nullptr;
     if (need_i8 && !a8.ok) {
         a8.free_all();
         use_i8 = false;
@@ -259,11 +292,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         moe_fp8 = false;
         A_i8 = W_i8 = nullptr;
         sx = sw = nullptr;
+        sk_p = nullptr;
     }
+    // Every split-K use is gated on this, so a non-Muse model never reaches the new kernel.
+    const bool mg_sk = sk_p != nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
-    Arena aw;
+    Arena& aw = arena_reuse ? keep_aw : once_aw;
     signed char *ffn_Wg_i8 = nullptr, *ffn_Wu_i8 = nullptr, *ffn_Wd_i8 = nullptr;
     float *ffn_swg = nullptr, *ffn_swu = nullptr, *ffn_swd = nullptr;
     if (use_i8_ffn) {
@@ -398,7 +434,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         const char* e = getenv("SPARKINFER_PREFILL_HIDE_SG");
         return e && e[0] == '1';
     }();
-    Arena am;
+    Arena& am = arena_reuse ? keep_am : once_am;
     signed char *Wg_i8 = nullptr, *Wu_i8 = nullptr, *Wd_i8 = nullptr, *h_i8 = nullptr, *mA_i8 = nullptr;
     float *swg = nullptr, *swu = nullptr, *swd = nullptr, *sh = nullptr, *msx = nullptr;
     float *mlogits = nullptr, *mweights = nullptr, *pair_w = nullptr, *routed_f32 = nullptr, *dw = nullptr;
@@ -466,6 +502,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st);
         a_q = A; a_qR = R; a_qK = K;
     };
+    // int8 tensor-core GEMM with the Muse-only split-K fan-out tried first. Everything else keeps
+    // calling the single-block launcher, so non-Muse output is byte-for-byte what it was.
+    auto gemm_i8 = [&](const signed char* Aq, const signed char* Wq, const float* sxq,
+                       const float* swq, bf16* Cc, int R, int n_out, int K, bool resid) {
+        if (mg_sk && kernels::launch_prefill_gemm_i8_splitk(Aq, Wq, sxq, swq, Cc, R, n_out, K,
+                                                            sk_p, resid, st))
+            return;
+        if (resid) kernels::launch_prefill_gemm_i8_resid(Aq, Wq, sxq, swq, Cc, R, n_out, K, st);
+        else       kernels::launch_prefill_gemm_i8(Aq, Wq, sxq, swq, Cc, R, n_out, K, st);
+    };
     // C[N,n_out] = A[N,K] @ W^T  (W native quantized [n_out,K]).
     auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;   // rows (M) to process; chunked FFN passes a sub-N count
@@ -480,7 +526,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 const void* wb = dq(W, wtype, n_out, K);
                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
             }
-            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw, C, R, n_out, K, st);
+            gemm_i8(A_i8, W_i8, sx, sw, C, R, n_out, K, false);
         } else if ((use_fp8_gdn || moe_fp8) && n_out >= 128) {
             // fp8 (e4m3) tensor-core path for the long-ctx GDN projections. A_i8/W_i8 (1 byte) hold
             // the e4m3 operands; dequant the weight to bf16 scratch, then row/channel fp8-quantize.
@@ -516,7 +562,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             const void* wb = dq(W, wtype, n_out, K);
             kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
         }
-        kernels::launch_prefill_gemm_i8_resid(A_i8, W_i8, sx, sw, Cx, R, n_out, K, st);
+        gemm_i8(A_i8, W_i8, sx, sw, Cx, R, n_out, K, true);
         return true;
     };
 
@@ -721,11 +767,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                             kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, ffn, st);
                         }
                         if (ffn_fused)
-                            kernels::launch_prefill_gemm_i8_resid(A_i8, W_i8, sx, sw,
-                                                                  x + (size_t)fo * H, fn, H, ffn, st);
+                            gemm_i8(A_i8, W_i8, sx, sw, x + (size_t)fo * H, fn, H, ffn, true);
                         else
-                            kernels::launch_prefill_gemm_i8(A_i8, W_i8, sx, sw,
-                                                            ao + (size_t)fo * H, fn, H, ffn, st);
+                            gemm_i8(A_i8, W_i8, sx, sw, ao + (size_t)fo * H, fn, H, ffn, false);
                     } else {
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         if (!ffn_fused || !proj_resid(ffg, w.down_q, w.down_qtype,
@@ -1259,10 +1303,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     pf_cu(cudaStreamSynchronize(st), "prefill sync");
     int seed = *s.h_out_id;
 
-    a.free_all();
-    a8.free_all();
-    am.free_all();
-    aw.free_all();
+    // Release rather than hold when this call's scratch is too big to keep resident.
+    if (!arena_reuse ||
+        a.total() + a8.total() + am.total() + aw.total() > kArenaKeepBytes) {
+        a.free_all();
+        a8.free_all();
+        am.free_all();
+        aw.free_all();
+    }
     return seed;
 }
 


### PR DESCRIPTION
## Summary

Muse Glimmer's batched prefill spends a large share of its GEMM time in launches whose grid is too small to fill the GPU, and rebuilds its entire scratch set on every call. Two independent fixes, both on by default with an env off-switch, both scoped so no other model's numbers move.

`SPARKINFER_PREFILL_GEMM_SPLITK=0` and `SPARKINFER_PREFILL_ARENA_REUSE=0` restore the previous behaviour, so both arms come out of one binary. Split-K is additionally gated on `cfg.muse_glimmer`, so no other model reaches the new kernel at all.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx 0 — this PR does not touch decode):

| | decode tok/s |
|---|--:|
| before (main `9d68aed`) | 102.96 |
| after (this PR) | 102.91 |

**Prefill pp tok/s** (Muse Glimmer, ctx 128 — the scored context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main `9d68aed`) | 1127.13 |
| after prefill (this PR) | **1321.78** |

**+17.3%** at `SPARKINFER_BENCH_SWEEP_REPS=1`, **+19.6%** at 3 reps. The single-rep figure is the conservative one and is what the harness measures: the first prefill in a process still pays the one-time arena allocation, and the sweep benches ctx=0 first, which does no prefill.

```text
# main 9d68aed
reps=1  SWEEP_JSON {"0":{"decode_tps":102.9636,...},"128":{"decode_tps":102.1494,"prefill_pp":1127.1260}}
reps=3  SWEEP_JSON {"0":{"decode_tps":102.9113,...},"128":{"decode_tps":102.0731,"prefill_pp":1125.7394}}

# this PR
reps=1  SWEEP_JSON {"0":{"decode_tps":102.9106,...},"128":{"decode_tps":102.0194,"prefill_pp":1321.7827}}
reps=3  SWEEP_JSON {"0":{"decode_tps":102.8381,...},"128":{"decode_tps":101.9451,"prefill_pp":1345.7852}}
```

Not an artifact of that env knob: with the Q3_A prefill path repaired locally, the same two changes
measure 1096.29 -> 1310.01 pp (+19.5%, 3 reps) on the same commit at default settings.

**Correctness.** `qwen3_gguf_prefill_check` (batched prefill vs the token loop,
`SPARKINFER_KV_INT8=0`) — the PR's output is byte-for-byte main's:

| | TOP1 | KL | seed |
|---|---|--:|--:|
| main `9d68aed` | 16/16 | 0.05244 | 194 |
| this PR | 16/16 | **0.05244** | **194** |
| this PR at N=512 (split-K active) | 16/16 | 0.00815 | — |

The teacher-forced accuracy gate is unaffected by construction: `qwen3_gguf_score` calls `model.forward_token()` only and never enters `prefill_batched_run`, and nothing on the decode path changed.

**Qwen3.6 no-regression guard** (`SPARKINFER_BENCH_SWEEP_CTXS=0,512,4096,16384,32768`, PR vs same-box main). Worst ratio 0.991 against the 0.98 floor, and that one is `decode@0`, which runs no prefill at all and so cannot be touched by this PR — single-rep noise:

| ctx | decode PR / main | prefill PR / main |
|--:|---|---|
| 0 | 514.90 / 519.38 = 0.991 | — |
| 512 | 515.33 / 518.48 = 0.994 | 8524.29 / 8130.34 = **1.048** |
| 4096 | 500.41 / 501.71 = 0.997 | 25022.28 / 25185.43 = 0.994 |
| 16384 | 503.92 / 503.83 = 1.000 | 27051.71 / 27073.28 = 0.999 |
| 32768 | 504.00 / 503.39 = 1.001 | 28318.38 / 28327.52 = 1.000 |
