### PR TITLE
perf(dspark): cut the draft's per-block bytes and its KV re-reads (1.039x dspark-decode@4k)

### DIFF
--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1311,7 +1311,28 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
         // Row-batched + KV-split path. Needs the caller's partial-state scratch; without it
         // (or below the sweep's crossover) fall through to the single-CTA-per-row kernel.
         if (fa_m && fa_l && fa_acc && attn_gqa_split_path_ok(q_len, kv_len, n_q, n_kv, d)) {
-            constexpr int ROWS = 2, NWARPS = 8;
+            constexpr int NWARPS = 8;
+            // QUERY ROWS PER CTA. The grid is (ceil(q_len/ROWS), n_q, n_splits) and the kv head is
+            // derived per q head, so each K/V byte is re-read (n_q/n_kv) x ceil(q_len/ROWS) times.
+            // On Qwen3.8's DSpark draft that is 5 x ceil(q_len/ROWS): at #913's block width of 7
+            // and ROWS=2 it is FOUR row groups, so 20 reads of every key. The draft's per-layer KV
+            // is ~17 MB at ctx 4k, small enough to sit in L2, which is why this shows up as
+            // ~139 GB/s of "DRAM" and 0.60 ms a block -- 29% of the whole draft -- rather than as
+            // a bandwidth wall. Widening the row tile is the only knob here that removes reads
+            // rather than moving them: ROWS >= q_len collapses the row groups to one.
+            // ROWS 2 -> 4 is on record as a REGRESSION, but that was measured when the block was
+            // 4 wide, where it was 2 row groups -> 1 and halved the grid. At #913's width of 7 it
+            // is 4 groups -> 1 and the trade is different, so it was re-derived rather than
+            // inherited. Measured at ctx 4096, K=65536, one binary, draft ms/block:
+            //     ROWS 2 -> 2.070    ROWS 4 -> 2.001    ROWS 8 -> 1.955
+            // Monotone, so the old note does not hold at this width. 8 covers the whole block in
+            // one group; the epilogue already drops rows past q_len, so the overhang is free.
+            // SPARKINFER_DFLASH_ATTN_ROWS pins it for an A/B out of one binary.
+            static const int rows_env = []{
+                const char* e = getenv("SPARKINFER_DFLASH_ATTN_ROWS");
+                int v = e ? atoi(e) : 8;
+                return (v == 2 || v == 4 || v == 8) ? v : 8;
+            }();
             const int n_splits_full = attn_gqa_splits(kv_len);
             // A sliding-window layer masks a key only after the kernel has loaded it and reduced
             // its QK dot, so past the window length it streams the whole cache to discard most of
@@ -1321,11 +1342,19 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
             // q_pos0 - k_pos0 - window is dead for the whole block: start the partition above it.
             const int kv_lo = attn_gqa_kv_lo(q_len, kv_len, n_q, n_kv, d, q_pos0, k_pos0, window);
             const int n_splits = kv_lo > 0 ? attn_gqa_splits(kv_len - kv_lo) : n_splits_full;
-            const size_t smem = (size_t)(2 * NWARPS * ROWS + NWARPS * ROWS * 128) * sizeof(float);
-            dim3 g((q_len + ROWS - 1) / ROWS, n_q, n_splits);
-            k_attn_rows_split_hd128<ROWS, NWARPS><<<g, NWARPS * 32, smem, stream>>>(
-                (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,
-                q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale, n_splits);
+#define SI_DF_ATTN_ROWS(R)                                                                    \
+            do {                                                                                  \
+                const size_t smem = (size_t)(2 * NWARPS * (R) + NWARPS * (R) * 128) * sizeof(float); \
+                dim3 g((q_len + (R) - 1) / (R), n_q, n_splits);                                   \
+                k_attn_rows_split_hd128<(R), NWARPS><<<g, NWARPS * 32, smem, stream>>>(           \
+                    (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,           \
+                    q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale,       \
+                    n_splits);                                                                    \
+            } while (0)
+            if (rows_env == 8)      SI_DF_ATTN_ROWS(8);
+            else if (rows_env == 4) SI_DF_ATTN_ROWS(4);
+            else                    SI_DF_ATTN_ROWS(2);
+#undef SI_DF_ATTN_ROWS
             k_attn_split_combine<<<dim3(q_len, n_q), 128, 0, stream>>>(
                 fa_m, fa_l, fa_acc, (bf16*)out, n_q, n_splits);
             return;

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1354,6 +1354,62 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // GEMV against the eagerly dequantized bf16 lm_head cache instead of a per-token
     // quantized GEMV loop.
     const int V = s.vocab > 0 ? s.vocab : c.vocab;
+    // DRAFT OUTPUT VOCABULARY (SPARKINFER_DFLASH_DRAFT_VOCAB, 0 = full).
+    //
+    // Everything downstream of the backbone is proportional to the vocabulary, and on Qwen3.8 that
+    // vocabulary is 248320. Per block the head streams the target's Q4_K LM head once (715 MB) and
+    // then the Markov chain re-reads w2 -- [248320, 256] int8 plus its per-32 scales, ~71 MB --
+    // ONCE PER PROPOSAL ROW, serially. Between them they are the two largest items in the draft,
+    // and #913 made that worse in the direction that matters here: at depth 4 the chain runs four
+    // rows, so the head moves 715 + 4 x 71 = ~1001 MB a block.
+    //
+    // Both are NOMINATION-only: a token this head cannot score is simply never proposed, which
+    // costs at most one acceptance and can never change what is emitted, because every emitted
+    // token is still a target argmax over the FULL vocabulary. So the head may score a prefix.
+    //
+    // The rows are contiguous in both tables ([vocab, ...], row-major), so a prefix is just a
+    // smaller length -- no repack, no second copy, no extra VRAM. Qwen3.8's vocabulary has no
+    // reserved tail to reclaim (only 243 of the 248320 ids are undefined), but it IS
+    // frequency-ordered, and coverage plateaus hard. Fraction of tokens with id < K:
+    //
+    //     K        bench_prompt_4k   repo prose   repo C++     LM head   w2+scales
+    //     32768        92.61%          90.86%      93.77%        94 MB      9.4 MB
+    //     65536        97.53%          96.64%      97.92%       189 MB     18.7 MB
+    //     98304        99.95%          99.23%     100.00%       283 MB     28.1 MB
+    //    163840        99.95%          99.38%     100.00%       472 MB     46.8 MB
+    //
+    // Three unrelated corpora agree on the shape: the ids above ~100k are rare scripts and exotic
+    // unicode, not this text, and by 65536 the curve has already flattened to within 2.5% of it.
+    //
+    // 65536 is NOT the throughput peak. Swept end to end at ctx 4096, one binary, tok/s and mean
+    // accept, with the draft's own per-block cost:
+    //
+    //     K         DSPARK tok/s   draft ms/block   mean accept
+    //     248320      122.87           2.575          1.8286
+    //     131072      125.90           2.250          1.8286
+    //      98304      125.98           2.159          1.8286
+    //      65536      127.08           2.075          1.8286
+    //      49152      127.84           2.03           1.8286   <- peak
+    //      32768      125.90           1.99           1.8028
+    //      24576      126.42           1.96           1.8028
+    //      16384      125.00           1.94           1.7778
+    //
+    // Acceptance is flat down to 49152 and turns over below it: at 32768 the generation needs an
+    // extra step (128 tokens in 71 instead of 70), which is what mean accept 1.8286 -> 1.8028 is.
+    // So 49152 sits ONE step from that edge, and its 0.6% advantage over 65536 was found by
+    // walking the prompt this benchmark scores. 65536 is taken off the coverage curve instead --
+    // the one three unrelated corpora agree on -- and keeps a full step of margin. Giving up 0.6%
+    // is the right side to err on for a change whose entire safety argument is coverage.
+    //
+    // The Markov head's OTHER table, w1, is indexed by the PREVIOUS token and is not pruned: the
+    // conditioning still accepts any target token, only the output side is narrowed.
+    static const int kDraftVocab = []{
+        const char* e = getenv("SPARKINFER_DFLASH_DRAFT_VOCAB");
+        return e ? atoi(e) : 65536;
+    }();
+    // Vd is the logits ROW STRIDE as well as the length: the multi-row head writes y[m*N + n], so
+    // the stride has to travel with it or the Markov chain reads the wrong row.
+    const int Vd = (kDraftVocab > 0 && kDraftVocab < V) ? kDraftVocab : V;
     // The batched bf16 head (#661) still streams the DEQUANTIZED head every step: at V=248k,
     // K=2048 that is ~1.0 GB per pass versus ~416 MB for the native Q6_K bytes, and it pins ~1 GB
     // of VRAM for the bf16 cache. Prefer a multi-row Q6_K MMVQ that keeps the head quantized: each
@@ -1390,31 +1446,31 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         if (s.lm_head_type == 12 && s.lm_head_i4)
             head_done = kernels::launch_gemv_i4_q81_multirow_f32(
                 s.head_q8, s.lm_head_i4, s.lm_head_i4_scale,
-                s.logits + (size_t)head_row0 * V, V, H, kProposalDepth, st);
+                s.logits + (size_t)head_row0 * Vd, Vd, H, kProposalDepth, st);
         else if (s.lm_head_type == 12 && head_i8 && s.lm_head_i8)
             head_done = kernels::launch_gemv_i8_q81_multirow_f32(
                 s.head_q8, s.lm_head_i8, s.lm_head_i8_scale,
-                s.logits + (size_t)head_row0 * V, V, H, kProposalDepth, st);
+                s.logits + (size_t)head_row0 * Vd, Vd, H, kProposalDepth, st);
         else if (s.lm_head_type == 12)
             head_done = kernels::launch_gemv_q4k_dp4a_multirow_f32(
-                s.head_q8, s.lm_head, s.logits + (size_t)head_row0 * V,
-                V, H, kProposalDepth, st);
+                s.head_q8, s.lm_head, s.logits + (size_t)head_row0 * Vd,
+                Vd, H, kProposalDepth, st);
         else
             head_done = kernels::launch_gemv_q6k_dp4a_multirow_f32(
-                s.head_q8, s.lm_head, s.logits + (size_t)head_row0 * V,
-                V, H, kProposalDepth, st);
+                s.head_q8, s.lm_head, s.logits + (size_t)head_row0 * Vd,
+                Vd, H, kProposalDepth, st);
     }
     if (!head_done) {
     if (BW == 16) {
-        dflash_kernels::launch_gemv_batched16_f32(s.xn, s.lm_head_bf16, s.logits, V, H, st);
+        dflash_kernels::launch_gemv_batched16_f32(s.xn, s.lm_head_bf16, s.logits, Vd, H, st);
     } else {
         for (int t = 0; t < B; t++) {
             const bf16* row = s.xn + (size_t)t * H;
-            float* logit_row = s.logits + (size_t)t * V;
+            float* logit_row = s.logits + (size_t)t * Vd;
             if (s.lm_head_type)
-                kernels::launch_gemv_q_f32(row, s.lm_head, s.lm_head_type, logit_row, V, H, st);
+                kernels::launch_gemv_q_f32(row, s.lm_head, s.lm_head_type, logit_row, Vd, H, st);
             else
-                kernels::launch_gemv_f32(row, s.lm_head, logit_row, V, H, st);
+                kernels::launch_gemv_f32(row, s.lm_head, logit_row, Vd, H, st);
         }
     }
     }
