### PR TITLE
perf(dspark): dp4a the NVFP4 projections, then restore the proposal depth they pay for (1.110x dspark-decode@4k)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -2757,15 +2757,39 @@ bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, 
     auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
     // Split-K chosen by N exactly as the float rows kernel does, so the two paths fan out over the
     // GPU identically and a comparison between them is a comparison of the arithmetic alone.
-#define SI_NVFP4_DP4A(S_, R_) do { \
-        constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
-        const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
-        gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
+    // NR (output rows per warp-group) was fixed at 2, which is right for the dense FFN this path
+    // was written for: at N = 17408 the grid is still ~4x the SM count, and folding two output
+    // rows into a warp-group halves the activation traffic. The GDN and attention projections are
+    // 2048 to 12288 rows wide, where halving the grid costs more occupancy than the sharing buys.
+    // Pick NR by N. SPARKINFER_NVFP4_DP4A_NR pins it for A/B.
+    static const int nr_pin = []{ const char* e = getenv("SPARKINFER_NVFP4_DP4A_NR");
+                                  int v = e ? atoi(e) : 0; return (v == 1 || v == 2) ? v : 0; }();
+    // Width above which two output rows per warp-group pays. Swept: see the PR notes.
+    // Measured, same binary, DSPARK_TPS / AR: NR=2 everywhere 108.52 / 87.32, NR=1 everywhere
+    // 109.17 / 90.02, NR=2 only at the FFN's width 109.29 / 89.10. Keying it on the ROW COUNT
+    // instead (NR=1 at M==1, NR=2 above) is worse -- 108.52 / 90.01 -- so width is the right
+    // discriminator, not batch.
+    static const int nr_wide = []{ const char* e = getenv("SPARKINFER_NVFP4_DP4A_NRW");
+                                   int v = e ? atoi(e) : 16384; return v > 0 ? v : 16384; }();
+    const int nr = nr_pin ? nr_pin : (N >= nr_wide ? 2 : 1);
+#define SI_NVFP4_DP4A_NR(S_, R_, NR_) do { \
+        constexpr int S = (S_), R = (R_), NR = (NR_), RPB = GEMV_WPB / S; \
+        const dim3 grid((N + RPB * NR - 1) / (RPB * NR)); \
+        gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, NR><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
     } while (0)
+#define SI_NVFP4_DP4A(S_, R_) do { \
+        if (nr == 2) SI_NVFP4_DP4A_NR(S_, R_, 2); else SI_NVFP4_DP4A_NR(S_, R_, 1); \
+    } while (0)
+    // Split count. Inherited from the float rows kernel's N thresholds; dp4a has a different
+    // instruction mix per byte, so the crossovers are not obviously the same. SPARKINFER_NVFP4_DP4A_S
+    // pins it for a sweep.
+    static const int s_pin = []{ const char* e = getenv("SPARKINFER_NVFP4_DP4A_S");
+                                 int v = e ? atoi(e) : 0; return (v==2||v==4||v==8) ? v : 0; }();
+    const int s_sel = s_pin ? s_pin : (N >= 8192 ? 2 : (N >= 4096 ? 4 : 8));
 #define SI_NVFP4_DP4A_S(R_) do { \
-        if (N >= 8192)      SI_NVFP4_DP4A(2, R_); \
-        else if (N >= 4096) SI_NVFP4_DP4A(4, R_); \
-        else                SI_NVFP4_DP4A(8, R_); \
+        if (s_sel == 2)      SI_NVFP4_DP4A(2, R_); \
+        else if (s_sel == 4) SI_NVFP4_DP4A(4, R_); \
+        else                 SI_NVFP4_DP4A(8, R_); \
     } while (0)
     switch (M) {
         case 1: SI_NVFP4_DP4A_S(1); break;  case 2: SI_NVFP4_DP4A_S(2); break;
@@ -2775,6 +2799,7 @@ bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, 
     }
 #undef SI_NVFP4_DP4A_S
 #undef SI_NVFP4_DP4A
