### PR TITLE
perf(dspark): dp4a the native NVFP4 dense FFN (1.08x dspark-decode@4k)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -951,6 +951,160 @@ __global__ void gemv_nvfp4_rows_sk_kernel(const __nv_bfloat16* __restrict__ x,
         }
     }
 }
+
+// ================= dp4a NVFP4 =================================================================
+//
+// The float path above decodes every nibble to a float and does 16 fp32 FMAs per group PER ROW.
+// ncu on the current default says that is what limits it: no pipe is saturated (DRAM 58.4%,
+// SM 55.3%, Mem Pipes 14.2%), ALU Heavy is 47-62% of executed instructions, and 40-48% of the ~11
+// cycles between issues is a Long Scoreboard stall on L1TEX that occupancy cannot hide because 64
+// registers/thread caps the kernel at 4 blocks/SM.
+//
+// NVFP4's decoded magnitudes are EXACT integers -- {0,+-1,+-2,+-3,+-4,+-6,+-8,+-12}, the doubled
+// e2m1 magnitudes -- so sum(w_k * x_k) over a group is exactly group_scale * sum(mag_k * xq_k)
+// once the activation is int8. That turns 16 FMAs into 4 dp4a per row, and lets the nibble decode
+// run as byte-parallel table lookups instead of per-nibble arithmetic.
+//
+// PRMT AS A BYTE LUT. __byte_perm(a, b, sel) uses four nibbles of `sel` to pick four bytes out of
+// {a, b} -- and the NVFP4 codes ARE nibbles already, so one instruction looks up four magnitudes.
+// A second lookup builds the sign mask (selector nibble 0/1 picks 0x00/0xFF), and __vsub4 applies
+// it byte-wise without borrowing across lanes. That is ~1.75 ALU ops per weight against ~10.5 for
+// the float decode, and the int8 staging is a quarter the registers of the float staging.
+//
+// -0 is handled: code 8 gives mag 0 and mask 0xFF, and (0 ^ 0xFF) - 0xFF is 0 in byte arithmetic,
+// which is the correct int8 for -0.
+__device__ __forceinline__ void si_nvfp4_i8x8(unsigned p, unsigned& q0, unsigned& q1) {
+    // Magnitudes for codes 0..3 and 4..7, one byte each, in the two PRMT source registers.
+    const unsigned MAG_LO = 0x03020100u;   // {0, 1, 2, 3}
+    const unsigned MAG_HI = 0x0C080604u;   // {4, 6, 8, 12}
+    const unsigned SGN    = 0x0000FF00u;   // byte 0 = 0x00 (positive), byte 1 = 0xFF (negative)
+    const unsigned msel = p & 0x77777777u;          // code & 7  -> magnitude index
+    const unsigned ssel = (p >> 3) & 0x11111111u;   // code >> 3 -> 0 or 1
+    const unsigned m0 = __byte_perm(MAG_LO, MAG_HI, msel);
+    const unsigned s0 = __byte_perm(SGN, 0u, ssel);
+    const unsigned m1 = __byte_perm(MAG_LO, MAG_HI, msel >> 16);
+    const unsigned s1 = __byte_perm(SGN, 0u, ssel >> 16);
+    q0 = __vsub4(m0 ^ s0, s0);
+    q1 = __vsub4(m1 ^ s1, s1);
+}
+
+// One thread per 16-element activation group: symmetric int8 with a per-group scale. Matching the
+// NVFP4 group width keeps the quantization as local as the weights it multiplies.
+__global__ void si_nvfp4_quant_x_kernel(const __nv_bfloat16* __restrict__ x,
+                                        signed char* __restrict__ xq,
+                                        float* __restrict__ xs, int ngroups) {
+    const int gi = blockIdx.x * blockDim.x + threadIdx.x;
+    if (gi >= ngroups) return;
+    const __nv_bfloat16* src = x + (size_t)gi * 16;
+    float v[16];
+    si_nvfp4_load_x16_v4(src, v);
+    float amax = 0.f;
+    #pragma unroll
+    for (int i = 0; i < 16; i++) { const float a = fabsf(v[i]); amax = a > amax ? a : amax; }
+    const float s   = amax * (1.f / 127.f);
+    const float inv = amax > 0.f ? 127.f / amax : 0.f;
+    signed char o[16];
+    #pragma unroll
+    for (int i = 0; i < 16; i++) o[i] = (signed char)__float2int_rn(v[i] * inv);
+    *reinterpret_cast<uint4*>(xq + (size_t)gi * 16) = *reinterpret_cast<const uint4*>(o);
+    xs[gi] = s;
+}
+
+template <typename OutT, int S, int R, int NR>
+__global__ void gemv_nvfp4_rows_dp4a_kernel(const signed char* __restrict__ xq,
+                                            const float* __restrict__ xs,
+                                            const void* __restrict__ packed,
+                                            OutT* __restrict__ y, int N, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float s_part[RPB][S][NR][R];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int n0 = blockIdx.x * (RPB * NR) + row_local * NR;
+    float acc[NR][R];
+    #pragma unroll
+    for (int j = 0; j < NR; j++)
+        #pragma unroll
+        for (int r = 0; r < R; r++) acc[j][r] = 0.f;
+    if (n0 < N) {
+        const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
+        const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
+        const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+        const int ng = K >> 4;
+        for (int g = split * 32 + lane; g < ng; g += S * 32) {
+            uint4 xv[R];
+            float sx[R];
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                xv[r] = *reinterpret_cast<const uint4*>(xq + (size_t)r * K + (size_t)g * 16);
+                sx[r] = xs[(size_t)r * ng + g];
+            }
+            #pragma unroll
+            for (int j = 0; j < NR; j++) {
+                const int nj = n0 + j;
+                if (NR > 1 && nj >= N) break;
+                const unsigned char* srow = sf + (size_t)nj * (size_t)(K >> 4);
+                const unsigned char* prow = w + (size_t)nj * (size_t)(K >> 1);
+                const uint2 pw = __ldg(reinterpret_cast<const uint2*>(prow + (size_t)g * 8));
+                unsigned q0, q1, q2, q3;
+                si_nvfp4_i8x8(pw.x, q0, q1);
+                si_nvfp4_i8x8(pw.y, q2, q3);
+                const float sw = si_ue4m3(srow[g]) * inv_g * 0.5f;
+                #pragma unroll
+                for (int r = 0; r < R; r++) {
+                    int iacc = 0;
+                    iacc = __dp4a((int)q0, (int)xv[r].x, iacc);
+                    iacc = __dp4a((int)q1, (int)xv[r].y, iacc);
+                    iacc = __dp4a((int)q2, (int)xv[r].z, iacc);
+                    iacc = __dp4a((int)q3, (int)xv[r].w, iacc);
+                    acc[j][r] += (sw * sx[r]) * (float)iacc;
+                }
+            }
+        }
+        #pragma unroll
+        for (int j = 0; j < NR; j++)
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                #pragma unroll
+                for (int m = 16; m > 0; m >>= 1)
+                    acc[j][r] += __shfl_xor_sync(0xffffffff, acc[j][r], m);
+            }
+        if (lane == 0) {
+            #pragma unroll
+            for (int j = 0; j < NR; j++)
+                #pragma unroll
+                for (int r = 0; r < R; r++) s_part[row_local][split][j][r] = acc[j][r];
+        }
+    }
+    __syncthreads();
+    if (n0 < N && split == 0 && lane == 0) {
+        #pragma unroll
+        for (int j = 0; j < NR; j++) {
+            const int nj = n0 + j;
+            if (NR > 1 && nj >= N) break;
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                float o = s_part[row_local][0][j][r];
+                #pragma unroll
+                for (int t = 1; t < S; t++) o += s_part[row_local][t][j][r];
+                gemv_write(y + (size_t)r * N + nj, o);
+            }
+        }
+    }
+}
+#ifndef _MSC_VER
+#define SI_NVFP4_DP4A_INST(S_, R_) \
+template __global__ void gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S_, R_, 2>(const signed char*, const float*, const void*, __nv_bfloat16*, int, int);
+SI_NVFP4_DP4A_INST(2, 1) SI_NVFP4_DP4A_INST(4, 1) SI_NVFP4_DP4A_INST(8, 1)
+SI_NVFP4_DP4A_INST(2, 2) SI_NVFP4_DP4A_INST(4, 2) SI_NVFP4_DP4A_INST(8, 2)
+SI_NVFP4_DP4A_INST(2, 3) SI_NVFP4_DP4A_INST(4, 3) SI_NVFP4_DP4A_INST(8, 3)
+SI_NVFP4_DP4A_INST(2, 4) SI_NVFP4_DP4A_INST(4, 4) SI_NVFP4_DP4A_INST(8, 4)
+SI_NVFP4_DP4A_INST(2, 5) SI_NVFP4_DP4A_INST(4, 5) SI_NVFP4_DP4A_INST(8, 5)
+SI_NVFP4_DP4A_INST(2, 6) SI_NVFP4_DP4A_INST(4, 6) SI_NVFP4_DP4A_INST(8, 6)
+SI_NVFP4_DP4A_INST(2, 7) SI_NVFP4_DP4A_INST(4, 7) SI_NVFP4_DP4A_INST(8, 7)
+SI_NVFP4_DP4A_INST(2, 8) SI_NVFP4_DP4A_INST(4, 8) SI_NVFP4_DP4A_INST(8, 8)
+#undef SI_NVFP4_DP4A_INST
+#endif
+
 #ifndef _MSC_VER
 #define SI_NVFP4_ROWS_INST(S_, R_) \
 template __global__ void gemv_nvfp4_rows_sk_kernel<__nv_bfloat16, S_, R_, 1, 0>(const __nv_bfloat16*, const void*, __nv_bfloat16*, int, int); \
