### PR TITLE
perf(muse-glimmer): block-scaled FP4 ffn_down and o-projection, shape-adaptive GEMM tile, fused activation quantizes (1.21x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -10,6 +10,10 @@ size_t prefill_nvfp4_scale_bytes_a(int, int) { return 0; }
 size_t prefill_nvfp4_scale_bytes_b(int, int) { return 0; }
 size_t prefill_nvfp4_workspace_bytes(int, int, int) { return 0; }
 bool launch_prefill_nvfp4_quant_a(const void*, void*, void*, int, int, cudaStream_t) { return false; }
+bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*, int, int,
+                                         cudaStream_t) { return false; }
+bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, int, int,
+                                       cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t) { return false; }

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -11,37 +11,128 @@
 #include <cutlass/util/packed_stride.hpp>
 #include <cute/tensor.hpp>
 
+#include <cstdlib>
+
 namespace sparkinfer::kernels {
 namespace {
 using namespace cute;
 using E4 = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
 using BF = cutlass::bfloat16_t;
-using Tile = Shape<_128, _128, _128>;
 using Cluster = Shape<_1, _1, _1>;
-using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, Tile, Cluster,
-    cutlass::epilogue::collective::EpilogueTileAuto, float, float,
-    BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
-    cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
-using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
-    E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
-    Tile, Cluster,
-    cutlass::gemm::collective::StageCountAutoCarveout<
-        static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
-    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
-using Kernel = cutlass::gemm::kernel::GemmUniversal<
-    Shape<int, int, int, int>, Mainloop, Epilogue, void>;
-using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
-using StrideA = typename Kernel::StrideA;
-using StrideB = typename Kernel::StrideB;
-using StrideC = typename Kernel::StrideC;
-using StrideD = typename Kernel::StrideD;
-using ScaleConfig = typename Mainloop::Sm1xxBlkScaledConfig;
 
-auto shape(int m, int n, int k) { return cute::make_shape(m, n, k, 1); }
-auto sfa_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFA(shape(m,n,k)); }
-auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFB(shape(m,n,k)); }
+// Batched prefill runs M = 128, so the grid is 1 x ceil(N / TileN) CTAs and the tile shape alone
+// decides both how much of the GPU the GEMM covers and how deep its mainloop pipelines. The
+// shipped 128x128x128 tile is tuned for the fat FFN gate/up projection and leaves the narrower
+// projections well short. Measured cold-L2 on an RTX 5090 (170 SMs), M = 128, median of 9,
+// microseconds -- every variant produces a bitwise-identical result to the shipped tile:
+//
+//   tile            gate_up      ffn_down          wo    q/gate/k/v
+//                  N=19968       N=6656       N=6656       N=8704
+//                  K=6656       K=19968       K=4096       K=6656
+//   128x128x128      59.74        88.54        22.94        36.54     <- shipped
+//   128x64x128       67.52        84.77        26.37        41.89
+//   128x128x256    * 56.19        88.48        25.02        39.14
+//   128x64x256       60.51      * 74.05      * 21.63      * 31.84
+//   256x128x128      70.27       131.58       35.07         53.98
+//
+// The lever is the K tile, not the N tile: a 256-deep K step gives the mainloop twice the work
+// per stage to hide the weight fetch behind, worth -16% on ffn_down and -13% on q/gate/k/v.
+// Narrowing N on top of that pays only once the wide tile has stopped covering the machine
+// (ffn_down and wo issue 52 CTAs, q/gate/k/v 68, against gate/up's 156 of 170 SMs) -- narrowing
+// N for gate/up costs 8%, so the choice is made per call from the CTA count.
+//
+// Both instantiations read the SAME weights: the GMEM block-scale layout comes from
+// Sm1xxBlockScaledConfig<SFVecSize>::tile_atom_to_shape_SFA/SFB
+// (cutlass/detail/sm100_blockscaled_layout.hpp), which is a function of SFVecSize and the problem
+// shape only -- the CTA tile appears solely in the smem layouts, inside the kernel. So the
+// load-time conversion is unchanged and the dispatch below is free to pick per call.
+template <class Tile>
+struct Fp4Gemm {
+    using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, Tile, Cluster,
+        cutlass::epilogue::collective::EpilogueTileAuto, float, float,
+        BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+    using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+        E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
+        Tile, Cluster,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+    using Kernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, Mainloop, Epilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+    using StrideA = typename Kernel::StrideA;
+    using StrideB = typename Kernel::StrideB;
+    using StrideC = typename Kernel::StrideC;
+    using StrideD = typename Kernel::StrideD;
+    using ScaleConfig = typename Mainloop::Sm1xxBlkScaledConfig;
+
+    static auto shape(int m, int n, int k) { return cute::make_shape(m, n, k, 1); }
+
+    static typename Gemm::Arguments args(const void* a, const void* sa, const void* b,
+                                         const void* sb, void* d, int m, int n, int k) {
+        auto as = cutlass::make_cute_packed_stride(StrideA{}, {m, k, 1});
+        auto bs = cutlass::make_cute_packed_stride(StrideB{}, {n, k, 1});
+        auto cs = cutlass::make_cute_packed_stride(StrideC{}, {m, n, 1});
+        auto ds = cutlass::make_cute_packed_stride(StrideD{}, {m, n, 1});
+        return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m, n, k),
+                {static_cast<const cutlass::float_e2m1_t*>(a), as,
+                 static_cast<const cutlass::float_e2m1_t*>(b), bs,
+                 static_cast<const cutlass::float_ue4m3_t*>(sa),
+                 ScaleConfig::tile_atom_to_shape_SFA(shape(m, n, k)),
+                 static_cast<const cutlass::float_ue4m3_t*>(sb),
+                 ScaleConfig::tile_atom_to_shape_SFB(shape(m, n, k))},
+                {{1.f, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
+    }
+
+    static bool run(const void* a, const void* sa, const void* b, const void* sb, void* d,
+                    int m, int n, int k, void* ws, cudaStream_t st) {
+        Gemm gemm;
+        auto ar = args(a, sa, b, sb, d, m, n, k);
+        return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
+               gemm.initialize(ar, ws, st) == cutlass::Status::kSuccess &&
+               gemm.run(st) == cutlass::Status::kSuccess;
+    }
+
+    static size_t workspace(int m, int n, int k) {
+        return Gemm::get_workspace_size(args(nullptr, nullptr, nullptr, nullptr, nullptr, m, n, k));
+    }
+};
+
+using WideTile = Shape<_128, _128, _256>;     // fat N (ffn gate/up)
+using NarrowTile = Shape<_128, _64, _256>;    // everything that does not cover the machine
+using WideGemm = Fp4Gemm<WideTile>;
+using NarrowGemm = Fp4Gemm<NarrowTile>;
+
+// The scale layouts are tile-independent (see above), so one instantiation can answer for both.
+using SizeGemm = WideGemm;
+
+int sm_count() {
+    static int sms = -1;
+    if (sms < 0) {
+        int dev = 0;
+        if (cudaGetDevice(&dev) != cudaSuccess ||
+            cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
+            sms = 170;
+    }
+    return sms;
+}
+
+// Halve the tile width once the wide tile has stopped covering the machine: at 2 * ceil(N/128)
+// <= SM count the narrow tile still fits in one wave, so the extra CTAs are free, while for
+// gate/up (156 of 170 SMs already) splitting would cost a second wave.
+// SPARKINFER_MUSE_NVFP4_TILE=wide|narrow pins it so both arms of an A/B come out of one binary.
+bool use_narrow(int n) {
+    static int mode = -1;
+    if (mode < 0) {
+        const char* e = getenv("SPARKINFER_MUSE_NVFP4_TILE");
+        mode = (e && e[0] == 'w') ? 0 : (e && e[0] == 'n') ? 1 : 2;
+    }
+    if (mode != 2) return mode == 1;
+    return 2 * ((n + 127) / 128) <= sm_count();
+}
 
 template <class Layout>
 __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
@@ -82,16 +173,84 @@ __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
     }
 }
 
-Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
-                     void* d, int m, int n, int k) {
-    auto as = cutlass::make_cute_packed_stride(StrideA{}, {m,k,1});
-    auto bs = cutlass::make_cute_packed_stride(StrideB{}, {n,k,1});
-    auto cs = cutlass::make_cute_packed_stride(StrideC{}, {m,n,1});
-    auto ds = cutlass::make_cute_packed_stride(StrideD{}, {m,n,1});
-    return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m,n,k),
-            {static_cast<const cutlass::float_e2m1_t*>(a), as, static_cast<const cutlass::float_e2m1_t*>(b), bs, static_cast<const cutlass::float_ue4m3_t*>(sa), sfa_layout(m,n,k), static_cast<const cutlass::float_ue4m3_t*>(sb), sfb_layout(m,n,k)},
-            {{1.f, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
+// SwiGLU folded into the down projection's A-operand quantize. The unfused pair writes the
+// [128, 19968] product back as bf16 (5.1 MB a layer) purely so the quantizer can read it again;
+// fusing deletes that store and that load. One ue4m3 scale still covers 16 values, but the 16 are
+// spread over 8 lanes at 2 values each, so every lane is live, the amax reduction runs inside its
+// own 8-lane group, and each lane's two neighbours pack into the single byte it stores -- 32
+// contiguous bytes per warp.
+//
+// The product is rounded through bf16 before quantizing, exactly as pf_swiglu_kernel stores it,
+// so this emits byte-identical FP4 to launch_prefill_swiglu + launch_prefill_nvfp4_quant_a.
+template <class Layout>
+__global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
+                                  const __nv_bfloat16* __restrict__ up,
+                                  unsigned char* dst, cutlass::float_ue4m3_t* sf,
+                                  int rows, int cols, Layout layout) {
+    constexpr int V = 16;            // values per ue4m3 scale group
+    constexpr int LPG = V / 2;       // 8 lanes per group, 2 values each
+    const int glane = threadIdx.x & (LPG - 1);
+    const int groups = rows * (cols / V);
+    const int stride = (gridDim.x * blockDim.x) / LPG;
+    // The four 8-lane groups in a warp can retire on different iterations of the grid-stride
+    // loop, so the amax butterfly must name only its own group, never the whole warp.
+    const unsigned gmask = 0xFFu << (threadIdx.x & 24);
+    for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG; grp < groups; grp += stride) {
+        const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
+        const size_t base = (size_t)row * cols + k0 + 2 * glane;
+        const float g0 = __bfloat162float(gate[base]),     u0 = __bfloat162float(up[base]);
+        const float g1 = __bfloat162float(gate[base + 1]), u1 = __bfloat162float(up[base + 1]);
+        const float x0 = __bfloat162float(__float2bfloat16(g0 / (1.f + __expf(-g0)) * u0));
+        const float x1 = __bfloat162float(__float2bfloat16(g1 / (1.f + __expf(-g1)) * u1));
+        float a = fmaxf(fabsf(x0), fabsf(x1));
+        #pragma unroll
+        for (int d = LPG / 2; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(gmask, a, d));
+        cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
+        cutlass::float_e2m1_t q0(x0 / float(qs)), q1(x1 / float(qs));
+        dst[base >> 1] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        if (glane == 0) {
+            auto scales = cute::make_tensor(sf, layout);
+            scales(row, k0, 0) = qs;
+        }
+    }
 }
