### PR TITLE
perf(qwen3.8): decode NVFP4 scales and nibbles arithmetically, not through local memory (1.22x decode@128)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -514,21 +514,58 @@ template __global__ void gemv_fp8_kernel<__nv_bfloat16>(const __nv_bfloat16*, co
 // Payload: [256 B header | ue4m3 scale[N*(K/16)] | packed u8[N*(K/2)]].
 // One scale group = 16 weights = 8 packed bytes. LUTs stay in registers --
 // __constant__ + cudaMemcpyToSymbol is unsafe from this static lib's .so link.
-__device__ __forceinline__ float si_e2m1(unsigned nibble) {
-    const float t[16] = {0.f, 0.5f, 1.f, 1.5f, 2.f, 3.f, 4.f, 6.f,
-                         -0.f, -0.5f, -1.f, -1.5f, -2.f, -3.f, -4.f, -6.f};
-    return t[nibble & 15u];
+// E2M1 nibble -> float, by arithmetic rather than table lookup.
+//
+// The table form (`const float t[16]` indexed by the nibble) does NOT stay in registers: the index
+// is a runtime value, so nvcc must place the array in LOCAL memory and every decode becomes a
+// local-memory load -- 16 of them per 16-weight group, per lane, on top of the 8 bytes of weight
+// the group actually reads. That is what held gemv_nvfp4_sk_kernel to 21-46% of this part's
+// bandwidth while the Q4_K dp4a GEMVs beside it run at 86-89%.
+//
+// e2m1 is s|ee|m with magnitude (e ? 2^(e-1) * (1 + m/2) : m/2). Doubling it makes every value an
+// integer -- {0,1,2,3,4,6,8,12} -- reachable as `e ? ((2+m) << (e-1)) : m`, so the decode is a
+// handful of integer ops and one int->float convert, with no memory touched at all.
+//
+// Bit-identical to the table: the doubled magnitude and the compensating 0.5 are both exact in
+// binary floating point, so (2*mag) * (0.5*s) rounds to exactly what mag * s did. Nibble 8 still
+// yields -0.0f.
+__device__ __forceinline__ float si_e2m1_x2(unsigned nibble) {
+    const unsigned n = nibble & 15u;
+    // The eight doubled magnitudes {0,1,2,3,4,6,8,12} are all < 16, so the whole table fits in the
+    // nibbles of one 32-bit literal and the lookup is a shift and a mask -- an immediate operand,
+    // not memory. (0xC8643210: nibble i, counting from the LSB, is magnitude i.) This replaces the
+    // exponent reconstruction, which needed a select and cost roughly half again as many ops.
+    const unsigned mag = (0xC8643210u >> ((n & 7u) << 2)) & 15u;
+    // graft the sign bit on rather than branching, so nibble 8 keeps its -0.0f
+    return __int_as_float(__float_as_int(__uint2float_rn(mag)) | ((n & 8u) << 28));
 }
+// Unsigned E4M3 group scale -> float, by assembling the fp32 bits.
+//
+// The ldexpf form costs a branch plus two library calls per 16-weight group. For e>0,
+// (8+m) * 2^(e-10) == (1 + m/8) * 2^(e-7), which is exactly an fp32 with exponent field e+120 and
+// mantissa m<<20 -- pure integer work. e==0 stays on the multiply (m * 2^-9); it is the rare
+// subnormal leg and keeping it explicit avoids special-casing the bit pattern.
 __device__ __forceinline__ float si_ue4m3(unsigned b) {
-    const int e = (int)((b >> 3) & 15u);
-    const int m = (int)(b & 7u);
-    if (e == 0) return ldexpf((float)m, -9);
-    return ldexpf(8.f + (float)m, e - 10);
+    const unsigned e = (b >> 3) & 15u, m = b & 7u;
+    if (e == 0) return (float)m * (1.f / 512.f);          // 2^-9, exact
+    return __int_as_float((int)(((e + 120u) << 23) | (m << 20)));
 }
 __device__ __forceinline__ float si_nvfp4_group_dot(const unsigned char* packed8,
                                                     unsigned char scale, float inv_g,
                                                     const __nv_bfloat16* x16) {
-    const float s = si_ue4m3(scale) * inv_g;
+    // si_e2m1_x2 returns twice the weight, so halve the scale here -- both are exact in binary
+    // floating point, and the product rounds to what (weight * s) did.
+    //
+    // The scale stays folded into every term rather than being applied once to the group's dot
+    // product. Hoisting it saves 16 fp32 multiplies per group and is 22% faster, but it is NOT
+    // equivalent here: measured against this same build with only that change, top1 fell to 0.9849
+    // and KL(main||pr) rose to 0.162 nats over 199 positions -- past the 0.99/0.01 gate. These are
+    // the Gated-DeltaNet in-projections, and its near-1 decay amplifies a last-ulp difference along
+    // the sequence (the same sensitivity prefill_gemm_fp8.cu's header documents). Do not re-try it.
+    const float s = si_ue4m3(scale) * inv_g * 0.5f;
+    // Left as two 4-byte loads: a uint2 would halve the load count but needs 8-byte alignment,
+    // which the row base only happens to have for these shapes (K/16 a multiple of 8), not in
+    // general. The warp reads the same 256 contiguous bytes either way.
     const unsigned int p0 = __ldg(reinterpret_cast<const unsigned int*>(packed8));
     const unsigned int p1 = __ldg(reinterpret_cast<const unsigned int*>(packed8 + 4));
     const __nv_bfloat162* x2 = reinterpret_cast<const __nv_bfloat162*>(x16);
@@ -537,13 +574,13 @@ __device__ __forceinline__ float si_nvfp4_group_dot(const unsigned char* packed8
     for (int i = 0; i < 4; i++) {
         const unsigned b = (p0 >> (8 * i)) & 255u;
         const float2 xf = __bfloat1622float2(x2[i]);
-        acc += (si_e2m1(b & 15u) * s) * xf.x + (si_e2m1(b >> 4) * s) * xf.y;
+        acc += (si_e2m1_x2(b & 15u) * s) * xf.x + (si_e2m1_x2(b >> 4) * s) * xf.y;
     }
     #pragma unroll
     for (int i = 0; i < 4; i++) {
         const unsigned b = (p1 >> (8 * i)) & 255u;
         const float2 xf = __bfloat1622float2(x2[i + 4]);
-        acc += (si_e2m1(b & 15u) * s) * xf.x + (si_e2m1(b >> 4) * s) * xf.y;
+        acc += (si_e2m1_x2(b & 15u) * s) * xf.x + (si_e2m1_x2(b >> 4) * s) * xf.y;
     }
     return acc;
 }


### PR DESCRIPTION
## Summary

The GDN in-projections (48 layers × qkv/z/out) are **35.8% of decode@128** on this checkpoint and
the only large term not already at roofline — the Q4_K FFN GEMVs beside them run at **86-89%** of
this part's bandwidth while these ran at **21-46%**. Both of `gemv_nvfp4_sk_kernel`'s per-group
helpers were paying for that off the critical path.

**`si_e2m1`** held its 16 magnitudes in `const float t[16]` declared *inside* the device function.
The index is a runtime nibble, so nvcc cannot keep that array in registers — it lands in **local
memory**, and every decode becomes a local-memory load. The kernel does 16 of them per 16-weight
group, per lane, on top of the 8 bytes of weight the group actually reads. (The comment above it
says the LUT stays in registers; a dynamically indexed local array is exactly what prevents that.)

Doubling the e2m1 magnitude makes every value an integer — `{0,1,2,3,4,6,8,12}` — and all eight are
below 16, so the **whole table fits in the nibbles of one 32-bit literal** (`0xC8643210`) and the
lookup becomes a shift and a mask against an immediate. No memory, no select. The compensating 0.5
folds into the group scale.

**`si_ue4m3`** cost a branch plus two `ldexpf` calls per group. For `e>0`, `(8+m) * 2^(e-10)` is
exactly an fp32 with exponent field `e+120` and mantissa `m<<20`, so that leg becomes pure integer
work; `e==0` stays on an exact multiply by `2^-9`.

**Bit-identical, not approximately.** The doubled magnitude and the halved scale are both exact in
binary floating point, so `(2*w) * (s/2)` rounds to exactly what `(w * s)` did; nibble 8 still
yields `-0.0f`; and the ue4m3 bit pattern is the value the `ldexpf` pair produced.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `qwen3_gguf_bench <dir> 128 sweep`, `REPS=3`, median of 3 rounds):

| | decode tok/s |
|---|--:|
| before (main) | 77.63 |
| after (this PR) | **95.01** |

**Prefill pp tok/s** (same sweep, same model load — this is a decode GEMV, so flat is the expected
result, not a gain):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2394.39 |
| after prefill (this PR) | 2389.04 |

**+22.4% decode@128.** Same-box RTX 5090, `models_q38_modelopt`, two separately configured build
trees (a CUDA binary cannot be copied out of its build tree), alternated. The baseline is `e06bfa8`,
which current main touches only in `eval/pr_modelopt_bot.py` — no runtime or kernel code differs, so
these numbers stand unchanged against main:

```text
  r1 base SWEEP_JSON {"128":{"decode_tps":77.9323,"prefill_pp":2394.3947}}
  r1 PR   SWEEP_JSON {"128":{"decode_tps":95.2351,"prefill_pp":2391.0067}}
  r2 base SWEEP_JSON {"128":{"decode_tps":77.6255,"prefill_pp":2398.0115}}
  r2 PR   SWEEP_JSON {"128":{"decode_tps":95.0081,"prefill_pp":2389.0431}}
  r3 base SWEEP_JSON {"128":{"decode_tps":77.3307,"prefill_pp":2383.9587}}
  r3 PR   SWEEP_JSON {"128":{"decode_tps":94.8320,"prefill_pp":2387.1864}}
```

Kernel-level, for the mechanism only (`nsys --cuda-graph-trace=node` — decode runs inside a CUDA
graph, and without that flag only load-time kernels appear): the two `gemv_nvfp4_sk` shapes drop
**556.6 → 373.9 ms** and total decode **1556.4 → 1350.3 ms** over the same 112 forward passes,
after the e2m1 change alone. They are still short of the Q4_K GEMVs' bandwidth, so this does not
exhaust the path — it removes the local-memory traffic that dominated it.

## Correctness

`qwen3_gguf_score` dumps over **199** teacher-forced positions are **byte-identical** between the
two builds, so the bot's differential gate reads top1 = 1.000 / KL = 0.000.

Batched-prefill parity (absolute gate, `bench/scripts/prefill_parity_check.py`, PR build):
`PARITY worst=1.000 bar=0.75 OK`.

## No-regression

Qwen3.8 (shipping unsloth checkpoint), same sweep:

| | decode tok/s | prefill pp |
|---|--:|--:|
| before | 84.26 | 4129.07 |
| after | 84.17 | 4125.40 |

Qwen3.6 (`ctx 0/512/4k/16k/32k`, ratio PR/main): decode 0.998–1.000, prefill 0.998–1.002.

## Scope

Touches only `si_e2m1` / `si_ue4m3` / `si_nvfp4_group_dot` in `kernels/csrc/cuda/gemm/gemv.cu`,
which are reached only by the two NVFP4 decode GEMVs. Nothing else reads them, and no other
checkpoint format's decode path changes.

A note on what this deliberately does **not** do: `015d226` measured requantizing these
projections to Q4_K at +23% decode for a real accuracy cost (top1 0.851 → 0.822, KL 0.247 → 0.300)
and no VRAM saving, both formats being 4.5 bits per weight. This keeps the native NVFP4 payload and
its accuracy, and takes most of that speed anyway.

Also not done: hoisting the per-group scale out of the 16 terms. It saves 16 fp32 multiplies and
measured **0.3%** faster than this, but it is not equivalent — with only that change top1 fell to
0.9849 and KL(main||pr) rose to 0.162 nats over 199 positions, past the 0.99/0.01 gate. These are
the Gated-DeltaNet in-projections and its near-1 decay amplifies a last-ulp difference along the
sequence. The comment in the source records that so it is not retried.
