### PR TITLE
perf(qwen3.8): CUTLASS FP8 GDN projections + warp-synchronous chunk prep

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -100,7 +100,8 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
                                     __nv_bfloat16* __restrict__ w_buf,
                                     __nv_bfloat16* __restrict__ u_buf,
                                     float* __restrict__ m_buf,
-                                    int n_tokens, int q_heads, int v_heads, bool qh_block) {
+                                    int n_tokens, int q_heads, int v_heads, bool qh_block,
+                                    bool warp_inv) {
     extern __shared__ char s_raw[];
     __nv_bfloat16* s_k = reinterpret_cast<__nv_bfloat16*>(s_raw);              // [C][HD+PAD]
     __nv_bfloat16* s_x = s_k + (size_t)C * (HD + PAD);                         // [C][HD+PAD] q then v
@@ -194,15 +195,60 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
     // ---- T = (I + A)^-1 in place, by forward substitution over rows ----
     //   T[i][j] = -A[i][j] - sum_{m=j+1}^{i-1} A[i][m] T[m][j]      (T[j][j] = 1)
     // Row i still holds A while it is being read; rows m < i already hold T.
-    for (int i = 1; i < C; i++) {
-        for (int j = tid; j < i; j += nthr) {
-            float acc = s_A[i * (C + PAD) + j];
-            for (int m = j + 1; m < i; m++) acc += s_A[i * (C + PAD) + m] * s_A[m * (C + PAD) + j];
-            s_t[j] = -acc;
+    //
+    // The substitution is inherently serial in i, and row i offers at most i < C units of work --
+    // 31 at C=32. Spreading that over the block's 256 threads means 225 of them do nothing while
+    // the loop still pays TWO BLOCK-WIDE BARRIERS PER ROW: 62 __syncthreads() across 8 warps for
+    // ~5k FMAs of actual arithmetic. That is why this kernel measures 33 us a layer (1.59 ms of a
+    // 26.9 ms prefill@128) despite being tiny in both flops and bytes -- it is barrier-bound, not
+    // compute- or bandwidth-bound.
+    //
+    // A single warp already covers a row, so run the whole substitution on warp 0 and synchronise
+    // with __syncwarp(): 62 block barriers collapse to the ONE __syncthreads() below that publishes
+    // T to the other warps. The s_t staging row goes away with them -- the read/write hazard on row
+    // i (lane j reads columns m > j of the row that lanes m < i are overwriting) is resolved by
+    // holding the results in registers across a __syncwarp() instead of bouncing them off shared.
+    //
+    // BIT-IDENTICAL: lane j evaluates the same expression with the same ascending-m summation order
+    // it had before; only who runs it and how they synchronise changes.
+    // SPARKINFER_PREFILL_GDN_PREP_WARP=0 restores the block-wide form (A/B in ONE binary).
+    if (warp_inv) {
+        constexpr int JPL = (C + 31) / 32;          // columns per lane
+        if ((tid >> 5) == 0) {
+            const int lane = tid & 31;
+            for (int i = 1; i < C; i++) {
+                float acc[JPL];
+                #pragma unroll
+                for (int s = 0; s < JPL; s++) {
+                    const int j = lane + s * 32;
+                    if (j < i) {
+                        float a = s_A[i * (C + PAD) + j];
+                        for (int m = j + 1; m < i; m++)
+                            a += s_A[i * (C + PAD) + m] * s_A[m * (C + PAD) + j];
+                        acc[s] = -a;
+                    }
+                }
+                __syncwarp();                        // all reads of row i done before any write
+                #pragma unroll
+                for (int s = 0; s < JPL; s++) {
+                    const int j = lane + s * 32;
+                    if (j < i) s_A[i * (C + PAD) + j] = acc[s];
+                }
+                __syncwarp();                        // row i is T before row i+1 reads it
+            }
         }
-        __syncthreads();
-        for (int j = tid; j < i; j += nthr) s_A[i * (C + PAD) + j] = s_t[j];
-        __syncthreads();
+        __syncthreads();                             // publish T to every warp
+    } else {
+        for (int i = 1; i < C; i++) {
+            for (int j = tid; j < i; j += nthr) {
+                float acc = s_A[i * (C + PAD) + j];
+                for (int m = j + 1; m < i; m++) acc += s_A[i * (C + PAD) + m] * s_A[m * (C + PAD) + j];
+                s_t[j] = -acc;
+            }
+            __syncthreads();
+            for (int j = tid; j < i; j += nthr) s_A[i * (C + PAD) + j] = s_t[j];
+            __syncthreads();
+        }
     }
 
     // ---- W^ = T . (b_m exp(G_m) k_m) ----
@@ -618,8 +664,15 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
     // PREP_THREADS is fixed by the 2x2 (i,j) tiling in the A/M pass: C*C == 4*PREP_THREADS.
     static_assert(C * C == PREP_THREADS * 4, "2x2 A/M tiling requires C*C == 4*PREP_THREADS");
     dim3 gprep(n_chunks, v_heads);
+    // See the forward-substitution block in pf_gdnc_prep_kernel: warp-synchronous by default,
+    // SPARKINFER_PREFILL_GDN_PREP_WARP=0 restores the 62-barrier block-wide form for A/B.
+    static const bool prep_warp_inv = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_PREP_WARP");
+        return !(e && e[0] == '0');
+    }();
     pf_gdnc_prep_kernel<C, HD><<<gprep, PREP_THREADS, sm_prep, stream>>>(
-        qb, kb, vb, ab, bb, db, aa, g_buf, w_buf, u_buf, m_buf, n_tokens, q_heads, v_heads, qh_block);
+        qb, kb, vb, ab, bb, db, aa, g_buf, w_buf, u_buf, m_buf, n_tokens, q_heads, v_heads, qh_block,
+        prep_warp_inv);
 
     // SCAN_THREADS is not free tuning: the register tiling below partitions the [C,JC] and [HD,JC]
     // outputs across exactly this many threads (2x2 and 4x4 tiles respectively).

--- a/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
@@ -21,6 +21,7 @@
 #include <cuda_pipeline.h>
 #include <cstdlib>
 #include "sparkinfer/kernels/prefill_fp8.h"
+#include "sparkinfer/kernels/prefill_nvfp4.h"   // launch_prefill_ct_fp8_gemm (stubbed when NVFP4 is off)
 
 namespace sparkinfer { namespace kernels {
 
@@ -77,6 +78,42 @@ __global__ void pf_quantize_rows_fp8_kernel(const __nv_bfloat16* __restrict__ x,
     if (lane == 0) scale[r] = d;
     for (int c = lane; c < cols; c += 32)
         q[(size_t)r * cols + c] = __nv_fp8_e4m3(__bfloat162float(x[(size_t)r * cols + c]) / d);
+}
+
+// Same quantize, one BLOCK per row instead of one warp. At the GDN widths (cols = 5120/6144) the
+// one-warp form gives each lane 160-192 strided 2-byte loads and reads the row twice, which is why
+// 96 launches of it cost 0.42 ms of a 26.9 ms prefill@128 at ~4.4 us each. 256 threads and
+// bf16x2 loads cut both the per-lane trip count and the request count 16x.
+// BIT-IDENTICAL: amax is a max-reduction, so widening it cannot change the value it produces, and
+// every element keeps the same x / d division and the same e4m3 rounding.
+__global__ __launch_bounds__(256) void pf_quantize_rows_fp8_wide_kernel(
+        const __nv_bfloat16* __restrict__ x, __nv_fp8_e4m3* __restrict__ q,
+        float* __restrict__ scale, int rows, int cols) {
+    __shared__ float s_part[8];
+    const int r = blockIdx.x, tid = threadIdx.x;
+    if (r >= rows) return;
+    const size_t base = (size_t)r * cols;
+    const int half = cols >> 1;                       // cols is even at every shape this serves
+    const __nv_bfloat162* x2 = reinterpret_cast<const __nv_bfloat162*>(x + base);
+    float amax = 0.f;
+    for (int c = tid; c < half; c += 256) {
+        const __nv_bfloat162 v = x2[c];
+        amax = fmaxf(amax, fmaxf(fabsf(__bfloat162float(v.x)), fabsf(__bfloat162float(v.y))));
+    }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, o));
+    if ((tid & 31) == 0) s_part[tid >> 5] = amax;
+    __syncthreads();
+    amax = s_part[0];
+    #pragma unroll
+    for (int w = 1; w < 8; w++) amax = fmaxf(amax, s_part[w]);
+    const float d = (amax == 0.f) ? 1.f : (amax / FP8_TGT);
+    if (tid == 0) scale[r] = d;
+    for (int c = tid; c < half; c += 256) {
+        const __nv_bfloat162 v = x2[c];
+        q[base + 2 * c]     = __nv_fp8_e4m3(__bfloat162float(v.x) / d);
+        q[base + 2 * c + 1] = __nv_fp8_e4m3(__bfloat162float(v.y) / d);
+    }
 }
 
 // The 2 in __launch_bounds__ mirrors the int8 kernel: unbounded, nvcc picks a register count that
@@ -256,6 +293,17 @@ void launch_prefill_fp8_wscales_bf16(const void* scale_bf16, float* sw, int n,
 
 void launch_prefill_quantize_rows_fp8(const void* x_bf16, void* q, float* scale,
                                       int rows, int cols, cudaStream_t stream) {
+    // SPARKINFER_PREFILL_FP8_QUANT_WIDE=0 restores the one-warp-per-row kernel (A/B in ONE binary).
+    static const bool wide = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_FP8_QUANT_WIDE");
+        return !(e && e[0] == '0');
+    }();
+    if (wide && rows > 0 && cols > 0 && !(cols & 1)) {
+        pf_quantize_rows_fp8_wide_kernel<<<rows, 256, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(x_bf16),
+            reinterpret_cast<__nv_fp8_e4m3*>(q), scale, rows, cols);
+        return;
+    }
     pf_quantize_rows_fp8_kernel<<<rows, 32, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x_bf16),
         reinterpret_cast<__nv_fp8_e4m3*>(q), scale, rows, cols);
