### PR TITLE
perf(prefill): ingest long prompts in position windows

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -330,6 +330,20 @@ __global__ void pf_mul_sigmoid_kernel(__nv_bfloat16* __restrict__ attn,
     attn[i] = __float2bfloat16(pf_to_f(attn[i]) * pf_sigmoid(pf_to_f(gate[i])));
 }
 
+// One tap of the Gated-DeltaNet causal conv, by token index relative to THIS pass. A windowed
+// pass starts mid-sequence, so the taps that reach back past its own token 0 are not zero: they
+// are the last conv_kernel-1 raw qkv rows of the previous window, handed in through conv_prev in
+// exactly the layout conv_state is written in (index 0 = oldest). conv_prev == nullptr -- the
+// whole-prompt pass, which really does begin at position 0 -- restores the zero pad, so every
+// unwindowed call keeps the arithmetic it had.
+__device__ __forceinline__ float pf_conv_tap(const __nv_bfloat16* __restrict__ qkv,
+                                             const __nv_bfloat16* __restrict__ conv_prev,
+                                             int src, int d, int qkv_dim, int conv_kernel) {
+    if (src >= 0)   return pf_to_f(qkv[(size_t)src * qkv_dim + d]);
+    if (!conv_prev) return 0.f;
+    return pf_to_f(conv_prev[(size_t)(src + conv_kernel - 1) * qkv_dim + d]);
+}
+
 // ============================================================================
 // Gated-DeltaNet causal conv + split + SiLU + L2-norm(q,k), scanned over N tokens.
 // One block per output head (blockDim = head_dim); each thread owns one channel and
