### PR TITLE
perf(dspark): delete the verify's activation-quantize nodes and shorten the draft attention chain

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -806,15 +806,94 @@ __global__ void df_gdn_conv_checkpoint_kernel(
     }
 }
 
+// TOKEN-PARALLEL form of df_gdn_conv_checkpoint_kernel.
+//
+// The causal conv is an FIR filter, not a recurrence: y[tok] depends only on the conv_kernel
+// inputs at positions tok-conv_kernel+1..tok, all of which are already in `qkv` (or, for negative
+// positions, in the seeded decode state). The kernel above nevertheless walks the tokens SERIALLY
+// so it can carry `hist` in registers, and pays for it twice -- the whole per-token chain
+// (including two or three block barriers for the q/k norm) is serialised, and the grid is only
+// 2*q_heads + v_heads = 80 CTAs, so 90 of this box's 170 SMs sit idle for the 4.3 us it takes.
+//
+// Reconstructing the window per token from memory costs conv_kernel-1 extra loads (they are the
+// same cache lines the neighbouring CTAs read) and gives grid.y = n_tokens.
+//
+// BIT-IDENTICAL to the serial kernel: the same taps in the same ascending order, the current
+// token's tap last -- the order the single-token decode conv uses, which is what keeps the batched
+// verify reproducing AR (see the serial kernel's own comment on #712) -- and the same block
+// reduction for the q/k norm.
+template <bool WRITE_CHECKPOINT>
+__global__ void df_gdn_conv_par_kernel(
+    const __nv_bfloat16* __restrict__ qkv, const __nv_bfloat16* __restrict__ conv_w,
+    const __nv_bfloat16* __restrict__ live_state, __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ v,
+    __nv_bfloat16* __restrict__ checkpoints, int n_tokens, int q_heads, int v_heads,
+    int head_dim, int qkv_dim, int conv_kernel, float eps) {
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int blk = blockIdx.x, tok = blockIdx.y, t = threadIdx.x;
+    int d, out_dim, hh; __nv_bfloat16* out; bool do_norm;
+    if (blk < q_heads) { hh = blk; d = hh * head_dim + t; out = q; out_dim = q_dim; do_norm = true; }
+    else if (blk < 2 * q_heads) { hh = blk - q_heads; d = q_dim + hh * head_dim + t; out = k; out_dim = q_dim; do_norm = true; }
+    else { hh = blk - 2 * q_heads; d = 2 * q_dim + hh * head_dim + t; out = v; out_dim = v_dim; do_norm = false; }
+    float w[8], hist[7];
+#pragma unroll
+    for (int c = 0; c < 8; c++) w[c] = c < conv_kernel ? pf_to_f(conv_w[(size_t)d * conv_kernel + c]) : 0.f;
+    // Window entering token `tok`: tap c is input position tok - (conv_kernel-1) + c. A negative
+    // position is decode state, and its live_state row is that position + (conv_kernel-1) = tok+c.
+#pragma unroll
+    for (int c = 0; c < 7; c++) {
+        if (c >= conv_kernel - 1) { hist[c] = 0.f; continue; }
+        const int p = tok - (conv_kernel - 1) + c;
+        hist[c] = p >= 0 ? pf_to_f(qkv[(size_t)p * qkv_dim + d])
+                         : pf_to_f(live_state[(size_t)(tok + c) * qkv_dim + d]);
+    }
+    const float cur = pf_to_f(qkv[(size_t)tok * qkv_dim + d]);
+    float y = 0.f;
+#pragma unroll
+    for (int c = 0; c < 7; c++) if (c < conv_kernel - 1) y += hist[c] * w[c];
+    y += cur * w[conv_kernel - 1];
+    float cval = pf_silu(y);
+    __shared__ float sw[32];
+    const int nwarp = (blockDim.x + 31) / 32;
+    if (do_norm) {
+        float ss = pf_wsum(cval * cval);
+        if ((t & 31) == 0) sw[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = t < nwarp ? sw[t] : 0.f;
+            vv = pf_wsum(vv);
+            if (t == 0) sw[0] = rsqrtf(vv + eps);
+        }
+        __syncthreads();
+        cval *= sw[0];
+    }
+    out[(size_t)tok * out_dim + hh * head_dim + t] = __float2bfloat16(cval);
+    if constexpr (WRITE_CHECKPOINT) {
+        const size_t state_elems = (size_t)(conv_kernel - 1) * qkv_dim;
+        // Window LEAVING token `tok`: shifted one, with `cur` in the last slot.
+#pragma unroll
+        for (int c = 0; c < 7; c++) if (c < conv_kernel - 1)
+            checkpoints[(size_t)tok * state_elems + (size_t)c * qkv_dim + d] =
+                __float2bfloat16(c < conv_kernel - 2 ? hist[c + 1] : cur);
+    }
+}
+
 // ============================================================================
 // Batched gated RMSNorm: out = (x/rms(x)) * weight * silu(z), per (token, v_head).
 // One warp per (token, v_head). Mirrors gated_norm_warp_kernel.
 // ============================================================================
