### PR TITLE
perf(muse-glimmer): split-K and widen the grouped prefill projections (1.08x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -489,6 +489,7 @@ struct PfQGroup {
     __nv_bfloat16*       C[PF_QGROUP_MAX];
     int                  N[PF_QGROUP_MAX];
     int                  first[PF_QGROUP_MAX];   // prefix sum of each group's tile count
+    int                  poff[PF_QGROUP_MAX];    // split-K: base of each group in `partials`
     int                  ngroup;
 };
 
@@ -519,28 +520,30 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
     __nv_bfloat16* C = C_arg;
     int N = N_arg;
     int xtile = blockIdx.x;
+    int grp = 0;
     if (GROUPED) {
-        int g = 0;
         #pragma unroll
         for (int i = 1; i < PF_QGROUP_MAX; i++)
-            if (i < gd.ngroup && (int)blockIdx.x >= gd.first[i]) g = i;
-        W_q = gd.W[g]; row_scale = gd.rs[g]; C = gd.C[g]; N = gd.N[g];
-        xtile = (int)blockIdx.x - gd.first[g];
+            if (i < gd.ngroup && (int)blockIdx.x >= gd.first[i]) grp = i;
+        W_q = gd.W[grp]; row_scale = gd.rs[grp]; C = gd.C[grp]; N = gd.N[grp];
+        xtile = (int)blockIdx.x - gd.first[grp];
     }
+    // Every group owns a disjoint [split][m][n] region of `partials`, so a grouped split-K launch
+    // needs its base here -- the one thing that kept the grouped launch from splitting.
+    const size_t pbase = GROUPED ? (size_t)gd.poff[grp] : 0;
     const int n0  = xtile * QM_BN;
     const int nsb = K >> 8;
 
     __shared__ __align__(16) signed char Bs[QM_BN][QM_LD];
     __shared__ __align__(16) signed char As[2][QM_BM][QM_BK];
-    __shared__ int s_tok[QM_BM];
 
     const int tid = threadIdx.x;
     const int warp = tid >> 5, lane = tid & 31;
     const int wm = warp & 3, wn = warp >> 2;
 
-    // Direct activation rows (no pair_tok gather): row r of this M-tile is global token p0 + r.
-    for (int r = tid; r < QM_BM; r += blockDim.x)
-        s_tok[r] = (r < M) ? (p0 + r) : -1;
+    // Direct activation rows: row r of this M-tile IS global token p0 + r, so it is computed in
+    // stageA rather than staged through smem (the pair_tok gather this kernel was cloned from is
+    // what needed a table). Saves 512 B of smem and the barrier that published it.
 
     // Decode assignment: 4 threads per weight row, one 64-value sub-block pair (j64) each.
     const int dr = tid >> 2, dj = tid & 3;
@@ -559,14 +562,13 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
     auto stageA = [&](int buf, int k0) {
         for (int idx = tid; idx < QM_BM * 2; idx += blockDim.x) {
             const int r = idx >> 1, c16 = (idx & 1) * 16;
-            const int arow = s_tok[r];
+            const int arow = (r < M) ? (p0 + r) : -1;
             qm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + k0 + c16],
                     arow >= 0 && (k0 + c16) < K);
         }
         __pipeline_commit();
     };
 
-    __syncthreads();          // s_tok published before stageA reads it
     const int sb_lo = SPLIT ? (int)blockIdx.z * sb_per_split : 0;
     const int sb_hi = SPLIT ? min(nsb, sb_lo + sb_per_split) : nsb;
     if (sb_lo >= sb_hi) return;
