### PR TITLE
perf(qwen3.8): FP8-direct GDN prefill projections (1.27x prefill@128) + the Muse Glimmer tensor-core/node stack

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -10,6 +10,7 @@
 // Numerics mirror the decode kernels (qwen36.cu / rope.cu) so the KV cache and recurrent
 // state left behind are faithful to the token-by-token path.
 
+#include <cstdint>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <cuda_runtime.h>
@@ -1230,6 +1231,44 @@ void launch_prefill_swiglu_ld(const void* gate, const void* up, void* h,
     pf_swiglu_ld_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
         reinterpret_cast<__nv_bfloat16*>(h), rows, cols, ld);
+}
+
+// One-launch split of the stacked [rows, 2*qdim + 2*kvdim] q|gate|k|v GEMM output into the four
+// tight-stride destinations the rest of the layer expects -- replaces four cudaMemcpy2DAsync
+// nodes per layer with a single kernel moving the same bytes. 16 B vectors: every column
+// boundary (qdim, 2*qdim, 2*qdim + kvdim) is a multiple of 8 bf16, so a vector never straddles
+// two destinations. Byte-identical to the copies by construction.
+__global__ void pf_qkvg_split_kernel(const uint4* __restrict__ src, uint4* __restrict__ qb,
+                                     uint4* __restrict__ qg, uint4* __restrict__ kf,
+                                     uint4* __restrict__ vf, int rows, int qd8, int kd8) {
+    const int rw = 2 * qd8 + 2 * kd8;                 // row width in 8-bf16 vectors
+    const long total = (long)rows * rw;
+    for (long i = (long)blockIdx.x * blockDim.x + threadIdx.x; i < total;
+         i += (long)gridDim.x * blockDim.x) {
+        const int r = (int)(i / rw), c = (int)(i - (long)r * rw);
+        const uint4 v = src[i];
+        if (c < qd8)                 qb[(long)r * qd8 + c] = v;
+        else if (c < 2 * qd8)        qg[(long)r * qd8 + (c - qd8)] = v;
+        else if (c < 2 * qd8 + kd8)  kf[(long)r * kd8 + (c - 2 * qd8)] = v;
+        else                         vf[(long)r * kd8 + (c - 2 * qd8 - kd8)] = v;
+    }
+}
+
+bool launch_prefill_qkvg_split(const void* src, void* qb, void* qg, void* kf, void* vf,
+                               int rows, int qdim, int kvdim, cudaStream_t stream) {
+    if ((qdim & 7) || (kvdim & 7) || rows <= 0) return false;
+    // The destinations are aliases into scratch; 16 B vectors need 16 B bases.
+    if ((reinterpret_cast<uintptr_t>(src) | reinterpret_cast<uintptr_t>(qb) |
+         reinterpret_cast<uintptr_t>(qg) | reinterpret_cast<uintptr_t>(kf) |
+         reinterpret_cast<uintptr_t>(vf)) & 15) return false;
+    const int qd8 = qdim >> 3, kd8 = kvdim >> 3;
+    const long total = (long)rows * (2 * qd8 + 2 * kd8);
+    int blocks = (int)((total + 255) / 256); if (blocks > 4096) blocks = 4096;
+    pf_qkvg_split_kernel<<<blocks, 256, 0, stream>>>(
+        reinterpret_cast<const uint4*>(src), reinterpret_cast<uint4*>(qb),
+        reinterpret_cast<uint4*>(qg), reinterpret_cast<uint4*>(kf),
+        reinterpret_cast<uint4*>(vf), rows, qd8, kd8);
+    return cudaPeekAtLastError() == cudaSuccess;
 }
 
 void launch_prefill_add(const void* a, const void* b, void* out, long n, cudaStream_t stream) {

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1211,6 +1211,27 @@ void launch_prefill_swiglu(const void* gate, const void* up, void* h, long n, cu
         reinterpret_cast<__nv_bfloat16*>(h), n);
 }
 
+// Strided-source SwiGLU: gate/up are column slices of one [rows, ld] tensor (the stacked gate|up
+// GEMM output), the result is written contiguous [rows, cols]. Per element this is exactly
+// pf_swiglu_kernel's value chain, so it is bit-identical to the unstrided form.
+__global__ void pf_swiglu_ld_kernel(const __nv_bfloat16* __restrict__ gate,
+                                    const __nv_bfloat16* __restrict__ up,
+                                    __nv_bfloat16* __restrict__ h, int rows, int cols, int ld) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= (long)rows * cols) return;
+    const int r = (int)(i / cols);
+    const long s = (long)r * ld + (int)(i - (long)r * cols);
+    h[i] = __float2bfloat16(pf_silu(pf_to_f(gate[s])) * pf_to_f(up[s]));
+}
+
+void launch_prefill_swiglu_ld(const void* gate, const void* up, void* h,
+                              int rows, int cols, int ld, cudaStream_t stream) {
+    const long n = (long)rows * cols;
+    pf_swiglu_ld_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
+        reinterpret_cast<__nv_bfloat16*>(h), rows, cols, ld);
+}
+
 void launch_prefill_add(const void* a, const void* b, void* out, long n, cudaStream_t stream) {
     pf_add_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(a), reinterpret_cast<const __nv_bfloat16*>(b),

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -937,12 +937,13 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
 // grid = (N, n_q_heads + 2*n_kv_heads); blockDim = head_dim.
 // ============================================================================
 __global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
-    __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
+    const __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ q_out,
+    const __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
     __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq) {
+    int block_size, int max_blocks_per_seq, int q_ld, int kv_ld) {
     const int tok  = blockIdx.x;
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
@@ -960,7 +961,9 @@ __global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
 
     if (is_q || is_k) {
         const int hh = is_q ? unit : (unit - n_q_heads);
-        const size_t base = ((size_t)tok * (is_q ? n_q_heads : n_kv_heads) + hh) * head_dim;
+        // Row stride of the SOURCE: tight (heads*head_dim) for split inputs, or the stacked
+        // q|gate|k|v GEMM output's full row width when reading it in place (no split copy).
+        const size_t base = (size_t)tok * (is_q ? q_ld : kv_ld) + (size_t)hh * head_dim;
         const __nv_bfloat16* src = is_q ? q : k;
         const __nv_bfloat16* nrm = is_q ? q_w : k_w;
         const float xv = pf_to_f(src[base + t]);
@@ -988,14 +991,16 @@ __global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
             out = ((t & 1) == 0) ? (x0 * c - x1 * s) : (x0 * s + x1 * c);
         }
         if (is_q) {
-            q[base + t] = __float2bfloat16(out);
+            // The normed/roped q always lands TIGHT ([tok, n_q_heads*head_dim]) -- the
+            // attention kernels read that layout regardless of where the raw q came from.
+            q_out[((size_t)tok * n_q_heads + hh) * head_dim + t] = __float2bfloat16(out);
         } else {
             const size_t dst = (ctok * n_kv_heads + hh) * head_dim;
             k_pool[dst + t] = __float2bfloat16(out);
         }
     } else {                                          // V: append as-is (no norm, no rope)
         const int hh = unit - n_q_heads - n_kv_heads;
-        const size_t base = ((size_t)tok * n_kv_heads + hh) * head_dim;
+        const size_t base = (size_t)tok * kv_ld + (size_t)hh * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
         v_pool[dst + t] = v[base + t];
     }
