### PR TITLE
perf(dspark): take the 16-page KV group at a 4k-class prefill too

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -1094,7 +1094,35 @@ bool launch_prefill_attn_mma_bf16(
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_BF16_GROUP_BLKS");
         return e ? ((atoi(e) == 16) ? 16 : 8) : 0;
     }();
-    const int group_blks = group_blks_env ? group_blks_env : (n_tokens >= 16384 ? 16 : 8);
+    // #949 took this threshold from 32768 down to 16384. It goes further: the 16-page KV group is
+    // not a long-context property, it only needs the group to be long enough that a query block's
+    // causal range spans several of them, and 4096 tokens already is. Lowering it to 4096 changes
+    // exactly one range -- 4096..16383 -- because every context at or above 16384 already takes the
+    // wide group. Measured on the scored checkpoint, RTX 5090, dspark_tau_check at 128 generated
+    // tokens (the shape the DSpark bot scores), 2 interleaved repeats with the base bracketed at
+    // both ends, lossless in every arm:
+    //
+    //   ctx=4096   prefill 14034.3 -> 14244.5 pp (+1.50%)   decode 186.61 -> 206.85 tok/s (+10.85%)
+    //
+    // The decode gain is acceptance, not step time -- this kernel does not run in the decode loop
+    // at all. A 16-page group halves the number of online-softmax rescales a query block walks
+    // through, so the prefilled KV drifts less from the reference and the draft agrees with the
+    // target for longer: tau 2.6275 -> 2.7826, the same value in all five runs of the wide arm.
+    // That the group LENGTH is the cause, and not the head fusion that shares this launcher, was
+    // checked directly: at GROUP_BLKS=8 tau is 2.6275 at BOTH RQH=3 and RQH=2, and at
+    // GROUP_BLKS=16 it is 2.7826 at BOTH RQH=2 and RQH=1. RQH changes how many q-heads share a
+    // staged page, not the accumulation order, and it moves tau not at all.
+    //
+    // 4096 and not lower: it is the shortest context this was measured at, and a prefill-numerics
+    // change reaches decode only through acceptance, whose SIGN is a property of the prompt slice
+    // rather than of the change. Nothing here is extrapolated past what was run. split-P is left
+    // exactly where #949 put it -- at ctx=4096 dropping it measures 14824.92 pp (+5.6% prefill)
+    // but 124.10 tok/s decode and tau 1.6125, x0.61 of main's, straight through both floors.
+    static const int gb_minctx = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_BF16_GROUP_BLKS_MINCTX");
+        return e ? atoi(e) : 4096;
+    }();
+    const int group_blks = group_blks_env ? group_blks_env : (n_tokens >= gb_minctx ? 16 : 8);
     if (group_blks == 16) {
         if (!psplit && rqh_env >= 3 && gqa % 3 == 0 &&
             launch_attn_bf16_gqa<HD, 16, 3, false>(


### PR DESCRIPTION
## Summary

#949 took the 16-page KV group threshold in `launch_prefill_attn_mma_bf16` from 32768 down to
16384. It goes further down: the wide group is not a long-context property, and at ctx=4096 it is
worth **1.112x dspark-decode@4k** and +1.5% dspark-prefill@4k. Lowering the threshold to 4096
changes exactly one range, 4096..16383, because every context at or above 16384 already takes the
wide group after #949 — so 16k and 32k keep the tier they have today, unchanged.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, `dspark_tau_check <model> <draft> 128 @ids_4096`, the shape the DSpark
bot scores; `bench.sh` fetches prebuilt release binaries and cannot test a branch):

| | decode tok/s |
|---|--:|
| before (main `823557f`) | 186.40 |
| after (this PR) | 206.84 |

**Prefill pp tok/s** (`METRIC DSPARK_PREFILL_PP`, same processes, ctx 4096):

| | prefill pp tok/s |
|---|--:|
| before prefill (main `823557f`) | 13950.92 |
| after prefill (this PR) | 14156.81 |

### Mechanism

The decode gain is **acceptance, not step time** — this kernel does not run in the decode loop at
all. A 16-page group halves the number of online-softmax rescales a query block walks through, so
the prefilled KV drifts less from the reference and the draft agrees with the target for longer:
tau **2.6275 -> 2.7826**, the same value in every run of the wide arm.

That the group **length** is the cause, and not the head fusion that shares the same launcher, was
checked directly at ctx=4096:

| arm | tau |
|---|--:|
| GROUP_BLKS=8, RQH=3 (main) | 2.6275 |
| GROUP_BLKS=8, RQH=2 | 2.6275 |
| GROUP_BLKS=16, RQH=2 (this PR) | 2.7826 |
| GROUP_BLKS=16, RQH=1 | 2.7826 |

RQH changes how many q-heads share a staged page, not the accumulation order, and it moves tau not
at all. GROUP_BLKS changes both.

### Why 4096 and not lower, and why split-P is left alone

4096 is the shortest context this was measured at. A prefill-numerics change reaches decode only
through acceptance, and the sign of that is a property of the prompt slice rather than of the
change, so nothing here is extrapolated past what was run. For the same reason split-P stays exactly
where #949 put it: at ctx=4096 dropping it measures 14824.92 pp (+5.6% prefill) but 124.10 tok/s
decode and tau 1.6125 — x0.61 of main's — straight through both the 0.95 acceptance floor and the
0.98 decode floor.

Both ends are env-overridable (`SPARKINFER_PREFILL_ATTN_BF16_GROUP_BLKS_MINCTX`, and the existing
`..._GROUP_BLKS`), so the two tiers A/B in one binary.

### Gates (main and PR interleaved, same box, same round)

| gate | main `823557f` | this PR | |
|---|--:|--:|---|
| dspark-decode@4k | 186.2742 | 207.1030 | **1.112x** |
| dspark-prefill@4k | 13982.42 | 14192.79 | 1.015x |
| dspark-decode@16k | 121.3340 | 121.2772 | 1.000x (same code path) |
| dspark-prefill@16k | 11531.25 | 11494.37 | 0.997x (same code path) |
| ar-decode@4k | 92.7008 | 93.1733 | 1.005x |
| ar-decode@16k | 88.8490 | 88.8330 | 1.000x |
| mean accept @4k | 2.6275 | 2.7826 | 1.059x |
| mean accept @16k | 1.6000 | 1.6000 | identical |
| losslessness | — | 3/3 fresh processes @4k, 1/1 @16k | |
| accuracy vs main | — | `top1=1.000000 kl=0.000000` | |

The 16k rows execute the same instructions as main by construction (both take the wide group at
16384), so their residuals are run-to-run spread on this box, not an effect of the diff. ctx=32768
is not quoted: a 32 GB 5090 cannot allocate the 32k batched-prefill arena, so there is no honest
32k number from this box — but 32768 selects the wide group before and after, unchanged.

```text
$ SPARKINFER_DSPARK_SPEC_REPS=1 si_mb/build/runtime/dspark_tau_check \
    models_q38_modelopt dspark 128 @ids_4096.txt        # main 823557f
DSPARK tau=2.628  tokens=128
DSPARK lossless=YES  matched 128/128
METRIC AR_TPS 92.7008
METRIC DSPARK_TPS 186.2742
METRIC DSPARK_PREFILL_PP 13982.4203
METRIC MEAN_ACCEPT 2.6275
METRIC LOSSLESS 1

$ SPARKINFER_DSPARK_SPEC_REPS=1 si_gb/build/runtime/dspark_tau_check \
    models_q38_modelopt dspark 128 @ids_4096.txt        # this PR
DSPARK tau=2.783  tokens=128
DSPARK lossless=YES  matched 128/128
METRIC AR_TPS 93.1733
METRIC DSPARK_TPS 207.1030
METRIC DSPARK_PREFILL_PP 14192.7908
METRIC MEAN_ACCEPT 2.7826
METRIC LOSSLESS 1
```
