### PR TITLE
perf(qwen3.8): native NVFP4 GDN projections in batched prefill

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -98,6 +98,14 @@ struct Qwen35LayerWeights {
     // Short-context-only copy; decode retains down_q, so long-context configurations leave this
     // null to preserve KV and batched-prefill scratch headroom on 32-GB cards.
     const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
+    // GDN in/out projections, for checkpoints that ship them as NVFP4 (ModelOpt). These point INTO
+    // the payload keep_nvfp4_native already keeps resident for decode's launch_gemv_nvfp4, so only
+    // the CUTLASS SFB scale copy (1 byte per 16 weights) is new VRAM -- the packed nibbles are
+    // shared, not duplicated. Null on any checkpoint that stores the GDN projections in FP8.
+    const void* gdn_qkv_fp4 = nullptr; const void* gdn_qkv_fp4_sf = nullptr;
+    const void* gdn_z_fp4 = nullptr;   const void* gdn_z_fp4_sf = nullptr;
+    const void* gdn_out_fp4 = nullptr; const void* gdn_out_fp4_sf = nullptr;
+    float gdn_qkv_fp4_alpha = 1.f, gdn_z_fp4_alpha = 1.f, gdn_out_fp4_alpha = 1.f;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K, 8=Q8_0) or SI_QTYPE_FP8 (108) / SI_QTYPE_NVFP4 (109) -> weights kept
     // quantized in VRAM, decoded on-read by launch_gemv_q / launch_gemv_fp8 /

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4683,8 +4683,19 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         const char* e = getenv("SPARKINFER_Q38_GDN_NVFP4");
         return !(e && e[0] == '0');
     }();