@@ -1468,20 +1473,24 @@ void launch_prefill_qknorm_rope_kv_int8(
 // Muse Glimmer bf16-KV counterpart: QK-norm + NORMAL RoPE (rotary_dim>0) / NoPE
 // (rotary_dim==0) + bf16 KV write. k_pool/v_pool are bf16 (muse uses a bf16 KV cache).
 void launch_prefill_qknorm_ropenorm_kv_bf16(
-    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    const void* q, void* q_out, const void* k, const void* v,
+    const void* q_w, const void* k_w,
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream) {
+    cudaStream_t stream, int q_ld, int kv_ld) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
     const size_t shmem = (size_t)head_dim * sizeof(float);
+    if (q_ld <= 0) q_ld = n_q_heads * head_dim;        // tight (split) inputs
+    if (kv_ld <= 0) kv_ld = n_kv_heads * head_dim;
     pf_qknorm_ropenorm_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(q_out),
+        reinterpret_cast<const __nv_bfloat16*>(k),
         reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
         reinterpret_cast<const __nv_bfloat16*>(k_w),
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq);
+        block_size, max_blocks_per_seq, q_ld, kv_ld);
 }
 
 void launch_prefill_attn_int8_paged(

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -27,6 +27,7 @@
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <mma.h>            // bf16 tensor-core path for Muse Glimmer's hd128 windowed attention
 
 #include <cstdlib>
 #include <type_traits>
@@ -867,6 +868,194 @@ bool launch_prefill_attn_windowed(
 
 // BF16-KV pure-window prefill attention for Muse Glimmer (hd128). win_blocks>0 =>
 // SWA layers (last win_blocks blocks); win_blocks<=0 => global/NoPE full causal.
+namespace {
+
+// ---------------------------------------------------------------------------------------------
+// bf16 TENSOR-CORE windowed prefill attention (Muse Glimmer: hd128, bf16 paged KV).
+//
+// prefill_attn_mma.h already states the problem: the scalar path "evaluates QK^T and PV with scalar
+// FMA plus a 5-shuffle warp reduction per key, which measures ~8 TFLOP/s on sm_120", and the repo
+// already fixed it on the tensor cores -- for Qwythos hd256 + INT8 paged KV
+// (pf_attn_mma_i8_kernel). Muse's windowed layers are hd128 + bf16 and never reach that path, so
+// they still pay one warp reduction per key. Measured standalone at Muse's exact shape
+// (n=128, 32 q heads, 2 kv heads, hd128, causal): scalar 28.67 us vs bf16 wmma 10.25 us = 2.80x,
+// and 5.02x at n=512.
+//
+// This is the int8 kernel's schedule with the int8 machinery REMOVED, not a new design:
+//   * QK and PV accumulate in fp32 directly, so the per-tile Q amax/round and the per-row P
+//     amax/round (plus its extra warp reduction) that existed only to feed int8 tensor cores are
+//     gone. P stays bf16.
+//   * K and V fragments are loaded STRAIGHT FROM THE PAGED POOL, no smem staging: block_size is 16
+//     and wmma's tile is 16x16, so a KV page IS a fragment with ldm = n_kv_heads*HEAD_DIM.
+//   * The per-row `corr` rescale of the O accumulator makes NO assumption about the fp32
+//     accumulator's element order -- an index fragment carrying (row<<8)|col is loaded once and
+//     `idxf.x[e] >> 8` names the row, exactly as pf_attn_mma_i8_kernel does.
+//
+// Mask is the scalar kernel's, term for term: per-query window start (NOT the block-level start)
+// and causal `gtok <= qtok`. NOT bit-identical to the scalar path -- fp32 tensor-core accumulation
+// reassociates the sum -- so the batched-prefill accuracy gate is mandatory before this ships.
+//
+// WARPS must divide HEAD_DIM/16 (each warp owns HEAD_DIM/16/WARPS output d-tiles in the PV mma)
+// and equals the number of KV pages consumed per group iteration.
+template <int HEAD_DIM, int WARPS>
+__global__ __launch_bounds__(WARPS * 32, 2) void win_prefill_mma_bf16_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    using namespace nvcuda::wmma;
+    constexpr int BM = 16;                 // query rows per block == wmma M == KV page size
+    constexpr int GN = 16 * WARPS;         // keys consumed per group iteration
+    constexpr int DT = HEAD_DIM / 16;      // d-tiles
+    constexpr int DPW = DT / WARPS;        // d-tiles per warp in the PV mma
+    constexpr int RPW = BM / WARPS;        // query rows per warp in the softmax
+    static_assert(DT % WARPS == 0, "HEAD_DIM/16 must be divisible by WARPS");
+    static_assert(BM % WARPS == 0, "BM must be divisible by WARPS");
+    static_assert(GN % 32 == 0, "GN must be a multiple of the warp width");
+
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int head = blockIdx.y, qbase = blockIdx.x * BM;
+    const int kvh = head / (n_q_heads / n_kv_heads);
+    const int KVLD = n_kv_heads * HEAD_DIM;          // ldm of a KV page in the pool
+    (void)max_blocks_per_seq;
+
+    extern __shared__ char mma_smem_bf[];
+    __nv_bfloat16* s_q = reinterpret_cast<__nv_bfloat16*>(mma_smem_bf);   // [BM][HEAD_DIM]
+    __nv_bfloat16* s_p = s_q + BM * HEAD_DIM;                             // [BM][GN]
+    float* s_s    = reinterpret_cast<float*>(s_p + BM * GN);              // [BM][GN]
+    float* s_o    = s_s + BM * GN;                                        // [BM][HEAD_DIM]
+    float* s_m    = s_o + BM * HEAD_DIM;                                  // [BM]
+    float* s_l    = s_m + BM;                                             // [BM]
+    float* s_corr = s_l + BM;                                             // [BM]
+
+    // Per-query window start, identical to the scalar kernel's win_start().
+    auto win_start = [&](int t) -> int {
+        if (win_blocks <= 0) return 0;
+        const int n_blk_q = (t + block_size) / block_size;
+        const int rsb = (win_blocks >= n_blk_q) ? 0 : (n_blk_q - win_blocks);
+        return rsb * block_size;
+    };
+
+    // Accumulator row map: no assumption about the fp32 fragment's element order.
+    fragment<accumulator, 16, 16, 16, float> ofr[DPW];
+    fragment<accumulator, 16, 16, 16, int> idxf;
+    {
+        int* tile = reinterpret_cast<int*>(s_s) + warp * 256;   // disjoint per warp, reused below
+        for (int i = lane; i < 256; i += 32) tile[i] = ((i >> 4) << 8) | (i & 15);
+        __syncwarp();
+        load_matrix_sync(idxf, tile, 16, mem_row_major);
+    }
+    #pragma unroll
+    for (int dd = 0; dd < DPW; dd++) fill_fragment(ofr[dd], 0.f);
+
+    for (int i = tid; i < BM * HEAD_DIM; i += blockDim.x) {
+        const int r = i / HEAD_DIM, c = i - r * HEAD_DIM, t = qbase + r;
+        s_q[i] = (t < n_tokens)
+               ? q[((size_t)t * n_q_heads + head) * HEAD_DIM + c] : __float2bfloat16(0.f);
+    }
+    for (int r = tid; r < BM; r += blockDim.x) { s_m[r] = -1e30f; s_l[r] = 0.f; }
+    __syncthreads();
+
+    const int last_q = min(qbase + BM - 1, n_tokens - 1);
+    const int blk_rs = win_start(qbase);   // monotonic in t, so this bounds every row in the tile
+
+    for (int k0 = blk_rs; k0 <= last_q; k0 += GN) {
+        const int gblk = min(WARPS, (last_q + 1 - k0 + 15) >> 4);   // live 16-key pages this group
+
+        // ---- QK: one page per warp, fp32 accumulate, land the tile in s_s ----
+        if (warp < gblk) {
+            const int pb = block_table[(k0 / block_size) + warp];
+            const __nv_bfloat16* kb =
+                k_pool + ((size_t)pb * block_size * n_kv_heads + kvh) * HEAD_DIM;
+            fragment<accumulator, 16, 16, 16, float> cf;
+            fill_fragment(cf, 0.f);
+            #pragma unroll
+            for (int d = 0; d < DT; d++) {
+                fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
+                fragment<matrix_b, 16, 16, 16, __nv_bfloat16, col_major> bf;
+                load_matrix_sync(af, s_q + d * 16, HEAD_DIM);
+                load_matrix_sync(bf, kb + d * 16, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            store_matrix_sync(s_s + warp * 16, cf, GN, mem_row_major);
+        }
+        __syncthreads();
+
+        // ---- online softmax over the whole GN-wide row, one warp per RPW rows ----
+        #pragma unroll
+        for (int rr = 0; rr < RPW; rr++) {
+            const int r = warp * RPW + rr, qtok = qbase + r;
+            const int my_rs = (qtok < n_tokens) ? win_start(qtok) : 0;
+            float sc[GN / 32], mx = -1e30f;
+            #pragma unroll
+            for (int u = 0; u < GN / 32; u++) {
+                const int t = lane + u * 32, gtok = k0 + t;
+                const bool live = (t < gblk * 16) && (qtok < n_tokens) &&
+                                  (gtok <= qtok) && (gtok >= my_rs);
+                sc[u] = live ? s_s[r * GN + t] * scale : -1e30f;
+                mx = fmaxf(mx, sc[u]);
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffffu, mx, o));
+            const float m_old = s_m[r], m_new = fmaxf(m_old, mx), corr = __expf(m_old - m_new);
+            float sum = 0.f;
+            #pragma unroll
+            for (int u = 0; u < GN / 32; u++) {
+                const int t = lane + u * 32;
+                const float p = (sc[u] > -1e29f) ? __expf(sc[u] - m_new) : 0.f;
+                sum += p;
+                s_p[r * GN + t] = __float2bfloat16(p);
+            }
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) sum += __shfl_xor_sync(0xffffffffu, sum, o);
+            if (lane == 0) {
+                s_m[r] = m_new; s_l[r] = s_l[r] * corr + sum; s_corr[r] = corr;
+            }
+        }
+        __syncthreads();
+
+        // ---- PV: each warp owns DPW output d-tiles; V comes straight from the pool ----
+        #pragma unroll
+        for (int dd = 0; dd < DPW; dd++) {
+            const int dt = warp * DPW + dd;
+            fragment<accumulator, 16, 16, 16, float> cf;
+            fill_fragment(cf, 0.f);
+            for (int ks = 0; ks < gblk; ks++) {
+                const int pb = block_table[(k0 / block_size) + ks];
+                const __nv_bfloat16* vb =
+                    v_pool + ((size_t)pb * block_size * n_kv_heads + kvh) * HEAD_DIM + dt * 16;
+                fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
+                fragment<matrix_b, 16, 16, 16, __nv_bfloat16, row_major> bf;
+                load_matrix_sync(af, s_p + ks * 16, GN);
+                load_matrix_sync(bf, vb, KVLD);
+                mma_sync(cf, af, bf, cf);
+            }
+            #pragma unroll
+            for (int e = 0; e < 8; e++) {
+                const int r = idxf.x[e] >> 8;
+                ofr[dd].x[e] = __fmaf_rn(ofr[dd].x[e], s_corr[r], cf.x[e]);
+            }
+        }
+        __syncthreads();   // s_s / s_p are rewritten by the next group
+    }
+
+    #pragma unroll
+    for (int dd = 0; dd < DPW; dd++)
+        store_matrix_sync(s_o + (warp * DPW + dd) * 16, ofr[dd], HEAD_DIM, mem_row_major);
+    __syncthreads();
+
+    for (int r = 0; r < BM; r++) {
+        const int qtok = qbase + r;
+        if (qtok >= n_tokens) break;
+        const float l = s_l[r], inv = (l > 0.f) ? (1.f / l) : 0.f;
+        for (int c = tid; c < HEAD_DIM; c += blockDim.x)
+            attn[((size_t)qtok * n_q_heads + head) * HEAD_DIM + c] =
+                __float2bfloat16(s_o[r * HEAD_DIM + c] * inv);
+    }
+}
+
+}  // namespace
+
 void launch_prefill_attn_swa_pure_bf16(
     const void* q, const void* k_pool, const void* v_pool,
     const int* block_table, void* attn,
@@ -882,6 +1071,54 @@ void launch_prefill_attn_swa_pure_bf16(
     // distribution setting the runtime. Halving TQ doubles the grid to 512 smaller blocks and
     // spreads them evenly, for the same total warps and the same K/V tile bytes per block.
     constexpr int TQ = 8, TK = 32, HD = 128;
+
+    // bf16 tensor-core path, ahead of the scalar schedules. Requires a 16-token KV page (a page is
+    // then exactly one wmma tile) and a GQA ratio, which Muse Glimmer satisfies (block_size 16,
+    // 32 q heads over 2 kv heads). Anything else falls through to the scalar kernels below,
+    // unchanged. SPARKINFER_MUSE_ATTN_MMA=0 disables (one-binary A/B control).
+    static const bool attn_mma = [] {
+        const char* e = getenv("SPARKINFER_MUSE_ATTN_MMA");
+        return !e || atoi(e) != 0;
+    }();
+    if (attn_mma && block_size == 16 && n_kv_heads > 0 && (n_q_heads % n_kv_heads) == 0) {
+        // WARPS is both the KV pages consumed per group iteration and the divisor of HD/16 output
+        // d-tiles. At prefill@128 with WARPS=8 the group is 128 keys wide, so the whole causal
+        // range for a 16-query tile is ONE iteration -- no group loop, no repeated barriers.
+        // SPARKINFER_MUSE_ATTN_MMA_WARPS selects (4 or 8) for a one-binary A/B.
+        static const int mw = [] {
+            const char* e = getenv("SPARKINFER_MUSE_ATTN_MMA_WARPS");
+            const int v = e ? atoi(e) : 8;
+            return (v == 4 || v == 8) ? v : 8;
+        }();
+        constexpr int MBM = 16;
+        auto sm_for = [&](int W) {
+            const int GNw = 16 * W;
+            return (size_t)MBM * HD * sizeof(__nv_bfloat16)          // s_q
+                 + (size_t)MBM * GNw * sizeof(__nv_bfloat16)         // s_p
+                 + (size_t)MBM * GNw * sizeof(float)                 // s_s (also the idx tile)
+                 + (size_t)MBM * HD * sizeof(float)                  // s_o
+                 + (size_t)3 * MBM * sizeof(float);                  // s_m / s_l / s_corr
+        };
+        dim3 gm((n_tokens + MBM - 1) / MBM, n_q_heads);
+        if (mw == 8) {
+            win_prefill_mma_bf16_kernel<HD, 8><<<gm, 8 * 32, sm_for(8), stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q),
+                reinterpret_cast<const __nv_bfloat16*>(k_pool),
+                reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
+                reinterpret_cast<__nv_bfloat16*>(attn),
+                n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
+        } else {
+            win_prefill_mma_bf16_kernel<HD, 4><<<gm, 4 * 32, sm_for(4), stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q),
+                reinterpret_cast<const __nv_bfloat16*>(k_pool),
+                reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
+                reinterpret_cast<__nv_bfloat16*>(attn),
+                n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
+        }
+        if (cudaPeekAtLastError() == cudaSuccess) return;
+        // else fall through: the scalar kernels below compute the same attention.
+    }
+
     // Lane-parallel schedule (one key per lane) by default; SPARKINFER_MUSE_ATTN_LANEPAR=0
     // restores the sequential one-key-at-a-time kernel. Same grid either way, so the only
     // difference is the schedule and the fp32 rounding order that comes with it.

--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -11,7 +11,7 @@ size_t prefill_nvfp4_scale_bytes_b(int, int) { return 0; }
 size_t prefill_nvfp4_workspace_bytes(int, int, int) { return 0; }
 bool launch_prefill_nvfp4_quant_a(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, int, int,
-                                       cudaStream_t) { return false; }
+                                       cudaStream_t, int) { return false; }
 bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*, int, int,
                                          cudaStream_t, int) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }

--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -13,7 +13,7 @@ bool launch_prefill_nvfp4_quant_a(const void*, void*, void*, int, int, cudaStrea
 bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, int, int,
                                        cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*, int, int,
-                                         cudaStream_t) { return false; }
+                                         cudaStream_t, int) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t, float) { return false; }

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -219,7 +219,7 @@ template <class Layout>
 __global__ void gate_quant_rows(const __nv_bfloat16* __restrict__ src,
                                 const __nv_bfloat16* __restrict__ gate,
                                 unsigned char* dst, cutlass::float_ue4m3_t* sf,
-                                int rows, int cols, Layout layout) {
+                                int rows, int cols, int gld, Layout layout) {
     constexpr int V = 16, LPG = V / 2;
     const int glane = threadIdx.x & (LPG - 1);
     const int groups = rows * (cols / V);
@@ -230,8 +230,11 @@ __global__ void gate_quant_rows(const __nv_bfloat16* __restrict__ src,
     for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG; grp < groups; grp += stride) {
         const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
         const size_t base = (size_t)row * cols + k0 + 2 * glane;
-        const float s0 = __bfloat162float(src[base]),     g0 = __bfloat162float(gate[base]);
-        const float s1 = __bfloat162float(src[base + 1]), g1 = __bfloat162float(gate[base + 1]);
+        // The gate may be a column slice of the stacked q|gate|k|v GEMM output (gld = its full
+        // row width) instead of a tight copy; the values are identical either way.
+        const size_t gbase = (size_t)row * gld + k0 + 2 * glane;
+        const float s0 = __bfloat162float(src[base]),     g0 = __bfloat162float(gate[gbase]);
+        const float s1 = __bfloat162float(src[base + 1]), g1 = __bfloat162float(gate[gbase + 1]);
         // Same expression and same bf16 rounding as pf_mul_sigmoid_kernel.
         const float x0 = __bfloat162float(__float2bfloat16(s0 / (1.f + __expf(-g0))));
         const float x1 = __bfloat162float(__float2bfloat16(s1 / (1.f + __expf(-g1))));
@@ -386,12 +389,14 @@ bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, void* sf,
-                                       int m, int k, cudaStream_t st) {
+                                       int m, int k, cudaStream_t st, int g_ld) {
     if (!sr || !g || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
+    const int gld = g_ld > 0 ? g_ld : k;
+    if (gld < k) return false;
     auto l = sfa_layout(m,128,k);
     int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
     gate_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)sr,(const __nv_bfloat16*)g,
-                                          (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
+                                          (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,gld,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_swiglu_quant_a(const void* g, const void* u, void* d, void* sf,

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -251,7 +251,7 @@ template <class Layout>
 __global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
                                   const __nv_bfloat16* __restrict__ up,
                                   unsigned char* dst, cutlass::float_ue4m3_t* sf,
-                                  int rows, int cols, Layout layout) {
+                                  int rows, int cols, int ld, Layout layout) {
     // 8 values per lane instead of 2, so two lanes cover a 16-value scale group. The two operand
     // reads become one 16-byte load each instead of four 4-byte loads, the store becomes one
     // 4-byte store instead of four 1-byte ones, and the amax butterfly collapses from three
@@ -266,9 +266,10 @@ __global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
     for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG;
          grp < groups; grp += stride) {
         const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
-        const size_t base = (size_t)row * cols + k0 + VPL * glane;
-        const __nv_bfloat162* g2 = reinterpret_cast<const __nv_bfloat162*>(gate + base);
-        const __nv_bfloat162* u2 = reinterpret_cast<const __nv_bfloat162*>(up + base);
+        const size_t base = (size_t)row * cols + k0 + VPL * glane;       // FP4 dst (contiguous)
+        const size_t lbase = (size_t)row * ld + k0 + VPL * glane;        // gate/up src (strided)
+        const __nv_bfloat162* g2 = reinterpret_cast<const __nv_bfloat162*>(gate + lbase);
+        const __nv_bfloat162* u2 = reinterpret_cast<const __nv_bfloat162*>(up + lbase);
         float x[VPL];
         float a = 0.f;
         #pragma unroll
@@ -394,13 +395,15 @@ bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, v
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_swiglu_quant_a(const void* g, const void* u, void* d, void* sf,
-                                         int m, int k, cudaStream_t st) {
+                                         int m, int k, cudaStream_t st, int ld_src) {
     if (!g || !u || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
+    const int ld = ld_src > 0 ? ld_src : k;
+    if (ld < k || (ld & 7)) return false;   // 16 B loads assume 8-value alignment per row
     auto l = sfa_layout(m,128,k);
     // 2 lanes per 16-value scale group (see swiglu_quant_rows), so one thread per 8 values.
     int blocks = (m * (k / 16) * 2 + 255) / 256; if (blocks > 4096) blocks = 4096;
     swiglu_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)g,(const __nv_bfloat16*)u,
-                                            (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
+                                            (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,ld,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k, cudaStream_t st) {

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -1100,6 +1100,115 @@ void launch_norm_then_add(const void* residual, const void* block_out, const voi
         reinterpret_cast<__nv_bfloat16*>(out), rows, cols, eps);
 }
 
+// The Muse sandwich pair as ONE node: out = residual + RMSNorm(block_out)*w1 (eps1, the 1e-8
+// sandwich eps) immediately followed by out2 = RMSNorm(out)*w2 (eps2, the model rms_eps -- the
+// pre-FFN norm after the attention sandwich, or the next layer's input norm after the FFN one).
+// Both halves are 1-CTA-per-row kernels on the same grid already, so this halves the node count
+// without touching occupancy -- the trap that killed the norm->quant fusion. Bit-identical: `out`
+// is rounded to bf16 BEFORE the second sum-of-squares (held in registers as the packed bf16), so
+// the second norm consumes exactly the tensor the separate rmsnorm re-read from memory, and every
+// reduction keeps the originals' per-thread order and rn_warp_sum tree.
+template <int PER>
+__global__ void norm_then_add_rmsnorm_kernel(const __nv_bfloat16* __restrict__ residual,
+                                             const __nv_bfloat16* __restrict__ block_out,
+                                             const __nv_bfloat16* __restrict__ w1,
+                                             __nv_bfloat16* __restrict__ out,
+                                             const __nv_bfloat16* __restrict__ w2,
+                                             __nv_bfloat16* __restrict__ out2,
+                                             int rows, int cols, float eps1, float eps2) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    const int npack = cols >> 3;                     // cols % 8 == 0, launcher-enforced
+    const uint4* b4  = reinterpret_cast<const uint4*>(block_out + base);
+    const uint4* r4  = reinterpret_cast<const uint4*>(residual + base);
+    const uint4* w14 = reinterpret_cast<const uint4*>(w1);
+    const uint4* w24 = reinterpret_cast<const uint4*>(w2);
+    uint4* o4  = reinterpret_cast<uint4*>(out + base);
+    uint4* o24 = reinterpret_cast<uint4*>(out2 + base);
+
+    float ss = 0.f;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        float bv[8]; rn_unpack8(__ldg(b4 + p), bv);
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss = __fmaf_rn(bv[j], bv[j], ss);
+    }
+    ss = rn_warp_sum(ss);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps1);
+    }
+    __syncthreads();
+    const float inv1 = s_warp[0];
+
+    uint4 hreg[PER];
+    float ss2 = 0.f;
+    int held = 0;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
+        float bv[8]; rn_unpack8(__ldg(b4 + p), bv);
+        float rv[8]; rn_unpack8(__ldg(r4 + p), rv);
+        float wv[8]; rn_unpack8(__ldg(w14 + p), wv);
+        float ov[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ov[j] = rv[j] + bv[j] * inv1 * wv[j];
+        const uint4 packed = rn_pack8(ov);           // the bf16 the first norm always wrote
+        o4[p] = packed;
+        hreg[held] = packed;
+        float hv[8]; rn_unpack8(packed, hv);         // second sumsq over the ROUNDED values
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ss2 = __fmaf_rn(hv[j], hv[j], ss2);
+    }
+    __syncthreads();                                 // everyone is past reading inv1
+    ss2 = rn_warp_sum(ss2);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss2;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = (threadIdx.x < (blockDim.x + 31) / 32) ? s_warp[threadIdx.x] : 0.f;
+        v = rn_warp_sum(v);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps2);
+    }
+    __syncthreads();
+    const float inv2 = s_warp[0];
+
+    held = 0;
+    for (int p = threadIdx.x; p < npack; p += blockDim.x, held++) {
+        float hv[8]; rn_unpack8(hreg[held], hv);
+        float wv[8]; rn_unpack8(__ldg(w24 + p), wv);
+        float ov[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) ov[j] = hv[j] * inv2 * wv[j];
+        o24[p] = rn_pack8(ov);
+    }
+}
+
+bool launch_norm_then_add_rmsnorm(const void* residual, const void* block_out, const void* w1,
+                                  void* out, const void* w2, void* out2,
+                                  int rows, int cols, float eps1, float eps2,
+                                  cudaStream_t stream) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_MUSE_SANDWICH_FUSE");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled || rows <= 0 || cols <= 0 || (cols & 7) != 0) return false;
+    const int npack = cols >> 3;
+    const int per = (npack + 255) / 256;
+    auto rb = reinterpret_cast<const __nv_bfloat16*>(residual);
+    auto bb = reinterpret_cast<const __nv_bfloat16*>(block_out);
+    auto w1b = reinterpret_cast<const __nv_bfloat16*>(w1);
+    auto w2b = reinterpret_cast<const __nv_bfloat16*>(w2);
+    auto ob = reinterpret_cast<__nv_bfloat16*>(out);
+    auto o2b = reinterpret_cast<__nv_bfloat16*>(out2);
+    if (per <= 1)      norm_then_add_rmsnorm_kernel<1><<<rows, 256, 0, stream>>>(rb, bb, w1b, ob, w2b, o2b, rows, cols, eps1, eps2);
+    else if (per <= 2) norm_then_add_rmsnorm_kernel<2><<<rows, 256, 0, stream>>>(rb, bb, w1b, ob, w2b, o2b, rows, cols, eps1, eps2);
+    else if (per <= 4) norm_then_add_rmsnorm_kernel<4><<<rows, 256, 0, stream>>>(rb, bb, w1b, ob, w2b, o2b, rows, cols, eps1, eps2);
+    else return false;
+    return true;
+}
+
 void launch_add_rmsnorm3(const void* x, const void* res1, const void* res2, const void* weight,
                          void* out_sum, void* out_norm, int rows, int cols, float eps,
                          cudaStream_t stream) {

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -44,6 +44,13 @@ void launch_norm_then_add_acc(const void* residual_bf16, const int* acc, const f
                               const float* row_scale, const void* weight_bf16, void* out_bf16,
                               int rows, int cols, float eps, cudaStream_t stream);
 
+// The Muse sandwich pair as one node: out = residual + RMSNorm(block_out, w1, eps1), then
+// out2 = RMSNorm(out, w2, eps2). Bit-identical to the two separate launches; false = caller
+// runs them separately (odd cols, or SPARKINFER_MUSE_SANDWICH_FUSE=0).
+bool launch_norm_then_add_rmsnorm(const void* residual, const void* block_out, const void* w1,
+                                  void* out, const void* w2, void* out2,
+                                  int rows, int cols, float eps1, float eps2,
+                                  cudaStream_t stream = nullptr);
 void launch_norm_then_add(const void* residual_bf16, const void* block_out_bf16,
                           const void* weight_bf16, void* out_bf16,
                           int rows, int cols, float eps, cudaStream_t stream = nullptr);

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -29,6 +29,9 @@ void launch_prefill_gemm(const void* A, const void* W, void* C,
 // gate/up as column slices of one [rows, ld] tensor; output contiguous [rows, cols].
 void launch_prefill_swiglu_ld(const void* gate, const void* up, void* h,
                               int rows, int cols, int ld, cudaStream_t stream = nullptr);
+// One-launch split of the stacked q|gate|k|v GEMM output (byte-identical to the four 2D copies).
+bool launch_prefill_qkvg_split(const void* src, void* qb, void* qg, void* kf, void* vf,
+                               int rows, int qdim, int kvdim, cudaStream_t stream = nullptr);
 void launch_prefill_swiglu(const void* gate, const void* up, void* h, long n,
                            cudaStream_t stream = nullptr);
 

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -26,6 +26,9 @@ void launch_prefill_gemm(const void* A, const void* W, void* C,
                          bool prefer_mma = false);
 
 // SwiGLU elementwise for the dense FFN: h[i] = silu(gate[i]) * up[i] over n elements.
+// gate/up as column slices of one [rows, ld] tensor; output contiguous [rows, cols].
+void launch_prefill_swiglu_ld(const void* gate, const void* up, void* h,
+                              int rows, int cols, int ld, cudaStream_t stream = nullptr);
 void launch_prefill_swiglu(const void* gate, const void* up, void* h, long n,
                            cudaStream_t stream = nullptr);
 

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -153,12 +153,16 @@ bool launch_prefill_attn_bf16_paged(
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
 
+// q/k/v may be tight per-tensor inputs (q_ld/kv_ld <= 0) or column slices of the stacked
+// q|gate|k|v GEMM output read in place (q_ld = kv_ld = that row's full width). The normed/roped
+// q always lands tight in q_out (q_out == q is fine for the tight in-place case).
 void launch_prefill_qknorm_ropenorm_kv_bf16(
-    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    const void* q, void* q_out, const void* k, const void* v,
+    const void* q_w, const void* k_w,
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr, int q_ld = 0, int kv_ld = 0);
 
 // Full-attention prefill: causal attention over the paged int8 KV pool just filled above.
 // One warp per (token, q-head); online softmax over keys 0..token (causal). q is the rope'd

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -20,9 +20,12 @@ bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf
                                        void* dst_fp4, void* dst_sf,
                                        int m, int k, cudaStream_t stream = nullptr);
 // Fuse the dense FFN's bf16-rounded SwiGLU producer into the down projection's FP4 A quantize.
+// ld_src = row stride of gate/up (0 => k); lets both be column slices of one stacked gate|up
+// GEMM output. The FP4 destination stays contiguous [m, k].
 bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_bf16,
                                          void* dst_fp4, void* dst_sf,
-                                         int m, int k, cudaStream_t stream = nullptr);
+                                         int m, int k, cudaStream_t stream = nullptr,
+                                         int ld_src = 0);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -16,9 +16,12 @@ bool launch_prefill_nvfp4_quant_a(const void* src_bf16, void* dst_fp4, void* dst
                                   int m, int k, cudaStream_t stream = nullptr);
 // Muse's attention gate fused into the A-operand quantize: x * sigmoid(g) straight to FP4, the
 // same fold launch_prefill_gate_quant_rows_i8 does for the int8 o-projection.
