### PR TITLE
perf(dspark): dp4a NVFP4 verify GEMV, and a second proposal now that the extra row is cheap

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -600,8 +600,23 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
     if (global_scale_dev) global_scale = *global_scale_dev;
     const float inv_gs = (ALU >= CT_ALU_RCP) ? (1.f / global_scale) : 0.f;
     const int ngroups = cols >> 4;
-    const int r = blockIdx.y;
-    if (r >= rows) return;
+    // GRID-STRIDE OVER ROWS. This was `const int r = blockIdx.y; if (r >= rows) return;`, which
+    // silently caps the kernel at 65535 rows -- CUDA's limit on gridDim.y. Every weight in the
+    // model clears that (the widest is the FFN gate/up at 17408) except ONE: lm_head, whose row
+    // count is the vocabulary. At V=248320 the launch is rejected with
+    // cudaErrorInvalidConfiguration, and because neither this launch nor the cudaStreamSynchronize
+    // after it is error-checked, the failure is silent -- the freshly cudaMalloc'd destination is
+    // simply never written, so the head dequantizes to all zeros.
+    //
+    // The symptom is a model that loads clean and produces uniform logits: every vocabulary entry
+    // scores identically, PPL comes out at exactly the vocab size, and argmax returns token 0 for
+    // any prompt. Everything upstream is healthy -- the final-norm output feeding the head measures
+    // l2=136.7 -- which is what makes it hard to see. It reaches DSpark as tau pinned at exactly
+    // 1.0000, i.e. a draft that never lands a proposal.
+    //
+    // Only the g16 fast path had this; the per-element fallback below already uses a 1-D grid over
+    // rows*cols, so SPARKINFER_CT_NVFP4_G16=0 was an accidental workaround.
+    for (int r = blockIdx.y; r < rows; r += gridDim.y) {
     const unsigned char* prow = packed + (size_t)r * (size_t)(cols >> 1);
     const unsigned char* srow = group_scale + (size_t)r * (size_t)ngroups;
     __nv_bfloat16* orow = out + (size_t)r * (size_t)cols;
@@ -624,6 +639,7 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
         }
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16)     = *reinterpret_cast<const uint4*>(o);
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16 + 8) = *reinterpret_cast<const uint4*>(o + 8);
+    }
     }
 }
 
@@ -752,7 +768,9 @@ static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_sca
         const int ngroups = cols >> 4;
         const int threads = 256;
         const int bx = (ngroups + threads - 1) / threads;
-        const dim3 grid(bx > 0 ? bx : 1, rows);
+        // gridDim.y maxes out at 65535; rows beyond that are covered by the kernel's row stride.
+        const int gy = rows > 65535 ? 65535 : rows;
+        const dim3 grid(bx > 0 ? bx : 1, gy);
         auto* pk = reinterpret_cast<const unsigned char*>(packed_u8);
         auto* gsc = reinterpret_cast<const unsigned char*>(group_scale_ue4m3);
         auto* ob = reinterpret_cast<__nv_bfloat16*>(out_bf16);

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -15,6 +15,7 @@
 #endif
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
 #include <cuda_runtime.h>
