### PR TITLE
perf(muse-glimmer): fused Q4_K-direct dense prefill GEMM — skip the int8 materialize (1.22x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -458,6 +458,131 @@ void dispatch_qi8_bm16(const signed char* A_i8, const float* sx, const void* W_q
             A_i8, sx, W, row_scale, pair_tok, pair_w, offsets, tilemap, d_ntiles, C, out_f32, n_out, K);
 }
 
+// ---------------------------------------------------------------------------
+// Dense (non-routed) fused-decode int8 GEMM: C[M,N] = A_i8[M,K] @ dequant(W_q[N,K])^T.
+// The same qm_decode_j64 B-stage + int8 WMMA as pfm_moe_gemm_qi8_kernel, with the expert /
+// pair-routing indirection stripped away: one dense weight [N,K], M contiguous activation rows,
+// C written directly (no gather, no scatter). Muse Glimmer's dense prefill uses this to consume
+// its native Q4_K/Q5_K attn + FFN gate/up weights straight from VRAM, skipping the per-layer int8
+// materialize (dequant -> write W_i8 -> read W_i8 back in the GEMM) that launch_prefill_gemm_i8
+// pays. The per-output-row scale is the one launch_gguf_dequant_rows_i8 itself produced,
+// precomputed once at load (Qwen35LayerWeights::*_rs), so every int8 byte -- and thus the whole
+// accumulation -- matches the materialize path by construction. BM=128 so each weight row is
+// decoded once per M-tile: at prefill's M=128 that is exactly once (one M-tile).
+template <int QT>
+__global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel(
+        const signed char* __restrict__ A_i8, const float* __restrict__ sx,
+        const unsigned char* __restrict__ W_q, const float* __restrict__ row_scale,
+        __nv_bfloat16* __restrict__ C, int Mtot, int N, int K) {
+    using namespace nvcuda;
+    constexpr int BS = qm_bs<QT>();
+    const int p0 = blockIdx.y * QM_BM;
+    const int M  = min(QM_BM, Mtot - p0);
+    if (M <= 0) return;
+    const int n0  = blockIdx.x * QM_BN;
+    const int nsb = K >> 8;
+
+    __shared__ __align__(16) signed char Bs[QM_BN][QM_LD];
+    __shared__ __align__(16) signed char As[2][QM_BM][QM_BK];
+    __shared__ int s_tok[QM_BM];
+
+    const int tid = threadIdx.x;
+    const int warp = tid >> 5, lane = tid & 31;
+    const int wm = warp & 3, wn = warp >> 2;
+
+    // Direct activation rows (no pair_tok gather): row r of this M-tile is global token p0 + r.
+    for (int r = tid; r < QM_BM; r += blockDim.x)
+        s_tok[r] = (r < M) ? (p0 + r) : -1;
+
+    // Decode assignment: 4 threads per weight row, one 64-value sub-block pair (j64) each.
+    const int dr = tid >> 2, dj = tid & 3;
+    const int dgn = n0 + dr;
+    const bool drow_ok = dgn < N;
+    const unsigned char* drow = W_q + (size_t)(drow_ok ? dgn : 0) * (size_t)nsb * BS;
+    const float dscale = drow_ok ? row_scale[dgn] : 0.f;
+    const float dinv = (dscale > 0.f) ? (1.f / dscale) : 0.f;
+
+    wmma::fragment<wmma::accumulator, 16, 16, 16, int> cf[2][2];
+#pragma unroll
+    for (int i = 0; i < 2; i++)
+#pragma unroll
+        for (int j = 0; j < 2; j++) wmma::fill_fragment(cf[i][j], 0);
+
+    auto stageA = [&](int buf, int k0) {
+        for (int idx = tid; idx < QM_BM * 2; idx += blockDim.x) {
+            const int r = idx >> 1, c16 = (idx & 1) * 16;
+            const int arow = s_tok[r];
+            qm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + k0 + c16],
+                    arow >= 0 && (k0 + c16) < K);
+        }
+        __pipeline_commit();
+    };
+
+    __syncthreads();          // s_tok published before stageA reads it
+    stageA(0, 0);
+    int abuf = 0;
+
+    for (int sb = 0; sb < nsb; sb++) {
+        __syncthreads();      // previous super-block's MMA finished reading Bs
+        if (drow_ok) {
+            const unsigned char* blk = drow + (size_t)sb * BS;
+            qm_decode_j64<QT>(blk, dj, dinv, &Bs[dr][0]);
+        } else if (dj == 0) {
+#pragma unroll
+            for (int i = 0; i < QM_SB / 16; i++)
+                *reinterpret_cast<uint4*>(&Bs[dr][i * 16]) = make_uint4(0u, 0u, 0u, 0u);
+        }
+        __syncthreads();      // Bs ready
+
+        for (int kk = 0; kk < QM_SB; kk += QM_BK) {
+            const int knext = sb * QM_SB + kk + QM_BK;
+            if (knext < K) stageA(abuf ^ 1, knext);
+            __pipeline_wait_prior(knext < K ? 1 : 0);
+            __syncthreads();
+#pragma unroll
+            for (int k16 = 0; k16 < QM_BK; k16 += 16) {
+                wmma::fragment<wmma::matrix_a, 16, 16, 16, signed char, wmma::row_major> af[2];
+                wmma::fragment<wmma::matrix_b, 16, 16, 16, signed char, wmma::col_major> bf[2];
+#pragma unroll
+                for (int i = 0; i < 2; i++)
+                    wmma::load_matrix_sync(af[i], &As[abuf][wm * 32 + i * 16][k16], QM_BK);
+#pragma unroll
+                for (int j = 0; j < 2; j++)
+                    wmma::load_matrix_sync(bf[j], &Bs[wn * 32 + j * 16][kk + k16], QM_LD);
+#pragma unroll
+                for (int i = 0; i < 2; i++)
+#pragma unroll
+                    for (int j = 0; j < 2; j++) wmma::mma_sync(cf[i][j], af[i], bf[j], cf[i][j]);
+            }
+            __syncthreads();
+            abuf ^= 1;
+        }
+    }
+
+    // Epilogue staging reuses Bs (the K loop is done with it).
+    __syncthreads();
+    int* Cs = reinterpret_cast<int*>(&Bs[0][0]);
+#pragma unroll
+    for (int i = 0; i < 2; i++) {
+#pragma unroll
+        for (int j = 0; j < 2; j++) {
+            const int rm0 = wm * 32 + i * 16, gn0 = n0 + wn * 32 + j * 16;
+            wmma::store_matrix_sync(&Cs[warp * 256], cf[i][j], 16, wmma::mem_row_major);
+            __syncwarp();
+            for (int el = lane; el < 256; el += 32) {
+                const int r = el >> 4, cc = el & 15;
+                const int rm = rm0 + r, rn = gn0 + cc;
+                if (rm < M && rn < N) {
+                    const int p = p0 + rm;
+                    const float v = (float)Cs[warp * 256 + el] * sx[p] * row_scale[rn];
+                    C[(size_t)p * N + rn] = __float2bfloat16(v);
+                }
+            }
+            __syncwarp();
+        }
+    }
+}
+
 } // namespace
 
 bool pfm_moe_gemm_qi8_supported(int ggml_type) {
@@ -493,6 +618,24 @@ bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float
     else
         dispatch_qi8<QMQ_Q5_K>(A_i8, sx, W_q, row_scale, pair_tok, pair_w, offsets, tilemap,
                                d_ntiles, C, out_f32, n_out, K, max_tiles, a_indirect, c_scatter, stream);
+    return true;
+}
+
+// Dense fused-decode int8 GEMM (single weight, no routing). See pf_dense_gemm_qi8_kernel.
+bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
+                                   const void* W_q, const float* row_scale, void* C_bf16,
+                                   int M, int N, int K, cudaStream_t stream) {
+    if (!pfm_moe_gemm_qi8_supported(ggml_type)) return false;   // Q4_K / Q5_K only
+    if (!row_scale || M <= 0) return false;
+    if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;         // whole super-blocks only
+    if (N <= 0 || (N % QM_BN) != 0) return false;               // 64-aligned output width
+    auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
+    const auto* W = reinterpret_cast<const unsigned char*>(W_q);
+    dim3 grid((N + QM_BN - 1) / QM_BN, (M + QM_BM - 1) / QM_BM);
+    if (ggml_type == QMQ_Q4_K)
+        pf_dense_gemm_qi8_kernel<QMQ_Q4_K><<<grid, 256, 0, stream>>>(A_i8, sx, W, row_scale, C, M, N, K);
+    else
+        pf_dense_gemm_qi8_kernel<QMQ_Q5_K><<<grid, 256, 0, stream>>>(A_i8, sx, W, row_scale, C, M, N, K);
     return true;
 }
 

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -36,5 +36,15 @@ bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float
 // True when launch_pfm_moe_gemm_qi8 has a decode for this ggml_type.
 bool pfm_moe_gemm_qi8_supported(int ggml_type);
 
