### PR TITLE
perf(muse-glimmer): pipeline FP4 down projection without long-context OOM

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -12,6 +12,8 @@ size_t prefill_nvfp4_workspace_bytes(int, int, int) { return 0; }
 bool launch_prefill_nvfp4_quant_a(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, int, int,
                                        cudaStream_t) { return false; }
+bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*, int, int,
+                                         cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t) { return false; }

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -135,6 +135,37 @@ __global__ void gate_quant_rows(const __nv_bfloat16* __restrict__ src,
     }
 }
 
+// The down projection is the only consumer of SwiGLU. Produce the exact bf16-rounded activation
+// directly into its FP4 A operand instead of writing and rereading the 128 x 19968 bf16 tensor.
+template <class Layout>
+__global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
+                                  const __nv_bfloat16* __restrict__ up,
+                                  unsigned char* dst, cutlass::float_ue4m3_t* sf,
+                                  int rows, int cols, Layout layout) {
+    constexpr int V = 16, LPG = V / 2;
+    const int glane = threadIdx.x & (LPG - 1);
+    const int groups = rows * (cols / V);
+    const int stride = (gridDim.x * blockDim.x) / LPG;
+    const unsigned gmask = 0xFFu << (threadIdx.x & 24);
+    for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG;
+         grp < groups; grp += stride) {
+        const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
+        const size_t base = (size_t)row * cols + k0 + 2 * glane;
+        const float g0 = __bfloat162float(gate[base]),     u0 = __bfloat162float(up[base]);
+        const float g1 = __bfloat162float(gate[base + 1]), u1 = __bfloat162float(up[base + 1]);
+        // Match pf_swiglu_kernel: SiLU and multiply in float, then round once to bf16.
+        const float x0 = __bfloat162float(__float2bfloat16(g0 / (1.f + __expf(-g0)) * u0));
+        const float x1 = __bfloat162float(__float2bfloat16(g1 / (1.f + __expf(-g1)) * u1));
+        float a = fmaxf(fabsf(x0), fabsf(x1));
+        #pragma unroll
+        for (int d = LPG / 2; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(gmask, a, d));
+        cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
+        cutlass::float_e2m1_t q0(x0 / float(qs)), q1(x1 / float(qs));
+        dst[base >> 1] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        if (glane == 0) { auto scales = cute::make_tensor(sf, layout); scales(row, k0, 0) = qs; }
+    }
+}
+
 template <class C = Wide>
 typename C::Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
                                  void* d, int m, int n, int k) {
@@ -229,6 +260,15 @@ bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, v
     int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
     gate_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)sr,(const __nv_bfloat16*)g,
                                           (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
+bool launch_prefill_nvfp4_swiglu_quant_a(const void* g, const void* u, void* d, void* sf,
+                                         int m, int k, cudaStream_t st) {
+    if (!g || !u || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
+    auto l = sfa_layout(m,128,k);
+    int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
+    swiglu_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)g,(const __nv_bfloat16*)u,
+                                            (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k, cudaStream_t st) {

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -436,11 +436,113 @@ __global__ void muse_sandwich_tail_kernel(const __nv_bfloat16* __restrict__ resi
                                           const __nv_bfloat16* __restrict__ next_w,
                                           __nv_bfloat16* __restrict__ out_x,
                                           __nv_bfloat16* __restrict__ out_xn,
-                                          int cols, float post_eps, float eps) {
+                                          si_blk_q8_1* __restrict__ out_q8,
+                                          int cols, float post_eps, float eps, int reg_tail) {
     const size_t base = (size_t)blockIdx.x * cols;
     __shared__ float s_warp[32];
     const int npack = cols >> 3;
     const int tail = npack << 3;
+
+    // One pack per thread -- Muse's 6656 columns is 832 packs against a 1024-thread block, and the
+    // scalar tail is empty -- lets the whole tail live in registers. Two things follow, and both
+    // are latency, not bandwidth: the bf16 stage 2 re-reads from out_x is the bf16 this thread
+    // just rounded, so keeping it deletes a store -> __syncthreads -> load round trip off the
+    // critical path; and with nothing downstream of a load, all four operands issue together
+    // instead of in three dependent waves. Same values, same order, so it stays bit-identical --
+    // rn_unpack8(rn_pack8(v)) is __bfloat162float(__float2bfloat16(v)), exactly what the global
+    // round trip returned. Wider rows keep the original path below.
+    if (reg_tail && npack <= blockDim.x && tail == cols) {
+        const int p = threadIdx.x;
+        const bool live = p < npack;
+        float bv[8], rv[8], pv[8], nv[8];
+        if (live) {
+            rn_unpack8(__ldg(reinterpret_cast<const uint4*>(branch + base) + p), bv);
+            rn_unpack8(__ldg(reinterpret_cast<const uint4*>(residual + base) + p), rv);
+            rn_unpack8(__ldg(reinterpret_cast<const uint4*>(post_w) + p), pv);
+            rn_unpack8(__ldg(reinterpret_cast<const uint4*>(next_w) + p), nv);
+        }
+        float ss = 0.f;
+        if (live) {
+            #pragma unroll
+            for (int j = 0; j < 8; j++) ss = __fmaf_rn(bv[j], bv[j], ss);
+        }
+        ss = rn_warp_sum(ss);
+        if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+        __syncthreads();
+        if (threadIdx.x < 32) {
+            float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+            v = rn_warp_sum(v);
+            if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + post_eps);
+        }
+        __syncthreads();
+        const float inv1 = s_warp[0];
+
+        float xv[8];
+        float ss2 = 0.f;
+        if (live) {
+            float ov[8];
+            #pragma unroll
+            for (int j = 0; j < 8; j++) ov[j] = rv[j] + bv[j] * inv1 * pv[j];
+            const uint4 packed = rn_pack8(ov);
+            reinterpret_cast<uint4*>(out_x + base)[p] = packed;
+            rn_unpack8(packed, xv);          // the bf16 the separate rmsnorm would have re-read
+            #pragma unroll
+            for (int j = 0; j < 8; j++) ss2 = __fmaf_rn(xv[j], xv[j], ss2);
+        }
+        ss2 = rn_warp_sum(ss2);
+        __syncthreads();                     // every thread has consumed inv1; s_warp is free
+        if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss2;
+        __syncthreads();
+        if (threadIdx.x < 32) {
+            float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+            v = rn_warp_sum(v);
+            if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps);
+        }
+        __syncthreads();
+        const float inv2 = s_warp[0];
+        if (live) {
+            float ov[8];
+            #pragma unroll
+            for (int j = 0; j < 8; j++) ov[j] = xv[j] * inv2 * nv[j];
+            const uint4 packed = rn_pack8(ov);
+            reinterpret_cast<uint4*>(out_xn + base)[p] = packed;
+            // Q8_1(out_xn) for whichever MMVQ consumes this row next -- the FFN's gate/up after
+            // the post-attention tail, the next layer's Q/K/V after the post-FFN one. Both used
+            // to launch a standalone quantize over a row this kernel had just written. Quantizes
+            // the *stored* bf16, and amax and the integer sum are both order-independent, so the
+            // 4-lane form here and the 32-lane si_quant_bf16_q8_1 emit the same block. The
+            // launcher only passes out_q8 when every warp is fully live, so these butterflies
+            // cannot diverge.
+            if (out_q8) {
+                float q[8]; rn_unpack8(packed, q);
+                const int b = p >> 2, r = p & 3;
+                float amax = 0.f;
+                #pragma unroll
+                for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(q[j]));
+                amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+                amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+                const float d = amax / 127.0f;
+                si_blk_q8_1* ob = out_q8 + (size_t)blockIdx.x * (cols >> 5) + b;
+                int s = 0;
+                unsigned w[2] = {0u, 0u};
+                #pragma unroll
+                for (int j = 0; j < 8; j++) {
+                    const int qi = (amax == 0.0f) ? 0 : (int)roundf(q[j] / d);
+                    w[j >> 2] |= ((unsigned)qi & 255u) << ((j & 3) * 8);
+                    s += qi;
+                }
+                // qs[r*8] sits at 36*b + 4 + 8*r, so the eight bytes this lane owns are always
+                // 4-byte aligned: two STG.32 instead of eight STG.U8, same bytes.
+                unsigned* qw = reinterpret_cast<unsigned*>(ob->qs + r * 8);
+                qw[0] = w[0];
+                qw[1] = w[1];
+                s += __shfl_xor_sync(0xffffffffu, s, 1);
+                s += __shfl_xor_sync(0xffffffffu, s, 2);
+                if (r == 0) ob->ds = __floats2half2_rn(d, d * (float)s);
+            }
+        }
+        return;
+    }
 
     // ---- stage 1: norm_then_add over `branch` ----
     const uint4* b4 = reinterpret_cast<const uint4*>(branch + base);
@@ -739,8 +841,8 @@ void launch_add_rmsnorm3_q8_rows(const void* x, const void* res1, const void* re
         reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
 }
 
-void launch_muse_sandwich_tail(const void* residual, const void* branch, const void* post_w,
-                               const void* next_w, void* out_x, void* out_xn,
+bool launch_muse_sandwich_tail(const void* residual, const void* branch, const void* post_w,
+                               const void* next_w, void* out_x, void* out_xn, void* out_q8,
                                int rows, int cols, float post_eps, float eps, cudaStream_t stream) {
     // 256 threads for a 6656-wide row means npack = 832 packs walked 3-4 deep per thread, twice,
     // on a chain of dependent loads -- and the whole thing is one CTA of a 170-SM device. One
@@ -760,13 +862,30 @@ void launch_muse_sandwich_tail(const void* residual, const void* branch, const v
         tail_w = e ? atoi(e) : 1024;
         if (tail_w != 256 && tail_w != 512 && tail_w != 768 && tail_w != 1024) tail_w = 1024;
     }
+    // SPARKINFER_MUSE_TAIL_REG=0 forces the global-memory path, so both arms of an A/B come out
+    // of one binary.
+    static int reg_tail = -1;
+    if (reg_tail < 0) {
+        const char* e = getenv("SPARKINFER_MUSE_TAIL_REG");
+        reg_tail = (e && e[0] == '0') ? 0 : 1;
+    }
+    // The Q8_1 side channel rides the register path only, and only when npack is a whole number
+    // of warps so the 4-lane butterflies stay convergent. Report what actually happened rather
+    // than letting the caller assume: a caller that skips its own quantize on a false promise
+    // feeds the next MMVQ a stale activation, which reads as a confident wrong distribution
+    // rather than as a crash.
+    const int npack = cols >> 3;
+    const bool q8 = out_q8 && reg_tail && npack <= tail_w && (npack << 3) == cols &&
+                    (npack & 31) == 0 && (cols & 31) == 0;
     muse_sandwich_tail_kernel<<<rows, tail_w, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(residual),
         reinterpret_cast<const __nv_bfloat16*>(branch),
         reinterpret_cast<const __nv_bfloat16*>(post_w),
         reinterpret_cast<const __nv_bfloat16*>(next_w),
         reinterpret_cast<__nv_bfloat16*>(out_x),
-        reinterpret_cast<__nv_bfloat16*>(out_xn), cols, post_eps, eps);
+        reinterpret_cast<__nv_bfloat16*>(out_xn),
+        q8 ? reinterpret_cast<si_blk_q8_1*>(out_q8) : nullptr, cols, post_eps, eps, reg_tail);
+    return q8;
 }
 
 // Same sandwich norm, fed straight from the split-K int32 accumulator instead of from a bf16

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -61,9 +61,12 @@ void launch_muse_qknorm_rope_kv(void* q, void* k, const void* v, const void* q_w
                                 int n_q_heads, int n_kv_heads, int head_dim, float theta,
                                 int block_size, float eps, bool do_rope, cudaStream_t stream = nullptr);
 
