### PR TITLE
perf(muse-glimmer): one grouped GEMM for the q/gate/k/v prefill projections (1.14x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -55,6 +55,7 @@ namespace {
 
 enum { QMQ_Q4_K = 12, QMQ_Q5_K = 13 };
 
+constexpr int PF_QGROUP_MAX = 4;   // projections fusable into one grouped launch
 constexpr int QM_BM = 128;    // pair rows per tile (must match the caller's tilemap)
 constexpr int QM_BN = 64;     // weight rows (output channels) per block
 constexpr int QM_SB = 256;    // values per GGUF super-block == the B-stage K depth
@@ -469,17 +470,47 @@ void dispatch_qi8_bm16(const signed char* A_i8, const float* sx, const void* W_q
 // precomputed once at load (Qwen35LayerWeights::*_rs), so every int8 byte -- and thus the whole
 // accumulation -- matches the materialize path by construction. BM=128 so each weight row is
 // decoded once per M-tile: at prefill's M=128 that is exactly once (one M-tile).
-template <int QT>
-__global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel(
+// Grouped form: several projections sharing the activation (same Mtot, same K), fused into ONE
+// launch. At prefill's M=128 the grid is (ceil(N/QM_BN), 1), so a projection gets ceil(N/64) CTAs
+// -- 64 for a 4096-wide q or gate, but only 4 for a 256-wide k or v. All are far under a 5090's
+// 170 SMs, so each launch costs a full CTA-duration however little work it carries: k and v each
+// burn a whole wave for four CTAs. Muse Glimmer's q/gate/k/v all read the same xn and are
+// mutually independent, so co-scheduling their tiles in one grid turns four waves into one.
+// blockIdx.x becomes a global tile id resolved against the descriptor; every other line of the
+// kernel is untouched, so each output tile computes exactly what its own launch would have.
+struct PfQGroup {
+    const unsigned char* W[PF_QGROUP_MAX];
+    const float*         rs[PF_QGROUP_MAX];
+    __nv_bfloat16*       C[PF_QGROUP_MAX];
+    int                  N[PF_QGROUP_MAX];
+    int                  first[PF_QGROUP_MAX];   // prefix sum of each group's tile count
+    int                  ngroup;
+};
+
+template <int QT, bool GROUPED>
+__global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
         const signed char* __restrict__ A_i8, const float* __restrict__ sx,
-        const unsigned char* __restrict__ W_q, const float* __restrict__ row_scale,
-        __nv_bfloat16* __restrict__ C, int Mtot, int N, int K) {
+        const unsigned char* __restrict__ W_q_arg, const float* __restrict__ row_scale_arg,
+        __nv_bfloat16* __restrict__ C_arg, int Mtot, int N_arg, int K, PfQGroup gd) {
     using namespace nvcuda;
     constexpr int BS = qm_bs<QT>();
     const int p0 = blockIdx.y * QM_BM;
     const int M  = min(QM_BM, Mtot - p0);
     if (M <= 0) return;
-    const int n0  = blockIdx.x * QM_BN;
+    const unsigned char* W_q = W_q_arg;
+    const float* row_scale = row_scale_arg;
+    __nv_bfloat16* C = C_arg;
+    int N = N_arg;
+    int xtile = blockIdx.x;
+    if (GROUPED) {
+        int g = 0;
+        #pragma unroll
+        for (int i = 1; i < PF_QGROUP_MAX; i++)
+            if (i < gd.ngroup && (int)blockIdx.x >= gd.first[i]) g = i;
+        W_q = gd.W[g]; row_scale = gd.rs[g]; C = gd.C[g]; N = gd.N[g];
+        xtile = (int)blockIdx.x - gd.first[g];
+    }
+    const int n0  = xtile * QM_BN;
     const int nsb = K >> 8;
 
     __shared__ __align__(16) signed char Bs[QM_BN][QM_LD];
@@ -633,9 +664,39 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
     const auto* W = reinterpret_cast<const unsigned char*>(W_q);
     dim3 grid((N + QM_BN - 1) / QM_BN, (M + QM_BM - 1) / QM_BM);
     if (ggml_type == QMQ_Q4_K)
-        pf_dense_gemm_qi8_kernel<QMQ_Q4_K><<<grid, 256, 0, stream>>>(A_i8, sx, W, row_scale, C, M, N, K);
+        pf_dense_gemm_qi8_kernel_g<QMQ_Q4_K, false><<<grid, 256, 0, stream>>>(A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{});
     else
-        pf_dense_gemm_qi8_kernel<QMQ_Q5_K><<<grid, 256, 0, stream>>>(A_i8, sx, W, row_scale, C, M, N, K);
+        pf_dense_gemm_qi8_kernel_g<QMQ_Q5_K, false><<<grid, 256, 0, stream>>>(A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{});
+    return true;
+}
+
+// Same kernel, one launch for up to PF_QGROUP_MAX projections sharing A_i8/sx (same M, same K).
+// Each output tile runs the identical decode, accumulation order and scales its own launch would
+// have, so the result is bit-identical; only the scheduling changes.
+bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8, const float* sx,
+                                         const void* const* W_q, const float* const* row_scale,
+                                         void* const* C_bf16, const int* N, int ngroup,
+                                         int M, int K, cudaStream_t stream) {
+    if (!pfm_moe_gemm_qi8_supported(ggml_type)) return false;
+    if (ngroup <= 0 || ngroup > PF_QGROUP_MAX || M <= 0) return false;
+    if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;
+    PfQGroup d{};
+    d.ngroup = ngroup;
+    int tiles = 0;
+    for (int i = 0; i < ngroup; i++) {
+        if (!row_scale[i] || N[i] <= 0 || (N[i] % QM_BN) != 0) return false;
+        d.W[i]  = reinterpret_cast<const unsigned char*>(W_q[i]);
+        d.rs[i] = row_scale[i];
+        d.C[i]  = reinterpret_cast<__nv_bfloat16*>(C_bf16[i]);
+        d.N[i]  = N[i];
+        d.first[i] = tiles;
+        tiles += N[i] / QM_BN;
+    }
+    dim3 grid(tiles, (M + QM_BM - 1) / QM_BM);
+    if (ggml_type == QMQ_Q4_K)
+        pf_dense_gemm_qi8_kernel_g<QMQ_Q4_K, true><<<grid, 256, 0, stream>>>(A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d);
+    else
+        pf_dense_gemm_qi8_kernel_g<QMQ_Q5_K, true><<<grid, 256, 0, stream>>>(A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d);
     return true;
 }
 

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -46,5 +46,15 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
                                    const void* W_q, const float* row_scale, void* C_bf16,
                                    int M, int N, int K, cudaStream_t stream = nullptr);
 
+// Fuse up to 4 projections sharing A_i8/sx (same M, same K) into ONE grid. At prefill's M=128 a
+// projection's grid is ceil(N/64) CTAs -- 64 for a 4096-wide q/gate but only 4 for a 256-wide
+// k/v -- all far under a 5090's 170 SMs, so every launch costs a full CTA-duration regardless of
+// how little work it carries. Bit-identical per output tile to the separate calls.
+// W_q/row_scale/C_bf16/N are ngroup-long arrays; all groups must share ggml_type.
+bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8, const float* sx,
+                                         const void* const* W_q, const float* const* row_scale,
+                                         void* const* C_bf16, const int* N, int ngroup,
+                                         int M, int K, cudaStream_t stream = nullptr);
+
 } // namespace kernels
 } // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -579,6 +579,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         const char* e = getenv("SPARKINFER_MUSE_PREFILL_QB");
         return !(e && e[0] == '0');
     }();
