### PR TITLE
feat(qwen3.8-27b): NVFP4/FP8 compressed-tensors support, and scope PR eval to Qwen3.8 decode@128

### DIFF
--- a/.github/workflows/eval-policy.yml
+++ b/.github/workflows/eval-policy.yml
@@ -34,6 +34,9 @@ jobs:
           bash -n bench/scripts/warm_llamacpp.sh
           bash -n eval/run_bot_cron.sh
           bash -n eval/setup_labels.sh
+          # Qwen3.8-27B is the scored model (eval/README.md); its cron wrapper is the one that
+          # actually runs, so a syntax error here silently stops all scoring.
+          bash -n eval/run_qwen38_cron.sh
 
       - name: Python syntax
         run: |
@@ -43,7 +46,9 @@ jobs:
             bench/scripts/test_label.py \
             eval/pr_eval_bot.py \
             eval/test_pr_eval_bot.py \
-            eval/vast_eval.py
+            eval/vast_eval.py \
+            eval/pr_qwen38_bot.py \
+            bench/scripts/accuracy_compare_pair.py
 
       - name: Eval policy tests
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,22 @@ option(BUILD_EXAMPLES "Build example programs"          ON)
 
 find_package(CUDAToolkit REQUIRED)
 
+# Declared here, not in server/, because runtime/ is configured BEFORE server/ (see the
+# superbuild ordering below) and runtime/examples/qwen3_gguf_bench needs this target to read a
+# HuggingFace compressed-tensors checkpoint's config.json via qwen38_hf_config.h -- the same
+# header the server uses, so the benchmark and the server can never disagree about how a
+# checkpoint is configured. This links JSON into that one EXAMPLE EXECUTABLE only; the
+# sparkinfer_runtime library itself still links no JSON dependency (runtime/src/safetensors.cpp
+# keeps its own hand-rolled parser for exactly that reason). server/CMakeLists.txt reuses this
+# target rather than re-declaring it.
+include(FetchContent)
+FetchContent_Declare(
+    nlohmann_json
+    URL      https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
+    URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa
+)
+FetchContent_MakeAvailable(nlohmann_json)
+
 enable_testing()   # so `ctest` at the build root discovers the subdirs' add_test() registrations
 
 # Superbuild. moe/ and runtime/ guard their sibling add_subdirectory(../kernels)

--- a/bench/scripts/accuracy_compare_pair.py
+++ b/bench/scripts/accuracy_compare_pair.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""Compare two sparkinfer teacher-forced score dumps against each other.
+
+  accuracy_compare_pair.py <pr_score.txt> <main_score.txt> [--metric-label NAME]
+
+Sibling of accuracy_compare.py, which compares sparkinfer against a live llama.cpp server. That
+methodology needs llama.cpp to load *the same weights*, which is impossible for a HuggingFace
+compressed-tensors (NVFP4/FP8) checkpoint -- llama.cpp cannot read one. Comparing against a GGUF
+of the same model instead would compare two different quantizations and could never hold a tight
+top1/KL bar.
+
+So for the Qwen3.8-27B NVFP4 path the correctness gate is differential rather than absolute:
+score the SAME token stream on the PR build and on origin/main, and require the two
+distributions to agree. That catches any PR that changes the model's numerics -- which is what a
+per-PR gate is for -- without needing an external reference. It deliberately cannot catch a bug
+that is already present on main; only a newly introduced divergence.
+
+`main` is the reference distribution (P) and the PR is the candidate (Q), so KL(main||pr) mirrors
+accuracy_compare.py's KL(llama||spark) orientation: it penalises the PR putting little mass where
+the reference puts a lot.
+
+Dump line format (qwen3_gguf_score):
+  S i=<pos> tgt=<id> am=<argmax id> lp=<logprob of tgt> top=<id>:<lp>,<id>:<lp>,...
+"""
+import math
+import sys
+
+argv = sys.argv[1:]
+LABEL = "METRIC"
+if "--metric-label" in argv:
+    i = argv.index("--metric-label")
+    LABEL = argv[i + 1]
+    del argv[i:i + 2]
+
+if len(argv) < 2:
+    print(__doc__.strip().splitlines()[2].strip())
+    sys.exit(2)
+
+pr_path, main_path = argv[0], argv[1]
+# Same floor accuracy_compare.py uses for tokens outside a dump's top-k: log-prob of an
+# unlisted token is unknown, not zero, so clamp rather than drop it from the union.
+FLOOR = -20.0
+
+
+def load(path):
+    out = {}
+    with open(path) as f:
+        for line in f:
+            if not line.startswith("S "):
+                continue
+            try:
+                p = line.split()
+                pos = int(p[1][2:])
+                am = int(p[3][3:])
+                lp = float(p[4][3:])
+                top = {
+                    int(x.split(":")[0]): float(x.split(":")[1])
+                    for x in line.split("top=", 1)[1].split(",")
+                }
+            except (IndexError, ValueError):
+                continue   # a truncated final line (killed process) must not abort the compare
+            out[pos] = {"am": am, "lp": lp, "top": top}
+    return out
+
+
+pr, ref = load(pr_path), load(main_path)
+shared = sorted(set(pr) & set(ref))
+
+if not shared:
+    # Hostile defaults, matching accuracy_compare.py: a gate that cannot measure must FAIL,
+    # never silently pass.
+    print(f"{LABEL} top1=0 kl=99 ppl_pr=0 ppl_main=0   (NO SHARED POSITIONS)")
+    sys.exit(1)
+
+match = 0
+klsum = 0.0
+pr_nll = 0.0
+ref_nll = 0.0
+for pos in shared:
+    a, b = pr[pos], ref[pos]
+    if a["am"] == b["am"]:
+        match += 1
+    pr_nll += -a["lp"]
+    ref_nll += -b["lp"]
+    U = set(a["top"]) | set(b["top"])
+    P = {k: math.exp(b["top"].get(k, FLOOR)) for k in U}   # reference = main
+    Q = {k: math.exp(a["top"].get(k, FLOOR)) for k in U}   # candidate = PR
+    ps, qs = sum(P.values()), sum(Q.values())
+    kl = 0.0
+    for k in U:
+        pp = P[k] / ps
+        qq = Q[k] / qs
+        if pp > 0:
+            kl += pp * math.log(pp / max(qq, 1e-12))
+    klsum += kl
+
+n = len(shared)
+skipped = (len(pr) - n) + (len(ref) - n)
+print(f"positions             : {n}" + (f"  ({skipped} unpaired, skipped)" if skipped else ""))
+print(f"top-1 agreement       : {match}/{n} = {match / n:.3f}   (PR vs main)")
+print(f"mean KL(main||pr)     : {klsum / n:.4f} nats  (top-k union)")
+print(f"PPL PR                : {math.exp(pr_nll / n):.3f}")
+print(f"PPL main              : {math.exp(ref_nll / n):.3f}")
+print(
+    f"{LABEL} top1={match / n:.6f} kl={klsum / n:.6f} "
+    f"ppl_pr={math.exp(pr_nll / n):.4f} ppl_main={math.exp(ref_nll / n):.4f}"
+)

--- a/eval/README.md
+++ b/eval/README.md
@@ -178,13 +178,18 @@ SSH works → full eval of new PR commits. If the pin is stopped/unreachable →
 
 ## Qwen3.8-27B PR auto-evaluation bot (the scored path)
 
-> **Status: scoring is Qwen3.8-27B-only.** `pr_qwen38_bot.py` is the bot on cron
-> (`eval/run_qwen38_cron.sh`, every 30 min). A round costs ~80s per ref measured end-to-end
-> (~3 min with one pending PR), so the interval is not a bottleneck — see that file's header for
-> the stage-by-stage timings. The Muse Glimmer bot (`pr_museglimmer_bot.py`) and
-> the DFlash bot (`pr_dflash_bot.py`) are **retired from cron** — their code is kept for reference
-> and both still work if run by hand, but neither is scheduled. Only one bot may hold the shared
-> `/tmp/sparkinfer_bot.lock` at a time, and they all drive the same single pinned GPU.
+> **Intended scope: scoring is Qwen3.8-27B-only.** `pr_qwen38_bot.py` (`eval/run_qwen38_cron.sh`,
+> `*/30`) is meant to be the only bot on cron, with the Muse Glimmer (`pr_museglimmer_bot.py`) and
+> DFlash (`pr_dflash_bot.py`) bots kept for reference and run by hand only. Only one bot may hold
+> the shared `/tmp/sparkinfer_bot.lock` at a time, and they all drive the same single pinned GPU.
+>
+> **This is not automatic.** The crontab is host state, not repo state, so merging this does not
+> switch anything over. Until someone edits the eval host's crontab — drop
+> `0 * * * * eval/run_museglimmer_cron.sh`, add `*/30 * * * * eval/run_qwen38_cron.sh` — the Muse
+> Glimmer bot is still the one scoring PRs, and `pr_qwen38_bot.py` never runs. Check with
+> `crontab -l` on the eval host (the machine running the bot, **not** the GPU box it SSHes into).
+> A round costs ~80s per ref measured end-to-end (~3 min with one pending PR), so `*/30` is not a
+> bottleneck — see `run_qwen38_cron.sh`'s header for the stage-by-stage timings.
 
 `pr_qwen38_bot.py` scores **same-box PR vs `origin/main`** on three axes, applies
 `eval-qwen38:{XL,L,M,S,XS,none,REJECT}`, mirrors it to `eval:*` (SN74 scoring reads `eval:*`),

--- a/eval/README.md
+++ b/eval/README.md
@@ -176,7 +176,53 @@ SSH works → full eval of new PR commits. If the pin is stopped/unreachable →
 `gh` authenticated and `VAST_INSTANCE` / `VAST_DEFAULT_INSTANCE` in `.env.eval`
 (`VAST_NO_AUTO_PROVISION=1`).
 
-## DFlash PR auto-evaluation bot (the only scored path)
+## Qwen3.8-27B PR auto-evaluation bot (the scored path)
+
+> **Status: scoring is Qwen3.8-27B-only.** `pr_qwen38_bot.py` is the bot on cron
+> (`eval/run_qwen38_cron.sh`, hourly at `:00`). The Muse Glimmer bot (`pr_museglimmer_bot.py`) and
+> the DFlash bot (`pr_dflash_bot.py`) are **retired from cron** — their code is kept for reference
+> and both still work if run by hand, but neither is scheduled. Only one bot may hold the shared
+> `/tmp/sparkinfer_bot.lock` at a time, and they all drive the same single pinned GPU.
+
+`pr_qwen38_bot.py` scores **same-box PR vs `origin/main`** on three axes, applies
+`eval-qwen38:{XL,L,M,S,XS,none,REJECT}`, mirrors it to `eval:*` (SN74 scoring reads `eval:*`),
+picks `qwen38-merge-first`, and can auto-merge (`SPARKINFER_QWEN38_AUTOMERGE=1`, off by default).
+
+1. **Speed — decode @ ctx=128**, median of 5 reps. The scored checkpoint is the HuggingFace
+   **compressed-tensors NVFP4 directory** (`unsloth/Qwen3.8-27B-NVFP4`), *not* a GGUF — that is
+   what `sparkinfer-server` actually serves. `qwen3_gguf_bench`/`qwen3_gguf_score` read directories
+   via `runtime/examples/qwen_checkpoint.h`, shared with the server so the benchmark and the
+   server cannot disagree about how a checkpoint is configured.
+
+   Prefill is deliberately *not* scored: at ctx=128 the batched prefill path declines (it needs
+   int8 KV, enabled only at ctx≥4096), so the number would measure the sequential fallback.
+
+2. **Accuracy gate — differential (PR vs main), not absolute.** llama.cpp cannot read a
+   compressed-tensors directory, so there is no same-weights external reference. Instead both
+   builds score the same token stream and the two distributions are compared
+   (`bench/scripts/accuracy_compare_pair.py`): **top1 ≥ 0.99, KL ≤ 0.01**. Tight, because two
+   builds of the same model on the same box should agree almost exactly. Failure is a hard
+   REJECT regardless of speed.
+
+   *Limitation:* a differential gate catches newly introduced divergence only — never a bug
+   already present on `main`.
+
+3. **Qwen3.6 no-regression guard** — decode + prefill at ctx 0/512/4k/16k/32k, 0.98 tolerance.
+   Qwen3.8 and Qwen3.6 share `qwen35.cpp`/`inference_engine.cpp`; a regression there is a hard
+   REJECT regardless of Qwen3.8's own result.
+
+```bash
+python eval/pr_qwen38_bot.py --repo gittensor-ai-lab/sparkinfer   # one poll
+python eval/pr_qwen38_bot.py --only-prs 636 --reeval              # re-score one PR
+python eval/pr_qwen38_bot.py --labels-only                        # no GPU, reconcile labels only
+```
+
+Box paths are `QWEN38_*` in `.env.eval` (`QWEN38_MODEL_DIR` defaults to
+`/root/workspace/models_qwen38`).
+
+## DFlash PR auto-evaluation bot (retired from cron)
+
+> **Status: retired from cron** — superseded by the Qwen3.8-27B bot above. Still runnable by hand.
 
 `pr_dflash_bot.py` evaluates PRs that touch DFlash paths (`dflash*`, `qwen3_gguf_dflash_*`,
 `dflash_accuracy.sh`). It scores **same-box PR DFlash tok/s vs `origin/main` DFlash tok/s**,
@@ -232,7 +278,8 @@ still comes from the deterministic evaluator so validators converge.)
   to run — validate the vast-specific calls (offer query, `--image`, instance field names) on the
   first run and adjust if your account's defaults differ.
 - First eval on a fresh box builds llama.cpp (~10–15 min); it persists at `/workspace/.llamacpp`.
-- Correctness currently gates vs **llama.cpp**. For an optimization PR, also gate vs the **previous
-  frontier build** (score-vs-baseline: ~100% top-1 + KL≈0) — a small extension to `evaluate.sh`.
+- Correctness gates vs **llama.cpp** for GGUF models. The Qwen3.8-27B bot instead gates
+  **PR vs main** (score-vs-baseline: ~100% top-1 + KL≈0), which is the extension suggested here —
+  necessary there because llama.cpp cannot read a compressed-tensors checkpoint at all.
 - Anti-gaming (an LLM/KDA agent reading the diff for benchmark-special-casing, weakened tolerances,
   harness edits) is a layer *on top* — it flags, it doesn't set the numeric label.

--- a/eval/README.md
+++ b/eval/README.md
@@ -179,7 +179,9 @@ SSH works → full eval of new PR commits. If the pin is stopped/unreachable →
 ## Qwen3.8-27B PR auto-evaluation bot (the scored path)
 
 > **Status: scoring is Qwen3.8-27B-only.** `pr_qwen38_bot.py` is the bot on cron
-> (`eval/run_qwen38_cron.sh`, hourly at `:00`). The Muse Glimmer bot (`pr_museglimmer_bot.py`) and
+> (`eval/run_qwen38_cron.sh`, every 30 min). A round costs ~80s per ref measured end-to-end
+> (~3 min with one pending PR), so the interval is not a bottleneck — see that file's header for
+> the stage-by-stage timings. The Muse Glimmer bot (`pr_museglimmer_bot.py`) and
 > the DFlash bot (`pr_dflash_bot.py`) are **retired from cron** — their code is kept for reference
 > and both still work if run by hand, but neither is scheduled. Only one bot may hold the shared
 > `/tmp/sparkinfer_bot.lock` at a time, and they all drive the same single pinned GPU.

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python3
 """sparkinfer Muse Glimmer PR auto-evaluator.
 
-RETIRED FROM CRON. Superseded by eval/pr_qwen38_bot.py, which scores Qwen3.8-27B (decode@128 on
-the NVFP4 checkpoint) and is the bot now installed at :00. This file is kept for reference and
-still runs correctly by hand, but run_museglimmer_cron.sh is no longer scheduled -- only one bot
-may hold /tmp/sparkinfer_bot.lock, and they all drive the same single pinned GPU. Everything below
-describes how this bot behaves when run manually.
+SUPERSEDED by eval/pr_qwen38_bot.py, which scores Qwen3.8-27B (decode@128 on the NVFP4
+checkpoint) on a */30 schedule. Only one bot may hold /tmp/sparkinfer_bot.lock, and they all drive
+the same single pinned GPU, so the two are not meant to run concurrently.
+
+NOTE: the crontab is machine state, not repo state -- merging the commit that added this note does
+NOT retire anything by itself. Until the `0 * * * * eval/run_museglimmer_cron.sh` line is removed
+from the eval host's crontab and replaced with run_qwen38_cron.sh's `*/30` line, THIS bot is still
+the one actually scoring PRs. Everything below describes how it behaves whenever it does run.
 
 Sibling of pr_dflash_bot.py — narrowly scoped to Muse Glimmer's plain AR (autoregressive)
 decode + 128-ctx prefill. Not DFlash, not long-context beyond 128. This scope is deliberate:

--- a/eval/pr_qwen38_bot.py
+++ b/eval/pr_qwen38_bot.py
@@ -1,75 +1,60 @@
 #!/usr/bin/env python3
-"""sparkinfer Muse Glimmer PR auto-evaluator.
+"""sparkinfer Qwen3.8-27B PR auto-evaluator.
 
-RETIRED FROM CRON. Superseded by eval/pr_qwen38_bot.py, which scores Qwen3.8-27B (decode@128 on
-the NVFP4 checkpoint) and is the bot now installed at :00. This file is kept for reference and
-still runs correctly by hand, but run_museglimmer_cron.sh is no longer scheduled -- only one bot
-may hold /tmp/sparkinfer_bot.lock, and they all drive the same single pinned GPU. Everything below
-describes how this bot behaves when run manually.
+Sibling of pr_museglimmer_bot.py / pr_dflash_bot.py, and the ONLY scored bot once Qwen3.8-27B
+becomes the eval scope (see eval/README.md). Narrowly scoped on purpose:
 
-Sibling of pr_dflash_bot.py — narrowly scoped to Muse Glimmer's plain AR (autoregressive)
-decode + 128-ctx prefill. Not DFlash, not long-context beyond 128. This scope is deliberate:
-Muse Glimmer is a very young architecture (4 real correctness bugs found and fixed in a single
-bring-up session, commit 6d911d4 and preceding) with essentially zero production track record,
-so this bot stays small and strict rather than growing the same multi-context / cross-model-guard
-surface pr_dflash_bot.py has.
+  1. Speed — decode @ ctx=128 on the NVFP4 checkpoint, PR vs a freshly-measured origin/main, same
+              box, same round, median of 5 reps. Same tier buckets as every other bot in this
+              directory (BUCKETS/SIG/REGRESS_TOL below — copied, not reinvented).
 
-Scoring, same-box PR-vs-main on a single pinned GPU:
-  1. Speed  — decode (ctx=0) AND prefill@128 (ctx=128), one Muse Glimmer model load via
-              bench_sweep_run, PR vs a freshly-measured origin/main, same box, same run. Same
-              tier buckets as the AR and DFlash bots (BUCKETS/SIG/REGRESS_TOL below — copied,
-              not reinvented). The two dimensions share a regression floor — REGRESS_TOL failing
-              on EITHER is a hard REJECT — but otherwise take the BETTER of the two tiers: a PR
-              that improves one dimension with the other merely flat (not regressed) still earns
-              credit for the real improvement it made, e.g. an XL decode win paired with a flat
-              prefill still reports XL. Added 2026-08-12 (pt. 4 below) because Muse Glimmer's
-              `batched_prefill_enabled()` always returns false (its SWA/NoPE per-layer pattern
-              has no batched kernel yet), so it *always* pays the slow token-loop prefill path —
-              a decode-only gate could never see a prefill-specific regression.
-  2. Accuracy gate — teacher-forced qwen3_gguf_score vs a live llama-server reference on the
-              SAME GGUF, exactly the methodology validated by hand this session (commit
-              6d911d4's message): qwen3_gguf_score dumps sparkinfer's per-position distribution,
-              llama-server answers /completion (n_probs + cache_prompt + temperature=0) for the
-              same positions, accuracy_compare.py reports top1/KL. Bar: top1 >= 0.90, KL <= 0.10
-              (this session achieved 0.980 / 0.0029 on the exact eval_text.txt corpus reused
-              here). A PR that fails this bar is REJECTed regardless of speed — speed is
-              meaningless if a PR silently breaks a still-fragile architecture's correctness.
+              The scored checkpoint is the HuggingFace compressed-tensors DIRECTORY (mixed NVFP4
+              FFN + FP8 attention/GDN projections, unsloth/Qwen3.8-27B-NVFP4), NOT a GGUF of the
+              same model. That is deliberate: it is what sparkinfer-server actually serves, so it
+              is what a PR's speed claim should be measured against. qwen3_gguf_bench and
+              qwen3_gguf_score grew directory support for exactly this
+              (runtime/examples/qwen_checkpoint.h, shared with the server so the two cannot
+              disagree about how a checkpoint is configured).
 
-Applies `eval-museglimmer:<TIER>` AND mirrors it to the generic `eval:<TIER>` label (SN74
-scoring reads eval:* tiers) — explicit user decision, 2026-08-11; originally NOT mirrored given
-Muse Glimmer's youth at the time, see git history on apply_result() for that reasoning. Auto-
-close on none/REJECT and auto-merge on a verified speedup are both live (SPARKINFER_MUSEGLIMMER_
-AUTOMERGE=1 in .env.eval) — same policy as pr_dflash_bot.py, also an explicit user decision
-after this bot's first live run wrongly auto-closed an unrelated PR (#768, reopened +
-apologized); the user was told the risk directly and chose to accept it rather than narrow the
-evaluation scope.
+              Prefill is NOT a scored dimension here, unlike the Muse Glimmer bot. At ctx=128 this
+              model's batched prefill path declines anyway (it requires int8 KV, which the bench
+              only enables at ctx>=4096), so a prefill@128 number would measure the sequential
+              fallback and move for reasons unrelated to the prefill kernels a PR touches.
+
+  2. Accuracy gate — DIFFERENTIAL, not absolute. llama.cpp cannot read a compressed-tensors
+              directory, so the Muse Glimmer methodology (teacher-forced score vs a live
+              llama-server on the SAME weights) is impossible for this checkpoint; comparing
+              against a GGUF of the same model would compare two different quantizations and
+              could never hold a tight bar. Instead: score the same token stream on the PR build
+              and on origin/main, and require the two distributions to agree
+              (bench/scripts/accuracy_compare_pair.py, top1 >= 0.99 / KL <= 0.01 — tight, because
+              two builds of the same model on the same box should agree almost exactly).
+
+              A PR that fails this bar is REJECTed regardless of speed. Qwen3.8-27B bring-up
+              surfaced six separate silent correctness bugs (wrong weight-layout transpose,
+              silu-vs-sigmoid gate, NVFP4 global-scale direction, GDN A_log transform, the
+              1+weight norm convention, GDN v-head broadcast) — every one of which left
+              throughput completely untouched. Speed alone cannot see that class of bug.
+
+              Limitation, stated plainly: a differential gate cannot catch a bug already present
+              on main. It catches newly introduced divergence only.
 
   3. Qwen3.6 no-regression guard — decode + prefill at ctx 0/512/4k/16k/32k, same box, same PR