+#include <cstdint>
 #endif
 
 namespace sparkinfer {
@@ -619,6 +620,7 @@ __device__ __forceinline__ float si_ue4m3(unsigned b) {
     if (e == 0) return (float)m * (1.f / 512.f);          // 2^-9, exact
     return __int_as_float((int)(((e + 120u) << 23) | (m << 20)));
 }
+template <bool XVEC = false>
 __device__ __forceinline__ float si_nvfp4_group_dot(const unsigned char* packed8,
                                                     unsigned char scale, float inv_g,
                                                     const __nv_bfloat16* x16) {
@@ -637,7 +639,25 @@ __device__ __forceinline__ float si_nvfp4_group_dot(const unsigned char* packed8
     // general. The warp reads the same 256 contiguous bytes either way.
     const unsigned int p0 = __ldg(reinterpret_cast<const unsigned int*>(packed8));
     const unsigned int p1 = __ldg(reinterpret_cast<const unsigned int*>(packed8 + 4));
-    const __nv_bfloat162* x2 = reinterpret_cast<const __nv_bfloat162*>(x16);
+    // XVEC: the group's 16 activations are 32 contiguous bytes, so fetch them as two 128-bit
+    // loads instead of eight 32-bit ones. The address is x + g*16 with g a runtime value, so the
+    // compiler cannot prove the alignment itself and emits the eight; launch_gemv_nvfp4 checks the
+    // base pointer once and only selects this instantiation when it holds (K is already required
+    // to be a multiple of 16, so a 16-byte-aligned base leaves every group aligned).
+    //
+    // Bit-identical, and that is load bearing on exactly this function: the scale stays folded per
+    // term, every conversion runs on the same halves in the same order, and `acc` accumulates the
+    // same sequence. Only the load width moves -- unlike the hoist the comment above rejects,
+    // which changed the arithmetic.
+    __nv_bfloat162 xb[8];
+    if (XVEC) {
+        int4 v[2];
+        v[0] = __ldg(reinterpret_cast<const int4*>(x16));
+        v[1] = __ldg(reinterpret_cast<const int4*>(x16) + 1);
+        #pragma unroll
+        for (int i = 0; i < 8; i++) xb[i] = reinterpret_cast<const __nv_bfloat162*>(v)[i];
+    }
+    const __nv_bfloat162* x2 = XVEC ? xb : reinterpret_cast<const __nv_bfloat162*>(x16);
     float acc = 0.f;
     #pragma unroll
     for (int i = 0; i < 4; i++) {
@@ -749,6 +769,45 @@ __device__ __forceinline__ void si_nvfp4_load_x16(const __nv_bfloat16* x16, floa
     }
 }
 
+// Same 16 activations, same conversions, same destination lanes -- fetched as two 128-bit loads
+// instead of eight 32-bit ones.
+//
+// A group is 16 bf16 = 32 contiguous bytes, but nothing in the scalar form above tells the
+// compiler that: the address is x + r*K + g*16 with K and g both runtime values, so it cannot
+// prove 16-byte alignment and emits eight 32-bit loads. On this kernel that is the dominant
+// instruction stream -- the activations are re-read for every output row a warp owns, which is
+// what the 3.41 GB L1 against 29.5 MB DRAM ratio recorded below is made of -- so what the x side
+// costs is the load COUNT, not the byte count. Two 128-bit loads carry the same 32 bytes in a
+// quarter of the issue slots.
+//
+// Alignment is a precondition, not an assumption: launch_gemv_nvfp4_rows checks the base pointer
+// once and selects an XVEC instantiation only when it holds. Every row starts at x + r*K and K is
+// a multiple of 16 (the launcher rejects anything else), so a 16-byte-aligned base leaves every
+// row and every group 16-byte aligned too.
+//
+// Bit-identical: __bfloat1622float2 runs over the same halves in the same order and writes the
+// same lanes of xv, so si_nvfp4_dot16 folds an identical term sequence. Only the load width moves.
+__device__ __forceinline__ void si_nvfp4_load_x16_vec(const __nv_bfloat16* x16,
+                                                      float* __restrict__ xv) {
+    int4 v[2];
+    v[0] = __ldg(reinterpret_cast<const int4*>(x16));
+    v[1] = __ldg(reinterpret_cast<const int4*>(x16) + 1);
+    const __nv_bfloat162* x2 = reinterpret_cast<const __nv_bfloat162*>(v);
+    #pragma unroll
+    for (int i = 0; i < 8; i++) {
+        const float2 xf = __bfloat1622float2(x2[i]);
+        xv[2 * i] = xf.x;
+        xv[2 * i + 1] = xf.y;
+    }
+}
+
+template <bool XVEC>
+__device__ __forceinline__ void si_nvfp4_load_x16_sel(const __nv_bfloat16* x16,
+                                                      float* __restrict__ xv) {
+    if (XVEC) si_nvfp4_load_x16_vec(x16, xv);
+    else      si_nvfp4_load_x16(x16, xv);
+}
+
 __device__ __forceinline__ float si_nvfp4_dot16(const float* __restrict__ ws,
                                                 const float* __restrict__ xv) {
     float acc = 0.f;
@@ -760,7 +819,8 @@ __device__ __forceinline__ float si_nvfp4_dot16(const float* __restrict__ ws,
     return acc;
 }
 
-template <typename OutT, int S>
+
+template <typename OutT, int S, bool XVEC>
 __global__ void gemv_nvfp4_sk_kernel(const __nv_bfloat16* __restrict__ x,
                                      const void* __restrict__ packed,
                                      OutT* __restrict__ y, int N, int K) {
@@ -778,7 +838,7 @@ __global__ void gemv_nvfp4_sk_kernel(const __nv_bfloat16* __restrict__ x,
         const unsigned char* prow = w + (size_t)n * (size_t)(K >> 1);
         const int ng = K >> 4;
         for (int g = split * 32 + lane; g < ng; g += S * 32)
-            acc += si_nvfp4_group_dot(prow + (size_t)g * 8, srow[g], inv_g, x + g * 16);
+            acc += si_nvfp4_group_dot<XVEC>(prow + (size_t)g * 8, srow[g], inv_g, x + g * 16);
         #pragma unroll
         for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffff, acc, m);
         if (lane == 0) s_part[row_local][split] = acc;
@@ -792,9 +852,184 @@ __global__ void gemv_nvfp4_sk_kernel(const __nv_bfloat16* __restrict__ x,
     }
 }
 #ifndef _MSC_VER
-template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 2>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
-template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 4>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
-template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 2, false>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 4, false>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8, false>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 2, true>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 4, true>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8, true>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+#endif
+
+// ---------------------------------------------------------------------------------------------
+// dp4a form of the row-batched NVFP4 GEMV.
+//
+// WHY. The row-batched verify reads its weights once for all R rows, so rows 2..R should be nearly
+// free. Measured on the Q4_K FFN on this exact path they are: gate_up goes 3.956 -> 4.184 ms from
+// R=1 to R=2, +2.4%. The NVFP4 projections on the same path go 3.264 -> 4.319 ms, +32% -- thirteen
+// times the row scaling for the same weights-read-once structure. That gap is the single largest
+// item in the second verify row (+1.055 ms of +1.61 ms) and it is not bandwidth: the extra FFMA is
+// 6.7x under roofline and the extra loads are ~0.01 ms.
+//
+// The difference is arithmetic form. Q4_K quantizes the activation to int8 ONCE and spends four
+// MACs per dp4a; NVFP4 decodes to fp32 and issues sixteen scalar FFMA per group PER ROW, holding
+// xv[R][16] + ws[16] live across the inner loop. That register and issue pressure is what four
+// separate micro-optimisations (NR=4, half-group, split-K resizing, wider loads) failed to move.
+//
+// WHAT MAKES IT POSSIBLE. The weights do NOT get requantized -- that is the thing this file warns
+// against, because a second 4-bit grid lands between the first one's points. NVFP4's decoded
+// magnitudes are {0,1,2,3,4,6,8,12} with a sign bit, i.e. already exact int8, so the weight side is
+// carried through dp4a bit-for-bit. Only the ACTIVATION is quantized, to int8 per 16-element group
+// -- exactly what Q4_K decode already does for every FFN in this model.
+//
+// NOT bit-identical, and that is the whole risk: the activation rounding is new. It is scoped to
+// the batched verify (the AR path keeps the fp32 one-row kernel), and it is checked against the
+// differential accuracy gate rather than assumed. SPARKINFER_NVFP4_ROWS_DP4A=0 restores fp32.
+__device__ __forceinline__ int si_e2m1_i8(unsigned nibble) {
+    const unsigned n = nibble & 15u;
+    const int mag = (int)((0xC8643210u >> ((n & 7u) << 2)) & 15u);
+    return (n & 8u) ? -mag : mag;   // exact: |value*2| in {0,1,2,3,4,6,8,12}
+}
+
+// 16 packed nibbles -> four int32 words of int8 lanes, in the element order si_nvfp4_group_dot
+// walks (elements 0..7 from the low word, 8..15 from the high one; within a byte, low nibble first).
+__device__ __forceinline__ void si_nvfp4_unpack_i8(const unsigned char* __restrict__ packed8,
+                                                   int* __restrict__ ww) {
+    const unsigned p[2] = { __ldg(reinterpret_cast<const unsigned*>(packed8)),
+                            __ldg(reinterpret_cast<const unsigned*>(packed8 + 4)) };
+    #pragma unroll
+    for (int h = 0; h < 2; h++) {
+        #pragma unroll
+        for (int q = 0; q < 2; q++) {
+            const unsigned b0 = (p[h] >> (16 * q)) & 255u;
+            const unsigned b1 = (p[h] >> (16 * q + 8)) & 255u;
+            const int e0 = si_e2m1_i8(b0 & 15u), e1 = si_e2m1_i8(b0 >> 4);
+            const int e2 = si_e2m1_i8(b1 & 15u), e3 = si_e2m1_i8(b1 >> 4);
+            ww[h * 2 + q] = (e0 & 255) | ((e1 & 255) << 8) | ((e2 & 255) << 16) | ((e3 & 255) << 24);
+        }
+    }
+}
+
+// Per-16 int8 quantization of R activation rows, matching NVFP4's own group size so one group's
+// dot needs exactly one scale multiply.
+// STATIC device scratch, not cudaMalloc. The batched verify is captured into a CUDA graph, and
+// cudaMalloc is illegal while a stream is capturing -- doing it here aborts the capture and leaves
+// an empty graph, which replays in 0.17 ms and produces nothing. A __device__ array needs no host
+// allocation and is addressable from the kernel directly, so the whole path is capture-safe.
+// Sized for the widest verify this kernel accepts: R<=4 rows of K<=32768. 128 KB + 32 KB.
+#define SI_NVFP4_DP4A_MAXR 4
+#define SI_NVFP4_DP4A_MAXK 32768
+__device__ signed char si_nvfp4_dp4a_xq[SI_NVFP4_DP4A_MAXR * SI_NVFP4_DP4A_MAXK];
+__device__ float si_nvfp4_dp4a_xs[SI_NVFP4_DP4A_MAXR * (SI_NVFP4_DP4A_MAXK / 16)];
+
+__global__ void nvfp4_quant_x_rows_kernel(const __nv_bfloat16* __restrict__ x,
+                                          int R, int K) {
+    signed char* __restrict__ xq = si_nvfp4_dp4a_xq;
+    float* __restrict__ xs = si_nvfp4_dp4a_xs;
+    const int ng = K >> 4;
+    const int g = blockIdx.x * blockDim.x + threadIdx.x;
+    const int r = blockIdx.y;
+    if (g >= ng || r >= R) return;
+    const __nv_bfloat16* src = x + (size_t)r * K + (size_t)g * 16;
+    float v[16];
+    float amax = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 16; i++) { v[i] = __bfloat162float(src[i]); amax = fmaxf(amax, fabsf(v[i])); }
+    const float sc = amax * (1.f / 127.f);
+    const float inv = (sc > 0.f) ? (1.f / sc) : 0.f;
+    xs[(size_t)r * ng + g] = sc;
+    signed char* dst = xq + (size_t)r * K + (size_t)g * 16;
+    #pragma unroll
+    for (int i = 0; i < 16; i++) dst[i] = (signed char)__float2int_rn(v[i] * inv);
+}
+
+template <typename OutT, int S, int R, int NR>
+__global__ void gemv_nvfp4_rows_dp4a_kernel(const void* __restrict__ packed,
+                                            OutT* __restrict__ y, int N, int K) {
+    const signed char* __restrict__ xq = si_nvfp4_dp4a_xq;
+    const float* __restrict__ xs = si_nvfp4_dp4a_xs;
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float s_part[RPB][S][NR][R];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n0 = blockIdx.x * (RPB * NR) + row_local * NR;
+    float acc[NR][R];
+    #pragma unroll
+    for (int j = 0; j < NR; j++)
+        #pragma unroll
+        for (int r = 0; r < R; r++) acc[j][r] = 0.f;
+    if (n0 < N) {
+        const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
+        const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
+        const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+        const int ng = K >> 4;
+        for (int g = split * 32 + lane; g < ng; g += S * 32) {
+            // The group's activations: 16 int8 per row, one 128-bit load, four dp4a operands.
+            int xw[R][4];
+            float xsc[R];
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                const int4 v = __ldg(reinterpret_cast<const int4*>(xq + (size_t)r * K + (size_t)g * 16));
+                xw[r][0] = v.x; xw[r][1] = v.y; xw[r][2] = v.z; xw[r][3] = v.w;
+                xsc[r] = __ldg(xs + (size_t)r * ng + g);
+            }
+            #pragma unroll
+            for (int j = 0; j < NR; j++) {
+                const int nj = n0 + j;
+                if (NR > 1 && nj >= N) break;
+                const unsigned char* srow = sf + (size_t)nj * (size_t)(K >> 4);
+                const unsigned char* prow = w + (size_t)nj * (size_t)(K >> 1);
+                int ww[4];
+                si_nvfp4_unpack_i8(prow + (size_t)g * 8, ww);
+                // si_e2m1_i8 carries twice the weight, so the 0.5 folds into the group scale --
+                // the same identity si_nvfp4_group_dot uses.
+                const float gs = si_ue4m3(srow[g]) * inv_g * 0.5f;
+                #pragma unroll
+                for (int r = 0; r < R; r++) {
+                    int d = 0;
+                    #pragma unroll
+                    for (int t = 0; t < 4; t++) d = __dp4a(ww[t], xw[r][t], d);
+                    acc[j][r] += (float)d * gs * xsc[r];
+                }
+            }
+        }
+        #pragma unroll
+        for (int j = 0; j < NR; j++)
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                #pragma unroll
+                for (int m = 16; m > 0; m >>= 1)
+                    acc[j][r] += __shfl_xor_sync(0xffffffff, acc[j][r], m);
+            }
+        if (lane == 0) {
+            #pragma unroll
+            for (int j = 0; j < NR; j++)
+                #pragma unroll
+                for (int r = 0; r < R; r++) s_part[row_local][split][j][r] = acc[j][r];
+        }
+    }
+    __syncthreads();
+    if (n0 < N && split == 0 && lane == 0) {
+        #pragma unroll
+        for (int j = 0; j < NR; j++) {
+            const int nj = n0 + j;
+            if (NR > 1 && nj >= N) break;
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                float o = s_part[row_local][0][j][r];
+                #pragma unroll
+                for (int t = 1; t < S; t++) o += s_part[row_local][t][j][r];
+                gemv_write(y + (size_t)r * N + nj, o);
+            }
+        }
+    }
+}
+#ifndef _MSC_VER
+#define SI_NVFP4_DP4A_INST(S_, R_) \
+template __global__ void gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S_, R_, 2>(const void*, __nv_bfloat16*, int, int);
+SI_NVFP4_DP4A_INST(2, 2) SI_NVFP4_DP4A_INST(4, 2) SI_NVFP4_DP4A_INST(8, 2)
+SI_NVFP4_DP4A_INST(2, 3) SI_NVFP4_DP4A_INST(4, 3) SI_NVFP4_DP4A_INST(8, 3)
+SI_NVFP4_DP4A_INST(2, 4) SI_NVFP4_DP4A_INST(4, 4) SI_NVFP4_DP4A_INST(8, 4)
+#undef SI_NVFP4_DP4A_INST
 #endif
 
 // Row-batched form of gemv_nvfp4_sk_kernel: R activation rows against ONE weight stream.
