### PR TITLE
perf(dspark): widen native NVFP4 verifier loads

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -717,6 +717,33 @@ __device__ __forceinline__ void si_nvfp4_group_decode(const unsigned char* packe
     }
 }
 
+// 8-BYTE form of the decode above. si_nvfp4_group_dot's header explains why the ONE-ROW kernel
+// leaves these as two 4-byte loads: a uint2 needs 8-byte alignment, which "the row base only
+// happens to have for these shapes, not in general". The ROWS kernel is not the general case --
+// launch_gemv_nvfp4_rows rejects any K with (K & 15), so a weight row base nj*(K>>1) is a multiple
+// of 8 bytes and the group offset g*8 always is, for every shape that can reach here. Same two
+// 32-bit words, same order (little-endian: .x is the low four bytes), so p0 and p1 hold exactly
+// the bits the two separate loads produced.
+__device__ __forceinline__ void si_nvfp4_group_decode_w8(const unsigned char* packed8,
+                                                         unsigned char scale, float inv_g,
+                                                         float* __restrict__ ws) {
+    const float s = si_ue4m3(scale) * inv_g * 0.5f;
+    const uint2 pw = __ldg(reinterpret_cast<const uint2*>(packed8));
+    const unsigned int p0 = pw.x, p1 = pw.y;
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const unsigned b = (p0 >> (8 * i)) & 255u;
+        ws[2 * i]     = si_e2m1_x2(b & 15u) * s;
+        ws[2 * i + 1] = si_e2m1_x2(b >> 4) * s;
+    }
+    #pragma unroll
+    for (int i = 0; i < 4; i++) {
+        const unsigned b = (p1 >> (8 * i)) & 255u;
+        ws[8 + 2 * i]     = si_e2m1_x2(b & 15u) * s;
+        ws[8 + 2 * i + 1] = si_e2m1_x2(b >> 4) * s;
+    }
+}
+
 // Same term order and same accumulation order as si_nvfp4_group_dot, reading pre-scaled weights.
 __device__ __forceinline__ float si_nvfp4_group_dot_decoded(const float* __restrict__ ws,
                                                             const __nv_bfloat16* x16) {
@@ -747,6 +774,34 @@ __device__ __forceinline__ void si_nvfp4_load_x16(const __nv_bfloat16* x16, floa
         xv[2 * i] = xf.x;
         xv[2 * i + 1] = xf.y;
     }
+}
+// 128-BIT form of the load above. The eight __nv_bfloat162 reads are eight separate LDG.E in SASS
+// -- nvcc cannot prove the 16-byte alignment because K is a runtime value, so it never widens
+// them. The group's 32 bytes ARE contiguous and aligned: launch_gemv_nvfp4_rows rejects any K
+// with (K & 15), so a row base r*K and a group base g*16 are both multiples of 16 elements = 32
+// bytes, and the x allocation itself is device-allocated (256-byte aligned).
+//
+// That matters because this kernel is load-ISSUE bound, not bandwidth bound. The header records
+// the ncu verdict -- memory pipe 88% of peak against SM 33%, "latency-bound on a dependent chain"
+// -- and at R=2, NR=2 the inner loop issues 20 LDG.E.CONSTANT per group, 16 of which are these
+// activation reads. Two uint4 loads per row replace eight, taking the group from 20 issued loads
+// to 8. No byte moves that did not move before.
+//
+// Bit-identical: the same 32 bytes are reinterpreted as the same eight __nv_bfloat162 in the same
+// order and converted by the same __bfloat1622float2, so every xv[] entry has the same bits.
+__device__ __forceinline__ void si_bf162_pair_to_f2(unsigned u, float* __restrict__ xv) {
+    const float2 f = __bfloat1622float2(*reinterpret_cast<const __nv_bfloat162*>(&u));
+    xv[0] = f.x;
+    xv[1] = f.y;
+}
+__device__ __forceinline__ void si_nvfp4_load_x16_v4(const __nv_bfloat16* x16,
+                                                     float* __restrict__ xv) {
+    const uint4 a = *reinterpret_cast<const uint4*>(x16);
+    const uint4 b = *reinterpret_cast<const uint4*>(x16 + 8);
+    si_bf162_pair_to_f2(a.x, xv +  0); si_bf162_pair_to_f2(a.y, xv +  2);
+    si_bf162_pair_to_f2(a.z, xv +  4); si_bf162_pair_to_f2(a.w, xv +  6);
+    si_bf162_pair_to_f2(b.x, xv +  8); si_bf162_pair_to_f2(b.y, xv + 10);
+    si_bf162_pair_to_f2(b.z, xv + 12); si_bf162_pair_to_f2(b.w, xv + 14);
 }
 
 __device__ __forceinline__ float si_nvfp4_dot16(const float* __restrict__ ws,
@@ -811,7 +866,7 @@ template __global__ void gemv_nvfp4_sk_kernel<__nv_bfloat16, 8>(const __nv_bfloa
 // stride), accumulates into its own float, and folds its splits in the same ascending order. Only
 // the weight and scale loads are shared between rows -- the arithmetic per row is untouched, which
 // is what keeps the speculative path lossless by construction rather than by measurement.
-template <typename OutT, int S, int R, int NR>
+template <typename OutT, int S, int R, int NR, int WIDE>
 __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
                                           const void* __restrict__ packed,
                                           OutT* __restrict__ y, int N, int K) {
@@ -845,8 +900,10 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
             // x for this group, once, shared by every output row this warp owns.
             float xv[R][16];
             #pragma unroll
-            for (int r = 0; r < R; r++)
-                si_nvfp4_load_x16(x + (size_t)r * K + (size_t)g * 16, xv[r]);
+            for (int r = 0; r < R; r++) {
+                if (WIDE) si_nvfp4_load_x16_v4(x + (size_t)r * K + (size_t)g * 16, xv[r]);
+                else      si_nvfp4_load_x16   (x + (size_t)r * K + (size_t)g * 16, xv[r]);
+            }
             #pragma unroll
             for (int j = 0; j < NR; j++) {
                 const int nj = n0 + j;
@@ -854,7 +911,8 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
                 const unsigned char* srow = sf + (size_t)nj * (size_t)(K >> 4);
                 const unsigned char* prow = w + (size_t)nj * (size_t)(K >> 1);
                 float ws[16];
-                si_nvfp4_group_decode(prow + (size_t)g * 8, srow[g], inv_g, ws);
+                if (WIDE >= 2) si_nvfp4_group_decode_w8(prow + (size_t)g * 8, srow[g], inv_g, ws);
+                else           si_nvfp4_group_decode   (prow + (size_t)g * 8, srow[g], inv_g, ws);
                 #pragma unroll
                 for (int r = 0; r < R; r++) acc[j][r] += si_nvfp4_dot16(ws, xv[r]);
             }
@@ -892,8 +950,10 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
 }
 #ifndef _MSC_VER
 #define SI_NVFP4_ROWS_INST(S_, R_) \
-template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
-template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1, 0>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2, 0>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2, 1>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
+template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 2, 2>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int);
 SI_NVFP4_ROWS_INST(2, 2) SI_NVFP4_ROWS_INST(4, 2) SI_NVFP4_ROWS_INST(8, 2)
 SI_NVFP4_ROWS_INST(2, 4) SI_NVFP4_ROWS_INST(4, 4) SI_NVFP4_ROWS_INST(8, 4)
 SI_NVFP4_ROWS_INST(2, 6) SI_NVFP4_ROWS_INST(4, 6) SI_NVFP4_ROWS_INST(8, 6)