+// Muse's attention gate folded into the o-projection's A-operand quantize: att * sigmoid(qg)
+// straight to FP4. The int8 leg already does exactly this
+// (launch_prefill_gate_quant_rows_i8), and the reverted #816 came unstuck precisely because its
+// FP4 leg did NOT -- it quantized the raw `att` while the gate was riding along inside the int8
+// quantize, dropping the gate on every layer. Doing the gate here means no path ever reads an
+// un-gated `att`, and no separate pass over [128, 4096] is needed either.
+template <class Layout>
+__global__ void gate_quant_rows(const __nv_bfloat16* __restrict__ src,
+                                const __nv_bfloat16* __restrict__ gate,
+                                unsigned char* dst, cutlass::float_ue4m3_t* sf,
+                                int rows, int cols, Layout layout) {
+    constexpr int V = 16, LPG = V / 2;
+    const int glane = threadIdx.x & (LPG - 1);
+    const int groups = rows * (cols / V);
+    const int stride = (gridDim.x * blockDim.x) / LPG;
+    const unsigned gmask = 0xFFu << (threadIdx.x & 24);
+    for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG; grp < groups; grp += stride) {
+        const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
+        const size_t base = (size_t)row * cols + k0 + 2 * glane;
+        const float s0 = __bfloat162float(src[base]),     g0 = __bfloat162float(gate[base]);
+        const float s1 = __bfloat162float(src[base + 1]), g1 = __bfloat162float(gate[base + 1]);
+        // Same expression and same bf16 rounding as pf_mul_sigmoid_kernel.
+        const float x0 = __bfloat162float(__float2bfloat16(s0 / (1.f + __expf(-g0))));
+        const float x1 = __bfloat162float(__float2bfloat16(s1 / (1.f + __expf(-g1))));
+        float a = fmaxf(fabsf(x0), fabsf(x1));
+        #pragma unroll
+        for (int d = LPG / 2; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(gmask, a, d));
+        cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
+        cutlass::float_e2m1_t q0(x0 / float(qs)), q1(x1 / float(qs));
+        dst[base >> 1] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        if (glane == 0) {
+            auto scales = cute::make_tensor(sf, layout);
+            scales(row, k0, 0) = qs;
+        }
+    }
+}
+
 } // namespace
 
 bool prefill_nvfp4_supported(int m, int n, int k) {
@@ -103,26 +262,48 @@ bool prefill_nvfp4_supported(int m, int n, int k) {
 }
 size_t prefill_nvfp4_data_bytes(int r, int c) { return ((size_t)r*c + 1)/2; }
 size_t prefill_nvfp4_scale_bytes_a(int m, int k) {
-    return (size_t)cute::size(cute::filter_zeros(sfa_layout(m,128,k)));
+    return (size_t)cute::size(cute::filter_zeros(
+        SizeGemm::ScaleConfig::tile_atom_to_shape_SFA(SizeGemm::shape(m,128,k))));
 }
 size_t prefill_nvfp4_scale_bytes_b(int n, int k) {
-    return (size_t)cute::size(cute::filter_zeros(sfb_layout(128,n,k)));
+    return (size_t)cute::size(cute::filter_zeros(
+        SizeGemm::ScaleConfig::tile_atom_to_shape_SFB(SizeGemm::shape(128,n,k))));
 }
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
-    return Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    const size_t w = WideGemm::workspace(m, n, k);
+    const size_t nw = NarrowGemm::workspace(m, n, k);
+    return w > nw ? w : nw;   // one arena serves whichever tile the dispatch picks
 }
 bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
