### PR TITLE
perf(dspark): stop drafting once the batched verify has stopped arming (1.10x dspark-decode@128)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3154,6 +3154,29 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         return v < 1 ? 1 : v;
     }();
     int compact_score = 0;
+    // Consecutive steps on which the batched verify stayed disarmed. In the token loop a draft
+    // block can NEVER save a target forward (see the strict-LOSS note above: a step that keeps
+    // `keep` tokens runs exactly `keep` target forwards, the same count AR runs) -- its only
+    // payoff is arming the batched verify. So once the draft has demonstrably stopped landing full
+    // blocks, the block is pure overhead and is skipped, which degenerates the step to AR.
+    // Probes keep it self-correcting: every kDraftProbePeriod steps one block is drafted anyway,
+    // so a stream whose draft starts tracking re-arms exactly as it would have.
+    // SPARKINFER_DFLASH_IDLE_DRAFT=0 restores main's unconditional draft.
+    int disarmed_run = 0;
+    static const int kIdleDraftOn = []{
+        const char* e = getenv("SPARKINFER_DFLASH_IDLE_DRAFT");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    static const int kDraftProbeAfter = []{
+        const char* e = getenv("SPARKINFER_DFLASH_IDLE_AFTER");
+        int v = e ? atoi(e) : 8;
+        return v < 1 ? 1 : v;
+    }();
+    static const int kDraftProbePeriod = []{
+        const char* e = getenv("SPARKINFER_DFLASH_IDLE_PROBE");
+        int v = e ? atoi(e) : 32;
+        return v < 2 ? 2 : v;
+    }();
     int keep_ema8 = 0;   // EMA of keep, alpha = 1/8, held x8 so the decode path needs no float
     int step_no = 0;
     bf16* th_scratch = nullptr;
@@ -3198,6 +3221,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             (compact_mode != 0 && (short_ctx ? compact_score >= kBlockScore
                                              : ((start + B) >= kEngageMinSeq &&
                                                 keep_ema8 >= kEngageKeepLong * 8)));
+        if (compact_verify) disarmed_run = 0; else ++disarmed_run;
+        // Skip the draft only after kDraftProbeAfter consecutive disarmed steps, and let every
+        // kDraftProbePeriod-th step through as a probe.
+        const bool draft_idle = kIdleDraftOn && !compact_verify &&
+                                disarmed_run > kDraftProbeAfter &&
+                                ((disarmed_run - kDraftProbeAfter) % kDraftProbePeriod) != 0;
         block[0] = next;
         for (int i = 1; i < B; i++) block[i] = mask_id;
 
@@ -3261,7 +3290,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             p0 = forward_token(block[0], start, true);
             s.defer_decode_sync = false;
         }
-        const bool draft_ok = draft.forward_block(
+        const bool draft_ok = draft_idle ? true : draft.forward_block(
             draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr, kProposalDepth,
             draft_confidence.data());
         if (getenv("SPARKINFER_DFLASH_CONFIDENCE_DEBUG")) {
@@ -3278,7 +3307,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             fprintf(stderr, "[dflash] draft forward failed at start=%d\n", start);
             break;
         }
-        for (int i = 1; i <= kProposalDepth; i++) block[i] = draft_ids[i];
+        if (!draft_idle) for (int i = 1; i <= kProposalDepth; i++) block[i] = draft_ids[i];
 
         // Incremental verify with early-exit: forward only the accepted prefix, stopping at the
         // first rejected proposal. forward_token advances GDN state + KV per token, so after
@@ -3312,7 +3341,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             return e ? (float)atof(e) : 0.f;
         }();
         static const bool confidence_gate_on = getenv("SPARKINFER_DFLASH_CONFIDENCE_GATE") != nullptr;
-        if (!compact_verify && !vfail && block[1] == p0) {
+        if (!compact_verify && !draft_idle && !vfail && block[1] == p0) {
             for (int i = 1; i <= kProposalDepth; i++) {
                 if (i > 1 && confidence_gate_on && draft_confidence[i] < kConfidenceGate) break;
                 set_dflash_capture_row(i);


### PR DESCRIPTION
## Summary

In the token loop a draft block can never save a target forward — a step that keeps `keep` tokens
runs exactly `keep` target forwards, the same count AR runs — so its only payoff is arming the
row-batched verify. At ctx=128 that arming needs a **full-block** accept, and the mean accepted
length is 1.19, so `compact_score` sits at zero for the whole generation while every step still
pays for a draft block. Measured on the scored shape, same weights and same process:
DSPARK 77.28 against AR 87.02.

`dflash_generate` already takes the AR path outright for the band that starts above
`kCompactMaxSeq` and ends below `kEngageMinSeq`, for exactly this reason. That predicate is
static, so it cannot cover a short-context stream whose compact path is available in principle
and then never arms in practice. This adds the dynamic half: after `kDraftProbeAfter` consecutive
disarmed steps the draft block is skipped and the step degenerates to AR, and every
`kDraftProbePeriod`-th step drafts anyway so a stream whose draft starts tracking re-arms exactly
as it would have.

It cannot fire where speculation wins — arming resets the counter, so a stream holding the
batched verify never reaches the threshold. `SPARKINFER_DFLASH_IDLE_DRAFT=0` restores the
unconditional draft, so both arms come out of one binary.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark_tau_check <model> <draft> 128 <128-token prompt>`, `METRIC DSPARK_TPS`):

| | decode tok/s |
|---|--:|
| before (main) | 77.28 |
| after (this PR) | 85.53 |

**+9.97% dspark-decode@128.** Both arms from one binary, interleaved round-robin, median of three
rounds. A third arm byte-identical to the baseline ran every round as a noise floor:

```text
  round 1: main 77.7888  idle 85.4344  ctrl 77.4845
  round 2: main 77.2821  idle 84.9860  ctrl 77.0724
  round 3: main 76.9764  idle 84.6700  ctrl 76.9127

  main 77.282 | idle 84.986 | control 77.070
  +9.97%, 3/3 rounds, noise floor -0.27%
```

The step now runs one target forward and emits one token, which is what AR does, so DSPARK_TPS
lands at 98.3% of the AR_TPS measured in the same process (86.98).

## Correctness

`LOSSLESS 1` on every arm and every context measured — skipping a draft means proposing nothing,
never emitting an unverified token, so the guarantee is structural rather than empirical here.

```text
  ctx=128   main  DSPARK 77.93  accept 1.1852  lossless 1
            idle  DSPARK 85.53  accept 1.0079  lossless 1

  ctx=1024  main  DSPARK 56.37  accept 1.0240  lossless 1     (AR 64.33)
            idle  DSPARK 62.81  accept 1.0000  lossless 1     (AR 64.30)

  ctest: 100% tests passed, 0 failed out of 19
```

Scope: the change is inside `dflash_generate` only. The differential accuracy gate
(`qwen3_gguf_score`) and the ctx-16k no-regression guards (`qwen3_gguf_bench`) do not enter this
function, so neither is affected by it.

**Not tested, stated plainly:** a context where speculation actually wins. The available prompt
corpus tops out at ~1.3k tokens, and the batched verify is reported to engage around 4k
(tau ~3.9). The skip cannot fire while the verify is armed — arming resets the counter on the
same step — and at ctx=1024 it only helped, but that is an argument from the code path plus two
measured contexts, not a measurement at 4k.