@@ -2536,12 +2596,20 @@ bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N,
     // arms of an A/B come out of one binary.
     static const int nr = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_NR");
                               return (e && e[0] == '1') ? 1 : 2; }();
+    // SPARKINFER_NVFP4_ROWS_V4 selects the load width: 0 restores main's scalar loads, 1 widens
+    // only the activations, 2 (default) widens the weight pair as well. All three arms come out of
+    // one binary the way the NR toggle beside it does.
+    static const int xv4 = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_V4");
+                               const int v = e ? atoi(e) : 2;
+                               return (v < 0 || v > 2) ? 2 : v; }();
 #define SI_NVFP4_ROWS(S_, R_) do { \
         constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
         if (nr == 2) { const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
-            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+            if (xv4 == 2)      gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); \
+            else if (xv4 == 1) gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); \
+            else               gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 2, 0><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
         else { const dim3 grid((N + RPB - 1) / RPB); \
-            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
+            gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S, R, 1, 0><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K); } \
     } while (0)
 #define SI_NVFP4_ROWS_S(R_) do { \
         if (N >= 8192)      SI_NVFP4_ROWS(2, R_); \

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4856,7 +4856,8 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             const char* e = getenv("SPARKINFER_QWEN38_PREFILL_NVFP4");
             return !(e && e[0] == '0');
         }();
