### PR TITLE
perf(prefill): widen the int8 attention KV-page group to 16 and register-stage the softmax

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -312,7 +312,7 @@ inline int attn_smem_pad() {
 }
 
 template <int HEAD_DIM, int GROUP_BLKS, int RQH>
-__global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_mma_gqa_kernel(
+__global__ __launch_bounds__(GROUP_BLKS * 32, (GROUP_BLKS >= 16 ? 1 : (RQH <= 3 ? 2 : 1))) void pf_attn_mma_gqa_kernel(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
     const __half* __restrict__ v_scale, const int* __restrict__ block_table,
@@ -455,7 +455,6 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_m
             for (int h = 0; h < RQH; h++) {
                 const int qh_head = head0 + h;
                 const int* s_si = reinterpret_cast<const int*>(s_s) + (size_t)h * BM * GN;
-                float* s_sh = s_s + (size_t)h * BM * GN;
                 signed char* s_pih = s_pi + (size_t)h * BM * pld;
                 #pragma unroll
                 for (int rr = 0; rr < BM / WARPS; rr++) {
@@ -475,6 +474,17 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_m
                     for (int o = 16; o > 0; o >>= 1) mx = fmaxf(mx, __shfl_xor_sync(0xffffffffu, mx, o));
                     const float m_old = s_m[h * BM + r], m_new = fmaxf(m_old, mx), corr = __expf(m_old - m_new);
                     float sum = 0.f, pamax = 0.f;
+                    // P' stays in registers between the exp and the quantize. Lane `lane` owns
+                    // exactly columns {lane + 32u}, and the quantize below re-reads exactly those
+                    // columns, so the round trip through s_sh that the two loops used to share was
+                    // a store and a reload of a value the thread already held. Dropping it removes
+                    // two of the three 4-byte shared accesses this section makes per score. The
+                    // padding note above measures the tensor pipe at 20.5% with the stalls on
+                    // mio_throttle, so shared-memory instructions are the currency here, not math
+                    // and not K/V bytes -- worth +2.7% at ctx=262144 on its own.
+                    // Arithmetic is untouched (a float survives shared memory exactly), so every
+                    // tier of this kernel stays bit-identical to what it produced before.
+                    float pvr[GN / 32];
                     #pragma unroll
                     for (int u = 0; u < GN / 32; u++) {
                         const int t = lane + u * 32;
@@ -483,7 +493,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_m
                             const float p = __expf(sc[u] - m_new);
                             sum += p; pv = p * s_vs[t]; pamax = fmaxf(pamax, fabsf(pv));
                         }
-                        s_sh[r * GN + t] = pv;
+                        pvr[u] = pv;
                     }
                     #pragma unroll
                     for (int o = 16; o > 0; o >>= 1) {
@@ -493,9 +503,13 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (RQH <= 3 ? 2 : 1)) void pf_attn_m
                     const float pd = pamax / 127.0f;
                     if (lane == 0) { s_m[h * BM + r] = m_new; s_l[h * BM + r] = s_l[h * BM + r] * corr + sum;
                                      s_ps[h * BM + r] = pd; s_corr[h * BM + r] = corr; }
-                    for (int t = lane; t < gblk * 16; t += 32)
-                        s_pih[r * GN + t] =
-                            (signed char)((pamax == 0.f) ? 0 : (int)roundf(s_sh[r * GN + t] / pd));
+                    #pragma unroll
+                    for (int u = 0; u < GN / 32; u++) {
+                        const int t = lane + u * 32;
+                        if (t < gblk * 16)
+                            s_pih[r * GN + t] =
+                                (signed char)((pamax == 0.f) ? 0 : (int)roundf(pvr[u] / pd));
+                    }
                 }
             }
             __syncthreads();
@@ -659,6 +673,14 @@ bool launch_prefill_attn_mma(
         const int v = e ? atoi(e) : dflt;
         return (v == 1 || v == 2 || v == 3 || v == 4) ? v : dflt;
     }();
+    // KV pages per group iteration for the RQH=3 tier; 8 restores the previous width (A/B in ONE
+    // binary). Only 8 and 16 are structurally valid -- GROUP_BLKS is also the warp count, and the
+    // kernel needs both BM and HEAD_DIM/16 to divide by it.
+    static const int gqa_gb = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_ATTN_GQA_GB");
+        const int v = e ? atoi(e) : 16;
+        return (v == 8 || v == 16) ? v : 16;
+    }();
 
     if (!enabled || head_dim != HD || block_size != 16 || n_tokens < minctx) return false;
     if (n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0) return false;
