### PR TITLE
perf(muse-glimmer): uncap the prefill split-K slice count, zero the accumulator on read (1.05x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -1274,12 +1274,15 @@ static int qm_uncap_splits() {
 
 // Minimum super-blocks a slice must own. Removing the plane cap alone is not the answer: it lets a
 // shallow-K launch be cut until each block holds almost no K, and then the per-block prologue and
-// the atomic epilogue cost more than the extra parallelism buys. Measured at M=128 -- ffn_down
-// (nsb=78) gains 5.3% going 8 -> 20 slices, while q/gate/k/v (nsb=26) LOSES 0.6% going 7 -> 13.
-// The floor is per-slice work, not a fraction of nsb.
+// the atomic epilogue cost more than the extra parallelism buys. Re-sweeping the complete
+// prefill@128 path after zero-on-read showed that a five-super-block floor is the stable balance:
+// alternating 9-repetition medians on an RTX 5090 were 3646.76/3655.41 pp at 5 versus
+// 3581.87/3592.25 pp at 4. The deeper FFN projections still receive extra slices; the shallow
+// q/gate/k/v projections avoid paying another CTA prologue for too little K. The floor is
+// per-slice work, not a fraction of nsb.
 static int qm_min_sb_per_split() {
     static int e = -1;
-    if (e < 0) { const char* v = getenv("SPARKINFER_MUSE_QB_MINSB"); e = v ? atoi(v) : 4; }
+    if (e < 0) { const char* v = getenv("SPARKINFER_MUSE_QB_MINSB"); e = v ? atoi(v) : 5; }
     return e < 1 ? 1 : e;
 }
 
@@ -1317,10 +1320,8 @@ static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int
         if (budget > partials_splits) budget = partials_splits;
         if (budget > nsb / 2) budget = nsb / 2;
         if (one_plane) {
-            // Extra slices are only worth taking while each still owns real K. Measured at M=128:
-            // ffn_down (nsb=78) goes 8 -> 16 slices, 4+ super-blocks each, and its launch drops
-            // 5.3%; q/gate/k/v (nsb=26) cut to 2 super-blocks a slice LOSES 0.6%. So bound the
-            // extra slices by the work floor and never go below what the budget already gave.
+            // Extra slices are only worth taking while each still owns real K. Bound them by the
+            // measured work floor and never go below what the caller's plane budget already gave.
             int deep = splits;
             const int mn = nsb / qm_min_sb_per_split();
             if (deep > mn) deep = mn;

--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -1167,25 +1167,32 @@ bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float
 
 // Sum the split-K int32 partials and apply sx*row_scale once. The sum is over int32, so the total
 // is exactly what the unsplit kernel accumulated and the bf16 store sees an identical value.
-__global__ void pf_dense_splitk_reduce_kernel(const int* __restrict__ partials,
+__global__ void pf_dense_splitk_reduce_kernel(int* __restrict__ partials,
                                               const float* __restrict__ sx,
                                               const float* __restrict__ row_scale,
                                               __nv_bfloat16* __restrict__ C,
-                                              int Mtot, int N, int splits) {
+                                              int Mtot, int N, int splits, int zero_after) {
     const size_t idx = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= (size_t)Mtot * (size_t)N) return;
     const int m = (int)(idx / (size_t)N);
     const int n = (int)(idx - (size_t)m * (size_t)N);
     int acc = 0;
-    for (int s = 0; s < splits; s++) acc += partials[((size_t)s * Mtot + m) * N + n];
+    for (int s = 0; s < splits; s++) {
+        const size_t off = ((size_t)s * Mtot + m) * N + n;
+        acc += partials[off];
+        // Hand the plane back zeroed for the next layer. This kernel has the line in cache already
+        // (it just read it), so the store rides along instead of costing a separate memset pass.
+        if (zero_after) partials[off] = 0;
+    }
     C[idx] = __float2bfloat16((float)acc * sx[m] * row_scale[n]);
 }
 
 // Grouped split-K reduce. One launch covers every group: the flattened column picks the group
 // from the same tile prefix sum the GEMM prologue uses, so no per-group reduce launches are needed.
-__global__ void pf_dense_splitk_reduce_group_kernel(const int* __restrict__ partials,
+__global__ void pf_dense_splitk_reduce_group_kernel(int* __restrict__ partials,
                                                     const float* __restrict__ sx,
-                                                    PfQGroup gd, int Mtot, int ncol, int splits) {
+                                                    PfQGroup gd, int Mtot, int ncol, int splits,
+                                                    int zero_after) {
     const size_t idx = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
     if (idx >= (size_t)Mtot * (size_t)ncol) return;
     const int m    = (int)(idx / (size_t)ncol);
@@ -1196,9 +1203,13 @@ __global__ void pf_dense_splitk_reduce_group_kernel(const int* __restrict__ part
         if (i < gd.ngroup && rest >= gd.first[i] * QM_BND) g = i;
     const int n = rest - gd.first[g] * QM_BND;
     const int N = gd.N[g];
-    const int* base = partials + (size_t)gd.poff[g];
+    int* base = partials + (size_t)gd.poff[g];
     int acc = 0;
-    for (int s = 0; s < splits; s++) acc += base[((size_t)s * Mtot + m) * N + n];
+    for (int s = 0; s < splits; s++) {
+        const size_t off = ((size_t)s * Mtot + m) * N + n;
+        acc += base[off];
+        if (zero_after) base[off] = 0;
+    }
     gd.C[g][(size_t)m * N + n] = __float2bfloat16((float)acc * sx[m] * gd.rs[g][n]);
 }
 
@@ -1247,18 +1258,76 @@ static int qm_wave_pick(int ntiles, int nsb, int want) {
         if (eff > best_eff + 1e-9 || (eff > best_eff - 1e-9 && s > best)) { best_eff = eff; best = s; }
     }
     return best;
+
+// `partials_splits` is how many private [m][n] planes the caller budgeted, so it bounds the slice
+// count only while each slice stores its own plane. The atomic accumulator sums every slice into
+// ONE plane, so under it the buffer says nothing about how finely K may be cut -- the real limits
+// are the target block count and "at least one whole super-block per slice". Leaving the plane
+// budget in place capped the 104-tile o/down launches at 8 slices when the chooser asked for 25,
+// i.e. 832 blocks of a 510-block device: 1.6 waves, and the second one two-thirds empty.
+// SPARKINFER_MUSE_QB_UNCAP=0 restores the plane-budget cap (A/B in one binary).
+static int qm_uncap_splits() {
+    static int e = -1;
+    if (e < 0) { const char* v = getenv("SPARKINFER_MUSE_QB_UNCAP"); e = (v && v[0] == '0') ? 0 : 1; }
+    return e;
+}
+
+// Minimum super-blocks a slice must own. Removing the plane cap alone is not the answer: it lets a
+// shallow-K launch be cut until each block holds almost no K, and then the per-block prologue and
+// the atomic epilogue cost more than the extra parallelism buys. Measured at M=128 -- ffn_down
+// (nsb=78) gains 5.3% going 8 -> 20 slices, while q/gate/k/v (nsb=26) LOSES 0.6% going 7 -> 13.
+// The floor is per-slice work, not a fraction of nsb.
+static int qm_min_sb_per_split() {
+    static int e = -1;
+    if (e < 0) { const char* v = getenv("SPARKINFER_MUSE_QB_MINSB"); e = v ? atoi(v) : 4; }
+    return e < 1 ? 1 : e;
+}
+
+// The atomic accumulator needs its plane to start at zero, which cost a cudaMemsetAsync before
+// EVERY split launch: 2.07 GB per prefill at M=128, and 234 extra kernels sitting on the stream
+// between each GEMM and the consumer that reads its result. Priced by skipping them outright
+// (wrong output, timing only): +5.37% -- well above the 0.72 ms of GPU-busy nsys attributes to
+// them, because the gaps they open in the pipeline cost more than their own runtime.
+//
+// Instead the consumer hands the plane back zeroed. Every element the GEMM wrote is read exactly
+// once -- by the reduce, or for the FFN pair by the fused SwiGLU -- so the zero store rides on a
+// line that is already in cache, and stream ordering does the rest: GEMM atomics -> consumer
+// reads-and-zeroes -> next layer's GEMM lands in an already-zero plane. One memset of the whole
+// buffer when it is allocated covers the first use of every region.
+// SPARKINFER_MUSE_QB_ZOR=0 restores the per-launch memset (A/B in one binary).
+bool pf_dense_zero_on_read() {
+    static int e = -1;
+    if (e < 0) { const char* v = getenv("SPARKINFER_MUSE_QB_ZOR"); e = (v && v[0] == '0') ? 0 : 1; }
+    return e != 0;
 }
 
 // K slices per launch. Shared by the single and grouped launchers so both fan out the same way.
-static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int partials_splits) {
+static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int partials_splits,
+                          bool atomic) {
     static int sk_env = -1;
     if (sk_env < 0) { const char* e = getenv("SPARKINFER_MUSE_QB_SPLITK"); sk_env = e ? atoi(e) : -2; }
+    const bool one_plane = atomic && qm_uncap_splits();
     int splits = 1;
-    if (have_partials && partials_splits > 1 && mtiles == 1 && sk_env != 0) {
+    if (have_partials && (partials_splits > 1 || one_plane) && mtiles == 1 && sk_env != 0) {
         const int nsb = K >> 8;
         splits = (sk_env > 0) ? sk_env : (QM_TARGET_BLOCKS + ntiles - 1) / ntiles;
-        if (splits > partials_splits) splits = partials_splits;
-        if (splits > nsb / 2) splits = nsb / 2;
+        // What the plane budget allows -- unchanged, and the floor for the one-plane case so a
+        // launch can only ever gain slices here, never lose them.
+        int budget = splits;
+        if (budget > partials_splits) budget = partials_splits;
+        if (budget > nsb / 2) budget = nsb / 2;
+        if (one_plane) {
+            // Extra slices are only worth taking while each still owns real K. Measured at M=128:
+            // ffn_down (nsb=78) goes 8 -> 16 slices, 4+ super-blocks each, and its launch drops
+            // 5.3%; q/gate/k/v (nsb=26) cut to 2 super-blocks a slice LOSES 0.6%. So bound the
+            // extra slices by the work floor and never go below what the budget already gave.
+            int deep = splits;
+            const int mn = nsb / qm_min_sb_per_split();
+            if (deep > mn) deep = mn;
+            splits = deep > budget ? deep : budget;
+        } else {
+            splits = budget;
+        }
         if (splits < 1) splits = 1;
         splits = qm_wave_pick(ntiles, nsb, splits);
     }
@@ -1303,7 +1372,10 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
     // Split K only when the plain grid leaves the device idle. With more than one M-tile the grid
     // already fans out over M and a split would only add the reduce pass. Each slice must own whole
     // super-blocks, at least 2, or the per-block prologue dominates it.
-    int splits = qm_pick_splits(ntiles, K, mtiles, partials != nullptr, partials_splits);
+    const int atomic = qm_atomic_acc();
+    // One plane is M*N ints; the caller budgets `partials_splits` planes of the widest projection,
+    // so the atomic plane always fits and the slice count needs no buffer clamp here.
+    int splits = qm_pick_splits(ntiles, K, mtiles, partials != nullptr, partials_splits, atomic != 0);
     if (splits > 1) {
         const int nsb_all = K >> 8;
         const int sb_per_split = (nsb_all + splits - 1) / splits;
@@ -1314,10 +1386,10 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
         // own at least one super-block.
         splits = (nsb_all + sb_per_split - 1) / sb_per_split;
         if (splits > 1) {
-            const int atomic = qm_atomic_acc();
             const size_t total = (size_t)M * (size_t)N;
             // The atomic accumulator must start at zero; one [m][n] plane, not `splits` of them.
-            if (atomic) cudaMemsetAsync(partials, 0, total * sizeof(int), stream);
+            const int zor = (atomic && pf_dense_zero_on_read()) ? 1 : 0;
+            if (atomic && !zor) cudaMemsetAsync(partials, 0, total * sizeof(int), stream);
             dim3 grid(splits, ntiles, mtiles);
             QM_LAUNCH_DENSE(false, true,
                     A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{}, partials, sb_per_split, atomic,
@@ -1326,7 +1398,7 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
             // reads the single plane (splits=1 indexes exactly the [m][n] the atomics wrote).
             if (atomic && out_acc) { *out_acc = 1; return true; }   // consumer reads the int32
             pf_dense_splitk_reduce_kernel<<<(unsigned)((total + 255) / 256), 256, 0, stream>>>(
-                partials, sx, row_scale, C, M, N, atomic ? 1 : splits);
+                partials, sx, row_scale, C, M, N, atomic ? 1 : splits, zor);
             return true;
         }
     }
@@ -1369,12 +1441,14 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
     // result stays bit-identical. SPARKINFER_MUSE_GROUP_SPLITK=0 restores the single-slice launch.
     static int gsk_env = -1;
     if (gsk_env < 0) { const char* e = getenv("SPARKINFER_MUSE_GROUP_SPLITK"); gsk_env = e ? atoi(e) : 1; }
-    int splits = gsk_env == 0 ? 1
-                              : qm_pick_splits(tiles, K, mtiles, partials != nullptr, partials_splits);
+    const int atomic = qm_atomic_acc();
+    int splits = gsk_env == 0
+                     ? 1
+                     : qm_pick_splits(tiles, K, mtiles, partials != nullptr, partials_splits,
+                                      atomic != 0);
     // The caller sizes `partials` for one projection at a time; a group needs the sum of its
     // widths, so clamp the slice count to what actually fits rather than trusting it. The atomic
     // accumulator needs one plane whatever the slice count, so there it is a yes/no test.
-    const int atomic = qm_atomic_acc();
     int ncol_all = 0;
     for (int i = 0; i < ngroup; i++) ncol_all += N[i];
     if (atomic) {
@@ -1394,7 +1468,8 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
             const int planes = atomic ? 1 : splits;
             for (int i = 0; i < ngroup; i++) { d.poff[i] = off; off += planes * M * N[i]; }
             // Every group's plane is packed back to back from `partials`, so one memset covers them.
-            if (atomic) cudaMemsetAsync(partials, 0, (size_t)off * sizeof(int), stream);
+            const int zor = (atomic && pf_dense_zero_on_read()) ? 1 : 0;
+            if (atomic && !zor) cudaMemsetAsync(partials, 0, (size_t)off * sizeof(int), stream);
             dim3 grid(splits, tiles, mtiles);
             QM_LAUNCH_DENSE(true, true,
                     A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d, partials, sb_per_split, atomic,
@@ -1405,13 +1480,13 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
             if (atomic && out_fused && fuse_q && ngroup == 2 && N[0] == N[1] &&
                 kernels::launch_prefill_swiglu_quant_i8_acc(
                     partials + d.poff[0], partials + d.poff[1], sx, d.rs[0], d.rs[1],
-                    fuse_q, fuse_sx, M, N[0], stream, fuse_qp)) {
+                    fuse_q, fuse_sx, M, N[0], stream, fuse_qp, zor)) {
                 *out_fused = 1;
                 return true;
             }
             const size_t total = (size_t)M * (size_t)tiles * QM_BND;
             pf_dense_splitk_reduce_group_kernel<<<(unsigned)((total + 255) / 256), 256, 0, stream>>>(
-                partials, sx, d, M, tiles * QM_BND, atomic ? 1 : splits);
+                partials, sx, d, M, tiles * QM_BND, atomic ? 1 : splits, zor);
             return true;
         }
     }

--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -1258,6 +1258,7 @@ static int qm_wave_pick(int ntiles, int nsb, int want) {
         if (eff > best_eff + 1e-9 || (eff > best_eff - 1e-9 && s > best)) { best_eff = eff; best = s; }
     }
     return best;
+}
 
 // `partials_splits` is how many private [m][n] planes the caller budgeted, so it bounds the slice
 // count only while each slice stores its own plane. The atomic accumulator sums every slice into
@@ -1265,10 +1266,11 @@ static int qm_wave_pick(int ntiles, int nsb, int want) {
 // are the target block count and "at least one whole super-block per slice". Leaving the plane
 // budget in place capped the 104-tile o/down launches at 8 slices when the chooser asked for 25,
 // i.e. 832 blocks of a 510-block device: 1.6 waves, and the second one two-thirds empty.
-// SPARKINFER_MUSE_QB_UNCAP=0 restores the plane-budget cap (A/B in one binary).
+// PR #808's wave-fit chooser makes the extra depth neutral-to-slightly-negative on the complete
+// path, so retain it as an experiment rather than the default. SPARKINFER_MUSE_QB_UNCAP=1 enables.
 static int qm_uncap_splits() {
     static int e = -1;
-    if (e < 0) { const char* v = getenv("SPARKINFER_MUSE_QB_UNCAP"); e = (v && v[0] == '0') ? 0 : 1; }
+    if (e < 0) { const char* v = getenv("SPARKINFER_MUSE_QB_UNCAP"); e = (v && v[0] == '1') ? 1 : 0; }
     return e;
 }
 

--- a/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
+++ b/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
@@ -127,11 +127,11 @@ __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_reg_kernel(
 // before, and everything downstream of that is the unchanged register-resident path.
 template <int MAXV>
 __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_acc_kernel(
-        const int* __restrict__ acc_g, const int* __restrict__ acc_u,
+        int* __restrict__ acc_g, int* __restrict__ acc_u,
         const float* __restrict__ sxr, const float* __restrict__ rs_g,
         const float* __restrict__ rs_u,
         signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols,
-        signed char* __restrict__ qp) {
+        signed char* __restrict__ qp, int zero_after) {
     const int row = blockIdx.x;
     if (row >= rows) return;
     const size_t base = (size_t)row * cols;
@@ -169,6 +169,11 @@ __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_acc_kernel(
             const signed char v8 = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(hv[i] / d));
             q[base + c] = v8;
             if (qp) qp[sq_pack_off(row, c, rows)] = v8;
+            // Hand both accumulator planes back zeroed. This MUST live in the store loop, not in
+            // the load loop above: this kernel runs 128 blocks of 1024 threads (under one block per
+            // SM), so it depends entirely on its MAXV unrolled loads being in flight together, and
+            // interleaving stores there serialised them -- 13.8 -> 153.7 us/call, an 11x blowup.
+            if (zero_after) { acc_g[base + c] = 0; acc_u[base + c] = 0; }
         }
     }
 }
@@ -176,10 +181,10 @@ __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_acc_kernel(
 
 // Returns false when the row is too wide/narrow for the register-resident form, in which case the
 // caller must keep the reduce + separate SwiGLU.
-bool launch_prefill_swiglu_quant_i8_acc(const int* acc_g, const int* acc_u, const float* sxr,
+bool launch_prefill_swiglu_quant_i8_acc(int* acc_g, int* acc_u, const float* sxr,
                                         const float* rs_g, const float* rs_u,
                                         signed char* q, float* scale, int rows, int cols,
-                                        cudaStream_t stream, signed char* qp) {
+                                        cudaStream_t stream, signed char* qp, int zero_after) {
     if (qp && (cols % 32) != 0) qp = nullptr;
     static const bool on = [] {
         const char* e = getenv("SPARKINFER_MUSE_FFN_FUSE_ACC");
@@ -187,10 +192,10 @@ bool launch_prefill_swiglu_quant_i8_acc(const int* acc_g, const int* acc_u, cons
     }();
     const int nv = (cols + 1023) / 1024;
     if (!on || cols < 2048 || nv > 20) return false;
-    if (nv <= 8)       pf_swiglu_quant_i8_acc_kernel<8><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
-    else if (nv <= 12) pf_swiglu_quant_i8_acc_kernel<12><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
-    else if (nv <= 16) pf_swiglu_quant_i8_acc_kernel<16><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
-    else               pf_swiglu_quant_i8_acc_kernel<20><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
+    if (nv <= 8)       pf_swiglu_quant_i8_acc_kernel<8><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp, zero_after);
+    else if (nv <= 12) pf_swiglu_quant_i8_acc_kernel<12><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp, zero_after);
+    else if (nv <= 16) pf_swiglu_quant_i8_acc_kernel<16><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp, zero_after);
+    else               pf_swiglu_quant_i8_acc_kernel<20><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp, zero_after);
     return true;
 }
 

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -784,7 +784,11 @@ __global__ void norm_then_add_acc_kernel(const __nv_bfloat16* __restrict__ resid
                                          const float* __restrict__ rs,
                                          const __nv_bfloat16* __restrict__ weight,
                                          __nv_bfloat16* __restrict__ out,
-                                         int rows, int cols, float eps, int zero_after) {
+                                         int rows, int cols, float eps, int zero_after,
+                                         const __nv_bfloat16* __restrict__ next_weight,
+                                         __nv_bfloat16* __restrict__ out_norm,
+                                         signed char* __restrict__ q, float* __restrict__ qscale,
+                                         signed char* __restrict__ qp, float next_eps) {
     const int row = blockIdx.x;
     if (row >= rows) return;
     const size_t base = (size_t)row * cols;
@@ -852,6 +856,77 @@ __global__ void norm_then_add_acc_kernel(const __nv_bfloat16* __restrict__ resid
         out[base + c] = __float2bfloat16(__bfloat162float(residual[base + c])
                                          + bv * inv_rms * __bfloat162float(weight[c]));
         if (zero_after) acc[base + c] = 0;
+    }
+
+    if (!next_weight) return;
+    __syncthreads();
+
+    // The pre-FFN RMSNorm consumes exactly the bf16 values written above. Re-read them here to
+    // preserve that rounding boundary, then emit both its bf16 output and the row-major/k-tiled
+    // int8 forms used by the grouped gate/up GEMM.
+    const uint4* x4 = reinterpret_cast<const uint4*>(out + base);
+    float ss2 = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float xv[8]; rn_unpack8(x4[p], xv);
+#pragma unroll
+        for (int j = 0; j < 8; j++) ss2 = __fmaf_rn(xv[j], xv[j], ss2);
+    }
+    ss2 = rn_warp_sum(ss2);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss2;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + next_eps);
+    }
+    __syncthreads();
+    const float inv2 = s_warp[0];
+    const uint4* nw4 = reinterpret_cast<const uint4*>(next_weight);
+    uint4* on4 = reinterpret_cast<uint4*>(out_norm + base);
+    __nv_bfloat16 norm_keep[4][8];
+    float amax = 0.f;
+    held = 0;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
+        float xv[8]; rn_unpack8(x4[p], xv);
+        float wv[8]; rn_unpack8(nw4[p], wv);
+        float nv[8];
+#pragma unroll
+        for (int j = 0; j < 8; j++) nv[j] = xv[j] * inv2 * wv[j];
+        const uint4 packed = rn_pack8(nv);
+        on4[p] = packed;
+        *reinterpret_cast<uint4*>(norm_keep[held]) = packed;
+#pragma unroll
+        for (int j = 0; j < 8; j++)
+            amax = fmaxf(amax, fabsf(__bfloat162float(norm_keep[held][j])));
+    }
+#pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = amax;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+#pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (threadIdx.x == 0) s_warp[0] = v;
+    }
+    __syncthreads();
+    const float amax_row = s_warp[0];
+    const float d = amax_row / 127.0f;
+    if (threadIdx.x == 0) qscale[row] = d;
+    held = 0;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
+        signed char o8[8];
+#pragma unroll
+        for (int j = 0; j < 8; j++)
+            o8[j] = (signed char)((amax_row == 0.f) ? 0
+                                 : (int)roundf(__bfloat162float(norm_keep[held][j]) / d));
+        *reinterpret_cast<uint2*>(&q[base + p * 8]) = *reinterpret_cast<const uint2*>(o8);
+        if (qp) {
+            const int c = p * 8;
+            *reinterpret_cast<uint2*>(
+                &qp[(size_t)(c >> 5) * (size_t)rows * 32 + (size_t)row * 32 + (size_t)(c & 31)]) =
+                *reinterpret_cast<const uint2*>(o8);
+        }
     }
 }
 
