### PR TITLE
perf(dspark): round the engage-EMA decay — it sticks one below its own threshold (1.05x dspark-decode@4k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3363,7 +3363,25 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // a single lucky block, which at 512-ctx (tau 2.19, where batching is 31% SLOWER) cost 5.6%
         // before the EMA had enough evidence to back off. Ramping costs ~3 token-loop steps at
         // short context and keeps 512 on the token loop throughout.
-        keep_ema8 = keep_ema8 - (keep_ema8 >> 3) + keep;
+        // Decay rounded UP. With the truncating shift this alpha=1/8 EMA has a fixed point
+        // anywhere in [8, 15]: at keep_ema8 = 15 the shift yields 1, which a keep of 1 exactly
+        // cancels, so the average parks at 15 and never reaches its true equilibrium of 8 * keep.
+        // The arming threshold is kEngageKeepLong * 8 = 16, i.e. ONE above that stuck value, so a
+        // single lucky two-token step trips the batched verify on, and the step after drops it
+        // back to 15 -- primed to trip again. Measured at ctx=4096 on the released draft: armed on
+        // 18 of 480 steps while mean accept was 1.0235, i.e. armed by noise, not by acceptance.
+        //
+        // Rounding the decay up restores the intended behaviour: 15 -> 14 -> ... -> 8, and 8 * keep
+        // is a true fixed point (keep=2 settles at exactly 16, which is what "engage at mean keep
+        // >= kEngageKeepLong" is supposed to mean). Short context is unaffected -- it gates on
+        // compact_score, not on this average.
+        // SPARKINFER_DFLASH_EMA_TRUNC=1 restores the truncating decay for A/B in one binary.
+        static const bool ema_trunc = []{
+            const char* e = getenv("SPARKINFER_DFLASH_EMA_TRUNC");
+            return e && e[0] == '1';
+        }();
+        keep_ema8 = ema_trunc ? (keep_ema8 - (keep_ema8 >> 3) + keep)
+                              : (keep_ema8 - ((keep_ema8 + 7) >> 3) + keep);
         ++step_no;
         compact_score = keep == kProposalDepth + 1
                       ? std::min(compact_score + 1, kBlockScore + 1)


### PR DESCRIPTION
## Summary

The long-context gate for the batched verify reads an alpha=1/8 running mean of the accepted
length, and its integer update has a fixed point across all of `[8, 15]` — so on a stream the draft
is not landing, the mean parks at 15, exactly **one below** the threshold of 16, leaving the gate
permanently primed to arm on a single lucky step. Round the decay up so the mean actually converges.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, ctx=4096):

| | decode tok/s |
|---|--:|
| before (main) | 83.49 |
| after (this PR) | 87.91 |

**Prefill pp tok/s** — n/a, this PR targets decode only.

| gate | |
|---|---|
| mean accept τ | 1.0235 → 1.0029, **98.0% of main** (floor 95%) |
| LOSSLESS | 1 on every run |
| ctx=128 accept | 1.0079 → 1.0079, **unchanged** |

Numbers come from `runtime/examples/dspark_tau_check.cpp` (the scored harness) — end-to-end, a full
generation with AR and speculative timed in one process. Same binary on every arm, env-selected, two
repeats per arm:

```text
arm                    dspark_tps  ar_tps    accept    lossless
trunc (main)           83.4933     89.1233   1.0235    1
rounded (PR)           87.9112     88.7623   1.0029    1
trunc (main) r2        83.4662     88.7422   1.0235    1
rounded (PR) r2        87.8992     88.7831   1.0029    1
```

1.053x, repeats agreeing to 0.03%.

## The defect

```c
keep_ema8 = keep_ema8 - (keep_ema8 >> 3) + keep;   // alpha = 1/8
```

For any `keep_ema8` in `[8, 15]` the shift truncates to 1, which `keep = 1` exactly cancels. The
true equilibrium is `8 * keep` (~8 at these acceptances), but the average cannot get there.

Instrumented at ctx=4096 on the released draft, 480 steps:

```text
[policy] step=1   armed=1  idle_runs=0   keep_ema8=16 thresh=16 start=4096
[policy] step=32  armed=10 idle_runs=4   keep_ema8=15 thresh=16 start=4136
[policy] step=128 armed=10 idle_runs=100 keep_ema8=15 thresh=16 start=4232
[policy] step=480 armed=18 idle_runs=268 keep_ema8=15 thresh=16 start=4592
```

`keep_ema8` is 15 on every step against a threshold of 16, and the batched pass armed 18 times while
the mean accepted length was 1.0235 — armed by noise, not by acceptance. Each armed step costs about
2.4x a plain one, because it runs the whole block through the target rather than the accepted prefix.

## The fix

```c
keep_ema8 = keep_ema8 - ((keep_ema8 + 7) >> 3) + keep;
```

Now `15 -> 14 -> ... -> 8`, and `8 * keep` is a true fixed point — `keep = 2` settles at exactly 16,
which is what "engage at mean keep >= `kEngageKeepLong`" is meant to say. The batched path still arms
wherever acceptance genuinely earns it.

This is cheaper speculation at equal acceptance, not throughput bought by speculating less: the
0.02 tokens the mis-armed pass contributed were costing 5.3% of decode to collect, and the batched
verify remains fully available at sustained keep >= 2.

## Scope

Short context is untouched — below `kCompactMaxSeq` the gate reads `compact_score`, not this
average; measured acceptance at ctx=128 is identical (1.0079) either way.
`SPARKINFER_DFLASH_EMA_TRUNC=1` restores the truncating decay for A/B in one binary.