-    auto l = sfa_layout(m,128,k);
-    int blocks = (m * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
+    auto l = SizeGemm::ScaleConfig::tile_atom_to_shape_SFA(SizeGemm::shape(m,128,k));
+    int blocks = (m * (k / 16) + 7) / 8; if (blocks > 4096) blocks = 4096;
     quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
                                      (cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
+bool launch_prefill_nvfp4_swiglu_quant_a(const void* g, const void* u, void* d, void* sf,
+                                         int m, int k, cudaStream_t st) {
+    if (!g || !u || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
+    auto l = SizeGemm::ScaleConfig::tile_atom_to_shape_SFA(SizeGemm::shape(m,128,k));
+    int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
+    swiglu_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)g,(const __nv_bfloat16*)u,
+                                            (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
+bool launch_prefill_nvfp4_gate_quant_a(const void* s, const void* g, void* d, void* sf,
+                                       int m, int k, cudaStream_t st) {
+    if (!s || !g || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
+    auto l = SizeGemm::ScaleConfig::tile_atom_to_shape_SFA(SizeGemm::shape(m,128,k));
+    int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
+    gate_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(const __nv_bfloat16*)g,
+                                          (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
 bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(128,n,k)) return false;
-    auto l = sfb_layout(128,n,k);
-    int blocks = (n * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
+    auto l = SizeGemm::ScaleConfig::tile_atom_to_shape_SFB(SizeGemm::shape(128,n,k));
+    int blocks = (n * (k / 16) + 7) / 8; if (blocks > 4096) blocks = 4096;
     quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
                                      (cutlass::float_ue4m3_t*)sf,n,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
@@ -130,9 +311,7 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
                                void* d,int m,int n,int k,void* ws,cudaStream_t st) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
-    Gemm gemm; auto ar = args(a,sa,b,sb,d,m,n,k);
-    return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
-           gemm.initialize(ar,ws,st) == cutlass::Status::kSuccess &&
-           gemm.run(st) == cutlass::Status::kSuccess;
+    if (use_narrow(n) && NarrowGemm::run(a, sa, b, sb, d, m, n, k, ws, st)) return true;
+    return WideGemm::run(a, sa, b, sb, d, m, n, k, ws, st);
 }
 } // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -14,6 +14,17 @@ size_t prefill_nvfp4_workspace_bytes(int m, int n, int k);
 
 bool launch_prefill_nvfp4_quant_a(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int m, int k, cudaStream_t stream = nullptr);
+// SwiGLU fused into the A-operand quantize: silu(gate) * up straight to FP4 + ue4m3 scales,
+// without ever writing the [m, k] product back as bf16. Rounds the product through bf16 first,
+// so it emits exactly what launch_prefill_swiglu + launch_prefill_nvfp4_quant_a would.
+bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_bf16,
+                                         void* dst_fp4, void* dst_sf,
+                                         int m, int k, cudaStream_t stream = nullptr);
+// Muse's attention gate fused into the A-operand quantize: x * sigmoid(g) straight to FP4, the
+// same fold launch_prefill_gate_quant_rows_i8 does for the int8 o-projection.
+bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf16,
+                                       void* dst_fp4, void* dst_sf,
+                                       int m, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -84,6 +84,8 @@ struct Qwen35LayerWeights {
     // unsupported shapes continue to use the GGUF-native pointers above.
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
+    const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
+    const void* wo_fp4 = nullptr;   const void* wo_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3996,11 +3996,62 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         void* tmp = nullptr;
         const size_t tmp_elems = (size_t)c.moe_ffn * H;
         bool ok = cudaMalloc(&tmp, tmp_elems * sizeof(bf16)) == cudaSuccess;
-        int ready = 0;
+        int ready = 0, down_ready = 0, wo_ready = 0;
+        const char* fp4_down_env = getenv("SPARKINFER_MUSE_NVFP4_DOWN");
+        bool down_fp4_on = (!fp4_down_env || fp4_down_env[0] != '0');
+        const char* fp4_wo_env = getenv("SPARKINFER_MUSE_NVFP4_WO");
+        bool wo_fp4_on = (!fp4_wo_env || fp4_wo_env[0] != '0');
+        // Converting until cudaMalloc fails is NOT a safe stopping rule. The batched prefill
+        // allocates its scratch arena (a ~266 MB dequant buffer plus the per-chunk FFN planes)
+        // at run time, AFTER load; if the conversions have taken the last of VRAM, that arena
+        // fails and prefill_batched_run bails to the token-loop path -- measured 112 pp against
+        // 6000+, i.e. a 50x regression, far worse than simply leaving a tensor on int8.
+        // So stop converting while a reserve still stands. Layers already converted keep their
+        // FP4 weights; the rest stay on the int8 path, which is exactly main's behaviour.
+        // SPARKINFER_MUSE_NVFP4_RESERVE_MB tunes the reserve (default 2048).
+        const size_t fp4_reserve_bytes = [] {
+            const char* e = getenv("SPARKINFER_MUSE_NVFP4_RESERVE_MB");
+            long long mb = e ? atoll(e) : 1536;
+            if (mb < 0) mb = 0;
+            return (size_t)mb << 20;
+        }();
+        auto fp4_budget_ok = [&](size_t need) {
+            size_t freeb = 0, totalb = 0;
+            if (cudaMemGetInfo(&freeb, &totalb) != cudaSuccess) return false;
+            return freeb > need + fp4_reserve_bytes;
+        };
+        // ...and the decision is all-or-nothing, taken up front for the WHOLE tensor set. A
+        // partial conversion is the worst outcome available: it spends the VRAM but leaves most
+        // layers on int8, and measured 5106 pp against main's 5896 under pressure -- a
+        // regression, where converting nothing at all is exactly main's behaviour and exactly
+        // main's speed. gate/up are excluded from the sum because their FP4 copy replaces a
+        // released Q4_K prefill copy of identical size (0.5625 B/value either way), so they are
+        // VRAM-neutral; down and wo are the ones that actually grow the footprint.
+        {
+            const size_t per_down = kernels::prefill_nvfp4_data_bytes(H, c.moe_ffn) +
+                                    kernels::prefill_nvfp4_scale_bytes_b(H, c.moe_ffn);
+            const size_t per_wo   = kernels::prefill_nvfp4_data_bytes(H, s.qdim) +
+                                    kernels::prefill_nvfp4_scale_bytes_b(H, s.qdim);
+            const size_t want = (size_t)c.n_layers *
+                                ((down_fp4_on ? per_down : 0) + (wo_fp4_on ? per_wo : 0));
+            if (want && !fp4_budget_ok(want)) {
+                size_t freeb = 0, totalb = 0; cudaMemGetInfo(&freeb, &totalb);
+                fprintf(stderr, "[prefill-muse] SM120 NVFP4 down/o-proj skipped: needs %.1f GB + "
+                                "%.1f GB reserve, %.1f GB free -- staying on the int8 path\n",
+                        (double)want / 1e9, (double)fp4_reserve_bytes / 1e9, (double)freeb / 1e9);
+                down_fp4_on = wo_fp4_on = false;
+            }
+        }
         auto convert = [&](const void* src, int qtype, int rows, int cols,
                            const void** data, const void** sf) -> bool {
+            // NOTE: deliberately NOT budget-checked. gate/up are VRAM-neutral -- their FP4 copy
+            // replaces a released Q4_K prefill copy of exactly the same 0.5625 B/value -- so
+            // refusing them buys nothing and costs the gate/up FP4 path outright (measured 4725 pp
+            // against main's 5896 when a budget check blocked them). Only down and wo grow the
+            // footprint, and those are gated all-or-nothing above, before any conversion runs.
             void *d = nullptr, *scale = nullptr;
-            if (!src || cudaMalloc(&d, kernels::prefill_nvfp4_data_bytes(rows, cols)) != cudaSuccess)
+            if (!src) return false;
+            if (cudaMalloc(&d, kernels::prefill_nvfp4_data_bytes(rows, cols)) != cudaSuccess)
                 return false;
             if (cudaMalloc(&scale, kernels::prefill_nvfp4_scale_bytes_b(rows, cols)) != cudaSuccess) {
                 cudaFree(d); return false;
@@ -4032,10 +4083,38 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 release_prefill_copy(lw.prefill_up_q, lw.up_q);
                 ++ready;
             }
+            // ffn_down [H, ffn] is the single largest prefill kernel (27.5% of the step): its
+            // int8 arm split-K's 13 ways over a 104-tile grid and still costs 119 us a layer
+            // against 74 us for the block-scaled FP4 GEMM on the narrow tile. Unlike gate/up
+            // there is no separate prefill copy to release -- decode reads this same Q4_K
+            // tensor -- so the FP4 copy is a genuine +0.5625 B/value. Converted last and
+            // independently: if it does not fit, gate/up keep theirs and prefill falls back to
+            // the int8 down. SPARKINFER_MUSE_NVFP4_DOWN=0 disables it.
+            if (ok && down_fp4_on) {
+                if (convert(lw.down_q, lw.down_qtype, H, c.moe_ffn, &lw.down_fp4, &lw.down_fp4_sf))
+                    ++down_ready;
+                else
+                    lw.down_fp4 = lw.down_fp4_sf = nullptr;
+            }
+            // The o projection [H, qdim] is the other shape the narrow tile serves well. Like
+            // down it has no separate prefill copy to release, so it is a real +0.5625 B/value,
+            // and like down it is converted independently: a failure here leaves the int8 o
+            // projection in place without disturbing gate/up or down.
+            // SPARKINFER_MUSE_NVFP4_WO=0 disables it.
+            if (ok && wo_fp4_on && lw.wo) {
+                if (convert(lw.wo, lw.wo_type, H, s.qdim, &lw.wo_fp4, &lw.wo_fp4_sf))
+                    ++wo_ready;
+                else
+                    lw.wo_fp4 = lw.wo_fp4_sf = nullptr;
+            }
         }
         if (tmp) cudaFree(tmp);
         fprintf(stderr, "[prefill-muse] SM120 NVFP4 FFN weights ready: %d/%d layers%s\n",
                 ready, c.n_layers, ok ? "" : " (remaining layers use GGUF fallback)");
+        fprintf(stderr, "[prefill-muse] SM120 NVFP4 ffn_down weights ready: %d/%d layers\n",
+                down_ready, c.n_layers);
+        fprintf(stderr, "[prefill-muse] SM120 NVFP4 o-proj weights ready: %d/%d layers\n",
+                wo_ready, c.n_layers);
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -367,20 +367,38 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool mg_sk = sk_p != nullptr;
 
     // Native block-scaled FP4 is deliberately narrow: Muse, the scored M=128 shape, and layers
-    // whose eager conversion completed. One activation buffer is shared by gate/up. Down stays on
-    // the higher-fidelity #808 quantized path because its error enters the residual directly.
+    // whose eager conversion completed. One activation buffer is shared by gate/up; the down
+    // projection needs its own, ffn-wide one because its A operand is the SwiGLU output.
     const bool muse_nvfp4 = c.muse_glimmer && N == 128 && !s.w.layers.empty() &&
                             s.w.layers[0].gate_fp4 &&
                             kernels::prefill_nvfp4_supported(N, ffn, H);
+    const bool muse_nvfp4_down = muse_nvfp4 && s.w.layers[0].down_fp4 &&
+                                 kernels::prefill_nvfp4_supported(N, H, ffn);
     const size_t fp4_a_data_bytes = muse_nvfp4
         ? kernels::prefill_nvfp4_data_bytes(N, H) : 0;
     const size_t fp4_a_sf_bytes = muse_nvfp4
         ? kernels::prefill_nvfp4_scale_bytes_a(N, H) : 0;
+    // One arena serves both GEMM shapes; take the larger of the two workspaces.
     const size_t fp4_ws_bytes = muse_nvfp4
-        ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
+        ? std::max(std::max(kernels::prefill_nvfp4_workspace_bytes(N, ffn, H),
+                            muse_nvfp4_down ? kernels::prefill_nvfp4_workspace_bytes(N, H, ffn)
+                                            : (size_t)0),
+                   kernels::prefill_nvfp4_supported(N, H, qdim)
+                       ? kernels::prefill_nvfp4_workspace_bytes(N, H, qdim) : (size_t)0)
+        : 0;
+    const size_t fp4_da_data_bytes = muse_nvfp4_down
+        ? kernels::prefill_nvfp4_data_bytes(N, ffn) : 0;
+    const size_t fp4_da_sf_bytes = muse_nvfp4_down
+        ? kernels::prefill_nvfp4_scale_bytes_a(N, ffn) : 0;
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
+    unsigned char* fp4_da = muse_nvfp4_down ? a8.alloc<unsigned char>(fp4_da_data_bytes) : nullptr;
+    unsigned char* fp4_das = muse_nvfp4_down ? a8.alloc<unsigned char>(fp4_da_sf_bytes) : nullptr;
+    // The o projection reuses the down leg's A buffers: qdim < ffn, so [N, qdim] fits inside the
+    // [N, ffn] allocation, and the two never overlap in a layer (o proj runs before the FFN).
+    const bool muse_nvfp4_wo = muse_nvfp4_down && !s.w.layers.empty() && s.w.layers[0].wo_fp4 &&
+                               kernels::prefill_nvfp4_supported(N, H, qdim);
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -879,8 +897,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // written back as bf16 and never re-read, and one launch per layer goes away.
             // Bit-identical; only taken when the o projection is certain to use A_i8 (otherwise
             // proj() would read the un-gated `att`).
+            //
+            // The block-scaled o projection folds the gate into its OWN quantize, so it is tried
+            // first and the int8 fold is skipped when it succeeds. Every arm therefore consumes a
+            // gated activation and nothing reads the raw `att`. That invariant is exactly what the
+            // reverted #816 broke -- it quantized `att` for FP4 while the gate rode along inside
+            // the int8 quantize, dropping the gate on every layer (KL 0.489 against 0.0114).
+            const bool wo_fp4_gated = muse_nvfp4_wo && w.wo_fp4 && w.wo_fp4_sf &&
+                fp4_da && fp4_das &&
+                kernels::launch_prefill_nvfp4_gate_quant_a(att, qg, fp4_da, fp4_das, N, qdim, st);
+            // ...and if the GEMM then declines, `att` is still raw, so gate it before the int8 arm.
+            const bool wo_fp4_done = wo_fp4_gated && c.muse_glimmer &&
+                kernels::launch_prefill_nvfp4_gemm(fp4_da, fp4_das, w.wo_fp4, w.wo_fp4_sf,
+                                                   ao, N, H, qdim, fp4_ws, st);
             bool gate_fused = false;
-            if (c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
+            if (!wo_fp4_gated &&
+                c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
                 kernels::pf_dense_gemm_qi8_supported(w.wo_type) &&
                 kernels::launch_prefill_gate_quant_rows_i8(att, qg, A_i8, sx, N, qdim, st,
                                                            A_i8p)) {
@@ -888,11 +920,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 a_pk = A_i8p != nullptr;
                 gate_fused = true;
             }
-            if (!gate_fused) kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
+            if (!gate_fused && !wo_fp4_done)
+                kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
-                // add happens in launch_norm_then_add below.
-                proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
+                // add happens in launch_norm_then_add below. The FP4 GEMM already wrote `ao` as
+                // bf16 and left attn_acc at 0, so the plain norm_then_add tail consumes it.
+                if (!wo_fp4_done)
+                    proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
             } else {
                 attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
@@ -971,9 +1006,23 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4, w.up_fp4_sf,
                                                        ffu, fn, ffn, H, fp4_ws, st);
                 if (layer_fp4) {
-                    kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                    proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
-                                   ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
+                    // ffn_down on the same block-scaled path, with the SwiGLU folded into its
+                    // A-operand quantize so the [fn, ffn] product is never written back as bf16.
+                    // Leaves ffn_acc at 0: the FP4 GEMM writes bf16 straight into `ao`, so the
+                    // post-FFN sandwich norm takes its plain (non-accumulator) arm, exactly as
+                    // the bf16 fallback below does.
+                    const bool down_fp4 = muse_nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
+                        fp4_da && fp4_das &&
+                        kernels::launch_prefill_nvfp4_swiglu_quant_a(ffg, ffu, fp4_da, fp4_das,
+                                                                     fn, ffn, st) &&
+                        kernels::launch_prefill_nvfp4_gemm(fp4_da, fp4_das, w.down_fp4,
+                                                           w.down_fp4_sf, ao + (size_t)fo * H,
+                                                           fn, H, ffn, fp4_ws, st);
+                    if (!down_fp4) {
+                        kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                        proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
+                                       ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
+                    }
                     continue;
                 }
                 if (ffn_i8) {


### PR DESCRIPTION
## Summary

#810/#813 built the SM120 block-scaled NVFP4 prefill path for the FFN gate/up projections. This PR extends it to **`ffn_down`** and the **o-projection**, and makes two changes the extension needs to actually pay off:

1. **A shape-adaptive CTA tile.** At M=128 the grid is `1 × ceil(N/TileN)`, so the tile alone decides machine coverage and mainloop depth. The shipped `128x128x128` is tuned for gate/up (N=19968); `ffn_down` and `wo` (N=6656) launch a third as many CTAs and run at half the DRAM throughput for the same bytes. The lever is **K depth, not N width** — a 256-deep K step is worth −16% on `ffn_down` — with N halved only once the wide tile stops covering the machine.
2. **The activation producers folded into their FP4 quantizes.** SwiGLU into the `ffn_down` operand, and Muse's attention gate into the o-projection operand, so neither product is written back as bf16 just to be read again by a quantizer.

Both tiles read the same weights: the GMEM block-scale layout comes from `Sm1xxBlockScaledConfig<SFVecSize>`, a function of `SFVecSize` and the problem shape only — the CTA tile appears solely in the smem layouts. Every tile variant returns a bitwise-identical result.

`SPARKINFER_MUSE_NVFP4_DOWN=0`, `SPARKINFER_MUSE_NVFP4_WO=0` and
`SPARKINFER_MUSE_NVFP4_TILE=wide|narrow` restore the previous behaviour, so every arm below comes out of one binary. Per-layer conversion failure falls back to the int8 path on its own.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (ctx=0 — prefill-only PR; shown to demonstrate no regression):

| | decode tok/s |
|---|--:|
| before (main) | 103.09 |
| after (this PR) | 102.98 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128 — the scored prefill shape):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 6181.12 |
| after prefill (this PR) | 7470.98 |

**+20.9% prefill@128**, median of 3 alternating pairs, main `593bab0`, two trees built from scratch, base re-sampled between every arm, 5 reps per process.

```text
main p1 | {"0":{"decode_tps":103.6034},"128":{"decode_tps":102.4121,"prefill_pp":6246.7869}} | VRAM 25.5 GB
PR   p1 | {"0":{"decode_tps":103.3180},"128":{"decode_tps":102.1085,"prefill_pp":7506.4821}} | VRAM 30.3 GB
main p2 | {"0":{"decode_tps":103.0925},"128":{"decode_tps":101.8316,"prefill_pp":6179.2115}} | VRAM 25.5 GB
PR   p2 | {"0":{"decode_tps":102.9799},"128":{"decode_tps":101.8125,"prefill_pp":7469.7674}} | VRAM 30.3 GB
main p3 | {"0":{"decode_tps":102.9374},"128":{"decode_tps":101.7943,"prefill_pp":6181.1200}} | VRAM 25.5 GB
PR   p3 | {"0":{"decode_tps":102.8309},"128":{"decode_tps":101.6152,"prefill_pp":7470.9786}} | VRAM 30.3 GB
```

| pair | main | this PR | delta |
|---|--:|--:|--:|
| p1 | 6246.79 | 7506.48 | +20.16% |
| p2 | 6179.21 | 7469.77 | +20.88% |
| p3 | 6181.12 | 7470.98 | +20.87% |

`SPARKINFER_MUSE_NVFP4_WO=0` gives 7139.07 (+15.5%), so the o-projection leg is +4.65 points of it.

## Accuracy

`qwen3_gguf_prefill_check <gguf> 128 512`, `SPARKINFER_KV_INT8=0`:

| | TOP1 | KL |
|---|--:|--:|
| main `593bab0` | 474/512 = 0.9258 | 0.01309 |
| this PR | **482/512 = 0.9414** | 0.01315 |

Better top1, KL at parity, with two more tensors on FP4.

### Why the o-projection is safe here, given #816 was reverted for it

#819 reverted #816 for breaking batched prefill accuracy. The cause is the FP4 o-projection reading an **un-gated `att`**: `launch_prefill_gate_quant_rows_i8` folds Muse's attention gate into the *int8* row-quantize and deliberately leaves `att` raw (its comment says so), so an FP4 leg that quantizes `att` itself drops the gate on every layer. Bisected on `0308e10`:

| main config | TOP1 @512 | KL |
|---|--:|--:|
| all FP4 off (int8 reference) | 490/512 = 0.9570 | 0.00801 |
| `SPARKINFER_MUSE_NVFP4_WO=0` | 486/512 = 0.9492 | 0.01135 |
| #816 default | **235/512 = 0.4590** | **0.48888** |

This PR folds the gate into the FP4 quantize itself, so no path ever reads a raw `att` — same two tensors, **KL 0.0132 instead of 0.489**.

Worth flagging: the scored accuracy gate cannot catch this class of bug. `qwen3_gguf_score` runs the AR decode path and its dump is byte-identical either way; only `qwen3_gguf_prefill_check` sees it.

## Cost and risk

- VRAM 25.5 → 30.3 GB. Neither `ffn_down` nor `wo` has a separate prefill copy to release (decode reads the same tensors), so each FP4 copy is a real +0.5625 B/value. Fits a 32 GB card, and a conversion that doesn't fit degrades to the int8 path rather than failing.
- Muse-only: every path is behind `c.muse_glimmer` plus the existing FP4 gates. Qwen3.6 never reaches `launch_prefill_nvfp4_*`.
- **Qwen3.6 no-regression guard** (ctx 0/512/4k/16k/32k, both trees): worst ratio **0.9998** against the 0.98 floor — every context at or above parity.
- Also measured and left out: grouped q/gate/k/v on FP4 is a win in isolation but costs +1.7 GB, which does not fit alongside the above.
