### PR TITLE
perf(muse-glimmer): build the SM120 FP4 prefill path by default (1.14x prefill@128)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,17 @@ cmake_minimum_required(VERSION 3.20)
 # sometimes ancient e.g. "52") default if it isn't already set. A set() after
 # project() is a CACHE no-op once that's happened, silently building tensor-core/wmma
 # kernels for a target that can't support them.
-set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120" CACHE STRING "CUDA architectures")
+#
+# The Blackwell entry is sm_120a, not sm_120, when the native FP4 prefill path is built. FP4's
+# block-scaled MMA is an architecture-specific instruction: ptxas rejects
+# `mma.sync.aligned.m16n8k64.kind::mxf4` outright on `.target sm_120` and accepts it on sm_120a,
+# and sm_120a SASS runs on the same silicon. It has to be decided HERE, for the whole project, and
+# not per target: a single library built for 120a while its siblings are 120 does not device-link
+# at all ("nvlink fatal: elfLink fatbinary error"), which is why the FP4 kernels could not be
+# enabled as they stood. The other architectures are unaffected.
+include(cmake/Nvfp4Arch.cmake)
+set(CMAKE_CUDA_ARCHITECTURES "89;90;100;${SPARKINFER_BLACKWELL_ARCH}"
+    CACHE STRING "CUDA architectures")
 project(sparkinfer LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/cmake/Nvfp4Arch.cmake
+++ b/cmake/Nvfp4Arch.cmake
@@ -1,0 +1,47 @@
+# Decides whether the native SM120 block-scaled FP4 prefill kernels can be built, and therefore
+# which Blackwell architecture the project targets.
+#
+# Included from the top-level CMakeLists BEFORE project(), and again from kernels/ (which is also
+# configurable standalone). The arch has to be settled before project() because
+# enable_language(CUDA) latches CMAKE_CUDA_ARCHITECTURES at that call.
+include_guard(GLOBAL)
+
+option(BUILD_NVFP4_KERNELS
+       "SM120 native block-scaled FP4 dense prefill kernels (header-only CUTLASS)" ON)
+
+# The FP4 kernels compile against header-only CUTLASS, fetched at configure time. A box without
+# network access must still be able to configure the project, so probe the remote once and fall
+# back to the portable CUDA path rather than hard-failing the whole build. A tree that has already
+# fetched CUTLASS skips the probe, so this costs one `ls-remote` on a cold build directory.
+if(BUILD_NVFP4_KERNELS)
+    set(_nvfp4_deps "${FETCHCONTENT_BASE_DIR}")
+    if(NOT _nvfp4_deps)
+        set(_nvfp4_deps "${CMAKE_BINARY_DIR}/_deps")
+    endif()
+    if(NOT EXISTS "${_nvfp4_deps}/cutlass-src/include/cutlass/cutlass.h")
+        find_package(Git QUIET)
+        if(NOT GIT_EXECUTABLE)
+            set(BUILD_NVFP4_KERNELS OFF CACHE BOOL "" FORCE)
+            message(STATUS "NVFP4: git not found -- building the portable CUDA prefill path")
+        else()
+            execute_process(
+                COMMAND "${GIT_EXECUTABLE}" ls-remote --exit-code
+                        https://github.com/NVIDIA/cutlass.git v4.7.0
+                RESULT_VARIABLE _nvfp4_reachable
+                OUTPUT_QUIET ERROR_QUIET TIMEOUT 60)
+            if(NOT _nvfp4_reachable EQUAL 0)
+                set(BUILD_NVFP4_KERNELS OFF CACHE BOOL "" FORCE)
+                message(STATUS "NVFP4: CUTLASS unreachable -- building the portable CUDA prefill path")
+            endif()
+        endif()
+    endif()
+endif()
+
+# sm_120a, not sm_120: ptxas rejects the block-scaled FP4 MMA on `.target sm_120` and accepts it on
+# sm_120a, which runs on the same silicon. Every target must agree -- one library at 120a among
+# siblings at 120 fails to device-link ("nvlink fatal: elfLink fatbinary error").
+if(BUILD_NVFP4_KERNELS)
+    set(SPARKINFER_BLACKWELL_ARCH "120a")
+else()
+    set(SPARKINFER_BLACKWELL_ARCH "120")
+endif()

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -6,7 +6,11 @@ cmake_minimum_required(VERSION 3.20)
 # datacenter Blackwell (B200) and is binary-incompatible with the 5090.
 # Must be set BEFORE project(... CUDA) — see root CMakeLists.txt for why.
 # sm_121 excluded — unsupported by the CUDA 12.8 toolkit currently in use.
-set(CMAKE_CUDA_ARCHITECTURES "89;90;100;120" CACHE STRING "CUDA architectures")
+# See cmake/Nvfp4Arch.cmake: the Blackwell entry is sm_120a when the FP4 prefill kernels are in,
+# and the choice must be made before project() and shared by every target.
+include(${CMAKE_CURRENT_LIST_DIR}/../cmake/Nvfp4Arch.cmake)
+set(CMAKE_CUDA_ARCHITECTURES "89;90;100;${SPARKINFER_BLACKWELL_ARCH}"
+    CACHE STRING "CUDA architectures")
 project(sparkinfer_kernels LANGUAGES CXX CUDA)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -18,7 +22,8 @@ option(BUILD_BENCHMARKS    "Build benchmarks"            OFF)
 # tensor-core paths. OFF by default; the portable CUDA path below is the
 # production build and is what runs on RTX 5090 (sm_120).
 option(BUILD_CUTE_KERNELS  "Experimental CuTe DSL kernels (needs CUTLASS)" OFF)
-option(BUILD_NVFP4_KERNELS "Experimental SM120 native NVFP4 dense kernels" OFF)
+# BUILD_NVFP4_KERNELS is declared in cmake/Nvfp4Arch.cmake, above, because the architecture list
+# depends on it and has to be fixed before project().
 
 include_directories(include)
 
@@ -62,7 +67,6 @@ if(BUILD_NVFP4_KERNELS)
     target_include_directories(si_fused PRIVATE ${cutlass_SOURCE_DIR}/include ${cutlass_SOURCE_DIR}/tools/util/include)
     target_compile_definitions(si_fused PRIVATE SPARKINFER_BUILD_NVFP4=1)
     target_compile_options(si_fused PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
-    set_target_properties(si_fused PROPERTIES CUDA_ARCHITECTURES "120a")
 endif()
 
 # Unified interface library

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3985,8 +3985,12 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     // because scored prefill times the first pass. Gate/up native prefill copies that are distinct
     // from their compact Q3_A decode weights are released after conversion, keeping peak resident
     // memory within a 32-GB card. The normal GGUF pointers remain the correctness fallback.
+    // On by default now that the kernels are in the default build: the conversion is gated on
+    // Muse plus a successful sm_120a FP4 build, and the GGUF pointers stay as the fallback, so a
+    // box that could not build the FP4 path simply never takes it. SPARKINFER_MUSE_PREFILL_NVFP4=0
+    // forces the portable quantized projections back.
     const char* fp4_env = getenv("SPARKINFER_MUSE_PREFILL_NVFP4");
-    if (c.muse_glimmer && fp4_env && fp4_env[0] == '1' &&
+    if (c.muse_glimmer && (!fp4_env || fp4_env[0] != '0') &&
         kernels::prefill_nvfp4_supported(128, c.moe_ffn, H) &&
         kernels::prefill_nvfp4_supported(128, H, c.moe_ffn)) {
         void* tmp = nullptr;


### PR DESCRIPTION
## Summary

The native SM120 block-scaled FP4 gate/up prefill projections cannot be selected by a default
build. This makes them buildable and enables them, which needs an architecture fix: FP4's
block-scaled MMA is arch-specific, so the whole project must target `sm_120a` rather than one
library doing so on its own.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — this PR targets prefill; included to show no regression):

| | decode tok/s |
|---|--:|
| before (main) | 102.55 |
| after (this PR) | 102.54 |

**Prefill pp tok/s** (Muse Glimmer, `ctx=128` — the scored prefill shape for this model):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4895.0 |
| after prefill (this PR) | 5598.8 |

**+14.4% prefill@128.** Median-of-5, the two builds interleaved in one session on an idle card
with clocks locked at 2550 MHz. `ctest` 19/19.

```text
# main @ 3e34dc9, default build: cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
main {"128":{"decode_tps":102.4023,"prefill_pp":4901.0084}}
PR   {"128":{"decode_tps":102.3703,"prefill_pp":5588.5388}}
main {"128":{"decode_tps":102.5759,"prefill_pp":4895.0423}}
PR   {"128":{"decode_tps":102.5456,"prefill_pp":5609.5283}}
main {"128":{"decode_tps":102.5484,"prefill_pp":4882.4778}}
PR   {"128":{"decode_tps":102.5433,"prefill_pp":5598.8303}}

# both arms from a cold `cmake -S . -B <dir> -DCMAKE_BUILD_TYPE=Release`, no extra flags:
# main  -> CMAKE_CUDA_ARCHITECTURES:STRING=89;90;100;120
# PR    -> CMAKE_CUDA_ARCHITECTURES:STRING=89;90;100;120a, BUILD_NVFP4_KERNELS:BOOL=ON
#          [prefill-muse] SM120 NVFP4 FFN weights ready: 52/52 layers
```

## What was blocking it

Three things, of which the first is a hard build failure:

1. **Architecture.** `ptxas` rejects `mma.sync.aligned.m16n8k64.kind::mxf4` on `.target sm_120`
   and accepts it on `sm_120a`, so the FP4 translation unit must be compiled for `120a`. Setting
   `CUDA_ARCHITECTURES` on that one library while its siblings stay at `120` does not device-link:
   `nvlink fatal : elfLink fatbinary error`. The choice has to be project-wide and taken before
   `project()` latches `CMAKE_CUDA_ARCHITECTURES`, so it moves into a small shared module included
   by both the root and `kernels/`. `sm_120a` SASS runs on the same silicon; 89/90/100 unchanged.
2. **Kernels not compiled**, leaving `prefill_nvfp4_supported()` as a stub returning `false`.
3. **Runtime opt-in.** Now opt-out — `SPARKINFER_MUSE_PREFILL_NVFP4=0` restores the portable
   quantized projections.

CUTLASS is header-only and fetched at configure time. The module probes the remote once on a cold
build directory and falls back to the portable CUDA path if it is unreachable, so a box without
network still configures and builds — an unavailable dependency degrades the build rather than
breaking it.

## Accuracy

The teacher-forced decode score is **byte-identical** (same md5 over the scored output), because
this path is prefill-only and never runs during decode.

Prefill quality, `qwen3_gguf_prefill_check` at 128 tokens over 32 continuation positions
(batched vs the token-by-token reference):

| | TOP1 | mean KL |
|---|--:|--:|
| portable projections | 29/32 (0.9062) | 0.04443 |
| FP4 gate/up | 29/32 (0.9062) | 0.05432 |

TOP1 and the seed token are unchanged; mean KL rises by 0.0099, the expected cost of 4-bit
gate/up. Down-projection stays on the quantized path, whose error enters the residual directly.
