### PR TITLE
perf(qwen3.8): NVFP4 attention and GDN chunk rework in batched prefill

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -277,14 +277,16 @@ __global__ void pf_add_kernel(const __nv_bfloat16* __restrict__ a,
 __global__ void pf_split_q_gate_kernel(const __nv_bfloat16* __restrict__ qraw,
                                        __nv_bfloat16* __restrict__ q,
                                        __nv_bfloat16* __restrict__ gate,
-                                       int n_tokens, int n_heads, int head_dim) {
+                                       int n_tokens, int n_heads, int head_dim, int row_stride) {
     const long gid = (long)blockIdx.x * blockDim.x + threadIdx.x;
     const long per = (long)n_heads * head_dim;
     if (gid >= (long)n_tokens * per) return;
     const int t = gid / per;
     const int r = gid % per;                       // within-token index
     const int h = r / head_dim, d = r % head_dim;
-    const size_t src = (size_t)t * 2 * per + (size_t)h * 2 * head_dim + d;
+    // row_stride is 2*per for a tight [q|gate] buffer, and wider when [q|gate] is the leading
+    // slice of a fused q|k|v GEMM output that this reads in place instead of copying out.
+    const size_t src = (size_t)t * row_stride + (size_t)h * 2 * head_dim + d;
     q[gid]    = qraw[src];
     gate[gid] = qraw[src + head_dim];
 }
@@ -1156,24 +1158,57 @@ __global__ void pf_attn_bf16_paged_kernel(
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
 
-    for (int kpos = 0; kpos <= qtok; kpos++) {
-        const int blk = kpos / block_size, within = kpos % block_size;
-        const int phys = block_table[blk];
-        const size_t ckt = ((size_t)phys * block_size + within);
-        const size_t kv_off = (ckt * n_kv_heads + kv_head) * HEAD_DIM;
-        float partial = 0.f;
+    // KEY TILE. One key per iteration made every key a serial dependency chain: an ELEMS-long
+    // dot, then a 5-step warp-shuffle reduction, then an online-softmax update that consumes the
+    // reduction -- ~40-50 cycles of latency to do 16 FMAs. Measured 7.7 TFLOPS = 3.9% of bf16 peak.
+    // Processing KT keys per iteration lets the KT reductions interleave (independent shuffle
+    // chains, so their latency overlaps instead of serialising) and pays the sequential softmax
+    // rescale once per tile instead of once per key. Mathematically the same online softmax;
+    // not bit-identical, because the running max now advances a tile at a time.
+    constexpr int KT = 8;
+    for (int kbase = 0; kbase <= qtok; kbase += KT) {
+        const int nk = min(KT, qtok - kbase + 1);
+        float score[KT];
+        size_t kv_offs[KT];
         #pragma unroll
-        for (int e = 0; e < ELEMS; e++)
-            partial += q_reg[e] * pf_to_f(k_pool[kv_off + lane + e * 32]);
-        const float score = pf_wsum(partial) * scale;
+        for (int t = 0; t < KT; t++) {
+            const int kpos = kbase + t;
+            const int kp = (t < nk) ? kpos : kbase;          // clamp: result discarded below
+            const int blk = kp / block_size, within = kp % block_size;
+            const size_t ckt = ((size_t)block_table[blk] * block_size + within);
+            kv_offs[t] = (ckt * n_kv_heads + kv_head) * HEAD_DIM;
+        }
+        #pragma unroll
+        for (int t = 0; t < KT; t++) {
+            float partial = 0.f;
+            #pragma unroll
+            for (int e = 0; e < ELEMS; e++)
+                partial += q_reg[e] * pf_to_f(k_pool[kv_offs[t] + lane + e * 32]);
+            score[t] = partial;                              // reduced below, interleaved
+        }
+        #pragma unroll
+        for (int t = 0; t < KT; t++) score[t] = pf_wsum(score[t]) * scale;
 
-        const float m_new = fmaxf(m, score);
-        const float corr  = __expf(m - m_new);
-        const float p     = __expf(score - m_new);
-        l = l * corr + p;
+        float m_new = m;
         #pragma unroll
-        for (int e = 0; e < ELEMS; e++)
-            acc[e] = acc[e] * corr + p * pf_to_f(v_pool[kv_off + lane + e * 32]);
+        for (int t = 0; t < KT; t++) if (t < nk) m_new = fmaxf(m_new, score[t]);
+        const float corr = __expf(m - m_new);
+        float psum = 0.f;
+        float pv[KT];
+        #pragma unroll
+        for (int t = 0; t < KT; t++) {
+            pv[t] = (t < nk) ? __expf(score[t] - m_new) : 0.f;
+            psum += pv[t];
+        }
+        l = l * corr + psum;
+        #pragma unroll
+        for (int e = 0; e < ELEMS; e++) {
+            float a = acc[e] * corr;
+            #pragma unroll
+            for (int t = 0; t < KT; t++)
+                if (t < nk) a += pv[t] * pf_to_f(v_pool[kv_offs[t] + lane + e * 32]);
+            acc[e] = a;
+        }
         m = m_new;
     }
     const float inv = (l > 0.f) ? (1.f / l) : 0.f;
@@ -1218,11 +1253,13 @@ void launch_prefill_add(const void* a, const void* b, void* out, long n, cudaStr
 }
 
 void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,
-                                 int n_tokens, int n_heads, int head_dim, cudaStream_t stream) {
+                                 int n_tokens, int n_heads, int head_dim, cudaStream_t stream,
+                                 int row_stride) {
     const long n = (long)n_tokens * n_heads * head_dim;
+    const int rs = row_stride > 0 ? row_stride : 2 * n_heads * head_dim;
     pf_split_q_gate_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(qraw), reinterpret_cast<__nv_bfloat16*>(q),
-        reinterpret_cast<__nv_bfloat16*>(gate), n_tokens, n_heads, head_dim);
+        reinterpret_cast<__nv_bfloat16*>(gate), n_tokens, n_heads, head_dim, rs);
 }
 
 void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int dim, cudaStream_t stream) {

--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -35,8 +35,10 @@
 //     (I + A) U^ = B (V - diag(exp G) K S_in),   A[i][j] = b_i (k_i.k_j) exp(G_i - G_j), j < i
 //     Y         = [ diag(exp G) (Q S_in) + M U^ ] * scale,  M[i][j] = (q_i.k_j) exp(G_i-G_j), j<=i
 //     S_out     = exp(G_last) S_in + K^T U~,     U~[j] = exp(G_last - G_j) U^[j]
-// (I + A) is unit lower triangular, so T = (I+A)^-1 is too and costs C^3/6 MACs by forward
-// substitution. The serial chain shortens from N to N/C and the inner work becomes dense matmuls
+// (I + A) is unit lower triangular, so T = (I+A)^-1 is too; it is built by BLOCKED inversion
+// (log2(C) levels of [[L11,0],[L21,L22]]^-1 = [[T11,0],[-T22 L21 T11, T22]]) rather than the
+// C^3/6-MAC forward substitution, which cost 62 block barriers and left 225 of 256 threads idle.
+// The serial chain shortens from N to N/C and the inner work becomes dense matmuls
 // over shared-memory tiles that every state column reuses.
 //
 // NUMERICS. ssm_a is negative for all 24 linear layers x 32 v-heads of this checkpoint (read from
@@ -191,18 +193,50 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
     }
     __syncthreads();
 