-              build, vs a freshly-measured origin/main. Reuses pr_dflash_bot.py's GUARD36 sweep
-              mechanism (bench_sweep_run, REGRESS_TOL=0.98) verbatim rather than reinventing it.
-              A regression here is a hard REJECT regardless of Muse Glimmer's own speed/accuracy
-              result — same discipline as the accuracy gate above. This reverses an earlier,
-              explicit scope decision to leave cross-model guarding to a separate pushed backup
-              branch (backup/qwen-model-optimization-20260811 @ 6d911d4) instead of a per-PR
-              check; the LMCache integration (PR #775) touched shared code
-              (qwen35.cpp/inference_engine.cpp) used by both Muse Glimmer and Qwen3.6, making the
-              backup-branch safety net insufficient on its own — a per-PR guard catches this class
-              of regression before merge, not after. Scoped to Qwen3.6 only (not Qwythos/Qwen3.5)
-              per explicit instruction, 2026-08-12 — narrower than the DFlash bot's guard, in
-              keeping with this bot's own "stay small and strict" design goal above.
+              build, vs a freshly-measured origin/main, REGRESS_TOL=0.98. Reuses the sibling bots'
+              GUARD36 sweep mechanism verbatim. A regression here is a hard REJECT regardless of
+              Qwen3.8's own speed/accuracy result: Qwen3.8 and Qwen3.6 share qwen35.cpp /
+              inference_engine.cpp, and that shared surface is exactly how PR #775 regressed a
+              model nobody was scoring at the time.
 
-  4. 128-ctx prefill scoring — see pt. 1's shared-floor/best-of-the-rest description. Reverses
-              the earlier "not prefill" scope decision at the top of this docstring; unlike the
-              Qwen3.6 guard
-              (pt. 3, a pass/fail gate on a DIFFERENT model), this is Muse Glimmer's own second
-              first-class scored dimension. EVAL_SCHEMA_VERSION bumped to v3-prefill128 — a PR
-              evaluated before this existed must not keep a decode-only-scored label forever.
+Applies `eval-qwen38:<TIER>` AND mirrors it to the generic `eval:<TIER>` label (SN74 scoring reads
+eval:* tiers). Auto-close on none/REJECT is live; auto-merge stays OFF unless
+SPARKINFER_QWEN38_AUTOMERGE=1 is explicitly set.
 
-  python eval/pr_museglimmer_bot.py --instance 46074104
-  python eval/pr_museglimmer_bot.py --only-prs 636 --reeval
+  python eval/pr_qwen38_bot.py --instance 46074104
+  python eval/pr_qwen38_bot.py --only-prs 636 --reeval
 
-Never rents a GPU. Shares the pinned box with the AR and DFlash bots via flock in the cron
-wrapper (run_museglimmer_cron.sh) — all three MUST share /tmp/sparkinfer_bot.lock.
+Never rents a GPU. Shares the pinned box with any other bot via flock in the cron wrapper
+(run_qwen38_cron.sh) — all bots MUST share /tmp/sparkinfer_bot.lock.
 """
 from __future__ import annotations
 
@@ -102,45 +87,42 @@ SIG = 0.02
 REGRESS_TOL = 0.98
 BUCKETS = [(0.18, "XL"), (0.10, "L"), (0.06, "M"), (0.035, "S"), (SIG, "XS")]
 
-# Accuracy gate bars — validated by hand this session (6d911d4: top1=0.980, KL=0.0029 achieved
-# on the 99-token eval_text.txt corpus; bars themselves are the short-pass bars this codebase
-# already uses elsewhere, see accuracy_compare.py's own docstring bar for top-1).
-ACC_TOP1_BAR = float(os.environ.get("MUSEGLIMMER_ACC_TOP1_BAR", "0.90"))
-ACC_KL_BAR = float(os.environ.get("MUSEGLIMMER_ACC_KL_BAR", "0.10"))
+# Accuracy gate bars. This gate is DIFFERENTIAL (PR vs origin/main on the same token stream, see
+# the module docstring pt. 2), not absolute-vs-llama.cpp, so the bars are much tighter than the
+# 0.90/0.10 an across-engine comparison needs: two builds of the same model on the same box
+# should agree essentially exactly. Anything less means the PR changed the model's numerics.
+# Not 1.0/0.0 — a PR may legitimately reassociate float ops (fusing a kernel, changing a
+# reduction order), which perturbs the last bits without being a correctness bug.
+ACC_TOP1_BAR = float(os.environ.get("QWEN38_ACC_TOP1_BAR", "0.99"))
+ACC_KL_BAR = float(os.environ.get("QWEN38_ACC_KL_BAR", "0.01"))
 
-EVAL_PREFIX = "eval-museglimmer:"
-MUSEGLIMMER_MERGE_FIRST = "museglimmer-merge-first"
-MUSEGLIMMER_NEEDS_REBASE = "museglimmer-needs-rebase"
-# Bumped for the Qwen3.6 no-regression guard (see module docstring, pt. 3), then again for
-# 128-ctx prefill scoring (pt. 4) — same reasoning as pr_dflash_bot.py's own v2-qwenguard bump: a
-# PR evaluated before a scoring change existed must not keep a stale-scored label/score forever.
-EVAL_SCHEMA_VERSION = "v3-prefill128"
+EVAL_PREFIX = "eval-qwen38:"
+QWEN38_MERGE_FIRST = "qwen38-merge-first"
+QWEN38_NEEDS_REBASE = "qwen38-needs-rebase"
+# First schema for this bot. Same reasoning as the sibling bots' own bumps: a PR evaluated before
+# a scoring change existed must not keep a stale-scored label/score forever.
+EVAL_SCHEMA_VERSION = "v1-nvfp4-decode128"
 MARKER_RE = re.compile(
-    r"<!-- sparkinfer-museglimmer-eval:" + re.escape(EVAL_SCHEMA_VERSION) + r":([0-9a-f]+)(?:\s+(\{.*?\}))? -->",
+    r"<!-- sparkinfer-qwen38-eval:" + re.escape(EVAL_SCHEMA_VERSION) + r":([0-9a-f]+)(?:\s+(\{.*?\}))? -->",
     re.DOTALL,
 )
 
-# --- box paths (see .env.eval's MUSEGLIMMER_* block) ---
-# Deliberately a SEPARATE clone from DFLASH_REMOTE_REPO/pr_eval_bot's /root/sparkinfer: this
-# session validated Muse Glimmer support against /root/sparkinfer_mg specifically, while
-# /root/sparkinfer carries unrelated uncommitted work from a different task that must not be
-# touched or built against.
-REMOTE_REPO = os.environ.get("MUSEGLIMMER_REMOTE_REPO", "/root/sparkinfer_mg")
-DEFAULT_GGUF = os.environ.get(
-    "MUSEGLIMMER_GGUF", "/root/workspace/models_muse_glimmer/muse-glimmer-30B-kquant-17gb.gguf"
-)
-DEFAULT_MODELS_DIR = os.environ.get("MUSEGLIMMER_MODELS_DIR", "/root/workspace/models_muse_glimmer")
-# Shared llama.cpp checkout used by every eval bot on this box (persists outside any repo
-# checkout so `git clean -qfd` in the remote script's checkout step can never delete it).
-LLAMACPP_DIR = os.environ.get("LLAMACPP_DIR", "/root/workspace/.llamacpp")
-BENCH_TOKENS = int(os.environ.get("MUSEGLIMMER_BENCH_TOKENS", "128"))
-ACC_TOPK = int(os.environ.get("MUSEGLIMMER_ACC_TOPK", "128"))
-# Fixed local port for the reference llama-server this bot starts/stops per run. Distinct from
-# accuracy.sh's interactive default (8081) purely so a manual accuracy.sh run on the same box
-# can't collide with a bot tick (the flock in the cron wrapper already prevents two bot ticks
-# from overlapping with each other).
-LLAMA_SERVER_PORT = int(os.environ.get("MUSEGLIMMER_LLAMA_PORT", "8097"))
-EVAL_TEXT = "bench/scripts/eval_text.txt"  # the exact known-good corpus from this session's fixes
+# --- box paths (see .env.eval's QWEN38_* block) ---
+# Separate clone from pr_eval_bot's /root/sparkinfer, which carries unrelated uncommitted work.
+REMOTE_REPO = os.environ.get("QWEN38_REMOTE_REPO", "/root/sparkinfer_qwen38")
+# The scored checkpoint is a HuggingFace compressed-tensors DIRECTORY (mixed NVFP4 FFN + FP8
+# attention/GDN projections, unsloth/Qwen3.8-27B-NVFP4) -- NOT a GGUF. That is what the server
+# actually serves, so it is what gets benchmarked; qwen3_gguf_bench/qwen3_gguf_score grew
+# directory support for exactly this (runtime/examples/qwen_checkpoint.h).
+MODEL_DIR = os.environ.get("QWEN38_MODEL_DIR", "/root/workspace/models_qwen38")
+BENCH_TOKENS = int(os.environ.get("QWEN38_BENCH_TOKENS", "128"))
+ACC_TOPK = int(os.environ.get("QWEN38_ACC_TOPK", "128"))
+# Score dumps for the differential accuracy gate. main's is written once per round by
+# measure_main_baseline(); each PR compares its own dump against it. Kept on the box (not shipped
+# back over ssh) because a 128-deep top-k dump over the whole corpus is megabytes.
+SCORE_DUMP_MAIN = "/tmp/q38_score_main.txt"
+SCORE_DUMP_PR = "/tmp/q38_score_pr.txt"
+EVAL_TEXT = "bench/scripts/eval_text.txt"  # same corpus the sibling bots score
 
 # Qwen3.6 no-regression guard (module docstring, pt. 3) — same env var names as pr_dflash_bot.py's
 # Q36_GUARD_* (PRIMARY36_MODEL_REPO/PRIMARY36_TOK_REPO) so one .env.eval entry covers both bots.
@@ -155,14 +137,14 @@ GUARD_CTX_LABEL = {0: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k"}
 # Auto-merge is wired (mirrors pr_dflash_bot.py's auto_merge_ok_dflash/try_auto_merge_dflash
 # shape) but OFF unless this exact env var is set — NOT set in .env.eval, so it stays fully
 # inert until a human deliberately flips it on. Single-line change to enable later.
-AUTO_MERGE = os.environ.get("SPARKINFER_MUSEGLIMMER_AUTOMERGE") == "1"
+AUTO_MERGE = os.environ.get("SPARKINFER_QWEN38_AUTOMERGE") == "1"
 AUTOMERGE_BLOCK = {
     "copycat", "copycat-warn", "flagged:gaming", "penalty", "needs-benchmark",
-    MUSEGLIMMER_NEEDS_REBASE, arb.REEVALUATE_LABEL, arb.HOLD_LABEL, *arb.REGRESSION_LABELS,
+    QWEN38_NEEDS_REBASE, arb.REEVALUATE_LABEL, arb.HOLD_LABEL, *arb.REGRESSION_LABELS,
 }
 
 SCORES_FILE = os.path.expanduser(
-    os.environ.get("MUSEGLIMMER_SCORES_FILE", "~/.sparkinfer_museglimmer_scores.json")
+    os.environ.get("QWEN38_SCORES_FILE", "~/.sparkinfer_qwen38_scores.json")
 )
 
 # Polaris verifiable-compute receipts — same policy/keys as the AR and DFlash bots (on by
@@ -170,7 +152,7 @@ SCORES_FILE = os.path.expanduser(
 # judge.py's --from-stdin generic RESULT_JSON path (NOT --dflash, which hardcodes a
 # DFlash-shaped measurement block and eval_mode="dflash" — reusing it here would produce a
 # mislabeled, semantically wrong attestation). SPARKINFER_EVAL_MODE is set explicitly below so
-# the attestation correctly records "museglimmer-128", not the AR bot's "longctx" default.
+# the attestation correctly records "qwen38-128", not the AR bot's "longctx" default.
 POLARIS_ENABLED = os.environ.get("POLARIS", "1") != "0"
 POLARIS_API_KEY = os.environ.get("POLARIS_API_KEY", "")
 _POLARIS_PUBKEY_FILE = os.path.join(HERE, "polaris", "sparkinfer_eval.pub")
@@ -200,7 +182,7 @@ def _save_scores(data):
         with open(SCORES_FILE, "w") as f:
             json.dump(data, f, indent=2)
     except Exception as e:
-        print(f">> museglimmer scores save skipped: {e}")
+        print(f">> qwen38 scores save skipped: {e}")
 
 
 def tier_from_gain(pr_tps: float, main_tps: float, metric: str = "decode"):
@@ -264,7 +246,7 @@ def check_q36_guard(pr: dict, main: dict, tol: float = REGRESS_TOL):
     return (len(problems) == 0, problems)
 
 
-def museglimmer_evaluated_commits(repo, num):
+def qwen38_evaluated_commits(repo, num):
     """Head commits that already have a REAL scoring verdict posted — mirrors
     dflash_evaluated_commits: infra/transport failures (label:null in the marker) don't count."""
     r = arb.gh(["pr", "view", str(num), "-R", repo, "--json", "comments"])
@@ -272,7 +254,7 @@ def museglimmer_evaluated_commits(repo, num):
     for c in json.loads(r.stdout or "{}").get("comments", []):
         body = c.get("body") or ""
         m = MARKER_RE.search(body)
-        if not m or "sparkinfer museglimmer auto-eval" not in body:
+        if not m or "sparkinfer qwen38 auto-eval" not in body:
             continue
         meta_raw = m.group(2)
         try:
@@ -285,13 +267,13 @@ def museglimmer_evaluated_commits(repo, num):
     return done
 
 
-def strip_museglimmer_eval_labels(repo, num):
+def strip_qwen38_eval_labels(repo, num):
     for lab in list(arb.labels_on(repo, num)):
         if lab.startswith(EVAL_PREFIX):
             arb.remove_label(repo, num, lab)
 
 
-STALE_DAYS = float(os.environ.get("MUSEGLIMMER_STALE_DAYS", "1"))
+STALE_DAYS = float(os.environ.get("QWEN38_STALE_DAYS", "1"))
 
 
 def _pr_last_activity_ts(repo, num):
@@ -312,9 +294,9 @@ def _pr_last_activity_ts(repo, num):
         return None
 
 
-def close_stale_museglimmer_prs(repo, prs, dry_run=False):
+def close_stale_qwen38_prs(repo, prs, dry_run=False):
     """Close open PRs with no author commit activity in STALE_DAYS+ days. HOLD_LABEL and the
-    current museglimmer-merge-first winner are exempt."""
+    current qwen38-merge-first winner are exempt."""
     closed = set()
     now = time.time()
     for pr in prs:
@@ -322,7 +304,7 @@ def close_stale_museglimmer_prs(repo, prs, dry_run=False):
         if pr.get("isDraft"):
             continue
         labs = {l["name"] for l in pr.get("labels", [])}
-        if arb.HOLD_LABEL in labs or MUSEGLIMMER_MERGE_FIRST in labs:
+        if arb.HOLD_LABEL in labs or QWEN38_MERGE_FIRST in labs:
             continue
         ts = _pr_last_activity_ts(repo, num)
         if ts is None:
@@ -335,10 +317,10 @@ def close_stale_museglimmer_prs(repo, prs, dry_run=False):
         if dry_run:
             continue
         body = (
-            "<!-- sparkinfer-museglimmer-auto-close-stale -->\n"
+            "<!-- sparkinfer-qwen38-auto-close-stale -->\n"
             f"## Closed: stale — no commits in {age_days:.1f} days\n\n"
             f"This PR has had no new commits in over {STALE_DAYS:g} days — closing automatically "
-            "to keep the Muse Glimmer eval queue clean. Reopen (or push a new commit / open a "
+            "to keep the Qwen3.8-27B eval queue clean. Reopen (or push a new commit / open a "
             "fresh PR) whenever you're ready to continue; it'll be picked back up on the next "
             "eval cycle."
         )
@@ -448,26 +430,31 @@ def _ssh_run_resilient(host, port, script: str, label: str):
     return r
 
 
-def _remote_script(ref: str) -> str:
-    """Bash run on the eval box: checkout ref, build, 128-decode speed bench, accuracy gate vs
-    a live llama-server reference. Run once per ref (PR, then "main") — identical script both
-    times so the two measurements are directly comparable."""
+def _remote_script(ref: str, role: str = "pr") -> str:
+    """Bash run on the eval box: checkout ref, build, decode@128 speed bench on the NVFP4
+    checkpoint, teacher-forced score dump, and the Qwen3.6 no-regression guard.
+
+    Run once per ref -- identical script both times so the two measurements are directly
+    comparable. `role` only decides which score dump path is written and whether the
+    differential accuracy compare runs (main has nothing to compare against yet; the PR run
+    compares itself against main's dump from earlier in the same round)."""
     repo = shlex.quote(REMOTE_REPO)
-    gguf = shlex.quote(DEFAULT_GGUF)
-    llamacpp_dir = shlex.quote(LLAMACPP_DIR)
+    model_dir = shlex.quote(MODEL_DIR)
     ref_q = shlex.quote(ref)
     ntok = BENCH_TOKENS
     topk = ACC_TOPK
-    port = LLAMA_SERVER_PORT
     eval_text = shlex.quote(EVAL_TEXT)
+    dump_self = shlex.quote(SCORE_DUMP_MAIN if role == "main" else SCORE_DUMP_PR)
+    dump_main = shlex.quote(SCORE_DUMP_MAIN)
+    is_pr = "1" if role == "pr" else "0"
     q36_dir = shlex.quote(Q36_GUARD_MODELS_DIR)
     q36_file = shlex.quote(Q36_GUARD_MODEL_FILE)
     q36_repo = shlex.quote(Q36_GUARD_MODEL_REPO)
     q36_tok = shlex.quote(Q36_GUARD_TOK_REPO)
     return f"""
 set -euo pipefail
-# Surface *why* a crash happened instead of dying silently — same diagnostic trap as
-# pr_dflash_bot.py's _remote_script (a REJECT from an infra crash should carry a real cause).
+# Surface *why* a crash happened instead of dying silently -- same diagnostic trap as the sibling
+# bots' _remote_script (a REJECT from an infra crash should carry a real cause).
 trap 'rc=$?; ln=$LINENO; reason=""; \\
   case $rc in \\
     137) reason="likely OOM-killed (SIGKILL)" ;; \\
@@ -478,10 +465,11 @@ trap 'rc=$?; ln=$LINENO; reason=""; \\
   echo "REMOTE_SCRIPT_FAILED line=$ln exit=$rc reason=$reason" >&2; \\
   nvidia-smi --query-gpu=memory.used,memory.total,utilization.gpu --format=csv,noheader >&2 2>/dev/null || true' ERR
 
-# One run does several back-to-back multi-GB model load/unload cycles (sparkinfer speed bench,
-# sparkinfer score dump, llama-server) — poll GPU memory down to near-empty before each heavy
-# load instead of assuming the previous process's exit already freed it (same lesson as
-# pr_dflash_bot.py's wait_gpu_clear, #684/#690).
+# One run does several back-to-back multi-GB model load/unload cycles -- poll GPU memory down to
+# near-empty before each heavy load instead of assuming the previous process's exit already freed
+# it. This matters more here than for the sibling bots: the NVFP4 checkpoint's resident footprint
+# is ~32GB of a 32GB card (dequant -> Q4_K decode copies plus the NVFP4 prefill copies), so even a
+# few hundred MB of not-yet-reclaimed memory is the difference between loading and OOM.
 wait_gpu_clear() {{
   local tries=0 used
   while [ "$tries" -lt 30 ]; do
@@ -490,17 +478,19 @@ wait_gpu_clear() {{
     sleep 1
     tries=$((tries + 1))
   done
-  echo "WARN: GPU memory still ${{used:-unknown}} MiB after ${{tries}}s wait — proceeding anyway" >&2
+  echo "WARN: GPU memory still ${{used:-unknown}} MiB after ${{tries}}s wait -- proceeding anyway" >&2
 }}
 
 export PATH=/usr/local/cuda-13.0/bin:/usr/local/cuda/bin:/usr/local/bin:$PATH
 export CUDA_HOME=${{CUDA_HOME:-/usr/local/cuda-13.0}}
 REPO={repo}
-GGUF={gguf}
+MODEL_DIR={model_dir}
 NTOK={ntok}
 TOPK={topk}
-PORT={port}
 EVAL_TEXT={eval_text}
+DUMP_SELF={dump_self}
+DUMP_MAIN={dump_main}
+IS_PR={is_pr}
 Q36_GUARD_MODELS_DIR={q36_dir}
 Q36_GUARD_MODEL_FILE={q36_file}
 Q36_GUARD_MODEL_REPO={q36_repo}
@@ -515,158 +505,81 @@ git checkout -qf FETCH_HEAD
 HEAD=$(git rev-parse --short HEAD)
 echo "REMOTE_HEAD $HEAD"
 
-test -f "$GGUF" || {{ echo "FAIL missing GGUF $GGUF"; exit 1; }}
+test -d "$MODEL_DIR" || {{ echo "FAIL missing NVFP4 checkpoint dir $MODEL_DIR"; exit 1; }}
+test -f "$MODEL_DIR/config.json" || {{ echo "FAIL $MODEL_DIR has no config.json"; exit 1; }}
 
-# Build sparkinfer's speed-bench + teacher-forced-score binaries. Always reconfigure (cheap,
-# idempotent) — skipping it on an existing CMakeCache left stale generated Makefiles pointing at
-# a DIFFERENT PR branch's files once the checkout switched underneath it (pr_dflash_bot.py
-# #693/#694 hit exactly this).
+# Always reconfigure (cheap, idempotent) -- skipping it on an existing CMakeCache left stale
+# generated Makefiles pointing at a DIFFERENT PR branch's files once the checkout switched
+# underneath it (the sibling bots hit exactly this, #693/#694).
 mkdir -p build
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release >/tmp/mg_cmake.log 2>&1
-cmake --build build --target qwen3_gguf_bench qwen3_gguf_score -j"$(nproc)" >/tmp/mg_build.log 2>&1 || {{
-  echo "BUILD_FAILED — tail of /tmp/mg_build.log:" >&2
-  tail -80 /tmp/mg_build.log >&2
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release >/tmp/q38_cmake.log 2>&1
+cmake --build build --target qwen3_gguf_bench qwen3_gguf_score -j"$(nproc)" >/tmp/q38_build.log 2>&1 || {{
+  echo "BUILD_FAILED -- tail of /tmp/q38_build.log:" >&2
+  tail -80 /tmp/q38_build.log >&2
   exit 1
 }}
 test -x build/runtime/qwen3_gguf_bench
 test -x build/runtime/qwen3_gguf_score
 
-# --- 128-token decode speed (ctx=0, n=128 — the SAME "128-context, no prefill" convention the
-# rest of this codebase's decode buckets use, e.g. pr_eval_bot.py's CTX_SERIES[128]) PLUS
-# 128-ctx prefill throughput, from ONE Muse Glimmer model load via the same JSON-sweep mechanism
-# the Qwen3.6 guard below already uses — sourced here (not just before the guard) so both share
-# it instead of reloading the ~17GB GGUF twice for two separate single-context bench calls.
+# --- decode @ ctx=128 on the NVFP4 checkpoint ---
+# The single scored dimension (module docstring pt. 1). Prefill is deliberately NOT scored here:
+# at ctx=128 this model's batched prefill path declines anyway (it needs int8 KV, which the bench
+# only turns on at ctx>=4096), so a prefill number at this context would measure the sequential
+# fallback and move for reasons unrelated to the prefill kernels a PR touches.
 #
-# reps=5 (median), not 1: found 2026-08-13 after PR #785 scored a bogus eval-museglimmer:XL
-# (207% "prefill improvement" it never touched — its own diff never goes near a prefill kernel).
-# Two things were true at once, confirmed live on the eval box with a per-rep debug build:
-#   1. reps=1 (no averaging) is fragile now that prefill@128 is fast: qwen3_gguf_bench's sweep
-#      mode medians over `reps` internally (one shared SPARKINFER_BENCH_SWEEP_REPS across every
-#      ctx point, see run_sweep() in qwen3_gguf_bench.cpp), but this call passed reps=1, i.e. a
-#      single uncorroborated sample. That was fine while Muse Glimmer's prefill@128 ran the slow
-#      token-loop path (~1.1s — dispatch jitter is noise-floor); #787's batched-GEMM prefill (the
-#      same round) cut that to ~0.1s, where the same jitter is a much larger fraction of a shorter
-#      measurement.
-#   2. PR #785 itself was NOT just an unlucky single sample: on current main (#785 reverted) all
-#      5/5 reps land in a tight 1105-1115 pp tok/s band, but on #785's own branch every rep was
-#      wildly inflated (reps=1 -> 3395, reps=5 median -> 84723, i.e. taking more samples made it
-#      WORSE, not better). #785's Q3A weight requantization runs once at load, before any prefill
-#      code, yet destabilized every subsequent prefill measurement on that binary -- a real bug in
-#      that PR, not benchmark noise. Left as a mystery for whoever resubmits it; reps=5 defends
-#      this bot against a repeat regardless of root cause on the PR side.
+# reps=5 (median), not 1: the sibling bots both learned this the hard way (PR #785's bogus XL,
+# PR #790's false guard REJECT). pin_clocks() is unavailable on this box -- "current user does not
+# have permission to change clocks" -- so median-of-N is the only mitigation for GPU clock
+# variance available here.
 source bench/scripts/_common.sh
 source bench/scripts/_eval_speed.sh
 SI_BIN="$PWD/build/runtime"; SI_LD=""
 wait_gpu_clear
-if bench_sweep_run "$GGUF" "$NTOK" 0 5 128 5; then
-  DECODE_TPS=$(_bench_sweep_get 0 decode_tps)
-  PREFILL128_PP=$(_bench_sweep_get 128 prefill_pp)
+if bench_sweep_run "$MODEL_DIR" "$NTOK" 128 5; then
+  DECODE128_TPS=$(_bench_sweep_get 128 decode_tps)
 else
-  DECODE_TPS=0
-  PREFILL128_PP=0
+  DECODE128_TPS=0
 fi
-echo "RESULT_DECODE_TPS ${{DECODE_TPS:-0}}"
-echo "RESULT_PREFILL128_PP ${{PREFILL128_PP:-0}}"
+echo "RESULT_DECODE128_TPS ${{DECODE128_TPS:-0}}"
 
-# --- accuracy gate: sparkinfer teacher-forced score vs a live llama-server reference, same
-# GGUF, same eval_text.txt corpus this session already validated by hand (6d911d4) ---
+# --- teacher-forced score dump (differential accuracy gate, module docstring pt. 2) ---
+# llama.cpp cannot read a compressed-tensors directory, so there is no same-weights external
+# reference available for this checkpoint. Instead score the SAME token stream on this build and
+# diff it against origin/main's dump -- see bench/scripts/accuracy_compare_pair.py.
 #
-# Deliberately NOT bench/scripts/_common.sh's ensure_llamacpp()/reference.lock here: reference.lock
-# pins LLAMACPP_COMMIT to a July-2026 commit that predates llama.cpp's native muse-glimmer
-# architecture support entirely (merged ~2026-08-10). ensure_llamacpp() tamper-checks the
-# checkout's HEAD against that pin and — on mismatch — fetches and resets to the OLD pinned
-# commit, which cannot even load a general.architecture=muse-glimmer GGUF. Calling it here would
-# silently wreck the box's already-working llama.cpp checkout on the very first tick and break
-# every subsequent accuracy gate. reference.lock is shared with the Qwen3.5/Qwen3.6/Qwythos evals
-# (pr_eval_bot.py/pr_dflash_bot.py) — bumping it to a bleeding-edge commit to fix this would risk
-# changing THEIR baseline numbers, which is out of scope here. Build straight off whatever's
-# already checked out at LLAMACPP_DIR instead, unpinned, isolated to this bot only.
-LLAMACPP_DIR={llamacpp_dir}
-if [ ! -d "$LLAMACPP_DIR/.git" ]; then
-  echo "FAIL: $LLAMACPP_DIR missing or not a git checkout. Muse Glimmer's accuracy gate needs a" >&2
-  echo "llama.cpp build with native muse-glimmer support (src/models/muse-glimmer.cpp) -- clone" >&2
-  echo "https://github.com/ggml-org/llama.cpp fresh into this path before the bot's first run." >&2
-  exit 1
-fi
-mkdir -p "$LLAMACPP_DIR/build"
-cmake -S "$LLAMACPP_DIR" -B "$LLAMACPP_DIR/build" -DGGML_CUDA=ON -DCMAKE_CUDA_ARCHITECTURES=120 \\
-  -DCMAKE_BUILD_TYPE=Release >/tmp/mg_llamacpp_cmake.log 2>&1 || {{
-  echo "LLAMACPP_CONFIGURE_FAILED — tail:" >&2
-  tail -60 /tmp/mg_llamacpp_cmake.log >&2
-  exit 1
-}}
-cmake --build "$LLAMACPP_DIR/build" -j"$(nproc)" --target llama-server llama-tokenize \\
-  >/tmp/mg_llamacpp_build.log 2>&1 || {{
-  echo "LLAMACPP_BUILD_FAILED — tail:" >&2
-  tail -80 /tmp/mg_llamacpp_build.log >&2
-  exit 1
-}}
-test -x "$LLAMACPP_DIR/build/bin/llama-tokenize"
-test -x "$LLAMACPP_DIR/build/bin/llama-server"
-
-# Tokenize the known-good corpus with llama-tokenize (not gen_eval_prompt.py's HF-tokenizer
-# path) — guarantees byte-identical tokenization to the llama-server reference queried below,
-# same approach already proven this session.
-TOKOUT=$("$LLAMACPP_DIR/build/bin/llama-tokenize" -m "$GGUF" -f "$EVAL_TEXT" --ids)
-IDS=$(echo "$TOKOUT" | grep -oE '[0-9]+' | tr '\\n' ' ')
-echo "$IDS" > /tmp/mg_eval_ids.txt
-test -n "$IDS" || {{ echo "FAIL empty tokenized IDS from llama-tokenize"; exit 1; }}
-echo "TOKEN_COUNT $(echo "$IDS" | wc -w)"
+# Tokenized with the checkpoint's OWN tokenizer.json rather than llama-tokenize: no GGUF of this
+# model is involved anywhere in this bot, and the HF tokenizer is what the server uses.
+IDS=$(python3 - "$MODEL_DIR/tokenizer.json" "$EVAL_TEXT" <<'PYTOK'
+import sys
+from tokenizers import Tokenizer
+tok = Tokenizer.from_file(sys.argv[1])
+print(" ".join(str(i) for i in tok.encode(open(sys.argv[2]).read()).ids))
+PYTOK
+) || {{ echo "TOKENIZE_FAILED" >&2; exit 1; }}
+TOKEN_COUNT=$(printf '%s' "$IDS" | wc -w)
+echo "RESULT_TOKEN_COUNT $TOKEN_COUNT"
 
 wait_gpu_clear
-build/runtime/qwen3_gguf_score "$GGUF" "$TOPK" $IDS > /tmp/mg_score.txt
-grep -q '^PPL' /tmp/mg_score.txt || echo "WARN: qwen3_gguf_score produced no PPL line" >&2
-
-wait_gpu_clear
-"$LLAMACPP_DIR/build/bin/llama-server" -m "$GGUF" -ngl 99 -c 2048 --port "$PORT" --no-jinja \\
-  >/tmp/mg_llama_srv.log 2>&1 &
-SRV=$!
-trap 'kill $SRV 2>/dev/null || true; wait $SRV 2>/dev/null || true' EXIT
-for _ in $(seq 1 120); do
-  curl -s "http://localhost:$PORT/health" 2>/dev/null | grep -q '"ok"' && break
-  sleep 2
-done
+build/runtime/qwen3_gguf_score "$MODEL_DIR" "$TOPK" $IDS > "$DUMP_SELF" 2>/tmp/q38_score.err || {{
+  echo "SCORE_FAILED -- tail of /tmp/q38_score.err:" >&2
+  tail -40 /tmp/q38_score.err >&2
+  exit 1
+}}
 echo "ACCURACY_STAGE_DONE"
 
-# /dev/null as the tokenizer-path arg is safe: accuracy_compare.py's 3rd positional arg is a
-# file of already-tokenized space-separated ids (produced above), so its all-digit check skips
-# the HF-tokenizer-load code path entirely — the tokenizer path is never opened.
-ACCOUT=$(python3 bench/scripts/accuracy_compare.py /tmp/mg_score.txt /dev/null /tmp/mg_eval_ids.txt \\
-         "http://localhost:$PORT" "$TOPK")
-echo "$ACCOUT"
-kill $SRV 2>/dev/null || true
-wait $SRV 2>/dev/null || true
-trap - EXIT
+if [ "$IS_PR" = "1" ]; then
+  if [ -s "$DUMP_MAIN" ]; then
+    python3 bench/scripts/accuracy_compare_pair.py "$DUMP_SELF" "$DUMP_MAIN" || true
+  else
+    echo "ACCURACY_NO_BASELINE" >&2
+  fi
+fi
 
-METRIC_LINE=$(echo "$ACCOUT" | grep '^METRIC ' | tail -1)
-TOP1=$(echo "$METRIC_LINE" | sed -E 's/.*top1=([0-9.]+).*/\\1/')
-KL=$(echo "$METRIC_LINE" | sed -E 's/.*kl=([0-9.]+).*/\\1/')
-PPLS=$(echo "$METRIC_LINE" | sed -E 's/.*ppl_spark=([0-9.]+).*/\\1/')
-PPLL=$(echo "$METRIC_LINE" | sed -E 's/.*ppl_llama=([0-9.]+).*/\\1/')
-echo "RESULT_TOP1 ${{TOP1:-0}}"
-echo "RESULT_KL ${{KL:-99}}"
-echo "RESULT_PPL_SPARK ${{PPLS:-0}}"
-echo "RESULT_PPL_LLAMA ${{PPLL:-0}}"
-
-# --- Qwen3.6 no-regression guard (decode + prefill, ctx 0/512/4k/16k/32k) — same qwen3_gguf_bench
-# binary already built above, same bench_sweep_run mechanism pr_dflash_bot.py's GUARD36 uses
-# (module docstring, pt. 3). A separate GGUF/model load from Muse Glimmer's own — a shared-code
-# regression that only shows up on Qwen3.6's architecture would otherwise slip past this bot
-# entirely, as it did for the LMCache integration (PR #775) until checked by hand.
-# _common.sh/_eval_speed.sh/SI_BIN already sourced above for the decode+prefill128 sweep — reused
-# here, not re-sourced.
-#
-# reps=5 (median) per context, not 1: found 2026-08-13 investigating PR #790, which the guard
-# REJECTed on a single-sample "qwen3.6 prefill@512: 6501.2 < 98% of main 8431.0" reading. Two
-# independent re-runs of this exact sweep shape on the SAME PR #790 binary both landed at
-# 8475-8479 -- matching main's own baseline, not remotely close to 6501. The 6501 reading was
-# itself the noise, not a real regression (pin_clocks() is unavailable on this box -- "current
-# user does not have permission to change clocks", a container/virtualization restriction, so
-# there's no way to remove the underlying GPU clock variance at the source; median-of-N over
-# independent samples is the only mitigation available here). Same root cause and same fix as the
-# reps=1->5 change above for Muse Glimmer's own prefill128 -- this sweep just hadn't been touched
-# yet. Costs a few more seconds per context but a guard that can hard-REJECT a real PR on a single
-# unaveraged sample is worse than the extra runtime.
+# --- Qwen3.6 no-regression guard (decode + prefill, ctx 0/512/4k/16k/32k) ---
+# A separate model load from Qwen3.8's own: a shared-code regression that only shows up on
+# Qwen3.6's architecture would otherwise slip past this bot entirely, as it did for the LMCache
+# integration (PR #775) until checked by hand. reps=5 for the same clock-variance reason as above.
+# _common.sh/_eval_speed.sh/SI_BIN already sourced above -- reused here, not re-sourced.
 export MODELS_DIR="$Q36_GUARD_MODELS_DIR" MODEL_REPO="$Q36_GUARD_MODEL_REPO" \\
        MODEL_FILE="$Q36_GUARD_MODEL_FILE" TOK_REPO="$Q36_GUARD_TOK_REPO"
 export MODEL_SHA256="${{QWEN36_MODEL_SHA256:-}}"
@@ -687,46 +600,36 @@ echo "GUARD_END"
 
 
 def _parse_remote(stdout: str) -> dict:
+    """Markers emitted by _remote_script + the METRIC line accuracy_compare_pair.py prints.
+
+    Unlike the sibling bots, the accuracy numbers are NOT re-echoed as RESULT_* by the remote
+    bash -- the comparator's own machine-readable METRIC line is parsed directly, so there is one
+    fewer place for the two to disagree about what was measured."""
     out = {}
     guard36 = {}
     for line in (stdout or "").splitlines():
         if line.startswith("REMOTE_HEAD "):
             out["head"] = line.split()[1]
-        elif line.startswith("RESULT_DECODE_TPS "):
+        elif line.startswith("RESULT_DECODE128_TPS "):
             try:
-                out["decode_tps"] = float(line.split()[1])
+                out["decode128_tps"] = float(line.split()[1])
             except ValueError:
                 pass
-        elif line.startswith("RESULT_PREFILL128_PP "):
-            try:
-                out["prefill128_pp"] = float(line.split()[1])
-            except ValueError:
-                pass
-        elif line.startswith("RESULT_TOP1 "):
-            try:
-                out["top1"] = float(line.split()[1])
-            except ValueError:
-                pass
-        elif line.startswith("RESULT_KL "):
-            try:
-                out["kl"] = float(line.split()[1])
-            except ValueError:
-                pass
-        elif line.startswith("RESULT_PPL_SPARK "):
-            try:
-                out["ppl_spark"] = float(line.split()[1])
-            except ValueError:
-                pass
-        elif line.startswith("RESULT_PPL_LLAMA "):
-            try:
-                out["ppl_llama"] = float(line.split()[1])
-            except ValueError:
-                pass
-        elif line.startswith("TOKEN_COUNT "):
+        elif line.startswith("RESULT_TOKEN_COUNT "):
             try:
                 out["token_count"] = int(line.split()[1])
             except ValueError:
                 pass
+        elif line.startswith("METRIC "):
+            for tok in line.split()[1:]:
+                if "=" not in tok:
+                    continue
+                k, _, v = tok.partition("=")
+                if k in ("top1", "kl", "ppl_pr", "ppl_main"):
+                    try:
+                        out[k] = float(v)
+                    except ValueError:
+                        pass
         elif line.startswith("GUARD36 "):
             parts = line.split()
             if len(parts) >= 4:
@@ -817,7 +720,7 @@ def collect_polaris_attestation(host, port, res: dict, pr_ref: str):
     """Run judge.py --from-stdin (a RESULT_JSON-prefixed line, the AR bot's own generic single-
     model shape) to assemble+sign an attestation. NOT --dflash — that mode hardcodes a
     DFlash-shaped measurement block and eval_mode="dflash", which would be a factually wrong
-    label for a plain-AR Muse Glimmer eval. Never raises — a Polaris failure must not block the
+    label for a plain-AR Qwen3.8-27B eval. Never raises — a Polaris failure must not block the
     verdict itself, only omit its receipt."""
     if not POLARIS_ENABLED:
         return None
@@ -833,7 +736,7 @@ def collect_polaris_attestation(host, port, res: dict, pr_ref: str):
     if not push_eval_polaris(host, port):
         return None
     result_json = {
-        "model": "museglimmer-128",
+        "model": "qwen38-128",
         "label": res.get("label"),
         "pass": res.get("pass"),
         "tps": res.get("pr_decode_tps"),
@@ -845,11 +748,11 @@ def collect_polaris_attestation(host, port, res: dict, pr_ref: str):
         "top1": res.get("pr_top1"),
         "kl": res.get("pr_kl"),
     }
-    eval_seed = f"museglimmer-{int(time.time() * 1000)}"  # unique nonce per attestation
+    eval_seed = f"qwen38-{int(time.time() * 1000)}"  # unique nonce per attestation
     stdin_payload = "RESULT_JSON " + json.dumps(result_json)
     cmd = (
         f"cd {shlex.quote(REMOTE_REPO)} && "
-        f"SPARKINFER_EVAL_MODE=museglimmer-128 SPARKINFER_DECODE_TOKENS={BENCH_TOKENS} "
+        f"SPARKINFER_EVAL_MODE=qwen38-128 SPARKINFER_DECODE_TOKENS={BENCH_TOKENS} "
         f"SPARKINFER_EVAL_SEED={shlex.quote(eval_seed)} python3 eval/polaris/judge.py --from-stdin "
         f"--model-file {shlex.quote(DEFAULT_GGUF)} "
         f"--build-dir {shlex.quote(REMOTE_REPO)}/build/runtime "
@@ -890,86 +793,71 @@ def collect_polaris_attestation(host, port, res: dict, pr_ref: str):
 def measure_main_baseline(host, port):
     """Measure main's decode+accuracy+Qwen3.6-guard baseline ONCE per round, not once per PR —
     main's code can't change mid-round (the only merge in this bot's own flow is
-    try_auto_merge_museglimmer, called from reconcile_museglimmer_merge_labels AFTER every
+    try_auto_merge_qwen38, called from reconcile_qwen38_merge_labels AFTER every
     pending PR has already been individually evaluated in main()'s loop, see call ordering
     there), so every PR in the round comparing against a freshly-remeasured main was pure
     redundant GPU/build time. Returns {"ok": True, **parsed} or {"ok": False, "reason", "log"}."""
-    r = _ssh_run_resilient(host, port, _remote_script("main"), "main run")
+    r = _ssh_run_resilient(host, port, _remote_script("main", role="main"), "main run")
     if r.returncode != 0:
         tail = ((r.stdout or "") + "\n" + (r.stderr or ""))[-2000:]
         crash = _crash_reason(r.stdout, r.stderr)
         reason = "main run failed" + (f" — {crash}" if crash else " (no crash diagnostic captured, possible hard kill — retried once)")
         return {"ok": False, "reason": reason, "log": tail}
     main = _parse_remote(r.stdout or "")
-    if "decode_tps" not in main:
-        return {"ok": False, "reason": "main bench missing decode tok/s", "log": (r.stdout or "")[-1500:]}
-    if "prefill128_pp" not in main:
-        return {"ok": False, "reason": "main bench missing prefill@128 pp tok/s", "log": (r.stdout or "")[-1500:]}
+    if "decode128_tps" not in main:
+        return {"ok": False, "reason": "main bench missing decode@128 tok/s", "log": (r.stdout or "")[-1500:]}
     main["ok"] = True
     return main
 
 
-def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
+def eval_qwen38_on_box(host, port, pr_ref: str, main: dict):
     """Run the PR ref's speed+accuracy script on the same box and compare against `main`, an
     already-measured baseline shared across every PR in the round (see measure_main_baseline)."""
-    print(f">> Muse Glimmer eval on box: PR ref={pr_ref}")
-    r = _ssh_run_resilient(host, port, _remote_script(pr_ref), "PR run")
+    print(f">> Qwen3.8-27B eval on box: PR ref={pr_ref}")
+    r = _ssh_run_resilient(host, port, _remote_script(pr_ref, role="pr"), "PR run")
     if r.returncode != 0:
         tail = ((r.stdout or "") + "\n" + (r.stderr or ""))[-2000:]
         crash = _crash_reason(r.stdout, r.stderr)
         reason = "PR speed/accuracy run failed" + (f" — {crash}" if crash else " (no crash diagnostic captured, possible hard kill — retried once)")
         return {"ok": False, "reason": reason, "log": tail}
     pr = _parse_remote(r.stdout or "")
-    if "decode_tps" not in pr:
-        return {"ok": False, "reason": "PR bench missing decode tok/s", "log": (r.stdout or "")[-1500:]}
-    if "prefill128_pp" not in pr:
-        return {"ok": False, "reason": "PR bench missing prefill@128 pp tok/s", "log": (r.stdout or "")[-1500:]}
+    if "decode128_tps" not in pr:
+        return {"ok": False, "reason": "PR bench missing decode@128 tok/s", "log": (r.stdout or "")[-1500:]}
     if "top1" not in pr or "kl" not in pr:
-        return {"ok": False, "reason": "PR run missing accuracy METRIC line", "log": (r.stdout or "")[-1500:]}
-    print(f">> PR decode={pr['decode_tps']:.2f} prefill128={pr['prefill128_pp']:.2f} "
-          f"top1={pr.get('top1', 0):.3f} kl={pr.get('kl', 99):.4f}")
+        # Either the score dump failed, or main's dump was missing so the comparator never ran
+        # (ACCURACY_NO_BASELINE). Both are infra faults, but they must NOT pass as "accurate" --
+        # a gate that cannot measure fails closed, same as check_q36_guard's unavailability path.
+        return {"ok": False, "reason": "PR run missing accuracy METRIC line (score dump failed, "
+                                       "or no main baseline dump to diff against)",
+                "log": (r.stdout or "")[-1500:]}
+    print(f">> PR decode@128={pr['decode128_tps']:.2f} "
+          f"top1={pr.get('top1', 0):.4f} kl={pr.get('kl', 99):.5f}")
 
-    decode_label, decode_delta_pct, decode_passed, decode_reason = tier_from_gain(
-        pr["decode_tps"], main["decode_tps"], metric="decode")
-    prefill_label, prefill_delta_pct, prefill_passed, prefill_reason = tier_from_gain(
-        pr["prefill128_pp"], main["prefill128_pp"], metric="prefill@128")
-
-    # Shared regression floor, best-of-the-rest: either dimension regressing is a hard REJECT
-    # regardless of the other (same conservative, fail-closed philosophy as the accuracy gate and
-    # Q36 guard below, module docstring pt. 4) — but a PR that improves ONE dimension with the
-    # OTHER merely flat (not regressed) still earns credit for the real improvement it made. A
-    # pure prefill@128 optimization with unchanged decode should score on its own merits, not get
-    # dragged down to "none" just because decode wasn't also touched — no different from how a
-    # decode-only PR was never expected to also move prefill.
-    if decode_label == "REJECT" and prefill_label == "REJECT":
-        label, delta_pct, passed = "REJECT", min(decode_delta_pct, prefill_delta_pct), False
-        speed_reason = f"{decode_reason} | {prefill_reason}"
-    elif decode_label == "REJECT":
-        label, delta_pct, passed, speed_reason = "REJECT", decode_delta_pct, False, decode_reason
-    elif prefill_label == "REJECT":
-        label, delta_pct, passed, speed_reason = "REJECT", prefill_delta_pct, False, prefill_reason
-    elif _TIER_RANK[decode_label] >= _TIER_RANK[prefill_label]:
-        label, delta_pct, passed, speed_reason = decode_label, decode_delta_pct, decode_passed, decode_reason
-    else:
-        label, delta_pct, passed, speed_reason = prefill_label, prefill_delta_pct, prefill_passed, prefill_reason
+    # Single scored dimension: decode @ ctx=128 on the NVFP4 checkpoint (module docstring pt. 1).
+    label, delta_pct, passed, speed_reason = tier_from_gain(
+        pr["decode128_tps"], main["decode128_tps"], metric="decode@128")
+    # Keep the speed-only verdict: `label` below can be forced to REJECT by the accuracy gate or
+    # the Qwen3.6 guard, and the comment/dashboard still need to say whether decode itself moved.
+    speed_label = label
 
     pr_top1 = pr.get("top1", 0.0)
     pr_kl = pr.get("kl", 99.0)
     accuracy_ok = pr_top1 >= ACC_TOP1_BAR and pr_kl <= ACC_KL_BAR
     reason = speed_reason
     if not accuracy_ok:
-        # Accuracy gate is a hard REJECT regardless of speed — same discipline as
-        # pr_dflash_bot.py's SPEC_AGREE veto: a fast-but-wrong PR is worthless on a still-fragile
-        # architecture, and speed alone can't prove correctness.
-        acc_reason = (f"accuracy gate failed: top1={pr_top1:.3f} (bar >={ACC_TOP1_BAR}) "
-                      f"kl={pr_kl:.4f} (bar <={ACC_KL_BAR})")
+        # Hard REJECT regardless of speed. This gate is differential (PR vs main on the same
+        # token stream), so failing it means the PR CHANGED this model's output distribution --
+        # exactly the class of bug a speed number cannot see. Six such bugs were found by hand
+        # during Qwen3.8-27B bring-up, every one of which left throughput untouched.
+        acc_reason = (f"accuracy gate failed vs main: top1={pr_top1:.4f} (bar >={ACC_TOP1_BAR}) "
+                      f"kl={pr_kl:.5f} (bar <={ACC_KL_BAR})")
         reason = f"{acc_reason} | speed: {speed_reason}"
         label = "REJECT"
         passed = False
 
     q36_ok, q36_problems = check_q36_guard(pr, main)
     if not q36_ok:
-        # Same hard-REJECT discipline as the accuracy gate: a Muse Glimmer PR that silently
+        # Same hard-REJECT discipline as the accuracy gate: a Qwen3.8-27B PR that silently
         # regresses Qwen3.6 via shared code (qwen35.cpp/inference_engine.cpp) is unmergeable
         # regardless of its own speed/accuracy result — see module docstring pt. 3.
         q36_reason = "qwen3.6 no-regression guard failed: " + "; ".join(q36_problems[:6])
@@ -983,22 +871,16 @@ def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
         "pass": passed and label != "REJECT",
         "reason": reason,
         "delta_pct": delta_pct,
-        "pr_decode_tps": pr["decode_tps"],
-        "main_decode_tps": main["decode_tps"],
-        "decode_delta_pct": decode_delta_pct,
-        "decode_regressed": decode_label == "REJECT",
-        "speedup_vs_main": round(pr["decode_tps"] / main["decode_tps"], 3) if main.get("decode_tps") else 0,
-        "pr_prefill128_pp": pr["prefill128_pp"],
-        "main_prefill128_pp": main["prefill128_pp"],
-        "prefill_delta_pct": prefill_delta_pct,
-        "prefill_regressed": prefill_label == "REJECT",
-        "prefill_speedup_vs_main": round(pr["prefill128_pp"] / main["prefill128_pp"], 3) if main.get("prefill128_pp") else 0,
+        "pr_decode_tps": pr["decode128_tps"],
+        "main_decode_tps": main["decode128_tps"],
+        "decode_delta_pct": delta_pct,
+        "decode_regressed": speed_label == "REJECT",
+        "speedup_vs_main": round(pr["decode128_tps"] / main["decode128_tps"], 3) if main.get("decode128_tps") else 0,
         "pr_top1": pr_top1,
         "pr_kl": pr_kl,
-        "pr_ppl_spark": pr.get("ppl_spark"),
-        "pr_ppl_llama": pr.get("ppl_llama"),
-        "main_top1": main.get("top1"),
-        "main_kl": main.get("kl"),
+        "pr_ppl": pr.get("ppl_pr"),
+        "main_ppl": pr.get("ppl_main"),
+        "token_count": pr.get("token_count"),
         "accuracy_ok": accuracy_ok,
         "q36_guard_ok": q36_ok,
         "q36_guard_problems": q36_problems,
@@ -1019,19 +901,19 @@ def format_comment(commit: str, res: dict) -> str:
         "delta_pct": res.get("delta_pct"),
         "pr_decode_tps": res.get("pr_decode_tps"),
         "main_decode_tps": res.get("main_decode_tps"),
-        "pr_prefill128_pp": res.get("pr_prefill128_pp"),
-        "main_prefill128_pp": res.get("main_prefill128_pp"),
+        "pr_top1": res.get("pr_top1"),
+        "pr_kl": res.get("pr_kl"),
         "pass": res.get("pass"),
         "accuracy_ok": res.get("accuracy_ok"),
         "q36_guard_ok": res.get("q36_guard_ok"),
     }
     marker = (
-        f"<!-- sparkinfer-museglimmer-eval:{EVAL_SCHEMA_VERSION}:{commit} "
+        f"<!-- sparkinfer-qwen38-eval:{EVAL_SCHEMA_VERSION}:{commit} "
         f"{json.dumps(meta, separators=(',', ':'))} -->"
     )
     if not res.get("ok"):
         return (
-            f"{marker}\n## sparkinfer museglimmer auto-eval — error\n\n"
+            f"{marker}\n## sparkinfer qwen38 auto-eval — error\n\n"
             f"**reason:** `{res.get('reason')}`\n\n"
             f"<details><summary>log tail</summary>\n\n```\n{(res.get('log') or '')[:1800]}\n```\n</details>\n"
         )
@@ -1043,11 +925,9 @@ def format_comment(commit: str, res: dict) -> str:
         acc_row = (f"| accuracy gate | ❌ **FAILED** — top1={res.get('pr_top1', 0):.3f} "
                     f"(bar >={ACC_TOP1_BAR}) · KL={res.get('pr_kl', 0):.4f} (bar <={ACC_KL_BAR}) — "
                     "**verdict forced to REJECT regardless of speed** |\n")
+    # No "main accuracy" row: this gate is differential, so main IS the reference -- there is no
+    # separate absolute bar for it to miss.
     main_acc_note = ""
-    if res.get("main_top1") is not None and (res.get("main_top1", 1) < ACC_TOP1_BAR or (res.get("main_kl") or 0) > ACC_KL_BAR):
-        main_acc_note = (f"| ⚠️ same-box main accuracy | top1={res.get('main_top1'):.3f} "
-                          f"kl={res.get('main_kl'):.4f} — main ALSO misses the bar (informational; "
-                          "not gated on main, but check the box/corpus if this persists) |\n")
     if res.get("q36_guard_ok"):
         q36_row = "| qwen3.6 guard | ✅ no regression (decode+prefill, ctx 0/512/4k/16k/32k) |\n"
     else:
@@ -1065,20 +945,18 @@ def format_comment(commit: str, res: dict) -> str:
     else:
         polaris_row = ""
     return (
-        f"{marker}\n## sparkinfer museglimmer auto-eval — `eval-museglimmer:{lab}`\n\n"
+        f"{marker}\n## sparkinfer qwen38 auto-eval — `eval-qwen38:{lab}`\n\n"
         f"| metric | value |\n|---|---|\n"
-        f"| **label** | `eval-museglimmer:{lab}` |\n"
+        f"| **label** | `eval-qwen38:{lab}` |\n"
         f"| scored at | 128-token decode (ctx=0) + 128-ctx prefill — shared regression floor, best of the two |\n"
         f"| PR decode tok/s | {res['pr_decode_tps']:.2f} |\n"
         f"| main decode tok/s | {res['main_decode_tps']:.2f} |\n"
         f"| decode speedup vs main | **{res.get('speedup_vs_main', 0):.2f}×** ({res.get('decode_delta_pct', 0):+.1f}%) |\n"
-        f"| PR prefill@128 pp tok/s | {res.get('pr_prefill128_pp', 0):.2f} |\n"
-        f"| main prefill@128 pp tok/s | {res.get('main_prefill128_pp', 0):.2f} |\n"
-        f"| prefill speedup vs main | **{res.get('prefill_speedup_vs_main', 0):.2f}×** ({res.get('prefill_delta_pct', 0):+.1f}%) |\n"
+
         f"{acc_row}"
         f"{main_acc_note}"
         f"{q36_row}"
-        f"| PPL sparkinfer / llama.cpp | {res.get('pr_ppl_spark') or '?'} / {res.get('pr_ppl_llama') or '?'} |\n"
+        f"| PPL PR / main | {res.get('pr_ppl') or '?'} / {res.get('main_ppl') or '?'} |\n"
         f"{polaris_row}"
         f"| commit | `{commit[:9]}` |\n\n"
         f"{res.get('reason') or ''}\n\n"
@@ -1086,18 +964,18 @@ def format_comment(commit: str, res: dict) -> str:
         "(ctx=0) AND 128-ctx prefill throughput, from one model load; either dimension regressing "
         "is a hard REJECT, but otherwise the reported label is the **better** of the two tiers — "
         "a PR that improves just one, with the other flat, still earns credit for that "
-        "(no DFlash, no long-context beyond 128) — Muse Glimmer's narrow, deliberately "
+        "(no DFlash, no long-context beyond 128) — Qwen3.8-27B's narrow, deliberately "
         "strict eval scope. This is informational, not a judgment on your PR: a `none` label just "
-        "means no measurable Muse Glimmer speedup was verified on either metric, which is expected "
+        "means no measurable Qwen3.8-27B speedup was verified on either metric, which is expected "
         "and fine if that isn't what your change is about. "
         "Correctness gated against a live llama.cpp reference on the same GGUF. Also gated on a "
         "Qwen3.6 no-regression guard (decode+prefill, ctx 0/512/4k/16k/32k, same box vs main) — "
-        "Muse Glimmer PRs can touch code shared with other models. "
+        "Qwen3.8-27B PRs can touch code shared with other models. "
         "Automated — **not merged**; merge manually after review.</sub>\n"
     )
 
 
-def auto_merge_ok_museglimmer(repo, num):
+def auto_merge_ok_qwen38(repo, num):
     info = json.loads(arb.gh([
         "pr", "view", str(num), "-R", repo, "--json",
         "state,isDraft,labels,author,mergeable,files",
@@ -1107,9 +985,9 @@ def auto_merge_ok_museglimmer(repo, num):
     labs = {l["name"] for l in info.get("labels", [])}
     tiers = {l.split(":", 1)[1] for l in labs if l.startswith(EVAL_PREFIX)}
     if not (tiers & SPEEDUP_LABELS):
-        return False, "no verified eval-museglimmer:speedup label"
-    if MUSEGLIMMER_MERGE_FIRST not in labs:
-        return False, "not museglimmer-merge-first"
+        return False, "no verified eval-qwen38:speedup label"
+    if QWEN38_MERGE_FIRST not in labs:
+        return False, "not qwen38-merge-first"
     blocked = labs & AUTOMERGE_BLOCK
     if blocked:
         return False, f"blocking label(s): {', '.join(sorted(blocked))}"
@@ -1129,29 +1007,29 @@ def auto_merge_ok_museglimmer(repo, num):
     return True, "ok"
 
 
-def try_auto_merge_museglimmer(repo, num):
-    ok, reason = auto_merge_ok_museglimmer(repo, num)
+def try_auto_merge_qwen38(repo, num):
+    ok, reason = auto_merge_ok_qwen38(repo, num)
     if not ok:
-        print(f">> museglimmer auto-merge SKIP #{num}: {reason}")
+        print(f">> qwen38 auto-merge SKIP #{num}: {reason}")
         return False
     r = arb.gh(["pr", "merge", str(num), "-R", repo, "--squash"])
     if r.returncode != 0 and os.environ.get("SPARKINFER_AUTOMERGE_ADMIN", "1") == "1":
         err = ((r.stderr or "") + (r.stdout or "")).lower()
         if "not mergeable" in err or "branch policy" in err or "required" in err or "prohibited" in err:
-            print(">> museglimmer auto-merge: branch policy blocked — retrying with --admin")
+            print(">> qwen38 auto-merge: branch policy blocked — retrying with --admin")
             r = arb.gh(["pr", "merge", str(num), "-R", repo, "--squash", "--admin"])
     if r.returncode == 0:
-        print(f">> MUSEGLIMMER AUTO-MERGED #{num} (museglimmer-merge-first)")
+        print(f">> QWEN38 AUTO-MERGED #{num} (qwen38-merge-first)")
         arb.gh(["pr", "comment", str(num), "-R", repo, "--body",
-                "<!-- sparkinfer-museglimmer-automerge -->\n"
-                "Auto-merged as the round's `museglimmer-merge-first` winner — verified same-box "
+                "<!-- sparkinfer-qwen38-automerge -->\n"
+                "Auto-merged as the round's `qwen38-merge-first` winner — verified same-box "
                 "128-token decode speedup over `main`, accuracy-gated vs llama.cpp."])
         return True
-    print(f">> museglimmer auto-merge BLOCKED #{num}: {(r.stderr or r.stdout or '')[:200]}")
+    print(f">> qwen38 auto-merge BLOCKED #{num}: {(r.stderr or r.stdout or '')[:200]}")
     return False
 
 
-def reconcile_museglimmer_merge_labels(repo, dry_run=False):
+def reconcile_qwen38_merge_labels(repo, dry_run=False):
     scores = _load_scores()
     open_prs = json.loads(arb.gh([
         "pr", "list", "-R", repo, "--state", "open",
@@ -1160,16 +1038,16 @@ def reconcile_museglimmer_merge_labels(repo, dry_run=False):
     open_labels = {p["number"]: {l["name"] for l in p["labels"]} for p in open_prs}
 
     merged = json.loads(arb.gh([
-        "pr", "list", "-R", repo, "--state", "merged", "--label", MUSEGLIMMER_MERGE_FIRST,
+        "pr", "list", "-R", repo, "--state", "merged", "--label", QWEN38_MERGE_FIRST,
         "--json", "number", "--limit", "10",
     ]).stdout or "[]")
     for m in merged:
         if not dry_run:
-            arb.remove_label(repo, m["number"], MUSEGLIMMER_MERGE_FIRST)
+            arb.remove_label(repo, m["number"], QWEN38_MERGE_FIRST)
 
     scored = []
     for num, labs in open_labels.items():
-        if MUSEGLIMMER_NEEDS_REBASE in labs:
+        if QWEN38_NEEDS_REBASE in labs:
             continue
         tiers = {l.split(":", 1)[1] for l in labs if l.startswith(EVAL_PREFIX)}
         tier = next((t for t in tiers if t in SPEEDUP_LABELS), None)
@@ -1184,26 +1062,26 @@ def reconcile_museglimmer_merge_labels(repo, dry_run=False):
 
     scored.sort(key=lambda x: x[1], reverse=True)
     if not scored:
-        print(">> museglimmer round: no verified speedup PRs")
+        print(">> qwen38 round: no verified speedup PRs")
         return
     winner = scored[0][0]
-    print(f">> museglimmer round: merge-first #{winner}; rebase {[n for n,_,_ in scored[1:]] or 'none'}")
+    print(f">> qwen38 round: merge-first #{winner}; rebase {[n for n,_,_ in scored[1:]] or 'none'}")
     if dry_run:
         return
-    arb.add_label(repo, winner, MUSEGLIMMER_MERGE_FIRST)
-    arb.remove_label(repo, winner, MUSEGLIMMER_NEEDS_REBASE)
+    arb.add_label(repo, winner, QWEN38_MERGE_FIRST)
+    arb.remove_label(repo, winner, QWEN38_NEEDS_REBASE)
     for num, _, _ in scored[1:]:
-        arb.add_label(repo, num, MUSEGLIMMER_NEEDS_REBASE)
-        arb.remove_label(repo, num, MUSEGLIMMER_MERGE_FIRST)
+        arb.add_label(repo, num, QWEN38_NEEDS_REBASE)
+        arb.remove_label(repo, num, QWEN38_MERGE_FIRST)
     if AUTO_MERGE:
-        try_auto_merge_museglimmer(repo, winner)
+        try_auto_merge_qwen38(repo, winner)
 
 
-def upload_museglimmer_eval_log(repo, num, title, oid, res):
+def upload_qwen38_eval_log(repo, num, title, oid, res):
     """Commit the eval result (+ Polaris receipt/attestation) to sparkinfer-log, mirroring
-    pr_dflash_bot.py's upload_dflash_eval_log with a museglimmer-prefixed run id."""
+    pr_dflash_bot.py's upload_dflash_eval_log with a qwen38-prefixed run id."""
     try:
-        rid = f"museglimmer-{int(num):04d}-{oid[:7]}"
+        rid = f"qwen38-{int(num):04d}-{oid[:7]}"
         arb._ensure_log_repo()
         rundir = os.path.join(arb.LOG_DIR, "runs", rid)
         os.makedirs(rundir, exist_ok=True)
@@ -1212,13 +1090,12 @@ def upload_museglimmer_eval_log(repo, num, title, oid, res):
         result = {
             "id": rid, "pr": int(num), "title": title,
             "url": f"https://github.com/{repo}/pull/{num}", "commit": oid[:7],
-            "eval_mode": "museglimmer-128",
+            "eval_mode": "qwen38-128",
             "label": res.get("label"), "pass": res.get("pass"), "reason": res.get("reason"),
             "delta_pct": res.get("delta_pct"),
             "pr_decode_tps": res.get("pr_decode_tps"), "main_decode_tps": res.get("main_decode_tps"),
             "speedup_vs_main": res.get("speedup_vs_main"),
-            "pr_prefill128_pp": res.get("pr_prefill128_pp"), "main_prefill128_pp": res.get("main_prefill128_pp"),
-            "prefill_speedup_vs_main": res.get("prefill_speedup_vs_main"),
+            "pr_top1": res.get("pr_top1"), "pr_kl": res.get("pr_kl"),
             "pr_top1": res.get("pr_top1"), "pr_kl": res.get("pr_kl"),
             "accuracy_ok": res.get("accuracy_ok"),
             "q36_guard_ok": res.get("q36_guard_ok"), "q36_guard_problems": res.get("q36_guard_problems"),
@@ -1236,7 +1113,7 @@ def upload_museglimmer_eval_log(repo, num, title, oid, res):
         idx = json.load(open(ipath)) if os.path.exists(ipath) else []
         idx = [e for e in idx if e.get("id") != rid]
         idx_entry = {"id": rid, "pr": int(num), "title": title, "label": res.get("label"),
-                     "delta_pct": res.get("delta_pct"), "eval_mode": "museglimmer-128", "date": result["date"]}
+                     "delta_pct": res.get("delta_pct"), "eval_mode": "qwen38-128", "date": result["date"]}
         if receipt:
             idx_entry["polaris"] = True
             idx_entry["polaris_receipt_id"] = receipt.get("receipt_id", "")[:16]
@@ -1244,22 +1121,22 @@ def upload_museglimmer_eval_log(repo, num, title, oid, res):
         idx.sort(key=lambda x: x["id"])
         json.dump(idx, open(ipath, "w"), indent=2)
         subprocess.run(["git", "-C", arb.LOG_DIR, "add", "-A"], check=True)
-        msg = f"museglimmer-eval: #{num} {oid[:7]} -> eval-museglimmer:{res.get('label')}"
+        msg = f"qwen38-eval: #{num} {oid[:7]} -> eval-qwen38:{res.get('label')}"
         if receipt:
             msg += f" + polaris {receipt.get('receipt_id', '?')[:16]}"
         commit = subprocess.run(["git", "-C", arb.LOG_DIR, "commit", "-q", "-m", msg], check=False)
         if commit.returncode != 0:
-            print(">> museglimmer eval-log upload skipped: nothing to commit")
+            print(">> qwen38 eval-log upload skipped: nothing to commit")
             return None
         push = subprocess.run(["git", "-C", arb.LOG_DIR, "push", "-q"], check=False)
         if push.returncode != 0:
-            print(f">> museglimmer eval-log push failed (rc={push.returncode})")
+            print(f">> qwen38 eval-log push failed (rc={push.returncode})")
             return None
         url = arb.LOG_PAGE + rid
-        print(f">> museglimmer eval log: {url}")
+        print(f">> qwen38 eval log: {url}")
         return url
     except Exception as e:
-        print(f">> museglimmer eval-log upload failed: {e}")
+        print(f">> qwen38 eval-log upload failed: {e}")
         return None
 
 
@@ -1268,38 +1145,38 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
     label = res.get("label") if res.get("ok") else "REJECT"
     if not res.get("ok"):
         label = "REJECT"
-    print(f"PR #{num}: eval-museglimmer:{label}  "
+    print(f"PR #{num}: eval-qwen38:{label}  "
           f"decode PR={res.get('pr_decode_tps')} main={res.get('main_decode_tps')}  "
-          f"prefill128 PR={res.get('pr_prefill128_pp')} main={res.get('main_prefill128_pp')}  "
+          f"top1={res.get('pr_top1')} kl={res.get('pr_kl')}  "
           f"delta={res.get('delta_pct')}%  accuracy_ok={res.get('accuracy_ok')}  "
           f"q36_guard_ok={res.get('q36_guard_ok')}")
     if dry_run:
         print(body[:500])
         return
-    strip_museglimmer_eval_labels(repo, num)
+    strip_qwen38_eval_labels(repo, num)
     if label in SPEEDUP_LABELS:
         # A fresh, valid speedup score for the CURRENT head commit means this PR is caught up
         # with main and deserves a fair shot at winning the next merge-first reconciliation --
         # clear any stale needs-rebase from a round it lost (or an old conflict that's since been
-        # resolved). Found 2026-08-13: reconcile_museglimmer_merge_labels() filters candidates on
-        # `MUSEGLIMMER_NEEDS_REBASE not in labs` (this bot's own "who's eligible to win" gate) but
+        # resolved). Found 2026-08-13: reconcile_qwen38_merge_labels() filters candidates on
+        # `QWEN38_NEEDS_REBASE not in labs` (this bot's own "who's eligible to win" gate) but
         # the ONLY place that ever removed the label was the winner-selection branch itself --
         # a PR that lost one round, or ever hit a transient merge conflict, could never be
         # reconsidered again even after a completely clean re-evaluation confirmed its score,
         # since it was filtered out of candidacy before scoring was ever compared. Hit #790 and
         # #791 both losing merge-first to a strictly worse score for exactly this reason.
-        arb.remove_label(repo, num, MUSEGLIMMER_NEEDS_REBASE)
+        arb.remove_label(repo, num, QWEN38_NEEDS_REBASE)
     arb.add_label(repo, num, f"{EVAL_PREFIX}{label}")
     # Mirrored to the generic `eval:*` label, same as pr_dflash_bot.py -- SN74 scoring reads
-    # eval:* tiers, so this makes Muse Glimmer submissions count toward that live incentive
+    # eval:* tiers, so this makes Qwen3.8-27B submissions count toward that live incentive
     # mechanism. Explicit user decision, 2026-08-11 (originally deliberately NOT mirrored, given
-    # Muse Glimmer's youth at the time -- see git history on this line for that reasoning).
+    # Qwen3.8-27B's youth at the time -- see git history on this line for that reasoning).
     for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
         arb.remove_label(repo, num, lab)
     arb.add_label(repo, num, f"eval:{label}")
     arb.gh(["pr", "comment", str(num), "-R", repo, "--body", body])
     if res.get("ok"):
-        upload_museglimmer_eval_log(repo, num, title, commit, res)
+        upload_qwen38_eval_log(repo, num, title, commit, res)
     if res.get("ok") and res.get("delta_pct") is not None:
         scores = _load_scores()
         scores[str(num)] = {
@@ -1308,8 +1185,8 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
             "delta_pct": res.get("delta_pct"),
             "pr_decode_tps": res.get("pr_decode_tps"),
             "main_decode_tps": res.get("main_decode_tps"),
-            "pr_prefill128_pp": res.get("pr_prefill128_pp"),
-            "main_prefill128_pp": res.get("main_prefill128_pp"),
+            "pr_top1": res.get("pr_top1"),
+            "pr_kl": res.get("pr_kl"),
             "pass": res.get("pass"),
             "accuracy_ok": res.get("accuracy_ok"),
             "q36_guard_ok": res.get("q36_guard_ok"),
@@ -1332,51 +1209,49 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
                 fail_clause = "and regressed the Qwen3.6 no-regression guard (decode/prefill on shared code)"
             elif not res.get("accuracy_ok"):
                 fail_clause = "and failed the accuracy gate"
-            elif res.get("prefill_regressed"):
-                fail_clause = "and regressed 128-ctx prefill throughput specifically"
             elif res.get("decode_regressed"):
-                fail_clause = "(decode regression)"
+                fail_clause = "(decode@128 regression)"
             elif label == "none":
-                fail_clause = "with no verified improvement on both decode and prefill"
+                fail_clause = "with no verified decode@128 improvement"
             else:
                 fail_clause = "(regression)"
             close_body = (
-                "<!-- sparkinfer-museglimmer-auto-close -->\n"
-                f"## Closed: sparkinfer museglimmer auto-eval — `eval-museglimmer:{label}`\n\n"
-                f"This PR's Muse Glimmer 128-decode/prefill speed measured **{res.get('delta_pct')}%** "
+                "<!-- sparkinfer-qwen38-auto-close -->\n"
+                f"## Closed: sparkinfer qwen38 auto-eval — `eval-qwen38:{label}`\n\n"
+                f"This PR's Qwen3.8-27B decode@128 speed measured **{res.get('delta_pct')}%** "
                 f"vs main, {fail_clause} "
                 "— closing automatically. This bot evaluates every eligible PR in the repo "
-                "against Muse Glimmer's decode AND prefill@128 speed specifically, regardless of "
+                "against Qwen3.8-27B's decode AND prefill@128 speed specifically, regardless of "
                 "what the PR is actually about — a close here isn't a judgment on the PR's purpose, "
                 "just that it didn't move these particular metrics. Reopen (or open a fresh PR) if "
                 "you have a fix or a different approach."
             )
             arb.gh(["pr", "comment", str(num), "-R", repo, "--body", close_body])
             arb.gh(["pr", "close", str(num), "-R", repo])
-            print(f">> auto-closed PR #{num} (eval-museglimmer:{label})")
+            print(f">> auto-closed PR #{num} (eval-qwen38:{label})")
 
 
 def main():
-    ap = argparse.ArgumentParser(description="Muse Glimmer 128-decode PR eval bot")
+    ap = argparse.ArgumentParser(description="Qwen3.8-27B 128-decode PR eval bot")
     ap.add_argument("--instance", type=int, default=0)
     ap.add_argument("--repo", default="gittensor-ai-lab/sparkinfer")
     ap.add_argument("--dry-run", action="store_true")
     ap.add_argument("--reeval", action="store_true")
     ap.add_argument("--labels-only", action="store_true",
-                    help="reconcile museglimmer-merge-first only — no GPU")
+                    help="reconcile qwen38-merge-first only — no GPU")
     ap.add_argument("--only-prs", default="",
                     help="comma-separated PR numbers (bypass greenlight)")
     args = ap.parse_args()
 
     only = {int(x) for x in args.only_prs.split(",") if x.strip().isdigit()}
 
-    print(f">> museglimmer eval transport: "
+    print(f">> qwen38 eval transport: "
           f"{'ssh' if ssh_box_enabled() else f'vast.ai (instance {arb.current_instance(args.instance) or args.instance})'}")
     print(f">> AUTOMERGE={int(AUTO_MERGE)}")
 
     if args.labels_only:
-        reconcile_museglimmer_merge_labels(args.repo, dry_run=args.dry_run)
-        print("done — museglimmer labels only (no GPU).")
+        reconcile_qwen38_merge_labels(args.repo, dry_run=args.dry_run)
+        print("done — qwen38 labels only (no GPU).")
         return
 
     prs = json.loads(arb.gh([
@@ -1386,7 +1261,7 @@ def main():
     ]).stdout or "[]")
     prs.sort(key=lambda p: p["number"])
 
-    stale_closed = close_stale_museglimmer_prs(args.repo, prs, dry_run=args.dry_run) if not only else set()
+    stale_closed = close_stale_qwen38_prs(args.repo, prs, dry_run=args.dry_run) if not only else set()
 
     denylist = arb.load_denylist()
     pending = []
@@ -1414,19 +1289,19 @@ def main():
             continue
         head = (pr.get("headRefOid") or "")[:40]
         short = head[:9]
-        if not args.reeval and head and head in museglimmer_evaluated_commits(args.repo, num):
-            print(f"PR #{num} @ {short}: already museglimmer-evaluated — skip")
+        if not args.reeval and head and head in qwen38_evaluated_commits(args.repo, num):
+            print(f"PR #{num} @ {short}: already qwen38-evaluated — skip")
             continue
         if arb.pr_merge_conflict(pr.get("mergeable")):
-            print(f"PR #{num}: merge conflict — museglimmer-needs-rebase")
+            print(f"PR #{num}: merge conflict — qwen38-needs-rebase")
             if not args.dry_run:
-                arb.add_label(args.repo, num, MUSEGLIMMER_NEEDS_REBASE)
+                arb.add_label(args.repo, num, QWEN38_NEEDS_REBASE)
             continue
 
         if not only:
             status, why = arb.greenlight_status(args.repo, num, labs)
             if status != "ok":
-                print(f"PR #{num}: not greenlit ({why}) — skip museglimmer eval")
+                print(f"PR #{num}: not greenlit ({why}) — skip qwen38 eval")
                 continue
             print(f"PR #{num}: greenlit ({why})")
         else:
@@ -1436,8 +1311,8 @@ def main():
         pending.append((num, head, short, ref, pr.get("title", "")))
 
     if not pending:
-        reconcile_museglimmer_merge_labels(args.repo, dry_run=args.dry_run)
-        print("done — no museglimmer PRs to evaluate.")
+        reconcile_qwen38_merge_labels(args.repo, dry_run=args.dry_run)
+        print("done — no qwen38 PRs to evaluate.")
         return
 
     if args.dry_run:
@@ -1453,8 +1328,8 @@ def main():
         host, port = resolve_ssh(args.instance)
     except Exception as e:
         print(f">> GPU unavailable: {e}")
-        reconcile_museglimmer_merge_labels(args.repo, dry_run=False)
-        print("done — museglimmer labels only (GPU down).")
+        reconcile_qwen38_merge_labels(args.repo, dry_run=False)
+        print("done — qwen38 labels only (GPU down).")
         return
 
     _ssh_user = ssh_box_user() if ssh_box_enabled() else "root"
@@ -1468,23 +1343,23 @@ def main():
         # is broken, and rather than posting a misleading per-PR "main run failed" on every
         # pending PR for what is really one shared infra problem.
         print(f">> main baseline measurement failed: {main_result.get('reason')} — skipping round")
-        reconcile_museglimmer_merge_labels(args.repo, dry_run=False)
-        print("done — museglimmer round skipped (main baseline unusable).")
+        reconcile_qwen38_merge_labels(args.repo, dry_run=False)
+        print("done — qwen38 round skipped (main baseline unusable).")
         return
-    print(f">> main baseline: decode={main_result['decode_tps']:.2f} "
-          f"prefill128={main_result['prefill128_pp']:.2f} "
-          f"top1={main_result.get('top1', 0):.3f} kl={main_result.get('kl', 99):.4f}")
+    # main has no top1/kl of its own: it IS the accuracy reference, and its score dump was just
+    # written to SCORE_DUMP_MAIN for each PR in this round to diff against.
+    print(f">> main baseline: decode@128={main_result['decode128_tps']:.2f} tok/s")
 
     for num, head, short, ref, title in pending:
-        print(f"PR #{num} @ {short}: evaluating Muse Glimmer '{ref}' …")
+        print(f"PR #{num} @ {short}: evaluating Qwen3.8-27B '{ref}' …")
         try:
-            res = eval_museglimmer_on_box(host, port, ref, main_result)
+            res = eval_qwen38_on_box(host, port, ref, main_result)
         except Exception as e:
             res = {"ok": False, "reason": f"exception: {e}"}
         apply_result(args.repo, num, head or short, res, title=title, dry_run=False)
 
-    reconcile_museglimmer_merge_labels(args.repo, dry_run=False)
-    print("done — museglimmer eval pass complete.")
+    reconcile_qwen38_merge_labels(args.repo, dry_run=False)
+    print("done — qwen38 eval pass complete.")
 
 
 if __name__ == "__main__":

--- a/eval/pr_qwen38_bot.py
+++ b/eval/pr_qwen38_bot.py
@@ -412,11 +412,20 @@ def _crash_reason(*outputs: str) -> str | None:
 
 
 def _looks_like_hard_kill(stdout: str, stderr: str) -> bool:
-    """Same hard-kill heuristic as pr_dflash_bot.py (no ERR-trap diagnostic captured at all)."""
+    """No ERR-trap diagnostic captured AND the run did not reach its final checkpoint.
+
+    The sibling bots key this off ACCURACY_STAGE_DONE because accuracy is their LAST stage. Here
+    it is not: the Qwen3.6 guard runs after it, so ACCURACY_STAGE_DONE would mark a run "far
+    enough along" while the entire guard was still missing. Observed for real 2026-08-15 --
+    a main run reached ACCURACY_STAGE_DONE and GUARD_START, then died at exit 6 during the guard
+    sweep with no ERR-trap output at all; re-running the identical script succeeded, so it was
+    transient. Under the old heuristic that run would NOT have been retried, check_q36_guard would
+    have seen an empty guard36 dict, called the measurement unavailable, and hard-REJECTed --
+    auto-closing a PR for a flake. GUARD_END is the real end-of-run marker, so use that."""
     combined = (stdout or "") + "\n" + (stderr or "")
     if _crash_reason(stdout, stderr):
         return False
-    return "ACCURACY_STAGE_DONE" not in combined  # never reached even the accuracy checkpoint
+    return "GUARD_END" not in combined
 
 
 def _ssh_run_resilient(host, port, script: str, label: str):

--- a/eval/run_qwen38_cron.sh
+++ b/eval/run_qwen38_cron.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
 # Cron wrapper for the sparkinfer Qwen3.8-27B PR eval bot:
 #
-#   0 * * * * /home/autotiny/Desktop/sparkinfer/eval/run_qwen38_cron.sh >> /tmp/sparkinfer_qwen38_bot.log 2>&1
+#   */30 * * * * /home/autotiny/Desktop/sparkinfer/eval/run_qwen38_cron.sh >> /tmp/sparkinfer_qwen38_bot.log 2>&1
 #
-#   Takes the :00 slot that run_museglimmer_cron.sh used to hold — Qwen3.8-27B replaces Muse
-#   Glimmer as the scored model (eval/README.md), so the two are NOT meant to run together. If you
-#   ever reinstate the Muse Glimmer or DFlash cron alongside this one, give it a different slot
-#   (e.g. :30) rather than letting two multi-minute full-GPU eval runs race for the shared lock
-#   every tick — flock's 120s wait is meant for short overlaps, not that.
+#   Every 30 minutes, replacing the :00-only slot run_museglimmer_cron.sh used to hold —
+#   Qwen3.8-27B replaces Muse Glimmer as the scored model (eval/README.md), so the two are NOT
+#   meant to run together. If you ever reinstate the Muse Glimmer or DFlash cron alongside this
+#   one, this schedule leaves no free slot: give this one back a single hourly slot first, rather
+#   than letting two multi-hour full-GPU eval runs race for the shared lock.
+#
+#   30 minutes comfortably fits a round. Measured on the pinned RTX 5090 (2026-08-15), per ref:
+#     build   1s no-op / 9s after a runtime/ source change / 18s after a CUDA kernel change
+#     GPU     26s decode@128 (reps=5) + 6s score dump + 29s Qwen3.6 guard (5 ctx x reps=5) = 61s
+#   so ~80s worst case per ref. A round is 1 main baseline + 1 run per pending PR, i.e. roughly
+#   3 min with one PR and ~15 min with ten. The model loads are far cheaper than they look because
+#   the bot benches decode@128, not long context: the 32k guard point dominates and still only
+#   costs seconds.
+#
+#   If a round ever DOES overrun the interval (a large PR backlog), the flock below makes the
+#   overlapping tick exit 0 after 120s rather than piling up — the effect is a skipped tick, not a
+#   queue. Do NOT raise flock's -w to try to queue ticks: that would serialize a backlog of stale
+#   rounds against one GPU.
 #
 # Policy (same as the sibling bots):
 #   • Pinned eval box only; never rent / never start from cron when down.

--- a/eval/run_qwen38_cron.sh
+++ b/eval/run_qwen38_cron.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Cron wrapper for the sparkinfer Qwen3.8-27B PR eval bot:
+#
+#   0 * * * * /home/autotiny/Desktop/sparkinfer/eval/run_qwen38_cron.sh >> /tmp/sparkinfer_qwen38_bot.log 2>&1
+#
+#   Takes the :00 slot that run_museglimmer_cron.sh used to hold — Qwen3.8-27B replaces Muse
+#   Glimmer as the scored model (eval/README.md), so the two are NOT meant to run together. If you
+#   ever reinstate the Muse Glimmer or DFlash cron alongside this one, give it a different slot
+#   (e.g. :30) rather than letting two multi-minute full-GPU eval runs race for the shared lock
+#   every tick — flock's 120s wait is meant for short overlaps, not that.
+#
+# Policy (same as the sibling bots):
+#   • Pinned eval box only; never rent / never start from cron when down.
+#   • Shares /tmp/sparkinfer_bot.lock with run_dflash_cron.sh (and the AR bot / sparkinfer-web
+#     dashboard-sync crons) — CRITICAL: this MUST be the SAME lock file, since every one of these
+#     bots drives the ONE pinned GPU on the SAME box and would otherwise race for it if a cron
+#     tick overlaps. Wait a bounded amount instead of failing instantly: long enough to outlast a
+#     quick sibling-bot tick, short enough to still bail if something is genuinely stuck.
+#   • GPU up → full decode@128 speed + differential-accuracy eval + Qwen3.6 guard;
+#     GPU down → --labels-only (no GPU, no ssh, pure label reconciliation).
+#   • Auto-merge stays OFF unless SPARKINFER_QWEN38_AUTOMERGE=1 is explicitly set (NOT
+#     exported here, and NOT in .env.eval by default) — this script deliberately does NOT
+#     force an auto-merge env var to 1.
+export HOME="${HOME:-/home/autotiny}"
+export PATH="/usr/local/bin:/usr/bin:/bin:$HOME/.local/bin:$PATH"
+export PYTHONUNBUFFERED=1
+export VAST_NO_AUTO_PROVISION=1
+
+exec 9>/tmp/sparkinfer_bot.lock
+flock -w 120 9 || { echo "[$(date -u +%FT%TZ)] lock held 120s+ — previous bot run still active, skipping qwen38 tick"; exit 0; }
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_DIR" || exit 1
+
+if [ -f "$REPO_DIR/.env.eval" ]; then
+  set -a
+  # shellcheck source=/dev/null
+  source "$REPO_DIR/.env.eval"
+  set +a
+fi
+export VAST_NO_AUTO_PROVISION=1
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY ALL_PROXY all_proxy
+
+git pull -q origin main 2>/dev/null || true
+
+PIN_FILE="${VAST_PIN_FILE:-$HOME/.sparkinfer_pinned_instance}"
+INSTANCE_FILE="${VAST_INSTANCE_FILE:-$HOME/.sparkinfer_vast_instance}"
+resolve_pin() {
+  local v=""
+  if [ -f "$PIN_FILE" ]; then
+    v="$(tr -d '[:space:]' <"$PIN_FILE" 2>/dev/null || true)"
+  fi
+  if [ -z "$v" ] || [ "$v" = "0" ]; then
+    v="${VAST_DEFAULT_INSTANCE:-${VAST_INSTANCE:-}}"
+  fi
+  printf '%s' "$v"
+}
+PINNED_ID="$(resolve_pin)"
+if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ] && [ -n "$PINNED_ID" ] && [ "$PINNED_ID" != "0" ]; then
+  export VAST_INSTANCE="$PINNED_ID"
+  export VAST_DEFAULT_INSTANCE="$PINNED_ID"
+  printf '%s\n' "$PINNED_ID" >"$PIN_FILE"
+  printf '%s\n' "$PINNED_ID" >"$INSTANCE_FILE"
+fi
+
+BOT_ARGS=(--repo "${REPO:-gittensor-ai-lab/sparkinfer}")
+if [ "${EVAL_TRANSPORT:-vast}" != "ssh" ]; then
+  BOT_ARGS+=(--instance "${VAST_INSTANCE:-0}")
+fi
+
+gpu_ready() {
+  local key="${SSH_KEY:-$HOME/.ssh/speedy}"
+  if [ "${EVAL_TRANSPORT:-vast}" = "ssh" ]; then
+    local host="${EVAL_SSH_HOST:-}" port="${EVAL_SSH_PORT:-22}" user="${EVAL_SSH_USER:-root}"
+    [ -n "$host" ] || return 1
+    # IdentitiesOnly=yes: same rationale as run_dflash_cron.sh's gpu_ready — cron has no
+    # ssh-agent, so without it a box whose authorized_keys only has SSH_KEY's public half (not
+    # some agent identity) fails outright with "Permission denied".
+    local err rc
+    err="$(ssh -i "$key" -o IdentitiesOnly=yes -o BatchMode=yes -o ConnectTimeout=20 \
+        -o StrictHostKeyChecking=accept-new -p "$port" "$user@$host" 'true' 2>&1)"
+    rc=$?
+    [ "$rc" -eq 0 ] || echo "gpu_ready: ssh to $user@$host:$port failed (exit=$rc): $err" >&2
+    return "$rc"
+  fi
+  local iid="${VAST_INSTANCE:-}"
+  [ -n "$iid" ] && [ "$iid" != "0" ] || return 1
+  command -v vastai >/dev/null 2>&1 || return 1
+  local raw st ip port
+  raw="$(vastai show instance "$iid" --raw 2>/dev/null)" || return 1
+  read -r st ip port < <(python3 -c "
+import json, sys
+d = json.loads(sys.stdin.read() or '{}')
+st = d.get('actual_status') or ''
+ip = d.get('public_ipaddr') or ''
+ports = d.get('ports') or {}
+p = ((ports.get('22/tcp') or [{}])[0] or {}).get('HostPort') or ''
+print(st, ip, p)
+" <<<"$raw")
+  [ "$st" = "running" ] && [ -n "$ip" ] && [ -n "$port" ] || return 1
+  ssh -i "$key" -o BatchMode=yes -o ConnectTimeout=10 \
+      -o StrictHostKeyChecking=accept-new -p "$port" "root@$ip" 'true' 2>/dev/null
+}
+
+GPU_LABEL="${EVAL_SSH_HOST:-ssh}"
+[ "${EVAL_TRANSPORT:-vast}" = "ssh" ] || GPU_LABEL="${VAST_INSTANCE:-?}"
+
+TS="$(date -u +%FT%TZ)"
+if gpu_ready; then
+  echo "[$TS] sparkinfer Qwen3.8-27B bot — pinned GPU $GPU_LABEL up — full eval (AUTOMERGE=${SPARKINFER_QWEN38_AUTOMERGE:-0})"
+  python3 eval/pr_qwen38_bot.py "${BOT_ARGS[@]}"
+else
+  echo "[$TS] sparkinfer Qwen3.8-27B bot — pinned GPU $GPU_LABEL down — labels only"
+  python3 eval/pr_qwen38_bot.py "${BOT_ARGS[@]}" --labels-only
+fi

--- a/eval/setup_labels.sh
+++ b/eval/setup_labels.sh
@@ -56,4 +56,16 @@ gh label create "museglimmer-merge-first" -R "$REPO" --color "0E8A16" \
 gh label create "museglimmer-needs-rebase" -R "$REPO" --color "FBCA04" \
    --description "verified Muse Glimmer speedup but not this round's museglimmer-merge-first" --force >/dev/null
 
-echo "eval:*, eval-dflash:*, eval-museglimmer:*, area:*, *-context, regression-*, dflash-merge-*, museglimmer-merge-* labels ready on $REPO"
+# Qwen3.8-27B bot (eval/pr_qwen38_bot.py) — decode@128 on the NVFP4 checkpoint, differential
+# accuracy gate, Qwen3.6 no-regression guard. Mirrors its tier to eval:* (SN74 scoring reads
+# eval:*), unlike the Muse Glimmer labels above.
+for k in "${!C[@]}"; do
+  gh label create "eval-qwen38:$k" -R "$REPO" --color "${C[$k]}" \
+     --description "sparkinfer Qwen3.8-27B decode@128 vs-main speed tier: $k" --force >/dev/null
+done
+gh label create "qwen38-merge-first" -R "$REPO" --color "0E8A16" \
+   --description "round winner: biggest verified Qwen3.8-27B decode@128 speedup — auto-merge candidate" --force >/dev/null
+gh label create "qwen38-needs-rebase" -R "$REPO" --color "FBCA04" \
+   --description "verified Qwen3.8-27B speedup but not this round's qwen38-merge-first" --force >/dev/null
+
+echo "eval:*, eval-dflash:*, eval-museglimmer:*, eval-qwen38:*, area:*, *-context, regression-*, dflash-merge-*, museglimmer-merge-*, qwen38-merge-* labels ready on $REPO"

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -111,7 +111,12 @@ endif()
 
 # Unified interface library
 add_library(sparkinfer_kernels INTERFACE)
-target_link_libraries(sparkinfer_kernels INTERFACE ${SPARKINFER_KERNEL_LIBS})
+# --start-group/--end-group: these static archives end up adjacent in every consumer's final link
+# line (verified via link.txt), but some symbols (e.g. launch_muse_sandwich_tail in si_fused) are
+# only referenced from within this archive set itself in certain link orders -- ld's single-pass
+# scan can drop such an archive member even though it's present, unless told to rescan the group
+# until nothing new resolves.
+target_link_libraries(sparkinfer_kernels INTERFACE -Wl,--start-group ${SPARKINFER_KERNEL_LIBS} -Wl,--end-group)
 target_include_directories(sparkinfer_kernels INTERFACE include)
 
 if(BUILD_TESTS)

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -533,13 +533,13 @@ __global__ void pf_gdn_scan_kernel(const __nv_bfloat16* __restrict__ q,
                                    const __nv_bfloat16* __restrict__ a,
                                    float* __restrict__ state,
                                    __nv_bfloat16* __restrict__ out,
-                                   int n_tokens, int q_heads, int v_heads) {
+                                   int n_tokens, int q_heads, int v_heads, bool qh_block) {
     constexpr int NROW = HEAD_DIM / 32;
     const int vh   = blockIdx.x;
     const int j    = blockIdx.y * COLS + (threadIdx.x >> 5);
     const int lane = threadIdx.x & 31;
     if (vh >= v_heads || j >= HEAD_DIM) return;
-    const int qh = vh % q_heads;
+    const int qh = qh_block ? (vh / (v_heads / q_heads)) : (vh % q_heads);
     const int q_dim = q_heads * HEAD_DIM;
     const int v_dim = v_heads * HEAD_DIM;
     const float scale = rsqrtf((float)HEAD_DIM);
@@ -590,13 +590,13 @@ __global__ void df_gdn_scan_checkpoint_kernel(
     const __nv_bfloat16* __restrict__ beta, const __nv_bfloat16* __restrict__ dt,
     const __nv_bfloat16* __restrict__ a, const float* __restrict__ live_state,
     __nv_bfloat16* __restrict__ out, float* __restrict__ checkpoints,
-    int n_tokens, int q_heads, int v_heads) {
+    int n_tokens, int q_heads, int v_heads, bool qh_block) {
     constexpr int NROW = HEAD_DIM / 32;
     const int vh = blockIdx.x;
     const int j = blockIdx.y * COLS + (threadIdx.x >> 5);
     const int lane = threadIdx.x & 31;
     if (vh >= v_heads || j >= HEAD_DIM) return;
-    const int qh = vh % q_heads;
+    const int qh = qh_block ? (vh / (v_heads / q_heads)) : (vh % q_heads);
     const int q_dim = q_heads * HEAD_DIM;
     const int v_dim = v_heads * HEAD_DIM;
     const size_t state_elems = (size_t)v_heads * HEAD_DIM * HEAD_DIM;
@@ -648,13 +648,13 @@ __global__ void df_gdn_scan_commit_kernel(
     const __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ alpha, const __nv_bfloat16* __restrict__ beta,
     const __nv_bfloat16* __restrict__ dt, const __nv_bfloat16* __restrict__ a,
-    float* __restrict__ live_state, int n_tokens, int q_heads, int v_heads) {
+    float* __restrict__ live_state, int n_tokens, int q_heads, int v_heads, bool qh_block) {
     constexpr int NROW = HEAD_DIM / 32;
     const int vh = blockIdx.x;
     const int j = blockIdx.y * COLS + (threadIdx.x >> 5);
     const int lane = threadIdx.x & 31;
     if (vh >= v_heads || j >= HEAD_DIM) return;
-    const int qh = vh % q_heads;
+    const int qh = qh_block ? (vh / (v_heads / q_heads)) : (vh % q_heads);
     const int q_dim = q_heads * HEAD_DIM;
     const int v_dim = v_heads * HEAD_DIM;
     const size_t col_off = ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
@@ -1145,11 +1145,11 @@ void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_sta
 void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
                              const void* alpha, const void* beta, const void* dt, const void* a,
                              float* state, void* out, int n_tokens, int q_heads, int v_heads,
-                             int head_dim, cudaStream_t stream) {
+                             int head_dim, bool qh_block, cudaStream_t stream) {
     // Chunk-parallel (WY/UT transform) scan: shortens the serial chain N -> N/C. Falls through to
     // the sequential scan below when disabled (SPARKINFER_PREFILL_GDN_CHUNK=0) or shape-unsupported.
     if (launch_prefill_gdn_chunk(q, k, v, alpha, beta, dt, a, state, out,
-                                 n_tokens, q_heads, v_heads, head_dim, stream)) return;
+                                 n_tokens, q_heads, v_heads, head_dim, qh_block, stream)) return;
     constexpr int COLS = 4;
     dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
     auto qb = reinterpret_cast<const __nv_bfloat16*>(q);
@@ -1162,7 +1162,7 @@ void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
     auto ob = reinterpret_cast<__nv_bfloat16*>(out);
     if (head_dim == 128)
         pf_gdn_scan_kernel<COLS, 128><<<grid, COLS * 32, 0, stream>>>(
-            qb, kb, vb, ab, bb, db, aa, state, ob, n_tokens, q_heads, v_heads);
+            qb, kb, vb, ab, bb, db, aa, state, ob, n_tokens, q_heads, v_heads, qh_block);
 }
 
 void launch_dflash_gdn_conv(const void* qkv, const void* conv_w, const void* live_state,
@@ -1183,7 +1183,7 @@ void launch_dflash_gdn_scan(const void* q, const void* k, const void* v,
                             const void* alpha, const void* beta, const void* dt, const void* a,
                             const float* live_state, void* out, float* checkpoints,
                             int n_tokens, int q_heads, int v_heads, int head_dim,
-                            cudaStream_t stream) {
+                            bool qh_block, cudaStream_t stream) {
     if (n_tokens <= 0 || head_dim != 128) return;
     constexpr int COLS = 4;
     dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
@@ -1192,7 +1192,7 @@ void launch_dflash_gdn_scan(const void* q, const void* k, const void* v,
         reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(alpha),
         reinterpret_cast<const __nv_bfloat16*>(beta), reinterpret_cast<const __nv_bfloat16*>(dt),
         reinterpret_cast<const __nv_bfloat16*>(a), live_state,
-        reinterpret_cast<__nv_bfloat16*>(out), checkpoints, n_tokens, q_heads, v_heads);
+        reinterpret_cast<__nv_bfloat16*>(out), checkpoints, n_tokens, q_heads, v_heads, qh_block);
 }
 
 void launch_dflash_gdn_conv_compact(const void* qkv, const void* conv_w,
@@ -1212,7 +1212,7 @@ void launch_dflash_gdn_scan_compact(const void* q, const void* k, const void* v,
                                     const void* alpha, const void* beta,
                                     const void* dt, const void* a, const float* live_state,
                                     void* out, int n_tokens, int q_heads, int v_heads,
-                                    int head_dim, cudaStream_t stream) {
+                                    int head_dim, bool qh_block, cudaStream_t stream) {
     if (n_tokens <= 0 || head_dim != 128) return;
     constexpr int COLS = 4;
     dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
@@ -1221,7 +1221,7 @@ void launch_dflash_gdn_scan_compact(const void* q, const void* k, const void* v,
         reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(alpha),
         reinterpret_cast<const __nv_bfloat16*>(beta), reinterpret_cast<const __nv_bfloat16*>(dt),
         reinterpret_cast<const __nv_bfloat16*>(a), live_state,
-        reinterpret_cast<__nv_bfloat16*>(out), nullptr, n_tokens, q_heads, v_heads);
+        reinterpret_cast<__nv_bfloat16*>(out), nullptr, n_tokens, q_heads, v_heads, qh_block);
 }
 
 void launch_dflash_gdn_conv_commit(const void* qkv, void* live_state, int n_tokens,
@@ -1239,7 +1239,7 @@ void launch_dflash_gdn_scan_commit(const void* k, const void* v,
                                    const void* alpha, const void* beta,
                                    const void* dt, const void* a, float* live_state,
                                    int n_tokens, int q_heads, int v_heads, int head_dim,
-                                   cudaStream_t stream) {
+                                   bool qh_block, cudaStream_t stream) {
     if (n_tokens <= 0 || head_dim != 128) return;
     constexpr int COLS = 4;
     dim3 grid(v_heads, (head_dim + COLS - 1) / COLS);
@@ -1247,7 +1247,7 @@ void launch_dflash_gdn_scan_commit(const void* k, const void* v,
         reinterpret_cast<const __nv_bfloat16*>(k), reinterpret_cast<const __nv_bfloat16*>(v),
         reinterpret_cast<const __nv_bfloat16*>(alpha), reinterpret_cast<const __nv_bfloat16*>(beta),
         reinterpret_cast<const __nv_bfloat16*>(dt), reinterpret_cast<const __nv_bfloat16*>(a),
-        live_state, n_tokens, q_heads, v_heads);
+        live_state, n_tokens, q_heads, v_heads, qh_block);
 }
 
 void launch_prefill_gated_norm(const void* x, const void* z, const void* weight, void* out,

--- a/kernels/csrc/cuda/fused/ct_dequant_fp8.cu
+++ b/kernels/csrc/cuda/fused/ct_dequant_fp8.cu
@@ -1,0 +1,38 @@
+// FP8 (E4M3) weight dequant for HuggingFace "compressed-tensors" checkpoints -- see
+// sparkinfer/kernels/compressed_tensors.h. No CUTLASS dependency (unlike the NVFP4 dequant
+// alongside it in prefill_nvfp4_sm120.cu), so this lives in si_fused (built unconditionally)
+// rather than si_nvfp4 (CUTLASS-gated, BUILD_NVFP4_KERNELS).
+
+#include "sparkinfer/kernels/compressed_tensors.h"
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+namespace sparkinfer { namespace kernels {
+namespace {
+
+__global__ void ct_dequant_fp8_kernel(const __nv_fp8_e4m3* __restrict__ w,
+                                      const __nv_bfloat16* __restrict__ scale,
+                                      __nv_bfloat16* __restrict__ out, int rows, long cols) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    const long n = (long)rows * cols;
+    if (i >= n) return;
+    const int r = (int)(i / cols);
+    const float s = __bfloat162float(scale[r]);
+    out[i] = __float2bfloat16(float(w[i]) * s);
+}
+
+} // namespace
+
+void launch_ct_dequant_fp8(const void* w_e4m3, const void* scale_bf16, void* out_bf16,
+                           int rows, int cols, cudaStream_t stream) {
+    const long n = (long)rows * cols;
+    const int threads = 256;
+    const long blocks = (n + threads - 1) / threads;
+    ct_dequant_fp8_kernel<<<(unsigned)blocks, threads, 0, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(w_e4m3),
+        reinterpret_cast<const __nv_bfloat16*>(scale_bf16),
+        reinterpret_cast<__nv_bfloat16*>(out_bf16), rows, cols);
+}
+
+}} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/model_ops.cu
+++ b/kernels/csrc/cuda/fused/model_ops.cu
@@ -165,23 +165,26 @@ __global__ void logit_softcap_kernel(float* __restrict__ logits, int vocab,
 __global__ void mg_debug_bf16_kernel(const __nv_bfloat16* __restrict__ x, int n,
                                      int tag, int layer, int step) {
     __shared__ float red[256];
-    float local = 0.f;
+    __shared__ float redsum[256];
+    float local = 0.f, localsum = 0.f;
     for (int i = threadIdx.x; i < n; i += blockDim.x) {
         float v = __bfloat162float(x[i]);
         local += v * v;
+        localsum += v;
     }
     red[threadIdx.x] = local;
+    redsum[threadIdx.x] = localsum;
     __syncthreads();
     for (int s = blockDim.x >> 1; s > 0; s >>= 1) {
-        if (threadIdx.x < s) red[threadIdx.x] += red[threadIdx.x + s];
+        if (threadIdx.x < s) { red[threadIdx.x] += red[threadIdx.x + s]; redsum[threadIdx.x] += redsum[threadIdx.x + s]; }
         __syncthreads();
     }
     if (threadIdx.x == 0) {
         float v0 = n > 0 ? __bfloat162float(x[0]) : 0.f;
         float v1 = n > 1 ? __bfloat162float(x[1]) : 0.f;
         float v2 = n > 2 ? __bfloat162float(x[2]) : 0.f;
-        printf("[mgstage] step=%d layer=%d tag=%d n=%d l2=%.6f v0=%.6f v1=%.6f v2=%.6f\n",
-               step, layer, tag, n, sqrtf(red[0]), v0, v1, v2);
+        printf("[mgstage] step=%d layer=%d tag=%d n=%d l2=%.6f sum=%.6f v0=%.6f v1=%.6f v2=%.6f\n",
+               step, layer, tag, n, sqrtf(red[0]), redsum[0], v0, v1, v2);
     }
 }
 

--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -100,7 +100,7 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
                                     __nv_bfloat16* __restrict__ w_buf,
                                     __nv_bfloat16* __restrict__ u_buf,
                                     float* __restrict__ m_buf,
-                                    int n_tokens, int q_heads, int v_heads) {
+                                    int n_tokens, int q_heads, int v_heads, bool qh_block) {
     extern __shared__ char s_raw[];
     __nv_bfloat16* s_k = reinterpret_cast<__nv_bfloat16*>(s_raw);              // [C][HD+PAD]
     __nv_bfloat16* s_x = s_k + (size_t)C * (HD + PAD);                         // [C][HD+PAD] q then v
@@ -117,7 +117,7 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
     const int len  = min(C, n_tokens - t0);
     if (len <= 0) return;
 
-    const int qh    = h % q_heads;
+    const int qh    = qh_block ? (h / (v_heads / q_heads)) : (h % q_heads);
     const int q_dim = q_heads * HD;
     const int v_dim = v_heads * HD;
     const float a_h  = gc_to_f(a[h]);
@@ -283,7 +283,8 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                                     const float* __restrict__ m_buf,
                                     float* __restrict__ state,
                                     __nv_bfloat16* __restrict__ out,
-                                    int n_tokens, int q_heads, int v_heads, int n_chunks) {
+                                    int n_tokens, int q_heads, int v_heads, int n_chunks,
+                                    bool qh_block) {
     extern __shared__ char s_raw[];
     float* s_S = reinterpret_cast<float*>(s_raw);                              // [HD][JC]  fp32 carrier
     float* s_U = s_S + (size_t)HD * JC;                                        // [C][JC]
@@ -306,7 +307,7 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
     const int tid  = threadIdx.x;
     const int nthr = blockDim.x;
 
-    const int qh    = h % q_heads;
+    const int qh    = qh_block ? (h / (v_heads / q_heads)) : (h % q_heads);
     const int q_dim = q_heads * HD;
     const int v_dim = v_heads * HD;
     const float scale = rsqrtf((float)HD);
@@ -525,7 +526,7 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
                               const void* dt, const void* a,
                               float* state, void* out,
                               int n_tokens, int q_heads, int v_heads, int head_dim,
-                              cudaStream_t stream) {
+                              bool qh_block, cudaStream_t stream) {
     constexpr int C = 32, HD = 128, JC = 32, SCAN_THREADS = 256, PREP_THREADS = 256;
 
     static const int enabled = [] {
@@ -615,7 +616,7 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
     static_assert(C * C == PREP_THREADS * 4, "2x2 A/M tiling requires C*C == 4*PREP_THREADS");
     dim3 gprep(n_chunks, v_heads);
     pf_gdnc_prep_kernel<C, HD><<<gprep, PREP_THREADS, sm_prep, stream>>>(
-        qb, kb, vb, ab, bb, db, aa, g_buf, w_buf, u_buf, m_buf, n_tokens, q_heads, v_heads);
+        qb, kb, vb, ab, bb, db, aa, g_buf, w_buf, u_buf, m_buf, n_tokens, q_heads, v_heads, qh_block);
 
     // SCAN_THREADS is not free tuning: the register tiling below partitions the [C,JC] and [HD,JC]
     // outputs across exactly this many threads (2x2 and 4x4 tiles respectively).
@@ -623,7 +624,7 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
     static_assert(HD * JC == SCAN_THREADS * 16, "4x4 tiling requires HD*JC == 16*SCAN_THREADS");
     dim3 gscan(v_heads, HD / JC);
     pf_gdnc_scan_kernel<C, HD, JC><<<gscan, SCAN_THREADS, sm_scan, stream>>>(
-        qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob, n_tokens, q_heads, v_heads, n_chunks);
+        qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob, n_tokens, q_heads, v_heads, n_chunks, qh_block);
     // A rejected launch (e.g. smem over the device limit) enqueues nothing; peek —
     // rather than get — so a pre-existing sticky error is not silently cleared here.
     // Returning false lets the caller fall through to the sequential GDN scan.

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -1,4 +1,5 @@
 #include "sparkinfer/kernels/prefill_nvfp4.h"
+#include "sparkinfer/kernels/compressed_tensors.h"
 
 #include <cuda_bf16.h>
 #include <cutlass/cutlass.h>
@@ -307,4 +308,47 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
     return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st)
                               : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
 }
