### PR TITLE
perf(dspark): hold the engage EMA at x64 so low acceptance can disarm the batched verify (1.14x dspark-decode@4k)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -15,6 +15,7 @@
 #endif
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
+#include <cstdint>
 #endif
 
 namespace sparkinfer {
@@ -749,6 +750,45 @@ __device__ __forceinline__ void si_nvfp4_load_x16(const __nv_bfloat16* x16, floa
     }
 }
 
+// Same 16 activations, same conversions, same destination lanes -- fetched as two 128-bit loads
+// instead of eight 32-bit ones.
+//
+// A group is 16 bf16 = 32 contiguous bytes, but nothing in the scalar form above tells the
+// compiler that: the address is x + r*K + g*16 with K and g both runtime values, so it cannot
+// prove 16-byte alignment and emits eight 32-bit loads. On this kernel that is the dominant
+// instruction stream -- the activations are re-read for every output row a warp owns, which is
+// what the 3.41 GB L1 against 29.5 MB DRAM ratio recorded below is made of -- so what the x side
+// costs is the load COUNT, not the byte count. Two 128-bit loads carry the same 32 bytes in a
+// quarter of the issue slots.
+//
+// Alignment is a precondition, not an assumption: launch_gemv_nvfp4_rows checks the base pointer
+// once and selects an XVEC instantiation only when it holds. Every row starts at x + r*K and K is
+// a multiple of 16 (the launcher rejects anything else), so a 16-byte-aligned base leaves every
+// row and every group 16-byte aligned too.
+//
+// Bit-identical: __bfloat1622float2 runs over the same halves in the same order and writes the
+// same lanes of xv, so si_nvfp4_dot16 folds an identical term sequence. Only the load width moves.
+__device__ __forceinline__ void si_nvfp4_load_x16_vec(const __nv_bfloat16* x16,
+                                                      float* __restrict__ xv) {
+    int4 v[2];
+    v[0] = __ldg(reinterpret_cast<const int4*>(x16));
+    v[1] = __ldg(reinterpret_cast<const int4*>(x16) + 1);
+    const __nv_bfloat162* x2 = reinterpret_cast<const __nv_bfloat162*>(v);
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        const float2 xf = __bfloat1622float2(x2[i]);
+        xv[2 * i] = xf.x;
+        xv[2 * i + 1] = xf.y;
+    }
+}
+
+template <bool XVEC>
+__device__ __forceinline__ void si_nvfp4_load_x16_sel(const __nv_bfloat16* x16,
+                                                      float* __restrict__ xv) {
+    if (XVEC) si_nvfp4_load_x16_vec(x16, xv);
+    else      si_nvfp4_load_x16(x16, xv);
+}
+
 __device__ __forceinline__ float si_nvfp4_dot16(const float* __restrict__ ws,
                                                 const float* __restrict__ xv) {
     float acc = 0.f;
@@ -811,7 +851,7 @@ template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloa
 // stride), accumulates into its own float, and folds its splits in the same ascending order. Only
 // the weight and scale loads are shared between rows -- the arithmetic per row is untouched, which
 // is what keeps the speculative path lossless by construction rather than by measurement.
-template <typename OutT, int S, int R, int NR>
+template <typename OutT, int S, int R, int NR, bool XVEC>
 __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
                                           const void* __restrict__ packed,
                                           OutT* __restrict__ y, int N, int K) {
@@ -830,6 +870,9 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
     //
     // Bit-identical: each (n, r) dot still walks the same groups in the same order and folds the
     // same S partials. Only which warp owns which output row changes. NR=1 is the original.
+    //
+    // XVEC selects 128-bit activation loads (si_nvfp4_load_x16_vec). It is orthogonal to NR: NR
+    // decides how OFTEN x is re-read, XVEC how many instructions each read costs.
     const int n0 = blockIdx.x * (RPB * NR) + row_local * NR;
     float acc[NR][R];
     #pragma unroll
@@ -846,7 +889,7 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
             float xv[R][16];
             #pragma unroll
             for (int r = 0; r < R; r++)
-                si_nvfp4_load_x16(x + (size_t)r * K + (size_t)g * 16, xv[r]);
+                si_nvfp4_load_x16_sel<XVEC>(x + (size_t)r * K + (size_t)g * 16, xv[r]);
             #pragma unroll
             for (int j = 0; j < NR; j++) {
                 const int nj = n0 + j;
@@ -892,8 +935,9 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
 }
 #ifndef _MSC_VER
 #define SI_NVFP4_ROWS_INST(S_, R_) \
-template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
-template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1, false>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2, false>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2, true>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
 SI_NVFP4_ROWS_INST(2, 2) SI_NVFP4_ROWS_INST(4, 2) SI_NVFP4_ROWS_INST(8, 2)
 SI_NVFP4_ROWS_INST(2, 4) SI_NVFP4_ROWS_INST(4, 4) SI_NVFP4_ROWS_INST(8, 4)
 SI_NVFP4_ROWS_INST(2, 6) SI_NVFP4_ROWS_INST(4, 6) SI_NVFP4_ROWS_INST(8, 6)
@@ -2532,16 +2576,34 @@ bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N,
     if (M < 2 || M > 8) return false;
     const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
     auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
-    // SPARKINFER_NVFP4_ROWS_NR=1 gives one output row per warp, i.e. main's kernel exactly, so both
-    // arms of an A/B come out of one binary.
+    // 128-bit activation loads, when the caller's buffer allows them. K is already known to be a
+    // multiple of 16 (rejected above otherwise), so every row base x + r*K sits a whole number of
+    // 32-byte groups from the base -- one check on the base therefore covers every row and every
+    // group. A caller that hands over an odd offset simply gets the scalar loads it gets today.
+    // SPARKINFER_NVFP4_ROWS_XVEC=0 forces the scalar loads back on, so "main's kernel" is one env
+    // away in the same binary rather than a second build.
+    static const bool xvec_off = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_XVEC");
+                                     return e && e[0] == '0'; }();
+    const bool xvec = !xvec_off && ((reinterpret_cast<uintptr_t>(xp) & 15u) == 0);
+    // SPARKINFER_NVFP4_ROWS_NR=1 gives one output row per warp, i.e. main's pre-#891 kernel, so
+    // both arms of an A/B come out of one binary.
+    //
+    // A WIDER TIER WAS TRIED AND IS NOT HERE. NR=4 removes half of the activation traffic NR=2
+    // leaves behind, so it should have been the obvious next step -- measured, it is slower:
+    // 69.30 tok/s against 69.97 for NR=2 at the scored context, batched verify 12.517 ms against
+    // 12.378. xv[R][16] is R*16 floats live across the whole group loop whatever NR is, and
+    // widening the accumulator on top of that spills the very registers the tier exists to keep
+    // resident. The activation traffic is real but it is not what this kernel is short of.
     static const int nr = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_NR");
                               return (e && e[0] == '1') ? 1 : 2; }();
 #define SI_NVFP4_ROWS(S_, R_) do { \
         constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
