### PR TITLE
perf(qwen3.8): keep checkpoint NVFP4 for prefill FFN (1.29x prefill@4096)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -16,6 +16,7 @@ bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*,
                                          cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
-                               int, void*, cudaStream_t) { return false; }
+                               int, void*, cudaStream_t, float) { return false; }
+bool launch_ct_nvfp4_pack_sfb(const void*, void*, int, int, cudaStream_t) { return false; }
 } // namespace sparkinfer::kernels
 #endif

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -299,14 +299,14 @@ __global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
 
 template <class C = Wide>
 typename C::Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
-                                 void* d, int m, int n, int k) {
+                                 void* d, int m, int n, int k, float alpha = 1.f) {
     auto as = cutlass::make_cute_packed_stride(StrideA{}, {m,k,1});
     auto bs = cutlass::make_cute_packed_stride(StrideB{}, {n,k,1});
     auto cs = cutlass::make_cute_packed_stride(StrideC{}, {m,n,1});
     auto ds = cutlass::make_cute_packed_stride(StrideD{}, {m,n,1});
     return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m,n,k),
             {static_cast<const cutlass::float_e2m1_t*>(a), as, static_cast<const cutlass::float_e2m1_t*>(b), bs, static_cast<const cutlass::float_ue4m3_t*>(sa), sfa_layout(m,n,k), static_cast<const cutlass::float_ue4m3_t*>(sb), sfb_layout(m,n,k)},
-            {{1.f, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
+            {{alpha, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
 }
 
 int sm_count() {
@@ -345,9 +345,9 @@ bool prefer_narrow(int m, int n) {
 
 template <class C>
 bool run_gemm(const void* a, const void* sa, const void* b, const void* sb,
-              void* d, int m, int n, int k, void* ws, cudaStream_t st) {
+              void* d, int m, int n, int k, void* ws, cudaStream_t st, float alpha) {
     typename C::Gemm gemm;
-    auto ar = args<C>(a, sa, b, sb, d, m, n, k);
+    auto ar = args<C>(a, sa, b, sb, d, m, n, k, alpha);
     return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
            gemm.initialize(ar, ws, st) == cutlass::Status::kSuccess &&
            gemm.run(st) == cutlass::Status::kSuccess;
@@ -412,7 +412,7 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
-                               void* d,int m,int n,int k,void* ws,cudaStream_t st) {
+                               void* d,int m,int n,int k,void* ws,cudaStream_t st, float alpha) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
     // Default ON; SPARKINFER_NVFP4_EVICT_FIRST=0 restores CUTLASS's stock loads for A/B.
     static const bool ef = [] {
@@ -420,10 +420,10 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
         return !e || atoi(e) != 0;
     }();
     if (ef)
-        return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st)
-                                  : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st);
-    return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st)
-                              : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st);
+        return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha)
+                                  : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha);
+    return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st,alpha)
+                              : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st,alpha);
 }
 
 // ---- HuggingFace "compressed-tensors" NVFP4 checkpoint dequant (load-time, one-shot) ----
@@ -466,6 +466,34 @@ void launch_ct_dequant_nvfp4(const void* packed_u8, const void* group_scale_ue4m
         reinterpret_cast<const unsigned char*>(packed_u8),
         reinterpret_cast<const unsigned char*>(group_scale_ue4m3), global_scale,
         reinterpret_cast<__nv_bfloat16*>(out_bf16), rows, cols);
+}
+
+template <class Layout>
+__global__ void pack_sfb_rows(const unsigned char* __restrict__ src,
+                              cutlass::float_ue4m3_t* sf, int rows, int cols,
+                              Layout layout) {
+    const int vpr = cols / 16;
+    const int total = rows * vpr;
+    for (int g = (int)(blockIdx.x * blockDim.x + threadIdx.x); g < total;
+         g += (int)(gridDim.x * blockDim.x)) {
+        const int row = g / vpr, k0 = (g - row * vpr) * 16;
+        auto scales = cute::make_tensor(sf, layout);
+        scales(row, k0, 0) = cutlass::float_ue4m3_t::bitcast(src[g]);
+    }
+}
+
+bool launch_ct_nvfp4_pack_sfb(const void* scale_rowmajor, void* sfb,
+                              int n, int k, cudaStream_t st) {
+    if (!scale_rowmajor || !sfb || !prefill_nvfp4_supported(128, n, k)) return false;
+    const size_t bytes = prefill_nvfp4_scale_bytes_b(n, k);
+    if (bytes && cudaMemsetAsync(sfb, 0, bytes, st) != cudaSuccess) return false;
+    auto l = sfb_layout(128, n, k);
+    int blocks = (n * (k / 16) + 255) / 256;
+    if (blocks > 4096) blocks = 4096;
+    pack_sfb_rows<<<blocks, 256, 0, st>>>(
+        reinterpret_cast<const unsigned char*>(scale_rowmajor),
+        reinterpret_cast<cutlass::float_ue4m3_t*>(sfb), n, k, l);
+    return cudaPeekAtLastError() == cudaSuccess;
 }
 
 } // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -509,6 +509,105 @@ __global__ void gemv_fp8_kernel(const __nv_bfloat16* __restrict__ x,
 #ifndef _MSC_VER
 template __global__ void gemv_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
 #endif
