### PR TITLE
server: token_id on every logprob entry, bytes on /v1/score

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -111,7 +111,7 @@ curl -s http://127.0.0.1:8080/v1/score -H 'Content-Type: application/json' -d '{
 | `top_logprobs` | optional, 0–20 alternatives per position. |
 | `enable_thinking` | optional, same meaning as chat completions. |
 
-Response: `tokens`, `token_ids`, `logprobs` (natural log, generation order), `sum_logprob`,
+Response: `tokens`, `token_ids`, `bytes` (raw UTF-8 bytes of each scored token), `logprobs` (natural log, generation order), `sum_logprob`,
 optional `top_logprobs`, and the same `usage` block every other endpoint returns.
 
 The numbers are **identical** to what `/v1/chat/completions` reports for the same token at the same

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -248,7 +248,7 @@ nlohmann::json token_logprob_entry_json(int token_id, float logprob) {
     const auto piece = g_tokenizer.id_to_raw_piece(token_id);
     nlohmann::json bytes = nlohmann::json::array();
     for (uint8_t b : piece.bytes) bytes.push_back((int)b);
-    return {{"token", piece.display}, {"logprob", logprob}, {"bytes", bytes}};
+    return {{"token", piece.display}, {"token_id", token_id}, {"logprob", logprob}, {"bytes", bytes}};
 }
 
 // Builds the OpenAI-shaped logprobs.content array from a flat, generation-ordered list of
@@ -679,6 +679,7 @@ int main(int argc, char** argv) {
 
         nlohmann::json tokens = nlohmann::json::array();
         nlohmann::json token_ids = nlohmann::json::array();
+        nlohmann::json token_bytes = nlohmann::json::array();
         nlohmann::json logprobs = nlohmann::json::array();
         nlohmann::json alts = nlohmann::json::array();
         double sum_logprob = 0.0;
@@ -686,6 +687,9 @@ int main(int argc, char** argv) {
             const auto piece = g_tokenizer.id_to_raw_piece(e.token_id);
             tokens.push_back(piece.display);
             token_ids.push_back(e.token_id);
+            nlohmann::json bytes = nlohmann::json::array();
+            for (uint8_t b : piece.bytes) bytes.push_back((int)b);
+            token_bytes.push_back(std::move(bytes));
             logprobs.push_back(e.logprob);
             sum_logprob += (double)e.logprob;
             if (top_logprobs > 0) {
@@ -710,6 +714,7 @@ int main(int argc, char** argv) {
                                {"model", g_model_name},
                                {"tokens", tokens},
                                {"token_ids", token_ids},
+                               {"bytes", token_bytes},
                                {"logprobs", logprobs},
                                {"sum_logprob", sum_logprob},
                                {"usage", usage}};


### PR DESCRIPTION
Two small additions so an external verifier can teacher-force a served completion exactly, without re-tokenizing its text.

- `logprobs.content[]` entries (chat completions, streaming and non-streaming, and legacy `/v1/completions` alternatives) now carry `token_id` next to `token`, `logprob`, `bytes`. Additive; existing fields unchanged.
- `/v1/score` response now includes `bytes` (raw UTF-8 bytes per scored token, same shape as the chat entries) alongside `tokens` / `token_ids`, so a caller that sent `completion_token_ids` can check they spell the text it received.

Motivation: on the SN74 validator, scoring a miner's decoded text via `completion` re-tokenizes it, and a greedy decode is not always the canonical tokenization of its own output (`"\n","\n"` vs `"\n\n"`, digit merges) — ~1 in 60 honest responses came back a different length and could not be compared. With `token_id` in the stream the validator forwards the exact sequence as `completion_token_ids` (which `/v1/score` already supports) and the mismatch disappears.