### PR TITLE
perf(muse-glimmer): k-tiled activation copy for the dense prefill GEMM (1.07x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
@@ -304,13 +304,15 @@ bool launch_prefill_gemm_i8_splitk(const signed char* A, const signed char* W,
     return true;
 }
 
-void launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
-                                     int rows, int cols, cudaStream_t stream) {
+bool launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
+                                     int rows, int cols, cudaStream_t stream, signed char* qp) {
     // Block-parallel single-pass path (one block per row, row held in registers; bit-identical).
     // SPARKINFER_PREFILL_QUANT_ROWS=0 restores the warp-per-row kernel below.
-    if (launch_prefill_quant_rows_fast(x_bf16, q, scale, rows, cols, stream)) return;
+    if (launch_prefill_quant_rows_fast(x_bf16, q, scale, rows, cols, stream, qp)) return true;
     pf_quantize_rows_i8<<<rows, 32, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x_bf16), q, scale, rows, cols);
+    // The warp-per-row fallback has no k-tiled output, so tell the caller its packed copy is stale.
+    return qp == nullptr;
 }
 
 void launch_prefill_gemm_i8(const signed char* A, const signed char* W,

--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -813,7 +813,8 @@ __global__ __launch_bounds__(256, 2) void pf_dense_gemm_qi8_kernel_g(
         const signed char* __restrict__ A_i8, const float* __restrict__ sx,
         const unsigned char* __restrict__ W_q_arg, const float* __restrict__ row_scale_arg,
         __nv_bfloat16* __restrict__ C_arg, int Mtot, int N_arg, int K, PfQGroup gd,
-        int* __restrict__ partials = nullptr, int sb_per_split = 0, int atomic_acc = 0) {
+        int* __restrict__ partials = nullptr, int sb_per_split = 0, int atomic_acc = 0,
+        const signed char* __restrict__ A_pack = nullptr) {
     using namespace nvcuda;
     constexpr int BS = qm_bs<QT>();
     // Split-K takes blockIdx.x for the K slice and shifts the tile/M indices up one dimension.
@@ -891,7 +892,19 @@ __global__ __launch_bounds__(256, 2) void pf_dense_gemm_qi8_kernel_g(
     const int a_r   = tid >> 1;
     const int a_c16 = (tid & 1) * 16;
     const int a_row = (a_r < M) ? (p0 + a_r) : -1;
-    const signed char* const a_src0 = A_i8 + (size_t)max(a_row, 0) * K + a_c16;
+    // A tile source. In the row-major activation the 128 chunks one stage wants are K bytes apart,
+    // so a warp's 16 rows issue 16 sector requests for 512 B. `A_pack` is the same int8 bytes in
+    // the k-tiled [k/32][row][32] layout the quantizer also emits (qr_pack_off, prefill_quant_rows.cu):
+    // there a stage is one contiguous 4 KB block, i.e. 4 line requests for the same 512 B per warp.
+    // Nothing else changes -- same cp.async count, same bytes, same destination -- so the int8 the
+    // MMA consumes is bit-identical and A_pack == nullptr keeps the original addressing.
+    const bool apk = A_pack != nullptr;
+    const signed char* const a_src0 =
+        apk ? (A_pack + (size_t)p0 * 32 + (size_t)tid * 16)
+            : (A_i8 + (size_t)max(a_row, 0) * K + a_c16);
+    // Bytes between consecutive QM_BK-wide stages. Both layouts advance by a constant, so the K
+    // loop carries a running pointer and one add either way.
+    const size_t a_step = apk ? (size_t)Mtot * 32 : (size_t)QM_BK;
     // XOR swizzle on the 16 B chunk index. As rows are QM_BK = 32 B apart, so the eight rows one
     // ldmatrix phase gathers land on only 16 of the 32 banks and every A-side phase pays a 2-way
     // conflict. Flipping the chunk order on rows whose bit 2 is set spreads those eight rows over
@@ -944,7 +957,9 @@ __global__ __launch_bounds__(256, 2) void pf_dense_gemm_qi8_kernel_g(
     const int sb_hi = SPLIT ? min(nsb, sb_lo + sb_per_split) : nsb;
     if (sb_lo >= sb_hi) return;
     const int kend = sb_hi << 8;          // first K past this block's slice
-    stageA(0, a_src0 + (sb_lo << 8));
+    const signed char* a_ptr = a_src0 + (apk ? (size_t)(sb_lo << 3) * (size_t)Mtot * 32
+                                             : (size_t)(sb_lo << 8));
+    stageA(0, a_ptr);
     int abuf = 0, bbuf = 0;
 
     // Zero-fill only ever applies to a tile past N, and those rows never change, so both planes
@@ -978,7 +993,7 @@ __global__ __launch_bounds__(256, 2) void pf_dense_gemm_qi8_kernel_g(
 
         for (int kk = 0; kk < QM_SB; kk += QM_BK) {
             const int knext = sb * QM_SB + kk + QM_BK;
-            if (knext < kend) stageA(abuf ^ 1, a_src0 + knext);
+            if (knext < kend) { a_ptr += a_step; stageA(abuf ^ 1, a_ptr); }
             __pipeline_wait_prior(knext < kend ? 1 : 0);
             __syncthreads();
             if constexpr (K32) {
@@ -1227,7 +1242,8 @@ static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int
 bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const float* sx,
                                    const void* W_q, const float* row_scale, void* C_bf16,
                                    int M, int N, int K, cudaStream_t stream,
-                                   int* partials, int partials_splits, int* out_acc) {
+                                   int* partials, int partials_splits, int* out_acc,
+                                   const signed char* A_pack) {
     if (!pf_dense_gemm_qi8_supported(ggml_type)) return false;   // Q4_K / Q5_K / Q6_K
     if (!row_scale || M <= 0) return false;
     if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;         // whole super-blocks only
@@ -1257,7 +1273,8 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
             if (atomic) cudaMemsetAsync(partials, 0, total * sizeof(int), stream);
             dim3 grid(splits, ntiles, mtiles);
             QM_LAUNCH_DENSE(false, true,
-                    A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{}, partials, sb_per_split, atomic);
+                    A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{}, partials, sb_per_split, atomic,
+                    A_pack);
             // With the atomic accumulator every slice has already been summed, so the reduce pass
             // reads the single plane (splits=1 indexes exactly the [m][n] the atomics wrote).
             if (atomic && out_acc) { *out_acc = 1; return true; }   // consumer reads the int32
@@ -1267,7 +1284,8 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
         }
     }
     dim3 grid(ntiles, mtiles);
-    QM_LAUNCH_DENSE(false, false, A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{});
+    QM_LAUNCH_DENSE(false, false, A_i8, sx, W, row_scale, C, M, N, K, PfQGroup{}, nullptr, 0, 0,
+                    A_pack);
     return true;
 }
 
@@ -1279,7 +1297,8 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
                                          void* const* C_bf16, const int* N, int ngroup,
                                          int M, int K, cudaStream_t stream,
                                          int* partials, int partials_splits, size_t partials_cap,
-                                         signed char* fuse_q, float* fuse_sx, int* out_fused) {
+                                         signed char* fuse_q, float* fuse_sx, int* out_fused,
+                                         const signed char* A_pack, signed char* fuse_qp) {
     if (!pf_dense_gemm_qi8_supported(ggml_type)) return false;
     if (ngroup <= 0 || ngroup > PF_QGROUP_MAX || M <= 0) return false;
     if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;
@@ -1331,14 +1350,15 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
             if (atomic) cudaMemsetAsync(partials, 0, (size_t)off * sizeof(int), stream);
             dim3 grid(splits, tiles, mtiles);
             QM_LAUNCH_DENSE(true, true,
-                    A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d, partials, sb_per_split, atomic);
+                    A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d, partials, sb_per_split, atomic,
+                    A_pack);
             // The FFN's gate/up pair is consumed by nothing except the SwiGLU + int8 quantize that
             // follows it, so when the caller asks for that, apply the scale inside it and never
             // materialize gate/up as bf16 at all: 20.4 MB of DRAM and one launch per layer gone.
             if (atomic && out_fused && fuse_q && ngroup == 2 && N[0] == N[1] &&
                 kernels::launch_prefill_swiglu_quant_i8_acc(
                     partials + d.poff[0], partials + d.poff[1], sx, d.rs[0], d.rs[1],
-                    fuse_q, fuse_sx, M, N[0], stream)) {
+                    fuse_q, fuse_sx, M, N[0], stream, fuse_qp)) {
                 *out_fused = 1;
                 return true;
             }
@@ -1349,7 +1369,8 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
         }
     }
     dim3 grid(tiles, mtiles);
