### PR TITLE
perf(qwen3.8): overlay the attention epilogue smem to unlock an RQH=6 GQA tier, and fix the ldmatrix swizzle bank conflict

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -287,8 +287,33 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
 // RQH=1 is bit-identical to the per-head kernel. Math (mask, online softmax, int8
 // round) is unchanged -- only the load ordering differs.
 // ============================================================================
+// Shared smem layout for the GQA kernel, so the kernel and its launcher cannot drift apart.
+//
+// s_o (the [BM][HEAD_DIM] float epilogue landing zone) is only ever touched AFTER the last key
+// group has been consumed, and s_qi/s_pi/s_s are all dead by that point -- only s_l survives into
+// the epilogue. So s_o does not need its own 16 KB: it can overlay the front of the block. That
+// is what puts RQH=6 -- Qwen3.8's whole GQA group, so each K page and V tile is read exactly once
+// instead of twice at RQH=3 -- under the 100 KB sm_120 cap at all: 105,344 B without this,
+// 88,960 B with it. It also takes RQH=3 from 61,376 B to 44,992 B, back to 2 blocks/SM.
+//
+// The overlay costs one extra __syncthreads() before the epilogue: the PV loop deliberately runs
+// without a trailing barrier (it leans on the next group's after-QK barrier), so without one a
+// fast warp's first s_o store would land on s_pi while a slow warp was still reading it.
 template <int HEAD_DIM, int GROUP_BLKS, int RQH>
