### PR TITLE
perf(muse-glimmer): block-scaled FP4 attention projection group (1.08x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -11,33 +11,51 @@
 #include <cutlass/util/packed_stride.hpp>
 #include <cute/tensor.hpp>
 
+#include <cstdlib>
+
 namespace sparkinfer::kernels {
 namespace {
 using namespace cute;
 using E4 = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
 using BF = cutlass::bfloat16_t;
-using Tile = Shape<_128, _128, _128>;
 using Cluster = Shape<_1, _1, _1>;
-using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, Tile, Cluster,
-    cutlass::epilogue::collective::EpilogueTileAuto, float, float,
-    BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
-    cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
-using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
-    E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
-    Tile, Cluster,
-    cutlass::gemm::collective::StageCountAutoCarveout<
-        static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
-    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
-using Kernel = cutlass::gemm::kernel::GemmUniversal<
-    Shape<int, int, int, int>, Mainloop, Epilogue, void>;
-using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+
+template <class TileShape>
+struct Cfg {
+    using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, TileShape, Cluster,
+        cutlass::epilogue::collective::EpilogueTileAuto, float, float,
+        BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+    using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+        E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
+        TileShape, Cluster,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+    using Kernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, Mainloop, Epilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+};
+
+// Two N-tilings of the same GEMM. The 128-wide tile reuses each A tile across twice as many
+// output columns and is the right default; the 64-wide one exists only to fill the machine when
+// the wide grid cannot (see nvfp4_prefer_narrow).
+using Wide = Cfg<Shape<_128, _128, _128>>;
+using Narrow = Cfg<Shape<_128, _64, _256>>;
+
+using Gemm = typename Wide::Gemm;
+using Kernel = typename Wide::Kernel;
 using StrideA = typename Kernel::StrideA;
 using StrideB = typename Kernel::StrideB;
 using StrideC = typename Kernel::StrideC;
 using StrideD = typename Kernel::StrideD;
-using ScaleConfig = typename Mainloop::Sm1xxBlkScaledConfig;
+// Depends only on the FP4 scale-vector size, not on the tile, so one quantized operand feeds
+// either config -- quant_a/quant_b stay tile-agnostic.
+using ScaleConfig = typename Wide::Mainloop::Sm1xxBlkScaledConfig;
+static_assert(cute::is_same_v<ScaleConfig, typename Narrow::Mainloop::Sm1xxBlkScaledConfig>,
+              "both tilings must agree on the block-scale layout");
 
 auto shape(int m, int n, int k) { return cute::make_shape(m, n, k, 1); }
 auto sfa_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFA(shape(m,n,k)); }
@@ -82,8 +100,9 @@ __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
     }
 }
 
-Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
-                     void* d, int m, int n, int k) {
+template <class C = Wide>
+typename C::Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
+                                 void* d, int m, int n, int k) {
     auto as = cutlass::make_cute_packed_stride(StrideA{}, {m,k,1});
     auto bs = cutlass::make_cute_packed_stride(StrideB{}, {n,k,1});
     auto cs = cutlass::make_cute_packed_stride(StrideC{}, {m,n,1});
@@ -91,6 +110,44 @@ Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* s
     return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m,n,k),
             {static_cast<const cutlass::float_e2m1_t*>(a), as, static_cast<const cutlass::float_e2m1_t*>(b), bs, static_cast<const cutlass::float_ue4m3_t*>(sa), sfa_layout(m,n,k), static_cast<const cutlass::float_ue4m3_t*>(sb), sfb_layout(m,n,k)},
             {{1.f, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
+}
+
+int sm_count() {
+    static const int sms = [] {
+        int dev = 0, c = 0;
+        if (cudaGetDevice(&dev) != cudaSuccess ||
+            cudaDeviceGetAttribute(&c, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
+            return 0;
+        return c;
+    }();
+    return sms;
+}
+
+// The wide tile wins whenever it can keep the GPU busy, because each of its CTAs amortizes one
+// A-tile load over twice as many output columns. It cannot at m <= 128: the grid is then one CTA
+// tall, so it is just ceil(n/128) blocks -- for Muse Glimmer's down/wo (n=6656) that is 52 CTAs on
+// a 170-SM RTX 5090, i.e. under a third of the machine. Halving the N tile doubles the block count
+// and the memory parallelism that goes with it. Measured on RTX 5090 at m=128 with DRAM-cold
+// weights, wide -> narrow: down (n=6656,k=19968) 66.7 -> 53.6 us, wo (n=6656,k=4096) 18.4 -> 14.3,
+// gate/up (n=19968,k=6656) 53.3 -> 51.2. From m=256 the wide tile is ahead at every one of those
+// shapes (1.09x-1.56x), so the narrow tiling stays confined to the single-CTA-tall case.
+bool prefer_narrow(int m, int n) {
+    static const bool on = [] {
+        const char* e = getenv("SPARKINFER_NVFP4_NARROW_TILE");
+        return !e || atoi(e) != 0;
+    }();
+    const int sms = sm_count();
+    return on && m <= 128 && sms > 0 && (n + 127) / 128 < sms;
+}
+
+template <class C>
+bool run_gemm(const void* a, const void* sa, const void* b, const void* sb,
+              void* d, int m, int n, int k, void* ws, cudaStream_t st) {
+    typename C::Gemm gemm;
+    auto ar = args<C>(a, sa, b, sb, d, m, n, k);
+    return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
+           gemm.initialize(ar, ws, st) == cutlass::Status::kSuccess &&
+           gemm.run(st) == cutlass::Status::kSuccess;
 }
 } // namespace
 
@@ -109,7 +166,12 @@ size_t prefill_nvfp4_scale_bytes_b(int n, int k) {
     return (size_t)cute::size(cute::filter_zeros(sfb_layout(128,n,k)));
 }
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
-    return Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    // Either tiling may run for a given shape, so the caller's buffer has to cover both.
+    const size_t w = Wide::Gemm::get_workspace_size(
+        args<Wide>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    const size_t nw = Narrow::Gemm::get_workspace_size(
+        args<Narrow>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    return w > nw ? w : nw;
 }
 bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
@@ -130,9 +192,7 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
                                void* d,int m,int n,int k,void* ws,cudaStream_t st) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
-    Gemm gemm; auto ar = args(a,sa,b,sb,d,m,n,k);
-    return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
-           gemm.initialize(ar,ws,st) == cutlass::Status::kSuccess &&
-           gemm.run(st) == cutlass::Status::kSuccess;
+    return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st)
+                              : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
 }
 } // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -84,6 +84,11 @@ struct Qwen35LayerWeights {
     // unsupported shapes continue to use the GGUF-native pointers above.
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
+    // q | attn_gate | k | v stacked into ONE [2*qdim + 2*kvdim, H] FP4 operand. They all project
+    // the same `xn` and the batched prefill already runs them as a single grouped GEMM to keep the
+    // grid full, so the FP4 form has to stay grouped too -- as four separate GEMMs at m=128 the
+    // biggest is 32 CTAs of a 170-SM part. Row order matches the split below: q, gate, k, v.
+    const void* qkvg_fp4 = nullptr; const void* qkvg_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3996,7 +3996,12 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         void* tmp = nullptr;
         const size_t tmp_elems = (size_t)c.moe_ffn * H;
         bool ok = cudaMalloc(&tmp, tmp_elems * sizeof(bf16)) == cudaSuccess;
