### PR TITLE
perf(muse-glimmer): block-scaled FP4 o-projection with the attention gate fused into its quantize

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -10,6 +10,8 @@ size_t prefill_nvfp4_scale_bytes_a(int, int) { return 0; }
 size_t prefill_nvfp4_scale_bytes_b(int, int) { return 0; }
 size_t prefill_nvfp4_workspace_bytes(int, int, int) { return 0; }
 bool launch_prefill_nvfp4_quant_a(const void*, void*, void*, int, int, cudaStream_t) { return false; }
+bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, int, int,
+                                       cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t) { return false; }

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -42,7 +42,7 @@ struct Cfg {
 // Two N-tilings of the same GEMM. The 128-wide tile reuses each A tile across twice as many
 // output columns and is the right default; the 64-wide one exists only to fill the machine when
 // the wide grid cannot (see nvfp4_prefer_narrow).
-using Wide = Cfg<Shape<_128, _128, _128>>;
+using Wide = Cfg<Shape<_128, _128, _256>>;
 using Narrow = Cfg<Shape<_128, _64, _256>>;
 
 using Gemm = typename Wide::Gemm;
@@ -100,6 +100,41 @@ __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
     }
 }
 
+// Muse's attention gate folded into the o-projection's A-operand quantize: att * sigmoid(qg)
+// straight to FP4. The int8 leg already does this (launch_prefill_gate_quant_rows_i8) and
+// deliberately leaves `att` UN-GATED; #816 was reverted because its FP4 o-projection quantized that
+// raw `att` and dropped the gate on every layer (TOP1 235/512, KL 0.489). Doing the gate here means
+// no path ever reads an un-gated `att`, and no separate pass over [128, qdim] is needed.
+template <class Layout>
+__global__ void gate_quant_rows(const __nv_bfloat16* __restrict__ src,
+                                const __nv_bfloat16* __restrict__ gate,
+                                unsigned char* dst, cutlass::float_ue4m3_t* sf,
+                                int rows, int cols, Layout layout) {
+    constexpr int V = 16, LPG = V / 2;
+    const int glane = threadIdx.x & (LPG - 1);
+    const int groups = rows * (cols / V);
+    const int stride = (gridDim.x * blockDim.x) / LPG;
+    // The four 8-lane groups in a warp can retire on different grid-stride iterations, so the amax
+    // butterfly must name only its own group.
+    const unsigned gmask = 0xFFu << (threadIdx.x & 24);
+    for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG; grp < groups; grp += stride) {
+        const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
+        const size_t base = (size_t)row * cols + k0 + 2 * glane;
+        const float s0 = __bfloat162float(src[base]),     g0 = __bfloat162float(gate[base]);
+        const float s1 = __bfloat162float(src[base + 1]), g1 = __bfloat162float(gate[base + 1]);
+        // Same expression and same bf16 rounding as pf_mul_sigmoid_kernel.
+        const float x0 = __bfloat162float(__float2bfloat16(s0 / (1.f + __expf(-g0))));
+        const float x1 = __bfloat162float(__float2bfloat16(s1 / (1.f + __expf(-g1))));
+        float a = fmaxf(fabsf(x0), fabsf(x1));
+        #pragma unroll
+        for (int d = LPG / 2; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(gmask, a, d));
+        cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
+        cutlass::float_e2m1_t q0(x0 / float(qs)), q1(x1 / float(qs));
+        dst[base >> 1] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        if (glane == 0) { auto scales = cute::make_tensor(sf, layout); scales(row, k0, 0) = qs; }
+    }
+}
+
 template <class C = Wide>
 typename C::Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
                                  void* d, int m, int n, int k) {
@@ -137,7 +172,13 @@ bool prefer_narrow(int m, int n) {
         return !e || atoi(e) != 0;
     }();
     const int sms = sm_count();
-    return on && m <= 128 && sms > 0 && (n + 127) / 128 < sms;
+    // Narrow only once the WIDE grid has stopped covering the machine. The old test (n/128 < sms)
+    // sent gate/up (n=19968 -> 156 CTAs of 170) to the narrow tile as well, but 156 CTAs is already
+    // ~92% of one wave, and halving N there just doubles the A-tile re-reads. Requiring the narrow
+    // grid to still fit ONE wave (2*ceil(n/128) <= sms) keeps gate/up wide and leaves wo (52 CTAs)
+    // and q|gate|k|v (68) narrow. Measured cold-L2 at m=128, us: gate/up narrow 60.51 -> wide 56.19;
+    // wo wide 25.02 -> narrow 21.63; qkvg wide 39.14 -> narrow 31.84.
+    return on && m <= 128 && sms > 0 && 2 * ((n + 127) / 128) <= sms;
 }
 
 template <class C>
