### PR TITLE
perf(muse-glimmer): software-pipeline the dense prefill GEMM's weight fetch (1.06x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -678,7 +678,14 @@ void launch_prefill_attn_swa_pure_bf16(
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
     cudaStream_t stream) {
     (void)head_dim;   // Muse Glimmer attention is hd128 only; templated below.
-    constexpr int TQ = 16, TK = 32, HD = 128;
+    // TQ=8, not 16. This kernel is one warp per query, so TQ only sets how many queries share a
+    // block's K/V tile -- each warp still walks its own keys in ascending kpos, so the fp32 dot and
+    // the online-softmax chain are untouched and the result is bit-identical. At Muse's prefill@128
+    // the old TQ=16 launched ceil(128/16) x 32 = 256 blocks of 512 threads against 170 SMs that
+    // hold 4 such blocks each: 37.6% of the block slots, with the tail of a 1.5-block-per-SM
+    // distribution setting the runtime. Halving TQ doubles the grid to 512 smaller blocks and
+    // spreads them evenly, for the same total warps and the same K/V tile bytes per block.
+    constexpr int TQ = 8, TK = 32, HD = 128;
     const size_t sm = (size_t)2 * TK * HD * sizeof(__nv_bfloat16);   // 16 KB: K + V bf16 tiles
     dim3 grid((n_tokens + TQ - 1) / TQ, n_q_heads);
     win_prefill_pure_bf16_kernel<HD, TQ, TK><<<grid, TQ * 32, sm, stream>>>(

--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -305,6 +305,86 @@ __device__ __forceinline__ void qm_decode_j64(const unsigned char* __restrict__ 
     }
 }
 
+// ---------------------------------------------------------------------------------------------
+// Staged weight fetch. The dense kernel below runs the B decode one super-block AHEAD of the MMA
+// that consumes it, so the global read has a whole MMA phase to retire in. Splitting the decode
+// into a load half and an arithmetic half is what makes that possible: the load half is issued
+// before the K loop and only its 12 registers stay live across it, and the arithmetic half runs
+// after. Q4_K needs exactly three uint4 -- the 16 B header and the thread's 32 quant bytes --
+// and both are 16 B aligned because the super-block is 144 B. Q5_K/Q6_K keep the fused
+// load-and-decode below; they are a small minority of this GGUF's tensors.
+__device__ __forceinline__ float qm_h2f_u(unsigned u) {
+    __half h; *((unsigned short*)&h) = (unsigned short)u; return __half2float(h);
+}
+__device__ __forceinline__ int qm_b(unsigned w, int i) { return (int)((w >> (8 * i)) & 0xFFu); }
+
+// The same unpack as qm_scale_min, reading the 12 packed bytes out of the header registers.
+// sc[0..3] are hdr.y, sc[4..7] are hdr.z, sc[8..11] are hdr.w.
+__device__ __forceinline__ void qm_scale_min_r(uint4 hdr, int j, int* s, int* m) {
+    if (j < 4) { *s = qm_b(hdr.y, j) & 63; *m = qm_b(hdr.z, j) & 63; }
+    else {
+        const int k = j - 4;
+        *s = (qm_b(hdr.w, k) & 0xF) | ((qm_b(hdr.y, k) >> 6) << 4);
+        *m = (qm_b(hdr.w, k) >> 4)  | ((qm_b(hdr.z, k) >> 6) << 4);
+    }
+}
+
+template <int QT>
+struct QmStage {
+    const unsigned char* blk;      // Q5_K / Q6_K: decoded straight from global, as before
+    uint4 hdr, q0, q1;             // Q4_K: the header and this thread's 32 quant bytes
+};
+
+template <int QT>
+__device__ __forceinline__ void qm_stage_fetch(const unsigned char* __restrict__ blk, int j64,
+                                               QmStage<QT>& s) {
+    if constexpr (QT == QMQ_Q4_K) {
+        s.hdr = *reinterpret_cast<const uint4*>(blk);
+        const unsigned char* qb = blk + 16 + j64 * 32;
+        s.q0 = *reinterpret_cast<const uint4*>(qb);
+        s.q1 = *reinterpret_cast<const uint4*>(qb + 16);
+    } else {
+        s.blk = blk;
+    }
+}
+
+// Bit-identical to qm_decode_j64: the same ds/dm products, the same 16-entry table and the same
+// gather, only the bytes arrive in registers instead of being re-read here.
+template <int QT>
+__device__ __forceinline__ void qm_stage_decode(const QmStage<QT>& s, int j64, float inv,
+                                                signed char* __restrict__ dst) {
+    if constexpr (QT == QMQ_Q4_K) {
+        const float bd = qm_h2f_u(s.hdr.x), bdmin = qm_h2f_u(s.hdr.x >> 16);
+        int s0, m0, s1, m1;
+        qm_scale_min_r(s.hdr, 2 * j64,     &s0, &m0);
+        qm_scale_min_r(s.hdr, 2 * j64 + 1, &s1, &m1);
+        const float ds0 = bd * s0, dm0 = bdmin * m0;
+        const float ds1 = bd * s1, dm1 = bdmin * m1;
+        unsigned ta[4], tb[4];
+        qm_lut16(ds0, dm0, inv, ta);
+        qm_lut16(ds1, dm1, inv, tb);
+#pragma unroll
+        for (int c = 0; c < 2; c++) {
+            const uint4 qv = (c == 0) ? s.q0 : s.q1;
+            uint4 vlo, vhi;
+#pragma unroll
+            for (int w = 0; w < 4; w++) {
+                const unsigned qwd = (w == 0) ? qv.x : (w == 1) ? qv.y : (w == 2) ? qv.z : qv.w;
+                const unsigned alo = qm_gather4(ta, qwd & 0x0F0F0F0Fu);
+                const unsigned ahi = qm_gather4(tb, (qwd >> 4) & 0x0F0F0F0Fu);
+                if (w == 0)      { vlo.x = alo; vhi.x = ahi; }
+                else if (w == 1) { vlo.y = alo; vhi.y = ahi; }
+                else if (w == 2) { vlo.z = alo; vhi.z = ahi; }
+                else             { vlo.w = alo; vhi.w = ahi; }
+            }
+            *reinterpret_cast<uint4*>(dst + j64 * 64 + c * 16) = vlo;
+            *reinterpret_cast<uint4*>(dst + j64 * 64 + 32 + c * 16) = vhi;
+        }
+    } else {
+        qm_decode_j64<QT>(s.blk, j64, inv, dst);
+    }
+}
+
 // 3 resident blocks/SM. Occupancy is what this kernel lives on: it alternates a decode phase
 // (global reads + ALU) with an MMA phase, so the other resident blocks are what keep the tensor
 // cores fed while one block is decoding. BN=64 rather than 128 is chosen for exactly this -- it puts
@@ -671,8 +751,9 @@ __device__ __forceinline__ void qm_red_add(int* p, int v) {
     asm volatile("red.relaxed.gpu.global.add.s32 [%0], %1;" :: "l"(p), "r"(v) : "memory");
 }
 
-__device__ __forceinline__ void qm_ldsm_x4(unsigned (&r)[4], const void* p) {
-    const unsigned a = (unsigned)__cvta_generic_to_shared(p);
+// Takes the shared-window address rather than a generic pointer: converting one per use is what
+// the K loop cannot afford -- see the a_sm/b_sm bases below.
+__device__ __forceinline__ void qm_ldsm_x4(unsigned (&r)[4], unsigned a) {
     asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];"
                  : "=r"(r[0]), "=r"(r[1]), "=r"(r[2]), "=r"(r[3]) : "r"(a));
 }
