### PR TITLE
perf(qwen3.8): fused Q4_K-in-GEMM + prefill graph (1.16x prefill@128)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4606,6 +4606,74 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     fprintf(stderr, "[compressed-tensors] loaded %d layers, native NVFP4 prefill FFN %d/%d "
             "(decode stays Q4_K)\n",
             c.n_layers, gu_ready, c.n_layers);
+
+    // Same fused Q4_K-in-GEMM row scales Muse uses, for the tensors this checkpoint still
+    // stores as Q4_K: full-attn q/k/v/o (16 layers) and FFN 56-63 (the 8 FP8 MLP layers
+    // requanted to Q4_K). Lets prefill decode Q4_K inside the GEMM instead of materializing
+    // int8 weights every layer. SPARKINFER_Q38_PREFILL_QB=0 skips (A/B).
+    {
+        const char* e = getenv("SPARKINFER_Q38_PREFILL_QB");
+        if (e && e[0] == '0') return true;
+        auto fusable = [](int t) { return t == 12 || t == 13 || t == 14; };
+        const int qd = c.n_q_heads * c.head_dim;
+        const int q_out = c.hybrid ? qd * 2 : qd;
+        const int kd = c.n_kv_heads * c.head_dim;
+        const int ff = c.moe_ffn;
+        const size_t per_layer = (size_t)q_out + (size_t)kd * 2 + (size_t)H + (size_t)ff * 2 + (size_t)H;
+        const size_t total = per_layer * (size_t)c.n_layers;
+        const size_t tmp_bytes = 64u << 20;
+        signed char* tmp = nullptr;
+        bool ok = cudaMalloc(&s.muse_rs, total * sizeof(float)) == cudaSuccess;
+        ok = ok && cudaMalloc(&tmp, tmp_bytes) == cudaSuccess;
+        auto fill = [&](int qtype, const void* src, float* dst, size_t rows, int cols) -> bool {
+            const int blk = (qtype == 12) ? 144 : (qtype == 13) ? 176 : 210;
+            const size_t rb = (size_t)(cols >> 8) * (size_t)blk;
+            const size_t chunk = tmp_bytes / (size_t)cols;
+            for (size_t r0 = 0; r0 < rows; r0 += chunk) {
+                const size_t nr = (rows - r0 < chunk) ? (rows - r0) : chunk;
+                if (!kernels::launch_gguf_dequant_rows_i8(
+                        qtype, (const char*)src + r0 * rb, tmp, dst + r0, (int)nr, cols, s.stream))
+                    return false;
+            }
+            return true;
+        };
+        for (int i = 0; ok && i < c.n_layers; i++) {
+            Qwen35LayerWeights& lw = s.w.layers[i];
+            float* base = s.muse_rs + (size_t)i * per_layer;
+            size_t off = 0;
+            auto place = [&](const void* W, int wt, const float** rs, int rows, int cols) {
+                float* dst = base + off; off += (size_t)rows;
+                if (ok && W && fusable(wt) && fill(wt, W, dst, (size_t)rows, cols)) *rs = dst;
+            };
+            place(lw.wq,     lw.wq_type,     &lw.wq_rs,    q_out, H);
+            place(lw.wk,     lw.wk_type,     &lw.wk_rs,    kd,    H);
+            place(lw.wv,     lw.wv_type,     &lw.wv_rs,    kd,    H);
+            place(lw.wo,     lw.wo_type,     &lw.wo_rs,    H,     qd);
+            // Layers 0-55 FFN stay on checkpoint NVFP4; only 56-63 are Q4_K in prefill.
+            if (ffn_is_fp8_layer(i)) {
+                place(lw.gate_q, lw.gate_qtype,  &lw.gate_rs,  ff, H);
+                place(lw.up_q,   lw.up_qtype,    &lw.up_rs,    ff, H);
+                place(lw.down_q, lw.down_qtype,  &lw.down_rs,  H,  ff);
+            } else {
+                off += (size_t)ff * 2 + (size_t)H;
+            }
+        }
+        if (ok) ok = cudaStreamSynchronize(s.stream) == cudaSuccess;
+        if (tmp) cudaFree(tmp);
+        if (!ok) {
+            cudaFree(s.muse_rs); s.muse_rs = nullptr;
+            for (int i = 0; i < c.n_layers; i++) {
+                Qwen35LayerWeights& lw = s.w.layers[i];
+                lw.wq_rs = lw.wk_rs = lw.wv_rs = lw.wo_rs = nullptr;
+                lw.gate_rs = lw.up_rs = lw.down_rs = nullptr;
+            }
+            fprintf(stderr, "[compressed-tensors] Q4_K row-scale precompute unavailable "
+                            "-> int8 materialize path\n");
+        } else {
+            fprintf(stderr, "[compressed-tensors] Q4_K prefill row scales ready (%.0f MB)\n",
+                    (double)(total * sizeof(float)) / (1024.0 * 1024.0));
+        }
+    }
     return true;
 }
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -335,7 +335,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     float* lm_ad = a8.alloc<float>((size_t)(H >> 5) + 1);
     float* lm_as = a8.alloc<float>((size_t)(H >> 5) + 1);
 
