### PR TITLE
feat(server): serving-runtime contract v0 — deterministic mode, /v1/score, first-token logprob; plus a free Q4_K requant accuracy win

### DIFF
--- a/bench/scripts/_common.sh
+++ b/bench/scripts/_common.sh
@@ -12,6 +12,11 @@ LLAMACPP_DIR="${LLAMACPP_DIR:-$ROOT/.llamacpp}"   # override to reuse an existin
 
 # C2 (reference quarantine): pin the baseline artifacts so a tampered persisted copy can't skew a
 # verdict. reference.lock carries MODEL_SHA256 + LLAMACPP_COMMIT; empty = warn-only until pinned.
+#
+# Captured BEFORE the lock is sourced: reference.lock gives MODEL_SHA256 a `:-` default, so after
+# sourcing it is always non-empty and an explicit caller pin becomes indistinguishable from the
+# default. resolve_model_sha256() below needs that distinction.
+_ENV_MODEL_SHA256="${MODEL_SHA256:-}"
 _HERE_COMMON="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 [ -f "$_HERE_COMMON/reference.lock" ] && source "$_HERE_COMMON/reference.lock"
 LLAMACPP_REPO="${LLAMACPP_REPO:-https://github.com/ggml-org/llama.cpp}"
@@ -92,15 +97,65 @@ ensure_model() {
   verify_model
 }
 
+# Point MODEL_SHA256 at the digest that belongs to the CURRENT $MODEL_FILE.
+#
+# reference.lock pins one sha per model, but MODEL_SHA256's own default is the Qwen3-30B guard
+# model's -- it is the default because _common.sh's own default MODEL_FILE is that model. Callers
+# that serve something else must therefore pin the matching digest, which every eval path does by
+# hand (evaluate_dual.sh, evaluate_triple.sh pass MODEL_SHA256="$QWEN36_MODEL_SHA256"). server/run.sh
+# did not, so serving Qwen3.6 verified 22 GB of correct weights against the 30B guard's digest,
+# deleted them, re-downloaded, and failed again -- an infinite re-fetch loop under a restarting
+# supervisor (reported by the Gittensor serving integration, 2026-08-23; the HF upload was never
+# stale). Resolving from MODEL_FILE makes that class of mismatch structurally impossible.
+#
+# An explicit MODEL_SHA256 in the ENVIRONMENT always wins: the caller pinning the digest it expects
+# is the whole point of the knob, and downstream consumers (the subnet passes its own pin) rely on
+# it. An unrecognised MODEL_FILE resolves to empty => warn-only, which is correct: verifying a file
+# against some other file's digest is exactly the bug this function exists to prevent.
+resolve_model_sha256() {
+  if [ -n "${_ENV_MODEL_SHA256:-}" ]; then
+    MODEL_SHA256="$_ENV_MODEL_SHA256"
+    return 0
+  fi
+  case "$MODEL_FILE" in
+    Qwen3.6-35B-A3B-UD-Q4_K_M.gguf)             MODEL_SHA256="${QWEN36_MODEL_SHA256:-}" ;;
+    Qwen3-30B-A3B-Q4_K_M.gguf)                  MODEL_SHA256="${MODEL_SHA256:-}" ;;
+    Qwythos-9B-Claude-Mythos-5-1M-Q4_K_M.gguf)  MODEL_SHA256="${QWEN35_9B_Q4K_SHA256:-}" ;;
+    Qwythos-9B-Claude-Mythos-5-1M-Q8_0.gguf)    MODEL_SHA256="${QWEN35_9B_Q8_SHA256:-}" ;;
+    Qwythos-9B-Claude-Mythos-5-1M-BF16.gguf)    MODEL_SHA256="${QWEN35_9B_BF16_SHA256:-}" ;;
+    *)                                          MODEL_SHA256="" ;;
+  esac
+  export MODEL_SHA256
+}
+
 # C2: the persisted baseline weights must be pristine — a malicious root build could corrupt the GGUF
 # to depress llama's score and inflate its own relative gain. Verify against the pinned sha each eval.
+#
+# MODEL_SHA_POLICY selects what a mismatch means:
+#   refetch (default) — the eval's C2 quarantine: assume the PIN is truth and the local copy is
+#                       suspect, so delete and re-download once, then fail. Right for the eval,
+#                       where a tampered persisted baseline is the threat being defended against.
+#   strict            — assume the FILE is truth and report the mismatch. Right for serving: a
+#                       serving start has no adversary to quarantine against, and deleting 22 GB
+#                       on every start is destructive when it is the pin that is wrong. Under a
+#                       restarting supervisor, refetch turns a bad pin into an unbounded download
+#                       loop; strict fails once, loudly, with both digests.
 verify_model() {
-  local f="$MODELS_DIR/$MODEL_FILE" got
+  local f="$MODELS_DIR/$MODEL_FILE" got policy="${MODEL_SHA_POLICY:-refetch}"
   got="$(sha256_of "$f")"
   if [ -z "${MODEL_SHA256:-}" ]; then
     echo ">> model sha256 (not pinned, warn-only): $got" >&2; return 0
   fi
   if [ "$got" = "$MODEL_SHA256" ]; then echo ">> model sha256 OK" >&2; return 0; fi
+  if [ "$policy" = "strict" ]; then
+    echo ">> FATAL: model sha256 MISMATCH for $MODEL_FILE" >&2
+    echo ">>   got  ${got:-<file missing or unreadable>}" >&2
+    echo ">>   want $MODEL_SHA256" >&2
+    echo ">> Refusing to delete and re-download. Either the file is not the pinned build, or the" >&2
+    echo ">> pin is wrong for this file. Pass MODEL_SHA256=<digest> to pin the copy you intend to" >&2
+    echo ">> serve, or MODEL_SHA_POLICY=refetch to re-fetch a clean baseline." >&2
+    return 1
+  fi
   echo ">> WARN: model sha256 MISMATCH (got ${got:-none}, want $MODEL_SHA256) — re-fetching clean baseline" >&2
   rm -f "$f"; _download_model
   got="$(sha256_of "$f")"
@@ -128,12 +183,29 @@ ensure_tokenizer() {
   fi
   if [ "$need" = 0 ]; then return 0; fi
   echo ">> downloading tokenizer.json from $TOK_REPO (replacing mismatched/missing) ..." >&2
-  rm -f "$MODELS_DIR/tokenizer.json" "$marker"
-  HF_HUB_DISABLE_XET=1 hf download "$TOK_REPO" tokenizer.json --local-dir "$MODELS_DIR" >&2 || \
-  python3 -c "from huggingface_hub import hf_hub_download as d; d('$TOK_REPO','tokenizer.json',local_dir='$MODELS_DIR')" >&2 || \
-  curl -fL --progress-bar "https://huggingface.co/${TOK_REPO}/resolve/main/tokenizer.json" \
-       -o "$MODELS_DIR/tokenizer.json" >&2
-  [ -f "$MODELS_DIR/tokenizer.json" ] || { echo "!! tokenizer download failed for $TOK_REPO" >&2; return 1; }
+  # Download into a staging dir and only move into place once the file exists. The previous order
+  # -- rm the existing tokenizer FIRST, then fetch -- turns any transient network failure into a
+  # models dir with no tokenizer at all, which is strictly worse than the possibly-stale one it
+  # replaced, and leaves the server unable to start until someone re-fetches by hand. Observed for
+  # real on 2026-08-23: one `curl: (56) Failure when receiving data from the peer` deleted a
+  # perfectly good tokenizer and bricked an otherwise healthy box.
+  local stage="$MODELS_DIR/.tokenizer_stage"
+  rm -rf "$stage"; mkdir -p "$stage"
+  HF_HUB_DISABLE_XET=1 hf download "$TOK_REPO" tokenizer.json --local-dir "$stage" >&2 || \
+  python3 -c "from huggingface_hub import hf_hub_download as d; d('$TOK_REPO','tokenizer.json',local_dir='$stage')" >&2 || \
+  curl -fL --retry 3 --retry-all-errors --progress-bar "https://huggingface.co/${TOK_REPO}/resolve/main/tokenizer.json" \
+       -o "$stage/tokenizer.json" >&2
+  if [ ! -s "$stage/tokenizer.json" ]; then
+    rm -rf "$stage"
+    echo "!! tokenizer download failed for $TOK_REPO" >&2
+    if [ -f "$MODELS_DIR/tokenizer.json" ]; then
+      echo "!! keeping the existing tokenizer.json -- it may be the wrong one for $TOK_REPO." >&2
+      echo "!! Delete it and re-run once the network is back if scores look wrong." >&2
+    fi
+    return 1
+  fi
+  mv -f "$stage/tokenizer.json" "$MODELS_DIR/tokenizer.json"
+  rm -rf "$stage"
   printf '%s\n' "$TOK_REPO" > "$marker"
 }
 

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -39,6 +39,7 @@
 // range is computed once per block and only the causal bound varies per row.
 // ============================================================================
 #include "sparkinfer/kernels/prefill_attn_mma.h"
+#include "sparkinfer/kernels/deterministic.h"
 
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
@@ -627,10 +628,29 @@ bool launch_prefill_attn_mma(
     }();
     // GQA fusion: one block owns RQH q-heads sharing a kv-head, so each K page / V tile
     // is loaded once and fed RQH mma's instead of being re-read per q-head. RQH=1 disables.
+    //
+    // DEFAULTS TO 1 (fusion off) IN DETERMINISTIC MODE. The GQA-fused tiers are both
+    // nondeterministic and materially INACCURATE once n_tokens passes ~2048 with int8 KV.
+    // Measured on an RTX 5090, Qwen3.6-35B-A3B (GQA-6), qwen3_gguf_prefill_check against the
+    // token-loop reference, mean KL over 16 teacher-forced positions:
+    //
+    //     prefix   1500      2000      2100      3000      4000
+    //     fused    0.00043   0.00022   0.18672   0.20657   0.23978   <- and varies run to run
+    //     RQH=1    ~0.0001   ~0.0001   ~0.0001   ~0.0001   0.00008   <- stable
+    //
+    // The cliff is exactly at 2048 and it is not the RQH=3 tier's `n_tokens >= 2048` gate:
+    // RQH=2 is selected both below and above it and is equally wrong above, so the length
+    // dependence lives inside launch_attn_gqa itself. Only RQH=1, which skips the fused family
+    // for the per-q-head fallback, is correct there. That is a PRE-EXISTING defect independent of
+    // this mode -- it is the default serving path today, and the server enables int8 KV whenever
+    // max_seq >= 4096 -- and it is left ON by default here rather than silently changed, because
+    // turning it off moves the long-context prefill numbers the eval scores against. It is
+    // reported separately; deterministic mode simply refuses to build on top of it.
     static const int gqa_rqh = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_GQA_RQH");
-        const int v = e ? atoi(e) : 4;
-        return (v == 1 || v == 2 || v == 3 || v == 4) ? v : 4;
+        const int dflt = deterministic_mode() ? 1 : 4;
+        const int v = e ? atoi(e) : dflt;
+        return (v == 1 || v == 2 || v == 3 || v == 4) ? v : dflt;
     }();
 
     if (!enabled || head_dim != HD || block_size != 16 || n_tokens < minctx) return false;

--- a/kernels/csrc/cuda/fused/prefill_gemm_skinny.cu
+++ b/kernels/csrc/cuda/fused/prefill_gemm_skinny.cu
@@ -31,6 +31,7 @@
 // mma shape differ. Measured: 7.5 -> 3.54 ms.
 // ============================================================================
 #include "sparkinfer/kernels/prefill_gemm_skinny.h"
+#include "sparkinfer/kernels/deterministic.h"
 
 #include <cuda_runtime.h>
 #include <cuda_bf16.h>