@@ -684,10 +706,34 @@ bool launch_prefill_attn_mma(
     // re-read, which only dominates once the window is long. At ctx=128 there is no re-read to
     // save and the wider block costs registers -- measured +1.9% at ctx=16384 against -0.45% on
     // prefill@128, which is a no-regression floor.
-    if (gqa_rqh >= 3 && gqa % 3 == 0 && n_tokens >= 2048 &&
-        launch_attn_gqa<HD, GROUP_BLKS, 3>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
-            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))
-        return true;
+    // GROUP_BLKS fixes BOTH the keys retired per group iteration (GN) and the warp count, so
+    // doubling it to 16 halves the number of group iterations a block runs -- and with it every
+    // per-iteration fixed cost. The one that matters is the online softmax's reductions: each
+    // (query row, q-head) pass ends in two warp butterflies (max, then sum+|P'|max) worth ~30
+    // instructions regardless of how many keys the group holds, and a block runs BM*RQH of them
+    // per iteration. At GN=128 that is 48 passes per 128 keys; at GN=256 it is 48 per 256. The
+    // two __syncthreads() per iteration halve per key with it. DPW also drops from 2 to 1, which
+    // frees the second set of RQH float accumulators -- enough to retire the 160 bytes of stack
+    // the RQH=3 tier was spilling.
+    //
+    // The cost is shared memory: 78,272 B against 46,528, so one block per SM instead of two. It
+    // is a wash on occupancy (16 warps either way, since the block itself doubles to 16 warps)
+    // and strongly positive on work per barrier. Measured on an RTX 5090 at the scored
+    // target-prefill@256k point, interleaved x2: 2872.08 vs 2609.18 pp/s, +10.08%.
+    //
+    // Only this tier. RQH=4 at GN=256 needs 103,680 B, past the device's 101,376 B ceiling, and
+    // RQH=2 would re-read each K page more often for a wider group -- so GQA-8 checkpoints
+    // (Qwen3.6) keep exactly the tier and the numerics they had. Falls through to the GN=128 tier
+    // if the wide launch is refused, so a device with a smaller ceiling still gets the old path.
+    if (gqa_rqh >= 3 && gqa % 3 == 0 && n_tokens >= 2048) {
+        if (gqa_gb >= 16 &&
+            launch_attn_gqa<HD, 16, 3>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
+                n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))
+            return true;
+        if (launch_attn_gqa<HD, GROUP_BLKS, 3>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
+                n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))
+            return true;
+    }
     if (gqa_rqh >= 2 && gqa % 2 == 0 &&
         launch_attn_gqa<HD, GROUP_BLKS, 2>(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
             n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))


### PR DESCRIPTION
## Summary

Two changes to the GQA-fused int8 prefill-attention kernel, both aimed at its per-group-iteration overhead at long context:

1. **Widen the KV-page group from 8 to 16 on the RQH=3 tier** (GQA-6, hd256). `GROUP_BLKS` sets both the keys a block retires per iteration and the block's warp count, so 16 halves the number  of iterations — and with it every per-iteration fixed cost.
2. **Keep P′ in registers across the softmax's two loops** instead of round-tripping it through shared memory. Bit-identical.

Together worth **+10.9% on `target-prefill@256k`**. That dimension is essentially one kernel: an nsys profile of the scored invocation puts `pf_attn_mma_gqa_kernel` at **80.5% of all GPU time** (82.5 s of 102.5 s, n=256 = 16 ingest windows × 16 full-attention layers).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

RTX 5090 32 GB, 575 W, CUDA 13.0. Base = upstream `0a2d9e1`. Every arm is the exact invocation `eval/pr_dspark_bot.py` uses for `target-prefill@256k`, run interleaved with its baseline and repeated. The PR binary is measured at its **default** env — no override.

**Decode tok/s** — not targeted; reported from the same runs to show it is unmoved:

| | decode tok/s |
|---|--:|
| before (main) | 54.41 |
| after (this PR) | 54.36 |