+#undef SI_NVFP4_DP4A_NR
     return true;
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -276,6 +276,17 @@ struct Qwen35Model::Impl {
     // a second feeds down. Sized for the widest K the FFN reads (moe_ffn for down).
     signed char *nv_xq = nullptr;
     float *nv_xs = nullptr;
+    // Separate int8 staging for the PROJECTIONS. The FFN pair above is re-quantized twice inside
+    // one layer (layer input, then the SwiGLU hidden), so the projections cannot share it: they
+    // are issued before the FFN and must survive until the last projection of the layer reads it.
+    signed char *nv_pxq = nullptr;
+    float *nv_pxs = nullptr;
+    // A SECOND pair for projections whose input is not xn (attention output, GDN gate input).
+    // Those are issued on the main stream only, while the xn pair above is read by projections
+    // the GDN branch forks onto stream_k -- one buffer for both would let the main stream
+    // overwrite the quantized xn while the forked stream is still reading it.
+    signed char *nv_fxq = nullptr;
+    float *nv_fxs = nullptr;
     float *sx_h = nullptr;   // pipelined shared-expert h_scratch (avoids racing routed mf_h)
     void  *sx_q8 = nullptr;  // pipelined shared-expert Q8_1(h) for down (avoids racing aq81)
     int   *mf_ids = nullptr, *mf_counts = nullptr;
@@ -512,6 +523,10 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->nv_h       = p_->alloc<bf16>(cfg.moe_ffn);
     p_->nv_xq      = p_->alloc<signed char>(cfg.moe_ffn);
     p_->nv_xs      = p_->alloc<float>(cfg.moe_ffn / 16 + 1);
+    p_->nv_pxq     = p_->alloc<signed char>(cfg.moe_ffn);
+    p_->nv_pxs     = p_->alloc<float>(cfg.moe_ffn / 16 + 1);
+    p_->nv_fxq     = p_->alloc<signed char>(cfg.moe_ffn);
+    p_->nv_fxs     = p_->alloc<float>(cfg.moe_ffn / 16 + 1);
     if (cfg.dense_ffn && cfg.top_k > 0) {
         cu(cudaMemcpy(p_->mf_ids, &zero, sizeof(int), cudaMemcpyHostToDevice), "dense expert id");
         cu(cudaMemcpy(p_->mf_weights, &one, sizeof(float), cudaMemcpyHostToDevice), "dense expert w");
@@ -761,6 +776,16 @@ int Qwen35Model::adaptive_nsplits_for(int seqlen) const {
         }
     }
     return want;
+}
+
+// Separate switch from the FFN's, so the two halves of the NVFP4 dp4a conversion can be A/B'd
+// independently in one binary. Both must be on for the projections to take the dp4a path.
+static inline bool nvfp4_dp4a_proj() {
+    static const bool v = [] {
+        const char* e = getenv("SPARKINFER_QWEN38_NVFP4_DP4A_PROJ");
+        return !e || e[0] != '0';
+    }();
+    return v;
 }
 
 int Qwen35Model::forward_token(int token_id, int position, bool sample, float temperature,
@@ -1147,6 +1172,10 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
         // mmvq_q4k/mmvq_q6k branches, which read s.aq81 unconditionally) ran against the wrong
         // layer's quantized activation. Force a fresh quantize every layer for muse_glimmer.
         bool xn_q8_ready = (fnq && L > 0 && !c.muse_glimmer) || muse_xn_q8;
+        // Same idea as xn_q8_ready, for the NVFP4 dp4a projections: q, k, v, the qkv gate and
+        // alpha/beta all read THIS layer's xn, so it is quantized once and reused. Reset per layer
+        // because s.xn is rewritten by the previous layer's tail.
+        bool nv_xn_ready = false;
         // Both flags are re-earned every layer by the tail that actually ran; consumed here, so
         // a layer whose tail declines falls back to its own quantize instead of inheriting.
         muse_hn_q8 = false;
@@ -1161,6 +1190,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 kernels::launch_quantize_q8_1(s.xn, s.aq8, s.aq8_d, s.aq8_s, H, st);
             }
         };