-    int* qb_partials = (c.muse_glimmer && use_i8 && N <= 128)
+    int* qb_partials = (use_i8 && N <= 128 && !moe)
         ? a8.alloc<int>(qb_partials_cap) : nullptr;
     // Muse Glimmer split-K partials for the skinny projections. launch_prefill_gemm_i8 puts one
     // 128x128 output tile in a block, so Muse's narrow n_out (attn k/v = 256 -> TWO blocks, q and
@@ -773,7 +773,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     auto proj_fused_acc = [&](const bf16* A, const void* W, int wtype, const float* rs,
                               bf16* C, int n_out, int K, int* acc, int rows = 0) {
         const int R = rows > 0 ? rows : N;
-        if (muse_qb && use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
+        if (use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
             quant_a_i8(A, R, K);
             if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
                                                        qb_partials, QB_SPLITS, acc, apk()))
@@ -784,7 +784,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     auto proj_fused = [&](const bf16* A, const void* W, int wtype, const float* rs,
                           bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;
-        if (muse_qb && use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
+        if (use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
             quant_a_i8(A, R, K);
             if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
                                                        qb_partials, QB_SPLITS, nullptr, apk()))
@@ -959,9 +959,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 if (!ink) proj_fused(xn, w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, H);
                 if (!inv) proj_fused(xn, w.wv,    w.wv_type,    w.wv_rs,    vf, kvdim, H);
             } else {
-                proj(xn, w.wq, w.wq_type, b8, wide,  H);             // qraw = [q|gate] per head
-                proj(xn, w.wk, w.wk_type, kf, kvdim, H);
-                proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+                proj_fused(xn, w.wq, w.wq_type, w.wq_rs, b8, wide,  H);  // qraw = [q|gate]
+                proj_fused(xn, w.wk, w.wk_type, w.wk_rs, kf, kvdim, H);
+                proj_fused(xn, w.wv, w.wv_type, w.wv_rs, vf, kvdim, H);
                 kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
             }
             if (c.muse_glimmer) {
@@ -1051,6 +1051,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 if (!wo_fp4_done)
                     proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
+            } else if (w.wo_rs) {
+                proj_fused(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim);
+                attn_fused = false;
             } else {
                 attn_fused = proj_resid(att, w.wo, w.wo_type, x, H, qdim);
                 if (!attn_fused) proj(att, w.wo, w.wo_type, ao, H, qdim);
@@ -1107,7 +1110,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     kernels::launch_prefill_quantize_rows_i8(wb, dst, scale, n_out, K, st);
                 }
             };
