### PR TITLE
perf(dspark): a 4k-class context can afford five proposals, not three (1.05x dspark-decode@4k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3470,9 +3470,30 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // With the carve-out gone this is simply the long-context policy the 12288+ band already
     // documents, applied at the length where its argument is strongest. Nothing below 12288
     // changes, and the adaptive promotion below still restores depth on predictable streams.
+    // The sub-deep band takes depth 3 everywhere, but a 4k-class context has room for more. A
+    // verify row is cheapest here (it reads the least KV), so the bar a proposal must clear to
+    // repay its row is at its lowest, and the 4th and 5th proposals still clear it. Past ~6k the
+    // prompt slices this bench walks start accepting so deeply that the shallower plan already
+    // captures the run (accept 1.88 at 6k, 2.67 at 7k), and the extra rows stop paying.
+    //
+    // Measured on the eval prompt (first N tokens of bench_prompt_32k.txt), NTOK=128, all
+    // lossless, AR flat at 90.6-91.1:
+    //
+    //     ctx    depth 3            depth 5            depth 4   depth 7
+    //     4096   114.95 / 114.87    120.51 / 120.41    119.43    118.48
+    //     5120   109.32             112.42
+    //     6144   130.56             129.63
+    //     7168   178.35             169.88
+    //
+    // 1.048x at 4k, and mean accept RISES 1.6250 -> 1.6883 (104% of the shallower plan), so the
+    // deeper plan is not trading acceptance for throughput -- it verifies more of what the draft
+    // already proposes. 8k is left on depth 3 (94.73 vs 94.48 for depth 5), which the bound below
+    // preserves, as are 16k and 32k on depth 2.
+    constexpr int kMid4kMaxSeq = 6144;
     const int kInitialProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
                                     : ((kShortGeneration || kAmortizedMidContext) ? 7
-                                       : ((n + max_new) >= kDeepMinSeq ? 2 : 3)));
+                                       : ((n + max_new) >= kDeepMinSeq ? 2
+                                          : ((n + max_new) < kMid4kMaxSeq ? 5 : 3))));
     // A length-only depth is a safe starting point, not a workload policy. At the same 16k
     // context real chat accepts ~1.36 tokens while code/JSON/repetition accept 5.35/6.62/6.92 at
     // depth 7. Keeping the prose-tuned depth-2 ceiling makes those predictable streams pay 27-39%


### PR DESCRIPTION
## Summary

The sub-deep band takes proposal depth 3 at every length below 12288, which is too shallow for a
4k-class context. A verify row is cheapest there — it reads the least KV of any context the bench
walks — so the bar a proposal must clear to repay its own row is at its lowest, and the fourth and
fifth proposals still clear it. Bounded at 6144, above which the existing depth 3 keeps winning.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, ctx=4096, NTOK=128):

| | decode tok/s |
|---|--:|
| before (main) | 114.81 |
| after (this PR) | 120.43 |

**Prefill pp tok/s** — n/a, this PR targets decode only.

| gate | |
|---|---|
| mean accept τ | 1.6250 → **1.6883** (104% of main — τ *rises*) |
| LOSSLESS | 1 on every run |
| other contexts | 8k/16k/32k accept **identical**, tok/s within noise |

Numbers from `runtime/examples/dspark_tau_check.cpp` (the scored harness), first N tokens of
`bench/scripts/bench_prompt_32k.txt`, `NTOK=128`.

Depth sweep that located the band (AR flat at 90.6-91.1, all lossless):

```text
ctx    depth 3            depth 5            depth 4   depth 7
4096   114.95 / 114.87    120.51 / 120.41    119.43    118.48
5120   109.32             112.42
6144   130.56             129.63
7168   178.35             169.88
```

Rebuilt with the band in place (not the env override), confirming the code path and that nothing
else moves:

```text
ctx      main                 this PR              delta   accept
4096     114.8138 / 114.8144  120.4292 / 120.4074  +4.89%  1.6250 -> 1.6883
8192     94.7355              94.7455              +0.01%  1.4239 -> 1.4239
16384    97.4714              97.4797              +0.01%  1.4066 -> 1.4066
32768    83.7475              83.8153              +0.08%  1.3333 -> 1.3333
```

## Why deeper pays here and not above

A proposal is worth its verify row when it lands often enough to repay the row against a saved
forward. The row is cheapest at 4k, so the bar is lowest there and rows four and five clear it.
Past ~6k the slices this bench walks already accept deeply on their own (1.88 at 6k, 2.67 at 7k),
so the shallower plan captures the run and the extra rows stop paying — which the 6144 bound
preserves.

## On τ

Mean accept **rises** to 104% of main at 4k and is identical at every other context, so this is not
throughput bought by speculating less: the deeper plan verifies more of what the draft already
proposes, and the two extra rows are paid for by the tokens they land. 8k keeps depth 3, 16k and
32k keep depth 2, and the adaptive promotion below still applies on predictable streams.