-        int ready = 0;
+        int ready = 0, qkvg_ready = 0;
+        const int qdim_a = c.n_q_heads * c.head_dim;
+        const int kvdim_a = c.n_kv_heads * c.head_dim;
+        const char* fp4q_env = getenv("SPARKINFER_MUSE_PREFILL_NVFP4_QKV");
+        const bool qkvg_fp4_on = (!fp4q_env || fp4q_env[0] != '0') &&
+                                 kernels::prefill_nvfp4_supported(128, 2 * qdim_a + 2 * kvdim_a, H);
         auto convert = [&](const void* src, int qtype, int rows, int cols,
                            const void** data, const void** sf) -> bool {
             void *d = nullptr, *scale = nullptr;
@@ -4007,6 +4012,37 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             }
             kernels::launch_gguf_dequant(qtype, src, tmp, (long)rows * cols, s.stream);
             if (!kernels::launch_prefill_nvfp4_quant_b(tmp, d, scale, rows, cols, s.stream) ||
+                cudaStreamSynchronize(s.stream) != cudaSuccess) {
+                cudaFree(d); cudaFree(scale); return false;
+            }
+            s.owned.push_back(d); s.owned.push_back(scale); *data = d; *sf = scale;
+            return true;
+        };
+        // Stack several row-blocks that share `cols` into one FP4 operand: dequantize each into its
+        // slice of `tmp`, then quantize the whole thing once so the scale factors come out in the
+        // single atom-tiled layout the GEMM expects for the combined row count.
+        auto convert_group = [&](const void* const* src, const int* qtype, const int* rows,
+                                 int nsrc, int cols, const void** data, const void** sf) -> bool {
+            int total = 0;
+            for (int i = 0; i < nsrc; ++i) {
+                if (!src[i]) return false;
+                total += rows[i];
+            }
+            if (!kernels::prefill_nvfp4_supported(128, total, cols) ||
+                (size_t)total * cols > tmp_elems) return false;
+            void *d = nullptr, *scale = nullptr;
+            if (cudaMalloc(&d, kernels::prefill_nvfp4_data_bytes(total, cols)) != cudaSuccess)
+                return false;
+            if (cudaMalloc(&scale, kernels::prefill_nvfp4_scale_bytes_b(total, cols)) != cudaSuccess) {
+                cudaFree(d); return false;
+            }
+            long off = 0;
+            for (int i = 0; i < nsrc; ++i) {
+                kernels::launch_gguf_dequant(qtype[i], src[i], (bf16*)tmp + off,
+                                             (long)rows[i] * cols, s.stream);
+                off += (long)rows[i] * cols;
+            }
+            if (!kernels::launch_prefill_nvfp4_quant_b(tmp, d, scale, total, cols, s.stream) ||
                 cudaStreamSynchronize(s.stream) != cudaSuccess) {
                 cudaFree(d); cudaFree(scale); return false;
             }
@@ -4027,15 +4063,29 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const int ut = lw.prefill_up_q ? lw.prefill_up_qtype : lw.up_qtype;
             ok = convert(g, gt, c.moe_ffn, H, &lw.gate_fp4, &lw.gate_fp4_sf) &&
                  convert(u, ut, c.moe_ffn, H, &lw.up_fp4, &lw.up_fp4_sf);
+            // The attention projection group. ~1.7 GB across 52 layers, against 3.9 GB for an
+            // ffn_down copy of the same kind, and it is the last dense int8 GEMM in the layer.
+            // Best-effort: a layer whose four weights are not all present just keeps the int8
+            // grouped path, which is what every layer does today.
+            if (ok && qkvg_fp4_on) {
+                const void* src[4] = { lw.wq, lw.wgate, lw.wk, lw.wv };
+                const int qt[4] = { lw.wq_type, lw.wgate_type, lw.wk_type, lw.wv_type };
+                const int rows[4] = { qdim_a, qdim_a, kvdim_a, kvdim_a };
+                if (!convert_group(src, qt, rows, 4, H, &lw.qkvg_fp4, &lw.qkvg_fp4_sf))
+                    lw.qkvg_fp4 = lw.qkvg_fp4_sf = nullptr;
+            }
             if (ok) {
                 release_prefill_copy(lw.prefill_gate_q, lw.gate_q);
                 release_prefill_copy(lw.prefill_up_q, lw.up_q);
                 ++ready;
+                if (lw.qkvg_fp4) ++qkvg_ready;
             }
         }
         if (tmp) cudaFree(tmp);