+// Dense (non-routed) fused-decode int8 GEMM: C[M,N] = A_i8[M,K] @ dequant(W_q[N,K])^T, reading the
+// weight in native Q4_K/Q5_K and decoding it to int8 inside the B-stage using a per-output-row
+// scale precomputed at load (row_scale[n] = amax/127, == launch_gguf_dequant_rows_i8's scale). Skips
+// the int8 materialize (dequant -> W_i8 -> reload) that launch_prefill_gemm_i8 pays. Returns false
+// (launching nothing) for an unsupported ggml_type, null row_scale, K not a super-block multiple, or
+// N not 64-aligned -- callers fall back to the materialize path. Used by Muse Glimmer dense prefill.
+bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
+                                   const void* W_q, const float* row_scale, void* C_bf16,
+                                   int M, int N, int K, cudaStream_t stream = nullptr);
+
 } // namespace kernels
 } // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -81,6 +81,15 @@ struct Qwen35LayerWeights {
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;
     int wqkv_type = 0, wqkv_gate_type = 0, ssm_beta_type = 0, ssm_alpha_type = 0, ssm_out_type = 0;
     int shared_gate_inp_type = 0;
+
+    // Muse Glimmer fused prefill: per-output-row int8 scales (amax/127) of the native Q4_K/Q5_K
+    // attn + FFN gate/up weights, precomputed once at load. Let the batched prefill GEMM decode the
+    // weight to int8 in-register (launch_prefill_gemm_qi8_dense) instead of materializing the whole
+    // int8 weight first. Null => that weight stays on the materialize path (e.g. Q6_K down, or when
+    // the precompute is disabled/unavailable). Owned by the model Impl, not freed per-layer.
+    const float* wq_rs = nullptr; const float* wgate_rs = nullptr;
+    const float* wk_rs = nullptr; const float* wv_rs = nullptr; const float* wo_rs = nullptr;
+    const float* gate_rs = nullptr; const float* up_rs = nullptr;
 };
 
 struct Qwen35Weights {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -190,6 +190,9 @@ struct Qwen35Model::Impl {
     // EAGERLY here at load, never lazily -- the scored sweep times each context exactly once
     // (512 first), so a lazy fill would land inside the very pass it is meant to speed up.
     float *moe_rs_gate = nullptr, *moe_rs_up = nullptr, *moe_rs_down = nullptr;
+    // Muse Glimmer dense prefill: one pool of per-output-row int8 scales for the native Q4_K/Q5_K
+    // attn + FFN gate/up weights (Qwen35LayerWeights::*_rs point into it). See load().
+    float *muse_rs = nullptr;
     // flash-decoding (KV-split) attention partials
     static constexpr int MAX_NSPLITS = 256;   // partials sized for this; adaptive n_splits <= this
     int n_splits = 32;
@@ -474,6 +477,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->sx_h); cudaFree(p_->sx_q8);
     cudaFree(p_->mf_ids); cudaFree(p_->mf_counts); cudaFree(p_->mf_rc);
     cudaFree(p_->moe_rs_gate); cudaFree(p_->moe_rs_up); cudaFree(p_->moe_rs_down);
+    cudaFree(p_->muse_rs);
     cudaFree(p_->fa_m); cudaFree(p_->fa_l); cudaFree(p_->fa_acc);
     cudaFree(p_->sparse_sel);
     cudaFree(p_->sparse_vtbl); cudaFree(p_->sparse_vlen);
@@ -3507,6 +3511,74 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             } else {
                 fprintf(stderr, "[prefill-moe] expert int8 row scales ready (%.0f MB)\n",
                         (double)((2 * ng + nd) * sizeof(float)) / (1024.0 * 1024.0));
+            }
+        }
+    }
+    // ---- Muse Glimmer: eager per-row int8 scales for the fused quantized-B dense prefill GEMM ----
+    // Muse's dense attn (wq/wgate/wk/wv/wo) and FFN gate/up ship as Q4_K. The batched prefill can
+    // decode them to int8 inside the GEMM's B-stage (prefill_moe_q.cu's dense path) rather than
+    // materializing the whole int8 weight per layer (dequant -> write W_i8 -> read W_i8 back). That
+    // needs the per-output-row int8 scale -- amax over the FULL row -- which is computed here with
+    // the SAME kernel the materialize path uses (launch_gguf_dequant_rows_i8, keeping only its
+    // `scale`), so the fused GEMM's int8 bytes match the materialize path's by construction, not by
+    // re-deriving the scale. Q6_K down (and any non-Q4/Q5 attn weight) is left null -> stays on the
+    // materialize path. ~11 MB for Muse-30B. SPARKINFER_MUSE_PREFILL_QB=0 skips the precompute.
+    if (c.muse_glimmer) {
+        const char* qb_env = getenv("SPARKINFER_MUSE_PREFILL_QB");
+        if (!qb_env || qb_env[0] != '0') {
+            auto fusable = [](int t) { return t == 12 || t == 13; };   // Q4_K / Q5_K
+            const int qd = c.n_q_heads * c.head_dim;                   // qdim (4096)
+            const int kd = c.n_kv_heads * c.head_dim;                  // kvdim (256)
+            const int ff = c.moe_ffn;                                  // dense FFN width (19968)
+            const size_t per_layer = (size_t)(2 * qd + 2 * kd + H + 2 * ff);  // rows/layer, all fusable
+            const size_t total = per_layer * (size_t)c.n_layers;
+            const size_t tmp_bytes = 64u << 20;                        // int8 scratch, thrown away
+            signed char* tmp = nullptr;
+            bool ok = cudaMalloc(&s.muse_rs, total * sizeof(float)) == cudaSuccess;
+            ok = ok && cudaMalloc(&tmp, tmp_bytes) == cudaSuccess;
+            auto fill = [&](int qtype, const void* src, float* dst, size_t rows, int cols) -> bool {
+                const int blk = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
+                const size_t rb = (size_t)(cols >> 8) * (size_t)blk;   // bytes per quantized row
+                const size_t chunk = tmp_bytes / (size_t)cols;        // rows/chunk fitting tmp
+                for (size_t r0 = 0; r0 < rows; r0 += chunk) {
+                    const size_t nr = (rows - r0 < chunk) ? (rows - r0) : chunk;
+                    if (!kernels::launch_gguf_dequant_rows_i8(
+                            qtype, (const char*)src + r0 * rb, tmp, dst + r0, (int)nr, cols, s.stream))
+                        return false;
+                }
+                return true;
+            };
+            for (int i = 0; ok && i < c.n_layers; i++) {
+                Qwen35LayerWeights& lw = s.w.layers[i];
+                float* base = s.muse_rs + (size_t)i * per_layer;
+                size_t off = 0;
+                // Compute a weight's row scales into the pool and publish its *_rs pointer; the pool
+                // slot is reserved for every weight (fixed layout) but filled only when fusable.
+                auto place = [&](const void* W, int wt, const float** rs, int rows, int cols) {
+                    float* dst = base + off; off += (size_t)rows;
+                    if (ok && W && fusable(wt) && fill(wt, W, dst, (size_t)rows, cols)) *rs = dst;
+                };
+                place(lw.wq,     lw.wq_type,     &lw.wq_rs,    qd, H);
+                place(lw.wgate,  lw.wgate_type,  &lw.wgate_rs, qd, H);
+                place(lw.wk,     lw.wk_type,     &lw.wk_rs,    kd, H);
+                place(lw.wv,     lw.wv_type,     &lw.wv_rs,    kd, H);
+                place(lw.wo,     lw.wo_type,     &lw.wo_rs,    H,  qd);
+                place(lw.gate_q, lw.gate_qtype,  &lw.gate_rs,  ff, H);
+                place(lw.up_q,   lw.up_qtype,    &lw.up_rs,    ff, H);
+            }
+            if (ok) ok = cudaStreamSynchronize(s.stream) == cudaSuccess;
+            if (tmp) cudaFree(tmp);
+            if (!ok) {
+                cudaFree(s.muse_rs); s.muse_rs = nullptr;
+                for (int i = 0; i < c.n_layers; i++) {
+                    Qwen35LayerWeights& lw = s.w.layers[i];
+                    lw.wq_rs = lw.wgate_rs = lw.wk_rs = lw.wv_rs = lw.wo_rs = lw.gate_rs = lw.up_rs = nullptr;
+                }
+                fprintf(stderr, "[prefill-muse] dense row-scale precompute unavailable "
+                                "-> int8 materialize path\n");
+            } else {
+                fprintf(stderr, "[prefill-muse] dense int8 row scales ready (%.0f MB)\n",
+                        (double)(total * sizeof(float)) / (1024.0 * 1024.0));
             }
         }
     }

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -520,6 +520,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         return true;
     };
 