**Prefill pp tok/s** — the scored dimension is ctx=262144 (the template's context list predates that row); the 4k and 16k contexts are in the guard table below:

| | prefill pp tok/s |
|---|--:|
| before prefill (main), ctx=262144 | 2644.77 |
| after prefill (this PR), ctx=262144 | 2933.75 |

```text
$ SPARKINFER_QWEN38_PREFILL_NVFP4=1 SPARKINFER_QWEN38_DECODE_NVFP4=1 SPARKINFER_KV_INT8=1 \
  SPARKINFER_PREFILL_BATCHED=1 SPARKINFER_BENCH_SWEEP_CTXS=262144 SPARKINFER_BENCH_SWEEP_REPS=1 \
  build/runtime/qwen3_gguf_bench <ModelOpt-NVFP4-dir> 128 sweep

main 0a2d9e1   prefill pp : 2668.74 tok/s   decode tg : 54.42 tok/s
this PR        prefill pp : 2941.71 tok/s   decode tg : 54.35 tok/s
main 0a2d9e1   prefill pp : 2620.79 tok/s   decode tg : 54.41 tok/s
this PR        prefill pp : 2925.78 tok/s   decode tg : 54.36 tok/s
```

Per-lever attribution, earlier interleaved batches against their own bracketed baselines, same invocation (the group width is env-selectable, so both widths come from one binary):

| arm | prefill pp @256k | vs its baseline |
|---|--:|--:|
| main | 2609.44 / 2608.92 / 2610.34 | — |
| P′ in registers only | 2680.75 / 2678.15 | +2.69% |
| GROUP_BLKS=16 only | 2872.83 / 2871.32 / 2872.49 | +9.85% |
| both (this PR) | 2941.71 / 2925.78 | **+10.93%** |

### Differential accuracy gate (`qwen3_gguf_score` on both builds → `accuracy_compare_pair.py`)

```text
positions             : 101
top-1 agreement       : 101/101 = 1.000   (PR vs main)
mean KL(main||pr)     : 0.0000 nats  (top-k union)
PPL PR                : 3.016
PPL main              : 3.016
METRIC top1=1.000000 kl=0.000000 ppl_pr=3.0160 ppl_main=3.0160
```

### Guards

Same `qwen3_gguf_bench ... sweep` form on both builds. These take int8 KV, so they *do* run the patched kernel. Qwen3.6-35B-A3B is GQA-8 and keeps the GN=128 tier by construction, so it isolates the register-staging half — and picks up +2.5% from it, which is the mechanism confirming itself on a checkpoint the group-width change cannot touch. (With only the group-width change, this same guard moved +0.48%, i.e. noise.)

| guard | metric | main | this PR | Δ |
|---|---|--:|--:|--:|
| Qwen3.8 (GQA-6) ctx=4096 | prefill pp | 11238.85 | 11539.95 | **+2.68%** |
| Qwen3.8 (GQA-6) ctx=4096 | decode tg | 83.790 | 83.799 | +0.01% |
| Qwen3.8 (GQA-6) ctx=16384 | prefill pp | 9800.42 | 10049.57 | **+2.54%** |
| Qwen3.8 (GQA-6) ctx=16384 | decode tg | 81.248 | 81.256 | +0.01% |
| Qwen3.6-35B-A3B (GQA-8) ctx=16384 | prefill pp | 25468.72 | 26107.10 | **+2.51%** |
| Qwen3.6-35B-A3B (GQA-8) ctx=16384 | decode tg | 472.55 | 472.18 | −0.08% |

```text
GUARD qwen38-GQA6 ctx=4096  main {"4096":{"decode_tps":83.7900,"prefill_pp":11238.8532}}
GUARD qwen38-GQA6 ctx=4096  PR   {"4096":{"decode_tps":83.7989,"prefill_pp":11539.9487}}
GUARD qwen38-GQA6 ctx=16384 main {"16384":{"decode_tps":81.2481,"prefill_pp":9800.4215}}
GUARD qwen38-GQA6 ctx=16384 PR   {"16384":{"decode_tps":81.2564,"prefill_pp":10049.5683}}
GUARD qwen36-GQA8 ctx=16384 main {"16384":{"decode_tps":472.5502,"prefill_pp":25468.7215}}
GUARD qwen36-GQA8 ctx=16384 PR   {"16384":{"decode_tps":472.1800,"prefill_pp":26107.1018}}
```
