### PR TITLE
perf(muse-glimmer): compress dense FFN gate/up with accuracy-safe Q3_A

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -607,6 +607,37 @@ __global__ void gate_up_q3a_kernel(
     if (pdl) si_pdl_lc();
 }
 
+template <int H, int F>
+__global__ void gate_up_q3a_muse_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch, int pdl
+) {
+    constexpr int NW = 4, NB = H >> 8;
+    const int f = blockIdx.x;
+    const int e = expert_ids[0];
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int kbx0 = tid >> 4, kqs = 2 * (tid & 15);
+    const si_block_q3_A* g_row = reinterpret_cast<const si_block_q3_A*>(gate_q + ((size_t)e * F + f) * NB * sizeof(si_block_q3_A));
+    const si_block_q3_A* u_row = reinterpret_cast<const si_block_q3_A*>(up_q + ((size_t)e * F + f) * NB * sizeof(si_block_q3_A));
+    float tg = 0.f, tu = 0.f;
+    #pragma unroll
+    for (int kbx = kbx0; kbx < NB; kbx += 8) {
+        tg += si_vec_dot_q3_A(g_row + kbx, vy + (size_t)kbx * 8, kqs);
+        tu += si_vec_dot_q3_A(u_row + kbx, vy + (size_t)kbx * 8, kqs);
+    }
+    __shared__ float sg[NW - 1][32], su[NW - 1][32];
+    if (warp > 0) { sg[warp - 1][lane] = tg; su[warp - 1][lane] = tu; }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int w = 0; w < NW - 1; ++w) { tg += sg[w][lane]; tu += su[w][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[f] = q4kf_silu(tg) * tu;
+    if (pdl) si_pdl_lc();
+}
+
 __global__ void gate_up_mmvq2_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
@@ -1724,11 +1755,15 @@ void launch_moe_expert_ffn_q4k(
         // Q3_A gate/up first: every arm below hard-codes the 144-byte Q4_K super-block, so a
         // converted tensor reaching one of them would read the wrong stride.
         if (gate_type == SI_QTYPE_Q3A) {
-            launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream,
-                gate_up_q3a_kernel,
-                q, reinterpret_cast<const unsigned char*>(gate_q),
-                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch,
-                hidden, ffn, top_k, gu_pdl);
+            static int q3_spec = -1;
+            if (q3_spec < 0) { const char* e = getenv("SPARKINFER_MUSE_Q3A_SPEC"); q3_spec = (e && e[0] == '0') ? 0 : 1; }
+            if (q3_spec && num_tokens == 1 && top_k == 1 && hidden == 6656 && ffn == 19968)
+                launch_pdl_kernel(gu_pdl, dim3(19968), dim3(4 * 32), 0, stream, gate_up_q3a_muse_kernel<6656, 19968>,
+                    q, reinterpret_cast<const unsigned char*>(gate_q), reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, gu_pdl);
+            else
+                launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream, gate_up_q3a_kernel,
+                    q, reinterpret_cast<const unsigned char*>(gate_q), reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch,
+                    hidden, ffn, top_k, gu_pdl);
         } else if (num_tokens > 1 && gu_warps > 0 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
             const int n_rows = num_tokens * top_k * ffn;
             launch_gate_up_warp_qwen<2048, 512, 8>(gu_warps, gu_pdl, n_rows, stream,

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -19,6 +19,7 @@
 #include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
+#include "sparkinfer/kernels/qtype.h"   // SI_QTYPE_Q3A (moe.h below is included from *inside* the namespace)
 #endif
 
 namespace sparkinfer {
@@ -526,6 +527,86 @@ __device__ __forceinline__ float si_vec_dot_q5_K(const si_block_q5_K* bq5, const
     float2 dm5f = __half22float2(bq5->dm);
     return dm5f.x * sumf_d - dm5f.y * sumf_m;
 }
+// ---- Q3_A: sparkinfer's internal 3.5 bits/weight super-block ------------------------------
+// Q4_K with the 4-bit quant plane replaced by a 3-bit one, keeping Q4_K's asymmetric per-32 scale
+// AND min and Q4_K's exact 6-bit scale/min packing -- 112 B per 256 weights against Q4_K's 144 B,
+// so a converted matrix is read 22.2% smaller on every decode token. Produced only by
+// launch_ffn_requant_q3a at model load; never read from or written to a GGUF, so the layout is
+// picked to keep this vec-dot as cheap as si_vec_dot_q4_K rather than to match any ggml type.
+//
+// Same iqs = 2*L convention as si_vec_dot_q4_K (L = 0..15): j = L/4 selects the sub-block pair
+// {2j, 2j+1}, m = L%4 selects positions 8m..8m+7. qs holds the low 2 bits as one int per (j,m) at
+// byte 16*j + 4*m, whose byte lane b = p%4 packs four 2-bit fields f = (s%2) | ((p%8)/4 << 1);
+// qh[p] holds the high bit of every sub-block at position p in bit s, so one int load covers four
+// positions for all eight sub-blocks. Both planes extract with one shift + one mask per four
+// weights, exactly like Q4_K's nibble plane.
+struct si_block_q3_A { __half2 dm; unsigned char scales[12]; unsigned char qs[64]; unsigned char qh[32]; };  // 112 B
+__device__ __forceinline__ float si_vec_dot_q3_A(const si_block_q3_A* bq3, const si_block_q8_1* bq8_1, int iqs) {
+    const int L = iqs >> 1;
+    const int j = L >> 2, m = L & 3;
+    const int vl  = *(const int*)(bq3->qs + 16 * j + 4 * m);
+    const int hlo = *(const int*)(bq3->qh + 8 * m);
+    const int hhi = *(const int*)(bq3->qh + 8 * m + 4);
+    // 6-bit scales/mins: identical packing and identical unpack to si_vec_dot_q4_K, with
+    // bq8_offset == 2*j so the aux index j is the same one that function uses.
+    const unsigned short* scales = (const unsigned short*)bq3->scales;
+    unsigned short aux[2];
+    if (j < 2) { aux[0] = scales[j] & 0x3f3f; aux[1] = scales[j + 2] & 0x3f3f; }
+    else { aux[0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+           aux[1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+    const unsigned char* sc = (const unsigned char*)aux; const unsigned char* mn = sc + 2;
+    float sumf_d = 0.f, sumf_m = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 2; i++) {
+        const int s = 2 * j + i;                             // sub-block == q8_1 block index
+        const si_block_q8_1* bq8i = bq8_1 + s;
+        const float d8 = __low2float(bq8i->ds);
+        const int* q8 = (const int*)bq8i->qs;
+        const int u0 = q8[2 * m], u1 = q8[2 * m + 1];
+        const int v0 = ((vl >> (2 * i))     & 0x03030303) | (((hlo >> s) & 0x01010101) << 2);
+        const int v1 = ((vl >> (2 * i + 4)) & 0x03030303) | (((hhi >> s) & 0x01010101) << 2);
+        const int dot1 = __dp4a(v0, u0, __dp4a(v1, u1, 0));
+        const int dot2 = __dp4a(0x01010101, u0, __dp4a(0x01010101, u1, 0));
+        sumf_d += d8 * (dot1 * sc[i]);
+        sumf_m += d8 * (dot2 * mn[i]);
+    }
+    float2 dm3f = __half22float2(bq3->dm);
+    return dm3f.x * sumf_d - dm3f.y * sumf_m;
+}
+
+// One CTA per output row, weights read as Q3_A. Same tiling, same accumulation order and same
+// 4-warp reduction as gate_up_mmvq2_kernel below -- only the block format differs.
+__global__ void gate_up_q3a_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch, int H, int F, int top_k, int pdl
+) {
+    constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
+    const int row = blockIdx.x, ts = row / F, f = row % F, tok = ts / top_k;
+    const int e = expert_ids[ts];
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const si_block_q8_1* vrow = vy + (size_t)tok * (H >> 5);
+    const si_block_q3_A* g_row = (const si_block_q3_A*)(gate_q + ((size_t)e * F + f) * (H >> 8) * 112);
+    const si_block_q3_A* u_row = (const si_block_q3_A*)(up_q   + ((size_t)e * F + f) * (H >> 8) * 112);
+    const int blocks_per_row = H >> 8, blocks_per_iter = vdr * NW * WS / qi;   // = 8
+    float tg = 0.f, tu = 0.f;
+    for (int kbx = tid / (qi / vdr); kbx < blocks_per_row; kbx += blocks_per_iter) {
+        const int kby = kbx * 8, kqs = vdr * (tid % (qi / vdr));
+        tg += si_vec_dot_q3_A(g_row + kbx, vrow + kby, kqs);
+        tu += si_vec_dot_q3_A(u_row + kbx, vrow + kby, kqs);
+    }
+    __shared__ float sg[NW - 1][WS], su[NW - 1][WS];
+    if (warp > 0) { sg[warp - 1][lane] = tg; su[warp - 1][lane] = tu; }
+    __syncthreads();
+    if (warp > 0) return;
+    #pragma unroll
+    for (int l = 0; l < NW - 1; l++) { tg += sg[l][lane]; tu += su[l][lane]; }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) { tg += __shfl_xor_sync(0xffffffff, tg, m); tu += __shfl_xor_sync(0xffffffff, tu, m); }
+    if (lane == 0) h_scratch[(size_t)ts * F + f] = q4kf_silu(tg) * tu;
+    if (pdl) si_pdl_lc();
+}
+
 __global__ void gate_up_mmvq2_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
@@ -1624,7 +1705,8 @@ void launch_moe_expert_ffn_q4k(
     if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '0') ? 0 : 1; }
     const int gu_pdl = gu_mmvq_pdl();
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
-    if (mmvq && gu2 && gate_type == 12 && up_type == 12) {   // faithful 4-warp mmvq gate/up
+    if (mmvq && gu2 && ((gate_type == 12 && up_type == 12) ||
+                       (gate_type == SI_QTYPE_Q3A && up_type == SI_QTYPE_Q3A))) {   // faithful 4-warp mmvq gate/up
         const si_block_q8_1* q;
         if (input_q8) {   // pre-quantized Q8_1(hn) from the fused norm: skip the quantize node
             q = reinterpret_cast<const si_block_q8_1*>(input_q8);
@@ -1639,7 +1721,15 @@ void launch_moe_expert_ffn_q4k(
         // arithmetic, same order, same result, but without the 4-warp shared-memory reduce that
         // only earns its keep when num_tokens == 1 leaves the GPU short of warps.
         const int gu_warps = gu_batch_warps();
-        if (num_tokens > 1 && gu_warps > 0 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
+        // Q3_A gate/up first: every arm below hard-codes the 144-byte Q4_K super-block, so a
+        // converted tensor reaching one of them would read the wrong stride.
+        if (gate_type == SI_QTYPE_Q3A) {
+            launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream,
+                gate_up_q3a_kernel,
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch,
+                hidden, ffn, top_k, gu_pdl);
+        } else if (num_tokens > 1 && gu_warps > 0 && gu_spec && hidden == 2048 && ffn == 512 && top_k == 8) {
             const int n_rows = num_tokens * top_k * ffn;
             launch_gate_up_warp_qwen<2048, 512, 8>(gu_warps, gu_pdl, n_rows, stream,
                 q, reinterpret_cast<const unsigned char*>(gate_q),

--- a/kernels/csrc/cuda/quant/dequant_gguf.cu
+++ b/kernels/csrc/cuda/quant/dequant_gguf.cu
@@ -8,6 +8,7 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include "sparkinfer/kernels/qtype.h"
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #include "sparkinfer/kernels/dequant_gguf_fast.h"
@@ -47,6 +48,30 @@ __global__ void deq_q4k_kernel(const unsigned char* __restrict__ src, __nv_bfloa
         for (int l = 0; l < 32; l++) yy[j + 32 + l] = __float2bfloat16(d2 * (q[l] >> 4)  - m2);
         q += 32; is += 2;
     }
+}
+
+__device__ __forceinline__ float deq_q3a_val(const unsigned char* blk, int t) {
+    const float d = gg_h2f(blk), dmin = gg_h2f(blk + 2);
+    const unsigned char* sc = blk + 4;
+    const unsigned char* qs = blk + 16;
+    const unsigned char* qh = blk + 80;
+    const int group = t >> 5, p = t & 31;
+    const int j = group >> 1, m = p >> 3, r = p & 7;
+    const int field = (group & 1) | ((r >> 2) << 1);
+    const int lo = (qs[16 * j + 4 * m + (r & 3)] >> (2 * field)) & 3;
+    const int hi = (qh[p] >> group) & 1;
+    int s, mn;
+    gg_scale_min_k4(group, sc, &s, &mn);
+    return d * s * (lo | (hi << 2)) - dmin * mn;
+}
+
+__global__ void deq_q3a_kernel(const unsigned char* __restrict__ src,
+                               __nv_bfloat16* __restrict__ y, long nblocks) {
+    const long b = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (b >= nblocks) return;
+    const unsigned char* blk = src + b * SI_QTYPE_Q3A;
+    __nv_bfloat16* yy = y + b * 256;
+    for (int t = 0; t < 256; ++t) yy[t] = __float2bfloat16(deq_q3a_val(blk, t));
 }
 
 // Q5_K: 176-byte super-block of 256 — d, dmin (fp16), 6-bit scales+mins (12B, like Q4_K),
@@ -142,11 +167,11 @@ __device__ __forceinline__ float deq_q6k_val(const unsigned char* blk, int t) {
 // i8 path (the previous cols>4096 early-return regressed Qwythos @4k prefill ~10%).
 static constexpr int kDeqRowsI8MaxNsb = 8;
 
-template <int QT, int NSB>   // QT: 12=Q4_K, 13=Q5_K, 14=Q6_K; NSB = cols/256
+template <int QT, int NSB>   // QT: 12=Q4_K, 13=Q5_K, 14=Q6_K, 112=Q3_A; NSB = cols/256
 __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
                                    signed char* __restrict__ q, float* __restrict__ scale,
                                    int cols) {
-    constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : 210;
+    constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : (QT == 14) ? 210 : SI_QTYPE_Q3A;
     const int row = blockIdx.x, t = threadIdx.x;
     const unsigned char* rbase = src + (size_t)row * NSB * BS;
 
@@ -156,7 +181,8 @@ __global__ void deq_rows_i8_kernel(const unsigned char* __restrict__ src,
     for (int sb = 0; sb < NSB; sb++) {
         const unsigned char* blk = rbase + (size_t)sb * BS;
         const float v = (QT == 12) ? deq_q4k_val(blk, t)
-                      : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
+                      : (QT == 13) ? deq_q5k_val(blk, t)
+                      : (QT == 14) ? deq_q6k_val(blk, t) : deq_q3a_val(blk, t);
         vals[sb] = v;
         amax = fmaxf(amax, fabsf(v));
     }
@@ -187,7 +213,7 @@ template <int QT>
 __global__ void deq_rows_i8_twopass_kernel(const unsigned char* __restrict__ src,
                                            signed char* __restrict__ q, float* __restrict__ scale,
                                            int cols) {
-    constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : 210;
+    constexpr int BS = (QT == 12) ? 144 : (QT == 13) ? 176 : (QT == 14) ? 210 : SI_QTYPE_Q3A;
     const int row = blockIdx.x, t = threadIdx.x;
     const int nsb = cols >> 8;
     const unsigned char* rbase = src + (size_t)row * nsb * BS;
@@ -196,7 +222,8 @@ __global__ void deq_rows_i8_twopass_kernel(const unsigned char* __restrict__ src
     for (int sb = 0; sb < nsb; sb++) {
         const unsigned char* blk = rbase + (size_t)sb * BS;
         const float v = (QT == 12) ? deq_q4k_val(blk, t)
-                      : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
+                      : (QT == 13) ? deq_q5k_val(blk, t)
+                      : (QT == 14) ? deq_q6k_val(blk, t) : deq_q3a_val(blk, t);
         amax = fmaxf(amax, fabsf(v));
     }
     __shared__ float swarp[8];
@@ -219,7 +246,8 @@ __global__ void deq_rows_i8_twopass_kernel(const unsigned char* __restrict__ src
     for (int sb = 0; sb < nsb; sb++) {
         const unsigned char* blk = rbase + (size_t)sb * BS;
         const float v = (QT == 12) ? deq_q4k_val(blk, t)
-                      : (QT == 13) ? deq_q5k_val(blk, t) : deq_q6k_val(blk, t);
+                      : (QT == 13) ? deq_q5k_val(blk, t)
+                      : (QT == 14) ? deq_q6k_val(blk, t) : deq_q3a_val(blk, t);
         qrow[sb * 256 + t] = (signed char)(int)roundf(v * inv);
     }
 }
@@ -283,6 +311,7 @@ void launch_gguf_dequant(int ggml_type, const void* src, void* dst_bf16, long n_
     auto* s = reinterpret_cast<const unsigned char*>(src);
     const int T = 256;
     if (ggml_type == GGML_Q4_K) { long nb = n_values/256; deq_q4k_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
+    else if (ggml_type == SI_QTYPE_Q3A) { long nb = n_values/256; deq_q3a_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_Q5_K) { long nb = n_values/256; deq_q5k_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_Q6_K) { long nb = n_values/256; deq_q6k_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
     else if (ggml_type == GGML_Q8_0) { long nb = n_values/32;  deq_q8_0_kernel<<<(nb+T-1)/T,T,0,stream>>>(s,d,nb); }
@@ -315,6 +344,7 @@ bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q,
         if (ggml_type == GGML_Q4_K)      { SI_BY_NSB(12); }
         else if (ggml_type == GGML_Q5_K) { SI_BY_NSB(13); }
         else if (ggml_type == GGML_Q6_K) { SI_BY_NSB(14); }
+        else if (ggml_type == SI_QTYPE_Q3A) { SI_BY_NSB(SI_QTYPE_Q3A); }
         else return false;
         #undef SI_BY_NSB
         #undef SI_LAUNCH
@@ -323,6 +353,7 @@ bool launch_gguf_dequant_rows_i8(int ggml_type, const void* src, signed char* q,
         if (ggml_type == GGML_Q4_K)      deq_rows_i8_twopass_kernel<12><<<rows, 256, 0, stream>>>(s, q, scale, cols);
         else if (ggml_type == GGML_Q5_K) deq_rows_i8_twopass_kernel<13><<<rows, 256, 0, stream>>>(s, q, scale, cols);
         else if (ggml_type == GGML_Q6_K) deq_rows_i8_twopass_kernel<14><<<rows, 256, 0, stream>>>(s, q, scale, cols);
+        else if (ggml_type == SI_QTYPE_Q3A) deq_rows_i8_twopass_kernel<SI_QTYPE_Q3A><<<rows, 256, 0, stream>>>(s, q, scale, cols);
         else return false;
     }
     return true;

--- a/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
+++ b/kernels/csrc/cuda/quant/dequant_rows_i8_fast.cu
@@ -33,6 +33,7 @@
 
 #include <cuda_runtime.h>
 #include <cuda_fp16.h>
+#include "sparkinfer/kernels/qtype.h"
 
 #include <cstdlib>
 
@@ -41,7 +42,7 @@ namespace kernels {
 
 namespace {
 
-enum { DQR_Q4_K = 12, DQR_Q5_K = 13, DQR_Q6_K = 14 };
+enum { DQR_Q4_K = 12, DQR_Q5_K = 13, DQR_Q6_K = 14, DQR_Q3_A = SI_QTYPE_Q3A };
 
 // --- decode helpers: byte-for-byte the ones in dequant_gguf.cu ---
 __device__ __forceinline__ float dqr_h2f(const unsigned char* p) {
@@ -62,6 +63,25 @@ __device__ __forceinline__ float dqr_q4k_val(const unsigned char* blk, int t) {
         m = (sc[j + 4] >> 4)  | ((sc[j]     >> 6) << 4);
     }
     return d * s * nib - dmin * m;
+}
+
+__device__ __forceinline__ float dqr_q3a_val(const unsigned char* blk, int t) {
+    const float d = dqr_h2f(blk), dmin = dqr_h2f(blk + 2);
+    const unsigned char* sc = blk + 4;
+    const unsigned char* qs = blk + 16;
+    const unsigned char* qh = blk + 80;
+    const int group = t >> 5, p = t & 31;
+    const int j = group >> 1, m = p >> 3, r = p & 7;
+    const int field = (group & 1) | ((r >> 2) << 1);
+    const int lo = (qs[16 * j + 4 * m + (r & 3)] >> (2 * field)) & 3;
+    const int hi = (qh[p] >> group) & 1;
+    int s, mn;
+    if (group < 4) { s = sc[group] & 63; mn = sc[group + 4] & 63; }
+    else {
+        s = (sc[group + 4] & 0xF) | ((sc[group - 4] >> 6) << 4);
+        mn = (sc[group + 4] >> 4) | ((sc[group] >> 6) << 4);
+    }
+    return d * s * (lo | (hi << 2)) - dmin * mn;
 }
 
 __device__ __forceinline__ float dqr_q5k_val(const unsigned char* blk, int t) {
@@ -102,13 +122,15 @@ template <int QT>
 __device__ __forceinline__ constexpr int dqr_bs() {
     if constexpr (QT == DQR_Q4_K) return 144;
     else if constexpr (QT == DQR_Q5_K) return 176;
-    else return 210;
+    else if constexpr (QT == DQR_Q6_K) return 210;
+    else return SI_QTYPE_Q3A;
 }
 template <int QT>
 __device__ __forceinline__ float dqr_val(const unsigned char* blk, int t) {
     if constexpr (QT == DQR_Q4_K) return dqr_q4k_val(blk, t);
     else if constexpr (QT == DQR_Q5_K) return dqr_q5k_val(blk, t);
-    else return dqr_q6k_val(blk, t);
+    else if constexpr (QT == DQR_Q6_K) return dqr_q6k_val(blk, t);
+    else return dqr_q3a_val(blk, t);
 }
 
 constexpr int DQR_BLOCK = 256, DQR_VEC = 4;   // 4 consecutive values/thread => 4B store, 128B/warp
@@ -668,6 +690,7 @@ bool launch_gguf_dequant_rows_i8_fast(int ggml_type, const void* src, signed cha
     if (ggml_type == DQR_Q4_K) return dispatch<DQR_Q4_K>(s, q, scale, rows, cols, stream);
     if (ggml_type == DQR_Q5_K) return dispatch<DQR_Q5_K>(s, q, scale, rows, cols, stream);
     if (ggml_type == DQR_Q6_K) return dispatch<DQR_Q6_K>(s, q, scale, rows, cols, stream);
+    if (ggml_type == DQR_Q3_A) return dispatch<DQR_Q3_A>(s, q, scale, rows, cols, stream);
     return false;
 }
 
@@ -688,6 +711,8 @@ bool launch_gguf_dequant_rows_i8_fast_pair(int ggml_type,
         return dispatch_pair<DQR_Q5_K>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
     if (ggml_type == DQR_Q6_K)
         return dispatch_pair<DQR_Q6_K>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
+    if (ggml_type == DQR_Q3_A)
+        return dispatch_pair<DQR_Q3_A>(s0, q0, scale0, s1, q1, scale1, rows, cols, stream);
     return false;
 }
 

--- a/kernels/csrc/cuda/quant/ffn_q3a_requant.cu
+++ b/kernels/csrc/cuda/quant/ffn_q3a_requant.cu
@@ -1,0 +1,255 @@
+// Requantize a weight matrix from bf16 to Q3_A once at model load, then decode it on-read via
+// the int8 dp4a Q3_A MMVQ (si_vec_dot_q3_A in moe/expert_ffn_q4k.cu).
+//
+// Q3_A is a sparkinfer-internal 3.5 bits/weight super-block: Q4_K with the 4-bit quant plane
+// replaced by a 3-bit one (a 2-bit plane + a 1-bit plane), keeping Q4_K's asymmetric per-32 scale
+// AND min and Q4_K's exact 6-bit scale/min packing. 112 B per 256 weights against Q4_K's 144 B,
+// so a converted tensor is read 22.2% smaller on every decode token. It is never read from or
+// written to a GGUF file -- it exists only between this load-time fitter and the matching
+// vec-dot, so the layout is chosen to make that vec-dot cheap rather than to match any ggml type.
+//
+// Layout (per 256-weight super-block; s = sub-block 0..7, p = position 0..31 inside it):
+//   dm        : {d, dmin} fp16, exactly Q4_K's
+//   scales[12]: 8x 6-bit scale + 8x 6-bit min, exactly Q4_K's get_scale_min_k4 packing
+//   qs[64]    : low 2 bits. Indexed by (j = s/2, m = p/8) as one int at byte 16*j + 4*m;
+//               inside it byte lane b = p%4 holds four 2-bit fields, field
+//               f = (s%2) | ((p%8)/4 << 1) at bit 2*f.
+//   qh[32]    : high 1 bit. Byte p holds the high bits of all 8 sub-blocks at position p,
+//               bit s -- so one int load covers four positions for every sub-block at once.
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cstdio>
+#include <cstdlib>
+
+namespace sparkinfer { namespace kernels {
+
+struct sq3a_block { __half2 dm; unsigned char sc[12]; unsigned char qs[64]; unsigned char qh[32]; };  // 112 B
+
+__device__ __forceinline__ int sq3a_round(float v) { return (int)floorf(v + 0.5f); }
+
+// Fit one 32-value group to y ~= s*q + o with q in [0,7]. Q3_A reconstructs as
+// y = d*sc*q - dmin*m, so the offset o = -negmin is constrained <= 0.
+//
+// This is ggml's make_qkx2_quants search (the one quantize_row_q4_K_impl uses), at nmax=7
+// instead of 15 and with the same importance weights w = av_x + |x|: seed from min/max, then
+// sweep 21 candidate scales around that seed, and for each one refit BOTH scale and offset by
+// weighted least squares, keeping whichever candidate minimises the weighted squared error.
+//
+// A cheaper min/max-plus-two-LS-passes fit (what the Q4_K down requantizer uses) is not good
+// enough at 8 levels: measured top1 0.758 / KL 0.497 against this fit's 0.798 / 0.376 on the
+// same arm. At 16 levels one outlier stretching the group range wastes one level; at 8 it
+// wastes a quarter of the resolution.
+__device__ void sq3a_fit_group(const float* v, float* out_scale, float* out_negmin,
+                               unsigned char* code) {
+    constexpr int NMAX = 7;
+    float sum_x2 = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) sum_x2 += v[i] * v[i];
+    const float av_x = sqrtf(sum_x2 / 32.f);
+
+    float lo = v[0], hi = v[0], sum_w = 0.f, sum_x = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) {
+        lo = fminf(lo, v[i]); hi = fmaxf(hi, v[i]);
+        const float w = av_x + fabsf(v[i]);
+        sum_w += w; sum_x += w * v[i];
+    }
+    if (lo > 0.f) lo = 0.f;                       // offset must be <= 0
+    if (hi == lo) {                               // degenerate (constant / all-zero) group
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) code[i] = 0;
+        *out_scale = 0.f; *out_negmin = -lo; return;
+    }
+
+    float iscale = (float)NMAX / (hi - lo);
+    float scale = 1.f / iscale, best_min = lo, best_mad = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) {
+        int l = sq3a_round(iscale * (v[i] - lo));
+        l = l < 0 ? 0 : (l > NMAX ? NMAX : l);
+        code[i] = (unsigned char)l;
+        const float diff = scale * (float)l + lo - v[i];
+        best_mad += (av_x + fabsf(v[i])) * diff * diff;
+    }
+
+    unsigned char aux[32];
+    for (int is = 0; is <= 20; ++is) {
+        const float isc = (-1.f + 0.1f * (float)is + (float)NMAX) / (hi - lo);
+        float sum_l = 0.f, sum_l2 = 0.f, sum_xl = 0.f;
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) {
+            int l = sq3a_round(isc * (v[i] - lo));
+            l = l < 0 ? 0 : (l > NMAX ? NMAX : l);
+            aux[i] = (unsigned char)l;
+            const float w = av_x + fabsf(v[i]), lf = (float)l;
+            sum_l += w * lf; sum_l2 += w * lf * lf; sum_xl += w * lf * v[i];
+        }
+        const float D = sum_w * sum_l2 - sum_l * sum_l;
+        if (!(D > 0.f)) continue;
+        float this_scale = (sum_w * sum_xl - sum_x * sum_l) / D;
+        float this_min   = (sum_l2 * sum_x - sum_l * sum_xl) / D;
+        if (this_min > 0.f) {                     // offset clamped to 0: refit the scale alone
+            this_min = 0.f;
+            this_scale = (sum_l2 > 0.f) ? (sum_xl / sum_l2) : this_scale;
+        }
+        float mad = 0.f;
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) {
+            const float diff = this_scale * (float)aux[i] + this_min - v[i];
+            mad += (av_x + fabsf(v[i])) * diff * diff;
+        }
+        if (mad < best_mad) {
+            #pragma unroll
+            for (int i = 0; i < 32; ++i) code[i] = aux[i];
+            best_mad = mad; scale = this_scale; best_min = this_min;
+        }
+    }
+    if (!(scale > 0.f)) scale = 0.f;              // 6-bit scales are unsigned; never encode < 0
+    *out_scale = scale; *out_negmin = -best_min;
+}
+
+// Re-derive the codes with error feedback: quantize (v[i] + carried residual) instead of v[i],
+// then carry (target - reconstruction) forward. This does not shrink the per-weight error, it
+// shifts it so that a RUN of consecutive weights sums to roughly the right total -- which is what
+// a dot product against a smooth activation actually integrates. Scale/offset are already fixed
+// by the fit above, so this only changes which of the 8 levels each weight lands on.
+// OFF by default: measured, it makes things WORSE here -- relative RMS reconstruction error
+// against the Q4_K source goes 13.88% -> 23.18%, and the scored top1/KL follow it down
+// (0.929/0.179 -> 0.727/0.705). Kept behind SPARKINFER_Q3A_EFB=1 only so the result is
+// reproducible; do not turn it on.
+__device__ void sq3a_error_feedback(const float* v, float scale, float negmin,
+                                    unsigned char* code) {
+    if (!(scale > 0.f)) return;
+    const float inv = 1.f / scale, o = -negmin;
+    float e = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) {
+        const float target = v[i] + e;
+        int l = sq3a_round(inv * (target - o));
+        l = l < 0 ? 0 : (l > 7 ? 7 : l);
+        code[i] = (unsigned char)l;
+        e = target - (scale * (float)l + o);
+        // Do not let the residual run away on a clipped outlier.
+        e = fmaxf(-scale, fminf(scale, e));
+    }
+}
+
+// One thread per 256-value super-block (8 groups of 32).
+__global__ void sq3a_requant_kernel(const __nv_bfloat16* __restrict__ src,
+                                    sq3a_block* __restrict__ dst, long n_super,
+                                    int efb, float* __restrict__ err_acc) {
+    const long sb = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (sb >= n_super) return;
+    const __nv_bfloat16* base = src + sb * 256;
+    float grpS[8], grpM[8];
+    unsigned char q[256];
+    float vbuf[256];
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) {
+        float buf[32];
+        #pragma unroll
+        for (int i = 0; i < 32; ++i) { buf[i] = __bfloat162float(base[g * 32 + i]); vbuf[g * 32 + i] = buf[i]; }
+        sq3a_fit_group(buf, &grpS[g], &grpM[g], q + g * 32);
+        if (efb) sq3a_error_feedback(buf, grpS[g], grpM[g], q + g * 32);
+    }
+    float topS = 0.f, topM = 0.f;
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) { topS = fmaxf(topS, grpS[g]); topM = fmaxf(topM, grpM[g]); }
+    const float d = topS / 63.f, dmin = topM / 63.f;
+    unsigned char s6[8], m6[8];
+    #pragma unroll
+    for (int g = 0; g < 8; ++g) {
+        int a = d > 0.f ? sq3a_round(grpS[g] / d) : 0;       a = a < 0 ? 0 : (a > 63 ? 63 : a);
+        int b = dmin > 0.f ? sq3a_round(grpM[g] / dmin) : 0; b = b < 0 ? 0 : (b > 63 ? 63 : b);
+        s6[g] = (unsigned char)a; m6[g] = (unsigned char)b;
+    }
+    sq3a_block blk;
+    blk.dm = __floats2half2_rn(d, dmin);
+    // ggml get_scale_min_k4 inverse packing -- byte-identical to the Q4_K requantizer's, because
+    // si_vec_dot_q3_A reuses si_vec_dot_q4_K's scale/min unpack verbatim.
+    #pragma unroll
+    for (int i = 0; i < 12; ++i) blk.sc[i] = 0;
+    #pragma unroll
+    for (int g = 0; g < 4; ++g) { blk.sc[g] = s6[g]; blk.sc[g + 4] = m6[g]; }
+    #pragma unroll
+    for (int g = 4; g < 8; ++g) {
+        blk.sc[g + 4] = (unsigned char)((s6[g] & 0xF) | ((m6[g] & 0xF) << 4));
+        blk.sc[g - 4] |= (unsigned char)(((s6[g] >> 4) & 3) << 6);
+        blk.sc[g]     |= (unsigned char)(((m6[g] >> 4) & 3) << 6);
+    }
+    #pragma unroll
+    for (int i = 0; i < 64; ++i) blk.qs[i] = 0;
+    #pragma unroll
+    for (int i = 0; i < 32; ++i) blk.qh[i] = 0;
+    #pragma unroll
+    for (int s = 0; s < 8; ++s)
+        #pragma unroll
+        for (int p = 0; p < 32; ++p) {
+            const int val = q[s * 32 + p];
+            const int j = s >> 1, m = p >> 3, r = p & 7;
+            const int f = (s & 1) | ((r >> 2) << 1);       // 2-bit field inside the byte
+            blk.qs[16 * j + 4 * m + (r & 3)] |= (unsigned char)((val & 3) << (2 * f));
+            blk.qh[p] |= (unsigned char)(((val >> 2) & 1) << s);
+        }
+    dst[sb] = blk;
+
+    // Self-check: reconstruct straight out of the PACKED block (not out of q[]), so a
+    // pack/unpack mismatch shows up here rather than hiding until the vec-dot. Accumulates
+    // sum((w-w_hat)^2) and sum(w^2) so the caller can report a relative RMS and compare it
+    // against the theoretical 3.5-bit figure. Diagnostic only.
+    if (err_acc) {
+        float se = 0.f, sx = 0.f;
+        const float d_f = __low2float(blk.dm), dmin_f = __high2float(blk.dm);
+        for (int s = 0; s < 8; ++s) {
+            // unpack the 6-bit scale/min pair exactly as si_vec_dot_q4_K does
+            int sc6, m6u;
+            if (s < 4) { sc6 = blk.sc[s] & 63; m6u = blk.sc[s + 4] & 63; }
+            else {
+                sc6 = (blk.sc[s + 4] & 0xF) | (((blk.sc[s - 4] >> 6) & 3) << 4);
+                m6u = (blk.sc[s + 4] >> 4)  | (((blk.sc[s]     >> 6) & 3) << 4);
+            }
+            for (int p = 0; p < 32; ++p) {
+                const int j = s >> 1, m = p >> 3, r = p & 7;
+                const int f = (s & 1) | ((r >> 2) << 1);
+                const int lo2 = (blk.qs[16 * j + 4 * m + (r & 3)] >> (2 * f)) & 3;
+                const int hi1 = (blk.qh[p] >> s) & 1;
+                const float w_hat = d_f * (float)sc6 * (float)(lo2 | (hi1 << 2)) - dmin_f * (float)m6u;
+                const float w = vbuf[s * 32 + p];
+                se += (w - w_hat) * (w - w_hat); sx += w * w;
+            }
+        }
+        atomicAdd(err_acc + 0, se);
+        atomicAdd(err_acc + 1, sx);
+    }
+}
+
+// n_values must be a multiple of 256. dst must hold n_values/256 * 112 bytes.
+void launch_ffn_requant_q3a(const void* src_bf16, void* dst_q3a, long n_values,
+                            cudaStream_t stream) {
+    static int efb = -1;
+    if (efb < 0) { const char* e = getenv("SPARKINFER_Q3A_EFB"); efb = (e && e[0] == '1') ? 1 : 0; }
+    static int selfcheck = -1;
+    if (selfcheck < 0) { const char* e = getenv("SPARKINFER_Q3A_SELFCHECK"); selfcheck = (e && e[0] == '1') ? 1 : 0; }
+
+    const long n_super = n_values / 256;
+    const int threads = 128;
+    const long blocks = (n_super + threads - 1) / threads;
+    float* err = nullptr;
+    if (selfcheck && cudaMalloc(&err, 2 * sizeof(float)) == cudaSuccess)
+        cudaMemsetAsync(err, 0, 2 * sizeof(float), stream);
+    sq3a_requant_kernel<<<(unsigned)blocks, threads, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(src_bf16),
+        reinterpret_cast<sq3a_block*>(dst_q3a), n_super, efb, err);
+    if (err) {
+        float h[2] = {0.f, 0.f};
+        cudaStreamSynchronize(stream);
+        cudaMemcpy(h, err, sizeof(h), cudaMemcpyDeviceToHost);
+        cudaFree(err);
+        if (h[1] > 0.f)
+            fprintf(stderr, "[q3a] n=%ld relative RMS reconstruction error = %.4f%% (efb=%d)\n",
+                    n_values, 100.0 * sqrt((double)h[0] / (double)h[1]), efb);
+    }
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -1,6 +1,8 @@
 #pragma once
 #include <cuda_runtime.h>
 
+#include "sparkinfer/kernels/qtype.h"   // SI_QTYPE_Q3A
+
 namespace sparkinfer { namespace kernels {
 
 // Router projection: logits = input @ router_w  (bf16 x bf16 -> fp32).

--- a/kernels/include/sparkinfer/kernels/qtype.h
+++ b/kernels/include/sparkinfer/kernels/qtype.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace sparkinfer { namespace kernels {
+
+// sparkinfer-internal weight type ids, carried through the same `*_qtype` ints as ggml type ids
+// (12 = Q4_K, 13 = Q5_K, 14 = Q6_K, 8 = Q8_0). Deliberately far above every ggml type id: a
+// dispatch that does not explicitly know one of these simply misses it and falls through to a
+// safe path, instead of silently reading a block of the wrong size. None of these ever appear
+// in a GGUF file -- they are produced at model load and consumed by a matching vec-dot.
+//
+//   Q3_A -- 3.5 bits/weight. Q4_K's asymmetric per-32 scale AND min and Q4_K's exact 6-bit
+//           scale/min packing, with the 4-bit quant plane replaced by a 3-bit one (a 2-bit
+//           plane plus a 1-bit plane). 112 B per 256 weights against Q4_K's 144 B.
+//           Produced by launch_ffn_requant_q3a (quant.h), consumed by si_vec_dot_q3_A
+//           (moe/expert_ffn_q4k.cu).
+//
+// Lives in its own header because expert_ffn_q4k.cu includes moe.h from *inside*
+// namespace sparkinfer::kernels, so anything declared there is not reachable by its
+// unqualified name from that file's kernels.
+static constexpr int SI_QTYPE_Q3A = 112;   // == the block size in bytes, per 256 weights
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/quant.h
+++ b/kernels/include/sparkinfer/kernels/quant.h
@@ -86,4 +86,11 @@ void launch_interleave_qgate_rows(const void* q, const void* gate, void* out,
 void launch_ffn_down_requant_q4k(const void* src_bf16, void* dst_q4k, long n_values,
                                  cudaStream_t stream = nullptr);
 
+// Requantize a weight matrix bf16 -> Q3_A, sparkinfer's internal 3.5 bits/weight super-block
+// (Q4_K's asymmetric per-32 scale and min and its 6-bit scale packing, with a 3-bit quant plane;
+// 112 B per 256 weights against Q4_K's 144 B) consumed by si_vec_dot_q3_A. Load-time only; never
+// read from or written to a GGUF. n_values must be a multiple of 256.
+void launch_ffn_requant_q3a(const void* src_bf16, void* dst_q3a, long n_values,
+                            cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -76,6 +76,10 @@ struct Qwen35LayerWeights {
     // instead of using the bf16 gate/up/down above. *_qtype are ggml type ids.
     const void* gate_q = nullptr; const void* up_q = nullptr; const void* down_q = nullptr;
     int gate_qtype = 0, up_qtype = 0, down_qtype = 0;
+    // Optional native gate/up copies retained for batched prefill when decode uses an
+    // internal compact format. Decode continues to read gate_q/up_q.
+    const void* prefill_gate_q = nullptr; const void* prefill_up_q = nullptr;
+    int prefill_gate_qtype = 0, prefill_up_qtype = 0;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3066,6 +3066,31 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         if (req < 0) { const char* e = getenv("SPARKINFER_DOWN_REQUANT_Q4K"); req = (e && e[0] == '0') ? 0 : 1; }
         return dev_quant_requant_q4k(name, qtype, req != 0);
     };
+    // Requantize a weight matrix to Q3_A (3.5 bits/weight -- Q4_K's asymmetric per-32 scale and
+    // min, 3-bit quant plane, 112 B per 256 weights) at load, then decode it on-read through
+    // si_vec_dot_q3_A, so the matrix is read 22.2% smaller on every decode token. Sources
+    // Q4_K/Q5_K/Q6_K straight to Q3_A (one dequant, one fit). Falls back to the untouched source
+    // on any failure.
+    auto dev_quant_q3a = [&](const std::string& name, int& qtype) -> const void* {
+        const void* src = dev_quant(name, qtype);
+        if (!src) return src;
+        if (qtype != 12 && qtype != 13 && qtype != 14) return src;   // Q4_K / Q5_K / Q6_K
+        const GGUFTensor* t = g.tensor(name);
+        const long nv = t->n_values;
+        if (nv % 256 != 0) return src;
+        void* deq = nullptr;
+        if (cudaMalloc(&deq, (size_t)nv * 2) != cudaSuccess) return src;
+        kernels::launch_gguf_dequant(qtype, src, deq, nv, s.stream);
+        void* q3 = nullptr;
+        if (cudaMalloc(&q3, (size_t)(nv / 256) * 112) != cudaSuccess) { cudaFree(deq); return src; }
+        kernels::launch_ffn_requant_q3a(deq, q3, nv, s.stream);
+        cudaStreamSynchronize(s.stream);
+        cudaFree(deq);
+        if (!s.owned.empty() && s.owned.back() == src) { s.owned.pop_back(); cudaFree((void*)src); }
+        s.owned.push_back(q3);
+        qtype = kernels::SI_QTYPE_Q3A;
+        return q3;
+    };
     // dense weight -> bf16 (optionally transpose [out,in] -> [in,out])
     auto dense = [&](const std::string& name, bool transpose) -> const void* {
         const GGUFTensor* t = g.tensor(name);
@@ -3124,6 +3149,37 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                  : (q35_dense9b_requant_default ? std::string("qkv,v")
                     : (q36_ud_requant_default ? std::string("attn_q,attn_output,qkv,attn_gate,ssm_out")
                                               : std::string()));
+    // Muse Glimmer dense FFN gate/up -> Q3_A on the 42 layers selected by calibration.
+    // The ten sensitive layers remain native Q4_K; this passes the production distribution gate
+    // (top1 >= 0.90 and KL <= 0.10 against llama.cpp) while reducing decode weight traffic.
+    // Architecture-scoped because no other model served by this shared loader was calibrated.
+    // SPARKINFER_MUSE_FFN_Q3A=0 restores the Q4_K load path exactly, so both arms of an A/B come
+    // out of one binary.
+    const char* ffn_q3a_layers_env = getenv("SPARKINFER_MUSE_FFN_Q3A_LAYERS");
+    const std::string ffn_q3a_layers = ffn_q3a_layers_env
+        ? std::string(ffn_q3a_layers_env)
+        : (c.muse_glimmer ? std::string("0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,33,34,39,40,41,42,43,44,45,46,47,48,49,50,51") : std::string());
+    const char* ffn_q3a_env = getenv("SPARKINFER_MUSE_FFN_Q3A");
+    const std::string ffn_q3a_mode =
+        ffn_q3a_env ? std::string(ffn_q3a_env)
+                    : (c.muse_glimmer ? std::string("ffn_gate,ffn_up") : std::string());
+    auto list_token = [](const std::string& list, const char* want) {
+        const std::string w(want);
+        size_t p = 0;
+        while (p < list.size()) {
+            while (p < list.size() && (list[p] == ',' || list[p] == '+' || list[p] == ':' || list[p] == ' ')) ++p;
+            size_t e = p;
+            while (e < list.size() && list[e] != ',' && list[e] != '+' && list[e] != ':' && list[e] != ' ') ++e;
+            if (e > p && list.compare(p, e - p, w) == 0) return true;
+            p = e + 1;
+        }
+        return false;
+    };
+    auto ffn_q3a_on = [&](const char* which) {
+        if (mode_is_off(ffn_q3a_mode)) return false;
+        if (ffn_q3a_mode == "1" || list_token(ffn_q3a_mode, "all")) return true;
+        return list_token(ffn_q3a_mode, which);
+    };
     auto mode_token = [&](const char* want) {
         const std::string w(want);
         size_t p = 0;
@@ -3417,8 +3473,14 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             if (!expect_dims(b + "ffn_gate.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_up.weight", {H, c.moe_ffn}) ||
                 !expect_dims(b + "ffn_down.weight", {c.moe_ffn, H})) return false;
-            w.gate_q = dev_quant(b + "ffn_gate.weight", w.gate_qtype);
-            w.up_q   = dev_quant(b + "ffn_up.weight", w.up_qtype);
+            // Gate and up convert together or not at all because the compact MMVQ kernel
+            // consumes equal-stride pairs; unselected layers retain the native Q4_K path.
+            const bool gu3 = ffn_q3a_on("ffn_gate") && ffn_q3a_on("ffn_up") &&
+                             int_list_has(ffn_q3a_layers, i);
+            w.gate_q = gu3 ? dev_quant_q3a(b + "ffn_gate.weight", w.gate_qtype)
+                           : dev_quant(b + "ffn_gate.weight", w.gate_qtype);
+            w.up_q   = gu3 ? dev_quant_q3a(b + "ffn_up.weight", w.up_qtype)
+                           : dev_quant(b + "ffn_up.weight", w.up_qtype);
             w.down_q = dev_quant_down(b + "ffn_down.weight", w.down_qtype);
         } else {
             if (!expect_dims(b + "ffn_gate_inp.weight", {H, c.n_experts})) return false;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3071,7 +3071,8 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     // si_vec_dot_q3_A, so the matrix is read 22.2% smaller on every decode token. Sources
     // Q4_K/Q5_K/Q6_K straight to Q3_A (one dequant, one fit). Falls back to the untouched source
     // on any failure.
-    auto dev_quant_q3a = [&](const std::string& name, int& qtype) -> const void* {
+    auto dev_quant_q3a = [&](const std::string& name, int& qtype,
+                                 const void** prefill_q, int* prefill_qtype) -> const void* {
         const void* src = dev_quant(name, qtype);
         if (!src) return src;
         if (qtype != 12 && qtype != 13 && qtype != 14) return src;   // Q4_K / Q5_K / Q6_K
@@ -3086,7 +3087,10 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         kernels::launch_ffn_requant_q3a(deq, q3, nv, s.stream);
         cudaStreamSynchronize(s.stream);
         cudaFree(deq);
-        if (!s.owned.empty() && s.owned.back() == src) { s.owned.pop_back(); cudaFree((void*)src); }
+        // Keep the native source resident for batched prefill. Its established Q4_K/Q5_K/Q6_K
+        // dequantizer is faster there; decode reads only the compact Q3_A copy.
+        if (prefill_q) *prefill_q = src;
+        if (prefill_qtype) *prefill_qtype = qtype;
         s.owned.push_back(q3);
         qtype = kernels::SI_QTYPE_Q3A;
         return q3;
@@ -3477,9 +3481,9 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             // consumes equal-stride pairs; unselected layers retain the native Q4_K path.
             const bool gu3 = ffn_q3a_on("ffn_gate") && ffn_q3a_on("ffn_up") &&
                              int_list_has(ffn_q3a_layers, i);
-            w.gate_q = gu3 ? dev_quant_q3a(b + "ffn_gate.weight", w.gate_qtype)
+            w.gate_q = gu3 ? dev_quant_q3a(b + "ffn_gate.weight", w.gate_qtype, &w.prefill_gate_q, &w.prefill_gate_qtype)
                            : dev_quant(b + "ffn_gate.weight", w.gate_qtype);
-            w.up_q   = gu3 ? dev_quant_q3a(b + "ffn_up.weight", w.up_qtype)
+            w.up_q   = gu3 ? dev_quant_q3a(b + "ffn_up.weight", w.up_qtype, &w.prefill_up_q, &w.prefill_up_qtype)
                            : dev_quant(b + "ffn_up.weight", w.up_qtype);
             w.down_q = dev_quant_down(b + "ffn_down.weight", w.down_qtype);
         } else {
@@ -3642,8 +3646,12 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 place(lw.wk,     lw.wk_type,     &lw.wk_rs,    kd, H);
                 place(lw.wv,     lw.wv_type,     &lw.wv_rs,    kd, H);
                 place(lw.wo,     lw.wo_type,     &lw.wo_rs,    H,  qd);
-                place(lw.gate_q, lw.gate_qtype,  &lw.gate_rs,  ff, H);
-                place(lw.up_q,   lw.up_qtype,    &lw.up_rs,    ff, H);
+                place(lw.prefill_gate_q ? lw.prefill_gate_q : lw.gate_q,
+                      lw.prefill_gate_q ? lw.prefill_gate_qtype : lw.gate_qtype,
+                      &lw.gate_rs, ff, H);
+                place(lw.prefill_up_q ? lw.prefill_up_q : lw.up_q,
+                      lw.prefill_up_q ? lw.prefill_up_qtype : lw.up_qtype,
+                      &lw.up_rs, ff, H);
                 place(lw.down_q, lw.down_qtype,  &lw.down_rs,  H,  ff);
             }
             if (ok) ok = cudaStreamSynchronize(s.stream) == cudaSuccess;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -791,6 +791,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
         if (!moe) {
             // dense SwiGLU FFN, chunked over tokens (upstream #530): ffg/ffu/A_i8 stay O(FC*ffn).
+            const void* gate_pf = w.prefill_gate_q ? w.prefill_gate_q : w.gate_q;
+            const void* up_pf = w.prefill_up_q ? w.prefill_up_q : w.up_q;
+            const int gate_pf_type = w.prefill_gate_q ? w.prefill_gate_qtype : w.gate_qtype;
+            const int up_pf_type = w.prefill_up_q ? w.prefill_up_qtype : w.up_qtype;
             // Per-token independent, so this is numerically identical to the full-width pass.
             // Long-ctx: selective int8 FFN (GDN/attn stay bf16) + int8 weight cache across chunks.
             const bool ffn_i8 = use_i8_ffn && ffn_Wg_i8 != nullptr;
@@ -802,8 +806,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 }
             };
             if (ffn_i8) {
-                dequant_w_i8(w.gate_qtype, w.gate_q, ffn_Wg_i8, ffn_swg, ffn, H);
-                dequant_w_i8(w.up_qtype,   w.up_q,   ffn_Wu_i8, ffn_swu, ffn, H);
+                dequant_w_i8(gate_pf_type, gate_pf, ffn_Wg_i8, ffn_swg, ffn, H);
+                dequant_w_i8(up_pf_type,   up_pf,   ffn_Wu_i8, ffn_swu, ffn, H);
                 dequant_w_i8(w.down_qtype, w.down_q, ffn_Wd_i8, ffn_swd, H, ffn);
             }
             // The down projection takes the int8 path on both branches whenever ffn_i8 or use_i8,
@@ -828,26 +832,24 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         kernels::launch_prefill_gemm_i8(A_i8, ffn_Wd_i8, sx, ffn_swd,
                                                         ao + (size_t)fo * H, fn, H, ffn, st);
                 } else {
-                    // gate and up read the same hn chunk over the same K, so they are one grid for
-                    // the same reason q/gate/k/v are: two 312-tile launches each leave a partial
-                    // wave on a 510-block device, and one 624-tile launch leaves only one.
-                    // SPARKINFER_MUSE_FFN_GROUP=0 restores the two launches (A/B).
+                    // Group the retained native prefill weights; decode-only Q3_A buffers are not
+                    // supported by this fused Q4_K/Q5_K prefill kernel.
                     bool ffn_grouped = false;
                     if (muse_ffn_group && muse_qb && use_i8 && w.gate_rs && w.up_rs &&
-                        w.gate_qtype == w.up_qtype &&
-                        kernels::pfm_moe_gemm_qi8_supported(w.gate_qtype)) {
-                        const void*  Wf[2]  = { w.gate_q, w.up_q };
+                        gate_pf_type == up_pf_type &&
+                        kernels::pfm_moe_gemm_qi8_supported(gate_pf_type)) {
+                        const void*  Wf[2]  = { gate_pf, up_pf };
                         const float* rsf[2] = { w.gate_rs, w.up_rs };
                         void*        Cf[2]  = { ffg, ffu };
                         const int    nf[2]  = { ffn, ffn };
                         quant_a_i8(hn_c, fn, H);
                         ffn_grouped = kernels::launch_prefill_gemm_qi8_dense_group(
-                            w.gate_qtype, A_i8, sx, Wf, rsf, Cf, nf, 2, fn, H, st,
+                            gate_pf_type, A_i8, sx, Wf, rsf, Cf, nf, 2, fn, H, st,
                             qb_partials, QB_SPLITS, qb_partials_cap);
                     }
                     if (!ffn_grouped) {
-                        proj_fused(hn_c, w.gate_q, w.gate_qtype, w.gate_rs, ffg, ffn, H, fn);
-                        proj_fused(hn_c, w.up_q,   w.up_qtype,   w.up_rs,   ffu, ffn, H, fn);
+                        proj_fused(hn_c, gate_pf, gate_pf_type, w.gate_rs, ffg, ffn, H, fn);
+                        proj_fused(hn_c, up_pf,   up_pf_type,   w.up_rs,   ffu, ffn, H, fn);
                     }
                     if (use_i8) {
                         // Same fused SwiGLU + per-row int8 quantize the long-ctx ffn_i8 branch


### PR DESCRIPTION
## Summary

Reintroduces the calibration-selected Muse Glimmer Q3_A dense-FFN gate/up decode path with a fixed-shape single-token kernel and repairs batched prefill. Selected decode weights use compact Q3_A while batched prefill retains and reads the native GGUF weights, preventing the illegal CUDA access that invalidated PR #785 prefill score.

On RTX 5090 against current main (`7fb6a20`), median-of-5 short decode improves from 104.38 to 110.78 tok/s (+6.13%, M). At context 128, decode improves from 103.45 to 109.71 tok/s (+6.05%) while prefill remains flat at 3066.81 to 3084.73 pp tok/s (+0.58%).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (128-token autoregressive decode, median of five alternating same-binary runs):

| | decode tok/s |
|---|--:|
| before (current main `7fb6a20`) | 104.38 |
| after (this PR) | 110.78 |

```text
run      before    after
1        104.38    110.80
2        104.37    110.78
3        104.42    110.78
4        104.39    110.73
5        104.36    110.75
median   104.38    110.78 tok/s
delta              +6.13%
```

**Prefill@128 pp tok/s** (median of five alternating same-binary runs):

| | prefill pp tok/s |
|---|--:|
| before (current main; native Q4_K) | 3066.81 |
| after (this PR; native prefill weights retained) | 3084.73 |

```text
run      before     after
1        3066.81    3085.94
2        3060.54    3084.25
3        3067.46    3084.73
4        3066.22    3086.52
5        3072.02    3083.69
median   3066.81    3084.73 pp tok/s
delta               +0.58%
```

No run reported a CUDA error. The invalid approximately 3.4k pp tok/s result from #785 is not used or claimed.

**Additional guarded-context check** (single isolated process per build):

| context | metric | before | after | delta |
|---:|---|---:|---:|---:|
| 128 | decode tok/s | 103.45 | 109.71 | +6.05% |
| 512 | decode tok/s | 102.38 | 108.40 | +5.88% |
| 512 | prefill pp tok/s | 3719.83 | 3690.44 | -0.79% |

## Design

- Forty-two calibrated layers use internal Q3_A gate/up weights for decode; ten sensitive layers remain native Q4_K.
- Q3_A reduces each 256-weight decode block from 144 to 112 bytes while retaining Q4_K asymmetric scale/min metadata.
- The Muse single-token kernel specializes `hidden=6656`, `ffn=19968`, and `top_k=1` at compile time.
- Native gate/up buffers are retained separately for batched prefill and dispatched through the established Q4_K/Q5_K/Q6_K dequantizer.
- Q3_A-to-BF16 and Q3_A-to-row-INT8 decoders provide safe generic fallback coverage; type 112 can no longer fall through as F32.

## Correctness

Teacher-forced candidate-vs-current-main scoring on an identical deterministic held-out 344-token prompt:

| Metric | Result | Required |
|---|---:|---:|
| Top-1 agreement | 312/343 = 0.909621 | >= 0.90 |
| Mean KL(main\|candidate) | 0.058529 | <= 0.10 |
| Current-main PPL | 4.75064 | informational |
| Candidate PPL | 4.87181 | informational |

Batched-prefill fidelity against the token loop:

| Prefix / continuation | Top-1 | Mean KL |
|---|---:|---:|
| 128 / 16 | 15/16 = 0.9375 | 0.03454 |
| 512 / 16 | 16/16 = 1.0000 | 0.01424 |

## Benchmark commands

```bash
SPARKINFER_MUSE_FFN_Q3A=0 build/runtime/qwen3_gguf_bench model.gguf 128 0
build/runtime/qwen3_gguf_bench model.gguf 128 0

SPARKINFER_MUSE_FFN_Q3A=0 build/runtime/qwen3_gguf_bench model.gguf 128 128
build/runtime/qwen3_gguf_bench model.gguf 128 128

SPARKINFER_KV_INT8=0 build/runtime/qwen3_gguf_prefill_check model.gguf 128 16
SPARKINFER_KV_INT8=0 build/runtime/qwen3_gguf_prefill_check model.gguf 512 16
```

## Validation

- Full CUDA `sm_120` build: passed.
- `ctest --test-dir build --output-on-failure`: 13/13 passed.
- `git diff --check`: passed.
- Candidate-vs-current-main held-out decode gate: passed (top-1 0.909621, KL 0.058529).
- Muse batched-prefill fidelity: passed without CUDA errors.

## Scope and tradeoffs

- Muse Glimmer dense FFN gate/up only.
- Other architectures retain their existing paths.
- Down projection is unchanged.
- Resident VRAM increases from 18.8 GB to 23.9 GB (+5.1 GB) because native gate/up buffers are retained for prefill alongside compact decode copies.
- The current-main one-load Muse long-context sweep reports illegal CUDA accesses and invalid throughput, so this PR makes no 4k/16k/32k claim from that broken sweep.
- `SPARKINFER_MUSE_FFN_Q3A=0` restores the current-main native path.
- `SPARKINFER_MUSE_Q3A_SPEC=0` selects the generic Q3_A decode kernel for diagnostics.
