### PR TITLE
perf(dspark): draft one more proposal, and instantiate the kernels that depth needs (1.042x dspark-decode@4k)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -3617,13 +3617,33 @@ bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
     dim3 grid(nblk);
     auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     auto* w = reinterpret_cast<const unsigned char*>(W);
-    // MFIXED 3 and 6 keep the row loop fully unrolled at the two depths the draft actually uses;
-    // anything else runs the MMAX=16 form with a runtime bound.
+    // One exact MFIXED per row count the proposal ladder can actually ask for, not just the two
+    // it used to ask for. MMAX sizes acc[MMAX] and bounds the row loop, so the fallback form runs
+    // SIXTEEN predicated rows to do five and carries 56 registers against 39-40 for the exact
+    // ones -- 2 CTAs of 16 warps against 3, i.e. 66% occupancy against 100%. Measured on the
+    // draft head (V=248320, K=5120): 838.6 us at M=5 on the fallback against 457.1 us at M=3 on
+    // the exact form. That gap was the largest single term in the cost of drafting a wider block,
+    // and it is why depth 6 (exact) was cheaper than depth 5 (fallback) despite proposing more.
+    // A/B switch: 0 restores the previous dispatch (exact only at M = 3 and 6).
+    static const bool mfixed_all = []{ const char* e = getenv("SPARKINFER_DFLASH_HEAD_MFIXED");
+                                       return !(e && e[0] == '0'); }();
     #define SI_MR_BY_M(NS) \
         do { \
-            if (M == 3)      si_mmvq_q4k_multirow_kernel<float, 16, NS, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
-            else if (M == 6) si_mmvq_q4k_multirow_kernel<float, 16, NS, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
-            else             si_mmvq_q4k_multirow_kernel<float, 16, NS, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
+            if (!mfixed_all) { \
+                if (M == 3)      si_mmvq_q4k_multirow_kernel<float, 16, NS, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
+                else if (M == 6) si_mmvq_q4k_multirow_kernel<float, 16, NS, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
+                else             si_mmvq_q4k_multirow_kernel<float, 16, NS, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); \
+            } else switch (M) { \
+                case 1: si_mmvq_q4k_multirow_kernel<float, 16, NS, 1, 1><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                case 2: si_mmvq_q4k_multirow_kernel<float, 16, NS, 2, 2><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                case 3: si_mmvq_q4k_multirow_kernel<float, 16, NS, 3, 3><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                case 4: si_mmvq_q4k_multirow_kernel<float, 16, NS, 4, 4><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                case 5: si_mmvq_q4k_multirow_kernel<float, 16, NS, 5, 5><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                case 6: si_mmvq_q4k_multirow_kernel<float, 16, NS, 6, 6><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                case 7: si_mmvq_q4k_multirow_kernel<float, 16, NS, 7, 7><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                case 8: si_mmvq_q4k_multirow_kernel<float, 16, NS, 8, 8><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+                default: si_mmvq_q4k_multirow_kernel<float, 16, NS, 16><<<grid, 16 * 32, 0, stream>>>(q, w, y, N, M); break; \
+            } \
         } while (0)
     if (nsuper == 8)       SI_MR_BY_M(8);
     else if (nsuper == 20) SI_MR_BY_M(20);

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1643,7 +1643,14 @@ __global__ void k_markov_bias_add_warp(const bf16* __restrict__ w1, const bf16* 
 // Quantizing a bias table is safe here for the same reason the warp reduction's reordered sum is:
 // the draft only NOMINATES, and every emitted token is still a target argmax. It can move tau and
 // nothing else.
-template <int RANK>
+// ROWS = vocabulary rows per warp. At RANK=256 and VEC=8 a warp's 32 lanes cover exactly one row
+// in a single int2 load each, so ROWS=1 leaves the warp with ONE load in flight and then five
+// shuffle steps in which 31 of 32 lanes discard their result. The table is already L2-resident
+// (71 MB in 96 MB), so 71 MB at L2 rate is a ~20 us floor against ~145 us measured -- this kernel
+// is latency-bound, not bandwidth-bound, and the fix is memory-level parallelism rather than fewer
+// bytes. ROWS consecutive rows are ROWS*256 CONTIGUOUS bytes, so the wider load stays perfectly
+// coalesced. Same knob as the NR/ROWS/MFIXED family elsewhere in this tree.
+template <int RANK, int ROWS>
 __global__ void k_markov_bias_add_warp_q8(const bf16* __restrict__ w1,
                                           const signed char* __restrict__ w2q,
                                           const float* __restrict__ w2s,
@@ -1661,26 +1668,44 @@ __global__ void k_markov_bias_add_warp_q8(const bf16* __restrict__ w1,
     if (out_latent && blockIdx.x == 0)
         for (int r = threadIdx.x; r < RANK; r += blockDim.x) out_latent[r] = latent[r];
     const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
-    const int v = blockIdx.x * (int)(blockDim.x >> 5) + warp;
-    if (v >= vocab) return;
-    const signed char* row = w2q + (size_t)v * RANK;
-    const float* rsc = w2s + (size_t)v * NSC;
-    float acc = 0.f;
+    const int v0 = (blockIdx.x * (int)(blockDim.x >> 5) + warp) * ROWS;
+    if (v0 >= vocab) return;
+    // Issue every row's load before reducing any of them: the reductions are what serialise, so
+    // the loads have to be in flight across all ROWS first for this to buy anything.
+    int2 raw[ROWS][PER_LANE];
+    float sc[ROWS][PER_LANE];
     #pragma unroll
-    for (int p = 0; p < PER_LANE; p++) {
-        const int base = (p * 32 + lane) * VEC;
-        const int2 raw = *reinterpret_cast<const int2*>(row + base);
-        const signed char* wv = reinterpret_cast<const signed char*>(&raw);
-        // VEC == 8 keeps every lane's slice inside one 32-wide scale block.
-        const float sc = rsc[base >> 5];
-        float part = 0.f;
+    for (int r = 0; r < ROWS; r++) {
+        const int v = v0 + r;
+        if (ROWS > 1 && v >= vocab) break;
+        const signed char* row = w2q + (size_t)v * RANK;
+        const float* rsc = w2s + (size_t)v * NSC;
         #pragma unroll
-        for (int i = 0; i < VEC; i++) part += latent[base + i] * (float)wv[i];
-        acc += part * sc;
+        for (int p = 0; p < PER_LANE; p++) {
+            const int base = (p * 32 + lane) * VEC;
+            raw[r][p] = *reinterpret_cast<const int2*>(row + base);
+            // VEC == 8 keeps every lane's slice inside one 32-wide scale block.
+            sc[r][p] = rsc[base >> 5];
+        }
     }
     #pragma unroll
-    for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
-    if (lane == 0) logits[v] += acc;
+    for (int r = 0; r < ROWS; r++) {
+        const int v = v0 + r;
+        if (ROWS > 1 && v >= vocab) break;
+        float acc = 0.f;
+        #pragma unroll
+        for (int p = 0; p < PER_LANE; p++) {
+            const int base = (p * 32 + lane) * VEC;
+            const signed char* wv = reinterpret_cast<const signed char*>(&raw[r][p]);
+            float part = 0.f;
+            #pragma unroll
+            for (int i = 0; i < VEC; i++) part += latent[base + i] * (float)wv[i];
+            acc += part * sc[r][p];
+        }
+        #pragma unroll
+        for (int m = 16; m > 0; m >>= 1) acc += __shfl_xor_sync(0xffffffffu, acc, m);
+        if (lane == 0) logits[v] += acc;
+    }
 }
 
 // confidence_logit = dot(hidden[H], w[0:H]) + dot(latent[rank], w[H:H+rank]) + bias -- a single
@@ -1725,9 +1750,26 @@ void launch_markov_bias_add_q8(const void* w1, const void* w2q, const float* w2s
                                cudaStream_t stream, float* out_latent) {
     if (vocab <= 0 || rank != 256 || !w2q || !w2s) return;
     const int threads = 256, warps_per_block = threads / 32;
-    const int blocks_w = (vocab + warps_per_block - 1) / warps_per_block;
-    k_markov_bias_add_warp_q8<256><<<blocks_w, threads, 0, stream>>>(
-        (const bf16*)w1, (const signed char*)w2q, w2s, prev_token, logits, vocab, out_latent);
+    // Rows per warp. 1 is the pre-existing kernel exactly, so both arms of the A/B come out of one
+    // binary the way the NR and MFIXED toggles beside them do.
+    // Measured at proposal depth 7 (PLAN=0, so draft ms is the only thing moving), draft ms:
+    //     ROWS=1  3.199 / 3.200      ROWS=2  3.106 / 3.107      ROWS=4  3.139 / 3.139
+    // 2 wins; the curve turns back up by 4, so this is not "more is better". ROWS=8 is deliberately
+    // NOT offered: its arm produced no output at all in the sweep and the cause was never found, so
+    // it is unmeasured, and an unmeasured path should not be selectable.
+    static const int mrows = []{ const char* e = getenv("SPARKINFER_DFLASH_MARKOV_ROWS");
+                                 const int v = e ? atoi(e) : 2;
+                                 return (v == 1 || v == 2 || v == 4) ? v : 2; }();
+#define SI_MARKOV_Q8(R_) do { \
+        constexpr int R = (R_); \
+        const int blocks_w = (vocab + warps_per_block * R - 1) / (warps_per_block * R); \
+        k_markov_bias_add_warp_q8<256, R><<<blocks_w, threads, 0, stream>>>( \
+            (const bf16*)w1, (const signed char*)w2q, w2s, prev_token, logits, vocab, out_latent); \
+    } while (0)
+    if (mrows == 1)      SI_MARKOV_Q8(1);
+    else if (mrows == 4) SI_MARKOV_Q8(4);
+    else                 SI_MARKOV_Q8(2);
+#undef SI_MARKOV_Q8
 }
 
 void launch_markov_bias_add(const void* w1, const void* w2, const int* prev_token,

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -444,11 +444,16 @@ struct DFlashDraftModel::Impl {
         logits = alloc<float>((size_t)B * std::max(cfg.vocab, 1));
         head_q8 = alloc<char>((size_t)B * kernels::llama_q8_1_bytes(H));
         d_ids = alloc<int>(B);
-        d_out = alloc<int>(B);
-        cu(cudaHostAlloc(&h_out, B * sizeof(int), cudaHostAllocDefault), "h_out");
+        // Proposal-indexed, not row-indexed. Under the row-shift mapping the chain writes
+        // d_out[r] / d_confidence[r] for r = 1..kProposalDepth, and a block_size-wide block
+        // backs kProposalDepth == B -- so index B is live and these need B+1 slots. d_ids stays
+        // at B: it holds the block's input ids, one per row.
+        d_out = alloc<int>(B + 1);
+        cu(cudaHostAlloc(&h_out, (B + 1) * sizeof(int), cudaHostAllocDefault), "h_out");
         if (confidence_w) {
-            d_confidence = alloc<float>(B);
-            cu(cudaHostAlloc(&h_confidence, B * sizeof(float), cudaHostAllocDefault), "h_confidence");
+            d_confidence = alloc<float>(B + 1);
+            cu(cudaHostAlloc(&h_confidence, (B + 1) * sizeof(float), cudaHostAllocDefault),
+               "h_confidence");
         }
 
         k_cache.resize(cfg.n_layers);
@@ -609,6 +614,7 @@ void DFlashDraftModel::set_shared_weights(const void* embed, const void* lm_head
 }
 
 void DFlashDraftModel::reset() { p_->seq_len = 0; }
+
 
 void DFlashDraftModel::crop(int keep) {
     if (keep < 0) keep = 0;
@@ -984,8 +990,12 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         int v = e ? atoi(e) : 5;
         return v < 1 ? 1 : (v > 15 ? 15 : v);
     }();
-    const int kProposalDepth = proposals > 0 ? (proposals > 15 ? 15 : proposals)
-                                             : kProposalDepthDefault;
+    // Also clamped to block_size: proposal r reads block row r-1 (or r without the row shift),
+    // so a block can never back more proposals than it has rows. Without this a checkpoint whose
+    // block_size is below the requested depth reads uninitialised argmax rows as proposals.
+    const int kProposalDepth = std::min(c.block_size,
+                                        proposals > 0 ? (proposals > 15 ? 15 : proposals)
+                                                      : kProposalDepthDefault);
     // Active diffusion width. Only rows 0..kProposalDepth are ever consumed (row 0 is the seed,
     // 1..kProposalDepth the scored proposals), yet the backbone was run at the checkpoint's full
     // block_size=16 — 12 of every 16 rows computed and discarded. The block's attention is
@@ -1019,6 +1029,13 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // 2.5 ms -> 9.9 ms. Widths 5/6/7 are instantiated now (see dflash_kernels.cu), so the
         // clamp lands on a batched width. This matters most at ctx >= SPARKINFER_DFLASH_DEEP_MIN_SEQ,
         // where the ladder in qwen35.cpp selects depth 7 and therefore width 7 on every block.
+        // DO NOT narrow this to depth+1. Tried it: at proposal depth 4 it takes the block from
+        // 7 rows to 5 and saves ~0.13 ms of draft, and it LOSES more than that in acceptance --
+        // 125.0920 tok/s at tau 1.8824 with the rounding below, against 124.2785 / 1.8551 with an
+        // exact width, measured on one binary with the arms alternated. The block's attention is
+        // bidirectional, so mask rows the verifier never reads are still trained CONTEXT for the
+        // rows it does read; the comment above about the two-row tier is the same effect at the
+        // other end, and the ceiling is not free either.
         const int w = v <= 2 ? 2 : (v <= 4 ? 4 : (v <= 8 ? 8 : 16));
         return w > c.block_size ? c.block_size : w;
     }();

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3205,7 +3205,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // deferring them is the branch above: a generation that takes the autoregressive path returns
     // before this line and never materialises them at all.
     draft.ensure_quant();
-    set_dflash_capture(true, dc.target_layer_ids, B);
+    // B + 1 rows, not B: the verify submits vn = kProposalDepth + 1 rows and captures a target
+    // hidden state for each, so a full-block plan captures row B. k_capture_row guards on
+    // max_rows, so sizing this at B did not corrupt memory -- it silently DROPPED the last
+    // row, handing the next draft block a stale hidden state precisely when everything was
+    // accepted, which is the case a full-depth plan is trying to produce.
+    set_dflash_capture(true, dc.target_layer_ids, B + 1);
 
     const int budget = session_token_budget(prompt.size(), max_new + B, s.cfg.max_seq);
     clear_prefix_cache();
@@ -3246,7 +3251,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     const void* target_hidden = dflash_context_buffer();
     int th_len = n;
 
-    std::vector<int> block(B), posterior(B), draft_ids(B);
+    // Depth-indexed buffers. With the SGLang row-shift mapping (dflash_draft.cpp), block row
+    // r-1 backs proposal r, so a block_size-wide block backs proposals 1..B -- and block[],
+    // posterior[] and draft_ids[] are every one of them indexed at B. Sized B alone, drafting
+    // the full block wrote one past the end of all three; draft_confidence already had the
+    // extra slot, which is why the overflow never showed up as a confidence bug.
+    std::vector<int> block(B + 1), posterior(B + 1), draft_ids(B + 1);
     std::vector<float> draft_confidence(B + 1, 0.f);
     // Proposal depth (also sets the draft's active diffusion width, depth+1). 5 is the measured
     // optimum at short context: accept length rises only 5.33 -> 5.95 -> 6.43 going to depth 6 and
@@ -3303,8 +3313,22 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // every proposal that block already computes. Depth 4 needs a 5-wide block, which rounds to
     // the checkpoint's block_size of 7 -- a width the draft's batched GEMV is not instantiated
     // for -- so the draft falls onto its per-token loop and costs 9.92 ms instead of 2.52.
-    const int kProposalDepth = kProposalDepthEnv > 0 ? kProposalDepthEnv
-                             : ((n + max_new) >= kDeepMinSeq ? 7 : 3);
+    // Clamp to block_size: the draft can only back as many proposals as its block has rows
+    // (row r-1 -> proposal r), so asking for more than B silently indexes past every
+    // depth-sized buffer above and reads stale argmax rows.
+    // Short-context depth is 4, not 3. The draft proposes a token per block row and the verify
+    // planner then prices each row against its own measured width cost, so the depth only has to
+    // be deep enough that the planner has a row left to buy when the draft is confident. Measured
+    // at ctx 4096, same binary, arms alternated and repeated (tok/s):
+    //     depth 3 (main)  119.8543 / 119.8760      depth 4  124.7007 / 124.4120
+    //     depth 5         123.2482 / 123.4245      depth 6  121.6701 / 121.6861
+    //     depth 7         117.0281
+    // Past 4 the extra proposal costs a block row of draft (~0.14 ms through 5 layers) plus a
+    // wider bootstrap walk, and buys nothing: uncensored acceptance -- planner disabled so every
+    // proposal reaches the target -- saturates at depth 6, where depth 6 and depth 7 return an
+    // IDENTICAL tau of 1.9692 over 65 steps.
+    const int kProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
+                             : ((n + max_new) >= kDeepMinSeq ? 7 : 4));
 
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN


### PR DESCRIPTION
## Summary

Raise the short-context proposal depth from 3 to 4, and instantiate the three kernels that depth
walks into. The verify planner already prices each row against its own measured cost, so a deeper
draft only spends where the planner buys: it plans 3.250 rows of 5 against 3.041 of 4, and mean
accept goes 1.7297 -> 1.8824.

The kernel fixes are enablers, not independent wins — all three together at depth 3 measure +0.03%.
They matter only because depth 4 puts the draft head at M=4 and the block at a width nothing was
instantiated for.

- `si_mmvq_q4k_multirow` had exact instantiations at M=3 and M=6 only, so M=4 ran the MMAX=16 form:
  sixteen predicated rows at 56-60 registers against 39-40. Instantiated exactly for M=1..8.
- The Markov bias kernel gave each warp one vocabulary row — a single 256-byte load, then a
  five-step shuffle reduction in which 31 of 32 lanes discard their result. The table is already
  L2-resident, so this is latency rather than bandwidth; two rows per warp puts two loads in flight.
- Drafting at a depth the block can only just back wrote past six proposal-indexed buffers, never
  clamped depth to `block_size`, and sized the target-hidden capture at `B` rows for a `B+1`-row
  verify. That last one has a bounds guard, so it dropped the row silently while `th_len = keep`
  still read one row past the allocation.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark-decode@4k`, the scored dimension, `runtime/examples/dspark_tau_check` on
the same prompt and 4096-id truncation the bot uses):

| | decode tok/s |
|---|--:|
| before (main) | 120.08 |
| after (this PR) | 125.18 |

**Prefill pp tok/s**

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090, Qwen3.8-27B NVFP4 + released DSpark draft, ctx=4096, max_new=128, SPEC-REPS 3,
clocks pinned. Baseline and candidate come out of ONE binary (baseline = every switch this
PR adds turned off), arms alternated, three repeats each.

before  120.0821 / 120.0936 / 120.0765   mean 120.084   tau 1.7297  draft 2.20 ms  plan 3.041/4
after   125.2120 / 125.1688 / 125.1559   mean 125.179   tau 1.8824  draft 2.61 ms  plan 3.26/5
                                                                                   = 1.042x
lossless 6/6 on every run; AR leg 90.38 tok/s on all arms.

An earlier run of the same arms on the identical tree gave 119.917 -> 125.076 (1.043x), so the
ratio reproduces across sessions as well as across repeats.

Depth, measured at the same width so the two are not confounded:
  depth 3  120.1792      depth 4  125.076      depth 5  121.8012

Attribution, each switch turned off against the full candidate at depth 4:
  head MFIXED off    122.8150   (+1.20% for the fix)
  markov rows off    124.0255   (+0.21%)
  all kernel fixes on but depth left at 3:  120.1190 against main's 120.087  -> +0.03%

Uncensored acceptance (planner disabled, so every proposal reaches the target and the accept
count is bounded by the draft rather than the plan):
  depth 3  1.7534   depth 4  1.9104   depth 5  1.9394   depth 6  1.9692   depth 7  1.9692
Depth 6 and 7 are identical, so proposals past 6 never land; 4 is where the marginal row still
repays its own verify time.

Kernel-level, each with a control at a row count the dispatch already handled:
  si_mmvq_q4k_multirow exact M=1..8
    depth 4  draft 2.942 -> 2.760 ms    depth 5  draft 3.110 -> 2.905 ms
    depth 6  draft 3.043 -> 3.032 ms    <- control: M=6 was already exact, and does not move
  Markov bias rows per warp, depth 7 draft: 1 -> 3.199/3.200 ms, 2 -> 3.106/3.107, 4 -> 3.139/3.139
```