### PR TITLE
perf(dspark): batch the draft LM head at K=5120 and gate the Markov head (1.20x dspark-decode@128)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -2609,7 +2609,14 @@ void launch_mmvq_q6k_f32(const void* q81, const void* W, float* y, int N, int K,
 // activation rows; y is [M, N] fp32. Returns false when the shape is unsupported (caller loops).
 bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream) {
-    if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
+    // NSUPER is K/256, the super-block count the kernel strides the weight by. It was
+    // instantiated for K=2048 alone, so every draft whose hidden size is not 2048 -- Qwen3.8-27B's
+    // DSpark draft is H=5120 -- silently declined here and fell back to the per-row LM-head loop
+    // in dflash_draft.cpp, which walks the whole 248k-row head once PER ROW. Same omission, and
+    // the same fix, as the K=5120/6144 instantiations launch_mmvq_q4k_rows already carries.
+    if (M < 1 || M > 16) return false;
+    const int nsuper = (K == 2048) ? 8 : (K == 5120) ? 20 : (K == 6144) ? 24 : 0;
+    if (!nsuper) return false;
     static const int cap = []{
         if (const char* e = getenv("SPARKINFER_DFLASH_HEAD_CTAS")) return atoi(e);
         int sm = 0, dev = 0;
@@ -2623,9 +2630,18 @@ bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
     dim3 grid(nblk);
     auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     auto* w = reinterpret_cast<const unsigned char*>(W);
-    if (M == 3) si_mmvq_q4k_multirow_kernel<float, 16, 8, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
-    else if (M == 6) si_mmvq_q4k_multirow_kernel<float, 16, 8, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
-    else si_mmvq_q4k_multirow_kernel<float, 16, 8, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M);
+    // MFIXED 3 and 6 keep the row loop fully unrolled at the two depths the draft actually uses;
+    // anything else runs the MMAX=16 form with a runtime bound.
+    #define SI_MR_BY_M(NS) \
+        do { \
+            if (M == 3)      si_mmvq_q4k_multirow_kernel<float, 16, NS, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
+            else if (M == 6) si_mmvq_q4k_multirow_kernel<float, 16, NS, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
+            else             si_mmvq_q4k_multirow_kernel<float, 16, NS, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
+        } while (0)
+    if (nsuper == 8)       SI_MR_BY_M(8);
+    else if (nsuper == 20) SI_MR_BY_M(20);
+    else                   SI_MR_BY_M(24);
+    #undef SI_MR_BY_M
     return true;
 }
 

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1302,7 +1302,39 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // prediction for position start+1 is redundant with the target's own verify-row-0 call, which
     // is strictly more reliable than any draft guess), so it only needs a plain argmax in the
     // !head_done path, where the batched LM-head GEMV computed it too and left it unscored.
