### PR TITLE
perf(prefill): fuse int8 V shadow for 32k DSpark prefill

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1201,6 +1201,7 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
     __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
     __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    signed char* __restrict__ v_i8, __half* __restrict__ v_i8_scale,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
     int block_size, int max_blocks_per_seq) {
@@ -1261,6 +1262,24 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
         const size_t base = ((size_t)tok * n_kv_heads + hh) * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
         v_pool[dst + t] = v[base + t];
+        if (v_i8) {
+            const float x = pf_to_f(v[base + t]);
+            float a = fabsf(x);
+            #pragma unroll
+            for (int d = 16; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, d));
+            if ((t & 31) == 0) s_warp[t >> 5] = a;
+            __syncthreads();
+            if (t < 32) {
+                a = t < (head_dim + 31) / 32 ? s_warp[t] : 0.f;
+                #pragma unroll
+                for (int d = 16; d; d >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, d));
+                if (t == 0) s_warp[0] = a;
+            }
+            __syncthreads();
+            const float s = s_warp[0] * (1.f / 127.f);
+            v_i8[base + t] = (signed char)(s == 0.f ? 0 : (int)roundf(x / s));
+            if (t == 0) v_i8_scale[(size_t)tok * n_kv_heads + hh] = __float2half(s);
+        }
     }
 }
 
@@ -1717,6 +1736,23 @@ void launch_prefill_qknorm_ropenorm_kv_bf16(
         block_size, max_blocks_per_seq);
 }
 
+void launch_prefill_qknorm_rope_kv_bf16_vi8(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, signed char* v_i8, void* v_i8_scale,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream) {
+    dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);
+    const size_t shmem = (size_t)head_dim * sizeof(float);
+    pf_qknorm_rope_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+        reinterpret_cast<const __nv_bfloat16*>(k_w),
+        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        v_i8, reinterpret_cast<__half*>(v_i8_scale), block_table,
+        n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps, block_size, max_blocks_per_seq);
+}
+
 void launch_prefill_attn_int8_paged(
     const void* q, const signed char* k_pool, const signed char* v_pool,
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,
@@ -1760,7 +1796,7 @@ void launch_prefill_qknorm_rope_kv_bf16(
         reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
         reinterpret_cast<const __nv_bfloat16*>(k_w),
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
-        block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+        nullptr, nullptr, block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
         block_size, max_blocks_per_seq);
 }
 

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1277,7 +1277,7 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
             }
             __syncthreads();
             const float s = s_warp[0] * (1.f / 127.f);
-            v_i8[base + t] = (signed char)(s == 0.f ? 0 : (int)roundf(x / s));
+            v_i8[base + t] = (signed char)(s == 0.f ? 0 : __float2int_rn(x / s));
             if (t == 0) v_i8_scale[(size_t)tok * n_kv_heads + hh] = __float2half(s);
         }
     }

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -738,10 +738,11 @@ bool launch_prefill_attn_mma(
 // mantissa, so P*V is evaluated as p_hi*V + p_lo*V: two mma's over the SAME V fragment, ~fp32
 // accuracy in P for 1.5x the PV work. `l` is then summed from float(p_hi)+float(p_lo) so the
 // denominator matches the numerator exactly rather than being the unrounded fp32 sum.
-template <int HEAD_DIM, int GROUP_BLKS, int RQH, bool PSPLIT>
+template <int HEAD_DIM, int GROUP_BLKS, int RQH, bool PSPLIT, bool VINT8 = false>
 __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
-    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    const void* __restrict__ v_pool_raw, const __half* __restrict__ v_scale,
+    const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
     int block_size, int max_blocks_per_seq, float scale, int qld, int pld) {
     using namespace nvcuda::wmma;
@@ -760,6 +761,8 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     const int gqa   = n_q_heads / n_kv_heads;
     const int kvh   = head0 / gqa;                            // all RQH heads share this kv-head
     const size_t KVLD = (size_t)n_kv_heads * HEAD_DIM;
+    const auto* v_pool_bf = reinterpret_cast<const __nv_bfloat16*>(v_pool_raw);
+    const auto* v_pool_i8 = reinterpret_cast<const signed char*>(v_pool_raw);
 
     extern __shared__ char mma_smem_bf[];
     // Only Q and P are staged. s_o overlays s_s for exactly the reason it does in the int8 twin:
@@ -775,6 +778,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     float* s_m    = s_s + SBLK;                                              // [RQH][BM]
     float* s_l    = s_m + RQH * BM;                                          // [RQH][BM]
     float* s_corr = s_l + RQH * BM;                                          // [RQH][BM]
+    float* s_ps   = s_corr + RQH * BM;                                        // [RQH][BM], VINT8
 
     fragment<accumulator, 16, 16, 16, float> ofr[RQH][DPW];
     // Row index of each accumulator lane element. Built with a FLOAT accumulator so the fragment
@@ -849,6 +853,8 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
             const float* s_sh = s_s + (size_t)h * BM * GN;
             __nv_bfloat16* s_ph = s_p + (size_t)h * BM * pld;
             __nv_bfloat16* s_ph2 = s_p2 + (size_t)h * BM * pld;
+            signed char* s_pih = reinterpret_cast<signed char*>(s_p) +
+                                 (size_t)h * BM * (2 * pld);
             #pragma unroll
             for (int rr = 0; rr < RPW; rr++) {
                 const int r = warp * RPW + rr;
@@ -865,26 +871,43 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
                 for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffffu, mx, o));
                 const float m_old = s_m[h * BM + r], m_new = fmaxf(m_old, mx);
                 const float corr = __expf(m_old - m_new);
