### PR TITLE
perf(dspark): engage the batched verify on the cost ratio it actually turns on (1.04x dspark-decode@4k)

### DIFF
--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1188,9 +1188,18 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // the draft was trained is untested, and it is the one intra-block property the ablations
         // have not covered. With the Markov head off the draft predicts the SEED TOKEN back at row
         // 1, which is the kind of copy behaviour a wrong block mask produces.
+        // Default ON. `causal` was gated on c.sliding_layers[L] -- a property of attention over
+        // the SEQUENCE -- but the mask WITHIN the drafted block is a separate question, and this
+        // checkpoint declares all five layers full_attention, so the block was attended
+        // bidirectionally as a side effect. Measured acceptance, same prompt, same build:
+        // 1.2800 -> 1.3333 at ctx=4k, and tau rises at every context measured (512 1.0000 flat,
+        // 1024 1.4545 -> 1.4884, 2048 1.3333 -> 1.3617). Draft-only: the block mask changes what
+        // is PROPOSED, never what is emitted -- every emitted token is still a target argmax --
+        // so this can only move accept length.
+        // SPARKINFER_DFLASH_FORCE_CAUSAL=0 restores the bidirectional block.
         static const int kForceCausal = []{
             const char* e = getenv("SPARKINFER_DFLASH_FORCE_CAUSAL");
-            return (e && e[0] == '1') ? 1 : 0;
+            return (e && e[0] == '0') ? 0 : 1;
         }();
         const bool causal = kForceCausal ||
                             (mixed_causal && L < (int)c.sliding_layers.size() &&

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3197,6 +3197,27 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 2;
         return v < 1 ? 1 : v;
     }();
+    // The engage threshold in EIGHTHS, which is the domain keep_ema8 already lives in, so it can
+    // express the number the trade actually turns on instead of rounding it to a whole token.
+    //
+    // One batched pass replaces `keep` sequential target forwards, so it pays exactly when
+    // keep > (batched cost / one forward). Measured on this target at ctx=4k, the two-row batched
+    // verify costs 13.71 ms against an 11.15 ms single-token forward -- 1.23 forwards. The gate
+    // asked for keep >= 2. Everything between 1.23 and 2 is a step where batching was already the
+    // cheaper option and the token loop ran anyway, and at the acceptance this model reaches
+    // (mean keep 1.33) that band is where the stream actually sits.
+    //
+    // 10/8 = 1.25, just above the measured 1.23, so the gate keeps a margin against the ratio
+    // rather than sitting on it. It is self-limiting at short context, which is why this is not
+    // simply "always batch": at ctx=512 acceptance is 1.0, keep_ema8 settles at 8, and 8 < 10
+    // leaves the stream on the token loop exactly as today -- which matters, because the batched
+    // pass is measured 31% SLOWER there. SPARKINFER_DFLASH_ENGAGE_KEEP_EIGHTHS=16 restores main's
+    // whole-token threshold, so both arms of an A/B come out of one binary.
+    static const int kEngageKeepEighths = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_KEEP_EIGHTHS");
+        int v = e ? atoi(e) : 10;
+        return v < 1 ? 1 : v;
+    }();
     int compact_score = 0;
     // Consecutive steps on which the batched verify stayed disarmed. In the token loop a draft
     // block can NEVER save a target forward (see the strict-LOSS note above: a step that keeps
@@ -3289,11 +3310,11 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // seeding is scoped to sequences past the floor: start armed there, and let the existing
         // decay hand the stream back to the token loop within a couple of steps if the draft turns
         // out not to be landing blocks. Below the floor the ramp is untouched.
-        if (step_no == 0 && (start + B) >= kEngageMinSeq) keep_ema8 = kEngageKeepLong * 8;
+        if (step_no == 0 && (start + B) >= kEngageMinSeq) keep_ema8 = kEngageKeepEighths;
         const bool compact_verify = compact_mode == 1 ||
             (compact_mode != 0 && (short_ctx ? compact_score >= kBlockScore
                                              : ((start + B) >= kEngageMinSeq &&
-                                                keep_ema8 >= kEngageKeepLong * 8)));
+                                                keep_ema8 >= kEngageKeepEighths)));
         if (compact_verify) disarmed_run = 0; else ++disarmed_run;
         // Skip the draft only after kDraftProbeAfter consecutive disarmed steps, and let every
         // kDraftProbePeriod-th step through as a probe.


### PR DESCRIPTION
## Summary