-    // ---- T = (I + A)^-1 in place, by forward substitution over rows ----
-    //   T[i][j] = -A[i][j] - sum_{m=j+1}^{i-1} A[i][m] T[m][j]      (T[j][j] = 1)
-    // Row i still holds A while it is being read; rows m < i already hold T.
-    for (int i = 1; i < C; i++) {
-        for (int j = tid; j < i; j += nthr) {
-            float acc = s_A[i * (C + PAD) + j];
-            for (int m = j + 1; m < i; m++) acc += s_A[i * (C + PAD) + m] * s_A[m * (C + PAD) + j];
-            s_t[j] = -acc;
+    // ---- T = (I + A)^-1 in place, by BLOCKED (divide-and-conquer) inversion ----
+    // For a diagonal block of size bw = 2*hb at offset o,
+    //     [[L11, 0], [L21, L22]]^-1 = [[T11, 0], [-T22 L21 T11, T22]]
+    // so each level only has to fill the (2,1) sub-block of every size-bw diagonal block: the two
+    // diagonal halves were inverted by level bw/2, and L21 is still raw A because no earlier level
+    // touches that region. T11 and T22 are themselves unit lower triangular, which is what lets the
+    // m-loops start at j+1 and stop at i (the implicit 1s are the initial `acc`).
+    //
+    // This replaces a row-at-a-time forward substitution, which was this kernel's serial
+    // bottleneck: C-1 = 31 rows x 2 block barriers = 62 barriers, a dependent FMA chain of
+    // sum(i-1) = 465, and never more than 31 of the 256 threads busy (row i has only i entries).
+    // The blocked form is log2(C) = 5 levels: 10 barriers, a chain of 2+4+8+16+32 = 62, and the
+    // last two levels carry 94% of the MACs at 128 and 256 threads. It issues ~2x the MACs
+    // (C^3/3 vs C^3/6) and still wins, because the grid is 192 blocks on 170 SMs -- barely one
+    // block per SM, so there is nothing to hide a barrier behind and arithmetic is nearly free.
+    //
+    // s_P aliases s_x: Q was consumed by the wmma pass above and V is not staged until after W^,
+    // so the scratch costs no extra shared memory (it must not overlap s_A, which sits above s_x).
+    {
+        float* s_P = reinterpret_cast<float*>(s_x);                          // [C][C+PAD]
+        for (int bw = 2; bw <= C; bw <<= 1) {
+            const int hb = bw >> 1;
+            const int nout = (C / bw) * hb * hb;
+            for (int e = tid; e < nout; e += nthr) {                         // P = L21 . T11
+                const int b = e / (hb * hb), r = e - b * hb * hb;
+                const int i = r / hb, j = r - i * hb, o = b * bw;
+                float acc = s_A[(o + hb + i) * (C + PAD) + o + j];           // m == j: T11[j][j] = 1
+                for (int m = j + 1; m < hb; m++)
+                    acc += s_A[(o + hb + i) * (C + PAD) + o + m]
+                         * s_A[(o + m) * (C + PAD) + o + j];
+                s_P[(o + hb + i) * (C + PAD) + o + j] = acc;
+            }
+            __syncthreads();
+            for (int e = tid; e < nout; e += nthr) {                         // T21 = -T22 . P
+                const int b = e / (hb * hb), r = e - b * hb * hb;
+                const int i = r / hb, j = r - i * hb, o = b * bw;
+                float acc = s_P[(o + hb + i) * (C + PAD) + o + j];           // m == i: T22[i][i] = 1
+                for (int m = 0; m < i; m++)
+                    acc += s_A[(o + hb + i) * (C + PAD) + o + hb + m]
+                         * s_P[(o + hb + m) * (C + PAD) + o + j];
+                s_A[(o + hb + i) * (C + PAD) + o + j] = -acc;
+            }
+            __syncthreads();
         }
-        __syncthreads();
-        for (int j = tid; j < i; j += nthr) s_A[i * (C + PAD) + j] = s_t[j];
-        __syncthreads();
     }
 
     // ---- W^ = T . (b_m exp(G_m) k_m) ----
@@ -284,7 +318,7 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                                     float* __restrict__ state,
                                     __nv_bfloat16* __restrict__ out,
                                     int n_tokens, int q_heads, int v_heads, int n_chunks,
-                                    bool qh_block, int carry) {
+                                    bool qh_block, int carry, int mwmma) {
     extern __shared__ char s_raw[];
     float* s_S = reinterpret_cast<float*>(s_raw);                              // [HD][JC]  fp32 carrier
     float* s_U = s_S + (size_t)HD * JC;                                        // [C][JC]
@@ -427,7 +461,54 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         // bit-identical to the reference element loop.
         for (int i = tid; i < C; i += nthr) s_eg[i] = __expf(s_g[i]);
         __syncthreads();
-        {
+        if (mwmma) {
+            // M . U^ on tensor cores. The scalar form below issues, per pp, one s_U load and FOUR
+            // broadcast s_M loads for only four FMAs -- ~1280 shared transactions per block-chunk
+            // against ~256 cycles of real FMA work. It is shared-INSTRUCTION bound, not FLOP
+            // bound, and wmma is what removes those instructions (16x16x16 per mma).
+            // m_buf already stores hard 0 for j>i (prep writes them), so a dense product is
+            // mathematically the masked one. Narrowing M/U^ to bf16 matches what this kernel
+            // already does for S and U~ on its other two matmuls.
+            // s_Mb aliases s_Sb (dead once the U^/Y0 pass above is done) and s_Ub is not written
+            // until the S update below -- so this costs no extra shared memory.
+            __nv_bfloat16* s_Mb = s_Sb;
+            for (int e = tid; e < C * C; e += nthr) {
+                const int i = e / C, pp = e - i * C;
+                s_Mb[i * (C + PAD) + pp] = __float2bfloat16(s_M[i * (C + PAD) + pp]);
+            }
+            for (int e = tid; e < C * JC; e += nthr) {
+                const int i = e / JC, jj = e - i * JC;
+                s_Ub[i * (JC + PAD) + jj] = __float2bfloat16(s_U[e]);
+            }
+            __syncthreads();
+            {
+                using namespace nvcuda;
+                const int warp = tid >> 5;
+                __shared__ float sMU[4][16][16];
+                if (warp < 4) {                       // [32,32]x[32,32] = 4 tiles, k-depth 2 steps
+                    const int ti = (warp >> 1) * 16, tj = (warp & 1) * 16;
+                    wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
+                    wmma::fill_fragment(cf, 0.f);
+                    #pragma unroll
+                    for (int kk = 0; kk < C; kk += 16) {
+                        wmma::fragment<wmma::matrix_a, 16, 16, 16, __nv_bfloat16, wmma::row_major> af;
+                        wmma::fragment<wmma::matrix_b, 16, 16, 16, __nv_bfloat16, wmma::row_major> bf;
+                        wmma::load_matrix_sync(af, s_Mb + (size_t)ti * (C + PAD) + kk, C + PAD);
+                        wmma::load_matrix_sync(bf, s_Ub + (size_t)kk * (JC + PAD) + tj, JC + PAD);
+                        wmma::mma_sync(cf, af, bf, cf);
+                    }
+                    wmma::store_matrix_sync(&sMU[warp][0][0], cf, 16, wmma::mem_row_major);
+                }
+                __syncthreads();
+                for (int e = tid; e < C * JC; e += nthr) {
+                    const int i = e / JC, jj = e - i * JC;
+                    if (t0 + i >= n_tokens) continue;
+                    const int w = ((i >> 4) << 1) | (jj >> 4);
+                    const float y = (s_eg[i] * s_Y[i * JC + jj] + sMU[w][i & 15][jj & 15]) * scale;
+                    out[(size_t)(t0 + i) * v_dim + h * HD + j0 + jj] = __float2bfloat16(y);
+                }
+            }
+        } else {
             constexpr int NTHR2 = 256;
             constexpr int OPT = (C * JC) / NTHR2;
             constexpr int ISTR2 = NTHR2 / JC;
@@ -477,13 +558,21 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
             using namespace nvcuda;
             const float gl = __expf(g_last);
             const int warp = tid >> 5;                       // 8 warps x 2 tiles = 16 tiles [128,32]
-            __shared__ float sC2[8][16][16];
+            // The accumulator IS the destination: seed cf with the decayed old state and let the
+            // mma add K^T U~ straight onto it, then store back to s_S. That removes the 8 KB sC2
+            // staging array, both __syncwarp, and a dependent shared round-trip per tile -- none of
+            // which has anything to hide behind at ~1.13 blocks/SM. Safe because tile = 2*warp+rep
+            // gives ti = 16*warp for BOTH reps, so warp w owns s_S rows [16w, 16w+16) exclusively
+            // and the two reps only differ in column half. Not bit-identical: the old form summed
+            // the products from zero and added gl*S afterwards, this one starts from gl*S.
             #pragma unroll
             for (int rep = 0; rep < 2; rep++) {
                 const int tile = warp * 2 + rep;             // 0..15
                 const int ti = (tile >> 1) * 16, tj = (tile & 1) * 16;
                 wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
-                wmma::fill_fragment(cf, 0.f);
+                wmma::load_matrix_sync(cf, s_S + (size_t)ti * JC + tj, JC, wmma::mem_row_major);
+                #pragma unroll
+                for (int e = 0; e < cf.num_elements; e++) cf.x[e] *= gl;
                 #pragma unroll
                 for (int kk = 0; kk < C; kk += 16) {
                     // K^T: A[m][p] = s_K[p][m] -> col_major over s_K gives the transpose for free
@@ -493,14 +582,7 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                     wmma::load_matrix_sync(bf, s_Ub + (size_t)kk * (JC + PAD) + tj, JC + PAD);
                     wmma::mma_sync(cf, af, bf, cf);
                 }
-                wmma::store_matrix_sync(&sC2[warp][0][0], cf, 16, wmma::mem_row_major);
-                __syncwarp();
-                for (int e = (tid & 31); e < 256; e += 32) {
-                    const int r = e >> 4, cc = e & 15;
-                    const int m = ti + r, jj = tj + cc;
-                    s_S[m * JC + jj] = gl * s_S[m * JC + jj] + sC2[warp][r][cc];
-                }
-                __syncwarp();
+                wmma::store_matrix_sync(s_S + (size_t)ti * JC + tj, cf, JC, wmma::mem_row_major);
             }
         }
         __syncthreads();
@@ -603,6 +685,7 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
         cfg[dev] = 1;
     }
 
+    static const int mwmma = [] { const char* e = getenv("SPARKINFER_SCAN_MWMMA"); return (e && e[0] == '0') ? 0 : 1; }();
     auto db = reinterpret_cast<const __nv_bfloat16*>(dt);
     auto aa = reinterpret_cast<const __nv_bfloat16*>(a);
 
@@ -638,7 +721,7 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
         dim3 gscan(v_heads, HD / JC);
         pf_gdnc_scan_kernel<C, HD, JC><<<gscan, SCAN_THREADS, sm_scan, stream>>>(
             qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob,
-            len, q_heads, v_heads, n_chunks, qh_block, carry);
+            len, q_heads, v_heads, n_chunks, qh_block, carry, mwmma);
         return cudaPeekAtLastError() == cudaSuccess;
     };
 

--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -13,10 +13,17 @@ bool launch_prefill_nvfp4_quant_a(const void*, void*, void*, int, int, cudaStrea
 bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, int, int,
                                        cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*, int, int,
-                                         cudaStream_t) { return false; }
+                                         cudaStream_t, int) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t, float) { return false; }
 bool launch_ct_nvfp4_pack_sfb(const void*, void*, int, int, cudaStream_t) { return false; }
+// Returning false here is not merely a link fix: the caller treats false as "shape unsupported"
+// and falls back to launch_add_rmsnorm2 + a separate quantize, which is the pre-fusion path.
+bool launch_prefill_gated_norm_nvfp4_a(const void*, const void*, const void*, void*, void*, void*,
+                                       int, int, int, float, cudaStream_t) { return false; }
+bool launch_prefill_add_rmsnorm2_nvfp4_a(const void*, const void*, const void*, void*, void*,
+                                         void*, void*, int, int, float,
+                                         cudaStream_t) { return false; }
 } // namespace sparkinfer::kernels
 #endif

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -171,6 +171,173 @@ auto shape(int m, int n, int k) { return cute::make_shape(m, n, k, 1); }
 auto sfa_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFA(shape(m,n,k)); }
 auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFB(shape(m,n,k)); }
 
