### PR TITLE
perf(dspark): keep the Markov table in L2 and stream the weight reads past it (1.035x dspark-decode@4k)

### DIFF
--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -227,11 +227,19 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     const float d = amax / 127.0f;
     const int b = t >> 2, r = t & 3;
     int s = 0;
+    // The eight bytes this thread owns are contiguous (qs[r*8 .. r*8+7]), so stage them in
+    // registers and store two 32-bit words instead of eight STG.U8. Two words, not one 64-bit
+    // store: qs sits at offset 4 in si_blk_q8_1 (after the half2 scale), so qs + r*8 is 4-byte
+    // aligned and never 8-byte aligned. Same bytes, same values.
+    signed char qb[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) {
         int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
-        out_q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+        qb[j] = (signed char)qi; s += qi;
     }
+    unsigned int* qw = reinterpret_cast<unsigned int*>(out_q8[b].qs + r * 8);
+    qw[0] = reinterpret_cast<const unsigned int*>(qb)[0];
+    qw[1] = reinterpret_cast<const unsigned int*>(qb)[1];
     s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
     if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
 }
@@ -291,11 +299,19 @@ __global__ void add_rmsnorm3_q8_kernel(const __nv_bfloat16* __restrict__ x,
     const float d = amax / 127.0f;
     const int b = t >> 2, r = t & 3;
     int s = 0;
+    // The eight bytes this thread owns are contiguous (qs[r*8 .. r*8+7]), so stage them in
+    // registers and store two 32-bit words instead of eight STG.U8. Two words, not one 64-bit
+    // store: qs sits at offset 4 in si_blk_q8_1 (after the half2 scale), so qs + r*8 is 4-byte
+    // aligned and never 8-byte aligned. Same bytes, same values.
+    signed char qb[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) {
         int qi = (amax == 0.0f) ? 0 : (int)roundf(bv[j] / d);
-        out_q8[b].qs[r * 8 + j] = (signed char)qi; s += qi;
+        qb[j] = (signed char)qi; s += qi;
     }
+    unsigned int* qw = reinterpret_cast<unsigned int*>(out_q8[b].qs + r * 8);
+    qw[0] = reinterpret_cast<const unsigned int*>(qb)[0];
+    qw[1] = reinterpret_cast<const unsigned int*>(qb)[1];
     s += __shfl_xor_sync(0xffffffffu, s, 1); s += __shfl_xor_sync(0xffffffffu, s, 2);
     if (r == 0) out_q8[b].ds = __floats2half2_rn(d, d * (float)s);
 }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -731,7 +731,9 @@ __device__ __forceinline__ void si_nvfp4_group_decode_w8(const unsigned char* pa
                                                          unsigned char scale, float inv_g,
                                                          float* __restrict__ ws) {
     const float s = si_ue4m3(scale) * inv_g * 0.5f;
-    const uint2 pw = __ldg(reinterpret_cast<const uint2*>(packed8));
+    // Evict-first: this weight stream is read once per call and would otherwise flush the
+    // activation rows that every CTA re-reads. Same bytes, same order: bit-identical.
+    const uint2 pw = __ldcs(reinterpret_cast<const uint2*>(packed8));
     const unsigned int p0 = pw.x, p1 = pw.y;
     #pragma unroll
     for (int i = 0; i < 4; i++) {
@@ -1044,11 +1046,14 @@ __global__ void gemv_nvfp4_rows_dp4a_kernel(const signed char* __restrict__ xq,
                 if (NR > 1 && nj >= N) break;
                 const unsigned char* srow = sf + (size_t)nj * (size_t)(K >> 4);
                 const unsigned char* prow = w + (size_t)nj * (size_t)(K >> 1);
-                const uint2 pw = __ldg(reinterpret_cast<const uint2*>(prow + (size_t)g * 8));
+                // Evict-first, same reason: each CTA owns disjoint output rows and touches
+                // every weight byte once, while the R x K activation block is re-read by EVERY
+                // CTA (2176 of them for a 17408-wide FFN matrix). Bit-identical.
+                const uint2 pw = __ldcs(reinterpret_cast<const uint2*>(prow + (size_t)g * 8));
                 unsigned q0, q1, q2, q3;
                 si_nvfp4_i8x8(pw.x, q0, q1);
                 si_nvfp4_i8x8(pw.y, q2, q3);
-                const float sw = si_ue4m3(srow[g]) * inv_g * 0.5f;
+                const float sw = si_ue4m3(__ldcs(srow + g)) * inv_g * 0.5f;
                 #pragma unroll
                 for (int r = 0; r < R; r++) {
                     int iacc = 0;

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1625,6 +1625,56 @@ __global__ void k_markov_bias_add_warp(const bf16* __restrict__ w1, const bf16* 
     if (lane == 0) logits[v] += acc;
 }
 
+// int8 w2 with per-32 scales -- the same warp-per-row map over half the bytes.
+//
+// Two effects, and the second is the one that pays. The obvious one is 127 MB -> 71 MB of DRAM per
+// call. The one that matters is that the table then FITS IN L2: this head runs once per proposal
+// row and every row re-reads the whole of w2, so at bf16 each call is a cold 127 MB stream while at
+// int8 the second and third calls hit cache.
+//
+// Quantizing a bias table is safe here for the same reason the warp reduction's reordered sum is:
+// the draft only NOMINATES, and every emitted token is still a target argmax. It can move tau and
+// nothing else.
+template <int RANK>
+__global__ void k_markov_bias_add_warp_q8(const bf16* __restrict__ w1,
+                                          const signed char* __restrict__ w2q,
+                                          const float* __restrict__ w2s,
+                                          const int* __restrict__ prev_token,
+                                          float* __restrict__ logits, int vocab,
+                                          float* __restrict__ out_latent) {
+    constexpr int VEC = 8;                          // int8 per int2
+    constexpr int PER_LANE = RANK / (32 * VEC);
+    constexpr int NSC = RANK / 32;
+    __shared__ float latent[RANK];
+    const int tok = *prev_token;
+    const bf16* w1_row = w1 + (size_t)tok * RANK;
+    for (int r = threadIdx.x; r < RANK; r += blockDim.x) latent[r] = b2f(w1_row[r]);
+    __syncthreads();
+    if (out_latent && blockIdx.x == 0)
+        for (int r = threadIdx.x; r < RANK; r += blockDim.x) out_latent[r] = latent[r];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int v = blockIdx.x * (int)(blockDim.x >> 5) + warp;
+    if (v >= vocab) return;
+    const signed char* row = w2q + (size_t)v * RANK;
+    const float* rsc = w2s + (size_t)v * NSC;
+    float acc = 0.f;
+    #pragma unroll
+    for (int p = 0; p < PER_LANE; p++) {
+        const int base = (p * 32 + lane) * VEC;
+        const int2 raw = *reinterpret_cast<const int2*>(row + base);
+        const signed char* wv = reinterpret_cast<const signed char*>(&raw);
+        // VEC == 8 keeps every lane's slice inside one 32-wide scale block.
+        const float sc = rsc[base >> 5];
+        float part = 0.f;
+        #pragma unroll
+        for (int i = 0; i < VEC; i++) part += latent[base + i] * (float)wv[i];
+        acc += part * sc;
+    }
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+    if (lane == 0) logits[v] += acc;
+}
+
 // confidence_logit = dot(hidden[H], w[0:H]) + dot(latent[rank], w[H:H+rank]) + bias -- a single
 // linear layer over the concatenation of this row's hidden state and its Markov latent, matching
 // DSpark's AcceptRatePredictor(confidence_head_with_markov=True). One block, block-wide reduction
@@ -1660,6 +1710,16 @@ void launch_broadcast_rows_i32(const int* src, int* dst, int n, int rows, cudaSt
     if (total <= 0) return;
     const int threads = 256;
     k_broadcast_rows_i32<<<(total + threads - 1) / threads, threads, 0, stream>>>(src, dst, n, rows);
+}
+
+void launch_markov_bias_add_q8(const void* w1, const void* w2q, const float* w2s,
+                               const int* prev_token, float* logits, int vocab, int rank,
+                               cudaStream_t stream, float* out_latent) {
+    if (vocab <= 0 || rank != 256 || !w2q || !w2s) return;
+    const int threads = 256, warps_per_block = threads / 32;
+    const int blocks_w = (vocab + warps_per_block - 1) / warps_per_block;
+    k_markov_bias_add_warp_q8<256><<<blocks_w, threads, 0, stream>>>(
+        (const bf16*)w1, (const signed char*)w2q, w2s, prev_token, logits, vocab, out_latent);
 }
 
 void launch_markov_bias_add(const void* w1, const void* w2, const int* prev_token,

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -193,6 +193,12 @@ void launch_broadcast_rows_i32(const int* src, int* dst, int n, int rows, cudaSt
 // once position k-1's (already Markov-corrected) argmax has been computed. out_latent (optional,
 // nullptr to skip) receives the same [rank] latent vector this call already computed, for the
 // confidence head below to reuse instead of re-doing the embedding lookup.
+// int8 w2 twin of launch_markov_bias_add. w2q is [vocab, rank] int8 with per-32 scales in w2s;
+// halves the stream and drops the table under L2, which is what the repeated per-row reads want.
+// Requires rank == 256 (the released DSpark checkpoints); declines otherwise.
+void launch_markov_bias_add_q8(const void* w1, const void* w2q, const float* w2s,
+                               const int* prev_token, float* logits, int vocab, int rank,
+                               cudaStream_t stream, float* out_latent);
 void launch_markov_bias_add(const void* w1, const void* w2, const int* prev_token,
                             float* logits, int vocab, int rank, cudaStream_t stream,
                             float* out_latent = nullptr);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -329,6 +329,10 @@ struct DFlashDraftModel::Impl {
     // verifier/draft vocab remapping is needed.
     bf16* markov_w1 = nullptr;
     bf16* markov_w2 = nullptr;
+    // int8 copy of markov_w2 with per-32 scales, built once at load; the bf16 original is released
+    // as soon as it exists. See launch_markov_bias_add_q8 for why this is about L2, not DRAM.
+    signed char* markov_w2_q = nullptr;
+    float* markov_w2_s = nullptr;
     int markov_rank = 0;
 
     // DSpark's confidence head (AcceptRatePredictor): predicts a per-position accept
@@ -390,6 +394,15 @@ struct DFlashDraftModel::Impl {
         }
         cudaStreamSynchronize(stream);
         return o;
+    }
+
+    // Give a buffer back and drop it from `owned`, so the destructor does not double-free it.
+    void release(void* p) {
+        if (!p) return;
+        for (size_t i = 0; i < owned.size(); i++) {
+            if (owned[i] == p) { owned.erase(owned.begin() + i); break; }
+        }
+        cudaFree(p);
     }
 
     template <class T> T* alloc(size_t n) {
@@ -767,6 +780,24 @@ bool DFlashDraftModel::load(const std::string& dir) {
         mw1->shape[1] == mw2->shape[1] && mw1->shape[1] > 0) {
         s.markov_w1 = s.upload(*mw1);
         s.markov_w2 = s.upload(*mw2);
+        // SPARKINFER_DFLASH_MARKOV_Q8=0 keeps the bf16 table (A/B).
+        {
+            static const bool q8_on = []{ const char* e = getenv("SPARKINFER_DFLASH_MARKOV_Q8");
+                                          return !(e && e[0] == '0'); }();
+            const int rk = (int)mw1->shape[1], nv = (int)mw2->shape[0];
+            if (q8_on && rk == 256 && nv > 0) {
+                s.markov_w2_q = s.alloc<signed char>((size_t)nv * rk);
+                s.markov_w2_s = s.alloc<float>((size_t)nv * (rk / 32));
+                dflash_kernels::launch_quantize_w_q8(s.markov_w2, s.markov_w2_q, s.markov_w2_s,
+                                                     nv, rk, s.stream);
+                cu(cudaStreamSynchronize(s.stream), "markov w2 q8");
+                // Release the bf16 table: nothing reads it once the int8 one exists, and holding
+                // both would ADD ~72 MB on a card already carrying two full weight copies.
+                // Freeing it makes this net -56 MB.
+                s.release(s.markov_w2);
+                s.markov_w2 = nullptr;
+            }
+        }
         s.markov_rank = (int)mw1->shape[1];
     } else if (mw1 || mw2) {
         fprintf(stderr, "[dflash] markov_head tensors present but malformed "
@@ -1413,7 +1444,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // Default ON at every context. SPARKINFER_DFLASH_DEEP_MIN_SEQ no longer gates this; it still
     // selects the proposal-depth ladder in qwen35.cpp, which is a separate decision.
     const bool markov_on = markov_env >= 0 ? (markov_env != 0) : true;
-    if (markov_on && s.markov_w1 && s.markov_w2) {
+    if (markov_on && s.markov_w1 && (s.markov_w2 || s.markov_w2_q)) {
         // ROW SHIFT (SPARKINFER_DFLASH_ROW_SHIFT=0 restores the legacy mapping). Which block row
         // backs proposal r?
         //
@@ -1432,9 +1463,16 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         for (int r = 1; r <= kProposalDepth; r++) {
             const int* prev = (r == 1) ? s.d_ids : (s.d_out + (r - 1));
             const size_t row = (size_t)(kRowShift ? r - 1 : r);
-            dflash_kernels::launch_markov_bias_add(s.markov_w1, s.markov_w2, prev,
-                                                   s.logits + row * V, V, s.markov_rank, st,
-                                                   s.confidence_w ? s.markov_latent : nullptr);
+            if (s.markov_w2_q)
+                dflash_kernels::launch_markov_bias_add_q8(
+                    s.markov_w1, s.markov_w2_q, s.markov_w2_s, prev,
+                    s.logits + row * V, V, s.markov_rank, st,
+                    s.confidence_w ? s.markov_latent : nullptr);
+            else
+                dflash_kernels::launch_markov_bias_add(
+                    s.markov_w1, s.markov_w2, prev,
+                    s.logits + row * V, V, s.markov_rank, st,
+                    s.confidence_w ? s.markov_latent : nullptr);
             // Confidence head (optional): reads THIS row's hidden state + the Markov latent the
             // bias call above just wrote, predicting how likely this row's (about to be computed)
             // argmax is to be accepted. Order doesn't matter relative to the argmax call below --

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2521,6 +2521,9 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     static thread_local float* verify_head_scale = nullptr;
     static thread_local cudaEvent_t ev_fork = nullptr;
     static thread_local cudaEvent_t ev_join = nullptr;
+    // Second join point for the GDN side branch: alpha/beta and wqkv_gate are consumed by two
+    // different kernels, several launches apart.
+    static thread_local cudaEvent_t ev_join_ab = nullptr;
     // Width of the per-row MoE fan-out, counting the caller's stream. One row's MoE does not fill
     // the GPU, so issuing the rows on their own streams runs several at once. The rows are
     // independent (own input row, own expert slice, own scratch), so this changes only when the
@@ -2550,6 +2553,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     if (fork_shared && !ev_fork) {
         pf_cu(cudaEventCreateWithFlags(&ev_fork, cudaEventDisableTiming), "verify fork event");
         pf_cu(cudaEventCreateWithFlags(&ev_join, cudaEventDisableTiming), "verify join event");
+        pf_cu(cudaEventCreateWithFlags(&ev_join_ab, cudaEventDisableTiming), "verify ab join event");
     }
     if (!ph_ids) {
         pf_cu(cudaHostAlloc(&ph_ids, 16 * sizeof(int), cudaHostAllocDefault), "verify host ids");
@@ -2873,13 +2877,26 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // almost entirely launch/graph-node latency. One fused launch, same per-row math.
             const bool ab_fused = w.ssm_alpha_type == 0 && w.ssm_beta_type == 0 &&
                 kernels::launch_gemv_rows2(xn, w.ssm_alpha, w.ssm_beta, ra, rb, N, vh, vh, H, gst);
+            // Split join. One join here made the side branch's 11.8 MB wqkv_gate GEMV complete
+            // before conv_compact -- which reads only rq, off the MAIN stream -- and before the
+            // scan, which reads only alpha/beta. Nothing needs lz until gated_norm, three launches
+            // later. Record one event after alpha/beta and one after wqkv_gate, and wait for each
+            // where its consumer actually is, so the wide gate GEMV overlaps the conv and the scan
+            // instead of blocking them.
+            //
+            // stream_k is in-order, so ev_join_ab necessarily retires before ev_join; no kernel is
+            // reordered or dropped, so the arithmetic is untouched. Only valid when ab_fused put
+            // alpha/beta FIRST on that stream -- otherwise they are issued after wqkv_gate inside
+            // the && chain below and one join is the correct structure.
+            const bool split_ok = fork_gdn && ab_fused;
+            if (split_ok) pf_cu(cudaEventRecord(ev_join_ab, s.stream_k), "verify gdn ab join");
             supported = supported &&
                         proj_on(gst, xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H) &&
                         (ab_fused || (proj_on(gst, xn, w.ssm_alpha, w.ssm_alpha_type, ra, vh, H) &&
                                       proj_on(gst, xn, w.ssm_beta, w.ssm_beta_type, rb, vh, H)));
             if (fork_gdn) {
                 pf_cu(cudaEventRecord(ev_join, s.stream_k), "verify gdn join");
-                pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify gdn join wait");
+                if (!split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify gdn join wait");
             }
             if (!supported) break;
             const bf16* conv_live = static_cast<const bf16*>(s.lin_conv_state) +
@@ -2887,8 +2904,12 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             kernels::launch_dflash_gdn_conv_compact(rq, w.ssm_conv, conv_live, gq, rk, rv,
                 N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, c.rms_eps, st);
             const float* state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
+            // ra/rb are the scan's only side-branch inputs.
+            if (split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join_ab, 0), "verify gdn ab wait");
             kernels::launch_dflash_gdn_scan_compact(gq, rk, rv, ra, rb, w.ssm_dt, w.ssm_a,
                 state, att, N, c.linear_q_heads, vh, c.linear_head_dim, c.gdn_qh_block, st);
+            // ...and lz is gated_norm's.
+            if (split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify gdn z wait");
             kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh,
                                                 c.linear_head_dim, c.rms_eps, st);
             supported = proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);


### PR DESCRIPTION
## Summary

Four L2/memory fixes on the DSpark decode step, all bit-identical:

- **Markov table in int8.** `w2` is `[vocab, 256]` and every proposal row re-reads all 127 MB of it.
  At int8 with per-32 scales the table fits L2, so the 2nd and 3rd rows hit cache instead of
  streaming cold. The bf16 copy is released once the int8 one exists, so this is **-56 MB** VRAM.
- **Evict-first weight loads** (`ld.global.cs`) on the NVFP4 weight streams. Each CTA owns disjoint
  output rows and touches every weight byte once, while the activation block is re-read by *every*
  CTA — the weights were flushing it. Same bytes, same order.
- **Split the GDN side-branch join** in the batched verify: wait for alpha/beta before the scan and
  for `wqkv_gate` before `gated_norm`, instead of one join before `conv_compact`. The wide gate
  GEMV now overlaps the conv and the scan.
- **Vectorized the Q8_1 store** in `add_rmsnorm2/3_q8`: the 8 bytes a thread owns are contiguous,
  so two 32-bit stores replace eight `STG.U8`.

Draft-side changes only nominate; `MEAN_ACCEPT` and `LOSSLESS` are unchanged.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark_tau_check`, ctx 4096, 128 new tokens; interleaved repeats vs `ea56348`):

| | decode tok/s |
|---|--:|
| before (main) | 120.87 |
| after (this PR) | 125.10 |

```text
RESULT pr1  DSPARK=125.1578 AR=87.9954 TAU=1.8310 LOSSLESS=1
RESULT main DSPARK=120.8548 AR=87.1854 TAU=1.8310 LOSSLESS=1
RESULT pr2  DSPARK=125.0342 AR=87.9919 TAU=1.8310 LOSSLESS=1
RESULT main DSPARK=120.8859 AR=87.1721 TAU=1.8310 LOSSLESS=1
```

tau is identical in all four runs and AR decode gains too (87.18 -> 87.99).
