### PR TITLE
perf(qwen3.8): one-wave GDN scan, GQA-6 attention tier, fused NVFP4 residual, native-FP4 attention projections (1.11x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -306,7 +306,7 @@ inline int attn_smem_pad() {
 }
 
 template <int HEAD_DIM, int GROUP_BLKS, int RQH>
-__global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_mma_gqa_kernel(
+__global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_mma_gqa_kernel(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
     const __half* __restrict__ v_scale, const int* __restrict__ block_table,
@@ -333,9 +333,15 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 2 ? 2 : 1)) void pf_attn_m
     // Per-q-head Q(int8), P(int8), scores(float); shared K/V scales; per-(qh,row) softmax state.
     signed char* s_qi = reinterpret_cast<signed char*>(mma_smem);   // [RQH][BM][qld]
     signed char* s_pi = s_qi + (size_t)RQH * BM * qld;               // [RQH][BM][pld]
+    // s_o OVERLAYS s_s. The scores are dead by the epilogue -- the last read of s_s is the P
+    // quantization inside the softmax section, and the PV mma after it touches only s_pi/s_ps/
+    // s_corr -- so the landing zone costs nothing on top of the score buffer it lands in. That
+    // is what makes RQH=3 fit: 46,528 B against the 51,200 a second resident block needs, where
+    // holding both buffers is 62,912 and caps this kernel at one block per SM.
+    constexpr int SBLK = (RQH * BM * GN > BM * HEAD_DIM) ? RQH * BM * GN : BM * HEAD_DIM;
     float* s_s  = reinterpret_cast<float*>(s_pi + (size_t)RQH * BM * pld); // [RQH][BM][GN]
-    float* s_o  = s_s + (size_t)RQH * BM * GN;                       // [BM][HEAD_DIM] epilogue landing
-    float* s_ks = s_o + BM * HEAD_DIM;                               // [GN] shared
+    float* s_o  = s_s;                                               // [BM][HEAD_DIM] epilogue landing
+    float* s_ks = s_s + SBLK;                                        // [GN] shared
     float* s_vs = s_ks + GN;                                         // [GN] shared
     float* s_qs = s_vs + GN;                                         // [RQH][BM]
     float* s_ps = s_qs + RQH * BM;                                   // [RQH][BM]
@@ -559,10 +565,11 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
     // small-context first call, after which every padded launch failed and silently fell back --
     // measured as -45% at ctx=16384 and -34% on the Qwen3.6 guard at ctx=4096, with no diagnostic.
     const int qld_max = HD + attn_smem_pad(), pld_max = GN + attn_smem_pad();
+    // s_o lands in s_s (dead by the epilogue), so the pair costs the larger of the two.
+    constexpr int SBLK = (RQH * BM * GN > BM * HD) ? RQH * BM * GN : BM * HD;
     const size_t sm = (size_t)RQH * BM * qld                         // s_qi (int8, padded)
                     + (size_t)RQH * BM * pld                         // s_pi (int8, padded)
-                    + (size_t)(RQH * BM * GN) * sizeof(float)        // s_s
-                    + (size_t)(BM * HD) * sizeof(float)              // s_o
+                    + (size_t)SBLK * sizeof(float)                   // s_s, with s_o overlaid
                     + (size_t)(2 * GN + 5 * RQH * BM) * sizeof(float);
     // At RQH=4 this is 76,032 B — past the 48 KB default, so the opt-in below is
     // REQUIRED for the launch to be valid, and both it and the launch itself have to
@@ -580,8 +587,7 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
     if (!cfg[dev]) {
         const size_t sm_max = (size_t)RQH * BM * qld_max
                             + (size_t)RQH * BM * pld_max
-                            + (size_t)(RQH * BM * GN) * sizeof(float)
-                            + (size_t)(BM * HD) * sizeof(float)
+                            + (size_t)SBLK * sizeof(float)
                             + (size_t)(2 * GN + 5 * RQH * BM) * sizeof(float);
         const cudaError_t ce = cudaFuncSetAttribute(
             pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH>,
@@ -624,7 +630,7 @@ bool launch_prefill_attn_mma(
     static const int gqa_rqh = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_GQA_RQH");
         const int v = e ? atoi(e) : 4;
-        return (v == 1 || v == 2 || v == 4) ? v : 4;
+        return (v == 1 || v == 2 || v == 3 || v == 4) ? v : 4;
     }();
 
     if (!enabled || head_dim != HD || block_size != 16 || n_tokens < minctx) return false;
@@ -637,6 +643,22 @@ bool launch_prefill_attn_mma(
     // returning success over an output buffer nothing wrote.
     if (gqa_rqh == 4 && gqa % 4 == 0 &&
         launch_attn_gqa<HD, GROUP_BLKS, 4>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
+        return true;
+    // RQH=3 exists for GQA-6 (this checkpoint: 24 q-heads over 4 kv-heads), where 4 does not
+    // divide the group and the tier above always falls through to 2. ncu at ctx=16384 puts this
+    // kernel at 80.3% of peak L2 throughput with DRAM at 1.7% -- it is bound by re-reading the
+    // same K/V pages out of L2, not by the tensor cores (SM 62.7%). RQH=3 loads each K page and V
+    // tile once for THREE q-heads instead of two, which is 1/3 off the dominant traffic term, and
+    // with s_o overlaid on s_s it still fits the two resident blocks its __launch_bounds__ asks
+    // for. Ordered after 4 and before 2 so a group that divides by 4 keeps the wider tier.
+    //
+    // Long context only, for the same reason the shared-memory padding is: the win is the L2
+    // re-read, which only dominates once the window is long. At ctx=128 there is no re-read to
+    // save and the wider block costs registers -- measured +1.9% at ctx=16384 against -0.45% on
+    // prefill@128, which is a no-regression floor.
+    if (gqa_rqh >= 3 && gqa % 3 == 0 && n_tokens >= 2048 &&
+        launch_attn_gqa<HD, GROUP_BLKS, 3>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
             n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
         return true;
     if (gqa_rqh >= 2 && gqa % 2 == 0 &&

--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -285,22 +285,37 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                                     __nv_bfloat16* __restrict__ out,
                                     int n_tokens, int q_heads, int v_heads, int n_chunks,
                                     bool qh_block, int carry) {
+    // ONE arena, with three regions reused at disjoint points of the chunk body. That reuse is
+    // what keeps JC=64 -- the one-wave launch shape, see launch_prefill_gdn_chunk -- inside the
+    // 100 KB an SM has; laid out naively it needs 133 KB and cannot be launched at all.
+    //   s_W|s_Q -> s_C  : the wmma accumulator staging for BOTH matmuls. W^ and Q are read only
+    //                     by the U^/Y0 k-loop, and are dead from there until the cp.async
+    //                     restage at the bottom of the iteration.
+    //   s_Sb    -> s_Y, then s_Ub : S's bf16 mirror is dead once that same k-loop has read it.
+    // s_K is NOT reused: the S update at the end of the chunk still needs it.
     extern __shared__ char s_raw[];
+    constexpr int NW = (C * JC) / 128;          // warps; == 2 x (C/16)x(JC/16) accumulator tiles
     float* s_S = reinterpret_cast<float*>(s_raw);                              // [HD][JC]  fp32 carrier
     float* s_U = s_S + (size_t)HD * JC;                                        // [C][JC]
     float* s_M = s_U + (size_t)C * JC;                                         // [C][C+PAD]
     float* s_g = s_M + (size_t)C * (C + PAD);                                  // [C]
     float* s_eg = s_g + C;                                                     // [C] hoisted per-row expf
-    float* s_Y = s_eg + C;                                                     // [C][JC]  Q S staging
     __nv_bfloat16* s_W =
-        reinterpret_cast<__nv_bfloat16*>(s_Y + (size_t)C * JC);                // [C][HD+PAD]
-    __nv_bfloat16* s_K = s_W + (size_t)C * (HD + PAD);                         // [C][HD+PAD]
-    __nv_bfloat16* s_Q = s_K + (size_t)C * (HD + PAD);                         // [C][HD+PAD]
+        reinterpret_cast<__nv_bfloat16*>(s_eg + C);                            // [C][HD+PAD]
+    __nv_bfloat16* s_Q = s_W + (size_t)C * (HD + PAD);                         // [C][HD+PAD]
+    __nv_bfloat16* s_K = s_Q + (size_t)C * (HD + PAD);                         // [C][HD+PAD]
     // bf16 operand mirrors. S stays fp32 across chunks (it is the recurrent carrier); it is
     // narrowed to bf16 ONCE per chunk to feed the tensor cores, which is the only precision the
     // wmma path costs over the fp32 register-tiled one — W^, K and Q are already bf16.
-    __nv_bfloat16* s_Sb = s_Q + (size_t)C * (HD + PAD);                        // [HD][JC+PAD]
-    __nv_bfloat16* s_Ub = s_Sb + (size_t)HD * (JC + PAD);                      // [C][JC+PAD]
+    __nv_bfloat16* s_Sb = s_K + (size_t)C * (HD + PAD);                        // [HD][JC+PAD]
+    float* s_C = reinterpret_cast<float*>(s_W);                                // [NW][16][16]
+    float* s_Y = reinterpret_cast<float*>(s_Sb);                               // [C][JC]  Q S staging
+    __nv_bfloat16* s_Ub = s_Sb;                                                // [C][JC+PAD]
+    static_assert(2 * C * (HD + PAD) * sizeof(__nv_bfloat16) >= (size_t)NW * 256 * sizeof(float),
+                  "s_C must fit in the s_W|s_Q pair");
+    static_assert(HD * (JC + PAD) * sizeof(__nv_bfloat16) >= (size_t)C * JC * sizeof(float),
+                  "s_Y must fit in s_Sb");
+    static_assert(HD * (JC + PAD) >= C * (JC + PAD), "s_Ub must fit in s_Sb");
 
     const int h    = blockIdx.x;
     const int j0   = blockIdx.y * JC;
@@ -391,12 +406,15 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         __syncthreads();
         {
             using namespace nvcuda;
-            // 8 warps, 8 output tiles of 16x16: warps 0-3 own U^ = W^ S, warps 4-7 own Y0 = Q S.
+            // NW warps, NW output tiles of 16x16: the first TU own U^ = W^ S, the rest Y0 = Q S.
             // Both contract over HD against the same s_Sb, so the two matmuls share its fragments.
+            constexpr int TJ = JC / 16;                      // tile columns
+            constexpr int TU = (C / 16) * TJ;                // tiles per matmul; NW == 2*TU
+            static_assert(NW == 2 * TU, "one accumulator tile per warp");
             const int warp = tid >> 5;
-            const bool isU = warp < 4;
-            const int t    = warp & 3;                       // 2x2 tile grid over [C=32, JC=32]
-            const int ti = (t >> 1) * 16, tj = (t & 1) * 16;
+            const bool isU = warp < TU;
+            const int t    = isU ? warp : warp - TU;         // (C/16) x TJ tile grid over [C, JC]
+            const int ti = (t / TJ) * 16, tj = (t % TJ) * 16;
             const __nv_bfloat16* Aop = isU ? s_W : s_Q;
             wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
             wmma::fill_fragment(cf, 0.f);
@@ -408,14 +426,17 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                 wmma::load_matrix_sync(bf, s_Sb + (size_t)kk * (JC + PAD) + tj, JC + PAD);
                 wmma::mma_sync(cf, af, bf, cf);
             }
-            __shared__ float sC[8][16][16];
-            wmma::store_matrix_sync(&sC[warp][0][0], cf, 16, wmma::mem_row_major);
+            // s_C overlays s_W|s_Q and s_Y overlays s_Sb — all three of which the loop above is
+            // still reading in the other warps, so nothing may land until every warp is out of it.
+            __syncthreads();
+            wmma::store_matrix_sync(s_C + (size_t)warp * 256, cf, 16, wmma::mem_row_major);
             __syncthreads();
             for (int e = tid; e < C * JC; e += nthr) {
                 const int i = e / JC, jj = e - i * JC;
-                const int w = ((i >> 4) << 1) | (jj >> 4);
-                s_U[e] -= sC[w][i & 15][jj & 15];             // U^ = U0 - W^ S
-                s_Y[e]  = sC[4 + w][i & 15][jj & 15];         // Y0 = Q S
+                const int w = (i >> 4) * TJ + (jj >> 4);
+                const int o = (i & 15) * 16 + (jj & 15);
+                s_U[e] -= s_C[(size_t)w * 256 + o];           // U^ = U0 - W^ S
+                s_Y[e]  = s_C[(size_t)(TU + w) * 256 + o];    // Y0 = Q S
             }
         }
         __syncthreads();
@@ -428,7 +449,7 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         for (int i = tid; i < C; i += nthr) s_eg[i] = __expf(s_g[i]);
         __syncthreads();
         {
-            constexpr int NTHR2 = 256;
+            constexpr int NTHR2 = NW * 32;
             constexpr int OPT = (C * JC) / NTHR2;
             constexpr int ISTR2 = NTHR2 / JC;
             const int jj = tid % JC, i0 = tid / JC;
@@ -476,12 +497,14 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         {
             using namespace nvcuda;
             const float gl = __expf(g_last);
-            const int warp = tid >> 5;                       // 8 warps x 2 tiles = 16 tiles [128,32]
-            __shared__ float sC2[8][16][16];
+            constexpr int TJ = JC / 16;
+            constexpr int REPS = ((HD / 16) * TJ) / NW;      // NW warps x REPS tiles = [HD,JC]
+            static_assert(REPS * NW == (HD / 16) * TJ, "S-update tiles must divide over the warps");
+            const int warp = tid >> 5;
             #pragma unroll
-            for (int rep = 0; rep < 2; rep++) {
-                const int tile = warp * 2 + rep;             // 0..15
-                const int ti = (tile >> 1) * 16, tj = (tile & 1) * 16;
+            for (int rep = 0; rep < REPS; rep++) {
+                const int tile = warp * REPS + rep;
+                const int ti = (tile / TJ) * 16, tj = (tile % TJ) * 16;
                 wmma::fragment<wmma::accumulator, 16, 16, 16, float> cf;
                 wmma::fill_fragment(cf, 0.f);
                 #pragma unroll
@@ -493,12 +516,12 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                     wmma::load_matrix_sync(bf, s_Ub + (size_t)kk * (JC + PAD) + tj, JC + PAD);
                     wmma::mma_sync(cf, af, bf, cf);
                 }
-                wmma::store_matrix_sync(&sC2[warp][0][0], cf, 16, wmma::mem_row_major);
+                wmma::store_matrix_sync(s_C + (size_t)warp * 256, cf, 16, wmma::mem_row_major);
                 __syncwarp();
                 for (int e = (tid & 31); e < 256; e += 32) {
                     const int r = e >> 4, cc = e & 15;
                     const int m = ti + r, jj = tj + cc;
-                    s_S[m * JC + jj] = gl * s_S[m * JC + jj] + sC2[warp][r][cc];
+                    s_S[m * JC + jj] = gl * s_S[m * JC + jj] + s_C[(size_t)warp * 256 + r * 16 + cc];
                 }
                 __syncwarp();
             }
@@ -541,6 +564,49 @@ size_t gdnc_workspace_bytes(int n_tokens, int v_heads, int C, int HD) {
          + n_w * sizeof(__nv_bfloat16) + n_w * sizeof(__nv_bfloat16);
 }
 
+// Shared memory for one scan block, matching the arena the kernel carves up (s_C, s_Y and s_Ub
+// are overlays and cost nothing here).
+template <int C, int HD, int JC>
+constexpr size_t gdnc_scan_smem() {
+    return (size_t)HD * JC * sizeof(float)                                  // s_S (fp32 carrier)
+         + (size_t)C * JC * sizeof(float)                                   // s_U
+         + (size_t)C * (C + PAD) * sizeof(float)                            // s_M
+         + (size_t)2 * C * sizeof(float)                                    // s_g, s_eg
+         + (size_t)3 * C * (HD + PAD) * sizeof(__nv_bfloat16)               // s_W, s_Q, s_K
+         + (size_t)HD * (JC + PAD) * sizeof(__nv_bfloat16);                 // s_Sb
+}
+
+int gdnc_sm_count() {
+    static const int sms = [] {
+        int dev = 0, c = 0;
+        if (cudaGetDevice(&dev) != cudaSuccess ||
+            cudaDeviceGetAttribute(&c, cudaDevAttrMultiProcessorCount, dev) != cudaSuccess)
+            return 0;
+        return c;
+    }();
+    return sms;
+}
+
+// The MaxDynamicSharedMemorySize opt-in, latched once per (device, JC). Both instantiations are
+// separate functions and the attribute is per-function AND per-device, so they need separate
+// latches — a shared one would leave whichever kernel ran second unconfigured, and its launches
+// would then fail silently and fall through to the sequential scan.
+template <int C, int HD, int JC>
+bool gdnc_scan_smem_ok(int dev) {
+    constexpr int kMaxDevices = 16;
+    static int cfg[kMaxDevices] = {0};                 // 0 unknown, 1 usable, 2 refused
+    if (dev < 0 || dev >= kMaxDevices) return false;
+    if (!cfg[dev]) {
+        constexpr size_t sm = gdnc_scan_smem<C, HD, JC>();
+        const cudaError_t ce = cudaFuncSetAttribute(
+            pf_gdnc_scan_kernel<C, HD, JC>,
+            cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm);
+        if (ce != cudaSuccess) cudaGetLastError();
+        cfg[dev] = (ce == cudaSuccess || sm <= 48u * 1024u) ? 1 : 2;
+    }
+    return cfg[dev] == 1;
+}
+
 }  // namespace
 
 bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
@@ -549,7 +615,10 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
                               float* state, void* out,
                               int n_tokens, int q_heads, int v_heads, int head_dim,
                               bool qh_block, cudaStream_t stream) {
-    constexpr int C = 32, HD = 128, JC = 32, SCAN_THREADS = 256, PREP_THREADS = 256;
+    constexpr int C = 32, HD = 128, PREP_THREADS = 256;
+    // State columns per scan block. JC_S is the shape every context used before; JC_B halves the
+    // grid — see use_big below for why that is the whole point at long context.
+    constexpr int JC_S = 32, JC_B = 64;
 
     static const int enabled = [] {
         const char* e = getenv("SPARKINFER_PREFILL_GDN_CHUNK");
@@ -562,29 +631,46 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
         // 256 was the Qwythos-era default; SPARKINFER_PREFILL_GDN_CHUNK_MINCTX=256 restores it.
         return e ? atoi(e) : 128;
     }();
+    // The scan block is far too big to double up on an SM (85 KB of the 100 KB an SM has, ncu:
+    // launch__occupancy_limit_shared_mem = 1), so the grid is the launch: v_heads x HD/JC blocks,
+    // one per SM, and any remainder past the SM count is a SECOND WAVE that costs a full serial
+    // chain to carry it. On this checkpoint (48 v-heads) JC=32 is 192 blocks on 170 SMs — 170 then
+    // 22 — so the launch is 56% efficient however fast the block itself is.
+    //
+    // JC=64 is 96 blocks: one wave, the same 1536 warps in flight (16 per block instead of 8), and
+    // half the W/K/Q staging per state column because one staged tile now serves 64 columns.
+    // Confirmed by the reverse experiment before building it: JC=16 is 384 blocks = three waves,
+    // and it measures ~21% slower on this kernel, which is what the wave count alone predicts.
+    //
+    // Gated on the NARROW GRID ACTUALLY SPILLING PAST ONE WAVE, not on the model or the context,
+    // because that spill IS the win — there is nothing else here to gain. A wider block is
+    // otherwise a straight loss: it costs ~1.65x the per-block time (16 warps queueing on the same
+    // __syncthreads) and leaves more SMs idle. Qwen3.5/3.6 carry 32 v-heads, so their narrow grid
+    // is 32*4 = 128 blocks and ALREADY fits one wave on 170 SMs; taking the wide block there halves
+    // the grid to 64 and cost the Qwen3.6 guard 6.1% at ctx=4096 (25487 -> 23924 pp, reproduced
+    // twice) while ctx=512 and every decode point stayed flat. Qwen3.8-27B carries 48, so 48*4 =
+    // 192 > 170, which is the case this exists for.
+    //
+    // Also gated on context: at ctx=128 the chain is 4 chunks long, too short for the second wave
+    // to pay for the wider block, and prefill@128 is a no-regression floor.
+    static const int bigjc_minctx = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_SCAN_BIGJC_MINCTX");
+        return e ? atoi(e) : 2048;
+    }();
 
     if (!enabled || head_dim != HD || n_tokens < minctx) return false;
-    if (q_heads <= 0 || v_heads <= 0 || (HD % JC) != 0) return false;
+    if (q_heads <= 0 || v_heads <= 0) return false;
 
     const size_t sm_prep = (size_t)2 * C * (HD + PAD) * sizeof(__nv_bfloat16)
                          + (size_t)C * (C + PAD) * sizeof(float)
                          + (size_t)3 * C * sizeof(float);
-    const size_t sm_scan = (size_t)HD * JC * sizeof(float)          // s_S (fp32 carrier)
-                         + (size_t)C * JC * sizeof(float)            // s_U
-                         + (size_t)C * (C + PAD) * sizeof(float)     // s_M
-                         + (size_t)2 * C * sizeof(float)             // s_g, s_eg
-                         + (size_t)C * JC * sizeof(float)            // s_Y
-                         + (size_t)3 * C * (HD + PAD) * sizeof(__nv_bfloat16)   // s_W, s_K, s_Q
-                         + (size_t)HD * (JC + PAD) * sizeof(__nv_bfloat16)      // s_Sb
-                         + (size_t)C * (JC + PAD) * sizeof(__nv_bfloat16);      // s_Ub
 
-    // sm_scan is ~68 KB — past the 48 KB default — so the MaxDynamicSharedMemorySize
-    // opt-in is REQUIRED for the scan launch to be valid. A discarded failure here used
-    // to still return true; the caller (launch_prefill_gdn_scan) then skipped the
-    // sequential pf_gdn_scan_kernel fallback and left GDN state/out untouched — silently
-    // wrong recurrence into decode. cudaFuncSetAttribute is also PER-DEVICE, so the
-    // do-once latch is keyed on the device ordinal (a process-wide latch left every
-    // device but the first unconfigured).
+    // The MaxDynamicSharedMemorySize opt-in is REQUIRED for either scan launch to be valid (both
+    // are past the 48 KB default). A discarded failure here used to still return true; the caller
+    // (launch_prefill_gdn_scan) then skipped the sequential pf_gdn_scan_kernel fallback and left
+    // GDN state/out untouched — silently wrong recurrence into decode. cudaFuncSetAttribute is
+    // also PER-DEVICE, so the do-once latch is keyed on the device ordinal (a process-wide latch
+    // left every device but the first unconfigured).
     constexpr int kMaxDevices = 16;
     static int cfg[kMaxDevices] = {0};
     int dev = 0;
@@ -594,22 +680,25 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
             pf_gdnc_prep_kernel<C, HD>,
             cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_prep);
         if (ce_prep != cudaSuccess && sm_prep > 48u * 1024u) return false;
-        const cudaError_t ce_scan = cudaFuncSetAttribute(
-            pf_gdnc_scan_kernel<C, HD, JC>,
-            cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_scan);
-        // Scan is the load-bearing raise (~68 KB); prep is under 48 KB on current shapes
-        // but check both when over the default so a refused opt-in falls through.
-        if (ce_scan != cudaSuccess && sm_scan > 48u * 1024u) return false;
         cfg[dev] = 1;
     }
+    if (!gdnc_scan_smem_ok<C, HD, JC_S>(dev)) return false;
+    // JC_B is ~89 KB and only the wide shape; a device that refuses it just keeps JC_S.
+    const int sms = gdnc_sm_count();
+    const bool spills = sms > 0 && v_heads * (HD / JC_S) > sms;
+    const bool use_big = spills && n_tokens >= bigjc_minctx &&
+                         gdnc_scan_smem_ok<C, HD, JC_B>(dev);
 
     auto db = reinterpret_cast<const __nv_bfloat16*>(dt);
     auto aa = reinterpret_cast<const __nv_bfloat16*>(a);
 
     // PREP_THREADS is fixed by the 2x2 (i,j) tiling in the A/M pass: C*C == 4*PREP_THREADS.
     static_assert(C * C == PREP_THREADS * 4, "2x2 A/M tiling requires C*C == 4*PREP_THREADS");
-    static_assert(C * JC == SCAN_THREADS * 4, "2x2 tiling requires C*JC == 4*SCAN_THREADS");
-    static_assert(HD * JC == SCAN_THREADS * 16, "4x4 tiling requires HD*JC == 16*SCAN_THREADS");
+    // One thread per 4 [C,JC] outputs and per 16 [HD,JC] outputs; both fix the same block size,
+    // which is why the warp count is derivable from JC alone (NW = C*JC/128 in the kernel).
+    static_assert(C * JC_S == (C * JC_S / 4) * 4 && HD * JC_S == (C * JC_S / 4) * 16, "JC_S tiling");
+    static_assert(C * JC_B == (C * JC_B / 4) * 4 && HD * JC_B == (C * JC_B / 4) * 16, "JC_B tiling");
+    static_assert(HD % JC_S == 0 && HD % JC_B == 0, "JC must divide the state rows");
 
     // One sequence-slice: workspace is O(len). carry=0 zeros S (fresh prefill);
     // carry=1 reloads the state the previous slice wrote.
@@ -635,10 +724,19 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
         pf_gdnc_prep_kernel<C, HD><<<gprep, PREP_THREADS, sm_prep, stream>>>(
             qb, kb, vb, ab, bb, db, aa, g_buf, w_buf, u_buf, m_buf,
             len, q_heads, v_heads, qh_block);
-        dim3 gscan(v_heads, HD / JC);
-        pf_gdnc_scan_kernel<C, HD, JC><<<gscan, SCAN_THREADS, sm_scan, stream>>>(
-            qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob,
-            len, q_heads, v_heads, n_chunks, qh_block, carry);
+        if (use_big) {
+            pf_gdnc_scan_kernel<C, HD, JC_B>
+                <<<dim3(v_heads, HD / JC_B), (C * JC_B) / 4,
+                   gdnc_scan_smem<C, HD, JC_B>(), stream>>>(
+                    qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob,
+                    len, q_heads, v_heads, n_chunks, qh_block, carry);
+        } else {
+            pf_gdnc_scan_kernel<C, HD, JC_S>
+                <<<dim3(v_heads, HD / JC_S), (C * JC_S) / 4,
+                   gdnc_scan_smem<C, HD, JC_S>(), stream>>>(
+                    qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob,
+                    len, q_heads, v_heads, n_chunks, qh_block, carry);
+        }
         return cudaPeekAtLastError() == cudaSuccess;
     };
 

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -318,14 +318,19 @@ __global__ void swiglu_quant_rows(const __nv_bfloat16* __restrict__ gate,
 
 template <class C = Wide>
 typename C::Gemm::Arguments args(const void* a, const void* sa, const void* b, const void* sb,
-                                 void* d, int m, int n, int k, float alpha = 1.f) {
+                                 void* d, int m, int n, int k, float alpha = 1.f,
+                                 const void* c = nullptr) {
     auto as = cutlass::make_cute_packed_stride(StrideA{}, {m,k,1});
     auto bs = cutlass::make_cute_packed_stride(StrideB{}, {n,k,1});
     auto cs = cutlass::make_cute_packed_stride(StrideC{}, {m,n,1});
     auto ds = cutlass::make_cute_packed_stride(StrideD{}, {m,n,1});
+    // beta is 1 exactly when a source is supplied — the residual accumulate. With c == nullptr
+    // beta MUST stay 0: the epilogue skips the C load entirely on beta == 0, and a non-zero beta
+    // over a null pointer faults.
+    const float beta = c ? 1.f : 0.f;
     return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m,n,k),
             {static_cast<const cutlass::float_e2m1_t*>(a), as, static_cast<const cutlass::float_e2m1_t*>(b), bs, static_cast<const cutlass::float_ue4m3_t*>(sa), sfa_layout(m,n,k), static_cast<const cutlass::float_ue4m3_t*>(sb), sfb_layout(m,n,k)},
-            {{alpha, 0.f}, static_cast<const BF*>(nullptr), cs, static_cast<BF*>(d), ds}};
+            {{alpha, beta}, static_cast<const BF*>(c), cs, static_cast<BF*>(d), ds}};
 }
 
 int sm_count() {
@@ -364,9 +369,10 @@ bool prefer_narrow(int m, int n) {
 
 template <class C>
 bool run_gemm(const void* a, const void* sa, const void* b, const void* sb,
-              void* d, int m, int n, int k, void* ws, cudaStream_t st, float alpha) {
+              void* d, int m, int n, int k, void* ws, cudaStream_t st, float alpha,
+              const void* c) {
     typename C::Gemm gemm;
-    auto ar = args<C>(a, sa, b, sb, d, m, n, k, alpha);
+    auto ar = args<C>(a, sa, b, sb, d, m, n, k, alpha, c);
     return gemm.can_implement(ar) == cutlass::Status::kSuccess &&
            gemm.initialize(ar, ws, st) == cutlass::Status::kSuccess &&
            gemm.run(st) == cutlass::Status::kSuccess;
@@ -439,7 +445,8 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
-                               void* d,int m,int n,int k,void* ws,cudaStream_t st, float alpha) {
+                               void* d,int m,int n,int k,void* ws,cudaStream_t st, float alpha,
+                               const void* c) {
     if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
     // Default ON; SPARKINFER_NVFP4_EVICT_FIRST=0 restores CUTLASS's stock loads for A/B.
     static const bool ef = [] {
@@ -451,14 +458,14 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
     // implement the shape.
     const int big = nvfp4_big_tile();
     if (big && m >= 512) {
-        if (run_gemm<BigM>(a,sa,b,sb,d,m,n,k,ws,st,alpha)) return true;
+        if (run_gemm<BigM>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c)) return true;
 
     }
     if (ef)
-        return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha)
-                                  : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha);
-    return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st,alpha)
-                              : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st,alpha);
+        return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c)
+                                  : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c);
+    return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c)
+                              : run_gemm<Wide>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c);
 }
 
 // ---- HuggingFace "compressed-tensors" NVFP4 checkpoint dequant (load-time, one-shot) ----

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -25,11 +25,16 @@ bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_b
                                          int m, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