@@ -627,7 +629,7 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
                 if (rm < M && rn < N) {
                     const int p = p0 + rm;
                     if (SPLIT) {
-                        partials[(((size_t)blockIdx.z * Mtot) + p) * N + rn] = Cs[warp * 256 + el];
+                        partials[pbase + (((size_t)blockIdx.z * Mtot) + p) * N + rn] = Cs[warp * 256 + el];
                     } else {
                         const float v = (float)Cs[warp * 256 + el] * sx[p] * row_scale[rn];
                         C[(size_t)p * N + rn] = __float2bfloat16(v);
@@ -693,6 +695,42 @@ __global__ void pf_dense_splitk_reduce_kernel(const int* __restrict__ partials,
     C[idx] = __float2bfloat16((float)acc * sx[m] * row_scale[n]);
 }
 
+// Grouped split-K reduce. One launch covers every group: the flattened column picks the group
+// from the same tile prefix sum the GEMM prologue uses, so no per-group reduce launches are needed.
+__global__ void pf_dense_splitk_reduce_group_kernel(const int* __restrict__ partials,
+                                                    const float* __restrict__ sx,
+                                                    PfQGroup gd, int Mtot, int ncol, int splits) {
+    const size_t idx = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx >= (size_t)Mtot * (size_t)ncol) return;
+    const int m    = (int)(idx / (size_t)ncol);
+    const int rest = (int)(idx - (size_t)m * (size_t)ncol);
+    int g = 0;
+#pragma unroll
+    for (int i = 1; i < PF_QGROUP_MAX; i++)
+        if (i < gd.ngroup && rest >= gd.first[i] * QM_BN) g = i;
+    const int n = rest - gd.first[g] * QM_BN;
+    const int N = gd.N[g];
+    const int* base = partials + (size_t)gd.poff[g];
+    int acc = 0;
+    for (int s = 0; s < splits; s++) acc += base[((size_t)s * Mtot + m) * N + n];
+    gd.C[g][(size_t)m * N + n] = __float2bfloat16((float)acc * sx[m] * gd.rs[g][n]);
+}
+
+// K slices per launch. Shared by the single and grouped launchers so both fan out the same way.
+static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int partials_splits) {
+    static int sk_env = -1;
+    if (sk_env < 0) { const char* e = getenv("SPARKINFER_MUSE_QB_SPLITK"); sk_env = e ? atoi(e) : -2; }
+    int splits = 1;
+    if (have_partials && partials_splits > 1 && mtiles == 1 && sk_env != 0) {
+        const int nsb = K >> 8;
+        splits = (sk_env > 0) ? sk_env : (QM_TARGET_BLOCKS + ntiles - 1) / ntiles;
+        if (splits > partials_splits) splits = partials_splits;
+        if (splits > nsb / 2) splits = nsb / 2;
+        if (splits < 1) splits = 1;
+    }
+    return splits;
+}
+
 // Dense fused-decode int8 GEMM (single weight, no routing). See pf_dense_gemm_qi8_kernel_g.
 bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
                                    const void* W_q, const float* row_scale, void* C_bf16,
@@ -710,16 +748,7 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
     // Split K only when the plain grid leaves the device idle. With more than one M-tile the grid
     // already fans out over M and a split would only add the reduce pass. Each slice must own whole
     // super-blocks, at least 2, or the per-block prologue dominates it.
-    static int sk_env = -1;
-    if (sk_env < 0) { const char* e = getenv("SPARKINFER_MUSE_QB_SPLITK"); sk_env = e ? atoi(e) : -2; }
-    int splits = 1;
-    if (partials && partials_splits > 1 && mtiles == 1 && sk_env != 0) {
-        const int nsb = K >> 8;
-        splits = (sk_env > 0) ? sk_env : (QM_TARGET_BLOCKS + ntiles - 1) / ntiles;
-        if (splits > partials_splits) splits = partials_splits;
-        if (splits > nsb / 2) splits = nsb / 2;
-        if (splits < 1) splits = 1;
-    }
+    int splits = qm_pick_splits(ntiles, K, mtiles, partials != nullptr, partials_splits);
     if (splits > 1) {
         const int nsb_all = K >> 8;
         const int sb_per_split = (nsb_all + splits - 1) / splits;
@@ -757,7 +786,8 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
 bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8, const float* sx,
                                          const void* const* W_q, const float* const* row_scale,
                                          void* const* C_bf16, const int* N, int ngroup,
-                                         int M, int K, cudaStream_t stream) {
+                                         int M, int K, cudaStream_t stream,
+                                         int* partials, int partials_splits, size_t partials_cap) {
     if (!pfm_moe_gemm_qi8_supported(ggml_type)) return false;
     if (ngroup <= 0 || ngroup > PF_QGROUP_MAX || M <= 0) return false;
     if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;
@@ -773,7 +803,45 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
         d.first[i] = tiles;
         tiles += N[i] / QM_BN;
     }