-    QM_LAUNCH_DENSE(true, false, A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d);
+    QM_LAUNCH_DENSE(true, false, A_i8, sx, nullptr, nullptr, nullptr, M, 0, K, d, nullptr, 0, 0,
+                    A_pack);
     return true;
 }
 

--- a/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
+++ b/kernels/csrc/cuda/fused/prefill_swiglu_quant.cu
@@ -66,10 +66,17 @@ __global__ void pf_swiglu_quant_i8_kernel(const __nv_bfloat16* __restrict__ gate
 // (exact and associative, so the changed thread->value map cannot move the max), same
 // `s_warp[0] == 0.f` guard and the same `h / d` -- NOT h * (1/d), which differs in the last ulp.
 // The static trip count is what keeps hv[] in registers; a `c += blockDim.x` loop would spill it.
+// See qr_pack_off in prefill_quant_rows.cu: the k-tiled [k/32][row][32] copy the Muse dense prefill
+// GEMM stages its A tile from. Written alongside the row-major output, never instead of it.
+__device__ __forceinline__ size_t sq_pack_off(int r, int c, int rows) {
+    return (size_t)(c >> 5) * (size_t)rows * 32 + (size_t)r * 32 + (size_t)(c & 31);
+}
+
 template <int MAXV>
 __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_reg_kernel(
         const __nv_bfloat16* __restrict__ gate, const __nv_bfloat16* __restrict__ up,
-        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols) {
+        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols,
+        signed char* __restrict__ qp) {
     const int row = blockIdx.x;
     if (row >= rows) return;
     const size_t base = (size_t)row * cols;
@@ -101,8 +108,11 @@ __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_reg_kernel(
     #pragma unroll
     for (int i = 0; i < MAXV; i++) {
         const int c = threadIdx.x + i * 1024;
-        if (c < cols)
-            q[base + c] = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(hv[i] / d));
+        if (c < cols) {
+            const signed char v8 = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(hv[i] / d));
+            q[base + c] = v8;
+            if (qp) qp[sq_pack_off(row, c, rows)] = v8;
+        }
     }
 }
 
@@ -120,7 +130,8 @@ __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_acc_kernel(
         const int* __restrict__ acc_g, const int* __restrict__ acc_u,
         const float* __restrict__ sxr, const float* __restrict__ rs_g,
         const float* __restrict__ rs_u,
-        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols) {
+        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols,
+        signed char* __restrict__ qp) {
     const int row = blockIdx.x;
     if (row >= rows) return;
     const size_t base = (size_t)row * cols;
@@ -154,8 +165,11 @@ __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_acc_kernel(
     #pragma unroll
     for (int i = 0; i < MAXV; i++) {
         const int c = threadIdx.x + i * 1024;
-        if (c < cols)
-            q[base + c] = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(hv[i] / d));
+        if (c < cols) {
+            const signed char v8 = (signed char)((s_warp[0] == 0.f) ? 0 : (int)roundf(hv[i] / d));
+            q[base + c] = v8;
+            if (qp) qp[sq_pack_off(row, c, rows)] = v8;
+        }
     }
 }
 } // namespace