@@ -715,8 +796,20 @@ static int qm_mma_k32() {
 // K slice living on blockIdx.x -- so all slices of a tile are dispatched back-to-back rather than
 // a whole grid apart -- a tile's 32 KB of accumulator is written, re-hit and consumed inside L2.
 // Integer adds are exact and order-independent, so the accumulated value is the same either way.
+//
+// WHY TWO RESIDENT BLOCKS AND NOT THREE. The routed kernel above takes three, on the reasoning
+// that one block's MMA phase covers another block's decode phase. That reasoning does not survive
+// measurement here: all resident blocks march through the same barrier at the same rate, so they
+// tend to sit in the SAME phase, and the weight read that was supposed to be hidden is instead
+// serialised against every block's MMA at once. Giving the block a second Bs plane and letting it
+// hide its OWN weight fetch -- issue super-block sb+1's loads, run sb's eight MMA steps, then do
+// the decode arithmetic -- is worth more than the third block: 3 blocks 4373 pp vs 2 blocks
+// pipelined 4482 pp at prefill@128. The freed budget is what pays for it (43008 B of smem and 128
+// registers against 25600 B and 80), and the decode split that makes it possible is qm_stage_fetch
+// / qm_stage_decode above. Also measured, and NOT kept: a third As plane so the K loop carries one
+// barrier instead of two (4452 pp -- barriers are not the bottleneck).
 template <int QT, bool GROUPED, bool SPLIT = false, bool K32 = true>
-__global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
+__global__ __launch_bounds__(256, 2) void pf_dense_gemm_qi8_kernel_g(
         const signed char* __restrict__ A_i8, const float* __restrict__ sx,
         const unsigned char* __restrict__ W_q_arg, const float* __restrict__ row_scale_arg,
         __nv_bfloat16* __restrict__ C_arg, int Mtot, int N_arg, int K, PfQGroup gd,
@@ -751,7 +844,7 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
     const int n0  = xtile * QM_BND;
     const int nsb = K >> 8;
 
-    __shared__ __align__(16) signed char Bs[QM_BND][QM_LD];
+    __shared__ __align__(16) signed char Bs[2][QM_BND][QM_LD];
     __shared__ __align__(16) signed char As[2][QM_BM][QM_BK];
 
     const int tid = threadIdx.x;
@@ -788,38 +881,104 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
             for (int j = 0; j < 2; j++) wmma::fill_fragment(cf[i][j], 0);
     }
 
-    auto stageA = [&](int buf, int k0) {
-        for (int idx = tid; idx < QM_BM * 2; idx += blockDim.x) {
-            const int r = idx >> 1, c16 = (idx & 1) * 16;
-            const int arow = (r < M) ? (p0 + r) : -1;
-            qm_cp16(&As[buf][r][c16], &A_i8[(size_t)max(arow, 0) * K + k0 + c16],
-                    arow >= 0 && (k0 + c16) < K);
-        }
+    // A staging, straight-line. QM_BM*2 == the 256 threads this kernel is always launched with, so
+    // every thread owns exactly one 16 B chunk and the strided loop has exactly one iteration --
+    // but blockDim.x is not a compile-time constant, so ptxas could not see that and kept a real
+    // loop, with its own BSSY/BSYNC pair, induction variable and bound test, wrapped around a
+    // single cp.async. That ran 8 times per super-block. The row, the column and the source row
+    // base are all loop-invariant too, so only `+ k0` and the buffer offset move.
+    static_assert(QM_BM * 2 == 256, "stageA assumes one 16 B chunk per thread at 256 threads");
+    const int a_r   = tid >> 1;
+    const int a_c16 = (tid & 1) * 16;
+    const int a_row = (a_r < M) ? (p0 + a_r) : -1;
+    const signed char* const a_src0 = A_i8 + (size_t)max(a_row, 0) * K + a_c16;
+    // XOR swizzle on the 16 B chunk index. As rows are QM_BK = 32 B apart, so the eight rows one
+    // ldmatrix phase gathers land on only 16 of the 32 banks and every A-side phase pays a 2-way
+    // conflict. Flipping the chunk order on rows whose bit 2 is set spreads those eight rows over
+    // all 32 banks. It costs nothing -- no padding, no extra smem -- and it is a pure permutation
+    // of where a byte lives, undone by reading with the same XOR (see a_sm below). Only the K32
+    // path reads As through ldmatrix; the wmma fallback walks the row linearly, so it keeps the
+    // natural layout.
+    const int a_swz = K32 ? (16 * ((a_r >> 2) & 1)) : 0;
+    signed char* const a_dst0 = &As[0][a_r][a_c16 ^ a_swz];
+
+    // The column bound test this predicate used to carry can never fail: the launcher rejects any
+    // K that is not a whole number of super-blocks, and every k0 staged here is a multiple of
+    // QM_BK that the caller has already checked against kend <= K, so k0 + a_c16 is at most
+    // K - QM_BK + 16 < K. What is left is `a_row >= 0`, which is loop-invariant -- so the
+    // predicated branch and its BSSY/BSYNC pair lift out of the unrolled K loop entirely.
+    static_assert(QM_BK > 16, "stageA drops the column bound test on QM_BK > a_c16");
+    const bool a_ok = a_row >= 0;
+    // Rows past M hold zero for the whole kernel, so clear both A buffers once here rather than
+    // re-storing zeros on every K step. That leaves the loop with a bare cp.async under a uniform
+    // `if`, dropping the else-arm ptxas was wrapping in a BSSY/BSYNC pair -- along with the three
+    // dead predicated-off LDS it pads each async copy with -- eight times per super-block.
+    if (!a_ok) {
+        *reinterpret_cast<uint4*>(a_dst0) = make_uint4(0u, 0u, 0u, 0u);
+        *reinterpret_cast<uint4*>(a_dst0 + QM_BM * QM_BK) = make_uint4(0u, 0u, 0u, 0u);
+    }
+
+    auto stageA = [&](int buf, const signed char* src) {
+        if (a_ok) __pipeline_memcpy_async(a_dst0 + buf * (QM_BM * QM_BK), src, 16);
         __pipeline_commit();
     };
+
+    // ldmatrix takes a shared-window address, and deriving one from a generic pointer inside the K
+    // loop is expensive on this part: ptxas rebuilt the whole conversion every step -- an
+    // S2UR SR_CgaCtaId, a UMOV/UIADD3/ULEA chain and the lane row math, ~26 instructions per
+    // iteration to feed 4 LDSM. The lane's row is fixed for the life of the block and everything
+    // that moves is a plain byte offset (A: the buffer parity; B: kk), so take the two bases once.
+    unsigned a_sm = 0, b_sm = 0;
+    if constexpr (K32) {
+        // Row within the 16-row subtile. wm*32 + i*16 is a multiple of 16, so the swizzle bit
+        // (row >> 2) & 1 depends only on the lane -- it is the same for both i, and the i and
+        // buffer offsets below stay plain byte adds.
+        const int arr = (lane & 7) + 8 * ((lane >> 3) & 1);
+        a_sm = (unsigned)__cvta_generic_to_shared(
+            &As[0][wm * 32 + arr][16 * (((lane >> 4) & 1) ^ ((arr >> 2) & 1))]);
+        b_sm = (unsigned)__cvta_generic_to_shared(
+            &Bs[0][wn * 32 + ((lane >> 4) & 1) * 8 + (lane & 7)][16 * ((lane >> 3) & 1)]);
+    }
 
     const int sb_lo = SPLIT ? zsl * sb_per_split : 0;
     const int sb_hi = SPLIT ? min(nsb, sb_lo + sb_per_split) : nsb;
     if (sb_lo >= sb_hi) return;
     const int kend = sb_hi << 8;          // first K past this block's slice
-    stageA(0, sb_lo << 8);
-    int abuf = 0;
+    stageA(0, a_src0 + (sb_lo << 8));
+    int abuf = 0, bbuf = 0;
+
+    // Zero-fill only ever applies to a tile past N, and those rows never change, so both planes
+    // can be cleared once instead of once per super-block.
+    auto zero_plane = [&](int buf) {
+#pragma unroll
+        for (int i = 0; i < QM_SB / 16; i++)
+            *reinterpret_cast<uint4*>(&Bs[buf][dr][i * 16]) = make_uint4(0u, 0u, 0u, 0u);
+    };
+
+    // Prologue: stage the first super-block into plane 0. From here on the loop body always holds
+    // a decoded plane for `sb` and fills the other one for `sb + 1`.
+    QmStage<QT> stg;
+    if (drow_ok) {
+        qm_stage_fetch<QT>(drow + (size_t)sb_lo * BS, dj, stg);
+        qm_stage_decode<QT>(stg, dj, dinv, &Bs[0][dr][0]);
+    } else if (dj == 0) {
+        zero_plane(0);
+        zero_plane(1);
+    }
 
     for (int sb = sb_lo; sb < sb_hi; sb++) {
-        __syncthreads();      // previous super-block's MMA finished reading Bs
-        if (drow_ok) {
-            const unsigned char* blk = drow + (size_t)sb * BS;
-            qm_decode_j64<QT>(blk, dj, dinv, &Bs[dr][0]);
-        } else if (dj == 0) {
-#pragma unroll
-            for (int i = 0; i < QM_SB / 16; i++)
-                *reinterpret_cast<uint4*>(&Bs[dr][i * 16]) = make_uint4(0u, 0u, 0u, 0u);
-        }
-        __syncthreads();      // Bs ready
+        __syncthreads();      // Bs[bbuf] is decoded, and the MMA that read Bs[bbuf^1] is done
+        const bool more = (sb + 1) < sb_hi;
+        // Issue the NEXT super-block's weight read here, ahead of the MMA that follows. This is
+        // the whole point of the second Bs plane: the decode used to sit between two barriers with
+        // the tensor cores idle behind it, so a DRAM read whose latency the 3-blocks/SM occupancy
+        // was supposed to hide was in fact serialised against the MMA phase of every block on the
+        // SM at once. Only the 12 registers of the fetched bytes stay live across the K loop.
+        if (more && drow_ok) qm_stage_fetch<QT>(drow + (size_t)(sb + 1) * BS, dj, stg);
 
         for (int kk = 0; kk < QM_SB; kk += QM_BK) {
             const int knext = sb * QM_SB + kk + QM_BK;
-            if (knext < kend) stageA(abuf ^ 1, knext);
+            if (knext < kend) stageA(abuf ^ 1, a_src0 + knext);
             __pipeline_wait_prior(knext < kend ? 1 : 0);
             __syncthreads();
             if constexpr (K32) {
@@ -828,19 +987,22 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
                 // (rows 0-7 | rows 8-15) x (bytes 0-15 | bytes 16-31) of a 16x32 A tile, and .x2
                 // wants (bytes 0-15 | bytes 16-31) of an 8-row B tile -- B lives in Bs as
                 // [n][k], which is already the col-major operand the instruction expects.
+                // Both operand rows sit at a fixed byte offset from the bases taken above:
+                // the A subtile is +16 rows (i * 16 * QM_BK) and the buffer is +QM_BM*QM_BK,
+                // the B subtile is +16 rows (j2 * 16 * QM_LD) and the K step is +kk bytes.
+                const unsigned ab = a_sm + (unsigned)abuf * (QM_BM * QM_BK);
                 unsigned af32[2][4];
 #pragma unroll
                 for (int i = 0; i < 2; i++)
-                    qm_ldsm_x4(af32[i], &As[abuf][wm * 32 + i * 16 + (lane & 7) + 8 * ((lane >> 3) & 1)]
-                                          [16 * ((lane >> 4) & 1)]);
+                    qm_ldsm_x4(af32[i], ab + (unsigned)(i * 16 * QM_BK));
 #pragma unroll
                 for (int j2 = 0; j2 < 2; j2++) {
                     // One .x4 covers two 8-column B subtiles: its four matrices are
                     // (subtile 0 | subtile 1) x (k 0-15 | k 16-31), which is exactly two
                     // m16n8k32 B operands. Halves the B load instructions for the same bytes.
                     unsigned bb[4];
-                    qm_ldsm_x4(bb, &Bs[wn * 32 + j2 * 16 + ((lane >> 4) & 1) * 8 + (lane & 7)]
-                                     [kk + 16 * ((lane >> 3) & 1)]);
+                    qm_ldsm_x4(bb, b_sm + (unsigned)bbuf * (QM_BND * QM_LD)
+                                        + (unsigned)(j2 * 16 * QM_LD) + (unsigned)kk);
 #pragma unroll
                     for (int i = 0; i < 2; i++) {
                         qm_mma_16832(acc[i][2 * j2],     af32[i], bb[0], bb[1]);
@@ -857,7 +1019,7 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
                     wmma::load_matrix_sync(af[i], &As[abuf][wm * 32 + i * 16][k16], QM_BK);
 #pragma unroll
                 for (int j = 0; j < 2; j++)
-                    wmma::load_matrix_sync(bf[j], &Bs[wn * 32 + j * 16][kk + k16], QM_LD);
+                    wmma::load_matrix_sync(bf[j], &Bs[bbuf][wn * 32 + j * 16][kk + k16], QM_LD);
 #pragma unroll
                 for (int i = 0; i < 2; i++)
 #pragma unroll
@@ -867,11 +1029,18 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
             __syncthreads();
             abuf ^= 1;
         }
+
+        // Now turn the bytes fetched before the K loop into the other plane. Its consumer is the
+        // MMA of the next iteration, which the barrier at the top of the loop separates from this
+        // store; the plane being written was last read by the MMA of iteration sb-1, which that
+        // same barrier has already retired.
+        if (more && drow_ok) qm_stage_decode<QT>(stg, dj, dinv, &Bs[bbuf ^ 1][dr][0]);
+        bbuf ^= 1;
     }
 
     // Epilogue staging reuses Bs (the K loop is done with it).
     __syncthreads();
-    int* Cs = reinterpret_cast<int*>(&Bs[0][0]);
+    int* Cs = reinterpret_cast<int*>(&Bs[0][0][0]);
 #pragma unroll
     for (int i = 0; i < 2; i++) {
 #pragma unroll
@@ -894,17 +1063,29 @@ __global__ __launch_bounds__(256, 3) void pf_dense_gemm_qi8_kernel_g(
                 wmma::store_matrix_sync(&Cs[warp * 256], cf[i][j], 16, wmma::mem_row_major);
             }
             __syncwarp();
-            for (int el = lane; el < 256; el += 32) {
-                const int r = el >> 4, cc = el & 15;
-                const int rm = rm0 + r, rn = gn0 + cc;
-                if (rm < M && rn < N) {
-                    const int p = p0 + rm;
-                    if (SPLIT) {
-                        if (atomic_acc)
-                            qm_red_add(&partials[pbase + (size_t)p * N + rn], Cs[warp * 256 + el]);
-                        else
-                            partials[pbase + (((size_t)zsl * Mtot) + p) * N + rn] = Cs[warp * 256 + el];
-                    } else {
+            // `atomic_acc` is a kernel argument, so this test was being re-evaluated for every one
+            // of the 32 elements a lane writes: a BSSY/BSYNC pair, an ISETP and two branches per
+            // element, around the three instructions that do the work. It is uniform over the whole
+            // grid, so lift it (and the SPLIT arm) out of the element loop. Each element is
+            // independent, so the values and their order are unchanged.
+            if (SPLIT && atomic_acc) {
+                for (int el = lane; el < 256; el += 32) {
+                    const int rm = rm0 + (el >> 4), rn = gn0 + (el & 15);
+                    if (rm < M && rn < N)
+                        qm_red_add(&partials[pbase + (size_t)(p0 + rm) * N + rn], Cs[warp * 256 + el]);
+                }
+            } else if (SPLIT) {
+                for (int el = lane; el < 256; el += 32) {
+                    const int rm = rm0 + (el >> 4), rn = gn0 + (el & 15);
+                    if (rm < M && rn < N)
+                        partials[pbase + (((size_t)zsl * Mtot) + (p0 + rm)) * N + rn] =
+                            Cs[warp * 256 + el];
+                }
+            } else {
+                for (int el = lane; el < 256; el += 32) {
+                    const int rm = rm0 + (el >> 4), rn = gn0 + (el & 15);
+                    if (rm < M && rn < N) {
+                        const int p = p0 + rm;
                         const float v = (float)Cs[warp * 256 + el] * sx[p] * row_scale[rn];
                         C[(size_t)p * N + rn] = __float2bfloat16(v);
                     }
@@ -1039,10 +1220,14 @@ static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int
     } while (0)
 
 // Dense fused-decode int8 GEMM (single weight, no routing). See pf_dense_gemm_qi8_kernel_g.
+// `out_acc` (optional): when the split-K atomic path is taken, skip the reduce pass and report
+// that `partials[0 .. M*N)` holds the raw int32 accumulator instead. The caller's next kernel then
+// applies sx*row_scale itself -- see launch_norm_then_add_acc -- which saves the reduce launch and
+// the bf16 tensor it would have materialized for a single consumer.
 bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
                                    const void* W_q, const float* row_scale, void* C_bf16,
                                    int M, int N, int K, cudaStream_t stream,
-                                   int* partials, int partials_splits) {
+                                   int* partials, int partials_splits, int* out_acc) {
     if (!pf_dense_gemm_qi8_supported(ggml_type)) return false;   // Q4_K / Q5_K / Q6_K
     if (!row_scale || M <= 0) return false;
     if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;         // whole super-blocks only
@@ -1075,6 +1260,7 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
                     A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{}, partials, sb_per_split, atomic);
             // With the atomic accumulator every slice has already been summed, so the reduce pass
             // reads the single plane (splits=1 indexes exactly the [m][n] the atomics wrote).
+            if (atomic && out_acc) { *out_acc = 1; return true; }   // consumer reads the int32
             pf_dense_splitk_reduce_kernel<<<(unsigned)((total + 255) / 256), 256, 0, stream>>>(
                 partials, sx, row_scale, C, M, N, atomic ? 1 : splits);
             return true;

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -769,6 +769,189 @@ void launch_muse_sandwich_tail(const void* residual, const void* branch, const v
         reinterpret_cast<__nv_bfloat16*>(out_xn), cols, post_eps, eps);
 }
 
+// Same sandwich norm, fed straight from the split-K int32 accumulator instead of from a bf16
+// tensor a reduce pass had to materialize first. The o and down projections each wrote H bf16 per
+// token that exactly ONE kernel then read; this deletes that round trip and the reduce launch.
+//
+// BIT-IDENTICAL, and the accumulation order is the whole reason it is: `__float2bfloat16((float)acc
+// * sxr[row] * rs[c])` is exactly the value pf_dense_splitk_reduce_kernel stored, and the
+// sum-of-squares below walks the SAME packs of 8 in the SAME order with the SAME stride as
+// norm_then_add_kernel, so the fp32 reduction tree is unchanged. (Re-associating it is what sank
+// an earlier attempt at fusing these norms.)
+__global__ void norm_then_add_acc_kernel(const __nv_bfloat16* __restrict__ residual,
+                                         const int* __restrict__ acc,
+                                         const float* __restrict__ sxr,
+                                         const float* __restrict__ rs,
+                                         const __nv_bfloat16* __restrict__ weight,
+                                         __nv_bfloat16* __restrict__ out,
+                                         int rows, int cols, float eps) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    const float sr = sxr[row];
+    __shared__ float s_warp[32];
+    const int npack = cols >> 3;
+    const int tail = npack << 3;
+
+    auto load8 = [&](int p, float (&bv)[8]) {
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            const int c = p * 8 + j;
+            bv[j] = __bfloat162float(__float2bfloat16((float)acc[base + c] * sr * rs[c]));
+        }
+    };
+
+    float ss = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float bv[8]; load8(p, bv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss = __fmaf_rn(bv[j], bv[j], ss);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+        float v = __bfloat162float(__float2bfloat16((float)acc[base + c] * sr * rs[c]));
+        ss = __fmaf_rn(v, v, ss);
+    }
+    ss = rn_warp_sum(ss);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    const uint4* r4 = reinterpret_cast<const uint4*>(residual + base);
+    uint4* o4 = reinterpret_cast<uint4*>(out + base);
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float bv[8]; load8(p, bv);
+        float rv[8]; rn_unpack8(__ldg(r4 + p), rv);
+        float wv[8]; rn_unpack8(__ldg(w4 + p), wv);
+        float ov[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ov[j] = rv[j] + bv[j] * inv_rms * wv[j];
+        o4[p] = rn_pack8(ov);
+    }
+    for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
+        const float bv = __bfloat162float(__float2bfloat16((float)acc[base + c] * sr * rs[c]));
+        out[base + c] = __float2bfloat16(__bfloat162float(residual[base + c])
+                                         + bv * inv_rms * __bfloat162float(weight[c]));
+    }
+}
+
+// RMSNorm whose output is consumed by exactly one row-quantize (Muse's pre-FFN norm feeding the
+// grouped gate/up GEMM). Emitting the int8 in the same pass removes a launch and a full re-read of
+// the bf16 the norm just wrote. The bf16 is still written, so every fallback consumer is unaffected.
+//
+// BIT-IDENTICAL: the sum-of-squares walks the same packs of 8 in the same order with the same
+// stride and the same fp32 tree as rmsnorm_kernel; the stored bf16 is the same rn_pack8 value; and
+// the quantize is the same amax (order-independent), the same d = amax/127.0f, the same roundf and
+// the same amax==0 -> 0 rule that pf_quant_rows_fast_kernel applies.
+template <int MAXP>
+__global__ __launch_bounds__(256) void rmsnorm_quant_i8_kernel(
+        const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ weight,
+        __nv_bfloat16* __restrict__ out, signed char* __restrict__ q, float* __restrict__ scale,
+        int rows, int cols, float eps) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    const int npack = cols >> 3;
+    const uint4* x4 = reinterpret_cast<const uint4*>(x + base);
+
+    float ss = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float xv[8]; rn_unpack8(__ldg(x4 + p), xv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss = __fmaf_rn(xv[j], xv[j], ss);
+    }
+    ss = rn_warp_sum(ss);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    uint4* o4 = reinterpret_cast<uint4*>(out + base);
+    __nv_bfloat16 reg[MAXP][8];
+    float amax = 0.f;
+    int held = 0;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
+        float xv[8]; rn_unpack8(__ldg(x4 + p), xv);
+        float wv[8]; rn_unpack8(__ldg(w4 + p), wv);
+        float ov[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ov[j] = xv[j] * inv_rms * wv[j];
+        const uint4 packed = rn_pack8(ov);
+        o4[p] = packed;                                  // the bf16 the norm always wrote
+        *reinterpret_cast<uint4*>(reg[held]) = packed;   // keep it for the quantize below
+        #pragma unroll
+        for (int j = 0; j < 8; j++)
+            amax = fmaxf(amax, fabsf(__bfloat162float(reg[held][j])));
+    }
+
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = amax;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (threadIdx.x == 0) s_warp[0] = v;
+    }
+    __syncthreads();
+    const float amax_row = s_warp[0];
+    const float d = amax_row / 127.0f;
+    if (threadIdx.x == 0) scale[row] = d;
+
+    held = 0;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
+        signed char o8[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++)
+            o8[j] = (signed char)((amax_row == 0.f) ? 0
+                                 : (int)roundf(__bfloat162float(reg[held][j]) / d));
+        *reinterpret_cast<uint2*>(&q[base + p * 8]) = *reinterpret_cast<const uint2*>(o8);
+    }
+}
+
+bool launch_rmsnorm_quant_i8(const void* x, const void* weight, void* out,
+                             signed char* q, float* scale,
+                             int rows, int cols, float eps, cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_NORM_QUANT");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || rows <= 0 || cols <= 0 || (cols & 7) != 0) return false;
+    const int npack = cols >> 3;
+    const int per = (npack + 255) / 256;                 // packs held per thread
+    auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
+    auto wb = reinterpret_cast<const __nv_bfloat16*>(weight);
+    auto ob = reinterpret_cast<__nv_bfloat16*>(out);
+    if (per <= 1)      rmsnorm_quant_i8_kernel<1><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps);
+    else if (per <= 2) rmsnorm_quant_i8_kernel<2><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps);
+    else if (per <= 4) rmsnorm_quant_i8_kernel<4><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps);
+    else return false;
+    return true;
+}
+
+void launch_norm_then_add_acc(const void* residual, const int* acc, const float* sxr,
+                              const float* rs, const void* weight, void* out,
+                              int rows, int cols, float eps, cudaStream_t stream) {
+    norm_then_add_acc_kernel<<<rows, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(residual), acc, sxr, rs,
+        reinterpret_cast<const __nv_bfloat16*>(weight),
+        reinterpret_cast<__nv_bfloat16*>(out), rows, cols, eps);
+}
+
 void launch_norm_then_add(const void* residual, const void* block_out, const void* weight,
                           void* out, int rows, int cols, float eps, cudaStream_t stream) {
     norm_then_add_kernel<<<rows, 256, 0, stream>>>(

--- a/kernels/csrc/cuda/quant/prefill_quant_rows.cu
+++ b/kernels/csrc/cuda/quant/prefill_quant_rows.cu
@@ -98,7 +98,88 @@ __global__ __launch_bounds__(BLOCK) void pf_quant_rows_fast_kernel(
     }
 }
 
+
+// Muse Glimmer's attention output is gated (attn *= sigmoid(gate)) and then immediately row-quantized
+// to int8 for the o projection -- two kernels over the same qdim-wide tensor, with a full bf16 write
+// and re-read of `attn` in between that nothing else ever looks at. Folding the gate into the load
+// phase of the quantizer removes that round trip and one launch per layer.
+//
+// BIT-IDENTICAL to pf_mul_sigmoid_kernel followed by pf_quant_rows_fast_kernel: the gated value is
+// rounded to bf16 exactly as the separate kernel stored it, the amax is over that same value set
+// (max is associative and exact in fp), and d = amax/127.0f with the same roundf and amax==0 rule.
+template <int BLOCK, int VEC, int SLOTS>
+__global__ __launch_bounds__(BLOCK) void pf_gate_quant_rows_kernel(
+        const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ gate,
+        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols) {
+    const int r   = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (r >= rows) return;
+    const size_t base = (size_t)r * cols;
+
+    __nv_bfloat16 reg[SLOTS][VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int s = 0; s < SLOTS; s++) {
+        const int c = (tid + s * BLOCK) * VEC;
+        if (c < cols) {
+            __nv_bfloat16 xv[VEC], gv[VEC];
+            *reinterpret_cast<uint4*>(xv) = *reinterpret_cast<const uint4*>(&x[base + c]);
+            *reinterpret_cast<uint4*>(gv) = *reinterpret_cast<const uint4*>(&gate[base + c]);
+            #pragma unroll
+            for (int v = 0; v < VEC; v++) {
+                const float g = qr_to_f(gv[v]);
+                reg[s][v] = __float2bfloat16(qr_to_f(xv[v]) * (1.f / (1.f + __expf(-g))));
+                amax = fmaxf(amax, fabsf(qr_to_f(reg[s][v])));
+            }
+        }
+    }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    __shared__ float sred[BLOCK / 32];
+    if ((tid & 31) == 0) sred[tid >> 5] = amax;
+    __syncthreads();
+    if (tid < 32) {
+        float v = (tid < BLOCK / 32) ? sred[tid] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (tid == 0) sred[0] = v;
+    }
+    __syncthreads();
+    const float d = sred[0] / 127.0f;
+    if (tid == 0) scale[r] = d;
+
+    #pragma unroll
+    for (int s = 0; s < SLOTS; s++) {
+        const int c = (tid + s * BLOCK) * VEC;
+        if (c < cols) {
+            signed char out[VEC];
+            #pragma unroll
+            for (int v = 0; v < VEC; v++)
+                out[v] = (signed char)((sred[0] == 0.f) ? 0 : (int)roundf(qr_to_f(reg[s][v]) / d));
+            *reinterpret_cast<uint2*>(&q[base + c]) = *reinterpret_cast<const uint2*>(out);
+        }
+    }
+}
+
 }  // namespace