-        if (nr == 2) { const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
-            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+        if (nr == 2 && xvec) { const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
+            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2, true><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+        else if (nr == 2) { const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
+            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2, false><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
         else { const dim3 grid((N + RPB - 1) / RPB); \
-            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 1, false><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
     } while (0)
 #define SI_NVFP4_ROWS_S(R_) do { \
         if (N >= 8192)      SI_NVFP4_ROWS(2, R_); \

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3172,7 +3172,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // hard bound that kept the batched verify away from long context entirely (the #712 gap); it
     // is now the boundary between "main's behaviour, unchanged" and "the new exact long-context
     // path", so nothing already validated at short context moves.
-    // Compared against keep_ema8 in the SCALED domain (kEngageKeep * 8), not by shifting the EMA
+    // Compared against the EMA in the SCALED domain (kEngageKeep * 8), not by shifting the EMA
     // down first. Shifting floors it, which collapses the very gap the gate exists to resolve:
     // 512-ctx sits at tau 2.19 (ema8 ~17.5) and 4k at tau 3.91 (ema8 ~31.3), and both floor to the
     // same value. Scaled, the threshold lands cleanly between them at 24.
@@ -3197,7 +3197,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 2;
         return v < 1 ? 1 : v;
     }();
-    // The engage threshold in EIGHTHS, which is the domain keep_ema8 already lives in, so it can
+    // The engage threshold in EIGHTHS, the domain the caller reasons about, so it can
     // express the number the trade actually turns on instead of rounding it to a whole token.
     //
     // One batched pass replaces `keep` sequential target forwards, so it pays exactly when
@@ -3209,10 +3209,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     //
     // 10/8 = 1.25, just above the measured 1.23, so the gate keeps a margin against the ratio
     // rather than sitting on it. It is self-limiting at short context, which is why this is not
-    // simply "always batch": at ctx=512 acceptance is 1.0, keep_ema8 settles at 8, and 8 < 10
-    // leaves the stream on the token loop exactly as today -- which matters, because the batched
-    // pass is measured 31% SLOWER there. SPARKINFER_DFLASH_ENGAGE_KEEP_EIGHTHS=16 restores main's
-    // whole-token threshold, so both arms of an A/B come out of one binary.
+    // simply "always batch": at ctx=512 acceptance is 1.0, the EMA settles at 1.0 tokens, which is
+    // below 1.25 and leaves the stream on the token loop -- which matters, because the batched
+    // pass is measured 31% SLOWER there. Since the EMA is held x64 it now settles there at ctx=4k
+    // too, where main's x8 form was pinned on the threshold by its own seed.
+    // SPARKINFER_DFLASH_ENGAGE_KEEP_EIGHTHS=16 restores main's whole-token threshold, so both arms
+    // of an A/B come out of one binary.
     static const int kEngageKeepEighths = []{
         const char* e = getenv("SPARKINFER_DFLASH_ENGAGE_KEEP_EIGHTHS");
         int v = e ? atoi(e) : 10;
@@ -3253,7 +3255,33 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 32;
         return v < 2 ? 2 : v;
     }();
-    int keep_ema8 = 0;   // EMA of keep, alpha = 1/8, held x8 so the decode path needs no float
+    // EMA of keep, alpha = 1/8. Held x64, not x8, and that factor is the whole point.
+    //
+    // AN INTEGER EMA HAS A DEAD BAND, AND THE SEED BELOW LANDED IN IT. The update was
+    // ema = ema - (ema >> 3) + keep, so ema is stationary whenever (ema >> 3) == keep, i.e. for
+    // EVERY ema in [8*keep, 8*keep+7] -- a band a full token wide. Held x8, the engage threshold
+    // (10 eighths) sits INSIDE the band for keep == 1: seed ema at 10, take keep == 1, and
+    // 10 - (10 >> 3) + 1 == 10 forever. The stream then never learns that acceptance is 1.0 and
+    // never hands itself back to the token loop, whatever the draft actually does.
+    //
+    // That is not hypothetical, it is the scored configuration. The seeding two screens down
+    // fires exactly when (start + B) >= kEngageMinSeq, so ctx=4096 starts pinned at 10 and stays
+    // there for the whole generation. The comment on kEngageKeepEighths reasons that "at ctx=512
+    // acceptance is 1.0, keep_ema8 settles at 8, and 8 < 10 leaves the stream on the token loop"
+    // -- true at 512 precisely BECAUSE 512 is below the floor and so is never seeded. Above the
+    // floor the same acceptance produced the opposite decision.
+    //
+    // Measured on RTX 5090 at ctx=4096 against the released DSpark draft, tau 1.0000 on both arms:
+    // the batched verify costs 12.771 ms/step against a 10.928 ms token-loop forward, so the gate
+    // armed the slower path on every one of 128 steps -- 68.09 tok/s where the token loop gives
+    // 77.90.
+    //
+    // x64 keeps alpha at 1/8 and shrinks the dead band from one token to an eighth of one:
+    // ema64 is stationary only on [64*keep - 7, 64*keep], so keep == 1 converges to 64 (= 1.0
+    // tokens, below the 80 the threshold now scales to) instead of parking on 80. Nothing about
+    // the POLICY moves -- same alpha, same threshold in eighths, same seeding, same floor. Only
+    // the resolution the policy is evaluated at.
+    int keep_ema64 = 0;
     int step_no = 0;
     bf16* th_scratch = nullptr;
     const int row_stride = dflash_hidden_row_stride();
@@ -3299,7 +3327,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // Below kCompactMaxSeq this is byte-identical to main: same acceptance-run rule, same
         // batched MoE. The change is purely additive above that bound, which main never reached.
         const bool short_ctx = (start + B) <= kCompactMaxSeq;
-        // keep_ema8 ramps from zero at alpha = 1/8, so it needs 8-10 steps to reach the engage
+        // The EMA ramps from zero at alpha = 1/8, so it needs 8-10 steps to reach the engage
         // threshold even on a stream that clears it comfortably. Measured at 4k (tau 3.91, ema8
         // settles at ~31 against a threshold of 24): the batched path ran on 20 of 33 steps, and
         // the 13 it missed were the warmup, not a genuine low-acceptance stretch -- worth 6.3% of
@@ -3310,11 +3338,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // seeding is scoped to sequences past the floor: start armed there, and let the existing
         // decay hand the stream back to the token loop within a couple of steps if the draft turns
         // out not to be landing blocks. Below the floor the ramp is untouched.
-        if (step_no == 0 && (start + B) >= kEngageMinSeq) keep_ema8 = kEngageKeepEighths;
+        if (step_no == 0 && (start + B) >= kEngageMinSeq)
+            keep_ema64 = kEngageKeepEighths * 8;
         const bool compact_verify = compact_mode == 1 ||
             (compact_mode != 0 && (short_ctx ? compact_score >= kBlockScore
                                              : ((start + B) >= kEngageMinSeq &&
-                                                keep_ema8 >= kEngageKeepEighths)));
+                                                keep_ema64 >= kEngageKeepEighths * 8)));
         if (compact_verify) disarmed_run = 0; else ++disarmed_run;
         // Skip the draft only after kDraftProbeAfter consecutive disarmed steps, and let every
         // kDraftProbePeriod-th step through as a probe.
