### PR TITLE
perf(dspark): propose 3 tokens below the deep threshold, not 5 (1.36x dspark-decode@128)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3087,8 +3087,29 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 0;
         return v < 0 ? 0 : (v > 15 ? 15 : v);
     }();
+    // Below the deep threshold the depth is 3, not 5. Two measurements decide it, both on the
+    // RTX 5090 against the released DSpark draft (block_size 7):
+    //
+    //   1. ACCEPTANCE SATURATES BELOW 4. At ctx=128 the mean accepted length is 1.2549 at depth 3
+    //      and *exactly* 1.2549 at 4, 5 and 6 -- proposals past the third are never accepted, so
+    //      every target row spent verifying them is spent for nothing. At ctx=4096 it is 1.113 at
+    //      depth 3 against 1.123 at depth 5, i.e. a hundredth of a token for two extra rows.
+    //
+    //   2. DEPTH 4 IS A CLIFF, NOT A SLOPE. The draft's active block width is
+    //      round_up(depth+1) over {4, 8, 16} capped at block_size, so depth 3 runs a 4-wide draft
+    //      block and depth 4 runs a 7-wide one. Crossing it costs a quarter of the throughput for
+    //      the zero extra accepts above:
+    //
+    //        ctx=128   depth 1/2/3 -> 64.89 / 65.00 / 66.13 tok/s   depth 4/5/6 -> 48.74 / 48.45 / 48.12
+    //        ctx=4096  depth 3 -> 29.88                             depth 5/7   -> 24.28 / 20.46
+    //        ctx=512   depth 3/5/7 -> 77.65 / 77.62 / 77.56         (accept 1.0: DSpark is inert here)
+    //
+    // So 3 is the largest depth that still fits the cheap block-width tier, and nothing below the
+    // deep threshold accepts deeply enough to pay for leaving it. The >= kDeepMinSeq branch keeps
+    // its 7: long context is where acceptance actually climbs (the ladder above this comment), and
+    // it is measured separately.
     const int kProposalDepth = kProposalDepthEnv > 0 ? kProposalDepthEnv
-                             : ((n + max_new) >= kDeepMinSeq ? 7 : 5);
+                             : ((n + max_new) >= kDeepMinSeq ? 7 : 3);
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN
     // accepted length, and it has no reason to sit at exactly B. Measured on RTX 5090 at the three


### PR DESCRIPTION
## Summary

Acceptance saturates below the fourth proposal, and the fourth proposal is exactly where the draft
block gets expensive. Together those mean the short-context depth was paying the higher price for
none of the benefit.

**Acceptance saturates below 4.** At ctx=128 the mean accepted length is **1.2549 at depth 3 and
exactly 1.2549 at 4, 5 and 6** — proposals past the third are never accepted, so every target row
spent verifying them is spent for nothing. At ctx=4096 it is 1.113 at depth 3 against 1.123 at
depth 5: a hundredth of a token for two more rows.

**Depth 4 is a cliff, not a slope.** The draft's active block width is `round_up(depth+1)` over
`{4, 8, 16}` capped at `block_size`, so depth 3 runs a **4-wide** draft block and depth 4 runs a
**7-wide** one. Crossing it costs a quarter of the throughput for the zero extra accepts above:

| ctx | depth 1 | 2 | 3 | 4 | 5 | 6 | 7 |
|---|--:|--:|--:|--:|--:|--:|--:|
| 128 | 64.89 | 65.00 | **66.13** | 48.74 | 48.45 | 48.12 | — |
| 512 | — | — | 77.65 | — | 77.62 | — | 77.56 |
| 4096 | — | — | **29.88** | — | 24.28 | — | 20.46 |

(ctx=512 accepts exactly 1.0 at every depth — DSpark is inert there, so depth cannot help or hurt.)

So **3 is the largest depth still inside the cheap block-width tier**, and no context below the deep
threshold accepts deeply enough to pay for leaving it. There is no measured short context where 5
beats 3, on throughput or on acceptance.

The `>= kDeepMinSeq` branch keeps its 7 untouched — long context is where acceptance actually
climbs, and it was measured separately by the ladder this change sits under.
`SPARKINFER_DFLASH_PROPOSALS` still pins any depth explicitly.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main), **dspark-decode@128** | 48.44 |
| after (this PR), **dspark-decode@128** | 66.13 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a — decode-only change |
| after prefill (this PR) | n/a |

```text
# runtime/examples/dspark_tau_check <ModelOpt dir> <DSpark draft dir> 128 <128 real prompt ids>
# -- the harness the eval uses, both legs in ONE process off one model load.
# RTX 5090 sm_120, main @ f1ef05b. ONE binary; MAIN arm pins the old depth via
# SPARKINFER_DFLASH_PROPOSALS=5, PR arm is the new default. Arm order rotated between rounds.

r1 MAIN(d5)   AR_TPS=88.9274 DSPARK_TPS=48.4943 MEAN_ACCEPT=1.2549 LOSSLESS=1
r1 PR(depth3) AR_TPS=88.9550 DSPARK_TPS=66.1385 MEAN_ACCEPT=1.2549 LOSSLESS=1
r2 PR(depth3) AR_TPS=88.9262 DSPARK_TPS=66.1287 MEAN_ACCEPT=1.2549 LOSSLESS=1
r2 MAIN(d5)   AR_TPS=88.8737 DSPARK_TPS=48.4384 MEAN_ACCEPT=1.2549 LOSSLESS=1
r3 MAIN(d5)   AR_TPS=88.8926 DSPARK_TPS=48.4362 MEAN_ACCEPT=1.2549 LOSSLESS=1
r3 PR(depth3) AR_TPS=88.8424 DSPARK_TPS=66.0144 MEAN_ACCEPT=1.2549 LOSSLESS=1

dspark-decode@128  48.44 -> 66.13 tok/s (+36.4% on medians). Ranges DISJOINT: main best 48.49 <
                   PR worst 66.01. Per-round +36.4 / +36.5 / +36.3%.
MEAN_ACCEPT        1.2549 -> 1.2549, unchanged. The win is entirely the verify rows and the draft
                   block width that stop being spent -- not a change in what the draft proposes.
LOSSLESS           1 in every run, both arms. Exact token equality against the AR reference.
ar-decode@128      88.87-88.96 across all six runs, both arms. The floor never enters this path;
                   depth only selects how many proposals the draft makes.

Full depth sweep behind the table above (same harness, same prompt):
  ctx=128   d1 64.89  d2 65.00  d3 66.13  d4 48.74  d5 48.45  d6 48.12   accept 1.196/1.243/1.2549/1.2549/1.2549/1.2549
  ctx=512   d3 77.65  d5 77.62  d7 77.56                                 accept 1.000 at every depth
  ctx=4096  d3 29.88  d5 24.28  d7 20.46                                 accept 1.113/1.123/1.4545
```