@@ -2581,6 +2735,47 @@ void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K, cuda
     }
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
     gemv_nvfp4_kernel<__nv_bfloat16><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, W, yp, N, K);
+}
+
+void launch_gemv_nvfp4_quant_x(const void* x, void* xq, void* xs, int M, int K,
+                               cudaStream_t stream) {
+    if (!x || !xq || !xs || M < 1 || K < 1 || (K & 15)) return;
+    const int ngroups = M * (K >> 4);
+    const int blk = 256;
+    si_nvfp4_quant_x_kernel<<<(ngroups + blk - 1) / blk, blk, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<signed char*>(xq),
+        reinterpret_cast<float*>(xs), ngroups);
+}
+
+bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, void* y,
+                                 int M, int N, int K, cudaStream_t stream) {
+    if (!xq || !xs || !W || !y || N < 1 || K < 1 || (K & 15)) return false;
+    if (!gemv_bf16_splitk()) return false;
+    if (M < 1 || M > 8) return false;
+    const auto* xp = reinterpret_cast<const signed char*>(xq);
+    const auto* sp = reinterpret_cast<const float*>(xs);
+    auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
+    // Split-K chosen by N exactly as the float rows kernel does, so the two paths fan out over the
+    // GPU identically and a comparison between them is a comparison of the arithmetic alone.
+#define SI_NVFP4_DP4A(S_, R_) do { \
+        constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
+        const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
+        gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
+    } while (0)
+#define SI_NVFP4_DP4A_S(R_) do { \
+        if (N >= 8192)      SI_NVFP4_DP4A(2, R_); \
+        else if (N >= 4096) SI_NVFP4_DP4A(4, R_); \
+        else                SI_NVFP4_DP4A(8, R_); \
+    } while (0)
+    switch (M) {
+        case 1: SI_NVFP4_DP4A_S(1); break;  case 2: SI_NVFP4_DP4A_S(2); break;
+        case 3: SI_NVFP4_DP4A_S(3); break;  case 4: SI_NVFP4_DP4A_S(4); break;
+        case 5: SI_NVFP4_DP4A_S(5); break;  case 6: SI_NVFP4_DP4A_S(6); break;
+        case 7: SI_NVFP4_DP4A_S(7); break;  default: SI_NVFP4_DP4A_S(8); break;
+    }
+#undef SI_NVFP4_DP4A_S
+#undef SI_NVFP4_DP4A
+    return true;
 }
 
 bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N, int K,

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstdlib>
 #include <cuda_runtime.h>
 
 namespace sparkinfer { namespace kernels {
@@ -91,6 +92,36 @@ bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N,
 
 void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K,
                        cudaStream_t stream = nullptr);
+
+// ---- dp4a NVFP4: exact-integer weight magnitudes against int8 activations ----
+//
+// NVFP4 decodes to w = mag * (group_scale/2) where mag is one of {0,+-1,+-2,+-3,+-4,+-6,+-8,+-12}
+// -- EXACT small integers. So a group's dot is group_scale * sum(mag_k * xq_k), an exact integer
+// reduction, which is what makes dp4a legal here rather than an approximation of the float path.
+// Weights stay exact; only the activation is quantized.
+//
+// launch_gemv_nvfp4_quant_x quantizes M rows of bf16 activations to int8 with ONE scale per
+// 16-element group -- the same granularity as the NVFP4 weight groups, and finer than the Q8_1
+// per-32 blocks the Q4_K path used. Call it once per activation buffer and reuse the result across
+// every projection that reads that buffer.
+//
+// The rows kernel is instantiated from M = 1, so AR decode (one row) and the speculative verify
+// (M rows) run the SAME kernel and agree by construction, which is what DSpark's losslessness
+// gate requires of any path that replaces launch_gemv_nvfp4.
+// ONE switch for both sides. Decode and the speculative verify must select the same FFN
+// arithmetic or DSpark stops reproducing AR and the losslessness gate fails on a path
+// inconsistency rather than on anything about accuracy.
+inline bool qwen38_nvfp4_dp4a() {
+    static const bool v = [] {
+        const char* e = getenv("SPARKINFER_QWEN38_NVFP4_DP4A");
+        return !e || e[0] != '0';
+    }();
+    return v;
+}
+void launch_gemv_nvfp4_quant_x(const void* x, void* xq, void* xs, int M, int K,
+                               cudaStream_t stream);
+bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, void* y,
+                                 int M, int N, int K, cudaStream_t stream);
 
 // Pre-quantized Q8_1 activation path: quantize x[K] ONCE (q8 int8 [K], ad/as [K/32]),
 // then run Q4_K dp4a GEMVs that read it — kills the per-block re-quantization that the

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -272,6 +272,10 @@ struct Qwen35Model::Impl {
     // the SwiGLU result that feeds down. bf16 [moe_ffn] each -- ~104 KB total at ffn=17408, so it
     // is allocated unconditionally rather than gated, keeping the decode path branch-free.
     bf16 *nv_gate = nullptr, *nv_up = nullptr, *nv_h = nullptr;
+    // int8 staging for the dp4a NVFP4 FFN: one quantize of the layer input feeds gate AND up,
+    // a second feeds down. Sized for the widest K the FFN reads (moe_ffn for down).
+    signed char *nv_xq = nullptr;
+    float *nv_xs = nullptr;
     float *sx_h = nullptr;   // pipelined shared-expert h_scratch (avoids racing routed mf_h)
     void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
@@ -506,6 +510,8 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->nv_gate    = p_->alloc<bf16>(cfg.moe_ffn);
     p_->nv_up      = p_->alloc<bf16>(cfg.moe_ffn);
     p_->nv_h       = p_->alloc<bf16>(cfg.moe_ffn);
+    p_->nv_xq      = p_->alloc<signed char>(cfg.moe_ffn);
+    p_->nv_xs      = p_->alloc<float>(cfg.moe_ffn / 16 + 1);
     if (cfg.dense_ffn && cfg.top_k > 0) {
         cu(cudaMemcpy(p_->mf_ids, &zero, sizeof(int), cudaMemcpyHostToDevice), "dense expert id");
         cu(cudaMemcpy(p_->mf_weights, &one, sizeof(float), cudaMemcpyHostToDevice), "dense expert w");
@@ -1729,10 +1735,31 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             // experiment; if the accuracy win is real, the fusion work follows, and NVFP4's
             // decoded magnitudes are exact int8 so a dp4a path is reachable.
             if (w.gate_nv && w.up_nv && w.down_nv && c.top_k == 1) {
+                // dp4a NVFP4 (SPARKINFER_QWEN38_NVFP4_DP4A=0 restores the float GEMVs). The
+                // weights stay exactly what the checkpoint ships -- NVFP4 magnitudes are integers,
+                // so the group dot is an exact integer reduction -- and only the activation is
+                // quantized, at one scale per 16 values.
+                //
+                // The verify in qwen35_prefill.cpp switches on the SAME flag and calls the SAME
+                // kernel at N rows. Both sides must move together: losslessness here is defined as
+                // the speculative output matching the AR output of this build, so a decode on
+                // dp4a against a verify on the float path would disagree and report LOSSLESS=0.
+                if (kernels::qwen38_nvfp4_dp4a()) {
+                    kernels::launch_gemv_nvfp4_quant_x(s.hn, s.nv_xq, s.nv_xs, 1, H, st);
+                    kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_xq, s.nv_xs, w.gate_nv, s.nv_gate,
+                                                         1, c.moe_ffn, H, st);
+                    kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_xq, s.nv_xs, w.up_nv, s.nv_up,
+                                                         1, c.moe_ffn, H, st);
+                    kernels::launch_prefill_swiglu(s.nv_gate, s.nv_up, s.nv_h, c.moe_ffn, st);
+                    kernels::launch_gemv_nvfp4_quant_x(s.nv_h, s.nv_xq, s.nv_xs, 1, c.moe_ffn, st);
+                    kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_xq, s.nv_xs, w.down_nv, s.routed,
+                                                         1, H, c.moe_ffn, st);
+                } else {
                 kernels::launch_gemv_nvfp4(s.hn, w.gate_nv, s.nv_gate, c.moe_ffn, H, st);
                 kernels::launch_gemv_nvfp4(s.hn, w.up_nv, s.nv_up, c.moe_ffn, H, st);
                 kernels::launch_prefill_swiglu(s.nv_gate, s.nv_up, s.nv_h, c.moe_ffn, st);
                 kernels::launch_gemv_nvfp4(s.nv_h, w.down_nv, s.routed, H, c.moe_ffn, st);
+                }
             } else
             kernels::launch_moe_expert_ffn_q4k(s.hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2364,6 +2364,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     bf16* x = a.alloc<bf16>((size_t)N * H);
     bf16* xn = a.alloc<bf16>((size_t)N * H);
     bf16* h = a.alloc<bf16>((size_t)N * H);
+    // dp4a NVFP4 FFN staging, hoisted OUT of the layer loop on purpose. Arena::alloc falls back to
+    // cudaMalloc on a miss, and this function runs inside the verify's CUDA graph capture, where
+    // cudaMalloc is illegal -- allocating per layer returned null on the first captured pass and
+    // the FFN silently declined. Everything else here is allocated up front for the same reason.
+    const int nv_kwide = (c.moe_ffn > H ? c.moe_ffn : H);
+    signed char* nv_xq = a.alloc<signed char>((size_t)N * nv_kwide);
+    float* nv_xs = a.alloc<float>((size_t)N * (nv_kwide / 16) + 1);
     // DEBUG ONLY (dspark_tau_check bisection, 2026-08-17): SPARKINFER_DFLASH_VERIFY_DUMP_ROW=<row>
     // dumps that row's pre-attn-norm xn after EVERY layer, plus the post-final-norm xn, into
     // [n_layers+1, H] bf16 written to SPARKINFER_DFLASH_VERIFY_DUMP_FILE (default
@@ -2908,7 +2915,27 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // the two disagree on weights that differ by ~8% and reports LOSSLESS=0 -- a path
             // inconsistency, not an accuracy finding. Measured exactly that way before this
             // branch existed.
-            if (native_ffn) {
+            // dp4a arm, selected by the SAME switch the decode branch reads (qwen35.cpp). One
+            // quantize of hn feeds both gate and up; a second feeds down. Scratch comes from the
+            // verify arena, so it is sized for N rows and released with the rest of the pass.
+            if (native_ffn && topk == 1 && kernels::qwen38_nvfp4_dp4a()) {
+                signed char* xq = nv_xq;
+                float* xs = nv_xs;
+                kernels::launch_gemv_nvfp4_quant_x(hn, xq, xs, N, H, st);
+                if (!kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.gate_nv, sg, N, ffn, H, st) ||
+                    !kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.up_nv, su, N, ffn, H, st)) {
+                    fprintf(stderr, "[dflash-verify] NVFP4 dp4a gate/up declined N=%d ffn=%d H=%d\n",
+                            N, ffn, H);
+                    supported = false; break;
+                }
+                kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
+                kernels::launch_gemv_nvfp4_quant_x(sh, xq, xs, N, ffn, st);
+                if (!kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.down_nv, routed, N, H, ffn, st)) {
+                    fprintf(stderr, "[dflash-verify] NVFP4 dp4a down declined N=%d H=%d ffn=%d\n",
+                            N, H, ffn);
+                    supported = false; break;
+                }
+            } else if (native_ffn) {
                 if (topk != 1 ||
                     !kernels::launch_gemv_nvfp4_rows(hn, w.gate_nv, sg, N, ffn, H, st) ||
                     !kernels::launch_gemv_nvfp4_rows(hn, w.up_nv, su, N, ffn, H, st)) {


### PR DESCRIPTION
## Summary

Run the native-NVFP4 dense FFN on dp4a instead of float GEMVs. NVFP4's decoded magnitudes are exact integers, so a group's dot is exactly `group_scale * sum(mag_k * xq_k)`; the weights stay bit-exact and only the activation is quantized, at one scale per 16 values. Decode and the speculative verify switch together and call the same kernel.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 95.85 |
| after (this PR) | 103.24 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090, Qwen3.8-27B NVFP4 + released DSpark draft, ctx=4096, max_new=128, SPEC-REPS 3

before (SPARKINFER_QWEN38_NVFP4_DP4A=0):
  DSPARK          95.85 tok/s
  AR              82.22 tok/s
  batched verify  13.590 ms/call
  tau             1.5059
  lossless        YES   (3 reps, 0 differ-from-first, 0 not-lossless-vs-AR)

after (dp4a):
  DSPARK         103.24 tok/s
  AR              88.33 tok/s
  batched verify  12.395 ms/call
  tau             1.5059
  lossless        YES   (3 reps, 0 differ-from-first, 0 not-lossless-vs-AR)

emitted stream is byte-identical to main:
  before  SPEC[ 2407 314 6337 421 369 524 177460 1196 ]  steps=85 tokens=128
  after   SPEC[ 2407 314 6337 421 369 524 177460 1196 ]  steps=85 tokens=128

single-rep repeats, alternated arms, same binary:
  off  95.37 / 95.10   verify 13.594 / 13.638
  on  103.33 / 103.35  verify 12.391 / 12.390

kernel (cuobjdump / ncu, gemv_nvfp4_rows_*_kernel<bf16,4,2,2>):
  registers    65 -> 48   (Block Limit Registers 4 -> 5)
  SASS         per-nibble I2F/shift/mask -> IDP.4A + PRMT
  before ncu   DRAM 58.4%, SM 55.3%, Mem Pipes 14.2%, ALU Heavy 47-62% of instructions,
               Long Scoreboard 40-48% of 11.1 cycles between issues,
               6.89 active warps/scheduler, 37.8% of cycles with no eligible warp

rejected on the same binary, kept out:
  half-group activation staging   87.20 tok/s  (registers 65 -> 62, does not change the block limit)
  2-group unroll of the g loop    94.31 tok/s  (registers 65 -> 72, block limit 4 -> 3)
```
