### PR TITLE
perf(qwen3.8): keep the batched prefill alive at ctx=16384 (25.6x prefill@16k)

### DIFF
--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -126,10 +126,16 @@ static bool init_session(BenchSession& s, const std::string& path, int max_ctx, 
     kvc.block_size = 16;
     const char* e8 = getenv("SPARKINFER_KV_INT8");
     kvc.int8_kv = e8 ? (e8[0] != '0') : (max_ctx >= 4096);
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV. On
+    // Qwen3.8-27B that is 16 slots of 64, so a 16k context fits where it used to OOM.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(s.cfg.n_layers, s.cfg.hybrid,
+                                                      s.cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, s.cfg.n_layers);
     const size_t epb = (size_t)16 * s.cfg.n_kv_heads * s.cfg.head_dim;
     const size_t blocks = (s.cfg.max_seq + 15) / 16 + 8;
     s.kv = std::make_unique<sparkinfer::KVCacheManager>(
-        kvc, (size_t)s.cfg.n_layers * 2 * epb * 2 * blocks);
+        kvc, (size_t)kvL * 2 * epb * 2 * blocks);
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = s.cfg.n_experts; mc.top_k = s.cfg.top_k;
     mc.hidden_dim = s.cfg.hidden; mc.ffn_dim = s.cfg.moe_ffn;

--- a/runtime/examples/qwen3_gguf_cb_bench.cpp
+++ b/runtime/examples/qwen3_gguf_cb_bench.cpp
@@ -93,10 +93,14 @@ int main(int argc, char** argv) {
         kvc.int8_kv = e ? (e[0] != '0')
                         : (cfg.muse_glimmer ? false : cfg.hybrid ? (cfg.max_seq >= 4096) : true);
     }
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     // Pool for concurrency streams + one long prefill.
     const size_t blocks = (size_t)(concurrency + 1) * ((cfg.max_seq + 15) / 16 + 4);
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts;