-void launch_muse_sandwich_tail(const void* residual_bf16, const void* branch_bf16,
+// Returns true if it also wrote Q8_1(out_xn) into out_q8, letting the caller skip the standalone
+// quantize its next MMVQ would otherwise need. Pass out_q8 = nullptr to opt out. Never assume the
+// emission happened -- it is conditional on the row shape and on the register path being taken.
+bool launch_muse_sandwich_tail(const void* residual_bf16, const void* branch_bf16,
                                const void* post_w_bf16, const void* next_w_bf16,
-                               void* out_x_bf16, void* out_xn_bf16,
+                               void* out_x_bf16, void* out_xn_bf16, void* out_q8,
                                int rows, int cols, float post_eps, float eps,
                                cudaStream_t stream = nullptr);
 

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -19,6 +19,10 @@ bool launch_prefill_nvfp4_quant_a(const void* src_bf16, void* dst_fp4, void* dst
 bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf16,
                                        void* dst_fp4, void* dst_sf,
                                        int m, int k, cudaStream_t stream = nullptr);
+// Fuse the dense FFN's bf16-rounded SwiGLU producer into the down projection's FP4 A quantize.
+bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_bf16,
+                                         void* dst_fp4, void* dst_sf,
+                                         int m, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -92,6 +92,9 @@ struct Qwen35LayerWeights {
     // o projection [H, qdim]. Unlike ffn_down (~3.9 GB, reverted in #825) this is ~0.8 GB, and it
     // is gated on a free-VRAM preflight so a card that cannot spare it keeps the int8 path.
     const void* wo_fp4 = nullptr;   const void* wo_fp4_sf = nullptr;
+    // Short-context-only copy; decode retains down_q, so long-context configurations leave this
+    // null to preserve KV and batched-prefill scratch headroom on 32-GB cards.
+    const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4002,6 +4002,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         const char* fp4q_env = getenv("SPARKINFER_MUSE_PREFILL_NVFP4_QKV");
         const bool qkvg_fp4_on = (!fp4q_env || fp4q_env[0] != '0') &&
                                  kernels::prefill_nvfp4_supported(128, 2 * qdim_a + 2 * kvdim_a, H);
+        int down_ready = 0;
         auto convert = [&](const void* src, int qtype, int rows, int cols,
                            const void** data, const void** sf) -> bool {
             void *d = nullptr, *scale = nullptr;
@@ -4059,6 +4060,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         int wo_ready = 0;
         const char* fp4_wo_env = getenv("SPARKINFER_MUSE_NVFP4_WO");
         bool wo_fp4_on = (!fp4_wo_env || fp4_wo_env[0] != '0');
+        const char* fp4o_env = getenv("SPARKINFER_MUSE_NVFP4_OUTPUTS");
+        size_t fp4_free = 0, fp4_total = 0;
+        cudaMemGetInfo(&fp4_free, &fp4_total);
+        (void)fp4_free;
+        bool down_fp4_on = c.max_seq <= 2048;
+        if (fp4o_env)
+            down_fp4_on = fp4o_env[0] == '1' || fp4o_env[0] == 'd';
+        // On a 32-GB card short prefill gets substantially more from down, while down+wo leaves no
+        // safe allocation margin. Long sessions use neither because these kernels require N=128.
+        wo_fp4_on = wo_fp4_on && c.max_seq <= 2048 && fp4_total >= (40ull << 30);
         {
             const size_t reserve = [] {
                 const char* e = getenv("SPARKINFER_MUSE_NVFP4_RESERVE_MB");
@@ -4120,6 +4131,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 ++ready;
                 if (lw.qkvg_fp4) ++qkvg_ready;
             }
+            // Output projections retain their compact GGUF tensors for decode; these FP4 copies
+            // are optional and failure-isolated, so a tight-memory card can still use gate/up.
+            if (ok && down_fp4_on &&
+                convert(lw.down_q, lw.down_qtype, H, c.moe_ffn,
+                        &lw.down_fp4, &lw.down_fp4_sf)) ++down_ready;
         }
         if (tmp) cudaFree(tmp);
         fprintf(stderr, "[prefill-muse] SM120 NVFP4 o-proj weights ready: %d/%d layers\n", wo_ready, c.n_layers);
@@ -4127,6 +4143,8 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                         " (qkv-gate %d/%d)\n",
                 ready, c.n_layers, ok ? "" : " (remaining layers use GGUF fallback)",
                 qkvg_ready, c.n_layers);
+        fprintf(stderr, "[prefill-muse] SM120 NVFP4 down weights ready: %d/%d layers\n",
+                down_ready, c.n_layers);
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
     return true;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1014,6 +1014,14 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
     // are already done. Only the prime norm above still needs the standalone quant (layer 0).
     const bool fnq = s.gguf && s.use_fnq && s.use_pq && s.use_llama;
 
+    // Muse Glimmer's sandwich tail can now emit the Q8_1 its consumer needs, the way
+    // add_rmsnorm2_q8 does for every other architecture. Both flags record what the tail
+    // ACTUALLY did (it declines on shapes its register path cannot serve), never what this
+    // architecture is assumed to do -- a wrong assumption here is the stale-aq81 failure the
+    // comments at the FFN and QKV call sites describe, and it degrades silently.
+    // muse_xn_q8 crosses the layer boundary: layer L's post-FFN tail feeds layer L+1's Q/K/V.
+    bool muse_hn_q8 = false, muse_xn_q8 = false;
+
     // ---- L2 weight prefetch into the sandwich-norm tail's idle window ----
     // Decode is DRAM-bound but only ~86% bus-utilized; the gap is time the bus idles inside a
     // latency-bound kernel. Muse Glimmer's two single-CTA sandwich tails per layer are the largest
@@ -1095,7 +1103,11 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
         // L=1..n_layers-1 (both wk_type=12 Q4_K and wv_type=14 Q6_K route through proj_xn's
         // mmvq_q4k/mmvq_q6k branches, which read s.aq81 unconditionally) ran against the wrong
         // layer's quantized activation. Force a fresh quantize every layer for muse_glimmer.
-        bool xn_q8_ready = fnq && L > 0 && !c.muse_glimmer;
+        bool xn_q8_ready = (fnq && L > 0 && !c.muse_glimmer) || muse_xn_q8;
+        // Both flags are re-earned every layer by the tail that actually ran; consumed here, so
+        // a layer whose tail declines falls back to its own quantize instead of inheriting.
+        muse_hn_q8 = false;
+        muse_xn_q8 = false;
         auto prepare_xn_quant = [&](bool any_q4k, bool any_q6k, bool any_q80) {
             if (!s.gguf || !s.use_pq) return;
             if (xn_q8_ready) return;
@@ -1547,8 +1559,13 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // Cover it with the FFN gate/up matrices, which are streamed immediately after it.
             if (pf_win & 2) pf_fork(w.gate_q, w.up_q);
             if (muse_fuse_tail())
-                kernels::launch_muse_sandwich_tail(s.x, s.ao, w.post_attn_norm, w.ffn_norm,
-                                                   s.h, s.hn, 1, H, 1e-8f, c.rms_eps, st);
+                // hn is the FFN's input; let the tail hand it over already quantized. Nothing
+                // between here and the dense FFN touches aq81 on this architecture (n_shared=0,
+                // no router), so the buffer still holds Q8_1(hn) when gate/up read it.
+                muse_hn_q8 = kernels::launch_muse_sandwich_tail(s.x, s.ao, w.post_attn_norm,
+                                                   w.ffn_norm, s.h, s.hn,
+                                                   fnq ? s.aq81 : nullptr, 1, H, 1e-8f,
+                                                   c.rms_eps, st);
             else {
             kernels::launch_norm_then_add(s.x, s.ao, w.post_attn_norm, s.h, 1, H, 1e-8f, st);
             dbg_bf16(s.h, H, 50, L);   // tag 50: h = x + sandwich_norm(ao)  (post-attn residual)
@@ -1654,7 +1671,8 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,
                                                1, c.top_k, H, c.moe_ffn,
-                                               (fnq && !c.muse_glimmer) ? s.aq81 : nullptr, st);
+                                               (muse_hn_q8 || (fnq && !c.muse_glimmer))
+                                                   ? s.aq81 : nullptr, st);
         } else if (w.gate_q) {   // GGUF fused: route, then dequant-on-read only the top_k experts
             // The per-expert token counts only feed the batched-dispatch sort; the single-token
             // decode expert FFN reads ids/weights directly and never touches them. Zeroing that
@@ -1796,8 +1814,13 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 }
             }
             if (muse_fuse_tail())
