### PR TITLE
perf(qwen3.8): integer NVFP4 decode straight to int8 rows (1.12x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -540,7 +540,108 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16 + 8) = *reinterpret_cast<const uint4*>(o + 8);
     }
 }
+
+// Fused NVFP4 -> per-row int8, so the bf16 never lands in DRAM.
+//
+// This was tried BEFORE the integer decode above and measured 1.2% SLOWER: it cut DRAM traffic
+// 4.4x (295 MB -> 85 MB per GDN qkv projection) and gained nothing, because at that point both
+// this kernel and the dequant it replaces were ALU bound -- ncu had them at SM 75-81% with DRAM
+// at 10-44%. Halving the per-element arithmetic changes that premise, so the traffic saving is
+// worth re-testing on top of it. SPARKINFER_CT_NVFP4_ROWS_I8 selects.
+//
+// The value set, the reduction and the rounding are pf_quant_rows_fast_kernel's, unchanged: the
+// same VEC=8 slots so a thread holds the same eight columns, the same bf16 rounding on the way in,
+// the same amax over that value set, the same d = amax/127.0f and roundf, and the same
+// amax==0 -> 0 rule. The row amax is a MAX, which is associative and exact in floating point, so
+// no thread mapping can change it. Bit-identical to the two-kernel path by construction.
+//
+// Eight consecutive columns from a multiple of 8 lie inside one 16-element group, so a slot is one
+// 4-byte packed load plus one scale byte.
+template <int BLOCK, int VEC, int SLOTS>
+__global__ __launch_bounds__(BLOCK) void ct_nvfp4_rows_i8_kernel(
+        const unsigned char* __restrict__ packed, const unsigned char* __restrict__ group_scale,
+        const float* __restrict__ global_scale_dev, signed char* __restrict__ q,
+        float* __restrict__ scale, int rows, int cols) {
+    const int r = blockIdx.x;
+    if (r >= rows) return;
+    const int tid = threadIdx.x;
+    const float gs = *global_scale_dev;
+    const unsigned char* prow = packed + (size_t)r * (size_t)(cols >> 1);
+    const unsigned char* srow = group_scale + (size_t)r * (size_t)(cols >> 4);
+    const size_t base = (size_t)r * (size_t)cols;
+
+    __nv_bfloat16 reg[SLOTS][VEC];
+    float amax = 0.f;
+    #pragma unroll
+    for (int s = 0; s < SLOTS; s++) {
+        const int c = (tid + s * BLOCK) * VEC;
+        if (c < cols) {
+            const unsigned pk = *reinterpret_cast<const unsigned*>(prow + (c >> 1));
+            const float gsc = ct_ue4m3(srow[c >> 4]);
+            #pragma unroll
+            for (int v = 0; v < VEC; v++) {
+                const unsigned byte = (pk >> (8 * (v >> 1))) & 255u;
+                const unsigned char nib = (unsigned char)((v & 1) ? (byte >> 4) : (byte & 0xF));
+                reg[s][v] = __float2bfloat16((0.5f * ct_e2m1_x2(nib)) * gsc / gs);
+                amax = fmaxf(amax, fabsf(__bfloat162float(reg[s][v])));
+            }
+        }
+    }
+    #pragma unroll
+    for (int o = 16; o > 0; o >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, o));
+    __shared__ float sred[BLOCK / 32];
+    if ((tid & 31) == 0) sred[tid >> 5] = amax;
+    __syncthreads();
+    if (tid < 32) {
+        float v = (tid < BLOCK / 32) ? sred[tid] : 0.f;
+        #pragma unroll
+        for (int o = 16; o > 0; o >>= 1) v = fmaxf(v, __shfl_xor_sync(0xffffffffu, v, o));
+        if (tid == 0) sred[0] = v;
+    }
+    __syncthreads();
+    const float d = sred[0] / 127.0f;
+    if (tid == 0) scale[r] = d;
+    #pragma unroll
+    for (int s = 0; s < SLOTS; s++) {
+        const int c = (tid + s * BLOCK) * VEC;
+        if (c < cols) {
+            signed char out[VEC];
+            #pragma unroll
+            for (int v = 0; v < VEC; v++)
+                out[v] = (signed char)((sred[0] == 0.f) ? 0
+                                       : (int)roundf(__bfloat162float(reg[s][v]) / d));
+            *reinterpret_cast<uint2*>(&q[base + c]) = *reinterpret_cast<const uint2*>(out);
+        }
+    }
+}
 } // namespace