+// c_bf16 is the epilogue's source operand: non-null makes this compute
+// D = alpha*(A*B) + C instead of D = alpha*(A*B), which is how a residual add is
+// folded into the block-scaled GEMM rather than run as a separate full-tensor pass.
+// c_bf16 may alias d_bf16 (the in-place x += proj form); the epilogue reads each
+// output tile before it stores it.
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,
                                const void* b_fp4, const void* sfb,
                                void* d_bf16, int m, int n, int k,
                                void* workspace, cudaStream_t stream = nullptr,
-                               float alpha = 1.f);
+                               float alpha = 1.f, const void* c_bf16 = nullptr);
 
 // Scatter a compressed-tensors row-major UE4M3 scale [n, k/16] into the CUTLASS
 // SFB layout launch_prefill_nvfp4_gemm expects for B. Packed E2M1 bytes are

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -98,6 +98,18 @@ struct Qwen35LayerWeights {
     // Short-context-only copy; decode retains down_q, so long-context configurations leave this
     // null to preserve KV and batched-prefill scratch headroom on 32-GB cards.
     const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
+    // Full-attention q/k/v projections as the checkpoint ships them (ModelOpt NVFP4). Unlike the
+    // GDN pointers below these do NOT alias a payload decode already holds: decode reads the Q4_K
+    // wq/wk/wv/wo built from the same bytes, because native NVFP4 GEMV is ~0.65x at m=1. So the
+    // packed nibbles are genuinely extra residency and are gated on a free-VRAM preflight.
+    // q and attn_gate stay ONE wide [2*qdim, H] operand, exactly as wq already is, so the
+    // split_q_gate that follows the projection is unchanged.
+    const void* wq_fp4 = nullptr; const void* wq_fp4_sf = nullptr;
+    const void* wk_fp4 = nullptr; const void* wk_fp4_sf = nullptr;
+    const void* wv_fp4 = nullptr; const void* wv_fp4_sf = nullptr;
+    // Muse builds wo_fp4 from bf16 and folds the global scale into UE4M3, leaving alpha 1; the
+    // checkpoint-native path carries 1/weight_global_scale here instead (pack_sfb omits it).
+    float wq_fp4_alpha = 1.f, wk_fp4_alpha = 1.f, wv_fp4_alpha = 1.f, wo_fp4_alpha = 1.f;
     // GDN in/out projections, for checkpoints that ship them as NVFP4 (ModelOpt). These point INTO
     // the payload keep_nvfp4_native already keeps resident for decode's launch_gemv_nvfp4, so only
     // the CUTLASS SFB scale copy (1 byte per 16 weights) is new VRAM -- the packed nibbles are

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4801,10 +4801,38 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             w.q_has_gate = c.hybrid;
             const std::string ab = b + "self_attn.";
             const int q_out = w.q_has_gate ? s.qdim * 2 : s.qdim;
-            w.wq = requant_q4k(dequant_any(ab + "q_proj", q_out, H), (long)q_out * H, w.wq_type);
-            w.wk = requant_q4k(dequant_any(ab + "k_proj", s.kvdim, H), (long)s.kvdim * H, w.wk_type);
-            w.wv = requant_q4k(dequant_any(ab + "v_proj", s.kvdim, H), (long)s.kvdim * H, w.wv_type);
-            w.wo = requant_q4k(dequant_any(ab + "o_proj", H, s.qdim), (long)H * s.qdim, w.wo_type);
+            // Same treatment the GDN projections get: keep the checkpoint's own NVFP4 bytes rather
+            // than fitting a second quantization to them. Batched prefill then feeds the packed
+            // nibbles to the SM120 block-scaled GEMM instead of streaming a Q4_K copy through a
+            // dp4a GEMM at ~30% of peak, and decode reads them through launch_gemv_nvfp4.
+            //
+            // This REPLACES the Q4_K copy rather than sitting beside it, which is what makes it
+            // affordable: the payload is 0.5625 B/weight against Q4_K's 0.5625, so only the
+            // CUTLASS SFB scale copy (0.0625 B/weight, ~105 MB over 16 layers) is new residency.
+            // Holding both would have cost ~1.05 GB, and this model already peaks at 31.9 GB of a
+            // 32.6 GB card at max_ctx=16384 -- there is 676 MB of headroom, so the both-copies
+            // form would have shrunk the 16k prefill arena, which is a no-regression floor.
+            // SPARKINFER_Q38_ATTN_NVFP4=0 restores the Q4_K requant (A/B in ONE binary).
+            static const bool attn_native_fp4 = [] {
+                const char* e = getenv("SPARKINFER_Q38_ATTN_NVFP4");
+                return !(e && e[0] == '0');
+            }();
+            // Per TENSOR, and only when it is genuinely NVFP4. keep_native would otherwise route
+            // an FP8 attention tensor to keep_fp8, which is exactly what the OTHER shipped
+            // Qwen3.8 checkpoint (unsloth: NVFP4 FFN + FP8 attention/GDN) stores -- that moved its
+            // decode off Q4_K MMVQ and cost it 3.4%, a model this change has no business touching.
+            // Probing per tensor keeps every non-NVFP4 attention weight on the exact path it had.
+            auto attn_w = [&](const std::string& nm, int rows, int cols, int& qt,
+                              const void** fp4, const void** fp4_sf, float* alpha) -> const void* {
+                NvFp4Src probe{};
+                if (attn_native_fp4 && nvfp4_src(ab + nm, rows, cols, probe))
+                    return keep_native(ab + nm, rows, cols, qt, fp4, fp4_sf, alpha);
+                return requant_q4k(dequant_any(ab + nm, rows, cols), (long)rows * cols, qt);
+            };
+            w.wq = attn_w("q_proj", q_out,   H,       w.wq_type, &w.wq_fp4, &w.wq_fp4_sf, &w.wq_fp4_alpha);
+            w.wk = attn_w("k_proj", s.kvdim, H,       w.wk_type, &w.wk_fp4, &w.wk_fp4_sf, &w.wk_fp4_alpha);
+            w.wv = attn_w("v_proj", s.kvdim, H,       w.wv_type, &w.wv_fp4, &w.wv_fp4_sf, &w.wv_fp4_alpha);
+            w.wo = attn_w("o_proj", H,       s.qdim,  w.wo_type, &w.wo_fp4, &w.wo_fp4_sf, &w.wo_fp4_alpha);
             w.q_norm = load_norm_plus1(ab + "q_norm.weight", c.head_dim);
             w.k_norm = load_norm_plus1(ab + "k_norm.weight", c.head_dim);
             if (!w.wq || !w.wk || !w.wv || !w.wo || !w.q_norm || !w.k_norm) return false;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -644,6 +644,58 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         fp4_gdn_ws = (wb <= fp4_ws_bytes && fp4_ws) ? fp4_ws : a8.alloc<unsigned char>(wb);
     }
 
