### PR TITLE
perf(muse-glimmer): admit Muse's weight widths to the vector-store i8 dequant (1.27x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
+++ b/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
@@ -113,13 +113,18 @@ __device__ __forceinline__ float dqr_val(const unsigned char* blk, int t) {
 
 constexpr int DQR_BLOCK = 256, DQR_VEC = 4;   // 4 consecutive values/thread => 4B store, 128B/warp
 
-// One block per row; NG groups of DQR_BLOCK*DQR_VEC values each.
-template <int QT, int NG>
-__global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_kernel(
+// One block per row; NG groups of BLK*DQR_VEC values each. BLK is a template parameter because
+// v[NG][DQR_VEC] lives in registers: a wide row at BLK=256 needs a large NG (Muse Glimmer's
+// ffn_down, cols=19968, needs NG=20 => 80 floats/thread) and the resulting register pressure
+// costs more occupancy than the extra threads cost. Widening the block instead keeps NG small
+// (BLK=1024 => NG=5 for the same row). Value->thread mapping is unchanged, so the decode, the
+// amax and the stores are all bit-identical whatever BLK is.
+template <int QT, int NG, int BLK = DQR_BLOCK>
+__global__ __launch_bounds__(BLK) void deq_rows_i8_vec_kernel(
         const unsigned char* __restrict__ src, signed char* __restrict__ q,
         float* __restrict__ scale, int cols) {
     constexpr int BS = dqr_bs<QT>();
-    constexpr int GSPAN = DQR_BLOCK * DQR_VEC;               // values per group
+    constexpr int GSPAN = BLK * DQR_VEC;                     // values per group
     const int row = blockIdx.x, t = threadIdx.x;
     const int nsb = cols >> 8;
     const unsigned char* rbase = src + (size_t)row * nsb * BS;
@@ -140,13 +145,13 @@ __global__ __launch_bounds__(DQR_BLOCK) void deq_rows_i8_vec_kernel(
         }
     }
 
-    __shared__ float swarp[DQR_BLOCK / 32];
+    __shared__ float swarp[BLK / 32];
     #pragma unroll
     for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
     if ((t & 31) == 0) swarp[t >> 5] = amax;
     __syncthreads();
     if (t < 32) {
-        float w = (t < DQR_BLOCK / 32) ? swarp[t] : 0.f;
+        float w = (t < BLK / 32) ? swarp[t] : 0.f;
         #pragma unroll
         for (int o = 16; o > 0; o >>= 1) w = fmaxf(w, __shfl_xor_sync(0xffffffffu, w, o));
         if (t == 0) swarp[0] = w;
@@ -177,7 +182,16 @@ bool dispatch(const unsigned char* s, signed char* q, float* scale, int rows, in
     else if (ng <= 4)  deq_rows_i8_vec_kernel<QT, 4><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
     else if (ng <= 8)  deq_rows_i8_vec_kernel<QT, 8><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
     else if (ng <= 12) deq_rows_i8_vec_kernel<QT, 12><<<rows, DQR_BLOCK, 0, stream>>>(s, q, scale, cols);
-    else return false;                                   // wider than the register budget
+    else {
+        // Beyond 12 groups the register array is the binding constraint, not the thread count:
+        // Muse Glimmer's ffn_down (cols=19968) would need NG=20 at 256 threads = 80 floats/thread.
+        // A 1024-wide block covers the same row in NG=5, so widen the block instead of growing NG.
+        constexpr int WBLK = 1024, WSPAN = WBLK * DQR_VEC;
+        const int ngw = (cols + WSPAN - 1) / WSPAN;
+        if (ngw <= 5)      deq_rows_i8_vec_kernel<QT, 5, WBLK><<<rows, WBLK, 0, stream>>>(s, q, scale, cols);
+        else if (ngw <= 8) deq_rows_i8_vec_kernel<QT, 8, WBLK><<<rows, WBLK, 0, stream>>>(s, q, scale, cols);
+        else return false;                               // wider than the register budget
+    }
     return true;
 }
 
@@ -628,9 +642,27 @@ bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed cha
         const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_FAST");
         return (e && e[0] == '0') ? 0 : 1;
     }();
-    // Full-row / bulk path: require a full 1024-wide group so no threads idle. Partial widths
-    // (MoE down cols=512) use the gather/mask launchers below.
-    if (!enabled || rows <= 0 || cols <= 0 || (cols % (DQR_BLOCK * DQR_VEC)) != 0) return false;
+    // The kernel only needs a thread's 4 values to sit inside one super-block, which 4-alignment
+    // already guarantees, and nsb = cols>>8 to be exact -- i.e. cols % 256 == 0. Every group is
+    // guarded by `base < cols`, so a trailing partial group is already handled. Requiring a full
+    // 1024-wide group on top of that was a throughput guard (no idle threads), but it excluded
+    // every width that is super-block- but not 1024-aligned: Muse Glimmer is 6656 (ng=7, last
+    // group half-used) and 19968 (ng=20), so all of its attention and FFN weights fell back to
+    // the two-pass kernel, which decodes the whole row TWICE (once for amax, once to quantize)
+    // and costs more than the i8 GEMM that consumes it. A half-idle final group is far cheaper
+    // than a second decode pass. Still bit-identical to the two-pass kernel -- same decode, same
+    // amax (max is associative and exact in fp), same d = amax/127.f, same roundf(v * inv).
+    // SPARKINFER_DEQUANT_ROWS_I8_ANYCOL=0 restores the 1024-aligned-only gate.
+    static const int anycol = [] {
+        const char* e = getenv("SPARKINFER_DEQUANT_ROWS_I8_ANYCOL");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    // Only widths with at least one full group are admitted, so a row is never dominated by its
+    // partial tail. That deliberately leaves every sub-1024 width (Qwen3.6's MoE down is cols=512,
+    // which the gather/mask launchers already serve) on exactly the path it takes today.
+    const bool wide_ok = anycol && (cols % 256) == 0 && cols >= (DQR_BLOCK * DQR_VEC);
+    if (!enabled || rows <= 0 || cols <= 0 ||
+        ((cols % (DQR_BLOCK * DQR_VEC)) != 0 && !wide_ok)) return false;
 
     auto s = reinterpret_cast<const unsigned char*>(src);
     if (ggml_type == DQR_Q4_K) return dispatch<DQR_Q4_K>(s, q, scale, rows, cols, stream);


### PR DESCRIPTION
## Summary

The batched prefill converts every Q4_K/Q6_K weight row to int8 before the i8 GEMM, and
`launch_gguf_dequant_rows_i8_fast` admitted only 1024-aligned rows:

```cpp
if (!enabled || rows <= 0 || cols <= 0 || (cols % (DQR_BLOCK * DQR_VEC)) != 0) return false;
```

Muse Glimmer is **6656** wide (attn q/gate/k/v, ffn gate/up) and **19968** wide (ffn_down). Both
are super-block aligned but leave 512 modulo 1024, so every one of them missed the vector-store
kernel and fell back to the byte-store two-pass kernel in `dequant_gguf.cu`. Only `attn_output`
(4096) qualified. In an nsys graph-node trace of a 128-token prefill that made the conversion cost
**more than the GEMM it feeds**:

| ms | % of prefill | kernel |
|--:|--:|---|
| 57.79 | **54** | `deq_rows_i8_twopass<12>` (Q4_K -> int8) |
| 42.44 | 40 | `pf_gemm_i8_kernel` |
| 2.38 | 2 | `win_prefill_pure_bf16` |

It ran at ~640 GB/s where the same fast kernel reaches ~1350 GB/s on the one width it did accept.

The 1024 requirement was a throughput guard, not a correctness one — every group in the kernel is
already guarded by `base < cols`, and a thread's 4 values are 4-aligned so they always land inside
one super-block. All the kernel actually needs is `cols % 256 == 0` so `nsb = cols>>8` is exact.
Admit that, restricted to widths with **at least one full group** so a row is never dominated by
its partial tail; everything below 1024 keeps exactly the path it takes today.

`ffn_down` needed a second fix. At 19968 it wants `NG=20`, i.e. `v[20][4]` = 80 floats/thread, and
that register pressure cost more occupancy than the extra threads were worth — 776 GB/s against
1153 for the same-traffic `ffn_gate`/`up`. The block width is now a template parameter, so a
1024-thread block covers that row in `NG=5`. The value->thread mapping is unchanged, so it is
purely an occupancy trade.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (128-token decode, ctx=0):

| | decode tok/s |
|---|--:|
| before (main) | 102.93 |
| after (this PR) | 102.92 |

**Prefill pp tok/s** (Muse Glimmer 128-ctx prefill — the metric this PR targets):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 1122.06 |
| after prefill (this PR) | **1429.48** |

`+27.40%` prefill, decode flat. Both arms come from **one binary**, switched by
`SPARKINFER_DEQUANT_ROWS_I8_ANYCOL` (`=0` restores the 1024-aligned-only gate), and the pairs are
interleaved so clock drift cancels:

```text
rep1 off=1123.26 on=1430.41
rep2 off=1120.38 on=1431.05
rep3 off=1126.18 on=1427.13
rep4 off=1122.93 on=1435.60
rep5 off=1122.87 on=1428.47
rep6 off=1116.72 on=1424.22
             mean 1122.06 -> 1429.48   (+27.40%)

decode @128 ctx=0:  off=102.91/102.93   on=102.92/102.91

dequant total in an nsys graph-node trace: 60.1 ms -> 38.7 ms
```

## Correctness

**Bit-identical**, not merely equivalent: same `dqr_q4k_val`/`dqr_q6k_val` decode, same `amax` over
the same value set (max is associative and exact in fp, so a different thread->value map cannot
move it), same `d = amax/127.f`, same `inv` guarded on `d > 0`, same `roundf(v * inv)`. The
teacher-forced `qwen3_gguf_score` dump over 192 ids is byte-for-byte identical with the gate off
and on:

```text
cmp -s off.txt on.txt  ->  CMP:IDENTICAL   (197 positions)
ctest                  ->  100% tests passed, 13/13
```

## Scope

Qwen3.6 is untouched by construction and by measurement. Its quantized tensors are only
`cols` 512 and 2048, so none enters the newly admitted band — 512 is below the one-full-group
floor, 2048 was already 1024-aligned — and its widest row is `ng=2`, which never reaches the new
block-width branch. Measured anyway, `ANYCOL=0` vs `1`:

| ctx | decode | prefill |
|---|--:|--:|
| 512 | -0.05% | +0.11% |
| 4096 | -0.01% | +0.15% |
| 16384 | +0.04% | +0.24% |

At `BLK=256` the templated kernel is textually what was there before, so every other model and
every other launcher (pair/gather/mask) is unchanged.
