### PR TITLE
perf(qwen3.8): chunk-size the FP4 activation arena and cap the fused Q4_K GEMM by M (1.22x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_moe_q.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe_q.cu
@@ -1133,6 +1133,30 @@ bool pf_dense_gemm_qi8_supported(int ggml_type) {
     return ggml_type == QMQ_Q4_K || ggml_type == QMQ_Q5_K || ggml_type == QMQ_Q6_K;
 }
 
+// Decoding Q4_K inside the GEMM skips the int8 materialize (dequant -> W_i8 -> reload), which is
+// the right trade only while that round trip is the dominant cost -- i.e. at the short-prompt M
+// this path was built for. It is not free: the decode sits on the MMA issue path, and measured on
+// an RTX 5090 at ctx=16384 this kernel sustains ~254 TOPS against the plain int8 GEMM's ~549 on
+// the same operands, so past a few hundred rows the materialize (a fixed ~154 us for a
+// 17408x5120 tensor) is repaid many times over by the faster GEMM.
+// Crossover from those two rates: the per-row saving of the faster GEMM equals the materialize at
+// M ~ 400, so decline past QB_MAX_M and let the caller take its own materialize path -- every
+// caller already treats `false` as "run your own GEMM". The two paths are bit-identical (same
+// activation int8 via the shared quant_a_i8 memo, same weight decode + per-row scale + int8 bytes,
+// same int8 tensor-core accumulation), so this is a pure scheduling choice, not a numeric one.
+// Measured end to end on Qwen3.8-27B: forcing this path off at EVERY M (the pre-existing
+// SPARKINFER_Q38_PREFILL_QB=0) is +21.8% at prefill@16k but -16.1% at prefill@128 -- the threshold
+// is what keeps both.
+// SPARKINFER_PREFILL_QB_MAX_M=0 disables the cap (restores the old always-fused behaviour).
+static int qb_max_m() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_QB_MAX_M");
+        const int x = e ? atoi(e) : 512;
+        return x > 0 ? x : (1 << 30);
+    }();
+    return v;
+}
+
 bool launch_pfm_moe_gemm_qi8(int ggml_type, const signed char* A_i8, const float* sx,
                              const void* W_q, const float* row_scale,
                              const int* pair_tok, const float* pair_w,
@@ -1292,7 +1316,7 @@ bool launch_prefill_gemm_qi8_dense(int ggml_type, const signed char* A_i8, const
                                    int* partials, int partials_splits, int* out_acc,
                                    const signed char* A_pack) {
     if (!pf_dense_gemm_qi8_supported(ggml_type)) return false;   // Q4_K / Q5_K / Q6_K
-    if (!row_scale || M <= 0) return false;
+    if (!row_scale || M <= 0 || M > qb_max_m()) return false;
     if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;         // whole super-blocks only
     if (N <= 0 || (N % QM_BND) != 0) return false;               // tile-aligned output width
     auto* C = reinterpret_cast<__nv_bfloat16*>(C_bf16);
@@ -1347,7 +1371,7 @@ bool launch_prefill_gemm_qi8_dense_group(int ggml_type, const signed char* A_i8,
                                          signed char* fuse_q, float* fuse_sx, int* out_fused,
                                          const signed char* A_pack, signed char* fuse_qp) {
     if (!pf_dense_gemm_qi8_supported(ggml_type)) return false;
-    if (ngroup <= 0 || ngroup > PF_QGROUP_MAX || M <= 0) return false;
+    if (ngroup <= 0 || ngroup > PF_QGROUP_MAX || M <= 0 || M > qb_max_m()) return false;
     if (K <= 0 || (K & (QM_SB - 1)) != 0) return false;
     PfQGroup d{};
     d.ngroup = ngroup;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -493,10 +493,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         return !(e && e[0] == '0');
     }();
     const bool gu_nvfp4 = muse_nvfp4 || q38_nvfp4;
+    // FP4 activation staging is sized by the FFN CHUNK, not the prompt: every consumer of these
+    // buffers runs inside the token-chunked FFN loop and passes fn <= FC rows. Sizing by N asked
+    // for 16x what is used at ctx=16384. Muse still gets N rows because it only reaches the FP4
+    // path at N == 128, where FC == N by construction (FC = min(N, ffn_chunk)).
+    // SPARKINFER_PREFILL_FP4_CHUNK_A=0 restores the N-sized buffers (A/B in ONE binary).
+    static const bool fp4_chunk_a = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_FP4_CHUNK_A");
+        return !(e && e[0] == '0');
+    }();
+    const int fp4_rows = fp4_chunk_a ? FC : N;
     const size_t fp4_a_data_bytes = gu_nvfp4
-        ? kernels::prefill_nvfp4_data_bytes(N, H) : 0;
+        ? kernels::prefill_nvfp4_data_bytes(fp4_rows, H) : 0;
     const size_t fp4_a_sf_bytes = gu_nvfp4
-        ? kernels::prefill_nvfp4_scale_bytes_a(N, H) : 0;
+        ? kernels::prefill_nvfp4_scale_bytes_a(fp4_rows, H) : 0;
     // The attention projection group: q | gate | k | v stacked, so one GEMM covers all four. Its A
     // operand is `xn` at k = H -- the same shape gate/up already quantize -- so fp4_a/fp4_as serve
     // it unchanged; only the [N, qkvg_n] bf16 output and a possibly wider workspace are new.
@@ -504,7 +514,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool muse_nvfp4_qkv = muse_nvfp4 && s.w.layers[0].qkvg_fp4 &&
                                 kernels::prefill_nvfp4_supported(N, qkvg_n, H);
     const size_t fp4_ws_gu = gu_nvfp4
-        ? kernels::prefill_nvfp4_workspace_bytes(N, ffn, H) : 0;
+        ? kernels::prefill_nvfp4_workspace_bytes(fp4_rows, ffn, H) : 0;
     const size_t fp4_ws_qkv = muse_nvfp4_qkv
         ? kernels::prefill_nvfp4_workspace_bytes(N, qkvg_n, H) : 0;
     // o projection: A is `att` at k = qdim <= H, so fp4_a/fp4_as (sized for k = H) already cover it.
@@ -517,8 +527,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const bool q38_nvfp4_down = q38_nvfp4 && s.w.layers[0].down_fp4 &&
                                 kernels::prefill_nvfp4_supported(N, H, ffn);
     const bool nvfp4_down = muse_nvfp4_down || q38_nvfp4_down;
+    // Same correction as fp4_down_a below: the down GEMM runs at m = fn <= FC, never at m = N.
     const size_t fp4_ws_down = nvfp4_down
-        ? kernels::prefill_nvfp4_workspace_bytes(N, H, ffn) : 0;
+        ? kernels::prefill_nvfp4_workspace_bytes(fp4_rows, H, ffn) : 0;
     size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
     if (fp4_ws_wo > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_wo;
     if (fp4_ws_down > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_down;
@@ -526,10 +537,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     unsigned char* fp4_as = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
     bf16* fp4_qkv = muse_nvfp4_qkv ? a8.alloc<bf16>((size_t)N * qkvg_n) : nullptr;
+    // Sized by the FFN CHUNK, not the prompt. These two feed exactly one call --
+    // launch_prefill_nvfp4_swiglu_quant_a(ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn) inside the
+    // token-chunked FFN loop -- so they never hold more than FC rows. Sizing them by N asked for
+    // 16x what is used at ctx=16384 (142.6 MB against 8.9 MB, FC=1024 after #852's VRAM sizing),
+    // the arena had nothing like that left, and a8.alloc handed back nullptr. That nullptr is not
+    // an error anywhere: `down_fp4_done` just tests fp4_down_a and quietly falls through, so the
+    // whole native-FP4 ffn_down leg was silently off at exactly the context it is worth the most,
+    // leaving `down` on dequant-to-int8 + int8 GEMM (nsys: 6.0% + 12.9% of the prefill).
+    // Muse is unaffected: it only reaches here at N == 128, where FC == N.
     unsigned char* fp4_down_a = nvfp4_down
-        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, ffn)) : nullptr;
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(fp4_rows, ffn)) : nullptr;
     unsigned char* fp4_down_as = nvfp4_down
