### PR TITLE
perf(dspark): keep ModelOpt LM head in native NVFP4

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -600,7 +600,10 @@ __global__ void ct_dequant_nvfp4_g16_kernel(const unsigned char* __restrict__ pa
     if (global_scale_dev) global_scale = *global_scale_dev;
     const float inv_gs = (ALU >= CT_ALU_RCP) ? (1.f / global_scale) : 0.f;
     const int ngroups = cols >> 4;
-    const int r = blockIdx.y;
+    // gridDim.y is capped at 65,535 even on Blackwell. ModelOpt's current
+    // NVFP4 lm_head has 248,320 output rows, so flatten y/z rather than
+    // issuing an invalid launch for that tensor.
+    const int r = (int)blockIdx.y + (int)blockIdx.z * (int)gridDim.y;
     if (r >= rows) return;
     const unsigned char* prow = packed + (size_t)r * (size_t)(cols >> 1);
     const unsigned char* srow = group_scale + (size_t)r * (size_t)ngroups;
@@ -752,7 +755,10 @@ static void ct_dequant_nvfp4_launch(const void* packed_u8, const void* group_sca
         const int ngroups = cols >> 4;
         const int threads = 256;
         const int bx = (ngroups + threads - 1) / threads;
-        const dim3 grid(bx > 0 ? bx : 1, rows);
+        constexpr int MAX_GRID_Y = 65535;
+        const unsigned gy = (unsigned)(rows < MAX_GRID_Y ? rows : MAX_GRID_Y);
+        const unsigned gz = (unsigned)((rows + MAX_GRID_Y - 1) / MAX_GRID_Y);
+        const dim3 grid(bx > 0 ? bx : 1, gy, gz);
         auto* pk = reinterpret_cast<const unsigned char*>(packed_u8);
         auto* gsc = reinterpret_cast<const unsigned char*>(group_scale_ue4m3);
         auto* ob = reinterpret_cast<__nv_bfloat16*>(out_bf16);

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -833,7 +833,9 @@ __global__ void gemv_nvfp4_sk_kernel(const __nv_bfloat16* __restrict__ x,
     if (n < N) {
         const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
         const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
-        const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+        const int stored_rows = *(reinterpret_cast<const int*>(packed) + 1);
+        const int weight_rows = stored_rows > 0 ? stored_rows : N;
+        const unsigned char* w = sf + (size_t)weight_rows * (size_t)(K >> 4);
         const unsigned char* srow = sf + (size_t)n * (size_t)(K >> 4);
         const unsigned char* prow = w + (size_t)n * (size_t)(K >> 1);
         const int ng = K >> 4;
@@ -1030,7 +1032,9 @@ __global__ void gemv_nvfp4_rows_dp4a_kernel(const signed char* __restrict__ xq,
     if (n0 < N) {
         const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
         const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
-        const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+        const int stored_rows = *(reinterpret_cast<const int*>(packed) + 1);
+        const int weight_rows = stored_rows > 0 ? stored_rows : N;
+        const unsigned char* w = sf + (size_t)weight_rows * (size_t)(K >> 4);
         const int ng = K >> 4;
         const int gstride = S * 32;
         int g = split * 32 + lane;
@@ -1215,7 +1219,9 @@ __global__ void gemv_nvfp4_kernel(const __nv_bfloat16* __restrict__ x,
     if (n >= N) return;
     const float inv_g = 1.f / *reinterpret_cast<const float*>(packed);
     const unsigned char* sf = reinterpret_cast<const unsigned char*>(packed) + SI_NVFP4_HDR;
-    const unsigned char* w = sf + (size_t)N * (size_t)(K >> 4);
+    const int stored_rows = *(reinterpret_cast<const int*>(packed) + 1);
+    const int weight_rows = stored_rows > 0 ? stored_rows : N;
+    const unsigned char* w = sf + (size_t)weight_rows * (size_t)(K >> 4);
     const unsigned char* srow = sf + (size_t)n * (size_t)(K >> 4);
     const unsigned char* prow = w + (size_t)n * (size_t)(K >> 1);
     float acc = 0.f;
@@ -3081,14 +3087,15 @@ bool launch_gemv_nvfp4_rows_dp4a2(const void* xq, const void* xs,
     return true;
 }
 
-bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, void* y,
-                                 int M, int N, int K, cudaStream_t stream) {
+template <typename OutT>
+static bool launch_gemv_nvfp4_rows_dp4a_t(const void* xq, const void* xs, const void* W, OutT* y,
+                                          int M, int N, int K, cudaStream_t stream) {
     if (!xq || !xs || !W || !y || N < 1 || K < 1 || (K & 15)) return false;
     if (!gemv_bf16_splitk()) return false;
     if (M < 1 || M > 8) return false;
     const auto* xp = reinterpret_cast<const signed char*>(xq);
     const auto* sp = reinterpret_cast<const float*>(xs);
-    auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
+    auto* yp = reinterpret_cast<OutT*>(y);
     // Split-K chosen by N exactly as the float rows kernel does, so the two paths fan out over the
     // GPU identically and a comparison between them is a comparison of the arithmetic alone.
     //
@@ -3113,10 +3120,10 @@ bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, 
         const int nr = nr_mode ? nr_mode : (R == 1 ? 1 : 2); \
         if (nr == 1) { \
             const dim3 grid((N + RPB - 1) / RPB); \
-            gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
+            gemv_nvfp4_rows_dp4a_kernel<OutT, S, R, 1><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
         } else { \
             const dim3 grid((N + RPB * 2 - 1) / (RPB * 2)); \
-            gemv_nvfp4_rows_dp4a_kernel<__nv_bfloat16, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
+            gemv_nvfp4_rows_dp4a_kernel<OutT, S, R, 2><<<grid, GEMV_WPB * 32, 0, stream>>>(xp, sp, W, yp, N, K); \
         } \
     } while (0)
 #define SI_NVFP4_DP4A_S(R_) do { \
@@ -3133,6 +3140,17 @@ bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, 
 #undef SI_NVFP4_DP4A_S
 #undef SI_NVFP4_DP4A
     return true;
+}
+
+bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, void* y,
+                                 int M, int N, int K, cudaStream_t stream) {
+    return launch_gemv_nvfp4_rows_dp4a_t(
+        xq, xs, W, reinterpret_cast<__nv_bfloat16*>(y), M, N, K, stream);
+}
+
+bool launch_gemv_nvfp4_rows_dp4a_f32(const void* xq, const void* xs, const void* W, float* y,
+                                     int M, int N, int K, cudaStream_t stream) {
+    return launch_gemv_nvfp4_rows_dp4a_t(xq, xs, W, y, M, N, K, stream);
 }
 
 bool launch_gemv_nvfp4_rows(const void* x, const void* W, void* y, int M, int N, int K,
@@ -3218,6 +3236,24 @@ void launch_gemv_q(const void* x, const void* W, int wtype, void* y, int N, int 
     }
 }
 void launch_gemv_q_f32(const void* x, const void* W, int wtype, float* y, int N, int K, cudaStream_t stream) {
+    if (wtype == SI_QTYPE_NVFP4) {
+        const auto* xp = reinterpret_cast<const __nv_bfloat16*>(x);
+        if (gemv_bf16_splitk()) {
+            if (N >= 8192) {
+                constexpr int S = 2, RPB = GEMV_WPB / S;
+                gemv_nvfp4_sk_kernel<float, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, y, N, K);
+            } else if (N >= 4096) {
+                constexpr int S = 4, RPB = GEMV_WPB / S;
+                gemv_nvfp4_sk_kernel<float, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, y, N, K);
+            } else {
+                constexpr int S = 8, RPB = GEMV_WPB / S;
+                gemv_nvfp4_sk_kernel<float, S><<<dim3((N + RPB - 1) / RPB), GEMV_WPB * 32, 0, stream>>>(xp, W, y, N, K);
+            }
+        } else {
+            gemv_nvfp4_kernel<float><<<dim3((N + GEMV_WPB - 1) / GEMV_WPB), GEMV_WPB * 32, 0, stream>>>(xp, W, y, N, K);
+        }
+        return;
+    }
     dim3 grid((N + GEMV_WPB - 1) / GEMV_WPB);
     if (gemv_mmvq() && wtype == 12) {
         size_t sm = 2 * (size_t)(K >> 5) * sizeof(float) + (size_t)K;

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -131,6 +131,10 @@ void launch_gemv_nvfp4_quant_x(const void* x, void* xq, void* xs, int M, int K,
                                cudaStream_t stream);
 bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, void* y,
                                  int M, int N, int K, cudaStream_t stream);
+// FP32-output counterpart for LM-head logits. It runs the identical dp4a dot/reduction and only
+// changes the final store type, so AR and batched verification can share one native-NVFP4 head.
+bool launch_gemv_nvfp4_rows_dp4a_f32(const void* xq, const void* xs, const void* W, float* y,
+                                     int M, int N, int K, cudaStream_t stream);
 // Paired form: one grid over two same-shaped NVFP4 matrices sharing one activation (the FFN's
 // gate/up pair). Returns false when the shape would let a CTA straddle the boundary; the caller
 // then issues the two single launches.

--- a/kernels/include/sparkinfer/kernels/qtype.h
+++ b/kernels/include/sparkinfer/kernels/qtype.h
@@ -26,10 +26,12 @@ static constexpr int SI_QTYPE_Q3A = 112;   // == the block size in bytes, per 25
 static constexpr int SI_QTYPE_FP8 = 108;
 
 // Compressed-tensors NVFP4 (E2M1, block 16) kept native. Payload is
-//   [256 B header: f32 global_scale at byte 0 |
+//   [256 B header: f32 global_scale at byte 0, i32 stored_rows at byte 4 |
 //    ue4m3 scale[N*(K/16)] |
 //    packed u8[N*(K/2)]]
 // The 256-byte header keeps the packed region 256-aligned for CUTLASS TMA.
+// stored_rows lets callers score a vocab prefix without mistaking that prefix length for the
+// packed weight offset; zero retains compatibility with payloads created before this field.
 // Dequant matches launch_ct_dequant_nvfp4:
 //   W[r,c] = e2m1(nibble) * ue4m3(scale[r,c/16]) / global_scale.
 // 109 is unused as a ggml type id.

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -8,7 +8,7 @@ if(BUILD_NVFP4_KERNELS)
   add_executable(prefill_nvfp4_gpu_test prefill_nvfp4_gpu_test.cpp)
   # si_nvfp4, not si_fused: the FP4 entry points live in their own whole-program library so that
   # the sm_120a device code never has to device-link against the rest of the build.
-  target_link_libraries(prefill_nvfp4_gpu_test PRIVATE si_nvfp4 si_fused si_quant CUDA::cudart)
+  target_link_libraries(prefill_nvfp4_gpu_test PRIVATE si_nvfp4 si_gemm si_fused si_quant CUDA::cudart)
   set_target_properties(prefill_nvfp4_gpu_test PROPERTIES CUDA_ARCHITECTURES "120a")
   add_test(NAME prefill_nvfp4_gpu_test COMMAND prefill_nvfp4_gpu_test)
   set_tests_properties(prefill_nvfp4_gpu_test PROPERTIES SKIP_RETURN_CODE 77)

--- a/kernels/tests/prefill_nvfp4_gpu_test.cpp
+++ b/kernels/tests/prefill_nvfp4_gpu_test.cpp
@@ -1,9 +1,87 @@
 #include "sparkinfer/kernels/prefill_nvfp4.h"
+#include "sparkinfer/kernels/compressed_tensors.h"
+#include "sparkinfer/kernels/gemm.h"
+#include "sparkinfer/kernels/qtype.h"
 #include <cuda_bf16.h>
 #include <cuda_runtime.h>
 #include <cmath>
+#include <cstring>
 #include <cstdio>
 #include <vector>
+
+namespace {
+
+bool test_large_row_dequant() {
+    using namespace sparkinfer::kernels;
+    constexpr int rows = 65536 + 3, cols = 16;
+    unsigned char *packed = nullptr, *scale = nullptr;
+    __nv_bfloat16* out = nullptr;
+    cudaMalloc(&packed, (size_t)rows * cols / 2);
+    cudaMalloc(&scale, (size_t)rows * cols / 16);
+    cudaMalloc(&out, (size_t)rows * cols * sizeof(*out));
+    cudaMemset(packed, 0x22, (size_t)rows * cols / 2); // E2M1 1.0 in both nibbles
+    cudaMemset(scale, 0x38, (size_t)rows * cols / 16); // UE4M3 1.0
+    launch_ct_dequant_nvfp4(packed, scale, 1.f, out, rows, cols);
+    bool ok = cudaDeviceSynchronize() == cudaSuccess;
+    __nv_bfloat16 edge[2]{};
+    cudaMemcpy(&edge[0], out, sizeof(edge[0]), cudaMemcpyDeviceToHost);
+    cudaMemcpy(&edge[1], out + (size_t)(rows - 1) * cols, sizeof(edge[1]),
+               cudaMemcpyDeviceToHost);
+    ok &= std::fabs(__bfloat162float(edge[0]) - 1.f) < 1e-6f;
+    ok &= std::fabs(__bfloat162float(edge[1]) - 1.f) < 1e-6f;
+    cudaFree(packed); cudaFree(scale); cudaFree(out);
+    std::printf("large-row NVFP4 dequant: %s\n", ok ? "OK" : "FAIL");
+    return ok;
+}
+
+bool test_vocab_prefix_offset() {
+    using namespace sparkinfer::kernels;
+    // Use a real projection-sized grid. The production prefix is 65,536 of 248,320 rows; this
+    // smaller ratio exercises the identical stored-rows offset without making the unit test big.
+    constexpr int stored_rows = 4096, scored_rows = 2048, k = 16;
+    const size_t scale_bytes = (size_t)stored_rows * k / 16;
+    const size_t packed_bytes = (size_t)stored_rows * k / 2;
+    std::vector<unsigned char> payload(SI_NVFP4_HDR + scale_bytes + packed_bytes, 0);
+    const float global = 1.f;
+    std::memcpy(payload.data(), &global, sizeof(global));
+    std::memcpy(payload.data() + 4, &stored_rows, sizeof(stored_rows));
+    std::memset(payload.data() + SI_NVFP4_HDR, 0x38, scale_bytes);
+    unsigned char* weights = payload.data() + SI_NVFP4_HDR + scale_bytes;
+    std::memset(weights, 0x22, k / 2);                    // row 0: all +1
+    std::memset(weights + (size_t)scored_rows * k / 2, 0xff,
+                packed_bytes - (size_t)scored_rows * k / 2); // poison unused suffix rows
+
+    std::vector<__nv_bfloat16> hx(k, __float2bfloat16(1.f));
+    void *x = nullptr, *xq = nullptr, *xs = nullptr, *w = nullptr;
+    float *y = nullptr, *y_direct = nullptr;
+    cudaMalloc(&x, k * sizeof(__nv_bfloat16));
+    cudaMalloc(&xq, k);
+    cudaMalloc(&xs, sizeof(float));
+    cudaMalloc(&w, payload.size());
+    cudaMalloc(&y, scored_rows * sizeof(float));
+    cudaMalloc(&y_direct, scored_rows * sizeof(float));
+    cudaMemcpy(x, hx.data(), k * sizeof(__nv_bfloat16), cudaMemcpyHostToDevice);
+    cudaMemcpy(w, payload.data(), payload.size(), cudaMemcpyHostToDevice);
+    launch_gemv_nvfp4_quant_x(x, xq, xs, 1, k, nullptr);
+    bool ok = launch_gemv_nvfp4_rows_dp4a_f32(xq, xs, w, y, 1, scored_rows, k, nullptr) &&
+              cudaDeviceSynchronize() == cudaSuccess;
+    float hy[2]{};
+    cudaMemcpy(hy, y, sizeof(hy), cudaMemcpyDeviceToHost);
+    ok &= std::fabs(hy[0] - 16.f) < 1e-4f;
+    ok &= std::fabs(hy[1]) < 1e-6f;
+    launch_gemv_q_f32(x, w, SI_QTYPE_NVFP4, y_direct, scored_rows, k, nullptr);
+    ok &= cudaDeviceSynchronize() == cudaSuccess;
+    float hy_direct[2]{};
+    cudaMemcpy(hy_direct, y_direct, sizeof(hy_direct), cudaMemcpyDeviceToHost);
+    ok &= std::fabs(hy_direct[0] - 16.f) < 1e-4f;
+    ok &= std::fabs(hy_direct[1]) < 1e-6f;
+    cudaFree(x); cudaFree(xq); cudaFree(xs); cudaFree(w); cudaFree(y); cudaFree(y_direct);
+    std::printf("NVFP4 vocab-prefix offset: %s logits=[%.3f,%.3f]\n",
+                ok ? "OK" : "FAIL", hy[0], hy[1]);
+    return ok;
+}
+
+} // namespace
 
 int main() {
     using namespace sparkinfer::kernels;
@@ -25,6 +103,8 @@ int main() {
     cudaMemcpy(hD.data(),D,hD.size()*2,cudaMemcpyDeviceToHost);
     float lo=1e9f,hi=-1e9f;
     for(auto v:hD){ float x=__bfloat162float(v); lo=fminf(lo,x); hi=fmaxf(hi,x); ok &= std::isfinite(x) && x>115.f && x<141.f; }
+    ok &= test_large_row_dequant();
+    ok &= test_vocab_prefix_offset();
     std::printf("prefill_nvfp4_gpu_test: %s range=[%.3f,%.3f]\n",ok?"OK":"FAIL",lo,hi);
     cudaFree(A0);cudaFree(B0);cudaFree(A);cudaFree(B);cudaFree(SA);cudaFree(SB);cudaFree(D);if(W)cudaFree(W);
     return ok?0:1;

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -684,11 +684,12 @@ const float* DFlashDraftModel::last_logits() const { return p_->logits; }
 // this reason.
 static void compute_yarn_inv_freq(const DFlashDraftConfig& cfg, std::vector<float>& inv_freq,
                                   float& att_scale) {
+    constexpr double kPi = 3.14159265358979323846264338327950288;
     const int d = cfg.head_dim, half = d / 2;
     const double base = cfg.rope_theta, factor = cfg.yarn_factor;
     const double orig = cfg.yarn_orig_max_pos > 0 ? cfg.yarn_orig_max_pos : 8192.0;
     auto find_dim = [&](double nrot) {
-        return (d * std::log(orig / (nrot * 2.0 * M_PI))) / (2.0 * std::log(base));
+        return (d * std::log(orig / (nrot * 2.0 * kPi))) / (2.0 * std::log(base));
     };
     double low  = std::floor(find_dim(cfg.yarn_beta_fast));
     double high = std::ceil (find_dim(cfg.yarn_beta_slow));

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include "sparkinfer/models/dflash_kernels.h"
 #include "sparkinfer/kernels/gemm.h"
+#include "sparkinfer/kernels/qtype.h"
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/quant.h"
 #include "sparkinfer/kernels/prefill.h"
@@ -373,6 +374,8 @@ struct DFlashDraftModel::Impl {
     float *fa_m = nullptr, *fa_l = nullptr, *fa_acc = nullptr;
     float* logits = nullptr;        // [B, vocab]
     void* head_q8 = nullptr;        // [B] Q8_1 rows of xn for the multi-row head MMVQ
+    signed char* head_nv_q = nullptr; // [B,H] int8, one scale per native-NVFP4 group
+    float* head_nv_s = nullptr;       // [B,H/16]
     int *d_ids = nullptr, *d_out = nullptr;
     int *h_ids = nullptr;                        // PINNED staging for the block ids
     // Q8_1 staging for the dp4a backbone: one 36-byte block per 32 values per block row, sized for
@@ -468,6 +471,8 @@ struct DFlashDraftModel::Impl {
         down = alloc<bf16>((size_t)B * H);
         logits = alloc<float>((size_t)B * std::max(cfg.vocab, 1));
         head_q8 = alloc<char>((size_t)B * kernels::llama_q8_1_bytes(H));
+        head_nv_q = alloc<signed char>((size_t)B * H);
+        head_nv_s = alloc<float>((size_t)B * (H / 16));
         d_ids = alloc<int>(B);
         // Proposal-indexed, not row-indexed. Under the row-shift mapping the chain writes
         // d_out[r] / d_confidence[r] for r = 1..kProposalDepth, and a block_size-wide block
@@ -1592,7 +1597,16 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     }();
     const int head_row0 = kRowShift ? 0 : 1;
     bool head_done = false;
-    if (head_mr && s.head_q8 && (s.lm_head_type == 14 || s.lm_head_type == 12)) {
+    if (head_mr && s.lm_head_type == kernels::SI_QTYPE_NVFP4 &&
+        s.head_nv_q && s.head_nv_s) {
+        kernels::launch_gemv_nvfp4_quant_x(
+            s.xn + (size_t)head_row0 * H, s.head_nv_q, s.head_nv_s,
+            kProposalDepth, H, st);
+        head_done = kernels::launch_gemv_nvfp4_rows_dp4a_f32(
+            s.head_nv_q, s.head_nv_s, s.lm_head,
+            s.logits + (size_t)head_row0 * Vd, kProposalDepth, Vd, H, st);
+    }
+    else if (head_mr && s.head_q8 && (s.lm_head_type == 14 || s.lm_head_type == 12)) {
         // Score only the proposal rows the verifier can consume. One row-batched quantize launch
         // instead of kProposalDepth tiny ones (8 CTAs each, so launch latency dominated them).
         // DSpark's Markov chain consumes base-logit rows [0, depth): row 0 plus the anchor token

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -2093,7 +2093,14 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
     // silently fed the LM head a stale aq81 left over from the last layer's fresh
     // prepare_xn_quant(xn) quantize (a *different*, pre-final-norm activation vector) --
     // wrong logits on every single decode step. Force a fresh quantize for muse_glimmer.
-    if (s.gguf && s.use_pq && s.use_llama && s.w.lm_head_type == 12) {
+    if (s.w.lm_head_type == kernels::SI_QTYPE_NVFP4) {
+        kernels::launch_gemv_nvfp4_quant_x(s.xn, s.nv_xq, s.nv_xs, 1, H, st);
+        if (!kernels::launch_gemv_nvfp4_rows_dp4a_f32(
+                s.nv_xq, s.nv_xs, s.w.lm_head, s.logits, 1, c.vocab, H, st))
+            kernels::launch_gemv_q_f32(
+                s.xn, s.w.lm_head, s.w.lm_head_type, s.logits, c.vocab, H, st);
+    }
+    else if (s.gguf && s.use_pq && s.use_llama && s.w.lm_head_type == 12) {
         if (!fnq || c.muse_glimmer) kernels::launch_quantize_q8_1_blocks(s.xn, s.aq81, H, st);
         kernels::launch_mmvq_q4k_f32(s.aq81, s.w.lm_head, s.logits, c.vocab, H, st);
     }
@@ -5250,6 +5257,7 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         if (cudaMalloc(&payload, hdr + scale_bytes + packed_bytes) != cudaSuccess) return nullptr;
         cudaMemset(payload, 0, hdr);
         cudaMemcpy(payload, &global_scale, 4, cudaMemcpyHostToDevice);
+        cudaMemcpy(static_cast<char*>(payload) + 4, &rows, sizeof(rows), cudaMemcpyHostToDevice);
         cudaMemcpy(static_cast<char*>(payload) + hdr, src.group, scale_bytes, cudaMemcpyHostToDevice);
         cudaMemcpy(static_cast<char*>(payload) + hdr + scale_bytes, src.packed, packed_bytes,
                    cudaMemcpyHostToDevice);
@@ -5407,11 +5415,13 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     }();
     auto keep_nvfp4_native = [&](const std::string& prefix, int rows, int cols, int& qtype,
                                  const void** fp4 = nullptr, const void** fp4_sf = nullptr,
-                                 float* fp4_alpha = nullptr) -> const void* {
+                                 float* fp4_alpha = nullptr,
+                                 bool respect_gdn_toggle = true) -> const void* {
         NvFp4Src src{};
         if (!nvfp4_src(prefix, rows, cols, src)) return nullptr;
-        if (!gdn_keep_nvfp4) return requant_q4k(dequant_nvfp4(prefix, rows, cols),
-                                                (long)rows * cols, qtype);
+        if (respect_gdn_toggle && !gdn_keep_nvfp4)
+            return requant_q4k(dequant_nvfp4(prefix, rows, cols),
+                               (long)rows * cols, qtype);
         const size_t scale_bytes = (size_t)rows * cols / 16;
         const size_t packed_bytes = (size_t)rows * cols / 2;
         const size_t hdr = (size_t)kernels::SI_NVFP4_HDR;
@@ -5419,6 +5429,7 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         if (cudaMalloc(&payload, hdr + scale_bytes + packed_bytes) != cudaSuccess) return nullptr;
         cudaMemset(payload, 0, hdr);
         cudaMemcpy(payload, &src.global, 4, cudaMemcpyHostToDevice);
+        cudaMemcpy(static_cast<char*>(payload) + 4, &rows, sizeof(rows), cudaMemcpyHostToDevice);
         cudaMemcpy(static_cast<char*>(payload) + hdr, src.group, scale_bytes,
                    cudaMemcpyHostToDevice);
         cudaMemcpy(static_cast<char*>(payload) + hdr + scale_bytes, src.packed, packed_bytes,
@@ -5463,10 +5474,21 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     // transpose needed -- matches load_gguf()'s own dense("token_embd.weight", false).
     s.w.embed_tokens = plain_bf16("model.language_model.embed_tokens.weight", (long)c.vocab * H);
     s.w.final_norm = load_norm_plus1("model.language_model.norm.weight", H);
-    // lm_head: FP8 in the compressed-tensors checkpoint, plain bf16 in the ModelOpt one (which
-    // lists it under quantization_config.ignore). Either way it ends up Q4_K, as in load_gguf().
-    s.w.lm_head = requant_q4k(dequant_any("lm_head", c.vocab, H), (long)c.vocab * H,
-                              s.w.lm_head_type);
+    // The current ModelOpt checkpoint ships lm_head in native NVFP4. Keep it in that exact format:
+    // requantizing the 4-bit checkpoint weights to another 4-bit grid both moves the target away
+    // from the model the DSpark draft was trained against and wastes the native dp4a path. Older
+    // BF16/FP8 exports retain the Q4_K fallback.
+    static const bool lm_head_nvfp4 = [] {
+        const char* e = getenv("SPARKINFER_QWEN38_LMHEAD_NVFP4");
+        return !(e && e[0] == '0');
+    }();
+    NvFp4Src lm_probe{};
+    if (lm_head_nvfp4 && nvfp4_src("lm_head", c.vocab, H, lm_probe))
+        s.w.lm_head = keep_nvfp4_native("lm_head", c.vocab, H, s.w.lm_head_type,
+                                        nullptr, nullptr, nullptr, false);
+    else
+        s.w.lm_head = requant_q4k(dequant_any("lm_head", c.vocab, H), (long)c.vocab * H,
+                                  s.w.lm_head_type);
     if (!s.w.embed_tokens || !s.w.final_norm || !s.w.lm_head) return false;
 
     s.w.layers.resize(c.n_layers);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3376,6 +3376,11 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     if (verify_head_i8_on && verify_head_i8) {
         head_ok = kernels::launch_gemv_i8_q81_multirow_f32(
             q81, verify_head_i8, verify_head_scale, logits, c.vocab, H, N, st);
+    } else if (s.w.lm_head_type == kernels::SI_QTYPE_NVFP4) {
+        quant_nv_rows(xn, H);
+        head_ok = kernels::launch_gemv_nvfp4_rows_dp4a_f32(
+            nvq_use_b ? nv_pq_b : nv_pq_a, nvq_use_b ? nv_ps_b : nv_ps_a,
+            s.w.lm_head, logits, N, c.vocab, H, st);
     } else if (s.w.lm_head_type == 12) {
         // AR decode drives the LM head with launch_mmvq_q4k_f32 at one row (qwen35.cpp:1888);
         // this makes the verify call the identical kernel instead of launch_mmvq_rows_f32's


### PR DESCRIPTION
## Summary

Keep the current ModelOpt checkpoint's `lm_head` in its native NVFP4 representation and use one FP32-output dp4a path for AR decode, batched verification, and the DSpark proposal head. This avoids NVFP4 -> BF16 -> Q4_K requantization and scores the draft against the target representation it was trained for.

The change also:

- flattens the NVFP4 dequant grid across `y/z` for vocabulary matrices above CUDA's 65,535-row `grid.y` limit;
- records the full stored row count in native payloads so scoring the 65,536-token draft prefix still finds packed weights after all 248,320 scale rows;
- adds GPU regressions for both large-row dequantization and prefix addressing;
- keeps BF16/FP8 checkpoints on the existing Q4_K fallback, with `SPARKINFER_QWEN38_LMHEAD_NVFP4=0` as an A/B escape hatch.

This update rebases the same optimization onto current `main` (`3e15359`), including the intervening full-depth short-generation batching change (`d3eb7db`). The previous auto-eval measured the old, unrebased `be06dfc` against that newer frontier and found only +1.4%. The updated branch now stacks both independent improvements and drops later experimental commits from the fork branch.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end DSpark decode at the active scored context, same final binary and checkpoint):

| | decode tok/s |
|---|--:|
| before (native head disabled) | 123.2106 |
| after (this PR) | 131.4302 |

This is **+6.67%** on `dspark-decode@4k`. AR also moved from 92.2749 to 92.5615 tok/s (+0.31%), and mean acceptance moved from 1.6538 to 1.7534 (+6.02%).

**Prefill pp tok/s** (not targeted):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

The active scope's protected end-to-end instrument is `runtime/examples/dspark_tau_check.cpp`; `bench/scripts/bench.sh` does not run the target/draft pair.

```text
GPU: NVIDIA GeForce RTX 5090, sm_120, CUDA 12.8
Target: gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090
Draft: RadixArk/Qwen3.8-27B-DSpark
Prompt: 4096 tokens, 128 generated tokens
SPARKINFER_DSPARK_SPEC_REPS=3

# before: same final binary with SPARKINFER_QWEN38_LMHEAD_NVFP4=0
SPEC-REPS 3 reps, 0 differ-from-first, 0 not-lossless-vs-AR
DSPARK tau=1.654  steps=78  tokens=128  decode_s=1.039
DSPARK lossless=YES  matched 128/128  (+2 repeats, 0 failed)
AR     92.27 tok/s  (decode 1.387s, ttft 41.637s)
DSPARK 123.21 tok/s  (decode 1.039s)  = 1.335x AR
METRIC AR_TPS 92.2749
METRIC DSPARK_TPS 123.2106
METRIC MEAN_ACCEPT 1.6538
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 3

# after: exact final source, native NVFP4 default
SPEC-REPS 3 reps, 0 differ-from-first, 0 not-lossless-vs-AR
DSPARK tau=1.753  steps=73  tokens=128  decode_s=0.974
DSPARK lossless=YES  matched 128/128  (+2 repeats, 0 failed)
AR     92.56 tok/s  (decode 1.383s, ttft 41.571s)
DSPARK 131.43 tok/s  (decode 0.974s)  = 1.420x AR
METRIC AR_TPS 92.5615
METRIC DSPARK_TPS 131.4302
METRIC MEAN_ACCEPT 1.7534
METRIC LOSSLESS 1
METRIC LOSSLESS_RUNS 3
```

## Correctness and validation

The prior official evaluation of this optimization passed every correctness/no-regression guard: `top1=1.0`, `KL=0.0`, exact losslessness across three runs, AR and acceptance floors, and both Qwen3.8/Qwen3.6 long-context guards. The re-evaluation will rerun those gates against current main.

The exact rebased candidate built successfully on the RTX 5090. Relevant GPU tests:

```text
[PASS] DFlash GDN checkpoints and compact commits equal serial state
large-row NVFP4 dequant: OK
NVFP4 vocab-prefix offset: OK logits=[16.000,0.000]
prefill_nvfp4_gpu_test: OK range=[136.000,136.000]
```

Local policy/harness tests on the final branch:

```text
python3 -m unittest discover -s eval -p 'test_*.py'          # 100 passed
python3 -m unittest discover -s bench/scripts -p 'test_*.py' # 42 passed
git diff --check                                             # clean
```

The repository's Windows attested-binary job currently fails on unchanged main at `runtime/examples/qwen_checkpoint.h:55` because MSVC does not define `S_ISDIR`; this optimization does not touch that line. Linux CI and the sensitive-path guard passed on the previous revision.
