### PR TITLE
perf(qwen3.8): 3-stage cp.async pipeline for the FP8 GDN prefill projections (1.03x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
@@ -83,14 +83,27 @@ __global__ void pf_quantize_rows_fp8_kernel(const __nv_bfloat16* __restrict__ x,
 // keeps only one block per SM resident.
 // SPLITK partitions the K loop across blockIdx.z (same occupancy fix as launch_prefill_gemm_i8_splitk)
 // and atomicAdds the unscaled fp32 tile into P[M,N]; a separate epilogue applies sx*sw.
-template <bool SPLITK>
+// STAGES is the cp.async pipeline depth. At 2 (one prefetch in flight) the K loop pays a full
+// global-memory latency on nearly every trip: the accumulators alone are acc[2][8][4] + h[2][8][2],
+// so __launch_bounds__(256,2) caps this at 8 warps x 2 blocks and there is no other warp resident
+// to cover the miss. Depth costs only shared memory, not registers -- measured on an RTX 5090 at
+// M=128, non-split-K, against the shipped depth: qkv 74.19 -> 62.49 us (+15.8%), z 73.81 -> 61.92
+// (+16.1%), out 86.48 -> 72.72 (+15.9%). It flattens at 3 (4/6 measure the same within noise), so
+// 3 it is: 48 KB, still two blocks per SM.
+//
+// Only the ISSUE point of the staging moves; the mma order and the FP8_FLUSH cadence are untouched,
+// so the result is bit-identical to the 2-stage path.
+template <bool SPLITK, int STAGES>
 __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
         const __nv_fp8_e4m3* __restrict__ A, const __nv_fp8_e4m3* __restrict__ W,
         const float* __restrict__ sx, const float* __restrict__ sw,
         __nv_bfloat16* __restrict__ C, float* __restrict__ P,
         int M, int N, int K, int ktiles) {
-    __shared__ __nv_fp8_e4m3 As[2][FP8_BM][FP8_BK];
-    __shared__ __nv_fp8_e4m3 Bs[2][FP8_BN][FP8_BK];
+    // Dynamic so depth > 2 can exceed the 48 KB static cap without a second kernel.
+    extern __shared__ __align__(16) char fp8_smem[];
+    auto As = reinterpret_cast<__nv_fp8_e4m3 (*)[FP8_BM][FP8_BK]>(fp8_smem);
+    auto Bs = reinterpret_cast<__nv_fp8_e4m3 (*)[FP8_BN][FP8_BK]>(
+        fp8_smem + (size_t)STAGES * FP8_BM * FP8_BK);
 
     const int tid  = threadIdx.x;
     const int warp = tid >> 5;
@@ -139,11 +152,16 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
         #pragma unroll
         for (int j = 0; j < FP8_NFRAG; j++) { h[i][j][0] = 0u; h[i][j][1] = 0u; }
 
-    stage(0, t0 * FP8_BK);
+    // Fill STAGES-1 buffers before the first mma; empty commits keep the outstanding count (and so
+    // the __pipeline_wait_prior depth below) uniform when the K range is shorter than the pipeline.
+    #pragma unroll
+    for (int i = 0; i < STAGES - 1; i++) {
+        if (t0 + i < t1) stage(i, (t0 + i) * FP8_BK);
+        else             __pipeline_commit();
+    }
     int buf = 0;
     for (int t = t0; t < t1; t++) {
-        if (t + 1 < t1) stage(buf ^ 1, (t + 1) * FP8_BK);
-        __pipeline_wait_prior(t + 1 < t1 ? 1 : 0);
+        __pipeline_wait_prior(STAGES - 2);
         __syncthreads();
 
         #pragma unroll
@@ -190,7 +208,11 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
                 }
         }
         __syncthreads();
-        buf ^= 1;
+        // Refill the buffer just consumed, STAGES-1 tiles ahead.
+        const int nxt = t + STAGES - 1;
+        if (nxt < t1) stage(buf, nxt * FP8_BK);
+        else          __pipeline_commit();
+        buf = (buf + 1 == STAGES) ? 0 : buf + 1;
     }
 
     if (SPLITK) {
@@ -261,13 +283,54 @@ void launch_prefill_quantize_rows_fp8(const void* x_bf16, void* q, float* scale,
         reinterpret_cast<__nv_fp8_e4m3*>(q), scale, rows, cols);
 }
 