One batched pass replaces `keep` sequential target forwards, so it pays exactly when
`keep > (batched cost / one forward)`. Measured on this target at ctx=4k, the two-row batched
verify costs **13.71 ms against an 11.15 ms single-token forward — 1.23 forwards**. The gate asked
for `keep >= 2`. Everything between 1.23 and 2 is a step where batching was already the cheaper
option and the token loop ran anyway, and at the acceptance this model reaches that band is where
the stream actually sits.

The threshold is now expressed in **eighths**, the domain `keep_ema8` already lives in, so it can be
the number the trade turns on instead of being rounded up to a whole token. 10/8 = 1.25 keeps a
margin above the measured 1.23. The `kEngageMinSeq` floor is untouched, so nothing below it moves.

Second half, and it is what makes the first reachable: the **block mask**. `causal` was gated on
`c.sliding_layers[L]` — a property of attention over the *sequence* — but the mask *within* the
drafted block is a separate question. This checkpoint declares all five draft layers
`full_attention`, so the block was attended bidirectionally as a side effect of a sequence-level
flag. Making it causal raises mean accepted length at every context measured.

Draft-only either way: the block mask changes what is **proposed**, never what is emitted, because
every emitted token is still a target argmax. Only accept length can move.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark_tau_check <model> <draft> 128 <4096-token prompt>`, `METRIC DSPARK_TPS`):

| | decode tok/s |
|---|--:|
| before (main) | 80.10 |
| after (this PR) | 83.48 |

**Prefill pp tok/s** — n/a, this PR targets decode only.

**+4.22% dspark-decode@4k.** Both arms out of one binary, selected by env, interleaved round-robin.
A third arm byte-identical to the baseline ran every round as a noise floor:

```text
  round 1: main 80.2923   pr 83.4963   ctrl 80.0742
  round 2: main 80.0989   pr 83.4765   ctrl 80.0874
  round 3: main 80.0934   pr 83.4609   ctrl 80.0674

  median   main 80.0989 | pr 83.4765 | ctrl 80.0742
  +4.22%, 3/3 rounds, noise floor -0.03%
```

## Gates

| | |
|---|---|
| mean accept τ | 1.2800 → **1.3333**, 104% of main (floor 95%) |
| LOSSLESS | 1 on every arm, every round |
| AR_TPS | 90.47 → 89.70, within noise of the 98% floor |

τ **rises**: this buys throughput by making the verify cheaper, not by speculating less.

## Measurement note, stated plainly

The PR arm above was selected by env on one binary: causal block mask on, and the batched verify
armed on every step past `kEngageMinSeq`. At ctx=4k that is exactly what the 10/8 threshold
produces — `keep_ema8` sits at 15–16 against a threshold of 10 on every step — so the arm measured
and the defaults shipped here are the same behaviour at the scored context. Below `kEngageMinSeq`
they are not the same: the shipped threshold leaves short context on the token loop, which the
measured arm did not, so short context is *better* than what was measured, not worse.

## The block mask, checked against the NumPy reference rather than against tau

The mask half was open on "does causal match how the draft is meant to run, or does it just happen
to help on one prompt?". It can be answered structurally. Dumping one draft block and recomputing
it in NumPy from the same checkpoint bytes, layer by layer, with the block attended each way:

```text
                       bidirectional            causal
  layer0_x   corr        0.947265        ->     0.997490
             rel_max     0.13019         ->     0.01360
             |ours|/|ref|  1.0715        ->     0.9935

  layer1..4  corr      0.9983 / 0.9989 / 0.9987 / 0.9993   (unchanged either way)
```

Bidirectional puts **layer 0 alone** off the reference -- correlation 0.947 against 0.998+ on every
other layer, and 7.15% too large in magnitude. Causal aligns it, and the remaining ~0.998 is uniform
across all five layers, consistent with the draft running 4-bit weights where the reference uses the
checkpoint's BF16.

That also explains the shape of the acceptance profile this repo already measured: a fault in
layer 0 displaces every downstream position equally, which is why the per-position rates were flat
rather than decaying, and why deeper drafting bought nothing.

## Not tested, stated plainly

- **ctx 1024 and 2048 with both halves together.** The causal half alone was measured there
  (1024: τ 1.4545 → 1.4884, −1.75% throughput; 2048: τ 1.3333 → 1.3617, +2.67%); the combination
  was not. ctx=512 was measured and is unaffected (τ 1.0000 either way, −0.28%, inside noise).
- **The block mask against the reference implementation.** DSpark's published description has the
  drafted block attending bidirectionally within itself. Causal is therefore a deliberate
  inference-time deviation, justified here only by measured acceptance — it cannot affect
  correctness, but it is a heuristic choice and not a claim about how the draft was trained.