@@ -313,6 +361,23 @@ bool launch_prefill_gemm_fp8_splitk(const void* A, const void* W,
         return !(e && e[0] == '0');
     }();
     if (!on || !partials || M <= 0 || M > FP8_BM || N <= 0 || K <= 0) return false;
+
+    // Prefer the CUTLASS F8F6F4 collective for the same problem. It applies sx/sw in its own
+    // epilogue with the same (acc*sx)*sw association and the same single bf16 rounding this file's
+    // pf_gemm_fp8_sk_epi_kernel uses, and writes bf16 straight to C -- so there is no fp32 tile, no
+    // second pass over M*N, and no zeroing pass (the split-K memset goes away with it).
+    // Only taken when CUTLASS wants no workspace: this runs inside the captured prefill graph,
+    // where there is nowhere to allocate one. SPARKINFER_PREFILL_FP8_CUTLASS=0 restores the
+    // hand-written split-K kernel (A/B in ONE binary).
+    static const bool ct_on = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_FP8_CUTLASS");
+        return !(e && e[0] == '0');
+    }();
+    if (ct_on && prefill_ct_fp8_gemm_supported(M, N, K) &&
+        prefill_ct_fp8_gemm_workspace_bytes(M, N, K) == 0 &&
+        launch_prefill_ct_fp8_gemm(A, W, C, sx, sw, M, N, K, nullptr, stream))
+        return true;
+
     const int splits = fp8_sk_splits(M, N, K);
     if (splits <= 1) return false;
     const int nk = (K + FP8_BK - 1) / FP8_BK;