-    dim3 grid(tiles, (M + QM_BM - 1) / QM_BM);
+    const int mtiles = (M + QM_BM - 1) / QM_BM;
+
+    // The grouped launch is the one the K split never reached, and at M=128 it is also the emptiest:
+    // q+gate+k+v is 136 tiles of a 510-block device, a quarter of one wave for the full K. Splitting
+    // it needs only the per-group base above; the arithmetic is the same exact int32 sum, so the
+    // result stays bit-identical. SPARKINFER_MUSE_GROUP_SPLITK=0 restores the single-slice launch.
+    static int gsk_env = -1;
+    if (gsk_env < 0) { const char* e = getenv("SPARKINFER_MUSE_GROUP_SPLITK"); gsk_env = e ? atoi(e) : 1; }
+    int splits = gsk_env == 0 ? 1
+                              : qm_pick_splits(tiles, K, mtiles, partials != nullptr, partials_splits);
+    // The caller sizes `partials` for one projection at a time; a group needs the sum of its
+    // widths, so clamp the slice count to what actually fits rather than trusting it.
+    int ncol_all = 0;
+    for (int i = 0; i < ngroup; i++) ncol_all += N[i];
+    while (splits > 1 && (size_t)splits * (size_t)M * (size_t)ncol_all > partials_cap) splits--;
+    if (splits > 1) {
+        const int nsb_all = K >> 8;
+        const int sb_per_split = (nsb_all + splits - 1) / splits;
+        // Same guard the single launcher documents: derive the launch count back from the slice
+        // size so every launched slice owns at least one super-block, or the reduce sums memory
+        // that was never written.
+        splits = (nsb_all + sb_per_split - 1) / sb_per_split;
+        if (splits > 1) {
+            int off = 0;
+            for (int i = 0; i < ngroup; i++) { d.poff[i] = off; off += splits * M * N[i]; }
+            dim3 grid(tiles, mtiles, splits);
+            if (ggml_type == QMQ_Q4_K)
+                pf_dense_gemm_qi8_kernel_g<QMQ_Q4_K, true, true><<<grid, 256, 0, stream>>>(
+                    A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d, partials, sb_per_split);
+            else
+                pf_dense_gemm_qi8_kernel_g<QMQ_Q5_K, true, true><<<grid, 256, 0, stream>>>(
+                    A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d, partials, sb_per_split);
+            const size_t total = (size_t)M * (size_t)tiles * QM_BN;
+            pf_dense_splitk_reduce_group_kernel<<<(unsigned)((total + 255) / 256), 256, 0, stream>>>(
+                partials, sx, d, M, tiles * QM_BN, splits);
+            return true;
+        }
+    }
+    dim3 grid(tiles, mtiles);
     if (ggml_type == QMQ_Q4_K)
         pf_dense_gemm_qi8_kernel_g<QMQ_Q4_K, true><<<grid, 256, 0, stream>>>(A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d);
     else

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -60,7 +60,9 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
 bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8, const float* sx,
                                          const void* const* W_q, const float* const* row_scale,
                                          void* const* C_bf16, const int* N, int ngroup,
-                                         int M, int K, cudaStream_t stream = nullptr);
+                                         int M, int K, cudaStream_t stream = nullptr,
+                                         int* partials = nullptr, int partials_splits = 0,
+                                         size_t partials_cap = 0);
 
 } // namespace kernels
 } // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -271,8 +271,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // M-tile (N <= QM_BM = 128): beyond that the plain grid already fans out over M, and the buffer
     // would scale with N. 8 * 128 * 19968 * 4 B = 82 MB, and only for Muse.
     constexpr int QB_SPLITS = 8;
+    const size_t qb_partials_cap = (size_t)QB_SPLITS * (size_t)N * (size_t)maxNO;
     int* qb_partials = (c.muse_glimmer && use_i8 && N <= 128)
-        ? a8.alloc<int>((size_t)QB_SPLITS * (size_t)N * (size_t)maxNO) : nullptr;
+        ? a8.alloc<int>(qb_partials_cap) : nullptr;
     // Muse Glimmer split-K partials for the skinny projections. launch_prefill_gemm_i8 puts one
     // 128x128 output tile in a block, so Muse's narrow n_out (attn k/v = 256 -> TWO blocks, q and
     // the q-gate = 4096 -> 32) leaves the device almost empty: measured on an RTX 5090 the 2-block