@@ -165,22 +179,24 @@ __global__ __launch_bounds__(1024) void pf_swiglu_quant_i8_acc_kernel(
 bool launch_prefill_swiglu_quant_i8_acc(const int* acc_g, const int* acc_u, const float* sxr,
                                         const float* rs_g, const float* rs_u,
                                         signed char* q, float* scale, int rows, int cols,
-                                        cudaStream_t stream) {
+                                        cudaStream_t stream, signed char* qp) {
+    if (qp && (cols % 32) != 0) qp = nullptr;
     static const bool on = [] {
         const char* e = getenv("SPARKINFER_MUSE_FFN_FUSE_ACC");
         return !(e && e[0] == '0');
     }();
     const int nv = (cols + 1023) / 1024;
     if (!on || cols < 2048 || nv > 20) return false;
-    if (nv <= 8)       pf_swiglu_quant_i8_acc_kernel<8><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols);
-    else if (nv <= 12) pf_swiglu_quant_i8_acc_kernel<12><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols);
-    else if (nv <= 16) pf_swiglu_quant_i8_acc_kernel<16><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols);
-    else               pf_swiglu_quant_i8_acc_kernel<20><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols);
+    if (nv <= 8)       pf_swiglu_quant_i8_acc_kernel<8><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
+    else if (nv <= 12) pf_swiglu_quant_i8_acc_kernel<12><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
+    else if (nv <= 16) pf_swiglu_quant_i8_acc_kernel<16><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
+    else               pf_swiglu_quant_i8_acc_kernel<20><<<rows, 1024, 0, stream>>>(acc_g, acc_u, sxr, rs_g, rs_u, q, scale, rows, cols, qp);
     return true;
 }
 
-void launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
-                                    int rows, int cols, cudaStream_t stream) {
+bool launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
+                                    int rows, int cols, cudaStream_t stream, signed char* qp) {
+    if (qp && (cols % 32) != 0) qp = nullptr;
     // Narrow rows (the MoE per-expert ffn) do not fill a 1024-wide block, and rows wider than
     // 20*1024 exceed the register budget; both keep the strided kernel.
     // SPARKINFER_PREFILL_SWIGLU_REG=0 restores it everywhere (A/B).
@@ -192,15 +208,17 @@ void launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed cha
     if (reg_ok && cols >= 2048 && nv <= 20) {
         auto* g = reinterpret_cast<const __nv_bfloat16*>(gate);
         auto* u = reinterpret_cast<const __nv_bfloat16*>(up);
-        if (nv <= 8)       pf_swiglu_quant_i8_reg_kernel<8><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
-        else if (nv <= 12) pf_swiglu_quant_i8_reg_kernel<12><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
-        else if (nv <= 16) pf_swiglu_quant_i8_reg_kernel<16><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
-        else               pf_swiglu_quant_i8_reg_kernel<20><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols);
-        return;
+        if (nv <= 8)       pf_swiglu_quant_i8_reg_kernel<8><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols, qp);
+        else if (nv <= 12) pf_swiglu_quant_i8_reg_kernel<12><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols, qp);
+        else if (nv <= 16) pf_swiglu_quant_i8_reg_kernel<16><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols, qp);
+        else               pf_swiglu_quant_i8_reg_kernel<20><<<rows, 1024, 0, stream>>>(g, u, q, scale, rows, cols, qp);
+        return true;
     }
     pf_swiglu_quant_i8_kernel<<<rows, 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
         q, scale, rows, cols);
+    // The strided fallback has no k-tiled output: report the caller's packed copy as stale.
+    return qp == nullptr;
 }
 
 }} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -853,7 +853,7 @@ template <int MAXP>
 __global__ __launch_bounds__(256) void rmsnorm_quant_i8_kernel(
         const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ weight,
         __nv_bfloat16* __restrict__ out, signed char* __restrict__ q, float* __restrict__ scale,
-        int rows, int cols, float eps) {
+        int rows, int cols, float eps, signed char* __restrict__ qp) {
     const int row = blockIdx.x;
     if (row >= rows) return;
     const size_t base = (size_t)row * cols;
@@ -920,12 +920,23 @@ __global__ __launch_bounds__(256) void rmsnorm_quant_i8_kernel(
             o8[j] = (signed char)((amax_row == 0.f) ? 0
                                  : (int)roundf(__bfloat162float(reg[held][j]) / d));
         *reinterpret_cast<uint2*>(&q[base + p * 8]) = *reinterpret_cast<const uint2*>(o8);
+        // Same bytes in the k-tiled [k/32][row][32] layout the dense prefill GEMM stages from
+        // (qr_pack_off, prefill_quant_rows.cu). This kernel is the pre-FFN norm's fused quantize,
+        // so it is one of the writers of that activation and has to emit both.
+        if (qp) {
+            const int c = p * 8;
+            *reinterpret_cast<uint2*>(
+                &qp[(size_t)(c >> 5) * (size_t)rows * 32 + (size_t)row * 32 + (size_t)(c & 31)]) =
+                *reinterpret_cast<const uint2*>(o8);
+        }
     }
 }
 
 bool launch_rmsnorm_quant_i8(const void* x, const void* weight, void* out,
                              signed char* q, float* scale,
-                             int rows, int cols, float eps, cudaStream_t stream) {
+                             int rows, int cols, float eps, cudaStream_t stream,
+                             signed char* qp) {
+    if (qp && (cols % 32) != 0) qp = nullptr;
     static const int enabled = [] {
         const char* e = getenv("SPARKINFER_PREFILL_NORM_QUANT");
         return (e && e[0] == '0') ? 0 : 1;
@@ -936,9 +947,9 @@ bool launch_rmsnorm_quant_i8(const void* x, const void* weight, void* out,
     auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
     auto wb = reinterpret_cast<const __nv_bfloat16*>(weight);
     auto ob = reinterpret_cast<__nv_bfloat16*>(out);
-    if (per <= 1)      rmsnorm_quant_i8_kernel<1><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps);
-    else if (per <= 2) rmsnorm_quant_i8_kernel<2><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps);
-    else if (per <= 4) rmsnorm_quant_i8_kernel<4><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps);
+    if (per <= 1)      rmsnorm_quant_i8_kernel<1><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps, qp);
+    else if (per <= 2) rmsnorm_quant_i8_kernel<2><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps, qp);
+    else if (per <= 4) rmsnorm_quant_i8_kernel<4><<<rows, 256, 0, stream>>>(xb, wb, ob, q, scale, rows, cols, eps, qp);
     else return false;
     return true;
 }