--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -17,6 +17,10 @@ bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*,
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t, float) { return false; }
+bool prefill_ct_fp8_gemm_supported(int, int, int) { return false; }
+size_t prefill_ct_fp8_gemm_workspace_bytes(int, int, int) { return 0; }
+bool launch_prefill_ct_fp8_gemm(const void*, const void*, void*, const float*, const float*,
+                                int, int, int, void*, cudaStream_t) { return false; }
 bool launch_ct_nvfp4_pack_sfb(const void*, void*, int, int, cudaStream_t) { return false; }
 } // namespace sparkinfer::kernels
 #endif

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -13,6 +13,7 @@
 #include <cute/tensor.hpp>
 
 #include <cstdlib>
+#include <cmath>
 
 namespace sparkinfer::kernels {
 namespace {
@@ -309,6 +310,134 @@ typename C::Gemm::Arguments args(const void* a, const void* sa, const void* b, c
             {{alpha, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
 }
 
+// ---------------------------------------------------------------------------------------------
+// PLAIN e4m3 GEMM ON THE SAME TENSOR CORES.
+//
+// The GDN projections (in_proj_qkv / in_proj_z / out_proj, 48 layers) are the one big weight
+// stream this checkpoint keeps as native FP8, and they run on a hand-written cp.async + ldmatrix
+// kernel (prefill_gemm_fp8.cu). At prefill@128 that kernel reaches 900 GB/s while the CUTLASS
+// block-scaled FFN GEMM in this same file reaches 1391 GB/s on the same box and the same M=128 --
+// the difference is warp specialization and TMA pipeline depth, not the shapes. Measured control:
+// handing the hand-written kernel 33% more CTAs moves it +0.3%, so it is not CTA-starved; it is
+// limited inside the CTA. So run these three shapes through CUTLASS instead.
+//
+// Structured deliberately so the two kernels share an epilogue: this entry point writes UNSCALED
+// FP32 into the caller's existing split-K partials buffer, and the caller then runs the SAME
+// pf_gemm_fp8_sk_epi_kernel it already ran to apply sx/sw and round to bf16. Nothing about how the
+// scales are applied changes, so the only numeric difference is the accumulator -- CUTLASS keeps
+// fp32 the whole way where the hand kernel accumulates in fp16 and flushes every FP8_FLUSH tiles.
+// It also needs no zeroing pass, which removes the per-call cudaMemsetAsync of M*N floats.
+using F8 = cutlass::float_e4m3_t;
+
+// The two dequant scales are applied INSIDE the epilogue, so the GEMM emits finished bf16 and no
+// fp32 tile is ever written to memory. Handing the result out as fp32 for a separate scale pass
+// costs a 4-byte store plus a 4-byte load plus the 2-byte store on every output element -- 10 bytes
+// where 2 will do. Across the 48 GDN layers' three projections that is ~1.06 GB of round-trip per
+// prefill@128, on kernels whose entire weight stream is 5.5 GB.
+//
+// Order is chosen to match pf_gemm_fp8_sk_epi_kernel exactly: it computes `p * s * sw[n]` in float,
+// i.e. (acc * sx) * sw, and rounds to bf16 once at the end. The tree below is the same association
+// with the same single rounding, so switching a projection between the two paths is bit-identical.
+constexpr auto kRN = cutlass::FloatRoundStyle::round_to_nearest;
+
+template <class TileShape>
+struct CfgF8 {
+    // sx is a per-row (per-token) scale -> column vector, stride <_1,_0,_0>.
+    // sw is a per-column (per-output-channel) scale -> row vector, stride <_0,_1,_0>.
+    using Sx = cutlass::epilogue::fusion::Sm90ColBroadcast<0, TileShape, float>;
+    using Sw = cutlass::epilogue::fusion::Sm90RowBroadcast<0, TileShape, float>;
+    using MulF32 = cutlass::epilogue::fusion::Sm90Compute<cutlass::multiplies, float, float, kRN>;
+    using MulOut = cutlass::epilogue::fusion::Sm90Compute<cutlass::multiplies, BF, float, kRN>;
+    using Inner = cutlass::epilogue::fusion::Sm90EVT<MulF32, Sx,
+                      cutlass::epilogue::fusion::Sm90AccFetch>;
+    using Fusion = cutlass::epilogue::fusion::Sm90EVT<MulOut, Sw, Inner>;
+
+    using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp, TileShape, Cluster,
+        cutlass::epilogue::collective::EpilogueTileAuto, float, float,
+        void, cutlass::layout::RowMajor, 1, BF, cutlass::layout::RowMajor, 8,
+        cutlass::epilogue::collective::EpilogueScheduleAuto, Fusion>::CollectiveOp;
+    using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
+        cutlass::arch::Sm120, cutlass::arch::OpClassTensorOp,
+        F8, cutlass::layout::RowMajor, 16, F8, cutlass::layout::ColumnMajor, 16, float,
+        TileShape, Cluster,
+        cutlass::gemm::collective::StageCountAutoCarveout<
+            static_cast<int>(sizeof(typename Epilogue::SharedStorage))>,
+        cutlass::gemm::collective::KernelScheduleAuto>::CollectiveOp;
+    using Kernel = cutlass::gemm::kernel::GemmUniversal<
+        Shape<int, int, int, int>, Mainloop, Epilogue, void>;
+    using Gemm = cutlass::gemm::device::GemmUniversalAdapter<Kernel>;
+};
+
+// Same two N-tilings, and the same reason as the block-scaled pair above: at m<=128 the grid is one
+// CTA tall, so the wide tile alone cannot cover the machine for the narrower GDN shapes.
+using F8Wide = CfgF8<Shape<_128, _128, _128>>;
+using F8Narrow = CfgF8<Shape<_128, _64, _128>>;
+using F8XNarrow = CfgF8<Shape<_128, _32, _128>>;
+
+// At m<=128 the grid is exactly ceil(n/TileN) CTAs -- one tile row, no second wave to hide a short
+// first one -- and this collective is one CTA per SM (384 threads, TMA-pipelined smem). So the tile
+// choice IS the occupancy choice, and the GDN shapes land badly on a fixed 64-wide tile. Measured
+// per-projection on an RTX 5090 (170 SMs) at prefill@128, after the switch to CUTLASS:
+//   gate/up  n=17408 -> 136 CTAs (0.80 wave)  1414 GB/s
+//   qkv      n=10240 -> 160 CTAs (0.94 wave)  1272 GB/s
+//   ffn_down n= 5120 ->  80 CTAs (0.47 wave)  1268 GB/s
+//   in_proj_z n=6144 ->  96 CTAs (0.56 wave)   885 GB/s
+//   out_proj n= 5120 ->  80 CTAs (0.47 wave)   797 GB/s
+// The two worst are exactly the two that leave half the machine idle. Note ffn_down is also 80 CTAs
+// yet reaches 1268: its K is 17408 against out_proj's 6144, so its K loop amortizes the prologue
+// over ~3x as many tiles. Occupancy hurts most where K is short.
+//
+// So pick TileN by how much of a WAVE the resulting grid fills, not by a fixed threshold. A grid of
+// 1.13 waves is 0.57 effective, worse than one of 0.94 -- the score below is `waves` when it fits
+// in one wave and `waves/ceil(waves)` when it spills, which is just "fraction of the launched slots
+// that do work". Larger tiles win ties because they re-read the shared A tile fewer times.
+// BIT-IDENTICAL: every output element still accumulates the whole K range in the same order; only
+// which CTA owns which output column changes.
+// SPARKINFER_PREFILL_FP8_TILEN=64 (or 128/32) pins one tile; =0 restores the old prefer_narrow.
+int sm_count();   // defined below, next to the block-scaled tile heuristic
+
+inline int f8_pick_tile_n(int m, int n) {
+    const int sms = sm_count();
+    if (m > 128 || sms <= 0) return 128;
+    int best = 128;
+    double best_fill = -1.0;
+    for (int t : {128, 64, 32}) {
+        const double waves = (double)((n + t - 1) / t) / (double)sms;
+        const double fill = waves <= 1.0 ? waves : waves / std::ceil(waves);
+        if (fill > best_fill + 1e-9) { best_fill = fill; best = t; }
+    }
+    return best;
+}
+
+template <class C>
+typename C::Gemm::Arguments f8_args(const void* a, const void* b, void* d,
+                                    const float* sx, const float* sw, int m, int n, int k) {
+    using SA = typename C::Kernel::StrideA;
+    using SB = typename C::Kernel::StrideB;
+    using SC = typename C::Kernel::StrideC;
+    using SD = typename C::Kernel::StrideD;
+    // Sm90EVT<Node, Child0, Child1>::Arguments is {child0, child1, node}, so the tree
+    // MulOut(Sw, MulF32(Sx, Acc)) nests as { {sw...}, { {sx...}, {}, {} }, {} }.
+    typename C::Fusion::Arguments fus = { {sw, 0.f, {}}, { {sx, 0.f, {}}, {}, {} }, {} };
+    return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m, n, k),
+            {static_cast<const F8*>(a), cutlass::make_cute_packed_stride(SA{}, {m, k, 1}),
+             static_cast<const F8*>(b), cutlass::make_cute_packed_stride(SB{}, {n, k, 1})},
+            {fus, static_cast<const BF*>(nullptr),
+             cutlass::make_cute_packed_stride(SC{}, {m, n, 1}),
+             static_cast<BF*>(d), cutlass::make_cute_packed_stride(SD{}, {m, n, 1})}};
+}
+
+template <class C>
+bool run_f8(const void* a, const void* b, void* d, const float* sx, const float* sw,
+            int m, int n, int k, void* ws, cudaStream_t st) {
+    typename C::Gemm gemm;
+    auto ar = f8_args<C>(a, b, d, sx, sw, m, n, k);
+    return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
+           gemm.initialize(ar, ws, st) == cutlass::Status::kSuccess &&
+           gemm.run(st) == cutlass::Status::kSuccess;
+}
+
 int sm_count() {
     static const int sms = [] {
         int dev = 0, c = 0;
@@ -419,11 +548,53 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
         const char* e = getenv("SPARKINFER_NVFP4_EVICT_FIRST");
         return !e || atoi(e) != 0;
     }();
+    // NOTE: the wave-fill tile picker the FP8 path uses (f8_pick_tile_n) was tried here too and
+    // measured WORSE -- 1.0782x -> 1.0434x prefill@128. ffn_down at n=5120 does move from 80 to 160
+    // CTAs, but a 32-wide tile halves the columns each A tile is amortized over while the
+    // block-scale operand's own N granularity stops paying for itself. The block-scaled path keeps
+    // two rungs; only the plain-FP8 one gets three.
     if (ef)
         return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha)
                                   : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha);
     return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st,alpha)
                               : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st,alpha);