@@ -974,7 +1049,25 @@ void launch_norm_then_add_acc(const void* residual, int* acc, const float* sxr,
     norm_then_add_acc_kernel<<<rows, 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(residual), acc, sxr, rs,
         reinterpret_cast<const __nv_bfloat16*>(weight),
-        reinterpret_cast<__nv_bfloat16*>(out), rows, cols, eps, zero_after);
+        reinterpret_cast<__nv_bfloat16*>(out), rows, cols, eps, zero_after,
+        nullptr, nullptr, nullptr, nullptr, nullptr, 0.f);
+}
+
+bool launch_norm_then_add_acc_quant(const void* residual, int* acc, const float* sxr,
+                                    const float* rs, const void* weight, void* out,
+                                    const void* next_weight, void* out_norm, signed char* q,
+                                    float* qscale, signed char* qp, int rows, int cols,
+                                    float eps, float next_eps, cudaStream_t stream,
+                                    int zero_after) {
+    if (rows <= 0 || cols <= 0 || (cols & 7) != 0 || ((cols >> 3) + 255) / 256 > 4)
+        return false;
+    if (qp && (cols % 32) != 0) qp = nullptr;
+    norm_then_add_acc_kernel<<<rows, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(residual), acc, sxr, rs,
+        reinterpret_cast<const __nv_bfloat16*>(weight), reinterpret_cast<__nv_bfloat16*>(out),
+        rows, cols, eps, zero_after, reinterpret_cast<const __nv_bfloat16*>(next_weight),
+        reinterpret_cast<__nv_bfloat16*>(out_norm), q, qscale, qp, next_eps);
+    return true;
 }
 
 void launch_norm_then_add(const void* residual, const void* block_out, const void* weight,

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -779,12 +779,12 @@ void launch_muse_sandwich_tail(const void* residual, const void* branch, const v
 // norm_then_add_kernel, so the fp32 reduction tree is unchanged. (Re-associating it is what sank
 // an earlier attempt at fusing these norms.)
 __global__ void norm_then_add_acc_kernel(const __nv_bfloat16* __restrict__ residual,
-                                         const int* __restrict__ acc,
+                                         int* __restrict__ acc,
                                          const float* __restrict__ sxr,
                                          const float* __restrict__ rs,
                                          const __nv_bfloat16* __restrict__ weight,
                                          __nv_bfloat16* __restrict__ out,
-                                         int rows, int cols, float eps) {
+                                         int rows, int cols, float eps, int zero_after) {
     const int row = blockIdx.x;
     if (row >= rows) return;
     const size_t base = (size_t)row * cols;
@@ -842,11 +842,16 @@ __global__ void norm_then_add_acc_kernel(const __nv_bfloat16* __restrict__ resid
         #pragma unroll
         for (int j = 0; j < 8; j++) ov[j] = rv[j] + bv[j] * inv_rms * wv[j];
         o4[p] = rn_pack8(ov);
+        if (zero_after) {
+#pragma unroll
+            for (int j = 0; j < 8; j++) acc[base + p * 8 + j] = 0;
+        }
     }
     for (int c = tail + threadIdx.x; c < cols; c += blockDim.x) {
         const float bv = __bfloat162float(__float2bfloat16((float)acc[base + c] * sr * rs[c]));
         out[base + c] = __float2bfloat16(__bfloat162float(residual[base + c])
                                          + bv * inv_rms * __bfloat162float(weight[c]));
+        if (zero_after) acc[base + c] = 0;
     }
 }
 
@@ -963,13 +968,13 @@ bool launch_rmsnorm_quant_i8(const void* x, const void* weight, void* out,
     return true;
 }
 
-void launch_norm_then_add_acc(const void* residual, const int* acc, const float* sxr,
+void launch_norm_then_add_acc(const void* residual, int* acc, const float* sxr,
                               const float* rs, const void* weight, void* out,
-                              int rows, int cols, float eps, cudaStream_t stream) {
+                              int rows, int cols, float eps, cudaStream_t stream, int zero_after) {
     norm_then_add_acc_kernel<<<rows, 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(residual), acc, sxr, rs,
         reinterpret_cast<const __nv_bfloat16*>(weight),
-        reinterpret_cast<__nv_bfloat16*>(out), rows, cols, eps);
+        reinterpret_cast<__nv_bfloat16*>(out), rows, cols, eps, zero_after);
 }
 
 void launch_norm_then_add(const void* residual, const void* block_out, const void* weight,

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -44,6 +44,12 @@ void launch_norm_then_add_acc(const void* residual_bf16, int* acc, const float* 
                               const float* row_scale, const void* weight_bf16, void* out_bf16,
                               int rows, int cols, float eps, cudaStream_t stream,
                               int zero_after = 0);
+bool launch_norm_then_add_acc_quant(const void* residual_bf16, int* acc, const float* sxr,
+                                    const float* row_scale, const void* weight_bf16, void* out_bf16,
+                                    const void* next_weight_bf16, void* out_norm_bf16,
+                                    signed char* q, float* qscale, signed char* qp,
+                                    int rows, int cols, float eps, float next_eps,
+                                    cudaStream_t stream, int zero_after = 0);
 
 void launch_norm_then_add(const void* residual_bf16, const void* block_out_bf16,
                           const void* weight_bf16, void* out_bf16,

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -40,9 +40,10 @@ bool launch_rmsnorm_quant_i8(const void* x, const void* weight, void* out,
                              signed char* qp = nullptr);
 
 // Sandwich norm fed from the split-K int32 accumulator (skips the reduce + the bf16 round trip).
-void launch_norm_then_add_acc(const void* residual_bf16, const int* acc, const float* sxr,
+void launch_norm_then_add_acc(const void* residual_bf16, int* acc, const float* sxr,
                               const float* row_scale, const void* weight_bf16, void* out_bf16,
-                              int rows, int cols, float eps, cudaStream_t stream);
+                              int rows, int cols, float eps, cudaStream_t stream,
+                              int zero_after = 0);
 
 void launch_norm_then_add(const void* residual_bf16, const void* block_out_bf16,
                           const void* weight_bf16, void* out_bf16,

--- a/kernels/include/sparkinfer/kernels/prefill_fp8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_fp8.h
@@ -36,10 +36,11 @@ void launch_prefill_gemm_fp8(const void* A, const void* W,
 // SwiGLU + per-row int8 quantize fed directly from the grouped GEMM's split-K int32 accumulator,
 // skipping the reduce pass that would otherwise materialize gate/up as bf16 first. Returns false if
 // the shape is not eligible (caller keeps reduce + launch_prefill_swiglu_quant_i8).
-bool launch_prefill_swiglu_quant_i8_acc(const int* acc_g, const int* acc_u, const float* sxr,
+bool launch_prefill_swiglu_quant_i8_acc(int* acc_g, int* acc_u, const float* sxr,
                                         const float* rs_g, const float* rs_u,
                                         signed char* q, float* scale, int rows, int cols,
-                                        cudaStream_t stream, signed char* qp = nullptr);
+                                        cudaStream_t stream, signed char* qp = nullptr,
+                                        int zero_after = 0);
 
 // Returns false only when `qp` was requested but the path that ran cannot write it.
 bool launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -61,6 +61,10 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
                                    // row-major addressing. Output is bit-identical either way.
                                    const signed char* A_pack = nullptr);
 
+// True when the split-K consumers hand their accumulator plane back zeroed, so the caller must
+// zero the buffer once at allocation instead of the launcher zeroing it before every launch.
+bool pf_dense_zero_on_read();
+
 // Fuse up to 4 projections sharing A_i8/sx (same M, same K) into ONE grid. At prefill's M=128 a
 // projection's grid is ceil(N/64) CTAs -- 64 for a 4096-wide q/gate but only 4 for a 256-wide
 // k/v -- all far under a 5090's 170 SMs, so every launch costs a full CTA-duration regardless of

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -334,6 +334,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
     int* qb_partials = (c.muse_glimmer && use_i8 && N <= 128)
         ? a8.alloc<int>(qb_partials_cap) : nullptr;
+    // With zero-on-read the consumers return each plane zeroed, so the only fill needed is this one
+    // -- it covers the first use of every region; from then on the buffer is self-maintaining.
+    // 82 MB once per prefill instead of 2.07 GB spread over 234 pre-launch memsets.
+    if (qb_partials && kernels::pf_dense_zero_on_read())
+        cudaMemsetAsync(qb_partials, 0, qb_partials_cap * sizeof(int), st);
     // Muse Glimmer split-K partials for the skinny projections. launch_prefill_gemm_i8 puts one
     // 128x128 output tile in a block, so Muse's narrow n_out (attn k/v = 256 -> TWO blocks, q and
     // the q-gate = 4096 -> 32) leaves the device almost empty: measured on an RTX 5090 the 2-block

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -314,6 +314,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         return !(e && e[0] == '0');
     }();
     signed char* A_i8p = muse_apack ? a8.alloc<signed char>(a_i8_sz) : nullptr;
+    signed char* xn_i8 = (c.muse_glimmer && need_i8) ? a8.alloc<signed char>((size_t)N * H) : nullptr;
+    signed char* xn_i8p = (muse_apack && xn_i8) ? a8.alloc<signed char>((size_t)N * H) : nullptr;
+    float* xn_sx = xn_i8 ? a8.alloc<float>((size_t)N) : nullptr;
+    bool xn_quantized = false;
+    signed char* lm_q8 = a8.alloc<signed char>((size_t)H + 32);
+    float* lm_ad = a8.alloc<float>((size_t)(H >> 5) + 1);
+    float* lm_as = a8.alloc<float>((size_t)(H >> 5) + 1);
     signed char* W_i8 = need_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = need_i8 ? a8.alloc<float>(sx_n) : nullptr;
     float* sw = need_i8 ? a8.alloc<float>((size_t)maxNO) : nullptr;
@@ -357,6 +364,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     if (need_i8 && !a8.ok) {
         a8.free_all();
         A_i8p = nullptr;
+        xn_i8 = xn_i8p = nullptr;
+        xn_sx = nullptr;
         use_i8 = false;
         use_i8_ffn = false;
         use_i8_attn = false;
@@ -742,7 +751,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // emb_norm_ones is a constant-1.0 weight, so this is a pure normalization of the embedding.
     if (c.muse_glimmer && s.emb_norm_ones)
         kernels::launch_rmsnorm(x, (const bf16*)s.emb_norm_ones, x, N, H, eps, st);
-    kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, eps, st);
+    xn_quantized = c.muse_glimmer && xn_i8 && xn_sx &&
+        kernels::launch_rmsnorm_quant_i8(x, s.w.layers[0].input_norm, xn, xn_i8, xn_sx,
+                                         N, H, eps, st, xn_i8p);
+    if (!xn_quantized)
+        kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, eps, st);
 
     // MoE aux events: overlap path and/or tiny shared-gate hide on stream_k.
     cudaEvent_t moe_ev_up{}, moe_ev_down0{}, moe_ev_ready{}, moe_ev_sg{};
@@ -818,11 +831,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 }
                 bool grouped = false;
                 if (ng >= 2) {
-                    quant_a_i8(xn, N, H);
+                    const signed char* group_a = A_i8;
+                    const float* group_sx = sx;
+                    const signed char* group_pack = nullptr;
+                    if (xn_quantized) {
+                        group_a = xn_i8;
+                        group_sx = xn_sx;
+                        group_pack = xn_i8p;
+                    } else {
+                        quant_a_i8(xn, N, H);
+                        group_pack = apk();
+                    }
                     grouped = kernels::launch_prefill_gemm_qi8_dense_group(
-                        w.wq_type, A_i8, sx, Wa, rsa, Ca, na, ng, N, H, st,
+                        w.wq_type, group_a, group_sx, Wa, rsa, Ca, na, ng, N, H, st,
                         qb_partials, QB_SPLITS, qb_partials_cap,
-                        nullptr, nullptr, nullptr, apk());
+                        nullptr, nullptr, nullptr, group_pack);
                 }
                 if (!grouped) { inq = ing = ink = inv = false; }
                 if (!inq) proj_fused(xn, w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  H);
