### PR TITLE
perf(dspark): dp4a the NVFP4 GDN/attention projections and take the depth they pay for (1.06x dspark-decode@4k)

### DIFF
--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -111,6 +111,15 @@ void launch_gemv_nvfp4(const void* x, const void* W, void* y, int N, int K,
 // ONE switch for both sides. Decode and the speculative verify must select the same FFN
 // arithmetic or DSpark stops reproducing AR and the losslessness gate fails on a path
 // inconsistency rather than on anything about accuracy.
+// Attention and GDN projections, switched separately from the FFN so each arm can be A/B'd on
+// its own. Decode and verify both read this, so they cannot disagree.
+inline bool qwen38_nvfp4_dp4a_proj() {
+    static const bool v = [] {
+        const char* e = getenv("SPARKINFER_QWEN38_NVFP4_DP4A_PROJ");
+        return !e || e[0] != '0';
+    }();
+    return v;
+}
 inline bool qwen38_nvfp4_dp4a() {
     static const bool v = [] {
         const char* e = getenv("SPARKINFER_QWEN38_NVFP4_DP4A");

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -276,6 +276,12 @@ struct Qwen35Model::Impl {
     // a second feeds down. Sized for the widest K the FFN reads (moe_ffn for down).
     signed char *nv_xq = nullptr;
     float *nv_xs = nullptr;
+    // Projection-side int8 staging (attention + GDN), separate from the FFN's. `a` holds the
+    // layer input xn, shared by every projection that reads it; `b` holds one-off inputs
+    // (o_proj's att, ssm_out's lnrm) so quantizing those cannot clobber xn while the parallel
+    // K/V and GDN streams are still reading it.
+    signed char *nv_pq_a = nullptr, *nv_pq_b = nullptr;
+    float *nv_ps_a = nullptr, *nv_ps_b = nullptr;
     float *sx_h = nullptr;   // pipelined shared-expert h_scratch (avoids racing routed mf_h)
     void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
@@ -512,6 +518,15 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->nv_h       = p_->alloc<bf16>(cfg.moe_ffn);
     p_->nv_xq      = p_->alloc<signed char>(cfg.moe_ffn);
     p_->nv_xs      = p_->alloc<float>(cfg.moe_ffn / 16 + 1);
+    {
+        int pw = cfg.hidden;
+        if (p_->qdim > pw) pw = p_->qdim;
+        if (p_->linear_vdim > pw) pw = p_->linear_vdim;
+        p_->nv_pq_a = p_->alloc<signed char>(pw);
+        p_->nv_ps_a = p_->alloc<float>(pw / 16 + 1);
+        p_->nv_pq_b = p_->alloc<signed char>(pw);
+        p_->nv_ps_b = p_->alloc<float>(pw / 16 + 1);
+    }
     if (cfg.dense_ffn && cfg.top_k > 0) {
         cu(cudaMemcpy(p_->mf_ids, &zero, sizeof(int), cudaMemcpyHostToDevice), "dense expert id");
         cu(cudaMemcpy(p_->mf_weights, &one, sizeof(float), cudaMemcpyHostToDevice), "dense expert w");
@@ -1161,6 +1176,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 kernels::launch_quantize_q8_1(s.xn, s.aq8, s.aq8_d, s.aq8_s, H, st);
             }
         };
+        // NVFP4 dp4a staging for xn. Issued on `st` before any stream fork, exactly like the
+        // Q8_1 quantize above, so the parallel K/V and GDN streams that read it inherit the same
+        // dependency they already have on xn itself. Not gated on use_pq: that flag selects the
+        // mmvq activation format, which this path does not use.
+        bool xn_nv_ready = false;
+        auto prepare_xn_nvfp4 = [&](bool any_nv) {
+            if (!any_nv || xn_nv_ready || !kernels::qwen38_nvfp4_dp4a_proj()) return;
+            kernels::launch_gemv_nvfp4_quant_x(s.xn, s.nv_pq_a, s.nv_ps_a, 1, H, st);
+            xn_nv_ready = true;
+        };
         auto proj_xn = [&](const void* W, int t, void* y, int N, cudaStream_t pst) {
             if (s.gguf) {
                 if (s.use_pq && t == 12) {
@@ -1173,8 +1198,12 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                     kernels::launch_mmvq_q80(s.aq81, W, y, N, H, pst);
                 else if (t == kernels::SI_QTYPE_FP8)
                     kernels::launch_gemv_fp8(s.xn, W, y, N, H, pst);
-                else if (t == kernels::SI_QTYPE_NVFP4)
-                    kernels::launch_gemv_nvfp4(s.xn, W, y, N, H, pst);
+                else if (t == kernels::SI_QTYPE_NVFP4) {
+                    if (!(xn_nv_ready &&
+                          kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_pq_a, s.nv_ps_a, W, y,
+                                                               1, N, H, pst)))
+                        kernels::launch_gemv_nvfp4(s.xn, W, y, N, H, pst);
+                }
                 else if (t) kernels::launch_gemv_q(s.xn, W, t, y, N, H, pst);
                 else        kernels::launch_gemv(s.xn, W, y, N, H, pst);
             } else {
@@ -1200,6 +1229,11 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 } else if (t == kernels::SI_QTYPE_FP8) {
                     kernels::launch_gemv_fp8(x, W, y, N, K, st);
                 } else if (t == kernels::SI_QTYPE_NVFP4) {
+                    if (kernels::qwen38_nvfp4_dp4a_proj()) {
+                        kernels::launch_gemv_nvfp4_quant_x(x, s.nv_pq_b, s.nv_ps_b, 1, K, st);
+                        if (kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_pq_b, s.nv_ps_b, W, y,
+                                                                 1, N, K, st)) return;
+                    }
                     kernels::launch_gemv_nvfp4(x, W, y, N, K, st);
                 } else if (t) kernels::launch_gemv_q(x, W, t, y, N, K, st);
                 else          kernels::launch_gemv(x, W, y, N, K, st);
@@ -1216,6 +1250,10 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             const bool any_q80 = (w.wqkv_type == 8 || w.wqkv_gate_type == 8 ||
                                   w.ssm_alpha_type == 8 || w.ssm_beta_type == 8);
             prepare_xn_quant(any_q4k, any_q6k, any_q80);
+            prepare_xn_nvfp4(w.wqkv_type == kernels::SI_QTYPE_NVFP4 ||
+                             w.wqkv_gate_type == kernels::SI_QTYPE_NVFP4 ||
+                             w.ssm_alpha_type == kernels::SI_QTYPE_NVFP4 ||
+                             w.ssm_beta_type == kernels::SI_QTYPE_NVFP4);
             const bool gdn_quad = s.use_gdn_quad && s.gguf && s.use_pq && s.use_llama && H == 2048
                                && w.wqkv_type == 12 && w.wqkv_gate_type == 12
                                && w.ssm_alpha_type == 12 && w.ssm_beta_type == 12;
@@ -1326,6 +1364,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
                 const bool any_q80 = (w.wq_type == 8 || w.wk_type == 8 || w.wv_type == 8);
                 prepare_xn_quant(any_q4k, any_q6k, any_q80);
+                prepare_xn_nvfp4(w.wq_type == kernels::SI_QTYPE_NVFP4 ||
+                                 w.wk_type == kernels::SI_QTYPE_NVFP4 ||
+                                 w.wv_type == kernels::SI_QTYPE_NVFP4);
                 // Muse Glimmer keeps attn_gate as its own quantized tensor (w.wgate), so Q goes
                 // straight to s.q and the gate straight to s.qgate -- no [q|gate] interleave to
                 // build and no split to undo it. Every other model still fuses them into s.qraw.
@@ -1589,6 +1630,15 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 kernels::launch_quantize_q8_1_blocks(s.attn, s.aq81, s.qdim, st);
                 kernels::launch_mmvq_q80(s.aq81, w.wo, s.ao, H, s.qdim, st);
             }
+            // o_proj does not go through proj_from, so it needs the dp4a arm spelled out here.
+            // The verify drives w.wo through its own proj(), which does take that arm -- leaving
+            // this one on the float GEMV made decode and verify disagree on 16 layers' worth of
+            // attention output, which showed up as LOSSLESS=0 rather than as a wrong number.
+            else if (s.gguf && w.wo_type == kernels::SI_QTYPE_NVFP4 &&
+                     kernels::qwen38_nvfp4_dp4a_proj() &&
+                     (kernels::launch_gemv_nvfp4_quant_x(s.attn, s.nv_pq_b, s.nv_ps_b, 1, s.qdim, st),
+                      kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_pq_b, s.nv_ps_b, w.wo, s.ao,
+                                                           1, H, s.qdim, st))) {}
             else if (s.gguf && w.wo_type) kernels::launch_gemv_q(s.attn, w.wo, w.wo_type, s.ao, H, s.qdim, st);
             else if (s.gguf)         kernels::launch_gemv(s.attn, w.wo, s.ao, H, s.qdim, st);
             else                     kernels::launch_gemm(s.attn, w.wo, s.ao, 1, H, s.qdim, 1.f, 0.f, gc, st);
@@ -3144,42 +3194,14 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 12288;
         return v < 1 ? 1 : v;
     }();