+// The GDN gated norm with the FP4 A-operand quantize folded in -- the third site where a norm's
+// output is immediately re-read and quantized (here `lnrm`, by the out projection).
+//
+// The existing pf_gated_norm_kernel puts ONE WARP on a (token, head) pair with lane-strided
+// elements (d = lane + r*32), which scatters a 16-value NVFP4 group across 16 lanes and makes the
+// packed store a cross-lane gather. This re-tiles instead: one block per TOKEN, 8 CONSECUTIVE
+// elements per thread. A head is then head_dim/8 consecutive lanes (16 at head_dim=128, so its
+// RMS reduction is a 4-step shuffle inside half a warp) and a scale group is exactly TWO lanes.
+//
+// Same arithmetic as pf_gated_norm_kernel: ss over the fp32 x, rsqrt(ss/head_dim + eps), and
+// x*inv*w*silu(z) rounded to bf16 -- and the quantize then reads that bf16-rounded value, so it
+// matches running the standalone quantizer on `lnrm` afterwards.
+template <class Layout>
+__global__ void gated_norm_nvfp4a_kernel(const __nv_bfloat16* __restrict__ x,
+                                         const __nv_bfloat16* __restrict__ z,
+                                         const __nv_bfloat16* __restrict__ wgt,
+                                         __nv_bfloat16* __restrict__ out,
+                                         unsigned char* __restrict__ dst,
+                                         cutlass::float_ue4m3_t* __restrict__ sf,
+                                         int cols, int head_dim, float eps, Layout layout) {
+    const int t = blockIdx.x, p = threadIdx.x;
+    const int tph = head_dim >> 3;            // threads per head (power of two, <= 32)
+    const int din = (p & (tph - 1)) << 3;     // element offset inside this head
+    const size_t base = (size_t)t * cols + (size_t)p * 8;
+
+    const uint4 xr = __ldg(reinterpret_cast<const uint4*>(x) + (base >> 3));
+    const uint4 zr = __ldg(reinterpret_cast<const uint4*>(z) + (base >> 3));
+    const uint4 wr = __ldg(reinterpret_cast<const uint4*>(wgt) + (din >> 3));
+    const __nv_bfloat162* xp = reinterpret_cast<const __nv_bfloat162*>(&xr);
+    const __nv_bfloat162* zp = reinterpret_cast<const __nv_bfloat162*>(&zr);
+    const __nv_bfloat162* wp = reinterpret_cast<const __nv_bfloat162*>(&wr);
+    float xv[8], zv[8], wv[8], ss = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const float2 a = __bfloat1622float2(xp[i]), b = __bfloat1622float2(zp[i]),
+                     c = __bfloat1622float2(wp[i]);
+        xv[2*i] = a.x; xv[2*i+1] = a.y;
+        zv[2*i] = b.x; zv[2*i+1] = b.y;
+        wv[2*i] = c.x; wv[2*i+1] = c.y;
+    }
+    #pragma unroll
+    for (int j = 0; j < 8; j++) ss += xv[j] * xv[j];
+    for (int d = 1; d < tph; d <<= 1) ss += __shfl_xor_sync(0xffffffffu, ss, d);
+    const float inv = rsqrtf(ss / (float)head_dim + eps);
+
+    float on[8]; __nv_bfloat162 no[4];
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const float s0 = 1.f / (1.f + __expf(-zv[2*i])), s1 = 1.f / (1.f + __expf(-zv[2*i+1]));
+        no[i] = __floats2bfloat162_rn(xv[2*i]   * inv * wv[2*i]   * (zv[2*i]   * s0),
+                                      xv[2*i+1] * inv * wv[2*i+1] * (zv[2*i+1] * s1));
+        const float2 rb = __bfloat1622float2(no[i]);   // quantize the BF16-ROUNDED output
+        on[2*i] = rb.x; on[2*i+1] = rb.y;
+    }
+    *(reinterpret_cast<uint4*>(out) + (base >> 3)) = *reinterpret_cast<const uint4*>(no);
+
+    float a = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) a = fmaxf(a, fabsf(on[j]));
+    a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, 1));
+    cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
+    unsigned int packed = 0;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        cutlass::float_e2m1_t q(on[j] / float(qs));
+        packed |= (unsigned int)(q.raw() & 15u) << (4 * j);
+    }
+    *reinterpret_cast<unsigned int*>(dst + (base >> 1)) = packed;
+    if ((p & 1) == 0) {
+        auto scales = cute::make_tensor(sf, layout);
+        scales(t, (p >> 1) * 16, 0) = qs;
+    }
+}
+
+// add_rmsnorm2 with the FP4 A-operand quantize folded in.
+//
+// Every batched-prefill GEMM group is preceded by a norm whose output it immediately quantizes:
+// the FFN reads `hn` straight out of the post-attention add+norm, and the GDN/attention groups read
+// `xn` out of the end-of-layer one. That is a whole kernel and a whole re-read of an N x H tensor
+// per site per layer for work the norm already had in registers.
+//
+// Specialised the same way add_rmsnorm2_q8_kernel is: exactly one 8-wide pack per thread
+// (blockDim*8 == cols), which makes a 16-value NVFP4 scale group exactly TWO adjacent lanes, so the
+// group amax is a single shuffle. Requires cols % 128 == 0 (the layout already demands it) and
+// cols <= 8192 so cols/8 fits a block.
+//
+// Numerically identical to running the two kernels back to back: `ss` accumulates on the fp32 sum
+// exactly as add_rmsnorm2_kernel does, out_norm is formed from the BF16-ROUNDED sum exactly as it
+// does, and the quantize then reads that same bf16-rounded out_norm -- the invariant
+// add_rmsnorm2_q8_kernel already relies on for its Q8_1 side output.
+template <class Layout>
+__global__ void add_rmsnorm2_nvfp4a_kernel(const __nv_bfloat16* __restrict__ x,
+                                           const __nv_bfloat16* __restrict__ res,
+                                           const __nv_bfloat16* __restrict__ wgt,
+                                           __nv_bfloat16* __restrict__ out_sum,
+                                           __nv_bfloat16* __restrict__ out_norm,
+                                           unsigned char* __restrict__ dst,
+                                           cutlass::float_ue4m3_t* __restrict__ sf,
+                                           int cols, float eps, Layout layout) {
+    const int row = blockIdx.x, p = threadIdx.x;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+
+    const uint4 xr = __ldg(reinterpret_cast<const uint4*>(x + base) + p);
+    const uint4 rr = __ldg(reinterpret_cast<const uint4*>(res + base) + p);
+    const __nv_bfloat162* xp = reinterpret_cast<const __nv_bfloat162*>(&xr);
+    const __nv_bfloat162* rp = reinterpret_cast<const __nv_bfloat162*>(&rr);
+    float sv[8]; float ss = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const float2 a = __bfloat1622float2(xp[i]), b = __bfloat1622float2(rp[i]);
+        sv[2 * i] = a.x + b.x; sv[2 * i + 1] = a.y + b.y;
+    }
+    #pragma unroll
+    for (int j = 0; j < 8; j++) ss = __fmaf_rn(sv[j], sv[j], ss);
+    // out_sum is the bf16 rounding of the fp32 sum; keep the rounded copy for the norm below so
+    // this matches add_rmsnorm2_kernel, which RE-READS out_sum rather than reusing sv.
+    __nv_bfloat162 so[4];
+    #pragma unroll
+    for (int i = 0; i < 4; i++) so[i] = __floats2bfloat162_rn(sv[2 * i], sv[2 * i + 1]);
+    *(reinterpret_cast<uint4*>(out_sum + base) + p) = *reinterpret_cast<const uint4*>(so);
+
+    #pragma unroll
+    for (int d = 16; d; d >>= 1) ss += __shfl_xor_sync(0xffffffffu, ss, d);
+    if ((p & 31) == 0) s_warp[p >> 5] = ss;
+    __syncthreads();
+    if (p < 32) {
+        float v = (p < (int)((blockDim.x + 31) / 32)) ? s_warp[p] : 0.f;
+        #pragma unroll
+        for (int d = 16; d; d >>= 1) v += __shfl_xor_sync(0xffffffffu, v, d);
+        if (p == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv_rms = s_warp[0];
+
+    const uint4 wr = __ldg(reinterpret_cast<const uint4*>(wgt) + p);
+    const __nv_bfloat162* wp = reinterpret_cast<const __nv_bfloat162*>(&wr);
+    const __nv_bfloat162* sp = reinterpret_cast<const __nv_bfloat162*>(so);
+    float on[8]; __nv_bfloat162 no[4];
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const float2 srf = __bfloat1622float2(sp[i]), wf = __bfloat1622float2(wp[i]);
+        const float o0 = srf.x * inv_rms * wf.x, o1 = srf.y * inv_rms * wf.y;
+        no[i] = __floats2bfloat162_rn(o0, o1);
+        const float2 rb = __bfloat1622float2(no[i]);   // quantize the BF16-ROUNDED out_norm
+        on[2 * i] = rb.x; on[2 * i + 1] = rb.y;
+    }
+    *(reinterpret_cast<uint4*>(out_norm + base) + p) = *reinterpret_cast<const uint4*>(no);
+
+    float a = 0.f;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) a = fmaxf(a, fabsf(on[j]));
+    a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, 1));      // group = two adjacent lanes
+    cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
+    unsigned int packed = 0;
+    #pragma unroll
+    for (int j = 0; j < 8; j++) {
+        cutlass::float_e2m1_t q(on[j] / float(qs));
+        packed |= (unsigned int)(q.raw() & 15u) << (4 * j);
+    }
+    *reinterpret_cast<unsigned int*>(dst + ((base + (size_t)p * 8) >> 1)) = packed;
+    if ((p & 1) == 0) {
+        auto scales = cute::make_tensor(sf, layout);
+        scales(row, (p >> 1) * 16, 0) = qs;
+    }
+}
+
 template <class Layout>
 __global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
                            cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout) {
@@ -251,7 +418,7 @@ template <class Layout>
 __global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
                                   const __nv_bfloat16* __restrict__ up,
                                   unsigned char* dst, cutlass::float_ue4m3_t* sf,
-                                  int rows, int cols, Layout layout) {
+                                  int rows, int cols, int src_stride, Layout layout) {
     // 8 values per lane instead of 2, so two lanes cover a 16-value scale group. The two operand
     // reads become one 16-byte load each instead of four 4-byte loads, the store becomes one
     // 4-byte store instead of four 1-byte ones, and the amax butterfly collapses from three
@@ -266,9 +433,12 @@ __global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
     for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG;
          grp < groups; grp += stride) {
         const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
+        // src_stride is elements per row in `gate`/`up`; wider than cols when they are the two
+        // halves of one fused gate|up GEMM output read in place. dst keeps the tight `cols` stride.
         const size_t base = (size_t)row * cols + k0 + VPL * glane;
-        const __nv_bfloat162* g2 = reinterpret_cast<const __nv_bfloat162*>(gate + base);
-        const __nv_bfloat162* u2 = reinterpret_cast<const __nv_bfloat162*>(up + base);
+        const size_t sbase = (size_t)row * src_stride + k0 + VPL * glane;
+        const __nv_bfloat162* g2 = reinterpret_cast<const __nv_bfloat162*>(gate + sbase);
+        const __nv_bfloat162* u2 = reinterpret_cast<const __nv_bfloat162*>(up + sbase);
         float x[VPL];
         float a = 0.f;
         #pragma unroll
@@ -384,6 +554,38 @@ bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k
                                      (cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
+// Fused GDN gated-norm + FP4-quantize. False = shape unsupported, nothing written.
+bool launch_prefill_gated_norm_nvfp4_a(const void* x, const void* z, const void* w, void* out,
+                                       void* d, void* sf, int rows, int cols, int head_dim,
+                                       float eps, cudaStream_t st) {
+    if (!x || !z || !w || !out || !d || !sf) return false;
+    if (head_dim <= 0 || (head_dim & 7) || cols <= 0 || (cols % head_dim)) return false;
+    const int tph = head_dim >> 3;
+    if (tph < 1 || tph > 32 || (tph & (tph - 1))) return false;   // power of two, within a warp
+    if ((cols & 127) || (cols >> 3) > 1024) return false;
+    if (!prefill_nvfp4_supported(rows, 128, cols)) return false;
+    auto l = sfa_layout(rows, 128, cols);
+    gated_norm_nvfp4a_kernel<<<rows, cols >> 3, 0, st>>>(
+        (const __nv_bfloat16*)x, (const __nv_bfloat16*)z, (const __nv_bfloat16*)w,
+        (__nv_bfloat16*)out, (unsigned char*)d, (cutlass::float_ue4m3_t*)sf,
+        cols, head_dim, eps, l);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
+// Fused add+RMSNorm+FP4-quantize. Returns false (having done nothing) unless the shape is one the
+// specialisation covers, so every caller keeps its existing two-kernel path as the fallback.
+bool launch_prefill_add_rmsnorm2_nvfp4_a(const void* x, const void* res, const void* w,
+                                         void* out_sum, void* out_norm, void* d, void* sf,
+                                         int rows, int cols, float eps, cudaStream_t st) {
+    if (!x || !res || !w || !out_sum || !out_norm || !d || !sf) return false;
+    if (cols <= 0 || (cols & 127) || (cols >> 3) > 1024) return false;
+    if (!prefill_nvfp4_supported(rows, 128, cols)) return false;
+    auto l = sfa_layout(rows, 128, cols);
+    add_rmsnorm2_nvfp4a_kernel<<<rows, cols >> 3, 0, st>>>(
+        (const __nv_bfloat16*)x, (const __nv_bfloat16*)res, (const __nv_bfloat16*)w,
+        (__nv_bfloat16*)out_sum, (__nv_bfloat16*)out_norm,
+        (unsigned char*)d, (cutlass::float_ue4m3_t*)sf, cols, eps, l);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
 bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, void* sf,
                                        int m, int k, cudaStream_t st) {
     if (!sr || !g || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
@@ -394,13 +596,14 @@ bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, v
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_swiglu_quant_a(const void* g, const void* u, void* d, void* sf,
-                                         int m, int k, cudaStream_t st) {
+                                         int m, int k, cudaStream_t st, int src_stride) {
     if (!g || !u || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
     auto l = sfa_layout(m,128,k);
+    const int ss = src_stride > 0 ? src_stride : k;
     // 2 lanes per 16-value scale group (see swiglu_quant_rows), so one thread per 8 values.
     int blocks = (m * (k / 16) * 2 + 255) / 256; if (blocks > 4096) blocks = 4096;
     swiglu_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)g,(const __nv_bfloat16*)u,
-                                            (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
+                                            (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,ss,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k, cudaStream_t st) {

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -35,9 +35,11 @@ void launch_prefill_add(const void* a, const void* b, void* out, long n,
 
 // Split interleaved-per-head [q|gate]: qraw[N, 2*n_heads*hd] (each head is hd q then hd gate)
 // -> q[N, n_heads*hd], gate[N, n_heads*hd]. Matches split_q_gate_kernel, batched over tokens.
+// row_stride = elements per token in `qraw` (0 = tight 2*n_heads*head_dim). A wider stride lets
+// this read [q|gate] in place as the leading slice of a fused q|k|v GEMM output.
 void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,
                                  int n_tokens, int n_heads, int head_dim,
-                                 cudaStream_t stream = nullptr);
+                                 cudaStream_t stream = nullptr, int row_stride = 0);
 
 // Batched attn *= sigmoid(gate), elementwise over n_tokens*dim (Qwen3.6 q-gate).
 void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int dim,

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -12,6 +12,19 @@ size_t prefill_nvfp4_scale_bytes_a(int m, int k);
 size_t prefill_nvfp4_scale_bytes_b(int n, int k);
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k);
 
+// GDN gated norm (out = x*rsqrt(mean(x^2)+eps)*w*silu(z)) with the FP4 A-operand quantize of the
+// result folded in. Numerically identical to launch_prefill_gated_norm + the standalone quantizer.
+bool launch_prefill_gated_norm_nvfp4_a(const void* x, const void* z, const void* w, void* out,
+                                       void* dst_fp4, void* dst_sf, int rows, int cols,
+                                       int head_dim, float eps, cudaStream_t stream = nullptr);
+// add_rmsnorm2 (out_sum = x + res; out_norm = rmsnorm(out_sum)*w) with the FP4 A-operand
+// quantize of out_norm folded in, so a GEMM group that follows a norm does not re-read it.
+// Numerically identical to the two kernels run back to back. False = shape unsupported, nothing
+// written, caller keeps its two-kernel path.
+bool launch_prefill_add_rmsnorm2_nvfp4_a(const void* x, const void* res, const void* w,
+                                         void* out_sum, void* out_norm, void* dst_fp4, void* dst_sf,
+                                         int rows, int cols, float eps,
+                                         cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_quant_a(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int m, int k, cudaStream_t stream = nullptr);
 // Muse's attention gate fused into the A-operand quantize: x * sigmoid(g) straight to FP4, the
@@ -20,9 +33,12 @@ bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf
                                        void* dst_fp4, void* dst_sf,
                                        int m, int k, cudaStream_t stream = nullptr);
 // Fuse the dense FFN's bf16-rounded SwiGLU producer into the down projection's FP4 A quantize.
+// src_stride = elements per row in gate/up (0 = tight k); wider when they are the two halves of
+// one fused gate|up GEMM output being read in place.
 bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_bf16,
                                          void* dst_fp4, void* dst_sf,
-                                         int m, int k, cudaStream_t stream = nullptr);
+                                         int m, int k, cudaStream_t stream = nullptr,
+                                         int src_stride = 0);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -82,6 +82,14 @@ struct Qwen35LayerWeights {
     int prefill_gate_qtype = 0, prefill_up_qtype = 0;
     // Optional SM120-native NVFP4 copies used only by Muse batched prefill. Decode and all
     // unsupported shapes continue to use the GGUF-native pointers above.
+    // gate|up as ONE [2*ffn, H] NVFP4 operand, REPLACING the two separate FP4 copies. Same
+    // exactness proof as qkv_cat: ModelOpt quantizes the pair together so weight_scale_2 is
+    // bit-identical, and both arrays are row-major, so the concat is a byte copy with one alpha.
+    // Halves the FFN's GEMM launches (128 -> 64 per pass); decode is untouched because it reads
+    // the Q4_K copies (gate_q/up_q), so this is prefill-only.
+    const void* gate_up_cat_fp4 = nullptr; const void* gate_up_cat_fp4_sf = nullptr;
+    float gate_up_cat_alpha = 1.f;
+    int gate_up_cat_rows = 0;
     const void* gate_fp4 = nullptr; const void* gate_fp4_sf = nullptr;
     const void* up_fp4 = nullptr;   const void* up_fp4_sf = nullptr;
     // 1/weight_global_scale for checkpoint-native NVFP4 B operands. Muse's
@@ -106,6 +114,27 @@ struct Qwen35LayerWeights {
     const void* gdn_z_fp4 = nullptr;   const void* gdn_z_fp4_sf = nullptr;
     const void* gdn_out_fp4 = nullptr; const void* gdn_out_fp4_sf = nullptr;
     float gdn_qkv_fp4_alpha = 1.f, gdn_z_fp4_alpha = 1.f, gdn_out_fp4_alpha = 1.f;
+    // Full-attention q/k/v/o for the same NVFP4 checkpoints. These REPLACE the Q4_K refit rather
+    // than sitting beside it: the payload below is what decode's launch_gemv_nvfp4 reads too, so
+    // the only new bytes on the card are the CUTLASS SFB (1 per 16 weights). Keeping a Q4_K copy
+    // as well would cost ~0.9 GB, and at ctx=16384 this model already runs with under 1 GB free.
+    // q|k|v stacked into ONE [q_out + 2*kvdim, H] NVFP4 operand, REPLACING the three separate
+    // payloads (same bytes, one allocation -- VRAM neutral). ModelOpt quantizes the three together
+    // so their weight_scale_2 is bit-identical per layer, which is what makes a row-wise concat
+    // EXACT: packed nibbles and group scales are both row-major and one shared global means one
+    // GEMM alpha. Worth doing because at m=128 the grid IS the N-tile count -- k and v (n=1024)
+    // cover 16 of 170 SMs and cost as much wall time as the 12288-row q for a sixth of the bytes.
+    // Fused, n=14336 takes the wide tile at 112 CTAs. wq/wk/wv all point at this payload so the
+    // load-time null checks still hold; nothing reads them individually once qkv_cat is set.
+    const void* qkv_cat = nullptr;          // whole payload (hdr|group scales|packed), decode GEMV
+    const void* qkv_cat_fp4 = nullptr;      // packed nibbles = CUTLASS B
+    const void* qkv_cat_fp4_sf = nullptr;   // CUTLASS SFB over all q_out+2*kvdim rows
+    float qkv_cat_alpha = 1.f;
+    int qkv_cat_rows = 0;
+    const void* wq_fp4 = nullptr; const void* wq_fp4_sf = nullptr;
+    const void* wk_fp4 = nullptr; const void* wk_fp4_sf = nullptr;
+    const void* wv_fp4 = nullptr; const void* wv_fp4_sf = nullptr;
+    float wq_fp4_alpha = 1.f, wk_fp4_alpha = 1.f, wv_fp4_alpha = 1.f, wo_fp4_alpha = 1.f;
     // attention projections: 0 = bf16 dense (default); else ggml type id (12=Q4_K,
     // 14=Q6_K, 8=Q8_0) or SI_QTYPE_FP8 (108) / SI_QTYPE_NVFP4 (109) -> weights kept
     // quantized in VRAM, decoded on-read by launch_gemv_q / launch_gemv_fp8 /

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -394,7 +394,11 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->h=p_->alloc<bf16>(H); p_->hn=p_->alloc<bf16>(H);
     p_->routed=p_->alloc<bf16>(H); p_->shared=p_->alloc<bf16>(H);
     if (cfg.hybrid) {
-        p_->qraw=p_->alloc<bf16>(p_->qdim * 2);
+        // Sized for the fused q|k|v GEMV (see qkv_cat): [q|gate] then k then v in one buffer, so
+        // the single GEMV writes in place and split_q_gate still reads the leading 2*qdim. Widening
+        // one allocation avoids aliasing s.k/s.v into it, which the per-pointer cudaFree at
+        // teardown would turn into a double free.
+        p_->qraw=p_->alloc<bf16>(p_->qdim * 2 + p_->kvdim * 2);
         p_->qgate=p_->alloc<bf16>(p_->qdim);
         p_->lin_qkv=p_->alloc<bf16>(p_->linear_qkvdim);
         p_->lin_q=p_->alloc<bf16>(p_->linear_qdim);
@@ -1318,7 +1322,18 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 const bool attn_qkv = !sep_gate && s.use_attn_qkv && s.use_pq && s.use_llama
                                    && (H == 2048 || H == 4096 || H == 5120)
                                    && w.wq_type == 12 && w.wk_type == 12 && w.wv_type == 12;
-                if (attn_qkv) {
+                if (w.qkv_cat && q_dst == s.qraw) {
+                    // One GEMV over the fused operand instead of three. k and v are n=1024 on
+                    // their own -- at m=1 that is three launches for one weight stream, and the
+                    // fused payload is exactly q_out+2*kvdim rows so the GEMV's own offsets line
+                    // up. Copy the two tails out (2 KB each) rather than aliasing s.k/s.v.
+                    kernels::launch_gemv_nvfp4(s.xn, w.qkv_cat, s.qraw, w.qkv_cat_rows, H, st);
+                    bf16* kv = static_cast<bf16*>(s.qraw) + nq;
+                    cudaMemcpyAsync(s.k, kv, (size_t)s.kvdim * sizeof(bf16),
+                                    cudaMemcpyDeviceToDevice, st);
+                    cudaMemcpyAsync(s.v, kv + s.kvdim, (size_t)s.kvdim * sizeof(bf16),
+                                    cudaMemcpyDeviceToDevice, st);
+                } else if (attn_qkv) {
                     kernels::launch_attn_qkv_mmvq_q4k(s.aq81, w.wq, w.wk, w.wv,
                         q_dst, s.k, s.v, nq, s.kvdim, s.kvdim, H, st);
                 } else if (s.use_qkvstream) {
@@ -4527,7 +4542,8 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     };
 
     auto keep_nvfp4 = [&](const std::string& prefix, int rows, int cols,
-                          const void** fp4, const void** fp4_sf, float& fp4_alpha) -> const void* {
+                          const void** fp4, const void** fp4_sf, float& fp4_alpha,
+                          bool want_fp4 = true) -> const void* {
         NvFp4Src src{};
         if (!nvfp4_src(prefix, rows, cols, src)) {
             fprintf(stderr, "[compressed-tensors] %s: missing/malformed NVFP4 tensors\n",
@@ -4563,10 +4579,14 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             const char* e = getenv("SPARKINFER_QWEN38_PREFILL_NVFP4");
             return !(e && e[0] == '0');
         }();
-        if (keep_prefill_fp4) s.owned.push_back(payload);
+        // want_fp4=false: the caller is building a fused operand instead, so this payload is
+        // transient -- still the SOURCE for q4k_from_nvfp4 below, then freed by the caller. Keeping
+        // it out of s.owned is what makes that early free safe.
+        const bool keep_this = keep_prefill_fp4 && want_fp4;
+        if (keep_this) s.owned.push_back(payload);
         fp4_alpha = (global_scale != 0.f) ? (1.f / global_scale) : 1.f;
         const void* packed = static_cast<char*>(payload) + hdr + scale_bytes;
-        if (keep_prefill_fp4 && kernels::prefill_nvfp4_supported(128, rows, cols)) {
+        if (keep_this && kernels::prefill_nvfp4_supported(128, rows, cols)) {
             void* sf = nullptr;
             const size_t sf_bytes = kernels::prefill_nvfp4_scale_bytes_b(rows, cols);
             if (sf_bytes && cudaMalloc(&sf, sf_bytes) == cudaSuccess &&
@@ -4733,6 +4753,179 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         return payload;
     };
 
+    // The 16 full-attention layers ship q/k/v/o as NVFP4 too (same weight/weight_scale/
+    // weight_scale_2 trio the MLP uses), but they were being refit to Q4_K at load, so batched
+    // prefill then re-expanded every one of them Q4_K -> int8 on EVERY pass -- 2.5625 bytes of
+    // traffic per stored weight against the 0.625 the native form needs. Over 16 layers x
+    // (12288 + 1024 + 1024 + 5120... ) = 1.68 G weights that is ~4.3 GB moved per pass to read a
+    // 0.94 GB operand, and it is the same expand-then-renarrow the GDN projections had.
+    //
+    // This REPLACES the Q4_K copy instead of sitting beside it, and that is deliberate: at
+    // ctx=16384 this model runs with under 1 GB free, and a second copy (~0.9 GB) would starve the
+    // FFN chunk and cost more at 16k than it wins at 128. Decode reads the same payload through
+    // launch_gemv_nvfp4 (proj_xn already dispatches SI_QTYPE_NVFP4), so the switch is
+    // all-or-nothing per tensor: either the native payload is built and both paths use it, or the
+    // Q4_K refit stands and both paths use that. SPARKINFER_Q38_ATTN_NVFP4=0 forces the latter.
+    static const bool attn_keep_nvfp4 = [] {
+        const char* e = getenv("SPARKINFER_Q38_ATTN_NVFP4");
+        return !(e && e[0] == '0');
+    }();
+    auto keep_attn = [&](const std::string& prefix, int rows, int cols, int& qtype,
+                         const void** fp4, const void** fp4_sf, float* fp4_alpha) -> const void* {
+        NvFp4Src probe{};
+        if (attn_keep_nvfp4 && gdn_keep_nvfp4 && nvfp4_src(prefix, rows, cols, probe)) {
+            // Roll back cleanly if the SFB does not get built: keep_nvfp4_native has already
+            // registered the payload in s.owned and stamped qtype NVFP4 by then, and a payload
+            // without an SFB is the worst of both -- prefill would have an NVFP4 type and no B
+            // operand to go with it. Half a conversion is not a usable state, so undo it.
+            const size_t owned0 = s.owned.size();
+            const int qtype0 = qtype;
+            if (const void* p = keep_nvfp4_native(prefix, rows, cols, qtype, fp4, fp4_sf, fp4_alpha)) {
+                if (*fp4 && *fp4_sf) return p;
+                for (size_t i = owned0; i < s.owned.size(); i++) cudaFree(s.owned[i]);
+                s.owned.resize(owned0);
+                *fp4 = nullptr; *fp4_sf = nullptr; qtype = qtype0;
+            }
+        }
+        return requant_q4k(dequant_any(prefix, rows, cols), (long)rows * cols, qtype);
+    };
+
+    // Build q|k|v as a single NVFP4 payload. Requires all three to be NVFP4 with the SAME
+    // weight_scale_2 -- ModelOpt guarantees it (they are quantized as one group) but it is checked
+    // rather than assumed, because a mismatch would silently rescale two thirds of attention.
+    // Returns false having touched nothing if any precondition fails.
+    static const bool attn_cat_on = [] {
+        const char* e = getenv("SPARKINFER_Q38_ATTN_QKV_CAT");
+        return !(e && e[0] == '0');
+    }();
+    auto keep_attn_cat = [&](const std::string& ab, int q_out, int kvd, int cols,
+                             Qwen35LayerWeights& w) -> bool {
+        if (!attn_cat_on || !attn_keep_nvfp4 || !gdn_keep_nvfp4) return false;
+        NvFp4Src sq{}, sk{}, sv{};
+        if (!nvfp4_src(ab + "q_proj", q_out, cols, sq) ||
+            !nvfp4_src(ab + "k_proj", kvd, cols, sk) ||
+            !nvfp4_src(ab + "v_proj", kvd, cols, sv)) return false;
+        if (!(sq.global == sk.global && sq.global == sv.global)) return false;
+        const int rows = q_out + 2 * kvd;
+        if (!kernels::prefill_nvfp4_supported(128, rows, cols)) return false;
+        const size_t hdr = (size_t)kernels::SI_NVFP4_HDR;
+        const size_t sc_all = (size_t)rows * cols / 16, pk_all = (size_t)rows * cols / 2;
+        void* pay = nullptr;
+        if (cudaMalloc(&pay, hdr + sc_all + pk_all) != cudaSuccess) return false;
+        cudaMemset(pay, 0, hdr);
+        cudaMemcpy(pay, &sq.global, 4, cudaMemcpyHostToDevice);
+        char* sc = static_cast<char*>(pay) + hdr;
+        char* pk = sc + sc_all;
+        const NvFp4Src* src[3] = { &sq, &sk, &sv };
+        const int rw[3] = { q_out, kvd, kvd };
+        for (int i = 0; i < 3; i++) {
+            const size_t sb = (size_t)rw[i] * cols / 16, pb = (size_t)rw[i] * cols / 2;
+            cudaMemcpy(sc, src[i]->group, sb, cudaMemcpyHostToDevice);  sc += sb;
+            cudaMemcpy(pk, src[i]->packed, pb, cudaMemcpyHostToDevice); pk += pb;
+        }
+        void* sf = nullptr;
+        const size_t sf_bytes = kernels::prefill_nvfp4_scale_bytes_b(rows, cols);
+        if (!sf_bytes || cudaMalloc(&sf, sf_bytes) != cudaSuccess ||
+            !kernels::launch_ct_nvfp4_pack_sfb(static_cast<char*>(pay) + hdr, sf, rows, cols,
+                                               s.stream) ||
+            cudaStreamSynchronize(s.stream) != cudaSuccess) {
+            if (sf) cudaFree(sf);
+            cudaFree(pay);
+            return false;
+        }
+        s.owned.push_back(pay);
+        s.owned.push_back(sf);
+        w.qkv_cat = pay;
+        w.qkv_cat_fp4 = static_cast<char*>(pay) + hdr + sc_all;
+        w.qkv_cat_fp4_sf = sf;
+        w.qkv_cat_alpha = (sq.global != 0.f) ? (1.f / sq.global) : 1.f;
+        w.qkv_cat_rows = rows;
+        // Keep the three pointers valid (the load-time null check reads them); nothing consumes
+        // them individually once qkv_cat is set.
+        w.wq = w.wk = w.wv = pay;
+        w.wq_type = w.wk_type = w.wv_type = kernels::SI_QTYPE_NVFP4;
+        return true;
+    };
+
+    // gate|up as a single NVFP4 operand -- same exactness argument as keep_attn_cat (ModelOpt gives
+    // the pair one shared weight_scale_2, checked not assumed). Built from the HOST checkpoint
+    // arrays, so the two per-tensor device payloads stay transient and are freed by the caller
+    // after they have served as the source for the Q4_K decode copies. VRAM is therefore a wash.
+    static const bool gu_cat_on = [] {
+        const char* e = getenv("SPARKINFER_Q38_FFN_GU_CAT");
+        return !(e && e[0] == '0');
+    }();
+    // ALL layers or none. Prefill makes ffg/ffu strided views of ONE buffer, so the fused layout
+    // is a property of the whole pass, and keep_nvfp4 below drops the per-tensor FP4 payload for
+    // exactly the layers that fused -- so a partially-fusable checkpoint has no correct layout at
+    // all. Measured on unsloth/Qwen3.8-27B-NVFP4, where gate_proj and up_proj share a
+    // weight_scale_2 on 56 of 64 layers: committing to the fused layout dropped prefill@16k to the
+    // token loop (8687 -> 80 pp), and merely refusing it at prefill time still cost -30%, because
+    // those 56 layers had already lost their per-tensor FP4 at load. Decide before anything loads,
+    // from host-side metadata only (nvfp4_src is st.tensor() lookups plus a 4-byte memcpy, no
+    // device work). The ModelOpt checkpoint qualifies on all 64 layers and is unaffected.
+    bool gu_cat_uniform = c.dense_ffn || c.n_experts <= 0;
+    if (gu_cat_uniform && gu_cat_on) {
+        int eligible = 0;
+        for (int i = 0; i < c.n_layers; i++) {
+            const std::string mb =
+                "model.language_model.layers." + std::to_string(i) + ".mlp.";
+            NvFp4Src sg{}, su{};
+            if (nvfp4_src(mb + "gate_proj", c.moe_ffn, H, sg) &&
+                nvfp4_src(mb + "up_proj", c.moe_ffn, H, su) && sg.global == su.global) eligible++;
+        }
+        if (eligible != c.n_layers) {
+            gu_cat_uniform = false;
+            if (eligible)
+                fprintf(stderr, "[compressed-tensors] gate|up fusable on %d/%d layers -- not "
+                                "uniform, keeping the per-tensor NVFP4 layout\n",
+                        eligible, c.n_layers);
+        }
+    }
+    auto keep_gu_cat = [&](const std::string& mb, int ff, int cols,
+                           Qwen35LayerWeights& w) -> bool {
+        // gu_cat_uniform is the all-or-nothing decision taken before any layer loaded; without it
+        // a partially-fusable checkpoint ends up with no correct ffg/ffu layout at all.
+        if (!gu_cat_on || !gu_cat_uniform) return false;
+        NvFp4Src sg{}, su{};
+        if (!nvfp4_src(mb + "gate_proj", ff, cols, sg) ||
+            !nvfp4_src(mb + "up_proj", ff, cols, su)) return false;
+        if (!(sg.global == su.global)) return false;
+        const int rows = 2 * ff;
+        if (!kernels::prefill_nvfp4_supported(128, rows, cols)) return false;
+        const size_t hdr = (size_t)kernels::SI_NVFP4_HDR;
+        const size_t sc_all = (size_t)rows * cols / 16, pk_all = (size_t)rows * cols / 2;
+        void* pay = nullptr;
+        if (cudaMalloc(&pay, hdr + sc_all + pk_all) != cudaSuccess) return false;
+        cudaMemset(pay, 0, hdr);
+        cudaMemcpy(pay, &sg.global, 4, cudaMemcpyHostToDevice);
+        char* sc = static_cast<char*>(pay) + hdr;
+        char* pk = sc + sc_all;
+        const NvFp4Src* src[2] = { &sg, &su };
+        for (int i = 0; i < 2; i++) {
+            const size_t sb = (size_t)ff * cols / 16, pb = (size_t)ff * cols / 2;
+            cudaMemcpy(sc, src[i]->group, sb, cudaMemcpyHostToDevice);  sc += sb;
+            cudaMemcpy(pk, src[i]->packed, pb, cudaMemcpyHostToDevice); pk += pb;
+        }
+        void* sf = nullptr;
+        const size_t sf_bytes = kernels::prefill_nvfp4_scale_bytes_b(rows, cols);
+        if (!sf_bytes || cudaMalloc(&sf, sf_bytes) != cudaSuccess ||
+            !kernels::launch_ct_nvfp4_pack_sfb(static_cast<char*>(pay) + hdr, sf, rows, cols,
+                                               s.stream) ||
+            cudaStreamSynchronize(s.stream) != cudaSuccess) {
+            if (sf) cudaFree(sf);
+            cudaFree(pay);
+            return false;
+        }
+        s.owned.push_back(pay);
+        s.owned.push_back(sf);
+        w.gate_up_cat_fp4 = static_cast<char*>(pay) + hdr + sc_all;
+        w.gate_up_cat_fp4_sf = sf;
+        w.gate_up_cat_alpha = (sg.global != 0.f) ? (1.f / sg.global) : 1.f;
+        w.gate_up_cat_rows = rows;
+        return true;
+    };
+
     // One Linear kept in whatever native form this checkpoint ships it in: FP8 stays FP8, NVFP4
     // stays NVFP4, and anything else falls back to a Q4_K fit from bf16. Used for the GDN
     // projections, where both shipped checkpoints deliberately avoid a second quantization.
@@ -4758,7 +4951,7 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     if (!s.w.embed_tokens || !s.w.final_norm || !s.w.lm_head) return false;
 
     s.w.layers.resize(c.n_layers);
-    int gu_ready = 0;
+    int gu_ready = 0, attn_ready = 0, attn_cat_ready = 0;
     for (int i = 0; i < c.n_layers; i++) {
         const std::string b = "model.language_model.layers." + std::to_string(i) + ".";
         Qwen35LayerWeights& w = s.w.layers[i];
@@ -4801,13 +4994,23 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             w.q_has_gate = c.hybrid;
             const std::string ab = b + "self_attn.";
             const int q_out = w.q_has_gate ? s.qdim * 2 : s.qdim;
-            w.wq = requant_q4k(dequant_any(ab + "q_proj", q_out, H), (long)q_out * H, w.wq_type);
-            w.wk = requant_q4k(dequant_any(ab + "k_proj", s.kvdim, H), (long)s.kvdim * H, w.wk_type);
-            w.wv = requant_q4k(dequant_any(ab + "v_proj", s.kvdim, H), (long)s.kvdim * H, w.wv_type);
-            w.wo = requant_q4k(dequant_any(ab + "o_proj", H, s.qdim), (long)H * s.qdim, w.wo_type);
+            // q|k|v as ONE operand when the checkpoint lets it be exact -- see qkv_cat in
+            // qwen35.h. keep_attn's per-tensor path is the fallback for everything else.
+            if (!keep_attn_cat(ab, q_out, s.kvdim, H, w)) {
+                w.wq = keep_attn(ab + "q_proj", q_out, H, w.wq_type,
+                                 &w.wq_fp4, &w.wq_fp4_sf, &w.wq_fp4_alpha);
+                w.wk = keep_attn(ab + "k_proj", s.kvdim, H, w.wk_type,
+                                 &w.wk_fp4, &w.wk_fp4_sf, &w.wk_fp4_alpha);
+                w.wv = keep_attn(ab + "v_proj", s.kvdim, H, w.wv_type,
+                                 &w.wv_fp4, &w.wv_fp4_sf, &w.wv_fp4_alpha);
+            }
+            w.wo = keep_attn(ab + "o_proj", H, s.qdim, w.wo_type,
+                             &w.wo_fp4, &w.wo_fp4_sf, &w.wo_fp4_alpha);
             w.q_norm = load_norm_plus1(ab + "q_norm.weight", c.head_dim);
             w.k_norm = load_norm_plus1(ab + "k_norm.weight", c.head_dim);
             if (!w.wq || !w.wk || !w.wv || !w.wo || !w.q_norm || !w.k_norm) return false;
+            if ((w.qkv_cat || (w.wq_fp4 && w.wk_fp4 && w.wv_fp4)) && w.wo_fp4) ++attn_ready;
+            if (w.qkv_cat) ++attn_cat_ready;
         }
 
         const std::string mb = b + "mlp.";
@@ -4819,16 +5022,22 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             w.down_q = requant_q4k(dequant_any(mb + "down_proj", H, c.moe_ffn),
                                    (long)H * c.moe_ffn, w.down_qtype);
         } else {
+            const bool gu_cat = keep_gu_cat(mb, c.moe_ffn, H, w);
             const void* g_pay = keep_nvfp4(mb + "gate_proj", c.moe_ffn, H,
-                                           &w.gate_fp4, &w.gate_fp4_sf, w.gate_fp4_alpha);
+                                           &w.gate_fp4, &w.gate_fp4_sf, w.gate_fp4_alpha, !gu_cat);
             const void* u_pay = keep_nvfp4(mb + "up_proj", c.moe_ffn, H,
-                                           &w.up_fp4, &w.up_fp4_sf, w.up_fp4_alpha);
+                                           &w.up_fp4, &w.up_fp4_sf, w.up_fp4_alpha, !gu_cat);
             const void* d_pay = keep_nvfp4(mb + "down_proj", H, c.moe_ffn,
                                            &w.down_fp4, &w.down_fp4_sf, w.down_fp4_alpha);
             w.gate_q = q4k_from_nvfp4(g_pay, c.moe_ffn, H, w.gate_qtype);
             w.up_q = q4k_from_nvfp4(u_pay, c.moe_ffn, H, w.up_qtype);
             w.down_q = q4k_from_nvfp4(d_pay, H, c.moe_ffn, w.down_qtype);
-            if (!w.gate_fp4) {
+            if (gu_cat) {
+                // The fused operand replaced them; these two only fed q4k_from_nvfp4 above.
+                cudaFree(const_cast<void*>(g_pay));
+                cudaFree(const_cast<void*>(u_pay));
+            }
+            if (!w.gate_fp4 && !gu_cat) {
                 // Prefill copies disabled: the payloads were deliberately not registered in
                 // s.owned (see keep_nvfp4), the Q4_K decode copies above are built, so release the
                 // NVFP4 source now rather than at teardown. Keyed on gate_fp4 being unset, which
@@ -4837,13 +5046,13 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
                 cudaFree(const_cast<void*>(u_pay));
                 cudaFree(const_cast<void*>(d_pay));
             }
-            if (w.gate_fp4 && w.up_fp4) ++gu_ready;
+            if ((w.gate_fp4 && w.up_fp4) || w.gate_up_cat_fp4) ++gu_ready;
         }
         if (!w.gate_q || !w.up_q || !w.down_q) return false;
     }
     fprintf(stderr, "[compressed-tensors] loaded %d layers, native NVFP4 prefill FFN %d/%d "
-            "(decode stays Q4_K)\n",
-            c.n_layers, gu_ready, c.n_layers);
+            "(decode stays Q4_K), full-attn q/k/v/o %d layers (qkv fused %d)\n",
+            c.n_layers, gu_ready, c.n_layers, attn_ready, attn_cat_ready);
 
     // Same fused Q4_K-in-GEMM row scales Muse uses, for whichever tensors ended up Q4_K after the
     // per-tensor routing above -- full-attn q/k/v/o always, plus any FFN layer with no native

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -279,8 +279,32 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                 "batched pass\n", fc_before, FC, N, fb >> 20);
         }
     }
-    bf16* ffg  = a.alloc<bf16>((size_t)FC * ffn);        // ffn gate (12288), bounded to FC tokens
-    bf16* ffu  = a.alloc<bf16>((size_t)FC * ffn);        // ffn up,          bounded to FC tokens
+    // With a fused gate|up operand the GEMM emits [FC, 2*ffn] (gate then up PER ROW), so ffg/ffu
+    // become strided views of one buffer rather than two tight ones. Same total bytes either way,
+    // which is what keeps this VRAM-neutral at ctx=16384 where the FFN chunk is already competing
+    // for the last ~900 MB.
+    // ALL-OR-NOTHING, and it must be: ffg/ffu below become strided views of ONE buffer, so the
+    // layout is a property of the whole pass, not of a layer. keep_gu_cat is per-layer and can
+    // legitimately decline for some layers (it requires gate_proj and up_proj to share one
+    // weight_scale_2, which only holds when the checkpoint quantized them as one group), and
+    // keep_nvfp4 then frees the per-tensor FP4 payload for exactly the layers that DID fuse. So a
+    // mixed checkpoint has no single correct layout, and probing for the FIRST layer that fused
+    // committed the pass to a stride the other layers cannot satisfy -- measured on
+    // unsloth/Qwen3.8-27B-NVFP4 at ctx=16384, where one non-fused layer dropped the entire
+    // prefill to the token loop (8687 -> 80 pp). Require every layer, so the fallback is the
+    // ordinary tight-buffer path rather than a bail.
+    int gu_cat_layers = 0;
+    for (const auto& lw : s.w.layers)
+        if (lw.gate_up_cat_fp4 && lw.gate_up_cat_fp4_sf) gu_cat_layers++;
+    const bool gu_cat_live = !moe && !s.w.layers.empty() &&
+                             gu_cat_layers == (int)s.w.layers.size();
+    if (!s.w.layers.empty() && gu_cat_layers && !gu_cat_live)
+        fprintf(stderr, "[prefill] gate|up fused on %d/%zu layers -- not uniform, using the "
+                        "per-tensor layout\n", gu_cat_layers, s.w.layers.size());
+    bf16* ffgu = gu_cat_live ? a.alloc<bf16>((size_t)FC * ffn * 2) : nullptr;
+    bf16* ffg  = gu_cat_live ? ffgu       : a.alloc<bf16>((size_t)FC * ffn);
+    bf16* ffu  = gu_cat_live ? ffgu + ffn : a.alloc<bf16>((size_t)FC * ffn);
+    const int gu_src_stride = gu_cat_live ? 2 * ffn : ffn;
     bf16* ffh  = ffg;                                    // SwiGLU computed in-place into ffg (down reads it)
     bf16* wbuf = a.alloc<bf16>(maxw);                    // dequantized-weight scratch (reused)
     int*  d_ids = a.alloc<int>((size_t)N);
@@ -511,7 +535,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // back on a throughput result alone, because throughput is what selected for the bug.
     // SPARKINFER_Q38_NVFP4=1 re-enables it for that debugging.
     const bool q38_nvfp4 = [&] {
-        if (!c.dense_ffn || c.muse_glimmer || s.w.layers.empty() || !s.w.layers[0].gate_fp4)
+        // gate_fp4 is null when the fused gate|up operand replaced the per-tensor pair, so probe
+        // for either form -- this predicate is what turns the whole FP4 FFN arm on.
+        if (!c.dense_ffn || c.muse_glimmer || s.w.layers.empty() ||
+            (!s.w.layers[0].gate_fp4 && !s.w.layers[0].gate_up_cat_fp4))
             return false;
         if (!kernels::prefill_nvfp4_supported(N, ffn, H)) return false;
         const char* e = getenv("SPARKINFER_Q38_NVFP4");
@@ -558,6 +585,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     size_t fp4_ws_bytes = (fp4_ws_qkv > fp4_ws_gu) ? fp4_ws_qkv : fp4_ws_gu;
     if (fp4_ws_wo > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_wo;
     if (fp4_ws_down > fp4_ws_bytes) fp4_ws_bytes = fp4_ws_down;
+    // The fused gate|up GEMM is twice as wide as either half, so it wants a bigger CUTLASS
+    // workspace than any shape above. Sizing this here is what the arm's success depends on --
+    // an undersized ws is exactly how run_gemm declines and the pass falls to the token loop.
+    for (const auto& lw : s.w.layers) {
+        if (!lw.gate_up_cat_fp4) continue;
+        const size_t w2 = kernels::prefill_nvfp4_workspace_bytes(fp4_rows, lw.gate_up_cat_rows, H);
+        if (w2 > fp4_ws_bytes) fp4_ws_bytes = w2;
+        break;
+    }
     unsigned char* fp4_a = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_a_data_bytes) : nullptr;
     unsigned char* fp4_as = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_a_sf_bytes) : nullptr;
     unsigned char* fp4_ws = gu_nvfp4 ? a8.alloc<unsigned char>(fp4_ws_bytes) : nullptr;
@@ -613,24 +649,82 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         kernels::prefill_nvfp4_supported(N, lqkv, H) &&
         kernels::prefill_nvfp4_supported(N, lvdim, H) &&
         kernels::prefill_nvfp4_supported(N, H, lvdim);
+    // ---- full-attention q/k/v/o straight off the checkpoint's NVFP4 bytes ----
+    // The other half of the same expand-then-renarrow the GDN arm above deletes. On this
+    // checkpoint q/k/v/o are NVFP4, but the loader used to refit them to Q4_K, so every pass ran
+    // Q4_K -> int8 (deq_rows_i8_vec, measured 2.34 ms of a 21.4 ms pass) -> int8 GEMM. With the
+    // native payload kept instead (see keep_attn in qwen35.cpp) the same SM120 block-scaled GEMM
+    // the FFN and GDN already use reads the packed nibbles directly.
+    //
+    // Bounded by the same N as the GDN arm and for the same two reasons: the saving is a per-layer
+    // FIXED cost so it is worth most where N is small, and a fixed bound keeps the scored shape off
+    // the cudaMemGetInfo-derived FC.
+    //
+    // The A/B switch is SPARKINFER_Q38_ATTN_NVFP4=0 (qwen35.cpp), NOT this mask: the conversion is
+    // all-or-nothing, so once the payload is NVFP4 there are no Q4_K row scales left for the int8
+    // group to use and clearing a bit here drops that projection to the generic proj() path rather
+    // than to the path this replaced. The mask is for pricing q/k/v (bit 0) against o_proj (bit 1)
+    // while both operands exist -- it is a probe, not an escape hatch.
+    static const int attn_fp4_mask = [] {
+        const char* e = getenv("SPARKINFER_Q38_ATTN_NVFP4_PREFILL");
+        return e ? atoi(e) : 3;
+    }();
+    const Qwen35LayerWeights* attn_probe = nullptr;
+    for (const auto& lw : s.w.layers)
+        if (!lw.linear_attn) { attn_probe = &lw; break; }
+    const bool attn_nvfp4 = attn_fp4_mask != 0 && !moe && attn_probe &&
+        (attn_probe->wq_fp4 || attn_probe->qkv_cat) &&
+        N <= gdn_fp4_maxn &&
+        kernels::prefill_nvfp4_supported(N, wide, H) &&
+        kernels::prefill_nvfp4_supported(N, kvdim, H) &&
+        kernels::prefill_nvfp4_supported(N, H, qdim);
     // out_proj's A operand is `lnrm` at k = lvdim, which is WIDER than the FFN's k = H on this
     // model (6144 vs 5120), so fp4_a/fp4_as cannot be reused -- they would be overrun by a quarter
-    // of a row. One staging pair sized for the widest GDN k covers all three projections.
-    const int gdn_k = (lvdim > H) ? lvdim : H;
-    unsigned char* fp4_gdn_a = gdn_nvfp4
+    // of a row. One staging pair sized for the widest GDN k covers all three projections; the
+    // attention arm shares it, so size it for the widest k of EITHER (o_proj reads att at k=qdim).
+    int gdn_k = (lvdim > H) ? lvdim : H;
+    if (attn_nvfp4 && qdim > gdn_k) gdn_k = qdim;
+    // Fused q|k|v GEMM output: [N, q_out + 2*kvdim]. split_q_gate reads the leading [q|gate] in
+    // place with this row stride; k and v are copied out (256 KB each) rather than teaching
+    // qknorm_rope a stride.
+    const Qwen35LayerWeights* attn_cat_probe = nullptr;
+    for (const auto& lw : s.w.layers)
+        if (!lw.linear_attn) { attn_cat_probe = &lw; break; }
+    const int qkvc_n = (attn_cat_probe && attn_cat_probe->qkv_cat) ? attn_cat_probe->qkv_cat_rows : 0;
+    bf16* qkvc = nullptr;
+    // With the fused operand there is no per-tensor q/k/v left to fall back to -- wq/wk/wv all
+    // point at the concatenated payload, which any per-tensor reader would mis-offset. If this N
+    // cannot run the fused GEMM, hand the whole pass to the token loop instead of reading garbage.
+    if (qkvc_n && !kernels::prefill_nvfp4_supported(N, qkvc_n, H)) {
+        a.free_all(); a8.free_all();
+        fprintf(stderr, "[prefill] fused q|k|v operand unsupported at N=%d -> token loop\n", N);
+        return -1;
+    }
+    const bool fp4_stage = gdn_nvfp4 || attn_nvfp4;
+    if (qkvc_n && attn_nvfp4) qkvc = a.alloc<bf16>((size_t)N * qkvc_n);
+    unsigned char* fp4_gdn_a = fp4_stage
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, gdn_k)) : nullptr;
-    unsigned char* fp4_gdn_as = gdn_nvfp4
+    unsigned char* fp4_gdn_as = fp4_stage
         ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, gdn_k)) : nullptr;
     // The three GDN shapes can each want more workspace than the FFN's, and fp4_ws is shared.
     unsigned char* fp4_gdn_ws = nullptr;
-    if (gdn_nvfp4) {
-        size_t wb = kernels::prefill_nvfp4_workspace_bytes(N, lqkv, H);
-        const size_t wz = kernels::prefill_nvfp4_workspace_bytes(N, lvdim, H);
-        const size_t wo = kernels::prefill_nvfp4_workspace_bytes(N, H, lvdim);
-        if (wz > wb) wb = wz;
-        if (wo > wb) wb = wo;
+    if (fp4_stage) {
+        size_t wb = 0;
+        auto need = [&](int n, int k) {
+            const size_t w = kernels::prefill_nvfp4_workspace_bytes(N, n, k);
+            if (w > wb) wb = w;
+        };
+        if (gdn_nvfp4) { need(lqkv, H); need(lvdim, H); need(H, lvdim); }
+        if (attn_nvfp4) { need(wide, H); need(kvdim, H); need(H, qdim); }
         fp4_gdn_ws = (wb <= fp4_ws_bytes && fp4_ws) ? fp4_ws : a8.alloc<unsigned char>(wb);
     }
+
+    // Set by the end-of-layer add+norm when it also wrote the FP4 A operand for the NEXT layer's
+    // qkv group, so that group can skip its own quantize. The memo crosses the loop boundary, so
+    // it is copied into `xn_fp4` and cleared at the top of every iteration -- a layer can only ever
+    // consume what its immediate predecessor left. Declared here rather than in the loop because
+    // gdn_qkv_z (defined below, before the loop) reads it.
+    bool xn_fp4_ready = false, xn_fp4 = false;
 
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
@@ -1029,7 +1123,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (gdn_nvfp4 && (gdn_fp4_mask & 1) &&
             w.gdn_qkv_fp4 && w.gdn_qkv_fp4_sf && w.gdn_z_fp4 && w.gdn_z_fp4_sf &&
             fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
-            kernels::launch_prefill_nvfp4_quant_a(A, fp4_gdn_a, fp4_gdn_as, N, H, st) &&
+            ((xn_fp4 && A == xn) ||
+             kernels::launch_prefill_nvfp4_quant_a(A, fp4_gdn_a, fp4_gdn_as, N, H, st)) &&
             kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
                                                w.gdn_qkv_fp4, w.gdn_qkv_fp4_sf,
                                                b8, N, lqkv, H, fp4_gdn_ws, st,
@@ -1097,10 +1192,24 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     if (moe_hide_sg)
         pf_cu(cudaEventCreateWithFlags(&moe_ev_sg, cudaEventDisableTiming), "moe ev_sg");
 
+    // Both residual adds in a dense layer land immediately before a norm with nothing in between,
+    // so launch_add_rmsnorm2 can do each pair in one pass instead of two -- one fewer launch per
+    // site per layer, and `x` is not re-read from L2 between them.
+    static const bool addnorm_fuse = [] {
+        const char* e = getenv("SPARKINFER_Q38_PREFILL_ADDNORM");
+        return !(e && e[0] == '0');
+    }();
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
         a_q = nullptr; a_pk = false;                   // xn/hn are refreshed in place each layer
         bool attn_fused = false;                       // post-attn residual folded into the proj?
+        // The dense FFN's residual add sits immediately before the end-of-layer norm with nothing
+        // between them, so defer it and let launch_add_rmsnorm2 do both -- the same pairing already
+        // taken after attention above. `ao` still holds the FFN output at the norm site.
+        bool ffn_add_pending = false;
+        bool hn_fp4_ready = false;     // post-attn norm already wrote fp4_a/fp4_as from `hn`
+        xn_fp4 = xn_fp4_ready;   // consume the predecessor's memo, then drop it
+        xn_fp4_ready = false;
         // Set when the o / ffn_down split-K accumulator was left un-reduced for the sandwich
         // norm to consume directly. Per layer: qb_partials is reused by the next GEMM.
         int attn_acc = 0, ffn_acc = 0;
@@ -1120,7 +1229,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             kernels::launch_prefill_gdn_scan(gq, gk, gv, la, lb, w.ssm_dt, w.ssm_a,
                 layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim,
                 c.gdn_qh_block, st);
-            kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
+            // The out projection below quantizes `lnrm` to FP4 immediately and nothing touches
+            // fp4_gdn_a in between, so fold that quantize into the gated norm. Consumed only under
+            // the same operand it was produced from; a false here just means the out projection
+            // quantizes for itself, as before.
+            bool lnrm_fp4_ready = false;
+            if (gdn_nvfp4 && (gdn_fp4_mask & 2) && w.gdn_out_fp4 && w.gdn_out_fp4_sf &&
+                fp4_gdn_a && fp4_gdn_as &&
+                kernels::launch_prefill_gated_norm_nvfp4_a(att, lz, w.ssm_norm, lnrm,
+                                                           fp4_gdn_a, fp4_gdn_as,
+                                                           N, lvdim, c.linear_head_dim, eps, st))
+                lnrm_fp4_ready = true;
+            else
+                kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
             // out_proj off the same NVFP4 bytes. The block-scaled GEMM cannot accumulate the
             // residual, so this writes the RAW projection to `ao` and leaves attn_fused false --
             // the `if (!attn_fused) launch_prefill_add(x, ao, x, ...)` below is what applies it,
@@ -1128,7 +1249,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             const bool out_fp4 = gdn_nvfp4 && (gdn_fp4_mask & 2) &&
                 w.gdn_out_fp4 && w.gdn_out_fp4_sf &&
                 fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
-                kernels::launch_prefill_nvfp4_quant_a(lnrm, fp4_gdn_a, fp4_gdn_as, N, lvdim, st) &&
+                (lnrm_fp4_ready ||
+                 kernels::launch_prefill_nvfp4_quant_a(lnrm, fp4_gdn_a, fp4_gdn_as, N, lvdim, st)) &&
                 kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
                                                    w.gdn_out_fp4, w.gdn_out_fp4_sf,
                                                    ao, N, H, lvdim, fp4_gdn_ws, st,
@@ -1214,8 +1336,53 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // Qwen3.8: [q|gate] is one wide wq, then skinny k/v (8 tiles each). One grouped
                 // launch fills the 5090; four separate ones leave k/v paying a full CTA duration
                 // for 8 blocks. Same kernel as Muse, bit-identical per tile.
-                bool grouped = false;
-                if (use_i8 && w.wq_rs && w.wk_rs && w.wv_rs &&
+                //
+                // Checkpoint-native NVFP4 first: quantize xn to FP4 ONCE (all three read it) and
+                // run three block-scaled GEMMs straight off the packed nibbles. Unlike the int8
+                // group this cannot batch the three into one launch, but it does not need to --
+                // the point here is the weight traffic, not the tile count, and k/v are 1/12th of
+                // wq. A_i8/sx are untouched, so the int8 activation memo stays valid downstream.
+                bool qkv_fp4 = false;
+                bool qkv_cat_done = false;
+                if (attn_nvfp4 && (attn_fp4_mask & 1) && qkvc && w.qkv_cat_fp4 && w.qkv_cat_fp4_sf &&
+                    fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
+                    kernels::prefill_nvfp4_supported(N, w.qkv_cat_rows, H) &&
+                    (xn_fp4 ||
+                     kernels::launch_prefill_nvfp4_quant_a(xn, fp4_gdn_a, fp4_gdn_as, N, H, st)) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                       w.qkv_cat_fp4, w.qkv_cat_fp4_sf,
+                                                       qkvc, N, w.qkv_cat_rows, H, fp4_gdn_ws, st,
+                                                       w.qkv_cat_alpha)) {
+                    // k and v are the two tails of the fused output.
+                    const size_t rs = (size_t)w.qkv_cat_rows * sizeof(bf16);
+                    const size_t kb = (size_t)kvdim * sizeof(bf16);
+                    qkv_cat_done =
+                        cudaMemcpy2DAsync(kf, kb, qkvc + wide, rs, kb, N,
+                                          cudaMemcpyDeviceToDevice, st) == cudaSuccess &&
+                        cudaMemcpy2DAsync(vf, kb, qkvc + wide + kvdim, rs, kb, N,
+                                          cudaMemcpyDeviceToDevice, st) == cudaSuccess;
+                }
+                if (qkv_cat_done) qkv_fp4 = true;
+                else if (attn_nvfp4 && (attn_fp4_mask & 1) &&
+                    w.wq_fp4 && w.wq_fp4_sf && w.wk_fp4 && w.wk_fp4_sf &&
+                    w.wv_fp4 && w.wv_fp4_sf && fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
+                    (xn_fp4 ||
+                     kernels::launch_prefill_nvfp4_quant_a(xn, fp4_gdn_a, fp4_gdn_as, N, H, st)) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                       w.wq_fp4, w.wq_fp4_sf,
+                                                       b8, N, wide, H, fp4_gdn_ws, st,
+                                                       w.wq_fp4_alpha) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                       w.wk_fp4, w.wk_fp4_sf,
+                                                       kf, N, kvdim, H, fp4_gdn_ws, st,
+                                                       w.wk_fp4_alpha) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                       w.wv_fp4, w.wv_fp4_sf,
+                                                       vf, N, kvdim, H, fp4_gdn_ws, st,
+                                                       w.wv_fp4_alpha))
+                    qkv_fp4 = true;
+                bool grouped = qkv_fp4;
+                if (!qkv_fp4 && use_i8 && w.wq_rs && w.wk_rs && w.wv_rs &&
                     w.wk_type == w.wq_type && w.wv_type == w.wq_type &&
                     kernels::pf_dense_gemm_qi8_supported(w.wq_type)) {
                     const void*  Wa[3]  = { w.wq, w.wk, w.wv };
@@ -1233,7 +1400,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     proj_fused(xn, w.wk, w.wk_type, w.wk_rs, kf, kvdim, H);
                     proj_fused(xn, w.wv, w.wv_type, w.wv_rs, vf, kvdim, H);
                 }
