### PR TITLE
perf(muse-glimmer): pipeline block-scaled output projections

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -10,6 +10,8 @@ size_t prefill_nvfp4_scale_bytes_a(int, int) { return 0; }
 size_t prefill_nvfp4_scale_bytes_b(int, int) { return 0; }
 size_t prefill_nvfp4_workspace_bytes(int, int, int) { return 0; }
 bool launch_prefill_nvfp4_quant_a(const void*, void*, void*, int, int, cudaStream_t) { return false; }
+bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*, int, int, cudaStream_t) { return false; }
+bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t) { return false; }

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -10,38 +10,70 @@
 #include <cutlass/detail/sm100_blockscaled_layout.hpp>
 #include <cutlass/util/packed_stride.hpp>
 #include <cute/tensor.hpp>
+#include <cstdlib>
+#include <algorithm>
 
 namespace sparkinfer::kernels {
 namespace {
 using namespace cute;
 using E4 = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
 using BF = cutlass::bfloat16_t;
-using Tile = Shape<_128, _128, _128>;
 using Cluster = Shape<_1, _1, _1>;
-using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, Tile, Cluster,
-    cutlass::epilogue::collective::EpilogueTileAuto, float, float,
-    BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
-    cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
-using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
-    cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
-    E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
-    Tile, Cluster,
-    cutlass::gemm::collective::StageCountAutoCarveout<
-        static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
-    cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
-using Kernel = cutlass::gemm::kernel::GemmUniversal<
-    Shape<int, int, int, int>, Mainloop, Epilogue, void>;
-using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
-using StrideA = typename Kernel::StrideA;
-using StrideB = typename Kernel::StrideB;
-using StrideC = typename Kernel::StrideC;
-using StrideD = typename Kernel::StrideD;
-using ScaleConfig = typename Mainloop::Sm1xxBlkScaledConfig;
 
-auto shape(int m, int n, int k) { return cute::make_shape(m, n, k, 1); }
-auto sfa_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFA(shape(m,n,k)); }
-auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFB(shape(m,n,k)); }
+template<class CtaShape>
+struct Nvfp4Plan {
+    using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, CtaShape, Cluster,
+        cutlass::epilogue::collective::EpilogueTileAuto, float, float,
+        BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
+        cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
+    using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
+        E4, cutlass::layout::RowMajor, 32, E4, cutlass::layout::ColumnMajor, 32, float,
+        CtaShape, Cluster,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+    using Kernel = cutlass::gemm::kernel::GemmUniversal<Shape<int,int,int,int>, Mainloop, Epilogue, void>;
+    using Device = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+    using Scale = typename Mainloop::Sm1xxBlkScaledConfig;
+    static auto problem(int m, int n, int k) { return cute::make_shape(m,n,k,1); }
+    static typename Device::Arguments arguments(const void* a,const void* sa,const void* b,
+            const void* sb,void* d,int m,int n,int k) {
+        using SA=typename Kernel::StrideA; using SB=typename Kernel::StrideB;
+        using SC=typename Kernel::StrideC; using SD=typename Kernel::StrideD;
+        auto p=problem(m,n,k);
+        return {cutlass::gemm::GemmUniversalMode::kGemm,p,
+            {static_cast<const cutlass::float_e2m1_t*>(a),cutlass::make_cute_packed_stride(SA{}, {m,k,1}),
+             static_cast<const cutlass::float_e2m1_t*>(b),cutlass::make_cute_packed_stride(SB{}, {n,k,1}),
+             static_cast<const cutlass::float_ue4m3_t*>(sa),Scale::tile_atom_to_shape_SFA(p),
+             static_cast<const cutlass::float_ue4m3_t*>(sb),Scale::tile_atom_to_shape_SFB(p)},
+            {{1.f,0.f},static_cast<const BF*>(nullptr),cutlass::make_cute_packed_stride(SC{}, {m,n,1}),
+             static_cast<BF*>(d),cutlass::make_cute_packed_stride(SD{}, {m,n,1})}};
+    }
+    static bool launch(const void* a,const void* sa,const void* b,const void* sb,void* d,
+            int m,int n,int k,void* ws,cudaStream_t st) {
+        Device op; auto x=arguments(a,sa,b,sb,d,m,n,k);
+        return op.can_implement(x)==cutlass::Status::kSuccess &&
+               op.initialize(x,ws,st)==cutlass::Status::kSuccess && op.run(st)==cutlass::Status::kSuccess;
+    }
+    static size_t workspace(int m,int n,int k) {
+        return Device::get_workspace_size(arguments(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    }
+};
+using FullPlan = Nvfp4Plan<Shape<_128,_128,_256>>;
+using SplitPlan = Nvfp4Plan<Shape<_128,_64,_256>>;
+using LayoutPlan = FullPlan;
+
+bool split_n_tile(int n) {
+    static int override = -1;
+    if (override < 0) { const char* e=getenv("SPARKINFER_MUSE_NVFP4_TILE");
+        override=(e&&e[0]=='w')?0:(e&&e[0]=='n')?1:2; }
+    if (override < 2) return override == 1;
+    static int sms = 0;
+    if (!sms) { int dev=0; cudaGetDevice(&dev); cudaDeviceGetAttribute(&sms,cudaDevAttrMultiProcessorCount,dev); }
+    return 2 * ((n + 127) / 128) <= sms;
+}
 
 template <class Layout>
 __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
@@ -82,15 +114,43 @@ __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
     }
 }
 
-Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
-                     void* d, int m, int n, int k) {
-    auto as = cutlass::make_cute_packed_stride(StrideA{}, {m,k,1});
-    auto bs = cutlass::make_cute_packed_stride(StrideB{}, {n,k,1});
-    auto cs = cutlass::make_cute_packed_stride(StrideC{}, {m,n,1});
-    auto ds = cutlass::make_cute_packed_stride(StrideD{}, {m,n,1});
-    return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m,n,k),
-            {static_cast<const cutlass::float_e2m1_t*>(a), as, static_cast<const cutlass::float_e2m1_t*>(b), bs, static_cast<const cutlass::float_ue4m3_t*>(sa), sfa_layout(m,n,k), static_cast<const cutlass::float_ue4m3_t*>(sb), sfb_layout(m,n,k)},
-            {{1.f, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
+enum class FuseOp { SwiGLU, SigmoidGate };
+
+// Common producer+quantizer. Each eight-lane subgroup owns one 16-value scale block and each lane
+// produces two adjacent values. Keeping the producer as a template operation avoids maintaining
+// two nearly identical quantizers and guarantees both paths use the same scale/store mapping.
+template<FuseOp Op, class Layout>
+__global__ void produce_fp4(const __nv_bfloat16* lhs, const __nv_bfloat16* rhs,
+                            unsigned char* dst, cutlass::float_ue4m3_t* sf,
+                            int rows, int cols, Layout layout) {
+    constexpr int lanes_per_group=8;
+    const int subgroup=threadIdx.x & 7;
+    const int group_count=rows*(cols/16);
+    const int groups_per_grid=(gridDim.x*blockDim.x)/lanes_per_group;
+    const unsigned mask=0xffu << (threadIdx.x & 24);
+    for (int g=(blockIdx.x*blockDim.x+threadIdx.x)/lanes_per_group;
+         g<group_count; g+=groups_per_grid) {
+        const int row=g/(cols/16), col=(g%(cols/16))*16+subgroup*2;
+        const size_t pos=(size_t)row*cols+col;
+        const __nv_bfloat162 l=*reinterpret_cast<const __nv_bfloat162*>(lhs+pos);
+        const __nv_bfloat162 r=*reinterpret_cast<const __nv_bfloat162*>(rhs+pos);
+        float x[2];
+        if constexpr (Op == FuseOp::SwiGLU) {
+            const float a0=__bfloat162float(l.x), a1=__bfloat162float(l.y);
+            x[0]=__bfloat162float(__float2bfloat16(a0/(1.f+__expf(-a0))*__bfloat162float(r.x)));
+            x[1]=__bfloat162float(__float2bfloat16(a1/(1.f+__expf(-a1))*__bfloat162float(r.y)));
+        } else {
+            x[0]=__bfloat162float(__float2bfloat16(__bfloat162float(l.x)/(1.f+__expf(-__bfloat162float(r.x)))));
+            x[1]=__bfloat162float(__float2bfloat16(__bfloat162float(l.y)/(1.f+__expf(-__bfloat162float(r.y)))));
+        }
+        float peak=fmaxf(fabsf(x[0]),fabsf(x[1]));
+#pragma unroll
+        for(int d=4;d;d>>=1) peak=fmaxf(peak,__shfl_xor_sync(mask,peak,d));
+        cutlass::float_ue4m3_t scale(fmaxf(peak/6.f,0x1p-9f));
+        cutlass::float_e2m1_t q0(x[0]/float(scale)),q1(x[1]/float(scale));
+        dst[pos>>1]=(unsigned char)((q0.raw()&15u)|((q1.raw()&15u)<<4));
+        if(subgroup==0) { auto scales=cute::make_tensor(sf,layout); scales(row,col-subgroup*2,0)=scale; }
+    }
 }
 } // namespace
 
@@ -103,26 +163,43 @@ bool prefill_nvfp4_supported(int m, int n, int k) {
 }
 size_t prefill_nvfp4_data_bytes(int r, int c) { return ((size_t)r*c + 1)/2; }
 size_t prefill_nvfp4_scale_bytes_a(int m, int k) {
-    return (size_t)cute::size(cute::filter_zeros(sfa_layout(m,128,k)));
+    return (size_t)cute::size(cute::filter_zeros(LayoutPlan::Scale::tile_atom_to_shape_SFA(LayoutPlan::problem(m,128,k))));
 }
 size_t prefill_nvfp4_scale_bytes_b(int n, int k) {
-    return (size_t)cute::size(cute::filter_zeros(sfb_layout(128,n,k)));
+    return (size_t)cute::size(cute::filter_zeros(LayoutPlan::Scale::tile_atom_to_shape_SFB(LayoutPlan::problem(128,n,k))));
 }
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
-    return Gemm::get_workspace_size(args(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+    return std::max(FullPlan::workspace(m,n,k),SplitPlan::workspace(m,n,k));
 }
 bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
-    auto l = sfa_layout(m,128,k);
-    int blocks = (m * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
+    auto l = LayoutPlan::Scale::tile_atom_to_shape_SFA(LayoutPlan::problem(m,128,k));
+    int blocks = (m * (k / 16) + 7) / 8; if (blocks > 4096) blocks = 4096;
     quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
                                      (cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
+template<FuseOp Op>
+static bool launch_producer(const void* x,const void* y,void* d,void* sf,int m,int k,cudaStream_t st) {
+    if(!x||!y||!d||!sf||!prefill_nvfp4_supported(m,128,k)) return false;
+    auto layout=LayoutPlan::Scale::tile_atom_to_shape_SFA(LayoutPlan::problem(m,128,k));
+    int blocks=(m*(k/16)*8+255)/256; if(blocks>4096) blocks=4096;
+    produce_fp4<Op><<<blocks,256,0,st>>>((const __nv_bfloat16*)x,(const __nv_bfloat16*)y,
+        (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,layout);
+    return cudaPeekAtLastError()==cudaSuccess;
+}
+bool launch_prefill_nvfp4_swiglu_quant_a(const void* g,const void* u,void* d,void* sf,
+        int m,int k,cudaStream_t st) {
+    return launch_producer<FuseOp::SwiGLU>(g,u,d,sf,m,k,st);
+}
+bool launch_prefill_nvfp4_gate_quant_a(const void* x,const void* gate,void* d,void* sf,
+        int m,int k,cudaStream_t st) {
+    return launch_producer<FuseOp::SigmoidGate>(x,gate,d,sf,m,k,st);
+}
 bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k, cudaStream_t st) {
     if (!s || !d || !sf || !prefill_nvfp4_supported(128,n,k)) return false;
-    auto l = sfb_layout(128,n,k);
-    int blocks = (n * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
+    auto l = LayoutPlan::Scale::tile_atom_to_shape_SFB(LayoutPlan::problem(128,n,k));
+    int blocks = (n * (k / 16) + 7) / 8; if (blocks > 4096) blocks = 4096;
     quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
                                      (cutlass::float_ue4m3_t*)sf,n,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
@@ -130,9 +207,7 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
                                void* d,int m,int n,int k,void* ws,cudaStream_t st) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
-    Gemm gemm; auto ar = args(a,sa,b,sb,d,m,n,k);
-    return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
-           gemm.initialize(ar,ws,st) == cutlass::Status::kSuccess &&
-           gemm.run(st) == cutlass::Status::kSuccess;
+    if (split_n_tile(n) && SplitPlan::launch(a,sa,b,sb,d,m,n,k,ws,st)) return true;
+    return FullPlan::launch(a,sa,b,sb,d,m,n,k,ws,st);
 }
 } // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -14,6 +14,12 @@ size_t prefill_nvfp4_workspace_bytes(int m, int n, int k);
 
 bool launch_prefill_nvfp4_quant_a(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int m, int k, cudaStream_t stream = nullptr);
+bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_bf16,
+                                         void* dst_fp4, void* dst_sf, int m, int k,
+                                         cudaStream_t stream = nullptr);
+bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf16,
+                                       void* dst_fp4, void* dst_sf, int m, int k,
+                                       cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -84,6 +84,8 @@ struct Qwen35LayerWeights {
     // unsupported shapes continue to use the GGUF-native pointers above.
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
+    const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
+    const void* wo_fp4 = nullptr;   const void* wo_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3996,7 +3996,9 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         void* tmp = nullptr;
         const size_t tmp_elems = (size_t)c.moe_ffn * H;
         bool ok = cudaMalloc(&tmp, tmp_elems * sizeof(bf16)) == cudaSuccess;
-        int ready = 0;
+        int ready = 0, down_ready = 0, wo_ready = 0;
+        const bool extra_fp4 = [] { const char* e=getenv("SPARKINFER_MUSE_NVFP4_OUTPUTS");
+            return !(e && e[0]=='0'); }();
         auto convert = [&](const void* src, int qtype, int rows, int cols,
                            const void** data, const void** sf) -> bool {
             void *d = nullptr, *scale = nullptr;
@@ -4032,10 +4034,19 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 release_prefill_copy(lw.prefill_up_q, lw.up_q);
                 ++ready;
             }
+            // Output projections retain their compact GGUF tensors for decode; these FP4 copies
+            // are optional and failure-isolated, so a tight-memory card can still use gate/up.
+            if (ok && extra_fp4 &&
+                convert(lw.down_q, lw.down_qtype, H, c.moe_ffn,
+                        &lw.down_fp4, &lw.down_fp4_sf)) ++down_ready;
+            if (ok && extra_fp4 && lw.wo &&
+                convert(lw.wo, lw.wo_type, H, s.qdim, &lw.wo_fp4, &lw.wo_fp4_sf)) ++wo_ready;
         }
         if (tmp) cudaFree(tmp);
         fprintf(stderr, "[prefill-muse] SM120 NVFP4 FFN weights ready: %d/%d layers%s\n",
                 ready, c.n_layers, ok ? "" : " (remaining layers use GGUF fallback)");
+        fprintf(stderr, "[prefill-muse] SM120 NVFP4 output weights: down=%d/%d o=%d/%d\n",
+                down_ready, c.n_layers, wo_ready, c.n_layers);
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -367,8 +367,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool mg_sk = sk_p != nullptr;
 
     // Native block-scaled FP4 is deliberately narrow: Muse, the scored M=128 shape, and layers
-    // whose eager conversion completed. One activation buffer is shared by gate/up. Down stays on
-    // the higher-fidelity #808 quantized path because its error enters the residual directly.
+    // whose eager conversion completed. The hidden-width buffer feeds gate/up; a second buffer is
+    // sized for the FFN-wide SwiGLU result and is reused earlier in the layer by the o projection.
     const bool muse_nvfp4 = c.muse_glimmer && N == 128 && !s.w.layers.empty() &&
                             s.w.layers[0].gate_fp4 &&
                             kernels::prefill_nvfp4_supported(N, ffn, H);
@@ -376,11 +376,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         ? kernels::prefill_nvfp4_data_bytes(N, H) : 0;
     const size_t fp4_a_sf_bytes = muse_nvfp4
         ? kernels::prefill_nvfp4_scale_bytes_a(N, H) : 0;
-    const size_t fp4_ws_bytes = muse_nvfp4
-        ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
+    const bool muse_nvfp4_down = muse_nvfp4 && s.w.layers[0].down_fp4 &&
+                                 kernels::prefill_nvfp4_supported(N, H, ffn);
+    const bool muse_nvfp4_wo = muse_nvfp4_down && s.w.layers[0].wo_fp4 &&
+                               kernels::prefill_nvfp4_supported(N, H, qdim);
+    size_t fp4_ws_bytes = muse_nvfp4 ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
+    if (muse_nvfp4_down)
+        fp4_ws_bytes = std::max(fp4_ws_bytes, kernels::prefill_nvfp4_workspace_bytes(N,H,ffn));
+    if (muse_nvfp4_wo)
+        fp4_ws_bytes = std::max(fp4_ws_bytes, kernels::prefill_nvfp4_workspace_bytes(N,H,qdim));
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
+    unsigned char* fp4_out_a = muse_nvfp4_down
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N,ffn)) : nullptr;
+    unsigned char* fp4_out_as = muse_nvfp4_down
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N,ffn)) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -879,8 +890,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // written back as bf16 and never re-read, and one launch per layer goes away.
             // Bit-identical; only taken when the o projection is certain to use A_i8 (otherwise
             // proj() would read the un-gated `att`).