+
+// ---- compressed-tensors NVFP4 (E2M1 + UE4M3 block-16 + F32 global) on-read GEMV --
+// Payload: [256 B header | ue4m3 scale[N*(K/16)] | packed u8[N*(K/2)]].
+// One scale group = 16 weights = 8 packed bytes. LUTs stay in registers --
+// __constant__ + cudaMemcpyToSymbol is unsafe from this static lib's .so link.
+__device__ __forceinline__ float si_e2m1(unsigned nibble) {
+    const float t[16] = {0.f, 0.5f, 1.f, 1.5f, 2.f, 3.f, 4.f, 6.f,
+                         -0.f, -0.5f, -1.f, -1.5f, -2.f, -3.f, -4.f, -6.f};
+    return t[nibble & 15u];
+}
+__device__ __forceinline__ float si_ue4m3(unsigned b) {
+    const int e = (int)((b >> 3) & 15u);
+    const int m = (int)(b & 7u);
+    if (e == 0) return ldexpf((float)m, -9);
+    return ldexpf(8.f + (float)m, e - 10);
+}
+__device__ __forceinline__ float si_nvfp4_group_dot(const unsigned char* packed8,
+                                                    unsigned char scale, float inv_g,
+                                                    const __nv_bfloat16* x16) {
+    const float s = si_ue4m3(scale) * inv_g;
+    const unsigned int p0 = __ldg(reinterpret_cast<const unsigned int*>(packed8));
+    const unsigned int p1 = __ldg(reinterpret_cast<const unsigned int*>(packed8 + 4));
+    const __nv_bfloat162* x2 = reinterpret_cast<const __nv_bfloat162*>(x16);
+    float acc = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const unsigned b = (p0 >> (8 * i)) & 255u;
+        const float2 xf = __bfloat1622float2(x2[i]);
+        acc += (si_e2m1(b & 15u) * s) * xf.x + (si_e2m1(b >> 4) * s) * xf.y;
+    }
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const unsigned b = (p1 >> (8 * i)) & 255u;
+        const float2 xf = __bfloat1622float2(x2[i + 4]);
+        acc += (si_e2m1(b & 15u) * s) * xf.x + (si_e2m1(b >> 4) * s) * xf.y;
+    }
+    return acc;
+}
+
+template <typename OutT, int S>
+__global__ void gemv_nvfp4_sk_kernel(const __nv_bfloat16* __restrict__ x,
+                                     const void* __restrict__ packed,
+                                     OutT* __restrict__ y, int N, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float s_part[RPB][S];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n = blockIdx.x * RPB + row_local;
+    float acc = 0.f;
+    if (n < N) {
+        const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
+        const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
+        const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+        const unsigned char* srow = sf + (size_t)n * (size_t)(K >> 4);
+        const unsigned char* prow = w + (size_t)n * (size_t)(K >> 1);
+        const int ng = K >> 4;
+        for (int g = split * 32 + lane; g < ng; g += S * 32)
+            acc += si_nvfp4_group_dot(prow + (size_t)g * 8, srow[g], inv_g, x + g * 16);
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+        if (lane == 0) s_part[row_local][split] = acc;
+    }
+    __syncthreads();
+    if (n < N && split == 0 && lane == 0) {
+        float o = s_part[row_local][0];
+        #pragma unroll
+        for (int t = 1; t < S; t++) o += s_part[row_local][t];
+        gemv_write(y + n, o);
+    }
+}
+#ifndef _MSC_VER
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 2>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+#endif
+
+template <typename OutT>
+__global__ void gemv_nvfp4_kernel(const __nv_bfloat16* __restrict__ x,
+                                  const void* __restrict__ packed,
+                                  OutT* __restrict__ y, int N, int K) {
+    const int warp = threadIdx.x / 32, lane = threadIdx.x & 31;
+    const int n = blockIdx.x * GEMV_WPB + warp;
+    if (n >= N) return;
+    const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
+    const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
+    const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+    const unsigned char* srow = sf + (size_t)n * (size_t)(K >> 4);
+    const unsigned char* prow = w + (size_t)n * (size_t)(K >> 1);
+    float acc = 0.f;
+    const int ng = K >> 4;
+    for (int g = lane; g < ng; g += 32)
+        acc += si_nvfp4_group_dot(prow + (size_t)g * 8, srow[g], inv_g, x + g * 16);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
+    if (lane == 0) gemv_write(y + n, acc);
+}
+#ifndef _MSC_VER
+template __global__ void gemv_nvfp4_kernel<__nv_bfloat16>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+#endif
 // ---- faithful llama.cpp int8 MMVQ for a dense Q4_K [N,K] GEMV --------------------
 // Quantizes the activation to Q8_1 (int8 + per-32 scale + sum) once per token, then
 // dp4a's the Q4_K weight nibbles against it — the same vec_dot_q4_K_q8_1 math llama.cpp
