### PR TITLE
Revert "perf(muse-glimmer): extend the SM120 NVFP4 prefill path to ffn_down and wo (1.10x prefill@128)"

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -83,8 +83,6 @@ struct Qwen35LayerWeights {
     // Optional SM120-native NVFP4 copies used only by Muse batched prefill. Decode and all
     // unsupported shapes continue to use the GGUF-native pointers above.
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
-    const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
-    const void* wo_fp4 = nullptr;   const void* wo_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4027,23 +4027,6 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const int ut = lw.prefill_up_q ? lw.prefill_up_qtype : lw.up_qtype;
             ok = convert(g, gt, c.moe_ffn, H, &lw.gate_fp4, &lw.gate_fp4_sf) &&
                  convert(u, ut, c.moe_ffn, H, &lw.up_fp4, &lw.up_fp4_sf);
-            // ffn_down too: same block-scaled format, [H rows, ffn cols]. #810/#813 stopped at
-            // gate/up; down passes the same shape gate (6656 %128, 19968 %128) and its input is
-            // the SwiGLU output this path already materializes as bf16. SPARKINFER_MUSE_NVFP4_DOWN=0
-            // keeps the shipped int8 down for A/B.
-            static const bool dn_on = [] {
-                const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN");
-                return !(e && e[0] == '0');
-            }();
-            if (ok && dn_on)
-                ok = convert(lw.down_q, lw.down_qtype, H, c.moe_ffn, &lw.down_fp4, &lw.down_fp4_sf);
-            // wo [H, qdim]: the other fat projection. SPARKINFER_MUSE_NVFP4_WO=0 disables.
-            static const bool wo_on = [] {
-                const char* e = getenv("SPARKINFER_MUSE_NVFP4_WO");
-                return !(e && e[0] == '0');
-            }();
-            if (ok && wo_on && lw.wo)
-                ok = convert(lw.wo, lw.wo_type, H, s.qdim, &lw.wo_fp4, &lw.wo_fp4_sf);
             if (ok) {
                 release_prefill_copy(lw.prefill_gate_q, lw.gate_q);
                 release_prefill_copy(lw.prefill_up_q, lw.up_q);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -381,17 +381,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
-    // Down-projection FP4 leg: the A operand is the SwiGLU output (k = ffn, not H), so it needs
-    // its own quant buffers and workspace. Only allocated when the load-time conversion produced
-    // down_fp4 weights (SPARKINFER_MUSE_NVFP4_DOWN=0 keeps these null).
-    const bool muse_nvfp4_dn = muse_nvfp4 && s.w.layers[0].down_fp4 &&
-                               kernels::prefill_nvfp4_supported(N, H, ffn);
-    unsigned char* fp4_a2 = muse_nvfp4_dn
-        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
-    unsigned char* fp4_as2 = muse_nvfp4_dn
-        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, ffn)) : nullptr;
-    unsigned char* fp4_ws2 = muse_nvfp4_dn
-        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_workspace_bytes(N, H, ffn)) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -903,16 +892,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
                 // add happens in launch_norm_then_add below.
-                // FP4 o-projection: att is bf16 here; one quant (k = qdim) + one block-scaled
-                // GEMM into ao, leaving attn_acc unset so the plain norm_then_add tail runs.
-                // Reuses the FFN-leg A buffers: qdim < ffn so both fit fp4_a2/fp4_as2, and the
-                // workspace for (N,H,qdim) is bounded by the (N,H,ffn) one already sized.
-                if (muse_nvfp4_dn && w.wo_fp4 && w.wo_fp4_sf &&
-                    kernels::launch_prefill_nvfp4_quant_a(att, fp4_a2, fp4_as2, N, qdim, st) &&
-                    kernels::launch_prefill_nvfp4_gemm(fp4_a2, fp4_as2, w.wo_fp4, w.wo_fp4_sf,
-                                                       ao, N, H, qdim, fp4_ws2, st)) {
-                    /* attn_acc stays 0 */
-                } else
                 proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
             } else {
@@ -993,17 +972,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                        ffu, fn, ffn, H, fp4_ws, st);
                 if (layer_fp4) {
                     kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                    // FP4 down leg: quantize the SwiGLU output once and hit the same block-scaled
-                    // GEMM. Writes ao directly (chunks are disjoint), leaving ffn_acc unset so the
-                    // plain norm_then_add tail consumes it. Falls back to the int8 down on any
-                    // launch failure, exactly like the gate/up legs above.
-                    if (muse_nvfp4_dn && w.down_fp4 && w.down_fp4_sf &&
-                        kernels::launch_prefill_nvfp4_quant_a(ffg, fp4_a2, fp4_as2, fn, ffn, st) &&
-                        kernels::launch_prefill_nvfp4_gemm(fp4_a2, fp4_as2, w.down_fp4,
-                                                           w.down_fp4_sf, ao + (size_t)fo * H,
-                                                           fn, H, ffn, fp4_ws2, st)) {
-                        continue;
-                    }
                     proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                    ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     continue;


### PR DESCRIPTION
Reverts gittensor-ai-lab/sparkinfer#816

Breaks batched prefill accuracy. Reverting to restore the shipped int8 down/wo
prefill path while the NVFP4 down+wo extension is investigated.