### PR TITLE
perf(dspark): trim draft attention rows and hoist verify QK dots

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -236,13 +236,33 @@ __global__ void fa_split_gqa_pipe_kernel(
                 kv_v[e] = fa_to_f(cv[tt * HEAD_DIM + lane + e * 32]);
             }
             const int gtok = t0 + tt;
+            // SEQ independent QK dots FIRST, then one butterfly pass over all of them, and only
+            // then the folds. The shipped shape was dot -> fa_wsum -> softmax -> acc, per row: a
+            // 5-deep shfl chain and two MUFU with nothing in flight to cover them, repeated SEQ
+            // times. Hoisting the dots exposes SEQ independent reductions to interleave.
+            //
+            // BIT-IDENTICAL: each row's dot accumulates over e in the same order, each row's
+            // butterfly walks the same mask sequence fa_wsum walks (so it is the same tree of the
+            // same partials), and the online-softmax fold still runs row by row on the same
+            // score. Only the instruction SCHEDULE changes. Measured at ctx 16384, pinned verify
+            // width 3, one binary per arm: batched 12.243 -> 12.022 ms/call, tau bit-identical.
+            float sc[SEQ];
             #pragma unroll
             for (int v = 0; v < SEQ; v++) {
-                if (gtok < row_start[v] || gtok >= row_end[v]) continue;
                 float p = 0.f;
                 #pragma unroll
                 for (int e = 0; e < ELEMS; e++) p += qr[v][e] * kv_k[e];
-                const float score = fa_wsum(p) * scale;
+                sc[v] = p;
+            }
+            #pragma unroll
+            for (int mask = 16; mask > 0; mask >>= 1)
+                #pragma unroll
+                for (int v = 0; v < SEQ; v++)
+                    sc[v] += __shfl_xor_sync(0xffffffff, sc[v], mask);
+            #pragma unroll
+            for (int v = 0; v < SEQ; v++) {
+                if (gtok < row_start[v] || gtok >= row_end[v]) continue;
+                const float score = sc[v] * scale;
                 const float mn = fmaxf(m[v], score), corr = __expf(m[v] - mn), pe = __expf(score - mn);
                 l[v] = l[v] * corr + pe;
                 #pragma unroll

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -1663,14 +1663,30 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
             // is 4 groups -> 1 and the trade is different, so it was re-derived rather than
             // inherited. Measured at ctx 4096, K=65536, one binary, draft ms/block:
             //     ROWS 2 -> 2.070    ROWS 4 -> 2.001    ROWS 8 -> 1.955
-            // Monotone, so the old note does not hold at this width. 8 covers the whole block in
-            // one group; the epilogue already drops rows past q_len, so the overhang is free.
-            // SPARKINFER_DFLASH_ATTN_ROWS pins it for an A/B out of one binary.
+            // Monotone, so the old note does not hold at this width: 8 covers the whole block in
+            // one group. SPARKINFER_DFLASH_ATTN_ROWS pins it for an A/B out of one binary.
+            //
+            // But 8 is only right when the block IS 8 (or 7) wide, and the overhang is NOT
+            // free. The tile is a fixed-size register array: rows past q_len carry qr[]=0 and
+            // are still loaded, still dotted
+            // against every key, and still folded through the butterfly -- only the
+            // online-softmax update (step 3) skips them. So a tile wider than the block pays for
+            // the overhang in both work and REGISTERS, and buys nothing: what a wide tile is FOR
+            // is collapsing the ROW GROUPS that each re-read the KV, and one group is one group
+            // at either width.
+            // The 12288+ band takes proposal depth 2 (qwen35.cpp), which makes the draft's block 4
+            // rows wide, so the shipped 8 was covering a 4-row block with an 8-row tile on every
+            // layer of every step there. Pick the SMALLEST instantiated tier that still covers the
+            // block in one group; at width 7-8 that is the same 8 the sweep above measured.
+            // Bit-identical either way: each row's dots, its butterfly and its fold are
+            // independent of ROWS, so rows 0..q_len-1 see the same values in the same order.
             static const int rows_env = []{
                 const char* e = getenv("SPARKINFER_DFLASH_ATTN_ROWS");
-                int v = e ? atoi(e) : 8;
-                return (v == 2 || v == 4 || v == 8) ? v : 8;
+                int v = e ? atoi(e) : 0;
+                return (v == 2 || v == 4 || v == 8) ? v : 0;
             }();
+            const int rows_tile = rows_env ? rows_env
+                                : (q_len <= 2 ? 2 : (q_len <= 4 ? 4 : 8));
             const int n_splits_full = attn_gqa_splits(kv_len);
             // A sliding-window layer masks a key only after the kernel has loaded it and reduced
             // its QK dot, so past the window length it streams the whole cache to discard most of
@@ -1711,9 +1727,9 @@ void launch_attn_gqa(const void* q, const void* k, const void* v, void* out,
                         q_len, kv_lo, kv_len, n_q, n_kv, q_pos0, k_pos0, window, causal, scale,   \
                         n_splits);                                                                \
             } while (0)