-        if (keep_prefill_fp4) s.owned.push_back(payload);
+        // Exactly one owner even when the same payload serves both prefill and native decode.
+        if (keep_prefill_fp4 || kDecodeNvfp4) s.owned.push_back(payload);
         fp4_alpha = (global_scale != 0.f) ? (1.f / global_scale) : 1.f;
         const void* packed = static_cast<char*>(payload) + hdr + scale_bytes;
         if (keep_prefill_fp4 && kernels::prefill_nvfp4_supported(128, rows, cols)) {
@@ -5146,24 +5147,22 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
                                            &w.up_fp4, &w.up_fp4_sf, w.up_fp4_alpha);
             const void* d_pay = keep_nvfp4(mb + "down_proj", H, c.moe_ffn,
                                            &w.down_fp4, &w.down_fp4_sf, w.down_fp4_alpha);
-            w.gate_q = q4k_from_nvfp4(g_pay, c.moe_ffn, H, w.gate_qtype);
-            w.up_q = q4k_from_nvfp4(u_pay, c.moe_ffn, H, w.up_qtype);
-            w.down_q = q4k_from_nvfp4(d_pay, H, c.moe_ffn, w.down_qtype);
             // SPARKINFER_QWEN38_DECODE_NVFP4=1 keeps the checkpoint's own payloads for DECODE, so
             // the FFN runs the numerics the checkpoint actually ships instead of a Q4_K
             // requantization of them (8.25% mean relative weight error -- see qwen35.h).
             //
-            // The Q4_K copies are still built, deliberately: this is an A/B, and holding both lets
-            // the path be toggled per run without a reload. That costs the second residency the
-            // comment in keep_nvfp4 describes (~9.6 GB), so it fits at 4k and will NOT fit
-            // alongside a long-context KV. Once the accuracy question is settled one of the two
-            // copies should go, not both stay.
+            // This is selected before loading and cannot change without reloading the model, so
+            // building Q4_K copies as well buys no usable runtime A/B: the dispatch flag is a
+            // process-static value too. It only requantizes every FFN at startup and holds another
+            // ~9.6 GB for weights no kernel can reach. Keep exactly one decode representation.
             if (kDecodeNvfp4) {
                 w.gate_nv = g_pay; w.up_nv = u_pay; w.down_nv = d_pay;
-                s.owned.push_back(const_cast<void*>(g_pay));
-                s.owned.push_back(const_cast<void*>(u_pay));
-                s.owned.push_back(const_cast<void*>(d_pay));
-            } else if (!w.gate_fp4) {
+            } else {
+                w.gate_q = q4k_from_nvfp4(g_pay, c.moe_ffn, H, w.gate_qtype);
+                w.up_q = q4k_from_nvfp4(u_pay, c.moe_ffn, H, w.up_qtype);
+                w.down_q = q4k_from_nvfp4(d_pay, H, c.moe_ffn, w.down_qtype);
+            }
+            if (!kDecodeNvfp4 && !w.gate_fp4) {
                 // Prefill copies disabled: the payloads were deliberately not registered in
                 // s.owned (see keep_nvfp4), the Q4_K decode copies above are built, so release the
                 // NVFP4 source now rather than at teardown. Keyed on gate_fp4 being unset, which
@@ -5174,11 +5173,13 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             }
             if (w.gate_fp4 && w.up_fp4) ++gu_ready;
         }
-        if (!w.gate_q || !w.up_q || !w.down_q) return false;
+        const bool native_ffn = w.gate_nv && w.up_nv && w.down_nv;
+        const bool q4_ffn = w.gate_q && w.up_q && w.down_q;
+        if (!native_ffn && !q4_ffn) return false;
     }
