### PR TITLE
perf(qwen3.8): native FP8 GDN decode GEMV (1.27x decode@128)

### DIFF
--- a/kernels/csrc/cuda/fused/ct_dequant_fp8.cu
+++ b/kernels/csrc/cuda/fused/ct_dequant_fp8.cu
@@ -35,4 +35,11 @@ void launch_ct_dequant_fp8(const void* w_e4m3, const void* scale_bf16, void* out
         reinterpret_cast<__nv_bfloat16*>(out_bf16), rows, cols);
 }
 
+void launch_ct_dequant_fp8_packed(const void* packed, void* out_bf16,
+                                  int rows, int cols, cudaStream_t stream) {
+    if (!packed || !out_bf16 || rows <= 0 || cols <= 0) return;
+    const char* p = reinterpret_cast<const char*>(packed);
+    launch_ct_dequant_fp8(p + (size_t)rows * 2, packed, out_bf16, rows, cols, stream);
+}
+
 }} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -9,6 +9,10 @@
 
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
+#include <cuda_fp8.h>
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include "sparkinfer/kernels/qtype.h"
+#endif
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
 #endif
@@ -427,6 +431,83 @@ template __global__ void gemv_q80_sk_kernel<float, 4>(const __nv_bfloat16*, cons
 #endif
 #ifndef _MSC_VER
 template __global__ void gemv_q80_sk_kernel<float, 8>(const __nv_bfloat16*, const unsigned char*, float*, int, int);
+#endif
+
+// ---- compressed-tensors FP8 (E4M3) on-read GEMV --------------------------------
+// Packed payload: [bf16 scale[N] | e4m3 W[N*K]]. Each weight is rounded to
+// bf16(float(e4m3)*scale) before the dot -- the same store launch_ct_dequant_fp8
+// writes -- so this is a bandwidth-halved stand-in for keep_bf16 + launch_gemv.
+// Split-K occupancy matches the Q8_0 / bf16 paths.
+__device__ __forceinline__ float si_fp8_deq(const __nv_fp8_e4m3* row, int k, float scale) {
+    return __bfloat162float(__float2bfloat16(float(row[k]) * scale));
+}
+
+template <typename OutT, int S>
+__global__ void gemv_fp8_sk_kernel(const __nv_bfloat16* __restrict__ x,
+                                   const void* __restrict__ packed,
+                                   OutT* __restrict__ y, int N, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float s_part[RPB][S];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n = blockIdx.x * RPB + row_local;
+    float acc = 0.f;
+    if (n < N) {
+        const float s = __bfloat162float(reinterpret_cast<const __nv_bfloat16*>(packed)[n]);
+        const __nv_fp8_e4m3* row = reinterpret_cast<const __nv_fp8_e4m3*>(
+            reinterpret_cast<const char*>(packed) + (size_t)N * 2) + (size_t)n * (size_t)K;
+        // Same K-association as gemv_f32_sk_kernel (8-wide uint4 chunks) so the
+        // fp32 reduction matches keep_bf16 + launch_gemv up to the on-read dequant.
+        const int n8 = K >> 3;
+        const uint4* x4 = reinterpret_cast<const uint4*>(x);
+        for (int i = split * 32 + lane; i < n8; i += S * 32) {
+            const uint4 xv = x4[i];
+            const __nv_bfloat162* xh = reinterpret_cast<const __nv_bfloat162*>(&xv);
+            const int base = i * 8;
+            #pragma unroll
+            for (int j = 0; j < 4; j++) {
+                const float2 xf = __bfloat1622float2(xh[j]);
+                acc += si_fp8_deq(row, base + 2 * j, s) * xf.x
+                    +  si_fp8_deq(row, base + 2 * j + 1, s) * xf.y;
+            }
+        }
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+        if (lane == 0) s_part[row_local][split] = acc;
+    }
+    __syncthreads();
+    if (n < N && split == 0 && lane == 0) {
+        float o = s_part[row_local][0];
+        #pragma unroll
+        for (int t = 1; t < S; t++) o += s_part[row_local][t];
+        gemv_write(y + n, o);
+    }
+}
+#ifndef _MSC_VER
+template __global__ void gemv_fp8_sk_kernel<__nv_bfloat16, 2>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_fp8_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_fp8_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+#endif
+
+template <typename OutT>
+__global__ void gemv_fp8_kernel(const __nv_bfloat16* __restrict__ x,
+                                const void* __restrict__ packed,
+                                OutT* __restrict__ y, int N, int K) {
+    const int warp = threadIdx.x / 32, lane = threadIdx.x & 31;
+    const int n = blockIdx.x * GEMV_WPB + warp;
+    if (n >= N) return;
+    const float s = __bfloat162float(reinterpret_cast<const __nv_bfloat16*>(packed)[n]);
+    const __nv_fp8_e4m3* row = reinterpret_cast<const __nv_fp8_e4m3*>(
+        reinterpret_cast<const char*>(packed) + (size_t)N * 2) + (size_t)n * (size_t)K;
+    float acc = 0.f;
+    for (int k = lane; k < K; k += 32)
+        acc += si_fp8_deq(row, k, s) * __bfloat162float(x[k]);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) gemv_write(y + n, acc);
+}
+#ifndef _MSC_VER
+template __global__ void gemv_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
 #endif
 // ---- faithful llama.cpp int8 MMVQ for a dense Q4_K [N,K] GEMV --------------------
 // Quantizes the activation to Q8_1 (int8 + per-32 scale + sum) once per token, then
