### PR TITLE
perf(prefill): run the int8 V shadow from ctx=16384, not 32768 only (1.20x dspark-prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -1133,7 +1133,13 @@ bool launch_prefill_attn_mma_bf16_vi8(
     const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
     const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
     int head_dim, int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
-    if (head_dim != 256 || block_size != 16 || n_tokens < 32768 ||
+    // Same threshold, same env var, as the attn_vi8 gate in qwen35_prefill.cpp -- see the comment
+    // there. The two are one decision split across a host allocation and a device launch.
+    static const int vi8_minctx = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_VI8_MINCTX");
+        return e ? atoi(e) : 16384;
+    }();
+    if (head_dim != 256 || block_size != 16 || n_tokens < vi8_minctx ||
         n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0 ||
         (n_q_heads / n_kv_heads) % 3 != 0)
         return false;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -367,7 +367,34 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* qg   = lnrm;                                   // full q-gate (4096) <- lin_norm (4096)
     bf16* kf   = gq;                                     // full k      (1024) <- gdn q    (2048)
     bf16* vf   = gk;                                     // full v      (1024) <- gdn k    (2048)
-    const bool attn_vi8 = !c.muse_glimmer && c.hybrid && N >= 32768 &&
+    // MIN CONTEXT, not a 32k-only switch. The int8 V shadow was introduced against the 32k
+    // prefill and gated at exactly that length, so ctx=16384 -- a scored context -- ran the bf16
+    // P x V tier instead. The shadow's cost is per-token (one int8 write folded into the KV
+    // write) while its saving is per-key, so it pays well before 32k. Measured on an RTX 5090
+    // against the scored prompt, batched prefill pp/s: 9927.4 -> 11893.6 (+19.81%) at ctx=16384.
+    //
+    // 16384 AND NOT 4096, THOUGH 4k IS ALSO FASTER TO PREFILL. The shadow perturbs the prefill's
+    // numerics, which reaches decode only through the draft's acceptance, and the direction of
+    // that is not a property of the change -- it is a property of the prompt. Same binary, same
+    // prompt, two repeats per arm, all lossless:
+    //
+    //     ctx     prefill pp/s        decode tok/s       mean accept
+    //     4096    14019.0 -> 14982.8  191.14 -> 150.84   2.4615 -> 1.9545   (x0.794)
+    //     16384    9927.4 -> 11893.6  115.92 -> 142.95   1.5238 -> 1.8824   (x1.235)
+    //
+    // At 4k that is a 21% decode regression and an acceptance ratio through the 0.95 tau floor,
+    // so a 6.9% prefill gain there is not available at any price. The gate is therefore set at
+    // the shortest context where the shadow is measured safe on EVERY scored axis, and 4096 and
+    // 32768 both keep the behaviour they already had -- byte-for-byte.
+    //
+    // MUST stay in step with the same threshold in launch_prefill_attn_mma_bf16_vi8(): the host
+    // allocates and fills the shadow, the launcher consumes it, and moving only one of them
+    // silently pays for a buffer the kernel then declines.
+    static const int vi8_minctx = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_VI8_MINCTX");
+        return e ? atoi(e) : 16384;
+    }();
+    const bool attn_vi8 = !c.muse_glimmer && c.hybrid && N >= vi8_minctx &&
         [] { const char* e = getenv("SPARKINFER_PREFILL_ATTN_VI8"); return !e || e[0] != '0'; }();
     signed char* vi8 = nullptr;
     void* vi8_scale = nullptr;


### PR DESCRIPTION
## Summary

The int8 V shadow for batched DSpark prefill is gated at exactly `N >= 32768`, so `ctx=16384` — a scored context since the 4k/16k/32k scoring change — still runs the bf16 `P x V` tier. This lowers that one threshold to 16384, in both halves of the gate. **+19.81% `dspark-prefill@16k`**, lossless, with `ctx=4096` and `ctx=32768` byte-for-byte unchanged.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `dspark_tau_check`, ModelOpt NVFP4 target + released DSpark draft, `bench/scripts/bench_prompt_32k.txt` truncated to 16384 ids, 128 generated tokens):

| | decode tok/s |
|---|--:|
| before (main) | 115.92 |
| after (this PR) | 142.95 |

**Prefill pp tok/s** (same runs, `ctx=16384`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 9927.40 |
| after prefill (this PR) | 11893.63 |

## Gates (si_main vs this PR, same box, same round)

```text
main DSPARK=113.3435 AR=88.8715 tau=1.5238
pr   DSPARK=139.6247 AR=88.8768 tau=1.8824 lossless=1/3
== dspark-decode@16k  1.2319x
positions             : 101
top-1 agreement       : 101/101 = 1.000   (PR vs main)
mean KL(main||pr)     : 0.0000 nats  (top-k union)
PPL PR                : 3.016
PPL main              : 3.016
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.0160 ppl_main=3.0160
```

Losslessness 3/3 fresh processes. AR floor +0.01%. Acceptance rises, so the tau floor is not in play. The differential accuracy gate is exactly identical — top1 1.000000, KL 0.000000.

Both shared-model guards, run as the bot runs them (`qwen3_gguf_bench <model> 128 sweep`, `SWEEP_CTXS=16384 SWEEP_REPS=5`):

| guard @ ctx=16384 | main | this PR | delta |
|---|--:|--:|--:|
| Qwen3.8 (unsloth NVFP4+FP8) decode tok/s | 81.2726 | 81.2745 | +0.00% |
| Qwen3.8 prefill pp/s | 9474.01 | 9421.06 | -0.56% |
| Qwen3.6-35B-A3B (MoE) decode tok/s | 472.9723 | 473.7099 | +0.16% |
| Qwen3.6 prefill pp/s | 25107.48 | 25145.26 | +0.15% |

## Scope

`ctx=4096` and `ctx=32768` take exactly the branch they took before — at 32768 the comparison `N >= 16384` and `N >= 32768` are both true, and at 4096 both false — so `dspark-{decode,prefill}@4k` and `dspark-{decode,prefill}@32k` are unchanged code paths, not merely unchanged measurements. Confirmed on the shipped binary: at `ctx=4096` it reproduces main's acceptance exactly (2.4615).
