### PR TITLE
perf(qwen3.8): native FP8 GDN prefill + split-K (1.52x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
@@ -19,6 +19,7 @@
 #include <cuda_fp8.h>
 #include <cuda_fp16.h>
 #include <cuda_pipeline.h>
+#include <cstdlib>
 #include "sparkinfer/kernels/prefill_fp8.h"
 
 namespace sparkinfer { namespace kernels {
@@ -80,10 +81,14 @@ __global__ void pf_quantize_rows_fp8_kernel(const __nv_bfloat16* __restrict__ x,
 
 // The 2 in __launch_bounds__ mirrors the int8 kernel: unbounded, nvcc picks a register count that
 // keeps only one block per SM resident.
+// SPLITK partitions the K loop across blockIdx.z (same occupancy fix as launch_prefill_gemm_i8_splitk)
+// and atomicAdds the unscaled fp32 tile into P[M,N]; a separate epilogue applies sx*sw.
+template <bool SPLITK>
 __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
         const __nv_fp8_e4m3* __restrict__ A, const __nv_fp8_e4m3* __restrict__ W,
         const float* __restrict__ sx, const float* __restrict__ sw,
-        __nv_bfloat16* __restrict__ C, int M, int N, int K) {
+        __nv_bfloat16* __restrict__ C, float* __restrict__ P,
+        int M, int N, int K, int ktiles) {
     __shared__ __nv_fp8_e4m3 As[2][FP8_BM][FP8_BK];
     __shared__ __nv_fp8_e4m3 Bs[2][FP8_BN][FP8_BK];
 
@@ -99,6 +104,13 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
     const int m0   = blockIdx.y * FP8_BM;
     const int n0   = blockIdx.x * FP8_BN;
     const int nk   = (K + FP8_BK - 1) / FP8_BK;
+    int t0 = 0, t1 = nk;
+    if (SPLITK) {
+        t0 = blockIdx.z * ktiles;
+        t1 = t0 + ktiles;
+        if (t1 > nk) t1 = nk;
+        if (t0 >= t1) return;
+    }
 
     float acc[FP8_MFRAG][FP8_NFRAG][4];
     #pragma unroll
@@ -127,11 +139,11 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
         #pragma unroll
         for (int j = 0; j < FP8_NFRAG; j++) { h[i][j][0] = 0u; h[i][j][1] = 0u; }
 
-    stage(0, 0);
+    stage(0, t0 * FP8_BK);
     int buf = 0;
-    for (int t = 0; t < nk; t++) {
-        if (t + 1 < nk) stage(buf ^ 1, (t + 1) * FP8_BK);
-        __pipeline_wait_prior(t + 1 < nk ? 1 : 0);
+    for (int t = t0; t < t1; t++) {
+        if (t + 1 < t1) stage(buf ^ 1, (t + 1) * FP8_BK);
+        __pipeline_wait_prior(t + 1 < t1 ? 1 : 0);
         __syncthreads();
 
         #pragma unroll
@@ -163,7 +175,7 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
                           "r"(bf[j][0]), "r"(bf[j][1]));
         }
         // flush fp16 partials into the fp32 accumulator every FP8_FLUSH tiles (and on the last one)
-        if ((t % FP8_FLUSH) == FP8_FLUSH - 1 || t == nk - 1) {
+        if ((t % FP8_FLUSH) == FP8_FLUSH - 1 || t == t1 - 1) {
             #pragma unroll
             for (int i = 0; i < FP8_MFRAG; i++)
                 #pragma unroll
@@ -179,6 +191,23 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
         }
         __syncthreads();
         buf ^= 1;
+    }
+
+    if (SPLITK) {
+        #pragma unroll
+        for (int i = 0; i < FP8_MFRAG; i++) {
+            #pragma unroll
+            for (int j = 0; j < FP8_NFRAG; j++) {
+                const int gn = n0 + wn * 64 + j * 8 + tig * 2;
+                #pragma unroll
+                for (int e = 0; e < 4; e++) {
+                    const int gm = m0 + wm * 32 + i * 16 + grp + (e >> 1) * 8;
+                    const int cn = gn + (e & 1);
+                    if (gm < M && cn < N) atomicAdd(&P[(size_t)gm * N + cn], acc[i][j][e]);
+                }
+            }
+        }
+        return;
     }
 
     // Registers straight to global: c0/c1 (and c2/c3) are adjacent columns -> one bf16x2 store each.
@@ -236,9 +265,69 @@ void launch_prefill_gemm_fp8(const void* A, const void* W,
                              const float* sx, const float* sw, void* C,
                              int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + FP8_BN - 1) / FP8_BN, (M + FP8_BM - 1) / FP8_BM);
-    pf_gemm_fp8_kernel<<<grid, 256, 0, stream>>>(
+    pf_gemm_fp8_kernel<false><<<grid, 256, 0, stream>>>(
         reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
-        sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N, K);
+        sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+}
+
+// Same occupancy knee as the int8 split-K launcher: one 128x128 tile per block, so GDN
+// qkv/z/out at M=128 are 64/48/40 blocks on a 170-SM 5090.
+constexpr int FP8_SK_TILES_MAX = 96;
+constexpr int FP8_SK_TARGET    = 170;
+constexpr int FP8_SK_MIN_KT    = 2;
+constexpr int FP8_SK_MAX       = 32;
+
+static int fp8_sk_splits(int M, int N, int K) {
+    const int tiles = ((N + FP8_BN - 1) / FP8_BN) * ((M + FP8_BM - 1) / FP8_BM);
+    if (tiles <= 0 || tiles >= FP8_SK_TILES_MAX) return 1;
+    int s = (FP8_SK_TARGET + tiles - 1) / tiles;
+    if (s > FP8_SK_MAX) s = FP8_SK_MAX;
+    const int smax = ((K + FP8_BK - 1) / FP8_BK) / FP8_SK_MIN_KT;
+    if (s > smax) s = smax;
+    return s > 1 ? s : 1;
+}
+
+__global__ void pf_gemm_fp8_sk_epi_kernel(const float* __restrict__ P, const float* __restrict__ sx,
+                                          const float* __restrict__ sw, __nv_bfloat16* __restrict__ C,
+                                          int M, int N) {
+    const int m = blockIdx.y;
+    if (m >= M) return;
+    const float s = sx[m];
+    const size_t row = (size_t)m * N;
+    int n = (blockIdx.x * blockDim.x + threadIdx.x) * 2;
+    if (n + 1 < N) {
+        const float2 p = *reinterpret_cast<const float2*>(&P[row + n]);
+        *reinterpret_cast<__nv_bfloat162*>(&C[row + n]) =
+            __floats2bfloat162_rn(p.x * s * sw[n], p.y * s * sw[n + 1]);
+    } else if (n < N) {
+        C[row + n] = __float2bfloat16(P[row + n] * s * sw[n]);
+    }
+}
+
+bool launch_prefill_gemm_fp8_splitk(const void* A, const void* W,
+                                    const float* sx, const float* sw, void* C,
+                                    int M, int N, int K, float* partials,
+                                    cudaStream_t stream) {
+    static const bool on = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GEMM_SPLITK");
+        return !(e && e[0] == '0');
+    }();
+    if (!on || !partials || M <= 0 || M > FP8_BM || N <= 0 || K <= 0) return false;
+    const int splits = fp8_sk_splits(M, N, K);
+    if (splits <= 1) return false;
+    const int nk = (K + FP8_BK - 1) / FP8_BK;
+    const int ktiles = (nk + splits - 1) / splits;
+    const int nz = (nk + ktiles - 1) / ktiles;
+    if (cudaMemsetAsync(partials, 0, (size_t)M * N * sizeof(float), stream) != cudaSuccess)
+        return false;
+    dim3 grid((N + FP8_BN - 1) / FP8_BN, (M + FP8_BM - 1) / FP8_BM, nz);
+    pf_gemm_fp8_kernel<true><<<grid, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
+        sx, sw, nullptr, partials, M, N, K, ktiles);
+    dim3 eg(((N + 1) / 2 + 255) / 256, M);
+    pf_gemm_fp8_sk_epi_kernel<<<eg, 256, 0, stream>>>(
+        partials, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N);
+    return true;
 }
 
 }} // namespace sparkinfer::kernels

