### PR TITLE
perf(qwen3.8): pipeline GDN scan loads and raise the 16k FFN chunk (1.02x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -324,14 +324,13 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         for (int e = tid; e < HD * JC; e += nthr) s_S[e] = 0.f;
     }
 
-    // The chunk loop is the ONE serial stage left in this prefill, and every iteration used
-    // to expose the full global latency of its 25 KB W/K/Q staging before any math could
-    // start. Issue those loads with cp.async at the END of the previous iteration (the
-    // S-update sync is the last read of the old tiles), so they overlap the g/U/M stages
-    // and the loop-carried sync. Same buffers, same staged values, same math -- only WHEN
-    // the loads are issued changes. Tail rows of a short final chunk are zeroed after the
-    // wait (cp.async cannot predicate, and reading past n_tokens would fault).
-    auto stage_wkq = [&](int c2) {
+    // The chunk loop is the ONE serial stage left in this prefill. Issue W/K/Q and the
+    // small g/U/M tiles with cp.async at the END of the previous iteration (the S-update
+    // sync is the last read of the old tiles) so they overlap the loop-carried math.
+    // Same buffers, same staged values, same math -- only WHEN the loads are issued
+    // changes. Tail rows of a short final chunk are zeroed after the wait (cp.async
+    // cannot predicate, and reading past n_tokens would fault).
+    auto stage_chunk = [&](int c2) {
         const int t0s = c2 * C;
         const int lens = min(C, n_tokens - t0s);
         for (int e8 = tid; e8 < (C * HD) / 8; e8 += nthr) {
@@ -345,25 +344,29 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                                         q + (size_t)(t0s + i) * q_dim + qh * HD + d, 16);
             }
         }
+        // g: C floats. U: JC bf16 per row into s_Ub (converted after the wait).
+        // M: C packed floats per row; s_M is padded so each row is its own copy.
+        if (tid < C && tid < lens)
+            __pipeline_memcpy_async(s_g + tid, g_buf + (size_t)(t0s + tid) * v_heads + h, 4);
+        for (int e8 = tid; e8 < (C * JC) / 8; e8 += nthr) {
+            const int i = e8 / (JC / 8), jj = (e8 % (JC / 8)) * 8;
+            if (i < lens)
+                __pipeline_memcpy_async(s_Ub + i * (JC + PAD) + jj,
+                                        u_buf + ((size_t)(t0s + i) * v_heads + h) * HD + j0 + jj, 16);
+        }
+        const float* msrc = m_buf + ((size_t)c2 * v_heads + h) * C * C;
+        for (int e4 = tid; e4 < (C * C) / 4; e4 += nthr) {
+            const int i = e4 / (C / 4), j = (e4 % (C / 4)) * 4;
+            __pipeline_memcpy_async(s_M + i * (C + PAD) + j, msrc + i * C + j, 16);
+        }
         __pipeline_commit();
     };
-    if (n_chunks > 0) stage_wkq(0);
+    if (n_chunks > 0) stage_chunk(0);
 
     for (int c = 0; c < n_chunks; c++) {
         const int t0  = c * C;
         const int len = min(C, n_tokens - t0);
 
-        // ---- stage the small linear tiles; W/K/Q arrive via the early-issued cp.async ----
-        for (int i = tid; i < C; i += nthr)
-            s_g[i] = (i < len) ? g_buf[(size_t)(t0 + i) * v_heads + h] : 0.f;
-        for (int e = tid; e < C * JC; e += nthr) {
-            const int i = e / JC, jj = e - i * JC;
-            s_U[e] = (i < len) ? gc_to_f(u_buf[((size_t)(t0 + i) * v_heads + h) * HD + j0 + jj]) : 0.f;
-        }
-        for (int e = tid; e < C * C; e += nthr) {
-            const int i = e / C, j = e - i * C;
-            s_M[i * (C + PAD) + j] = m_buf[(size_t)e + ((size_t)c * v_heads + h) * C * C];
-        }
         __pipeline_wait_prior(0);
         if (len < C) {
             for (int e = tid; e < C * HD; e += nthr) {
@@ -374,6 +377,12 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                     s_Q[i * (HD + PAD) + d] = __float2bfloat16(0.f);
                 }
             }
+            for (int i = tid; i < C; i += nthr)
+                if (i >= len) s_g[i] = 0.f;
+        }
+        for (int e = tid; e < C * JC; e += nthr) {
+            const int i = e / JC, jj = e - i * JC;
+            s_U[e] = (i < len) ? gc_to_f(s_Ub[i * (JC + PAD) + jj]) : 0.f;
         }
         __syncthreads();
 