@@ -898,7 +921,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // attn_norm/ffn_norm/q_norm/k_norm -- mirrors the decode fix (qwen35.cpp:6d911d4).
             if (attn_acc)
                 kernels::launch_norm_then_add_acc(x, qb_partials, sx, w.wo_rs, w.post_attn_norm,
-                                                  h, N, H, 1e-8f, st);
+                                                  h, N, H, 1e-8f, st,
+                                                  kernels::pf_dense_zero_on_read());
             else
                 kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
             // hn's only consumer is the grouped FFN's row-quantize, so emit the int8 in the same
@@ -1049,7 +1073,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // Same 1e-8 post_norm_eps as the post-attn sandwich norm above.
                 if (ffn_acc)
                     kernels::launch_norm_then_add_acc(h, qb_partials, sx, w.down_rs,
-                                                      w.post_ffn_norm, x, N, H, 1e-8f, st);
+                                                      w.post_ffn_norm, x, N, H, 1e-8f, st,
+                                                      kernels::pf_dense_zero_on_read());
                 else
                     kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
             } else if (!ffn_fused) {
@@ -1545,7 +1570,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         }
 
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        xn_quantized = c.muse_glimmer && xn_i8 && xn_sx &&
+            kernels::launch_rmsnorm_quant_i8(x, next_norm, xn, xn_i8, xn_sx,
+                                             N, H, eps, st, xn_i8p);
+        if (!xn_quantized)
+            kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
     }
 
     if (moe_overlap) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -334,11 +334,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // 13 is the peak, and raising QM_TARGET_BLOCKS with it only adds atomic traffic (swept too).
     constexpr int QB_SPLITS = 13;
     const size_t qb_partials_cap = (size_t)QB_SPLITS * (size_t)N * (size_t)maxNO;