-__global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_mma_gqa_kernel(
+struct attn_gqa_smem {
+    static constexpr int    BM    = 16;
+    static constexpr int    GN    = GROUP_BLKS * 16;
+    static constexpr size_t front = (size_t)RQH * BM * HEAD_DIM                    // s_qi (int8)
+                                  + (size_t)RQH * BM * GN                          // s_pi (int8)
+                                  + (size_t)(RQH * BM * GN) * sizeof(float);       // s_s
+    static constexpr size_t olen  = (size_t)(BM * HEAD_DIM) * sizeof(float);       // s_o
+    static constexpr bool   alias = front >= olen;                                 // holds for RQH>=2
+    static constexpr size_t bytes = front + (alias ? 0 : olen)
+                                  + (size_t)(2 * GN + 5 * RQH * BM) * sizeof(float);
+};
+
+template <int HEAD_DIM, int GROUP_BLKS, int RQH>
+__global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_mma_gqa_kernel(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
     const __half* __restrict__ v_scale, const int* __restrict__ block_table,
@@ -316,8 +341,11 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
     signed char* s_qi = reinterpret_cast<signed char*>(mma_smem);   // [RQH][BM][HEAD_DIM]
     signed char* s_pi = s_qi + (size_t)RQH * BM * HEAD_DIM;          // [RQH][BM][GN]
     float* s_s  = reinterpret_cast<float*>(s_pi + (size_t)RQH * BM * GN); // [RQH][BM][GN]
-    float* s_o  = s_s + (size_t)RQH * BM * GN;                       // [BM][HEAD_DIM] epilogue landing
-    float* s_ks = s_o + BM * HEAD_DIM;                               // [GN] shared
+    using SM = attn_gqa_smem<HEAD_DIM, GROUP_BLKS, RQH>;
+    // [BM][HEAD_DIM] epilogue landing -- overlays s_qi/s_pi/s_s, which are dead by the epilogue.
+    float* s_o  = SM::alias ? reinterpret_cast<float*>(mma_smem)
+                            : reinterpret_cast<float*>(mma_smem + SM::front);
+    float* s_ks = reinterpret_cast<float*>(mma_smem + SM::front + (SM::alias ? 0 : SM::olen));
     float* s_vs = s_ks + GN;                                         // [GN] shared
     float* s_qs = s_vs + GN;                                         // [RQH][BM]
     float* s_ps = s_qs + RQH * BM;                                   // [RQH][BM]
@@ -501,6 +529,10 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
     run_range(split_sink ? blk_rs : 0, last_q + 1);
 
     // ---- epilogue: one head at a time through the shared s_o landing zone ----
+    // s_o overlays s_qi/s_pi/s_s (see attn_gqa_smem), and the PV loop above exits without a
+    // trailing barrier, so fence here before the first store lands on a buffer another warp
+    // may still be reading.
+    __syncthreads();
     #pragma unroll
     for (int h = 0; h < RQH; h++) {
         const int head = head0 + h;
@@ -527,13 +559,10 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
                             void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
                             int block_size, int max_blocks_per_seq, float scale, int win_blocks,
                             cudaStream_t stream) {
-    constexpr int BM = 16, GN = GROUP_BLKS * 16;
-    const size_t sm = (size_t)RQH * BM * HD                          // s_qi (int8)
-                    + (size_t)RQH * BM * GN                          // s_pi (int8)
-                    + (size_t)(RQH * BM * GN) * sizeof(float)        // s_s
-                    + (size_t)(BM * HD) * sizeof(float)              // s_o
-                    + (size_t)(2 * GN + 5 * RQH * BM) * sizeof(float);
-    // At RQH=4 this is 76,032 B — past the 48 KB default, so the opt-in below is
+    constexpr int BM = 16;
+    const size_t sm = attn_gqa_smem<HD, GROUP_BLKS, RQH>::bytes;
+    // With the s_o overlay this is 30,336 / 44,992 / 59,648 / 88,960 B at RQH=2/3/4/6 — every
+    // tier above RQH=2 is past the 48 KB default, so the opt-in below is
     // REQUIRED for the launch to be valid, and both it and the launch itself have to
     // be checked: a discarded failure here used to report success to the caller, which
     // then skipped the scalar fallback and consumed whatever `attn` already held —
@@ -587,8 +616,13 @@ bool launch_prefill_attn_mma(
     // is loaded once and fed RQH mma's instead of being re-read per q-head. RQH=1 disables.
     static const int gqa_rqh = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_GQA_RQH");
-        const int v = e ? atoi(e) : 4;
-        return (v == 1 || v == 2 || v == 4) ? v : 4;
+        const int v = e ? atoi(e) : 6;
+        return (v == 1 || v == 2 || v == 3 || v == 4 || v == 6) ? v : 6;
+    }();
+    // Token floor for the widest (grid-narrowing) tier -- see the RQH=6 dispatch below.
+    static const int minctx6 = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_GQA_MINCTX6");
+        return e ? atoi(e) : 2048;
     }();
 
     if (!enabled || head_dim != HD || block_size != 16 || n_tokens < minctx) return false;
@@ -599,8 +633,33 @@ bool launch_prefill_attn_mma(
     // launch invalid) cascades to the next tier — RQH=2 needs 46,720 B, under the
     // 48 KB default — and finally to the per-q-head kernel below, instead of
     // returning success over an output buffer nothing wrote.
-    if (gqa_rqh == 4 && gqa % 4 == 0 &&
+    // RQH=6 tier: the entire GQA group in one block, so each K page and V tile is read exactly
+    // once per kv-head instead of twice at RQH=3. Only fits because s_o overlays the front of the
+    // block (see attn_gqa_smem) -- 88,960 B against the 100 KB sm_120 cap, where the un-overlaid
+    // layout wanted 105,344 B and could not launch at all. 1 block/SM either way, so unlike the
+    // RQH=3 tier this is pure traffic reduction with no occupancy given up.
+    //
+    // Fusing RQH heads divides the grid's head dimension by RQH, so it only pays once the grid is
+    // wide enough to fill the device without it: at ctx=128 the grid is 8 x (24/6) = 32 blocks and
+    // RQH=6 measured -0.9% against RQH=3's 64, while at ctx=16384 it is 1024 x 4 and measured
+    // +1.0%. Gate on token count -- a shape property, so the tier choice is identical on every box.
+    if (gqa_rqh >= 6 && gqa % 6 == 0 && n_tokens >= minctx6 &&
+        launch_attn_gqa<HD, GROUP_BLKS, 6>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
+        return true;
+    // >= 4, not == 4: the default is now 6 (for GQA-6 checkpoints), and a gqa=4 model such as
+    // Qwen3.6 must still take this tier rather than falling past it to RQH=2.
+    if (gqa_rqh >= 4 && gqa % 4 == 0 &&
         launch_attn_gqa<HD, GROUP_BLKS, 4>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
+        return true;
+    // RQH=3 tier: Qwen3.8 is GQA-6, which 4 cannot divide, so it used to fall straight to 2 and
+    // re-read each K page / V tile 3x per kv-head instead of 2x. Measured +1.4% at prefill@16k.
+    // With the s_o overlay it needs 44,992 B, so it keeps 2 blocks/SM (it cost 61,376 B and one
+    // block/SM before) -- which is why the launch bound above is 2 for RQH<=3. Also the tier
+    // RQH=6 falls back to below ctx=2048.
+    if (gqa_rqh >= 3 && gqa % 3 == 0 &&
+        launch_attn_gqa<HD, GROUP_BLKS, 3>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
             n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
         return true;
     if (gqa_rqh >= 2 && gqa % 2 == 0 &&

--- a/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_fp8.cu
@@ -49,8 +49,29 @@ __device__ __forceinline__ void fp8_cp16(void* dst, const void* src, bool pred) 
 
 // XOR swizzle at 16B granularity: chunk c of row r lives at chunk (c ^ (r & 3)) -- rows 0..3 (the
 // stride the 4B operand loads walk) land on disjoint banks. Same scheme as the int8 GEMM.
+// XOR swizzle at 16B granularity: chunk c of row r lives at chunk (c ^ key(r)).
+//
+// SWZ8=false is the legacy key (row & 3). The smem row stride is FP8_BK = 64 B = 16 banks, so
+// row bit 0 ALREADY flips the 4-bank group by 16; keying the XOR on row bits 0-1 therefore
+// yields only 4 distinct (parity, chunk) states across the 8 rows one ldmatrix.m8n8 phase
+// reads, and rows d and d+4 land on the SAME 4 banks -- every ldmatrix.x4 phase is 2-way
+// conflicted. SWZ8=true keys on ((row >> 1) & 3) instead, which composes with the stride's own
+// parity flip so the 8 rows of a phase cover 8 disjoint 4-bank groups: conflict-free.
+//
+// Both are bijections on the chunk index for a fixed row, and writer and reader apply the same
+// function of (k, row), so the bytes staged and the registers loaded are IDENTICAL either way.
+template <bool SWZ8>
 __device__ __forceinline__ int fp8_swz(int k, int row) {
-    return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
+    return (((k >> 4) ^ (SWZ8 ? ((row >> 1) & 3) : (row & 3))) << 4) | (k & 15);
+}
+
+// Default ON; SPARKINFER_PREFILL_FP8_SWZ8=0 restores the legacy key for A/B.
+static bool fp8_use_swz8() {
+    static const bool v = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_FP8_SWZ8");
+        return !e || e[0] != '0';
+    }();
+    return v;
 }
 
 // ldmatrix.x4 operand staging, same as the int8 GEMM: one instruction per four 8x8 tiles instead
@@ -83,7 +104,7 @@ __global__ void pf_quantize_rows_fp8_kernel(const __nv_bfloat16* __restrict__ x,
 // keeps only one block per SM resident.
 // SPLITK partitions the K loop across blockIdx.z (same occupancy fix as launch_prefill_gemm_i8_splitk)
 // and atomicAdds the unscaled fp32 tile into P[M,N]; a separate epilogue applies sx*sw.
-template <bool SPLITK>
+template <bool SPLITK, bool SWZ8>
 __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
         const __nv_fp8_e4m3* __restrict__ A, const __nv_fp8_e4m3* __restrict__ W,
         const float* __restrict__ sx, const float* __restrict__ sw,
@@ -126,8 +147,8 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
         for (int s = tid; s < 512; s += 256) {
             const int r = s >> 2, c = s & 3, k = c << 4;
             const int gm = m0 + r, gn = n0 + r, gk = k0 + k;
-            fp8_cp16(&As[buf][r][fp8_swz(k, r)], &A[(size_t)gm * K + gk], gm < M && gk < K);
-            fp8_cp16(&Bs[buf][r][fp8_swz(k, r)], &W[(size_t)gn * K + gk], gn < N && gk < K);
+            fp8_cp16(&As[buf][r][fp8_swz<SWZ8>(k, r)], &A[(size_t)gm * K + gk], gm < M && gk < K);
+            fp8_cp16(&Bs[buf][r][fp8_swz<SWZ8>(k, r)], &W[(size_t)gn * K + gk], gn < N && gk < K);
         }
         __pipeline_commit();
     };
@@ -154,14 +175,14 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_fp8_kernel(
             for (int i = 0; i < FP8_MFRAG; i++) {
                 const int row = wm * 32 + i * 16 + (sub & 1) * 8 + lrow;
                 fp8_ldm_x4(af[i][0], af[i][1], af[i][2], af[i][3],
-                           &As[buf][row][fp8_swz(kk + (sub >> 1) * 16, row)]);
+                           &As[buf][row][fp8_swz<SWZ8>(kk + (sub >> 1) * 16, row)]);
             }
             // B pair (j, j+1): tiles {cols j,k0} {cols j,k16} {cols j+1,k0} {cols j+1,k16}
             #pragma unroll
             for (int jp = 0; jp < FP8_NFRAG; jp += 2) {
                 const int col = wn * 64 + (jp + (sub >> 1)) * 8 + lrow;
                 fp8_ldm_x4(bf[jp][0], bf[jp][1], bf[jp + 1][0], bf[jp + 1][1],
-                           &Bs[buf][col][fp8_swz(kk + (sub & 1) * 16, col)]);
+                           &Bs[buf][col][fp8_swz<SWZ8>(kk + (sub & 1) * 16, col)]);
             }
             #pragma unroll
             for (int i = 0; i < FP8_MFRAG; i++)
@@ -265,9 +286,14 @@ void launch_prefill_gemm_fp8(const void* A, const void* W,
                              const float* sx, const float* sw, void* C,
                              int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + FP8_BN - 1) / FP8_BN, (M + FP8_BM - 1) / FP8_BM);
-    pf_gemm_fp8_kernel<false><<<grid, 256, 0, stream>>>(
-        reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
-        sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+    if (fp8_use_swz8())
+        pf_gemm_fp8_kernel<false, true><<<grid, 256, 0, stream>>>(
+            reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
+            sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+    else
+        pf_gemm_fp8_kernel<false, false><<<grid, 256, 0, stream>>>(
+            reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
+            sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
 }
 
 // Same occupancy knee as the int8 split-K launcher: one 128x128 tile per block, so GDN
@@ -321,9 +347,14 @@ bool launch_prefill_gemm_fp8_splitk(const void* A, const void* W,
     if (cudaMemsetAsync(partials, 0, (size_t)M * N * sizeof(float), stream) != cudaSuccess)
         return false;
     dim3 grid((N + FP8_BN - 1) / FP8_BN, (M + FP8_BM - 1) / FP8_BM, nz);
-    pf_gemm_fp8_kernel<true><<<grid, 256, 0, stream>>>(
-        reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
-        sx, sw, nullptr, partials, M, N, K, ktiles);
+    if (fp8_use_swz8())
+        pf_gemm_fp8_kernel<true, true><<<grid, 256, 0, stream>>>(
+            reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
+            sx, sw, nullptr, partials, M, N, K, ktiles);
+    else
+        pf_gemm_fp8_kernel<true, false><<<grid, 256, 0, stream>>>(
+            reinterpret_cast<const __nv_fp8_e4m3*>(A), reinterpret_cast<const __nv_fp8_e4m3*>(W),
+            sx, sw, nullptr, partials, M, N, K, ktiles);
     dim3 eg(((N + 1) / 2 + 255) / 256, M);
     pf_gemm_fp8_sk_epi_kernel<<<eg, 256, 0, stream>>>(
         partials, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), M, N);

--- a/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_i8.cu
@@ -30,10 +30,28 @@ __device__ __forceinline__ void pf_cp16(void* dst, const void* src, bool pred) {
     else      *reinterpret_cast<uint4*>(dst) = make_uint4(0u, 0u, 0u, 0u);
 }
 
-// XOR swizzle at 16B granularity: chunk c of row r lives at chunk (c ^ (r & 3)). Rows 4 apart still
-// collide (2-way); rows 0..3 -- the stride the 4B operand loads walk -- land on disjoint banks.
+// XOR swizzle at 16B granularity: chunk c of row r lives at chunk (c ^ key(r)).
+//
+// SWZ8=false is the legacy key (row & 3), whose 2-way collision this comment used to concede:
+// the smem row stride is PF_BK = 64 B = 16 banks, so row bit 0 already flips the 4-bank group by
+// 16, and keying on row bits 0-1 leaves rows d and d+4 on the SAME banks -- every phase of every
+// ldmatrix.x4 is 2-way conflicted. SWZ8=true keys on ((row >> 1) & 3), which composes with the
+// stride's own parity flip so the 8 rows one ldmatrix.m8n8 phase reads cover 8 disjoint 4-bank
+// groups. Both are bijections on the chunk index for a fixed row and writer and reader apply the
+// same function of (k, row), so the staged bytes and loaded registers are IDENTICAL either way
+// (int32 accumulation is exact, so the GEMM output is bit-for-bit unchanged).
+template <bool SWZ8>
 __device__ __forceinline__ int pf_swz(int k, int row) {
-    return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
+    return (((k >> 4) ^ (SWZ8 ? ((row >> 1) & 3) : (row & 3))) << 4) | (k & 15);
+}
+
+// Default ON; SPARKINFER_PREFILL_I8_SWZ8=0 restores the legacy key for A/B.
+static bool i8_use_swz8() {
+    static const bool v = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_I8_SWZ8");
+        return !e || e[0] != '0';
+    }();
+    return v;
 }
 
 // ldmatrix.x4: one instruction moves all four 8x8 operand tiles of an mma fragment through the
@@ -73,7 +91,7 @@ __global__ void pf_quantize_rows_i8(const __nv_bfloat16* __restrict__ x, signed 
 // tile into P[M,N] with atomicAdd instead of storing C; a separate epilogue applies sx/sw. The
 // output is bit-identical because the accumulator is int32: integer addition is exact and
 // associative, so the reordered partial sums land on the same value the single-block loop produces.
-template <bool RESID, bool SPLITK>
+template <bool RESID, bool SPLITK, bool SWZ8>
 __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         const signed char* __restrict__ A, const signed char* __restrict__ W,
         const float* __restrict__ sx, const float* __restrict__ sw,
@@ -116,8 +134,8 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
         for (int s = tid; s < 512; s += 256) {
             const int r = s >> 2, c = s & 3, k = c << 4;
             const int gm = m0 + r, gn = n0 + r, gk = k0 + k;
-            pf_cp16(&As[buf][r][pf_swz(k, r)], &A[(size_t)gm * K + gk], gm < M && gk < K);
-            pf_cp16(&Bs[buf][r][pf_swz(k, r)], &W[(size_t)gn * K + gk], gn < N && gk < K);
+            pf_cp16(&As[buf][r][pf_swz<SWZ8>(k, r)], &A[(size_t)gm * K + gk], gm < M && gk < K);
+            pf_cp16(&Bs[buf][r][pf_swz<SWZ8>(k, r)], &W[(size_t)gn * K + gk], gn < N && gk < K);
         }
         __pipeline_commit();
     };
@@ -137,14 +155,14 @@ __global__ __launch_bounds__(256, 2) void pf_gemm_i8_kernel(
             for (int i = 0; i < PF_MFRAG; i++) {
                 const int row = wm * 32 + i * 16 + (sub & 1) * 8 + lrow;
                 pf_ldm_x4(af[i][0], af[i][1], af[i][2], af[i][3],
-                          &As[buf][row][pf_swz(kk + (sub >> 1) * 16, row)]);
+                          &As[buf][row][pf_swz<SWZ8>(kk + (sub >> 1) * 16, row)]);
             }
             // B pair (j, j+1): tiles {cols j,k0} {cols j,k16} {cols j+1,k0} {cols j+1,k16}
             #pragma unroll
             for (int jp = 0; jp < PF_NFRAG; jp += 2) {
                 const int col = wn * 64 + (jp + (sub >> 1)) * 8 + lrow;
                 pf_ldm_x4(bf[jp][0], bf[jp][1], bf[jp + 1][0], bf[jp + 1][1],
-                          &Bs[buf][col][pf_swz(kk + (sub & 1) * 16, col)]);
+                          &Bs[buf][col][pf_swz<SWZ8>(kk + (sub & 1) * 16, col)]);
             }
             #pragma unroll
             for (int i = 0; i < PF_MFRAG; i++)
@@ -292,8 +310,12 @@ bool launch_prefill_gemm_i8_splitk(const signed char* A, const signed char* W,
     const int nz = (nk + ktiles - 1) / ktiles;
     if (cudaMemsetAsync(partials, 0, (size_t)M * N * sizeof(int), stream) != cudaSuccess) return false;
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM, nz);
-    pf_gemm_i8_kernel<false, true><<<grid, 256, 0, stream>>>(
-        A, W, sx, sw, nullptr, partials, M, N, K, ktiles);
+    if (i8_use_swz8())
+        pf_gemm_i8_kernel<false, true, true><<<grid, 256, 0, stream>>>(
+            A, W, sx, sw, nullptr, partials, M, N, K, ktiles);
+    else
+        pf_gemm_i8_kernel<false, true, false><<<grid, 256, 0, stream>>>(
+            A, W, sx, sw, nullptr, partials, M, N, K, ktiles);
     dim3 eg(((N + 1) / 2 + 255) / 256, M);
     if (resid)
         pf_gemm_i8_sk_epi_kernel<true><<<eg, 256, 0, stream>>>(
@@ -319,8 +341,12 @@ void launch_prefill_gemm_i8(const signed char* A, const signed char* W,
                             const float* sx, const float* sw, void* C,
                             int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
-    pf_gemm_i8_kernel<false, false><<<grid, 256, 0, stream>>>(
-        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+    if (i8_use_swz8())
+        pf_gemm_i8_kernel<false, false, true><<<grid, 256, 0, stream>>>(
+            A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+    else
+        pf_gemm_i8_kernel<false, false, false><<<grid, 256, 0, stream>>>(
+            A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
 }
 
 // Residual-fused variant: C[m,n] += bf16(acc*sx*sw) with pf_add's rounding. Passing the residual
@@ -329,8 +355,12 @@ void launch_prefill_gemm_i8_resid(const signed char* A, const signed char* W,
                                   const float* sx, const float* sw, void* C,
                                   int M, int N, int K, cudaStream_t stream) {
     dim3 grid((N + PF_BN - 1) / PF_BN, (M + PF_BM - 1) / PF_BM);
-    pf_gemm_i8_kernel<true, false><<<grid, 256, 0, stream>>>(
-        A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+    if (i8_use_swz8())
+        pf_gemm_i8_kernel<true, false, true><<<grid, 256, 0, stream>>>(
+            A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
+    else
+        pf_gemm_i8_kernel<true, false, false><<<grid, 256, 0, stream>>>(
+            A, W, sx, sw, reinterpret_cast<__nv_bfloat16*>(C), nullptr, M, N, K, 0);
 }
 
 }} // namespace sparkinfer::kernels


### PR DESCRIPTION
## Summary

Overlay the prefill attention epilogue's shared-memory landing zone onto buffers that are already dead by that point, which frees 16 KB/CTA and makes an RQH=6 GQA-fusion tier fit under sm_120's 100 KB cap; and key the `ldmatrix` XOR swizzle on `(row>>1)&3` in both hand-written GEMMs so the 8 rows of a phase stop colliding. Both are bit-identical to `main`.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 83.26 |
| after (this PR) | 83.26 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 8625.68 |
| after prefill (this PR) | 8909.30 |

(at **ctx=16384**, the Qwen3.8 bot's scored dimension — `SCORING_DIM = "prefill@16k"`; prefill@128 and decode@128 are its no-regression floors and are reported in the evidence block below.)

```text
# Qwen3.8-27B NVFP4 checkpoint, RTX 5090 (sm_120, SW power cap 525 W), CUDA 12.8.
# Two binaries — main @ dc576f9 and this branch — alternated in one session, 3 pairs, median.
#   SPARKINFER_BENCH_PROMPT_FILE=/tmp/q38ids.txt
#   SPARKINFER_BENCH_SWEEP_CTXS=128,16384 SPARKINFER_BENCH_SWEEP_REPS=5
#   ./build/runtime/qwen3_gguf_bench <model_dir> 128 sweep
# startup: [compressed-tensors] loaded 64 layers, native NVFP4 prefill FFN 56/64 (decode stays Q4_K)

main {"128":{"decode_tps":83.3693,"prefill_pp":5099.7845},"16384":{"decode_tps":70.6359,"prefill_pp":8661.2608}}
PR   {"128":{"decode_tps":83.3313,"prefill_pp":5086.9349},"16384":{"decode_tps":70.5842,"prefill_pp":8932.2497}}
main {"128":{"decode_tps":83.2608,"prefill_pp":5097.4992},"16384":{"decode_tps":70.5418,"prefill_pp":8625.6833}}
PR   {"128":{"decode_tps":83.2551,"prefill_pp":5087.8161},"16384":{"decode_tps":70.5659,"prefill_pp":8909.2987}}
main {"128":{"decode_tps":83.2277,"prefill_pp":5086.4184},"16384":{"decode_tps":70.4983,"prefill_pp":8600.3927}}
PR   {"128":{"decode_tps":83.2197,"prefill_pp":5082.2662},"16384":{"decode_tps":70.5144,"prefill_pp":8906.6444}}

medians
  prefill@16384   main 8625.68  ->  PR 8909.30   +3.29%   (scored dimension)
  prefill@128     main 5097.50  ->  PR 5086.93   -0.21%   (no-regression floor, tol -2%)
  decode@128      main   83.26  ->  PR   83.26   -0.01%   (no-regression floor, tol -2%)

# Correctness: bit-identical, not merely close. qwen3_gguf_generate over a 2250-token prompt,
# max_new=24, repeated — main and every attention tier and both swizzle settings agree exactly:
#   main    OUTPUT_IDS: 46838 42903 15814 8070 1379 314 836 854 6992 13914 4598 1056 3604 33633 ...
#   RQH=6   OUTPUT_IDS: 46838 42903 15814 8070 1379 314 836 854 6992 13914 4598 1056 3604 33633 ...
#   RQH=3   OUTPUT_IDS: 46838 42903 15814 8070 1379 314 836 854 6992 13914 4598 1056 3604 33633 ...
#   RQH=2   OUTPUT_IDS: 46838 42903 15814 8070 1379 314 836 854 6992 13914 4598 1056 3604 33633 ...
#   SWZ8=0  OUTPUT_IDS: 46838 42903 15814 8070 1379 314 836 854 6992 13914 4598 1056 3604 33633 ...
```

**Qwen3.6 guard**: decode + prefill at ctx 0/512/4k/16k/32k, same box, PR vs main — no regression (PR is +0.3–0.5% on prefill, decode flat).