+}
+
+bool prefill_ct_fp8_gemm_supported(int m, int n, int k) {
+    int dev = 0, major = 0, minor = 0;
+    // 16-element alignment on both operands is the F8F6F4 collective's requirement; the FP32 D
+    // operand needs 4. The GDN shapes (k=5120/6144, n=10240/6144/5120) clear all of them.
+    return cudaGetDevice(&dev) == cudaSuccess &&
+           cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, dev) == cudaSuccess &&
+           cudaDeviceGetAttribute(&minor, cudaDevAttrComputeCapabilityMinor, dev) == cudaSuccess &&
+           major == 12 && minor == 0 && m > 0 && n > 0 && k > 0 &&
+           !(k & 15) && !(n & 15) && !(n & 3);
+}
+
+size_t prefill_ct_fp8_gemm_workspace_bytes(int m, int n, int k) {
+    const size_t w = F8Wide::Gemm::get_workspace_size(
+        f8_args<F8Wide>(nullptr, nullptr, nullptr, nullptr, nullptr, m, n, k));
+    const size_t nw = F8Narrow::Gemm::get_workspace_size(
+        f8_args<F8Narrow>(nullptr, nullptr, nullptr, nullptr, nullptr, m, n, k));
+    const size_t xw = F8XNarrow::Gemm::get_workspace_size(
+        f8_args<F8XNarrow>(nullptr, nullptr, nullptr, nullptr, nullptr, m, n, k));
+    return w > nw ? (w > xw ? w : xw) : (nw > xw ? nw : xw);
+}
+
+bool launch_prefill_ct_fp8_gemm(const void* a, const void* b, void* d,
+                                const float* sx, const float* sw,
+                                int m, int n, int k, void* ws, cudaStream_t st) {
+    if (!a || !b || !d || !sx || !sw || !prefill_ct_fp8_gemm_supported(m, n, k)) return false;
+    static const int pin = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_FP8_TILEN");
+        return e ? atoi(e) : -1;
+    }();
+    const int t = (pin == 128 || pin == 64 || pin == 32) ? pin
+                : (pin == 0 ? (prefer_narrow(m, n) ? 64 : 128)   // legacy sizing
+                            : f8_pick_tile_n(m, n));
+    if (t == 32) return run_f8<F8XNarrow>(a, b, d, sx, sw, m, n, k, ws, st);
+    if (t == 64) return run_f8<F8Narrow>(a, b, d, sx, sw, m, n, k, ws, st);
+    return run_f8<F8Wide>(a, b, d, sx, sw, m, n, k, ws, st);
 }
 
 // ---- HuggingFace "compressed-tensors" NVFP4 checkpoint dequant (load-time, one-shot) ----

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -31,6 +31,23 @@ bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,
                                void* workspace, cudaStream_t stream = nullptr,
                                float alpha = 1.f);
 