-        fprintf(stderr, "[prefill-muse] SM120 NVFP4 FFN weights ready: %d/%d layers%s\n",
-                ready, c.n_layers, ok ? "" : " (remaining layers use GGUF fallback)");
+        fprintf(stderr, "[prefill-muse] SM120 NVFP4 FFN weights ready: %d/%d layers%s"
+                        " (qkv-gate %d/%d)\n",
+                ready, c.n_layers, ok ? "" : " (remaining layers use GGUF fallback)",
+                qkvg_ready, c.n_layers);
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -376,11 +376,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         ? kernels::prefill_nvfp4_data_bytes(N, H) : 0;
     const size_t fp4_a_sf_bytes = muse_nvfp4
         ? kernels::prefill_nvfp4_scale_bytes_a(N, H) : 0;
-    const size_t fp4_ws_bytes = muse_nvfp4
+    // The attention projection group: q | gate | k | v stacked, so one GEMM covers all four. Its A
+    // operand is `xn` at k = H -- the same shape gate/up already quantize -- so fp4_a/fp4_as serve
+    // it unchanged; only the [N, qkvg_n] bf16 output and a possibly wider workspace are new.
+    const int qkvg_n = 2 * qdim + 2 * kvdim;
+    const bool muse_nvfp4_qkv = muse_nvfp4 && s.w.layers[0].qkvg_fp4 &&
+                                kernels::prefill_nvfp4_supported(N, qkvg_n, H);
+    const size_t fp4_ws_gu = muse_nvfp4
         ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
+    const size_t fp4_ws_qkv = muse_nvfp4_qkv
+        ? kernels::prefill_nvfp4_workspace_bytes(N, qkvg_n, H) : 0;
+    const size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
+    bf16* fp4_qkv = muse_nvfp4_qkv ? a8.alloc<bf16>((size_t)N * qkvg_n) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -815,7 +825,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 const void* Wa[4]; const float* rsa[4]; void* Ca[4]; int na[4];
                 bool inq = false, ing = false, ink = false, inv = false;
                 int ng = 0;
-                if (muse_group && muse_qb && use_i8 &&
+                // FP4 form of that same grouped GEMM: q|gate|k|v are one [qkvg_n, H] operand, so
+                // this is a single block-scaled GEMM into a contiguous [N, qkvg_n] buffer, then
+                // four strided copies out to the destinations the rest of the layer expects
+                // (they are aliases into the GDN scratch and each wants a tight row stride).
+                // 2.2 MB of copy per layer against ~25 MB less weight traffic.
+                bool qkvg_fp4 = false;
+                if (muse_nvfp4_qkv && w.qkvg_fp4 && w.qkvg_fp4_sf && fp4_a && fp4_as && fp4_qkv &&
+                    kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_as, N, H, st) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.qkvg_fp4, w.qkvg_fp4_sf,
+                                                       fp4_qkv, N, qkvg_n, H, fp4_ws, st)) {
+                    const size_t sp = (size_t)qkvg_n * sizeof(bf16);
+                    struct { void* dst; int off, n; } cut[4] = {
+                        { qb, 0,            qdim  }, { qg, qdim,          qdim  },
+                        { kf, 2 * qdim,     kvdim }, { vf, 2 * qdim + kvdim, kvdim },
+                    };
+                    qkvg_fp4 = true;
+                    for (auto& cu : cut)
+                        qkvg_fp4 &= cudaMemcpy2DAsync(cu.dst, (size_t)cu.n * sizeof(bf16),
+                                                      fp4_qkv + cu.off, sp,
+                                                      (size_t)cu.n * sizeof(bf16), N,
+                                                      cudaMemcpyDeviceToDevice, st) == cudaSuccess;
+                    if (qkvg_fp4) inq = ing = ink = inv = true;
+                }
+                if (!qkvg_fp4 && muse_group && muse_qb && use_i8 &&
                     kernels::pfm_moe_gemm_qi8_supported(w.wq_type)) {
                     const int at = w.wq_type;
                     auto take = [&](const void* W, int t, const float* rs, void* C, int n, bool& in) {
@@ -836,7 +869,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         qb_partials, QB_SPLITS, qb_partials_cap,
                         nullptr, nullptr, nullptr, apk());
                 }
