### PR TITLE
feat(qwen38): decode the FFN from the checkpoint's own NVFP4, behind a flag (PPL 3.204 -> 3.010)

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -107,6 +107,14 @@ struct Qwen35LayerWeights {
     // 8.25% mean relative weight error against the NVFP4 source (corr 0.9968) -- NVFP4's 8
     // magnitudes per 16-element group with an e4m3 scale and Q4_K's 16 levels per 32 with a 6-bit
     // scale/min do not nest, so the conversion is pure loss on top of an already-lossy format.
+    // Measured cost of that conversion, same corpus, same build, only this flag changed:
+    //
+    //     Q4_K decode (default)   PPL 3.204
+    //     NVFP4 decode            PPL 3.010     6.1% better
+    //
+    // So it is a real quality regression, not a theoretical one. What it is NOT is the cause of
+    // the DSpark acceptance gap: tau measured 1.6552 on Q4_K against 1.6333 on NVFP4, i.e.
+    // unchanged, so the draft is not being held back by the target's requantized weights.
     // Set by SPARKINFER_QWEN38_DECODE_NVFP4=1 so the decode FFN can read the checkpoint directly.
     const void* gate_nv = nullptr; const void* up_nv = nullptr; const void* down_nv = nullptr;
     // Full-attention q/k/v projections as the checkpoint ships them (ModelOpt NVFP4). Unlike the

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -98,6 +98,17 @@ struct Qwen35LayerWeights {
     // Short-context-only copy; decode retains down_q, so long-context configurations leave this
     // null to preserve KV and batched-prefill scratch headroom on 32-GB cards.
     const void* down_fp4 = nullptr; const void* down_fp4_sf = nullptr;
+    // The checkpoint's OWN NVFP4 FFN payloads, in the single-blob layout launch_gemv_nvfp4 reads
+    // ([SI_NVFP4_HDR | ue4m3 group scales | packed e2m1]). Distinct from the *_fp4/_fp4_sf pair
+    // above, which is the split layout the batched-prefill GEMM wants.
+    //
+    // These exist because decode does NOT currently run the checkpoint's numerics. gate_q/up_q/
+    // down_q are built by dequantizing these payloads and REQUANTIZING to Q4_K, which measures
+    // 8.25% mean relative weight error against the NVFP4 source (corr 0.9968) -- NVFP4's 8
+    // magnitudes per 16-element group with an e4m3 scale and Q4_K's 16 levels per 32 with a 6-bit
+    // scale/min do not nest, so the conversion is pure loss on top of an already-lossy format.
+    // Set by SPARKINFER_QWEN38_DECODE_NVFP4=1 so the decode FFN can read the checkpoint directly.
+    const void* gate_nv = nullptr; const void* up_nv = nullptr; const void* down_nv = nullptr;
     // Full-attention q/k/v projections as the checkpoint ships them (ModelOpt NVFP4). Unlike the
     // GDN pointers below these do NOT alias a payload decode already holds: decode reads the Q4_K
     // wq/wk/wv/wo built from the same bytes, because native NVFP4 GEMV is ~0.65x at m=1. So the

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1718,8 +1718,6 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // experiment; if the accuracy win is real, the fusion work follows, and NVFP4's
             // decoded magnitudes are exact int8 so a dp4a path is reachable.
             if (w.gate_nv && w.up_nv && w.down_nv && c.top_k == 1) {
-                { static bool once = false;
-                  if (!once) { once = true; fprintf(stderr, "[nvfp4-decode] FFN on checkpoint NVFP4\n"); } }
                 kernels::launch_gemv_nvfp4(s.hn, w.gate_nv, s.nv_gate, c.moe_ffn, H, st);
                 kernels::launch_gemv_nvfp4(s.hn, w.up_nv, s.nv_up, c.moe_ffn, H, st);
                 kernels::launch_prefill_swiglu(s.nv_gate, s.nv_up, s.nv_h, c.moe_ffn, st);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1718,6 +1718,8 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // experiment; if the accuracy win is real, the fusion work follows, and NVFP4's
             // decoded magnitudes are exact int8 so a dp4a path is reachable.
             if (w.gate_nv && w.up_nv && w.down_nv && c.top_k == 1) {
+                { static bool once = false;
+                  if (!once) { once = true; fprintf(stderr, "[nvfp4-decode] FFN on checkpoint NVFP4\n"); } }
                 kernels::launch_gemv_nvfp4(s.hn, w.gate_nv, s.nv_gate, c.moe_ffn, H, st);
                 kernels::launch_gemv_nvfp4(s.hn, w.up_nv, s.nv_up, c.moe_ffn, H, st);
                 kernels::launch_prefill_swiglu(s.nv_gate, s.nv_up, s.nv_h, c.moe_ffn, st);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -20,6 +20,7 @@
 #include "sparkinfer/kernels/compressed_tensors.h"
 #include "sparkinfer/kernels/attention.h"
 #include "sparkinfer/kernels/gemm.h"
+#include "sparkinfer/kernels/prefill.h"   // launch_prefill_swiglu, for the NVFP4 decode FFN
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/quant.h"
@@ -257,6 +258,10 @@ struct Qwen35Model::Impl {
     std::vector<void*> owned;   // device buffers from load_weights / load_gguf
     // GGUF fused-expert decode scratch (allocated by load_gguf)
     float *mf_logits = nullptr, *mf_weights = nullptr, *mf_h = nullptr, *mf_out = nullptr;
+    // Decode-side NVFP4 FFN scratch (SPARKINFER_QWEN38_DECODE_NVFP4=1): gate and up outputs, and
+    // the SwiGLU result that feeds down. bf16 [moe_ffn] each -- ~104 KB total at ffn=17408, so it
+    // is allocated unconditionally rather than gated, keeping the decode path branch-free.
+    bf16 *nv_gate = nullptr, *nv_up = nullptr, *nv_h = nullptr;
     float *sx_h = nullptr;   // pipelined shared-expert h_scratch (avoids racing routed mf_h)
     void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
@@ -488,6 +493,9 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     cu(cudaMemset(p_->mf_rc, 0, sizeof(unsigned int)), "mf_rc zero");   // grid-completion counter starts at 0
     p_->mf_h       = p_->alloc<float>((size_t)std::max(1, cfg.top_k) * cfg.moe_ffn);
     p_->mf_out     = p_->alloc<float>(cfg.hidden);
+    p_->nv_gate    = p_->alloc<bf16>(cfg.moe_ffn);
+    p_->nv_up      = p_->alloc<bf16>(cfg.moe_ffn);
+    p_->nv_h       = p_->alloc<bf16>(cfg.moe_ffn);
     if (cfg.dense_ffn && cfg.top_k > 0) {
         cu(cudaMemcpy(p_->mf_ids, &zero, sizeof(int), cudaMemcpyHostToDevice), "dense expert id");
         cu(cudaMemcpy(p_->mf_weights, &one, sizeof(float), cudaMemcpyHostToDevice), "dense expert w");
@@ -1699,6 +1707,22 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // garbage FFN output that still looked like a confident (but wrong) distribution
             // downstream, rather than crashing or NaN-ing. Force nullptr for muse_glimmer so
             // launch_moe_expert_ffn_q4k quantizes s.hn fresh instead of trusting the stale cache.
+            // Checkpoint-native decode FFN (SPARKINFER_QWEN38_DECODE_NVFP4=1). gate_q/up_q/down_q
+            // are a Q4_K REQUANTIZATION of the NVFP4 the checkpoint ships -- 8.25% mean relative
+            // weight error, corr 0.9968 -- so this path exists to answer whether decoding the
+            // actual checkpoint numerics changes anything measurable. It is dense-only (top_k==1,
+            // one expert): the 256-expert MoE routes per token and has no single payload to read.
+            //
+            // Deliberately unfused: three GEMVs and an elementwise SwiGLU, against the Q4_K path's
+            // single fused kernel. That is the slow-but-obviously-correct shape for an accuracy
+            // experiment; if the accuracy win is real, the fusion work follows, and NVFP4's
+            // decoded magnitudes are exact int8 so a dp4a path is reachable.
+            if (w.gate_nv && w.up_nv && w.down_nv && c.top_k == 1) {
+                kernels::launch_gemv_nvfp4(s.hn, w.gate_nv, s.nv_gate, c.moe_ffn, H, st);
+                kernels::launch_gemv_nvfp4(s.hn, w.up_nv, s.nv_up, c.moe_ffn, H, st);
+                kernels::launch_prefill_swiglu(s.nv_gate, s.nv_up, s.nv_h, c.moe_ffn, st);
+                kernels::launch_gemv_nvfp4(s.nv_h, w.down_nv, s.routed, H, c.moe_ffn, st);
+            } else
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                s.mf_ids, s.mf_weights, s.routed, s.mf_h, s.mf_out,
@@ -4787,6 +4811,14 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         return true;
     };
 
+    // Run the DECODE FFN on the checkpoint's own NVFP4 weights instead of a Q4_K requantization
+    // of them. Off by default: it is an accuracy experiment with a real throughput risk, since
+    // the Q4_K path is dp4a int8 MMVQ and heavily tuned while launch_gemv_nvfp4 dequantizes to
+    // float. See the gate_nv/up_nv/down_nv comment in qwen35.h for what the conversion costs.
+    static const bool kDecodeNvfp4 = [] {
+        const char* e = getenv("SPARKINFER_QWEN38_DECODE_NVFP4");
+        return e && e[0] == '1';
+    }();
     auto keep_nvfp4 = [&](const std::string& prefix, int rows, int cols,
                           const void** fp4, const void** fp4_sf, float& fp4_alpha) -> const void* {
         NvFp4Src src{};
@@ -5117,7 +5149,21 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             w.gate_q = q4k_from_nvfp4(g_pay, c.moe_ffn, H, w.gate_qtype);
             w.up_q = q4k_from_nvfp4(u_pay, c.moe_ffn, H, w.up_qtype);
             w.down_q = q4k_from_nvfp4(d_pay, H, c.moe_ffn, w.down_qtype);
-            if (!w.gate_fp4) {
+            // SPARKINFER_QWEN38_DECODE_NVFP4=1 keeps the checkpoint's own payloads for DECODE, so
+            // the FFN runs the numerics the checkpoint actually ships instead of a Q4_K
+            // requantization of them (8.25% mean relative weight error -- see qwen35.h).
+            //
+            // The Q4_K copies are still built, deliberately: this is an A/B, and holding both lets
+            // the path be toggled per run without a reload. That costs the second residency the
+            // comment in keep_nvfp4 describes (~9.6 GB), so it fits at 4k and will NOT fit
+            // alongside a long-context KV. Once the accuracy question is settled one of the two
+            // copies should go, not both stay.
+            if (kDecodeNvfp4) {
+                w.gate_nv = g_pay; w.up_nv = u_pay; w.down_nv = d_pay;
+                s.owned.push_back(const_cast<void*>(g_pay));
+                s.owned.push_back(const_cast<void*>(u_pay));
+                s.owned.push_back(const_cast<void*>(d_pay));
+            } else if (!w.gate_fp4) {
                 // Prefill copies disabled: the payloads were deliberately not registered in
                 // s.owned (see keep_nvfp4), the Q4_K decode copies above are built, so release the
                 // NVFP4 source now rather than at teardown. Keyed on gate_fp4 being unset, which

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2885,6 +2885,27 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 fprintf(stderr, "[dflash-verify] dense layer=%d missing gate/up/down\n", L);
                 supported = false; break;
             }
+            // Checkpoint-native NVFP4 FFN, matching the decode path's own branch
+            // (SPARKINFER_QWEN38_DECODE_NVFP4=1, see qwen35.cpp). BOTH sides have to switch
+            // together: losslessness is defined as the speculative output matching the AR output
+            // of the SAME build, so running NVFP4 in decode while the verify stays on Q4_K makes
+            // the two disagree on weights that differ by ~8% and reports LOSSLESS=0 -- a path
+            // inconsistency, not an accuracy finding. Measured exactly that way before this
+            // branch existed.
+            static const bool kDecodeNvfp4 = [] {
+                const char* e = getenv("SPARKINFER_QWEN38_DECODE_NVFP4");
+                return e && e[0] == '1';
+            }();
+            if (kDecodeNvfp4 && w.gate_nv && w.up_nv && w.down_nv && topk == 1 &&
+                kernels::launch_gemv_nvfp4_rows(hn, w.gate_nv, sg, N, ffn, H, st) &&
+                kernels::launch_gemv_nvfp4_rows(hn, w.up_nv, su, N, ffn, H, st)) {
+                kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
+                if (!kernels::launch_gemv_nvfp4_rows(sh, w.down_nv, routed, N, H, ffn, st)) {
+                    fprintf(stderr, "[dflash-verify] NVFP4 down declined N=%d H=%d ffn=%d\n",
+                            N, H, ffn);
+                    supported = false; break;
+                }
+            } else
             kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                expert_ids, expert_w, routed, moe_h, moe_out,


### PR DESCRIPTION
## What

Decode does not currently run this checkpoint's numerics. `gate_q`/`up_q`/`down_q` are built by
dequantizing the NVFP4 the checkpoint ships and **requantizing to Q4_K**. Measured against the
NVFP4 source on `layers.0.mlp.gate_proj`:

```
mean |dW| / mean |W| = 8.25%      max |dW| / max |W| = 5.20%      corr = 0.9968
```

NVFP4 stores 8 magnitudes per 16-element group with an e4m3 group scale; Q4_K stores 16 levels per
32 with a 6-bit scale and min. They do not nest, so the conversion is pure loss on top of an
already-lossy format, and every decode forward runs on weights ~8% off the checkpoint.

`SPARKINFER_QWEN38_DECODE_NVFP4=1` keeps the checkpoint payloads resident and routes the dense
decode FFN through them: gate/up NVFP4 GEMV, elementwise SwiGLU, down NVFP4 GEMV. Both the decode
path and the batched verify switch together.

## Measured

Same corpus, same build, only the flag changed:

| | PPL | tau | AR tok/s |
|---|---:|---:|---:|
| Q4_K decode (default) | 3.204 | 1.6552 | 90.28 |
| NVFP4 decode (flag on) | **3.010** | 1.6333 | 82.30 |

**Quality improves 6.1%.** The 8.25% weight error is real and shows up where it matters.

**It is NOT the cause of the DSpark acceptance gap** — tau is unchanged (marginally down), so the
draft is not being held back by the target's requantized weights. That hypothesis is closed, which
is what this experiment was built to answer.

**Cost is AR -8.8%** in this form: three GEMVs and an elementwise SwiGLU against one fused dp4a
kernel. That is implementation cost, not inherent -- NVFP4's decoded magnitudes are exact int8, so
the dp4a path the Q4_K side already enjoys is reachable, and the FFN is currently unfused.

## Why this is safe to merge now

**Off by default, and the default path is untouched.** With the flag unset: the loader frees the
payloads exactly as before, `gate_nv` stays null so the decode branch never fires, and the verify
branch is additionally gated on the flag itself. Verified on the box at ctx=4096 -- AR 90.58,
DSpark 110.64, tau 1.6552, LOSSLESS=1, matching main within run variance.

The only unconditional cost is 3 x bf16[moe_ffn] of scratch, ~104 KB.

While the flag is ON both weight copies are held (~9.6 GB extra, the second residency `keep_nvfp4`
already documents), so it fits at 4k and will **not** fit alongside a long-context KV. Once the
tradeoff is settled one copy has to go.

## Not for scoring

Maintainer merge. This is a correctness/quality change measured by perplexity, not a speedup -- and
switching decode numerics is exactly what the differential accuracy gate flags, so enabling it by
default would need a deliberate baseline reset.

One trap worth recording: the first cut changed only the decode dispatch and left the verify on
Q4_K, so the two disagreed on 8%-different weights within one build and reported `LOSSLESS=0`. That
was a path inconsistency, not an accuracy result, and it would have been easy to read as the
experiment failing. Both sides must switch together.