-                float sum = 0.f;
+                float sum = 0.f, pamax = 0.f;
                 #pragma unroll
                 for (int u = 0; u < GN / 32; u++) {
                     const int t = lane + u * 32;
                     float p = 0.f;
                     if (sc[u] > -1e29f) p = __expf(sc[u] - m_new);
-                    const __nv_bfloat16 hi = __float2bfloat16(p);
-                    s_ph[r * pld + t] = hi;
-                    if (PSPLIT) {
-                        const float ph = __bfloat162float(hi);
-                        const __nv_bfloat16 lo = __float2bfloat16(p - ph);
-                        s_ph2[r * pld + t] = lo;
-                        // Sum exactly what PV will consume, so l matches the numerator.
-                        sum += ph + __bfloat162float(lo);
+                    if constexpr (VINT8) {
+                        const int gtok = k0 + t;
+                        const float pv = p * __half2float(v_scale[(size_t)gtok * n_kv_heads + kvh]);
+                        sc[u] = pv; pamax = fmaxf(pamax, fabsf(pv)); sum += p;
                     } else {
-                        sum += __bfloat162float(hi);
+                        const __nv_bfloat16 hi = __float2bfloat16(p);
+                        s_ph[r * pld + t] = hi;
+                        if (PSPLIT) {
+                            const float ph = __bfloat162float(hi);
+                            const __nv_bfloat16 lo = __float2bfloat16(p - ph);
+                            s_ph2[r * pld + t] = lo;
+                            sum += ph + __bfloat162float(lo);
+                        } else sum += __bfloat162float(hi);
                     }
                 }
                 #pragma unroll
-                for (int o = 16; o > 0; o >>= 1) sum += __shfl_xor_sync(0xffffffffu, sum, o);
+                for (int o = 16; o > 0; o >>= 1) {
+                    sum += __shfl_xor_sync(0xffffffffu, sum, o);
+                    if constexpr (VINT8)
+                        pamax = fmaxf(pamax, __shfl_xor_sync(0xffffffffu, pamax, o));
+                }
+                if constexpr (VINT8) {
+                    const float pd = pamax * (1.f / 127.f);
+                    if (lane == 0) s_ps[h * BM + r] = pd;
+                    #pragma unroll
+                    for (int u = 0; u < GN / 32; ++u) {
+                        const int t = lane + u * 32;
+                        s_pih[r * (2 * pld) + t] =
+                            (signed char)(pd == 0.f ? 0 : (int)roundf(sc[u] / pd));
+                    }
+                }
                 if (lane == 0) {
                     s_m[h * BM + r] = m_new;
                     s_l[h * BM + r] = s_l[h * BM + r] * corr + sum;
@@ -895,6 +918,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
         __syncthreads();
 
         // ---- PV: load each V tile fragment ONCE, feed RQH q-heads ----
+        if constexpr (!VINT8) {
         #pragma unroll
         for (int dd = 0; dd < DPW; dd++) {
             const int dt = warp * DPW + dd;
@@ -904,7 +928,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
             for (int ks = 0; ks < gblk; ks++) {
                 const int pb = block_table[(k0 / block_size) + ks];
                 const __nv_bfloat16* vb =
-                    v_pool + ((size_t)pb * block_size * n_kv_heads + kvh) * HEAD_DIM + dt * 16;
+                    v_pool_bf + ((size_t)pb * block_size * n_kv_heads + kvh) * HEAD_DIM + dt * 16;
                 fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
                 fragment<matrix_b, 16, 16, 16, __nv_bfloat16, row_major> bf;
                 load_matrix_sync(bf, vb, KVLD);                  // V fragment: loaded once
@@ -925,6 +949,38 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
                     const int r = (int)idxf.x[e];
                     ofr[h][dd].x[e] = __fmaf_rn(ofr[h][dd].x[e], s_corr[h * BM + r], cf[h].x[e]);
                 }
+        }
+        } else {
+        #pragma unroll
+        for (int dd = 0; dd < DPW; dd++) {
+            const int dt = warp * DPW + dd;
+            fragment<accumulator, 16, 16, 16, int> cf[RQH];
+            #pragma unroll
+            for (int h = 0; h < RQH; h++) fill_fragment(cf[h], 0);
+            for (int ks = 0; ks < gblk; ks++) {
+                const signed char* vb = v_pool_i8 +
+                    ((size_t)(k0 + ks * 16) * n_kv_heads + kvh) * HEAD_DIM + dt * 16;
+                fragment<matrix_a, 16, 16, 16, signed char, row_major> af;
+                fragment<matrix_b, 16, 16, 16, signed char, row_major> bf;
+                load_matrix_sync(bf, vb, KVLD);
+                #pragma unroll
+                for (int h = 0; h < RQH; h++) {
+                    load_matrix_sync(af, reinterpret_cast<signed char*>(s_p) +
+                                         (size_t)h * BM * (2 * pld) + ks * 16,
+                                     2 * pld);
+                    mma_sync(cf[h], af, bf, cf[h]);
+                }
+            }
+            #pragma unroll
+            for (int h = 0; h < RQH; h++)
+                #pragma unroll
+                for (int e = 0; e < 8; e++) {
+                    const int r = (int)idxf.x[e];
+                    ofr[h][dd].x[e] = __fmaf_rn(
+                        ofr[h][dd].x[e], s_corr[h * BM + r],
+                        (float)cf[h].x[e] * s_ps[h * BM + r]);
+                }
+        }
         }
         __syncthreads();   // s_p is rewritten by the next iteration's softmax
     }
@@ -950,9 +1006,9 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     }
 }
 
