### PR TITLE
perf(muse-glimmer): split-K the fused Q4_K prefill GEMM, and fuse the Q4_K ffn_down (1.29x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -45,6 +45,7 @@
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
+#include <cstdlib>
 #include <cuda_pipeline.h>
 #include <mma.h>
 
@@ -56,6 +57,10 @@ namespace {
 enum { QMQ_Q4_K = 12, QMQ_Q5_K = 13 };
 
 constexpr int PF_QGROUP_MAX = 4;   // projections fusable into one grouped launch
+// Block-slot budget the split-K fan-out aims at: ~3 passes over a 5090's 170 SMs x 3 blocks/SM.
+// Measured: aiming at ONE pass picks 2 splits for the 312-tile FFN and loses to 4 (2211 vs 2550
+// pp) -- oversubscribing hides latency and shortens the tail. A target, never a cap.
+constexpr int QM_TARGET_BLOCKS = 1536;
 constexpr int QM_BM = 128;    // pair rows per tile (must match the caller's tilemap)
 constexpr int QM_BN = 64;     // weight rows (output channels) per block
 constexpr int QM_SB = 256;    // values per GGUF super-block == the B-stage K depth
@@ -487,11 +492,23 @@ struct PfQGroup {
     int                  ngroup;
 };
 
-template <int QT, bool GROUPED>
+// SPLIT=true: blockIdx.z owns a slice of the K super-blocks and writes its raw int32 tile to
+// `partials`; pf_dense_splitk_reduce_kernel sums the slices and applies sx*row_scale once. int32
+// accumulation is exact and associative, so the summed value is BIT-IDENTICAL to the unsplit
+// kernel -- only the block count changes.
+//
+// At prefill's M=128 grid.y collapses to 1, leaving a grid of just N/QM_BN blocks: 104 for the
+// 6656-wide o/down, 312 for the 19968-wide FFN pair, against ~510 block slots on a 5090. ncu on
+// the unsplit kernel: 0.13 waves/SM, 16.7% achieved occupancy, DRAM 6.0%, SM throughput 13.1% --
+// the kernel is neither bandwidth- nor compute-bound, it simply is not on the machine.
+// Only the UNGROUPED form splits: a grouped launch resolves a different N/C per output tile, so
+// its partials would need a per-group offset table, and it is the smallest of the five launches.
+template <int QT, bool GROUPED, bool SPLIT = false>
 __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
         const signed char* __restrict__ A_i8, const float* __restrict__ sx,
         const unsigned char* __restrict__ W_q_arg, const float* __restrict__ row_scale_arg,
-        __nv_bfloat16* __restrict__ C_arg, int Mtot, int N_arg, int K, PfQGroup gd) {
+        __nv_bfloat16* __restrict__ C_arg, int Mtot, int N_arg, int K, PfQGroup gd,
+        int* __restrict__ partials = nullptr, int sb_per_split = 0) {
     using namespace nvcuda;
     constexpr int BS = qm_bs<QT>();
     const int p0 = blockIdx.y * QM_BM;
@@ -550,10 +567,14 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
     };
 
     __syncthreads();          // s_tok published before stageA reads it
-    stageA(0, 0);
+    const int sb_lo = SPLIT ? (int)blockIdx.z * sb_per_split : 0;
+    const int sb_hi = SPLIT ? min(nsb, sb_lo + sb_per_split) : nsb;
+    if (sb_lo >= sb_hi) return;
+    const int kend = sb_hi << 8;          // first K past this block's slice
+    stageA(0, sb_lo << 8);
     int abuf = 0;
 
-    for (int sb = 0; sb < nsb; sb++) {
+    for (int sb = sb_lo; sb < sb_hi; sb++) {
         __syncthreads();      // previous super-block's MMA finished reading Bs
         if (drow_ok) {
             const unsigned char* blk = drow + (size_t)sb * BS;
@@ -567,8 +588,8 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
 
         for (int kk = 0; kk < QM_SB; kk += QM_BK) {
             const int knext = sb * QM_SB + kk + QM_BK;
-            if (knext < K) stageA(abuf ^ 1, knext);
-            __pipeline_wait_prior(knext < K ? 1 : 0);
+            if (knext < kend) stageA(abuf ^ 1, knext);
+            __pipeline_wait_prior(knext < kend ? 1 : 0);
             __syncthreads();
 #pragma unroll
             for (int k16 = 0; k16 < QM_BK; k16 += 16) {
@@ -605,8 +626,12 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
                 const int rm = rm0 + r, rn = gn0 + cc;
                 if (rm < M && rn < N) {
                     const int p = p0 + rm;
-                    const float v = (float)Cs[warp * 256 + el] * sx[p] * row_scale[rn];
-                    C[(size_t)p * N + rn] = __float2bfloat16(v);
+                    if (SPLIT) {
+                        partials[(((size_t)blockIdx.z * Mtot) + p) * N + rn] = Cs[warp * 256 + el];
+                    } else {
+                        const float v = (float)Cs[warp * 256 + el] * sx[p] * row_scale[rn];
+                        C[(size_t)p * N + rn] = __float2bfloat16(v);
+                    }
                 }
             }
             __syncwarp();
@@ -652,17 +677,73 @@ bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float
     return true;
 }
 
-// Dense fused-decode int8 GEMM (single weight, no routing). See pf_dense_gemm_qi8_kernel.
+// Sum the split-K int32 partials and apply sx*row_scale once. The sum is over int32, so the total
+// is exactly what the unsplit kernel accumulated and the bf16 store sees an identical value.
+__global__ void pf_dense_splitk_reduce_kernel(const int* __restrict__ partials,
+                                              const float* __restrict__ sx,
+                                              const float* __restrict__ row_scale,
+                                              __nv_bfloat16* __restrict__ C,
+                                              int Mtot, int N, int splits) {
+    const size_t idx = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= (size_t)Mtot * (size_t)N) return;
+    const int m = (int)(idx / (size_t)N);
+    const int n = (int)(idx - (size_t)m * (size_t)N);
+    int acc = 0;
+    for (int s = 0; s < splits; s++) acc += partials[((size_t)s * Mtot + m) * N + n];
+    C[idx] = __float2bfloat16((float)acc * sx[m] * row_scale[n]);
+}
+
+// Dense fused-decode int8 GEMM (single weight, no routing). See pf_dense_gemm_qi8_kernel_g.
 bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
                                    const void* W_q, const float* row_scale, void* C_bf16,
-                                   int M, int N, int K, cudaStream_t stream) {
+                                   int M, int N, int K, cudaStream_t stream,
+                                   int* partials, int partials_splits) {
     if (!pfm_moe_gemm_qi8_supported(ggml_type)) return false;   // Q4_K / Q5_K only
     if (!row_scale || M <= 0) return false;
     if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;         // whole super-blocks only
     if (N <= 0 || (N % QM_BN) != 0) return false;               // 64-aligned output width
     auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
     const auto* W = reinterpret_cast<const unsigned char*>(W_q);
-    dim3 grid((N + QM_BN - 1) / QM_BN, (M + QM_BM - 1) / QM_BM);
+    const int ntiles = (N + QM_BN - 1) / QM_BN;
+    const int mtiles = (M + QM_BM - 1) / QM_BM;
+
+    // Split K only when the plain grid leaves the device idle. With more than one M-tile the grid
+    // already fans out over M and a split would only add the reduce pass. Each slice must own whole
+    // super-blocks, at least 2, or the per-block prologue dominates it.
+    static int sk_env = -1;
+    if (sk_env < 0) { const char* e = getenv("SPARKINFER_MUSE_QB_SPLITK"); sk_env = e ? atoi(e) : -2; }
+    int splits = 1;
+    if (partials && partials_splits > 1 && mtiles == 1 && sk_env != 0) {
+        const int nsb = K >> 8;
+        splits = (sk_env > 0) ? sk_env : (QM_TARGET_BLOCKS + ntiles - 1) / ntiles;
+        if (splits > partials_splits) splits = partials_splits;
+        if (splits > nsb / 2) splits = nsb / 2;
+        if (splits < 1) splits = 1;
+    }
+    if (splits > 1) {
+        const int nsb_all = K >> 8;
+        const int sb_per_split = (nsb_all + splits - 1) / splits;
+        // Re-derive the launch count from the slice size. Going the other way leaves trailing z
+        // slices with sb_lo >= nsb: those blocks return before writing, the reduce then sums
+        // never-written partials and the output is garbage (measured: TOP1 0.92 -> 0.67,
+        // KL 0.036 -> 0.306, while the throughput still looked fine). Every launched slice must
+        // own at least one super-block.
+        splits = (nsb_all + sb_per_split - 1) / sb_per_split;
+        if (splits > 1) {
+            dim3 grid(ntiles, mtiles, splits);
+            if (ggml_type == QMQ_Q4_K)
+                pf_dense_gemm_qi8_kernel_g<QMQ_Q4_K, false, true><<<grid, 256, 0, stream>>>(
+                    A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{}, partials, sb_per_split);
+            else
+                pf_dense_gemm_qi8_kernel_g<QMQ_Q5_K, false, true><<<grid, 256, 0, stream>>>(
+                    A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{}, partials, sb_per_split);
+            const size_t total = (size_t)M * (size_t)N;
+            pf_dense_splitk_reduce_kernel<<<(unsigned)((total + 255) / 256), 256, 0, stream>>>(
+                partials, sx, row_scale, C, M, N, splits);
+            return true;
+        }
+    }
+    dim3 grid(ntiles, mtiles);
     if (ggml_type == QMQ_Q4_K)
         pf_dense_gemm_qi8_kernel_g<QMQ_Q4_K, false><<<grid, 256, 0, stream>>>(A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{});
     else

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -42,9 +42,15 @@ bool pfm_moe_gemm_qi8_supported(int ggml_type);
 // the int8 materialize (dequant -> W_i8 -> reload) that launch_prefill_gemm_i8 pays. Returns false
 // (launching nothing) for an unsupported ggml_type, null row_scale, K not a super-block multiple, or
 // N not 64-aligned -- callers fall back to the materialize path. Used by Muse Glimmer dense prefill.
+// `partials` (int32, >= partials_splits * M * N) enables a split-K fan-out: at prefill's M=128 the
+// plain grid is only N/64 blocks, far under the device, so K is sliced across blockIdx.z and the
+// int32 tiles are summed in a second pass. int32 accumulation is exact and associative => the
+// result is BIT-IDENTICAL to the unsplit launch. partials=nullptr (or splits<=1) disables it;
+// SPARKINFER_MUSE_QB_SPLITK=0 disables, >0 pins the slice count.
 bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
                                    const void* W_q, const float* row_scale, void* C_bf16,
-                                   int M, int N, int K, cudaStream_t stream = nullptr);
+                                   int M, int N, int K, cudaStream_t stream = nullptr,
+                                   int* partials = nullptr, int partials_splits = 0);
 
 // Fuse up to 4 projections sharing A_i8/sx (same M, same K) into ONE grid. At prefill's M=128 a
 // projection's grid is ceil(N/64) CTAs -- 64 for a 4096-wide q/gate but only 4 for a 256-wide

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -90,6 +90,11 @@ struct Qwen35LayerWeights {
     const float* wq_rs = nullptr; const float* wgate_rs = nullptr;
     const float* wk_rs = nullptr; const float* wv_rs = nullptr; const float* wo_rs = nullptr;
     const float* gate_rs = nullptr; const float* up_rs = nullptr;
+    // ffn_down's per-row int8 scale. Left out of the original dense set on the assumption that
+    // down is always Q6_K; in the shipped Muse Q4_K_M GGUF a large share of the down tensors are
+    // Q4_K, i.e. fusable, and were falling back to the int8 materialize only because the scale
+    // pool had no slot for them. Null when this layer's down really is unfusable (Q6_K).
+    const float* down_rs = nullptr;
 };
 
 struct Qwen35Weights {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3530,7 +3530,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const int qd = c.n_q_heads * c.head_dim;                   // qdim (4096)
             const int kd = c.n_kv_heads * c.head_dim;                  // kvdim (256)
             const int ff = c.moe_ffn;                                  // dense FFN width (19968)
-            const size_t per_layer = (size_t)(2 * qd + 2 * kd + H + 2 * ff);  // rows/layer, all fusable
+            // + H for ffn_down: the original layout reserved no slot for it, so every Q4_K down
+            // fell back to the materialize path regardless of being a fusable type. Slots are
+            // reserved for all eight; a slot stays unfilled (and its *_rs null) when that
+            // weight's type is not fusable, so a Q6_K down still takes the materialize path.
+            const size_t per_layer = (size_t)(2 * qd + 2 * kd + H + 2 * ff + H);  // rows/layer
             const size_t total = per_layer * (size_t)c.n_layers;
             const size_t tmp_bytes = 64u << 20;                        // int8 scratch, thrown away
             signed char* tmp = nullptr;
@@ -3565,6 +3569,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 place(lw.wo,     lw.wo_type,     &lw.wo_rs,    H,  qd);
                 place(lw.gate_q, lw.gate_qtype,  &lw.gate_rs,  ff, H);
                 place(lw.up_q,   lw.up_qtype,    &lw.up_rs,    ff, H);
+                place(lw.down_q, lw.down_qtype,  &lw.down_rs,  H,  ff);
             }
             if (ok) ok = cudaStreamSynchronize(s.stream) == cudaSuccess;
             if (tmp) cudaFree(tmp);
@@ -3573,6 +3578,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 for (int i = 0; i < c.n_layers; i++) {
                     Qwen35LayerWeights& lw = s.w.layers[i];
                     lw.wq_rs = lw.wgate_rs = lw.wk_rs = lw.wv_rs = lw.wo_rs = lw.gate_rs = lw.up_rs = nullptr;
+                    lw.down_rs = nullptr;
                 }
                 fprintf(stderr, "[prefill-muse] dense row-scale precompute unavailable "
                                 "-> int8 materialize path\n");

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -267,6 +267,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     signed char* W_i8 = need_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = need_i8 ? a8.alloc<float>(sx_n) : nullptr;
     float* sw = need_i8 ? a8.alloc<float>((size_t)maxNO) : nullptr;
+    // int32 partials for the fused GEMM's split-K fan-out. Only while the whole prompt is one
+    // M-tile (N <= QM_BM = 128): beyond that the plain grid already fans out over M, and the buffer
+    // would scale with N. 8 * 128 * 19968 * 4 B = 82 MB, and only for Muse.
+    constexpr int QB_SPLITS = 8;
+    int* qb_partials = (c.muse_glimmer && use_i8 && N <= 128)
+        ? a8.alloc<int>((size_t)QB_SPLITS * (size_t)N * (size_t)maxNO) : nullptr;
     // Muse Glimmer split-K partials for the skinny projections. launch_prefill_gemm_i8 puts one
     // 128x128 output tile in a block, so Muse's narrow n_out (attn k/v = 256 -> TWO blocks, q and
     // the q-gate = 4096 -> 32) leaves the device almost empty: measured on an RTX 5090 the 2-block
@@ -586,7 +592,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         const int R = rows > 0 ? rows : N;
         if (muse_qb && use_i8 && rs && n_out >= 128 && kernels::pfm_moe_gemm_qi8_supported(wtype)) {
             quant_a_i8(A, R, K);
-            if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st))
+            if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
+                                                       qb_partials, QB_SPLITS))
                 return;
         }
         proj(A, W, wtype, C, n_out, K, rows);