-    if (s.markov_w1 && s.markov_w2) {
+    // MARKOV HEAD, PRICED. It raises acceptance and costs more than the acceptance is worth
+    // below long context, so it is gated on the same sequence-length threshold the proposal-depth
+    // ladder uses rather than run unconditionally.
+    //
+    // What it costs: w2 is [vocab, rank] = 248320 x 256 bf16 = 127 MB, re-read once per proposal
+    // row -- 381 MB a step at depth 3 -- because row r's latent conditions on row r-1's own
+    // corrected argmax. That chain also replaces ONE batched argmax over the whole block with a
+    // sequential bias -> confidence -> argmax triple per row. Measured, the pair is 1.41 ms of a
+    // 16.3 ms step, well past the ~419 us the bias GEMVs alone account for.
+    //
+    // What it buys, measured on RTX 5090 against the released draft (accept -> tok/s):
+    //     ctx=128    1.2549 -> 76.93     off: 1.1852 -> 79.53   (+3.4% without it)
+    //     ctx=4096   1.1130 -> 32.16     off: 1.0579 -> 33.04   (+2.7% without it)
+    //     ctx=512    1.0000 -> 77.61     off: 1.0000 -> 77.63   (accept 1.0: DSpark inert here)
+    // Acceptance does fall, and it still loses: the extra 0.07 tokens a step do not pay for the
+    // step getting 1.41 ms longer.
+    //
+    // Deep context keeps it: that is where acceptance actually climbs and where the ladder above
+    // already switches strategy, and it is not measured here. Draft-only either way -- this shifts
+    // what is proposed, never what is emitted, which is why LOSSLESS is unaffected.
+    // SPARKINFER_DFLASH_MARKOV=1/0 pins it explicitly.
+    static const int kMarkovDeepMinSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_DEEP_MIN_SEQ");
+        int v = e ? atoi(e) : 12288;
+        return v < 1 ? 1 : v;
+    }();
+    static const int markov_env = []{
+        const char* e = getenv("SPARKINFER_DFLASH_MARKOV");
+        return e ? (e[0] == '0' ? 0 : 1) : -1;
+    }();
+    const bool markov_on = markov_env >= 0 ? (markov_env != 0)
+                                           : (past + BW >= kMarkovDeepMinSeq);
+    if (markov_on && s.markov_w1 && s.markov_w2) {
         if (!head_done) kernels::launch_argmax(s.logits, s.d_out, 1, V, st);
         for (int r = 1; r <= kProposalDepth; r++) {
             const int* prev = (r == 1) ? s.d_ids : (s.d_out + (r - 1));


### PR DESCRIPTION
## Summary

`launch_gemv_q4k_dp4a_multirow_f32` guarded on `K != 2048` — the hidden size of the draft it was
first written for:

```c
if (K != 2048 || M < 1 || M > 16) return false;   // draft head shape (H=2048, B<=16)
```

Qwen3.8-27B's DSpark draft is **H=5120**, so that guard rejected it on every call.
`dflash_draft.cpp` saw `head_done == false` and fell back to the per-row LM-head loop underneath —
**one full pass over the 248320-row head per row of the block**, and that loop is bounded by
`block_size` (7), not by the rows the verifier actually consumes.

nsys at ctx=128 shows the cost plainly: `gemv_q_dp4a_kernel<float>` ran **714 times at 438 µs —
seven per step, 3.07 ms of a ~19 ms step** — to produce four rows of logits.

`NSUPER` is just `K/256`, the super-block stride the kernel walks the weight by
(`W + row * NSUPER * 144`, loop `p < NSUPER * 16`), so supporting 5120 and 6144 is an
**instantiation, not a new kernel**. This is the same omission — and the same fix — that
`launch_mmvq_q4k_rows` already carries for exactly these two widths; the draft's head was missed.

Batched, the head streams the 248320-row weight **once for the whole block** instead of once per
row. The draft computes the same logits; it just stops re-reading the weight.

**Second change: the Markov head now runs only where it pays.** It raises acceptance and costs more
than the acceptance is worth below long context.

*What it costs.* `w2` is `[vocab, rank]` = 248320 x 256 bf16 = **127 MB, re-read once per proposal
row** — 381 MB a step at depth 3 — because row *r*'s latent conditions on row *r-1*'s own corrected
argmax. That chain also replaces **one** batched argmax over the block with a sequential
`bias -> confidence -> argmax` triple per row. Measured, the pair costs **1.41 ms of a 16.3 ms
step**, well past the ~419 µs the bias GEMVs alone account for (nsys: `k_markov_bias_add` 139.7 µs x 3).

*What it buys* (accept -> tok/s, RTX 5090, released draft):

| ctx | Markov on | Markov off |
|---|---|---|
| 128 | 1.2549 -> 76.93 | 1.1852 -> **79.53** (+3.4%) |
| 4096 | 1.1130 -> 32.16 | 1.0579 -> **33.04** (+2.7%) |
| 512 | 1.0000 -> 77.61 | 1.0000 -> 77.63 (accept 1.0: DSpark inert) |

Acceptance genuinely falls — and it still loses: the extra ~0.07 tokens a step do not pay for the
step getting 1.41 ms longer. So it is gated on the same sequence-length threshold the proposal-depth
ladder already uses; **deep context keeps it**, since that is where acceptance climbs and it is not
measured here. `SPARKINFER_DFLASH_MARKOV=1/0` pins it either way.

Both changes are draft-only: they shift what the draft *proposes*, never what is *emitted*.
`LOSSLESS=1` in every run of every arm.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main), **dspark-decode@128** | 66.08 |
| after (this PR), **dspark-decode@128** | 79.51 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a — decode-only change |
| after prefill (this PR) | n/a |

```text
# runtime/examples/dspark_tau_check <ModelOpt dir> <DSpark draft dir> 128 <128 real prompt ids>
# -- the harness the eval uses, both legs in ONE process off one model load. RTX 5090 sm_120.
# ONE binary. BASE pins today's behaviour (SPARKINFER_DFLASH_HEAD_MULTIROW=0 -- the K guard made
# the batched head unreachable anyway -- plus SPARKINFER_DFLASH_MARKOV=1); PR is the new default.
# Arm order rotated between rounds.

r1 BASE AR_TPS=88.9167 DSPARK_TPS=66.1518 MEAN_ACCEPT=1.2549 LOSSLESS=1
r1 PR   AR_TPS=88.9747 DSPARK_TPS=79.5375 MEAN_ACCEPT=1.1852 LOSSLESS=1
r2 PR   AR_TPS=88.8858 DSPARK_TPS=79.5080 MEAN_ACCEPT=1.1852 LOSSLESS=1
r2 BASE AR_TPS=88.8879 DSPARK_TPS=66.0849 MEAN_ACCEPT=1.2549 LOSSLESS=1
r3 BASE AR_TPS=88.8399 DSPARK_TPS=66.0342 MEAN_ACCEPT=1.2549 LOSSLESS=1
r3 PR   AR_TPS=88.8344 DSPARK_TPS=79.4833 MEAN_ACCEPT=1.1852 LOSSLESS=1

dspark-decode@128  66.08 -> 79.51 tok/s (+20.3% on medians). Ranges DISJOINT: base best 66.15 <
                   PR worst 79.48. Per-round +20.2 / +20.3 / +20.4%.
LOSSLESS           1 in all six runs, both arms. Exact token equality against the AR reference in
                   the same process -- the draft changing what it proposes cannot change output.
MEAN_ACCEPT        1.2549 -> 1.1852. Reported as a REGRESSION in acceptance, deliberately: the
                   Markov head does raise it, and this still wins because the step gets shorter by
                   more than the lost accepts are worth. The split is measured in the table above.
ar-decode@128      88.83-88.97 across all six runs, both arms. Neither change touches the AR path.

Isolated contribution of each change at ctx=128 (same harness, rotated):
  batched head only   66.14 -> 76.89  (+16.3%)
  + Markov gate       76.89 -> 79.51  (+3.4%)
```