+    // ---- full-attention q|gate / k / v / o straight off the checkpoint's NVFP4 bytes ----
+    // The 16 softmax-attention layers were the last projections still leaving the block-scaled
+    // GEMM: proj() ran them as a dp4a int8 GEMM over the Q4_K copy, measured at ~30% of peak
+    // against the FP4 GEMM's 76% beside it (nsys, ctx=128: 1.076 ms for q|gate,k,v + 0.589 ms for
+    // o, per pass, moving 0.94 GB). Loading them with keep_native (qwen35.cpp) makes the packed
+    // nibbles the resident form, so this is the same GEMM the FFN and GDN already use.
+    //
+    // Bounded by N like the GDN arm and for the same reason -- the saving is per-layer fixed cost,
+    // so it is worth the most where N is small -- and so the scored ctx=128 shape cannot depend on
+    // the cudaMemGetInfo-derived FC. Bit 0 is q|gate/k/v (which share one A quantize), bit 1 is o.
+    static const int attn_fp4_mask = [] {
+        const char* e = getenv("SPARKINFER_Q38_ATTN_NVFP4_PREFILL");
+        return e ? atoi(e) : 3;
+    }();
+    // Unlike the GDN arm this is NOT bounded to short prompts. #860 bounds GDN at 2048 because
+    // the delta-rule recurrence compounds activation-quant error along the sequence; softmax
+    // attention has no such carry -- each q/k/v row is projected independently -- so the FP4
+    // activation error does not accumulate with N. It also MUST cover every length here: the Q4_K
+    // copy no longer exists, so any N that misses this arm falls back to expanding the NVFP4
+    // weight to bf16 and then to int8 on every pass, which is far worse than the arm is good
+    // (measured: -3.7% at ctx=16384 when the bound was left at 2048).
+    static const int attn_fp4_maxn = [] {
+        const char* e = getenv("SPARKINFER_Q38_ATTN_NVFP4_MAXN");
+        return e ? atoi(e) : (1 << 30);
+    }();
+    // Layer 0 is a GDN layer under full_attention_interval, so probe for the first full-attn one.
+    const Qwen35LayerWeights* attn_probe = nullptr;
+    for (const auto& lw : s.w.layers)
+        if (!lw.linear_attn) { attn_probe = &lw; break; }
+    const int wide_n = 2 * qdim;                     // wq holds [q|gate] as one operand
+    const bool attn_nvfp4 = attn_fp4_mask != 0 && !moe && !c.muse_glimmer &&
+        attn_probe && attn_probe->wq_fp4 && N <= attn_fp4_maxn &&
+        kernels::prefill_nvfp4_supported(N, wide_n, H) &&
+        kernels::prefill_nvfp4_supported(N, kvdim, H) &&
+        kernels::prefill_nvfp4_supported(N, H, qdim);
+    // o's A operand is `att` at k = qdim (6144 here), wider than the q/k/v k = H, so one staging
+    // pair sized for the widest of the two covers all four projections.
+    const int attn_k = (qdim > H) ? qdim : H;
+    unsigned char* fp4_attn_a = attn_nvfp4
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_data_bytes(N, attn_k)) : nullptr;
+    unsigned char* fp4_attn_as = attn_nvfp4
+        ? a8.alloc<unsigned char>(kernels::prefill_nvfp4_scale_bytes_a(N, attn_k)) : nullptr;
+    unsigned char* fp4_attn_ws = nullptr;
+    if (attn_nvfp4) {
+        size_t wb = kernels::prefill_nvfp4_workspace_bytes(N, wide_n, H);
+        const size_t wk = kernels::prefill_nvfp4_workspace_bytes(N, kvdim, H);
+        const size_t wo2 = kernels::prefill_nvfp4_workspace_bytes(N, H, qdim);
+        if (wk > wb) wb = wk;
+        if (wo2 > wb) wb = wo2;
+        fp4_attn_ws = (wb <= fp4_ws_bytes && fp4_ws) ? fp4_ws : a8.alloc<unsigned char>(wb);
+    }
+
     // Long-ctx FFN int8: keep gate/up/down int8 weights (+scales) across token chunks so each
     // layer dequants once instead of once per chunk. ~150 MB vs ~300 MB for a bf16 cache.
     Arena& aw = arena_reuse ? keep_aw : once_aw;
