### PR TITLE
perf(prefill): run the 32k DSpark prefill P x V stage on int8 tensor cores

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1203,7 +1203,8 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
     __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq) {
+    int block_size, int max_blocks_per_seq,
+    signed char* __restrict__ v8, __half* __restrict__ v8_scale) {
     const int tok  = blockIdx.x;
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
@@ -1261,6 +1262,30 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
         const size_t base = ((size_t)tok * n_kv_heads + hh) * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
         v_pool[dst + t] = v[base + t];
+        // INT8 V SHADOW for the >=32k prefill P x V stage. The bf16 pool above stays authoritative
+        // -- decode and every shorter context read only that -- so this adds a second copy rather
+        // than degrading the cache. One scale per (token, kv-head): the attention folds it into P
+        // before quantizing, which is what keeps the int32 accumulation exact.
+        // Token-indexed, not paged: batched prefill always starts at position 0.
+        if (v8) {
+            __shared__ float s_va[32];
+            const float vf = pf_to_f(v[base + t]);
+            float a = fabsf(vf);
+            #pragma unroll
+            for (int o = 16; o > 0; o >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffffu, a, o));
+            const int w = t >> 5, ln = t & 31;
+            if (ln == 0) s_va[w] = a;
+            __syncthreads();
+            float m2 = 0.f;
+            const int nw = (int)((blockDim.x + 31) >> 5);
+            for (int i2 = 0; i2 < nw; i2++) m2 = fmaxf(m2, s_va[i2]);
+            const float sv = (m2 > 0.f) ? m2 * (1.f / 127.f) : 1.f;
+            const int q8 = __float2int_rn(vf / sv);
+            const size_t vd = ((size_t)tok * n_kv_heads + hh) * head_dim + t;
+            v8[vd] = (signed char)(q8 < -127 ? -127 : (q8 > 127 ? 127 : q8));
+            if (t == 0) v8_scale[(size_t)tok * n_kv_heads + hh] = __float2half(sv);
+            __syncthreads();
+        }
     }
 }
 
@@ -1752,7 +1777,7 @@ void launch_prefill_qknorm_rope_kv_bf16(
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream) {
+    cudaStream_t stream, void* v8, void* v8_scale) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);
     const size_t shmem = (size_t)head_dim * sizeof(float);
     pf_qknorm_rope_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