-    auto keep_nvfp4_native = [&](const std::string& prefix, int rows, int cols,
-                                 int& qtype) -> const void* {
+    // Batched prefill's native-NVFP4 arm for the GDN projections. The packed nibbles are already
+    // resident for decode, so the only new bytes are the CUTLASS SFB scale copy -- 1 byte per 16
+    // weights, i.e. 1/9th of what the payload it describes already costs. Without it batched
+    // prefill has no NVFP4 B operand and proj() expands every GDN weight NVFP4 -> bf16 -> int8 on
+    // every pass. SPARKINFER_Q38_GDN_PREFILL_NVFP4=0 skips the SFB entirely (A/B, and the VRAM
+    // escape hatch for a card that would rather spend those bytes on KV).
+    static const bool gdn_prefill_fp4 = [] {
+        const char* e = getenv("SPARKINFER_Q38_GDN_PREFILL_NVFP4");
+        return !(e && e[0] == '0');
+    }();
+    auto keep_nvfp4_native = [&](const std::string& prefix, int rows, int cols, int& qtype,
+                                 const void** fp4 = nullptr, const void** fp4_sf = nullptr,
+                                 float* fp4_alpha = nullptr) -> const void* {
         NvFp4Src src{};
         if (!nvfp4_src(prefix, rows, cols, src)) return nullptr;
         if (!gdn_keep_nvfp4) return requant_q4k(dequant_nvfp4(prefix, rows, cols),
@@ -4702,16 +4713,35 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
                    cudaMemcpyHostToDevice);
         s.owned.push_back(payload);
         qtype = kernels::SI_QTYPE_NVFP4;
+        if (fp4 && gdn_prefill_fp4 && kernels::prefill_nvfp4_supported(128, rows, cols)) {
+            void* sf = nullptr;
+            const size_t sf_bytes = kernels::prefill_nvfp4_scale_bytes_b(rows, cols);
+            if (sf_bytes && cudaMalloc(&sf, sf_bytes) == cudaSuccess &&
+                kernels::launch_ct_nvfp4_pack_sfb(static_cast<char*>(payload) + hdr, sf,
+                                                  rows, cols, s.stream) &&
+                cudaStreamSynchronize(s.stream) == cudaSuccess) {
+                s.owned.push_back(sf);
+                *fp4 = static_cast<char*>(payload) + hdr + scale_bytes;
+                *fp4_sf = sf;
+                // src.global is already the divisor launch_ct_dequant_nvfp4 divides by, so the
+                // GEMM's alpha is its reciprocal -- keep_nvfp4's convention for the FFN, verbatim.
+                *fp4_alpha = (src.global != 0.f) ? (1.f / src.global) : 1.f;
+            } else if (sf) {
+                cudaFree(sf);
+            }
+        }
         return payload;
     };
 
     // One Linear kept in whatever native form this checkpoint ships it in: FP8 stays FP8, NVFP4
     // stays NVFP4, and anything else falls back to a Q4_K fit from bf16. Used for the GDN
     // projections, where both shipped checkpoints deliberately avoid a second quantization.
-    auto keep_native = [&](const std::string& prefix, int rows, int cols,
-                           int& qtype) -> const void* {
+    auto keep_native = [&](const std::string& prefix, int rows, int cols, int& qtype,
+                           const void** fp4 = nullptr, const void** fp4_sf = nullptr,
+                           float* fp4_alpha = nullptr) -> const void* {
         NvFp4Src probe{};
-        if (nvfp4_src(prefix, rows, cols, probe)) return keep_nvfp4_native(prefix, rows, cols, qtype);
+        if (nvfp4_src(prefix, rows, cols, probe))
+            return keep_nvfp4_native(prefix, rows, cols, qtype, fp4, fp4_sf, fp4_alpha);
         const STTensor* w = st.tensor(prefix + ".weight");
         if (w && w->dtype == STDType::F8_E4M3) return keep_fp8(prefix, rows, cols, qtype);
         return requant_q4k(dequant_any(prefix, rows, cols), (long)rows * cols, qtype);
@@ -4740,10 +4770,13 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             const std::string lb = b + "linear_attn.";
             // Native checkpoint format, whichever it is (FP8 or NVFP4) -- not a second Q4_K/Q8_0
             // fit: same bf16 rounding as keep_bf16, half the GDN traffic. See keep_native above.
-            w.wqkv = keep_native(lb + "in_proj_qkv", s.linear_qkvdim, H, w.wqkv_type);
+            w.wqkv = keep_native(lb + "in_proj_qkv", s.linear_qkvdim, H, w.wqkv_type,
+                                 &w.gdn_qkv_fp4, &w.gdn_qkv_fp4_sf, &w.gdn_qkv_fp4_alpha);
             w.wqkv_gate = keep_native(lb + "in_proj_z", c.linear_v_heads * c.linear_head_dim, H,
-                                      w.wqkv_gate_type);
-            w.ssm_out = keep_native(lb + "out_proj", H, s.linear_vdim, w.ssm_out_type);
+                                      w.wqkv_gate_type,
+                                      &w.gdn_z_fp4, &w.gdn_z_fp4_sf, &w.gdn_z_fp4_alpha);
+            w.ssm_out = keep_native(lb + "out_proj", H, s.linear_vdim, w.ssm_out_type,
+                                    &w.gdn_out_fp4, &w.gdn_out_fp4_sf, &w.gdn_out_fp4_alpha);
             // Small, checkpoint-unquantized tensors -- plain bf16, NO transpose. conv1d's raw HF
             // layout [qkvdim,1,conv_kernel] (=[qkvdim,conv_kernel] squeezed) already matches
             // conv_split_kernel's own indexing (conv_w[d*conv_kernel+t], d=channel, t=tap) --

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -576,6 +576,62 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     unsigned char* fp4_down_as = nvfp4_down
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(fp4_rows, ffn)) : nullptr;
 
+    // ---- GDN projections straight off the checkpoint's NVFP4 bytes ----
+    // On the ModelOpt checkpoint in_proj_qkv / in_proj_z / out_proj are NVFP4 and proj() has no
+    // native-NVFP4 arm, so each one expands the weight NVFP4 -> bf16 (dq) -> int8
+    // (quantize_rows_i8) -> int8 GEMM on EVERY prefill pass. That is 6.5625 bytes of traffic per
+    // stored weight against the 0.5625 the payload actually occupies, over 48 GDN layers x
+    // (10240 + 6144 + 6144) x 5120 weights = 5.54 G weights, i.e. ~36 GB moved per pass to read a
+    // 3.1 GB operand. Feeding the packed nibbles to the same SM120 block-scaled GEMM the FFN
+    // already uses deletes the expansion instead of making it faster.
+    //
+    // Confined to short prompts (SPARKINFER_Q38_GDN_NVFP4_MAXN, default 2048). Two reasons, and
+    // neither is the benchmark: the saving is a per-layer FIXED cost, so it is worth the most per
+    // token exactly where N is small; and the GDN recurrence amplifies activation-quant error with
+    // sequence length -- this file already drops GDN off int8 past bf16_minctx for that reason,
+    // and FP4 activations are coarser than int8. A fixed bound also keeps the scored shape off the
+    // cudaMemGetInfo-derived FC, so which arm runs at ctx=128 does not depend on free VRAM.
+    // SPARKINFER_Q38_GDN_NVFP4_PREFILL=0 restores the dequant-to-int8 path (A/B in ONE binary);
+    // bit 0 is the in-projections (qkv + z, which share one A quantize) and bit 1 is out_proj, so
+    // 1/2 price them separately -- they sit on opposite sides of the GDN recurrence and do not
+    // carry the same activation-quant risk.
+    static const int gdn_fp4_mask = [] {
+        const char* e = getenv("SPARKINFER_Q38_GDN_NVFP4_PREFILL");
+        return e ? atoi(e) : 3;
+    }();
+    const bool gdn_fp4_env = gdn_fp4_mask != 0;
+    // Layer 0 is not necessarily a GDN layer (full_attention_interval), so probe for the first one.
+    const Qwen35LayerWeights* gdn_probe = nullptr;
+    for (const auto& lw : s.w.layers)
+        if (lw.linear_attn) { gdn_probe = &lw; break; }
+    static const int gdn_fp4_maxn = [] {
+        const char* e = getenv("SPARKINFER_Q38_GDN_NVFP4_MAXN");
+        return e ? atoi(e) : 2048;
+    }();
+    const bool gdn_nvfp4 = gdn_fp4_env && !moe && gdn_probe && gdn_probe->gdn_qkv_fp4 &&
+        N <= gdn_fp4_maxn &&
+        kernels::prefill_nvfp4_supported(N, lqkv, H) &&
+        kernels::prefill_nvfp4_supported(N, lvdim, H) &&
+        kernels::prefill_nvfp4_supported(N, H, lvdim);
+    // out_proj's A operand is `lnrm` at k = lvdim, which is WIDER than the FFN's k = H on this
+    // model (6144 vs 5120), so fp4_a/fp4_as cannot be reused -- they would be overrun by a quarter
+    // of a row. One staging pair sized for the widest GDN k covers all three projections.
+    const int gdn_k = (lvdim > H) ? lvdim : H;
+    unsigned char* fp4_gdn_a = gdn_nvfp4
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, gdn_k)) : nullptr;
+    unsigned char* fp4_gdn_as = gdn_nvfp4
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, gdn_k)) : nullptr;
+    // The three GDN shapes can each want more workspace than the FFN's, and fp4_ws is shared.
+    unsigned char* fp4_gdn_ws = nullptr;
+    if (gdn_nvfp4) {
+        size_t wb = kernels::prefill_nvfp4_workspace_bytes(N, lqkv, H);
+        const size_t wz = kernels::prefill_nvfp4_workspace_bytes(N, lvdim, H);
+        const size_t wo = kernels::prefill_nvfp4_workspace_bytes(N, H, lvdim);
+        if (wz > wb) wb = wz;
+        if (wo > wb) wb = wo;
+        fp4_gdn_ws = (wb <= fp4_ws_bytes && fp4_ws) ? fp4_ws : a8.alloc<unsigned char>(wb);
+    }
+
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
     Arena& aw = arena_reuse ? keep_aw : once_aw;
