### PR TITLE
perf(qwen3.8): size the prefill activation buffer for the widest projection (2.27x prefill@16k)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -339,19 +339,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // SPARKINFER_PREFILL_FP8_GDN=0 restores the bf16 GDN projections (A/B).
     const char* _pfp8 = getenv("SPARKINFER_PREFILL_FP8_GDN");
     bool use_fp8_gdn = long_bf16 && (!_pfp8 || _pfp8[0] != '0');
-    // The int8 projection path has only ever run with FC == N (main chunks the FFN only above
-    // 32k, and at those contexts it fails the scratch alloc and falls back before reaching here).
-    // With FC < N it corrupts memory: at ctx=16384 the pass ends in an illegal memory access that
-    // kills the decode graph right after it, reproducible at chunk 4096/2048 and cleared by
-    // SPARKINFER_PREFILL_I8=0. Rather than enable a path that is not demonstrably correct, run the
-    // chunked pass on the NVFP4/bf16 projections -- measured 2233 pp at 16k against the 79 pp
-    // token-loop fallback. ctx=128 has FC == N, so the scored floor keeps int8 exactly as today.
-    if (!moe && FC < N) {
-        use_i8 = false;
-        use_i8_ffn = false;
-        use_i8_attn = false;
-        use_fp8_gdn = false;
-    }
+    // #845 disabled the int8 projections whenever FC < N: that combination ended the pass in an
+    // illegal memory access which took the decode graph with it. The cause was the A_i8 sizing
+    // below (N*H, while the o projection quantizes N*qdim), not the int8 path itself, so with the
+    // sizing corrected the workaround is gone and the chunked pass keeps its tensor-core
+    // projections -- worth 66.6% of the 16k pass, which was falling back to bf16 pf_gemm_kernel.
     // MoE (Qwen3.6): run the attn/GDN projections on the fp8 (e4m3) tensor cores instead of
     // the bf16 wmma GEMM. Default ON again: the #586/#587 prefill_check failures traced to the
     // opt-in MOE_GPU tilemap path's mask dequant silently no-opping (down cols=mffn declines
@@ -363,19 +355,24 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const char* _pmfp8 = getenv("SPARKINFER_PREFILL_MOE_FP8");
     bool moe_fp8 = moe && (!_pmfp8 || _pmfp8[0] != '0');
     Arena& a8 = arena_reuse ? keep_a8 : once_a8;
-    // A_i8 holds the quantized activation. Dense full-i8: non-FFN projs quantize N rows x K(<=H);
-    // chunked FFN quantizes at most FC rows x ffn. Long-ctx selective: N*H if attn-i8/fp8-gdn else FC*ffn.
+    // A_i8 holds the quantized activation. The comment below used to say the non-FFN projections
+    // quantize "N rows x K(<=H)" -- they do not: the o projection's A is `att` at k = qdim, and on
+    // Qwen3.8-27B qdim (24*256 = 6144) is WIDER than H (5120). N*H under-sizes it by N*(qdim-H).
+    // That was invisible while FC == N, because the FC*ffn term (ffn = 17408) covered everything;
+    // chunk the FFN and the cover disappears, and pf_quantize_rows_fp8_kernel writes past the end
+    // (compute-sanitizer: "Invalid __global__ write ... 962561 bytes after the nearest allocation
+    // of size 20971520", i.e. N*H, from the o-projection quantize at N x 6144).
+    // So: N rows x the widest K any N-row projection uses, OR FC rows x ffn for the chunked FFN.
     // MoE: no chunked FFN; projections quantize N rows x maxAK.
     const bool need_i8 = use_i8 || use_i8_ffn || use_i8_attn || use_fp8_gdn || moe_shared_i8 || moe_fp8;
-    // Take the max on BOTH dense paths. The int8-projections-off branch used to size against
-    // FC*ffn alone, below the N*H the non-FFN projections quantize once the FFN chunk drops
-    // below N*H/ffn -- a silent overrun rather than an alloc failure. FC is floored above so this
-    // is a no-op in practice; it keeps a hand-set SPARKINFER_PREFILL_FFN_CHUNK from overrunning.
-    const size_t a_i8_dense = ((size_t)N * H > (size_t)FC * ffn) ? (size_t)N * H : (size_t)FC * ffn;
+    // Both terms, on both dense paths: the N-row projections and the FC-row FFN chunk each have to
+    // fit, and neither one bounds the other once FC and N can differ.
+    const int a_wide_k = imax(H, imax(qdim, lvdim));   // widest K quantized with N rows
+    const size_t a_i8_rows_n = (size_t)N * (size_t)a_wide_k;
+    const size_t a_i8_dense = (a_i8_rows_n > (size_t)FC * ffn) ? a_i8_rows_n : (size_t)FC * ffn;
     const size_t a_i8_sz = moe ? (size_t)N * maxAK : a_i8_dense;