--- a/kernels/csrc/cuda/quant/prefill_quant_rows.cu
+++ b/kernels/csrc/cuda/quant/prefill_quant_rows.cu
@@ -44,11 +44,23 @@ namespace {
 
 __device__ __forceinline__ float qr_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
 
+// K-TILED ACTIVATION COPY. Muse Glimmer's dense prefill GEMM stages a 32-byte K slice of all 128
+// rows per pipeline step. In this [row][k] layout those 128 chunks sit K bytes apart, so a warp's
+// 16 rows issue 16 separate sector requests for 512 B; the same stage out of a [k/32][row][32]
+// buffer is one contiguous 4 KB block, i.e. 4 line requests. Same bytes, same cp.async count, a
+// quarter of the transactions -- and the GEMM re-reads the whole activation once per output tile
+// (312 times for the 19968-wide FFN pair), so the read side is worth far more than the scattered
+// store it costs here. Written ALONGSIDE the row-major output, never instead of it: proj()'s
+// materialize fallback and every non-Muse consumer still read [row][k].
+__device__ __forceinline__ size_t qr_pack_off(int r, int c, int rows) {
+    return (size_t)(c >> 5) * (size_t)rows * 32 + (size_t)r * 32 + (size_t)(c & 31);
+}
+
 // One block per row. VEC bf16 per thread per slot; SLOTS slots keeps the row in registers.
 template <int BLOCK, int VEC, int SLOTS>
 __global__ __launch_bounds__(BLOCK) void pf_quant_rows_fast_kernel(
         const __nv_bfloat16* __restrict__ x, signed char* __restrict__ q,
-        float* __restrict__ scale, int rows, int cols) {
+        float* __restrict__ scale, int rows, int cols, signed char* __restrict__ qp) {
     const int r   = blockIdx.x;
     const int tid = threadIdx.x;
     if (r >= rows) return;
@@ -94,6 +106,9 @@ __global__ __launch_bounds__(BLOCK) void pf_quant_rows_fast_kernel(
             for (int v = 0; v < VEC; v++)
                 out[v] = (signed char)((sred[0] == 0.f) ? 0 : (int)roundf(qr_to_f(reg[s][v]) / d));
             *reinterpret_cast<uint2*>(&q[base + c]) = *reinterpret_cast<const uint2*>(out);
+            if (qp)
+                *reinterpret_cast<uint2*>(&qp[qr_pack_off(r, c, rows)]) =
+                    *reinterpret_cast<const uint2*>(out);
         }
     }
 }
@@ -110,7 +125,8 @@ __global__ __launch_bounds__(BLOCK) void pf_quant_rows_fast_kernel(
 template <int BLOCK, int VEC, int SLOTS>
 __global__ __launch_bounds__(BLOCK) void pf_gate_quant_rows_kernel(
         const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ gate,
-        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols) {
+        signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols,
+        signed char* __restrict__ qp) {
     const int r   = blockIdx.x;
     const int tid = threadIdx.x;
     if (r >= rows) return;
@@ -157,6 +173,9 @@ __global__ __launch_bounds__(BLOCK) void pf_gate_quant_rows_kernel(
             for (int v = 0; v < VEC; v++)
                 out[v] = (signed char)((sred[0] == 0.f) ? 0 : (int)roundf(qr_to_f(reg[s][v]) / d));
             *reinterpret_cast<uint2*>(&q[base + c]) = *reinterpret_cast<const uint2*>(out);
+            if (qp)
+                *reinterpret_cast<uint2*>(&qp[qr_pack_off(r, c, rows)]) =
+                    *reinterpret_cast<const uint2*>(out);
         }
     }
 }
@@ -164,8 +183,12 @@ __global__ __launch_bounds__(BLOCK) void pf_gate_quant_rows_kernel(
 }  // namespace
 
 bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed char* q, float* scale,
-                                       int rows, int cols, cudaStream_t stream) {
+                                       int rows, int cols, cudaStream_t stream,
+                                       signed char* qp) {
     constexpr int BLOCK = 256, VEC = 8;
+    // The k-tiled copy is only defined on whole 32-column groups; K into the dense GEMM is always a
+    // whole number of 256-value super-blocks, so this only ever declines shapes it never serves.
+    if (qp && (cols % 32) != 0) qp = nullptr;
     static const int enabled = [] {
         const char* e = getenv("SPARKINFER_PREFILL_GATE_QUANT");
         return (e && e[0] == '0') ? 0 : 1;
@@ -174,16 +197,17 @@ bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed c
     auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
     auto gb = reinterpret_cast<const __nv_bfloat16*>(gate);
     const int vecs = cols / VEC;
-    if (vecs <= BLOCK * 1)      pf_gate_quant_rows_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols);
-    else if (vecs <= BLOCK * 2) pf_gate_quant_rows_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols);
-    else if (vecs <= BLOCK * 4) pf_gate_quant_rows_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols);
+    if (vecs <= BLOCK * 1)      pf_gate_quant_rows_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp);
+    else if (vecs <= BLOCK * 2) pf_gate_quant_rows_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp);
+    else if (vecs <= BLOCK * 4) pf_gate_quant_rows_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp);
     else return false;
     return true;
 }
 
 bool launch_prefill_quant_rows_fast(const void* x, signed char* q, float* scale,
-                                    int rows, int cols, cudaStream_t stream) {
+                                    int rows, int cols, cudaStream_t stream, signed char* qp) {
     constexpr int BLOCK = 256, VEC = 8;
+    if (qp && (cols % 32) != 0) qp = nullptr;
 
     static const int enabled = [] {
         const char* e = getenv("SPARKINFER_PREFILL_QUANT_ROWS");
@@ -195,10 +219,10 @@ bool launch_prefill_quant_rows_fast(const void* x, signed char* q, float* scale,
     auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
     const int vecs = cols / VEC;                          // vector slots in a row
     // SLOTS is a compile-time register budget; dispatch the smallest that covers the row.
-    if (vecs <= BLOCK * 1)      pf_quant_rows_fast_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
-    else if (vecs <= BLOCK * 2) pf_quant_rows_fast_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
-    else if (vecs <= BLOCK * 4) pf_quant_rows_fast_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
-    else if (vecs <= BLOCK * 6) pf_quant_rows_fast_kernel<BLOCK, VEC, 6><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols);
+    if (vecs <= BLOCK * 1)      pf_quant_rows_fast_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
+    else if (vecs <= BLOCK * 2) pf_quant_rows_fast_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
+    else if (vecs <= BLOCK * 4) pf_quant_rows_fast_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
+    else if (vecs <= BLOCK * 6) pf_quant_rows_fast_kernel<BLOCK, VEC, 6><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
     else return false;                                    // very wide rows: keep the scalar path
     return true;
 }

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -36,7 +36,8 @@ void launch_add_rmsnorm2_q8_rows(const void* x_bf16, const void* residual_bf16,
 // RMSNorm + per-row int8 quantize in one pass (still writes the bf16). Bit-identical.
 bool launch_rmsnorm_quant_i8(const void* x, const void* weight, void* out,
                              signed char* q, float* scale, int rows, int cols,
-                             float eps, cudaStream_t stream);
+                             float eps, cudaStream_t stream,
+                             signed char* qp = nullptr);
 
 // Sandwich norm fed from the split-K int32 accumulator (skips the reduce + the bf16 round trip).
 void launch_norm_then_add_acc(const void* residual_bf16, const int* acc, const float* sxr,

--- a/kernels/include/sparkinfer/kernels/prefill_fp8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_fp8.h
@@ -39,9 +39,11 @@ void launch_prefill_gemm_fp8(const void* A, const void* W,
 bool launch_prefill_swiglu_quant_i8_acc(const int* acc_g, const int* acc_u, const float* sxr,
                                         const float* rs_g, const float* rs_u,
                                         signed char* q, float* scale, int rows, int cols,
-                                        cudaStream_t stream);
+                                        cudaStream_t stream, signed char* qp = nullptr);
 
-void launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
-                                    int rows, int cols, cudaStream_t stream = nullptr);
+// Returns false only when `qp` was requested but the path that ran cannot write it.
+bool launch_prefill_swiglu_quant_i8(const void* gate, const void* up, signed char* q, float* scale,
+                                    int rows, int cols, cudaStream_t stream = nullptr,
+                                    signed char* qp = nullptr);
 
 }} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/prefill_i8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8.h