@@ -342,7 +356,8 @@ __global__ void pf_gdn_conv_kernel(const __nv_bfloat16* __restrict__ qkv,
                                    __nv_bfloat16* __restrict__ k,
                                    __nv_bfloat16* __restrict__ v,
                                    int n_tokens, int q_heads, int v_heads,
-                                   int head_dim, int qkv_dim, int conv_kernel, float eps) {
+                                   int head_dim, int qkv_dim, int conv_kernel, float eps,
+                                   const __nv_bfloat16* __restrict__ conv_prev) {
     const int q_dim = q_heads * head_dim;
     const int v_dim = v_heads * head_dim;
     const int blk = blockIdx.x;                    // output head
@@ -357,7 +372,10 @@ __global__ void pf_gdn_conv_kernel(const __nv_bfloat16* __restrict__ qkv,
     for (int c = 0; c < 8; c++) w[c] = (c < conv_kernel) ? pf_to_f(conv_w[(size_t)d * conv_kernel + c]) : 0.f;
     float hist[7];                                 // last conv_kernel-1 raw qkv (<=7)
     #pragma unroll
-    for (int c = 0; c < 7; c++) hist[c] = 0.f;
+    for (int c = 0; c < 7; c++)
+        hist[c] = (c < conv_kernel - 1) ? pf_conv_tap(qkv, conv_prev, c - (conv_kernel - 1), d,
+                                                      qkv_dim, conv_kernel)
+                                        : 0.f;
 
     __shared__ float sw[32];
     const int nwarp = (blockDim.x + 31) / 32;
@@ -414,7 +432,8 @@ __global__ void pf_gdn_conv_par_kernel(const __nv_bfloat16* __restrict__ qkv,
                                        __nv_bfloat16* __restrict__ k,
                                        __nv_bfloat16* __restrict__ v,
                                        int n_tokens, int q_heads, int v_heads,
-                                       int head_dim, int qkv_dim, int conv_kernel, float eps) {
+                                       int head_dim, int qkv_dim, int conv_kernel, float eps,
+                                       const __nv_bfloat16* __restrict__ conv_prev) {
     const int q_dim = q_heads * head_dim;
     const int v_dim = v_heads * head_dim;
     const int tok = blockIdx.x;
@@ -430,8 +449,9 @@ __global__ void pf_gdn_conv_par_kernel(const __nv_bfloat16* __restrict__ qkv,
     for (int c = 0; c < 8; c++) {
         if (c >= conv_kernel) break;
         const int src = tok - (conv_kernel - 1) + c;
-        if (src >= 0)
-            y += pf_to_f(conv_w[(size_t)d * conv_kernel + c]) * pf_to_f(qkv[(size_t)src * qkv_dim + d]);
+        if (src >= 0 || conv_prev)
+            y += pf_to_f(conv_w[(size_t)d * conv_kernel + c]) *
+                 pf_conv_tap(qkv, conv_prev, src, d, qkv_dim, conv_kernel);
     }
 
     float cval = pf_silu(y);
@@ -456,9 +476,11 @@ __global__ void pf_gdn_conv_par_kernel(const __nv_bfloat16* __restrict__ qkv,
         #pragma unroll
         for (int c = 0; c < 7; c++) {
             if (c >= conv_kernel - 1) break;
+            // src < 0 means this pass was shorter than the conv window: the rows it did not
+            // supply come from the window before it, not from zero.
             const int src = n_tokens - 1 - (conv_kernel - 2 - c);
             conv_state[(size_t)c * qkv_dim + d] =
-                (src >= 0) ? qkv[(size_t)src * qkv_dim + d] : __float2bfloat16(0.f);
+                __float2bfloat16(pf_conv_tap(qkv, conv_prev, src, d, qkv_dim, conv_kernel));
         }
     }
 }
@@ -481,7 +503,8 @@ __global__ void pf_gdn_conv_tile_kernel(const __nv_bfloat16* __restrict__ qkv,
                                         __nv_bfloat16* __restrict__ k,
                                         __nv_bfloat16* __restrict__ v,
                                         int n_tokens, int q_heads, int v_heads,
-                                        int head_dim, int qkv_dim, int conv_kernel, float eps) {
+                                        int head_dim, int qkv_dim, int conv_kernel, float eps,
+                                        const __nv_bfloat16* __restrict__ conv_prev) {
     const int q_dim = q_heads * head_dim;
     const int v_dim = v_heads * head_dim;
     const int tok0 = blockIdx.x * PF_CONV_TT;
@@ -499,7 +522,8 @@ __global__ void pf_gdn_conv_tile_kernel(const __nv_bfloat16* __restrict__ qkv,
     #pragma unroll
     for (int c = 0; c < 7; c++) {
         const int src = tok0 - (conv_kernel - 1) + c;
-        hist[c] = (c < conv_kernel - 1 && src >= 0) ? pf_to_f(qkv[(size_t)src * qkv_dim + d]) : 0.f;
+        hist[c] = (c < conv_kernel - 1) ? pf_conv_tap(qkv, conv_prev, src, d, qkv_dim, conv_kernel)
+                                        : 0.f;
     }
 
     __shared__ float sw[32];
@@ -545,9 +569,11 @@ __global__ void pf_gdn_conv_tile_kernel(const __nv_bfloat16* __restrict__ qkv,
         #pragma unroll
         for (int c = 0; c < 7; c++) {
             if (c >= conv_kernel - 1) break;
+            // src < 0 means this pass was shorter than the conv window: the rows it did not
+            // supply come from the window before it, not from zero.
             const int src = n_tokens - 1 - (conv_kernel - 2 - c);
             conv_state[(size_t)c * qkv_dim + d] =
-                (src >= 0) ? qkv[(size_t)src * qkv_dim + d] : __float2bfloat16(0.f);
+                __float2bfloat16(pf_conv_tap(qkv, conv_prev, src, d, qkv_dim, conv_kernel));
         }
     }
 }
@@ -948,12 +974,16 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
     __half* __restrict__ k_scale, __half* __restrict__ v_scale,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq) {
+    int block_size, int max_blocks_per_seq, int pos0) {
     const int tok  = blockIdx.x;                    // token (grid.x avoids 65535 grid.y cap)
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
     const int rhalf = rotary_dim >> 1;
-    const int pos   = tok;                              // prefill: position == token index
+    // `tok` indexes THIS PASS's activation buffers; `pos` indexes the sequence. The two were
+    // equal while prefill always ingested [0, N) in a single pass. pos0 separates them so a long
+    // prompt can be ingested in windows: the RoPE angle and the block-table slot below both follow
+    // the sequence position, while q/k/v stay addressed by the local row.
+    const int pos = pos0 + tok;
     const int blk   = pos / block_size, within = pos % block_size;
     const int phys  = block_table[blk];                // single sequence
     const size_t ctok = (size_t)phys * block_size + within;
@@ -1071,11 +1101,15 @@ __global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
     __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq) {
+    int block_size, int max_blocks_per_seq, int pos0) {
     const int tok  = blockIdx.x;
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
-    const int pos  = tok;                              // prefill: position == token index
+    // `tok` indexes THIS PASS's activation buffers; `pos` indexes the sequence. The two were
+    // equal while prefill always ingested [0, N) in a single pass. pos0 separates them so a long
+    // prompt can be ingested in windows: the RoPE angle and the block-table slot below both follow
+    // the sequence position, while q/k/v stay addressed by the local row.
+    const int pos = pos0 + tok;
     const int blk  = pos / block_size, within = pos % block_size;
     const int phys = block_table[blk];                // single sequence
     const size_t ctok = (size_t)phys * block_size + within;
@@ -1140,7 +1174,7 @@ __global__ void pf_attn_int8_paged_kernel(
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
     const __half* __restrict__ v_scale, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale) {
+    int block_size, int max_blocks_per_seq, float scale, int q_pos0) {
     constexpr int ELEMS = HEAD_DIM / 32;
     const int head = blockIdx.y;                    // q-head
     const int qtok = blockIdx.x;                    // query token (grid.x avoids 65535 grid.y cap)
@@ -1157,7 +1191,10 @@ __global__ void pf_attn_int8_paged_kernel(
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
 
-    for (int kpos = 0; kpos <= qtok; kpos++) {
+    // qtok is the query's row in THIS pass; q_pos0 + qtok is its position in the sequence, and
+    // both the causal bound and the KV scan follow the latter -- a windowed pass attends over
+    // everything already in the paged cache, not only over its own window.
+    for (int kpos = 0; kpos <= q_pos0 + qtok; kpos++) {
         const int blk = kpos / block_size, within = kpos % block_size;
         const int phys = block_table[blk];
         const size_t ckt = ((size_t)phys * block_size + within);
@@ -1204,11 +1241,15 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
     signed char* __restrict__ v_i8, __half* __restrict__ v_i8_scale,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq) {
+    int block_size, int max_blocks_per_seq, int pos0) {
     const int tok  = blockIdx.x;
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
-    const int pos  = tok;                              // prefill: position == token index
+    // `tok` indexes THIS PASS's activation buffers; `pos` indexes the sequence. The two were
+    // equal while prefill always ingested [0, N) in a single pass. pos0 separates them so a long
+    // prompt can be ingested in windows: the RoPE angle and the block-table slot below both follow
+    // the sequence position, while q/k/v stay addressed by the local row.
+    const int pos = pos0 + tok;
     const int blk  = pos / block_size, within = pos % block_size;
     const int phys = block_table[blk];
     const size_t ctok = (size_t)phys * block_size + within;
@@ -1292,7 +1333,7 @@ __global__ void pf_attn_bf16_paged_kernel(
     const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
     const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale) {
+    int block_size, int max_blocks_per_seq, float scale, int q_pos0) {
     constexpr int ELEMS = HEAD_DIM / 32;
     const int head = blockIdx.y;
     const int qtok = blockIdx.x;
@@ -1309,7 +1350,8 @@ __global__ void pf_attn_bf16_paged_kernel(
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
 
-    for (int kpos = 0; kpos <= qtok; kpos++) {
+    // Sequence position, not row-in-this-pass: see pf_attn_int8_paged_kernel.
+    for (int kpos = 0; kpos <= q_pos0 + qtok; kpos++) {
         const int blk = kpos / block_size, within = kpos % block_size;
         const int phys = block_table[blk];
         const size_t ckt = ((size_t)phys * block_size + within);
@@ -1357,7 +1399,7 @@ __global__ __launch_bounds__(NWARP * 32) void pf_attn_bf16_paged_tiled_kernel(
     const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
     const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale) {
+    int block_size, int max_blocks_per_seq, float scale, int q_pos0) {
     constexpr int ELEMS = HEAD_DIM / 32;
     extern __shared__ __nv_bfloat16 pf_tile_smem[];
     __nv_bfloat16* sK = pf_tile_smem;
@@ -1385,7 +1427,10 @@ __global__ __launch_bounds__(NWARP * 32) void pf_attn_bf16_paged_tiled_kernel(
     #pragma unroll
     for (int e = 0; e < ELEMS; e++) acc[e] = 0.f;
 
-    const int qmax = min(q0 + NWARP - 1, n_tokens - 1);
+    // Sequence position of the last query this block owns: the KV tile loop below walks absolute
+    // positions (kpos indexes the paged cache directly), so it has to stop where the sequence
+    // says, not where this pass's row numbering does.
+    const int qmax = q_pos0 + min(q0 + NWARP - 1, n_tokens - 1);
 
     for (int t0 = 0; t0 <= qmax; t0 += TK) {
         const int tk = min(TK, qmax - t0 + 1);
@@ -1401,7 +1446,7 @@ __global__ __launch_bounds__(NWARP * 32) void pf_attn_bf16_paged_tiled_kernel(
         }
         __syncthreads();
         if (qtok < n_tokens) {
-            const int kend = min(tk, qtok - t0 + 1);
+            const int kend = min(tk, q_pos0 + qtok - t0 + 1);   // causal, in sequence positions
             for (int kk = 0; kk < kend; kk++) {
                 float partial = 0.f;
                 #pragma unroll
@@ -1494,7 +1539,8 @@ void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int 
 
 void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_state,
                              void* q, void* k, void* v, int n_tokens, int q_heads, int v_heads,
-                             int head_dim, int conv_kernel, float eps, cudaStream_t stream) {
+                             int head_dim, int conv_kernel, float eps, cudaStream_t stream,
+                             const void* conv_prev) {
     const int qkv_dim = 2 * q_heads * head_dim + v_heads * head_dim;
     const int blocks = 2 * q_heads + v_heads;
     static int seq = [] {   // SPARKINFER_PREFILL_GDN_CONV_SEQ=1 restores the token-loop kernel
@@ -1511,7 +1557,8 @@ void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_sta
             reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
             reinterpret_cast<__nv_bfloat16*>(conv_state), reinterpret_cast<__nv_bfloat16*>(q),
             reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
-            n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps);
+            n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps,
+            reinterpret_cast<const __nv_bfloat16*>(conv_prev));
         return;
     }
     if (!seq) {
@@ -1520,14 +1567,16 @@ void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_sta
             reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
             reinterpret_cast<__nv_bfloat16*>(conv_state), reinterpret_cast<__nv_bfloat16*>(q),
             reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
-            n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps);
+            n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps,
+            reinterpret_cast<const __nv_bfloat16*>(conv_prev));
         return;
     }
     pf_gdn_conv_kernel<<<blocks, head_dim, 0, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(qkv), reinterpret_cast<const __nv_bfloat16*>(conv_w),
         reinterpret_cast<__nv_bfloat16*>(conv_state), reinterpret_cast<__nv_bfloat16*>(q),
         reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
-        n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps);
+        n_tokens, q_heads, v_heads, head_dim, qkv_dim, conv_kernel, eps,
+        reinterpret_cast<const __nv_bfloat16*>(conv_prev));
 }
 
 void launch_prefill_gdn_scan(const void* q, const void* k, const void* v,
@@ -1709,7 +1758,7 @@ void launch_prefill_qknorm_rope_kv_int8(
     signed char* k_pool, signed char* v_pool, void* k_scale, void* v_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream) {
+    cudaStream_t stream, int pos0) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
     const size_t shmem = (size_t)head_dim * sizeof(float);
     pf_qknorm_rope_kv_int8_kernel<<<grid, head_dim, shmem, stream>>>(
@@ -1718,7 +1767,7 @@ void launch_prefill_qknorm_rope_kv_int8(
         reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool,
         reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq);
+        block_size, max_blocks_per_seq, pos0);
 }
 
 // Muse Glimmer bf16-KV counterpart: QK-norm + NORMAL RoPE (rotary_dim>0) / NoPE
@@ -1728,7 +1777,7 @@ void launch_prefill_qknorm_ropenorm_kv_bf16(
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream) {
+    cudaStream_t stream, int pos0) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
     const size_t shmem = (size_t)head_dim * sizeof(float);
     pf_qknorm_ropenorm_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
@@ -1737,7 +1786,7 @@ void launch_prefill_qknorm_ropenorm_kv_bf16(
         reinterpret_cast<const __nv_bfloat16*>(k_w),
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq);
+        block_size, max_blocks_per_seq, pos0);
 }
 
 void launch_prefill_qknorm_rope_kv_bf16_vi8(
@@ -1745,7 +1794,7 @@ void launch_prefill_qknorm_rope_kv_bf16_vi8(
     void* k_pool, void* v_pool, signed char* v_i8, void* v_i8_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream) {
+    cudaStream_t stream, int pos0) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);
     const size_t shmem = (size_t)head_dim * sizeof(float);
     pf_qknorm_rope_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
@@ -1754,37 +1803,50 @@ void launch_prefill_qknorm_rope_kv_bf16_vi8(
         reinterpret_cast<const __nv_bfloat16*>(k_w),
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
         v_i8, reinterpret_cast<__half*>(v_i8_scale), block_table,
-        n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps, block_size, max_blocks_per_seq);
+        n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps, block_size, max_blocks_per_seq, pos0);
 }
 
-void launch_prefill_attn_int8_paged(
+bool launch_prefill_attn_int8_paged(
     const void* q, const signed char* k_pool, const signed char* v_pool,
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, int win_blocks, cudaStream_t stream) {
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks, cudaStream_t stream,
+    int q_pos0) {
     // int8 tensor-core prefill attention: same mask + online softmax as the scalar path below,
     // run on the wmma int8 cores (the scalar kernels are compute-bound at ~8 TFLOP/s). Honours the
     // caller's per-layer window (zero means global/full). SPARKINFER_PREFILL_ATTN_MMA=0 falls through.
     if (launch_prefill_attn_mma(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
             n_tokens, n_q_heads, n_kv_heads, head_dim, block_size, max_blocks_per_seq, scale,
-            win_blocks, stream))
-        return;
+            win_blocks, stream, q_pos0))
+        return true;
     // Sink + sliding-window sparse prefill attention (StreamingLLM, matches the merged decode
     // sparse-KV #379): O(N*window) instead of O(N^2) at long context. Returns false when the
     // caller requests full attention and the tiled full kernel is disabled, or for unsupported HD.
-    if (launch_prefill_attn_windowed(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
+    // Skipped for a windowed pass: this one takes its sink and window bounds from the local row
+    // index, so it would attend over the wrong span. The scalar kernel below is exact at any
+    // q_pos0 and takes over.
+    if (q_pos0 == 0 &&
+        launch_prefill_attn_windowed(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
             n_tokens, n_q_heads, n_kv_heads, head_dim, block_size, max_blocks_per_seq, scale,
             win_blocks, stream))
-        return;
+        return true;
     dim3 grid(n_tokens, n_q_heads);   // token on grid.x
     auto qb = reinterpret_cast<const __nv_bfloat16*>(q);
     auto ks = reinterpret_cast<const __half*>(k_scale);
     auto vs = reinterpret_cast<const __half*>(v_scale);
     auto ob = reinterpret_cast<__nv_bfloat16*>(attn);
-    if (head_dim == 256)
-        pf_attn_int8_paged_kernel<256><<<grid, 32, 0, stream>>>(
-            qb, k_pool, v_pool, ks, vs, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
-            block_size, max_blocks_per_seq, scale);
+    // The scalar kernel is full-causal only -- it has no notion of a sink or a sliding window.
+    // At q_pos0 == 0 that is how it has always been reached (the windowed kernel above handles
+    // win_blocks and returns true), but on a windowed pass that kernel is skipped, so a layer
+    // with a real window would silently get full attention over the whole prefix. Refuse.
+    if (q_pos0 != 0 && win_blocks > 0) return false;
+    // The scalar fallback exists only for head_dim 256; for anything else there is no correct
+    // path left, and saying so beats leaving `attn` holding whatever the scratch held before.
+    if (head_dim != 256) return false;
+    pf_attn_int8_paged_kernel<256><<<grid, 32, 0, stream>>>(
+        qb, k_pool, v_pool, ks, vs, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
+        block_size, max_blocks_per_seq, scale, q_pos0);
+    return true;
 }
 
 void launch_prefill_qknorm_rope_kv_bf16(
@@ -1792,7 +1854,7 @@ void launch_prefill_qknorm_rope_kv_bf16(
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream) {
+    cudaStream_t stream, int pos0) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);
     const size_t shmem = (size_t)head_dim * sizeof(float);
     pf_qknorm_rope_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
@@ -1801,19 +1863,19 @@ void launch_prefill_qknorm_rope_kv_bf16(
         reinterpret_cast<const __nv_bfloat16*>(k_w),
         reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
         nullptr, nullptr, block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq);
+        block_size, max_blocks_per_seq, pos0);
 }
 
 bool launch_prefill_attn_bf16_paged(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream, int q_pos0) {
     // Tensor cores first. pf_attn_bf16_paged_kernel below is one warp per (query, q-head) walking
     // the causal history a key at a time; at long context that is the prompt pass's largest single
     // cost. The mma kernel declines any shape it does not cover, so this stays a strict addition.
     if (launch_prefill_attn_mma_bf16(q, k_pool, v_pool, block_table, attn, n_tokens, n_q_heads,
                                      n_kv_heads, head_dim, block_size, max_blocks_per_seq,
-                                     scale, stream))
+                                     scale, stream, q_pos0))
         return true;
     dim3 grid(n_tokens, n_q_heads);
     auto qb = reinterpret_cast<const __nv_bfloat16*>(q);
@@ -1842,7 +1904,7 @@ bool launch_prefill_attn_bf16_paged(
             dim3 gt((n_tokens + (NW) - 1) / (NW), n_q_heads);                                      \
             pf_attn_bf16_paged_tiled_kernel<256, (TK), (NW)><<<gt, (NW) * 32, sm, stream>>>(       \
                 qb, kb, vb, block_table, ob, n_tokens, n_q_heads, n_kv_heads,                      \
-                block_size, max_blocks_per_seq, scale);                                            \
+                block_size, max_blocks_per_seq, scale, q_pos0);                                    \
         } while (0)
         if      (tile ==  8 && tw ==  4) SI_PF_TILE(8, 4);
         else if (tile ==  8 && tw ==  8) SI_PF_TILE(8, 8);
@@ -1863,13 +1925,13 @@ bool launch_prefill_attn_bf16_paged(
     if (head_dim == 256) {
         pf_attn_bf16_paged_kernel<256><<<grid, 32, 0, stream>>>(
             qb, kb, vb, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
-            block_size, max_blocks_per_seq, scale);
+            block_size, max_blocks_per_seq, scale, q_pos0);
         return true;
     }
     if (head_dim == 128) {
         pf_attn_bf16_paged_kernel<128><<<grid, 32, 0, stream>>>(
             qb, kb, vb, block_table, ob, n_tokens, n_q_heads, n_kv_heads,
-            block_size, max_blocks_per_seq, scale);
+            block_size, max_blocks_per_seq, scale, q_pos0);
         return true;
     }
     return false;

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -62,7 +62,12 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
     const __half* __restrict__ v_scale, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks, int q_pos0) {
+    // q_pos0 is where this pass's queries START in the sequence. It was implicitly 0 while
+    // prefill always ingested [0, N) in a single pass; carrying it lets a long prompt be
+    // ingested in windows. Queries and outputs stay addressed by the LOCAL row, while the
+    // causal bound and key range below run in sequence coordinates, so a window attends
+    // over the whole prefix that precedes it.
     using namespace nvcuda::wmma;
     constexpr int BM    = 16;                    // query rows per block == wmma M == KV page size
     constexpr int GN    = GROUP_BLKS * 16;       // keys per group
@@ -135,10 +140,10 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
     __syncthreads();
 
     // ---- sink/window range for this (16-aligned) query tile ----
-    const int last_q = min(qbase + BM - 1, n_tokens - 1);
+    const int last_q = q_pos0 + min(qbase + BM - 1, n_tokens - 1);
     int blk_rs = 0;                                   // first token of the recent window
     if (win_blocks > 0) {
-        const int n_blk_q = (qbase + block_size) / block_size;   // constant across the tile
+        const int n_blk_q = (q_pos0 + qbase + block_size) / block_size;   // constant across the tile
         const int rsb = (win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks);
         blk_rs = rsb * block_size;
     }
@@ -189,7 +194,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, 3) void pf_attn_mma_i8_kernel(
                     const int t = lane + u * 32, gtok = k0 + t;
                     // causal + (sink OR recent window); the window start is uniform across the tile
                     const bool live = (t < gblk * 16) && (gtok < hi) && (qtok < n_tokens) &&
-                                      (gtok <= qtok) &&
+                                      (gtok <= q_pos0 + qtok) &&
                                       (win_blocks <= 0 || gtok < block_size || gtok >= blk_rs);
                     sc[u] = live ? (float)s_si[r * GN + t] * s_qs[r] * s_ks[t] * scale : -1e30f;
                     mx = fmaxf(mx, sc[u]);
@@ -312,7 +317,12 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_m
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
     const __half* __restrict__ v_scale, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale, int win_blocks, int qld, int pld) {
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks, int qld, int pld, int q_pos0) {
+    // q_pos0 is where this pass's queries START in the sequence. It was implicitly 0 while
+    // prefill always ingested [0, N) in a single pass; carrying it lets a long prompt be
+    // ingested in windows. Queries and outputs stay addressed by the LOCAL row, while the
+    // causal bound and key range below run in sequence coordinates, so a window attends
+    // over the whole prefix that precedes it.
     using namespace nvcuda::wmma;
     constexpr int BM    = 16;
     constexpr int GN    = GROUP_BLKS * 16;
@@ -392,10 +402,10 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_m
     if (tid < RQH * BM) { s_m[tid] = -1e30f; s_l[tid] = 0.f; }
     __syncthreads();
 
-    const int last_q = min(qbase + BM - 1, n_tokens - 1);
+    const int last_q = q_pos0 + min(qbase + BM - 1, n_tokens - 1);
     int blk_rs = 0;
     if (win_blocks > 0) {
-        const int n_blk_q = (qbase + block_size) / block_size;
+        const int n_blk_q = (q_pos0 + qbase + block_size) / block_size;
         const int rsb = (win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks);
         blk_rs = rsb * block_size;
     }
@@ -456,7 +466,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_m
                     for (int u = 0; u < GN / 32; u++) {
                         const int t = lane + u * 32, gtok = k0 + t;
                         const bool live = (t < gblk * 16) && (gtok < hi) && (qtok < n_tokens) &&
-                                          (gtok <= qtok) &&
+                                          (gtok <= q_pos0 + qtok) &&
                                           (win_blocks <= 0 || gtok < block_size || gtok >= blk_rs);
                         sc[u] = live ? (float)s_si[r * GN + t] * s_qs[h * BM + r] * s_ks[t] * scale : -1e30f;
                         mx = fmaxf(mx, sc[u]);
@@ -551,7 +561,7 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
                             const void* k_scale, const void* v_scale, const int* block_table,
                             void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
                             int block_size, int max_blocks_per_seq, float scale, int win_blocks,
-                            cudaStream_t stream) {
+                            cudaStream_t stream, int q_pos0) {
     constexpr int BM = 16, GN = GROUP_BLKS * 16;
     // Only at long context. The padding costs ~1 KB of shared memory per block, which is enough to
     // push this kernel past the 2-blocks-per-SM occupancy its __launch_bounds__ asks for at RQH<=2.
@@ -601,7 +611,7 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
         reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),
         block_table, reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
-        block_size, max_blocks_per_seq, scale, win_blocks, qld, pld);
+        block_size, max_blocks_per_seq, scale, win_blocks, qld, pld, q_pos0);
     // A rejected launch (e.g. smem over the device limit) enqueues nothing; peek —
     // rather than get — so a pre-existing sticky error is not silently cleared here.
     return cudaPeekAtLastError() == cudaSuccess;
