### PR TITLE
perf(qwen3.8): keep the chunk-parallel GDN scan alive at 16k + size the FFN chunk to fit (1.24x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -55,6 +55,7 @@
 // The state stays fp32 and is written back in the SAME transposed [v_head][col][row] layout the
 // decode gdn_ar_fast kernel expects, so this is a drop-in replacement and decode is untouched.
 // ============================================================================
+#include <algorithm>
 #include "sparkinfer/kernels/prefill_gdn_chunk.h"
 
 #include <cuda_runtime.h>
@@ -561,7 +562,52 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
     const size_t off_w = off_m + n_m * sizeof(float);
     const size_t off_u = off_w + n_w * sizeof(__nv_bfloat16);
     const size_t total = off_u + n_w * sizeof(__nv_bfloat16);
-    if (!ws_reserve(total)) return false;
+    if (!ws_reserve(total)) {
+        // The workspace is O(N): W^ and U0 alone are n_tokens*v_heads*HD bf16 each, so it reaches
+        // ~322 MB at ctx=16384 and stops fitting long before the sequence itself does. Falling
+        // through here drops the whole layer onto the SEQUENTIAL scan -- which is what ctx=16384
+        // has been getting, at ~2x the cost of this path (measured at ctx=4096, where the
+        // workspace still fits: 8275.82 pp with this path vs 7059.03 pp forced sequential).
+        //
+        // The scan is already sequential ACROSS chunks and carries `state` in and out, so a
+        // segment boundary on a multiple of C is just another chunk boundary: process the sequence
+        // in segments whose workspace does fit and let the recurrence carry, instead of giving the
+        // path up. Same chunk boundaries, same arithmetic, same order.
+        // ws_reserve's cudaMalloc just failed and we are handling that here, so clear the sticky
+        // error: several launchers report success as `cudaPeekAtLastError() == cudaSuccess`, which
+        // does not clear and cannot tell whose error it is.
+        cudaGetLastError();
+        size_t free_b = 0, total_b = 0;
+        if (cudaMemGetInfo(&free_b, &total_b) != cudaSuccess) return false;
+        const size_t margin = (size_t)32 << 20;
+        const size_t avail = (free_b > margin) ? (free_b - margin) : 0;
+        // ws(S) = S*v_heads*(sizeof(float) + C*sizeof(float) + 2*HD*sizeof(bf16))
+        const size_t per_tok = (size_t)v_heads *
+            (sizeof(float) + (size_t)C * sizeof(float) + (size_t)2 * HD * sizeof(__nv_bfloat16));
+        size_t seg = per_tok ? (avail / per_tok) : 0;
+        seg -= seg % (size_t)C;                       // land segments on chunk boundaries
+        if (seg < (size_t)C) return false;            // cannot even hold one chunk -> sequential
+        if (seg > (size_t)n_tokens) seg = (size_t)n_tokens;
+
+        const size_t q_dim = (size_t)q_heads * HD;
+        const size_t v_dim = (size_t)v_heads * HD;
+        auto qb = reinterpret_cast<const __nv_bfloat16*>(q);
+        auto kb = reinterpret_cast<const __nv_bfloat16*>(k);
+        auto vb = reinterpret_cast<const __nv_bfloat16*>(v);
+        auto ab = reinterpret_cast<const __nv_bfloat16*>(alpha);
+        auto bb = reinterpret_cast<const __nv_bfloat16*>(beta);
+        auto ob = reinterpret_cast<__nv_bfloat16*>(out);
+        for (size_t off = 0; off < (size_t)n_tokens; off += seg) {
+            const int len = (int)std::min(seg, (size_t)n_tokens - off);
+            // dt and a are per-HEAD, not per-token, so they are passed through unshifted.
+            if (!launch_prefill_gdn_chunk(qb + off * q_dim, kb + off * q_dim, vb + off * v_dim,
+                                          ab + off * v_heads, bb + off * v_heads, dt, a,
+                                          state, ob + off * v_dim,
+                                          len, q_heads, v_heads, head_dim, qh_block, stream))
+                return false;   // a segment that cannot run leaves the caller its sequential path
+        }
+        return true;
+    }
 
     char* base  = reinterpret_cast<char*>(g_ws);
     float* g_buf = reinterpret_cast<float*>(base + off_g);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -252,17 +252,27 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (cudaMemGetInfo(&fb, &tb) == cudaSuccess) {
             // What still has to come out of `fb` after the FC-scaled pair, so the chunk is sized
             // against the real remainder rather than all of free VRAM.
-            const size_t tail = (size_t)maxw * sizeof(bf16)                    // wbuf
-                              + (size_t)maxw                                  // W_i8
-                              + (size_t)N * H                                 // A_i8 (int8) floor
-                              + (size_t)N * (sizeof(float) + sizeof(int));    // sx + d_ids
-            const size_t margin = (size_t)64 << 20;    // split-K partials + allocator slack
+            // Reserve for A_i8 and nothing else. wbuf/W_i8 are sized by maxw (N-independent) and
+            // are already resident from an earlier call, so they cost nothing here; the FP4
+            // activation buffers are allocated after the int8 arena's own ok-check, so if they
+            // miss, only the FP4 path declines. A_i8 is the one that must fit: it is allocated
+            // before that check, so losing it turns the int8 projections off for the whole pass
+            // (measured at ctx=16384: chunk 4096 leaves 48 MB, A_i8 misses, and prefill drops from
+            // ~4970 to ~2200 pp). Reserving the full tail instead costs a chunk step, which is
+            // worth more than the slack it buys -- chunk 2048 measures ~5.9% over 1024.
+            const size_t tail = (size_t)N * (size_t)imax(H, imax(qdim, lvdim));   // A_i8
+            const size_t margin = (size_t)32 << 20;    // allocator slack
             const size_t avail = (fb > tail + margin) ? fb - tail - margin : 0;
             const int fc_before = FC;
-            // Test the HALVED value, not the current one: `FC > floor` would step straight past it.
-            while ((FC >> 1) >= kMinFfnChunk &&
-                   (size_t)2 * (size_t)FC * (size_t)ffn * sizeof(bf16) > avail)
-                FC >>= 1;
+            // Take the LARGEST chunk that fits, not the largest power-of-two step: halving jumps
+            // 4096 -> 2048 and leaves most of the budget unused, and every extra token per chunk is
+            // one fewer pass over the FFN weights. Rounded down to 256 (the FFN chunk loop takes any
+            // fn, and 256 keeps m%8 for the block-scaled kernels) and floored at kMinFfnChunk.
+            const size_t per_tok = (size_t)2 * (size_t)ffn * sizeof(bf16);   // ffg + ffu, per token
+            size_t fc_fit = per_tok ? (avail / per_tok) : 0;
+            fc_fit &= ~(size_t)255;
+            if (fc_fit < (size_t)kMinFfnChunk) fc_fit = (size_t)kMinFfnChunk;
+            if ((size_t)FC > fc_fit) FC = (int)fc_fit;
             if (FC != fc_before)
                 fprintf(stderr, "[prefill] ffn chunk %d -> %d (ctx=%d, free=%zu MB) to keep the "
                                 "batched pass\n", fc_before, FC, N, fb >> 20);


### PR DESCRIPTION
## Summary

**At ctx=16384 the chunk-parallel GDN scan cannot fit its workspace, so all 48 linear layers fall
back to the sequential scan — silently. Segmenting the scan keeps the fast path, and sizing the FFN
chunk to what is actually free keeps more of the pass batched: prefill@16k 4687.61 -> **5803.88** pp
(1.238x, +23.8%).**

Two independent changes, both sizing problems at long context rather than new kernels.

### 1. The chunk-parallel GDN scan gives up at 16k

`launch_prefill_gdn_chunk` reserves a workspace that scales with the sequence: `W^` and `U0` are
each `n_tokens * v_heads * head_dim` bf16, so it grows to **~322 MB at ctx=16384** and stops fitting
well before the sequence itself does. `ws_reserve` then fails and the launcher returns false, which
drops every linear layer onto the sequential scan below it. Nothing is logged; the pass is simply
slower.

That path is worth a lot. Measured at ctx=4096, where the workspace still fits, by toggling
`SPARKINFER_PREFILL_GDN_CHUNK`:

```text
ctx=4096  chunk-parallel : 8275.82 pp
ctx=4096  sequential     : 7059.03 pp     <- what ctx=16384 has been getting
```

The scan is already sequential **across** chunks and carries `state` in and out, so a segment
boundary on a multiple of `C` is just another chunk boundary. When the whole-sequence workspace
does not fit, the sequence is processed in segments whose workspace does, with the recurrence
carrying between them — same chunk boundaries, same arithmetic, same order. If even one chunk
cannot be held, the caller still gets exactly today's sequential fallback.

### 2. The FFN chunk is sized against a model, not against what is free

The adaptive chunk (#845) reserved for `wbuf`, `W_i8` and `A_i8` and stepped by halving. `wbuf` and
`W_i8` are sized by `maxw`, which does not depend on N, so they are already resident and cost
nothing at that point. `A_i8` is the one that must fit — it is taken *before* the int8 arena's
ok-check, so failing it turns the int8 projections off for the whole pass, whereas the FP4 buffers
are taken after that check and only cost the FP4 path. Reserving `A_i8` alone, and taking the
largest chunk that fits (rounded to 256, keeping `m % 8` for the block-scaled kernels) instead of
the first power of two, gives chunk 1024 -> 3072 at 16k: six passes over the FFN weights, not
sixteen.

Oversizing is the failure that matters and is measured, not assumed: at chunk 4096 the pass leaves
~48 MB, `A_i8` misses, and prefill@16k drops to ~2200 pp. The chunk still only ever shrinks from the
configured value, and an explicit `SPARKINFER_PREFILL_FFN_CHUNK` is honoured as given.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — this PR is prefill-only):

| | decode tok/s |
|---|--:|
| before (main) | 83.89 |
| after (this PR) | 83.88 |

**Prefill pp tok/s** (Qwen3.8-27B NVFP4, ctx=16384 — the dimension `pr_qwen38_bot.py` scores):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4687.61 |
| after prefill (this PR) | **5803.88 (1.238x, +23.8%)** |

```text
# RTX 5090 sm_120, unsloth/Qwen3.8-27B-NVFP4, main @ aa117dc. SHIPPED DEFAULTS -- the only env
# vars set are the two the bot's own bench_sweep_run exports. Arms rebuilt between runs (one build
# dir, so no stale runtime .so can cross an arm), alternated, serialized, and in the bot's sweep
# ORDER (128 then 16384), which is the order that leaves VRAM tight.

MAIN  pair1 {"128":{"decode_tps":83.9007,"prefill_pp":4372.0933},"16384":{"decode_tps":71.6097,"prefill_pp":4695.9423}}
STACK pair1 {"128":{"decode_tps":83.8933,"prefill_pp":4372.6632},"16384":{"decode_tps":71.3675,"prefill_pp":5810.3192}}
MAIN  pair2 {"128":{"decode_tps":83.8746,"prefill_pp":4359.2897},"16384":{"decode_tps":71.5397,"prefill_pp":4679.2696}}
STACK pair2 {"128":{"decode_tps":83.8729,"prefill_pp":4359.4516},"16384":{"decode_tps":71.3275,"prefill_pp":5797.4473}}

prefill@16k  median 4687.61 -> 5803.88  = 1.238x  (+23.8%)   <- the scored dimension
prefill@128  median 4365.69 -> 4366.06  = 1.0001x (floor, tol 0.98)
decode@128   median   83.89 ->   83.88  = 0.9999x (floor, tol 0.98)

# Each arm is identifiable in-trace by the FFN chunk it selects (main 1024, this PR 3072 at the
# bench's free-VRAM level); the GDN change leaves no line of its own, so the kernel it restores is
# the check that it engaged.
```

**Generation identity through the batched pass at ctx=16384.** `qwen3_gguf_score` teacher-forces per
token and does not route through `prefill_batched_run`, so a score-based diff cannot see the path
this PR changes (verified: flipping `SPARKINFER_PREFILL_BATCHED` leaves its dump byte-identical).
The check that does exercise it is generation — same binary, env-flipped, 16384-token prompt:

```text
# 16384-token prompt, 24 tokens generated, same binary, env-flipped.
batched    OUTPUT_IDS: 7 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197
tokenloop  OUTPUT_IDS: 7 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197 8 197 197
# 24/24 identical: the segmented scan reproduces the sequential prefill exactly.
# The prompt is synthetic (a non-repeating id ramp), so the continuation is repetitive and argmax is
# less sensitive than natural text would be -- reported as an end-to-end identity check through the
# changed path at the scored context, not as a tight numerical bound.
```

**Differential accuracy gate** (`accuracy_compare_pair.py`, PR vs main, TOPK=128). The `ctx=128`
path is untouched by construction — the FFN chunk is inert where `FC == N`, and the GDN workspace at
that length is ~2.5 MB so the segmentation never engages:

```text
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.2812 ppl_main=3.2812
```

**Qwen3.6 cross-model guard** (ctx 0/512/4k/16k/32k, tol 0.98), measured because both changes are
shared prefill code and Qwen3.6 is hybrid too:

```text
ctx      0 decode_tps  main    491.23 -> PR    490.42  0.9983x  ok
ctx    512 decode_tps  main    485.13 -> PR    483.97  0.9976x  ok
ctx    512 prefill_pp  main  10029.30 -> PR  10005.70  0.9976x  ok
ctx   4096 decode_tps  main    466.36 -> PR    465.39  0.9979x  ok
ctx   4096 prefill_pp  main  26026.59 -> PR  25968.89  0.9978x  ok
ctx  16384 decode_tps  main    465.48 -> PR    465.07  0.9991x  ok
ctx  16384 prefill_pp  main  27026.95 -> PR  26967.50  0.9978x  ok
ctx  32768 decode_tps  main    465.32 -> PR    464.95  0.9992x  ok
ctx  32768 prefill_pp  main  28258.51 -> PR  28168.63  0.9968x  ok
```

## Credit

#843 (@flashatten) is the chunk-parallel WY/UT GDN scan this keeps alive at long context — the
segmentation only changes how much of the sequence it holds at once, not the transform. #845 is the
adaptive chunk this refines and the batched-prefill-at-16k work both rest on; #848 is the activation
sizing that lets the chunked pass keep its tensor-core projections.