@@ -21,11 +21,16 @@ namespace sparkinfer { namespace kernels {
 // q[r,c] = round(x[r,c] / scale[r]).  x: [rows,cols] bf16 -> q: [rows,cols] int8, scale: [rows] fp32.
 // One warp per row. Used for both the per-token activation A and (once, resident) the weight W.
 // Muse: fold attn *= sigmoid(gate) into the row-quantize load phase (bit-identical).
+// `qp` (optional): also emit the k-tiled [k/32][row][32] copy for the dense prefill GEMM.
 bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed char* q,
-                                      float* scale, int rows, int cols, cudaStream_t stream);
+                                      float* scale, int rows, int cols, cudaStream_t stream,
+                                      signed char* qp = nullptr);
 
-void launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
-                                     int rows, int cols, cudaStream_t stream = nullptr);
+// Returns false only when `qp` was requested but the path that ran cannot write it (the
+// warp-per-row fallback), i.e. the caller's k-tiled copy is now stale and must not be used.
+bool launch_prefill_quantize_rows_i8(const void* x_bf16, signed char* q, float* scale,
+                                     int rows, int cols, cudaStream_t stream = nullptr,
+                                     signed char* qp = nullptr);
 
 // int8 GEMM:  C[M,N] = A[M,K] @ W^T,  W native GGUF [N,K] row-major (so C[m,n]=sum_k A[m,k]*W[n,k]).
 // A/W int8 with per-row scales sx[M] (per token) and sw[N] (per output channel). Output C is bf16

--- a/kernels/include/sparkinfer/kernels/prefill_moe_q.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe_q.h
@@ -54,7 +54,12 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
                                    const void* W_q, const float* row_scale, void* C_bf16,
                                    int M, int N, int K, cudaStream_t stream = nullptr,
                                    int* partials = nullptr, int partials_splits = 0,
-                                   int* out_acc = nullptr);
+                                   int* out_acc = nullptr,
+                                   // Optional k-tiled [k/32][row][32] copy of A_i8 (see
+                                   // qr_pack_off, prefill_quant_rows.cu). Same bytes, staged with
+                                   // a quarter of the memory transactions; nullptr keeps the
+                                   // row-major addressing. Output is bit-identical either way.
+                                   const signed char* A_pack = nullptr);
 
 // Fuse up to 4 projections sharing A_i8/sx (same M, same K) into ONE grid. At prefill's M=128 a
 // projection's grid is ceil(N/64) CTAs -- 64 for a 4096-wide q/gate but only 4 for a 256-wide
@@ -70,7 +75,11 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
                                          // Fuse the FFN's SwiGLU + int8 quantize into the split-K
                                          // epilogue: gate/up never become bf16. Sets *out_fused.
                                          signed char* fuse_q = nullptr, float* fuse_sx = nullptr,
-                                         int* out_fused = nullptr);
+                                         int* out_fused = nullptr,
+                                         const signed char* A_pack = nullptr,
+                                         // k-tiled copy of the fused SwiGLU's int8 output, for the
+                                         // down projection that consumes it next.
+                                         signed char* fuse_qp = nullptr);
 
 } // namespace kernels
 } // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/prefill_quant_rows.h
+++ b/kernels/include/sparkinfer/kernels/prefill_quant_rows.h
@@ -24,8 +24,14 @@ namespace kernels {
 //
 // Env knobs:
 //   SPARKINFER_PREFILL_QUANT_ROWS  (default 1)  0 disables (A/B) -> falls through to #422's kernel.
+//   qp (optional)  when non-null, ALSO write the k-tiled [k/32][row][32] copy of the same int8
+//                  bytes that the Muse dense prefill GEMM stages its A tile from (see
+//                  qr_pack_off in the .cu). The row-major output is unaffected, so every other
+//                  consumer is unchanged; qp must have room for rows*cols bytes. Ignored when
+//                  cols is not a whole number of 32-column groups.
 bool launch_prefill_quant_rows_fast(const void* x, signed char* q, float* scale,
-                                    int rows, int cols, cudaStream_t stream = nullptr);
+                                    int rows, int cols, cudaStream_t stream = nullptr,
+                                    signed char* qp = nullptr);
 
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -301,6 +301,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                   : (size_t)FC * ffn);
     const size_t sx_n = (wide_a || moe_shared_i8) ? (size_t)N : (size_t)FC;
     signed char* A_i8 = need_i8 ? a8.alloc<signed char>(a_i8_sz) : nullptr;