@@ -611,7 +621,8 @@ bool launch_prefill_attn_mma(
     const void* q, const signed char* k_pool, const signed char* v_pool,
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, int win_blocks, cudaStream_t stream) {
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks, cudaStream_t stream,
+    int q_pos0) {
     constexpr int HD = 256, GROUP_BLKS = 8, BM = 16;
 
     static const int enabled = [] {
@@ -659,7 +670,7 @@ bool launch_prefill_attn_mma(
     // returning success over an output buffer nothing wrote.
     if (gqa_rqh == 4 && gqa % 4 == 0 &&
         launch_attn_gqa<HD, GROUP_BLKS, 4>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
-            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))
         return true;
     // RQH=3 exists for GQA-6 (this checkpoint: 24 q-heads over 4 kv-heads), where 4 does not
     // divide the group and the tier above always falls through to 2. ncu at ctx=16384 puts this
@@ -675,11 +686,11 @@ bool launch_prefill_attn_mma(
     // prefill@128, which is a no-regression floor.
     if (gqa_rqh >= 3 && gqa % 3 == 0 && n_tokens >= 2048 &&
         launch_attn_gqa<HD, GROUP_BLKS, 3>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
-            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))
         return true;
     if (gqa_rqh >= 2 && gqa % 2 == 0 &&
         launch_attn_gqa<HD, GROUP_BLKS, 2>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
-            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream))
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))
         return true;
 
     // Fallback: original per-q-head kernel.
