### PR TITLE
perf(dspark): narrow the draft's mid-context attention window to 2048

### DIFF
--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1206,8 +1206,32 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     // beats 8192 everywhere it was checked and the band under 24576 was simply unserved.
     // kMidCtxMinSeq is deliberately the same 12288 boundary the proposal-depth ladder in
     // qwen35.cpp uses -- the two policies describe the same regime and should not drift apart.
-    static const int kMidCtxWindow = 4096;
+    //
+    // 2048 rather than 4096 in the band this can be measured in. Re-swept on the SCORED prompt
+    // (first 16384 tokens of bench_prompt_32k.txt) at the shipped proposal depth, not the depth-2
+    // ladder the 4096 column above was taken at. Both terms move the right way -- old context is
+    // not buying acceptance here, it is only costing draft time:
+    //
+    //   window    8192     4096     3072     2560     2048     1536     1024
+    //   tok/s    117.72   118.94   122.42   122.69   126.11   123.20   123.77   (128 gen tokens)
+    //   tau      1.6203   1.6000   1.6410   1.6410   1.6842   1.6410   1.6410
+    //   draft ms  1.691    1.370    1.310    1.263    1.235    1.203    1.168
+    //
+    // tau at 128 generated tokens is quantised (128/80, /78, /76), so the peak was re-measured at
+    // 512 to confirm it is a mechanism and not a step boundary: 4096 -> 150.85 tok/s at tau 2.0397
+    // and draft 1.287 ms, 2048 -> 155.23 at tau 2.0894 and draft 1.183, with 1536 (154.02) and
+    // 3072 (151.87) on either side. Acceptance +2.4% and draft cost -8% at the same time.
+    // 2048 reproduces exactly across fresh processes (126.095 / 126.125, tau 1.6842 in both).
+    //
+    // The band is CLOSED at the top rather than extended: 24576 and above keeps the 4096 that was
+    // independently measured there. Narrowing further at 32k is plausible from the trend, but a
+    // 32 GB card cannot run ctx=32768 through the batched prefill at all (the scratch arena is
+    // ~13 MB short and the run falls back), so it cannot be measured here -- and dspark-decode@32k
+    // is both a scored dimension and a no-regression floor. Ship what is measured.
+    static const int kMidCtxWindow = 2048;
     static const int kMidCtxMinSeq = 12288;
+    static const int kMidCtxMaxSeq = 24576;
+    static const int kLongCtxWindow = 4096;
     int kFullWindow = kFullWindowEnv >= 0 ? kFullWindowEnv : 3 * c.sliding_window;
     if (kFullWindowEnv < 0 && kFullWindow <= 0) {
         const int total_ctx = past + ctx_len;
@@ -1227,7 +1251,8 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
         // 4096 rather than the marginally better 3072: the peak is broad, 3072 is worth 0.8% on
         // ONE prompt, and reusing the constant the scored regime already uses is worth more than
         // that. So a single threshold now covers everything from 12288 up.
-        if (total_ctx >= kMidCtxMinSeq) kFullWindow = kMidCtxWindow;
+        if (total_ctx >= kMidCtxMinSeq)
+            kFullWindow = total_ctx < kMidCtxMaxSeq ? kMidCtxWindow : kLongCtxWindow;
     }
     // fc trim: once the full-attn layer is windowed, NO layer reads target_proj older than the
     // largest window across layers, so project only that tail. Uses the same attn_gqa_kv_lo bound


### PR DESCRIPTION
## Summary

The draft's full-attention window above ctx 12288 is 4096. On the scored prompt it should be 2048: the draft gets **both** more accurate and cheaper, because old context is not buying acceptance here, it is only costing draft time.

Mean accept 1.6000 → 1.6842 and draft 1.371 → 1.235 ms/call, which is **+6.00% dspark-decode@16k**. One constant. ctx=4096 is byte-identical and ctx=32768 is untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 119.08 |
| after (this PR) | 126.23 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 12046.04 |
| after prefill (this PR) | 11961.90 |

This PR targets decode; prefill is shown only as the no-regression floor it is (unchanged — the draft does not run in the prompt pass).

`bench/scripts/bench.sh` downloads release prebuilts and takes a `.gguf` file, so it cannot run a branch against this compressed-tensors checkpoint. These come from `runtime/dspark_tau_check` on the scored `Qwen3.8-27B-NVFP4-RTX5090`, the same binary and shape the DSpark bot scores, at 128 generated tokens with `SPARKINFER_DSPARK_SPEC_REPS=3`.