+    // k-tiled [k/32][row][32] copy of the int8 activation for Muse's dense prefill GEMM. That
+    // kernel stages a 32-byte K slice of all 128 rows per pipeline step; out of the row-major A
+    // those chunks are K bytes apart, so a warp issues 16 sector requests for 512 B, while out of
+    // this layout the same stage is one contiguous 4 KB block -- 4 line requests. Measured on an
+    // RTX 5090 by feeding the GEMM a contiguous address for the same bytes: prefill@128 30.65 ms
+    // vs 32.21 ms, i.e. the scatter alone is 5% of the prefill. The quantizer writes it alongside
+    // the row-major output, so nothing else has to change and every other consumer is untouched.
+    // SPARKINFER_MUSE_QB_APACK=0 restores row-major staging (A/B in one binary).
+    const bool muse_apack = c.muse_glimmer && need_i8 && [] {
+        const char* e = getenv("SPARKINFER_MUSE_QB_APACK");
+        return !(e && e[0] == '0');
+    }();
+    signed char* A_i8p = muse_apack ? a8.alloc<signed char>(a_i8_sz) : nullptr;
     signed char* W_i8 = need_i8 ? a8.alloc<signed char>(maxw) : nullptr;
     float* sx = need_i8 ? a8.alloc<float>(sx_n) : nullptr;
     float* sw = need_i8 ? a8.alloc<float>((size_t)maxNO) : nullptr;
@@ -333,6 +346,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     int* sk_p = want_sk ? a8.alloc<int>((size_t)N * maxNO) : nullptr;
     if (need_i8 && !a8.ok) {
         a8.free_all();
+        A_i8p = nullptr;
         use_i8 = false;
         use_i8_ffn = false;
         use_i8_attn = false;
@@ -559,9 +573,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // bit-identical, it reuses the exact bytes the first call produced. The memo is reset at
     // every layer top (xn/hn refresh in place) and wherever A_i8 is written outside proj().
     const bf16* a_q = nullptr; int a_qR = 0, a_qK = 0;
+    // Whether A_i8p currently holds the k-tiled copy of what is in A_i8. Every writer of A_i8
+    // either refreshes it or clears this, so a stale copy can never reach the GEMM.
+    bool a_pk = false;
+    auto apk = [&]() -> const signed char* { return a_pk ? A_i8p : nullptr; };
     auto quant_a_i8 = [&](const bf16* A, int R, int K) {
         if (a_q == A && a_qR == R && a_qK == K) return;
-        kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st);
+        a_pk = kernels::launch_prefill_quantize_rows_i8(A, A_i8, sx, R, K, st, A_i8p) && A_i8p;
         a_q = A; a_qR = R; a_qK = K;
     };
     // int8 tensor-core GEMM with the Muse-only split-K fan-out tried first. Everything else keeps
@@ -592,7 +610,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         } else if ((use_fp8_gdn || moe_fp8) && n_out >= 128) {
             // fp8 (e4m3) tensor-core path for the long-ctx GDN projections. A_i8/W_i8 (1 byte) hold
             // the e4m3 operands; dequant the weight to bf16 scratch, then row/channel fp8-quantize.
-            a_q = nullptr;                              // A_i8 becomes e4m3 -- invalidate the memo
+            a_q = nullptr; a_pk = false;                // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, R, K, st);
             const void* wb = dq(W, wtype, n_out, K);
             kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, n_out, K, st);
@@ -659,7 +677,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (muse_qb && use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
             quant_a_i8(A, R, K);
             if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
-                                                       qb_partials, QB_SPLITS, acc))
+                                                       qb_partials, QB_SPLITS, acc, apk()))
                 return;
         }
         proj(A, W, wtype, C, n_out, K, rows);
@@ -670,7 +688,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (muse_qb && use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
             quant_a_i8(A, R, K);
             if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
-                                                       qb_partials, QB_SPLITS))
+                                                       qb_partials, QB_SPLITS, nullptr, apk()))
                 return;
         }
         proj(A, W, wtype, C, n_out, K, rows);
@@ -685,7 +703,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool fp8_shareq = (use_fp8_gdn || moe_fp8) && (!_pshareq || _pshareq[0] != '0');
     auto gdn_qkv_z = [&](const bf16* A, const Qwen35LayerWeights& w) {
         if (fp8_shareq) {
-            a_q = nullptr;                              // A_i8 becomes e4m3 -- invalidate the memo
+            a_q = nullptr; a_pk = false;                // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);   // xn -> e4m3 once
             const void* wb = dq(w.wqkv, w.wqkv_type, lqkv, H);
             kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lqkv, H, st);
@@ -728,7 +746,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
-        a_q = nullptr;                                 // xn/hn are refreshed in place each layer
+        a_q = nullptr; a_pk = false;                   // xn/hn are refreshed in place each layer
         bool attn_fused = false;                       // post-attn residual folded into the proj?
         // Set when the o / ffn_down split-K accumulator was left un-reduced for the sandwich
         // norm to consume directly. Per layer: qb_partials is reused by the next GEMM.
@@ -793,7 +811,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     quant_a_i8(xn, N, H);
                     grouped = kernels::launch_prefill_gemm_qi8_dense_group(
                         w.wq_type, A_i8, sx, Wa, rsa, Ca, na, ng, N, H, st,
-                        qb_partials, QB_SPLITS, qb_partials_cap);
+                        qb_partials, QB_SPLITS, qb_partials_cap,
+                        nullptr, nullptr, nullptr, apk());
                 }
                 if (!grouped) { inq = ing = ink = inv = false; }
                 if (!inq) proj_fused(xn, w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  H);