@@ -1476,19 +1532,19 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // That is consistent with the symptom: tau lands well above 1.0 because the Markov bias,
         // conditioned correctly, partially compensates for the wrong base row -- but it is capped,
         // and deeper drafting buys nothing because every position is displaced.
-        if (!head_done) kernels::launch_argmax(s.logits, s.d_out, 1, V, st);
+        if (!head_done) kernels::launch_argmax(s.logits, s.d_out, 1, Vd, st);
         for (int r = 1; r <= kProposalDepth; r++) {
             const int* prev = (r == 1) ? s.d_ids : (s.d_out + (r - 1));
             const size_t row = (size_t)(kRowShift ? r - 1 : r);
             if (s.markov_w2_q)
                 dflash_kernels::launch_markov_bias_add_q8(
                     s.markov_w1, s.markov_w2_q, s.markov_w2_s, prev,
-                    s.logits + row * V, V, s.markov_rank, st,
+                    s.logits + row * Vd, Vd, s.markov_rank, st,
                     s.confidence_w ? s.markov_latent : nullptr);
             else
                 dflash_kernels::launch_markov_bias_add(
                     s.markov_w1, s.markov_w2, prev,
-                    s.logits + row * V, V, s.markov_rank, st,
+                    s.logits + row * Vd, Vd, s.markov_rank, st,
                     s.confidence_w ? s.markov_latent : nullptr);
             // Confidence head (optional): reads THIS row's hidden state + the Markov latent the
             // bias call above just wrote, predicting how likely this row's (about to be computed)
@@ -1498,12 +1554,12 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                 dflash_kernels::launch_confidence_head(s.xn + row * H, s.markov_latent,
                                                        s.confidence_w, s.confidence_bias, H,
                                                        s.markov_rank, s.d_confidence + r, st);
-            kernels::launch_argmax(s.logits + row * V, s.d_out + r, 1, V, st);
+            kernels::launch_argmax(s.logits + row * Vd, s.d_out + r, 1, Vd, st);
         }
     } else {
-        kernels::launch_argmax(s.logits + (size_t)(head_done ? head_row0 : 0) * V,
+        kernels::launch_argmax(s.logits + (size_t)(head_done ? head_row0 : 0) * Vd,
                                s.d_out + (head_done ? 1 : 0),
-                               head_done ? kProposalDepth : B, V, st);
+                               head_done ? kProposalDepth : B, Vd, st);
     }
     if (head_done)
         cu(cudaMemcpyAsync(s.h_out + 1, s.d_out + 1, kProposalDepth * sizeof(int),


### PR DESCRIPTION
## Summary

Two changes to the DSpark drafter, both found by profiling the decode loop with
`nsys --cuda-graph-trace=node`. The draft block was 17.3% of the step at ctx 4096 and cost
2.575 ms; it now costs 1.953 ms, for `dspark-decode@4k` 122.790 -> 127.632 = **1.039x**.

- **The draft nominates over a vocabulary prefix.** Everything downstream of the draft backbone is
  proportional to the vocabulary, and on Qwen3.8 that is 248320. Per block the head streams the
  target's Q4_K LM head once (715 MB) and then the Markov chain re-reads `w2` — `[248320, 256]`
  int8 plus per-32 scales, ~71 MB — *once per proposal row, serially*. #913's depth 4 makes that
  four rows: 715 + 4 x 71 = ~1001 MB of a ~1.4 GB block. Both tables are nomination-only, so a
  token the head cannot score is simply never proposed: it costs at most one acceptance and can
  never change what is emitted, because every emitted token is still a target argmax over the FULL
  vocabulary. Both are row-major `[vocab, ...]`, so a prefix is one smaller length — no repack, no
  second copy, no extra VRAM. `w1` is indexed by the PREVIOUS token and is not pruned, so the
  conditioning still accepts any target token; only the output side narrows.
- **The draft's attention read its KV 20x per layer.** `k_attn_rows_split_hd128` grids as
  `(ceil(q_len/ROWS), n_q, n_splits)` and derives the kv head per q head, so every K/V byte is
  re-read `(n_q/n_kv) x ceil(q_len/ROWS)` times — 5 x 4 = 20 at #913's block width of 7 with
  ROWS=2. Its per-layer KV is only ~17 MB at ctx 4k, small enough to live in L2, which is why it
  showed up as 0.60 ms a block (29% of the draft) at an apparent ~139 GB/s rather than as a
  bandwidth wall. ROWS=8 collapses the four row groups to one.

Both stay A/B-able out of one binary: `SPARKINFER_DFLASH_DRAFT_VOCAB=0` restores the full
vocabulary, `SPARKINFER_DFLASH_ATTN_ROWS=2` the old row tile.

Implementation note: `si_mmvq_q4k_multirow` writes `y[m*N + n]`, so the pruned vocabulary length is
also the logits ROW STRIDE — it has to travel with the length or the Markov chain reads the wrong
row.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark-decode@4k`, the scored dimension, end-to-end via
`runtime/examples/dspark_tau_check` on the same prompt and 4096-id truncation the bot uses — not an
isolated-kernel microbenchmark):

| | decode tok/s |
|---|--:|
| before (main) | 122.790 |
| after (this PR) | 127.632 |

**Prefill pp tok/s** (this PR does not target prefill; the Qwen3.8 and Qwen3.6 @16k prefill
no-regression guards are in the block below):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090 (sm_120), 525 W cap. Qwen3.8-27B ModelOpt NVFP4 (rev 2ed84505) + the released DSpark
draft. ctx=4096, max_new=128. main = ebbaa69. Arms interleaved, THREE repeats each -- not two,
because the generation lands in either 70 or 71 steps depending on what the verify-width
planner's online cost model does, and that alone is ~1.4% of tok/s.

arm     DSPARK tok/s              AR tok/s                mean accept
main    122.865 122.631 122.875   94.588 94.413 94.399    1.8286 x3
PR      128.252 127.300 127.345   94.451 94.423 94.432    1.8286 1.8028 1.8028

  dspark-decode@4k   127.632 / 122.790 = 1.039x
  mean accept        1.8114 / 1.8286   = 0.991x   (floor 0.95)
  AR decode          94.436 /  94.467  = 1.000x   (floor 0.98)
  draft              2.579 -> 1.953 ms/block  (-24.3%)
  step              14.892 -> 14.192 ms

AR decode is flat across every arm, so this is bytes and re-reads off the draft, not throughput
bought by speculating less.

GATES
  LOSSLESS = 1 at SPARKINFER_DSPARK_SPEC_REPS=3, both arms
  differential accuracy vs main: top1 = 1.000000  kl = 0.000000  PPL 3.0198 both
      (the target path is bit-identical -- which is the point: the draft only nominates)
  qwen3.8   @16k guard: decode 92.32  vs 92.23    prefill 12564.8 vs 12506.3
  qwen3.6   @16k guard: decode 469.76 vs 469.11   prefill 27661.5 vs 27589.7
  both guards land slightly ahead of main.

VOCABULARY PREFIX -- coverage, share of tokens with id < K, three unrelated corpora
  K         bench_prompt_4k   repo prose   repo C++
  32768         92.61%          90.86%      93.77%
  65536         97.53%          96.64%      97.92%
  98304         99.95%          99.23%     100.00%
 163840         99.95%          99.38%     100.00%
Qwen3.8 has no reserved tail to reclaim -- only 243 of the 248320 ids are undefined -- but the
vocabulary is frequency-ordered and coverage plateaus just under 100k.

VOCABULARY PREFIX -- swept end to end, one binary (SPARKINFER_DFLASH_DRAFT_VOCAB)
  K         DSPARK tok/s   draft ms/block   mean accept
  248320      122.87           2.575          1.8286
  131072      125.90           2.250          1.8286
   98304      125.98           2.159          1.8286
   65536      127.08           2.075          1.8286   <- shipped
   49152      127.84           2.03           1.8286   <- peak
   32768      125.90           1.99           1.8028
   24576      126.42           1.96           1.8028
   16384      125.00           1.94           1.7778
Acceptance is flat down to 49152 and only turns over below it: at 32768 the generation needs a
71st step, which is what 1.8286 (128/70) -> 1.8028 (128/71) is.

Shipped 65536, NOT the 49152 peak. 49152 sits one step from that edge and its 0.6% advantage was
found by walking the prompt this benchmark scores; 65536 comes off the coverage curve that three
unrelated corpora agree on and keeps a full step of margin. For a change whose entire safety
argument is coverage, that is the side to err on.

ATTENTION ROW TILE -- draft ms/block, one binary (SPARKINFER_DFLASH_ATTN_ROWS), K=65536
  ROWS 2 -> 2.070    ROWS 4 -> 2.001    ROWS 8 -> 1.955
Monotone. ROWS 2 -> 4 is on record in this repo as a REGRESSION, but that was measured when the
block was 4 wide, where it is 2 row groups -> 1 and halves the grid; at #913's width of 7 it is
4 -> 1 and the trade is different, so it was re-derived rather than inherited. ROWS=8 covers the
whole block in one group and the kernel epilogue already does `if (qt >= q_len) continue;`, so the
overhang is free. smem is 32.5 KB at ROWS=8, under the 48 KB default.

PROFILE (nsys --cuda-graph-trace=node; without it the batched verify is ONE opaque graph node)
main step 14.891 ms = batched verify 12.317 (82.7%) + draft 2.575 (17.3%)
  verify = C0 9.707 + c1 0.801 x 3.257 rows; per-width, PLAN=0: w2 11.285 ms, w3 12.119 ms
per-kernel groups, ms/step (nsys-inflated ~8%):
  NVFP4 dp4a2 gate+up (paired)   4.176   1517 GB/s
  NVFP4 dp4a S=4                 3.871   ~1300-1365 GB/s
  NVFP4 dp4a S=2                 1.506
  verify LM head rows_exact      0.702   1019 GB/s
  draft backbone fused3_q4_ks    0.630
  DRAFT ATTENTION                0.603    139 GB/s   <- fixed here
  verify attention fa_split_gqa  0.548
  gdn scan+conv checkpoint       0.471
  add_rmsnorm2_q8 (128/step)     0.316
  nvfp4 quant_x (192/step)       0.243
  draft LM head multirow         0.134   1410 GB/s   <- shrunk here

MEASURED AND NOT TAKEN
- Covering the verify's 5-row attention fold. #913 makes width 5 the widest plan a short-context
  verify can ask for, and the GQA-6 fold takes the narrowest width that divides the row count
  exactly -- nothing, for 5 -- so it stages the whole KV five times. Covering 5 as 2+3 measured
  122.72 against main's 122.87, i.e. nothing: the planner reaches width 5 too rarely to pay.
- CUDA-graphing the draft block. Total kernel time 1036 ms against a decode wall of 1073 ms over
  70 steps = 96.5% GPU-busy. The draft is not launch-bound, whatever the comment in
  dflash_draft.cpp says, so a graph capture cannot buy more than ~0.5 ms and realistically far
  less.

WHAT THIS DOES NOT DO
+3.9% is not a tier win and I do not think a tier is available on this axis. The same profile puts
the NVFP4 weight GEMVs at 63% of the step and, corrected for nsys overhead, within ~4% of their
byte floor; C0 alone is 65%. After these two changes the draft is down to 13.8% of the step. The
largest remaining single item is the verify's LM head at 1019 GB/s, and that is blocked by design:
si_mmvq_q4k_rows_exact exists to reproduce AR decode's single-row reduction order bit-for-bit,
which is what keeps the speculative path lossless by construction, and AR's own kernel is faster
than both alternatives -- so there is nothing faster to unify on.
```
