### PR TITLE
perf(muse-glimmer): wider prefill attention loads and a one-pass q|gate|k|v split (1.03x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1090,6 +1090,52 @@ void launch_prefill_add(const void* a, const void* b, void* out, long n, cudaStr
         reinterpret_cast<__nv_bfloat16*>(out), n);
 }
 
+// Scatter one contiguous [N, src_cols] projection block into four tight destinations.
+//
+// Muse's q|gate|k|v prefill projection is a single grouped GEMM into a [N, qdim*2 + kvdim*2]
+// buffer, and the rest of the layer wants four arrays each with its own tight row stride. That
+// was four cudaMemcpy2DAsync calls -- four launches and four strided engine passes over the same
+// 2.2 MB, 1.39 us apiece measured at prefill@128. One pass with a uint4 body does the same bytes
+// in one launch: every thread moves 8 bf16, and each segment boundary (0, qdim, 2*qdim,
+// 2*qdim+kvdim, src_cols) is a multiple of 8 for every shape this runs on, so no thread ever
+// straddles two destinations. Same bytes, same order, bit-identical.
+__global__ void pf_split4_kernel(const __nv_bfloat16* __restrict__ src,
+                                 __nv_bfloat16* __restrict__ d0, __nv_bfloat16* __restrict__ d1,
+                                 __nv_bfloat16* __restrict__ d2, __nv_bfloat16* __restrict__ d3,
+                                 int rows, int src_cols, int n0, int n1, int n2, int n3) {
+    constexpr int V = 8;
+    const long vec_per_row = src_cols / V;
+    const long total = (long)rows * vec_per_row;
+    for (long i = (long)blockIdx.x * blockDim.x + threadIdx.x; i < total;
+         i += (long)gridDim.x * blockDim.x) {
+        const int row = (int)(i / vec_per_row);
+        const int c = (int)(i - (long)row * vec_per_row) * V;
+        const uint4 v = *reinterpret_cast<const uint4*>(src + (long)row * src_cols + c);
+        __nv_bfloat16* dst;
+        int off;
+        if (c < n0)                     { dst = d0; off = c;                     }
+        else if (c < n0 + n1)           { dst = d1; off = c - n0;                }
+        else if (c < n0 + n1 + n2)      { dst = d2; off = c - n0 - n1;           }
+        else                            { dst = d3; off = c - n0 - n1 - n2;      }
+        const int w = (dst == d0) ? n0 : (dst == d1) ? n1 : (dst == d2) ? n2 : n3;
+        *reinterpret_cast<uint4*>(dst + (long)row * w + off) = v;
+    }
+}
+
+void launch_prefill_split4(const void* src, void* d0, void* d1, void* d2, void* d3,
+                           int rows, int n0, int n1, int n2, int n3, cudaStream_t stream) {
+    const int src_cols = n0 + n1 + n2 + n3;
+    if (rows <= 0 || (src_cols & 7) || (n0 & 7) || (n1 & 7) || (n2 & 7) || (n3 & 7)) return;
+    const long total = (long)rows * (src_cols / 8);
+    int blocks = (int)((total + 255) / 256);
+    if (blocks > 8192) blocks = 8192;
+    if (blocks < 1) blocks = 1;
+    pf_split4_kernel<<<blocks, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(src), reinterpret_cast<__nv_bfloat16*>(d0),
+        reinterpret_cast<__nv_bfloat16*>(d1), reinterpret_cast<__nv_bfloat16*>(d2),
+        reinterpret_cast<__nv_bfloat16*>(d3), rows, src_cols, n0, n1, n2, n3);
+}
+
 void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,
                                  int n_tokens, int n_heads, int head_dim, cudaStream_t stream) {
     const long n = (long)n_tokens * n_heads * head_dim;

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -669,6 +669,165 @@ bool launch_prefill_attn_windowed(
     return false;   // window + tiling both off -> caller runs full attention
 }
 
+// ----------------------------------------------------------------------------
+// Faster and more accurate schedule for the kernel above. Same decomposition --
+// one warp per query, keys walked in ascending kpos, the same fp32 online
+// softmax, the same pure rolling-window predicate -- with three changes.
+//
+// 1. Lane owns 4 CONSECUTIVE head dims instead of `lane + e*32`. The strided
+//    form is a 2-byte-per-lane shared load, so a warp moves 64 B per
+//    instruction, and it pays that four times per key for K and four for V.
+//    Consecutive-four is one __nv_bfloat162 pair: 256 B per warp instruction
+//    and a quarter of the LDS. Q, the V accumulation and the store follow.
+//
+// 2. KG keys are scored before any of them is reduced. Per key the old loop is
+//    a single dependent chain -- 4 FMAs, a 5-step shuffle butterfly, two
+//    __expf, then the loop-carried m/l/acc update -- and only the FMAs are
+//    work. Scoring KG first makes the butterflies independent so their shuffle
+//    steps interleave. KG=4 measured best of {1,2,4,8} (+1.24 / +1.88 / +1.45%
+//    end to end at 1,4,8); past 4 the live scores cost more than they buy.
+//
+// 3. The cross-lane butterfly runs ASCENDING (1,2,4,8,16). win_warp_sum() goes
+//    16->1, which pairs each lane with the one holding dims 16 away before
+//    pairing neighbours; ascending sums adjacent dims first, which are far
+//    closer in magnitude, so the 32-term reduction is better conditioned. This
+//    is why the kernel is MORE accurate than the one above, not less.
+//
+// ncu at prefill@128 on the old kernel: L1/TEX throughput 67.95% with DRAM at
+// 1.61% and 39.7% of a 9.75-cycle issue gap in MIO short-scoreboard -- bound by
+// shared-memory issue, not bandwidth and not math. After: 60.68% and 8.03.
+//
+// Numerics move (the 32-term dot is re-associated) and they move the right way.
+// qwen3_gguf_prefill_check 128/512, SPARKINFER_KV_INT8=0, batched vs the token
+// reference:  main 469/512 = 0.9160, KL 0.01818  ->  this 480/512 = 0.9375,
+// KL 0.01427. The per-lane 4-term sum is exact in fp32 (a bf16*bf16 product
+// carries at most 16 mantissa bits), so only the cross-lane order matters --
+// reversing the per-lane order alone is bit-identical.
+// SPARKINFER_MUSE_PREFILL_ATTN_WIDE=0 restores the kernel above.
+// ----------------------------------------------------------------------------
+template <int HEAD_DIM, int TQ, int TK, int KG>
+__global__ void win_prefill_pure_bf16_wide_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    (void)max_blocks_per_seq;
+    constexpr int ELEMS = HEAD_DIM / 32;
+    static_assert(ELEMS == 4, "four consecutive dims per lane");
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int head = blockIdx.y;
+    const int qbase = blockIdx.x * TQ;
+    const int qtok = qbase + warp;
+    const int kv_head = head / (n_q_heads / n_kv_heads);
+    const bool active = (qtok < n_tokens) && (head < n_q_heads);
+    const int d0 = lane * ELEMS;
+
+    auto win_start = [&](int t) -> int {
+        if (win_blocks <= 0) return 0;
+        const int n_blk_q = (t + block_size) / block_size;
+        const int rsb = (win_blocks >= n_blk_q) ? 0 : (n_blk_q - win_blocks);
+        return rsb * block_size;
+    };
+    const int my_rs = active ? win_start(qtok) : 0;
+
+    extern __shared__ __nv_bfloat16 smem_bfw[];
+    __nv_bfloat16* sK = smem_bfw;
+    __nv_bfloat16* sV = smem_bfw + TK * HEAD_DIM;
+
+    float q_reg[ELEMS];
+    if (active) {
+        const size_t q_off = ((size_t)qtok * n_q_heads + head) * HEAD_DIM;
+        const __nv_bfloat162* qp = reinterpret_cast<const __nv_bfloat162*>(q + q_off + d0);
+        const __nv_bfloat162 a = qp[0], b = qp[1];
+        q_reg[0] = __bfloat162float(a.x); q_reg[1] = __bfloat162float(a.y);
+        q_reg[2] = __bfloat162float(b.x); q_reg[3] = __bfloat162float(b.y);
+    }
+    float m = -1e30f, l = 0.f, acc[ELEMS];
+#pragma unroll
+    for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
+
+    const int last_q = min(qbase + TQ - 1, n_tokens - 1);
+    const int blk_rs = win_start(qbase);
+
+    for (int k0 = blk_rs; k0 <= last_q; k0 += TK) {
+        const int tk = min(TK, last_q + 1 - k0);
+        // One 16-byte copy per thread, and the paged-KV address math once per THREAD rather than
+        // once per element (see win_prefill_pure_bf16_kernel). Same bytes, same order.
+        constexpr int VPT = 8;
+        constexpr int DCH = HEAD_DIM / VPT;
+        for (int idx = threadIdx.x; idx < tk * DCH; idx += blockDim.x) {
+            const int kk = idx / DCH, d = (idx - kk * DCH) * VPT;
+            const int kpos = k0 + kk;
+            const int blk = kpos / block_size, within = kpos - blk * block_size;
+            const int phys = block_table[blk];
+            const size_t ckt = (size_t)phys * block_size + within;
+            const size_t off = (ckt * n_kv_heads + kv_head) * HEAD_DIM + d;
+            *reinterpret_cast<uint4*>(sK + (size_t)kk * HEAD_DIM + d) =
+                *reinterpret_cast<const uint4*>(k_pool + off);
+            *reinterpret_cast<uint4*>(sV + (size_t)kk * HEAD_DIM + d) =
+                *reinterpret_cast<const uint4*>(v_pool + off);
+        }
+        __syncthreads();
+        if (active) {
+            // Warp-uniform, so a key's validity is warp-uniform and the grouping below never
+            // splits a warp before its butterfly.
+            const int lo = max(k0, my_rs);
+            const int hi = min(k0 + tk - 1, qtok);
+            for (int base = lo; base <= hi; base += KG) {
+                const int n = min(KG, hi + 1 - base);
+                float part[KG];
+#pragma unroll
+                for (int g = 0; g < KG; g++) {
+                    part[g] = 0.f;
+                    if (g < n) {
+                        const __nv_bfloat162* kp = reinterpret_cast<const __nv_bfloat162*>(
+                            sK + (size_t)(base + g - k0) * HEAD_DIM + d0);
+                        const __nv_bfloat162 a = kp[0], b = kp[1];
+                        part[g] = q_reg[0] * __bfloat162float(a.x)
+                                + q_reg[1] * __bfloat162float(a.y)
+                                + q_reg[2] * __bfloat162float(b.x)
+                                + q_reg[3] * __bfloat162float(b.y);
+                    }
+                }
+#pragma unroll
+                for (int d2 = 1; d2 <= 16; d2 <<= 1) {
+#pragma unroll
+                    for (int g = 0; g < KG; g++)
+                        part[g] += __shfl_xor_sync(0xffffffffu, part[g], d2);
+                }
+#pragma unroll
+                for (int g = 0; g < KG; g++) {
+                    if (g >= n) break;
+                    const float score = part[g] * scale;
+                    const float m_new = fmaxf(m, score);
+                    const float corr = __expf(m - m_new);
+                    const float pr = __expf(score - m_new);
+                    l = l * corr + pr;
+                    const __nv_bfloat162* vp = reinterpret_cast<const __nv_bfloat162*>(
+                        sV + (size_t)(base + g - k0) * HEAD_DIM + d0);
+                    const __nv_bfloat162 a = vp[0], b = vp[1];
+                    acc[0] = acc[0] * corr + pr * __bfloat162float(a.x);
+                    acc[1] = acc[1] * corr + pr * __bfloat162float(a.y);
+                    acc[2] = acc[2] * corr + pr * __bfloat162float(b.x);
+                    acc[3] = acc[3] * corr + pr * __bfloat162float(b.y);
+                    m = m_new;
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (active) {
+        const size_t q_off = ((size_t)qtok * n_q_heads + head) * HEAD_DIM;
+        const float inv = (l > 0.f) ? (1.f / l) : 0.f;
+        __nv_bfloat162 o0, o1;
+        o0.x = __float2bfloat16(acc[0] * inv); o0.y = __float2bfloat16(acc[1] * inv);
+        o1.x = __float2bfloat16(acc[2] * inv); o1.y = __float2bfloat16(acc[3] * inv);
+        __nv_bfloat162* op = reinterpret_cast<__nv_bfloat162*>(attn + q_off + d0);
+        op[0] = o0; op[1] = o1;
+    }
+}
+
 // BF16-KV pure-window prefill attention for Muse Glimmer (hd128). win_blocks>0 =>
 // SWA layers (last win_blocks blocks); win_blocks<=0 => global/NoPE full causal.
 void launch_prefill_attn_swa_pure_bf16(
@@ -688,6 +847,18 @@ void launch_prefill_attn_swa_pure_bf16(
     constexpr int TQ = 8, TK = 32, HD = 128;
     const size_t sm = (size_t)2 * TK * HD * sizeof(__nv_bfloat16);   // 16 KB: K + V bf16 tiles
     dim3 grid((n_tokens + TQ - 1) / TQ, n_q_heads);
+    static const bool wide = [] {
+        const char* e = getenv("SPARKINFER_MUSE_PREFILL_ATTN_WIDE");
+        return !(e && e[0] == '0');
+    }();
+    if (wide) {
+        win_prefill_pure_bf16_wide_kernel<HD, TQ, TK, 4><<<grid, TQ * 32, sm, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
+            reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
+            reinterpret_cast<__nv_bfloat16*>(attn),
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
+        return;
+    }
     win_prefill_pure_bf16_kernel<HD, TQ, TK><<<grid, TQ * 32, sm, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
         reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -33,6 +33,12 @@ void launch_prefill_swiglu(const void* gate, const void* up, void* h, long n,
 void launch_prefill_add(const void* a, const void* b, void* out, long n,
                         cudaStream_t stream = nullptr);
 
+// Scatter a contiguous [rows, n0+n1+n2+n3] block into four tight [rows, ni] destinations in one
+// pass. Every ni and their sum must be a multiple of 8. Replaces a run of cudaMemcpy2DAsync.
+void launch_prefill_split4(const void* src, void* d0, void* d1, void* d2, void* d3,
+                           int rows, int n0, int n1, int n2, int n3,
+                           cudaStream_t stream = nullptr);
+
 // Split interleaved-per-head [q|gate]: qraw[N, 2*n_heads*hd] (each head is hd q then hd gate)
 // -> q[N, n_heads*hd], gate[N, n_heads*hd]. Matches split_q_gate_kernel, batched over tokens.
 void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -850,17 +850,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_as, N, H, st) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.qkvg_fp4, w.qkvg_fp4_sf,
                                                        fp4_qkv, N, qkvg_n, H, fp4_ws, st)) {
-                    const size_t sp = (size_t)qkvg_n * sizeof(bf16);
-                    struct { void* dst; int off, n; } cut[4] = {
-                        { qb, 0,            qdim  }, { qg, qdim,          qdim  },
-                        { kf, 2 * qdim,     kvdim }, { vf, 2 * qdim + kvdim, kvdim },
-                    };
-                    qkvg_fp4 = true;
-                    for (auto& cu : cut)
-                        qkvg_fp4 &= cudaMemcpy2DAsync(cu.dst, (size_t)cu.n * sizeof(bf16),
-                                                      fp4_qkv + cu.off, sp,
-                                                      (size_t)cu.n * sizeof(bf16), N,
-                                                      cudaMemcpyDeviceToDevice, st) == cudaSuccess;
+                    // One scatter pass instead of four strided D2D copies (four launches over
+                    // the same 2.2 MB). Same bytes, same destinations, bit-identical.
+                    // SPARKINFER_MUSE_PREFILL_SPLIT4=0 restores the copies.
+                    static const bool split4 = [] {
+                        const char* e = getenv("SPARKINFER_MUSE_PREFILL_SPLIT4");
+                        return !(e && e[0] == '0');
+                    }();
+                    if (split4) {
+                        kernels::launch_prefill_split4(fp4_qkv, qb, qg, kf, vf, N,
+                                                       qdim, qdim, kvdim, kvdim, st);
+                        qkvg_fp4 = cudaPeekAtLastError() == cudaSuccess;
+                    } else {
+                        const size_t sp = (size_t)qkvg_n * sizeof(bf16);
+                        struct { void* dst; int off, n; } cut[4] = {
+                            { qb, 0,            qdim  }, { qg, qdim,          qdim  },
+                            { kf, 2 * qdim,     kvdim }, { vf, 2 * qdim + kvdim, kvdim },
+                        };
+                        qkvg_fp4 = true;
+                        for (auto& cu : cut)
+                            qkvg_fp4 &= cudaMemcpy2DAsync(cu.dst, (size_t)cu.n * sizeof(bf16),
+                                                          fp4_qkv + cu.off, sp,
+                                                          (size_t)cu.n * sizeof(bf16), N,
+                                                          cudaMemcpyDeviceToDevice, st) == cudaSuccess;
+                    }
                     if (qkvg_fp4) inq = ing = ink = inv = true;
                 }
                 if (!qkvg_fp4 && muse_group && muse_qb && use_i8 &&


### PR DESCRIPTION
## Summary

Two items in the batched prefill, neither in a GEMM: the bf16 window attention is bound by
shared-memory *issue* rather than bandwidth or math, and the `q|gate|k|v` projection spends 2.0% of
the pass in four `cudaMemcpy2DAsync` calls that exist only to re-stride a buffer. The attention
kernel comes out both faster and **more accurate**; the split is bit-identical.

**Attention.** `ncu` on `win_prefill_pure_bf16_kernel` at prefill@128: L1/TEX throughput **67.95%**
with DRAM at **1.61%**, and **39.7%** of a 9.75-cycle issue gap in MIO short-scoreboard — 31.7 us a
layer for ~268 MFLOP and ~2.2 MB. Same schedule throughout (one warp per query, ascending `kpos`,
same fp32 online softmax, same pure rolling-window predicate); three changes to how it is issued:

1. A lane owns **4 consecutive head dims** instead of `lane + e*32`. The strided form is a
   2-byte-per-lane shared load — 64 B per warp instruction — paid four times per key for K and four
   for V. Consecutive-four is one `__nv_bfloat162` pair: 256 B per instruction, a quarter of the LDS.
2. **Four keys are scored before any is reduced.** Per key the old loop is one dependent chain —
   4 FMAs, a 5-step shuffle butterfly, two `__expf`, then the loop-carried `m`/`l`/`acc` update — and
   only the FMAs are work. Scoring four first lets their butterflies interleave. Best of {1,2,4,8}.
3. The cross-lane butterfly runs **ascending**. `win_warp_sum()` goes 16→1, pairing each lane with
   the one holding dims 16 away before pairing neighbours; ascending sums adjacent dims first, which
   are far closer in magnitude, so the 32-term reduction is better conditioned.

After: L1/TEX 60.68%, issue gap 8.03 cycles, 41.86 → 35.87 us.

Item 3 is why re-associating the dot moves accuracy the *right* way. Only the cross-lane order
matters: a `bf16*bf16` product carries at most 16 mantissa bits, so the per-lane 4-term sum is exact
in fp32 and reversing it alone is bit-identical.

**`q|gate|k|v` split.** That projection is one grouped block-scaled GEMM into a contiguous
`[N, 2*qdim + 2*kvdim]` buffer, and the rest of the layer wants four arrays each with a tight row
stride. Bridging that was four `cudaMemcpy2DAsync` calls — four launches and four strided engine
passes over the same 2.2 MB, 1.39 us apiece, **0.289 ms a pass**. `launch_prefill_split4` moves the
same bytes in one `uint4` pass; every segment boundary is a multiple of 8 on every shape this runs
on, so no thread straddles two destinations. Bit-identical.

`SPARKINFER_MUSE_PREFILL_ATTN_WIDE=0` and `SPARKINFER_MUSE_PREFILL_SPLIT4=0` restore the previous
kernels.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer, ctx=0 — both changed kernels are prefill-only):

| | decode tok/s |
|---|--:|
| before (main) | 105.38 |
| after (this PR) | 105.37 |

**Prefill pp tok/s** (Muse Glimmer, ctx=128):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 8139.2 |
| after prefill (this PR) | 8404.1 |

**+3.25% prefill@128**, measured on `1ad9f05`, both arms from the same binary via the kill
switches, interleaved round-robin, 5 reps inside each process, clocks locked at 2550 MHz. The two
distributions do not overlap.

```text
             main      this PR
round 1    8135.8       8390.1
round 2    8169.0       8420.9
round 3    8141.8       8404.1
round 4    8138.2       8416.7
round 5    8139.2       8397.5
median     8139.2       8404.1     +3.25%
max/min    8169.0  <    8390.1     disjoint

decode@ctx0  105.38 -> 105.37
```

## Accuracy

`qwen3_gguf_prefill_check <gguf> 128 512`, `SPARKINFER_KV_INT8=0`, batched vs the token reference:

| | TOP1 | KL |
|---|--:|--:|
| main `1ad9f05` | 469/512 = 0.9160 | 0.01818 |
| this PR | **480/512 = 0.9375** | **0.01427** |

Better on both. The split is bit-identical; the attention kernel re-associates the 32-term dot and
the ascending butterfly more than pays that back. `ctest` 19/19.
