### PR TITLE
perf(dspark): row-batched NVFP4 GEMV for the speculative verify — one weight stream for N rows

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -622,6 +622,76 @@ template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloa
 template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
 #endif
 
+// Row-batched form of gemv_nvfp4_sk_kernel: R activation rows against ONE weight stream.
+//
+// The speculative verify projects R rows through the same weight matrix. For every quantized type
+// that has a rows kernel (launch_mmvq_rows) it streams the weights once for all R; NVFP4 had no
+// such kernel, so the verify fell back to R separate one-row launches and re-read the whole
+// matrix R times. On the ModelOpt checkpoint every GDN and attention projection is NVFP4, so that
+// is the batched verify's dominant cost and a reason it stays more expensive per emitted token
+// than the token loop it is meant to replace.
+//
+// Bit-identical per row, by construction and for the same reason launch_mmvq_q4k_rows is: row r
+// walks exactly the group sequence the one-row kernel walks for it (same split, same lane, same
+// stride), accumulates into its own float, and folds its splits in the same ascending order. Only
+// the weight and scale loads are shared between rows -- the arithmetic per row is untouched, which
+// is what keeps the speculative path lossless by construction rather than by measurement.
+template <typename OutT, int S, int R>
+__global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
+                                          const void* __restrict__ packed,
+                                          OutT* __restrict__ y, int N, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float s_part[RPB][S][R];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n = blockIdx.x * RPB + row_local;
+    float acc[R];
+    #pragma unroll
+    for (int r = 0; r < R; r++) acc[r] = 0.f;
+    if (n < N) {
+        const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
+        const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
+        const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+        const unsigned char* srow = sf + (size_t)n * (size_t)(K >> 4);
+        const unsigned char* prow = w + (size_t)n * (size_t)(K >> 1);
+        const int ng = K >> 4;
+        for (int g = split * 32 + lane; g < ng; g += S * 32) {
+            const unsigned char sc = srow[g];
+            #pragma unroll
+            for (int r = 0; r < R; r++)
+                acc[r] += si_nvfp4_group_dot(prow + (size_t)g * 8, sc, inv_g,
+                                             x + (size_t)r * K + (size_t)g * 16);
+        }
+        #pragma unroll
+        for (int r = 0; r < R; r++) {
+            #pragma unroll
+            for (int m = 16; m > 0; m >>= 1) acc[r] += __shfl_xor_sync(0xffffffff, acc[r], m);
+        }
+        if (lane == 0) {
+            #pragma unroll
+            for (int r = 0; r < R; r++) s_part[row_local][split][r] = acc[r];
+        }
+    }
+    __syncthreads();
+    if (n < N && split == 0 && lane == 0) {
+        #pragma unroll
+        for (int r = 0; r < R; r++) {
+            float o = s_part[row_local][0][r];
+            #pragma unroll
+            for (int t = 1; t < S; t++) o += s_part[row_local][t][r];
+            gemv_write(y + (size_t)r * N + n, o);
+        }
+    }
+}
+#ifndef _MSC_VER
+#define SI_NVFP4_ROWS_INST(S_, R_) \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+SI_NVFP4_ROWS_INST(2, 2) SI_NVFP4_ROWS_INST(4, 2) SI_NVFP4_ROWS_INST(8, 2)
+SI_NVFP4_ROWS_INST(2, 4) SI_NVFP4_ROWS_INST(4, 4) SI_NVFP4_ROWS_INST(8, 4)
+SI_NVFP4_ROWS_INST(2, 6) SI_NVFP4_ROWS_INST(4, 6) SI_NVFP4_ROWS_INST(8, 6)
+#undef SI_NVFP4_ROWS_INST
+#endif
+
 template <typename OutT>
 __global__ void gemv_nvfp4_kernel(const __nv_bfloat16* __restrict__ x,
                                   const void* __restrict__ packed,
@@ -2204,6 +2274,31 @@ void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K, cuda
     }
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
     gemv_nvfp4_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+}