@@ -587,6 +588,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     }();
     const bool muse_group = c.muse_glimmer &&
         [] { const char* e = getenv("SPARKINFER_MUSE_PREFILL_GROUP"); return !(e && e[0] == '0'); }();
+    // SPARKINFER_MUSE_FFN_GROUP=0 keeps ffn gate/up as two launches (A/B).
+    const bool muse_ffn_group = c.muse_glimmer &&
+        [] { const char* e = getenv("SPARKINFER_MUSE_FFN_GROUP"); return !(e && e[0] == '0'); }();
+    // SPARKINFER_MUSE_GROUP_SUBSET=0 goes back to grouping only when all four projections share a
+    // type, which is the all-or-nothing test this replaces (A/B).
+    const bool muse_gsubset =
+        [] { const char* e = getenv("SPARKINFER_MUSE_GROUP_SUBSET"); return !(e && e[0] == '0'); }();
     auto proj_fused = [&](const bf16* A, const void* W, int wtype, const float* rs,
                           bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;
@@ -686,25 +694,39 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // they cost four full CTA-durations, two of which carry four CTAs of work. One
                 // grid for all four collapses that to one. Bit-identical per output tile.
                 // SPARKINFER_MUSE_PREFILL_GROUP=0 restores the four separate launches.
-                bool grouped = false;
+                // Group whichever of the four share the anchor type instead of demanding that all
+                // four match: this GGUF gives half its layers a Q6_K attn_v, and the all-or-nothing
+                // test dropped every one of those layers back to four separate launches -- q and
+                // gate at 64 tiles, k at 4. Anything left out (or unsupported) still goes through
+                // proj_fused, the same path it took before, so its result is unchanged.
+                const void* Wa[4]; const float* rsa[4]; void* Ca[4]; int na[4];
+                bool inq = false, ing = false, ink = false, inv = false;
+                int ng = 0;
                 if (muse_group && muse_qb && use_i8 &&
-                    w.wq_rs && w.wgate_rs && w.wk_rs && w.wv_rs &&
-                    w.wq_type == w.wgate_type && w.wq_type == w.wk_type && w.wq_type == w.wv_type &&
                     kernels::pfm_moe_gemm_qi8_supported(w.wq_type)) {
-                    const void* Wp[4]  = { w.wq, w.wgate, w.wk, w.wv };
-                    const float* rsp[4] = { w.wq_rs, w.wgate_rs, w.wk_rs, w.wv_rs };
-                    void* Cp[4]        = { qb, qg, kf, vf };
-                    const int nout[4]  = { qdim, qdim, kvdim, kvdim };
+                    const int at = w.wq_type;
+                    auto take = [&](const void* W, int t, const float* rs, void* C, int n, bool& in) {
+                        if (!W || !rs || t != at) return;
+                        Wa[ng] = W; rsa[ng] = rs; Ca[ng] = C; na[ng] = n; ng++; in = true;
+                    };
+                    take(w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  inq);
+                    take(w.wgate, w.wgate_type, w.wgate_rs, qg, qdim,  ing);
+                    take(w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, ink);
+                    take(w.wv,    w.wv_type,    w.wv_rs,    vf, kvdim, inv);
+                    if (!muse_gsubset && ng != 4) { ng = 0; inq = ing = ink = inv = false; }
+                }
+                bool grouped = false;
+                if (ng >= 2) {
                     quant_a_i8(xn, N, H);
                     grouped = kernels::launch_prefill_gemm_qi8_dense_group(
-                        w.wq_type, A_i8, sx, Wp, rsp, Cp, nout, 4, N, H, st);
+                        w.wq_type, A_i8, sx, Wa, rsa, Ca, na, ng, N, H, st,
+                        qb_partials, QB_SPLITS, qb_partials_cap);
                 }