@@ -700,7 +711,7 @@ bool launch_prefill_attn_mma(
         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
         reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),
         block_table, reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
-        block_size, max_blocks_per_seq, scale, win_blocks);
+        block_size, max_blocks_per_seq, scale, win_blocks, q_pos0);
     return true;
 }
 
@@ -744,7 +755,12 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     const void* __restrict__ v_pool_raw, const __half* __restrict__ v_scale,
     const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int block_size, int max_blocks_per_seq, float scale, int qld, int pld) {
+    int block_size, int max_blocks_per_seq, float scale, int qld, int pld, int q_pos0) {
+    // q_pos0 is where this pass's queries START in the sequence. It was implicitly 0 while
+    // prefill always ingested [0, N) in a single pass; carrying it lets a long prompt be
+    // ingested in windows. Queries and outputs stay addressed by the LOCAL row, while the
+    // causal bound and key range below run in sequence coordinates, so a window attends
+    // over the whole prefix that precedes it.
     using namespace nvcuda::wmma;
     constexpr int BM    = 16;                    // query rows per block == wmma M == KV page size
     constexpr int GN    = GROUP_BLKS * 16;       // keys per iteration
@@ -815,7 +831,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
     if (tid < RQH * BM) { s_m[tid] = -1e30f; s_l[tid] = 0.f; }
     __syncthreads();
 
-    const int last_q = min(qbase + BM - 1, n_tokens - 1);
+    const int last_q = q_pos0 + min(qbase + BM - 1, n_tokens - 1);
 
     for (int k0 = 0; k0 < last_q + 1; k0 += GN) {
         const int nk   = min(GN, last_q + 1 - k0);
@@ -881,7 +897,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32) void pf_attn_mma_bf16_kernel(
                 #pragma unroll
                 for (int u = 0; u < GN / 32; u++) {
                     const int t = lane + u * 32, gtok = k0 + t;
-                    const bool live = (t < gblk * 16) && (qtok < n_tokens) && (gtok <= qtok);
+                    const bool live = (t < gblk * 16) && (qtok < n_tokens) && (gtok <= q_pos0 + qtok);
                     sc[u] = live ? s_sh[r * GN + t] * scale : -1e30f;
                     mx = fmaxf(mx, sc[u]);
                 }
@@ -1029,7 +1045,8 @@ template <int HD, int GROUP_BLKS, int RQH, bool PSPLIT, bool VINT8 = false>
 static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* v_pool,
                                  const void* v_scale, const int* block_table, void* attn, int n_tokens,
                                  int n_q_heads, int n_kv_heads, int block_size,
-                                 int max_blocks_per_seq, float scale, cudaStream_t stream) {
+                                 int max_blocks_per_seq, float scale, cudaStream_t stream,
+                                 int q_pos0) {
     constexpr int BM = 16, GN = GROUP_BLKS * 16;
     // Same bank-conflict argument as attn_smem_pad() above, in bf16 elements: an unpadded row
     // stride of HD (512 B) or GN (256 B) is a whole multiple of the 128-byte bank row, so all 16
@@ -1053,7 +1070,7 @@ static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* 
         reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k_pool),
         v_pool, reinterpret_cast<const __half*>(v_scale), block_table,
         reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
-        block_size, max_blocks_per_seq, scale, qld, pld);
+        block_size, max_blocks_per_seq, scale, qld, pld, q_pos0);
     // A rejected launch (e.g. smem over the device limit) enqueues nothing; peek --
     // rather than get -- so a pre-existing sticky error is not silently cleared here.
     return cudaPeekAtLastError() == cudaSuccess;
