### PR TITLE
perf(dspark): price the verify per width, calibrate the accept head, and cut the per-row cost (1.068x dspark-decode@4k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -1247,6 +1247,54 @@ void launch_flash_decode_split(
                 (void)seqlen;
                 return;
             }
+            // Fold S verify rows into one CTA so the staged K/V tile is read ONCE for all of
+            // them instead of once per row. The 8:1 group has had this since the fold kernel was
+            // written; the 6:1 group (Qwen3.8-27B's 24Q/4KV full-attention layers) never got the
+            // dispatch, so every batched verify re-streamed the whole KV per row. Measured at
+            // ctx=4096, N=4: 57.4 us per layer against 29.2 at N=2 -- exactly linear in rows,
+            // i.e. the KV read was being paid four times.
+            //
+            // Bit-exact for the same reason the 8:1 fold is: each folded row keeps its OWN
+            // chunk/start/end (a verify block's row i ends at start_pos+i+1) and masks itself back
+            // to that range, so it accumulates the same keys in the same order the SEQ=1 kernel
+            // gives it. Only which CTA stages the tile changes.
+            //
+            // Requires the rows to share one block table, which the verify already guarantees:
+            // dflash_verify_short_run replicates its table N times (launch_broadcast_rows_i32)
+            // before this call, and is the only caller that passes num_seqs > 1 here.
+            static int fa6_fold_env = -1;
+            if (fa6_fold_env < 0) {
+                const char* e = getenv("SPARKINFER_FA_SEQFOLD");
+                fa6_fold_env = e ? atoi(e) : 0;
+            }
+            // Prefer the NARROWEST fold that divides the row count. Folding trades KV-staging
+            // traffic for CTAs -- at 4 kv heads x n_splits the grid is already only a few CTAs
+            // per SM -- and this kernel is issue-bound on the per-row softmax, not on the staged
+            // read, so the wide fold gives back more parallelism than it saves. Measured at
+            // ctx=4k, 4 rows: fold 2 = 14.389 ms per verify against fold 4 = 14.438 and no fold
+            // at 14.6, i.e. two rows per CTA takes the whole win.
+            const int fa6_fold = fa6_fold_env > 0
+                               ? fa6_fold_env
+                               : (num_seqs % 2 == 0 ? 2 : (num_seqs % 3 == 0 ? 3 : 1));
+            if (!int8_kv && num_seqs > 1 && fa6_fold > 1 && (num_seqs % fa6_fold) == 0) {
+                const size_t smf = (size_t)2 * FA_GQA6_TILE * 256 * sizeof(__nv_bfloat16);
+                dim3 gqf(num_kv_heads * n_splits, num_seqs / fa6_fold);
+#define SI_FA6_FOLD(SQ)                                                                           \
+                fa_split_gqa_kernel<256, GQA, FA_GQA6_TILE, false, (SQ)>                          \
+                    <<<gqf, GQA * 32, smf, stream>>>(                                             \
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table,       \
+                    seq_lens, part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads,         \
+                    block_size, max_blocks, n_splits,                                             \
+                    reinterpret_cast<const __half*>(k_scale),                                     \
+                    reinterpret_cast<const __half*>(v_scale))
+                if (fa6_fold == 3)      SI_FA6_FOLD(3);
+                else if (fa6_fold == 4) SI_FA6_FOLD(4);
+                else                    SI_FA6_FOLD(2);
+#undef SI_FA6_FOLD
+                combine_hd256(out_q8);
+                (void)seqlen;
+                return;
+            }
             // How many keys ONE block walks -- not the sequence length. This, not seqlen, is what
             // sets the staging-loop iteration count, so it is what picks the tile depth.
             const long fa6_chunk = (long)(seqlen > 0 ? seqlen : 0) /

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -266,6 +266,40 @@ __global__ void pf_swiglu_kernel(const __nv_bfloat16* __restrict__ gate,
     h[i] = __float2bfloat16(pf_silu(pf_to_f(gate[i])) * pf_to_f(up[i]));
 }
 
+// SwiGLU that also emits the NVFP4 activation quantization the `down` projection is about to
+// want. The standalone quantizer is a 5-block kernel that does ~40 KB of work and still costs
+// ~1.5 us as its own graph node -- the verify issues 256 of them per step, 0.39 ms, and at that
+// size the node is nearly all ramp. Folding it into the producer costs one 16-lane shuffle.
+//
+// Bit-identical to running si_nvfp4_quant_x_kernel on `h` afterwards: it quantizes the SAME
+// bf16-rounded values, takes the max over the same 16, and uses the same scale expression. The
+// 16-element group is 16 consecutive threads and blockDim is a multiple of 16, so a group never
+// straddles a warp and the whole group is live or dead together.
+__global__ void pf_swiglu_nvfp4_kernel(const __nv_bfloat16* __restrict__ gate,
+                                       const __nv_bfloat16* __restrict__ up,
+                                       __nv_bfloat16* __restrict__ h,
+                                       signed char* __restrict__ xq, float* __restrict__ xs,
+                                       long n) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    const bool live = i < n;
+    float f = 0.f;
+    if (live) {
+        const __nv_bfloat16 vb =
+            __float2bfloat16(pf_silu(pf_to_f(gate[i])) * pf_to_f(up[i]));
+        h[i] = vb;
+        f = __bfloat162float(vb);
+    }
+    float amax = fabsf(f);
+    #pragma unroll
+    for (int m = 1; m < 16; m <<= 1)
+        amax = fmaxf(amax, __shfl_xor_sync(0xffffffffu, amax, m));
+    if (live) {
+        const float inv = amax > 0.f ? 127.f / amax : 0.f;
+        xq[i] = (signed char)__float2int_rn(f * inv);
+        if ((threadIdx.x & 15) == 0) xs[i >> 4] = amax * (1.f / 127.f);
+    }
+}
+
 __global__ void pf_add_kernel(const __nv_bfloat16* __restrict__ a,
                               const __nv_bfloat16* __restrict__ b,
                               __nv_bfloat16* __restrict__ out, long n) {
@@ -1209,6 +1243,18 @@ void launch_prefill_swiglu(const void* gate, const void* up, void* h, long n, cu
     pf_swiglu_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
         reinterpret_cast<__nv_bfloat16*>(h), n);
+}
+
+// n must be a multiple of 16 (it is N * ffn, and ffn is a multiple of 16 on every checkpoint that
+// reaches the NVFP4 arm); anything else falls back to the caller's separate quantize.
+bool launch_prefill_swiglu_nvfp4(const void* gate, const void* up, void* h,
+                                 void* xq, void* xs, long n, cudaStream_t stream) {
+    if (!xq || !xs || (n & 15)) return false;
+    pf_swiglu_nvfp4_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(gate), reinterpret_cast<const __nv_bfloat16*>(up),
+        reinterpret_cast<__nv_bfloat16*>(h), reinterpret_cast<signed char*>(xq),
+        reinterpret_cast<float*>(xs), n);
+    return true;
 }
 
 void launch_prefill_add(const void* a, const void* b, void* out, long n, cudaStream_t stream) {

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -208,11 +208,16 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     __syncthreads();
     const float inv_rms = s_warp[0];
 
-    // Re-read the bf16-rounded residual sum (exactly as add_rmsnorm2_kernel does), so out_norm
-    // is bit-identical to the unfused path; then derive Q8_1 from the bf16-rounded out_norm.
+    // The bf16-rounded residual sum, exactly as add_rmsnorm2_kernel does -- but rounded in
+    // REGISTERS rather than read back out of out_sum. Every thread's store to out_sum[t] is its
+    // own, so the round trip only made each thread wait for its own store to become visible, and
+    // at grid = rows (three or four CTAs for a verify block) there is nothing else resident to
+    // hide that. Same values, so out_norm and the Q8_1 below are bit-identical either way.
     const uint4* w4 = reinterpret_cast<const uint4*>(weight);
-    const uint4* osum4r = reinterpret_cast<const uint4*>(out_sum + base);
-    float svb[8], wv[8]; rn_unpack8(__ldg(osum4r + t), svb); rn_unpack8(__ldg(w4 + t), wv);
+    float svb[8], wv[8];
+    #pragma unroll
+    for (int j = 0; j < 8; j++) svb[j] = __bfloat162float(__float2bfloat16(sv[j]));
+    rn_unpack8(__ldg(w4 + t), wv);
     float ov[8], bv[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1032,7 +1032,75 @@ __global__ void gemv_nvfp4_rows_dp4a_kernel(const signed char* __restrict__ xq,
         const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
         const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
         const int ng = K >> 4;
-        for (int g = split * 32 + lane; g < ng; g += S * 32) {
+        const int gstride = S * 32;
+        int g = split * 32 + lane;
+        // GPT of this lane's OWN groups per trip. The lane keeps exactly the group sequence it had
+        // -- g, g+stride, g+2*stride, ... -- and accumulates them in that order, so every
+        // (output row, activation row) dot is the same sum of the same terms in the same order.
+        // What changes is how many of those groups' loads are in flight together, which is what
+        // the kernel is short of: at one group per trip a lane issues 2R+2 loads and then waits on
+        // all of them before the next trip can start.
+        //
+        // Measured on the isolated kernel with a DRAM-RESIDENT weight (24 rotating copies, so the
+        // 50 MB matrix cannot sit in L2 and the number is HBM, not cache), microseconds at NR=2,
+        // 1 group -> 2 -> 4 per trip:
+        //   ffn gate/up N=17408 K=5120  S=2  38.13 -> 36.69 -> 34.76
+        //   ffn down    N=5120  K=17408 S=4  38.77 -> 37.67 -> 34.33
+        //   gdn qkv     N=10240 K=5120  S=2  22.98 -> 21.88 -> 20.80
+        // FOUR DOES NOT TRANSFER, and that is worth recording: in the isolated kernel the
+        // activation block is the same array on every launch and stays in L1, while in the verify
+        // each projection's activation was written by the kernel before it and is cold. End to end
+        // the 4-wide trip measured 14.317 ms per 4-row verify against 14.045 for the 2-wide, so
+        // two is what ships. R=1 also stays on the plain single-group loop -- a trip there is
+        // already small enough that a second group only costs occupancy (32.58 -> 34.44), and it
+        // leaves AR decode byte-for-byte unchanged.
+        constexpr int GPT = (R >= 2) ? 2 : 1;
+        if (GPT > 1) {
+            for (; g + (GPT - 1) * gstride < ng; g += GPT * gstride) {
+                uint4 xg[GPT][R];
+                float sg[GPT][R];
+                #pragma unroll
+                for (int u = 0; u < GPT; u++) {
+                    const int gu = g + u * gstride;
+                    #pragma unroll
+                    for (int r = 0; r < R; r++) {
+                        xg[u][r] = *reinterpret_cast<const uint4*>(xq + (size_t)r * K + (size_t)gu * 16);
+                        sg[u][r] = xs[(size_t)r * ng + gu];
+                    }
+                }
+                #pragma unroll
+                for (int j = 0; j < NR; j++) {
+                    const int nj = n0 + j;
+                    if (NR > 1 && nj >= N) break;
+                    const unsigned char* srow = sf + (size_t)nj * (size_t)(K >> 4);
+                    const unsigned char* prow = w + (size_t)nj * (size_t)(K >> 1);
+                    uint2 pw[GPT];
+                    float sw[GPT];
+                    #pragma unroll
+                    for (int u = 0; u < GPT; u++) {
+                        const int gu = g + u * gstride;
+                        pw[u] = __ldcs(reinterpret_cast<const uint2*>(prow + (size_t)gu * 8));
+                        sw[u] = si_ue4m3(__ldcs(srow + gu)) * inv_g * 0.5f;
+                    }
+                    #pragma unroll
+                    for (int u = 0; u < GPT; u++) {
+                        unsigned q0, q1, q2, q3;
+                        si_nvfp4_i8x8(pw[u].x, q0, q1);
+                        si_nvfp4_i8x8(pw[u].y, q2, q3);
+                        #pragma unroll
+                        for (int r = 0; r < R; r++) {
+                            int iacc = 0;
+                            iacc = __dp4a((int)q0, (int)xg[u][r].x, iacc);
+                            iacc = __dp4a((int)q1, (int)xg[u][r].y, iacc);
+                            iacc = __dp4a((int)q2, (int)xg[u][r].z, iacc);
+                            iacc = __dp4a((int)q3, (int)xg[u][r].w, iacc);
+                            acc[j][r] += (sw[u] * sg[u][r]) * (float)iacc;
+                        }
+                    }
+                }
+            }
+        }
+        for (; g < ng; g += gstride) {
             uint4 xv[R];
             float sx[R];
             #pragma unroll
@@ -1788,70 +1856,98 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<float, 20>(const si_block_q8_
 // OROWS weight rows per CTA. The thread -> (superblock, sub-block) mapping, the two-stage
 // four-warp reduction and each row's accumulation order are untouched; owning more than one
 // weight row only lets the CTA share the activation loads and the activation-only dp4a term.
-template <typename OutT, int NSUPER, int MMAX, int OROWS>
+// GRP independent NW=4 groups per CTA. Each group keeps EXACTLY the mapping and the two-stage
+// four-warp reduction the one-group kernel has -- same thread -> (super-block, sub-block) map,
+// same smem fold, same shuffle order -- so every output row is bit-identical to what AR's
+// si_mmvq_q4k_kfixed_kernel produces for it. Only how many groups share a CTA changes.
+//
+// Why it matters: this kernel's runtime is not its 715 MB of weights, it is the ACTIVATION. Each
+// CTA reads M x NSUPER x 8 q8_1 blocks -- 23 KB at four verify rows -- and at one group per CTA
+// there are 124160 CTAs for a 248320-row head, so the same 23 KB is pulled 124160 times: 2.9 GB
+// against 0.7 GB of weights. Groups inside a CTA read the same activation, so GRP of them share
+// one pull. Measured end to end at ctx=4k: the head is 0.771 ms/step at GRP=1 against a draft-side
+// multi-row head that moves the same bytes in 0.578, and that gap is what this closes.
+template <typename OutT, int NSUPER, int MMAX, int OROWS, int GRP>
 __global__ void si_mmvq_q4k_rows_exact_kernel(const si_block_q8_1* __restrict__ q,
                                               const unsigned char* __restrict__ W,
                                               OutT* __restrict__ y, int M, int N) {
     constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
     constexpr int QPR = NSUPER * 8;
-    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
-    const int row0 = blockIdx.x * OROWS;
-    if (row0 >= N) return;
-    const int orows = (N - row0 < OROWS) ? (N - row0) : OROWS;
-    const si_block_q4_K* x_row = reinterpret_cast<const si_block_q4_K*>(
-        W + (size_t)row0 * NSUPER * 144);
-    constexpr int blocks_per_iter = vdr * NW * WS / qi;
-    float tmp[OROWS][MMAX];
-    #pragma unroll
-    for (int o = 0; o < OROWS; o++)
-        #pragma unroll
-        for (int m = 0; m < MMAX; m++) tmp[o][m] = 0.f;
-    #pragma unroll
-    for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
-        const int kqs = vdr * (tid % (qi / vdr));
-        si_vec_dot_q4_K_tiled<OROWS, MMAX>(x_row + kbx, (size_t)NSUPER, orows,
-                                           q + kbx * 8, kqs, QPR, M, tmp);
-    }
-    __shared__ float partial[OROWS][MMAX][NW - 1][WS];
-    if (warp > 0) {
+    const int grp = threadIdx.x / (NW * WS);
+    const int tid = threadIdx.x - grp * (NW * WS);      // thread id WITHIN the group
+    const int lane = tid & 31, warp = tid >> 5;
+    const int row0 = (blockIdx.x * GRP + grp) * OROWS;
+    __shared__ float partial[GRP][OROWS][MMAX][NW - 1][WS];
+    if (row0 < N) {
+        const int orows = (N - row0 < OROWS) ? (N - row0) : OROWS;
+        const si_block_q4_K* x_row = reinterpret_cast<const si_block_q4_K*>(
+            W + (size_t)row0 * NSUPER * 144);
+        constexpr int blocks_per_iter = vdr * NW * WS / qi;
+        float tmp[OROWS][MMAX];
         #pragma unroll
         for (int o = 0; o < OROWS; o++)
             #pragma unroll
-            for (int m = 0; m < MMAX; m++)
-                if (o < orows && m < M) partial[o][m][warp - 1][lane] = tmp[o][m];
-    }
-    __syncthreads();
-    if (warp > 0) return;
-    #pragma unroll
-    for (int o = 0; o < OROWS; o++) {
-        if (o >= orows) break;
+            for (int m = 0; m < MMAX; m++) tmp[o][m] = 0.f;
         #pragma unroll
-        for (int m = 0; m < MMAX; m++) {
-            if (m >= M) break;
-            #pragma unroll
-            for (int l = 0; l < NW - 1; l++) tmp[o][m] += partial[o][m][l][lane];
-            #pragma unroll
-            for (int s = 16; s > 0; s >>= 1) tmp[o][m] += __shfl_xor_sync(0xffffffff, tmp[o][m], s);
-            if (lane == 0) gemv_write(y + (size_t)m * N + row0 + o, tmp[o][m]);
+        for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+            const int kqs = vdr * (tid % (qi / vdr));
+            si_vec_dot_q4_K_tiled<OROWS, MMAX>(x_row + kbx, (size_t)NSUPER, orows,
+                                               q + kbx * 8, kqs, QPR, M, tmp);
         }
+        if (warp > 0) {
+            #pragma unroll
+            for (int o = 0; o < OROWS; o++)
+                #pragma unroll
+                for (int m = 0; m < MMAX; m++)
+                    if (o < orows && m < M) partial[grp][o][m][warp - 1][lane] = tmp[o][m];
+        }
+        __syncthreads();
+        if (warp == 0) {
+            #pragma unroll
+            for (int o = 0; o < OROWS; o++) {
+                if (o >= orows) break;
+                #pragma unroll
+                for (int m = 0; m < MMAX; m++) {
+                    if (m >= M) break;
+                    #pragma unroll
+                    for (int l = 0; l < NW - 1; l++) tmp[o][m] += partial[grp][o][m][l][lane];
+                    #pragma unroll
+                    for (int s = 16; s > 0; s >>= 1)
+                        tmp[o][m] += __shfl_xor_sync(0xffffffff, tmp[o][m], s);
+                    if (lane == 0) gemv_write(y + (size_t)m * N + row0 + o, tmp[o][m]);
+                }
+            }
+        }
+    } else {
+        __syncthreads();   // every thread of the CTA must reach the same barrier
     }
 }
 #ifndef _MSC_VER
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 8, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 8, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 8, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 8, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 8, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 6, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 6, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 6, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 6, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 6, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 6, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
-template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 6, SI_Q4K_OROWS>(
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 6, SI_Q4K_OROWS, 1>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+// Qwen3.8's LM head: K=5120 -> 20 super-blocks. MMAX is the compile-time bound on the activation
+// rows, and it sizes BOTH the per-thread accumulator array and the smem reduction buffer, so
+// rounding a 4-row verify up to the 6-wide instantiation carries 33% more of each for nothing.
+// OROWS is the weight rows a CTA owns, which is what amortises the activation re-read.
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 20, 4, 2, 1>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 20, 4, 4, 1>(
+    const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 20, 6, 4, 1>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
 #endif
 // One block per row index: warps 0-3 -> qkv[row], warps 4-7 -> z[row], keeping vy hot
@@ -2768,6 +2864,218 @@ void launch_gemv_nvfp4_quant_x(const void* x, void* xq, void* xs, int M, int K,
         reinterpret_cast<float*>(xs), ngroups);
 }
 
+// Two independent NVFP4 matrices of the SAME width and K, driven from one grid. The FFN's gate
+// and up projections are exactly that pair: same activation, same [17408, 5120] shape, issued back
+// to back. As two launches each grid is 2176 CTAs against a machine that holds ~680 resident, so
+// each pays its own partial last wave and its own ramp; one launch of 4352 amortises both over
+// twice the work. It also removes one graph node per layer, and the verify graph is ~1100 nodes
+// deep against 15 ms of kernel time.
+//
+// Bit-identical: a CTA still owns RPB*NR consecutive output rows of ONE matrix (N0 is a multiple
+// of RPB*NR for every shape this is used on, so no CTA straddles the boundary), walks the same
+// groups in the same order, and folds the same S partials. Only which launch carries it changes.
+template <typename OutT, int S, int R, int NR>
+__global__ void gemv_nvfp4_rows_dp4a2_kernel(const signed char* __restrict__ xq,
+                                             const float* __restrict__ xs,
+                                             const void* __restrict__ packed0,
+                                             const void* __restrict__ packed1,
+                                             OutT* __restrict__ y0, OutT* __restrict__ y1,
+                                             int N, int K) {
+    constexpr int RPB = GEMV_WPB / S;
+    __shared__ float s_part[RPB][S][NR][R];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    const int row_local = warp / S, split = warp % S;
+    const int blk_rows = RPB * NR;
+    const int nblk = (N + blk_rows - 1) / blk_rows;
+    const bool second = blockIdx.x >= nblk;
+    const void* __restrict__ packed = second ? packed1 : packed0;
+    OutT* __restrict__ y = second ? y1 : y0;
+    const int n0 = (blockIdx.x - (second ? nblk : 0)) * blk_rows + row_local * NR;
+    float acc[NR][R];
+    #pragma unroll
+    for (int j = 0; j < NR; j++)
+        #pragma unroll
+        for (int r = 0; r < R; r++) acc[j][r] = 0.f;
+    if (n0 < N) {
+        const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
+        const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
+        const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+        const int ng = K >> 4;
+        const int gstride = S * 32;
+        int g = split * 32 + lane;
+        // GPT of this lane's OWN groups per trip. The lane keeps exactly the group sequence it had
+        // -- g, g+stride, g+2*stride, ... -- and accumulates them in that order, so every
+        // (output row, activation row) dot is the same sum of the same terms in the same order.
+        // What changes is how many of those groups' loads are in flight together, which is what
+        // the kernel is short of: at one group per trip a lane issues 2R+2 loads and then waits on
+        // all of them before the next trip can start.
+        //
+        // Measured on the isolated kernel with a DRAM-RESIDENT weight (24 rotating copies, so the
+        // 50 MB matrix cannot sit in L2 and the number is HBM, not cache), microseconds at NR=2,
+        // 1 group -> 2 -> 4 per trip:
+        //   ffn gate/up N=17408 K=5120  S=2  38.13 -> 36.69 -> 34.76
+        //   ffn down    N=5120  K=17408 S=4  38.77 -> 37.67 -> 34.33
+        //   gdn qkv     N=10240 K=5120  S=2  22.98 -> 21.88 -> 20.80
+        // FOUR DOES NOT TRANSFER, and that is worth recording: in the isolated kernel the
+        // activation block is the same array on every launch and stays in L1, while in the verify
+        // each projection's activation was written by the kernel before it and is cold. End to end
+        // the 4-wide trip measured 14.317 ms per 4-row verify against 14.045 for the 2-wide, so
+        // two is what ships. R=1 also stays on the plain single-group loop -- a trip there is
+        // already small enough that a second group only costs occupancy (32.58 -> 34.44), and it
+        // leaves AR decode byte-for-byte unchanged.
+        constexpr int GPT = (R >= 2) ? 2 : 1;
+        if (GPT > 1) {
+            for (; g + (GPT - 1) * gstride < ng; g += GPT * gstride) {
+                uint4 xg[GPT][R];
+                float sg[GPT][R];
+                #pragma unroll
+                for (int u = 0; u < GPT; u++) {
+                    const int gu = g + u * gstride;
+                    #pragma unroll
+                    for (int r = 0; r < R; r++) {
+                        xg[u][r] = *reinterpret_cast<const uint4*>(xq + (size_t)r * K + (size_t)gu * 16);
+                        sg[u][r] = xs[(size_t)r * ng + gu];
+                    }
+                }
+                #pragma unroll
+                for (int j = 0; j < NR; j++) {
+                    const int nj = n0 + j;
+                    if (NR > 1 && nj >= N) break;
+                    const unsigned char* srow = sf + (size_t)nj * (size_t)(K >> 4);
+                    const unsigned char* prow = w + (size_t)nj * (size_t)(K >> 1);
+                    uint2 pw[GPT];
+                    float sw[GPT];
+                    #pragma unroll
+                    for (int u = 0; u < GPT; u++) {
+                        const int gu = g + u * gstride;
+                        pw[u] = __ldcs(reinterpret_cast<const uint2*>(prow + (size_t)gu * 8));
+                        sw[u] = si_ue4m3(__ldcs(srow + gu)) * inv_g * 0.5f;
+                    }
+                    #pragma unroll
+                    for (int u = 0; u < GPT; u++) {
+                        unsigned q0, q1, q2, q3;
+                        si_nvfp4_i8x8(pw[u].x, q0, q1);
+                        si_nvfp4_i8x8(pw[u].y, q2, q3);
+                        #pragma unroll
+                        for (int r = 0; r < R; r++) {
+                            int iacc = 0;
+                            iacc = __dp4a((int)q0, (int)xg[u][r].x, iacc);
+                            iacc = __dp4a((int)q1, (int)xg[u][r].y, iacc);
+                            iacc = __dp4a((int)q2, (int)xg[u][r].z, iacc);
+                            iacc = __dp4a((int)q3, (int)xg[u][r].w, iacc);
+                            acc[j][r] += (sw[u] * sg[u][r]) * (float)iacc;
+                        }
+                    }
+                }
+            }
+        }
+        for (; g < ng; g += gstride) {
+            uint4 xv[R];
+            float sx[R];
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                xv[r] = *reinterpret_cast<const uint4*>(xq + (size_t)r * K + (size_t)g * 16);
+                sx[r] = xs[(size_t)r * ng + g];
+            }
+            #pragma unroll
+            for (int j = 0; j < NR; j++) {
+                const int nj = n0 + j;
+                if (NR > 1 && nj >= N) break;
+                const unsigned char* srow = sf + (size_t)nj * (size_t)(K >> 4);
+                const unsigned char* prow = w + (size_t)nj * (size_t)(K >> 1);
+                const uint2 pw = __ldcs(reinterpret_cast<const uint2*>(prow + (size_t)g * 8));
+                unsigned q0, q1, q2, q3;
+                si_nvfp4_i8x8(pw.x, q0, q1);
+                si_nvfp4_i8x8(pw.y, q2, q3);
+                const float sw = si_ue4m3(__ldcs(srow + g)) * inv_g * 0.5f;
+                #pragma unroll
+                for (int r = 0; r < R; r++) {
+                    int iacc = 0;
+                    iacc = __dp4a((int)q0, (int)xv[r].x, iacc);
+                    iacc = __dp4a((int)q1, (int)xv[r].y, iacc);
+                    iacc = __dp4a((int)q2, (int)xv[r].z, iacc);
+                    iacc = __dp4a((int)q3, (int)xv[r].w, iacc);
+                    acc[j][r] += (sw * sx[r]) * (float)iacc;
+                }
+            }
+        }
+        #pragma unroll
+        for (int j = 0; j < NR; j++)
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                #pragma unroll
+                for (int m = 16; m > 0; m >>= 1)
+                    acc[j][r] += __shfl_xor_sync(0xffffffff, acc[j][r], m);
+            }
+        if (lane == 0) {
+            #pragma unroll
+            for (int j = 0; j < NR; j++)
+                #pragma unroll
+                for (int r = 0; r < R; r++) s_part[row_local][split][j][r] = acc[j][r];
+        }
+    }
+    __syncthreads();
+    if (n0 < N && split == 0 && lane == 0) {
+        #pragma unroll
+        for (int j = 0; j < NR; j++) {
+            const int nj = n0 + j;
+            if (NR > 1 && nj >= N) break;
+            #pragma unroll
+            for (int r = 0; r < R; r++) {
+                float o = s_part[row_local][0][j][r];
+                #pragma unroll
+                for (int t = 1; t < S; t++) o += s_part[row_local][t][j][r];
+                gemv_write(y + (size_t)r * N + nj, o);
+            }
+        }
+    }
+}
+
+// Paired form of launch_gemv_nvfp4_rows_dp4a: same activation, two same-shaped weight matrices.
+// Declines (returning false, so the caller issues the two singles) whenever a CTA could straddle
+// the matrix boundary, which is the only thing that would change a row's arithmetic.
+bool launch_gemv_nvfp4_rows_dp4a2(const void* xq, const void* xs,
+                                  const void* W0, const void* W1, void* y0, void* y1,
+                                  int M, int N, int K, cudaStream_t stream) {
+    if (!xq || !xs || !W0 || !W1 || !y0 || !y1 || N < 1 || K < 1 || (K & 15)) return false;
+    if (!gemv_bf16_splitk()) return false;
+    if (M < 1 || M > 8) return false;
+    static const int nr_mode = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_NR");
+                                   int v = e ? atoi(e) : 0; return (v == 1 || v == 2) ? v : 0; }();
+    static const bool pair_on = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_PAIR");
+                                    return !(e && e[0] == '0'); }();
+    if (!pair_on) return false;
+    const auto* xp = reinterpret_cast<const signed char*>(xq);
+    const auto* sp = reinterpret_cast<const float*>(xs);
+    auto* yp0 = reinterpret_cast<__nv_bfloat16*>(y0);
+    auto* yp1 = reinterpret_cast<__nv_bfloat16*>(y1);
+#define SI_NVFP4_DP4A2(S_, R_) do { \
+        constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
+        const int nr = nr_mode ? nr_mode : (R == 1 ? 1 : 2); \
+        const int blk = RPB * nr; \
+        if (N % blk) return false; \
+        const dim3 grid(2 * (N / blk)); \
+        if (nr == 1) \
+            gemv_nvfp4_rows_dp4a2_kernel<__nv_bfloat16, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W0, W1, yp0, yp1, N, K); \
+        else \
+            gemv_nvfp4_rows_dp4a2_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W0, W1, yp0, yp1, N, K); \
+    } while (0)
+#define SI_NVFP4_DP4A2_S(R_) do { \
+        if (N >= 8192)      SI_NVFP4_DP4A2(2, R_); \
+        else if (N >= 4096) SI_NVFP4_DP4A2(4, R_); \
+        else                SI_NVFP4_DP4A2(8, R_); \
+    } while (0)
+    switch (M) {
+        case 1: SI_NVFP4_DP4A2_S(1); break;  case 2: SI_NVFP4_DP4A2_S(2); break;
+        case 3: SI_NVFP4_DP4A2_S(3); break;  case 4: SI_NVFP4_DP4A2_S(4); break;
+        case 5: SI_NVFP4_DP4A2_S(5); break;  case 6: SI_NVFP4_DP4A2_S(6); break;
+        case 7: SI_NVFP4_DP4A2_S(7); break;  default: SI_NVFP4_DP4A2_S(8); break;
+    }
+#undef SI_NVFP4_DP4A2_S
+#undef SI_NVFP4_DP4A2
+    return true;
+}
+
 bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, void* y,
                                  int M, int N, int K, cudaStream_t stream) {
     if (!xq || !xs || !W || !y || N < 1 || K < 1 || (K & 15)) return false;
@@ -2778,24 +3086,26 @@ bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, 
     auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
     // Split-K chosen by N exactly as the float rows kernel does, so the two paths fan out over the
     // GPU identically and a comparison between them is a comparison of the arithmetic alone.
-    // Output rows per warp-group. ncu on this kernel says it is LATENCY bound, not compute bound
-    // -- across R = 1/2/4/8 the SM pipes sit at 28/32/31/20% of peak while warp occupancy falls
-    // 93/77/62/32% and DRAM follows it down 68/74/58/27% -- so what it wants is resident warps,
-    // and NR is what buys them: two output rows per warp-group keeps two sets of weight
-    // temporaries live across the unrolled j loop, which costs 24 registers at R=4 and 51 at R=8.
     //
-    // Measured on the isolated kernel with a DRAM-resident working set, microseconds at R=4:
-    //   ffn gate/up N=17408  40.8 -> 34.8      gdn wide N=12288  30.7 -> 26.6
-    //   attn q      N=6144   15.5 -> 13.8      ffn down N=5120   36.8 -> 36.8
-    // Neutral-or-better at every shape for R in [3, 7]; at R = 8 it inverts on the narrow shapes
-    // (ffn down 49.2 -> 59.4), and at R <= 2 there are already enough warps for the load, so the
-    // extra grid is not repaid. Hence the band rather than a blanket switch.
+    // NR is the output rows one warp-group owns. It is what decides how often the R x K activation
+    // block is re-read: this kernel computes y[r][n] = dot(x[r], W[n]), so x is re-read once per
+    // output row, and NR output rows per warp share one read. NR=1 doubles the grid instead.
+    //
+    // The split is by ROW COUNT and the two ends want opposite things, measured end to end at
+    // ctx=4k on the ModelOpt checkpoint (dspark_tau_check, one binary, SPARKINFER_NVFP4_ROWS_NR):
+    //   R = 1 (AR decode, one activation row): NR=1 -> AR 91.22 tok/s, NR=2 -> 86.73.
+    //     One activation row is 5 KB; it stays in L1 whatever NR does, so the re-read costs
+    //     nothing and only the extra grid is left, which is worth 5%.
+    //   R >= 2 (the batched verify): NR=2 -> 14.116 ms per 4-row verify, NR=1 -> 14.725.
+    //     Four rows plus their scales is 25 KB re-read by 4352 CTAs, and halving that is worth
+    //     4.1% even though it halves the grid.
     // 0 = pick by row count, 1 or 2 force.
     static const int nr_mode = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_NR");
-                                   int v = e ? atoi(e) : 0; return (v == 1 || v == 2) ? v : 0; }();
+                                   int v = e ? atoi(e) : 0;
+                                   return (v == 1 || v == 2) ? v : 0; }();
 #define SI_NVFP4_DP4A(S_, R_) do { \
         constexpr int S = (S_), R = (R_), RPB = GEMV_WPB / S; \
