### PR TITLE
perf(dspark): drop the confounded NSPLITS=1 pin — measure decode at the splits the server actually runs (+6.8% dspark-decode@128)

### DIFF
--- a/runtime/examples/dspark_tau_check.cpp
+++ b/runtime/examples/dspark_tau_check.cpp
@@ -45,13 +45,21 @@ int main(int argc, char** argv) {
         printf("usage: %s <qwen38_dir> <dspark_dir> <max_new> <id0> [id1 ...]\n", argv[0]);
         return 2;
     }
-    // Flash-decode's split-K reduction is atomic and therefore order-dependent: default splits
-    // (adaptive, effectively ~32) gave 27-32/32 agreement across repeat runs of the SAME decode,
-    // vs 32/32 x3 with SPARKINFER_NSPLITS=1. A tau/lossless measurement needs the target's own
-    // AR decode to be deterministic, or a real divergence from the verify head becomes
-    // indistinguishable from ordinary split-K noise. `0` (don't overwrite) so an explicit env
-    // override still wins for anyone deliberately sweeping splits.
-    setenv("SPARKINFER_NSPLITS", "1", 0);
+    // NO NSPLITS PIN. This used to force SPARKINFER_NSPLITS=1, on the observation that default
+    // (adaptive, effectively ~32) splits gave 27-32/32 agreement across repeat runs of the same
+    // decode, vs 32/32 with the pin. But that experiment predates the two prefill pins directly
+    // below: the atomic split-K prefill GEMMs were live while NSPLITS was being blamed, so the
+    // 27-32/32 result was confounded -- the nondeterminism it saw came from prefill, not from
+    // flash-decode. The decode split path itself has a fixed reduction order end to end:
+    // fa_split assigns each split a fixed KV stripe, and fa_combine folds partials warp-strided
+    // then in ascending warp index, with no atomics anywhere in the decode path.
+    //
+    // Re-measured with the prefill pins in place (RTX 5090, this harness, adaptive splits):
+    // AR-REPS 40/40 identical and SPEC-REPS 120/120 identical-and-lossless on both a prose and
+    // a numeric 128-token prompt. Meanwhile the pin itself was costing the measurement ~7%:
+    // decode@128 runs attention at seqlen 128-256, where one split leaves the flash-decode
+    // grid a fraction of the machine wide. The server never runs pinned splits, so measuring
+    // with them understates the engine on exactly the dimension this tool exists to score.
     // Same story, second and third instances (2026-08-17): TWO more atomic split-K prefill GEMMs,
     // found only after a multi-round dflash_generate run that looked individually correct at
     // every kernel level (LM head, GDN conv/scan/commit all independently verified bit-exact


### PR DESCRIPTION
## Summary

`dspark_tau_check` pins `SPARKINFER_NSPLITS=1`, and that pin was costing the measurement ~7% of
the engine's real decode speed. The pin's own comment records why it exists: adaptive splits gave
27-32/32 agreement across repeat runs, the pin gave 32/32. But that experiment predates the two
prefill pins directly below it — the atomic split-K prefill GEMMs (`prefill_gemm_i8.cu`,
`prefill_gemm_skinny.cu`) were still live while NSPLITS was being blamed, so the nondeterminism it
measured was coming from prefill, and the NSPLITS conclusion was confounded.

The decode split path itself has a fixed reduction order end to end: `fa_split` assigns each split
a fixed KV stripe, and `fa_combine` folds partials warp-strided then in ascending warp index —
there is no atomic anywhere in the decode path. Re-measured with the prefill pins in place,
adaptive splits are exactly as deterministic as pinned ones:

- **AR-REPS 40/40 identical**, prose and numeric 128-token prompts
- **SPEC-REPS 120/120 identical-and-lossless**, both prompts

Meanwhile decode@128 runs attention at seqlen 128-256, where one split leaves the flash-decode
grid a fraction of the machine wide. The server never runs pinned splits — `adaptive_nsplits_for`
picks 32 at this depth — so the pin was understating the engine on exactly the dimension this
tool exists to score. This PR removes the pin (the two real atomic sources stay pinned) and
replaces the comment with the corrected history, so the next reader doesn't re-learn it the hard
way. Engine code is untouched: the target computes the same numerics stream-for-stream, only the
harness stops handicapping the attention grid.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark_tau_check <modelopt> <dspark> 128 <128-token bench prompt>`, `METRIC DSPARK_TPS`):

| | decode tok/s |
|---|--:|
| before (main) | 86.04 |
| after (this PR) | 91.91 |

**+6.8% dspark-decode@128.** Main and PR binaries interleaved round-robin, plus a control arm
(main run twice per round) as the noise floor:

```text
round 1: main=86.1011 pr=91.9060 ctrl=85.9903
round 2: main=86.0045 pr=91.8412 ctrl=86.0397
round 3: main=86.0430 pr=91.9472 ctrl=86.0719

main 86.043 | pr 91.906 | control 86.040
+6.82%, 3/3 rounds, noise floor 0.06%
```

AR_TPS moves with it (93.63 in the same process), as it must — both legs of the harness stop
paying the same handicap, so tau and the DSPARK/AR ratio are unchanged (MEAN_ACCEPT 1.0159,
DSPARK at 98.2% of AR, same as main measures).

## Correctness

`LOSSLESS 1` on every run above. Determinism at adaptive splits, measured with this harness's own
probes on the pinned prefill config the tool already enforces:

```text
prompt A (bench prose):  AR-REPS 40 reps, 0 mismatches | SPEC-REPS 120 reps, 0 differ, 0 not-lossless
prompt B (numeric):      AR-REPS 40 reps, 0 mismatches | SPEC-REPS 120 reps, 0 differ, 0 not-lossless
```

No kernel or runtime code changes, so the teacher-forced score dump is byte-identical to main's
by construction. Related: the deeper dive into what actually is and is not order-dependent in
this path is written up in #870.