-                if (!grouped) { inq = ing = ink = inv = false; }
+                if (!grouped && !qkvg_fp4) { inq = ing = ink = inv = false; }
                 if (!inq) proj_fused(xn, w.wq,    w.wq_type,    w.wq_rs,    qb, qdim,  H);
                 if (!ing) proj_fused(xn, w.wgate, w.wgate_type, w.wgate_rs, qg, qdim,  H);
                 if (!ink) proj_fused(xn, w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, H);


### PR DESCRIPTION
## Summary

Muse Glimmer's attention projection group — q, attn_gate, k, v — is the last dense int8 GEMM left in
a prefill layer once the FFN moved to NVFP4. This puts it on the block-scaled path too, and adds the
GEMM tiling that shape needs.

**1. q | attn_gate | k | v as one FP4 operand.** The four weights all project the same `xn` and the
batched prefill already runs them as a *single* grouped int8 GEMM, because at m=128 four separate
launches would be 64, 64, 4 and 4 CTAs of a 170-SM part. The FP4 form has to keep that property, so
the conversion stacks them into one `[2*qdim + 2*kvdim, H]` = `[8704, 6656]` operand rather than
converting each weight on its own: each block is dequantized into its slice of the existing staging
buffer and the whole thing is quantized once, so the scale factors come out in the single atom-tiled
layout the GEMM expects for the combined row count. Prefill then runs one block-scaled GEMM into a
contiguous `[N, 8704]` buffer and splits it out with four strided copies — the destinations are
aliases into the GDN scratch and each wants a tight row stride. That copy is 2.2 MB a layer against
~25 MB less weight traffic (57.9 MB of int8 rows becomes 32.6 MB of FP4 + scales).

Best-effort per layer: a layer whose four weights are not all present, or a box where the conversion
does not fit, simply keeps the int8 grouped path. `SPARKINFER_MUSE_PREFILL_NVFP4_QKV=0` skips the
conversion — with it set, the prefill-accuracy check reproduces `main` exactly (115/128, KL 0.03026),
so the leg is inert when off.

**2. A second GEMM tiling, for grids that are one CTA tall.** The kernel shipped a single
`128x128x128` tile. Batched prefill runs m=128, so the grid is `1 x ceil(n/128)` and the tile alone
decides occupancy — this group is n=8704, i.e. **68 CTAs on a 170-SM RTX 5090**. Halving the N tile
doubles the block count and the memory parallelism with it. Measured per-GEMM with DRAM-cold weights
(rotating six B operands so the 96 MB L2 cannot hold one):

| shape | 128x128x128 | 128x64x256 |
|---|--:|--:|
| `n=6656 k=19968` | 66.2 us | **53.5 us** |
| `n=6656 k=4096` | 18.4 us | **14.3 us** |
| `n=19968 k=6656` | 53.3 us | **51.2 us** |

The wide tile amortizes each A tile over twice as many output columns, so it stays the default; from
m=256 it is ahead at every one of those shapes (1.09x–1.56x). The dispatch is therefore gated on the
grid being a single CTA tall *and* short of one wave, read from the device's own SM count. Both
tilings share the block-scale layout — it depends only on the FP4 vector size, not the tile — so one
quantized operand feeds either, asserted at compile time.

**Cost.** The FP4 copy of the group is ~1.7 GB across 52 layers: 25.5 -> 27.2 GB of a 32 GB card.
Long-context batched prefill is unaffected (ctx16384 measured below).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx=0, median of 5, 3 rotations):

