### PR TITLE
perf(prefill): fuse 32k norms into FP4 quantization

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1255,7 +1255,11 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
             q[base + t] = __float2bfloat16(out);
         } else {
             const size_t dst = (ctok * n_kv_heads + hh) * head_dim;
-            k_pool[dst + t] = __float2bfloat16(out);
+            const __nv_bfloat16 ko = __float2bfloat16(out);
+            k_pool[dst + t] = ko;
+            // The V-int8 attention path consumes a contiguous shadow. Keep rotated K in its
+            // existing projection buffer too; decode still receives the identical paged write.
+            if (v_i8) k[base + t] = ko;
         }
     } else {
         const int hh = unit - n_q_heads - n_kv_heads;

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -821,11 +821,29 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
         const int nk   = min(GN, last_q + 1 - k0);
         const int gblk = (nk + 15) / 16;
 
+        // VINT8 scales are shared by all BM rows and all RQH query heads, but loading them in the
+        // softmax loop repeats the same half load BM*RQH times. Stage one copy per key into the
+        // otherwise-unused 8-column padding of the first 2*BM Q rows. This consumes no additional
+        // shared memory and preserves the exact __half2float conversion at the consumer.
+        if constexpr (VINT8) {
+            __half* s_vs_pad = reinterpret_cast<__half*>(s_q);
+            for (int t = tid; t < GN; t += blockDim.x) {
+                const int pr = t >> 3, pc = HEAD_DIM + (t & 7);
+                s_vs_pad[pr * qld + pc] = (t < nk)
+                    ? v_scale[(size_t)(k0 + t) * n_kv_heads + kvh]
+                    : __float2half(0.f);
+            }
+        }
+
         // ---- QK: load each K page fragment ONCE, feed RQH q-heads ----
         if (warp < gblk) {
-            const int pb = block_table[(k0 / block_size) + warp];
-            const __nv_bfloat16* kb =
-                k_pool + ((size_t)pb * block_size * n_kv_heads + kvh) * HEAD_DIM;
+            const __nv_bfloat16* kb;
+            if constexpr (VINT8) {
+                kb = k_pool + ((size_t)(k0 + warp * 16) * n_kv_heads + kvh) * HEAD_DIM;
+            } else {
+                const int pb = block_table[(k0 / block_size) + warp];
+                kb = k_pool + ((size_t)pb * block_size * n_kv_heads + kvh) * HEAD_DIM;
+            }
             fragment<matrix_a, 16, 16, 16, __nv_bfloat16, row_major> af;
             fragment<matrix_b, 16, 16, 16, __nv_bfloat16, col_major> bf;
             fragment<accumulator, 16, 16, 16, float> cf[RQH];
@@ -878,8 +896,9 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
                     float p = 0.f;
                     if (sc[u] > -1e29f) p = __expf(sc[u] - m_new);
                     if constexpr (VINT8) {
-                        const int gtok = k0 + t;
-                        const float pv = p * __half2float(v_scale[(size_t)gtok * n_kv_heads + kvh]);
+                        const __half* s_vs_pad = reinterpret_cast<const __half*>(s_q);
+                        const int pr = t >> 3, pc = HEAD_DIM + (t & 7);
+                        const float pv = p * __half2float(s_vs_pad[pr * qld + pc]);
                         sc[u] = pv; pamax = fmaxf(pamax, fabsf(pv)); sum += p;
                     } else {
                         const __nv_bfloat16 hi = __float2bfloat16(p);

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -273,6 +273,65 @@ void quant_rows_dispatch(int blocks, cudaStream_t st, const __nv_bfloat16* src, 
     }
 }
 
+template <class Layout>
+__global__ void rmsnorm_quant_rows(const __nv_bfloat16* __restrict__ src,
+                                   const __nv_bfloat16* __restrict__ weight,
+                                   unsigned char* dst, cutlass::float_ue4m3_t* sf,
+                                   int rows, int cols, float eps, Layout layout) {
+    const int row = blockIdx.x;
+    if (row >= rows) return;
+    const size_t base = (size_t)row * cols;
+    __shared__ float s_warp[32];
+    const int npack = cols >> 3;
+    float ss = 0.f;
+    const uint4* x4 = reinterpret_cast<const uint4*>(src + base);
+    for (int p = threadIdx.x; p < npack; p += blockDim.x) {
+        const uint4 q = __ldg(x4 + p);
+        const __nv_bfloat16* h = reinterpret_cast<const __nv_bfloat16*>(&q);
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            const float v = __bfloat162float(h[j]);
+            ss = __fmaf_rn(v, v, ss);
+        }
+    }
+    #pragma unroll
+    for (int d = 16; d; d >>= 1) ss += __shfl_xor_sync(0xffffffffu, ss, d);
+    if ((threadIdx.x & 31) == 0) s_warp[threadIdx.x >> 5] = ss;
+    __syncthreads();
+    if (threadIdx.x < 32) {
+        float v = threadIdx.x < (blockDim.x + 31) / 32 ? s_warp[threadIdx.x] : 0.f;
+        #pragma unroll
+        for (int d = 16; d; d >>= 1) v += __shfl_xor_sync(0xffffffffu, v, d);
+        if (threadIdx.x == 0) s_warp[0] = rsqrtf(v / cols + eps);
+    }
+    __syncthreads();
+    const float inv = s_warp[0];
+    const int groups = cols >> 4;
+    for (int g = threadIdx.x; g < groups; g += blockDim.x) {
+        const int k0 = g << 4;
+        float x[16], a = 0.f;
+        #pragma unroll
+        for (int j = 0; j < 16; ++j) {
+            const __nv_bfloat16 nv = __float2bfloat16(
+                __bfloat162float(src[base + k0 + j]) * inv *
+                __bfloat162float(weight[k0 + j]));
+            x[j] = __bfloat162float(nv);
+            a = fmaxf(a, fabsf(x[j]));
+        }
+        cutlass::float_ue4m3_t qs(fmaxf(a * (1.f / 6.f), 0x1p-9f));
+        unsigned char packed[8];
+        #pragma unroll
+        for (int j = 0; j < 8; ++j) {
+            cutlass::float_e2m1_t q0(x[2*j] / float(qs)), q1(x[2*j+1] / float(qs));
+            packed[j] = (unsigned char)((q0.raw() & 15u) | ((q1.raw() & 15u) << 4));
+        }
+        *reinterpret_cast<unsigned long long*>(dst + (base >> 1) + (k0 >> 1)) =
+            *reinterpret_cast<const unsigned long long*>(packed);
+        auto scales = cute::make_tensor(sf, layout);
+        scales(row, k0, 0) = qs;
+    }
+}
+
 // Muse's attention gate folded into the o-projection's A-operand quantize: att * sigmoid(qg)
 // straight to FP4. The int8 leg already does this (launch_prefill_gate_quant_rows_i8) and
 // deliberately leaves `att` UN-GATED; #816 was reverted because its FP4 o-projection quantized that
@@ -459,6 +518,16 @@ bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k
     int blocks = (m * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
     quant_rows_dispatch(blocks,st,(const __nv_bfloat16*)s,(unsigned char*)d,
                         (cutlass::float_ue4m3_t*)sf,m,k,l);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
+bool launch_prefill_nvfp4_rmsnorm_quant_a(const void* s, const void* w, void* d, void* sf,
+                                          int m, int k, float eps, cudaStream_t st) {
+    if (!s || !w || !d || !sf || !prefill_nvfp4_supported(m,128,k) || (k & 15)) return false;
+    auto l = sfa_layout(m,128,k);
+    rmsnorm_quant_rows<<<m,256,0,st>>>((const __nv_bfloat16*)s,
+                                      (const __nv_bfloat16*)w,
+                                      (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,
+                                      m,k,eps,l);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, void* sf,

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -14,6 +14,10 @@ size_t prefill_nvfp4_workspace_bytes(int m, int n, int k);
 
 bool launch_prefill_nvfp4_quant_a(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int m, int k, cudaStream_t stream = nullptr);
+bool launch_prefill_nvfp4_rmsnorm_quant_a(const void* src_bf16, const void* weight_bf16,
+                                          void* dst_fp4, void* dst_sf,
+                                          int m, int k, float eps,
+                                          cudaStream_t stream = nullptr);
 // Muse's attention gate fused into the A-operand quantize: x * sigmoid(g) straight to FP4, the
 // same fold launch_prefill_gate_quant_rows_i8 does for the int8 o-projection.
 bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf16,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1296,14 +1296,18 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // or MoE); SPARKINFER_PREFILL_FP8_GDN_SHAREQ=0 restores the per-projection quantize (A/B).
     const char* _pshareq = getenv("SPARKINFER_PREFILL_FP8_GDN_SHAREQ");
     const bool fp8_shareq = (use_fp8_gdn || moe_fp8) && (!_pshareq || _pshareq[0] != '0');
-    auto gdn_qkv_z = [&](const bf16* A, const Qwen35LayerWeights& w) {
+    auto gdn_qkv_z = [&](const bf16* A, const Qwen35LayerWeights& w, bool norm_deferred) {
         // Checkpoint-native NVFP4: quantize xn to FP4 ONCE (both projections read it) and run two
         // block-scaled GEMMs straight off the packed nibbles. A_i8/sx are not touched, so the int8
         // activation memo stays valid for whatever runs next in the layer.
         if (gdn_nvfp4 && (gdn_fp4_mask & 1) &&
             w.gdn_qkv_fp4 && w.gdn_qkv_fp4_sf && w.gdn_z_fp4 && w.gdn_z_fp4_sf &&
             fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws &&
-            kernels::launch_prefill_nvfp4_quant_a(A, fp4_gdn_a, fp4_gdn_as, N, H, st) &&
+            (norm_deferred
+             ? kernels::launch_prefill_nvfp4_rmsnorm_quant_a(
+                   x, w.input_norm, fp4_gdn_a, fp4_gdn_as, N, H, c.rms_eps, st)
+             : kernels::launch_prefill_nvfp4_quant_a(
+                   A, fp4_gdn_a, fp4_gdn_as, N, H, st)) &&
             kernels::launch_prefill_nvfp4_gemm(fp4_gdn_a, fp4_gdn_as,
                                                w.gdn_qkv_fp4, w.gdn_qkv_fp4_sf,
                                                b8, N, lqkv, H, fp4_gdn_ws, st,
@@ -1371,6 +1375,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     if (moe_hide_sg)
         pf_cu(cudaEventCreateWithFlags(&moe_ev_sg, cudaEventDisableTiming), "moe ev_sg");
 
+    bool attn_norm_deferred = false;
     for (int L = 0; L < c.n_layers; L++) {
         const Qwen35LayerWeights& w = s.w.layers[L];
         a_q = nullptr; a_pk = false;                   // xn/hn are refreshed in place each layer
@@ -1384,7 +1389,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // Short-ctx dense: hold GDN on bf16 unless SPARKINFER_PREFILL_I8_GDN=1.
             const bool restore_i8_gdn = use_i8;
             if (use_i8 && !use_i8_gdn) use_i8 = false;
-            gdn_qkv_z(xn, w);                                       // qkv + z gate (fp8: fused)
+            gdn_qkv_z(xn, w, attn_norm_deferred);                    // qkv + z gate (fp8: fused)
             proj(xn, w.ssm_alpha, w.ssm_alpha_type, la, vh,    H);
             proj(xn, w.ssm_beta,  w.ssm_beta_type,  lb, vh,    H);
             bf16* conv_state = lin_conv_state + (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
@@ -1508,7 +1513,11 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 if (attn_nvfp4 && (attn_fp4_mask & 1) &&
                     w.wq_fp4 && w.wq_fp4_sf && w.wk_fp4 && w.wk_fp4_sf &&
                     w.wv_fp4 && w.wv_fp4_sf && fp4_attn_a && fp4_attn_as && fp4_attn_ws &&
-                    kernels::launch_prefill_nvfp4_quant_a(xn, fp4_attn_a, fp4_attn_as, N, H, st) &&
+                    (attn_norm_deferred
+                     ? kernels::launch_prefill_nvfp4_rmsnorm_quant_a(
+                           x, w.input_norm, fp4_attn_a, fp4_attn_as, N, H, eps, st)
+                     : kernels::launch_prefill_nvfp4_quant_a(
+                           xn, fp4_attn_a, fp4_attn_as, N, H, st)) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_attn_a, fp4_attn_as,
                                                        w.wq_fp4, w.wq_fp4_sf,
                                                        b8, N, wide, H, fp4_attn_ws, st,
@@ -1593,7 +1602,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                             c.n_q_heads, c.n_kv_heads, c.head_dim,
                             rope_dim, rope_theta, eps, bs, mbs, st);
                     const bool vi8_done = vi8 && kernels::launch_prefill_attn_mma_bf16_vi8(
-                        qb, kpool, vi8, vi8_scale, btable, att, N, c.n_q_heads, c.n_kv_heads,
+                        qb, kf, vi8, vi8_scale, btable, att, N, c.n_q_heads, c.n_kv_heads,
                         c.head_dim, bs, mbs, attn_scale, st);
                     if (!vi8_done)
                         kernels::launch_prefill_attn_bf16_paged(qb, kpool, vpool, btable, att,
@@ -1681,6 +1690,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             use_i8 = restore_i8;
         }
 
+        const bool ffn_norm_fp4 = !c.muse_glimmer && !moe && N >= 32768 && gu_nvfp4 &&
+            w.gate_fp4 && w.gate_fp4_sf && w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as &&
+            [] { const char* e = getenv("SPARKINFER_Q38_FFN_NORM_FP4");
+                 return !e || e[0] != '0'; }();
         if (c.muse_glimmer) {
             // Sandwich norm (post-attn): h = x + RMSNorm(ao) * post_attn_norm -- norm the attention
             // output ALONE, then add to the residual (decode qwen35.cpp:1112). ffn_norm is a genuine
@@ -1711,7 +1724,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             // x += ao (post-attn residual, in-place; skipped when folded into the output proj)
             // hn = RMSNorm(x, post_attn_norm)
             if (!attn_fused) kernels::launch_prefill_add(x, ao, x, (long)N * H, st);
-            kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
+            if (!ffn_norm_fp4)
+                kernels::launch_rmsnorm(x, w.post_attn_norm, hn, N, H, eps, st);
         }
 
         if (!moe) {
@@ -1796,7 +1810,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                 const bool layer_fp4 = gu_nvfp4 && w.gate_fp4 && w.gate_fp4_sf &&
                     w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as &&
                     kernels::prefill_nvfp4_supported(fn, ffn, H) &&
-                    kernels::launch_prefill_nvfp4_quant_a(hn_c, fp4_a, fp4_as, fn, H, st) &&
+                    (ffn_norm_fp4
+                     ? kernels::launch_prefill_nvfp4_rmsnorm_quant_a(
+                           x + (size_t)fo * H, w.post_attn_norm,
+                           fp4_a, fp4_as, fn, H, eps, st)
+                     : kernels::launch_prefill_nvfp4_quant_a(
+                           hn_c, fp4_a, fp4_as, fn, H, st)) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.gate_fp4, w.gate_fp4_sf,
                                                        ffg, fn, ffn, H, fp4_ws, st,
                                                        w.gate_fp4_alpha) &&
@@ -2489,8 +2508,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             }
         }
 
+        const Qwen35LayerWeights* nw = L + 1 < c.n_layers ? &s.w.layers[L + 1] : nullptr;
+        const bool next_attn_fp4 = nw &&
+            (nw->linear_attn
+             ? (gdn_nvfp4 && (gdn_fp4_mask & 1) && nw->gdn_qkv_fp4 && nw->gdn_qkv_fp4_sf &&
+                nw->gdn_z_fp4 && nw->gdn_z_fp4_sf && fp4_gdn_a && fp4_gdn_as && fp4_gdn_ws)
+             : attn_nvfp4);
+        const bool defer_next_attn_norm = L + 1 < c.n_layers && N >= 32768 &&
+            !c.muse_glimmer && next_attn_fp4 &&
+            [] { const char* e = getenv("SPARKINFER_Q38_ATTN_NORM_FP4");
+                 return !e || e[0] != '0'; }();
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        if (!defer_next_attn_norm) kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        attn_norm_deferred = defer_next_attn_norm;
     }
 
     if (moe_overlap) {


### PR DESCRIPTION
## Summary

Fuse Qwen3.8's 32k RMSNorm directly into native NVFP4 activation quantization across both GDN and full-attention layers. Keep rotated K contiguous for the V-int8 prefill kernel and cache per-token V scales in existing shared-memory padding; decode KV remains unchanged.


## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090**. False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 34.03 |
| after (this PR) | 34.09 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 9368.23 |
| after prefill (this PR) | 9570.56 |

<!-- Paste the bench output backing the numbers above (baseline -> this PR). Isolated-kernel
     microbenchmarks are welcome as extra evidence but do NOT count as before/after. -->

```text
RTX 5090, Qwen3.8-27B NVFP4 target + released DSpark draft
exact 32768-token eval prompt; evaluator-style environment, max_new=1

32k DSpark-enabled prefill:
  main              9368.2302 prompt tok/s   lossless 1
  this PR run 1     9574.4521 prompt tok/s   lossless 1 (+2 repeats, 0 failed)
  this PR run 2     9566.6724 prompt tok/s   lossless 1 (+2 repeats, 0 failed)
  this PR mean      9570.5623 prompt tok/s   +2.16%

decode:
  main              34.03 tok/s
  this PR           34.09 tok/s

The fused paths are restricted to Qwen3.8 dense NVFP4 prefill at N >= 32768.
SPARKINFER_Q38_FFN_NORM_FP4=0 and SPARKINFER_Q38_ATTN_NORM_FP4=0 restore separate RMSNorm.
Shorter contexts and decode retain the upstream paths.
```

<!-- More checklist items will be added here later. -->