@@ -504,7 +513,7 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
             }
         }
         __syncthreads();
-        if (c + 1 < n_chunks) stage_wkq(c + 1);   // last read of W/K/Q was above this sync
+        if (c + 1 < n_chunks) stage_chunk(c + 1);   // last read of W/K/Q/U/M/g was above this sync
     }
 
     // ---- final state, in the transposed [v_head][col][row] layout decode expects ----

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -211,16 +211,31 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         pf_cu(cudaStreamSynchronize(st), "pfb graph sync");
         return *s.h_out_id;
     }
+    // Drop a graph recorded for a different N before the scratch allocs. At ctx=16384 the
+    // ctx=128 graph is ~300 MB and was still resident while the FFN chunk was sized, which
+    // left the first 16k pass ~350 MB tighter than the later ones.
+    if (graph_ok && g_pfb_exec && g_pfb_n != N) {
+        cudaGraphExecDestroy(g_pfb_exec); g_pfb_exec = nullptr;
+        if (g_pfb_graph) { cudaGraphDestroy(g_pfb_graph); g_pfb_graph = nullptr; }
+        g_pfb_n = -1;
+    }
     pf_vram("entry");
     bf16* x    = a.alloc<bf16>((size_t)N * H);
     bf16* xn   = a.alloc<bf16>((size_t)N * H);
-    bf16* hn   = a.alloc<bf16>((size_t)N * H);
-    bf16* ao   = a.alloc<bf16>((size_t)N * H);
+    // xn (pre-attn RMSNorm) dies at the post-attn residual; hn (pre-FFN RMSNorm) is born
+    // there. They never overlap on the non-sandwich path, so one N*H buffer is enough.
+    // Saves 160 MB at ctx=16384 (H=5120). Muse sandwich keeps both:
+    // its post-attn residual lives in `h`, but decode-faithful sandwich still writes hn
+    // from h while xn is the next layer's input-norm (same buffer would race).
+    bf16* hn   = c.muse_glimmer ? a.alloc<bf16>((size_t)N * H) : xn;
     // Muse Glimmer sandwich norm keeps the post-attention residual stream (h = x + RMSNorm(ao)*
     // post_attn_norm) live across the FFN so the post-FFN sandwich can add onto it; other models
     // fold the residual in place and need no extra buffer.
     bf16* h    = c.muse_glimmer ? a.alloc<bf16>((size_t)N * H) : nullptr;
     bf16* b8   = a.alloc<bf16>((size_t)N * wide);        // qraw / lin_qkv (8192)
+    // ao (attn / FFN down dest) is born after qraw is split or GDN conv consumes b8.
+    // wide >= H on every hybrid this pass accepts, so ao rides in the same allocation.
+    bf16* ao   = (wide >= H) ? b8 : a.alloc<bf16>((size_t)N * H);
     bf16* lz   = a.alloc<bf16>((size_t)N * lvdim);       // lin_z (4096)
     bf16* gq   = a.alloc<bf16>((size_t)N * s.linear_qdim);   // gdn q (2048)
     bf16* gk   = a.alloc<bf16>((size_t)N * s.linear_qdim);   // gdn k (2048)
@@ -266,7 +281,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             //
             // This can only make the chunk SMALLER, which is the safe direction: an oversized
             // chunk is what fails the arena alloc and drops the whole pass to the token loop.
-            const size_t gdn_reserve = c.hybrid ? ((size_t)256 << 20) : 0;
+            //
+            // When the 16k arena has settled there is enough free for a 2048-token FFN pair
+            // plus an 8192-token GDN slice (~241 MB, two launches). That beats #852's
+            // 1024-token FFN + one-shot 483 MB scan: the FFN re-reads its NVFP4 weights
+            // once per chunk. Fall back to the 256 MB paper reserve when the pair does
+            // not fit, so a tight first pass still keeps the batched path.
+            const size_t gdn_full = (size_t)256 << 20;
+            const size_t gdn_half = (size_t)200 << 20;   // 8192-token slice + slack
+            const size_t ffn_2048 = (size_t)2 * 2048 * (size_t)ffn * sizeof(bf16);
+            const size_t gdn_reserve = !c.hybrid ? 0
+                : (fb > tail + margin + ffn_2048 + gdn_half ? gdn_half : gdn_full);
             const size_t claimed = tail + margin + gdn_reserve;
             const size_t avail = (fb > claimed) ? fb - claimed : 0;
             const int fc_before = FC;
