### PR TITLE
tools(dflash): env-gated DOT dump of the captured decode graph (no speedup claimed)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1959,6 +1959,20 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 fprintf(stderr, "[dflash-graph] capture pos=%d seqlen=%d n_splits=%d attn_mode=%d mma_chunk=%d sparse=%d\n",
                         position, seqlen, s.n_splits, attn_graph_mode, mma_chunk, sparse_on ? 1 : 0);
             }
+            // SPARKINFER_DFLASH_GRAPH_DOT=<path> writes the captured DFlash decode graph out in
+            // DOT form, with kernel names and node parameters. What that buys is a question the
+            // timeline cannot answer: whether two nodes are ORDERED. Reachability over the dumped
+            // DAG decides it exactly -- for the verify-overlap investigation in #870 it showed
+            // 879 nodes / 1132 edges whose only unordered pairs were the five intended GDN-pipe
+            // overlaps, and the capture_row nodes with none at all, which ruled out a missing
+            // intra-graph dependency without another day of bisection. Env-gated, so it costs a
+            // getenv on the capture path and nothing anywhere else.
+            if (const char* dot = getenv("SPARKINFER_DFLASH_GRAPH_DOT")) {
+                cudaGraphDebugDotPrint(s.cu_dflash_graph, dot,
+                                       cudaGraphDebugDotFlagsVerbose |
+                                       cudaGraphDebugDotFlagsKernelNodeParams);
+                fprintf(stderr, "[dflash-graph] dot written to %s\n", dot);
+            }
         }
         cu(cudaGraphLaunch(s.cu_dflash_exec, st), "dflash graph launch (first)");
     } else if (capturing_graph) {


### PR DESCRIPTION
## Summary

`SPARKINFER_DFLASH_GRAPH_DOT=<path>` writes the captured DFlash decode graph out in DOT form, with
kernel names and node parameters, right after `cudaGraphInstantiate`. Env-gated: one `getenv` on
the capture path, nothing anywhere else, no behaviour change when unset.

**Not a speedup, and not submitted as one** — no `eval` label is sought. It is the tool that
answered a question the timeline could not.

While investigating the disabled verify/draft overlap (#870), the open question was whether two
kernels are *ordered* — a race hypothesis the nsys timeline cannot settle, because a timeline
shows what did happen on one run, not what the graph permits. Reachability over the dumped DAG
settles it exactly. On this checkpoint the captured graph is 879 nodes / 1132 edges, and the only
unordered node pairs are the five intended GDN-pipe overlaps:

```text
x192  gemv_f32_sk_kernel        || gemv_nvfp4_sk_kernel
x96   gemv_nvfp4_sk_kernel      || gemv_nvfp4_sk_kernel
x96   conv_split_l2norm_fused   || gemv_f32_sk_kernel
x48   conv_split_l2norm_fused   || gemv_nvfp4_sk_kernel
x48   gdn_ar_fast_kernel        || gemv_nvfp4_sk_kernel
```

with the five `capture_row` nodes having **zero** concurrent nodes. That ruled out a missing
intra-graph dependency — and the capture-vs-overwrite hypothesis with it — in one run instead of
another day of bisection.

The checker itself is ~20 lines of Python over the DOT file (parse nodes and edges, topological
order, reachability bitsets, report unordered pairs by kernel name). Happy to add it under
`runtime/tools/` in this PR if you would rather it lived in the tree than in a gist; I left it out
to keep the diff to the one env-gated call.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`) — the dump was produced and consumed on one, and
`dspark_tau_check` reports `LOSSLESS 1` with the flag set and unset.

No decode table: this PR makes nothing faster and does not claim to. Per CONTRIBUTING,
non-speedup PRs are welcome but score zero, which is exactly what this is.
