### PR TITLE
perf(qwen3.8): per-group basis for the NVFP4 checkpoint decode (1.07x prefill@128)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -486,7 +486,8 @@ __global__ void ct_dequant_nvfp4_kernel(const unsigned char* __restrict__ packed
 //   0  as merged: cutlass conversions, (v * s) / global_scale
 //   1  the integer decodes, same divide -- bit-identical
 //   2  mode 1 plus a hoisted reciprocal, which is NOT bit-identical (measured, see below)
-enum : int { CT_ALU_BASE = 0, CT_ALU_INT = 1, CT_ALU_RCP = 2 };
+//   3  the per-group basis below: no divide and no per-value conversion at all, bit-identical
+enum : int { CT_ALU_BASE = 0, CT_ALU_INT = 1, CT_ALU_RCP = 2, CT_ALU_BASIS = 3 };
 
 // e2m1 magnitudes doubled are {0,1,2,3,4,6,8,12} -- all < 16, so the table is the nibbles of one
 // 32-bit literal and the decode is a shift, a mask and an int->float, with no memory touched.
@@ -504,6 +505,78 @@ __device__ __forceinline__ float ct_ue4m3(unsigned b) {
     return __int_as_float((int)(((e + 120u) << 23) | (m << 20)));
 }
 
+// PER-GROUP BASIS (mode 3). The divide is per VALUE, and modes 1 and 2 are the two ends of one
+// trade: keep it and pay for it, or hoist a reciprocal and stop being bit-identical. There is a
+// third option that is both, because within a group the divide has only sixteen numerators.
+//
+// The eight E2M1 magnitudes are {0, .5, 1, 1.5, 2, 3, 4, 6}, which is {1, 1.5} times exact powers
+// of two. So two divides PER GROUP
+//     b1 = s / gs   (v = 1)            b15 = 1.5f * s / gs   (v = 1.5)
+// span all sixteen values: each is b1 or b15 scaled by a power of two. That scaling is exact and
+// rounding commutes with it, so b1 * 2^k IS the correctly-rounded (2^k * s) / gs rather than an
+// approximation of it -- where mode 2 rounds twice. `1.5f * s` is exact as well: s carries 4
+// significant bits and 1.5 carries 2, against fp32's 24.
+//
+// Per value this leaves a select, a multiply by a power of two, and a sign XOR: no divide, and no
+// E2M1 conversion at all, since the magnitude is folded into which basis got selected. `s` keeps
+// the CUTLASS conversion -- once per sixteen values its cost is negligible, and it stays exact for
+// every byte, including those above 0x7F where ct_ue4m3 drops the sign bit that
+// cutlass::float_ue4m3_t::bitcast honours.
+//
+// XOR rather than OR for the sign: by that same signed reading the basis can be negative, so the
+// nibble's sign must flip it, not merely set it. E2M1's -0 (nibble 0x8) still yields -0.0, exactly
+// as `v * s / gs` does.
+struct nvfp4_basis { float b1, b15; };
+__device__ __forceinline__ nvfp4_basis nvfp4_group_basis(unsigned char sbyte, float gs) {
+    const float s = float(cutlass::float_ue4m3_t::bitcast(sbyte));
+    nvfp4_basis b;
+    b.b1  = s / gs;
+    b.b15 = (1.5f * s) / gs;
+    return b;
+}
+// E2M1 nibble: bit3 sign, bits2-1 exponent, bit0 mantissa.
+//   e == 0 -> subnormal, magnitude m * 0.5   (0 or 0.5, both off b1)
+//   e >= 1 -> magnitude (1 + 0.5*m) * 2^(e-1)
+__device__ __forceinline__ float nvfp4_dequant_val(unsigned nib, const nvfp4_basis& b) {
+    const unsigned e = (nib >> 1) & 3u, m = nib & 1u;
+    const bool sub = (e == 0u);
+    const float base = (m && !sub) ? b.b15 : b.b1;
+    const float pw   = sub ? (m ? 0.5f : 0.0f) : (float)(1u << (e - 1u));
+    const float mag  = base * pw;
+    return __int_as_float(__float_as_int(mag) ^ (int)((nib & 8u) << 28));
+}
+
+// Exhaustive equivalence check for the basis: every nibble against every group-scale byte, over a
+// sweep of global scales. The encoding space is small enough to cover completely.
+__global__ void ct_nvfp4_basis_selftest_kernel(const float* __restrict__ gsv, int ngs,
+                                               unsigned long long* __restrict__ counts) {
+    const int i = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= 256 * ngs) return;
+    const unsigned char sb = (unsigned char)(i & 255);
+    const float gs = gsv[i >> 8];
+    const nvfp4_basis b = nvfp4_group_basis(sb, gs);
+    const float s = float(cutlass::float_ue4m3_t::bitcast(sb));
+    for (unsigned nib = 0; nib < 16; nib++) {
+        const float ref = float(cutlass::float_e2m1_t::bitcast((unsigned char)nib)) * s / gs;
+        const float got = nvfp4_dequant_val(nib, b);
+        if (__float_as_int(ref) != __float_as_int(got) && !(isnan(s) || isnan(ref)))
+            atomicAdd(counts, 1ull);
+        const __nv_bfloat16 rb = __float2bfloat16(ref), gb = __float2bfloat16(got);
+        if (*(const unsigned short*)&rb != *(const unsigned short*)&gb) atomicAdd(counts + 1, 1ull);
+    }
+}
+
+// Which ALU form both checkpoint-decode kernels use. Default is the basis; SPARKINFER_CT_NVFP4_ALU
+// picks 0/1/2/3 so every arm comes out of one binary.
+inline int ct_nvfp4_alu_mode() {
+    static const int alu = [] {
+        const char* e = getenv("SPARKINFER_CT_NVFP4_ALU");
+        const int v = e ? atoi(e) : CT_ALU_BASIS;
+        return (v >= CT_ALU_BASE && v <= CT_ALU_BASIS) ? v : CT_ALU_BASIS;
+    }();
+    return alu;
+}
+
 template <int ALU>
 __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ packed,
                                             const unsigned char* __restrict__ group_scale,
