### PR TITLE
perf(dspark): drop the draft's fifth layer and widen its attention and Markov loads

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -600,8 +600,9 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
     if (global_scale_dev) global_scale = *global_scale_dev;
     const float inv_gs = (ALU >= CT_ALU_RCP) ? (1.f / global_scale) : 0.f;
     const int ngroups = cols >> 4;
-    const int r = blockIdx.y;
-    if (r >= rows) return;
+    // Grid-stride over rows: gridDim.y is capped at 65535, and lm_head has `vocab` rows (248320
+    // on this checkpoint), so the launch is silently rejected and the head dequantizes to zeros.
+    for (int r = blockIdx.y; r < rows; r += gridDim.y) {
     const unsigned char* prow = packed + (size_t)r * (size_t)(cols >> 1);
     const unsigned char* srow = group_scale + (size_t)r * (size_t)ngroups;
     __nv_bfloat16* orow = out + (size_t)r * (size_t)cols;
@@ -624,6 +625,7 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
         }
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16)     = *reinterpret_cast<const uint4*>(o);
         *reinterpret_cast<uint4*>(orow + (size_t)g * 16 + 8) = *reinterpret_cast<const uint4*>(o + 8);
+    }
     }
 }
 
@@ -752,7 +754,7 @@ static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_sca
         const int ngroups = cols >> 4;
         const int threads = 256;
         const int bx = (ngroups + threads - 1) / threads;
-        const dim3 grid(bx > 0 ? bx : 1, rows);
+        const dim3 grid(bx > 0 ? bx : 1, rows > 65535 ? 65535 : rows);
         auto* pk = reinterpret_cast<const unsigned char*>(packed_u8);
         auto* gsc = reinterpret_cast<const unsigned char*>(group_scale_ue4m3);
         auto* ob = reinterpret_cast<__nv_bfloat16*>(out_bf16);

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -310,6 +310,24 @@ __global__ void k_attn(const bf16* q, const bf16* k, const bf16* v, bf16* out,
 // serial chain shortens and the grid grows with context. Per-split partial (m, l, acc)
 // states are merged by k_attn_split_combine, which is the same online-softmax merge the
 // in-CTA warp reduction already does -- exact for any split count.
+// Widened bf16 loads for the draft's own kernels.
+//
+// The verify GEMV had this treatment (#891, #899) and it is worth ~2% there; the DRAFT's kernels
+// never did, and they carry 1.18 ms of the 14.75 ms decode step. Each of the loops below fetches
+// contiguous bf16 one element at a time, so a lane issues four or eight separate 16-bit loads
+// where one 64- or 128-bit load carries the same bytes.
+//
+// Bit-identical: b2f runs on the same halves in the same order into the same registers -- only the
+// load width moves. Alignment is structural, not assumed: every offset below is a whole multiple
+// of the vector width in elements (E=4 for the hd128 attention lanes, 8 for the Markov rows), so a
+// cudaMalloc'd base keeps every access aligned.
+__device__ __forceinline__ void df_ld4_bf16(const bf16* __restrict__ p, float* __restrict__ out) {
+    const int2 v = __ldg(reinterpret_cast<const int2*>(p));
+    const bf16* c = reinterpret_cast<const bf16*>(&v);
+#pragma unroll
+    for (int e = 0; e < 4; e++) out[e] = b2f(c[e]);
+}
+
 template <int ROWS, int NWARPS>
 __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
     const bf16* __restrict__ q, const bf16* __restrict__ k, const bf16* __restrict__ v,
@@ -329,7 +347,12 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
         const int qt = qt0 + r;
         const bf16* qv = q + ((size_t)qt * n_q + qh) * D + base;
 #pragma unroll
-        for (int e = 0; e < E; e++) { qr[r][e] = (qt < q_len) ? b2f(qv[e]) : 0.f; acc[r][e] = 0.f; }
+        if (qt < q_len && E == 4) df_ld4_bf16(qv, qr[r]);
+        else
+#pragma unroll
+            for (int e = 0; e < E; e++) qr[r][e] = (qt < q_len) ? b2f(qv[e]) : 0.f;
+#pragma unroll
+        for (int e = 0; e < E; e++) acc[r][e] = 0.f;
         max_s[r] = -1e30f;
         sum[r] = 0.f;
     }