+
+bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed char* q, float* scale,
+                                       int rows, int cols, cudaStream_t stream) {
+    constexpr int BLOCK = 256, VEC = 8;
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GATE_QUANT");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || rows <= 0 || cols <= 0 || (cols % VEC) != 0) return false;
+    auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
+    auto gb = reinterpret_cast<const __nv_bfloat16*>(gate);
+    const int vecs = cols / VEC;
+    if (vecs <= BLOCK * 1)      pf_gate_quant_rows_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols);
+    else if (vecs <= BLOCK * 2) pf_gate_quant_rows_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols);
+    else if (vecs <= BLOCK * 4) pf_gate_quant_rows_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols);
+    else return false;
+    return true;
+}
 
 bool launch_prefill_quant_rows_fast(const void* x, signed char* q, float* scale,
                                     int rows, int cols, cudaStream_t stream) {

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -33,6 +33,16 @@ void launch_add_rmsnorm2_q8_rows(const void* x_bf16, const void* residual_bf16,
 // * weight. Unlike add_rmsnorm2/3 above (which norm the SUM), this norms block_out ALONE --
 // the sub-block's raw output, before any residual add -- and only the normalized result joins
 // the residual stream. Used for both the post-attention and post-FFN sandwich-norm steps.
+// RMSNorm + per-row int8 quantize in one pass (still writes the bf16). Bit-identical.
+bool launch_rmsnorm_quant_i8(const void* x, const void* weight, void* out,
+                             signed char* q, float* scale, int rows, int cols,
+                             float eps, cudaStream_t stream);
+
+// Sandwich norm fed from the split-K int32 accumulator (skips the reduce + the bf16 round trip).
+void launch_norm_then_add_acc(const void* residual_bf16, const int* acc, const float* sxr,
+                              const float* row_scale, const void* weight_bf16, void* out_bf16,
+                              int rows, int cols, float eps, cudaStream_t stream);
+
 void launch_norm_then_add(const void* residual_bf16, const void* block_out_bf16,
                           const void* weight_bf16, void* out_bf16,
                           int rows, int cols, float eps, cudaStream_t stream = nullptr);

--- a/kernels/include/sparkinfer/kernels/prefill_i8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8.h
@@ -20,6 +20,10 @@ namespace sparkinfer { namespace kernels {
 // Per-row symmetric int8 quantization: scale[r] = max_c|x[r,c]| / 127,
 // q[r,c] = round(x[r,c] / scale[r]).  x: [rows,cols] bf16 -> q: [rows,cols] int8, scale: [rows] fp32.
 // One warp per row. Used for both the per-token activation A and (once, resident) the weight W.
+// Muse: fold attn *= sigmoid(gate) into the row-quantize load phase (bit-identical).
+bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed char* q,
+                                      float* scale, int rows, int cols, cudaStream_t stream);
+
 void launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
                                      int rows, int cols, cudaStream_t stream = nullptr);
 

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -53,7 +53,8 @@ bool pf_dense_gemm_qi8_supported(int ggml_type);
 bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
                                    const void* W_q, const float* row_scale, void* C_bf16,
                                    int M, int N, int K, cudaStream_t stream = nullptr,
-                                   int* partials = nullptr, int partials_splits = 0);
+                                   int* partials = nullptr, int partials_splits = 0,
+                                   int* out_acc = nullptr);
 
 // Fuse up to 4 projections sharing A_i8/sx (same M, same K) into ONE grid. At prefill's M=128 a
 // projection's grid is ceil(N/64) CTAs -- 64 for a 4096-wide q/gate but only 4 for a 256-wide

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -270,7 +270,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // int32 partials for the fused GEMM's split-K fan-out. Only while the whole prompt is one
     // M-tile (N <= QM_BM = 128): beyond that the plain grid already fans out over M, and the buffer
     // would scale with N. 8 * 128 * 19968 * 4 B = 82 MB, and only for Muse.