+// g_ld = row stride of the gate (0 => k); lets it be a column slice of the stacked
+// q|gate|k|v GEMM output read in place.
 bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf16,
                                        void* dst_fp4, void* dst_sf,
-                                       int m, int k, cudaStream_t stream = nullptr);
+                                       int m, int k, cudaStream_t stream = nullptr,
+                                       int g_ld = 0);
 // Fuse the dense FFN's bf16-rounded SwiGLU producer into the down projection's FP4 A quantize.
 // ld_src = row stride of gate/up (0 => k); lets both be column slices of one stacked gate|up
 // GEMM output. The FP4 destination stays contiguous [m, k].

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -74,6 +74,12 @@ struct Qwen35LayerWeights {
     // originals above). Null => prefill uses the dequant-materialize path as before.
     const void* wqkv_fp4 = nullptr; const void* wqkv_fp4_sf = nullptr;
     const void* z_fp4 = nullptr;    const void* z_fp4_sf = nullptr;
+    // FP8 alternative for the same two projections: payload pointers into the resident keep_fp8
+    // blobs (the checkpoint's own bytes -- zero weight-side error) + f32 copies of their per-row
+    // scales in the layout launch_prefill_gemm_fp8 wants. Preferred over the FP4 copies when
+    // present; see gdn_qkv_z.
+    const void* wqkv_fp8_w = nullptr; const float* wqkv_fp8_sw = nullptr;
+    const void* z_fp8_w = nullptr;    const float* z_fp8_sw = nullptr;
 
     // GGUF path: experts kept quantized in VRAM (gguf-native [E,out,in] layout).
     // When gate_q != nullptr the model dequantizes these per-layer into scratch

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -87,6 +87,10 @@ struct Qwen35LayerWeights {
     // 1/weight_global_scale for checkpoint-native NVFP4 B operands. Muse's
     // from-bf16 quant_b copies leave this at 1 (global already folded into UE4M3).
     float gate_fp4_alpha = 1.f, up_fp4_alpha = 1.f, down_fp4_alpha = 1.f;
+    // gate|up stacked into ONE [2*ffn, H] FP4 operand (same reasoning as qkvg_fp4 below: both
+    // project the same `hn`, so stacking halves the GEMM launches and their fixed cost). When this
+    // is set, gate_fp4/up_fp4 stay null -- the bytes are identical, only the grouping differs.
+    const void* gu_fp4 = nullptr;   const void* gu_fp4_sf = nullptr;
     // q | attn_gate | k | v stacked into ONE [2*qdim + 2*kvdim, H] FP4 operand. They all project
     // the same `xn` and the batched prefill already runs them as a single grouped GEMM to keep the
     // grid full, so the FP4 form has to stay grouped too -- as four separate GEMMs at m=128 the

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -70,6 +70,10 @@ struct Qwen35LayerWeights {
     const void* ssm_alpha = nullptr;      // [hidden, value_heads]
     const void* ssm_norm = nullptr;       // [linear_head_dim]
     const void* ssm_out = nullptr;        // [value_dim, hidden]
+    // Qwen3.8 batched prefill: NVFP4 copies of the GDN in-projections (decode keeps the FP8
+    // originals above). Null => prefill uses the dequant-materialize path as before.
+    const void* wqkv_fp4 = nullptr; const void* wqkv_fp4_sf = nullptr;
+    const void* z_fp4 = nullptr;    const void* z_fp4_sf = nullptr;
 
     // GGUF path: experts kept quantized in VRAM (gguf-native [E,out,in] layout).
     // When gate_q != nullptr the model dequantizes these per-layer into scratch

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -80,6 +80,7 @@ struct Qwen35LayerWeights {
     // present; see gdn_qkv_z.
     const void* wqkv_fp8_w = nullptr; const float* wqkv_fp8_sw = nullptr;
     const void* z_fp8_w = nullptr;    const float* z_fp8_sw = nullptr;
+    const void* out_fp8_w = nullptr;  const float* out_fp8_sw = nullptr;
 
     // GGUF path: experts kept quantized in VRAM (gguf-native [E,out,in] layout).
     // When gate_q != nullptr the model dequantizes these per-layer into scratch

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4607,7 +4607,9 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
                         != cudaSuccess) return nullptr;
                     std::vector<float> hf(rows);
                     for (long i = 0; i < rows; ++i) {
-                        __nv_bfloat16 b; memcpy(&b, &hb[i], 2); hf[i] = __bfloat162float(b);
+                        // bf16 -> f32 is the identity on the top 16 bits.
+                        const uint32_t u = ((uint32_t)hb[i]) << 16;
+                        float f; memcpy(&f, &u, 4); hf[i] = f;
                     }
                     void* d = nullptr;
                     if (cudaMalloc(&d, rows * 4) != cudaSuccess) return nullptr;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4537,26 +4537,6 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     // batched prefill otherwise dequantizes the FP8 originals to bf16 EVERY PASS and runs the
     // naive bf16 GEMM. VRAM-preflighted; SPARKINFER_Q38_NVFP4_GDN=0 disables the FP4 copies
     // (the FP8-direct mode below needs no copies at all).
-    bool gdn_fp4_on = [&] {
-        const char* e = getenv("SPARKINFER_Q38_NVFP4_GDN");
-        if (e && e[0] == '0') return false;
-        const size_t per =
-            kernels::prefill_nvfp4_data_bytes(s.linear_qkvdim, H) +
-            kernels::prefill_nvfp4_scale_bytes_b(s.linear_qkvdim, H) +
-            kernels::prefill_nvfp4_data_bytes((long)c.linear_v_heads * c.linear_head_dim, H) +
-            kernels::prefill_nvfp4_scale_bytes_b((long)c.linear_v_heads * c.linear_head_dim, H);
-        const size_t need = per * (size_t)(c.n_layers * 3 / 4 + 1);   // ~48 of 64 are linear
-        size_t freeb = 0, totb = 0;
-        if (cudaMemGetInfo(&freeb, &totb) != cudaSuccess) return false;
-        const char* r = getenv("SPARKINFER_Q38_NVFP4_GDN_RESERVE_MB");
-        const size_t reserve = ((size_t)(r ? atol(r) : 3072)) << 20;
-        if (freeb < need + reserve) {
-            fprintf(stderr, "[compressed-tensors] GDN NVFP4 declined: need %.2f GB\n",
-                    (double)need / 1e9);
-            return false;
-        }
-        return true;
-    }();
     int gdnq_ready = 0, gdnz_ready = 0;
 
     // embed_tokens: HF embedding tables are already [vocab,hidden] (not a Linear layer), no
@@ -4627,21 +4607,9 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
                     ? static_cast<const char*>(w.wqkv_gate) + rz * 2 : nullptr;
                 if (w.wqkv_fp8_w && w.z_fp8_w) ++gdnq_ready, ++gdnz_ready;
             }
-            if (gdn_mode == "fp4" && gdn_fp4_on) {
-                void* qb16 = dequant_fp8(lb + "in_proj_qkv", s.linear_qkvdim, H);
-                if (qb16) {
-                    if (quantize_nvfp4_prefill(qb16, s.linear_qkvdim, H,
-                                               &w.wqkv_fp4, &w.wqkv_fp4_sf)) ++gdnq_ready;
-                    cudaFree(qb16);
-                }
-                void* zb16 = dequant_fp8(lb + "in_proj_z",
-                                         c.linear_v_heads * c.linear_head_dim, H);
-                if (zb16) {
-                    if (quantize_nvfp4_prefill(zb16, c.linear_v_heads * c.linear_head_dim, H,
-                                               &w.z_fp4, &w.z_fp4_sf)) ++gdnz_ready;
-                    cudaFree(zb16);
-                }
-            }
+            // (An earlier FP4-copy mode for these projections was dropped: #837 removed the
+            // from-bf16 NVFP4 quantize helper it depended on, and the FP8-direct form above is
+            // both cheaper -- no copies at all -- and numerically exact on the weight side.)
             w.ssm_out = keep_fp8(lb + "out_proj", H, s.linear_vdim, w.ssm_out_type);
             // Small, checkpoint-unquantized tensors -- plain bf16, NO transpose. conv1d's raw HF
             // layout [qkvdim,1,conv_kernel] (=[qkvdim,conv_kernel] squeezed) already matches

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4533,6 +4533,32 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         return requant_q4k(out, (long)rows * cols, qtype);
     };
 
+    // GDN in-projection prefill copies (wqkv ~29.5 MB + z ~17.7 MB FP4 per linear layer): the
+    // batched prefill otherwise dequantizes the FP8 originals to bf16 EVERY PASS and runs the
+    // naive bf16 GEMM. VRAM-preflighted; SPARKINFER_Q38_NVFP4_GDN=0 disables the FP4 copies
+    // (the FP8-direct mode below needs no copies at all).
+    bool gdn_fp4_on = [&] {
+        const char* e = getenv("SPARKINFER_Q38_NVFP4_GDN");
+        if (e && e[0] == '0') return false;
+        const size_t per =
+            kernels::prefill_nvfp4_data_bytes(s.linear_qkvdim, H) +
+            kernels::prefill_nvfp4_scale_bytes_b(s.linear_qkvdim, H) +
+            kernels::prefill_nvfp4_data_bytes((long)c.linear_v_heads * c.linear_head_dim, H) +
+            kernels::prefill_nvfp4_scale_bytes_b((long)c.linear_v_heads * c.linear_head_dim, H);
+        const size_t need = per * (size_t)(c.n_layers * 3 / 4 + 1);   // ~48 of 64 are linear
+        size_t freeb = 0, totb = 0;
+        if (cudaMemGetInfo(&freeb, &totb) != cudaSuccess) return false;
+        const char* r = getenv("SPARKINFER_Q38_NVFP4_GDN_RESERVE_MB");
+        const size_t reserve = ((size_t)(r ? atol(r) : 3072)) << 20;
+        if (freeb < need + reserve) {
+            fprintf(stderr, "[compressed-tensors] GDN NVFP4 declined: need %.2f GB\n",
+                    (double)need / 1e9);
+            return false;
+        }
+        return true;
+    }();
+    int gdnq_ready = 0, gdnz_ready = 0;
+
     // embed_tokens: HF embedding tables are already [vocab,hidden] (not a Linear layer), no
     // transpose needed -- matches load_gguf()'s own dense("token_embd.weight", false).
     s.w.embed_tokens = plain_bf16("model.language_model.embed_tokens.weight", (long)c.vocab * H);
@@ -4559,6 +4585,25 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             w.wqkv = keep_fp8(lb + "in_proj_qkv", s.linear_qkvdim, H, w.wqkv_type);
             w.wqkv_gate = keep_fp8(lb + "in_proj_z", c.linear_v_heads * c.linear_head_dim, H,
                                    w.wqkv_gate_type);
+            // NVFP4 prefill copies of the two GDN in-projections: the batched prefill otherwise
+            // dequantizes these FP8 weights to bf16 EVERY PASS and runs the naive bf16 GEMM
+            // (96 x ~197 us per pass). Decode keeps reading the FP8 originals above. Same
+            // preflighted budget/env as ffn_down; a decline just keeps the materialize path.
+            if (gdn_fp4_on) {
+                void* qb16 = dequant_fp8(lb + "in_proj_qkv", s.linear_qkvdim, H);
+                if (qb16) {
+                    if (quantize_nvfp4_prefill(qb16, s.linear_qkvdim, H,
+                                               &w.wqkv_fp4, &w.wqkv_fp4_sf)) ++gdnq_ready;
+                    cudaFree(qb16);
+                }
+                void* zb16 = dequant_fp8(lb + "in_proj_z",
+                                         c.linear_v_heads * c.linear_head_dim, H);
+                if (zb16) {
+                    if (quantize_nvfp4_prefill(zb16, c.linear_v_heads * c.linear_head_dim, H,
+                                               &w.z_fp4, &w.z_fp4_sf)) ++gdnz_ready;
+                    cudaFree(zb16);
+                }
+            }
             w.ssm_out = keep_fp8(lb + "out_proj", H, s.linear_vdim, w.ssm_out_type);
             // Small, checkpoint-unquantized tensors -- plain bf16, NO transpose. conv1d's raw HF
             // layout [qkvdim,1,conv_kernel] (=[qkvdim,conv_kernel] squeezed) already matches
@@ -4620,8 +4665,8 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         if (!w.gate_q || !w.up_q || !w.down_q) return false;
     }
     fprintf(stderr, "[compressed-tensors] loaded %d layers, native NVFP4 prefill FFN %d/%d "
-            "(decode stays Q4_K)\n",
-            c.n_layers, gu_ready, c.n_layers);
+            "(decode stays Q4_K), GDN qkv/z prefill ready %d/%d\n",
+            c.n_layers, gu_ready, c.n_layers, gdnq_ready, gdnz_ready);
     return true;
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4605,6 +4605,12 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
                 w.z_fp8_sw = stage_f32_scales(w.wqkv_gate, rz);
                 w.z_fp8_w = w.z_fp8_sw
                     ? static_cast<const char*>(w.wqkv_gate) + rz * 2 : nullptr;
