### PR TITLE
perf(dspark): drive the draft backbone on q8_1 activations + dp4a

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -1267,6 +1267,11 @@ void launch_flash_decode_split(
                 const char* e = getenv("SPARKINFER_FA_SEQFOLD");
                 fa6_fold_env = e ? atoi(e) : 0;
             }
+            // SPARKINFER_FA_PIPE is read again further down for the num_seqs == 1 path; same knob,
+            // hoisted so the fold above can honour it too.
+            static int fa6_pipe_ok = -1;
+            if (fa6_pipe_ok < 0) { const char* e = getenv("SPARKINFER_FA_PIPE");
+                                   fa6_pipe_ok = (e && e[0] == '0') ? 0 : 1; }
             // Prefer the NARROWEST fold that divides the row count. Folding trades KV-staging
             // traffic for CTAs -- at 4 kv heads x n_splits the grid is already only a few CTAs
             // per SM -- and this kernel is issue-bound on the per-row softmax, not on the staged
@@ -1276,6 +1281,45 @@ void launch_flash_decode_split(
             const int fa6_fold = fa6_fold_env > 0
                                ? fa6_fold_env
                                : (num_seqs % 2 == 0 ? 2 : (num_seqs % 3 == 0 ? 3 : 1));
+            // cp.async DOUBLE BUFFERING FOR THE FOLD. fa_split_gqa_pipe_kernel has carried a SEQ
+            // template parameter since it was written and has never been instantiated above 1: the
+            // fold below returns before the pipelined/KV-group dispatch further down, and that
+            // dispatch is gated on num_seqs == 1 anyway. So the batched verify -- which is where
+            // nearly all of this kernel's time is -- has only ever run the SYNCHRONOUS tile, which
+            // does stage -> __syncthreads -> compute -> __syncthreads and exposes the global read
+            // latency once per tile. At ctx 4k each CTA walks ~32 keys in 4 tiles of 8, so there
+            // are four exposed round trips to overlap.
+            //
+            // Shallow tile deliberately: the pipelined path further down pairs cp.async with a
+            // DEEP tile because it runs at long context, where a CTA has hundreds of tiles. Here
+            // the chunk is 32 keys, so a deep tile would be one tile and there would be nothing to
+            // overlap -- the win is the pipeline, not the tile depth. 4*8*256*2 = 16 KB, under the
+            // 48 KB default, so no cudaFuncSetAttribute is needed.
+            //
+            // Bit-identical to the synchronous fold: cp.async changes WHEN bytes land in shared
+            // memory, not their values, and the token walk (start..end, consecutive tiles, the
+            // per-token online-softmax update) is unchanged. SPARKINFER_FA_FOLD_PIPE=0 reverts.
+            static int fa6_fold_pipe = -1;
+            if (fa6_fold_pipe < 0) { const char* e = getenv("SPARKINFER_FA_FOLD_PIPE");
+                                     fa6_fold_pipe = (e && e[0] == '0') ? 0 : 1; }
+            if (!int8_kv && num_seqs > 1 && fa6_fold > 1 && (num_seqs % fa6_fold) == 0 &&
+                fa6_pipe_ok && fa6_fold_pipe) {
+                const size_t smp = (size_t)4 * FA_GQA6_TILE * 256 * sizeof(__nv_bfloat16);
+                dim3 gqp(num_kv_heads * n_splits, num_seqs / fa6_fold);
+#define SI_FA6_FOLD_PIPE(SQ)                                                                      \
+                fa_split_gqa_pipe_kernel<256, GQA, FA_GQA6_TILE, (SQ)>                            \
+                    <<<gqp, GQA * 32, smp, stream>>>(                                             \
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table,       \
+                    seq_lens, part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads,         \
+                    block_size, max_blocks, n_splits)
+                if (fa6_fold == 3)      SI_FA6_FOLD_PIPE(3);
+                else if (fa6_fold == 4) SI_FA6_FOLD_PIPE(4);
+                else                    SI_FA6_FOLD_PIPE(2);
+#undef SI_FA6_FOLD_PIPE
+                combine_hd256(out_q8);
+                (void)seqlen;
+                return;
+            }
             if (!int8_kv && num_seqs > 1 && fa6_fold > 1 && (num_seqs % fa6_fold) == 0) {
                 const size_t smf = (size_t)2 * FA_GQA6_TILE * 256 * sizeof(__nv_bfloat16);
                 dim3 gqf(num_kv_heads * n_splits, num_seqs / fa6_fold);

--- a/kernels/csrc/cuda/fused/rmsnorm.cu
+++ b/kernels/csrc/cuda/fused/rmsnorm.cu
@@ -219,13 +219,15 @@ __global__ void add_rmsnorm2_q8_kernel(const __nv_bfloat16* __restrict__ x,
     ss = rn_warp_sum(ss);
     if ((t & 31) == 0) s_warp[t >> 5] = ss;
     __syncthreads();
-    if (t < 32) {
-        float v = (t < (blockDim.x + 31) / 32) ? s_warp[t] : 0.f;
-        v = rn_warp_sum(v);
-        if (t == 0) s_warp[0] = rsqrtf(v / cols + eps);
-    }
-    __syncthreads();
-    const float inv_rms = s_warp[0];
+    // EVERY warp folds the per-warp partials itself, over the same 32 lanes and the same tree the
+    // one reducing warp used, so the result is the same float -- but the second __syncthreads and
+    // the dependent read of s_warp[0] that followed it both leave the critical chain. At grid =
+    // rows (three or four CTAs for a verify block) there is nothing else resident to hide either,
+    // and this kernel is 128 launches a step of ~2.3 us each, almost all of it chain.
+    const int nw = (int)((blockDim.x + 31) / 32);
+    float red = ((t & 31) < nw) ? s_warp[t & 31] : 0.f;
+    red = rn_warp_sum(red);
+    const float inv_rms = rsqrtf(red / cols + eps);
 
     // The bf16-rounded residual sum, exactly as add_rmsnorm2_kernel does -- but rounded in
     // REGISTERS rather than read back out of out_sum. Every thread's store to out_sum[t] is its

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -1507,6 +1507,11 @@ struct si_q4k_packet {
 __device__ __forceinline__ si_q4k_packet si_q4k_decode(const si_block_q4_K* __restrict__ bq4,
                                                       int bq8_offset, int qoff) {
     si_q4k_packet p;
+    // NOT __ldcs. Q4_K keeps a superblock's scales and quants in ONE 144-byte struct that several
+    // threads of a CTA read, so an evict-first hint here destroys intra-block reuse rather than
+    // protecting anything: measured +0.012 ms on the verify's batched call. The draft's Q4 backbone
+    // is the opposite shape -- a flat [N][K/2] array where each thread owns its own word -- and
+    // does want the hint.
     const int* q4 = (const int*)(bq4->qs + 16 * bq8_offset + 4 * qoff);
     const int v0 = q4[0], v1 = q4[4];
     const unsigned short* scales = (const unsigned short*)bq4->scales;

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -73,8 +73,30 @@ __global__ void k_rms(const bf16* x, const bf16* w, bf16* out, int rows, int col
 // Residual add fused with the RMSNorm that always follows it: sum = a + b (kept for the next
 // residual) and out = rms(sum) * w. Identical arithmetic to launch_add followed by launch_rms, but
 // one eager launch instead of two and `sum` stays in registers for the norm's first pass.
+// llama q8_1 layout, same struct the target's MMVQ kernels use: 36 B per 32 values, with
+// ds = (d, d*sum(q)) so the affine dequant's second term needs no extra reduction.
+struct si_q81_blk { __half2 ds; signed char qs[32]; };
+
+// Emit ONE q8_1 block from a warp that already holds its 32 values, one per lane. Character for
+// character the arithmetic of si_quantize_q8_1_rows -- same amax butterfly, same d = amax/127,
+// same roundf, same d*sum(q) in ds.y -- so folding it into a producer is bit-identical to running
+// that kernel afterwards, and just deletes the launch. The draft issues 27 of those a step at ~1 us
+// each purely because the dp4a backbone needs its activation quantized.
+__device__ __forceinline__ void si_q81_emit(si_q81_blk* dst, int lane, float xv) {
+    float a = fabsf(xv);
+#pragma unroll
+    for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, m));
+    const float d = a / 127.0f;
+    const int qi = (a == 0.0f) ? 0 : (int)roundf(xv / d);
+    dst->qs[lane] = (signed char)qi;
+    int sm = qi;
+#pragma unroll
+    for (int m = 16; m > 0; m >>= 1) sm += __shfl_xor_sync(0xffffffffu, sm, m);
+    if (lane == 0) dst->ds = __floats2half2_rn(d, d * (float)sm);
+}
+
 __global__ void k_add_rms(const bf16* a, const bf16* b, bf16* sum, const bf16* w, bf16* out,
-                          int rows, int cols, float eps) {
+                          int rows, int cols, float eps, si_q81_blk* q81) {
     const int r = blockIdx.x;
     if (r >= rows) return;
     const bf16* ar = a + (size_t)r * cols;
@@ -103,8 +125,14 @@ __global__ void k_add_rms(const bf16* a, const bf16* b, bf16* sum, const bf16* w
     float tot = 0.f;
     for (int i = 0; i < nwarps; i++) tot += ws[i];
     const float inv = rsqrtf(tot / (float)cols + eps);
-    for (int i = threadIdx.x; i < cols; i += blockDim.x)
-        orow[i] = f2b(b2f(sr[i]) * inv * b2f(w[i]));
+    for (int i = threadIdx.x; i < cols; i += blockDim.x) {
+        const bf16 ob = f2b(b2f(sr[i]) * inv * b2f(w[i]));
+        orow[i] = ob;
+        // The dp4a backbone wants Q8_1 of exactly this row. blockDim is a multiple of 32, so on
+        // every pass element i sits on lane i%32 of one warp and the 32 lanes of that warp hold
+        // the whole 32-group -- which is precisely what the standalone quantizer assumes.
+        if (q81) si_q81_emit(q81 + (size_t)r * (cols >> 5) + (i >> 5), threadIdx.x & 31, b2f(ob));
+    }
 }
 
 __global__ void k_rms_heads(bf16* x, const bf16* w, int seq, int n_heads, int d, float eps) {
@@ -1144,6 +1172,126 @@ __global__ void k_gemv_batched_fused3_q4(
 // at 0.75-4.5 CTAs/SM on a 170-SM device -- far too few to cover DRAM latency -- so parallelism,
 // not bytes, is what they are short of. Cutting ROWS instead would also add CTAs, but it multiplies
 // the activation re-reads, which is why 4 -> 2 -> 1 measured progressively worse.
+// The Q4 weight and scale reads are __ldcs (evict-first). This kernel streams 620 MB of draft
+// weights per block and every byte is read exactly once, so caching them is pure harm: it evicts
+// the small, genuinely hot data the rest of the step re-reads -- the verify's staged activations,
+// which every CTA of every NVFP4 GEMV pulls from L2, and the KV caches. #909 put the same hint on
+// the target's NVFP4 weight stream for +3.50%; this kernel and the two LM heads were the streams
+// it did not cover, and between them they were pushing 1.8 GB/step through L2 with default policy.
+// DP4A form of k_gemv_batched_fused3_q4_ks.
+//
+// The draft was the one part of this engine that never got the treatment the verify has. Its
+// backbone multiplied BF16 activations by dequantized-to-float Q4 weights, which costs on three
+// axes at once, and the axes are not independent:
+//   * TRAFFIC. Activation reads are grid x BATCH x K x 2 B, and grid is total/ROWS. At the draft's
+//     shapes that is 3.86 GB of activation per block against 620 MB of weights -- 6:1. Cutting it
+//     by raising ROWS was measured (1.484 -> 1.546 ms): it halves the traffic and doubles the
+//     registers, and the registers win. The only escape is fewer BYTES per element.
+//   * INSTRUCTIONS. `wf[r][j] = q*d + m` then a float FMA per (r, b, j) is ONE MAC per
+//     instruction. Measured 0.69 MACs/instruction against the verify's dp4a path at 2.3.
+//   * REGISTERS. `float wf[ROWS][8]` is 32 registers of dequantized weight held live across the
+//     activation loop.
+// A q8_1 activation fixes all three in the same direction: 1.125 B/element instead of 2, eight
+// dp4a instead of 32 float FMAs per (r, b) per 32-block, and the weights stay packed as int8 (8
+// registers, not 32). sum(w.x) = d_w*d_x*dp4a(q, xq) + m_w*(d_x*sum(xq)), and q8_1 already carries
+// d_x*sum(xq) in ds.y, so the affine term is free.
+//
+// Draft-only, so this is NOMINATION-only: it can move which tokens are proposed, never which are
+// emitted. LOSSLESS is unaffected.
+template <int BATCH, int ROWS, int KSPLIT>
+__global__ void k_gemv_batched_fused3_q4_dp4a(
+        const si_q81_blk* __restrict__ xq,
+        const unsigned char* __restrict__ Q0, const unsigned char* __restrict__ Q1,
+        const unsigned char* __restrict__ Q2,
+        const __half2* __restrict__ D0, const __half2* __restrict__ D1, const __half2* __restrict__ D2,
+        bf16* __restrict__ y0, bf16* __restrict__ y1, bf16* __restrict__ y2,
+        int N0, int N1, int N2, int K) {
+    __shared__ float red[KSPLIT][ROWS][BATCH];
+    const int total = N0 + N1 + N2;
+    const int warp = threadIdx.x >> 5;
+    const int lane = threadIdx.x & 31;
+    const int KB = K / 32;                       // 32-value blocks: one weight (d, m) pair each
+    for (int global_n = blockIdx.x * ROWS; global_n < total; global_n += gridDim.x * ROWS) {
+        const unsigned char* Q; const __half2* D; bf16* y; int N, n0;
+        if (global_n < N0)           { Q = Q0; D = D0; y = y0; N = N0; n0 = global_n; }
+        else if (global_n < N0 + N1) { Q = Q1; D = D1; y = y1; N = N1; n0 = global_n - N0; }
+        else                         { Q = Q2; D = D2; y = y2; N = N2; n0 = global_n - N0 - N1; }
+        const int nr = (N - n0 < ROWS) ? (N - n0) : ROWS;
+        float acc[ROWS][BATCH];
+#pragma unroll
+        for (int r = 0; r < ROWS; r++)
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) acc[r][b] = 0.f;
+        for (int kb = warp * 32 + lane; kb < KB; kb += KSPLIT * 32) {
+            unsigned wq[ROWS][8];
+            float dw[ROWS], mw[ROWS];
+#pragma unroll
+            for (int r = 0; r < ROWS; r++) {
+                const int rr = (r < nr) ? r : 0;
+                const uint4 pk = __ldcs(reinterpret_cast<const uint4*>(
+                    Q + (size_t)(rr + n0) * (K / 2) + (size_t)kb * 16));
+                const float2 dmf = __half22float2(__ldcs(&D[(size_t)(rr + n0) * KB + kb]));
+                dw[r] = dmf.x; mw[r] = dmf.y;
+                const unsigned pv[4] = { pk.x, pk.y, pk.z, pk.w };
+#pragma unroll
+                for (int u = 0; u < 4; u++) {
+                    // Element e of a word: nibble e, little-endian -- so even elements are the low
+                    // nibbles and odd the high, and the two interleave back with one byte_perm.
+                    const unsigned lo = pv[u] & 0x0F0F0F0Fu;
+                    const unsigned hi = (pv[u] >> 4) & 0x0F0F0F0Fu;
+                    wq[r][2 * u]     = __byte_perm(lo, hi, 0x5140);
+                    wq[r][2 * u + 1] = __byte_perm(lo, hi, 0x7362);
+                }
+            }
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) {
+                const si_q81_blk* xb = xq + (size_t)b * KB + kb;
+                const float2 dsf = __half22float2(xb->ds);
+                // FOUR-byte loads, not uint4: a q8_1 block is 36 bytes with ds first, so qs sits at
+                // byte 36*b + 4 and is never 16-byte aligned. A uint4 load there is misaligned and
+                // silently returns garbage -- it took the whole verify down (batched 0.095 ms,
+                // tau 4.64, LOSSLESS 0) because the draft then fed out-of-range ids into it.
+                const unsigned* ap = reinterpret_cast<const unsigned*>(xb->qs);
+                unsigned av[8];
+#pragma unroll
+                for (int u = 0; u < 8; u++) av[u] = ap[u];
+#pragma unroll
+                for (int r = 0; r < ROWS; r++) {
+                    int d1 = 0;
+#pragma unroll
+                    for (int u = 0; u < 8; u++) d1 = __dp4a((int)wq[r][u], (int)av[u], d1);
+                    acc[r][b] += dw[r] * (dsf.x * (float)d1) + mw[r] * dsf.y;
+                }
+            }
+        }
+#pragma unroll
+        for (int r = 0; r < ROWS; r++)
+#pragma unroll
+            for (int b = 0; b < BATCH; b++) {
+#pragma unroll
+                for (int off = 16; off > 0; off >>= 1)
+                    acc[r][b] += __shfl_down_sync(0xffffffffu, acc[r][b], off);
+            }
+        if (lane == 0) {
+#pragma unroll
+            for (int r = 0; r < ROWS; r++)
+#pragma unroll
+                for (int b = 0; b < BATCH; b++) red[warp][r][b] = acc[r][b];
+        }
+        __syncthreads();
+        if (warp == 0 && lane < ROWS * BATCH) {
+            const int r = lane / BATCH, b = lane % BATCH;
+            if (r < nr) {
+                float o = 0.f;
+#pragma unroll
+                for (int w = 0; w < KSPLIT; w++) o += red[w][r][b];
+                y[(size_t)b * N + n0 + r] = f2b(o);
+            }
+        }
+        __syncthreads();
+    }
+}
+
 template <int BATCH, int ROWS, int KSPLIT>
 __global__ void k_gemv_batched_fused3_q4_ks(
         const bf16* __restrict__ x,
@@ -1174,8 +1322,8 @@ __global__ void k_gemv_batched_fused3_q4_ks(
             for (int r = 0; r < ROWS; r++) {
                 const int rr = (r < nr) ? r : 0;
                 const unsigned int packed =
-                    reinterpret_cast<const unsigned int*>(Q + (size_t)(n0 + rr) * (K / 2))[k8];
-                const float2 dmf = __half22float2(D[(size_t)(n0 + rr) * KS + (k8 >> 2)]);
+                    __ldcs(&reinterpret_cast<const unsigned int*>(Q + (size_t)(n0 + rr) * (K / 2))[k8]);
+                const float2 dmf = __half22float2(__ldcs(&D[(size_t)(n0 + rr) * KS + (k8 >> 2)]));
 #pragma unroll
                 for (int j = 0; j < 4; j++) {
                     const unsigned int byte = (packed >> (8 * j)) & 0xFFu;
@@ -1234,6 +1382,36 @@ void launch_quantize_w_q4(const void* w, void* q, void* dm, int N, int K, cudaSt
         (const bf16*)w, (unsigned char*)q, (__half2*)dm, nblocks);
 }
 
+// dp4a twin of launch_gemv_batched_q4_fused3. `xq81` is Q8_1(x) -- one si_q81_blk per 32 values
+// per batch row -- which the caller produces once and reuses for every projection sharing that
+// activation. Declines when the shapes do not line up so the caller keeps the float path.
+void launch_gemv_batched_q4_dp4a_fused3(const void* xq81,
+                                        const void* Q0, const void* Q1, const void* Q2,
+                                        const void* D0, const void* D1, const void* D2,
+                                        void* y0, void* y1, void* y2,
+                                        int N0, int N1, int N2, int K, cudaStream_t stream,
+                                        int batch) {
+    const int total = N0 + N1 + N2;
+    if (total <= 0 || (K & 31)) return;
+    constexpr int ROWS = 4, KS = 2;
+    const int nblk = (total + ROWS - 1) / ROWS;
+    const dim3 grid(nblk), blk(KS * 32);
+    const auto* xp = reinterpret_cast<const si_q81_blk*>(xq81);
+#define SI_DP4A_F3(BW_) k_gemv_batched_fused3_q4_dp4a<BW_, ROWS, KS><<<grid, blk, 0, stream>>>( \
+        xp, (const unsigned char*)Q0, (const unsigned char*)Q1, (const unsigned char*)Q2,       \
+        (const __half2*)D0, (const __half2*)D1, (const __half2*)D2,                            \
+        (bf16*)y0, (bf16*)y1, (bf16*)y2, N0, N1, N2, K)
+    if (batch == 1)      SI_DP4A_F3(1);
+    else if (batch == 2) SI_DP4A_F3(2);
+    else if (batch == 3) SI_DP4A_F3(3);
+    else if (batch == 4) SI_DP4A_F3(4);
+    else if (batch == 5) SI_DP4A_F3(5);
+    else if (batch == 6) SI_DP4A_F3(6);
+    else if (batch == 7) SI_DP4A_F3(7);
+    else                 SI_DP4A_F3(8);
+#undef SI_DP4A_F3
+}
+
 void launch_gemv_batched_q4_fused3(const void* x,
                                    const void* Q0, const void* Q1, const void* Q2,
                                    const void* D0, const void* D1, const void* D2,
@@ -1273,7 +1451,13 @@ void launch_gemv_batched_q4_fused3(const void* x,
         // which is not a power of two: rounding depth+1 up over {2,4,8,16} and clamping to 7
         // produced a width nothing was compiled for, and the caller fell back to a per-token
         // GEMV loop that re-reads every weight row once per row.
-        if (batch == 2)      SI_Q4KS_B(2);
+        // Widths 1 and 3 exist for the draft's CONTEXT rows and its fc projection, whose row
+        // count is the ACCEPTED length: 1 is its mode and 3 its next most common value. Without
+        // them a 1- or 3-row call fell through to the 16-wide branch and would read up to 15 rows
+        // of activation past the end of the caller's buffer.
+        if (batch == 1)      SI_Q4KS_B(1);
+        else if (batch == 2) SI_Q4KS_B(2);
+        else if (batch == 3) SI_Q4KS_B(3);
         else if (batch == 4) SI_Q4KS_B(4);
         else if (batch == 5) SI_Q4KS_B(5);
         else if (batch == 6) SI_Q4KS_B(6);
@@ -1363,13 +1547,14 @@ void launch_rms(const void* x, const void* w, void* out, int rows, int cols, flo
 }
 
 void launch_add_rms(const void* a, const void* b, void* sum, const void* w, void* out,
-                    int rows, int cols, float eps, cudaStream_t stream) {
+                    int rows, int cols, float eps, cudaStream_t stream, void* q81) {
     if (rows <= 0 || cols <= 0) return;
     // One CTA per row and only 256 threads left a 5120-wide row at 20 elements per thread with
     // four CTAs resident on a 170-SM device. Widen the CTA instead: same reduction (warp sums
     // folded in ascending warp order through ws[]), four times the memory-level parallelism.
     k_add_rms<<<rows, 1024, 0, stream>>>((const bf16*)a, (const bf16*)b, (bf16*)sum,
-                                        (const bf16*)w, (bf16*)out, rows, cols, eps);
+                                        (const bf16*)w, (bf16*)out, rows, cols, eps,
+                                        reinterpret_cast<si_q81_blk*>(q81));
 }
 
 void launch_rms_heads_rope(void* x, const void* w, int seq, int n_heads, int d, float eps,
@@ -1414,9 +1599,19 @@ int attn_gqa_splits(int kv_len) {
     // kv_len 128 -> 2, 512 -> 8, 4096 -> 16 splits were each at or within ~2% of the best
     // (splits, rows) pair, and every point beat the unsplit kernel. Splitting past 16 starts
     // losing to the per-split combine and the shrinking per-CTA key count.
+    // Probe knob. The sweep behind the constant above was taken against the ONE-KEY-AT-A-TIME
+    // kernel; the key tile shortened the per-warp chain, which is exactly the quantity the split
+    // count trades against the per-split partial writes and the combine, so the optimum is worth
+    // re-deriving rather than inherited. Clamped to the compiled cap -- fa_m/fa_l/fa_acc are sized
+    // for it.
+    static const int cap = []{
+        const char* e = getenv("SPARKINFER_DFLASH_ATTN_SPLITS");
+        const int v = e ? atoi(e) : kDFlashAttnMaxSplits;
+        return (v >= 1 && v <= kDFlashAttnMaxSplits) ? v : kDFlashAttnMaxSplits;
+    }();
     int s = kv_len / 64;
     if (s < 2) s = 2;
-    if (s > kDFlashAttnMaxSplits) s = kDFlashAttnMaxSplits;
+    if (s > cap) s = cap;
     return s;
 }
 
@@ -1921,6 +2116,36 @@ __global__ void k_confidence_head(const bf16* __restrict__ hidden, const float* 
     }
     if (threadIdx.x == 0) *out_confidence = sred[0] + bias_val;
 }
+
+// ROW-BATCHED confidence head. Identical arithmetic to k_confidence_head -- same dot, same block
+// size, same shared-memory tree -- with blockIdx.x selecting the row.
+//
+// The single-row form runs on a grid of ONE, so its 8.5 us is almost entirely launch and reduction
+// latency, and DSpark's Markov chain calls it once per proposal: four grid-1 launches, 34 us of a
+// 1.5 ms draft. They were serialised only because `markov_latent` was one buffer that each chain
+// step overwrote; giving the latent a per-row stride lets all four run as one grid-4 launch after
+// the chain, which is what this kernel is for. Nothing about the chain's own ordering changes --
+// the confidence head never fed back into it.
+__global__ void k_confidence_head_rows(const bf16* __restrict__ hidden, int hidden_stride,
+                                       const float* __restrict__ latent, int latent_stride,
+                                       const bf16* __restrict__ w, float bias_val,
+                                       int H, int rank, int row0,
+                                       float* __restrict__ out_confidence) {
+    extern __shared__ float sred[];
+    const int b = blockIdx.x;
+    const bf16* hp = hidden + (size_t)(row0 + b) * hidden_stride;
+    const float* lp = latent + (size_t)(b + 1) * latent_stride;
+    float acc = 0.f;
+    for (int i = threadIdx.x; i < H; i += blockDim.x) acc += b2f(hp[i]) * b2f(w[i]);
+    for (int i = threadIdx.x; i < rank; i += blockDim.x) acc += lp[i] * b2f(w[H + i]);
+    sred[threadIdx.x] = acc;
+    __syncthreads();
+    for (int s = blockDim.x / 2; s > 0; s >>= 1) {
+        if (threadIdx.x < s) sred[threadIdx.x] += sred[threadIdx.x + s];
+        __syncthreads();
+    }
+    if (threadIdx.x == 0) out_confidence[b + 1] = sred[0] + bias_val;
+}
 } // namespace
 
 void launch_capture_rows(const void* src, void* dst, int rows, int hidden, int dst_row_stride,
@@ -1995,6 +2220,17 @@ void launch_confidence_head(const void* hidden, const float* latent, const void*
     const int threads = 256;
     k_confidence_head<<<1, threads, threads * sizeof(float), stream>>>(
         (const bf16*)hidden, latent, (const bf16*)w, bias, H, rank, out_confidence);
+}
+
+void launch_confidence_head_rows(const void* hidden, int hidden_stride,
+                                 const float* latent, int latent_stride,
+                                 const void* w, float bias, int H, int rank,
+                                 int row0, int rows, float* out_confidence, cudaStream_t stream) {
+    if (H <= 0 || rank < 0 || rows <= 0) return;
+    const int threads = 256;
+    k_confidence_head_rows<<<rows, threads, threads * sizeof(float), stream>>>(
+        (const bf16*)hidden, hidden_stride, latent, latent_stride,
+        (const bf16*)w, bias, H, rank, row0, out_confidence);
 }
 
 } // namespace dflash_kernels

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -51,8 +51,11 @@ void launch_add(const void* x, const void* y, void* out, int n,
                 cudaStream_t stream);
 
 // sum = a + b, then out = rms(sum) * w. One launch for the residual+norm pair.
+// `q81`, when non-null, additionally emits Q8_1(out) -- 36 B per 32 values per row -- so the dp4a
+// backbone's activation needs no separate quantize launch. Bit-identical to running
+// launch_quantize_q8_1_rows on `out` afterwards.
 void launch_add_rms(const void* a, const void* b, void* sum, const void* w, void* out,
-                    int rows, int cols, float eps, cudaStream_t stream);
+                    int rows, int cols, float eps, cudaStream_t stream, void* q81 = nullptr);
 
 // RMSNorm over last dim: x [rows, cols] -> out [rows, cols], weight [cols].
 void launch_rms(const void* x, const void* w, void* out, int rows, int cols,
@@ -85,6 +88,13 @@ void launch_capture_row(const void* x, void* hidden, const int* cap_row, int slo
 void launch_quantize_w_q4(const void* w, void* q, void* dm, int N, int K, cudaStream_t stream);
 
 // int4-weight form of launch_gemv_batched16_fused3 (~5 bits/weight vs Q8_0's 9).
+// dp4a twin of the Q4 fused3 below; `xq81` is Q8_1(x), 36 B per 32 values per batch row.
+void launch_gemv_batched_q4_dp4a_fused3(const void* xq81,
+                                        const void* Q0, const void* Q1, const void* Q2,
+                                        const void* D0, const void* D1, const void* D2,
+                                        void* y0, void* y1, void* y2,
+                                        int N0, int N1, int N2, int K, cudaStream_t stream,
+                                        int batch);
 void launch_gemv_batched_q4_fused3(const void* x,
                                    const void* Q0, const void* Q1, const void* Q2,
                                    const void* D0, const void* D1, const void* D2,
@@ -209,6 +219,12 @@ void launch_markov_bias_add(const void* w1, const void* w2, const int* prev_toke
 // comparisons). `latent` must already hold the SAME row's Markov latent (see out_latent above).
 void launch_confidence_head(const void* hidden, const float* latent, const void* w, float bias,
                             int H, int rank, float* out_confidence, cudaStream_t stream);
+// Row-batched form of the above: one launch for every proposal row instead of one per row inside
+// the Markov chain. `latent` must have a per-row stride (see Impl::markov_latent).
+void launch_confidence_head_rows(const void* hidden, int hidden_stride,
+                                 const float* latent, int latent_stride,
+                                 const void* w, float bias, int H, int rank,
+                                 int row0, int rows, float* out_confidence, cudaStream_t stream);
 
 } // namespace dflash_kernels
 } // namespace sparkinfer

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -319,6 +319,10 @@ struct DFlashDraftModel::Impl {
     float  yarn_att_scale = 1.0f;
     bf16* hidden_norm = nullptr;
     bf16* final_norm = nullptr;
+    // Quantized copy of `fc`. The projector is [hidden, n_cap*hidden] = [5120, 25600] on DSpark,
+    // 262 MB of bf16 -- and it was the ONE draft matrix still read at full precision, once per
+    // block, to project 1-5 context rows. Every other projection has had a Q4 copy since #661.
+    Q8W q8_fc;
     std::vector<void*> owned;
 
     // Shared target pointers
@@ -351,7 +355,12 @@ struct DFlashDraftModel::Impl {
     // (confidence_head_with_markov=True for every DSpark checkpoint released so far).
     bf16* confidence_w = nullptr;   // [hidden + markov_rank]
     float confidence_bias = 0.f;    // scalar, read back to host once at load (cheap, load-time only)
-    float* markov_latent = nullptr; // [markov_rank] scratch, reused per row of the sequential loop
+    // [block_size+1][markov_rank]. It USED to be a single [markov_rank] scratch overwritten by
+    // every step of the sequential Markov loop, which forced the confidence head to run inside
+    // that loop -- four separate grid-of-ONE launches, 8.5 us each, for a dot product. With a
+    // per-row stride the four become one grid-4 launch after the chain. The chain itself is
+    // unaffected: nothing in it ever read the latent back.
+    float* markov_latent = nullptr;
 
     // Scratch
     cudaStream_t stream{};
@@ -365,6 +374,11 @@ struct DFlashDraftModel::Impl {
     float* logits = nullptr;        // [B, vocab]
     void* head_q8 = nullptr;        // [B] Q8_1 rows of xn for the multi-row head MMVQ
     int *d_ids = nullptr, *d_out = nullptr;
+    int *h_ids = nullptr;                        // PINNED staging for the block ids
+    // Q8_1 staging for the dp4a backbone: one 36-byte block per 32 values per block row, sized for
+    // the widest K any projection uses (the FFN's intermediate).
+    void* xq81 = nullptr;
+
     int *h_out = nullptr;
     float *d_confidence = nullptr, *h_confidence = nullptr;   // [B], confidence head output
 
@@ -461,6 +475,20 @@ struct DFlashDraftModel::Impl {
         // at B: it holds the block's input ids, one per row.
         d_out = alloc<int>(B + 1);
         cu(cudaHostAlloc(&h_out, (B + 1) * sizeof(int), cudaHostAllocDefault), "h_out");
+        // The block ids arrive in a caller-owned std::vector, i.e. PAGEABLE memory, and CUDA
+        // performs a stream synchronize before a pageable H2D copy is initiated. Every other host
+        // buffer on this path (h_out, h_confidence, and the verify's ph_ids/ph_pos/ph_seq) is
+        // already pinned; this one was the exception, and it sits at the very first instruction of
+        // the draft block -- immediately after the verify has left a 158 us GDN state commit in
+        // flight on the target's stream, which shares no data with the draft and should overlap it.
+        cu(cudaHostAlloc(&h_ids, (B + 1) * sizeof(int), cudaHostAllocDefault), "h_ids");
+        {
+            int kmax = (cfg.intermediate > cfg.hidden ? cfg.intermediate : cfg.hidden);
+            const int kfc = (int)cfg.target_layer_ids.size() * cfg.hidden;   // the fc projector
+            if (kfc > kmax) kmax = kfc;
+            const size_t blocks = (size_t)(B + 1) * ((kmax + 31) / 32);
+            xq81 = alloc<char>(blocks * 36);
+        }
         if (confidence_w) {
             d_confidence = alloc<float>(B + 1);
             cu(cudaHostAlloc(&h_confidence, (B + 1) * sizeof(float), cudaHostAllocDefault),
@@ -553,6 +581,7 @@ DFlashDraftModel::~DFlashDraftModel() {
     if (!p_) return;
     for (void* p : p_->owned) cudaFree(p);
     if (p_->h_out) cudaFreeHost(p_->h_out);
+    if (p_->h_ids) cudaFreeHost(p_->h_ids);
     if (p_->h_confidence) cudaFreeHost(p_->h_confidence);
     if (p_->stream) cudaStreamDestroy(p_->stream);
     delete p_;
@@ -744,6 +773,12 @@ bool DFlashDraftModel::load(const std::string& dir) {
     s.fc = s.upload(*fc);
     s.hidden_norm = s.upload(*hn);
     s.final_norm = s.upload(*nn);
+    // Quantize the projector alongside the layer weights (see Impl::q8_fc). The bf16 copy stays:
+    // the FIRST block projects the whole prompt and routes to the tensor-core GEMM, which is
+    // compute-bound and wants bf16.
+    if (q8_on())
+        s.pending_quant.push_back({s.fc, s.cfg.hidden,
+                                   (int)s.cfg.target_layer_ids.size() * s.cfg.hidden, &s.q8_fc});
 
     s.layers.resize(s.cfg.n_layers);
     for (int L = 0; L < s.cfg.n_layers; L++) {
@@ -838,7 +873,7 @@ bool DFlashDraftModel::load(const std::string& dir) {
             const unsigned short raw = *reinterpret_cast<const unsigned short*>(cb->data);
             unsigned int bits = (unsigned int)raw << 16;
             std::memcpy(&s.confidence_bias, &bits, sizeof(float));
-            if (cudaMalloc(&s.markov_latent, (size_t)s.markov_rank * sizeof(float)) != cudaSuccess)
+            if (cudaMalloc(&s.markov_latent, (size_t)(s.cfg.block_size + 1) * s.markov_rank * sizeof(float)) != cudaSuccess)
                 s.confidence_w = nullptr;  // can't run the head without scratch -- disable cleanly
             else
                 s.owned.push_back(s.markov_latent);
@@ -915,6 +950,9 @@ bool DFlashDraftModel::load_gguf(const std::string& path) {
     s.hidden_norm = dense("enc.output_norm.weight");
     s.final_norm = dense("output_norm.weight");
     if (!s.fc || !s.hidden_norm || !s.final_norm) return false;
+    if (q8_on())
+        s.pending_quant.push_back({s.fc, s.cfg.hidden,
+                                   (int)s.cfg.target_layer_ids.size() * s.cfg.hidden, &s.q8_fc});
 
     const int H = s.cfg.hidden;
     const int I = s.cfg.intermediate;
@@ -1050,6 +1088,41 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         const int w = v <= 2 ? 2 : (v <= 4 ? 4 : (v <= 8 ? 8 : 16));
         return w > c.block_size ? c.block_size : w;
     }();
+    // DP4A BACKBONE (SPARKINFER_DFLASH_DP4A=0 restores the float path). Quantizes each activation
+    // to Q8_1 once and drives every projection that shares it through the dp4a kernel: 1.125 B per
+    // element instead of 2, eight dp4a instead of 32 float FMAs per (weight row, block row) per
+    // 32-block, and the weights stay packed. Draft-only, so it moves what is PROPOSED, never what
+    // is emitted.
+    // BITMASK: 1 = Q/K/V, 2 = o-proj, 4 = gate/up, 8 = down. Swept at 512 generated tokens, where
+    // tau resolves to 512/222 rather than 128/71 -- at 128 the step-count lottery is 1.4% and
+    // swamps the effect, and reading it there produced a confident but WRONG conclusion that the
+    // o-projection could not take a quantized activation:
+    //
+    //     mask           draft ms   step ms   tau      DSPARK
+    //     0  (none)       1.475     13.374    2.3198   172.44
+    //     12 (FFN)        1.382     13.278    2.3198   173.68
+    //     14 (+o_proj)    1.369     13.246    2.3094   173.33
+    //     15 (all four)   1.336     13.215    2.3198   174.51   <- default
+    //
+    // All four take Q8_1 for free. Draft-only either way: this moves what is PROPOSED, never what
+    // is emitted, and LOSSLESS stays 1.
+    static const int kDp4a = []{ const char* e = getenv("SPARKINFER_DFLASH_DP4A");
+                                 return e ? atoi(e) : 15; }();
+    const bool dp4a_ok = s.xq81 != nullptr;
+    const bool dp4a_qkv  = dp4a_ok && (kDp4a & 1);
+    const bool dp4a_o    = dp4a_ok && (kDp4a & 2);
+    const bool dp4a_gu   = dp4a_ok && (kDp4a & 4);
+    const bool dp4a_down = dp4a_ok && (kDp4a & 8);
+    // Set when the producing norm has already emitted Q8_1 of the activation, so the projection
+    // that consumes it can skip the standalone quantize launch. The single staging buffer is safe
+    // because each fold is immediately followed by its one consumer -- nothing else touches xq81
+    // in between.
+    bool xn_ready = false, hn_ready = false;
+    auto q81n = [&](const bf16* src, int kk, int rows) {
+        kernels::launch_quantize_q8_1_rows(src, s.xq81, kk, rows, kk, st);
+        return s.xq81;
+    };
+    auto q81 = [&](const bf16* src, int kk) { return q81n(src, kk, BW); };
     const float scale = 1.f / sqrtf((float)d);
     const int past = s.seq_len;
     // The fixed-size (block_size) projections below can use a batched-GEMV kernel that reads
@@ -1059,7 +1132,15 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     const bool fast16 = (BW == 16 || BW == 8 || BW == 7 || BW == 6 || BW == 5 ||
                          BW == 4 || BW == 2);
 
-    cu(cudaMemcpyAsync(s.d_ids, noise_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
+    // Stage through pinned memory (see h_ids): a pageable H2D would sync the stream here.
+    static const bool kPinIds = []{ const char* e = getenv("SPARKINFER_DFLASH_PIN_IDS");
+                                    return !(e && e[0] == '0'); }();
+    if (kPinIds && s.h_ids) {
+        for (int i = 0; i < BW; i++) s.h_ids[i] = noise_ids[i];
+        cu(cudaMemcpyAsync(s.d_ids, s.h_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
+    } else {
+        cu(cudaMemcpyAsync(s.d_ids, noise_ids, BW * sizeof(int), cudaMemcpyHostToDevice, st), "ids");
+    }
     kernels::launch_embedding(s.d_ids, s.embed, s.noise, BW, H, st);
 
     // target_hidden [ctx, n_cap*H] -> fc -> hidden_norm -> target_proj [ctx, H]
@@ -1100,11 +1181,25 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         }
     }
     const int fc_rows = ctx_len - fc_skip;
+    // Route the two remaining BF16 weight reads in this block -- the projector above and the
+    // per-layer context K/V below -- through the Q4 copies. 0 restores bf16 for both.
+    static const bool kCtxQ4 = []{ const char* e = getenv("SPARKINFER_DFLASH_CTX_Q4");
+                                   return !(e && e[0] == '0'); }();
     if (fc_rows > 0) {
         const bf16* th = (const bf16*)target_hidden + (size_t)fc_skip * n_cap * H;
         bf16* tp = s.target_proj + (size_t)fc_skip * H;
+        const bool fc_q4 = kCtxQ4 && s.q8_fc.q4 && fc_rows >= 1 && fc_rows <= 8;
         if (ctx_gemm) {
             kernels::launch_prefill_gemm(th, s.fc, tp, fc_rows, H, n_cap * H, st);
+        } else if (fc_q4 && dp4a_ok) {
+            dflash_kernels::launch_gemv_batched_q4_dp4a_fused3(
+                q81n(th, n_cap * H, fc_rows), s.q8_fc.q4, nullptr, nullptr,
+                s.q8_fc.dm, nullptr, nullptr,
+                tp, nullptr, nullptr, H, 0, 0, n_cap * H, st, fc_rows);
+        } else if (fc_q4) {
+            dflash_kernels::launch_gemv_batched_q4_fused3(
+                th, s.q8_fc.q4, nullptr, nullptr, s.q8_fc.dm, nullptr, nullptr,
+                tp, nullptr, nullptr, H, 0, 0, n_cap * H, st, fc_rows);
         } else if (fc_rows > 1) {
             dflash_kernels::launch_gemv_rows_batched(th, s.fc, tp, fc_rows, H, n_cap * H, st);
         } else {
@@ -1155,7 +1250,13 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
 
         // Q from noise, K/V from cat(target, noise)
         if (fast16) {
-            if (w.q8_wq.q4)
+            if (w.q8_wq.q4 && dp4a_qkv)
+                dflash_kernels::launch_gemv_batched_q4_dp4a_fused3(
+                    xn_ready ? s.xq81 : q81(s.xn, H), w.q8_wq.q4, w.q8_wk.q4, w.q8_wv.q4,
+                    w.q8_wq.dm, w.q8_wk.dm, w.q8_wv.dm,
+                    s.q, kdst + (size_t)ctx_len * kvdim, vdst + (size_t)ctx_len * kvdim,
+                    qdim, kvdim, kvdim, H, st, BW);
+            else if (w.q8_wq.q4)
                 dflash_kernels::launch_gemv_batched_q4_fused3(
                     s.xn, w.q8_wq.q4, w.q8_wk.q4, w.q8_wv.q4, w.q8_wq.dm, w.q8_wk.dm, w.q8_wv.dm,
                     s.q, kdst + (size_t)ctx_len * kvdim, vdst + (size_t)ctx_len * kvdim,
@@ -1175,6 +1276,7 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.xn + (size_t)t * H, w.wq, s.q + (size_t)t * qdim, qdim, H, st);
         }
+        xn_ready = false;   // consumed above; xq81 is reused by the projections that follow
         // Context half of cat(k_ctx, k_noise), written ahead of the noise rows.
         //
         // A windowed layer never reads a key older than `window` before the query, and
@@ -1198,9 +1300,42 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         const bf16* const ctx_src = s.target_proj + (size_t)ctx_skip * H;
         bf16* const kdst_ctx = kdst + (size_t)ctx_skip * kvdim;
         bf16* const vdst_ctx = vdst + (size_t)ctx_skip * kvdim;
+        // The steady-state context rows went through the BF16 wk/wv while every other projection
+        // in this block -- including the noise rows' own K/V, from the same two matrices -- goes
+        // through the Q4 copies. That is 21 MB of weights per layer against 2.6 MB, on a path that
+        // runs 1-5 rows and is therefore purely weight-bound.
+        //
+        // It was left bf16 out of caution about the context being the one place the TARGET's
+        // information enters the draft. Measured, that caution is unfounded: sweeping the draft's
+        // whole backbone precision (SPARKINFER_DFLASH_WBITS) does not move acceptance in the
+        // direction precision would predict. At 512 generated tokens, MORE precision gives LOWER
+        // acceptance -- Q4 tau 2.3733, Q8 tau 2.3624 for +0.47 ms of draft -- so what is being
+        // read is numeric luck, not draft quality. Judge changes on this path by `draft ms/call`
+        // and `batched ms/call`, which are deterministic to ~0.005 ms; a tau delta under ~2% on a
+        // single prompt says nothing. The draft is insensitive to weight precision, so the context
+        // rows may use the same Q4 copies the block rows do.
+        //
+        // The wide first-block case (ctx_gemm) stays on the bf16 tensor-core GEMM: at 4096 rows it
+        // is COMPUTE bound and already runs at ~169 TFLOPS, ~80% of this card's bf16 peak, where a
+        // dequantising path would only add work. SPARKINFER_DFLASH_CTX_Q4=0 restores bf16.
+        // ctx_rows is the ACCEPTED length, so 1 is its modal value -- and the single-row case was
+        // the most expensive of all, two separate bf16 GEMVs each streaming the whole 10.5 MB
+        // matrix to produce one row. Cover 1..8, not just the multi-row tiers.
+        const bool ctx_q4 = kCtxQ4 && w.q8_wk.q4 && w.q8_wv.q4 && ctx_rows >= 1 && ctx_rows <= 8;
         if (ctx_rows > 0 && ctx_gemm) {
             kernels::launch_prefill_gemm(ctx_src, w.wk, kdst_ctx, ctx_rows, kvdim, H, st);
             kernels::launch_prefill_gemm(ctx_src, w.wv, vdst_ctx, ctx_rows, kvdim, H, st);
+        } else if (ctx_q4 && dp4a_ok) {
+            dflash_kernels::launch_gemv_batched_q4_dp4a_fused3(
+                q81n(ctx_src, H, ctx_rows), w.q8_wk.q4, w.q8_wv.q4, nullptr,
+                w.q8_wk.dm, w.q8_wv.dm, nullptr,
+                kdst_ctx, vdst_ctx, nullptr, kvdim, kvdim, 0, H, st, ctx_rows);
+        } else if (ctx_q4) {
+            // Same fused pair the noise rows use; y0/y1 are written as [row][kvdim], which is
+            // exactly the cache slice's layout.
+            dflash_kernels::launch_gemv_batched_q4_fused3(
+                ctx_src, w.q8_wk.q4, w.q8_wv.q4, nullptr, w.q8_wk.dm, w.q8_wv.dm, nullptr,
+                kdst_ctx, vdst_ctx, nullptr, kvdim, kvdim, 0, H, st, ctx_rows);
         } else if (ctx_rows > 1) {
             dflash_kernels::launch_gemv_rows_exact_fused2(
                 ctx_src, w.wk, w.wv, kdst_ctx, vdst_ctx,
@@ -1285,7 +1420,12 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                         s.fa_m, s.fa_l, s.fa_acc);
 
         if (fast16) {
-            if (w.q8_wo.q4)
+            if (w.q8_wo.q4 && dp4a_o)
+                dflash_kernels::launch_gemv_batched_q4_dp4a_fused3(
+                    q81(s.attn, qdim), w.q8_wo.q4, nullptr, nullptr,
+                    w.q8_wo.dm, nullptr, nullptr,
+                    s.ao, nullptr, nullptr, H, 0, 0, qdim, st, BW);
+            else if (w.q8_wo.q4)
                 dflash_kernels::launch_gemv_batched_q4_fused3(
                     s.attn, w.q8_wo.q4, nullptr, nullptr, w.q8_wo.dm, nullptr, nullptr,
                     s.ao, nullptr, nullptr, H, 0, 0, qdim, st, BW);
@@ -1299,9 +1439,16 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
             for (int t = 0; t < BW; t++)
                 kernels::launch_gemv(s.attn + (size_t)t * qdim, w.wo, s.ao + (size_t)t * H, H, qdim, st);
         }
-        dflash_kernels::launch_add_rms(s.x, s.ao, s.h, w.post_norm, s.hn, BW, H, c.rms_eps, st);
+        dflash_kernels::launch_add_rms(s.x, s.ao, s.h, w.post_norm, s.hn, BW, H, c.rms_eps, st,
+                                       dp4a_gu ? s.xq81 : nullptr);
+        hn_ready = dp4a_gu;
         if (fast16) {
-            if (w.q8_gate.q4)
+            if (w.q8_gate.q4 && dp4a_gu)
+                dflash_kernels::launch_gemv_batched_q4_dp4a_fused3(
+                    hn_ready ? s.xq81 : q81(s.hn, H), w.q8_gate.q4, w.q8_up.q4, nullptr,
+                    w.q8_gate.dm, w.q8_up.dm, nullptr,
+                    s.gate, s.up, nullptr, I, I, 0, H, st, BW);
+            else if (w.q8_gate.q4)
                 dflash_kernels::launch_gemv_batched_q4_fused3(
                     s.hn, w.q8_gate.q4, w.q8_up.q4, nullptr, w.q8_gate.dm, w.q8_up.dm, nullptr,
                     s.gate, s.up, nullptr, I, I, 0, H, st, BW);
@@ -1320,7 +1467,12 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         }
         dflash_kernels::launch_swiglu(s.gate, s.up, s.gate, BW * I, st);
         if (fast16) {
-            if (w.q8_down.q4)
+            if (w.q8_down.q4 && dp4a_down)
+                dflash_kernels::launch_gemv_batched_q4_dp4a_fused3(
+                    q81(s.gate, I), w.q8_down.q4, nullptr, nullptr,
+                    w.q8_down.dm, nullptr, nullptr,
+                    s.down, nullptr, nullptr, H, 0, 0, I, st, BW);
+            else if (w.q8_down.q4)
                 dflash_kernels::launch_gemv_batched_q4_fused3(
                     s.gate, w.q8_down.q4, nullptr, nullptr, w.q8_down.dm, nullptr, nullptr,
                     s.down, nullptr, nullptr, H, 0, 0, I, st, BW);
@@ -1338,7 +1490,9 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // norm, or the final norm after the last layer. Same math, one launch instead of two, and
         // the draft is eager-launched so each saved launch is also a saved gap.
         const bf16* next_norm = (L + 1 < run_layers) ? s.layers[L + 1].input_norm : s.final_norm;
-        dflash_kernels::launch_add_rms(s.h, s.down, s.x, next_norm, s.xn, BW, H, c.rms_eps, st);
+        dflash_kernels::launch_add_rms(s.h, s.down, s.x, next_norm, s.xn, BW, H, c.rms_eps, st,
+                                       dp4a_qkv ? s.xq81 : nullptr);
+        xn_ready = dp4a_qkv;
         // Per-layer residual stream, for the differential (see the dump block below). s.x is the
         // layer's output residual; comparing it layer by layer turns "the backbone diverges"
         // into "layer N diverges", which is the difference between a search and a fix.
@@ -1551,22 +1705,23 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                 dflash_kernels::launch_markov_bias_add_q8(
                     s.markov_w1, s.markov_w2_q, s.markov_w2_s, prev,
                     s.logits + row * Vd, Vd, s.markov_rank, st,
-                    s.confidence_w ? s.markov_latent : nullptr);
+                    s.confidence_w ? s.markov_latent + (size_t)r * s.markov_rank : nullptr);
             else
                 dflash_kernels::launch_markov_bias_add(
                     s.markov_w1, s.markov_w2, prev,
                     s.logits + row * Vd, Vd, s.markov_rank, st,
-                    s.confidence_w ? s.markov_latent : nullptr);
-            // Confidence head (optional): reads THIS row's hidden state + the Markov latent the
-            // bias call above just wrote, predicting how likely this row's (about to be computed)
-            // argmax is to be accepted. Order doesn't matter relative to the argmax call below --
-            // it depends on s.xn and s.markov_latent, neither of which the argmax touches.
-            if (s.confidence_w)
-                dflash_kernels::launch_confidence_head(s.xn + row * H, s.markov_latent,
-                                                       s.confidence_w, s.confidence_bias, H,
-                                                       s.markov_rank, s.d_confidence + r, st);
+                    s.confidence_w ? s.markov_latent + (size_t)r * s.markov_rank : nullptr);
             kernels::launch_argmax(s.logits + row * Vd, s.d_out + r, 1, Vd, st);
         }
+        // Confidence head (optional), for every proposal row at once. It reads row r's hidden
+        // state and the Markov latent that row's bias call wrote, and nothing in the chain ever
+        // consumed it, so hoisting it out of the loop changes no value -- only the launch count,
+        // from kProposalDepth grid-of-one kernels to one.
+        if (s.confidence_w)
+            dflash_kernels::launch_confidence_head_rows(
+                s.xn, H, s.markov_latent, s.markov_rank,
+                s.confidence_w, s.confidence_bias, H, s.markov_rank,
+                kRowShift ? 0 : 1, kProposalDepth, s.d_confidence, st);
     } else {
         kernels::launch_argmax(s.logits + (size_t)(head_done ? head_row0 : 0) * Vd,
                                s.d_out + (head_done ? 1 : 0),

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2730,6 +2730,30 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         }
         return true;
     };
+    // Two SAME-SHAPED NVFP4 projections over one activation, on one grid -- the pattern
+    // launch_gemv_nvfp4_rows_dp4a2 exists for, and which the FFN's gate/up already uses. `wk` and
+    // `wv` are exactly that: both [kvdim, H], both reading the staged `xn`, issued back to back.
+    // At Qwen3.8's 4 kv heads x 256 head_dim that is a 1024-row matrix whose own launch is ~5.2 us
+    // for 2.95 MB -- a third of the streaming ceiling, because a grid that small is nearly all
+    // per-launch cost. One grid for the pair halves the launches and doubles the work each one
+    // amortises over.
+    //
+    // Bit-identical to the two singles by the paired kernel's own construction: a CTA still owns
+    // RPB*NR consecutive output rows of ONE of the two matrices, walks the same groups in the same
+    // order and folds the same S partials -- only which launch carries it changes. It declines
+    // (and the caller issues the singles) for any shape where a CTA could straddle the boundary.
+    // Returns false when it did NOT fuse, so the caller falls back rather than skipping work.
+    auto proj_pair_nv_on = [&](cudaStream_t ps, const bf16* in, const void* w0, int t0,
+                               const void* w1, int t1, bf16* o0, bf16* o1, int no, int k) -> bool {
+        if (t0 != kernels::SI_QTYPE_NVFP4 || t1 != kernels::SI_QTYPE_NVFP4) return false;
+        if (!kernels::qwen38_nvfp4_dp4a_proj()) return false;
+        const bool ha = (nvq_src_a == in && nvq_k_a == k);
+        const bool hb = (nvq_src_b == in && nvq_k_b == k);
+        if (!ha && !hb) return false;             // `in` was never staged -- do not quantize here
+        return kernels::launch_gemv_nvfp4_rows_dp4a2(hb ? nv_pq_b : nv_pq_a,
+                                                     hb ? nv_ps_b : nv_ps_a,
+                                                     w0, w1, o0, o1, N, no, k, ps);
+    };
     // proj() on an arbitrary stream. Callers must have `in` already quantized into q81 (checked at
     // each call site), because quantizing here would write shared scratch off the main stream.
     auto proj_on = [&](cudaStream_t ps, const bf16* in, const void* w, int type, bf16* out,
@@ -3004,8 +3028,10 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 pf_cu(cudaStreamWaitEvent(s.stream_k, ev_fork, 0), "verify attn fork wait");
             }
             supported = proj(xn, w.wq, w.wq_type, b8, 2 * qdim, H) &&
-                        proj_on(ast, xn, w.wk, w.wk_type, kf, kvdim, H) &&
-                        proj_on(ast, xn, w.wv, w.wv_type, vf, kvdim, H);
+                        (proj_pair_nv_on(ast, xn, w.wk, w.wk_type, w.wv, w.wv_type,
+                                         kf, vf, kvdim, H) ||
+                         (proj_on(ast, xn, w.wk, w.wk_type, kf, kvdim, H) &&
+                          proj_on(ast, xn, w.wv, w.wv_type, vf, kvdim, H)));
             if (fork_attn) {
                 pf_cu(cudaEventRecord(ev_join, s.stream_k), "verify attn join");
                 pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify attn join wait");


### PR DESCRIPTION
## Summary

The DSpark draft block multiplied **bf16 activations** by Q4 weights dequantized to float, so it moved 3.86 GB of activation L2 traffic against 620 MB of weights and ran at **1095 GB/s** where the verify's NVFP4 path gets **1704 GB/s** on the same card. This quantizes each activation to q8_1 once and drives every projection that shares it through a dp4a kernel — 1.125 B/element instead of 2, eight `dp4a` instead of 32 float FMAs per (weight row, block row) per 32-block, weights stay packed — plus the last two bf16 weight reads (the `fc` projector and the per-layer context K/V) onto the Q4 copies.

Draft-side changes move what is **proposed**, never what is emitted: `LOSSLESS=1`, top-1 `1.000`, `KL 0.0000`.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `dspark-decode@4k` — the scored dimension, from `runtime/dspark_tau_check` on the ModelOpt NVFP4 checkpoint, n=128, 4096-token prompt):

| | decode tok/s |
|---|--:|
| before (main) | 137.82 |
| after (this PR) | **141.45** |

**Prefill pp tok/s** — not targeted by this PR; the 16k prefill guards are in the no-regression table below.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

### Where the time goes

`dspark_tau_check` at **512** generated tokens (at n=128 the step count quantizes acceptance to 1/71, a ±1.4% lottery that swamps the effect — see the note below):

| | draft ms/call | batched ms/call | **step ms** |
|---|--:|--:|--:|
| main `d625a09` | 1.642 | 11.978 | 13.620 |
| this PR | **1.301** | **11.843** | **13.144** |

**−0.476 ms/step, −3.50%.** The draft block itself is 21% cheaper.

### Gates

```text
main DSPARK=137.8228  AR=95.1474  tau=1.8286
pr   DSPARK=141.4480  AR=95.2988  tau=1.8028   LOSSLESS=1 over 3 reps
== dspark-decode@4k  1.0263x

positions             : 101
top-1 agreement       : 101/101 = 1.000   (PR vs main)
mean KL(main||pr)     : 0.0000 nats  (top-k union)
PPL PR                : 3.020
PPL main              : 3.020
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.0198 ppl_main=3.0198
```

No regression on the non-speculative decoder (`runtime/qwen3_gguf_bench`, the binary `bench.sh` drives, invoked directly from each tree's own build so it exercises this branch rather than the release prebuilts):

```text
########## si_main : qwen3_gguf_bench <gguf> 128 4096
model        : Qwen3.5/Qwen3.6-35B-A3B hybrid  (40 layers, 256 experts top-8)
VRAM used    : 23.7 GB
max seq      : 4240
decode tg    : 467.26 tok/s  (2.1 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 26365.59 tok/s  (ctx=4096, sequential KV fill)
GPU          : 52°C · 277 W · 2692 MHz (peak under load)
########## si_bot : qwen3_gguf_bench <gguf> 128 4096
model        : Qwen3.5/Qwen3.6-35B-A3B hybrid  (40 layers, 256 experts top-8)
VRAM used    : 23.7 GB
max seq      : 4240
decode tg    : 467.60 tok/s  (2.1 ms/token, n=128, ctx=4096, bs=1)
prefill pp   : 26262.87 tok/s  (ctx=4096, sequential KV fill)
GPU          : 54°C · 275 W · 2670 MHz (peak under load)
```

16k guards, both models, same binary:

```text
                      decode tg    prefill pp
GUARD38 si_main 16384    78.46       1090.79
GUARD38 si_bot  16384    78.65       1146.13
GUARD36 si_main 16384   380.07       1257.33
GUARD36 si_bot  16384   381.17       1279.34
```

Box: RTX 5090 capped at 525 W / 575 W, driver 595.84, CUDA 13.0.
