### PR TITLE
perf(qwen3.8): long-context prefill takes the paths tuned for ctx=128 (1.20x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -287,13 +287,31 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
 // RQH=1 is bit-identical to the per-head kernel. Math (mask, online softmax, int8
 // round) is unchanged -- only the load ordering differs.
 // ============================================================================
+// Shared-memory row padding for the int8 wmma operands. Without it s_qi's row stride is HEAD_DIM
+// (256 B = 64 banks) and s_pi's is GN (128 B = 32 banks), both exact multiples of the 128-byte bank
+// row, so all 16 rows of a tile start on bank 0 and every ldmatrix replays 16-way. Measured on the
+// unpadded kernel at ctx=16384: 2.48e9 shared-load bank conflicts over 3.27e9 wavefronts for
+// 4.37e8 instructions -- 7.5 wavefronts per instruction against an ideal of 1, which is why the
+// tensor pipe sits at 20.5% while the stalls are mio_throttle and short_scoreboard.
+// +16 B keeps the 16-byte alignment int8 ldmatrix requires and takes gcd(stride/4, 32) from 32 to
+// 4, i.e. 8 distinct starting banks instead of 1 (16-way -> 2-way).
+// SPARKINFER_PREFILL_ATTN_SMEM_PAD=0 restores the packed layout (A/B in ONE binary).
+inline int attn_smem_pad() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_SMEM_PAD");
+        const int x = e ? atoi(e) : 16;
+        return (x == 0 || x == 16 || x == 32) ? x : 16;
+    }();
+    return v;
+}
+
 template <int HEAD_DIM, int GROUP_BLKS, int RQH>
 __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_mma_gqa_kernel(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
     const __half* __restrict__ v_scale, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks, int qld, int pld) {
     using namespace nvcuda::wmma;
     constexpr int BM    = 16;
     constexpr int GN    = GROUP_BLKS * 16;
@@ -313,9 +331,9 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
 
     extern __shared__ char mma_smem[];
     // Per-q-head Q(int8), P(int8), scores(float); shared K/V scales; per-(qh,row) softmax state.
-    signed char* s_qi = reinterpret_cast<signed char*>(mma_smem);   // [RQH][BM][HEAD_DIM]
-    signed char* s_pi = s_qi + (size_t)RQH * BM * HEAD_DIM;          // [RQH][BM][GN]
-    float* s_s  = reinterpret_cast<float*>(s_pi + (size_t)RQH * BM * GN); // [RQH][BM][GN]
+    signed char* s_qi = reinterpret_cast<signed char*>(mma_smem);   // [RQH][BM][qld]
+    signed char* s_pi = s_qi + (size_t)RQH * BM * qld;               // [RQH][BM][pld]
+    float* s_s  = reinterpret_cast<float*>(s_pi + (size_t)RQH * BM * pld); // [RQH][BM][GN]
     float* s_o  = s_s + (size_t)RQH * BM * GN;                       // [BM][HEAD_DIM] epilogue landing
     float* s_ks = s_o + BM * HEAD_DIM;                               // [GN] shared
     float* s_vs = s_ks + GN;                                         // [GN] shared
@@ -360,7 +378,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
             if (lane == 0) s_qs[h * BM + r] = d;
             #pragma unroll
             for (int e = 0; e < QE; e++)
-                s_qi[((size_t)h * BM + r) * HEAD_DIM + lane + e * 32] =
+                s_qi[((size_t)h * BM + r) * qld + lane + e * 32] =
                     (signed char)((amax == 0.f) ? 0 : (int)roundf(qv[e] / d));
         }
     }
@@ -404,7 +422,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
                     load_matrix_sync(bf, kb + ks * 16, KVLD);        // K fragment: loaded once
                     #pragma unroll
                     for (int h = 0; h < RQH; h++) {
-                        load_matrix_sync(af, s_qi + ((size_t)h * BM) * HEAD_DIM + ks * 16, HEAD_DIM);
+                        load_matrix_sync(af, s_qi + ((size_t)h * BM) * qld + ks * 16, qld);
                         mma_sync(cf[h], af, bf, cf[h]);
                     }
                 }
@@ -421,7 +439,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
                 const int qh_head = head0 + h;
                 const int* s_si = reinterpret_cast<const int*>(s_s) + (size_t)h * BM * GN;
                 float* s_sh = s_s + (size_t)h * BM * GN;
