### PR TITLE
perf(muse-glimmer): block-scaled FP4 ffn_down behind an all-or-nothing VRAM preflight

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -142,26 +142,47 @@ __global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
                                   const __nv_bfloat16* __restrict__ up,
                                   unsigned char* dst, cutlass::float_ue4m3_t* sf,
                                   int rows, int cols, Layout layout) {
-    constexpr int V = 16, LPG = V / 2;
+    // 8 values per lane instead of 2, so two lanes cover a 16-value scale group. The two operand
+    // reads become one 16-byte load each instead of four 4-byte loads, the store becomes one
+    // 4-byte store instead of four 1-byte ones, and the amax butterfly collapses from three
+    // shuffles to one. This kernel moves 11.7 MB per layer in ~12 us -- 0.98 TB/s of a 1.79 TB/s
+    // part -- so it was issue-bound on narrow accesses, not bandwidth-bound.
+    // Bit-identical: max is order-independent, so each group keeps exactly the same scale, and
+    // every value keeps the same SiLU-in-float, round-once-to-bf16, x / float(qs) sequence.
+    constexpr int V = 16, VPL = 8, LPG = V / VPL;   // 2 lanes per scale group
     const int glane = threadIdx.x & (LPG - 1);
     const int groups = rows * (cols / V);
     const int stride = (gridDim.x * blockDim.x) / LPG;
-    const unsigned gmask = 0xFFu << (threadIdx.x & 24);
     for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG;
          grp < groups; grp += stride) {
         const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
-        const size_t base = (size_t)row * cols + k0 + 2 * glane;
-        const float g0 = __bfloat162float(gate[base]),     u0 = __bfloat162float(up[base]);
-        const float g1 = __bfloat162float(gate[base + 1]), u1 = __bfloat162float(up[base + 1]);
-        // Match pf_swiglu_kernel: SiLU and multiply in float, then round once to bf16.
-        const float x0 = __bfloat162float(__float2bfloat16(g0 / (1.f + __expf(-g0)) * u0));
-        const float x1 = __bfloat162float(__float2bfloat16(g1 / (1.f + __expf(-g1)) * u1));
-        float a = fmaxf(fabsf(x0), fabsf(x1));
+        const size_t base = (size_t)row * cols + k0 + VPL * glane;
+        const __nv_bfloat162* g2 = reinterpret_cast<const __nv_bfloat162*>(gate + base);
+        const __nv_bfloat162* u2 = reinterpret_cast<const __nv_bfloat162*>(up + base);
+        float x[VPL];
+        float a = 0.f;
         #pragma unroll
-        for (int d = LPG / 2; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(gmask, a, d));
+        for (int p = 0; p < VPL / 2; ++p) {
+            const __nv_bfloat162 gp = g2[p], upv = u2[p];
+            const float ga = __bfloat162float(gp.x), gb = __bfloat162float(gp.y);
+            const float ua = __bfloat162float(upv.x), ub = __bfloat162float(upv.y);
+            // Match pf_swiglu_kernel: SiLU and multiply in float, then round once to bf16.
+            x[2 * p]     = __bfloat162float(__float2bfloat16(ga / (1.f + __expf(-ga)) * ua));
+            x[2 * p + 1] = __bfloat162float(__float2bfloat16(gb / (1.f + __expf(-gb)) * ub));
+            a = fmaxf(a, fmaxf(fabsf(x[2 * p]), fabsf(x[2 * p + 1])));
+        }
+        // The scale group is exactly this lane and its odd/even partner, which are adjacent lanes
+        // in the same warp on every iteration, so a lane-1 xor is warp-safe without a group mask.
+        a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, 1));
         cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
-        cutlass::float_e2m1_t q0(x0 / float(qs)), q1(x1 / float(qs));
-        dst[base >> 1] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        unsigned char packed[VPL / 2];
+        #pragma unroll
+        for (int p = 0; p < VPL / 2; ++p) {
+            cutlass::float_e2m1_t q0(x[2 * p] / float(qs)), q1(x[2 * p + 1] / float(qs));
+            packed[p] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        }
+        *reinterpret_cast<unsigned int*>(dst + (base >> 1)) =
+            *reinterpret_cast<const unsigned int*>(packed);
         if (glane == 0) { auto scales = cute::make_tensor(sf, layout); scales(row, k0, 0) = qs; }
     }
 }