-template <int HEAD_DIM>
+// NV: also emit the NVFP4 activation form of `out`, which is exactly what the GDN out-projection
+// quantizes next -- one si_nvfp4_quant_x node per linear-attention layer, 48 a step at ~1.26 us
+// for ~40 KB of work. Bit-identical to that kernel run on `out`: the same bf16-rounded values, the
+// max over the same 16, and the same `amax * (1/127)` scale and `127/amax` inverse. A 16-group is
+// SIXTEEN LANES of one warp at a fixed r (lane l owns dim l + 32r), so one shuffle completes it.
+template <int HEAD_DIM, bool NV>
 __global__ void pf_gated_norm_kernel(const __nv_bfloat16* __restrict__ x,
                                      const __nv_bfloat16* __restrict__ z,
                                      const __nv_bfloat16* __restrict__ weight,
                                      __nv_bfloat16* __restrict__ out,
+                                     signed char* __restrict__ nv_q, float* __restrict__ nv_s,
                                      int n_tokens, int v_heads, float eps) {
     constexpr int NROW = HEAD_DIM / 32;
     const int h    = blockIdx.y;                    // v_head
@@ -835,7 +914,19 @@ __global__ void pf_gated_norm_kernel(const __nv_bfloat16* __restrict__ x,
     #pragma unroll
     for (int r = 0; r < NROW; r++) {
         const int d = lane + r * 32;
-        out[base + d] = __float2bfloat16(xv[r] * inv * wv[r] * pf_silu(zv[r]));
+        const __nv_bfloat16 ob = __float2bfloat16(xv[r] * inv * wv[r] * pf_silu(zv[r]));
+        out[base + d] = ob;
+        if (NV) {
+            const float f = __bfloat162float(ob);
+            float a16 = fabsf(f);
+            a16 = fmaxf(a16, __shfl_xor_sync(0xffffffffu, a16, 1));
+            a16 = fmaxf(a16, __shfl_xor_sync(0xffffffffu, a16, 2));
+            a16 = fmaxf(a16, __shfl_xor_sync(0xffffffffu, a16, 4));
+            a16 = fmaxf(a16, __shfl_xor_sync(0xffffffffu, a16, 8));
+            const float iq = a16 > 0.f ? 127.f / a16 : 0.f;
+            nv_q[base + d] = (signed char)__float2int_rn(f * iq);
+            if ((lane & 15) == 0) nv_s[(base >> 4) + (d >> 4)] = a16 * (1.f / 127.f);
+        }
     }
 }
 
@@ -1338,12 +1429,28 @@ void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
             qb, kb, vb, ab, bb, db, aa, state, ob, n_tokens, q_heads, v_heads, qh_block);
 }
 
+// SPARKINFER_GDN_CONV_PAR=0 keeps the serial-over-tokens kernel, for an A/B out of one binary.
+static inline bool df_gdn_conv_par() {
+    static const bool on = []{ const char* e = getenv("SPARKINFER_GDN_CONV_PAR");
+                               return !(e && e[0] == '0'); }();
+    return on;
+}
+
 void launch_dflash_gdn_conv(const void* qkv, const void* conv_w, const void* live_state,
                             void* q, void* k, void* v, void* checkpoints,
                             int n_tokens, int q_heads, int v_heads, int head_dim,
                             int conv_kernel, float eps, cudaStream_t stream) {
     if (n_tokens <= 0 || head_dim <= 0 || conv_kernel < 2 || conv_kernel > 8) return;
     const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
+    if (df_gdn_conv_par()) {
+        df_gdn_conv_par_kernel<true><<<dim3(2 * q_heads + v_heads, n_tokens), head_dim, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
+            reinterpret_cast<const __nv_bfloat16*>(live_state), reinterpret_cast<__nv_bfloat16*>(q),
+            reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
+            reinterpret_cast<__nv_bfloat16*>(checkpoints), n_tokens, q_heads, v_heads,
+            head_dim, qkv_dim, conv_kernel, eps);
+        return;
+    }
     df_gdn_conv_checkpoint_kernel<true><<<2 * q_heads + v_heads, head_dim, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
         reinterpret_cast<const __nv_bfloat16*>(live_state), reinterpret_cast<__nv_bfloat16*>(q),
@@ -1374,6 +1481,14 @@ void launch_dflash_gdn_conv_compact(const void* qkv, const void* conv_w,
                                     int conv_kernel, float eps, cudaStream_t stream) {
     if (n_tokens <= 0 || head_dim <= 0 || conv_kernel < 2 || conv_kernel > 8) return;
     const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
+    if (df_gdn_conv_par()) {
+        df_gdn_conv_par_kernel<false><<<dim3(2 * q_heads + v_heads, n_tokens), head_dim, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
+            reinterpret_cast<const __nv_bfloat16*>(live_state), reinterpret_cast<__nv_bfloat16*>(q),
+            reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v), nullptr,
+            n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps);
+        return;
+    }
     df_gdn_conv_checkpoint_kernel<false><<<2 * q_heads + v_heads, head_dim, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
         reinterpret_cast<const __nv_bfloat16*>(live_state), reinterpret_cast<__nv_bfloat16*>(q),