@@ -841,8 +860,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             bool gate_fused = false;
             if (c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
                 kernels::pf_dense_gemm_qi8_supported(w.wo_type) &&
-                kernels::launch_prefill_gate_quant_rows_i8(att, qg, A_i8, sx, N, qdim, st)) {
+                kernels::launch_prefill_gate_quant_rows_i8(att, qg, A_i8, sx, N, qdim, st,
+                                                           A_i8p)) {
                 a_q = att; a_qR = N; a_qK = qdim;      // quant_a_i8(att, N, qdim) is now a no-op
+                a_pk = A_i8p != nullptr;
                 gate_fused = true;
             }
             if (!gate_fused) kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
@@ -874,8 +895,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // pass. Only when one chunk covers the prompt: a second chunk would need A_i8/sx again
             // after the first has overwritten them. The bf16 hn is still written either way.
             if (muse_ffn_group && muse_qb && use_i8 && FC >= N &&
-                kernels::launch_rmsnorm_quant_i8(h, w.ffn_norm, hn, A_i8, sx, N, H, eps, st)) {
+                kernels::launch_rmsnorm_quant_i8(h, w.ffn_norm, hn, A_i8, sx, N, H, eps, st,
+                                                 A_i8p)) {
                 hn_quantized = true;
+                // This kernel writes A_i8 itself, so it owns the k-tiled copy's validity too --
+                // the memo below makes quant_a_i8 a no-op, which would otherwise leave a_pk
+                // asserting the ATTENTION activation still packed at cols=qdim.
+                a_pk = A_i8p != nullptr;
             } else {
                 kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, eps, st);
             }
@@ -917,11 +943,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 const bf16* hn_c = hn + (size_t)fo * H;
                 if (ffn_i8) {
                     a_q = nullptr;                     // this branch writes A_i8/sx directly
-                    kernels::launch_prefill_quantize_rows_i8(hn_c, A_i8, sx, fn, H, st);
+                    a_pk = kernels::launch_prefill_quantize_rows_i8(hn_c, A_i8, sx, fn, H, st,
+                                                                    A_i8p) && A_i8p;
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wg_i8, sx, ffn_swg, ffg, fn, ffn, H, st);
                     kernels::launch_prefill_gemm_i8(A_i8, ffn_Wu_i8, sx, ffn_swu, ffu, fn, ffn, H, st);
                     // fused SwiGLU + int8 quantize for the down input (skips the ffg DRAM round-trip)
-                    kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st);
+                    a_pk = kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st,
+                                                                   A_i8p) && A_i8p;
                     if (ffn_fused)
                         kernels::launch_prefill_gemm_i8_resid(A_i8, ffn_Wd_i8, sx, ffn_swd,
                                                               x + (size_t)fo * H, fn, H, ffn, st);
@@ -952,7 +980,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         ffn_grouped = kernels::launch_prefill_gemm_qi8_dense_group(
                             gate_pf_type, A_i8, sx, Wf, rsf, Cf, nf, 2, fn, H, st,
                             qb_partials, QB_SPLITS, qb_partials_cap,
-                            A_i8, sx, &ffn_fused_swiglu);
+                            A_i8, sx, &ffn_fused_swiglu, apk(), A_i8p);
                     }
                     if (!ffn_grouped) {
                         proj_fused(hn_c, gate_pf, gate_pf_type, w.gate_rs, ffg, ffn, H, fn);
@@ -963,8 +991,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         // runs (bit-identical to swiglu-then-quantize; both bf16-round first) --
                         // skips the ffg store + reload that proj()'s internal quantize would pay.
                         a_q = nullptr;                 // swiglu_quant writes A_i8/sx directly
+                        // The fused epilogue already emitted the k-tiled copy (fuse_qp below).
                         if (!ffn_fused_swiglu)
-                            kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st);
+                            a_pk = kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn,
+                                                                          ffn, st, A_i8p) && A_i8p;
+                        else
+                            a_pk = A_i8p != nullptr;
                         // Fused quantized-B down projection. The activation is ALREADY in A_i8/sx
                         // (the fused SwiGLU wrote it), so this cannot go through proj_fused, which
                         // would re-quantize -- call the dense fused GEMM directly. Only the
@@ -979,7 +1011,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                             down_fused = kernels::launch_prefill_gemm_qi8_dense(
                                 w.down_qtype, A_i8, sx, w.down_q, w.down_rs,
                                 ao + (size_t)fo * H, fn, H, ffn, st, qb_partials, QB_SPLITS,
-                                (fn == N) ? &ffn_acc : nullptr);
+                                (fn == N) ? &ffn_acc : nullptr, apk());
                         }
                         if (!down_fused) {
                             if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,


### PR DESCRIPTION
## Summary

`pf_dense_gemm_qi8_kernel_g` (kernels/csrc/cuda/fused/prefill_moe_q.cu) stages a 32-byte K slice of all 128 rows per pipeline step. Out of the row-major activation those 128 chunks are K bytes apart, so a warp's 16 rows issue **16 separate sector requests** to move 512 B.

This emits a second, k-tiled `[k/32][row][32]` copy of the same int8 activation from the kernels that already produce it, and points the GEMM's A stage at it. One stage then becomes a contiguous 4 KB block — **4 line requests for the same 512 B**. Same bytes, same `cp.async` count, same shared-memory destination; only the addresses change, so the int8 the MMA consumes is unchanged and the K loop still carries one add per stage (`a_step` is a constant in both layouts).

I priced the axis before building it, by feeding the kernel a contiguous address for the same bytes (numerically wrong, timing only): **prefill@128 30.65 ms vs 32.21 ms**, so the scatter alone was 5% of the prefill.

The copy is written *alongside* the row-major output, never instead of it, so `proj()`'s materialize fallback and every non-Muse consumer are untouched. All five kernels that write that activation emit both (`pf_quant_rows_fast`, `pf_gate_quant_rows`, `rmsnorm_quant_i8`, `pf_swiglu_quant_i8_reg`, `pf_swiglu_quant_i8_acc`), and a validity flag in the prefill tracks which one wrote last so a stale copy cannot reach the GEMM — the pre-FFN norm's fused quantize is one of those writers and is followed by a memo that makes the normal quantize a no-op, which is exactly the case a flag is needed for.

Cost is one extra store in the quantizer — scattered, because a block owns one row whose packed bytes are 32 B chunks `rows*32` apart — against a read the GEMM repeats once per output tile, 312 times for the 19968-wide FFN pair. In the profile that is 0.48 ms of a 29 ms prefill (`rmsnorm_quant_i8` 0.242 + `pf_quant_rows_fast` 0.121 + `pf_gate_quant_rows` 0.119) against ~2.3 ms saved.

`SPARKINFER_MUSE_QB_APACK=0` restores row-major staging (A/B in one binary).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

Two separate build trees (`build_main` from `origin/main`, `build` with this change) run alternately on the same box — a CUDA binary cannot be copied out of its build tree.

**Decode tok/s** (Muse Glimmer, ctx=0, median of 5):

| | decode tok/s |
|---|--:|
| before (main) | 103.81 |
| after (this PR) | 103.80 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128, median of 5):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4353.21 |
| after prefill (this PR) | 4675.58 |

