### PR TITLE
perf(qwen3.8): group-wise NVFP4 checkpoint dequant for prefill (1.28x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -462,11 +462,77 @@ __global__ void ct_dequant_nvfp4_kernel(const unsigned char* __restrict__ packed
     // the expected ~0.01-0.05 std typical of a trained projection matrix.
     out[i] = __float2bfloat16(v * s / global_scale);
 }
+
+// Group-wise twin of the kernel above. Same arithmetic, same operand order, same
+// __float2bfloat16 -- only the work decomposition changes, so the output is bit-identical.
+//
+// The per-element kernel is the dominant cost of a ModelOpt prefill: nsys puts it at 33.2 ms of a
+// 52.9 ms prefill@128 (63%), moving 138 MB per GDN qkv call at ~730 GB/s while the GEMVs beside it
+// run at ~1500. Per thread it paid a 64-bit `i / cols` division, re-read each packed byte from two
+// threads and each scale byte from sixteen, and issued a 2-byte store.
+//
+// One thread owns one 16-element group instead -- exactly the granularity the scale is stored at:
+//   * the row index comes from blockIdx.y, so the division disappears;
+//   * the group's 8 packed bytes are one 8-byte load (the row pitch is cols/2 and cols%16==0, so
+//     every group is 8-byte aligned), and its scale is one byte read once, not sixteen times;
+//   * the 16 results leave as two 16-byte stores.
+// A warp then reads 256 contiguous packed bytes and writes 1 KB, all coalesced.
+__global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ packed,
+                                            const unsigned char* __restrict__ group_scale,
+                                            float global_scale,
+                                            const float* __restrict__ global_scale_dev,
+                                            __nv_bfloat16* __restrict__ out,
+                                            int rows, int cols) {
+    if (global_scale_dev) global_scale = *global_scale_dev;
+    const int ngroups = cols >> 4;
+    const int r = blockIdx.y;
+    if (r >= rows) return;
+    const unsigned char* prow = packed + (size_t)r * (size_t)(cols >> 1);
+    const unsigned char* srow = group_scale + (size_t)r * (size_t)ngroups;
+    __nv_bfloat16* orow = out + (size_t)r * (size_t)cols;
+    for (int g = blockIdx.x * blockDim.x + threadIdx.x; g < ngroups;
+         g += gridDim.x * blockDim.x) {
+        const uint2 pk = *reinterpret_cast<const uint2*>(prow + (size_t)g * 8);
+        const float s = float(cutlass::float_ue4m3_t::bitcast(srow[g]));
+        // __align__(16) so the two uint4 stores below are legal; indices are compile-time constant
+        // under the unroll, so this stays in registers (verified: ncu local ld/st = 0).
+        __align__(16) __nv_bfloat16 o[16];
+        #pragma unroll
+        for (int j = 0; j < 16; j++) {
+            const unsigned word = (j < 8) ? pk.x : pk.y;
+            const unsigned byte = (word >> (8 * ((j & 7) >> 1))) & 255u;
+            const unsigned char nib = (unsigned char)((j & 1) ? (byte >> 4) : (byte & 0xF));
+            const float v = float(cutlass::float_e2m1_t::bitcast(nib));
+            o[j] = __float2bfloat16(v * s / global_scale);
+        }
+        *reinterpret_cast<uint4*>(orow + (size_t)g * 16)     = *reinterpret_cast<const uint4*>(o);
+        *reinterpret_cast<uint4*>(orow + (size_t)g * 16 + 8) = *reinterpret_cast<const uint4*>(o + 8);
+    }
+}
 } // namespace
 
 static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_scale_ue4m3,
                                     float global_scale, const float* global_scale_dev,
                                     void* out_bf16, int rows, int cols, cudaStream_t stream) {
+    // Group-wise path when the shape allows it (SPARKINFER_CT_NVFP4_G16=0 restores the
+    // per-element kernel for A/B). cols%16==0 makes every group's 8 packed bytes 8-byte aligned
+    // and every 16-value output run 32-byte aligned; the payload pointers themselves come from
+    // cudaMalloc plus a 256-byte header, so both bases are aligned too.
+    static const int g16 = [] {
+        const char* e = getenv("SPARKINFER_CT_NVFP4_G16");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (g16 && rows > 0 && cols > 0 && (cols & 15) == 0 &&
+        ((reinterpret_cast<size_t>(packed_u8) | reinterpret_cast<size_t>(out_bf16)) & 15u) == 0) {
+        const int ngroups = cols >> 4;
+        const int threads = 256;
+        const int bx = (ngroups + threads - 1) / threads;
+        ct_dequant_nvfp4_g16_kernel<<<dim3(bx > 0 ? bx : 1, rows), threads, 0, stream>>>(
+            reinterpret_cast<const unsigned char*>(packed_u8),
+            reinterpret_cast<const unsigned char*>(group_scale_ue4m3), global_scale,
+            global_scale_dev, reinterpret_cast<__nv_bfloat16*>(out_bf16), rows, cols);
+        return;
+    }
     const long n = (long)rows * cols;
     const int threads = 256;
     const long blocks = (n + threads - 1) / threads;


### PR DESCRIPTION
## Summary

On the ModelOpt checkpoint the GDN projections are NVFP4 and `proj()` has no native-NVFP4 arm, so
every one of them goes NVFP4 -> bf16 -> int8 each prefill. The bf16 expansion alone —
`ct_dequant_nvfp4_kernel`, 176 calls at 189 us — is **33.2 ms of a 52.9 ms prefill@128 (63%)**,
against 5.1 ms for the int8 GEMM that finally consumes it. For the qkv projection that turns a
29.5 MB payload into ~343 MB of traffic.

The kernel is one thread per weight *element*, and each thread pays a 64-bit `i / cols` division,
a packed byte its neighbour thread also loads, a group-scale byte fifteen other threads also load,
a floating-point divide, and a 2-byte store. It moves 138 MB at ~730 GB/s while the GEMVs beside it
run at ~1500.

This adds a group-wise twin: **one thread per 16-element group**, which is the granularity the
scale is already stored at.

* the row index comes from `blockIdx.y`, so the division disappears;
* the group's 8 packed bytes are one 8-byte load — the row pitch is `cols/2` and `cols % 16 == 0`,
  so every group is 8-byte aligned;
* its scale byte is read once instead of sixteen times;
* the 16 results leave as two 16-byte stores.

A warp then reads 256 contiguous packed bytes and writes 1 KB, all coalesced.

Same arithmetic, same operand order, same `__float2bfloat16`. In particular the `/ global_scale`
division is kept as a division — folding a reciprocal would be faster and would **not** be
bit-identical. Only the work decomposition changes, so the result is bit-identical, which the
teacher-forced score dumps confirm byte-for-byte.

Guarded on `cols % 16 == 0` and on the payload/output base alignment; anything else keeps the
per-element kernel, as does `SPARKINFER_CT_NVFP4_G16=0` for A/B.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 93.93 |
| after (this PR) | 94.05 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 2568.03 |
| after prefill (this PR) | 3294.61 |

```text
# bench_sweep_run <ModelOpt dir> 128 128 5 16384 5 -- the harness the eval uses
# (qwen3_gguf_bench ... sweep, median of 5 reps). RTX 5090 sm_120.
# SPARKINFER_CT_NVFP4_G16=0 is the per-element kernel, i.e. the pre-change path, so both arms
# come out of one binary and one model load.
#
# Arm ORDER IS ROTATED between rounds: an earlier A/B on this box drifted monotonically with
# position within a round, by about as much as the effect being measured. Here the patch wins all
# four rounds including the two where it ran first.

r1 G16=0  decode128=94.9368  pp128=2599.9103  pp16k=9708.6105
r1 G16=1  decode128=94.5596  pp128=3314.4619  pp16k=9585.7088
r2 G16=1  decode128=94.2543  pp128=3298.0252  pp16k=9463.0138
r2 G16=0  decode128=93.9551  pp128=2569.1072  pp16k=9373.0816
r3 G16=0  decode128=93.9076  pp128=2566.9563  pp16k=9343.3406
r3 G16=1  decode128=93.8372  pp128=3291.1942  pp16k=9373.0669
r4 G16=1  decode128=93.7637  pp128=3291.0438  pp16k=9371.1615
r4 G16=0  decode128=93.7207  pp128=2562.5700  pp16k=9305.4479

prefill@128  2568.03 -> 3294.61 pp  (+28.29%); ranges disjoint, before best 2599.91 <
             after worst 3291.04.
decode@128   93.93 -> 94.05 tok/s and prefill@16k 9358.21 -> 9418.04 pp: both flat. No decode
             kernel is touched -- decode reads the NVFP4 weights through the GEMV, not this
             dequant.

Accuracy: teacher-forced score dumps over 101 positions are BYTE-IDENTICAL between
SPARKINFER_CT_NVFP4_G16=0 and =1 (top1 1.000000, KL 0.000000).

No-regression guards, same build, SPARKINFER_CT_NVFP4_G16=1 vs =0:
  Qwen3.6  ctx 0/512/4k/16k/32k   decode 1.003/1.004/1.003/1.002/1.003
                                  prefill    -/1.009/1.007/1.007/1.007
  Qwen3.8  ctx 0/4k/16k           decode 1.002/1.001/1.002
                                  prefill    -/1.008/1.007

ctest: 100% tests passed, 0 failed out of 19.
```
