### PR TITLE
perf(qwen3.8): reserve the GDN scan's workspace when sizing the FFN chunk (1.08x prefill@16k)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -257,7 +257,18 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                               + (size_t)N * H                                 // A_i8 (int8) floor
                               + (size_t)N * (sizeof(float) + sizeof(int));    // sx + d_ids
             const size_t margin = (size_t)64 << 20;    // split-K partials + allocator slack
-            const size_t avail = (fb > tail + margin) ? fb - tail - margin : 0;
+            // The chunk-parallel GDN scan draws on this same budget, AFTER this point, and it is
+            // the larger consumer: its workspace is O(N) (~483 MB at ctx=16384). Sizing the FFN
+            // chunk against everything that is free leaves the scan ~25 MB, which forces it into
+            // ~199-token slices -- 83 per layer -- and most of the win from running it at all is
+            // lost. Reserve a working segment for it here so the two are balanced rather than
+            // first-come-first-served. Hybrid stacks only; nothing else runs that scan.
+            //
+            // This can only make the chunk SMALLER, which is the safe direction: an oversized
+            // chunk is what fails the arena alloc and drops the whole pass to the token loop.
+            const size_t gdn_reserve = c.hybrid ? ((size_t)256 << 20) : 0;
+            const size_t claimed = tail + margin + gdn_reserve;
+            const size_t avail = (fb > claimed) ? fb - claimed : 0;
             const int fc_before = FC;
             // Test the HALVED value, not the current one: `FC > floor` would step straight past it.
             while ((FC >> 1) >= kMinFfnChunk &&


### PR DESCRIPTION
## Summary

**The FFN chunk and the chunk-parallel GDN scan draw on one VRAM budget, and nothing arbitrates
between them. The chunk is sized first against everything free, so the scan gets ~25 MB and cuts
the sequence into ~199-token slices — 83 launches per layer. Reserving the scan's working room
before sizing the chunk: prefill@16k 7483.31 -> 8052.17 pp (1.076x).**

#850 made the scan survive at 16k by slicing when its O(N) workspace does not fit. What decides how
big those slices are is what is left over *after* the FFN chunk has taken its share — and the chunk
is sized against all free VRAM, with no knowledge that the larger consumer comes later:

```text
[gdn] N=16384 need=483 MB free=25 MB
[gdn] SEGMENT path N=16384 avail=5 MB per_tok=30912 seg=199
```

So the FFN chunk wins the budget by arriving first, and the scan runs in slices small enough to
give most of its advantage back. Sizing the chunk with the scan's requirement reserved balances the
two. On this checkpoint at ctx=16384 the chunk moves 4096 -> 1024, which an independent sweep puts
at the optimum:

```text
FFN chunk 4096 (main): 7312.40 pp     FFN chunk 1024: 7678.90 pp
FFN chunk 2048       : 7273.12 pp     FFN chunk  512: 7691.61 pp
```

The reservation applies to hybrid stacks only — nothing else runs that scan — and it can only make
the chunk **smaller**. That is the safe direction: an oversized chunk is what fails the arena
allocation and drops the whole pass to the per-token loop, so this moves away from that failure,
never toward it. ctx=128 is untouched (`FC == N` there, and the scan's workspace is ~1 MB).

**Builds on #851.** That PR enlarges the slices obtained from whatever budget remains; this one
enlarges the budget itself, so the two compose rather than overlap. The numbers below are measured
with #851 already in main.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end — this PR is prefill-only):

| | decode tok/s |
|---|--:|
| before (main, incl. #851) | 83.80 |
| after (this PR) | 83.66 |

**Prefill pp tok/s** (Qwen3.8-27B NVFP4, ctx=16384 — the dimension `pr_qwen38_bot.py` scores):

| | prefill pp tok/s |
|---|--:|
| before prefill (main, incl. #851) | 7483.31 |
| after prefill (this PR) | **8052.17 (1.076x, +7.6%)** |

```text
# RTX 5090 sm_120, unsloth/Qwen3.8-27B-NVFP4, main with #851. SHIPPED DEFAULTS; the only env vars
# set are the two the bot's own bench_sweep_run exports, and REPS=5 as the bot uses. Arms rebuilt
# between runs (one build dir), alternated, serialized behind a GPU-exclusivity check, in the bot's
# sweep ORDER (128 then 16384).

MAIN pair1 {"128":{"decode_tps":83.9178,"prefill_pp":5100.2443},"16384":{"decode_tps":71.3611,"prefill_pp":7551.3140}}
PR   pair1 {"128":{"decode_tps":83.7940,"prefill_pp":5083.7712},"16384":{"decode_tps":71.1561,"prefill_pp":8095.8421}}
MAIN pair2 {"128":{"decode_tps":83.6787,"prefill_pp":5074.9780},"16384":{"decode_tps":70.9898,"prefill_pp":7415.3060}}
PR   pair2 {"128":{"decode_tps":83.5290,"prefill_pp":5066.3961},"16384":{"decode_tps":70.8875,"prefill_pp":8008.4954}}

prefill@16k  median 7483.31 -> 8052.17  = 1.076x  (+7.6%)   <- the scored dimension
prefill@128  median 5087.61 -> 5075.08  = 0.9975x (floor, tol 0.98)
decode@128   median   83.80 ->   83.66  = 0.9983x (floor, tol 0.98)

# Each arm is identifiable in-trace by the chunk it selects: main 4096, this PR 1024.
```

**Differential accuracy gate** (`accuracy_compare_pair.py`, PR vs main, TOPK=128):

```text
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.2812 ppl_main=3.2812
```

**Qwen3.6 cross-model guard** (ctx 0/512/4k/16k/32k, tol 0.98), measured because this is shared
prefill code and Qwen3.6 is hybrid too:

```text
ctx      0 decode_tps  main    491.31 -> PR    491.00  0.9994x  ok
ctx    512 decode_tps  main    485.32 -> PR    484.76  0.9989x  ok
ctx    512 prefill_pp  main  10041.11 -> PR  10031.33  0.9990x  ok
ctx   4096 decode_tps  main    466.35 -> PR    465.76  0.9987x  ok
ctx   4096 prefill_pp  main  26094.11 -> PR  26042.55  0.9980x  ok
ctx  16384 decode_tps  main    466.26 -> PR    465.35  0.9980x  ok
ctx  16384 prefill_pp  main  27137.34 -> PR  27064.39  0.9973x  ok
ctx  32768 decode_tps  main    465.97 -> PR    465.04  0.9980x  ok
ctx  32768 prefill_pp  main  28365.72 -> PR  28286.70  0.9972x  ok
```

## Credit

#850 and #851 (@flashatten) are the segmented GDN scan and its malloc-probed slice sizing that this
gives room to; they enlarge the slices obtained from the remaining budget where this enlarges the
budget itself, so the two compose rather than overlap. #845 is the
adaptive FFN chunk whose sizing this corrects.
