### PR TITLE
perf(qwen3.8): batched prefill over a bf16 KV cache (14.9x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1055,6 +1055,133 @@ __global__ void pf_attn_int8_paged_kernel(
 }
 
 // ============================================================================
+// bf16-KV batched prefill for the hybrid dense models (Qwen3.8): a NeoX-RoPE
+// QK-norm/append and a full-causal paged attention that need no int8 KV.
+//
+// Batched prefill previously required an int8 KV cache, and the bench only turns int8 on at
+// ctx>=4096, so Qwen3.8's prefill@128 declined to the sequential per-token path -- 88.0 tok/s
+// against 84.2 tok/s of decode, i.e. 128 full weight-streaming passes to fill 128 positions.
+// These are bf16 twins of pf_qknorm_rope_kv_int8_kernel and pf_attn_int8_paged_kernel<256>:
+// same schedule, same fp32 online softmax, same NeoX (i, i+half) partial rotation, with the
+// int8 quantize/dequantize removed and the pool typed bf16 -- which is exactly the KV a
+// forward_token decode step writes when kv8 is off, so a decode continuing from this cache
+// reads a consistent one.
+// ============================================================================
+__global__ void pf_qknorm_rope_kv_bf16_kernel(
+    __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
+    const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
+    __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    const int* __restrict__ block_table,
+    int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
+    int block_size, int max_blocks_per_seq) {
+    const int tok  = blockIdx.x;
+    const int unit = blockIdx.y;
+    const int t    = threadIdx.x;
+    const int pos  = tok;                              // prefill: position == token index
+    const int blk  = pos / block_size, within = pos % block_size;
+    const int phys = block_table[blk];
+    const size_t ctok = (size_t)phys * block_size + within;
+
+    extern __shared__ float s_h[];
+    __shared__ float s_warp[32];
+
+    const bool is_q = unit < n_q_heads;
+    const bool is_k = !is_q && unit < n_q_heads + n_kv_heads;
+    if (unit >= n_q_heads + 2 * n_kv_heads) return;
+
+    if (is_q || is_k) {
+        const int hh = is_q ? unit : (unit - n_q_heads);
+        const size_t base = ((size_t)tok * (is_q ? n_q_heads : n_kv_heads) + hh) * head_dim;
+        const __nv_bfloat16* src = is_q ? q : k;
+        const __nv_bfloat16* nrm = is_q ? q_w : k_w;
+        const float xv = pf_to_f(src[base + t]);
+        float ss = xv * xv;
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) ss += __shfl_xor_sync(0xffffffff, ss, m);
+        if ((t & 31) == 0) s_warp[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = (t < (head_dim + 31) / 32) ? s_warp[t] : 0.f;
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) vv += __shfl_xor_sync(0xffffffff, vv, m);
+            if (t == 0) s_warp[0] = rsqrtf(vv / head_dim + eps);
+        }
+        __syncthreads();
+        s_h[t] = pf_to_f(__float2bfloat16(xv * s_warp[0] * pf_to_f(nrm[t])));
+        __syncthreads();
+        // NeoX rotate-half over the first rotary_dim dims (partial rotary): pair (i, i+half),
+        // out[i] = x[i]*cos - x[i+half]*sin, out[i+half] = x[i+half]*cos + x[i]*sin.
+        float out = s_h[t];
+        if (rotary_dim > 0 && t < rotary_dim) {
+            const int half = rotary_dim >> 1;
+            const int i    = (t < half) ? t : (t - half);
+            const float freq = __powf(theta, -2.f * (float)i / (float)rotary_dim);
+            const float ang = (float)pos * freq, c = __cosf(ang), sn = __sinf(ang);
+            const float x0 = s_h[i], x1 = s_h[i + half];
+            out = (t < half) ? (x0 * c - x1 * sn) : (x1 * c + x0 * sn);
+        }
+        if (is_q) {
+            q[base + t] = __float2bfloat16(out);
+        } else {
+            const size_t dst = (ctok * n_kv_heads + hh) * head_dim;
+            k_pool[dst + t] = __float2bfloat16(out);
+        }
+    } else {
+        const int hh = unit - n_q_heads - n_kv_heads;
+        const size_t base = ((size_t)tok * n_kv_heads + hh) * head_dim;
+        const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+        v_pool[dst + t] = v[base + t];
+    }
+}
+
+template <int HEAD_DIM>
+__global__ void pf_attn_bf16_paged_kernel(
+    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
+    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int block_size, int max_blocks_per_seq, float scale) {
+    constexpr int ELEMS = HEAD_DIM / 32;
+    const int head = blockIdx.y;
+    const int qtok = blockIdx.x;
+    const int lane = threadIdx.x;
+    if (head >= n_q_heads || qtok >= n_tokens) return;
+    const int kv_head = head / (n_q_heads / n_kv_heads);
+
+    const size_t q_off = ((size_t)qtok * n_q_heads + head) * HEAD_DIM;
+    float q_reg[ELEMS];
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) q_reg[e] = pf_to_f(q[q_off + lane + e * 32]);
+
+    float m = -1e30f, l = 0.f, acc[ELEMS];
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
+
+    for (int kpos = 0; kpos <= qtok; kpos++) {
+        const int blk = kpos / block_size, within = kpos % block_size;
+        const int phys = block_table[blk];
+        const size_t ckt = ((size_t)phys * block_size + within);
+        const size_t kv_off = (ckt * n_kv_heads + kv_head) * HEAD_DIM;
+        float partial = 0.f;
+        #pragma unroll
+        for (int e = 0; e < ELEMS; e++)
+            partial += q_reg[e] * pf_to_f(k_pool[kv_off + lane + e * 32]);
+        const float score = pf_wsum(partial) * scale;
+
+        const float m_new = fmaxf(m, score);
+        const float corr  = __expf(m - m_new);
+        const float p     = __expf(score - m_new);
+        l = l * corr + p;
+        #pragma unroll
+        for (int e = 0; e < ELEMS; e++)
+            acc[e] = acc[e] * corr + p * pf_to_f(v_pool[kv_off + lane + e * 32]);
+        m = m_new;
+    }
+    const float inv = (l > 0.f) ? (1.f / l) : 0.f;
+    #pragma unroll
+    for (int e = 0; e < ELEMS; e++) attn[q_off + lane + e * 32] = __float2bfloat16(acc[e] * inv);
+}
+
+// ============================================================================
 // Host launchers
 // ============================================================================
 void launch_prefill_gemm(const void* A, const void* W, void* C,
@@ -1323,6 +1450,47 @@ void launch_prefill_attn_int8_paged(
         pf_attn_int8_paged_kernel<256><<<grid, 32, 0, stream>>>(
             qb, k_pool, v_pool, ks, vs, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
             block_size, max_blocks_per_seq, scale);
+}
+
+void launch_prefill_qknorm_rope_kv_bf16(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream) {
+    dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);
+    const size_t shmem = (size_t)head_dim * sizeof(float);
+    pf_qknorm_rope_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+        reinterpret_cast<const __nv_bfloat16*>(k_w),
+        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+        block_size, max_blocks_per_seq);
+}
+
+bool launch_prefill_attn_bf16_paged(
+    const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
+    dim3 grid(n_tokens, n_q_heads);
+    auto qb = reinterpret_cast<const __nv_bfloat16*>(q);
+    auto kb = reinterpret_cast<const __nv_bfloat16*>(k_pool);
+    auto vb = reinterpret_cast<const __nv_bfloat16*>(v_pool);
+    auto ob = reinterpret_cast<__nv_bfloat16*>(attn);
+    if (head_dim == 256) {
+        pf_attn_bf16_paged_kernel<256><<<grid, 32, 0, stream>>>(
+            qb, kb, vb, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
+            block_size, max_blocks_per_seq, scale);
+        return true;
+    }
+    if (head_dim == 128) {
+        pf_attn_bf16_paged_kernel<128><<<grid, 32, 0, stream>>>(
+            qb, kb, vb, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
+            block_size, max_blocks_per_seq, scale);
+        return true;
+    }
+    return false;
 }
 
 } // namespace kernels

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -132,6 +132,21 @@ void launch_prefill_qknorm_rope_kv_int8(
 // RoPE when rotary_dim>0 (SWA layers), or NoPE when rotary_dim==0 (global layers) + bf16 KV
 // write. Muse Glimmer runs a bf16 KV cache (its decode KV write is bf16), so no int8 scale.
 //   k_pool/v_pool: bf16 [phys_tok, n_kv_heads, hd]
+// bf16-KV twin of launch_prefill_qknorm_rope_kv_int8: NeoX (i, i+half) partial RoPE and a bf16
+// KV write, for hybrid dense models whose bench runs a bf16 cache at short context (Qwen3.8).
+void launch_prefill_qknorm_rope_kv_bf16(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream = nullptr);
+
+// Full-causal attention over a bf16 paged KV pool. false = no instantiation for head_dim.
+bool launch_prefill_attn_bf16_paged(
+    const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
+
 void launch_prefill_qknorm_ropenorm_kv_bf16(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
     void* k_pool, void* v_pool,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -935,12 +935,37 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
                 void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
                 void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-                if (!kv8) { a.free_all(); a8.free_all(); am.free_all(); aw.free_all(); fprintf(stderr, "[prefill] batched prefill requires int8 KV\n"); return -1; }
+                // bf16 KV: batched prefill used to decline here, which sent Qwen3.8's prefill@128
+                // down the sequential per-token path (88.0 tok/s, barely above its own 84.2 tok/s
+                // decode, because that path re-streams every weight once per position). The bf16
+                // twins below take the same schedule as the int8 pair with the quantize removed,
+                // and write exactly the bf16 KV a forward_token decode writes when kv8 is off, so
+                // a decode continuing from this cache reads a consistent one.
+                // SPARKINFER_PREFILL_BF16_KV=0 restores the decline.
+                static int pf_bf16kv = -1;
+                if (pf_bf16kv < 0) { const char* e = getenv("SPARKINFER_PREFILL_BF16_KV"); pf_bf16kv = (e && e[0] == '0') ? 0 : 1; }
+                if (!kv8) {
+                    // Capability check by shape, NOT by calling the launcher -- invoking it as a
+                    // probe would really launch the kernel, on the wrong stream and over a KV pool
+                    // this pass has not written yet.
+                    const bool bf16_attn_ok = pf_bf16kv && (c.head_dim == 128 || c.head_dim == 256);
+                    if (!bf16_attn_ok) {
+                        a.free_all(); a8.free_all(); am.free_all(); aw.free_all();
+                        fprintf(stderr, "[prefill] batched prefill requires int8 KV\n");
+                        return -1;
+                    }
+                    kernels::launch_prefill_qknorm_rope_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
+                        kpool, vpool, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                        rope_dim, rope_theta, eps, bs, mbs, st);
+                    kernels::launch_prefill_attn_bf16_paged(qb, kpool, vpool, btable, att,
+                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
+                } else {
                 kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
                     kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
                     rope_dim, rope_theta, eps, bs, mbs, st);
                 kernels::launch_prefill_attn_int8_paged(qb, kpool, vpool, kscale, vscale, btable, att,
                     N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
+                }
             }
             // Muse: the gated attention output feeds exactly one consumer -- the o projection's
             // row-quantize -- so fold the gate into that quantize's load phase. `att` is then never


### PR DESCRIPTION
## Summary

Batched prefill required an int8 KV cache, and the bench only turns int8 on at ctx>=4096, so
Qwen3.8's prefill@128 declined to the sequential per-token path — 87.70 pp against this model's
own 83.78 tok/s decode. Prefill being barely faster than decode is the signature of filling 128
positions with 128 full weight-streaming passes instead of one batched GEMM pass. Two bf16 twins
of the existing int8 prefill kernels remove that requirement.

- `pf_qknorm_rope_kv_bf16_kernel` — `pf_qknorm_rope_kv_int8_kernel` with the quantize/scale
  dropped and the pool typed bf16, keeping the same NeoX `(i, i+half)` partial rotation.
- `pf_attn_bf16_paged_kernel<256>` — `pf_attn_int8_paged_kernel<256>` with the dequant dropped,
  keeping the same one-warp-per-query schedule and the same fp32 online softmax.

Both write exactly the bf16 KV a `forward_token` decode step writes when int8 KV is off, so a
decode continuing from this cache reads a consistent one. The int8 branch is untouched and still
taken whenever int8 KV is on; the bf16 branch is only reachable for `head_dim` 128/256.
`SPARKINFER_PREFILL_BF16_KV=0` restores the decline, so both arms come out of one binary.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `bench_sweep_run <dir> 128 128 5`, compressed-tensors checkpoint):

| | decode tok/s |
|---|--:|
| before (main) | 83.78 |
| after (this PR) | 83.88 |

**Prefill pp tok/s** (same sweep, same model load, ctx=128):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 87.70 |
| after prefill (this PR) | 1308.78 |

**+1392% prefill@128 (14.92x)**, decode unchanged. Both arms from one binary, interleaved
round-robin, five reps inside each process, median of five rounds, with
`SPARKINFER_BENCH_PROMPT_FILE` set to the tokenized `bench/scripts/bench_prompt.txt` (225 ids).
A third arm byte-identical to the baseline ran every round as a noise floor:

```text
  round 1: main pp=88.0880  batched pp=1313.7707  ctrl pp=87.9644
  round 2: main pp=87.8207  batched pp=1312.1579  ctrl pp=87.7219
  round 3: main pp=87.7000  batched pp=1308.7811  ctrl pp=87.6667
  round 4: main pp=87.6380  batched pp=1308.0574  ctrl pp=87.6470
  round 5: main pp=87.6278  batched pp=1308.6681  ctrl pp=87.7011

  prefill  main 87.70 | batched 1308.78 | control 87.70
  +1392.34% (14.92x), 5/5 rounds, noise floor +0.00%
  decode   main 83.78 | batched   83.88 | control 83.75   (no regression)
```

## Correctness

This moves ctx=128 onto the batched prefill path, which has its own numerics — as it already does
for every model and context that uses it today. That is worth measuring rather than asserting, so
the prefix was filled through each path and the same positions then scored
(`SPARKINFER_PREFIX_CACHE_LEN=64`, `bench/scripts/accuracy_compare_pair.py`):

```text
  this PR's bf16 batched   vs  the existing int8 batched : top1 0.973  KL 0.021
  the existing int8 batched vs  sequential fill          : top1 0.892  KL 0.107
  this PR's bf16 batched   vs  sequential fill           : top1 0.919  KL 0.111

  PPL: sequential 3.116 | int8 batched 3.025 | bf16 batched 2.972
```

The new kernels track the batched path already in the tree (0.973); the batched-vs-sequential gap
is pre-existing and slightly larger for the int8 path than for this one; both batched paths score
lower perplexity than the sequential fill.

Stated plainly, because the harness cannot show it: the differential accuracy gate runs
`qwen3_gguf_score` with no prefix cache, i.e. sequential `forward_token`, so it never exercises
batched prefill and will report top1 1.000 / KL 0.000 for this change regardless of what it did.
The numbers above are the check that gate cannot perform, not a substitute for it.

```text
ctest: 100% tests passed, 21/21
```

## Qwen3.6 no-regression

`batched_prefill.cu` and `qwen35_prefill.cpp` are shared, so the cross-model sweep was run rather
than argued:

```text
  ctx        decode A -> B            prefill A -> B
       0     479.14 ->   479.26
     512     473.17 ->   472.82      9342.52 ->   9291.82
    4096     455.18 ->   455.12     25131.05 ->  25253.05
```

Max deviation 0.54%.