@@ -1062,7 +1079,7 @@ static bool launch_attn_bf16_gqa(const void* q, const void* k_pool, const void* 
 bool launch_prefill_attn_mma_bf16(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream, int q_pos0) {
     constexpr int HD = 256;
     static const int enabled = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_BF16_MMA");
@@ -1099,29 +1116,29 @@ bool launch_prefill_attn_mma_bf16(
         if (!psplit && rqh_env >= 3 && gqa % 3 == 0 &&
             launch_attn_bf16_gqa<HD, 16, 3, false>(
                 q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads, n_kv_heads,
-                block_size, max_blocks_per_seq, scale, stream))
+                block_size, max_blocks_per_seq, scale, stream, q_pos0))
             return true;
         if (rqh_env >= 2 && gqa % 2 == 0) {
             if (psplit ? launch_attn_bf16_gqa<HD, 16, 2, true>(
                              q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
-                             n_kv_heads, block_size, max_blocks_per_seq, scale, stream)
+                             n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0)
                        : launch_attn_bf16_gqa<HD, 16, 2, false>(
                              q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
-                             n_kv_heads, block_size, max_blocks_per_seq, scale, stream))
+                             n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0))
                 return true;
         }
         return psplit ? launch_attn_bf16_gqa<HD, 16, 1, true>(
                             q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
-                            n_kv_heads, block_size, max_blocks_per_seq, scale, stream)
+                            n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0)
                       : launch_attn_bf16_gqa<HD, 16, 1, false>(
                             q, k_pool, v_pool, nullptr, block_table, attn, n_tokens, n_q_heads,
-                            n_kv_heads, block_size, max_blocks_per_seq, scale, stream);
+                            n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0);
     }
 #define SI_MMA_BF16_TRY(RQH_)                                                                     \
     (psplit ? launch_attn_bf16_gqa<HD, 8, RQH_, true>(q, k_pool, v_pool, nullptr, block_table, attn,       \
-                  n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream) \
+                  n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0) \
             : launch_attn_bf16_gqa<HD, 8, RQH_, false>(q, k_pool, v_pool, nullptr, block_table, attn,      \
-                  n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream))
+                  n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0))
     if (rqh_env >= 3 && gqa % 3 == 0 && SI_MMA_BF16_TRY(3)) return true;
     if (rqh_env >= 2 && gqa % 2 == 0 && SI_MMA_BF16_TRY(2)) return true;
     return SI_MMA_BF16_TRY(1);
@@ -1131,14 +1148,15 @@ bool launch_prefill_attn_mma_bf16(
 bool launch_prefill_attn_mma_bf16_vi8(
     const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
     const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
-    int head_dim, int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream) {
+    int head_dim, int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream,
+    int q_pos0) {
     if (head_dim != 256 || block_size != 16 || n_tokens < 32768 ||
         n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0 ||
         (n_q_heads / n_kv_heads) % 3 != 0)
         return false;
     return launch_attn_bf16_gqa<256, 16, 3, false, true>(
         q, k_pool, v_i8, v_scale, block_table, attn, n_tokens, n_q_heads, n_kv_heads,
-        block_size, max_blocks_per_seq, scale, stream);
+        block_size, max_blocks_per_seq, scale, stream, q_pos0);
 }
 
 }  // namespace kernels

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -54,10 +54,16 @@ void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int 
 // over all N tokens. Leaves the last conv_kernel-1 raw qkv rows in conv_state (decode layout).
 //   qkv:        [N, 2*q_heads*hd + v_heads*hd]      conv_w: [qkv_dim, conv_kernel]
 //   conv_state: [conv_kernel-1, qkv_dim] (bf16)     q/k: [N, q_heads*hd]   v: [N, v_heads*hd]
+//   conv_prev:  [conv_kernel-1, qkv_dim] (bf16), same layout as conv_state -- the previous
+//               window's trailing raw qkv rows, for a pass that does not start at position 0.
+//               nullptr (the default) pads with zeros, which is correct only at position 0.
+//               MUST NOT alias conv_state: the kernel writes conv_state from the block holding
+//               the pass's last token while other blocks may still be reading conv_prev.
 void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_state,
                              void* q, void* k, void* v,
                              int n_tokens, int q_heads, int v_heads, int head_dim,
-                             int conv_kernel, float eps, cudaStream_t stream = nullptr);
+                             int conv_kernel, float eps, cudaStream_t stream = nullptr,
+                             const void* conv_prev = nullptr);
 
 // Gated-DeltaNet sequential recurrence scan over all N tokens (one launch). Produces
 // out[N, v_heads*hd] and leaves the recurrent state in the SPARKINFER_GDN_FAST transposed
@@ -140,7 +146,8 @@ void launch_prefill_qknorm_rope_kv_int8(
     signed char* k_pool, signed char* v_pool, void* k_scale, void* v_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    int pos0 = 0);
 
 // Muse Glimmer bf16-KV counterpart: QK-norm + NORMAL (consecutive-pair, LLAMA_ROPE_TYPE_NORM)
 // RoPE when rotary_dim>0 (SWA layers), or NoPE when rotary_dim==0 (global layers) + bf16 KV
@@ -153,42 +160,48 @@ void launch_prefill_qknorm_rope_kv_bf16(
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    int pos0 = 0);
 
 void launch_prefill_qknorm_rope_kv_bf16_vi8(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
     void* k_pool, void* v_pool, signed char* v_i8, void* v_i8_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    int pos0 = 0);
 
 // Full-causal attention over a bf16 paged KV pool. false = no instantiation for head_dim.
 bool launch_prefill_attn_bf16_paged(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr,
+    int q_pos0 = 0);
 
 bool launch_prefill_attn_mma_bf16_vi8(
     const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
     const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
     int head_dim, int block_size, int max_blocks_per_seq, float scale,
-    cudaStream_t stream);
+    cudaStream_t stream, int q_pos0 = 0);
 
 void launch_prefill_qknorm_ropenorm_kv_bf16(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    int pos0 = 0);
 
 // Full-attention prefill: causal attention over the paged int8 KV pool just filled above.
-// One warp per (token, q-head); online softmax over keys 0..token (causal). q is the rope'd
+// One warp per (token, q-head); online softmax over keys 0..q_pos0+token (causal). q is the rope'd
 // bf16 query [N,n_q_heads*hd]; out attn[N,n_q_heads*hd].
-void launch_prefill_attn_int8_paged(
+// q_pos0: sequence position of this pass's first query (0 for a whole-prompt pass). Returns
+// false when no kernel here covers the shape, leaving `attn` unwritten -- callers must check.
+bool launch_prefill_attn_int8_paged(
     const void* q, const signed char* k_pool, const signed char* v_pool,
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr, int q_pos0 = 0);
 
 }} // namespace sparkinfer::kernels

--- a/kernels/include/sparkinfer/kernels/prefill_attn_mma.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_mma.h
@@ -32,7 +32,8 @@ bool launch_prefill_attn_mma(
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream = nullptr,
+    int q_pos0 = 0);
 
 // BF16-KV twin, full causal, hd256 GQA. The int8 entry above cannot serve a bf16 KV pool, and the
 // bf16 pool is what the DSpark harness runs (dspark_tau_check pins int8_kv=false), so without this
@@ -44,13 +45,15 @@ bool launch_prefill_attn_mma(
 bool launch_prefill_attn_mma_bf16(
     const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
-    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr);
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream = nullptr,
+    int q_pos0 = 0);
 
 bool launch_prefill_attn_mma_bf16_vi8(
     const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
     const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
     int head_dim, int block_size, int max_blocks_per_seq, float scale,
-    cudaStream_t stream = nullptr);
+    cudaStream_t stream,
+    int q_pos0);   // default declared in prefill.h
 
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/runtime/examples/qwen3_gguf_prefill_check.cpp
+++ b/runtime/examples/qwen3_gguf_prefill_check.cpp
@@ -4,7 +4,13 @@
 // Fills the cache two ways over the SAME prompt, then teacher-forces the SAME continuation
 // tokens and compares the per-position next-token logits:
 //   TOKEN   : forward_token() over the whole prompt (the reference path)
