### PR TITLE
perf(muse-glimmer): extend the SM120 NVFP4 prefill path to ffn_down (1.08x prefill@128)

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -83,6 +83,7 @@ struct Qwen35LayerWeights {
     // Optional SM120-native NVFP4 copies used only by Muse batched prefill. Decode and all
     // unsupported shapes continue to use the GGUF-native pointers above.
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
+    const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4027,6 +4027,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const int ut = lw.prefill_up_q ? lw.prefill_up_qtype : lw.up_qtype;
             ok = convert(g, gt, c.moe_ffn, H, &lw.gate_fp4, &lw.gate_fp4_sf) &&
                  convert(u, ut, c.moe_ffn, H, &lw.up_fp4, &lw.up_fp4_sf);
+            // ffn_down too: same block-scaled format, [H rows, ffn cols]. #810/#813 stopped at
+            // gate/up; down passes the same shape gate (6656 %128, 19968 %128) and its input is
+            // the SwiGLU output this path already materializes as bf16. SPARKINFER_MUSE_NVFP4_DOWN=0
+            // keeps the shipped int8 down for A/B.
+            static const bool dn_on = [] {
+                const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN");
+                return !(e && e[0] == '0');
+            }();
+            if (ok && dn_on)
+                ok = convert(lw.down_q, lw.down_qtype, H, c.moe_ffn, &lw.down_fp4, &lw.down_fp4_sf);
             if (ok) {
                 release_prefill_copy(lw.prefill_gate_q, lw.gate_q);
                 release_prefill_copy(lw.prefill_up_q, lw.up_q);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -381,6 +381,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
+    // Down-projection FP4 leg: the A operand is the SwiGLU output (k = ffn, not H), so it needs
+    // its own quant buffers and workspace. Only allocated when the load-time conversion produced
+    // down_fp4 weights (SPARKINFER_MUSE_NVFP4_DOWN=0 keeps these null).
+    const bool muse_nvfp4_dn = muse_nvfp4 && s.w.layers[0].down_fp4 &&
+                               kernels::prefill_nvfp4_supported(N, H, ffn);
+    unsigned char* fp4_a2 = muse_nvfp4_dn
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
+    unsigned char* fp4_as2 = muse_nvfp4_dn
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, ffn)) : nullptr;
+    unsigned char* fp4_ws2 = muse_nvfp4_dn
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_workspace_bytes(N, H, ffn)) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -972,6 +983,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                        ffu, fn, ffn, H, fp4_ws, st);
                 if (layer_fp4) {
                     kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                    // FP4 down leg: quantize the SwiGLU output once and hit the same block-scaled
+                    // GEMM. Writes ao directly (chunks are disjoint), leaving ffn_acc unset so the
+                    // plain norm_then_add tail consumes it. Falls back to the int8 down on any
+                    // launch failure, exactly like the gate/up legs above.
+                    if (muse_nvfp4_dn && w.down_fp4 && w.down_fp4_sf &&
+                        kernels::launch_prefill_nvfp4_quant_a(ffg, fp4_a2, fp4_as2, fn, ffn, st) &&
+                        kernels::launch_prefill_nvfp4_gemm(fp4_a2, fp4_as2, w.down_fp4,
+                                                           w.down_fp4_sf, ao + (size_t)fo * H,
+                                                           fn, H, ffn, fp4_ws2, st)) {
+                        continue;
+                    }
                     proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                    ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     continue;


### PR DESCRIPTION
## Summary

#810 added the SM120 block-scaled NVFP4 prefill path; #813 made it the default build — for the FFN **gate/up** projections. This PR completes the FFN: **`ffn_down`** passes the same `%128` shape gate (6656×19968) and its A operand — the SwiGLU output — is already materialized as bf16 on the FP4 branch. One `quant_a` + one block-scaled GEMM replaces the int8 fused-down and its split-K partials. 33 lines; the int8 path remains the runtime fallback on any launch failure; `SPARKINFER_MUSE_NVFP4_DOWN=0` restores it outright.

Credit: the NVFP4 kernels, quantizers and conversion design are #810 (@andriypolanski), enabled by #813 (@inference2026). This PR only widens which tensors use them.

Also measured and deliberately **excluded**: the same extension to `q/gate/k/v` is a *loss* (−4.6% — four skinny FP4 GEMMs lose to #791's single grouped int8 launch). Kept out so this diff is only the part that wins.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

RTX 5090, Muse Glimmer 17 GB GGUF (`muse-glimmer-30B-kquant-17gb.gguf`), main `61d49da`.

Base re-sampled between every arm, one binary (env-gated), shipped defaults otherwise; two independent sessions.

| pair | base pp | this PR pp | delta |
|---|--:|--:|--:|
| A1 | 6114.2 | 6689.5 | +9.41% |
| A2 | 6113.4 | 6616.1 | +8.22% |
| A3 | 6109.2 | 6593.5 | +7.93% |
| B1 | 6095.8 | 6582.1 | +7.98% |
| B2 | 6087.3 | 6618.0 | +8.72% |

**mean +8.45%** (session means +8.52% / +8.35%). Control drift ≤1.5% within sessions.

**decode** (both ctx keys): 106.59 → 106.59 tok/s — untouched, as expected for a prefill-only path.

**Mixed-context sequence test** (`SWEEP_CTXS=512,4096`, reps 5 — the #809 reproducer class): exit 0, clean, both sessions, with this path live.

## Accuracy

The down weights go through the identical NVFP4 quantizer #810/#813 shipped and validated for gate/up (tensors 1× this size, 2 per layer vs 1 here); the eval's top1/KL gate applies as usual.

Note for maintainers, found while validating: **`qwen3_gguf_prefill_check` currently fails on stock `61d49da`** (`[FAIL] prefill_batched unsupported (seed=-1)`) with the FP4 path on *or* off — so prefill TOP1 tables are currently unobtainable for any PR. Reproducer: `qwen3_gguf_prefill_check <muse gguf> 128 16`. Happy to split the report into an issue.