+        // Quantize xn ONCE per layer, on the main stream, before anything forks. Every NVFP4
+        // projection of this layer reads the same xn, so one quantize serves q/k/v, the qkv gate
+        // and alpha/beta -- and doing it here rather than inside proj_xn is what keeps the forked
+        // stream_k projections reading a buffer nobody is still writing.
+        auto prepare_xn_nvfp4 = [&](bool any_nv) {
+            if (!any_nv || nv_xn_ready) return;
+            if (!kernels::qwen38_nvfp4_dp4a() || !nvfp4_dp4a_proj()) return;
+            kernels::launch_gemv_nvfp4_quant_x(s.xn, s.nv_pxq, s.nv_pxs, 1, H, st);
+            nv_xn_ready = true;
+        };
         auto proj_xn = [&](const void* W, int t, void* y, int N, cudaStream_t pst) {
             if (s.gguf) {
                 if (s.use_pq && t == 12) {
@@ -1173,8 +1212,33 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                     kernels::launch_mmvq_q80(s.aq81, W, y, N, H, pst);
                 else if (t == kernels::SI_QTYPE_FP8)
                     kernels::launch_gemv_fp8(s.xn, W, y, N, H, pst);
-                else if (t == kernels::SI_QTYPE_NVFP4)
+                else if (t == kernels::SI_QTYPE_NVFP4) {
+                    // dp4a for the checkpoint's native NVFP4 GDN/attention projections, by the
+                    // same argument #904 used for the dense FFN: the decoded magnitudes are exact
+                    // integers, so the group dot is group_scale * sum(mag * xq) -- an exact
+                    // integer reduction. The weights stay bit-exact and only the activation is
+                    // quantized, at one scale per 16 values, matching the weight group size.
+                    //
+                    // #904 converted the FFN and left these on the float GEMV. They are the
+                    // remainder of the checkpoint's NVFP4 -- every GDN in-projection and output,
+                    // plus the full-attention q/k/v/o -- and on a decode step that is weight-bound
+                    // they are read in full for every token.
+                    //
+                    // Gated on the SAME switch as the FFN so decode and the speculative verify
+                    // never disagree: losslessness here means the speculative stream matches THIS
+                    // build's AR stream, so one side on dp4a and the other on the float path would
+                    // fail the gate on path inconsistency rather than on accuracy.
+                    // Consumes the quantize prepare_xn_nvfp4() already issued on the MAIN
+                    // stream. It must not quantize here: the GDN branch forks the qkv gate and
+                    // alpha/beta onto stream_k, so an inline quantize would have two streams
+                    // writing one staging buffer. (That is exactly what a first cut did, and it
+                    // showed up as LOSSLESS=0 with tau collapsed to 1.0 -- the verify and decode
+                    // disagreeing because decode's own projections were racing.)
+                    if (nv_xn_ready &&
+                        kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_pxq, s.nv_pxs, W, y, 1, N, H, pst))
+                        return;
                     kernels::launch_gemv_nvfp4(s.xn, W, y, N, H, pst);
+                }
                 else if (t) kernels::launch_gemv_q(s.xn, W, t, y, N, H, pst);
                 else        kernels::launch_gemv(s.xn, W, y, N, H, pst);
             } else {
@@ -1200,6 +1264,14 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 } else if (t == kernels::SI_QTYPE_FP8) {
                     kernels::launch_gemv_fp8(x, W, y, N, K, st);
                 } else if (t == kernels::SI_QTYPE_NVFP4) {
+                    // Own quantize: unlike proj_xn the source differs per call (attention output,
+                    // GDN gated norm). Measured net positive even so -- the verify amortizes it
+                    // over N rows and decode's extra launch is smaller than the dp4a saving.
+                    if (kernels::qwen38_nvfp4_dp4a() && nvfp4_dp4a_proj()) {
+                        kernels::launch_gemv_nvfp4_quant_x(x, s.nv_fxq, s.nv_fxs, 1, K, st);
+                        if (kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_fxq, s.nv_fxs, W, y, 1, N, K, st))
+                            return;
+                    }
                     kernels::launch_gemv_nvfp4(x, W, y, N, K, st);
                 } else if (t) kernels::launch_gemv_q(x, W, t, y, N, K, st);
                 else          kernels::launch_gemv(x, W, y, N, K, st);
@@ -1216,6 +1288,10 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             const bool any_q80 = (w.wqkv_type == 8 || w.wqkv_gate_type == 8 ||
                                   w.ssm_alpha_type == 8 || w.ssm_beta_type == 8);
             prepare_xn_quant(any_q4k, any_q6k, any_q80);
