### PR TITLE
feat(server): add OpenAI-compatible Qwen3.6 tool calling

### DIFF
--- a/.github/workflows/build-attested-binaries.yml
+++ b/.github/workflows/build-attested-binaries.yml
@@ -61,7 +61,7 @@ jobs:
             -DBUILD_EXAMPLES=ON
 
       - name: Build
-        run: cmake --build build -j"$(nproc)" --target qwen3_gguf_bench chat_tools_test chat_tokenizer_test
+        run: cmake --build build -j"$(nproc)" --target qwen3_gguf_bench sparkinfer_server chat_tools_test chat_tokenizer_test
 
       - name: Test chat protocol
         working-directory: build
@@ -72,9 +72,11 @@ jobs:
           set -euo pipefail
           mkdir -p "${BUNDLE}/bin" "${BUNDLE}/lib"
           install -m755 build/runtime/qwen3_gguf_bench "${BUNDLE}/bin/"
+          install -m755 build/server/sparkinfer_server "${BUNDLE}/bin/"
           find build/runtime build/moe -maxdepth 1 \( -name 'libsparkinfer_runtime.so*' -o -name 'libsparkinfer_moe.so*' \) \
             -exec install -m755 {} "${BUNDLE}/lib/" \;
           BENCH_SHA="$(sha256sum "${BUNDLE}/bin/qwen3_gguf_bench" | awk '{print $1}')"
+          SERVER_SHA="$(sha256sum "${BUNDLE}/bin/sparkinfer_server" | awk '{print $1}')"
           jq -n \
             --arg platform "linux-amd64" \
             --arg cuda "12.8" \
@@ -83,9 +85,13 @@ jobs:
             --arg ref "${GITHUB_REF}" \
             --arg binary "bin/qwen3_gguf_bench" \
             --arg binary_sha256 "${BENCH_SHA}" \