@@ -811,7 +1046,7 @@ template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloa
 // stride), accumulates into its own float, and folds its splits in the same ascending order. Only
 // the weight and scale loads are shared between rows -- the arithmetic per row is untouched, which
 // is what keeps the speculative path lossless by construction rather than by measurement.
-template <typename OutT, int S, int R, int NR>
+template <typename OutT, int S, int R, int NR, bool XVEC>
 __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
                                           const void* __restrict__ packed,
                                           OutT* __restrict__ y, int N, int K) {
@@ -830,6 +1065,9 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
     //
     // Bit-identical: each (n, r) dot still walks the same groups in the same order and folds the
     // same S partials. Only which warp owns which output row changes. NR=1 is the original.
+    //
+    // XVEC selects 128-bit activation loads (si_nvfp4_load_x16_vec). It is orthogonal to NR: NR
+    // decides how OFTEN x is re-read, XVEC how many instructions each read costs.
     const int n0 = blockIdx.x * (RPB * NR) + row_local * NR;
     float acc[NR][R];
     #pragma unroll
@@ -846,7 +1084,7 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
             float xv[R][16];
             #pragma unroll
             for (int r = 0; r < R; r++)
-                si_nvfp4_load_x16(x + (size_t)r * K + (size_t)g * 16, xv[r]);
+                si_nvfp4_load_x16_sel<XVEC>(x + (size_t)r * K + (size_t)g * 16, xv[r]);
             #pragma unroll
             for (int j = 0; j < NR; j++) {
                 const int nj = n0 + j;
@@ -892,8 +1130,9 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
 }
 #ifndef _MSC_VER
 #define SI_NVFP4_ROWS_INST(S_, R_) \
-template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
-template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1, false>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2, false>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2, true>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
 SI_NVFP4_ROWS_INST(2, 2) SI_NVFP4_ROWS_INST(4, 2) SI_NVFP4_ROWS_INST(8, 2)
 SI_NVFP4_ROWS_INST(2, 4) SI_NVFP4_ROWS_INST(4, 4) SI_NVFP4_ROWS_INST(8, 4)
 SI_NVFP4_ROWS_INST(2, 6) SI_NVFP4_ROWS_INST(4, 6) SI_NVFP4_ROWS_INST(8, 6)
@@ -2504,16 +2743,24 @@ void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K, cuda
     const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
     auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
     if (gemv_bf16_splitk()) {
-        if (N >= 8192) {
-            constexpr int S = 2, RPB = GEMV_WPB / S;
-            gemv_nvfp4_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
-        } else if (N >= 4096) {
-            constexpr int S = 4, RPB = GEMV_WPB / S;
-            gemv_nvfp4_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
-        } else {
-            constexpr int S = 8, RPB = GEMV_WPB / S;
-            gemv_nvfp4_sk_kernel<__nv_bfloat16, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
-        }
+        // Same activation-load widening as the row-batched form, and it matters MORE here: with
+        // the engage gate resolving acceptance properly, ctx=4k runs the token loop, so this
+        // one-row kernel is the NVFP4 path the scored decode actually executes -- 3.26 ms/step
+        // across the GDN and attention projections, against 0.42 ms for the whole LM head.
+        // SPARKINFER_NVFP4_XVEC=0 restores the scalar loads.
+        static const bool xvec_off = []{ const char* e = getenv("SPARKINFER_NVFP4_XVEC");
+                                         return e && e[0] == '0'; }();
+        const bool xv = !xvec_off && ((reinterpret_cast<size_t>(xp) & 15u) == 0);
+#define SI_NVFP4_1ROW(S_) do { \
+            constexpr int S = (S_), RPB = GEMV_WPB / S; \
+            const dim3 grid((N + RPB - 1) / RPB); \
+            if (xv) gemv_nvfp4_sk_kernel<__nv_bfloat16, S, true><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); \
+            else    gemv_nvfp4_sk_kernel<__nv_bfloat16, S, false><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); \
+        } while (0)
+        if (N >= 8192)      SI_NVFP4_1ROW(2);
+        else if (N >= 4096) SI_NVFP4_1ROW(4);
+        else                SI_NVFP4_1ROW(8);
+#undef SI_NVFP4_1ROW
         return;
     }
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
@@ -2532,16 +2779,66 @@ bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N,
     if (M < 2 || M > 8) return false;
     const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
     auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
