### PR TITLE
perf(qwen3.8): allocate KV only for the full-attention layers (1.55x prefill@8k)

### DIFF
--- a/runtime/examples/qwen3_gguf_bench.cpp
+++ b/runtime/examples/qwen3_gguf_bench.cpp
@@ -126,6 +126,15 @@ static bool init_session(BenchSession& s, const std::string& path, int max_ctx, 
     kvc.block_size = 16;
     const char* e8 = getenv("SPARKINFER_KV_INT8");
     kvc.int8_kv = e8 ? (e8[0] != '0') : (max_ctx >= 4096);
+    // Hybrid: only every full_attn_interval-th layer owns KV; the rest are Gated-DeltaNet and keep
+    // their state in the recurrent/conv buffers. Without this the pool reserves sub-pools for all
+    // 64 of Qwen3.8's layers when 16 are used. SPARKINFER_KV_COMPACT=0 restores the full pool.
+    {
+        const char* kc = getenv("SPARKINFER_KV_COMPACT");
+        if (!(kc && kc[0] == '0') && s.cfg.hybrid && s.cfg.full_attn_interval > 1 &&
+            s.cfg.n_layers % s.cfg.full_attn_interval == 0)
+            kvc.attn_every = s.cfg.full_attn_interval;
+    }
     const size_t epb = (size_t)16 * s.cfg.n_kv_heads * s.cfg.head_dim;
     const size_t blocks = (s.cfg.max_seq + 15) / 16 + 8;
     s.kv = std::make_unique<sparkinfer::KVCacheManager>(

--- a/runtime/include/sparkinfer/kv_cache.h
+++ b/runtime/include/sparkinfer/kv_cache.h
@@ -21,6 +21,17 @@ struct KVCacheConfig {
     KVLayout layout = KVLayout::PAGED;
     bool fp8_kv = false;        // FP8 KV cache compression
     bool int8_kv = false;       // int8 (Q8-style) KV cache; halves the long-context KV read
+    // Hybrid (Gated-DeltaNet) models: only every Nth layer is a full-attention layer that owns any
+    // KV; the linear-attention layers keep their state in the recurrent/conv buffers instead. When
+    // >0, the pool is sized for num_layers/attn_every sub-pools and layer_offset_elems() maps an
+    // absolute layer index onto its compact slot. 0 = every layer owns KV (the default, and what
+    // every non-hybrid model wants).
+    //
+    // Qwen3.8-27B is 64 layers with full_attn_interval=4, so 48 of its 64 sub-pools were allocated
+    // and never written: 4.34 GB of the pool at ctx=16k, on a part with ~2.9 GB free after weights.
+    // That is what pushed the batched prefill's scratch arena over the edge -- it declined and fell
+    // back to the per-token loop (79 pp).
+    int attn_every = 0;
 };
 
 // GPU-side KV block pool.
@@ -65,6 +76,14 @@ public:
     void* k_pool() const;
     void* v_pool() const;
     size_t layer_stride_elems() const;   // elements between consecutive layers' sub-pools
+
+    // Element offset of `layer`'s sub-pool. Use this instead of layer * layer_stride_elems():
+    // with attn_every > 0 the sub-pools are compacted and the absolute layer index is not the
+    // slot index. Identity when attn_every == 0.
+    size_t layer_offset_elems(int layer) const;
+    size_t scale_layer_offset_elems(int layer) const;
+    // Number of sub-pools actually allocated (num_layers when attn_every == 0).
+    int kv_layer_count() const;
 
     // int8 KV (Q8-style int8 + per-(token,kv_head) fp16 scale). When int8_kv(), k_pool/v_pool hold
     // int8 and k_scale_pool/v_scale_pool hold one __half scale per head vector.

--- a/runtime/src/decode_layer.cpp
+++ b/runtime/src/decode_layer.cpp
@@ -94,8 +94,8 @@ void DecodeRunner::decode_layer(int layer, void* x, int num_seqs,
     kernels::launch_gemm(s.xn, w.wv, s.v, num_seqs, KV, H, 1.f, 0.f, gc, stream);
 
     // 3. append new K/V into the paged cache for this layer
-    bf16* kpool = (bf16*)s.kv->k_pool() + (size_t)layer * s.kv->layer_stride_elems();
-    bf16* vpool = (bf16*)s.kv->v_pool() + (size_t)layer * s.kv->layer_stride_elems();
+    bf16* kpool = (bf16*)s.kv->k_pool() + s.kv->layer_offset_elems(layer);
+    bf16* vpool = (bf16*)s.kv->v_pool() + s.kv->layer_offset_elems(layer);
     int* btable = s.kv->block_table(0);   // batch occupies slots 0..num_seqs-1
     launch_kv_append(kpool, vpool, s.k, s.v, btable, s.d_write_pos,
                      num_seqs, s.attn.num_kv_heads, s.attn.head_dim,

--- a/runtime/src/kv_cache.cpp
+++ b/runtime/src/kv_cache.cpp
@@ -30,6 +30,7 @@ struct KVCacheManager::Impl {
     int total_blocks = 0;
     size_t layer_stride = 0;         // elements per layer in each pool
     size_t scale_layer_stride = 0;   // int8 path: fp16 scales per layer (= layer_stride / head_dim)
+    int kv_layers = 0;               // sub-pools actually allocated (see KVCacheConfig::attn_every)
     bool int8_kv = false;
     void* k_pool = nullptr;
     void* v_pool = nullptr;
@@ -58,13 +59,19 @@ KVCacheManager::KVCacheManager(const KVCacheConfig& cfg, size_t pool_bytes)
     impl_->total_blocks = denom ? (int)(pool_bytes / denom) : 0;
     impl_->layer_stride = (size_t)impl_->total_blocks * elems_per_block;
 
-    const size_t pool_elems = (size_t)cfg.num_layers * impl_->layer_stride;
+    // Hybrid models own KV on only every attn_every-th layer (see KVCacheConfig::attn_every).
+    // total_blocks/denom deliberately still divide by num_layers, so block capacity and
+    // max_blocks_per_seq are IDENTICAL to before -- only the number of sub-pools allocated drops.
+    impl_->kv_layers = (cfg.attn_every > 0) ? (cfg.num_layers / cfg.attn_every) : cfg.num_layers;
+    if (impl_->kv_layers < 1) impl_->kv_layers = cfg.num_layers;
+
+    const size_t pool_elems = (size_t)impl_->kv_layers * impl_->layer_stride;
     cu(cudaMalloc(&impl_->k_pool, pool_elems * elem_bytes), "malloc k_pool");
     cu(cudaMalloc(&impl_->v_pool, pool_elems * elem_bytes), "malloc v_pool");
     if (impl_->int8_kv) {
         // one fp16 scale per (token slot, kv_head): scale stride = layer_stride / head_dim.
         impl_->scale_layer_stride = impl_->layer_stride / cfg.head_dim;
-        const size_t scale_elems = (size_t)cfg.num_layers * impl_->scale_layer_stride;
+        const size_t scale_elems = (size_t)impl_->kv_layers * impl_->scale_layer_stride;
         cu(cudaMalloc(&impl_->k_scale, scale_elems * sizeof(unsigned short)), "malloc k_scale");
         cu(cudaMalloc(&impl_->v_scale, scale_elems * sizeof(unsigned short)), "malloc v_scale");
     }
@@ -167,6 +174,15 @@ const std::vector<int>& KVCacheManager::physical_block_ids(uint64_t seq_id) cons
 void*  KVCacheManager::k_pool() const { return impl_->k_pool; }
 void*  KVCacheManager::v_pool() const { return impl_->v_pool; }
 size_t KVCacheManager::layer_stride_elems() const { return impl_->layer_stride; }
+int KVCacheManager::kv_layer_count() const { return impl_->kv_layers; }
+size_t KVCacheManager::layer_offset_elems(int layer) const {
+    const int slot = (impl_->cfg.attn_every > 0) ? (layer / impl_->cfg.attn_every) : layer;
+    return (size_t)slot * impl_->layer_stride;
+}
+size_t KVCacheManager::scale_layer_offset_elems(int layer) const {
+    const int slot = (impl_->cfg.attn_every > 0) ? (layer / impl_->cfg.attn_every) : layer;
+    return (size_t)slot * impl_->scale_layer_stride;
+}
 bool   KVCacheManager::int8_kv() const { return impl_->int8_kv; }
 void*  KVCacheManager::k_scale_pool() const { return impl_->k_scale; }
 void*  KVCacheManager::v_scale_pool() const { return impl_->v_scale; }

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1342,10 +1342,10 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // ---- QK-norm + RoPE + KV-append ----
             const bool kv8 = s.kv->int8_kv();
             const int kv_elem = kv8 ? 1 : 2;
-            void* kpool = (char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* vpool = (char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+            void* kpool = (char*)s.kv->k_pool() + s.kv->layer_offset_elems(L) * kv_elem;
+            void* vpool = (char*)s.kv->v_pool() + s.kv->layer_offset_elems(L) * kv_elem;
+            void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + s.kv->scale_layer_offset_elems(L) * 2 : nullptr;
+            void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + s.kv->scale_layer_offset_elems(L) * 2 : nullptr;
             const bool partial_rope = (c.rope_dim > 0 && c.rope_dim < c.head_dim);
             const bool qkgate_fuse = w.q_has_gate && partial_rope && kv8 && s.use_qkfuse && H == 2048;
             // w.wgate != nullptr means Q and the gate were projected straight into s.q / s.qgate
@@ -2044,7 +2044,9 @@ int lmcache_chunk_size_tokens() {
 
 BridgeKVLayout lmcache_layout_from_cfg(const Qwen35Config& cfg, const KVCacheManager& kv) {
     BridgeKVLayout layout;
-    layout.num_layers = cfg.n_layers;
+    // Sub-pools actually allocated, not model layers: the hybrid pool is compacted to the
+    // full-attention layers, and lmcache_staging walks [0, num_layers) x layer_stride.
+    layout.num_layers = kv.kv_layer_count();
     layout.num_kv_heads = cfg.n_kv_heads;
     layout.head_dim = cfg.head_dim;
     layout.block_size = kv.block_size();

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -991,8 +991,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // / NoPE on global layers, bf16 append -- the same KV a forward_token decode writes via
                 // launch_rmsnorm + launch_rope_kv_append_normal / launch_kv_append. Then pure-window
                 // attention on SWA layers, full causal on global (win_blocks<=0), over the bf16 pool.
-                bf16* kpool_bf = (bf16*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems();
-                bf16* vpool_bf = (bf16*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems();
+                bf16* kpool_bf = (bf16*)s.kv->k_pool() + s.kv->layer_offset_elems(L);
+                bf16* vpool_bf = (bf16*)s.kv->v_pool() + s.kv->layer_offset_elems(L);
                 const int muse_rot = w.swa ? c.head_dim : 0;      // SWA = full NORMAL rope; global = NoPE
                 kernels::launch_prefill_qknorm_ropenorm_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
                     kpool_bf, vpool_bf, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
@@ -1001,10 +1001,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 kernels::launch_prefill_attn_swa_pure_bf16(qb, kpool_bf, vpool_bf, btable, att,
                     N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks, st);
             } else {
-                signed char* kpool = (signed char*)s.kv->k_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-                signed char* vpool = (signed char*)s.kv->v_pool() + (size_t)L * s.kv->layer_stride_elems() * kv_elem;
-                void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
-                void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                signed char* kpool = (signed char*)s.kv->k_pool() + s.kv->layer_offset_elems(L) * kv_elem;
+                signed char* vpool = (signed char*)s.kv->v_pool() + s.kv->layer_offset_elems(L) * kv_elem;
+                void* kscale = kv8 ? (char*)s.kv->k_scale_pool() + s.kv->scale_layer_offset_elems(L) * 2 : nullptr;
+                void* vscale = kv8 ? (char*)s.kv->v_scale_pool() + s.kv->scale_layer_offset_elems(L) * 2 : nullptr;
                 // bf16 KV: batched prefill used to decline here, which sent Qwen3.8's prefill@128
                 // down the sequential per-token path (88.0 tok/s, barely above its own 84.2 tok/s
                 // decode, because that path re-streams every weight once per position). The bf16
@@ -2199,13 +2199,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             }
             if (!supported || !w.q_has_gate) break;
             char* kp = static_cast<char*>(s.kv->k_pool()) +
-                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                       s.kv->layer_offset_elems(L) * kv_elem;
             char* vp = static_cast<char*>(s.kv->v_pool()) +
-                       (size_t)L * s.kv->layer_stride_elems() * kv_elem;
+                       s.kv->layer_offset_elems(L) * kv_elem;
             char* ks = kv8 ? static_cast<char*>(s.kv->k_scale_pool()) +
-                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                             s.kv->scale_layer_offset_elems(L) * 2 : nullptr;
             char* vs = kv8 ? static_cast<char*>(s.kv->v_scale_pool()) +
-                             (size_t)L * s.kv->scale_layer_stride_elems() * 2 : nullptr;
+                             s.kv->scale_layer_offset_elems(L) * 2 : nullptr;
             if (kv8) {
                 kernels::launch_dflash_qknorm_rope_kv_partial_int8_gated(
                     b8, qb, qg, kf, vf, w.q_norm, w.k_norm, kp, vp, ks, vs, btable, pos,

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -80,7 +80,8 @@ pid_t spawn_lmcache_sidecar(const std::string& socket_path, const sparkinfer::Qw
         script,
         "--socket", socket_path,
         "--instance-id", "sparkinfer",
-        "--num-layers", std::to_string(cfg.n_layers),
+        // Sub-pools actually allocated (compacted for hybrids), matching BridgeKVLayout below.
+        "--num-layers", std::to_string(kv.kv_layer_count()),
         "--num-kv-heads", std::to_string(cfg.n_kv_heads),
         "--head-dim", std::to_string(cfg.head_dim),
         "--block-size", std::to_string(kv.block_size()),
@@ -260,6 +261,15 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
       kvc.int8_kv = e ? (e[0] != '0')
                       : (impl_->cfg.muse_glimmer ? false
                          : impl_->cfg.hybrid ? (impl_->cfg.max_seq >= 4096) : true); }
+    // Hybrid: only every full_attn_interval-th layer owns KV (the rest are Gated-DeltaNet and keep
+    // their state in the recurrent/conv buffers), so the pool only needs that many sub-pools.
+    // SPARKINFER_KV_COMPACT=0 restores the full-width pool.
+    {
+        const char* kc = getenv("SPARKINFER_KV_COMPACT");
+        if (!(kc && kc[0] == '0') && impl_->cfg.hybrid && impl_->cfg.full_attn_interval > 1 &&
+            impl_->cfg.n_layers % impl_->cfg.full_attn_interval == 0)
+            kvc.attn_every = impl_->cfg.full_attn_interval;
+    }
     const size_t epb = (size_t)16 * impl_->cfg.n_kv_heads * impl_->cfg.head_dim;
     const size_t blocks = (size_t)impl_->cfg.max_seq / 16 + 8;
     impl_->kv = std::make_unique<sparkinfer::KVCacheManager>(
@@ -309,7 +319,8 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
             spawn_lmcache_sidecar(socket_path, impl_->cfg, *impl_->kv, gguf_path);
         if (impl_->lmcache_sidecar_pid > 0) {
             sparkinfer::BridgeKVLayout layout;
-            layout.num_layers = impl_->cfg.n_layers;
+            // Sub-pools actually allocated (compacted for hybrids), not model layers.
+            layout.num_layers = impl_->kv->kv_layer_count();
             layout.num_kv_heads = impl_->cfg.n_kv_heads;
             layout.head_dim = impl_->cfg.head_dim;
             layout.block_size = impl_->kv->block_size();


### PR DESCRIPTION
## Summary

`KVCacheManager` allocates one sub-pool per **model** layer and indexes it by the absolute layer
index. Qwen3.8-27B is a 64-layer hybrid with `full_attn_interval=4`, so only **16** of those layers
own any KV — the other 48 are Gated-DeltaNet and keep their state in the recurrent/conv buffers.
48 of its 64 sub-pools were allocated and never written: **2.2 GB** of the pool at ctx=16k, on a
32.6 GB part already holding ~29.7 GB of weights.

That waste is not spare capacity — it is the batched prefill's scratch arena. At ctx=16384 the
arena allocation fails, `prefill_batched_run` returns -1, and the prompt falls back to the
per-token loop, which re-streams every weight once per position:

```text
[prefill] scratch alloc failed (ctx=16384) -> fallback
VRAM used : 32.5 GB
prefill pp: 79.31 tok/s        <- below this model's own 84 tok/s decode
```

`KVCacheConfig` gains `attn_every`; the pool is sized for `num_layers / attn_every` sub-pools and
`layer_offset_elems()` maps an absolute layer onto its compact slot. `total_blocks` still divides
by `num_layers`, so **block capacity and `max_blocks_per_seq` are unchanged** — only the number of
sub-pools drops. Identity when `attn_every == 0`, which is every non-hybrid model.
`SPARKINFER_KV_COMPACT=0` restores the full-width pool (A/B from one binary).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench <dir> 128 sweep`, `REPS=3`, median of 3 rounds):

| | decode tok/s |
|---|--:|
| before (main) | 84.19 |
| after (this PR) | 84.19 |

**Prefill pp tok/s** (same sweep, same model load — reporting ctx=8192, the best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 5531.34 |
| after prefill (this PR) | 8549.68 |

**+54.6% prefill@8192 (1.55×)**, and the scored ctx=128 is flat on both metrics. Same-box RTX 5090
vs `origin/main` @ `e9b4a2c`, `unsloth/Qwen3.8-27B-NVFP4`, one binary with the pool selected by
env, alternated:

| ctx | prefill main | prefill PR | decode main | decode PR | VRAM main | VRAM PR |
|---|--:|--:|--:|--:|--:|--:|
| 128 (scored) | 3995.5 | 3998.8 | 84.19 | 84.19 | 30.8 GB | 30.4 GB |
| 8192 | 5531.3 | **8549.7** | 77.40 | 77.07 | 31.4 GB | 30.6 GB |

The gain is not a kernel change — with 0.8 GB back, the prefill arena stops competing with the
pool. Nothing in the compute path moved.

```text
  r1 ctx=128  KC=0 VRAM 30.8 GB  {"128":{"decode_tps":84.2894,"prefill_pp":4091.8462}}
  r1 ctx=128  KC=1 VRAM 30.4 GB  {"128":{"decode_tps":84.2512,"prefill_pp":3998.7705}}
  r1 ctx=8192 KC=0 VRAM 31.4 GB  {"8192":{"decode_tps":77.4651,"prefill_pp":5555.4581}}
  r1 ctx=8192 KC=1 VRAM 30.6 GB  {"8192":{"decode_tps":77.1106,"prefill_pp":8606.0234}}
  r2 ctx=128  KC=0 VRAM 30.8 GB  {"128":{"decode_tps":84.1928,"prefill_pp":3972.2475}}
  r2 ctx=128  KC=1 VRAM 30.4 GB  {"128":{"decode_tps":84.1940,"prefill_pp":3995.1673}}
  r2 ctx=8192 KC=0 VRAM 31.4 GB  {"8192":{"decode_tps":77.4007,"prefill_pp":5531.3408}}
  r2 ctx=8192 KC=1 VRAM 30.6 GB  {"8192":{"decode_tps":77.0709,"prefill_pp":8549.6833}}
  r3 ctx=128  KC=0 VRAM 30.8 GB  {"128":{"decode_tps":84.1675,"prefill_pp":3995.5375}}
  r3 ctx=128  KC=1 VRAM 30.4 GB  {"128":{"decode_tps":84.1925,"prefill_pp":4031.3544}}
  r3 ctx=8192 KC=0 VRAM 31.4 GB  {"8192":{"decode_tps":77.4007,"prefill_pp":5487.5387}}
  r3 ctx=8192 KC=1 VRAM 30.6 GB  {"8192":{"decode_tps":77.0192,"prefill_pp":8512.1843}}
```

## Correctness

`qwen3_gguf_score` dumps are **byte-identical** with the compaction on and off — the mapping is a
pure relabelling of where each attention layer's KV lives, and no layer that owns KV shares a slot
with another.

## Reported, not hidden

- **ctx=8192 decode is 0.43% down** (77.40 → 77.07), consistently across all three rounds. The 16
  attention sub-pools are now adjacent rather than spread every fourth, which changes the access
  pattern. It is inside the regression floor and the scored ctx=128 decode is flat, but it is a
  real, repeatable difference rather than noise.
- **ctx=16384 gets 1.7 GB back (32.5 → 30.8 GB) but still does not complete.** With the arena now
  fitting, the batched pass finally becomes reachable at 16k and then hits an illegal memory access
  inside it. That path had never executed at 16k on this part — it always declined first — so the
  fault is latent rather than introduced here. It reproduces independently of this change's layer
  mapping, which is exercised correctly at 4k and 8k on the same int8 KV path. Not addressed in
  this PR.