@@ -718,13 +743,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     }
 
     // Capture on the SECOND sighting of this N (arena warm => no cudaMalloc inside the capture).
+    // A graph for a different N was already destroyed above, before the scratch allocs.
     bool pfb_capturing = false;
-    // Re-capture when N changes: a graph is only valid for the N it recorded.
-    if (graph_ok && g_pfb_exec && g_pfb_n != N) {
-        cudaGraphExecDestroy(g_pfb_exec); g_pfb_exec = nullptr;
-        if (g_pfb_graph) { cudaGraphDestroy(g_pfb_graph); g_pfb_graph = nullptr; }
-        g_pfb_n = -1;
-    }
     if (graph_ok && !g_pfb_exec && g_pfb_warm_n == N) {
         if (cudaStreamBeginCapture(st, cudaStreamCaptureModeThreadLocal) == cudaSuccess)
             pfb_capturing = true;


### PR DESCRIPTION
## Summary

**On top of #852: pipeline the GDN scan's g/U/M tiles with the existing W/K/Q cp.async, and free ~320 MB of 16k scratch so the FFN chunk can stay at 2048 without starving the scan (1.02x prefill@16k).**

#852 paper-reserves 256 MB so the O(N) GDN workspace can one-shot after the first 16k pass. Two leftovers:

1. **The serial scan still waited on g/U/M.** W/K/Q were already issued with `cp.async` at the end of the previous chunk; g, U0 and M were still synchronous global loads at the top of the next one. Those copies now ride the same pipeline commit (U into the existing `s_Ub` tile, converted after the wait). Same values, same math — only *when* the loads issue changes.

2. **16k scratch over-allocated two `N*H` buffers that never overlap.** `xn` (pre-attn RMSNorm) dies at the post-attn residual; `hn` (pre-FFN RMSNorm) is born there. `ao` is born after qraw/`b8` is consumed. Aliasing them (Muse sandwich keeps its own `hn`) plus tearing down the ctx=128 graph *before* the 16k arena is sized recovers ~320 MB. A settled 16k pass then fits a 2048-token FFN pair and an 8192-token GDN slice; a tight first pass still takes #852's 256 MB reserve.

FC=4096 was measured and lost: it starves the GDN workspace and drops 16k to ~7964 pp.

Official bot sweep (`SPARKINFER_BENCH_SWEEP_CTXS=128,16384`, `REPS=5`, one load). Same-box main is #852 @ `874456f`.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s**

| | decode@128 | decode@16k |
|---|--:|--:|
| before (main #852) | 84.45 | 71.96 |
| after (this PR) | 84.74 | 71.97 |

**Prefill pp tok/s** (Qwen3.8-27B NVFP4, scored `prefill@16k`)

| | prefill@128 | prefill@16k |
|---|--:|--:|
| before (main #852) | 5196 | 8517 |
| after (this PR) | 5328 | 8709 |

```text
# main #852 @ 874456f  (official 128 then 16k, reps=5)
SWEEP_JSON {"128":{"decode_tps":84.4456,"prefill_pp":5196.3565},"16384":{"decode_tps":71.9603,"prefill_pp":8517.0426}}

# this PR
SWEEP_JSON {"128":{"decode_tps":84.7383,"prefill_pp":5328.3043},"16384":{"decode_tps":71.9748,"prefill_pp":8708.5268}}
```

128 floors hold (decode 1.00x, prefill 1.03x). 16k is +2.2% on this pair (earlier same-box main was 8553; PR repeats 8708–8719).

## Test plan

- [x] Official `128,16384` sweep x5 vs same-box main #852 on RTX 5090
- [x] Confirm 128 decode/prefill stay ≥ 0.98x
- [x] FC=4096 A/B rejected (starves GDN, 7964 pp)
- [ ] Bot eval vs main (top-1 / KL + scored prefill@16k)