-                signed char* s_pih = s_pi + (size_t)h * BM * GN;
+                signed char* s_pih = s_pi + (size_t)h * BM * pld;
                 #pragma unroll
                 for (int rr = 0; rr < BM / WARPS; rr++) {
                     const int r = warp * (BM / WARPS) + rr;
@@ -481,7 +499,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
                     load_matrix_sync(bf, vb, KVLD);                  // V fragment: loaded once
                     #pragma unroll
                     for (int h = 0; h < RQH; h++) {
-                        load_matrix_sync(af, s_pi + (size_t)h * BM * GN + ks * 16, GN);
+                        load_matrix_sync(af, s_pi + (size_t)h * BM * pld + ks * 16, pld);
                         mma_sync(cf[h], af, bf, cf[h]);
                     }
                 }
@@ -528,8 +546,21 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
                             int block_size, int max_blocks_per_seq, float scale, int win_blocks,
                             cudaStream_t stream) {
     constexpr int BM = 16, GN = GROUP_BLKS * 16;
-    const size_t sm = (size_t)RQH * BM * HD                          // s_qi (int8)
-                    + (size_t)RQH * BM * GN                          // s_pi (int8)
+    // Only at long context. The padding costs ~1 KB of shared memory per block, which is enough to
+    // push this kernel past the 2-blocks-per-SM occupancy its __launch_bounds__ asks for at RQH<=2.
+    // Where attention dominates (ctx>=2048) trading that occupancy for 8x fewer ldmatrix replays is
+    // strongly positive; where it does not, the occupancy is worth more than the conflicts --
+    // measured on the Qwen3.6 guard at ctx=512, padding unconditionally cost 5.8% (9993 -> 9410 pp)
+    // while the same build at ctx=4096 was +0.3% and Qwen3.8 at ctx=16384 was +5.1%.
+    const int pad = (n_tokens >= 2048) ? attn_smem_pad() : 0;
+    const int qld = HD + pad, pld = GN + pad;
+    // The opt-in below is latched once per device, so it MUST be raised to the largest size any
+    // later launch can ask for. Sizing it from THIS call's pad locked in the unpadded size on a
+    // small-context first call, after which every padded launch failed and silently fell back --
+    // measured as -45% at ctx=16384 and -34% on the Qwen3.6 guard at ctx=4096, with no diagnostic.
+    const int qld_max = HD + attn_smem_pad(), pld_max = GN + attn_smem_pad();
+    const size_t sm = (size_t)RQH * BM * qld                         // s_qi (int8, padded)
+                    + (size_t)RQH * BM * pld                         // s_pi (int8, padded)
                     + (size_t)(RQH * BM * GN) * sizeof(float)        // s_s
                     + (size_t)(BM * HD) * sizeof(float)              // s_o
                     + (size_t)(2 * GN + 5 * RQH * BM) * sizeof(float);
@@ -547,10 +578,15 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
     int dev = 0;
     if (cudaGetDevice(&dev) != cudaSuccess || dev < 0 || dev >= kMaxDevices) return false;
     if (!cfg[dev]) {
+        const size_t sm_max = (size_t)RQH * BM * qld_max
+                            + (size_t)RQH * BM * pld_max
+                            + (size_t)(RQH * BM * GN) * sizeof(float)
+                            + (size_t)(BM * HD) * sizeof(float)
+                            + (size_t)(2 * GN + 5 * RQH * BM) * sizeof(float);
         const cudaError_t ce = cudaFuncSetAttribute(
             pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm);
-        if (ce != cudaSuccess && sm > 48u * 1024u) return false;  // opt-in refused where it is required
+            cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_max);
+        if (ce != cudaSuccess && sm_max > 48u * 1024u) return false;  // opt-in refused where required
         cfg[dev] = 1;
     }
     dim3 grid((n_tokens + BM - 1) / BM, n_q_heads / RQH);
@@ -558,7 +594,7 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
         reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),
         block_table, reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