-    // ...and then stop proposing deeper than the DRAFT's own context cost can pay for.
+    // ...and then propose as deep as the draft's own block already reaches.
     //
-    // Each extra proposal is another row in the draft block: another 248320-wide LM-head row and
-    // argmax, and another row of the draft's own attention over the same KV. The first two are
-    // fixed, but the third grows with context, so the depth that pays is not a property of the
-    // model, it is a property of how long the sequence already is. In the token loop the extra
-    // proposals buy nothing unless they are actually accepted, and at this model's acceptance
-    // they are not: mean accepted length is identical at depth 1, 2 and 3 at 4k.
+    // Each extra proposal is another row in the draft block -- another 248320-wide LM-head row and
+    // argmax, and another row of the draft's own attention over the same KV -- and another row in
+    // the target's batched verify. Whether that pays is decided by what a verify row costs, and
+    // that number moved: with every NVFP4 projection on dp4a the marginal row is 0.963 ms against
+    // the ~3.6 ms it cost when this ladder last chose one proposal.
     //
-    // Measured on RTX 5090 at the split counts the server runs (not the harness pin), one binary,
-    // DSPARK_TPS with lossless=1 everywhere:
-    //
-    //     ctx    depth 1    depth 3     mean accept (d1 / d3)
-    //     128     81.94      91.69      1.1034 / 1.0159      <- depth 3 wins
-    //     512     92.32      91.95      1.0000 / 1.0000      <- tie, draft inert
-    //     1024    78.72      68.30      1.1429 / 1.1566      <- depth 1 by 15.3%
-    //     2048    83.04      78.35      1.0435 / 1.0435      <- depth 1 by 6.0%
-    //     4096    81.23      74.82      1.0756 / 1.0756      <- depth 1 by 8.6%
-    //
-    // 128 is the one context that prefers the wide block, and for a reason that is visible in its
-    // acceptance column rather than its throughput: at depth 3 the draft accepts essentially
-    // nothing (1.0159), the idle-draft rule stops drafting altogether, and the stream runs at AR
-    // speed. Narrowing raises acceptance just enough (1.1034) to keep the draft alive without
-    // being worth its cost. So the rule is not "narrow always" -- it is "narrow once the draft is
-    // carrying a context whose per-row cost the deeper proposals cannot repay", which is what the
-    // 512 tie and everything above it show.
-    //
-    // Scope: only the band this measures. Below kNarrowMinSeq nothing changes, and the
-    // >= kDeepMinSeq branch keeps its own depth of 7 -- long context is where acceptance actually
-    // climbs and it is measured separately. The batched verify also keeps the static depth: its
-    // row count has to match the graph dflash_warm_verify captured for kProposalDepth+1 rows.
-    static const int kNarrowMinSeq = []{
-        const char* e = getenv("SPARKINFER_DFLASH_NARROW_MINSEQ");
-        int v = e ? atoi(e) : 512;
-        return v < 1 ? 1 : v;
-    }();
     // Explicit override wins; 0/unset selects by length. Keep in sync with dflash_draft.cpp, which
     // reads the same variable for its own default and is handed this value per block.
     static const int kProposalDepthEnv = []{
@@ -3187,35 +3209,18 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         int v = e ? atoi(e) : 0;
         return v < 0 ? 0 : (v > 15 ? 15 : v);
     }();
