### PR TITLE
perf(muse-glimmer): build the SM120 FP4 prefill path by default (1.15x prefill@128)

### DIFF
--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -18,7 +18,38 @@ option(BUILD_BENCHMARKS    "Build benchmarks"            OFF)
 # tensor-core paths. OFF by default; the portable CUDA path below is the
 # production build and is what runs on RTX 5090 (sm_120).
 option(BUILD_CUTE_KERNELS  "Experimental CuTe DSL kernels (needs CUTLASS)" OFF)
-option(BUILD_NVFP4_KERNELS "Experimental SM120 native NVFP4 dense kernels" OFF)
+# Native SM120 block-scaled FP4 prefill kernels. Deliberately NOT an option(): option() writes a
+# cache entry and then does nothing at all once one exists, and build directories here are reused
+# across configures -- so a tree that was ever configured while these kernels were off would pin
+# them off forever, and the default below would never be read again. A normal variable is
+# recomputed every configure and shadows any stale cache entry of the same name.
+# -DSPARKINFER_NVFP4=OFF opts out.
+if(DEFINED SPARKINFER_NVFP4)
+    set(BUILD_NVFP4_KERNELS ${SPARKINFER_NVFP4})
+else()
+    set(BUILD_NVFP4_KERNELS ON)
+endif()
+
+# CUTLASS is header-only and fetched at configure time. A box with no network must still be able
+# to configure, so probe the remote once on a cold build tree and fall back to the portable CUDA
+# path instead of failing the whole build.
+if(BUILD_NVFP4_KERNELS AND
+   NOT EXISTS "${CMAKE_BINARY_DIR}/_deps/cutlass-src/include/cutlass/cutlass.h")
+    find_package(Git QUIET)
+    if(NOT GIT_EXECUTABLE)
+        set(BUILD_NVFP4_KERNELS OFF)
+        message(STATUS "NVFP4: git not found -- building the portable CUDA prefill path")
+    else()
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" ls-remote --exit-code
+                    https://github.com/NVIDIA/cutlass.git v4.7.0
+            RESULT_VARIABLE _nvfp4_reachable OUTPUT_QUIET ERROR_QUIET TIMEOUT 60)
+        if(NOT _nvfp4_reachable EQUAL 0)
+            set(BUILD_NVFP4_KERNELS OFF)
+            message(STATUS "NVFP4: CUTLASS unreachable -- building the portable CUDA prefill path")
+        endif()
+    endif()
+endif()
 
 include_directories(include)
 
@@ -58,11 +89,24 @@ if(BUILD_CUTE_KERNELS)
 endif()
 
 if(BUILD_NVFP4_KERNELS)
