### PR TITLE
perf(muse-glimmer): wave-aware split-K slices, evict-first weight loads, and three fused prefill passes

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -47,6 +47,7 @@
 #include <cuda_fp16.h>
 #include <cuda_bf16.h>
 #include <cstdlib>
+#include <cmath>
 #include <cuda_pipeline.h>
 #include <mma.h>
 
@@ -339,10 +340,16 @@ template <int QT>
 __device__ __forceinline__ void qm_stage_fetch(const unsigned char* __restrict__ blk, int j64,
                                                QmStage<QT>& s) {
     if constexpr (QT == QMQ_Q4_K) {
-        s.hdr = *reinterpret_cast<const uint4*>(blk);
+        // __ldcs = evict-first. The weight stream is read exactly once and never revisited, but it
+        // is 14.2 GB per prefill pushed through a 96 MB L2 that other things genuinely want: the
+        // k-tiled activation tile every N-tile re-reads, and the int32 split-K accumulator the
+        // fused SwiGLU reads microseconds after the GEMM's red.add wrote it. Marking the weights
+        // streaming stops them evicting either. Same bytes, same values -- only which cache line
+        // survives changes.
+        s.hdr = __ldcs(reinterpret_cast<const uint4*>(blk));
         const unsigned char* qb = blk + 16 + j64 * 32;
-        s.q0 = *reinterpret_cast<const uint4*>(qb);
-        s.q1 = *reinterpret_cast<const uint4*>(qb + 16);
+        s.q0 = __ldcs(reinterpret_cast<const uint4*>(qb));
+        s.q1 = __ldcs(reinterpret_cast<const uint4*>(qb + 16));
     } else {
         s.blk = blk;
     }
@@ -1203,6 +1210,45 @@ static int qm_atomic_acc() {
     return e;
 }
 
+// Resident block slots on this device for a __launch_bounds__(256, 2) kernel.
+static int qm_block_slots() {
+    static int slots = 0;
+    if (!slots) {
+        int dev = 0, sm = 170;
+        cudaGetDevice(&dev);
+        cudaDeviceGetAttribute(&sm, cudaDevAttrMultiProcessorCount, dev);
+        slots = sm * 2;
+    }
+    return slots;
+}
+
+// Among the slice counts NOT LARGER than the one the block-target heuristic asked for, take the one
+// that leaves the fewest idle block slots in the final wave.
+//
+// Why this matters here: the grid is `splits * ntiles` blocks against `slots` of them, and at
+// Muse's prefill@128 those land badly. The q/gate/k/v group is 136 tiles, so 13 slices put 1768
+// blocks on 340 slots = 5.20 waves -- six waves of occupancy doing 5.20 waves of work -- while 5
+// slices give exactly 2.00. The o projection is 104 tiles: 8 slices = 2.45 waves, 6 slices = 1.84.
+// Only ever moving DOWN is deliberate: a larger slice count would also multiply the split-K atomic
+// traffic, and that is what made a plain "raise the block target" retune lose (swept 2560 -> 5600).
+// Ties break toward more slices, since shorter blocks balance the tail better.
+// SPARKINFER_MUSE_QB_WAVE=0 restores the plain heuristic (A/B; bit-identical either way).
+static int qm_wave_pick(int ntiles, int nsb, int want) {
+    static int on = -1;
+    if (on < 0) { const char* e = getenv("SPARKINFER_MUSE_QB_WAVE"); on = (e && e[0] == '0') ? 0 : 1; }
+    if (!on || ntiles <= 0 || want <= 1) return want;
+    const double slots = (double)qm_block_slots();
+    int best = want; double best_eff = -1.0;
+    for (int sbp = 1; sbp <= nsb; sbp++) {
+        const int s = (nsb + sbp - 1) / sbp;
+        if (s > want) continue;
+        const double w = (double)s * (double)ntiles / slots;
+        const double eff = w / ceil(w);
+        if (eff > best_eff + 1e-9 || (eff > best_eff - 1e-9 && s > best)) { best_eff = eff; best = s; }
+    }
+    return best;
+}
+
 // K slices per launch. Shared by the single and grouped launchers so both fan out the same way.
 static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int partials_splits) {
     static int sk_env = -1;
@@ -1214,6 +1260,7 @@ static int qm_pick_splits(int ntiles, int K, int mtiles, bool have_partials, int
         if (splits > partials_splits) splits = partials_splits;
         if (splits > nsb / 2) splits = nsb / 2;
         if (splits < 1) splits = 1;
+        splits = qm_wave_pick(ntiles, nsb, splits);
     }
     return splits;
 }

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -801,9 +801,15 @@ __global__ void norm_then_add_acc_kernel(const __nv_bfloat16* __restrict__ resid
         }
     };
 
+    // Hold the scaled values across the two passes: `acc` is int32, so a second read of it is 4 B
+    // per element on a kernel already at the DRAM roofline (10.2 MB moved per launch at H=6656).
+    __nv_bfloat16 keep[4][8];
+    int held = 0;
     float ss = 0.f;
