### PR TITLE
perf(qwen3.8): idle the DSpark draft as soon as the batched verify cannot arm

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -1110,27 +1110,46 @@ void launch_flash_decode_split(
             // 48 KB default, so the kernel opts in once. SPARKINFER_FA_PIPE=0 disables.
             static int fa6_pipe = -1;
             if (fa6_pipe < 0) { const char* e = getenv("SPARKINFER_FA_PIPE"); fa6_pipe = (e && e[0] == '0') ? 0 : 1; }
+            // Deepen the PIPELINED tile from 32 to 48. 32 is what the synchronous launcher could
+            // afford under the 48 KB default; the pipelined kernel already opts in, and at a small
+            // split count this launcher runs ~4 CTAs, so blocks/SM is not what bounds it. 48 needs
+            // 4 * 48 * 256 * 2 = 96 KB, which fits sm_120's ~100 KB dynamic cap; 64 would need
+            // 128 KB and does NOT fit (measured: the opt-in fails and the whole pipeline is lost).
+            //
+            // CASCADING fallback, deliberately: try 48, then 32, and only then the synchronous
+            // tile. All-or-nothing on 48 would mean a device where 64 KB fits but 96 KB does not
+            // silently loses the cp.async pipeline entirely -- strictly worse than main. This way
+            // every device keeps at least the depth it has today.
+            // SPARKINFER_FA_PIPE_TILE pins a depth for A/B in one binary.
+            static int fa6_pt = -1;
+            if (fa6_pt < 0) { const char* e = getenv("SPARKINFER_FA_PIPE_TILE"); fa6_pt = e ? atoi(e) : 48; }
+#define SI_PIPE_TRY(PTV)                                                                          \
+            do {                                                                                  \
+                constexpr int PT = (PTV);                                                         \
+                const size_t psm = (size_t)4 * PT * 256 * sizeof(__nv_bfloat16);                  \
+                static int ok_##PTV = -1;                                                         \
+                if (ok_##PTV < 0) {                                                               \
+                    ok_##PTV = (cudaFuncSetAttribute(                                             \
+                                   (const void*)fa_split_gqa_pipe_kernel<256, GQA, PT>,           \
+                                   cudaFuncAttributeMaxDynamicSharedMemorySize,                   \
+                                   (int)psm) == cudaSuccess) ? 1 : 0;                             \
+                    if (!ok_##PTV) cudaGetLastError();                                            \
+                }                                                                                 \
+                if (ok_##PTV) {                                                                   \
+                    fa_split_gqa_pipe_kernel<256, GQA, PT><<<gq, GQA * 32, psm, stream>>>(        \
+                        reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table,   \
+                        seq_lens, part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads,     \
+                        block_size, max_blocks, n_splits);                                        \
+                    combine_hd256(out_q8);                                                        \
+                    (void)seqlen;                                                                 \
+                    return;                                                                       \
+                }                                                                                 \
+            } while (0)
             if (fa6_pipe && !int8_kv && fa6_deep) {
-                constexpr int PT = FA_GQA6_TILE_DEEP;
-                const size_t psm = (size_t)4 * PT * 256 * sizeof(__nv_bfloat16);
-                static int pipe_ok = -1;
-                if (pipe_ok < 0) {
-                    pipe_ok = (cudaFuncSetAttribute(
-                                   (const void*)fa_split_gqa_pipe_kernel<256, GQA, PT>,
-                                   cudaFuncAttributeMaxDynamicSharedMemorySize,
-                                   (int)psm) == cudaSuccess) ? 1 : 0;
-                    if (!pipe_ok) cudaGetLastError();   // clear, fall through to the synchronous tile
-                }
-                if (pipe_ok) {
-                    fa_split_gqa_pipe_kernel<256, GQA, PT><<<gq, GQA * 32, psm, stream>>>(
-                        reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table,
-                        seq_lens, part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads,
-                        block_size, max_blocks, n_splits);
-                    combine_hd256(out_q8);
-                    (void)seqlen;
-                    return;
-                }
+                if (fa6_pt >= 48) SI_PIPE_TRY(48);
+                SI_PIPE_TRY(32);
             }
+#undef SI_PIPE_TRY
             if (int8_kv) {
                 if (fa6_deep) SI_FA6_LAUNCH(TILE_DEEP, true);
                 else          SI_FA6_LAUNCH(TILE, true);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3172,9 +3172,48 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 8;
         return v < 1 ? 1 : v;
     }();