@@ -807,15 +814,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         // skips the ffg store + reload that proj()'s internal quantize would pay.
                         a_q = nullptr;                 // swiglu_quant writes A_i8/sx directly
                         kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st);
-                        if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,
-                                                                  W_i8, sw, H, ffn, st)) {
-                            const void* wb = dq(w.down_q, w.down_qtype, H, ffn);
-                            kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, ffn, st);
+                        // Fused quantized-B down projection. The activation is ALREADY in A_i8/sx
+                        // (the fused SwiGLU wrote it), so this cannot go through proj_fused, which
+                        // would re-quantize -- call the dense fused GEMM directly. Only the
+                        // residual-unfused form is eligible; Muse never takes the fused-residual
+                        // branch anyway (its sandwich norm needs the raw FFN output in ao).
+                        bool down_fused = false;
+                        if (!ffn_fused && muse_qb && w.down_rs &&
+                            kernels::pfm_moe_gemm_qi8_supported(w.down_qtype)) {
+                            down_fused = kernels::launch_prefill_gemm_qi8_dense(
+                                w.down_qtype, A_i8, sx, w.down_q, w.down_rs,
+                                ao + (size_t)fo * H, fn, H, ffn, st, qb_partials, QB_SPLITS);
                         }
-                        if (ffn_fused)
-                            gemm_i8(A_i8, W_i8, sx, sw, x + (size_t)fo * H, fn, H, ffn, true);
-                        else
-                            gemm_i8(A_i8, W_i8, sx, sw, ao + (size_t)fo * H, fn, H, ffn, false);
+                        if (!down_fused) {
+                            if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,
+                                                                      W_i8, sw, H, ffn, st)) {
+                                const void* wb = dq(w.down_q, w.down_qtype, H, ffn);
+                                kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, ffn, st);
+                            }
+                            // keeps #795's split-K fan-out for whatever still materializes (Q6_K down)
+                            if (ffn_fused)
+                                gemm_i8(A_i8, W_i8, sx, sw, x + (size_t)fo * H, fn, H, ffn, true);
+                            else
+                                gemm_i8(A_i8, W_i8, sx, sw, ao + (size_t)fo * H, fn, H, ffn, false);
+                        }
                     } else {
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         if (!ffn_fused || !proj_resid(ffg, w.down_q, w.down_qtype,


### PR DESCRIPTION
## Summary

At prefill's `M=128` the fused quantized-B dense GEMM's `grid.y` collapses to 1, so its grid is only
`n_out/64` blocks — 104 for the 6656-wide o/down, 312 for the 19968-wide FFN pair — against ~510
block slots on a 5090. `ncu` on it: **0.13 waves/SM**, 16.7% achieved occupancy, DRAM 6.0%, SM
throughput 13.1%. It is neither bandwidth- nor compute-bound; it simply is not on the machine.

`blockIdx.z` now owns a slice of the K super-blocks and writes its raw int32 tile to a partials
buffer; a reduce pass sums the slices and applies `sx * row_scale` once. int32 accumulation is exact
and associative, so the summed result is **bit-identical** to the unsplit launch — only the block
count changes.

The split count is derived from the slice size, so every launched slice owns at least one
super-block. Deriving it the other way leaves trailing slices that return before writing, and the
reduce then sums uninitialised memory — that produced correct-looking throughput with TOP1 0.92 →
0.67. Only the ungrouped launches split; a grouped launch resolves a different `n_out`/`C` per
output tile and would need a per-group partials offset table.

Separately, `ffn_down` was reserved no slot in the dense row-scale pool, on the assumption that down
is always Q6_K. In this GGUF a large share of the down tensors are Q4_K — fusable — and were falling
back to the int8 materialize purely for lack of a scale. Adding the slot lets them take the fused
path; a genuinely Q6_K down still materializes.

`SPARKINFER_MUSE_QB_SPLITK=0` restores the unsplit launch, `>0` pins the slice count.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (ctx=0, unchanged — this PR does not touch the decode path):

| | decode tok/s |
|---|--:|
| before (main) | 100.57 |
| after (this PR) | 100.57 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128 — the context this PR targets):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2073.69 |
| after prefill (this PR) | 2666.93 |

**+28.61%** prefill@128. Median-of-5, same binary, toggled with `SPARKINFER_MUSE_QB_SPLITK`, clocks
locked at 2550 MHz.

```text
### prefill@128 median-of-5, same binary ###
  split off (== main behaviour) : 2073.69
  split on  (this PR)           : 2666.93
  DELTA = +28.61%

### decode@ctx0 ###
  rep1 decode=100.57
  rep2 decode=100.57
  rep3 decode=100.56

### slice-count sweep (prefill@128) ###
  off 2077 | 4 -> 2557 | 6 -> 2566 | 8 -> 2586 | auto 2681
```

### Correctness

Bit-identity is the claim, so it is checked rather than argued — `qwen3_gguf_prefill_check` fills the
KV both ways over the same prompt and teacher-forces the same continuation (64 positions, bf16 KV):

```text
  [split off ] prefix=128  59/64 0.9219  KL 0.03558
  [split auto] prefix=128  59/64 0.9219  KL 0.03558
  [split =2  ] prefix=128  59/64 0.9219  KL 0.03558
  [split =8  ] prefix=128  59/64 0.9219  KL 0.03558
  [split on  ] prefix=512  60/64 0.9375  KL 0.00906

ctest: 100% tests passed, 11/11
```

Every slice count agrees to the digit with the unsplit launch, as the int32 argument requires.

### Scope

Reachable only from Muse Glimmer's batched prefill (`c.muse_glimmer`); the partials buffer is
allocated only there, and only while the prompt is a single M-tile. The routed-MoE kernels in the
same file are untouched, and `launch_prefill_gemm_qi8_dense` is not on any other model's path.

### Qwen3.6 no-regression

This edits `prefill_moe_q.cu`, which the routed-MoE prefill shares, so the cross-model guard was run
rather than argued — same sweep the eval uses (`ctx 0/512/4k/16k/32k`, median-of-5), two arms each
built and run in place on the same box:

```text
  ctx        decode A -> B            prefill A -> B
       0     481.20 ->   481.17        0.00 ->      0.00
     512     475.64 ->   475.51     8066.82 ->   8062.83
    4096     455.32 ->   455.29    22590.14 ->  22632.83
   16384     457.32 ->   457.37    24804.65 ->  24799.50
   32768     457.64 ->   457.51    26170.70 ->  26165.89
```

Max deviation ~0.03%, i.e. run-to-run noise. Expected: the routed-MoE kernels are untouched, and the
dense fused GEMM is gated behind `c.muse_glimmer`, so Qwen3.6 never reaches it.