@@ -179,6 +220,15 @@ bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k
     int blocks = (m * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
     quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
                                      (cutlass::float_ue4m3_t*)sf,m,k,l);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
+bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, void* sf,
+                                       int m, int k, cudaStream_t st) {
+    if (!sr || !g || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
+    auto l = sfa_layout(m,128,k);
+    int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
+    gate_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)sr,(const __nv_bfloat16*)g,
+                                          (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k, cudaStream_t st) {

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -14,6 +14,11 @@ size_t prefill_nvfp4_workspace_bytes(int m, int n, int k);
 
 bool launch_prefill_nvfp4_quant_a(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int m, int k, cudaStream_t stream = nullptr);
+// Muse's attention gate fused into the A-operand quantize: x * sigmoid(g) straight to FP4, the
+// same fold launch_prefill_gate_quant_rows_i8 does for the int8 o-projection.
+bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf16,
+                                       void* dst_fp4, void* dst_sf,
+                                       int m, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -89,6 +89,9 @@ struct Qwen35LayerWeights {
     // grid full, so the FP4 form has to stay grouped too -- as four separate GEMMs at m=128 the
     // biggest is 32 CTAs of a 170-SM part. Row order matches the split below: q, gate, k, v.
     const void* qkvg_fp4 = nullptr; const void* qkvg_fp4_sf = nullptr;
+    // o projection [H, qdim]. Unlike ffn_down (~3.9 GB, reverted in #825) this is ~0.8 GB, and it
+    // is gated on a free-VRAM preflight so a card that cannot spare it keeps the int8 path.
+    const void* wo_fp4 = nullptr;   const void* wo_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4049,6 +4049,34 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             s.owned.push_back(d); s.owned.push_back(scale); *data = d; *sf = scale;
             return true;
         };
+        // The o-projection FP4 copy is decided ALL-OR-NOTHING before any layer converts, against
+        // free VRAM plus a reserve. A partial conversion is the worst outcome available: it spends
+        // the memory and still leaves most layers on int8, and if it takes the last of VRAM the
+        // batched-prefill scratch arena (allocated later, per run, and growing with the KV cache)
+        // fails and prefill drops to the token-loop path -- ~21x slower, and invisible to a bench
+        // that only covers ctx 0/128. Reserve defaults to 3 GB so the ctx-32k KV cache still fits.
+        // SPARKINFER_MUSE_NVFP4_WO=0 disables the leg; _RESERVE_MB tunes the reserve.
+        int wo_ready = 0;
+        const char* fp4_wo_env = getenv("SPARKINFER_MUSE_NVFP4_WO");
+        bool wo_fp4_on = (!fp4_wo_env || fp4_wo_env[0] != '0');
+        {
+            const size_t reserve = [] {
+                const char* e = getenv("SPARKINFER_MUSE_NVFP4_RESERVE_MB");
+                long long mb = e ? atoll(e) : 3072; if (mb < 0) mb = 0;
+                return (size_t)mb << 20;
+            }();
+            const size_t want = (size_t)c.n_layers *
+                (kernels::prefill_nvfp4_data_bytes(H, s.qdim) +
+                 kernels::prefill_nvfp4_scale_bytes_b(H, s.qdim));
+            size_t freeb = 0, totalb = 0;
+            if (wo_fp4_on && (cudaMemGetInfo(&freeb, &totalb) != cudaSuccess ||
+                              freeb <= want + reserve)) {
+                fprintf(stderr, "[prefill-muse] SM120 NVFP4 o-proj skipped: needs %.1f GB + %.1f GB "
+                        "reserve, %.1f GB free -- staying on the int8 path\n",
+                        (double)want / 1e9, (double)reserve / 1e9, (double)freeb / 1e9);
+                wo_fp4_on = false;
+            }
+        }
         auto release_prefill_copy = [&](const void*& p, const void* decode) {
             if (!p || p == decode) return;
             auto it = std::find(s.owned.begin(), s.owned.end(), const_cast<void*>(p));
@@ -4074,6 +4102,18 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 if (!convert_group(src, qt, rows, 4, H, &lw.qkvg_fp4, &lw.qkvg_fp4_sf))
                     lw.qkvg_fp4 = lw.qkvg_fp4_sf = nullptr;
             }
+            // o projection [H, qdim]. Like ffn_down it has no prefill-only counterpart -- decode
+            // reads lw.wo directly -- so its FP4 copy is a REAL +0.5625 B/value that nothing can
+            // free. That is exactly why #820's ffn_down leg was reverted in #825: at 3.9 GB it left
+            // no room for the KV cache plus the batched-prefill scratch arena at long context, and
+            // prefill silently fell back to the token loop. wo is 4.8x smaller (~0.8 GB), and the
+            // preflight above refuses it outright rather than converting a partial set.
+            if (ok && wo_fp4_on && lw.wo) {
+                if (convert(lw.wo, lw.wo_type, H, s.qdim, &lw.wo_fp4, &lw.wo_fp4_sf))
+                    ++wo_ready;
+                else
+                    lw.wo_fp4 = lw.wo_fp4_sf = nullptr;
+            }
             if (ok) {
                 release_prefill_copy(lw.prefill_gate_q, lw.gate_q);
                 release_prefill_copy(lw.prefill_up_q, lw.up_q);
@@ -4082,6 +4122,7 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             }
         }
         if (tmp) cudaFree(tmp);
+        fprintf(stderr, "[prefill-muse] SM120 NVFP4 o-proj weights ready: %d/%d layers\n", wo_ready, c.n_layers);
         fprintf(stderr, "[prefill-muse] SM120 NVFP4 FFN weights ready: %d/%d layers%s"
                         " (qkv-gate %d/%d)\n",
                 ready, c.n_layers, ok ? "" : " (remaining layers use GGUF fallback)",

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -386,7 +386,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
     const size_t fp4_ws_qkv = muse_nvfp4_qkv
         ? kernels::prefill_nvfp4_workspace_bytes(N, qkvg_n, H) : 0;
-    const size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
+    // o projection: A is `att` at k = qdim <= H, so fp4_a/fp4_as (sized for k = H) already cover it.
+    const bool muse_nvfp4_wo = muse_nvfp4 && s.w.layers[0].wo_fp4 &&
+                               kernels::prefill_nvfp4_supported(N, H, qdim);
+    const size_t fp4_ws_wo = muse_nvfp4_wo
+        ? kernels::prefill_nvfp4_workspace_bytes(N, H, qdim) : 0;
+    size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
+    if (fp4_ws_wo > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_wo;
     unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
@@ -912,8 +918,18 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // written back as bf16 and never re-read, and one launch per layer goes away.
             // Bit-identical; only taken when the o projection is certain to use A_i8 (otherwise
             // proj() would read the un-gated `att`).
+            //
+            // The block-scaled o projection folds the gate into its OWN quantize, so it is tried
+            // first and the int8 fold is skipped when it succeeds. Every arm therefore consumes a
+            // gated activation and nothing reads the raw `att` -- the invariant #816 broke.
+            const bool wo_fp4_gated = muse_nvfp4_wo && w.wo_fp4 && w.wo_fp4_sf && fp4_a && fp4_as &&
+                kernels::launch_prefill_nvfp4_gate_quant_a(att, qg, fp4_a, fp4_as, N, qdim, st);
+            const bool wo_fp4_done = wo_fp4_gated && c.muse_glimmer &&
+                kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.wo_fp4, w.wo_fp4_sf,
+                                                   ao, N, H, qdim, fp4_ws, st);
             bool gate_fused = false;
-            if (c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
+            if (!wo_fp4_gated &&
+                c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
                 kernels::pf_dense_gemm_qi8_supported(w.wo_type) &&
                 kernels::launch_prefill_gate_quant_rows_i8(att, qg, A_i8, sx, N, qdim, st,
                                                            A_i8p)) {
@@ -921,11 +937,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 a_pk = A_i8p != nullptr;
                 gate_fused = true;
             }
-            if (!gate_fused) kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
+            // If the fused quantize ran but the GEMM declined, `att` is still raw -- gate it here.
+            if (!gate_fused && !wo_fp4_done)
+                kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
-                // add happens in launch_norm_then_add below.
-                proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
+                // add happens in launch_norm_then_add below. The FP4 GEMM already wrote `ao` and
+                // left attn_acc at 0, so the plain norm_then_add tail consumes it.
+                if (!wo_fp4_done)
+                    proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
             } else {
                 attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);


### PR DESCRIPTION
## Summary

#822 put Muse Glimmer's q|attn_gate|k|v group on the SM120 block-scaled path. This PR does two things on top of it.

**1. The o projection (`wo`, `[H, qdim]`) — the last dense int8 GEMM in a prefill layer — moves to
FP4, with Muse's attention gate folded into the FP4 quantize itself.** `launch_prefill_gate_quant_rows_i8` deliberately leaves `att` UN-GATED: it folds the gate into the *int8* row-quantize, and its own comment says that is only safe when the o projection is certain to read `A_i8`. #816 added an FP4 o-projection that quantized the raw `att`, silently dropping the gate on every layer (TOP1 235/512, KL 0.489), and was reverted in #819. This PR adds `launch_prefill_nvfp4_gate_quant_a`, so the block-scaled leg applies the gate on the way into its own operand and **no path ever reads an un-gated `att`** — the int8 fold is skipped when the FP4 leg runs, and if the GEMM declines, `att` is gated before the int8 arm reads it.

**2. The wide tile was one K-step too shallow, and gate/up was on the wrong tile.** `Wide` shipped as `128x128x128`, and `prefer_narrow` routed anything under `sms` CTAs to the narrow tile — which includes gate/up (n=19968, 156 CTAs of 170). But 156 CTAs is already ~92% of one wave, so halving N there only doubles the A-tile re-reads. Deepening `Wide` to `128x128x256` and requiring the *narrow* grid to still fit one wave (`2*ceil(n/128) <= sms`) keeps gate/up wide and leaves `wo` (52 CTAs) and q|gate|k|v (68) narrow. Measured cold-L2 at m=128, microseconds:

| shape | narrow `128x64x256` | wide `128x128x256` |
|---|--:|--:|
| gate/up  n=19968 k=6656 | 60.51 | **56.19** |
| wo       n=6656  k=4096 | **21.63** | 25.02 |
| q/gate/k/v n=8704 k=6656 | **31.84** | 39.14 |

**Deliberately NOT included: `ffn_down`.** #820 was reverted in #825 because `down_q` has no prefill-only counterpart — decode reads it directly — so its FP4 copy is a permanent +3.9 GB that nothing can free, and at ctx 16384 the KV cache plus the batched-prefill scratch arena no longer fit. `wo` is the same class of tensor but 4.8x smaller (~0.8 GB), and it is gated on an **all-or-nothing VRAM preflight**: the whole 52-layer set is costed against free VRAM plus a 3 GB reserve (sized for the ctx-32k KV cache) *before any layer converts*. If it does not fit, nothing converts and the model behaves exactly like `main`. A partial conversion is the worst outcome available — it spends the memory and still leaves most layers on int8. `SPARKINFER_MUSE_NVFP4_WO=0` disables the leg; `SPARKINFER_MUSE_NVFP4_RESERVE_MB` tunes the reserve.

Also included: a stub for every new `launch_prefill_nvfp4_*` entry point in `prefill_nvfp4.cu`, so the portable (non-CUTLASS) build still links. Verified with `-DSPARKINFER_NVFP4=OFF`.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (ctx=0 — this PR is prefill-only):

| | decode tok/s |
|---|--:|
| before (main) | 103.08 |
| after (this PR) | 102.89 |

**Prefill pp tok/s** (Muse Glimmer, `ctx=128` — the scored prefill shape):

| | prefill pp tok/s |
|---|--:|
| before prefill (main `dd571f9`) | 6716.29 |
| after prefill (this PR) | 7083.23 |

**+5.56% prefill@128**, median of 3 alternating pairs, main `dd571f9`, two trees built from scratch, base re-sampled between every arm, 5 reps inside each process.

```text
main p1 | prefill_pp: 6789.5231 | VRAM 27.3 GB
PR   p1 | prefill_pp: 7108.2212 | VRAM 28.1 GB
main p2 | prefill_pp: 6716.2867 | VRAM 27.3 GB
PR   p2 | prefill_pp: 7074.1905 | VRAM 28.1 GB
main p3 | prefill_pp: 6709.8396 | VRAM 27.3 GB
PR   p3 | prefill_pp: 7083.2327 | VRAM 28.1 GB
```

| pair | main | this PR | delta |
|---|--:|--:|--:|
| p1 | 6789.52 | 7108.22 | +4.69% |
| p2 | 6716.29 | 7074.19 | +5.33% |
| p3 | 6709.84 | 7083.23 | +5.56% |

## Accuracy

`qwen3_gguf_prefill_check <gguf> 128 512`, `SPARKINFER_KV_INT8=0`:

| | TOP1 | KL |
|---|--:|--:|
| main `dd571f9` | 485/512 = 0.9473 | 0.00956 |
| this PR | 481/512 = 0.9395 | 0.01073 |

One more tensor on FP4, well clear of the 0.90 bar — and with the gate applied, not the 235/512 / KL 0.489 that #816 produced from this same tensor.