-                kernels::launch_muse_sandwich_tail(s.h, s.routed, w.post_ffn_norm, nextnorm,
-                                                   s.x, s.xn, 1, H, 1e-8f, c.rms_eps, st);
+                // xn is the NEXT layer's Q/K/V input; emitting Q8_1(xn) here is what finally
+                // lets muse_glimmer take the xn_q8_ready path other architectures already get
+                // from add_rmsnorm2_q8 / add_rmsnorm3_q8.
+                muse_xn_q8 = kernels::launch_muse_sandwich_tail(s.h, s.routed, w.post_ffn_norm,
+                                                   nextnorm, s.x, s.xn,
+                                                   fnq ? s.aq81 : nullptr, 1, H, 1e-8f,
+                                                   c.rms_eps, st);
             else {
             kernels::launch_norm_then_add(s.h, s.routed, w.post_ffn_norm, s.x, 1, H, 1e-8f, st);
             dbg_bf16(s.x, H, 70, L);   // tag 70: x = h + sandwich_norm(routed)  (layer output)

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1033,17 +1033,18 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4, w.up_fp4_sf,
                                                        ffu, fn, ffn, H, fp4_ws, st);
                 if (layer_fp4) {
-                    kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                     const bool down_fp4_done = muse_nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
                         fp4_down_a && fp4_down_as &&
-                        kernels::launch_prefill_nvfp4_quant_a(
-                            ffg, fp4_down_a, fp4_down_as, fn, ffn, st) &&
+                        kernels::launch_prefill_nvfp4_swiglu_quant_a(
+                            ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn, st) &&
                         kernels::launch_prefill_nvfp4_gemm(
                             fp4_down_a, fp4_down_as, w.down_fp4, w.down_fp4_sf,
                             ao + (size_t)fo * H, fn, H, ffn, fp4_ws, st);
-                    if (!down_fp4_done)
+                    if (!down_fp4_done) {
+                        kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                        ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
+                    }
                     continue;
                 }
                 if (ffn_i8) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -391,12 +391,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                kernels::prefill_nvfp4_supported(N, H, qdim);
     const size_t fp4_ws_wo = muse_nvfp4_wo
         ? kernels::prefill_nvfp4_workspace_bytes(N, H, qdim) : 0;