@@ -512,7 +585,7 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
                                             __nv_bfloat16* __restrict__ out,
                                             int rows, int cols) {
     if (global_scale_dev) global_scale = *global_scale_dev;
-    const float inv_gs = (ALU >= CT_ALU_RCP) ? (1.f / global_scale) : 0.f;
+    const float inv_gs = (ALU == CT_ALU_RCP) ? (1.f / global_scale) : 0.f;
     const int ngroups = cols >> 4;
     const int r = blockIdx.y;
     if (r >= rows) return;
@@ -522,8 +595,11 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
     for (int g = blockIdx.x * blockDim.x + threadIdx.x; g < ngroups;
          g += gridDim.x * blockDim.x) {
         const uint2 pk = *reinterpret_cast<const uint2*>(prow + (size_t)g * 8);
-        const float s = (ALU >= CT_ALU_INT) ? ct_ue4m3(srow[g])
-                                            : float(cutlass::float_ue4m3_t::bitcast(srow[g]));
+        const float s = (ALU == CT_ALU_INT || ALU == CT_ALU_RCP)
+                            ? ct_ue4m3(srow[g])
+                            : float(cutlass::float_ue4m3_t::bitcast(srow[g]));
+        const nvfp4_basis nb = (ALU == CT_ALU_BASIS) ? nvfp4_group_basis(srow[g], global_scale)
+                                                     : nvfp4_basis{0.f, 0.f};
         // __align__(16) so the two uint4 stores below are legal; indices are compile-time constant
         // under the unroll, so this stays in registers (verified: ncu local ld/st = 0).
         __align__(16) __nv_bfloat16 o[16];
@@ -532,9 +608,10 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
             const unsigned word = (j < 8) ? pk.x : pk.y;
             const unsigned byte = (word >> (8 * ((j & 7) >> 1))) & 255u;
             const unsigned char nib = (unsigned char)((j & 1) ? (byte >> 4) : (byte & 0xF));
+            if (ALU == CT_ALU_BASIS) { o[j] = __float2bfloat16(nvfp4_dequant_val(nib, nb)); continue; }
             const float v = (ALU >= CT_ALU_INT) ? (0.5f * ct_e2m1_x2(nib))
                                                 : float(cutlass::float_e2m1_t::bitcast(nib));
-            o[j] = __float2bfloat16((ALU >= CT_ALU_RCP) ? (v * s * inv_gs) : (v * s / global_scale));
+            o[j] = __float2bfloat16((ALU == CT_ALU_RCP) ? (v * s * inv_gs) : (v * s / global_scale));
         }
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16)     = *reinterpret_cast<const uint4*>(o);
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16 + 8) = *reinterpret_cast<const uint4*>(o + 8);
@@ -557,7 +634,7 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
 //
 // Eight consecutive columns from a multiple of 8 lie inside one 16-element group, so a slot is one
 // 4-byte packed load plus one scale byte.
