### PR TITLE
perf(dspark): give the mid-context band the draft policy it never got

### DIFF
--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1200,9 +1200,13 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // ingests -- the whole prompt on the first block and then just `keep` (1..8) on every one
     // after -- so gating on it alone engages the window for one block and switches it off for the
     // rest of the run.
-    static const int kDefaultWindow = 8192;
-    static const int kScored32kWindow = 4096;
-    static const int kScored32kMinSeq = 32768;
+    // One window, one threshold. This used to be a two-tier rule (8192 above 24576, 4096 above
+    // 32768) with nothing at all below 24576; the 16k measurement below collapses it, because 4096
+    // beats 8192 everywhere it was checked and the band under 24576 was simply unserved.
+    // kMidCtxMinSeq is deliberately the same 12288 boundary the proposal-depth ladder in
+    // qwen35.cpp uses -- the two policies describe the same regime and should not drift apart.
+    static const int kMidCtxWindow = 4096;
+    static const int kMidCtxMinSeq = 12288;
     int kFullWindow = kFullWindowEnv >= 0 ? kFullWindowEnv : 3 * c.sliding_window;
     if (kFullWindowEnv < 0 && kFullWindow <= 0) {
         const int total_ctx = past + ctx_len;
@@ -1211,8 +1215,18 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // 4096 cuts draft time 1.920 -> 1.525 ms while remaining lossless and moving end-to-end
         // throughput 89.85 -> 91.80 tok/s. Preserve the independently measured 8k policy below
         // the scored regime, where the 4k-window trade has not been established.
-        if (total_ctx >= kScored32kMinSeq) kFullWindow = kScored32kWindow;
-        else if (total_ctx >= 3 * kDefaultWindow) kFullWindow = kDefaultWindow;
+        // ...and the same is true from 12k up, which is where the draft's attention first becomes
+        // a large share of the step. Below 24576 the rule above never fired at all -- kFullWindow
+        // is 3 * c.sliding_window and the checkpoint's sliding_window parses to 0 -- so at 16k the
+        // draft was still attending all 16384 tokens and costing 2.886 ms of a 15.7 ms step.
+        // Measured at ctx=16384 on the first 16384 tokens of bench_prompt_32k.txt (real prose, not
+        // a tiling), three fresh processes per arm, every arm lossless and AR flat at 85.39-85.50:
+        //     window   none     8192     4096     3072     2048      (at proposal depth 2)
+        //     tok/s   82.478   86.093   92.031   92.749   91.594
+        // 4096 rather than the marginally better 3072: the peak is broad, 3072 is worth 0.8% on
+        // ONE prompt, and reusing the constant the scored regime already uses is worth more than
+        // that. So a single threshold now covers everything from 12288 up.
+        if (total_ctx >= kMidCtxMinSeq) kFullWindow = kMidCtxWindow;
     }
     // fc trim: once the full-attn layer is windowed, NO layer reads target_proj older than the
     // largest window across layers, so project only that tail. Uses the same attn_gqa_kv_lo bound

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3397,12 +3397,25 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // seven checkpoint proposals available lets structured output collapse far more decode steps.
     // On the six matched 19-41 prompt-token / 200-256 output-token workloads this moved throughput
     // from 92-318 to 151-432 tok/s, while the 4k regime above keeps its measured depth-4 optimum.
+    // And the 12288..32768 band takes depth 2. That band kept the deep tier's 7 long after the
+    // acceptance that justified it was gone: the note above records 32k accepting 5.61 of a
+    // maximum 6, whereas ctx=16384 on real prose accepts 1.29. Seven proposals there are not
+    // merely unused -- they LOWER tau, because the planner spends verify rows on deep proposals
+    // that are wrong (1.2929 at depth 7 against 1.3061 at depth 3-4). Measured at ctx=16384 on the
+    // first 16384 tokens of bench_prompt_32k.txt, three fresh processes per arm, all lossless,
+    // AR flat at 85.39-85.50 (tok/s, at the 4096 window this band now also gets):
+    //     depth   7(was)      4        3        2        1
+    //             82.478    90.926   91.517   92.031   91.897
+    // Depth 2 with the window is +11.58% end to end and takes DSpark from 0.966x AR -- an outright
+    // net loss against not speculating at all -- to 1.078x. The two changes stack because they cut
+    // different costs: depth removes the planner's bootstrap walk and a 248320-wide head row per
+    // proposal, the window removes draft attention.
     const bool kShortGeneration = (n + max_new + B) <= kCompactMaxSeq;
     constexpr int kScored32kMinSeq = 32768;
     const int kProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
                              : (kShortGeneration ? 7
                                 : ((n + max_new) >= kScored32kMinSeq ? 3
-                                   : ((n + max_new) >= kDeepMinSeq ? 7 : 4))));
+                                   : ((n + max_new) >= kDeepMinSeq ? 2 : 4))));
 
     // ...but "full block accepted" is a proxy, and a lossy one. What actually decides whether the
     // batched pass pays is how many sequential target forwards it collapses -- that is the MEAN