-    // Below the deep threshold the depth is 3, not 5. Two measurements decide it, both on the
-    // RTX 5090 against the released DSpark draft (block_size 7):
+    // Measured on RTX 5090 at ctx=4096, reps=3, one binary, all lossless:
     //
-    //   1. ACCEPTANCE SATURATES BELOW 4. At ctx=128 the mean accepted length is 1.2549 at depth 3
-    //      and *exactly* 1.2549 at 4, 5 and 6 -- proposals past the third are never accepted, so
-    //      every target row spent verifying them is spent for nothing. At ctx=4096 it is 1.113 at
-    //      depth 3 against 1.123 at depth 5, i.e. a hundredth of a token for two extra rows.
+    //     depth 1  104.28 tok/s  tau 1.5059   depth 3  109.48 tok/s  tau 1.8056
+    //     depth 2  109.30 tok/s  tau 1.7200   depth 4   76.24 tok/s  tau 1.9403
     //
-    //   2. DEPTH 4 IS A CLIFF, NOT A SLOPE. The draft's active block width is
-    //      round_up(depth+1) over {2, 4, 8, 16} capped at block_size, so depth 3 runs a 4-wide draft
-    //      block and depth 4 runs a 7-wide one. Crossing it costs a quarter of the throughput for
-    //      the zero extra accepts above:
-    //
-    //        ctx=128   depth 1/2/3 -> 64.89 / 65.00 / 66.13 tok/s   depth 4/5/6 -> 48.74 / 48.45 / 48.12
-    //        ctx=4096  depth 3 -> 29.88                             depth 5/7   -> 24.28 / 20.46
-    //        ctx=512   depth 3/5/7 -> 77.65 / 77.62 / 77.56         (accept 1.0: DSpark is inert here)
-    //
-    // So 3 is the largest depth that still fits the cheap block-width tier, and nothing below the
-    // deep threshold accepts deeply enough to pay for leaving it. The >= kDeepMinSeq branch keeps
-    // its 7: long context is where acceptance actually climbs (the ladder above this comment), and
-    // it is measured separately.
-    // Narrow band (see the table below): a generation that STARTS above kNarrowMinSeq and stays
-    // below the deep threshold proposes one token, not three. Decided once per generation rather
-    // than per step, because the verify graph dflash_warm_verify captures is sized from this and
-    // a graph built for a row count the stream never uses costs more than the rows it saves --
-    // measured, per-step narrowing under a 4-row warm graph recovers only 0.7% of the 9.4%.
+    // Three is the natural stop, and not by tuning: the draft's block is already FOUR rows wide
+    // (dflash_draft.cpp widens it to 4 whenever a Markov head is present), so depth 3 consumes
+    // every proposal that block already computes. Depth 4 needs a 5-wide block, which rounds to
+    // the checkpoint's block_size of 7 -- a width the draft's batched GEMV is not instantiated
+    // for -- so the draft falls onto its per-token loop and costs 9.92 ms instead of 2.52.
     const int kProposalDepth = kProposalDepthEnv > 0 ? kProposalDepthEnv