+// ---- plain (non block-scaled) e4m3 GEMM on the same SM120 tensor cores --------------------------
+// A [m,k] row-major e4m3, B [n,k] row-major e4m3 (i.e. TN, K-major on both, which is the only
+// layout the SM120 F8F6F4 collective accepts), D [m,n] row-major bf16.
+// The per-row activation scale sx[m] and per-column weight scale sw[n] are applied INSIDE the
+// epilogue as (acc * sx) * sw with a single round to bf16 -- the same association and the same
+// single rounding pf_gemm_fp8_sk_epi_kernel performs, so a projection can move between this path
+// and the hand-written split-K one bit-identically. Emitting bf16 here means no fp32 tile is ever
+// written to memory.
+// Returns false when NVFP4 support is compiled out, the device is not sm_120, the shape is not
+// 16-element aligned, or CUTLASS declines the problem -- caller falls back to its own kernel.
+bool prefill_ct_fp8_gemm_supported(int m, int n, int k);
+size_t prefill_ct_fp8_gemm_workspace_bytes(int m, int n, int k);
+bool launch_prefill_ct_fp8_gemm(const void* a_e4m3, const void* b_e4m3, void* d_bf16,
+                                const float* sx, const float* sw,
+                                int m, int n, int k, void* workspace,
+                                cudaStream_t stream = nullptr);
+
 // Scatter a compressed-tensors row-major UE4M3 scale [n, k/16] into the CUTLASS
 // SFB layout launch_prefill_nvfp4_gemm expects for B. Packed E2M1 bytes are
 // already the same nibble order as launch_prefill_nvfp4_quant_b, so they are


