### PR TITLE
fix(qwen3.8): restore the dropped FFN residual in the block-scaled prefill

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -94,7 +94,8 @@ if(BUILD_EXAMPLES)
                           nlohmann_json::nlohmann_json)   # same reason as qwen3_gguf_bench above
     add_executable(qwen3_gguf_prefill_check examples/qwen3_gguf_prefill_check.cpp)
     target_include_directories(qwen3_gguf_prefill_check PRIVATE include)
-    target_link_libraries(qwen3_gguf_prefill_check PRIVATE sparkinfer_runtime CUDA::cudart)
+    target_link_libraries(qwen3_gguf_prefill_check PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)   # same reason as qwen3_gguf_bench above
     add_executable(qwen3_gguf_dflash_check examples/qwen3_gguf_dflash_check.cpp)
     target_include_directories(qwen3_gguf_dflash_check PRIVATE include)
     target_link_libraries(qwen3_gguf_dflash_check PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/examples/qwen3_gguf_prefill_check.cpp
+++ b/runtime/examples/qwen3_gguf_prefill_check.cpp
@@ -15,6 +15,7 @@
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/moe/engine.h"
 #include "qwen3_gguf_config.h"
+#include "qwen_checkpoint.h"   // after models/qwen35.h: it references sparkinfer::Qwen35Model
 
 #include <cuda_runtime.h>
 #include <cstdio>
@@ -53,10 +54,17 @@ int main(int argc, char** argv) {
     const int P = argc > 2 ? atoi(argv[2]) : 4096;
     const int C = argc > 3 ? atoi(argv[3]) : 16;
 
+    // Same three-way detection the bench/score tools use, so this checker can verify a
+    // compressed-tensors (NVFP4/FP8) directory too -- previously it only opened a .gguf, which
+    // left the one model whose prefill@128 is scored with no batched-prefill correctness gate.
     sparkinfer::GGUF g;
-    if (!g.open(path)) { printf("[FAIL] open %s\n", path.c_str()); return 1; }
     sparkinfer::Qwen35Config cfg;
-    qwen3_config_from_gguf(g, cfg);
+    QwenCheckpointKind kind = QwenCheckpointKind::Gguf;
+    std::string cperr;
+    if (!qwen_checkpoint_open(path, cfg, g, kind, cperr)) {
+        printf("[FAIL] open %s: %s\n", path.c_str(), cperr.c_str());
+        return 1;
+    }
     cfg.max_seq = P + C + 16;
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
@@ -71,7 +79,7 @@ int main(int argc, char** argv) {
     mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;
     auto engine = sparkinfer::moe::MoEEngine::create(mc);
     sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
-    if (!model.load_gguf(path)) { printf("[FAIL] load_gguf\n"); return 1; }
+    if (!qwen_checkpoint_load(model, path, kind)) { printf("[FAIL] load (%s)\n", qwen_checkpoint_kind_label(kind)); return 1; }
 
     std::vector<int> prompt(P), cont(C);
     for (int i = 0; i < P; i++) prompt[i] = 100 + (i % 20000);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1144,6 +1144,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                        ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     }
+                    // Both arms above land the FFN output in `ao`, and the epilogue only folds `ao`
+                    // into the residual when !ffn_fused. That held while Muse Glimmer was the only
+                    // model reaching here (ffn_fused is `!c.muse_glimmer && ...`, so always false
+                    // for it). Qwen3.8-27B is the first non-Muse model in this branch and it DOES
+                    // fuse the residual, so the epilogue skipped the add and every FP4 layer's FFN
+                    // output was computed and then dropped -- batched-vs-token-loop top1 4/16,
+                    // KL 3.13. Add it here for the chunk rather than declining the FP4 arms, which
+                    // would give the residual back at the cost of the block-scaled down GEMM.
+                    if (ffn_fused)
+                        kernels::launch_prefill_add(x + (size_t)fo * H, ao + (size_t)fo * H,
+                                                    x + (size_t)fo * H, (long)fn * H, st);
                     continue;
                 }
                 if (ffn_i8) {


### PR DESCRIPTION
## Summary

**This is a correctness fix, not a speedup.** Rescoped after rebase: the block-scaled prefill work
this branch originally carried is now on main, and what remains is a live bug that path exposes.

`prefill_batched_run`'s block-scaled FFN branch lands its output in `ao` and then `continue`s, while
the epilogue folds `ao` into the residual stream only when `!ffn_fused`. That invariant held while
Muse Glimmer was the only model reaching the branch — `ffn_fused` is `!c.muse_glimmer && ...`, so it
is always false there. Qwen3.8-27B is the first non-Muse model in that branch and it *does* fuse the
residual, so the epilogue skips the add and **every block-scaled layer computes its FFN output and
then discards it**.

The fix adds the chunk residual inside the branch. Declining the block-scaled arms would also restore
it, but at the cost of the block-scaled down GEMM, so this keeps them.

`qwen3_gguf_prefill_check` grows compressed-tensors directory support. It opened GGUF only, so the
model whose prefill@128 is scored has had **no batched-prefill correctness gate at all** —
`qwen3_gguf_score` cannot stand in for one, because it drives `forward_token` and never calls
`prefill_batched`, so it emits a byte-identical dump whether this path is right or catastrophically
wrong. That is why this survived several rounds of prefill work.

## Correctness

`qwen3_gguf_prefill_check <dir> 128 64` with `SPARKINFER_KV_INT8=0` — fills the KV cache
token-by-token and via `prefill_batched` over the same prompt, teacher-forces the same 64
continuation tokens, compares per-position logits. Both arms from one binary, RTX 5090 (`sm_120`),
`unsloth/Qwen3.8-27B-NVFP4`, against `origin/main` @ `222ad65`:

| | top1 | KL(token \|\| batched) |
|---|--:|--:|
| before (main) | 24/64 = 0.3750 | 1.04584 |
| after (this PR) | **57/64 = 0.8906** | **0.02879** |

Longer prefixes on the fixed build stay in the same band the batched path holds elsewhere:
512 → 16/16 KL 0.00457, 1024 → 15/16 KL 0.00570, 4096 → 15/16 KL 0.00434.

## Throughput

- [x] Tested on **RTX 5090** (`sm_120`)

No speedup is claimed. The added residual is one `N*H` bf16 add per FFN chunk; it costs ~0.6% of
prefill@128, which is inside the 2% regression floor. Reported for completeness, not as a gain —
`bench_sweep_run <dir> 128 128 5`, two separately-configured build trees, alternated, median of 3:

| | decode tok/s | prefill pp tok/s |
|---|--:|--:|
| before (main) | 84.43 | 2439.31 |
| after (this PR) | 84.36 | 2424.58 |

```text
  round 1  main prefill=2444.6701 decode=84.5484   this PR prefill=2429.7398 decode=84.4712
  round 2  main prefill=2439.3092 decode=84.4253   this PR prefill=2424.5819 decode=84.3623
  round 3  main prefill=2428.4906 decode=84.3183   this PR prefill=2416.4693 decode=84.2781
```

The prefill numbers on main above are produced by the path this PR shows to be numerically wrong, so
they are not a like-for-like baseline for throughput purposes — they are here to show the fix does
not regress beyond the floor.