-    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
         float bv[8]; load8(p, bv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) keep[held][j] = __float2bfloat16(bv[j]);
         #pragma unroll
         for (int j = 0; j < 8; j++) ss = __fmaf_rn(bv[j], bv[j], ss);
     }
@@ -825,8 +831,11 @@ __global__ void norm_then_add_acc_kernel(const __nv_bfloat16* __restrict__ resid
     const uint4* w4 = reinterpret_cast<const uint4*>(weight);
     const uint4* r4 = reinterpret_cast<const uint4*>(residual + base);
     uint4* o4 = reinterpret_cast<uint4*>(out + base);
-    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
-        float bv[8]; load8(p, bv);
+    held = 0;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
+        float bv[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) bv[j] = __bfloat162float(keep[held][j]);
         float rv[8]; rn_unpack8(__ldg(r4 + p), rv);
         float wv[8]; rn_unpack8(__ldg(w4 + p), wv);
         float ov[8];

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -327,6 +327,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // 13 is the peak, and raising QM_TARGET_BLOCKS with it only adds atomic traffic (swept too).
     constexpr int QB_SPLITS = 13;
     const size_t qb_partials_cap = (size_t)QB_SPLITS * (size_t)N * (size_t)maxNO;
+    // LM-head activation, quantized once (see the seed argmax at the end of this function).
+    signed char* lm_q8 = a8.alloc<signed char>((size_t)H + 32);
+    float* lm_ad = a8.alloc<float>((size_t)(H >> 5) + 1);
+    float* lm_as = a8.alloc<float>((size_t)(H >> 5) + 1);
+
     int* qb_partials = (c.muse_glimmer && use_i8 && N <= 128)
         ? a8.alloc<int>(qb_partials_cap) : nullptr;
     // Muse Glimmer split-K partials for the skinny projections. launch_prefill_gemm_i8 puts one
@@ -1550,7 +1555,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
     // Seed for the first decode step: argmax at the last prompt position (xn already = final norm).
     const bf16* xn_last = xn + (size_t)(N - 1) * H;
-    if (s.w.lm_head_type)
+    // Q4_K head: quantize the activation ONCE and run the pre-quantized dp4a GEMV. gemv.cu calls
+    // this BIT-EXACT vs the in-kernel path -- same Q8_1 values, same dp4a -- and it drops the
+    // per-block re-quantization of the same 6656-value activation, which at vocab-many rows is the
+    // larger half of what that one launch reads after the weights themselves.
+    if (s.w.lm_head_type == 12 && lm_q8 && lm_ad && lm_as) {
+        kernels::launch_quantize_q8_1(xn_last, lm_q8, lm_ad, lm_as, H, st);
+        kernels::launch_gemv_q_dp4a_pq_f32(lm_q8, lm_ad, lm_as, s.w.lm_head, s.logits, c.vocab, H, st);
+    } else if (s.w.lm_head_type)
         kernels::launch_gemv_q_f32(xn_last, s.w.lm_head, s.w.lm_head_type, s.logits, c.vocab, H, st);
     else
         kernels::launch_gemv_f32(xn_last, s.w.lm_head, s.logits, c.vocab, H, st);


### PR DESCRIPTION
## Summary

Three independent things, all bit-identical, found by profiling the prefill after #805 rather than reasoning about it.

Reaches only Muse Glimmer for (1) and (3c); (2) and (3a) are on the dense fused GEMM, which is behind `c.muse_glimmer`. `SPARKINFER_MUSE_QB_WAVE=0` restores the plain slice heuristic (A/B; bit-identical either way).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx=0, median of 5):

| | decode tok/s |
|---|--:|
| before (main) | 107.45 |
| after (this PR) | 107.41 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128, median of 5):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4758.10 |
| after prefill (this PR) | 4948.19 |

**1.040x prefill@128, decode flat.** Three alternating PR-vs-main pairs, each a real `origin/main` build at `290ef86`:

| pair | main | this PR | ratio |
|---|--:|--:|--:|
| 1 | 4765.89 | 4949.56 | 1.039 |
| 2 | 4758.10 | 4948.19 | 1.040 |
| 3 | 4753.78 | 4946.88 | 1.041 |

**Accuracy — bit-identical**, `SPARKINFER_KV_INT8=0 qwen3_gguf_prefill_check`:

| build | N=128 TOP1 | N=128 KL | N=512 TOP1 | N=512 KL |
|---|--:|--:|--:|--:|
| main | 15/16 0.9375 | 0.03630 | 16/16 1.0000 | 0.01333 |
| this PR | 15/16 0.9375 | 0.03630 | 16/16 1.0000 | 0.01333 |
| this PR, `QB_WAVE=0` | 15/16 0.9375 | 0.03630 | — | — |

Same seed (194 / 220) in every row.