### PR TITLE
fix(windows): define S_ISDIR for MSVC in qwen_checkpoint.h

### DIFF
--- a/runtime/examples/qwen_checkpoint.h
+++ b/runtime/examples/qwen_checkpoint.h
@@ -27,6 +27,10 @@
 #include "qwen38_hf_config.h"
 
 #include <sys/stat.h>
+// MSVC's <sys/stat.h> defines _S_IFDIR but not the POSIX S_ISDIR macro family.
+#if defined(_MSC_VER) && !defined(S_ISDIR)
+#define S_ISDIR(m) (((m) & _S_IFMT) == _S_IFDIR)
+#endif
 
 #include <fstream>
 #include <string>


### PR DESCRIPTION
`build-windows` is red on main since #831: `qwen_checkpoint.h(52): error C3861: 'S_ISDIR': identifier not found` — MSVC's `<sys/stat.h>` defines `_S_IFDIR`/`_S_IFMT` but not the POSIX `S_ISDIR` macro. Standard 3-line shim, no behavior change on POSIX.