-            if (ffn_i8) {
+            const bool ffn_qi8 = use_i8 && w.gate_rs && w.up_rs &&
+                kernels::pf_dense_gemm_qi8_supported(gate_pf_type);
+            if (ffn_i8 && !ffn_qi8) {
                 dequant_w_i8(gate_pf_type, gate_pf, ffn_Wg_i8, ffn_swg, ffn, H);
                 dequant_w_i8(up_pf_type,   up_pf,   ffn_Wu_i8, ffn_swu, ffn, H);
                 dequant_w_i8(w.down_qtype, w.down_q, ffn_Wd_i8, ffn_swd, H, ffn);
@@ -1116,7 +1121,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // so the FFN residual can ride the residual-fused GEMM straight into x per chunk.
             // Muse Glimmer must NOT residual-fuse: the post-FFN sandwich (norm_then_add below) needs
             // the RAW FFN output in `ao`, and the residual it adds onto is `h` (not x).
-            const bool ffn_fused = !c.muse_glimmer && resid_fuse && (ffn_i8 || use_i8);
+            const bool ffn_fused = !c.muse_glimmer && resid_fuse && (ffn_i8 || use_i8) && !ffn_qi8;
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
@@ -1143,6 +1148,32 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                        ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
+                    }
+                    continue;
+                }
+                if (ffn_qi8) {
+                    proj_fused(hn_c, gate_pf, gate_pf_type, w.gate_rs, ffg, ffn, H, fn);
+                    proj_fused(hn_c, up_pf,   up_pf_type,   w.up_rs,   ffu, ffn, H, fn);
+                    a_q = nullptr;
+                    a_pk = kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st,
+                                                                   A_i8p) && A_i8p;
+                    bool down_fused = false;
+                    if (w.down_rs && kernels::pf_dense_gemm_qi8_supported(w.down_qtype)) {
+                        down_fused = kernels::launch_prefill_gemm_qi8_dense(
+                            w.down_qtype, A_i8, sx, w.down_q, w.down_rs,
+                            ao + (size_t)fo * H, fn, H, ffn, st,
+                            qb_partials, QB_SPLITS, nullptr, apk());
+                    }
+                    if (!down_fused) {
+                        if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,
+                                                                  W_i8, sw, H, ffn, st)) {
+                            const void* wb = dq(w.down_q, w.down_qtype, H, ffn);
+                            kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, ffn, st);
+                        }
+                        if (ffn_fused)
+                            gemm_i8(A_i8, W_i8, sx, sw, x + (size_t)fo * H, fn, H, ffn, true);
+                        else
+                            gemm_i8(A_i8, W_i8, sx, sw, ao + (size_t)fo * H, fn, H, ffn, false);
                     }
                     continue;
                 }

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -177,13 +177,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     static cudaGraphExec_t g_pfb_exec  = nullptr;
     static int  g_pfb_n = -1, g_pfb_warm_n = -1, g_pfb_pin_cap = 0;
     static int* g_pfb_pin = nullptr;
-    // DEFAULT ON: measured +5.91% on prefill@128, byte-identical output (SCORE_EQ IDENTICAL,
-    // TOP1 16/16). SPARKINFER_MUSE_PREFILL_GRAPH=0 restores eager dispatch.
+    // DEFAULT ON: measured +5.91% on Muse prefill@128, byte-identical output (SCORE_EQ IDENTICAL,
+    // TOP1 16/16). Qwen3.8-27B is the same dense-hybrid launch storm (~20 kernels/layer × 64)
+    // and the same warm-arena capture is legal there — MoE stays off (host tilemaps / events).
+    // SPARKINFER_MUSE_PREFILL_GRAPH=0 restores eager dispatch.
     static const bool graph_env = [] {
         const char* e = getenv("SPARKINFER_MUSE_PREFILL_GRAPH");
         return !(e && e[0] == '0');
     }();