-                if (!grouped) {
-                proj_fused(xn, w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  H);
-                proj_fused(xn, w.wgate, w.wgate_type, w.wgate_rs, qg, qdim,  H);
-                proj_fused(xn, w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, H);
-                proj_fused(xn, w.wv,    w.wv_type,    w.wv_rs,    vf, kvdim, H);
-                }
+                if (!grouped) { inq = ing = ink = inv = false; }
+                if (!inq) proj_fused(xn, w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  H);
+                if (!ing) proj_fused(xn, w.wgate, w.wgate_type, w.wgate_rs, qg, qdim,  H);
+                if (!ink) proj_fused(xn, w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, H);
+                if (!inv) proj_fused(xn, w.wv,    w.wv_type,    w.wv_rs,    vf, kvdim, H);
             } else {
                 proj(xn, w.wq, w.wq_type, b8, wide,  H);             // qraw = [q|gate] per head
                 proj(xn, w.wk, w.wk_type, kf, kvdim, H);
@@ -806,8 +828,27 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         kernels::launch_prefill_gemm_i8(A_i8, ffn_Wd_i8, sx, ffn_swd,
                                                         ao + (size_t)fo * H, fn, H, ffn, st);
                 } else {
-                    proj_fused(hn_c, w.gate_q, w.gate_qtype, w.gate_rs, ffg, ffn, H, fn);
-                    proj_fused(hn_c, w.up_q,   w.up_qtype,   w.up_rs,   ffu, ffn, H, fn);
+                    // gate and up read the same hn chunk over the same K, so they are one grid for
+                    // the same reason q/gate/k/v are: two 312-tile launches each leave a partial
+                    // wave on a 510-block device, and one 624-tile launch leaves only one.
+                    // SPARKINFER_MUSE_FFN_GROUP=0 restores the two launches (A/B).
+                    bool ffn_grouped = false;
+                    if (muse_ffn_group && muse_qb && use_i8 && w.gate_rs && w.up_rs &&
+                        w.gate_qtype == w.up_qtype &&
+                        kernels::pfm_moe_gemm_qi8_supported(w.gate_qtype)) {
+                        const void*  Wf[2]  = { w.gate_q, w.up_q };
+                        const float* rsf[2] = { w.gate_rs, w.up_rs };
+                        void*        Cf[2]  = { ffg, ffu };
+                        const int    nf[2]  = { ffn, ffn };
+                        quant_a_i8(hn_c, fn, H);
+                        ffn_grouped = kernels::launch_prefill_gemm_qi8_dense_group(
+                            w.gate_qtype, A_i8, sx, Wf, rsf, Cf, nf, 2, fn, H, st,
+                            qb_partials, QB_SPLITS, qb_partials_cap);
+                    }
+                    if (!ffn_grouped) {
+                        proj_fused(hn_c, w.gate_q, w.gate_qtype, w.gate_rs, ffg, ffn, H, fn);
+                        proj_fused(hn_c, w.up_q,   w.up_qtype,   w.up_rs,   ffu, ffn, H, fn);
+                    }
                     if (use_i8) {
                         // Same fused SwiGLU + per-row int8 quantize the long-ctx ffn_i8 branch
                         // runs (bit-identical to swiglu-then-quantize; both bf16-round first) --


### PR DESCRIPTION
## Summary

At prefill's `M=128` the fused quantized-B GEMM fans out over output tiles, so a launch is only as
wide as `n_out/64` tiles. Three of them never filled the device: the grouped q/gate/k/v launch could
not take a K split, half the layers were disqualified from grouping outright, and ffn gate/up ran as
two launches. This gives the grouped launch a K split, forms a group from whichever projections
share a weight type instead of demanding that all of them do, and puts ffn gate/up on one grid.

**Grouped split-K.** A grouped launch resolves a different `n_out`/`C` per output tile, so its int32
partials need a per-group base — that is the whole reason `blockIdx.z` could not own a K slice here.
A `poff[]` in the descriptor supplies it, and one reduce still covers every group: the flattened
output column picks its group from the same tile prefix sum the GEMM prologue already walks. int32
accumulation is exact and associative, so the summed value is **bit-identical** to the unsplit
launch — only the block count changes.

**Subset grouping.** The group was all-or-nothing on weight type. This GGUF gives 26 of 52 layers a
Q6_K `attn_v`, and a single mismatched tensor dropped the whole layer back to four separate launches
— q and gate at 64 tiles, k at 4, against ~510 block slots on a 5090. Grouping the subset that does
match keeps those layers on one grid; anything left out still takes `proj_fused`, the same path it
took before, so its result is unchanged.

**ffn gate/up.** Both read the same `hn` chunk over the same K. Two 312-tile launches each strand a
partial wave; one 624-tile launch strands one.

Measured wave efficiency (blocks / (waves x 510)): grouped projections 26.7% -> 93.3%, ffn
76.5% -> 91.8%, and tail-wave waste summed over every fused-GEMM launch 27.0% -> 11.7%.

Also drops a vestigial `s_tok[128]` staging array from the dense kernel — row `r` of the M-tile is
just `p0 + r` there, so it is computed in `stageA` instead of published through shared memory. The
MoE kernel this was cloned from really does gather `pair_tok` and keeps its copy. Saves 512 B of
shared memory and a `__syncthreads`.

`SPARKINFER_MUSE_GROUP_SPLITK=0`, `SPARKINFER_MUSE_GROUP_SUBSET=0` and `SPARKINFER_MUSE_FFN_GROUP=0`
each restore the previous behaviour for A/B.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (ctx=0, unchanged — this PR does not touch the decode path):

| | decode tok/s |
|---|--:|
| before (main) | 99.65 |
| after (this PR) | 99.62 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128 — the context this PR targets):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2822.91 |
| after prefill (this PR) | 3038.87 |

**+7.65%** prefill@128. Two binaries built from the same tree, benched interleaved, three rounds of
median-of-5 each, clocks locked at 2550 MHz.

```text
### prefill@128, interleaved, median-of-5 per row, clocks 2550 ###
  r1 main 2813.02   r1 this PR 3054.94
  r2 main 2829.51   r2 this PR 3032.57
  r3 main 2822.91   r3 this PR 3038.87
  median  2822.91           ->  3038.87     = +7.65%

### decode@ctx0 (same runs) ###
  main    99.6881 / 99.6385 / 99.6125
  this PR 99.6313 / 99.6201 / 99.6140

### fused-GEMM launch shapes at ctx=128 (nsys, per prefill) ###
  launch                       before                     after
  q/gate/k/v grouped   136 blk  0.27 waves  26.7%   952 blk  1.87 waves  93.3%
  q/gate ungrouped     448 blk  0.88 waves  87.8%   (folded into the group)
  k/v ungrouped         28 blk  0.05 waves   5.5%   (folded into the group)
  ffn gate/up         1560 blk  3.06 waves  76.5%  1872 blk  3.67 waves  91.8%
  tail-wave waste over all launches   27.0%  ->  11.7%
```

### Correctness

Bit-identity is the claim, so it is checked rather than argued — `qwen3_gguf_prefill_check` fills
the KV over the same prompt and teacher-forces the same 64 continuation positions (bf16 KV), with
each toggle on and off:

```text
prefix=128  SPLITK=1 SUBSET=1 FFN=1   TOP1 59/64 0.9219   KL 0.03558
prefix=128  SPLITK=0 SUBSET=0 FFN=0   TOP1 59/64 0.9219   KL 0.03558
prefix=512  SPLITK=1 SUBSET=1 FFN=1   TOP1 60/64 0.9375   KL 0.00906
prefix=512  SPLITK=0 SUBSET=0 FFN=0   TOP1 60/64 0.9375   KL 0.00906
```

`ctest --test-dir build -E lmcache`: 11/11 passed (the lmcache pair blocks on an IPC sidecar absent
on this box and hangs on clean main too).

### Qwen3.6 no-regression guard

`prefill_moe_q.cu` is shared with the routed-MoE prefill, so both arms were built and swept in place
(ctx 0/512/4k/16k/32k, median-of-3). Max deviation 0.22%:

```text
ctx        decode  main -> PR        prefill pp  main -> PR
0          481.60 -> 481.82          -
512        476.03 -> 476.41          8060.4 -> 8082.5
4096       455.86 -> 456.09         22740.6 -> 22690.1
16384      457.49 -> 457.63         24848.6 -> 24843.7
32768      457.97 -> 458.07         26198.2 -> 26200.2
```