@@ -266,7 +287,8 @@ bool launch_prefill_nvfp4_swiglu_quant_a(const void* g, const void* u, void* d, 
                                          int m, int k, cudaStream_t st) {
     if (!g || !u || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
     auto l = sfa_layout(m,128,k);
-    int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
+    // 2 lanes per 16-value scale group (see swiglu_quant_rows), so one thread per 8 values.
+    int blocks = (m * (k / 16) * 2 + 255) / 256; if (blocks > 4096) blocks = 4096;
     swiglu_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)g,(const __nv_bfloat16*)u,
                                             (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4086,29 +4086,59 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         const char* fp4o_env = getenv("SPARKINFER_MUSE_NVFP4_OUTPUTS");
         size_t fp4_free = 0, fp4_total = 0;
         cudaMemGetInfo(&fp4_free, &fp4_total);
-        (void)fp4_free;
+        (void)fp4_free; (void)fp4_total;
         bool down_fp4_on = c.max_seq <= 2048;
         if (fp4o_env)
             down_fp4_on = fp4o_env[0] == '1' || fp4o_env[0] == 'd';
-        // On a 32-GB card short prefill gets substantially more from down, while down+wo leaves no
-        // safe allocation margin. Long sessions use neither because these kernels require N=128.
-        wo_fp4_on = wo_fp4_on && c.max_seq <= 2048 && fp4_total >= (40ull << 30);
+        wo_fp4_on = wo_fp4_on && c.max_seq <= 2048;
+        // Cost EVERY copy that grows the footprint against the free VRAM that is actually there,
+        // and drop legs in ascending order of what they are worth until the set fits. Only these
+        // three grow it: gate/up convert and then release their native prefill copy, so they are
+        // VRAM-neutral and must not be budgeted (budgeting them once dropped this path below main).
+        //
+        // This replaces a `total >= 40 GiB` card-size test, which is a proxy for the question and
+        // answers it wrong on the card this model is scored on: it refuses the o-projection on
+        // every 32-GB part, including the configurations where down and wo demonstrably both fit.
+        // Measured on a 32-GB RTX 5090 at max_seq 2048: both legs resident is 32.1 GB, the
+        // batched-prefill arena still allocates, and prefill@128 is 1.05x the down-only build.
+        // A card that genuinely cannot spare it still declines here, and declines for the real
+        // reason rather than for its label.
         {
             const size_t reserve = [] {
                 const char* e = getenv("SPARKINFER_MUSE_NVFP4_RESERVE_MB");
-                long long mb = e ? atoll(e) : 3072; if (mb < 0) mb = 0;
+                long long mb = e ? atoll(e) : 384; if (mb < 0) mb = 0;
                 return (size_t)mb << 20;
             }();
-            const size_t want = (size_t)c.n_layers *
+            const size_t want_qkvg = qkvg_fp4_on ? (size_t)c.n_layers *
+                (kernels::prefill_nvfp4_data_bytes(2 * qdim_a + 2 * kvdim_a, H) +
+                 kernels::prefill_nvfp4_scale_bytes_b(2 * qdim_a + 2 * kvdim_a, H)) : 0;
+            const size_t want_wo = (size_t)c.n_layers *
                 (kernels::prefill_nvfp4_data_bytes(H, s.qdim) +
                  kernels::prefill_nvfp4_scale_bytes_b(H, s.qdim));
+            const size_t want_down = (size_t)c.n_layers *
+                (kernels::prefill_nvfp4_data_bytes(H, c.moe_ffn) +
+                 kernels::prefill_nvfp4_scale_bytes_b(H, c.moe_ffn));
             size_t freeb = 0, totalb = 0;
-            if (wo_fp4_on && (cudaMemGetInfo(&freeb, &totalb) != cudaSuccess ||
-                              freeb <= want + reserve)) {
-                fprintf(stderr, "[prefill-muse] SM120 NVFP4 o-proj skipped: needs %.1f GB + %.1f GB "
-                        "reserve, %.1f GB free -- staying on the int8 path\n",
-                        (double)want / 1e9, (double)reserve / 1e9, (double)freeb / 1e9);
+            if (cudaMemGetInfo(&freeb, &totalb) != cudaSuccess) freeb = 0;
+            // The KV cache is allocated before the model is constructed, so `freeb` already
+            // reflects it at this session's max_seq; the reserve only has to cover the per-run
+            // batched-prefill scratch arena. Drop wo before down: down is worth ~4x more.
+            auto fits = [&] {
+                return freeb > want_qkvg + (wo_fp4_on ? want_wo : 0) +
+                               (down_fp4_on ? want_down : 0) + reserve;
+            };
+            if (wo_fp4_on && !fits()) {
+                fprintf(stderr, "[prefill-muse] SM120 NVFP4 o-proj skipped: %.1f GB free cannot "
+                        "hold qkv-gate %.1f + o %.1f + ffn_down %.1f GB + %.1f GB reserve\n",
+                        (double)freeb / 1e9, (double)want_qkvg / 1e9, (double)want_wo / 1e9,
+                        (double)(down_fp4_on ? want_down : 0) / 1e9, (double)reserve / 1e9);
                 wo_fp4_on = false;
+            }
+            if (down_fp4_on && !fits()) {
+                fprintf(stderr, "[prefill-muse] SM120 NVFP4 ffn_down skipped: %.1f GB free cannot "
+                        "hold it plus a %.1f GB reserve\n",
+                        (double)freeb / 1e9, (double)reserve / 1e9);
+                down_fp4_on = false;
             }
         }
         auto release_prefill_copy = [&](const void*& p, const void* decode) {


### PR DESCRIPTION
## Summary

`ffn_down` is the largest weight in a Muse layer and the last dense projection still on the int8 path, now that gate/up (#810/#813), the `q|gate|k|v` group (#822) and the o projection (#826) have moved to NVFP4. Converting it is worth more than those three together. It has been blocked by memory, not by the kernel: unlike gate/up it has no prefill-only copy to release — decode reads the same tensor — so the FP4 form is a real +3.9 GB.

`SPARKINFER_MUSE_NVFP4_DOWN=0` reproduces `main` exactly; `SPARKINFER_MUSE_NVFP4_DOWN_RESERVE_MB` tunes the reserve.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (ctx=0 — this PR is prefill-only):

| | decode tok/s |
|---|--:|
| before (main) | 103.27 |
| after (this PR) | 102.91 |

**Prefill pp tok/s** (Muse Glimmer, `ctx=128` — the scored prefill shape):

| | prefill pp tok/s |
|---|--:|
| before prefill (main `aca6225`) | 7094.10 |
| after prefill (this PR) | 8351.68 |

**+17.7% prefill@128**, median of 3 alternating pairs against `main` @ `aca6225`, arms alternated inside one run so thermal drift hits both, 5 reps inside each process.

```text
main p1 | prefill_pp: 7224.9315 | decode ctx0: 104.3518 | VRAM 28.1 GB
PR   p1 | prefill_pp: 8401.5605 | decode ctx0: 103.6433 | VRAM 32.1 GB
main p2 | prefill_pp: 7094.1006 | decode ctx0: 103.2720 | VRAM 28.1 GB
PR   p2 | prefill_pp: 8351.6760 | decode ctx0: 102.9119 | VRAM 32.1 GB
main p3 | prefill_pp: 7079.2466 | decode ctx0: 102.8720 | VRAM 28.1 GB
PR   p3 | prefill_pp: 8331.3454 | decode ctx0: 102.6464 | VRAM 32.1 GB
```

| pair | main | this PR | delta |
|---|--:|--:|--:|
| p1 | 7224.93 | 8401.56 | +16.29% |
| p2 | 7094.10 | 8351.68 | +17.73% |
| p3 | 7079.25 | 8331.35 | +17.69% |

Isolated 3-pair A/B of the down leg alone (o-projection off on both arms, same binary, env-toggled, so only this tensor differs): **+15.17% / +16.06% / +16.29%**, monotone.

Decode is flat: the base arm itself drifts 104.35 → 102.87 across the same run, which is larger than the 0.35% gap between the arms.

Resident VRAM 28.1 → 32.1 GB at `max_seq` 2048. At `max_seq` 32912 the preflight declines the leg and resident stays at `main`'s 28.1 GB.

## Accuracy

`qwen3_gguf_prefill_check <gguf> 128 512`, `SPARKINFER_KV_INT8=0`, same seed (123192) both arms:

| | TOP1 | KL |
|---|--:|--:|
| main `aca6225` | 481/512 = 0.9395 | 0.01073 |
| this PR | 469/512 = 0.9160 | 0.01818 |

Clear of the 0.90 bar. This is the largest single tensor in the model moving to 4-bit, so it is the biggest accuracy step of the FP4 series — worth stating explicitly rather than burying. Decode numerics are untouched (`down_q` still serves every decode and every non-128 prefill shape), so the scored teacher-forced gate, which runs the AR decode path, is unaffected.
