### PR TITLE
perf(dspark): plan the verify length, and fix the two kernels the profile blames (1.080x dspark-decode@4k)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1103,6 +1103,22 @@ SI_NVFP4_DP4A_INST(2, 6) SI_NVFP4_DP4A_INST(4, 6) SI_NVFP4_DP4A_INST(8, 6)
 SI_NVFP4_DP4A_INST(2, 7) SI_NVFP4_DP4A_INST(4, 7) SI_NVFP4_DP4A_INST(8, 7)
 SI_NVFP4_DP4A_INST(2, 8) SI_NVFP4_DP4A_INST(4, 8) SI_NVFP4_DP4A_INST(8, 8)
 #undef SI_NVFP4_DP4A_INST
+// NR = 1 as well. NR is how many OUTPUT rows a warp-group owns, and at NR = 2 the compiler keeps
+// two sets of weight temporaries (pw, the four decoded quads, the group scale) live across the
+// unrolled j loop on top of the second acc column. That costs far more than the acc array alone:
+// registers run 47/48/56/64/70/78/80/93 across R = 1..8 at NR = 2 against 38/39/39/40/42/40/44/42
+// at NR = 1, i.e. NR = 1 is nearly FLAT in the row count where NR = 2 is not.
+#define SI_NVFP4_DP4A_INST1(S_, R_) \
+template __global__ void gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S_, R_, 1>(const signed char*, const float*, const void*, __nv_bfloat16*, int, int);
+SI_NVFP4_DP4A_INST1(2, 1) SI_NVFP4_DP4A_INST1(4, 1) SI_NVFP4_DP4A_INST1(8, 1)
+SI_NVFP4_DP4A_INST1(2, 2) SI_NVFP4_DP4A_INST1(4, 2) SI_NVFP4_DP4A_INST1(8, 2)
+SI_NVFP4_DP4A_INST1(2, 3) SI_NVFP4_DP4A_INST1(4, 3) SI_NVFP4_DP4A_INST1(8, 3)
+SI_NVFP4_DP4A_INST1(2, 4) SI_NVFP4_DP4A_INST1(4, 4) SI_NVFP4_DP4A_INST1(8, 4)
+SI_NVFP4_DP4A_INST1(2, 5) SI_NVFP4_DP4A_INST1(4, 5) SI_NVFP4_DP4A_INST1(8, 5)
+SI_NVFP4_DP4A_INST1(2, 6) SI_NVFP4_DP4A_INST1(4, 6) SI_NVFP4_DP4A_INST1(8, 6)
+SI_NVFP4_DP4A_INST1(2, 7) SI_NVFP4_DP4A_INST1(4, 7) SI_NVFP4_DP4A_INST1(8, 7)
+SI_NVFP4_DP4A_INST1(2, 8) SI_NVFP4_DP4A_INST1(4, 8) SI_NVFP4_DP4A_INST1(8, 8)
+#undef SI_NVFP4_DP4A_INST1
 #endif
 
 #ifndef _MSC_VER
@@ -2757,10 +2773,31 @@ bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, 
     auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
     // Split-K chosen by N exactly as the float rows kernel does, so the two paths fan out over the
     // GPU identically and a comparison between them is a comparison of the arithmetic alone.
+    // Output rows per warp-group. ncu on this kernel says it is LATENCY bound, not compute bound
+    // -- across R = 1/2/4/8 the SM pipes sit at 28/32/31/20% of peak while warp occupancy falls
+    // 93/77/62/32% and DRAM follows it down 68/74/58/27% -- so what it wants is resident warps,
+    // and NR is what buys them: two output rows per warp-group keeps two sets of weight
+    // temporaries live across the unrolled j loop, which costs 24 registers at R=4 and 51 at R=8.
+    //
+    // Measured on the isolated kernel with a DRAM-resident working set, microseconds at R=4:
+    //   ffn gate/up N=17408  40.8 -> 34.8      gdn wide N=12288  30.7 -> 26.6
+    //   attn q      N=6144   15.5 -> 13.8      ffn down N=5120   36.8 -> 36.8
+    // Neutral-or-better at every shape for R in [3, 7]; at R = 8 it inverts on the narrow shapes
+    // (ffn down 49.2 -> 59.4), and at R <= 2 there are already enough warps for the load, so the
+    // extra grid is not repaid. Hence the band rather than a blanket switch.
+    // 0 = pick by row count, 1 or 2 force.
+    static const int nr_mode = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_NR");
+                                   int v = e ? atoi(e) : 0; return (v == 1 || v == 2) ? v : 0; }();
 #define SI_NVFP4_DP4A(S_, R_) do { \
         constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
-        const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
-        gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
+        const int nr = nr_mode ? nr_mode : ((R >= 3 && R <= 7) ? 1 : 2); \
+        if (nr == 1) { \
+            const dim3 grid((N + RPB - 1) / RPB); \
+            gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
+        } else { \
+            const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
+            gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
+        } \
     } while (0)
 #define SI_NVFP4_DP4A_S(R_) do { \
         if (N >= 8192)      SI_NVFP4_DP4A(2, R_); \

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1121,8 +1121,15 @@ void launch_gemv_batched_q4_fused3(const void* x,
 #define SI_Q4KS_B(BW_) do { if (ksplit == 2) SI_Q4KS(BW_, 2);                                     \
                             else if (ksplit == 4) SI_Q4KS(BW_, 4);                                \
                             else SI_Q4KS(BW_, 8); } while (0)
+        // Widths 5/6/7 are instantiated because the released DSpark draft's block_size is 7,
+        // which is not a power of two: rounding depth+1 up over {2,4,8,16} and clamping to 7
+        // produced a width nothing was compiled for, and the caller fell back to a per-token
+        // GEMV loop that re-reads every weight row once per row.
         if (batch == 2)      SI_Q4KS_B(2);
         else if (batch == 4) SI_Q4KS_B(4);
+        else if (batch == 5) SI_Q4KS_B(5);
+        else if (batch == 6) SI_Q4KS_B(6);
+        else if (batch == 7) SI_Q4KS_B(7);
         else if (batch == 8) SI_Q4KS_B(8);
         else                 SI_Q4KS_B(16);
 #undef SI_Q4KS_B