+    // Muse Glimmer fused quantized-B projection: decode the native Q4_K/Q5_K weight to int8 INSIDE
+    // the GEMM (launch_prefill_gemm_qi8_dense) using the per-row scale precomputed at load (w.*_rs),
+    // skipping the int8 materialize (dequant -> W_i8 -> reload) that proj()'s int8 path pays -- the
+    // dominant weight-bandwidth cost at prefill's M=128, where the GEMM tile is compute-bound and the
+    // materialize round-trip is pure overhead. Bit-identical to proj(): same activation int8 (shared
+    // quant_a_i8 memo), same weight decode + per-row scale + int8 bytes, same int8 tensor-core
+    // accumulation. Falls back to proj() when the scale is absent (Q6_K down, precompute off) or the
+    // weight type/shape is unsupported. Reaches ONLY Muse (c.muse_glimmer); every other model's proj()
+    // calls are untouched. SPARKINFER_MUSE_PREFILL_QB=0 forces the materialize path (A/B).
+    const bool muse_qb = c.muse_glimmer && [] {
+        const char* e = getenv("SPARKINFER_MUSE_PREFILL_QB");
+        return !(e && e[0] == '0');
+    }();
+    auto proj_fused = [&](const bf16* A, const void* W, int wtype, const float* rs,
+                          bf16* C, int n_out, int K, int rows = 0) {
+        const int R = rows > 0 ? rows : N;
+        if (muse_qb && use_i8 && rs && n_out >= 128 && kernels::pfm_moe_gemm_qi8_supported(wtype)) {
+            quant_a_i8(A, R, K);
+            if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st))
+                return;
+        }
+        proj(A, W, wtype, C, n_out, K, rows);
+    };
+
     // GDN wqkv + wqkv_gate both project the same input xn, so on the fp8 path quantize xn to e4m3
     // ONCE and share it across both GEMMs (proj() would otherwise re-quantize xn per projection --
     // a full redundant read of xn and rewrite of the e4m3 activation each layer). Bit-identical to