-    // LM-head activation, quantized once (see the seed argmax at the end of this function).
-    signed char* lm_q8 = a8.alloc<signed char>((size_t)H + 32);
-    float* lm_ad = a8.alloc<float>((size_t)(H >> 5) + 1);
-    float* lm_as = a8.alloc<float>((size_t)(H >> 5) + 1);
-
     int* qb_partials = (c.muse_glimmer && use_i8 && N <= 128)
         ? a8.alloc<int>(qb_partials_cap) : nullptr;
     // With zero-on-read the consumers return each plane zeroed, so the only fill needed is this one
@@ -919,16 +914,26 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // Sandwich (post_attn_norm/post_ffn_norm) RMSNorm uses its OWN eps 1e-8
             // (upstream post_norm_eps), NOT the model's rms_eps (1e-5) which drives
             // attn_norm/ffn_norm/q_norm/k_norm -- mirrors the decode fix (qwen35.cpp:6d911d4).
-            if (attn_acc)
+            bool fused_pre_ffn = false;
+            if (attn_acc && muse_ffn_group && muse_qb && use_i8 && FC >= N) {
+                fused_pre_ffn = kernels::launch_norm_then_add_acc_quant(
+                    x, qb_partials, sx, w.wo_rs, w.post_attn_norm, h, w.ffn_norm, hn,
+                    A_i8, sx, A_i8p, N, H, 1e-8f, eps, st,
+                    kernels::pf_dense_zero_on_read());
+            } else if (attn_acc) {
                 kernels::launch_norm_then_add_acc(x, qb_partials, sx, w.wo_rs, w.post_attn_norm,
                                                   h, N, H, 1e-8f, st,
                                                   kernels::pf_dense_zero_on_read());
-            else
+            } else {
                 kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
+            }
             // hn's only consumer is the grouped FFN's row-quantize, so emit the int8 in the same
             // pass. Only when one chunk covers the prompt: a second chunk would need A_i8/sx again
             // after the first has overwritten them. The bf16 hn is still written either way.