+namespace {
+constexpr int FP8_STAGES = 3;
+constexpr size_t FP8_SMEM(int stages) {
+    return (size_t)stages * (FP8_BM * FP8_BK + FP8_BN * FP8_BK);
+}
+
+// SPARKINFER_PREFILL_FP8_STAGES=2 restores the shipped single-prefetch pipeline (A/B from one
+// binary); 4 is kept instantiated so the depth sweep can be re-run on other parts.
+static int fp8_stages_env() {
+    static const int s = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_FP8_STAGES");
+        const int v = e ? atoi(e) : FP8_STAGES;
+        return (v == 2 || v == 3 || v == 4) ? v : FP8_STAGES;
+    }();
+    return s;
+}
+
+// >48 KB of shared memory per block is opt-in, once per kernel.
+template <bool SPLITK, int STAGES>
+static bool fp8_opt_in_smem() {
+    static const bool ok = [] {
+        if (FP8_SMEM(STAGES) <= 48 * 1024) return true;
+        return cudaFuncSetAttribute(pf_gemm_fp8_kernel<SPLITK, STAGES>,
+                                    cudaFuncAttributeMaxDynamicSharedMemorySize,
+                                    (int)FP8_SMEM(STAGES)) == cudaSuccess;
+    }();
+    return ok;
+}
+} // namespace
+
 void launch_prefill_gemm_fp8(const void* A, const void* W,
                              const float* sx, const float* sw, void* C,
                              int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + FP8_BN - 1) / FP8_BN, (M + FP8_BM - 1) / FP8_BM);
-    pf_gemm_fp8_kernel<false><<<grid, 256, 0, stream>>>(
-        reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
-        sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+    const auto a = reinterpret_cast<const __nv_fp8_e4m3*>(A);
+    const auto w = reinterpret_cast<const __nv_fp8_e4m3*>(W);
+    const auto c = reinterpret_cast<__nv_bfloat16*>(C);
+    const int st_ = fp8_stages_env();
+    if (st_ == 4 && fp8_opt_in_smem<false, 4>()) {
+        pf_gemm_fp8_kernel<false, 4><<<grid, 256, FP8_SMEM(4), stream>>>(
+            a, w, sx, sw, c, nullptr, M, N, K, 0);
+    } else if (st_ != 2 && fp8_opt_in_smem<false, 3>()) {
+        pf_gemm_fp8_kernel<false, 3><<<grid, 256, FP8_SMEM(3), stream>>>(
+            a, w, sx, sw, c, nullptr, M, N, K, 0);
+    } else {
+        pf_gemm_fp8_kernel<false, 2><<<grid, 256, FP8_SMEM(2), stream>>>(
+            a, w, sx, sw, c, nullptr, M, N, K, 0);
+    }
 }
 
 // Same occupancy knee as the int8 split-K launcher: one 128x128 tile per block, so GDN
@@ -321,9 +384,19 @@ bool launch_prefill_gemm_fp8_splitk(const void* A, const void* W,
     if (cudaMemsetAsync(partials, 0, (size_t)M * N * sizeof(float), stream) != cudaSuccess)
         return false;
     dim3 grid((N + FP8_BN - 1) / FP8_BN, (M + FP8_BM - 1) / FP8_BM, nz);
-    pf_gemm_fp8_kernel<true><<<grid, 256, 0, stream>>>(
-        reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
-        sx, sw, nullptr, partials, M, N, K, ktiles);
+    const auto a = reinterpret_cast<const __nv_fp8_e4m3*>(A);
+    const auto w = reinterpret_cast<const __nv_fp8_e4m3*>(W);
+    const int st_ = fp8_stages_env();
+    if (st_ == 4 && fp8_opt_in_smem<true, 4>()) {
+        pf_gemm_fp8_kernel<true, 4><<<grid, 256, FP8_SMEM(4), stream>>>(
+            a, w, sx, sw, nullptr, partials, M, N, K, ktiles);
+    } else if (st_ != 2 && fp8_opt_in_smem<true, 3>()) {
+        pf_gemm_fp8_kernel<true, 3><<<grid, 256, FP8_SMEM(3), stream>>>(
+            a, w, sx, sw, nullptr, partials, M, N, K, ktiles);
+    } else {
+        pf_gemm_fp8_kernel<true, 2><<<grid, 256, FP8_SMEM(2), stream>>>(
+            a, w, sx, sw, nullptr, partials, M, N, K, ktiles);
+    }
     dim3 eg(((N + 1) / 2 + 255) / 256, M);
     pf_gemm_fp8_sk_epi_kernel<<<eg, 256, 0, stream>>>(
         partials, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N);

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -94,7 +94,8 @@ if(BUILD_EXAMPLES)
                           nlohmann_json::nlohmann_json)   # same reason as qwen3_gguf_bench above
     add_executable(qwen3_gguf_prefill_check examples/qwen3_gguf_prefill_check.cpp)
     target_include_directories(qwen3_gguf_prefill_check PRIVATE include)
