### PR TITLE
perf(dspark): give the deepest context its own depth and window (1.03x dspark-decode@32k)

### DIFF
--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -1231,7 +1231,22 @@ bool DFlashDraftModel::forward_block(const void* target_hidden, int ctx_len,
     static const int kMidCtxWindow = 2048;
     static const int kMidCtxMinSeq = 12288;
     static const int kMidCtxMaxSeq = 24576;
-    static const int kLongCtxWindow = 4096;
+    // The long band keeps 4096 while the mid band was narrowed to 2048, but the reason the mid
+    // band moved applies harder here, not less: acceptance falls with context while the draft's
+    // attention cost rises with it, so at 32k old context buys even less than it does at 16k.
+    // Measured at ctx=32768 on bench_prompt_32k.txt, lossless at every point, MEAN_ACCEPT
+    // identical (1.2800) across the whole range -- this is draft time removed, not acceptance
+    // traded away:
+    //
+    //     window   4096     3072     2048     1024      256
+    //     tok/s   89.28    89.88    90.44    90.79    91.33
+    //
+    // 2048 rather than the faster 256, for the reason the mid band chose 4096 over 3072: 512 and
+    // 768 sit in a reproducible acceptance dip (tau 1.2673 and 1.2549), so the narrow end is not a
+    // broad peak on this prompt and picking its best point is fitting one corpus. 2048 is the
+    // constant the band below already uses, which collapses the window ladder to one value above
+    // 12288.
+    static const int kLongCtxWindow = 2048;
     int kFullWindow = kFullWindowEnv >= 0 ? kFullWindowEnv : 3 * c.sliding_window;
     if (kFullWindowEnv < 0 && kFullWindow <= 0) {
         const int total_ctx = past + ctx_len;

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3609,10 +3609,32 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // already proposes. 8k is left on depth 3 (94.73 vs 94.48 for depth 5), which the bound below
     // preserves, as are 16k and 32k on depth 2.
     constexpr int kMid4kMaxSeq = 6144;
+    // The deep band's depth of 2 was measured at 16k and carried to every length above it, but the
+    // band spans a factor of two in verify cost and the two ends do not want the same plan. A
+    // verify row at 32k reads twice the KV a 16k row does, while acceptance FALLS with length, so
+    // the second proposal is charged more and lands less often. Measured on RTX 5090, reps=1,
+    // lossless everywhere, `bench_prompt_32k.txt` truncated to each context:
+    //
+    //     ctx    depth 1              depth 2              main (adaptive)
+    //     16384  115.38 / 115.17      125.58 / 125.50      126.11 / 125.20     <- 2 is right
+    //     32768   89.34 /  89.39       87.00               87.19 /  87.20      <- 1 is right
+    //
+    // At 16k the second proposal is worth 8.9% and at 32k it costs 2.5%. Split the band rather
+    // than move it: 16k keeps exactly the plan it has.
+    //
+    // This is the INITIAL depth, and the adaptive controller below can only promote from it and
+    // demote back TO it -- `depth_demote_run` is gated on `active_proposal_depth >
+    // kInitialProposalDepth`, so the initial value is a floor. That is why 32k could not reach
+    // depth 1 on its own: the floor was 2. Lowering the floor keeps the whole promotion path
+    // intact, so a predictable stream at 32k still climbs to 4 or B exactly as before.
+    // 24576 is not a new boundary: it is the one dflash_draft.cpp's window ladder already splits
+    // the long band at, so the depth plan and the draft's attention window change together.
+    constexpr int kVeryDeepMinSeq = 24576;
     const int kInitialProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
                                     : ((kShortGeneration || kAmortizedMidContext) ? 7
-                                       : ((n + max_new) >= kDeepMinSeq ? 2
-                                          : ((n + max_new) < kMid4kMaxSeq ? 5 : 3))));
+                                       : ((n + max_new) >= kVeryDeepMinSeq ? 1
+                                          : ((n + max_new) >= kDeepMinSeq ? 2
+                                             : ((n + max_new) < kMid4kMaxSeq ? 5 : 3)))));
     // A length-only depth is a safe starting point, not a workload policy. At the same 16k
     // context real chat accepts ~1.36 tokens while code/JSON/repetition accept 5.35/6.62/6.92 at
     // depth 7. Keeping the prose-tuned depth-2 ceiling makes those predictable streams pay 27-39%


