### PR TITLE
perf(muse-glimmer): full-warp FP4 activation quantize, and let the ffn width reach the fast int8 quantize (1.11x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -46,23 +46,36 @@ auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SF
 template <class Layout>
 __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
                            cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout) {
+    // V is fixed by the format: one ue4m3 scale per 16 values. The mapping of lanes onto those 16
+    // is not. One lane per value left half of every warp idle (lane < V), reduced 16 real values
+    // across 32 lanes, and stored 8 bytes per warp per step -- 63 GB/s, 3.5% of peak. Two values
+    // per lane puts 8 lanes on a group and 4 groups on a warp: every lane live, the amax reduction
+    // is 3 steps inside its own 8-lane group, and the warp's 4 groups store 32 contiguous bytes.
+    // Bit-identical: max is order-independent, and each value keeps the same scale and the same
+    // x / float(qs) rounding it had before.
     constexpr int V = 16;
-    constexpr int WARPS = 8;
-    int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
-    const int total = rows * (cols / V);
-    for (int vec = blockIdx.x * WARPS + warp; vec < total; vec += gridDim.x * WARPS) {
-        int row = vec / (cols / V), k0 = (vec % (cols / V)) * V;
-        float x = lane < V ? __bfloat162float(src[(size_t)row * cols + k0 + lane]) : 0.f;
-        float a = fabsf(x);
+    constexpr int LPV = 8;            // lanes per scale group (2 values each)
+    constexpr int GPW = 32 / LPV;     // scale groups per warp
+    const int vpr = cols / V;
+    const int gpb = (int)(blockDim.x >> 5) * GPW;
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+    const int sub = lane & (LPV - 1);
+    const int gin = lane >> 3;
+    const int total = rows * vpr;
+    for (int g = blockIdx.x * gpb + warp * GPW + gin; g < total; g += gridDim.x * gpb) {
+        const int row = g / vpr, k0 = (g - row * vpr) * V;
+        const size_t base = (size_t)row * cols + k0 + sub * 2;
+        const __nv_bfloat162 v2 = *reinterpret_cast<const __nv_bfloat162*>(src + base);
+        const float x0 = __bfloat162float(v2.x), x1 = __bfloat162float(v2.y);
+        float a = fmaxf(fabsf(x0), fabsf(x1));
         #pragma unroll
-        for (int d = 16; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, d));
+        for (int d = LPV >> 1; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, d));
         cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
-        cutlass::float_e2m1_t q(x / float(qs));
-        unsigned nibble = q.raw() & 15u;
-        unsigned hi = __shfl_down_sync(0xffffffffu, nibble, 1);
-        if (lane < V && !(lane & 1))
-            dst[((size_t)row * cols + k0 + lane) >> 1] = (unsigned char)(nibble | (hi << 4));
-        if (lane == 0) {
+        cutlass::float_e2m1_t q0(x0 / float(qs));
+        cutlass::float_e2m1_t q1(x1 / float(qs));
+        dst[base >> 1] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        if (sub == 0) {
             auto scales = cute::make_tensor(sf, layout);
             scales(row, k0, 0) = qs;
         }
@@ -101,7 +114,7 @@ size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
 bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
     auto l = sfa_layout(m,128,k);
-    int blocks = (m * (k / 16) + 7) / 8; if (blocks > 4096) blocks = 4096;
+    int blocks = (m * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
     quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
                                      (cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
@@ -109,7 +122,7 @@ bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k
 bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(128,n,k)) return false;
     auto l = sfb_layout(128,n,k);
-    int blocks = (n * (k / 16) + 7) / 8; if (blocks > 4096) blocks = 4096;
+    int blocks = (n * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
     quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
                                      (cutlass::float_ue4m3_t*)sf,n,k,l);
     return cudaPeekAtLastError() == cudaSuccess;

--- a/kernels/csrc/cuda/quant/prefill_quant_rows.cu
+++ b/kernels/csrc/cuda/quant/prefill_quant_rows.cu
@@ -223,6 +223,11 @@ bool launch_prefill_quant_rows_fast(const void* x, signed char* q, float* scale,
     else if (vecs <= BLOCK * 2) pf_quant_rows_fast_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
     else if (vecs <= BLOCK * 4) pf_quant_rows_fast_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
     else if (vecs <= BLOCK * 6) pf_quant_rows_fast_kernel<BLOCK, VEC, 6><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
+    else if (vecs <= BLOCK * 8) pf_quant_rows_fast_kernel<BLOCK, VEC, 8><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
+    // Muse's ffn width (19968 -> 2496 vectors) sat just past SLOTS=6 and fell to the warp-per-row
+    // scalar kernel: 128 blocks of 32 threads, the row read twice, 18.9 us a call against 2.0 for
+    // this one. SLOTS=10 covers it in registers (10 * VEC bf16 = 40 registers of a 256-budget).
+    else if (vecs <= BLOCK * 10) pf_quant_rows_fast_kernel<BLOCK, VEC, 10><<<rows, BLOCK, 0, stream>>>(xb, q, scale, rows, cols, qp);
     else return false;                                    // very wide rows: keep the scalar path
     return true;
 }


### PR DESCRIPTION
## Summary

The two row-quantizers feeding the prefill GEMMs run at 3.5% and 7.5% of memory peak, while the FP4
gate/up GEMM beside them runs at 74%. Both are bit-identical after this.

**`quant_rows` — one lane per value idles half of every warp.** `V=16` is fixed by the format (one
`ue4m3` scale per 16 values); the mapping of lanes onto those 16 is not. With `lane < V` doing the
work, lanes 16-31 sit out the load, the `amax` reduction runs all five shuffle steps across 32
lanes for 16 live values, and only the even lanes store — 8 bytes per warp per step. Two values per
lane via one 32-bit load puts 8 lanes on a scale group and 4 groups on a warp: every lane live, the
reduction runs inside its own 8-lane group, and a warp's four groups store 32 contiguous bytes.

**The int8 quantizer never reached its own fast path at this model's ffn width.**
`launch_prefill_quant_rows_fast` dispatches a register-resident block-per-row kernel on a
compile-time `SLOTS` budget of `{1,2,4,6}`, and `SLOTS=6` covers `vecs <= 1536`, i.e. 12288 columns.
Muse's ffn width is 19968 → 2496 vectors → the dispatch returns false and the warp-per-row scalar
kernel runs instead: 128 blocks of 32 threads, the row read twice, 18.9 us a call against 3.0 for
the fast kernel, 52 calls a prefill. `SLOTS=8` and `10` cover it, at 40 registers of a 256 budget.

That second one also removes work from the *consumer*: the scalar fallback reports its packed copy
stale, so the fast path's k-tiled output saves a re-pack. `pf_dense_gemm_qi8` drops 8.004 → 7.058 ms
without being touched, about a third of the total gain.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx=0 — this PR does not touch the decode path):

| | decode tok/s |
|---|--:|
| before (main) | 103.52 |
| after (this PR) | 103.51 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 5607.54 |
| after prefill (this PR) | 6214.30 |

**+10.82% prefill@128**, measured on `61d49da` with both arms configured and built from scratch,
interleaved round-robin, five reps inside each process, clocks locked at 2550 MHz. The two
distributions do not overlap:

```text
  round 1: main=5592.35  mine=6217.73
  round 2: main=5605.33  mine=6214.30
  round 3: main=5611.22  mine=6146.52
  round 4: main=5598.15  mine=6213.12
  round 5: main=5609.54  mine=6204.96
  round 6: main=5607.54  mine=6216.88
  round 7: main=5630.92  mine=6225.69

  main 5607.54 (min 5592.35 max 5630.92) | mine 6214.30 (min 6146.52 max 6225.69)
  +10.82%, 7/7 rounds
```

Both arms were checked to contain a live FP4 path before comparing — 104 `cutlass::device_kernel`
launches each — since a tree that quietly compiles it out would make the baseline meaningless.

Per-kernel, same nsys window:

```text
  quant_rows            2.160 -> 0.779 ms   (40.8 -> 14.7 us/call)
  pf_quantize_rows_i8   0.982 ms -> gone; absorbed by pf_quant_rows_fast at 3.0 us/call
  pf_dense_gemm_qi8     8.004 -> 7.058 ms   (untouched; reads the packed copy instead of re-packing)
  GPU-busy total       24.73 -> 21.60 ms
```

### Correctness

Bit-identity is the claim, so it is checked rather than argued — `qwen3_gguf_prefill_check` fills
the KV and teacher-forces the same 64 positions on both builds:

```text
  main       prefix=128  58/64 0.9062  KL 0.04732
  this PR    prefix=128  58/64 0.9062  KL 0.04732
  main       prefix=512  58/64 0.9062  KL 0.00700
  this PR    prefix=512  58/64 0.9062  KL 0.00700

ctest: 100% tests passed, 17/17
```

`max` is order-independent, so every scale group keeps the same `amax` and the same `qs`; each value
keeps the same `x / float(qs)` rounding; and the nibble packing keeps the same byte layout that
one-lane-per-value produced.

### Qwen3.6 no-regression

`prefill_quant_rows.cu` is shared with the routed-MoE prefill, so the cross-model guard was run
rather than argued — the eval's own sweep (`ctx 0/512/4k/16k/32k`, median-of-5), two builds each run
in place:

```text
  ctx        decode A -> B            prefill A -> B
       0     454.15 ->   453.83
     512     447.15 ->   447.15     8348.23 ->   8367.88
    4096     429.36 ->   429.24    22917.82 ->  22909.75
   16384     430.54 ->   430.22    24856.24 ->  24859.54
   32768     430.72 ->   431.01    26227.87 ->  26197.63
```

Max deviation 0.12%. That sweep was taken on the immediately preceding base with this same two-file
change; the FP4 build wiring that differs between the two bases is not on any Qwen3.6 path.