-    // SPARKINFER_NVFP4_ROWS_NR=1 gives one output row per warp, i.e. main's kernel exactly, so both
-    // arms of an A/B come out of one binary.
+    // 128-bit activation loads, when the caller's buffer allows them. K is already known to be a
+    // multiple of 16 (rejected above otherwise), so every row base x + r*K sits a whole number of
+    // 32-byte groups from the base -- one check on the base therefore covers every row and every
+    // group. A caller that hands over an odd offset simply gets the scalar loads it gets today.
+    // SPARKINFER_NVFP4_ROWS_XVEC=0 forces the scalar loads back on, so "main's kernel" is one env
+    // away in the same binary rather than a second build.
+    static const bool xvec_off = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_XVEC");
+                                     return e && e[0] == '0'; }();
+    const bool xvec = !xvec_off && ((reinterpret_cast<size_t>(xp) & 15u) == 0);
+    // dp4a path (default ON for R<=4, which covers every proposal depth the verify runs). See the
+    // kernel above for why: the fp32 form's per-row cost is what makes the second verify row 13x
+    // more expensive than the same row on the Q4_K FFN.
+    static const bool dp4a_off = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_DP4A");
+                                     return e && e[0] == '0'; }();
+    const bool dp4a_ok = (!dp4a_off && M >= 2 && M <= SI_NVFP4_DP4A_MAXR &&
+                          K <= SI_NVFP4_DP4A_MAXK && (K & 15) == 0);
+    if (dp4a_ok) {
+        {
+            const int ng = K >> 4;
+            const int qt = 256;
+            nvfp4_quant_x_rows_kernel<<<dim3((ng + qt - 1) / qt, M), qt, 0, stream>>>(xp, M, K);
+#define SI_NVFP4_DP4A(S_, R_) do { \
+                constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
+                const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
+                gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(W, yp, N, K); \
+            } while (0)
+#define SI_NVFP4_DP4A_S(R_) do { \
+                if (N >= 8192)      SI_NVFP4_DP4A(2, R_); \
+                else if (N >= 4096) SI_NVFP4_DP4A(4, R_); \
+                else                SI_NVFP4_DP4A(8, R_); \
+            } while (0)
+            switch (M) {
+                case 2: SI_NVFP4_DP4A_S(2); break;
+                case 3: SI_NVFP4_DP4A_S(3); break;
+                default: SI_NVFP4_DP4A_S(4); break;
+            }
+#undef SI_NVFP4_DP4A_S
+#undef SI_NVFP4_DP4A
+            return true;
+        }
+    }
+    // SPARKINFER_NVFP4_ROWS_NR=1 gives one output row per warp, i.e. main's pre-#891 kernel, so
+    // both arms of an A/B come out of one binary.
+    //
+    // A WIDER TIER WAS TRIED AND IS NOT HERE. NR=4 removes half of the activation traffic NR=2
+    // leaves behind, so it should have been the obvious next step -- measured, it is slower:
+    // 69.30 tok/s against 69.97 for NR=2 at the scored context, batched verify 12.517 ms against
+    // 12.378. xv[R][16] is R*16 floats live across the whole group loop whatever NR is, and
+    // widening the accumulator on top of that spills the very registers the tier exists to keep
+    // resident. The activation traffic is real but it is not what this kernel is short of.
     static const int nr = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_NR");
                               return (e && e[0] == '1') ? 1 : 2; }();
 #define SI_NVFP4_ROWS(S_, R_) do { \
         constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