+            prepare_xn_nvfp4(w.wqkv_type == kernels::SI_QTYPE_NVFP4 ||
+                             w.wqkv_gate_type == kernels::SI_QTYPE_NVFP4 ||
+                             w.ssm_alpha_type == kernels::SI_QTYPE_NVFP4 ||
+                             w.ssm_beta_type == kernels::SI_QTYPE_NVFP4);
             const bool gdn_quad = s.use_gdn_quad && s.gguf && s.use_pq && s.use_llama && H == 2048
                                && w.wqkv_type == 12 && w.wqkv_gate_type == 12
                                && w.ssm_alpha_type == 12 && w.ssm_beta_type == 12;
@@ -1326,6 +1402,9 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 const bool any_q6k = (w.wq_type == 14 || w.wk_type == 14 || w.wv_type == 14);
                 const bool any_q80 = (w.wq_type == 8 || w.wk_type == 8 || w.wv_type == 8);
                 prepare_xn_quant(any_q4k, any_q6k, any_q80);
+                prepare_xn_nvfp4(w.wq_type == kernels::SI_QTYPE_NVFP4 ||
+                                 w.wk_type == kernels::SI_QTYPE_NVFP4 ||
+                                 w.wv_type == kernels::SI_QTYPE_NVFP4);
                 // Muse Glimmer keeps attn_gate as its own quantized tensor (w.wgate), so Q goes
                 // straight to s.q and the gate straight to s.qgate -- no [q|gate] interleave to
                 // build and no split to undo it. Every other model still fuses them into s.qraw.
@@ -3213,9 +3292,32 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // than per step, because the verify graph dflash_warm_verify captures is sized from this and
     // a graph built for a row count the stream never uses costs more than the rows it saves --
     // measured, per-step narrowing under a 4-row warm graph recovers only 0.7% of the 9.4%.
+    // #878's narrowing was correct for the cost curve it measured and is not correct for this
+    // one. Its case was that "each extra proposal is another row in the draft block... and another
+    // row of the draft's own attention over the same KV", i.e. an extra verify row cost close to a
+    // full extra pass over the model's weights, so proposals the target rejected were pure loss.
+    // The NVFP4 projections are dp4a and row-batched now (this PR, on top of #904's dense FFN), so
+    // an extra verify row costs the activation work alone and the weight stream is read once for
+    // all rows. That flips the trade back.
+    //
+    // Measured at ctx=4096, same binary, DSPARK_TPS / MEAN_ACCEPT, against main's 106.70 / 1.5542:
+    //
+    //     depth   on main            with this PR
+    //       1     106.70 / 1.5542    109.31 / 1.5542
+    //       2     102.58 / 1.7333    110.95 / 1.7333
+    //       3       -                118.41 / 1.9118   <- shipped
+    //       4       -                 80.26 / 1.9403
+    //
+    // Depth 2 REGRESSES main by 3.9% and gains here: the narrowing and the un-narrowing are the
+    // same measurement taken either side of the row-batching, which is why this is a re-tune and
+    // not a revert. Depth 4 is the cliff #869 documented -- the draft's active block width rounds
+    // up over {4, 8, 16}, so depth 4 runs an 8-wide draft block for 0.03 more accepted tokens.
+    // Tied to the dp4a switch so the two move together: with the projections back on the float
+    // path the old cost curve returns and so does depth 1.
+    const bool nv_dp4a = kernels::qwen38_nvfp4_dp4a() && nvfp4_dp4a_proj();
     const int kProposalDepth = kProposalDepthEnv > 0 ? kProposalDepthEnv
                              : ((n + max_new) >= kDeepMinSeq ? 7
-                                : (n >= kNarrowMinSeq ? 1 : 3));
+                                : (n >= kNarrowMinSeq ? (nv_dp4a ? 3 : 1) : 3));
 
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2319,6 +2319,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     return seed;
 }
 