@@ -967,6 +1023,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const char* _pshareq = getenv("SPARKINFER_PREFILL_FP8_GDN_SHAREQ");
     const bool fp8_shareq = (use_fp8_gdn || moe_fp8) && (!_pshareq || _pshareq[0] != '0');
     auto gdn_qkv_z = [&](const bf16* A, const Qwen35LayerWeights& w) {
+        // Checkpoint-native NVFP4: quantize xn to FP4 ONCE (both projections read it) and run two
+        // block-scaled GEMMs straight off the packed nibbles. A_i8/sx are not touched, so the int8
+        // activation memo stays valid for whatever runs next in the layer.
+        if (gdn_nvfp4 && (gdn_fp4_mask & 1) &&
+            w.gdn_qkv_fp4 && w.gdn_qkv_fp4_sf && w.gdn_z_fp4 && w.gdn_z_fp4_sf &&
+            fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
+            kernels::launch_prefill_nvfp4_quant_a(A, fp4_gdn_a, fp4_gdn_as, N, H, st) &&
+            kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                               w.gdn_qkv_fp4, w.gdn_qkv_fp4_sf,
+                                               b8, N, lqkv, H, fp4_gdn_ws, st,
+                                               w.gdn_qkv_fp4_alpha) &&
+            kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                               w.gdn_z_fp4, w.gdn_z_fp4_sf,
+                                               lz, N, lvdim, H, fp4_gdn_ws, st,
+                                               w.gdn_z_fp4_alpha))
+            return;
         if (q38_fp8_prefill && w.wqkv_type == kernels::SI_QTYPE_FP8 &&
             w.wqkv_gate_type == kernels::SI_QTYPE_FP8 && A_i8 && sx && sw) {
             a_q = nullptr; a_pk = false;
@@ -1049,8 +1121,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim,
                 c.gdn_qh_block, st);
             kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