### PR DESCRIPTION
## Summary

Runs the Gated-DeltaNet `in_proj_qkv` / `in_proj_z` / `out_proj` through a CUTLASS SM120 F8F6F4 collective instead of the hand-written `cp.async` GEMM, and makes the GDN chunk-prep triangular inverse warp-synchronous. 1.054x prefill@128 on the NVFP4 checkpoint, decode flat.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 83.77 |
| after (this PR) | 83.72 |

**Prefill pp tok/s** (Qwen3.8-27B NVFP4 checkpoint, `--ctx 128` — the context `eval/pr_qwen38_bot.py` scores):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4786.28 |
| after prefill (this PR) | 5046.17 |

```text
# 3 alternating main/PR pairs, ONE binary, ONE session, median of 5 reps each
# (bench sweep at ctx=128 — the same bench_sweep_run path bench.sh / _eval_speed.sh drive,
#  end-to-end model load + prefill + decode, not an isolated kernel)
# main = e9b4a2c, RTX 5090 sm_120, CUDA 12.8

pair1 MAIN {"128":{"decode_tps":83.8297,"prefill_pp":4793.4603}}
pair1 PR   {"128":{"decode_tps":83.7230,"prefill_pp":5049.4124}}
pair2 MAIN {"128":{"decode_tps":83.7712,"prefill_pp":4781.8537}}
pair2 PR   {"128":{"decode_tps":83.7252,"prefill_pp":5043.1056}}
pair3 MAIN {"128":{"decode_tps":83.6883,"prefill_pp":4786.2777}}
pair3 PR   {"128":{"decode_tps":83.7104,"prefill_pp":5046.1663}}

prefill median 4786.28 -> 5046.17   = 1.0543x  (+5.43%)
decode  median   83.77 ->   83.72   = 0.9994x  (flat)

# differential accuracy gate, PR vs main, same token stream
positions             : 101
top-1 agreement       : 101/101 = 1.000   (PR vs main)
mean KL(main||pr)     : 0.0000 nats  (top-k union)
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.2812 ppl_main=3.2812

# generation identity through the batched prefill (147-token prompt, 24 new tokens)
# 16/16 runs across all four switch combinations produce byte-identical OUTPUT_IDS
```