-                             : ((n + max_new) >= kDeepMinSeq ? 7
-                                : (n >= kNarrowMinSeq ? 1 : 3));
+                             : ((n + max_new) >= kDeepMinSeq ? 7 : 3);
 
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2371,6 +2371,14 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     const int nv_kwide = (c.moe_ffn > H ? c.moe_ffn : H);
     signed char* nv_xq = a.alloc<signed char>((size_t)N * nv_kwide);
     float* nv_xs = a.alloc<float>((size_t)N * (nv_kwide / 16) + 1);
+    // Projection-side int8 staging, separate from the FFN's. Two buffers, not one: the q/k/v and
+    // GDN in-projections run on parallel streams reading the SAME quantized xn, and the o_proj /
+    // ssm_out quantize that follows must not overwrite it while those are still in flight.
+    const int nv_pwide = [&]{ int m = H; if (s.qdim > m) m = s.qdim; if (s.linear_vdim > m) m = s.linear_vdim; return m; }();
+    signed char* nv_pq_a = a.alloc<signed char>((size_t)N * nv_pwide);
+    float* nv_ps_a = a.alloc<float>((size_t)N * (nv_pwide / 16) + 1);
+    signed char* nv_pq_b = a.alloc<signed char>((size_t)N * nv_pwide);
+    float* nv_ps_b = a.alloc<float>((size_t)N * (nv_pwide / 16) + 1);
     // DEBUG ONLY (dspark_tau_check bisection, 2026-08-17): SPARKINFER_DFLASH_VERIFY_DUMP_ROW=<row>
     // dumps that row's pre-attn-norm xn after EVERY layer, plus the post-final-norm xn, into
     // [n_layers+1, H] bf16 written to SPARKINFER_DFLASH_VERIFY_DUMP_FILE (default