### PR DESCRIPTION
## Summary

Split the long context band: at ctx ≥ 24576 the proposal depth starts at 1 rather than 2, and the draft's attention window is 2048 rather than 4096. Both hinge on a boundary `dflash_draft.cpp` already uses, so the depth plan and the draft's window now change together. 16k and 4k are untouched.

## Proof of speedup

> ⚠️ **The on-device eval runs only when BOTH are true:** (1) the box below is ticked, and
> (2) at least one **decode tok/s** or **Qwythos prefill pp** table shows a **real end-to-end
> improvement** (`after > before`, filled from `bench/scripts/bench.sh` — *not* an isolated-kernel
> microbenchmark). A ticked box with empty/placeholder tables (or no claimed gain on either metric)
> gets `needs-benchmark` and is **not** evaluated.
>
> Tick the box **only if you actually ran it on an RTX 5090.** False attestation is treated as
> gaming — the account is **blocked** ([`.github/blocked-contributors.txt`](blocked-contributors.txt)),
> same as copycatting or sybil farming.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark-decode@32k`, a scored dimension, measured with `runtime/examples/dspark_tau_check` on the same prompt and truncation `eval/pr_dspark_bot.py` uses; `bench.sh` has no DSpark leg):

| | decode tok/s |
|---|--:|
| before (main) | 87.51 |
| after (this PR) | 90.40 |

**Prefill pp tok/s** (Qwythos / Qwen3.5 — fill if this PR targets prefill; use `--ctx 4096`, `32768`,
`65536`, or `131072` and copy the `prefill pp` line — report your best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | N/A |
| after prefill (this PR) | N/A |

```text
RTX 5090, Qwen3.8-27B NVFP4 + released DSpark draft, bench_prompt_32k.txt truncated to each
context, 128 tokens, SPEC-REPS 3. main is reproduced in the SAME binary by pinning the depth and
window the old ladders chose at 32k (PROPOSALS=2, FULL_WINDOW=4096).

ctx=32768
  main   88.1541 / 86.8646 tok/s   tau 1.3333   lossless 3/3   AR 80.997 / 80.258
  PR     90.4678 / 90.3392 tok/s   tau 1.2800   lossless 3/3   AR 80.465 / 80.704

untouched bands, PR build at its default (16512 and 4224 do not cross the threshold):
  ctx=16384  125.3579 / 125.1543   tau 1.7297   lossless 3/3
  ctx=4096   124.2831 / 124.5654   tau 1.6883   lossless 3/3

why the band splits rather than moves (reps=1, lossless everywhere):
  ctx    depth 1            depth 2            main (adaptive)
  16384  115.38 / 115.17    125.58 / 125.50    126.11 / 125.20
  32768   89.34 /  89.39     87.00             87.19 /  87.20
  the second proposal is worth 8.9% at 16k and costs 2.5% at 32k.

why the initial depth is a floor, not a hint: the adaptive controller only promotes from
kInitialProposalDepth and demotes back TO it -- depth_demote_run is gated on
active_proposal_depth > kInitialProposalDepth -- so 32k could not reach depth 1 on its own.
The promotion path is unchanged; a predictable stream at 32k still climbs to 4 or B.

window at ctx=32768, MEAN_ACCEPT identical (1.2800) across the whole range, so this is draft
time removed rather than acceptance traded away:
  window   4096     3072     2048     1024      256
  tok/s   89.28    89.88    90.44    90.79    91.33
  2048, not the faster 256: 512 and 768 sit in a reproducible acceptance dip (tau 1.2673 and
  1.2549), so the narrow end is not a broad peak on this prompt, and 2048 is the constant the
  band below already uses.

tau at 32k moves 1.3333 -> 1.2800, which is 96.0% of main and clears the 95% floor. It is not a
noisy quantity here: 128 tokens over 96 steps against 128 over 100.
```