```text
=== gate, dspark_tau_check, scored checkpoint, NTOK=128, SPEC_REPS=3 ===
ctx=16384 main DSPARK=119.0836 AR=88.8821 tau=1.6000 pp=12046.0403 lossless=1
ctx=16384 pr   DSPARK=126.2288 AR=88.7162 tau=1.6842 pp=11961.9024 lossless=1/3
ctx=16384  dspark-decode +6.00%
ctx=4096  main DSPARK=186.4988 AR=93.3837 tau=2.4615 pp=14540.3438 lossless=1
ctx=4096  pr   DSPARK=186.5863 AR=93.3419 tau=2.4615 pp=14573.6217 lossless=1/3
ctx=4096   dspark-decode +0.05%   dspark-prefill +0.23%

=== differential accuracy (qwen3_gguf_score + bench/scripts/accuracy_compare_pair.py) ===
top-1 agreement       : 101/101 = 1.000   (PR vs main)
mean KL(main||pr)     : 0.0000 nats  (top-k union)
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.0160 ppl_main=3.0160

=== no-regression guards, qwen3_gguf_bench <model> 128 sweep @ ctx=16384 ===
GUARD38 main {"16384":{"decode_tps":81.2664,"prefill_pp":9814.1005}}
GUARD38 pr   {"16384":{"decode_tps":81.3126,"prefill_pp":9826.5088}}
GUARD36 main {"16384":{"decode_tps":472.5133,"prefill_pp":25620.4344}}
GUARD36 pr   {"16384":{"decode_tps":473.0874,"prefill_pp":25924.6478}}

ALL GATES GREEN

=== three paired repeats, fresh process per arm, ctx=16384 ===
main 119.15 / 118.82 / 118.70   tau 1.6000   draft 1.371 ms   batched 12.056
pr   126.32 / 126.19 / 126.04   tau 1.6842   draft 1.235 ms   batched 12.099
                                             +6.01% / +6.20% / +6.18%

=== ctx=4096, three paired repeats: unchanged by construction ===
main 186.74 / 186.56 / 186.51   tau 2.4615   draft 1.776 ms
pr   186.85 / 186.52 / 186.60   tau 2.4615   draft 1.776 ms
```

## The sweep

Scored prompt (first 16384 tokens of `bench_prompt_32k.txt`), at the shipped proposal depth:

| window | 8192 | 4096 | 3072 | 2560 | **2048** | 1536 | 1024 |
|---|--:|--:|--:|--:|--:|--:|--:|
| tok/s | 117.72 | 118.94 | 122.42 | 122.69 | **126.11** | 123.20 | 123.77 |
| tau | 1.6203 | 1.6000 | 1.6410 | 1.6410 | **1.6842** | 1.6410 | 1.6410 |
| draft ms | 1.691 | 1.370 | 1.310 | 1.263 | **1.235** | 1.203 | 1.168 |

Both terms move the right way at 2048, which is what makes this a mechanism and not a trade.

tau at 128 generated tokens is quantised (128/80, /78, /76), so the peak was re-measured at **512** generated tokens, where the resolution is ~0.4%:

| window | 4096 | 3072 | **2048** | 1536 |
|---|--:|--:|--:|--:|
| tok/s | 150.85 | 151.87 | **155.23** | 154.02 |
| tau | 2.0397 | 2.0560 | **2.0894** | 2.0726 |
| draft ms | 1.287 | 1.242 | **1.183** | 1.160 |

Acceptance +2.4% and draft cost −8% at the same time. 2048 reproduces exactly across fresh processes (126.095 / 126.125, tau 1.6842 in both).

## Why the shipped 4096 was not wrong when it was chosen

The sweep that selected it is annotated *"(at proposal depth 2)"* and was taken on a different prompt, where 2048 came out slightly behind 3072/4096. Window and proposal depth were each tuned alone; their interaction was never swept. Re-swept at the shipped depth on the scored prompt, 2048 is a clear peak.

Depth was re-checked at the new window and stays at 2 — the extra verify row costs 0.812 ms against a step of 13.305 ms (+6.1%) to buy tau 1.6842 → 1.7297 (+2.7%), so it still loses:

| depth | 2 (shipped) | 3 | 4 | 5 |
|---|--:|--:|--:|--:|
| tok/s | **126.69** | 122.37 | 123.03 | 121.97 |
| tau | 1.6842 | 1.7297 | 1.6842 | 1.6842 |

## Scope

The band is closed at the top rather than extended. `total_ctx >= 12288` still gates it, so **ctx=4096 never windows and is byte-identical** (tau 2.4615 and draft 1.776 ms in both arms, above). `>= 24576` keeps the 4096 that was independently measured there: narrowing further at 32k looks plausible from the trend, but a 32 GB card cannot run ctx=32768 through the batched prefill (its scratch arena is ~13 MB short and the pass falls back), so it cannot be measured here — and `dspark-decode@32k` is both a scored dimension and a no-regression floor. Ship what is measured.
