### PR TITLE
perf(qwen3.8): wider activation-quantize lanes and a register-resident GDN state (1.03x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
+++ b/kernels/csrc/cuda/fused/prefill_gdn_chunk.cu
@@ -274,7 +274,22 @@ __global__ void pf_gdnc_prep_kernel(const __nv_bfloat16* __restrict__ q,
 // grid = (v_heads, HD/JC); each block owns JC state columns of one v-head and walks the chunks.
 // Per chunk: U^ = U0 - W^ S ; Y = [diag(exp G)(Q S) + M U^] * scale ; S = exp(G_last) S + K^T U~.
 // ---------------------------------------------------------------------------
-template <int C, int HD, int JC>
+// REGS keeps the recurrent state S in REGISTERS instead of shared memory. S is [HD][JC] fp32 and
+// every loop that touches it already walks `for (e = tid; e < HD*JC; e += nthr)`, so thread tid
+// owns exactly the elements e = tid + t*NTHR -- a fixed (m, jj) = (warp + t*NW, lane) mapping, no
+// communication. That frees HD*JC*4 B of shared memory, which is what buys a SECOND resident block
+// per SM: 45,824 B against the 51,200 two blocks need, where the smem-S form is 62,208 and caps
+// the kernel at one. The whole grid is then resident in one wave using every SM, instead of the
+// 96-block/96-SM shape JC=64 had to use to avoid a second wave.
+//
+// The cost is that the S update can no longer write its own tile per warp: each thread now reads
+// back the tile covering ITS elements, so all (HD/16)x(JC/16) accumulator tiles must be live at
+// once. At JC=32 that is 16 KB, which still fits the s_W|s_Q alias window; at JC=64 it would be
+// 32 KB and does not, so REGS is a JC=32 shape only.
+//
+// Bit-identical: same values, same per-element order, same `gl * S + K^T U~` arithmetic -- only
+// where S lives changes.
+template <int C, int HD, int JC, bool REGS = false>
 __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                                     const __nv_bfloat16* __restrict__ k,
                                     const float* __restrict__ g_buf,
@@ -295,8 +310,12 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
     // s_K is NOT reused: the S update at the end of the chunk still needs it.
     extern __shared__ char s_raw[];
     constexpr int NW = (C * JC) / 128;          // warps; == 2 x (C/16)x(JC/16) accumulator tiles
+    constexpr int NTHR = NW * 32;
+    constexpr int SPT = (HD * JC) / NTHR;       // S elements per thread when REGS
+    float sreg[REGS ? SPT : 1];
+    // With REGS the arena simply starts where s_S used to end.
     float* s_S = reinterpret_cast<float*>(s_raw);                              // [HD][JC]  fp32 carrier
-    float* s_U = s_S + (size_t)HD * JC;                                        // [C][JC]
+    float* s_U = REGS ? s_S : s_S + (size_t)HD * JC;                           // [C][JC]
     float* s_M = s_U + (size_t)C * JC;                                         // [C][C+PAD]
     float* s_g = s_M + (size_t)C * (C + PAD);                                  // [C]
     float* s_eg = s_g + C;                                                     // [C] hoisted per-row expf
@@ -330,7 +349,14 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
     // Fresh prefill zeros S. A segment continuation reloads the transposed
     // [v_head][col][row] state the previous segment wrote, so a workspace split
     // is just another chunk boundary and decode still sees one recurrence.
-    if (carry) {
+    if constexpr (REGS) {
+        #pragma unroll
+        for (int t = 0; t < SPT; t++) {
+            const int e = tid + t * NTHR;
+            const int m = e / JC, jj = e - m * JC;
+            sreg[t] = carry ? state[((size_t)h * HD + (j0 + jj)) * HD + m] : 0.f;
+        }
+    } else if (carry) {
         for (int e = tid; e < HD * JC; e += nthr) {
             const int m = e / JC, jj = e - m * JC;
             s_S[e] = state[((size_t)h * HD + (j0 + jj)) * HD + m];
@@ -399,9 +425,18 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
         // each loaded value twice: 4 loads per 4 FMAs, and 4 independent accumulators to hide latency.
         // [C=32,JC=32] outputs / 256 threads = exactly 4 each, so the tiling divides evenly.
         // ---- narrow S to bf16 once, then run U^ = U0 - W^ S and Y0 = Q S on tensor cores ----
-        for (int e = tid; e < HD * JC; e += nthr) {
-            const int m = e / JC, jj = e - m * JC;
-            s_Sb[m * (JC + PAD) + jj] = __float2bfloat16(s_S[e]);
+        if constexpr (REGS) {
+            #pragma unroll
+            for (int t = 0; t < SPT; t++) {
+                const int e = tid + t * NTHR;
+                const int m = e / JC, jj = e - m * JC;
+                s_Sb[m * (JC + PAD) + jj] = __float2bfloat16(sreg[t]);
+            }
+        } else {
+            for (int e = tid; e < HD * JC; e += nthr) {
+                const int m = e / JC, jj = e - m * JC;
+                s_Sb[m * (JC + PAD) + jj] = __float2bfloat16(s_S[e]);
+            }
         }
         __syncthreads();
         {
@@ -500,6 +535,11 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
             constexpr int TJ = JC / 16;
             constexpr int REPS = ((HD / 16) * TJ) / NW;      // NW warps x REPS tiles = [HD,JC]
             static_assert(REPS * NW == (HD / 16) * TJ, "S-update tiles must divide over the warps");
+            // With REGS every tile has to survive until the per-thread readback below, so each one
+            // lands in its own slot; the smem-S form reuses one slot per warp.
+            static_assert(!REGS || (size_t)2 * C * (HD + PAD) * sizeof(__nv_bfloat16) >=
+                                       (size_t)(HD / 16) * TJ * 256 * sizeof(float),
+                          "REGS needs every S tile live in the s_W|s_Q window");
             const int warp = tid >> 5;
             #pragma unroll
             for (int rep = 0; rep < REPS; rep++) {
@@ -516,14 +556,28 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
                     wmma::load_matrix_sync(bf, s_Ub + (size_t)kk * (JC + PAD) + tj, JC + PAD);
                     wmma::mma_sync(cf, af, bf, cf);
                 }
-                wmma::store_matrix_sync(s_C + (size_t)warp * 256, cf, 16, wmma::mem_row_major);
-                __syncwarp();
-                for (int e = (tid & 31); e < 256; e += 32) {
-                    const int r = e >> 4, cc = e & 15;
-                    const int m = ti + r, jj = tj + cc;
-                    s_S[m * JC + jj] = gl * s_S[m * JC + jj] + s_C[(size_t)warp * 256 + r * 16 + cc];
+                if constexpr (REGS) {
+                    wmma::store_matrix_sync(s_C + (size_t)tile * 256, cf, 16, wmma::mem_row_major);
+                } else {
+                    wmma::store_matrix_sync(s_C + (size_t)warp * 256, cf, 16, wmma::mem_row_major);
+                    __syncwarp();
+                    for (int e = (tid & 31); e < 256; e += 32) {
+                        const int r = e >> 4, cc = e & 15;
+                        const int m = ti + r, jj = tj + cc;
+                        s_S[m * JC + jj] = gl * s_S[m * JC + jj] + s_C[(size_t)warp * 256 + r * 16 + cc];
+                    }
+                    __syncwarp();
                 }
-                __syncwarp();
+            }
+            if constexpr (REGS) {
+                __syncthreads();                 // every tile written before any thread reads back
+                #pragma unroll
+                for (int t = 0; t < SPT; t++) {
+                    const int e = tid + t * NTHR;
+                    const int m = e / JC, jj = e - m * JC;
+                    const int tile = (m >> 4) * TJ + (jj >> 4);
+                    sreg[t] = gl * sreg[t] + s_C[(size_t)tile * 256 + (m & 15) * 16 + (jj & 15)];
+                }
             }
         }
         __syncthreads();
@@ -531,9 +585,18 @@ __global__ void pf_gdnc_scan_kernel(const __nv_bfloat16* __restrict__ q,
     }
 
     // ---- final state, in the transposed [v_head][col][row] layout decode expects ----
-    for (int e = tid; e < HD * JC; e += nthr) {
-        const int m = e / JC, jj = e - m * JC;
-        state[((size_t)h * HD + (j0 + jj)) * HD + m] = s_S[e];
+    if constexpr (REGS) {
+        #pragma unroll
+        for (int t = 0; t < SPT; t++) {
+            const int e = tid + t * NTHR;
+            const int m = e / JC, jj = e - m * JC;
+            state[((size_t)h * HD + (j0 + jj)) * HD + m] = sreg[t];
+        }
+    } else {
+        for (int e = tid; e < HD * JC; e += nthr) {
+            const int m = e / JC, jj = e - m * JC;
+            state[((size_t)h * HD + (j0 + jj)) * HD + m] = s_S[e];
+        }
     }
 }
 
@@ -566,9 +629,9 @@ size_t gdnc_workspace_bytes(int n_tokens, int v_heads, int C, int HD) {
 
 // Shared memory for one scan block, matching the arena the kernel carves up (s_C, s_Y and s_Ub
 // are overlays and cost nothing here).
-template <int C, int HD, int JC>
+template <int C, int HD, int JC, bool REGS = false>
 constexpr size_t gdnc_scan_smem() {
-    return (size_t)HD * JC * sizeof(float)                                  // s_S (fp32 carrier)
+    return (REGS ? 0 : (size_t)HD * JC * sizeof(float))                     // s_S (fp32 carrier)
          + (size_t)C * JC * sizeof(float)                                   // s_U
          + (size_t)C * (C + PAD) * sizeof(float)                            // s_M
          + (size_t)2 * C * sizeof(float)                                    // s_g, s_eg
@@ -591,15 +654,15 @@ int gdnc_sm_count() {
 // separate functions and the attribute is per-function AND per-device, so they need separate
 // latches — a shared one would leave whichever kernel ran second unconfigured, and its launches
 // would then fail silently and fall through to the sequential scan.
-template <int C, int HD, int JC>
+template <int C, int HD, int JC, bool REGS = false>
 bool gdnc_scan_smem_ok(int dev) {
     constexpr int kMaxDevices = 16;
     static int cfg[kMaxDevices] = {0};                 // 0 unknown, 1 usable, 2 refused
     if (dev < 0 || dev >= kMaxDevices) return false;
     if (!cfg[dev]) {
-        constexpr size_t sm = gdnc_scan_smem<C, HD, JC>();
+        constexpr size_t sm = gdnc_scan_smem<C, HD, JC, REGS>();
         const cudaError_t ce = cudaFuncSetAttribute(
-            pf_gdnc_scan_kernel<C, HD, JC>,
+            pf_gdnc_scan_kernel<C, HD, JC, REGS>,
             cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm);
         if (ce != cudaSuccess) cudaGetLastError();
         cfg[dev] = (ce == cudaSuccess || sm <= 48u * 1024u) ? 1 : 2;
@@ -686,7 +749,20 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
     // JC_B is ~89 KB and only the wide shape; a device that refuses it just keeps JC_S.
     const int sms = gdnc_sm_count();
     const bool spills = sms > 0 && v_heads * (HD / JC_S) > sms;
-    const bool use_big = spills && n_tokens >= bigjc_minctx &&
+    // Register-resident S at JC_S. This is the shape to want when the narrow grid spills: it fits
+    // TWO blocks per SM, so every block is resident at once across EVERY SM, where JC_B avoids the
+    // second wave only by halving the grid and leaving 43% of the SMs idle. Falls back to JC_B and
+    // then to plain JC_S if the device refuses the opt-in.
+    // SPARKINFER_PREFILL_GDN_SCAN_REGS=0 disables (A/B in ONE binary).
+    static const bool regs_on = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_GDN_SCAN_REGS");
+        return !(e && e[0] == '0');
+    }();
+    constexpr size_t sm_regs = gdnc_scan_smem<C, HD, JC_S, true>();
+    const bool use_regs = regs_on && spills && n_tokens >= bigjc_minctx &&
+                          2 * sm_regs <= (size_t)102400 &&
+                          gdnc_scan_smem_ok<C, HD, JC_S, true>(dev);
+    const bool use_big = !use_regs && spills && n_tokens >= bigjc_minctx &&
                          gdnc_scan_smem_ok<C, HD, JC_B>(dev);
 
     auto db = reinterpret_cast<const __nv_bfloat16*>(dt);
@@ -724,7 +800,13 @@ bool launch_prefill_gdn_chunk(const void* q, const void* k, const void* v,
         pf_gdnc_prep_kernel<C, HD><<<gprep, PREP_THREADS, sm_prep, stream>>>(
             qb, kb, vb, ab, bb, db, aa, g_buf, w_buf, u_buf, m_buf,
             len, q_heads, v_heads, qh_block);
-        if (use_big) {
+        if (use_regs) {
+            pf_gdnc_scan_kernel<C, HD, JC_S, true>
+                <<<dim3(v_heads, HD / JC_S), (C * JC_S) / 4,
+                   gdnc_scan_smem<C, HD, JC_S, true>(), stream>>>(
+                    qb, kb, g_buf, w_buf, u_buf, m_buf, state, ob,
+                    len, q_heads, v_heads, n_chunks, qh_block, carry);
+        } else if (use_big) {
             pf_gdnc_scan_kernel<C, HD, JC_B>
                 <<<dim3(v_heads, HD / JC_B), (C * JC_B) / 4,
                    gdnc_scan_smem<C, HD, JC_B>(), stream>>>(

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -190,42 +190,86 @@ auto shape(int m, int n, int k) { return cute::make_shape(m, n, k, 1); }
 auto sfa_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFA(shape(m,n,k)); }
 auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SFB(shape(m,n,k)); }
 
-template <class Layout>
-__global__ void quant_rows(const __nv_bfloat16* src, unsigned char* dst,
-                           cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout) {
-    // V is fixed by the format: one ue4m3 scale per 16 values. The mapping of lanes onto those 16
-    // is not. One lane per value left half of every warp idle (lane < V), reduced 16 real values
-    // across 32 lanes, and stored 8 bytes per warp per step -- 63 GB/s, 3.5% of peak. Two values
-    // per lane puts 8 lanes on a group and 4 groups on a warp: every lane live, the amax reduction
-    // is 3 steps inside its own 8-lane group, and the warp's 4 groups store 32 contiguous bytes.
-    // Bit-identical: max is order-independent, and each value keeps the same scale and the same
-    // x / float(qs) rounding it had before.
+// V is fixed by the format: one ue4m3 scale per 16 values. The mapping of lanes onto those 16 is
+// not, and it is worth a lot. One lane per value left half of every warp idle (lane < V) and stored
+// 8 bytes per warp -- 63 GB/s, 3.5% of peak. Two values per lane (LPV=8) put every lane live and
+// took the warp's store to 32 contiguous bytes.
+//
+// EIGHT values per lane (LPV=2) is the shape below. Per lane that is one 16-byte load and one
+// 4-byte store, so a warp moves 512 B in and 128 B out in single transactions, against 128 B in /
+// 32 B out before -- and the amax reduction collapses from 3 shuffles to 1. The kernel is pure
+// bandwidth (2 B read and 0.5625 B written per element) and was measured at ~30% of peak, which is
+// what a 1-byte-per-lane store costs.
+//
+// Bit-identical at any LPV: max is order-independent, so the group's amax is the same however the
+// 16 values are split across lanes, and each value then keeps the same qs and the same
+// x / float(qs) rounding. LPV is a template parameter only so the two can be A/B'd in one binary.
+template <int LPV, class Layout>
+__global__ void quant_rows_t(const __nv_bfloat16* src, unsigned char* dst,
+                             cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout) {
     constexpr int V = 16;
-    constexpr int LPV = 8;            // lanes per scale group (2 values each)
+    constexpr int VPL = V / LPV;      // values per lane
     constexpr int GPW = 32 / LPV;     // scale groups per warp
     const int vpr = cols / V;
     const int gpb = (int)(blockDim.x >> 5) * GPW;
     const int lane = threadIdx.x & 31;
     const int warp = threadIdx.x >> 5;
     const int sub = lane & (LPV - 1);
-    const int gin = lane >> 3;
+    const int gin = lane / LPV;
     const int total = rows * vpr;
     for (int g = blockIdx.x * gpb + warp * GPW + gin; g < total; g += gridDim.x * gpb) {
         const int row = g / vpr, k0 = (g - row * vpr) * V;
-        const size_t base = (size_t)row * cols + k0 + sub * 2;
-        const __nv_bfloat162 v2 = *reinterpret_cast<const __nv_bfloat162*>(src + base);
-        const float x0 = __bfloat162float(v2.x), x1 = __bfloat162float(v2.y);
-        float a = fmaxf(fabsf(x0), fabsf(x1));
+        const size_t base = (size_t)row * cols + k0 + sub * VPL;
+        // VPL is 2, 4 or 8 values = 4, 8 or 16 B, and base is a multiple of VPL, so this is a
+        // single naturally-aligned vector load whenever cols is (5120 / 6144 / 17408 all are).
+        __nv_bfloat162 v2[VPL / 2];
+        #pragma unroll
+        for (int i = 0; i < VPL / 2; i++)
+            v2[i] = reinterpret_cast<const __nv_bfloat162*>(src + base)[i];
+        float x[VPL];
+        float a = 0.f;
+        #pragma unroll
+        for (int i = 0; i < VPL / 2; i++) {
+            x[2 * i]     = __bfloat162float(v2[i].x);
+            x[2 * i + 1] = __bfloat162float(v2[i].y);
+            a = fmaxf(a, fmaxf(fabsf(x[2 * i]), fabsf(x[2 * i + 1])));
+        }
         #pragma unroll
         for (int d = LPV >> 1; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, d));
         cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
-        cutlass::float_e2m1_t q0(x0 / float(qs));
-        cutlass::float_e2m1_t q1(x1 / float(qs));
-        dst[base >> 1] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        const float qsf = float(qs);
+        // One packed store per lane: VPL nibbles = VPL/2 bytes, and base is a multiple of VPL so
+        // base>>1 is a multiple of VPL/2 -- naturally aligned for the 2- or 4-byte case.
+        unsigned char packed[VPL / 2];
+        #pragma unroll
+        for (int i = 0; i < VPL / 2; i++) {
+            cutlass::float_e2m1_t q0(x[2 * i] / qsf), q1(x[2 * i + 1] / qsf);
+            packed[i] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        }
+        #pragma unroll
+        for (int i = 0; i < VPL / 2; i++) dst[(base >> 1) + i] = packed[i];
         if (sub == 0) {
             auto scales = cute::make_tensor(sf, layout);
             scales(row, k0, 0) = qs;
         }
+    }
+}
+// SPARKINFER_NVFP4_QUANT_LPV=8 restores the two-values-per-lane shape (A/B in ONE binary).
+inline int nvfp4_quant_lpv() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_NVFP4_QUANT_LPV");
+        const int x = e ? atoi(e) : 2;
+        return (x == 2 || x == 4 || x == 8) ? x : 2;
+    }();
+    return v;
+}
+template <class Layout>
+void quant_rows_dispatch(int blocks, cudaStream_t st, const __nv_bfloat16* src, unsigned char* dst,
+                         cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout) {
+    switch (nvfp4_quant_lpv()) {
+        case 8:  quant_rows_t<8><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout); break;
+        case 4:  quant_rows_t<4><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout); break;
+        default: quant_rows_t<2><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout); break;
     }
 }
 
@@ -413,8 +457,8 @@ bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k
     if (!s || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
     auto l = sfa_layout(m,128,k);
     int blocks = (m * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
-    quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
-                                     (cutlass::float_ue4m3_t*)sf,m,k,l);
+    quant_rows_dispatch(blocks,st,(const __nv_bfloat16*)s,(unsigned char*)d,
+                        (cutlass::float_ue4m3_t*)sf,m,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, void* sf,
@@ -440,8 +484,8 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
     if (!s || !d || !sf || !prefill_nvfp4_supported(128,n,k)) return false;
     auto l = sfb_layout(128,n,k);
     int blocks = (n * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
-    quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)s,(unsigned char*)d,
-                                     (cutlass::float_ue4m3_t*)sf,n,k,l);
+    quant_rows_dispatch(blocks,st,(const __nv_bfloat16*)s,(unsigned char*)d,
+                        (cutlass::float_ue4m3_t*)sf,n,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,


### PR DESCRIPTION
## Summary

Two changes at ctx=16384, both **bit-identical** — the `qwen3_gguf_score` dumps compare
byte-for-byte equal against the arm-off build, each one checked on its own.

**1. The NVFP4 activation quantizer mapped two values to a lane.** `quant_rows` did a 4-byte load
and a **one-byte store** per lane, so a whole warp stored 32 contiguous bytes; it was moving
~33.8 GB per pass in 62.8 ms, roughly **30% of this part's bandwidth**, while doing nothing but
copy. Eight values per lane makes that one 16-byte load and one 4-byte store, and the amax butterfly
collapses from 3 shuffles to 1.

The tell that this was the shape to want: its sibling `swiglu_quant_rows` **already had it**, and
its own comment records the same rewrite ("0.98 TB/s of a 1.79 TB/s part... issue-bound on narrow
accesses"). That is exactly why swiglu profiles near 55% of peak and this one did not. Bit-identical
because max is order-independent, so every group keeps the same scale and every value the same
`x / float(qs)` rounding. **+1.0%**

**2. The GDN scan kept its recurrent state in shared memory when it does not need to.** Every loop
that touches S already walks `e = tid; e < HD*JC; e += nthr`, so thread `tid` owns a fixed private
set of elements — `(m, jj) = (warp + t*NW, lane)` — with no communication between threads. S can
therefore live in registers. That frees `HD*JC*4` B and takes the block from **62,208 to 45,824 B,
under the 51,200 a SECOND resident block per SM needs**, so the whole grid is resident across every
SM instead of the half-width 96-block shape that was used to dodge a second wave.

The cost is that the S update can no longer write one tile per warp: each thread reads back the tile
covering its own elements, so all `(HD/16)x(JC/16)` accumulator tiles have to be live at once. At
JC=32 that is 16 KB and still fits the existing `s_W|s_Q` alias window; at JC=64 it would be 32 KB
and does not, so this is a JC=32 shape. Gated on the narrow grid actually spilling past the SM
count, which is why Qwen3.5/3.6 — 32 v-heads, 128 blocks, already one wave — never take it. **+0.9%**

**On (2), the arithmetic was optimistic and the measurement is what is reported.** Two resident
blocks per SM predicted ~+5%; it delivered +0.9%. The residency does appear — the restructuring
needed to reach it (one extra `__syncthreads`, and writing 16 tiles instead of reusing 8 slots)
spends most of the gain. Occupancy arithmetic is an upper bound, not an estimate.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 93.74 |
| after (this PR) | 93.75 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 12853.47 |
| after prefill (this PR) | **13182.85** |

**1.0256x prefill@16k.** Qwen3.8-27B ModelOpt NVFP4, ONE binary with both arms behind env knobs,
warm-up first then main/PR alternated x3 at 5 reps. Cross-*process* comparison on this box drifts
about 1%, which is half this result, so every number below is same-binary alternated — a reps=1 run
also reads ~5% high because the first pass gets a larger FFN chunk than reps 2-5.

```text
  warmup  {"128":{"decode_tps":94.2123,"prefill_pp":6935.4418},"16384":{"decode_tps":88.9242,"prefill_pp":12953.8207}}
  r1 main {"128":{"decode_tps":94.0005,"prefill_pp":6912.4896},"16384":{"decode_tps":88.6536,"prefill_pp":12893.3111}}
  r1 PR   {"128":{"decode_tps":93.8858,"prefill_pp":6887.8469},"16384":{"decode_tps":88.6422,"prefill_pp":13208.5705}}
  r2 main {"128":{"decode_tps":93.7368,"prefill_pp":6901.9602},"16384":{"decode_tps":88.4646,"prefill_pp":12853.4703}}
  r2 PR   {"128":{"decode_tps":93.6995,"prefill_pp":6889.8709},"16384":{"decode_tps":88.4863,"prefill_pp":13182.8451}}
  r3 main {"128":{"decode_tps":93.6306,"prefill_pp":6903.1443},"16384":{"decode_tps":88.4693,"prefill_pp":12845.2413}}
  r3 PR   {"128":{"decode_tps":93.7498,"prefill_pp":6907.1376},"16384":{"decode_tps":88.5337,"prefill_pp":13178.7579}}

medians   prefill@16k 12853.47 -> 13182.85 = 1.0256x
          prefill@128  6903.14 ->  6889.87 = 0.9981
          decode@128     93.74 ->    93.75 = 1.0001
          decode@16k     88.47 ->    88.53 = 1.0007
```

Per change, each A/B'd on its own in the same binary: quantizer lane width +1.0% (+0.82% / +1.19%),
register-resident S +0.9% (+0.60% / +1.13%).

## Correctness

Both changes are bit-identical by construction and were checked that way rather than argued:

| check | result |
|---|---|
| `qwen3_gguf_score` dump, quantizer arm on vs off | **byte-for-byte identical** (`cmp` clean) |
| `qwen3_gguf_score` dump, register-S arm on vs off | **byte-for-byte identical** (`cmp` clean) |
| batched-prefill parity (absolute, batched vs token loop) | `PARITY worst=1.000 bar=0.75 OK` |

For (1) max is order-independent, so a group's amax is the same however its 16 values are split
across lanes, and each value then keeps the same `qs` and the same division. For (2) only *where* S
lives changes — same values, same per-element order, same `gl * S + K^T U~`.

## No-regression

Both guards warm-up-first and alternated, same protocol:

| guard | main | this PR | |
|---|--:|--:|--:|
| Qwen3.6 prefill@4096 | 25519.20 | 25529.12 | 1.0004 |
| Qwen3.6 prefill@512 | 9974.26 | 9978.05 | 1.0004 |
| Qwen3.8 (unsloth) prefill@128 | 4117.57 | 4130.62 | 1.003 |
| Qwen3.8 (unsloth) decode@128 | 84.90 | 84.91 | 1.000 |

Qwen3.6 decode is flat at 0/512/4096 (495.16-496.08 / 488.98-489.79 / 470.08-470.18 main against
495.37-495.66 / 489.20-489.48 / 469.58-470.40).

## Scope

`SPARKINFER_NVFP4_QUANT_LPV=8` and `SPARKINFER_PREFILL_GDN_SCAN_REGS=0` each restore the previous
behaviour, so both arms A/B in one binary — which is how the per-change numbers above were taken.
The register-S path is additionally gated on `v_heads * HD/JC > sm_count`, so a model whose scan
grid already fits one wave never enters it.