-    fprintf(stderr, "[compressed-tensors] loaded %d layers, native NVFP4 prefill FFN %d/%d "
-            "(decode stays Q4_K)\n",
-            c.n_layers, gu_ready, c.n_layers);
+    fprintf(stderr, "[compressed-tensors] loaded %d layers, native NVFP4 prefill FFN %d/%d, "
+            "decode FFN %s\n", c.n_layers, gu_ready, c.n_layers,
+            kDecodeNvfp4 ? "NVFP4" : "Q4_K");
 
     // Same fused Q4_K-in-GEMM row scales Muse uses, for whichever tensors ended up Q4_K after the
     // per-tensor routing above -- full-attn q/k/v/o always, plus any FFN layer with no native

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2881,7 +2881,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // constants AR uses (expert 0, weight 1.0) and run the identical expert kernel at N rows,
         // then skip straight past the MoE routing/shared machinery below.
         if (dense) {
-            if (!w.gate_q || !w.up_q || !w.down_q) {
+            static const bool kDecodeNvfp4 = [] {
+                const char* e = getenv("SPARKINFER_QWEN38_DECODE_NVFP4");
+                return e && e[0] == '1';
+            }();
+            const bool native_ffn = kDecodeNvfp4 && w.gate_nv && w.up_nv && w.down_nv;
+            const bool q4_ffn = w.gate_q && w.up_q && w.down_q;
+            if (!native_ffn && !q4_ffn) {
                 fprintf(stderr, "[dflash-verify] dense layer=%d missing gate/up/down\n", L);
                 supported = false; break;
             }
@@ -2892,24 +2898,26 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // the two disagree on weights that differ by ~8% and reports LOSSLESS=0 -- a path
             // inconsistency, not an accuracy finding. Measured exactly that way before this
             // branch existed.
-            static const bool kDecodeNvfp4 = [] {
-                const char* e = getenv("SPARKINFER_QWEN38_DECODE_NVFP4");
-                return e && e[0] == '1';
-            }();
-            if (kDecodeNvfp4 && w.gate_nv && w.up_nv && w.down_nv && topk == 1 &&
-                kernels::launch_gemv_nvfp4_rows(hn, w.gate_nv, sg, N, ffn, H, st) &&
-                kernels::launch_gemv_nvfp4_rows(hn, w.up_nv, su, N, ffn, H, st)) {
+            if (native_ffn) {
+                if (topk != 1 ||
+                    !kernels::launch_gemv_nvfp4_rows(hn, w.gate_nv, sg, N, ffn, H, st) ||
+                    !kernels::launch_gemv_nvfp4_rows(hn, w.up_nv, su, N, ffn, H, st)) {
+                    fprintf(stderr, "[dflash-verify] NVFP4 gate/up declined N=%d ffn=%d H=%d\n",
+                            N, ffn, H);
+                    supported = false; break;
+                }
                 kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
                 if (!kernels::launch_gemv_nvfp4_rows(sh, w.down_nv, routed, N, H, ffn, st)) {
                     fprintf(stderr, "[dflash-verify] NVFP4 down declined N=%d H=%d ffn=%d\n",
                             N, H, ffn);
                     supported = false; break;
                 }
-            } else
-            kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
-                                               w.gate_qtype, w.up_qtype, w.down_qtype,
-                                               expert_ids, expert_w, routed, moe_h, moe_out,
-                                               N, topk, H, ffn, q81, st);
+            } else {
+                kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
+                                                   w.gate_qtype, w.up_qtype, w.down_qtype,
+                                                   expert_ids, expert_w, routed, moe_h, moe_out,
+                                                   N, topk, H, ffn, q81, st);
+            }
             if (L == 0) vdbg_snapshot2(routed, 3);
             // Residual + next-layer norm, matching the MoE branch's tail.
             const void* nn = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;


### PR DESCRIPTION
## Summary

Speed up native-NVFP4 DSpark verification by widening provably aligned activation and weight loads, and stop building an unreachable Q4_K FFN copy when native NVFP4 decode is selected.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 89.22 |
| after (this PR) | 94.75 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090, Qwen3.8-27B NVFP4 + released DSpark draft, ctx=4096, max_new=128
SPARKINFER_QWEN38_DECODE_NVFP4=1

before (SPARKINFER_NVFP4_ROWS_V4=0):
  batched verify  14.680 ms/call
  DSPARK          89.22 tok/s
  tau             1.5059
  lossless        YES

after (vectorized activation + aligned weight loads):
  batched verify  13.697 ms/call
  DSPARK          94.75 tok/s
  tau             1.5059
  lossless        YES

repeat validation:
  SPEC-REPS 3 reps, 0 differ-from-first, 0 not-lossless-vs-AR
  verifier times 13.697 / 13.708 / 13.718 ms

same-binary controls:
  activation widening only (V4=1): 94.41 tok/s, 13.754 ms
  NR=4: 85.92 tok/s, 15.332 ms (rejected and removed)
```
