### PR TITLE
perf(dspark): cap planner bootstrap width

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3565,7 +3565,19 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     long   w_n[kPlanMaxW] = {0};
     // Bootstrap cursor: the first sample of the run is discarded (it carries whatever warm-up the
     // first batched call still has), then widths are walked from the widest down to 1.
-    int boot_w = kProposalDepth + 1;
+    // Bootstrap is exploration, not useful work: forcing every available width is especially
+    // expensive for short generations, where it can consume most of the decode steps before the
+    // planner starts using the confidence head. Four rows are enough to fit the affine cost and
+    // populate the non-linear knee used by the narrow planner. Wider choices remain available
+    // through that fit and get their own running mean as soon as the planner selects them.
+    // Set 0 to restore the exhaustive walk, or a positive value to cap it explicitly.
+    static const int kPlanBootMax = []{
+        const char* e = getenv("SPARKINFER_DSPARK_PLAN_BOOT_MAX");
+        int v = e ? atoi(e) : 4;
+        return v >= 0 ? v : 4;
+    }();
+    int boot_w = kPlanBootMax > 0 ? std::min(kProposalDepth + 1, kPlanBootMax)
+                                  : kProposalDepth + 1;
     bool boot_first = true;
     // The run's own achieved rate, tokens per millisecond of WHOLE step (draft included). The plan
     // maximises worth(d) - rate * cost(d+1) rather than the ratio worth(d)/cost(d+1): the ratio


### PR DESCRIPTION
## Summary

Cap DSpark planner bootstrap exploration at four verify rows. Exhaustively forcing every available width consumed 6 of 15 decode steps in the 32-token scored run; wider widths remain selectable through the online affine fit and receive a running mean when selected.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, Qwen3.8 DSpark hourly scoring harness at ctx=4096):

| | decode tok/s |
|---|--:|
| before (main) | 142.3823 |
| after (this PR) | 143.9817 |

**Prefill pp tok/s** (Qwythos / Qwen3.5):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

`bench/scripts/bench.sh` exercises the generic GGUF decode runner and does not enter DSpark. These numbers therefore come from `runtime/examples/dspark_tau_check.cpp`, which the source identifies as the hourly `dspark-decode@4k` scoring harness. Both arms used the same binary and prompt tokens; the environment override selects the old exhaustive bootstrap for the control.

```text
# before: SPARKINFER_DSPARK_PLAN_BOOT_MAX=0
METRIC AR_TPS 90.4449
METRIC DSPARK_TPS 142.3823
METRIC MEAN_ACCEPT 2.3333
METRIC LOSSLESS 1
[timing] plan 3.533 rows/step (of 5)
[timing] batched 12.462 ms/call

# after: default capped bootstrap
METRIC AR_TPS 90.4230
METRIC DSPARK_TPS 143.9817
METRIC MEAN_ACCEPT 2.3333
METRIC LOSSLESS 1
[timing] plan 3.400 rows/step (of 5)
[timing] batched 12.295 ms/call

# command (same binary, 32 generated tokens, 4096-token prompt)
SPARKINFER_DSPARK_TIMING=1 SPARKINFER_DSPARK_SPEC_REPS=1 \
  xargs ./bd/runtime/dspark_tau_check \
  /root/workspace/models_q38_modelopt /root/workspace/dspark 32 \
  < /tmp/frandev_ids_4096.txt
```