-//   BATCHED : prefill_batched() over the prompt
+//   BATCHED : prefill_batched_chunked() over the prompt
+//
+// SPARKINFER_PREFILL_WINDOW sets the batched pass's window size, so this same A/B is also the
+// test for WINDOWED prefill: set it well below the prefix length (e.g. 512 against a 4096-token
+// prefix) and the batched side runs as eight chained passes whose positions, causal masks and
+// Gated-DeltaNet carry-over all have to line up with the token loop's, or the logits diverge.
+// SPARKINFER_PREFILL_WINDOW=0 forces the single unwindowed pass.
 // Reports top-1 agreement and mean KL(token || batched) over the continuation positions.
 //
 // Usage: qwen3_gguf_prefill_check <model.gguf|checkpoint_dir> [prefix_len=4096] [cont_len=16]
@@ -119,7 +125,7 @@ int main(int argc, char** argv) {
 
     // ---- BATCHED path ----
     if (!kv.allocate(0, cfg.max_seq)) { printf("[FAIL] kv allocate\n"); return 1; }
-    int seed = model.prefill_batched(prompt.data(), P);
+    int seed = model.prefill_batched_chunked(prompt.data(), P);
     if (seed < 0) { printf("[FAIL] prefill_batched unsupported (seed=%d)\n", seed); return 1; }
     for (int j = 0; j < C; j++) { amB[j] = model.forward_token(cont[j], P + j); model.copy_logits(LB[j].data()); }
     kv.free(0);

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -390,7 +390,14 @@ public:
     // seed token, so last_token_logprobs() is valid immediately after this returns -- see
     // ingest_prompt_range's identical parameter. Off by default: it costs a full-vocab sort, and
     // the seed's logprob is only wanted when the request asked for logprobs.
-    int prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob = false);
+    int prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob = false,
+                        int pos0 = 0);
+    // Same pass, ingested as position-windows so the scratch arena is bounded by the window
+    // rather than by n. Returns the seed for the last token, or -1 if a window was refused --
+    // in which case *out_done (when given) reports how many leading tokens ARE in the cache,
+    // so the caller can finish from there instead of recomputing from zero.
+    int prefill_batched_chunked(const int* prompt_ids, int n, bool want_seed_logprob = false,
+                                int* out_done = nullptr);
 
     // Prefill prompt tokens [start, end) with the batched path when start==0 and eligible, else
     // the token loop. chunk_limit > 0 caps the token-loop path to at most chunk_limit tokens per

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -2245,6 +2245,32 @@ bool batched_prefill_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
            n_tokens <= batched_maxctx;
 }
 
+// Tokens per batched-prefill window. The single-pass arena scales with the token count (mostly
+// the N*H activations and the attention scratch): it measured ~8.4 GB at 128k, which no longer
+// fits beside an NVFP4 27B and its 128k+ KV cache -- the allocation fails and the WHOLE prompt
+// drops onto the token loop, ~50x slower. Windowing bounds the arena by this constant instead,
+// so a 256k prompt costs the same arena as a 32k one. Only prompts LONGER than a window are
+// split, so every context that already fit in one pass is left on exactly the path it had.
+// SPARKINFER_PREFILL_WINDOW overrides; 0 restores the single unwindowed pass.
+int prefill_window_tokens() {
+    static const int w = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_WINDOW");
+        const int v = e ? atoi(e) : 32768;
+        return v < 0 ? 0 : v;
+    }();
+    return w;
+}
+
+// Batched-prefill eligibility for a prompt that may be windowed: every condition of
+// batched_prefill_enabled() except the context cap, which a window makes irrelevant -- what has
+// to fit is one window, not the prompt.
+bool batched_prefill_windowed_enabled(bool gguf, const Qwen35Config& cfg, int n_tokens) {
+    const int w = prefill_window_tokens();
+    if (n_tokens <= 0) return false;
+    if (w <= 0 || n_tokens <= w) return batched_prefill_enabled(gguf, cfg, n_tokens);
+    return batched_prefill_enabled(gguf, cfg, w);
+}
+
 // LMCache chunk size, tokens. Doubles as both the LOOKUP eligibility threshold (below this many
 // tokens, always recompute locally rather than pay an IPC round trip) and the STORE alignment
 // unit (a store range is rounded down to the nearest multiple, matching what the sidecar's own