**1.07x prefill@128, decode flat.** Three alternating PR-vs-main pairs on the same box:

| pair | main | this PR | ratio |
|---|--:|--:|--:|
| 1 | 4363.36 | 4682.82 | 1.073 |
| 2 | 4327.73 | 4675.58 | 1.080 |
| 3 | 4353.21 | 4675.51 | 1.074 |

**Accuracy — unchanged**, `SPARKINFER_KV_INT8=0 qwen3_gguf_prefill_check` (batched prefill vs the token-by-token path):

| build | N=128 TOP1 | N=128 KL | N=512 TOP1 | N=512 KL |
|---|--:|--:|--:|--:|
| main | 15/16 0.9375 | 0.03630 | 16/16 1.0000 | 0.01333 |
| this PR | 15/16 0.9375 | 0.03630 | 16/16 1.0000 | 0.01333 |

Same seed (194 / 220) in every row, and identical again with `SPARKINFER_MUSE_PREFILL_GRAPH=0`, so the result does not depend on whether the batched prefill is replayed from a graph. The same check with `SPARKINFER_MUSE_QB_APACK=0` vs `=1` inside this build also matches exactly at N=128/512/1024 (1024: 15/16 0.9375, KL 0.01730, seed 220 both ways).

**Muse Glimmer multi-context** (`SPARKINFER_KV_INT8=0 SPARKINFER_MUSE_PREFILL_GRAPH=0`, median of 5) — the longer prompts gain more, because past one M-tile there is no split-K and every M-tile re-streams its own activation rows:

| ctx | decode ratio | prefill ratio |
|---|--:|--:|
| 0 | 0.9998 | — |
| 128 | 0.9998 | 1.061 |
| 512 | 0.9997 | 1.216 |
| 4096 | 0.9999 | 1.112 |

Both flags are needed to take this sweep at all, on main as well as here, and neither is related to this change: int8 KV is broken on Muse at ctx >= 4k, and a sweep that prefills at several different N in one process segfaults with prefill graph capture enabled (main at `98af9ec` exits 139 on `0,128,512,4096`; the same sweep with `SPARKINFER_MUSE_PREFILL_GRAPH=0` completes). The scored ctx-0/128 sweep above uses stock defaults.

**Qwen3.6 no-regression guard** (`Qwen3.6-35B-A3B-UD-Q4_K_M`, ctx 0/512/4k/16k/32k, median of 5), PR/main ratio — floor is 0.98:

| ctx | decode | prefill |
|---|--:|--:|
| 0 | 1.0000 | — |
| 512 | 1.0003 | 1.0046 |
| 4096 | 1.0002 | 1.0019 |
| 16384 | 1.0004 | 0.9997 |
| 32768 | 0.9996 | 1.0002 |

```text
########## ACCURACY FIRST, graph ON (default) ##########
  N=128 main: TOP1  15/16 0.9375 KL    0.03630 (mean over 16 positions)
  N=128  PR : TOP1  15/16 0.9375 KL    0.03630 (mean over 16 positions)
  N=512 main: TOP1  16/16 1.0000 KL    0.01333 (mean over 16 positions)
  N=512  PR : TOP1  16/16 1.0000 KL    0.01333 (mean over 16 positions)
########## ACCURACY, graph OFF ##########
  N=128  PR (GRAPH=0): TOP1  15/16 0.9375 KL    0.03630 (mean over 16 positions)
  N=512  PR (GRAPH=0): TOP1  16/16 1.0000 KL    0.01333 (mean over 16 positions)
########## SPEED, alternating pairs (stock defaults) ##########
  pair1 main: ctx0 d=103.82 p=0.00  ctx128 d=102.84 p=4363.36
  pair1  PR : ctx0 d=103.80 p=0.00  ctx128 d=102.81 p=4682.82
  pair2 main: ctx0 d=103.81 p=0.00  ctx128 d=102.82 p=4327.73
  pair2  PR : ctx0 d=103.79 p=0.00  ctx128 d=102.79 p=4675.58
  pair3 main: ctx0 d=103.80 p=0.00  ctx128 d=102.81 p=4353.21
  pair3  PR : ctx0 d=103.81 p=0.00  ctx128 d=102.80 p=4675.51
########## Muse multi-ctx (KV_INT8=0, GRAPH=0) ##########
  main: ctx0 d=103.48 p=0.00  ctx128 d=102.52 p=4025.98  ctx512 d=101.04 p=4036.21  ctx4096 d=94.25 p=2905.09
  PR  : ctx0 d=103.46 p=0.00  ctx128 d=102.50 p=4269.74  ctx512 d=101.01 p=4909.33  ctx4096 d=94.24 p=3230.36
########## Qwen3.6 guard ##########
  main: ctx0 d=453.94 p=0.00  ctx512 d=447.50 p=8308.20  ctx4096 d=429.94 p=22874.25  ctx16384 d=431.86 p=24843.26  ctx32768 d=431.89 p=26187.05
  PR  : ctx0 d=453.96 p=0.00  ctx512 d=447.65 p=8346.76  ctx4096 d=430.04 p=22916.82  ctx16384 d=432.05 p=24835.48  ctx32768 d=431.72 p=26192.42
```

Profile after the change (nsys, prefill@128 window, 29.0 ms): the dense GEMM is 22.0 ms (75.6%), attention 1.66 ms, GPU idle 1.84 ms, and the three activation quantizers together 0.48 ms.