@@ -602,10 +626,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // goes straight to qb and the gate straight to qg, with no [q|gate] interleave to build
                 // and no split to undo (matches decode's sep_gate path, qwen35.cpp:988-1007). Projecting
                 // w.wq as `wide` (2*qdim) would dequant-read qdim rows PAST the 4096-row wq tensor.
-                proj(xn, w.wq,    w.wq_type,    qb, qdim,  H);
-                proj(xn, w.wgate, w.wgate_type, qg, qdim,  H);
-                proj(xn, w.wk,    w.wk_type,    kf, kvdim, H);
-                proj(xn, w.wv,    w.wv_type,    vf, kvdim, H);
+                proj_fused(xn, w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  H);
+                proj_fused(xn, w.wgate, w.wgate_type, w.wgate_rs, qg, qdim,  H);
+                proj_fused(xn, w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, H);
+                proj_fused(xn, w.wv,    w.wv_type,    w.wv_rs,    vf, kvdim, H);
             } else {
                 proj(xn, w.wq, w.wq_type, b8, wide,  H);             // qraw = [q|gate] per head
                 proj(xn, w.wk, w.wk_type, kf, kvdim, H);
@@ -643,7 +667,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
                 // add happens in launch_norm_then_add below.
-                proj(att, w.wo, w.wo_type, ao, H, qdim);
+                proj_fused(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim);
                 attn_fused = false;
             } else {
                 attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
@@ -707,8 +731,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         kernels::launch_prefill_gemm_i8(A_i8, ffn_Wd_i8, sx, ffn_swd,
                                                         ao + (size_t)fo * H, fn, H, ffn, st);
                 } else {
-                    proj(hn_c, w.gate_q, w.gate_qtype, ffg, ffn, H, fn);
-                    proj(hn_c, w.up_q,   w.up_qtype,   ffu, ffn, H, fn);
+                    proj_fused(hn_c, w.gate_q, w.gate_qtype, w.gate_rs, ffg, ffn, H, fn);
+                    proj_fused(hn_c, w.up_q,   w.up_qtype,   w.up_rs,   ffu, ffn, H, fn);
                     if (use_i8) {
                         // Same fused SwiGLU + per-row int8 quantize the long-ctx ffn_i8 branch
                         // runs (bit-identical to swiglu-then-quantize; both bf16-round first) --


### PR DESCRIPTION
## Summary

Fused **Q4_K-direct** dense prefill GEMM for Muse Glimmer — moves `prefill@128` by decoding each
native Q4_K weight to int8 **inside** the GEMM's B-stage, so the per-layer int8 *materialize*
(dequant → write `W_i8` → read `W_i8` back) never happens. At prefill's M=128 that materialize
round-trip is the dominant weight-bandwidth cost and pure overhead — the 128×128 GEMM tile is
compute-bound whatever M is — so removing it is the win. This **composes with** #790 (which speeds
up the *materialize's* dequant): the Q4_K attn + FFN gate/up weights skip the materialize entirely
here, while the Q6_K `ffn_down` this PR still materializes rides #790's faster dequant.

The mechanism already exists in-tree for the **routed MoE** path (`pfm_moe_gemm_qi8_kernel`,
`prefill_moe_q.cu`, fed by the eager `moe_rs_*` scales); this PR brings it to the **dense** path
(Muse's attn q/gate/k/v/o + FFN gate/up, all Q4_K) which had no equivalent and still materialized.
`pf_dense_gemm_qi8_kernel` strips the expert/pair routing from that kernel and reuses its
`qm_decode_j64` B-stage verbatim. The per-output-row int8 scale is precomputed once at load with the
**same** kernel the materialize path uses (`launch_gguf_dequant_rows_i8`, keeping only its `scale`),
so the fused GEMM emits the identical int8 bytes — and, int32 accumulation being order-independent,
the identical result — by construction.

**Default on**; `SPARKINFER_MUSE_PREFILL_QB=0` restores the materialize path (A/B). Reaches **only**
Muse Glimmer (`c.muse_glimmer`); every other model's `proj()` is byte-for-byte unchanged, and decode
is untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (Muse Glimmer `prefill@128`, `qwen3_gguf_bench <gguf> 8 128`, RTX 5090, medians of 5):

| | prefill pp tok/s |
|---|--:|
| before prefill (main, incl. #790) | 1263.6 |
| after prefill (this PR, fused Q4_K) | 1540.5 |

**+22.0% (1.22×)** at the scored context, on top of the already-merged #790 dequant-width path.

**Decode tok/s** (Muse Glimmer, ctx=0 — unchanged; this PR targets prefill only):

| | decode tok/s |
|---|--:|
| before (main) | 100.71 |
| after (this PR) | 100.71 |

```text
# qwen3_gguf_bench muse-glimmer-30B-kquant-17gb.gguf 8 128   (RTX 5090, sm_120, on current main b13d69e)
main (incl #790, materialize) : prefill pp : 1263.6 1259.9 1264.7 1262.3 1264.9  (median 1263.6)
this PR (fused, default)      : prefill pp : 1540.0 1537.9 1547.0 1540.5 1546.4  (median 1540.5)
# SPARKINFER_MUSE_PREFILL_QB=0 reproduces the main number; decode tg ctx=0 unchanged 100.71 -> 100.71
```

## Correctness

Fused (`SPARKINFER_MUSE_PREFILL_QB=1`, default) vs materialize (`=0`), `qwen3_gguf_prefill_check`
(batched vs the validated token-loop), bf16 KV — **identical at every context**:

| ctx | materialize (QB=0) — TOP1 / KL | fused (QB=1) — TOP1 / KL |
|---|--:|--:|
| 128  | 16/16 / 0.05244 | 16/16 / 0.05244 |
| 512  | 16/16 / 0.00987 | 16/16 / 0.00987 |
| 3072 (SWA window clips) | 15/16 / 0.00755 | 15/16 / 0.00755 |

Bit-for-bit equal to the materialize path — the fused decode uses the same per-row scale and int8
bytes, and int32 tensor-core accumulation is order-independent. `compute-sanitizer memcheck`:
**0 errors**. `ctest`: **13/13 passed**. Qwen3.6 / Qwythos: the change is gated behind
`c.muse_glimmer`, so their `proj()` path is unchanged (no-regression guard unaffected).