--- a/runtime/examples/qwen3_gguf_dflash_bench.cpp
+++ b/runtime/examples/qwen3_gguf_dflash_bench.cpp
@@ -57,9 +57,13 @@ int main(int argc, char** argv) {
     kvc.head_dim = cfg.head_dim;
     kvc.block_size = 16;
     kvc.int8_kv = false;
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts;

--- a/runtime/examples/qwen3_gguf_dflash_check.cpp
+++ b/runtime/examples/qwen3_gguf_dflash_check.cpp
@@ -52,9 +52,13 @@ int main(int argc, char** argv) {
     kvc.head_dim = cfg.head_dim;
     kvc.block_size = 16;
     kvc.int8_kv = false;
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts;

--- a/runtime/examples/qwen3_gguf_generate.cpp
+++ b/runtime/examples/qwen3_gguf_generate.cpp
@@ -61,9 +61,13 @@ int main(int argc, char** argv) {
     // int8 KV is the Qwen3-MoE head_dim=128 tensor-core path; Qwen3.6 attention (gated, head_dim=256) writes bf16 KV.
     { const char* e = getenv("SPARKINFER_KV_INT8");   // hybrid: int8 KV when prompt length >= 4k
       kvc.int8_kv = e ? (e[0] != '0') : (cfg.hybrid ? ((argc - 3) >= 4096) : true); }
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
 
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts; mc.top_k = cfg.top_k; mc.hidden_dim = cfg.hidden;

--- a/runtime/examples/qwen3_gguf_prefill_check.cpp
+++ b/runtime/examples/qwen3_gguf_prefill_check.cpp
@@ -63,9 +63,13 @@ int main(int argc, char** argv) {
     sparkinfer::KVCacheConfig kvc;
     kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads; kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
     { const char* e = getenv("SPARKINFER_KV_INT8"); kvc.int8_kv = e ? (e[0] != '0') : true; }  // batched prefill uses int8 KV
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts; mc.top_k = cfg.top_k; mc.hidden_dim = cfg.hidden;
     mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;

--- a/runtime/examples/qwen3_gguf_score.cpp
+++ b/runtime/examples/qwen3_gguf_score.cpp
@@ -77,9 +77,13 @@ int main(int argc, char** argv) {
     // that is the gate working — see the long-context probe in accuracy.sh.
     { const char* e = getenv("SPARKINFER_KV_INT8");
       kvc.int8_kv = e ? (e[0] != '0') : (cfg.hybrid ? ((argc - 3) >= 4096) : true); }
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
     const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
     const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers * 2 * epb * 2 * blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts = cfg.n_experts; mc.top_k = cfg.top_k; mc.hidden_dim = cfg.hidden;
     mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;

--- a/runtime/examples/thermal_sweep.cpp
+++ b/runtime/examples/thermal_sweep.cpp
@@ -55,8 +55,12 @@ int main(int argc, char** argv) {
     auto rt = sparkinfer::Runtime::create({}); rt->initialize();
     sparkinfer::KVCacheConfig kvc;
     kvc.num_layers=cfg.n_layers; kvc.num_kv_heads=cfg.n_kv_heads; kvc.head_dim=cfg.head_dim; kvc.block_size=16;
+    // Only the full-attention layers get a pool slot (hybrid_kv_layer_slots): the
+    // Gated-DeltaNet layers carry a recurrent state and never read paged KV.
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
     const size_t epb=(size_t)16*cfg.n_kv_heads*cfg.head_dim, blocks=(cfg.max_seq+15)/16+8;
-    sparkinfer::KVCacheManager kv(kvc, (size_t)cfg.n_layers*2*epb*2*blocks);
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL*2*epb*2*blocks);
     sparkinfer::moe::MoEConfig mc;
     mc.num_experts=cfg.n_experts; mc.top_k=cfg.top_k; mc.hidden_dim=cfg.hidden; mc.ffn_dim=cfg.moe_ffn; mc.num_layers=cfg.n_layers;
     auto engine = sparkinfer::moe::MoEEngine::create(mc);

--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -21,7 +21,33 @@ struct KVCacheConfig {
     KVLayout layout = KVLayout::PAGED;
     bool fp8_kv = false;        // FP8 KV cache compression
     bool int8_kv = false;       // int8 (Q8-style) KV cache; halves the long-context KV read
+    // Hybrid stacks (Qwen3.5/3.6/3.8) give paged KV to the FULL-ATTENTION layers only -- the
+    // Gated-DeltaNet layers carry a recurrent state instead and never touch these pools. Sizing
+    // the pool for every layer therefore over-allocates by n_layers/n_attn_layers (4x on
+    // Qwen3.8-27B: 16 attention layers of 64). layer_slot maps a layer index to its pool slot,
+    // -1 for layers with no KV; empty = identity (every layer has a slot, the old behaviour).
+    std::vector<int> layer_slot;
 };
+
+// Layer -> pool-slot map for the hybrid interval rule these models share: with
+// full_attn_interval = k, layer L is a linear (Gated-DeltaNet) layer -- which carries a recurrent
+// state and never touches paged KV -- unless (L+1) % k == 0. Returns an empty map for non-hybrid
+// models, which KVCacheManager reads as the identity (every layer gets a slot).
+inline std::vector<int> hybrid_kv_layer_slots(int num_layers, bool hybrid, int full_attn_interval) {
+    if (!hybrid || full_attn_interval <= 0 || num_layers <= 0) return {};
+    std::vector<int> slot((size_t)num_layers, -1);
+    int n = 0;
+    for (int L = 0; L < num_layers; ++L)
+        if (((L + 1) % full_attn_interval) == 0) slot[(size_t)L] = n++;
+    if (n == 0 || n == num_layers) return {};   // nothing to compact
+    return slot;
+}
+inline int kv_slot_count(const std::vector<int>& slot, int num_layers) {
+    if (slot.empty()) return num_layers;
+    int n = 0;
+    for (int v : slot) if (v + 1 > n) n = v + 1;
+    return n;
+}
 
 // GPU-side KV block pool.
 // Manages a fixed-size pool of blocks and maps sequence positions
@@ -60,15 +86,21 @@ public:
     // allocate()/free()/truncate_blocks() call for this seq_id.
     const std::vector<int>& physical_block_ids(uint64_t seq_id) const;
 
-    // Device pointers to K and V storage pools (base = layer 0).
-    // Per-layer pointer = (bf16*)k_pool() + layer * layer_stride_elems().
+    // Device pointers to K and V storage pools (base = the first slot).
+    // Per-layer pointer = (bf16*)k_pool() + layer_base_elems(layer) -- NOT layer * layer_stride,
+    // which is only the same thing while the pool is uncompacted.
     void* k_pool() const;
     void* v_pool() const;
-    size_t layer_stride_elems() const;   // elements between consecutive layers' sub-pools
+    size_t layer_stride_elems() const;   // elements between consecutive slots' sub-pools
+    int kv_slots() const;                // slots actually allocated (== num_layers uncompacted)
+    // Element offset of `layer`'s slice. A layer with no KV lands on a trap slice (and warns once)
+    // rather than aliasing a real layer's slot.
+    size_t layer_base_elems(int layer) const;
+    size_t scale_layer_base_elems(int layer) const;
 
     // int8 KV (Q8-style int8 + per-(token,kv_head) fp16 scale). When int8_kv(), k_pool/v_pool hold
     // int8 and k_scale_pool/v_scale_pool hold one __half scale per head vector.
-    // Per-layer scale pointer = (__half*)k_scale_pool() + layer * scale_layer_stride_elems().
+    // Per-layer scale pointer = (__half*)k_scale_pool() + scale_layer_base_elems(layer).
     bool int8_kv() const;
     void* k_scale_pool() const;
     void* v_scale_pool() const;

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -94,8 +94,8 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     kernels::launch_gemm(s.xn, w.wv, s.v, num_seqs, KV, H, 1.f, 0.f, gc, stream);
 
     // 3. append new K/V into the paged cache for this layer
-    bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)layer * s.kv->layer_stride_elems();
-    bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)layer * s.kv->layer_stride_elems();
+    bf16* kpool = (bf16*)s.kv->k_pool() + s.kv->layer_base_elems(layer);
+    bf16* vpool = (bf16*)s.kv->v_pool() + s.kv->layer_base_elems(layer);
     int* btable = s.kv->block_table(0);   // batch occupies slots 0..num_seqs-1
     launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
                      num_seqs, s.attn.num_kv_heads, s.attn.head_dim,

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -33,6 +33,7 @@ struct KVCacheManager::Impl {
     bool int8_kv = false;
     void* k_pool = nullptr;
     void* v_pool = nullptr;
+    int n_slots = 0;
     void* k_scale = nullptr;         // int8 path only: [num_layers, ..., 1] __half per (token, kv_head)
     void* v_scale = nullptr;
     int* d_block_tables = nullptr;   // [kMaxSeqs, kMaxBlocksPerSeq]
@@ -54,17 +55,27 @@ KVCacheManager::KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes)
     // total_blocks sized against the bf16 budget so callers/capacity are unchanged; int8 just mallocs
     // fewer bytes (+ the small scale pools).
     const size_t bytes_per_block = elems_per_block * sizeof(unsigned short); // bf16 budget
-    const size_t denom = (size_t)cfg.num_layers * 2 * bytes_per_block;
+    // Only layers that actually hold KV get a pool slot (see KVCacheConfig::layer_slot).
+    int n_slots = 0;
+    for (int v : cfg.layer_slot) n_slots = (v + 1 > n_slots) ? v + 1 : n_slots;
+    if (cfg.layer_slot.empty()) n_slots = cfg.num_layers;
+    impl_->n_slots = n_slots;
+    const size_t denom = (size_t)n_slots * 2 * bytes_per_block;
     impl_->total_blocks = denom ? (int)(pool_bytes / denom) : 0;
     impl_->layer_stride = (size_t)impl_->total_blocks * elems_per_block;
 
-    const size_t pool_elems = (size_t)cfg.num_layers * impl_->layer_stride;
+    // One extra TRAP slice when compacted. A layer with no slot has no KV by construction, so
+    // reaching it means a caller ignored the layer typing; the trap absorbs that write instead of
+    // letting it alias slot 0 (a real layer's KV) and corrupt attention silently. Costs one slice
+    // of the n_slots the pool already shrank to.
+    const int alloc_slices = n_slots + (cfg.layer_slot.empty() ? 0 : 1);
+    const size_t pool_elems = (size_t)alloc_slices * impl_->layer_stride;
     cu(cudaMalloc(&impl_->k_pool, pool_elems * elem_bytes), "malloc k_pool");
     cu(cudaMalloc(&impl_->v_pool, pool_elems * elem_bytes), "malloc v_pool");
     if (impl_->int8_kv) {
         // one fp16 scale per (token slot, kv_head): scale stride = layer_stride / head_dim.
         impl_->scale_layer_stride = impl_->layer_stride / cfg.head_dim;
-        const size_t scale_elems = (size_t)cfg.num_layers * impl_->scale_layer_stride;
+        const size_t scale_elems = (size_t)alloc_slices * impl_->scale_layer_stride;
         cu(cudaMalloc(&impl_->k_scale, scale_elems * sizeof(unsigned short)), "malloc k_scale");
         cu(cudaMalloc(&impl_->v_scale, scale_elems * sizeof(unsigned short)), "malloc v_scale");
     }
@@ -167,6 +178,36 @@ const std::vector<int>& KVCacheManager::physical_block_ids(uint64_t seq_id) cons
 void*  KVCacheManager::k_pool() const { return impl_->k_pool; }
 void*  KVCacheManager::v_pool() const { return impl_->v_pool; }
 size_t KVCacheManager::layer_stride_elems() const { return impl_->layer_stride; }
+int KVCacheManager::kv_slots() const { return impl_->n_slots; }
+namespace {
+// A slot-less layer means the caller ignored the layer typing the pool was built from. Say so once
+// -- the trap slice keeps it from corrupting a real layer, but it is still a bug worth seeing.
+int kv_trap_slot(const std::vector<int>& m, int layer) {
+    const int s = (layer >= 0 && layer < (int)m.size()) ? m[layer] : -1;
+    if (s < 0) {
+        static bool warned = false;
+        if (!warned) {
+            warned = true;
+            fprintf(stderr, "[kv] layer %d has no KV slot (linear/GDN layer) -- routed to the trap "
+                            "slice; this layer should not be touching the paged pool\n", layer);
+        }
+    }
+    return s;
+}
+}  // namespace
+
+size_t KVCacheManager::layer_base_elems(int layer) const {
+    const auto& m = impl_->cfg.layer_slot;
+    if (m.empty()) return (size_t)layer * impl_->layer_stride;
+    const int s = kv_trap_slot(m, layer);
+    return (size_t)(s < 0 ? impl_->n_slots : s) * impl_->layer_stride;
+}
+size_t KVCacheManager::scale_layer_base_elems(int layer) const {
+    const auto& m = impl_->cfg.layer_slot;
+    if (m.empty()) return (size_t)layer * impl_->scale_layer_stride;
+    const int s = kv_trap_slot(m, layer);
+    return (size_t)(s < 0 ? impl_->n_slots : s) * impl_->scale_layer_stride;
+}
 bool   KVCacheManager::int8_kv() const { return impl_->int8_kv; }
 void*  KVCacheManager::k_scale_pool() const { return impl_->k_scale; }
 void*  KVCacheManager::v_scale_pool() const { return impl_->v_scale; }

--- a/runtime/src/lmcache_staging.cpp
+++ b/runtime/src/lmcache_staging.cpp
@@ -85,6 +85,10 @@ bool stage_kv_to_shm(KVCacheManager& kv, const BridgeKVLayout& layout, uint64_t 
     const int first_block = start_tok / layout.block_size;
     const int n_blocks = n_tok / layout.block_size;
 
+    // A compacted (hybrid) pool holds one slice per FULL-ATTENTION layer, indexed by slot, so
+    // the per-layer offsets below would walk past its end. Refuse rather than mis-index; this
+    // path is not used by the hybrid models that compact.
+    if (kv.kv_slots() != layout.num_layers) return false;
     const std::vector<int>& phys = kv.physical_block_ids(seq_id);
     if ((int)phys.size() < first_block + n_blocks) return false;
 
@@ -161,6 +165,10 @@ bool restore_kv_from_shm(KVCacheManager& kv, const BridgeKVLayout& layout, uint6
     const int first_block = start_tok / layout.block_size;
     const int n_blocks = len_tok / layout.block_size;
 
+    // A compacted (hybrid) pool holds one slice per FULL-ATTENTION layer, indexed by slot, so
+    // the per-layer offsets below would walk past its end. Refuse rather than mis-index; this
+    // path is not used by the hybrid models that compact.
+    if (kv.kv_slots() != layout.num_layers) return false;
     const std::vector<int>& phys = kv.physical_block_ids(seq_id);
     if ((int)phys.size() < first_block + n_blocks) return false;
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1342,10 +1342,10 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // ---- QK-norm + RoPE + KV-append ----
             const bool kv8 = s.kv->int8_kv();
             const int kv_elem = kv8 ? 1 : 2;
-            void* kpool = (char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* vpool = (char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            void* kpool = (char*)s.kv->k_pool() + s.kv->layer_base_elems(L) * kv_elem;
+            void* vpool = (char*)s.kv->v_pool() + s.kv->layer_base_elems(L) * kv_elem;
+            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + s.kv->scale_layer_base_elems(L) * 2 : nullptr;
+            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + s.kv->scale_layer_base_elems(L) * 2 : nullptr;
             const bool partial_rope = (c.rope_dim > 0 && c.rope_dim < c.head_dim);
             const bool qkgate_fuse = w.q_has_gate && partial_rope && kv8 && s.use_qkfuse && H == 2048;
             // w.wgate != nullptr means Q and the gate were projected straight into s.q / s.qgate

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -123,6 +123,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const int lvdim = s.linear_vdim;                     // 4096
     const int vh   = c.linear_v_heads;                   // 32
     const int ffn  = c.moe_ffn;                          // dense: 12288; MoE: per-expert 512
+    // Floor for the VRAM-adaptive FFN chunk below: past this the chunk loop costs more in
+    // weight re-reads than the batched pass saves over the token loop.
+    constexpr int kMinFfnChunk = 1024;
+    // SPARKINFER_PREFILL_VERBOSE=1 reports the VRAM map around the batched scratch. Off by default.
+    const bool pf_verbose = []{ const char* e = getenv("SPARKINFER_PREFILL_VERBOSE"); return e && e[0] == '1'; }();
+    auto pf_vram = [&](const char* where) {
+        if (!pf_verbose) return;
+        size_t f = 0, t = 0;
+        cudaMemGetInfo(&f, &t);
+        fprintf(stderr, "[prefill/vram] %-22s free=%zu MB used=%zu MB\n", where, f >> 20, (t - f) >> 20);
+    };
     const int wide = 2 * qdim;                           // 8192 (qraw); also >= lqkv
     // wbuf must hold the largest weight the `dq` lambda dequantizes: the dense FFN (ffn*H) OR, on the
     // MoE path (small ffn=512), the biggest projection (wide/lqkv * H). Cover all of them.
@@ -139,7 +150,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // FFN is per-token independent, so chunking is numerically identical. Env override; default 32768.
     // (MoE doesn't use ffg/ffu — its grouped FFN has its own O(N*top_k) scratch, so chunking is moot.)
     const int ffn_chunk = []{ const char* e = getenv("SPARKINFER_PREFILL_FFN_CHUNK"); int c = e ? atoi(e) : 32768; return c > 0 ? c : 32768; }();
-    const int FC = (N < ffn_chunk) ? N : ffn_chunk;
+    int FC = (N < ffn_chunk) ? N : ffn_chunk;
     bf16* lin_conv_state = static_cast<bf16*>(s.lin_conv_state);
 
     // ---- scratch ----
@@ -200,6 +211,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         pf_cu(cudaStreamSynchronize(st), "pfb graph sync");
         return *s.h_out_id;
     }
+    pf_vram("entry");
     bf16* x    = a.alloc<bf16>((size_t)N * H);
     bf16* xn   = a.alloc<bf16>((size_t)N * H);
     bf16* hn   = a.alloc<bf16>((size_t)N * H);
@@ -225,12 +237,55 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* qg   = lnrm;                                   // full q-gate (4096) <- lin_norm (4096)
     bf16* kf   = gq;                                     // full k      (1024) <- gdn q    (2048)
     bf16* vf   = gk;                                     // full v      (1024) <- gdn k    (2048)
+    // Everything above is FC-independent and already allocated, so cudaMemGetInfo here reports
+    // exactly what is left for the FC-scaled pair -- size the chunk to that instead of to a
+    // constant. When ffg+ffu do not fit, the WHOLE arena alloc fails and prefill_batched returns
+    // -1, so the caller silently drops to the sequential token loop: at ctx=16384 that is 79 pp
+    // against 2191 pp batched, ~28x. A 27B NVFP4 checkpoint holds BOTH the NVFP4 prefill and Q4_K
+    // decode weight copies, which leaves a 32 GB card short of the default chunk's 1.1 GB.
+    // This only ever SHRINKS the chunk; FC < N is the same path every context above 32k already
+    // takes, and the FFN is per-token independent, so it stays numerically identical.
+    pf_vram("before ffg/ffu");
+    // An explicit SPARKINFER_PREFILL_FFN_CHUNK is an operator decision -- honour it as given.
+    if (!moe && !getenv("SPARKINFER_PREFILL_FFN_CHUNK")) {
+        size_t fb = 0, tb = 0;
+        if (cudaMemGetInfo(&fb, &tb) == cudaSuccess) {
+            // What still has to come out of `fb` after the FC-scaled pair, so the chunk is sized
+            // against the real remainder rather than all of free VRAM.
+            const size_t tail = (size_t)maxw * sizeof(bf16)                    // wbuf
+                              + (size_t)maxw                                  // W_i8
+                              + (size_t)N * H                                 // A_i8 (int8) floor
+                              + (size_t)N * (sizeof(float) + sizeof(int));    // sx + d_ids
+            const size_t margin = (size_t)64 << 20;    // split-K partials + allocator slack
+            const size_t avail = (fb > tail + margin) ? fb - tail - margin : 0;
+            const int fc_before = FC;
+            // Test the HALVED value, not the current one: `FC > floor` would step straight past it.
+            while ((FC >> 1) >= kMinFfnChunk &&
+                   (size_t)2 * (size_t)FC * (size_t)ffn * sizeof(bf16) > avail)
+                FC >>= 1;
+            if (FC != fc_before)
+                fprintf(stderr, "[prefill] ffn chunk %d -> %d (ctx=%d, free=%zu MB) to keep the "
+                                "batched pass\n", fc_before, FC, N, fb >> 20);
+        }
+    }
     bf16* ffg  = a.alloc<bf16>((size_t)FC * ffn);        // ffn gate (12288), bounded to FC tokens
     bf16* ffu  = a.alloc<bf16>((size_t)FC * ffn);        // ffn up,          bounded to FC tokens
     bf16* ffh  = ffg;                                    // SwiGLU computed in-place into ffg (down reads it)
     bf16* wbuf = a.alloc<bf16>(maxw);                    // dequantized-weight scratch (reused)
     int*  d_ids = a.alloc<int>((size_t)N);
-    if (!a.ok) { a.free_all(); fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d) -> fallback\n", N); return -1; }
+    pf_vram("after dense arena");
+    if (!a.ok) {
+        // Report the numbers, not just the fact: this fallback costs ~50x at long context and the
+        // old message gave no way to tell a genuinely-too-small card from a chunk set too large.
+        size_t fb = 0, tb = 0;
+        cudaMemGetInfo(&fb, &tb);
+        const size_t held = a.total();
+        a.free_all();
+        fprintf(stderr, "[prefill] scratch alloc failed (ctx=%d, chunk=%d, held=%zu MB, "
+                        "free=%zu/%zu MB) -> fallback\n",
+                N, FC, held >> 20, fb >> 20, tb >> 20);
+        return -1;
+    }
     // int8 tensor-core projections (prefill_gemm_i8): ~2x the bf16 GEMM at int8==bf16 output fidelity
     // (GGUF weights are already Q4_K/Q6_K -> int8 weight-quant is lossless vs what's stored). Default
     // ON at every batched context; SPARKINFER_PREFILL_I8=0 disables (A/B). The int8 scratch lives in
@@ -284,6 +339,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // SPARKINFER_PREFILL_FP8_GDN=0 restores the bf16 GDN projections (A/B).
     const char* _pfp8 = getenv("SPARKINFER_PREFILL_FP8_GDN");
     bool use_fp8_gdn = long_bf16 && (!_pfp8 || _pfp8[0] != '0');
+    // The int8 projection path has only ever run with FC == N (main chunks the FFN only above
+    // 32k, and at those contexts it fails the scratch alloc and falls back before reaching here).
+    // With FC < N it corrupts memory: at ctx=16384 the pass ends in an illegal memory access that
+    // kills the decode graph right after it, reproducible at chunk 4096/2048 and cleared by
+    // SPARKINFER_PREFILL_I8=0. Rather than enable a path that is not demonstrably correct, run the
+    // chunked pass on the NVFP4/bf16 projections -- measured 2233 pp at 16k against the 79 pp
+    // token-loop fallback. ctx=128 has FC == N, so the scored floor keeps int8 exactly as today.
+    if (!moe && FC < N) {
+        use_i8 = false;
+        use_i8_ffn = false;
+        use_i8_attn = false;
+        use_fp8_gdn = false;
+    }
     // MoE (Qwen3.6): run the attn/GDN projections on the fp8 (e4m3) tensor cores instead of
     // the bf16 wmma GEMM. Default ON again: the #586/#587 prefill_check failures traced to the
     // opt-in MOE_GPU tilemap path's mask dequant silently no-opping (down cols=mffn declines
@@ -298,13 +366,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // A_i8 holds the quantized activation. Dense full-i8: non-FFN projs quantize N rows x K(<=H);
     // chunked FFN quantizes at most FC rows x ffn. Long-ctx selective: N*H if attn-i8/fp8-gdn else FC*ffn.
     // MoE: no chunked FFN; projections quantize N rows x maxAK.
-    const bool wide_a = use_i8 || use_i8_attn || use_fp8_gdn || moe_fp8;
     const bool need_i8 = use_i8 || use_i8_ffn || use_i8_attn || use_fp8_gdn || moe_shared_i8 || moe_fp8;
-    const size_t a_i8_sz = moe ? (size_t)N * maxAK
-                               : (wide_a
-                                  ? (((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn)
-                                  : (size_t)FC * ffn);
-    const size_t sx_n = (wide_a || moe_shared_i8) ? (size_t)N : (size_t)FC;
+    // Take the max on BOTH dense paths. The int8-projections-off branch used to size against
+    // FC*ffn alone, below the N*H the non-FFN projections quantize once the FFN chunk drops
+    // below N*H/ffn -- a silent overrun rather than an alloc failure. FC is floored above so this
+    // is a no-op in practice; it keeps a hand-set SPARKINFER_PREFILL_FFN_CHUNK from overrunning.
+    const size_t a_i8_dense = ((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn;
+    const size_t a_i8_sz = moe ? (size_t)N * maxAK : a_i8_dense;
+    // N, not FC: sx is the per-row scale that pairs with A_i8 above, and the same non-FFN
+    // projections write N of them. FC >= the chunk floor makes this equal in practice (FC <= N
+    // always), and it costs N floats to be right when the chunk is small.
+    const size_t sx_n = (size_t)N;
     signed char* A_i8 = need_i8 ? a8.alloc<signed char>(a_i8_sz) : nullptr;
     // k-tiled [k/32][row][32] copy of the int8 activation for Muse's dense prefill GEMM. That
     // kernel stages a 32-byte K slice of all 128 rows per pipeline step; out of the row-major A
@@ -368,6 +440,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         A_i8 = W_i8 = nullptr;
         sx = sw = nullptr;
         sk_p = nullptr;
+        // free_all() above also released the LM-head seed buffers and the split-K partials, which
+        // were taken from THIS arena further up -- those pointers now dangle into freed VRAM, and
+        // the seed argmax at the end of this function writes through the LM-head trio
+        // unconditionally. Re-take them (they are a few KB); the partials are only read on the
+        // int8 path that just turned off, so drop them instead of re-allocating.
+        qb_partials = nullptr;
+        a8.rewind();                       // free_all() clears the buffers but leaves ok=false
+        lm_q8 = a8.alloc<signed char>((size_t)H + 32);
+        lm_ad = a8.alloc<float>((size_t)(H >> 5) + 1);
+        lm_as = a8.alloc<float>((size_t)(H >> 5) + 1);
+        if (!a8.ok) {
+            a.free_all(); a8.free_all();
+            fprintf(stderr, "[prefill] lm-head seed scratch alloc failed (ctx=%d) -> fallback\n", N);
+            return -1;
+        }
     }
     const bool mg_sk = sk_p != nullptr;
 
@@ -991,8 +1078,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // / NoPE on global layers, bf16 append -- the same KV a forward_token decode writes via
                 // launch_rmsnorm + launch_rope_kv_append_normal / launch_kv_append. Then pure-window
                 // attention on SWA layers, full causal on global (win_blocks<=0), over the bf16 pool.
-                bf16* kpool_bf = (bf16*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems();
-                bf16* vpool_bf = (bf16*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems();
+                bf16* kpool_bf = (bf16*)s.kv->k_pool() + s.kv->layer_base_elems(L);
+                bf16* vpool_bf = (bf16*)s.kv->v_pool() + s.kv->layer_base_elems(L);
                 const int muse_rot = w.swa ? c.head_dim : 0;      // SWA = full NORMAL rope; global = NoPE
                 kernels::launch_prefill_qknorm_ropenorm_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
                     kpool_bf, vpool_bf, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
@@ -1001,10 +1088,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_prefill_attn_swa_pure_bf16(qb, kpool_bf, vpool_bf, btable, att,
                     N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks, st);
             } else {
-                signed char* kpool = (signed char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-                signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-                void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-                void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                signed char* kpool = (signed char*)s.kv->k_pool() + s.kv->layer_base_elems(L) * kv_elem;
+                signed char* vpool = (signed char*)s.kv->v_pool() + s.kv->layer_base_elems(L) * kv_elem;
+                void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + s.kv->scale_layer_base_elems(L) * 2 : nullptr;
+                void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + s.kv->scale_layer_base_elems(L) * 2 : nullptr;
                 // bf16 KV: batched prefill used to decline here, which sent Qwen3.8's prefill@128
                 // down the sequential per-token path (88.0 tok/s, barely above its own 84.2 tok/s
                 // decode, because that path re-streams every weight once per position). The bf16
@@ -2199,13 +2286,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             }
             if (!supported || !w.q_has_gate) break;
             char* kp = static_cast<char*>(s.kv->k_pool()) +
-                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                       s.kv->layer_base_elems(L) * kv_elem;
             char* vp = static_cast<char*>(s.kv->v_pool()) +
-                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                       s.kv->layer_base_elems(L) * kv_elem;
             char* ks = kv8 ? static_cast<char*>(s.kv->k_scale_pool()) +
-                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                             s.kv->scale_layer_base_elems(L) * 2 : nullptr;
             char* vs = kv8 ? static_cast<char*>(s.kv->v_scale_pool()) +
-                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                             s.kv->scale_layer_base_elems(L) * 2 : nullptr;
             if (kv8) {
                 kernels::launch_dflash_qknorm_rope_kv_partial_int8_gated(
                     b8, qb, qg, kf, vf, w.q_norm, w.k_norm, kp, vp, ks, vs, btable, pos,


### PR DESCRIPTION
## Summary

**Keeps the batched prefill alive at ctx=16384 — the context `eval/pr_qwen38_bot.py` scores since
`784c3f1` — instead of silently dropping the prompt onto the per-token loop. 79.26 -> 2029.24 pp, 25.6x.**

At ctx=16384 on this checkpoint, `prefill_batched_run` cannot allocate its scratch arena, returns
-1, and `bench_decode` falls back to the sequential token loop that re-streams every weight once
per position. main today:

```text
[prefill] scratch alloc failed (ctx=16384) -> fallback
SWEEP_JSON {"128":{"decode_tps":84.0116,"prefill_pp":4369.3982},
            "16384":{"decode_tps":70.3848,"prefill_pp":79.4258}}
```

79 pp is not a slow prefill — it is *no* batched prefill. It sits next to this model's own 70 tok/s
decode because it **is** decode, run 16384 times. prefill@128 on the same load is 4369 pp.

Two things starve that allocation, and both are sized wrong rather than genuinely too big:

1. **The paged-KV pool is allocated per model layer.** Qwen3.8-27B is 64 layers with
   `full_attn_interval=4`, so only **16** own KV — the other 48 are Gated-DeltaNet and keep their
   state in the recurrent/conv buffers. `KVCacheConfig` gains a `layer_slot` map (empty = identity,
   i.e. every non-hybrid model is untouched), the pool is sized to the slots that exist, and every
   consumer goes through `layer_base_elems()` instead of `layer * layer_stride`. `total_blocks`
   still divides by the same slot count, so **block capacity and max context are unchanged**.
2. **The FFN chunk is a fixed constant.** `ffg+ffu` are `2*FC*ffn` bf16 = 1.14 GB at the default
   32768 chunk, demanded regardless of what is free. It is now sized against a `cudaMemGetInfo`
   reading taken *immediately before* that pair is allocated — the point where every FC-independent
   buffer is already resident, so the number is measured rather than modelled. It only ever
   **shrinks**, so a wrong estimate degrades to today's fallback and never to corruption. `FC < N`
   is the same token-chunked path every context above 32k already takes, and the FFN is per-token
   independent, so it stays numerically identical. An explicit `SPARKINFER_PREFILL_FFN_CHUNK` is
   honoured as given.

Leg 1 alone is **not** sufficient at 16384 — measured, it still falls back at 79.0 pp. It is
sufficient at 8192, which is where #847 (@FranDev132, filed ~1h before this) reports its 1.55x;
that PR reaches the same diagnosis and the same quoted fallback line for the KV half, and this
change would rebase cleanly onto it. What moves the *scored* context is leg 2 on top.

## Two latent bugs this had to fix first

Both are on main today, both are reachable through main's own `SPARKINFER_PREFILL_FFN_CHUNK`, and
both surface only when the batched pass runs under memory pressure — which is exactly the state
this PR puts it in.

- **Use-after-free in the int8 degrade path.** When the `a8` arena cannot fit, the handler calls
  `a8.free_all()` and nulls the int8 pointers — but `lm_q8/lm_ad/lm_as` were taken from that same
  arena and are *not* re-taken, and the seed argmax at the end of the function writes through them
  unconditionally. They now get re-allocated (a few KB) with a clean fallback if even that fails,
  and the split-K partials are dropped rather than left dangling.
- **`A_i8` / `sx` under-sized once the chunk drops below `N*H/ffn`.** `a_i8_sz` was `FC*ffn` on the
  non-int8-projection path while the *non-FFN* projections quantize `N` rows x `H` into that same
  buffer; `sx` had the same shape mismatch. Both now take the max. At ctx=16384 the boundary sits
  between chunk 8192 and 4096, and 4096 killed the CUDA context.

Separately, the int8 **projection** path is left off when the FFN is chunked (`FC < N`). It has
only ever run with `FC == N`, and with a smaller chunk it ends the pass in an illegal memory access
that takes the decode graph with it — reproducible at chunk 4096/2048 and cleared by
`SPARKINFER_PREFILL_I8=0`. Rather than ship a path that is not demonstrably correct, the chunked
pass runs on the NVFP4/bf16 projections. **ctx=128 has `FC == N`, so the scored floor keeps int8
exactly as it is today.** The underlying defect is left for its own PR.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `bench/scripts/bench.sh` path — this PR is prefill-only):

| | decode tok/s |
|---|--:|
| before (main) | 83.74 |
| after (this PR) | 83.38 (0.996x — inside main's own 0.66% spread) |

**Prefill pp tok/s** (Qwen3.8-27B NVFP4, ctx=16384 — the dimension `pr_qwen38_bot.py` scores):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 79.26 |
| after prefill (this PR) | **2029.24 (25.6x, +2460%)** |

```text
# RTX 5090 sm_120, unsloth/Qwen3.8-27B-NVFP4, main @ 784c3f1. SHIPPED DEFAULTS -- no env
# overrides; the only vars set are the two the bot's own bench_sweep_run exports. Arms rebuilt
# between runs (one build dir, so no stale runtime .so can leak across an arm) and alternated
# main/PR/main/PR, serialized so no two benches ever share the GPU. Sweep order is the bot's own
# (128 first, then 16384) -- that order is what leaves VRAM tight, and measuring 16384 alone
# understates the problem.

MAIN pair1 {"128":{"decode_tps":84.0116,"prefill_pp":4369.3982},"16384":{"decode_tps":70.3848,"prefill_pp":79.4258}}
PR   pair1 {"128":{"decode_tps":83.4213,"prefill_pp":4343.4116},"16384":{"decode_tps":70.8359,"prefill_pp":2034.0784}}
MAIN pair2 {"128":{"decode_tps":83.4616,"prefill_pp":4338.1144},"16384":{"decode_tps":70.2443,"prefill_pp":79.0950}}
PR   pair2 {"128":{"decode_tps":83.3447,"prefill_pp":4332.9715},"16384":{"decode_tps":70.6564,"prefill_pp":2024.4055}}

prefill@16k  median   79.26 -> 2029.24  = 25.60x   (+2460.2%)   <- the scored dimension
prefill@128  median 4353.76 -> 4338.19  = 0.9964x  (floor, tol 0.98)
decode@128   median   83.74 ->   83.38  = 0.9958x  (floor, tol 0.98)
decode@16k   median   70.31 ->   70.75  = 1.0063x

# Both floors sit inside main's own run-to-run spread (its two decode@128 samples differ by
# 0.66%); nothing in this change touches the ctx=128 path, where FC == N and int8 stays on.
# Every PR arm logs the chunk it chose, so the arm is identifiable in-trace:
#   [prefill] ffn chunk 16384 -> 1024 (ctx=16384, free=333 MB) to keep the batched pass
# and every main arm logs the fallback it took:
#   [prefill] scratch alloc failed (ctx=16384) -> fallback
```

**Differential accuracy gate** (`bench/scripts/accuracy_compare_pair.py`, PR vs main, same token
stream, TOPK=128):

```text
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.2812 ppl_main=3.2812

# 102-token stream from the checkpoint's own tokenizer.json, TOPK=128 (QWEN38_ACC_TOPK default),
# PR dump vs origin/main dump. Bars: top1 >= 0.99, KL <= 0.01. Bit-identical: the ctx=128 path is
# untouched (FC == N, int8 on), and the KV compaction relabels where a layer's slice lives without
# changing a value in it.
```

**16k differential accuracy** (the same comparator, on a 16384-token stream). The bot's gate uses
a ~102-token stream, so it only exercises the ctx=128 path — and this PR is what makes the batched
pass run at 16384 at all. At that length **main takes the token loop and this PR takes the batched
pass**, so this compares the two paths directly rather than two variants of one path:

```text
METRIC top1=1.000000 kl=0.000000 ppl_pr=1.0089 ppl_main=1.0089

# 16384-token stream (the eval corpus tiled), 16386 dump lines on each side, TOPK=128.
# The chunked FFN and the compacted KV pool reproduce the sequential token loop's distribution
# exactly -- which is the claim the "numerically identical" wording above rests on, measured
# rather than asserted. (ppl ~1.0 is the tiled stream being trivially predictable; it is the
# PR-vs-main agreement that matters here, and both sides see the identical stream.)
```

**Qwen3.6 cross-model guard** (ctx 0/512/4k/16k/32k, tol 0.98). This change touches shared prefill
code *and* compacts Qwen3.6's pool too (it is hybrid with the same interval), so it is measured:

```text
ctx      0 decode_tps  main    492.63 -> PR    489.87  0.9944x  ok
ctx    512 decode_tps  main    486.45 -> PR    483.95  0.9949x  ok
ctx    512 prefill_pp  main  10000.54 -> PR   9982.48  0.9982x  ok
ctx   4096 decode_tps  main    467.69 -> PR    465.06  0.9944x  ok
ctx   4096 prefill_pp  main  25899.97 -> PR  25868.96  0.9988x  ok
ctx  16384 decode_tps  main    467.01 -> PR    464.80  0.9953x  ok
ctx  16384 prefill_pp  main  26786.60 -> PR  26786.93  1.0000x  ok
ctx  32768 decode_tps  main    466.98 -> PR    464.51  0.9947x  ok
ctx  32768 prefill_pp  main  27969.43 -> PR  27971.82  1.0001x  ok

# tol 0.98 on every row. The uniform ~0.5% on decode is thermal drift across sequentially
# run arms (the two Qwen3.8 main arms differ by 0.66% between themselves); prefill is flat to
# 4 decimal places at 16k/32k, which is where a KV-pool change would show up if it were wrong.
```

## Credit

#847 (@FranDev132) independently reaches the KV-pool half of this diagnosis and filed first; leg 1
here is the same idea and this PR rebases onto it cleanly if it lands. #835 is the batched
prefill-attention path this keeps alive at long context, and #800/#530 are the token-chunked FFN
this sizes dynamically rather than by a constant.
