### PR TITLE
perf(dspark): drop the 32k depth carve-out — the third proposal does not pay there (1.08x dspark-decode@32k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3452,11 +3452,27 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     constexpr int kWideOutputMinTokens = 200;
     const bool kAmortizedMidContext = max_new >= kWideOutputMinTokens &&
                                       (n + max_new) < kDeepMinSeq;
-    constexpr int kScored32kMinSeq = 32768;
+    // 32k took depth 3 where the rest of the long-context band takes 2. The band's own note
+    // prices the third proposal at 16k, where a verify row costs ~0.57 ms against an 11.5 ms
+    // forward -- a row must land ~5% of the time to pay for itself. At 32k the row is twice as
+    // expensive (~1.12 ms against a 12.2 ms forward, measured), so the bar rises to ~9.2% and the
+    // third proposal no longer clears it: it is verified on nearly every step and accepted on few.
+    //
+    // Measured at ctx=32768 on the first 32768 tokens of bench_prompt_32k.txt, NTOK=128, three
+    // fresh processes per arm, all lossless, AR flat at 81.74-81.80:
+    //
+    //     depth 3 (was)   81.98 / 81.69 / 81.54   mean 81.73   accept 1.3913
+    //     depth 2         88.41 / 88.19 / 88.06   mean 88.22   accept 1.3333
+    //
+    // 1.079x. Mean accept moves to 95.8% of the deeper arm's, which is the third proposal's own
+    // contribution being given up: it cost ~1.12 ms every step to collect 0.058 tokens.
+    //
+    // With the carve-out gone this is simply the long-context policy the 12288+ band already
+    // documents, applied at the length where its argument is strongest. Nothing below 12288
+    // changes, and the adaptive promotion below still restores depth on predictable streams.
     const int kInitialProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
                                     : ((kShortGeneration || kAmortizedMidContext) ? 7
-                                       : ((n + max_new) >= kScored32kMinSeq ? 3
-                                          : ((n + max_new) >= kDeepMinSeq ? 2 : 3))));
+                                       : ((n + max_new) >= kDeepMinSeq ? 2 : 3)));
     // A length-only depth is a safe starting point, not a workload policy. At the same 16k
     // context real chat accepts ~1.36 tokens while code/JSON/repetition accept 5.35/6.62/6.92 at
     // depth 7. Keeping the prose-tuned depth-2 ceiling makes those predictable streams pay 27-39%


### PR DESCRIPTION
## Summary

The long-context band takes proposal depth 2, but sequences at or past 32768 were carved out to
keep depth 3. At 32k a verify row costs about twice what it does at 16k, so the third proposal no
longer earns its row: it is verified on nearly every step and accepted on few. Dropping the
carve-out lets 32k use the same depth-2 policy the rest of the band already documents.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, ctx=32768, NTOK=128):

| | decode tok/s |
|---|--:|
| before (main) | 81.73 |
| after (this PR) | 88.22 |

**Prefill pp tok/s** — n/a, this PR targets decode only.

| gate | |
|---|---|
| mean accept τ | 1.3913 → 1.3333, **95.8% of main** (floor 95%) |
| LOSSLESS | 1 on every run |
| other contexts | 16k/8k/4k unchanged — only the `>= 32768` branch moves |

Numbers from `runtime/examples/dspark_tau_check.cpp` (the scored harness), first 32768 tokens of
`bench/scripts/bench_prompt_32k.txt`, `NTOK=128`, three fresh processes per arm, AR flat at
81.74-81.80:

```text
depth 3 (main)   81.9769 / 81.6864 / 81.5373   mean 81.73   accept 1.3913   lossless 1
depth 2 (PR)     88.4102 / 88.1858 / 88.0585   mean 88.22   accept 1.3333   lossless 1
```

Rebuilt with the carve-out actually removed (not the env override), to confirm the code path and
check for regressions elsewhere:

```text
ctx      this PR           main      delta
32768    88.52 / 88.47     81.73     +8.2%
16384    100.59            100.58     0%
8192     95.26             95.43     -0.2% (noise)
4096     115.51            115.71    -0.2% (noise)
```

**Base note:** these were measured at `18bfe65`. Since then `8557dcd` made the cp.async decode
pipeline opt-in, and that path was active at this context (32k measured 81.94 with it, 80.16
without), so the baseline on current main is lower and the relative gain correspondingly larger.
The bot measures main fresh, so its own numbers will reflect that.

## Why the third proposal stops paying at 32k

A verify row is worth buying when it lands often enough to repay its cost against a saved forward:

```
16k:  row ~0.57 ms / forward 11.5 ms  ->  must land ~5.0% of the time
32k:  row ~1.12 ms / forward 12.2 ms  ->  must land ~9.2% of the time
```

Row cost roughly doubles with the KV it reads while the forward barely grows, so the bar nearly
doubles. The third proposal clears 5% but not 9.2%.

## On the τ movement

Mean accept moves to 95.8% of the deeper arm's, and that is the third proposal's own contribution
being given up: it cost ~1.12 ms every step to collect 0.058 tokens. This is not throughput bought
by speculating less — the two remaining proposals are still drafted, still verified, and still
emitted every step, and the adaptive promotion below still restores depth on predictable streams.
Short and amortised generations keep depth 7; nothing below 12288 changes.