-            attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
-            if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            // out_proj off the same NVFP4 bytes. The block-scaled GEMM cannot accumulate the
+            // residual, so this writes the RAW projection to `ao` and leaves attn_fused false --
+            // the `if (!attn_fused) launch_prefill_add(x, ao, x, ...)` below is what applies it,
+            // exactly as the Muse wo_fp4 arm does for the o projection.
+            const bool out_fp4 = gdn_nvfp4 && (gdn_fp4_mask & 2) &&
+                w.gdn_out_fp4 && w.gdn_out_fp4_sf &&
+                fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
+                kernels::launch_prefill_nvfp4_quant_a(lnrm, fp4_gdn_a, fp4_gdn_as, N, lvdim, st) &&
+                kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                   w.gdn_out_fp4, w.gdn_out_fp4_sf,
+                                                   ao, N, H, lvdim, fp4_gdn_ws, st,
+                                                   w.gdn_out_fp4_alpha);
+            if (!out_fp4) {
+                attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
+                if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            }
             use_i8 = restore_i8_gdn;
         } else {
             // ---- full softmax-attention layer (q_has_gate, partial RoPE, int8 KV) ----


### PR DESCRIPTION
## Summary

On the ModelOpt checkpoint the GDN projections are stored NVFP4 but `proj()` has no native-NVFP4 arm, so batched prefill expands every GDN weight to bf16 and then to int8 on each pass; this feeds the packed nibbles straight to the SM120 block-scaled GEMM the FFN already uses.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 93.71 |
| after (this PR) | 93.73 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 3331.22 |
| after prefill (this PR) | 6646.41 |

```text
# bench_sweep_run <ModelOpt dir> 128 128 5 16384 5 -- the harness the eval uses
# (qwen3_gguf_bench ... sweep, median of 5 reps). RTX 5090 sm_120, main @ 91ce034.
# Separate main/PR binaries, arm order rotated between rounds.

r1 main  ctx128 decode=94.0646 pp=3331.8000   ctx16384 decode=78.4906 pp=9393.5674
r1 pr    ctx128 decode=93.8844 pp=6650.3940   ctx16384 decode=78.3422 pp=9520.8622
r2 pr    ctx128 decode=93.7278 pp=6634.3573   ctx16384 decode=78.2642 pp=9506.3734
r2 main  ctx128 decode=93.7060 pp=3330.2745   ctx16384 decode=78.3296 pp=9338.6743
r3 main  ctx128 decode=93.6727 pp=3331.2217   ctx16384 decode=78.3423 pp=9326.6468
r3 pr    ctx128 decode=93.6906 pp=6646.4076   ctx16384 decode=78.2234 pp=9488.6504

# medians: prefill@128 3331.22 -> 6646.41 (1.995x); decode@128 93.71 -> 93.73 (1.000);
# prefill@16k 9338.67 -> 9506.37 (1.018).

# Same-binary A/B (SPARKINFER_Q38_GDN_NVFP4_PREFILL=0/3), order rotated, same box, same session:
r1 OFF  ctx128 decode=94.1927 pp=3332.6593    r1 ON  ctx128 decode=94.0535 pp=6570.8348
r2 ON   ctx128 decode=93.9134 pp=6650.3947    r2 OFF ctx128 decode=93.7590 pp=3324.2233
r3 OFF  ctx128 decode=93.6904 pp=3321.7287    r3 ON  ctx128 decode=93.6668 pp=6643.1551
# medians: 3324.22 -> 6643.16 (1.999x), agreeing with the two-binary comparison.
```