### PR DESCRIPTION
## Summary

The 12288..32768 context band kept defaults that were never measured for it.

**The draft-attention window rule could not fire there at all.** `kFullWindow` is `3 * c.sliding_window`, and the checkpoint ships `"sliding_window": null`, which `parse_config_json`'s `find_int` runs `strtol` over and reads as **0** — so the whole windowing path is gated off below 24576. At ctx=16384 the draft was attending all 16384 tokens and costing **2.88 ms of a 15.7 ms step**.

**The proposal-depth ladder gave that band 7**, a value chosen when long context accepted 5.61 of a maximum 6. On the 16k prose it accepts 1.29, and seven proposals there do not merely go unused — they *lower* tau (1.2929 at depth 7 against 1.3061 at depth 3-4), because the verify planner spends rows on deep proposals that are wrong.

This collapses the two-tier window (8192 above 24576, 4096 above 32768, nothing below 24576) into a single threshold at 12288, and gives the same band depth 2. The two stack because they cut different costs: depth removes the planner's bootstrap walk and a 248320-wide head row per proposal, the window removes draft attention.

At ctx=16384 this takes DSpark from **0.962x AR — an outright loss against not speculating at all — to 1.067x**.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`runtime/examples/dspark_tau_check.cpp`, ctx=16384 on `bench/scripts/bench_prompt_32k.txt`, 128 tokens, three fresh processes each `SPARKINFER_DSPARK_SPEC_REPS=1`, clocks pinned 2550):

| | decode tok/s |
|---|--:|
| before (main) | 82.50 |
| after (this PR) | 91.14 |

**+10.51%.** tau 1.2929 -> 1.2673, AR flat (85.71 -> 85.43), lossless 128/128 on all three fresh-process repetitions of both arms. Draft 2.884 -> 1.490 ms per step; verify 12.788 -> 12.415.

Arms were alternated and the baseline reproduces: 82.4952 / 82.4398 either side of the change.

Component sweep at ctx=16384 (tok/s), showing the two levers are independent and additive:

| | no window | window 4096 |
|---|--:|--:|
| depth 7 (before) | 82.478 | 87.855 |
| depth 2 | 86.087* | **92.031** |

<sub>*depth 3; depth 2 without a window was not separately swept.</sub>

```text
# before (main), ctx=16384
DSPARK tau=1.293  steps=99  tokens=128  decode_s=1.552
DSPARK lossless=YES  matched 128/128
AR     85.71 tok/s  (decode 1.493s, ttft 10.666s)
DSPARK 82.50 tok/s  (decode 1.552s)  = 0.962x AR
METRIC AR_TPS 85.7096
METRIC DSPARK_TPS 82.4952
METRIC MEAN_ACCEPT 1.2929
METRIC LOSSLESS 1

# after (this PR), ctx=16384
DSPARK tau=1.267  steps=101  tokens=128  decode_s=1.404
DSPARK lossless=YES  matched 128/128
AR     85.43 tok/s  (decode 1.498s, ttft 10.680s)
DSPARK 91.14 tok/s  (decode 1.404s)  = 1.067x AR
METRIC AR_TPS 85.4346
METRIC DSPARK_TPS 91.1360
METRIC MEAN_ACCEPT 1.2673
METRIC LOSSLESS 1
```

Window 4096 rather than the marginally better 3072 (92.75 vs 92.03 on this prompt): the peak is broad, 0.8% on one prompt is not worth a bespoke constant, and 12288 is deliberately the same boundary the depth ladder already uses so the two policies cannot drift apart.