-    // N, not FC: sx is the per-row scale that pairs with A_i8 above, and the same non-FFN
-    // projections write N of them. FC >= the chunk floor makes this equal in practice (FC <= N
-    // always), and it costs N floats to be right when the chunk is small.
+    // N, not FC: sx is the per-row scale that pairs with A_i8 above, and the non-FFN projections
+    // write N of them regardless of how small the FFN chunk gets. Costs N floats.
     const size_t sx_n = (size_t)N;
     signed char* A_i8 = need_i8 ? a8.alloc<signed char>(a_i8_sz) : nullptr;
     // k-tiled [k/32][row][32] copy of the int8 activation for Muse's dense prefill GEMM. That


### PR DESCRIPTION
## Summary

**The prefill activation buffer is sized for the wrong projection width, which corrupts memory as
soon as the FFN is chunked. Fixing the sizing puts the chunked pass back on its tensor-core
projections: prefill@16k 2054.74 -> 4653.52 pp (2.27x).**

`a_i8_sz` on the dense path is `max(N*H, FC*ffn)`, and the comment above it states that the
non-FFN projections quantize "N rows x K(<=H)". **They do not.** The o projection's A operand is
`att` at `k = qdim`, and on Qwen3.8-27B `qdim` (24 * 256 = **6144**) is wider than `H` (**5120**),
so that buffer is short by `N * (qdim - H)` bytes.

It has been invisible because while `FC == N` the other term, `FC*ffn` (ffn = 17408), is far larger
and covers the shortfall. Chunk the FFN — which main does above 32k on its own, and which #845 does
at 16k to keep the batched pass alive — and the cover disappears:

```text
# compute-sanitizer memcheck, PLAIN main (784c3f1, no patch), ctx=4096,
# SPARKINFER_PREFILL_FFN_CHUNK=1024
Invalid __global__ write of size 1 bytes
  at pf_quantize_rows_fp8_kernel(...) in prefill_gemm_fp8.cu:79
  by thread (0,0,0) in block (3570,0,0)
  Address 0x7ada95eeb000 is out of bounds
  and is 962561 bytes after the nearest allocation at 0x7ada94a00000 of size 20971520 bytes
  Host Frame: sparkinfer::prefill_batched_run(...)
```

20971520 is exactly `N*H` (4096 * 5120), which identifies the buffer; block 3570 writing at
~21,934,081 implies `cols ~= 6144`, which identifies the projection as the o projection at `qdim`.
The fault is a dead CUDA context, so the run does not error — it returns nonsense (`decode_tps` in
the 5e5 range) and any consumer that trusts the number is reading noise.

The fix sizes the N-row term against the widest K any N-row projection actually uses:

```cpp
const int a_wide_k = imax(H, imax(qdim, lvdim));   // widest K quantized with N rows
const size_t a_i8_rows_n = (size_t)N * (size_t)a_wide_k;
const size_t a_i8_dense = (a_i8_rows_n > (size_t)FC * ffn) ? a_i8_rows_n : (size_t)FC * ffn;
```

`FC == N` is unchanged by construction (the `FC*ffn` term still dominates there), so **ctx=128 is
byte-for-byte what it is today**. Only the chunked path changes, and only to become correct.

With the sizing right, the workaround #845 shipped — disabling the int8 projections whenever
`FC < N` — is no longer needed and is removed. That workaround is what dropped the chunked pass
onto the bf16 GEMM path instead of the tensor-core projections it was meant to use.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — this PR is prefill-only):

| | decode tok/s |
|---|--:|
| before (main) | 83.88 |
| after (this PR) | 83.80 |

**Prefill pp tok/s** (Qwen3.8-27B NVFP4, ctx=16384 — the dimension `pr_qwen38_bot.py` scores):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2054.74 |
| after prefill (this PR) | **4653.52 (2.27x, +126.5%)** |

