### PR TITLE
feat(dspark): report target rank in draft top-k

### DIFF
--- a/runtime/include/sparkinfer/models/dflash_draft.h
+++ b/runtime/include/sparkinfer/models/dflash_draft.h
@@ -46,6 +46,11 @@ struct DFlashDraftConfig {
     float yarn_beta_slow = 1.f;
 };
 
+// DEBUG (SPARKINFER_DSPARK_TOPK=<K>): the top-K candidates of the row that backs each proposal,
+// captured inside forward_block. [r*K + j] is proposal r's j-th best; [r*K+0] == out_argmax[r].
+int dflash_debug_topk_k();
+const int* dflash_debug_topk();
+
 class DFlashDraftModel {
 public:
     explicit DFlashDraftModel(const DFlashDraftConfig& cfg);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -635,6 +635,15 @@ void DFlashDraftModel::crop(int keep) {
 
 int DFlashDraftModel::seq_len() const { return p_->seq_len; }
 
+// ---- DEBUG: per-proposal top-K of the row that actually backs it -------------------------
+// SPARKINFER_DSPARK_TOPK=<K>. Filled inside forward_block at the exact point the argmax is taken,
+// from the exact pointer the argmax reads -- AFTER the Markov bias has been added in place -- so
+// the row mapping cannot be misattributed the way an after-the-fact read of last_logits() can.
+// g_dbg_topk[r*K + j] is the j-th best candidate for proposal r; [r*K+0] is out_argmax[r] by
+// construction, which is the built-in self-check.
+namespace { std::vector<int> g_dbg_topk; std::vector<float> g_dbg_row; int g_dbg_K = 0; }
+int dflash_debug_topk_k() { return g_dbg_K; }
+const int* dflash_debug_topk() { return g_dbg_topk.empty() ? nullptr : g_dbg_topk.data(); }
 const float* DFlashDraftModel::last_logits() const { return p_->logits; }
 
 // YaRN inverse-frequency table, computed exactly as HuggingFace's _compute_yarn_parameters does
@@ -1437,6 +1446,9 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         return (e && e[0] == '0') ? 0 : 1;
     }();
     const int head_row0 = kRowShift ? 0 : 1;
+    { static const int k = []{ const char* e = getenv("SPARKINFER_DSPARK_TOPK");
+                               int v = e ? atoi(e) : 0; return v < 0 ? 0 : (v > 32 ? 32 : v); }();
+      g_dbg_K = k; }
     bool head_done = false;
     if (head_mr && s.head_q8 && (s.lm_head_type == 14 || s.lm_head_type == 12)) {
         // Score only the proposal rows the verifier can consume. One row-batched quantize launch
@@ -1566,6 +1578,23 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                                        s.confidence_w, s.confidence_bias, H,
                                                        s.markov_rank, s.d_confidence + r, st);
             kernels::launch_argmax(s.logits + row * Vd, s.d_out + r, 1, Vd, st);
+            if (g_dbg_K > 0) {
+                // Debug path: synchronous, and deliberately so -- it reads the same row the
+                // argmax above just consumed, before the next iteration can touch it.
+                if (g_dbg_row.size() < (size_t)Vd) g_dbg_row.resize(Vd);
+                if (g_dbg_topk.size() < (size_t)(kProposalDepth + 1) * g_dbg_K)
+                    g_dbg_topk.assign((size_t)(kProposalDepth + 1) * g_dbg_K, -1);
+                if (cudaStreamSynchronize(st) == cudaSuccess &&
+                    cudaMemcpy(g_dbg_row.data(), s.logits + row * Vd,
+                               (size_t)Vd * sizeof(float), cudaMemcpyDeviceToHost) == cudaSuccess) {
+                    std::vector<int> idx(Vd);
+                    for (int j = 0; j < Vd; j++) idx[j] = j;
+                    const int K = g_dbg_K < Vd ? g_dbg_K : Vd;
+                    std::partial_sort(idx.begin(), idx.begin() + K, idx.end(),
+                        [&](int a, int b){ return g_dbg_row[a] > g_dbg_row[b]; });
+                    for (int j = 0; j < K; j++) g_dbg_topk[(size_t)r * g_dbg_K + j] = idx[j];
+                }
+            }
         }
     } else {
         kernels::launch_argmax(s.logits + (size_t)(head_done ? head_row0 : 0) * Vd,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3574,6 +3574,12 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // between a token and a millisecond is exactly the throughput the run is already achieving,
     // and that is a number this loop can measure instead of assume.
     double plan_tok = 0, plan_ms = 0;
+    // Rank-probe accumulators (debug; see the probe below).
+    static const bool kRankProbe = []{ const char* e = getenv("SPARKINFER_DSPARK_TOPK");
+                                       return e && atoi(e) > 0; }();
+    long rp_seen[kPlanMaxW] = {0}, rp_out[kPlanMaxW] = {0};
+    long rp_nomap[kPlanMaxW] = {0};
+    long rp_rank[kPlanMaxW][32] = {{0}};
     // Online calibration of the confidence head, per proposal position.
     //
     // The head is an accept-rate predictor, so sigmoid(logit) is read as P(this position is
@@ -3746,7 +3752,6 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             break;
         }
         if (!draft_idle) for (int i = 1; i <= kProposalDepth; i++) block[i] = draft_ids[i];
-
         // Incremental verify with early-exit: forward only the accepted prefix, stopping at the
         // first rejected proposal. forward_token advances GDN state + KV per token, so after
         // block[0..keep-1] the recurrent state and KV sit exactly at start+keep -- no snapshot /
@@ -3825,6 +3830,27 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
                 plan_rows_sum += vn; plan_steps++;
                 while (accept < vn - 1 && block[accept + 1] == posterior[accept]) ++accept;
                 keep = accept + 1;
+                // ---- RANK PROBE (SPARKINFER_DSPARK_TOPK=<K>, debug only) -------------------
+                // The chain accepts position i only when the draft's ARGMAX equals the target's.
+                // A width-k tree accepts whenever the target's token is anywhere in the draft's
+                // top k there. dflash_debug_topk() is captured INSIDE forward_block from the exact
+                // row the argmax reads, so [i*K+0] == block[i] by construction -- checked, and a
+                // mismatch drops the sample instead of counting it.
+                if (kRankProbe) {
+                    const int K = dflash_debug_topk_k();
+                    const int* tk = dflash_debug_topk();
+                    if (K > 0 && tk) {
+                        for (int i = 1; i <= kProposalDepth && i <= vn - 1 && i < kPlanMaxW; i++) {
+                            if (accept < i - 1) break;
+                            const int tgt = posterior[i - 1];
+                            if (tk[(size_t)i * K] != block[i]) { rp_nomap[i]++; continue; }
+                            int rank = -1;
+                            for (int j = 0; j < K; j++) if (tk[(size_t)i * K + j] == tgt) { rank = j; break; }
+                            rp_seen[i]++;
+                            if (rank < 0) rp_out[i]++; else rp_rank[i][rank]++;
+                        }
+                    }
+                }
                 // Feed the achieved rate. The draft is part of the step it paid for, so it is in
                 // the denominator here even though it is not in plan_cost().
                 plan_tok += (double)keep;
@@ -3935,6 +3961,32 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     auto t_end = std::chrono::steady_clock::now();
     if (stats) {
         stats->steps = steps;
+        if (kRankProbe) {
+            const int K = dflash_debug_topk_k();
+            fprintf(stderr, "\n[rankprobe] rank of the TARGET's token inside the DRAFT's top-%d\n", K);
+            fprintf(stderr, "[rankprobe] pos  seen");
+            for (int j = 0; j < K; j++) fprintf(stderr, "  r%-2d", j + 1);
+            fprintf(stderr, "   out  nomap\n");
+            for (int i = 1; i < kPlanMaxW; i++) {
+                if (!rp_seen[i]) continue;
+                fprintf(stderr, "[rankprobe] %3d %5ld", i, rp_seen[i]);
+                for (int j = 0; j < K; j++) fprintf(stderr, " %4ld", rp_rank[i][j]);
+                fprintf(stderr, " %5ld %6ld\n", rp_out[i], rp_nomap[i]);
+            }
+            // tau(width w) = 1 + sum_i prod_{j<=i} P(target in draft top-w at j)
+            fprintf(stderr, "[rankprobe] tau ceiling by tree width:\n");
+            for (int w = 1; w <= K; w++) {
+                double surv = 1.0, tau = 1.0;
+                for (int i = 1; i < kPlanMaxW; i++) {
+                    if (!rp_seen[i]) break;
+                    long hit = 0;
+                    for (int j = 0; j < w; j++) hit += rp_rank[i][j];
+                    surv *= (double)hit / (double)rp_seen[i];
+                    tau += surv;
+                }
+                fprintf(stderr, "[rankprobe]   width %2d  tau %.3f\n", w, tau);
+            }
+        }
         stats->mean_accept = steps > 0 ? accept_sum / steps : 0;
         stats->ttft_s = std::chrono::duration<double>(t1 - t0).count();
         if (kProfile) cudaProfilerStop();


### PR DESCRIPTION
## Summary

- add an opt-in `SPARKINFER_DSPARK_TOPK=<K>` probe at the exact draft-logit row consumed by argmax
- report the target token rank by proposal position
- estimate the attainable tau ceiling for tree widths 1..K
- keep the production path unchanged when the environment variable is unset

## Motivation

DSpark tree verification only pays if the target token remains inside the draft top-k after a chain miss. This probe measures that condition at the source row, after Markov bias, and checks row mapping by requiring rank-1 to equal the emitted proposal.

On the rebased `29ecf70` baseline at ctx=4096, the normal path remains lossless and measures 149.99 tok/s (90.45 tok/s AR, 1.658x). This PR is diagnostic instrumentation for selecting the next tree/runtime optimization; it does not claim a production throughput improvement by itself.

## Validation

- `cmake --build bd -j2 --target dspark_tau_check`
- ctx=4096 DSpark run: `LOSSLESS=1`, 32/32 matched
- normal-path metric: `DSPARK_TPS 149.9917`