@@ -1761,19 +1786,21 @@ void launch_prefill_qknorm_rope_kv_bf16(
         reinterpret_cast<const __nv_bfloat16*>(k_w),
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq);
+        block_size, max_blocks_per_seq,
+        reinterpret_cast<signed char*>(v8), reinterpret_cast<__half*>(v8_scale));
 }
 
 bool launch_prefill_attn_bf16_paged(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream,
+    const void* v8, const void* v8_scale) {
     // Tensor cores first. pf_attn_bf16_paged_kernel below is one warp per (query, q-head) walking
     // the causal history a key at a time; at long context that is the prompt pass's largest single
     // cost. The mma kernel declines any shape it does not cover, so this stays a strict addition.
     if (launch_prefill_attn_mma_bf16(q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads,
                                      n_kv_heads, head_dim, block_size, max_blocks_per_seq,
-                                     scale, stream))
+                                     scale, stream, v8, v8_scale))
         return true;
     dim3 grid(n_tokens, n_q_heads);
     auto qb = reinterpret_cast<const __nv_bfloat16*>(q);

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -738,12 +738,13 @@ bool launch_prefill_attn_mma(
 // mantissa, so P*V is evaluated as p_hi*V + p_lo*V: two mma's over the SAME V fragment, ~fp32
 // accuracy in P for 1.5x the PV work. `l` is then summed from float(p_hi)+float(p_lo) so the
 // denominator matches the numerator exactly rather than being the unrounded fp32 sum.
-template <int HEAD_DIM, int GROUP_BLKS, int RQH, bool PSPLIT>
+template <int HEAD_DIM, int GROUP_BLKS, int RQH, bool PSPLIT, bool VI8 = false>
 __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
     const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale, int qld, int pld) {
+    int block_size, int max_blocks_per_seq, float scale, int qld, int pld,
+    const signed char* __restrict__ v8, const __half* __restrict__ v8_scale) {
     using namespace nvcuda::wmma;
     constexpr int BM    = 16;                    // query rows per block == wmma M == KV page size
     constexpr int GN    = GROUP_BLKS * 16;       // keys per iteration
@@ -769,10 +770,25 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     // Low half of the split P, immediately after the high half; zero-sized when PSPLIT is off.
     __nv_bfloat16* s_p2 = s_p + (size_t)RQH * BM * pld;                   // [RQH][BM][pld]
     constexpr int PPLANES = PSPLIT ? 2 : 1;
+    // INT8 P plane. It REPLACES the bf16 one (PV reads only this when VI8), so the block gets
+    // SMALLER: 12,672 B of int8 against 25,344 B of bf16 at RQH=3/GROUP_BLKS=16.
+    // INT8 leading dimension must be a multiple of 16 -- wmma's int8 fragment loads want a
+    // 16-BYTE aligned row start, and pld = GN + 8 = 264 is only a multiple of 8. Legal for bf16
+    // (8 elements = 16 B), a misaligned-address fault for int8. Give the int8 plane its own pitch.
+    const int pld8 = (GN + 16);
+    signed char* s_pi = reinterpret_cast<signed char*>(s_p);              // [RQH][BM][pld8]
     constexpr int SBLK = (RQH * BM * GN > BM * HEAD_DIM) ? RQH * BM * GN : BM * HEAD_DIM;
-    float* s_s    = reinterpret_cast<float*>(s_p + (size_t)PPLANES * RQH * BM * pld);  // [RQH][BM][GN]
+    // The P plane is int8 under VI8 and bf16 otherwise, so s_s has to step over the ACTUAL byte
+    // count -- stepping over PPLANES*RQH*BM*pld bf16 ELEMENTS in the int8 case overruns the
+    // launcher's allocation by RQH*BM*pld bytes and corrupts everything past s_s.
+    float* s_s    = reinterpret_cast<float*>(
+        VI8 ? reinterpret_cast<char*>(s_p) + (size_t)RQH * BM * pld8
+            : reinterpret_cast<char*>(s_p)
+                  + (size_t)PPLANES * RQH * BM * pld * sizeof(__nv_bfloat16));  // [BM][GN]
     float* s_o    = s_s;                                                     // [BM][HEAD_DIM]
-    float* s_m    = s_s + SBLK;                                              // [RQH][BM]
+    float* s_vs   = s_s + SBLK;                                              // [GN]  per-key V scale
+    float* s_ps   = s_vs + (VI8 ? GN : 0);                                   // [RQH][BM] P scale
+    float* s_m    = s_ps + (VI8 ? RQH * BM : 0);                             // [RQH][BM]
     float* s_l    = s_m + RQH * BM;                                          // [RQH][BM]
     float* s_corr = s_l + RQH * BM;                                          // [RQH][BM]
 
@@ -816,6 +832,20 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     for (int k0 = 0; k0 < last_q + 1; k0 += GN) {
         const int nk   = min(GN, last_q + 1 - k0);
         const int gblk = (nk + 15) / 16;
+
+        // Per-KEY V scale for this group. It cannot be applied after the int8 P x V mma -- the
+        // mma sums over keys, so a per-key factor does not come out of the int32 accumulator.
+        // Fold it into P instead (see below): sum_k P[r,k]*sv[k]*V8[k,d] means quantizing
+        // P'[r,k] = P[r,k]*sv[k], after which the epilogue needs only the per-ROW P scale. This is
+        // exactly why the int8 twin above carries s_ps[] and no V scale.
+        if (VI8) {
+            for (int j = tid; j < GN; j += blockDim.x) {
+                const int gt = k0 + j;
+                s_vs[j] = (gt < n_tokens) ? __half2float(v8_scale[(size_t)gt * n_kv_heads + kvh])
+                                          : 0.f;
+            }
+            __syncthreads();
+        }
 
         // ---- QK: load each K page fragment ONCE, feed RQH q-heads ----
         if (warp < gblk) {
@@ -866,11 +896,13 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
                 const float m_old = s_m[h * BM + r], m_new = fmaxf(m_old, mx);
                 const float corr = __expf(m_old - m_new);
                 float sum = 0.f;
+                float pvv[GN / 32], pam = 0.f;
                 #pragma unroll
                 for (int u = 0; u < GN / 32; u++) {
                     const int t = lane + u * 32;
                     float p = 0.f;
                     if (sc[u] > -1e29f) p = __expf(sc[u] - m_new);
+                    if (VI8) { pvv[u] = p * s_vs[t]; pam = fmaxf(pam, pvv[u]); continue; }
                     const __nv_bfloat16 hi = __float2bfloat16(p);
                     s_ph[r * pld + t] = hi;
                     if (PSPLIT) {
@@ -882,6 +914,25 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
                     } else {
                         sum += __bfloat162float(hi);
                     }
+                }
+                if (VI8) {
+                    // Row max of P' -> the one scale the epilogue needs.
+                    #pragma unroll
+                    for (int o = 16; o > 0; o >>= 1)
+                        pam = fmaxf(pam, __shfl_xor_sync(0xffffffffu, pam, o));
+                    const float sp  = pam > 0.f ? pam * (1.f / 127.f) : 1.f;
+                    const float isp = 1.f / sp;
+                    #pragma unroll
+                    for (int u = 0; u < GN / 32; u++) {
+                        const int t = lane + u * 32;
+                        const int q = __float2int_rn(pvv[u] * isp);
+                        s_pi[((size_t)h * BM + r) * pld8 + t] =
+                            (signed char)(q < -127 ? -127 : (q > 127 ? 127 : q));
+                        // l must count exactly what PV will consume, so re-dequantize.
+                        const float sv = s_vs[t];
+                        sum += (sv > 0.f) ? ((float)q * sp / sv) : 0.f;
+                    }
+                    if (lane == 0) s_ps[h * BM + r] = sp;
                 }
                 #pragma unroll
                 for (int o = 16; o > 0; o >>= 1) sum += __shfl_xor_sync(0xffffffffu, sum, o);
@@ -898,6 +949,34 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
         #pragma unroll
         for (int dd = 0; dd < DPW; dd++) {
             const int dt = warp * DPW + dd;
+            if (VI8) {
+                fragment<accumulator, 16, 16, 16, int> ci[RQH];
+                #pragma unroll
+                for (int h = 0; h < RQH; h++) fill_fragment(ci[h], 0);
+                for (int ks = 0; ks < gblk; ks++) {
+                    // Token-indexed shadow: batched prefill always starts at position 0, so key
+                    // token == key index and no block_table hop is needed.
+                    const signed char* v8b =
+                        v8 + ((size_t)(k0 + ks * 16) * n_kv_heads + kvh) * HEAD_DIM + dt * 16;
+                    fragment<matrix_a, 16, 16, 16, signed char, row_major> ai;
+                    fragment<matrix_b, 16, 16, 16, signed char, row_major> bi;
+                    load_matrix_sync(bi, v8b, KVLD);
+                    #pragma unroll
+                    for (int h = 0; h < RQH; h++) {
+                        load_matrix_sync(ai, s_pi + ((size_t)h * BM) * pld8 + ks * 16, pld8);
+                        mma_sync(ci[h], ai, bi, ci[h]);
+                    }
+                }
+                #pragma unroll
+                for (int h = 0; h < RQH; h++)
+                    #pragma unroll
+                    for (int e = 0; e < 8; e++) {
+                        const int r = (int)idxf.x[e];
+                        ofr[h][dd].x[e] = __fmaf_rn((float)ci[h].x[e], s_ps[h * BM + r],
+                                                    ofr[h][dd].x[e] * s_corr[h * BM + r]);
+                    }
+                continue;
+            }
             fragment<accumulator, 16, 16, 16, float> cf[RQH];
             #pragma unroll
             for (int h = 0; h < RQH; h++) fill_fragment(cf[h], 0.f);
@@ -950,11 +1029,12 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     }
 }
 
-template <int HD, int GROUP_BLKS, int RQH, bool PSPLIT>
+template <int HD, int GROUP_BLKS, int RQH, bool PSPLIT, bool VI8 = false>
 static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* v_pool,
                                  const int* block_table, void* attn, int n_tokens,
                                  int n_q_heads, int n_kv_heads, int block_size,
-                                 int max_blocks_per_seq, float scale, cudaStream_t stream) {
+                                 int max_blocks_per_seq, float scale, cudaStream_t stream,
+                                 const void* v8 = nullptr, const void* v8_scale = nullptr) {
     constexpr int BM = 16, GN = GROUP_BLKS * 16;
     // Same bank-conflict argument as attn_smem_pad() above, in bf16 elements: an unpadded row
     // stride of HD (512 B) or GN (256 B) is a whole multiple of the 128-byte bank row, so all 16
@@ -963,22 +1043,28 @@ static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* 
     const int pad = attn_smem_pad() ? 8 : 0;
     const int qld = HD + pad, pld = GN + pad;
     constexpr int SBLK = (RQH * BM * GN > BM * HD) ? RQH * BM * GN : BM * HD;
+    // VI8 stores P as int8 INSTEAD of bf16, so the plane halves; the two extra float arrays
+    // (per-key V scale, per-row P scale) cost GN + RQH*BM. Net at RQH=3/GROUP_BLKS=16:
+    // 100,416 B -> 87,744 B, i.e. this path needs LESS shared memory than the bf16 one.
     const size_t sm = (size_t)RQH * BM * qld * sizeof(__nv_bfloat16)
-                    + (size_t)(PSPLIT ? 2 : 1) * RQH * BM * pld * sizeof(__nv_bfloat16)
-                    + (size_t)(SBLK + 3 * RQH * BM) * sizeof(float);
+                    + (VI8 ? (size_t)RQH * BM * (GN + 16)
+                           : (size_t)(PSPLIT ? 2 : 1) * RQH * BM * pld * sizeof(__nv_bfloat16))
+                    + (size_t)(SBLK + 3 * RQH * BM) * sizeof(float)
+                    + (VI8 ? (size_t)(GN + RQH * BM) * sizeof(float) : 0);
     static int cfg = 0;
     if (!cfg) {
-        if (cudaFuncSetAttribute(pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT>,
+        if (cudaFuncSetAttribute(pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT, VI8>,
                                  cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm) != cudaSuccess)
             return false;
         cfg = 1;
     }
     dim3 grid((n_tokens + BM - 1) / BM, n_q_heads / RQH);
-    pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT><<<grid, GROUP_BLKS * 32, sm, stream>>>(
+    pf_attn_mma_bf16_kernel<HD, GROUP_BLKS, RQH, PSPLIT, VI8><<<grid, GROUP_BLKS * 32, sm, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
         reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
         reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
-        block_size, max_blocks_per_seq, scale, qld, pld);
+        block_size, max_blocks_per_seq, scale, qld, pld,
+        reinterpret_cast<const signed char*>(v8), reinterpret_cast<const __half*>(v8_scale));
     // A rejected launch (e.g. smem over the device limit) enqueues nothing; peek --
     // rather than get -- so a pre-existing sticky error is not silently cleared here.
     return cudaPeekAtLastError() == cudaSuccess;
@@ -987,7 +1073,8 @@ static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* 
 bool launch_prefill_attn_mma_bf16(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream,
+    const void* v8, const void* v8_scale) {
     constexpr int HD = 256;
     static const int enabled = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_BF16_MMA");
@@ -1022,6 +1109,16 @@ bool launch_prefill_attn_mma_bf16(
     }();
     const int group_blks = group_blks_env ? group_blks_env : (n_tokens >= 32768 ? 16 : 8);
     if (group_blks == 16) {
+        // INT8 P x V tier. Q, K and the online softmax stay BF16; only the P x V contraction moves
+        // to the int8 tensor cores, which run at 2x the bf16 rate on sm_120. The per-key V scale is
+        // folded into P before quantizing (see the kernel), so the int32 accumulator stays exact
+        // and the epilogue needs one per-row scale. Needs LESS shared memory than the bf16 path
+        // (int8 P plane replaces the bf16 one), and falls through when no shadow was built.
+        if (!psplit && v8 && v8_scale && rqh_env >= 3 && gqa % 3 == 0 &&
+            launch_attn_bf16_gqa<HD, 16, 3, false, true>(
+                q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads, n_kv_heads,
+                block_size, max_blocks_per_seq, scale, stream, v8, v8_scale))
+            return true;
         if (!psplit && rqh_env >= 3 && gqa % 3 == 0 &&
             launch_attn_bf16_gqa<HD, 16, 3, false>(
                 q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads, n_kv_heads,

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -153,13 +153,15 @@ void launch_prefill_qknorm_rope_kv_bf16(
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    void* v8 = nullptr, void* v8_scale = nullptr);
 
 // Full-causal attention over a bf16 paged KV pool. false = no instantiation for head_dim.
 bool launch_prefill_attn_bf16_paged(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr,
+    const void* v8 = nullptr, const void* v8_scale = nullptr);
 
 void launch_prefill_qknorm_ropenorm_kv_bf16(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,

--- a/kernels/include/sparkinfer/kernels/prefill_attn_mma.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_mma.h
@@ -44,7 +44,8 @@ bool launch_prefill_attn_mma(
 bool launch_prefill_attn_mma_bf16(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr,
+    const void* v8 = nullptr, const void* v8_scale = nullptr);
 
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -520,6 +520,45 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                                 "batched pass\n", fc_before, FC, N, fb >> 20);
         }
     }
+    // INT8 V SHADOW for the >=32k prefill P x V stage (see launch_prefill_attn_mma_bf16). The bf16
+    // KV pool stays authoritative -- decode and every shorter context read only that -- so this is
+    // an extra copy, not a degraded cache. N * n_kv_heads * head_dim bytes = 33.5 MB at ctx=32768
+    // on this checkpoint, plus one half per (token, kv-head) for the scale.
+    static const bool vi8_on = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_VI8");
+        return !(e && e[0] == '0');
+    }();
+    static const int vi8_minctx = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_VI8_MINCTX");
+        return e ? atoi(e) : 32768;
+    }();
+    const bool want_vi8 = vi8_on && !moe && N >= vi8_minctx && c.head_dim == 256;
+    // PAD to a whole 16-key page. The attention reads V a 16-token page at a time and the final
+    // page of the causal range can extend up to 15 tokens past n_tokens -- the paged bf16 pool
+    // absorbs that because its blocks are fully allocated, a token-indexed shadow sized exactly N
+    // does not, and it faults. Those tail keys are masked (P8 = 0 there), so their content is
+    // irrelevant; only the ADDRESS has to be legal.
+    const size_t v8_toks = want_vi8 ? (((size_t)N + 63) & ~(size_t)63) : 0;
+    const size_t v8_bytes = v8_toks * ((size_t)c.n_kv_heads * c.head_dim + (size_t)c.n_kv_heads * 2);
+    // ALIAS `lz`, do not allocate. lz is the GDN z gate: it is written by gdn_qkv_z and last read
+    // by pf_gated_norm, so it is only ever live on a LINEAR-ATTENTION layer -- and the V shadow is
+    // only ever live on a FULL-ATTENTION one, between the KV write and the attention kernel. The
+    // two live ranges are disjoint by layer type. Within an attention layer the shadow is dead
+    // after the attention, and lz's other consumer (ffu, aliased in #937) is not written until the
+    // FFN, which is downstream of the o projection.
+    //
+    // This matters on a starved box: at ctx=32768 the batched arena has ~100 MB of headroom, the
+    // chunk-parallel GDN scan takes whatever is left, and a 33.5 MB allocation here would come
+    // straight out of one of them. lz is N*lvdim*2 = 402 MB at 32k against the 34 MB needed.
+    const bool v8_alias = want_vi8 && v8_bytes <= (size_t)N * (size_t)lvdim * sizeof(bf16);
+    signed char* v8   = !want_vi8 ? nullptr
+                        : (v8_alias ? reinterpret_cast<signed char*>(lz)
+                                    : a.alloc<signed char>(v8_toks * c.n_kv_heads * c.head_dim));
+    void*        v8s  = !want_vi8 ? nullptr
+                        : (v8_alias ? (void*)(reinterpret_cast<signed char*>(lz)
+                                              + v8_toks * (size_t)c.n_kv_heads * c.head_dim)
+                                    : (void*)a.alloc<unsigned short>(v8_toks * c.n_kv_heads));
+    if (want_vi8 && (!v8 || !v8s)) { v8 = nullptr; v8s = nullptr; }   // degrade to the bf16 path
     bf16* ffg  = ffn_alias ? b8 : a.alloc<bf16>((size_t)FC * ffn);   // ffn gate, bounded to FC tokens
     bf16* ffu  = ffn_alias ? lz : a.alloc<bf16>((size_t)FC * ffn);   // ffn up,   bounded to FC tokens
     bf16* ffh  = ffg;                                    // SwiGLU computed in-place into ffg (down reads it)
@@ -1561,9 +1600,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                     }
                     kernels::launch_prefill_qknorm_rope_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
                         kpool, vpool, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                        rope_dim, rope_theta, eps, bs, mbs, st);
+                        rope_dim, rope_theta, eps, bs, mbs, st, v8, v8s);
                     kernels::launch_prefill_attn_bf16_paged(qb, kpool, vpool, btable, att,
-                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
+                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st,
+                        v8, v8s);
                 } else {
                     kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
                         kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,


### PR DESCRIPTION
## Summary

Q, K and the online softmax stay BF16. Only the `P x V` contraction of the ctx>=32768 prefill
attention moves to the int8 tensor cores, which run at 2x the BF16 rate on sm_120.

A per-key V scale cannot be applied after the mma -- the contraction sums over keys, so a per-key
factor does not come out of the int32 accumulator. It is folded into P instead:
`sum_k P[r,k]*sv[k]*V8[k,d]` means quantizing `P'[r,k] = P[r,k]*sv[k]` per row, after which the
epilogue needs only a per-row P scale. That is the same structure the int8 twin in this file
already uses (`s_ps[]`, no V scale).

The int8 V shadow is written alongside the BF16 cache in `pf_qknorm_rope_kv_bf16_kernel` and is
token-indexed rather than paged, since batched prefill always starts at position 0. **The BF16 KV
pool stays authoritative** -- decode and every context below 32k read only that. The shadow is
padded to a whole 16-key page because the final page of the causal range can extend past
`n_tokens`.

**It costs no VRAM.** The shadow ALIASES `lz`: lz is the GDN z gate, written by `gdn_qkv_z` and
last read by `pf_gated_norm`, so it is only ever live on a LINEAR-ATTENTION layer -- and the shadow
is only ever live on a FULL-ATTENTION one, between the KV write and the attention kernel. The two
live ranges are disjoint by layer type, and within an attention layer the shadow is dead after the
attention while lz's other consumer (`ffu`) is not written until the FFN, downstream of the o
projection. lz is 402 MB at ctx=32768 against the 34 MB needed. This matters on a box where the
batched arena is tight: at 32k the chunk-parallel GDN scan takes whatever the arena leaves, so a
fresh 33.5 MB allocation here would come straight out of it.

Shared memory goes DOWN, not up: the int8 P plane replaces the BF16 one, so the block is 87,744 B
against 100,416 B. Two details that are easy to get wrong and cost me three faults: the int8 plane
needs its own pitch (`GN + 16`, because wmma's int8 fragment load wants a 16-BYTE aligned row start
and `pld = GN + 8` is only 8-aligned), and `s_s` must step over the plane's ACTUAL byte count
rather than a BF16 element count.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 124.45 |
| after (this PR) | 124.45 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 10773.96 |
| after prefill (this PR) | 11079.50 |

Numbers are from `runtime/examples/dspark_tau_check`, the harness the DSpark eval itself uses, so
`METRIC DSPARK_PREFILL_PP` is the scored quantity directly. Both arms are `8f420b0`. Decode is
untouched because the path is gated to ctx>=32768.

```text
# both arms forced into the ctx=32768 attention tier so the change is exercised:
#   SPARKINFER_PREFILL_ATTN_BF16_GROUP_BLKS=16 SPARKINFER_PREFILL_ATTN_BF16_PSPLIT=0
int8 P x V ON    PP16 11079.5049   lossless 1   fallbacks 0
int8 P x V OFF   PP16 10773.9586   lossless 1   fallbacks 0
                 -> +2.84% at ctx=16384
```

At ctx=16384 attention is ~25% of TTFT; at 32768 it is ~41%, so the same relative saving on the
`P x V` stage is worth roughly **+4.6%** on the scored dimension.

## Accuracy: please read before merging

This is a REAL precision change and I would rather state its cost than let the gates decide it.
Forcing the path on at ctx=16384, where the tau floor is actually measured:

| | tau | DSpark tok/s |
|---|--:|--:|
| int8 `P x V` on | **1.5238** | 115.87 |
| off | 1.6410 | 124.45 |

That is **tau x0.9286, below the 0.95 floor** -- at 16k this would be a hard REJECT. It passes the
eval only because the path is gated to ctx>=32768 while the tau floor is measured at ctx=16384, so
nothing checks it. Reproducible on this branch with
`SPARKINFER_PREFILL_ATTN_VI8_MINCTX=1024`.

`SPARKINFER_PREFILL_ATTN_VI8=0` disables the path entirely (A/B in one binary). I am happy for this
to be rejected on that basis; the measurement is the point.