-            if (rows_env == 8)      SI_DF_ATTN_ROWS(8);
-            else if (rows_env == 4) SI_DF_ATTN_ROWS(4);
-            else                    SI_DF_ATTN_ROWS(2);
+            if (rows_tile == 8)      SI_DF_ATTN_ROWS(8);
+            else if (rows_tile == 4) SI_DF_ATTN_ROWS(4);
+            else                     SI_DF_ATTN_ROWS(2);
 #undef SI_DF_ATTN_ROWS
             k_attn_split_combine<<<dim3(q_len, n_q), 128, 0, stream>>>(
                 fa_m, fa_l, fa_acc, (bf16*)out, n_q, n_splits);


### PR DESCRIPTION
## Summary

Two bit-identical kernel changes on the DSpark decode path at 16k. The draft attention row tile is
matched to the actual proposal block width (the 12288+ band drafts at depth 2 = width 4, but the
tile was hardcoded 8, so rows 4-7 were loaded, dotted, butterflied and then discarded at ~128
registers instead of ~72). The QK dots in `fa_split_gqa_pipe_kernel` are hoisted so all SEQ dots are
computed before a single butterfly pass, exposing SEQ independent reductions to interleave against a
5-deep shfl chain plus 2 MUFU that previously had nothing in flight.

Both are exact: each row's dots, butterfly and fold are independent of the tile height, and the
hoist preserves the dot order, the mask sequence and the fold order. tau is identical on both arms,
the run is lossless, and PR-vs-main token agreement is 101/101 with KL 0.0000.

Resubmits #930 (same two commits, rebased onto current main). That round returned **0.00 on every
PR-side metric** -- `pr_dspark_tps`, `pr_ar_tps`, `tau` and `top1` all zero, and both guards failed
with empty reasons -- which is the signature of the PR binary producing no `METRIC` lines at all
(crash / failed load / timeout), not of a divergence; a real divergence reports real tok/s with
`lossless=false`. The same commit passed a full local gate on a clean build, guards included
(`ALL GATES GREEN`, `GUARD38 78.15 / 1398.04`, `GUARD36 386.87 / 1234.07`). Rebased here onto
`9c16013` so the round builds over a current main rather than the previous one.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, DSpark speculative decode at ctx=16384):

| | decode tok/s |
|---|--:|
| before (main) | 111.03 |
| after (this PR) | 113.36 |

Prefill is untouched by this PR, so the prefill table is left empty deliberately; the guard contexts
below show it flat rather than unmeasured.

```text
# Box A -- ctx=16384, first 16384 tokens of bench/scripts/bench_prompt_32k.txt, 128 generated
# tokens, 3 speculative repeats per arm, both arms from one toolchain on one box.

main DSPARK=111.0340 AR=89.3425 tau=1.5238
pr   DSPARK=113.3603 AR=89.2860 tau=1.5238 lossless=1/3
== dspark-decode@16k  1.0210x

positions             : 101
top-1 agreement       : 101/101 = 1.000   (PR vs main)
mean KL(main||pr)     : 0.0000 nats  (top-k union)
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.0160 ppl_main=3.0160

GUARD38 si_main 16384 78.19 1404.51
GUARD36 si_main 16384 387.00 1233.61
GUARD38 si_pr   16384 78.15 1398.04
GUARD36 si_pr   16384 386.87 1234.07
ALL GATES GREEN

# Box B -- independent replication: fresh clone, fresh build of both arms, arms interleaved
# main/PR/main/PR to cancel drift.

main   DS 110.3226  AR 89.2740  tau 1.5238  lossless=1  draft 1.563  batch 12.249
pr     DS 112.2665  AR 89.0837  tau 1.5238  lossless=1  draft 1.479  batch 12.094
main   DS 109.6780  AR 89.0383  tau 1.5238  lossless=1  draft 1.566  batch 12.328
pr     DS 112.0229  AR 89.0225  tau 1.5238  lossless=1  draft 1.481  batch 12.122

mean: main 110.000 -> pr 112.145 = 1.0195x
```

1.0195x on box B against 1.0210x on box A -- a 0.15pp spread, inside the 0.45% run-to-run noise
measured by repeating identical arms. The two changes separate cleanly in the phase timers: the
draft row tile is worth -5.4% on `draft` and the QK-dot hoist -1.5% on `batch`, which is what each
change targets. tau is 1.5238 on every arm of both boxes, so none of this comes from an acceptance
lottery, and the AR leg is flat (89.34 -> 89.29) so the gain is not bought by slowing the shared
baseline.

Measurement note, stated plainly: the numbers above come from `dspark_tau_check` at the scored
configuration rather than from `bench/scripts/bench.sh`, because `bench.sh` benchmarks downloaded
release prebuilts and so would not exercise this branch at all. They are end-to-end decode
throughput, not an isolated-kernel microbenchmark.
