### PR TITLE
perf(qwen3.8): larger GDN scan segments via malloc probe (1.09x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -654,27 +654,32 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
     // onto the sequential scan. A segment boundary on a multiple of C is the same
     // as a chunk boundary once the scan reloads S, so the sequence is processed
     // in slices whose workspace fits. ctx=128 still takes the one-shot path.
+    //
+    // Size the slice by probing cudaMalloc, not cudaMemGetInfo. After a failed
+    // 483 MB grow the allocator reported 37 MB free and a 32 MB margin left
+    // 192-token slices (85 launches/layer). A 1024-token workspace is ~30 MB
+    // and allocates; each doubling cuts the launch count in half.
     const size_t total = gdnc_workspace_bytes(n_tokens, v_heads, C, HD);
     if (ws_reserve(total))
         return run_slice(qb, kb, vb, ab, bb, ob, n_tokens, 0);
     cudaGetLastError();   // clear the failed grow so later peek/getinfo are clean
 
-    const size_t per_tok = (size_t)v_heads *
-        (sizeof(float) + (size_t)C * sizeof(float) + (size_t)2 * HD * sizeof(__nv_bfloat16));
-    size_t free_b = 0, tot_b = 0;
-    if (cudaMemGetInfo(&free_b, &tot_b) != cudaSuccess) return false;
-    const size_t margin = (size_t)32 << 20;
-    const size_t avail = (free_b > margin) ? (free_b - margin) : 0;
-    size_t seg = per_tok ? (avail / per_tok) : 0;
-    seg -= seg % (size_t)C;
-    if (seg < (size_t)C) return false;
-    if (seg > (size_t)n_tokens) seg = (size_t)n_tokens;
+    int seg = 0;
+    for (int cand = n_tokens >> 1; cand >= C; cand >>= 1) {
+        cand -= cand % C;
+        if (cand < C) break;
+        if (ws_reserve(gdnc_workspace_bytes(cand, v_heads, C, HD))) {
+            seg = cand;
+            break;
+        }
+        cudaGetLastError();
+    }
+    if (seg < C) return false;
 
     static int once_seg = 0;
     if (!once_seg) {
-        fprintf(stderr, "[gdn-chunk] workspace %zu MB does not fit; %d-token segments (ctx=%d, free=%zu MB)\n",
-                gdnc_workspace_bytes(n_tokens, v_heads, C, HD) >> 20,
-                (int)seg, n_tokens, free_b >> 20);
+        fprintf(stderr, "[gdn-chunk] workspace %zu MB does not fit; %d-token segments (ctx=%d)\n",
+                total >> 20, seg, n_tokens);
         once_seg = 1;
     }
 

--- a/kernels/include/sparkinfer/kernels/prefill_gdn_chunk.h
+++ b/kernels/include/sparkinfer/kernels/prefill_gdn_chunk.h
@@ -29,7 +29,8 @@ namespace kernels {
 // Returns true if the kernels were launched, false if the caller should run its own scan (shape
 // not specialized, disabled by env, or even one chunk of workspace cannot be allocated).
 // When the O(N) W^/U0 workspace does not fit, the sequence is scanned in chunk-aligned
-// segments and the recurrence is carried through `state` — same arithmetic, same order.
+// segments (largest slice cudaMalloc accepts) and the recurrence is carried through
+// `state` — same arithmetic, same order.
 //
 // Produces out[N, v_heads*head_dim] and leaves the recurrent state in the SAME transposed
 // [v_head][col][row] layout the decode gdn_ar_fast kernel expects, so this is a drop-in


### PR DESCRIPTION
## Summary

**#850 kept the chunk-parallel GDN scan alive at 16k, but sized slices from `cudaMemGetInfo` after a failed 483 MB grow. That reading was 37 MB, a 32 MB margin left 192-token slices (85 launches/layer). Probing `cudaMalloc` for the largest power-of-two slice that actually allocates gets 512-token segments: official prefill@16k 7219 → 7854 pp (1.09x).**

Same recurrence, same chunk boundaries, same state carry as #850. ctx=128 still takes the one-shot path (workspace is ~1 MB). FFN chunk math is untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — this PR is prefill-only):

| | decode tok/s |
|---|--:|
| before (main / #850) | 84.51 |
| after (this PR) | 84.53 |

**Prefill pp tok/s** (Qwen3.8-27B NVFP4 — official `pr_qwen38_bot.py` protocol):

| | prefill@128 | prefill@16k |
|---|--:|--:|
| before (main / #850) | 5171 | 7219 |
| after (this PR) | 5209 | **7854 (1.09x, +8.8%)** |

```text
# RTX 5090 sm_120, unsloth/Qwen3.8-27B-NVFP4, main @ 32759f5 (#850).
# SHIPPED DEFAULTS — official order: 128 then 16384, reps=5.

#850  {"128":{"decode_tps":84.51,"prefill_pp":5171},"16384":{"prefill_pp":7219}}
THIS  {"128":{"decode_tps":84.53,"prefill_pp":5209},"16384":{"prefill_pp":7854}}

#850  [gdn-chunk] workspace 483 MB does not fit; 192-token segments (ctx=16384, free=37 MB)
THIS  [gdn-chunk] workspace 483 MB does not fit; 512-token segments (ctx=16384)
```

128 floors: decode 1.00x, prefill 1.01x (bar 0.98x).

## Test plan

- [ ] Bot official sweep: `SPARKINFER_BENCH_SWEEP_CTXS=128,16384 SPARKINFER_BENCH_SWEEP_REPS=5`
- [ ] Confirm decode@128 and prefill@128 stay ≥ 0.98× main
- [ ] Confirm the log shows segments larger than 192 tokens and 16k stays batched (not ~80 pp)