-        block_size, max_blocks_per_seq, scale, win_blocks);
+        block_size, max_blocks_per_seq, scale, win_blocks, qld, pld);
     // A rejected launch (e.g. smem over the device limit) enqueues nothing; peek —
     // rather than get — so a pre-existing sticky error is not silently cleared here.
     return cudaPeekAtLastError() == cudaSuccess;

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -154,6 +154,25 @@ using Narrow = Cfg<Shape<_128, _64, _256>>;
 // measure it without a rebuild between arms.
 using WideEF = Cfg<Shape<_128, _128, _256>, true>;
 using NarrowEF = Cfg<Shape<_128, _64, _256>, true>;
+// Both tiles above are M=128 because they were chosen for the scored ctx=128, where the grid is
+// exactly one CTA tall and only N matters. Long-context prefill runs the SAME GEMMs at m=16384
+// (FFN chunks and the GDN projections), where an M=128 tile reloads each B tile once per 128 rows
+// -- 128 times over the operand. A taller tile amortises that. SPARKINFER_NVFP4_BIG_TILE picks:
+//   1 = 256x128, 2 = 128x256, 3 = 256x256   (0 = off, keep the M=128 tiles)
+// K tile halved to 128: at 256 the MN-larger tiles need more smem per stage than
+// StageCountAutoCarveout can carve two stages out of, which CUTLASS rejects outright.
+// Measured at ctx=16384 against 128x128x256: 256x128x128 +6.7%, 128x256x128 -14%, 256x256x64 -76%
+// (K=64 leaves the mainloop too little per stage). M is the axis that pays. 384x128 / 512x128 /
+// 256x64x256 do not compile -- CUTLASS cannot carve two mainloop stages out of their shared memory
+// -- and non-power-of-two tiles fail cute's stride-divisibility and the epilogue's
+// MMA_TILE_M | EPI_TILE_M check, so 256x128x128 is the reachable optimum.
+using BigM = Cfg<Shape<_256, _128, _128>, true>;
+// M is the axis that pays (256x128 beat 128x128 by 6.7% at m=16384 while 128x256 lost 14%), so
+// probe further up it. K stays >=128: at 64 the mainloop has too few elements per stage to cover
+// its own latency and the GEMM collapses (measured 2494 pp, a 4x loss).
+// EVICT_FIRST on B stays correct at this tile too: dropping it measured 11310 vs 11409 pp.
+// Non-power-of-two tiles are not reachable: K=192 fails cute's stride-divisibility check and
+// M=192 fails the epilogue's "MMA_TILE_M must divide EPI_TILE_M", so 256x128x128 stands.
 
 using Gemm = typename Wide::Gemm;
 using Kernel = typename Wide::Kernel;
@@ -368,6 +387,14 @@ size_t prefill_nvfp4_scale_bytes_a(int m, int k) {
 size_t prefill_nvfp4_scale_bytes_b(int n, int k) {
     return (size_t)cute::size(cute::filter_zeros(sfb_layout(128,n,k)));
 }
+int nvfp4_big_tile() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_NVFP4_BIG_TILE");
+        const int x = e ? atoi(e) : 1;
+        return (x == 0 || x == 1) ? x : 1;
+    }();
+    return v;
+}
 size_t prefill_nvfp4_workspace_bytes(int m, int n, int k) {
     // Either tiling may run for a given shape, so the caller's buffer has to cover both.
     const size_t w = Wide::Gemm::get_workspace_size(
@@ -419,6 +446,14 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
         const char* e = getenv("SPARKINFER_NVFP4_EVICT_FIRST");
         return !e || atoi(e) != 0;
     }();
+    // Long-context: a taller/wider tile than the m=128-tuned pair above. Gated on a many-CTA-tall
+    // grid so the scored ctx=128 shape is untouched, and it falls through if CUTLASS cannot
+    // implement the shape.
+    const int big = nvfp4_big_tile();
+    if (big && m >= 512) {
+        if (run_gemm<BigM>(a,sa,b,sb,d,m,n,k,ws,st,alpha)) return true;
+
+    }
     if (ef)
         return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha)
                                   : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -604,9 +604,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const Qwen35LayerWeights* gdn_probe = nullptr;
     for (const auto& lw : s.w.layers)
         if (lw.linear_attn) { gdn_probe = &lw; break; }
