### PR TITLE
perf(muse-glimmer): NVFP4 ffn_down prefill leg (fixed #816) + finer FP4 CTA tile (1.12x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -1,5 +1,6 @@
 #include "sparkinfer/kernels/prefill_nvfp4.h"
 
+#include <cstdlib>
 #include <cuda_bf16.h>
 #include <cutlass/cutlass.h>
 #include <cutlass/float_subbyte.h>
@@ -16,32 +17,55 @@ namespace {
 using namespace cute;
 using E4 = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
 using BF = cutlass::bfloat16_t;
-using Tile = Shape<_128, _128, _128>;
 using Cluster = Shape<_1, _1, _1>;
-using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, Tile, Cluster,
-    cutlass::epilogue::collective::EpilogueTileAuto, float, float,
-    BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
-    cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
-using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
-    E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
-    Tile, Cluster,
-    cutlass::gemm::collective::StageCountAutoCarveout<
-        static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
-    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
-using Kernel = cutlass::gemm::kernel::GemmUniversal<
-    Shape<int, int, int, int>, Mainloop, Epilogue, void>;
-using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+
+// The GEMM stack, parameterized on the CTA tile. At m == 128 rows there is one M-tile, so
+// CTAs = n/TILE_N: with the 128-wide tile the two hidden-output GEMMs (ffn_down, wo; n=6656)
+// launch 52 CTAs on a 170-SM part and stream their weights at ~1.06 TB/s, and even gate/up's
+// 156 CTAs are one incomplete wave at 1.24. The 64-wide tile doubles the CTAs in flight and
+// measured faster for every shape this path serves. The scale-factor layout atoms come from
+// the UMMA blockscaled format (Sm1xxBlkScaledConfig), not the CTA tile, so both variants read
+// the same packed A/B scale buffers -- asserted below.
+template <int TILE_N>
+struct FP4Stack {
+    using Tile = Shape<_128, Int<TILE_N>, _128>;
+    using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, Tile, Cluster,
+        cutlass::epilogue::collective::EpilogueTileAuto, float, float,
+        BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+    using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+        E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
+        Tile, Cluster,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+    using Kernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, Mainloop, Epilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+    using ScaleConfig = typename Mainloop::Sm1xxBlkScaledConfig;
+};
+using Wide = FP4Stack<128>;
+using Skinny = FP4Stack<64>;
+using Kernel = Wide::Kernel;
+using Gemm = Wide::Gemm;
 using StrideA = typename Kernel::StrideA;
 using StrideB = typename Kernel::StrideB;
 using StrideC = typename Kernel::StrideC;
 using StrideD = typename Kernel::StrideD;
-using ScaleConfig = typename Mainloop::Sm1xxBlkScaledConfig;
+using ScaleConfig = typename Wide::Mainloop::Sm1xxBlkScaledConfig;
 
 auto shape(int m, int n, int k) { return cute::make_shape(m, n, k, 1); }
 auto sfa_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFA(shape(m,n,k)); }
 auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFB(shape(m,n,k)); }
+// Both tile variants must agree on the packed scale buffer layouts, or the skinny variant
+// would read scales packed for the wide one.
+static_assert(std::is_same_v<decltype(Wide::ScaleConfig::tile_atom_to_shape_SFA(
+                                 cute::make_shape(1, 1, 1, 1))),
+                             decltype(Skinny::ScaleConfig::tile_atom_to_shape_SFA(
+                                 cute::make_shape(1, 1, 1, 1)))>,
+              "scale-factor layouts diverge across tile variants");
 
 template <class Layout>
 __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
@@ -82,15 +106,28 @@ __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
     }
 }
 
-Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
-                     void* d, int m, int n, int k) {
-    auto as = cutlass::make_cute_packed_stride(StrideA{}, {m,k,1});
-    auto bs = cutlass::make_cute_packed_stride(StrideB{}, {n,k,1});
-    auto cs = cutlass::make_cute_packed_stride(StrideC{}, {m,n,1});
-    auto ds = cutlass::make_cute_packed_stride(StrideD{}, {m,n,1});
+template <class S>
+typename S::Gemm::Arguments args_t(const void* a, const void* sa, const void* b, const void* sb,
+                                   void* d, int m, int n, int k) {
+    auto as = cutlass::make_cute_packed_stride(typename S::Kernel::StrideA{}, {m,k,1});
+    auto bs = cutlass::make_cute_packed_stride(typename S::Kernel::StrideB{}, {n,k,1});
+    auto cs = cutlass::make_cute_packed_stride(typename S::Kernel::StrideC{}, {m,n,1});
+    auto ds = cutlass::make_cute_packed_stride(typename S::Kernel::StrideD{}, {m,n,1});
     return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m,n,k),
             {static_cast<const cutlass::float_e2m1_t*>(a), as, static_cast<const cutlass::float_e2m1_t*>(b), bs, static_cast<const cutlass::float_ue4m3_t*>(sa), sfa_layout(m,n,k), static_cast<const cutlass::float_ue4m3_t*>(sb), sfb_layout(m,n,k)},
             {{1.f, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
+}
+Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
+                     void* d, int m, int n, int k) {
+    return args_t<Wide>(a, sa, b, sb, d, m, n, k);
+}
+template <class S>
+bool run_gemm(const void* a, const void* sa, const void* b, const void* sb,
+              void* d, int m, int n, int k, void* ws, cudaStream_t st) {
+    typename S::Gemm gemm; auto ar = args_t<S>(a,sa,b,sb,d,m,n,k);
+    return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
+           gemm.initialize(ar,ws,st) == cutlass::Status::kSuccess &&
+           gemm.run(st) == cutlass::Status::kSuccess;
 }
 } // namespace
 
@@ -109,7 +146,10 @@ size_t prefill_nvfp4_scale_bytes_b(int n, int k) {
     return (size_t)cute::size(cute::filter_zeros(sfb_layout(128,n,k)));
 }
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
-    return Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    const size_t w = Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    const size_t s = Skinny::Gemm::get_workspace_size(
+        args_t<Skinny>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    return w > s ? w : s;
 }
 bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
@@ -130,9 +170,17 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
                                void* d,int m,int n,int k,void* ws,cudaStream_t st) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
-    Gemm gemm; auto ar = args(a,sa,b,sb,d,m,n,k);
-    return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
-           gemm.initialize(ar,ws,st) == cutlass::Status::kSuccess &&
-           gemm.run(st) == cutlass::Status::kSuccess;
+    // At m = 128 rows one M-tile is all there is, so CTAs = n / TILE_N: the 128-wide tile
+    // put 52 CTAs on 170 SMs for the hidden-output GEMMs (ffn_down, wo) and one incomplete
+    // 156-CTA wave for gate/up. The 64-wide tile doubles both -- measured faster for every
+    // shape this path serves, so it is the default; SPARKINFER_MUSE_NVFP4_SKINNY sets an
+    // n threshold above which the 128-wide tile returns (0 restores it everywhere).
+    static int sk = -1;
+    if (sk < 0) {
+        const char* e = getenv("SPARKINFER_MUSE_NVFP4_SKINNY");
+        sk = e ? atoi(e) : 1 << 30;
+    }
+    if (n <= sk) return run_gemm<Skinny>(a,sa,b,sb,d,m,n,k,ws,st);
+    return run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
 }
 } // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -26,9 +26,9 @@ using Cluster = Shape<_1, _1, _1>;
 // measured faster for every shape this path serves. The scale-factor layout atoms come from
 // the UMMA blockscaled format (Sm1xxBlkScaledConfig), not the CTA tile, so both variants read
 // the same packed A/B scale buffers -- asserted below.