@@ -966,6 +1018,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // Bit-identical to the two-step path. SPARKINFER_PREFILL_RESID_FUSE=0 disables (A/B).
     const char* _prfuse = getenv("SPARKINFER_PREFILL_RESID_FUSE");
     const bool resid_fuse = !_prfuse || _prfuse[0] != '0';
+    // Same idea for the block-scaled NVFP4 projections, which used to be excluded from it because
+    // the launcher had no source operand: CUTLASS's LinearCombination epilogue is already
+    // D = alpha*Acc + beta*C, so passing the residual as C and beta=1 folds the add in.
+    // SPARKINFER_PREFILL_NVFP4_RESID_FUSE=0 restores the raw-projection + separate-add form (A/B).
+    const bool nvfp4_resid_fuse = resid_fuse && [] {
+        const char* e = getenv("SPARKINFER_PREFILL_NVFP4_RESID_FUSE");
+        return !(e && e[0] == '0');
+    }();
     auto proj_resid = [&](const bf16* A, const void* W, int wtype, bf16* Cx, int n_out, int K,
                           int rows = 0) -> bool {
         if (!resid_fuse || !use_i8 || n_out < 128 || wtype == kernels::SI_QTYPE_FP8) return false;
@@ -1133,18 +1193,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim,
                 c.gdn_qh_block, st);
             kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh, c.linear_head_dim, eps, st);