-        if (nr == 2) { const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
-            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+        if (nr == 2 && xvec) { const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
+            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2, true><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+        else if (nr == 2) { const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
+            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2, false><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
         else { const dim3 grid((N + RPB - 1) / RPB); \
-            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 1, false><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
     } while (0)
 #define SI_NVFP4_ROWS_S(R_) do { \
         if (N >= 8192)      SI_NVFP4_ROWS(2, R_); \

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -310,6 +310,23 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
 // serial chain shortens and the grid grows with context. Per-split partial (m, l, acc)
 // states are merged by k_attn_split_combine, which is the same online-softmax merge the
 // in-CTA warp reduction already does -- exact for any split count.
+// One 64-bit load for the four contiguous bf16 a lane owns, instead of four 16-bit ones.
+//
+// D=128 with 32 lanes gives E=4, and lane L owns elements [4L, 4L+4) -- 8 contiguous bytes. The
+// warp's 32 lanes therefore cover 256 contiguous bytes and the access is already coalesced; what
+// it is not is CHEAP, because each element is its own load instruction and the q/k/v triple sits
+// in the innermost loop over the whole KV range. Four 16-bit loads become one 64-bit load.
+//
+// Bit-identical: b2f runs on the same four halves in the same order into the same registers.
+// The element offset is always a multiple of E=4, so the address is 8-byte aligned whenever the
+// cache base is, which cudaMalloc guarantees.
+__device__ __forceinline__ void df_load4_bf16(const bf16* __restrict__ p, float* __restrict__ out) {
+    const int2 packed = __ldg(reinterpret_cast<const int2*>(p));
+    const bf16* c = reinterpret_cast<const bf16*>(&packed);
+#pragma unroll
+    for (int e = 0; e < 4; e++) out[e] = b2f(c[e]);
+}
+
 template <int ROWS, int NWARPS>
 __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
     const bf16* __restrict__ q, const bf16* __restrict__ k, const bf16* __restrict__ v,
@@ -329,7 +346,12 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
         const int qt = qt0 + r;
         const bf16* qv = q + ((size_t)qt * n_q + qh) * D + base;
 #pragma unroll
-        for (int e = 0; e < E; e++) { qr[r][e] = (qt < q_len) ? b2f(qv[e]) : 0.f; acc[r][e] = 0.f; }
+        if (qt < q_len && E == 4) df_load4_bf16(qv, qr[r]);
+        else
+#pragma unroll
+            for (int e = 0; e < E; e++) qr[r][e] = (qt < q_len) ? b2f(qv[e]) : 0.f;
+#pragma unroll
+        for (int e = 0; e < E; e++) acc[r][e] = 0.f;
         max_s[r] = -1e30f;
         sum[r] = 0.f;
     }
@@ -345,8 +367,10 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
         const int k_pos = k_pos0 + t;
         const bf16* kp = k + ((size_t)t * n_kv + kv_h) * D + base;
         float kreg[E];
+        if (E == 4) df_load4_bf16(kp, kreg);
+        else
 #pragma unroll
-        for (int e = 0; e < E; e++) kreg[e] = b2f(kp[e]);
+            for (int e = 0; e < E; e++) kreg[e] = b2f(kp[e]);
         float dots[ROWS];
 #pragma unroll
         for (int r = 0; r < ROWS; r++) {
@@ -370,8 +394,10 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
             if (window > 0 && (q_pos - k_pos) >= window) continue;
             if (!vloaded) {
                 const bf16* vp = v + ((size_t)t * n_kv + kv_h) * D + base;
+                if (E == 4) df_load4_bf16(vp, vreg);
+                else
 #pragma unroll
-                for (int e = 0; e < E; e++) vreg[e] = b2f(vp[e]);
+                    for (int e = 0; e < E; e++) vreg[e] = b2f(vp[e]);
                 vloaded = true;
             }
             const float score = __shfl_sync(0xffffffffu, dots[r], 0) * scale;
@@ -1561,7 +1587,21 @@ __global__ void k_markov_bias_add(const bf16* __restrict__ w1, const bf16* __res
     if (v >= vocab) return;
     const bf16* w2_row = w2 + (size_t)v * rank;
     float acc = 0.f;
-    for (int r = 0; r < rank; r++) acc += latent[r] * b2f(w2_row[r]);
+    // Eight contiguous bf16 per load instead of one. This row is `rank` long and every thread
+    // walks its own, so the loop is 256 dependent 16-bit loads per vocab entry -- the kernel
+    // streams 127 MB of w2 per call at roughly half the bandwidth it should. Rows are rank*2
+    // bytes apart, so a 16-byte load stays aligned whenever rank is a multiple of 8; the scalar
+    // tail below covers any other rank. Bit-identical: same terms, same order, same running sum.
+    int r = 0;
+    if ((rank & 7) == 0 && ((reinterpret_cast<size_t>(w2_row) & 15u) == 0)) {
+        for (; r + 8 <= rank; r += 8) {
+            const int4 packed = __ldg(reinterpret_cast<const int4*>(w2_row + r));
+            const bf16* c = reinterpret_cast<const bf16*>(&packed);
+#pragma unroll
+            for (int j = 0; j < 8; j++) acc += latent[r + j] * b2f(c[j]);
+        }
+    }
+    for (; r < rank; r++) acc += latent[r] * b2f(w2_row[r]);
     logits[v] += acc;
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3150,9 +3150,30 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // than per step, because the verify graph dflash_warm_verify captures is sized from this and
     // a graph built for a row count the stream never uses costs more than the rows it saves --
     // measured, per-step narrowing under a 4-row warm graph recovers only 0.7% of the 9.4%.
+    // TWO proposals in the narrow band, and it only pays because of the dp4a verify GEMV in this
+    // same change. Measured on RTX 5090 at ctx=4096, both arms lossless:
+    //
+    //     verify GEMV   depth 1              depth 2              verdict
+    //     fp32 (main)   99.04 tok/s          96.05 tok/s          depth 2 LOSES by 3.0%
+    //     dp4a (here)   103.17 tok/s         106.20 tok/s         depth 2 WINS by 2.9%
+    //
+    // The extra proposal costs exactly one more verify row, and what changed is that row's price:
+    // 2.43 ms with the fp32 kernel, 1.42 ms with dp4a. Below that crossover the row cannot repay
+    // the acceptance it buys, which is why #878 measured depth 1 as optimal and why re-testing it
+    // on its own would measure the same thing again -- I did, and it came out -2.8%.
+    //
+    // Acceptance does rise with depth now: tau 1.5000 -> 1.7200 at depths 1 -> 2 on this box.
+    // #878's grid found it flat ("identical at depth 1, 2 and 3"), but that was taken through two
+    // defects since fixed -- #893's displaced Markov rows, which flattened precisely the deeper
+    // positions, and #894's causal block mask. The draft also already computes four block rows at
+    // depth 1 (#894 pins the width for the bidirectional context), so rows 2 and 3 are produced
+    // and discarded today; asking for one of them costs the draft 2.150 -> 2.378 ms.
+    //
+    // Depth 3 was measured too and is worse than 2 (tau 1.8169 but a third extra row): scope stays
+    // the narrow band, below kNarrowMinSeq keeps 3 and the >= kDeepMinSeq branch keeps 7.
     const int kProposalDepth = kProposalDepthEnv > 0 ? kProposalDepthEnv
                              : ((n + max_new) >= kDeepMinSeq ? 7
-                                : (n >= kNarrowMinSeq ? 1 : 3));
+                                : (n >= kNarrowMinSeq ? 2 : 3));
 
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN


### PR DESCRIPTION
## Summary

Give the row-batched NVFP4 verify GEMV a `dp4a` path, which cuts the cost of an extra verify row from 2.43 ms to 1.42 ms, and then take a second proposal in the narrow band, which only pays once that row is cheap. Also fixes `ct_dequant_nvfp4_g16_kernel`, which cannot dequantize a tensor with more than 65535 rows and so silently zeroes `lm_head` on any checkpoint that ships it as NVFP4.

Neither perf change is worth anything alone — depth 2 measures **−3.0%** on main's fp32 GEMV and **+2.9%** on the dp4a one. Weights are not requantized: NVFP4's decoded magnitudes `{0,1,2,3,4,6,8,12}` are already exact int8, so only the activation is quantized, as Q4_K decode already does for every FFN here.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `dspark-decode@4k`):

| | decode tok/s |
|---|--:|
| before (main) | 99.04 |
| after (this PR) | **106.86** |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

Guards: `ctest` 19/19 · `LOSSLESS=YES` 128/128 over 2 repeats · AR 91.46 → 92.62 (improved) · tau 1.5000 → 1.7200 (raised).

```text
# BEFORE -- origin/main + lm_head fix
METRIC AR_TPS 91.4596
METRIC DSPARK_TPS 99.0405
METRIC MEAN_ACCEPT 1.5000
METRIC LOSSLESS 1
[timing] draft      2.194 ms/call   [timing] batched   12.834 ms/call

# AFTER -- this PR
METRIC AR_TPS 92.6238
METRIC DSPARK_TPS 106.8627
METRIC MEAN_ACCEPT 1.7200
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 2
SPEC-REPS 2 reps, 0 differ-from-first, 0 not-lossless-vs-AR
[timing] draft      2.378 ms/call   [timing] batched   13.692 ms/call

# ablation, same box
baseline                  99.04 tok/s   tau 1.5000
+ dp4a only              103.17         tau 1.5000
+ depth 2 only (no dp4a)  96.05         tau 1.7200
+ both                   106.86         tau 1.7200
```

Env switches for A/B from one binary: `SPARKINFER_NVFP4_ROWS_DP4A=0`, `SPARKINFER_DFLASH_PROPOSALS=1`, `SPARKINFER_CT_NVFP4_G16=0`.
