### PR TITLE
fix(dspark_tau_check): remove the confounded NSPLITS=1 pin — measurement fidelity, no speedup claimed (resubmit of #871 as requested)

### DIFF
--- a/runtime/examples/dspark_tau_check.cpp
+++ b/runtime/examples/dspark_tau_check.cpp
@@ -45,13 +45,25 @@ int main(int argc, char** argv) {
         printf("usage: %s <qwen38_dir> <dspark_dir> <max_new> <id0> [id1 ...]\n", argv[0]);
         return 2;
     }
-    // Flash-decode's split-K reduction is atomic and therefore order-dependent: default splits
-    // (adaptive, effectively ~32) gave 27-32/32 agreement across repeat runs of the SAME decode,
-    // vs 32/32 x3 with SPARKINFER_NSPLITS=1. A tau/lossless measurement needs the target's own
-    // AR decode to be deterministic, or a real divergence from the verify head becomes
-    // indistinguishable from ordinary split-K noise. `0` (don't overwrite) so an explicit env
-    // override still wins for anyone deliberately sweeping splits.
-    setenv("SPARKINFER_NSPLITS", "1", 0);
+    // NO NSPLITS PIN (measurement-fidelity fix; see PR discussion on the first attempt and the
+    // maintainer's independent finding of the same contradiction). This used to force
+    // SPARKINFER_NSPLITS=1, on the observation that default (adaptive) splits gave 27-32/32
+    // agreement across repeat runs of the same decode, vs 32/32 with the pin. That experiment
+    // predates the two prefill pins directly below: the atomic split-K prefill GEMMs were live
+    // while NSPLITS was being blamed, so the 27-32/32 result was confounded -- the
+    // nondeterminism came from prefill, not from flash-decode. Consistent with that,
+    // Qwen35Model's own constructor documents the split count as occupancy tuning with
+    // identical math for any value: fa_split assigns each split a fixed KV stripe and
+    // fa_combine folds partials warp-strided then in ascending warp index, with no atomics
+    // anywhere in the decode path.
+    //
+    // Determinism re-verified on THIS tree at the scored context (RTX 5090, ctx=4096 prompt from
+    // bench_prompt_4k.txt, adaptive splits, prefill pins in place): AR-REPS and SPEC-REPS
+    // identical-and-lossless on every repeat, two prompts -- numbers in the PR that made this
+    // change. The pin therefore bought no determinism, while measuring attention at one split
+    // ran the tool's decode legs in a configuration the server never uses; both legs shift
+    // together and tau/lossless are unaffected, so nothing this tool reports gets easier --
+    // the instrument just stops disagreeing with the engine's own configuration.
     // Same story, second and third instances (2026-08-17): TWO more atomic split-K prefill GEMMs,
     // found only after a multi-round dflash_generate run that looked individually correct at
     // every kernel level (LM head, GDN conv/scan/commit all independently verified bit-exact


### PR DESCRIPTION
## Summary

Resubmit of #871 in the form requested there: **a measurement-fidelity fix, explicitly not a
speedup claim.** No `eval:*` tier is sought; the engine is untouched and no served request gets
faster. The change removes `dspark_tau_check`'s `SPARKINFER_NSPLITS=1` pin so the tool's AR and
DSpark legs run attention at the split count the engine itself selects, and replaces the pin's
comment with the corrected history so the confound is recorded where it happened.

Why the pin is wrong, briefly: its justification (27-32/32 agreement at adaptive splits) was
measured while the two atomic split-K prefill GEMMs were still live — the nondeterminism it saw
came from prefill, later root-caused and pinned separately. The decode split path has a fixed
reduction order end to end (`fa_split` owns fixed KV stripes; `fa_combine` folds warp-strided then
in ascending warp index; no atomics), consistent with `Qwen35Model`'s own "occupancy tuning only"
note — the contradiction you said you hit independently. Both of the tool's legs shift together
under the fix, so tau, the DSPARK/AR ratio, and losslessness verdicts are unaffected; the
instrument just stops disagreeing with the engine's configuration.

## Determinism evidence, rerun on THIS tree at the scored context

As requested: current main (post #867/#868/#869 — depth ladder, Markov gate, idle draft), ctx=4096
prompt built exactly as the bot builds it (`bench_prompt_4k.txt`, 4096 real tokens), adaptive
splits, prefill pins in place, RTX 5090:

```text
prompt A (bench_prompt_4k): AR-REPS 20 reps, 0 mismatches
                            SPEC-REPS 40 reps, 0 differ-from-first, 0 not-lossless-vs-AR
                            MEAN_ACCEPT 1.0756  LOSSLESS 1  LOSSLESS_RUNS 40
prompt B (eval_corpus-derived, 4096 tokens): SPEC-REPS 24 reps, 0 differ-from-first, 0 not-lossless-vs-AR
```

Every repeat re-runs the full generation including the token-loop prompt prefill, so these
cover the exact system the bot now measures.

## Proof of speedup

Not applicable, and deliberately not claimed — this PR must not tier. It changes
`runtime/examples/dspark_tau_check.cpp` only. Per #871's close, a delta the bot measures for this
diff is the instrument moving, not decode; if the bot runs it, the honest label is the one that
reflects that.

- [x] Tested on **RTX 5090** (`sm_120`) — all evidence above from a real 5090.
