### PR TITLE
fix(runtime): enable the vocab fallback in convert_gguf.py

### DIFF
--- a/runtime/tools/convert_gguf.py
+++ b/runtime/tools/convert_gguf.py
@@ -57,7 +57,7 @@ def main():
     # vocab from token_embd if metadata missing
     ten = {t.name: t for t in r.tensors}
     if "token_embd.weight" in ten:
-        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
+        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1])
 
     with open(os.path.join(out, "config.txt"), "w") as f:
         for k, v in cfg.items():


### PR DESCRIPTION
Fixes #637.

## Summary

`token_embd.weight`'s shape fallback in `runtime/tools/convert_gguf.py` was dead-coded behind `if False`, so `config.txt` always kept the metadata-derived `vocab` value even when it disagreed with the tensor — the C++ GGUF load path already prefers the embedding tensor's shape (`emb->dims[1]` in `qwen3_gguf_config.h` / `qwen35.cpp`), so this brought the Python converter in line with it.

## Fix

One-line change: remove the dead `if False` branch so the tensor-derived vocab is actually applied.

```diff
-        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1]) if False else cfg["vocab"]
+        cfg["vocab"] = int(ten["token_embd.weight"].shape[-1])
```

`ten["token_embd.weight"]` comes from `gguf.GGUFReader`, whose `.shape` follows GGUF's native `ne[]` order — `(hidden, vocab)` for this 2D tensor — so `shape[-1]` already equals `shape[1]`, matching what the runtime reads. No indexing change needed, only enabling the existing computation.

## Scope

No GPU required — tooling correctness only, per the issue.

## Testing

Verified the logic in isolation with a minimal repro (no real GGUF fixture needed for a one-line dead-code fix):

```
OLD (dead code) result: 151936 <- stuck on wrong metadata value
NEW (fixed) result:     152064 <- correctly derived from tensor
```