-            '{platform:$platform,cuda:$cuda,sm:$sm,commit:$commit,ref:$ref,binary:$binary,binary_sha256:$binary_sha256}' \
+            --arg server_binary "bin/sparkinfer_server" \
+            --arg server_binary_sha256 "${SERVER_SHA}" \
+            '{platform:$platform,cuda:$cuda,sm:$sm,commit:$commit,ref:$ref,binary:$binary,binary_sha256:$binary_sha256,server_binary:$server_binary,server_binary_sha256:$server_binary_sha256}' \
             > "${BUNDLE}/BUILD_MANIFEST.json"
           (cd "${BUNDLE}" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
+          (cd "${BUNDLE}" && sha256sum -c SHA256SUMS)
+          LD_LIBRARY_PATH="${BUNDLE}/lib:${LD_LIBRARY_PATH:-}" "${BUNDLE}/bin/sparkinfer_server" --help
           ls -laR "${BUNDLE}"
 
       - name: Generate artifact attestation

--- a/.github/workflows/build-attested-binaries.yml
+++ b/.github/workflows/build-attested-binaries.yml
@@ -15,6 +15,7 @@ on:
       - "kernels/**"
       - "moe/**"
       - "runtime/**"
+      - "server/**"
       - ".github/workflows/build-attested-binaries.yml"
   push:
     tags: ["v*"]
@@ -24,6 +25,7 @@ on:
       - "kernels/**"
       - "moe/**"
       - "runtime/**"
+      - "server/**"
       - ".github/workflows/build-attested-binaries.yml"
 
 permissions:
@@ -54,11 +56,16 @@ jobs:
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_CUDA_ARCHITECTURES="${CUDA_ARCH}" \
-            -DBUILD_TESTS=OFF \
+            -DBUILD_SERVER=ON \
+            -DBUILD_TESTS=ON \
             -DBUILD_EXAMPLES=ON
 
       - name: Build
-        run: cmake --build build -j"$(nproc)" --target qwen3_gguf_bench
+        run: cmake --build build -j"$(nproc)" --target qwen3_gguf_bench chat_tools_test chat_tokenizer_test
+
+      - name: Test chat protocol
+        working-directory: build
+        run: ctest -R '^chat_(tools|tokenizer)_test$' --output-on-failure
 
       - name: Package
         run: |

--- a/.github/workflows/build-attested-binaries.yml
+++ b/.github/workflows/build-attested-binaries.yml
@@ -91,7 +91,15 @@ jobs:
             > "${BUNDLE}/BUILD_MANIFEST.json"
           (cd "${BUNDLE}" && find . -type f ! -name SHA256SUMS -print0 | sort -z | xargs -0 sha256sum > SHA256SUMS)
           (cd "${BUNDLE}" && sha256sum -c SHA256SUMS)
-          LD_LIBRARY_PATH="${BUNDLE}/lib:${LD_LIBRARY_PATH:-}" "${BUNDLE}/bin/sparkinfer_server" --help
+          # Hosted runners have the toolkit's official NVML link stub but no NVIDIA
+          # driver, so provide the runtime SONAME only for this --help relocation smoke.
+          NVML_STUB="$(find "${CUDA_PATH}" -path '*/stubs/libnvidia-ml.so' -print -quit)"
+          test -n "${NVML_STUB}"
+          NVML_SMOKE_DIR="${RUNNER_TEMP}/sparkinfer-nvml-stub"
+          mkdir -p "${NVML_SMOKE_DIR}"
+          ln -s "${NVML_STUB}" "${NVML_SMOKE_DIR}/libnvidia-ml.so.1"
+          LD_LIBRARY_PATH="${BUNDLE}/lib:${NVML_SMOKE_DIR}:${LD_LIBRARY_PATH:-}" \
+            "${BUNDLE}/bin/sparkinfer_server" --help
           ls -laR "${BUNDLE}"
 
       - name: Generate artifact attestation

--- a/runtime/include/sparkinfer/inference_engine.h
+++ b/runtime/include/sparkinfer/inference_engine.h
@@ -49,6 +49,10 @@ public:
         bool timed_out = false;
         // true => on_token returned false (client went away mid-stream); not an error.
         bool cancelled = false;
+        // true => generation exhausted max_new_tokens instead of reaching an EOS token.
+        // HTTP callers surface this as finish_reason="length"; in particular, a truncated
+        // tool-call payload must never be reported as a successful "stop".
+        bool reached_token_limit = false;
         // GPU-side timings (exclude SSE/on_token backpressure).
         double ttft_ms = -1.0;
         double generation_ms = -1.0;

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -60,6 +60,7 @@ struct ContinuousBatchEngine::Job {
     bool overloaded = false;
     bool timed_out = false;
     bool cancelled = false;
+    bool reached_token_limit = false;
 
     std::chrono::steady_clock::time_point t_submit{};
     std::chrono::steady_clock::time_point t_first{};
@@ -193,6 +194,7 @@ ContinuousBatchEngine::Result ContinuousBatchEngine::wait_locked(uint64_t reques
     out.overloaded = it->second->overloaded;
     out.timed_out = it->second->timed_out;
     out.cancelled = it->second->cancelled;
+    out.reached_token_limit = it->second->reached_token_limit;
     out.ttft_ms = it->second->ttft_ms;
     out.generation_ms = it->second->generation_ms;
     out.decode_tps = it->second->decode_tps;
@@ -360,8 +362,11 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
         return true;
     }
 
-    if (job.next_token == cfg.eos_id || (cfg.eos_id2 >= 0 && job.next_token == cfg.eos_id2) ||
-        job.decode_emitted >= job.req.max_new_tokens) {
+    const bool hit_eos = job.next_token == cfg.eos_id ||
+                         (cfg.eos_id2 >= 0 && job.next_token == cfg.eos_id2);
+    const bool hit_token_limit = job.decode_emitted >= job.req.max_new_tokens;
+    if (hit_eos || hit_token_limit) {
+        job.reached_token_limit = hit_token_limit && !hit_eos;
         const auto t_end = std::chrono::steady_clock::now();
         job.generation_ms = std::chrono::duration<double, std::milli>(t_end - job.t_submit).count();
         if (job.saw_first_tok && job.generation_ms > job.ttft_ms && job.decode_emitted > 0) {

--- a/runtime/tests/batch_engine_gpu_test.cpp
+++ b/runtime/tests/batch_engine_gpu_test.cpp
@@ -110,6 +110,10 @@ int main() {
         printf("[FAIL] request A: expected 4 tokens, got %zu\n", ra.tokens.size());
         return 1;
     }
+    if (!ra.reached_token_limit) {
+        printf("[FAIL] request A: expected max_new_tokens termination\n");
+        return 1;
+    }
 
     sparkinfer::ContinuousBatchEngine::Request b;
     b.prompt = {2, 6, 10, 14};
@@ -122,6 +126,29 @@ int main() {
     }
     if ((int)rb.tokens.size() != 6) {
         printf("[FAIL] request B: expected 6 tokens, got %zu\n", rb.tokens.size());
+        return 1;
+    }
+    if (!rb.reached_token_limit) {
+        printf("[FAIL] request B: expected max_new_tokens termination\n");
+        return 1;
+    }
+
+    // The termination cause must survive the batch-engine boundary: HTTP maps this flag to
+    // finish_reason="stop" rather than "length". Reuse request A's deterministic first token
+    // as EOS so this synthetic model stops on its first emission.
+    cfg.eos_id = ra.tokens.front();
+    sparkinfer::Qwen35Model eos_model(cfg, &kv, engine.get());
+    eos_model.set_weights(w);
+    sparkinfer::ContinuousBatchEngine eos_batch(&eos_model, &kv, 8);
+    sparkinfer::ContinuousBatchEngine::Request eos_request;
+    eos_request.prompt = a.prompt;
+    eos_request.max_new_tokens = 4;
+    const auto eos_result = eos_batch.complete(eos_request);
+    if (!eos_result.error.empty() || eos_result.tokens.size() != 1 ||
+        eos_result.reached_token_limit) {
+        printf("[FAIL] EOS termination: error=%s tokens=%zu limit=%d\n",
+               eos_result.error.c_str(), eos_result.tokens.size(),
+               eos_result.reached_token_limit ? 1 : 0);
         return 1;
     }
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -17,6 +17,18 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(nlohmann_json)
 
+# JSON Schema patterns come from untrusted API requests. Use RE2's bounded,
+# linear-time engine instead of std::regex, whose backtracking implementation
+# can be driven into exponential runtime by a short adversarial pattern/value.
+set(RE2_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+set(RE2_USE_ICU OFF CACHE BOOL "" FORCE)
+FetchContent_Declare(
+    re2
+    URL      https://github.com/google/re2/archive/refs/tags/2023-03-01.tar.gz
+    URL_HASH SHA256=7a9a4824958586980926a300b4717202485c4b4115ac031822e29aa4ef207e48
+)
+FetchContent_MakeAvailable(re2)
+
 add_executable(sparkinfer_server
     src/sparkinfer_server.cpp
     src/model_engine.cpp
@@ -34,6 +46,7 @@ target_link_libraries(sparkinfer_server PRIVATE
     sparkinfer_runtime
     tokenizers_cpp
     nlohmann_json::nlohmann_json
+    re2::re2
     CUDA::cudart
     Threads::Threads
 )
@@ -50,6 +63,7 @@ if(BUILD_TESTS)
     )
     target_link_libraries(chat_tools_test PRIVATE
         nlohmann_json::nlohmann_json
+        re2::re2
     )
     target_compile_definitions(chat_tools_test PRIVATE
         SPARKINFER_SERVER_TEST_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests"
@@ -68,6 +82,7 @@ if(BUILD_TESTS)
     target_link_libraries(chat_tokenizer_test PRIVATE
         tokenizers_cpp
         nlohmann_json::nlohmann_json
+        re2::re2
     )
     target_compile_features(chat_tokenizer_test PRIVATE cxx_std_17)
     add_test(NAME chat_tokenizer_test COMMAND chat_tokenizer_test)

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -10,10 +10,18 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(tokenizers_cpp)
 
+FetchContent_Declare(
+    nlohmann_json
+    URL      https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+    URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 add_executable(sparkinfer_server
     src/sparkinfer_server.cpp
     src/model_engine.cpp
     src/chat_tokenizer.cpp
+    src/chat_tools.cpp
 )
 
 target_include_directories(sparkinfer_server PRIVATE
@@ -25,10 +33,44 @@ target_include_directories(sparkinfer_server PRIVATE
 target_link_libraries(sparkinfer_server PRIVATE
     sparkinfer_runtime
     tokenizers_cpp
+    nlohmann_json::nlohmann_json
     CUDA::cudart
     Threads::Threads
 )
 
 target_compile_features(sparkinfer_server PRIVATE cxx_std_17)
+
+if(BUILD_TESTS)
+    add_executable(chat_tools_test
+        tests/chat_tools_test.cpp
+        src/chat_tools.cpp
+    )
+    target_include_directories(chat_tools_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(chat_tools_test PRIVATE
+        nlohmann_json::nlohmann_json
+    )
+    target_compile_definitions(chat_tools_test PRIVATE
+        SPARKINFER_SERVER_TEST_DIR="${CMAKE_CURRENT_SOURCE_DIR}/tests"
+    )
+    target_compile_features(chat_tools_test PRIVATE cxx_std_17)
+    add_test(NAME chat_tools_test COMMAND chat_tools_test)
+
+    add_executable(chat_tokenizer_test
+        tests/chat_tokenizer_test.cpp
+        src/chat_tokenizer.cpp
+        src/chat_tools.cpp
+    )
+    target_include_directories(chat_tokenizer_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(chat_tokenizer_test PRIVATE
+        tokenizers_cpp
+        nlohmann_json::nlohmann_json
+    )
+    target_compile_features(chat_tokenizer_test PRIVATE cxx_std_17)
+    add_test(NAME chat_tokenizer_test COMMAND chat_tokenizer_test)
+endif()
 
 install(TARGETS sparkinfer_server RUNTIME DESTINATION bin)

--- a/server/README.md
+++ b/server/README.md
@@ -47,7 +47,18 @@ export SPARKINFER_ROOT="$(pwd)"
 | `GET /v1/capacity` | This worker's live occupancy: `active_requests`, `free_kv_blocks`, `max_queue_depth`, `accepting_requests`. Single-process only — not fleet-wide. |
 | `GET /metrics` | Prometheus text-exposition counters/gauges: request totals by outcome (`ok`/`client_error`/`overloaded`/`timeout`/`cancelled`/`server_error`), prompt/completion token totals, active requests, free KV blocks, uptime. |
 | `POST /v1/tokenize` | Token count for a chat request body |
-| `POST /v1/chat/completions` | Chat (JSON `messages`, optional `stream`, `enable_thinking`). Responses include OpenAI `usage` (`prompt_tokens`, `completion_tokens`, `total_tokens`) plus additive GPU timing fields (`ttft_ms`, `generation_ms`, `decode_tps`) that standard OpenAI SDKs ignore. Streaming sends a final chunk with `choices:[]` + `usage` before `[DONE]`. A streaming client that disconnects mid-response cancels generation (checked via `DataSink::is_writable()`) instead of running to completion for nobody. Overload (no queue capacity) returns `429`; a request that exceeds `SPARKINFER_REQUEST_TIMEOUT_S` returns `504`. |
+| `POST /v1/chat/completions` | Chat (JSON `messages`, optional `tools`, `tool_choice`, `stream`, `enable_thinking`). Responses include OpenAI `usage` (`prompt_tokens`, `completion_tokens`, `total_tokens`) plus additive GPU timing fields (`ttft_ms`, `generation_ms`, `decode_tps`) that standard OpenAI SDKs ignore. With `stream_options.include_usage=true`, streaming sends a final chunk with `choices:[]` + `usage` before `[DONE]`. A streaming client that disconnects mid-response cancels generation (checked via `DataSink::is_writable()`) instead of running to completion for nobody. Overload (no queue capacity) returns `429`; a request that exceeds `SPARKINFER_REQUEST_TIMEOUT_S` returns `504`. |
+
+### Function tools
+
+Qwen3.6 accepts OpenAI function definitions in `tools`, assistant `tool_calls` history, and
+matching `role: "tool"` results. Both streaming and non-streaming responses expose native model
+calls as `message.tool_calls` / `delta.tool_calls` with `finish_reason: "tool_calls"`; native XML
+control markup is validated against the offered schema and is never exposed to clients.
+
+Omitted `tool_choice`, `"auto"`, and `"none"` are supported. Forced/named choices and
+`parallel_tool_calls: false` return `400` until those constraints can be enforced by the runtime.
+Tool calls are currently Qwen3.6-only; Muse Glimmer uses a different tool protocol.
 
 ### Graceful shutdown
 

--- a/server/README.md
+++ b/server/README.md
@@ -13,6 +13,13 @@ cmake -S . -B build -DCMAKE_CUDA_ARCHITECTURES=120 -DBUILD_SERVER=ON
 cmake --build build -j$(nproc) --target sparkinfer_server
 ```
 
+Pull-request and release CI packages the Linux server with its runtime libraries and includes it
+in GitHub Artifact Attestations. After downloading the bundle, verify the server provenance with:
+
+```bash
+gh attestation verify sparkinfer-bin/bin/sparkinfer_server -R gittensor-ai-lab/sparkinfer
+```
+
 Or reuse the bench harness build root:
 
 ```bash
@@ -59,6 +66,16 @@ control markup is validated against the offered schema and is never exposed to c
 Omitted `tool_choice`, `"auto"`, and `"none"` are supported. Forced/named choices and
 `parallel_tool_calls: false` return `400` until those constraints can be enforced by the runtime.
 Tool calls are currently Qwen3.6-only; Muse Glimmer uses a different tool protocol.
+Muse requests containing tool definitions or tool-call history return `400`, including when
+`tool_choice` is `"none"`, so unsupported protocol data cannot be silently dropped.
+JSON Schema `pattern` uses the safe, linear-time RE2 syntax; unsupported expressions are rejected.
+Supported validation keywords are `type`, `properties`, `required`, `additionalProperties`,
+`items`, `enum`, numeric bounds, item/string length bounds, and `pattern`; unsupported validation
+keywords return `400` rather than being silently ignored. Annotation keywords `description`,
+`default`, and `title` are retained in the model prompt.
+Qwen's native XML leaves string values unquoted. For a mixed string/non-string union, a value
+that is valid JSON is interpreted as its JSON type first (for example, `1` becomes an integer);
+avoid such unions when JSON-looking text must remain a string.
 
 ### Graceful shutdown
 

--- a/server/include/chat_tokenizer.hpp
+++ b/server/include/chat_tokenizer.hpp
@@ -1,15 +1,12 @@
 #pragma once
 
+#include "chat_tools.hpp"
+
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace sparkinfer_server {
-
-struct ChatMessage {
-    std::string role;
-    std::string content;
-};
 
 // HuggingFace tokenizer.json + Qwen3.6 chat template.
 class ChatTokenizer {
@@ -25,7 +22,7 @@ public:
     void set_museglimmer(bool on);
 
     bool encode_chat_request(const std::string& request_json, std::vector<int>& ids, bool enable_thinking,
-                             std::string& err) const;
+                             std::string& err, ChatRequest* parsed_request = nullptr) const;
     std::string decode(const std::vector<int>& ids) const;
     std::string decode_delta(std::vector<int>& acc, int new_id) const;
 
@@ -37,6 +34,8 @@ private:
 struct ParsedAssistantOutput {
     std::string reasoning_content;
     std::string content;
+    std::vector<ToolCall> tool_calls;
+    std::string error;
 };
 
 // Incrementally routes decoded text into reasoning vs answer for SSE streaming.
@@ -76,6 +75,8 @@ bool parse_enable_thinking(const std::string& request_json, bool default_value =
 std::string apply_qwen36_chat_template(const std::vector<ChatMessage>& messages, bool enable_thinking = false);
 std::string apply_museglimmer_chat_template(const std::vector<ChatMessage>& messages,
                                             const std::string& reasoning_strength = "high");
-ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable_thinking, bool museglimmer = false);
+ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable_thinking,
+                                             bool museglimmer = false,
+                                             const ChatRequest* request = nullptr);
 
 }  // namespace sparkinfer_server

--- a/server/include/chat_tokenizer.hpp
+++ b/server/include/chat_tokenizer.hpp
@@ -72,6 +72,8 @@ private:
 
 bool parse_chat_messages(const std::string& request_json, std::vector<ChatMessage>& messages, std::string& err);
 bool parse_enable_thinking(const std::string& request_json, bool default_value = false);
+bool validate_chat_request_model_support(const ChatRequest& request, bool museglimmer,
+                                         std::string& err);
 std::string apply_qwen36_chat_template(const std::vector<ChatMessage>& messages, bool enable_thinking = false);
 std::string apply_museglimmer_chat_template(const std::vector<ChatMessage>& messages,
                                             const std::string& reasoning_strength = "high");

--- a/server/include/chat_tokenizer.hpp
+++ b/server/include/chat_tokenizer.hpp
@@ -55,6 +55,12 @@ private:
     enum class Phase { kBeforeThink, kInThink, kInAnswer } phase_ = Phase::kBeforeThink;
     std::string carry_;
     std::string prefix_buffer_;
+    // Qwen (non-museglimmer) starts in Phase::kInThink directly (the prompt already primes
+    // "<think>\n"), but a generation can still defensively repeat the opening marker -- see
+    // parse_assistant_output's identical handling for the non-streaming path. Checked once,
+    // on the first non-empty data seen in kInThink, so a literal "<think>" appearing later in
+    // genuine reasoning text is never mistaken for the marker.
+    bool think_open_checked_ = false;
 
     // Muse Glimmer (harmony-style) state: segments are <|start|>{header}<|message|>{body}
     // then <|eom|> (more segments follow, same assistant turn) or <|eot|> (turn done). The

--- a/server/include/chat_tools.hpp
+++ b/server/include/chat_tools.hpp
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <nlohmann/json.hpp>
+
+#include <string>
+#include <vector>
+
+namespace sparkinfer_server {
+
+struct ToolCall {
+    std::string id;
+    std::string name;
+    // OpenAI wire representation: a compact JSON object encoded as a string.
+    std::string arguments;
+};
+
+struct ToolDefinition {
+    std::string name;
+    // The complete top-level OpenAI tool object ({"type":"function","function":{...}}).
+    nlohmann::json spec;
+};
+
+enum class ToolChoiceMode {
+    kAuto,
+    kNone,
+};
+
+struct ChatMessage {
+    std::string role;
+    std::string content;
+    bool content_is_null = false;
+    std::string reasoning_content;
+    std::string name;
+    std::string tool_call_id;
+    std::vector<ToolCall> tool_calls;
+};
+
+struct ChatRequest {
+    std::vector<ChatMessage> messages;
+    std::vector<ToolDefinition> tools;
+    ToolChoiceMode tool_choice = ToolChoiceMode::kAuto;
+    bool parallel_tool_calls = true;
+};
+
+struct ParsedToolOutput {
+    std::string reasoning_content;
+    std::string content;
+    std::vector<ToolCall> tool_calls;
+    std::string error;
+};
+
+bool parse_chat_request_json(const std::string& body, ChatRequest& request, std::string& err);
+
+std::string apply_qwen36_tools_template(const ChatRequest& request,
+                                        bool enable_thinking = false);
+
+ParsedToolOutput parse_qwen36_tool_output(const std::string& raw,
+                                          bool enable_thinking,
+                                          const ChatRequest& request);
+
+}  // namespace sparkinfer_server

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -19,6 +19,7 @@ struct CompletionResult {
                                  // 503 (permanent until restart), never 429 (implies transient/retry)
     bool timed_out = false;   // true => a per-request deadline was exceeded
     bool cancelled = false;   // true => on_token returned false; not an error
+    bool reached_token_limit = false;  // true => max_new_tokens, not EOS, ended generation
     double ttft_ms = -1.0;
     double generation_ms = -1.0;
     double decode_tps = -1.0;

--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -1,5 +1,6 @@
 #include "chat_tokenizer.hpp"
 
+#include <nlohmann/json.hpp>
 #include <tokenizers_cpp.h>
 
 #include <algorithm>
@@ -20,89 +21,14 @@ std::string read_file(const std::string& path) {
     return ss.str();
 }
 
-// Unescape a minimal JSON string value (handles \\ \n \t \").
-std::string json_unescape(const std::string& s) {
-    std::string out;
-    out.reserve(s.size());
-    for (size_t i = 0; i < s.size(); i++) {
-        if (s[i] != '\\' || i + 1 >= s.size()) {
-            out.push_back(s[i]);
-            continue;
-        }
-        char c = s[++i];
-        switch (c) {
-            case '"': out.push_back('"'); break;
-            case '\\': out.push_back('\\'); break;
-            case '/': out.push_back('/'); break;
-            case 'b': out.push_back('\b'); break;
-            case 'f': out.push_back('\f'); break;
-            case 'n': out.push_back('\n'); break;
-            case 'r': out.push_back('\r'); break;
-            case 't': out.push_back('\t'); break;
-            default: out.push_back(c); break;
-        }
-    }
-    return out;
-}
-
-bool extract_json_string(const std::string& body, size_t start, size_t& end, std::string& out) {
-    size_t q = body.find('"', start);
-    if (q == std::string::npos) return false;
-    std::string raw;
-    for (size_t i = q + 1; i < body.size(); i++) {
-        if (body[i] == '\\' && i + 1 < body.size()) {
-            raw.push_back(body[i++]);
-            raw.push_back(body[i]);
-            continue;
-        }
-        if (body[i] == '"') {
-            end = i + 1;
-            out = json_unescape(raw);
-            return true;
-        }
-        raw.push_back(body[i]);
-    }
-    return false;
-}
-
-// Find closing brace of a JSON object, respecting quoted strings.
-size_t find_json_object_end(const std::string& s, size_t start) {
-    if (start >= s.size() || s[start] != '{') return std::string::npos;
-    int depth = 0;
-    bool in_string = false;
-    for (size_t i = start; i < s.size(); i++) {
-        const char c = s[i];
-        if (in_string) {
-            if (c == '\\' && i + 1 < s.size()) {
-                i++;
-                continue;
-            }
-            if (c == '"') in_string = false;
-            continue;
-        }
-        if (c == '"') {
-            in_string = true;
-            continue;
-        }
-        if (c == '{')
-            depth++;
-        else if (c == '}') {
-            depth--;
-            if (depth == 0) return i;
-        }
-    }
-    return std::string::npos;
-}
-
 constexpr const char* kImEnd = "<|" "im_end|>";
 constexpr const char* kThinkOpen = "<" "think>";
 constexpr const char* kThinkClose = "</" "think>";
 
 // Muse Glimmer harmony-style segment markers (server/scripts equivalent of Qwen3.6's
 // im_start/im_end/think tags). See tokenizer.chat_template in the model's GGUF for the
-// canonical jinja this mirrors (system/user/assistant/tool rendering, tool calls and
-// per-tool-namespace recipients are not implemented -- request parsing has no `tools` field
-// yet, so those branches of the upstream template are never exercised here).
+// canonical jinja this mirrors. Muse's ATEM tool protocol is deliberately rejected at request
+// validation until it receives its own renderer/parser; Qwen3.6 tools must never be sent here.
 constexpr const char* kMgStart = "<|start|>";
 constexpr const char* kMgMessage = "<|message|>";
 constexpr const char* kMgEot = "<|eot|>";
@@ -119,6 +45,11 @@ size_t marker_prefix_len(const std::string& data, const char* marker) {
 
 void trim_leading_ws(std::string& s) {
     while (!s.empty() && (s[0] == '\n' || s[0] == '\r' || s[0] == ' ' || s[0] == '\t')) s.erase(0, 1);
+}
+
+void trim_trailing_ws(std::string& s) {
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r' || s.back() == ' ' || s.back() == '\t'))
+        s.pop_back();
 }
 
 void strip_trailing_im_end(std::string& s) {
@@ -215,111 +146,22 @@ void ChatTokenizer::set_museglimmer(bool on) {
 }
 
 bool parse_chat_messages(const std::string& request_json, std::vector<ChatMessage>& messages, std::string& err) {
-    messages.clear();
-    const std::string key = "\"messages\"";
-    size_t p = request_json.find(key);
-    if (p == std::string::npos) {
-        err = "missing messages in request";
-        return false;
-    }
-    p = request_json.find('[', p);
-    if (p == std::string::npos) {
-        err = "malformed messages array";
-        return false;
-    }
-
-    size_t i = p + 1;
-    while (i < request_json.size()) {
-        while (i < request_json.size() && (request_json[i] == ' ' || request_json[i] == ',')) i++;
-        if (i >= request_json.size() || request_json[i] == ']') break;
-        if (request_json[i] != '{') {
-            err = "malformed message object";
-            return false;
-        }
-
-        ChatMessage msg;
-        const size_t obj_end = find_json_object_end(request_json, i);
-        if (obj_end == std::string::npos) {
-            err = "unterminated message object";
-            return false;
-        }
-        const std::string obj = request_json.substr(i, obj_end - i + 1);
-
-        size_t role_pos = obj.find("\"role\"");
-        if (role_pos != std::string::npos) {
-            size_t dummy = 0;
-            extract_json_string(obj, role_pos + 6, dummy, msg.role);
-        }
-        size_t content_pos = obj.find("\"content\"");
-        if (content_pos != std::string::npos) {
-            size_t c = obj.find(':', content_pos);
-            if (c != std::string::npos) {
-                while (c < obj.size() && (obj[c] == ':' || obj[c] == ' ')) c++;
-                if (c < obj.size() && obj[c] == '"') {
-                    size_t dummy = 0;
-                    extract_json_string(obj, c, dummy, msg.content);
-                } else if (c < obj.size() && obj[c] == '[') {
-                    // Multimodal content parts: only concatenate "text" KEY values.
-                    // A naive find("\"text\"") also matches the type VALUE {"type":"text"},
-                    // and when extract fails `j` never advances → infinite loop / OOM.
-                    size_t j = c;
-                    const size_t lim = obj.size();
-                    while (j < lim) {
-                        const size_t text_key = obj.find("\"text\"", j);
-                        if (text_key == std::string::npos) break;
-                        j = text_key + 6;  // always past this match — scan cannot rewind
-                        size_t v = j;
-                        while (v < lim && (obj[v] == ':' || obj[v] == ' ')) ++v;
-                        if (v == j || v >= lim || obj[v] != '"') continue;  // type value, not a key
-                        size_t part_end = 0;
-                        std::string piece;
-                        if (!extract_json_string(obj, v, part_end, piece)) break;
-                        if (!msg.content.empty()) msg.content.push_back(' ');
-                        msg.content += piece;
-                        j = part_end;
-                    }
-                }
-            }
-        }
-
-        if (msg.role.empty()) msg.role = "user";
-        messages.push_back(std::move(msg));
-        i = obj_end + 1;
-    }
-
-    if (messages.empty()) {
-        err = "no messages in request";
-        return false;
-    }
+    ChatRequest request;
+    if (!parse_chat_request_json(request_json, request, err)) return false;
+    messages = std::move(request.messages);
     return true;
 }
 
 bool parse_enable_thinking(const std::string& request_json, bool default_value) {
-    const std::string needle = "\"enable_thinking\"";
-    auto parse_at = [&](size_t pos) -> bool {
-        pos = request_json.find(':', pos);
-        if (pos == std::string::npos) return default_value;
-        const size_t t = request_json.find("true", pos);
-        const size_t f = request_json.find("false", pos);
-        const size_t comma = request_json.find(',', pos);
-        const size_t end = comma == std::string::npos ? request_json.size() : comma;
-        if (t != std::string::npos && t < end) return true;
-        if (f != std::string::npos && f < end) return false;
-        return default_value;
-    };
-
-    const size_t messages = request_json.find("\"messages\"");
-    const size_t first = request_json.find(needle);
-    if (first != std::string::npos && (messages == std::string::npos || first < messages))
-        return parse_at(first);
-
-    const size_t kwargs = request_json.find("chat_template_kwargs");
-    if (kwargs != std::string::npos) {
-        const size_t in_kwargs = request_json.find(needle, kwargs);
-        if (in_kwargs != std::string::npos) return parse_at(in_kwargs);
+    const auto root = nlohmann::json::parse(request_json, nullptr, false);
+    if (root.is_discarded() || !root.is_object()) return default_value;
+    const auto top = root.find("enable_thinking");
+    if (top != root.end() && top->is_boolean()) return top->get<bool>();
+    const auto kwargs = root.find("chat_template_kwargs");
+    if (kwargs != root.end() && kwargs->is_object()) {
+        const auto nested = kwargs->find("enable_thinking");
+        if (nested != kwargs->end() && nested->is_boolean()) return nested->get<bool>();
     }
-
-    if (first != std::string::npos) return parse_at(first);
     return default_value;
 }
 
@@ -414,8 +256,19 @@ ParsedAssistantOutput parse_museglimmer_output(const std::string& raw, bool enab
     return out;
 }
 
-ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable_thinking, bool museglimmer) {
+ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable_thinking, bool museglimmer,
+                                             const ChatRequest* request) {
     if (museglimmer) return parse_museglimmer_output(raw, enable_thinking);
+
+    if (request && !request->tools.empty() && request->tool_choice != ToolChoiceMode::kNone) {
+        const ParsedToolOutput parsed = parse_qwen36_tool_output(raw, enable_thinking, *request);
+        ParsedAssistantOutput out;
+        out.reasoning_content = parsed.reasoning_content;
+        out.content = parsed.content;
+        out.tool_calls = parsed.tool_calls;
+        out.error = parsed.error;
+        return out;
+    }
 
     ParsedAssistantOutput out;
     if (!enable_thinking) {
@@ -424,14 +277,11 @@ ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable
         return out;
     }
 
+    // The official Qwen3.6 generation prompt already ends in "<think>\n" when thinking is
+    // enabled, so generated text normally starts inside that block and contains only the
+    // closing marker. Accept a repeated opening marker defensively, but do not require one.
     const size_t open = raw.find(kThinkOpen);
-    if (open == std::string::npos) {
-        out.content = strip_think_markers(raw);
-        strip_trailing_im_end(out.content);
-        return out;
-    }
-
-    const size_t body_start = open + strlen(kThinkOpen);
+    const size_t body_start = open == 0 ? strlen(kThinkOpen) : 0;
     const size_t close = raw.find(kThinkClose, body_start);
     if (close != std::string::npos) {
         out.reasoning_content = raw.substr(body_start, close - body_start);
@@ -440,6 +290,7 @@ ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable
         out.reasoning_content = raw.substr(body_start);
     }
     trim_leading_ws(out.reasoning_content);
+    trim_trailing_ws(out.reasoning_content);
     trim_leading_ws(out.content);
     out.content = strip_think_markers(std::move(out.content));
     strip_trailing_im_end(out.content);
@@ -449,6 +300,12 @@ ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable
 ThinkingStreamSplitter::ThinkingStreamSplitter(bool enable_thinking, bool museglimmer)
     : enable_thinking_(enable_thinking), museglimmer_(museglimmer) {
     if (!enable_thinking_) phase_ = Phase::kInAnswer;
+    else if (!museglimmer_) {
+        // Qwen3.6's prompt pre-fills "<think>\n". Streaming therefore begins in the body,
+        // not before an opening marker; wait directly for </think> and never leak reasoning
+        // into delta.content.
+        phase_ = Phase::kInThink;
+    }
 }
 
 ThinkingStreamSplitter::Delta ThinkingStreamSplitter::feed(const std::string& piece) {
@@ -627,25 +484,31 @@ void ThinkingStreamSplitter::finish(Delta& tail) {
     trim_leading_ws(tail.content);
 }
 
-bool ChatTokenizer::encode_chat_request(const std::string& request_json, std::vector<int>& ids, bool enable_thinking,
-                                         std::string& err) const {
+bool ChatTokenizer::encode_chat_request(const std::string& request_json, std::vector<int>& ids,
+                                         bool enable_thinking, std::string& err,
+                                         ChatRequest* parsed_request) const {
     ids.clear();
     if (!impl_->tok) {
         err = "tokenizer not loaded";
         return false;
     }
-    std::vector<ChatMessage> messages;
-    if (!parse_chat_messages(request_json, messages, err)) return false;
+    ChatRequest request;
+    if (!parse_chat_request_json(request_json, request, err)) return false;
+    if (impl_->museglimmer && !request.tools.empty() && request.tool_choice != ToolChoiceMode::kNone) {
+        err = "tool calling is currently supported only for Qwen3.6 models";
+        return false;
+    }
 
     const std::string prompt = impl_->museglimmer
-        ? apply_museglimmer_chat_template(messages, enable_thinking ? "high" : "low")
-        : apply_qwen36_chat_template(messages, enable_thinking);
+        ? apply_museglimmer_chat_template(request.messages, enable_thinking ? "high" : "low")
+        : apply_qwen36_tools_template(request, enable_thinking);
     const std::vector<int32_t> enc = impl_->tok->Encode(prompt);
     ids.assign(enc.begin(), enc.end());
     if (ids.empty()) {
         err = "tokenize returned no ids";
         return false;
     }
+    if (parsed_request) *parsed_request = std::move(request);
     return true;
 }
 

--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -165,6 +165,23 @@ bool parse_enable_thinking(const std::string& request_json, bool default_value) 
     return default_value;
 }
 
+bool validate_chat_request_model_support(const ChatRequest& request, bool museglimmer,
+                                         std::string& err) {
+    if (!museglimmer) return true;
+    bool has_tool_history = false;
+    for (const ChatMessage& message : request.messages) {
+        if (message.role == "tool" || !message.tool_calls.empty()) {
+            has_tool_history = true;
+            break;
+        }
+    }
+    if (!request.tools.empty() || has_tool_history) {
+        err = "tool calling is currently supported only for Qwen3.6 models";
+        return false;
+    }
+    return true;
+}
+
 std::string apply_qwen36_chat_template(const std::vector<ChatMessage>& messages, bool enable_thinking) {
     // Matches server/scripts/chat_tokens.py (thinking disabled) and HF enable_thinking=true.
     std::ostringstream parts;
@@ -260,7 +277,7 @@ ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable
                                              const ChatRequest* request) {
     if (museglimmer) return parse_museglimmer_output(raw, enable_thinking);
 
-    if (request && !request->tools.empty() && request->tool_choice != ToolChoiceMode::kNone) {
+    if (request && !request->tools.empty()) {
         const ParsedToolOutput parsed = parse_qwen36_tool_output(raw, enable_thinking, *request);
         ParsedAssistantOutput out;
         out.reasoning_content = parsed.reasoning_content;
@@ -494,10 +511,7 @@ bool ChatTokenizer::encode_chat_request(const std::string& request_json, std::ve
     }
     ChatRequest request;
     if (!parse_chat_request_json(request_json, request, err)) return false;
-    if (impl_->museglimmer && !request.tools.empty() && request.tool_choice != ToolChoiceMode::kNone) {
-        err = "tool calling is currently supported only for Qwen3.6 models";
-        return false;
-    }
+    if (!validate_chat_request_model_support(request, impl_->museglimmer, err)) return false;
 
     const std::string prompt = impl_->museglimmer
         ? apply_museglimmer_chat_template(request.messages, enable_thinking ? "high" : "low")

--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -298,7 +298,7 @@ ParsedAssistantOutput parse_assistant_output(const std::string& raw, bool enable
     // enabled, so generated text normally starts inside that block and contains only the
     // closing marker. Accept a repeated opening marker defensively, but do not require one.
     const size_t open = raw.find(kThinkOpen);
-    const size_t body_start = open == 0 ? strlen(kThinkOpen) : 0;
+    const size_t body_start = open == std::string::npos ? 0 : open + strlen(kThinkOpen);
     const size_t close = raw.find(kThinkClose, body_start);
     if (close != std::string::npos) {
         out.reasoning_content = raw.substr(body_start, close - body_start);
@@ -431,6 +431,21 @@ ThinkingStreamSplitter::Delta ThinkingStreamSplitter::feed(const std::string& pi
         }
 
         if (phase_ == Phase::kInThink) {
+            if (!think_open_checked_ && !data.empty()) {
+                if (data.compare(0, strlen(kThinkOpen), kThinkOpen) == 0) {
+                    data.erase(0, strlen(kThinkOpen));
+                    think_open_checked_ = true;
+                } else {
+                    const size_t keep = marker_prefix_len(data, kThinkOpen);
+                    if (keep > 0 && keep == data.size()) {
+                        // Whole chunk so far could still be a partial opening marker --
+                        // hold it and re-decide once more data arrives.
+                        carry_ = data;
+                        break;
+                    }
+                    think_open_checked_ = true;
+                }
+            }
             const size_t pos = data.find(kThinkClose);
             if (pos == std::string::npos) {
                 const size_t keep = marker_prefix_len(data, kThinkClose);

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -63,69 +63,35 @@ bool set_error(std::string& err, const std::string& message) {
     return false;
 }
 
-// nlohmann's ordinary DOM parser accepts duplicate object keys (last value wins). That is
-// dangerous for tool requests: an auditor, prompt renderer, and executor could otherwise see
-// different meanings for the same schema or argument object. Forward SAX events to its DOM
-// builder while rejecting a repeated key at every nesting level.
-class StrictJsonSax final : public json::json_sax_t {
-public:
-    explicit StrictJsonSax(json& result) : dom_(result, false) {}
-
-    bool null() override { return dom_.null(); }
-    bool boolean(bool value) override { return dom_.boolean(value); }
-    bool number_integer(number_integer_t value) override { return dom_.number_integer(value); }
-    bool number_unsigned(number_unsigned_t value) override { return dom_.number_unsigned(value); }
-    bool number_float(number_float_t value, const string_t& token) override {
-        return dom_.number_float(value, token);
-    }
-    bool string(string_t& value) override { return dom_.string(value); }
-    bool binary(binary_t& value) override { return dom_.binary(value); }
-    bool start_object(std::size_t count) override {
-        object_keys_.emplace_back();
-        return dom_.start_object(count);
-    }
-    bool key(string_t& value) override {
-        if (object_keys_.empty()) {
-            error_ = "JSON parser received an object key outside an object";
-            return false;
-        }
-        if (!object_keys_.back().insert(value).second) {
-            error_ = "duplicate JSON object key " + value;
-            return false;
-        }
-        return dom_.key(value);
-    }
-    bool end_object() override {
-        if (object_keys_.empty()) {
-            error_ = "JSON parser received an unmatched object close";
-            return false;
-        }
-        const bool ok = dom_.end_object();
-        object_keys_.pop_back();
-        return ok;
-    }
-    bool start_array(std::size_t count) override { return dom_.start_array(count); }
-    bool end_array() override { return dom_.end_array(); }
-    bool parse_error(std::size_t, const std::string&, const nlohmann::detail::exception& ex) override {
-        error_ = ex.what();
-        return false;
-    }
-
-    const std::string& error() const { return error_; }
-
-private:
-    nlohmann::detail::json_sax_dom_parser<json> dom_;
-    std::vector<std::set<std::string>> object_keys_;
-    std::string error_;
-};
-
 bool parse_strict_json(const std::string& text, json& value, std::string& err,
                        const std::string& where) {
-    value = json();
-    StrictJsonSax sax(value);
-    if (!json::sax_parse(text, &sax, json::input_format_t::json, true)) {
-        return set_error(err, where + ": " + (sax.error().empty() ? "invalid JSON" : sax.error()));
+    // nlohmann's ordinary DOM parser accepts duplicate object keys (last value wins). That is
+    // dangerous for tool requests: an auditor, prompt renderer, and executor could otherwise
+    // see different meanings. Its public parser callback reports every object/key boundary,
+    // which lets us reject duplicates without depending on version-specific detail classes.
+    std::vector<std::set<std::string>> object_keys;
+    std::string duplicate_key;
+    const json::parser_callback_t callback =
+        [&](int, json::parse_event_t event, json& parsed) -> bool {
+            if (event == json::parse_event_t::object_start) {
+                object_keys.emplace_back();
+            } else if (event == json::parse_event_t::key) {
+                const std::string key = parsed.get<std::string>();
+                if (object_keys.empty() || !object_keys.back().insert(key).second) {
+                    if (duplicate_key.empty()) duplicate_key = key;
+                }
+            } else if (event == json::parse_event_t::object_end && !object_keys.empty()) {
+                object_keys.pop_back();
+            }
+            return true;
+        };
+    try {
+        value = json::parse(text, callback, true, false);
+    } catch (const json::exception& ex) {
+        return set_error(err, where + ": " + ex.what());
     }
+    if (!duplicate_key.empty())
+        return set_error(err, where + ": duplicate JSON object key " + duplicate_key);
     return true;
 }
 

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -1,0 +1,961 @@
+#include "chat_tools.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <map>
+#include <regex>
+#include <set>
+#include <sstream>
+#include <utility>
+
+namespace sparkinfer_server {
+namespace {
+
+using json = nlohmann::json;
+
+constexpr const char* kImStart = "<|im_start|>";
+constexpr const char* kImEnd = "<|im_end|>";
+constexpr const char* kThinkOpen = "<think>";
+constexpr const char* kThinkClose = "</think>";
+constexpr const char* kToolCallOpen = "<tool_call>";
+constexpr const char* kToolCallClose = "</tool_call>";
+constexpr const char* kFunctionOpen = "<function=";
+constexpr const char* kFunctionClose = "</function>";
+constexpr const char* kParameterOpen = "<parameter=";
+constexpr const char* kParameterClose = "</parameter>";
+constexpr const char* kToolResponseOpen = "<tool_response>";
+constexpr const char* kToolResponseClose = "</tool_response>";
+
+const char* kToolInstructions = R"(# Tools
+
+You have access to the following functions:
+
+<tools>)";
+
+const char* kToolInstructionsTail = R"(
+</tools>
+
+If you choose to call a function ONLY reply in the following format with NO suffix:
+
+<tool_call>
+<function=example_function_name>
+<parameter=example_parameter_1>
+value_1
+</parameter>
+<parameter=example_parameter_2>
+This is the value for the second parameter
+that can span
+multiple lines
+</parameter>
+</function>
+</tool_call>
+
+<IMPORTANT>
+Reminder:
+- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags
+- Required parameters MUST be specified
+- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after
+- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls
+</IMPORTANT>)";
+
+bool set_error(std::string& err, const std::string& message) {
+    err = message;
+    return false;
+}
+
+// nlohmann's ordinary DOM parser accepts duplicate object keys (last value wins). That is
+// dangerous for tool requests: an auditor, prompt renderer, and executor could otherwise see
+// different meanings for the same schema or argument object. Forward SAX events to its DOM
+// builder while rejecting a repeated key at every nesting level.
+class StrictJsonSax final : public json::json_sax_t {
+public:
+    explicit StrictJsonSax(json& result) : dom_(result, false) {}
+
+    bool null() override { return dom_.null(); }
+    bool boolean(bool value) override { return dom_.boolean(value); }
+    bool number_integer(number_integer_t value) override { return dom_.number_integer(value); }
+    bool number_unsigned(number_unsigned_t value) override { return dom_.number_unsigned(value); }
+    bool number_float(number_float_t value, const string_t& token) override {
+        return dom_.number_float(value, token);
+    }
+    bool string(string_t& value) override { return dom_.string(value); }
+    bool binary(binary_t& value) override { return dom_.binary(value); }
+    bool start_object(std::size_t count) override {
+        object_keys_.emplace_back();
+        return dom_.start_object(count);
+    }
+    bool key(string_t& value) override {
+        if (object_keys_.empty()) {
+            error_ = "JSON parser received an object key outside an object";
+            return false;
+        }
+        if (!object_keys_.back().insert(value).second) {
+            error_ = "duplicate JSON object key " + value;
+            return false;
+        }
+        return dom_.key(value);
+    }
+    bool end_object() override {
+        if (object_keys_.empty()) {
+            error_ = "JSON parser received an unmatched object close";
+            return false;
+        }
+        const bool ok = dom_.end_object();
+        object_keys_.pop_back();
+        return ok;
+    }
+    bool start_array(std::size_t count) override { return dom_.start_array(count); }
+    bool end_array() override { return dom_.end_array(); }
+    bool parse_error(std::size_t, const std::string&, const nlohmann::detail::exception& ex) override {
+        error_ = ex.what();
+        return false;
+    }
+
+    const std::string& error() const { return error_; }
+
+private:
+    nlohmann::detail::json_sax_dom_parser<json> dom_;
+    std::vector<std::set<std::string>> object_keys_;
+    std::string error_;
+};
+
+bool parse_strict_json(const std::string& text, json& value, std::string& err,
+                       const std::string& where) {
+    value = json();
+    StrictJsonSax sax(value);
+    if (!json::sax_parse(text, &sax, json::input_format_t::json, true)) {
+        return set_error(err, where + ": " + (sax.error().empty() ? "invalid JSON" : sax.error()));
+    }
+    return true;
+}
+
+bool safe_protocol_name(const std::string& value) {
+    if (value.empty()) return false;
+    // Function and top-level argument names are injected into unquoted Qwen protocol tags.
+    // Keep the accepted alphabet deliberately narrower than JSON object keys so no control,
+    // whitespace, quoting, or tag-delimiter byte can change the rendered structure.
+    for (const unsigned char c : value) {
+        if (!std::isalnum(c) && c != '_' && c != '-' && c != '.' && c != ':') return false;
+    }
+    return true;
+}
+
+std::string htmlsafe_json_string(const std::string& value) {
+    std::string encoded = json(value).dump(-1, ' ', true);
+    std::string safe;
+    safe.reserve(encoded.size());
+    for (const char c : encoded) {
+        switch (c) {
+            case '<': safe += "\\u003c"; break;
+            case '>': safe += "\\u003e"; break;
+            case '&': safe += "\\u0026"; break;
+            case '\'': safe += "\\u0027"; break;
+            default: safe.push_back(c); break;
+        }
+    }
+    return safe;
+}
+
+// Jinja's `tojson` filter uses htmlsafe Python json.dumps: sorted object keys, ASCII escapes,
+// and a space after commas/colons. Match that byte-for-byte for the JSON shapes used by the
+// pinned Qwen3.6 template so tools cannot inject template tags through descriptions/schemas.
+std::string qwen_template_json(const json& value) {
+    if (value.is_string()) return htmlsafe_json_string(value.get_ref<const std::string&>());
+    if (value.is_array()) {
+        std::ostringstream out;
+        out << '[';
+        for (size_t i = 0; i < value.size(); ++i) {
+            if (i) out << ", ";
+            out << qwen_template_json(value[i]);
+        }
+        out << ']';
+        return out.str();
+    }
+    if (value.is_object()) {
+        std::ostringstream out;
+        out << '{';
+        bool first = true;
+        for (const auto& item : value.items()) {
+            if (!first) out << ", ";
+            first = false;
+            out << htmlsafe_json_string(item.key()) << ": "
+                << qwen_template_json(item.value());
+        }
+        out << '}';
+        return out.str();
+    }
+    return value.dump(-1, ' ', true);
+}
+
+bool is_allowed_key(const json& object, const std::set<std::string>& allowed,
+                    const std::string& where, std::string& err) {
+    for (const auto& item : object.items()) {
+        if (!allowed.count(item.key()))
+            return set_error(err, where + " contains unsupported field " + item.key());
+    }
+    return true;
+}
+
+bool parse_content(const json& value, std::string& content, bool& is_null,
+                   const std::string& where, std::string& err) {
+    content.clear();
+    is_null = value.is_null();
+    if (is_null) return true;
+    if (value.is_string()) {
+        content = value.get<std::string>();
+        return true;
+    }
+    if (!value.is_array())
+        return set_error(err, where + ".content must be a string, null, or array of text parts");
+    for (size_t i = 0; i < value.size(); ++i) {
+        const json& part = value[i];
+        if (!part.is_object() || !part.contains("type") || !part["type"].is_string())
+            return set_error(err, where + ".content[" + std::to_string(i) + "] must have a string type");
+        if (part["type"] != "text")
+            return set_error(err, where + ".content[" + std::to_string(i) + "] has unsupported non-text type");
+        if (!part.contains("text") || !part["text"].is_string())
+            return set_error(err, where + ".content[" + std::to_string(i) + "].text must be a string");
+        content += part["text"].get<std::string>();
+    }
+    return true;
+}
+
+bool parse_arguments(const json& value, std::string& compact, const std::string& where,
+                     std::string& err) {
+    json arguments;
+    if (value.is_object()) {
+        arguments = value;
+    } else if (value.is_string()) {
+        if (!parse_strict_json(value.get_ref<const std::string&>(), arguments, err,
+                               where + " is not valid JSON")) return false;
+    } else {
+        return set_error(err, where + " must be a JSON object or an object encoded as a string");
+    }
+    if (!arguments.is_object()) return set_error(err, where + " must encode a JSON object");
+    compact = arguments.dump();
+    return true;
+}
+
+bool parse_tool_call(const json& value, ToolCall& call, const std::string& where,
+                     std::string& err) {
+    if (!value.is_object()) return set_error(err, where + " must be an object");
+    if (!is_allowed_key(value, {"id", "type", "function"}, where, err)) return false;
+    if (!value.contains("id") || !value["id"].is_string() || value["id"].get_ref<const std::string&>().empty())
+        return set_error(err, where + ".id must be a non-empty string");
+    if (value.contains("type") && (!value["type"].is_string() || value["type"] != "function"))
+        return set_error(err, where + ".type must be function");
+    if (!value.contains("function") || !value["function"].is_object())
+        return set_error(err, where + ".function must be an object");
+    const json& function = value["function"];
+    if (!is_allowed_key(function, {"name", "arguments"}, where + ".function", err)) return false;
+    if (!function.contains("name") || !function["name"].is_string() ||
+        !safe_protocol_name(function["name"].get_ref<const std::string&>()))
+        return set_error(err, where + ".function.name must be a non-empty string");
+    if (!function.contains("arguments"))
+        return set_error(err, where + ".function.arguments is required");
+    call.id = value["id"].get<std::string>();
+    call.name = function["name"].get<std::string>();
+    return parse_arguments(function["arguments"], call.arguments, where + ".function.arguments", err);
+}
+
+bool is_nonnegative_integer(const json& value) {
+    return value.is_number_unsigned() ||
+           (value.is_number_integer() && value.get<json::number_integer_t>() >= 0);
+}
+
+bool valid_schema_node(const json& schema, const std::string& where, bool top_level,
+                       std::string& err) {
+    if (!schema.is_object()) return set_error(err, where + " must be an object");
+    const std::set<std::string> allowed_types = {
+        "array", "boolean", "integer", "null", "number", "object", "string"};
+    if (schema.contains("type")) {
+        const json& type = schema["type"];
+        if (top_level) {
+            if (!type.is_string() || type != "object")
+                return set_error(err, where + ".type must be object");
+        } else if (type.is_string()) {
+            if (!allowed_types.count(type.get<std::string>()))
+                return set_error(err, where + ".type is unsupported");
+        } else if (type.is_array() && !type.empty()) {
+            std::set<std::string> seen;
+            for (const auto& item : type) {
+                if (!item.is_string() || !allowed_types.count(item.get<std::string>()))
+                    return set_error(err, where + ".type contains an unsupported type");
+                if (!seen.insert(item.get<std::string>()).second)
+                    return set_error(err, where + ".type contains a duplicate type");
+            }
+        } else {
+            return set_error(err, where + ".type must be a string or non-empty array of strings");
+        }
+    }
+    if (schema.contains("properties")) {
+        if (!schema["properties"].is_object())
+            return set_error(err, where + ".properties must be an object");
+        for (const auto& property : schema["properties"].items()) {
+            if (!valid_schema_node(property.value(), where + ".properties." + property.key(),
+                                   false, err)) return false;
+        }
+    }
+    if (schema.contains("required")) {
+        if (!schema["required"].is_array()) return set_error(err, where + ".required must be an array");
+        std::set<std::string> seen;
+        for (const auto& item : schema["required"]) {
+            if (!item.is_string() || item.get_ref<const std::string&>().empty())
+                return set_error(err, where + ".required entries must be non-empty strings");
+            const std::string name = item.get<std::string>();
+            if (!seen.insert(name).second) return set_error(err, where + ".required contains duplicate " + name);
+            if (schema.contains("properties") && !schema["properties"].contains(name))
+                return set_error(err, where + ".required names unknown property " + name);
+        }
+    }
+    if (schema.contains("additionalProperties") && !schema["additionalProperties"].is_boolean() &&
+        !schema["additionalProperties"].is_object())
+        return set_error(err, where + ".additionalProperties must be boolean or an object schema");
+    if (schema.contains("additionalProperties") && schema["additionalProperties"].is_object() &&
+        !valid_schema_node(schema["additionalProperties"], where + ".additionalProperties",
+                           false, err)) return false;
+    if (schema.contains("items")) {
+        if (!schema["items"].is_object())
+            return set_error(err, where + ".items must be an object schema");
+        if (!valid_schema_node(schema["items"], where + ".items", false, err)) return false;
+    }
+    if (schema.contains("enum") && !schema["enum"].is_array())
+        return set_error(err, where + ".enum must be an array");
+    for (const char* keyword : {"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"}) {
+        if (schema.contains(keyword) && !schema[keyword].is_number())
+            return set_error(err, where + "." + keyword + " must be a number");
+    }
+    if (schema.contains("minimum") && schema.contains("maximum") &&
+        schema["minimum"].get<double>() > schema["maximum"].get<double>())
+        return set_error(err, where + ".minimum must not exceed maximum");
+    for (const char* keyword : {"minItems", "maxItems", "minLength", "maxLength"}) {
+        if (schema.contains(keyword) && !is_nonnegative_integer(schema[keyword]))
+            return set_error(err, where + "." + keyword + " must be a non-negative integer");
+    }
+    if (schema.contains("minItems") && schema.contains("maxItems") &&
+        schema["minItems"].get<std::size_t>() > schema["maxItems"].get<std::size_t>())
+        return set_error(err, where + ".minItems must not exceed maxItems");
+    if (schema.contains("minLength") && schema.contains("maxLength") &&
+        schema["minLength"].get<std::size_t>() > schema["maxLength"].get<std::size_t>())
+        return set_error(err, where + ".minLength must not exceed maxLength");
+    if (schema.contains("pattern")) {
+        if (!schema["pattern"].is_string())
+            return set_error(err, where + ".pattern must be a string");
+        try {
+            (void)std::regex(schema["pattern"].get<std::string>(), std::regex::ECMAScript);
+        } catch (const std::regex_error&) {
+            return set_error(err, where + ".pattern is not a valid ECMAScript regular expression");
+        }
+    }
+    return true;
+}
+
+bool valid_schema(const json& schema, const std::string& where, std::string& err) {
+    return valid_schema_node(schema, where, true, err);
+}
+
+bool parse_tool_definition(const json& value, ToolDefinition& tool, const std::string& where,
+                           std::string& err) {
+    if (!value.is_object()) return set_error(err, where + " must be an object");
+    if (!is_allowed_key(value, {"type", "function"}, where, err)) return false;
+    if (!value.contains("type") || !value["type"].is_string() || value["type"] != "function")
+        return set_error(err, where + ".type must be function");
+    if (!value.contains("function") || !value["function"].is_object())
+        return set_error(err, where + ".function must be an object");
+    const json& function = value["function"];
+    if (!is_allowed_key(function, {"name", "description", "parameters", "strict"},
+                        where + ".function", err)) return false;
+    if (!function.contains("name") || !function["name"].is_string() ||
+        !safe_protocol_name(function["name"].get_ref<const std::string&>()))
+        return set_error(err, where + ".function.name is not safe for the Qwen tool protocol");
+    if (function.contains("description") && !function["description"].is_string())
+        return set_error(err, where + ".function.description must be a string");
+    if (!function.contains("parameters"))
+        return set_error(err, where + ".function.parameters is required");
+    if (!valid_schema(function["parameters"], where + ".function.parameters", err)) return false;
+    if (function["parameters"].contains("properties")) {
+        for (const auto& property : function["parameters"]["properties"].items()) {
+            if (!safe_protocol_name(property.key()))
+                return set_error(err, where + ".function.parameters property " + property.key() +
+                                      " is not safe for the Qwen tool protocol");
+        }
+    }
+    if (function.contains("strict") && !function["strict"].is_boolean())
+        return set_error(err, where + ".function.strict must be boolean");
+    tool.name = function["name"].get<std::string>();
+    tool.spec = value;
+    return true;
+}
+
+std::string trim_copy(std::string value) {
+    auto ws = [](unsigned char c) { return std::isspace(c) != 0; };
+    while (!value.empty() && ws(static_cast<unsigned char>(value.front()))) value.erase(value.begin());
+    while (!value.empty() && ws(static_cast<unsigned char>(value.back()))) value.pop_back();
+    return value;
+}
+
+void trim_leading_ws(std::string& value) {
+    while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front()))) value.erase(value.begin());
+}
+
+void trim_trailing_ws(std::string& value) {
+    while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back()))) value.pop_back();
+}
+
+void strip_trailing_im_end(std::string& value) {
+    const std::string marker = kImEnd;
+    const size_t pos = value.rfind(marker);
+    if (pos != std::string::npos && value.substr(pos + marker.size()).find_first_not_of(" \t\r\n") == std::string::npos)
+        value.resize(pos);
+    trim_trailing_ws(value);
+}
+
+bool parse_message(const json& value, ChatMessage& message, size_t index, std::string& err) {
+    const std::string where = "messages[" + std::to_string(index) + "]";
+    if (!value.is_object()) return set_error(err, where + " must be an object");
+    if (!is_allowed_key(value,
+                        {"role", "content", "reasoning_content", "name", "tool_call_id", "tool_calls"},
+                        where, err)) return false;
+    if (!value.contains("role") || !value["role"].is_string())
+        return set_error(err, where + ".role must be a string");
+    message.role = value["role"].get<std::string>();
+    if (message.role != "system" && message.role != "user" && message.role != "assistant" &&
+        message.role != "tool")
+        return set_error(err, where + ".role is unsupported");
+    if (value.contains("content")) {
+        if (!parse_content(value["content"], message.content, message.content_is_null, where, err)) return false;
+    } else {
+        message.content_is_null = true;
+    }
+    if (value.contains("reasoning_content")) {
+        if (!value["reasoning_content"].is_string())
+            return set_error(err, where + ".reasoning_content must be a string");
+        message.reasoning_content = value["reasoning_content"].get<std::string>();
+    }
+    if (value.contains("name")) {
+        if (!value["name"].is_string()) return set_error(err, where + ".name must be a string");
+        message.name = value["name"].get<std::string>();
+    }
+    if (value.contains("tool_call_id")) {
+        if (!value["tool_call_id"].is_string() || value["tool_call_id"].get_ref<const std::string&>().empty())
+            return set_error(err, where + ".tool_call_id must be a non-empty string");
+        message.tool_call_id = value["tool_call_id"].get<std::string>();
+    }
+    if (value.contains("tool_calls")) {
+        if (message.role != "assistant") return set_error(err, where + ".tool_calls is only valid for assistant");
+        if (!value["tool_calls"].is_array() || value["tool_calls"].empty())
+            return set_error(err, where + ".tool_calls must be a non-empty array");
+        std::set<std::string> ids;
+        for (size_t i = 0; i < value["tool_calls"].size(); ++i) {
+            ToolCall call;
+            if (!parse_tool_call(value["tool_calls"][i], call,
+                                 where + ".tool_calls[" + std::to_string(i) + "]", err)) return false;
+            if (!ids.insert(call.id).second) return set_error(err, where + ".tool_calls contains duplicate id " + call.id);
+            message.tool_calls.push_back(std::move(call));
+        }
+    }
+    if (message.role == "system" && index != 0)
+        return set_error(err, "system message must be first");
+    if (message.role == "tool") {
+        if (message.content_is_null) return set_error(err, where + ".content is required for tool messages");
+        if (message.tool_call_id.empty()) return set_error(err, where + ".tool_call_id is required for tool messages");
+    } else if (!message.tool_call_id.empty()) {
+        return set_error(err, where + ".tool_call_id is only valid for tool messages");
+    }
+    if (message.role != "assistant" && message.content_is_null)
+        return set_error(err, where + ".content must not be null for role " + message.role);
+    if (message.role == "assistant" && message.content_is_null && message.tool_calls.empty())
+        return set_error(err, where + " must contain content or tool_calls");
+    return true;
+}
+
+bool resolve_history(const ChatRequest& request, std::string& err) {
+    std::map<std::string, std::string> pending;
+    for (size_t i = 0; i < request.messages.size(); ++i) {
+        const ChatMessage& message = request.messages[i];
+        if (message.role == "assistant" && !message.tool_calls.empty()) {
+            if (!pending.empty())
+                return set_error(err, "messages[" + std::to_string(i) + "] starts new tool calls before all prior tool results");
+            for (const ToolCall& call : message.tool_calls) pending.emplace(call.id, call.name);
+        } else if (message.role == "tool") {
+            auto it = pending.find(message.tool_call_id);
+            if (it == pending.end())
+                return set_error(err, "messages[" + std::to_string(i) + "].tool_call_id does not reference a pending call");
+            if (!message.name.empty() && message.name != it->second)
+                return set_error(err, "messages[" + std::to_string(i) + "].name disagrees with its tool call");
+            pending.erase(it);
+        } else if (!pending.empty()) {
+            return set_error(err, "tool results must immediately follow their assistant tool calls");
+        }
+    }
+    if (!pending.empty()) return set_error(err, "assistant tool calls are missing tool result messages");
+    return true;
+}
+
+std::string json_value_for_parameter(const json& value) {
+    return value.is_string() ? value.get<std::string>() : qwen_template_json(value);
+}
+
+std::string render_tool_call(const ToolCall& call) {
+    json arguments = json::parse(call.arguments);
+    std::ostringstream out;
+    out << kToolCallOpen << '\n' << kFunctionOpen << call.name << ">\n";
+    for (const auto& item : arguments.items()) {
+        out << kParameterOpen << item.key() << ">\n" << json_value_for_parameter(item.value())
+            << '\n' << kParameterClose << '\n';
+    }
+    out << kFunctionClose << '\n' << kToolCallClose;
+    return out.str();
+}
+
+bool has_protocol_markup(const std::string& text) {
+    // Match incomplete/misspelled openings too. A partial protocol tag must never be returned as
+    // assistant content merely because it failed to reach the exact full-marker search below.
+    return text.find("<tool") != std::string::npos || text.find("</tool") != std::string::npos ||
+           text.find("<function") != std::string::npos || text.find("</function") != std::string::npos ||
+           text.find("<parameter") != std::string::npos || text.find("</parameter") != std::string::npos ||
+           text.find("<think") != std::string::npos || text.find("</think") != std::string::npos ||
+           text.find("<tool_response") != std::string::npos ||
+           text.find("</tool_response") != std::string::npos ||
+           text.find("<|im_") != std::string::npos;
+}
+
+ParsedToolOutput fail_tool_output(ParsedToolOutput out, const std::string& error) {
+    out.reasoning_content.clear();
+    out.content.clear();
+    out.tool_calls.clear();
+    out.error = error;
+    return out;
+}
+
+bool parse_scalar_from_text(const std::string& value, json& parsed) {
+    std::string ignored;
+    return parse_strict_json(value, parsed, ignored, "parameter value");
+}
+
+bool validate_value(const json& value, const json& schema, const std::string& path, std::string& err) {
+    if (!schema.is_object()) return true;
+    if (schema.contains("type")) {
+        auto matches = [&](const std::string& type) {
+            if (type == "object") return value.is_object();
+            if (type == "array") return value.is_array();
+            if (type == "string") return value.is_string();
+            if (type == "integer") return value.is_number_integer() || value.is_number_unsigned();
+            if (type == "number") return value.is_number();
+            if (type == "boolean") return value.is_boolean();
+            if (type == "null") return value.is_null();
+            return false;
+        };
+        bool ok = false;
+        if (schema["type"].is_string()) ok = matches(schema["type"].get<std::string>());
+        else if (schema["type"].is_array())
+            for (const auto& type : schema["type"])
+                if (type.is_string() && matches(type.get<std::string>())) ok = true;
+        if (!ok) return set_error(err, path + " has the wrong JSON type");
+    }
+    if (schema.contains("enum")) {
+        if (!schema["enum"].is_array()) return set_error(err, path + " has invalid enum schema");
+        if (std::find(schema["enum"].begin(), schema["enum"].end(), value) == schema["enum"].end())
+            return set_error(err, path + " is not one of the allowed enum values");
+    }
+    if (value.is_number()) {
+        const double number = value.get<double>();
+        if (schema.contains("minimum") && schema["minimum"].is_number() &&
+            number < schema["minimum"].get<double>())
+            return set_error(err, path + " is below minimum");
+        if (schema.contains("maximum") && schema["maximum"].is_number() &&
+            number > schema["maximum"].get<double>())
+            return set_error(err, path + " is above maximum");
+        if (schema.contains("exclusiveMinimum") && schema["exclusiveMinimum"].is_number() &&
+            number <= schema["exclusiveMinimum"].get<double>())
+            return set_error(err, path + " is not above exclusiveMinimum");
+        if (schema.contains("exclusiveMaximum") && schema["exclusiveMaximum"].is_number() &&
+            number >= schema["exclusiveMaximum"].get<double>())
+            return set_error(err, path + " is not below exclusiveMaximum");
+    }
+    if (value.is_string()) {
+        const std::string& string_value = value.get_ref<const std::string&>();
+        if (schema.contains("minLength") &&
+            string_value.size() < schema["minLength"].get<std::size_t>())
+            return set_error(err, path + " is shorter than minLength");
+        if (schema.contains("maxLength") &&
+            string_value.size() > schema["maxLength"].get<std::size_t>())
+            return set_error(err, path + " is longer than maxLength");
+        if (schema.contains("pattern")) {
+            try {
+                const std::regex pattern(schema["pattern"].get<std::string>(),
+                                         std::regex::ECMAScript);
+                if (!std::regex_search(string_value, pattern))
+                    return set_error(err, path + " does not match pattern");
+            } catch (const std::regex_error&) {
+                return set_error(err, path + " has an invalid pattern schema");
+            }
+        }
+    }
+    if (value.is_object()) {
+        const json properties = schema.value("properties", json::object());
+        if (schema.contains("required")) {
+            for (const auto& name : schema["required"])
+                if (!value.contains(name.get<std::string>()))
+                    return set_error(err, path + " is missing required parameter " + name.get<std::string>());
+        }
+        // JSON Schema defaults additionalProperties to true. Only an explicit false closes
+        // the object; this matters for permissive nested schemas such as {"type":"object"}.
+        const bool allow_unknown = !schema.contains("additionalProperties") ||
+                                   schema["additionalProperties"] != json(false);
+        for (const auto& item : value.items()) {
+            if (properties.contains(item.key())) {
+                if (!validate_value(item.value(), properties[item.key()], path + "." + item.key(), err)) return false;
+            } else if (!allow_unknown) {
+                return set_error(err, path + " contains unknown parameter " + item.key());
+            } else if (schema.contains("additionalProperties") &&
+                       schema["additionalProperties"].is_object() &&
+                       !validate_value(item.value(), schema["additionalProperties"],
+                                       path + "." + item.key(), err)) {
+                return false;
+            }
+        }
+    } else if (value.is_array()) {
+        if (schema.contains("minItems") && value.size() < schema["minItems"].get<std::size_t>())
+            return set_error(err, path + " has fewer than minItems elements");
+        if (schema.contains("maxItems") && value.size() > schema["maxItems"].get<std::size_t>())
+            return set_error(err, path + " has more than maxItems elements");
+        if (schema.contains("items")) {
+            for (size_t i = 0; i < value.size(); ++i)
+                if (!validate_value(value[i], schema["items"],
+                                    path + "[" + std::to_string(i) + "]", err)) return false;
+        }
+    }
+    return true;
+}
+
+const ToolDefinition* offered_tool(const ChatRequest& request, const std::string& name) {
+    for (const ToolDefinition& tool : request.tools)
+        if (tool.name == name) return &tool;
+    return nullptr;
+}
+
+bool parse_one_xml_call(const std::string& block, const ChatRequest& request, ToolCall& call,
+                        std::string& err) {
+    size_t pos = 0;
+    while (pos < block.size() && std::isspace(static_cast<unsigned char>(block[pos]))) ++pos;
+    if (block.compare(pos, std::char_traits<char>::length(kFunctionOpen), kFunctionOpen) != 0)
+        return set_error(err, "tool call is missing <function=...>");
+    const size_t name_start = pos + std::char_traits<char>::length(kFunctionOpen);
+    const size_t name_end = block.find('>', name_start);
+    if (name_end == std::string::npos) return set_error(err, "tool call has an unterminated function name");
+    call.name = block.substr(name_start, name_end - name_start);
+    if (!safe_protocol_name(call.name))
+        return set_error(err, "tool call has an invalid function name");
+    const ToolDefinition* tool = offered_tool(request, call.name);
+    if (!tool) return set_error(err, "model called unoffered function " + call.name);
+
+    const json& schema = tool->spec["function"]["parameters"];
+    const json properties = schema.value("properties", json::object());
+    json arguments = json::object();
+    pos = name_end + 1;
+    while (true) {
+        while (pos < block.size() && std::isspace(static_cast<unsigned char>(block[pos]))) ++pos;
+        if (block.compare(pos, std::char_traits<char>::length(kFunctionClose), kFunctionClose) == 0) {
+            pos += std::char_traits<char>::length(kFunctionClose);
+            break;
+        }
+        if (block.compare(pos, std::char_traits<char>::length(kParameterOpen), kParameterOpen) != 0)
+            return set_error(err, "tool call contains malformed text outside parameter tags");
+        const size_t key_start = pos + std::char_traits<char>::length(kParameterOpen);
+        const size_t key_end = block.find('>', key_start);
+        if (key_end == std::string::npos) return set_error(err, "tool call has an unterminated parameter name");
+        const std::string key = block.substr(key_start, key_end - key_start);
+        if (!safe_protocol_name(key))
+            return set_error(err, "tool call has an invalid parameter name");
+        if (arguments.contains(key)) return set_error(err, "tool call contains duplicate parameter " + key);
+        if (!properties.contains(key)) return set_error(err, "tool call contains unknown parameter " + key);
+        const size_t value_start = key_end + 1;
+        const size_t value_end = block.find(kParameterClose, value_start);
+        if (value_end == std::string::npos) return set_error(err, "tool call has an unterminated parameter " + key);
+        std::string value = block.substr(value_start, value_end - value_start);
+        // The official template puts one newline on each side of the value. They are protocol
+        // delimiters, not part of a string argument; preserve every other byte exactly.
+        if (!value.empty() && value.front() == '\n') value.erase(value.begin());
+        if (!value.empty() && value.back() == '\n') value.pop_back();
+        if (has_protocol_markup(value))
+            return set_error(err, "parameter " + key + " contains reserved protocol markup");
+        const json& property_schema = properties[key];
+        std::string type;
+        if (property_schema.contains("type") && property_schema["type"].is_string())
+            type = property_schema["type"].get<std::string>();
+        json parsed;
+        if (type == "string") {
+            parsed = value;
+        } else {
+            if (!parse_scalar_from_text(value, parsed))
+                return set_error(err, "parameter " + key + " is not valid JSON for its schema type");
+        }
+        if (!validate_value(parsed, property_schema, "parameter " + key, err)) return false;
+        arguments[key] = std::move(parsed);
+        pos = value_end + std::char_traits<char>::length(kParameterClose);
+    }
+    if (block.substr(pos).find_first_not_of(" \t\r\n") != std::string::npos)
+        return set_error(err, "tool call contains text after </function>");
+    if (!validate_value(arguments, schema, "arguments for " + call.name, err)) return false;
+    call.arguments = arguments.dump();
+    call.id.clear();
+    return true;
+}
+
+}  // namespace
+
+bool parse_chat_request_json(const std::string& body, ChatRequest& request, std::string& err) {
+    ChatRequest parsed;
+    err.clear();
+    json root;
+    if (!parse_strict_json(body, root, err, "invalid JSON")) return false;
+    if (!root.is_object()) return set_error(err, "request body must be a JSON object");
+    if (!root.contains("messages") || !root["messages"].is_array() || root["messages"].empty())
+        return set_error(err, "messages must be a non-empty array");
+    for (size_t i = 0; i < root["messages"].size(); ++i) {
+        ChatMessage message;
+        if (!parse_message(root["messages"][i], message, i, err)) return false;
+        parsed.messages.push_back(std::move(message));
+    }
+    if (root.contains("tools")) {
+        if (!root["tools"].is_array()) return set_error(err, "tools must be an array");
+        std::set<std::string> names;
+        for (size_t i = 0; i < root["tools"].size(); ++i) {
+            ToolDefinition tool;
+            if (!parse_tool_definition(root["tools"][i], tool,
+                                       "tools[" + std::to_string(i) + "]", err)) return false;
+            if (!names.insert(tool.name).second) return set_error(err, "tools contains duplicate function " + tool.name);
+            parsed.tools.push_back(std::move(tool));
+        }
+    }
+    if (root.contains("tool_choice")) {
+        const json& choice = root["tool_choice"];
+        if (!choice.is_string())
+            return set_error(err, "named/object tool_choice is not supported; use auto or none");
+        const std::string value = choice.get<std::string>();
+        if (value == "auto") parsed.tool_choice = ToolChoiceMode::kAuto;
+        else if (value == "none") parsed.tool_choice = ToolChoiceMode::kNone;
+        else if (value == "required") return set_error(err, "tool_choice=required is not supported");
+        else return set_error(err, "unsupported tool_choice " + value + "; use auto or none");
+    }
+    if (root.contains("parallel_tool_calls")) {
+        if (!root["parallel_tool_calls"].is_boolean())
+            return set_error(err, "parallel_tool_calls must be a boolean");
+        parsed.parallel_tool_calls = root["parallel_tool_calls"].get<bool>();
+        if (!parsed.parallel_tool_calls)
+            return set_error(err, "parallel_tool_calls=false is not supported");
+    }
+    if (parsed.tools.empty() && parsed.tool_choice != ToolChoiceMode::kNone)
+        parsed.tool_choice = ToolChoiceMode::kNone;
+    std::set<std::string> offered;
+    for (const ToolDefinition& tool : parsed.tools) offered.insert(tool.name);
+    for (size_t i = 0; i < parsed.messages.size(); ++i) {
+        for (const ToolCall& call : parsed.messages[i].tool_calls) {
+            if (!offered.count(call.name))
+                return set_error(err, "messages[" + std::to_string(i) + "] references unoffered function " + call.name);
+            const ToolDefinition* tool = offered_tool(parsed, call.name);
+            json arguments;
+            if (!parse_strict_json(call.arguments, arguments, err,
+                                   "messages[" + std::to_string(i) +
+                                       "].tool_calls arguments")) return false;
+            const json properties =
+                tool->spec["function"]["parameters"].value("properties", json::object());
+            for (const auto& argument : arguments.items()) {
+                if (!safe_protocol_name(argument.key()))
+                    return set_error(err, "messages[" + std::to_string(i) +
+                                              "].tool_calls contains an unsafe parameter name");
+                if (!properties.contains(argument.key()))
+                    return set_error(err, "messages[" + std::to_string(i) +
+                                              "].tool_calls contains unknown parameter " +
+                                              argument.key());
+            }
+            if (!validate_value(arguments, tool->spec["function"]["parameters"],
+                                "messages[" + std::to_string(i) + "].tool_calls arguments", err)) return false;
+        }
+    }
+    if (!resolve_history(parsed, err)) return false;
+    request = std::move(parsed);
+    return true;
+}
+
+std::string apply_qwen36_tools_template(const ChatRequest& request, bool enable_thinking) {
+    std::ostringstream out;
+    size_t first_message = 0;
+    if (!request.tools.empty() && request.tool_choice == ToolChoiceMode::kAuto) {
+        out << kImStart << "system\n" << kToolInstructions;
+        for (const ToolDefinition& tool : request.tools)
+            out << '\n' << qwen_template_json(tool.spec);
+        out << kToolInstructionsTail;
+        if (!request.messages.empty() && request.messages[0].role == "system") {
+            const std::string system_content = trim_copy(request.messages[0].content);
+            if (!system_content.empty()) out << "\n\n" << system_content;
+        }
+        out << kImEnd << '\n';
+        if (!request.messages.empty() && request.messages[0].role == "system") first_message = 1;
+    }
+    size_t last_user = request.messages.size();
+    for (size_t i = request.messages.size(); i > 0; --i) {
+        if (request.messages[i - 1].role == "user") {
+            last_user = i - 1;
+            break;
+        }
+    }
+    for (size_t i = first_message; i < request.messages.size(); ++i) {
+        const ChatMessage& message = request.messages[i];
+        if (message.role == "tool") {
+            out << kImStart << "user";
+            do {
+                out << '\n' << kToolResponseOpen << '\n' << trim_copy(request.messages[i].content)
+                    << '\n' << kToolResponseClose;
+                ++i;
+            } while (i < request.messages.size() && request.messages[i].role == "tool");
+            out << kImEnd << '\n';
+            --i;
+            continue;
+        }
+        out << kImStart << message.role << '\n';
+        if (message.role == "assistant") {
+            std::string content = trim_copy(message.content);
+            std::string reasoning = trim_copy(message.reasoning_content);
+            // Match the pinned tokenizer template's compatibility path for clients which put
+            // a previous turn's reasoning and answer together in content instead of sending
+            // reasoning_content separately.
+            if (reasoning.empty()) {
+                const size_t first_close = content.find(kThinkClose);
+                if (first_close != std::string::npos) {
+                    std::string embedded_reasoning = content.substr(0, first_close);
+                    const size_t last_open = embedded_reasoning.rfind(kThinkOpen);
+                    if (last_open != std::string::npos)
+                        embedded_reasoning.erase(0, last_open +
+                                                        std::char_traits<char>::length(kThinkOpen));
+                    reasoning = trim_copy(std::move(embedded_reasoning));
+                    const size_t last_close = content.rfind(kThinkClose);
+                    content = trim_copy(content.substr(last_close +
+                                                       std::char_traits<char>::length(kThinkClose)));
+                }
+            }
+            // The pinned template preserves reasoning only for assistant/tool steps after the
+            // latest real user query. Older chain-of-thought is intentionally not replayed.
+            if (i > last_user)
+                out << kThinkOpen << '\n' << reasoning << '\n' << kThinkClose << "\n\n";
+            if (!message.content_is_null) out << content;
+            for (size_t j = 0; j < message.tool_calls.size(); ++j) {
+                if (j == 0 && !content.empty()) out << "\n\n";
+                else if (j > 0) out << '\n';
+                out << render_tool_call(message.tool_calls[j]);
+            }
+        } else {
+            out << trim_copy(message.content);
+        }
+        out << kImEnd << '\n';
+    }
+    out << kImStart << "assistant\n";
+    if (enable_thinking) out << kThinkOpen << '\n';
+    else out << kThinkOpen << "\n\n" << kThinkClose << "\n\n";
+    return out.str();
+}
+
+ParsedToolOutput parse_qwen36_tool_output(const std::string& raw, bool enable_thinking,
+                                          const ChatRequest& request) {
+    ParsedToolOutput out;
+    std::string remaining = raw;
+    if (enable_thinking) {
+        const size_t open = remaining.find(kThinkOpen);
+        if (open != std::string::npos) {
+            if (remaining.substr(0, open).find_first_not_of(" \t\r\n") != std::string::npos) {
+                return fail_tool_output(std::move(out), "unexpected text before <think>");
+            }
+            const size_t close = remaining.find(kThinkClose, open + std::char_traits<char>::length(kThinkOpen));
+            if (close == std::string::npos) {
+                return fail_tool_output(std::move(out), "unterminated <think> block");
+            }
+            out.reasoning_content = remaining.substr(open + std::char_traits<char>::length(kThinkOpen),
+                                                     close - open - std::char_traits<char>::length(kThinkOpen));
+            trim_leading_ws(out.reasoning_content);
+            trim_trailing_ws(out.reasoning_content);
+            remaining.erase(0, close + std::char_traits<char>::length(kThinkClose));
+            trim_leading_ws(remaining);
+        } else {
+            // With enable_thinking=true the generation prompt itself ends in "<think>\n", so the
+            // generated suffix normally begins with reasoning text and only emits </think>.
+            const size_t close = remaining.find(kThinkClose);
+            if (close != std::string::npos) {
+                out.reasoning_content = remaining.substr(0, close);
+                trim_leading_ws(out.reasoning_content);
+                trim_trailing_ws(out.reasoning_content);
+                remaining.erase(0, close + std::char_traits<char>::length(kThinkClose));
+                trim_leading_ws(remaining);
+            } else {
+                return fail_tool_output(std::move(out), "unterminated implicit <think> block");
+            }
+        }
+    } else {
+        const size_t close = remaining.find(kThinkClose);
+        if (close != std::string::npos) {
+            const size_t open = remaining.rfind(kThinkOpen, close);
+            if (open == std::string::npos) {
+                return fail_tool_output(std::move(out), "unmatched </think> marker");
+            }
+            remaining.erase(open, close + std::char_traits<char>::length(kThinkClose) - open);
+            trim_leading_ws(remaining);
+        }
+    }
+
+    if (has_protocol_markup(out.reasoning_content)) {
+        return fail_tool_output(std::move(out), "reasoning contains reserved protocol markup");
+    }
+
+    const size_t first_call = remaining.find(kToolCallOpen);
+    if (first_call == std::string::npos) {
+        out.content = remaining;
+        strip_trailing_im_end(out.content);
+        if (has_protocol_markup(out.content)) {
+            return fail_tool_output(std::move(out), "malformed tool-call markup");
+        }
+        return out;
+    }
+    if (request.tools.empty() || request.tool_choice == ToolChoiceMode::kNone) {
+        return fail_tool_output(std::move(out), "model emitted a tool call when tools were unavailable");
+    }
+    out.content = remaining.substr(0, first_call);
+    trim_trailing_ws(out.content);
+    if (has_protocol_markup(out.content)) {
+        return fail_tool_output(std::move(out),
+                                "assistant content contains reserved protocol markup");
+    }
+    size_t pos = first_call;
+    while (pos < remaining.size()) {
+        while (pos < remaining.size() && std::isspace(static_cast<unsigned char>(remaining[pos]))) ++pos;
+        if (remaining.compare(pos, std::char_traits<char>::length(kImEnd), kImEnd) == 0) {
+            pos += std::char_traits<char>::length(kImEnd);
+            while (pos < remaining.size() && std::isspace(static_cast<unsigned char>(remaining[pos]))) ++pos;
+            if (pos != remaining.size()) {
+                return fail_tool_output(std::move(out), "text follows terminal <|im_end|>");
+            }
+            break;
+        }
+        if (remaining.compare(pos, std::char_traits<char>::length(kToolCallOpen), kToolCallOpen) != 0) {
+            return fail_tool_output(std::move(out), "text or malformed markup appears after a tool call");
+        }
+        const size_t body_start = pos + std::char_traits<char>::length(kToolCallOpen);
+        const size_t end = remaining.find(kToolCallClose, body_start);
+        if (end == std::string::npos) {
+            return fail_tool_output(std::move(out), "unterminated <tool_call> block");
+        }
+        ToolCall call;
+        if (!parse_one_xml_call(remaining.substr(body_start, end - body_start), request, call, out.error)) {
+            const std::string error = out.error;
+            return fail_tool_output(std::move(out), error);
+        }
+        out.tool_calls.push_back(std::move(call));
+        pos = end + std::char_traits<char>::length(kToolCallClose);
+    }
+    if (!request.parallel_tool_calls && out.tool_calls.size() > 1) {
+        return fail_tool_output(std::move(out),
+                                "model emitted parallel tool calls when they were disabled");
+    }
+    return out;
+}
+
+}  // namespace sparkinfer_server

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -185,8 +185,11 @@ bool parse_content(const json& value, std::string& content, bool& is_null,
         const json& part = value[i];
         if (!part.is_object() || !part.contains("type") || !part["type"].is_string())
             return set_error(err, where + ".content[" + std::to_string(i) + "] must have a string type");
-        if (part["type"] != "text")
-            return set_error(err, where + ".content[" + std::to_string(i) + "] has unsupported non-text type");
+        // Non-text parts (image_url, audio, ...) are ignored, not rejected -- this backend has
+        // no vision/audio input path, but a client sending a mixed multimodal payload (common
+        // even against text-only backends, since agent frameworks often build one payload
+        // shape for every provider) should still get an answer from the text that IS present.
+        if (part["type"] != "text") continue;
         if (!part.contains("text") || !part["text"].is_string())
             return set_error(err, where + ".content[" + std::to_string(i) + "].text must be a string");
         content += part["text"].get<std::string>();
@@ -511,6 +514,10 @@ bool parse_message(const json& value, ChatMessage& message, size_t index, std::s
     if (!value.contains("role") || !value["role"].is_string())
         return set_error(err, where + ".role must be a string");
     message.role = value["role"].get<std::string>();
+    // "developer" is OpenAI's newer replacement for "system" (some current client SDKs send
+    // it by default) -- treat it as an alias rather than rejecting a request this backend can
+    // otherwise serve perfectly well.
+    if (message.role == "developer") message.role = "system";
     if (message.role != "system" && message.role != "user" && message.role != "assistant" &&
         message.role != "tool")
         return set_error(err, where + ".role is unsupported");
@@ -589,7 +596,14 @@ std::string json_value_for_parameter(const json& value) {
 }
 
 std::string render_tool_call(const ToolCall& call) {
-    json arguments = json::parse(call.arguments);
+    // call.arguments is always produced internally by parse_arguments's own .dump(), so this
+    // should be unreachable -- but every other JSON parse in this file goes through the
+    // exception-safe parse_strict_json rather than the throwing overload, to avoid an uncaught
+    // exception surfacing as an unstructured 500 from inside the HTTP handler.
+    json arguments;
+    std::string parse_err;
+    if (!parse_strict_json(call.arguments, arguments, parse_err, "tool call arguments"))
+        arguments = json::object();
     std::ostringstream out;
     out << kToolCallOpen << '\n' << kFunctionOpen << call.name << ">\n";
     for (const auto& item : arguments.items()) {
@@ -1106,6 +1120,11 @@ ParsedToolOutput parse_qwen36_tool_output(const std::string& raw, bool enable_th
     size_t pos = first_call;
     while (pos < remaining.size()) {
         while (pos < remaining.size() && std::isspace(static_cast<unsigned char>(remaining[pos]))) ++pos;
+        // Trailing whitespace with nothing after it (e.g. a lone newline the model emitted
+        // right before hitting EOS/token-limit, with no literal <|im_end|> text -- decode()
+        // skips special-token text entirely, so that's the common case, not an edge case) is a
+        // clean end of output, not "malformed markup after a tool call".
+        if (pos == remaining.size()) break;
         if (remaining.compare(pos, std::char_traits<char>::length(kImEnd), kImEnd) == 0) {
             pos += std::char_traits<char>::length(kImEnd);
             while (pos < remaining.size() && std::isspace(static_cast<unsigned char>(remaining[pos]))) ++pos;

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstdint>
+#include <initializer_list>
 #include <map>
-#include <regex>
+#include <re2/re2.h>
 #include <set>
 #include <sstream>
 #include <utility>
@@ -61,6 +63,12 @@ Reminder:
 bool set_error(std::string& err, const std::string& message) {
     err = message;
     return false;
+}
+
+re2::RE2::Options safe_regex_options() {
+    re2::RE2::Options options;
+    options.set_log_errors(false);
+    return options;
 }
 
 bool parse_strict_json(const std::string& text, json& value, std::string& err,
@@ -229,9 +237,100 @@ bool is_nonnegative_integer(const json& value) {
            (value.is_number_integer() && value.get<json::number_integer_t>() >= 0);
 }
 
+int compare_integer_to_float(const json& integer, double floating) {
+    if (integer.is_number_unsigned()) {
+        const uint64_t value = integer.get<json::number_unsigned_t>();
+        if (floating < 0.0) return 1;
+        // 2^64 is exactly representable as double; every uint64_t is below it.
+        if (floating >= 18446744073709551616.0) return -1;
+        const uint64_t truncated = static_cast<uint64_t>(floating);
+        if (value < truncated) return -1;
+        if (value > truncated) return 1;
+        if (floating > static_cast<double>(truncated)) return -1;
+        return 0;
+    }
+    const int64_t value = integer.get<json::number_integer_t>();
+    // Both powers of two are exact doubles and bound every int64_t conversion.
+    if (floating < -9223372036854775808.0) return 1;
+    if (floating >= 9223372036854775808.0) return -1;
+    const int64_t truncated = static_cast<int64_t>(floating);
+    if (value < truncated) return -1;
+    if (value > truncated) return 1;
+    const double truncated_float = static_cast<double>(truncated);
+    if (floating > truncated_float) return -1;
+    if (floating < truncated_float) return 1;
+    return 0;
+}
+
+int compare_json_numbers(const json& lhs, const json& rhs) {
+    const bool lhs_float = lhs.is_number_float();
+    const bool rhs_float = rhs.is_number_float();
+    if (lhs_float && rhs_float) {
+        const double left = lhs.get<json::number_float_t>();
+        const double right = rhs.get<json::number_float_t>();
+        return left < right ? -1 : (left > right ? 1 : 0);
+    }
+    if (!lhs_float && rhs_float)
+        return compare_integer_to_float(lhs, rhs.get<json::number_float_t>());
+    if (lhs_float && !rhs_float)
+        return -compare_integer_to_float(rhs, lhs.get<json::number_float_t>());
+    if (lhs.is_number_unsigned() && rhs.is_number_unsigned()) {
+        const uint64_t left = lhs.get<json::number_unsigned_t>();
+        const uint64_t right = rhs.get<json::number_unsigned_t>();
+        return left < right ? -1 : (left > right ? 1 : 0);
+    }
+    if (!lhs.is_number_unsigned() && !rhs.is_number_unsigned()) {
+        const int64_t left = lhs.get<json::number_integer_t>();
+        const int64_t right = rhs.get<json::number_integer_t>();
+        return left < right ? -1 : (left > right ? 1 : 0);
+    }
+    if (lhs.is_number_unsigned()) {
+        const int64_t right = rhs.get<json::number_integer_t>();
+        if (right < 0) return 1;
+        const uint64_t left = lhs.get<json::number_unsigned_t>();
+        const uint64_t converted = static_cast<uint64_t>(right);
+        return left < converted ? -1 : (left > converted ? 1 : 0);
+    }
+    const int64_t left = lhs.get<json::number_integer_t>();
+    if (left < 0) return -1;
+    const uint64_t converted = static_cast<uint64_t>(left);
+    const uint64_t right = rhs.get<json::number_unsigned_t>();
+    return converted < right ? -1 : (converted > right ? 1 : 0);
+}
+
+bool declared_type_allows(const json& schema, const char* wanted) {
+    if (!schema.contains("type")) return true;
+    const json& type = schema["type"];
+    if (type.is_string()) return type == wanted;
+    if (type.is_array())
+        return std::find(type.begin(), type.end(), json(wanted)) != type.end();
+    return false;
+}
+
+bool require_keyword_type(const json& schema, const std::string& where,
+                          std::initializer_list<const char*> keywords,
+                          const char* required_type, std::string& err) {
+    if (declared_type_allows(schema, required_type)) return true;
+    for (const char* keyword : keywords) {
+        if (schema.contains(keyword))
+            return set_error(err, where + "." + keyword + " requires type " + required_type);
+    }
+    return true;
+}
+
 bool valid_schema_node(const json& schema, const std::string& where, bool top_level,
                        std::string& err) {
     if (!schema.is_object()) return set_error(err, where + " must be an object");
+    if (!is_allowed_key(schema,
+                        {"type", "description", "default", "title", "properties",
+                         "required", "additionalProperties", "items", "enum", "minimum",
+                         "maximum", "exclusiveMinimum", "exclusiveMaximum", "minItems",
+                         "maxItems", "minLength", "maxLength", "pattern"},
+                        where, err)) return false;
+    for (const char* annotation : {"description", "title"}) {
+        if (schema.contains(annotation) && !schema[annotation].is_string())
+            return set_error(err, where + "." + annotation + " must be a string");
+    }
     const std::set<std::string> allowed_types = {
         "array", "boolean", "integer", "null", "number", "object", "string"};
     if (schema.contains("type")) {
@@ -254,6 +353,22 @@ bool valid_schema_node(const json& schema, const std::string& where, bool top_le
             return set_error(err, where + ".type must be a string or non-empty array of strings");
         }
     }
+    if (!require_keyword_type(schema, where,
+                              {"properties", "required", "additionalProperties"},
+                              "object", err) ||
+        !require_keyword_type(schema, where, {"items", "minItems", "maxItems"},
+                              "array", err) ||
+        !require_keyword_type(schema, where, {"minLength", "maxLength", "pattern"},
+                              "string", err)) return false;
+    if (!declared_type_allows(schema, "number") &&
+        !declared_type_allows(schema, "integer")) {
+        for (const char* keyword :
+             {"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"}) {
+            if (schema.contains(keyword))
+                return set_error(err, where + "." + keyword +
+                                      " requires type number or integer");
+        }
+    }
     if (schema.contains("properties")) {
         if (!schema["properties"].is_object())
             return set_error(err, where + ".properties must be an object");
@@ -270,8 +385,11 @@ bool valid_schema_node(const json& schema, const std::string& where, bool top_le
                 return set_error(err, where + ".required entries must be non-empty strings");
             const std::string name = item.get<std::string>();
             if (!seen.insert(name).second) return set_error(err, where + ".required contains duplicate " + name);
-            if (schema.contains("properties") && !schema["properties"].contains(name))
-                return set_error(err, where + ".required names unknown property " + name);
+            if (schema.contains("properties") && !schema["properties"].contains(name) &&
+                schema.contains("additionalProperties") &&
+                schema["additionalProperties"].is_boolean() &&
+                !schema["additionalProperties"].get<bool>())
+                return set_error(err, where + ".required names a forbidden property " + name);
         }
     }
     if (schema.contains("additionalProperties") && !schema["additionalProperties"].is_boolean() &&
@@ -285,14 +403,15 @@ bool valid_schema_node(const json& schema, const std::string& where, bool top_le
             return set_error(err, where + ".items must be an object schema");
         if (!valid_schema_node(schema["items"], where + ".items", false, err)) return false;
     }
-    if (schema.contains("enum") && !schema["enum"].is_array())
-        return set_error(err, where + ".enum must be an array");
+    if (schema.contains("enum") &&
+        (!schema["enum"].is_array() || schema["enum"].empty()))
+        return set_error(err, where + ".enum must be a non-empty array");
     for (const char* keyword : {"minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum"}) {
         if (schema.contains(keyword) && !schema[keyword].is_number())
             return set_error(err, where + "." + keyword + " must be a number");
     }
     if (schema.contains("minimum") && schema.contains("maximum") &&
-        schema["minimum"].get<double>() > schema["maximum"].get<double>())
+        compare_json_numbers(schema["minimum"], schema["maximum"]) > 0)
         return set_error(err, where + ".minimum must not exceed maximum");
     for (const char* keyword : {"minItems", "maxItems", "minLength", "maxLength"}) {
         if (schema.contains(keyword) && !is_nonnegative_integer(schema[keyword]))
@@ -307,11 +426,10 @@ bool valid_schema_node(const json& schema, const std::string& where, bool top_le
     if (schema.contains("pattern")) {
         if (!schema["pattern"].is_string())
             return set_error(err, where + ".pattern must be a string");
-        try {
-            (void)std::regex(schema["pattern"].get<std::string>(), std::regex::ECMAScript);
-        } catch (const std::regex_error&) {
-            return set_error(err, where + ".pattern is not a valid ECMAScript regular expression");
-        }
+        const re2::RE2 pattern(schema["pattern"].get_ref<const std::string&>(),
+                               safe_regex_options());
+        if (!pattern.ok())
+            return set_error(err, where + ".pattern is not a supported safe regular expression");
     }
     return true;
 }
@@ -343,6 +461,14 @@ bool parse_tool_definition(const json& value, ToolDefinition& tool, const std::s
         for (const auto& property : function["parameters"]["properties"].items()) {
             if (!safe_protocol_name(property.key()))
                 return set_error(err, where + ".function.parameters property " + property.key() +
+                                      " is not safe for the Qwen tool protocol");
+        }
+    }
+    if (function["parameters"].contains("required")) {
+        for (const auto& property : function["parameters"]["required"]) {
+            if (!safe_protocol_name(property.get_ref<const std::string&>()))
+                return set_error(err, where + ".function.parameters required property " +
+                                      property.get<std::string>() +
                                       " is not safe for the Qwen tool protocol");
         }
     }
@@ -499,6 +625,69 @@ bool parse_scalar_from_text(const std::string& value, json& parsed) {
     return parse_strict_json(value, parsed, ignored, "parameter value");
 }
 
+bool schema_allows_type(const json& schema, const std::string& wanted) {
+    if (schema.contains("type")) {
+        const json& type = schema["type"];
+        if (type.is_string()) return type == wanted;
+        if (type.is_array())
+            return std::find(type.begin(), type.end(), json(wanted)) != type.end();
+        return false;
+    }
+    if (!schema.contains("enum")) return true;
+    for (const auto& item : schema["enum"]) {
+        if ((wanted == "string" && item.is_string()) ||
+            (wanted == "object" && item.is_object()) ||
+            (wanted == "array" && item.is_array()) ||
+            (wanted == "integer" && (item.is_number_integer() || item.is_number_unsigned())) ||
+            (wanted == "number" && item.is_number()) ||
+            (wanted == "boolean" && item.is_boolean()) ||
+            (wanted == "null" && item.is_null())) return true;
+    }
+    return false;
+}
+
+bool schema_allows_non_string(const json& schema) {
+    for (const char* type : {"object", "array", "integer", "number", "boolean", "null"})
+        if (schema_allows_type(schema, type)) return true;
+    return false;
+}
+
+bool utf8_code_point_count(const std::string& value, std::size_t& count) {
+    count = 0;
+    for (std::size_t i = 0; i < value.size();) {
+        const unsigned char lead = static_cast<unsigned char>(value[i]);
+        std::size_t length = 0;
+        uint32_t code_point = 0;
+        if (lead <= 0x7f) {
+            length = 1;
+            code_point = lead;
+        } else if (lead >= 0xc2 && lead <= 0xdf) {
+            length = 2;
+            code_point = lead & 0x1f;
+        } else if (lead >= 0xe0 && lead <= 0xef) {
+            length = 3;
+            code_point = lead & 0x0f;
+        } else if (lead >= 0xf0 && lead <= 0xf4) {
+            length = 4;
+            code_point = lead & 0x07;
+        } else {
+            return false;
+        }
+        if (i + length > value.size()) return false;
+        for (std::size_t j = 1; j < length; ++j) {
+            const unsigned char continuation = static_cast<unsigned char>(value[i + j]);
+            if ((continuation & 0xc0) != 0x80) return false;
+            code_point = (code_point << 6) | (continuation & 0x3f);
+        }
+        if ((length == 3 && code_point >= 0xd800 && code_point <= 0xdfff) ||
+            (length == 3 && code_point < 0x800) ||
+            (length == 4 && (code_point < 0x10000 || code_point > 0x10ffff))) return false;
+        ++count;
+        i += length;
+    }
+    return true;
+}
+
 bool validate_value(const json& value, const json& schema, const std::string& path, std::string& err) {
     if (!schema.is_object()) return true;
     if (schema.contains("type")) {
@@ -525,37 +714,37 @@ bool validate_value(const json& value, const json& schema, const std::string& pa
             return set_error(err, path + " is not one of the allowed enum values");
     }
     if (value.is_number()) {
-        const double number = value.get<double>();
         if (schema.contains("minimum") && schema["minimum"].is_number() &&
-            number < schema["minimum"].get<double>())
+            compare_json_numbers(value, schema["minimum"]) < 0)
             return set_error(err, path + " is below minimum");
         if (schema.contains("maximum") && schema["maximum"].is_number() &&
-            number > schema["maximum"].get<double>())
+            compare_json_numbers(value, schema["maximum"]) > 0)
             return set_error(err, path + " is above maximum");
         if (schema.contains("exclusiveMinimum") && schema["exclusiveMinimum"].is_number() &&
-            number <= schema["exclusiveMinimum"].get<double>())
+            compare_json_numbers(value, schema["exclusiveMinimum"]) <= 0)
             return set_error(err, path + " is not above exclusiveMinimum");
         if (schema.contains("exclusiveMaximum") && schema["exclusiveMaximum"].is_number() &&
-            number >= schema["exclusiveMaximum"].get<double>())
+            compare_json_numbers(value, schema["exclusiveMaximum"]) >= 0)
             return set_error(err, path + " is not below exclusiveMaximum");
     }
     if (value.is_string()) {
         const std::string& string_value = value.get_ref<const std::string&>();
+        std::size_t string_length = 0;
+        if (!utf8_code_point_count(string_value, string_length))
+            return set_error(err, path + " is not valid UTF-8");
         if (schema.contains("minLength") &&
-            string_value.size() < schema["minLength"].get<std::size_t>())
+            string_length < schema["minLength"].get<std::size_t>())
             return set_error(err, path + " is shorter than minLength");
         if (schema.contains("maxLength") &&
-            string_value.size() > schema["maxLength"].get<std::size_t>())
+            string_length > schema["maxLength"].get<std::size_t>())
             return set_error(err, path + " is longer than maxLength");
         if (schema.contains("pattern")) {
-            try {
-                const std::regex pattern(schema["pattern"].get<std::string>(),
-                                         std::regex::ECMAScript);
-                if (!std::regex_search(string_value, pattern))
-                    return set_error(err, path + " does not match pattern");
-            } catch (const std::regex_error&) {
+            const re2::RE2 pattern(schema["pattern"].get_ref<const std::string&>(),
+                                   safe_regex_options());
+            if (!pattern.ok())
                 return set_error(err, path + " has an invalid pattern schema");
-            }
+            if (!re2::RE2::PartialMatch(string_value, pattern))
+                return set_error(err, path + " does not match pattern");
         }
     }
     if (value.is_object()) {
@@ -593,6 +782,42 @@ bool validate_value(const json& value, const json& schema, const std::string& pa
         }
     }
     return true;
+}
+
+bool parse_parameter_value(const std::string& value, const json& schema, json& parsed) {
+    const bool allows_string = schema_allows_type(schema, "string");
+    const bool allows_non_string = schema_allows_non_string(schema);
+    if (allows_string && !allows_non_string) {
+        parsed = value;
+        return true;
+    }
+    if (allows_non_string) {
+        json candidate;
+        if (parse_scalar_from_text(value, candidate)) {
+            std::string validation_error;
+            if (validate_value(candidate, schema, "parameter value", validation_error)) {
+                parsed = std::move(candidate);
+                return true;
+            }
+        }
+    }
+    if (allows_string) {
+        parsed = value;
+        return true;
+    }
+    return false;
+}
+
+const json* property_schema_for_key(const json& object_schema, const json& properties,
+                                    const std::string& key) {
+    if (properties.contains(key)) return &properties[key];
+    if (object_schema.contains("additionalProperties")) {
+        const json& additional = object_schema["additionalProperties"];
+        if (additional.is_boolean() && !additional.get<bool>()) return nullptr;
+        if (additional.is_object()) return &additional;
+    }
+    static const json unconstrained = json::object();
+    return &unconstrained;
 }
 
 const ToolDefinition* offered_tool(const ChatRequest& request, const std::string& name) {
@@ -635,7 +860,9 @@ bool parse_one_xml_call(const std::string& block, const ChatRequest& request, To
         if (!safe_protocol_name(key))
             return set_error(err, "tool call has an invalid parameter name");
         if (arguments.contains(key)) return set_error(err, "tool call contains duplicate parameter " + key);
-        if (!properties.contains(key)) return set_error(err, "tool call contains unknown parameter " + key);
+        const json* property_schema = property_schema_for_key(schema, properties, key);
+        if (!property_schema)
+            return set_error(err, "tool call contains unknown parameter " + key);
         const size_t value_start = key_end + 1;
         const size_t value_end = block.find(kParameterClose, value_start);
         if (value_end == std::string::npos) return set_error(err, "tool call has an unterminated parameter " + key);
@@ -646,18 +873,10 @@ bool parse_one_xml_call(const std::string& block, const ChatRequest& request, To
         if (!value.empty() && value.back() == '\n') value.pop_back();
         if (has_protocol_markup(value))
             return set_error(err, "parameter " + key + " contains reserved protocol markup");
-        const json& property_schema = properties[key];
-        std::string type;
-        if (property_schema.contains("type") && property_schema["type"].is_string())
-            type = property_schema["type"].get<std::string>();
         json parsed;
-        if (type == "string") {
-            parsed = value;
-        } else {
-            if (!parse_scalar_from_text(value, parsed))
-                return set_error(err, "parameter " + key + " is not valid JSON for its schema type");
-        }
-        if (!validate_value(parsed, property_schema, "parameter " + key, err)) return false;
+        if (!parse_parameter_value(value, *property_schema, parsed))
+            return set_error(err, "parameter " + key + " is not valid for its schema type");
+        if (!validate_value(parsed, *property_schema, "parameter " + key, err)) return false;
         arguments[key] = std::move(parsed);
         pos = value_end + std::char_traits<char>::length(kParameterClose);
     }
@@ -725,16 +944,10 @@ bool parse_chat_request_json(const std::string& body, ChatRequest& request, std:
             if (!parse_strict_json(call.arguments, arguments, err,
                                    "messages[" + std::to_string(i) +
                                        "].tool_calls arguments")) return false;
-            const json properties =
-                tool->spec["function"]["parameters"].value("properties", json::object());
             for (const auto& argument : arguments.items()) {
                 if (!safe_protocol_name(argument.key()))
                     return set_error(err, "messages[" + std::to_string(i) +
                                               "].tool_calls contains an unsafe parameter name");
-                if (!properties.contains(argument.key()))
-                    return set_error(err, "messages[" + std::to_string(i) +
-                                              "].tool_calls contains unknown parameter " +
-                                              argument.key());
             }
             if (!validate_value(arguments, tool->spec["function"]["parameters"],
                                 "messages[" + std::to_string(i) + "].tool_calls arguments", err)) return false;

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -435,6 +435,7 @@ CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_
     out.alloc_failed = result.alloc_failed;
     out.timed_out = result.timed_out;
     out.cancelled = result.cancelled;
+    out.reached_token_limit = result.reached_token_limit;
     out.ttft_ms = result.ttft_ms;
     out.generation_ms = result.generation_ms;
     out.decode_tps = result.decode_tps;

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -49,6 +49,11 @@ std::atomic<uint64_t> g_requests_alloc_failed{0};   // 503 -- real device OOM, n
 std::atomic<uint64_t> g_requests_timeout{0};
 std::atomic<uint64_t> g_requests_cancelled{0};
 std::atomic<uint64_t> g_requests_server_error{0};   // 5xx
+// 502 -- the model produced tool-call output that failed schema/markup validation for a reason
+// other than truncation. Distinct from server_error so monitoring doesn't conflate model-output
+// quality variance with a real infrastructure fault -- the exact conflation #779 already
+// documented once for overloaded (429) vs alloc_failed (503).
+std::atomic<uint64_t> g_requests_invalid_tool_output{0};
 std::atomic<uint64_t> g_prompt_tokens_total{0};
 std::atomic<uint64_t> g_completion_tokens_total{0};
 
@@ -385,6 +390,8 @@ int main(int argc, char** argv) {
              << g_requests_cancelled.load() << "\n"
              << "sparkinfer_requests_by_outcome_total{outcome=\"server_error\"} "
              << g_requests_server_error.load() << "\n"
+             << "sparkinfer_requests_by_outcome_total{outcome=\"invalid_tool_output\"} "
+             << g_requests_invalid_tool_output.load() << "\n"
                 "# HELP sparkinfer_tokens_total Tokens processed\n"
                 "# TYPE sparkinfer_tokens_total counter\n"
              << "sparkinfer_tokens_total{kind=\"prompt\"} " << g_prompt_tokens_total.load() << "\n"
@@ -573,6 +580,13 @@ int main(int argc, char** argv) {
                                  err_chunk << "data: {\"error\":{\"message\":\"" << json_escape(outcome.error)
                                            << "\"}}\n\n";
                                  sink.write(err_chunk.str().c_str(), (size_t)err_chunk.str().size());
+                                 // A client that explicitly asked for usage still deserves the
+                                 // token counts even though generation faulted -- ttft/generation
+                                 // timing isn't meaningful for a hard engine error, so omit those
+                                 // (write_stream_usage only includes a field when its arg is >= 0).
+                                 if (include_usage)
+                                     write_stream_usage(sink, cid, created, prompt_tokens,
+                                                        completion_tokens, -1.0, -1.0, -1.0);
                                  write_stream_done(sink);
                                  sink.done();
                                  return true;
@@ -599,7 +613,7 @@ int main(int argc, char** argv) {
                                          // Emit no buffered markup and finish with "length".
                                          parsed = {};
                                      } else {
-                                         g_requests_server_error++;
+                                         g_requests_invalid_tool_output++;
                                          const nlohmann::json error = {
                                              {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
                                          write_sse_json(sink, error);
@@ -611,13 +625,16 @@ int main(int argc, char** argv) {
                                  write_stream_delta(sink, cid, created, "reasoning_content",
                                                     parsed.reasoning_content);
                                  write_stream_delta(sink, cid, created, "content", parsed.content);
-                                 if (!outcome.reached_token_limit) {
-                                     for (size_t i = 0; i < parsed.tool_calls.size(); ++i) {
-                                         parsed.tool_calls[i].id = random_id("call_");
-                                         write_stream_tool_call(sink, cid, created, i, parsed.tool_calls[i]);
-                                     }
-                                     if (!parsed.tool_calls.empty()) finish_reason = "tool_calls";
+                                 // parsed.tool_calls is only non-empty here when parsed.error was
+                                 // empty (the reached_token_limit-and-error case already reset
+                                 // parsed to {} above) -- i.e. a complete, valid call, even if the
+                                 // model also happened to exhaust its token budget emitting it.
+                                 // Gating this on !reached_token_limit dropped that call entirely.
+                                 for (size_t i = 0; i < parsed.tool_calls.size(); ++i) {
+                                     parsed.tool_calls[i].id = random_id("call_");
+                                     write_stream_tool_call(sink, cid, created, i, parsed.tool_calls[i]);
                                  }
+                                 if (!parsed.tool_calls.empty()) finish_reason = "tool_calls";
                              } else {
                                  sparkinfer_server::ThinkingStreamSplitter::Delta flush;
                                  splitter.finish(flush);
@@ -666,8 +683,8 @@ int main(int argc, char** argv) {
                          // valid completion, so return an empty assistant result instead of 5xx.
                          parsed = {};
                      } else {
-                         g_requests_server_error++;
-                         res.status = 500;
+                         g_requests_invalid_tool_output++;
+                         res.status = 502;
                          const nlohmann::json error = {
                              {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
                          res.set_content(error.dump(), "application/json");
@@ -679,7 +696,9 @@ int main(int argc, char** argv) {
                  if (!parsed.reasoning_content.empty())
                      message["reasoning_content"] = parsed.reasoning_content;
                  std::string finish_reason = outcome.reached_token_limit ? "length" : "stop";
-                 if (!parsed.tool_calls.empty() && !outcome.reached_token_limit) {
+                 // See the streaming path's identical comment: parsed.tool_calls is only
+                 // non-empty here for a complete, successfully-parsed call.
+                 if (!parsed.tool_calls.empty()) {
                      message["content"] = parsed.content.empty()
                          ? nlohmann::json(nullptr) : nlohmann::json(parsed.content);
                      message["tool_calls"] = nlohmann::json::array();

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -1,6 +1,8 @@
 #include "chat_tokenizer.hpp"
 #include "model_engine.hpp"
 
+#include <nlohmann/json.hpp>
+
 // Do not define CPPHTTPLIB_OPENSSL_SUPPORT — even `= 0` enables OpenSSL in httplib.
 #include "../third_party/httplib.h"
 
@@ -11,6 +13,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
+#include <limits>
 #include <random>
 #include <sstream>
 #include <string>
@@ -58,42 +61,6 @@ std::string repo_root() {
     return ".";
 }
 
-// Minimal JSON helpers (avoid extra deps on this branch).
-std::string json_get_string(const std::string& body, const std::string& key) {
-    const std::string needle = "\"" + key + "\"";
-    size_t p = body.find(needle);
-    if (p == std::string::npos) return {};
-    p = body.find(':', p);
-    if (p == std::string::npos) return {};
-    p = body.find('"', p);
-    if (p == std::string::npos) return {};
-    size_t e = body.find('"', p + 1);
-    if (e == std::string::npos) return {};
-    return body.substr(p + 1, e - p - 1);
-}
-
-bool json_get_bool(const std::string& body, const std::string& key, bool def) {
-    const std::string needle = "\"" + key + "\"";
-    size_t p = body.find(needle);
-    if (p == std::string::npos) return def;
-    p = body.find(':', p);
-    if (p == std::string::npos) return def;
-    if (body.find("true", p) != std::string::npos && body.find("true", p) < body.find(',', p))
-        return true;
-    if (body.find("false", p) != std::string::npos && body.find("false", p) < body.find(',', p))
-        return false;
-    return def;
-}
-
-int json_get_int(const std::string& body, const std::string& key, int def) {
-    const std::string needle = "\"" + key + "\"";
-    size_t p = body.find(needle);
-    if (p == std::string::npos) return def;
-    p = body.find(':', p);
-    if (p == std::string::npos) return def;
-    return atoi(body.c_str() + p + 1);
-}
-
 std::string json_escape(const std::string& s) {
     std::ostringstream o;
     for (unsigned char c : s) {
@@ -111,26 +78,12 @@ std::string json_escape(const std::string& s) {
     return o.str();
 }
 
-std::string random_id() {
-    static std::mt19937_64 rng{std::random_device{}()};
+std::string random_id(const char* prefix = "chatcmpl-") {
+    thread_local std::mt19937_64 rng{std::random_device{}()};
     std::uniform_int_distribution<uint64_t> dist;
     std::ostringstream ss;
-    ss << "chatcmpl-" << std::hex << dist(rng);
+    ss << prefix << std::hex << dist(rng);
     return ss.str();
-}
-
-std::string usage_json(int prompt_tokens, int completion_tokens, double ttft_ms = -1.0,
-                       double generation_ms = -1.0, double decode_tps = -1.0) {
-    std::ostringstream o;
-    const int total = prompt_tokens + completion_tokens;
-    o << "\"usage\":{\"prompt_tokens\":" << prompt_tokens << ",\"completion_tokens\":" << completion_tokens
-      << ",\"total_tokens\":" << total;
-    // Additive OpenAI-compatible fields only -- ignored by standard SDKs/clients.
-    if (ttft_ms >= 0.0) o << ",\"ttft_ms\":" << std::fixed << std::setprecision(3) << ttft_ms;
-    if (generation_ms >= 0.0) o << ",\"generation_ms\":" << std::fixed << std::setprecision(3) << generation_ms;
-    if (decode_tps >= 0.0) o << ",\"decode_tps\":" << std::fixed << std::setprecision(2) << decode_tps;
-    o << "}";
-    return o.str();
 }
 
 bool auth_ok(const httplib::Request& req) {
@@ -143,19 +96,135 @@ bool auth_ok(const httplib::Request& req) {
            it->second.substr(prefix.size()) == g_api_key;
 }
 
-bool encode_messages(const std::string& body, std::vector<int>& ids, bool enable_thinking, std::string& err) {
-    return g_tokenizer.encode_chat_request(body, ids, enable_thinking, err);
+bool encode_messages(const std::string& body, std::vector<int>& ids, bool enable_thinking,
+                     std::string& err, sparkinfer_server::ChatRequest* request = nullptr) {
+    return g_tokenizer.encode_chat_request(body, ids, enable_thinking, err, request);
+}
+
+struct RequestControls {
+    bool stream = false;
+    bool include_usage = false;
+    int max_tokens = 256;
+};
+
+bool parse_request_controls(const std::string& body, RequestControls& out, std::string& err) {
+    const auto root = nlohmann::json::parse(body, nullptr, false);
+    if (root.is_discarded() || !root.is_object()) {
+        err = "request body must be a JSON object";
+        return false;
+    }
+    if (root.contains("stream")) {
+        if (!root["stream"].is_boolean()) {
+            err = "stream must be a boolean";
+            return false;
+        }
+        out.stream = root["stream"].get<bool>();
+    }
+    const char* max_key = root.contains("max_completion_tokens") ? "max_completion_tokens" : "max_tokens";
+    if (root.contains(max_key)) {
+        const auto& value = root[max_key];
+        if (!value.is_number_integer() && !value.is_number_unsigned()) {
+            err = std::string(max_key) + " must be a positive integer";
+            return false;
+        }
+        try {
+            const auto requested = value.get<long long>();
+            if (requested <= 0 || requested > std::numeric_limits<int>::max()) {
+                err = std::string(max_key) + " is outside the supported range";
+                return false;
+            }
+            out.max_tokens = static_cast<int>(requested);
+        } catch (const nlohmann::json::exception&) {
+            err = std::string(max_key) + " is outside the supported range";
+            return false;
+        }
+    }
+    if (root.contains("stream_options")) {
+        if (!root["stream_options"].is_object()) {
+            err = "stream_options must be an object";
+            return false;
+        }
+        const auto& opts = root["stream_options"];
+        if (opts.contains("include_usage")) {
+            if (!opts["include_usage"].is_boolean()) {
+                err = "stream_options.include_usage must be a boolean";
+                return false;
+            }
+            out.include_usage = opts["include_usage"].get<bool>();
+        }
+    }
+    return true;
+}
+
+nlohmann::json stream_chunk_base(const std::string& cid, long long created) {
+    return {{"id", cid}, {"object", "chat.completion.chunk"}, {"created", created},
+            {"model", g_model_name}};
+}
+
+bool write_sse_json(httplib::DataSink& sink, const nlohmann::json& value) {
+    const std::string event = "data: " + value.dump() + "\n\n";
+    return sink.write(event.c_str(), event.size());
+}
+
+bool write_stream_role(httplib::DataSink& sink, const std::string& cid, long long created) {
+    auto chunk = stream_chunk_base(cid, created);
+    chunk["choices"] = nlohmann::json::array({{{"index", 0},
+                                                {"delta", {{"role", "assistant"},
+                                                           {"content", nullptr}}},
+                                                {"finish_reason", nullptr}}});
+    return write_sse_json(sink, chunk);
 }
 
 bool write_stream_delta(httplib::DataSink& sink, const std::string& cid, long long created, const std::string& field,
                         const std::string& piece) {
     if (piece.empty()) return true;
-    std::ostringstream chunk;
-    chunk << "data: {\"id\":\"" << cid << "\",\"object\":\"chat.completion.chunk\","
-          << "\"created\":" << created << ",\"model\":\"" << g_model_name << "\","
-          << "\"choices\":[{\"index\":0,\"delta\":{\"" << field << "\":\"" << json_escape(piece)
-          << "\"},\"finish_reason\":null}]}\n\n";
-    return sink.write(chunk.str().c_str(), (size_t)chunk.str().size());
+    auto chunk = stream_chunk_base(cid, created);
+    chunk["choices"] = nlohmann::json::array({{{"index", 0},
+                                                {"delta", {{field, piece}}},
+                                                {"finish_reason", nullptr}}});
+    return write_sse_json(sink, chunk);
+}
+
+bool write_stream_tool_call(httplib::DataSink& sink, const std::string& cid, long long created,
+                            size_t index, const sparkinfer_server::ToolCall& call) {
+    auto chunk = stream_chunk_base(cid, created);
+    nlohmann::json delta_call = {{"index", index}, {"id", call.id}, {"type", "function"},
+                                {"function", {{"name", call.name},
+                                              {"arguments", call.arguments}}}};
+    chunk["choices"] = nlohmann::json::array({{{"index", 0},
+                                                {"delta", {{"tool_calls",
+                                                            nlohmann::json::array({delta_call})}}},
+                                                {"finish_reason", nullptr}}});
+    return write_sse_json(sink, chunk);
+}
+
+bool write_stream_finish(httplib::DataSink& sink, const std::string& cid, long long created,
+                         const std::string& reason) {
+    auto chunk = stream_chunk_base(cid, created);
+    chunk["choices"] = nlohmann::json::array({{{"index", 0},
+                                                {"delta", nlohmann::json::object()},
+                                                {"finish_reason", reason}}});
+    return write_sse_json(sink, chunk);
+}
+
+bool write_stream_usage(httplib::DataSink& sink, const std::string& cid, long long created,
+                        int prompt_tokens, int completion_tokens, double ttft_ms,
+                        double generation_ms, double decode_tps) {
+    auto chunk = stream_chunk_base(cid, created);
+    chunk["choices"] = nlohmann::json::array();
+    nlohmann::json usage = {{"prompt_tokens", prompt_tokens},
+                            {"completion_tokens", completion_tokens},
+                            {"total_tokens", prompt_tokens + completion_tokens}};
+    if (ttft_ms >= 0.0) usage["ttft_ms"] = ttft_ms;
+    if (generation_ms >= 0.0) usage["generation_ms"] = generation_ms;
+    if (decode_tps >= 0.0) usage["decode_tps"] = decode_tps;
+    chunk["usage"] = std::move(usage);
+    return write_sse_json(sink, chunk);
+}
+
+bool write_stream_done(httplib::DataSink& sink) {
+    static const std::string done = "data: [DONE]\n\n";
+    return sink.write(done.c_str(), done.size());
 }
 
 bool decode_ids(const std::vector<int>& ids, std::string& text, std::string& err) {
@@ -385,22 +454,33 @@ int main(int argc, char** argv) {
                  }
 
                  g_requests_total++;
-                 const bool stream = json_get_bool(req.body, "stream", false);
-                 if (stream) g_requests_streaming++;
-                 const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, false);
-                 int max_tokens = json_get_int(req.body, "max_tokens", 256);
-                 if (max_tokens <= 0) max_tokens = 256;
-                 if (max_tokens > max_output_tokens()) max_tokens = max_output_tokens();
-
-                 std::vector<int> prompt_ids;
+                 RequestControls controls;
                  std::string err;
-                 if (!encode_messages(req.body, prompt_ids, enable_thinking, err)) {
+                 if (!parse_request_controls(req.body, controls, err)) {
                      g_requests_client_error++;
                      res.status = 400;
                      res.set_content("{\"error\":{\"message\":\"" + json_escape(err) + "\"}}",
                                      "application/json");
                      return;
                  }
+                 const bool stream = controls.stream;
+                 if (stream) g_requests_streaming++;
+                 const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, false);
+                 int max_tokens = controls.max_tokens;
+                 if (max_tokens <= 0) max_tokens = 256;
+                 if (max_tokens > max_output_tokens()) max_tokens = max_output_tokens();
+
+                 std::vector<int> prompt_ids;
+                 sparkinfer_server::ChatRequest chat_request;
+                 if (!encode_messages(req.body, prompt_ids, enable_thinking, err, &chat_request)) {
+                     g_requests_client_error++;
+                     res.status = 400;
+                     res.set_content("{\"error\":{\"message\":\"" + json_escape(err) + "\"}}",
+                                     "application/json");
+                     return;
+                 }
+                 const bool tool_mode = !chat_request.tools.empty() &&
+                     chat_request.tool_choice != sparkinfer_server::ToolChoiceMode::kNone;
                  if ((int)prompt_ids.size() + max_tokens > engine.max_seq()) {
                      g_requests_client_error++;
                      res.status = 400;
@@ -435,9 +515,15 @@ int main(int argc, char** argv) {
                  if (stream) {
                      res.set_chunked_content_provider(
                          "text/event-stream",
-                         [&engine, prompt_ids, max_tokens, cid, created, enable_thinking](size_t offset,
-                                                                                          httplib::DataSink& sink) {
+                         [&engine, prompt_ids, max_tokens, cid, created, enable_thinking,
+                          chat_request, tool_mode, include_usage = controls.include_usage]
+                         (size_t offset, httplib::DataSink& sink) {
                              if (offset > 0) {
+                                 sink.done();
+                                 return true;
+                             }
+                             if (!write_stream_role(sink, cid, created)) {
+                                 g_requests_cancelled++;
                                  sink.done();
                                  return true;
                              }
@@ -447,6 +533,14 @@ int main(int argc, char** argv) {
                              // Returning false cancels generation -- the client is gone, so there
                              // is no point spending GPU time finishing the response.
                              auto on_tok = [&](int tid) -> bool {
+                                 // Tool-capable responses are intentionally buffered until the
+                                 // native Qwen XML is complete and schema-valid. This still emits
+                                 // valid atomic OpenAI SSE deltas, and guarantees malformed or
+                                 // partial markup can never leak as executable client content.
+                                 if (tool_mode) {
+                                     stream_ids.push_back(tid);
+                                     return sink.is_writable();
+                                 }
                                  std::string piece = g_tokenizer.decode_delta(stream_ids, tid);
                                  const auto delta = splitter.feed(piece);
                                  bool ok = true;
@@ -468,10 +562,6 @@ int main(int argc, char** argv) {
                                  sink.done();
                                  return true;
                              }
-                             sparkinfer_server::ThinkingStreamSplitter::Delta flush;
-                             splitter.finish(flush);
-                             write_stream_delta(sink, cid, created, "reasoning_content", flush.reasoning_content);
-                             write_stream_delta(sink, cid, created, "content", flush.content);
                              if (!outcome.error.empty()) {
                                  if (outcome.overloaded) g_requests_overloaded++;
                                  else if (outcome.alloc_failed) g_requests_alloc_failed++;
@@ -481,23 +571,57 @@ int main(int argc, char** argv) {
                                  err_chunk << "data: {\"error\":{\"message\":\"" << json_escape(outcome.error)
                                            << "\"}}\n\n";
                                  sink.write(err_chunk.str().c_str(), (size_t)err_chunk.str().size());
-                             } else {
-                                 g_requests_ok++;
+                                 write_stream_done(sink);
+                                 sink.done();
+                                 return true;
                              }
-                             std::ostringstream usage_chunk;
-                             usage_chunk << "data: {\"id\":\"" << cid << "\",\"object\":\"chat.completion.chunk\","
-                                         << "\"created\":" << created << ",\"model\":\"" << g_model_name << "\","
-                                         << "\"choices\":[],"
-                                         << usage_json(prompt_tokens, completion_tokens, outcome.ttft_ms,
-                                                       outcome.generation_ms, outcome.decode_tps)
-                                         << "}\n\n";
-                             sink.write(usage_chunk.str().c_str(), (size_t)usage_chunk.str().size());
-                             std::string tail =
-                                 "data: {\"id\":\"" + cid +
-                                 "\",\"object\":\"chat.completion.chunk\",\"choices\":[{\"index\":0,"
-                                 "\"delta\":{},\"finish_reason\":\"stop\"}]}\n\n"
-                                 "data: [DONE]\n\n";
-                             sink.write(tail.c_str(), tail.size());
+
+                             std::string finish_reason = outcome.reached_token_limit ? "length" : "stop";
+                             if (tool_mode) {
+                                 std::string text;
+                                 std::string decode_err;
+                                 if (!decode_ids(stream_ids, text, decode_err)) {
+                                     g_requests_server_error++;
+                                     const nlohmann::json error = {{"error", {{"message", decode_err}}}};
+                                     write_sse_json(sink, error);
+                                     write_stream_done(sink);
+                                     sink.done();
+                                     return true;
+                                 }
+                                 auto parsed = sparkinfer_server::parse_assistant_output(
+                                     text, enable_thinking, engine.is_museglimmer(), &chat_request);
+                                 if (!parsed.error.empty()) {
+                                     g_requests_server_error++;
+                                     const nlohmann::json error = {
+                                         {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
+                                     write_sse_json(sink, error);
+                                     write_stream_done(sink);
+                                     sink.done();
+                                     return true;
+                                 }
+                                 write_stream_delta(sink, cid, created, "reasoning_content",
+                                                    parsed.reasoning_content);
+                                 write_stream_delta(sink, cid, created, "content", parsed.content);
+                                 for (size_t i = 0; i < parsed.tool_calls.size(); ++i) {
+                                     parsed.tool_calls[i].id = random_id("call_");
+                                     write_stream_tool_call(sink, cid, created, i, parsed.tool_calls[i]);
+                                 }
+                                 if (!parsed.tool_calls.empty()) finish_reason = "tool_calls";
+                             } else {
+                                 sparkinfer_server::ThinkingStreamSplitter::Delta flush;
+                                 splitter.finish(flush);
+                                 write_stream_delta(sink, cid, created, "reasoning_content",
+                                                    flush.reasoning_content);
+                                 write_stream_delta(sink, cid, created, "content", flush.content);
+                             }
+
+                             g_requests_ok++;
+                             write_stream_finish(sink, cid, created, finish_reason);
+                             if (include_usage)
+                                 write_stream_usage(sink, cid, created, prompt_tokens,
+                                                    completion_tokens, outcome.ttft_ms,
+                                                    outcome.generation_ms, outcome.decode_tps);
+                             write_stream_done(sink);
                              sink.done();
                              return true;
                          });
@@ -519,24 +643,55 @@ int main(int argc, char** argv) {
                                      "application/json");
                      return;
                  }
-                 g_requests_ok++;
                  g_prompt_tokens_total += (uint64_t)prompt_ids.size();
                  g_completion_tokens_total += (uint64_t)outcome.tokens.size();
 
-                 const auto parsed = sparkinfer_server::parse_assistant_output(text, enable_thinking, engine.is_museglimmer());
+                 auto parsed = sparkinfer_server::parse_assistant_output(
+                     text, enable_thinking, engine.is_museglimmer(), tool_mode ? &chat_request : nullptr);
+                 if (!parsed.error.empty()) {
+                     g_requests_server_error++;
+                     res.status = 500;
+                     const nlohmann::json error = {
+                         {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
+                     res.set_content(error.dump(), "application/json");
+                     return;
+                 }
 
-                 std::ostringstream body;
-                 body << "{\"id\":\"" << cid << "\",\"object\":\"chat.completion\",\"created\":" << created
-                      << ",\"model\":\"" << g_model_name << "\",\"choices\":[{\"index\":0,\"message\":{"
-                      << "\"role\":\"assistant\"";
+                 nlohmann::json message = {{"role", "assistant"}};
                  if (!parsed.reasoning_content.empty())
-                     body << ",\"reasoning_content\":\"" << json_escape(parsed.reasoning_content) << "\"";
-                 body << ",\"content\":\"" << json_escape(parsed.content) << "\""
-                      << "},\"finish_reason\":\"stop\"}],"
-                      << usage_json((int)prompt_ids.size(), (int)outcome.tokens.size(), outcome.ttft_ms,
-                                    outcome.generation_ms, outcome.decode_tps)
-                      << "}";
-                 res.set_content(body.str(), "application/json");
+                     message["reasoning_content"] = parsed.reasoning_content;
+                 std::string finish_reason = outcome.reached_token_limit ? "length" : "stop";
+                 if (!parsed.tool_calls.empty()) {
+                     message["content"] = parsed.content.empty()
+                         ? nlohmann::json(nullptr) : nlohmann::json(parsed.content);
+                     message["tool_calls"] = nlohmann::json::array();
+                     for (auto& call : parsed.tool_calls) {
+                         call.id = random_id("call_");
+                         message["tool_calls"].push_back({
+                             {"id", call.id}, {"type", "function"},
+                             {"function", {{"name", call.name}, {"arguments", call.arguments}}}});
+                     }
+                     finish_reason = "tool_calls";
+                 } else {
+                     message["content"] = parsed.content;
+                 }
+
+                 nlohmann::json usage = {
+                     {"prompt_tokens", (int)prompt_ids.size()},
+                     {"completion_tokens", (int)outcome.tokens.size()},
+                     {"total_tokens", (int)(prompt_ids.size() + outcome.tokens.size())}};
+                 if (outcome.ttft_ms >= 0.0) usage["ttft_ms"] = outcome.ttft_ms;
+                 if (outcome.generation_ms >= 0.0) usage["generation_ms"] = outcome.generation_ms;
+                 if (outcome.decode_tps >= 0.0) usage["decode_tps"] = outcome.decode_tps;
+                 const nlohmann::json body = {
+                     {"id", cid}, {"object", "chat.completion"}, {"created", created},
+                     {"model", g_model_name},
+                     {"choices", nlohmann::json::array({{{"index", 0},
+                                                          {"message", message},
+                                                          {"finish_reason", finish_reason}}})},
+                     {"usage", usage}};
+                 g_requests_ok++;
+                 res.set_content(body.dump(), "application/json");
              });
 
     // Transport-level deadlines. Defaults are generous, not aggressive: a cold 32k-context

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -479,8 +479,10 @@ int main(int argc, char** argv) {
                                      "application/json");
                      return;
                  }
-                 const bool tool_mode = !chat_request.tools.empty() &&
-                     chat_request.tool_choice != sparkinfer_server::ToolChoiceMode::kNone;
+                 // Presence of a tool protocol requires strict, buffered parsing even when
+                 // tool_choice=none. The latter disables execution, not output validation:
+                 // native tool markup must never leak through as ordinary assistant content.
+                 const bool tool_protocol = !chat_request.tools.empty();
                  if ((int)prompt_ids.size() + max_tokens > engine.max_seq()) {
                      g_requests_client_error++;
                      res.status = 400;
@@ -516,7 +518,7 @@ int main(int argc, char** argv) {
                      res.set_chunked_content_provider(
                          "text/event-stream",
                          [&engine, prompt_ids, max_tokens, cid, created, enable_thinking,
-                          chat_request, tool_mode, include_usage = controls.include_usage]
+                          chat_request, tool_protocol, include_usage = controls.include_usage]
                          (size_t offset, httplib::DataSink& sink) {
                              if (offset > 0) {
                                  sink.done();
@@ -537,7 +539,7 @@ int main(int argc, char** argv) {
                                  // native Qwen XML is complete and schema-valid. This still emits
                                  // valid atomic OpenAI SSE deltas, and guarantees malformed or
                                  // partial markup can never leak as executable client content.
-                                 if (tool_mode) {
+                                 if (tool_protocol) {
                                      stream_ids.push_back(tid);
                                      return sink.is_writable();
                                  }
@@ -577,7 +579,7 @@ int main(int argc, char** argv) {
                              }
 
                              std::string finish_reason = outcome.reached_token_limit ? "length" : "stop";
-                             if (tool_mode) {
+                             if (tool_protocol) {
                                  std::string text;
                                  std::string decode_err;
                                  if (!decode_ids(stream_ids, text, decode_err)) {
@@ -591,22 +593,31 @@ int main(int argc, char** argv) {
                                  auto parsed = sparkinfer_server::parse_assistant_output(
                                      text, enable_thinking, engine.is_museglimmer(), &chat_request);
                                  if (!parsed.error.empty()) {
-                                     g_requests_server_error++;
-                                     const nlohmann::json error = {
-                                         {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
-                                     write_sse_json(sink, error);
-                                     write_stream_done(sink);
-                                     sink.done();
-                                     return true;
+                                     if (outcome.reached_token_limit) {
+                                         // A truncated native call is not an executable result,
+                                         // but token exhaustion is still a normal completion.
+                                         // Emit no buffered markup and finish with "length".
+                                         parsed = {};
+                                     } else {
+                                         g_requests_server_error++;
+                                         const nlohmann::json error = {
+                                             {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
+                                         write_sse_json(sink, error);
+                                         write_stream_done(sink);
+                                         sink.done();
+                                         return true;
+                                     }
                                  }
                                  write_stream_delta(sink, cid, created, "reasoning_content",
                                                     parsed.reasoning_content);
                                  write_stream_delta(sink, cid, created, "content", parsed.content);
-                                 for (size_t i = 0; i < parsed.tool_calls.size(); ++i) {
-                                     parsed.tool_calls[i].id = random_id("call_");
-                                     write_stream_tool_call(sink, cid, created, i, parsed.tool_calls[i]);
+                                 if (!outcome.reached_token_limit) {
+                                     for (size_t i = 0; i < parsed.tool_calls.size(); ++i) {
+                                         parsed.tool_calls[i].id = random_id("call_");
+                                         write_stream_tool_call(sink, cid, created, i, parsed.tool_calls[i]);
+                                     }
+                                     if (!parsed.tool_calls.empty()) finish_reason = "tool_calls";
                                  }
-                                 if (!parsed.tool_calls.empty()) finish_reason = "tool_calls";
                              } else {
                                  sparkinfer_server::ThinkingStreamSplitter::Delta flush;
                                  splitter.finish(flush);
@@ -647,21 +658,28 @@ int main(int argc, char** argv) {
                  g_completion_tokens_total += (uint64_t)outcome.tokens.size();
 
                  auto parsed = sparkinfer_server::parse_assistant_output(
-                     text, enable_thinking, engine.is_museglimmer(), tool_mode ? &chat_request : nullptr);
+                     text, enable_thinking, engine.is_museglimmer(),
+                     tool_protocol ? &chat_request : nullptr);
                  if (!parsed.error.empty()) {
-                     g_requests_server_error++;
-                     res.status = 500;
-                     const nlohmann::json error = {
-                         {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
-                     res.set_content(error.dump(), "application/json");
-                     return;
+                     if (outcome.reached_token_limit) {
+                         // Never expose a truncated native tag sequence. A length stop is a
+                         // valid completion, so return an empty assistant result instead of 5xx.
+                         parsed = {};
+                     } else {
+                         g_requests_server_error++;
+                         res.status = 500;
+                         const nlohmann::json error = {
+                             {"error", {{"message", "invalid model tool call: " + parsed.error}}}};
+                         res.set_content(error.dump(), "application/json");
+                         return;
+                     }
                  }
 
                  nlohmann::json message = {{"role", "assistant"}};
                  if (!parsed.reasoning_content.empty())
                      message["reasoning_content"] = parsed.reasoning_content;
                  std::string finish_reason = outcome.reached_token_limit ? "length" : "stop";
-                 if (!parsed.tool_calls.empty()) {
+                 if (!parsed.tool_calls.empty() && !outcome.reached_token_limit) {
                      message["content"] = parsed.content.empty()
                          ? nlohmann::json(nullptr) : nlohmann::json(parsed.content);
                      message["tool_calls"] = nlohmann::json::array();

--- a/server/tests/chat_tokenizer_test.cpp
+++ b/server/tests/chat_tokenizer_test.cpp
@@ -37,6 +37,14 @@ bool test_thinking_prompt_and_nonstream_parser() {
         "<think>\nreason\n</think>\nanswer", true, false);
     CHECK(repeated.reasoning_content == "reason");
     CHECK(repeated.content == "answer");
+
+    // Same tolerance when the repeated marker isn't the very first byte (e.g. a stray leading
+    // token before it) -- the marker itself must never leak into reasoning_content.
+    const auto repeated_not_at_start = sparkinfer_server::parse_assistant_output(
+        " <think>\nreason\n</think>\nanswer", true, false);
+    CHECK(repeated_not_at_start.reasoning_content == "reason");
+    CHECK(repeated_not_at_start.content == "answer");
+    CHECK(repeated_not_at_start.reasoning_content.find("<think>") == std::string::npos);
     return true;
 }
 
@@ -59,6 +67,32 @@ bool test_thinking_stream_boundaries() {
     CHECK(content.find("<think>") == std::string::npos);
     CHECK(content.find("</think>") == std::string::npos);
     CHECK(content.find("<|im_end|>") == std::string::npos);
+    return true;
+}
+
+bool test_thinking_stream_repeated_opening_marker() {
+    // Streaming starts directly in the "inside <think>" phase (the prompt already primed
+    // "<think>\n"), but must still tolerate -- and strip -- a defensively repeated opening
+    // marker the same way the non-streaming parser does, rather than leaking it into
+    // reasoning_content.
+    sparkinfer_server::ThinkingStreamSplitter splitter(true, false);
+    std::string reasoning;
+    std::string content;
+    for (const char* piece : {"<thi", "nk>\nreason\n</thi", "nk>\nanswer"}) {
+        const auto delta = splitter.feed(piece);
+        reasoning += delta.reasoning_content;
+        content += delta.content;
+    }
+    sparkinfer_server::ThinkingStreamSplitter::Delta tail;
+    splitter.finish(tail);
+    reasoning += tail.reasoning_content;
+    content += tail.content;
+    // Streaming reasoning_content chunks aren't leading-whitespace-trimmed the way the
+    // non-streaming parser's final string is (pre-existing, orthogonal to this fix) -- the
+    // marker itself must simply never appear in the output.
+    CHECK(reasoning == "\nreason\n");
+    CHECK(content == "answer");
+    CHECK(reasoning.find("<think>") == std::string::npos);
     return true;
 }
 
@@ -132,6 +166,7 @@ bool test_tool_choice_none_still_uses_strict_output_parser() {
 int main() {
     if (!test_thinking_prompt_and_nonstream_parser()) return 1;
     if (!test_thinking_stream_boundaries()) return 1;
+    if (!test_thinking_stream_repeated_opening_marker()) return 1;
     if (!test_nonthinking_stream_hides_terminal_marker()) return 1;
     if (!test_muse_rejects_all_tool_protocol_history()) return 1;
     if (!test_tool_choice_none_still_uses_strict_output_parser()) return 1;

--- a/server/tests/chat_tokenizer_test.cpp
+++ b/server/tests/chat_tokenizer_test.cpp
@@ -1,0 +1,85 @@
+#include "chat_tokenizer.hpp"
+
+#include <cstdio>
+#include <string>
+#include <utility>
+
+namespace {
+
+#define CHECK(expr)                                                                            \
+    do {                                                                                       \
+        if (!(expr)) {                                                                         \
+            std::fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #expr);             \
+            return false;                                                                      \
+        }                                                                                      \
+    } while (0)
+
+bool test_thinking_prompt_and_nonstream_parser() {
+    sparkinfer_server::ChatRequest request;
+    sparkinfer_server::ChatMessage message;
+    message.role = "user";
+    message.content = "Explain briefly.";
+    request.messages.push_back(std::move(message));
+    const std::string prompt = sparkinfer_server::apply_qwen36_tools_template(request, true);
+    const std::string suffix = "<|im_start|>assistant\n<think>\n";
+    CHECK(prompt.size() >= suffix.size());
+    CHECK(prompt.compare(prompt.size() - suffix.size(), suffix.size(), suffix) == 0);
+
+    const auto parsed = sparkinfer_server::parse_assistant_output(
+        "private reasoning\n</think>\n\nPublic answer.<|im_end|>", true, false);
+    CHECK(parsed.error.empty());
+    CHECK(parsed.reasoning_content == "private reasoning");
+    CHECK(parsed.content == "Public answer.");
+    CHECK(parsed.tool_calls.empty());
+
+    // Defensively tolerate a model that repeats the already-prefilled opening marker.
+    const auto repeated = sparkinfer_server::parse_assistant_output(
+        "<think>\nreason\n</think>\nanswer", true, false);
+    CHECK(repeated.reasoning_content == "reason");
+    CHECK(repeated.content == "answer");
+    return true;
+}
+
+bool test_thinking_stream_boundaries() {
+    sparkinfer_server::ThinkingStreamSplitter splitter(true, false);
+    std::string reasoning;
+    std::string content;
+    for (const char* piece : {"private ", "reasoning\n</thi", "nk>\n\nPublic ",
+                              "answer.<|im_", "end|>"}) {
+        const auto delta = splitter.feed(piece);
+        reasoning += delta.reasoning_content;
+        content += delta.content;
+    }
+    sparkinfer_server::ThinkingStreamSplitter::Delta tail;
+    splitter.finish(tail);
+    reasoning += tail.reasoning_content;
+    content += tail.content;
+    CHECK(reasoning == "private reasoning\n");
+    CHECK(content == "Public answer.");
+    CHECK(content.find("<think>") == std::string::npos);
+    CHECK(content.find("</think>") == std::string::npos);
+    CHECK(content.find("<|im_end|>") == std::string::npos);
+    return true;
+}
+
+bool test_nonthinking_stream_hides_terminal_marker() {
+    sparkinfer_server::ThinkingStreamSplitter splitter(false, false);
+    std::string content;
+    for (const char* piece : {"hello", "<|im_", "end|>"})
+        content += splitter.feed(piece).content;
+    sparkinfer_server::ThinkingStreamSplitter::Delta tail;
+    splitter.finish(tail);
+    content += tail.content;
+    CHECK(content == "hello");
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    if (!test_thinking_prompt_and_nonstream_parser()) return 1;
+    if (!test_thinking_stream_boundaries()) return 1;
+    if (!test_nonthinking_stream_hides_terminal_marker()) return 1;
+    std::printf("chat_tokenizer_test: OK\n");
+    return 0;
+}

--- a/server/tests/chat_tokenizer_test.cpp
+++ b/server/tests/chat_tokenizer_test.cpp
@@ -74,12 +74,67 @@ bool test_nonthinking_stream_hides_terminal_marker() {
     return true;
 }
 
+bool test_muse_rejects_all_tool_protocol_history() {
+    sparkinfer_server::ChatRequest parsed;
+    std::string error;
+    const std::string request = R"JSON({
+      "messages":[
+        {"role":"assistant","content":null,"tool_calls":[{
+          "id":"call_1","type":"function",
+          "function":{"name":"lookup","arguments":"{\"query\":\"x\"}"}
+        }]},
+        {"role":"tool","tool_call_id":"call_1","content":"ok"},
+        {"role":"user","content":"continue"}
+      ],
+      "tools":[{"type":"function","function":{
+        "name":"lookup",
+        "parameters":{"type":"object","properties":{"query":{"type":"string"}}}
+      }}],
+      "tool_choice":"none"
+    })JSON";
+    CHECK(sparkinfer_server::parse_chat_request_json(request, parsed, error));
+    CHECK(!sparkinfer_server::validate_chat_request_model_support(parsed, true, error));
+    CHECK(error.find("supported only for Qwen3.6") != std::string::npos);
+    error.clear();
+    CHECK(sparkinfer_server::validate_chat_request_model_support(parsed, false, error));
+    return true;
+}
+
+bool test_tool_choice_none_still_uses_strict_output_parser() {
+    const std::string request_json = R"JSON({
+      "messages":[{"role":"user","content":"Do not call tools."}],
+      "tools":[{"type":"function","function":{
+        "name":"terminal",
+        "parameters":{"type":"object","properties":{"command":{"type":"string"}}}
+      }}],
+      "tool_choice":"none"
+    })JSON";
+    sparkinfer_server::ChatRequest request;
+    std::string error;
+    CHECK(sparkinfer_server::parse_chat_request_json(request_json, request, error));
+    const auto forbidden = sparkinfer_server::parse_assistant_output(
+        "<tool_call>\n<function=terminal>\n<parameter=command>\nid\n</parameter>\n"
+        "</function>\n</tool_call>",
+        false, false, &request);
+    CHECK(!forbidden.error.empty());
+    CHECK(forbidden.content.empty());
+    CHECK(forbidden.tool_calls.empty());
+
+    const auto answer = sparkinfer_server::parse_assistant_output(
+        "No tool used.<|im_end|>", false, false, &request);
+    CHECK(answer.error.empty());
+    CHECK(answer.content == "No tool used.");
+    return true;
+}
+
 }  // namespace
 
 int main() {
     if (!test_thinking_prompt_and_nonstream_parser()) return 1;
     if (!test_thinking_stream_boundaries()) return 1;
     if (!test_nonthinking_stream_hides_terminal_marker()) return 1;
+    if (!test_muse_rejects_all_tool_protocol_history()) return 1;
+    if (!test_tool_choice_none_still_uses_strict_output_parser()) return 1;
     std::printf("chat_tokenizer_test: OK\n");
     return 0;
 }

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -2,6 +2,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include <chrono>
 #include <cstdio>
 #include <fstream>
 #include <iterator>
@@ -433,6 +434,239 @@ bool test_schema_constraints() {
     return true;
 }
 
+bool test_schema_pattern_is_linear_time() {
+    const std::string body = R"JSON({
+      "messages":[{"role":"user","content":"Check a value."}],
+      "tools":[{"type":"function","function":{
+        "name":"check_value",
+        "parameters":{
+          "type":"object",
+          "properties":{"value":{"type":"string","pattern":"^(a+)+$"}},
+          "required":["value"],
+          "additionalProperties":false
+        }
+      }}]
+    })JSON";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    const std::string raw =
+        "<tool_call>\n<function=check_value>\n<parameter=value>\n" +
+        std::string(30, 'a') + "!\n</parameter>\n</function>\n</tool_call>";
+    const auto start = std::chrono::steady_clock::now();
+    const ParsedToolOutput output = parse_qwen36_tool_output(raw, false, request);
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+    CHECK(!output.error.empty());
+    CHECK(elapsed < std::chrono::seconds(1));
+    return true;
+}
+
+bool test_schema_unions_and_dynamic_properties() {
+    const std::string body = R"JSON({
+      "messages":[{"role":"user","content":"Send dynamic values."}],
+      "tools":[{"type":"function","function":{
+        "name":"dynamic_values",
+        "parameters":{
+          "type":"object",
+          "properties":{
+            "nullable_text":{"type":["string","null"]},
+            "nullable_null":{"type":["string","null"]},
+            "json_like_text":{"type":["string","null"]},
+            "mixed_value":{"type":["string","integer"]},
+            "inferred_text":{"enum":["red","blue"]},
+            "inferred_number":{"enum":[1,2]}
+          },
+          "required":["dynamic_count"],
+          "additionalProperties":{"type":"integer"}
+        }
+      }}]
+    })JSON";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    const std::string raw =
+        "<tool_call>\n<function=dynamic_values>\n"
+        "<parameter=nullable_text>\nhello\n</parameter>\n"
+        "<parameter=nullable_null>\nnull\n</parameter>\n"
+        "<parameter=json_like_text>\n123\n</parameter>\n"
+        "<parameter=mixed_value>\n123\n</parameter>\n"
+        "<parameter=inferred_text>\nred\n</parameter>\n"
+        "<parameter=inferred_number>\n2\n</parameter>\n"
+        "<parameter=dynamic_count>\n3\n</parameter>\n"
+        "</function>\n</tool_call>";
+    const ParsedToolOutput output = parse_qwen36_tool_output(raw, false, request);
+    CHECK(output.error.empty());
+    CHECK(output.tool_calls.size() == 1);
+    const json args = arguments(output.tool_calls[0]);
+    CHECK(args["nullable_text"] == "hello");
+    CHECK(args["nullable_null"].is_null());
+    CHECK(args["json_like_text"].is_string() && args["json_like_text"] == "123");
+    CHECK(args["mixed_value"].is_number_integer() && args["mixed_value"] == 123);
+    CHECK(args["inferred_text"] == "red");
+    CHECK(args["inferred_number"].is_number_integer() && args["inferred_number"] == 2);
+    CHECK(args["dynamic_count"] == 3);
+
+    const std::string bad_dynamic =
+        "<tool_call>\n<function=dynamic_values>\n"
+        "<parameter=dynamic_count>\nnot-an-integer\n</parameter>\n"
+        "</function>\n</tool_call>";
+    CHECK(!parse_qwen36_tool_output(bad_dynamic, false, request).error.empty());
+
+    json history = json::parse(body);
+    history["messages"] = json::array({
+        {{"role", "assistant"},
+         {"content", nullptr},
+         {"tool_calls", json::array({
+             {{"id", "call_dynamic"},
+              {"type", "function"},
+              {"function", {{"name", "dynamic_values"},
+                            {"arguments", "{\"dynamic_count\":3,\"nullable_text\":\"hello\"}"}}}}
+         })}},
+        {{"role", "tool"}, {"tool_call_id", "call_dynamic"}, {"content", "ok"}},
+        {{"role", "user"}, {"content", "Continue."}}
+    });
+    ChatRequest history_request;
+    CHECK(parse_request(history.dump(), history_request));
+    const std::string prompt = apply_qwen36_tools_template(history_request, false);
+    CHECK(contains(prompt, "<parameter=nullable_text>\nhello\n</parameter>"));
+    CHECK(contains(prompt, "<parameter=dynamic_count>\n3\n</parameter>"));
+
+    for (const json& additional : {json(), json(true)}) {
+        json permissive = json::parse(body);
+        json& schema = permissive["tools"][0]["function"]["parameters"];
+        schema.erase("additionalProperties");
+        if (!additional.is_null()) schema["additionalProperties"] = additional;
+        ChatRequest permissive_request;
+        CHECK(parse_request(permissive.dump(), permissive_request));
+        const std::string freeform =
+            "<tool_call>\n<function=dynamic_values>\n"
+            "<parameter=dynamic_count>\n3\n</parameter>\n"
+            "<parameter=freeform>\n{\"nested\":true}\n</parameter>\n"
+            "</function>\n</tool_call>";
+        const ParsedToolOutput accepted =
+            parse_qwen36_tool_output(freeform, false, permissive_request);
+        CHECK(accepted.error.empty());
+        CHECK(arguments(accepted.tool_calls[0])["freeform"]["nested"] == true);
+    }
+
+    json closed = json::parse(body);
+    closed["tools"][0]["function"]["parameters"]["additionalProperties"] = false;
+    closed["tools"][0]["function"]["parameters"].erase("required");
+    ChatRequest closed_request;
+    CHECK(parse_request(closed.dump(), closed_request));
+    CHECK(!parse_qwen36_tool_output(raw, false, closed_request).error.empty());
+
+    history["messages"][0]["tool_calls"][0]["function"]["arguments"] =
+        "{\"dynamic_count\":\"wrong\"}";
+    std::string history_error;
+    CHECK(!parse_chat_request_json(history.dump(), history_request, history_error));
+    return true;
+}
+
+bool test_unicode_string_lengths() {
+    const std::string body = R"JSON({
+      "messages":[{"role":"user","content":"Send one character."}],
+      "tools":[{"type":"function","function":{
+        "name":"one_character",
+        "parameters":{
+          "type":"object",
+          "properties":{"value":{"type":"string","minLength":1,"maxLength":1}},
+          "required":["value"],
+          "additionalProperties":false
+        }
+      }}]
+    })JSON";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    auto call = [](const std::string& value) {
+        return "<tool_call>\n<function=one_character>\n<parameter=value>\n" + value +
+               "\n</parameter>\n</function>\n</tool_call>";
+    };
+    CHECK(parse_qwen36_tool_output(call("é"), false, request).error.empty());
+    CHECK(parse_qwen36_tool_output(call("😀"), false, request).error.empty());
+    CHECK(!parse_qwen36_tool_output(call("ab"), false, request).error.empty());
+    return true;
+}
+
+bool test_large_integer_bounds_are_exact() {
+    const std::string body = R"JSON({
+      "messages":[{"role":"user","content":"Send a large integer."}],
+      "tools":[{"type":"function","function":{
+        "name":"large_integer",
+        "parameters":{
+          "type":"object",
+          "properties":{"value":{"type":"integer","minimum":9007199254740993}},
+          "required":["value"],
+          "additionalProperties":false
+        }
+      }}]
+    })JSON";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    auto call = [](const char* value) {
+        return std::string("<tool_call>\n<function=large_integer>\n<parameter=value>\n") +
+               value + "\n</parameter>\n</function>\n</tool_call>";
+    };
+    CHECK(!parse_qwen36_tool_output(call("9007199254740992"), false, request).error.empty());
+    CHECK(parse_qwen36_tool_output(call("9007199254740993"), false, request).error.empty());
+    return true;
+}
+
+bool test_schema_keyword_type_applicability() {
+    for (const auto& invalid : {
+             std::pair<const char*, json>{"required", {{"type", "string"},
+                                                        {"required", {"x"}}}},
+             std::pair<const char*, json>{"items", {{"type", "object"},
+                                                     {"items", json::object()}}},
+             std::pair<const char*, json>{"maxLength", {{"type", "integer"},
+                                                         {"maxLength", 1}}},
+             std::pair<const char*, json>{"minimum", {{"type", "string"},
+                                                       {"minimum", 1}}}}) {
+        json body = {
+            {"messages", {{{"role", "user"}, {"content", "test"}}}},
+            {"tools", json::array({{
+                {"type", "function"},
+                {"function", {
+                    {"name", "schema_test"},
+                    {"parameters", {
+                        {"type", "object"},
+                        {"properties", {{"value", invalid.second}}}
+                    }}
+                }}
+            }})}
+        };
+        ChatRequest request;
+        std::string error;
+        CHECK(!parse_chat_request_json(body.dump(), request, error));
+        CHECK(contains(error, invalid.first));
+    }
+    return true;
+}
+
+bool test_unsupported_schema_keywords_are_rejected() {
+    for (const char* unsupported : {"const", "multipleOf", "oneOf"}) {
+        json body = {
+            {"messages", {{{"role", "user"}, {"content", "test"}}}},
+            {"tools", json::array({{
+                {"type", "function"},
+                {"function", {
+                    {"name", "schema_test"},
+                    {"parameters", {
+                        {"type", "object"},
+                        {"properties", {{"value", {{"type", "integer"},
+                                                     {unsupported, unsupported == std::string("oneOf")
+                                                         ? json::array({json{{"type", "integer"}}})
+                                                         : json(2)}}}}}
+                    }}
+                }}
+            }})}
+        };
+        ChatRequest request;
+        std::string error;
+        CHECK(!parse_chat_request_json(body.dump(), request, error));
+        CHECK(contains(error, "unsupported field"));
+    }
+    return true;
+}
+
 bool test_parallel_tool_calls() {
     ChatRequest request;
     CHECK(parse_request(hermes_request(), request));
@@ -644,6 +878,12 @@ int main() {
     if (!test_implicit_thinking_prefill_suffix()) return 1;
     if (!test_all_json_schema_value_types()) return 1;
     if (!test_schema_constraints()) return 1;
+    if (!test_schema_pattern_is_linear_time()) return 1;
+    if (!test_schema_unions_and_dynamic_properties()) return 1;
+    if (!test_unicode_string_lengths()) return 1;
+    if (!test_large_integer_bounds_are_exact()) return 1;
+    if (!test_schema_keyword_type_applicability()) return 1;
+    if (!test_unsupported_schema_keywords_are_rejected()) return 1;
     if (!test_parallel_tool_calls()) return 1;
     if (!test_plain_answer()) return 1;
     if (!test_control_markup_never_leaks_as_content()) return 1;

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -1,0 +1,655 @@
+#include "chat_tools.hpp"
+
+#include <nlohmann/json.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <utility>
+
+namespace {
+
+using nlohmann::json;
+using sparkinfer_server::ChatRequest;
+using sparkinfer_server::ParsedToolOutput;
+using sparkinfer_server::ToolChoiceMode;
+using sparkinfer_server::ToolCall;
+using sparkinfer_server::apply_qwen36_tools_template;
+using sparkinfer_server::parse_chat_request_json;
+using sparkinfer_server::parse_qwen36_tool_output;
+
+#define CHECK(expr)                                                                            \
+    do {                                                                                       \
+        if (!(expr)) {                                                                         \
+            std::fprintf(stderr, "FAIL: %s:%d: %s\n", __FILE__, __LINE__, #expr);             \
+            return false;                                                                      \
+        }                                                                                      \
+    } while (0)
+
+bool contains(const std::string& haystack, const std::string& needle) {
+    return haystack.find(needle) != std::string::npos;
+}
+
+bool parse_request(const std::string& body, ChatRequest& request) {
+    std::string error;
+    if (!parse_chat_request_json(body, request, error)) {
+        std::fprintf(stderr, "unexpected request parse failure: %s\n", error.c_str());
+        return false;
+    }
+    if (!error.empty()) {
+        std::fprintf(stderr, "successful request parse left an error: %s\n", error.c_str());
+        return false;
+    }
+    return true;
+}
+
+json arguments(const ToolCall& call) {
+    return json::parse(call.arguments);
+}
+
+const std::string& hermes_request() {
+    static const std::string body = [] {
+        std::ifstream in(std::string(SPARKINFER_SERVER_TEST_DIR) +
+                         "/fixtures/hermes_tool_request.json", std::ios::binary);
+        return std::string(std::istreambuf_iterator<char>(in),
+                           std::istreambuf_iterator<char>());
+    }();
+    return body;
+}
+
+bool test_hermes_request_and_template() {
+    ChatRequest request;
+    CHECK(!hermes_request().empty());
+    CHECK(parse_request(hermes_request(), request));
+    CHECK(request.messages.size() == 2);
+    CHECK(request.messages[0].role == "system");
+    CHECK(request.messages[1].role == "user");
+    CHECK(request.tools.size() == 2);
+    CHECK(request.tools[0].name == "lookup_catalog");
+    CHECK(request.tools[1].name == "summarize_items");
+    CHECK(request.tool_choice == ToolChoiceMode::kAuto);
+    CHECK(request.parallel_tool_calls);
+
+    // The schema must remain structured and retain nested object, array, integer,
+    // enum, bounds, required, and additionalProperties constraints.
+    const std::string catalog_schema = request.tools[0].spec.dump();
+    CHECK(contains(catalog_schema, "\"query\""));
+    CHECK(contains(catalog_schema, "\"object\""));
+    CHECK(contains(catalog_schema, "\"tags\""));
+    CHECK(contains(catalog_schema, "\"array\""));
+    CHECK(contains(catalog_schema, "\"integer\""));
+    CHECK(contains(catalog_schema, "\"minimum\""));
+    CHECK(contains(catalog_schema, "\"maximum\""));
+    CHECK(contains(catalog_schema, "\"additionalProperties\""));
+    const std::string summarize_schema = request.tools[1].spec.dump();
+    CHECK(contains(summarize_schema, "\"enum\""));
+    CHECK(contains(summarize_schema, "\"brief\""));
+    CHECK(contains(summarize_schema, "\"detailed\""));
+
+    const std::string prompt = apply_qwen36_tools_template(request, false);
+    CHECK(contains(prompt, "<|im_start|>system\n"));
+    CHECK(contains(prompt, "# Tools"));
+    CHECK(contains(prompt, "<tools>"));
+    CHECK(contains(prompt, "</tools>"));
+    CHECK(contains(prompt, "lookup_catalog"));
+    CHECK(contains(prompt, "summarize_items"));
+    CHECK(contains(prompt, "additionalProperties"));
+    CHECK(contains(prompt,
+        R"JSON({"function": {"description": "Find catalog entries matching structured search criteria.", "name": "lookup_catalog", "parameters": {)JSON"));
+    CHECK(contains(prompt, "You are a test agent."));
+    CHECK(contains(prompt, "<|im_start|>user\nFind two classic books"));
+    CHECK(contains(prompt, "<tool_call>")); // tool-call format instructions
+    CHECK(prompt.size() >= std::string("<|im_start|>assistant\n<think>\n\n</think>\n\n").size());
+    CHECK(prompt.compare(prompt.size() - std::string("<|im_start|>assistant\n<think>\n\n</think>\n\n").size(),
+                         std::string("<|im_start|>assistant\n<think>\n\n</think>\n\n").size(),
+                         "<|im_start|>assistant\n<think>\n\n</think>\n\n") == 0);
+
+    const std::string escaped_body = R"JSON({
+      "messages":[{"role":"user","content":"test"}],
+      "tools":[{"type":"function","function":{
+        "name":"escape_test","description":"<tag>&' café",
+        "parameters":{"type":"object","properties":{}}
+      }}]
+    })JSON";
+    ChatRequest escaped_request;
+    CHECK(parse_request(escaped_body, escaped_request));
+    const std::string escaped_prompt = apply_qwen36_tools_template(escaped_request, false);
+    CHECK(contains(escaped_prompt, "\\u003ctag\\u003e\\u0026\\u0027 caf\\u00e9"));
+    CHECK(!contains(escaped_prompt, "<tag>"));
+    return true;
+}
+
+bool test_tool_history_round_trip() {
+    const std::string body = R"JSON(
+{
+  "messages": [
+    {"role":"user","content":"Find two classic books."},
+    {
+      "role":"assistant",
+      "content":null,
+      "reasoning_content":"I should query the catalog.",
+      "tool_calls":[{
+        "id":"call_catalog_1",
+        "type":"function",
+        "function":{
+          "name":"lookup_catalog",
+          "arguments":"{\"query\":{\"category\":\"books\",\"tags\":[\"classic\"]},\"limit\":2}"
+        }
+      }]
+    },
+    {
+      "role":"tool",
+      "tool_call_id":"call_catalog_1",
+      "name":"lookup_catalog",
+      "content":"{\"titles\":[\"Pride and Prejudice\",\"Moby-Dick\"]}"
+    },
+    {"role":"user","content":"Now summarize them."}
+  ],
+  "tools":[{
+    "type":"function",
+    "function":{
+      "name":"lookup_catalog",
+      "description":"Find books.",
+      "parameters":{
+        "type":"object",
+        "properties":{
+          "query":{"type":"object"},
+          "limit":{"type":"integer"}
+        },
+        "required":["query","limit"]
+      }
+    }
+  }]
+}
+)JSON";
+
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    CHECK(request.messages.size() == 4);
+    const auto& assistant = request.messages[1];
+    CHECK(assistant.role == "assistant");
+    CHECK(assistant.content_is_null);
+    CHECK(assistant.reasoning_content == "I should query the catalog.");
+    CHECK(assistant.tool_calls.size() == 1);
+    CHECK(assistant.tool_calls[0].id == "call_catalog_1");
+    CHECK(assistant.tool_calls[0].name == "lookup_catalog");
+    CHECK(arguments(assistant.tool_calls[0])["limit"] == 2);
+    const auto& result = request.messages[2];
+    CHECK(result.role == "tool");
+    CHECK(result.tool_call_id == "call_catalog_1");
+    CHECK(result.name == "lookup_catalog");
+
+    const std::string prompt = apply_qwen36_tools_template(request, false);
+    CHECK(contains(prompt, "<|im_start|>assistant\n"));
+    CHECK(contains(prompt, "<function=lookup_catalog>"));
+    CHECK(contains(prompt, "<parameter=query>"));
+    CHECK(contains(prompt, "<parameter=limit>\n2\n</parameter>"));
+    CHECK(contains(prompt, "<tool_response>"));
+    CHECK(contains(prompt, "Pride and Prejudice"));
+    CHECK(contains(prompt, "</tool_response>"));
+    CHECK(contains(prompt, "<|im_start|>user\nNow summarize them."));
+    return true;
+}
+
+bool test_tool_choice_modes() {
+    const std::string prefix = R"JSON({
+      "messages":[{"role":"user","content":"Use lookup if allowed."}],
+      "tools":[{"type":"function","function":{"name":"lookup","parameters":{"type":"object"}}}],
+      "tool_choice":)JSON";
+
+    ChatRequest request;
+    CHECK(parse_request(prefix + "\"auto\"}", request));
+    CHECK(request.tool_choice == ToolChoiceMode::kAuto);
+    CHECK(contains(apply_qwen36_tools_template(request, false), "<tools>"));
+
+    CHECK(parse_request(prefix + "\"none\"}", request));
+    CHECK(request.tool_choice == ToolChoiceMode::kNone);
+    const std::string no_tools_prompt = apply_qwen36_tools_template(request, false);
+    CHECK(!contains(no_tools_prompt, "<tools>"));
+    CHECK(!contains(no_tools_prompt, "<function=lookup>"));
+    CHECK(contains(no_tools_prompt, "<|im_start|>user\nUse lookup if allowed."));
+
+    for (const std::string& bad_choice : {
+             std::string("\"required\""),
+             std::string("\"sometimes\""),
+             std::string("7"),
+             std::string(R"JSON({"type":"function","function":{"name":"lookup"}})JSON"),
+             std::string(R"JSON({"type":"function","function":{}})JSON"),
+             std::string(R"JSON({"type":"other","function":{"name":"lookup"}})JSON")}) {
+        std::string error;
+        ChatRequest invalid;
+        CHECK(!parse_chat_request_json(prefix + bad_choice + "}", invalid, error));
+        CHECK(!error.empty());
+    }
+    return true;
+}
+
+bool test_tool_choice_none_preserves_history() {
+    const std::string body = R"JSON({
+      "messages":[
+        {"role":"system","content":"Do not call new tools."},
+        {"role":"user","content":"Look up the record."},
+        {
+          "role":"assistant",
+          "content":null,
+          "reasoning_content":"The earlier request required a lookup.",
+          "tool_calls":[{
+            "id":"call_prior",
+            "type":"function",
+            "function":{"name":"lookup","arguments":"{\"key\":\"alpha\"}"}
+          }]
+        },
+        {
+          "role":"tool",
+          "tool_call_id":"call_prior",
+          "name":"lookup",
+          "content":"{\"value\":42}"
+        }
+      ],
+      "tools":[{"type":"function","function":{
+        "name":"lookup",
+        "description":"Look up a record.",
+        "parameters":{
+          "type":"object",
+          "properties":{"key":{"type":"string"}},
+          "required":["key"],
+          "additionalProperties":false
+        }
+      }}],
+      "tool_choice":"none"
+    })JSON";
+
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    CHECK(request.tool_choice == ToolChoiceMode::kNone);
+    CHECK(request.tools.size() == 1); // none disables new calls; it does not erase history metadata
+    CHECK(request.tools[0].name == "lookup");
+    CHECK(request.messages[2].tool_calls.size() == 1);
+
+    const std::string prompt = apply_qwen36_tools_template(request, false);
+    CHECK(!contains(prompt, "# Tools"));
+    CHECK(!contains(prompt, "<tools>"));
+    CHECK(contains(prompt, "<function=lookup>"));
+    CHECK(contains(prompt, "<parameter=key>\nalpha\n</parameter>"));
+    CHECK(contains(prompt, "<tool_response>\n{\"value\":42}\n</tool_response>"));
+    CHECK(contains(prompt, "The earlier request required a lookup."));
+    return true;
+}
+
+bool test_one_tool_call_and_schema_types() {
+    ChatRequest request;
+    CHECK(parse_request(hermes_request(), request));
+    const std::string raw =
+        "<think>\nI need the catalog.\n</think>\n\n"
+        "<tool_call>\n"
+        "<function=lookup_catalog>\n"
+        "<parameter=query>\n"
+        "{\"category\":\"books\",\"tags\":[\"classic\"]}\n"
+        "</parameter>\n"
+        "<parameter=limit>\n2\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>";
+
+    const ParsedToolOutput output = parse_qwen36_tool_output(raw, true, request);
+    CHECK(output.error.empty());
+    CHECK(output.reasoning_content == "I need the catalog.");
+    CHECK(output.content.empty());
+    CHECK(output.tool_calls.size() == 1);
+    CHECK(output.tool_calls[0].id.empty()); // response transport owns call IDs
+    CHECK(output.tool_calls[0].name == "lookup_catalog");
+    const json args = arguments(output.tool_calls[0]);
+    CHECK(args.is_object());
+    CHECK(args["query"].is_object());
+    CHECK(args["query"]["category"].is_string());
+    CHECK(args["query"]["tags"].is_array());
+    CHECK(args["query"]["tags"][0] == "classic");
+    CHECK(args["limit"].is_number_integer());
+    CHECK(args["limit"] == 2);
+    return true;
+}
+
+bool test_implicit_thinking_prefill_suffix() {
+    ChatRequest request;
+    CHECK(parse_request(hermes_request(), request));
+    // With thinking enabled, the prompt already ends in "<think>\n". The generated suffix
+    // therefore starts with reasoning and closes the inherited block without another opener.
+    const std::string raw =
+        "I should query the catalog before answering.\n</think>\n\n"
+        "<tool_call>\n<function=lookup_catalog>\n"
+        "<parameter=query>\n{\"category\":\"books\",\"tags\":[]}\n</parameter>\n"
+        "<parameter=limit>\n2\n</parameter>\n"
+        "</function>\n</tool_call>";
+    const ParsedToolOutput output = parse_qwen36_tool_output(raw, true, request);
+    CHECK(output.error.empty());
+    CHECK(output.reasoning_content == "I should query the catalog before answering.");
+    CHECK(output.content.empty());
+    CHECK(output.tool_calls.size() == 1);
+    CHECK(output.tool_calls[0].name == "lookup_catalog");
+    CHECK(arguments(output.tool_calls[0])["limit"] == 2);
+    return true;
+}
+
+bool test_all_json_schema_value_types() {
+    const std::string body = R"JSON({
+      "messages":[{"role":"user","content":"Send typed values."}],
+      "tools":[{"type":"function","function":{
+        "name":"typed_values",
+        "parameters":{
+          "type":"object",
+          "properties":{
+            "text":{"type":"string"},
+            "count":{"type":"integer"},
+            "ratio":{"type":"number"},
+            "enabled":{"type":"boolean"},
+            "items":{"type":"array"},
+            "config":{"type":"object"},
+            "nothing":{"type":"null"}
+          },
+          "required":["text","count","ratio","enabled","items","config","nothing"],
+          "additionalProperties":false
+        }
+      }}]
+    })JSON";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    const std::string raw =
+        "<tool_call>\n<function=typed_values>\n"
+        "<parameter=text>\nhello\n</parameter>\n"
+        "<parameter=count>\n7\n</parameter>\n"
+        "<parameter=ratio>\n1.25\n</parameter>\n"
+        "<parameter=enabled>\ntrue\n</parameter>\n"
+        "<parameter=items>\n[\"a\",2]\n</parameter>\n"
+        "<parameter=config>\n{\"x\":1}\n</parameter>\n"
+        "<parameter=nothing>\nnull\n</parameter>\n"
+        "</function>\n</tool_call>";
+    const ParsedToolOutput output = parse_qwen36_tool_output(raw, false, request);
+    CHECK(output.error.empty());
+    CHECK(output.tool_calls.size() == 1);
+    const json args = arguments(output.tool_calls[0]);
+    CHECK(args["text"].is_string() && args["text"] == "hello");
+    CHECK(args["count"].is_number_integer() && args["count"] == 7);
+    CHECK(args["ratio"].is_number_float() && args["ratio"] == 1.25);
+    CHECK(args["enabled"].is_boolean() && args["enabled"] == true);
+    CHECK(args["items"].is_array() && args["items"].size() == 2);
+    CHECK(args["config"].is_object() && args["config"]["x"] == 1);
+    CHECK(args["nothing"].is_null());
+    return true;
+}
+
+bool test_schema_constraints() {
+    const std::string body = R"JSON({
+      "messages":[{"role":"user","content":"Send constrained values."}],
+      "tools":[{"type":"function","function":{
+        "name":"constrained",
+        "parameters":{
+          "type":"object",
+          "properties":{
+            "count":{"type":"integer","minimum":1,"maximum":3},
+            "tags":{
+              "type":"array",
+              "minItems":1,
+              "maxItems":2,
+              "items":{"type":"string"}
+            },
+            "code":{"type":"string","pattern":"^[A-Z]{2}[0-9]{2}$"}
+          },
+          "required":["count","tags","code"],
+          "additionalProperties":false
+        }
+      }}]
+    })JSON";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    auto call = [](const std::string& count, const std::string& tags,
+                   const std::string& code) {
+        return "<tool_call>\n<function=constrained>\n"
+               "<parameter=count>\n" + count + "\n</parameter>\n"
+               "<parameter=tags>\n" + tags + "\n</parameter>\n"
+               "<parameter=code>\n" + code + "\n</parameter>\n"
+               "</function>\n</tool_call>";
+    };
+
+    const ParsedToolOutput valid = parse_qwen36_tool_output(
+        call("2", "[\"classic\",\"fiction\"]", "AB12"), false, request);
+    CHECK(valid.error.empty());
+    CHECK(valid.tool_calls.size() == 1);
+
+    for (const auto& invalid : {
+             std::pair<const char*, std::string>{"minimum", call("0", "[\"classic\"]", "AB12")},
+             std::pair<const char*, std::string>{"maximum", call("4", "[\"classic\"]", "AB12")},
+             std::pair<const char*, std::string>{"minItems", call("2", "[]", "AB12")},
+             std::pair<const char*, std::string>{"maxItems", call("2", "[\"a\",\"b\",\"c\"]", "AB12")},
+             std::pair<const char*, std::string>{"pattern", call("2", "[\"classic\"]", "bad-code")}}) {
+        const ParsedToolOutput output = parse_qwen36_tool_output(invalid.second, false, request);
+        if (output.error.empty()) {
+            std::fprintf(stderr, "FAIL: schema constraint %s was not enforced\n", invalid.first);
+            return false;
+        }
+        CHECK(output.reasoning_content.empty());
+        CHECK(output.content.empty());
+        CHECK(output.tool_calls.empty());
+    }
+    return true;
+}
+
+bool test_parallel_tool_calls() {
+    ChatRequest request;
+    CHECK(parse_request(hermes_request(), request));
+    const std::string raw =
+        "<tool_call>\n"
+        "<function=lookup_catalog>\n"
+        "<parameter=query>\n{\"category\":\"books\",\"tags\":[]}\n</parameter>\n"
+        "<parameter=limit>\n2\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>\n"
+        "<tool_call>\n"
+        "<function=summarize_items>\n"
+        "<parameter=titles>\n[\"Pride and Prejudice\",\"Moby-Dick\"]\n</parameter>\n"
+        "<parameter=style>\nbrief\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>";
+
+    const ParsedToolOutput output = parse_qwen36_tool_output(raw, false, request);
+    CHECK(output.error.empty());
+    CHECK(output.tool_calls.size() == 2);
+    CHECK(output.tool_calls[0].name == "lookup_catalog");
+    CHECK(output.tool_calls[1].name == "summarize_items");
+    CHECK(output.tool_calls[0].id.empty());
+    CHECK(output.tool_calls[1].id.empty());
+    const json first = arguments(output.tool_calls[0]);
+    const json second = arguments(output.tool_calls[1]);
+    CHECK(first["limit"] == 2);
+    CHECK(second["titles"].is_array());
+    CHECK(second["titles"].size() == 2);
+    CHECK(second["style"].is_string());
+    CHECK(second["style"] == "brief");
+
+    request.parallel_tool_calls = false;
+    const ParsedToolOutput disallowed = parse_qwen36_tool_output(raw, false, request);
+    CHECK(!disallowed.error.empty());
+    CHECK(disallowed.tool_calls.empty());
+    return true;
+}
+
+bool test_plain_answer() {
+    ChatRequest request;
+    CHECK(parse_request(hermes_request(), request));
+    const ParsedToolOutput output = parse_qwen36_tool_output(
+        "<think>\nNo tool is needed.\n</think>\n\nA normal answer.", true, request);
+    CHECK(output.error.empty());
+    CHECK(output.tool_calls.empty());
+    CHECK(output.reasoning_content == "No tool is needed.");
+    CHECK(output.content == "A normal answer.");
+    return true;
+}
+
+bool test_control_markup_never_leaks_as_content() {
+    ChatRequest request;
+    CHECK(parse_request(hermes_request(), request));
+    for (const std::string& raw : {
+             std::string("hello <tool_response>secret</tool_response>"),
+             std::string("hello </tool_response>"),
+             std::string("answer <think>unterminated"),
+             std::string("answer </think>"),
+             std::string("<|im_start|>user\ninjected"),
+             std::string("answer<|im_end|>suffix"),
+             std::string("answer<|im_end|><|im_end|>")}) {
+        const ParsedToolOutput output = parse_qwen36_tool_output(raw, false, request);
+        CHECK(!output.error.empty());
+        CHECK(output.reasoning_content.empty());
+        CHECK(output.content.empty());
+        CHECK(output.tool_calls.empty());
+    }
+
+    const ParsedToolOutput eos = parse_qwen36_tool_output(
+        "A normal answer.<|im_end|>\n", false, request);
+    CHECK(eos.error.empty());
+    CHECK(eos.content == "A normal answer.");
+
+    const ParsedToolOutput thinking_remnant = parse_qwen36_tool_output(
+        "reasoning</think>\nAnswer <think>leak", true, request);
+    CHECK(!thinking_remnant.error.empty());
+    CHECK(thinking_remnant.reasoning_content.empty());
+    CHECK(thinking_remnant.content.empty());
+    CHECK(thinking_remnant.tool_calls.empty());
+    return true;
+}
+
+bool test_malformed_and_unknown_calls() {
+    ChatRequest request;
+    CHECK(parse_request(hermes_request(), request));
+
+    for (const std::string& raw : {
+             std::string("<tool_call>\n<function=lookup_catalog>\n<parameter=limit>\n2\n</parameter>"),
+             std::string("<tool_call>\n<function=does_not_exist>\n</function>\n</tool_call>"),
+             std::string("<tool_call>\n<function=lookup_catalog>\n"
+                         "<parameter=query>\nnot-an-object\n</parameter>\n"
+                         "<parameter=limit>\n2\n</parameter>\n"
+                         "</function>\n</tool_call>"),
+             std::string("<tool_call>\n<function=lookup_catalog>\n"
+                         "<parameter=query>\n{}\n</parameter>\n"
+                         "<parameter=limit>\ntwo\n</parameter>\n"
+                         "</function>\n</tool_call>"),
+             std::string("<tool_call>\n<function=lookup_catalog>\n"
+                         "<parameter=query>\n{}\n</parameter>\n"
+                         "<parameter=query>\n{}\n</parameter>\n"
+                         "<parameter=limit>\n2\n</parameter>\n"
+                         "</function>\n</tool_call>"),
+             std::string("<tool_call>\n<function=lookup_catalog>\n"
+                         "<parameter=query>\n{}\n</parameter>\n"
+                         "<parameter=limit>\n2\n</parameter>\n"
+                         "<parameter=surprise>\ntrue\n</parameter>\n"
+                         "</function>\n</tool_call>"),
+             std::string("<tool_call>\n<function=summarize_items>\n"
+                         "<parameter=titles>\n[\"Moby-Dick\"]\n</parameter>\n"
+                         "<parameter=style>\nverbose\n</parameter>\n"
+                         "</function>\n</tool_call>"),
+             std::string("<tool_call>\n<function=lookup_catalog>\n"
+                         "<parameter=query>\n{}\n</parameter>\n"
+                         "</function>\n</tool_call>")}) {
+        const ParsedToolOutput output = parse_qwen36_tool_output(raw, false, request);
+        CHECK(!output.error.empty());
+        CHECK(output.tool_calls.empty());
+    }
+
+    ChatRequest none_request;
+    std::string none_body = hermes_request();
+    const size_t final_brace = none_body.find_last_of('}');
+    CHECK(final_brace != std::string::npos);
+    none_body.insert(final_brace, ",\"tool_choice\":\"none\"");
+    CHECK(parse_request(none_body, none_request));
+    const std::string valid_call =
+        "<tool_call>\n<function=lookup_catalog>\n"
+        "<parameter=query>\n{}\n</parameter>\n"
+        "<parameter=limit>\n2\n</parameter>\n"
+        "</function>\n</tool_call>";
+    const ParsedToolOutput forbidden = parse_qwen36_tool_output(valid_call, false, none_request);
+    CHECK(!forbidden.error.empty());
+    CHECK(forbidden.tool_calls.empty());
+    return true;
+}
+
+bool test_invalid_requests_and_duplicate_tools() {
+    for (const std::string& body : {
+             std::string("{"),
+             std::string("[]"),
+             std::string(R"JSON({"messages":[]})JSON"),
+             std::string(R"JSON({
+               "messages":[{"role":"user","content":"hi"}],
+               "tools":[
+                 {"type":"function","function":{"name":"same","parameters":{"type":"object"}}},
+                 {"type":"function","function":{"name":"same","parameters":{"type":"object"}}}
+               ]
+             })JSON")}) {
+        ChatRequest request;
+        std::string error;
+        CHECK(!parse_chat_request_json(body, request, error));
+        CHECK(!error.empty());
+    }
+    return true;
+}
+
+bool test_unsafe_protocol_names() {
+    auto request_with_names = [](const std::string& function_name,
+                                 const std::string& parameter_name) {
+        json body = {
+            {"messages", {{{"role", "user"}, {"content", "test"}}}},
+            {"tools", {{
+                {"type", "function"},
+                {"function", {
+                    {"name", function_name},
+                    {"parameters", {
+                        {"type", "object"},
+                        {"properties", {{parameter_name, {{"type", "string"}}}}}
+                    }}
+                }}
+            }}}
+        };
+        return body.dump();
+    };
+
+    ChatRequest valid;
+    CHECK(parse_request(request_with_names("safe_name-1", "safe_parameter-1"), valid));
+    for (const std::string& name : {
+             std::string("bad name"), std::string("bad\tname"), std::string("bad\nname"),
+             std::string("bad<name"), std::string("bad>name"), std::string("bad&name"),
+             std::string("bad\"name"), std::string("bad'name")}) {
+        ChatRequest request;
+        std::string error;
+        CHECK(!parse_chat_request_json(request_with_names(name, "safe"), request, error));
+        CHECK(!error.empty());
+    }
+    for (const std::string& name : {
+             std::string("bad parameter"), std::string("bad\tparameter"),
+             std::string("bad\nparameter"), std::string("bad<parameter"),
+             std::string("bad>parameter"), std::string("bad&parameter"),
+             std::string("bad\"parameter"), std::string("bad'parameter")}) {
+        ChatRequest request;
+        std::string error;
+        CHECK(!parse_chat_request_json(request_with_names("safe", name), request, error));
+        CHECK(!error.empty());
+    }
+    return true;
+}
+
+} // namespace
+
+int main() {
+    if (!test_hermes_request_and_template()) return 1;
+    if (!test_tool_history_round_trip()) return 1;
+    if (!test_tool_choice_modes()) return 1;
+    if (!test_tool_choice_none_preserves_history()) return 1;
+    if (!test_one_tool_call_and_schema_types()) return 1;
+    if (!test_implicit_thinking_prefill_suffix()) return 1;
+    if (!test_all_json_schema_value_types()) return 1;
+    if (!test_schema_constraints()) return 1;
+    if (!test_parallel_tool_calls()) return 1;
+    if (!test_plain_answer()) return 1;
+    if (!test_control_markup_never_leaks_as_content()) return 1;
+    if (!test_malformed_and_unknown_calls()) return 1;
+    if (!test_invalid_requests_and_duplicate_tools()) return 1;
+    if (!test_unsafe_protocol_names()) return 1;
+    std::printf("chat_tools_test: OK\n");
+    return 0;
+}

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -706,6 +706,42 @@ bool test_parallel_tool_calls() {
     return true;
 }
 
+bool test_nontext_content_parts_are_ignored_not_rejected() {
+    // A mixed multimodal payload (common even against text-only backends -- agent frameworks
+    // often build one request shape for every provider) must still succeed using whatever text
+    // parts are present, not hard-reject the whole request.
+    json body = {
+        {"model", "spark"},
+        {"messages", json::array({json::object({
+             {"role", "user"},
+             {"content", json::array({
+                  json::object({{"type", "text"}, {"text", "describe this: "}}),
+                  json::object({{"type", "image_url"}, {"image_url", json::object({{"url", "http://x/y.png"}})}}),
+                  json::object({{"type", "text"}, {"text", "please"}}),
+              })},
+         })})},
+    };
+    ChatRequest request;
+    CHECK(parse_request(body.dump(), request));
+    CHECK(request.messages.size() == 1);
+    CHECK(request.messages[0].content == "describe this: please");
+    return true;
+}
+
+bool test_developer_role_is_accepted_as_system_alias() {
+    json body = {
+        {"model", "spark"},
+        {"messages", json::array({json::object({
+             {"role", "developer"}, {"content", "be terse"},
+         })})},
+    };
+    ChatRequest request;
+    CHECK(parse_request(body.dump(), request));
+    CHECK(request.messages.size() == 1);
+    CHECK(request.messages[0].role == "system");
+    return true;
+}
+
 bool test_plain_answer() {
     ChatRequest request;
     CHECK(parse_request(hermes_request(), request));
@@ -747,6 +783,25 @@ bool test_control_markup_never_leaks_as_content() {
     CHECK(thinking_remnant.reasoning_content.empty());
     CHECK(thinking_remnant.content.empty());
     CHECK(thinking_remnant.tool_calls.empty());
+    return true;
+}
+
+bool test_trailing_whitespace_after_tool_call_is_not_malformed() {
+    // ChatTokenizer::decode() skips literal text for special tokens (including <|im_end|>), so
+    // on a normal EOS stop the decoded text usually does NOT contain a literal <|im_end|>
+    // suffix -- any whitespace-only token the model emits right before EOS must not be treated
+    // as "text or malformed markup appears after a tool call".
+    ChatRequest request;
+    CHECK(parse_request(hermes_request(), request));
+    const std::string raw =
+        "<tool_call>\n<function=lookup_catalog>\n"
+        "<parameter=query>\n{\"category\":\"books\",\"tags\":[]}\n</parameter>\n"
+        "<parameter=limit>\n2\n</parameter>\n"
+        "</function>\n</tool_call>\n";
+    const ParsedToolOutput output = parse_qwen36_tool_output(raw, false, request);
+    CHECK(output.error.empty());
+    CHECK(output.tool_calls.size() == 1);
+    CHECK(output.tool_calls[0].name == "lookup_catalog");
     return true;
 }
 
@@ -887,6 +942,9 @@ int main() {
     if (!test_parallel_tool_calls()) return 1;
     if (!test_plain_answer()) return 1;
     if (!test_control_markup_never_leaks_as_content()) return 1;
+    if (!test_trailing_whitespace_after_tool_call_is_not_malformed()) return 1;
+    if (!test_nontext_content_parts_are_ignored_not_rejected()) return 1;
+    if (!test_developer_role_is_accepted_as_system_alias()) return 1;
     if (!test_malformed_and_unknown_calls()) return 1;
     if (!test_invalid_requests_and_duplicate_tools()) return 1;
     if (!test_unsafe_protocol_names()) return 1;

--- a/server/tests/fixtures/hermes_tool_request.json
+++ b/server/tests/fixtures/hermes_tool_request.json
@@ -1,0 +1,88 @@
+{
+  "messages": [
+    {
+      "role": "system",
+      "content": "You are a test agent. Use the provided functions when they are needed."
+    },
+    {
+      "role": "user",
+      "content": "Find two classic books and then summarize their titles."
+    }
+  ],
+  "model": "qwen3.6-35b-a3b-ud-q4-k-m",
+  "max_tokens": 4096,
+  "stream": true,
+  "stream_options": {
+    "include_usage": true
+  },
+  "tools": [
+    {
+      "type": "function",
+      "function": {
+        "name": "lookup_catalog",
+        "description": "Find catalog entries matching structured search criteria.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "query": {
+              "type": "object",
+              "properties": {
+                "category": {
+                  "type": "string"
+                },
+                "tags": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "category"
+              ],
+              "additionalProperties": false
+            },
+            "limit": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 10
+            }
+          },
+          "required": [
+            "query",
+            "limit"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "type": "function",
+      "function": {
+        "name": "summarize_items",
+        "description": "Summarize a list of item titles.",
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "titles": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "style": {
+              "type": "string",
+              "enum": [
+                "brief",
+                "detailed"
+              ]
+            }
+          },
+          "required": [
+            "titles"
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- add OpenAI-compatible function tools to the Qwen3.6 chat endpoint
- render the pinned Qwen3.6 tool template, including assistant tool-call history and grouped tool results
- parse native Qwen `<tool_call>` output into structured non-streaming and SSE responses
- carry EOS vs token-limit termination through the runtime so `finish_reason` is accurate
- add CPU conformance tests and build/package/attest the server in the Linux artifact workflow

## Protocol and safety

- accepts Hermes/OpenAI `tools`, nullable assistant content, `tool_calls`, and matching `role: "tool"` history
- supports omitted/`auto` and `none` tool choice plus default/true parallel calls
- returns `400` for forced/named choices, `parallel_tool_calls: false`, unsupported schemas, or any tool protocol on Muse instead of silently ignoring it
- buffers tool-mode streaming output until native XML and arguments are complete
- uses pinned RE2 for linear-time untrusted schema patterns and suppresses pattern text in logs
- rejects duplicate JSON keys, unknown functions, malformed/truncated markup, unsafe XML names, missing required fields, and schema type/constraint violations
- validates dynamic `additionalProperties`, nullable unions, Unicode string lengths, and full-width 64-bit numeric bounds without lossy conversion
- withholds complete or partial tool calls when generation reaches its token limit
- emits stable `call_...` IDs, JSON-string arguments, and `finish_reason: "tool_calls"`; raw model control markup is never exposed to clients

## Validation

- `chat_tools_test: OK` with `-Wall -Wextra -Werror`
- `chat_tokenizer_test: OK` with marker-boundary streaming coverage
- full server compiles and links with `-Wall -Wextra -Werror`; ASan/UBSan protocol suite passes
- sanitized Hermes v0.20 fixture covers nested schemas and two tool calls
- the captured real 22-tool Hermes request parses successfully
- rendered fixture matches the pinned official Qwen3.6 Jinja byte-for-byte
- OpenAI Python SDK 2.24 passes non-streaming, SSE+usage, and assistant/tool replay against the real HTTP handler
- Hermes Agent v0.20 completes a two-turn terminal-tool execution/replay loop through the real HTTP handler

The Linux CI job builds and smoke-tests `sparkinfer_server`, records its SHA-256 in the bundle
manifest, and includes the binary in GitHub Artifact Attestations.