+
+bool launch_ct_dequant_nvfp4_rows_i8(const void* packed_u8, const void* group_scale_ue4m3,
+                                     const float* global_scale_dev, signed char* q, float* scale,
+                                     int rows, int cols, cudaStream_t stream) {
+    static const int on = [] {
+        const char* e = getenv("SPARKINFER_CT_NVFP4_ROWS_I8");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    constexpr int BLOCK = 256, VEC = 8;
+    if (!on || !packed_u8 || !group_scale_ue4m3 || !global_scale_dev || !q || !scale) return false;
+    if (rows <= 0 || cols <= 0 || (cols & 15) != 0) return false;
+    const int slots = (cols + BLOCK * VEC - 1) / (BLOCK * VEC);
+    #define SI_NVFP4_ROWS_I8(S) \
+        ct_nvfp4_rows_i8_kernel<BLOCK, VEC, S><<<rows, BLOCK, 0, stream>>>( \
+            reinterpret_cast<const unsigned char*>(packed_u8), \
+            reinterpret_cast<const unsigned char*>(group_scale_ue4m3), \
+            global_scale_dev, q, scale, rows, cols)
+    switch (slots) {
+        case 1: SI_NVFP4_ROWS_I8(1); break;
+        case 2: SI_NVFP4_ROWS_I8(2); break;
+        case 3: SI_NVFP4_ROWS_I8(3); break;
+        case 4: SI_NVFP4_ROWS_I8(4); break;
+        default: return false;
+    }
+    #undef SI_NVFP4_ROWS_I8
+    return cudaPeekAtLastError() == cudaSuccess;
+}
 
 static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_scale_ue4m3,
                                     float global_scale, const float* global_scale_dev,

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -477,6 +477,34 @@ __global__ void ct_dequant_nvfp4_kernel(const unsigned char* __restrict__ packed
 //     every group is 8-byte aligned), and its scale is one byte read once, not sixteen times;
 //   * the 16 results leave as two 16-byte stores.
 // A warp then reads 256 contiguous packed bytes and writes 1 KB, all coalesced.
+// ALU MODES. ncu says this kernel is NOT bandwidth bound -- DRAM 43.7% against SM 80.9% at 78%
+// warps active, with zero local memory. It is the per-element decode that costs, so the levers are
+// the two CUTLASS conversions and the fp32 divide, not the byte count. (Fusing this kernel into the
+// row-quantize that follows it cuts DRAM traffic 4.4x and measures 1.2% SLOWER, which is the
+// control that proves the point -- do not re-try it.)
+//
+//   0  as merged: cutlass conversions, (v * s) / global_scale
+//   1  the integer decodes, same divide -- bit-identical
+//   2  mode 1 plus a hoisted reciprocal, which is NOT bit-identical (measured, see below)
+enum : int { CT_ALU_BASE = 0, CT_ALU_INT = 1, CT_ALU_RCP = 2 };
+
+// e2m1 magnitudes doubled are {0,1,2,3,4,6,8,12} -- all < 16, so the table is the nibbles of one
+// 32-bit literal and the decode is a shift, a mask and an int->float, with no memory touched.
+// Halving the result is exact in binary floating point, so 0.5f * this is exactly the value
+// cutlass::float_e2m1_t::bitcast produces, sign and -0.0 included.
+__device__ __forceinline__ float ct_e2m1_x2(unsigned n) {
+    const unsigned mag = (0xC8643210u >> ((n & 7u) << 2)) & 15u;
+    return __int_as_float(__float_as_int(__uint2float_rn(mag)) | ((n & 8u) << 28));
+}
+// Unsigned E4M3 -> float by assembling the bits. For e>0, (8+m) * 2^(e-10) is exactly the fp32
+// with exponent field e+120 and mantissa m<<20; e==0 is the subnormal leg, an exact multiply.
+__device__ __forceinline__ float ct_ue4m3(unsigned b) {
+    const unsigned e = (b >> 3) & 15u, m = b & 7u;
+    if (e == 0) return (float)m * (1.f / 512.f);
+    return __int_as_float((int)(((e + 120u) << 23) | (m << 20)));
+}
+
+template <int ALU>
 __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ packed,
                                             const unsigned char* __restrict__ group_scale,
                                             float global_scale,
@@ -484,6 +512,7 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
                                             __nv_bfloat16* __restrict__ out,
                                             int rows, int cols) {
     if (global_scale_dev) global_scale = *global_scale_dev;
+    const float inv_gs = (ALU >= CT_ALU_RCP) ? (1.f / global_scale) : 0.f;
     const int ngroups = cols >> 4;
     const int r = blockIdx.y;
     if (r >= rows) return;
@@ -493,7 +522,8 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
     for (int g = blockIdx.x * blockDim.x + threadIdx.x; g < ngroups;
          g += gridDim.x * blockDim.x) {
         const uint2 pk = *reinterpret_cast<const uint2*>(prow + (size_t)g * 8);
-        const float s = float(cutlass::float_ue4m3_t::bitcast(srow[g]));
+        const float s = (ALU >= CT_ALU_INT) ? ct_ue4m3(srow[g])
+                                            : float(cutlass::float_ue4m3_t::bitcast(srow[g]));
         // __align__(16) so the two uint4 stores below are legal; indices are compile-time constant
         // under the unroll, so this stays in registers (verified: ncu local ld/st = 0).
         __align__(16) __nv_bfloat16 o[16];
@@ -502,8 +532,9 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
             const unsigned word = (j < 8) ? pk.x : pk.y;
             const unsigned byte = (word >> (8 * ((j & 7) >> 1))) & 255u;
             const unsigned char nib = (unsigned char)((j & 1) ? (byte >> 4) : (byte & 0xF));
-            const float v = float(cutlass::float_e2m1_t::bitcast(nib));
-            o[j] = __float2bfloat16(v * s / global_scale);
+            const float v = (ALU >= CT_ALU_INT) ? (0.5f * ct_e2m1_x2(nib))
+                                                : float(cutlass::float_e2m1_t::bitcast(nib));
+            o[j] = __float2bfloat16((ALU >= CT_ALU_RCP) ? (v * s * inv_gs) : (v * s / global_scale));
         }
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16)     = *reinterpret_cast<const uint4*>(o);
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16 + 8) = *reinterpret_cast<const uint4*>(o + 8);
@@ -522,15 +553,31 @@ static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_sca
         const char* e = getenv("SPARKINFER_CT_NVFP4_G16");
         return (e && e[0] == '0') ? 0 : 1;
     }();