-    target_link_libraries(qwen3_gguf_prefill_check PRIVATE sparkinfer_runtime CUDA::cudart)
+    target_link_libraries(qwen3_gguf_prefill_check PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)   # same reason as qwen3_gguf_bench above
     add_executable(qwen3_gguf_dflash_check examples/qwen3_gguf_dflash_check.cpp)
     target_include_directories(qwen3_gguf_dflash_check PRIVATE include)
     target_link_libraries(qwen3_gguf_dflash_check PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/examples/qwen3_gguf_prefill_check.cpp
+++ b/runtime/examples/qwen3_gguf_prefill_check.cpp
@@ -15,6 +15,7 @@
 #include "sparkinfer/models/qwen35.h"
 #include "sparkinfer/moe/engine.h"
 #include "qwen3_gguf_config.h"
+#include "qwen_checkpoint.h"   // after models/qwen35.h: it references sparkinfer::Qwen35Model
 
 #include <cuda_runtime.h>
 #include <cstdio>
@@ -53,10 +54,17 @@ int main(int argc, char** argv) {
     const int P = argc > 2 ? atoi(argv[2]) : 4096;
     const int C = argc > 3 ? atoi(argv[3]) : 16;
 
+    // Same three-way detection the bench/score tools use, so this checker can verify a
+    // compressed-tensors (NVFP4/FP8) directory too -- previously it only opened a .gguf, which
+    // left the one model whose prefill@128 is scored with no batched-prefill correctness gate.
     sparkinfer::GGUF g;
-    if (!g.open(path)) { printf("[FAIL] open %s\n", path.c_str()); return 1; }
     sparkinfer::Qwen35Config cfg;
-    qwen3_config_from_gguf(g, cfg);
+    QwenCheckpointKind kind = QwenCheckpointKind::Gguf;
+    std::string cperr;
+    if (!qwen_checkpoint_open(path, cfg, g, kind, cperr)) {
+        printf("[FAIL] open %s: %s\n", path.c_str(), cperr.c_str());
+        return 1;
+    }
     cfg.max_seq = P + C + 16;
 
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
@@ -71,7 +79,7 @@ int main(int argc, char** argv) {
     mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;
     auto engine = sparkinfer::moe::MoEEngine::create(mc);
     sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
-    if (!model.load_gguf(path)) { printf("[FAIL] load_gguf\n"); return 1; }
+    if (!qwen_checkpoint_load(model, path, kind)) { printf("[FAIL] load (%s)\n", qwen_checkpoint_kind_label(kind)); return 1; }
 
     std::vector<int> prompt(P), cont(C);
     for (int i = 0; i < P; i++) prompt[i] = 100 + (i % 20000);


### PR DESCRIPTION
## Summary

The GDN in-projections (`in_proj_qkv`, `in_proj_z`, `out_proj`, 48 layers) are the largest single
group left in prefill@128 — 6.40 ms of a 26.16 ms pass — and they move 5.54 GB of e4m3 weight at
only ~48% of this part's bandwidth. The cause is pipeline depth, not tiling: `pf_gemm_fp8_kernel`
runs a **2-stage** cp.async double buffer, so exactly one prefetch is ever in flight, and its
accumulators (`acc[2][8][4]` + `h[2][8][2]`) hold `__launch_bounds__(256, 2)` to 8 warps × 2 blocks
with no other warp resident to cover the miss. At 1.1–1.4 waves these shapes have no neighbouring
block to hide latency either, so the K loop pays a full global latency on nearly every trip.

This takes the pipeline to 3 stages. Depth costs shared memory, not registers, so occupancy is
unchanged: 3 × 16 KB = 48 KB, still two blocks per SM. Shared memory moves to dynamic so the depth
is a template parameter rather than a second kernel.

Only the **issue point** of the staging moves — the mma order and the `FP8_FLUSH` cadence are
untouched, so the result is bit-identical (verified below, not asserted).

Depth 4 measures *worse than the shipped 2* (4802 vs 4839 pp): 64 KB puts one block on an SM and
halves occupancy. 3 is the knee, and it is where the isolated kernel saturates too.

`SPARKINFER_PREFILL_FP8_STAGES=2` restores the shipped pipeline, and `=4` is kept instantiated, so
all three depths A/B from one binary.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench <dir> 128 sweep`, `SWEEP_CTXS=128`, `REPS=5`):

| | decode tok/s |
|---|--:|
| before (main) | 84.35 |
| after (this PR) | 84.33 |

**Prefill pp tok/s** (same sweep, same model load, ctx=128 — the scored context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4839.19 |
| after prefill (this PR) | 4971.01 |

**+2.72% prefill@128**, decode flat, VRAM unchanged at 30.8 GB. Same-box RTX 5090 vs `origin/main`
@ `e9b4a2c`, `unsloth/Qwen3.8-27B-NVFP4`, one binary with the depth selected by env, alternated,
5 reps inside each process, median of three rounds:

```text
  r1 stages=2 SWEEP_JSON {"128":{"decode_tps":84.4489,"prefill_pp":4839.3702}}
  r1 stages=3 SWEEP_JSON {"128":{"decode_tps":84.4205,"prefill_pp":4992.4883}}
  r1 stages=4 SWEEP_JSON {"128":{"decode_tps":84.3786,"prefill_pp":4830.7405}}
  r2 stages=2 SWEEP_JSON {"128":{"decode_tps":84.3455,"prefill_pp":4839.1854}}
  r2 stages=3 SWEEP_JSON {"128":{"decode_tps":84.3289,"prefill_pp":4971.0056}}
  r2 stages=4 SWEEP_JSON {"128":{"decode_tps":84.3002,"prefill_pp":4802.2496}}
  r3 stages=2 SWEEP_JSON {"128":{"decode_tps":84.2967,"prefill_pp":4821.7256}}
  r3 stages=3 SWEEP_JSON {"128":{"decode_tps":84.2757,"prefill_pp":4957.7090}}
  r3 stages=4 SWEEP_JSON {"128":{"decode_tps":84.2480,"prefill_pp":4791.4295}}
```

```text
# main (2-stage)
[compressed-tensors] loaded 64 layers, native NVFP4 prefill FFN 56/64 (decode stays Q4_K)
VRAM used    : 30.8 GB
decode tg    : 84.44 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 4834.37 tok/s  (ctx=128)
SWEEP_JSON {"128":{"decode_tps":84.4412,"prefill_pp":4834.3732}}

# this PR (3-stage)
[compressed-tensors] loaded 64 layers, native NVFP4 prefill FFN 56/64 (decode stays Q4_K)
VRAM used    : 30.8 GB
decode tg    : 84.41 tok/s  (n=128, ctx=128, bs=1)
prefill pp   : 4969.31 tok/s  (ctx=128)
SWEEP_JSON {"128":{"decode_tps":84.4072,"prefill_pp":4969.3056}}
```

Isolated kernel, for the mechanism only (not the before/after claim above) — M=128, non-split-K,
same three shapes, 300 iterations:

```text
qkv [10240,5120]   2-stage 74.19 us -> 3-stage 62.49 us  (+15.8%)
z   [ 6144,5120]   2-stage 73.81 us -> 3-stage 61.92 us  (+16.1%)
out [ 5120,6144]   2-stage 86.48 us -> 3-stage 72.72 us  (+15.9%)
```

## Correctness

Bit-identical, not merely within tolerance. `qwen3_gguf_prefill_check <dir> 128 64` with
`SPARKINFER_KV_INT8=0` (batched prefill vs the token loop over the same prompt, teacher-forced,
per-position logits) returns the same value at every depth from one binary:

| depth | TOP1 | KL |
|---|--:|--:|
| 2 (main) | 0/64 | 7.83639 |
| 3 (this PR) | 0/64 | 7.83639 |
| 4 | 0/64 | 7.83639 |

`qwen3_gguf_score` dumps compare byte-identical between depth 2 and 3.

> The absolute TOP1/KL above are main's, unchanged by this PR — the ctx=128 batched-prefill path is
> already numerically divergent from the token loop on this model before this change. This PR does
> not move it in either direction; the point of the table is that all three depths agree exactly.

`qwen3_gguf_prefill_check` grows compressed-tensors directory support so this check can run on this
model at all — it opened GGUF only.

## Qwen3.6 no-regression

`launch_prefill_gemm_fp8` is shared with Qwen3.6's MoE prefill, so the same binary was swept there
(`SWEEP_CTXS=0,512,4096,16384,32768`, `REPS=2`, ratio = 3-stage / 2-stage):

| ctx | decode | prefill |
|---|--:|--:|
| 0 | 1.000 | — |
| 512 | 1.000 | 1.015 |
| 4096 | 1.001 | 1.002 |
| 16384 | 0.999 | 0.999 |
| 32768 | 0.998 | 0.999 |
