### PR TITLE
perf(dspark): fuse native NVFP4 gate-up and SwiGLU

### DIFF
--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -190,7 +190,7 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     const uint4* x4 = reinterpret_cast<const uint4*>(x + base);
     const uint4* r4 = reinterpret_cast<const uint4*>(residual + base);
     uint4* osum4 = reinterpret_cast<uint4*>(out_sum + base);
-    out_q8 += (size_t)blockIdx.x * (cols >> 5);
+    if (out_q8) out_q8 += (size_t)blockIdx.x * (cols >> 5);
 
     float xv[8], rv[8]; rn_unpack8(__ldg(x4 + t), xv); rn_unpack8(__ldg(r4 + t), rv);
     float sv[8]; float ss = 0.f;
@@ -213,27 +213,32 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     const uint4* w4 = reinterpret_cast<const uint4*>(weight);
     const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum + base);
     float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
-    float ov[8], bv[8];
+    float ov[8];
     #pragma unroll
-    for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
+    for (int j = 0; j < 8; j++) ov[j] = svb[j] * inv_rms * wv[j];
     reinterpret_cast<uint4*>(out_norm + base)[t] = rn_pack8(ov);
 
-    // Q8_1 of the bf16-rounded out_norm. 32-block = 4 consecutive threads (t&~3 .. +3).
-    float amax = 0.f;
-    #pragma unroll
-    for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(bv[j]));
-    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
-    amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
-    const float d = amax / 127.0f;
-    const int b = t >> 2, r = t & 3;
-    int s = 0;
-    #pragma unroll
-    for (int j = 0; j < 8; j++) {
-        int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
-        out_q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+    if (out_q8) {
+        float bv[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) bv[j] = __bfloat162float(__float2bfloat16(ov[j]));
+        // Q8_1 of the bf16-rounded out_norm. 32-block = 4 consecutive threads (t&~3 .. +3).
+        float amax = 0.f;
+        #pragma unroll
+        for (int j = 0; j < 8; j++) amax = fmaxf(amax, fabsf(bv[j]));
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 1));
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, 2));
+        const float d = amax / 127.0f;
+        const int b = t >> 2, r = t & 3;
+        int s = 0;
+        #pragma unroll
+        for (int j = 0; j < 8; j++) {
+            int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
+            out_q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+        }
+        s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
+        if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
     }
-    s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
-    if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
 }
 
 // 3-input add_rmsnorm2_q8: out_sum = x + (res1 + res2), folding a residual_add node.

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -951,6 +951,80 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
         }
     }
 }
+
+// Two independent projections of the same activation rows. This preserves the exact arithmetic
+// of gemv_nvfp4_rows_sk_kernel for each output, but loads each x group only once for gate+up.
+template <int S>
+__global__ void gemv_nvfp4_rows_dual_sk_kernel(const __nv_bfloat16* __restrict__ x,
+        const void* __restrict__ packed0, const void* __restrict__ packed1,
+        __nv_bfloat16* __restrict__ h, int N, int K) {
+    constexpr int R = 2, NR = 2, RPB = GEMV_WPB / S;
+    __shared__ float part[2][RPB][S][NR][R];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int rl = warp / S, split = warp % S;
+    const int n0 = blockIdx.x * (RPB * NR) + rl * NR;
+    float acc[2][NR][R] = {};
+    if (n0 < N) {
+        const void* pp[2] = {packed0, packed1};
+        const float inv[2] = {1.f / *reinterpret_cast<const float*>(packed0),
+                              1.f / *reinterpret_cast<const float*>(packed1)};
+        const int ng = K >> 4;
+        for (int g = split * 32 + lane; g < ng; g += S * 32) {
+            float xv[R][16];
+            #pragma unroll
+            for (int r = 0; r < R; ++r)
+                si_nvfp4_load_x16_v4(x + (size_t)r * K + (size_t)g * 16, xv[r]);
+            #pragma unroll
+            for (int p = 0; p < 2; ++p) {
+                const unsigned char* sf = reinterpret_cast<const unsigned char*>(pp[p]) + SI_NVFP4_HDR;
+                const unsigned char* wb = sf + (size_t)N * (size_t)(K >> 4);
+                #pragma unroll
+                for (int j = 0; j < NR; ++j) {
+                    const int n = n0 + j;
+                    if (n >= N) break;
+                    float ws[16];
+                    si_nvfp4_group_decode_w8(wb + (size_t)n * (size_t)(K >> 1) + (size_t)g * 8,
+                                             sf[(size_t)n * (size_t)(K >> 4) + g], inv[p], ws);
+                    #pragma unroll
+                    for (int r = 0; r < R; ++r) acc[p][j][r] += si_nvfp4_dot16(ws, xv[r]);
+                }
+            }
+        }
+        #pragma unroll
+        for (int p = 0; p < 2; ++p) {
+            #pragma unroll
+            for (int j = 0; j < NR; ++j) {
+                #pragma unroll
+                for (int r = 0; r < R; ++r) {
+                    #pragma unroll
+                    for (int m = 16; m > 0; m >>= 1)
+                        acc[p][j][r] += __shfl_xor_sync(0xffffffff, acc[p][j][r], m);
+                    if (lane == 0) part[p][rl][split][j][r] = acc[p][j][r];
+                }
+            }
+        }
+    }
+    __syncthreads();
+    if (n0 < N && split == 0 && lane == 0) {
+        #pragma unroll
+        for (int j = 0; j < NR; ++j) {
+            const int n = n0 + j; if (n >= N) break;
+            #pragma unroll
+            for (int r = 0; r < R; ++r) {
+                float g = part[0][rl][0][j][r], u = part[1][rl][0][j][r];
+                #pragma unroll
+                for (int t = 1; t < S; ++t) {
+                    g += part[0][rl][t][j][r];
+                    u += part[1][rl][t][j][r];
+                }
+                // Match the separate GEMVs' bf16 stores and pf_swiglu_kernel exactly.
+                g = __bfloat162float(__float2bfloat16(g));
+                u = __bfloat162float(__float2bfloat16(u));
+                h[(size_t)r * N + n] = __float2bfloat16((g / (1.f + __expf(-g))) * u);
+            }
+        }
+    }
+}
 #ifndef _MSC_VER
 #define SI_NVFP4_ROWS_INST(S_, R_) \
 template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1, 0>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