| | decode tok/s |
|---|--:|
| before (main) | 105.69 |
| after (this PR) | 105.68 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128, median of 5 — this PR targets Muse's 128-ctx prefill, so
the table is filled from that model rather than Qwythos):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 6690.68 |
| after prefill (this PR) | 7204.74 |

**1.08x prefill@128, decode flat.** Three rotations, alternating, GPU confirmed idle before every
measurement, `main` built in its own tree:

```text
  main               r1: decode@0=105.79  prefill@128=6782.80 pp (18.87 ms)
  qkv-gate fp4       r1: decode@0=105.75  prefill@128=7222.65 pp (17.72 ms)
  qkv fp4, wide tile r1: decode@0=105.71  prefill@128=7132.87 pp (17.95 ms)
  main               r2: decode@0=105.69  prefill@128=6690.68 pp (19.13 ms)
  qkv-gate fp4       r2: decode@0=105.68  prefill@128=7204.74 pp (17.77 ms)
  qkv fp4, wide tile r2: decode@0=105.69  prefill@128=7085.60 pp (18.06 ms)
  main               r3: decode@0=105.68  prefill@128=6636.71 pp (19.29 ms)
  qkv-gate fp4       r3: decode@0=105.64  prefill@128=7202.00 pp (17.77 ms)
  qkv fp4, wide tile r3: decode@0=105.69  prefill@128=7109.94 pp (18.00 ms)
```

The `wide tile` arm is the same binary with `SPARKINFER_NVFP4_NARROW_TILE=0`: the projection group on
FP4 is worth 1.062x on its own, and the tiling that fits its 68-CTA grid adds the remaining 1.4%.

**Accuracy**, `SPARKINFER_KV_INT8=0 qwen3_gguf_prefill_check` (batched prefill vs the token-by-token
path), 128 continuation positions:

| build | TOP1 | KL |
|---|--:|--:|
| main | 115/128 0.8984 | 0.03026 |
| this PR | **119/128 0.9297** | **0.02565** |
| this PR, `NVFP4_QKV=0` | 115/128 0.8984 | 0.03026 |

It improves: the int8 grouped path carries one scale per output row, while the FP4 operand carries
one per 16 values, so the projection weights round closer. 128 positions, not 16 — at 16 this
comparison sits within one token of noise and can invert.

**Qwen3.6 no-regression guard** (shared code: `qwen35.cpp` / `qwen35_prefill.cpp`; Qwen3.6 is MoE and
never enters this path):

```text
  main    : ctx0 d=479.59  ctx512 p=9357.92  ctx4096 p=25446.21  ctx16384 p=26972.51  ctx32768 p=28292.14
  this PR : ctx0 d=479.52  ctx512 p=9351.46  ctx4096 p=25427.95  ctx16384 p=26989.34  ctx32768 p=28308.20
```

Worst ratio 0.9993.

**Muse multi-ctx** (`SPARKINFER_KV_INT8=0`, two rotations — the added resident memory has to not cost
long-context prefill):

```text
  main    r1: ctx512 p=4547.03  ctx4096 p=3362.49  ctx16384 p=2122.85
  this PR r1: ctx512 p=4508.96  ctx4096 p=3319.04  ctx16384 p=2100.63
  main    r2: ctx512 p=4465.47  ctx4096 p=3303.00  ctx16384 p=2091.05
  this PR r2: ctx512 p=4481.95  ctx4096 p=3309.26  ctx16384 p=2091.81
```

Averaged over both rotations: ctx512 0.998, ctx4096 0.994, ctx16384 0.995.

## Notes

`prefill_nvfp4_workspace_bytes` returns the larger of the two tilings' workspaces, so one buffer
serves either. `SPARKINFER_NVFP4_NARROW_TILE=0` pins the shipped tiling and
`SPARKINFER_MUSE_PREFILL_NVFP4_QKV=0` drops the projection leg, so both arms of an A/B come out of a
single binary.