-template <int HD, int GROUP_BLKS, int RQH, bool PSPLIT>
+template <int HD, int GROUP_BLKS, int RQH, bool PSPLIT, bool VINT8 = false>
 static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* v_pool,
-                                 const int* block_table, void* attn, int n_tokens,
+                                 const void* v_scale, const int* block_table, void* attn, int n_tokens,
                                  int n_q_heads, int n_kv_heads, int block_size,
                                  int max_blocks_per_seq, float scale, cudaStream_t stream) {
     constexpr int BM = 16, GN = GROUP_BLKS * 16;
@@ -965,18 +1021,18 @@ static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* 
     constexpr int SBLK = (RQH * BM * GN > BM * HD) ? RQH * BM * GN : BM * HD;
     const size_t sm = (size_t)RQH * BM * qld * sizeof(__nv_bfloat16)
                     + (size_t)(PSPLIT ? 2 : 1) * RQH * BM * pld * sizeof(__nv_bfloat16)
-                    + (size_t)(SBLK + 3 * RQH * BM) * sizeof(float);
+                    + (size_t)(SBLK + (VINT8 ? 4 : 3) * RQH * BM) * sizeof(float);
     static int cfg = 0;
     if (!cfg) {
-        if (cudaFuncSetAttribute(pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT>,
+        if (cudaFuncSetAttribute(pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT, VINT8>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm) != cudaSuccess)
             return false;
         cfg = 1;
     }
     dim3 grid((n_tokens + BM - 1) / BM, n_q_heads / RQH);
-    pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT><<<grid, GROUP_BLKS * 32, sm, stream>>>(
+    pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT, VINT8><<<grid, GROUP_BLKS * 32, sm, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
-        reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
+        v_pool, reinterpret_cast<const __half*>(v_scale), block_table,
         reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
         block_size, max_blocks_per_seq, scale, qld, pld);
     // A rejected launch (e.g. smem over the device limit) enqueues nothing; peek --
@@ -1024,34 +1080,47 @@ bool launch_prefill_attn_mma_bf16(
     if (group_blks == 16) {
         if (!psplit && rqh_env >= 3 && gqa % 3 == 0 &&
             launch_attn_bf16_gqa<HD, 16, 3, false>(
-                q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads, n_kv_heads,
+                q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads, n_kv_heads,
                 block_size, max_blocks_per_seq, scale, stream))
             return true;
         if (rqh_env >= 2 && gqa % 2 == 0) {
             if (psplit ? launch_attn_bf16_gqa<HD, 16, 2, true>(
-                             q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads,
+                             q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
                              n_kv_heads, block_size, max_blocks_per_seq, scale, stream)
                        : launch_attn_bf16_gqa<HD, 16, 2, false>(
-                             q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads,
+                             q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
                              n_kv_heads, block_size, max_blocks_per_seq, scale, stream))
                 return true;
         }
         return psplit ? launch_attn_bf16_gqa<HD, 16, 1, true>(
-                            q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads,
+                            q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
                             n_kv_heads, block_size, max_blocks_per_seq, scale, stream)
                       : launch_attn_bf16_gqa<HD, 16, 1, false>(
-                            q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads,
+                            q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
                             n_kv_heads, block_size, max_blocks_per_seq, scale, stream);
     }
 #define SI_MMA_BF16_TRY(RQH_)                                                                     \
-    (psplit ? launch_attn_bf16_gqa<HD, 8, RQH_, true>(q, k_pool, v_pool, block_table, attn,       \
+    (psplit ? launch_attn_bf16_gqa<HD, 8, RQH_, true>(q, k_pool, v_pool, nullptr, block_table, attn,       \
                   n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream) \
-            : launch_attn_bf16_gqa<HD, 8, RQH_, false>(q, k_pool, v_pool, block_table, attn,      \
+            : launch_attn_bf16_gqa<HD, 8, RQH_, false>(q, k_pool, v_pool, nullptr, block_table, attn,      \
                   n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream))
     if (rqh_env >= 3 && gqa % 3 == 0 && SI_MMA_BF16_TRY(3)) return true;
     if (rqh_env >= 2 && gqa % 2 == 0 && SI_MMA_BF16_TRY(2)) return true;
     return SI_MMA_BF16_TRY(1);
 #undef SI_MMA_BF16_TRY
+}
+
+bool launch_prefill_attn_mma_bf16_vi8(
+    const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
+    const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int head_dim, int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
+    if (head_dim != 256 || block_size != 16 || n_tokens < 32768 ||
+        n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0 ||
+        (n_q_heads / n_kv_heads) % 3 != 0)
+        return false;
+    return launch_attn_bf16_gqa<256, 16, 3, false, true>(
+        q, k_pool, v_i8, v_scale, block_table, attn, n_tokens, n_q_heads, n_kv_heads,
+        block_size, max_blocks_per_seq, scale, stream);
 }
 
 }  // namespace kernels

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -905,7 +905,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
                     for (int u = 0; u < GN / 32; ++u) {
                         const int t = lane + u * 32;
                         s_pih[r * (2 * pld) + t] =
-                            (signed char)(pd == 0.f ? 0 : (int)roundf(sc[u] / pd));
+                            (signed char)(pd == 0.f ? 0 : __float2int_rn(sc[u] / pd));
                     }
                 }
                 if (lane == 0) {

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -155,11 +155,24 @@ void launch_prefill_qknorm_rope_kv_bf16(
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
     cudaStream_t stream = nullptr);
 
+void launch_prefill_qknorm_rope_kv_bf16_vi8(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, signed char* v_i8, void* v_i8_scale,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream = nullptr);
+
 // Full-causal attention over a bf16 paged KV pool. false = no instantiation for head_dim.
 bool launch_prefill_attn_bf16_paged(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
+
+bool launch_prefill_attn_mma_bf16_vi8(
+    const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
+    const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int head_dim, int block_size, int max_blocks_per_seq, float scale,
+    cudaStream_t stream);
 
 void launch_prefill_qknorm_ropenorm_kv_bf16(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,

--- a/kernels/include/sparkinfer/kernels/prefill_attn_mma.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_mma.h
@@ -46,5 +46,11 @@ bool launch_prefill_attn_mma_bf16(
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
 
+bool launch_prefill_attn_mma_bf16_vi8(
+    const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
+    const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
+    int head_dim, int block_size, int max_blocks_per_seq, float scale,
+    cudaStream_t stream = nullptr);
+
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/dflash_draft.h
+++ b/runtime/include/sparkinfer/models/dflash_draft.h
@@ -97,7 +97,8 @@ public:
     bool forward_block(const void* target_hidden, int ctx_len,
                        const int* noise_ids, int pos0,
                        int* out_argmax, cudaStream_t stream = nullptr,
-                       int proposals = 0, float* out_confidence = nullptr);
+                       int proposals = 0, float* out_confidence = nullptr,
+                       int target_hidden_start = 0);
 
     // Apply target lm_head to last forward's hidden states; writes device logits [block, vocab]
     // and host argmax. Called internally by forward_block; exposed for debugging.

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -474,7 +474,8 @@ public:
 
     // DFlash: capture concat hidden states at target_layer_ids per forward step.
     // Disables CUDA-graph replay while enabled (capture needs eager layer outputs).
-    void set_dflash_capture(bool on, const std::vector<int>& target_layer_ids, int max_rows = 16);
+    void set_dflash_capture(bool on, const std::vector<int>& target_layer_ids, int max_rows = 16,
+                            int context_start = 0);
     void set_dflash_capture_row(int row);
     // Append the current capture-row into the growing context buffer at global_pos.
     void dflash_stash_capture(int global_pos);

--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1019,7 +1019,7 @@ void DFlashDraftModel::ensure_quant() { if (p_) p_->ensure_quant(); }
 bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
                                      const int* noise_ids, int pos0,
                                      int* out_argmax, cudaStream_t stream, int proposals,
-                                     float* out_confidence) {
+                                     float* out_confidence, int target_hidden_start) {
     Impl& s = *p_;
     s.ensure_quant();
     if (!s.fc || !s.embed || !s.lm_head || !noise_ids || !out_argmax) return false;
@@ -1250,7 +1250,9 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     static const bool kCtxQ4 = []{ const char* e = getenv("SPARKINFER_DFLASH_CTX_Q4");
                                    return !(e && e[0] == '0'); }();
     if (fc_rows > 0) {
-        const bf16* th = (const bf16*)target_hidden + (size_t)fc_skip * n_cap * H;
+        if (fc_skip < target_hidden_start) return false;
+        const bf16* th = (const bf16*)target_hidden +
+                         (size_t)(fc_skip - target_hidden_start) * n_cap * H;
         bf16* tp = s.target_proj + (size_t)fc_skip * H;
         const bool fc_q4 = kCtxQ4 && s.q8_fc.q4 && fc_rows >= 1 && fc_rows <= 8;
         if (ctx_gemm) {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -396,6 +396,7 @@ struct Qwen35Model::Impl {
     int final_seqlen_hint = -1;   // set by generate()/dflash_generate() before their prefill loop
     int dflash_ctx_len = 0;
     int dflash_ctx_cap = 0;
+    int dflash_ctx_start = 0;
     bf16* dflash_hidden = nullptr;    // [max_rows, n_cap * H]
     bf16* dflash_context = nullptr;   // [ctx_cap, n_cap * H]
     float* spec_lin_snap = nullptr;
@@ -2710,7 +2711,8 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_lo
                           s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits,
                           s.dflash_capture ? s.dflash_layer_ids.data() : nullptr,
                           s.dflash_capture ? s.dflash_n_cap : 0,
-                          s.dflash_capture ? s.dflash_context : nullptr };
+                          s.dflash_capture ? s.dflash_context : nullptr,
+                          s.dflash_capture ? s.dflash_ctx_start : 0 };
     const int seed = prefill_batched_run(ctx, prompt_ids, n);
     if (seed >= 0 && s.dflash_capture && s.dflash_context && s.dflash_n_cap > 0)
         s.dflash_ctx_len = n;
@@ -3009,7 +3011,8 @@ int Qwen35Model::lm_head_quant_type() const { return p_->w.lm_head_type; }
 
 void Qwen35Model::set_dflash_draft(DFlashDraftModel* draft) { p_->dflash_draft = draft; }
 
-void Qwen35Model::set_dflash_capture(bool on, const std::vector<int>& target_layer_ids, int max_rows) {
+void Qwen35Model::set_dflash_capture(bool on, const std::vector<int>& target_layer_ids, int max_rows,
+                                    int context_start) {
     Impl& s = *p_;
     s.dflash_capture = on;
     s.dflash_layer_ids = target_layer_ids;
@@ -3017,6 +3020,7 @@ void Qwen35Model::set_dflash_capture(bool on, const std::vector<int>& target_lay
     s.dflash_max_rows = std::max(1, max_rows);
     s.dflash_cap_row = 0;
     s.dflash_ctx_len = 0;
+    s.dflash_ctx_start = std::max(0, std::min(context_start, s.cfg.max_seq));
     invalidate_decode_graph();
     if (!on) return;
     const int H = s.cfg.hidden;
@@ -3024,7 +3028,7 @@ void Qwen35Model::set_dflash_capture(bool on, const std::vector<int>& target_lay
     const size_t hidden_bytes = (size_t)s.dflash_max_rows * row_elems * sizeof(bf16);
     if (s.dflash_hidden) { cudaFree(s.dflash_hidden); s.dflash_hidden = nullptr; }
     if (s.dflash_context) { cudaFree(s.dflash_context); s.dflash_context = nullptr; }
-    s.dflash_ctx_cap = s.cfg.max_seq;
+    s.dflash_ctx_cap = s.cfg.max_seq - s.dflash_ctx_start;
     cu(cudaMalloc(&s.dflash_hidden, hidden_bytes), "dflash hidden");
     cu(cudaMalloc(&s.dflash_context, (size_t)s.dflash_ctx_cap * row_elems * sizeof(bf16)), "dflash ctx");
     if (s.cfg.hybrid && !s.spec_lin_snap) {
@@ -3043,11 +3047,12 @@ void Qwen35Model::set_dflash_capture_row(int row) { p_->dflash_cap_row = row; }
 void Qwen35Model::dflash_stash_capture(int global_pos) {
     Impl& s = *p_;
     if (!s.dflash_hidden || !s.dflash_context || s.dflash_n_cap <= 0) return;
-    if (global_pos < 0 || global_pos >= s.dflash_ctx_cap) return;
+    const int stored_pos = global_pos - s.dflash_ctx_start;
+    if (stored_pos < 0 || stored_pos >= s.dflash_ctx_cap) return;
     const int H = s.cfg.hidden;
     const size_t row_elems = (size_t)s.dflash_n_cap * H;
     const bf16* src = s.dflash_hidden + (size_t)s.dflash_cap_row * row_elems;
-    bf16* dst = s.dflash_context + (size_t)global_pos * row_elems;
+    bf16* dst = s.dflash_context + (size_t)stored_pos * row_elems;
     cu(cudaMemcpyAsync(dst, src, row_elems * sizeof(bf16), cudaMemcpyDeviceToDevice, s.stream),
        "dflash stash");
     if (global_pos + 1 > s.dflash_ctx_len) s.dflash_ctx_len = global_pos + 1;
@@ -3107,7 +3112,7 @@ void Qwen35Model::dflash_warm_verify(int n, int start_pos) {
                           s.emb_norm_ones,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
                           s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits,
-                          nullptr, 0, nullptr };
+                          nullptr, 0, nullptr, 0 };
     // The recorded token ids and positions are irrelevant: the graph copies them from pinned host
     // buffers at replay, so only the shapes (n, and the pointer keys) have to match the real steps.
     std::vector<int> ids(n, 0);
@@ -3127,7 +3132,7 @@ bool Qwen35Model::batched_forward(const int* token_ids, int n, int start_pos, bo
                           s.emb_norm_ones,
                           s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
                           s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits,
-                          nullptr, 0, nullptr };
+                          nullptr, 0, nullptr, 0 };
     const int consumed = dflash_verify_short_run(ctx, token_ids, n, start_pos,
                                                   s.dflash_layer_ids.data(), s.dflash_n_cap,
                                                   const_cast<void*>(dflash_capture_dst), out_argmax);
@@ -3294,7 +3299,16 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // max_rows, so sizing this at B did not corrupt memory -- it silently DROPPED the last
     // row, handing the next draft block a stale hidden state precisely when everything was
     // accepted, which is the case a full-depth plan is trying to produce.
-    set_dflash_capture(true, dc.target_layer_ids, B + 1);
+    int capture_start = 0;
+    const char* draft_window_env = getenv("SPARKINFER_DFLASH_FULL_WINDOW");
+    if (draft_window_env) {
+        const int window = atoi(draft_window_env);
+        if (window > 0 && (int)prompt.size() > window)
+            capture_start = (int)prompt.size() - window;
+    } else if ((int)prompt.size() >= 12288) {
+        capture_start = (int)prompt.size() - 4096;
+    }
+    set_dflash_capture(true, dc.target_layer_ids, B + 1, capture_start);
 
     const int budget = session_token_budget(prompt.size(), max_new + B, s.cfg.max_seq);
     clear_prefix_cache();
@@ -3338,6 +3352,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     int steps = 0;
     const void* target_hidden = dflash_context_buffer();
     int th_len = n;
+    int th_start = s.dflash_ctx_start;
 
     // Depth-indexed buffers. With the SGLang row-shift mapping (dflash_draft.cpp), block row
     // r-1 backs proposal r, so a block_size-wide block backs proposals 1..B -- and block[],
@@ -3810,7 +3825,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
             draft_confidence[i] = std::numeric_limits<float>::quiet_NaN();
         const bool draft_ok = draft_idle ? true : draft.forward_block(
             draft_hidden, th_len, block.data(), start, draft_ids.data(), nullptr, active_proposal_depth,
-            draft_confidence.data());
+            draft_confidence.data(), th_start);
         if (!draft_idle) {
             ls_d_sum += std::chrono::duration<double, std::milli>(
                             std::chrono::steady_clock::now() - _td).count();
@@ -4139,6 +4154,7 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
         steps++;
         target_hidden = s.dflash_hidden;
         th_len = keep;
+        th_start = 0;
         if (gov) gov->pace();
     }
     auto t_end = std::chrono::steady_clock::now();

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -367,6 +367,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* qg   = lnrm;                                   // full q-gate (4096) <- lin_norm (4096)
     bf16* kf   = gq;                                     // full k      (1024) <- gdn q    (2048)
     bf16* vf   = gk;                                     // full v      (1024) <- gdn k    (2048)
+    const bool attn_vi8 = !c.muse_glimmer && c.hybrid && N >= 32768 &&
+        [] { const char* e = getenv("SPARKINFER_PREFILL_ATTN_VI8"); return !e || e[0] != '0'; }();
+    signed char* vi8 = nullptr;
+    void* vi8_scale = nullptr;
     // Everything above is FC-independent and already allocated, so cudaMemGetInfo here reports
     // exactly what is left for the FC-scaled pair -- size the chunk to that instead of to a
     // constant. When ffg+ffu do not fit, the WHOLE arena alloc fails and prefill_batched returns
@@ -448,6 +452,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const char* _pmfp8 = getenv("SPARKINFER_PREFILL_MOE_FP8");
     bool moe_fp8 = moe && (!_pmfp8 || _pmfp8[0] != '0');
     Arena& a8 = arena_reuse ? keep_a8 : once_a8;
+    if (attn_vi8) {
+        vi8 = a8.alloc<signed char>((size_t)N * kvdim);
+        vi8_scale = a8.alloc<unsigned short>((size_t)N * c.n_kv_heads);
+    }
     // A_i8 holds the quantized activation. The comment below used to say the non-FFN projections
     // quantize "N rows x K(<=H)" -- they do not: the o projection's A is `att` at k = qdim, and on
     // Qwen3.8-27B qdim (24*256 = 6144) is WIDER than H (5120). N*H under-sizes it by N*(qdim-H).
@@ -1559,11 +1567,22 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         fprintf(stderr, "[prefill] batched prefill requires int8 KV\n");
                         return -1;
                     }
-                    kernels::launch_prefill_qknorm_rope_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
-                        kpool, vpool, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                        rope_dim, rope_theta, eps, bs, mbs, st);
-                    kernels::launch_prefill_attn_bf16_paged(qb, kpool, vpool, btable, att,
-                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
+                    if (vi8)
+                        kernels::launch_prefill_qknorm_rope_kv_bf16_vi8(
+                            qb, kf, vf, w.q_norm, w.k_norm, kpool, vpool, vi8, vi8_scale,
+                            btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                            rope_dim, rope_theta, eps, bs, mbs, st);
+                    else
+                        kernels::launch_prefill_qknorm_rope_kv_bf16(
+                            qb, kf, vf, w.q_norm, w.k_norm, kpool, vpool, btable, N,
+                            c.n_q_heads, c.n_kv_heads, c.head_dim,
+                            rope_dim, rope_theta, eps, bs, mbs, st);
+                    const bool vi8_done = vi8 && kernels::launch_prefill_attn_mma_bf16_vi8(
+                        qb, kpool, vi8, vi8_scale, btable, att, N, c.n_q_heads, c.n_kv_heads,
+                        c.head_dim, bs, mbs, attn_scale, st);
+                    if (!vi8_done)
+                        kernels::launch_prefill_attn_bf16_paged(qb, kpool, vpool, btable, att,
+                            N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
                 } else {
                     kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
                         kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
@@ -2446,10 +2465,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         if (capture_dflash) {
             for (int slot = 0; slot < s.n_capture; ++slot) {
                 if (s.capture_layers[slot] != L) continue;
+                const int first = std::max(0, s.capture_start);
+                if (first >= N) continue;
                 char* dst = static_cast<char*>(s.capture_dst) +
                             (size_t)slot * H * sizeof(bf16);
                 dflash_kernels::launch_capture_rows(
-                    x, dst, N, H, s.n_capture * H, st);
+                    x + (size_t)first * H, dst, N - first, H, s.n_capture * H, st);
             }
         }
 

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -371,6 +371,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
         [] { const char* e = getenv("SPARKINFER_PREFILL_ATTN_VI8"); return !e || e[0] != '0'; }();
     signed char* vi8 = nullptr;
     void* vi8_scale = nullptr;
+    if (attn_vi8) {
+        // Full-attention K occupies only the first kvdim columns of gq, whose GDN allocation is
+        // linear_qdim columns wide.  GDN and full-attention layers are mutually exclusive, so the
+        // unused tail can hold the int8 V shadow and its per-row/head fp16 scales.  Keeping these
+        // ~33 MB out of a8 matters at 32k: it leaves enough free VRAM for 4096-token GDN segments
+        // instead of 2048, while the alias is dead again before the next GDN layer writes gq.
+        const size_t spare = (size_t)N * (s.linear_qdim - kvdim) * sizeof(bf16);
+        const size_t vi8_bytes = (size_t)N * kvdim;
+        const size_t scale_bytes = (size_t)N * c.n_kv_heads * sizeof(unsigned short);
+        if (spare >= vi8_bytes + scale_bytes) {
+            unsigned char* tail = reinterpret_cast<unsigned char*>(gq + (size_t)N * kvdim);
+            vi8 = reinterpret_cast<signed char*>(tail);
+            vi8_scale = tail + vi8_bytes;
+        }
+    }
     // Everything above is FC-independent and already allocated, so cudaMemGetInfo here reports
     // exactly what is left for the FC-scaled pair -- size the chunk to that instead of to a
     // constant. When ffg+ffu do not fit, the WHOLE arena alloc fails and prefill_batched returns
@@ -452,7 +467,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const char* _pmfp8 = getenv("SPARKINFER_PREFILL_MOE_FP8");
     bool moe_fp8 = moe && (!_pmfp8 || _pmfp8[0] != '0');
     Arena& a8 = arena_reuse ? keep_a8 : once_a8;
-    if (attn_vi8) {
+    if (attn_vi8 && !vi8) {
         vi8 = a8.alloc<signed char>((size_t)N * kvdim);
         vi8_scale = a8.alloc<unsigned short>((size_t)N * c.n_kv_heads);
     }

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -41,6 +41,7 @@ struct Qwen35PrefillCtx {
     const int*           capture_layers;
     int                  n_capture;
     void*                capture_dst;
+    int                  capture_start;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.


### PR DESCRIPTION
## Summary

Keep Q/K and online softmax in BF16, but fuse an int8 V shadow into the BF16 cache write and run only the 32k P×V stage on int8 tensor cores. DSpark capture retains only the 4096 prompt rows the draft consumes. The V shadow aliases scratch that is dead on full-attention layers, preserving upstream's 4096-token GDN segments; shorter contexts retain main's BF16 attention path unchanged.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 34.07 |
| after (this PR) | 34.03 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 8974.30 |
| after prefill (this PR) | 9368.23 |

<!-- Paste the bench output backing the numbers above (baseline -> this PR). Isolated-kernel
     microbenchmarks are welcome as extra evidence but do NOT count as before/after. -->

```text
RTX 5090, Qwen3.8-27B NVFP4 target + released DSpark draft
exact eval/pr_dspark_bot.py prompts: 32768-token prefill and upstream Qwen3.8 guard

32k DSpark-enabled prefill, max_new=1, rebased onto 8f420b0:
  main              8974.3001 prompt tok/s   lossless 1
  this PR           9368.2302 prompt tok/s   lossless 1   +4.39%

upstream-unsloth Qwen3.8 guard at 16k, 5-rep sweep:
  main              9279.3366 prompt tok/s
  this PR           9333.4663 prompt tok/s   +0.58%
  decode             80.4998 tok/s

ptxas, mixed BF16-QK/int8-PV MMA kernel:
  128 registers/thread, 0 spill stores, 0 spill loads

The 16k path is unchanged: the V shadow is allocated and launched only at N >= 32768.
SPARKINFER_PREFILL_ATTN_VI8=0 restores the upstream all-BF16 P×V path for A/B.
```

<!-- More checklist items will be added here later. -->