-        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, ffn)) : nullptr;
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(fp4_rows, ffn)) : nullptr;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.


### PR DESCRIPTION
## Summary

At ctx=16384 the native NVFP4 `ffn_down` leg was silently off — its activation staging is sized by the prompt instead of the FFN chunk, so the arena refused it and `nullptr` fell through as "skip" — and every large-M projection took the fused Q4_K-in-GEMM path that only pays off at short-prompt M.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 83.24 |
| after (this PR) | 83.24 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 7046.44 |
| after prefill (this PR) | 8597.42 |

```text
Qwen3.8-27B NVFP4, RTX 5090 (sm_120), CUDA 12.8. One binary, arms selected by env so both sides are the same build. 3 alternating main/PR pairs, reps=5, medians reported.

  SPARKINFER_BENCH_PROMPT_FILE=/tmp/q38ids.txt \
  SPARKINFER_BENCH_SWEEP_CTXS=128,16384 SPARKINFER_BENCH_SWEEP_REPS=5 \
  ./build/runtime/qwen3_gguf_bench <model_dir> 128 sweep
  # main arm adds SPARKINFER_PREFILL_FP4_CHUNK_A=0 SPARKINFER_PREFILL_QB_MAX_M=0

MAIN_1 {"128":{"decode_tps":83.4216,"prefill_pp":5093.5788},"16384":{"decode_tps":70.7404,"prefill_pp":7092.7266}}
PR_1   {"128":{"decode_tps":83.3806,"prefill_pp":5101.5758},"16384":{"decode_tps":70.5718,"prefill_pp":8636.3535}}
MAIN_2 {"128":{"decode_tps":83.2407,"prefill_pp":5089.5397},"16384":{"decode_tps":70.5673,"prefill_pp":7046.4417}}
PR_2   {"128":{"decode_tps":83.2350,"prefill_pp":5092.9011},"16384":{"decode_tps":70.4995,"prefill_pp":8597.4172}}
MAIN_3 {"128":{"decode_tps":83.2367,"prefill_pp":5079.3951},"16384":{"decode_tps":70.5163,"prefill_pp":7029.7055}}
PR_3   {"128":{"decode_tps":83.1993,"prefill_pp":5088.7904},"16384":{"decode_tps":70.4298,"prefill_pp":8567.5670}}

medians          main        PR        ratio
  prefill@16k    7046.44   8597.42     1.2201
  prefill@128    5089.54   5092.90     1.0007
  decode@128       83.24     83.24     0.9999

Qwen3.6-35B-A3B guard (same binary, decode+prefill, ctx 0/512/4k/16k/32k, reps=3):
  ctx        decode main -> PR        prefill main -> PR
      0      487.03 -> 487.43         -
    512      480.35 -> 480.76         10450.95 -> 10462.77
   4096      462.26 -> 463.06         26240.35 -> 26227.16
  16384      463.47 -> 463.80         26813.88 -> 26853.74
  32768      462.71 -> 463.44         27956.93 -> 27975.27
  every dimension within +-0.2%.

Correctness: qwen3_gguf_generate over a 2250-token prompt (long enough to cross the M cap), max_new fixed at 16, main vs PR, twice each -- OUTPUT_IDS byte-identical every run: 46838 42903 15814 8070 1379 314 836 854 6992 13914 4598 1056 3604 33633 13 357 (qwen3_gguf_score is teacher-forced and does not exercise the batched prefill, so it reports top1=1.0/KL=0 for any prefill-only change and is not evidence here.)

Note on the box: this 5090 is software-power-capped at 525 W against a 575 W default (clocks_throttle_reasons.sw_power_cap Active, 2561 MHz avg under load vs 3105 max), which I cannot lift. Both arms run under the same cap so the ratios hold, but the absolute pp figures sit below an unthrottled part's.
```

### Env switches (both default on; each restores the old behaviour for A/B in one binary)

- `SPARKINFER_PREFILL_FP4_CHUNK_A=0` — restores the N-sized FP4 activation buffers.
- `SPARKINFER_PREFILL_QB_MAX_M=0` — removes the M cap on the fused Q4_K GEMM.