+
+bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N, int K,
+                            cudaStream_t stream) {
+    if (!x || !W || !y || N < 1 || K < 1 || (K & 15)) return false;
+    if (!gemv_bf16_splitk()) return false;          // the rows kernel exists in split-K form only
+    if (M != 2 && M != 4 && M != 6) return false;   // instantiated widths; caller loops otherwise
+    const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+    auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
+#define SI_NVFP4_ROWS(S_, R_) do { \
+        constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
+        const dim3 grid((N + RPB - 1) / RPB); \
+        gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); \
+    } while (0)
+#define SI_NVFP4_ROWS_S(R_) do { \
+        if (N >= 8192)      SI_NVFP4_ROWS(2, R_); \
+        else if (N >= 4096) SI_NVFP4_ROWS(4, R_); \
+        else                SI_NVFP4_ROWS(8, R_); \
+    } while (0)
+    if (M == 2)      SI_NVFP4_ROWS_S(2);
+    else if (M == 4) SI_NVFP4_ROWS_S(4);
+    else             SI_NVFP4_ROWS_S(6);
+#undef SI_NVFP4_ROWS_S
+#undef SI_NVFP4_ROWS
+    return true;
 }
 
 void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int K, cudaStream_t stream) {

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -74,6 +74,13 @@ void launch_gemv_fp8(const void* x, const void* W, void* y, int N, int K,
 // [256 B header with f32 global_scale | ue4m3 scale[N*(K/16)] | packed u8[N*(K/2)]].
 // Dequant matches launch_ct_dequant_nvfp4 then a bf16 GEMV: each weight is rounded
 // to bf16(e2m1 * ue4m3 / global_scale) before the dot. K must be a multiple of 16.
+// Row-batched NVFP4 GEMV: M activation rows [M,K] against one weight stream -> y [M,N].
+// Each row reproduces launch_gemv_nvfp4's own dot/reduction order exactly, so results are
+// bit-identical to M separate one-row calls; only the weight/scale loads are shared.
+// Returns false for widths/shapes it does not cover, so callers keep their row loop as fallback.
+bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N, int K,
+                            cudaStream_t stream = nullptr);
+
 void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K,
                        cudaStream_t stream = nullptr);
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2578,6 +2578,11 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // N one-row calls are bit-identical to N AR steps, which is what keeps the speculative
         // path lossless by construction rather than by measurement.
         if (type == kernels::SI_QTYPE_NVFP4) {
+            // One weight stream for all N rows when a rows kernel covers this width. It reproduces
+            // the one-row kernel's dot and split-fold order per row, so the results are the same
+            // bits the loop below produces -- the loop stays as the fallback for widths it does
+            // not cover, and is what every other N still runs.
+            if (kernels::launch_gemv_nvfp4_rows(in, w, out, N, no, k, st)) return true;
             for (int r = 0; r < N; ++r)
                 kernels::launch_gemv_nvfp4(in + (size_t)r * k, w, out + (size_t)r * no, no, k, st);
             return true;
@@ -2605,6 +2610,8 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // Native FP8/NVFP4 touch no shared q81 scratch, so unlike the mmvq path below they are
         // safe on ANY stream and never need the fall-back to `st`.
         if (type == kernels::SI_QTYPE_FP8 || type == kernels::SI_QTYPE_NVFP4) {
+            if (type == kernels::SI_QTYPE_NVFP4 &&
+                kernels::launch_gemv_nvfp4_rows(in, w, out, N, no, k, ps)) return true;
             for (int r = 0; r < N; ++r) {
                 const bf16* xr = in + (size_t)r * k;
                 bf16* yr = out + (size_t)r * no;


### PR DESCRIPTION
## Summary

Every quantized weight type the speculative verify projects through has a rows kernel — one weight
stream serving all N verify rows (`launch_mmvq_rows`, used for Q4_K/Q6_K/Q8_0). NVFP4 did not, so
`dflash_verify_short_run` fell back to N separate one-row launches:

```c
if (type == kernels::SI_QTYPE_NVFP4) {
    for (int r = 0; r < N; ++r)
        kernels::launch_gemv_nvfp4(in + r*k, w, out + r*no, no, k, st);
```

On the ModelOpt checkpoint that is not a corner case: **every** GDN and attention projection is
NVFP4, so the batched verify re-read each of those matrices once per row. `nsys` at ctx=4096 with
the batched path engaged shows `gemv_nvfp4_sk_kernel` at **31,668 launches** (≈621 per step,
~35% of the step) against ~4,900 for the FFN kernels that *are* row-batched — the shape of a
missing kernel rather than a slow one.

This adds `launch_gemv_nvfp4_rows`: R rows against one weight stream, R ∈ {2,4,6}, with the row
loop kept as the fallback for widths it does not cover.

**Bit-identical per row, by construction** — the same property `launch_mmvq_q4k_rows` documents for
its own type. Row r walks exactly the group sequence the one-row kernel walks for it (same split,
same lane, same stride), accumulates into its own float, and folds its splits in the same ascending
order; only the weight and scale loads are shared. That matters here specifically, because the
comment on the row loop above says why it existed: N one-row calls are bit-identical to N AR steps,
which is what keeps the speculative path lossless *by construction*. This preserves that.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

Measured where the code path runs — the batched verify, forced on
(`SPARKINFER_DFLASH_COMPACT_VERIFY=1`) so the kernel is exercised every step — at ctx=4096 and
production split counts:

| | decode tok/s |
|---|--:|
| before (main) | 36.50 |
| after (this PR) | 39.28 |

**+7.6% on the batched-verify path.** Interleaved round-robin, one binary each:

```text
round 1: main=36.5464 | rows [DSPARK_TPS=39.3022 MEAN_ACCEPT=1.2308 LOSSLESS=1]
round 2: main=36.4801 | rows [DSPARK_TPS=39.2662 MEAN_ACCEPT=1.2308 LOSSLESS=1]
round 3: main=36.5037 | rows [DSPARK_TPS=39.2751 MEAN_ACCEPT=1.2308 LOSSLESS=1]
```

Read that number for exactly what it is: it is the gain **when the batched verify runs**. The
arming heuristic keeps that path off for most of a ctx=4096 stream at this model's acceptance, so
the headline `dspark-decode@4k` figure moves much less than this — I am not claiming otherwise.
What this removes is a structural asymmetry (one quant type paying N× the weight traffic its peers
pay), which is worth having on its own and worth more as the verify path gets cheaper to arm.

## Correctness

`LOSSLESS 1` on every run, with `MEAN_ACCEPT` identical to main's (1.2308 on the forced-batched
config) — the proposals and verdicts are unchanged, which is what bit-identical per row predicts.