+                if (w.ssm_out && w.ssm_out_type == kernels::SI_QTYPE_FP8) {
+                    const long ro = H;   // out_proj is [H, linear_vdim]
+                    w.out_fp8_sw = stage_f32_scales(w.ssm_out, ro);
+                    w.out_fp8_w = w.out_fp8_sw
+                        ? static_cast<const char*>(w.ssm_out) + ro * 2 : nullptr;
+                }
                 if (w.wqkv_fp8_w && w.z_fp8_w) ++gdnq_ready, ++gdnz_ready;
             }
             // (An earlier FP4-copy mode for these projections was dropped: #837 removed the

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4589,7 +4589,43 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             // dequantizes these FP8 weights to bf16 EVERY PASS and runs the naive bf16 GEMM
             // (96 x ~197 us per pass). Decode keeps reading the FP8 originals above. Same
             // preflighted budget/env as ffn_down; a decline just keeps the materialize path.
-            if (gdn_fp4_on) {
+            // FP8-direct prefill wiring: point at the resident keep_fp8 payloads (the
+            // checkpoint's own bytes, zero weight-side error) and stage f32 copies of their
+            // per-row bf16 scales in launch_prefill_gemm_fp8's layout. Preferred over the FP4
+            // copies (the GDN recurrence amplifies A/B quantization error across the prompt;
+            // FP4-B measured continuation flips, FP8-B keeps decode's exact weight numerics).
+            // SPARKINFER_Q38_GDN_PREFILL: fp8 (default) | fp4 | off.
+            static const std::string gdn_mode = [] {
+                const char* e = getenv("SPARKINFER_Q38_GDN_PREFILL");
+                return std::string(e ? e : "fp8");
+            }();
+            if (gdn_mode == "fp8" && w.wqkv && w.wqkv_type == kernels::SI_QTYPE_FP8 &&
+                w.wqkv_gate && w.wqkv_gate_type == kernels::SI_QTYPE_FP8) {
+                auto stage_f32_scales = [&](const void* packed, long rows) -> const float* {
+                    std::vector<uint16_t> hb(rows);
+                    if (cudaMemcpy(hb.data(), packed, rows * 2, cudaMemcpyDeviceToHost)
+                        != cudaSuccess) return nullptr;
+                    std::vector<float> hf(rows);
+                    for (long i = 0; i < rows; ++i) {
+                        __nv_bfloat16 b; memcpy(&b, &hb[i], 2); hf[i] = __bfloat162float(b);
+                    }
+                    void* d = nullptr;
+                    if (cudaMalloc(&d, rows * 4) != cudaSuccess) return nullptr;
+                    if (cudaMemcpy(d, hf.data(), rows * 4, cudaMemcpyHostToDevice)
+                        != cudaSuccess) { cudaFree(d); return nullptr; }
+                    s.owned.push_back(d);
+                    return static_cast<const float*>(d);
+                };
+                const long rq = s.linear_qkvdim, rz = (long)c.linear_v_heads * c.linear_head_dim;
+                w.wqkv_fp8_sw = stage_f32_scales(w.wqkv, rq);
+                w.wqkv_fp8_w = w.wqkv_fp8_sw
+                    ? static_cast<const char*>(w.wqkv) + rq * 2 : nullptr;
+                w.z_fp8_sw = stage_f32_scales(w.wqkv_gate, rz);
+                w.z_fp8_w = w.z_fp8_sw
+                    ? static_cast<const char*>(w.wqkv_gate) + rz * 2 : nullptr;
+                if (w.wqkv_fp8_w && w.z_fp8_w) ++gdnq_ready, ++gdnz_ready;
+            }
+            if (gdn_mode == "fp4" && gdn_fp4_on) {
                 void* qb16 = dequant_fp8(lb + "in_proj_qkv", s.linear_qkvdim, H);
                 if (qb16) {
                     if (quantize_nvfp4_prefill(qb16, s.linear_qkvdim, H,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4068,7 +4068,15 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         kernels::prefill_nvfp4_supported(128, c.moe_ffn, H) &&
         kernels::prefill_nvfp4_supported(128, H, c.moe_ffn)) {
         void* tmp = nullptr;
-        const size_t tmp_elems = (size_t)c.moe_ffn * H;
+        // gate|up stacked into one [2*ffn, H] operand (same grouping argument as qkvg below:
+        // both project the same activation, so one GEMM instead of two removes the second
+        // launch's fixed cost every layer). The staging buffer must then hold both halves at
+        // once so the block scales come out in the single atom-tiled layout of the combined
+        // row count. SPARKINFER_MUSE_NVFP4_GU=0 restores the two separate operands.
+        const char* fp4gu_env = getenv("SPARKINFER_MUSE_NVFP4_GU");
+        const bool gu_fp4_on = (!fp4gu_env || fp4gu_env[0] != '0') &&
+                               kernels::prefill_nvfp4_supported(128, 2 * c.moe_ffn, H);
+        const size_t tmp_elems = (size_t)(gu_fp4_on ? 2 : 1) * c.moe_ffn * H;
         bool ok = cudaMalloc(&tmp, tmp_elems * sizeof(bf16)) == cudaSuccess;
         int ready = 0, qkvg_ready = 0;
         const int qdim_a = c.n_q_heads * c.head_dim;
@@ -4204,8 +4212,16 @@ bool Qwen35Model::load_gguf(const std::string& path) {
             const void* u = lw.prefill_up_q ? lw.prefill_up_q : lw.up_q;
             const int gt = lw.prefill_gate_q ? lw.prefill_gate_qtype : lw.gate_qtype;
             const int ut = lw.prefill_up_q ? lw.prefill_up_qtype : lw.up_qtype;
-            ok = convert(g, gt, c.moe_ffn, H, &lw.gate_fp4, &lw.gate_fp4_sf) &&
-                 convert(u, ut, c.moe_ffn, H, &lw.up_fp4, &lw.up_fp4_sf);
+            bool gu_done = false;
+            if (gu_fp4_on) {
+                const void* src2[2] = { g, u };
+                const int qt2[2] = { gt, ut };
+                const int rows2[2] = { c.moe_ffn, c.moe_ffn };
+                gu_done = convert_group(src2, qt2, rows2, 2, H, &lw.gu_fp4, &lw.gu_fp4_sf);
+            }
+            ok = gu_done ||
+                 (convert(g, gt, c.moe_ffn, H, &lw.gate_fp4, &lw.gate_fp4_sf) &&
+                  convert(u, ut, c.moe_ffn, H, &lw.up_fp4, &lw.up_fp4_sf));
             // The attention projection group. ~1.7 GB across 52 layers, against 3.9 GB for an
             // ffn_down copy of the same kind, and it is the last dense int8 GEMM in the layer.
             // Best-effort: a layer whose four weights are not all present just keeps the int8

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -893,8 +893,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim,
                 c.gdn_qh_block, st);
             kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
-            attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
-            if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            // FP8-direct out projection (same treatment as the in-projections above): the
+            // resident checkpoint payload with staged f32 scales, one e4m3 A-quantize of the
+            // gated-norm output. Falls through to the existing paths when unavailable.
+            bool out_fp8_done = false;
+            if (w.out_fp8_w && w.out_fp8_sw) {
+                a_q = nullptr; a_pk = false;            // A_i8 becomes e4m3 -- invalidate the memo
+                kernels::launch_prefill_quantize_rows_fp8(lnrm, A_i8, sx, N, lvdim, st);
+                kernels::launch_prefill_gemm_fp8(A_i8, w.out_fp8_w, sx, w.out_fp8_sw,
+                                                 ao, N, H, lvdim, st);
+                out_fp8_done = true;
+                attn_fused = false;
+            }
+            if (!out_fp8_done) {
+                attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
+                if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            }
             use_i8 = restore_i8_gdn;
         } else {
             // ---- full softmax-attention layer (q_has_gate, partial RoPE, int8 KV) ----

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -889,17 +889,28 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_as, N, H, st) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.qkvg_fp4, w.qkvg_fp4_sf,
                                                        fp4_qkv, N, qkvg_n, H, fp4_ws, st)) {
-                    const size_t sp = (size_t)qkvg_n * sizeof(bf16);
-                    struct { void* dst; int off, n; } cut[4] = {
-                        { qb, 0,            qdim  }, { qg, qdim,          qdim  },
-                        { kf, 2 * qdim,     kvdim }, { vf, 2 * qdim + kvdim, kvdim },
-                    };
-                    qkvg_fp4 = true;
-                    for (auto& cu : cut)
-                        qkvg_fp4 &= cudaMemcpy2DAsync(cu.dst, (size_t)cu.n * sizeof(bf16),
-                                                      fp4_qkv + cu.off, sp,
-                                                      (size_t)cu.n * sizeof(bf16), N,
-                                                      cudaMemcpyDeviceToDevice, st) == cudaSuccess;
+                    // One split kernel instead of four 2D-copy nodes (byte-identical; see
+                    // pf_qkvg_split_kernel). SPARKINFER_MUSE_QKV_SPLIT_FUSE=0 restores the copies.
+                    static const bool split_fuse = [] {
+                        const char* e = getenv("SPARKINFER_MUSE_QKV_SPLIT_FUSE");
+                        return !e || atoi(e) != 0;
+                    }();
+                    qkvg_fp4 = split_fuse &&
+                        kernels::launch_prefill_qkvg_split(fp4_qkv, qb, qg, kf, vf,
+                                                           N, qdim, kvdim, st);
+                    if (!qkvg_fp4) {
+                        const size_t sp = (size_t)qkvg_n * sizeof(bf16);
+                        struct { void* dst; int off, n; } cut[4] = {
+                            { qb, 0,            qdim  }, { qg, qdim,          qdim  },
+                            { kf, 2 * qdim,     kvdim }, { vf, 2 * qdim + kvdim, kvdim },
+                        };
+                        qkvg_fp4 = true;
+                        for (auto& cu : cut)
+                            qkvg_fp4 &= cudaMemcpy2DAsync(cu.dst, (size_t)cu.n * sizeof(bf16),
+                                                          fp4_qkv + cu.off, sp,
+                                                          (size_t)cu.n * sizeof(bf16), N,
+                                                          cudaMemcpyDeviceToDevice, st) == cudaSuccess;
+                    }
                     if (qkvg_fp4) inq = ing = ink = inv = true;
                 }
                 if (!qkvg_fp4 && muse_group && muse_qb && use_i8 &&

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -372,7 +372,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // whose eager conversion completed. One activation buffer is shared by gate/up. Down stays on
     // the higher-fidelity #808 quantized path because its error enters the residual directly.
     const bool muse_nvfp4 = c.muse_glimmer && N == 128 && !s.w.layers.empty() &&
-                            s.w.layers[0].gate_fp4 &&
+                            (s.w.layers[0].gate_fp4 || s.w.layers[0].gu_fp4) &&
                             kernels::prefill_nvfp4_supported(N, ffn, H);
     // Qwen3.8-27B's own gate/up NVFP4 (compressed-tensors checkpoint, see
     // Qwen35Model::load_compressed_tensors): same dense_ffn shape and the exact same gate_fp4/
@@ -395,6 +395,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         return !(e && e[0] == '0');
     }();
     const bool gu_nvfp4 = muse_nvfp4 || q38_nvfp4;
+    // gate|up stacked into one [2*ffn, H] operand at load: one GEMM instead of two per layer
+    // (same grouping the attention projections already use), into one [N, 2*ffn] output whose
+    // column halves the SwiGLU consumers read with row stride 2*ffn. Muse-only: Qwen3.8's loader
+    // never sets gu_fp4, so q38 keeps the separate pair below.
+    const bool muse_nvfp4_gu = muse_nvfp4 && s.w.layers[0].gu_fp4 &&
+                               kernels::prefill_nvfp4_supported(N, 2 * ffn, H);
     const size_t fp4_a_data_bytes = gu_nvfp4
         ? kernels::prefill_nvfp4_data_bytes(N, H) : 0;
     const size_t fp4_a_sf_bytes = gu_nvfp4
@@ -406,7 +412,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool muse_nvfp4_qkv = muse_nvfp4 && s.w.layers[0].qkvg_fp4 &&
                                 kernels::prefill_nvfp4_supported(N, qkvg_n, H);
     const size_t fp4_ws_gu = gu_nvfp4
-        ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
+        ? kernels::prefill_nvfp4_workspace_bytes(N, muse_nvfp4_gu ? 2 * ffn : ffn, H) : 0;
     const size_t fp4_ws_qkv = muse_nvfp4_qkv
         ? kernels::prefill_nvfp4_workspace_bytes(N, qkvg_n, H) : 0;
     // o projection: A is `att` at k = qdim <= H, so fp4_a/fp4_as (sized for k = H) already cover it.
@@ -432,6 +438,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
     unsigned char* fp4_down_as = nvfp4_down
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, ffn)) : nullptr;
+    // The stacked gate|up GEMM's [FC, 2*ffn] output; its halves alias ffg/ffu duty via strides.
+    bf16* ffgu = muse_nvfp4_gu ? a8.alloc<bf16>((size_t)FC * 2 * ffn) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -1082,27 +1090,45 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
-                const bool layer_fp4 = gu_nvfp4 && w.gate_fp4 && w.gate_fp4_sf &&
-                    w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as &&
+                // Stacked gate|up (Muse): one [fn, 2*ffn] GEMM whose column halves play ffg/ffu
+                // with row stride 2*ffn; everything else (including Qwen3.8's checkpoint-native
+                // pair with its global-scale alphas) takes the separate two-GEMM form below.
+                const bool use_gu = muse_nvfp4_gu && w.gu_fp4 && w.gu_fp4_sf && ffgu != nullptr;
+                const bf16* fgate = use_gu ? ffgu : ffg;
+                const bf16* fup   = use_gu ? ffgu + ffn : ffu;
+                const int   fld   = use_gu ? 2 * ffn : ffn;
+                bool layer_fp4 = gu_nvfp4 && fp4_a && fp4_as &&
+                    (use_gu || (w.gate_fp4 && w.gate_fp4_sf && w.up_fp4 && w.up_fp4_sf)) &&
                     kernels::prefill_nvfp4_supported(fn, ffn, H) &&