@@ -2049,8 +2148,30 @@ void launch_gemv_fp8(const void* x, const void* W, void* y, int N, int K, cudaSt
     gemv_fp8_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
 }
 
+void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K, cudaStream_t stream) {
+    if (!x || !W || !y || N < 1 || K < 1 || (K & 15)) return;
+    const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+    auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
+    if (gemv_bf16_splitk()) {
+        if (N >= 8192) {
+            constexpr int S = 2, RPB = GEMV_WPB / S;
+            gemv_nvfp4_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+        } else if (N >= 4096) {
+            constexpr int S = 4, RPB = GEMV_WPB / S;
+            gemv_nvfp4_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+        } else {
+            constexpr int S = 8, RPB = GEMV_WPB / S;
+            gemv_nvfp4_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+        }
+        return;
+    }
+    dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
+    gemv_nvfp4_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+}
+
 void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int K, cudaStream_t stream) {
     if (wtype == SI_QTYPE_FP8) { launch_gemv_fp8(x, W, y, N, K, stream); return; }
+    if (wtype == SI_QTYPE_NVFP4) { launch_gemv_nvfp4(x, W, y, N, K, stream); return; }
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
     if (gemv_mmvq() && wtype == 12) {   // faithful int8 dp4a (Q4_K)
         size_t sm = 2 * (size_t)(K >> 5) * sizeof(float) + (size_t)K;

--- a/kernels/include/sparkinfer/kernels/compressed_tensors.h
+++ b/kernels/include/sparkinfer/kernels/compressed_tensors.h
@@ -3,8 +3,9 @@
 
 // HuggingFace "compressed-tensors" checkpoints (NVIDIA ModelOpt / llm-compressor --
 // e.g. unsloth/Qwen3.8-27B-NVFP4). Two consumers:
-//   - load-time dequant to bf16, then the same Q4_K / NVFP4 requant pipeline load_gguf() uses
+//   - load-time dequant to bf16, then the same Q4_K requant pipeline load_gguf() uses (FP8 FFN)
 //   - decode GEMV that keeps checkpoint FP8 native (SI_QTYPE_FP8 packed payload; launch_gemv_fp8)
+//   - decode GEMV / prefill GEMM that keep checkpoint NVFP4 native (SI_QTYPE_NVFP4; launch_gemv_nvfp4)
 
 namespace sparkinfer { namespace kernels {
 

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -70,6 +70,13 @@ void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N,
 void launch_gemv_fp8(const void* x, const void* W, void* y, int N, int K,
                      cudaStream_t stream = nullptr);
 
+// Compressed-tensors NVFP4 on-read GEMV. W is the SI_QTYPE_NVFP4 payload
+// [256 B header with f32 global_scale | ue4m3 scale[N*(K/16)] | packed u8[N*(K/2)]].
+// Dequant matches launch_ct_dequant_nvfp4 then a bf16 GEMV: each weight is rounded
+// to bf16(e2m1 * ue4m3 / global_scale) before the dot. K must be a multiple of 16.
+void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K,
+                       cudaStream_t stream = nullptr);
+
 // Pre-quantized Q8_1 activation path: quantize x[K] ONCE (q8 int8 [K], ad/as [K/32]),
 // then run Q4_K dp4a GEMVs that read it — kills the per-block re-quantization that the
 // in-kernel dp4a path repeats N/8 times (and per GEMV). Output is bit-exact vs that path.

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -28,6 +28,15 @@ bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,
                                const void* b_fp4, const void* sfb,
                                void* d_bf16, int m, int n, int k,
-                               void* workspace, cudaStream_t stream = nullptr);
+                               void* workspace, cudaStream_t stream = nullptr,
+                               float alpha = 1.f);
+
+// Scatter a compressed-tensors row-major UE4M3 scale [n, k/16] into the CUTLASS
+// SFB layout launch_prefill_nvfp4_gemm expects for B. Packed E2M1 bytes are
+// already the same nibble order as launch_prefill_nvfp4_quant_b, so they are
+// used as-is. The checkpoint's tensor-wide global_scale is applied as GEMM
+// alpha (1/global_scale), not folded into these UE4M3 bytes.
+bool launch_ct_nvfp4_pack_sfb(const void* scale_rowmajor, void* sfb,
+                              int n, int k, cudaStream_t stream = nullptr);
 
 } // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/qtype.h