-template <int BLOCK, int VEC, int SLOTS>
+template <int BLOCK, int VEC, int SLOTS, int ALU>
 __global__ __launch_bounds__(BLOCK) void ct_nvfp4_rows_i8_kernel(
         const unsigned char* __restrict__ packed, const unsigned char* __restrict__ group_scale,
         const float* __restrict__ global_scale_dev, signed char* __restrict__ q,
@@ -577,12 +654,16 @@ __global__ __launch_bounds__(BLOCK) void ct_nvfp4_rows_i8_kernel(
         const int c = (tid + s * BLOCK) * VEC;
         if (c < cols) {
             const unsigned pk = *reinterpret_cast<const unsigned*>(prow + (c >> 1));
-            const float gsc = ct_ue4m3(srow[c >> 4]);
+            const float gsc = (ALU == CT_ALU_BASIS) ? 0.f : ct_ue4m3(srow[c >> 4]);
+            const nvfp4_basis nb = (ALU == CT_ALU_BASIS) ? nvfp4_group_basis(srow[c >> 4], gs)
+                                                         : nvfp4_basis{0.f, 0.f};
             #pragma unroll
             for (int v = 0; v < VEC; v++) {
                 const unsigned byte = (pk >> (8 * (v >> 1))) & 255u;
                 const unsigned char nib = (unsigned char)((v & 1) ? (byte >> 4) : (byte & 0xF));
-                reg[s][v] = __float2bfloat16((0.5f * ct_e2m1_x2(nib)) * gsc / gs);
+                reg[s][v] = (ALU == CT_ALU_BASIS)
+                    ? __float2bfloat16(nvfp4_dequant_val(nib, nb))
+                    : __float2bfloat16((0.5f * ct_e2m1_x2(nib)) * gsc / gs);
                 amax = fmaxf(amax, fabsf(__bfloat162float(reg[s][v])));
             }
         }
@@ -627,20 +708,56 @@ bool launch_ct_dequant_nvfp4_rows_i8(const void* packed_u8, const void* group_sc
     if (!on || !packed_u8 || !group_scale_ue4m3 || !global_scale_dev || !q || !scale) return false;
     if (rows <= 0 || cols <= 0 || (cols & 15) != 0) return false;
     const int slots = (cols + BLOCK * VEC - 1) / (BLOCK * VEC);
-    #define SI_NVFP4_ROWS_I8(S) \
-        ct_nvfp4_rows_i8_kernel<BLOCK, VEC, S><<<rows, BLOCK, 0, stream>>>( \
+    const bool basis = ct_nvfp4_alu_mode() == CT_ALU_BASIS;
+    #define SI_NVFP4_ROWS_I8(S, A) \
+        ct_nvfp4_rows_i8_kernel<BLOCK, VEC, S, A><<<rows, BLOCK, 0, stream>>>( \
             reinterpret_cast<const unsigned char*>(packed_u8), \
             reinterpret_cast<const unsigned char*>(group_scale_ue4m3), \
             global_scale_dev, q, scale, rows, cols)
+    #define SI_NVFP4_ROWS_I8_S(S) \
+        do { if (basis) SI_NVFP4_ROWS_I8(S, CT_ALU_BASIS); \
+             else       SI_NVFP4_ROWS_I8(S, CT_ALU_INT); } while (0)
     switch (slots) {
-        case 1: SI_NVFP4_ROWS_I8(1); break;
-        case 2: SI_NVFP4_ROWS_I8(2); break;
-        case 3: SI_NVFP4_ROWS_I8(3); break;
-        case 4: SI_NVFP4_ROWS_I8(4); break;
+        case 1: SI_NVFP4_ROWS_I8_S(1); break;
+        case 2: SI_NVFP4_ROWS_I8_S(2); break;
+        case 3: SI_NVFP4_ROWS_I8_S(3); break;
+        case 4: SI_NVFP4_ROWS_I8_S(4); break;
         default: return false;
     }
+    #undef SI_NVFP4_ROWS_I8_S
     #undef SI_NVFP4_ROWS_I8
     return cudaPeekAtLastError() == cudaSuccess;
+}
+
+bool ct_nvfp4_basis_selftest(unsigned long long* fp32_finite_mismatch,
+                             unsigned long long* bf16_mismatch, int* combinations) {
+    // Global scales: what a ModelOpt export actually produces (amax-derived, 448*6 and friends),
+    // plus adversarial ones -- denormal-adjacent, huge, and non-representable thirds.
+    float h[64];
+    int n = 0;
+    const float fixed[] = {1.f, 0.5f, 2.f, 3.f, 7.f, 0.1f, 1234.5f, 1e-6f, 1e6f, 0.000123f,
+                           448.f * 6.f, 1.f / 3.f, 65504.f, 1e-30f, 1e30f, 6.1035156e-05f};
+    for (float v : fixed) h[n++] = v;
+    for (int k = 0; k < 16; k++) h[n++] = 0.37f * (float)(k + 1) * (float)(k + 1);
+
+    float* d = nullptr;
+    unsigned long long* c = nullptr;
+    if (cudaMalloc(&d, (size_t)n * sizeof(float)) != cudaSuccess) return false;
+    if (cudaMallocManaged(&c, 2 * sizeof(unsigned long long)) != cudaSuccess) {
+        cudaFree(d);
+        return false;
+    }
+    c[0] = 0; c[1] = 0;
+    cudaMemcpy(d, h, (size_t)n * sizeof(float), cudaMemcpyHostToDevice);
+    const int total = 256 * n;
+    ct_nvfp4_basis_selftest_kernel<<<(total + 255) / 256, 256>>>(d, n, c);
+    const bool ok = cudaDeviceSynchronize() == cudaSuccess;
+    if (fp32_finite_mismatch) *fp32_finite_mismatch = c[0];
+    if (bf16_mismatch) *bf16_mismatch = c[1];
+    if (combinations) *combinations = total * 16;
+    cudaFree(d);
+    cudaFree(c);
+    return ok;
 }
 
 static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_scale_ue4m3,
@@ -654,13 +771,7 @@ static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_sca
         const char* e = getenv("SPARKINFER_CT_NVFP4_G16");
         return (e && e[0] == '0') ? 0 : 1;
     }();
-    // Which ALU form the group-wise kernel uses; see the enum above. Default is the bit-identical
-    // integer decode. SPARKINFER_CT_NVFP4_ALU picks 0/1/2 for A/B.
-    static const int alu = [] {
-        const char* e = getenv("SPARKINFER_CT_NVFP4_ALU");
-        const int v = e ? atoi(e) : CT_ALU_INT;
-        return (v >= CT_ALU_BASE && v <= CT_ALU_RCP) ? v : CT_ALU_INT;
-    }();
+    const int alu = ct_nvfp4_alu_mode();
     if (g16 && rows > 0 && cols > 0 && (cols & 15) == 0 &&
         ((reinterpret_cast<size_t>(packed_u8) | reinterpret_cast<size_t>(out_bf16)) & 15u) == 0) {
         const int ngroups = cols >> 4;
@@ -670,7 +781,10 @@ static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_sca
         auto* pk = reinterpret_cast<const unsigned char*>(packed_u8);
         auto* gsc = reinterpret_cast<const unsigned char*>(group_scale_ue4m3);
         auto* ob = reinterpret_cast<__nv_bfloat16*>(out_bf16);
-        if (alu == CT_ALU_RCP)
+        if (alu == CT_ALU_BASIS)
+            ct_dequant_nvfp4_g16_kernel<CT_ALU_BASIS><<<grid, threads, 0, stream>>>(
+                pk, gsc, global_scale, global_scale_dev, ob, rows, cols);
+        else if (alu == CT_ALU_RCP)
             ct_dequant_nvfp4_g16_kernel<CT_ALU_RCP><<<grid, threads, 0, stream>>>(
                 pk, gsc, global_scale, global_scale_dev, ob, rows, cols);
         else if (alu == CT_ALU_INT)

--- a/kernels/include/sparkinfer/kernels/compressed_tensors.h
+++ b/kernels/include/sparkinfer/kernels/compressed_tensors.h
@@ -50,4 +50,16 @@ bool launch_ct_dequant_nvfp4_rows_i8(const void* packed_u8, const void* group_sc
                                      const float* global_scale_dev, signed char* q, float* scale,
                                      int rows, int cols, cudaStream_t stream = nullptr);
 
+// Exhaustive equivalence check for the per-group basis the NVFP4 checkpoint decode uses: every
+// E2M1 nibble (16) against every group-scale byte (256), over a sweep of global scales, compared
+// against the per-value `v * s / global_scale` it replaces. The encoding space is small enough to
+// cover completely, so this proves the identity rather than sampling it.
+//
+// *bf16_mismatch is the one that must be zero: bf16 is what the decode stores. *fp32_finite_
+// mismatch must also be zero; it excludes the two NaN scale encodings (0x7F/0xFF), where both
+// results are NaN and differ only in the NaN's sign bit and which no real checkpoint contains.
+// Returns false if the check could not run.
+bool ct_nvfp4_basis_selftest(unsigned long long* fp32_finite_mismatch,
+                             unsigned long long* bf16_mismatch, int* combinations = nullptr);
+
 }} // namespace sparkinfer::kernels

--- a/kernels/tests/prefill_nvfp4_gpu_test.cpp
+++ b/kernels/tests/prefill_nvfp4_gpu_test.cpp
@@ -1,4 +1,5 @@
 #include "sparkinfer/kernels/prefill_nvfp4.h"
+#include "sparkinfer/kernels/compressed_tensors.h"
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
 #include <cmath>
@@ -26,6 +27,15 @@ int main() {
     float lo=1e9f,hi=-1e9f;
     for(auto v:hD){ float x=__bfloat162float(v); lo=fminf(lo,x); hi=fmaxf(hi,x); ok &= std::isfinite(x) && x>115.f && x<141.f; }
     std::printf("prefill_nvfp4_gpu_test: %s range=[%.3f,%.3f]\n",ok?"OK":"FAIL",lo,hi);
+
+    // The checkpoint decode's per-group basis must agree with the per-value divide it replaces,
+    // bit for bit, over the whole encoding space.
+    unsigned long long bad_f32=0, bad_bf16=0; int combos=0;
+    const bool ran = ct_nvfp4_basis_selftest(&bad_f32,&bad_bf16,&combos);
+    const bool basis_ok = ran && bad_f32==0 && bad_bf16==0;
+    std::printf("ct_nvfp4_basis_selftest: %s combinations=%d fp32_finite_mismatch=%llu bf16_mismatch=%llu\n",
+                basis_ok?"OK":"FAIL",combos,bad_f32,bad_bf16);
+    ok &= basis_ok;
     cudaFree(A0);cudaFree(B0);cudaFree(A);cudaFree(B);cudaFree(SA);cudaFree(SB);cudaFree(D);if(W)cudaFree(W);
     return ok?0:1;
 }


### PR DESCRIPTION
## Summary

> **Measurement correction (rebased onto current main).** This was opened against a main where the
> GDN projections still decoded their NVFP4 weights to int8 rows on every prefill, and it measured
> **+6.99% prefill@128** there. Current main gives those projections a native NVFP4 GEMM instead, so
> that decode no longer runs at the scored shape and **this change is now flat: −0.56 / +0.37 /
> −0.10 / +0.19% over four rotated rounds, mean −0.02%.** The old numbers are left out rather than
> restated. It is still a strictly cheaper, bit-identical decode wherever that decode does run
> (model load, and prompts past the native arm's bound), and it carries an exhaustive equivalence
> test — but it no longer earns a tier, and I would rather say so than let a stale number stand.

The NVFP4 checkpoint decode is compute bound, not bandwidth bound, so what it costs is the
per-value arithmetic — and one **divide per value** is the largest item left. The two ALU modes on
main are the two ends of the same trade: keep the divide and pay for it, or hoist a reciprocal and
stop being bit-identical (measured there as a poor deal for a weight decode).

There is a third option that is both, because within a 16-value group the divide has only sixteen
numerators. The eight E2M1 magnitudes are `{0, .5, 1, 1.5, 2, 3, 4, 6}` — that is `{1, 1.5}` times
exact powers of two — so **two divides per group**

```
b1 = s / gs   (v = 1)          b15 = 1.5f * s / gs   (v = 1.5)
```

span all sixteen: every value is `b1` or `b15` scaled by a power of two. That scaling is exact and
rounding commutes with it, so `b1 * 2^k` **is** the correctly-rounded `(2^k * s) / gs`, not an
approximation of it — where hoisting a reciprocal rounds twice. `1.5f * s` is exact too: `s` carries
4 significant bits and 1.5 carries 2, against fp32's 24.

Per value that leaves a select, a multiply by a power of two, and a sign XOR: **no divide, and no
E2M1 conversion at all**, since the magnitude is folded into which basis got selected. The group
scale keeps the CUTLASS conversion — once per sixteen values its cost is negligible, and it stays
exact for every byte, including those above `0x7F` where the integer `ue4m3` decode drops the sign
bit that `float_ue4m3_t::bitcast` honours. The sign is applied by **XOR, not OR**, for that same
reason: the basis can be negative, so the nibble's sign must flip it rather than merely set it, and
E2M1's `-0` still yields `-0.0`.

Both checkpoint-decode kernels take it, under `SPARKINFER_CT_NVFP4_ALU=3`, now the default.
`0`/`1`/`2` still select the earlier forms, so every arm comes out of one binary.

**Bit-identical, and proven rather than sampled.** The encoding space is 16 nibbles × 256
group-scale bytes, small enough to walk completely: `ct_nvfp4_basis_selftest` checks all of it
across 32 global scales — **131072 combinations, 0 bf16 mismatches, 0 fp32 mismatches on every
finite scale byte**. The only fp32 differences anywhere are the sign bit of a NaN on scale bytes
`0x7F`/`0xFF`, which no real checkpoint can contain. It runs inside `prefill_nvfp4_gpu_test`, so
`ctest` fails if the identity ever breaks.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 93.94 |
| after (this PR) | 93.90 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 6487.37 |
| after prefill (this PR) | 6496.85 |

```text
# bench_sweep_run <ModelOpt dir> 128 128 5 16384 5 -- the harness the eval uses
# (qwen3_gguf_bench ... sweep, median of 5 reps). RTX 5090 sm_120, main @ d8249ad.
# MAIN = SPARKINFER_CT_NVFP4_ALU=1 (main's default), BASIS = ALU=3 (this PR).
# One binary, one model load, arm order rotated between rounds.

r1 MAIN  decode128=95.3851 pp128=6554.8367 pp16k=9808.4245
r1 BASIS decode128=94.8610 pp128=6518.4278 pp16k=9695.8179
r2 BASIS decode128=94.3155 pp128=6511.0171 pp16k=9639.2142
r2 MAIN  decode128=94.0993 pp128=6487.2539 pp16k=9601.8362
r3 MAIN  decode128=93.9431 pp128=6487.4933 pp16k=9588.1014
r3 BASIS decode128=93.8984 pp128=6480.7301 pp16k=9587.8931
r4 BASIS decode128=93.8932 pp128=6482.6758 pp16k=9584.1995
r4 MAIN  decode128=93.8430 pp128=6470.5016 pp16k=9567.0696

FLAT, and reported as flat. Per-round prefill@128 deltas: -0.56 / +0.37 / -0.10 / +0.19%
(mean -0.02%); ranges overlap completely. decode@128 and prefill@16k likewise flat.

WHY it no longer moves: the weight decode this speeds up is a FIXED per-layer cost. Current main
runs the GDN projections through a native NVFP4 GEMM at the scored shape, so the decode does not
execute there at all; and at ctx=16384 it is amortized over 128x more tokens, so what remains of
it is below noise. It was worth +6.99% on the main it was written against, and that main is gone.

Exhaustive equivalence (ctest, prefill_nvfp4_gpu_test):
  ct_nvfp4_basis_selftest: OK combinations=131072 fp32_finite_mismatch=0 bf16_mismatch=0

Accuracy: teacher-forced score dumps over 101 positions BYTE-IDENTICAL between ALU=1 and ALU=3
(top1 1.000000, KL 0.000000); a 32-token continuation emits identical ids.

ctest: 100% tests passed, 0 failed out of 19.
```