--- a/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
@@ -212,6 +212,19 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
 }
 } // namespace
 
+__global__ void pf_fp8_wscales_bf16_kernel(const __nv_bfloat16* __restrict__ s,
+                                           float* __restrict__ sw, int n) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i < n) sw[i] = __bfloat162float(s[i]);
+}
+
+void launch_prefill_fp8_wscales_bf16(const void* scale_bf16, float* sw, int n,
+                                     cudaStream_t stream) {
+    if (n <= 0) return;
+    pf_fp8_wscales_bf16_kernel<<<(n + 255) / 256, 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(scale_bf16), sw, n);
+}
+
 void launch_prefill_quantize_rows_fp8(const void* x_bf16, void* q, float* scale,
                                       int rows, int cols, cudaStream_t stream) {
     pf_quantize_rows_fp8_kernel<<<rows, 32, 0, stream>>>(

--- a/kernels/include/sparkinfer/kernels/prefill_fp8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_fp8.h
@@ -23,6 +23,11 @@ namespace sparkinfer { namespace kernels {
 void launch_prefill_quantize_rows_fp8(const void* x_bf16, void* q, float* scale,
                                       int rows, int cols, cudaStream_t stream = nullptr);
 
+// Checkpoint SI_QTYPE_FP8 stores per-row scales as bf16. The GEMM epilogue wants fp32 sw[N]
+// with the same multiply convention (W_bf16 = e4m3 * scale).
+void launch_prefill_fp8_wscales_bf16(const void* scale_bf16, float* sw, int n,
+                                     cudaStream_t stream = nullptr);
+
 // fp8 GEMM: C[M,N] = A[M,K] @ W^T, W dequantized bf16 [N,K] row-major (C[m,n]=sum_k A[m,k]*W[n,k]).
 // A/W e4m3 with per-row scales sx[M] (per token) and sw[N] (per output channel). Output C is bf16
 // with the dequant sx[m]*sw[n] fused into the store. fp16 accumulate with a per-BK-tile fp32 flush.

--- a/kernels/include/sparkinfer/kernels/prefill_fp8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_fp8.h
@@ -35,6 +35,14 @@ void launch_prefill_gemm_fp8(const void* A, const void* W,
                              const float* sx, const float* sw, void* C,
                              int M, int N, int K, cudaStream_t stream = nullptr);
 
+// Split-K variant for the scored M=128 GDN projections (40-64 tiles on a 170-SM 5090).
+// `partials` is M*N fp32. Returns false when the shape already fills the device (caller
+// keeps launch_prefill_gemm_fp8). SPARKINFER_PREFILL_GEMM_SPLITK=0 disables.
+bool launch_prefill_gemm_fp8_splitk(const void* A, const void* W,
+                                    const float* sx, const float* sw, void* C,
+                                    int M, int N, int K, float* partials,
+                                    cudaStream_t stream = nullptr);
+
 // Fused SwiGLU + per-row int8 quantize: q[r,:] = int8(silu(gate[r,:]) * up[r,:]) with
 // scale[r] = amax_c|.| / 127. Replaces launch_prefill_swiglu + launch_prefill_quantize_rows_i8 on
 // the ffn-wide intermediate (one block per row), removing its DRAM round-trip. Bit-identical.

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -347,7 +347,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // already has grid.y tiles to fill the device with, so the launcher declines it anyway.
     // SPARKINFER_PREFILL_GEMM_SPLITK=0 disables (A/B).
     constexpr int kSkMaxRows = 512;
-    const bool want_sk = c.muse_glimmer && !moe && need_i8 && N <= kSkMaxRows && [] {
+    // Muse Glimmer and Qwen3.8-27B both score M=128, where a 128x128 tile leaves the 5090
+    // empty on skinny n_out (GDN out=40 tiles, attn k/v=8). Qwen3.6 is MoE and stays off.
+    const bool want_sk = !moe && need_i8 && N <= kSkMaxRows && [] {
         const char* e = getenv("SPARKINFER_PREFILL_GEMM_SPLITK");
         return !(e && e[0] == '0');
     }();
@@ -365,7 +367,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         sx = sw = nullptr;
         sk_p = nullptr;
     }
-    // Every split-K use is gated on this, so a non-Muse model never reaches the new kernel.
     const bool mg_sk = sk_p != nullptr;
 
     // Native block-scaled FP4 is deliberately narrow: Muse, the scored M=128 shape, and layers
@@ -683,8 +684,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         a_q = nullptr; a_pk = false;
         kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, R, K, st);
         kernels::launch_prefill_fp8_wscales_bf16(W, sw, n_out, st);
-        kernels::launch_prefill_gemm_fp8(A_i8, static_cast<const char*>(W) + (size_t)n_out * 2,
-                                         sx, sw, C, R, n_out, K, st);
+        const void* We4 = static_cast<const char*>(W) + (size_t)n_out * 2;
+        if (!(sk_p && kernels::launch_prefill_gemm_fp8_splitk(
+                A_i8, We4, sx, sw, C, R, n_out, K,
+                reinterpret_cast<float*>(sk_p), st)))
+            kernels::launch_prefill_gemm_fp8(A_i8, We4, sx, sw, C, R, n_out, K, st);
         return true;
     };
     auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K, int rows = 0) {
@@ -802,11 +806,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             a_q = nullptr; a_pk = false;
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);
             kernels::launch_prefill_fp8_wscales_bf16(w.wqkv, sw, lqkv, st);
-            kernels::launch_prefill_gemm_fp8(A_i8, static_cast<const char*>(w.wqkv) + (size_t)lqkv * 2,
-                                             sx, sw, b8, N, lqkv, H, st);
+            const void* Wq = static_cast<const char*>(w.wqkv) + (size_t)lqkv * 2;
+            if (!(sk_p && kernels::launch_prefill_gemm_fp8_splitk(
+                    A_i8, Wq, sx, sw, b8, N, lqkv, H,
+                    reinterpret_cast<float*>(sk_p), st)))
+                kernels::launch_prefill_gemm_fp8(A_i8, Wq, sx, sw, b8, N, lqkv, H, st);
             kernels::launch_prefill_fp8_wscales_bf16(w.wqkv_gate, sw, lvdim, st);
-            kernels::launch_prefill_gemm_fp8(A_i8, static_cast<const char*>(w.wqkv_gate) + (size_t)lvdim * 2,
-                                             sx, sw, lz, N, lvdim, H, st);
+            const void* Wz = static_cast<const char*>(w.wqkv_gate) + (size_t)lvdim * 2;
+            if (!(sk_p && kernels::launch_prefill_gemm_fp8_splitk(
+                    A_i8, Wz, sx, sw, lz, N, lvdim, H,
+                    reinterpret_cast<float*>(sk_p), st)))
+                kernels::launch_prefill_gemm_fp8(A_i8, Wz, sx, sw, lz, N, lvdim, H, st);
         } else if (fp8_shareq) {
             a_q = nullptr; a_pk = false;                // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);   // xn -> e4m3 once

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -670,8 +670,26 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         else       kernels::launch_prefill_gemm_i8(Aq, Wq, sxq, swq, Cc, R, n_out, K, st);
     };
     // C[N,n_out] = A[N,K] @ W^T  (W native quantized [n_out,K]).