@@ -346,7 +369,10 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
         const bf16* kp = k + ((size_t)t * n_kv + kv_h) * D + base;
         float kreg[E];
 #pragma unroll
-        for (int e = 0; e < E; e++) kreg[e] = b2f(kp[e]);
+        if (E == 4) df_ld4_bf16(kp, kreg);
+        else
+#pragma unroll
+            for (int e = 0; e < E; e++) kreg[e] = b2f(kp[e]);
         float dots[ROWS];
 #pragma unroll
         for (int r = 0; r < ROWS; r++) {
@@ -371,7 +397,10 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
             if (!vloaded) {
                 const bf16* vp = v + ((size_t)t * n_kv + kv_h) * D + base;
 #pragma unroll
-                for (int e = 0; e < E; e++) vreg[e] = b2f(vp[e]);
+                if (E == 4) df_ld4_bf16(vp, vreg);
+                else
+#pragma unroll
+                    for (int e = 0; e < E; e++) vreg[e] = b2f(vp[e]);
                 vloaded = true;
             }
             const float score = __shfl_sync(0xffffffffu, dots[r], 0) * scale;
@@ -1561,7 +1590,20 @@ __global__ void k_markov_bias_add(const bf16* __restrict__ w1, const bf16* __res
     if (v >= vocab) return;
     const bf16* w2_row = w2 + (size_t)v * rank;
     float acc = 0.f;
-    for (int r = 0; r < rank; r++) acc += latent[r] * b2f(w2_row[r]);
+    // Eight contiguous bf16 per load instead of one. Every thread walks its own `rank`-long row,
+    // so this loop is `rank` dependent 16-bit loads per vocabulary entry and the kernel streams
+    // 127 MB of w2 per call. Rows are rank*2 bytes apart, so a 16-byte load stays aligned whenever
+    // rank is a multiple of 8; the scalar tail covers any other rank.
+    int r = 0;
+    if ((rank & 7) == 0 && ((reinterpret_cast<size_t>(w2_row) & 15u) == 0)) {
+        for (; r + 8 <= rank; r += 8) {
+            const int4 v = __ldg(reinterpret_cast<const int4*>(w2_row + r));
+            const bf16* c = reinterpret_cast<const bf16*>(&v);
+#pragma unroll
+            for (int j = 0; j < 8; j++) acc += latent[r + j] * b2f(c[j]);
+        }
+    }
+    for (; r < rank; r++) acc += latent[r] * b2f(w2_row[r]);
     logits[v] += acc;
 }
 

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1051,9 +1051,27 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     cu(cudaMemcpyAsync(s.x, s.noise, (size_t)BW * H * sizeof(bf16), cudaMemcpyDeviceToDevice, st),
        "noise->x");
 
+    // FOUR OF THE DRAFT'S FIVE LAYERS, at the scored context.
+    //
+    // The draft's cost and its acceptance are not equally elastic, and the balance point is not
+    // where it was when this defaulted to the full stack. Measured on RTX 5090 at ctx=4096 against
+    // the released DSpark draft, all arms lossless:
+    //
+    //     layers   draft ms   tau      dspark tok/s
+    //       5        2.201    1.5000     98.91      <- previous default
+    //       4        1.967    1.4884    100.34      <- +1.4%, tau -0.8%
+    //       3        1.718    1.3763     94.33
+    //       2        1.483    1.3196     91.91
+    //
+    // Below four the curve turns over hard: layer three costs 8% of acceptance to buy 22% of the
+    // draft, which is a net loss. Four is the one point where the trade is positive, and it stays
+    // comfortably inside the acceptance floor (0.992x, bar 0.95x). Context trimming was measured on
+    // the same grid and loses at this length -- windowing the full-attention layer to 1024 or 512
+    // takes tau to 1.4066 / 1.4176 for 0.32 ms, both net negative -- so the window keeps its
+    // existing 3x-sliding default and only the depth moves.
     static const int active_layers = [] {
         const char* e = getenv("SPARKINFER_DFLASH_LAYERS");
-        return e ? atoi(e) : 0;
+        return e ? atoi(e) : 4;
     }();
     const int run_layers = active_layers > 0 ? std::min(active_layers, c.n_layers) : c.n_layers;
     // cat(k_ctx, k_noise) is built at exactly the layout and length the cache slice expects, so


### PR DESCRIPTION
## Summary

Run the DSpark draft at four of its five layers, and widen the draft's own attention and Markov
loads. The draft's cost and its acceptance are not equally elastic, and the balance point is not
where the full stack sits. Also fixes `ct_dequant_nvfp4_g16_kernel`, which cannot dequantize a
tensor with more than 65535 rows and so silently zeroes `lm_head` on any checkpoint shipping it as
NVFP4.

Measured at ctx=4096, all arms lossless:

| draft layers | draft ms | tau | dspark tok/s |
|---:|---:|---:|---:|
| 5 (previous default) | 2.201 | 1.5000 | 98.91 |
| **4** | **1.967** | **1.4884** | **100.34** |
| 3 | 1.718 | 1.3763 | 94.33 |
| 2 | 1.483 | 1.3196 | 91.91 |

Below four the curve turns over hard — layer three costs 8% of acceptance to buy 22% of the draft.
Four is the one point where the trade is positive, and it stays well inside the acceptance floor
(0.992x against a 0.95x bar). Context trimming was measured on the same grid and loses at this
length: windowing the full-attention layer to 1024 or 512 takes tau to 1.4066 / 1.4176 for 0.32 ms,
both net negative, so the window keeps its 3x-sliding default and only the depth moves.

The load widening is the technique from #891/#899 applied to the draft's own kernels, which never
had it: `k_attn_rows_split_hd128` fetched its q/k/v four separate 16-bit loads at a time, and
`k_markov_bias_add` streamed 127 MB of `w2` one element per load. Bit-identical -- same
conversions, same order, only the load width moves.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `dspark-decode@4k`):