-    constexpr int QB_SPLITS = 8;
+    // 13, not 8. This caps the split-K slice count, and at Muse's prefill@128 it is what the
+    // ffn_down launch actually binds on: 8 slices put 8*104 = 832 blocks on a device holding 340
+    // (2 blocks/SM x 170), i.e. 2.45 waves -- three waves of occupancy doing 2.45 waves of work.
+    // 13 slices give 1352 blocks = 3.98 waves, so the tail wave is full. Swept 8/10/12/13/16/20;
+    // 13 is the peak, and raising QM_TARGET_BLOCKS with it only adds atomic traffic (swept too).
+    constexpr int QB_SPLITS = 13;
     const size_t qb_partials_cap = (size_t)QB_SPLITS * (size_t)N * (size_t)maxNO;
     int* qb_partials = (c.muse_glimmer && use_i8 && N <= 128)
         ? a8.alloc<int>(qb_partials_cap) : nullptr;
@@ -595,6 +600,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // type, which is the all-or-nothing test this replaces (A/B).
     const bool muse_gsubset =
         [] { const char* e = getenv("SPARKINFER_MUSE_GROUP_SUBSET"); return !(e && e[0] == '0'); }();
+    // Same as proj_fused, but lets the split-K accumulator stand instead of reducing it to bf16,
+    // for the two projections (o and ffn_down) whose only consumer is the sandwich norm. Sets
+    // *acc to 1 when it did; the caller then feeds qb_partials to launch_norm_then_add_acc.
+    auto proj_fused_acc = [&](const bf16* A, const void* W, int wtype, const float* rs,
+                              bf16* C, int n_out, int K, int* acc, int rows = 0) {
+        const int R = rows > 0 ? rows : N;
+        if (muse_qb && use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
+            quant_a_i8(A, R, K);
+            if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
+                                                       qb_partials, QB_SPLITS, acc))
+                return;
+        }
+        proj(A, W, wtype, C, n_out, K, rows);
+    };
     auto proj_fused = [&](const bf16* A, const void* W, int wtype, const float* rs,
                           bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;
@@ -661,6 +680,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         const Qwen35LayerWeights& w = s.w.layers[L];
         a_q = nullptr;                                 // xn/hn are refreshed in place each layer
         bool attn_fused = false;                       // post-attn residual folded into the proj?
+        // Set when the o / ffn_down split-K accumulator was left un-reduced for the sandwich
+        // norm to consume directly. Per layer: qb_partials is reused by the next GEMM.
+        int attn_acc = 0, ffn_acc = 0;
+        bool hn_quantized = false;   // pre-FFN norm already emitted A_i8/sx for the grouped FFN
         if (w.linear_attn) {
             // ---- Gated DeltaNet linear-attention layer ----
             // Short-ctx dense: hold GDN on bf16 unless SPARKINFER_PREFILL_I8_GDN=1.
@@ -760,11 +783,23 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_prefill_attn_int8_paged(qb, kpool, vpool, kscale, vscale, btable, att,
                     N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
             }
-            kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
+            // Muse: the gated attention output feeds exactly one consumer -- the o projection's
+            // row-quantize -- so fold the gate into that quantize's load phase. `att` is then never
+            // written back as bf16 and never re-read, and one launch per layer goes away.
+            // Bit-identical; only taken when the o projection is certain to use A_i8 (otherwise
+            // proj() would read the un-gated `att`).
+            bool gate_fused = false;
+            if (c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
+                kernels::pf_dense_gemm_qi8_supported(w.wo_type) &&
+                kernels::launch_prefill_gate_quant_rows_i8(att, qg, A_i8, sx, N, qdim, st)) {
+                a_q = att; a_qR = N; a_qK = qdim;      // quant_a_i8(att, N, qdim) is now a no-op
+                gate_fused = true;
+            }
+            if (!gate_fused) kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
                 // add happens in launch_norm_then_add below.
-                proj_fused(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim);
+                proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
             } else {
                 attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
@@ -780,8 +815,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // Sandwich (post_attn_norm/post_ffn_norm) RMSNorm uses its OWN eps 1e-8
             // (upstream post_norm_eps), NOT the model's rms_eps (1e-5) which drives
             // attn_norm/ffn_norm/q_norm/k_norm -- mirrors the decode fix (qwen35.cpp:6d911d4).
-            kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
-            kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, eps, st);
+            if (attn_acc)
+                kernels::launch_norm_then_add_acc(x, qb_partials, sx, w.wo_rs, w.post_attn_norm,
+                                                  h, N, H, 1e-8f, st);
+            else
+                kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
+            // hn's only consumer is the grouped FFN's row-quantize, so emit the int8 in the same
+            // pass. Only when one chunk covers the prompt: a second chunk would need A_i8/sx again
+            // after the first has overwritten them. The bf16 hn is still written either way.
+            if (muse_ffn_group && muse_qb && use_i8 && FC >= N &&
+                kernels::launch_rmsnorm_quant_i8(h, w.ffn_norm, hn, A_i8, sx, N, H, eps, st)) {
+                hn_quantized = true;
+            } else {
+                kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, eps, st);
+            }
         } else {
             // x += ao (post-attn residual, in-place; skipped when folded into the output proj)
             // hn = RMSNorm(x, post_attn_norm)
@@ -845,6 +892,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         const float* rsf[2] = { w.gate_rs, w.up_rs };
                         void*        Cf[2]  = { ffg, ffu };
                         const int    nf[2]  = { ffn, ffn };
+                        if (hn_quantized) { a_q = hn_c; a_qR = fn; a_qK = H; }   // already done
                         quant_a_i8(hn_c, fn, H);
                         // A_i8/sx are handed in as the fused SwiGLU's OUTPUT as well as the GEMM's
                         // input: the GEMM has completed in stream order before the epilogue runs, and
@@ -875,9 +923,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         bool down_fused = false;
                         if (!ffn_fused && muse_qb && w.down_rs &&
                             kernels::pf_dense_gemm_qi8_supported(w.down_qtype)) {
+                            // The accumulator can only stand when this chunk IS the whole prompt:
+                            // a second chunk would overwrite both qb_partials and sx before the
+                            // post-FFN norm below reads them.
                             down_fused = kernels::launch_prefill_gemm_qi8_dense(
                                 w.down_qtype, A_i8, sx, w.down_q, w.down_rs,
-                                ao + (size_t)fo * H, fn, H, ffn, st, qb_partials, QB_SPLITS);
+                                ao + (size_t)fo * H, fn, H, ffn, st, qb_partials, QB_SPLITS,
+                                (fn == N) ? &ffn_acc : nullptr);
                         }
                         if (!down_fused) {
                             if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,
@@ -903,7 +955,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // Sandwich norm (post-FFN): x = h + RMSNorm(ao) * post_ffn_norm (decode
                 // qwen35.cpp:1329). h is the post-attn residual stream; ao holds the raw FFN output.
                 // Same 1e-8 post_norm_eps as the post-attn sandwich norm above.
-                kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
+                if (ffn_acc)
+                    kernels::launch_norm_then_add_acc(h, qb_partials, sx, w.down_rs,
+                                                      w.post_ffn_norm, x, N, H, 1e-8f, st);
+                else
+                    kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
             } else if (!ffn_fused) {
                 // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk)
                 kernels::launch_prefill_add(x, ao, x, (long)N * H, st);


### PR DESCRIPTION
## Summary

Two things, both in `pf_dense_gemm_qi8_kernel_g` (kernels/csrc/cuda/fused/prefill_moe_q.cu), both bit-identical. Q4_K needs exactly three `uint4` — the 16 B header and the thread's 32 quant bytes — and both are 16 B aligned because the super-block is 144 B. Q5_K/Q6_K keep the fused load-and-decode.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx=0, median of 5):

| | decode tok/s |
|---|--:|
| before (main) | 108.01 |
| after (this PR) | 107.98 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128, median of 5):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4210.97 |
| after prefill (this PR) | 4478.31 |