-    target_sources(si_fused PRIVATE csrc/cuda/fused/prefill_nvfp4_sm120.cu)
-    target_include_directories(si_fused PRIVATE ${cutlass_SOURCE_DIR}/include ${cutlass_SOURCE_DIR}/tools/util/include)
+    # A library of its OWN, compiled whole-program. The block-scaled FP4 MMA only assembles for
+    # sm_120a, and a RELOCATABLE object at 120a cannot be device-linked against its 120 siblings
+    # ("nvlink fatal: elfLink fatbinary error"). Turning separable compilation off keeps the device
+    # link inside this one translation unit, so this is the only target that needs the arch and the
+    # rest of the build keeps the architecture list it was configured with. The entry points are
+    # host functions, and prefill_nvfp4_supported() gates on cc 12.0 at runtime, so a non-Blackwell
+    # device simply never calls in.
+    add_library(si_nvfp4 STATIC csrc/cuda/fused/prefill_nvfp4_sm120.cu)
+    target_include_directories(si_nvfp4 PRIVATE include
+        ${cutlass_SOURCE_DIR}/include ${cutlass_SOURCE_DIR}/tools/util/include)
+    target_compile_options(si_nvfp4 PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
+    set_target_properties(si_nvfp4 PROPERTIES
+        CUDA_ARCHITECTURES "120a"
+        CUDA_SEPARABLE_COMPILATION OFF
+        POSITION_INDEPENDENT_CODE ON)
+    # Compiles out the linkable fallbacks in prefill_nvfp4.cu, which si_fused owns.
     target_compile_definitions(si_fused PRIVATE SPARKINFER_BUILD_NVFP4=1)
-    target_compile_options(si_fused PRIVATE $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>)
-    set_target_properties(si_fused PROPERTIES CUDA_ARCHITECTURES "120a")
+    list(APPEND SPARKINFER_KERNEL_LIBS si_nvfp4)
 endif()
 
 # Unified interface library

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -6,7 +6,9 @@ add_test(NAME cpu_reference_test COMMAND cpu_reference_test)
 
 if(BUILD_NVFP4_KERNELS)
   add_executable(prefill_nvfp4_gpu_test prefill_nvfp4_gpu_test.cpp)
-  target_link_libraries(prefill_nvfp4_gpu_test PRIVATE si_fused si_quant CUDA::cudart)
+  # si_nvfp4, not si_fused: the FP4 entry points live in their own whole-program library so that
+  # the sm_120a device code never has to device-link against the rest of the build.
+  target_link_libraries(prefill_nvfp4_gpu_test PRIVATE si_nvfp4 si_fused si_quant CUDA::cudart)
   set_target_properties(prefill_nvfp4_gpu_test PROPERTIES CUDA_ARCHITECTURES "120a")
   add_test(NAME prefill_nvfp4_gpu_test COMMAND prefill_nvfp4_gpu_test)
   set_tests_properties(prefill_nvfp4_gpu_test PROPERTIES SKIP_RETURN_CODE 77)

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3985,8 +3985,12 @@ bool Qwen35Model::load_gguf(const std::string& path) {
     // because scored prefill times the first pass. Gate/up native prefill copies that are distinct
     // from their compact Q3_A decode weights are released after conversion, keeping peak resident
     // memory within a 32-GB card. The normal GGUF pointers remain the correctness fallback.
+    // On by default now that the kernels are in the default build: the conversion is gated on
+    // Muse plus a successful sm_120a FP4 build, and the GGUF pointers stay as the fallback, so a
+    // box that could not build the FP4 path simply never takes it. SPARKINFER_MUSE_PREFILL_NVFP4=0
+    // forces the portable quantized projections back.
     const char* fp4_env = getenv("SPARKINFER_MUSE_PREFILL_NVFP4");
-    if (c.muse_glimmer && fp4_env && fp4_env[0] == '1' &&
+    if (c.muse_glimmer && (!fp4_env || fp4_env[0] != '0') &&
         kernels::prefill_nvfp4_supported(128, c.moe_ffn, H) &&
         kernels::prefill_nvfp4_supported(128, H, c.moe_ffn)) {
         void* tmp = nullptr;


### PR DESCRIPTION
## Summary

The native SM120 block-scaled FP4 gate/up prefill projections cannot be reached by a default
build. This makes them buildable and enables them, in a way that survives a build directory reused
across configures — the earlier revision of this PR did not, and measured as a no-op.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — this PR targets prefill; included to show no regression):

| | decode tok/s |
|---|--:|
| before (main) | 102.39 |
| after (this PR) | 102.53 |

**Prefill pp tok/s** (Muse Glimmer, `ctx=128` — the scored prefill shape for this model):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4889.7 |
| after prefill (this PR) | 5611.7 |

**+14.8% prefill@128.** Median-of-5, the two builds interleaved in one session on an idle card
with clocks locked at 2550 MHz. `ctest` 19/19.

```text
main {"128":{"decode_tps":102.3895,"prefill_pp":4943.1925}}
PR   {"128":{"decode_tps":102.3366,"prefill_pp":5602.3937}}
main {"128":{"decode_tps":102.3523,"prefill_pp":4889.6843}}
PR   {"128":{"decode_tps":102.5284,"prefill_pp":5613.2679}}
main {"128":{"decode_tps":102.5729,"prefill_pp":4884.2002}}
PR   {"128":{"decode_tps":102.5394,"prefill_pp":5611.6706}}

# PR build, from a tree already cached at sm_120 with the kernels previously off:
#   [prefill-muse] SM120 NVFP4 FFN weights ready: 52/52 layers
```

## What was blocking it

**Architecture.** `ptxas` rejects `mma.sync.aligned.m16n8k64.kind::mxf4` on `.target sm_120` and
accepts it on `sm_120a`. Compiling that translation unit for 120a inside a *relocatable* library
whose siblings are 120 does not link:

```
nvlink fatal : elfLink fatbinary error
```

Raising the whole project to 120a would work on a fresh tree but is invasive, and
`CMAKE_CUDA_ARCHITECTURES` is cached — a `set()` against an existing cache entry does nothing, so
an already-configured build directory would silently keep 120. Instead the FP4 sources move into
their own **whole-program (non-RDC) library** carrying 120a alone. The device link stays inside
that translation unit, every other target keeps the architecture list it was configured with, and
the entry points are host functions so nothing else changes. `prefill_nvfp4_supported()` already
gates on cc 12.0, so a non-Blackwell device never calls in.

**Selection.** The build flag is no longer an `option()`. `option()` writes a cache entry and does
nothing once one exists, so a tree configured before these kernels existed pins them off
permanently and never reads the default again. A normal variable is recomputed every configure and
shadows a stale cache entry of the same name; `-DSPARKINFER_NVFP4=OFF` opts out. The runtime path
is opt-out as well — `SPARKINFER_MUSE_PREFILL_NVFP4=0` restores the portable projections.

CUTLASS is header-only and fetched at configure time, so a cold build tree probes the remote once
and falls back to the portable CUDA path if it is unreachable: an unavailable dependency degrades
the build rather than breaking it.

Verified from a cold tree, from a warm tree already cached at `sm_120` with the kernels off, and
with `-DSPARKINFER_NVFP4=OFF`.

## Accuracy

The teacher-forced decode score is **byte-identical** (same md5 over the scored output), because
this path is prefill-only and never runs during decode.

Prefill quality, `qwen3_gguf_prefill_check` at 128 tokens over 32 continuation positions
(batched vs the token-by-token reference):

| | TOP1 | mean KL |
|---|--:|--:|
| portable projections | 29/32 (0.9062) | 0.04443 |
| FP4 gate/up | 29/32 (0.9062) | 0.05432 |

TOP1 and the seed token are unchanged; mean KL rises by 0.0099, the expected cost of 4-bit
gate/up. The down projection stays on the quantized path, whose error enters the residual directly.