-            // out_proj off the same NVFP4 bytes. The block-scaled GEMM cannot accumulate the
-            // residual, so this writes the RAW projection to `ao` and leaves attn_fused false --
-            // the `if (!attn_fused) launch_prefill_add(x, ao, x, ...)` below is what applies it,
-            // exactly as the Muse wo_fp4 arm does for the o projection.
-            const bool out_fp4 = gdn_nvfp4 && (gdn_fp4_mask & 2) &&
-                w.gdn_out_fp4 && w.gdn_out_fp4_sf &&
+            // out_proj off the same NVFP4 bytes, with the residual folded into the block-scaled
+            // GEMM's own epilogue (D = A*B + C, C aliasing D aliasing x) instead of written raw
+            // to `ao` for a separate full-tensor add. That add is three N*H bf16 streams (read x,
+            // read ao, write x) for one flop per element; the epilogue already holds the
+            // accumulator in registers, so folding it in costs one read and removes the pass.
+            // The fused form claims the residual itself -- attn_fused suppresses the add below.
+            bool out_fp4 = false;
+            if (gdn_nvfp4 && (gdn_fp4_mask & 2) && w.gdn_out_fp4 && w.gdn_out_fp4_sf &&
                 fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
-                kernels::launch_prefill_nvfp4_quant_a(lnrm, fp4_gdn_a, fp4_gdn_as, N, lvdim, st) &&
-                kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
-                                                   w.gdn_out_fp4, w.gdn_out_fp4_sf,
-                                                   ao, N, H, lvdim, fp4_gdn_ws, st,
-                                                   w.gdn_out_fp4_alpha);
+                kernels::launch_prefill_nvfp4_quant_a(lnrm, fp4_gdn_a, fp4_gdn_as, N, lvdim, st)) {
+                if (nvfp4_resid_fuse &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                       w.gdn_out_fp4, w.gdn_out_fp4_sf,
+                                                       x, N, H, lvdim, fp4_gdn_ws, st,
+                                                       w.gdn_out_fp4_alpha, x)) {
+                    out_fp4 = true;
+                    attn_fused = true;
+                } else if (kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
+                                                              w.gdn_out_fp4, w.gdn_out_fp4_sf,
+                                                              ao, N, H, lvdim, fp4_gdn_ws, st,
+                                                              w.gdn_out_fp4_alpha)) {
+                    out_fp4 = true;
+                }
+            }
             if (!out_fp4) {
                 attn_fused = proj_resid(lnrm, w.ssm_out, w.ssm_out_type, x, H, lvdim);
                 if (!attn_fused) proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
@@ -1226,8 +1298,30 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 // Qwen3.8: [q|gate] is one wide wq, then skinny k/v (8 tiles each). One grouped
                 // launch fills the 5090; four separate ones leave k/v paying a full CTA duration
                 // for 8 blocks. Same kernel as Muse, bit-identical per tile.
-                bool grouped = false;
-                if (use_i8 && w.wq_rs && w.wk_rs && w.wv_rs &&
+                // Checkpoint-native NVFP4: quantize xn to FP4 ONCE (all three projections read it)
+                // and run three block-scaled GEMMs off the packed nibbles. [q|gate] stays the one
+                // wide operand it already is, so the split below is untouched. A_i8/sx are not
+                // written, so the int8 activation memo stays valid for whatever runs next.
+                bool qkv_fp4 = false;
+                if (attn_nvfp4 && (attn_fp4_mask & 1) &&
+                    w.wq_fp4 && w.wq_fp4_sf && w.wk_fp4 && w.wk_fp4_sf &&
+                    w.wv_fp4 && w.wv_fp4_sf && fp4_attn_a && fp4_attn_as && fp4_attn_ws &&
+                    kernels::launch_prefill_nvfp4_quant_a(xn, fp4_attn_a, fp4_attn_as, N, H, st) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_attn_a, fp4_attn_as,
+                                                       w.wq_fp4, w.wq_fp4_sf,
+                                                       b8, N, wide, H, fp4_attn_ws, st,
+                                                       w.wq_fp4_alpha) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_attn_a, fp4_attn_as,
+                                                       w.wk_fp4, w.wk_fp4_sf,
+                                                       kf, N, kvdim, H, fp4_attn_ws, st,
+                                                       w.wk_fp4_alpha) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_attn_a, fp4_attn_as,
+                                                       w.wv_fp4, w.wv_fp4_sf,
+                                                       vf, N, kvdim, H, fp4_attn_ws, st,
+                                                       w.wv_fp4_alpha))
+                    qkv_fp4 = true;
+                bool grouped = qkv_fp4;
+                if (!qkv_fp4 && use_i8 && w.wq_rs && w.wk_rs && w.wv_rs &&
                     w.wk_type == w.wq_type && w.wv_type == w.wq_type &&
                     kernels::pf_dense_gemm_qi8_supported(w.wq_type)) {
                     const void*  Wa[3]  = { w.wq, w.wk, w.wv };
@@ -1327,7 +1421,32 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             if (!gate_fused && !wo_fp4_done) {
                 kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
             }
-            if (c.muse_glimmer) {
+            // o off the same NVFP4 bytes, reading the already-gated `att`, with the residual taken
+            // by the epilogue's C operand (same fold as the GDN out_proj above) so no separate
+            // full-tensor add pass is needed. If the fused form declines, fall back to writing the
+            // raw projection to `ao` and let the `if (!attn_fused) launch_prefill_add(...)` tail
+            // apply it, exactly as the Muse wo_fp4 arm does.
+            bool wo_fp4_q38 = false, wo_fp4_resid = false;
+            if (attn_nvfp4 && (attn_fp4_mask & 2) &&
+                w.wo_fp4 && w.wo_fp4_sf && fp4_attn_a && fp4_attn_as && fp4_attn_ws &&
+                kernels::launch_prefill_nvfp4_quant_a(att, fp4_attn_a, fp4_attn_as, N, qdim, st)) {
+                if (nvfp4_resid_fuse && !c.muse_glimmer &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_attn_a, fp4_attn_as,
+                                                       w.wo_fp4, w.wo_fp4_sf,
+                                                       x, N, H, qdim, fp4_attn_ws, st,
+                                                       w.wo_fp4_alpha, x)) {
+                    wo_fp4_q38 = true;
+                    wo_fp4_resid = true;
+                } else if (kernels::launch_prefill_nvfp4_gemm(fp4_attn_a, fp4_attn_as,
+                                                              w.wo_fp4, w.wo_fp4_sf,
+                                                              ao, N, H, qdim, fp4_attn_ws, st,
+                                                              w.wo_fp4_alpha)) {
+                    wo_fp4_q38 = true;
+                }
+            }
+            if (wo_fp4_q38) {
+                attn_fused = wo_fp4_resid;
+            } else if (c.muse_glimmer) {
                 // Sandwich norm needs the RAW O-proj output in `ao` (not fused into x); the residual
                 // add happens in launch_norm_then_add below. The FP4 GEMM already wrote `ao` and
                 // left attn_acc at 0, so the plain norm_then_add tail consumes it.
@@ -1426,6 +1545,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                           w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as;
             const bool ffn_fused = !c.muse_glimmer && !ffn_fp4_possible &&
                                    resid_fuse && (ffn_i8 || use_i8) && !ffn_qi8;
+            // The FP4 down projection accumulates the residual in its own epilogue (see the GDN
+            // out_proj above). Decided per LAYER, not per chunk, so the whole layer takes one
+            // route: a chunk that fuses has already applied its residual to x, so a mix would
+            // need the trailing add to skip exactly those rows. When it is on, any chunk whose
+            // fused GEMM declines applies its own residual immediately instead.
+            const bool ffn_fp4_resid = nvfp4_resid_fuse && ffn_fp4_possible && !c.muse_glimmer &&
+                                       nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
+                                       fp4_down_a && fp4_down_as;
             for (int fo = 0; fo < N; fo += FC) {
                 const int fn = (N - fo < FC) ? (N - fo) : FC;
                 const bf16* hn_c = hn + (size_t)fo * H;
@@ -1440,19 +1567,31 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                        ffu, fn, ffn, H, fp4_ws, st,
                                                        w.up_fp4_alpha);
                 if (layer_fp4) {
-                    const bool down_fp4_done = nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
+                    bf16* xc = x + (size_t)fo * H;
+                    const bool down_swiglu_q = nvfp4_down && w.down_fp4 && w.down_fp4_sf &&
                         fp4_down_a && fp4_down_as &&
                         kernels::launch_prefill_nvfp4_swiglu_quant_a(
-                            ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn, st) &&
+                            ffg, ffu, fp4_down_a, fp4_down_as, fn, ffn, st);
+                    const bool down_fp4_resid = down_swiglu_q && ffn_fp4_resid &&
                         kernels::launch_prefill_nvfp4_gemm(
                             fp4_down_a, fp4_down_as, w.down_fp4, w.down_fp4_sf,
+                            xc, fn, H, ffn, fp4_ws, st, w.down_fp4_alpha, xc);
+                    const bool down_fp4_done = down_fp4_resid ||
+                        (down_swiglu_q &&
+                         kernels::launch_prefill_nvfp4_gemm(
+                            fp4_down_a, fp4_down_as, w.down_fp4, w.down_fp4_sf,
                             ao + (size_t)fo * H, fn, H, ffn, fp4_ws, st,
-                            w.down_fp4_alpha);
+                            w.down_fp4_alpha));
                     if (!down_fp4_done) {
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
                         proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
                                        ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     }
+                    // Keep the layer on one route: if the residual-fused arm is active but this
+                    // chunk fell through it, that chunk's rows are still raw in `ao` and the
+                    // trailing whole-tensor add is going to be skipped, so apply them here.
+                    if (ffn_fp4_resid && !down_fp4_resid)
+                        kernels::launch_prefill_add(xc, ao + (size_t)fo * H, xc, (long)fn * H, st);
                     continue;
                 }
                 if (ffn_qi8) {
@@ -1596,8 +1735,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                       w.post_ffn_norm, x, N, H, 1e-8f, st);
                 else
                     kernels::launch_norm_then_add(h, ao, w.post_ffn_norm, x, N, H, 1e-8f, st);