| | decode tok/s |
|---|--:|
| before (main) | 98.85 |
| after (this PR) | **102.73** |

**Prefill pp tok/s** (not targeted):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

Guards: `ctest` 19/19 · `LOSSLESS=YES` over 2 repeats on **two independent prompts** ·
AR 91.19 -> 91.24 (unchanged) · tau 1.5000 -> 1.4884 (0.992x, bar 0.95x).

Run-to-run variance on this box is ~1-2%, so read the headline as **+2.5% to +4%** rather than a
sharp 3.9%.

> **On the baseline.** This box downloads the current checkpoint, whose NVFP4 `lm_head` hits the
> `gridDim.y` bug fixed here and dequantizes to zeros -- the model loads clean, emits uniform
> logits, and pins tau at exactly 1.0000. **The baseline above includes that fix.** With it the box
> reconciles with this repo's own numbers: draft 2.20 ms vs 2.202 in #894, AR 91.2 vs 90.5,
> PPL 3.177 vs 3.204.

```text
# BEFORE -- origin/main + lm_head fix
METRIC AR_TPS 91.1874
METRIC DSPARK_TPS 98.8453
METRIC MEAN_ACCEPT 1.5000
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 2

# AFTER -- this PR, prompt 1
METRIC AR_TPS 91.2372
METRIC DSPARK_TPS 102.7281
METRIC MEAN_ACCEPT 1.4884
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 2

# AFTER -- this PR, second independent prompt
METRIC DSPARK_TPS 107.6057
METRIC MEAN_ACCEPT 1.5610
METRIC AR_TPS 91.1430
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 2
```

Env switches: `SPARKINFER_DFLASH_LAYERS=5` restores the full stack,
`SPARKINFER_CT_NVFP4_G16=0` the per-element dequant.

<sub>Measured and rejected on the way, recorded so they are not retried: NR=4 output rows per warp
(slower on float x, and still slower with x held packed in fewer registers than NR=2 uses today, so
activation traffic is not what that kernel is short of), a half-group register restructure, split-K
resizing, grid-stride/wave capping (fewer blocks is worse -- the kernel wants oversubscription), a
dp4a NVFP4 GEMV (verify gain only 0.12 ms and it breaks the AR floor, since losslessness forces AR
and the verify onto identical arithmetic), and proposal depth 2 (-3.0%).</sub>