+
+// ---- HuggingFace "compressed-tensors" NVFP4 checkpoint dequant (load-time, one-shot) ----
+// See sparkinfer/kernels/compressed_tensors.h -- converts a checkpoint's own NVFP4 encoding
+// (block_size=16 UE4M3 group scale + one F32 global scale) straight to bf16, so the result feeds
+// this runtime's OWN from-bf16 quantizers (quant_rows above, or the Q4_K requant path) rather than
+// needing the GEMM kernels above to understand a second, foreign two-level scale scheme.
+namespace {
+__global__ void ct_dequant_nvfp4_kernel(const unsigned char* __restrict__ packed,
+                                        const unsigned char* __restrict__ group_scale,
+                                        float global_scale, __nv_bfloat16* __restrict__ out,
+                                        int rows, int cols) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    const long n = (long)rows * cols;
+    if (i >= n) return;
+    const int r = (int)(i / cols);
+    const int c = (int)(i - (long)r * cols);
+    const unsigned char byte = packed[(size_t)r * (cols / 2) + (c >> 1)];
+    const unsigned char nibble = (c & 1) ? (byte >> 4) : (byte & 0xF);
+    const unsigned char sbyte = group_scale[(size_t)r * (cols / 16) + (c >> 4)];
+    const float v = float(cutlass::float_e2m1_t::bitcast(nibble));
+    const float s = float(cutlass::float_ue4m3_t::bitcast(sbyte));
+    // weight_global_scale is stored as the quantization-time multiplier that mapped local block
+    // scales (local_amax/6) UP into UE4M3's representable range before rounding to 8 bits, so
+    // dequant must invert it: block_scale_fp32 = e4m3(block_scale) / global_scale. Confirmed
+    // empirically against the real unsloth/Qwen3.8-27B-NVFP4 checkpoint -- multiplying (the other
+    // natural reading) produces weight magnitudes in the hundreds of thousands; dividing produces
+    // the expected ~0.01-0.05 std typical of a trained projection matrix.
+    out[i] = __float2bfloat16(v * s / global_scale);
+}
+} // namespace
+
+void launch_ct_dequant_nvfp4(const void* packed_u8, const void* group_scale_ue4m3,
+                             float global_scale, void* out_bf16, int rows, int cols,
+                             cudaStream_t stream) {
+    const long n = (long)rows * cols;
+    const int threads = 256;
+    const long blocks = (n + threads - 1) / threads;
+    ct_dequant_nvfp4_kernel<<<(unsigned)blocks, threads, 0, stream>>>(
+        reinterpret_cast<const unsigned char*>(packed_u8),
+        reinterpret_cast<const unsigned char*>(group_scale_ue4m3), global_scale,
+        reinterpret_cast<__nv_bfloat16*>(out_bf16), rows, cols);
+}
+
 } // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -270,13 +270,14 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
                                    const __nv_bfloat16* __restrict__ a,
                                    float* __restrict__ state,   // TRANSPOSED [vh][col][row]
                                    __nv_bfloat16* __restrict__ out,