+    // Which ALU form the group-wise kernel uses; see the enum above. Default is the bit-identical
+    // integer decode. SPARKINFER_CT_NVFP4_ALU picks 0/1/2 for A/B.
+    static const int alu = [] {
+        const char* e = getenv("SPARKINFER_CT_NVFP4_ALU");
+        const int v = e ? atoi(e) : CT_ALU_INT;
+        return (v >= CT_ALU_BASE && v <= CT_ALU_RCP) ? v : CT_ALU_INT;
+    }();
     if (g16 && rows > 0 && cols > 0 && (cols & 15) == 0 &&
         ((reinterpret_cast<size_t>(packed_u8) | reinterpret_cast<size_t>(out_bf16)) & 15u) == 0) {
         const int ngroups = cols >> 4;
         const int threads = 256;
         const int bx = (ngroups + threads - 1) / threads;
-        ct_dequant_nvfp4_g16_kernel<<<dim3(bx > 0 ? bx : 1, rows), threads, 0, stream>>>(
-            reinterpret_cast<const unsigned char*>(packed_u8),
-            reinterpret_cast<const unsigned char*>(group_scale_ue4m3), global_scale,
-            global_scale_dev, reinterpret_cast<__nv_bfloat16*>(out_bf16), rows, cols);
+        const dim3 grid(bx > 0 ? bx : 1, rows);
+        auto* pk = reinterpret_cast<const unsigned char*>(packed_u8);
+        auto* gsc = reinterpret_cast<const unsigned char*>(group_scale_ue4m3);
+        auto* ob = reinterpret_cast<__nv_bfloat16*>(out_bf16);
+        if (alu == CT_ALU_RCP)
+            ct_dequant_nvfp4_g16_kernel<CT_ALU_RCP><<<grid, threads, 0, stream>>>(
+                pk, gsc, global_scale, global_scale_dev, ob, rows, cols);
+        else if (alu == CT_ALU_INT)
+            ct_dequant_nvfp4_g16_kernel<CT_ALU_INT><<<grid, threads, 0, stream>>>(
+                pk, gsc, global_scale, global_scale_dev, ob, rows, cols);
+        else
+            ct_dequant_nvfp4_g16_kernel<CT_ALU_BASE><<<grid, threads, 0, stream>>>(
+                pk, gsc, global_scale, global_scale_dev, ob, rows, cols);
         return;
     }
     const long n = (long)rows * cols;