@@ -2627,6 +2701,26 @@ bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N,
     }
 #undef SI_NVFP4_ROWS_S
 #undef SI_NVFP4_ROWS
+    return true;
+}
+
+bool launch_gemv_nvfp4_rows_dual_swiglu(const void* x, const void* W0, const void* W1,
+                                        void* h, int M, int N, int K, cudaStream_t stream) {
+    if (!x || !W0 || !W1 || !h || M != 2 || N < 1 || K < 1 || (K & 15) ||
+        !gemv_bf16_splitk()) return false;
+    constexpr int NR = 2;
+    const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+    auto* hp = reinterpret_cast<__nv_bfloat16*>(h);
+    if (N >= 8192) {
+        constexpr int S=2, RPB=GEMV_WPB/S;
+        gemv_nvfp4_rows_dual_sk_kernel<S><<<dim3((N+RPB*NR-1)/(RPB*NR)),GEMV_WPB*32,0,stream>>>(xp,W0,W1,hp,N,K);
+    } else if (N >= 4096) {
+        constexpr int S=4, RPB=GEMV_WPB/S;
+        gemv_nvfp4_rows_dual_sk_kernel<S><<<dim3((N+RPB*NR-1)/(RPB*NR)),GEMV_WPB*32,0,stream>>>(xp,W0,W1,hp,N,K);
+    } else {
+        constexpr int S=8, RPB=GEMV_WPB/S;
+        gemv_nvfp4_rows_dual_sk_kernel<S><<<dim3((N+RPB*NR-1)/(RPB*NR)),GEMV_WPB*32,0,stream>>>(xp,W0,W1,hp,N,K);
+    }
     return true;
 }
 

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -88,6 +88,9 @@ bool launch_gemv_fp8_rows(const void* x, const void* W, void* y, int M, int N, i
 // Returns false for widths/shapes it does not cover, so callers keep their row loop as fallback.
 bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N, int K,
                             cudaStream_t stream = nullptr);
+bool launch_gemv_nvfp4_rows_dual_swiglu(const void* x, const void* W0, const void* W1,
+                                        void* h, int M, int N, int K,
+                                        cudaStream_t stream = nullptr);
 
 void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K,
                        cudaStream_t stream = nullptr);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2874,7 +2874,14 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // kernel args (a printf's tag/step) do not, which is why this uses vdbg_snapshot's
         // approach and not a live stat-printer call here.
         if (L == 0) vdbg_snapshot2(ao, 0);