-            if (muse_ffn_group && muse_qb && use_i8 && FC >= N &&
+            if (fused_pre_ffn) {
+                hn_quantized = true;
+                a_pk = A_i8p != nullptr;
+            } else if (muse_ffn_group && muse_qb && use_i8 && FC >= N &&
                 kernels::launch_rmsnorm_quant_i8(h, w.ffn_norm, hn, A_i8, sx, N, H, eps, st,
                                                  A_i8p)) {
                 hn_quantized = true;


### PR DESCRIPTION
## Summary

Two things in the Muse Glimmer prefill's split-K path, both bit-identical.

**The K-slice count was bounded by a buffer that no longer bounds it.** `qm_pick_splits` clamps the
slice count to `partials_splits`, the number of private `[m][n]` planes the caller budgeted. That
was the right limit while each slice stored its own plane. The atomic accumulator sums every slice
into one plane, so under it the plane budget says nothing about how finely K may be cut — yet the
clamp still applied, and the 104-tile `o`/`down` launches got 8 slices where the chooser asked for
25: 832 blocks of a ~510-block device, 1.6 waves with the second two-thirds empty.

Extra slices are only worth taking while each still owns real K. Measured at `M=128`: `ffn_down`
(`nsb=78`) goes 8 → 16 slices at 4+ super-blocks each and its launch drops 3.8%, while cutting
`q/gate/k/v` (`nsb=26`) to 2 super-blocks a slice *costs* 0.6%. So the new count is
`max(what the budget already gave, target bounded by the work floor)` — a launch can only gain
slices, never lose them. `q/gate/k/v`, `o` and the FFN pair keep the grids they had.

**The accumulator was zero-filled by a memset before every split launch** — 2.07 GB per prefill,
and 234 kernels sitting on the stream between each GEMM and the consumer that reads its result.
Every element the GEMM writes is read exactly once, by the reduce or by the fused SwiGLU, so the
consumer hands the plane back zeroed instead and stream ordering supplies the barrier: atomics →
read-and-zero → next layer's atomics land in an already-zero plane. One memset when the buffer is
allocated covers first use.

Placement matters in the SwiGLU consumer: it runs 128 blocks of 1024 threads, under one block per
SM, so it depends on its unrolled loads being in flight together. The zero stores go in the loop
that already stores; interleaving them into the load loop serialized it (13.8 → 153.7 us/call).

`SPARKINFER_MUSE_QB_UNCAP=0` and `SPARKINFER_MUSE_QB_ZOR=0` restore the previous behaviour
independently, so both halves A/B in one binary.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx=0 — this PR does not touch the decode path; interleaved arms,
median of 5):

| | decode tok/s |
|---|--:|
| before (main) | 104.14 |
| after (this PR) | 104.13 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 3380.42 |
| after prefill (this PR) | 3564.09 |

**+5.43% prefill@128**, measured at parent `9e523df` (the rebase onto current main changes only
sampling/server code, nothing on the prefill path). Arms interleaved round-robin in one binary,
five reps inside each process, clocks locked at 2550 MHz. A third arm identical to the baseline bounds the noise at **-0.10%**,
and the two distributions do not overlap:

```text
  round 1:  A=3391.65   B=3573.35   A'=3386.07
  round 2:  A=3390.34   B=3579.86   A'=3362.75
  round 3:  A=3372.39   B=3553.07   A'=3376.84
  round 4:  A=3386.12   B=3554.86   A'=3363.30
  round 5:  A=3362.74   B=3582.95   A'=3395.49
  round 6:  A=3370.76   B=3564.09   A'=3377.04
  round 7:  A=3380.42   B=3558.04   A'=3383.03

  A  median 3380.42   B median 3564.09   A' median 3377.04
  B vs A  = +5.43%  (7/7 rounds)      A' vs A = -0.10%  (noise floor)
```

Per-launch, from the same nsys window:

```text
  ungrouped GEMM (o + ffn_down)   9.750 -> 9.379 ms    grid 8x104 -> 16x104
  grouped GEMM (qgkv + ffn pair) 17.398 -> 17.345 ms   grid unchanged
  [CUDA memset] x234              0.722 ms -> gone
```

### Correctness

Both halves are exact: int32 slice sums are associative, and the zeroing only restores a plane the
next launch would have received from a memset. Checked rather than argued — every toggle
combination must agree to the digit (`SPARKINFER_KV_INT8=0 qwen3_gguf_prefill_check`, 64
teacher-forced positions):

```text
  [neither      ] prefix=128  59/64 0.9219  KL 0.02816
  [uncap only   ] prefix=128  59/64 0.9219  KL 0.02816
  [zero-on-read ] prefix=128  59/64 0.9219  KL 0.02816
  [both         ] prefix=128  59/64 0.9219  KL 0.02816
  [both         ] prefix=512  57/64 0.8906  KL 0.01074

ctest: 100% tests passed, 12/12
```

### Scope

Reachable only from Muse Glimmer's batched prefill (`c.muse_glimmer`), and only while the prompt is
a single M-tile. The routed-MoE kernels in the same file are untouched.

### Qwen3.6 no-regression

`prefill_moe_q.cu` is shared with the routed-MoE prefill, so the cross-model guard was run rather
than argued — the eval's own sweep (`ctx 0/512/4k/16k/32k`, median-of-5), two arms each built and
run in place:

```text
  ctx        decode A -> B            prefill A -> B
       0     475.06 ->   473.44
     512     466.88 ->   465.90     8330.89 ->   8340.60
    4096     447.29 ->   446.44    22896.54 ->  22863.49
   16384     448.80 ->   447.72    24850.36 ->  24830.30
   32768     449.01 ->   448.18    26194.07 ->  26183.78
```

Max deviation 0.34%, i.e. run-to-run noise.