+    const bool muse_group = c.muse_glimmer &&
+        [] { const char* e = getenv("SPARKINFER_MUSE_PREFILL_GROUP"); return !(e && e[0] == '0'); }();
     auto proj_fused = [&](const bf16* A, const void* W, int wtype, const float* rs,
                           bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;
@@ -672,10 +674,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // goes straight to qb and the gate straight to qg, with no [q|gate] interleave to build
                 // and no split to undo (matches decode's sep_gate path, qwen35.cpp:988-1007). Projecting
                 // w.wq as `wide` (2*qdim) would dequant-read qdim rows PAST the 4096-row wq tensor.
+                // q/gate/k/v all read xn and are mutually independent. At M=128 each of them is
+                // ceil(n_out/64) CTAs of a 170-SM machine -- 64, 64, 4, 4 -- so as four launches
+                // they cost four full CTA-durations, two of which carry four CTAs of work. One
+                // grid for all four collapses that to one. Bit-identical per output tile.
+                // SPARKINFER_MUSE_PREFILL_GROUP=0 restores the four separate launches.
+                bool grouped = false;
+                if (muse_group && muse_qb && use_i8 &&
+                    w.wq_rs && w.wgate_rs && w.wk_rs && w.wv_rs &&
+                    w.wq_type == w.wgate_type && w.wq_type == w.wk_type && w.wq_type == w.wv_type &&
+                    kernels::pfm_moe_gemm_qi8_supported(w.wq_type)) {
+                    const void* Wp[4]  = { w.wq, w.wgate, w.wk, w.wv };
+                    const float* rsp[4] = { w.wq_rs, w.wgate_rs, w.wk_rs, w.wv_rs };
+                    void* Cp[4]        = { qb, qg, kf, vf };
+                    const int nout[4]  = { qdim, qdim, kvdim, kvdim };
+                    quant_a_i8(xn, N, H);
+                    grouped = kernels::launch_prefill_gemm_qi8_dense_group(
+                        w.wq_type, A_i8, sx, Wp, rsp, Cp, nout, 4, N, H, st);
+                }
+                if (!grouped) {
                 proj_fused(xn, w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  H);
                 proj_fused(xn, w.wgate, w.wgate_type, w.wgate_rs, qg, qdim,  H);
                 proj_fused(xn, w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, H);
                 proj_fused(xn, w.wv,    w.wv_type,    w.wv_rs,    vf, kvdim, H);
+                }
             } else {
                 proj(xn, w.wq, w.wq_type, b8, wide,  H);             // qraw = [q|gate] per head
                 proj(xn, w.wk, w.wk_type, kf, kvdim, H);


### PR DESCRIPTION
## Summary

The fused Q4_K-direct prefill GEMM from #793 launches with grid `(ceil(N/QM_BN), ceil(M/QM_BM))`.
At prefill's M=128 that is a **single tile row**, so a projection gets `ceil(n_out/64)` CTAs:
**64** for a 4096-wide q or gate, but only **4** for a 256-wide k or v. Every one of those is far
below a 5090's 170 SMs, so each launch costs a full CTA-duration however little work it carries —
k and v each burn a whole wave for four CTAs, a large share of the projection time for 0.35% of
the FLOPs.

Muse Glimmer's q/gate/k/v all read the same `xn` and are mutually independent, so their tiles can
share one grid. `blockIdx.x` becomes a global tile id resolved against a 4-entry descriptor; every
other line of the kernel is untouched, so each output tile runs the same decode, the same
accumulation order and the same scales as its own launch would have. Four waves become one.

**Bit-identical, not merely close:** teacher-forced TOP1 16/16 and KL 0.05244 are unchanged to
five decimals with the grouping on and off. This is a scheduling change only — no split-K, no
cross-tile reduction, no reassociation.

Stacks on #793 and #795 rather than competing with either. #793 removed the int8 materialize ahead
of the GEMM; this fixes how the GEMM that consumes it is *scheduled*. #795's split-K unstarves the
skinny projections on the **int8 materialize** path (`launch_prefill_gemm_i8_splitk`), but Muse's
q/gate/k/v go through `proj_fused` → `launch_prefill_gemm_qi8_dense` and never reach it — measured
additive on top of both.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (untouched — the grouping lives inside `prefill_batched_run`):

| | decode tok/s |
|---|--:|
| before (main) | 100.65 |
| after (this PR) | 100.63 |

**Prefill pp tok/s** (Muse Glimmer, 128-ctx):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 1748.19 |
| after prefill (this PR) | 2001.13 |

```text
# RTX 5090, clocks locked 2550, official 17 GB Muse Glimmer GGUF, main = ebfda4e (incl. #793, #795)
# five samples per arm, medians in the tables above

main       prefill pp : 1743.93 1747.73 1748.19 1749.96 1751.41   median 1748.19
this PR    prefill pp : 2001.13 1990.82 2004.19 2005.05 1995.18   median 2001.13
                                                                   +14.47%

decode tg @ ctx=0     main 100.65    this PR 100.63

correctness vs the token loop (qwen3_gguf_prefill_check, bf16 KV, 16 positions)
  grouping OFF   TOP1 16/16 1.0000   KL 0.05244
  grouping ON    TOP1 16/16 1.0000   KL 0.05244      <- bit-identical

ctest: 100% tests passed, 0 tests failed out of 13
```

`SPARKINFER_MUSE_PREFILL_GROUP=0` restores the four separate launches.