@@ -2376,7 +2402,7 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     // naive) falls back to the token loop below, which is left byte-identical to main on purpose.
     bool batched_done = false;
     if (start_pos > 0) {
-        if (batched_prefill_enabled(s.gguf, s.cfg, start_pos)) {
+        if (batched_prefill_windowed_enabled(s.gguf, s.cfg, start_pos)) {
             std::vector<int> ids(start_pos);
             // Default is a synthetic ramp, NOT text. That is fine for a weight-bandwidth-bound
             // dense decode, but it is out-of-distribution for anything whose cost depends on token
@@ -2388,7 +2414,10 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
             if (!bench_prompt_ids_from_env(ids, start_pos))
                 for (int i = 0; i < start_pos; i++) ids[i] = 100 + (i % 20000);   // deterministic pseudo-prompt
             auto pb0 = std::chrono::high_resolution_clock::now();
-            int seed = prefill_batched(ids.data(), start_pos);
+            // No out_done: on a refusal the loop below re-ingests from position 0, and since it
+            // feeds its own output back as the next input (this is a synthetic bench prompt, not
+            // ids[]) resuming mid-way would not reproduce the same sequence anyway.
+            int seed = prefill_batched_chunked(ids.data(), start_pos);
             cudaDeviceSynchronize();
             auto pb1 = std::chrono::high_resolution_clock::now();
             if (seed >= 0) {
@@ -2503,12 +2532,14 @@ int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chu
         return -1;
     }
     const int n = end - start;
-    // Batched GEMM prefill never chunks (no start_pos support in prefill_batched_run yet) --
-    // only eligible on the very first call for this range (start==0) and always covers the
-    // whole [0,end) in one pass regardless of chunk_limit.
-    if (start == 0 && batched_prefill_enabled(s.gguf, s.cfg, n)) {
-        int seed = prefill_batched(ids, n, want_seed_logprob);
-        if (seed >= 0 && seed < s.cfg.vocab) {
+    // Batched GEMM prefill. Only eligible on the very first call for this range (start==0) --
+    // a windowed pass carries the Gated-DeltaNet recurrence forward from wherever the state
+    // already is, so it has to begin where the state does -- and it always covers the whole
+    // [0,end), in prefill_window_tokens()-sized windows, regardless of chunk_limit.
+    int batched_done = 0;
+    if (start == 0 && batched_prefill_windowed_enabled(s.gguf, s.cfg, n)) {
+        int seed = prefill_batched_chunked(ids, n, want_seed_logprob, &batched_done);
+        if (seed >= 0) {
             if (out_pos) *out_pos = end;
             return seed;
         }
@@ -2528,8 +2559,10 @@ int Qwen35Model::ingest_prompt_range(const int* ids, int start, int end, int chu
     // lmcache_e2e_gpu_test.cpp -- exactly the class of bug that test exists to catch).
     // lookup() already handles "is the bridge actually reachable" internally via its own
     // lazy-connect + cooldown/backoff, bounded by the 5ms default timeout either way.
-    int actual_start = start;
-    if (start == 0 && s.lmcache_bridge && n >= lmcache_chunk_size_tokens()) {
+    // Whatever the batched windows did land is already correct in the KV cache and in the GDN
+    // state, so the token loop resumes from there instead of recomputing it.
+    int actual_start = start + batched_done;
+    if (actual_start == 0 && s.lmcache_bridge && n >= lmcache_chunk_size_tokens()) {
         LookupResult res = s.lmcache_bridge->lookup(std::vector<int>(ids, ids + end));
         if (res.ok && res.matched_tokens > 0) {
             const BridgeKVLayout layout = lmcache_layout_from_cfg(s.cfg, *s.kv);
@@ -2698,7 +2731,8 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
 
 // Thin adapter: hand the batched-prefill orchestration (qwen35_prefill.cpp) exactly the scratch
 // buffers, streams and config it needs, so Impl stays private to this file.
-int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob) {
+int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob,
+                                 int pos0) {
     Impl& s = *p_;
     auto it = s.sessions.find(s.active_seq_id);
     float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
@@ -2713,9 +2747,9 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_lo
                           s.dflash_capture ? s.dflash_n_cap : 0,
                           s.dflash_capture ? s.dflash_context : nullptr,
                           s.dflash_capture ? s.dflash_ctx_start : 0 };
-    const int seed = prefill_batched_run(ctx, prompt_ids, n);
+    const int seed = prefill_batched_run(ctx, prompt_ids, n, pos0);
     if (seed >= 0 && s.dflash_capture && s.dflash_context && s.dflash_n_cap > 0)
-        s.dflash_ctx_len = n;
+        s.dflash_ctx_len = pos0 + n;
     // Seed-token logprob (see ingest_prompt_range's want_seed_logprob). prefill_batched_run's
     // LM-head tail stops at argmax -- it never runs the sort/scan that last_token_logprobs()
     // reads -- so without this the FIRST token of every response has no logprob entry and
@@ -2747,6 +2781,44 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_lo
         cu(cudaStreamSynchronize(s.stream), "prefill seed logprob sync");
     }
     return seed;
+}
+
+int Qwen35Model::prefill_batched_chunked(const int* prompt_ids, int n, bool want_seed_logprob,
+                                         int* out_done) {
+    if (out_done) *out_done = 0;
+    if (!prompt_ids || n <= 0) return -1;
+    const int window = prefill_window_tokens();
+    Impl& s = *p_;
+    // Short enough for one pass: run exactly the call this function replaced, so no context that
+    // already worked changes kernel path, tile shape or arithmetic.
+    if (window <= 0 || n <= window) {
+        const int seed = prefill_batched(prompt_ids, n, want_seed_logprob);
+        if (seed < 0 || seed >= s.cfg.vocab) return -1;
+        if (out_done) *out_done = n;
+        return seed;
+    }
+    for (int pos = 0; pos < n; pos += window) {
+        const int len = std::min(window, n - pos);
+        const bool last = (pos + len >= n);
+        // Only the final window needs the seed logprob -- the earlier ones exist to fill KV and
+        // carry the Gated-DeltaNet recurrence, and nothing ever reads their argmax.
+        const int seed = prefill_batched(prompt_ids + pos, len, want_seed_logprob && last, pos);
+        // A window that declines -- a path with no start position (Muse's rolling-window
+        // attention, a DSpark capture), or a scratch allocation that failed even at window size
+        // -- leaves [0, pos) correct in the cache and stops there: the caller finishes the rest
+        // token by token rather than recomputing what already landed.
+        if (seed < 0) return -1;
+        // *out_done advances only over windows whose result is trustworthy: a final window that
+        // produced a nonsense seed is not counted, so the caller redoes it rather than trusting
+        // a KV range whose own LM head disagreed with itself.
+        if (last) {
+            if (seed >= s.cfg.vocab) return -1;
+            if (out_done) *out_done = n;
+            return seed;
+        }
+        if (out_done) *out_done = pos + len;
+    }
+    return -1;
 }
 
 int Qwen35Model::session_token_budget(size_t prompt_len, int max_new, int max_seq) {
@@ -3328,10 +3400,11 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     s.final_seqlen_hint = n + max_new;
     auto t0 = std::chrono::steady_clock::now();
     int next = -1;
-    if (batched_prefill_enabled(s.gguf, s.cfg, n))
-        next = prefill_batched(prompt.data(), n);
+    int batched_done = 0;
+    if (batched_prefill_windowed_enabled(s.gguf, s.cfg, n))
+        next = prefill_batched_chunked(prompt.data(), n, false, &batched_done);
     if (next < 0) {
-        for (int i = 0; i < n; i++) {
+        for (int i = batched_done; i < n; i++) {
             set_dflash_capture_row(0);
             const bool sample = (i + 1 == n);
             int r = forward_token(prompt[i], i, sample);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -107,7 +107,8 @@ void dflash_release_verify_cache() {
     cache.arena.free_all();
 }
 
-int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n) {
+int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
+                        int pos0) {
     const Qwen35Config& c = s.cfg;
     // Batched prefill supports the Qwen3.5 dense-hybrid (Qwythos) AND the Qwen3.6-35B-A3B MoE hybrid.
     // Both share the GDN + full-attention batched kernels (identical math at 128/16/32 GDN dims and
@@ -150,12 +151,25 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     const int N = n;
     cudaStream_t st = s.stream;
 
-    // This path always starts at position zero, so its recurrent GDN state must start from zero
+    // A windowed ingest (pos0 > 0) resumes mid-sequence. Every path below that has no notion of a
+    // start position has to refuse HERE, before the first kernel runs: bailing out from inside the
+    // layer loop would leave the Gated-DeltaNet state advanced for the layers already done and not
+    // for the rest, and nothing downstream can tell that apart from a clean state or undo it.
+    if (pos0 < 0) return -1;
+    if (pos0 != 0) {
+        if (c.muse_glimmer) return -1;   // rolling-window SWA attention indexes from token 0
+        if (s.capture_dst && s.capture_layers && s.n_capture > 0) return -1;  // DSpark capture rows
+    }
+
+    // A pass that starts at position zero must start its recurrent GDN state from zero,
     // just like forward_token(position=0). Session buffers come from cudaMalloc and may reuse pages
     // from a previous request; the scan consumes their initial value before writing the final one.
     // Without this reset the first request after process start is correct, while later batched
     // prefills can inherit the preceding request's state and diverge despite identical tokens.
-    if (s.lin_state && s.lin_conv_state) {
+    // ...but only for the window that actually starts at position zero. A windowed ingest carries
+    // the recurrence forward: zeroing here on a later window would discard everything the previous
+    // ones accumulated and produce a confidently wrong continuation.
+    if (pos0 == 0 && s.lin_state && s.lin_conv_state) {
         pf_cu(cudaMemsetAsync(
                   s.lin_state, 0,
                   (size_t)c.n_layers * c.linear_v_heads * c.linear_head_dim *
@@ -309,7 +323,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     // DSpark capture destinations are session-owned and change between generations. Do not replay
     // a whole-prefill graph whose memcpy nodes captured a previous session's destination.
     const bool capture_dflash = s.capture_dst && s.capture_layers && s.n_capture > 0;
-    const bool graph_on = graph_env && arena_reuse && c.dense_ffn && !capture_dflash;
+    // A captured graph bakes in every kernel PARAMETER, pos0 among them, and replay is keyed on
+    // the token count -- so a windowed prefill, whose windows all share one N and differ only in
+    // pos0, would replay the first window's positions for every window after it: right length,
+    // wrong place in the sequence, no error anywhere. Windows are unique in pos0 and could never
+    // reuse each other's graph anyway, so they run eager. pos0 == 0 (the whole-prompt pass, and
+    // the first window) still captures and still replays a graph an earlier pass left behind.
+    const bool graph_on = graph_env && arena_reuse && c.dense_ffn && !capture_dflash && pos0 == 0;
     const void* const pfb_btable = s.kv->block_table(s.seq_id);
     // A whole-prefill graph embeds every pointer passed to its kernel nodes. The arena addresses
     // are deliberately stable, but recurrent state and the paged-KV block table are session-owned:
@@ -359,6 +379,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
     bf16* lnrm = a.alloc<bf16>((size_t)N * lvdim);       // lin_norm (4096)
     bf16* la   = a.alloc<bf16>((size_t)N * vh);          // lin_alpha (32)
     bf16* lb   = a.alloc<bf16>((size_t)N * vh);          // lin_beta (32)
+    // The previous window's trailing raw-qkv rows, staged out of the live conv state so the conv
+    // kernel can read them while it overwrites conv_state with this window's own. One layer's
+    // worth is enough -- the layer loop copies into it immediately before each conv. Allocated
+    // unconditionally (it is ~48 KB) even though only a windowed pass has a predecessor: the
+    // arena hands out buffers by CURSOR POSITION and reuses them across calls, so a slot that
+    // appears only on some calls would shift every later allocation's index and make each pass
+    // free and re-cudaMalloc the whole chain. `cconv` below is what decides zeros vs carry-in.
+    bf16* cprev = a.alloc<bf16>((size_t)(c.linear_conv_kernel - 1) * lqkv);
+    // At pos0 == 0 the conv genuinely starts from zeros -- pass nullptr and the kernels take
+    // exactly the arithmetic path they had before windowing existed.
+    bf16* cconv = (pos0 != 0) ? cprev : nullptr;
     // Full-attention scratch ALIASES the GDN scratch: a layer is either linear-attn (GDN) or full
     // softmax-attn, never both, and qb/qg/kf/vf are pairwise-distinct within a full-attn layer while
     // the GDN buffers they map onto are unused there (and vice-versa). Saves ~10K bf16/token of peak
@@ -1393,8 +1424,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
             proj(xn, w.ssm_alpha, w.ssm_alpha_type, la, vh,    H);
             proj(xn, w.ssm_beta,  w.ssm_beta_type,  lb, vh,    H);
             bf16* conv_state = lin_conv_state + (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
+            if (cconv)
+                pf_cu(cudaMemcpyAsync(cprev, conv_state,
+                                      (size_t)(c.linear_conv_kernel - 1) * lqkv * sizeof(bf16),
+                                      cudaMemcpyDeviceToDevice, st), "gdn conv carry-in");
             kernels::launch_prefill_gdn_conv(b8, w.ssm_conv, conv_state, gq, gk, gv,
-                N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, eps, st);
+                N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, eps, st, cconv);
             float* layer_state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
             kernels::launch_prefill_gdn_scan(gq, gk, gv, la, lb, w.ssm_dt, w.ssm_a,
                 layer_state, att, N, c.linear_q_heads, vh, c.linear_head_dim,
@@ -1595,29 +1630,41 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n)
                         kernels::launch_prefill_qknorm_rope_kv_bf16_vi8(
                             qb, kf, vf, w.q_norm, w.k_norm, kpool, vpool, vi8, vi8_scale,
                             btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                            rope_dim, rope_theta, eps, bs, mbs, st);
+                            rope_dim, rope_theta, eps, bs, mbs, st, pos0);
                     else
                         kernels::launch_prefill_qknorm_rope_kv_bf16(
                             qb, kf, vf, w.q_norm, w.k_norm, kpool, vpool, btable, N,
                             c.n_q_heads, c.n_kv_heads, c.head_dim,
-                            rope_dim, rope_theta, eps, bs, mbs, st);
+                            rope_dim, rope_theta, eps, bs, mbs, st, pos0);
                     const bool vi8_done = vi8 && kernels::launch_prefill_attn_mma_bf16_vi8(
                         qb, kf, vi8, vi8_scale, btable, att, N, c.n_q_heads, c.n_kv_heads,
-                        c.head_dim, bs, mbs, attn_scale, st);
+                        c.head_dim, bs, mbs, attn_scale, st, pos0);
                     if (!vi8_done)
-                        kernels::launch_prefill_attn_bf16_paged(qb, kpool, vpool, btable, att,
-                            N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, st);
+                        if (!kernels::launch_prefill_attn_bf16_paged(qb, kpool, vpool, btable, att,
+                                N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale,
+                                st, pos0)) {
+                            a.free_all(); a8.free_all(); am.free_all(); aw.free_all();
+                            fprintf(stderr, "[prefill] windowed pass declined by attention "
+                                            "(pos0=%d)\n", pos0);
+                            return -1;
+                        }
                 } else {
                     kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
                         kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                        rope_dim, rope_theta, eps, bs, mbs, st);
+                        rope_dim, rope_theta, eps, bs, mbs, st, pos0);
                     // Qwen3.8 interleaves SWA and global-attention layers. The old int8 launcher
                     // read one process-wide 4096-token window for every layer, silently truncating
                     // the global layers at long context. Pass the layer contract explicitly, as
                     // the BF16/Muse path above already does: zero means full causal attention.
                     const int win_blocks = w.swa ? (c.sliding_window + bs - 1) / bs : 0;
-                    kernels::launch_prefill_attn_int8_paged(qb, kpool, vpool, kscale, vscale, btable, att,
-                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks, st);
+                    if (!kernels::launch_prefill_attn_int8_paged(qb, kpool, vpool, kscale, vscale,
+                            btable, att, N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs,
+                            attn_scale, win_blocks, st, pos0)) {
+                        a.free_all(); a8.free_all(); am.free_all(); aw.free_all();
+                        fprintf(stderr, "[prefill] no int8 attention kernel for hd=%d win=%d "
+                                        "pos0=%d\n", c.head_dim, win_blocks, pos0);
+                        return -1;
+                    }
                 }
             }
             // Muse: the gated attention output feeds exactly one consumer -- the o projection's

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -47,7 +47,8 @@ struct Qwen35PrefillCtx {
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.
 // Returns the argmax at the last prompt position (seed for the first decode step), or -1 if the
 // batched path is unsupported for this model/config (caller falls back to the token loop).
-int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n);
+// pos0: where this pass's tokens start in the sequence (0 = whole prompt in one pass).
+int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n, int pos0 = 0);
 
 // Exact short-block DFlash verifier. It evaluates all candidate rows from the live hybrid state,
 // commits only the accepted prefix, and leaves rejected KV rows outside the logical sequence.


### PR DESCRIPTION
## Summary

Batched prefill sized its scratch arena by the whole prompt: ~8.4 GB at `ctx=131072`, against
237 MB free once an NVFP4 27B and its KV cache are resident. The allocation fails, the whole prompt
drops onto the per-token loop — which re-streams every weight once per position — and 256k prefill
runs at 66 tok/s where 32k does 9748.

`prefill_batched_run` now takes a start position, so a long prompt is ingested in 32k windows and
the arena is bounded by the window instead of by the prompt. A prompt that already fits in one pass
still takes one pass, on the same kernels with the same arithmetic.

Following the sequence position rather than the row index in the current pass: the RoPE angle and
paged-KV slot, and the causal mask, KV scan bound and sink/window base in the prefill attention
kernels. Carried across a window boundary: the Gated-DeltaNet recurrent state, and its short-conv
history — which seeded from this pass's own buffer and zero-padded before row 0, so a boundary
would otherwise have zeroed `conv_kernel-1` real tokens per layer. The whole-prefill CUDA graph is
keyed on token count, which every window shares, so its capture and replay are gated on
`start == 0`. Paths with no start position refuse before the first kernel runs, rather than leaving
the recurrent state advanced for some layers and not others.

`SPARKINFER_PREFILL_WINDOW=0` restores the single unwindowed pass.

**Accuracy.** `qwen3_gguf_prefill_check` teacher-forces the same continuation through both states
and compares against the token-by-token reference, on real token ids, both arms in the same session:

| prefix | windows | TOP1 | mean KL |
|---|---|--:|--:|
| 4096 | 1 (unwindowed) | 16/16 | 0.256 |
| 4096 | 8 × 512 | 16/16 | 0.228 |
| 32768 | 1 (unwindowed) | 14/16 | 0.473 |
| 32768 | 2 × 16384 | 14/16 | 0.505 |

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (`--ctx 131072`; 262144 also shown — same binary, arms back to back):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 80.44 |
| after prefill (this PR) | **4559.70** |

**56.7x at 131072; 32.1x at 262144** (66.44 → 2135.36). Decode is unaffected and VRAM is unchanged.

```text
BEFORE (main)
######## ctx=131072 ########
[prefill] scratch alloc failed (ctx=131072, chunk=32768, held=8386 MB, free=237/32109 MB) -> fallback
VRAM used    : 24.6 GB
decode tg    : 65.75 tok/s  (n=128, ctx=131072, bs=1)
prefill pp   : 80.44 tok/s  (ctx=131072, sequential KV fill)

AFTER (this PR)
######## ctx=131072 ########
VRAM used    : 24.6 GB
decode tg    : 65.48 tok/s  (n=128, ctx=131072, bs=1)
prefill pp   : 4559.70 tok/s  (ctx=131072, sequential KV fill)

ctx=262144, one 262,144-token sweep row, INT8 KV, native NVFP4 prefill/decode:
BEFORE  VRAM 29.2 GB   decode tg 50.32 tok/s   prefill pp   66.44 tok/s
AFTER   VRAM 29.2 GB   decode tg 50.33 tok/s   prefill pp 2135.36 tok/s

Unchanged where the prompt already fits one pass:
######## ctx=32768, before ########   prefill pp : 9777.47 tok/s
######## ctx=32768, after  ########   prefill pp : 9748.50 tok/s
```