--- a/kernels/include/sparkinfer/kernels/compressed_tensors.h
+++ b/kernels/include/sparkinfer/kernels/compressed_tensors.h
@@ -36,4 +36,18 @@ void launch_ct_dequant_nvfp4_dev(const void* packed_u8, const void* group_scale_
                                  const float* global_scale_dev, void* out_bf16, int rows, int cols,
                                  cudaStream_t stream = nullptr);
 
+// Fused NVFP4 -> per-row int8 (q[rows,cols] + scale[rows]) for the int8 projection path, which
+// otherwise dequantizes to a bf16 scratch and row-quantizes out of it -- a full bf16 write and
+// re-read of the weight that nothing else ever looks at.
+//
+// Bit-identical to launch_ct_dequant_nvfp4_dev followed by launch_prefill_quantize_rows_i8: the
+// same eight columns per thread, the same bf16 rounding, the same amax over that value set (a max,
+// so associative and exact), the same d = amax/127.0f and roundf, the same amax==0 -> 0 rule.
+//
+// Returns false for shapes it does not handle (cols % 16, or a K needing more than four register
+// slots) so the caller keeps the two-kernel path. SPARKINFER_CT_NVFP4_ROWS_I8=0 disables.
+bool launch_ct_dequant_nvfp4_rows_i8(const void* packed_u8, const void* group_scale_ue4m3,
+                                     const float* global_scale_dev, signed char* q, float* scale,
+                                     int rows, int cols, cudaStream_t stream = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -855,7 +855,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (use_i8 && n_out >= 128) {
             quant_a_i8(A, R, K);
             // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
-            if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
+            bool w_i8_ready = kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st);
+            // Same for a checkpoint NVFP4 weight, which otherwise has no fused arm at all: dq()
+            // writes the whole [n_out,K] as bf16 and the row-quantizer reads it straight back.
+            // Bit-identical to that pair -- see launch_ct_dequant_nvfp4_rows_i8.
+            if (!w_i8_ready && wtype == kernels::SI_QTYPE_NVFP4) {
+                const size_t hdr = (size_t)kernels::SI_NVFP4_HDR;
+                const size_t scale_bytes = (size_t)n_out * K / 16;
+                w_i8_ready = kernels::launch_ct_dequant_nvfp4_rows_i8(
+                    static_cast<const char*>(W) + hdr + scale_bytes,
+                    static_cast<const char*>(W) + hdr,
+                    static_cast<const float*>(W), W_i8, sw, n_out, K, st);
+            }
+            if (!w_i8_ready) {
                 const void* wb = dq(W, wtype, n_out, K);
                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
             }


### PR DESCRIPTION
## Summary

Two changes to the NVFP4 checkpoint dequant path, in the order they had to happen — the second only
works because of the first.

**1. Integer decode.** The group-wise dequant is the largest single item in a ModelOpt
prefill@128, and ncu says it is *not* bandwidth bound: DRAM 43.7% against **SM 80.9%** at 78% warps
active, zero local memory. So the cost is the per-element decode, and this replaces the two CUTLASS
conversions with integer arithmetic:

* **e2m1** — the eight magnitudes doubled are `{0,1,2,3,4,6,8,12}`, all below 16, so the table is
  the nibbles of one 32-bit literal and the decode is a shift, a mask and an int->float, with no
  memory and no select. Halving is exact in binary floating point, so `0.5f *` that is exactly what
  `cutlass::float_e2m1_t::bitcast` produced — sign and `-0.0` included.
* **ue4m3** — for `e > 0`, `(8+m) * 2^(e-10)` is exactly the fp32 with exponent field `e+120` and
  mantissa `m<<20`; `e == 0` stays an exact multiply by `2^-9`.

**2. Decode straight to int8 rows.** With the arithmetic halved the kernel is no longer ALU bound,
so the bf16 round trip it feeds becomes the cost. `proj()` has no native-NVFP4 arm: the weight is
expanded to a bf16 scratch and the row-quantizer reads it straight back — 295 MB of traffic per GDN
qkv projection to produce the 52 MB of int8 the GEMM consumes. Fusing them moves 85 MB, in one
kernel.

That fusion was tried **before** the integer decode and measured **1.2% slower** — it cut DRAM
traffic 4.4x and gained nothing, because both kernels were arithmetic bound. It is included here
because the first change removes that premise, and on top of it the same fusion is worth +4.5%.

`ct_nvfp4_rows_i8_kernel` is `pf_quant_rows_fast_kernel` with the load phase replaced: the same
`VEC=8` slots so a thread owns the same eight columns, the same bf16 rounding, the same `amax` over
that value set, the same `d = amax/127.0f`, `roundf` and `amax == 0 -> 0` rule. The row `amax` is a
**max** — associative and exact in floating point — so no thread mapping can change it.

**Bit-identical throughout**, and measured as such: teacher-forced score dumps are byte-for-byte
equal to main for both stages, top1 1.000000, KL 0.000000.

The `(v * s) / global_scale` division is deliberately left as a division; hoisting a reciprocal is
faster but is not bit-identical. It stays available as `SPARKINFER_CT_NVFP4_ALU=2` with its price
measured: **+0.88%** for KL 0.004494, which is a poor trade for a weight dequant.
`SPARKINFER_CT_NVFP4_ALU=0` restores the CUTLASS conversions and
`SPARKINFER_CT_NVFP4_ROWS_I8=0` the two-kernel path, so every arm comes out of one binary.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 93.90 |
| after (this PR) | 94.02 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 3295.99 |
| after prefill (this PR) | 3682.85 |

```text
# bench_sweep_run <ModelOpt dir> 128 128 5 16384 5 -- the harness the eval uses
# (qwen3_gguf_bench ... sweep, median of 5 reps). RTX 5090 sm_120, main @ 91ce034.
# MAIN = ALU 0 / FUSE 0 (i.e. main), ALU = stage 1 only, ALU+FUSE = this PR.
# Arm ORDER IS ROTATED through all three positions between rounds.

r1 MAIN      decode128=94.9264  pp128=3340.0743  pp16k=9736.4356
r1 ALU       decode128=94.5780  pp128=3545.9325  pp16k=9578.7581
r1 ALU+FUSE  decode128=94.2006  pp128=3688.4612  pp16k=9472.9901
r2 ALU+FUSE  decode128=94.0172  pp128=3682.8516  pp16k=9440.7430
r2 MAIN      decode128=93.8975  pp128=3292.0514  pp16k=9397.1759
r2 ALU       decode128=93.8766  pp128=3528.1350  pp16k=9394.3384
r3 ALU       decode128=93.7822  pp128=3533.2674  pp16k=9381.2459
r3 ALU+FUSE  decode128=93.8387  pp128=3672.3599  pp16k=9384.8040
r3 MAIN      decode128=93.8694  pp128=3295.9885  pp16k=9374.6885

prefill@128  3295.99 -> 3682.85 pp (+11.74%); the integer decode alone is +7.20%, the fusion
             adds +4.5% on top. Fully disjoint: main's best round 3340.07 < ALU's worst 3528.14
             < this PR's worst 3672.36, and this PR wins from every position in the rotation.
decode@128   93.90 -> 94.02 and prefill@16k 9397.18 -> 9440.74: both flat. Decode reaches these
             weights through the NVFP4 GEMV, not this dequant, so it is untouched by design.

Accuracy: score dumps BYTE-IDENTICAL to main at both stages (top1 1.000000, KL 0.000000).
Control, for reference only: SPARKINFER_CT_NVFP4_ALU=2 (hoisted reciprocal) is +0.88% further
and top1 1.000000 / KL 0.004494, so it is not the default.

No-regression guards, same build, ALU=1/FUSE=1 vs ALU=0/FUSE=0:
  Qwen3.6  ctx 0/512/4k/16k/32k   decode  1.0028 / 1.0032 / 1.0037 / 1.0035 / 1.0029
                                  prefill      -  / 1.0064 / 1.0082 / 1.0086 / 1.0084
  Qwen3.8  ctx 0/4k/16k           decode  1.0028 / 1.0024 / 1.0026
                                  prefill      -  / 1.0115 / 1.0096
ctest: 100% tests passed, 0 tests failed out of 19.
```