+    // Long context takes this arm too. The 2048 bound rested on two claims, and measurement on an
+    // RTX 5090 contradicts both. (a) "the saving is a per-layer FIXED cost, worth the most where N
+    // is small": it is not only the avoided NVFP4->bf16->int8 expansion -- the block-scaled GEMM
+    // itself replaces the int8 GEMM, and at ctx=16384 those 48x3 projections are 144 of the 208
+    // pf_gemm_i8 launches that make up 22.9% of the pass (nsys), so extending the arm is worth
+    // +7.7% prefill@16k (9660 -> 10404 pp, medians of 3 alternated rounds, reps=5).
+    // (b) "the GDN recurrence amplifies activation-quant error with sequence length": batched
+    // prefill against the token-loop reference in the same build agrees 24/24 = 1.000 at N =
+    // 512 / 2048 / 8192 / 16384 with this arm on -- identical to the int8 arm at every one of
+    // those lengths, so the FP4 activations do not drift as the recurrence lengthens.
+    // The third claim ("a fixed bound keeps the scored ctx=128 shape off the VRAM-derived FC") is
+    // untouched: 128 was already inside the bound, and prefill@128 and decode@128 both measure flat.
     static const int gdn_fp4_maxn = [] {
         const char* e = getenv("SPARKINFER_Q38_GDN_NVFP4_MAXN");
-        return e ? atoi(e) : 2048;
+        return e ? atoi(e) : (1 << 30);
     }();
     const bool gdn_nvfp4 = gdn_fp4_env && !moe && gdn_probe && gdn_probe->gdn_qkv_fp4 &&
         N <= gdn_fp4_maxn &&


### PR DESCRIPTION
## Summary

Three parts of the batched prefill are still shaped for the 128-token case, and at ctx=16384 that
is where the time is. nsys on the ModelOpt checkpoint, per prefill pass: FP4 GEMM 599.7 ms, GDN
scan 256.1, attention 229.6, `pf_gemm_i8` 384.8.

**1. The native-FP4 GDN arm stops at N ≤ 2048**, so at 16k every GDN projection falls back to the
int8 path. The tell is `pf_gemm_i8` firing exactly **208 times per pass = 48 GDN layers × 3 + 16
attention layers × 4**. That bound rested on two claims and measurement contradicts both. The
saving is not only the avoided `NVFP4 → bf16 → int8` expansion — the block-scaled GEMM *replaces*
the int8 GEMM. And the recurrence does not amplify the coarser activations with length: batched
prefill against the token-loop reference in the same build agrees **24/24 = 1.000 at N = 512 /
2048 / 8192 / 16384**, identical to the int8 arm at every one of those lengths. **+7.65%**

**2. Both NVFP4 GEMM tiles are M=128**, because at ctx=128 the grid is exactly one CTA tall and
only N matters. At m=16384 an M=128 tile reloads each B tile once per 128 rows. A **256×128×128**
tile for m ≥ 512 takes the GEMM **599.7 → 488.7 ms, 1238 → 1518 TFLOPS ≈ 91% of this part's NVFP4
peak**. **+6.7%**

Alternatives measured, so the choice is not a guess: 128×256×128 **−14%**, 256×256×64 **−76%**
(K=64 starves the mainloop). 384×128, 512×128 and 256×64×256 cannot carve two mainloop stages out
of shared memory, and non-power-of-two tiles fail cute's stride-divisibility and the epilogue's
`MMA_TILE_M | EPI_TILE_M` check — so 256×128×128 is the reachable optimum. `EVICT_FIRST` on B
stays correct at this tile (dropping it: 11310 vs 11409 pp).

**3. The attention kernel's int8 shared tiles collide on every access.** `s_qi`'s row stride is
HEAD_DIM (256 B) and `s_pi`'s is GN (128 B) — both exact multiples of the 128-byte bank row, so all
16 rows of a tile start on bank 0 and every `ldmatrix` replays. ncu at ctx=16384:

```
shared-load bank conflicts   2.48e9
shared-load wavefronts       3.27e9
shared-load instructions     4.37e8   -> 7.5 wavefronts/instruction (ideal 1)
tensor pipe active           20.5%    stalls: mio_throttle, short_scoreboard
```

Padding both by 16 B keeps the 16-byte alignment int8 `ldmatrix` requires and takes
`gcd(stride/4, 32)` from 32 to 4 — 8 distinct starting banks instead of 1. **+5.1%** (a 32 B pad
is worse than 16 B, as the arithmetic predicts: 4 distinct starts).