@@ -1431,7 +1546,25 @@ void launch_prefill_gated_norm(const void* x, const void* z, const void* weight,
     auto wb = reinterpret_cast<const __nv_bfloat16*>(weight);
     auto ob = reinterpret_cast<__nv_bfloat16*>(out);
     if (head_dim == 128)
-        pf_gated_norm_kernel<128><<<grid, 32, 0, stream>>>(xb, zb, wb, ob, n_tokens, v_heads, eps);
+        pf_gated_norm_kernel<128, false><<<grid, 32, 0, stream>>>(
+            xb, zb, wb, ob, nullptr, nullptr, n_tokens, v_heads, eps);
+}
+
+// Same, plus the NVFP4 activation form of `out` (int8 quants + one fp32 scale per 16), which is
+// what the GDN out-projection wants next. Bit-identical to launch_gemv_nvfp4_quant_x on `out`.
+// False (and nothing written) for a shape it cannot cover, so the caller keeps its own quantize.
+bool launch_prefill_gated_norm_nvfp4(const void* x, const void* z, const void* weight, void* out,
+                                     void* nv_q, void* nv_s,
+                                     int n_tokens, int v_heads, int head_dim, float eps,
+                                     cudaStream_t stream) {
+    if (!nv_q || !nv_s || head_dim != 128 || n_tokens <= 0 || v_heads <= 0) return false;
+    dim3 grid(n_tokens, v_heads);
+    pf_gated_norm_kernel<128, true><<<grid, 32, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(z),
+        reinterpret_cast<const __nv_bfloat16*>(weight), reinterpret_cast<__nv_bfloat16*>(out),
+        reinterpret_cast<signed char*>(nv_q), reinterpret_cast<float*>(nv_s),
+        n_tokens, v_heads, eps);
+    return true;
 }
 
 void launch_prefill_qknorm_rope_kv_int8(

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -177,12 +177,24 @@ __global__ void add_rmsnorm2_kernel(const __nv_bfloat16* __restrict__ x,
 // (blockDim*8 == cols), so each 32-element Q8_1 block maps to 4 consecutive threads. The Q8_1
 // is computed from the bf16-rounded out_norm, so it is bit-identical to running the standalone
 // quantizer on out_norm afterwards.
+//
+// NV: also emit the NVFP4 activation form (symmetric int8 with one fp32 scale per 16) that the
+// checkpoint-native FFN/projection GEMVs want. The verify issues one standalone
+// si_nvfp4_quant_x_kernel per norm output -- 128 of them a step at ~1.26 us, nearly all node ramp
+// for ~40 KB of work -- and every input it reads is a value this kernel already has in registers.
+// Bit-identical to that kernel on out_norm: same bf16-rounded values, max over the same 16, and
+// the same `amax * (1/127)` scale and `127/amax` inverse, in the same order. The 16-element group
+// is two ADJACENT threads (each owns 8 consecutive elements of the row) and blockDim is a multiple
+// of 16, so a group never straddles a warp -- one shuffle completes it.
+template <bool NV>
 __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
                                        const __nv_bfloat16* __restrict__ residual,
                                        const __nv_bfloat16* __restrict__ weight,
                                        __nv_bfloat16* __restrict__ out_sum,
                                        __nv_bfloat16* __restrict__ out_norm,
                                        si_blk_q8_1* __restrict__ out_q8,
+                                       signed char* __restrict__ nv_q,
+                                       float* __restrict__ nv_s,
                                        int cols, float eps) {
     const size_t base = (size_t)blockIdx.x * cols;
     __shared__ float s_warp[32];
@@ -192,7 +204,14 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     uint4* osum4 = reinterpret_cast<uint4*>(out_sum + base);
     out_q8 += (size_t)blockIdx.x * (cols >> 5);
 
-    float xv[8], rv[8]; rn_unpack8(__ldg(x4 + t), xv); rn_unpack8(__ldg(r4 + t), rv);
+    // The norm weight is issued WITH x and residual rather than after the block reduction. It
+    // never depended on the reduction, and at grid = rows (three or four CTAs for a verify block)
+    // there is no other work resident to hide a load started that late. Same values. On its own
+    // this was inside the run-to-run spread; it is here because it costs nothing and it is the
+    // same shape of fix as the register round-trip the comment below describes.
+    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
+    float xv[8], rv[8], wv[8];
+    rn_unpack8(__ldg(x4 + t), xv); rn_unpack8(__ldg(r4 + t), rv); rn_unpack8(__ldg(w4 + t), wv);
     float sv[8]; float ss = 0.f;
     #pragma unroll
     for (int j = 0; j < 8; j++) { sv[j] = xv[j] + rv[j]; ss = __fmaf_rn(sv[j], sv[j], ss); }
@@ -213,15 +232,26 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     // own, so the round trip only made each thread wait for its own store to become visible, and
     // at grid = rows (three or four CTAs for a verify block) there is nothing else resident to
     // hide that. Same values, so out_norm and the Q8_1 below are bit-identical either way.
-    const uint4* w4 = reinterpret_cast<const uint4*>(weight);
-    float svb[8], wv[8];
+    float svb[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) svb[j] = __bfloat162float(__float2bfloat16(sv[j]));
-    rn_unpack8(__ldg(w4 + t), wv);
     float ov[8], bv[8];
     #pragma unroll
     for (int j = 0; j < 8; j++) { ov[j] = svb[j] * inv_rms * wv[j]; bv[j] = __bfloat162float(__float2bfloat16(ov[j])); }
     reinterpret_cast<uint4*>(out_norm + base)[t] = rn_pack8(ov);
+
+    if (NV) {
+        float a16 = 0.f;
+        #pragma unroll
+        for (int j = 0; j < 8; j++) a16 = fmaxf(a16, fabsf(bv[j]));
+        a16 = fmaxf(a16, __shfl_xor_sync(0xffffffffu, a16, 1));
+        const float inv = a16 > 0.f ? 127.f / a16 : 0.f;
+        signed char nb[8];
+        #pragma unroll
+        for (int j = 0; j < 8; j++) nb[j] = (signed char)__float2int_rn(bv[j] * inv);
+        reinterpret_cast<uint2*>(nv_q + base)[t] = *reinterpret_cast<const uint2*>(nb);
+        if ((t & 1) == 0) nv_s[(base >> 4) + (t >> 1)] = a16 * (1.f / 127.f);
+    }
 
     // Q8_1 of the bf16-rounded out_norm. 32-block = 4 consecutive threads (t&~3 .. +3).
     float amax = 0.f;
@@ -818,13 +848,13 @@ void launch_add_rmsnorm2_q8(const void* x, const void* residual, const void* wei
     // cols % 256 == 0 (every warp full, each 32-block within one warp) and cols/8 <= 1024
     // (max block dim). The decode residual width (hidden = 2048) satisfies both.
     assert(cols % 256 == 0 && (cols >> 3) <= 1024);
-    add_rmsnorm2_q8_kernel<<<1, cols >> 3, 0, stream>>>(
+    add_rmsnorm2_q8_kernel<false><<<1, cols >> 3, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x),
         reinterpret_cast<const __nv_bfloat16*>(residual),
         reinterpret_cast<const __nv_bfloat16*>(weight),
         reinterpret_cast<__nv_bfloat16*>(out_sum),
         reinterpret_cast<__nv_bfloat16*>(out_norm),
-        reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
+        reinterpret_cast<si_blk_q8_1*>(out_q8), nullptr, nullptr, cols, eps);
 }
 
 void launch_add_rmsnorm3_q8(const void* x, const void* res1, const void* res2, const void* weight,
@@ -845,10 +875,27 @@ void launch_add_rmsnorm2_q8_rows(const void* x, const void* residual, const void
                                  void* out_sum, void* out_norm, void* out_q8,
                                  int rows, int cols, float eps, cudaStream_t stream) {
     assert(rows > 0 && cols % 256 == 0 && (cols >> 3) <= 1024);
-    add_rmsnorm2_q8_kernel<<<rows, cols >> 3, 0, stream>>>(
+    add_rmsnorm2_q8_kernel<false><<<rows, cols >> 3, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(residual),
         reinterpret_cast<const __nv_bfloat16*>(weight), reinterpret_cast<__nv_bfloat16*>(out_sum),
-        reinterpret_cast<__nv_bfloat16*>(out_norm), reinterpret_cast<si_blk_q8_1*>(out_q8), cols, eps);
+        reinterpret_cast<__nv_bfloat16*>(out_norm), reinterpret_cast<si_blk_q8_1*>(out_q8),
+        nullptr, nullptr, cols, eps);
+}
+
+// Same, plus the NVFP4 activation form of out_norm. cols must be a multiple of 256 (which already
+// makes it a multiple of 16, so the per-16 groups tile the row exactly). Declines -- writing
+// nothing and returning false -- for anything else, so the caller keeps its standalone quantize.
+bool launch_add_rmsnorm2_q8_nvfp4_rows(const void* x, const void* residual, const void* weight,
+                                       void* out_sum, void* out_norm, void* out_q8,
+                                       void* nv_q, void* nv_s,
+                                       int rows, int cols, float eps, cudaStream_t stream) {
+    if (!nv_q || !nv_s || rows <= 0 || (cols % 256) != 0 || (cols >> 3) > 1024) return false;
+    add_rmsnorm2_q8_kernel<true><<<rows, cols >> 3, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(x), reinterpret_cast<const __nv_bfloat16*>(residual),
+        reinterpret_cast<const __nv_bfloat16*>(weight), reinterpret_cast<__nv_bfloat16*>(out_sum),
+        reinterpret_cast<__nv_bfloat16*>(out_norm), reinterpret_cast<si_blk_q8_1*>(out_q8),
+        reinterpret_cast<signed char*>(nv_q), reinterpret_cast<float*>(nv_s), cols, eps);
+    return true;
 }
 
 void launch_add_rmsnorm3_q8_rows(const void* x, const void* res1, const void* res2,

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -28,6 +28,14 @@ void launch_add_rmsnorm2_q8_rows(const void* x_bf16, const void* residual_bf16,
                                  const void* weight_bf16, void* out_sum_bf16,
                                  void* out_norm_bf16, void* out_q8, int rows, int cols,
                                  float eps, cudaStream_t stream = nullptr);
+// Same, and ALSO writes the NVFP4 activation form of out_norm (int8 quants + one fp32 scale per
+// 16), bit-identical to launch_gemv_nvfp4_quant_x run on out_norm afterwards. False (and nothing
+// written) when the shape does not fit, so the caller keeps its standalone quantize.
+bool launch_add_rmsnorm2_q8_nvfp4_rows(const void* x_bf16, const void* residual_bf16,
+                                       const void* weight_bf16, void* out_sum_bf16,
+                                       void* out_norm_bf16, void* out_q8,
+                                       void* nv_q, void* nv_s, int rows, int cols,
+                                       float eps, cudaStream_t stream = nullptr);
 
 // Sandwich-norm residual add (Gemma2/Muse-Glimmer style): out = residual + RMSNorm(block_out)
 // * weight. Unlike add_rmsnorm2/3 above (which norm the SUM), this norms block_out ALONE --

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -119,6 +119,13 @@ void launch_dflash_gdn_scan_commit(const void* k, const void* v,
 
 // Batched gated RMSNorm: out[t,h,:] = (x/rms(x)) * weight * silu(z), per (token, v_head).
 //   x/z: [N, v_heads*hd]   weight: [hd]   out: [N, v_heads*hd]
+// Gated RMSNorm that ALSO writes the NVFP4 activation form of `out` (int8 quants + one fp32
+// scale per 16), bit-identical to launch_gemv_nvfp4_quant_x run on `out` afterwards. False (and
+// nothing written) for a shape it cannot cover.
+bool launch_prefill_gated_norm_nvfp4(const void* x, const void* z, const void* weight, void* out,
+                                     void* nv_q, void* nv_s,
+                                     int n_tokens, int v_heads, int head_dim, float eps,
+                                     cudaStream_t stream = nullptr);
 void launch_prefill_gated_norm(const void* x, const void* z, const void* weight, void* out,
                                int n_tokens, int v_heads, int head_dim, float eps,
                                cudaStream_t stream = nullptr);

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -425,6 +425,149 @@ __global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_split_hd128(
     }
 }
 
+// KEY-TILED form of k_attn_rows_split_hd128. BIT-IDENTICAL to it -- same value, same last bit.
+//
+// What is wrong with the one-key-at-a-time loop: it does a FIVE-STEP warp reduction per key and
+// then folds that key into the online-softmax state, so every iteration is
+//   reduce -> broadcast -> exp -> rescale acc
+// with the reduction INSIDE the loop-carried chain. The kernel is not DRAM-bound (135 GB/s
+// unique), not L2-bound (677) and not compute-bound (2.4 TFLOP/s) at this shape; it is waiting on
+// that chain. The ROWS sweep is the proof: ROWS 2 -> 8 cuts the K/V traffic FOURFOLD and buys only
+// 5%, because the traffic was never the cost and the per-warp key count -- and so the chain length
+// -- is the same either way.
+//
+// This form gives each warp KT of its OWN keys per trip and splits the iteration in two:
+//   1. the KT x ROWS QK dots are computed first, so their reductions are mutually INDEPENDENT and
+//      pipeline instead of each one serialising behind the previous key's softmax update;
+//   2. the reduction is a shfl_xor BUTTERFLY, which pairs lanes in exactly the tree shfl_down
+//      builds at lane 0 -- so it is the same float -- and leaves it in EVERY lane, retiring the
+//      separate broadcast shuffle each row needed;
+//   3. only then are the KT keys folded into the state, one at a time, in the original order.
+//
+// Step 3 is deliberately NOT tiled. Taking a max over KT keys at once would shorten the carried
+// chain further, but it changes the rescale factors in the last bits -- and while that is legal
+// here (the draft only nominates; the target verifies every proposal, so losslessness cannot
+// move), it perturbs which tokens get proposed and measured as a whole generation step of tau. The
+// win is the reduction leaving the chain, not the softmax fold, so this keeps the free half.
+//
+// The warp's key SEQUENCE is also preserved: warp w still walks t0+w, t0+w+NWARPS, ... in that
+// order, so its partial (m, l, acc) -- and the cross-warp merge in the epilogue -- are unchanged.
+template <int ROWS, int NWARPS, int KT>
+__global__ __launch_bounds__(NWARPS * 32) void k_attn_rows_tile_hd128(
+    const bf16* __restrict__ q, const bf16* __restrict__ k, const bf16* __restrict__ v,
+    float* __restrict__ p_m, float* __restrict__ p_l, float* __restrict__ p_acc,
+    int q_len, int kv_lo, int kv_len, int n_q, int n_kv,
+    int q_pos0, int k_pos0, int window, bool causal, float scale, int n_splits) {
+    constexpr int D = 128, E = D / 32;
+    const int rg = blockIdx.x, qh = blockIdx.y, sp = blockIdx.z;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5;
+    const int base = lane * E;
+    const int kv_h = qh / (n_q / n_kv);
+    const int qt0 = rg * ROWS;
+
+    float qr[ROWS][E], acc[ROWS][E], max_s[ROWS], sum[ROWS];
+#pragma unroll
+    for (int r = 0; r < ROWS; r++) {
+        const int qt = qt0 + r;
+        const bf16* qv = q + ((size_t)qt * n_q + qh) * D + base;
+#pragma unroll
+        for (int e = 0; e < E; e++) { qr[r][e] = (qt < q_len) ? b2f(qv[e]) : 0.f; acc[r][e] = 0.f; }
+        max_s[r] = -1e30f;
+        sum[r] = 0.f;
+    }
+
+    const int chunk = (kv_len - kv_lo + n_splits - 1) / n_splits;
+    const int t0 = kv_lo + sp * chunk;
+    const int t1 = min(kv_len, t0 + chunk);
+
+    for (int tb = t0 + warp; tb < t1; tb += NWARPS * KT) {
+        float sc[ROWS][KT], vr[KT][E];
+        // 1. KT independent key loads and KT x ROWS independent dots.
+#pragma unroll
+        for (int u = 0; u < KT; u++) {
+            const int t = tb + u * NWARPS;
+            const int ts = (t < t1) ? t : tb;              // in-range address for the dead lane-set
+            const bf16* kp = k + ((size_t)ts * n_kv + kv_h) * D + base;
+            const bf16* vp = v + ((size_t)ts * n_kv + kv_h) * D + base;
+            float kreg[E];
+#pragma unroll
+            for (int e = 0; e < E; e++) { kreg[e] = b2f(kp[e]); vr[u][e] = b2f(vp[e]); }
+#pragma unroll
+            for (int r = 0; r < ROWS; r++) {
+                float d = 0.f;
+#pragma unroll
+                for (int e = 0; e < E; e++) d += qr[r][e] * kreg[e];
+                sc[r][u] = d;
+            }
+        }
+        // 2. One butterfly pass over all ROWS*KT partial dots.
+#pragma unroll
+        for (int off = 16; off > 0; off >>= 1)
+#pragma unroll
+            for (int r = 0; r < ROWS; r++)
+#pragma unroll
+                for (int u = 0; u < KT; u++)
+                    sc[r][u] += __shfl_xor_sync(0xffffffffu, sc[r][u], off);
+        // 3. Fold the tile into the state, key by key, in the original order.
+#pragma unroll
+        for (int u = 0; u < KT; u++) {
+            const int t = tb + u * NWARPS;
+            if (t >= t1) break;
+            const int k_pos = k_pos0 + t;
+#pragma unroll
+            for (int r = 0; r < ROWS; r++) {
+                const int qt = qt0 + r;
+                if (qt >= q_len) continue;
+                const int q_pos = q_pos0 + qt;
+                if (causal && k_pos > q_pos) continue;
+                if (window > 0 && (q_pos - k_pos) >= window) continue;
+                const float score = sc[r][u] * scale;
+                const float new_max = fmaxf(max_s[r], score);
+                const float e1 = __expf(max_s[r] - new_max);
+                const float e2 = __expf(score - new_max);
+                sum[r] = sum[r] * e1 + e2;
+#pragma unroll
+                for (int e = 0; e < E; e++) acc[r][e] = acc[r][e] * e1 + e2 * vr[u][e];
+                max_s[r] = new_max;
+            }
+        }
+    }
+
+    extern __shared__ float sm[];
+    float* s_max = sm;
+    float* s_sum = s_max + NWARPS * ROWS;
+    float* s_acc = s_sum + NWARPS * ROWS;
+#pragma unroll
+    for (int r = 0; r < ROWS; r++) {
+        if (lane == 0) { s_max[warp * ROWS + r] = max_s[r]; s_sum[warp * ROWS + r] = sum[r]; }
+#pragma unroll
+        for (int e = 0; e < E; e++)
+            s_acc[((size_t)warp * ROWS + r) * D + base + e] = acc[r][e];
+    }
+    __syncthreads();
+    if (warp != 0) return;
+#pragma unroll
+    for (int r = 0; r < ROWS; r++) {
+        const int qt = qt0 + r;
+        if (qt >= q_len) continue;
+        float gmax = -1e30f;
+        for (int w = 0; w < NWARPS; w++) gmax = fmaxf(gmax, s_max[w * ROWS + r]);
+        float gsum = 0.f;
+        float result[E] = {0.f, 0.f, 0.f, 0.f};
+        for (int w = 0; w < NWARPS; w++) {
+            const float c = __expf(s_max[w * ROWS + r] - gmax);
+            gsum += s_sum[w * ROWS + r] * c;
+#pragma unroll
+            for (int e = 0; e < E; e++)
+                result[e] += s_acc[((size_t)w * ROWS + r) * D + base + e] * c;
+        }
+        const size_t o = ((size_t)qt * n_q + qh) * n_splits + sp;
+#pragma unroll
+        for (int e = 0; e < E; e++) p_acc[o * D + base + e] = result[e];
+        if (lane == 0) { p_m[o] = gmax; p_l[o] = gsum; }
+    }
+}
+
 // Merge the per-split online-softmax partials into the bf16 output.
 __global__ void k_attn_split_combine(const float* __restrict__ p_m, const float* __restrict__ p_l,
                                      const float* __restrict__ p_acc, bf16* __restrict__ out,
@@ -1342,14 +1485,43 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
             // q_pos0 - k_pos0 - window is dead for the whole block: start the partition above it.
             const int kv_lo = attn_gqa_kv_lo(q_len, kv_len, n_q, n_kv, d, q_pos0, k_pos0, window);
             const int n_splits = kv_lo > 0 ? attn_gqa_splits(kv_len - kv_lo) : n_splits_full;
+            // KEYS PER TRIP for the tiled kernel above. 0 keeps the one-key-at-a-time kernel,
+            // which is what every earlier measurement on this shape was taken against.
+            // Swept end to end at ctx 4k, one binary, draft ms/block (the low-noise signal --
+            // tok/s is quantised by a whole generation step here):
+            //     KT 0 (untiled) 1.951    KT 2 -> 1.784    KT 4 -> 1.853    KT 8 -> 1.880
+            // Unimodal at 2. Wider tiles shorten the carried chain further but hold KT keys' worth
+            // of V and KT*ROWS partial dots live, and at ROWS=8 that costs more occupancy than the
+            // chain buys back. 0 keeps the one-key-at-a-time kernel for an A/B.
+            static const int kt_env = []{
+                const char* e = getenv("SPARKINFER_DFLASH_ATTN_KT");
+                int v = e ? atoi(e) : 2;
+                return (v == 0 || v == 2 || v == 4 || v == 8) ? v : 2;
+            }();
 #define SI_DF_ATTN_ROWS(R)                                                                    \
             do {                                                                                  \
                 const size_t smem = (size_t)(2 * NWARPS * (R) + NWARPS * (R) * 128) * sizeof(float); \
                 dim3 g((q_len + (R) - 1) / (R), n_q, n_splits);                                   \
-                k_attn_rows_split_hd128<(R), NWARPS><<<g, NWARPS * 32, smem, stream>>>(           \
-                    (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,           \
-                    q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale,       \
-                    n_splits);                                                                    \
+                if (kt_env == 2)                                                                  \
+                    k_attn_rows_tile_hd128<(R), NWARPS, 2><<<g, NWARPS * 32, smem, stream>>>(     \
+                        (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,       \
+                        q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale,   \
+                        n_splits);                                                                \
+                else if (kt_env == 4)                                                             \
+                    k_attn_rows_tile_hd128<(R), NWARPS, 4><<<g, NWARPS * 32, smem, stream>>>(     \
+                        (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,       \
+                        q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale,   \
+                        n_splits);                                                                \
+                else if (kt_env == 8)                                                             \
+                    k_attn_rows_tile_hd128<(R), NWARPS, 8><<<g, NWARPS * 32, smem, stream>>>(     \
+                        (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,       \
+                        q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale,   \
+                        n_splits);                                                                \
+                else                                                                              \
+                    k_attn_rows_split_hd128<(R), NWARPS><<<g, NWARPS * 32, smem, stream>>>(       \
+                        (const bf16*)q, (const bf16*)k, (const bf16*)v, fa_m, fa_l, fa_acc,       \
+                        q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale,   \
+                        n_splits);                                                                \
             } while (0)
             if (rows_env == 8)      SI_DF_ATTN_ROWS(8);
             else if (rows_env == 4) SI_DF_ATTN_ROWS(4);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2630,6 +2630,27 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     const bf16* nvq_src_a = nullptr; int nvq_k_a = 0;
     const bf16* nvq_src_b = nullptr; int nvq_k_b = 0;
     bool nvq_use_b = false;
+    // Set by a layer tail that folded the NVFP4 quantize of its `xn` into the norm; read (and
+    // cleared) by the next layer's cache reset, which must not throw that staging away.
+    const bf16* nv_staged_src = nullptr; int nv_staged_k = 0; bool nv_staged_b = false;
+    // SPARKINFER_VERIFY_NORMFOLD=0 keeps the standalone si_nvfp4_quant_x nodes, for an A/B out of
+    // one binary. The folded and unfolded paths write the same bytes, so the two arms differ only
+    // in how many graph nodes the verify carries.
+    static const bool kNormFold = []{ const char* e = getenv("SPARKINFER_VERIFY_NORMFOLD");
+                                      return !(e && e[0] == '0'); }();
+    // Which of the A/B pair the NEXT quantize would write, and how to record it as written --
+    // without issuing anything. The norm kernels below can emit the NVFP4 form of their own output
+    // for free (they already hold the bf16-rounded values in registers), so a norm claims the
+    // buffer here and the consumer downstream then finds the activation already staged. Same
+    // buffer, same alternation, same bits -- only the launch that produced them goes away.
+    auto quant_nv_claim = [&](signed char** q, float** sc) {
+        if (!nvq_use_b) { *q = nv_pq_b; *sc = nv_ps_b; }
+        else            { *q = nv_pq_a; *sc = nv_ps_a; }
+    };
+    auto quant_nv_commit = [&](const bf16* in, int k) {
+        if (!nvq_use_b) { nvq_src_b = in; nvq_k_b = k; nvq_use_b = true; }
+        else            { nvq_src_a = in; nvq_k_a = k; nvq_use_b = false; }
+    };
     auto quant_nv_rows = [&](const bf16* in, int k) {
         if (nvq_src_a == in && nvq_k_a == k) { nvq_use_b = false; return; }
         if (nvq_src_b == in && nvq_k_b == k) { nvq_use_b = true;  return; }
@@ -2871,6 +2892,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // emits a fresh Q8_1(xn); nothing re-stamps this one, so clear it here.
         nvq_src_a = nullptr; nvq_k_a = 0;
         nvq_src_b = nullptr; nvq_k_b = 0;
+        // ...except an entry the PREVIOUS layer's tail norm emitted itself. That one IS this
+        // layer's xn, written by the kernel that produced xn, so it is fresh by construction --
+        // the staleness this reset exists for is a pointer-keyed hit on a buffer some EARLIER
+        // layer filled, which cannot happen for a value written one statement ago.
+        if (nv_staged_src) {
+            if (nv_staged_b) { nvq_src_b = nv_staged_src; nvq_k_b = nv_staged_k; }
+            else             { nvq_src_a = nv_staged_src; nvq_k_a = nv_staged_k; }
+            nv_staged_src = nullptr;
+        }
         vfail_L = L;
         vdbg_snapshot(xn, L);
         if (L == 0) vdbg_snapshot2(x, 4);   // raw pre-norm residual stream (h = x + ao)
@@ -2939,8 +2969,22 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 state, att, N, c.linear_q_heads, vh, c.linear_head_dim, c.gdn_qh_block, st);
             // ...and lz is gated_norm's.
             if (split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify gdn z wait");
-            kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh,
-                                                c.linear_head_dim, c.rms_eps, st);
+            // The out-projection is about to quantize lnrm to the NVFP4 activation form; this
+            // kernel already holds the bf16-rounded lnrm in registers, so it can write it and the
+            // standalone quantize node goes away. Claim the A/B slot exactly as quant_nv_rows
+            // would, so the buffer and the alternation are unchanged.
+            signed char* gnq = nullptr; float* gns = nullptr;
+            const bool gn_nv = kNormFold && kernels::qwen38_nvfp4_dp4a_proj() &&
+                               w.ssm_out_type == kernels::SI_QTYPE_NVFP4;
+            if (gn_nv) quant_nv_claim(&gnq, &gns);
+            if (gn_nv && kernels::launch_prefill_gated_norm_nvfp4(
+                             att, lz, w.ssm_norm, lnrm, gnq, gns, N, vh,
+                             c.linear_head_dim, c.rms_eps, st)) {
+                quant_nv_commit(lnrm, lvdim);
+            } else {
+                kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh,
+                                                    c.linear_head_dim, c.rms_eps, st);
+            }
             supported = proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
         } else {
             // Same shape of win as the GDN block: wq is 2*qdim rows and saturates, while wk and wv
@@ -3018,8 +3062,23 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         // kernel args (a printf's tag/step) do not, which is why this uses vdbg_snapshot's
         // approach and not a live stat-printer call here.
         if (L == 0) vdbg_snapshot2(ao, 0);
-        kernels::launch_add_rmsnorm2_q8_rows(x, ao, w.post_attn_norm, h, hn, q81,
-                                             N, H, c.rms_eps, st);
+        // Same fold as the layer tail, for the activation the dense FFN's gate/up read. This one
+        // has no A/B alternation to keep: the dense branch below quantizes hn into the dedicated
+        // nv_xq/nv_xs pair, and nothing else writes it before gate/up run.
+        bool hn_nv_folded = false;
+        {
+            static const bool kDecodeNvfp4 = [] {
+                const char* e = getenv("SPARKINFER_QWEN38_DECODE_NVFP4");
+                return !(e && e[0] == '0');
+            }();
+            if (kNormFold && dense && topk == 1 && kDecodeNvfp4 && kernels::qwen38_nvfp4_dp4a() &&
+                w.gate_nv && w.up_nv && w.down_nv)
+                hn_nv_folded = kernels::launch_add_rmsnorm2_q8_nvfp4_rows(
+                    x, ao, w.post_attn_norm, h, hn, q81, nv_xq, nv_xs, N, H, c.rms_eps, st);
+        }
+        if (!hn_nv_folded)
+            kernels::launch_add_rmsnorm2_q8_rows(x, ao, w.post_attn_norm, h, hn, q81,
+                                                 N, H, c.rms_eps, st);
         // FIXED (2026-08-17): this used to snapshot h BEFORE this kernel wrote it -- h is an
         // arena buffer reused every layer, so the earlier capture was reading whatever the
         // PREVIOUS layer's residual left there, not this layer's real value. That stale read is
@@ -3058,7 +3117,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             if (native_ffn && topk == 1 && kernels::qwen38_nvfp4_dp4a()) {
                 signed char* xq = nv_xq;
                 float* xs = nv_xs;
-                kernels::launch_gemv_nvfp4_quant_x(hn, xq, xs, N, H, st);
+                if (!hn_nv_folded) kernels::launch_gemv_nvfp4_quant_x(hn, xq, xs, N, H, st);
                 // gate and up are the same shape over the same activation, so one grid can carry
                 // both: half the launches, and one partial last wave instead of two. Falls back to
                 // the pair of singles for any shape the paired launcher declines.
@@ -3103,8 +3162,21 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             if (L == 0) vdbg_snapshot2(routed, 3);
             // Residual + next-layer norm, matching the MoE branch's tail.
             const void* nn = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-            kernels::launch_add_rmsnorm2_q8_rows(h, routed, nn, x, xn, q81,
-                                                 N, H, c.rms_eps, st);
+            // The next layer's projections want xn in the NVFP4 activation form, and this kernel
+            // already holds the bf16-rounded xn in registers -- see the fold's own comment in
+            // rmsnorm.cu. Claiming the A/B slot here keeps the alternation the standalone
+            // quantizer had, so the buffer, the bytes and the reader are all unchanged.
+            signed char* nvq = nullptr; float* nvs = nullptr;
+            if (kNormFold && kernels::qwen38_nvfp4_dp4a_proj()) quant_nv_claim(&nvq, &nvs);
+            if (nvq && kernels::launch_add_rmsnorm2_q8_nvfp4_rows(h, routed, nn, x, xn, q81,
+                                                                  nvq, nvs, N, H, c.rms_eps, st)) {
+                nv_staged_b = (nvq == nv_pq_b);
+                nv_staged_src = xn; nv_staged_k = H;
+                quant_nv_commit(xn, H);
+            } else {
+                kernels::launch_add_rmsnorm2_q8_rows(h, routed, nn, x, xn, q81,
+                                                     N, H, c.rms_eps, st);
+            }
             q81_src = xn; q81_k = H;
             // capture(L) MUST still run: it is the last statement of the layer loop and it is what
             // hands this layer's hidden state to the draft. An earlier revision of this branch used


### PR DESCRIPTION
## Summary

Three node/latency cuts on the `dspark-decode@4k` path, all **bit-identical** to `main` — the
differential accuracy check reports `top1=1.000000 kl=0.000000` and both arms print the same PPL:

1. **Fold the NVFP4 activation quantize into the norm that produces it** (`add_rmsnorm2_q8_kernel`,
   `pf_gated_norm_kernel`). `si_nvfp4_quant_x_kernel` ran **192 times a step at 1.26 us on a 4-CTA
   grid** — almost entirely node cost for ~40 KB of work — and every value it reads is one the
   producing norm already holds in registers. Emitting the int8 + per-16-scale form there deletes
   **176 of those 192 launches**. A 16-element group is two adjacent threads in the rmsnorm and 16
   adjacent lanes in the gated norm, so one shuffle completes it.
2. **A key tile in the draft's `k_attn_rows_split_hd128`.** It did a five-step warp reduction *per
   key* with the online-softmax update carried across the loop. Computing KT keys' dots first makes
   their reductions independent, and a `shfl_xor` butterfly pairs lanes in exactly the tree
   `shfl_down` builds at lane 0 — same float, and now in every lane, so the per-row broadcast
   shuffle disappears. The tile is then folded into the state one key at a time in the original
   order, and each warp keeps its original key sequence (`tb + u*NWARPS`), so the result is
   bit-for-bit what the old loop produced. `draft 1.953 -> 1.801 ms/block`.
3. **Token-parallel GDN conv** (`df_gdn_conv_checkpoint_kernel`). The causal conv is an FIR filter,
   not a recurrence, but the kernel walked tokens serially — with two or three block barriers each —
   on a grid of only `2*q_heads + v_heads` = 80 CTAs. Rebuilding each token's window from `qkv` and
   the seeded state gives `grid.y = n_tokens`. Same taps, same ascending order, so bit-identical.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — `dspark-decode@4k`, the scored dimension: `dspark_tau_check <model> <draft> 128
$(cat ids_4096.txt)` with the 4096 prompt ids from `bench/scripts/bench_prompt_4k.txt`, on the
ModelOpt NVFP4 checkpoint. Not an isolated-kernel microbenchmark.

| | decode tok/s |
|---|--:|
| before (main `f711b53`) | 126.84 |
| after (this PR) | **130.77** |

**Prefill pp tok/s** (Qwythos / Qwen3.5): N/A — this PR does not target prefill.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
# Gate run, SPARKINFER_DSPARK_SPEC_REPS=3, 525 W RTX 5090, ctx 4096, 128 new tokens
main DSPARK=126.8429 AR=94.3848 tau=1.8028 lossless=1/3
pr   DSPARK=130.7684 AR=94.5470 tau=1.8028 lossless=1/3
== dspark-decode@4k  1.0309x        (tau IDENTICAL on both arms, AR +0.17%)

# 2 interleaved main/PR repeats, same box, with the per-phase breakdown
main.t1  DSPARK 128.3277  AR 94.6003  tau 1.8286  lossless 1
  draft 1.952 ms/call   batched 12.298 ms/call   3.229 rows/step   fit C0=9.692 c1=0.807
pr.t1    DSPARK 130.5308  AR 94.5693  tau 1.8028  lossless 1
  draft 1.800 ms/call   batched 12.011 ms/call   3.141 rows/step   fit C0=9.504 c1=0.798
main.t2  DSPARK 128.4323  AR 94.4002  tau 1.8286  lossless 1
  draft 1.954 ms/call   batched 12.284 ms/call   3.200 rows/step   fit C0=9.707 c1=0.805
pr.t2    DSPARK 130.8615  AR 94.5377  tau 1.8028  lossless 1
  draft 1.802 ms/call   batched 11.974 ms/call   3.085 rows/step   fit C0=9.481 c1=0.808

# Step decomposition at a common 3.21 rows/step:
#   verify C0  9.700 -> 9.492 ms   (-0.207)   <- the deleted quantize nodes
#   draft      1.953 -> 1.801 ms   (-0.152)   <- the key tile
#   step      14.243 -> 13.875 ms  (-0.368 = 2.66%)

# Differential accuracy, PR vs main on the same token stream
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.0198 ppl_main=3.0198
```

**On the two tok/s numbers.** `dspark_tau_check` generates exactly 128 tokens, so a run lands in a
whole number of steps and mean-accept is quantised to `128/70 = 1.8286` or `128/71 = 1.8028` — one
step is ~1.4% of tok/s. In the gate run both arms landed on 71 steps and the ratio is the clean
one: **1.0309x**. In the interleaved pairs `main` landed on 70 and this PR on 71, which reads as
+1.8%. That is not a regression in acceptance: the verify-width planner maximises tokens/second
from measured per-width costs, and a cheaper fixed cost per step (`draft + C0`, which this PR cuts
by 0.36 ms) correctly shifts its optimum by a fraction of a row. The step-time reduction — 2.66%,
and independent of where the step boundary falls — is the physical change.

## Gates

| gate | result |
|---|---|
| `LOSSLESS` at `SPEC_REPS=3` | 1, over 3 runs |
| tau floor (0.95 x main) | 1.8028 vs 1.8028 — identical |
| `AR_TPS` floor (0.98 x main) | 94.547 vs 94.385 = 1.0017x |
| differential accuracy | top1 1.000000, KL 0.000000 (bar 0.90 / 0.1) |
| long-context guard @16k, Qwen3.8 | dec 92.263 -> 92.442, pp 12502.5 -> 12574.8 |
| long-context guard @16k, Qwen3.6 | dec 469.164 -> 470.656, pp 27550.5 -> 27615.9 |

```text
GUARD38 si_main 16384 dec=92.2634 pp=12502.5336
GUARD36 si_main 16384 dec=469.164 pp=27550.4562
GUARD38 si_pr   16384 dec=92.4423 pp=12574.8487
GUARD36 si_pr   16384 dec=470.6557 pp=27615.8523
ALL GATES GREEN
```

Both guards come out slightly ahead of `main` rather than merely clean: the norm fold is on the
`add_rmsnorm2_q8` path the AR decode uses too.

## What did NOT go in

Recorded so the next reader does not re-derive them. All measured on the same box, one binary per
arm, env-switched:

* The same key tile on the **verify's** attention (`fa_split_gqa_kernel`) is a **loss** — batched
  12.000 -> 12.074 ms at 3.17 rows. It already stages K/V in shared memory and walks only ~32 keys
  per CTA at 4k, and at head_dim 256 holding the tile's V costs 32 registers.
* A **K-aware split-K rule** for the NVFP4 row GEMVs (narrow split for deep-K `ffn_down`): +0.072
  ms/step and AR -1.4%. Pinning S globally gives C0/c1/AR = 9.849/0.756/92.98 at S=2,
  9.637/0.822/94.62 at S=4 (the current rule), 8.801/1.440/92.51 at S=8 — S down buys activation
  reuse and costs grid, and the c1 it saves is smaller than the C0 it costs at every shape here.
* Exercising the LM head's existing `GRP` template parameter (row-groups per CTA, to share the
  activation pull) at 2 and 4: -0.009 ms, i.e. noise.
* Exact `MMAX` instantiations per verify width: neutral. That head is ~linear in the real row
  count, not in `MMAX` — 665 us at mean M 3.1 against 989 at 5.15.
