### PR TITLE
perf(dspark): align Markov rows and add a two-row draft tier

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1121,7 +1121,8 @@ void launch_gemv_batched_q4_fused3(const void* x,
 #define SI_Q4KS_B(BW_) do { if (ksplit == 2) SI_Q4KS(BW_, 2);                                     \
                             else if (ksplit == 4) SI_Q4KS(BW_, 4);                                \
                             else SI_Q4KS(BW_, 8); } while (0)
-        if (batch == 4)      SI_Q4KS_B(4);
+        if (batch == 2)      SI_Q4KS_B(2);
+        else if (batch == 4) SI_Q4KS_B(4);
         else if (batch == 8) SI_Q4KS_B(8);
         else                 SI_Q4KS_B(16);
 #undef SI_Q4KS_B
@@ -1135,7 +1136,8 @@ void launch_gemv_batched_q4_fused3(const void* x,
         (const bf16*)x, (const unsigned char*)Q0, (const unsigned char*)Q1,                     \
         (const unsigned char*)Q2, (const __half2*)D0, (const __half2*)D1, (const __half2*)D2,   \
         (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
-    if (batch == 4)      SI_Q4F3(4);
+    if (batch == 2)      SI_Q4F3(2);
+    else if (batch == 4) SI_Q4F3(4);
     else if (batch == 8) SI_Q4F3(8);
     else                 SI_Q4F3(16);
 #undef SI_Q4F3
@@ -1176,7 +1178,8 @@ void launch_gemv_batched_q8_fused3(const void* x,
 #define SI_Q8F3(BW_) k_gemv_batched_fused3_q8<BW_, ROWS><<<grid, blk, 0, stream>>>(               \
         (const bf16*)x, (const signed char*)Q0, (const signed char*)Q1, (const signed char*)Q2,   \
         S0, S1, S2, (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
-    if (batch == 4)      SI_Q8F3(4);
+    if (batch == 2)      SI_Q8F3(2);
+    else if (batch == 4) SI_Q8F3(4);
     else if (batch == 8) SI_Q8F3(8);
     else                 SI_Q8F3(16);
 #undef SI_Q8F3
@@ -1342,7 +1345,8 @@ void launch_gemv_batched16_fused3(const void* x,
 #define SI_FUSED3(BW_) k_gemv_batched_fused3<BW_, ROWS><<<grid, blk, 0, stream>>>(              \
         (const bf16*)x, (const bf16*)W0, (const bf16*)W1, (const bf16*)W2,                     \
         (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
-    if (batch == 4)       SI_FUSED3(4);
+    if (batch == 2)       SI_FUSED3(2);
+    else if (batch == 4)  SI_FUSED3(4);
     else if (batch == 8)  SI_FUSED3(8);
     else                  SI_FUSED3(16);
 #undef SI_FUSED3

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -966,16 +966,16 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         if (v < kProposalDepth + 1) v = kProposalDepth + 1;
         // Round up to a width the batched-GEMV path is instantiated for; anything else falls
         // back to the per-token GEMV loop, which costs far more than the rows it saves.
-        const int w = v <= 4 ? 4 : (v <= 8 ? 8 : 16);
+        const int w = v <= 2 ? 2 : (v <= 4 ? 4 : (v <= 8 ? 8 : 16));
         return w > c.block_size ? c.block_size : w;
     }();
     const float scale = 1.f / sqrtf((float)d);
     const int past = s.seq_len;
     // The fixed-size (block_size) projections below can use a batched-GEMV kernel that reads
     // each weight row from DRAM once instead of once per token (see dflash_kernels.cu). It's
-    // compiled for exactly 16 rows, so it's only used when the draft's block_size is 16 (true
-    // for the current checkpoint); any other block_size falls back to the per-token GEMV loop.
-    const bool fast16 = (BW == 16 || BW == 8 || BW == 4);
+    // instantiated for the active width tiers below; an unsupported width falls back to the
+    // per-token GEMV loop.
+    const bool fast16 = (BW == 16 || BW == 8 || BW == 4 || BW == 2);
 
     cu(cudaMemcpyAsync(s.d_ids, noise_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
     kernels::launch_embedding(s.d_ids, s.embed, s.noise, BW, H, st);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1298,11 +1298,25 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // SPARKINFER_DFLASH_HEAD_MULTIROW=0 falls back to the bf16 batched path.
     static int head_mr = -1;
     if (head_mr < 0) { const char* e = getenv("SPARKINFER_DFLASH_HEAD_MULTIROW"); head_mr = (e && e[0] == '0') ? 0 : 1; }
+    // SGLang consumes base-logit rows [0, depth). Keep the legacy [1, depth+1) producer and
+    // consumer together behind one A/B switch; changing only one side reads the wrong (or, on the
+    // multi-row fast path, uninitialised) logits and is not a meaningful comparison.
+    static const int kRowShift = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ROW_SHIFT");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    const int head_row0 = kRowShift ? 0 : 1;
     bool head_done = false;
     if (head_mr && s.head_q8 && (s.lm_head_type == 14 || s.lm_head_type == 12)) {
         // Score only the proposal rows the verifier can consume. One row-batched quantize launch
         // instead of kProposalDepth tiny ones (8 CTAs each, so launch latency dominated them).
-        kernels::launch_quantize_q8_1_rows(s.xn + (size_t)H, s.head_q8, H, kProposalDepth, H, st);
+        // DSpark's Markov chain consumes base-logit rows [0, depth): row 0 plus the anchor token
+        // produces proposal 1, row 1 plus proposal 1 produces proposal 2, and so on. Quantizing
+        // rows [1, depth+1) here was the other half of the legacy row displacement below: merely
+        // fixing the consumer would otherwise make row 0 read uninitialised logits on this fast
+        // multi-row head path.
+        kernels::launch_quantize_q8_1_rows(s.xn + (size_t)head_row0 * H,
+                                           s.head_q8, H, kProposalDepth, H, st);
         // Prefer the Q4_K head when one is bound: this kernel already runs near HBM peak, so its
         // runtime IS its weight bytes -- ~280 MB in Q4_K against ~417 MB in Q6_K at V=248k.
         static const bool head_i8 = [] {
@@ -1312,17 +1326,19 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         if (s.lm_head_type == 12 && s.lm_head_i4)
             head_done = kernels::launch_gemv_i4_q81_multirow_f32(
                 s.head_q8, s.lm_head_i4, s.lm_head_i4_scale,
-                s.logits + V, V, H, kProposalDepth, st);
+                s.logits + (size_t)head_row0 * V, V, H, kProposalDepth, st);
         else if (s.lm_head_type == 12 && head_i8 && s.lm_head_i8)
             head_done = kernels::launch_gemv_i8_q81_multirow_f32(
                 s.head_q8, s.lm_head_i8, s.lm_head_i8_scale,
-                s.logits + V, V, H, kProposalDepth, st);
+                s.logits + (size_t)head_row0 * V, V, H, kProposalDepth, st);
         else if (s.lm_head_type == 12)
             head_done = kernels::launch_gemv_q4k_dp4a_multirow_f32(
-                s.head_q8, s.lm_head, s.logits + V, V, H, kProposalDepth, st);
+                s.head_q8, s.lm_head, s.logits + (size_t)head_row0 * V,
+                V, H, kProposalDepth, st);
         else
             head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(
-                s.head_q8, s.lm_head, s.logits + V, V, H, kProposalDepth, st);
+                s.head_q8, s.lm_head, s.logits + (size_t)head_row0 * V,
+                V, H, kProposalDepth, st);
     }
     if (!head_done) {
     if (BW == 16) {
@@ -1341,13 +1357,11 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // DSpark's Markov head: position r's logit bias conditions on the token AT position r itself
     // (the anchor for r==0, its own -- just-chosen -- prediction for r>0), predicting position
     // r+1. That token is only known once position r-1's own Markov-corrected argmax has run, so
-    // rows 1..kProposalDepth chain sequentially instead of the single batched argmax below --
+    // proposals 1..kProposalDepth chain sequentially instead of the single batched argmax below --
     // each launch reads its "previous token" from device memory (s.d_ids[0], the real anchor, for
     // r==1; this same loop's own s.d_out[r-1] for r>1), so the chain needs no host round-trip
-    // until the final readback already below. Row 0 itself is never consumed by the caller (its
-    // prediction for position start+1 is redundant with the target's own verify-row-0 call, which
-    // is strictly more reliable than any draft guess), so it only needs a plain argmax in the
-    // !head_done path, where the batched LM-head GEMV computed it too and left it unscored.
+    // until the final readback already below. Base row 0 is consumed to form proposal 1; d_out[0]
+    // itself is not a proposal because the caller already owns the target-produced anchor token.
     // MARKOV HEAD: ALWAYS ON. It was gated on sequence length (#868, threshold 12288) because it
     // "raises acceptance and costs more than the acceptance is worth below long context". That was
     // measured inside the regime the gate itself creates, and the conclusion was wrong.
@@ -1384,9 +1398,10 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // selects the proposal-depth ladder in qwen35.cpp, which is a separate decision.
     const bool markov_on = markov_env >= 0 ? (markov_env != 0) : true;
     if (markov_on && s.markov_w1 && s.markov_w2) {
-        // ROW SHIFT (SPARKINFER_DFLASH_ROW_SHIFT=1). Which block row backs proposal r?
+        // ROW SHIFT (SPARKINFER_DFLASH_ROW_SHIFT=0 restores the legacy mapping). Which block row
+        // backs proposal r?
         //
-        // We read row r. SGLang reads row r-1: its run_markov_block iterates step_idx over ALL
+        // The legacy path reads row r. SGLang reads row r-1: its Markov sampler iterates over ALL
         // gamma rows of base_logits starting at row 0, with first_prev_tokens = the anchor
         // (draft_block_ids[:,0], the bonus token) -- so its FIRST proposal comes from row 0, the
         // row holding the real seed token, and its gamma-th from row gamma-1. Ours discards row 0
@@ -1397,10 +1412,6 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // That is consistent with the symptom: tau lands well above 1.0 because the Markov bias,
         // conditioned correctly, partially compensates for the wrong base row -- but it is capped,
         // and deeper drafting buys nothing because every position is displaced.
-        static const int kRowShift = []{
-            const char* e = getenv("SPARKINFER_DFLASH_ROW_SHIFT");
-            return (e && e[0] == '1') ? 1 : 0;
-        }();
         if (!head_done) kernels::launch_argmax(s.logits, s.d_out, 1, V, st);
         for (int r = 1; r <= kProposalDepth; r++) {
             const int* prev = (r == 1) ? s.d_ids : (s.d_out + (r - 1));
@@ -1413,19 +1424,22 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             // argmax is to be accepted. Order doesn't matter relative to the argmax call below --
             // it depends on s.xn and s.markov_latent, neither of which the argmax touches.
             if (s.confidence_w)
-                dflash_kernels::launch_confidence_head(s.xn + (size_t)r * H, s.markov_latent,
+                dflash_kernels::launch_confidence_head(s.xn + row * H, s.markov_latent,
                                                        s.confidence_w, s.confidence_bias, H,
                                                        s.markov_rank, s.d_confidence + r, st);
             kernels::launch_argmax(s.logits + row * V, s.d_out + r, 1, V, st);
         }
     } else {
-        kernels::launch_argmax(s.logits + (head_done ? V : 0),
+        kernels::launch_argmax(s.logits + (size_t)(head_done ? head_row0 : 0) * V,
                                s.d_out + (head_done ? 1 : 0),
                                head_done ? kProposalDepth : B, V, st);
     }
-    cu(cudaMemcpyAsync(s.h_out, s.d_out,
-                       (head_done ? kProposalDepth + 1 : B) * sizeof(int),
-                       cudaMemcpyDeviceToHost, st), "argmax");
+    if (head_done)
+        cu(cudaMemcpyAsync(s.h_out + 1, s.d_out + 1, kProposalDepth * sizeof(int),
+                           cudaMemcpyDeviceToHost, st), "argmax");
+    else
+        cu(cudaMemcpyAsync(s.h_out, s.d_out, B * sizeof(int),
+                           cudaMemcpyDeviceToHost, st), "argmax");
 
     // NUMERICAL DIFFERENTIAL DUMP (SPARKINFER_DSPARK_DUMP=<dir>). Writes ONE block's worth of
     // inputs and intermediates so a Python reference can recompute the same step from the same
@@ -1479,7 +1493,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                            kProposalDepth * sizeof(float), cudaMemcpyDeviceToHost, st),
            "confidence readback");
     cu(cudaStreamSynchronize(st), "draft sync");
-    for (int t = 0; t <= kProposalDepth; t++) out_argmax[t] = s.h_out[t];
+    for (int t = head_done ? 1 : 0; t <= kProposalDepth; t++) out_argmax[t] = s.h_out[t];
     if (out_confidence && s.confidence_w)
         for (int t = 1; t <= kProposalDepth; t++) out_confidence[t] = s.h_confidence[t];
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3133,7 +3133,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     //      depth 3 against 1.123 at depth 5, i.e. a hundredth of a token for two extra rows.
     //
     //   2. DEPTH 4 IS A CLIFF, NOT A SLOPE. The draft's active block width is
-    //      round_up(depth+1) over {4, 8, 16} capped at block_size, so depth 3 runs a 4-wide draft
+    //      round_up(depth+1) over {2, 4, 8, 16} capped at block_size, so depth 3 runs a 4-wide draft
     //      block and depth 4 runs a 7-wide one. Crossing it costs a quarter of the throughput for
     //      the zero extra accepts above:
     //


### PR DESCRIPTION
## Summary

Align the Markov head with DSpark base-logit positions and add a native two-row draft tier, raising scored DSpark decode@4k throughput by 18.17% while preserving exact target-token equality.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 90.0416 |
| after (this PR) | 106.4036 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) |  |
| after prefill (this PR) |  |

The active DSpark scope uses `runtime/examples/dspark_tau_check.cpp` at ctx=4096 rather than the generic GGUF `bench.sh` path. Both runs used the pinned 4096-token prompt, Qwen3.8-27B ModelOpt NVFP4 target, released DSpark draft, 128 output tokens, and three speculative repeats.

```text
# main
draft: layers=5 B=7 n_cap=5  target: layers=64 dense_ffn=1 experts=1
DSPARK tau=1.333  steps=96  tokens=128  decode_s=1.422
AR     90.53 tok/s  (decode 1.414s, ttft 42.407s)
METRIC AR_TPS 90.5276
METRIC DSPARK_TPS 90.0416
METRIC MEAN_ACCEPT 1.3333
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 3

# this PR
draft: layers=5 B=7 n_cap=5  target: layers=64 dense_ffn=1 experts=1
DSPARK tau=1.561  steps=82  tokens=128  decode_s=1.203
AR     89.78 tok/s  (decode 1.426s, ttft 42.824s)
METRIC AR_TPS 89.7753
METRIC DSPARK_TPS 106.4036
METRIC MEAN_ACCEPT 1.5610
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 3
```

<!-- More checklist items will be added here later. -->