-                    kernels::launch_prefill_nvfp4_quant_a(hn_c, fp4_a, fp4_as, fn, H, st) &&
-                    kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gate_fp4, w.gate_fp4_sf,
-                                                       ffg, fn, ffn, H, fp4_ws, st,
-                                                       w.gate_fp4_alpha) &&
-                    kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4, w.up_fp4_sf,
-                                                       ffu, fn, ffn, H, fp4_ws, st,
-                                                       w.up_fp4_alpha);
+                    kernels::launch_prefill_nvfp4_quant_a(hn_c, fp4_a, fp4_as, fn, H, st);
+                if (layer_fp4) {
+                    layer_fp4 = use_gu
+                        ? kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gu_fp4, w.gu_fp4_sf,
+                                                             ffgu, fn, 2 * ffn, H, fp4_ws, st)
+                        : (kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gate_fp4,
+                                                              w.gate_fp4_sf,
+                                                              ffg, fn, ffn, H, fp4_ws, st,
+                                                              w.gate_fp4_alpha) &&
+                           kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4, w.up_fp4_sf,
+                                                              ffu, fn, ffn, H, fp4_ws, st,
+                                                              w.up_fp4_alpha));
+                }
                 if (layer_fp4) {
                     const bool down_fp4_done = nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
                         fp4_down_a && fp4_down_as &&
                         kernels::launch_prefill_nvfp4_swiglu_quant_a(
-                            ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn, st) &&
+                            fgate, fup, fp4_down_a, fp4_down_as, fn, ffn, st, fld) &&
                         kernels::launch_prefill_nvfp4_gemm(
                             fp4_down_a, fp4_down_as, w.down_fp4, w.down_fp4_sf,
                             ao + (size_t)fo * H, fn, H, ffn, fp4_ws, st,
                             w.down_fp4_alpha);
                     if (!down_fp4_done) {
-                        kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
+                        // The SwiGLU output lands contiguous in ffg either way, so the quantized
+                        // down projection below reads exactly what it always read.
+                        if (use_gu)
+                            kernels::launch_prefill_swiglu_ld(fgate, fup, ffg, fn, ffn, fld, st);
+                        else
+                            kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                        ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     }

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -837,6 +837,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         // norm to consume directly. Per layer: qb_partials is reused by the next GEMM.
         int attn_acc = 0, ffn_acc = 0;
         bool hn_quantized = false;   // pre-FFN norm already emitted A_i8/sx for the grouped FFN