+    static const bool q38_fp8_prefill = [] {
+        const char* e = getenv("SPARKINFER_Q38_FP8_PREFILL");
+        return !(e && e[0] == '0');
+    }();
+    auto proj_fp8_native = [&](const bf16* A, const void* W, bf16* C, int R, int n_out, int K) -> bool {
+        // Checkpoint SI_QTYPE_FP8 is already e4m3 + per-row bf16 scale. At the scored
+        // ctx=128 the int8 arm dequants that to bf16 and requants to s8 every GDN
+        // projection (48 layers × qkv/z/out). Feed the packed e4m3 to the existing
+        // fp8 GEMM instead. SPARKINFER_Q38_FP8_PREFILL=0 restores the requant path.
+        if (!q38_fp8_prefill || !W || !A_i8 || !sx || !sw || n_out < 128) return false;
+        a_q = nullptr; a_pk = false;
+        kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, R, K, st);
+        kernels::launch_prefill_fp8_wscales_bf16(W, sw, n_out, st);
+        kernels::launch_prefill_gemm_fp8(A_i8, static_cast<const char*>(W) + (size_t)n_out * 2,
+                                         sx, sw, C, R, n_out, K, st);
+        return true;
+    };
     auto proj = [&](const bf16* A, const void* W, int wtype, bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;   // rows (M) to process; chunked FFN passes a sub-N count
+        if (wtype == kernels::SI_QTYPE_FP8 && proj_fp8_native(A, W, C, R, n_out, K)) return;
         // int8 only for the big weight-bound projections; keep the tiny per-v-head gate
         // projections (ssm_alpha/ssm_beta, n_out == v_heads) in bf16 — they feed the GDN
         // sigmoid gates, where per-row int8 quant of a 32-wide weight costs more accuracy
@@ -712,7 +730,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool resid_fuse = !_prfuse || _prfuse[0] != '0';
     auto proj_resid = [&](const bf16* A, const void* W, int wtype, bf16* Cx, int n_out, int K,
                           int rows = 0) -> bool {
-        if (!resid_fuse || !use_i8 || n_out < 128) return false;
+        if (!resid_fuse || !use_i8 || n_out < 128 || wtype == kernels::SI_QTYPE_FP8) return false;
         const int R = rows > 0 ? rows : N;
         quant_a_i8(A, R, K);
         if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
@@ -779,7 +797,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const char* _pshareq = getenv("SPARKINFER_PREFILL_FP8_GDN_SHAREQ");
     const bool fp8_shareq = (use_fp8_gdn || moe_fp8) && (!_pshareq || _pshareq[0] != '0');
     auto gdn_qkv_z = [&](const bf16* A, const Qwen35LayerWeights& w) {
-        if (fp8_shareq) {
+        if (q38_fp8_prefill && w.wqkv_type == kernels::SI_QTYPE_FP8 &&
+            w.wqkv_gate_type == kernels::SI_QTYPE_FP8 && A_i8 && sx && sw) {
+            a_q = nullptr; a_pk = false;
+            kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);
+            kernels::launch_prefill_fp8_wscales_bf16(w.wqkv, sw, lqkv, st);
+            kernels::launch_prefill_gemm_fp8(A_i8, static_cast<const char*>(w.wqkv) + (size_t)lqkv * 2,
+                                             sx, sw, b8, N, lqkv, H, st);
+            kernels::launch_prefill_fp8_wscales_bf16(w.wqkv_gate, sw, lvdim, st);
+            kernels::launch_prefill_gemm_fp8(A_i8, static_cast<const char*>(w.wqkv_gate) + (size_t)lvdim * 2,
+                                             sx, sw, lz, N, lvdim, H, st);
+        } else if (fp8_shareq) {
             a_q = nullptr; a_pk = false;                // A_i8 becomes e4m3 -- invalidate the memo
             kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, N, H, st);   // xn -> e4m3 once
             const void* wb = dq(w.wqkv, w.wqkv_type, lqkv, H);


### PR DESCRIPTION
## Summary

Two stacked prefill@128 wins on Qwen3.8-27B, decode unchanged:

1. **Native checkpoint FP8 for GDN** — at ctx=128, GDN still dequantized resident FP8 to BF16 and requantized to int8 on every `qkv` / `z` / `out` projection. Feed the packed e4m3 payload into the existing prefill FP8 GEMM. `SPARKINFER_Q38_FP8_PREFILL=0` restores the requant path.
2. **Split-K occupancy** — at M=128 the 128×128 tile leaves the 5090 empty (GDN 40–64 blocks, attn k/v 8, on 170 SMs). Split K for those FP8 GDN GEMMs and enable the existing int8 split-K for attn. `SPARKINFER_PREFILL_GEMM_SPLITK=0` restores the single-tile path.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 84.93 |
| after (this PR) | 84.91 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 1639.87 |
| after prefill (this PR) | 2488.51 |

Same-box RTX 5090 vs current `origin/main` (#837), `unsloth/Qwen3.8-27B-NVFP4`, isolated `LD_LIBRARY_PATH` binaries, median of 5. Prefill@128 **+51.8% (1.52×)** (1639.87 → 2279.65 native FP8, then → 2488.51 split-K). Decode does not regress. VRAM unchanged at 30.8 GB.

```text
# main 02770d5 / #837, median of 5
=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=128 ===
VRAM used    : 30.8 GB
decode tg    : 84.93 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 1639.87 tok/s  (ctx=128)
SWEEP_JSON {"128":{"decode_tps":84.9295,"prefill_pp":1639.8709}}

# native FP8 only (first commit), median of 5
=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=128 ===
VRAM used    : 30.8 GB
decode tg    : 84.93 tok/s
prefill pp   : 2279.65 tok/s
SWEEP_JSON {"128":{"decode_tps":84.9311,"prefill_pp":2279.6474}}

# this PR (FP8 + split-K), median of 5
=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=128 ===
VRAM used    : 30.8 GB
decode tg    : 84.91 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 2488.51 tok/s  (ctx=128)
SWEEP_JSON {"128":{"decode_tps":84.9090,"prefill_pp":2488.5064}}
```