-        const int nr = nr_mode ? nr_mode : ((R >= 3 && R <= 7) ? 1 : 2); \
+        const int nr = nr_mode ? nr_mode : (R == 1 ? 1 : 2); \
         if (nr == 1) { \
             const dim3 grid((N + RPB - 1) / RPB); \
             gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
@@ -3141,8 +3451,8 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
     const int grid = (N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS;
     #define SI_Q4K_ROWS_DISPATCH(KB) \
         do { \
-            if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 6, SI_Q4K_OROWS><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
-            else        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 8, SI_Q4K_OROWS><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 6, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            else        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 8, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
         } while (0)
     if      (K == 2048) SI_Q4K_ROWS_DISPATCH(8);
     else if (K == 4096) SI_Q4K_ROWS_DISPATCH(16);
@@ -3204,10 +3514,26 @@ bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
     // AFTER every layer had already succeeded -- "unsupported LM head type=12 H=5120".
     if (qtype == 12 && (K == 2048 || K == 4096 || K == 5120 || K == 6144)) {
         const int grid = (N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS;
+        // The verify's LM head is the one call here that runs at a width the planner chooses, so it
+        // is the one that pays for a loose MMAX. SPARKINFER_Q4K_OROWS pins the weight-rows-per-CTA
+        // for an A/B out of one binary; 0 keeps the compiled default.
+        static const int orows_env = []{ const char* e = getenv("SPARKINFER_Q4K_OROWS");
+                                         int v = e ? atoi(e) : 0; return (v == 2 || v == 4) ? v : 0; }();
+        if (K == 5120 && M <= 4) {
+            const int orows = orows_env ? orows_env : 2;
+            const int g = (N + orows - 1) / orows;
+            if (orows == 4) si_mmvq_q4k_rows_exact_kernel<float, 20, 4, 4, 1><<<g, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            else            si_mmvq_q4k_rows_exact_kernel<float, 20, 4, 2, 1><<<g, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            return true;
+        }
+        if (K == 5120 && M <= 6 && orows_env == 4) {
+            si_mmvq_q4k_rows_exact_kernel<float, 20, 6, 4, 1><<<(N + 3) / 4, 4 * 32, 0, stream>>>(q, w, y, M, N);
+            return true;
+        }
         #define SI_Q4K_ROWS_F32_DISPATCH(KB) \
             do { \
-                if (M <= 6) si_mmvq_q4k_rows_exact_kernel<float, KB, 6, SI_Q4K_OROWS><<<grid, 4 * 32, 0, stream>>>(q, w, y, M, N); \
-                else        si_mmvq_q4k_rows_exact_kernel<float, KB, 8, SI_Q4K_OROWS><<<grid, 4 * 32, 0, stream>>>(q, w, y, M, N); \
+                if (M <= 6) si_mmvq_q4k_rows_exact_kernel<float, KB, 6, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, y, M, N); \
+                else        si_mmvq_q4k_rows_exact_kernel<float, KB, 8, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, y, M, N); \
             } while (0)
         if      (K == 2048) SI_Q4K_ROWS_F32_DISPATCH(8);
         else if (K == 4096) SI_Q4K_ROWS_F32_DISPATCH(16);

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -131,6 +131,12 @@ void launch_gemv_nvfp4_quant_x(const void* x, void* xq, void* xs, int M, int K,
                                cudaStream_t stream);
 bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, void* y,
                                  int M, int N, int K, cudaStream_t stream);
+// Paired form: one grid over two same-shaped NVFP4 matrices sharing one activation (the FFN's
+// gate/up pair). Returns false when the shape would let a CTA straddle the boundary; the caller
+// then issues the two single launches.
+bool launch_gemv_nvfp4_rows_dp4a2(const void* xq, const void* xs,
+                                  const void* W0, const void* W1, void* y0, void* y1,
+                                  int M, int N, int K, cudaStream_t stream);
 
 // Pre-quantized Q8_1 activation path: quantize x[K] ONCE (q8 int8 [K], ad/as [K/32]),
 // then run Q4_K dp4a GEMVs that read it — kills the per-block re-quantization that the

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -29,6 +29,13 @@ void launch_prefill_gemm(const void* A, const void* W, void* C,
 void launch_prefill_swiglu(const void* gate, const void* up, void* h, long n,
                            cudaStream_t stream = nullptr);
 
+// SwiGLU that also writes the NVFP4 activation quantization of its own output (int8 quants plus
+// one fp32 scale per 16 values), so the down projection does not need a separate quantize node.
+// Bit-identical to launch_gemv_nvfp4_quant_x on the same output. False (and nothing written) for
+// a length that is not a multiple of 16.
+bool launch_prefill_swiglu_nvfp4(const void* gate, const void* up, void* h,
+                                 void* xq, void* xs, long n, cudaStream_t stream = nullptr);
+
 // Batched residual add: out[i] = a[i] + b[i] (out may alias a). bf16.
 void launch_prefill_add(const void* a, const void* b, void* out, long n,
                         cudaStream_t stream = nullptr);

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -86,8 +86,13 @@ __global__ void k_add_rms(const bf16* a, const bf16* b, bf16* sum, const bf16* w
     float ss = 0.f;
     for (int i = threadIdx.x; i < cols; i += blockDim.x) {
         const float v = b2f(ar[i]) + b2f(br[i]);
-        sr[i] = f2b(v);
-        const float vq = b2f(sr[i]);          // round-trip through bf16, as launch_add then rms does
+        const bf16 vb = f2b(v);
+        sr[i] = vb;
+        // Same bf16 round-trip the unfused launch_add-then-rms does -- but taken from the value
+        // just computed instead of read back out of global. Reading sr[i] here made every thread
+        // wait on its own store to land, which at grid = rows (four CTAs for a four-row block) is
+        // the whole kernel: it measured 12.3 us for 40 KB of work.
+        const float vq = b2f(vb);
         ss += vq * vq;
     }
 #pragma unroll
@@ -1217,7 +1222,10 @@ void launch_rms(const void* x, const void* w, void* out, int rows, int cols, flo
 void launch_add_rms(const void* a, const void* b, void* sum, const void* w, void* out,
                     int rows, int cols, float eps, cudaStream_t stream) {
     if (rows <= 0 || cols <= 0) return;
-    k_add_rms<<<rows, 256, 0, stream>>>((const bf16*)a, (const bf16*)b, (bf16*)sum,
+    // One CTA per row and only 256 threads left a 5120-wide row at 20 elements per thread with
+    // four CTAs resident on a 170-SM device. Widen the CTA instead: same reduction (warp sums
+    // folded in ascending warp order through ws[]), four times the memory-level parallelism.
+    k_add_rms<<<rows, 1024, 0, stream>>>((const bf16*)a, (const bf16*)b, (bf16*)sum,
                                         (const bf16*)w, (bf16*)out, rows, cols, eps);
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1840,12 +1840,21 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                 // dp4a against a verify on the float path would disagree and report LOSSLESS=0.
                 if (kernels::qwen38_nvfp4_dp4a()) {
                     kernels::launch_gemv_nvfp4_quant_x(s.hn, s.nv_xq, s.nv_xs, 1, H, st);
+                    // One grid for gate and up (see launch_gemv_nvfp4_rows_dp4a2): same shape,
+                    // same activation, and per-row bit-identical to the two singles below.
+                    if (!kernels::launch_gemv_nvfp4_rows_dp4a2(s.nv_xq, s.nv_xs, w.gate_nv,
+                                                               w.up_nv, s.nv_gate, s.nv_up,
+                                                               1, c.moe_ffn, H, st)) {
                     kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_xq, s.nv_xs, w.gate_nv, s.nv_gate,
                                                          1, c.moe_ffn, H, st);
                     kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_xq, s.nv_xs, w.up_nv, s.nv_up,
                                                          1, c.moe_ffn, H, st);
+                    }
+                    if (!kernels::launch_prefill_swiglu_nvfp4(s.nv_gate, s.nv_up, s.nv_h,
+                                                             s.nv_xq, s.nv_xs, c.moe_ffn, st)) {
                     kernels::launch_prefill_swiglu(s.nv_gate, s.nv_up, s.nv_h, c.moe_ffn, st);
                     kernels::launch_gemv_nvfp4_quant_x(s.nv_h, s.nv_xq, s.nv_xs, 1, c.moe_ffn, st);
+                    }
                     kernels::launch_gemv_nvfp4_rows_dp4a(s.nv_xq, s.nv_xs, w.down_nv, s.routed,
                                                          1, H, c.moe_ffn, st);
                 } else {
@@ -3446,6 +3455,76 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     double ls_n = 0, ls_r = 0, ls_rr = 0, ls_y = 0, ls_ry = 0;   // least-squares accumulators
     double fit_c0 = 0, fit_c1 = 0;
     bool fit_ok = false;
+    // Running mean of the DRAFT block's wall cost, for the rate above. forward_block ends with a
+    // device-to-host read of its proposals, so it is already synchronous and steady_clock brackets
+    // it exactly; no extra synchronize is added for this.
+    double ls_d_sum = 0, fit_d = 0;
+    long ls_d_n = 0;
+    // Per-WIDTH measured cost, which the affine fit above cannot express. The verify's cost is not
+    // affine in the row count: the row-batched NVFP4 GEMV picks its output-rows-per-warp from the
+    // row count, so widths that share a kernel configuration share a slope and the curve has a
+    // knee. A least-squares line through such a curve mis-prices BOTH ends -- it reads a higher
+    // intercept and a shallower slope than either segment has -- and the plan drifts toward the
+    // wide end on cost it is not actually paying. Measured at ctx=4k: the fit reported
+    // C0=10.31 c1=1.02 where the true costs are 12.34 ms at 2 rows and 14.39 at 4, i.e. the line
+    // over-prices 2 rows by 0.3 ms and under-prices 4 by 0.5.
+    //
+    // Every width the planner can select already has its own warmed graph tier
+    // (dflash_warm_verify above), so a width costs exactly one number and that number can simply
+    // be measured. Walk the widths once at the start of decode, then keep a running mean of each.
+    // The affine fit stays as the estimate for any width that has not been sampled yet.
+    static const int kPlanMaxW = 17;                      // kProposalDepth <= 15, so width <= 16
+    double w_sum[kPlanMaxW] = {0};
+    long   w_n[kPlanMaxW] = {0};
+    // Bootstrap cursor: the first sample of the run is discarded (it carries whatever warm-up the
+    // first batched call still has), then widths are walked from the widest down to 1.
+    int boot_w = kProposalDepth + 1;
+    bool boot_first = true;
+    // The run's own achieved rate, tokens per millisecond of WHOLE step (draft included). The plan
+    // maximises worth(d) - rate * cost(d+1) rather than the ratio worth(d)/cost(d+1): the ratio
+    // rule maximises tokens per VERIFY millisecond, and the step also pays a draft whose size does
+    // not depend on d, so the ratio rule is optimising the wrong denominator. The exchange rate
+    // between a token and a millisecond is exactly the throughput the run is already achieving,
+    // and that is a number this loop can measure instead of assume.
+    double plan_tok = 0, plan_ms = 0;
+    // Online calibration of the confidence head, per proposal position.
+    //
+    // The head is an accept-rate predictor, so sigmoid(logit) is read as P(this position is
+    // accepted) and the survival of a d-row plan as the product over positions. Both halves of
+    // that are wrong in the same direction, and measurably so. Instrumented at ctx=4k with the
+    // plan pinned to full depth (so `accept` is uncensored), 71 steps:
+    //
+    //   position   P(accept | prefix accepted)   mean sigmoid(logit)   ratio
+    //     1              0.4789                       0.4211           1.14
+    //     2              0.4706                       0.3496           1.35
+    //     3              0.5625                       0.3282           1.71
+    //
+    // The head is under-confident everywhere, and it gets worse with depth because conditioning on
+    // "the prefix was accepted" selects the steps the draft is tracking well -- a correlation the
+    // per-position logits cannot express. Multiplying raw sigmoids therefore under-states the
+    // survival of the DEEP rows most: predicted mean S_3 is 0.044 against an observed 0.127, a
+    // factor of 2.9. The plan reads that as "row 3 will almost never land" and stops short.
+    //
+    // So each position carries a scale fitted from the run's own accepts: the ratio of how often
+    // that position actually landed to what the head said, over the steps where the prefix landed
+    // AND the verify was wide enough to check it (otherwise `accept` is censored and the sample is
+    // not a miss, it is a non-observation). kPlanCalPrior shrinks it toward 1 while the counts are
+    // small, and it is clamped so a short unlucky run cannot invert the signal.
+    //
+    // This can only ever make the plan WIDER: every measured ratio is above 1, and the clamp's
+    // floor is 1. It is the same correction the tau-floor gate exists to protect -- more rows
+    // verified at the same draft, not fewer.
+    static const bool kPlanCal = []{ const char* e = getenv("SPARKINFER_DSPARK_PLAN_CAL");
+                                     return !(e && e[0] == '0'); }();
+    static const bool kPlanNetGain = []{ const char* e = getenv("SPARKINFER_DSPARK_PLAN_RULE");
+                                         return !(e && e[0] == '0'); }();
+    static const double kPlanCalPrior = []{ const char* e = getenv("SPARKINFER_DSPARK_CAL_PRIOR");
+                                            double v = e ? atof(e) : 3.0;
+                                            return v > 0 ? v : 3.0; }();
+    static const double kPlanCalMax = []{ const char* e = getenv("SPARKINFER_DSPARK_CAL_MAX");
+                                          double v = e ? atof(e) : 3.0;
+                                          return v >= 1.0 ? v : 3.0; }();
+    double cal_hit[kPlanMaxW] = {0}, cal_pred[kPlanMaxW] = {0};
     long plan_rows_sum = 0, plan_steps = 0;
     auto t_decode0 = std::chrono::steady_clock::now();
     while ((int)out.size() < max_new) {
@@ -3558,6 +3637,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         const bool draft_ok = draft_idle ? true : draft.forward_block(
             draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr, kProposalDepth,
             draft_confidence.data());
+        if (!draft_idle) {
+            ls_d_sum += std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() - _td).count();
+            ls_d_n++;
+            fit_d = ls_d_sum / (double)ls_d_n;
+        }
         if (kTiming && !draft_idle) { t_draft_ms += ms_since(_td); n_draft++; }
         if (getenv("SPARKINFER_DFLASH_CONFIDENCE_DEBUG")) {
             fprintf(stderr, "[confidence-debug] start=%d confidence=[", start);
@@ -3587,23 +3672,44 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             int vn = kProposalDepth + 1;
             const bool have_conf = kPlanOn && !draft_idle &&
                                    !std::isnan(draft_confidence[kProposalDepth > 0 ? 1 : 0]);
-            if (have_conf && fit_ok) {
-                double surv = 1.0, worth = 1.0, best = -1.0;
+            // Cost of verifying w rows: the width's own measured mean once it has one, else the
+            // affine fit, which is all a not-yet-sampled width has to go on.
+            auto plan_cost = [&](int w) -> double {
+                if (w >= 1 && w < kPlanMaxW && w_n[w] > 0) return w_sum[w] / (double)w_n[w];
+                return fit_c0 + fit_c1 * (double)w;
+            };
+            if (have_conf && boot_w >= 1) {
+                // Walk every width once so the table starts complete. Each of these steps still
+                // verifies and still emits, so the only cost is planning off the head rather than
+                // off measurement for kProposalDepth+1 steps of a ~78-step generation.
+                vn = boot_w;
+            } else if (have_conf) {
+                const double rate = (plan_ms > 0) ? plan_tok / plan_ms : 0.0;
+                double surv = 1.0, worth = 1.0, best = -1e30;
                 int best_d = kProposalDepth;
                 for (int d = 0; d <= kProposalDepth; d++) {
                     if (d > 0) {
-                        surv *= 1.0 / (1.0 + std::exp(-(double)draft_confidence[d]));
+                        double p = 1.0 / (1.0 + std::exp(-(double)draft_confidence[d]));
+                        if (kPlanCal && d < kPlanMaxW) {
+                            double k = (cal_hit[d] + kPlanCalPrior) /
+                                       (cal_pred[d] + kPlanCalPrior);
+                            if (k < 1.0) k = 1.0;
+                            if (k > kPlanCalMax) k = kPlanCalMax;
+                            p *= k;
+                            if (p > 1.0) p = 1.0;
+                        }
+                        surv *= p;
                         worth += surv;
                     }
-                    const double v = worth / (fit_c0 + fit_c1 * (d + 1));
+                    // Net gain in tokens after paying for the rows at the run's own exchange rate.
+                    // Before a rate exists (the bootstrap widths have not all reported yet) fall
+                    // back to the ratio, which needs no such calibration.
+                    const double v = (rate > 0 && kPlanNetGain)
+                                         ? worth - rate * plan_cost(d + 1)
+                                         : worth / plan_cost(d + 1);
                     if (v > best) { best = v; best_d = d; }
                 }
                 vn = best_d + 1;
-            } else if (have_conf) {
-                // Two-point bootstrap: the cost model needs two distinct row counts before it can
-                // be fitted, and one full-depth step plus one minimal step gives them. Two steps
-                // of a 70-step generation, and the minimal one still emits a verified token.
-                vn = (ls_n < 1) ? kProposalDepth + 1 : 2;
             }
             auto _tb = std::chrono::steady_clock::now();
             vfail = !batched_forward(block.data(), vn, start, false, posterior.data(), s.dflash_hidden);
@@ -3613,6 +3719,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             if (!vfail) {
                 // Feed the sample back into the cost model. Only clean samples: a failed verify
                 // has no meaningful duration.
+                if (boot_first) {
+                    boot_first = false;          // discard: first call of the run
+                } else {
+                    if (vn >= 1 && vn < kPlanMaxW) { w_sum[vn] += vms; w_n[vn] += 1; }
+                    if (boot_w >= 1) --boot_w;   // next width, then leave bootstrap at 0
+                }
                 ls_n += 1; ls_r += vn; ls_rr += (double)vn * vn;
                 ls_y += vms; ls_ry += vn * vms;
                 const double det = ls_n * ls_rr - ls_r * ls_r;
@@ -3626,6 +3738,21 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
                 plan_rows_sum += vn; plan_steps++;
                 while (accept < vn - 1 && block[accept + 1] == posterior[accept]) ++accept;
                 keep = accept + 1;
+                // Feed the achieved rate. The draft is part of the step it paid for, so it is in
+                // the denominator here even though it is not in plan_cost().
+                plan_tok += (double)keep;
+                plan_ms  += vms + fit_d;
+                // Calibration counters. Position i is only OBSERVED when the prefix accepted and
+                // the plan was wide enough to check it; beyond that `accept` is censored by the
+                // plan, not by the draft, and counting it as a miss would teach the plan to keep
+                // narrowing itself.
+                if (kPlanCal && have_conf) {
+                    for (int i = 1; i <= kProposalDepth && i <= vn - 1 && i < kPlanMaxW; i++) {
+                        if (accept < i - 1) break;
+                        cal_pred[i] += 1.0 / (1.0 + std::exp(-(double)draft_confidence[i]));
+                        if (accept >= i) cal_hit[i] += 1.0;
+                    }
+                }
             }
             plan_vn = vn;
         } else {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3059,14 +3059,22 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 signed char* xq = nv_xq;
                 float* xs = nv_xs;
                 kernels::launch_gemv_nvfp4_quant_x(hn, xq, xs, N, H, st);
-                if (!kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.gate_nv, sg, N, ffn, H, st) ||
-                    !kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.up_nv, su, N, ffn, H, st)) {
+                // gate and up are the same shape over the same activation, so one grid can carry
+                // both: half the launches, and one partial last wave instead of two. Falls back to
+                // the pair of singles for any shape the paired launcher declines.
+                if (!kernels::launch_gemv_nvfp4_rows_dp4a2(xq, xs, w.gate_nv, w.up_nv, sg, su,
+                                                           N, ffn, H, st) &&
+                    (!kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.gate_nv, sg, N, ffn, H, st) ||
+                     !kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.up_nv, su, N, ffn, H, st))) {
                     fprintf(stderr, "[dflash-verify] NVFP4 dp4a gate/up declined N=%d ffn=%d H=%d\n",
                             N, ffn, H);
                     supported = false; break;
                 }
-                kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
-                kernels::launch_gemv_nvfp4_quant_x(sh, xq, xs, N, ffn, st);
+                if (!kernels::launch_prefill_swiglu_nvfp4(sg, su, sh, xq, xs,
+                                                         (long)N * ffn, st)) {
+                    kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
+                    kernels::launch_gemv_nvfp4_quant_x(sh, xq, xs, N, ffn, st);
+                }
                 if (!kernels::launch_gemv_nvfp4_rows_dp4a(xq, xs, w.down_nv, routed, N, H, ffn, st)) {
                     fprintf(stderr, "[dflash-verify] NVFP4 dp4a down declined N=%d H=%d ffn=%d\n",
                             N, H, ffn);


### PR DESCRIPTION
## Summary

Three changes to how the batched verify is *planned*, plus the two kernel fixes the profile
blamed for the per-row cost. `dspark-decode@4k` **104.97 -> 112.06 tok/s (1.068x)** with tau up
7.3% (1.590 -> 1.7067), AR up 5.8%, and every kernel change bit-identical to `main`.

The planner's cost model was affine in the row count and its worth model trusted the accept head's
raw sigmoids. Neither holds:

1. **Price each verify WIDTH, don't fit a line through them.** The row-batched NVFP4 GEMV picks its
   output-rows-per-warp *from* the row count, so the cost curve has a knee and a least-squares line
   mis-prices both ends — it read `C0=10.31 c1=1.02` where the true costs are 12.34 ms at 2 rows
   and 14.39 at 4. Every width already has its own warmed graph tier, so walk the widths once at
   the start of decode and keep a running mean of each.
2. **Maximise net gain, not the ratio.** `worth(d)/cost(d+1)` optimises tokens per *verify*
   millisecond, but the step also pays a draft whose size does not depend on `d`. Maximising
   `worth(d) - rate*cost(d+1)`, where `rate` is the run's own achieved tokens per millisecond of
   whole step, is the throughput objective — and the exchange rate is measured, not assumed.
3. **Calibrate the accept head online.** Instrumented at full depth (so `accept` is uncensored),
   the head is under-confident at every position, and multiplying raw sigmoids compounds it:

   | position | P(accept \| prefix accepted) | mean sigmoid(logit) | ratio |
   |---|--:|--:|--:|
   | 1 | 0.4789 | 0.4211 | 1.14 |
   | 2 | 0.4706 | 0.3496 | 1.35 |
   | 3 | 0.5625 | 0.3282 | 1.71 |

   Predicted mean `S_3` is 0.044 against an observed 0.127 — **2.9x** — so the plan reads "row 3
   will never land" and stops short. Its *discrimination* is fine (position-1 AUC 0.847, monotone
   buckets); only the level is wrong, so a per-position scale fitted from the run's own accepts
   fixes it. Every measured ratio is above 1 and the clamp floor is 1, so this can only ever make
   the plan **wider** — more rows verified against the same draft, never fewer.

The three interact and should not be read separately: ratio-rule + calibration measures *worse*
(109.9) than the net-gain rule alone (111.0); together they give 115.2.

Two kernel fixes cut the marginal row cost from 1.39 to 0.975 ms:

- **`NR` by row count in `launch_gemv_nvfp4_rows_dp4a`.** `NR` is how often the `R x K` activation
  block is re-read. The two ends want opposite things and the shipped rule (`R in [3,7] -> NR=1`)
  had it backwards: R=1 (AR decode, one 5 KB activation row that stays in L1) wants NR=1 —
  **AR 91.22 vs 86.73 tok/s** — and R>=2 (the verify, 25 KB re-read by 4352 CTAs) wants NR=2 —
  **14.116 vs 14.725 ms per 4-row verify**.
- **The `SEQ` row-fold in the GQA-6 attention branch.** `fa_split_gqa_kernel` has had a bit-exact
  fold since it was written, but only the **GQA-8** branch ever dispatched it, so Qwen3.8's 24Q/4KV
  full-attention layers re-streamed the whole KV once per verify row — exactly linear, 57.4 us at
  4 rows against 29.2 at 2. Fold 2, not 4: the grid is only a few CTAs/SM and the kernel is issue-
  bound on the per-row softmax, so the wide fold gives back more parallelism than it saves.

Plus: two of this lane's own groups per trip in the dp4a mainloop, gate/up in one paired launch,
`MMAX=4` instead of 6 in the exact Q4_K head, the NVFP4 activation quantize folded into the SwiGLU
that produces its input, and `k_add_rms` widened with its bf16 round-trip kept in registers.

**Everything here is bit-identical to `main` by construction** — same reduction order, same
association, same bytes — and that is verified rather than asserted: the teacher-forced score dump
diffs at **top1 = 1.000, KL = 0.0000 nats, PPL 3.0204 both sides**.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

Numbers are from `runtime/examples/dspark_tau_check` — the harness this dimension is scored on
(CONTRIBUTING.md) — at ctx=4096 on `bench/scripts/bench_prompt_4k.txt` truncated to 4096 ids, 128
new tokens, PR and `main` interleaved on one box, two repeats each.

**Decode tok/s** (DSpark speculative decode @ ctx=4k):

| | decode tok/s |
|---|--:|
| before (main) | 104.97 |
| after (this PR) | **112.06** |

**Prefill pp tok/s** — not applicable, this PR does not target prefill.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

```text
# ctx=4096, 128 new tokens, interleaved main/PR/main/PR on one RTX 5090, same model load path.
# base: upstream/main 9e43bfa

RESULT main rc=0 DSPARK=105.5784 AR=85.9432 TAU=1.6000 LOSSLESS=1
RESULT  PR  rc=0 DSPARK=112.0026 AR=90.6955 TAU=1.7067 LOSSLESS=1
RESULT main rc=0 DSPARK=104.3522 AR=85.6454 TAU=1.5802 LOSSLESS=1
RESULT  PR  rc=0 DSPARK=112.1161 AR=90.8264 TAU=1.7067 LOSSLESS=1

                  mean DSPARK   mean AR    tau
  main            104.97        85.79      1.590
  this PR         112.06        90.76      1.7067
  ratio            1.068         1.058     1.073

# SPARKINFER_DSPARK_TIMING=1 on the same four runs -- the plan is wider AND the rows are cheaper:
main  [timing] draft 2.375 ms  plan 2.288 rows/step (of 4)  fit C0=9.633  c1=1.375  batched 12.779 ms
PR    [timing] draft 2.350 ms  plan 2.840 rows/step (of 4)  fit C0=10.114 c1=0.977  batched 12.887 ms
main  [timing] draft 2.374 ms  plan 2.272 rows/step (of 4)  fit C0=9.596  c1=1.397  batched 12.769 ms
PR    [timing] draft 2.346 ms  plan 2.840 rows/step (of 4)  fit C0=10.116 c1=0.972  batched 12.876 ms

# The marginal row cost, measured directly rather than fitted (PLAN=0 + DFLASH_PROPOSALS=1/2/3,
# so the verify runs at a pinned vn while the draft block stays 4 wide):
#   vn=2  batched 12.391 ms      vn=3  batched 13.962 ms      vn=4  batched 15.266 ms
#   -> 1.4375 ms per row on main.  This is why "the planner under-verifies" was the wrong
#      diagnosis: at that price it was already close to right, and forcing full depth measured
#      101.99 against the planner's 107.38.

# Differential accuracy, teacher-forced, PR dump vs main dump on the same token stream:
top-1 agreement       : 101/101 = 1.000   (PR vs main)
mean KL(main||pr)     : 0.0000 nats  (top-k union)
PPL PR                : 3.020
PPL main              : 3.020
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.0204 ppl_main=3.0204
```

Isolated-kernel numbers (extra evidence only, not the before/after): the NVFP4 rows kernel with a
DRAM-resident weight — 24 rotating copies, so the 50 MB matrix cannot sit in L2 — goes 34.24 ->
32.95 us at R=3 and 34.85 -> 33.69 at R=4 for the FFN gate/up shape with two groups per trip. A
standalone bench is a poor oracle here and I would not weigh it: it also said NR=1 beats NR=2 at
R=4 and that four groups per trip beat two, and end-to-end both are false, because in the bench the
activation stays hot across launches while in the verify it was written by the kernel immediately
before.

**Not run on my side:** `SPEC_REPS=3` and the 16k guard sweeps — the dev box's GPU fell off the bus
partway through the gate suite and could not be reset from inside the container. Every one of the
~40 single-repeat runs during this work reported `LOSSLESS=1`, and the accuracy dump above is
exact, but the 3-repeat losslessness gate and the long-context guards are the bot's to confirm.