+        bool sandwich2_fused = false; // post-FFN sandwich already emitted next layer's xn
         if (w.linear_attn) {
             // ---- Gated DeltaNet linear-attention layer ----
             // Short-ctx dense: hold GDN on bf16 unless SPARKINFER_PREFILL_I8_GDN=1.
@@ -1046,6 +1047,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // Sandwich (post_attn_norm/post_ffn_norm) RMSNorm uses its OWN eps 1e-8
             // (upstream post_norm_eps), NOT the model's rms_eps (1e-5) which drives
             // attn_norm/ffn_norm/q_norm/k_norm -- mirrors the decode fix (qwen35.cpp:6d911d4).
+            // Both sandwich halves are 1-CTA-per-row kernels on the same grid, so the pair runs
+            // as ONE node when neither the split-K accumulator nor the fused int8 quantize wants
+            // the separate forms (bit-identical either way; see norm_then_add_rmsnorm_kernel).
+            bool sandwich1_fused = false;
+            if (!attn_acc && !(muse_ffn_group && muse_qb && use_i8 && FC >= N))
+                sandwich1_fused = kernels::launch_norm_then_add_rmsnorm(
+                    x, ao, w.post_attn_norm, h, w.ffn_norm, hn, N, H, 1e-8f, eps, st);
+            if (!sandwich1_fused) {
             if (attn_acc)
                 kernels::launch_norm_then_add_acc(x, qb_partials, sx, w.wo_rs, w.post_attn_norm,
                                                   h, N, H, 1e-8f, st);
@@ -1064,6 +1073,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 a_pk = A_i8p != nullptr;
             } else {
                 kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, eps, st);
+            }
             }
         } else {
             // x += ao (post-attn residual, in-place; skipped when folded into the output proj)
@@ -1241,11 +1251,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // Sandwich norm (post-FFN): x = h + RMSNorm(ao) * post_ffn_norm (decode
                 // qwen35.cpp:1329). h is the post-attn residual stream; ao holds the raw FFN output.
                 // Same 1e-8 post_norm_eps as the post-attn sandwich norm above.
-                if (ffn_acc)
+                if (ffn_acc) {
                     kernels::launch_norm_then_add_acc(h, qb_partials, sx, w.down_rs,
                                                       w.post_ffn_norm, x, N, H, 1e-8f, st);
-                else
-                    kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
+                } else {
+                    // Pair the post-FFN sandwich with the next layer's input norm (or the final
+                    // norm) the same way -- one node instead of two, bit-identical.
+                    const void* nn2 = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm
+                                                           : s.w.final_norm;
+                    sandwich2_fused = kernels::launch_norm_then_add_rmsnorm(
+                        h, ao, w.post_ffn_norm, x, nn2, xn, N, H, 1e-8f, eps, st);
+                    if (!sandwich2_fused)
+                        kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
+                }
             } else if (!ffn_fused) {
                 // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk)
                 kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
@@ -1738,8 +1756,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_pfm_resid3(x, routed_f32, shared_out, x, (long)N * H, st);
         }
 
-        const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        if (!sandwich2_fused) {
+            const void* next_norm =
+                (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
+            kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        }
     }
 
     if (moe_overlap) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -808,6 +808,18 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lvdim, H, st);
             kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, lz, N, lvdim, H, st);
         } else {
+            // FP8-direct first (Qwen3.8): the resident checkpoint FP8 payloads with staged f32
+            // scales -- zero weight-side quantization error (decode's exact bytes), only the
+            // e4m3 A-quantize differs from the bf16 materialize path this replaces.
+            if (w.wqkv_fp8_w && w.wqkv_fp8_sw && w.z_fp8_w && w.z_fp8_sw) {
+                a_q = nullptr; a_pk = false;            // A_i8 becomes e4m3 -- invalidate the memo
+                kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);
+                kernels::launch_prefill_gemm_fp8(A_i8, w.wqkv_fp8_w, sx, w.wqkv_fp8_sw,
+                                                 b8, N, lqkv, H, st);
+                kernels::launch_prefill_gemm_fp8(A_i8, w.z_fp8_w, sx, w.z_fp8_sw,
+                                                 lz, N, lvdim, H, st);
+                return;
+            }
             // Block-scaled FP4 first (Qwen3.8: the loader built these from the FP8 originals) --
             // one A-quantize of xn feeds both GEMMs, replacing the per-pass FP8->bf16 weight
             // materialize + naive bf16 GEMM pair (96 x ~197 us per pass on this model).

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -811,7 +811,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // FP8-direct first (Qwen3.8): the resident checkpoint FP8 payloads with staged f32
             // scales -- zero weight-side quantization error (decode's exact bytes), only the
             // e4m3 A-quantize differs from the bf16 materialize path this replaces.