-template <int TILE_N>
+template <int TILE_N, int TILE_K = 128>
 struct FP4Stack {
-    using Tile = Shape<_128, Int<TILE_N>, _128>;
+    using Tile = Shape<_128, Int<TILE_N>, Int<TILE_K>>;
     using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
         cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, Tile, Cluster,
         cutlass::epilogue::collective::EpilogueTileAuto, float, float,
@@ -48,6 +48,10 @@ struct FP4Stack {
 };
 using Wide = FP4Stack<128>;
 using Skinny = FP4Stack<64>;
+// 256-deep K tile: fewer mainloop trips and longer contiguous weight reads per CTA;
+// measured additive on top of the 64-wide tile. Shipped default; K=128 stays for the env A/B.
+using SkinnyK256 = FP4Stack<64, 256>;
+using WideK256 = FP4Stack<128, 256>;
 using Kernel = Wide::Kernel;
 using Gemm = Wide::Gemm;
 using StrideA = typename Kernel::StrideA;
@@ -64,6 +68,14 @@ auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SF
 static_assert(std::is_same_v<decltype(Wide::ScaleConfig::tile_atom_to_shape_SFA(
                                  cute::make_shape(1, 1, 1, 1))),
                              decltype(Skinny::ScaleConfig::tile_atom_to_shape_SFA(
+                                 cute::make_shape(1, 1, 1, 1)))> &&
+              std::is_same_v<decltype(Wide::ScaleConfig::tile_atom_to_shape_SFA(
+                                 cute::make_shape(1, 1, 1, 1))),
+                             decltype(SkinnyK256::ScaleConfig::tile_atom_to_shape_SFA(
+                                 cute::make_shape(1, 1, 1, 1)))> &&
+              std::is_same_v<decltype(Wide::ScaleConfig::tile_atom_to_shape_SFA(
+                                 cute::make_shape(1, 1, 1, 1))),
+                             decltype(WideK256::ScaleConfig::tile_atom_to_shape_SFA(
                                  cute::make_shape(1, 1, 1, 1)))>,
               "scale-factor layouts diverge across tile variants");
 
@@ -146,10 +158,13 @@ size_t prefill_nvfp4_scale_bytes_b(int n, int k) {
     return (size_t)cute::size(cute::filter_zeros(sfb_layout(128,n,k)));
 }
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
-    const size_t w = Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
-    const size_t s = Skinny::Gemm::get_workspace_size(
-        args_t<Skinny>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
-    return w > s ? w : s;
+    size_t r = Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    const size_t cand[3] = {
+        Skinny::Gemm::get_workspace_size(args_t<Skinny>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k)),
+        SkinnyK256::Gemm::get_workspace_size(args_t<SkinnyK256>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k)),
+        WideK256::Gemm::get_workspace_size(args_t<WideK256>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k))};
+    for (size_t c : cand) if (c > r) r = c;
+    return r;
 }
 bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
@@ -180,7 +195,13 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
         const char* e = getenv("SPARKINFER_MUSE_NVFP4_SKINNY");
         sk = e ? atoi(e) : 1 << 30;
     }
-    if (n <= sk) return run_gemm<Skinny>(a,sa,b,sb,d,m,n,k,ws,st);
-    return run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
+    // 256-deep K tile: fewer mainloop trips, longer contiguous weight reads per CTA --
+    // measured +0.8% on top of the 64-wide tile, output bit-identical. =0 restores K=128.
+    static int k256 = -1;
+    if (k256 < 0) { const char* e = getenv("SPARKINFER_MUSE_NVFP4_K256"); k256 = (e && e[0]=='0') ? 0 : 1; }
+    if (n <= sk) return k256 ? run_gemm<SkinnyK256>(a,sa,b,sb,d,m,n,k,ws,st)
+                             : run_gemm<Skinny>(a,sa,b,sb,d,m,n,k,ws,st);
+    return k256 ? run_gemm<WideK256>(a,sa,b,sb,d,m,n,k,ws,st)
+                : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
 }
 } // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -46,12 +46,12 @@ struct FP4Stack {
     using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
     using ScaleConfig = typename Mainloop::Sm1xxBlkScaledConfig;
 };
-using Wide = FP4Stack<128>;
-using Skinny = FP4Stack<64>;
-// 256-deep K tile: fewer mainloop trips and longer contiguous weight reads per CTA;
-// measured additive on top of the 64-wide tile. Shipped default; K=128 stays for the env A/B.
-using SkinnyK256 = FP4Stack<64, 256>;
-using WideK256 = FP4Stack<128, 256>;
+// Exactly two instantiations: the shipped tile (main's 128x128x128) and this PR's
+// 128x64x256. Each is a full CUTLASS blockscaled GEMM, so extra variants cost real
+// compile time in this translation unit for no runtime benefit -- the intermediate
+// shapes were tuning arms and are gone.
+using Wide = FP4Stack<128, 128>;
+using Skinny = FP4Stack<64, 256>;
 using Kernel = Wide::Kernel;
 using Gemm = Wide::Gemm;
 using StrideA = typename Kernel::StrideA;