Padding is applied only at **ctx ≥ 2048**. It costs ~1 KB per block, which is enough to break the
2-blocks-per-SM tier `__launch_bounds__` asks for at RQH ≤ 2: applied unconditionally it cost the
Qwen3.6 guard **5.8% at ctx=512** while being +0.3% at 4096. The shared-memory opt-in is also
latched at the **largest** size any later launch can request rather than this call's — sizing it
from the current pad locked in the unpadded size on a small-context first call, after which every
padded launch silently failed and fell back (−45% at 16k, no diagnostic).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 94.97 |
| after (this PR) | 94.69 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 9675.52 |
| after prefill (this PR) | **11576.80** |

**1.1965× prefill@16k.** Qwen3.8-27B ModelOpt NVFP4, one binary, warm-up first then main/PR
alternated ×3 at 5 reps (an unalternated first run on this box reads cold and invents ~20% swings).

```text
  warmup  {"128":{"decode_tps":95.9328,"prefill_pp":6557.32},"16384":{"decode_tps":90.4085,"prefill_pp":9860.16}}
  r1 main {"128":{"decode_tps":95.4198,"prefill_pp":6513.34},"16384":{"decode_tps":89.9874,"prefill_pp":9756.05}}
  r1 PR   {"128":{"decode_tps":95.1443,"prefill_pp":6497.71},"16384":{"decode_tps":89.7269,"prefill_pp":11624.67}}
  r2 main {"128":{"decode_tps":94.9740,"prefill_pp":6490.45},"16384":{"decode_tps":89.5127,"prefill_pp":9675.52}}
  r2 PR   {"128":{"decode_tps":94.6915,"prefill_pp":6493.15},"16384":{"decode_tps":89.3941,"prefill_pp":11576.80}}
  r3 main {"128":{"decode_tps":94.6595,"prefill_pp":6497.50},"16384":{"decode_tps":89.3617,"prefill_pp":9655.67}}
  r3 PR   {"128":{"decode_tps":94.6364,"prefill_pp":6490.24},"16384":{"decode_tps":89.3176,"prefill_pp":11562.59}}

medians   prefill@16k 9675.52 -> 11576.80  = 1.1965x
          prefill@128 6497.50 -> 6493.15   = 0.9993
          decode@128    94.97 -> 94.69     = 0.9970
          decode@16k    89.51 -> 89.39     = 0.9987
```

## Correctness

All three changes are confined to `prefill_batched_run()`, which `qwen3_gguf_score` never enters,
so the teacher-forced score dumps are **byte-identical**: top1 1.000000, KL 0.000000, ppl 3.2348
both arms (real prompt via the checkpoint's own tokenizer, topk 128).

Batched-prefill parity, which *can* see this path: `PARITY worst=1.000 bar=0.75 OK`.

And the long-context check the GDN bound existed for — same prompt, token-loop reference vs batched
with the arm off and on, common-prefix agreement:

| N | int8 GDN | native-FP4 GDN |
|--:|---|---|
| 512 | 24/24 = 1.000 | 24/24 = 1.000 |
| 2048 | 24/24 = 1.000 | 24/24 = 1.000 |
| 8192 | 24/24 = 1.000 | 24/24 = 1.000 |
| 16384 | 24/24 = 1.000 | 24/24 = 1.000 |

## No-regression

Both guards warm-up-first and alternated, same protocol as above:

| guard | main | this PR | |
|---|--:|--:|--:|
| Qwen3.8 (unsloth) prefill@128 | 4106.61 | 4098.31 | 0.998 |
| Qwen3.8 (unsloth) decode@128 | 84.91 | 84.88 | 1.000 |
| Qwen3.6 prefill@512 | 9963.56 | 9971.21 | 1.001 |
| Qwen3.6 prefill@4096 | 25359.14 | 25407.05 | 1.002 |

Qwen3.6 decode is flat at 0/512/4096 (495.19–495.72 / 488.30–489.40 / 469.40–469.81).

## Scope

`SPARKINFER_Q38_GDN_NVFP4_MAXN=2048`, `SPARKINFER_NVFP4_BIG_TILE=0` and
`SPARKINFER_PREFILL_ATTN_SMEM_PAD=0` each restore the previous behaviour, so all three arms A/B in
one binary. The GEMM tile is gated on `m >= 512` and the padding on `ctx >= 2048`, so the ctx=128
shapes are untouched — which is what prefill@128 and decode@128 measuring flat above confirms.