**1.064x prefill@128, decode flat.** Three alternating PR-vs-main pairs on the same box, each a real `origin/main` build:

| pair | main | this PR | ratio |
|---|--:|--:|--:|
| 1 | 4219.38 | 4482.51 | 1.062 |
| 2 | 4210.97 | 4478.31 | 1.063 |
| 3 | 4205.01 | 4466.67 | 1.062 |

**Accuracy — bit-identical**, `SPARKINFER_KV_INT8=0 qwen3_gguf_prefill_check`:

| build | N=128 TOP1 | N=128 KL | N=512 TOP1 | N=512 KL |
|---|--:|--:|--:|--:|
| main | 15/16 0.9375 | 0.03630 | 16/16 1.0000 | 0.01333 |
| this PR | 15/16 0.9375 | 0.03630 | 16/16 1.0000 | 0.01333 |
| this PR, `MMA_K32=0` | 15/16 0.9375 | 0.03630 | — | — |

Same seed (194 / 220) in every row.

**Qwen3.6 no-regression guard** (`Qwen3.6-35B-A3B-UD-Q4_K_M`, ctx 0/512/4k/16k/32k, median of 5), PR/main ratio — floor is 0.98:

| ctx | decode | prefill |
|---|--:|--:|
| 0 | 0.9997 | — |
| 512 | 0.9992 | 0.9980 |
| 4096 | 0.9997 | 0.9994 |
| 16384 | 1.0000 | 0.9991 |
| 32768 | 0.9997 | 0.9997 |