@@ -68,14 +68,6 @@ auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SF
 static_assert(std::is_same_v<decltype(Wide::ScaleConfig::tile_atom_to_shape_SFA(
                                  cute::make_shape(1, 1, 1, 1))),
                              decltype(Skinny::ScaleConfig::tile_atom_to_shape_SFA(
-                                 cute::make_shape(1, 1, 1, 1)))> &&
-              std::is_same_v<decltype(Wide::ScaleConfig::tile_atom_to_shape_SFA(
-                                 cute::make_shape(1, 1, 1, 1))),
-                             decltype(SkinnyK256::ScaleConfig::tile_atom_to_shape_SFA(
-                                 cute::make_shape(1, 1, 1, 1)))> &&
-              std::is_same_v<decltype(Wide::ScaleConfig::tile_atom_to_shape_SFA(
-                                 cute::make_shape(1, 1, 1, 1))),
-                             decltype(WideK256::ScaleConfig::tile_atom_to_shape_SFA(
                                  cute::make_shape(1, 1, 1, 1)))>,
               "scale-factor layouts diverge across tile variants");
 
@@ -159,11 +151,9 @@ size_t prefill_nvfp4_scale_bytes_b(int n, int k) {
 }
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
     size_t r = Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
-    const size_t cand[3] = {
-        Skinny::Gemm::get_workspace_size(args_t<Skinny>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k)),
-        SkinnyK256::Gemm::get_workspace_size(args_t<SkinnyK256>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k)),
-        WideK256::Gemm::get_workspace_size(args_t<WideK256>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k))};
-    for (size_t c : cand) if (c > r) r = c;
+    const size_t sk = Skinny::Gemm::get_workspace_size(
+        args_t<Skinny>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    if (sk > r) r = sk;
     return r;
 }
 bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k, cudaStream_t st) {
@@ -185,23 +175,17 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
                                void* d,int m,int n,int k,void* ws,cudaStream_t st) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
-    // At m = 128 rows one M-tile is all there is, so CTAs = n / TILE_N: the 128-wide tile
-    // put 52 CTAs on 170 SMs for the hidden-output GEMMs (ffn_down, wo) and one incomplete
-    // 156-CTA wave for gate/up. The 64-wide tile doubles both -- measured faster for every
-    // shape this path serves, so it is the default; SPARKINFER_MUSE_NVFP4_SKINNY sets an
-    // n threshold above which the 128-wide tile returns (0 restores it everywhere).
+    // At m = 128 rows one M-tile is all there is, so CTAs = n / TILE_N: the shipped 128-wide
+    // tile puts 52 CTAs on 170 SMs for the hidden-output GEMM and one incomplete 156-CTA wave
+    // for gate/up. 128x64x256 doubles the CTAs and halves the mainloop trips, and measured
+    // faster for every shape this path serves. SPARKINFER_MUSE_NVFP4_SKINNY=0 restores the
+    // shipped tile (n above the threshold also falls back to it).
     static int sk = -1;
     if (sk < 0) {
         const char* e = getenv("SPARKINFER_MUSE_NVFP4_SKINNY");
         sk = e ? atoi(e) : 1 << 30;
     }
-    // 256-deep K tile: fewer mainloop trips, longer contiguous weight reads per CTA --
-    // measured +0.8% on top of the 64-wide tile, output bit-identical. =0 restores K=128.
-    static int k256 = -1;
-    if (k256 < 0) { const char* e = getenv("SPARKINFER_MUSE_NVFP4_K256"); k256 = (e && e[0]=='0') ? 0 : 1; }
-    if (n <= sk) return k256 ? run_gemm<SkinnyK256>(a,sa,b,sb,d,m,n,k,ws,st)
-                             : run_gemm<Skinny>(a,sa,b,sb,d,m,n,k,ws,st);
-    return k256 ? run_gemm<WideK256>(a,sa,b,sb,d,m,n,k,ws,st)
-                : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
+    if (n <= sk) return run_gemm<Skinny>(a,sa,b,sb,d,m,n,k,ws,st);
+    return run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
 }
 } // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -83,6 +83,7 @@ struct Qwen35LayerWeights {
     // Optional SM120-native NVFP4 copies used only by Muse batched prefill. Decode and all
     // unsupported shapes continue to use the GGUF-native pointers above.
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
+    const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4027,6 +4027,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const int ut = lw.prefill_up_q ? lw.prefill_up_qtype : lw.up_qtype;
             ok = convert(g, gt, c.moe_ffn, H, &lw.gate_fp4, &lw.gate_fp4_sf) &&
                  convert(u, ut, c.moe_ffn, H, &lw.up_fp4, &lw.up_fp4_sf);