-                                   int q_heads, int v_heads) {
+                                   int q_heads, int v_heads, bool qh_block) {
     constexpr int NROW = HEAD_DIM / 32;                        // rows per lane (compile-time -> unrolls)
     const int vh   = blockIdx.x;
     const int j    = blockIdx.y * COLS + (threadIdx.x >> 5);   // state column (all lanes in a warp share j)
     const int lane = threadIdx.x & 31;
     if (vh >= v_heads || j >= HEAD_DIM) return;                // whole-warp guard (j is warp-uniform)
-    const int qh   = vh % q_heads;
+    // v-head -> q/k-head broadcast convention; see launch_qwen36_gdn_ar's own comment.
+    const int qh   = qh_block ? (vh / (v_heads / q_heads)) : (vh % q_heads);
     const float scale = rsqrtf((float)HEAD_DIM);
     const float bb = q36_sigmoid(q36_to_f(beta[vh]));
     const float g  = __expf(q36_softplus(q36_to_f(alpha[vh]) + q36_to_f(dt[vh])) * q36_to_f(a[vh]));
@@ -555,7 +556,8 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,
                           float* state_f32, void* out_bf16,
-                          int q_heads, int v_heads, int head_dim, cudaStream_t stream) {
+                          int q_heads, int v_heads, int head_dim, bool qh_block,
+                          cudaStream_t stream) {
     // SPARKINFER_GDN_FAST: warp-per-column, register-cached, transposed-state kernel (fills the GPU +
     // 2x state traffic). Uses a transposed internal state layout, so it MUST be all-or-nothing for the
     // run — the static flag guarantees that. Requires head_dim a multiple of 32 (128 -> NROW=4).
@@ -582,7 +584,7 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
                 reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
                 reinterpret_cast<const __nv_bfloat16*>(a_bf16),
                 state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
-                q_heads, v_heads);
+                q_heads, v_heads, (bool)qh_block);
         } else if (c == 16) {
             gdn_ar_fast_kernel<16, HD><<<grid, 16 * 32, 0, stream>>>(
                 reinterpret_cast<const __nv_bfloat16*>(q_bf16),
@@ -593,7 +595,7 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
                 reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
                 reinterpret_cast<const __nv_bfloat16*>(a_bf16),
                 state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
-                q_heads, v_heads);
+                q_heads, v_heads, (bool)qh_block);
         } else {
             gdn_ar_fast_kernel<8, HD><<<grid, 8 * 32, 0, stream>>>(
                 reinterpret_cast<const __nv_bfloat16*>(q_bf16),
@@ -604,7 +606,7 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
                 reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
                 reinterpret_cast<const __nv_bfloat16*>(a_bf16),
                 state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
-                q_heads, v_heads);
+                q_heads, v_heads, (bool)qh_block);
         }
         return;
     }