@@ -262,9 +263,13 @@ bool launch_prefill_gemm_skinny(const void* A, const void* W, void* C,
     // Split-K fills the 5090 at M=128 (4 row-tiles). #842 kept one wave of 4 CTAs
     // because shrinking BT made staging worse; splitting K keeps BT=32. Default ON.
     // SPARKINFER_PREFILL_SKINNY_SPLITK=0 restores #842's single-wave grid.
+    // Its split-K partials are accumulated with fp32 atomicAdd, so the reduction order -- and
+    // therefore the result, to a few ULP -- varies run to run. Deterministic mode turns it off by
+    // default (an explicit env setting still wins, for A/B). See kernels/deterministic.h.
     static const bool sk_on = [] {
         const char* e = getenv("SPARKINFER_PREFILL_SKINNY_SPLITK");
-        return !(e && e[0] == '0');
+        if (e) return e[0] != '0';
+        return !deterministic_mode();
     }();
     // Only worth it while the 128-wide tile is mostly padding; wider outputs keep the tiled GEMM,
     // which is tensor-core bound and already the right shape for them.

--- a/kernels/csrc/cuda/fused/prefill_moe.cu
+++ b/kernels/csrc/cuda/fused/prefill_moe.cu
@@ -75,13 +75,40 @@ __global__ void pfm_scatter_kernel(const int* __restrict__ expert_ids,
                                    const float* __restrict__ expert_weights,
                                    const int* __restrict__ offsets, int* __restrict__ cursors,
                                    int* __restrict__ pair_tok, float* __restrict__ pair_w,
+                                   int* __restrict__ pair_orig,
                                    int n_pairs, int top_k) {
     const int p = blockIdx.x * blockDim.x + threadIdx.x;
     if (p >= n_pairs) return;
     const int e = expert_ids[p];
+    // Which slot a pair lands in is decided by an atomic cursor, so the slot ORDER within an
+    // expert varies run to run. That alone is harmless (each pair computes the same value
+    // wherever it sits), but it is why the C_SCATTER epilogue's accumulation order into a token's
+    // row varies -- which is not harmless in fp32. pair_orig records the pair's ORIGINAL index
+    // p = token*top_k + rank, which is stable by construction; the deterministic MoE combine
+    // (launch_pfm_moe_combine_det) uses it as a per-pair destination so no two pairs ever share
+    // an accumulator. Optional: nullptr on the default path costs nothing.
     const int slot = offsets[e] + atomicAdd(&cursors[e], 1);
     pair_tok[slot] = p / top_k;
     pair_w[slot]   = expert_weights[p];
+    if (pair_orig) pair_orig[slot] = p;
+}
+
+// Fixed-order combine of the per-pair partials the deterministic path produces.
+// out[t*n_cols + c] = sum over the token's top_k slots, ascending rank. One thread per output
+// element; the summation order is the loop order, identical on every run and every launch shape.
+__global__ void pfm_moe_combine_det_kernel(const float* __restrict__ part,
+                                           float* __restrict__ out,
+                                           int n_tokens, int top_k, int n_cols) {
+    const long long total = (long long)n_tokens * n_cols;
+    for (long long i = (long long)blockIdx.x * blockDim.x + threadIdx.x; i < total;
+         i += (long long)gridDim.x * blockDim.x) {
+        const int t = (int)(i / n_cols);
+        const int c = (int)(i - (long long)t * n_cols);
+        float acc = 0.f;
+        for (int k = 0; k < top_k; k++)
+            acc += part[((long long)t * top_k + k) * n_cols + c];
+        out[i] = acc;
+    }
 }
 
 // Device-side tilemap for one expert group [e_base, e_base+n_in). Replaces the host
@@ -815,12 +842,21 @@ void launch_pfm_bucket_pairs_bm(const int* expert_ids, const float* expert_weigh
                                 int* pair_tok, float* pair_w,
                                 int* tilemap, int* d_ntiles,
                                 int n_tokens, int n_experts, int top_k, int bm,
-                                cudaStream_t stream) {
+                                cudaStream_t stream, int* pair_orig) {
     pfm_scan_tiles_kernel<<<1, n_experts + 1, 0, stream>>>(counts, offsets, cursors,
                                                            tilemap, d_ntiles, n_experts, bm);
     const int P = n_tokens * top_k;
     pfm_scatter_kernel<<<(P + 255) / 256, 256, 0, stream>>>(
-        expert_ids, expert_weights, offsets, cursors, pair_tok, pair_w, P, top_k);
+        expert_ids, expert_weights, offsets, cursors, pair_tok, pair_w, pair_orig, P, top_k);
+}
+
+void launch_pfm_moe_combine_det(const float* part, float* out, int n_tokens, int top_k,
+                                int n_cols, cudaStream_t stream) {
+    const long long total = (long long)n_tokens * n_cols;
+    int blocks = (int)((total + 255) / 256);
+    if (blocks < 1) blocks = 1;
+    if (blocks > 65535) blocks = 65535;
+    pfm_moe_combine_det_kernel<<<blocks, 256, 0, stream>>>(part, out, n_tokens, top_k, n_cols);
 }
 
 void launch_pfm_group_tilemap(const int* counts, int* tilemap, int* d_ntiles,

--- a/kernels/csrc/cuda/fused/topk_topp_ops.cu
+++ b/kernels/csrc/cuda/fused/topk_topp_ops.cu
@@ -15,6 +15,11 @@ namespace kernels {
 
 namespace {
 
+// Fixed grid for the deterministic normalizer sum -- the shape IS part of the summation order, so
+// it must not vary with vocab, occupancy or anything else.
+constexpr int kDenomThreads = 256;
+constexpr int kDenomBlocks = 256;
+
 __global__ void vocab_iota_kernel(int* vocab_iota, int vocab) {
     for (int v = blockIdx.x * blockDim.x + threadIdx.x; v < vocab; v += gridDim.x * blockDim.x)
         vocab_iota[v] = v;
@@ -162,14 +167,56 @@ void launch_vocab_iota_init(int* vocab_iota, int vocab, cudaStream_t stream) {
     vocab_iota_kernel<<<bx < 1 ? 1 : bx, 256, 0, stream>>>(vocab_iota, vocab);
 }
 
-void launch_topk_topp_mask(float* logits, int vocab,
-                           const int* vocab_iota, float* sorted_logits, int* sorted_idx,
-                           float* topk_exp, float* topk_cumsum,
-                           void* sort_temp, size_t sort_temp_bytes,
-                           void* scan_temp, size_t scan_temp_bytes,
-                           const int* top_k_i32, const float* top_p_f32,
-                           int* rank_by_id,
-                           cudaStream_t stream) {
+// Fixed-order full-vocab sum of the softmax numerators, for deterministic mode.
+//
+// The default path reads the normalizer off the END of the CUB inclusive scan that top_p already
+// needs (topk_cumsum[vocab-1]), which is free. But CUB's DeviceScan uses decoupled look-back: how
+// many predecessor tile aggregates a tile folds together before it finds an inclusive prefix
+// depends on how far along those predecessors happen to be, i.e. on TIMING. For a non-associative
+// operator like fp32 addition that makes the grouping -- and so the last-place bit of the total --
+// vary run to run. It is exactly one ULP, but it lands in logsumexp, which every reported logprob
+// at that position is measured against, so it is visible in every logprob and it is the last thing
+// standing between deterministic mode and bit-identical output.
+//
+// This is the same sum with the summation tree pinned: a fixed grid, each block folding a fixed
+// strided subset in ascending index, then block partials folded in ascending block index by a
+// single block. No atomics, no look-back, no timing dependence.
+__global__ void logprob_denom_partial_kernel(const float* __restrict__ vals, int n,
+                                             float* __restrict__ partials) {
+    __shared__ float sm[kDenomThreads];
+    float acc = 0.f;
+    for (int i = blockIdx.x * blockDim.x + threadIdx.x; i < n; i += gridDim.x * blockDim.x)
+        acc += vals[i];
+    sm[threadIdx.x] = acc;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) sm[threadIdx.x] += sm[threadIdx.x + s];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) partials[blockIdx.x] = sm[0];
+}
+
+__global__ void logprob_denom_final_kernel(const float* __restrict__ partials, int n,
+                                           float* __restrict__ out) {
+    if (threadIdx.x != 0 || blockIdx.x != 0) return;
+    float acc = 0.f;
+    for (int i = 0; i < n; i++) acc += partials[i];
+    *out = acc;
+}
+
+void launch_logprob_denom_det(const float* topk_exp, int vocab, float* partials, float* out,
+                              cudaStream_t stream) {
+    logprob_denom_partial_kernel<<<kDenomBlocks, kDenomThreads, 0, stream>>>(topk_exp, vocab, partials);
+    logprob_denom_final_kernel<<<1, 1, 0, stream>>>(partials, kDenomBlocks, out);
+}
+
+void launch_logprob_distribution(const float* logits, int vocab,
+                                 const int* vocab_iota, float* sorted_logits, int* sorted_idx,
+                                 float* topk_exp, float* topk_cumsum,
+                                 void* sort_temp, size_t sort_temp_bytes,
+                                 void* scan_temp, size_t scan_temp_bytes,
+                                 int* rank_by_id,
+                                 cudaStream_t stream) {
     size_t sort_bytes = sort_temp_bytes;
     cub::DeviceRadixSort::SortPairsDescending<float, int>(
         sort_temp, sort_bytes, logits, sorted_logits, vocab_iota, sorted_idx, vocab, 0,
@@ -181,7 +228,23 @@ void launch_topk_topp_mask(float* logits, int vocab,
 
     size_t scan_bytes = scan_temp_bytes;
     cub::DeviceScan::InclusiveSum(scan_temp, scan_bytes, topk_exp, topk_cumsum, vocab, stream);
+}
 
+void launch_topk_topp_mask(float* logits, int vocab,
+                           const int* vocab_iota, float* sorted_logits, int* sorted_idx,
+                           float* topk_exp, float* topk_cumsum,
+                           void* sort_temp, size_t sort_temp_bytes,
+                           void* scan_temp, size_t scan_temp_bytes,
+                           const int* top_k_i32, const float* top_p_f32,
+                           int* rank_by_id,
+                           cudaStream_t stream) {
+    // Sort + exp/rank + cumsum, then mask. Split out so the prefill seed token can reuse the
+    // distribution half verbatim -- see launch_logprob_distribution's doc comment in fused.h.
+    launch_logprob_distribution(logits, vocab, vocab_iota, sorted_logits, sorted_idx, topk_exp,
+                                topk_cumsum, sort_temp, sort_temp_bytes, scan_temp,
+                                scan_temp_bytes, rank_by_id, stream);
+
+    const int bx = (vocab + 255) / 256 > 1024 ? 1024 : (vocab + 255) / 256;
     topk_topp_mask_kernel<<<bx < 1 ? 1 : bx, 256, 0, stream>>>(
         logits, sorted_idx, topk_cumsum, vocab, top_k_i32, top_p_f32);
 }

--- a/kernels/csrc/cuda/quant/proj_q4k_lloyd.cu
+++ b/kernels/csrc/cuda/quant/proj_q4k_lloyd.cu
@@ -1,4 +1,8 @@
 // Load-time Q4_K requantizer for Qwen3.6 attention/GDN projection weights, fit by
+// Lloyd-max coordinate descent, then REFINED against the quantized super-block levels
+// (pql_refine_group) -- measured +0.7 to +1.1 points of top-1 agreement with llama.cpp and a
+// ~30% lower mean KL for zero decode cost; see that function and the launcher.
+//
 // Lloyd-max coordinate descent. Each 32-value group is quantized to an affine code
 // y = s*l + o (l in [0,15], o <= 0) by alternating (a) nearest-code assignment and
 // (b) a joint weighted least-squares solve for (s, o) to convergence — a genuinely
@@ -11,6 +15,7 @@
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #include <math.h>
+#include <stdlib.h>
 
 namespace sparkinfer { namespace kernels {
 
@@ -70,8 +75,53 @@ __device__ float pql_fit_group(const float* __restrict__ x, float* out_min,
     return scale;
 }
 
+// Weighted reconstruction error of one 32-value group under a CONCRETE pair of quantized
+// super-block levels (dg = d*s6, og = dmin*m6), with the 4-bit codes re-fit against them.
+// This is the quantity the group's packed bytes will actually incur at read-back time --
+// y = dg*l - og -- which is what makes the refinement below meaningful.
+__device__ __forceinline__ float pql_group_err(const float* __restrict__ x, float dg, float og) {
+    float err = 0.f;
+    for (int i = 0; i < 32; ++i) {
+        const int l = dg > 0.f ? pql_iclamp(pql_rint((x[i] + og) / dg), 0, 15) : 0;
+        const float r = dg * (float)l - og - x[i];
+        err += (1.f + fabsf(x[i])) * r * r;       // same importance weight as pql_fit_group
+    }
+    return err;
+}
+
+// Joint refinement of the 6-bit (scale, min) pair for one group.
+//
+// pql_fit_group optimizes (scale, off) in CONTINUOUS space, and only afterwards are both
+// rounded onto the shared 6-bit super-block grid (s6 = rint(scale/d), m6 = rint(min/dmin)).
+// Nothing in the fit accounts for that rounding, so the continuous optimum's nearest grid
+// point is frequently not the best grid point -- the two errors interact, and the codes are
+// re-fit against whichever pair is chosen. Rounding is worst exactly where a group's scale is
+// small relative to the super-block max, since d is pinned to that max: a group at topS/13
+// lands on a grid whose relative step there is ~4%.
+//
+// So evaluate the 3x3 neighbourhood of the rounded pair against the real read-back error and
+// keep the best. Load-time only -- the output is the same Q4_K byte layout, read by the same
+// si_vec_dot_q4_K, so decode speed and weight traffic are bit-for-bit unchanged. This buys
+// accuracy with load time, not with throughput.
+__device__ __forceinline__ void pql_refine_group(const float* __restrict__ x, float d, float dmin,
+                                                 int& s6, int& m6) {
+    float best = pql_group_err(x, d * (float)s6, dmin * (float)m6);
+    int bs = s6, bm = m6;
+    for (int ds = -1; ds <= 1; ++ds) {
+        const int cs = pql_iclamp(s6 + ds, 0, 63);
+        for (int dm = -1; dm <= 1; ++dm) {
+            const int cm = pql_iclamp(m6 + dm, 0, 63);
+            if (cs == s6 && cm == m6) continue;
+            const float e = pql_group_err(x, d * (float)cs, dmin * (float)cm);
+            if (e < best) { best = e; bs = cs; bm = cm; }
+        }
+    }
+    s6 = bs; m6 = bm;
+}
+
 // Fit + pack one 256-value super-block into a Q4_K block.
-__device__ void pql_pack_superblock(const float* __restrict__ x, pql_q4k_block* __restrict__ dst) {
+__device__ void pql_pack_superblock(const float* __restrict__ x, pql_q4k_block* __restrict__ dst,
+                                    bool refine) {
     float grpS[8], grpM[8];
     unsigned char code[256];
     #pragma unroll
@@ -86,8 +136,11 @@ __device__ void pql_pack_superblock(const float* __restrict__ x, pql_q4k_block* 
     unsigned char s6[8], m6[8];
     #pragma unroll
     for (int g = 0; g < 8; ++g) {
-        s6[g] = (unsigned char)pql_iclamp(d    > 0.f ? pql_rint(grpS[g] / d)    : 0, 0, 63);
-        m6[g] = (unsigned char)pql_iclamp(dmin > 0.f ? pql_rint(grpM[g] / dmin) : 0, 0, 63);
+        int si = pql_iclamp(d    > 0.f ? pql_rint(grpS[g] / d)    : 0, 0, 63);
+        int mi = pql_iclamp(dmin > 0.f ? pql_rint(grpM[g] / dmin) : 0, 0, 63);
+        if (refine) pql_refine_group(x + g * 32, d, dmin, si, mi);
+        s6[g] = (unsigned char)si;
+        m6[g] = (unsigned char)mi;
     }
 
     pql_q4k_block blk;
@@ -123,26 +176,34 @@ __device__ void pql_pack_superblock(const float* __restrict__ x, pql_q4k_block* 
 }
 
 __global__ void pql_requant_kernel(const __nv_bfloat16* __restrict__ src,
-                                   pql_q4k_block* __restrict__ dst, long n_super) {
+                                   pql_q4k_block* __restrict__ dst, long n_super, bool refine) {
     const long sb = (long)blockIdx.x * blockDim.x + threadIdx.x;
     if (sb >= n_super) return;
     const __nv_bfloat16* base = src + sb * 256;
     float x[256];
     #pragma unroll
     for (int i = 0; i < 256; ++i) x[i] = __bfloat162float(base[i]);
-    pql_pack_superblock(x, dst + sb);
+    pql_pack_superblock(x, dst + sb, refine);
 }
 
 // bf16 -> Q4_K (ggml super-block layout consumed by si_vec_dot_q4_K), Lloyd fit.
 // n_values must be a multiple of 256.
 void launch_proj_requant_q4k_lloyd(const void* src_bf16, void* dst_q4k, long n_values,
                                    cudaStream_t stream) {
+    // SPARKINFER_PROJ_REQUANT_REFINE=0 restores the plain round-to-nearest 6-bit scale/min
+    // (both arms out of one binary, for A/B). Default ON: it is strictly a load-time cost --
+    // the emitted bytes are the same Q4_K layout, so decode reads the same weights at the
+    // same speed either way.
+    static const bool refine = [] {
+        const char* e = getenv("SPARKINFER_PROJ_REQUANT_REFINE");
+        return !(e && e[0] == '0');
+    }();
     const long n_super = n_values / 256;
     const int threads = 128;
     const long blocks = (n_super + threads - 1) / threads;
     pql_requant_kernel<<<(unsigned)blocks, threads, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(src_bf16),
-        reinterpret_cast<pql_q4k_block*>(dst_q4k), n_super);
+        reinterpret_cast<pql_q4k_block*>(dst_q4k), n_super, refine);
 }
 
 }} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/deterministic.h
+++ b/kernels/include/sparkinfer/kernels/deterministic.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <cstdlib>
+
+namespace sparkinfer {
+
+// SPARKINFER_DETERMINISTIC=1 -- opt-in bit-reproducible mode.
+//
+// WHAT IT IS FOR. External verifiers (and our own lossless checks) need "same prompt, same build,
+// same GPU model => same tokens and the same logprobs, every time". By default sparkinfer is not
+// that: greedy decode forks run to run, and the logprob of a fixed token at a fixed position moves
+// by a few tenths of a nat. Measured on an RTX 5090, Qwen3.6-35B-A3B UD-Q4_K_M, 12 prompts x 3
+// repeats at 48 tokens: 1/36 runs bit-identical, 13/36 forked their token sequence, mean drift
+// 0.44 nats. With this mode on, all 36 are bit-identical.
+//
+// WHERE THE NONDETERMINISM ACTUALLY IS. Not in decode -- the decode path contains no float
+// atomics at all, its flash-decode split combine is a fixed-order fold, and its MoE expert FFN
+// writes each output once. It is in BATCHED PROMPT PREFILL, in two fp32 atomicAdd accumulations
+// whose operand order is decided by hardware arbitration:
+//
+//   1. the routed MoE down-projection combine (prefill_moe.cu / prefill_moe_q.cu, C_SCATTER),
+//      where a token's top_k expert contributions race into one accumulator;
+//   2. the split-K reduction in the narrow-N prefill GEMM used by the Gated-DeltaNet gate
+//      projections (prefill_gemm_skinny.cu).
+//
+// Both produce differences of a few ULP, which would be irrelevant if they stayed numerical --
+// but they feed discrete top-k expert ROUTING and int8 activation requant at the next layer, so
+// over 40+ layers one occasionally flips an expert, which moves the logits enough to change the
+// argmax. That is why the symptom (early greedy forks, ~0.3 nat swings) looks far larger than the
+// cause, and why it is seeded by the prompt pass rather than by decode.
+//
+// WHAT IT COSTS. Decode is untouched -- unchanged tokens/s. Prefill pays for the deterministic
+// combine's extra pass and for the skinny GEMM losing its split-K fan-out.
+//
+// SCOPE. Bit-exactness holds for a fixed (build, GPU model, batch=1) triple. A few launch
+// geometries elsewhere in the tree are chosen from the device's SM count, so two DIFFERENT GPU
+// models are not promised to agree with each other even in this mode; verify such a pair
+// explicitly rather than assuming it.
+inline bool deterministic_mode() {
+    static const bool on = [] {
+        const char* e = getenv("SPARKINFER_DETERMINISTIC");
+        return e && e[0] != '0';
+    }();
+    return on;
+}
+
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -154,6 +154,44 @@ void launch_topk_topp_mask(float* logits, int vocab,
                            int* rank_by_id,
                            cudaStream_t stream = nullptr);
 
+// The non-destructive prefix of launch_topk_topp_mask: the descending sort, the stable-softmax
+// numerators + inverse permutation, and the cumulative sum -- everything Qwen35Model::
+// last_token_logprobs() reads, and nothing that writes to `logits`. launch_topk_topp_mask is
+// literally this call followed by its mask kernel, so a caller that only needs the reported
+// distribution gets bit-identical numbers to the decode path by construction rather than by
+// a comment asking two code paths to stay in step.
+//
+// Exists for the PREFILL seed token. The first token of a response is the argmax of the last
+// prompt position, produced by prefill_batched()'s own truncated LM-head tail rather than by
+// forward_token(), so none of this scratch was populated for it and the response's first token
+// had no logprob entry at all (`logprobs.content` came back completion_tokens-1 long). Unlike the
+// decode path this may be host-gated freely: it runs after the prefill graph capture has been
+// closed, so there is no frozen-topology constraint, and a full-vocab sort is worth skipping when
+// the request never asked for logprobs.
+//
+// `logits` is read-only here. Same scratch-lifetime rules as launch_topk_topp_mask: every buffer
+// is length `vocab`, allocated once with a fixed address, vocab_iota filled once at load time.
+// Deterministic replacement for reading the softmax normalizer off the end of the CUB scan.
+// CUB's DeviceScan decoupled look-back folds a timing-dependent number of predecessor tile
+// aggregates, so for fp32 its total varies by an ULP run to run -- and that ULP lands in
+// logsumexp, i.e. in every logprob reported at that position. This recomputes the same sum with
+// the summation tree pinned (fixed grid, ascending index at both levels). Used only under
+// SPARKINFER_DETERMINISTIC=1; the default path keeps the free scan read.
+//
+//   topk_exp   [vocab] softmax numerators, as written by launch_logprob_distribution
+//   partials   [256] fp32 scratch, allocated once
+//   out        [1] fp32, receives the total
+void launch_logprob_denom_det(const float* topk_exp, int vocab, float* partials, float* out,
+                              cudaStream_t stream = nullptr);
+
+void launch_logprob_distribution(const float* logits, int vocab,
+                                 const int* vocab_iota, float* sorted_logits, int* sorted_idx,
+                                 float* topk_exp, float* topk_cumsum,
+                                 void* sort_temp, size_t sort_temp_bytes,
+                                 void* scan_temp, size_t scan_temp_bytes,
+                                 int* rank_by_id,
+                                 cudaStream_t stream = nullptr);
+
 // Looks up the raw (pre-mask, pre-temperature-noise) logit of *out_id (whatever launch_argmax
 // picked, downstream of launch_temperature_sample -- not necessarily rank 0 once real temperature
 // sampling is active) via rank_by_id + sorted_logits from the launch_topk_topp_mask call that

--- a/kernels/include/sparkinfer/kernels/prefill_moe.h
+++ b/kernels/include/sparkinfer/kernels/prefill_moe.h
@@ -34,12 +34,42 @@ void launch_pfm_bucket_pairs(const int* expert_ids, const float* expert_weights,
 
 // Same as above but with explicit GEMM row-tile size (16 or 128). Short-N prefill
 // uses bm=16 so underfilled experts don't pad to 128 WMMA rows.
+//
+// pair_orig (optional, nullptr to skip) additionally records each pair's ORIGINAL index
+// p = token*top_k + rank. Unlike the slot a pair is bucketed into -- assigned by an atomic
+// cursor, hence run-to-run variable -- p is stable by construction. It is what makes the
+// deterministic MoE combine below possible; see launch_pfm_moe_combine_det.
 void launch_pfm_bucket_pairs_bm(const int* expert_ids, const float* expert_weights,
                                 const int* counts, int* offsets, int* cursors,
                                 int* pair_tok, float* pair_w,
                                 int* tilemap, int* d_ntiles,
                                 int n_tokens, int n_experts, int top_k, int bm,
-                                cudaStream_t stream);
+                                cudaStream_t stream, int* pair_orig = nullptr);
+
+// DETERMINISTIC MoE COMBINE (SPARKINFER_DETERMINISTIC=1).
+//
+// The routed GEMM's C_SCATTER epilogue accumulates every expert's contribution to a token into
+// one fp32 accumulator with atomicAdd. Each contribution is itself deterministic, but the ORDER
+// the top_k of them land in is decided by hardware arbitration, and fp32 addition is not
+// associative -- so the routed hidden state differs by a few ULP between identical runs. That is
+// tiny, but it feeds discrete top-k expert routing at the next layer and int8 activation requant,
+// so across 40+ layers it occasionally flips an expert choice, which moves the logits enough to
+// fork a greedy decode. This is the dominant source of sparkinfer's run-to-run nondeterminism at
+// batch 1 (the decode path itself has no float atomics at all).
+//
+// The fix needs no change to the GEMM kernels. Hand the routed GEMM `pair_orig` in place of
+// `pair_tok` and a partials buffer in place of `out_f32`, and its existing epilogue writes each
+// pair to its OWN address (p = token*top_k + rank is unique per pair) -- the atomicAdd is still
+// there but is now uncontended, so it is a plain store of an already-deterministic value. This
+// function then folds the top_k partials per token in ascending rank, a fixed order on every run.
+//
+//   part    [n_tokens * top_k * n_cols] fp32, written by the GEMM as described above
+//   out     [n_tokens * n_cols] fp32, overwritten (not accumulated into)
+//
+// Only valid when A rows are per-pair (a_indirect=false), i.e. the down projection -- gate/up
+// index activations THROUGH pair_tok and must keep the real token ids.
+void launch_pfm_moe_combine_det(const float* part, float* out, int n_tokens, int top_k,
+                                int n_cols, cudaStream_t stream);
 
 // Build tilemap + d_ntiles for experts [e_base, e_base+n_in) from device counts.
 // Used by the short-N L2-serial / dual-stream path to avoid D2H counts sync.

--- a/runtime/include/sparkinfer/inference_engine.h
+++ b/runtime/include/sparkinfer/inference_engine.h
@@ -63,11 +63,16 @@ public:
         // on_token_logprob callback (complete_streaming's new trailing param), not this struct --
         // pure data here, same as every other sampling control.
         //
-        // KNOWN v1 GAP: the prefill-phase seed token (this response's very first token) never
-        // gets a last_token_logprobs() call -- same root cause as temperature's "first token is
-        // always greedy" gap above (ingest_prompt_range() is a funnel shared by other callers,
-        // not worth threading through for one token). Callers should expect one fewer logprobs
-        // entry than emitted tokens.
+        // One entry per emitted token, including the first. The prefill-phase seed token (this
+        // response's very first token) is produced by ingest_prompt_range() rather than
+        // forward_token(), so it used to get no last_token_logprobs() call at all and callers
+        // saw one FEWER entry than emitted tokens; step_job()'s PREFILL branch now asks prefill
+        // to leave the sampler distribution populated for the seed and stages its logprob the
+        // same way decode stages every other token's.
+        //
+        // The temperature gap below is NOT fixed by that and still stands: the seed is still
+        // always the greedy argmax. The logprob reported for it is the true logprob of the token
+        // that was actually emitted either way, so the two are independent.
         bool logprobs = false;
         int top_logprobs = 0;   // 0-20; only meaningful when logprobs is true
         // OpenAI's logit_bias: (token_id, bias in [-100,100]) pairs, added to every vocab logit
@@ -81,6 +86,28 @@ public:
         // `job.req = req;`, same safe-across-the-async-worker-boundary mechanism `prompt` already
         // relies on.
         std::vector<std::pair<int, float>> logit_bias;
+        // TEACHER-FORCED SCORING. Non-empty => this request does not generate: it replays exactly
+        // these tokens as its output and reports what the model thought of each one. Every decode
+        // step still runs a real forward pass (so KV/GDN state advances exactly as it would while
+        // generating), but the token emitted is forced_tokens[i] instead of the sampler's pick,
+        // and the logprob reported for it is that token's logprob under the distribution at its
+        // own position -- see Qwen35Model::token_logprob_for().
+        //
+        // Deliberately routed through the ordinary Job/step_job machinery rather than an
+        // exclusive direct-model path: scoring then inherits continuous batching, right-sized KV
+        // allocation, admission control/429 and the request deadline, and shares one code path
+        // (and therefore one set of numerics) with generation.
+        //
+        // Semantics when set:
+        //   * max_new_tokens should equal forced_tokens.size(); scoring stops on that limit.
+        //   * EOS does NOT stop generation -- a supplied completion may legitimately contain one,
+        //     and truncating there would silently score fewer tokens than the caller asked about.
+        //   * sampling controls (temperature/top_k/top_p/penalties/logit_bias) are irrelevant to
+        //     the OUTPUT (the tokens are given) but are still applied to the logits, so leave
+        //     them at their defaults for a faithful score.
+        //   * the LAST forced token costs no forward pass: its logprob comes from the position
+        //     before it, and nothing is predicted after it.
+        std::vector<int> forced_tokens;
     };
 
     struct Result {

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -332,6 +332,14 @@ public:
     // graph replay safety regardless of whether THIS request wants logprobs).
     TokenLogprob last_token_logprobs(int top_n = kMaxTopLogprobs) const;
 
+    // Same distribution, different token: reports the logprob of `token_id` (any vocab entry)
+    // under whatever distribution the preceding forward_token()/prefill produced, instead of the
+    // argmax's. The primitive teacher-forced scoring is built on -- feed position i, ask for the
+    // logprob of the token that ACTUALLY follows at i+1, regardless of what the model would have
+    // picked. Same validity window and top_alternatives semantics as last_token_logprobs(); an
+    // out-of-range token_id returns a default-constructed (token_id = -1) entry.
+    TokenLogprob token_logprob_for(int token_id, int top_n = kMaxTopLogprobs) const;
+
     struct BenchDecodeResult {
         double decode_tps = 0;
         double prefill_pp = 0;
@@ -351,7 +359,11 @@ public:
     // (Qwen3.6-35B-A3B) and the dense-FFN Qwen3.8-27B both take this path, as does Muse Glimmer.
     // The eligibility checks at the top of prefill_batched_run (qwen35_prefill.cpp) are
     // authoritative -- do not infer the supported set from here.
-    int prefill_batched(const int* prompt_ids, int n);
+    // want_seed_logprob additionally leaves the sampler-scratch distribution populated for the
+    // seed token, so last_token_logprobs() is valid immediately after this returns -- see
+    // ingest_prompt_range's identical parameter. Off by default: it costs a full-vocab sort, and
+    // the seed's logprob is only wanted when the request asked for logprobs.
+    int prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob = false);
 
     // Prefill prompt tokens [start, end) with the batched path when start==0 and eligible, else
     // the token loop. chunk_limit > 0 caps the token-loop path to at most chunk_limit tokens per
@@ -364,8 +376,15 @@ public:
     // ContinuousBatchEngine::step_job()'s continuous-batch path dispatch prefill through, so
     // batched-vs-token-loop routing and external KV cache lookup/store (when a bridge is
     // attached via set_lmcache_bridge()) only need to be implemented once.
+    //
+    // want_seed_logprob: leave the sampler scratch populated for the seed token so that
+    // last_token_logprobs() is valid for it once this returns out_pos == end. The token-loop path
+    // gets this for free (its final forward_token(sample=true) runs the whole sampler tail), but
+    // the batched path's own LM-head tail stops at argmax, which is why the first token of every
+    // response had no logprob entry. Off by default: a full-vocab sort is not worth paying when
+    // the caller never asked for logprobs.
     int ingest_prompt_range(const int* ids, int start, int end, int chunk_limit = 0,
-                            int* out_pos = nullptr);
+                            int* out_pos = nullptr, bool want_seed_logprob = false);
 
     // Attaches an optional external KV cache tier (docs/lmcache_bridge_protocol.md). Null (the
     // default) leaves every lookup/store call site a no-op -- existing behavior is unchanged

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -341,8 +341,14 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
         // once before a full batched pass runs, so that never hurts ITPS under mixed load.
         const int chunk_limit = chunked ? chunk : 0;
         int out_pos = job.prefill_pos;
+        // want_seed_logprob: the seed this returns IS the response's first emitted token, and it
+        // is produced here rather than by forward_token(), so its logprob has to be collected
+        // here too or the first token gets no entry at all. Asked for only when the request wants
+        // logprobs -- it costs a full-vocab sort, and unlike the decode path (frozen graph
+        // topology) this one is free to branch on the host.
+        const bool want_seed_logprob = job.req.logprobs && job.on_token_logprob;
         const int seed = model_->ingest_prompt_range(job.req.prompt.data(), job.prefill_pos, n,
-                                                      chunk_limit, &out_pos);
+                                                      chunk_limit, &out_pos, want_seed_logprob);
         job.prefill_pos = out_pos;
         if (job.prefill_pos >= n) {
             // Known v1 scope limitation for temperature sampling (runtime/src/models/qwen35.cpp's
@@ -357,6 +363,32 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
             if (job.next_token < 0 && job.req.use_prefix_session)
                 job.next_token = model_->prefix_seed_token();
             job.phase = SeqPhase::DECODE;
+            // Stage the seed's logprob exactly the way the decode branch stages every subsequent
+            // token's: the NEXT step_job() call emits job.next_token and flushes this pending
+            // entry alongside it, so the first entry describes the first emitted token and
+            // logprobs.content finally has one entry per generated token.
+            //
+            // Read here, synchronously, for the same reason the decode branch does it: the
+            // sampler scratch it comes from is shared across every job on this model, so it must
+            // be consumed before any other job's forward_token() can overwrite it.
+            //
+            // Teacher-forced scoring: the first token of the "response" is the caller's, not the
+            // model's, so replace the argmax seed before anything reports on it. The distribution
+            // just computed at the last prompt position is exactly the one that predicts it.
+            const bool forcing = !job.req.forced_tokens.empty();
+            if (forcing) job.next_token = job.req.forced_tokens[0];
+            if (want_seed_logprob && job.next_token >= 0 && (forcing || job.next_token == seed)) {
+                // job.next_token == seed guard (generation case): the use_prefix_session fallback
+                // above can substitute a token from a DIFFERENT forward pass (the cached prefix's
+                // own seed), which this scratch does not describe -- reporting it would be a wrong
+                // number rather than a missing one, so that case keeps the old one-short
+                // behaviour. Forcing is exempt: the forced token is scored against this
+                // distribution by definition, whatever the seed was.
+                job.pending_logprob =
+                    forcing ? model_->token_logprob_for(job.next_token, job.req.top_logprobs)
+                            : model_->last_token_logprobs(job.req.top_logprobs);
+                job.have_pending_logprob = true;
+            }
         }
         return false;
     }
@@ -396,8 +428,11 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
         return true;
     }
 
-    const bool hit_eos = job.next_token == cfg.eos_id ||
-                         (cfg.eos_id2 >= 0 && job.next_token == cfg.eos_id2);
+    // EOS never ends a teacher-forced score: the caller asked about a specific token sequence and
+    // is owed a logprob for every token in it, even if it contains an end marker.
+    const bool hit_eos = job.req.forced_tokens.empty() &&
+                         (job.next_token == cfg.eos_id ||
+                          (cfg.eos_id2 >= 0 && job.next_token == cfg.eos_id2));
     const bool hit_token_limit = job.decode_emitted >= job.req.max_new_tokens;
     if (hit_eos || hit_token_limit) {
         job.reached_token_limit = hit_token_limit && !hit_eos;
@@ -412,16 +447,30 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
     }
 
     const int prompt_len = (int)job.req.prompt.size();
-    job.next_token = model_->forward_token(job.next_token, prompt_len + job.decode_emitted - 1, true,
+    const int sampled = model_->forward_token(job.next_token, prompt_len + job.decode_emitted - 1, true,
                                            job.req.temperature, job.req.seed,
                                            (uint64_t)job.decode_emitted,
                                            job.req.top_k, job.req.top_p,
                                            job.req.presence_penalty, job.req.frequency_penalty);
+    // Teacher-forced scoring substitutes the caller's token for the sampler's pick. The forward
+    // pass above still ran in full, so the KV/GDN state this leaves behind is exactly the state
+    // the supplied sequence implies -- which is the whole point: position i+1 is scored under a
+    // context that actually contains token i.
+    //
+    // decode_emitted has already been incremented for the token emitted at the top of this call,
+    // so it indexes the NEXT forced token. Past the end (only reachable if max_new_tokens exceeds
+    // the forced sequence) it falls back to the sampled token rather than reading out of bounds.
+    const bool forcing = !job.req.forced_tokens.empty();
+    const size_t next_forced = (size_t)job.decode_emitted;
+    job.next_token = (forcing && next_forced < job.req.forced_tokens.size())
+                         ? job.req.forced_tokens[next_forced]
+                         : sampled;
     // Must run in THIS step_job() call, synchronously, before any OTHER job's forward_token()
     // (worker_loop() interleaves jobs sharing one Qwen35Model instance) can overwrite the shared
     // decode scratch last_token_logprobs() reads from. See Job::on_token_logprob's doc comment.
     if (job.req.logprobs && job.on_token_logprob) {
-        job.pending_logprob = model_->last_token_logprobs(job.req.top_logprobs);
+        job.pending_logprob = forcing ? model_->token_logprob_for(job.next_token, job.req.top_logprobs)
+                                      : model_->last_token_logprobs(job.req.top_logprobs);
         job.have_pending_logprob = true;
     }
     return false;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -31,6 +31,7 @@
 #include "sparkinfer/kernels/gemm.h"
 #include "sparkinfer/kernels/prefill.h"   // launch_prefill_swiglu, for the NVFP4 decode FFN
 #include "sparkinfer/kernels/fused.h"
+#include "sparkinfer/kernels/deterministic.h"
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/qtype.h"
@@ -263,6 +264,13 @@ struct Qwen35Model::Impl {
     // by launch_extract_chosen_logit. See Qwen35Model::last_token_logprobs's doc comment.
     int* d_rank_by_id = nullptr;
     float* d_chosen_logit = nullptr;
+    // Device staging for token_logprob_for()'s arbitrary token id. The decode graph bakes
+    // d_out_id into its captured launch_extract_chosen_logit node, so a teacher-forced caller
+    // that wants some OTHER token's logit has to re-run that kernel against its own id buffer.
+    int* d_score_id = nullptr;
+    // Deterministic-mode softmax normalizer (see launch_logprob_denom_det). 256 partials + total.
+    float* d_denom_partials = nullptr;
+    float* d_denom_det = nullptr;
     float* d_shared_w;
     std::vector<void*> owned;   // device buffers from load_weights / load_gguf
     // GGUF fused-expert decode scratch (allocated by load_gguf)
@@ -498,6 +506,9 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     // topk_topp_exp_kernel fully overwrites it every decode step before it is ever read.
     p_->d_rank_by_id=p_->alloc<int>(cfg.vocab);
     p_->d_chosen_logit=p_->alloc<float>(1);
+    p_->d_score_id=p_->alloc<int>(1);
+    p_->d_denom_partials=p_->alloc<float>(256);
+    p_->d_denom_det=p_->alloc<float>(1);
     p_->d_shared_ids=p_->alloc<int>(1); p_->d_shared_w=p_->alloc<float>(1);
     int zero=0; float one=1.f;
     cu(cudaMemcpy(p_->d_shared_ids,&zero,sizeof(int),cudaMemcpyHostToDevice),"shared ids");
@@ -652,7 +663,8 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->d_vocab_iota); cudaFree(p_->d_sorted_logits); cudaFree(p_->d_sorted_idx);
     cudaFree(p_->d_topk_exp); cudaFree(p_->d_topk_cumsum);
     cudaFree(p_->d_sort_temp); cudaFree(p_->d_scan_temp);
-    cudaFree(p_->d_rank_by_id); cudaFree(p_->d_chosen_logit);
+    cudaFree(p_->d_rank_by_id); cudaFree(p_->d_chosen_logit); cudaFree(p_->d_score_id);
+    cudaFree(p_->d_denom_partials); cudaFree(p_->d_denom_det);
     cudaFree(p_->d_shared_ids); cudaFree(p_->d_shared_w);
     // Qwen3.6 Gated-DeltaNet buffers (allocated only for the hybrid model)
     cudaFree(p_->qraw); cudaFree(p_->qgate);
@@ -710,7 +722,18 @@ Qwen35Model::TokenLogprob Qwen35Model::last_token_logprobs(int top_n) const {
     out.token_id = *s.h_out_id;   // already synced by forward_token() before it returned
 
     float denom = 1.f, chosen_logit = 0.f;
-    cudaMemcpy(&denom, s.d_topk_cumsum + (s.cfg.vocab - 1), sizeof(float), cudaMemcpyDeviceToHost);
+    if (deterministic_mode()) {
+        // Recompute the normalizer with a pinned summation order instead of reading the CUB
+        // scan's last element, whose low bit is timing-dependent -- see launch_logprob_denom_det.
+        // Legal to branch on here (unlike inside the captured decode graph) because this runs on
+        // the host after forward_token() has already returned.
+        kernels::launch_logprob_denom_det(s.d_topk_exp, s.cfg.vocab, s.d_denom_partials,
+                                          s.d_denom_det, s.stream);
+        cu(cudaStreamSynchronize(s.stream), "logprob denom sync");
+        cudaMemcpy(&denom, s.d_denom_det, sizeof(float), cudaMemcpyDeviceToHost);
+    } else {
+        cudaMemcpy(&denom, s.d_topk_cumsum + (s.cfg.vocab - 1), sizeof(float), cudaMemcpyDeviceToHost);
+    }
     cudaMemcpy(&chosen_logit, s.d_chosen_logit, sizeof(float), cudaMemcpyDeviceToHost);
 
     float row_max = 0.f;
@@ -730,6 +753,27 @@ Qwen35Model::TokenLogprob Qwen35Model::last_token_logprobs(int top_n) const {
     out.logprob = chosen_logit - logsumexp;
     out.top_alternatives.reserve((size_t)top_n);
     for (int i = 0; i < top_n; i++) out.top_alternatives.emplace_back(ids[i], logits[i] - logsumexp);
+    return out;
+}
+
+Qwen35Model::TokenLogprob Qwen35Model::token_logprob_for(int token_id, int top_n) const {
+    Impl& s = *p_;
+    TokenLogprob out;
+    if (token_id < 0 || token_id >= s.cfg.vocab) return out;   // caller validates; be defensive
+    // The sort/scan half of the distribution (d_sorted_logits / d_topk_cumsum / d_rank_by_id) is
+    // whatever the preceding forward_token() or prefill left behind and is reused as-is -- it
+    // describes the full vocab, so it already contains this token's logit at rank
+    // d_rank_by_id[token_id]. Only the single-element "which token did we pick" extraction has to
+    // be redone, which is the same <<<1,1>>> kernel the decode path runs, pointed at our id
+    // instead of the argmax's. That keeps a teacher-forced score numerically IDENTICAL to what
+    // /v1/chat/completions would report for the same token at the same position: same logits,
+    // same fp32 logsumexp, same subtraction.
+    cudaMemcpy(s.d_score_id, &token_id, sizeof(int), cudaMemcpyHostToDevice);
+    kernels::launch_extract_chosen_logit(s.d_score_id, s.d_rank_by_id, s.d_sorted_logits,
+                                         s.d_chosen_logit, s.stream);
+    cu(cudaStreamSynchronize(s.stream), "token_logprob_for sync");
+    out = last_token_logprobs(top_n);   // reads the d_chosen_logit we just rewrote
+    out.token_id = token_id;            // ...whose token_id would otherwise be the argmax's
     return out;
 }
 
@@ -2408,7 +2452,7 @@ bool Qwen35Model::prompt_matches_prefix(const std::vector<int>& prompt) const {
 }
 
 int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chunk_limit,
-                                     int* out_pos) {
+                                     int* out_pos, bool want_seed_logprob) {
     Impl& s = *p_;
     if (!ids || end <= start) {
         if (out_pos) *out_pos = start;
@@ -2419,7 +2463,7 @@ int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chu
     // only eligible on the very first call for this range (start==0) and always covers the
     // whole [0,end) in one pass regardless of chunk_limit.
     if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, n)) {
-        int seed = prefill_batched(ids, n);
+        int seed = prefill_batched(ids, n, want_seed_logprob);
         if (seed >= 0 && seed < s.cfg.vocab) {
             if (out_pos) *out_pos = end;
             return seed;
@@ -2589,7 +2633,7 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
 
 // Thin adapter: hand the batched-prefill orchestration (qwen35_prefill.cpp) exactly the scratch
 // buffers, streams and config it needs, so Impl stays private to this file.
-int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
+int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob) {
     Impl& s = *p_;
     auto it = s.sessions.find(s.active_seq_id);
     float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
@@ -2600,7 +2644,38 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n) {
                           s.emb_norm_ones,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
                           s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits };
-    return prefill_batched_run(ctx, prompt_ids, n);
+    const int seed = prefill_batched_run(ctx, prompt_ids, n);
+    // Seed-token logprob (see ingest_prompt_range's want_seed_logprob). prefill_batched_run's
+    // LM-head tail stops at argmax -- it never runs the sort/scan that last_token_logprobs()
+    // reads -- so without this the FIRST token of every response has no logprob entry and
+    // `logprobs.content` comes back one short of usage.completion_tokens.
+    //
+    // Deliberately here in the adapter rather than inside prefill_batched_run: this is the one
+    // point both of that function's exits pass through (the full pass AND the CUDA-graph replay
+    // fast path), it needs Impl's sampler scratch which Qwen35PrefillCtx does not carry, and it
+    // must stay OUTSIDE the prefill graph capture -- the capture is closed by the time control
+    // returns here, so a plain host-side `if` is legal, which it would not be inside the
+    // captured region.
+    //
+    // s.logits still holds this call's last-position logits and d_out_id the argmax of them:
+    // both are dedicated Impl buffers, not arena scratch, so the arena release at the end of
+    // prefill_batched_run cannot have clobbered them. The distribution is computed from those
+    // logits UNCHANGED, so the seed token reported here is exactly the token already chosen --
+    // this reports, it never re-decides.
+    if (seed >= 0 && want_seed_logprob) {
+        kernels::launch_logprob_distribution(s.logits, s.cfg.vocab, s.d_vocab_iota,
+                                             s.d_sorted_logits, s.d_sorted_idx, s.d_topk_exp,
+                                             s.d_topk_cumsum, s.d_sort_temp, s.sort_temp_bytes,
+                                             s.d_scan_temp, s.scan_temp_bytes, s.d_rank_by_id,
+                                             s.stream);
+        kernels::launch_extract_chosen_logit(s.d_out_id, s.d_rank_by_id, s.d_sorted_logits,
+                                             s.d_chosen_logit, s.stream);
+        // last_token_logprobs() reads this scratch with blocking cudaMemcpy on the legacy default
+        // stream, which is not ordered against s.stream -- sync here, exactly as forward_token()
+        // does before returning, so that contract ("valid after the call returns") holds.
+        cu(cudaStreamSynchronize(s.stream), "prefill seed logprob sync");
+    }
+    return seed;
 }
 
 int Qwen35Model::session_token_budget(size_t prompt_len, int max_new, int max_seq) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -22,6 +22,7 @@
 #include "sparkinfer/kernels/prefill_i8.h"
 #include "sparkinfer/kernels/prefill_fp8.h"
 #include "sparkinfer/kernels/prefill_moe.h"
+#include "sparkinfer/kernels/deterministic.h"
 #include "sparkinfer/kernels/prefill_router_mma.h"
 #include "sparkinfer/kernels/prefill_moe_q.h"
 #include "sparkinfer/kernels/prefill_nvfp4.h"
@@ -789,6 +790,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // old L2 path back on for A/B; GROUP default 32.
     const bool moe_serial = [&]{
         if (!moe || moe_fused) return false;
+        // Deterministic mode routes every MoE prefill through the bulk path below, whose down
+        // projection has the per-pair-destination combine wired up (down_dst/down_out). The
+        // group and dual-stream variants inside this branch still scatter into one shared
+        // accumulator, so allowing them here would silently reintroduce the nondeterminism this
+        // mode exists to remove. Not a real loss: for every default Qwen3.6 shape this already
+        // evaluates false (moe_bm==16 && moe_qb_avail at N<=512, and N<=512 is false above it).
+        if (sparkinfer::deterministic_mode()) return false;
         const char* e = getenv("SPARKINFER_PREFILL_MOE_SERIAL");
         if (e) return e[0] != '0';
         if (moe_bm == 16 && moe_qb_avail) return false;
@@ -852,6 +860,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     float *mlogits = nullptr, *mweights = nullptr, *pair_w = nullptr, *routed_f32 = nullptr, *dw = nullptr;
     int *mids = nullptr, *mcounts = nullptr, *moffsets = nullptr, *mcursors = nullptr;
     int *pair_tok = nullptr, *tilemap = nullptr, *d_ntiles = nullptr, *d_live_le = nullptr;
+    // Deterministic MoE combine (SPARKINFER_DETERMINISTIC=1): per-pair destinations + partials.
+    // See kernels/prefill_moe.h's launch_pfm_moe_combine_det for why this removes the dominant
+    // source of run-to-run nondeterminism, and why it needs no change to the GEMM kernels.
+    int* pair_orig = nullptr;
+    float* moe_part = nullptr;
     bf16 *hg = nullptr, *hu = nullptr, *hh = nullptr, *sfg = nullptr, *sfu = nullptr, *sfh = nullptr;
     if (moe) {
         if (!moe_fused) {
@@ -882,6 +895,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         h_i8 = am.alloc<signed char>((size_t)P * mffn);
         sh = am.alloc<float>((size_t)P);
         routed_f32 = am.alloc<float>((size_t)N * H);
+        if (sparkinfer::deterministic_mode()) {
+            pair_orig = am.alloc<int>((size_t)P);
+            moe_part = am.alloc<float>((size_t)P * H);   // P = N*topk, so topk x routed_f32
+        }
         dw = am.alloc<float>((size_t)N);
         mA_i8 = am.alloc<signed char>((size_t)N * H);          // int8 activation for the grouped GEMMs
         msx = am.alloc<float>((size_t)N);
@@ -1768,7 +1785,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             pf_cu(cudaMemsetAsync(mcounts, 0, E * sizeof(int), st), "moe counts zero");
             kernels::launch_moe_router(mlogits, mids, mweights, mcounts, N, E, topk, 1, st);
             kernels::launch_pfm_bucket_pairs_bm(mids, mweights, mcounts, moffsets, mcursors,
-                                                pair_tok, pair_w, tilemap, d_ntiles, N, E, topk, moe_bm, st);
+                                                pair_tok, pair_w, tilemap, d_ntiles, N, E, topk, moe_bm, st,
+                                                pair_orig);
+            // Deterministic combine: hand the DOWN projection per-pair destinations and a partials
+            // buffer instead of token destinations and the shared accumulator, so its C_SCATTER
+            // epilogue writes one value per address rather than racing top_k of them into one.
+            // Only the down projection -- gate/up pass a_indirect=true and index activations
+            // THROUGH pair_tok, which must stay real token ids.
+            const bool det_moe = moe_part != nullptr && pair_orig != nullptr;
+            const int* down_dst = det_moe ? pair_orig : pair_tok;
+            float* down_out = det_moe ? moe_part : routed_f32;
+            const size_t down_zero_elems = det_moe ? (size_t)P * H : (size_t)N * H;
             kernels::launch_prefill_quantize_rows_i8(hn, mA_i8, msx, N, H, st);
             bool sg_hid = false;  // shared-gate scalar already on stream_k
             if (moe_fused) {
@@ -1780,10 +1807,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                 moffsets, tilemap, d_ntiles, hu, nullptr, mffn, H, max_tiles,
                                                 true, false, st);
                 kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
-                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
-                kernels::launch_pfm_moe_gemm_qk(h_i8, sh, w.down_q, w.down_qtype, pair_tok, pair_w,
-                                                moffsets, tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles,
+                pf_cu(cudaMemsetAsync(down_out, 0, down_zero_elems * sizeof(float), st), "routed zero");
+                kernels::launch_pfm_moe_gemm_qk(h_i8, sh, w.down_q, w.down_qtype, down_dst, pair_w,
+                                                moffsets, tilemap, d_ntiles, nullptr, down_out, H, mffn, max_tiles,
                                                 /*a_indirect=*/false, /*c_scatter=*/true, st);
+                if (det_moe) kernels::launch_pfm_moe_combine_det(moe_part, routed_f32, N, topk, H, st);
             } else if (moe_serial) {
                 // Expert-group L2 path on top of main(#561), tuned for N≈512:
                 //   - D2H counts, skip empty groups, exact-ntm GEMM grids
@@ -2192,19 +2220,20 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                                            true, false, st);
                 }
                 kernels::launch_prefill_swiglu_quant_i8(hg, hu, h_i8, sh, P, mffn, st);
-                pf_cu(cudaMemsetAsync(routed_f32, 0, (size_t)N * H * sizeof(float), st), "routed zero");
+                pf_cu(cudaMemsetAsync(down_out, 0, down_zero_elems * sizeof(float), st), "routed zero");
                 bool qb_d = false;
                 if (rs_d && (moe_qb_mask & 4))
                     qb_d = kernels::launch_pfm_moe_gemm_qi8(
-                        w.down_qtype, h_i8, sh, w.down_q, rs_d, pair_tok, pair_w, moffsets,
-                        tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,
+                        w.down_qtype, h_i8, sh, w.down_q, rs_d, down_dst, pair_w, moffsets,
+                        tilemap, d_ntiles, nullptr, down_out, H, mffn, max_tiles, moe_bm,
                         /*a_indirect=*/false, /*c_scatter=*/true, st);
                 if (!qb_d) {
                     kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q, Wd_i8, swd, E * H, mffn, st);
-                    kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, pair_tok, pair_w, moffsets,
-                                                       tilemap, d_ntiles, nullptr, routed_f32, H, mffn, max_tiles, moe_bm,
+                    kernels::launch_pfm_moe_gemm_i8_bm(h_i8, sh, Wd_i8, swd, down_dst, pair_w, moffsets,
+                                                       tilemap, d_ntiles, nullptr, down_out, H, mffn, max_tiles, moe_bm,
                                                        /*a_indirect=*/false, /*c_scatter=*/true, st);
                 }
+                if (det_moe) kernels::launch_pfm_moe_combine_det(moe_part, routed_f32, N, topk, H, st);
             }
             // Shared expert (Qwen3.6 UD): out scaled by sigmoid(hn . gate_inp) per token.
             bf16* shared_out = nullptr;

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -36,6 +36,8 @@ target_include_directories(sparkinfer_server PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/include
     ${CMAKE_CURRENT_SOURCE_DIR}/third_party
     ${CMAKE_CURRENT_SOURCE_DIR}/../runtime/examples
+    # kernels/deterministic.h -- header-only, for the SPARKINFER_DETERMINISTIC banner line.
+    ${CMAKE_CURRENT_SOURCE_DIR}/../kernels/include
 )
 
 target_link_libraries(sparkinfer_server PRIVATE

--- a/server/README.md
+++ b/server/README.md
@@ -58,6 +58,19 @@ export SPARKINFER_ROOT="$(pwd)"
 | `POST /v1/score` | **Teacher-forced scoring.** Per-token logprobs of a *supplied* continuation, no generation. See below. |
 | `POST /v1/chat/completions` | Chat (JSON `messages`, optional `tools`, `tool_choice`, `stream`, `enable_thinking`). Responses include OpenAI `usage` (`prompt_tokens`, `completion_tokens`, `total_tokens`) plus additive GPU timing fields (`ttft_ms`, `generation_ms`, `decode_tps`) that standard OpenAI SDKs ignore. With `stream_options.include_usage=true`, streaming sends a final chunk with `choices:[]` + `usage` before `[DONE]`. A streaming client that disconnects mid-response cancels generation (checked via `DataSink::is_writable()`) instead of running to completion for nobody. Overload (no queue capacity) returns `429`; a request that exceeds `SPARKINFER_REQUEST_TIMEOUT_S` returns `504`. |
 
+### Streaming logprobs
+
+With `stream: true` and `logprobs: true`, each chunk's `logprobs.content` holds the entries for the
+tokens that produced *that chunk's* text, so concatenating them across the stream yields exactly one
+entry per generated token — the same array the non-streaming response returns, in the same order.
+Reasoning deltas carry their own tokens' entries (a sparkinfer extension: OpenAI has no
+`reasoning_content`), and if generation ends with entries whose tokens produced no text of their
+own, a final `content: ""` delta carries them rather than dropping them.
+
+Two earlier defects here are fixed: entries for tokens routed to `reasoning_content` used to be
+held back and attached to the next *content* chunk (so a chunk reported logprobs for tokens whose
+text it did not contain), and any entries still pending at end of generation were dropped outright.
+
 ### Teacher-forced scoring (`POST /v1/score`)
 
 Given a prompt and a completion you supply, returns the per-token logprob of each completion token

--- a/server/README.md
+++ b/server/README.md
@@ -54,7 +54,105 @@ export SPARKINFER_ROOT="$(pwd)"
 | `GET /v1/capacity` | This worker's live occupancy: `active_requests`, `free_kv_blocks`, `max_queue_depth`, `accepting_requests`. Single-process only — not fleet-wide. |
 | `GET /metrics` | Prometheus text-exposition counters/gauges: request totals by outcome (`ok`/`client_error`/`overloaded`/`timeout`/`cancelled`/`server_error`), prompt/completion token totals, active requests, free KV blocks, uptime. |
 | `POST /v1/tokenize` | Token count for a chat request body |
+| `POST /v1/completions` | Legacy OpenAI text completion (`prompt` string, `echo`, integer `logprobs`). `echo` prepends the prompt TEXT; it does not report per-prompt-token logprobs — use `/v1/score` for that. |
+| `POST /v1/score` | **Teacher-forced scoring.** Per-token logprobs of a *supplied* continuation, no generation. See below. |
 | `POST /v1/chat/completions` | Chat (JSON `messages`, optional `tools`, `tool_choice`, `stream`, `enable_thinking`). Responses include OpenAI `usage` (`prompt_tokens`, `completion_tokens`, `total_tokens`) plus additive GPU timing fields (`ttft_ms`, `generation_ms`, `decode_tps`) that standard OpenAI SDKs ignore. With `stream_options.include_usage=true`, streaming sends a final chunk with `choices:[]` + `usage` before `[DONE]`. A streaming client that disconnects mid-response cancels generation (checked via `DataSink::is_writable()`) instead of running to completion for nobody. Overload (no queue capacity) returns `429`; a request that exceeds `SPARKINFER_REQUEST_TIMEOUT_S` returns `504`. |
+
+### Teacher-forced scoring (`POST /v1/score`)
+
+Given a prompt and a completion you supply, returns the per-token logprob of each completion token
+under the model — without generating anything. Use it to score text the model did not produce:
+another server's answer, a perturbed reference, recorded traffic. Verifying a runtime by comparing
+its *own* greedy output only ever probes one trajectory; scoring probes any of them, so there is no
+fixed answer set to memorise.
+
+```bash
+curl -s http://127.0.0.1:8080/v1/score -H 'Content-Type: application/json' -d '{
+  "model": "qwen3.6-35b-a3b",
+  "messages": [{"role":"user","content":"What is the capital of France?"}],
+  "completion": "The capital of France is Paris.",
+  "top_logprobs": 2
+}'
+```
+
+| field | |
+|---|---|
+| `messages` **or** `prompt` | exactly one. `messages` applies the chat template exactly as `/v1/chat/completions` does; `prompt` is raw text, no template. |
+| `completion` **or** `completion_token_ids` | exactly one; ids win if both are given and bypass tokenisation entirely. |
+| `top_logprobs` | optional, 0–20 alternatives per position. |
+| `enable_thinking` | optional, same meaning as chat completions. |
+
+Response: `tokens`, `token_ids`, `logprobs` (natural log, generation order), `sum_logprob`,
+optional `top_logprobs`, and the same `usage` block every other endpoint returns.
+
+The numbers are **identical** to what `/v1/chat/completions` reports for the same token at the same
+position — same logits, same fp32 log-sum-exp — because scoring runs the same forward pass and the
+same extraction, substituting your token for the sampler's pick. Scoring costs about what
+generating that completion would; it batches, 429s and reports timings like any other request. The
+last completion token costs no forward pass (nothing is predicted after it).
+
+### Determinism (`SPARKINFER_DETERMINISTIC=1`)
+
+By default sparkinfer is **not** run-to-run reproducible: repeat the same greedy request and the
+token sequence can fork and per-token logprobs move by a few tenths of a nat. Set
+`SPARKINFER_DETERMINISTIC=1` for bit-reproducible output.
+
+Measured on an RTX 5090, Qwen3.6-35B-A3B UD-Q4_K_M, 12 prompts × 3 repeats at 48 tokens:
+
+| | default | `SPARKINFER_DETERMINISTIC=1` |
+|---|---|---|
+| bit-identical runs | 1/36 | **36/36** |
+| token-sequence forks | 13/36 | **0/36** |
+| mean logprob drift | 0.44 nats | **0** |
+| max logprob drift | 1.43 nats | **0** |
+
+It is also batch-invariant: a request returns the same bytes whether the server is idle or serving
+concurrent traffic, so a server can be audited while it is in use.
+
+The nondeterminism is not in decode — the decode path has no float atomics at all. It is in batched
+prompt prefill, in two fp32 `atomicAdd` accumulations whose operand order is decided by hardware
+arbitration: the routed MoE down-projection combine, and the split-K reduction in the narrow-N GEMM
+used by the Gated-DeltaNet gate projections. Both differ by only a few ULP, but they feed discrete
+top-k expert *routing* and int8 activation requant at the next layer, so over 40+ layers one
+occasionally flips an expert and moves the logits enough to change the argmax — which is why the
+symptom looks far larger than the cause, and why it is seeded by the prompt pass rather than decode.
+A third, smaller source is the reported logprob's own normalizer, read off a CUB inclusive scan
+whose decoupled look-back folds a timing-dependent number of tile aggregates. See
+`kernels/include/sparkinfer/kernels/deterministic.h`.
+
+Verified bit-identical at every prompt length up to a full 8k context (117 / 782 / 1922 / 2492 /
+3822 / 7622 tokens, 3 repeats each).
+
+Cost, same hardware and model: decode throughput is unchanged (decode is untouched); TTFT is
+**+2% at short prompts and +8% at 2k**. Above ~2048 tokens the mode also turns the GQA-fused int8
+MMA prefill attention off (`SPARKINFER_PREFILL_ATTN_GQA_RQH=1`), which costs some long-context
+prefill throughput — see the warning below for why. Bit-exactness holds for a fixed (build, GPU
+model, batch = 1) triple — a few launch geometries elsewhere are chosen from the device's SM count,
+so two *different* GPU models are not promised to agree with each other even in this mode.
+
+> **Known defect, independent of this mode: GQA-fused int8 prefill attention above ~2048 tokens.**
+> With int8 KV (which the server enables whenever `--ctx` ≥ 4096) and a prompt of 2048 tokens or
+> more, the GQA-fused MMA prefill attention disagrees sharply with the token-loop reference, and
+> not reproducibly. `qwen3_gguf_prefill_check` against that reference, Qwen3.6-35B-A3B on an RTX
+> 5090, mean KL over 16 teacher-forced positions:
+>
+> | prefix | 1500 | 2000 | **2100** | 3000 | 4000 |
+> |---|---|---|---|---|---|
+> | default (fused) | 0.00043 | 0.00022 | **0.18672** | 0.20657 | 0.23978 |
+> | `…GQA_RQH=1` | ~0.0001 | ~0.0001 | ~0.0001 | ~0.0001 | 0.00008 |
+>
+> The cliff is exactly at 2048 and it is not the RQH=3 tier's own `n_tokens >= 2048` gate: RQH=2 is
+> chosen both below and above it and is equally wrong above, so the length dependence is inside
+> `launch_attn_gqa`. Only `RQH=1`, which drops to the per-q-head fallback, is correct there.
+> Reproduce with:
+>
+> ```bash
+> SPARKINFER_KV_INT8=1 ./build/runtime/qwen3_gguf_prefill_check <model.gguf> 4000 16 <4000+ real token ids>
+> ```
+>
+> This is left ON by default rather than silently switched off, because disabling it moves the
+> long-context prefill throughput the eval scores against — that call belongs with whoever owns the
+> kernel. Deterministic mode simply declines to build on top of it.
 
 ### Function tools
 
@@ -155,6 +253,7 @@ Prior requests cannot leak decode context into later ones (KV is freed after eac
 | `SPARKINFER_SERVER_PREFIX_TOKEN_FILE` | — | JSON `[id,...]` warmed via `cache_prefix` each request |
 | `SPARKINFER_SERVER_PREFIX_TOKEN_IDS` | — | Comma-separated token ids (same as above) |
 | `SPARKINFER_PREFILL_BATCHED` | `1` | Batched prefill in `cache_prefix` / cold prompts |
+| `SPARKINFER_DETERMINISTIC` | `0` | `1` = bit-reproducible output (see **Determinism** above). Decode speed unchanged; TTFT +2–8%. |
 | `SPARKINFER_MAX_OUTPUT_TOKENS` | `4096` | Per-request generation cap (independent of context length, which is checked separately against the live `--ctx`) |
 | `SPARKINFER_MAX_QUEUE_DEPTH` | `0` (unlimited) | Admission-time cap on in-flight + queued requests. Beyond it, new requests are rejected as `429` before any KV allocation is attempted, instead of failing later on KV exhaustion. |
 | `SPARKINFER_REQUEST_TIMEOUT_S` | `0` (disabled) | Per-request wall-clock deadline from submission to finish; exceeding it returns `504`. Left disabled by default — a cold 32k-context prefill alone has been measured taking ~90s of TTFT, so an aggressive default would misfire on legitimate long-context requests. |

--- a/server/include/chat_tools.hpp
+++ b/server/include/chat_tools.hpp
@@ -140,6 +140,31 @@ bool parse_request_controls(const std::string& body, RequestControls& out, std::
 bool parse_legacy_completion_request(const std::string& body, std::string& prompt_out,
                                      bool& echo_out, std::string& err);
 
+// POST /v1/score (teacher-forced scoring) request fields. Split out of the handler so the
+// validation has a unit-test seam, exactly like parse_chat_request_json/parse_request_controls.
+//
+// Exactly one of messages/prompt, and exactly one of completion/completion_token_ids, must be
+// supplied; supplying both or neither of a pair is an error rather than a silent precedence rule,
+// because a verifier that thinks it pinned token ids and actually got its text re-tokenised would
+// compare the wrong thing and never know.
+struct ScoreRequest {
+    // True => the caller sent `messages` and the chat template must be applied to it. The messages
+    // themselves are not parsed here: the caller hands the SAME body to the chat tokenizer, which
+    // already owns that parse.
+    bool use_messages = false;
+    std::string prompt;                     // raw prompt text, when use_messages is false
+    bool completion_is_ids = false;         // true => completion_token_ids, false => completion text
+    std::string completion;                 // completion text, when completion_is_ids is false
+    std::vector<int> completion_token_ids;  // when completion_is_ids is true
+    int top_logprobs = 0;                   // 0-20
+};
+
+// vocab, when > 0, rejects any completion_token_ids entry outside [0, vocab). 0 skips that check
+// (the ids are still required to be non-negative integers), so a caller without a vocab handy can
+// still validate everything else.
+bool parse_score_request(const std::string& body, ScoreRequest& out, std::string& err,
+                         int vocab = 0);
+
 // Pure decision function for the DFlash+temperature-sampling incompatibility (kept separate from
 // getenv() so it's unit-testable without a process-wide env var): true => the request should be
 // rejected with 400. temperature<=0 is always accepted regardless of dflash_env_on.

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -85,7 +85,8 @@ public:
     // token, only when logprobs is true AND this callback is non-null -- pass nullptr (not a
     // no-op lambda) when logprobs aren't wanted; see ContinuousBatchEngine::complete_streaming's
     // doc comment for why an always-non-null callback would defeat the "costs nothing extra when
-    // unused" property. Same "first token has no logprobs" v1 gap as above.
+    // unused" property. Fires for EVERY emitted token including the first -- the old "first token
+    // has no logprobs" gap is fixed in ContinuousBatchEngine::step_job()'s PREFILL branch.
     CompletionResult complete_streaming(const std::vector<int>& prompt_ids, int max_new_tokens,
                                         const std::function<bool(int)>& on_token,
                                         float temperature = 0.f, uint64_t seed = 0,
@@ -94,7 +95,17 @@ public:
                                         const std::vector<std::pair<int, float>>& logit_bias = {},
                                         bool logprobs = false, int top_logprobs = 0,
                                         const std::function<void(const TokenLogprob&)>&
-                                            on_token_logprob = nullptr);
+                                            on_token_logprob = nullptr,
+                                        const std::vector<int>& forced_tokens = {});
+
+    // TEACHER-FORCED SCORING (POST /v1/score): non-empty `forced_tokens` turns the call into a
+    // scoring pass instead of a generation. max_new_tokens must equal forced_tokens.size(); the
+    // emitted tokens ARE forced_tokens; each on_token_logprob entry carries that token's logprob
+    // under the distribution at its own position rather than the sampler's pick. Numerically
+    // identical to what /v1/chat/completions reports for the same token at the same position --
+    // same logits, same fp32 logsumexp (Qwen35Model::token_logprob_for). See
+    // ContinuousBatchEngine::Request::forced_tokens for the rest of the semantics.
+
 
     // Live occupancy, for capacity-reporting endpoints. 0/0 if the model isn't loaded yet.
     int active_requests() const;

--- a/server/run.sh
+++ b/server/run.sh
@@ -11,6 +11,11 @@ export TOK_REPO="${TOK_REPO:-Qwen/Qwen3.6-35B-A3B}"
 export MODEL_NAME="${MODEL_NAME:-qwen3.6-35b-a3b}"
 # shellcheck source=../bench/scripts/_common.sh
 source "$ROOT/bench/scripts/_common.sh"
+# Verify against the digest of the model we are actually serving, not _common.sh's Qwen3-30B
+# default (an explicit MODEL_SHA256 in the environment still wins), and fail fast on a mismatch
+# instead of deleting 22 GB and re-downloading -- see resolve_model_sha256/verify_model.
+resolve_model_sha256
+export MODEL_SHA_POLICY="${MODEL_SHA_POLICY:-strict}"
 
 ARCH="$(detect_arch)"
 GGUF="${1:-$MODELS_DIR/$MODEL_FILE}"

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -27,6 +27,9 @@ constexpr int kMaxLogitBiasEntries = 1024;
 // (see ContinuousBatchEngine::submit_locked / max_queue_depth in sparkinfer_server.cpp); this
 // caps how much queue footprint one HTTP request can claim via n-fanout.
 constexpr int kMaxN = 8;
+// OpenAI's documented ceiling for top_logprobs, and the same bound Qwen35Model::last_token_logprobs
+// clamps to on the device side.
+constexpr int kMaxTopLogprobs = 20;
 
 constexpr const char* kImStart = "<|im_start|>";
 constexpr const char* kImEnd = "<|im_end|>";
@@ -1360,6 +1363,96 @@ bool parse_legacy_completion_request(const std::string& body, std::string& promp
         }
     }
     prompt_out = prompt;
+    return true;
+}
+
+bool parse_score_request(const std::string& body, ScoreRequest& out, std::string& err, int vocab) {
+    out = ScoreRequest{};
+    json root;
+    try {
+        root = json::parse(body);
+    } catch (const std::exception&) {
+        err = "invalid JSON body";
+        return false;
+    }
+    if (!root.is_object()) {
+        err = "body must be a JSON object";
+        return false;
+    }
+
+    const bool has_messages = root.contains("messages") && !root["messages"].is_null();
+    const bool has_prompt = root.contains("prompt") && !root["prompt"].is_null();
+    if (has_messages == has_prompt) {
+        err = "provide exactly one of `messages` or `prompt`";
+        return false;
+    }
+    out.use_messages = has_messages;
+    if (has_prompt) {
+        if (!root["prompt"].is_string()) {
+            err = "prompt must be a string";
+            return false;
+        }
+        out.prompt = root["prompt"].get<std::string>();
+        if (out.prompt.empty()) {
+            err = "prompt is empty";
+            return false;
+        }
+    }
+
+    const bool has_ids = root.contains("completion_token_ids") && !root["completion_token_ids"].is_null();
+    const bool has_text = root.contains("completion") && !root["completion"].is_null();
+    if (has_ids == has_text) {
+        err = "provide exactly one of `completion` or `completion_token_ids`";
+        return false;
+    }
+    if (has_ids) {
+        if (!root["completion_token_ids"].is_array()) {
+            err = "completion_token_ids must be an array of integers";
+            return false;
+        }
+        const auto& arr = root["completion_token_ids"];
+        if (arr.empty()) {
+            err = "completion_token_ids is empty (no tokens to score)";
+            return false;
+        }
+        out.completion_token_ids.reserve(arr.size());
+        for (const auto& v : arr) {
+            if (!v.is_number_integer() && !v.is_number_unsigned()) {
+                err = "completion_token_ids must contain only integers";
+                return false;
+            }
+            const long long t = v.get<long long>();
+            if (t < 0 || (vocab > 0 && t >= (long long)vocab)) {
+                err = "completion_token_ids entry out of range: " + std::to_string(t);
+                return false;
+            }
+            out.completion_token_ids.push_back((int)t);
+        }
+        out.completion_is_ids = true;
+    } else {
+        if (!root["completion"].is_string()) {
+            err = "completion must be a string";
+            return false;
+        }
+        out.completion = root["completion"].get<std::string>();
+        if (out.completion.empty()) {
+            err = "completion is empty (no tokens to score)";
+            return false;
+        }
+    }
+
+    if (root.contains("top_logprobs") && !root["top_logprobs"].is_null()) {
+        if (!root["top_logprobs"].is_number_integer()) {
+            err = "top_logprobs must be an integer";
+            return false;
+        }
+        const long long n = root["top_logprobs"].get<long long>();
+        if (n < 0 || n > kMaxTopLogprobs) {
+            err = "top_logprobs must be between 0 and " + std::to_string(kMaxTopLogprobs);
+            return false;
+        }
+        out.top_logprobs = (int)n;
+    }
     return true;
 }
 

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -453,11 +453,13 @@ CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_
                                                  const std::vector<std::pair<int, float>>& logit_bias,
                                                  bool logprobs, int top_logprobs,
                                                  const std::function<void(const TokenLogprob&)>&
-                                                     on_token_logprob) {
+                                                     on_token_logprob,
+                                                 const std::vector<int>& forced_tokens) {
     CompletionResult out;
     sparkinfer::ContinuousBatchEngine::Request req;
     req.prompt = prompt_ids;
     req.max_new_tokens = max_new_tokens;
+    req.forced_tokens = forced_tokens;
     req.temperature = temperature;
     req.seed = seed;
     req.top_k = top_k;
@@ -482,6 +484,18 @@ CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_
             out.error = "max_new_tokens must be positive";
             return out;
         }
+        if (!forced_tokens.empty()) {
+            if ((int)forced_tokens.size() != max_new_tokens) {
+                out.error = "forced_tokens size must equal max_new_tokens";
+                return out;
+            }
+            for (int t : forced_tokens) {
+                if (t < 0 || t >= impl_->cfg.vocab) {
+                    out.error = "forced token id out of range: " + std::to_string(t);
+                    return out;
+                }
+            }
+        }
         if ((int)prompt_ids.size() + max_new_tokens > impl_->cfg.max_seq) {
             out.error = "prompt + max_tokens exceeds context limit (" +
                         std::to_string(impl_->cfg.max_seq) + ")";
@@ -491,7 +505,17 @@ CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_
         }
 
         // Shared prefix KV (session 0) is only safe when no other request is in-flight.
-        const bool prefix_match = !impl_->prefix_tokens.empty() &&
+        //
+        // Never used for a teacher-forced score. Taking the prefix path prefills the shared
+        // prefix on its own (batched prefill at M = prefix_len) and only the suffix per request,
+        // versus one batched pass at M = prompt_len otherwise -- a different tile decomposition,
+        // so a few ULP of difference in the KV the score is computed against. Which branch runs
+        // depends on whether another request happened to be in flight (prefix_exclusive), so with
+        // a prefix configured the same /v1/score call could return marginally different logprobs
+        // depending on server load. A scoring endpoint exists to be compared against another copy
+        // of itself; co-tenancy-dependent numerics defeat that, and the prefill it saves is not
+        // worth it.
+        const bool prefix_match = forced_tokens.empty() && !impl_->prefix_tokens.empty() &&
                                   prompt_starts_with(prompt_ids, impl_->prefix_tokens);
         const bool prefix_exclusive = impl_->batch_engine->num_active() == 0;
         if (prefix_match && prefix_exclusive) {

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -1,5 +1,6 @@
 #include "chat_tokenizer.hpp"
 #include "model_engine.hpp"
+#include "sparkinfer/kernels/deterministic.h"
 
 #include <nlohmann/json.hpp>
 
@@ -521,6 +522,219 @@ int main(int argc, char** argv) {
         body << "{\"tokens\":" << ids.size() << ",\"max_context\":" << engine.max_seq()
              << ",\"max_output_tokens\":" << max_output_tokens() << ",\"model\":\"" << g_model_name << "\"}";
         res.set_content(body.str(), "application/json");
+    });
+
+    // ---- POST /v1/score : teacher-forced scoring -------------------------------------------
+    //
+    // Given a prompt and a SUPPLIED continuation, return the per-token logprob of each
+    // continuation token under the model, without generating anything. The audit primitive an
+    // external verifier needs: it can score any text (another server's answer, a perturbed
+    // reference, mirrored organic traffic) rather than being limited to comparing its own
+    // sampled output, so there is no finite answer set to memorise.
+    //
+    // Why a dedicated endpoint rather than OpenAI's legacy `/v1/completions` with
+    // `echo: true, logprobs: 1, max_tokens: 0`: echo's contract is to report logprobs for the
+    // PROMPT tokens, and this runtime cannot produce those -- batched prefill runs the LM head
+    // only at the final prompt position, so per-prompt-token logits do not exist without a
+    // second, batched LM-head pass over the whole prompt. Rather than half-implement echo and
+    // return a shape that silently omits most of what the field promises, /v1/score states
+    // exactly what it does. (`/v1/completions` keeps its existing echo behaviour: text only.)
+    //
+    // Request:
+    //   {"model": "...",
+    //    "messages": [...],            // chat-templated, exactly as /v1/chat/completions
+    //     OR "prompt": "raw text",     // no chat template applied
+    //    "completion": "text to score",
+    //     OR "completion_token_ids": [1,2,3],   // bypasses tokenisation entirely
+    //    "top_logprobs": 0-20,         // optional, per-position alternatives
+    //    "enable_thinking": bool}      // optional, same meaning as chat completions
+    //
+    // Response: token/token_id/logprob triples in generation order, plus sum_logprob and the
+    // same `usage` block (including the ttft_ms/generation_ms/decode_tps timing fields) every
+    // other endpoint reports.
+    svr.Post("/v1/score", [&engine](const httplib::Request& req, httplib::Response& res) {
+        if (!auth_ok(req)) {
+            res.status = 401;
+            res.set_content("{\"error\":{\"message\":\"unauthorized\"}}", "application/json");
+            return;
+        }
+        auto fail = [&res](int status, const std::string& msg) {
+            res.status = status;
+            res.set_content("{\"error\":{\"message\":\"" + json_escape(msg) + "\"}}",
+                            "application/json");
+        };
+
+        nlohmann::json root;
+        try {
+            root = nlohmann::json::parse(req.body);
+        } catch (const std::exception&) {
+            fail(400, "invalid JSON body");
+            return;
+        }
+        if (!root.is_object()) { fail(400, "body must be a JSON object"); return; }
+
+        const bool has_messages = root.contains("messages") && !root["messages"].is_null();
+        const bool has_prompt = root.contains("prompt") && !root["prompt"].is_null();
+        if (has_messages == has_prompt) {
+            fail(400, "provide exactly one of `messages` or `prompt`");
+            return;
+        }
+
+        // Prompt side.
+        std::vector<int> prompt_ids;
+        if (has_messages) {
+            const bool enable_thinking =
+                sparkinfer_server::parse_enable_thinking(req.body, engine.is_qwen38());
+            std::string err;
+            if (!encode_messages(req.body, prompt_ids, enable_thinking, err)) {
+                fail(400, err);
+                return;
+            }
+        } else {
+            if (!root["prompt"].is_string()) { fail(400, "prompt must be a string"); return; }
+            prompt_ids = g_tokenizer.encode_raw(root["prompt"].get<std::string>());
+        }
+        if (prompt_ids.empty()) { fail(400, "empty prompt"); return; }
+
+        // Completion side. Token ids win when both are present -- they are the unambiguous form,
+        // and a caller that supplies them is explicitly opting out of tokenisation drift.
+        std::vector<int> forced;
+        const bool has_ids = root.contains("completion_token_ids") &&
+                             !root["completion_token_ids"].is_null();
+        const bool has_text = root.contains("completion") && !root["completion"].is_null();
+        if (!has_ids && !has_text) {
+            fail(400, "provide `completion` (string) or `completion_token_ids` (array of ints)");
+            return;
+        }
+        if (has_ids) {
+            if (!root["completion_token_ids"].is_array()) {
+                fail(400, "completion_token_ids must be an array of integers");
+                return;
+            }
+            for (const auto& v : root["completion_token_ids"]) {
+                if (!v.is_number_integer() && !v.is_number_unsigned()) {
+                    fail(400, "completion_token_ids must contain only integers");
+                    return;
+                }
+                const long long t = v.get<long long>();
+                if (t < 0 || t >= engine.vocab()) {
+                    fail(400, "completion_token_ids entry out of range: " + std::to_string(t));
+                    return;
+                }
+                forced.push_back((int)t);
+            }
+        } else {
+            if (!root["completion"].is_string()) { fail(400, "completion must be a string"); return; }
+            forced = g_tokenizer.encode_raw(root["completion"].get<std::string>());
+        }
+        if (forced.empty()) { fail(400, "completion is empty (no tokens to score)"); return; }
+
+        int top_logprobs = 0;
+        if (root.contains("top_logprobs") && !root["top_logprobs"].is_null()) {
+            if (!root["top_logprobs"].is_number_integer()) {
+                fail(400, "top_logprobs must be an integer");
+                return;
+            }
+            const long long n = root["top_logprobs"].get<long long>();
+            if (n < 0 || n > 20) { fail(400, "top_logprobs must be between 0 and 20"); return; }
+            top_logprobs = (int)n;
+        }
+
+        // Bounded by the same per-request output cap generation uses, and by the live context.
+        if ((int)forced.size() > max_output_tokens()) {
+            fail(400, "completion has " + std::to_string(forced.size()) +
+                          " tokens, exceeds max_output_tokens=" + std::to_string(max_output_tokens()));
+            return;
+        }
+        if ((int)prompt_ids.size() + (int)forced.size() > engine.max_seq()) {
+            fail(400, "prompt + completion = " +
+                          std::to_string(prompt_ids.size() + forced.size()) +
+                          " tokens exceeds server ctx=" + std::to_string(engine.max_seq()));
+            return;
+        }
+
+        std::vector<sparkinfer_server::TokenLogprob> entries;
+        entries.reserve(forced.size());
+        auto outcome = engine.complete_streaming(
+            prompt_ids, (int)forced.size(), [](int) { return true; },
+            /*temperature=*/0.f, /*seed=*/0, /*top_k=*/0, /*top_p=*/1.0f,
+            /*presence_penalty=*/0.f, /*frequency_penalty=*/0.f, /*logit_bias=*/{},
+            /*logprobs=*/true, top_logprobs,
+            [&entries](const sparkinfer_server::TokenLogprob& tl) { entries.push_back(tl); },
+            forced);
+
+        if (!outcome.error.empty()) {
+            g_requests_total++;
+            if (outcome.overloaded) {
+                g_requests_overloaded++;
+                fail(429, outcome.error);
+            } else if (outcome.alloc_failed) {
+                g_requests_server_error++;
+                fail(503, outcome.error);
+            } else if (outcome.timed_out) {
+                g_requests_timeout++;
+                fail(504, outcome.error);
+            } else {
+                g_requests_client_error++;
+                fail(400, outcome.error);
+            }
+            return;
+        }
+
+        // The engine emits exactly the forced tokens, so a length mismatch here would mean the
+        // forced path silently diverged -- report it rather than returning a misaligned array
+        // that a verifier would compare position-by-position against its own reference.
+        if (outcome.tokens.size() != forced.size() || entries.size() != forced.size()) {
+            g_requests_total++;
+            g_requests_server_error++;
+            fail(500, "scoring returned " + std::to_string(entries.size()) + " logprobs for " +
+                          std::to_string(forced.size()) + " tokens");
+            return;
+        }
+
+        nlohmann::json tokens = nlohmann::json::array();
+        nlohmann::json token_ids = nlohmann::json::array();
+        nlohmann::json logprobs = nlohmann::json::array();
+        nlohmann::json alts = nlohmann::json::array();
+        double sum_logprob = 0.0;
+        for (const auto& e : entries) {
+            const auto piece = g_tokenizer.id_to_raw_piece(e.token_id);
+            tokens.push_back(piece.display);
+            token_ids.push_back(e.token_id);
+            logprobs.push_back(e.logprob);
+            sum_logprob += (double)e.logprob;
+            if (top_logprobs > 0) {
+                nlohmann::json per = nlohmann::json::array();
+                const int n = std::min((int)e.top_alternatives.size(), top_logprobs);
+                for (int i = 0; i < n; i++)
+                    per.push_back(token_logprob_entry_json(e.top_alternatives[i].first,
+                                                           e.top_alternatives[i].second));
+                alts.push_back(per);
+            }
+        }
+
+        nlohmann::json usage = {{"prompt_tokens", (int)prompt_ids.size()},
+                                {"completion_tokens", (int)forced.size()},
+                                {"total_tokens", (int)(prompt_ids.size() + forced.size())}};
+        if (outcome.ttft_ms >= 0) usage["ttft_ms"] = outcome.ttft_ms;
+        if (outcome.generation_ms >= 0) usage["generation_ms"] = outcome.generation_ms;
+        if (outcome.decode_tps >= 0) usage["decode_tps"] = outcome.decode_tps;
+
+        nlohmann::json body = {{"id", random_id()},
+                               {"object", "score"},
+                               {"model", g_model_name},
+                               {"tokens", tokens},
+                               {"token_ids", token_ids},
+                               {"logprobs", logprobs},
+                               {"sum_logprob", sum_logprob},
+                               {"usage", usage}};
+        if (top_logprobs > 0) body["top_logprobs"] = alts;
+
+        g_requests_total++;
+        g_requests_ok++;
+        g_prompt_tokens_total += prompt_ids.size();
+        g_completion_tokens_total += forced.size();
+        res.set_content(body.dump(), "application/json");
     });
 
     svr.Post("/v1/chat/completions",
@@ -1951,6 +2165,22 @@ int main(int argc, char** argv) {
     // gap between "signal received" and "svr.stop() called" (at most one poll interval) only
     // means a few new requests might land right before shutdown starts, not that the drain window
     // is unbounded.
+    // Bind BEFORE the shutdown watcher exists. listen() returning early is ambiguous -- it means
+    // either "we were asked to stop" or "we could never start" -- and the old code treated both as
+    // a shutdown: a port clash printed "shutdown signal received, draining in-flight requests...",
+    // sat through the full 30s grace period, and only then said what had actually gone wrong.
+    // Under a supervisor that restart-loops, that reads as a server that starts and mysteriously
+    // stops. Splitting the bind out reports the real cause immediately, on the first line.
+    if (!svr.bind_to_port(host.c_str(), port)) {
+        fprintf(stderr,
+                "[sparkinfer-server] FATAL: cannot bind %s:%d (in use, or not permitted).\n"
+                "  Another process is probably already listening there -- check with:\n"
+                "    ss -tlnp | grep :%d\n"
+                "  Then free it or start with a different --port / PORT=<n>.\n",
+                host.c_str(), port, port);
+        return 1;
+    }
+
     std::thread shutdown_watcher([&svr] {
         while (!g_shutdown_requested.load()) std::this_thread::sleep_for(std::chrono::milliseconds(100));
         fprintf(stderr, "[sparkinfer-server] shutdown signal received, draining in-flight requests...\n");
@@ -1981,16 +2211,15 @@ int main(int argc, char** argv) {
             "  GET  /metrics\n"
             "  POST /v1/tokenize\n"
             "  POST /v1/chat/completions\n"
-            "  read_timeout=%lds write_timeout=%lds max_output_tokens=%d max_queue_depth=%s\n",
+            "  POST /v1/completions\n"
+            "  POST /v1/score\n"
+            "  read_timeout=%lds write_timeout=%lds max_output_tokens=%d max_queue_depth=%s%s\n",
             host.c_str(), port, read_timeout_s, write_timeout_s, max_output_tokens(),
-            queue_depth_label.c_str());
+            queue_depth_label.c_str(),
+            sparkinfer::deterministic_mode() ? "  DETERMINISTIC=1 (bit-reproducible)" : "");
 
-    const bool bound = svr.listen(host.c_str(), port);
+    svr.listen_after_bind();   // bind already succeeded above; this only returns on stop()
     g_shutdown_requested = true;  // unblock the watcher thread if listen() returned on its own
     shutdown_watcher.join();
-    if (!bound) {
-        fprintf(stderr, "[sparkinfer-server] failed to bind %s:%d\n", host.c_str(), port);
-        return 1;
-    }
     return 0;
 }

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -170,6 +170,23 @@ bool write_stream_role(GuardedSink& gs, const std::string& cid, long long create
     return write_sse_json(gs, chunk);
 }
 
+// Emits a delta carrying ONLY logprobs (empty content). write_stream_delta drops empty pieces, so
+// without this any entries still pending when generation ends -- the last tokens produced no text
+// of their own, e.g. a stop-sequence holdback or a trailing partial UTF-8 sequence -- would be
+// silently dropped, and the concatenated stream would carry fewer entries than completion_tokens.
+// A content delta with an empty string is well-formed and OpenAI clients tolerate it.
+bool write_stream_logprobs_only(GuardedSink& gs, const std::string& cid, long long created,
+                                int choice_index, const nlohmann::json& logprobs,
+                                const char* field = "content",
+                                const char* object = "chat.completion.chunk") {
+    auto chunk = stream_chunk_base(cid, created, object);
+    chunk["choices"] = nlohmann::json::array({{{"index", choice_index},
+                                                {"delta", {{field, ""}}},
+                                                {"finish_reason", nullptr},
+                                                {"logprobs", logprobs}}});
+    return write_sse_json(gs, chunk);
+}
+
 bool write_stream_delta(GuardedSink& gs, const std::string& cid, long long created, const std::string& field,
                         const std::string& piece, int choice_index, const nlohmann::json& logprobs = nullptr,
                         const char* object = "chat.completion.chunk") {
@@ -564,25 +581,17 @@ int main(int argc, char** argv) {
                             "application/json");
         };
 
-        nlohmann::json root;
-        try {
-            root = nlohmann::json::parse(req.body);
-        } catch (const std::exception&) {
-            fail(400, "invalid JSON body");
-            return;
-        }
-        if (!root.is_object()) { fail(400, "body must be a JSON object"); return; }
-
-        const bool has_messages = root.contains("messages") && !root["messages"].is_null();
-        const bool has_prompt = root.contains("prompt") && !root["prompt"].is_null();
-        if (has_messages == has_prompt) {
-            fail(400, "provide exactly one of `messages` or `prompt`");
+        sparkinfer_server::ScoreRequest sreq;
+        std::string perr;
+        if (!sparkinfer_server::parse_score_request(req.body, sreq, perr, engine.vocab())) {
+            fail(400, perr);
             return;
         }
 
-        // Prompt side.
+        // Prompt side. The messages parse itself belongs to the chat tokenizer, which already
+        // owns it -- parse_score_request only decided WHICH form was supplied.
         std::vector<int> prompt_ids;
-        if (has_messages) {
+        if (sreq.use_messages) {
             const bool enable_thinking =
                 sparkinfer_server::parse_enable_thinking(req.body, engine.is_qwen38());
             std::string err;
@@ -591,54 +600,14 @@ int main(int argc, char** argv) {
                 return;
             }
         } else {
-            if (!root["prompt"].is_string()) { fail(400, "prompt must be a string"); return; }
-            prompt_ids = g_tokenizer.encode_raw(root["prompt"].get<std::string>());
+            prompt_ids = g_tokenizer.encode_raw(sreq.prompt);
         }
-        if (prompt_ids.empty()) { fail(400, "empty prompt"); return; }
+        if (prompt_ids.empty()) { fail(400, "prompt encoded to zero tokens"); return; }
 
-        // Completion side. Token ids win when both are present -- they are the unambiguous form,
-        // and a caller that supplies them is explicitly opting out of tokenisation drift.
-        std::vector<int> forced;
-        const bool has_ids = root.contains("completion_token_ids") &&
-                             !root["completion_token_ids"].is_null();
-        const bool has_text = root.contains("completion") && !root["completion"].is_null();
-        if (!has_ids && !has_text) {
-            fail(400, "provide `completion` (string) or `completion_token_ids` (array of ints)");
-            return;
-        }
-        if (has_ids) {
-            if (!root["completion_token_ids"].is_array()) {
-                fail(400, "completion_token_ids must be an array of integers");
-                return;
-            }
-            for (const auto& v : root["completion_token_ids"]) {
-                if (!v.is_number_integer() && !v.is_number_unsigned()) {
-                    fail(400, "completion_token_ids must contain only integers");
-                    return;
-                }
-                const long long t = v.get<long long>();
-                if (t < 0 || t >= engine.vocab()) {
-                    fail(400, "completion_token_ids entry out of range: " + std::to_string(t));
-                    return;
-                }
-                forced.push_back((int)t);
-            }
-        } else {
-            if (!root["completion"].is_string()) { fail(400, "completion must be a string"); return; }
-            forced = g_tokenizer.encode_raw(root["completion"].get<std::string>());
-        }
-        if (forced.empty()) { fail(400, "completion is empty (no tokens to score)"); return; }
-
-        int top_logprobs = 0;
-        if (root.contains("top_logprobs") && !root["top_logprobs"].is_null()) {
-            if (!root["top_logprobs"].is_number_integer()) {
-                fail(400, "top_logprobs must be an integer");
-                return;
-            }
-            const long long n = root["top_logprobs"].get<long long>();
-            if (n < 0 || n > 20) { fail(400, "top_logprobs must be between 0 and 20"); return; }
-            top_logprobs = (int)n;
-        }
+        std::vector<int> forced = sreq.completion_is_ids ? sreq.completion_token_ids
+                                                         : g_tokenizer.encode_raw(sreq.completion);
+        if (forced.empty()) { fail(400, "completion encoded to zero tokens"); return; }
+        const int top_logprobs = sreq.top_logprobs;
 
         // Bounded by the same per-request output cap generation uses, and by the live context.
         if ((int)forced.size() > max_output_tokens()) {
@@ -1050,6 +1019,17 @@ int main(int argc, char** argv) {
                                  auto on_tok_logprob = [&](const sparkinfer_server::TokenLogprob& tl) {
                                      pending_logprobs.push_back(tl);
                                  };
+                                 // Hand off every entry accumulated since the last delta and clear
+                                 // the buffer, so no entry is emitted twice or left behind. Returns
+                                 // null (not an empty array) when there is nothing to report or the
+                                 // request never asked -- which is what `"logprobs": null` means.
+                                 auto take_pending = [&]() -> nlohmann::json {
+                                     if (!want_logprobs || pending_logprobs.empty()) return nullptr;
+                                     nlohmann::json lp{{"content",
+                                         build_logprobs_content_json(pending_logprobs, top_logprobs)}};
+                                     pending_logprobs.clear();
+                                     return lp;
+                                 };
                                  auto on_tok = [&](int tid) -> bool {
                                      // Tool-capable responses are intentionally buffered until the
                                      // native Qwen XML is complete and schema-valid.
@@ -1073,34 +1053,31 @@ int main(int argc, char** argv) {
                                              const auto delta = splitter.feed(safe);
                                              if (!delta.reasoning_content.empty())
                                                  write_stream_delta(gs, cid, created, "reasoning_content",
-                                                                    delta.reasoning_content, ci);
-                                             if (!delta.content.empty()) {
-                                                 nlohmann::json lp = nullptr;
-                                                 if (want_logprobs) {
-                                                     lp = nlohmann::json{{"content",
-                                                         build_logprobs_content_json(pending_logprobs, top_logprobs)}};
-                                                     pending_logprobs.clear();
-                                                 }
-                                                 write_stream_delta(gs, cid, created, "content", delta.content, ci, lp);
-                                             }
+                                                                    delta.reasoning_content, ci, take_pending());
+                                             if (!delta.content.empty())
+                                                 write_stream_delta(gs, cid, created, "content", delta.content,
+                                                                    ci, take_pending());
                                          }
                                          stopped_by_sequence = true;
                                          return false;
                                      }
                                      const auto delta = splitter.feed(safe);
                                      bool ok = true;
+                                     // take_pending() empties the buffer, so whichever delta is
+                                     // written first carries the entries for the tokens that
+                                     // produced it. Reasoning deltas take them too: a token routed
+                                     // to reasoning_content used to leave its entry behind to be
+                                     // misattributed to the next CONTENT chunk, which then reported
+                                     // logprobs for tokens whose text it does not contain.
+                                     // Concatenating every chunk's entries now yields exactly one
+                                     // per generated token, matching the non-streaming response.
                                      if (!delta.reasoning_content.empty())
                                          ok = write_stream_delta(gs, cid, created, "reasoning_content",
-                                                                  delta.reasoning_content, ci) && ok;
-                                     if (!delta.content.empty()) {
-                                         nlohmann::json lp = nullptr;
-                                         if (want_logprobs) {
-                                             lp = nlohmann::json{{"content",
-                                                 build_logprobs_content_json(pending_logprobs, top_logprobs)}};
-                                             pending_logprobs.clear();
-                                         }
-                                         ok = write_stream_delta(gs, cid, created, "content", delta.content, ci, lp) && ok;
-                                     }
+                                                                  delta.reasoning_content, ci,
+                                                                  take_pending()) && ok;
+                                     if (!delta.content.empty())
+                                         ok = write_stream_delta(gs, cid, created, "content", delta.content,
+                                                                 ci, take_pending()) && ok;
                                      return ok && sink.is_writable();
                                  };
                                  const std::function<void(const sparkinfer_server::TokenLogprob&)> maybe_on_tok_logprob =
@@ -1167,10 +1144,24 @@ int main(int argc, char** argv) {
                                      // never vetted -- generation ends at the match point regardless.
                                      sparkinfer_server::ThinkingStreamSplitter::Delta flush;
                                      splitter.finish(flush);
-                                     write_stream_delta(gs, cid, created, "reasoning_content",
-                                                        flush.reasoning_content, ci);
-                                     write_stream_delta(gs, cid, created, "content", flush.content, ci);
+                                     // Guarded on non-empty exactly like the on_tok path: arguments
+                                     // are evaluated before the call, and write_stream_delta drops
+                                     // empty pieces, so an unguarded take_pending() here would
+                                     // consume the entries and then throw them away with the
+                                     // delta -- and the safety net below could not see them,
+                                     // because the buffer would already be clear.
+                                     if (!flush.reasoning_content.empty())
+                                         write_stream_delta(gs, cid, created, "reasoning_content",
+                                                            flush.reasoning_content, ci, take_pending());
+                                     if (!flush.content.empty())
+                                         write_stream_delta(gs, cid, created, "content", flush.content,
+                                                            ci, take_pending());
                                  }
+                                 // Neither flush piece may have had text to hang them on. Emit
+                                 // them rather than lose them.
+                                 if (want_logprobs && !pending_logprobs.empty())
+                                     write_stream_logprobs_only(gs, cid, created, ci, take_pending(),
+                                                                "content");
                                  out->ttft_ms = outcome.ttft_ms;
                                  out->generation_ms = outcome.generation_ms;
                                  out->decode_tps = outcome.decode_tps;
@@ -1876,6 +1867,19 @@ int main(int argc, char** argv) {
                                                                     : BranchOutcome::Fail::server_error;
                                      out->fail_message = outcome.error;
                                      return;
+                                 }
+                                 // Entries whose tokens decoded to no text of their own (a
+                                 // stop-sequence holdback, a partial UTF-8 sequence) are still
+                                 // pending here and would otherwise be dropped, leaving the
+                                 // concatenated stream short of usage.completion_tokens -- the
+                                 // same defect the chat path had at its tail flush.
+                                 if (logprobs && !pending_logprobs.empty()) {
+                                     write_stream_logprobs_only(
+                                         gs, cid, created, ci,
+                                         build_legacy_logprobs_json(pending_logprobs, top_logprobs,
+                                                                    offset_so_far),
+                                         "text", "text_completion");
+                                     pending_logprobs.clear();
                                  }
                                  out->ttft_ms = outcome.ttft_ms;
                                  out->generation_ms = outcome.generation_ms;

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -24,6 +24,8 @@ using sparkinfer_server::parse_chat_request_json;
 using sparkinfer_server::parse_legacy_completion_request;
 using sparkinfer_server::parse_qwen36_tool_output;
 using sparkinfer_server::parse_request_controls;
+using sparkinfer_server::parse_score_request;
+using sparkinfer_server::ScoreRequest;
 using sparkinfer_server::should_reject_dflash_logit_bias;
 using sparkinfer_server::should_reject_dflash_penalty;
 using sparkinfer_server::should_reject_dflash_temperature;
@@ -1417,6 +1419,96 @@ bool test_unsafe_protocol_names() {
 
 } // namespace
 
+
+// ---- POST /v1/score (teacher-forced scoring) -------------------------------------------------
+bool test_parse_score_request() {
+    ScoreRequest r;
+    std::string err;
+
+    // messages + completion text: the ordinary audit shape.
+    CHECK(parse_score_request(
+        R"({"model":"m","messages":[{"role":"user","content":"hi"}],"completion":"there"})", r, err));
+    CHECK(r.use_messages);
+    CHECK(r.prompt.empty());
+    CHECK(!r.completion_is_ids);
+    CHECK(r.completion == "there");
+    CHECK(r.top_logprobs == 0);
+
+    // prompt + token ids: the drift-free shape a verifier should prefer.
+    r = ScoreRequest{};
+    CHECK(parse_score_request(R"({"prompt":"raw text","completion_token_ids":[1,2,3]})", r, err));
+    CHECK(!r.use_messages);
+    CHECK(r.prompt == "raw text");
+    CHECK(r.completion_is_ids);
+    CHECK(r.completion_token_ids == std::vector<int>({1, 2, 3}));
+
+    // top_logprobs bounds.
+    r = ScoreRequest{};
+    CHECK(parse_score_request(R"({"prompt":"p","completion":"c","top_logprobs":20})", r, err));
+    CHECK(r.top_logprobs == 20);
+    CHECK(parse_score_request(R"({"prompt":"p","completion":"c","top_logprobs":0})", r, err));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion":"c","top_logprobs":21})", r, err));
+    CHECK(contains(err, "between 0 and 20"));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion":"c","top_logprobs":-1})", r, err));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion":"c","top_logprobs":1.5})", r, err));
+    CHECK(contains(err, "must be an integer"));
+
+    // Exactly one prompt form. Both and neither are errors, NOT a silent precedence rule: a
+    // verifier that believes it pinned one and silently got the other compares the wrong thing.
+    CHECK(!parse_score_request(
+        R"({"messages":[{"role":"user","content":"hi"}],"prompt":"p","completion":"c"})", r, err));
+    CHECK(contains(err, "exactly one of `messages` or `prompt`"));
+    CHECK(!parse_score_request(R"({"completion":"c"})", r, err));
+    CHECK(contains(err, "exactly one of `messages` or `prompt`"));
+
+    // Exactly one completion form, same reasoning.
+    CHECK(!parse_score_request(R"({"prompt":"p","completion":"c","completion_token_ids":[1]})", r, err));
+    CHECK(contains(err, "exactly one of `completion` or `completion_token_ids`"));
+    CHECK(!parse_score_request(R"({"prompt":"p"})", r, err));
+    CHECK(contains(err, "exactly one of `completion` or `completion_token_ids`"));
+
+    // Nothing to score is an error, not a zero-length success -- a caller that gets back an empty
+    // logprobs array would read it as "scored, and it agreed".
+    CHECK(!parse_score_request(R"({"prompt":"p","completion":""})", r, err));
+    CHECK(contains(err, "no tokens to score"));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion_token_ids":[]})", r, err));
+    CHECK(contains(err, "no tokens to score"));
+    CHECK(!parse_score_request(R"({"prompt":"","completion":"c"})", r, err));
+    CHECK(contains(err, "prompt is empty"));
+
+    // Token id typing and range. vocab=0 skips only the UPPER bound; negatives are always rejected.
+    CHECK(!parse_score_request(R"({"prompt":"p","completion_token_ids":[1,"2"]})", r, err));
+    CHECK(contains(err, "only integers"));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion_token_ids":[1,-3]})", r, err));
+    CHECK(contains(err, "out of range"));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion_token_ids":[1,999]})", r, err, /*vocab=*/100));
+    CHECK(contains(err, "out of range"));
+    CHECK(parse_score_request(R"({"prompt":"p","completion_token_ids":[1,99]})", r, err, /*vocab=*/100));
+    CHECK(parse_score_request(R"({"prompt":"p","completion_token_ids":[999999]})", r, err, /*vocab=*/0));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion_token_ids":{"a":1}})", r, err));
+    CHECK(contains(err, "array of integers"));
+
+    // Wrong scalar types.
+    CHECK(!parse_score_request(R"({"prompt":123,"completion":"c"})", r, err));
+    CHECK(contains(err, "prompt must be a string"));
+    CHECK(!parse_score_request(R"({"prompt":"p","completion":123})", r, err));
+    CHECK(contains(err, "completion must be a string"));
+
+    // Malformed bodies.
+    CHECK(!parse_score_request("not json", r, err));
+    CHECK(contains(err, "invalid JSON"));
+    CHECK(!parse_score_request("[1,2,3]", r, err));
+    CHECK(contains(err, "must be a JSON object"));
+
+    // A completion that happens to contain an end marker is still just text to score -- nothing
+    // here may treat it as a stop condition (the engine's forced path suppresses EOS for the same
+    // reason: the caller is owed a logprob for every token they asked about).
+    r = ScoreRequest{};
+    CHECK(parse_score_request(R"({"prompt":"p","completion":"a<|im_end|>b"})", r, err));
+    CHECK(r.completion == "a<|im_end|>b");
+    return true;
+}
+
 int main() {
     if (!test_hermes_request_and_template()) return 1;
     if (!test_tool_history_round_trip()) return 1;
@@ -1461,6 +1553,7 @@ int main() {
     if (!test_should_reject_dflash_logit_bias()) return 1;
     if (!test_request_controls_n_validation()) return 1;
     if (!test_parse_legacy_completion_request()) return 1;
+    if (!test_parse_score_request()) return 1;
     if (!test_request_controls_legacy_logprobs_validation()) return 1;
     if (!test_malformed_and_unknown_calls()) return 1;
     if (!test_invalid_requests_and_duplicate_tools()) return 1;


### PR DESCRIPTION
## Summary

Four things the Gittensor serving integration ([entrius/gittensor#1691](https://github.com/entrius/gittensor/pull/1691)) needs from this runtime, plus a free accuracy win found while verifying them. Everything below was measured on a rented **RTX 5090** against Qwen3.6-35B-A3B UD-Q4_K_M.

> **Not a speed submission.** There is no decode or prefill gain to claim, so the *Proof of speedup* box is deliberately left unticked — this should not be routed to the on-device speed eval. The relevant performance claim here is the opposite one: **decode throughput is unchanged**, evidence below.

| | |
|---|---|
| `SPARKINFER_DETERMINISTIC=1` | bit-reproducible greedy decode (1/36 → **36/36** identical runs) |
| `POST /v1/score` | teacher-forced scoring over HTTP |
| first-token logprob | `logprobs.content` was `completion_tokens − 1` long |
| `server/run.sh` model pin | verified Qwen3.6 weights against the Qwen3-30B digest → infinite re-download loop |
| Q4_K requant refinement | **+0.7 to +1.1 pts top-1 vs llama.cpp, at zero decode cost** |

---

## 1. Q4_K requant refinement — accuracy, free

The load-time attention/GDN requantizer (`proj_q4k_lloyd.cu`) fits each group's `(scale, offset)` by Lloyd-max in **continuous** space, then rounds both onto the shared 6-bit super-block grid. Nothing in the fit accounts for that rounding, so the continuous optimum's *nearest* grid point is frequently not the *best* one — the two errors interact, and the 4-bit codes are re-fit against whichever pair is chosen anyway. It is worst where a group's scale is small relative to the super-block max (`d` is pinned to that max): a group at `topS/13` lands on a grid whose relative step there is ~4%.

`pql_refine_group` now evaluates the 3×3 neighbourhood of the rounded `(s6, m6)` against the **real read-back error** (`y = d·s6·l − dmin·m6`, codes re-fit, same importance weight) and keeps the best.

**4 independent held-out eval seeds, teacher-forced against llama.cpp on the same token sequence:**

| config | top-1 mean | KL mean | KL worst | decode@128 |
|---|--:|--:|--:|--:|
| default requant (main) | 0.8997 | 0.0655 | 0.0970 | 491.5 |
| **default + refine (this PR)** | **0.9066** | **0.0602** | **0.0664** | **491.5** |
| `attn_q,attn_output` only | 0.9192 | 0.0414 | 0.0669 | 428.3 |
| `attn_q,attn_output` + refine | 0.9302 | 0.0315 | 0.0347 | 428.3 |
| requant off | 0.9358 | 0.0282 | 0.0306 | 415.4 |

The **worst-case KL** column is the useful one: refinement takes the default's worst seed from 0.0970 → 0.0664, which is what fixing scale-quantization outliers should look like.

**Why it is free:** the output is the same Q4_K byte layout read by the same `si_vec_dot_q4_K`, so weight traffic and throughput are bit-for-bit unchanged. `SPARKINFER_PROJ_REQUANT_REFINE=0` restores round-to-nearest, so both arms come out of one binary.

**Decode tok/s (`qwen3_gguf_bench`, n=128, 3 reps, median) — the no-regression evidence:**

| | decode@128 | decode@4k |
|---|--:|--:|
| before (main) | 491.5 | 470.1 |
| after (this PR) | 491.5 | 470.1 |

Load time is also unchanged (8.0s vs 8.1s end-to-end).

> Note on the gate: `accuracy.sh`'s default `seed=fixed` prompt is on the pessimistic end — it reports top-1 **0.860** for the *current default* where the 4-seed mean is **0.8997**. Per-seed spread is ~±3 points, so a single manual run is a noisy sample. The eval bot draws a fresh `SPARKINFER_EVAL_SEED` per run.

## 2. Deterministic mode

Repeating an identical batch-1 greedy request forked the token sequence and moved per-token logprobs by tenths of a nat. `SPARKINFER_DETERMINISTIC=1` fixes it:

| 12 prompts × 3 repeats @ 48 tok | default | `DETERMINISTIC=1` |
|---|--:|--:|
| bit-identical runs | 1/36 | **36/36** |
| token-sequence forks | 13/36 | **0/36** |
| mean logprob drift | 0.44 nats | **0** |

Also **batch-invariant** (16/16 identical under 6 concurrent background requests) and verified bit-identical at 117 / 782 / 1922 / 2492 / 3822 / 7622 prompt tokens.

**The cause was not decode** — the decode path has no float atomics at all. It was batched *prompt* prefill, in two fp32 `atomicAdd` accumulations whose operand order is hardware-arbitrated (the routed MoE down-projection combine, and the split-K in the narrow-N GDN gate GEMM), plus the reported logprob's own normalizer, read off a CUB `DeviceScan` whose decoupled look-back folds a timing-dependent number of tile aggregates. Each differs by a few ULP, but they feed discrete top-k expert *routing* and int8 activation requant, so over 40+ layers one occasionally flips an expert and moves the argmax.

The MoE fix needs **no GEMM kernel change**: hand the down projection `pair_orig` instead of `pair_tok` and a partials buffer instead of the shared accumulator, and its existing epilogue writes each pair to its own address, so the atomicAdd becomes uncontended. A fixed-order kernel then folds the partials.

Cost: decode unchanged, TTFT +2% short / +8% at 2k. No accuracy loss — `qwen3_gguf_prefill_check` gives the same seed token and TOP1 24/24 in both modes, with *lower* KL against the token-loop reference (0.00112 vs 0.00176).

## 3. `POST /v1/score` — teacher-forced scoring

Per-token logprobs of a *supplied* continuation, no generation, so a verifier can score any text rather than only its own greedy output. Routed through the ordinary `Job`/`step_job` machinery via `Request::forced_tokens`, so it inherits continuous batching, right-sized KV, 429 and the request deadline — and shares one set of numerics with generation (a scored token reports exactly what `/v1/chat/completions` reports for that token at that position, verified identical).

Deliberately **not** spelled as OpenAI's `/v1/completions` `echo`+`logprobs`: echo's contract is to report logprobs for *prompt* tokens, which batched prefill cannot produce (it runs the LM head only at the final prompt position).

## 4. First-token logprob, and `run.sh`'s model pin

The response's first token comes from prefill's argmax seed, whose LM-head tail stopped before the sort/scan `last_token_logprobs()` reads — so `logprobs.content` came back one short and silently misaligned any consumer zipping it with the output. Entries 2..N were always correct, so the off-by-one hit *every* token, not just the first.

`server/run.sh` serves Qwen3.6 but `verify_model` read `MODEL_SHA256`, whose `reference.lock` default is the **Qwen3-30B guard model's** digest — so a correct 22 GB download mismatched, was deleted, re-fetched and failed again, unbounded under a restarting supervisor. The HF upload was never stale (`ac0e2c11…` still matches `QWEN36_MODEL_SHA256`). `resolve_model_sha256()` now picks the digest belonging to `MODEL_FILE`, and `MODEL_SHA_POLICY=strict` reports a mismatch instead of deleting 22 GB.

## Also fixed

- **Streaming logprobs**: entries for tokens routed to `reasoning_content` were held back and attached to the next *content* chunk; anything still pending at end of generation was dropped. A request whose output was entirely reasoning returned **zero** entries. Fixed in the chat and legacy paths — concatenating every chunk now reproduces the non-streaming array exactly.
- **`ensure_tokenizer` deleted before downloading**, so one transient `curl: (56)` left the models dir with no tokenizer at all. Hit for real during this work. Now stages and only moves on success.
- **A port clash** printed `shutdown signal received`, drained 30s, and only then mentioned binding. Now fails immediately with the cause. `/v1/completions` and `/v1/score` were missing from the startup banner.

## Two defects found and NOT fixed here

1. **GQA-fused int8 prefill attention above ~2048 tokens.** With int8 KV (which the server enables whenever `--ctx ≥ 4096`) the fused kernel disagrees sharply with the token-loop reference, nondeterministically — mean KL 0.00022 at 2000 tokens vs **0.18672** at 2100, against ~0.0001 for the per-q-head fallback at both. The cliff is exactly at 2048 but is *not* the RQH=3 tier's own `n_tokens >= 2048` gate (RQH=2 is chosen either side of it and is equally wrong above), so the length dependence is inside `launch_attn_gqa`. Pre-existing and independent of everything here. **Left on by default** because switching it off moves long-context prefill throughput the eval scores against; deterministic mode defaults `SPARKINFER_PREFILL_ATTN_GQA_RQH=1` so that mode is trustworthy at every length.

2. **The accuracy gate cannot see it.** H2 scores long context but through `qwen3_gguf_score` (token loop, not batched prefill); H3 exercises batched prefill but at `prefix=512`, below the cliff. The defect lives exactly in the gap.

## Verification

- **Full `bench/scripts/accuracy.sh`** run end to end on this build **and on pristine `75508fb`**. Both report `top1=0.860000 kl=0.080407 ppl_spark=2.8284` on `seed=fixed` — identical to six figures, confirming the serving changes are numerically inert on the default path. (The requant refinement then moves it, as intended and measured above.) The gate's enforced vetoes pass: H3 `top1=0.8750 kl=0.00650` (bars 0.80 / 0.05); long-context int8-KV mean `top1=0.9583 kl=0.4250` over 3 seeds (bars 0.875 / 1.00).
- **21/21** `ctest` targets pass, including new `chat_tools_test` coverage for `/v1/score` parsing.
- **Gittensor's own `scripts/check_serving_runtime.py`**: `CONFORMANT: 0 MUST failure(s), 0 SHOULD warning(s)` with the deterministic flag on (D1 prefix agreement p05 **1.000**, logprob drift p95 **0.0000**).

## Proof of speedup

- [ ] Tested on **RTX 5090** (`sm_120`)

Intentionally unticked — see the note at the top. All measurements above were taken on an RTX 5090 (`sm_120`), but this PR claims **no** decode or prefill gain and should not be routed to the speed eval. The decode table in §1 is a no-regression control, not a speedup claim.
