### PR TITLE
fix(runtime): NVFP4 lm_head dequant exceeds gridDim.y; batched prefill derefs null FFN weights

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -5555,8 +5555,20 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         cudaMemcpy(pd, src.packed, packed_bytes, cudaMemcpyHostToDevice);
         cudaMemcpy(gd, src.group, scale_bytes, cudaMemcpyHostToDevice);
         kernels::launch_ct_dequant_nvfp4(pd, gd, src.global, out, rows, cols, s.stream);
-        cudaStreamSynchronize(s.stream);
+        // CHECKED, because an unchecked failure here is invisible in the worst possible way: the
+        // output buffer is left as cudaMalloc returned it and the caller requantizes that into a
+        // perfectly well-formed weight of zeros. A zero lm_head yields a uniform distribution over
+        // the vocabulary, so the model emits token 0 forever while every layer's activations look
+        // healthy -- which is exactly how the gridDim.y overflow fixed above stayed hidden.
+        cudaError_t de = cudaGetLastError();
+        if (de == cudaSuccess) de = cudaStreamSynchronize(s.stream);
         cudaFree(pd); cudaFree(gd);
+        if (de != cudaSuccess) {
+            fprintf(stderr, "[compressed-tensors] %s: NVFP4 dequant failed (%s) for [%d,%d]\n",
+                    prefix.c_str(), cudaGetErrorString(de), rows, cols);
+            cudaFree(out);
+            return nullptr;
+        }
         return out;
     };
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1603,10 +1603,29 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
 
         if (!moe) {
             // dense SwiGLU FFN, chunked over tokens (upstream #530): ffg/ffu/A_i8 stay O(FC*ffn).
-            const void* gate_pf = w.prefill_gate_q ? w.prefill_gate_q : w.gate_q;
-            const void* up_pf = w.prefill_up_q ? w.prefill_up_q : w.up_q;
-            const int gate_pf_type = w.prefill_gate_q ? w.prefill_gate_qtype : w.gate_qtype;
-            const int up_pf_type = w.prefill_up_q ? w.prefill_up_qtype : w.up_qtype;
+            // Third fallback, to the checkpoint's own NVFP4 payload. Under
+            // SPARKINFER_QWEN38_DECODE_NVFP4 (ON by default) the loader makes those payloads the
+            // DECODE weights and deliberately builds no Q4_K copy at all, so gate_q/up_q/down_q
+            // are null -- and every consumer below reached them without a null check, handing a
+            // null source straight to launch_prefill_quantize_rows_i8 (illegal read at ~NULL, CUDA
+            // context lost on the first batched prefill). Only the fp4 fast arms were reachable,
+            // and the down projection has no fp4 arm on this shape, so the crash was unconditional.
+            // dq() already dequantizes SI_QTYPE_NVFP4, so resolving the type here is all the rest
+            // of this function needs.
+            auto ffn_pf = [](const void* pref, int pref_t, const void* q4, int q4_t,
+                             const void* nv, const void** out_w, int* out_t) {
+                if (pref)     { *out_w = pref; *out_t = pref_t; return; }
+                if (q4)       { *out_w = q4;   *out_t = q4_t;   return; }
+                *out_w = nv; *out_t = kernels::SI_QTYPE_NVFP4;
+            };
+            const void* gate_pf; int gate_pf_type;
+            const void* up_pf;   int up_pf_type;
+            const void* down_pf; int down_pf_type;
+            ffn_pf(w.prefill_gate_q, w.prefill_gate_qtype, w.gate_q, w.gate_qtype, w.gate_nv,
+                   &gate_pf, &gate_pf_type);
+            ffn_pf(w.prefill_up_q, w.prefill_up_qtype, w.up_q, w.up_qtype, w.up_nv,
+                   &up_pf, &up_pf_type);
+            ffn_pf(nullptr, 0, w.down_q, w.down_qtype, w.down_nv, &down_pf, &down_pf_type);
             // Per-token independent, so this is numerically identical to the full-width pass.
             // Long-ctx: selective int8 FFN (GDN/attn stay bf16) + int8 weight cache across chunks.
             const bool ffn_i8 = use_i8_ffn && ffn_Wg_i8 != nullptr;
@@ -1622,7 +1641,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             if (ffn_i8 && !ffn_qi8) {
                 dequant_w_i8(gate_pf_type, gate_pf, ffn_Wg_i8, ffn_swg, ffn, H);
                 dequant_w_i8(up_pf_type,   up_pf,   ffn_Wu_i8, ffn_swu, ffn, H);
-                dequant_w_i8(w.down_qtype, w.down_q, ffn_Wd_i8, ffn_swd, H, ffn);
+                dequant_w_i8(down_pf_type, down_pf, ffn_Wd_i8, ffn_swd, H, ffn);
             }
             // The down projection takes the int8 path on both branches whenever ffn_i8 or use_i8,
             // so the FFN residual can ride the residual-fused GEMM straight into x per chunk.
@@ -1689,7 +1708,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                             w.down_fp4_alpha));
                     if (!down_fp4_done) {
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                        proj_fused_acc(ffg, w.down_q, w.down_qtype, w.down_rs,
+                        proj_fused_acc(ffg, down_pf, down_pf_type, w.down_rs,
                                        ao + (size_t)fo * H, H, ffn, &ffn_acc, fn);
                     }
                     // Keep the layer on one route: if the residual-fused arm is active but this
@@ -1720,16 +1739,16 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     a_pk = kernels::launch_prefill_swiglu_quant_i8(ffg, ffu, A_i8, sx, fn, ffn, st,
                                                                    A_i8p) && A_i8p;
                     bool down_fused = false;
-                    if (w.down_rs && kernels::pf_dense_gemm_qi8_supported(w.down_qtype)) {
+                    if (w.down_rs && kernels::pf_dense_gemm_qi8_supported(down_pf_type)) {
                         down_fused = kernels::launch_prefill_gemm_qi8_dense(
-                            w.down_qtype, A_i8, sx, w.down_q, w.down_rs,
+                            down_pf_type, A_i8, sx, down_pf, w.down_rs,
                             ao + (size_t)fo * H, fn, H, ffn, st,
                             qb_partials, QB_SPLITS, nullptr, apk());
                     }
                     if (!down_fused) {
-                        if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,
+                        if (!kernels::launch_gguf_dequant_rows_i8(down_pf_type, down_pf,
                                                                   W_i8, sw, H, ffn, st)) {
-                            const void* wb = dq(w.down_q, w.down_qtype, H, ffn);
+                            const void* wb = dq(down_pf, down_pf_type, H, ffn);
                             kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, ffn, st);
                         }
                         if (ffn_fused)
@@ -1802,19 +1821,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         // branch anyway (its sandwich norm needs the raw FFN output in ao).
                         bool down_fused = false;
                         if (!ffn_fused && muse_qb && w.down_rs &&
-                            kernels::pf_dense_gemm_qi8_supported(w.down_qtype)) {
+                            kernels::pf_dense_gemm_qi8_supported(down_pf_type)) {
                             // The accumulator can only stand when this chunk IS the whole prompt:
                             // a second chunk would overwrite both qb_partials and sx before the
                             // post-FFN norm below reads them.
                             down_fused = kernels::launch_prefill_gemm_qi8_dense(
-                                w.down_qtype, A_i8, sx, w.down_q, w.down_rs,
+                                down_pf_type, A_i8, sx, down_pf, w.down_rs,
                                 ao + (size_t)fo * H, fn, H, ffn, st, qb_partials, QB_SPLITS,
                                 (fn == N) ? &ffn_acc : nullptr, apk());
                         }
                         if (!down_fused) {
-                            if (!kernels::launch_gguf_dequant_rows_i8(w.down_qtype, w.down_q,
+                            if (!kernels::launch_gguf_dequant_rows_i8(down_pf_type, down_pf,
                                                                       W_i8, sw, H, ffn, st)) {
-                                const void* wb = dq(w.down_q, w.down_qtype, H, ffn);
+                                const void* wb = dq(down_pf, down_pf_type, H, ffn);
                                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, H, ffn, st);
                             }
                             // keeps #795's split-K fan-out for whatever still materializes (Q6_K down)
@@ -1825,9 +1844,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         }
                     } else {
                         kernels::launch_prefill_swiglu(ffg, ffu, ffg, (long)fn * ffn, st);
-                        if (!ffn_fused || !proj_resid(ffg, w.down_q, w.down_qtype,
+                        if (!ffn_fused || !proj_resid(ffg, down_pf, down_pf_type,
                                                       x + (size_t)fo * H, H, ffn, fn))
-                            proj(ffg, w.down_q, w.down_qtype, ao + (size_t)fo * H, H, ffn, fn);
+                            proj(ffg, down_pf, down_pf_type, ao + (size_t)fo * H, H, ffn, fn);
                     }
                 }
             }


### PR DESCRIPTION
## Summary

Two independent bugs on the compressed-tensors **NVFP4** path made
`gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090` emit token 0 (`'!'`) forever on every prompt, and
crash with an illegal memory access whenever batched prefill was enabled.

**1. `ct_dequant_nvfp4` exceeded `gridDim.y`, silently zeroing the lm_head.**
The launcher used one block per weight *row*: `dim3 grid(bx, rows)`. CUDA caps `gridDim.y` at
**65535**. Every layer weight clears that (the widest is the dense FFN at 17408 rows), but
`lm_head` is `[vocab, hidden]` and vocab is **248320**. The launch failed with
`cudaErrorInvalidConfiguration`, **the return code was never checked**, and `requant_q4k` then
quantized the untouched output buffer into a perfectly well-formed Q4_K lm_head of **zeros**.

Zero logits are a *uniform* distribution, so argmax returns token 0 on every step while every
layer's activations stay healthy — it presents as a model-quality problem, not a launch error.
Pinned down with the existing `SPARKINFER_MG_STAGE_DEBUG` taps:

| tap | value |
|---|---|
| `tag=80` final-norm output (lm_head **input**) | `l2 = 136.17` — healthy |
| `tag=90` logits | `l2 = 0.000000` |
| every returned logprob | exactly `-12.4224739` = `ln(1/248320)` |

Fixed by grid-striding the row dimension and clamping `grid.y`. Rows ≤ 65535 still take exactly
one iteration, so this is **byte-identical for every tensor that already worked**. The launch is
now checked — the silence is what made this expensive to find.

**2. Batched prefill dereferenced null FFN weights.**
Prefill read `w.gate_q / up_q / down_q` with no null check. Under `SPARKINFER_QWEN38_DECODE_NVFP4`
(**ON by default**) the loader makes the NVFP4 payloads the decode weights and deliberately builds
no Q4_K copy, so those pointers are null. Only the fp4 fast arms were reachable, and the down
projection has no fp4 arm on this shape, so a null source reached
`launch_prefill_quantize_rows_i8` unconditionally — invalid read near NULL, CUDA context lost on
the first batched prefill. Fixed with a third fallback to the checkpoint's own NVFP4 payload;
`dq()` already dequantizes `SI_QTYPE_NVFP4`, so nothing else in the path changes.

The two interacted: (1)'s sticky CUDA error also suppressed the prefill SFB packs, so the loader
reported `native NVFP4 prefill FFN 0/64`. It now reports **64/64**.

## Verification

RTX 5090 / CUDA 12.8 / `g++-12`, `-DCMAKE_CUDA_ARCHITECTURES=120`, default config (no env pins).

```text
before: "The capital of France is Paris. The capital of Germany is" -> '!!!!!!!!!!!!'
after :                                                             -> ' Berlin. The capital of Italy is Rome.
                                                                        The capital of Spain is Madrid.
                                                                        The capital of Portugal is Lisbon.'
```

- `ctest` **21/21 passed**, zero build warnings.
- DSpark speculative decode — which could never match a constant token stream — goes from
  **τ 1.000 (0.728× AR)** to **τ 1.743 (1.399× AR)**, lossless 128/128 across 3 repeats.

## Proof of speedup

**Intentionally unticked — this is a correctness fix, not a speedup, and I am not asking for
evaluation.** Opened as a draft per CONTRIBUTING's Lane 2 guidance ("open it as a draft … and say
in the description that it's a correctness fix not seeking evaluation"), since it touches
`runtime/`.

There is **no before/after speedup to claim, and filling the tables would misrepresent it**:
before this PR the same harness reported ~93 tok/s while the model produced nothing but `'!'` —
it was timing the production of garbage. Throughput is essentially unchanged; the tokens are now
real. For reference only, `qwen3_gguf_bench` sweep after the fix (3 reps, one model load):

| ctx | decode tok/s | prefill pp tok/s |
|---:|---:|---:|
| 128 | 99.01 | 5406 |
| 4k | 96.77 | 14711 |
| 16k | 93.44 | 13784 |

- [ ] Tested on **RTX 5090** (`sm_120`)

<sub>(Box deliberately left unticked — see above. The change *was* developed and verified on an
RTX 5090; the box is the evaluation opt-in, and this PR is not claiming a speedup.)</sub>