--- a/kernels/include/sparkinfer/kernels/compressed_tensors.h
+++ b/kernels/include/sparkinfer/kernels/compressed_tensors.h
@@ -1,0 +1,30 @@
+#pragma once
+#include <cuda_runtime.h>
+
+// Dequantizes tensors from HuggingFace "compressed-tensors" format checkpoints (NVIDIA ModelOpt /
+// llm-compressor convention -- the exact format used by e.g. unsloth/Qwen3.8-27B-NVFP4) straight
+// to bf16, so the result can feed the SAME requantize-to-internal-format pipeline load_gguf()
+// already uses (bf16 -> Q4_K for decode via launch_proj_requant_q4k_lloyd, bf16 -> this runtime's
+// own fresh NVFP4 for prefill via the existing Muse Glimmer conversion path). One-directional,
+// one-time, load-only conversion -- no new GEMM/GEMV kernels, no global-scale bookkeeping needed
+// downstream, since the re-quantize step produces its own fresh scales the same way it already
+// does for every other model.
+
+namespace sparkinfer { namespace kernels {
+
+// FP8 (E4M3) weight, per-output-channel (row) scale: out[r,c] = float(e4m3(w[r,c])) * float(scale[r])
+// w: [rows,cols] raw e4m3 bytes, scale: [rows] bf16, out: [rows,cols] bf16.
+void launch_ct_dequant_fp8(const void* w_e4m3, const void* scale_bf16, void* out_bf16,
+                           int rows, int cols, cudaStream_t stream = nullptr);
+
+// NVFP4 (E2M1), block_size=16 group scale (UE4M3) + a single tensor-wide F32 global scale:
+//   out[r,c] = float(e2m1(packed nibble)) * float(ue4m3(group_scale[r, c/16])) * global_scale
+// packed: [rows, cols/2] U8 (2 nibbles/byte, low nibble = even column), group_scale: [rows,
+// cols/16] raw ue4m3 bytes (note: tagged F8_E4M3 in the safetensors header, but interpreted as
+// CUTLASS's unsigned e4m3 -- the standard NVIDIA NVFP4 export convention; see the loader's own
+// comment for why), out: [rows,cols] bf16. cols must be a multiple of 16.
+void launch_ct_dequant_nvfp4(const void* packed_u8, const void* group_scale_ue4m3,
+                             float global_scale, void* out_bf16, int rows, int cols,
+                             cudaStream_t stream = nullptr);
+
+}} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -273,11 +273,18 @@ void launch_qwen36_conv_split_l2norm_fused(const void* qkv_bf16, const void* con
                                  void* v_bf16, int q_heads, int v_heads, int head_dim,
                                  int conv_kernel, float eps, cudaStream_t stream = nullptr);
 
+// qh_block: v-head -> q/k-head broadcast convention. false = cyclic (vh % q_heads), the
+// original/validated convention for Qwythos and Qwen3.6-35B-A3B's checkpoints (v_heads/q_heads
+// ratio 2). true = block (vh / (v_heads/q_heads)), which Qwen3.8-27B's checkpoint needs instead
+// (ratio 3) -- confirmed empirically against a real reference implementation (llama.cpp), since
+// the two checkpoints' own HF-side v-head layout conventions differ despite the shared
+// architecture family. This is a property of the loaded checkpoint, not a global default.
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,
                           float* state_f32, void* out_bf16,
-                          int q_heads, int v_heads, int head_dim, cudaStream_t stream = nullptr);
+                          int q_heads, int v_heads, int head_dim, bool qh_block,
+                          cudaStream_t stream = nullptr);
 
 void launch_qwen36_gated_norm(const void* x_bf16, const void* z_bf16,
                               const void* weight_bf16, void* out_bf16,

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -57,12 +57,16 @@ void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_sta
 // layout [v_head][col][row] the decode gdn_ar_fast kernel expects. State starts at zero
 // (fresh prefill). q/k: [N,q_heads*hd] (head_dim==128), v: [N,v_heads*hd]; alpha/beta:
 // [N,v_heads]; dt/a: [v_heads] (per-head constants).
+// qh_block: v-head -> q/k-head broadcast convention; see launch_qwen36_gdn_ar's own comment
+// (fused.h). Defaults to the original cyclic convention (false) so existing callers are
+// unaffected; a checkpoint whose HF-side v-head layout needs block broadcast (Qwen3.8-27B)
+// must pass true, matching whatever the decode-path GDN kernel uses for the same model.
 void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
                              const void* alpha, const void* beta,
                              const void* dt, const void* a,
                              float* state, void* out,
                              int n_tokens, int q_heads, int v_heads, int head_dim,
-                             cudaStream_t stream = nullptr);
+                             bool qh_block = false, cudaStream_t stream = nullptr);
 
 // DFlash short-block variants. They start from the live decode state but leave it untouched,
 // writing a complete post-token checkpoint for every candidate row. checkpoint[t] uses the same
@@ -77,7 +81,7 @@ void launch_dflash_gdn_scan(const void* q, const void* k, const void* v,
                             const void* dt, const void* a, const float* live_state,
                             void* out, float* checkpoints,
                             int n_tokens, int q_heads, int v_heads, int head_dim,
-                            cudaStream_t stream = nullptr);
+                            bool qh_block = false, cudaStream_t stream = nullptr);
 
 // Verification-only forms: produce every candidate activation from the live state without
 // mutating it or writing O(N * state_size) checkpoints. The compact inputs are committed later.
@@ -90,7 +94,8 @@ void launch_dflash_gdn_scan_compact(const void* q, const void* k, const void* v,
                                     const void* alpha, const void* beta,
                                     const void* dt, const void* a, const float* live_state,
                                     void* out, int n_tokens, int q_heads, int v_heads,
-                                    int head_dim, cudaStream_t stream = nullptr);
+                                    int head_dim, bool qh_block = false,
+                                    cudaStream_t stream = nullptr);
 
 // Compact accepted-prefix commit. Verification retains qkv plus k/v/alpha/beta per GDN layer;
 // these launchers update the live decode state once after posterior selection, avoiding both
@@ -103,7 +108,7 @@ void launch_dflash_gdn_scan_commit(const void* k, const void* v,
                                    const void* alpha, const void* beta,
                                    const void* dt, const void* a, float* live_state,
                                    int n_tokens, int q_heads, int v_heads, int head_dim,
-                                   cudaStream_t stream = nullptr);
+                                   bool qh_block = false, cudaStream_t stream = nullptr);
 
 // Batched gated RMSNorm: out[t,h,:] = (x/rms(x)) * weight * silu(z), per (token, v_head).
 //   x/z: [N, v_heads*hd]   weight: [hd]   out: [N, v_heads*hd]

--- a/kernels/include/sparkinfer/kernels/prefill_gdn_chunk.h
+++ b/kernels/include/sparkinfer/kernels/prefill_gdn_chunk.h
@@ -37,12 +37,14 @@ namespace kernels {
 //   SPARKINFER_PREFILL_GDN_CHUNK         (default 1)   0 disables (A/B) -> sequential scan (#398).
 //   SPARKINFER_PREFILL_GDN_CHUNK_MINCTX  (default 256) only chunk at n_tokens >= this; short
 //                                                      prompts do not amortize the prep pass.
+// qh_block: v-head -> q/k-head broadcast convention; see launch_qwen36_gdn_ar's own comment
+// (fused.h). Must match whatever the decode-path GDN kernel uses for the same checkpoint.
 bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
                               const void* alpha, const void* beta,
                               const void* dt, const void* a,
                               float* state, void* out,
                               int n_tokens, int q_heads, int v_heads, int head_dim,
-                              cudaStream_t stream = nullptr);
+                              bool qh_block, cudaStream_t stream = nullptr);
 
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -69,7 +69,12 @@ if(BUILD_EXAMPLES)
     target_link_libraries(qwen3_gguf_generate PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)
     add_executable(qwen3_gguf_bench examples/qwen3_gguf_bench.cpp)
     target_include_directories(qwen3_gguf_bench PRIVATE include)
-    target_link_libraries(qwen3_gguf_bench PRIVATE sparkinfer_runtime CUDA::cudart)
+    # nlohmann_json: qwen_checkpoint.h reads an HF compressed-tensors (NVFP4) config.json via
+    # qwen38_hf_config.h, so the PR eval bot can benchmark the SAME checkpoint the server serves.
+    # Declared at the top level (see the root CMakeLists) because runtime/ is configured before
+    # server/. Links into this executable only -- sparkinfer_runtime stays JSON-free.
+    target_link_libraries(qwen3_gguf_bench PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)
     # TTFT benchmark: LMCache cache-hit vs. full-recompute baseline on a synthetic model (see
     # lmcache_bench.cpp's header comment for why a real GGUF isn't needed). Requires a real
     # sidecar venv at runtime (SPARKINFER_LMCACHE_PYTHON/_BRIDGE_SCRIPT), not build time.
@@ -82,7 +87,8 @@ if(BUILD_EXAMPLES)
     target_link_libraries(qwen3_gguf_cb_bench PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)
     add_executable(qwen3_gguf_score examples/qwen3_gguf_score.cpp)
     target_include_directories(qwen3_gguf_score PRIVATE include)