+    const bool muse_nvfp4_down = muse_nvfp4 && s.w.layers[0].down_fp4 &&
+                                 kernels::prefill_nvfp4_supported(N, H, ffn);
+    const size_t fp4_ws_down = muse_nvfp4_down
+        ? kernels::prefill_nvfp4_workspace_bytes(N, H, ffn) : 0;
     size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
     if (fp4_ws_wo > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_wo;
+    if (fp4_ws_down > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_down;
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
     bf16* fp4_qkv = muse_nvfp4_qkv ? a8.alloc<bf16>((size_t)N * qkvg_n) : nullptr;
+    unsigned char* fp4_down_a = muse_nvfp4_down
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
+    unsigned char* fp4_down_as = muse_nvfp4_down
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, ffn)) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -1025,8 +1034,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                        ffu, fn, ffn, H, fp4_ws, st);
                 if (layer_fp4) {
                     kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                    proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
-                                   ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
+                    const bool down_fp4_done = muse_nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
+                        fp4_down_a && fp4_down_as &&
+                        kernels::launch_prefill_nvfp4_quant_a(
+                            ffg, fp4_down_a, fp4_down_as, fn, ffn, st) &&
+                        kernels::launch_prefill_nvfp4_gemm(
+                            fp4_down_a, fp4_down_as, w.down_fp4, w.down_fp4_sf,
+                            ao + (size_t)fo * H, fn, H, ffn, fp4_ws, st);
+                    if (!down_fp4_done)
+                        proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
+                                       ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     continue;
                 }
                 if (ffn_i8) {


### PR DESCRIPTION
## Summary

Pipeline Muse Glimmer's SM120 FP4 `ffn_down` projection and reuse decode sandwich-tail activation quantization. Keep duplicate FP4 output weights context/VRAM-aware so 32 GB long-context prefill retains enough scratch memory.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 102.48 |
| after (this PR) | 104.30 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 5392.51 |
| after prefill (this PR) | 5885.97 |

<!-- Paste the bench output backing the numbers above (baseline -> this PR). Isolated-kernel
     microbenchmarks are welcome as extra evidence but do NOT count as before/after. -->

```text
RTX 5090, CUDA 12.8, Release sm_120
main: aca62258a68166412dd1aba6256c48ebfe8a1b87
PR:   908b5a1bc68a07442124326a2eff936be6a6dfe8

Command (five alternating runs per commit):
ARCH=120 bench/scripts/bench.sh muse-glimmer-30B-kquant-17gb.gguf --tokens 128 --ctx 128

main decode tok/s:  102.48, 102.48, 102.45, 102.47, 102.50  median 102.48
PR decode tok/s:    104.31, 104.30, 104.30, 104.29, 104.31  median 104.30

main prefill pp:    5010.08, 5263.50, 5593.96, 5392.51, 5476.16  median 5392.51
PR prefill pp:      6001.59, 6117.58, 5549.47, 5537.32, 5885.97  median 5885.97

main VRAM used: 28.1 GB
PR VRAM used:   31.1 GB (ctx128 automatic policy: down=52/52, o=0/52)

Long-context regression check (ctx16384, BF16 KV):
old eager down+o: 31.0 GB, 99.29 tok/s (scratch fallback)
this PR auto:     28.0 GB, 2038.63 tok/s (down=0/52, o=0/52)
```

<!-- More checklist items will be added here later. -->