-            } else if (!ffn_fused) {
-                // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk)
+            } else if (!ffn_fused && !ffn_fp4_resid) {
+                // x += ffn_out (skipped when the down GEMM already accumulated into x per chunk,
+                // whether through the int8 fused-residual GEMM or the FP4 epilogue's C operand)
                 kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
             }
         } else {


### PR DESCRIPTION
## Summary

Four things at ctx=16384, found by profiling the pass rather than tuning kernels. Per prefill pass
(nsys, load-time kernels excluded): FP4 GEMM 500.7 ms at 1492 TFLOPS = **89% of NVFP4 peak, so it is
already at roofline and is not touched here**; GDN scan 256.9; attention 164.3; attention projections
88.7.

**1. The GDN scan was spending half its time on an empty second wave.** Its grid is
`v_heads x HD/JC` = 48 x 4 = **192 blocks**, and at 68.9 KB dynamic + 16.4 KB static shared memory
only ONE fits per SM (`ncu: launch__occupancy_limit_shared_mem = 1`). On 170 SMs that is 170 blocks
then 22 — **56% efficient no matter how fast the block is**, and nothing inside the block can see it.
JC=64 makes it 96 blocks and one wave, with the same 1536 warps in flight and half the W/K/Q staging
per state column.

The wave model was checked against an existing measurement *before* the rewrite: JC=16 is 384 blocks
= three waves and predicts ~20% slower on this kernel; it measures 21%. Laid out naively JC=64 needs
133 KB, so three regions are reused at disjoint points of the chunk body (`s_C` over `s_W|s_Q`, then
`s_Y` and `s_Ub` over `s_Sb`) to land at 89 KB. Numerics are unchanged — same tile shapes, same
k-loop order, same ascending reduction order. **+3.0%**

Gated on `v_heads * HD/JC > sm_count`, i.e. on the narrow grid *actually* spilling, not on the model
or the context. That gate is load-bearing: Qwen3.5/3.6 carry 32 v-heads, so their grid is 128 blocks
and already fits one wave, and widening it there pays a ~1.65x per-block cost for a wave saving that
does not exist — measured as **-6.1% on the Qwen3.6 guard at ctx=4096** before the gate was
corrected.

**2. Attention re-reads K/V out of L2, and GQA-6 never got the wide tier.** ncu at ctx=16384:

```
L2 throughput        80.3% of peak      <- the bound
L1TEX                75.1%
SM throughput        62.7%
DRAM                  1.7%              <- not a memory-bandwidth problem
```

The group is 24/4 = 6, so the shipped tiers (RQH=4, then 2) always fall through to 2 — 4 does not
divide 6. RQH=3 loads each K page and V tile once for three q-heads instead of two, taking a third
off the dominant traffic term. It stays at the two resident blocks its `__launch_bounds__` asks for
only because `s_o` (the epilogue landing zone) now overlays `s_s` (the scores, dead by the epilogue):
46,528 B against the 51,200 a second block needs, where holding both is 62,912 and caps it at one.
Long context only — it is +1.9% at 16k and -0.45% at ctx=128. **+1.9%**

**3. The block-scaled GEMM can accumulate the residual after all.** Two call sites carried a comment
saying it could not, so they wrote a raw projection to `ao` and paid a separate full-tensor add —
three N x H bf16 streams for one flop per element. CUTLASS's `LinearCombination` epilogue is already
`D = alpha*Acc + beta*C`; `launch_prefill_nvfp4_gemm` simply had no C parameter. Passing the residual
as C (aliasing D, which the epilogue handles — each output tile is read before it is stored) deletes
the pass. **+2.0% at 16k, and +0.96% at ctx=128.**

**4. The full-attention q/k/v/o were the last projections still on the int8 GEMM** — 88.7 ms/pass at
620 TOPS, 74% of the int8 peak, against the FP4 GEMM's 89% beside it. Loading them as the checkpoint
ships them (NVFP4) puts them on the same block-scaled GEMM. This REPLACES the Q4_K refit rather than
sitting beside it: the payload is 0.5625 B/weight either way, so only the CUTLASS SFB scale copy is
new residency, where holding both would have cost ~1.05 GB on a model that already peaks near the
card. Probed per tensor and only when the tensor is genuinely NVFP4 — the other shipped Qwen3.8
checkpoint stores FP8 attention, and routing that through the native path moves its decode off Q4_K
MMVQ. **+2.5% at 16k, +5.0% at ctx=128.**

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 94.96 |
| after (this PR) | 94.33 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 11609.00 |
| after prefill (this PR) | **12841.38** |

**1.1062x prefill@16k.** Qwen3.8-27B ModelOpt NVFP4, ONE binary, warm-up first then main/PR
alternated x3 at 5 reps (an unalternated first run on this box reads cold and invents ~20% swings).

```text
  warmup  {"128":{"decode_tps":95.6529,"prefill_pp":6528.4502},"16384":{"decode_tps":90.1480,"prefill_pp":11766.4936}}
  r1 main {"128":{"decode_tps":95.3176,"prefill_pp":6510.4081},"16384":{"decode_tps":89.8600,"prefill_pp":11680.9791}}
  r1 PR   {"128":{"decode_tps":94.5552,"prefill_pp":6905.1433},"16384":{"decode_tps":89.1144,"prefill_pp":12885.9172}}
  r2 main {"128":{"decode_tps":94.9636,"prefill_pp":6505.8168},"16384":{"decode_tps":89.5145,"prefill_pp":11609.0005}}
  r2 PR   {"128":{"decode_tps":94.3298,"prefill_pp":6914.9628},"16384":{"decode_tps":88.9593,"prefill_pp":12841.3847}}
  r3 main {"128":{"decode_tps":94.8801,"prefill_pp":6498.5578},"16384":{"decode_tps":89.4433,"prefill_pp":11591.0142}}
  r3 PR   {"128":{"decode_tps":94.3190,"prefill_pp":6903.1726},"16384":{"decode_tps":88.9675,"prefill_pp":12836.0364}}

medians   prefill@16k 11609.00 -> 12841.38 = 1.1062x
          prefill@128  6505.82 ->  6905.14 = 1.0614x
          decode@128     94.96 ->    94.33 = 0.9934
          decode@16k     89.51 ->    88.96 = 0.9939
```

Per-change, each A/B'd on its own in the same binary: scan +3.0%, RQH=3 +1.9%, residual fold +2.0%,
native-FP4 attention +2.5%.

## Correctness

Changes 1-3 are confined to `prefill_batched_run()`, which `qwen3_gguf_score` never enters. Change 4
moves the attention weights decode reads, so the differential gate genuinely applies — measured the
way the bot measures it (the checkpoint's own tokenizer over `bench/scripts/eval_text.txt`, topk 128):

| | value | bar |
|---|--:|--:|
| top1 vs main | **0.980198** | >= 0.90 |
| KL vs main | **0.017701** | <= 0.10 |
| perplexity | **3.2348 -> 3.2040** | — |

Perplexity *improves*: the checkpoint's own NVFP4 bytes are more faithful to it than a Q4_K refit of
them. Batched-prefill parity, which does see the prefill path: `PARITY worst=1.000 bar=0.75 OK`.

## No-regression

Both guards warm-up-first and alternated, same protocol:

| guard | main | this PR | |
|---|--:|--:|--:|
| Qwen3.6 prefill@4096 | 25663.69 | 25660.54 | 0.9999 |
| Qwen3.6 prefill@512 | 10004.10 | 10010.13 | 1.0006 |
| Qwen3.8 (unsloth) prefill@128 | 4114.30 | 4144.38 | 1.007 |
| Qwen3.8 (unsloth) decode@128 | 85.12 | 85.05 | 0.999 |

Qwen3.6 decode is flat at 0/512/4096 (496.61-496.71 / 489.96-490.38 / 470.85-471.36 main against
496.46-496.64 / 489.89-490.31 / 470.65-470.93).

## Scope

`SPARKINFER_PREFILL_GDN_SCAN_BIGJC_MINCTX=999999`, `SPARKINFER_PREFILL_ATTN_GQA_RQH=2`,
`SPARKINFER_PREFILL_NVFP4_RESID_FUSE=0` and `SPARKINFER_Q38_ATTN_NVFP4=0` each restore the previous
behaviour, so all four arms A/B in one binary — which is how the per-change numbers above were taken
and how the Qwen3.6 regression was isolated to exactly one of them.