@@ -2566,6 +2574,24 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         q81_src = in;
         q81_k = k;
     };
+    // Same caching discipline as quant_rows above, for the NVFP4 dp4a path: q/k/v (and the four
+    // GDN in-projections) all read one `xn`, so it is quantized once per layer and reused. The A/B
+    // buffers alternate by source so a later quantize cannot clobber one a parallel stream is
+    // still reading.
+    const bf16* nvq_src_a = nullptr; int nvq_k_a = 0;
+    const bf16* nvq_src_b = nullptr; int nvq_k_b = 0;
+    bool nvq_use_b = false;
+    auto quant_nv_rows = [&](const bf16* in, int k) {
+        if (nvq_src_a == in && nvq_k_a == k) { nvq_use_b = false; return; }
+        if (nvq_src_b == in && nvq_k_b == k) { nvq_use_b = true;  return; }
+        if (!nvq_use_b) {
+            kernels::launch_gemv_nvfp4_quant_x(in, nv_pq_b, nv_ps_b, N, k, st);
+            nvq_src_b = in; nvq_k_b = k; nvq_use_b = true;
+        } else {
+            kernels::launch_gemv_nvfp4_quant_x(in, nv_pq_a, nv_ps_a, N, k, st);
+            nvq_src_a = in; nvq_k_a = k; nvq_use_b = false;
+        }
+    };
     auto proj = [&](const bf16* in, const void* w, int type, bf16* out, int no, int k) -> bool {
         if (type == 0) {
             return kernels::launch_gemv_rows(in, w, out, N, no, k, st);
@@ -2608,6 +2634,12 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // the one-row kernel's dot and split-fold order per row, so the results are the same
             // bits the loop below produces -- the loop stays as the fallback for widths it does
             // not cover, and is what every other N still runs.
+            if (kernels::qwen38_nvfp4_dp4a_proj()) {
+                quant_nv_rows(in, k);
+                if (kernels::launch_gemv_nvfp4_rows_dp4a(nvq_use_b ? nv_pq_b : nv_pq_a,
+                                                         nvq_use_b ? nv_ps_b : nv_ps_a,
+                                                         w, out, N, no, k, st)) return true;
+            }
             if (kernels::launch_gemv_nvfp4_rows(in, w, out, N, no, k, st)) return true;
             for (int r = 0; r < N; ++r)
                 kernels::launch_gemv_nvfp4(in + (size_t)r * k, w, out + (size_t)r * no, no, k, st);
@@ -2636,6 +2668,18 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // Native FP8/NVFP4 touch no shared q81 scratch, so unlike the mmvq path below they are
         // safe on ANY stream and never need the fall-back to `st`.
         if (type == kernels::SI_QTYPE_FP8 || type == kernels::SI_QTYPE_NVFP4) {
+            // Reads the quantized `in` proj() already produced on `st` for this same buffer --
+            // never quantizes here, for the reason the header note gives: writing shared scratch
+            // off the main stream races. Falls through to the float path if it was not staged,
+            // which keeps this correct if a caller ever reorders.
+            if (type == kernels::SI_QTYPE_NVFP4 && kernels::qwen38_nvfp4_dp4a_proj()) {
+                const bool ha = (nvq_src_a == in && nvq_k_a == k);
+                const bool hb = (nvq_src_b == in && nvq_k_b == k);
+                if ((ha || hb) &&
+                    kernels::launch_gemv_nvfp4_rows_dp4a(hb ? nv_pq_b : nv_pq_a,
+                                                         hb ? nv_ps_b : nv_ps_a,
+                                                         w, out, N, no, k, ps)) return true;
+            }
             if (type == kernels::SI_QTYPE_NVFP4 &&
                 kernels::launch_gemv_nvfp4_rows(in, w, out, N, no, k, ps)) return true;
             if (type == kernels::SI_QTYPE_FP8 &&
@@ -2768,6 +2812,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     kernels::launch_embedding(ids, s.w.embed_tokens, x, N, H, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, c.rms_eps, st);
     for (int L = 0; L < c.n_layers && supported; ++L) {
+        // Reset the dp4a activation cache every layer. `xn` is the SAME buffer at every layer, so
+        // a pointer-keyed cache that is never invalidated silently reuses layer 0's quantization
+        // for all 64 -- which is the stale-activation failure this file documents for s.aq81. The
+        // Q8_1 cache beside it stays valid only because the layer tail re-stamps q81_src when it
+        // emits a fresh Q8_1(xn); nothing re-stamps this one, so clear it here.
+        nvq_src_a = nullptr; nvq_k_a = 0;
+        nvq_src_b = nullptr; nvq_k_b = 0;
         vfail_L = L;
         vdbg_snapshot(xn, L);
         if (L == 0) vdbg_snapshot2(x, 4);   // raw pre-norm residual stream (h = x + ao)
@@ -2783,6 +2834,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // at ~3 and ~0.4 CTAs per SM, so serializing them behind wqkv just adds their latency
             // to the chain. Push the two small ones onto stream_k. Safe only once q81 already
             // holds xn -- otherwise proj() would have to quantize, which writes shared scratch.
+            // Stage xn for dp4a BEFORE the fork, for the same reason the fork below is gated on
+            // q81 already holding xn: anything proj() issues lands AFTER the fork event, so a
+            // parallel stream reading it would race. With xn staged here, proj() hits the cache
+            // and issues nothing, and proj_on() finds it already there.
+            if (kernels::qwen38_nvfp4_dp4a_proj() &&
+                (w.wqkv_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.wqkv_gate_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.ssm_alpha_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.ssm_beta_type == kernels::SI_QTYPE_NVFP4)) quant_nv_rows(xn, H);
             const bool fork_gdn = fork_shared && q81_src == xn && q81_k == H;
             cudaStream_t gst = fork_gdn ? s.stream_k : st;
             if (fork_gdn) {
@@ -2816,6 +2876,14 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         } else {
             // Same shape of win as the GDN block: wq is 2*qdim rows and saturates, while wk and wv
             // are kvdim rows apiece and run at well under one CTA per SM.
+            // Stage xn for dp4a BEFORE the fork, for the same reason the fork below is gated on
+            // q81 already holding xn: anything proj() issues lands AFTER the fork event, so a
+            // parallel stream reading it would race. With xn staged here, proj() hits the cache
+            // and issues nothing, and proj_on() finds it already there.
+            if (kernels::qwen38_nvfp4_dp4a_proj() &&
+                (w.wq_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.wk_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.wv_type == kernels::SI_QTYPE_NVFP4)) quant_nv_rows(xn, H);
             const bool fork_attn = fork_shared && q81_src == xn && q81_k == H;
             cudaStream_t ast = fork_attn ? s.stream_k : st;
             if (fork_attn) {


### PR DESCRIPTION
## Summary

Route the GDN and attention projections — the rest of the checkpoint's NVFP4 — through dp4a, and take the proposal depth that a cheaper verify row makes profitable. One activation quantize per layer, cached by pointer so the four GDN in-projections and q/k/v share the one `xn`.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090.** False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark-decode@4k`, the scored dimension, measured with `runtime/examples/dspark_tau_check` on the same prompt and 4096-id truncation `eval/pr_dspark_bot.py` uses; `bench.sh` has no DSpark leg):

| | decode tok/s |
|---|--:|
| before (main) | 102.91 |
| after (this PR) | 109.46 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090, Qwen3.8-27B NVFP4 + released DSpark draft, ctx=4096, max_new=128, SPEC-REPS 3,
alternating arms in one binary.

before (SPARKINFER_QWEN38_NVFP4_DP4A_PROJ=0, SPARKINFER_DFLASH_PROPOSALS=1):
  DSPARK   102.9566 / 102.8691 tok/s     tau 1.5059   verify 12.445 ms   lossless 3/3
after (default):
  DSPARK   109.4385 / 109.4827 / 109.4480 tok/s
                                          tau 1.8056   verify 13.718 ms   lossless 3/3
  emitted stream byte-identical:
    before  SPEC[ 2407 314 6337 421 369 524 177460 1196 ]
    after   SPEC[ 2407 314 6337 421 369 524 177460 1196 ]

what a marginal verify ROW costs, which is what decides the depth:
  all float                3.640 ms    best depth 1
  FFN dp4a only            2.044 ms    best depth 1 (depth 2 behind by 1.2%)
  + these projections      0.963 ms    best depth 3

depth curve at ctx=4096, reps=3, all lossless:
  depth 1  104.28 tok/s  tau 1.5059  draft 2.178 ms  verify 12.261 ms
  depth 2  109.30 tok/s  tau 1.7200  draft 2.389 ms  verify 13.224 ms
  depth 3  109.48 tok/s  tau 1.8056  draft 2.517 ms  verify 13.717 ms
  depth 4   76.24 tok/s  tau 1.9403  draft 9.922 ms  verify 15.131 ms
    depth 4 needs a 5-wide draft block, which rounds to the checkpoint's block_size 7 -- a width
    the draft's batched GEMV is not instantiated for -- so the draft falls to its per-token loop.

other contexts, same build, reps=3, lossless at both:
  ctx=1024   109.24 -> 120.07 tok/s   tau 1.5238 -> 1.8551
  ctx=2048   107.15 -> 118.11 tok/s   tau 1.5238 -> 1.8551
  ctx=512     90.32 ->  90.30 tok/s   tau 1.0000 (draft inert here, unchanged)

correctness, and why ctx=4096 alone would not have caught it:
  o_proj does not go through proj_from -- it has an inline branch that kept the float GEMV while
  the verifier converted w.wo, so decode and verify disagreed on sixteen layers of attention
  output. That reports LOSSLESS=0, not a wrong number, and ctx=4096 PASSES it by luck:
    ctx=1024, o_proj left on float:   LOSSLESS=0
    ctx=1024, o_proj converted:       LOSSLESS=1  (3/3)
```