-                kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
+                if (qkv_cat_done)
+                    kernels::launch_prefill_split_q_gate(qkvc, qb, qg, N, c.n_q_heads, c.head_dim,
+                                                         st, w.qkv_cat_rows);
+                else
+                    kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
             }
             if (c.muse_glimmer) {
                 // Muse Glimmer runs a BF16 KV cache (its decode KV-write is bf16, qwen35.cpp:1065/1087),
@@ -1322,6 +1493,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 if (!wo_fp4_done)
                     proj_fused_acc(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim, &attn_acc);
                 attn_fused = false;
+            } else if (attn_nvfp4 && (attn_fp4_mask & 2) &&
+                       w.wo_fp4 && w.wo_fp4_sf &&
+                       fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
+                       kernels::launch_prefill_nvfp4_quant_a(att, fp4_gdn_a, fp4_gdn_as,
+                                                             N, qdim, st) &&
+                       kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                          w.wo_fp4, w.wo_fp4_sf,
+                                                          ao, N, H, qdim, fp4_gdn_ws, st,
+                                                          w.wo_fp4_alpha)) {
+                // `att` is already gated by the mul_sigmoid above, so this quantizes the same
+                // activation the int8 arms would have. The block-scaled GEMM cannot accumulate the
+                // residual, so leave attn_fused false and let the launch_prefill_add below apply
+                // it -- the same bookkeeping the GDN out_proj arm uses.
+                attn_fused = false;
             } else if (w.wo_rs) {
                 proj_fused(att, w.wo, w.wo_type, w.wo_rs, ao, H, qdim);
                 attn_fused = false;
@@ -1361,8 +1546,41 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         } else {
             // x += ao (post-attn residual, in-place; skipped when folded into the output proj)
             // hn = RMSNorm(x, post_attn_norm)
-            if (!attn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
-            kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
+            //
+            // One kernel instead of two when the add is actually taken: launch_add_rmsnorm2 emits
+            // BOTH the residual sum and its norm, which is exactly this pair, and it saves the
+            // round trip that re-reads `x` from L2 between them plus one launch per layer. At
+            // N=128 these tensors are L2-resident so the win is the launch and the re-read, not
+            // DRAM. Same arithmetic -- same add, same rms over the same sum, same weight -- but
+            // the fused kernel owns its reduction order, so this is numerically equivalent rather
+            // than provably bit-identical; the batched-prefill parity gate is what checks it.
+            // SPARKINFER_Q38_PREFILL_ADDNORM=0 restores the split pairs (A/B in ONE binary).
+            // The FFN quantizes `hn` to FP4 immediately below and nothing touches fp4_a in
+            // between, so fold that quantize in here too when the FFN will read the whole tensor
+            // as ONE chunk. The flag is consumed only under `fo == 0 && fn == N` at the actual use
+            // site, so if the chunk loop disagrees with this prediction the FFN simply quantizes
+            // for itself -- a redundant kernel, never stale data. That asymmetry is deliberate:
+            // a residual-stream flag decided here and trusted there is exactly what silently
+            // dropped the FFN for twelve PRs (#837..#ccd7818).
+            hn_fp4_ready = false;
+            if (!attn_fused && addnorm_fuse) {
+                // The FFN's FP4 arm is live under EITHER operand form. Testing only the per-tensor
+                // w.gate_fp4 silently disabled this fold on every layer of a checkpoint whose
+                // gate|up fused, because keep_nvfp4(..., want_fp4 = !gu_cat) leaves that pointer
+                // null exactly when the concat took it -- the same "predicate reads a pointer the
+                // concat nulls" shape as the q38_nvfp4 bug.
+                const bool ffn_fp4_live = (w.gate_up_cat_fp4 && w.gate_up_cat_fp4_sf) ||
+                                          (w.gate_fp4 && w.gate_fp4_sf);
+                if (N <= FC && ffn_fp4_live && fp4_a && fp4_as &&
+                    kernels::launch_prefill_add_rmsnorm2_nvfp4_a(
+                        x, ao, w.post_attn_norm, x, hn, fp4_a, fp4_as, N, H, eps, st))
+                    hn_fp4_ready = true;
+                else
+                    kernels::launch_add_rmsnorm2(x, ao, w.post_attn_norm, x, hn, N, H, eps, st);
+            } else {
+                if (!attn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+                kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
+            }
         }
 
         if (!moe) {
@@ -1417,25 +1635,44 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
-                const bool layer_fp4 = gu_nvfp4 && w.gate_fp4 && w.gate_fp4_sf &&
-                    w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as &&
+                const bool layer_fp4 = gu_nvfp4 && (gu_cat_live || (w.gate_fp4 && w.gate_fp4_sf)) &&
+                    (gu_cat_live || (w.up_fp4 && w.up_fp4_sf)) && fp4_a && fp4_as &&
                     kernels::prefill_nvfp4_supported(fn, ffn, H) &&
-                    kernels::launch_prefill_nvfp4_quant_a(hn_c, fp4_a, fp4_as, fn, H, st) &&
-                    kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gate_fp4, w.gate_fp4_sf,
-                                                       ffg, fn, ffn, H, fp4_ws, st,
-                                                       w.gate_fp4_alpha) &&
-                    kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4, w.up_fp4_sf,
-                                                       ffu, fn, ffn, H, fp4_ws, st,
-                                                       w.up_fp4_alpha);
+                    (!gu_cat_live ||
+                     kernels::prefill_nvfp4_supported(fn, w.gate_up_cat_rows, H)) &&
+                    ((hn_fp4_ready && fo == 0 && fn == N) ||
+                     kernels::launch_prefill_nvfp4_quant_a(hn_c, fp4_a, fp4_as, fn, H, st)) &&
+                    (gu_cat_live
+                        ? kernels::launch_prefill_nvfp4_gemm(
+                              fp4_a, fp4_as, w.gate_up_cat_fp4, w.gate_up_cat_fp4_sf,
+                              ffgu, fn, w.gate_up_cat_rows, H, fp4_ws, st, w.gate_up_cat_alpha)
+                        : (kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gate_fp4,
+                                                              w.gate_fp4_sf, ffg, fn, ffn, H,
+                                                              fp4_ws, st, w.gate_fp4_alpha) &&
+                           kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.up_fp4,
+                                                              w.up_fp4_sf, ffu, fn, ffn, H,
+                                                              fp4_ws, st, w.up_fp4_alpha)));
+                if (!layer_fp4 && gu_cat_live) {
+                    a.free_all(); a8.free_all();
+                    fprintf(stderr, "[prefill] fused gate|up GEMM declined at fn=%d -> token loop\n", fn);
+                    return -1;
+                }
                 if (layer_fp4) {
                     const bool down_fp4_done = nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
                         fp4_down_a && fp4_down_as &&
                         kernels::launch_prefill_nvfp4_swiglu_quant_a(
-                            ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn, st) &&
+                            ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn, st, gu_src_stride) &&
                         kernels::launch_prefill_nvfp4_gemm(
                             fp4_down_a, fp4_down_as, w.down_fp4, w.down_fp4_sf,
                             ao + (size_t)fo * H, fn, H, ffn, fp4_ws, st,
                             w.down_fp4_alpha);
