### PR TITLE
perf(qwen3.8): GQA-6 shared-KV and int8 tensor-core flash-decode split (1.10x decode@16k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -394,6 +394,9 @@ __global__ void fa_combine_gated_q8_kernel(
 #ifndef FA_GQA_TILE
 #define FA_GQA_TILE 14      // bf16 smem + uint4 ldg sweet spot at n_splits=128
 #endif
+#ifndef FA_GQA6_TILE
+#define FA_GQA6_TILE 8     // Qwen3.8-27B hd256 GQA-6 (24Q/4KV); independently sweepable
+#endif
 #ifndef FA_GQA4_TILE
 #define FA_GQA4_TILE 8     // Qwythos hd256 GQA-4 (16Q/4KV); independently sweepable
 #endif
@@ -483,6 +486,7 @@ template __global__ void fa_combine_gated_q8_kernel<256, FA_COMBINE_DG, 16>(
 // hd256 GQA-4 MMA needs 8 warps (128-token KV groups) even though only 4 q-rows are live.
 template <int HEAD_DIM, int GQA> struct fa_mma_block_threads { static constexpr int v = GQA * 32; };
 template <> struct fa_mma_block_threads<256, 4> { static constexpr int v = 256; };
+template <> struct fa_mma_block_threads<256, 6> { static constexpr int v = 256; };
 
 // Tensor-core (wmma int8) GQA flash-decode split for long context. The 8 GQA q-heads of a kv-head are
 // the batch (M) dim, so S = Q·Kᵀ and O = P·V become small matmuls on the tensor cores, replacing the
@@ -689,6 +693,12 @@ template __global__ void fa_split_gqa_mma_i8_kernel<256, 4>(const __nv_bfloat16*
     const signed char*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int,
     const __half*, const __half*);
 #endif
+// Qwen3.8-27B full-attn: 24Q/4KV hd256 — same kernel again, M = 6 rows padded to the 16-row mma.
+#ifndef _MSC_VER
+template __global__ void fa_split_gqa_mma_i8_kernel<256, 6>(const __nv_bfloat16*, const signed char*,
+    const signed char*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int,
+    const __half*, const __half*);
+#endif
 template <int NW>
 static inline void fa_launch_combine(
     const float* part_m, const float* part_l, const float* part_acc,
@@ -856,6 +866,57 @@ void launch_flash_decode_split(
                         part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                         reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
             }
+            combine_hd256(out_q8);
+            (void)seqlen;
+            return;
+        }
+        // Qwen3.8-27B: 24Q/4KV full-attn. The shared-KV tile above is instantiated for GQA 4 and
+        // 8 only, so a 6:1 group fell through to the scalar one-warp-per-block kernel, where every
+        // q-head re-reads its group's K and V from global. At ctx=16384 that is the whole
+        // long-context cost of decode: the split pass moves 67.1 MB per layer per token at
+        // 635 GB/s, 35% of this part's bandwidth, and 13.8% of the decode step. Staging the tile
+        // once per (kv head, split) reads each K/V byte once for all six q-heads instead of six
+        // times. Same partials, same layout, same combine pass -- only who reads the KV changes.
+        // SPARKINFER_FAGQA6=0 restores the scalar kernel (A/B in ONE binary).
+        static int fagqa6 = -1;
+        if (fagqa6 < 0) { const char* e = getenv("SPARKINFER_FAGQA6"); fagqa6 = (e && e[0] == '0') ? 0 : 1; }
+        if (fagqa6 && num_kv_heads > 0 && num_q_heads == num_kv_heads * 6) {
+            constexpr int GQA = 6, TILE = FA_GQA6_TILE;
+            dim3 gq(num_kv_heads * n_splits, num_seqs);
+            // int8 tensor-core arm, same as the 4:1 and 8:1 groups already take: Q and P go to
+            // int8 so QK and PV run on the int8 tensor cores, and the KV global read halves
+            // again. M is the group's 6 q-heads padded to the 16-row mma; blockDim stays 256
+            // because the mainloop gives one of its 8 warps to each of 8 KV blocks per iteration,
+            // which is independent of GQA. SPARKINFER_FAMMA6=0 keeps the bf16 tile kernel.
+            static int famma6 = -1;
+            if (famma6 < 0) { const char* e = getenv("SPARKINFER_FAMMA6"); famma6 = (e && e[0] == '0') ? 0 : 1; }
+            if (mma_ok256 && int8_kv && famma6) {
+                constexpr int MMA_THREADS = fa_mma_block_threads<256, GQA>::v;
+                const size_t i8_smem = (size_t)2 * 16 * 256 * sizeof(signed char)
+                                     + (size_t)(16 + GQA) * 256 * sizeof(float)
+                                     + (size_t)(16 + 16 + 128 + 128 + 16 + 16) * sizeof(float);
+                fa_split_gqa_mma_i8_kernel<256, GQA><<<gq, MMA_THREADS, i8_smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const signed char*>(k_pool),
+                    reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+                combine_hd256(out_q8);
+                (void)seqlen;
+                return;
+            }
+            const size_t smem = (size_t)2 * TILE * 256 * sizeof(__nv_bfloat16);
+            // int8_kv must use the <...,true> instantiation: it dequants int8 -> bf16 into the
+            // staged tile, and reading the int8 pool as bf16 would be garbage.
+            if (int8_kv)
+                fa_split_gqa_kernel<256, GQA, TILE, true><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
+            else
+                fa_split_gqa_kernel<256, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale));
             combine_hd256(out_q8);
             (void)seqlen;
             return;


### PR DESCRIPTION
## Summary

The hd256 shared-KV flash-decode split is instantiated for GQA **4** and **8** only. Qwen3.8-27B's
full-attention layers are 24Q/4KV — **GQA 6** — so they matched neither and fell through to the
scalar one-warp-per-block kernel, where each of the six q-heads in a group re-reads that group's K
and V from global memory independently.

At ctx=16384 that is the entire long-context cost of a decode step. ncu on the split pass: it moves
67.1 MB per layer per token in 105.7 us — **635 GB/s against this part's 1792**, and 13.8% of the
step — while the FFN kernels beside it already run at 86–87% of peak (`gate_up_mmvq2` 1539 GB/s,
`down_q4k_mmvq` 1552 GB/s). It was the only slack left in the step.

Two commits, both closing the same kind of gap — a missing instantiation, not slow code:

**1. GQA-6 shared-KV tile.** Stages the K/V tile once per (kv head, split) so all six q-heads read
each byte once instead of six times. Same per-q-head partials, same layout, same combine pass,
accumulated over the same keys in the same order; `qh = kvh*GQA + warp` reproduces the scalar
kernel's own `kvh = qh / (num_q_heads/num_kv_heads)` mapping exactly. **Bit-exact by construction.**

**2. GQA-6 int8 tensor-core arm.** The int8 MMA split had the same 4-and-8-only gap. It needs an
**8-warp block regardless of GQA** — the mainloop gives one of its 8 warps to each of 8 KV blocks
per iteration, and the Q quantize walks 16 padded rows as `warp*2+rr` — which is exactly why GQA=4
already carries a 256-thread `fa_mma_block_threads` specialisation (4*32 would give it 4 warps).
GQA=6 needs the same one and gets it here; the rest of the kernel is already generic in GQA
(`s_o` is `[GQA][HD]`, rows `>= GQA` are zero pad). Q and P go to int8 so QK and PV run on the int8
tensor cores and the KV global read halves again.

Unlike (1), (2) quantizes Q and P, so it is **not** bit-exact by construction — the same trade the
4:1 and 8:1 groups already ship. Measured rather than assumed: teacher-forced continuations are
**identical at ctx 256, 512, 4096 and 16384** (32/32 tokens at 16k), covering both the bf16-KV and
int8-KV arms. `SPARKINFER_FAGQA6=0` restores the scalar kernel and `SPARKINFER_FAMMA6=0` the bf16
tile kernel, so every arm comes out of one binary.

**Scope, stated plainly:** the gain is at **ctx 16384**. `decode@128`, `prefill@128` and
`prefill@16k` are all flat — the MMA arm requires `seqlen > 512`, and at ctx=128 the KV is 128
positions and this pass costs 2.8 us. The decode table below is therefore filled at ctx=16384; the
full sweep is in the log block so nothing is hidden.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main), **ctx 16384** | 81.14 |
| after (this PR), **ctx 16384** | 89.80 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 9665.79 |
| after prefill (this PR) | 9694.63 |

```text
# bench_sweep_run <ModelOpt dir> 128 128 5 16384 5 -- the harness the eval uses
# (qwen3_gguf_bench ... sweep, median of 5 reps). RTX 5090 sm_120, main @ d8249ad.
# ONE binary; MAIN = SPARKINFER_FAGQA6=0 (the scalar kernel main uses), PR = both arms on.
# Arm order rotated between rounds.

r1 MAIN ctx128 decode=95.5543 pp=6578.9176   ctx16384 decode=82.3033 pp=9880.6436
r1 PR   ctx128 decode=95.4315 pp=6541.2154   ctx16384 decode=90.0588 pp=9749.5234
r2 PR   ctx128 decode=95.1989 pp=6507.2330   ctx16384 decode=89.8017 pp=9694.6326
r2 MAIN ctx128 decode=94.6222 pp=6499.8939   ctx16384 decode=81.1361 pp=9665.7881
r3 MAIN ctx128 decode=94.5225 pp=6498.6795   ctx16384 decode=81.0289 pp=9645.3215
r3 PR   ctx128 decode=94.8487 pp=6491.9527   ctx16384 decode=89.4394 pp=9640.1482

decode@16k  81.14 -> 89.80 tok/s (+10.2% on medians). Ranges DISJOINT: main best 82.30 <
            PR worst 89.44. Per-round +9.42 / +10.68 / +10.38%.
decode@128  94.62 -> 95.20 and prefill@128 6499.89 -> 6507.23, prefill@16k 9665.79 -> 9694.63:
            all flat, deltas inside the round-to-round drift and signed both ways.

Stage breakdown of the same change (three rotated rounds each, one binary):
  scalar -> GQA-6 tile   82.38/81.40/81.25 -> 87.86/87.60/87.00  (+6.65 / +7.62 / +7.08%)
  tile   -> +int8 MMA    88.43/87.40/87.27 -> 90.38/90.12/89.69  (+2.21 / +3.11 / +2.77%)

nsys, decode@16k: the split pass falls 105.71 -> 35.96 us per call, 230.0 -> 78.3 ms over the
run, i.e. 13.8% -> 3.4% of the decode step.

Accuracy: teacher-forced continuations byte-IDENTICAL between FAGQA6=0 and both arms on, at
ctx 256, 512, 4096 and 16384 (the last two exercise the int8-KV path, which takes the separate
dequant-into-smem instantiation).

ctest: 100% tests passed, 0 failed out of 19.

Measured and NOT included, so they are not re-tried: forcing the NVFP4 GEMV split-K width
(auto vs 2/4/8) is flat (-0.23/+0.26/+0.04%), and extending the GDN side-stream fork to
compressed-tensors checkpoints so the two 48-block bf16 alpha/beta GEMVs overlap is flat
(-0.46/+0.14/-0.06%) -- graph capture already overlaps them.
```