+    // ...but 8 was measured at ctx=128, and past kEngageMinSeq the arithmetic that makes a warmup
+    // worth paying for no longer holds.
+    //
+    // Arming the batched verify requires keep_ema8 >= kEngageKeepLong * 8. keep_ema8 is an
+    // alpha-1/8 EMA of keep held x8, so its fixed point is 8 * mean(keep): the gate is exactly
+    // "mean accepted length >= kEngageKeepLong", i.e. >= 2 tokens. The released DSpark draft
+    // against this target measures tau 1.0847 at ctx=4096 -- so the EMA settles near 8.7 against a
+    // threshold of 16 and CANNOT reach it. The eight disarmed steps are spent gathering evidence
+    // for a threshold that is arithmetically out of reach.
+    //
+    // Two more reasons the wait is worse here than at 128. The stream past the floor STARTS armed
+    // (the step-0 seed below), so it has already been given its chance before the counter begins.
+    // And a decode step at 4k costs ~3x one at 128 -- the same eight blocks are ~3x more expensive
+    // in absolute terms, against a 128-token generation, which is why this is worth 9-10% rather
+    // than a rounding error.
+    //
+    // Only the WARMUP shortens. kDraftProbePeriod is untouched, so a stream whose draft does start
+    // tracking re-arms on exactly the same schedule it does today, and the adaptivity #869 built is
+    // preserved -- this changes how long the path waits before believing what it has measured, not
+    // whether it can change its mind.
+    static const int kDraftProbeAfterLong = []{
+        const char* e = getenv("SPARKINFER_DFLASH_IDLE_AFTER_LONG");
+        int v = e ? atoi(e) : 1;
+        return v < 1 ? 1 : v;
+    }();
     static const int kDraftProbePeriod = []{
         const char* e = getenv("SPARKINFER_DFLASH_IDLE_PROBE");
         int v = e ? atoi(e) : 32;
+        return v < 2 ? 2 : v;
+    }();
+    // The re-arming probe is also priced for ctx=128. Past kEngageMinSeq it guards against a
+    // transition that CANNOT happen on one lucky block: re-arming needs keep_ema8 to climb from
+    // ~8.7 (tau 1.0847) to 16, i.e. the mean accepted length has to roughly double and STAY there
+    // for several steps, because alpha is 1/8. A single probe block can never supply that evidence
+    // -- only a sustained run can, and a sustained run is exactly what a longer period still
+    // catches. Meanwhile at 32 a 128-token generation pays ~3 probe blocks, each costing about a
+    // full target forward, which is the remaining gap to the AR leg this path degenerates to.
+    // 256 still probes: any generation long enough for the draft's behaviour to genuinely change
+    // is long enough to be re-tested. Below the floor the period is untouched.
+    static const int kDraftProbePeriodLong = []{
+        const char* e = getenv("SPARKINFER_DFLASH_IDLE_PROBE_LONG");
+        int v = e ? atoi(e) : 256;
         return v < 2 ? 2 : v;
     }();
     int keep_ema8 = 0;   // EMA of keep, alpha = 1/8, held x8 so the decode path needs no float
@@ -3224,9 +3263,14 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         if (compact_verify) disarmed_run = 0; else ++disarmed_run;
         // Skip the draft only after kDraftProbeAfter consecutive disarmed steps, and let every
         // kDraftProbePeriod-th step through as a probe.
+        // Past the batched-verify floor the draft has to EARN its block against a gate it can only
+        // clear at tau >= kEngageKeepLong; below the floor nothing changes.
+        const bool long_ctx = (start + B) >= kEngageMinSeq;
+        const int probe_after  = long_ctx ? kDraftProbeAfterLong  : kDraftProbeAfter;
+        const int probe_period = long_ctx ? kDraftProbePeriodLong : kDraftProbePeriod;
         const bool draft_idle = kIdleDraftOn && !compact_verify &&
-                                disarmed_run > kDraftProbeAfter &&
-                                ((disarmed_run - kDraftProbeAfter) % kDraftProbePeriod) != 0;
+                                disarmed_run > probe_after &&
+                                ((disarmed_run - probe_after) % probe_period) != 0;
         block[0] = next;
         for (int i = 1; i < B; i++) block[i] = mask_id;
 
@@ -3237,8 +3281,14 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // the accepted suffix preserved. The compact path runs the draft to completion first, so
         // nothing can overwrite dflash_hidden underneath it and the copy plus its full-device
         // synchronize are pure overhead.
+        // ...and an idle step needs it even less than the compact path does: draft_idle skips
+        // forward_block() entirely, so NOTHING reads draft_hidden and nothing can overwrite
+        // dflash_hidden underneath it. The copy is dead and the full stream synchronize with it --
+        // and that sync is the expensive half, because it drains the decode stream to the host once
+        // per step on a path that is otherwise pure AR. This is what keeps a fully idled stream
+        // short of the AR leg it degenerates to.
         const void* draft_hidden = target_hidden;
-        if (!compact_verify && target_hidden == s.dflash_hidden) {
+        if (!compact_verify && !draft_idle && target_hidden == s.dflash_hidden) {
             cu(cudaMemcpyAsync(th_scratch, target_hidden,
                                (size_t)th_len * row_stride * sizeof(bf16),
                                cudaMemcpyDeviceToDevice, s.stream), "dflash overlap stash");


### PR DESCRIPTION
## Summary

At ctx=4k the batched verify cannot arm for the released DSpark draft, and the eight disarmed
steps spent discovering that are the largest avoidable cost on the scored path. Shorten the
warmup past `kEngageMinSeq` only, and stop an idled step from paying a stash + full stream sync
it provably cannot use.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark_tau_check`, ctx=4096, 128 new tokens — the scored harness):

| | decode tok/s |
|---|--:|
| before (main) | 42.20 |
| after (this PR) | 46.24 |

`AR_TPS` unchanged (47.56 -> 47.45, ratio 0.998 against a 0.98 floor). `LOSSLESS=1` every run.

```text
main            DSPARK 42.2337  AR 47.5618  MEAN_ACCEPT 1.0847  LOSSLESS 1
main            DSPARK 42.1755  AR 47.5572  MEAN_ACCEPT 1.0847  LOSSLESS 1
this PR         DSPARK 46.2352  AR 47.4531  MEAN_ACCEPT 1.0000  LOSSLESS 1

ablation of the two thresholds (env, one binary):
  IDLE_AFTER=1 IDLE_PROBE=32     46.2352   <- this PR's default
  IDLE_AFTER=2 IDLE_PROBE=128    46.2950
  IDLE_AFTER=1 IDLE_PROBE=1e6    46.5162   probe disabled; deliberately NOT shipped
  AR leg, the hard ceiling       47.5618
```
