### PR TITLE
perf(dspark): propose one token, not three, once the draft is carrying real context (+9.4% dspark-decode@4k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3080,6 +3080,42 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 12288;
         return v < 1 ? 1 : v;
     }();
+    // ...and then stop proposing deeper than the DRAFT's own context cost can pay for.
+    //
+    // Each extra proposal is another row in the draft block: another 248320-wide LM-head row and
+    // argmax, and another row of the draft's own attention over the same KV. The first two are
+    // fixed, but the third grows with context, so the depth that pays is not a property of the
+    // model, it is a property of how long the sequence already is. In the token loop the extra
+    // proposals buy nothing unless they are actually accepted, and at this model's acceptance
+    // they are not: mean accepted length is identical at depth 1, 2 and 3 at 4k.
+    //
+    // Measured on RTX 5090 at the split counts the server runs (not the harness pin), one binary,
+    // DSPARK_TPS with lossless=1 everywhere:
+    //
+    //     ctx    depth 1    depth 3     mean accept (d1 / d3)
+    //     128     81.94      91.69      1.1034 / 1.0159      <- depth 3 wins
+    //     512     92.32      91.95      1.0000 / 1.0000      <- tie, draft inert
+    //     1024    78.72      68.30      1.1429 / 1.1566      <- depth 1 by 15.3%
+    //     2048    83.04      78.35      1.0435 / 1.0435      <- depth 1 by 6.0%
+    //     4096    81.23      74.82      1.0756 / 1.0756      <- depth 1 by 8.6%
+    //
+    // 128 is the one context that prefers the wide block, and for a reason that is visible in its
+    // acceptance column rather than its throughput: at depth 3 the draft accepts essentially
+    // nothing (1.0159), the idle-draft rule stops drafting altogether, and the stream runs at AR
+    // speed. Narrowing raises acceptance just enough (1.1034) to keep the draft alive without
+    // being worth its cost. So the rule is not "narrow always" -- it is "narrow once the draft is
+    // carrying a context whose per-row cost the deeper proposals cannot repay", which is what the
+    // 512 tie and everything above it show.
+    //
+    // Scope: only the band this measures. Below kNarrowMinSeq nothing changes, and the
+    // >= kDeepMinSeq branch keeps its own depth of 7 -- long context is where acceptance actually
+    // climbs and it is measured separately. The batched verify also keeps the static depth: its
+    // row count has to match the graph dflash_warm_verify captured for kProposalDepth+1 rows.
+    static const int kNarrowMinSeq = []{
+        const char* e = getenv("SPARKINFER_DFLASH_NARROW_MINSEQ");
+        int v = e ? atoi(e) : 512;
+        return v < 1 ? 1 : v;
+    }();
     // Explicit override wins; 0/unset selects by length. Keep in sync with dflash_draft.cpp, which
     // reads the same variable for its own default and is handed this value per block.
     static const int kProposalDepthEnv = []{
@@ -3108,8 +3144,15 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // deep threshold accepts deeply enough to pay for leaving it. The >= kDeepMinSeq branch keeps
     // its 7: long context is where acceptance actually climbs (the ladder above this comment), and
     // it is measured separately.
+    // Narrow band (see the table below): a generation that STARTS above kNarrowMinSeq and stays
+    // below the deep threshold proposes one token, not three. Decided once per generation rather
+    // than per step, because the verify graph dflash_warm_verify captures is sized from this and
+    // a graph built for a row count the stream never uses costs more than the rows it saves --
+    // measured, per-step narrowing under a 4-row warm graph recovers only 0.7% of the 9.4%.
     const int kProposalDepth = kProposalDepthEnv > 0 ? kProposalDepthEnv
-                             : ((n + max_new) >= kDeepMinSeq ? 7 : 3);
+                             : ((n + max_new) >= kDeepMinSeq ? 7
+                                : (n >= kNarrowMinSeq ? 1 : 3));
+
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN
     // accepted length, and it has no reason to sit at exactly B. Measured on RTX 5090 at the three


### PR DESCRIPTION
## Summary

Below the deep threshold the draft proposes 3 tokens. At this model's acceptance those extra
proposals are never accepted, so they are pure draft cost — and the cost is not constant: each
proposal is another row of the draft's own attention over the same KV, so it grows with context
while what it buys stays at zero.

The measurements the depth-3 choice rests on were taken with the harness's `NSPLITS=1` pin in
place. At the split counts the server actually runs, the attention that pin inflates is cheap, the
draft's fixed cost is a much larger share of the step, and the balance moves. Measured on RTX 5090
at production split counts, one binary, `LOSSLESS 1` on every run:

| ctx | depth 1 | depth 3 | mean accept (d1 / d3) |
|---:|---:|---:|---|
| 128 | 81.94 | **91.69** | 1.1034 / 1.0159 |
| 512 | 92.32 | 91.95 | 1.0000 / 1.0000 |
| 1024 | **78.72** | 68.30 | 1.1429 / 1.1566 |
| 2048 | **83.04** | 78.35 | 1.0435 / 1.0435 |
| 4096 | **81.23** | 74.82 | 1.0756 / 1.0756 |

Acceptance is *identical* at 4k and 2048 — depth 3 buys exactly nothing there. 128 is the one
context that prefers the wide block, and its acceptance column says why: at depth 3 the draft
accepts essentially nothing (1.0159), the idle-draft rule stops drafting, and the stream runs at
AR speed. Narrowing raises acceptance just enough (1.1034) to keep the draft alive without being
worth its cost. So this does not narrow always — it narrows once the draft is carrying a context
whose per-row cost the deeper proposals cannot repay, which is what the 512 tie and everything
above it show. Below `kNarrowMinSeq` (512) nothing changes, and the `>= kDeepMinSeq` branch keeps
its 7 — long context is where acceptance actually climbs and it is measured separately.

**Decided once per generation, not per step, and that distinction is load-bearing.** The verify
graph `dflash_warm_verify` captures is sized from this depth; narrowing per step under a warm
graph built for 4 rows recovers only 0.7% of the 9.4%, because the mismatched graph costs more
than the rows it saves. Both were measured; the static form is the one that pays.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark_tau_check <modelopt> <dspark> 128 <4096-token prompt>`, `METRIC DSPARK_TPS`,
production split counts):

| | decode tok/s |
|---|--:|
| before (main) | 73.87 |
| after (this PR) | 80.82 |

**+9.4% dspark-decode@4k.** Main and PR binaries interleaved round-robin:

```text
round 1: main=73.7986  pr=80.8077   (accept 1.0756, lossless)
round 2: main=73.8362  pr=80.8594   (accept 1.0756, lossless)
round 3: main=73.9694  pr=80.7974   (accept 1.0756, lossless)

main 73.868 | pr 80.822 | +9.41%, 3/3 rounds
```

No context regresses, and the two below the band are unchanged by construction:

```text
ctx=128   main 90.92  pr 91.30    (+0.4%, depth unchanged)
ctx=512   main 91.89  pr 91.86    (-0.0%, tie)
ctx=1024  main 68.27  pr 78.73    (+15.3%)
ctx=2048  main 78.45  pr 83.04    (+5.9%)
```

## Correctness

`LOSSLESS 1` on every run above, including the interleaved rounds and all four guard contexts.

**Mean accept is unchanged: 1.0756 on main, 1.0756 with this PR**, at 4k — this PR does not buy
throughput with acceptance, it removes draft rows that acceptance was never using. That is the
tau floor's own question, answered by identity rather than by tolerance.

Multi-rep losslessness at the scored context is in a comment below (running as this was written;
`SPARKINFER_DSPARK_SPEC_REPS` at ctx=4096).

`SPARKINFER_DFLASH_NARROW_MINSEQ` pins the band boundary (default 512) and
`SPARKINFER_DFLASH_PROPOSALS` still overrides the depth outright, so both arms come out of one
binary.