@@ -3480,7 +3509,11 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
                 fprintf(stderr, "%d ", (compact_verify || i <= accept) ? posterior[i] : -1);
             fprintf(stderr, "]\n");
         }
-        keep_ema8 = keep_ema8 - (keep_ema8 >> 3) + keep;
+        // ema += (target - ema) / 8, with the target held in the same x64 domain. Written as a
+        // signed difference rather than main's decay-then-add so the step is driven by the error:
+        // the shift then rounds toward the target from both sides and the only stationary states
+        // are the eighth-token band around it, instead of a token-wide band the seed can sit in.
+        keep_ema64 += (keep * 64 - keep_ema64) >> 3;
         ++step_no;
         compact_score = keep == kProposalDepth + 1
                       ? std::min(compact_score + 1, kBlockScore + 1)


### PR DESCRIPTION
## Summary

The batched-verify gate compares an integer EMA of `keep` against a threshold in eighths of a token. Held x8, that EMA has a dead band **a full token wide** — `ema - (ema >> 3) + keep` is stationary for every `ema` in `[8*keep, 8*keep+7]` — and the engage threshold (10 eighths) sits *inside* that band for `keep == 1`. `dflash_generate` seeds the EMA at exactly that threshold whenever the sequence clears `kEngageMinSeq`, so at ctx >= 1024 `10 - (10 >> 3) + 1 == 10` forever: the stream never learns acceptance is 1.0 and never hands itself back to the token loop.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

