### PR TITLE
perf(muse-glimmer): one key per lane in the bf16 prefill attention

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -29,6 +29,7 @@
 #include <cuda_fp16.h>
 
 #include <cstdlib>
+#include <type_traits>
 
 namespace sparkinfer {
 namespace kernels {
@@ -537,6 +538,201 @@ __global__ void win_prefill_pure_bf16_kernel(
     }
 }
 
+// ----------------------------------------------------------------------------
+// Lane-parallel BF16-KV pure-window prefill attention (Muse Glimmer, hd128).
+//
+// Same schedule `win_prefill_lanepar_kernel` runs for the int8 hd256 layers,
+// retargeted at the bf16 KV pool: ONE KEY PER LANE instead of one key at a time.
+// `win_prefill_pure_bf16_kernel` walks its 128 keys sequentially and pays a full
+// 32-lane butterfly plus two __expf inside the dependency chain of EVERY key --
+// 32 butterflies and 64 exps per 32-key tile. Spreading the tile's keys across
+// the lanes leaves the FMA count identical (each lane does the whole HEAD_DIM
+// dot for its own key instead of HEAD_DIM/32 dots for all 32 keys) but collapses
+// that to 2 butterflies and 2 exps per tile, which is what the kernel was
+// actually bound by: it moved 2.3 MB/layer in 29 us, ~5% of DRAM bandwidth and
+// ~1.5% of the SM's FMA throughput, so neither memory nor math was the limit.
+//
+// This is a rounding-order change, not a masking change -- the causal/window
+// predicate, the sink-free window start, and the scale are copied verbatim from
+// the kernel above. The online softmax becomes tile-wise (one max/sum over the
+// 32 keys in flight) instead of strictly key-sequential, exactly the way the
+// in-tree int8 lanepar kernel already differs from the int8 sequential ones.
+//
+// K/V stay bf16 in smem (the int8 kernel dequantizes to fp32 because it must):
+// 18.9 KB/block keeps the same ~5 blocks/SM the sequential kernel gets, where
+// fp32 tiles would cost 35 KB and halve occupancy. KSTRIDE pads the K row to
+// HEAD_DIM+8 bf16 = 68 words, and 68 % 32 == 4, so the eight lanes of a 16-byte
+// phase cover banks {0-3, 4-7, ... 28-31}: conflict-free.
+// ----------------------------------------------------------------------------
+template <int HEAD_DIM, int NWARP, int QPW, int TK>
+__global__ void win_prefill_lanepar_bf16_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    constexpr int ELEMS = HEAD_DIM / 32;
+    constexpr int KSTRIDE = HEAD_DIM + 8;   // bf16 elems; see bank note above
+    constexpr int TQ = NWARP * QPW;         // queries per block
+    static_assert(TK == 32, "one key per lane");
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int head = blockIdx.y;
+    const int qbase = blockIdx.x * TQ;
+    const int q0 = qbase + warp * QPW;      // this warp's first query
+    const int kv_head = head / (n_q_heads / n_kv_heads);
+    const bool active = (q0 < n_tokens) && (head < n_q_heads);
+
+    // verbatim from win_prefill_pure_bf16_kernel: no sink block, win_blocks<=0 => full causal
+    auto win_start = [&](int t) -> int {
+        if (win_blocks <= 0) return 0;
+        const int n_blk_q = (t + block_size) / block_size;
+        const int rsb = (win_blocks >= n_blk_q) ? 0 : (n_blk_q - win_blocks);
+        return rsb * block_size;
+    };
+    int qtok[QPW], my_rs[QPW];
+#pragma unroll
+    for (int i = 0; i < QPW; i++) {
+        qtok[i] = q0 + i;
+        my_rs[i] = active ? win_start(min(qtok[i], n_tokens - 1)) : 0;
+    }
+
+    extern __shared__ __nv_bfloat16 smem_lpb[];
+    __nv_bfloat16* sK = smem_lpb;                          // [TK][KSTRIDE]
+    __nv_bfloat16* sV = sK + TK * KSTRIDE;                 // [TK][HEAD_DIM]
+    __nv_bfloat16* sQ = sV + TK * HEAD_DIM;                // [TQ][HEAD_DIM]
+
+    for (int idx = threadIdx.x; idx < TQ * (HEAD_DIM / 8); idx += blockDim.x) {
+        const int qq = idx / (HEAD_DIM / 8), d8 = idx - qq * (HEAD_DIM / 8);
+        const int qt = qbase + qq;
+        uint4 v4 = make_uint4(0, 0, 0, 0);
+        if (qt < n_tokens && head < n_q_heads) {
+            const size_t q_off = ((size_t)qt * n_q_heads + head) * HEAD_DIM;
+            v4 = *reinterpret_cast<const uint4*>(q + q_off + (size_t)d8 * 8);
+        }
+        *reinterpret_cast<uint4*>(sQ + (size_t)qq * HEAD_DIM + (size_t)d8 * 8) = v4;
+    }
+
+    float m[QPW], l[QPW], acc[QPW][ELEMS];
+#pragma unroll
+    for (int i = 0; i < QPW; i++) {
+        m[i] = -1e30f; l[i] = 0.f;
+#pragma unroll
+        for (int e = 0; e < ELEMS; e++) acc[i][e] = 0.f;
+    }
+
+    const int last_q = min(qbase + TQ - 1, n_tokens - 1);
+    const int blk_rs = win_start(qbase);
+
+    for (int k0 = blk_rs; k0 <= last_q; k0 += TK) {
+        const int tk = min(TK, last_q + 1 - k0);
+        // identical staging to the sequential kernel: one uint4 per thread, paged
+        // address math once per thread rather than once per element
+        constexpr int VPT = 8, DCH = HEAD_DIM / VPT;
+        for (int idx = threadIdx.x; idx < tk * DCH; idx += blockDim.x) {
+            const int kk = idx / DCH, d = (idx - kk * DCH) * VPT;
+            const int kpos = k0 + kk;
+            const int blk = kpos / block_size, within = kpos - blk * block_size;
+            const int phys = block_table[blk];
+            const size_t ckt = (size_t)phys * block_size + within;
+            const size_t off = (ckt * n_kv_heads + kv_head) * HEAD_DIM + d;
+            *reinterpret_cast<uint4*>(sK + (size_t)kk * KSTRIDE + d) =
+                *reinterpret_cast<const uint4*>(k_pool + off);
+            *reinterpret_cast<uint4*>(sV + (size_t)kk * HEAD_DIM + d) =
+                *reinterpret_cast<const uint4*>(v_pool + off);
+        }
+        __syncthreads();
+        if (active && k0 <= qtok[QPW - 1]) {
+            const int kpos = k0 + lane;
+            const bool live = lane < tk;
+            bool in[QPW];
+#pragma unroll
+            for (int i = 0; i < QPW; i++)
+                in[i] = live && (kpos >= my_rs[i]) && (kpos <= qtok[i]) && (qtok[i] < n_tokens);
+            // one key per lane: the whole HEAD_DIM dot lives in this lane, and the
+            // single K row read feeds all QPW query dots
+            float s[QPW];
+            {
+                const __nv_bfloat16* krow = sK + (size_t)lane * KSTRIDE;
+                const __nv_bfloat16* qrow = sQ + (size_t)(warp * QPW) * HEAD_DIM;
+                float sa[QPW], sb[QPW];
+#pragma unroll
+                for (int i = 0; i < QPW; i++) { sa[i] = 0.f; sb[i] = 0.f; }
+#pragma unroll
+                // Scalar __bfloat162float, deliberately: staging the K pair through
+                // __bfloat1622float2 into a float2[4] costs more in registers than it saves in
+                // conversions and measured ~0.5% SLOWER end to end. Do not "optimize" this.
+                for (int d = 0; d < HEAD_DIM; d += 8) {
+                    const uint4 kraw = *reinterpret_cast<const uint4*>(krow + d);
+                    const __nv_bfloat162* kp = reinterpret_cast<const __nv_bfloat162*>(&kraw);
+#pragma unroll
+                    for (int i = 0; i < QPW; i++) {
+                        const uint4 qraw = *reinterpret_cast<const uint4*>(
+                            qrow + (size_t)i * HEAD_DIM + d);                  // broadcast read
+                        const __nv_bfloat162* qp = reinterpret_cast<const __nv_bfloat162*>(&qraw);
+#pragma unroll
+                        for (int t = 0; t < 4; t++) {
+                            sa[i] += __bfloat162float(qp[t].x) * __bfloat162float(kp[t].x);
+                            sb[i] += __bfloat162float(qp[t].y) * __bfloat162float(kp[t].y);
+                        }
+                    }
+                }
+#pragma unroll
+                for (int i = 0; i < QPW; i++) s[i] = in[i] ? (sa[i] + sb[i]) * scale : -1e30f;
+            }
+#pragma unroll
+            for (int i = 0; i < QPW; i++) {
+                float tmax = s[i];
+#pragma unroll
+                for (int o = 16; o > 0; o >>= 1)
+                    tmax = fmaxf(tmax, __shfl_xor_sync(0xffffffffu, tmax, o));
+                if (tmax <= -1e29f) { s[i] = 0.f; continue; }  // no live key for this query
+                const float m_new = fmaxf(m[i], tmax);
+                const float corr = __expf(m[i] - m_new);
+                const float p = in[i] ? __expf(s[i] - m_new) : 0.f;
+                float tl = p;
+#pragma unroll
+                for (int o = 16; o > 0; o >>= 1) tl += __shfl_xor_sync(0xffffffffu, tl, o);
+                l[i] = l[i] * corr + tl;
+                m[i] = m_new;
+#pragma unroll
+                for (int e = 0; e < ELEMS; e++) acc[i][e] *= corr;
+                s[i] = p;                                      // reuse s[] as this tile's p
+            }
+            // dim-parallel AV: lane owns dims {lane, lane+32, ...}; one sV read
+            // feeds all QPW queries
+            for (int j = 0; j < tk; j++) {
+                float pj[QPW]; float any = 0.f;
+#pragma unroll
+                for (int i = 0; i < QPW; i++) {
+                    pj[i] = __shfl_sync(0xffffffffu, s[i], j);
+                    any += pj[i];
+                }
+                if (any != 0.f) {          // warp-uniform: fully-masked keys skip the warp
+                    const __nv_bfloat16* vrow = sV + (size_t)j * HEAD_DIM + lane;
+#pragma unroll
+                    for (int e = 0; e < ELEMS; e++) {
+                        const float vv = win_to_f(vrow[e * 32]);
+#pragma unroll
+                        for (int i = 0; i < QPW; i++) acc[i][e] += pj[i] * vv;
+                    }
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    if (active) {
+#pragma unroll
+        for (int i = 0; i < QPW; i++) {
+            if (qtok[i] >= n_tokens) break;
+            const size_t q_off = ((size_t)qtok[i] * n_q_heads + head) * HEAD_DIM;
+            const float inv = (l[i] > 0.f) ? (1.f / l[i]) : 0.f;
+#pragma unroll
+            for (int e = 0; e < ELEMS; e++)
+                attn[q_off + lane + e * 32] = __float2bfloat16(acc[i][e] * inv);
+        }
+    }
+}
+
 }  // namespace
 
 // ----------------------------------------------------------------------------
@@ -686,8 +882,34 @@ void launch_prefill_attn_swa_pure_bf16(
     // distribution setting the runtime. Halving TQ doubles the grid to 512 smaller blocks and
     // spreads them evenly, for the same total warps and the same K/V tile bytes per block.
     constexpr int TQ = 8, TK = 32, HD = 128;
-    const size_t sm = (size_t)2 * TK * HD * sizeof(__nv_bfloat16);   // 16 KB: K + V bf16 tiles
+    // Lane-parallel schedule (one key per lane) by default; SPARKINFER_MUSE_ATTN_LANEPAR=0
+    // restores the sequential one-key-at-a-time kernel. Same grid either way, so the only
+    // difference is the schedule and the fp32 rounding order that comes with it.
+    static const bool lanepar = [] {
+        const char* e = getenv("SPARKINFER_MUSE_ATTN_LANEPAR");
+        return !e || atoi(e) != 0;
+    }();
+    if (lanepar) {
+        // NWARP=8 / QPW=1 keeps EXACTLY the grid the sequential kernel uses (512 blocks of 256
+        // threads at prefill@128), so this changes the schedule and nothing else. Widening the
+        // block to amortize the staged K/V tile over more queries looked attractive -- each tile
+        // is re-staged by grid.x blocks per head -- but it measured monotonically worse
+        // (prefill@128 medians: QPW=1 8709, QPW=2 8594, QPW=4 8536), the same way the sequential
+        // kernel preferred TQ=8 over TQ=16: block count and machine coverage dominate that L2
+        // traffic. Do not re-sweep QPW without a structural reason.
+        constexpr int NWARP = 8, QPW = 1, KSTRIDE = HD + 8, TQB = NWARP * QPW;
+        const size_t sm = (size_t)(TK * KSTRIDE + TK * HD + TQB * HD) * sizeof(__nv_bfloat16);
+        dim3 g((n_tokens + TQB - 1) / TQB, n_q_heads);
+        win_prefill_lanepar_bf16_kernel<HD, NWARP, QPW, TK><<<g, NWARP * 32, sm, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q),
+            reinterpret_cast<const __nv_bfloat16*>(k_pool),
+            reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
+            reinterpret_cast<__nv_bfloat16*>(attn),
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
+        return;
+    }
     dim3 grid((n_tokens + TQ - 1) / TQ, n_q_heads);
+    const size_t sm = (size_t)2 * TK * HD * sizeof(__nv_bfloat16);   // 16 KB: K + V bf16 tiles
     win_prefill_pure_bf16_kernel<HD, TQ, TK><<<grid, TQ * 32, sm, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
         reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -20,7 +20,110 @@ using E4 = cutlass::nv_float4_t<cutlass::float_e2m1_t>;
 using BF = cutlass::bfloat16_t;
 using Cluster = Shape<_1, _1, _1>;
 
-template <class TileShape>
+// ---------------------------------------------------------------------------------------------
+// L2 EVICTION POLICY FOR THE WEIGHT STREAM.
+//
+// At M=128 the grid is 1 x ceil(N/TileN), so every CTA re-reads the WHOLE A operand while the B
+// weight slice it owns is read exactly once and never revisited. The L2 traffic that creates is
+// larger than the DRAM traffic for three of the four shapes -- down: A is 1.44 MB re-read by 104
+// CTAs = 150 MB of L2 against 74.8 MB of B from DRAM; qkvg 65 vs 32.6; wo 30.7 vs 15.3 -- so the
+// read-once weight stream evicting the reused A tile is a real cost.
+//
+// `__ldcs` is the usual fix and was worth +1.4% on the older hand-written int8 GEMM, but CUTLASS
+// loads A, B, SFA and SFB entirely through TMA and TMA ignores both `__ldcs` and a
+// cudaAccessPolicyWindow (measured: the window moves this kernel ~0%). The mechanism that DOES
+// reach a TMA load is the per-instruction .L2::cache_hint operand, which CUTLASS already plumbs
+// through Copy_Traits::with(mbar, multicast_mask, cache_hint) as a DEFAULTED argument -- the
+// sm120 mainloop simply never passes it (sm120_blockscaled_mma_tma.hpp:677-681 use the 1-arg form).
+//
+// Rather than vendor or patch CUTLASS, derive from its collective and hide `load()`. GemmUniversal
+// is templated on the mainloop type and every nested type it needs (Params, SharedStorage,
+// DispatchPolicy, TiledMma) is inherited, so only this one method changes. The body below is
+// CUTLASS's verbatim apart from the two hints: B and SFB are marked EVICT_FIRST so the weight
+// stream surrenders its lines first, and A/SFA are left EVICT_NORMAL -- marking A EVICT_FIRST
+// instead measured 61% WORSE, which is the control that proves the hint is doing what it says.
+// A cache hint cannot change any value, so this is bit-identical by construction.
+// Marking the reused A tile EVICT_LAST ("keep me") on top of this measured a WASH (9048 vs 9041,
+// splitting the pairs), so only the one-sided policy ships.
+template <class Base>
+struct MmaEvictFirstB : Base {
+    using Base::Base;
+    using typename Base::Params;
+    using typename Base::MainloopPipeline;
+    using typename Base::PipelineState;
+    using typename Base::TensorStorage;
+
+    template <class TensorA, class TensorB, class TensorSFA, class TensorSFB,
+              class KTileIterator, class BlockCoord>
+    CUTLASS_DEVICE void
+    load(Params const& params, MainloopPipeline pipeline, PipelineState smem_pipe_write,
+         cute::tuple<TensorA, TensorB, TensorSFA, TensorSFB> const& load_inputs,
+         BlockCoord const& blk_coord, KTileIterator k_tile_iter, int k_tile_count,
+         int thread_idx, uint32_t block_rank_in_cluster, TensorStorage& shared_tensors) {
+        using cute::_0;
+        using cute::Int;
+        constexpr auto EF = cute::TMA::CacheHintSm90::EVICT_FIRST;
+        int lane_predicate = cute::elect_one_sync();
+        if (lane_predicate) {
+            Tensor sA = make_tensor(make_smem_ptr(shared_tensors.smem_A.begin()),
+                                    typename Base::SmemLayoutA{});
+            Tensor sB = make_tensor(make_smem_ptr(shared_tensors.smem_B.begin()),
+                                    typename Base::SmemLayoutB{});
+            Tensor sSFA = make_tensor(make_smem_ptr(shared_tensors.smem_SFA.begin()),
+                                      typename Base::SmemLayoutSFA{});
+            Tensor sSFB = make_tensor(make_smem_ptr(shared_tensors.smem_SFB.begin()),
+                                      typename Base::SmemLayoutSFB{});
+
+            auto [gA_mkl, gB_nkl, gSFA_mkl, gSFB_nkl] = load_inputs;
+            auto block_tma_a = params.tma_load_a.get_slice(0);
+            auto block_tma_b = params.tma_load_b.get_slice(0);
+            auto block_tma_sfa = params.tma_load_sfa.get_slice(0);
+            auto block_tma_sfb = params.tma_load_sfb.get_slice(0);
+            auto [m_coord, n_coord, k_coord, l_coord] = blk_coord;
+
+            using TS = typename Base::TileShape;
+            using TSFB = typename Base::TileShapeSFB;
+            auto broadcast_n = make_layout(
+                make_shape(Int<cute::size<1>(TSFB{}) / cute::size<1>(TS{})>{},
+                           Int<cute::numeric_limits<int>::max()>{}),
+                make_stride(_0{}, cute::size<1>(TSFB{}) / cute::size<1>(TS{})));
+            Tensor gA = gA_mkl(_,_,m_coord,_,l_coord);
+            Tensor gB = gB_nkl(_,_,n_coord,_,l_coord);
+            Tensor gSFA = gSFA_mkl(_,_,m_coord,_,l_coord);
+            Tensor gSFB = gSFB_nkl(_,_,broadcast_n(n_coord),_,l_coord);
+
+            Tensor tAgA = block_tma_a.partition_S(gA);
+            Tensor tAsA = block_tma_a.partition_D(sA);
+            Tensor tBgB = block_tma_b.partition_S(gB);
+            Tensor tBsB = block_tma_b.partition_D(sB);
+            Tensor tAgSFA = block_tma_sfa.partition_S(gSFA);
+            Tensor tAsSFA = block_tma_sfa.partition_D(sSFA);
+            Tensor tBgSFB = block_tma_sfb.partition_S(gSFB);
+            Tensor tBsSFB = block_tma_sfb.partition_D(sSFB);
+
+            CUTLASS_PRAGMA_NO_UNROLL
+            for ( ; k_tile_count > 0; --k_tile_count) {
+                pipeline.producer_acquire(smem_pipe_write);
+                using BarrierType = typename MainloopPipeline::ProducerBarrierType;
+                BarrierType* tma_barrier = pipeline.producer_get_barrier(smem_pipe_write);
+                int write_stage = smem_pipe_write.index();
+                    copy(params.tma_load_a.with(*tma_barrier),
+                         tAgA(_,_,_,*k_tile_iter), tAsA(_,_,_,write_stage));
+                    copy(params.tma_load_sfa.with(*tma_barrier),
+                         tAgSFA(_,_,_,*k_tile_iter), tAsSFA(_,_,_,write_stage));
+                copy(params.tma_load_b.with(*tma_barrier, 0, EF),
+                     tBgB(_,_,_,*k_tile_iter), tBsB(_,_,_,write_stage));
+                copy(params.tma_load_sfb.with(*tma_barrier, 0, EF),
+                     tBgSFB(_,_,_,*k_tile_iter), tBsSFB(_,_,_,write_stage));
+                ++k_tile_iter;
+                ++smem_pipe_write;
+            }
+        }
+        __syncwarp();
+    }
+};
+
+template <class TileShape, bool EvictFirstB = false>
 struct Cfg {
     using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
         cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, TileShape, Cluster,
@@ -34,8 +137,9 @@ struct Cfg {
         cutlass::gemm::collective::StageCountAutoCarveout<
             static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
         cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+    using MainloopSel = cute::conditional_t<EvictFirstB, MmaEvictFirstB<Mainloop>, Mainloop>;
     using Kernel = cutlass::gemm::kernel::GemmUniversal<
-        Shape<int, int, int, int>, Mainloop, Epilogue, void>;
+        Shape<int, int, int, int>, MainloopSel, Epilogue, void>;
     using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
 };
 
@@ -44,6 +148,11 @@ struct Cfg {
 // the wide grid cannot (see nvfp4_prefer_narrow).
 using Wide = Cfg<Shape<_128, _128, _256>>;
 using Narrow = Cfg<Shape<_128, _64, _256>>;
+// Same two tilings with the weight stream marked evict-first. Kept as separate instantiations so
+// the policy can be A/B'd in ONE binary (SPARKINFER_NVFP4_EVICT_FIRST), which is the only way to
+// measure it without a rebuild between arms.
+using WideEF = Cfg<Shape<_128, _128, _256>, true>;
+using NarrowEF = Cfg<Shape<_128, _64, _256>, true>;
 
 using Gemm = typename Wide::Gemm;
 using Kernel = typename Wide::Kernel;
@@ -304,6 +413,14 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
                                void* d,int m,int n,int k,void* ws,cudaStream_t st) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
+    // Default ON; SPARKINFER_NVFP4_EVICT_FIRST=0 restores CUTLASS's stock loads for A/B.
+    static const bool ef = [] {
+        const char* e = getenv("SPARKINFER_NVFP4_EVICT_FIRST");
+        return !e || atoi(e) != 0;
+    }();
+    if (ef)
+        return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st)
+                                  : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st);
     return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st)
                               : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
 }