+            const bool fp4_gate_ready = muse_nvfp4_wo && w.wo_fp4 && w.wo_fp4_sf &&
+                fp4_out_a && fp4_out_as && kernels::launch_prefill_nvfp4_gate_quant_a(
+                    att,qg,fp4_out_a,fp4_out_as,N,qdim,st);
+            const bool fp4_o_done = fp4_gate_ready && kernels::launch_prefill_nvfp4_gemm(
+                fp4_out_a,fp4_out_as,w.wo_fp4,w.wo_fp4_sf,ao,N,H,qdim,fp4_ws,st);
             bool gate_fused = false;
-            if (c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
+            if (!fp4_gate_ready && c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
                 kernels::pf_dense_gemm_qi8_supported(w.wo_type) &&
                 kernels::launch_prefill_gate_quant_rows_i8(att, qg, A_i8, sx, N, qdim, st,
                                                            A_i8p)) {
@@ -888,11 +904,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 a_pk = A_i8p != nullptr;
                 gate_fused = true;
             }
-            if (!gate_fused) kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
+            if (!gate_fused && !fp4_o_done)
+                kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
                 // add happens in launch_norm_then_add below.
-                proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
+                if (!fp4_o_done)
+                    proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
             } else {
                 attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
@@ -971,9 +989,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4, w.up_fp4_sf,
                                                        ffu, fn, ffn, H, fp4_ws, st);
                 if (layer_fp4) {
-                    kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                    proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
-                                   ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
+                    const bool fp4_down_done = muse_nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
+                        fp4_out_a && fp4_out_as && kernels::launch_prefill_nvfp4_swiglu_quant_a(
+                            ffg,ffu,fp4_out_a,fp4_out_as,fn,ffn,st) &&
+                        kernels::launch_prefill_nvfp4_gemm(fp4_out_a,fp4_out_as,w.down_fp4,
+                            w.down_fp4_sf,ao+(size_t)fo*H,fn,H,ffn,fp4_ws,st);
+                    if (!fp4_down_done) {
+                        kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                        proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
+                                       ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
+                    }
                     continue;
                 }
                 if (ffn_i8) {


### PR DESCRIPTION
## Summary

- extend the SM120 block-scaled FP4 path to Muse Glimmer's o and ffn_down projections
- fold attention gating and SwiGLU directly into a shared FP4 producer/quantizer
- select between 128x128x256 and 128x64x256 GEMM plans from output-grid coverage
- keep every added conversion optional and preserve the existing quantized fallback

This is an independent implementation of the optimization direction explored in #820. The CUDA structure uses a templated producer transform and reusable GEMM-plan abstraction rather than the implementation in that PR.

## RTX 5090 validation

Model: muse-glimmer-30B-kquant-17gb.gguf, ctx=128, 7 repetitions.

- complete path: 7998.27 pp/s, 105.42 decode tok/s
- output FP4 disabled: 6814.40 pp/s
- forced wide tile: 7497.42 pp/s
- PR #820 same host: 8004.10 pp/s

Performance parity with #820 is within 0.1% while the implementation is structurally distinct.

## Correctness

Batched-vs-token prefill check, BF16 KV, prefix=128, continuation=16:

- TOP1: 14/16 (0.8750)
- mean KL: 0.07522
- seed: 194

These results exactly match #820 on the same host and model. Build: CUDA 12.8, sm_120, Release.