Pristine `origin/main` @ `30ddb88` and the PR built into **separate trees** and run alternately on the same box, same prompt (`bench_prompt_4k.txt`, first 4096 ids), same model pair (`Qwen3.8-27B-NVFP4-RTX5090` + released DSpark draft).

**Decode tok/s** (`dspark-decode@4k`, the scored dimension — mean of 3 alternating pairs):

| | decode tok/s |
|---|--:|
| before (main) | 67.109 |
| after (this PR) | **76.684** |

**1.143x.** Per-pair: 67.1705/76.7071, 67.0530/76.6694, 67.1026/76.6752 — spread under 0.2%.

Guards, all measured in the same runs:

| gate | before | after | bar |
|---|--:|--:|---|
| AR no-regression | 91.77 | 91.60 | >= 0.98x — **0.998x** |
| acceptance (tau) | 1.0000 | 1.0000 | >= 0.95x — **1.000x** |
| losslessness | yes | **yes, 3/3 repeats** | exact token equality |
| `ctest` | 19/19 | 19/19 | all pass |

Note on tau: this box measures tau = 1.0000 at ctx=4096, consistent with the range the bot's own `SCOPE` block records ("at the current tau of ~1.0-1.1 full blocks essentially never happen"). The size of this delta is a function of measured acceptance by construction — that is the point of the gate. Below 1.25 accepted tokens the batched pass cannot pay for itself and the fix hands the stream back to the token loop; at or above 1.25 the gate arms exactly as it does today and this change is inert.

```text
# BEFORE — origin/main @ 30ddb88, SPARKINFER_DSPARK_SPEC_REPS=3
[timing] draft      2.126 ms/call  n=128
[timing] fwd_tok    0.000 ms/call  n=0  (token-loop verify)
[timing] batched   12.789 ms/call  n=128  = 0.00 forwards
SPEC-REPS 3 reps, 0 differ-from-first, 0 not-lossless-vs-AR
DSPARK tau=1.000  steps=128  tokens=128  decode_s=1.909
DSPARK lossless=YES  matched 128/128  (+2 repeats, 0 failed)
AR     91.54 tok/s  (decode 1.398s, ttft 42.074s)
METRIC AR_TPS 91.5401
METRIC DSPARK_TPS 67.0482
METRIC MEAN_ACCEPT 1.0000
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 3

# AFTER — this PR, SPARKINFER_DSPARK_SPEC_REPS=3
[timing] draft      2.103 ms/call  n=128
[timing] fwd_tok   10.931 ms/call  n=127  (token-loop verify)
[timing] batched   12.434 ms/call  n=1  = 1.14 forwards
SPEC-REPS 3 reps, 0 differ-from-first, 0 not-lossless-vs-AR
DSPARK tau=1.000  steps=128  tokens=128  decode_s=1.671
DSPARK lossless=YES  matched 128/128  (+2 repeats, 0 failed)
AR     91.54 tok/s  (decode 1.398s, ttft 42.074s)
METRIC AR_TPS 91.5398
METRIC DSPARK_TPS 76.6129
METRIC MEAN_ACCEPT 1.0000
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 3
```