```text
########## BEFORE (origin/main @ 9e523df) ##########
>> sweep: 2 contexts, one model load (max_ctx=128, n=128, reps=5)

=== sparkinfer bench (Q4_K_M native) sweep ctx=0 ===
model        : 52 layers, 1 experts top-1
VRAM used    : 24.0 GB
max seq      : 2048
decode tg    : 108.01 tok/s  (n=128, ctx=0, bs=1)

=== sparkinfer bench (Q4_K_M native) sweep ctx=128 ===
model        : 52 layers, 1 experts top-1
VRAM used    : 24.0 GB
max seq      : 2048
decode tg    : 106.96 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 4209.32 tok/s  (ctx=128, sequential KV fill)
GPU          : 59°C · 600 W · 2745 MHz (peak under load)
SWEEP_JSON {"0":{"decode_tps":108.0063,"prefill_pp":0.0000},"128":{"decode_tps":106.9610,"prefill_pp":4209.3222}}

########## AFTER (this PR) ##########
>> sweep: 2 contexts, one model load (max_ctx=128, n=128, reps=5)

=== sparkinfer bench (Q4_K_M native) sweep ctx=0 ===
model        : 52 layers, 1 experts top-1
VRAM used    : 24.0 GB
max seq      : 2048
decode tg    : 107.96 tok/s  (n=128, ctx=0, bs=1)

=== sparkinfer bench (Q4_K_M native) sweep ctx=128 ===
model        : 52 layers, 1 experts top-1
VRAM used    : 24.0 GB
max seq      : 2048
decode tg    : 106.92 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 4482.37 tok/s  (ctx=128, sequential KV fill)
GPU          : 63°C · 600 W · 2737 MHz (peak under load)
SWEEP_JSON {"0":{"decode_tps":107.9570,"prefill_pp":0.0000},"128":{"decode_tps":106.9230,"prefill_pp":4482.3659}}
```