+// Mirrors qwen35.cpp's switch of the same name: both sides must select the same projection
+// arithmetic or DSpark stops reproducing AR and the losslessness gate fails on path inconsistency.
+static inline bool verify_nvfp4_dp4a_proj() {
+    static const bool v = [] {
+        const char* e = getenv("SPARKINFER_QWEN38_NVFP4_DP4A_PROJ");
+        return !e || e[0] != '0';
+    }();
+    return v;
+}
+
 int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int n, int start_pos,
                             const int* capture_layers, int n_capture, void* capture_dst,
                             int* out_argmax, bool capture_only) {
@@ -2464,6 +2474,16 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     float* shared_h = a.alloc<float>((size_t)N * ffn);
     float* logits = a.alloc<float>((size_t)N * c.vocab);
     int* out_ids = a.alloc<int>(N);
+    // int8 staging for the dp4a NVFP4 projections (see proj() below), one scale per 16 values.
+    const int nv_kmax = std::max(std::max(H, lvdim), std::max(s.linear_qdim, qdim));
+    signed char* nvp_xq = a.alloc<signed char>((size_t)N * nv_kmax);
+    float* nvp_xs = a.alloc<float>((size_t)N * (nv_kmax / 16 + 1));
+    // Second pair for projections whose input is NOT xn. The xn pair is filled once per layer on
+    // the main stream and then read by projections this function forks onto stream_k, so a single
+    // shared buffer would let a later main-stream quantize overwrite it mid-flight.
+    signed char* nvf_xq = a.alloc<signed char>((size_t)N * nv_kmax);
+    float* nvf_xs = a.alloc<float>((size_t)N * (nv_kmax / 16 + 1));
+    bool nv_xn_ready = false;
     const size_t q81_stride_max = kernels::llama_q8_1_bytes(std::max(H, lvdim));
     void* q81 = a.alloc<unsigned char>((size_t)N * q81_stride_max);
     const int ns = std::max(1, s.n_splits);
@@ -2604,6 +2624,23 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // N one-row calls are bit-identical to N AR steps, which is what keeps the speculative
         // path lossless by construction rather than by measurement.
         if (type == kernels::SI_QTYPE_NVFP4) {
+            // dp4a first, on the same switch decode uses. #904 established that NVFP4's decoded
+            // magnitudes are exact integers, so a group's dot is group_scale * sum(mag * xq) -- an
+            // exact integer reduction -- and applied it to the dense FFN. These projections are
+            // the rest of the checkpoint's NVFP4 and were left on the float rows kernel below.
+            // The dp4a rows kernel is instantiated from M = 1, so the N rows here run the same
+            // kernel AR decode runs at one row, which is what keeps this path lossless.
+            if (kernels::qwen38_nvfp4_dp4a() && verify_nvfp4_dp4a_proj()) {
+                const bool is_xn = (in == xn);
+                signed char* xq = is_xn ? nvp_xq : nvf_xq;
+                float* xs = is_xn ? nvp_xs : nvf_xs;
+                if (!is_xn || !nv_xn_ready) {
+                    kernels::launch_gemv_nvfp4_quant_x(in, xq, xs, N, k, st);
+                    if (is_xn) nv_xn_ready = true;
+                }
+                if (kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w, out, N, no, k, st))
+                    return true;
+            }
             // One weight stream for all N rows when a rows kernel covers this width. It reproduces
             // the one-row kernel's dot and split-fold order per row, so the results are the same
             // bits the loop below produces -- the loop stays as the fallback for widths it does
@@ -2636,6 +2673,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // Native FP8/NVFP4 touch no shared q81 scratch, so unlike the mmvq path below they are
         // safe on ANY stream and never need the fall-back to `st`.
         if (type == kernels::SI_QTYPE_FP8 || type == kernels::SI_QTYPE_NVFP4) {
+            // Same contract as the q81 path above: the caller has already quantized `in` on the
+            // main stream, so this never writes shared scratch off-stream.
+            if (type == kernels::SI_QTYPE_NVFP4 && kernels::qwen38_nvfp4_dp4a() &&
+                verify_nvfp4_dp4a_proj() && in == xn && nv_xn_ready) {
+                if (kernels::launch_gemv_nvfp4_rows_dp4a(nvp_xq, nvp_xs, w, out, N, no, k, ps))
+                    return true;
+            }
             if (type == kernels::SI_QTYPE_NVFP4 &&
                 kernels::launch_gemv_nvfp4_rows(in, w, out, N, no, k, ps)) return true;
             if (type == kernels::SI_QTYPE_FP8 &&
@@ -2772,6 +2816,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         vdbg_snapshot(xn, L);
         if (L == 0) vdbg_snapshot2(x, 4);   // raw pre-norm residual stream (h = x + ao)
         const Qwen35LayerWeights& w = s.w.layers[L];
+        nv_xn_ready = false;   // xn was rewritten by the previous layer's tail
         if (w.linear_attn) {
             bf16* rq = rec_qkv + (size_t)L * N * lqkv;
             bf16* rk = rec_k + (size_t)L * N * s.linear_qdim;
@@ -2785,6 +2830,18 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // holds xn -- otherwise proj() would have to quantize, which writes shared scratch.
             const bool fork_gdn = fork_shared && q81_src == xn && q81_k == H;
             cudaStream_t gst = fork_gdn ? s.stream_k : st;
+            // Same precondition the q81 comment above states, for the dp4a NVFP4 staging: quantize
+            // xn on the MAIN stream BEFORE the fork event is recorded, so stream_k's wait covers
+            // it. Issued here rather than lazily inside proj() because proj_on() runs on stream_k
+            // and the fork event is recorded before proj() would have had a chance to fill it.
+            if (kernels::qwen38_nvfp4_dp4a() && verify_nvfp4_dp4a_proj() && !nv_xn_ready &&
+                (w.wqkv_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.wqkv_gate_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.ssm_alpha_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.ssm_beta_type == kernels::SI_QTYPE_NVFP4)) {
+                kernels::launch_gemv_nvfp4_quant_x(xn, nvp_xq, nvp_xs, N, H, st);
+                nv_xn_ready = true;
+            }
             if (fork_gdn) {
                 pf_cu(cudaEventRecord(ev_fork, st), "verify gdn fork");
                 pf_cu(cudaStreamWaitEvent(s.stream_k, ev_fork, 0), "verify gdn fork wait");
@@ -2818,6 +2875,16 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // are kvdim rows apiece and run at well under one CTA per SM.
             const bool fork_attn = fork_shared && q81_src == xn && q81_k == H;
             cudaStream_t ast = fork_attn ? s.stream_k : st;
+            // Same pre-fork quantize as the GDN branch above: wk and wv are issued on stream_k,
+            // so xn's int8 staging has to be filled on the main stream before the fork event is
+            // recorded, or stream_k's wait does not cover it.
+            if (kernels::qwen38_nvfp4_dp4a() && verify_nvfp4_dp4a_proj() && !nv_xn_ready &&
+                (w.wq_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.wk_type == kernels::SI_QTYPE_NVFP4 ||
+                 w.wv_type == kernels::SI_QTYPE_NVFP4)) {
+                kernels::launch_gemv_nvfp4_quant_x(xn, nvp_xq, nvp_xs, N, H, st);
+                nv_xn_ready = true;
+            }
             if (fork_attn) {
                 pf_cu(cudaEventRecord(ev_fork, st), "verify attn fork");
                 pf_cu(cudaStreamWaitEvent(s.stream_k, ev_fork, 0), "verify attn fork wait");


### PR DESCRIPTION
## Summary

Two changes that only work together. #904 put the native-NVFP4 **dense FFN** on dp4a; this does the
same for the **GDN and attention projections** — the rest of the checkpoint's NVFP4 — which makes an
extra speculative verify row nearly free. That in turn invalidates #878's proposal narrowing, which
was correct when each extra row cost a full pass over the model's weights. Restoring depth 3 on top
of the cheaper rows takes **dspark-decode@4k 106.71 → 118.42 tok/s (1.110x)** with **MEAN_ACCEPT
1.5542 → 1.9118 (+23%)**, AR +0.7%, lossless.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark-decode@4k`, the scored dimension, via `runtime/examples/dspark_tau_check`
— the same binary, prompt and 4096-id truncation `eval/pr_dspark_bot.py` uses; `bench.sh` has no
DSpark leg):

| | decode tok/s |
|---|--:|
| before (main) | 106.71 |
| after (this PR) | 118.42 |

```text
ctx=4096, max_new=128, bench_prompt_4k.txt truncated to exactly 4096 ids, alternating, GPU lock

main @8de703a  DSPARK=106.7103  AR=88.5543  TAU=1.5542  LOSSLESS=1
this PR        DSPARK=118.3746  AR=89.1035  TAU=1.9118  LOSSLESS=1
main @8de703a  DSPARK=106.7078  AR=88.4724  TAU=1.5542  LOSSLESS=1
this PR        DSPARK=118.4213  AR=89.0934  TAU=1.9118  LOSSLESS=1
this PR        DSPARK=118.4979  AR=89.1048  TAU=1.9118  LOSSLESS=1  RUNS=3  (SPEC-REPS 3)

emitted stream identical to main:  AR [ 2407 314 6337 421 369 524 177460 1196 ]
```

MEAN_ACCEPT rises 23% and AR rises 0.7%, so neither the tau floor nor the AR floor is in play. No
prefill table: this PR does not touch prefill.

## Why the two halves are one change

The step budget on main, measured with timers around each phase of `dflash_generate`:

| | per step | share |
|---|--:|--:|
| batched verify | 12.267 ms | 82% |
| draft block | 2.185 ms | 18% |

Proposal depth is a trade between those two. #878 measured it when an extra verify row re-streamed
the whole weight set, and narrowing to 1 was worth +9.4%. With the projections row-batched and on
dp4a, an extra row costs the activation work alone. The same sweep, both sides of that change:

| depth | on main | with this PR |
|---|--:|--:|
| 1 | **106.70** / 1.5542 | 109.31 / 1.5542 |
| 2 | 102.58 / 1.7333 | 110.95 / 1.7333 |
| 3 | — | **118.41** / 1.9118 |
| 4 | — | 80.26 / 1.9403 |

Depth 2 **regresses main by 3.9%** and gains 1.5% here. That is the same measurement taken either
side of the row-batching, which is why this is a re-tune rather than a revert of #878 — its number
was right for its cost curve. Depth 4 is the cliff #869 documented: the draft's active block width
rounds up over {4, 8, 16}, so depth 4 runs an 8-wide draft block for 0.03 more accepted tokens.

The depth is tied to the dp4a switch, so `SPARKINFER_QWEN38_NVFP4_DP4A_PROJ=0` restores both the
float projections and depth 1 together — the old cost curve and the tuning that matched it.

## The dp4a half

NVFP4 decodes to `mag * (group_scale/2)` with `mag` an exact small integer, so a group's dot is
`group_scale * sum(mag * xq)` — an exact integer reduction. Weights stay bit-exact; only the
activation is quantized, at one scale per 16 values. Decode (`proj_xn`, `proj_from`) and the verify
(`proj`, `proj_on`) switch on the same flag and call the same kernel, which is what keeps DSpark
reproducing AR.

`xn` is quantized once per layer on the main stream **before anything forks**. q/k/v, the qkv gate
and alpha/beta all read it, and both sides fork some of them onto `stream_k`; a first cut quantized
lazily inside the projection and had two streams writing one staging buffer, which showed up as
`LOSSLESS=0` with MEAN_ACCEPT collapsing 1.55 → 1.00. Sources that are not `xn` use a second buffer.

`NR` (output rows per warp-group) is chosen by width instead of fixed at 2. Two rows is right for
the FFN's N=17408 and wrong for 2048–12288-wide projections, where it halves the grid:

| | DSpark | AR |
|---|--:|--:|
| NR=2 everywhere | 108.52 | 87.32 |
| NR=1 everywhere | 109.17 | 90.02 |
| **NR=2 only at the FFN's width** | **109.29** | **89.10** |

Keying it on row count instead (NR=1 at M==1, NR=2 above) is worse — 108.52 / 90.01. This also
moves #904's `down` (N=5120) to NR=1, which is where most of the AR gain comes from.

## Scope

Three files. FP8, Q4_K, Q6_K, Q8_0 and bf16 paths are untouched, so anything that is not this
checkpoint's native NVFP4 runs byte-identical code. `qwen3_gguf_bench` / `qwen3_gguf_score` reach
the decode path only, and it is bit-exact per row by construction.