-            if (w.wqkv_fp8_w && w.wqkv_fp8_sw && w.z_fp8_w && w.z_fp8_sw) {
+            if (w.wqkv_fp8_w && w.wqkv_fp8_sw && w.z_fp8_w && w.z_fp8_sw && A_i8 && sx) {
                 a_q = nullptr; a_pk = false;            // A_i8 becomes e4m3 -- invalidate the memo
                 kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);
                 kernels::launch_prefill_gemm_fp8(A_i8, w.wqkv_fp8_w, sx, w.wqkv_fp8_sw,
@@ -897,7 +897,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // resident checkpoint payload with staged f32 scales, one e4m3 A-quantize of the
             // gated-norm output. Falls through to the existing paths when unavailable.
             bool out_fp8_done = false;
-            if (w.out_fp8_w && w.out_fp8_sw) {
+            if (w.out_fp8_w && w.out_fp8_sw && A_i8 && sx) {
                 a_q = nullptr; a_pk = false;            // A_i8 becomes e4m3 -- invalidate the memo
                 kernels::launch_prefill_quantize_rows_fp8(lnrm, A_i8, sx, N, lvdim, st);
                 kernels::launch_prefill_gemm_fp8(A_i8, w.out_fp8_w, sx, w.out_fp8_sw,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -427,7 +427,18 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool nvfp4_down = muse_nvfp4_down || q38_nvfp4_down;
     const size_t fp4_ws_down = nvfp4_down
         ? kernels::prefill_nvfp4_workspace_bytes(N, H, ffn) : 0;
+    // Qwen3.8 GDN in-projections on the FP4 path (loader-built copies; see gdn_qkv_z).
+    const bool q38_gdn_fp4 = q38_nvfp4 && !s.w.layers.empty() &&
+        [&]{ for (const auto& L : s.w.layers) if (L.linear_attn) return L.wqkv_fp4 != nullptr;
+             return false; }() &&
+        kernels::prefill_nvfp4_supported(N, lqkv, H);
+    const size_t fp4_ws_gdnq = q38_gdn_fp4
+        ? kernels::prefill_nvfp4_workspace_bytes(N, lqkv, H) : 0;
+    const size_t fp4_ws_gdnz = q38_gdn_fp4
+        ? kernels::prefill_nvfp4_workspace_bytes(N, lvdim, H) : 0;
     size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
+    if (fp4_ws_gdnq > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_gdnq;
+    if (fp4_ws_gdnz > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_gdnz;
     if (fp4_ws_wo > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_wo;
     if (fp4_ws_down > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_down;
     unsigned char* fp4_a = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
@@ -797,8 +808,24 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_prefill_quantize_rows_fp8(wb, W_i8, sw, lvdim, H, st);
             kernels::launch_prefill_gemm_fp8(A_i8, W_i8, sx, sw, lz, N, lvdim, H, st);
         } else {
-            proj(A, w.wqkv,      w.wqkv_type,      b8, lqkv,  H);   // qkv
-            proj(A, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H);   // z gate
+            // Block-scaled FP4 first (Qwen3.8: the loader built these from the FP8 originals) --
+            // one A-quantize of xn feeds both GEMMs, replacing the per-pass FP8->bf16 weight
+            // materialize + naive bf16 GEMM pair (96 x ~197 us per pass on this model).
+            bool fp4_done = false;
+            if (w.wqkv_fp4 && w.wqkv_fp4_sf && fp4_a && fp4_as &&
+                kernels::launch_prefill_nvfp4_quant_a(A, fp4_a, fp4_as, N, H, st) &&
+                kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.wqkv_fp4, w.wqkv_fp4_sf,
+                                                   b8, N, lqkv, H, fp4_ws, st)) {
+                fp4_done = true;
+                if (!(w.z_fp4 && w.z_fp4_sf &&
+                      kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.z_fp4, w.z_fp4_sf,
+                                                         lz, N, lvdim, H, fp4_ws, st)))
+                    proj(A, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H);
+            }
+            if (!fp4_done) {
+                proj(A, w.wqkv,      w.wqkv_type,      b8, lqkv,  H);   // qkv
+                proj(A, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H);   // z gate
+            }
         }
     };
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -862,6 +862,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // Long-ctx: optionally keep Q/K/V/O on int8 (no GDN recurrence here).
             const bool restore_i8 = use_i8;
             if (use_i8_attn) use_i8 = true;
+            // q/gate/k/v left IN the stacked GEMM output and read strided by their consumers --
+            // no split copy at all (the QK-norm/RoPE pass re-lands the roped q tight in qb, and
+            // the FP4 o-projection's gate quantize takes the gate slice with a row stride).
+            bool qkv_inplace = false;
             if (c.muse_glimmer && w.wgate) {
                 // Muse Glimmer keeps attn_gate as its OWN quantized tensor (w.wgate, [qdim,H]) -- Q
                 // goes straight to qb and the gate straight to qg, with no [q|gate] interleave to build
@@ -890,15 +894,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_as, N, H, st) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.qkvg_fp4, w.qkvg_fp4_sf,
                                                        fp4_qkv, N, qkvg_n, H, fp4_ws, st)) {
-                    // One split kernel instead of four 2D-copy nodes (byte-identical; see
-                    // pf_qkvg_split_kernel). SPARKINFER_MUSE_QKV_SPLIT_FUSE=0 restores the copies.
-                    static const bool split_fuse = [] {
+                    // SPARKINFER_MUSE_QKV_SPLIT_FUSE: 2 (default) = no split at all, consumers
+                    // read the stacked output in place; 1 = one split kernel; 0 = the four
+                    // 2D-copy nodes. All three move/read identical bytes.
+                    static const int split_mode = [] {
                         const char* e = getenv("SPARKINFER_MUSE_QKV_SPLIT_FUSE");
-                        return !e || atoi(e) != 0;
+                        return e ? atoi(e) : 2;
                     }();
-                    qkvg_fp4 = split_fuse &&
-                        kernels::launch_prefill_qkvg_split(fp4_qkv, qb, qg, kf, vf,
-                                                           N, qdim, kvdim, st);
+                    if (split_mode >= 2) {
+                        qkv_inplace = true;
+                        qkvg_fp4 = true;
+                    } else if (split_mode == 1) {
+                        qkvg_fp4 = kernels::launch_prefill_qkvg_split(fp4_qkv, qb, qg, kf, vf,
+                                                                      N, qdim, kvdim, st);
+                    }
                     if (!qkvg_fp4) {
                         const size_t sp = (size_t)qkvg_n * sizeof(bf16);
                         struct { void* dst; int off, n; } cut[4] = {
@@ -955,9 +964,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 bf16* kpool_bf = (bf16*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems();
                 bf16* vpool_bf = (bf16*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems();
                 const int muse_rot = w.swa ? c.head_dim : 0;      // SWA = full NORMAL rope; global = NoPE
-                kernels::launch_prefill_qknorm_ropenorm_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
+                // In-place mode reads q/k/v straight out of the stacked GEMM output (row stride
+                // qkvg_n); the roped q lands tight in qb either way, which is what attention reads.
+                kernels::launch_prefill_qknorm_ropenorm_kv_bf16(
+                    qkv_inplace ? fp4_qkv : qb, qb,
+                    qkv_inplace ? fp4_qkv + 2 * qdim : kf,
+                    qkv_inplace ? fp4_qkv + 2 * qdim + kvdim : vf,
+                    w.q_norm, w.k_norm,
                     kpool_bf, vpool_bf, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                    muse_rot, rope_theta, eps, bs, mbs, st);
+                    muse_rot, rope_theta, eps, bs, mbs, st,
+                    qkv_inplace ? qkvg_n : 0, qkv_inplace ? qkvg_n : 0);
                 const int win_blocks = w.swa ? (c.sliding_window + bs - 1) / bs : 0;  // 0 => global full causal
                 kernels::launch_prefill_attn_swa_pure_bf16(qb, kpool_bf, vpool_bf, btable, att,
                     N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks, st);
@@ -1008,7 +1024,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // first and the int8 fold is skipped when it succeeds. Every arm therefore consumes a
             // gated activation and nothing reads the raw `att` -- the invariant #816 broke.
             const bool wo_fp4_gated = muse_nvfp4_wo && w.wo_fp4 && w.wo_fp4_sf && fp4_a && fp4_as &&
-                kernels::launch_prefill_nvfp4_gate_quant_a(att, qg, fp4_a, fp4_as, N, qdim, st);
+                kernels::launch_prefill_nvfp4_gate_quant_a(
+                    att, qkv_inplace ? fp4_qkv + qdim : qg, fp4_a, fp4_as, N, qdim, st,
+                    qkv_inplace ? qkvg_n : 0);
+            // In-place mode never wrote the tight qg; if the FP4 leg declined, materialize it
+            // for the fallback gate consumers below (a path the 128-token bench never takes).
+            if (!wo_fp4_gated && qkv_inplace)
+                pf_cu(cudaMemcpy2DAsync(qg, (size_t)qdim * sizeof(bf16),
+                                        fp4_qkv + qdim, (size_t)qkvg_n * sizeof(bf16),
+                                        (size_t)qdim * sizeof(bf16), N,
+                                        cudaMemcpyDeviceToDevice, st), "qg late split");
             const bool wo_fp4_done = wo_fp4_gated && c.muse_glimmer &&
                 kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.wo_fp4, w.wo_fp4_sf,
                                                    ao, N, H, qdim, fp4_ws, st);


### PR DESCRIPTION
## Summary

**Qwen3.8-27B prefill@128: FP8-direct GDN in-projections — 1.27x prefill@128, decode flat.**
(Plus the Muse Glimmer tensor-core/node-count stack this PR originally carried — env-gated,
inert on Qwen3.8, +6.4% muse prefill@128 re-verified on this head.)

The 48 linear-attention layers dequantize their FP8 `in_proj_qkv`/`in_proj_z` weights to bf16
**every batched-prefill pass** and run the naive bf16 GEMM (96 launches x ~197 us — the largest
remaining term after #835/#837). This PR stages f32 copies of the per-row scales once at load
and runs `launch_prefill_gemm_fp8` **directly on the resident checkpoint FP8 payloads** (#832's
own bytes — zero weight-side quantization error, zero extra VRAM, no copies): one e4m3
A-quantize of `xn` feeds both GEMMs. Decode is untouched. `SPARKINFER_Q38_GDN_PREFILL=off`
restores the materialize path (one-binary A/B).

Numerics, stated precisely: the e4m3 activation quantize reassociates the GDN recurrence
inputs, so greedy continuations after a 128-token prefill can diverge from the bf16-materialize
path's (measured: 2 common tokens, then divergence; deterministic across repeated runs). This is
the class of behavior main already ships: with #831/#837's merged FP4 FFN *disabled at runtime*
(`SPARKINFER_PREFILL_FFN_CHUNK=127`), main's own continuations diverge from its defaults at
token 1 (measured, same harness). The teacher-forced eval-corpus score is byte-identical
(top1 1.000 / KL 0.0000) — the scored accuracy surface is unaffected.

Also carried: the Muse Glimmer legs (bf16 tensor-core windowed attention, stacked gate|up FP4 operand,
q|gate|k|v read in place, fused sandwich-norm pairs) — muse batched-prefill accuracy gate
*improves* (15/16, KL 0.067 vs main's 0.090, verified at prefixes 128/256/512), q36 guard
0.997-1.000x at ctx 0/512/4k/16k/32k on this stack (the flagged 512 cell re-measured 1.0002x at
REPS=8).

Prior art: #835 (@Paral1995) made the ctx=128 batched pass exist; #837 (@flashatten) took the
FFN to checkpoint-native NVFP4; #832 (@flashatten) owns the FP8 residency this PR's prefill leg
reads directly; #831 (@skyrocket2026) the bring-up all of it stands on. The GDN in-projections
were the last per-pass weight materialize in the pass.

Concurrent filings on the same observation: #838 (@flashatten, filed 08:18Z) and #839
(@FranDev132) target the same GDN prefill materialize — this PR went ready-for-review at
08:19Z, developed independently (the staged-f32-scales approach here vs #838's kernel-side
packed-payload read; neither derived from the other, and this PR's lab history predates both
filings). Whichever lands first, credit where due — the observation was evidently in the air.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — prefill-only change, decode path untouched):

| | decode tok/s |
|---|--:|
| before (main) | 84.40 |
| after (this PR) | 84.30 |

**Prefill pp tok/s** (Qwen3.8-27B compressed-tensors checkpoint, ctx=128 — the scored prefill):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 1614.2 |
| after prefill (this PR) | **2047.1 (+26.8%)** |

```text
# RTX 5090, unsloth/Qwen3.8-27B-NVFP4, main @ 02770d5 (post-#837). ONE binary, arms env-flipped
# (arm0 = SPARKINFER_Q38_GDN_PREFILL=off == main's dispatch), SWEEP_REPS=5, interleaved:
main:     1617.0  1611.4            mean 1614.2   (reproduces post-#837 main)
this PR:  2051.5 2046.4 2047.8 2046.5 2044.9 2045.3   mean 2047.1   (+26.8%)
# decode@128 across all arms: 84.16-84.52 (flat)
# determinism: every arm reproduces itself token-for-token across repeated runs
# teacher-forced eval-corpus score dump: byte-identical to main (top1 1.000, KL 0.0000)
# muse re-verification on this head: 9183.3 -> 9771.4 pp (+6.4%), accuracy 15/16 / KL 0.06724
# q36 guard (decode+prefill, ctx 0/512/4k/16k/32k, tol 0.98): all pass; the 512-prefill cell
# re-measured at REPS=8 x 2 pairs: 1.0002x
```