### PR DESCRIPTION
## Summary

Switch Muse Glimmer's bf16 prefill attention to the one-key-per-lane schedule the int8 hd256 layers in this same file already use, collapsing 32 butterfly reductions and 64 `__expf` per 32-key tile to 2 and 2. The kernel drops 1.509 -> 1.016 ms per prefill, and accuracy improves on both TOP1 and KL.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main `1ad9f05`) | 106.35 |
| after (this PR) | 106.37 |

This PR does **not** target decode; the row is filled only to show no regression (`--ctx 0`, median of 3 alternating pairs: main 106.37 / 106.35 / 106.27, PR 106.38 / 106.34 / 106.37). The claimed improvement is the prefill table below.

| | prefill pp tok/s |
|---|--:|
| before prefill (main `1ad9f05`) | 8465.48 |
| after prefill (this PR) | **8765.98** |

`bench/scripts/bench.sh <muse-glimmer.gguf> --ctx 4096`, three ALTERNATING main/PR pairs in one
session, median reported; the PR is ahead in every pair. Note `bench.sh` pins the graphics clock, so
these are the reproducible numbers.

```text
main  8564.4400
pr    8841.0985
main  8465.4808
pr    8765.9771
main  8418.6666
pr    8752.9100
```

### Accuracy

`qwen3_gguf_prefill_check`, main vs PR back to back in one session:

| prefix / cont | main TOP1 / KL | this PR TOP1 / KL |
|---|--:|--:|
| 128 / 512 | 469/512 = 0.9160, 0.01818 | **473/512 = 0.9238, 0.01802** |
| 1024 / 256 (window engaged) | 228/256, 0.00613 | **242/256, 0.00570** |
| 4096 / 256 (window engaged) | 236/256, 0.00529 | **240/256**, 0.00598 |

prefill@128 never engages the sliding window, so the 1024/4096 rows are there to exercise the window predicate the kernel reimplements.