+++ b/kernels/include/sparkinfer/kernels/qtype.h
@@ -25,4 +25,15 @@ static constexpr int SI_QTYPE_Q3A = 112;   // == the block size in bytes, per 25
 // 108 is unused as a ggml type id (ggml's 108 is not a weight format we ship).
 static constexpr int SI_QTYPE_FP8 = 108;
 
+// Compressed-tensors NVFP4 (E2M1, block 16) kept native. Payload is
+//   [256 B header: f32 global_scale at byte 0 |
+//    ue4m3 scale[N*(K/16)] |
+//    packed u8[N*(K/2)]]
+// The 256-byte header keeps the packed region 256-aligned for CUTLASS TMA.
+// Dequant matches launch_ct_dequant_nvfp4:
+//   W[r,c] = e2m1(nibble) * ue4m3(scale[r,c/16]) / global_scale.
+// 109 is unused as a ggml type id.
+static constexpr int SI_QTYPE_NVFP4 = 109;
+static constexpr int SI_NVFP4_HDR = 256;
+
 }} // namespace sparkinfer::kernels

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -84,6 +84,9 @@ struct Qwen35LayerWeights {
     // unsupported shapes continue to use the GGUF-native pointers above.
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
+    // 1/weight_global_scale for checkpoint-native NVFP4 B operands. Muse's
+    // from-bf16 quant_b copies leave this at 1 (global already folded into UE4M3).
+    float gate_fp4_alpha = 1.f, up_fp4_alpha = 1.f, down_fp4_alpha = 1.f;
     // q | attn_gate | k | v stacked into ONE [2*qdim + 2*kvdim, H] FP4 operand. They all project
     // the same `xn` and the batched prefill already runs them as a single grouped GEMM to keep the
     // grid full, so the FP4 form has to stay grouped too -- as four separate GEMMs at m=128 the
@@ -96,8 +99,9 @@ struct Qwen35LayerWeights {
     // null to preserve KV and batched-prefill scratch headroom on 32-GB cards.
     const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
-    // 14=Q6_K, 8=Q8_0) or SI_QTYPE_FP8 (108) -> weights kept quantized in VRAM,
-    // decoded on-read by launch_gemv_q / launch_gemv_fp8.
+    // 14=Q6_K, 8=Q8_0) or SI_QTYPE_FP8 (108) / SI_QTYPE_NVFP4 (109) -> weights kept
+    // quantized in VRAM, decoded on-read by launch_gemv_q / launch_gemv_fp8 /
+    // launch_gemv_nvfp4.
     int wq_type = 0, wgate_type = 0, wk_type = 0, wv_type = 0, wo_type = 0;
     int wqkv_type = 0, wqkv_gate_type = 0, ssm_beta_type = 0, ssm_alpha_type = 0, ssm_out_type = 0;
     int shared_gate_inp_type = 0;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -193,6 +193,7 @@ struct Qwen35Model::Impl {
     bf16 *lin_z = nullptr, *lin_alpha = nullptr, *lin_beta = nullptr;
     bf16 *lin_gdn = nullptr, *lin_norm = nullptr, *shared_gate_tmp = nullptr;
     bf16 *sh_gate = nullptr, *sh_up = nullptr, *sh_h = nullptr;   // shared-expert GEMV scratch [moe_ffn]
+    bf16 *nvfp4_g = nullptr, *nvfp4_u = nullptr, *nvfp4_h = nullptr;  // native NVFP4 dense-FFN decode scratch
     bf16 *lin_conv_state = nullptr;
     float* lin_state = nullptr;
     // "Current" session's penalty_counts (swapped by activate_session(), unconditionally, for
@@ -620,6 +621,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->lin_z); cudaFree(p_->lin_alpha); cudaFree(p_->lin_beta);
     cudaFree(p_->lin_gdn); cudaFree(p_->lin_norm); cudaFree(p_->lin_conv_state); cudaFree(p_->lin_state);
     cudaFree(p_->shared_gate_tmp);
+    cudaFree(p_->nvfp4_g); cudaFree(p_->nvfp4_u); cudaFree(p_->nvfp4_h);
     cudaFree(p_->mf_logits); cudaFree(p_->mf_weights); cudaFree(p_->mf_h); cudaFree(p_->mf_out);
     cudaFree(p_->sx_h); cudaFree(p_->sx_q8);
     cudaFree(p_->mf_ids); cudaFree(p_->mf_counts); cudaFree(p_->mf_rc);
@@ -4237,12 +4239,10 @@ bool Qwen35Model::load_gguf(const std::string& path) {
 // comment, and silently mis-shaped every projection in the model; see the dequant_fp8 comment for
 // the three kernels whose contracts pin the layout down.
 //
-// Every quantized tensor is dequantized to bf16 once (via the new launch_ct_dequant_fp8/
-// launch_ct_dequant_nvfp4 kernels), then requantized into the SAME internal formats load_gguf()
-// already produces for every other model: Q4_K (gate_q/up_q/down_q/wq/wk/wv/wo, decode path,
-// launch_proj_requant_q4k_lloyd) and, for the NVFP4-routed FFN layers only, this runtime's own
-// fresh NVFP4 (gate_fp4/up_fp4, prefill path, launch_prefill_nvfp4_quant_b) -- no new GEMM/GEMV
-// kernels, no checkpoint-provided global scale carried past the initial dequant.
+// FP8 tensors are either kept native (GDN, launch_gemv_fp8) or dequantized to bf16 and
+// requantized to Q4_K (attn q/k/v/o, lm_head, FFN layers 56-63). NVFP4 FFN tensors
+// (layers 0-55) keep the checkpoint packed bytes for prefill (CUTLASS SFB + GEMM
+// alpha = 1/weight_global_scale) and a Q4_K decode copy (native GEMV is slower).
 bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     Impl& s = *p_;
     SafeTensorsModel st;
@@ -4379,31 +4379,6 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         return out;   // caller owns; either requantizes from it (then frees) or pushes to s.owned
     };
 
-    // NVFP4 weight [rows,cols] (HF [out,in], block_size=16) -> dequant -> bf16, layout unchanged.
-    auto dequant_nvfp4 = [&](const std::string& prefix, int rows, int cols) -> void* {
-        const STTensor* wp = st.tensor(prefix + ".weight_packed");
-        const STTensor* gs = st.tensor(prefix + ".weight_scale");
-        const STTensor* glob = st.tensor(prefix + ".weight_global_scale");
-        if (!wp || !gs || !glob || wp->dtype != STDType::U8 || wp->n_values != (long)rows * cols / 2 ||
-            gs->n_values != (long)rows * cols / 16 || glob->n_values != 1) {
-            fprintf(stderr, "[compressed-tensors] %s: missing/malformed NVFP4 tensors\n", prefix.c_str());
-            return nullptr;
-        }
-        float global_scale = 1.f;
-        memcpy(&global_scale, glob->data, sizeof(float));
-        void *wpd = nullptr, *gsd = nullptr, *out = nullptr;
-        const size_t packed_bytes = (size_t)rows * cols / 2, scale_bytes = (size_t)rows * cols / 16;
-        if (cudaMalloc(&wpd, packed_bytes) != cudaSuccess) return nullptr;
-        if (cudaMalloc(&gsd, scale_bytes) != cudaSuccess) { cudaFree(wpd); return nullptr; }
-        if (cudaMalloc(&out, (size_t)rows * cols * 2) != cudaSuccess) { cudaFree(wpd); cudaFree(gsd); return nullptr; }
-        cudaMemcpy(wpd, wp->data, packed_bytes, cudaMemcpyHostToDevice);
-        cudaMemcpy(gsd, gs->data, scale_bytes, cudaMemcpyHostToDevice);
-        kernels::launch_ct_dequant_nvfp4(wpd, gsd, global_scale, out, rows, cols, s.stream);
-        cudaStreamSynchronize(s.stream);
-        cudaFree(wpd); cudaFree(gsd);
-        return out;
-    };
-
     // Checkpoint FP8 kept native: [bf16 scale[rows] | e4m3 W[rows*cols]]. Decode reads it via
     // launch_gemv_fp8, which applies the same bf16(float(e4m3)*scale) rounding as dequant_fp8
     // so the GEMV matches keep_bf16 at half the GDN traffic. A second quant (Q4_K / Q8_0) on
@@ -4442,23 +4417,70 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         return q4;
     };
 
-    // bf16 [out,in] source -> fresh NVFP4 (prefill path, gate_fp4/up_fp4 shape). Does NOT free
-    // bf16_src -- caller (FFN loop below) still needs it for the Q4_K decode copy.
-    auto quantize_nvfp4_prefill = [&](const void* bf16_src, int rows, int cols,
-                                      const void** data, const void** sf) -> bool {
-        if (!bf16_src || !kernels::prefill_nvfp4_supported(128, rows, cols)) return false;
-        void *d = nullptr, *scale = nullptr;
-        if (cudaMalloc(&d, kernels::prefill_nvfp4_data_bytes(rows, cols)) != cudaSuccess) return false;
-        if (cudaMalloc(&scale, kernels::prefill_nvfp4_scale_bytes_b(rows, cols)) != cudaSuccess) {
-            cudaFree(d); return false;
+    // Checkpoint NVFP4 kept native: [256 B header with f32 global_scale |
+    // ue4m3 scale[rows*cols/16] | packed u8[rows*cols/2]]. Decode reads it via
+    // launch_gemv_nvfp4. Prefill reuses the packed region as CUTLASS B and
+    // scatters the UE4M3 scales into SFB; the tensor-wide global_scale becomes
+    // GEMM alpha (1/global), matching launch_ct_dequant_nvfp4's divide. The
+    // header is 256 B so the packed region stays TMA-aligned.
+    auto keep_nvfp4 = [&](const std::string& prefix, int rows, int cols,
+                          const void** fp4, const void** fp4_sf, float& fp4_alpha) -> const void* {
+        const STTensor* wp = st.tensor(prefix + ".weight_packed");
+        const STTensor* gs = st.tensor(prefix + ".weight_scale");
+        const STTensor* glob = st.tensor(prefix + ".weight_global_scale");
+        if (!wp || !gs || !glob || wp->dtype != STDType::U8 ||
+            wp->n_values != (long)rows * cols / 2 ||
+            gs->n_values != (long)rows * cols / 16 || glob->n_values != 1) {
+            fprintf(stderr, "[compressed-tensors] %s: missing/malformed NVFP4 tensors\n",
+                    prefix.c_str());
+            return nullptr;
         }
-        if (!kernels::launch_prefill_nvfp4_quant_b(bf16_src, d, scale, rows, cols, s.stream) ||
-            cudaStreamSynchronize(s.stream) != cudaSuccess) {
-            cudaFree(d); cudaFree(scale); return false;
+        float global_scale = 1.f;
+        memcpy(&global_scale, glob->data, sizeof(float));
+        const size_t scale_bytes = (size_t)rows * cols / 16;
+        const size_t packed_bytes = (size_t)rows * cols / 2;
+        const size_t hdr = (size_t)kernels::SI_NVFP4_HDR;
+        void* payload = nullptr;
+        if (cudaMalloc(&payload, hdr + scale_bytes + packed_bytes) != cudaSuccess) return nullptr;
+        cudaMemset(payload, 0, hdr);
+        cudaMemcpy(payload, &global_scale, 4, cudaMemcpyHostToDevice);
+        cudaMemcpy(static_cast<char*>(payload) + hdr, gs->data, scale_bytes, cudaMemcpyHostToDevice);
+        cudaMemcpy(static_cast<char*>(payload) + hdr + scale_bytes, wp->data, packed_bytes,
+                   cudaMemcpyHostToDevice);
+        s.owned.push_back(payload);
+        fp4_alpha = (global_scale != 0.f) ? (1.f / global_scale) : 1.f;
+        const void* packed = static_cast<char*>(payload) + hdr + scale_bytes;
+        if (kernels::prefill_nvfp4_supported(128, rows, cols)) {
+            void* sf = nullptr;
+            const size_t sf_bytes = kernels::prefill_nvfp4_scale_bytes_b(rows, cols);
+            if (sf_bytes && cudaMalloc(&sf, sf_bytes) == cudaSuccess &&
+                kernels::launch_ct_nvfp4_pack_sfb(static_cast<char*>(payload) + hdr, sf,
+                                                  rows, cols, s.stream) &&
+                cudaStreamSynchronize(s.stream) == cudaSuccess) {
+                s.owned.push_back(sf);
+                *fp4 = packed;
+                *fp4_sf = sf;
+            } else if (sf) {
+                cudaFree(sf);
+            }
         }
-        s.owned.push_back(d); s.owned.push_back(scale);
-        *data = d; *sf = scale;
-        return true;
+        return payload;
+    };
+
+    // Decode stays on the existing Q4_K MMVQ path (native NVFP4 GEMV is ~0.65x).
+    // Dequant from the payload we already uploaded so the host tensors are not reread.
+    auto q4k_from_nvfp4 = [&](const void* payload, int rows, int cols, int& qtype) -> const void* {
+        if (!payload) return nullptr;
+        const size_t hdr = (size_t)kernels::SI_NVFP4_HDR;
+        const size_t scale_bytes = (size_t)rows * cols / 16;
+        float gs = 1.f;
+        cudaMemcpy(&gs, payload, 4, cudaMemcpyDeviceToHost);
+        void* out = nullptr;
+        if (cudaMalloc(&out, (size_t)rows * cols * 2) != cudaSuccess) return nullptr;
+        kernels::launch_ct_dequant_nvfp4(
+            static_cast<const char*>(payload) + hdr + scale_bytes,
+            static_cast<const char*>(payload) + hdr, gs, out, rows, cols, s.stream);
+        return requant_q4k(out, (long)rows * cols, qtype);
     };
 
     // embed_tokens: HF embedding tables are already [vocab,hidden] (not a Linear layer), no
@@ -4534,20 +4556,21 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             void* d = dequant_fp8(mb + "down_proj", H, c.moe_ffn);
             w.down_q = requant_q4k(d, (long)H * c.moe_ffn, w.down_qtype);
         } else {
-            void* g_bf16 = dequant_nvfp4(mb + "gate_proj", c.moe_ffn, H);
-            void* u_bf16 = dequant_nvfp4(mb + "up_proj", c.moe_ffn, H);
-            void* d_bf16 = dequant_nvfp4(mb + "down_proj", H, c.moe_ffn);
-            bool gu_ok = g_bf16 && u_bf16 &&
-                quantize_nvfp4_prefill(g_bf16, c.moe_ffn, H, &w.gate_fp4, &w.gate_fp4_sf) &&
-                quantize_nvfp4_prefill(u_bf16, c.moe_ffn, H, &w.up_fp4, &w.up_fp4_sf);
-            if (gu_ok) ++gu_ready;
-            w.gate_q = requant_q4k(g_bf16, (long)c.moe_ffn * H, w.gate_qtype);
-            w.up_q = requant_q4k(u_bf16, (long)c.moe_ffn * H, w.up_qtype);
-            w.down_q = requant_q4k(d_bf16, (long)H * c.moe_ffn, w.down_qtype);
+            const void* g_pay = keep_nvfp4(mb + "gate_proj", c.moe_ffn, H,
+                                           &w.gate_fp4, &w.gate_fp4_sf, w.gate_fp4_alpha);
+            const void* u_pay = keep_nvfp4(mb + "up_proj", c.moe_ffn, H,
+                                           &w.up_fp4, &w.up_fp4_sf, w.up_fp4_alpha);
+            const void* d_pay = keep_nvfp4(mb + "down_proj", H, c.moe_ffn,
+                                           &w.down_fp4, &w.down_fp4_sf, w.down_fp4_alpha);
+            w.gate_q = q4k_from_nvfp4(g_pay, c.moe_ffn, H, w.gate_qtype);
+            w.up_q = q4k_from_nvfp4(u_pay, c.moe_ffn, H, w.up_qtype);
+            w.down_q = q4k_from_nvfp4(d_pay, H, c.moe_ffn, w.down_qtype);
+            if (w.gate_fp4 && w.up_fp4) ++gu_ready;
         }
         if (!w.gate_q || !w.up_q || !w.down_q) return false;
     }
-    fprintf(stderr, "[compressed-tensors] loaded %d layers, gate/up NVFP4 prefill ready %d/%d\n",
+    fprintf(stderr, "[compressed-tensors] loaded %d layers, native NVFP4 prefill FFN %d/%d "
+            "(decode stays Q4_K)\n",
             c.n_layers, gu_ready, c.n_layers);
     return true;
 }

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -383,9 +383,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // function (qkv-fusion, wo-fusion, sandwich norm) -- those are structurally specific to
     // Muse's own tensor layout (a separate wgate tensor; Qwen3.8-27B fuses its gate into Q's
     // projection width instead) and don't apply here.
-    const bool q38_nvfp4 = c.dense_ffn && !c.muse_glimmer && N == 128 && !s.w.layers.empty() &&
-                           s.w.layers[0].gate_fp4 &&
-                           kernels::prefill_nvfp4_supported(N, ffn, H);
+    // Muse keeps N==128 (its scored shape). Qwen3.8 batched prefill only runs at ctx>=4096
+    // (int8 KV), so pinning this to N==128 meant the native gate/up NVFP4 GEMM never fired
+    // on the path the bench actually times. CUTLASS accepts any m%8==0, n/k%128==0 — 4k x
+    // 17408 x 5120 qualifies. SPARKINFER_Q38_NVFP4=0 restores the int8/bf16 FFN.
+    const bool q38_nvfp4 = [&] {
+        if (!c.dense_ffn || c.muse_glimmer || s.w.layers.empty() || !s.w.layers[0].gate_fp4)
+            return false;
+        if (!kernels::prefill_nvfp4_supported(N, ffn, H)) return false;
+        const char* e = getenv("SPARKINFER_Q38_NVFP4");
+        return !(e && e[0] == '0');
+    }();
     const bool gu_nvfp4 = muse_nvfp4 || q38_nvfp4;
     const size_t fp4_a_data_bytes = gu_nvfp4
         ? kernels::prefill_nvfp4_data_bytes(N, H) : 0;
@@ -408,7 +416,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         ? kernels::prefill_nvfp4_workspace_bytes(N, H, qdim) : 0;
     const bool muse_nvfp4_down = muse_nvfp4 && s.w.layers[0].down_fp4 &&
                                  kernels::prefill_nvfp4_supported(N, H, ffn);
-    const size_t fp4_ws_down = muse_nvfp4_down
+    const bool q38_nvfp4_down = q38_nvfp4 && s.w.layers[0].down_fp4 &&
+                                kernels::prefill_nvfp4_supported(N, H, ffn);
+    const bool nvfp4_down = muse_nvfp4_down || q38_nvfp4_down;
+    const size_t fp4_ws_down = nvfp4_down
         ? kernels::prefill_nvfp4_workspace_bytes(N, H, ffn) : 0;
     size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
     if (fp4_ws_wo > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_wo;
@@ -417,9 +428,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     unsigned char* fp4_as = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
     bf16* fp4_qkv = muse_nvfp4_qkv ? a8.alloc<bf16>((size_t)N * qkvg_n) : nullptr;
-    unsigned char* fp4_down_a = muse_nvfp4_down
+    unsigned char* fp4_down_a = nvfp4_down
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
-    unsigned char* fp4_down_as = muse_nvfp4_down
+    unsigned char* fp4_down_as = nvfp4_down
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, ffn)) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
@@ -1046,21 +1057,25 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
-                const bool layer_fp4 = gu_nvfp4 && fn == 128 && w.gate_fp4 && w.gate_fp4_sf &&
+                const bool layer_fp4 = gu_nvfp4 && w.gate_fp4 && w.gate_fp4_sf &&
                     w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as &&
+                    kernels::prefill_nvfp4_supported(fn, ffn, H) &&
                     kernels::launch_prefill_nvfp4_quant_a(hn_c, fp4_a, fp4_as, fn, H, st) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gate_fp4, w.gate_fp4_sf,
-                                                       ffg, fn, ffn, H, fp4_ws, st) &&
+                                                       ffg, fn, ffn, H, fp4_ws, st,
+                                                       w.gate_fp4_alpha) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4, w.up_fp4_sf,
-                                                       ffu, fn, ffn, H, fp4_ws, st);
+                                                       ffu, fn, ffn, H, fp4_ws, st,
+                                                       w.up_fp4_alpha);
                 if (layer_fp4) {
-                    const bool down_fp4_done = muse_nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
+                    const bool down_fp4_done = nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
                         fp4_down_a && fp4_down_as &&
                         kernels::launch_prefill_nvfp4_swiglu_quant_a(
                             ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn, st) &&
                         kernels::launch_prefill_nvfp4_gemm(
                             fp4_down_a, fp4_down_as, w.down_fp4, w.down_fp4_sf,
-                            ao + (size_t)fo * H, fn, H, ffn, fp4_ws, st);
+                            ao + (size_t)fo * H, fn, H, ffn, fp4_ws, st,
+                            w.down_fp4_alpha);
                     if (!down_fp4_done) {
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,


### PR DESCRIPTION
## Summary
Keep the compressed-tensors NVFP4 FFN weights in their checkpoint encoding for batched prefill, instead of dequantizing to BF16 and requantizing. Decode stays on Q4_K so tok/s does not regress.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 84.83 |
| after (this PR) | 84.88 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 7465.67 |
| after prefill (this PR) | 9595.52 |

Same-box RTX 5090, `unsloth/Qwen3.8-27B-NVFP4`, isolated `LD_LIBRARY_PATH` binaries. Prefill is batched at ctx=4096 (int8 KV). Decode@128 is the scored metric and does not regress. VRAM 27.2 → 30.8 GB (checkpoint NVFP4 copy kept next to Q4_K).

```text
# main (e6cfc2d / same-box /tmp/base_bin)
=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=4096 ===
VRAM used    : 27.2 GB
decode tg    : 81.41 tok/s
prefill pp   : 7465.67 tok/s  (ctx=4096)
SWEEP_JSON {"4096":{"decode_tps":81.41,"prefill_pp":7465.67}}

=== sparkinfer bench sweep ctx=128 ===
decode tg    : 84.83 tok/s  (n=128, ctx=128, bs=1)
VRAM used    : 27.2 GB

# this PR (/tmp/opt_bin)
[compressed-tensors] loaded 64 layers, native NVFP4 prefill FFN 56/64 (decode stays Q4_K)

=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=4096 ===
VRAM used    : 30.8 GB
decode tg    : 81.40 tok/s  (n=32, ctx=4096, bs=1)
prefill pp   : 9595.52 tok/s  (ctx=4096)
SWEEP_JSON {"4096":{"decode_tps":81.4003,"prefill_pp":9595.5225}}

=== sparkinfer bench sweep ctx=128 (median of 5) ===
VRAM used    : 30.8 GB
decode tg    : 84.88 tok/s  (n=128, ctx=128, bs=1)
SWEEP_JSON {"128":{"decode_tps":84.8760,"prefill_pp":88.7738}}
```