@@ -879,6 +960,8 @@ template __global__ void si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 64>(const si_b
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 128>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 160>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+template __global__ void si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 192>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q80_kfixed_kernel<float, 64>(const si_block_q8_1*, const unsigned char*, float*, int);
@@ -1031,12 +1114,17 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 16>(const si_b
 // Muse Glimmer hidden = 6656 -> 26 superblocks. Same loop and same reduction as the generic
 // kernel, so the result is bit-identical; only the trip count becomes a compile-time constant.
 template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 26>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
+// Qwen3.8-27B hidden = 5120 -> 20 superblocks. Same loop/reduction as the generic kernel.
+template __global__ void si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 20>(const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int);
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 8>(const si_block_q8_1*, const unsigned char*, float*, int);
 #endif
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q4k_kfixed_kernel<float, 16>(const si_block_q8_1*, const unsigned char*, float*, int);
+#endif
+#ifndef _MSC_VER
+template __global__ void si_mmvq_q4k_kfixed_kernel<float, 20>(const si_block_q8_1*, const unsigned char*, float*, int);
 #endif
 // Short-row Q4_K MMVQ for exact target verification. The thread-to-fragment mapping and the
 // two-stage four-warp reduction are identical to si_mmvq_q4k_kfixed_kernel. Each CTA owns one
@@ -1166,6 +1254,11 @@ __global__ void si_mmvq_gdn_qkv_z_pack2_kernel(const si_block_q8_1* __restrict__
 
 #ifndef _MSC_VER
 template __global__ void si_mmvq_gdn_qkv_z_pack2_kernel<8>(const si_block_q8_1*, const unsigned char*,
+                                                          const unsigned char*, __nv_bfloat16*,
+                                                          __nv_bfloat16*, int, int);
+#endif
+#ifndef _MSC_VER
+template __global__ void si_mmvq_gdn_qkv_z_pack2_kernel<20>(const si_block_q8_1*, const unsigned char*,
                                                           const unsigned char*, __nv_bfloat16*,
                                                           __nv_bfloat16*, int, int);
 #endif
@@ -1337,6 +1430,10 @@ template __global__ void si_attn_qkv_mmvq_q4k_kernel<__nv_bfloat16, 8>(const si_
 #endif
 #ifndef _MSC_VER
 template __global__ void si_attn_qkv_mmvq_q4k_kernel<__nv_bfloat16, 16>(const si_block_q8_1*, const unsigned char*,
+    const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
+#endif
+#ifndef _MSC_VER
+template __global__ void si_attn_qkv_mmvq_q4k_kernel<__nv_bfloat16, 20>(const si_block_q8_1*, const unsigned char*,
     const unsigned char*, const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, int, int, int);
 #endif
 // ===== faithful llama Q6_K mmvq for the fp32-path GEMVs (attn-V upgrades + LM head) =====
@@ -1931,7 +2028,29 @@ bool launch_gemv_rows_f32(const void* x, const void* W, float* y,
     return launch_gemv_rows_t<float, 4>(x, W, y, M, N, K, stream);
 }
 
+void launch_gemv_fp8(const void* x, const void* W, void* y, int N, int K, cudaStream_t stream) {
+    if (!x || !W || !y || N < 1 || K < 1) return;
+    const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+    auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
+    if (gemv_bf16_splitk() && (K & 7) == 0 && N < 16384) {
+        if (N >= 8192) {
+            constexpr int S = 2, RPB = GEMV_WPB / S;
+            gemv_fp8_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+        } else if (N >= 4096) {
+            constexpr int S = 4, RPB = GEMV_WPB / S;
+            gemv_fp8_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+        } else {
+            constexpr int S = 8, RPB = GEMV_WPB / S;
+            gemv_fp8_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+        }
+        return;
+    }
+    dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
+    gemv_fp8_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+}
+
 void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int K, cudaStream_t stream) {
+    if (wtype == SI_QTYPE_FP8) { launch_gemv_fp8(x, W, y, N, K, stream); return; }
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
     if (gemv_mmvq() && wtype == 12) {   // faithful int8 dp4a (Q4_K)
         size_t sm = 2 * (size_t)(K >> 5) * sizeof(float) + (size_t)K;
@@ -2134,6 +2253,7 @@ void launch_mmvq_q4k(const void* q81, const void* W, void* y, int N, int K, cuda
     // runtime-K kernel, measured at 1042 GB/s against 1374 GB/s for the K=4096 kfixed o_proj
     // sitting next to them in the same layer.
     else if (K == 6656) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 26><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 5120) si_mmvq_q4k_kfixed_kernel<__nv_bfloat16, 20><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else                si_mmvq_q4k_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }
 void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void* z_w,
@@ -2143,6 +2263,14 @@ void launch_mmvq_gdn_qkv_z_pack2(const void* q81, const void* qkv_w, const void*
     if (grid <= 0) return;
     if (K == 4096) {
         si_mmvq_gdn_qkv_z_pack2_kernel<16><<<grid, 8 * 32, 0, stream>>>(
+            reinterpret_cast<const si_block_q8_1*>(q81),
+            reinterpret_cast<const unsigned char*>(qkv_w),
+            reinterpret_cast<const unsigned char*>(z_w),
+            reinterpret_cast<__nv_bfloat16*>(qkv_out),
+            reinterpret_cast<__nv_bfloat16*>(z_out),
+            n_qkv, n_z);
+    } else if (K == 5120) {
+        si_mmvq_gdn_qkv_z_pack2_kernel<20><<<grid, 8 * 32, 0, stream>>>(
             reinterpret_cast<const si_block_q8_1*>(q81),
             reinterpret_cast<const unsigned char*>(qkv_w),
             reinterpret_cast<const unsigned char*>(z_w),
@@ -2173,6 +2301,7 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
         si_mmvq_q4k_dualrow_kernel<float, 8><<<(N + 1) / 2, 8 * 32, 0, stream>>>(q, w, y, N);
     else if (K == 2048)      si_mmvq_q4k_kfixed_kernel<float, 8><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else if (K == 4096) si_mmvq_q4k_kfixed_kernel<float, 16><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
+    else if (K == 5120) si_mmvq_q4k_kfixed_kernel<float, 20><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
 bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
@@ -2274,6 +2403,8 @@ void launch_mmvq_q80(const void* q81, const void* W, void* y, int N, int K, cuda
     __nv_bfloat16* out = reinterpret_cast<__nv_bfloat16*>(y);
     if (K == 2048)      si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 64><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else if (K == 4096) si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 128><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 5120) si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 160><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
+    else if (K == 6144) si_mmvq_q80_kfixed_kernel<__nv_bfloat16, 192><<<N, 4 * 32, 0, stream>>>(q, w, out, N);
     else                si_mmvq_q80_kernel<__nv_bfloat16><<<N, 4 * 32, 0, stream>>>(q, w, out, N, K);
 }
 void launch_mmvq_q80_f32(const void* q81, const void* W, float* y, int N, int K, cudaStream_t stream) {
@@ -2460,6 +2591,12 @@ void launch_attn_qkv_mmvq_q4k(const void* q81,
             reinterpret_cast<__nv_bfloat16*>(yv), Nq, Nk, Nv);
     else if (K == 4096)
         si_attn_qkv_mmvq_q4k_kernel<__nv_bfloat16, 16><<<total, 4 * 32, 0, stream>>>(
+            q, reinterpret_cast<const unsigned char*>(Wq), reinterpret_cast<const unsigned char*>(Wk),
+            reinterpret_cast<const unsigned char*>(Wv),
+            reinterpret_cast<__nv_bfloat16*>(yq), reinterpret_cast<__nv_bfloat16*>(yk),
+            reinterpret_cast<__nv_bfloat16*>(yv), Nq, Nk, Nv);
+    else if (K == 5120)
+        si_attn_qkv_mmvq_q4k_kernel<__nv_bfloat16, 20><<<total, 4 * 32, 0, stream>>>(
             q, reinterpret_cast<const unsigned char*>(Wq), reinterpret_cast<const unsigned char*>(Wk),
             reinterpret_cast<const unsigned char*>(Wv),
             reinterpret_cast<__nv_bfloat16*>(yq), reinterpret_cast<__nv_bfloat16*>(yk),

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1831,6 +1831,15 @@ void launch_moe_expert_ffn_q4k(
                     q, reinterpret_cast<const unsigned char*>(gate_q),
                     reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, gu_pdl);
         }
+        // Qwen3.8-27B dense hybrid (hidden 5120, ffn 17408). Same recipe as Muse's 6656x19968
+        // arm: F is already large enough that pack2 coarsens scheduling. Compile-time H/F
+        // makes NB = H>>8 = 20 a known trip count; same dots in the same order as the
+        // generic kernel, so the result is bit-identical.
+        else if (gu_spec && hidden == 5120 && ffn == 17408 && top_k == 1)
+            launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream,
+                gate_up_mmvq2_qwen_kernel<5120, 17408, 1>,
+                q, reinterpret_cast<const unsigned char*>(gate_q),
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, gu_pdl);
         else
             launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream,
                 gate_up_mmvq2_kernel,

--- a/kernels/include/sparkinfer/kernels/compressed_tensors.h
+++ b/kernels/include/sparkinfer/kernels/compressed_tensors.h
@@ -1,14 +1,10 @@
 #pragma once
 #include <cuda_runtime.h>
 
-// Dequantizes tensors from HuggingFace "compressed-tensors" format checkpoints (NVIDIA ModelOpt /
-// llm-compressor convention -- the exact format used by e.g. unsloth/Qwen3.8-27B-NVFP4) straight
-// to bf16, so the result can feed the SAME requantize-to-internal-format pipeline load_gguf()
-// already uses (bf16 -> Q4_K for decode via launch_proj_requant_q4k_lloyd, bf16 -> this runtime's
-// own fresh NVFP4 for prefill via the existing Muse Glimmer conversion path). One-directional,
-// one-time, load-only conversion -- no new GEMM/GEMV kernels, no global-scale bookkeeping needed
-// downstream, since the re-quantize step produces its own fresh scales the same way it already
-// does for every other model.
+// HuggingFace "compressed-tensors" checkpoints (NVIDIA ModelOpt / llm-compressor --
+// e.g. unsloth/Qwen3.8-27B-NVFP4). Two consumers:
+//   - load-time dequant to bf16, then the same Q4_K / NVFP4 requant pipeline load_gguf() uses
+//   - decode GEMV that keeps checkpoint FP8 native (SI_QTYPE_FP8 packed payload; launch_gemv_fp8)
 
 namespace sparkinfer { namespace kernels {
 
@@ -16,6 +12,10 @@ namespace sparkinfer { namespace kernels {
 // w: [rows,cols] raw e4m3 bytes, scale: [rows] bf16, out: [rows,cols] bf16.
 void launch_ct_dequant_fp8(const void* w_e4m3, const void* scale_bf16, void* out_bf16,
                            int rows, int cols, cudaStream_t stream = nullptr);
+
+// Same dequant, packed as [bf16 scale[rows] | e4m3 w[rows*cols]] (SI_QTYPE_FP8 decode payload).
+void launch_ct_dequant_fp8_packed(const void* packed, void* out_bf16,
+                                  int rows, int cols, cudaStream_t stream = nullptr);
 
 // NVFP4 (E2M1), block_size=16 group scale (UE4M3) + a single tensor-wide F32 global scale:
 //   out[r,c] = float(e2m1(packed nibble)) * float(ue4m3(group_scale[r, c/16])) * global_scale

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -64,6 +64,12 @@ void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int 
 void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N, int K,
                        cudaStream_t stream = nullptr);
 
+// Compressed-tensors FP8 (E4M3) on-read GEMV. W is the packed payload
+// [bf16 scale[N] | e4m3 weight[N*K]] (SI_QTYPE_FP8). Dequant matches launch_ct_dequant_fp8
+// then a bf16 GEMV: each weight is rounded to bf16(float(e4m3)*scale) before the dot.
+void launch_gemv_fp8(const void* x, const void* W, void* y, int N, int K,
+                     cudaStream_t stream = nullptr);
+
 // Pre-quantized Q8_1 activation path: quantize x[K] ONCE (q8 int8 [K], ad/as [K/32]),
 // then run Q4_K dp4a GEMVs that read it — kills the per-block re-quantization that the
 // in-kernel dp4a path repeats N/8 times (and per GEMV). Output is bit-exact vs that path.

--- a/kernels/include/sparkinfer/kernels/qtype.h
+++ b/kernels/include/sparkinfer/kernels/qtype.h
@@ -19,4 +19,10 @@ namespace sparkinfer { namespace kernels {
 // unqualified name from that file's kernels.
 static constexpr int SI_QTYPE_Q3A = 112;   // == the block size in bytes, per 256 weights
 
+// Compressed-tensors FP8 (E4M3) kept native for decode GEMV. Payload is
+//   [bf16 scale[N] | e4m3 W[N*K]]
+// matching launch_ct_dequant_fp8's per-row scale: W_bf16[r,c] = bf16(float(e4m3)*float(scale[r])).
+// 108 is unused as a ggml type id (ggml's 108 is not a weight format we ship).
+static constexpr int SI_QTYPE_FP8 = 108;
+
 }} // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -96,7 +96,8 @@ struct Qwen35LayerWeights {
     // null to preserve KV and batched-prefill scratch headroom on 32-GB cards.
     const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
-    // 14=Q6_K) -> weights kept quantized in VRAM, decoded on-read by launch_gemv_q.
+    // 14=Q6_K, 8=Q8_0) or SI_QTYPE_FP8 (108) -> weights kept quantized in VRAM,
+    // decoded on-read by launch_gemv_q / launch_gemv_fp8.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;
     int wqkv_type = 0, wqkv_gate_type = 0, ssm_beta_type = 0, ssm_alpha_type = 0, ssm_out_type = 0;
     int shared_gate_inp_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -23,6 +23,7 @@
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/quant.h"
+#include "sparkinfer/kernels/qtype.h"
 #include "sparkinfer/kernels/proj_requant.h"
 #include "sparkinfer/kernels/prefill_nvfp4.h"
 #include "sparkinfer/lmcache_bridge_client.h"
@@ -1133,6 +1134,8 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                     kernels::launch_mmvq_q6k(s.aq81, W, y, N, H, pst);
                 else if (s.use_pq && s.use_llama && t == 8)
                     kernels::launch_mmvq_q80(s.aq81, W, y, N, H, pst);
+                else if (t == kernels::SI_QTYPE_FP8)
+                    kernels::launch_gemv_fp8(s.xn, W, y, N, H, pst);
                 else if (t) kernels::launch_gemv_q(s.xn, W, t, y, N, H, pst);
                 else        kernels::launch_gemv(s.xn, W, y, N, H, pst);
             } else {
@@ -1155,6 +1158,8 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 } else if (s.use_pq && s.use_llama && t == 8) {
                     kernels::launch_quantize_q8_1_blocks(x, s.aq81, K, st);
                     kernels::launch_mmvq_q80(s.aq81, W, y, N, K, st);
+                } else if (t == kernels::SI_QTYPE_FP8) {
+                    kernels::launch_gemv_fp8(x, W, y, N, K, st);
                 } else if (t) kernels::launch_gemv_q(x, W, t, y, N, K, st);
                 else          kernels::launch_gemv(x, W, y, N, K, st);
             } else {
@@ -1180,7 +1185,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                     fuse = (e && e[0] == '0') ? 0 : 1; }
                 return fuse && s.gguf && s.use_pq && s.use_llama &&
                        w.wqkv_type == 12 && w.wqkv_gate_type == 12 &&
-                       (H == 2048 || H == 4096) && s.linear_qkvdim > 0 && s.linear_vdim > 0;
+                       (H == 2048 || H == 4096 || H == 5120) && s.linear_qkvdim > 0 && s.linear_vdim > 0;
             }();
             if (gdn_quad) {
                 kernels::launch_gdn_quad_mmvq_q4k(s.aq81, w.wqkv, w.wqkv_gate, w.ssm_alpha, w.ssm_beta,
@@ -1224,7 +1229,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             static int gdn_fuse = -1;
             if (gdn_fuse < 0) { const char* e = getenv("SPARKINFER_GDN_FUSE"); gdn_fuse = (e && e[0] == '0') ? 0 : 1; }
             if (gdn_fuse && c.linear_head_dim == 128 && c.linear_q_heads == 16 &&
-                c.linear_v_heads == 32) {
+                (c.linear_v_heads == 32 || c.linear_v_heads == 48)) {
                 kernels::launch_qwen36_conv_split_l2norm_fused(s.lin_qkv, w.ssm_conv, conv_state,
                                                  s.lin_q, s.lin_k, s.lin_v,
                                                  c.linear_q_heads, c.linear_v_heads,
@@ -1305,7 +1310,7 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 // The fused QKV kernel writes one contiguous q of width nq and knows nothing about
                 // a separate gate tensor, so it cannot serve this path.
                 const bool attn_qkv = !sep_gate && s.use_attn_qkv && s.use_pq && s.use_llama
-                                   && (H == 2048 || H == 4096)
+                                   && (H == 2048 || H == 4096 || H == 5120)
                                    && w.wq_type == 12 && w.wk_type == 12 && w.wv_type == 12;
                 if (attn_qkv) {
                     kernels::launch_attn_qkv_mmvq_q4k(s.aq81, w.wq, w.wk, w.wv,
@@ -4399,17 +4404,29 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         return out;
     };
 
-    // bf16 [out,in] source -> kept resident as-is (qtype=0), decode reads it via the existing
-    // plain-bf16 launch_gemv fallback in proj_xn/proj_from (the t==0 branch of the same dispatch
-    // Q4_K/Q6_K/Q8_0 share). Used for GDN's projections instead of requant_q4k: these weights are
-    // themselves dequantized from FP8 at load time, and re-quantizing an already-quantized source
-    // to 4 bits a second time compounds error more than a single quantization step from a native
-    // bf16/fp32 checkpoint would.
-    auto keep_bf16 = [&](void* bf16_src, int& qtype) -> const void* {
-        if (!bf16_src) return nullptr;
-        s.owned.push_back(bf16_src);
-        qtype = 0;
-        return bf16_src;
+    // Checkpoint FP8 kept native: [bf16 scale[rows] | e4m3 W[rows*cols]]. Decode reads it via
+    // launch_gemv_fp8, which applies the same bf16(float(e4m3)*scale) rounding as dequant_fp8
+    // so the GEMV matches keep_bf16 at half the GDN traffic. A second quant (Q4_K / Q8_0) on
+    // these already-FP8 weights fails the PR-vs-main gate (Q4_K: top1 0.96 / KL 0.035;
+    // Q8_0: top1 1.00 / KL 0.015, bar is 0.01).
+    auto keep_fp8 = [&](const std::string& prefix, int rows, int cols, int& qtype) -> const void* {
+        const STTensor* w = st.tensor(prefix + ".weight");
+        const STTensor* sc = st.tensor(prefix + ".weight_scale");
+        if (!w || !sc || w->dtype != STDType::F8_E4M3 || w->n_values != (long)rows * cols ||
+            sc->n_values != rows) {
+            fprintf(stderr, "[compressed-tensors] %s: missing/malformed FP8 weight or scale\n",
+                    prefix.c_str());
+            return nullptr;
+        }
+        const size_t scale_bytes = (size_t)rows * 2;
+        const size_t w_bytes = (size_t)rows * (size_t)cols;
+        void* packed = nullptr;
+        if (cudaMalloc(&packed, scale_bytes + w_bytes) != cudaSuccess) return nullptr;
+        cudaMemcpy(packed, sc->data, scale_bytes, cudaMemcpyHostToDevice);
+        cudaMemcpy(static_cast<char*>(packed) + scale_bytes, w->data, w_bytes, cudaMemcpyHostToDevice);
+        s.owned.push_back(packed);
+        qtype = kernels::SI_QTYPE_FP8;
+        return packed;
     };
 
     // bf16 [out,in] source -> resident Q4_K (decode path). Frees the source.
@@ -4465,12 +4482,12 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
 
         if (w.linear_attn) {
             const std::string lb = b + "linear_attn.";
-            void* qkv = dequant_fp8(lb + "in_proj_qkv", s.linear_qkvdim, H);
-            w.wqkv = keep_bf16(qkv, w.wqkv_type);
-            void* z = dequant_fp8(lb + "in_proj_z", c.linear_v_heads * c.linear_head_dim, H);
-            w.wqkv_gate = keep_bf16(z, w.wqkv_gate_type);
-            void* op = dequant_fp8(lb + "out_proj", H, s.linear_vdim);
-            w.ssm_out = keep_bf16(op, w.ssm_out_type);
+            // Native checkpoint FP8 (not a second Q4_K/Q8_0 fit): same bf16 rounding as
+            // keep_bf16, half the GDN traffic. See keep_fp8 above.
+            w.wqkv = keep_fp8(lb + "in_proj_qkv", s.linear_qkvdim, H, w.wqkv_type);
+            w.wqkv_gate = keep_fp8(lb + "in_proj_z", c.linear_v_heads * c.linear_head_dim, H,
+                                   w.wqkv_gate_type);
+            w.ssm_out = keep_fp8(lb + "out_proj", H, s.linear_vdim, w.ssm_out_type);
             // Small, checkpoint-unquantized tensors -- plain bf16, NO transpose. conv1d's raw HF
             // layout [qkvdim,1,conv_kernel] (=[qkvdim,conv_kernel] squeezed) already matches
             // conv_split_kernel's own indexing (conv_w[d*conv_kernel+t], d=channel, t=tap) --

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -16,6 +16,8 @@
 #include "sparkinfer/kernels/prefill_attn_window.h"
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/quant.h"
+#include "sparkinfer/kernels/qtype.h"
+#include "sparkinfer/kernels/compressed_tensors.h"
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/prefill_i8.h"
 #include "sparkinfer/kernels/prefill_fp8.h"
@@ -624,6 +626,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // Dequantize a native GGUF weight [n_out,K] to bf16 scratch; return a bf16 [n_out,K] ptr.
     auto dq = [&](const void* W, int wtype, int n_out, int K) -> const void* {
         if (wtype == 0) return W;   // already bf16 dense
+        if (wtype == kernels::SI_QTYPE_FP8) {
+            kernels::launch_ct_dequant_fp8_packed(W, wbuf, n_out, K, st);
+            return wbuf;
+        }
         kernels::launch_gguf_dequant(wtype, W, wbuf, (long)n_out * K, st);
         return wbuf;
     };


### PR DESCRIPTION
## Summary

**Native FP8 (E4M3) on-read GEMV for Qwen3.8-27B GDN projections (1.27x decode@128; differential accuracy is bit-identical).**

#831 keeps the three large GDN weights (`in_proj_qkv`, `in_proj_z`, `out_proj`) as BF16 after a load-time FP8 dequant. Those 48 layers are the decode bandwidth bottleneck on this checkpoint: ~10.6 GB of BF16 GDN traffic per token vs ~5.3 GB if the checkpoint E4M3 stays resident. A second quant of those already-FP8 weights is faster but fails the PR-vs-main gate (Q4_K: top1 0.96 / KL 0.035; Q8_0: top1 1.00 / KL 0.015, bar is 0.01). This PR keeps the checkpoint bytes and dequants on read.

Two mechanisms. The first is the scored win; the second is shape enablement that does not move the needle while GDN is still BF16:

1. **`launch_gemv_fp8` / `SI_QTYPE_FP8`** — packed payload `[bf16 scale[N] | e4m3 W[N*K]]`, same per-row scale as `launch_ct_dequant_fp8`. Each weight is rounded to `bf16(float(e4m3)*scale)` before the dot, and the split-K walk uses the same 8-wide association as `gemv_f32_sk_kernel`, so the result matches keep_bf16 + `launch_gemv`. Prefill `dq()` dequants the packed form back to bf16 so batched prefill does not treat type 108 as F32. Occupancy split matches the existing Q8_0 / bf16 GEMV (`SPARKINFER_GEMV_SK=0` restores the one-warp kernel).
2. **Qwen3.8 shape specs** — `si_mmvq_q4k_kfixed` / attn-QKV / GDN pack2 NSUPER=20 (K=5120), `gate_up_mmvq2_qwen_kernel<5120,17408,1>`, `gdn_fused_proj` / `attn_qkv` allow H=5120, `conv_split_l2norm_fused` allows `linear_v_heads==48`. Same dots in the same order as the generic kernels (bit-identical). Alone, with GDN still BF16, this was +0.75% — below XS.

Anything that is not this checkpoint's GDN decode (other models, Q4_K FFN/attn, the H=2048/4096 fused paths) goes through the existing dispatch unchanged.

Credit / prior art: #831 (@skyrocket2026) is the compressed-tensors loader this sits on; `launch_ct_dequant_fp8` is the rounding this GEMV must match; the split-K occupancy lever is the same one main already uses for bf16 / Q8_0 GEMV.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `qwen3_gguf_bench` on the scored compressed-tensors directory — the Qwen3.8 bot's own tool; `bench/scripts/bench.sh` is GGUF-only):

| | decode tok/s |
|---|--:|
| before (main) | 66.44 |
| after (this PR) | 84.54 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

```text
# RTX 5090, unsloth/Qwen3.8-27B-NVFP4 (compressed-tensors directory),
# qwen3_gguf_bench, SPARKINFER_BENCH_SWEEP_CTXS=128 REPS=5, isolated binaries
# (LD_LIBRARY_PATH pinned per build).
=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=128 ===
# main (#831 loader):
decode tg    : 66.44 tok/s  (n=128, ctx=128, bs=1)
VRAM used    : 32.4 GB
# this PR:
decode tg    : 84.54 tok/s  (n=128, ctx=128, bs=1)   (+27.2%; XL bar is +18%)
VRAM used    : 27.2 GB
# same-box bot measurement on 743d30f (before the DEFAULT_GGUF crash voided the label):
#   PR 82.76 vs main 64.81  (+27.7%)  top1=1.0000  kl=0.00000
# rejected alternatives, same box, same protocol:
#   GDN requant Q4_K: 96.92 tok/s but top1 0.960 / KL 0.035  REJECT
#   GDN requant Q8_0: 84.17 tok/s but top1 1.000 / KL 0.015  REJECT (bar KL <= 0.01)
#   kfixed/FFN/fuse only, GDN still BF16: 66.94 tok/s (+0.75%, below XS)
```

**Differential accuracy** (`qwen3_gguf_score` + `accuracy_compare_pair.py`, official `eval_text.txt`, topk=128 — the Qwen3.8 bot gate, top1 >= 0.99 / KL <= 0.01):

| | top-1 | KL | PPL |
|---|--:|--:|--:|
| main | — | — | 3.281 |
| this PR | **101/101 (1.000)** | **0.0000** | 3.281 |

**Qwen3.6 no-regression guard** — not re-run on this box (no Qwen3.6 GGUF here). The new dispatch is additive (H=5120 / v_heads=48 / `SI_QTYPE_FP8`); existing 2048/4096/32 paths are unchanged. The eval bot will measure ctx 0/512/4k/16k/32k vs `origin/main`.

**Resident VRAM** (bench-reported, same checkpoint, ctx=128):

| | main | this PR |
|---|--:|--:|
| decode@128 | 32.4 GB | 27.2 GB |

The drop is the 48 GDN layers no longer storing a BF16 expansion of the checkpoint FP8 weights.