@@ -1138,6 +1145,9 @@ void launch_gemv_batched_q4_fused3(const void* x,
         (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
     if (batch == 2)      SI_Q4F3(2);
     else if (batch == 4) SI_Q4F3(4);
+    else if (batch == 5) SI_Q4F3(5);
+    else if (batch == 6) SI_Q4F3(6);
+    else if (batch == 7) SI_Q4F3(7);
     else if (batch == 8) SI_Q4F3(8);
     else                 SI_Q4F3(16);
 #undef SI_Q4F3
@@ -1180,6 +1190,9 @@ void launch_gemv_batched_q8_fused3(const void* x,
         S0, S1, S2, (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
     if (batch == 2)      SI_Q8F3(2);
     else if (batch == 4) SI_Q8F3(4);
+    else if (batch == 5) SI_Q8F3(5);
+    else if (batch == 6) SI_Q8F3(6);
+    else if (batch == 7) SI_Q8F3(7);
     else if (batch == 8) SI_Q8F3(8);
     else                 SI_Q8F3(16);
 #undef SI_Q8F3
@@ -1347,6 +1360,9 @@ void launch_gemv_batched16_fused3(const void* x,
         (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
     if (batch == 2)       SI_FUSED3(2);
     else if (batch == 4)  SI_FUSED3(4);
+    else if (batch == 5)  SI_FUSED3(5);
+    else if (batch == 6)  SI_FUSED3(6);
+    else if (batch == 7)  SI_FUSED3(7);
     else if (batch == 8)  SI_FUSED3(8);
     else                  SI_FUSED3(16);
 #undef SI_FUSED3
@@ -1565,6 +1581,50 @@ __global__ void k_markov_bias_add(const bf16* __restrict__ w1, const bf16* __res
     logits[v] += acc;
 }
 
+// Same bias, one WARP per vocabulary row instead of one thread.
+//
+// w2 is [vocab, rank] row major, so a thread per row puts consecutive lanes `rank * 2` bytes
+// apart -- 512 B at rank 256 -- and each 2-byte load pulls a whole sector. The kernel is nothing
+// but a stream over w2 (127 MB at V=248320, rank 256) and it was reaching 870 GB/s of a 1.79 TB/s
+// part, alone among the draft's kernels in not being at roofline. A warp per row reads that row
+// as 32 lanes x uint4 = one contiguous 512 B burst.
+//
+// The warp reduction sums in a different order than the sequential loop, so the bias differs in
+// the last bits. That is DRAFT-ONLY: it can shift which token the draft proposes, never which
+// token is emitted, because every emitted token is still a target argmax. Losslessness is
+// untouched; only acceptance can move.
+template <int RANK>
+__global__ void k_markov_bias_add_warp(const bf16* __restrict__ w1, const bf16* __restrict__ w2,
+                                       const int* __restrict__ prev_token,
+                                       float* __restrict__ logits, int vocab,
+                                       float* __restrict__ out_latent) {
+    constexpr int VEC = 8;                          // bf16 per uint4
+    constexpr int PER_LANE = RANK / (32 * VEC);
+    __shared__ float latent[RANK];
+    const int tok = *prev_token;
+    const bf16* w1_row = w1 + (size_t)tok * RANK;
+    for (int r = threadIdx.x; r < RANK; r += blockDim.x) latent[r] = b2f(w1_row[r]);
+    __syncthreads();
+    if (out_latent && blockIdx.x == 0)
+        for (int r = threadIdx.x; r < RANK; r += blockDim.x) out_latent[r] = latent[r];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int v = blockIdx.x * (int)(blockDim.x >> 5) + warp;
+    if (v >= vocab) return;
+    const bf16* w2_row = w2 + (size_t)v * RANK;
+    float acc = 0.f;
+    #pragma unroll
+    for (int p = 0; p < PER_LANE; p++) {
+        const int base = (p * 32 + lane) * VEC;
+        const uint4 raw = *reinterpret_cast<const uint4*>(w2_row + base);
+        const bf16* wv = reinterpret_cast<const bf16*>(&raw);
+        #pragma unroll
+        for (int i = 0; i < VEC; i++) acc += latent[base + i] * b2f(wv[i]);
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+    if (lane == 0) logits[v] += acc;
+}
+
 // confidence_logit = dot(hidden[H], w[0:H]) + dot(latent[rank], w[H:H+rank]) + bias -- a single
 // linear layer over the concatenation of this row's hidden state and its Markov latent, matching
 // DSpark's AcceptRatePredictor(confidence_head_with_markov=True). One block, block-wide reduction
@@ -1607,6 +1667,19 @@ void launch_markov_bias_add(const void* w1, const void* w2, const int* prev_toke
                             float* out_latent) {
     if (vocab <= 0 || rank <= 0) return;
     const int threads = 256;
+    // Warp-per-row form for the rank the released DSpark checkpoints actually carry. It needs the
+    // row length to be a compile-time multiple of 32 lanes x 8 bf16 so the uint4 loads land, and
+    // 16-byte-aligned rows, which rank 256 (512 B per row) gives. Any other rank keeps the
+    // original thread-per-row kernel.
+    static const bool warp_rows = []{ const char* e = getenv("SPARKINFER_DFLASH_MARKOV_WARP");
+                                      return !(e && e[0] == '0'); }();
+    if (warp_rows && rank == 256) {
+        const int warps_per_block = threads / 32;
+        const int blocks_w = (vocab + warps_per_block - 1) / warps_per_block;
+        k_markov_bias_add_warp<256><<<blocks_w, threads, 0, stream>>>(
+            (const bf16*)w1, (const bf16*)w2, prev_token, logits, vocab, out_latent);
+        return;
+    }
     const int blocks = (vocab + threads - 1) / threads;
     k_markov_bias_add<<<blocks, threads, rank * sizeof(float), stream>>>(
         (const bf16*)w1, (const bf16*)w2, prev_token, logits, vocab, rank, out_latent);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -981,6 +981,13 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         if (v < kProposalDepth + 1) v = kProposalDepth + 1;
         // Round up to a width the batched-GEMV path is instantiated for; anything else falls
         // back to the per-token GEMV loop, which costs far more than the rows it saves.
+        //
+        // The rounding targets {2,4,8,16} and is then CLAMPED to block_size, which is 7 on the
+        // released DSpark checkpoints -- not a power of two. So every depth from 4 up asked for a
+        // width of 7, nothing was instantiated for 7, and the draft fell to the per-token loop:
+        // 2.5 ms -> 9.9 ms. Widths 5/6/7 are instantiated now (see dflash_kernels.cu), so the
+        // clamp lands on a batched width. This matters most at ctx >= SPARKINFER_DFLASH_DEEP_MIN_SEQ,
+        // where the ladder in qwen35.cpp selects depth 7 and therefore width 7 on every block.
         const int w = v <= 2 ? 2 : (v <= 4 ? 4 : (v <= 8 ? 8 : 16));
         return w > c.block_size ? c.block_size : w;
     }();
@@ -990,7 +997,8 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // each weight row from DRAM once instead of once per token (see dflash_kernels.cu). It's
     // instantiated for the active width tiers below; an unsupported width falls back to the
     // per-token GEMV loop.
-    const bool fast16 = (BW == 16 || BW == 8 || BW == 4 || BW == 2);
+    const bool fast16 = (BW == 16 || BW == 8 || BW == 7 || BW == 6 || BW == 5 ||
+                         BW == 4 || BW == 2);
 
     cu(cudaMemcpyAsync(s.d_ids, noise_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
     kernels::launch_embedding(s.d_ids, s.embed, s.noise, BW, H, st);

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3329,7 +3329,11 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // Build the verify replay graph before the decode clock starts. Capture records kernels
     // rather than running them, so this changes no state -- it just stops decode step 2 from
     // paying for graph construction.
-    dflash_warm_verify(kProposalDepth + 1, start);
+    // Warm EVERY row count the planner below can select, not just the deepest. Each width is a
+    // separate graph tier (see dflash_verify_short_run); building them here keeps graph capture
+    // off the decode clock, and capture records kernels rather than running them, so warming a
+    // tier the stream never uses costs nothing but the capture itself.
+    for (int t = 1; t <= kProposalDepth + 1; t++) dflash_warm_verify(t, start);
     // Verify-path cost breakdown (SPARKINFER_DSPARK_TIMING=1). The two verify implementations are
     // timed per call so their cost can be compared directly rather than inferred from end-to-end
     // throughput. Synchronises around each call -- a measurement mode, not a benchmark -- but both
@@ -3348,6 +3352,26 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         cudaStreamSynchronize(s.stream);
         return std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
     };
+    // ---- Confidence-planned verify length -------------------------------------------------
+    // The draft proposes kProposalDepth tokens every step; how many of them are worth VERIFYING
+    // is a per-step question, not a per-generation constant. DSpark's confidence head already
+    // scores each proposal's own accept probability, and this loop already reads it back -- on
+    // the batched path it was then thrown away. Survival S_i = prod_{j<=i} sigmoid(conf_j) is the
+    // probability that row i is both reached and accepted, so verifying d+1 rows is worth
+    // 1 + sum_{i<=d} S_i tokens and costs C0 + c1*(d+1) ms. Take the d that maximises the ratio.
+    //
+    // There is no tuned constant anywhere in this. The probabilities are the head's own sigmoid
+    // (it is trained as an accept-rate predictor, so sigmoid(logit) IS its calibrated output --
+    // fitting a per-position logistic on top measured no better). C0 and c1 are least-squares
+    // fitted ONLINE from this run's own (rows, ms) verify samples, so the model is measured on
+    // whatever GPU is running rather than baked in. batched_forward already synchronises before
+    // it returns, so the sample costs no extra sync.
+    static const bool kPlanOn = []{ const char* e = getenv("SPARKINFER_DSPARK_PLAN");
+                                    return !(e && e[0] == '0'); }();
+    double ls_n = 0, ls_r = 0, ls_rr = 0, ls_y = 0, ls_ry = 0;   // least-squares accumulators
+    double fit_c0 = 0, fit_c1 = 0;
+    bool fit_ok = false;
+    long plan_rows_sum = 0, plan_steps = 0;
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
         // The context bound this used to carry (SPARKINFER_DFLASH_COMPACT_MAX_SEQ, default 384)
@@ -3452,6 +3476,10 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             s.defer_decode_sync = false;
         }
         auto _td = std::chrono::steady_clock::now();
+        // Sentinel: forward_block fills these only when the checkpoint HAS a confidence head.
+        // A NaN survivor means no head, and the planner falls back to the fixed depth.
+        for (int i = 0; i <= kProposalDepth; i++)
+            draft_confidence[i] = std::numeric_limits<float>::quiet_NaN();
         const bool draft_ok = draft_idle ? true : draft.forward_block(
             draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr, kProposalDepth,
             draft_confidence.data());
@@ -3478,16 +3506,53 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         // restore / KV-truncate / replay needed (greedy speculative decoding is exact). Rejected
         // proposals (block[keep..B-1]) are never forwarded, saving ~B-keep target forwards/step.
         int accept = 0, keep = 1;
+        int plan_vn = kProposalDepth + 1;
         bool vfail = false;
         if (compact_verify) {
-            const int vn = kProposalDepth + 1;
+            int vn = kProposalDepth + 1;
+            const bool have_conf = kPlanOn && !draft_idle &&
+                                   !std::isnan(draft_confidence[kProposalDepth > 0 ? 1 : 0]);
+            if (have_conf && fit_ok) {
+                double surv = 1.0, worth = 1.0, best = -1.0;
+                int best_d = kProposalDepth;
+                for (int d = 0; d <= kProposalDepth; d++) {
+                    if (d > 0) {
+                        surv *= 1.0 / (1.0 + std::exp(-(double)draft_confidence[d]));
+                        worth += surv;
+                    }
+                    const double v = worth / (fit_c0 + fit_c1 * (d + 1));
+                    if (v > best) { best = v; best_d = d; }
+                }
+                vn = best_d + 1;
+            } else if (have_conf) {
+                // Two-point bootstrap: the cost model needs two distinct row counts before it can
+                // be fitted, and one full-depth step plus one minimal step gives them. Two steps
+                // of a 70-step generation, and the minimal one still emits a verified token.
+                vn = (ls_n < 1) ? kProposalDepth + 1 : 2;
+            }
             auto _tb = std::chrono::steady_clock::now();
             vfail = !batched_forward(block.data(), vn, start, false, posterior.data(), s.dflash_hidden);
-            if (kTiming) { t_batched_ms += ms_since(_tb); n_batched++; }
+            const double vms = std::chrono::duration<double, std::milli>(
+                                   std::chrono::steady_clock::now() - _tb).count();
+            if (kTiming) { t_batched_ms += vms; n_batched++; }
             if (!vfail) {
-                while (accept < kProposalDepth && block[accept + 1] == posterior[accept]) ++accept;
+                // Feed the sample back into the cost model. Only clean samples: a failed verify
+                // has no meaningful duration.
+                ls_n += 1; ls_r += vn; ls_rr += (double)vn * vn;
+                ls_y += vms; ls_ry += vn * vms;
+                const double det = ls_n * ls_rr - ls_r * ls_r;
+                if (det > 1e-9) {
+                    const double c1 = (ls_n * ls_ry - ls_r * ls_y) / det;
+                    const double c0 = (ls_y - c1 * ls_r) / ls_n;
+                    // A negative marginal row cost is noise, not a measurement; keep the previous
+                    // fit (or stay unfitted) rather than planning off it.
+                    if (c1 > 0 && c0 > 0) { fit_c1 = c1; fit_c0 = c0; fit_ok = true; }
+                }
+                plan_rows_sum += vn; plan_steps++;
+                while (accept < vn - 1 && block[accept + 1] == posterior[accept]) ++accept;
                 keep = accept + 1;
             }
+            plan_vn = vn;
         } else {
             vfail = p0 < 0;
             posterior[0] = p0;
@@ -3547,7 +3612,10 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         }
         keep_ema8 = keep_ema8 - (keep_ema8 >> 3) + keep;
         ++step_no;
-        compact_score = keep == kProposalDepth + 1
+        // "Full block" now means "everything we asked to be verified was accepted", which is
+        // the planned width, not the static depth -- otherwise a step the planner deliberately
+        // narrowed would read as a partial accept and decay the engage score.
+        compact_score = keep == plan_vn
                       ? std::min(compact_score + 1, kBlockScore + 1)
                       : std::max(compact_score - 1, 0);
         // forward_token() synchronizes after sampling, so the accepted capture rows are already
@@ -3585,6 +3653,9 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             const double fpc = n_fwd ? t_fwd_ms / n_fwd : 0.0;
             fprintf(stderr, "[timing] draft   %8.3f ms/call  n=%ld\n", n_draft ? t_draft_ms / n_draft : 0.0, n_draft);
             fprintf(stderr, "[timing] fwd_tok %8.3f ms/call  n=%ld  (token-loop verify)\n", fpc, n_fwd);
+            if (plan_steps)
+                fprintf(stderr, "[timing] plan    %8.3f rows/step (of %d)  fit C0=%.3f c1=%.3f ms\n",
+                        (double)plan_rows_sum / plan_steps, kProposalDepth + 1, fit_c0, fit_c1);
             fprintf(stderr, "[timing] batched %8.3f ms/call  n=%ld  = %.2f forwards\n",
                     n_batched ? t_batched_ms / n_batched : 0.0, n_batched,
                     (n_batched && fpc > 0) ? (t_batched_ms / n_batched) / fpc : 0.0);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -73,6 +73,11 @@ struct Arena {
     void free_all() { for (void* b : bufs) cudaFree(b); bufs.clear(); sizes.clear(); cursor = 0; }
     size_t total() const { size_t t = 0; for (size_t b : sizes) t += b; return t; }
 };
+
+// Widest verify block dflash_verify_short_run accepts. Also the number of GRAPH TIERS it keeps:
+// one instantiated graph per row count, so the caller can pick the block width per step instead
+// of being locked to whatever width the single warm graph happened to be captured at.
+constexpr int kVerifyMaxRows = 8;
 } // namespace
 
 int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n) {
@@ -2335,7 +2340,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     // unverified draft tokens -- observed echoing the prompt back), so DSpark cannot work at all
     // until this branch exists.
     const bool dense = c.dense_ffn;
-    if (!token_ids || !out_argmax || n < 1 || n > 8 || !s.gguf || !c.hybrid) {
+    if (!token_ids || !out_argmax || n < 1 || n > kVerifyMaxRows || !s.gguf || !c.hybrid) {
         fprintf(stderr, "[dflash-verify] base unsupported n=%d gguf=%d hybrid=%d\n",
                 n, (int)s.gguf, (int)c.hybrid);
         return -1;
@@ -2347,6 +2352,12 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         return -1;
     }
     const int H = c.hidden, N = n, qdim = s.qdim, kvdim = s.kvdim;
+    // Every arena buffer below is sized for the WIDEST verify tier, not for this call's N.
+    // The per-tier graphs each bake their own device pointers, and Arena::alloc frees and
+    // reallocates a slot the moment a later call asks it for more bytes -- which would leave an
+    // already-instantiated narrower graph pointing at freed memory. Sizing at the maximum makes
+    // the arena layout identical for every tier, so the tiers can coexist.
+    const int NA = kVerifyMaxRows;
     const int lqkv = s.linear_qkvdim, lvdim = s.linear_vdim, vh = c.linear_v_heads;
     const int ffn = c.moe_ffn, E = c.n_experts, topk = c.top_k;
     // DEBUG ONLY (dspark_tau_check bisection, 2026-08-17): confirm the row<->position mapping
@@ -2361,24 +2372,24 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     static thread_local Arena verify_arena;
     verify_arena.rewind();
     Arena& a = verify_arena;
-    bf16* x = a.alloc<bf16>((size_t)N * H);
-    bf16* xn = a.alloc<bf16>((size_t)N * H);
-    bf16* h = a.alloc<bf16>((size_t)N * H);
+    bf16* x = a.alloc<bf16>((size_t)NA * H);
+    bf16* xn = a.alloc<bf16>((size_t)NA * H);
+    bf16* h = a.alloc<bf16>((size_t)NA * H);
     // dp4a NVFP4 FFN staging, hoisted OUT of the layer loop on purpose. Arena::alloc falls back to
     // cudaMalloc on a miss, and this function runs inside the verify's CUDA graph capture, where
     // cudaMalloc is illegal -- allocating per layer returned null on the first captured pass and
     // the FFN silently declined. Everything else here is allocated up front for the same reason.
     const int nv_kwide = (c.moe_ffn > H ? c.moe_ffn : H);
-    signed char* nv_xq = a.alloc<signed char>((size_t)N * nv_kwide);
-    float* nv_xs = a.alloc<float>((size_t)N * (nv_kwide / 16) + 1);
+    signed char* nv_xq = a.alloc<signed char>((size_t)NA * nv_kwide);
+    float* nv_xs = a.alloc<float>((size_t)NA * (nv_kwide / 16) + 1);
     // Projection-side int8 staging, separate from the FFN's. Two buffers, not one: the q/k/v and
     // GDN in-projections run on parallel streams reading the SAME quantized xn, and the o_proj /
     // ssm_out quantize that follows must not overwrite it while those are still in flight.
     const int nv_pwide = [&]{ int m = H; if (s.qdim > m) m = s.qdim; if (s.linear_vdim > m) m = s.linear_vdim; return m; }();
-    signed char* nv_pq_a = a.alloc<signed char>((size_t)N * nv_pwide);
-    float* nv_ps_a = a.alloc<float>((size_t)N * (nv_pwide / 16) + 1);
-    signed char* nv_pq_b = a.alloc<signed char>((size_t)N * nv_pwide);
-    float* nv_ps_b = a.alloc<float>((size_t)N * (nv_pwide / 16) + 1);
+    signed char* nv_pq_a = a.alloc<signed char>((size_t)NA * nv_pwide);
+    float* nv_ps_a = a.alloc<float>((size_t)NA * (nv_pwide / 16) + 1);
+    signed char* nv_pq_b = a.alloc<signed char>((size_t)NA * nv_pwide);
+    float* nv_ps_b = a.alloc<float>((size_t)NA * (nv_pwide / 16) + 1);
     // DEBUG ONLY (dspark_tau_check bisection, 2026-08-17): SPARKINFER_DFLASH_VERIFY_DUMP_ROW=<row>
     // dumps that row's pre-attn-norm xn after EVERY layer, plus the post-final-norm xn, into
     // [n_layers+1, H] bf16 written to SPARKINFER_DFLASH_VERIFY_DUMP_FILE (default
@@ -2429,35 +2440,35 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                                         (size_t)H * sizeof(bf16), cudaMemcpyDeviceToDevice, st),
                         "verify_dbg2 snapshot");
     };
-    bf16* hn = a.alloc<bf16>((size_t)N * H);
-    bf16* ao = a.alloc<bf16>((size_t)N * H);
-    bf16* routed = a.alloc<bf16>((size_t)N * H);
-    bf16* shared = a.alloc<bf16>((size_t)N * H);
-    bf16* b8 = a.alloc<bf16>((size_t)N * 2 * qdim);
-    bf16* lz = a.alloc<bf16>((size_t)N * lvdim);
-    bf16* gq = a.alloc<bf16>((size_t)N * s.linear_qdim);
-    bf16* gk = a.alloc<bf16>((size_t)N * s.linear_qdim);
-    bf16* gv = a.alloc<bf16>((size_t)N * lvdim);
-    bf16* att = a.alloc<bf16>((size_t)N * lvdim);
-    bf16* lnrm = a.alloc<bf16>((size_t)N * lvdim);
-    bf16* la = a.alloc<bf16>((size_t)N * vh);
-    bf16* lb = a.alloc<bf16>((size_t)N * vh);
+    bf16* hn = a.alloc<bf16>((size_t)NA * H);
+    bf16* ao = a.alloc<bf16>((size_t)NA * H);
+    bf16* routed = a.alloc<bf16>((size_t)NA * H);
+    bf16* shared = a.alloc<bf16>((size_t)NA * H);
+    bf16* b8 = a.alloc<bf16>((size_t)NA * 2 * qdim);
+    bf16* lz = a.alloc<bf16>((size_t)NA * lvdim);
+    bf16* gq = a.alloc<bf16>((size_t)NA * s.linear_qdim);
+    bf16* gk = a.alloc<bf16>((size_t)NA * s.linear_qdim);
+    bf16* gv = a.alloc<bf16>((size_t)NA * lvdim);
+    bf16* att = a.alloc<bf16>((size_t)NA * lvdim);
+    bf16* lnrm = a.alloc<bf16>((size_t)NA * lvdim);
+    bf16* la = a.alloc<bf16>((size_t)NA * vh);
+    bf16* lb = a.alloc<bf16>((size_t)NA * vh);
     bf16* qb = gv;
     bf16* qg = lnrm;
     bf16* kf = gq;
     bf16* vf = gk;
-    bf16* sg = a.alloc<bf16>((size_t)N * ffn);
-    bf16* su = a.alloc<bf16>((size_t)N * ffn);
-    bf16* sh = a.alloc<bf16>((size_t)N * ffn);
-    bf16* gate_raw = a.alloc<bf16>(N);
-    float* gate_w = a.alloc<float>(N);
-    int* ids = a.alloc<int>(N);
-    int* pos = a.alloc<int>(N);
-    int* seq = a.alloc<int>(N);
-    int* expert_ids = a.alloc<int>((size_t)N * topk);
-    float* expert_w = a.alloc<float>((size_t)N * topk);
-    float* router_logits = a.alloc<float>((size_t)N * E);
-    float* moe_h = a.alloc<float>((size_t)N * topk * ffn);
+    bf16* sg = a.alloc<bf16>((size_t)NA * ffn);
+    bf16* su = a.alloc<bf16>((size_t)NA * ffn);
+    bf16* sh = a.alloc<bf16>((size_t)NA * ffn);
+    bf16* gate_raw = a.alloc<bf16>(NA);
+    float* gate_w = a.alloc<float>(NA);
+    int* ids = a.alloc<int>(NA);
+    int* pos = a.alloc<int>(NA);
+    int* seq = a.alloc<int>(NA);
+    int* expert_ids = a.alloc<int>((size_t)NA * topk);
+    float* expert_w = a.alloc<float>((size_t)NA * topk);
+    float* router_logits = a.alloc<float>((size_t)NA * E);
+    float* moe_h = a.alloc<float>((size_t)NA * topk * ffn);
     // out_scratch is not just the [N, H] fp32 output: launch_moe_expert_ffn_q4k also reuses it as
     // the Q8_1 staging buffer for the SwiGLU hidden, which needs
     // num_tokens * top_k * llama_q8_1_bytes(ffn) bytes. That kernel's "<= hidden floats; fits"
@@ -2466,34 +2477,39 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     // after the overflow point. Size for both uses.
     const size_t moe_out_floats = std::max((size_t)N * H,
         ((size_t)N * topk * kernels::llama_q8_1_bytes(ffn) + sizeof(float) - 1) / sizeof(float));
-    float* moe_out = a.alloc<float>(moe_out_floats);
+    // Both terms of moe_out_floats scale linearly in the row count, so widening to NA is a
+    // ceil-divide away; rounding UP keeps the widest tier's requirement covered exactly.
+    float* moe_out = a.alloc<float>(((moe_out_floats + (size_t)N - 1) / (size_t)N) * (size_t)NA);
     // Dedicated hidden scratch for the shared expert. It used to borrow moe_h, which is the one
     // thing that stopped the shared branch from running concurrently with the routed one.
-    float* shared_h = a.alloc<float>((size_t)N * ffn);
-    float* logits = a.alloc<float>((size_t)N * c.vocab);
-    int* out_ids = a.alloc<int>(N);
+    float* shared_h = a.alloc<float>((size_t)NA * ffn);
+    float* logits = a.alloc<float>((size_t)NA * c.vocab);
+    int* out_ids = a.alloc<int>(NA);
     const size_t q81_stride_max = kernels::llama_q8_1_bytes(std::max(H, lvdim));
-    void* q81 = a.alloc<unsigned char>((size_t)N * q81_stride_max);
+    void* q81 = a.alloc<unsigned char>((size_t)NA * q81_stride_max);
     const int ns = std::max(1, s.n_splits);
-    float* fa_m = a.alloc<float>((size_t)N * c.n_q_heads * ns);
-    float* fa_l = a.alloc<float>((size_t)N * c.n_q_heads * ns);
-    float* fa_acc = a.alloc<float>((size_t)N * c.n_q_heads * ns * c.head_dim);
+    float* fa_m = a.alloc<float>((size_t)NA * c.n_q_heads * ns);
+    float* fa_l = a.alloc<float>((size_t)NA * c.n_q_heads * ns);
+    float* fa_acc = a.alloc<float>((size_t)NA * c.n_q_heads * ns * c.head_dim);
     // Compact recurrence records retained until posterior selection.
-    bf16* rec_qkv = a.alloc<bf16>((size_t)c.n_layers * N * lqkv);
-    bf16* rec_k = a.alloc<bf16>((size_t)c.n_layers * N * s.linear_qdim);
-    bf16* rec_v = a.alloc<bf16>((size_t)c.n_layers * N * lvdim);
-    bf16* rec_a = a.alloc<bf16>((size_t)c.n_layers * N * vh);
-    bf16* rec_b = a.alloc<bf16>((size_t)c.n_layers * N * vh);
+    bf16* rec_qkv = a.alloc<bf16>((size_t)c.n_layers * NA * lqkv);
+    bf16* rec_k = a.alloc<bf16>((size_t)c.n_layers * NA * s.linear_qdim);
+    bf16* rec_v = a.alloc<bf16>((size_t)c.n_layers * NA * lvdim);
+    bf16* rec_a = a.alloc<bf16>((size_t)c.n_layers * NA * vh);
+    bf16* rec_b = a.alloc<bf16>((size_t)c.n_layers * NA * vh);
     if (!a.ok) { fprintf(stderr, "[dflash-verify] scratch allocation failed\n"); return -1; }
 
     static thread_local int* ph_ids = nullptr;
     static thread_local int* ph_pos = nullptr;
     static thread_local int* ph_seq = nullptr;
     static thread_local int* ph_out = nullptr;
-    static thread_local cudaGraph_t verify_graph = nullptr;
-    static thread_local cudaGraphExec_t verify_exec = nullptr;
+    // One graph per row count (index 1..kVerifyMaxRows). A single slot meant the verify could
+    // only ever replay the width dflash_warm_verify captured, which is why the block width had to
+    // be a per-GENERATION constant; with a tier per width the caller can choose it per step.
+    static thread_local cudaGraph_t verify_graph[kVerifyMaxRows + 1] = {};
+    static thread_local cudaGraphExec_t verify_exec[kVerifyMaxRows + 1] = {};
     static thread_local bool graph_warm = false;
-    static thread_local bool graph_ready = false;
+    static thread_local bool graph_ready_t[kVerifyMaxRows + 1] = {};
     static thread_local const void* graph_model_key = nullptr;
     static thread_local const void* graph_state_key = nullptr;
     static thread_local const void* graph_conv_key = nullptr;
@@ -2718,7 +2734,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     // a few KB) so the 10 full-attention layers each run ONE split + ONE combine instead of one per
     // row. That removes 2*(N-1) graph nodes per attention layer, and the graph is ~1000 nodes deep
     // against only ~5.6 ms of kernel time, so node count is itself a real cost here.
-    int* btab_rows = (N > 1) ? a.alloc<int>((size_t)N * mbs) : nullptr;
+    int* btab_rows = (N > 1) ? a.alloc<int>((size_t)NA * mbs) : nullptr;
     if (!a.ok) { fprintf(stderr, "[dflash-verify] block-table scratch allocation failed\n"); return -1; }
     bool supported = true;
     int  vfail_L = -1;   // layer whose stage declined, for the bailout diagnostic below
@@ -2742,10 +2758,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     if (graph_model_key != s.w.lm_head || graph_state_key != s.lin_state ||
         graph_conv_key != s.lin_conv_state || graph_capture_key != capture_dst ||
         graph_btable_key != btable || graph_ns_key != ns) {
-        if (verify_exec) cudaGraphExecDestroy(verify_exec);
-        if (verify_graph) cudaGraphDestroy(verify_graph);
-        verify_exec = nullptr; verify_graph = nullptr;
-        graph_ready = false; graph_warm = false;
+        for (int t = 1; t <= kVerifyMaxRows; t++) {
+            if (verify_exec[t]) cudaGraphExecDestroy(verify_exec[t]);
+            if (verify_graph[t]) cudaGraphDestroy(verify_graph[t]);
+            verify_exec[t] = nullptr; verify_graph[t] = nullptr;
+            graph_ready_t[t] = false;
+        }
+        graph_warm = false;
         graph_model_key = s.w.lm_head;
         graph_state_key = s.lin_state;
         graph_conv_key = s.lin_conv_state;
@@ -2753,9 +2772,9 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         graph_btable_key = btable;
         graph_ns_key = ns;
     }
-    if (graph_ready && capture_only) return 0;   // already built
-    if (graph_ready) {
-        pf_cu(cudaGraphLaunch(verify_exec, st), "verify graph launch");
+    if (graph_ready_t[N] && capture_only) return 0;   // this tier is already built
+    if (graph_ready_t[N]) {
+        pf_cu(cudaGraphLaunch(verify_exec[N], st), "verify graph launch");
         pf_cu(cudaStreamSynchronize(st), "verify graph sync");
         std::memcpy(out_argmax, ph_out, (size_t)N * sizeof(int));
         if (vdbg_dump_now) {
@@ -3259,14 +3278,14 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     pf_cu(cudaMemcpyAsync(ph_out, out_ids, (size_t)N * sizeof(int), cudaMemcpyDeviceToHost, st),
           "verify argmax");
     if (recording) {
-        pf_cu(cudaStreamEndCapture(st, &verify_graph), "verify graph end");
-        pf_cu(cudaGraphInstantiate(&verify_exec, verify_graph, 0), "verify graph instantiate");
-        graph_ready = true;
+        pf_cu(cudaStreamEndCapture(st, &verify_graph[N]), "verify graph end");
+        pf_cu(cudaGraphInstantiate(&verify_exec[N], verify_graph[N], 0), "verify graph instantiate");
+        graph_ready_t[N] = true;
         graph_warm = true;
         // Nothing ran: capture records the kernels rather than executing them, so the model state
         // is exactly as it was and there is no work to launch or collect.
         if (capture_only) return 0;
-        pf_cu(cudaGraphLaunch(verify_exec, st), "verify graph first launch");
+        pf_cu(cudaGraphLaunch(verify_exec[N], st), "verify graph first launch");
     }
     pf_cu(cudaStreamSynchronize(st), "verify sync");
     std::memcpy(out_argmax, ph_out, (size_t)N * sizeof(int));


### PR DESCRIPTION
## Summary

Three changes to the DSpark decode step, all measured on the scored dimension.

The draft already scores every proposal's own accept probability and the batched verify discarded
it, verifying a fixed `kProposalDepth + 1` rows on every step — including the 52.8% of steps that
accept nothing. Choose the row count per step from that score against a cost model measured
online. Then fix the two kernels the profile says are leaving the most on the table: the Markov
bias, which was the only draft kernel not at roofline, and the NVFP4 rows GEMV, which is 67% of
the step and is latency bound rather than compute bound.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090.** False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark-decode@4k`, the scored dimension, measured with
`runtime/examples/dspark_tau_check` on the same prompt and 4096-id truncation `eval/pr_dspark_bot.py`
uses; `bench.sh` has no DSpark leg):

| | decode tok/s |
|---|--:|
| before (main) | 104.68 |
| after (this PR) | 113.03 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090, Qwen3.8-27B NVFP4 + released DSpark draft, ctx=4096, max_new=128, SPEC-REPS 3.
Clocks PINNED at 2550 MHz (nvidia-smi -lgc 2550) and arms ALTERNATED, because this box
power-throttles: an unpinned pair of runs moved the AR leg 88.3 -> 90.9 tok/s on its own, which
is larger than the effect being measured. Every arm is the SAME binary -- all three changes are
runtime switches -- so nothing but the switch differs between arms.

  base_1    DSPARK 104.7116  AR 85.6434  MEAN_ACCEPT 1.8056  LOSSLESS 3/3
  base_2    DSPARK 104.6457  AR 85.6226  MEAN_ACCEPT 1.8056  LOSSLESS 3/3
  full_1    DSPARK 112.9917  AR 85.6115  MEAN_ACCEPT 1.7808  LOSSLESS 3/3
  full_2    DSPARK 113.0766  AR 85.6114  MEAN_ACCEPT 1.7808  LOSSLESS 3/3

  base mean 104.6787 (spread 0.06%)  ->  113.0342 (spread 0.08%)  =  +7.98%
  AR -0.02%.  mean accept 98.6% of main.  LOSSLESS on every arm of every run.

each part on its own, same binary, same session, same clock:

  all three off (main behaviour)          104.5231   AR 85.6265   MEAN_ACCEPT 1.8056
  GEMV row mapping only                   109.9277   AR 85.6228   MEAN_ACCEPT 1.8056   +5.17%
  planner + Markov, GEMV mapping off      108.3444   AR 85.6442   MEAN_ACCEPT 1.7568   +3.65%
  planner + Markov, Markov off            111.4443   AR 85.3193   MEAN_ACCEPT 1.7568
  all three                               113.0342   AR 85.6115   MEAN_ACCEPT 1.7808   +7.98%

The GEMV mapping is worth MORE on its own (+5.17%) than stacked (+4.34%), because without the
planner every step verifies four rows, which is exactly where it helps most. Mean accept RISES
when the two are combined (1.7568 -> 1.7808) -- the cost model is fitted online, cheaper rows
lower its per-row term, and the planner then buys more of them.

structural changes alone are neutral, which is the check worth doing first:

  main                                    109.7259 tok/s  AR 88.4077  MEAN_ACCEPT 1.8056
  this PR, all three switches off         109.6516 tok/s  AR 88.3378  MEAN_ACCEPT 1.8056   -0.07%
```

## Verify length

`S_i = prod_{j<=i} sigmoid(confidence_j)` is the probability that row `i` is both reached and
accepted, so verifying `d+1` rows is worth `1 + sum_{i<=d} S_i` tokens and costs `C0 + c1*(d+1)`
ms. Take the `d` that maximises the ratio.

There is no tuned constant in it. The probabilities are the head's own sigmoid — it is trained as
an accept-rate predictor, so `sigmoid(logit)` is already its calibrated output, and fitting a
per-position logistic on top measured no better (+7.14% against +7.18% on the same trace). `C0`
and `c1` are least-squares fitted online from the run's own `(rows, ms)` samples;
`batched_forward` already synchronises before it returns, so the sample costs no extra sync. The
fit converges to the same place the offline sweep found:

```text
offline, SPARKINFER_DFLASH_PROPOSALS=1/2/3 with SPARKINFER_DSPARK_TIMING=1:
  rows 2 -> verify 12.260 ms    rows 3 -> 13.238 ms    rows 4 -> 13.710 ms
  least squares: verify_ms = 10.894 + 0.725 * rows      (the 1-row intercept is AR's own 11.3 ms)

online, from the stream's own samples:
  [timing] plan  2.778 rows/step (of 6)  fit C0=10.692 c1=0.811 ms
```

Why it is worth choosing per step — the accept distribution is bimodal, and the head separates it
(`SPARKINFER_DSPARK_PROBE=1`, 72 steps at ctx=4096):

```text
  accepted proposals   0      1      2      3
  share of steps      52.8%  25.0%  11.1%  11.1%

  mean raw confidence at position 1: +0.580 where accepted, -0.707 where rejected
  positions 2 and 3 separate by +0.98 and +0.79
```

Note the direction this moves acceptance. It is not throughput bought by speculating less: the
rows it declines are rows the target was going to reject.

This needed the verify graph keyed by row count — it was keyed on model / state / conv / capture /
btable / nsplits and **not** on N, so the single graph `dflash_warm_verify` captured was replayed
for every step and the width could only be a per-generation constant. Every arena buffer in that
function is now sized for the widest tier, because `Arena::alloc` frees and reallocates a slot the
moment a later call asks it for more bytes, which would have left an already-instantiated narrower
graph pointing at freed memory.

## The two kernels

**Markov bias.** `w2` is `[vocab, rank]` row major, so one thread per vocabulary row put
consecutive lanes `rank*2` = 512 B apart and each 2-byte load pulled a whole sector. It was the
only draft kernel not at roofline — 870 GB/s on a 127 MB stream against 1.56 TB/s for the LM head
and 1.53 TB/s for the projections. One warp per row, `uint4` loads.

**NVFP4 rows GEMV.** 67% of the step, and ncu says latency, not compute:

```text
  rows      1      2      4      8
  DRAM %  68.2   74.1   57.6   27.0
  SM   %  27.9   31.7   31.2   19.8     <- never above a third of peak
  warps%  93.5   76.8   62.3   31.7
```

`NR` — output rows per warp-group — is what buys warps back. At NR=2 the compiler keeps two sets
of weight temporaries live across the unrolled `j` loop, which costs far more than the second acc
column:

```text
  R          1   2   3   4   5   6   7   8
  NR=2 reg  47  48  56  64  70  78  80  93     <- climbs with the row count
  NR=1 reg  38  39  39  40  42  40  44  42     <- flat
```

Banded rather than switched blanket, because it is not free everywhere. Isolated kernel with a
DRAM-resident working set, microseconds at four rows:

```text
  ffn gate/up N=17408  40.8 -> 34.8      gdn wide N=12288  30.7 -> 26.6
  attn q      N=6144   15.5 -> 13.8      ffn down N=5120   36.8 -> 36.8
                                         attn kv  N=1024    6.2 ->  6.2
```

Neutral or better at every shape for R in [3,7]; at eight rows it inverts on the narrow shapes
(ffn down 49.2 -> 59.4) and at two rows or fewer there are already enough warps, so the doubled
grid is not repaid.

For anyone tempted by tensor cores here: the SM pipes above are the reason not to. The SM120
block-scaled NVFP4 GEMM already in the tree is **slower** than this GEMV at m=8 on the same
weights (ffn gate/up 47.1 -> 51.2 us, ffn down 49.2 -> 77.7, gdn wide 34.8 -> 36.9), and
`prefill_nvfp4_supported` requires `m % 8 == 0`, which AR's single row cannot satisfy.

## Scope and safety

Each output row of the GEMV is still computed by one warp-group over the same group ordering with
the same reduction, so that change is bit-identical; only the row-to-warp mapping moves.

The planner and the Markov kernel are inert on checkpoints without a confidence head:
`forward_block` leaves the buffer untouched, the NaN sentinel survives, and the fixed depth is
used — plain DFlash is byte-unchanged.

`SPARKINFER_DSPARK_PLAN=0`, `SPARKINFER_DFLASH_MARKOV_WARP=0` and `SPARKINFER_NVFP4_ROWS_NR=1|2`
restore the previous behaviour of each part independently, which is how the isolation above was
measured.

The Markov change alters the order of a float reduction, so it can shift which token the draft
proposes. It can never shift which token is emitted — every emitted token is still a target argmax
— so losslessness is unaffected and only acceptance can move.

Also instantiates the draft's batched GEMV at widths 5/6/7: `block_size` is 7 on the released
checkpoints, so rounding `depth+1` over {2,4,8,16} and clamping produced a width nothing was
compiled for, and the draft fell to a per-token loop at every depth above 3 (2.5 ms -> 9.9 ms).
That path is reached at `ctx >= SPARKINFER_DFLASH_DEEP_MIN_SEQ`, where the ladder selects depth 7.