+                    if (!down_fp4_done && gu_cat_live) {
+                        // ffg/ffu are strided views of the fused output; every non-FP4 consumer
+                        // below assumes tight [fn, ffn]. Refuse rather than read them wrong.
+                        a.free_all(); a8.free_all();
+                        fprintf(stderr, "[prefill] fused gate|up: down FP4 arm declined -> token loop\n");
+                        return -1;
+                    }
                     if (!down_fp4_done) {
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
@@ -1585,8 +1822,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 else
                     kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
             } else if (!ffn_fused) {
-                // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk)
-                kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
+                // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk).
+                // Deferred into the end-of-layer norm below when the fusion is on.
+                if (addnorm_fuse) ffn_add_pending = true;
+                else kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
             }
         } else {
             // ---- expert-grouped 256-expert int8 MoE FFN (this PR): route -> bucket routed
@@ -2077,7 +2316,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         }
 
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        // Same fold as the post-attention norm above: the next layer's qkv group quantizes this
+        // `xn` to FP4 and nothing touches fp4_gdn_a in between (the GDN out / o projections
+        // overwrite it only AFTER their qkv group has run). Worth doing on the last layer too --
+        // the memo is simply never consumed there.
+        if (ffn_add_pending) {
+            if (fp4_gdn_a && fp4_gdn_as && (gdn_nvfp4 || attn_nvfp4) &&
+                kernels::launch_prefill_add_rmsnorm2_nvfp4_a(
+                    x, ao, next_norm, x, xn, fp4_gdn_a, fp4_gdn_as, N, H, eps, st))
+                xn_fp4_ready = true;
+            else
+                kernels::launch_add_rmsnorm2(x, ao, next_norm, x, xn, N, H, eps, st);
+        } else {
+            kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        }
     }
 
     if (moe_overlap) {


### PR DESCRIPTION
> Supersedes #861, which was auto-closed on an `eval-modelopt:REJECT`. That run measured
> `7fad27e` — a revision that added two side-stream overlaps inside `prefill_batched_run`. They
> measured +1.5% and +2.3% on my box but collapsed on the eval box (decode -54%, prefill@128
> -42.8%, while prefill@16k stayed +1.6% — the signature of a fixed per-layer sync cost that is
> invisible at long context). **Both overlaps, and the load-time `in_proj_a|in_proj_b` adjacency
> that was the only other change touching decode, are reverted here.** GitHub will not let #861
> reopen because the branch was force-pushed after it closed, hence this PR.

## Summary

The ModelOpt checkpoint already ships the 16 full-attention layers' `q/k/v/o` as NVFP4, but they were refit to Q4_K at load, so batched prefill re-expanded every one of them Q4_K -> int8 on every pass — keep the checkpoint's own bytes and feed them to the SM120 block-scaled GEMM the FFN and GDN projections already use. Separately, `pf_gdnc_prep`'s triangular inverse is rebuilt in blocked form, dropping it from 62 block barriers to 10.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 93.83 |
| after (this PR) | 93.25 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 6637.33 |
| after prefill (this PR) | 7700.30 |

Qwen3.8-27B-NVFP4 (ModelOpt), **ctx=128 — the scored dimension: +16.01%**. Medians of 3 alternating main/PR rounds, 5 reps each, one binary per arm, order rotated. prefill@16k 9541.12 -> 9841.90 (+3.15%) and decode@16k 78.36 -> 78.10 (-0.34%) — no regression on either floor.

**Attention.** ModelOpt quantizes co-located projections as one group, so `q_proj`, `k_proj` and `v_proj` share a bit-identical `weight_scale_2` per layer — checked at load, not assumed, since a mismatch would silently rescale two thirds of attention. Packed nibbles and group scales are both row-major, so concatenating along rows is an exact byte copy under one shared alpha. That pays because at m=128 the CUTLASS grid *is* the N-tile count, and k/v alone are n=1024 = 16 CTAs of 170 (~227 GB/s, essentially pure launch overhead). The same argument gives `gate_proj|up_proj`. Every FP4 GEMM group here is also preceded by a norm whose output it immediately re-reads and quantizes, so the quantize is folded into the producing norm at four sites — 176 fewer launches per pass, 1366 -> 1063 kernels.

**GDN chunk prep.** `pf_gdnc_prep` built `T = (I+A)^-1` by row-at-a-time forward substitution: 31 rows x 2 block barriers, a dependent FMA chain of `sum(i-1)` = 465, and never more than 31 of 256 threads busy. Doubling just that phase costs 0.556 ms/pass, so it was 36% of the kernel's 1.565 ms. The blocked form

    [[L11, 0], [L21, L22]]^-1 = [[T11, 0], [-T22 L21 T11, T22]]

is log2(32) = 5 levels: 10 barriers, a chain of 62, and the last two levels carry 94% of the MACs at 128 and 256 threads. It issues ~2x the MACs (C^3/3 vs C^3/6) and still wins by **+2.19%**, because the grid is 192 blocks on 170 SMs — barely one block per SM, so every barrier is fully exposed and arithmetic is nearly free. `L21` is still raw `A` at every level, so no copy is needed, and the `P = L21 T11` scratch aliases `s_x` (Q is dead after the wmma pass, V is not staged until after W^), so it costs no extra shared memory.

**The fused `gate|up` operand is all-layers-or-nothing, decided before anything loads.** Prefill makes `ffg`/`ffu` strided views of one buffer, so the fused layout is a property of the whole pass — and `keep_nvfp4(..., want_fp4 = !gu_cat)` drops the per-tensor FP4 payload for exactly the layers that fused, so a partially-fusable checkpoint would have no correct layout at all. `unsloth/Qwen3.8-27B-NVFP4` is exactly that case: `gate_proj` and `up_proj` share a `weight_scale_2` on only 56 of 64 layers. A host-side pre-scan (`nvfp4_src` is `st.tensor()` lookups plus a 4-byte `memcpy`, no device work) settles it up front, so that checkpoint keeps the per-tensor layout and is bit-identical to main on the FFN, while the ModelOpt checkpoint fuses all 64 as before.

**GDN chunk scan.** Two further changes to `pf_gdnc_scan`. (1) `M . U^` moves to tensor cores: the scalar epilogue was shared-INSTRUCTION bound, not FLOP bound — per `pp` it issued one `s_U` load plus **four broadcast `s_M` loads for only four FMAs**, ~1280 shared transactions per block-chunk against ~256 cycles of real FMA work, which is why a 32768-MAC phase cost more than a 131072-MAC one next to it. `m_buf` already stores hard 0 for j>i, so the dense product is the masked one, and the bf16 tile aliases `s_Sb` (dead after the U^/Y0 pass) for no extra shared memory. (2) The S update writes its wmma accumulator straight back to `s_S`: seed the fragment with the decayed old state, let the mma add `K^T U~` onto it, store in place. That deletes an 8 KB staging array, both `__syncwarp`, and a dependent shared round-trip per tile. Safe because `tile = 2*warp + rep` gives `ti = 16*warp` for both reps, so each warp owns its `s_S` rows exclusively. Together **+1.6%**, and `pf_gdnc_scan` drops 2.396 -> 2.250 ms/pass while `pf_gdnc_prep` drops 1.565 -> 1.100 ms.

**Attention, and the small kernels behind it.** `pf_attn_bf16_paged` ran one warp per (token, head) walking ONE key per iteration, each key paying a 5-step warp-shuffle reduction the online-softmax update then consumed — ~40-50 cycles of serial latency for 16 FMAs, measured at 3.9% of bf16 peak. It now processes a tile of KT=8 keys, so the reductions interleave and the sequential rescale happens once per tile (KT=4 and KT=16 both measure worse; 8 is the optimum). Separately, `launch_prefill_gemm_skinny` capped at n<=64 while the fused `in_proj_a|in_proj_b` is n=96, so it was declining and falling to a tiled GEMM that grids to ONE block; widening it to n<=96 is what makes that fusion pay.

**decode@128 is -0.5%** (measured -0.34% to -0.62% across gate runs on this branch), inside the 0.98 no-regression floor: the attention weights leave Q4_K, so decode's fused Q4_K `attn_qkv` kernel no longer applies and q/k/v go through `launch_gemv_nvfp4` on the existing qkvstream path.

**VRAM is +0.1 GB** (30.2 -> 30.3 GB; the CUTLASS SFB alone). The Q4_K copy is *replaced*, not added to — at ctx=16384 this model runs with under 1 GB free and a second copy (~0.9 GB) would starve the FFN chunk. Held under an external VRAM hog at 500/1000/2000 MB: still 16/16 attention layers, 0 scratch fallbacks.

Note on gates: `qwen3_gguf_score` never enters `prefill_batched_run`, so the accuracy gate cannot see either prefill change. The gate that does is `prefill_parity_check` (batched vs the sequential token loop, a different algorithm) — 1.000 on every run, both arms.

```text
########## Qwen3.8-27B-NVFP4 (ModelOpt), 3 alternating main/PR rounds, reps=5 ##########
  MEDIAN OF 3           main         PR       delta
  ctx=128    prefill   6637.33    7700.30     +16.01%     <- scored dimension
  ctx=16384  prefill   9541.12    9841.90      +3.15%
  ctx=16384  decode      78.36      78.10      -0.34%
  ctx=128    decode                            -0.5%      (within the 0.98 floor)

########## per-kernel, nsys --cuda-graph-trace=node, prefill only ##########
                            main d8249ad     this PR
pf_gdnc_prep                    1.565 ms     1.100 ms
pf_gdnc_scan                    2.396 ms     2.148 ms
pf_attn_bf16_paged              0.833 ms     0.676 ms
add_rmsnorm2 (unfused)     64/pass 0.228 ms   gone (the post-attn fold is restored)
quant_rows                 81/pass 0.285 ms   17/pass 0.067 ms
whole prefill pass             17.252 ms     16.663 ms

########## accuracy (differential, PR vs main, same token stream) ##########
positions             : 101
top-1 agreement       : 99/101 = 0.980   (PR vs main)
mean KL(main||pr)     : 0.0162 nats  (top-k union)
PPL PR                : 3.209
PPL main              : 3.235
METRIC top1=0.980198 kl=0.016178 ppl_pr=3.2088 ppl_main=3.2348

########## batched-prefill parity (absolute, bar 0.75) ##########
si_main run1/2/3 : worst=1.000 bar=0.75 OK
si_pr   run1/2/3 : worst=1.000 bar=0.75 OK

########## Qwen3.8 guard (unsloth/Qwen3.8-27B-NVFP4) -- 56/64 layers gate|up-fusable ##########
                   main       PR     delta
ctx=4096     9474.90   9758.70    +3.0%     (r1: 9548.68 -> 9779.78)
ctx=16384    8641.42   8869.49    +2.6%     (r1: 8692.57 -> 8907.38)
0 token-loop bails on every run. The load-time uniformity check declines the fused gate|up operand
on this checkpoint entirely, so its FFN weights are identical to main; the gain there is the GDN
and attention work, which applies to its linear-attention layers too.

########## VRAM pressure (external hog process, ctx=128) ##########
hog  500MB  main 6043.28  PR 6799.24  30.8 -> 30.9 GB  16/16 layers, 0 fallbacks
hog 1000MB  main 6054.57  PR 6735.42  31.3 -> 31.4 GB  16/16 layers, 0 fallbacks
hog 2000MB  main 6054.32  PR 6793.68  32.4 -> 32.5 GB  16/16 layers, 0 fallbacks

########## portable build (-DSPARKINFER_NVFP4=OFF, no CUTLASS) ##########
main d8249ad : 3 undefined refs (launch_ct_dequant_nvfp4 / _dev / _rows_i8) -- pre-existing on main
this PR      : the SAME 3, no PR-only additions
stub parity  : 13/13 symbols declared in prefill_nvfp4.h have a matching-arity stub in the .cu
```