-    const bool graph_on = graph_env && arena_reuse && c.muse_glimmer;
+    const bool graph_on = graph_env && arena_reuse && c.dense_ffn;
     if (graph_on && N > g_pfb_pin_cap) {
         if (g_pfb_pin) cudaFreeHost(g_pfb_pin);
         g_pfb_pin = nullptr; g_pfb_pin_cap = 0;
@@ -959,9 +961,28 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 if (!ink) proj_fused(xn, w.wk,    w.wk_type,    w.wk_rs,    kf, kvdim, H);
                 if (!inv) proj_fused(xn, w.wv,    w.wv_type,    w.wv_rs,    vf, kvdim, H);
             } else {
-                proj_fused(xn, w.wq, w.wq_type, w.wq_rs, b8, wide,  H);  // qraw = [q|gate]
-                proj_fused(xn, w.wk, w.wk_type, w.wk_rs, kf, kvdim, H);
-                proj_fused(xn, w.wv, w.wv_type, w.wv_rs, vf, kvdim, H);
+                // Qwen3.8: [q|gate] is one wide wq, then skinny k/v (8 tiles each). One grouped
+                // launch fills the 5090; four separate ones leave k/v paying a full CTA duration
+                // for 8 blocks. Same kernel as Muse, bit-identical per tile.
+                bool grouped = false;
+                if (use_i8 && w.wq_rs && w.wk_rs && w.wv_rs &&
+                    w.wk_type == w.wq_type && w.wv_type == w.wq_type &&
+                    kernels::pf_dense_gemm_qi8_supported(w.wq_type)) {
+                    const void*  Wa[3]  = { w.wq, w.wk, w.wv };
+                    const float* rsa[3] = { w.wq_rs, w.wk_rs, w.wv_rs };
+                    void*        Ca[3]  = { b8, kf, vf };
+                    const int    na[3]  = { wide, kvdim, kvdim };
+                    quant_a_i8(xn, N, H);
+                    grouped = kernels::launch_prefill_gemm_qi8_dense_group(
+                        w.wq_type, A_i8, sx, Wa, rsa, Ca, na, 3, N, H, st,
+                        qb_partials, QB_SPLITS, qb_partials_cap,
+                        nullptr, nullptr, nullptr, apk());
+                }
+                if (!grouped) {
+                    proj_fused(xn, w.wq, w.wq_type, w.wq_rs, b8, wide,  H);  // qraw = [q|gate]
+                    proj_fused(xn, w.wk, w.wk_type, w.wk_rs, kf, kvdim, H);
+                    proj_fused(xn, w.wv, w.wv_type, w.wv_rs, vf, kvdim, H);
+                }
                 kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
             }
             if (c.muse_glimmer) {
@@ -1152,8 +1173,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     continue;
                 }
                 if (ffn_qi8) {
-                    proj_fused(hn_c, gate_pf, gate_pf_type, w.gate_rs, ffg, ffn, H, fn);
-                    proj_fused(hn_c, up_pf,   up_pf_type,   w.up_rs,   ffu, ffn, H, fn);
+                    bool gu_grouped = false;
+                    if (gate_pf_type == up_pf_type && w.gate_rs && w.up_rs) {
+                        const void*  Wf[2]  = { gate_pf, up_pf };
+                        const float* rsf[2] = { w.gate_rs, w.up_rs };
+                        void*        Cf[2]  = { ffg, ffu };
+                        const int    nf[2]  = { ffn, ffn };
+                        quant_a_i8(hn_c, fn, H);
+                        gu_grouped = kernels::launch_prefill_gemm_qi8_dense_group(
+                            gate_pf_type, A_i8, sx, Wf, rsf, Cf, nf, 2, fn, H, st,
+                            qb_partials, QB_SPLITS, qb_partials_cap,
+                            nullptr, nullptr, nullptr, apk());
+                    }
+                    if (!gu_grouped) {
+                        proj_fused(hn_c, gate_pf, gate_pf_type, w.gate_rs, ffg, ffn, H, fn);
+                        proj_fused(hn_c, up_pf,   up_pf_type,   w.up_rs,   ffu, ffn, H, fn);
+                    }
                     a_q = nullptr;
                     a_pk = kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st,
                                                                    A_i8p) && A_i8p;


### PR DESCRIPTION
## Summary

Rebased onto [#838](https://github.com/gittensor-ai-lab/sparkinfer/pull/838) (now on main). Three stacked prefill@128 increments, all decode-neutral:

1. **Fused Q4_K-in-GEMM** for the remaining Q4_K tensors (16 full-attn layers + FFN 56–63). Precompute per-row scales at load (14 MB) and decode Q4_K inside the existing dense GEMM.
2. **CUDA-graph replay** of the dense batched prefill (the Muse path, previously gated off for Qwen3.8).
3. **Grouped qi8** for skinny attn k/v and FFN-56-63 gate/up.

`SPARKINFER_Q38_PREFILL_QB=0` restores the materialize path. `SPARKINFER_MUSE_PREFILL_GRAPH=0` restores eager dispatch.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main / #838) | 84.90 |
| after (this PR) | 84.92 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main / #838) | 2489.07 |
| after prefill (this PR) | 2881.27 |

Same-box RTX 5090 vs main (#838), `unsloth/Qwen3.8-27B-NVFP4`, isolated `LD_LIBRARY_PATH`, median of 5. Prefill@128 **+15.8% (1.16×)**. Decode does not regress. VRAM unchanged at 30.8 GB.

```text
# main / #838 path (SPARKINFER_Q38_PREFILL_QB=0), median of 5
=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=128 ===
VRAM used    : 30.8 GB
decode tg    : 84.90 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 2489.07 tok/s  (ctx=128)
SWEEP_JSON {"128":{"decode_tps":84.9039,"prefill_pp":2489.0689}}

# this PR, median of 5
[compressed-tensors] Q4_K prefill row scales ready (14 MB)
=== sparkinfer bench (compressed-tensors NVFP4/FP8) sweep ctx=128 ===
VRAM used    : 30.8 GB
decode tg    : 84.92 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 2881.27 tok/s  (ctx=128)
SWEEP_JSON {"128":{"decode_tps":84.9206,"prefill_pp":2881.2748}}
```