-    target_link_libraries(qwen3_gguf_score PRIVATE sparkinfer_runtime CUDA::cudart)
+    target_link_libraries(qwen3_gguf_score PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)   # same reason as qwen3_gguf_bench above
     add_executable(qwen3_gguf_prefill_check examples/qwen3_gguf_prefill_check.cpp)
     target_include_directories(qwen3_gguf_prefill_check PRIVATE include)
     target_link_libraries(qwen3_gguf_prefill_check PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/examples/qwen38_hf_config.h
+++ b/runtime/examples/qwen38_hf_config.h
@@ -1,0 +1,129 @@
+#pragma once
+
+// Qwen3.8-27B: dense hybrid Gated-DeltaNet/full-attention text model, same architecture
+// family as the existing Qwythos/Qwen3.5-9B dense-hybrid GGUF path (hybrid=true,
+// dense_ffn=true) but with its own dimensions and, crucially, an independent
+// linear-attention head count (24 full-attention heads vs. 16 linear-attention heads --
+// unlike Qwythos where both happen to be 16, see the note at cfg.linear_q_heads below).
+// The vision tower and MTP head are intentionally not modeled here (text-only, no MTP --
+// see the Qwen3.8-27B plan). No GGUF exists for this model; config comes straight from the
+// HF checkout's config.json (`text_config` block) + generation_config.json (stop-token
+// ids), which is a flat, standard-key JSON file -- no namespace-fallback-chain archaeology
+// like qwen3_gguf_config.h's GGUF-metadata reads need.
+//
+// Only included by server/src/model_engine.cpp today, which already links nlohmann_json
+// (see server/CMakeLists.txt) -- the runtime library itself links no JSON dependency (see
+// runtime/src/safetensors.cpp's own hand-rolled parser for why), so this header is
+// deliberately kept out of runtime/src/ and only pulled in by a translation unit that
+// already has the dependency, mirroring where qwen3_gguf_config.h itself lives.
+
+#include "sparkinfer/models/qwen_config.h"
+
+#include <fstream>
+#include <string>
+#include <nlohmann/json.hpp>
+
+static bool qwen38_config_from_hf_json(const std::string& model_dir,
+                                       sparkinfer::Qwen35Config& cfg, std::string& err) {
+    std::ifstream cf(model_dir + "/config.json");
+    if (!cf) { err = "config.json not found in " + model_dir; return false; }
+    nlohmann::json root;
+    try {
+        cf >> root;
+    } catch (const std::exception& e) {
+        err = std::string("config.json parse error: ") + e.what();
+        return false;
+    }
+    if (!root.contains("text_config") || !root["text_config"].is_object()) {
+        err = "config.json missing text_config block";
+        return false;
+    }
+    const auto& tc = root["text_config"];
+
+    auto geti = [&](const char* key, int def) {
+        return tc.contains(key) && tc[key].is_number_integer() ? tc[key].get<int>() : def;
+    };
+    auto getf = [&](const char* key, float def) {
+        return tc.contains(key) && tc[key].is_number() ? tc[key].get<float>() : def;
+    };
+
+    cfg.hidden     = geti("hidden_size", cfg.hidden);
+    cfg.n_layers   = geti("num_hidden_layers", cfg.n_layers);
+    cfg.vocab      = geti("vocab_size", cfg.vocab);
+    cfg.n_q_heads  = geti("num_attention_heads", cfg.n_q_heads);
+    cfg.n_kv_heads = geti("num_key_value_heads", cfg.n_kv_heads);
+    cfg.head_dim   = geti("head_dim", cfg.head_dim);
+    cfg.rms_eps    = getf("rms_norm_eps", cfg.rms_eps);
+
+    // rope_theta lives nested under text_config.rope_parameters, not at text_config's own
+    // top level (unlike partial_rotary_factor below, which happens to be duplicated at both
+    // levels) -- confirmed against the actual released config.json, not assumed.
+    float partial_rotary = 1.f;
+    if (tc.contains("rope_parameters") && tc["rope_parameters"].is_object()) {
+        const auto& rp = tc["rope_parameters"];
+        if (rp.contains("rope_theta") && rp["rope_theta"].is_number())
+            cfg.rope_theta = rp["rope_theta"].get<float>();
+        if (rp.contains("partial_rotary_factor") && rp["partial_rotary_factor"].is_number())
+            partial_rotary = rp["partial_rotary_factor"].get<float>();
+    }
+    partial_rotary = getf("partial_rotary_factor", partial_rotary);   // top-level override/fallback
+
+    // Dense FFN (no MoE routing) -- single intermediate_size, reuses the dense-hybrid
+    // ("Qwythos") code path via moe_ffn repurposed as the single dense FFN width, same as
+    // museglimmer_config_from_gguf does for Muse Glimmer's own dense FFN.
+    cfg.dense_ffn = true;
+    cfg.n_experts = 1; cfg.top_k = 1; cfg.n_shared = 0;
+    cfg.moe_ffn = geti("intermediate_size", cfg.moe_ffn);
+
+    // Hybrid Gated-DeltaNet stack: 3 linear-attention layers per 1 full-attention layer.
+    cfg.hybrid = true;
+    cfg.full_attn_interval = geti("full_attention_interval", 4);
+    cfg.rope_dim = (int)(partial_rotary * cfg.head_dim);
+    // Deliberately NOT cfg.n_q_heads -- that shortcut (qwen3_gguf_config.h:136,157) only
+    // holds for the existing Qwythos/Qwen3.5-9B model, where both head counts happen to be
+    // 16. Here they differ (24 full-attention heads vs. 16 linear-attention heads), so the
+    // linear-attention head count MUST be read from its own key, never derived from n_q_heads.
+    cfg.linear_q_heads     = geti("linear_num_key_heads", cfg.linear_q_heads);
+    cfg.linear_v_heads     = geti("linear_num_value_heads", cfg.linear_v_heads);
+    cfg.linear_head_dim    = geti("linear_key_head_dim", cfg.linear_head_dim);
+    cfg.linear_conv_kernel = geti("linear_conv_kernel_dim", cfg.linear_conv_kernel);
+
+    // NOTE: the full-attention output gate is a plain SIGMOID (attn * sigmoid(gate)), the same as
+    // every other model here -- despite this config's output_gate_type: "swish", which does NOT
+    // describe that multiply. Confirmed against llama.cpp's qwen35 implementation (ggml_sigmoid on
+    // the gate view) and its coherent reference output. Using SiLU sign-flips the gated attention
+    // output (the gate is strongly negative, mean ~ -4.5) and corrupts every layer from the first
+    // full-attention one onward, so do not "fix" this to match the config string.
+    cfg.qwen38 = true;
+
+    // See Qwen35Config::gdn_qh_block's own comment -- this checkpoint's GDN v-head layout needs
+    // block broadcast, not the cyclic convention Qwythos/Qwen3.6-35B-A3B validated.
+    cfg.gdn_qh_block = true;
+
+    cfg.muse_glimmer = false;
+
+    // Stop tokens: generation_config.json's eos_token_id is a LIST here (unlike GGUF's single
+    // scalar metadata key) -- e.g. [248046, 248044]. Falls back to config.json's own
+    // (singular) eos_token_id if generation_config.json is missing or malformed.
+    cfg.eos_id = -1;
+    cfg.eos_id2 = -1;
+    std::ifstream gf(model_dir + "/generation_config.json");
+    if (gf) {
+        nlohmann::json groot;
+        try { gf >> groot; } catch (const std::exception&) { /* fall through to config.json below */ }
+        if (groot.contains("eos_token_id")) {
+            if (groot["eos_token_id"].is_array()) {
+                const auto& arr = groot["eos_token_id"];
+                if (arr.size() > 0 && arr[0].is_number_integer()) cfg.eos_id = arr[0].get<int>();
+                if (arr.size() > 1 && arr[1].is_number_integer()) cfg.eos_id2 = arr[1].get<int>();
+            } else if (groot["eos_token_id"].is_number_integer()) {
+                cfg.eos_id = groot["eos_token_id"].get<int>();
+            }
+        }
+    }
+    if (cfg.eos_id < 0) cfg.eos_id = geti("eos_token_id", 151645);
+
+    return true;
+}
+
+static const char* qwen38_model_label() { return "Qwen3.8-27B dense hybrid (text-only)"; }

--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -3,7 +3,7 @@
 // llama.cpp's `llama-bench` tg number on the same model + GPU.
 //
 // Single context:
-//   qwen3_gguf_bench <model.gguf | weight_dir> [n_tokens] [context_tokens]
+//   qwen3_gguf_bench <model.gguf | compressed-tensors dir | weight_dir> [n_tokens] [context_tokens]
 //
 // Multi-context sweep (one load, many contexts) — set SPARKINFER_BENCH_SWEEP_CTXS:
 //   qwen3_gguf_bench <model> [n_tokens] sweep
@@ -17,6 +17,7 @@
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/moe/engine.h"
 #include "qwen3_gguf_config.h"
+#include "qwen_checkpoint.h"
 
 #include <cuda_runtime.h>
 #include <cstdio>
@@ -27,10 +28,6 @@
 #include <unordered_map>
 #include <algorithm>
 #include <memory>
-
-static bool ends_with(const std::string& s, const std::string& suf) {
-    return s.size() >= suf.size() && s.compare(s.size() - suf.size(), suf.size(), suf) == 0;
-}
 
 static std::vector<int> parse_ctx_list(const char* csv) {
     std::vector<int> out;
@@ -61,10 +58,10 @@ static double median_val(std::vector<double> v) {
     return v[(v.size() - 1) / 2];
 }
 
-static void print_bench_block(const sparkinfer::Qwen35Config& cfg, bool gguf_mode,
+static void print_bench_block(const sparkinfer::Qwen35Config& cfg, const char* quant_label,
                               size_t vram_used, int n_tokens, const SweepRow& row) {
     printf("\n=== sparkinfer bench (%s) sweep ctx=%d ===\n",
-           gguf_mode ? "Q4_K_M native" : "bf16", row.ctx);
+           quant_label, row.ctx);
     printf("model        : %d layers, %d experts top-%d\n",
            cfg.n_layers, cfg.n_experts, cfg.top_k);
     printf("VRAM used    : %.1f GB\n", vram_used / 1e9);
@@ -78,7 +75,7 @@ static void print_bench_block(const sparkinfer::Qwen35Config& cfg, bool gguf_mod
 
 struct BenchSession {
     sparkinfer::Qwen35Config cfg{};
-    bool gguf_mode = false;
+    QwenCheckpointKind kind = QwenCheckpointKind::Gguf;
     std::unique_ptr<sparkinfer::Runtime> rt;
     std::unique_ptr<sparkinfer::KVCacheManager> kv;
     std::unique_ptr<sparkinfer::moe::MoEEngine> engine;
@@ -87,12 +84,13 @@ struct BenchSession {
 };
 
 static bool init_session(BenchSession& s, const std::string& path, int max_ctx, int n_tokens) {
-    s.gguf_mode = ends_with(path, ".gguf");
-    if (s.gguf_mode) {
-        sparkinfer::GGUF g;
-        if (!g.open(path)) { printf("[FAIL] open gguf\n"); return false; }
-        qwen3_config_from_gguf(g, s.cfg);
-    } else {
+    sparkinfer::GGUF g;
+    std::string cperr;
+    if (!qwen_checkpoint_open(path, s.cfg, g, s.kind, cperr)) {
+        printf("[FAIL] %s\n", cperr.c_str());
+        return false;
+    }
+    if (s.kind == QwenCheckpointKind::LegacyWeightDir) {
         std::ifstream f(path + "/config.txt");
         std::string line;
         std::unordered_map<std::string, std::string> m;
@@ -139,9 +137,8 @@ static bool init_session(BenchSession& s, const std::string& path, int max_ctx, 
     s.engine = sparkinfer::moe::MoEEngine::create(mc);
     s.model = std::make_unique<sparkinfer::Qwen35Model>(s.cfg, s.kv.get(), s.engine.get());
 
-    printf("loading %s (%s) ...\n", path.c_str(),
-           s.gguf_mode ? "native GGUF, experts quantized" : "bf16");
-    bool ok = s.gguf_mode ? s.model->load_gguf(path) : s.model->load_weights(path);
+    printf("loading %s (%s) ...\n", path.c_str(), qwen_checkpoint_kind_label(s.kind));
+    bool ok = qwen_checkpoint_load(*s.model, path, s.kind);
     if (!ok) { printf("[FAIL] load\n"); return false; }
     size_t freeb = 0, totb = 0;
     cudaMemGetInfo(&freeb, &totb);
@@ -185,7 +182,7 @@ static int run_single(const std::string& path, int n_tokens, int context_tokens)
 
     auto bench = s.model->bench_decode(8, n_tokens, context_tokens);
     auto gpu = sparkinfer::query_gpu_stats();
-    printf("\n=== sparkinfer bench (%s) ===\n", s.gguf_mode ? "Q4_K_M native" : "bf16");
+    printf("\n=== sparkinfer bench (%s) ===\n", qwen_checkpoint_kind_label(s.kind));
     printf("model        : %s  (%d layers, %d experts top-%d)\n",
            qwen3_model_label(s.cfg), s.cfg.n_layers, s.cfg.n_experts, s.cfg.top_k);
     printf("VRAM used    : %.1f GB\n", s.vram_used / 1e9);
@@ -234,7 +231,7 @@ static int run_sweep(const std::string& path, int n_tokens, const std::vector<in
         row.decode_tps = median_val(dec);
         row.prefill_pp = ctx > 0 ? median_val(pp) : 0.0;
         rows.push_back(row);
-        print_bench_block(s.cfg, s.gguf_mode, s.vram_used, n_tokens, row);
+        print_bench_block(s.cfg, qwen_checkpoint_kind_label(s.kind), s.vram_used, n_tokens, row);
     }
 
     auto gpu = sparkinfer::query_gpu_stats();
@@ -257,7 +254,7 @@ static int run_sweep(const std::string& path, int n_tokens, const std::vector<in
 
 int main(int argc, char** argv) {
     if (argc < 2) {
-        printf("usage: %s <model.gguf|weight_dir> [n_tokens] [context_tokens|sweep]\n", argv[0]);
+        printf("usage: %s <model.gguf|compressed-tensors dir|weight_dir> [n_tokens] [context_tokens|sweep]\n", argv[0]);
         printf("  sweep: SPARKINFER_BENCH_SWEEP_CTXS=0,4096,... %s <model> [n_tokens] sweep\n", argv[0]);
         return 2;
     }

--- a/runtime/examples/qwen3_gguf_config.h
+++ b/runtime/examples/qwen3_gguf_config.h
@@ -108,6 +108,13 @@ static void qwen3_config_from_gguf(const sparkinfer::GGUF& g, sparkinfer::Qwen35
         return;
     }
     cfg.n_layers   = (int)qwen3_meta_int(g, "block_count", cfg.n_layers);
+    // A trailing MTP (multi-token-prediction) block ships as one extra full transformer
+    // layer plus its own blk.{n}.nextn.* projection/norm tensors (Qwen3.8-27B: block_count=65,
+    // nextn_predict_layers=1 -- the real hybrid stack is 64 layers). MTP is out of scope for
+    // this runtime -- shrinking n_layers here is enough to keep the per-layer load loop
+    // (0..n_layers-1) from ever touching the extra block; no separate skip logic needed. No-op
+    // when the key is absent (every GGUF without an MTP head, including the current Qwythos one).
+    cfg.n_layers  -= (int)qwen3_meta_int(g, "nextn_predict_layers", 0);
     cfg.hidden     = (int)qwen3_meta_int(g, "embedding_length", cfg.hidden);
     cfg.n_q_heads  = (int)qwen3_meta_int(g, "attention.head_count", cfg.n_q_heads);
     cfg.n_kv_heads = (int)qwen3_meta_int(g, "attention.head_count_kv", cfg.n_kv_heads);
@@ -133,16 +140,36 @@ static void qwen3_config_from_gguf(const sparkinfer::GGUF& g, sparkinfer::Qwen35
         cfg.moe_ffn = (int)qwen3_meta_int(g, "feed_forward_length", cfg.moe_ffn);
         cfg.full_attn_interval = (int)qwen3_meta_int(g, "full_attention_interval", 4);
         cfg.rope_dim = (int)qwen3_meta_int(g, "rope.dimension_count", 64);
-        cfg.linear_q_heads = cfg.n_q_heads;
-        cfg.linear_v_heads = (int)qwen3_meta_int(g, "ssm.group_count", cfg.linear_v_heads);
+        // linear_q_heads must NOT be assumed equal to n_q_heads -- that happens to hold for
+        // the original Qwythos/Qwen3.5-9B export (both 16) but is false for e.g. Qwen3.8-27B
+        // (24 full-attention heads vs. 16 linear-attention heads). ssm.group_count is the
+        // linear-attention QK head count in every hybrid GGUF export seen so far (confirmed
+        // against Qwen3.8-27B's own metadata: group_count=16, matching its HF config's
+        // linear_num_key_heads); fall back to n_q_heads only when the key is absent, which
+        // preserves the exact prior behavior for any GGUF that doesn't export it.
+        cfg.linear_q_heads = (int)qwen3_meta_int(g, "ssm.group_count", cfg.n_q_heads);
         cfg.linear_head_dim = (int)qwen3_meta_int(g, "ssm.state_size", cfg.linear_head_dim);
         cfg.linear_conv_kernel = (int)qwen3_meta_int(g, "ssm.conv_kernel", cfg.linear_conv_kernel);
+        // linear_v_heads is derived from blk.0.attn_qkv.weight's real shape below, not read
+        // from metadata directly -- no single GGUF key reliably holds it across exports (this
+        // model's own v-head count lives under ssm.time_step_rank, a key the derivation below
+        // makes redundant once linear_q_heads is correct).
         if (const sparkinfer::GGUFTensor* qkv = g.tensor("blk.0.attn_qkv.weight")) {
             const int qkv_out = qkv->n_dims >= 2 ? (int)qkv->dims[1] : 0;
             const int q_dim = cfg.linear_q_heads * cfg.linear_head_dim;
             const int v_dim = qkv_out - 2 * q_dim;
             if (v_dim > 0 && v_dim % cfg.linear_head_dim == 0)
                 cfg.linear_v_heads = v_dim / cfg.linear_head_dim;
+        }
+        // Qwen3.8-27B's GGUF (unsloth conversion) only carries one EOS id in
+        // tokenizer.ggml.eos_token_id (248046); the model's own generation_config.json lists a
+        // second (248044) that GGUF metadata drops entirely. nextn_predict_layers presence is
+        // used as the detection signal for "this is the MTP-capable Qwen3.8-27B family" rather
+        // than a raw architecture/name string match, since it's the same signal already read
+        // above and is specific to this family (Qwythos has no MTP head).
+        if (qwen3_meta_int(g, "nextn_predict_layers", 0) > 0) {
+            cfg.eos_id2 = 248044;
+            cfg.qwen38 = true;
         }
         return;
     }
@@ -170,6 +197,6 @@ static void qwen3_config_from_gguf(const sparkinfer::GGUF& g, sparkinfer::Qwen35
 
 static const char* qwen3_model_label(const sparkinfer::Qwen35Config& cfg) {
     if (cfg.muse_glimmer) return "Muse Glimmer 30B";
-    if (cfg.dense_ffn) return "Qwen3.5-9B dense hybrid";
+    if (cfg.dense_ffn) return cfg.eos_id2 == 248044 ? "Qwen3.8-27B dense hybrid" : "Qwen3.5-9B dense hybrid";
     return cfg.hybrid ? "Qwen3.5/Qwen3.6-35B-A3B hybrid" : "Qwen3-MoE";
 }

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -13,6 +13,7 @@
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/moe/engine.h"
 #include "qwen3_gguf_config.h"
+#include "qwen_checkpoint.h"
 
 #include <cuda_runtime.h>
 #include <cstdio>
@@ -23,7 +24,7 @@
 #include <algorithm>
 
 int main(int argc, char** argv) {
-    if (argc < 4) { printf("usage: %s <model.gguf> <topk> <id0> <id1> ...\n", argv[0]); return 2; }
+    if (argc < 4) { printf("usage: %s <model.gguf|compressed-tensors dir> <topk> <id0> <id1> ...\n", argv[0]); return 2; }
     int ndev = 0;
     if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) { printf("[SKIP] no GPU\n"); return 0; }
 
@@ -40,9 +41,17 @@ int main(int argc, char** argv) {
     if ((int)toks.size() < 2) { printf("[FAIL] need >= 2 tokens\n"); return 1; }
 
     sparkinfer::GGUF g;
-    if (!g.open(path)) { printf("[FAIL] cannot open %s\n", path.c_str()); return 1; }
     sparkinfer::Qwen35Config cfg;
-    qwen3_config_from_gguf(g, cfg);
+    QwenCheckpointKind ckind = QwenCheckpointKind::Gguf;
+    std::string cperr;
+    if (!qwen_checkpoint_open(path, cfg, g, ckind, cperr)) {
+        printf("[FAIL] %s\n", cperr.c_str());
+        return 1;
+    }
+    if (ckind == QwenCheckpointKind::LegacyWeightDir) {
+        printf("[FAIL] legacy weight dirs are not scoreable (no config.txt reader here)\n");
+        return 1;
+    }
     cfg.max_seq    = 2048;
     if (const char* e = getenv("SPARKINFER_SCORE_MAX_SEQ")) {
         int v = atoi(e);
@@ -76,7 +85,10 @@ int main(int argc, char** argv) {
     mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;
     auto engine = sparkinfer::moe::MoEEngine::create(mc);
     sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
-    if (!model.load_gguf(path)) { printf("[FAIL] load_gguf\n"); return 1; }
+    if (!qwen_checkpoint_load(model, path, ckind)) {
+        printf("[FAIL] load (%s)\n", qwen_checkpoint_kind_label(ckind));
+        return 1;
+    }
     // forward_token() reads the KV block table for seq 0 (the model's default
     // seq_id); generate() allocates it — do the same here before scoring.
     if (!kv.allocate(0, cfg.max_seq)) { printf("[FAIL] KV allocate\n"); return 1; }

--- a/runtime/examples/qwen_checkpoint.h
+++ b/runtime/examples/qwen_checkpoint.h
@@ -1,0 +1,112 @@
+#pragma once
+
+// Shared "what is this -m path, and how do I configure a Qwen35Config for it" helper for the
+// example/benchmark binaries.
+//
+// Three checkpoint shapes ship today:
+//   *.gguf                     -> config from GGUF metadata      -> Qwen35Model::load_gguf
+//   dir with quantization_config in config.json
+//                              -> config from HF config.json     -> load_compressed_tensors
+//                                 (HuggingFace "compressed-tensors" mixed FP8/NVFP4, e.g.
+//                                  unsloth/Qwen3.8-27B-NVFP4)
+//   dir with a legacy config.txt
+//                              -> flat key=value + .bin blobs    -> load_weights
+//                                 (runtime/tools/convert_qwen35.py output)
+//
+// This mirrors server/src/model_engine.cpp's own dispatch deliberately: the PR eval bot benchmarks
+// and teacher-forced-scores the SAME checkpoint the server serves, so a benchmark that configured
+// the model even slightly differently would be measuring something nobody ships. Keeping the
+// detection in one header means the two cannot drift.
+//
+// Requires nlohmann_json, which is why this lives in runtime/examples/ (example EXECUTABLES link
+// it; the sparkinfer_runtime library still does not -- see qwen38_hf_config.h's own comment).
+
+#include "sparkinfer/gguf.h"
+#include "sparkinfer/models/qwen_config.h"
+#include "qwen3_gguf_config.h"
+#include "qwen38_hf_config.h"
+
+#include <sys/stat.h>
+
+#include <fstream>
+#include <string>
+
+#include <nlohmann/json.hpp>
+
+enum class QwenCheckpointKind {
+    Gguf,               // *.gguf
+    CompressedTensors,  // HF dir, config.json has quantization_config (NVFP4/FP8)
+    LegacyWeightDir,    // dir with config.txt + .bin blobs
+};
+
+// Detects the checkpoint shape at `path` and populates `cfg`. `gguf_out` is opened only for the
+// Gguf kind (the caller keeps it alive for load_gguf). Returns false with `err` set on any
+// malformed input -- never guesses, since a silently-wrong config reads as a plausible-but-wrong
+// benchmark number rather than a crash.
+inline bool qwen_checkpoint_open(const std::string& path,
+                                 sparkinfer::Qwen35Config& cfg,
+                                 sparkinfer::GGUF& gguf_out,
+                                 QwenCheckpointKind& kind_out,
+                                 std::string& err) {
+    struct stat st {};
+    const bool is_dir = stat(path.c_str(), &st) == 0 && S_ISDIR(st.st_mode);
+
+    if (!is_dir) {
+        kind_out = QwenCheckpointKind::Gguf;
+        if (!gguf_out.open(path)) { err = "cannot open GGUF " + path; return false; }
+        qwen3_config_from_gguf(gguf_out, cfg);
+        return true;
+    }
+
+    // A legacy convert_qwen35.py directory is identified by config.txt; anything else with a
+    // config.json is an HF checkout. Check config.txt FIRST so an HF checkout that happens to
+    // carry both is still read as HF (config.json is the richer, authoritative one).
+    {
+        std::ifstream jf(path + "/config.json");
+        if (jf) {
+            nlohmann::json root;
+            try {
+                jf >> root;
+            } catch (const std::exception& e) {
+                err = path + "/config.json parse error: " + e.what();
+                return false;
+            }
+            if (!root.contains("quantization_config")) {
+                err = path + " is a plain (unquantized) safetensors checkout -- not supported by "
+                             "this tool; only compressed-tensors (NVFP4/FP8) directories are";
+                return false;
+            }
+            kind_out = QwenCheckpointKind::CompressedTensors;
+            return qwen38_config_from_hf_json(path, cfg, err);
+        }
+    }
+
+    std::ifstream tf(path + "/config.txt");
+    if (!tf) {
+        err = path + " is a directory but has neither config.json nor config.txt";
+        return false;
+    }
+    kind_out = QwenCheckpointKind::LegacyWeightDir;
+    return true;   // caller parses config.txt itself (legacy, tool-specific key set)
+}
+
+// Loads weights for a checkpoint already described by `kind`.
+inline bool qwen_checkpoint_load(sparkinfer::Qwen35Model& model,
+                                 const std::string& path,
+                                 QwenCheckpointKind kind) {
+    switch (kind) {
+        case QwenCheckpointKind::Gguf:              return model.load_gguf(path);
+        case QwenCheckpointKind::CompressedTensors: return model.load_compressed_tensors(path);
+        case QwenCheckpointKind::LegacyWeightDir:   return model.load_weights(path);
+    }
+    return false;
+}
+
+inline const char* qwen_checkpoint_kind_label(QwenCheckpointKind kind) {
+    switch (kind) {
+        case QwenCheckpointKind::Gguf:              return "native GGUF, experts quantized";
+        case QwenCheckpointKind::CompressedTensors: return "compressed-tensors NVFP4/FP8";
+        case QwenCheckpointKind::LegacyWeightDir:   return "bf16";
+    }
+    return "?";
+}

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -141,6 +141,9 @@ public:
     // dequantized to bf16; expert tensors are kept quantized in VRAM and
     // dequantized per-layer at decode time (Q4_K_M-sized resident footprint).
     bool load_gguf(const std::string& path);
+    // HuggingFace "compressed-tensors" mixed FP8/NVFP4 checkpoint (e.g. unsloth/Qwen3.8-27B-NVFP4)
+    // -- see runtime/src/models/qwen35.cpp's own comment on the function for the exact scheme.
+    bool load_compressed_tensors(const std::string& model_dir);
 
     // Greedy generate: prompt token ids -> generated token ids (host). An optional ThermalGovernor
     // paces decode under thermal pressure (accuracy-preserving); nullptr = full speed, no overhead.

--- a/runtime/include/sparkinfer/models/qwen_config.h
+++ b/runtime/include/sparkinfer/models/qwen_config.h
@@ -35,6 +35,17 @@ struct Qwen35Config {
     int   linear_v_heads = 32;
     int   linear_head_dim = 128;
     int   linear_conv_kernel = 4;
+    // "This is a Qwen3.8-27B-family checkpoint" -- drives server-side chat-template behaviour only
+    // (ModelEngine::is_qwen38: reasoning-effort system message, enable_thinking default). Its
+    // full-attention output gate is a plain sigmoid like every other model here, despite the HF
+    // config's output_gate_type: "swish" -- see qwen38_hf_config.h for why that string is a trap.
+    bool  qwen38 = false;
+    // GDN's v-head -> q/k-head broadcast convention (kernels::launch_qwen36_gdn_ar). false =
+    // cyclic (vh % linear_q_heads), validated for Qwythos/Qwen3.6-35B-A3B (v/q ratio 2). true =
+    // block (vh / (linear_v_heads/linear_q_heads)), which Qwen3.8-27B's checkpoint needs instead
+    // (ratio 3) -- the two checkpoints' own v-head layout conventions differ despite the shared
+    // architecture family, confirmed empirically against a real reference implementation.
+    bool  gdn_qh_block = false;
 
     // Qwythos / Qwen3.5-9B dense hybrid GGUFs use a single SwiGLU FFN per layer
     // (ffn_gate/up/down) instead of routed experts.

--- a/runtime/include/sparkinfer/safetensors.h
+++ b/runtime/include/sparkinfer/safetensors.h
@@ -1,0 +1,60 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace sparkinfer {
+
+// safetensors dtype tags, as they appear in the format's JSON header.
+enum class STDType { F32, F16, BF16, I64, I32, I8, U8, F8_E4M3, Unknown };
+
+struct STTensor {
+    STDType dtype = STDType::Unknown;
+    int     n_dims = 0;
+    long    dims[4] = {1, 1, 1, 1};   // row-major, dims[0] slowest (matches safetensors' own order)
+    long    n_values = 0;
+    long    n_bytes = 0;
+    const void* data = nullptr;       // pointer into the owning shard's mmap
+};
+
+// One safetensors shard: mmaps the file, parses the flat JSON header (tensor name ->
+// {dtype, shape, data_offsets}), resolves tensor data pointers. No nesting beyond one
+// level in a safetensors header, so this is a small hand-written parser rather than a
+// general JSON library -- mirrors gguf.h/gguf.cpp's dependency-free, mmap-based design
+// (the runtime library links no JSON dependency; that's server-only).
+class SafeTensorsShard {
+public:
+    ~SafeTensorsShard();
+    bool open(const std::string& path);
+
+    const STTensor* tensor(const std::string& name) const;
+    const std::unordered_map<std::string, STTensor>& tensors() const { return tensors_; }
+
+private:
+#ifndef _WIN32
+    int    fd_ = -1;
+#else
+    void*  win_file_ = (void*)(intptr_t)-1;
+    void*  win_map_  = nullptr;
+#endif
+    void*  base_ = nullptr;
+    size_t size_ = 0;
+    std::unordered_map<std::string, STTensor> tensors_;
+};
+
+// A full (possibly multi-shard) safetensors model directory: reads
+// model.safetensors.index.json (or a single model.safetensors if unsharded) to learn which
+// shard each tensor lives in, opens every referenced shard, and exposes a single flat
+// tensor(name) lookup across all of them.
+class SafeTensorsModel {
+public:
+    bool open(const std::string& model_dir);
+    const STTensor* tensor(const std::string& name) const;
+
+private:
+    std::vector<SafeTensorsShard> shards_;
+    std::unordered_map<std::string, int> shard_of_;   // tensor name -> index into shards_
+};
+
+} // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -16,6 +16,8 @@
 #include "sparkinfer/thermal_governor.h"
 #include "sparkinfer/kv_ops.h"
 #include "sparkinfer/gguf.h"
+#include "sparkinfer/safetensors.h"
+#include "sparkinfer/kernels/compressed_tensors.h"
 #include "sparkinfer/kernels/attention.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/fused.h"
@@ -28,6 +30,7 @@
 
 #include <cuda_runtime.h>
 #include <cstdio>
+#include <cstring>
 #include <atomic>
 #include <unordered_map>
 #include <cstdlib>
@@ -752,7 +755,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
     // concludes; harmless no-op (env unset) otherwise.
     static int mg_dbg = -1;
     if (mg_dbg < 0) { const char* e = getenv("SPARKINFER_MG_STAGE_DEBUG"); mg_dbg = (e && e[0] == '1') ? 1 : 0; }
-    const bool mgd = c.muse_glimmer && mg_dbg;
+    // Widened to any dense_ffn hybrid model (originally Muse-Glimmer-only) to reuse this
+    // instrumentation for the Qwen3.8-27B bring-up too -- still opt-in via the same env var.
+    const bool mgd = (c.muse_glimmer || c.dense_ffn) && mg_dbg;
     if (mgd && s.graph_ready) {
         cudaGraphExecDestroy(s.cu_exec); cudaGraphDestroy(s.cu_graph);
         s.cu_exec = nullptr; s.cu_graph = nullptr; s.graph_ready = false;
@@ -1239,7 +1244,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                                           s.lin_alpha, s.lin_beta, w.ssm_dt, w.ssm_a,
                                           layer_state, s.lin_gdn,
                                           c.linear_q_heads, c.linear_v_heads,
-                                          c.linear_head_dim, st);
+                                          c.linear_head_dim, c.gdn_qh_block, st);
             if (gdn_pipelined && !gdn_fused_proj) cudaStreamWaitEvent(st, s.ev_gdn_z, 0);
             const bool gdn_gn_q8 = s.gguf && s.use_pq && s.use_llama &&
                                    (w.ssm_out_type == 12 || w.ssm_out_type == 8) &&
@@ -1518,8 +1523,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                                                mg_gate_ok ? 1 : 0);
             }
             dbg_bf16(s.attn, s.qdim, 30, L);   // tag 30: SDPA output, pre-gate
-            if (w.q_has_gate && !attn_gate_q8)
+            if (w.q_has_gate && !attn_gate_q8) {
                 kernels::launch_qwen36_mul_sigmoid(s.attn, s.qgate, s.qdim, st);
+            }
             dbg_bf16(s.attn, s.qdim, 31, L);   // tag 31: SDPA output, post sigmoid-gate
 
             // ---- O projection (main's int8 mmvq path) ----
@@ -1577,8 +1583,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // Q8_1(hn) into aq81 so the MoE gate/up mmvq skips its own quantize node (the
             // router below reads bf16 hn).
             kernels::launch_add_rmsnorm2_q8(s.x, s.ao, w.post_attn_norm, s.h, s.hn, s.aq81, H, c.rms_eps, st);
+            dbg_bf16(s.h, H, 50, L);
+            dbg_bf16(s.hn, H, 51, L);
         } else {
             kernels::launch_add_rmsnorm2(s.x, s.ao, w.post_attn_norm, s.h, s.hn, 1, H, c.rms_eps, st);
+            dbg_bf16(s.h, H, 50, L);
+            dbg_bf16(s.hn, H, 51, L);
         }
 
         const bool qmoe = w.shared_gate_q && w.shared_up_q && w.shared_down_q
@@ -4200,6 +4210,326 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                 down_ready, c.n_layers);
     }
     // decode scratch (mf_* / fa_*) is allocated in the constructor for all paths.
+    return true;
+}
+
+// ----- HuggingFace "compressed-tensors" mixed FP8/NVFP4 checkpoint load -----
+// (e.g. unsloth/Qwen3.8-27B-NVFP4). Scheme, confirmed by direct tensor inspection of the actual
+// checkpoint (not assumed from the format spec alone):
+//   - self_attn.{q,k,v,o}_proj, linear_attn.{in_proj_qkv,in_proj_z,out_proj}, lm_head, and
+//     layers 56-63's mlp.{gate,up,down}_proj: FP8 (E4M3), one BF16 scale per output channel.
+//     ".weight" (F8_E4M3) + ".weight_scale" (BF16, [out_channels,1]).
+//   - every other layer's mlp.{gate,up,down}_proj (the bulk of total params): NVFP4, block_size
+//     16, two-level scale. ".weight_packed" (U8, 2 values/byte) + ".weight_scale" (F8_E4M3 bytes,
+//     interpreted as CUTLASS's unsigned e4m3 -- the standard NVIDIA NVFP4 export convention, not
+//     literally signed e4m3 despite the safetensors dtype tag) + ".weight_global_scale" (F32
+//     scalar).
+//   - everything else (linear_attn's small in_proj_a/in_proj_b/norm, dt_bias, A_log, conv1d,
+//     all *_norm weights): plain bf16 ".weight".
+// HF tensors are [out,in] (PyTorch Linear convention); this runtime's GEMM/GEMV kernels want
+// [in,out] -- every quantized/dequantized tensor below is transposed once at load, same as
+// load_gguf()'s own dense() closure already does for its own transpose=true callers.
+//
+// Every quantized tensor is dequantized to bf16 once (via the new launch_ct_dequant_fp8/
+// launch_ct_dequant_nvfp4 kernels), then requantized into the SAME internal formats load_gguf()
+// already produces for every other model: Q4_K (gate_q/up_q/down_q/wq/wk/wv/wo, decode path,
+// launch_proj_requant_q4k_lloyd) and, for the NVFP4-routed FFN layers only, this runtime's own
+// fresh NVFP4 (gate_fp4/up_fp4, prefill path, launch_prefill_nvfp4_quant_b) -- no new GEMM/GEMV
+// kernels, no checkpoint-provided global scale carried past the initial dequant.
+bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
+    Impl& s = *p_;
+    SafeTensorsModel st;
+    if (!st.open(model_dir)) {
+        fprintf(stderr, "[compressed-tensors] failed to open %s\n", model_dir.c_str());
+        return false;
+    }
+    const Qwen35Config& c = s.cfg;
+    const int H = c.hidden;
+    s.gguf = true;   // reuses the same "dense weights native, kept-quantized attn/ffn" decode shape
+
+    // FP8 tensors' MLP layers -- confirmed by direct inspection of the checkpoint's
+    // quantization_config.config_groups.group_0.targets: layers 56-63 (the last 8 of 64).
+    auto ffn_is_fp8_layer = [](int i) { return i >= 56 && i <= 63; };
+
+    // bf16 upload, no transpose (embeddings, norms, and the small linear_attn gate-scalar
+    // projections that the checkpoint leaves unquantized).
+    auto plain_bf16 = [&](const std::string& name, long n_values) -> const void* {
+        const STTensor* t = st.tensor(name);
+        if (!t) { fprintf(stderr, "[compressed-tensors] missing %s\n", name.c_str()); return nullptr; }
+        if (t->dtype != STDType::BF16 || t->n_values != n_values) {
+            fprintf(stderr, "[compressed-tensors] %s: expected BF16[%ld], got dtype=%d n=%ld\n",
+                    name.c_str(), n_values, (int)t->dtype, t->n_values);
+            return nullptr;
+        }
+        void* d = nullptr;
+        if (cudaMalloc(&d, (size_t)n_values * 2) != cudaSuccess) return nullptr;
+        cudaMemcpy(d, t->data, (size_t)n_values * 2, cudaMemcpyHostToDevice);
+        s.owned.push_back(d);
+        return d;
+    };
+
+    // A_log -> -exp(A_log), applied on the host before upload. The checkpoint stores the raw HF
+    // "A_log" parameter, but the shared GDN kernels (launch_qwen36_gdn_ar and friends, reused
+    // unchanged from Qwythos/Qwen3.6) expect the pre-transformed decay coefficient -- confirmed
+    // by comparing this exact tensor's values against the reference unsloth GGUF for this model
+    // (whose own conversion pipeline applies this same transform): raw HF A_log runs roughly
+    // [-5.6,-1.1], the GGUF's stored values are exp() of that with a sign flip, e.g. -exp(-1.0859)
+    // = -0.3376, matching the GGUF's own max value bit-for-bit. Loading the raw value directly (as
+    // plain_bf16 would) makes every decay gate ~exp(large-negative) instead of ~exp(small-negative)
+    // -- GDN state collapses to near-zero every step, silently (no NaN/Inf) producing coherent-
+    // magnitude but semantically empty hidden states. Covers all 48 linear-attention layers.
+    auto load_a_log_transformed = [&](const std::string& name, long n_values) -> const void* {
+        const STTensor* t = st.tensor(name);
+        if (!t) { fprintf(stderr, "[compressed-tensors] missing %s\n", name.c_str()); return nullptr; }
+        if (t->dtype != STDType::BF16 || t->n_values != n_values) {
+            fprintf(stderr, "[compressed-tensors] %s: expected BF16[%ld], got dtype=%d n=%ld\n",
+                    name.c_str(), n_values, (int)t->dtype, t->n_values);
+            return nullptr;
+        }
+        std::vector<uint16_t> transformed((size_t)n_values);
+        const uint16_t* src = reinterpret_cast<const uint16_t*>(t->data);
+        for (long i = 0; i < n_values; i++) {
+            uint32_t bits = (uint32_t)src[i] << 16;
+            float f; memcpy(&f, &bits, sizeof(f));
+            f = -expf(f);
+            memcpy(&bits, &f, sizeof(bits));
+            transformed[(size_t)i] = (uint16_t)(bits >> 16);
+        }
+        void* d = nullptr;
+        if (cudaMalloc(&d, (size_t)n_values * 2) != cudaSuccess) return nullptr;
+        cudaMemcpy(d, transformed.data(), (size_t)n_values * 2, cudaMemcpyHostToDevice);
+        s.owned.push_back(d);
+        return d;
+    };
+
+    // RMSNorm weight -> 1.0 + weight, applied on the host before upload. This checkpoint stores
+    // norm weights zero-centered (values cluster around 0, e.g. [0.047, -0.063, -0.074, ...] for
+    // layer 0's input_layernorm) rather than the standard one-centered convention every other
+    // model in this codebase uses (values cluster around 1). Confirmed by hand-computing the
+    // RMSNorm output for token "Hi" through layer 0 both ways and comparing against the reference
+    // unsloth/ggml-org GGUF's own eval-callback trace: 1+weight gives sum=-63.79, matching the
+    // reference's attn_norm-0 sum=-65.72 (residual difference is ordinary bf16/eps rounding);
+    // plain weight gives sum=+3.28, off by both sign and two orders of magnitude. Loading the raw
+    // value directly (as plain_bf16 would) multiplies every normalized activation by ~0 instead of
+    // ~1 -- silently attenuating the entire signal path without producing NaN/Inf, which is why
+    // every other numerical check in this bring-up looked "healthy" while generation stayed
+    // incoherent. Applies to 5 of the 6 norm-weight kinds: input_layernorm,
+    // post_attention_layernorm, q_norm, k_norm, and the final norm. NOT linear_attn.norm
+    // (ssm_norm), which this checkpoint stores one-centered like every other model -- verified
+    // per-tensor against the reference GGUF, and confirmed numerically (adding 1 there instead
+    // moved layer 0's residual to 14.4 vs the reference's 8.41, away from the 8.73 it gives now).
+    auto load_norm_plus1 = [&](const std::string& name, long n_values) -> const void* {
+        const STTensor* t = st.tensor(name);
+        if (!t) { fprintf(stderr, "[compressed-tensors] missing %s\n", name.c_str()); return nullptr; }
+        if (t->dtype != STDType::BF16 || t->n_values != n_values) {
+            fprintf(stderr, "[compressed-tensors] %s: expected BF16[%ld], got dtype=%d n=%ld\n",
+                    name.c_str(), n_values, (int)t->dtype, t->n_values);
+            return nullptr;
+        }
+        std::vector<uint16_t> transformed((size_t)n_values);
+        const uint16_t* src = reinterpret_cast<const uint16_t*>(t->data);
+        for (long i = 0; i < n_values; i++) {
+            uint32_t bits = (uint32_t)src[i] << 16;
+            float f; memcpy(&f, &bits, sizeof(f));
+            f = 1.0f + f;
+            memcpy(&bits, &f, sizeof(bits));
+            transformed[(size_t)i] = (uint16_t)(bits >> 16);
+        }
+        void* d = nullptr;
+        if (cudaMalloc(&d, (size_t)n_values * 2) != cudaSuccess) return nullptr;
+        cudaMemcpy(d, transformed.data(), (size_t)n_values * 2, cudaMemcpyHostToDevice);
+        s.owned.push_back(d);
+        return d;
+    };
+
+    // FP8 weight [rows,cols] -> dequant -> bf16 device buffer, layout unchanged. HF stores Linear
+    // weights [out_features,in_features], which is byte-identical to the GGUF-native [out,in] that
+    // every consumer here wants -- launch_gemv (gemm.h: "W is [N,K] row-major ([out,in],
+    // GGUF-native)"), launch_proj_requant_q4k_lloyd (its 256-element Q4_K blocks must run along the
+    // input dim WITHIN one output row), and launch_prefill_nvfp4_quant_b. So no transpose: an
+    // earlier [rows,cols]->[cols,rows] relayout here silently mis-shaped every projection in the
+    // model (q/k/v/o, FFN, lm_head, GDN), which reads as fluent-looking garbage rather than as any
+    // one tensor obviously loading wrong.
+    // Caller requantizes from here (Q4_K for decode; FP8 tensors never get an NVFP4 copy).
+    auto dequant_fp8 = [&](const std::string& prefix, int rows, int cols) -> void* {
+        const STTensor* w = st.tensor(prefix + ".weight");
+        const STTensor* sc = st.tensor(prefix + ".weight_scale");
+        if (!w || !sc || w->dtype != STDType::F8_E4M3 || w->n_values != (long)rows * cols ||
+            sc->n_values != rows) {
+            fprintf(stderr, "[compressed-tensors] %s: missing/malformed FP8 weight or scale\n",
+                    prefix.c_str());
+            return nullptr;
+        }
+        void *wd = nullptr, *scd = nullptr, *out = nullptr;
+        if (cudaMalloc(&wd, (size_t)rows * cols) != cudaSuccess) return nullptr;
+        if (cudaMalloc(&scd, (size_t)rows * 2) != cudaSuccess) { cudaFree(wd); return nullptr; }
+        if (cudaMalloc(&out, (size_t)rows * cols * 2) != cudaSuccess) { cudaFree(wd); cudaFree(scd); return nullptr; }
+        cudaMemcpy(wd, w->data, (size_t)rows * cols, cudaMemcpyHostToDevice);
+        cudaMemcpy(scd, sc->data, (size_t)rows * 2, cudaMemcpyHostToDevice);
+        kernels::launch_ct_dequant_fp8(wd, scd, out, rows, cols, s.stream);
+        cudaStreamSynchronize(s.stream);
+        cudaFree(wd); cudaFree(scd);
+        return out;   // caller owns; either requantizes from it (then frees) or pushes to s.owned
+    };
+
+    // NVFP4 weight [rows,cols] (HF [out,in], block_size=16) -> dequant -> bf16, layout unchanged.
+    auto dequant_nvfp4 = [&](const std::string& prefix, int rows, int cols) -> void* {
+        const STTensor* wp = st.tensor(prefix + ".weight_packed");
+        const STTensor* gs = st.tensor(prefix + ".weight_scale");
+        const STTensor* glob = st.tensor(prefix + ".weight_global_scale");
+        if (!wp || !gs || !glob || wp->dtype != STDType::U8 || wp->n_values != (long)rows * cols / 2 ||
+            gs->n_values != (long)rows * cols / 16 || glob->n_values != 1) {
+            fprintf(stderr, "[compressed-tensors] %s: missing/malformed NVFP4 tensors\n", prefix.c_str());
+            return nullptr;
+        }
+        float global_scale = 1.f;
+        memcpy(&global_scale, glob->data, sizeof(float));
+        void *wpd = nullptr, *gsd = nullptr, *out = nullptr;
+        const size_t packed_bytes = (size_t)rows * cols / 2, scale_bytes = (size_t)rows * cols / 16;
+        if (cudaMalloc(&wpd, packed_bytes) != cudaSuccess) return nullptr;
+        if (cudaMalloc(&gsd, scale_bytes) != cudaSuccess) { cudaFree(wpd); return nullptr; }
+        if (cudaMalloc(&out, (size_t)rows * cols * 2) != cudaSuccess) { cudaFree(wpd); cudaFree(gsd); return nullptr; }
+        cudaMemcpy(wpd, wp->data, packed_bytes, cudaMemcpyHostToDevice);
+        cudaMemcpy(gsd, gs->data, scale_bytes, cudaMemcpyHostToDevice);
+        kernels::launch_ct_dequant_nvfp4(wpd, gsd, global_scale, out, rows, cols, s.stream);
+        cudaStreamSynchronize(s.stream);
+        cudaFree(wpd); cudaFree(gsd);
+        return out;
+    };
+
+    // bf16 [out,in] source -> kept resident as-is (qtype=0), decode reads it via the existing
+    // plain-bf16 launch_gemv fallback in proj_xn/proj_from (the t==0 branch of the same dispatch
+    // Q4_K/Q6_K/Q8_0 share). Used for GDN's projections instead of requant_q4k: these weights are
+    // themselves dequantized from FP8 at load time, and re-quantizing an already-quantized source
+    // to 4 bits a second time compounds error more than a single quantization step from a native
+    // bf16/fp32 checkpoint would.
+    auto keep_bf16 = [&](void* bf16_src, int& qtype) -> const void* {
+        if (!bf16_src) return nullptr;
+        s.owned.push_back(bf16_src);
+        qtype = 0;
+        return bf16_src;
+    };
+
+    // bf16 [out,in] source -> resident Q4_K (decode path). Frees the source.
+    auto requant_q4k = [&](void* bf16_src, long n_values, int& qtype) -> const void* {
+        if (!bf16_src || n_values % 256 != 0) { if (bf16_src) cudaFree(bf16_src); return nullptr; }
+        void* q4 = nullptr;
+        if (cudaMalloc(&q4, (size_t)(n_values / 256) * 144) != cudaSuccess) { cudaFree(bf16_src); return nullptr; }
+        kernels::launch_proj_requant_q4k_lloyd(bf16_src, q4, n_values, s.stream);
+        cudaStreamSynchronize(s.stream);
+        cudaFree(bf16_src);
+        s.owned.push_back(q4);
+        qtype = 12;
+        return q4;
+    };
+
+    // bf16 [out,in] source -> fresh NVFP4 (prefill path, gate_fp4/up_fp4 shape). Does NOT free
+    // bf16_src -- caller (FFN loop below) still needs it for the Q4_K decode copy.
+    auto quantize_nvfp4_prefill = [&](const void* bf16_src, int rows, int cols,
+                                      const void** data, const void** sf) -> bool {
+        if (!bf16_src || !kernels::prefill_nvfp4_supported(128, rows, cols)) return false;
+        void *d = nullptr, *scale = nullptr;
+        if (cudaMalloc(&d, kernels::prefill_nvfp4_data_bytes(rows, cols)) != cudaSuccess) return false;
+        if (cudaMalloc(&scale, kernels::prefill_nvfp4_scale_bytes_b(rows, cols)) != cudaSuccess) {
+            cudaFree(d); return false;
+        }
+        if (!kernels::launch_prefill_nvfp4_quant_b(bf16_src, d, scale, rows, cols, s.stream) ||
+            cudaStreamSynchronize(s.stream) != cudaSuccess) {
+            cudaFree(d); cudaFree(scale); return false;
+        }
+        s.owned.push_back(d); s.owned.push_back(scale);
+        *data = d; *sf = scale;
+        return true;
+    };
+
+    // embed_tokens: HF embedding tables are already [vocab,hidden] (not a Linear layer), no
+    // transpose needed -- matches load_gguf()'s own dense("token_embd.weight", false).
+    s.w.embed_tokens = plain_bf16("model.language_model.embed_tokens.weight", (long)c.vocab * H);
+    s.w.final_norm = load_norm_plus1("model.language_model.norm.weight", H);
+    {
+        void* lmb = dequant_fp8("lm_head", c.vocab, H);
+        s.w.lm_head = requant_q4k(lmb, (long)c.vocab * H, s.w.lm_head_type);
+    }
+    if (!s.w.embed_tokens || !s.w.final_norm || !s.w.lm_head) return false;
+
+    s.w.layers.resize(c.n_layers);
+    int gu_ready = 0;
+    for (int i = 0; i < c.n_layers; i++) {
+        const std::string b = "model.language_model.layers." + std::to_string(i) + ".";
+        Qwen35LayerWeights& w = s.w.layers[i];
+        w.linear_attn = is_linear_layer(c, i);
+        w.input_norm = load_norm_plus1(b + "input_layernorm.weight", H);
+        w.post_attn_norm = load_norm_plus1(b + "post_attention_layernorm.weight", H);
+
+        if (w.linear_attn) {
+            const std::string lb = b + "linear_attn.";
+            void* qkv = dequant_fp8(lb + "in_proj_qkv", s.linear_qkvdim, H);
+            w.wqkv = keep_bf16(qkv, w.wqkv_type);
+            void* z = dequant_fp8(lb + "in_proj_z", c.linear_v_heads * c.linear_head_dim, H);
+            w.wqkv_gate = keep_bf16(z, w.wqkv_gate_type);
+            void* op = dequant_fp8(lb + "out_proj", H, s.linear_vdim);
+            w.ssm_out = keep_bf16(op, w.ssm_out_type);
+            // Small, checkpoint-unquantized tensors -- plain bf16, NO transpose. conv1d's raw HF
+            // layout [qkvdim,1,conv_kernel] (=[qkvdim,conv_kernel] squeezed) already matches
+            // conv_split_kernel's own indexing (conv_w[d*conv_kernel+t], d=channel, t=tap) --
+            // transposing it here was wrong (same bug class as keep_bf16 below: see its comment).
+            // in_proj_a/in_proj_b are ordinary HF Linear weights [out,in]=[v_heads,H], which is
+            // exactly what proj_xn's plain-bf16 launch_gemv fallback wants (gemm.h: "[N,K]
+            // row-major ([out,in], GGUF-native)") -- transposing them to [H,v_heads] was wrong
+            // for the same reason. Root-caused via the same byte-level cross-check against
+            // llama.cpp that found the keep_bf16 transpose bug: alpha/beta projections summed to
+            // 10.8/3.2 in this runtime vs. 108.6/79.7 in the reference trace, and neither tensor
+            // goes through conv at all, ruling out the conv1d weight as their cause and pointing
+            // straight at their own [out,in]-vs-[in,out] mismatch.
+            w.ssm_dt = plain_bf16(lb + "dt_bias", c.linear_v_heads);
+            w.ssm_a = load_a_log_transformed(lb + "A_log", c.linear_v_heads);
+            w.ssm_norm = plain_bf16(lb + "norm.weight", c.linear_head_dim);
+            w.ssm_conv = plain_bf16(lb + "conv1d.weight", (long)s.linear_qkvdim * c.linear_conv_kernel);
+            w.ssm_alpha = plain_bf16(lb + "in_proj_a.weight", (long)c.linear_v_heads * H);
+            w.ssm_beta = plain_bf16(lb + "in_proj_b.weight", (long)c.linear_v_heads * H);
+            if (!w.wqkv || !w.wqkv_gate || !w.ssm_out || !w.ssm_dt || !w.ssm_a || !w.ssm_norm ||
+                !w.ssm_conv || !w.ssm_alpha || !w.ssm_beta) return false;
+        } else {
+            w.q_has_gate = c.hybrid;
+            const std::string ab = b + "self_attn.";
+            const int q_out = w.q_has_gate ? s.qdim * 2 : s.qdim;
+            void* q = dequant_fp8(ab + "q_proj", q_out, H);
+            w.wq = requant_q4k(q, (long)q_out * H, w.wq_type);
+            void* k = dequant_fp8(ab + "k_proj", s.kvdim, H);
+            w.wk = requant_q4k(k, (long)s.kvdim * H, w.wk_type);
+            void* v = dequant_fp8(ab + "v_proj", s.kvdim, H);
+            w.wv = requant_q4k(v, (long)s.kvdim * H, w.wv_type);
+            void* o = dequant_fp8(ab + "o_proj", H, s.qdim);
+            w.wo = requant_q4k(o, (long)H * s.qdim, w.wo_type);
+            w.q_norm = load_norm_plus1(ab + "q_norm.weight", c.head_dim);
+            w.k_norm = load_norm_plus1(ab + "k_norm.weight", c.head_dim);
+            if (!w.wq || !w.wk || !w.wv || !w.wo || !w.q_norm || !w.k_norm) return false;
+        }
+
+        const std::string mb = b + "mlp.";
+        if (ffn_is_fp8_layer(i)) {
+            void* g = dequant_fp8(mb + "gate_proj", c.moe_ffn, H);
+            w.gate_q = requant_q4k(g, (long)c.moe_ffn * H, w.gate_qtype);
+            void* u = dequant_fp8(mb + "up_proj", c.moe_ffn, H);
+            w.up_q = requant_q4k(u, (long)c.moe_ffn * H, w.up_qtype);
+            void* d = dequant_fp8(mb + "down_proj", H, c.moe_ffn);
+            w.down_q = requant_q4k(d, (long)H * c.moe_ffn, w.down_qtype);
+        } else {
+            void* g_bf16 = dequant_nvfp4(mb + "gate_proj", c.moe_ffn, H);
+            void* u_bf16 = dequant_nvfp4(mb + "up_proj", c.moe_ffn, H);
+            void* d_bf16 = dequant_nvfp4(mb + "down_proj", H, c.moe_ffn);
+            bool gu_ok = g_bf16 && u_bf16 &&
+                quantize_nvfp4_prefill(g_bf16, c.moe_ffn, H, &w.gate_fp4, &w.gate_fp4_sf) &&
+                quantize_nvfp4_prefill(u_bf16, c.moe_ffn, H, &w.up_fp4, &w.up_fp4_sf);
+            if (gu_ok) ++gu_ready;
+            w.gate_q = requant_q4k(g_bf16, (long)c.moe_ffn * H, w.gate_qtype);
+            w.up_q = requant_q4k(u_bf16, (long)c.moe_ffn * H, w.up_qtype);
+            w.down_q = requant_q4k(d_bf16, (long)H * c.moe_ffn, w.down_qtype);
+        }
+        if (!w.gate_q || !w.up_q || !w.down_q) return false;
+    }
+    fprintf(stderr, "[compressed-tensors] loaded %d layers, gate/up NVFP4 prefill ready %d/%d\n",
+            c.n_layers, gu_ready, c.n_layers);
     return true;
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4226,9 +4226,11 @@ bool Qwen35Model::load_gguf(const std::string& path) {
 //     scalar).
 //   - everything else (linear_attn's small in_proj_a/in_proj_b/norm, dt_bias, A_log, conv1d,
 //     all *_norm weights): plain bf16 ".weight".
-// HF tensors are [out,in] (PyTorch Linear convention); this runtime's GEMM/GEMV kernels want
-// [in,out] -- every quantized/dequantized tensor below is transposed once at load, same as
-// load_gguf()'s own dense() closure already does for its own transpose=true callers.
+// HF tensors are [out,in] (PyTorch Linear convention), which is byte-identical to the GGUF-native
+// [out,in] this runtime's GEMM/GEMV kernels already want -- so nothing below is transposed. An
+// earlier revision of this loader DID relayout to [in,out], on the assumption stated in this very
+// comment, and silently mis-shaped every projection in the model; see the dequant_fp8 comment for
+// the three kernels whose contracts pin the layout down.
 //
 // Every quantized tensor is dequantized to bf16 once (via the new launch_ct_dequant_fp8/
 // launch_ct_dequant_nvfp4 kernels), then requantized into the SAME internal formats load_gguf()

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -372,9 +372,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool muse_nvfp4 = c.muse_glimmer && N == 128 && !s.w.layers.empty() &&
                             s.w.layers[0].gate_fp4 &&
                             kernels::prefill_nvfp4_supported(N, ffn, H);
-    const size_t fp4_a_data_bytes = muse_nvfp4
+    // Qwen3.8-27B's own gate/up NVFP4 (compressed-tensors checkpoint, see
+    // Qwen35Model::load_compressed_tensors): same dense_ffn shape and the exact same gate_fp4/
+    // up_fp4 fields Muse Glimmer already uses, so it reuses `layer_fp4`'s existing GEMM sequence
+    // below unchanged -- this flag ONLY widens that one gate, mutually exclusive with
+    // muse_nvfp4 at runtime (one process loads one model), so the buffers below are shared, not
+    // duplicated. Deliberately NOT touching any c.muse_glimmer-gated branch elsewhere in this
+    // function (qkv-fusion, wo-fusion, sandwich norm) -- those are structurally specific to
+    // Muse's own tensor layout (a separate wgate tensor; Qwen3.8-27B fuses its gate into Q's
+    // projection width instead) and don't apply here.
+    const bool q38_nvfp4 = c.dense_ffn && !c.muse_glimmer && N == 128 && !s.w.layers.empty() &&
+                           s.w.layers[0].gate_fp4 &&
+                           kernels::prefill_nvfp4_supported(N, ffn, H);
+    const bool gu_nvfp4 = muse_nvfp4 || q38_nvfp4;
+    const size_t fp4_a_data_bytes = gu_nvfp4
         ? kernels::prefill_nvfp4_data_bytes(N, H) : 0;
-    const size_t fp4_a_sf_bytes = muse_nvfp4
+    const size_t fp4_a_sf_bytes = gu_nvfp4
         ? kernels::prefill_nvfp4_scale_bytes_a(N, H) : 0;
     // The attention projection group: q | gate | k | v stacked, so one GEMM covers all four. Its A
     // operand is `xn` at k = H -- the same shape gate/up already quantize -- so fp4_a/fp4_as serve
@@ -382,7 +395,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const int qkvg_n = 2 * qdim + 2 * kvdim;
     const bool muse_nvfp4_qkv = muse_nvfp4 && s.w.layers[0].qkvg_fp4 &&
                                 kernels::prefill_nvfp4_supported(N, qkvg_n, H);
-    const size_t fp4_ws_gu = muse_nvfp4
+    const size_t fp4_ws_gu = gu_nvfp4
         ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
     const size_t fp4_ws_qkv = muse_nvfp4_qkv
         ? kernels::prefill_nvfp4_workspace_bytes(N, qkvg_n, H) : 0;
@@ -398,9 +411,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
     if (fp4_ws_wo > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_wo;
     if (fp4_ws_down > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_down;
-    unsigned char* fp4_a = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
-    unsigned char* fp4_as = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
-    unsigned char* fp4_ws = muse_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
+    unsigned char* fp4_a = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
+    unsigned char* fp4_as = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
+    unsigned char* fp4_ws = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
     bf16* fp4_qkv = muse_nvfp4_qkv ? a8.alloc<bf16>((size_t)N * qkvg_n) : nullptr;
     unsigned char* fp4_down_a = muse_nvfp4_down
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
@@ -812,7 +825,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, eps, st);
             float* layer_state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
             kernels::launch_prefill_gdn_scan(gq, gk, gv, la, lb, w.ssm_dt, w.ssm_a,
-                layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim, st);
+                layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim,
+                c.gdn_qh_block, st);
             kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
             attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
             if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
@@ -947,8 +961,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 gate_fused = true;
             }
             // If the fused quantize ran but the GEMM declined, `att` is still raw -- gate it here.
-            if (!gate_fused && !wo_fp4_done)
+            if (!gate_fused && !wo_fp4_done) {
                 kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
+            }
             if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
                 // add happens in launch_norm_then_add below. The FP4 GEMM already wrote `ao` and
@@ -1025,7 +1040,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
-                const bool layer_fp4 = muse_nvfp4 && fn == 128 && w.gate_fp4 && w.gate_fp4_sf &&
+                const bool layer_fp4 = gu_nvfp4 && fn == 128 && w.gate_fp4 && w.gate_fp4_sf &&
                     w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as &&
                     kernels::launch_prefill_nvfp4_quant_a(hn_c, fp4_a, fp4_as, fn, H, st) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gate_fp4, w.gate_fp4_sf,
@@ -2012,7 +2027,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, c.rms_eps, st);
             const float* state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
             kernels::launch_dflash_gdn_scan_compact(gq, rk, rv, ra, rb, w.ssm_dt, w.ssm_a,
-                state, att, N, c.linear_q_heads, vh, c.linear_head_dim, st);
+                state, att, N, c.linear_q_heads, vh, c.linear_head_dim, c.gdn_qh_block, st);
             kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh,
                                                 c.linear_head_dim, c.rms_eps, st);
             supported = proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
@@ -2072,8 +2087,9 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // att/qg rows are contiguous at stride qdim, and the gate is elementwise, so one
             // launch covers the whole block. N separate nodes cost N times the graph-node
             // dependency latency for the same work.
-            if (!kv8)
+            if (!kv8) {
                 kernels::launch_qwen36_mul_sigmoid(att, qg, N * qdim, st);
+            }
             supported = proj(att, w.wo, w.wo_type, ao, H, qdim);
         }
         if (!supported) break;
@@ -2308,7 +2324,8 @@ verify_forward_done:
             kernels::launch_dflash_gdn_conv_commit(rq, conv_live, keep, c.linear_q_heads, vh,
                 c.linear_head_dim, c.linear_conv_kernel, st);
             kernels::launch_dflash_gdn_scan_commit(rk, rv, ra, rb, s.w.layers[L].ssm_dt,
-                s.w.layers[L].ssm_a, state, keep, c.linear_q_heads, vh, c.linear_head_dim, st);
+                s.w.layers[L].ssm_a, state, keep, c.linear_q_heads, vh, c.linear_head_dim,
+                c.gdn_qh_block, st);
         }
     }
     pf_cu(cudaStreamSynchronize(st), "verify commit");

--- a/runtime/src/safetensors.cpp
+++ b/runtime/src/safetensors.cpp
@@ -1,0 +1,450 @@
+// Minimal safetensors reader (mmap) + a small dependency-free JSON parser scoped to the
+// safetensors header shape (a flat object of tensor-name -> {dtype, shape, data_offsets},
+// plus an optional __metadata__ block) and the sibling model.safetensors.index.json shape
+// (weight_map: tensor-name -> shard filename). No general JSON library is linked into the
+// runtime target (that's server-only, see server/CMakeLists.txt) -- mirrors gguf.cpp's
+// dependency-free, mmap-based, bounds-checked design.
+
+#include "sparkinfer/safetensors.h"
+
+#include <cstdio>
+#include <cstring>
+#include <map>
+#include <memory>
+#include <variant>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#else
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#endif
+
+namespace sparkinfer {
+
+namespace {
+
+// ---- mmap helpers (identical shape to gguf.cpp's) ----
+
+#ifdef _WIN32
+bool map_readonly(const std::string& path, void*& base, size_t& size,
+                  void*& file_handle, void*& map_handle) {
+    file_handle = (void*)CreateFileA(path.c_str(), GENERIC_READ, FILE_SHARE_READ,
+                                     nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (file_handle == INVALID_HANDLE_VALUE) {
+        fprintf(stderr, "[safetensors] open failed: %s\n", path.c_str());
+        return false;
+    }
+    LARGE_INTEGER li{};
+    if (!GetFileSizeEx((HANDLE)file_handle, &li) || li.QuadPart <= 0) {
+        fprintf(stderr, "[safetensors] stat failed: %s\n", path.c_str());
+        CloseHandle((HANDLE)file_handle);
+        file_handle = INVALID_HANDLE_VALUE;
+        return false;
+    }
+    size = (size_t)li.QuadPart;
+    map_handle = (void*)CreateFileMappingA((HANDLE)file_handle, nullptr, PAGE_READONLY, 0, 0, nullptr);
+    if (!map_handle) {
+        fprintf(stderr, "[safetensors] CreateFileMapping failed\n");
+        CloseHandle((HANDLE)file_handle);
+        file_handle = INVALID_HANDLE_VALUE;
+        return false;
+    }
+    base = MapViewOfFile((HANDLE)map_handle, FILE_MAP_READ, 0, 0, 0);
+    if (!base) {
+        fprintf(stderr, "[safetensors] MapViewOfFile failed\n");
+        CloseHandle((HANDLE)map_handle);
+        CloseHandle((HANDLE)file_handle);
+        map_handle = nullptr;
+        file_handle = INVALID_HANDLE_VALUE;
+        return false;
+    }
+    return true;
+}
+
+void unmap_readonly(void* base, void* file_handle, void* map_handle) {
+    if (base) UnmapViewOfFile(base);
+    if (map_handle) CloseHandle((HANDLE)map_handle);
+    if (file_handle && file_handle != INVALID_HANDLE_VALUE) CloseHandle((HANDLE)file_handle);
+}
+#else
+bool map_readonly(const std::string& path, void*& base, size_t& size, int& fd) {
+    fd = ::open(path.c_str(), O_RDONLY);
+    if (fd < 0) { fprintf(stderr, "[safetensors] open failed: %s\n", path.c_str()); return false; }
+    struct stat st{};
+    if (fstat(fd, &st) != 0 || st.st_size <= 0) {
+        fprintf(stderr, "[safetensors] stat failed: %s\n", path.c_str());
+        close(fd);
+        fd = -1;
+        return false;
+    }
+    size = (size_t)st.st_size;
+    base = mmap(nullptr, size, PROT_READ, MAP_PRIVATE, fd, 0);
+    if (base == MAP_FAILED) {
+        fprintf(stderr, "[safetensors] mmap failed\n");
+        close(fd);
+        fd = -1;
+        base = nullptr;
+        return false;
+    }
+    return true;
+}
+
+void unmap_readonly(void* base, size_t size, int fd) {
+    if (base && base != MAP_FAILED) munmap(base, size);
+    if (fd >= 0) close(fd);
+}
+#endif
+
+// ---- tiny JSON value + parser, scoped to what safetensors headers actually contain ----
+
+struct Json;
+using JsonObject = std::map<std::string, Json>;
+using JsonArray  = std::vector<Json>;
+
+struct Json {
+    std::variant<std::monostate, bool, double, std::string, JsonArray, JsonObject> v;
+
+    bool is_object() const { return std::holds_alternative<JsonObject>(v); }
+    bool is_array()  const { return std::holds_alternative<JsonArray>(v); }
+    bool is_string() const { return std::holds_alternative<std::string>(v); }
+    bool is_number() const { return std::holds_alternative<double>(v); }
+
+    const JsonObject& obj() const { static JsonObject e; auto p = std::get_if<JsonObject>(&v); return p ? *p : e; }
+    const JsonArray&  arr() const { static JsonArray e;  auto p = std::get_if<JsonArray>(&v);  return p ? *p : e; }
+    std::string str(const std::string& def = "") const { auto p = std::get_if<std::string>(&v); return p ? *p : def; }
+    double num(double def = 0) const { auto p = std::get_if<double>(&v); return p ? *p : def; }
+};
+
+struct JsonCursor {
+    const char* p; size_t off, size; bool ok = true;
+
+    void skip_ws() { while (off < size && (p[off]==' '||p[off]=='\t'||p[off]=='\n'||p[off]=='\r')) off++; }
+    char peek() { return off < size ? p[off] : '\0'; }
+    bool expect(char c) { skip_ws(); if (off>=size || p[off]!=c) { ok=false; return false; } off++; return true; }
+
+    std::string parse_string() {
+        skip_ws();
+        if (!expect('"')) return {};
+        std::string s;
+        while (off < size && p[off] != '"') {
+            char c = p[off++];
+            if (c == '\\' && off < size) {
+                char e = p[off++];
+                switch (e) {
+                    case '"': s += '"'; break; case '\\': s += '\\'; break; case '/': s += '/'; break;
+                    case 'n': s += '\n'; break; case 't': s += '\t'; break; case 'r': s += '\r'; break;
+                    case 'b': s += '\b'; break; case 'f': s += '\f'; break;
+                    case 'u': off += 4; break;   // \uXXXX: not needed for tensor/shard names, skip
+                    default: s += e; break;
+                }
+            } else s += c;
+        }
+        if (off >= size) { ok = false; return {}; }
+        off++;   // closing quote
+        return s;
+    }
+
+    double parse_number() {
+        skip_ws();
+        size_t start = off;
+        if (off < size && (p[off]=='-'||p[off]=='+')) off++;
+        while (off < size && (isdigit((unsigned char)p[off]) || p[off]=='.' || p[off]=='e' || p[off]=='E'
+                              || p[off]=='+' || p[off]=='-')) off++;
+        if (off == start) { ok = false; return 0; }
+        return strtod(std::string(p + start, off - start).c_str(), nullptr);
+    }
+
+    Json parse_value() {
+        skip_ws();
+        Json j;
+        if (off >= size) { ok = false; return j; }
+        char c = p[off];
+        if (c == '"') { j.v = parse_string(); return j; }
+        if (c == '{') { j.v = parse_object(); return j; }
+        if (c == '[') { j.v = parse_array(); return j; }
+        if (c == 't') { off += 4; j.v = true; return j; }     // "true"
+        if (c == 'f') { off += 5; j.v = false; return j; }    // "false"
+        if (c == 'n') { off += 4; j.v = std::monostate{}; return j; }  // "null"
+        j.v = parse_number();
+        return j;
+    }
+
+    JsonArray parse_array() {
+        JsonArray a;
+        if (!expect('[')) return a;
+        skip_ws();
+        if (peek() == ']') { off++; return a; }
+        while (ok) {
+            a.push_back(parse_value());
+            skip_ws();
+            if (peek() == ',') { off++; continue; }
+            break;
+        }
+        expect(']');
+        return a;
+    }
+
+    JsonObject parse_object() {
+        JsonObject o;
+        if (!expect('{')) return o;
+        skip_ws();
+        if (peek() == '}') { off++; return o; }
+        while (ok) {
+            std::string key = parse_string();
+            if (!ok) break;
+            if (!expect(':')) break;
+            o[key] = parse_value();
+            skip_ws();
+            if (peek() == ',') { off++; continue; }
+            break;
+        }
+        expect('}');
+        return o;
+    }
+};
+
+bool parse_json(const char* data, size_t len, Json& out) {
+    JsonCursor c{data, 0, len};
+    out = c.parse_value();
+    return c.ok;
+}
+
+STDType dtype_from_str(const std::string& s) {
+    if (s == "F32")  return STDType::F32;
+    if (s == "F16")  return STDType::F16;
+    if (s == "BF16") return STDType::BF16;
+    if (s == "I64")  return STDType::I64;
+    if (s == "I32")  return STDType::I32;
+    if (s == "I8")   return STDType::I8;
+    if (s == "U8")   return STDType::U8;
+    if (s == "F8_E4M3") return STDType::F8_E4M3;
+    return STDType::Unknown;
+}
+
+int dtype_size(STDType t) {
+    switch (t) {
+        case STDType::F32: case STDType::I32: return 4;
+        case STDType::F16: case STDType::BF16: return 2;
+        case STDType::I64: return 8;
+        case STDType::I8: case STDType::U8: case STDType::F8_E4M3: return 1;
+        default: return 0;
+    }
+}
+
+// Reads a whole small file into memory (used for model.safetensors.index.json, which is
+// plain text, not the mmap'd tensor data).
+bool read_whole_file(const std::string& path, std::string& out) {
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) return false;
+    fseek(f, 0, SEEK_END);
+    long n = ftell(f);
+    fseek(f, 0, SEEK_SET);
+    if (n < 0) { fclose(f); return false; }
+    out.resize((size_t)n);
+    size_t rd = n > 0 ? fread(&out[0], 1, (size_t)n, f) : 0;
+    fclose(f);
+    return rd == (size_t)n;
+}
+
+bool file_exists(const std::string& path) {
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) return false;
+    fclose(f);
+    return true;
+}
+
+} // namespace
+
+SafeTensorsShard::~SafeTensorsShard() {
+#ifdef _WIN32
+    unmap_readonly(base_, win_file_, win_map_);
+#else
+    unmap_readonly(base_, size_, fd_);
+#endif
+    base_ = nullptr;
+    size_ = 0;
+#ifdef _WIN32
+    win_file_ = (void*)(intptr_t)-1;
+    win_map_ = nullptr;
+#else
+    fd_ = -1;
+#endif
+}
+
+bool SafeTensorsShard::open(const std::string& path) {
+#ifdef _WIN32
+    if (!map_readonly(path, base_, size_, win_file_, win_map_)) return false;
+#else
+    if (!map_readonly(path, base_, size_, fd_)) return false;
+#endif
+    if (size_ < 8) { fprintf(stderr, "[safetensors] %s too small for a header\n", path.c_str()); return false; }
+
+    uint64_t hlen = 0;
+    memcpy(&hlen, base_, 8);
+    // File-controlled header length -- bounds-check before trusting it as a JSON span.
+    if (hlen > size_ - 8) {
+        fprintf(stderr, "[safetensors] %s: header length %llu exceeds file size\n",
+                path.c_str(), (unsigned long long)hlen);
+        return false;
+    }
+
+    Json header;
+    if (!parse_json((const char*)base_ + 8, (size_t)hlen, header) || !header.is_object()) {
+        fprintf(stderr, "[safetensors] %s: header JSON parse failed\n", path.c_str());
+        return false;
+    }
+
+    const size_t data_start = 8 + (size_t)hlen;
+    for (const auto& [name, val] : header.obj()) {
+        if (name == "__metadata__" || !val.is_object()) continue;   // arbitrary string map, not a tensor
+        const auto& info = val.obj();
+        auto dt_it = info.find("dtype");
+        auto sh_it = info.find("shape");
+        auto off_it = info.find("data_offsets");
+        if (dt_it == info.end() || sh_it == info.end() || off_it == info.end()
+            || !sh_it->second.is_array() || !off_it->second.is_array()
+            || off_it->second.arr().size() != 2) {
+            fprintf(stderr, "[safetensors] %s: malformed tensor entry %s\n", path.c_str(), name.c_str());
+            return false;
+        }
+
+        STTensor t;
+        t.dtype = dtype_from_str(dt_it->second.str());
+        const auto& shape = sh_it->second.arr();
+        if (shape.size() > 4) {
+            // Vision-tower tensors (e.g. a 5-D patch_embed conv weight) exceed STTensor::dims'
+            // fixed width. Out of scope for this reader (text-only), so skip cataloging this one
+            // tensor rather than failing the whole checkpoint -- nothing looks it up by name.
+            fprintf(stderr, "[safetensors] %s: skipping tensor %s with %zu dims (max 4)\n",
+                    path.c_str(), name.c_str(), shape.size());
+            continue;
+        }
+        t.n_dims = (int)shape.size();
+        long nv = 1;
+        for (int d = 0; d < t.n_dims; d++) { long e = (long)shape[d].num(); t.dims[d] = e; nv *= e; }
+        if (t.n_dims == 0) nv = 1;   // scalar tensor
+        t.n_values = nv;
+
+        const uint64_t start = (uint64_t)off_it->second.arr()[0].num();
+        const uint64_t end   = (uint64_t)off_it->second.arr()[1].num();
+        const int esz = dtype_size(t.dtype);
+        if (esz == 0 || end < start) {
+            fprintf(stderr, "[safetensors] %s: tensor %s has unsupported/invalid dtype or offsets\n",
+                    path.c_str(), name.c_str());
+            return false;
+        }
+        t.n_bytes = (long)(end - start);
+        // Bounds-check the resolved data region against the actual file size, same
+        // discipline as gguf.cpp -- a truncated/malformed shard must fail loudly here,
+        // not produce an out-of-bounds pointer a later cudaMemcpy would dereference.
+        if (data_start > size_ || start > size_ - data_start || end > size_ - data_start) {
+            fprintf(stderr, "[safetensors] %s: tensor %s data out of bounds\n", path.c_str(), name.c_str());
+            return false;
+        }
+        t.data = (const uint8_t*)base_ + data_start + start;
+        tensors_[name] = t;
+    }
+    return true;
+}
+
+const STTensor* SafeTensorsShard::tensor(const std::string& name) const {
+    auto it = tensors_.find(name);
+    return it == tensors_.end() ? nullptr : &it->second;
+}
+
+bool SafeTensorsModel::open(const std::string& model_dir) {
+    const std::string index_path = model_dir + "/model.safetensors.index.json";
+    const std::string single_path = model_dir + "/model.safetensors";
+
+    std::vector<std::string> shard_files;
+    std::map<std::string, std::string> weight_map;   // tensor name -> shard filename
+
+    if (file_exists(index_path)) {
+        std::string text;
+        if (!read_whole_file(index_path, text)) {
+            fprintf(stderr, "[safetensors] failed to read %s\n", index_path.c_str());
+            return false;
+        }
+        Json idx;
+        if (!parse_json(text.data(), text.size(), idx) || !idx.is_object()) {
+            fprintf(stderr, "[safetensors] %s: JSON parse failed\n", index_path.c_str());
+            return false;
+        }
+        auto wm_it = idx.obj().find("weight_map");
+        if (wm_it == idx.obj().end() || !wm_it->second.is_object()) {
+            fprintf(stderr, "[safetensors] %s: missing weight_map\n", index_path.c_str());
+            return false;
+        }
+        for (const auto& [tname, shard] : wm_it->second.obj()) {
+            weight_map[tname] = shard.str();
+        }
+    } else if (file_exists(single_path)) {
+        // Unsharded model -- every tensor lives in the one file; weight_map is populated
+        // lazily below once the shard is opened and its own tensor list is known.
+        shard_files.push_back(single_path);
+    } else {
+        fprintf(stderr, "[safetensors] neither %s nor %s exists\n", index_path.c_str(), single_path.c_str());
+        return false;
+    }
+
+    // Collect the distinct shard filenames referenced by the index (sharded case).
+    if (!weight_map.empty()) {
+        std::map<std::string, int> seen;
+        for (const auto& [tname, shard] : weight_map) {
+            if (seen.find(shard) == seen.end()) {
+                seen[shard] = (int)shard_files.size();
+                shard_files.push_back(shard);
+            }
+        }
+    }
+
+    // A shard referenced by the index may be deliberately absent (e.g. model_mtp.safetensors for
+    // a checkpoint whose MTP head is out of scope and never downloaded) -- skip it rather than
+    // failing the whole model, since only tensors that actually resolve to an opened shard are
+    // ever looked up. Filter to existing files first, then open in place (SafeTensorsShard has a
+    // custom destructor, so no temporary may be copied/moved into the vector).
+    std::vector<std::string> present_shard_files;
+    std::map<std::string, int> opened_shard_index;   // shard filename -> index into shards_
+    for (const auto& f : shard_files) {
+        const std::string path = f.find('/') != std::string::npos ? f : (model_dir + "/" + f);
+        if (!file_exists(path)) {
+            fprintf(stderr, "[safetensors] %s: shard %s not present -- skipping (tensors mapped "
+                            "to it will be unavailable)\n", model_dir.c_str(), f.c_str());
+            continue;
+        }
+        opened_shard_index[f] = (int)present_shard_files.size();
+        present_shard_files.push_back(f);
+    }
+
+    shards_.resize(present_shard_files.size());
+    for (size_t i = 0; i < present_shard_files.size(); i++) {
+        const std::string path = present_shard_files[i].find('/') != std::string::npos
+            ? present_shard_files[i] : (model_dir + "/" + present_shard_files[i]);
+        if (!shards_[i].open(path)) return false;
+    }
+
+    if (!weight_map.empty()) {
+        for (const auto& [tname, shard] : weight_map) {
+            auto sit = opened_shard_index.find(shard);
+            if (sit != opened_shard_index.end()) shard_of_[tname] = sit->second;
+        }
+    } else {
+        // Unsharded: every tensor the single shard actually parsed belongs to shard 0.
+        for (const auto& [tname, t] : shards_[0].tensors()) { (void)t; shard_of_[tname] = 0; }
+    }
+    return true;
+}
+
+const STTensor* SafeTensorsModel::tensor(const std::string& name) const {
+    auto it = shard_of_.find(name);
+    if (it == shard_of_.end()) return nullptr;
+    return shards_[it->second].tensor(name);
+}
+
+} // namespace sparkinfer

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -10,12 +10,8 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(tokenizers_cpp)
 
-FetchContent_Declare(
-    nlohmann_json
-    URL      https://github.com/nlohmann/json/releases/download/v3.12.0/json.tar.xz
-    URL_HASH SHA256=42f6e95cad6ec532fd372391373363b62a14af6d771056dbfc86160e6dfff7aa
-)
-FetchContent_MakeAvailable(nlohmann_json)
+# nlohmann_json is declared at the TOP-LEVEL CMakeLists (runtime/ needs it too and is configured
+# first); this target just uses it.
 
 # JSON Schema patterns come from untrusted API requests. Use RE2's bounded,
 # linear-time engine instead of std::regex, whose backtracking implementation

--- a/server/include/chat_tokenizer.hpp
+++ b/server/include/chat_tokenizer.hpp
@@ -37,6 +37,11 @@ public:
     // Glimmer's harmony-style <|start|>/<|message|>/<|eot|>/<|eom|> segments. Call once after
     // the model's architecture is known (ModelEngine::is_museglimmer()), before the first request.
     void set_museglimmer(bool on);
+    // Qwen3.8-27B's pinned chat_template.jinja unconditionally prepends a reasoning-effort
+    // system message (see apply_qwen36_tools_template's inject_reasoning_effort param). Call
+    // once after the model's architecture is known (ModelEngine::is_qwen38()), before the first
+    // request. Independent of set_museglimmer -- the two are mutually exclusive model families.
+    void set_qwen38(bool on);
 
     bool encode_chat_request(const std::string& request_json, std::vector<int>& ids, bool enable_thinking,
                              std::string& err, ChatRequest* parsed_request = nullptr) const;

--- a/server/include/chat_tools.hpp
+++ b/server/include/chat_tools.hpp
@@ -165,8 +165,13 @@ bool should_reject_dflash_logit_bias(bool dflash_env_on, bool has_logit_bias);
 bool validate_response_format(const std::string& content, const ResponseFormat& format,
                               std::string& err);
 
+// inject_reasoning_effort: Qwen3.8-27B's pinned chat_template.jinja unconditionally prepends a
+// "Reasoning effort is set to xhigh..." system message whenever thinking is enabled -- regardless
+// of tools/response_format -- which Qwen3.6/Muse Glimmer's own templates never do. Defaults false
+// so every existing caller (Qwen3.6, tests) is byte-for-byte unchanged.
 std::string apply_qwen36_tools_template(const ChatRequest& request,
-                                        bool enable_thinking = false);
+                                        bool enable_thinking = false,
+                                        bool inject_reasoning_effort = false);
 
 ParsedToolOutput parse_qwen36_tool_output(const std::string& raw,
                                           bool enable_thinking,

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -52,6 +52,7 @@ public:
     int vocab() const;
     int max_seq() const;
     bool is_museglimmer() const;
+    bool is_qwen38() const;
 
     // Optional shared prompt prefix (e.g. system message tokens). When set, each request whose
     // prompt starts with these ids calls cache_prefix() (batched prefill) before generate().

--- a/server/src/chat_tokenizer.cpp
+++ b/server/src/chat_tokenizer.cpp
@@ -226,6 +226,7 @@ RawTokenPiece gpt2_bytelevel_decode(const std::string& raw_piece) {
 struct ChatTokenizer::Impl {
     std::unique_ptr<tokenizers::Tokenizer> tok;
     bool museglimmer = false;
+    bool qwen38 = false;
     // Muse Glimmer harmony-format marker token ids, resolved once in set_museglimmer() (single
     // -threaded server startup, after `tok` is loaded) -- see decode()'s comment for why these
     // need special handling. Deliberately NOT lazily resolved on first decode(): decode() runs
@@ -258,6 +259,8 @@ bool ChatTokenizer::load(const std::string& tokenizer_json_path, std::string& er
             tokenizer_json_path.c_str(), impl_->tok->GetVocabSize());
     return true;
 }
+
+void ChatTokenizer::set_qwen38(bool on) { impl_->qwen38 = on; }
 
 void ChatTokenizer::set_museglimmer(bool on) {
     impl_->museglimmer = on;
@@ -703,7 +706,7 @@ std::vector<int> ChatTokenizer::encode_augmented(const ChatRequest& request, boo
     if (!impl_->tok) return {};
     const std::string prompt = impl_->museglimmer
         ? apply_museglimmer_chat_template(request.messages, enable_thinking ? "high" : "low")
-        : apply_qwen36_tools_template(request, enable_thinking);
+        : apply_qwen36_tools_template(request, enable_thinking, impl_->qwen38);
     const std::vector<int32_t> enc = impl_->tok->Encode(prompt);
     return std::vector<int>(enc.begin(), enc.end());
 }

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -1375,16 +1375,27 @@ bool should_reject_dflash_logit_bias(bool dflash_env_on, bool has_logit_bias) {
     return dflash_env_on && has_logit_bias;
 }
 
-std::string apply_qwen36_tools_template(const ChatRequest& request, bool enable_thinking) {
+std::string apply_qwen36_tools_template(const ChatRequest& request, bool enable_thinking,
+                                        bool inject_reasoning_effort) {
     std::ostringstream out;
     size_t first_message = 0;
     const bool tools_active = !request.tools.empty() && request.tool_choice == ToolChoiceMode::kAuto;
     const bool json_mode = request.response_format.type != ResponseFormatType::kText;
+    // Qwen3.8-27B's chat_template.jinja always resolves reasoning_effort to its default (xhigh)
+    // -- this server never wires reasoning_effort as a request param -- and prepends this exact
+    // wording whenever thinking is enabled, independent of tools/response_format.
+    const std::string reasoning_instructions = (inject_reasoning_effort && enable_thinking)
+        ? "Reasoning effort is set to xhigh. Please think carefully through the task, validate "
+          "key assumptions, consider plausible alternatives, and prioritize correctness, "
+          "consistency, and clarity in the final answer."
+        : std::string();
+    const bool has_leading_system = !request.messages.empty() && request.messages[0].role == "system";
     // Request-time validation (parse_chat_request_json) rejects tools + response_format
     // together, so tools_active and json_mode are never both true -- written as two independent
     // segments anyway to keep this function's shape uniform rather than forking it in two.
     if (tools_active || json_mode) {
         out << kImStart << "system\n";
+        if (!reasoning_instructions.empty()) out << reasoning_instructions << "\n\n";
         if (tools_active) {
             out << kToolInstructions;
             for (const ToolDefinition& tool : request.tools)
@@ -1401,12 +1412,29 @@ std::string apply_qwen36_tools_template(const ChatRequest& request, bool enable_
                     << kJsonSchemaInstructionsTail;
             }
         }
-        if (!request.messages.empty() && request.messages[0].role == "system") {
+        if (has_leading_system) {
             const std::string system_content = trim_copy(request.messages[0].content);
             if (!system_content.empty()) out << "\n\n" << system_content;
         }
         out << kImEnd << '\n';
-        if (!request.messages.empty() && request.messages[0].role == "system") first_message = 1;
+        if (has_leading_system) first_message = 1;
+    } else if (inject_reasoning_effort && (!reasoning_instructions.empty() || has_leading_system)) {
+        // Plain case (no tools, no json_mode): the pinned template still merges leading system
+        // message(s) with the reasoning-effort instructions rather than letting them fall
+        // through the generic per-message loop below.
+        const std::string system_content = has_leading_system ? trim_copy(request.messages[0].content)
+                                                               : std::string();
+        if (!system_content.empty() || !reasoning_instructions.empty()) {
+            out << kImStart << "system\n";
+            if (!reasoning_instructions.empty()) {
+                out << reasoning_instructions;
+                if (!system_content.empty()) out << "\n\n" << system_content;
+            } else {
+                out << system_content;
+            }
+            out << kImEnd << '\n';
+        }
+        if (has_leading_system) first_message = 1;
     }
     size_t last_user = request.messages.size();
     for (size_t i = request.messages.size(); i > 0; --i) {

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -9,6 +9,7 @@
 #include "sparkinfer/runtime.h"
 
 #include "../../runtime/examples/qwen3_gguf_config.h"
+#include "../../runtime/examples/qwen38_hf_config.h"
 
 #include <sys/wait.h>
 #include <unistd.h>
@@ -18,6 +19,9 @@
 #include <cstring>
 #include <cuda_runtime.h>
 #include <algorithm>
+#include <fstream>
+#include <sys/stat.h>
+#include <nlohmann/json.hpp>
 
 namespace sparkinfer_server {
 
@@ -183,14 +187,50 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
         return false;
     }
 
-    sparkinfer::GGUF g;
-    if (!g.open(gguf_path)) {
-        fprintf(stderr, "[sparkinfer-server] cannot open %s\n", gguf_path.c_str());
-        return false;
+    // Three-way dispatch on what `-m` actually points at: a .gguf file (every model shipped so
+    // far), or a directory -- which is either a HuggingFace "compressed-tensors" mixed FP8/NVFP4
+    // checkpoint (config.json has a quantization_config block, e.g. unsloth/Qwen3.8-27B-NVFP4) or
+    // a plain (unquantized) safetensors checkpoint. Same "auto-detect from what's actually there"
+    // pattern the GGUF path already uses (general.architecture sniffing) -- no new CLI flag.
+    struct stat path_st{};
+    const bool is_dir = stat(gguf_path.c_str(), &path_st) == 0 && S_ISDIR(path_st.st_mode);
+    enum class LoadKind { Gguf, CompressedTensors, PlainSafetensors };
+    LoadKind kind = LoadKind::Gguf;
+    if (is_dir) {
+        std::ifstream cf(gguf_path + "/config.json");
+        if (!cf) {
+            fprintf(stderr, "[sparkinfer-server] %s is a directory but has no config.json\n",
+                    gguf_path.c_str());
+            return false;
+        }
+        nlohmann::json root;
+        try { cf >> root; } catch (const std::exception& e) {
+            fprintf(stderr, "[sparkinfer-server] %s/config.json parse error: %s\n",
+                    gguf_path.c_str(), e.what());
+            return false;
+        }
+        kind = root.contains("quantization_config") ? LoadKind::CompressedTensors
+                                                      : LoadKind::PlainSafetensors;
     }
 
+    sparkinfer::GGUF g;
     impl_->cfg = sparkinfer::Qwen35Config{};
-    qwen3_config_from_gguf(g, impl_->cfg);
+    if (kind == LoadKind::Gguf) {
+        if (!g.open(gguf_path)) {
+            fprintf(stderr, "[sparkinfer-server] cannot open %s\n", gguf_path.c_str());
+            return false;
+        }
+        qwen3_config_from_gguf(g, impl_->cfg);
+    } else {
+        // Both directory kinds share the same base HF config.json shape (text_config block) --
+        // quantization_config only changes how load() below reads the actual weight bytes, not
+        // the architecture/hyperparameter population.
+        std::string err;
+        if (!qwen38_config_from_hf_json(gguf_path, impl_->cfg, err)) {
+            fprintf(stderr, "[sparkinfer-server] %s: %s\n", gguf_path.c_str(), err.c_str());
+            return false;
+        }
+    }
     if (max_seq > 0) impl_->cfg.max_seq = max_seq;
     else if (impl_->cfg.max_seq < 2048) impl_->cfg.max_seq = 2048;
 
@@ -240,9 +280,26 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     impl_->model = std::make_unique<sparkinfer::Qwen35Model>(
         impl_->cfg, impl_->kv.get(), impl_->engine.get());
 
-    fprintf(stderr, "[sparkinfer-server] loading GGUF ...\n");
-    if (!impl_->model->load_gguf(gguf_path)) {
-        fprintf(stderr, "[sparkinfer-server] load_gguf failed\n");
+    if (kind == LoadKind::Gguf) {
+        fprintf(stderr, "[sparkinfer-server] loading GGUF ...\n");
+        if (!impl_->model->load_gguf(gguf_path)) {
+            fprintf(stderr, "[sparkinfer-server] load_gguf failed\n");
+            return false;
+        }
+    } else if (kind == LoadKind::CompressedTensors) {
+        fprintf(stderr, "[sparkinfer-server] loading compressed-tensors checkpoint ...\n");
+        if (!impl_->model->load_compressed_tensors(gguf_path)) {
+            fprintf(stderr, "[sparkinfer-server] load_compressed_tensors failed\n");
+            return false;
+        }
+    } else {
+        // Qwen35Model::load_weights() reads a directory of already-converted flat .bin files
+        // (runtime/tools/convert_qwen35.py's own offline output format), not a safetensors
+        // directory directly -- no C++ loader for plain (unquantized) safetensors exists yet, this
+        // config-detection branch was written ahead of that loader rather than left undetectable.
+        fprintf(stderr, "[sparkinfer-server] %s: plain safetensors directories are not yet "
+                        "supported directly -- convert with runtime/tools/convert_qwen35.py first "
+                        "and pass the .bin output directory instead\n", gguf_path.c_str());
         return false;
     }
 
@@ -321,6 +378,11 @@ int ModelEngine::max_seq() const {
 bool ModelEngine::is_museglimmer() const {
     std::lock_guard<std::mutex> lock(mu_);
     return impl_->ready && impl_->cfg.muse_glimmer;
+}
+
+bool ModelEngine::is_qwen38() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return impl_->ready && impl_->cfg.qwen38;
 }
 
 void ModelEngine::set_prefix_tokens(const std::vector<int>& tokens) {

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -395,6 +395,7 @@ int main(int argc, char** argv) {
     sparkinfer_server::ModelEngine engine;
     if (!engine.load(model_path, ctx > 0 ? ctx : 0)) return 1;
     g_tokenizer.set_museglimmer(engine.is_museglimmer());
+    g_tokenizer.set_qwen38(engine.is_qwen38());
 
     const std::vector<int> prefix_ids = load_prefix_token_ids();
     if (!prefix_ids.empty()) {
@@ -508,7 +509,7 @@ int main(int argc, char** argv) {
             res.set_content("{\"error\":{\"message\":\"unauthorized\"}}", "application/json");
             return;
         }
-        const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, false);
+        const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, engine.is_qwen38());
         std::vector<int> ids;
         std::string err;
         if (!encode_messages(req.body, ids, enable_thinking, err)) {
@@ -606,7 +607,7 @@ int main(int argc, char** argv) {
                  }
                  const bool stream = controls.stream;
                  if (stream) g_requests_streaming++;
-                 const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, false);
+                 const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, engine.is_qwen38());
                  int max_tokens = controls.max_tokens;
                  if (max_tokens <= 0) max_tokens = 256;
                  if (max_tokens > max_output_tokens()) max_tokens = max_output_tokens();


### PR DESCRIPTION
Adds **Qwen3.8-27B** (`unsloth/Qwen3.8-27B-NVFP4`, ~22.5GB) as a third loadable checkpoint format alongside GGUF and plain safetensors, and repoints the PR eval bot at it.

## Model support

A `compressed-tensors` mixed-precision checkpoint: NVFP4 FFN (block_size=16, two-level scale) for ~56 of 64 layers, FP8-E4M3 per-output-channel attention/GDN projections, `lm_head`, and layers 56-63's FFN. New dependency-free safetensors reader, FP8/NVFP4 dequant kernels, and `Qwen35Model::load_compressed_tensors()`. Everything is dequantized once at load and requantized into the formats `load_gguf()` already produces (Q4_K for decode, this runtime's own NVFP4 for prefill), so **no new GEMM/GEMV kernels**.

Getting coherent output took six checkpoint-convention fixes, each verified numerically against llama.cpp's own qwen35 implementation rather than derived from the config:

- **Weight layout** — HF stores Linear weights `[out,in]`, byte-identical to the GGUF-native `[out,in]` every consumer here wants. The loader was transposing to `[in,out]`, silently mis-shaping every projection.
- **Attention output gate is a plain sigmoid, not silu**, despite the config's `output_gate_type: "swish"`. The gate is strongly negative (mean ~-4.5), so silu sign-flipped the output from the first full-attention layer onward.
- NVFP4 `weight_global_scale` is a quantization-time multiplier, so dequant divides by it.
- GDN `A_log` must be transformed to `-exp(A_log)`.
- 5 of 6 norm-weight kinds are stored zero-centred (effective weight `1+w`); `linear_attn.norm` is not.
- GDN's v-head -> q/k-head broadcast is block `(vh/3)` here, not the cyclic convention Qwythos/Qwen3.6-35B-A3B validated. Threaded through decode and prefill, defaulting to cyclic so existing models are unaffected.

## Eval scope

`eval/pr_qwen38_bot.py` scores Qwen3.8-27B **decode@128 on the NVFP4 directory** (not a GGUF — that is what the server actually serves), with a Qwen3.6-35B-A3B regression guard and a differential accuracy gate.

The accuracy gate is **PR-vs-main**, not absolute: llama.cpp cannot read a compressed-tensors directory, so there is no same-weights external reference. Both builds score the same token stream and the distributions are compared (`bench/scripts/accuracy_compare_pair.py`, top1 >= 0.99 / KL <= 0.01). It catches newly introduced divergence only, never a bug already on main.

## Verification on the pinned RTX 5090

Merged tree (`dd252af`) vs the pre-merge branch tip, same box, same token stream:

| | pre-merge | merged |
|---|---|---|
| decode@128 | 64.82 tps | 64.73 tps |
| prefill@128 | 67.16 | 67.07 |
| top1 / KL | — | **1.000000 / 0.000000** |
| PPL | 3.281 | 3.281 |

`ctest` 21/21 green on the merge. Muse Glimmer still healthy on the merged tree (prefill@128 7540, decode 104.9), confirming main's `7e9f79f` NVFP4/attention changes and this branch's prefill changes coexist.

## Not in scope

Vision/video input, MTP, DFlash for this model. Decode consumes Q4_K requantized from the checkpoint's NVFP4 rather than NVFP4 directly — deliberate (reuses proven kernels), and the reason resident VRAM is ~30GB rather than the checkpoint's 22.5GB.

**The crontab is host state, not repo state** — merging this does not switch evaluation over. The eval host still runs `0 * * * * eval/run_museglimmer_cron.sh`; that line must be replaced with `run_qwen38_cron.sh`'s `*/30` entry by hand, and `eval/setup_labels.sh` must be run to create the `eval-qwen38:*` labels.