```text
# RTX 5090 sm_120, unsloth/Qwen3.8-27B-NVFP4. SHIPPED DEFAULTS -- the only env vars set are the
# two the bot's own bench_sweep_run exports. Arms rebuilt between runs (one build dir, so no stale
# runtime .so can cross an arm), alternated, serialized, and in the bot's sweep ORDER (128 then
# 16384) because that order is what leaves VRAM tight.

BASE pair1 {"128":{"decode_tps":83.9254,"prefill_pp":4371.8974},"16384":{"decode_tps":71.6284,"prefill_pp":2057.5490}}
PR   pair1 {"128":{"decode_tps":83.8496,"prefill_pp":4370.0840},"16384":{"decode_tps":71.4947,"prefill_pp":4665.5758}}
BASE pair2 {"128":{"decode_tps":83.8346,"prefill_pp":4354.4597},"16384":{"decode_tps":71.4325,"prefill_pp":2051.9345}}
PR   pair2 {"128":{"decode_tps":83.7589,"prefill_pp":4358.5863},"16384":{"decode_tps":71.3553,"prefill_pp":4641.4601}}

prefill@16k  median 2054.74 -> 4653.52  = 2.265x  (+126.5%)   <- the scored dimension
prefill@128  median 4363.18 -> 4364.34  = 1.0003x (floor, tol 0.98)
decode@128   median   83.88 ->   83.80  = 0.9991x (floor, tol 0.98)
```

**The overrun is gone, on the exact configuration that produced it:**

```text
# compute-sanitizer memcheck, THIS build, ctx=4096, FFN_CHUNK=1024, int8 projections ON
========= ERROR SUMMARY: 0 errors
```

**Differential accuracy gate** (`accuracy_compare_pair.py`, PR vs main, TOPK=128):

```text
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.2812 ppl_main=3.2812

# 102-token stream from the checkpoint's own tokenizer, TOPK=128. Byte-identical by construction:
# at ctx=128 FC == N, so the sizing expression collapses to exactly the value it has today.
```

**Generation identity through the batched pass at ctx=16384.** `qwen3_gguf_score` teacher-forces
per token and does not route through `prefill_batched_run`, so a score-based diff cannot see this
path (verified: flipping `SPARKINFER_PREFILL_BATCHED` leaves its dump byte-identical). The check
that does exercise it is generation: same binary, env-flipped, 16384-token prompt, 24 tokens out.

```text
# batched arm (what this PR changes) -- identifiable in-trace by a line the other arm cannot print:
[prefill] ffn chunk 16384 -> 2048 (ctx=16384, free=551 MB) to keep the batched pass
batched    OUTPUT_IDS: 7 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197
tokenloop  OUTPUT_IDS: 7 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197
# 24/24 identical: the chunked pass with int8 projections reproduces the sequential prefill exactly.

# Stated plainly: this prompt is synthetic (a non-repeating id ramp), so the continuation is
# repetitive and a stable attractor makes argmax less sensitive than natural text would be. It is
# reported as what it is -- an end-to-end identity check through the changed path at the scored
# context -- not as a tight numerical bound.
```

**Qwen3.6 cross-model guard** (ctx 0/512/4k/16k/32k, tol 0.98). `a_i8_sz` is shared prefill code,
so this is measured rather than assumed (Qwen3.6 is MoE and takes the `N*maxAK` branch, which this
PR does not touch):

```text
ctx      0 decode_tps  main    490.08 -> PR    490.02  0.9999x  ok
ctx    512 decode_tps  main    484.44 -> PR    483.86  0.9988x  ok
ctx    512 prefill_pp  main  10002.10 -> PR   9982.38  0.9980x  ok
ctx   4096 decode_tps  main    465.70 -> PR    464.89  0.9983x  ok
ctx   4096 prefill_pp  main  25867.88 -> PR  25804.38  0.9975x  ok
ctx  16384 decode_tps  main    465.07 -> PR    464.50  0.9988x  ok
ctx  16384 prefill_pp  main  26807.44 -> PR  26731.10  0.9972x  ok
ctx  32768 decode_tps  main    464.67 -> PR    464.58  0.9998x  ok
ctx  32768 prefill_pp  main  27965.28 -> PR  27890.37  0.9973x  ok

# tol 0.98 on every row. Qwen3.6 is MoE and takes the `N*maxAK` branch, which this PR does not
# touch, so it is expected to be flat -- measured anyway because a_i8_sz is shared prefill code.
```

## Credit

#845 is the batched-prefill-at-16k work this builds on and whose `FC < N` workaround this removes;
the defect that workaround was avoiding is diagnosed here. #557 (@Paral1995) is the selective
long-context int8 FFN/attn path whose projections this restores to the chunked pass. #530/#800 are
the token-chunked FFN whose interaction with the activation sizing this corrects.