-        kernels::launch_add_rmsnorm2_q8_rows(x, ao, w.post_attn_norm, h, hn, q81,
+        static const bool kDecodeNvfp4 = [] {
+            const char* e = getenv("SPARKINFER_QWEN38_DECODE_NVFP4");
+            return !(e && e[0] == '0');
+        }();
+        const bool native_ffn_here = dense && kDecodeNvfp4 &&
+                                     w.gate_nv && w.up_nv && w.down_nv;
+        kernels::launch_add_rmsnorm2_q8_rows(x, ao, w.post_attn_norm, h, hn,
+                                             native_ffn_here ? nullptr : q81,
                                              N, H, c.rms_eps, st);
         // FIXED (2026-08-17): this used to snapshot h BEFORE this kernel wrote it -- h is an
         // arena buffer reused every layer, so the earlier capture was reading whatever the
@@ -2889,12 +2896,6 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // constants AR uses (expert 0, weight 1.0) and run the identical expert kernel at N rows,
         // then skip straight past the MoE routing/shared machinery below.
         if (dense) {
-            // Same default and same env as the decode dispatch in qwen35.cpp -- ON unless
-            // SPARKINFER_QWEN38_DECODE_NVFP4=0. These two MUST stay in lockstep; see below.
-            static const bool kDecodeNvfp4 = [] {
-                const char* e = getenv("SPARKINFER_QWEN38_DECODE_NVFP4");
-                return !(e && e[0] == '0');
-            }();
             const bool native_ffn = kDecodeNvfp4 && w.gate_nv && w.up_nv && w.down_nv;
             const bool q4_ffn = w.gate_q && w.up_q && w.down_q;
             if (!native_ffn && !q4_ffn) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2909,14 +2909,16 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // inconsistency, not an accuracy finding. Measured exactly that way before this
             // branch existed.
             if (native_ffn) {
-                if (topk != 1 ||
+                const bool dual = topk == 1 && kernels::launch_gemv_nvfp4_rows_dual_swiglu(
+                    hn, w.gate_nv, w.up_nv, sh, N, ffn, H, st);
+                if (!dual && (topk != 1 ||
                     !kernels::launch_gemv_nvfp4_rows(hn, w.gate_nv, sg, N, ffn, H, st) ||
-                    !kernels::launch_gemv_nvfp4_rows(hn, w.up_nv, su, N, ffn, H, st)) {
+                    !kernels::launch_gemv_nvfp4_rows(hn, w.up_nv, su, N, ffn, H, st))) {
                     fprintf(stderr, "[dflash-verify] NVFP4 gate/up declined N=%d ffn=%d H=%d\n",
                             N, ffn, H);
                     supported = false; break;
                 }
-                kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
+                if (!dual) kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
                 if (!kernels::launch_gemv_nvfp4_rows(sh, w.down_nv, routed, N, H, ffn, st)) {
                     fprintf(stderr, "[dflash-verify] NVFP4 down declined N=%d H=%d ffn=%d\n",
                             N, H, ffn);


### PR DESCRIPTION
## Summary

Fuse the two native-NVFP4 dense-FFN gate/up projections and their SwiGLU epilogue in the DSpark verifier. The fused kernel loads each activation group once for both weight streams, preserves each projection's reduction order and BF16 rounding point, and removes the standalone SwiGLU graph node.

Skip the fused RMSNorm kernel's Q8_1 epilogue when the verifier immediately enters a checkpoint-native NVFP4 FFN. Native NVFP4 consumes the BF16 normalized rows directly, so those 64 per-layer quantizations and stores were dead work. The RMSNorm reduction and BF16 output path are unchanged.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 94.69 |
| after (this PR) | 97.14 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090, Qwen3.8-27B NVFP4 + released DSpark draft, ctx=4096, max_new=128
SPARKINFER_QWEN38_DECODE_NVFP4=1

before (upstream/main):
  DSPARK          94.6927 tok/s
  tau             1.5059
  lossless        YES

after (fused NVFP4 FFN + unused Q8 epilogue removal):
  DSPARK          97.1365 tok/s
  tau             1.5059
  lossless        YES

repeat validation:
  SPEC-REPS 3 reps, 0 differ-from-first, 0 not-lossless-vs-AR
  DSPARK          96.7339 tok/s
  tau             1.5059

rejected controls (not included):
  fused Markov bias + argmax: 95.9997 tok/s
  native LMHead4 prototype: rejected (compact verifier differential)
  one output/warp: 95.8728 tok/s
  three outputs/warp: 95.7584 tok/s
  fused attention K/V: 96.2491 tok/s
```