+            // ffn_down too: same block-scaled format, [H rows, ffn cols]. #810/#813 stopped at
+            // gate/up; down passes the same shape gate (6656 %128, 19968 %128) and its input is
+            // the SwiGLU output this path already materializes as bf16. SPARKINFER_MUSE_NVFP4_DOWN=0
+            // keeps the shipped int8 down for A/B.
+            static const bool dn_on = [] {
+                const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN");
+                return !(e && e[0] == '0');
+            }();
+            if (ok && dn_on)
+                ok = convert(lw.down_q, lw.down_qtype, H, c.moe_ffn, &lw.down_fp4, &lw.down_fp4_sf);
             if (ok) {
                 release_prefill_copy(lw.prefill_gate_q, lw.gate_q);
                 release_prefill_copy(lw.prefill_up_q, lw.up_q);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -381,6 +381,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
+    // Down-projection FP4 leg: the A operand is the SwiGLU output (k = ffn, not H), so it needs
+    // its own quant buffers and workspace. Only allocated when the load-time conversion produced
+    // down_fp4 weights (SPARKINFER_MUSE_NVFP4_DOWN=0 keeps these null).
+    const bool muse_nvfp4_dn = muse_nvfp4 && s.w.layers[0].down_fp4 &&
+                               kernels::prefill_nvfp4_supported(N, H, ffn);
+    unsigned char* fp4_a2 = muse_nvfp4_dn
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
+    unsigned char* fp4_as2 = muse_nvfp4_dn
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, ffn)) : nullptr;
+    unsigned char* fp4_ws2 = muse_nvfp4_dn
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_workspace_bytes(N, H, ffn)) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -892,6 +903,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
                 // add happens in launch_norm_then_add below.
+                // FP4 o-projection: att is bf16 here; one quant (k = qdim) + one block-scaled
                 proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
             } else {
@@ -972,6 +984,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                        ffu, fn, ffn, H, fp4_ws, st);
                 if (layer_fp4) {
                     kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                    // FP4 down leg: quantize the SwiGLU output once and hit the same block-scaled
+                    // GEMM. Writes ao directly (chunks are disjoint), leaving ffn_acc unset so the
+                    // plain norm_then_add tail consumes it. Falls back to the int8 down on any
+                    // launch failure, exactly like the gate/up legs above.
+                    if (muse_nvfp4_dn && w.down_fp4 && w.down_fp4_sf &&
+                        kernels::launch_prefill_nvfp4_quant_a(ffg, fp4_a2, fp4_as2, fn, ffn, st) &&
+                        kernels::launch_prefill_nvfp4_gemm(fp4_a2, fp4_as2, w.down_fp4,
+                                                           w.down_fp4_sf, ao + (size_t)fo * H,
+                                                           fn, H, ffn, fp4_ws2, st)) {
+                        continue;
+                    }
                     proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                    ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     continue;


### PR DESCRIPTION
## Summary

The fixed resubmit of #816, which #819 reverted for breaking batched prefill accuracy, together with finer CTA tiles for the FP4 GEMMs it feeds. #816 shipped **two** NVFP4 legs — `ffn_down` and the o-projection (`wo`). Isolated on a 5090, the defect is entirely the o-projection: **`ffn_down` alone clears the accuracy gate, `wo` destroys it.** This restores only the `ffn_down` leg and drops `wo`. 1.12x prefill@128, decode untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 104.92 |
| after (this PR) | 104.85 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 6666.9 |
| after prefill (this PR) | 7455.2 |

```text
# One binary, arms env-flipped (SPARKINFER_MUSE_NVFP4_DOWN=0 SKINNY=0 == main's dispatch),
# SWEEP_REPS=9 so the median sits in #800's prefill-graph replay regime.
# RTX 5090, main @ 593bab0. B = main, T = this PR. prefill@128:
B: 6721 6643 6637        mean 6666.9
T: 7473 7461 7432        mean 7455.2   (+11.82%)
# earlier run of the same change, 4/4 interleaved: 6774.2 -> 7523.6 (+11.06%)
# decode unchanged: 104.92 -> 104.85
```

## Why #816 broke, and what changed

`qwen3_gguf_prefill_check` is the gate for this path, and it is easy to mis-run: Muse Glimmer's
batched prefill refuses an int8 KV cache, so the tool's default prints
`[FAIL] prefill_batched unsupported (seed=-1)` and looks broken. It needs
**`SPARKINFER_KV_INT8=0`**. With that set, one leg toggled at a time (same binary, `P=128`,
16 continuation positions):

| configuration | TOP1 | KL |
|---|--:|--:|
| reference (no FP4 legs) | 15/16 | 0.06349 |
| **`ffn_down` leg only** | **14/16** | **0.05623** |
| `ffn_down` + `wo` (i.e. #816) | 2/16 | 4.56426 |

Those last two rows differ by the o-projection alone, so the o-projection carries the defect —
KL 4.6 is not quantization error, it is a wrong result. It is removed here, along with its
weight conversion, its `wo_fp4`/`wo_fp4_sf` pointers and its dead buffers. The `ffn_down` leg
sits at or below the reference's own divergence from the token-by-token path.

Verification for this PR as submitted:

```text
prefill_check, SPARKINFER_KV_INT8=0, RTX 5090
  P=128 cont=64   PR: TOP1 58/64  KL 0.04554   |  ref: TOP1 58/64  KL 0.04732
  P=128 cont=16   PR: TOP1 14/16  KL 0.05623   |  ref: TOP1 15/16  KL 0.06349
  P=512 cont=16   PR: TOP1 16/16  KL 0.00815   |  ref: TOP1 16/16  KL 0.00815   (identical;
                                                   the FP4 path engages only at N=128)
```

Over 64 continuation positions the top-1 agreement is **identical** to the reference and the KL
is marginally lower; the single top-1 difference in the 16-position run is one near-tie flipping,
which the wider sample resolves. Mixed-context sweep (512, 4096 x 2) clean.

## The tiles, and why they belong with this leg

At m = 128 rows the tile grid is a single M-row, so CTAs = n/TileN. With the shipped
128x128x128 tile the hidden-output GEMM this leg adds (n = 6656) launches **52 CTAs on 170 SMs**
and streams weights at 1.06 TB/s, against gate/up's 156 CTAs at 1.24 (peak 1.79). A 128x64 tile
doubles the CTAs in flight, and a 256-deep K tile cuts the mainloop trips; together they take
the FP4 GEMM term from 9.892 ms to 8.906 ms on one trace. Measured alone against a main without
this leg, the tiles are worth +0.15% — they only pay when the skinny GEMM exists, which is why
the two ship together. `SPARKINFER_MUSE_NVFP4_SKINNY` / `_K256` restore the single shipped tile,
and the scale-factor layout is fixed by `Sm1xxBlkScaledConfig` rather than the CTA tile
(`static_assert`ed across variants), so every variant reads the same packed scales.

## Note on the qwen3.6 guard (why this is a re-file)

The previous submission of this work (#817) measured **1.12x prefill@128** with the accuracy
gate green (`top1=0.970`, `KL=0.0906`) and was still auto-closed, because the qwen3.6
no-regression guard reported `measurement unavailable` — every qwen3.6 metric came back
*missing/zero* rather than as a regression against a value.

Nothing in this diff is reachable outside Muse Glimmer: every FP4 entry point sits behind
`c.muse_glimmer` (`muse_nvfp4` in qwen35_prefill.cpp, and the load-time conversion in
qwen35.cpp), so a qwen3.6 run executes exactly main's code. #816 — a strictly larger version of
this change — passed the same guard (`q36_guard_ok: true`). The FP4 translation unit has also
been trimmed from four CUTLASS tile instantiations to the two that actually ship, so the build
is smaller than the one that was measured (99 s for the bench + prefill_check targets here).

If the guard reports missing measurements again I would appreciate a pointer to the harness
log — happy to chase it from our side, but I cannot reproduce a qwen3.6 path that this diff
can reach.

## Lineage

#810 (@andriypolanski) added the SM120 block-scaled FP4 prefill path; #813 (@inference2026)
made it default; #814 (@Paral1995) sharpened the activation quantize this leg feeds; #800's
prefill graph is why the kernel-level saving survives to the wall clock. #816 was ours and
#819 reverted it — thanks for the clear revert note; this is the fixed version it asked for.
