### PR TITLE
feat(vision): image input, and the rotary position embeddings the tower was missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ Your own model: `bench/scripts/bench.sh /path/to/model.gguf --tokens 256`. Optio
 | [`moe/`](moe) | sync-free MoE router + expert dispatch |
 | [`bench/`](bench) | reproducible benchmarks + eval harness |
 | [`dashboard/`](dashboard) | static frontier dashboard (GitHub Pages) |
-| [`server/`](server) | OpenAI-compatible HTTP API (`BUILD_SERVER=ON`) |
+| [`server/`](server) | OpenAI-compatible HTTP API (`BUILD_SERVER=ON`), incl. [image input](docs/image_input.md) |
 
 **Scoring is speedup-only.** SN74 pays verified marginal speedups labeled **XL / L / M / S / XS**. Sub-2% gains are never aggregated across contexts. See [`.gittensor/weights.json`](.gittensor/weights.json).
 

--- a/bench/scripts/vision_hf_check.py
+++ b/bench/scripts/vision_hf_check.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Diff our CUDA vision tower against transformers' own Qwen3_5VisionModel.
+
+This exists because bench/scripts/vision_ref.py is NOT independent enough. It is a re-derivation
+written by hand from the architecture, and a re-derivation can miss exactly what the C++ missed --
+which is what happened: both omitted the vision tower's rotary position embeddings, so they agreed
+to cosine 0.999 while both being wrong. Only the real implementation can catch that class of error.
+
+Both sides are fed the SAME pixel tensor, so this tests the tower alone. Ours consumes row-major
+patch order; transformers consumes merge-block-major, so the pixels are permuted for it here.
+
+Usage: vision_hf_check.py <ckpt_dir> --pixels ROWMAJOR.bin --gh GH --gw GW [--compare OURS.bin]
+"""
+import argparse, glob, os, sys
+import numpy as np
+import torch
+from safetensors.torch import load_file
+from transformers import AutoConfig
+from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5VisionModel
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("model_dir"); ap.add_argument("--pixels", required=True)
+    ap.add_argument("--gh", type=int, required=True); ap.add_argument("--gw", type=int, required=True)
+    ap.add_argument("--compare", default=""); ap.add_argument("--dump", default="")
+    a = ap.parse_args()
+
+    cfg = AutoConfig.from_pretrained(a.model_dir).vision_config
+    m = cfg.spatial_merge_size
+    gh, gw = a.gh, a.gw
+    patch_in = cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size ** 2
+
+    pix = np.fromfile(a.pixels, dtype=np.float32).reshape(gh * gw, patch_in)
+
+    # row-major -> merge-block-major. perm[k] is the row-major index of the k-th patch in the
+    # order transformers expects: blocks in raster order, and within a block its m*m patches.
+    perm = np.arange(gh * gw).reshape(gh // m, m, gw // m, m).transpose(0, 2, 1, 3).reshape(-1)
+    pix_mbm = pix[perm]
+
+    # float32 throughout: the point is to isolate an ALGORITHMIC difference, and bf16 noise on a
+    # 27-block tower is large enough (cosine ~0.9993 at 2304 patches) to hide or mimic one.
+    model = Qwen3_5VisionModel._from_config(cfg).to(torch.float32).eval()
+    sd = {}
+    for f in sorted(glob.glob(os.path.join(a.model_dir, "*.safetensors"))):
+        for k, v in load_file(f).items():
+            if k.startswith("model.visual."):
+                sd[k[len("model.visual."):]] = v.to(torch.float32)
+    missing, unexpected = model.load_state_dict(sd, strict=False)
+    missing = [k for k in missing if "inv_freq" not in k]   # buffers, recomputed not stored
+    print(f"loaded vision tower: {len(sd)} tensors, missing={missing[:4]} unexpected={unexpected[:4]}")
+    if missing:
+        print("[FAIL] missing required weights"); sys.exit(1)
+
+    grid_t = torch.tensor([[1, gh, gw]], dtype=torch.long)
+    with torch.no_grad():
+        out = model(torch.from_numpy(pix_mbm.copy()), grid_t).pooler_output
+    ref = out.float().numpy()
+
+    # Run the SAME reference in bf16 to measure what precision alone costs at THIS size, instead
+    # of hardcoding a floor. Attention error accumulates with sequence length, so a bar that is
+    # right at 784 patches is wrong at 6144 -- and a fixed bar would either pass a real bug at
+    # large grids or fail correct code. The floor is measured per invocation for that reason.
+    with torch.no_grad():
+        ref_bf16 = model.to(torch.bfloat16)(
+            torch.from_numpy(pix_mbm.copy()).to(torch.bfloat16), grid_t).pooler_output.float().numpy()
+    model.to(torch.float32)
+    floor = float((ref_bf16.ravel() @ ref.ravel()) /
+                  (np.linalg.norm(ref_bf16) * np.linalg.norm(ref) + 1e-30))
+    print(f"  bf16 noise floor at this size: cosine={floor:.8f}  "
+          f"(reference against itself in bf16 -- our best possible)")
+    print(f"transformers: grid {gh}x{gw} -> {ref.shape[0]} merged embeddings of {ref.shape[1]}")
+    print(f"  mean={ref.mean():+.6f} std={ref.std():.6f} absmax={np.abs(ref).max():.4f}")
+    if a.dump:
+        ref.astype(np.float32).tofile(a.dump); print(f"  dumped -> {a.dump}")
+
+    if not a.compare:
+        return
+    got = np.fromfile(a.compare, dtype=np.float32)
+    if got.size != ref.size:
+        print(f"[FAIL] size mismatch: reference {ref.size}, candidate {got.size}"); sys.exit(1)
+    got = got.reshape(ref.shape)
+    d = np.abs(got - ref)
+    cos = float((got.ravel() @ ref.ravel()) / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-30))
+    print(f"\ncompare vs {a.compare}")
+    print(f"  max|diff|={d.max():.6f}  mean|diff|={d.mean():.6f}  rel={d.max()/max(np.abs(ref).max(),1e-9):.3e}")
+    print(f"  cosine={cos:.8f}   (candidate absmax {np.abs(got).max():.4f} vs reference {np.abs(ref).max():.4f})")
+    # Judged against the MEASURED floor, not a guessed constant: we compute in bf16, so agreeing
+    # with an fp32 reference better than bf16 itself does is not possible. The margin covers our
+    # kernels rounding at different points than torch does, not a different algorithm.
+    print()
+    if cos >= floor - 0.002:
+        print(f"VERDICT: MATCH -- cosine {cos:.6f} is at the bf16 floor {floor:.6f}")
+    else:
+        print(f"VERDICT: MISMATCH -- cosine {cos:.6f} vs bf16 floor {floor:.6f}; "
+              f"the gap ({floor - cos:.6f}) is algorithmic, not precision")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/scripts/vision_hf_check.py
+++ b/bench/scripts/vision_hf_check.py
@@ -22,14 +22,35 @@ from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5VisionModel
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("model_dir"); ap.add_argument("--pixels", required=True)
-    ap.add_argument("--gh", type=int, required=True); ap.add_argument("--gw", type=int, required=True)
+    ap.add_argument("--gh", type=int, default=0); ap.add_argument("--gw", type=int, default=0)
+    ap.add_argument("--image", default="", help="also diff OUR preprocessing against the real "
+                    "AutoImageProcessor for this image, and take the grid from it")
     ap.add_argument("--compare", default=""); ap.add_argument("--dump", default="")
     a = ap.parse_args()
 
     cfg = AutoConfig.from_pretrained(a.model_dir).vision_config
     m = cfg.spatial_merge_size
-    gh, gw = a.gh, a.gw
     patch_in = cfg.in_channels * cfg.temporal_patch_size * cfg.patch_size ** 2
+
+    hf_pix = None
+    if a.image:
+        # The REAL processor. The tower diff below feeds both sides identical pixels, so it can
+        # say nothing about preprocessing conventions -- resize, normalisation, patch order, and
+        # the still-image repeat across the temporal axis were all still resting on a reference
+        # written by the same hand as the code. This is the only check that settles them.
+        from PIL import Image
+        from transformers import AutoImageProcessor
+        ip = AutoImageProcessor.from_pretrained(a.model_dir)
+        enc = ip(images=Image.open(a.image).convert("RGB"), return_tensors="np")
+        hf_pix = np.asarray(enc["pixel_values"], dtype=np.float32)
+        t_, gh, gw = (int(v) for v in np.asarray(enc["image_grid_thw"])[0])
+        print(f"real processor: {a.image} -> grid t={t_} {gh}x{gw}, pixel_values {hf_pix.shape}")
+        if a.gh and (a.gh, a.gw) != (gh, gw):
+            print(f"[FAIL] our grid {a.gh}x{a.gw} != processor grid {gh}x{gw}"); sys.exit(1)
+    else:
+        gh, gw = a.gh, a.gw
+    if gh <= 0 or gw <= 0:
+        print("[FAIL] need --gh/--gw or --image"); sys.exit(1)
 
     pix = np.fromfile(a.pixels, dtype=np.float32).reshape(gh * gw, patch_in)
 
@@ -37,6 +58,19 @@ def main():
     # order transformers expects: blocks in raster order, and within a block its m*m patches.
     perm = np.arange(gh * gw).reshape(gh // m, m, gw // m, m).transpose(0, 2, 1, 3).reshape(-1)
     pix_mbm = pix[perm]
+
+    if hf_pix is not None:
+        if hf_pix.shape != pix_mbm.shape:
+            print(f"[FAIL] processor produced {hf_pix.shape}, we produced {pix_mbm.shape}")
+            sys.exit(1)
+        dp = np.abs(pix_mbm - hf_pix)
+        lsb = (1.0 / 255.0) / 0.5
+        print(f"  preprocessing vs real processor: max|diff|={dp.max():.6f} "
+              f"mean|diff|={dp.mean():.6f}  (one uint8 LSB = {lsb:.6f})")
+        if dp.max() > 1.01 * lsb:
+            print("[FAIL] preprocessing disagrees with the real processor by more than one LSB")
+            sys.exit(1)
+        print("  preprocessing: MATCH")
 
     # float32 throughout: the point is to isolate an ALGORITHMIC difference, and bf16 noise on a
     # 27-block tower is large enough (cosine ~0.9993 at 2304 patches) to hide or mimic one.

--- a/bench/scripts/vision_order_check.py
+++ b/bench/scripts/vision_order_check.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Does patch ORDER change the merged embeddings?
+
+vision_ref.py feeds patches row-major and regroups into 2x2 merge blocks at the merger.
+HF's Qwen2VLImageProcessor feeds them merge-block-major from the start:
+
+    patches.reshape(b, C, gh//m, m, P, gw//m, m, P).permute(0, 2, 5, 3, 6, 1, 4, 7)
+
+Attention here is full and bidirectional, so it is permutation-EQUIVARIANT, and position
+embeddings travel with their own patch in both schemes. The two orderings should therefore cancel
+and produce identical merged rows. That is an argument, not a result -- so run both and diff.
+
+If they disagree, vision_ref.py is emitting image regions in the wrong sequence: correctly shaped,
+correctly normed, confidently wrong, and invisible to every check that is not this one.
+"""
+import importlib.util, json, sys
+import numpy as np
+
+import os
+_HERE = os.path.dirname(os.path.abspath(__file__))
+spec = importlib.util.spec_from_file_location("vr", os.path.join(_HERE, "vision_ref.py"))
+vr = importlib.util.module_from_spec(spec); sys.modules["vr"] = vr; spec.loader.exec_module(vr)
+
+D = sys.argv[1] if len(sys.argv) > 1 else "/workspace/eval/models/qwen38-target"
+cfg = json.load(open(D + "/config.json"))["vision_config"]
+P, T, C = cfg["patch_size"], cfg["temporal_patch_size"], cfg["in_channels"]
+m, H = cfg["spatial_merge_size"], cfg["hidden_size"]
+st = vr.ST(D)
+
+h = w = 64
+gh, gw = h // P, w // P                      # full patch grid
+bh, bw = gh // m, gw // m                    # merge-block grid
+yy, xx = np.meshgrid(np.arange(h), np.arange(w), indexing="ij")
+img = np.stack([(yy / (h - 1)) * 2 - 1, (xx / (w - 1)) * 2 - 1,
+                ((yy + xx) / (h + w - 2)) * 2 - 1]).astype(np.float32)   # [C,H,W]
+
+# --- A: row-major, exactly what vision_ref.py does ---
+a = img.reshape(C, gh, P, gw, P).transpose(1, 3, 0, 2, 4)
+a = np.repeat(a[:, :, :, None], T, axis=3).reshape(gh * gw, C * T * P * P).astype(np.float32)
+out_a = vr.run_tower(st, cfg, a, gh, gw)
+
+# --- B: HF's exact reshape+permute, merge-block-major ---
+b = img.reshape(C, bh, m, P, bw, m, P).transpose(1, 4, 2, 5, 0, 3, 6)   # [bh,bw,m,m,C,P,P]
+b = np.repeat(b[..., None, :, :], T, axis=-3) if False else b           # keep layout explicit
+b = np.stack([b] * T, axis=-3).reshape(gh * gw, C * T * P * P).astype(np.float32) \
+    if False else np.repeat(b.reshape(gh * gw, C, P, P)[:, :, None], T, axis=2).reshape(gh * gw, C * T * P * P).astype(np.float32)
+
+# B needs its position embeddings in the SAME merge-block-major sequence. Build the row-major
+# tower's pos grid, then permute it identically so each patch keeps its own spatial embedding.
+perm = np.arange(gh * gw).reshape(bh, m, bw, m).transpose(0, 2, 1, 3).reshape(-1)  # rowmajor idx per B slot
+def run_B():
+    pos = st.get("model.visual.pos_embed.weight")
+    side = int(round(pos.shape[0] ** 0.5))
+    pg = pos.reshape(side, side, H)
+    ys = np.linspace(0, side - 1, gh); xs = np.linspace(0, side - 1, gw)
+    y0 = np.clip(np.floor(ys).astype(int), 0, side-1); y1 = np.clip(y0+1, 0, side-1)
+    x0 = np.clip(np.floor(xs).astype(int), 0, side-1); x1 = np.clip(x0+1, 0, side-1)
+    wy = (ys - y0)[:, None, None]; wx = (xs - x0)[None, :, None]
+    p = (pg[np.ix_(y0,x0)]*(1-wy)*(1-wx) + pg[np.ix_(y1,x0)]*wy*(1-wx)
+         + pg[np.ix_(y0,x1)]*(1-wy)*wx + pg[np.ix_(y1,x1)]*wy*wx).reshape(gh*gw, H)
+    pw = st.get("model.visual.patch_embed.proj.weight"); pb = st.get("model.visual.patch_embed.proj.bias")
+    x = b @ pw.reshape(H, -1).T + pb
+    x = x + p[perm]                                   # each B slot gets ITS OWN spatial embedding
+    N = x.shape[0]; heads = cfg["num_heads"]; hd = H // heads
+    for i in range(cfg["depth"]):
+        pfx = f"model.visual.blocks.{i}."
+        hh = vr.layernorm(x, st.get(pfx+"norm1.weight"), st.get(pfx+"norm1.bias"))
+        qkv = hh @ st.get(pfx+"attn.qkv.weight").T + st.get(pfx+"attn.qkv.bias")
+        q,k,v = np.split(qkv,3,axis=-1)
+        q=q.reshape(N,heads,hd).transpose(1,0,2); k=k.reshape(N,heads,hd).transpose(1,0,2); v=v.reshape(N,heads,hd).transpose(1,0,2)
+        att = vr.softmax((q@k.transpose(0,2,1))/np.sqrt(hd), axis=-1)
+        o=(att@v).transpose(1,0,2).reshape(N,H)
+        x = x + o @ st.get(pfx+"attn.proj.weight").T + st.get(pfx+"attn.proj.bias")
+        hh = vr.layernorm(x, st.get(pfx+"norm2.weight"), st.get(pfx+"norm2.bias"))
+        hh = vr.gelu_tanh(hh @ st.get(pfx+"mlp.linear_fc1.weight").T + st.get(pfx+"mlp.linear_fc1.bias"))
+        x = x + hh @ st.get(pfx+"mlp.linear_fc2.weight").T + st.get(pfx+"mlp.linear_fc2.bias")
+    x = vr.layernorm(x, st.get("model.visual.merger.norm.weight"), st.get("model.visual.merger.norm.bias"))
+    # already merge-block-major: consecutive m*m rows ARE one block, no transpose needed
+    x = x.reshape(bh*bw, m*m*H)
+    x = vr.gelu_tanh(x @ st.get("model.visual.merger.linear_fc1.weight").T + st.get("model.visual.merger.linear_fc1.bias"))
+    return x @ st.get("model.visual.merger.linear_fc2.weight").T + st.get("model.visual.merger.linear_fc2.bias")
+
+out_b = run_B()
+d = np.abs(out_a - out_b)
+den = max(np.abs(out_a).max(), 1e-9)
+cos = float((out_a.ravel()@out_b.ravel())/(np.linalg.norm(out_a)*np.linalg.norm(out_b)))
+print(f"A row-major (vision_ref) : {out_a.shape}  absmax={np.abs(out_a).max():.4f}")
+print(f"B merge-block-major (HF) : {out_b.shape}  absmax={np.abs(out_b).max():.4f}")
+print(f"max|A-B| = {d.max():.3e}   rel = {d.max()/den:.3e}   cosine = {cos:.10f}")
+ok = d.max()/den < 1e-4
+print("VERDICT:", "orderings AGREE -- vision_ref is correct" if ok
+      else "orderings DISAGREE -- vision_ref emits regions in the wrong sequence")
+sys.exit(0 if ok else 1)

--- a/bench/scripts/vision_preprocess_ref.py
+++ b/bench/scripts/vision_preprocess_ref.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""PIL/HF reference for image preprocessing, to judge vision_preprocess_check's dump.
+
+Written from transformers' Qwen2VLImageProcessor, not from sparkinfer's C++, for the same reason
+vision_ref.py is: a differential written by mirroring the thing under test validates arithmetic,
+not convention.
+
+The ordering subtlety this exists to measure: HF resizes the **uint8** image through PIL and only
+then rescales to [0,1] and normalizes. sparkinfer rescales to float first and resizes in float.
+Resampling is linear, so the scaling itself commutes -- but PIL's uint8 path ROUNDS to integers
+and CLAMPS bicubic's overshoot at high-contrast edges, and neither of those commutes. So this
+reports our dump against both orders:
+
+  hf_uint8  -- what transformers actually computes (the bar that matters)
+  float32   -- PIL's own resampler run in float, isolating rounding/clamping from resampler bugs
+
+If we match float32 closely but not hf_uint8, the resampler is correct and the gap is purely the
+rescale-before-resize ordering. If we match neither, the resampler itself is wrong.
+
+Usage: vision_preprocess_ref.py <ckpt_dir> <image> [--compare FILE]
+"""
+import argparse, json, math, os, sys
+import numpy as np
+from PIL import Image
+
+
+def smart_resize(height, width, factor, min_pixels, max_pixels):
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError("absolute aspect ratio must be smaller than 200")
+    rnd = lambda n: int(round(n / factor)) * factor      # noqa: E731  (Python's banker's rounding)
+    flr = lambda n: int(math.floor(n / factor)) * factor  # noqa: E731
+    cel = lambda n: int(math.ceil(n / factor)) * factor   # noqa: E731
+    h_bar, w_bar = max(factor, rnd(height)), max(factor, rnd(width))
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar, w_bar = flr(height / beta), flr(width / beta)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar, w_bar = cel(height * beta), cel(width * beta)
+    return h_bar, w_bar
+
+
+def patchify(arr, gh, gw, C, T, P):
+    """[C,H,W] -> [gh*gw, C*T*P*P], each patch laid out (C,T,P,P), still image repeated over T."""
+    x = arr.reshape(C, gh, P, gw, P).transpose(1, 3, 0, 2, 4)      # [gh,gw,C,P,P]
+    x = np.repeat(x[:, :, :, None], T, axis=3)                     # [gh,gw,C,T,P,P]
+    return x.reshape(gh * gw, C * T * P * P).astype(np.float32)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("model_dir"); ap.add_argument("image")
+    ap.add_argument("--compare", default="")
+    a = ap.parse_args()
+
+    cfg = json.load(open(os.path.join(a.model_dir, "config.json")))["vision_config"]
+    P, T, C = cfg["patch_size"], cfg["temporal_patch_size"], cfg["in_channels"]
+    merge = cfg["spatial_merge_size"]
+    factor = P * merge
+    mean = np.array(cfg.get("image_mean", [0.5, 0.5, 0.5]), np.float32).reshape(3, 1, 1)
+    std = np.array(cfg.get("image_std", [0.5, 0.5, 0.5]), np.float32).reshape(3, 1, 1)
+    min_px, max_px = 65536, 16777216
+
+    im = Image.open(a.image).convert("RGB")
+    w, h = im.size
+    h_bar, w_bar = smart_resize(h, w, factor, min_px, max_px)
+    gh, gw = h_bar // P, w_bar // P
+    print(f"image {w}x{h} -> resized {w_bar}x{h_bar} -> patch grid {gh}x{gw} = {gh*gw} patches")
+    if (h_bar, w_bar) == (h, w):
+        print("  NOTE: smart_resize is the IDENTITY here -- this image does not exercise the resampler")
+
+    # (a) exactly what transformers does: PIL resize on uint8, then rescale, then normalize
+    u8 = np.asarray(im.resize((w_bar, h_bar), Image.BICUBIC), dtype=np.uint8)
+    hf = (u8.astype(np.float32).transpose(2, 0, 1) / 255.0 - mean) / std
+
+    # (b) PIL's same resampler in float, per channel ('F' mode is single-channel), no round/clamp
+    src = np.asarray(im, dtype=np.float32).transpose(2, 0, 1) / 255.0
+    fl = np.stack([np.asarray(Image.fromarray(src[c], mode="F").resize((w_bar, h_bar), Image.BICUBIC),
+                              dtype=np.float32) for c in range(C)])
+    fl = (fl - mean) / std
+
+    # (c) torchvision's bicubic: identical separable/antialias structure, but a = -0.75 rather
+    # than PIL's -0.5. preprocessor_config.json declares Qwen2VLImageProcessorFast (torchvision),
+    # while processor_config.json declares the slow PIL one, so which is "the" reference is
+    # genuinely ambiguous -- this quantifies what the choice costs.
+    def tv_resize(src_u8, oh, ow, a=-0.75):
+        def cubic(x):
+            x = np.abs(x)
+            return np.where(x < 1, ((a + 2) * x - (a + 3)) * x * x + 1,
+                   np.where(x < 2, (((x - 5) * x + 8) * x - 4) * a, 0.0))
+        def axis(arr, out_len, ax):
+            in_len = arr.shape[ax]
+            sc = in_len / out_len
+            fs = max(sc, 1.0)
+            o = np.arange(out_len)
+            ctr = (o + 0.5) * sc
+            lo = np.maximum(0, np.floor(ctr - 2 * fs + 0.5).astype(int))
+            hi = np.minimum(in_len, np.floor(ctr + 2 * fs + 0.5).astype(int))
+            out = np.zeros(tuple(out_len if i == ax else d for i, d in enumerate(arr.shape)), np.float64)
+            for k in range(out_len):
+                idx = np.arange(lo[k], hi[k])
+                w = cubic(((idx + 0.5) - ctr[k]) / fs)
+                w = w / w.sum()
+                sl = np.take(arr, idx, axis=ax)
+                sh = [1] * arr.ndim; sh[ax] = len(idx)
+                np.copyto(np.take(out, [k], axis=ax), 0)
+                acc = (sl * w.reshape(sh)).sum(axis=ax)
+                if ax == 0: out[k] = acc
+                else: out[:, k] = acc
+            return out
+        x = axis(src_u8.astype(np.float64), ow, 1)
+        x = axis(x, oh, 0)
+        return np.clip(np.floor(x + 0.5), 0, 255)
+
+    src_u8 = np.asarray(im, dtype=np.uint8).transpose(2, 0, 1)
+    tv = np.stack([tv_resize(src_u8[c], h_bar, w_bar) for c in range(C)]).astype(np.float32)
+    tv = (tv / 255.0 - mean) / std
+
+    refs = {"hf_uint8": patchify(hf, gh, gw, C, T, P), "float32": patchify(fl, gh, gw, C, T, P),
+            "tv_uint8": patchify(tv, gh, gw, C, T, P)}
+    print(f"  hf_uint8 vs float32 differ by max {np.abs(refs['hf_uint8']-refs['float32']).max():.6f}"
+          f"  (this is the rounding/clamping the orders disagree on)")
+
+    if not a.compare:
+        return
+    got = np.fromfile(a.compare, dtype=np.float32)
+    if got.size != refs["hf_uint8"].size:
+        print(f"[FAIL] size mismatch: reference {refs['hf_uint8'].size}, candidate {got.size}")
+        sys.exit(1)
+    got = got.reshape(refs["hf_uint8"].shape)
+    print(f"\ncompare vs {a.compare}")
+    results = {}
+    for name, ref in refs.items():
+        d = np.abs(got - ref)
+        den = max(float(np.abs(ref).max()), 1e-9)
+        cos = float((got.ravel() @ ref.ravel()) / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-30))
+        results[name] = (float(d.max()), float(d.max()) / den, cos, float(d.mean()))
+        print(f"  vs {name:9s} max|diff|={d.max():.6f}  rel={d.max()/den:.3e}  "
+              f"mean|diff|={d.mean():.6f}  cosine={cos:.8f}")
+
+    # The bar is agreement with what transformers ACTUALLY computes (hf_uint8), and it is tight
+    # on purpose: an earlier version of this script passed a preprocessor that was off by 0.127,
+    # because it judged on cosine, which barely moves when a few edge pixels are wrong. A gate
+    # that passes before and after a real fix is not a gate.
+    #
+    # The irreducible floor is one uint8 LSB -- PIL accumulates its 8-bit passes in fixed point,
+    # so exact .5 ties can break either way. Anything above that is a genuine divergence: wrong
+    # rescale/resize order, a missing intermediate round, or the wrong cubic coefficient.
+    lsb = (1.0 / 255.0) / float(min(std.ravel()))
+    max_hf, _, cos_hf, mean_hf = results["hf_uint8"]
+    print(f"  one uint8 LSB in normalized units = {lsb:.6f}")
+    print()
+    if max_hf <= 1.01 * lsb and mean_hf <= 0.01 * lsb:
+        print(f"VERDICT: MATCH -- within one uint8 LSB of transformers "
+              f"(max {max_hf:.6f} <= {lsb:.6f}, mean {mean_hf:.6f})")
+    else:
+        print(f"VERDICT: MISMATCH -- max {max_hf:.6f} vs 1 LSB {lsb:.6f}, mean {mean_hf:.6f}")
+        print("  vs float32 closer than vs hf_uint8 => rescale/resize ORDER or intermediate "
+              "rounding is wrong; vs tv_uint8 closer => cubic coefficient is wrong")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/scripts/vision_ref.py
+++ b/bench/scripts/vision_ref.py
@@ -133,6 +133,7 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("model_dir"); ap.add_argument("--h", type=int, default=64)
     ap.add_argument("--w", type=int, default=64); ap.add_argument("--dump", default="")
+    ap.add_argument("--compare", default="", help="raw f32 file from vision_forward_check to judge")
     a = ap.parse_args()
     cfg = json.load(open(os.path.join(a.model_dir, "config.json")))["vision_config"]
     P, T, C, merge = cfg["patch_size"], cfg["temporal_patch_size"], cfg["in_channels"], cfg["spatial_merge_size"]
@@ -170,6 +171,41 @@ def main():
     if a.dump:
         np.savez(a.dump, pixels=pixels, out=out, **trace)
         print(f"dumped -> {a.dump}")
+
+    if a.compare:
+        # The tolerance lives HERE, not in the C++ binary, so the two cannot drift apart.
+        got = np.fromfile(a.compare, dtype=np.float32)
+        if got.size != out.size:
+            print(f"[FAIL] size mismatch: reference {out.size}, candidate {got.size}")
+            sys.exit(1)
+        got = got.reshape(out.shape)
+        d = np.abs(got - out)
+        den = max(float(np.abs(out).max()), 1e-9)
+        rel = float(d.max()) / den
+        cos = float((got.ravel() @ out.ravel()) /
+                    (np.linalg.norm(got) * np.linalg.norm(out) + 1e-30))
+        print(f"\ncompare vs {a.compare}")
+        print(f"  max|diff| = {d.max():.6f}   rel = {rel:.3e}   cosine = {cos:.8f}")
+        print(f"  reference absmax = {np.abs(out).max():.4f}   candidate absmax = {np.abs(got).max():.4f}")
+        # COSINE is the bar, not max-relative. Measured on the released weights by re-running
+        # this reference with every intermediate rounded to bf16 (what the CUDA path stores),
+        # bf16 ALONE costs:
+        #
+        #     256x256 ( 256 patches)   rel 1.73e-02   cos 0.99980
+        #     768x768 (2304 patches)   rel 4.64e-02   cos 0.99934
+        #
+        # So max-relative on the single largest element is dominated by bf16 noise that grows
+        # with patch count, and any fixed threshold on it is either unreachable at scale or
+        # useless at small sizes. An earlier 2% bar sat BELOW the noise floor at 768x768 and
+        # failed a correct implementation.
+        #
+        # Cosine over the whole tensor is stable across sizes (>= 0.9987 measured) and still
+        # collapses instantly under a real convention error -- a causal mask, a wrong patch
+        # order or the erf-GELU moves it to 0.9x or worse, not to the fourth decimal.
+        ok = cos > 0.998 and rel < 0.25
+        print("VERDICT:", "MATCH -- CUDA tower agrees with the reference" if ok
+              else "MISMATCH -- the CUDA tower does not implement this architecture")
+        sys.exit(0 if ok else 1)
 
 if __name__ == "__main__":
     main()

--- a/bench/scripts/vision_ref.py
+++ b/bench/scripts/vision_ref.py
@@ -85,6 +85,8 @@ def run_tower(st, cfg, pixels, grid_h, grid_w, trace=None):
 
     # learned position embedding, bilinearly resampled from the 48x48 table to this grid --
     # Qwen3-VL interpolates rather than truncating, so a non-48 grid is not a slice.
+    # The table is 48x48. At a 48x48 patch grid (a 768x768 image) the resample below is the
+    # identity, which is the shape to validate at first -- it removes interpolation as a variable.
     pos = st.get("model.visual.pos_embed.weight")                # [2304, H]
     side = int(round(pos.shape[0] ** 0.5))
     pg = pos.reshape(side, side, H)
@@ -148,6 +150,12 @@ def main():
                     ((yy + xx) / max(a.h + a.w - 2, 1)) * 2 - 1]).astype(np.float32)  # [C,H,W]
     # patchify: [C,H,W] -> [gh*gw, C*T*P*P]; a still image repeats across the temporal axis.
     pt = img.reshape(C, gh, P, gw, P).transpose(1, 3, 0, 2, 4)           # [gh,gw,C,P,P]
+    # A still image is REPEATED across the temporal axis, not zero-padded. Verified against the
+    # released weights rather than assumed: the Conv3d's two temporal slices are cosine 0.997
+    # similar (max|t0-t1| 0.005 against absmax 0.075). Filters that similar can only arise if both
+    # slices always saw the same input in training. Zero-padding slice 1 would have left it
+    # without image gradient -- it would look random or near-zero, not 99.7% correlated with
+    # slice 0. Getting this backwards halves or doubles the patch-embed signal.
     pt = np.repeat(pt[:, :, :, None], T, axis=3)                         # [gh,gw,C,T,P,P]
     pixels = pt.reshape(gh * gw, C * T * P * P).astype(np.float32)
 

--- a/bench/scripts/vision_ref.py
+++ b/bench/scripts/vision_ref.py
@@ -100,6 +100,25 @@ def run_tower(st, cfg, pixels, grid_h, grid_w, trace=None):
     if trace is not None: trace["after_pos_embed"] = x.copy()
 
     N = x.shape[0]
+
+    # 2D rotary, applied to q and k in every block. A head_dim/2-wide frequency vector -- first
+    # half driven by the patch's ROW, second by its COLUMN -- concatenated with itself to head_dim
+    # before cos/sin, then q <- q*cos + rotate_half(q)*sin.
+    #
+    # This file originally omitted it, and so did the CUDA it exists to check, so the two agreed
+    # at cosine 0.999 while BOTH disagreed with transformers at 0.77. That is the precise failure
+    # mode a hand-written reference has: it can only catch errors its author did not also make.
+    # bench/scripts/vision_hf_check.py diffs against transformers itself and is the real gate.
+    half, per_axis = hd // 2, hd // 4
+    inv = 10000.0 ** (-np.arange(per_axis, dtype=np.float64) / per_axis)
+    rr, cc = np.meshgrid(np.arange(grid_h), np.arange(grid_w), indexing="ij")
+    freqs = np.concatenate([rr.reshape(-1, 1) * inv, cc.reshape(-1, 1) * inv], axis=1)   # [N, half]
+    emb = np.concatenate([freqs, freqs], axis=1)                                         # [N, hd]
+    rcos, rsin = np.cos(emb), np.sin(emb)
+
+    def rotate_half(t):                       # t: [heads, N, hd]
+        return np.concatenate([-t[..., half:], t[..., :half]], axis=-1)
+
     for b in range(depth):
         pfx = f"model.visual.blocks.{b}."
         h = layernorm(x, st.get(pfx + "norm1.weight"), st.get(pfx + "norm1.bias"))
@@ -108,6 +127,8 @@ def run_tower(st, cfg, pixels, grid_h, grid_w, trace=None):
         q = q.reshape(N, heads, hd).transpose(1, 0, 2)
         k = k.reshape(N, heads, hd).transpose(1, 0, 2)
         v = v.reshape(N, heads, hd).transpose(1, 0, 2)
+        q = q * rcos + rotate_half(q) * rsin
+        k = k * rcos + rotate_half(k) * rsin
         # FULL bidirectional attention over all patches -- no causal mask. A causal mask here is
         # the classic silent bug: it still produces embeddings, just wrong ones.
         att = softmax((q @ k.transpose(0, 2, 1)) / np.sqrt(hd), axis=-1)

--- a/bench/scripts/vision_ref.py
+++ b/bench/scripts/vision_ref.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""NumPy reference for Qwen3.8-27B's vision tower, read straight from checkpoint bytes.
+
+This is GROUND TRUTH for the CUDA implementation, so it is deliberately written from the
+architecture (config.json + HF's Qwen3-VL definition) rather than by mirroring sparkinfer's C++.
+A differential written by copying the thing under test validates arithmetic, not convention --
+that mistake cost real time on the DSpark draft, where a q-only YaRN scale matched our own code
+and was wrong against HF.
+
+No torch, no safetensors package: just mmap + the flat JSON header + numpy.
+
+Usage: vision_ref.py <checkpoint_dir> [--h 64 --w 64] [--dump out.npz]
+"""
+import argparse, glob, json, mmap, os, struct, sys
+import numpy as np
+
+# ---------- checkpoint reader ----------
+class ST:
+    def __init__(self, d):
+        self.maps, self.index = [], {}
+        for f in sorted(glob.glob(os.path.join(d, "*.safetensors"))):
+            fh = open(f, "rb")
+            n = struct.unpack("<Q", fh.read(8))[0]
+            hdr = json.loads(fh.read(n))
+            mm = mmap.mmap(fh.fileno(), 0, access=mmap.ACCESS_READ)
+            base = 8 + n
+            self.maps.append((fh, mm))
+            for k, v in hdr.items():
+                if k == "__metadata__":
+                    continue
+                self.index[k] = (mm, base + v["data_offsets"][0], base + v["data_offsets"][1],
+                                 v["dtype"], tuple(v["shape"]))
+
+    def get(self, name):
+        if name not in self.index:
+            raise KeyError(name)
+        mm, a, b, dt, shape = self.index[name]
+        raw = mm[a:b]
+        if dt == "BF16":
+            u16 = np.frombuffer(raw, dtype=np.uint16)
+            # bf16 -> f32 is a pure left shift into the high half; no table, no rounding.
+            out = (u16.astype(np.uint32) << 16).view(np.float32)
+        elif dt == "F32":
+            out = np.frombuffer(raw, dtype=np.float32)
+        elif dt == "F16":
+            out = np.frombuffer(raw, dtype=np.float16).astype(np.float32)
+        else:
+            raise ValueError(f"{name}: unhandled dtype {dt}")
+        return out.reshape(shape)
+
+# ---------- ops ----------
+# eps is NOT in the checkpoint's vision_config. It does not matter: measured on the released
+# weights, 1e-6 vs torch's 1e-5 default differ by rel 1.5e-05 / cosine 0.9999999995 on the final
+# merged embeddings -- far below what bf16 CUDA arithmetic will contribute. The norms carry both
+# `weight` and `bias`, which settles the other half of the question: LayerNorm, not RMSNorm.
+def layernorm(x, w, b, eps=1e-6):
+    mu = x.mean(-1, keepdims=True)
+    var = x.var(-1, keepdims=True)
+    return (x - mu) / np.sqrt(var + eps) * w + b
+
+def gelu_tanh(x):
+    # gelu_pytorch_tanh: the tanh approximation, NOT the erf form. They differ by ~1e-3 at the
+    # knee, which is far above the tolerance a 27-block tower needs.
+    return 0.5 * x * (1.0 + np.tanh(0.7978845608028654 * (x + 0.044715 * x ** 3)))
+
+def softmax(x, axis=-1):
+    m = x.max(axis=axis, keepdims=True)
+    e = np.exp(x - m)
+    return e / e.sum(axis=axis, keepdims=True)
+
+# ---------- tower ----------
+def run_tower(st, cfg, pixels, grid_h, grid_w, trace=None):
+    """pixels: [n_patches, in_ch * temporal * patch * patch] already patchified.
+    Returns merged embeddings [n_patches // merge^2, out_hidden]."""
+    H, heads = cfg["hidden_size"], cfg["num_heads"]
+    hd = H // heads
+    depth, inter = cfg["depth"], cfg["intermediate_size"]
+    merge = cfg["spatial_merge_size"]
+
+    # patch embed: the Conv3d is a dense matmul over each flattened patch.
+    pw = st.get("model.visual.patch_embed.proj.weight")          # [H, C, T, P, P]
+    pb = st.get("model.visual.patch_embed.proj.bias")            # [H]
+    x = pixels @ pw.reshape(H, -1).T + pb                        # [N, H]
+    if trace is not None: trace["after_patch_embed"] = x.copy()
+
+    # learned position embedding, bilinearly resampled from the 48x48 table to this grid --
+    # Qwen3-VL interpolates rather than truncating, so a non-48 grid is not a slice.
+    pos = st.get("model.visual.pos_embed.weight")                # [2304, H]
+    side = int(round(pos.shape[0] ** 0.5))
+    pg = pos.reshape(side, side, H)
+    ys = np.linspace(0, side - 1, grid_h); xs = np.linspace(0, side - 1, grid_w)
+    y0 = np.clip(np.floor(ys).astype(int), 0, side - 1); y1 = np.clip(y0 + 1, 0, side - 1)
+    x0 = np.clip(np.floor(xs).astype(int), 0, side - 1); x1 = np.clip(x0 + 1, 0, side - 1)
+    wy = (ys - y0)[:, None, None]; wx = (xs - x0)[None, :, None]
+    p = (pg[np.ix_(y0, x0)] * (1 - wy) * (1 - wx) + pg[np.ix_(y1, x0)] * wy * (1 - wx)
+         + pg[np.ix_(y0, x1)] * (1 - wy) * wx + pg[np.ix_(y1, x1)] * wy * wx)
+    x = x + p.reshape(grid_h * grid_w, H)
+    if trace is not None: trace["after_pos_embed"] = x.copy()
+
+    N = x.shape[0]
+    for b in range(depth):
+        pfx = f"model.visual.blocks.{b}."
+        h = layernorm(x, st.get(pfx + "norm1.weight"), st.get(pfx + "norm1.bias"))
+        qkv = h @ st.get(pfx + "attn.qkv.weight").T + st.get(pfx + "attn.qkv.bias")   # [N, 3H]
+        q, k, v = np.split(qkv, 3, axis=-1)
+        q = q.reshape(N, heads, hd).transpose(1, 0, 2)
+        k = k.reshape(N, heads, hd).transpose(1, 0, 2)
+        v = v.reshape(N, heads, hd).transpose(1, 0, 2)
+        # FULL bidirectional attention over all patches -- no causal mask. A causal mask here is
+        # the classic silent bug: it still produces embeddings, just wrong ones.
+        att = softmax((q @ k.transpose(0, 2, 1)) / np.sqrt(hd), axis=-1)
+        o = (att @ v).transpose(1, 0, 2).reshape(N, H)
+        x = x + o @ st.get(pfx + "attn.proj.weight").T + st.get(pfx + "attn.proj.bias")
+        h = layernorm(x, st.get(pfx + "norm2.weight"), st.get(pfx + "norm2.bias"))
+        h = gelu_tanh(h @ st.get(pfx + "mlp.linear_fc1.weight").T + st.get(pfx + "mlp.linear_fc1.bias"))
+        x = x + h @ st.get(pfx + "mlp.linear_fc2.weight").T + st.get(pfx + "mlp.linear_fc2.bias")
+        if trace is not None and b in (0, depth // 2, depth - 1):
+            trace[f"after_block_{b}"] = x.copy()
+
+    # merger: norm per patch, then group each 2x2 spatial block into one row.
+    x = layernorm(x, st.get("model.visual.merger.norm.weight"), st.get("model.visual.merger.norm.bias"))
+    gh, gw = grid_h // merge, grid_w // merge
+    x = (x.reshape(gh, merge, gw, merge, H).transpose(0, 2, 1, 3, 4).reshape(gh * gw, merge * merge * H))
+    x = gelu_tanh(x @ st.get("model.visual.merger.linear_fc1.weight").T
+                  + st.get("model.visual.merger.linear_fc1.bias"))
+    x = x @ st.get("model.visual.merger.linear_fc2.weight").T + st.get("model.visual.merger.linear_fc2.bias")
+    if trace is not None: trace["merged"] = x.copy()
+    return x
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("model_dir"); ap.add_argument("--h", type=int, default=64)
+    ap.add_argument("--w", type=int, default=64); ap.add_argument("--dump", default="")
+    a = ap.parse_args()
+    cfg = json.load(open(os.path.join(a.model_dir, "config.json")))["vision_config"]
+    P, T, C, merge = cfg["patch_size"], cfg["temporal_patch_size"], cfg["in_channels"], cfg["spatial_merge_size"]
+    gran = P * merge
+    if a.h % gran or a.w % gran:
+        sys.exit(f"image dims must be multiples of {gran}")
+    gh, gw = a.h // P, a.w // P
+
+    # Deterministic synthetic image in [-1, 1], so the C++ side can reproduce the exact input
+    # without an image decoder existing yet. A smooth ramp, not noise: a wrong patch order or a
+    # transposed grid shows up as structure, where noise would just look like noise.
+    yy, xx = np.meshgrid(np.arange(a.h), np.arange(a.w), indexing="ij")
+    img = np.stack([(yy / max(a.h - 1, 1)) * 2 - 1,
+                    (xx / max(a.w - 1, 1)) * 2 - 1,
+                    ((yy + xx) / max(a.h + a.w - 2, 1)) * 2 - 1]).astype(np.float32)  # [C,H,W]
+    # patchify: [C,H,W] -> [gh*gw, C*T*P*P]; a still image repeats across the temporal axis.
+    pt = img.reshape(C, gh, P, gw, P).transpose(1, 3, 0, 2, 4)           # [gh,gw,C,P,P]
+    pt = np.repeat(pt[:, :, :, None], T, axis=3)                         # [gh,gw,C,T,P,P]
+    pixels = pt.reshape(gh * gw, C * T * P * P).astype(np.float32)
+
+    st = ST(a.model_dir)
+    trace = {}
+    out = run_tower(st, cfg, pixels, gh, gw, trace)
+    print(f"image {a.h}x{a.w} -> patch grid {gh}x{gw} = {gh*gw} patches -> {out.shape[0]} merged embeddings")
+    print(f"output shape {out.shape} (expect [{gh//merge*gw//merge}, {cfg['out_hidden_size']}])")
+    for k, v in trace.items():
+        print(f"  {k:22s} shape={str(v.shape):16s} mean={v.mean():+.6f} std={v.std():.6f} "
+              f"absmax={np.abs(v).max():.4f} sum={v.sum():+.6f}")
+    if a.dump:
+        np.savez(a.dump, pixels=pixels, out=out, **trace)
+        print(f"dumped -> {a.dump}")
+
+if __name__ == "__main__":
+    main()

--- a/bench/scripts/vision_resize_check.py
+++ b/bench/scripts/vision_resize_check.py
@@ -26,7 +26,9 @@ def smart_resize(height, width, factor, min_pixels, max_pixels):
     return h_bar, w_bar
 
 lines = open(sys.argv[1]).read().splitlines()
-hdr = next(l for l in lines if l.startswith("#"))
+# Match the PARAMETER header specifically: the candidate also prints "# <check> ok" lines
+# for the placeholder-expansion checks, and taking the first "#" line grabbed one of those.
+hdr = next(l for l in lines if l.startswith("#") and "factor=" in l)
 factor = int(re.search(r"factor=(\d+)", hdr).group(1))
 minp = int(re.search(r"min_pixels=(\d+)", hdr).group(1))
 maxp = int(re.search(r"max_pixels=(\d+)", hdr).group(1))

--- a/bench/scripts/vision_resize_check.py
+++ b/bench/scripts/vision_resize_check.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Diff vision_resize_check's smart_resize output against the transformers original.
+
+Exact integer logic on both sides, so this is a strict equality check -- no tolerance. An
+off-by-one changes the patch grid, which changes how many image placeholder tokens the prompt
+must carry, which silently misaligns the whole embedding splice.
+
+Usage:  vision_resize_check <candidate.txt>
+"""
+import math, re, sys
+
+def smart_resize(height, width, factor, min_pixels, max_pixels):
+    """Verbatim from transformers/models/qwen2_vl/image_processing_qwen2_vl.py."""
+    if max(height, width) / min(height, width) > 200:
+        raise ValueError("aspect")
+    h_bar = round(height / factor) * factor
+    w_bar = round(width / factor) * factor
+    if h_bar * w_bar > max_pixels:
+        beta = math.sqrt((height * width) / max_pixels)
+        h_bar = max(factor, math.floor(height / beta / factor) * factor)
+        w_bar = max(factor, math.floor(width / beta / factor) * factor)
+    elif h_bar * w_bar < min_pixels:
+        beta = math.sqrt(min_pixels / (height * width))
+        h_bar = math.ceil(height * beta / factor) * factor
+        w_bar = math.ceil(width * beta / factor) * factor
+    return h_bar, w_bar
+
+lines = open(sys.argv[1]).read().splitlines()
+hdr = next(l for l in lines if l.startswith("#"))
+factor = int(re.search(r"factor=(\d+)", hdr).group(1))
+minp = int(re.search(r"min_pixels=(\d+)", hdr).group(1))
+maxp = int(re.search(r"max_pixels=(\d+)", hdr).group(1))
+
+n = bad = 0
+for l in lines:
+    if l.startswith("#") or not l.strip():
+        continue
+    m = re.match(r"(\d+) (\d+) -> (ERR|(\d+) (\d+))", l)
+    h, w = int(m.group(1)), int(m.group(2))
+    try:
+        want = smart_resize(h, w, factor, minp, maxp)
+    except ValueError:
+        want = None
+    got = None if m.group(3) == "ERR" else (int(m.group(4)), int(m.group(5)))
+    n += 1
+    if got != want:
+        bad += 1
+        if bad <= 10:
+            print(f"  MISMATCH {h}x{w}: candidate {got}, reference {want}")
+print(f"{n} cases, {bad} mismatches")
+print("VERDICT:", "MATCH -- smart_resize is a faithful port" if bad == 0 else "MISMATCH")
+sys.exit(0 if bad == 0 else 1)

--- a/docs/image_input.md
+++ b/docs/image_input.md
@@ -1,0 +1,100 @@
+# Image input
+
+sparkinfer accepts images as **input** on checkpoints that ship a vision tower. It does not
+generate images.
+
+The tower loads automatically when the checkpoint's `config.json` has a `vision_config` block —
+Qwen3.8-27B does. A text-only checkpoint simply has none, `has_vision()` stays false, and a
+request carrying an image is refused rather than answered from its text alone (a silently dropped
+image produces a fluent, confident description of something the model never saw).
+
+## API
+
+Standard OpenAI content parts on `POST /v1/chat/completions`:
+
+```json
+{
+  "model": "qwen3.8-27b",
+  "messages": [{
+    "role": "user",
+    "content": [
+      {"type": "image_url", "image_url": {"url": "data:image/png;base64,iVBORw0KG..."}},
+      {"type": "text", "text": "What object is shown in this image?"}
+    ]
+  }]
+}
+```
+
+PNG, JPEG and BMP decode — the only three stb_image decoders compiled in. Alpha is dropped rather
+than composited, matching what the reference processor does when it converts to RGB.
+
+Several images in one request work, and they may be different sizes; each expands to the token
+count its own resized grid needs. Text and image parts interleave in the order given.
+
+### `data:` URLs only
+
+A remote `http(s)` URL is **refused**, not fetched:
+
+```
+image 0: only data: URLs are accepted; remote image fetching is disabled by policy
+(it would let a request drive server-side HTTP to arbitrary hosts)
+```
+
+An inference server that fetches URLs on request is an SSRF primitive — internal metadata
+endpoints, private hosts, anything the box can reach. Whether to accept that is a deployment
+decision for whoever runs the server, not a default.
+
+### Other endpoints
+
+`/v1/tokenize` and `/v1/score` reject requests containing images. Neither can answer honestly: an
+image's token count depends on its resized grid, so tokenize would report a number short by
+hundreds of tokens, and a scoring endpoint returning logprobs for the text alone defeats the one
+thing it exists for. Non-image non-text parts (audio) are still ignored everywhere, so mixed
+payloads from provider-agnostic clients keep working.
+
+Images in a `system`/`developer` message are rejected, mirroring the chat template, which raises
+on exactly that.
+
+## Token accounting
+
+The template emits **one** `<|image_pad|>` per image. The processor — not the template — expands
+it, because only the processor knows the resized grid:
+
+    tokens = (grid_h / merge) * (grid_w / merge)      # merge = spatial_merge_size = 2
+
+A 1024x1536 image is a 96x64 patch grid, so 1536 tokens. Budget for that: images dominate the
+prompt. Expansion happens before the context-length check, so an image that does not fit is
+rejected up front rather than failing inside prefill.
+
+## Verification
+
+The tower and the preprocessing are both diffed against **transformers itself**, not against a
+reimplementation:
+
+```bash
+# tower: our CUDA vs transformers' Qwen3_5VisionModel, on identical pixels
+build/runtime/vision_preprocess_check  $MODEL_DIR image.png --out /tmp/px.bin
+build/runtime/vision_forward_check     $MODEL_DIR --pixels /tmp/px.bin --gh 28 --gw 28 --out /tmp/ours.bin
+python bench/scripts/vision_hf_check.py $MODEL_DIR --pixels /tmp/px.bin --gh 28 --gw 28 \
+                                        --compare /tmp/ours.bin --image image.png
+```
+
+That needs `torch` + `transformers` (CPU is fine — the reference forward does not need the GPU).
+The `--image` flag additionally runs the real `AutoImageProcessor` and diffs our preprocessing
+against it.
+
+Both gates judge against a **measured** floor rather than a constant: the tower against the bf16
+noise floor computed per invocation (it moves with grid size — 0.99887 at 784 patches, 0.99562 at
+2204), and preprocessing against one uint8 LSB, which is the irreducible disagreement from PIL
+accumulating its 8-bit passes in fixed point.
+
+`bench/scripts/vision_ref.py` is a hand-written NumPy reference kept for fast iteration. It is
+**not** the gate: it and the CUDA once shared an omission — neither applied the tower's rotary
+position embeddings — and agreed with each other at cosine 0.99915 while both disagreed with
+transformers at 0.77. A reference written by the same hand as the code can only catch mistakes its
+author did not also make.
+
+## Not supported
+
+Video input, and checkpoints with a non-empty `deepstack_visual_indexes` (refused at load rather
+than silently ignored). The tower runs in bf16.

--- a/kernels/CMakeLists.txt
+++ b/kernels/CMakeLists.txt
@@ -59,8 +59,9 @@ add_subdirectory(csrc/cuda/gemm)        # GEMM, GEMV, batched GEMM
 add_subdirectory(csrc/cuda/moe)         # MoE router, grouped GEMM + SwiGLU
 add_subdirectory(csrc/cuda/quant)       # quantization helpers
 add_subdirectory(csrc/cuda/fused)       # fused GEMM + epilogue (non-CuTe path)
+add_subdirectory(csrc/cuda/vision)      # vision tower: LayerNorm, GELU, patch attention
 
-set(SPARKINFER_KERNEL_LIBS si_attn si_gemm si_moe si_quant si_fused)
+set(SPARKINFER_KERNEL_LIBS si_attn si_gemm si_moe si_quant si_fused si_vision)
 
 if(MSVC)
   # MSVC device link of RDC static libs into a DLL is brittle; whole-TU compile is fine.

--- a/kernels/csrc/cuda/vision/CMakeLists.txt
+++ b/kernels/csrc/cuda/vision/CMakeLists.txt
@@ -1,0 +1,17 @@
+# Vision-tower kernels: LayerNorm, tanh-GELU, full bidirectional patch attention, 2x2 merge.
+# Separate from si_fused because none of it is shared with the text path -- the text model is
+# RMSNorm + SwiGLU with causal/windowed attention throughout.
+#
+# NOTE: no --use_fast_math here, unlike the sibling domains. This tower is validated against
+# bench/scripts/vision_ref.py, and fast-math's reassociation and lower-precision tanhf/expf would
+# put a floor under that diff that has nothing to do with whether the port is correct. Speed is
+# not the constraint: 27 blocks at hidden=1152 over a few thousand patches is a rounding error
+# beside a 27B decode step.
+file(GLOB SRC "*.cu")
+add_library(si_vision STATIC ${SRC})
+target_include_directories(si_vision PUBLIC ${PROJECT_SOURCE_DIR}/include)
+target_compile_options(si_vision PRIVATE
+    $<$<COMPILE_LANGUAGE:CUDA>:-O3;-lineinfo;--ptxas-options=-v>)
+set_target_properties(si_vision PROPERTIES
+    CUDA_SEPARABLE_COMPILATION ON
+    POSITION_INDEPENDENT_CODE ON)

--- a/kernels/csrc/cuda/vision/vision_ops.cu
+++ b/kernels/csrc/cuda/vision/vision_ops.cu
@@ -87,6 +87,35 @@ __global__ void vis_residual_add_kernel(bf16* __restrict__ acc, const bf16* __re
     acc[i] = f2b(b2f(acc[i]) + b2f(add[i]));
 }
 
+// 2D rotary position embedding, applied to q and k before attention.
+//
+// The reference builds a frequency vector of width head_dim/2 -- its first half driven by a
+// patch's ROW index and its second by its COLUMN -- then concatenates it with ITSELF to head_dim
+// before taking cos/sin. So only head_dim/2 distinct table entries exist per token, and the
+// upper half of the rotation reuses them; that is why cos_t/sin_t are [n_tokens, head_dim/2].
+//
+// One thread per (token, head, d) with d < head_dim/2, rotating the PAIR (d, d + head_dim/2)
+// together. A thread per element would race: the rotation mixes the two halves, so a thread
+// would read a partner another thread had already overwritten.
+__global__ void vis_rope_kernel(bf16* __restrict__ q, bf16* __restrict__ k,
+                                const float* __restrict__ cos_t, const float* __restrict__ sin_t,
+                                long n_tokens, int n_heads, int head_dim) {
+    const int half = head_dim >> 1;
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n_tokens * (long)n_heads * half) return;
+    const int d = (int)(i % half);
+    const long hidx = i / half;                  // token * n_heads + head
+    const long tok = hidx / n_heads;
+    const long base = hidx * (long)head_dim + d;
+    const float c = cos_t[tok * half + d], sn = sin_t[tok * half + d];
+    const float q0 = b2f(q[base]), q1 = b2f(q[base + half]);
+    q[base]        = f2b(q0 * c - q1 * sn);
+    q[base + half] = f2b(q1 * c + q0 * sn);
+    const float k0 = b2f(k[base]), k1 = b2f(k[base + half]);
+    k[base]        = f2b(k0 * c - k1 * sn);
+    k[base + half] = f2b(k1 * c + k0 * sn);
+}
+
 // One warp per (head, query). Online softmax over all keys -- no mask, every query sees every
 // patch. head_dim is 72 here, so each lane holds ceil(72/32)=3 accumulators.
 __global__ void vis_attention_kernel(const bf16* __restrict__ q, const bf16* __restrict__ k,
@@ -202,6 +231,15 @@ void launch_vision_residual_add(void* acc, const void* add, long n, cudaStream_t
     if (n <= 0) return;
     vis_residual_add_kernel<<<(unsigned)((n + 255) / 256), 256, 0, stream>>>(
         (bf16*)acc, (const bf16*)add, n);
+}
+
+void launch_vision_rope(void* q, void* k, const void* cos_table, const void* sin_table,
+                        int n_tokens, int n_heads, int head_dim, cudaStream_t stream) {
+    if (n_tokens <= 0 || n_heads <= 0 || head_dim <= 1 || (head_dim & 1)) return;
+    const long n = (long)n_tokens * n_heads * (head_dim >> 1);
+    vis_rope_kernel<<<(unsigned)((n + 255) / 256), 256, 0, stream>>>(
+        (bf16*)q, (bf16*)k, (const float*)cos_table, (const float*)sin_table,
+        n_tokens, n_heads, head_dim);
 }
 
 void launch_vision_attention(const void* q, const void* k, const void* v, void* out,

--- a/kernels/csrc/cuda/vision/vision_ops.cu
+++ b/kernels/csrc/cuda/vision/vision_ops.cu
@@ -157,7 +157,28 @@ __global__ void vis_patch_merge_kernel(const bf16* __restrict__ x, bf16* __restr
     }
 }
 
+__global__ void vis_splice_kernel(bf16* __restrict__ x, const int* __restrict__ pos,
+                                  const bf16* __restrict__ emb, int n_img, int hidden) {
+    const long total = (long)n_img * hidden;
+    for (long i = (long)blockIdx.x * blockDim.x + threadIdx.x; i < total;
+         i += (long)gridDim.x * blockDim.x) {
+        const int d = (int)(i % hidden);
+        const int r = (int)(i / hidden);
+        x[(size_t)pos[r] * hidden + d] = emb[i];
+    }
+}
+
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+void launch_vision_splice(void* x, const int* positions, const void* emb,
+                          int n_img, int hidden, cudaStream_t stream) {
+    if (n_img <= 0 || hidden <= 0) return;
+    const long total = (long)n_img * hidden;
+    unsigned blocks = (unsigned)((total + 255) / 256);
+    if (blocks > 65535) blocks = 65535;
+    vis_splice_kernel<<<blocks, 256, 0, stream>>>(
+        (bf16*)x, positions, (const bf16*)emb, n_img, hidden);
+}
+
 void launch_vision_layernorm(const void* x, const void* weight, const void* bias, void* out,
                              int n_rows, int dim, float eps, cudaStream_t stream) {
     if (n_rows <= 0 || dim <= 0) return;

--- a/kernels/csrc/cuda/vision/vision_ops.cu
+++ b/kernels/csrc/cuda/vision/vision_ops.cu
@@ -1,0 +1,208 @@
+// Vision-tower kernels: LayerNorm, bias-add, tanh-GELU, residual add, full bidirectional
+// attention, and the 2x2 patch merge. See kernels/include/sparkinfer/kernels/vision.h for why
+// these are new rather than reuses of the text path's RMSNorm/SwiGLU.
+//
+// Portable CUDA — sm_89/90/100/120, the set CMAKE_CUDA_ARCHITECTURES builds.
+#include <cuda_bf16.h>
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include <cuda_runtime.h>
+#include "sparkinfer/kernels/vision.h"
+#endif
+
+namespace sparkinfer {
+namespace kernels {
+
+using bf16 = __nv_bfloat16;
+
+__device__ __forceinline__ float b2f(bf16 x) { return __bfloat162float(x); }
+__device__ __forceinline__ bf16 f2b(float x) { return __float2bfloat16(x); }
+
+__device__ __forceinline__ float warp_sum(float v) {
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) v += __shfl_xor_sync(0xffffffff, v, m);
+    return v;
+}
+
+// One block per row, 256 threads. Two passes over the row (mean, then variance) rather than a
+// fused sum/sum-of-squares: dim is only 1152, the row is in L1 after the first pass, and the
+// numerically stabler form is worth more here than one saved read.
+__global__ void vis_layernorm_kernel(const bf16* __restrict__ x, const bf16* __restrict__ w,
+                                     const bf16* __restrict__ b, bf16* __restrict__ out,
+                                     int dim, float eps) {
+    const int row = blockIdx.x;
+    const bf16* xr = x + (size_t)row * dim;
+    bf16* orow = out + (size_t)row * dim;
+
+    __shared__ float s_mean, s_rstd;
+    float acc = 0.f;
+    for (int i = threadIdx.x; i < dim; i += blockDim.x) acc += b2f(xr[i]);
+    acc = warp_sum(acc);
+    __shared__ float warp_acc[8];
+    const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
+    if (lane == 0) warp_acc[warp] = acc;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        float t = 0.f;
+        for (int i = 0; i < (blockDim.x + 31) / 32; i++) t += warp_acc[i];
+        s_mean = t / dim;
+    }
+    __syncthreads();
+    const float mean = s_mean;
+
+    float v = 0.f;
+    for (int i = threadIdx.x; i < dim; i += blockDim.x) { float d = b2f(xr[i]) - mean; v += d * d; }
+    v = warp_sum(v);
+    if (lane == 0) warp_acc[warp] = v;
+    __syncthreads();
+    if (threadIdx.x == 0) {
+        float t = 0.f;
+        for (int i = 0; i < (blockDim.x + 31) / 32; i++) t += warp_acc[i];
+        s_rstd = rsqrtf(t / dim + eps);
+    }
+    __syncthreads();
+    const float rstd = s_rstd;
+
+    for (int i = threadIdx.x; i < dim; i += blockDim.x)
+        orow[i] = f2b((b2f(xr[i]) - mean) * rstd * b2f(w[i]) + b2f(b[i]));
+}
+
+__global__ void vis_add_bias_kernel(bf16* __restrict__ x, const bf16* __restrict__ bias,
+                                    long n_rows, int dim) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n_rows * dim) return;
+    x[i] = f2b(b2f(x[i]) + b2f(bias[i % dim]));
+}
+
+__global__ void vis_gelu_tanh_kernel(bf16* __restrict__ x, long n) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    const float v = b2f(x[i]);
+    // 0.7978845608028654 = sqrt(2/pi)
+    x[i] = f2b(0.5f * v * (1.f + tanhf(0.7978845608028654f * (v + 0.044715f * v * v * v))));
+}
+
+__global__ void vis_residual_add_kernel(bf16* __restrict__ acc, const bf16* __restrict__ add, long n) {
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    acc[i] = f2b(b2f(acc[i]) + b2f(add[i]));
+}
+
+// One warp per (head, query). Online softmax over all keys -- no mask, every query sees every
+// patch. head_dim is 72 here, so each lane holds ceil(72/32)=3 accumulators.
+__global__ void vis_attention_kernel(const bf16* __restrict__ q, const bf16* __restrict__ k,
+                                     const bf16* __restrict__ v, bf16* __restrict__ out,
+                                     int n_tokens, int n_heads, int head_dim, float scale) {
+    const int head = blockIdx.y;
+    const int qi = blockIdx.x;
+    if (qi >= n_tokens || head >= n_heads) return;
+    const int lane = threadIdx.x;
+    const int stride = n_heads * head_dim;
+    const int off = head * head_dim;
+    const int ELEMS = (head_dim + 31) / 32;
+
+    float qr[8];
+    #pragma unroll
+    for (int e = 0; e < 8; e++) {
+        const int d = lane + e * 32;
+        qr[e] = (e < ELEMS && d < head_dim) ? b2f(q[(size_t)qi * stride + off + d]) : 0.f;
+    }
+
+    float m = -1e30f, l = 0.f, acc[8];
+    #pragma unroll
+    for (int e = 0; e < 8; e++) acc[e] = 0.f;
+
+    for (int kj = 0; kj < n_tokens; kj++) {
+        float dot = 0.f;
+        #pragma unroll
+        for (int e = 0; e < 8; e++) {
+            const int d = lane + e * 32;
+            if (e < ELEMS && d < head_dim) dot += qr[e] * b2f(k[(size_t)kj * stride + off + d]);
+        }
+        const float score = warp_sum(dot) * scale;
+        const float mn = fmaxf(m, score);
+        const float corr = __expf(m - mn), pe = __expf(score - mn);
+        l = l * corr + pe;
+        #pragma unroll
+        for (int e = 0; e < 8; e++) {
+            const int d = lane + e * 32;
+            const float vv = (e < ELEMS && d < head_dim) ? b2f(v[(size_t)kj * stride + off + d]) : 0.f;
+            acc[e] = acc[e] * corr + pe * vv;
+        }
+        m = mn;
+    }
+
+    const float inv = l > 0.f ? 1.f / l : 0.f;
+    #pragma unroll
+    for (int e = 0; e < 8; e++) {
+        const int d = lane + e * 32;
+        if (e < ELEMS && d < head_dim) out[(size_t)qi * stride + off + d] = f2b(acc[e] * inv);
+    }
+}
+
+__global__ void vis_patch_merge_kernel(const bf16* __restrict__ x, bf16* __restrict__ out,
+                                       int grid_h, int grid_w, int merge, int dim) {
+    const int bw = grid_w / merge;
+    const int blocks = (grid_h / merge) * bw;
+    const long total = (long)blocks * merge * merge * dim;
+    for (long i = (long)blockIdx.x * blockDim.x + threadIdx.x; i < total;
+         i += (long)gridDim.x * blockDim.x) {
+        const int d = (int)(i % dim);
+        const long t = i / dim;
+        const int c = (int)(t % merge);
+        const int r = (int)((t / merge) % merge);
+        const long b = t / (merge * merge);
+        const int bx = (int)(b % bw), by = (int)(b / bw);
+        const long src = (long)((by * merge + r) * grid_w + (bx * merge + c)) * dim + d;
+        out[i] = x[src];
+    }
+}
+
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+void launch_vision_layernorm(const void* x, const void* weight, const void* bias, void* out,
+                             int n_rows, int dim, float eps, cudaStream_t stream) {
+    if (n_rows <= 0 || dim <= 0) return;
+    vis_layernorm_kernel<<<n_rows, 256, 0, stream>>>(
+        (const bf16*)x, (const bf16*)weight, (const bf16*)bias, (bf16*)out, dim, eps);
+}
+
+void launch_vision_add_bias(void* x, const void* bias, int n_rows, int dim, cudaStream_t stream) {
+    const long n = (long)n_rows * dim;
+    if (n <= 0) return;
+    vis_add_bias_kernel<<<(unsigned)((n + 255) / 256), 256, 0, stream>>>(
+        (bf16*)x, (const bf16*)bias, n_rows, dim);
+}
+
+void launch_vision_gelu_tanh(void* x, long n, cudaStream_t stream) {
+    if (n <= 0) return;
+    vis_gelu_tanh_kernel<<<(unsigned)((n + 255) / 256), 256, 0, stream>>>((bf16*)x, n);
+}
+
+void launch_vision_residual_add(void* acc, const void* add, long n, cudaStream_t stream) {
+    if (n <= 0) return;
+    vis_residual_add_kernel<<<(unsigned)((n + 255) / 256), 256, 0, stream>>>(
+        (bf16*)acc, (const bf16*)add, n);
+}
+
+void launch_vision_attention(const void* q, const void* k, const void* v, void* out,
+                             int n_tokens, int n_heads, int head_dim, float scale,
+                             cudaStream_t stream) {
+    if (n_tokens <= 0 || n_heads <= 0 || head_dim <= 0 || head_dim > 256) return;
+    dim3 grid((unsigned)n_tokens, (unsigned)n_heads);
+    vis_attention_kernel<<<grid, 32, 0, stream>>>(
+        (const bf16*)q, (const bf16*)k, (const bf16*)v, (bf16*)out,
+        n_tokens, n_heads, head_dim, scale);
+}
+
+void launch_vision_patch_merge(const void* x, void* out, int grid_h, int grid_w, int merge,
+                               int dim, cudaStream_t stream) {
+    if (grid_h <= 0 || grid_w <= 0 || merge <= 0 || dim <= 0) return;
+    if (grid_h % merge || grid_w % merge) return;   // caller must pad to the merge granularity
+    const long total = (long)(grid_h / merge) * (grid_w / merge) * merge * merge * dim;
+    const unsigned blocks = (unsigned)((total + 255) / 256 > 65535 ? 65535 : (total + 255) / 256);
+    vis_patch_merge_kernel<<<blocks, 256, 0, stream>>>(
+        (const bf16*)x, (bf16*)out, grid_h, grid_w, merge, dim);
+}
+#endif
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/vision.h
+++ b/kernels/include/sparkinfer/kernels/vision.h
@@ -1,0 +1,54 @@
+#pragma once
+#include <cuda_runtime.h>
+
+namespace sparkinfer {
+namespace kernels {
+
+// Kernels the vision tower needs that the text path does not have.
+//
+// The text model is RMSNorm + SwiGLU throughout; the vision tower is LayerNorm + GELU, and its
+// attention is FULL and bidirectional over patches with no KV cache and no mask. So these are
+// genuinely new rather than a re-parameterisation of existing kernels.
+//
+// Deliberately simple: the tower is 27 blocks at hidden=1152 over at most a few thousand patches,
+// which is a rounding error next to a 27B decode step. Correctness against bench/scripts/vision_ref.py
+// comes first; if the tower ever shows up in a profile it can be revisited.
+// All tensors bf16, fp32 accumulation.
+
+// out[r, :] = (x[r, :] - mean) / sqrt(var + eps) * weight + bias
+// LayerNorm proper -- subtracts the mean, unlike the text path's RMSNorm. Both weight AND bias,
+// which is what the checkpoint's norm1/norm2/merger.norm tensors carry.
+void launch_vision_layernorm(const void* x, const void* weight, const void* bias, void* out,
+                             int n_rows, int dim, float eps, cudaStream_t stream = nullptr);
+
+// x[r, c] += bias[c]. launch_prefill_gemm has no bias term, so every vision Linear is a GEMM
+// followed by this.
+void launch_vision_add_bias(void* x, const void* bias, int n_rows, int dim,
+                            cudaStream_t stream = nullptr);
+
+// x[i] = 0.5*x*(1 + tanh(sqrt(2/pi)*(x + 0.044715*x^3))), in place.
+// The TANH approximation, matching config's hidden_act="gelu_pytorch_tanh". The erf form differs
+// by ~1e-3 near the knee, which compounds over 27 blocks.
+void launch_vision_gelu_tanh(void* x, long n, cudaStream_t stream = nullptr);
+
+// acc[i] += add[i], in place -- the residual connections.
+void launch_vision_residual_add(void* acc, const void* add, long n, cudaStream_t stream = nullptr);
+
+// Full bidirectional attention over all patches, one kernel per (head, query).
+// q/k/v are [n_tokens, n_heads*head_dim] as the QKV projection leaves them; out matches.
+// No mask: a causal mask here is the classic silent bug -- it still produces embeddings, just
+// wrong ones, and nothing downstream can tell.
+void launch_vision_attention(const void* q, const void* k, const void* v, void* out,
+                             int n_tokens, int n_heads, int head_dim, float scale,
+                             cudaStream_t stream = nullptr);
+
+// Regroup row-major patches into merge x merge blocks:
+//   out[b, (r*merge + c)*dim + d] = x[((by*merge + r)*grid_w + (bx*merge + c)), d]
+// where b = by*(grid_w/merge) + bx. This is the transpose vision_ref.py does at the merger, and
+// it is what makes a row-major patch order equivalent to HF's merge-block-major one (proved to
+// 1e-15 in bench/scripts/vision_order_check.py).
+void launch_vision_patch_merge(const void* x, void* out, int grid_h, int grid_w, int merge,
+                               int dim, cudaStream_t stream = nullptr);
+
+}  // namespace kernels
+}  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/vision.h
+++ b/kernels/include/sparkinfer/kernels/vision.h
@@ -50,5 +50,15 @@ void launch_vision_attention(const void* q, const void* k, const void* v, void* 
 void launch_vision_patch_merge(const void* x, void* out, int grid_h, int grid_w, int merge,
                                int dim, cudaStream_t stream = nullptr);
 
+// Overwrite selected rows of the embedded prompt with vision embeddings:
+//   x[positions[i], :] = emb[i, :]   for i in [0, n_img)
+// x is the [n_tokens, hidden] bf16 output of launch_embedding; emb is [n_img, hidden] bf16.
+// positions is device-side and must be strictly increasing (the caller derives it from the token
+// stream). Nothing here validates the COUNT -- qwen_vision_splice_embeddings does that on the
+// host, before any device work, because a count mismatch shifts every later token and must be an
+// error rather than a partial write.
+void launch_vision_splice(void* x, const int* positions, const void* emb,
+                          int n_img, int hidden, cudaStream_t stream = nullptr);
+
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/kernels/include/sparkinfer/kernels/vision.h
+++ b/kernels/include/sparkinfer/kernels/vision.h
@@ -38,6 +38,18 @@ void launch_vision_residual_add(void* acc, const void* add, long n, cudaStream_t
 // q/k/v are [n_tokens, n_heads*head_dim] as the QKV projection leaves them; out matches.
 // No mask: a causal mask here is the classic silent bug -- it still produces embeddings, just
 // wrong ones, and nothing downstream can tell.
+// 2D rotary position embedding for the vision tower, applied IN PLACE to q and k before
+// attention. Every block re-projects qkv, so this runs once per block, not once per image.
+//
+// cos_table/sin_table are float [n_tokens, head_dim/2], row-major over the patch grid, and hold
+// only the DISTINCT half of the frequencies: the reference concatenates its width-head_dim/2
+// frequency vector with itself before taking cos/sin, so the upper half repeats the lower.
+//
+// Omitting this entirely is what made the tower agree with a hand-written reference while both
+// disagreed with transformers at cosine 0.77 -- see bench/scripts/vision_hf_check.py.
+void launch_vision_rope(void* q, void* k, const void* cos_table, const void* sin_table,
+                        int n_tokens, int n_heads, int head_dim, cudaStream_t stream = nullptr);
+
 void launch_vision_attention(const void* q, const void* k, const void* v, void* out,
                              int n_tokens, int n_heads, int head_dim, float scale,
                              cudaStream_t stream = nullptr);

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -141,6 +141,13 @@ if(BUILD_EXAMPLES)
     add_executable(vision_splice_check examples/vision_splice_check.cpp)
     target_include_directories(vision_splice_check PRIVATE include)
     target_link_libraries(vision_splice_check PRIVATE sparkinfer_runtime CUDA::cudart)
+    # End-to-end: a real image file through decode -> preprocess -> tower -> splice -> generate.
+    # Needs server/third_party for the vendored stb_image.h.
+    add_executable(vision_e2e examples/vision_e2e.cpp)
+    target_include_directories(vision_e2e PRIVATE include
+                               ${CMAKE_CURRENT_SOURCE_DIR}/../server/third_party)
+    target_link_libraries(vision_e2e PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)
     add_executable(vision_forward_check examples/vision_forward_check.cpp)
     target_include_directories(vision_forward_check PRIVATE include)
     target_link_libraries(vision_forward_check PRIVATE sparkinfer_runtime CUDA::cudart

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -136,6 +136,11 @@ if(BUILD_EXAMPLES)
     add_executable(vision_resize_check examples/vision_resize_check.cpp)
     target_include_directories(vision_resize_check PRIVATE include)
     target_link_libraries(vision_resize_check PRIVATE sparkinfer_runtime CUDA::cudart)
+    # Splice behaviour, especially the REFUSALS -- a count mismatch must be a hard error, never
+    # a partial write, or the model silently reads a truncated image region.
+    add_executable(vision_splice_check examples/vision_splice_check.cpp)
+    target_include_directories(vision_splice_check PRIVATE include)
+    target_link_libraries(vision_splice_check PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(vision_forward_check examples/vision_forward_check.cpp)
     target_include_directories(vision_forward_check PRIVATE include)
     target_link_libraries(vision_forward_check PRIVATE sparkinfer_runtime CUDA::cudart

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -129,6 +129,12 @@ if(BUILD_EXAMPLES)
     target_include_directories(vision_probe PRIVATE include)
     target_link_libraries(vision_probe PRIVATE sparkinfer_runtime CUDA::cudart
                           nlohmann_json::nlohmann_json)
+    # Runs the CUDA tower on vision_ref.py's exact synthetic input and dumps the embeddings for
+    # that script to judge. The reference owns the tolerance, not this binary.
+    add_executable(vision_forward_check examples/vision_forward_check.cpp)
+    target_include_directories(vision_forward_check PRIVATE include)
+    target_link_libraries(vision_forward_check PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)
     add_executable(thermal_sweep examples/thermal_sweep.cpp)   # force each thermal mode, measure W/°C/tok/s
     target_include_directories(thermal_sweep PRIVATE include)
     target_link_libraries(thermal_sweep PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -148,6 +148,12 @@ if(BUILD_EXAMPLES)
                                ${CMAKE_CURRENT_SOURCE_DIR}/../server/third_party)
     target_link_libraries(vision_e2e PRIVATE sparkinfer_runtime CUDA::cudart
                           nlohmann_json::nlohmann_json)
+    # Preprocessing differential (CPU only, no GPU) -- also needs the vendored stb_image.h.
+    add_executable(vision_preprocess_check examples/vision_preprocess_check.cpp)
+    target_include_directories(vision_preprocess_check PRIVATE include
+                               ${CMAKE_CURRENT_SOURCE_DIR}/../server/third_party)
+    target_link_libraries(vision_preprocess_check PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)
     add_executable(vision_forward_check examples/vision_forward_check.cpp)
     target_include_directories(vision_forward_check PRIVATE include)
     target_link_libraries(vision_forward_check PRIVATE sparkinfer_runtime CUDA::cudart

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -131,6 +131,11 @@ if(BUILD_EXAMPLES)
                           nlohmann_json::nlohmann_json)
     # Runs the CUDA tower on vision_ref.py's exact synthetic input and dumps the embeddings for
     # that script to judge. The reference owns the tolerance, not this binary.
+    # Cross-checks the smart_resize port against the Python original over a grid of shapes.
+    # Exact integer logic, so bench/scripts/vision_resize_check.py demands strict equality.
+    add_executable(vision_resize_check examples/vision_resize_check.cpp)
+    target_include_directories(vision_resize_check PRIVATE include)
+    target_link_libraries(vision_resize_check PRIVATE sparkinfer_runtime CUDA::cudart)
     add_executable(vision_forward_check examples/vision_forward_check.cpp)
     target_include_directories(vision_forward_check PRIVATE include)
     target_link_libraries(vision_forward_check PRIVATE sparkinfer_runtime CUDA::cudart

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -121,6 +121,14 @@ if(BUILD_EXAMPLES)
     target_include_directories(dspark_tau_check PRIVATE include)
     target_link_libraries(dspark_tau_check PRIVATE sparkinfer_runtime CUDA::cudart
                           nlohmann_json::nlohmann_json)
+    # Vision-tower probe: does this checkpoint carry a complete vision encoder, and does every
+    # tensor match the shape its own vision_config implies? Stage 1 of image support -- no
+    # inference, just a structural check, because a silently missing or mis-shaped vision weight
+    # produces plausible garbage rather than an error.
+    add_executable(vision_probe examples/vision_probe.cpp)
+    target_include_directories(vision_probe PRIVATE include)
+    target_link_libraries(vision_probe PRIVATE sparkinfer_runtime CUDA::cudart
+                          nlohmann_json::nlohmann_json)
     add_executable(thermal_sweep examples/thermal_sweep.cpp)   # force each thermal mode, measure W/°C/tok/s
     target_include_directories(thermal_sweep PRIVATE include)
     target_link_libraries(thermal_sweep PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)

--- a/runtime/examples/qwen_vision_hf_config.h
+++ b/runtime/examples/qwen_vision_hf_config.h
@@ -1,0 +1,95 @@
+#pragma once
+// Reads config.json's `vision_config` block (and preprocessor_config.json) into a
+// QwenVisionConfig. Companion to qwen38_hf_config.h, kept separate so a text-only caller does not
+// have to care that the tower exists.
+//
+// Absence is NOT an error: a checkpoint with no vision_config is a text-only checkpoint, and
+// `present` stays false so callers can decide. Only a MALFORMED block is an error.
+#include <fstream>
+#include <string>
+#include <nlohmann/json.hpp>
+#include "sparkinfer/models/qwen_vision_config.h"
+
+static bool qwen_vision_config_from_hf_json(const std::string& model_dir,
+                                            sparkinfer::QwenVisionConfig& vc, std::string& err) {
+    std::ifstream cf(model_dir + "/config.json");
+    if (!cf) { err = "config.json not found in " + model_dir; return false; }
+    nlohmann::json root;
+    try { cf >> root; }
+    catch (const std::exception& e) { err = std::string("config.json parse error: ") + e.what(); return false; }
+
+    // The block sits at the top level on this checkpoint, but tolerate it nested under
+    // text_config the way some exports place it.
+    const nlohmann::json* v = nullptr;
+    if (root.contains("vision_config") && root["vision_config"].is_object()) v = &root["vision_config"];
+    else if (root.contains("text_config") && root["text_config"].is_object()
+             && root["text_config"].contains("vision_config")
+             && root["text_config"]["vision_config"].is_object()) v = &root["text_config"]["vision_config"];
+    if (!v) { vc.present = false; return true; }   // text-only checkpoint
+
+    const auto& j = *v;
+    auto geti = [&](const char* k, int d) {
+        return j.contains(k) && j[k].is_number_integer() ? j[k].get<int>() : d; };
+    vc.present            = true;
+    vc.depth              = geti("depth", vc.depth);
+    vc.hidden             = geti("hidden_size", vc.hidden);
+    vc.n_heads            = geti("num_heads", vc.n_heads);
+    vc.intermediate       = geti("intermediate_size", vc.intermediate);
+    vc.in_channels        = geti("in_channels", vc.in_channels);
+    vc.patch_size         = geti("patch_size", vc.patch_size);
+    vc.temporal_patch     = geti("temporal_patch_size", vc.temporal_patch);
+    vc.spatial_merge      = geti("spatial_merge_size", vc.spatial_merge);
+    vc.num_pos_embeddings = geti("num_position_embeddings", vc.num_pos_embeddings);
+    vc.out_hidden         = geti("out_hidden_size", vc.out_hidden);
+    if (j.contains("hidden_act") && j["hidden_act"].is_string())
+        vc.hidden_act = j["hidden_act"].get<std::string>();
+
+    // deepstack taps intermediate tower layers into the LM. This checkpoint ships an EMPTY list,
+    // so there is nothing to wire -- but a non-empty one would silently change the contract, so
+    // refuse rather than quietly producing wrong embeddings.
+    if (j.contains("deepstack_visual_indexes") && j["deepstack_visual_indexes"].is_array()
+        && !j["deepstack_visual_indexes"].empty()) {
+        err = "vision_config.deepstack_visual_indexes is non-empty; deepstack is not implemented";
+        return false;
+    }
+
+    auto gettok = [&](const char* k, int d) {
+        return root.contains(k) && root[k].is_number_integer() ? root[k].get<int>() : d; };
+    vc.vision_start_token_id = gettok("vision_start_token_id", vc.vision_start_token_id);
+    vc.vision_end_token_id   = gettok("vision_end_token_id",   vc.vision_end_token_id);
+    vc.image_token_id        = gettok("image_token_id",        vc.image_token_id);
+    vc.video_token_id        = gettok("video_token_id",        vc.video_token_id);
+
+    // Preprocessing. Optional: the defaults already match this checkpoint, and a missing file
+    // should not stop the tower loading.
+    std::ifstream pf(model_dir + "/preprocessor_config.json");
+    if (pf) {
+        nlohmann::json p;
+        try {
+            pf >> p;
+            if (p.contains("image_mean") && p["image_mean"].is_array() && p["image_mean"].size() == 3)
+                for (int i = 0; i < 3; i++) vc.mean[i] = p["image_mean"][i].get<float>();
+            if (p.contains("image_std") && p["image_std"].is_array() && p["image_std"].size() == 3)
+                for (int i = 0; i < 3; i++) vc.std_[i] = p["image_std"][i].get<float>();
+            // "size" is a pixel BUDGET here, not width/height: shortest_edge/longest_edge are
+            // min/max total pixels for Qwen2VLImageProcessorFast's dynamic resolution.
+            if (p.contains("size") && p["size"].is_object()) {
+                const auto& sz = p["size"];
+                if (sz.contains("shortest_edge") && sz["shortest_edge"].is_number_integer())
+                    vc.min_pixels = sz["shortest_edge"].get<long>();
+                if (sz.contains("longest_edge") && sz["longest_edge"].is_number_integer())
+                    vc.max_pixels = sz["longest_edge"].get<long>();
+            }
+        } catch (const std::exception&) { /* defaults already correct for this checkpoint */ }
+    }
+
+    if (vc.hidden <= 0 || vc.n_heads <= 0 || vc.hidden % vc.n_heads != 0) {
+        err = "vision_config: hidden_size must be a positive multiple of num_heads";
+        return false;
+    }
+    if (vc.spatial_merge <= 0 || vc.patch_size <= 0) {
+        err = "vision_config: patch_size and spatial_merge_size must be positive";
+        return false;
+    }
+    return true;
+}

--- a/runtime/examples/vision_e2e.cpp
+++ b/runtime/examples/vision_e2e.cpp
@@ -1,0 +1,116 @@
+// End-to-end image understanding: a real image file in, generated tokens out.
+//
+// This is the test every other vision check cannot do. The numeric checks prove the tower
+// reproduces a reference and the resize matches upstream; none of them prove the MODEL
+// understands what it is being shown. A convention error that survived all of them would surface
+// here as a fluent caption about the wrong thing.
+//
+// Usage: vision_e2e <checkpoint_dir> <image_file> <max_new> <id0> <id1> ...
+//   The token ids are the chat-templated prompt containing exactly ONE image_token_id, which this
+//   binary expands to the count the resized grid needs (as the reference processor does).
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "sparkinfer/runtime.h"
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/gguf.h"
+#include "sparkinfer/moe/engine.h"
+#include "sparkinfer/safetensors.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/models/qwen_vision.h"
+#include "sparkinfer/models/qwen_vision_preprocess.h"
+#include "qwen_checkpoint.h"
+#include "qwen_vision_hf_config.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_PNG
+#define STBI_ONLY_JPEG
+#define STBI_NO_FAILURE_STRINGS_MUTABLE
+#include "stb_image.h"
+
+using namespace sparkinfer;
+
+int main(int argc, char** argv) {
+    if (argc < 5) { printf("usage: %s <ckpt_dir> <image> <max_new> <id0> ...\n", argv[0]); return 2; }
+    const std::string dir = argv[1], img_path = argv[2];
+    const int max_new = atoi(argv[3]);
+    std::vector<int> prompt;
+    for (int i = 4; i < argc; i++) prompt.push_back(atoi(argv[i]));
+
+    // ---- vision config + image ----
+    QwenVisionConfig vc; std::string err;
+    if (!qwen_vision_config_from_hf_json(dir, vc, err) || !vc.present) {
+        printf("[FAIL] vision config: %s\n", err.c_str()); return 1;
+    }
+    int iw = 0, ih = 0, ch = 0;
+    unsigned char* px = stbi_load(img_path.c_str(), &iw, &ih, &ch, 3);
+    if (!px) { printf("[FAIL] decode %s\n", img_path.c_str()); return 1; }
+    printf("image: %s  %dx%d (source channels %d)\n", img_path.c_str(), iw, ih, ch);
+
+    std::vector<float> pixels; int gh = 0, gw = 0;
+    if (!qwen_vision_preprocess(px, ih, iw, vc, pixels, &gh, &gw, err)) {
+        printf("[FAIL] preprocess: %s\n", err.c_str()); stbi_image_free(px); return 1;
+    }
+    stbi_image_free(px);
+    const int n_img = qwen_vision_num_tokens(gh, gw, vc);
+    printf("resized to patch grid %dx%d (%d patches) -> %d image tokens\n", gh, gw, gh * gw, n_img);
+
+    // ---- expand the template's single placeholder ----
+    std::vector<int> ids;
+    if (!qwen_vision_expand_placeholders(prompt, vc.image_token_id, {n_img}, ids, err)) {
+        printf("[FAIL] expand: %s\n", err.c_str()); return 1;
+    }
+    printf("prompt: %zu tokens -> %zu after expansion\n", prompt.size(), ids.size());
+
+    // ---- model ----
+    GGUF g; Qwen35Config cfg; QwenCheckpointKind kind{}; std::string cerr_msg;
+    if (!qwen_checkpoint_open(dir, cfg, g, kind, cerr_msg)) { printf("[FAIL] %s\n", cerr_msg.c_str()); return 1; }
+    cfg.max_seq = std::max(4096, (int)ids.size() + max_new + 64);
+    auto rt = Runtime::create({}); rt->initialize();
+    KVCacheConfig kvc;
+    kvc.num_layers = cfg.n_layers; kvc.num_kv_heads = cfg.n_kv_heads;
+    kvc.head_dim = cfg.head_dim; kvc.block_size = 16;
+    { const char* e = getenv("SPARKINFER_KV_INT8"); kvc.int8_kv = e ? (e[0] != '0') : false; }
+    kvc.layer_slot = hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = kv_slot_count(kvc.layer_slot, cfg.n_layers);
+    const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
+    const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
+    KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
+    moe::MoEConfig mc;
+    mc.num_experts = cfg.n_experts; mc.top_k = cfg.top_k; mc.hidden_dim = cfg.hidden;
+    mc.ffn_dim = cfg.moe_ffn; mc.num_layers = cfg.n_layers;
+    auto engine = moe::MoEEngine::create(mc);
+    Qwen35Model model(cfg, &kv, engine.get());
+    printf("loading checkpoint (%s) ...\n", qwen_checkpoint_kind_label(kind));
+    if (!qwen_checkpoint_load(model, dir, kind)) { printf("[FAIL] checkpoint load\n"); return 1; }
+
+    // ---- vision tower ----
+    SafeTensorsModel st;
+    if (!st.open(dir)) { printf("[FAIL] safetensors open\n"); return 1; }
+    QwenVisionWeights vw;
+    if (!load_qwen_vision_weights(st, vc, vw, err)) { printf("[FAIL] vision weights: %s\n", err.c_str()); return 1; }
+    std::vector<float> emb((size_t)n_img * vc.out_hidden);
+    printf("running vision tower (%d blocks) ...\n", vc.depth);
+    if (!qwen_vision_forward(vw, vc, pixels.data(), gh, gw, emb.data(), err)) {
+        printf("[FAIL] vision forward: %s\n", err.c_str()); free_qwen_vision_weights(vw); return 1;
+    }
+    free_qwen_vision_weights(vw);
+    double amax = 0; for (float v : emb) if (std::fabs((double)v) > amax) amax = std::fabs((double)v);
+    printf("vision embeddings: [%d, %d] absmax %.3f\n", n_img, vc.out_hidden, amax);
+
+    // ---- stage + generate ----
+    std::vector<int> pos;
+    for (size_t t = 0; t < ids.size(); t++) if (ids[t] == vc.image_token_id) pos.push_back((int)t);
+    if (!model.set_pending_vision(emb.data(), pos.data(), n_img, cfg.hidden)) {
+        printf("[FAIL] set_pending_vision\n"); return 1;
+    }
+    printf("generating %d tokens ...\n", max_new);
+    auto out = model.generate(ids, max_new, nullptr);
+    printf("OUTPUT_IDS");
+    for (int t : out) printf(" %d", t);
+    printf("\n");
+    return 0;
+}

--- a/runtime/examples/vision_e2e.cpp
+++ b/runtime/examples/vision_e2e.cpp
@@ -23,7 +23,7 @@
 #include "sparkinfer/models/qwen_vision.h"
 #include "sparkinfer/models/qwen_vision_preprocess.h"
 #include "qwen_checkpoint.h"
-#include "qwen_vision_hf_config.h"
+#include "sparkinfer/models/qwen_vision_hf_config.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_ONLY_PNG

--- a/runtime/examples/vision_forward_check.cpp
+++ b/runtime/examples/vision_forward_check.cpp
@@ -1,0 +1,88 @@
+// Runs the CUDA vision tower on the same synthetic input bench/scripts/vision_ref.py uses, and
+// writes the merged embeddings to a raw f32 file for that script to diff against.
+//
+// The reference is the contract. This binary deliberately does NOT decide whether the result is
+// correct -- it only produces the number; vision_ref.py --compare does the judging, so the
+// tolerance lives in one place and cannot drift between the two.
+//
+// Usage: vision_forward_check <checkpoint_dir> [--h 768 --w 768] [--out /tmp/vision_cuda.bin]
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "sparkinfer/safetensors.h"
+#include "sparkinfer/models/qwen_vision.h"
+#include "qwen_vision_hf_config.h"
+
+using namespace sparkinfer;
+
+int main(int argc, char** argv) {
+    if (argc < 2) { printf("usage: %s <checkpoint_dir> [--h H --w W] [--out FILE]\n", argv[0]); return 2; }
+    const std::string dir = argv[1];
+    int h = 768, w = 768;                       // 48x48 patch grid: pos-embed resample is the
+    std::string out_path = "/tmp/vision_cuda.bin";   // identity there, one less variable
+    for (int i = 2; i + 1 < argc; i += 2) {
+        if (!strcmp(argv[i], "--h")) h = atoi(argv[i + 1]);
+        else if (!strcmp(argv[i], "--w")) w = atoi(argv[i + 1]);
+        else if (!strcmp(argv[i], "--out")) out_path = argv[i + 1];
+    }
+
+    QwenVisionConfig cfg; std::string err;
+    if (!qwen_vision_config_from_hf_json(dir, cfg, err)) { printf("[FAIL] %s\n", err.c_str()); return 1; }
+    if (!cfg.present) { printf("[FAIL] no vision_config\n"); return 1; }
+    const int gran = cfg.size_granularity();
+    if (h % gran || w % gran) { printf("[FAIL] dims must be multiples of %d\n", gran); return 1; }
+
+    const int P = cfg.patch_size, T = cfg.temporal_patch, C = cfg.in_channels;
+    const int gh = h / P, gw = w / P, N = gh * gw;
+    const int patch_in = C * T * P * P;
+
+    // The same deterministic ramp vision_ref.py builds, patchified the same way: row-major over
+    // the grid, each patch (C, T, P, P) with the still image repeated across T.
+    std::vector<float> pix((size_t)N * patch_in);
+    for (int gy = 0; gy < gh; gy++)
+      for (int gx = 0; gx < gw; gx++) {
+        float* dst = &pix[((size_t)gy * gw + gx) * patch_in];
+        for (int c = 0; c < C; c++)
+          for (int t = 0; t < T; t++)
+            for (int py = 0; py < P; py++)
+              for (int px = 0; px < P; px++) {
+                const int Y = gy * P + py, X = gx * P + px;
+                float v = c == 0 ? (float)Y / (h - 1) : c == 1 ? (float)X / (w - 1)
+                                                               : (float)(Y + X) / (h + w - 2);
+                dst[((c * T + t) * P + py) * P + px] = v * 2.f - 1.f;
+              }
+      }
+
+    SafeTensorsModel st;
+    if (!st.open(dir)) { printf("[FAIL] cannot open safetensors in %s\n", dir.c_str()); return 1; }
+    QwenVisionWeights vw;
+    if (!load_qwen_vision_weights(st, cfg, vw, err)) { printf("[FAIL] load: %s\n", err.c_str()); return 1; }
+    printf("loaded vision tower: %d blocks, hidden=%d, pos table %dx%d\n",
+           (int)vw.blocks.size(), cfg.hidden, vw.pos_side, vw.pos_side);
+
+    const int nblk = (gh / cfg.spatial_merge) * (gw / cfg.spatial_merge);
+    std::vector<float> out((size_t)nblk * cfg.out_hidden);
+    if (!qwen_vision_forward(vw, cfg, pix.data(), gh, gw, out.data(), err)) {
+        printf("[FAIL] forward: %s\n", err.c_str()); free_qwen_vision_weights(vw); return 1;
+    }
+    free_qwen_vision_weights(vw);
+
+    double mean = 0, absmax = 0;
+    for (float v : out) { mean += v; absmax = std::fmax(absmax, std::fabs((double)v)); }
+    mean /= out.size();
+    double var = 0; for (float v : out) var += (v - mean) * (v - mean);
+    printf("image %dx%d -> grid %dx%d = %d patches -> %d merged embeddings of %d\n",
+           h, w, gh, gw, N, nblk, cfg.out_hidden);
+    printf("out mean=%+.6f std=%.6f absmax=%.4f\n", mean, std::sqrt(var / out.size()), absmax);
+
+    FILE* f = fopen(out_path.c_str(), "wb");
+    if (!f) { printf("[FAIL] cannot write %s\n", out_path.c_str()); return 1; }
+    fwrite(out.data(), sizeof(float), out.size(), f);
+    fclose(f);
+    printf("wrote %zu floats -> %s\n", out.size(), out_path.c_str());
+    printf("compare with: vision_ref.py <dir> --h %d --w %d --compare %s\n", h, w, out_path.c_str());
+    return 0;
+}

--- a/runtime/examples/vision_forward_check.cpp
+++ b/runtime/examples/vision_forward_check.cpp
@@ -5,7 +5,14 @@
 // correct -- it only produces the number; vision_ref.py --compare does the judging, so the
 // tolerance lives in one place and cannot drift between the two.
 //
+// With --pixels, the patch tensor is read from a file instead of synthesised. That is how the
+// tower gets compared against transformers itself: feeding HF's OWN pixel_values in means the
+// comparison tests the tower alone, with preprocessing eliminated as a variable rather than
+// assumed correct. The file is raw f32, [gh*gw, C*T*P*P], row-major over the patch grid --
+// callers holding HF's merge-block-major order must permute it first.
+//
 // Usage: vision_forward_check <checkpoint_dir> [--h 768 --w 768] [--out /tmp/vision_cuda.bin]
+//        vision_forward_check <checkpoint_dir> --pixels FILE --gh GH --gw GW [--out FILE]
 #include <cmath>
 #include <cstdio>
 #include <cstring>
@@ -23,25 +30,55 @@ int main(int argc, char** argv) {
     const std::string dir = argv[1];
     int h = 768, w = 768;                       // 48x48 patch grid: pos-embed resample is the
     std::string out_path = "/tmp/vision_cuda.bin";   // identity there, one less variable
+    std::string pix_path;
+    int arg_gh = 0, arg_gw = 0;
     for (int i = 2; i + 1 < argc; i += 2) {
         if (!strcmp(argv[i], "--h")) h = atoi(argv[i + 1]);
         else if (!strcmp(argv[i], "--w")) w = atoi(argv[i + 1]);
         else if (!strcmp(argv[i], "--out")) out_path = argv[i + 1];
+        else if (!strcmp(argv[i], "--pixels")) pix_path = argv[i + 1];
+        else if (!strcmp(argv[i], "--gh")) arg_gh = atoi(argv[i + 1]);
+        else if (!strcmp(argv[i], "--gw")) arg_gw = atoi(argv[i + 1]);
     }
 
     QwenVisionConfig cfg; std::string err;
     if (!qwen_vision_config_from_hf_json(dir, cfg, err)) { printf("[FAIL] %s\n", err.c_str()); return 1; }
     if (!cfg.present) { printf("[FAIL] no vision_config\n"); return 1; }
     const int gran = cfg.size_granularity();
-    if (h % gran || w % gran) { printf("[FAIL] dims must be multiples of %d\n", gran); return 1; }
-
     const int P = cfg.patch_size, T = cfg.temporal_patch, C = cfg.in_channels;
-    const int gh = h / P, gw = w / P, N = gh * gw;
+    int gh, gw;
+    if (!pix_path.empty()) {
+        if (arg_gh <= 0 || arg_gw <= 0) { printf("[FAIL] --pixels needs --gh and --gw\n"); return 1; }
+        gh = arg_gh; gw = arg_gw; h = gh * P; w = gw * P;
+    } else {
+        if (h % gran || w % gran) { printf("[FAIL] dims must be multiples of %d\n", gran); return 1; }
+        gh = h / P; gw = w / P;
+    }
+    if (gh % cfg.spatial_merge || gw % cfg.spatial_merge) {
+        printf("[FAIL] patch grid %dx%d not divisible by merge %d\n", gh, gw, cfg.spatial_merge);
+        return 1;
+    }
+    const int N = gh * gw;
     const int patch_in = C * T * P * P;
 
     // The same deterministic ramp vision_ref.py builds, patchified the same way: row-major over
     // the grid, each patch (C, T, P, P) with the still image repeated across T.
     std::vector<float> pix((size_t)N * patch_in);
+    if (!pix_path.empty()) {
+        FILE* pf = fopen(pix_path.c_str(), "rb");
+        if (!pf) { printf("[FAIL] cannot read %s\n", pix_path.c_str()); return 1; }
+        fseek(pf, 0, SEEK_END); const long bytes = ftell(pf); fseek(pf, 0, SEEK_SET);
+        if (bytes != (long)(pix.size() * sizeof(float))) {
+            printf("[FAIL] %s holds %ld bytes, expected %zu for [%d,%d]\n",
+                   pix_path.c_str(), bytes, pix.size() * sizeof(float), N, patch_in);
+            fclose(pf); return 1;
+        }
+        if (fread(pix.data(), sizeof(float), pix.size(), pf) != pix.size()) {
+            printf("[FAIL] short read from %s\n", pix_path.c_str()); fclose(pf); return 1;
+        }
+        fclose(pf);
+        printf("pixels from %s: [%d, %d]\n", pix_path.c_str(), N, patch_in);
+    } else
     for (int gy = 0; gy < gh; gy++)
       for (int gx = 0; gx < gw; gx++) {
         float* dst = &pix[((size_t)gy * gw + gx) * patch_in];

--- a/runtime/examples/vision_forward_check.cpp
+++ b/runtime/examples/vision_forward_check.cpp
@@ -21,7 +21,7 @@
 
 #include "sparkinfer/safetensors.h"
 #include "sparkinfer/models/qwen_vision.h"
-#include "qwen_vision_hf_config.h"
+#include "sparkinfer/models/qwen_vision_hf_config.h"
 
 using namespace sparkinfer;
 

--- a/runtime/examples/vision_preprocess_check.cpp
+++ b/runtime/examples/vision_preprocess_check.cpp
@@ -16,7 +16,7 @@
 
 #include "sparkinfer/models/qwen_vision_config.h"
 #include "sparkinfer/models/qwen_vision_preprocess.h"
-#include "qwen_vision_hf_config.h"
+#include "sparkinfer/models/qwen_vision_hf_config.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #define STBI_ONLY_PNG

--- a/runtime/examples/vision_preprocess_check.cpp
+++ b/runtime/examples/vision_preprocess_check.cpp
@@ -1,0 +1,60 @@
+// Differential for image preprocessing: our resize/normalize/patchify vs. HF's, on a real image.
+//
+// Every other vision check so far happened to use images whose sides were already multiples of
+// 32, which makes smart_resize the identity -- so the bicubic resampler, the one stage never
+// verified against upstream, never actually ran. This binary dumps the preprocessed tensor for
+// ANY image so bench/scripts/vision_preprocess_ref.py can judge it against PIL.
+//
+// CPU only: no runtime init, no device allocation, so this is safe to run while the eval bot
+// has the GPU.
+//
+// Usage: vision_preprocess_check <ckpt_dir> <image> [--out FILE]
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "sparkinfer/models/qwen_vision_config.h"
+#include "sparkinfer/models/qwen_vision_preprocess.h"
+#include "qwen_vision_hf_config.h"
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_PNG
+#define STBI_ONLY_JPEG
+#define STBI_NO_FAILURE_STRINGS_MUTABLE
+#include "stb_image.h"
+
+using namespace sparkinfer;
+
+int main(int argc, char** argv) {
+    if (argc < 3) { printf("usage: %s <ckpt_dir> <image> [--out FILE]\n", argv[0]); return 2; }
+    const std::string dir = argv[1], img_path = argv[2];
+    std::string out_path = "/tmp/vision_pre.bin";
+    for (int i = 3; i + 1 < argc; i++)
+        if (!strcmp(argv[i], "--out")) out_path = argv[i + 1];
+
+    QwenVisionConfig vc; std::string err;
+    if (!qwen_vision_config_from_hf_json(dir, vc, err) || !vc.present) {
+        printf("[FAIL] vision config: %s\n", err.c_str()); return 1;
+    }
+    int w = 0, h = 0, ch = 0;
+    unsigned char* rgb = stbi_load(img_path.c_str(), &w, &h, &ch, 3);
+    if (!rgb) { printf("[FAIL] cannot decode %s\n", img_path.c_str()); return 1; }
+    printf("image %s  %dx%d (source channels %d)\n", img_path.c_str(), w, h, ch);
+
+    std::vector<float> pixels; int gh = 0, gw = 0;
+    if (!qwen_vision_preprocess(rgb, h, w, vc, pixels, &gh, &gw, err)) {
+        printf("[FAIL] preprocess: %s\n", err.c_str()); stbi_image_free(rgb); return 1;
+    }
+    stbi_image_free(rgb);
+
+    FILE* f = fopen(out_path.c_str(), "wb");
+    if (!f) { printf("[FAIL] cannot write %s\n", out_path.c_str()); return 1; }
+    fwrite(pixels.data(), sizeof(float), pixels.size(), f);
+    fclose(f);
+    printf("patch grid %dx%d = %d patches, %zu floats -> %s\n", gh, gw, gh * gw, pixels.size(),
+           out_path.c_str());
+    printf("compare with: vision_preprocess_ref.py <dir> %s --compare %s\n",
+           img_path.c_str(), out_path.c_str());
+    return 0;
+}

--- a/runtime/examples/vision_probe.cpp
+++ b/runtime/examples/vision_probe.cpp
@@ -14,7 +14,7 @@
 
 #include "sparkinfer/safetensors.h"
 #include "sparkinfer/models/qwen_vision_config.h"
-#include "qwen_vision_hf_config.h"
+#include "sparkinfer/models/qwen_vision_hf_config.h"
 
 using sparkinfer::QwenVisionConfig;
 using sparkinfer::SafeTensorsModel;

--- a/runtime/examples/vision_probe.cpp
+++ b/runtime/examples/vision_probe.cpp
@@ -1,0 +1,120 @@
+// Does this checkpoint carry a usable vision tower, and does it match its own config?
+//
+// Stage 1 of image support. Deliberately does NO inference: it reads config.json's vision_config,
+// then walks the safetensors shards and checks that every tensor the tower needs is present with
+// the shape the config implies. Getting this wrong silently -- a missing block, a transposed
+// weight, a patch embed the reader skipped -- is how vision integrations produce plausible
+// garbage, so the shapes are asserted against the config rather than merely reported.
+//
+// Usage: vision_probe <checkpoint_dir>
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include "sparkinfer/safetensors.h"
+#include "sparkinfer/models/qwen_vision_config.h"
+#include "qwen_vision_hf_config.h"
+
+using sparkinfer::QwenVisionConfig;
+using sparkinfer::SafeTensorsModel;
+using sparkinfer::STTensor;
+
+namespace {
+
+int g_fail = 0;
+
+const STTensor* find(SafeTensorsModel& st, const std::string& name) { return st.tensor(name); }
+
+// Checks presence AND shape. `want` is the config-derived expectation; -1 means "don't care".
+void expect(SafeTensorsModel& st, const std::string& name, std::vector<long> want) {
+    const STTensor* t = find(st, name);
+    if (!t) { printf("  MISSING  %s\n", name.c_str()); g_fail++; return; }
+    bool ok = (int)want.size() == t->n_dims;
+    for (size_t i = 0; ok && i < want.size(); i++)
+        if (want[i] >= 0 && want[i] != t->dims[i]) ok = false;
+    if (!ok) {
+        printf("  SHAPE    %s got [", name.c_str());
+        for (int i = 0; i < t->n_dims; i++) printf("%ld%s", t->dims[i], i + 1 < t->n_dims ? ", " : "");
+        printf("] want [");
+        for (size_t i = 0; i < want.size(); i++)
+            printf("%s%s", want[i] < 0 ? "*" : std::to_string(want[i]).c_str(), i + 1 < want.size() ? ", " : "");
+        printf("]\n");
+        g_fail++;
+    }
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc < 2) { printf("usage: %s <checkpoint_dir>\n", argv[0]); return 2; }
+    const std::string dir = argv[1];
+
+    QwenVisionConfig vc;
+    std::string err;
+    if (!qwen_vision_config_from_hf_json(dir, vc, err)) { printf("[FAIL] %s\n", err.c_str()); return 1; }
+    if (!vc.present) { printf("[FAIL] no vision_config -- text-only checkpoint\n"); return 1; }
+
+    printf("vision_config: depth=%d hidden=%d heads=%d (head_dim=%d) inter=%d\n",
+           vc.depth, vc.hidden, vc.n_heads, vc.head_dim(), vc.intermediate);
+    printf("               patch=%d temporal=%d merge=%d -> merged_dim=%d out_hidden=%d\n",
+           vc.patch_size, vc.temporal_patch, vc.spatial_merge, vc.merged_patch_dim(), vc.out_hidden);
+    printf("               act=%s pos_embeddings=%d granularity=%d px\n",
+           vc.hidden_act.c_str(), vc.num_pos_embeddings, vc.size_granularity());
+    printf("               tokens: vision_start=%d image=%d vision_end=%d\n",
+           vc.vision_start_token_id, vc.image_token_id, vc.vision_end_token_id);
+    printf("               norm: mean=%.2f std=%.2f  pixels=[%ld, %ld]\n",
+           vc.mean[0], vc.std_[0], vc.min_pixels, vc.max_pixels);
+
+    SafeTensorsModel st;
+    if (!st.open(dir)) { printf("[FAIL] could not open safetensors model in %s\n", dir.c_str()); return 1; }
+
+    const int H = vc.hidden, I = vc.intermediate;
+    // Conv3d patch embed: [out, in_ch, t_patch, ph, pw]. This is the 5-D tensor the reader used to
+    // skip outright -- if it is missing here, the dims[5] widening did not take.
+    expect(st, "model.visual.patch_embed.proj.weight",
+           {H, vc.in_channels, vc.temporal_patch, vc.patch_size, vc.patch_size});
+    expect(st, "model.visual.patch_embed.proj.bias", {H});
+    expect(st, "model.visual.pos_embed.weight", {vc.num_pos_embeddings, H});
+
+    for (int b = 0; b < vc.depth; b++) {
+        const std::string p = "model.visual.blocks." + std::to_string(b) + ".";
+        expect(st, p + "norm1.weight", {H});
+        expect(st, p + "norm1.bias",   {H});
+        expect(st, p + "attn.qkv.weight", {3 * H, H});
+        expect(st, p + "attn.qkv.bias",   {3 * H});
+        expect(st, p + "attn.proj.weight", {H, H});
+        expect(st, p + "attn.proj.bias",   {H});
+        expect(st, p + "norm2.weight", {H});
+        expect(st, p + "norm2.bias",   {H});
+        expect(st, p + "mlp.linear_fc1.weight", {I, H});
+        expect(st, p + "mlp.linear_fc1.bias",   {I});
+        expect(st, p + "mlp.linear_fc2.weight", {H, I});
+        expect(st, p + "mlp.linear_fc2.bias",   {H});
+    }
+
+    // Merger: norm over one patch, then 2x2-merged patches (4608) -> LM hidden (5120).
+    expect(st, "model.visual.merger.norm.weight", {H});
+    expect(st, "model.visual.merger.norm.bias",   {H});
+    expect(st, "model.visual.merger.linear_fc1.weight", {vc.merged_patch_dim(), vc.merged_patch_dim()});
+    expect(st, "model.visual.merger.linear_fc1.bias",   {vc.merged_patch_dim()});
+    expect(st, "model.visual.merger.linear_fc2.weight", {vc.out_hidden, vc.merged_patch_dim()});
+    expect(st, "model.visual.merger.linear_fc2.bias",   {vc.out_hidden});
+
+    // The merger's output must equal the LM hidden size or the embeddings cannot be spliced in.
+    // Checked here rather than assumed: a mismatch is the whole feature failing, quietly.
+    const STTensor* emb = find(st, "model.language_model.embed_tokens.weight");
+    if (!emb) emb = find(st, "model.embed_tokens.weight");
+    if (emb && emb->n_dims == 2 && emb->dims[1] != vc.out_hidden) {
+        printf("  MISMATCH merger out_hidden=%d but LM embed dim=%ld\n", vc.out_hidden, emb->dims[1]);
+        g_fail++;
+    } else if (emb) {
+        printf("LM embed dim %ld matches merger out_hidden %d\n", emb->dims[1], vc.out_hidden);
+    }
+
+    const int expected = 3 + vc.depth * 12 + 6;
+    printf("\nchecked %d vision tensors across %d blocks\n", expected, vc.depth);
+    if (g_fail) { printf("[FAIL] %d problem(s)\n", g_fail); return 1; }
+    printf("[OK] vision tower is complete and matches its config\n");
+    return 0;
+}

--- a/runtime/examples/vision_resize_check.cpp
+++ b/runtime/examples/vision_resize_check.cpp
@@ -1,0 +1,29 @@
+// Cross-checks qwen_vision_smart_resize against the Python reference over a grid of shapes.
+// Prints one line per case as "h w -> H W" so bench/scripts/vision_resize_check.py can diff it
+// against transformers' own smart_resize. Exact integer logic, so any disagreement is a real bug,
+// not tolerance -- and an off-by-one here changes the patch grid and therefore how many image
+// tokens the prompt must carry.
+#include <cstdio>
+#include <string>
+#include "sparkinfer/models/qwen_vision_preprocess.h"
+#include "sparkinfer/models/qwen_vision_config.h"
+using namespace sparkinfer;
+
+int main(int argc, char** argv) {
+    QwenVisionConfig cfg;              // defaults match the released checkpoint
+    const int factor = cfg.size_granularity();
+    long minp = cfg.min_pixels, maxp = cfg.max_pixels;
+    if (argc >= 3) { minp = atol(argv[1]); maxp = atol(argv[2]); }
+    printf("# factor=%d min_pixels=%ld max_pixels=%ld\n", factor, minp, maxp);
+    const int dims[] = {1, 7, 16, 31, 32, 33, 64, 100, 127, 224, 256, 333, 512, 768,
+                        1024, 1080, 1920, 2048, 3000, 4096, 8192};
+    for (int h : dims)
+        for (int w : dims) {
+            int oh = 0, ow = 0; std::string err;
+            if (qwen_vision_smart_resize(h, w, factor, minp, maxp, &oh, &ow, err))
+                printf("%d %d -> %d %d\n", h, w, oh, ow);
+            else
+                printf("%d %d -> ERR\n", h, w);
+        }
+    return 0;
+}

--- a/runtime/examples/vision_resize_check.cpp
+++ b/runtime/examples/vision_resize_check.cpp
@@ -5,11 +5,52 @@
 // tokens the prompt must carry.
 #include <cstdio>
 #include <string>
+#include <vector>
 #include "sparkinfer/models/qwen_vision_preprocess.h"
 #include "sparkinfer/models/qwen_vision_config.h"
 using namespace sparkinfer;
 
+// Placeholder expansion, checked alongside smart_resize because the two together determine
+// whether the prompt's image-token count matches what the tower produces -- the single condition
+// the splice refuses on.
+static int expand_checks() {
+    QwenVisionConfig cfg;
+    const int IMG = cfg.image_token_id, VS = cfg.vision_start_token_id, VE = cfg.vision_end_token_id;
+    int fail = 0;
+    auto want = [&](bool ok, const char* what) {
+        printf("# %-56s %s\n", what, ok ? "ok" : "FAIL"); if (!ok) fail++;
+    };
+    std::string err; std::vector<int> out;
+
+    // one image, template emits a single pad, expands to 4
+    want(qwen_vision_expand_placeholders({1, VS, IMG, VE, 2}, IMG, {4}, out, err)
+         && out == std::vector<int>({1, VS, IMG, IMG, IMG, IMG, VE, 2}),
+         "single placeholder expands to N in place");
+    // two images with different grids
+    want(qwen_vision_expand_placeholders({VS, IMG, VE, 9, VS, IMG, VE}, IMG, {2, 3}, out, err)
+         && out == std::vector<int>({VS, IMG, IMG, VE, 9, VS, IMG, IMG, IMG, VE}),
+         "two images expand independently, in order");
+    // text-only prompt is untouched
+    want(qwen_vision_expand_placeholders({1, 2, 3}, IMG, {}, out, err)
+         && out == std::vector<int>({1, 2, 3}),
+         "text-only prompt passes through unchanged");
+    // count mismatches must fail, not guess
+    want(!qwen_vision_expand_placeholders({VS, IMG, VE}, IMG, {2, 2}, out, err),
+         "more images than placeholders is an error");
+    want(!qwen_vision_expand_placeholders({VS, IMG, VE, VS, IMG, VE}, IMG, {2}, out, err),
+         "more placeholders than images is an error");
+    want(!qwen_vision_expand_placeholders({VS, IMG, VE}, IMG, {0}, out, err),
+         "a zero token count is an error");
+    // grid -> token count agrees with the reference formula
+    want(qwen_vision_num_tokens(48, 48, cfg) == 576, "48x48 grid -> 576 image tokens");
+    want(qwen_vision_num_tokens(4, 4, cfg) == 4,      "4x4 grid -> 4 image tokens");
+    want(qwen_vision_num_tokens(5, 4, cfg) == 0,      "odd grid -> 0 (caller must pad)");
+    return fail;
+}
+
 int main(int argc, char** argv) {
+    const int ef = expand_checks();
+    if (ef) printf("# EXPAND CHECKS FAILED: %d\n", ef);
     QwenVisionConfig cfg;              // defaults match the released checkpoint
     const int factor = cfg.size_granularity();
     long minp = cfg.min_pixels, maxp = cfg.max_pixels;

--- a/runtime/examples/vision_splice_check.cpp
+++ b/runtime/examples/vision_splice_check.cpp
@@ -11,6 +11,7 @@
 #include <vector>
 #include <cuda_runtime.h>
 #include "sparkinfer/models/qwen_vision.h"
+#include "sparkinfer/models/qwen_vision_preprocess.h"
 
 using namespace sparkinfer;
 static int g_fail = 0;
@@ -74,6 +75,35 @@ int main() {
           "a text-only prompt (0 images, 0 placeholders) is a no-op success");
 
     cudaFree(d_x);
-    printf(g_fail ? "[FAIL] %d check(s) failed\n" : "[OK] splice behaves correctly\n", g_fail);
+
+    // ---- placeholder expansion, MULTIPLE images ----
+    // Every test so far has used exactly one image, so the per-image counts vector -- the whole
+    // reason expand takes a vector rather than an int -- has never actually been exercised. Two
+    // images of DIFFERENT sizes is the case that catches an expansion that reuses one count, or
+    // that expands in the wrong order: with equal counts both bugs are invisible.
+    {
+        const std::vector<int> in = {1, IMG, 2, IMG, 3};
+        std::vector<int> out;
+        check(qwen_vision_expand_placeholders(in, IMG, {2, 3}, out, err),
+              "expand accepts two images with different token counts");
+        const std::vector<int> want = {1, IMG, IMG, 2, IMG, IMG, IMG, 3};
+        check(out == want, "each placeholder expands to ITS OWN count, in order");
+
+        check(!qwen_vision_expand_placeholders(in, IMG, {2}, out, err),
+              "refuses 2 placeholders but 1 image");
+        check(!qwen_vision_expand_placeholders(in, IMG, {2, 3, 4}, out, err),
+              "refuses 2 placeholders but 3 images");
+        check(!qwen_vision_expand_placeholders(in, IMG, {2, 0}, out, err),
+              "refuses a zero token count");
+        check(!qwen_vision_expand_placeholders(in, IMG, {2, -1}, out, err),
+              "refuses a negative token count");
+
+        std::vector<int> out2;
+        check(qwen_vision_expand_placeholders({1, 2, 3}, IMG, {}, out2, err) &&
+              out2 == std::vector<int>({1, 2, 3}),
+              "a text-only prompt with no images passes through unchanged");
+    }
+
+    printf(g_fail ? "[FAIL] %d check(s) failed\n" : "[OK] splice and expansion behave correctly\n", g_fail);
     return g_fail ? 1 : 0;
 }

--- a/runtime/examples/vision_splice_check.cpp
+++ b/runtime/examples/vision_splice_check.cpp
@@ -1,0 +1,79 @@
+// Exercises qwen_vision_splice_embeddings: does it put the right rows in the right places, and
+// does it REFUSE a count mismatch instead of writing a partial result?
+//
+// The refusal cases matter more than the happy path. Too few placeholders drops later image
+// embeddings; too many leaves stale token embeddings inside the image span. Either way the model
+// gets a prompt whose image region is quietly truncated or padded, describes it fluently, and
+// nothing downstream can tell. This test exists to keep that a hard error.
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+#include <cuda_runtime.h>
+#include "sparkinfer/models/qwen_vision.h"
+
+using namespace sparkinfer;
+static int g_fail = 0;
+static void check(bool ok, const char* what) {
+    printf("  %-58s %s\n", what, ok ? "ok" : "FAIL");
+    if (!ok) g_fail++;
+}
+
+int main() {
+    const int H = 8, IMG = 248056, N = 10, n_img = 3;
+    // positions 2, 5, 6 carry the placeholder
+    std::vector<int> ids = {1, 2, IMG, 4, 5, IMG, IMG, 8, 9, 10};
+
+    std::vector<unsigned short> host_x((size_t)N * H);
+    for (size_t i = 0; i < host_x.size(); i++) host_x[i] = 0x3F80 >> 0;   // arbitrary sentinel
+    void* d_x = nullptr;
+    if (cudaMalloc(&d_x, host_x.size() * sizeof(unsigned short)) != cudaSuccess) {
+        printf("[FAIL] cudaMalloc\n"); return 1;
+    }
+    cudaMemcpy(d_x, host_x.data(), host_x.size() * sizeof(unsigned short), cudaMemcpyHostToDevice);
+
+    // Distinct, exactly-bf16-representable values per row so a misplaced row is unambiguous.
+    std::vector<float> emb((size_t)n_img * H);
+    for (int r = 0; r < n_img; r++)
+        for (int d = 0; d < H; d++) emb[(size_t)r * H + d] = (float)(r + 1) * 16.0f + d;
+
+    std::string err;
+    check(qwen_vision_splice_embeddings(d_x, ids.data(), N, emb.data(), n_img, H, IMG, err),
+          "splice with matching placeholder count succeeds");
+
+    std::vector<unsigned short> got(host_x.size());
+    cudaMemcpy(got.data(), d_x, got.size() * sizeof(unsigned short), cudaMemcpyDeviceToHost);
+    auto bf2f = [](unsigned short h) { unsigned u = (unsigned)h << 16; float f; memcpy(&f, &u, 4); return f; };
+
+    bool placed = true, untouched = true;
+    const int expect_pos[3] = {2, 5, 6};
+    for (int r = 0; r < n_img; r++)
+        for (int d = 0; d < H; d++)
+            if (bf2f(got[(size_t)expect_pos[r] * H + d]) != emb[(size_t)r * H + d]) placed = false;
+    for (int t = 0; t < N; t++) {
+        if (t == 2 || t == 5 || t == 6) continue;
+        for (int d = 0; d < H; d++)
+            if (got[(size_t)t * H + d] != host_x[(size_t)t * H + d]) untouched = false;
+    }
+    check(placed, "image rows land at exactly the placeholder positions");
+    check(untouched, "non-placeholder rows are left untouched");
+
+    // Refusals. Each must fail AND leave the buffer alone.
+    cudaMemcpy(d_x, host_x.data(), host_x.size() * sizeof(unsigned short), cudaMemcpyHostToDevice);
+    check(!qwen_vision_splice_embeddings(d_x, ids.data(), N, emb.data(), 2, H, IMG, err),
+          "refuses when embeddings < placeholders");
+    check(!qwen_vision_splice_embeddings(d_x, ids.data(), N, emb.data(), 4, H, IMG, err),
+          "refuses when embeddings > placeholders");
+    std::vector<int> none(N, 7);
+    check(!qwen_vision_splice_embeddings(d_x, none.data(), N, emb.data(), n_img, H, IMG, err),
+          "refuses when the prompt has no placeholders at all");
+    cudaMemcpy(got.data(), d_x, got.size() * sizeof(unsigned short), cudaMemcpyDeviceToHost);
+    check(memcmp(got.data(), host_x.data(), host_x.size() * sizeof(unsigned short)) == 0,
+          "a refused splice writes NOTHING (no partial state)");
+    check(qwen_vision_splice_embeddings(d_x, none.data(), N, emb.data(), 0, H, IMG, err),
+          "a text-only prompt (0 images, 0 placeholders) is a no-op success");
+
+    cudaFree(d_x);
+    printf(g_fail ? "[FAIL] %d check(s) failed\n" : "[OK] splice behaves correctly\n", g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/runtime/include/sparkinfer/inference_engine.h
+++ b/runtime/include/sparkinfer/inference_engine.h
@@ -29,6 +29,11 @@ namespace sparkinfer {
 // speculation. Anyone picking this up owns the sampling guard: Qwen35Model::generate has no
 // check against a temperature-sampling caller (see its comment), and step_job serves arbitrary
 // per-request sampling params, so multi-accept here needs one.
+// Held by pointer only, so a forward declaration keeps the vision tower out of every
+// translation unit that merely wants to submit a request.
+struct QwenVisionWeights;
+struct QwenVisionConfig;
+
 class ContinuousBatchEngine {
 public:
     struct Request {
@@ -108,6 +113,32 @@ public:
         //   * the LAST forced token costs no forward pass: its logprob comes from the position
         //     before it, and nothing is predicted after it.
         std::vector<int> forced_tokens;
+        // MULTIMODAL. One entry per image, in prompt order; vision_pos holds the absolute
+        // prompt indices the resulting embedding rows overwrite (the expanded <|image_pad|> run),
+        // concatenated across images. Empty for a text request, which is the no-op path.
+        //
+        // PIXELS, not embeddings, and deliberately so. Two reasons, and both are load-bearing:
+        //
+        // 1. The tower must run on the WORKER thread. qwen_vision_forward issues its work on the
+        //    legacy default stream, and the decode path captures CUDA graphs; the legacy stream
+        //    implicitly synchronises with capturing blocking streams, so running the tower from a
+        //    submitting HTTP thread would break capture out from under an unrelated decoding job.
+        //    Preprocessing (decode, resize, normalise) is pure CPU and stays with the caller.
+        //
+        // 2. The embeddings are staged on the SHARED model via set_pending_vision, a single slot
+        //    consumed by the next prefill. Only the worker knows which job that is. Staging from
+        //    the submitting thread would splice one request's image into another's prefill --
+        //    the same shape as the clear_prefix_cache race in ModelEngine::complete_streaming,
+        //    which corrupted the KV cache under concurrent load.
+        //
+        // Deep-copied into Job by submit_locked's `job.req = req;`, like prompt and logit_bias.
+        struct VisionImage {
+            std::vector<float> pixels;   // [grid_h*grid_w, in_ch*temporal*patch*patch], row-major
+            int grid_h = 0;
+            int grid_w = 0;
+        };
+        std::vector<VisionImage> vision_images;
+        std::vector<int> vision_pos;
     };
 
     struct Result {
@@ -161,6 +192,12 @@ public:
                                   on_token_logprob = nullptr);
 
     int num_active() const;
+
+    // Vision tower used by step_job when a request carries images. Both non-owning and expected
+    // to outlive the engine (ModelEngine owns them). Never set => a request with images is
+    // rejected rather than silently answered from its text alone, which would produce a fluent
+    // description of an image the model never saw.
+    void set_vision(const QwenVisionWeights* weights, const QwenVisionConfig* cfg);
     int num_free_kv_blocks() const;
     // Admission-time queue depth cap (SPARKINFER_MAX_QUEUE_DEPTH, 0 = unlimited). Requests
     // beyond this are rejected as overloaded before any KV allocation is attempted.
@@ -180,6 +217,8 @@ private:
     KVCacheManager* kv_;
     Scheduler scheduler_;
     SchedulePolicy policy_ = SchedulePolicy::CONTINUOUS_BATCHING;
+    const QwenVisionWeights* vision_weights_ = nullptr;
+    const QwenVisionConfig* vision_cfg_ = nullptr;
     std::thread worker_;
     std::atomic<bool> running_{false};
     mutable std::mutex mu_;

--- a/runtime/include/sparkinfer/inference_engine.h
+++ b/runtime/include/sparkinfer/inference_engine.h
@@ -133,7 +133,11 @@ public:
         //
         // Deep-copied into Job by submit_locked's `job.req = req;`, like prompt and logit_bias.
         struct VisionImage {
-            std::vector<float> pixels;   // [grid_h*grid_w, in_ch*temporal*patch*patch], row-major
+            // Shared, not owned: Request is deep-copied into Job, and a request that retries or
+            // fans out into branches copies it again. A 1536-token image is ~9 MB of patch
+            // tensor, so copying it per hop is worth avoiding; nothing mutates it after
+            // preprocessing.
+            std::shared_ptr<const std::vector<float>> pixels;
             int grid_h = 0;
             int grid_w = 0;
         };

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -214,6 +214,14 @@ public:
     // thread still blocks normally.
     std::recursive_mutex& device_mutex();
 
+    // Stage an image for the NEXT prefill_batched call. emb is [n_img, hidden] float32 from
+    // qwen_vision_forward; positions are the prompt indices carrying image_token_id, which the
+    // caller has already checked number exactly n_img. Consumed by that one prefill and then
+    // cleared -- it is per-request state, not model state, and leaving it set would splice a
+    // stale image into the next prompt.
+    bool set_pending_vision(const float* emb, const int* positions, int n_img, int hidden);
+    void clear_pending_vision();
+
     // Load weights from a sparkinfer weight directory (see runtime/tools/convert_qwen35.py).
     // Returns false on failure. Allocates device buffers it owns.
     bool load_weights(const std::string& dir);

--- a/runtime/include/sparkinfer/models/qwen_vision.h
+++ b/runtime/include/sparkinfer/models/qwen_vision.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "sparkinfer/models/qwen_vision_config.h"
+
+namespace sparkinfer {
+
+class SafeTensorsModel;
+
+// Device-resident vision tower. All bf16: the checkpoint's quantization_config ignores
+// model.visual.*, so there is no NVFP4/FP8 path to mirror here -- it loads as shipped.
+struct QwenVisionBlockWeights {
+    const void* norm1_w = nullptr; const void* norm1_b = nullptr;
+    const void* qkv_w   = nullptr; const void* qkv_b   = nullptr;   // [3H, H], [3H]
+    const void* proj_w  = nullptr; const void* proj_b  = nullptr;   // [H, H],  [H]
+    const void* norm2_w = nullptr; const void* norm2_b = nullptr;
+    const void* fc1_w   = nullptr; const void* fc1_b   = nullptr;   // [I, H],  [I]
+    const void* fc2_w   = nullptr; const void* fc2_b   = nullptr;   // [H, I],  [H]
+};
+
+struct QwenVisionWeights {
+    const void* patch_w = nullptr;   // [H, C*T*P*P] -- the Conv3d flattened to a dense matrix
+    const void* patch_b = nullptr;   // [H]
+    std::vector<QwenVisionBlockWeights> blocks;
+    const void* merger_norm_w = nullptr; const void* merger_norm_b = nullptr;
+    const void* merger_fc1_w  = nullptr; const void* merger_fc1_b  = nullptr;  // [4H_m, 4H_m]
+    const void* merger_fc2_w  = nullptr; const void* merger_fc2_b  = nullptr;  // [out, 4H_m]
+    // Host copy of the learned position table, [num_pos, H]. Kept on the HOST because the
+    // bilinear resample to an arbitrary patch grid is done host-side and uploaded per image --
+    // it is a few hundred KB and depends on the image's grid, so precomputing it there keeps the
+    // device path free of an interpolation kernel and matches vision_ref.py exactly.
+    std::vector<float> pos_table;
+    int pos_side = 0;                // sqrt(num_pos); the table is a pos_side x pos_side grid
+    std::vector<void*> owned;        // every cudaMalloc above, for teardown
+};
+
+// Loads model.visual.* from an already-open checkpoint onto the device.
+bool load_qwen_vision_weights(SafeTensorsModel& st, const QwenVisionConfig& cfg,
+                              QwenVisionWeights& w, std::string& err);
+void free_qwen_vision_weights(QwenVisionWeights& w);
+
+// Runs the tower on one image's patches.
+//   pixels_host: [grid_h*grid_w, C*T*P*P] float32, ROW-MAJOR over the patch grid, each patch laid
+//                out (C, T, P, P). Row-major is equivalent to HF's merge-block-major ordering --
+//                proved to 1e-15 by bench/scripts/vision_order_check.py -- and the merge kernel
+//                does the regroup that makes it so.
+//   out_host:    [(grid_h/merge)*(grid_w/merge), out_hidden] float32, ready to splice into the
+//                token embedding stream at image_token_id positions.
+bool qwen_vision_forward(const QwenVisionWeights& w, const QwenVisionConfig& cfg,
+                         const float* pixels_host, int grid_h, int grid_w,
+                         float* out_host, std::string& err);
+
+}  // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen_vision.h
+++ b/runtime/include/sparkinfer/models/qwen_vision.h
@@ -50,4 +50,20 @@ bool qwen_vision_forward(const QwenVisionWeights& w, const QwenVisionConfig& cfg
                          const float* pixels_host, int grid_h, int grid_w,
                          float* out_host, std::string& err);
 
+// Splices vision embeddings into an already-embedded prompt, in place.
+//
+//   d_x:        [n_tokens, hidden] bf16 on device -- the output of launch_embedding
+//   token_ids:  [n_tokens] host, the prompt as tokenized
+//   vision_emb: [n_img, hidden] host float32 -- qwen_vision_forward's output
+//
+// Fails (writing nothing) unless the number of image_token_id placeholders in token_ids is
+// EXACTLY n_img. That check is the whole point of this function existing rather than callers
+// scattering rows themselves: too few placeholders and later image embeddings are dropped, too
+// many and stale token embeddings survive inside the image span. Either way the model reads a
+// prompt whose image region is silently truncated or padded, produces fluent text about it, and
+// nothing downstream can tell. A hard error is the only safe behaviour.
+bool qwen_vision_splice_embeddings(void* d_x, const int* token_ids, int n_tokens,
+                                   const float* vision_emb, int n_img, int hidden,
+                                   int image_token_id, std::string& err);
+
 }  // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen_vision_config.h
+++ b/runtime/include/sparkinfer/models/qwen_vision_config.h
@@ -1,0 +1,52 @@
+#pragma once
+#include <string>
+
+namespace sparkinfer {
+
+// Vision tower geometry for Qwen3.8-27B's `qwen3_5_vision` encoder, read from config.json's
+// `vision_config` block. Defaults are the values the released ModelOpt checkpoint ships, so a
+// checkpoint that omits a field still lands on something correct for that model rather than zero.
+//
+// The tower is UNQUANTIZED bf16 (666 tensors, ~1.1 GB) even in the NVFP4 checkpoint: the
+// quantization_config's `ignore` list excludes `model.visual.*`. So it loads as plain bf16 and
+// needs no NVFP4/FP8 path -- see load_compressed_tensors.
+struct QwenVisionConfig {
+    bool  present      = false;   // true once a vision_config block was actually found
+    int   depth        = 27;      // transformer blocks in the tower
+    int   hidden       = 1152;
+    int   n_heads      = 16;      // head_dim = hidden / n_heads = 72
+    int   intermediate = 4304;    // MLP inner width (linear_fc1 -> gelu -> linear_fc2)
+    int   in_channels  = 3;
+    int   patch_size   = 16;
+    int   temporal_patch = 2;     // Conv3d kernel's time extent; a still image is duplicated to 2
+    int   spatial_merge  = 2;     // 2x2 patches merged before projection -> merger input is
+                                  // hidden * spatial_merge^2 = 4608
+    int   num_pos_embeddings = 2304;   // learned table, 48x48 grid
+    int   out_hidden   = 5120;    // merger output == the LM's hidden size, so merged patch
+                                  // embeddings drop straight into the token embedding stream
+    std::string hidden_act = "gelu_pytorch_tanh";
+
+    // Special token ids that mark where image embeddings are spliced into the prompt. The tower
+    // produces one embedding per MERGED patch, and exactly that many image_token_id placeholders
+    // must appear between vision_start and vision_end.
+    int vision_start_token_id = 248053;
+    int vision_end_token_id   = 248054;
+    int image_token_id        = 248056;
+    int video_token_id        = 248057;
+
+    // Preprocessing (preprocessor_config.json). Qwen2VLImageProcessorFast is dynamic-resolution:
+    // it does not resize to fixed dimensions, it scales so the pixel COUNT lands in
+    // [min_pixels, max_pixels] and both sides are multiples of patch_size * spatial_merge.
+    float mean[3] = {0.5f, 0.5f, 0.5f};
+    float std_[3] = {0.5f, 0.5f, 0.5f};
+    long  min_pixels = 65536;
+    long  max_pixels = 16777216;
+
+    int merged_patch_dim() const { return hidden * spatial_merge * spatial_merge; }
+    int head_dim() const { return n_heads > 0 ? hidden / n_heads : 0; }
+    // Both image dimensions must be a multiple of this, so the patch grid divides evenly into
+    // the 2x2 merge blocks.
+    int size_granularity() const { return patch_size * spatial_merge; }
+};
+
+}  // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen_vision_hf_config.h
+++ b/runtime/include/sparkinfer/models/qwen_vision_hf_config.h
@@ -10,7 +10,7 @@
 #include <nlohmann/json.hpp>
 #include "sparkinfer/models/qwen_vision_config.h"
 
-static bool qwen_vision_config_from_hf_json(const std::string& model_dir,
+inline bool qwen_vision_config_from_hf_json(const std::string& model_dir,
                                             sparkinfer::QwenVisionConfig& vc, std::string& err) {
     std::ifstream cf(model_dir + "/config.json");
     if (!cf) { err = "config.json not found in " + model_dir; return false; }

--- a/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
+++ b/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
@@ -37,4 +37,24 @@ bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
 // silently misaligns the whole sequence.
 int qwen_vision_num_tokens(int grid_h, int grid_w, const QwenVisionConfig& cfg);
 
+// Expands each single image placeholder into the number of tokens its image actually needs.
+//
+// The chat template emits exactly ONE <|image_pad|> per image:
+//     "<|vision_start|><|image_pad|><|vision_end|>"
+// and the reference PROCESSOR (not the template) expands it, because only the processor knows the
+// resized grid:
+//     num_image_tokens = image_grid_thw.prod() // merge_size**2
+// which for a still image is (grid_h/merge)*(grid_w/merge) -- qwen_vision_num_tokens.
+//
+// Done in token space rather than by editing the rendered string: the template's output has
+// already been tokenized, expanding text would force a re-tokenize, and a re-tokenize can shift
+// unrelated tokens through merge effects at the seams.
+//
+// counts must have one entry per placeholder found, in order. A mismatch is an error rather than
+// a best-effort expansion: it means the caller preprocessed a different number of images than the
+// prompt refers to, and guessing which is right would produce a silently misaligned prompt.
+bool qwen_vision_expand_placeholders(const std::vector<int>& in, int image_token_id,
+                                     const std::vector<int>& counts,
+                                     std::vector<int>& out, std::string& err);
+
 }  // namespace sparkinfer

--- a/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
+++ b/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
@@ -1,0 +1,40 @@
+#pragma once
+#include <string>
+#include <vector>
+#include "sparkinfer/models/qwen_vision_config.h"
+
+namespace sparkinfer {
+
+// Qwen2VLImageProcessor's dynamic-resolution sizing, ported exactly from
+// transformers/models/qwen2_vl/image_processing_qwen2_vl.py::smart_resize.
+//
+// Both sides end up divisible by `factor` (= patch_size * spatial_merge, 32 here) and the total
+// pixel count lands in [min_pixels, max_pixels] while keeping the aspect ratio as close as
+// possible. Integer logic with round/floor/ceil at specific points -- ported verbatim rather than
+// re-derived, because an off-by-one changes the patch grid and therefore how many image tokens
+// the prompt must carry.
+//
+// Returns false (and sets err) for an aspect ratio beyond 200:1, matching the reference's own
+// refusal rather than silently producing a degenerate grid.
+bool qwen_vision_smart_resize(int height, int width, int factor, long min_pixels, long max_pixels,
+                              int* out_h, int* out_w, std::string& err);
+
+// Full preprocess: RGB8 -> resized, normalized, patchified float32 ready for the tower.
+//
+//   rgb:      [height, width, 3] uint8, row-major
+//   pixels:   [grid_h*grid_w, in_ch*temporal*patch*patch] float32, row-major over the patch grid,
+//             each patch laid out (C, T, P, P) with the still image repeated across T.
+//
+// Row-major patch order is equivalent to HF's merge-block-major -- proved to 1e-15 by
+// bench/scripts/vision_order_check.py -- and launch_vision_patch_merge does the regroup.
+bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
+                            const QwenVisionConfig& cfg,
+                            std::vector<float>& pixels, int* grid_h, int* grid_w,
+                            std::string& err);
+
+// How many image placeholder tokens a given grid needs: one per MERGED patch. The prompt must
+// carry exactly this many image_token_id between vision_start and vision_end, or the splice
+// silently misaligns the whole sequence.
+int qwen_vision_num_tokens(int grid_h, int grid_w, const QwenVisionConfig& cfg);
+
+}  // namespace sparkinfer

--- a/runtime/include/sparkinfer/safetensors.h
+++ b/runtime/include/sparkinfer/safetensors.h
@@ -12,7 +12,11 @@ enum class STDType { F32, F16, BF16, I64, I32, I8, U8, F8_E4M3, Unknown };
 struct STTensor {
     STDType dtype = STDType::Unknown;
     int     n_dims = 0;
-    long    dims[4] = {1, 1, 1, 1};   // row-major, dims[0] slowest (matches safetensors' own order)
+    // 5 slots, not 4: Qwen3.8's vision tower carries a 5-D Conv3d patch-embed weight
+    // (model.visual.patch_embed.proj.weight, [out, in_ch, t_patch, ph, pw]). A 4-wide array made
+    // that tensor uncatalogable, so the reader skipped it and image input was structurally
+    // impossible regardless of what else was implemented.
+    long    dims[5] = {1, 1, 1, 1, 1};   // row-major, dims[0] slowest (matches safetensors' own order)
     long    n_values = 0;
     long    n_bytes = 0;
     const void* data = nullptr;       // pointer into the owning shard's mmap

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -414,7 +414,8 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
                                  (img.grid_w / vision_cfg_->spatial_merge);
                 const size_t off = emb.size();
                 emb.resize(off + (size_t)nblk * vision_cfg_->out_hidden);
-                if (!qwen_vision_forward(*vision_weights_, *vision_cfg_, img.pixels.data(),
+                if (!img.pixels ||
+                    !qwen_vision_forward(*vision_weights_, *vision_cfg_, img.pixels->data(),
                                          img.grid_h, img.grid_w, emb.data() + off, verr)) {
                     job.error = "vision tower failed: " + verr;
                     finish_job(job);

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -1,4 +1,5 @@
 #include "sparkinfer/inference_engine.h"
+#include "sparkinfer/models/qwen_vision.h"
 
 #include "sparkinfer/device_health.h"
 
@@ -136,6 +137,13 @@ ContinuousBatchEngine::Result ContinuousBatchEngine::complete_streaming(
         return out;
     }
     return wait_locked(rid);
+}
+
+void ContinuousBatchEngine::set_vision(const QwenVisionWeights* weights,
+                                      const QwenVisionConfig* cfg) {
+    std::lock_guard<std::mutex> lock(mu_);
+    vision_weights_ = weights;
+    vision_cfg_ = cfg;
 }
 
 int ContinuousBatchEngine::num_active() const {
@@ -386,8 +394,45 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
         // logprobs -- it costs a full-vocab sort, and unlike the decode path (frozen graph
         // topology) this one is free to branch on the host.
         const bool want_seed_logprob = job.req.logprobs && job.on_token_logprob;
+        // Run the vision tower for this job HERE, on the worker thread, and stage the result
+        // only for the prefill immediately below. Both halves of that are required: the tower
+        // issues work on the legacy default stream, which cannot overlap another job's CUDA
+        // graph capture, and set_pending_vision is a single slot on the shared model, so leaving
+        // it set would splice this request's image into whatever job prefills next. One worker
+        // thread runs step_job, so nothing can prefill between the set and the clear.
+        const bool has_vision = !job.req.vision_pos.empty();
+        if (has_vision && (!vision_weights_ || !vision_cfg_)) {
+            job.error = "this model has no vision tower; image input is not supported";
+            finish_job(job);
+            return true;
+        }
+        if (has_vision) {
+            std::vector<float> emb;
+            std::string verr;
+            for (const auto& img : job.req.vision_images) {
+                const int nblk = (img.grid_h / vision_cfg_->spatial_merge) *
+                                 (img.grid_w / vision_cfg_->spatial_merge);
+                const size_t off = emb.size();
+                emb.resize(off + (size_t)nblk * vision_cfg_->out_hidden);
+                if (!qwen_vision_forward(*vision_weights_, *vision_cfg_, img.pixels.data(),
+                                         img.grid_h, img.grid_w, emb.data() + off, verr)) {
+                    job.error = "vision tower failed: " + verr;
+                    finish_job(job);
+                    return true;
+                }
+            }
+            if (emb.size() != job.req.vision_pos.size() * (size_t)vision_cfg_->out_hidden ||
+                !model_->set_pending_vision(emb.data(), job.req.vision_pos.data(),
+                                            (int)job.req.vision_pos.size(),
+                                            vision_cfg_->out_hidden)) {
+                job.error = "failed to stage image embeddings for prefill";
+                finish_job(job);
+                return true;
+            }
+        }
         const int seed = model_->ingest_prompt_range(job.req.prompt.data(), job.prefill_pos, n,
                                                       chunk_limit, &out_pos, want_seed_logprob);
+        if (has_vision) model_->clear_pending_vision();
         job.prefill_pos = out_pos;
         if (job.prefill_pos >= n) {
             // Known v1 scope limitation for temperature sampling (runtime/src/models/qwen35.cpp's

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -89,6 +89,14 @@ inline bool muse_fuse_tail() {
 }
 using bf16 = unsigned short;
 
+// float -> bf16 on the host. Truncating (not round-to-nearest-even), matching what the rest of
+// this file's host-side conversions do; the vision embeddings it converts are already the output
+// of a bf16 tower, so the low bits being dropped here carry no information.
+inline bf16 f32_to_bf16_host(float f) {
+    unsigned u; std::memcpy(&u, &f, sizeof(u));
+    return (bf16)(u >> 16);
+}
+
 // forward_token() sentinel: the decode graph was enqueued but not yet collected. Never a valid
 // token id, so it cannot be confused with a real argmax.
 constexpr int kDFlashDeferred = INT_MIN;
@@ -193,6 +201,12 @@ struct Qwen35Model::Impl {
     int qdim, kvdim;
     int linear_qdim = 0, linear_vdim = 0, linear_qkvdim = 0;
     bool gguf = false;   // true after load_gguf: dense weights are native [out,in], use GEMV
+    // Pending image input for the NEXT prefill_batched call, set by set_pending_vision and
+    // cleared once consumed. Device-resident so prefill can splice without a host round trip.
+    // Null on every text-only request, which is what keeps the vision path off the measured path.
+    void* d_vision_emb = nullptr;
+    int*  d_vision_pos = nullptr;
+    int   vision_n = 0;
     // Guards the capture window against legacy-default-stream work issued by other threads.
     // See Qwen35Model::device_mutex() in the header for why this is required.
     std::recursive_mutex device_mu;
@@ -865,6 +879,33 @@ int Qwen35Model::adaptive_nsplits_for(int seqlen) const {
 }
 
 std::recursive_mutex& Qwen35Model::device_mutex() { return p_->device_mu; }
+
+bool Qwen35Model::set_pending_vision(const float* emb, const int* positions, int n_img, int hidden) {
+    Impl& s = *p_;
+    clear_pending_vision();
+    if (!emb || !positions || n_img <= 0) return false;
+    if (hidden != s.cfg.hidden) return false;   // merger output must match the LM embedding width
+    const size_t n = (size_t)n_img * hidden;
+    std::vector<bf16> h(n);
+    for (size_t i = 0; i < n; i++) h[i] = f32_to_bf16_host(emb[i]);
+    if (cudaMalloc(&s.d_vision_emb, n * sizeof(bf16)) != cudaSuccess) return false;
+    if (cudaMalloc((void**)&s.d_vision_pos, (size_t)n_img * sizeof(int)) != cudaSuccess) {
+        cudaFree(s.d_vision_emb); s.d_vision_emb = nullptr; return false;
+    }
+    if (cudaMemcpy(s.d_vision_emb, h.data(), n * sizeof(bf16), cudaMemcpyHostToDevice) != cudaSuccess
+     || cudaMemcpy(s.d_vision_pos, positions, (size_t)n_img * sizeof(int), cudaMemcpyHostToDevice) != cudaSuccess) {
+        clear_pending_vision(); return false;
+    }
+    s.vision_n = n_img;
+    return true;
+}
+
+void Qwen35Model::clear_pending_vision() {
+    Impl& s = *p_;
+    if (s.d_vision_emb) cudaFree(s.d_vision_emb);
+    if (s.d_vision_pos) cudaFree(s.d_vision_pos);
+    s.d_vision_emb = nullptr; s.d_vision_pos = nullptr; s.vision_n = 0;
+}
 
 int Qwen35Model::forward_token(int token_id, int position, bool sample, float temperature,
                                unsigned long long seed, unsigned long long sample_step,
@@ -2791,8 +2832,18 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_lo
                           s.dflash_capture ? s.dflash_layer_ids.data() : nullptr,
                           s.dflash_capture ? s.dflash_n_cap : 0,
                           s.dflash_capture ? s.dflash_context : nullptr,
-                          s.dflash_capture ? s.dflash_ctx_start : 0 };
+                          s.dflash_capture ? s.dflash_ctx_start : 0,
+                          // Image input, if set_pending_vision was called for this prompt.
+                          // Only prefill_batched gets these: the other two Qwen35PrefillCtx
+                          // sites are DSpark verify paths, which replay already-generated
+                          // tokens and can never contain an image placeholder.
+                          s.d_vision_emb, s.d_vision_pos, s.vision_n };
     const int seed = prefill_batched_run(ctx, prompt_ids, n, pos0);
+    // Consume it. This is PER-REQUEST state, not model state: leaving it set would splice the
+    // previous request's image into the next prompt, which would produce fluent, confident text
+    // about an image the caller never sent. Cleared on every path out, including the failure
+    // path below, because a prefill that returned -1 has still consumed the staging.
+    clear_pending_vision();
     if (seed >= 0 && s.dflash_capture && s.dflash_context && s.dflash_n_cap > 0)
         s.dflash_ctx_len = pos0 + n;
     // Seed-token logprob (see ingest_prompt_range's want_seed_logprob). prefill_batched_run's

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -13,6 +13,7 @@
 
 #include "qwen35_prefill.h"
 #include "sparkinfer/kernels/prefill.h"
+#include "sparkinfer/kernels/vision.h"
 #include "sparkinfer/kernels/prefill_attn_window.h"
 #include "sparkinfer/kernels/fused.h"
 #include "sparkinfer/kernels/quant.h"
@@ -1390,6 +1391,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
 
     // embed -> x, prime xn = RMSNorm(x, layer0.input_norm)
     kernels::launch_embedding(d_ids, s.w.embed_tokens, x, N, H, st);
+    // Image input, if any: overwrite the rows whose token is image_token_id with the vision
+    // tower's merged embeddings. Strictly additive -- s.vision_emb is null for every text-only
+    // request, so this branch is not taken and no vision code is referenced at all. The caller
+    // has already checked that vision_n equals the placeholder count; by here they agree.
+    //
+    // Placed immediately after the gather and before ANY layer runs, because from the model's
+    // point of view an image embedding is just a token embedding that came from somewhere else.
+    // Everything downstream -- RoPE, attention, the KV write -- treats those rows identically,
+    // which is what makes plain 1-D RoPE sufficient (this checkpoint has no M-RoPE).
+    if (s.vision_emb && s.vision_pos && s.vision_n > 0)
+        kernels::launch_vision_splice(x, s.vision_pos, s.vision_emb, s.vision_n, H, st);
     // Muse Glimmer: unweighted embedding RMSNorm on x before layer 0 (decode qwen35.cpp:724-725).
     // emb_norm_ones is a constant-1.0 weight, so this is a pure normalization of the embedding.
     if (c.muse_glimmer && s.emb_norm_ones)

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -42,6 +42,21 @@ struct Qwen35PrefillCtx {
     int                  n_capture;
     void*                capture_dst;
     int                  capture_start;
+    // Optional image input. MUST STAY LAST: every Qwen35PrefillCtx is built with positional
+    // aggregate initialization, so a field inserted mid-struct silently shifts every later value
+    // -- putting these after n_splits made capture_layers land in vision_emb. At the end, the
+    // existing initializers simply omit them and they value-initialize to null/0, which is
+    // exactly the text-only default.
+    //
+    // Null (always so for a text-only request) means the vision path is not merely skipped but
+    // never referenced -- the splice site in prefill_batched_run is guarded on this pointer.
+    //   vision_emb: [vision_n, hidden] bf16 on device, the tower's merged embeddings
+    //   vision_pos: [vision_n] int32 on device, prompt positions carrying image_token_id
+    // The caller validates vision_n against the placeholder count BEFORE building this, so by the
+    // time prefill sees it the two are known to agree.
+    const void*          vision_emb = nullptr;
+    const int*           vision_pos = nullptr;
+    int                  vision_n   = 0;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.

--- a/runtime/src/models/qwen_vision.cpp
+++ b/runtime/src/models/qwen_vision.cpp
@@ -144,7 +144,10 @@ bool qwen_vision_forward(const QwenVisionWeights& w, const QwenVisionConfig& cfg
     void* d_mlp  = alloc((size_t)N * I * sizeof(bf16));
     void* d_mrg  = alloc((size_t)nblk * M * sizeof(bf16));
     void* d_out  = alloc((size_t)nblk * (size_t)cfg.out_hidden * sizeof(bf16));
-    if (!d_pix || !d_x || !d_h || !d_qkv || !d_q || !d_k || !d_v || !d_att || !d_mlp || !d_mrg || !d_out) {
+    void* d_cos  = alloc((size_t)N * (hd / 2) * sizeof(float));
+    void* d_sin  = alloc((size_t)N * (hd / 2) * sizeof(float));
+    if (!d_pix || !d_x || !d_h || !d_qkv || !d_q || !d_k || !d_v || !d_att || !d_mlp || !d_mrg ||
+        !d_out || !d_cos || !d_sin) {
         cleanup(); err = "vision forward: device allocation failed"; return false;
     }
 
@@ -187,6 +190,34 @@ bool qwen_vision_forward(const QwenVisionWeights& w, const QwenVisionConfig& cfg
     }
     kernels::launch_vision_residual_add(d_x, d_h, (long)N * H, s);
 
+    // --- 2D rotary tables ---
+    // Built here rather than per block: q/k are re-projected every block, but the rotation each
+    // patch receives depends only on where it sits in the grid, so the tables are computed once.
+    //
+    // The frequency vector is head_dim/2 wide: its first half rotates by the patch's ROW, its
+    // second by its COLUMN, giving attention a way to resolve relative position that the learned
+    // pos_embed -- added once, before the first block -- cannot. inv_freq matches the reference's
+    // 1 / theta^(2i/rope_dim) with rope_dim = head_dim/2, so exponents run i/(head_dim/4).
+    {
+        const int half = hd / 2, per_axis = half / 2;
+        std::vector<float> hc((size_t)N * half), hs((size_t)N * half);
+        for (int y = 0; y < grid_h; y++)
+            for (int x = 0; x < grid_w; x++) {
+                const size_t t = (size_t)y * grid_w + x;
+                for (int j = 0; j < half; j++) {
+                    const int i2 = (j < per_axis) ? j : j - per_axis;
+                    const double pos = (j < per_axis) ? (double)y : (double)x;
+                    const double f = pos * std::pow(10000.0, -(double)i2 / (double)per_axis);
+                    hc[t * half + j] = (float)std::cos(f);
+                    hs[t * half + j] = (float)std::sin(f);
+                }
+            }
+        if (!cu_ok(cudaMemcpy(d_cos, hc.data(), hc.size() * sizeof(float), cudaMemcpyHostToDevice),
+                   "upload rope cos", err) ||
+            !cu_ok(cudaMemcpy(d_sin, hs.data(), hs.size() * sizeof(float), cudaMemcpyHostToDevice),
+                   "upload rope sin", err)) { cleanup(); return false; }
+    }
+
     const float scale = 1.0f / std::sqrt((float)hd);
     for (int b = 0; b < cfg.depth; b++) {
         const auto& B = w.blocks[b];
@@ -199,6 +230,7 @@ bool qwen_vision_forward(const QwenVisionWeights& w, const QwenVisionConfig& cfg
         cudaMemcpy2DAsync(d_q, col, (const char*)d_qkv,             row, col, N, cudaMemcpyDeviceToDevice, s);
         cudaMemcpy2DAsync(d_k, col, (const char*)d_qkv + col,       row, col, N, cudaMemcpyDeviceToDevice, s);
         cudaMemcpy2DAsync(d_v, col, (const char*)d_qkv + 2 * col,   row, col, N, cudaMemcpyDeviceToDevice, s);
+        kernels::launch_vision_rope(d_q, d_k, d_cos, d_sin, N, heads, hd, s);
         kernels::launch_vision_attention(d_q, d_k, d_v, d_att, N, heads, hd, scale, s);
         kernels::launch_prefill_gemm(d_att, B.proj_w, d_h, N, H, H, s);
         kernels::launch_vision_add_bias(d_h, B.proj_b, N, H, s);

--- a/runtime/src/models/qwen_vision.cpp
+++ b/runtime/src/models/qwen_vision.cpp
@@ -237,4 +237,41 @@ bool qwen_vision_forward(const QwenVisionWeights& w, const QwenVisionConfig& cfg
     return true;
 }
 
+bool qwen_vision_splice_embeddings(void* d_x, const int* token_ids, int n_tokens,
+                                   const float* vision_emb, int n_img, int hidden,
+                                   int image_token_id, std::string& err) {
+    if (!d_x || !token_ids || !vision_emb || hidden <= 0) { err = "splice: null argument"; return false; }
+
+    std::vector<int> pos;
+    pos.reserve(n_img > 0 ? n_img : 0);
+    for (int t = 0; t < n_tokens; t++) if (token_ids[t] == image_token_id) pos.push_back(t);
+
+    if ((int)pos.size() != n_img) {
+        err = "splice: prompt carries " + std::to_string(pos.size()) + " image placeholder(s) but "
+            + std::to_string(n_img) + " vision embedding(s) were produced -- the prompt's image "
+              "token count must equal (grid_h/merge)*(grid_w/merge)";
+        return false;
+    }
+    if (n_img == 0) return true;   // no image in this prompt; nothing to do
+
+    void* d_pos = nullptr; void* d_emb = nullptr;
+    if (!cu_ok(cudaMalloc(&d_pos, pos.size() * sizeof(int)), "splice positions alloc", err)) return false;
+    if (!cu_ok(cudaMalloc(&d_emb, (size_t)n_img * hidden * sizeof(bf16)), "splice emb alloc", err)) {
+        cudaFree(d_pos); return false;
+    }
+    std::vector<bf16> hemb((size_t)n_img * hidden);
+    for (size_t i = 0; i < hemb.size(); i++) hemb[i] = f32_to_bf16(vision_emb[i]);
+
+    bool ok = cu_ok(cudaMemcpy(d_pos, pos.data(), pos.size() * sizeof(int), cudaMemcpyHostToDevice),
+                    "upload splice positions", err)
+           && cu_ok(cudaMemcpy(d_emb, hemb.data(), hemb.size() * sizeof(bf16), cudaMemcpyHostToDevice),
+                    "upload vision embeddings", err);
+    if (ok) {
+        kernels::launch_vision_splice(d_x, (const int*)d_pos, d_emb, n_img, hidden, nullptr);
+        ok = cu_ok(cudaDeviceSynchronize(), "splice sync", err);
+    }
+    cudaFree(d_pos); cudaFree(d_emb);
+    return ok;
+}
+
 }  // namespace sparkinfer

--- a/runtime/src/models/qwen_vision.cpp
+++ b/runtime/src/models/qwen_vision.cpp
@@ -1,0 +1,240 @@
+// Vision tower forward: patch embed -> position embed -> N blocks -> 2x2 merger.
+//
+// Validated against bench/scripts/vision_ref.py, which was itself validated against the released
+// weights and the transformers reference (see the stage commits on this branch). The reference is
+// the contract: if this file and vision_ref.py disagree, this file is wrong.
+#include "sparkinfer/models/qwen_vision.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+#include <cuda_runtime.h>
+#include "sparkinfer/safetensors.h"
+#include "sparkinfer/kernels/prefill.h"
+#include "sparkinfer/kernels/vision.h"
+
+namespace sparkinfer {
+
+namespace {
+
+using bf16 = unsigned short;
+
+bool cu_ok(cudaError_t e, const char* what, std::string& err) {
+    if (e == cudaSuccess) return true;
+    err = std::string(what) + ": " + cudaGetErrorString(e);
+    return false;
+}
+
+float bf16_to_f32(bf16 h) { unsigned u = (unsigned)h << 16; float f; std::memcpy(&f, &u, 4); return f; }
+bf16 f32_to_bf16(float f) { unsigned u; std::memcpy(&u, &f, 4); return (bf16)(u >> 16); }
+
+// Upload a checkpoint tensor verbatim. Everything under model.visual.* is already bf16, so this
+// is a straight copy -- no dequant, no requant, no layout change.
+const void* upload(SafeTensorsModel& st, const std::string& name, long want_values,
+                   QwenVisionWeights& w, std::string& err) {
+    const STTensor* t = st.tensor(name);
+    if (!t) { err = "missing vision tensor " + name; return nullptr; }
+    if (t->dtype != STDType::BF16) { err = name + ": expected BF16"; return nullptr; }
+    if (want_values > 0 && t->n_values != want_values) {
+        err = name + ": expected " + std::to_string(want_values) + " values, got "
+            + std::to_string(t->n_values);
+        return nullptr;
+    }
+    void* d = nullptr;
+    if (!cu_ok(cudaMalloc(&d, (size_t)t->n_values * sizeof(bf16)), ("cudaMalloc " + name).c_str(), err))
+        return nullptr;
+    if (!cu_ok(cudaMemcpy(d, t->data, (size_t)t->n_values * sizeof(bf16), cudaMemcpyHostToDevice),
+               ("upload " + name).c_str(), err)) { cudaFree(d); return nullptr; }
+    w.owned.push_back(d);
+    return d;
+}
+
+}  // namespace
+
+bool load_qwen_vision_weights(SafeTensorsModel& st, const QwenVisionConfig& cfg,
+                              QwenVisionWeights& w, std::string& err) {
+    const long H = cfg.hidden, I = cfg.intermediate;
+    const long patch_in = (long)cfg.in_channels * cfg.temporal_patch * cfg.patch_size * cfg.patch_size;
+    const long M = cfg.merged_patch_dim();
+
+    w.patch_w = upload(st, "model.visual.patch_embed.proj.weight", H * patch_in, w, err);
+    if (!w.patch_w) return false;
+    w.patch_b = upload(st, "model.visual.patch_embed.proj.bias", H, w, err);
+    if (!w.patch_b) return false;
+
+    // Position table stays on the host: the bilinear resample depends on the image's patch grid,
+    // so it is recomputed and uploaded per image rather than baked in here.
+    const STTensor* pos = st.tensor("model.visual.pos_embed.weight");
+    if (!pos || pos->n_values != (long)cfg.num_pos_embeddings * H) {
+        err = "model.visual.pos_embed.weight missing or wrong size"; return false;
+    }
+    w.pos_side = (int)llround(std::sqrt((double)cfg.num_pos_embeddings));
+    if ((long)w.pos_side * w.pos_side != cfg.num_pos_embeddings) {
+        err = "num_position_embeddings is not a perfect square"; return false;
+    }
+    w.pos_table.resize((size_t)pos->n_values);
+    for (long i = 0; i < pos->n_values; i++)
+        w.pos_table[i] = bf16_to_f32(((const bf16*)pos->data)[i]);
+
+    w.blocks.resize(cfg.depth);
+    for (int b = 0; b < cfg.depth; b++) {
+        const std::string p = "model.visual.blocks." + std::to_string(b) + ".";
+        auto& B = w.blocks[b];
+        B.norm1_w = upload(st, p + "norm1.weight", H, w, err); if (!B.norm1_w) return false;
+        B.norm1_b = upload(st, p + "norm1.bias",   H, w, err); if (!B.norm1_b) return false;
+        B.qkv_w   = upload(st, p + "attn.qkv.weight", 3 * H * H, w, err); if (!B.qkv_w) return false;
+        B.qkv_b   = upload(st, p + "attn.qkv.bias",   3 * H,     w, err); if (!B.qkv_b) return false;
+        B.proj_w  = upload(st, p + "attn.proj.weight", H * H, w, err); if (!B.proj_w) return false;
+        B.proj_b  = upload(st, p + "attn.proj.bias",   H,     w, err); if (!B.proj_b) return false;
+        B.norm2_w = upload(st, p + "norm2.weight", H, w, err); if (!B.norm2_w) return false;
+        B.norm2_b = upload(st, p + "norm2.bias",   H, w, err); if (!B.norm2_b) return false;
+        B.fc1_w   = upload(st, p + "mlp.linear_fc1.weight", I * H, w, err); if (!B.fc1_w) return false;
+        B.fc1_b   = upload(st, p + "mlp.linear_fc1.bias",   I,     w, err); if (!B.fc1_b) return false;
+        B.fc2_w   = upload(st, p + "mlp.linear_fc2.weight", H * I, w, err); if (!B.fc2_w) return false;
+        B.fc2_b   = upload(st, p + "mlp.linear_fc2.bias",   H,     w, err); if (!B.fc2_b) return false;
+    }
+
+    w.merger_norm_w = upload(st, "model.visual.merger.norm.weight", H, w, err); if (!w.merger_norm_w) return false;
+    w.merger_norm_b = upload(st, "model.visual.merger.norm.bias",   H, w, err); if (!w.merger_norm_b) return false;
+    w.merger_fc1_w  = upload(st, "model.visual.merger.linear_fc1.weight", M * M, w, err); if (!w.merger_fc1_w) return false;
+    w.merger_fc1_b  = upload(st, "model.visual.merger.linear_fc1.bias",   M,     w, err); if (!w.merger_fc1_b) return false;
+    w.merger_fc2_w  = upload(st, "model.visual.merger.linear_fc2.weight", (long)cfg.out_hidden * M, w, err);
+    if (!w.merger_fc2_w) return false;
+    w.merger_fc2_b  = upload(st, "model.visual.merger.linear_fc2.bias", cfg.out_hidden, w, err);
+    if (!w.merger_fc2_b) return false;
+    return true;
+}
+
+void free_qwen_vision_weights(QwenVisionWeights& w) {
+    for (void* p : w.owned) cudaFree(p);
+    w.owned.clear();
+    w.blocks.clear();
+    w.pos_table.clear();
+}
+
+bool qwen_vision_forward(const QwenVisionWeights& w, const QwenVisionConfig& cfg,
+                         const float* pixels_host, int grid_h, int grid_w,
+                         float* out_host, std::string& err) {
+    const int H = cfg.hidden, I = cfg.intermediate, heads = cfg.n_heads, hd = cfg.head_dim();
+    const int merge = cfg.spatial_merge;
+    const int N = grid_h * grid_w;
+    const int patch_in = cfg.in_channels * cfg.temporal_patch * cfg.patch_size * cfg.patch_size;
+    const int M = cfg.merged_patch_dim(), nblk = (grid_h / merge) * (grid_w / merge);
+    if (grid_h % merge || grid_w % merge) { err = "patch grid must divide by spatial_merge"; return false; }
+
+    cudaStream_t s = nullptr;
+    std::vector<void*> tmp;
+    auto alloc = [&](size_t bytes) -> void* {
+        void* p = nullptr;
+        if (cudaMalloc(&p, bytes) != cudaSuccess) return nullptr;
+        tmp.push_back(p); return p;
+    };
+    auto cleanup = [&]() { for (void* p : tmp) cudaFree(p); tmp.clear(); };
+
+    void* d_pix  = alloc((size_t)N * patch_in * sizeof(bf16));
+    void* d_x    = alloc((size_t)N * H * sizeof(bf16));
+    void* d_h    = alloc((size_t)N * H * sizeof(bf16));
+    void* d_qkv  = alloc((size_t)N * 3 * H * sizeof(bf16));
+    void* d_q    = alloc((size_t)N * H * sizeof(bf16));
+    void* d_k    = alloc((size_t)N * H * sizeof(bf16));
+    void* d_v    = alloc((size_t)N * H * sizeof(bf16));
+    void* d_att  = alloc((size_t)N * H * sizeof(bf16));
+    void* d_mlp  = alloc((size_t)N * I * sizeof(bf16));
+    void* d_mrg  = alloc((size_t)nblk * M * sizeof(bf16));
+    void* d_out  = alloc((size_t)nblk * (size_t)cfg.out_hidden * sizeof(bf16));
+    if (!d_pix || !d_x || !d_h || !d_qkv || !d_q || !d_k || !d_v || !d_att || !d_mlp || !d_mrg || !d_out) {
+        cleanup(); err = "vision forward: device allocation failed"; return false;
+    }
+
+    // --- patch embed: [N, patch_in] @ [H, patch_in]^T -> [N, H] ---
+    {
+        std::vector<bf16> hp((size_t)N * patch_in);
+        for (size_t i = 0; i < hp.size(); i++) hp[i] = f32_to_bf16(pixels_host[i]);
+        if (!cu_ok(cudaMemcpy(d_pix, hp.data(), hp.size() * sizeof(bf16), cudaMemcpyHostToDevice),
+                   "upload pixels", err)) { cleanup(); return false; }
+    }
+    kernels::launch_prefill_gemm(d_pix, w.patch_w, d_x, N, H, patch_in, s);
+    kernels::launch_vision_add_bias(d_x, w.patch_b, N, H, s);
+
+    // --- position embed: bilinear resample of the pos_side x pos_side table onto this grid ---
+    // Host-side and uploaded, matching vision_ref.py exactly. At grid == pos_side this is the
+    // identity, which is the shape the forward is first validated at.
+    {
+        const int side = w.pos_side;
+        std::vector<bf16> hp((size_t)N * H);
+        for (int gy = 0; gy < grid_h; gy++) {
+            const float fy = grid_h > 1 ? (float)gy * (side - 1) / (grid_h - 1) : 0.f;
+            const int y0 = (int)floorf(fy), y1 = y0 + 1 < side ? y0 + 1 : side - 1;
+            const float wy = fy - y0;
+            for (int gx = 0; gx < grid_w; gx++) {
+                const float fx = grid_w > 1 ? (float)gx * (side - 1) / (grid_w - 1) : 0.f;
+                const int x0 = (int)floorf(fx), x1 = x0 + 1 < side ? x0 + 1 : side - 1;
+                const float wx = fx - x0;
+                const float* p00 = &w.pos_table[((size_t)y0 * side + x0) * H];
+                const float* p01 = &w.pos_table[((size_t)y0 * side + x1) * H];
+                const float* p10 = &w.pos_table[((size_t)y1 * side + x0) * H];
+                const float* p11 = &w.pos_table[((size_t)y1 * side + x1) * H];
+                bf16* dst = &hp[((size_t)gy * grid_w + gx) * H];
+                for (int d = 0; d < H; d++)
+                    dst[d] = f32_to_bf16(p00[d] * (1 - wy) * (1 - wx) + p01[d] * (1 - wy) * wx
+                                       + p10[d] * wy * (1 - wx) + p11[d] * wy * wx);
+            }
+        }
+        if (!cu_ok(cudaMemcpy(d_h, hp.data(), hp.size() * sizeof(bf16), cudaMemcpyHostToDevice),
+                   "upload pos embed", err)) { cleanup(); return false; }
+    }
+    kernels::launch_vision_residual_add(d_x, d_h, (long)N * H, s);
+
+    const float scale = 1.0f / std::sqrt((float)hd);
+    for (int b = 0; b < cfg.depth; b++) {
+        const auto& B = w.blocks[b];
+        kernels::launch_vision_layernorm(d_x, B.norm1_w, B.norm1_b, d_h, N, H, 1e-6f, s);
+        kernels::launch_prefill_gemm(d_h, B.qkv_w, d_qkv, N, 3 * H, H, s);
+        kernels::launch_vision_add_bias(d_qkv, B.qkv_b, N, 3 * H, s);
+        // Split the fused [N, 3H] into q/k/v. cudaMemcpy2D does the strided extraction, so the
+        // attention kernel can assume a contiguous [N, heads*hd] layout.
+        const size_t row = (size_t)3 * H * sizeof(bf16), col = (size_t)H * sizeof(bf16);
+        cudaMemcpy2DAsync(d_q, col, (const char*)d_qkv,             row, col, N, cudaMemcpyDeviceToDevice, s);
+        cudaMemcpy2DAsync(d_k, col, (const char*)d_qkv + col,       row, col, N, cudaMemcpyDeviceToDevice, s);
+        cudaMemcpy2DAsync(d_v, col, (const char*)d_qkv + 2 * col,   row, col, N, cudaMemcpyDeviceToDevice, s);
+        kernels::launch_vision_attention(d_q, d_k, d_v, d_att, N, heads, hd, scale, s);
+        kernels::launch_prefill_gemm(d_att, B.proj_w, d_h, N, H, H, s);
+        kernels::launch_vision_add_bias(d_h, B.proj_b, N, H, s);
+        kernels::launch_vision_residual_add(d_x, d_h, (long)N * H, s);
+
+        kernels::launch_vision_layernorm(d_x, B.norm2_w, B.norm2_b, d_h, N, H, 1e-6f, s);
+        kernels::launch_prefill_gemm(d_h, B.fc1_w, d_mlp, N, I, H, s);
+        kernels::launch_vision_add_bias(d_mlp, B.fc1_b, N, I, s);
+        kernels::launch_vision_gelu_tanh(d_mlp, (long)N * I, s);
+        kernels::launch_prefill_gemm(d_mlp, B.fc2_w, d_h, N, H, I, s);
+        kernels::launch_vision_add_bias(d_h, B.fc2_b, N, H, s);
+        kernels::launch_vision_residual_add(d_x, d_h, (long)N * H, s);
+    }
+
+    // --- merger ---
+    kernels::launch_vision_layernorm(d_x, w.merger_norm_w, w.merger_norm_b, d_h, N, H, 1e-6f, s);
+    kernels::launch_vision_patch_merge(d_h, d_mrg, grid_h, grid_w, merge, H, s);
+    kernels::launch_prefill_gemm(d_mrg, w.merger_fc1_w, d_out, nblk, M, M, s);
+    kernels::launch_vision_add_bias(d_out, w.merger_fc1_b, nblk, M, s);
+    kernels::launch_vision_gelu_tanh(d_out, (long)nblk * M, s);
+    // fc1 wrote M-wide into d_out; fc2 reads that and writes out_hidden-wide. Bounce through
+    // d_mrg so the GEMM's input and output never alias.
+    if (!cu_ok(cudaMemcpyAsync(d_mrg, d_out, (size_t)nblk * M * sizeof(bf16),
+                               cudaMemcpyDeviceToDevice, s), "merger bounce", err)) { cleanup(); return false; }
+    kernels::launch_prefill_gemm(d_mrg, w.merger_fc2_w, d_out, nblk, cfg.out_hidden, M, s);
+    kernels::launch_vision_add_bias(d_out, w.merger_fc2_b, nblk, cfg.out_hidden, s);
+
+    if (!cu_ok(cudaStreamSynchronize(s), "vision forward sync", err)) { cleanup(); return false; }
+    {
+        std::vector<bf16> ho((size_t)nblk * cfg.out_hidden);
+        if (!cu_ok(cudaMemcpy(ho.data(), d_out, ho.size() * sizeof(bf16), cudaMemcpyDeviceToHost),
+                   "download vision out", err)) { cleanup(); return false; }
+        for (size_t i = 0; i < ho.size(); i++) out_host[i] = bf16_to_f32(ho[i]);
+    }
+    cleanup();
+    return true;
+}
+
+}  // namespace sparkinfer

--- a/runtime/src/models/qwen_vision_preprocess.cpp
+++ b/runtime/src/models/qwen_vision_preprocess.cpp
@@ -1,0 +1,138 @@
+// Image preprocessing for the vision tower: smart_resize -> bicubic -> normalize -> patchify.
+#include "sparkinfer/models/qwen_vision_preprocess.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+
+namespace sparkinfer {
+
+namespace {
+
+// PIL/torchvision BICUBIC kernel, a = -0.5. When DOWNscaling, the filter support is widened by
+// the scale factor (antialiasing) -- without that, downsampling aliases badly and the resized
+// image differs visibly from the reference, not just numerically.
+inline float cubic(float x, float a = -0.5f) {
+    x = std::fabs(x);
+    if (x < 1.0f) return ((a + 2.0f) * x - (a + 3.0f)) * x * x + 1.0f;
+    if (x < 2.0f) return (((x - 5.0f) * x + 8.0f) * x - 4.0f) * a;
+    return 0.0f;
+}
+
+// Separable bicubic resample of one channel plane, with antialias support scaling on downscale.
+void resample_axis(const float* src, int src_len, int dst_len, int stride_src, int stride_dst,
+                   int lines, int line_stride_src, int line_stride_dst, float* dst) {
+    const float scale = (float)src_len / (float)dst_len;
+    const float filter_scale = scale > 1.0f ? scale : 1.0f;   // widen only when shrinking
+    const float support = 2.0f * filter_scale;
+    for (int o = 0; o < dst_len; o++) {
+        const float center = (o + 0.5f) * scale;
+        const int lo = std::max(0, (int)std::floor(center - support + 0.5f));
+        const int hi = std::min(src_len, (int)std::floor(center + support + 0.5f));
+        float wsum = 0.0f;
+        float wts[64]; int n = 0;
+        for (int i = lo; i < hi && n < 64; i++, n++) {
+            const float w = cubic(((i + 0.5f) - center) / filter_scale);
+            wts[n] = w; wsum += w;
+        }
+        if (wsum == 0.0f) { wsum = 1.0f; if (n > 0) wts[0] = 1.0f; }
+        for (int L = 0; L < lines; L++) {
+            const float* s = src + (size_t)L * line_stride_src;
+            float acc = 0.0f;
+            for (int i = 0; i < n; i++) acc += wts[i] * s[(size_t)(lo + i) * stride_src];
+            dst[(size_t)L * line_stride_dst + (size_t)o * stride_dst] = acc / wsum;
+        }
+    }
+}
+
+}  // namespace
+
+bool qwen_vision_smart_resize(int height, int width, int factor, long min_pixels, long max_pixels,
+                              int* out_h, int* out_w, std::string& err) {
+    if (height <= 0 || width <= 0 || factor <= 0) { err = "smart_resize: non-positive input"; return false; }
+    const int mx = std::max(height, width), mn = std::min(height, width);
+    if ((double)mx / (double)mn > 200.0) {
+        err = "smart_resize: absolute aspect ratio must be smaller than 200";
+        return false;
+    }
+    // round(x / f) * f, with PYTHON's round -- banker's rounding, ties to even. std::lround
+    // rounds ties away from zero and is WRONG here. This is not pedantry: at 16x2048,
+    // round(16/32) = round(0.5) is 0 in Python and 1 with lround, so Python's h_bar*w_bar is 0
+    // and falls into the scale-up branch, returning 2912 where lround returns 2048. Caught by
+    // bench/scripts/vision_resize_check.py, which demands exact equality for exactly this reason.
+    //
+    // std::nearbyint honours the current rounding mode, which is round-to-nearest-EVEN by
+    // default under IEEE 754 -- the same rule Python's round() applies.
+    long h_bar = (long)std::nearbyint((double)height / factor) * factor;
+    long w_bar = (long)std::nearbyint((double)width / factor) * factor;
+    if (h_bar * w_bar > max_pixels) {
+        const double beta = std::sqrt(((double)height * width) / (double)max_pixels);
+        h_bar = std::max((long)factor, (long)std::floor(height / beta / factor) * factor);
+        w_bar = std::max((long)factor, (long)std::floor(width  / beta / factor) * factor);
+    } else if (h_bar * w_bar < min_pixels) {
+        const double beta = std::sqrt((double)min_pixels / ((double)height * width));
+        h_bar = (long)std::ceil(height * beta / factor) * factor;
+        w_bar = (long)std::ceil(width  * beta / factor) * factor;
+    }
+    if (h_bar <= 0 || w_bar <= 0) { err = "smart_resize: degenerate result"; return false; }
+    *out_h = (int)h_bar; *out_w = (int)w_bar;
+    return true;
+}
+
+int qwen_vision_num_tokens(int grid_h, int grid_w, const QwenVisionConfig& cfg) {
+    const int m = cfg.spatial_merge;
+    if (m <= 0 || grid_h % m || grid_w % m) return 0;
+    return (grid_h / m) * (grid_w / m);
+}
+
+bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
+                            const QwenVisionConfig& cfg,
+                            std::vector<float>& pixels, int* grid_h, int* grid_w,
+                            std::string& err) {
+    if (!rgb || height <= 0 || width <= 0) { err = "preprocess: empty image"; return false; }
+    int rh = 0, rw = 0;
+    if (!qwen_vision_smart_resize(height, width, cfg.size_granularity(),
+                                  cfg.min_pixels, cfg.max_pixels, &rh, &rw, err)) return false;
+
+    const int C = cfg.in_channels, P = cfg.patch_size, T = cfg.temporal_patch;
+    const int gh = rh / P, gw = rw / P;
+
+    // uint8 -> float in [0,1], planar, then resize each plane, then normalize with mean/std.
+    // Order matters: the reference rescales BEFORE normalizing, and normalizes AFTER resizing.
+    std::vector<float> plane((size_t)C * height * width);
+    for (int c = 0; c < C; c++)
+        for (int y = 0; y < height; y++)
+            for (int x = 0; x < width; x++)
+                plane[((size_t)c * height + y) * width + x] =
+                    rgb[((size_t)y * width + x) * C + c] * (1.0f / 255.0f);
+
+    std::vector<float> tmp((size_t)C * height * rw), out((size_t)C * rh * rw);
+    for (int c = 0; c < C; c++) {   // horizontal then vertical
+        resample_axis(&plane[(size_t)c * height * width], width, rw, 1, 1,
+                      height, width, rw, &tmp[(size_t)c * height * rw]);
+        resample_axis(&tmp[(size_t)c * height * rw], height, rh, rw, rw,
+                      rw, 1, 1, &out[(size_t)c * rh * rw]);
+    }
+    for (int c = 0; c < C; c++) {
+        const float mu = cfg.mean[c], sd = cfg.std_[c] != 0.f ? cfg.std_[c] : 1.f;
+        float* p = &out[(size_t)c * rh * rw];
+        for (long i = 0; i < (long)rh * rw; i++) p[i] = (p[i] - mu) / sd;
+    }
+
+    // Patchify: row-major over the grid, each patch (C, T, P, P), still image repeated across T.
+    pixels.assign((size_t)gh * gw * C * T * P * P, 0.0f);
+    for (int gy = 0; gy < gh; gy++)
+      for (int gx = 0; gx < gw; gx++) {
+        float* dst = &pixels[((size_t)gy * gw + gx) * C * T * P * P];
+        for (int c = 0; c < C; c++)
+          for (int t = 0; t < T; t++)
+            for (int py = 0; py < P; py++)
+              for (int px = 0; px < P; px++)
+                dst[((c * T + t) * P + py) * P + px] =
+                    out[((size_t)c * rh + (gy * P + py)) * rw + (gx * P + px)];
+      }
+    *grid_h = gh; *grid_w = gw;
+    return true;
+}
+
+}  // namespace sparkinfer

--- a/runtime/src/models/qwen_vision_preprocess.cpp
+++ b/runtime/src/models/qwen_vision_preprocess.cpp
@@ -135,4 +135,32 @@ bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
     return true;
 }
 
+bool qwen_vision_expand_placeholders(const std::vector<int>& in, int image_token_id,
+                                     const std::vector<int>& counts,
+                                     std::vector<int>& out, std::string& err) {
+    size_t found = 0;
+    for (int t : in) if (t == image_token_id) found++;
+    if (found != counts.size()) {
+        err = "expand: prompt has " + std::to_string(found) + " image placeholder(s) but "
+            + std::to_string(counts.size()) + " image(s) were supplied";
+        return false;
+    }
+    for (size_t i = 0; i < counts.size(); i++) {
+        if (counts[i] <= 0) {
+            err = "expand: image " + std::to_string(i) + " needs a positive token count";
+            return false;
+        }
+    }
+    size_t total = in.size();
+    for (int c : counts) total += (size_t)c - 1;   // each placeholder becomes c tokens
+    out.clear();
+    out.reserve(total);
+    size_t idx = 0;
+    for (int t : in) {
+        if (t == image_token_id) out.insert(out.end(), (size_t)counts[idx++], image_token_id);
+        else out.push_back(t);
+    }
+    return true;
+}
+
 }  // namespace sparkinfer

--- a/runtime/src/models/qwen_vision_preprocess.cpp
+++ b/runtime/src/models/qwen_vision_preprocess.cpp
@@ -9,9 +9,14 @@ namespace sparkinfer {
 
 namespace {
 
-// PIL/torchvision BICUBIC kernel, a = -0.5. When DOWNscaling, the filter support is widened by
-// the scale factor (antialiasing) -- without that, downsampling aliases badly and the resized
-// image differs visibly from the reference, not just numerically.
+// PIL's BICUBIC kernel, a = -0.5. NOT torchvision's, which uses a = -0.75 -- the two libraries
+// genuinely disagree on this constant, so "bicubic" alone does not pin the filter down. We match
+// PIL, i.e. the slow Qwen2VLImageProcessor; see bench/scripts/vision_preprocess_ref.py for the
+// measured cost of that choice against the fast (torchvision) processor the checkpoint declares.
+//
+// When DOWNscaling, the filter support is widened by the scale factor (antialiasing) -- without
+// that, downsampling aliases badly and the resized image differs visibly from the reference, not
+// just numerically. Verified against PIL to max|diff| 1e-4 by vision_preprocess_ref.py.
 inline float cubic(float x, float a = -0.5f) {
     x = std::fabs(x);
     if (x < 1.0f) return ((a + 2.0f) * x - (a + 3.0f)) * x * x + 1.0f;
@@ -97,26 +102,47 @@ bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
     const int C = cfg.in_channels, P = cfg.patch_size, T = cfg.temporal_patch;
     const int gh = rh / P, gw = rw / P;
 
-    // uint8 -> float in [0,1], planar, then resize each plane, then normalize with mean/std.
-    // Order matters: the reference rescales BEFORE normalizing, and normalizes AFTER resizing.
+    // Planar uint8 VALUES (0..255, not yet rescaled), then resize, then rescale, then normalize.
+    //
+    // This order is the reference's, and it is not interchangeable with rescaling first even
+    // though resampling is linear: transformers resizes the uint8 image and casts the result back
+    // to uint8 -- PIL in the slow processor, torchvision in the fast one -- which ROUNDS to
+    // nearest and CLAMPS bicubic's overshoot into [0,255]. Neither of those commutes with
+    // scaling. Rescaling first (which this did until measured) leaves the overshoot in place and
+    // drifts from the reference by up to 0.127 in normalized units at high-contrast edges, where
+    // rounding alone would account for only ~0.004.
     std::vector<float> plane((size_t)C * height * width);
     for (int c = 0; c < C; c++)
         for (int y = 0; y < height; y++)
             for (int x = 0; x < width; x++)
                 plane[((size_t)c * height + y) * width + x] =
-                    rgb[((size_t)y * width + x) * C + c] * (1.0f / 255.0f);
+                    (float)rgb[((size_t)y * width + x) * C + c];
 
     std::vector<float> tmp((size_t)C * height * rw), out((size_t)C * rh * rw);
     for (int c = 0; c < C; c++) {   // horizontal then vertical
         resample_axis(&plane[(size_t)c * height * width], width, rw, 1, 1,
                       height, width, rw, &tmp[(size_t)c * height * rw]);
-        resample_axis(&tmp[(size_t)c * height * rw], height, rh, rw, rw,
-                      rw, 1, 1, &out[(size_t)c * rh * rw]);
+        // The reference's INTERMEDIATE image is uint8 too: PIL resamples horizontally into an
+        // 8-bit temp, then vertically out of it, so the round-and-clamp happens TWICE. Carrying
+        // float through both passes and rounding once at the end is more accurate but drifts
+        // from the reference by several LSB at edges, which is not ours to decide.
+        float* t = &tmp[(size_t)c * height * rw];
+        for (long i = 0; i < (long)height * rw; i++)
+            t[i] = std::min(255.0f, std::max(0.0f, std::floor(t[i] + 0.5f)));
+        resample_axis(t, height, rh, rw, rw, rw, 1, 1, &out[(size_t)c * rh * rw]);
     }
     for (int c = 0; c < C; c++) {
         const float mu = cfg.mean[c], sd = cfg.std_[c] != 0.f ? cfg.std_[c] : 1.f;
         float* p = &out[(size_t)c * rh * rw];
-        for (long i = 0; i < (long)rh * rw; i++) p[i] = (p[i] - mu) / sd;
+        for (long i = 0; i < (long)rh * rw; i++) {
+            // The uint8 round-trip the reference performs, then rescale, then normalize.
+            // floor(x+0.5), i.e. round-half-UP, because PIL's 8-bit resample accumulates in
+            // fixed point and rounds with a half-LSB add -- not nearbyint's round-half-to-EVEN,
+            // which disagrees on exact .5 ties. (smart_resize above genuinely does want
+            // banker's rounding; that is Python's round(), a different reference entirely.)
+            const float q = std::min(255.0f, std::max(0.0f, std::floor(p[i] + 0.5f)));
+            p[i] = (q * (1.0f / 255.0f) - mu) / sd;
+        }
     }
 
     // Patchify: row-major over the grid, each patch (C, T, P, P), still image repeated across T.

--- a/runtime/src/safetensors.cpp
+++ b/runtime/src/safetensors.cpp
@@ -317,11 +317,12 @@ bool SafeTensorsShard::open(const std::string& path) {
         STTensor t;
         t.dtype = dtype_from_str(dt_it->second.str());
         const auto& shape = sh_it->second.arr();
-        if (shape.size() > 4) {
-            // Vision-tower tensors (e.g. a 5-D patch_embed conv weight) exceed STTensor::dims'
-            // fixed width. Out of scope for this reader (text-only), so skip cataloging this one
-            // tensor rather than failing the whole checkpoint -- nothing looks it up by name.
-            fprintf(stderr, "[safetensors] %s: skipping tensor %s with %zu dims (max 4)\n",
+        if (shape.size() > 5) {
+            // 5 dims covers everything these checkpoints ship -- the widest is the vision tower's
+            // Conv3d patch embed at [out, in_ch, t_patch, ph, pw]. Anything wider is unexpected;
+            // skip cataloging it rather than failing the whole checkpoint, and say so loudly
+            // (this used to fire on the 5-D patch embed, silently making image input impossible).
+            fprintf(stderr, "[safetensors] %s: skipping tensor %s with %zu dims (max 5)\n",
                     path.c_str(), name.c_str(), shape.size());
             continue;
         }

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -26,6 +26,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(re2)
 
 add_executable(sparkinfer_server
+    src/image_input.cpp
     src/sparkinfer_server.cpp
     src/model_engine.cpp
     src/chat_tokenizer.cpp
@@ -68,6 +69,19 @@ if(BUILD_TESTS)
     )
     target_compile_features(chat_tools_test PRIVATE cxx_std_17)
     add_test(NAME chat_tools_test COMMAND chat_tools_test)
+
+    # Image input: base64, data: URL parsing, decode -- and the refusals, which are the
+    # security-relevant half (no remote fetch, bounded payloads, no silent truncation).
+    add_executable(image_input_test
+        tests/image_input_test.cpp
+        src/image_input.cpp
+    )
+    target_include_directories(image_input_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party
+    )
+    target_compile_features(image_input_test PRIVATE cxx_std_17)
+    add_test(NAME image_input_test COMMAND image_input_test)
 
     add_executable(chat_tokenizer_test
         tests/chat_tokenizer_test.cpp

--- a/server/include/chat_tools.hpp
+++ b/server/include/chat_tools.hpp
@@ -37,6 +37,11 @@ struct ChatMessage {
     std::string name;
     std::string tool_call_id;
     std::vector<ToolCall> tool_calls;
+    // image_url values from multimodal content parts, in the order they appeared. The rendered
+    // content carries one <|vision_start|><|image_pad|><|vision_end|> per entry at the position
+    // that part occupied, so this vector and those markers stay in lockstep -- the processor, not
+    // the template, later expands each placeholder to the token count its grid needs.
+    std::vector<std::string> images;
 };
 
 enum class ResponseFormatType {

--- a/server/include/image_input.hpp
+++ b/server/include/image_input.hpp
@@ -1,0 +1,41 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace sparkinfer_server {
+
+// Decoded image, always 3-channel RGB8 regardless of what the source encoded.
+struct DecodedImage {
+    int width = 0, height = 0;
+    std::vector<unsigned char> rgb;   // [height * width * 3]
+};
+
+// Decodes PNG / JPEG / BMP / GIF / TGA bytes (whatever stb_image supports) to RGB8.
+//
+// Alpha is DROPPED, not composited: stb is asked for 3 channels, so an RGBA source loses its
+// alpha rather than being flattened onto a background. The vision tower has no alpha channel and
+// the reference processor converts to RGB the same way, so this matches -- but it does mean a
+// transparent PNG renders as whatever RGB its transparent pixels happen to carry.
+bool decode_image(const unsigned char* bytes, size_t n, DecodedImage& out, std::string& err);
+
+// Decodes standard base64 (RFC 4648, with '=' padding). Rejects any character outside the
+// alphabet rather than skipping it: a data: URL that fails to decode cleanly is far more likely
+// to be a malformed request than something worth salvaging, and silently dropping bytes would
+// hand the decoder a truncated image.
+bool base64_decode(const std::string& in, std::vector<unsigned char>& out, std::string& err);
+
+// Parses an OpenAI image_url value. Supports data: URLs only --
+//     data:image/png;base64,iVBORw0KG...
+// A remote http(s) URL is REFUSED rather than fetched: having an inference server fetch
+// arbitrary URLs on request is an SSRF primitive (internal metadata endpoints, private hosts),
+// and that is a deliberate deployment decision for whoever runs it, not a default. The error
+// says so explicitly so callers know it is policy, not a parse failure.
+bool parse_image_url(const std::string& url, std::vector<unsigned char>& bytes, std::string& err);
+
+// Byte ceiling for one decoded data: URL, before decoding. Guards against a request that expands
+// into gigabytes of pixels; the pixel budget in smart_resize bounds what reaches the tower, but
+// the DECODE itself happens first and has to be bounded separately.
+constexpr size_t kMaxImageBytes = 32u * 1024u * 1024u;
+
+}  // namespace sparkinfer_server

--- a/server/include/image_input.hpp
+++ b/server/include/image_input.hpp
@@ -11,7 +11,9 @@ struct DecodedImage {
     std::vector<unsigned char> rgb;   // [height * width * 3]
 };
 
-// Decodes PNG / JPEG / BMP / GIF / TGA bytes (whatever stb_image supports) to RGB8.
+// Decodes PNG / JPEG / BMP bytes to RGB8. Those three and no others: image_input.cpp sets
+// STBI_ONLY_PNG/JPEG/BMP, so stb's GIF, TGA, PSD, HDR, PIC and PNM decoders are not compiled in
+// -- fewer parsers reachable from untrusted request bytes.
 //
 // Alpha is DROPPED, not composited: stb is asked for 3 channels, so an RGBA source loses its
 // alpha rather than being flattened onto a background. The vision tower has no alpha channel and

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -35,6 +35,25 @@ struct CompletionResult {
     double decode_tps = -1.0;
 };
 
+// Images already decoded and preprocessed, ready for the vision tower. Mirrored field-by-field
+// into ContinuousBatchEngine::Request, keeping this header's "never re-expose runtime types"
+// convention -- same reason TokenLogprob above is a hand-copied struct.
+//
+// Pixels, not embeddings: the tower has to run on the batch engine's worker thread (CUDA graph
+// capture), so all this carries is the CPU-side preprocessing result.
+struct PreparedImages {
+    struct Image {
+        // Shared so a copy of PreparedImages is cheap. Branch and retry paths each need their
+        // OWN positions (see reexpand_images) while sharing one preprocessing result, and they
+        // run concurrently, so mutating a single shared copy is not an option.
+        std::shared_ptr<const std::vector<float>> pixels;
+        int grid_h = 0;
+        int grid_w = 0;
+    };
+    std::vector<Image> images;
+    std::vector<int> positions;      // absolute prompt indices of the expanded placeholder run
+};
+
 // Thread-safe wrapper around sparkinfer::Qwen35Model + GGUF load.
 class ModelEngine {
 public:
@@ -61,6 +80,32 @@ public:
     int max_seq() const;
     bool is_museglimmer() const;
     bool is_qwen38() const;
+    // True when the loaded checkpoint shipped a vision tower and it loaded successfully. False
+    // for every text-only model, and for a vision checkpoint whose tower failed to load -- in
+    // both cases a request carrying images is refused rather than answered from its text.
+    bool has_vision() const;
+
+    // Decodes image_url values, preprocesses each to the tower's patch tensor, expands the
+    // prompt's single <|image_pad|> per image to the token count that image's grid needs, and
+    // reports where those tokens landed. prompt_ids is rewritten in place.
+    //
+    // The expansion belongs here rather than in the chat template because only the processor
+    // knows the resized grid -- the template emits exactly one placeholder per image and the
+    // reference processor expands it the same way.
+    bool prepare_images(const std::vector<std::string>& urls, int image_token_id,
+                        std::vector<int>& prompt_ids, PreparedImages& out,
+                        std::string& err) const;
+
+    // Re-expands placeholders and recomputes positions against a prompt that was rebuilt after
+    // prepare_images already ran. The tool-call continuation path re-renders the entire prompt
+    // from the message list, so both the earlier expansion and the offsets it recorded are stale
+    // -- it comes back with one bare <|image_pad|> per image again. Reuses the preprocessing;
+    // only the token bookkeeping is redone.
+    //
+    // Takes its own PreparedImages copy per branch by design: concurrent branches must not share
+    // one positions vector.
+    bool reexpand_images(int image_token_id, std::vector<int>& prompt_ids, PreparedImages& io,
+                         std::string& err) const;
 
     // Optional shared prompt prefix (e.g. system message tokens). When set, each request whose
     // prompt starts with these ids calls cache_prefix() (batched prefill) before generate().
@@ -104,7 +149,8 @@ public:
                                         bool logprobs = false, int top_logprobs = 0,
                                         const std::function<void(const TokenLogprob&)>&
                                             on_token_logprob = nullptr,
-                                        const std::vector<int>& forced_tokens = {});
+                                        const std::vector<int>& forced_tokens = {},
+                                        const PreparedImages* images = nullptr);
 
     // TEACHER-FORCED SCORING (POST /v1/score): non-empty `forced_tokens` turns the call into a
     // scoring pass instead of a generation. max_new_tokens must equal forced_tokens.size(); the

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -32,6 +32,9 @@ constexpr int kMaxN = 8;
 constexpr int kMaxTopLogprobs = 20;
 
 constexpr const char* kImStart = "<|im_start|>";
+constexpr const char* kVisionStart = "<|vision_start|>";
+constexpr const char* kImagePad    = "<|image_pad|>";
+constexpr const char* kVisionEnd   = "<|vision_end|>";
 constexpr const char* kImEnd = "<|im_end|>";
 constexpr const char* kThinkOpen = "<think>";
 constexpr const char* kThinkClose = "</think>";
@@ -204,7 +207,8 @@ bool is_allowed_key(const json& object, const std::set<std::string>& allowed,
 }
 
 bool parse_content(const json& value, std::string& content, bool& is_null,
-                   const std::string& where, std::string& err) {
+                   const std::string& where, std::string& err,
+                   std::vector<std::string>* images, const std::string& role) {
     content.clear();
     is_null = value.is_null();
     if (is_null) return true;
@@ -218,10 +222,27 @@ bool parse_content(const json& value, std::string& content, bool& is_null,
         const json& part = value[i];
         if (!part.is_object() || !part.contains("type") || !part["type"].is_string())
             return set_error(err, where + ".content[" + std::to_string(i) + "] must have a string type");
-        // Non-text parts (image_url, audio, ...) are ignored, not rejected -- this backend has
-        // no vision/audio input path, but a client sending a mixed multimodal payload (common
-        // even against text-only backends, since agent frameworks often build one payload
-        // shape for every provider) should still get an answer from the text that IS present.
+        if (part["type"] == "image_url" && images) {
+            // Mirrors the template: an image part renders as this marker, and a system/developer
+            // message containing one is refused outright rather than producing a prompt shape the
+            // model was never trained to read.
+            if (role == "system")
+                return set_error(err, where + ".content[" + std::to_string(i) +
+                                      "]: system/developer messages cannot contain images");
+            const json& iu = part.contains("image_url") ? part["image_url"] : json();
+            if (!iu.is_object() || !iu.contains("url") || !iu["url"].is_string())
+                return set_error(err, where + ".content[" + std::to_string(i) +
+                                      "].image_url.url must be a string");
+            images->push_back(iu["url"].get<std::string>());
+            content += kVisionStart;
+            content += kImagePad;
+            content += kVisionEnd;
+            continue;
+        }
+        // Remaining non-text parts (audio, and image_url when the caller passes no image sink)
+        // are ignored rather than rejected: a client sending a mixed multimodal payload -- common
+        // even against text-only backends, since agent frameworks build one payload shape for
+        // every provider -- should still get an answer from the text that IS present.
         if (part["type"] != "text") continue;
         if (!part.contains("text") || !part["text"].is_string())
             return set_error(err, where + ".content[" + std::to_string(i) + "].text must be a string");
@@ -555,7 +576,8 @@ bool parse_message(const json& value, ChatMessage& message, size_t index, std::s
         message.role != "tool")
         return set_error(err, where + ".role is unsupported");
     if (value.contains("content")) {
-        if (!parse_content(value["content"], message.content, message.content_is_null, where, err)) return false;
+        if (!parse_content(value["content"], message.content, message.content_is_null, where, err,
+                           &message.images, message.role)) return false;
     } else {
         message.content_is_null = true;
     }

--- a/server/src/image_input.cpp
+++ b/server/src/image_input.cpp
@@ -1,0 +1,77 @@
+#include "image_input.hpp"
+
+#include <cstring>
+
+#define STB_IMAGE_IMPLEMENTATION
+#define STBI_ONLY_PNG
+#define STBI_ONLY_JPEG
+#define STBI_ONLY_BMP
+#define STBI_NO_STDIO          // requests arrive as bytes; no filesystem path is ever taken
+#define STBI_NO_FAILURE_STRINGS_MUTABLE
+#include "stb_image.h"
+
+namespace sparkinfer_server {
+
+bool decode_image(const unsigned char* bytes, size_t n, DecodedImage& out, std::string& err) {
+    if (!bytes || n == 0) { err = "empty image payload"; return false; }
+    if (n > kMaxImageBytes) { err = "image payload exceeds the size limit"; return false; }
+    int w = 0, h = 0, ch = 0;
+    // 3 = force RGB. stb handles the source's own channel count and any palette.
+    unsigned char* p = stbi_load_from_memory(bytes, (int)n, &w, &h, &ch, 3);
+    if (!p) { err = std::string("image decode failed: ") + (stbi_failure_reason() ?: "unknown"); return false; }
+    if (w <= 0 || h <= 0) { stbi_image_free(p); err = "decoded image has zero extent"; return false; }
+    out.width = w; out.height = h;
+    out.rgb.assign(p, p + (size_t)w * h * 3);
+    stbi_image_free(p);
+    return true;
+}
+
+bool base64_decode(const std::string& in, std::vector<unsigned char>& out, std::string& err) {
+    static signed char T[256];
+    static bool init = false;
+    if (!init) {
+        std::memset(T, -1, sizeof(T));
+        const char* A = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        for (int i = 0; i < 64; i++) T[(unsigned char)A[i]] = (signed char)i;
+        init = true;
+    }
+    out.clear();
+    out.reserve(in.size() / 4 * 3 + 3);
+    int acc = 0, bits = 0;
+    size_t pad = 0;
+    for (char c : in) {
+        if (c == '\n' || c == '\r') continue;   // wrapped base64 is common and harmless
+        if (c == '=') { pad++; continue; }
+        if (pad) { err = "base64: data after padding"; return false; }
+        const signed char v = T[(unsigned char)c];
+        if (v < 0) { err = "base64: invalid character"; return false; }
+        acc = (acc << 6) | v; bits += 6;
+        if (bits >= 8) { bits -= 8; out.push_back((unsigned char)((acc >> bits) & 0xFF)); }
+    }
+    if (pad > 2) { err = "base64: too much padding"; return false; }
+    return true;
+}
+
+bool parse_image_url(const std::string& url, std::vector<unsigned char>& bytes, std::string& err) {
+    if (url.rfind("data:", 0) != 0) {
+        err = "only data: URLs are accepted; remote image fetching is disabled by policy "
+              "(it would let a request drive server-side HTTP to arbitrary hosts)";
+        return false;
+    }
+    const size_t comma = url.find(',');
+    if (comma == std::string::npos) { err = "malformed data: URL (no comma)"; return false; }
+    const std::string meta = url.substr(5, comma - 5);
+    if (meta.find("base64") == std::string::npos) {
+        err = "data: URL must be base64-encoded";
+        return false;
+    }
+    // Roughly bound the ENCODED length too -- 4/3 expansion means decoding a huge string
+    // allocates before any size check inside decode_image could fire.
+    if (url.size() - comma - 1 > kMaxImageBytes / 3 * 4 + 4) {
+        err = "image payload exceeds the size limit";
+        return false;
+    }
+    return base64_decode(url.substr(comma + 1), bytes, err);
+}
+
+}  // namespace sparkinfer_server

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -6,6 +6,11 @@
 #include "sparkinfer/kv_cache.h"
 #include "sparkinfer/lmcache_bridge_client.h"
 #include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/models/qwen_vision.h"
+#include "sparkinfer/models/qwen_vision_hf_config.h"
+#include "sparkinfer/models/qwen_vision_preprocess.h"
+#include "sparkinfer/safetensors.h"
+#include "image_input.hpp"
 #include "sparkinfer/moe/engine.h"
 #include "sparkinfer/runtime.h"
 
@@ -154,11 +159,26 @@ struct ModelEngine::Impl {
     std::unique_ptr<sparkinfer::BridgeClient> lmcache_bridge;
     pid_t lmcache_sidecar_pid = -1;
 
+    // Vision tower, when the checkpoint ships one. Owned here and handed to the batch engine by
+    // pointer, so it must outlive it -- and must be freed while the CUDA context is still alive,
+    // which is why reset_vision() is called from ~Impl's BODY rather than left to member order.
+    sparkinfer::QwenVisionConfig vcfg{};
+    sparkinfer::QwenVisionWeights vweights{};
+    bool vision_ready = false;
+
+    void reset_vision() {
+        if (!vision_ready) return;
+        free_qwen_vision_weights(vweights);
+        vweights = sparkinfer::QwenVisionWeights{};
+        vision_ready = false;
+    }
+
     // Explicit teardown order: destroy the BridgeClient first (joins its ping/store threads,
     // which may otherwise be mid-handshake against the sidecar) before killing the sidecar out
     // from under it -- tearing them down in the other order risks those threads observing a
     // closed socket mid-operation instead of a clean, already-stopped state.
     ~Impl() {
+        reset_vision();
         lmcache_bridge.reset();
         terminate_lmcache_sidecar(lmcache_sidecar_pid);
     }
@@ -170,6 +190,7 @@ ModelEngine::~ModelEngine() = default;
 bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     std::lock_guard<std::mutex> lock(mu_);
     impl_->ready = false;
+    impl_->reset_vision();
     impl_->batch_engine.reset();
     impl_->model.reset();
     impl_->engine.reset();
@@ -363,6 +384,28 @@ bool ModelEngine::load(const std::string& gguf_path, int max_seq) {
     impl_->batch_engine = std::make_unique<sparkinfer::ContinuousBatchEngine>(
         impl_->model.get(), impl_->kv.get(), batch_tokens_per_step(), policy);
 
+    // Vision tower. Absence is NOT an error -- a text-only checkpoint has no vision_config and
+    // has_vision() stays false -- but a tower that is present and fails to load is reported here
+    // rather than left to surface as a confusing per-request failure much later.
+    if (is_dir) {
+        std::string verr;
+        if (!qwen_vision_config_from_hf_json(gguf_path, impl_->vcfg, verr)) {
+            fprintf(stderr, "[sparkinfer-server] vision config malformed: %s\n", verr.c_str());
+        } else if (impl_->vcfg.present) {
+            sparkinfer::SafeTensorsModel vst;
+            if (!vst.open(gguf_path)) {
+                fprintf(stderr, "[sparkinfer-server] vision: cannot open safetensors\n");
+            } else if (!load_qwen_vision_weights(vst, impl_->vcfg, impl_->vweights, verr)) {
+                fprintf(stderr, "[sparkinfer-server] vision tower load failed: %s\n", verr.c_str());
+            } else {
+                impl_->vision_ready = true;
+                impl_->batch_engine->set_vision(&impl_->vweights, &impl_->vcfg);
+                fprintf(stderr, "[sparkinfer-server] vision tower ready: %d blocks, out_hidden=%d\n",
+                        impl_->vcfg.depth, impl_->vcfg.out_hidden);
+            }
+        }
+    }
+
     impl_->path = gguf_path;
     impl_->ready = true;
     fprintf(stderr, "[sparkinfer-server] continuous batching enabled (policy=%d, batch=%d)\n",
@@ -407,6 +450,71 @@ int ModelEngine::max_seq() const {
 bool ModelEngine::is_museglimmer() const {
     std::lock_guard<std::mutex> lock(mu_);
     return impl_->ready && impl_->cfg.muse_glimmer;
+}
+
+bool ModelEngine::has_vision() const {
+    std::lock_guard<std::mutex> lock(mu_);
+    return impl_->vision_ready;
+}
+
+bool ModelEngine::prepare_images(const std::vector<std::string>& urls, int image_token_id,
+                                 std::vector<int>& prompt_ids, PreparedImages& out,
+                                 std::string& err) const {
+    out.images.clear();
+    out.positions.clear();
+    if (urls.empty()) return true;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (!impl_->vision_ready) {
+            err = "this model has no vision tower; image input is not supported";
+            return false;
+        }
+    }
+    // vcfg is written only by load() and read-only afterwards, and the tower weights are not
+    // touched here at all -- this does CPU preprocessing only, so it runs without the engine
+    // mutex and without contending for the GPU.
+    for (size_t i = 0; i < urls.size(); i++) {
+        const std::string where = "image " + std::to_string(i);
+        std::vector<unsigned char> bytes;
+        if (!parse_image_url(urls[i], bytes, err)) { err = where + ": " + err; return false; }
+        DecodedImage img;
+        if (!decode_image(bytes.data(), bytes.size(), img, err)) { err = where + ": " + err; return false; }
+        PreparedImages::Image pi;
+        int gh = 0, gw = 0;
+        auto pixels = std::make_shared<std::vector<float>>();
+        if (!sparkinfer::qwen_vision_preprocess(img.rgb.data(), img.height, img.width, impl_->vcfg,
+                                                *pixels, &gh, &gw, err)) {
+            err = where + ": " + err;
+            return false;
+        }
+        pi.pixels = std::move(pixels);
+        pi.grid_h = gh;
+        pi.grid_w = gw;
+        out.images.push_back(std::move(pi));
+    }
+    // One placeholder per image goes in, the count each grid needs comes out. A mismatch here is
+    // an error, never a best-effort expansion: guessing would hand the model a prompt whose image
+    // span is quietly truncated or padded, which it will describe fluently either way.
+    return reexpand_images(image_token_id, prompt_ids, out, err);
+}
+
+bool ModelEngine::reexpand_images(int image_token_id, std::vector<int>& prompt_ids,
+                                  PreparedImages& io, std::string& err) const {
+    io.positions.clear();
+    if (io.images.empty()) return true;
+    // Counts come from the grids, not from a remembered list, so this is correct whether it runs
+    // on the first prompt or on one rebuilt from scratch afterwards.
+    std::vector<int> counts;
+    counts.reserve(io.images.size());
+    for (const auto& im : io.images)
+        counts.push_back(sparkinfer::qwen_vision_num_tokens(im.grid_h, im.grid_w, impl_->vcfg));
+    std::vector<int> expanded;
+    if (!sparkinfer::qwen_vision_expand_placeholders(prompt_ids, image_token_id, counts, expanded, err))
+        return false;
+    prompt_ids.swap(expanded);
+    for (size_t i = 0; i < prompt_ids.size(); i++)
+        if (prompt_ids[i] == image_token_id) io.positions.push_back((int)i);
+    return true;
 }
 
 bool ModelEngine::is_qwen38() const {
@@ -463,12 +571,19 @@ CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_
                                                  bool logprobs, int top_logprobs,
                                                  const std::function<void(const TokenLogprob&)>&
                                                      on_token_logprob,
-                                                 const std::vector<int>& forced_tokens) {
+                                                 const std::vector<int>& forced_tokens,
+                                                 const PreparedImages* images) {
     CompletionResult out;
     sparkinfer::ContinuousBatchEngine::Request req;
     req.prompt = prompt_ids;
     req.max_new_tokens = max_new_tokens;
     req.forced_tokens = forced_tokens;
+    if (images && !images->positions.empty()) {
+        req.vision_pos = images->positions;
+        req.vision_images.reserve(images->images.size());
+        for (const auto& im : images->images)
+            req.vision_images.push_back({im.pixels, im.grid_h, im.grid_w});   // shares the buffer
+    }
     req.temperature = temperature;
     req.seed = seed;
     req.top_k = top_k;

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -160,6 +160,26 @@ bool encode_messages(const std::string& body, std::vector<int>& ids, bool enable
     return g_tokenizer.encode_chat_request(body, ids, enable_thinking, err, request);
 }
 
+// The image placeholder's token id, resolved from the loaded tokenizer rather than hardcoded --
+// it differs between checkpoints and a wrong constant would splice embeddings over ordinary text.
+// Negative when this tokenizer has no such token, which is how a text-only model reports that it
+// cannot take images. Resolved once: it cannot change while a model is loaded.
+int image_pad_token_id() {
+    static const int id = [] {
+        const std::vector<int> ids = g_tokenizer.encode_raw("<|image_pad|>");
+        return ids.size() == 1 ? ids[0] : -1;
+    }();
+    return id;
+}
+
+// Collects every image_url in the request, in message order, matching the order the rendered
+// prompt's placeholders appear in.
+std::vector<std::string> collect_image_urls(const sparkinfer_server::ChatRequest& r) {
+    std::vector<std::string> urls;
+    for (const auto& m : r.messages) urls.insert(urls.end(), m.images.begin(), m.images.end());
+    return urls;
+}
+
 // RequestControls / parse_request_controls / should_reject_dflash_temperature now live in
 // chat_tools.hpp/.cpp (moved so `stop`/`temperature`/`seed` validation has a unit-test seam via
 // chat_tools_test, same as ChatRequest/parse_chat_request_json already had).
@@ -718,6 +738,24 @@ int main(int argc, char** argv) {
         const bool enable_thinking = sparkinfer_server::parse_enable_thinking(req.body, engine.is_qwen38());
         std::vector<int> ids;
         std::string err;
+        // Images would render a bare <|image_pad|> into these ids: the count each image really
+        // needs depends on its resized grid, which only the preprocessor knows. Reporting the
+        // unexpanded number would understate the prompt by hundreds or thousands of tokens, so
+        // this says so rather than returning a wrong count.
+        {
+            sparkinfer_server::ChatRequest probe;
+            std::string perr;
+            if (encode_messages(req.body, ids, enable_thinking, perr, &probe) &&
+                !collect_image_urls(probe).empty()) {
+                g_requests_client_error++;
+                res.status = 400;
+                res.set_content("{\"error\":{\"message\":\"/v1/tokenize does not support image "
+                                "content parts; token counts for images depend on the resized "
+                                "grid\"}}", "application/json");
+                return;
+            }
+            ids.clear();
+        }
         if (!encode_messages(req.body, ids, enable_thinking, err)) {
             res.status = 400;
             res.set_content("{\"error\":{\"message\":\"" + json_escape(err) + "\"}}", "application/json");
@@ -783,6 +821,19 @@ int main(int argc, char** argv) {
             const bool enable_thinking =
                 sparkinfer_server::parse_enable_thinking(req.body, engine.is_qwen38());
             std::string err;
+            // Scoring an image prompt would need the tower run and the placeholders expanded.
+            // Silently dropping the image and returning logprobs for the text alone is the worst
+            // option for an endpoint that exists to be compared against another copy of itself.
+            {
+                sparkinfer_server::ChatRequest probe;
+                std::string perr;
+                if (encode_messages(req.body, prompt_ids, enable_thinking, perr, &probe) &&
+                    !collect_image_urls(probe).empty()) {
+                    fail(400, "/v1/score does not support image content parts");
+                    return;
+                }
+                prompt_ids.clear();
+            }
             if (!encode_messages(req.body, prompt_ids, enable_thinking, err)) {
                 fail(400, err);
                 return;
@@ -944,12 +995,38 @@ int main(int argc, char** argv) {
 
                  std::vector<int> prompt_ids;
                  sparkinfer_server::ChatRequest chat_request;
+                 sparkinfer_server::PreparedImages prepared;
                  if (!encode_messages(req.body, prompt_ids, enable_thinking, err, &chat_request)) {
                      g_requests_client_error++;
                      res.status = 400;
                      res.set_content("{\"error\":{\"message\":\"" + json_escape(err) + "\"}}",
                                      "application/json");
                      return;
+                 }
+                 // Images: decode, preprocess, and expand each placeholder to the token count
+                 // its grid needs. Deliberately BEFORE the max_seq check below -- a 1024x1536
+                 // image expands one placeholder into 1536 tokens, so checking the unexpanded
+                 // prompt would admit a request that cannot fit and fail it deep in prefill.
+                 {
+                     const std::vector<std::string> urls =
+                         collect_image_urls(chat_request);
+                     if (!urls.empty()) {
+                         const int pad_id = image_pad_token_id();
+                         std::string ierr;
+                         if (pad_id < 0) {
+                             ierr = "this model's tokenizer has no image placeholder token; "
+                                    "image input is not supported";
+                         } else if (!engine.prepare_images(urls, pad_id, prompt_ids, prepared, ierr)) {
+                             // ierr already names which image and why.
+                         }
+                         if (!ierr.empty()) {
+                             g_requests_client_error++;
+                             res.status = 400;
+                             res.set_content("{\"error\":{\"message\":\"" + json_escape(ierr) + "\"}}",
+                                             "application/json");
+                             return;
+                         }
+                     }
                  }
                  // Presence of a tool protocol requires strict, buffered parsing even when
                  // tool_choice=none. The latter disables execution, not output validation:
@@ -996,6 +1073,10 @@ int main(int argc, char** argv) {
                      res.set_chunked_content_provider(
                          "text/event-stream",
                          [&engine, prompt_ids, max_tokens, cid, created, enable_thinking,
+                          // BY VALUE, like prompt_ids beside it: this provider runs after the
+                          // handler returns, so a reference would dangle. Cheap -- PreparedImages
+                          // shares its pixel buffers rather than owning them.
+                          prepared,
                           chat_request, tool_protocol, json_mode_active,
                           include_usage = controls.include_usage || always_stream_usage(), stop = controls.stop,
                           temperature = controls.temperature, seed = controls.seed,
@@ -1070,6 +1151,10 @@ int main(int argc, char** argv) {
                              // valid attempt is confirmed.
                              auto run_json_mode_branch = [&](int ci, uint64_t branch_seed, BranchOutcome* out) {
                                  std::vector<int> cur_prompt_ids = prompt_ids;
+                                 // Per-branch copy: the continuation below re-renders the prompt,
+                                 // which moves every placeholder, and branches run concurrently.
+                                 // The copy is cheap -- the pixel buffers are shared, not cloned.
+                                 sparkinfer_server::PreparedImages cur_images = prepared;
                                  sparkinfer_server::ChatRequest cur_request = chat_request;
                                  sparkinfer_server::CompletionResult outcome;
                                  bool ok = false;
@@ -1097,7 +1182,8 @@ int main(int argc, char** argv) {
                                      };
                                      outcome = engine.complete_streaming(cur_prompt_ids, max_tokens, on_tok,
                                          temperature, branch_seed, top_k, top_p, presence_penalty,
-                                         frequency_penalty, logit_bias);
+                                         frequency_penalty, logit_bias, false, 0, nullptr, {},
+                                         &cur_images);
                                      out->prompt_tokens += (long long)cur_prompt_ids.size();
                                      out->completion_tokens += (long long)ids.size();
                                      if (outcome.cancelled && !stopped_by_sequence) {
@@ -1140,6 +1226,17 @@ int main(int argc, char** argv) {
                                      if (attempt == 1) {
                                          cur_request = build_retry_request(chat_request, out->parsed.content, validation_err);
                                          cur_prompt_ids = g_tokenizer.encode_augmented(cur_request, enable_thinking);
+                                         // Same re-expansion as the non-streaming branch: the
+                                         // rebuilt prompt's placeholders moved.
+                                         if (!cur_images.images.empty()) {
+                                             std::string rerr;
+                                             if (!engine.reexpand_images(image_pad_token_id(),
+                                                                         cur_prompt_ids, cur_images, rerr)) {
+                                                 out->fail = BranchOutcome::Fail::server_error;
+                                                 out->fail_message = "image re-expansion failed: " + rerr;
+                                                 return;
+                                             }
+                                         }
                                      }
                                  }
                                  if (!ok) {
@@ -1239,7 +1336,8 @@ int main(int argc, char** argv) {
                                                   : nullptr;
                                  const auto outcome = engine.complete_streaming(prompt_ids, max_tokens, on_tok,
                                      temperature, branch_seed, top_k, top_p, presence_penalty, frequency_penalty,
-                                     logit_bias, logprobs, top_logprobs, maybe_on_tok_logprob);
+                                     logit_bias, logprobs, top_logprobs, maybe_on_tok_logprob,
+                                     {}, &prepared);
                                  out->prompt_tokens = (long long)prompt_ids.size();
                                  out->completion_tokens = (long long)stream_ids.size();
                                  if (outcome.cancelled && !stopped_by_sequence) {
@@ -1505,6 +1603,7 @@ int main(int argc, char** argv) {
                          // anywhere -- resubmitting the identical prompt would just reproduce the
                          // same invalid output) before giving up.
                          std::vector<int> cur_prompt_ids = prompt_ids;
+                         sparkinfer_server::PreparedImages cur_images = prepared;
                          sparkinfer_server::ChatRequest cur_request = chat_request;
                          bool ok = false;
                          std::string validation_err;
@@ -1531,7 +1630,8 @@ int main(int argc, char** argv) {
                              };
                              outcome = engine.complete_streaming(cur_prompt_ids, max_tokens, on_tok,
                                  controls.temperature, branch_seed, controls.top_k, controls.top_p,
-                                 controls.presence_penalty, controls.frequency_penalty, controls.logit_bias);
+                                 controls.presence_penalty, controls.frequency_penalty, controls.logit_bias,
+                                 false, 0, nullptr, {}, &cur_images);
                              out.prompt_tokens += (long long)cur_prompt_ids.size();
                              out.completion_tokens += (long long)ids.size();
                              if (!outcome.error.empty()) {
@@ -1577,6 +1677,19 @@ int main(int argc, char** argv) {
                              if (attempt == 1) {
                                  cur_request = build_retry_request(chat_request, parsed.content, validation_err);
                                  cur_prompt_ids = g_tokenizer.encode_augmented(cur_request, enable_thinking);
+                                 // The rebuilt prompt carries one bare placeholder per image
+                                 // again, at new offsets -- re-expand, or the splice lands on the
+                                 // wrong tokens.
+                                 if (!cur_images.images.empty()) {
+                                     std::string rerr;
+                                     if (!engine.reexpand_images(image_pad_token_id(), cur_prompt_ids,
+                                                                 cur_images, rerr)) {
+                                         out.http_status = 500;
+                                         out.fail = NonStreamBranchOutcome::Fail::server_error;
+                                         out.http_error = "image re-expansion failed: " + rerr;
+                                         return out;
+                                     }
+                                 }
                              }
                          }
                          if (!ok) {
@@ -1620,7 +1733,8 @@ int main(int argc, char** argv) {
                          outcome = engine.complete_streaming(prompt_ids, max_tokens, nonstream_on_tok,
                              controls.temperature, branch_seed, controls.top_k, controls.top_p,
                              controls.presence_penalty, controls.frequency_penalty, controls.logit_bias,
-                             controls.logprobs, controls.top_logprobs, maybe_nonstream_on_tok_logprob);
+                             controls.logprobs, controls.top_logprobs, maybe_nonstream_on_tok_logprob,
+                             {}, &prepared);
                          // Defensive clamp -- should already hold, cheap insurance against any
                          // subtle off-by-one between the two accumulation paths above.
                          if (logprob_entries.size() > outcome.tokens.size())

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -763,13 +763,17 @@ bool test_nontext_content_parts_are_ignored_not_rejected() {
     // A mixed multimodal payload (common even against text-only backends -- agent frameworks
     // often build one request shape for every provider) must still succeed using whatever text
     // parts are present, not hard-reject the whole request.
+    //
+    // This used to cover image_url too. It no longer can: images are honored now, so they get
+    // their own tests below. Anything still genuinely unsupported -- audio here -- must keep
+    // being skipped rather than rejected.
     json body = {
         {"model", "spark"},
         {"messages", json::array({json::object({
              {"role", "user"},
              {"content", json::array({
                   json::object({{"type", "text"}, {"text", "describe this: "}}),
-                  json::object({{"type", "image_url"}, {"image_url", json::object({{"url", "http://x/y.png"}})}}),
+                  json::object({{"type", "input_audio"}, {"input_audio", json::object({{"data", "AAA"}})}}),
                   json::object({{"type", "text"}, {"text", "please"}}),
               })},
          })})},
@@ -778,6 +782,79 @@ bool test_nontext_content_parts_are_ignored_not_rejected() {
     CHECK(parse_request(body.dump(), request));
     CHECK(request.messages.size() == 1);
     CHECK(request.messages[0].content == "describe this: please");
+    CHECK(request.messages[0].images.empty());
+    return true;
+}
+
+bool test_image_parts_render_a_marker_and_collect_urls() {
+    // Each image_url renders the marker the template emits, AT the position the part occupied,
+    // and its URL is collected in the same order. The two must stay in lockstep: the processor
+    // pairs the Nth placeholder with the Nth image to expand it to that image's token count, so
+    // an ordering or count skew here silently splices one image's embeddings over another's span.
+    json body = {
+        {"model", "spark"},
+        {"messages", json::array({json::object({
+             {"role", "user"},
+             {"content", json::array({
+                  json::object({{"type", "text"}, {"text", "A:"}}),
+                  json::object({{"type", "image_url"},
+                                {"image_url", json::object({{"url", "data:image/png;base64,AAA"}})}}),
+                  json::object({{"type", "text"}, {"text", " B:"}}),
+                  json::object({{"type", "image_url"},
+                                {"image_url", json::object({{"url", "data:image/png;base64,BBB"}})}}),
+              })},
+         })})},
+    };
+    ChatRequest request;
+    CHECK(parse_request(body.dump(), request));
+    CHECK(request.messages[0].images.size() == 2);
+    CHECK(request.messages[0].images[0] == "data:image/png;base64,AAA");
+    CHECK(request.messages[0].images[1] == "data:image/png;base64,BBB");
+    CHECK(request.messages[0].content ==
+          "A:<|vision_start|><|image_pad|><|vision_end|>"
+          " B:<|vision_start|><|image_pad|><|vision_end|>");
+    return true;
+}
+
+bool test_image_in_system_message_is_rejected() {
+    // The chat template raises on this outright; parsing mirrors it rather than building a
+    // prompt shape the model was never trained to read. "developer" is aliased to system, so it
+    // has to be refused by the SAME rule and not slip past on the role name.
+    for (const char* role : {"system", "developer"}) {
+        json body = {
+            {"model", "spark"},
+            {"messages", json::array({json::object({
+                 {"role", role},
+                 {"content", json::array({json::object({
+                      {"type", "image_url"},
+                      {"image_url", json::object({{"url", "data:image/png;base64,AAA"}})}})})},
+             })})},
+        };
+        ChatRequest request;
+        CHECK(!parse_request(body.dump(), request));
+    }
+    return true;
+}
+
+bool test_malformed_image_url_is_rejected() {
+    // A part that says it is an image but carries no usable url is a broken request, not
+    // something to skip: skipping it would drop an image the caller believes was sent and answer
+    // confidently about what is left.
+    const char* bad[] = {
+        R"([{"type":"image_url"}])",
+        R"([{"type":"image_url","image_url":{}}])",
+        R"([{"type":"image_url","image_url":{"url":123}}])",
+        R"([{"type":"image_url","image_url":"data:image/png;base64,AAA"}])",
+    };
+    for (const char* parts : bad) {
+        json body = {
+            {"model", "spark"},
+            {"messages", json::array({json::object({
+                 {"role", "user"}, {"content", json::parse(parts)}})})},
+        };
+        ChatRequest request;
+        CHECK(!parse_request(body.dump(), request));
+    }
     return true;
 }
 
@@ -1573,6 +1650,9 @@ int main() {
     if (!test_control_markup_never_leaks_as_content()) return 1;
     if (!test_trailing_whitespace_after_tool_call_is_not_malformed()) return 1;
     if (!test_nontext_content_parts_are_ignored_not_rejected()) return 1;
+    if (!test_image_parts_render_a_marker_and_collect_urls()) return 1;
+    if (!test_image_in_system_message_is_rejected()) return 1;
+    if (!test_malformed_image_url_is_rejected()) return 1;
     if (!test_developer_role_is_accepted_as_system_alias()) return 1;
     if (!test_response_format_type_validation()) return 1;
     if (!test_response_format_json_object_parses()) return 1;

--- a/server/tests/image_input_test.cpp
+++ b/server/tests/image_input_test.cpp
@@ -1,0 +1,66 @@
+// base64 + data: URL + decode behaviour, including the refusals.
+//
+// The refusals are the security-relevant half: a remote URL must NOT be fetched (SSRF), oversized
+// payloads must be rejected before allocation, and malformed base64 must fail rather than silently
+// yielding truncated bytes that stb then misinterprets.
+#include <cstdio>
+#include <cstring>
+#include <string>
+#include <vector>
+#include "image_input.hpp"
+
+using namespace sparkinfer_server;
+static int g_fail = 0;
+static void check(bool ok, const char* what) {
+    printf("  %-62s %s\n", what, ok ? "ok" : "FAIL");
+    if (!ok) g_fail++;
+}
+
+int main() {
+    std::string err;
+    std::vector<unsigned char> out;
+
+    check(base64_decode("", out, err) && out.empty(), "empty base64 -> empty output");
+    check(base64_decode("TWFu", out, err) && out.size() == 3 && !memcmp(out.data(), "Man", 3),
+          "base64 'TWFu' -> 'Man'");
+    check(base64_decode("TWE=", out, err) && out.size() == 2 && !memcmp(out.data(), "Ma", 2),
+          "base64 with one pad char");
+    check(base64_decode("TQ==", out, err) && out.size() == 1 && out[0] == 'M',
+          "base64 with two pad chars");
+    check(base64_decode("TWFu\nTWFu", out, err) && out.size() == 6,
+          "newlines inside base64 are tolerated");
+    check(!base64_decode("TW*u", out, err), "invalid base64 character is rejected");
+    check(!base64_decode("TWE=Zg", out, err), "data after base64 padding is rejected");
+
+    // A 1x1 red PNG, base64 -- the smallest real decode path.
+    const std::string png1x1 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+    std::vector<unsigned char> bytes;
+    check(parse_image_url("data:image/png;base64," + png1x1, bytes, err) && !bytes.empty(),
+          "data: URL with base64 PNG parses");
+    DecodedImage img;
+    check(decode_image(bytes.data(), bytes.size(), img, err) && img.width == 1 && img.height == 1
+              && img.rgb.size() == 3,
+          "1x1 PNG decodes to exactly 3 RGB bytes");
+
+    check(!parse_image_url("https://example.com/cat.png", bytes, err),
+          "remote https URL is REFUSED, not fetched (SSRF)");
+    check(err.find("policy") != std::string::npos,
+          "  ...and the error says it is policy, not a parse failure");
+    check(!parse_image_url("http://169.254.169.254/latest/meta-data/", bytes, err),
+          "cloud metadata URL is refused too");
+    check(!parse_image_url("data:image/png,notbase64", bytes, err),
+          "non-base64 data: URL is refused");
+    check(!parse_image_url("data:image/png;base64", bytes, err),
+          "data: URL with no comma is refused");
+    check(!parse_image_url("data:image/png;base64," + std::string(kMaxImageBytes / 3 * 4 + 64, 'A'),
+                           bytes, err),
+          "oversized data: URL is refused before decoding");
+
+    const unsigned char junk[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+    check(!decode_image(junk, sizeof(junk), img, err), "non-image bytes fail to decode");
+    check(!decode_image(nullptr, 0, img, err), "empty payload fails to decode");
+
+    printf(g_fail ? "[FAIL] %d check(s) failed\n" : "[OK] image input handling is correct\n", g_fail);
+    return g_fail ? 1 : 0;
+}

--- a/server/third_party/stb_image.h
+++ b/server/third_party/stb_image.h
@@ -1,0 +1,7988 @@
+/* stb_image - v2.30 - public domain image loader - http://nothings.org/stb
+                                  no warranty implied; use at your own risk
+
+   Do this:
+      #define STB_IMAGE_IMPLEMENTATION
+   before you include this file in *one* C or C++ file to create the implementation.
+
+   // i.e. it should look like this:
+   #include ...
+   #include ...
+   #include ...
+   #define STB_IMAGE_IMPLEMENTATION
+   #include "stb_image.h"
+
+   You can #define STBI_ASSERT(x) before the #include to avoid using assert.h.
+   And #define STBI_MALLOC, STBI_REALLOC, and STBI_FREE to avoid using malloc,realloc,free
+
+
+   QUICK NOTES:
+      Primarily of interest to game developers and other people who can
+          avoid problematic images and only need the trivial interface
+
+      JPEG baseline & progressive (12 bpc/arithmetic not supported, same as stock IJG lib)
+      PNG 1/2/4/8/16-bit-per-channel
+
+      TGA (not sure what subset, if a subset)
+      BMP non-1bpp, non-RLE
+      PSD (composited view only, no extra channels, 8/16 bit-per-channel)
+
+      GIF (*comp always reports as 4-channel)
+      HDR (radiance rgbE format)
+      PIC (Softimage PIC)
+      PNM (PPM and PGM binary only)
+
+      Animated GIF still needs a proper API, but here's one way to do it:
+          http://gist.github.com/urraka/685d9a6340b26b830d49
+
+      - decode from memory or through FILE (define STBI_NO_STDIO to remove code)
+      - decode from arbitrary I/O callbacks
+      - SIMD acceleration on x86/x64 (SSE2) and ARM (NEON)
+
+   Full documentation under "DOCUMENTATION" below.
+
+
+LICENSE
+
+  See end of file for license information.
+
+RECENT REVISION HISTORY:
+
+      2.30  (2024-05-31) avoid erroneous gcc warning
+      2.29  (2023-05-xx) optimizations
+      2.28  (2023-01-29) many error fixes, security errors, just tons of stuff
+      2.27  (2021-07-11) document stbi_info better, 16-bit PNM support, bug fixes
+      2.26  (2020-07-13) many minor fixes
+      2.25  (2020-02-02) fix warnings
+      2.24  (2020-02-02) fix warnings; thread-local failure_reason and flip_vertically
+      2.23  (2019-08-11) fix clang static analysis warning
+      2.22  (2019-03-04) gif fixes, fix warnings
+      2.21  (2019-02-25) fix typo in comment
+      2.20  (2019-02-07) support utf8 filenames in Windows; fix warnings and platform ifdefs
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) bugfix, 1-bit BMP, 16-bitness query, fix warnings
+      2.16  (2017-07-23) all functions have 16-bit variants; optimizations; bugfixes
+      2.15  (2017-03-18) fix png-1,2,4; all Imagenet JPGs; no runtime SSE detection on GCC
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-12-04) experimental 16-bit API, only for PNG so far; fixes
+      2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
+      2.11  (2016-04-02) 16-bit PNGS; enable SSE2 in non-gcc x64
+                         RGB-format JPEG; remove white matting in PSD;
+                         allocate large structures on the stack;
+                         correct channel count for PNG & BMP
+      2.10  (2016-01-22) avoid warning introduced in 2.09
+      2.09  (2016-01-16) 16-bit TGA; comments in PNM files; STBI_REALLOC_SIZED
+
+   See end of file for full revision history.
+
+
+ ============================    Contributors    =========================
+
+ Image formats                          Extensions, features
+    Sean Barrett (jpeg, png, bmp)          Jetro Lauha (stbi_info)
+    Nicolas Schulz (hdr, psd)              Martin "SpartanJ" Golini (stbi_info)
+    Jonathan Dummer (tga)                  James "moose2000" Brown (iPhone PNG)
+    Jean-Marc Lienher (gif)                Ben "Disch" Wenger (io callbacks)
+    Tom Seddon (pic)                       Omar Cornut (1/2/4-bit PNG)
+    Thatcher Ulrich (psd)                  Nicolas Guillemot (vertical flip)
+    Ken Miller (pgm, ppm)                  Richard Mitton (16-bit PSD)
+    github:urraka (animated gif)           Junggon Kim (PNM comments)
+    Christopher Forseth (animated gif)     Daniel Gibson (16-bit TGA)
+                                           socks-the-fox (16-bit PNG)
+                                           Jeremy Sawicki (handle all ImageNet JPGs)
+ Optimizations & bugfixes                  Mikhail Morozov (1-bit BMP)
+    Fabian "ryg" Giesen                    Anael Seghezzi (is-16-bit query)
+    Arseny Kapoulkine                      Simon Breuss (16-bit PNM)
+    John-Mark Allen
+    Carmelo J Fdez-Aguera
+
+ Bug & warning fixes
+    Marc LeBlanc            David Woo          Guillaume George     Martins Mozeiko
+    Christpher Lloyd        Jerry Jansson      Joseph Thomson       Blazej Dariusz Roszkowski
+    Phil Jordan                                Dave Moore           Roy Eltham
+    Hayaki Saito            Nathan Reed        Won Chun
+    Luke Graham             Johan Duparc       Nick Verigakis       the Horde3D community
+    Thomas Ruf              Ronny Chevalier                         github:rlyeh
+    Janez Zemva             John Bartholomew   Michal Cichon        github:romigrou
+    Jonathan Blow           Ken Hamada         Tero Hanninen        github:svdijk
+    Eugene Golushkov        Laurent Gomila     Cort Stratton        github:snagar
+    Aruelien Pocheville     Sergio Gonzalez    Thibault Reuille     github:Zelex
+    Cass Everitt            Ryamond Barbiero                        github:grim210
+    Paul Du Bois            Engin Manap        Aldo Culquicondor    github:sammyhw
+    Philipp Wiesemann       Dale Weiler        Oriol Ferrer Mesia   github:phprus
+    Josh Tobin              Neil Bickford      Matthew Gregan       github:poppolopoppo
+    Julian Raschke          Gregory Mullen     Christian Floisand   github:darealshinji
+    Baldur Karlsson         Kevin Schmidt      JR Smith             github:Michaelangel007
+                            Brad Weinberger    Matvey Cherevko      github:mosra
+    Luca Sas                Alexander Veselov  Zack Middleton       [reserved]
+    Ryan C. Gordon          [reserved]                              [reserved]
+                     DO NOT ADD YOUR NAME HERE
+
+                     Jacko Dirks
+
+  To add your name to the credits, pick a random blank space in the middle and fill it.
+  80% of merge conflicts on stb PRs are due to people adding their name at the end
+  of the credits.
+*/
+
+#ifndef STBI_INCLUDE_STB_IMAGE_H
+#define STBI_INCLUDE_STB_IMAGE_H
+
+// DOCUMENTATION
+//
+// Limitations:
+//    - no 12-bit-per-channel JPEG
+//    - no JPEGs with arithmetic coding
+//    - GIF always returns *comp=4
+//
+// Basic usage (see HDR discussion below for HDR usage):
+//    int x,y,n;
+//    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
+//    // ... process data if not NULL ...
+//    // ... x = width, y = height, n = # 8-bit components per pixel ...
+//    // ... replace '0' with '1'..'4' to force that many components per pixel
+//    // ... but 'n' will always be the number that it would have been if you said 0
+//    stbi_image_free(data);
+//
+// Standard parameters:
+//    int *x                 -- outputs image width in pixels
+//    int *y                 -- outputs image height in pixels
+//    int *channels_in_file  -- outputs # of image components in image file
+//    int desired_channels   -- if non-zero, # of image components requested in result
+//
+// The return value from an image loader is an 'unsigned char *' which points
+// to the pixel data, or NULL on an allocation failure or if the image is
+// corrupt or invalid. The pixel data consists of *y scanlines of *x pixels,
+// with each pixel consisting of N interleaved 8-bit components; the first
+// pixel pointed to is top-left-most in the image. There is no padding between
+// image scanlines or between pixels, regardless of format. The number of
+// components N is 'desired_channels' if desired_channels is non-zero, or
+// *channels_in_file otherwise. If desired_channels is non-zero,
+// *channels_in_file has the number of components that _would_ have been
+// output otherwise. E.g. if you set desired_channels to 4, you will always
+// get RGBA output, but you can check *channels_in_file to see if it's trivially
+// opaque because e.g. there were only 3 channels in the source image.
+//
+// An output image with N components has the following components interleaved
+// in this order in each pixel:
+//
+//     N=#comp     components
+//       1           grey
+//       2           grey, alpha
+//       3           red, green, blue
+//       4           red, green, blue, alpha
+//
+// If image loading fails for any reason, the return value will be NULL,
+// and *x, *y, *channels_in_file will be unchanged. The function
+// stbi_failure_reason() can be queried for an extremely brief, end-user
+// unfriendly explanation of why the load failed. Define STBI_NO_FAILURE_STRINGS
+// to avoid compiling these strings at all, and STBI_FAILURE_USERMSG to get slightly
+// more user-friendly ones.
+//
+// Paletted PNG, BMP, GIF, and PIC images are automatically depalettized.
+//
+// To query the width, height and component count of an image without having to
+// decode the full file, you can use the stbi_info family of functions:
+//
+//   int x,y,n,ok;
+//   ok = stbi_info(filename, &x, &y, &n);
+//   // returns ok=1 and sets x, y, n if image is a supported format,
+//   // 0 otherwise.
+//
+// Note that stb_image pervasively uses ints in its public API for sizes,
+// including sizes of memory buffers. This is now part of the API and thus
+// hard to change without causing breakage. As a result, the various image
+// loaders all have certain limits on image size; these differ somewhat
+// by format but generally boil down to either just under 2GB or just under
+// 1GB. When the decoded image would be larger than this, stb_image decoding
+// will fail.
+//
+// Additionally, stb_image will reject image files that have any of their
+// dimensions set to a larger value than the configurable STBI_MAX_DIMENSIONS,
+// which defaults to 2**24 = 16777216 pixels. Due to the above memory limit,
+// the only way to have an image with such dimensions load correctly
+// is for it to have a rather extreme aspect ratio. Either way, the
+// assumption here is that such larger images are likely to be malformed
+// or malicious. If you do need to load an image with individual dimensions
+// larger than that, and it still fits in the overall size limit, you can
+// #define STBI_MAX_DIMENSIONS on your own to be something larger.
+//
+// ===========================================================================
+//
+// UNICODE:
+//
+//   If compiling for Windows and you wish to use Unicode filenames, compile
+//   with
+//       #define STBI_WINDOWS_UTF8
+//   and pass utf8-encoded filenames. Call stbi_convert_wchar_to_utf8 to convert
+//   Windows wchar_t filenames to utf8.
+//
+// ===========================================================================
+//
+// Philosophy
+//
+// stb libraries are designed with the following priorities:
+//
+//    1. easy to use
+//    2. easy to maintain
+//    3. good performance
+//
+// Sometimes I let "good performance" creep up in priority over "easy to maintain",
+// and for best performance I may provide less-easy-to-use APIs that give higher
+// performance, in addition to the easy-to-use ones. Nevertheless, it's important
+// to keep in mind that from the standpoint of you, a client of this library,
+// all you care about is #1 and #3, and stb libraries DO NOT emphasize #3 above all.
+//
+// Some secondary priorities arise directly from the first two, some of which
+// provide more explicit reasons why performance can't be emphasized.
+//
+//    - Portable ("ease of use")
+//    - Small source code footprint ("easy to maintain")
+//    - No dependencies ("ease of use")
+//
+// ===========================================================================
+//
+// I/O callbacks
+//
+// I/O callbacks allow you to read from arbitrary sources, like packaged
+// files or some other source. Data read from callbacks are processed
+// through a small internal buffer (currently 128 bytes) to try to reduce
+// overhead.
+//
+// The three functions you must define are "read" (reads some bytes of data),
+// "skip" (skips some bytes of data), "eof" (reports if the stream is at the end).
+//
+// ===========================================================================
+//
+// SIMD support
+//
+// The JPEG decoder will try to automatically use SIMD kernels on x86 when
+// supported by the compiler. For ARM Neon support, you must explicitly
+// request it.
+//
+// (The old do-it-yourself SIMD API is no longer supported in the current
+// code.)
+//
+// On x86, SSE2 will automatically be used when available based on a run-time
+// test; if not, the generic C versions are used as a fall-back. On ARM targets,
+// the typical path is to have separate builds for NEON and non-NEON devices
+// (at least this is true for iOS and Android). Therefore, the NEON support is
+// toggled by a build flag: define STBI_NEON to get NEON loops.
+//
+// If for some reason you do not want to use any of SIMD code, or if
+// you have issues compiling it, you can disable it entirely by
+// defining STBI_NO_SIMD.
+//
+// ===========================================================================
+//
+// HDR image support   (disable by defining STBI_NO_HDR)
+//
+// stb_image supports loading HDR images in general, and currently the Radiance
+// .HDR file format specifically. You can still load any file through the existing
+// interface; if you attempt to load an HDR file, it will be automatically remapped
+// to LDR, assuming gamma 2.2 and an arbitrary scale factor defaulting to 1;
+// both of these constants can be reconfigured through this interface:
+//
+//     stbi_hdr_to_ldr_gamma(2.2f);
+//     stbi_hdr_to_ldr_scale(1.0f);
+//
+// (note, do not use _inverse_ constants; stbi_image will invert them
+// appropriately).
+//
+// Additionally, there is a new, parallel interface for loading files as
+// (linear) floats to preserve the full dynamic range:
+//
+//    float *data = stbi_loadf(filename, &x, &y, &n, 0);
+//
+// If you load LDR images through this interface, those images will
+// be promoted to floating point values, run through the inverse of
+// constants corresponding to the above:
+//
+//     stbi_ldr_to_hdr_scale(1.0f);
+//     stbi_ldr_to_hdr_gamma(2.2f);
+//
+// Finally, given a filename (or an open file or memory block--see header
+// file for details) containing image data, you can query for the "most
+// appropriate" interface to use (that is, whether the image is HDR or
+// not), using:
+//
+//     stbi_is_hdr(char *filename);
+//
+// ===========================================================================
+//
+// iPhone PNG support:
+//
+// We optionally support converting iPhone-formatted PNGs (which store
+// premultiplied BGRA) back to RGB, even though they're internally encoded
+// differently. To enable this conversion, call
+// stbi_convert_iphone_png_to_rgb(1).
+//
+// Call stbi_set_unpremultiply_on_load(1) as well to force a divide per
+// pixel to remove any premultiplied alpha *only* if the image file explicitly
+// says there's premultiplied data (currently only happens in iPhone images,
+// and only if iPhone convert-to-rgb processing is on).
+//
+// ===========================================================================
+//
+// ADDITIONAL CONFIGURATION
+//
+//  - You can suppress implementation of any of the decoders to reduce
+//    your code footprint by #defining one or more of the following
+//    symbols before creating the implementation.
+//
+//        STBI_NO_JPEG
+//        STBI_NO_PNG
+//        STBI_NO_BMP
+//        STBI_NO_PSD
+//        STBI_NO_TGA
+//        STBI_NO_GIF
+//        STBI_NO_HDR
+//        STBI_NO_PIC
+//        STBI_NO_PNM   (.ppm and .pgm)
+//
+//  - You can request *only* certain decoders and suppress all other ones
+//    (this will be more forward-compatible, as addition of new decoders
+//    doesn't require you to disable them explicitly):
+//
+//        STBI_ONLY_JPEG
+//        STBI_ONLY_PNG
+//        STBI_ONLY_BMP
+//        STBI_ONLY_PSD
+//        STBI_ONLY_TGA
+//        STBI_ONLY_GIF
+//        STBI_ONLY_HDR
+//        STBI_ONLY_PIC
+//        STBI_ONLY_PNM   (.ppm and .pgm)
+//
+//   - If you use STBI_NO_PNG (or _ONLY_ without PNG), and you still
+//     want the zlib decoder to be available, #define STBI_SUPPORT_ZLIB
+//
+//  - If you define STBI_MAX_DIMENSIONS, stb_image will reject images greater
+//    than that size (in either width or height) without further processing.
+//    This is to let programs in the wild set an upper bound to prevent
+//    denial-of-service attacks on untrusted data, as one could generate a
+//    valid image of gigantic dimensions and force stb_image to allocate a
+//    huge block of memory and spend disproportionate time decoding it. By
+//    default this is set to (1 << 24), which is 16777216, but that's still
+//    very big.
+
+#ifndef STBI_NO_STDIO
+#include <stdio.h>
+#endif // STBI_NO_STDIO
+
+#define STBI_VERSION 1
+
+enum
+{
+   STBI_default = 0, // only used for desired_channels
+
+   STBI_grey       = 1,
+   STBI_grey_alpha = 2,
+   STBI_rgb        = 3,
+   STBI_rgb_alpha  = 4
+};
+
+#include <stdlib.h>
+typedef unsigned char stbi_uc;
+typedef unsigned short stbi_us;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef STBIDEF
+#ifdef STB_IMAGE_STATIC
+#define STBIDEF static
+#else
+#define STBIDEF extern
+#endif
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// PRIMARY API - works on images of any type
+//
+
+//
+// load image by filename, open file, or memory buffer
+//
+
+typedef struct
+{
+   int      (*read)  (void *user,char *data,int size);   // fill 'data' with 'size' bytes.  return number of bytes actually read
+   void     (*skip)  (void *user,int n);                 // skip the next 'n' bytes, or 'unget' the last -n bytes if negative
+   int      (*eof)   (void *user);                       // returns nonzero if we are at end of file/data
+} stbi_io_callbacks;
+
+////////////////////////////////////
+//
+// 8-bits-per-channel interface
+//
+
+STBIDEF stbi_uc *stbi_load_from_memory   (stbi_uc           const *buffer, int len   , int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk  , void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+
+#ifndef STBI_NO_STDIO
+STBIDEF stbi_uc *stbi_load            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_uc *stbi_load_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+// for stbi_load_from_file, file pointer is left pointing immediately after image
+#endif
+
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
+#endif
+
+#ifdef STBI_WINDOWS_UTF8
+STBIDEF int stbi_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input);
+#endif
+
+////////////////////////////////////
+//
+// 16-bits-per-channel interface
+//
+
+STBIDEF stbi_us *stbi_load_16_from_memory   (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels);
+
+#ifndef STBI_NO_STDIO
+STBIDEF stbi_us *stbi_load_16          (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+STBIDEF stbi_us *stbi_load_from_file_16(FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+#endif
+
+////////////////////////////////////
+//
+// float-per-channel interface
+//
+#ifndef STBI_NO_LINEAR
+   STBIDEF float *stbi_loadf_from_memory     (stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_callbacks  (stbi_io_callbacks const *clbk, void *user, int *x, int *y,  int *channels_in_file, int desired_channels);
+
+   #ifndef STBI_NO_STDIO
+   STBIDEF float *stbi_loadf            (char const *filename, int *x, int *y, int *channels_in_file, int desired_channels);
+   STBIDEF float *stbi_loadf_from_file  (FILE *f, int *x, int *y, int *channels_in_file, int desired_channels);
+   #endif
+#endif
+
+#ifndef STBI_NO_HDR
+   STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma);
+   STBIDEF void   stbi_hdr_to_ldr_scale(float scale);
+#endif // STBI_NO_HDR
+
+#ifndef STBI_NO_LINEAR
+   STBIDEF void   stbi_ldr_to_hdr_gamma(float gamma);
+   STBIDEF void   stbi_ldr_to_hdr_scale(float scale);
+#endif // STBI_NO_LINEAR
+
+// stbi_is_hdr is always defined, but always returns false if STBI_NO_HDR
+STBIDEF int    stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user);
+STBIDEF int    stbi_is_hdr_from_memory(stbi_uc const *buffer, int len);
+#ifndef STBI_NO_STDIO
+STBIDEF int      stbi_is_hdr          (char const *filename);
+STBIDEF int      stbi_is_hdr_from_file(FILE *f);
+#endif // STBI_NO_STDIO
+
+
+// get a VERY brief reason for failure
+// on most compilers (and ALL modern mainstream compilers) this is threadsafe
+STBIDEF const char *stbi_failure_reason  (void);
+
+// free the loaded image -- this is just free()
+STBIDEF void     stbi_image_free      (void *retval_from_stbi_load);
+
+// get image dimensions & components without fully decoding
+STBIDEF int      stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp);
+STBIDEF int      stbi_info_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len);
+STBIDEF int      stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *clbk, void *user);
+
+#ifndef STBI_NO_STDIO
+STBIDEF int      stbi_info               (char const *filename,     int *x, int *y, int *comp);
+STBIDEF int      stbi_info_from_file     (FILE *f,                  int *x, int *y, int *comp);
+STBIDEF int      stbi_is_16_bit          (char const *filename);
+STBIDEF int      stbi_is_16_bit_from_file(FILE *f);
+#endif
+
+
+
+// for image formats that explicitly notate that they have premultiplied alpha,
+// we just return the colors as stored in the file. set this flag to force
+// unpremultiplication. results are undefined if the unpremultiply overflow.
+STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply);
+
+// indicate whether we should process iphone images back to canonical format,
+// or just pass them through "as-is"
+STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert);
+
+// flip the image vertically, so the first pixel in the output array is the bottom left
+STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip);
+
+// as above, but only applies to images loaded on the thread that calls the function
+// this function is only available if your compiler supports thread-local variables;
+// calling it will fail to link if your compiler doesn't
+STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply);
+STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert);
+STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip);
+
+// ZLIB client - used by PNG, available for other purposes
+
+STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen);
+STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header);
+STBIDEF char *stbi_zlib_decode_malloc(const char *buffer, int len, int *outlen);
+STBIDEF int   stbi_zlib_decode_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+
+STBIDEF char *stbi_zlib_decode_noheader_malloc(const char *buffer, int len, int *outlen);
+STBIDEF int   stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+//
+//
+////   end header file   /////////////////////////////////////////////////////
+#endif // STBI_INCLUDE_STB_IMAGE_H
+
+#ifdef STB_IMAGE_IMPLEMENTATION
+
+#if defined(STBI_ONLY_JPEG) || defined(STBI_ONLY_PNG) || defined(STBI_ONLY_BMP) \
+  || defined(STBI_ONLY_TGA) || defined(STBI_ONLY_GIF) || defined(STBI_ONLY_PSD) \
+  || defined(STBI_ONLY_HDR) || defined(STBI_ONLY_PIC) || defined(STBI_ONLY_PNM) \
+  || defined(STBI_ONLY_ZLIB)
+   #ifndef STBI_ONLY_JPEG
+   #define STBI_NO_JPEG
+   #endif
+   #ifndef STBI_ONLY_PNG
+   #define STBI_NO_PNG
+   #endif
+   #ifndef STBI_ONLY_BMP
+   #define STBI_NO_BMP
+   #endif
+   #ifndef STBI_ONLY_PSD
+   #define STBI_NO_PSD
+   #endif
+   #ifndef STBI_ONLY_TGA
+   #define STBI_NO_TGA
+   #endif
+   #ifndef STBI_ONLY_GIF
+   #define STBI_NO_GIF
+   #endif
+   #ifndef STBI_ONLY_HDR
+   #define STBI_NO_HDR
+   #endif
+   #ifndef STBI_ONLY_PIC
+   #define STBI_NO_PIC
+   #endif
+   #ifndef STBI_ONLY_PNM
+   #define STBI_NO_PNM
+   #endif
+#endif
+
+#if defined(STBI_NO_PNG) && !defined(STBI_SUPPORT_ZLIB) && !defined(STBI_NO_ZLIB)
+#define STBI_NO_ZLIB
+#endif
+
+
+#include <stdarg.h>
+#include <stddef.h> // ptrdiff_t on osx
+#include <stdlib.h>
+#include <string.h>
+#include <limits.h>
+
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR)
+#include <math.h>  // ldexp, pow
+#endif
+
+#ifndef STBI_NO_STDIO
+#include <stdio.h>
+#endif
+
+#ifndef STBI_ASSERT
+#include <assert.h>
+#define STBI_ASSERT(x) assert(x)
+#endif
+
+#ifdef __cplusplus
+#define STBI_EXTERN extern "C"
+#else
+#define STBI_EXTERN extern
+#endif
+
+
+#ifndef _MSC_VER
+   #ifdef __cplusplus
+   #define stbi_inline inline
+   #else
+   #define stbi_inline
+   #endif
+#else
+   #define stbi_inline __forceinline
+#endif
+
+#ifndef STBI_NO_THREAD_LOCALS
+   #if defined(__cplusplus) &&  __cplusplus >= 201103L
+      #define STBI_THREAD_LOCAL       thread_local
+   #elif defined(__GNUC__) && __GNUC__ < 5
+      #define STBI_THREAD_LOCAL       __thread
+   #elif defined(_MSC_VER)
+      #define STBI_THREAD_LOCAL       __declspec(thread)
+   #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && !defined(__STDC_NO_THREADS__)
+      #define STBI_THREAD_LOCAL       _Thread_local
+   #endif
+
+   #ifndef STBI_THREAD_LOCAL
+      #if defined(__GNUC__)
+        #define STBI_THREAD_LOCAL       __thread
+      #endif
+   #endif
+#endif
+
+#if defined(_MSC_VER) || defined(__SYMBIAN32__)
+typedef unsigned short stbi__uint16;
+typedef   signed short stbi__int16;
+typedef unsigned int   stbi__uint32;
+typedef   signed int   stbi__int32;
+#else
+#include <stdint.h>
+typedef uint16_t stbi__uint16;
+typedef int16_t  stbi__int16;
+typedef uint32_t stbi__uint32;
+typedef int32_t  stbi__int32;
+#endif
+
+// should produce compiler error if size is wrong
+typedef unsigned char validate_uint32[sizeof(stbi__uint32)==4 ? 1 : -1];
+
+#ifdef _MSC_VER
+#define STBI_NOTUSED(v)  (void)(v)
+#else
+#define STBI_NOTUSED(v)  (void)sizeof(v)
+#endif
+
+#ifdef _MSC_VER
+#define STBI_HAS_LROTL
+#endif
+
+#ifdef STBI_HAS_LROTL
+   #define stbi_lrot(x,y)  _lrotl(x,y)
+#else
+   #define stbi_lrot(x,y)  (((x) << (y)) | ((x) >> (-(y) & 31)))
+#endif
+
+#if defined(STBI_MALLOC) && defined(STBI_FREE) && (defined(STBI_REALLOC) || defined(STBI_REALLOC_SIZED))
+// ok
+#elif !defined(STBI_MALLOC) && !defined(STBI_FREE) && !defined(STBI_REALLOC) && !defined(STBI_REALLOC_SIZED)
+// ok
+#else
+#error "Must define all or none of STBI_MALLOC, STBI_FREE, and STBI_REALLOC (or STBI_REALLOC_SIZED)."
+#endif
+
+#ifndef STBI_MALLOC
+#define STBI_MALLOC(sz)           malloc(sz)
+#define STBI_REALLOC(p,newsz)     realloc(p,newsz)
+#define STBI_FREE(p)              free(p)
+#endif
+
+#ifndef STBI_REALLOC_SIZED
+#define STBI_REALLOC_SIZED(p,oldsz,newsz) STBI_REALLOC(p,newsz)
+#endif
+
+// x86/x64 detection
+#if defined(__x86_64__) || defined(_M_X64)
+#define STBI__X64_TARGET
+#elif defined(__i386) || defined(_M_IX86)
+#define STBI__X86_TARGET
+#endif
+
+#if defined(__GNUC__) && defined(STBI__X86_TARGET) && !defined(__SSE2__) && !defined(STBI_NO_SIMD)
+// gcc doesn't support sse2 intrinsics unless you compile with -msse2,
+// which in turn means it gets to use SSE2 everywhere. This is unfortunate,
+// but previous attempts to provide the SSE2 functions with runtime
+// detection caused numerous issues. The way architecture extensions are
+// exposed in GCC/Clang is, sadly, not really suited for one-file libs.
+// New behavior: if compiled with -msse2, we use SSE2 without any
+// detection; if not, we don't use it at all.
+#define STBI_NO_SIMD
+#endif
+
+#if defined(__MINGW32__) && defined(STBI__X86_TARGET) && !defined(STBI_MINGW_ENABLE_SSE2) && !defined(STBI_NO_SIMD)
+// Note that __MINGW32__ doesn't actually mean 32-bit, so we have to avoid STBI__X64_TARGET
+//
+// 32-bit MinGW wants ESP to be 16-byte aligned, but this is not in the
+// Windows ABI and VC++ as well as Windows DLLs don't maintain that invariant.
+// As a result, enabling SSE2 on 32-bit MinGW is dangerous when not
+// simultaneously enabling "-mstackrealign".
+//
+// See https://github.com/nothings/stb/issues/81 for more information.
+//
+// So default to no SSE2 on 32-bit MinGW. If you've read this far and added
+// -mstackrealign to your build settings, feel free to #define STBI_MINGW_ENABLE_SSE2.
+#define STBI_NO_SIMD
+#endif
+
+#if !defined(STBI_NO_SIMD) && (defined(STBI__X86_TARGET) || defined(STBI__X64_TARGET))
+#define STBI_SSE2
+#include <emmintrin.h>
+
+#ifdef _MSC_VER
+
+#if _MSC_VER >= 1400  // not VC6
+#include <intrin.h> // __cpuid
+static int stbi__cpuid3(void)
+{
+   int info[4];
+   __cpuid(info,1);
+   return info[3];
+}
+#else
+static int stbi__cpuid3(void)
+{
+   int res;
+   __asm {
+      mov  eax,1
+      cpuid
+      mov  res,edx
+   }
+   return res;
+}
+#endif
+
+#define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
+
+#if !defined(STBI_NO_JPEG) && defined(STBI_SSE2)
+static int stbi__sse2_available(void)
+{
+   int info3 = stbi__cpuid3();
+   return ((info3 >> 26) & 1) != 0;
+}
+#endif
+
+#else // assume GCC-style if not VC++
+#define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
+
+#if !defined(STBI_NO_JPEG) && defined(STBI_SSE2)
+static int stbi__sse2_available(void)
+{
+   // If we're even attempting to compile this on GCC/Clang, that means
+   // -msse2 is on, which means the compiler is allowed to use SSE2
+   // instructions at will, and so are we.
+   return 1;
+}
+#endif
+
+#endif
+#endif
+
+// ARM NEON
+#if defined(STBI_NO_SIMD) && defined(STBI_NEON)
+#undef STBI_NEON
+#endif
+
+#ifdef STBI_NEON
+#include <arm_neon.h>
+#ifdef _MSC_VER
+#define STBI_SIMD_ALIGN(type, name) __declspec(align(16)) type name
+#else
+#define STBI_SIMD_ALIGN(type, name) type name __attribute__((aligned(16)))
+#endif
+#endif
+
+#ifndef STBI_SIMD_ALIGN
+#define STBI_SIMD_ALIGN(type, name) type name
+#endif
+
+#ifndef STBI_MAX_DIMENSIONS
+#define STBI_MAX_DIMENSIONS (1 << 24)
+#endif
+
+///////////////////////////////////////////////
+//
+//  stbi__context struct and start_xxx functions
+
+// stbi__context structure is our basic context used by all images, so it
+// contains all the IO context, plus some basic image information
+typedef struct
+{
+   stbi__uint32 img_x, img_y;
+   int img_n, img_out_n;
+
+   stbi_io_callbacks io;
+   void *io_user_data;
+
+   int read_from_callbacks;
+   int buflen;
+   stbi_uc buffer_start[128];
+   int callback_already_read;
+
+   stbi_uc *img_buffer, *img_buffer_end;
+   stbi_uc *img_buffer_original, *img_buffer_original_end;
+} stbi__context;
+
+
+static void stbi__refill_buffer(stbi__context *s);
+
+// initialize a memory-decode context
+static void stbi__start_mem(stbi__context *s, stbi_uc const *buffer, int len)
+{
+   s->io.read = NULL;
+   s->read_from_callbacks = 0;
+   s->callback_already_read = 0;
+   s->img_buffer = s->img_buffer_original = (stbi_uc *) buffer;
+   s->img_buffer_end = s->img_buffer_original_end = (stbi_uc *) buffer+len;
+}
+
+// initialize a callback-based context
+static void stbi__start_callbacks(stbi__context *s, stbi_io_callbacks *c, void *user)
+{
+   s->io = *c;
+   s->io_user_data = user;
+   s->buflen = sizeof(s->buffer_start);
+   s->read_from_callbacks = 1;
+   s->callback_already_read = 0;
+   s->img_buffer = s->img_buffer_original = s->buffer_start;
+   stbi__refill_buffer(s);
+   s->img_buffer_original_end = s->img_buffer_end;
+}
+
+#ifndef STBI_NO_STDIO
+
+static int stbi__stdio_read(void *user, char *data, int size)
+{
+   return (int) fread(data,1,size,(FILE*) user);
+}
+
+static void stbi__stdio_skip(void *user, int n)
+{
+   int ch;
+   fseek((FILE*) user, n, SEEK_CUR);
+   ch = fgetc((FILE*) user);  /* have to read a byte to reset feof()'s flag */
+   if (ch != EOF) {
+      ungetc(ch, (FILE *) user);  /* push byte back onto stream if valid. */
+   }
+}
+
+static int stbi__stdio_eof(void *user)
+{
+   return feof((FILE*) user) || ferror((FILE *) user);
+}
+
+static stbi_io_callbacks stbi__stdio_callbacks =
+{
+   stbi__stdio_read,
+   stbi__stdio_skip,
+   stbi__stdio_eof,
+};
+
+static void stbi__start_file(stbi__context *s, FILE *f)
+{
+   stbi__start_callbacks(s, &stbi__stdio_callbacks, (void *) f);
+}
+
+//static void stop_file(stbi__context *s) { }
+
+#endif // !STBI_NO_STDIO
+
+static void stbi__rewind(stbi__context *s)
+{
+   // conceptually rewind SHOULD rewind to the beginning of the stream,
+   // but we just rewind to the beginning of the initial buffer, because
+   // we only use it after doing 'test', which only ever looks at at most 92 bytes
+   s->img_buffer = s->img_buffer_original;
+   s->img_buffer_end = s->img_buffer_original_end;
+}
+
+enum
+{
+   STBI_ORDER_RGB,
+   STBI_ORDER_BGR
+};
+
+typedef struct
+{
+   int bits_per_channel;
+   int num_channels;
+   int channel_order;
+} stbi__result_info;
+
+#ifndef STBI_NO_JPEG
+static int      stbi__jpeg_test(stbi__context *s);
+static void    *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PNG
+static int      stbi__png_test(stbi__context *s);
+static void    *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__png_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__png_is16(stbi__context *s);
+#endif
+
+#ifndef STBI_NO_BMP
+static int      stbi__bmp_test(stbi__context *s);
+static void    *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_TGA
+static int      stbi__tga_test(stbi__context *s);
+static void    *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__tga_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PSD
+static int      stbi__psd_test(stbi__context *s);
+static void    *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc);
+static int      stbi__psd_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__psd_is16(stbi__context *s);
+#endif
+
+#ifndef STBI_NO_HDR
+static int      stbi__hdr_test(stbi__context *s);
+static float   *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PIC
+static int      stbi__pic_test(stbi__context *s);
+static void    *stbi__pic_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__pic_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_GIF
+static int      stbi__gif_test(stbi__context *s);
+static void    *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static void    *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp);
+static int      stbi__gif_info(stbi__context *s, int *x, int *y, int *comp);
+#endif
+
+#ifndef STBI_NO_PNM
+static int      stbi__pnm_test(stbi__context *s);
+static void    *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri);
+static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp);
+static int      stbi__pnm_is16(stbi__context *s);
+#endif
+
+static
+#ifdef STBI_THREAD_LOCAL
+STBI_THREAD_LOCAL
+#endif
+const char *stbi__g_failure_reason;
+
+STBIDEF const char *stbi_failure_reason(void)
+{
+   return stbi__g_failure_reason;
+}
+
+#ifndef STBI_NO_FAILURE_STRINGS
+static int stbi__err(const char *str)
+{
+   stbi__g_failure_reason = str;
+   return 0;
+}
+#endif
+
+static void *stbi__malloc(size_t size)
+{
+    return STBI_MALLOC(size);
+}
+
+// stb_image uses ints pervasively, including for offset calculations.
+// therefore the largest decoded image size we can support with the
+// current code, even on 64-bit targets, is INT_MAX. this is not a
+// significant limitation for the intended use case.
+//
+// we do, however, need to make sure our size calculations don't
+// overflow. hence a few helper functions for size calculations that
+// multiply integers together, making sure that they're non-negative
+// and no overflow occurs.
+
+// return 1 if the sum is valid, 0 on overflow.
+// negative terms are considered invalid.
+static int stbi__addsizes_valid(int a, int b)
+{
+   if (b < 0) return 0;
+   // now 0 <= b <= INT_MAX, hence also
+   // 0 <= INT_MAX - b <= INTMAX.
+   // And "a + b <= INT_MAX" (which might overflow) is the
+   // same as a <= INT_MAX - b (no overflow)
+   return a <= INT_MAX - b;
+}
+
+// returns 1 if the product is valid, 0 on overflow.
+// negative factors are considered invalid.
+static int stbi__mul2sizes_valid(int a, int b)
+{
+   if (a < 0 || b < 0) return 0;
+   if (b == 0) return 1; // mul-by-0 is always safe
+   // portable way to check for no overflows in a*b
+   return a <= INT_MAX/b;
+}
+
+#if !defined(STBI_NO_JPEG) || !defined(STBI_NO_PNG) || !defined(STBI_NO_TGA) || !defined(STBI_NO_HDR)
+// returns 1 if "a*b + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad2sizes_valid(int a, int b, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__addsizes_valid(a*b, add);
+}
+#endif
+
+// returns 1 if "a*b*c + add" has no negative terms/factors and doesn't overflow
+static int stbi__mad3sizes_valid(int a, int b, int c, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__addsizes_valid(a*b*c, add);
+}
+
+// returns 1 if "a*b*c*d + add" has no negative terms/factors and doesn't overflow
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
+static int stbi__mad4sizes_valid(int a, int b, int c, int d, int add)
+{
+   return stbi__mul2sizes_valid(a, b) && stbi__mul2sizes_valid(a*b, c) &&
+      stbi__mul2sizes_valid(a*b*c, d) && stbi__addsizes_valid(a*b*c*d, add);
+}
+#endif
+
+#if !defined(STBI_NO_JPEG) || !defined(STBI_NO_PNG) || !defined(STBI_NO_TGA) || !defined(STBI_NO_HDR)
+// mallocs with size overflow checking
+static void *stbi__malloc_mad2(int a, int b, int add)
+{
+   if (!stbi__mad2sizes_valid(a, b, add)) return NULL;
+   return stbi__malloc(a*b + add);
+}
+#endif
+
+static void *stbi__malloc_mad3(int a, int b, int c, int add)
+{
+   if (!stbi__mad3sizes_valid(a, b, c, add)) return NULL;
+   return stbi__malloc(a*b*c + add);
+}
+
+#if !defined(STBI_NO_LINEAR) || !defined(STBI_NO_HDR) || !defined(STBI_NO_PNM)
+static void *stbi__malloc_mad4(int a, int b, int c, int d, int add)
+{
+   if (!stbi__mad4sizes_valid(a, b, c, d, add)) return NULL;
+   return stbi__malloc(a*b*c*d + add);
+}
+#endif
+
+// returns 1 if the sum of two signed ints is valid (between -2^31 and 2^31-1 inclusive), 0 on overflow.
+static int stbi__addints_valid(int a, int b)
+{
+   if ((a >= 0) != (b >= 0)) return 1; // a and b have different signs, so no overflow
+   if (a < 0 && b < 0) return a >= INT_MIN - b; // same as a + b >= INT_MIN; INT_MIN - b cannot overflow since b < 0.
+   return a <= INT_MAX - b;
+}
+
+// returns 1 if the product of two ints fits in a signed short, 0 on overflow.
+static int stbi__mul2shorts_valid(int a, int b)
+{
+   if (b == 0 || b == -1) return 1; // multiplication by 0 is always 0; check for -1 so SHRT_MIN/b doesn't overflow
+   if ((a >= 0) == (b >= 0)) return a <= SHRT_MAX/b; // product is positive, so similar to mul2sizes_valid
+   if (b < 0) return a <= SHRT_MIN / b; // same as a * b >= SHRT_MIN
+   return a >= SHRT_MIN / b;
+}
+
+// stbi__err - error
+// stbi__errpf - error returning pointer to float
+// stbi__errpuc - error returning pointer to unsigned char
+
+#ifdef STBI_NO_FAILURE_STRINGS
+   #define stbi__err(x,y)  0
+#elif defined(STBI_FAILURE_USERMSG)
+   #define stbi__err(x,y)  stbi__err(y)
+#else
+   #define stbi__err(x,y)  stbi__err(x)
+#endif
+
+#define stbi__errpf(x,y)   ((float *)(size_t) (stbi__err(x,y)?NULL:NULL))
+#define stbi__errpuc(x,y)  ((unsigned char *)(size_t) (stbi__err(x,y)?NULL:NULL))
+
+STBIDEF void stbi_image_free(void *retval_from_stbi_load)
+{
+   STBI_FREE(retval_from_stbi_load);
+}
+
+#ifndef STBI_NO_LINEAR
+static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp);
+#endif
+
+#ifndef STBI_NO_HDR
+static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp);
+#endif
+
+static int stbi__vertically_flip_on_load_global = 0;
+
+STBIDEF void stbi_set_flip_vertically_on_load(int flag_true_if_should_flip)
+{
+   stbi__vertically_flip_on_load_global = flag_true_if_should_flip;
+}
+
+#ifndef STBI_THREAD_LOCAL
+#define stbi__vertically_flip_on_load  stbi__vertically_flip_on_load_global
+#else
+static STBI_THREAD_LOCAL int stbi__vertically_flip_on_load_local, stbi__vertically_flip_on_load_set;
+
+STBIDEF void stbi_set_flip_vertically_on_load_thread(int flag_true_if_should_flip)
+{
+   stbi__vertically_flip_on_load_local = flag_true_if_should_flip;
+   stbi__vertically_flip_on_load_set = 1;
+}
+
+#define stbi__vertically_flip_on_load  (stbi__vertically_flip_on_load_set       \
+                                         ? stbi__vertically_flip_on_load_local  \
+                                         : stbi__vertically_flip_on_load_global)
+#endif // STBI_THREAD_LOCAL
+
+static void *stbi__load_main(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
+{
+   memset(ri, 0, sizeof(*ri)); // make sure it's initialized if we add new fields
+   ri->bits_per_channel = 8; // default is 8 so most paths don't have to be changed
+   ri->channel_order = STBI_ORDER_RGB; // all current input & output are this, but this is here so we can add BGR order
+   ri->num_channels = 0;
+
+   // test the formats with a very explicit header first (at least a FOURCC
+   // or distinctive magic number first)
+   #ifndef STBI_NO_PNG
+   if (stbi__png_test(s))  return stbi__png_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_BMP
+   if (stbi__bmp_test(s))  return stbi__bmp_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_GIF
+   if (stbi__gif_test(s))  return stbi__gif_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_test(s))  return stbi__psd_load(s,x,y,comp,req_comp, ri, bpc);
+   #else
+   STBI_NOTUSED(bpc);
+   #endif
+   #ifndef STBI_NO_PIC
+   if (stbi__pic_test(s))  return stbi__pic_load(s,x,y,comp,req_comp, ri);
+   #endif
+
+   // then the formats that can end up attempting to load with just 1 or 2
+   // bytes matching expectations; these are prone to false positives, so
+   // try them later
+   #ifndef STBI_NO_JPEG
+   if (stbi__jpeg_test(s)) return stbi__jpeg_load(s,x,y,comp,req_comp, ri);
+   #endif
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_test(s))  return stbi__pnm_load(s,x,y,comp,req_comp, ri);
+   #endif
+
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_test(s)) {
+      float *hdr = stbi__hdr_load(s, x,y,comp,req_comp, ri);
+      return stbi__hdr_to_ldr(hdr, *x, *y, req_comp ? req_comp : *comp);
+   }
+   #endif
+
+   #ifndef STBI_NO_TGA
+   // test tga last because it's a crappy test!
+   if (stbi__tga_test(s))
+      return stbi__tga_load(s,x,y,comp,req_comp, ri);
+   #endif
+
+   return stbi__errpuc("unknown image type", "Image not of any known type, or corrupt");
+}
+
+static stbi_uc *stbi__convert_16_to_8(stbi__uint16 *orig, int w, int h, int channels)
+{
+   int i;
+   int img_len = w * h * channels;
+   stbi_uc *reduced;
+
+   reduced = (stbi_uc *) stbi__malloc(img_len);
+   if (reduced == NULL) return stbi__errpuc("outofmem", "Out of memory");
+
+   for (i = 0; i < img_len; ++i)
+      reduced[i] = (stbi_uc)((orig[i] >> 8) & 0xFF); // top half of each byte is sufficient approx of 16->8 bit scaling
+
+   STBI_FREE(orig);
+   return reduced;
+}
+
+static stbi__uint16 *stbi__convert_8_to_16(stbi_uc *orig, int w, int h, int channels)
+{
+   int i;
+   int img_len = w * h * channels;
+   stbi__uint16 *enlarged;
+
+   enlarged = (stbi__uint16 *) stbi__malloc(img_len*2);
+   if (enlarged == NULL) return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+
+   for (i = 0; i < img_len; ++i)
+      enlarged[i] = (stbi__uint16)((orig[i] << 8) + orig[i]); // replicate to high and low byte, maps 0->0, 255->0xffff
+
+   STBI_FREE(orig);
+   return enlarged;
+}
+
+static void stbi__vertical_flip(void *image, int w, int h, int bytes_per_pixel)
+{
+   int row;
+   size_t bytes_per_row = (size_t)w * bytes_per_pixel;
+   stbi_uc temp[2048];
+   stbi_uc *bytes = (stbi_uc *)image;
+
+   for (row = 0; row < (h>>1); row++) {
+      stbi_uc *row0 = bytes + row*bytes_per_row;
+      stbi_uc *row1 = bytes + (h - row - 1)*bytes_per_row;
+      // swap row0 with row1
+      size_t bytes_left = bytes_per_row;
+      while (bytes_left) {
+         size_t bytes_copy = (bytes_left < sizeof(temp)) ? bytes_left : sizeof(temp);
+         memcpy(temp, row0, bytes_copy);
+         memcpy(row0, row1, bytes_copy);
+         memcpy(row1, temp, bytes_copy);
+         row0 += bytes_copy;
+         row1 += bytes_copy;
+         bytes_left -= bytes_copy;
+      }
+   }
+}
+
+#ifndef STBI_NO_GIF
+static void stbi__vertical_flip_slices(void *image, int w, int h, int z, int bytes_per_pixel)
+{
+   int slice;
+   int slice_size = w * h * bytes_per_pixel;
+
+   stbi_uc *bytes = (stbi_uc *)image;
+   for (slice = 0; slice < z; ++slice) {
+      stbi__vertical_flip(bytes, w, h, bytes_per_pixel);
+      bytes += slice_size;
+   }
+}
+#endif
+
+static unsigned char *stbi__load_and_postprocess_8bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 8);
+
+   if (result == NULL)
+      return NULL;
+
+   // it is the responsibility of the loaders to make sure we get either 8 or 16 bit.
+   STBI_ASSERT(ri.bits_per_channel == 8 || ri.bits_per_channel == 16);
+
+   if (ri.bits_per_channel != 8) {
+      result = stbi__convert_16_to_8((stbi__uint16 *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 8;
+   }
+
+   // @TODO: move stbi__convert_format to here
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi_uc));
+   }
+
+   return (unsigned char *) result;
+}
+
+static stbi__uint16 *stbi__load_and_postprocess_16bit(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__result_info ri;
+   void *result = stbi__load_main(s, x, y, comp, req_comp, &ri, 16);
+
+   if (result == NULL)
+      return NULL;
+
+   // it is the responsibility of the loaders to make sure we get either 8 or 16 bit.
+   STBI_ASSERT(ri.bits_per_channel == 8 || ri.bits_per_channel == 16);
+
+   if (ri.bits_per_channel != 16) {
+      result = stbi__convert_8_to_16((stbi_uc *) result, *x, *y, req_comp == 0 ? *comp : req_comp);
+      ri.bits_per_channel = 16;
+   }
+
+   // @TODO: move stbi__convert_format16 to here
+   // @TODO: special case RGB-to-Y (and RGBA-to-YA) for 8-bit-to-16-bit case to keep more precision
+
+   if (stbi__vertically_flip_on_load) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(stbi__uint16));
+   }
+
+   return (stbi__uint16 *) result;
+}
+
+#if !defined(STBI_NO_HDR) && !defined(STBI_NO_LINEAR)
+static void stbi__float_postprocess(float *result, int *x, int *y, int *comp, int req_comp)
+{
+   if (stbi__vertically_flip_on_load && result != NULL) {
+      int channels = req_comp ? req_comp : *comp;
+      stbi__vertical_flip(result, *x, *y, channels * sizeof(float));
+   }
+}
+#endif
+
+#ifndef STBI_NO_STDIO
+
+#if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
+STBI_EXTERN __declspec(dllimport) int __stdcall MultiByteToWideChar(unsigned int cp, unsigned long flags, const char *str, int cbmb, wchar_t *widestr, int cchwide);
+STBI_EXTERN __declspec(dllimport) int __stdcall WideCharToMultiByte(unsigned int cp, unsigned long flags, const wchar_t *widestr, int cchwide, char *str, int cbmb, const char *defchar, int *used_default);
+#endif
+
+#if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
+STBIDEF int stbi_convert_wchar_to_utf8(char *buffer, size_t bufferlen, const wchar_t* input)
+{
+	return WideCharToMultiByte(65001 /* UTF8 */, 0, input, -1, buffer, (int) bufferlen, NULL, NULL);
+}
+#endif
+
+static FILE *stbi__fopen(char const *filename, char const *mode)
+{
+   FILE *f;
+#if defined(_WIN32) && defined(STBI_WINDOWS_UTF8)
+   wchar_t wMode[64];
+   wchar_t wFilename[1024];
+	if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, filename, -1, wFilename, sizeof(wFilename)/sizeof(*wFilename)))
+      return 0;
+
+	if (0 == MultiByteToWideChar(65001 /* UTF8 */, 0, mode, -1, wMode, sizeof(wMode)/sizeof(*wMode)))
+      return 0;
+
+#if defined(_MSC_VER) && _MSC_VER >= 1400
+	if (0 != _wfopen_s(&f, wFilename, wMode))
+		f = 0;
+#else
+   f = _wfopen(wFilename, wMode);
+#endif
+
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
+   if (0 != fopen_s(&f, filename, mode))
+      f=0;
+#else
+   f = fopen(filename, mode);
+#endif
+   return f;
+}
+
+
+STBIDEF stbi_uc *stbi_load(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   unsigned char *result;
+   if (!f) return stbi__errpuc("can't fopen", "Unable to open file");
+   result = stbi_load_from_file(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+STBIDEF stbi_uc *stbi_load_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   unsigned char *result;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   result = stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
+   if (result) {
+      // need to 'unget' all the characters in the IO buffer
+      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+   }
+   return result;
+}
+
+STBIDEF stbi__uint16 *stbi_load_from_file_16(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__uint16 *result;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   result = stbi__load_and_postprocess_16bit(&s,x,y,comp,req_comp);
+   if (result) {
+      // need to 'unget' all the characters in the IO buffer
+      fseek(f, - (int) (s.img_buffer_end - s.img_buffer), SEEK_CUR);
+   }
+   return result;
+}
+
+STBIDEF stbi_us *stbi_load_16(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   stbi__uint16 *result;
+   if (!f) return (stbi_us *) stbi__errpuc("can't fopen", "Unable to open file");
+   result = stbi_load_from_file_16(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+
+#endif //!STBI_NO_STDIO
+
+STBIDEF stbi_us *stbi_load_16_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
+
+STBIDEF stbi_us *stbi_load_16_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *channels_in_file, int desired_channels)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *)clbk, user);
+   return stbi__load_and_postprocess_16bit(&s,x,y,channels_in_file,desired_channels);
+}
+
+STBIDEF stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
+}
+
+STBIDEF stbi_uc *stbi_load_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__load_and_postprocess_8bit(&s,x,y,comp,req_comp);
+}
+
+#ifndef STBI_NO_GIF
+STBIDEF stbi_uc *stbi_load_gif_from_memory(stbi_uc const *buffer, int len, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
+{
+   unsigned char *result;
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+
+   result = (unsigned char*) stbi__load_gif_main(&s, delays, x, y, z, comp, req_comp);
+   if (stbi__vertically_flip_on_load) {
+      stbi__vertical_flip_slices( result, *x, *y, *z, *comp );
+   }
+
+   return result;
+}
+#endif
+
+#ifndef STBI_NO_LINEAR
+static float *stbi__loadf_main(stbi__context *s, int *x, int *y, int *comp, int req_comp)
+{
+   unsigned char *data;
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_test(s)) {
+      stbi__result_info ri;
+      float *hdr_data = stbi__hdr_load(s,x,y,comp,req_comp, &ri);
+      if (hdr_data)
+         stbi__float_postprocess(hdr_data,x,y,comp,req_comp);
+      return hdr_data;
+   }
+   #endif
+   data = stbi__load_and_postprocess_8bit(s, x, y, comp, req_comp);
+   if (data)
+      return stbi__ldr_to_hdr(data, *x, *y, req_comp ? req_comp : *comp);
+   return stbi__errpf("unknown image type", "Image not of any known type, or corrupt");
+}
+
+STBIDEF float *stbi_loadf_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
+}
+
+STBIDEF float *stbi_loadf_from_callbacks(stbi_io_callbacks const *clbk, void *user, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
+}
+
+#ifndef STBI_NO_STDIO
+STBIDEF float *stbi_loadf(char const *filename, int *x, int *y, int *comp, int req_comp)
+{
+   float *result;
+   FILE *f = stbi__fopen(filename, "rb");
+   if (!f) return stbi__errpf("can't fopen", "Unable to open file");
+   result = stbi_loadf_from_file(f,x,y,comp,req_comp);
+   fclose(f);
+   return result;
+}
+
+STBIDEF float *stbi_loadf_from_file(FILE *f, int *x, int *y, int *comp, int req_comp)
+{
+   stbi__context s;
+   stbi__start_file(&s,f);
+   return stbi__loadf_main(&s,x,y,comp,req_comp);
+}
+#endif // !STBI_NO_STDIO
+
+#endif // !STBI_NO_LINEAR
+
+// these is-hdr-or-not is defined independent of whether STBI_NO_LINEAR is
+// defined, for API simplicity; if STBI_NO_LINEAR is defined, it always
+// reports false!
+
+STBIDEF int stbi_is_hdr_from_memory(stbi_uc const *buffer, int len)
+{
+   #ifndef STBI_NO_HDR
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__hdr_test(&s);
+   #else
+   STBI_NOTUSED(buffer);
+   STBI_NOTUSED(len);
+   return 0;
+   #endif
+}
+
+#ifndef STBI_NO_STDIO
+STBIDEF int      stbi_is_hdr          (char const *filename)
+{
+   FILE *f = stbi__fopen(filename, "rb");
+   int result=0;
+   if (f) {
+      result = stbi_is_hdr_from_file(f);
+      fclose(f);
+   }
+   return result;
+}
+
+STBIDEF int stbi_is_hdr_from_file(FILE *f)
+{
+   #ifndef STBI_NO_HDR
+   long pos = ftell(f);
+   int res;
+   stbi__context s;
+   stbi__start_file(&s,f);
+   res = stbi__hdr_test(&s);
+   fseek(f, pos, SEEK_SET);
+   return res;
+   #else
+   STBI_NOTUSED(f);
+   return 0;
+   #endif
+}
+#endif // !STBI_NO_STDIO
+
+STBIDEF int      stbi_is_hdr_from_callbacks(stbi_io_callbacks const *clbk, void *user)
+{
+   #ifndef STBI_NO_HDR
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) clbk, user);
+   return stbi__hdr_test(&s);
+   #else
+   STBI_NOTUSED(clbk);
+   STBI_NOTUSED(user);
+   return 0;
+   #endif
+}
+
+#ifndef STBI_NO_LINEAR
+static float stbi__l2h_gamma=2.2f, stbi__l2h_scale=1.0f;
+
+STBIDEF void   stbi_ldr_to_hdr_gamma(float gamma) { stbi__l2h_gamma = gamma; }
+STBIDEF void   stbi_ldr_to_hdr_scale(float scale) { stbi__l2h_scale = scale; }
+#endif
+
+static float stbi__h2l_gamma_i=1.0f/2.2f, stbi__h2l_scale_i=1.0f;
+
+STBIDEF void   stbi_hdr_to_ldr_gamma(float gamma) { stbi__h2l_gamma_i = 1/gamma; }
+STBIDEF void   stbi_hdr_to_ldr_scale(float scale) { stbi__h2l_scale_i = 1/scale; }
+
+
+//////////////////////////////////////////////////////////////////////////////
+//
+// Common code used by all image loaders
+//
+
+enum
+{
+   STBI__SCAN_load=0,
+   STBI__SCAN_type,
+   STBI__SCAN_header
+};
+
+static void stbi__refill_buffer(stbi__context *s)
+{
+   int n = (s->io.read)(s->io_user_data,(char*)s->buffer_start,s->buflen);
+   s->callback_already_read += (int) (s->img_buffer - s->img_buffer_original);
+   if (n == 0) {
+      // at end of file, treat same as if from memory, but need to handle case
+      // where s->img_buffer isn't pointing to safe memory, e.g. 0-byte file
+      s->read_from_callbacks = 0;
+      s->img_buffer = s->buffer_start;
+      s->img_buffer_end = s->buffer_start+1;
+      *s->img_buffer = 0;
+   } else {
+      s->img_buffer = s->buffer_start;
+      s->img_buffer_end = s->buffer_start + n;
+   }
+}
+
+stbi_inline static stbi_uc stbi__get8(stbi__context *s)
+{
+   if (s->img_buffer < s->img_buffer_end)
+      return *s->img_buffer++;
+   if (s->read_from_callbacks) {
+      stbi__refill_buffer(s);
+      return *s->img_buffer++;
+   }
+   return 0;
+}
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_HDR) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+// nothing
+#else
+stbi_inline static int stbi__at_eof(stbi__context *s)
+{
+   if (s->io.read) {
+      if (!(s->io.eof)(s->io_user_data)) return 0;
+      // if feof() is true, check if buffer = end
+      // special case: we've only got the special 0 character at the end
+      if (s->read_from_callbacks == 0) return 1;
+   }
+
+   return s->img_buffer >= s->img_buffer_end;
+}
+#endif
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC)
+// nothing
+#else
+static void stbi__skip(stbi__context *s, int n)
+{
+   if (n == 0) return;  // already there!
+   if (n < 0) {
+      s->img_buffer = s->img_buffer_end;
+      return;
+   }
+   if (s->io.read) {
+      int blen = (int) (s->img_buffer_end - s->img_buffer);
+      if (blen < n) {
+         s->img_buffer = s->img_buffer_end;
+         (s->io.skip)(s->io_user_data, n - blen);
+         return;
+      }
+   }
+   s->img_buffer += n;
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_TGA) && defined(STBI_NO_HDR) && defined(STBI_NO_PNM)
+// nothing
+#else
+static int stbi__getn(stbi__context *s, stbi_uc *buffer, int n)
+{
+   if (s->io.read) {
+      int blen = (int) (s->img_buffer_end - s->img_buffer);
+      if (blen < n) {
+         int res, count;
+
+         memcpy(buffer, s->img_buffer, blen);
+
+         count = (s->io.read)(s->io_user_data, (char*) buffer + blen, n - blen);
+         res = (count == (n-blen));
+         s->img_buffer = s->img_buffer_end;
+         return res;
+      }
+   }
+
+   if (s->img_buffer+n <= s->img_buffer_end) {
+      memcpy(buffer, s->img_buffer, n);
+      s->img_buffer += n;
+      return 1;
+   } else
+      return 0;
+}
+#endif
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_PSD) && defined(STBI_NO_PIC)
+// nothing
+#else
+static int stbi__get16be(stbi__context *s)
+{
+   int z = stbi__get8(s);
+   return (z << 8) + stbi__get8(s);
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_PSD) && defined(STBI_NO_PIC)
+// nothing
+#else
+static stbi__uint32 stbi__get32be(stbi__context *s)
+{
+   stbi__uint32 z = stbi__get16be(s);
+   return (z << 16) + stbi__get16be(s);
+}
+#endif
+
+#if defined(STBI_NO_BMP) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF)
+// nothing
+#else
+static int stbi__get16le(stbi__context *s)
+{
+   int z = stbi__get8(s);
+   return z + (stbi__get8(s) << 8);
+}
+#endif
+
+#ifndef STBI_NO_BMP
+static stbi__uint32 stbi__get32le(stbi__context *s)
+{
+   stbi__uint32 z = stbi__get16le(s);
+   z += (stbi__uint32)stbi__get16le(s) << 16;
+   return z;
+}
+#endif
+
+#define STBI__BYTECAST(x)  ((stbi_uc) ((x) & 255))  // truncate int to byte without warnings
+
+#if defined(STBI_NO_JPEG) && defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+// nothing
+#else
+//////////////////////////////////////////////////////////////////////////////
+//
+//  generic converter from built-in img_n to req_comp
+//    individual types do this automatically as much as possible (e.g. jpeg
+//    does all cases internally since it needs to colorspace convert anyway,
+//    and it never has alpha, so very few cases ). png can automatically
+//    interleave an alpha=255 channel, but falls back to this for other cases
+//
+//  assume data buffer is malloced, so malloc a new one and free that one
+//  only failure mode is malloc failing
+
+static stbi_uc stbi__compute_y(int r, int g, int b)
+{
+   return (stbi_uc) (((r*77) + (g*150) +  (29*b)) >> 8);
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_BMP) && defined(STBI_NO_PSD) && defined(STBI_NO_TGA) && defined(STBI_NO_GIF) && defined(STBI_NO_PIC) && defined(STBI_NO_PNM)
+// nothing
+#else
+static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int req_comp, unsigned int x, unsigned int y)
+{
+   int i,j;
+   unsigned char *good;
+
+   if (req_comp == img_n) return data;
+   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+
+   good = (unsigned char *) stbi__malloc_mad3(req_comp, x, y, 0);
+   if (good == NULL) {
+      STBI_FREE(data);
+      return stbi__errpuc("outofmem", "Out of memory");
+   }
+
+   for (j=0; j < (int) y; ++j) {
+      unsigned char *src  = data + j * x * img_n   ;
+      unsigned char *dest = good + j * x * req_comp;
+
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      // convert source image with img_n components to one with req_comp components;
+      // avoid switch per pixel, so use switch per scanline and massive macros
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0]; dest[1]=255;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=255;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                  } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                  } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                  } break;
+         STBI__CASE(3,4) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=255;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = 255;    } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y(src[0],src[1],src[2]); dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                    } break;
+         default: STBI_ASSERT(0); STBI_FREE(data); STBI_FREE(good); return stbi__errpuc("unsupported", "Unsupported format conversion");
+      }
+      #undef STBI__CASE
+   }
+
+   STBI_FREE(data);
+   return good;
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_PSD)
+// nothing
+#else
+static stbi__uint16 stbi__compute_y_16(int r, int g, int b)
+{
+   return (stbi__uint16) (((r*77) + (g*150) +  (29*b)) >> 8);
+}
+#endif
+
+#if defined(STBI_NO_PNG) && defined(STBI_NO_PSD)
+// nothing
+#else
+static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int req_comp, unsigned int x, unsigned int y)
+{
+   int i,j;
+   stbi__uint16 *good;
+
+   if (req_comp == img_n) return data;
+   STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
+
+   good = (stbi__uint16 *) stbi__malloc(req_comp * x * y * 2);
+   if (good == NULL) {
+      STBI_FREE(data);
+      return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
+   }
+
+   for (j=0; j < (int) y; ++j) {
+      stbi__uint16 *src  = data + j * x * img_n   ;
+      stbi__uint16 *dest = good + j * x * req_comp;
+
+      #define STBI__COMBO(a,b)  ((a)*8+(b))
+      #define STBI__CASE(a,b)   case STBI__COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
+      // convert source image with img_n components to one with req_comp components;
+      // avoid switch per pixel, so use switch per scanline and massive macros
+      switch (STBI__COMBO(img_n, req_comp)) {
+         STBI__CASE(1,2) { dest[0]=src[0]; dest[1]=0xffff;                                     } break;
+         STBI__CASE(1,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(1,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=0xffff;                     } break;
+         STBI__CASE(2,1) { dest[0]=src[0];                                                     } break;
+         STBI__CASE(2,3) { dest[0]=dest[1]=dest[2]=src[0];                                     } break;
+         STBI__CASE(2,4) { dest[0]=dest[1]=dest[2]=src[0]; dest[3]=src[1];                     } break;
+         STBI__CASE(3,4) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];dest[3]=0xffff;        } break;
+         STBI__CASE(3,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(3,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]); dest[1] = 0xffff; } break;
+         STBI__CASE(4,1) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]);                   } break;
+         STBI__CASE(4,2) { dest[0]=stbi__compute_y_16(src[0],src[1],src[2]); dest[1] = src[3]; } break;
+         STBI__CASE(4,3) { dest[0]=src[0];dest[1]=src[1];dest[2]=src[2];                       } break;
+         default: STBI_ASSERT(0); STBI_FREE(data); STBI_FREE(good); return (stbi__uint16*) stbi__errpuc("unsupported", "Unsupported format conversion");
+      }
+      #undef STBI__CASE
+   }
+
+   STBI_FREE(data);
+   return good;
+}
+#endif
+
+#ifndef STBI_NO_LINEAR
+static float   *stbi__ldr_to_hdr(stbi_uc *data, int x, int y, int comp)
+{
+   int i,k,n;
+   float *output;
+   if (!data) return NULL;
+   output = (float *) stbi__malloc_mad4(x, y, comp, sizeof(float), 0);
+   if (output == NULL) { STBI_FREE(data); return stbi__errpf("outofmem", "Out of memory"); }
+   // compute number of non-alpha components
+   if (comp & 1) n = comp; else n = comp-1;
+   for (i=0; i < x*y; ++i) {
+      for (k=0; k < n; ++k) {
+         output[i*comp + k] = (float) (pow(data[i*comp+k]/255.0f, stbi__l2h_gamma) * stbi__l2h_scale);
+      }
+   }
+   if (n < comp) {
+      for (i=0; i < x*y; ++i) {
+         output[i*comp + n] = data[i*comp + n]/255.0f;
+      }
+   }
+   STBI_FREE(data);
+   return output;
+}
+#endif
+
+#ifndef STBI_NO_HDR
+#define stbi__float2int(x)   ((int) (x))
+static stbi_uc *stbi__hdr_to_ldr(float   *data, int x, int y, int comp)
+{
+   int i,k,n;
+   stbi_uc *output;
+   if (!data) return NULL;
+   output = (stbi_uc *) stbi__malloc_mad3(x, y, comp, 0);
+   if (output == NULL) { STBI_FREE(data); return stbi__errpuc("outofmem", "Out of memory"); }
+   // compute number of non-alpha components
+   if (comp & 1) n = comp; else n = comp-1;
+   for (i=0; i < x*y; ++i) {
+      for (k=0; k < n; ++k) {
+         float z = (float) pow(data[i*comp+k]*stbi__h2l_scale_i, stbi__h2l_gamma_i) * 255 + 0.5f;
+         if (z < 0) z = 0;
+         if (z > 255) z = 255;
+         output[i*comp + k] = (stbi_uc) stbi__float2int(z);
+      }
+      if (k < comp) {
+         float z = data[i*comp+k] * 255 + 0.5f;
+         if (z < 0) z = 0;
+         if (z > 255) z = 255;
+         output[i*comp + k] = (stbi_uc) stbi__float2int(z);
+      }
+   }
+   STBI_FREE(data);
+   return output;
+}
+#endif
+
+//////////////////////////////////////////////////////////////////////////////
+//
+//  "baseline" JPEG/JFIF decoder
+//
+//    simple implementation
+//      - doesn't support delayed output of y-dimension
+//      - simple interface (only one output format: 8-bit interleaved RGB)
+//      - doesn't try to recover corrupt jpegs
+//      - doesn't allow partial loading, loading multiple at once
+//      - still fast on x86 (copying globals into locals doesn't help x86)
+//      - allocates lots of intermediate memory (full size of all components)
+//        - non-interleaved case requires this anyway
+//        - allows good upsampling (see next)
+//    high-quality
+//      - upsampled channels are bilinearly interpolated, even across blocks
+//      - quality integer IDCT derived from IJG's 'slow'
+//    performance
+//      - fast huffman; reasonable integer IDCT
+//      - some SIMD kernels for common paths on targets with SSE2/NEON
+//      - uses a lot of intermediate memory, could cache poorly
+
+#ifndef STBI_NO_JPEG
+
+// huffman decoding acceleration
+#define FAST_BITS   9  // larger handles more cases; smaller stomps less cache
+
+typedef struct
+{
+   stbi_uc  fast[1 << FAST_BITS];
+   // weirdly, repacking this into AoS is a 10% speed loss, instead of a win
+   stbi__uint16 code[256];
+   stbi_uc  values[256];
+   stbi_uc  size[257];
+   unsigned int maxcode[18];
+   int    delta[17];   // old 'firstsymbol' - old 'firstcode'
+} stbi__huffman;
+
+typedef struct
+{
+   stbi__context *s;
+   stbi__huffman huff_dc[4];
+   stbi__huffman huff_ac[4];
+   stbi__uint16 dequant[4][64];
+   stbi__int16 fast_ac[4][1 << FAST_BITS];
+
+// sizes for components, interleaved MCUs
+   int img_h_max, img_v_max;
+   int img_mcu_x, img_mcu_y;
+   int img_mcu_w, img_mcu_h;
+
+// definition of jpeg image component
+   struct
+   {
+      int id;
+      int h,v;
+      int tq;
+      int hd,ha;
+      int dc_pred;
+
+      int x,y,w2,h2;
+      stbi_uc *data;
+      void *raw_data, *raw_coeff;
+      stbi_uc *linebuf;
+      short   *coeff;   // progressive only
+      int      coeff_w, coeff_h; // number of 8x8 coefficient blocks
+   } img_comp[4];
+
+   stbi__uint32   code_buffer; // jpeg entropy-coded buffer
+   int            code_bits;   // number of valid bits
+   unsigned char  marker;      // marker seen while filling entropy buffer
+   int            nomore;      // flag if we saw a marker so must stop
+
+   int            progressive;
+   int            spec_start;
+   int            spec_end;
+   int            succ_high;
+   int            succ_low;
+   int            eob_run;
+   int            jfif;
+   int            app14_color_transform; // Adobe APP14 tag
+   int            rgb;
+
+   int scan_n, order[4];
+   int restart_interval, todo;
+
+// kernels
+   void (*idct_block_kernel)(stbi_uc *out, int out_stride, short data[64]);
+   void (*YCbCr_to_RGB_kernel)(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step);
+   stbi_uc *(*resample_row_hv_2_kernel)(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs);
+} stbi__jpeg;
+
+static int stbi__build_huffman(stbi__huffman *h, int *count)
+{
+   int i,j,k=0;
+   unsigned int code;
+   // build size list for each symbol (from JPEG spec)
+   for (i=0; i < 16; ++i) {
+      for (j=0; j < count[i]; ++j) {
+         h->size[k++] = (stbi_uc) (i+1);
+         if(k >= 257) return stbi__err("bad size list","Corrupt JPEG");
+      }
+   }
+   h->size[k] = 0;
+
+   // compute actual symbols (from jpeg spec)
+   code = 0;
+   k = 0;
+   for(j=1; j <= 16; ++j) {
+      // compute delta to add to code to compute symbol id
+      h->delta[j] = k - code;
+      if (h->size[k] == j) {
+         while (h->size[k] == j)
+            h->code[k++] = (stbi__uint16) (code++);
+         if (code-1 >= (1u << j)) return stbi__err("bad code lengths","Corrupt JPEG");
+      }
+      // compute largest code + 1 for this size, preshifted as needed later
+      h->maxcode[j] = code << (16-j);
+      code <<= 1;
+   }
+   h->maxcode[j] = 0xffffffff;
+
+   // build non-spec acceleration table; 255 is flag for not-accelerated
+   memset(h->fast, 255, 1 << FAST_BITS);
+   for (i=0; i < k; ++i) {
+      int s = h->size[i];
+      if (s <= FAST_BITS) {
+         int c = h->code[i] << (FAST_BITS-s);
+         int m = 1 << (FAST_BITS-s);
+         for (j=0; j < m; ++j) {
+            h->fast[c+j] = (stbi_uc) i;
+         }
+      }
+   }
+   return 1;
+}
+
+// build a table that decodes both magnitude and value of small ACs in
+// one go.
+static void stbi__build_fast_ac(stbi__int16 *fast_ac, stbi__huffman *h)
+{
+   int i;
+   for (i=0; i < (1 << FAST_BITS); ++i) {
+      stbi_uc fast = h->fast[i];
+      fast_ac[i] = 0;
+      if (fast < 255) {
+         int rs = h->values[fast];
+         int run = (rs >> 4) & 15;
+         int magbits = rs & 15;
+         int len = h->size[fast];
+
+         if (magbits && len + magbits <= FAST_BITS) {
+            // magnitude code followed by receive_extend code
+            int k = ((i << len) & ((1 << FAST_BITS) - 1)) >> (FAST_BITS - magbits);
+            int m = 1 << (magbits - 1);
+            if (k < m) k += (~0U << magbits) + 1;
+            // if the result is small enough, we can fit it in fast_ac table
+            if (k >= -128 && k <= 127)
+               fast_ac[i] = (stbi__int16) ((k * 256) + (run * 16) + (len + magbits));
+         }
+      }
+   }
+}
+
+static void stbi__grow_buffer_unsafe(stbi__jpeg *j)
+{
+   do {
+      unsigned int b = j->nomore ? 0 : stbi__get8(j->s);
+      if (b == 0xff) {
+         int c = stbi__get8(j->s);
+         while (c == 0xff) c = stbi__get8(j->s); // consume fill bytes
+         if (c != 0) {
+            j->marker = (unsigned char) c;
+            j->nomore = 1;
+            return;
+         }
+      }
+      j->code_buffer |= b << (24 - j->code_bits);
+      j->code_bits += 8;
+   } while (j->code_bits <= 24);
+}
+
+// (1 << n) - 1
+static const stbi__uint32 stbi__bmask[17]={0,1,3,7,15,31,63,127,255,511,1023,2047,4095,8191,16383,32767,65535};
+
+// decode a jpeg huffman value from the bitstream
+stbi_inline static int stbi__jpeg_huff_decode(stbi__jpeg *j, stbi__huffman *h)
+{
+   unsigned int temp;
+   int c,k;
+
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+
+   // look at the top FAST_BITS and determine what symbol ID it is,
+   // if the code is <= FAST_BITS
+   c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+   k = h->fast[c];
+   if (k < 255) {
+      int s = h->size[k];
+      if (s > j->code_bits)
+         return -1;
+      j->code_buffer <<= s;
+      j->code_bits -= s;
+      return h->values[k];
+   }
+
+   // naive test is to shift the code_buffer down so k bits are
+   // valid, then test against maxcode. To speed this up, we've
+   // preshifted maxcode left so that it has (16-k) 0s at the
+   // end; in other words, regardless of the number of bits, it
+   // wants to be compared against something shifted to have 16;
+   // that way we don't need to shift inside the loop.
+   temp = j->code_buffer >> 16;
+   for (k=FAST_BITS+1 ; ; ++k)
+      if (temp < h->maxcode[k])
+         break;
+   if (k == 17) {
+      // error! code not found
+      j->code_bits -= 16;
+      return -1;
+   }
+
+   if (k > j->code_bits)
+      return -1;
+
+   // convert the huffman code to the symbol id
+   c = ((j->code_buffer >> (32 - k)) & stbi__bmask[k]) + h->delta[k];
+   if(c < 0 || c >= 256) // symbol id out of bounds!
+       return -1;
+   STBI_ASSERT((((j->code_buffer) >> (32 - h->size[c])) & stbi__bmask[h->size[c]]) == h->code[c]);
+
+   // convert the id to a symbol
+   j->code_bits -= k;
+   j->code_buffer <<= k;
+   return h->values[c];
+}
+
+// bias[n] = (-1<<n) + 1
+static const int stbi__jbias[16] = {0,-1,-3,-7,-15,-31,-63,-127,-255,-511,-1023,-2047,-4095,-8191,-16383,-32767};
+
+// combined JPEG 'receive' and JPEG 'extend', since baseline
+// always extends everything it receives.
+stbi_inline static int stbi__extend_receive(stbi__jpeg *j, int n)
+{
+   unsigned int k;
+   int sgn;
+   if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < n) return 0; // ran out of bits from stream, return 0s intead of continuing
+
+   sgn = j->code_buffer >> 31; // sign bit always in MSB; 0 if MSB clear (positive), 1 if MSB set (negative)
+   k = stbi_lrot(j->code_buffer, n);
+   j->code_buffer = k & ~stbi__bmask[n];
+   k &= stbi__bmask[n];
+   j->code_bits -= n;
+   return k + (stbi__jbias[n] & (sgn - 1));
+}
+
+// get some unsigned bits
+stbi_inline static int stbi__jpeg_get_bits(stbi__jpeg *j, int n)
+{
+   unsigned int k;
+   if (j->code_bits < n) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < n) return 0; // ran out of bits from stream, return 0s intead of continuing
+   k = stbi_lrot(j->code_buffer, n);
+   j->code_buffer = k & ~stbi__bmask[n];
+   k &= stbi__bmask[n];
+   j->code_bits -= n;
+   return k;
+}
+
+stbi_inline static int stbi__jpeg_get_bit(stbi__jpeg *j)
+{
+   unsigned int k;
+   if (j->code_bits < 1) stbi__grow_buffer_unsafe(j);
+   if (j->code_bits < 1) return 0; // ran out of bits from stream, return 0s intead of continuing
+   k = j->code_buffer;
+   j->code_buffer <<= 1;
+   --j->code_bits;
+   return k & 0x80000000;
+}
+
+// given a value that's at position X in the zigzag stream,
+// where does it appear in the 8x8 matrix coded as row-major?
+static const stbi_uc stbi__jpeg_dezigzag[64+15] =
+{
+    0,  1,  8, 16,  9,  2,  3, 10,
+   17, 24, 32, 25, 18, 11,  4,  5,
+   12, 19, 26, 33, 40, 48, 41, 34,
+   27, 20, 13,  6,  7, 14, 21, 28,
+   35, 42, 49, 56, 57, 50, 43, 36,
+   29, 22, 15, 23, 30, 37, 44, 51,
+   58, 59, 52, 45, 38, 31, 39, 46,
+   53, 60, 61, 54, 47, 55, 62, 63,
+   // let corrupt input sample past end
+   63, 63, 63, 63, 63, 63, 63, 63,
+   63, 63, 63, 63, 63, 63, 63
+};
+
+// decode one 64-entry block--
+static int stbi__jpeg_decode_block(stbi__jpeg *j, short data[64], stbi__huffman *hdc, stbi__huffman *hac, stbi__int16 *fac, int b, stbi__uint16 *dequant)
+{
+   int diff,dc,k;
+   int t;
+
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+   t = stbi__jpeg_huff_decode(j, hdc);
+   if (t < 0 || t > 15) return stbi__err("bad huffman code","Corrupt JPEG");
+
+   // 0 all the ac values now so we can do it 32-bits at a time
+   memset(data,0,64*sizeof(data[0]));
+
+   diff = t ? stbi__extend_receive(j, t) : 0;
+   if (!stbi__addints_valid(j->img_comp[b].dc_pred, diff)) return stbi__err("bad delta","Corrupt JPEG");
+   dc = j->img_comp[b].dc_pred + diff;
+   j->img_comp[b].dc_pred = dc;
+   if (!stbi__mul2shorts_valid(dc, dequant[0])) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+   data[0] = (short) (dc * dequant[0]);
+
+   // decode AC components, see JPEG spec
+   k = 1;
+   do {
+      unsigned int zig;
+      int c,r,s;
+      if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+      c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+      r = fac[c];
+      if (r) { // fast-AC path
+         k += (r >> 4) & 15; // run
+         s = r & 15; // combined length
+         if (s > j->code_bits) return stbi__err("bad huffman code", "Combined length longer than code bits available");
+         j->code_buffer <<= s;
+         j->code_bits -= s;
+         // decode into unzigzag'd location
+         zig = stbi__jpeg_dezigzag[k++];
+         data[zig] = (short) ((r >> 8) * dequant[zig]);
+      } else {
+         int rs = stbi__jpeg_huff_decode(j, hac);
+         if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+         s = rs & 15;
+         r = rs >> 4;
+         if (s == 0) {
+            if (rs != 0xf0) break; // end block
+            k += 16;
+         } else {
+            k += r;
+            // decode into unzigzag'd location
+            zig = stbi__jpeg_dezigzag[k++];
+            data[zig] = (short) (stbi__extend_receive(j,s) * dequant[zig]);
+         }
+      }
+   } while (k < 64);
+   return 1;
+}
+
+static int stbi__jpeg_decode_block_prog_dc(stbi__jpeg *j, short data[64], stbi__huffman *hdc, int b)
+{
+   int diff,dc;
+   int t;
+   if (j->spec_end != 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+
+   if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+
+   if (j->succ_high == 0) {
+      // first scan for DC coefficient, must be first
+      memset(data,0,64*sizeof(data[0])); // 0 all the ac values now
+      t = stbi__jpeg_huff_decode(j, hdc);
+      if (t < 0 || t > 15) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+      diff = t ? stbi__extend_receive(j, t) : 0;
+
+      if (!stbi__addints_valid(j->img_comp[b].dc_pred, diff)) return stbi__err("bad delta", "Corrupt JPEG");
+      dc = j->img_comp[b].dc_pred + diff;
+      j->img_comp[b].dc_pred = dc;
+      if (!stbi__mul2shorts_valid(dc, 1 << j->succ_low)) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+      data[0] = (short) (dc * (1 << j->succ_low));
+   } else {
+      // refinement scan for DC coefficient
+      if (stbi__jpeg_get_bit(j))
+         data[0] += (short) (1 << j->succ_low);
+   }
+   return 1;
+}
+
+// @OPTIMIZE: store non-zigzagged during the decode passes,
+// and only de-zigzag when dequantizing
+static int stbi__jpeg_decode_block_prog_ac(stbi__jpeg *j, short data[64], stbi__huffman *hac, stbi__int16 *fac)
+{
+   int k;
+   if (j->spec_start == 0) return stbi__err("can't merge dc and ac", "Corrupt JPEG");
+
+   if (j->succ_high == 0) {
+      int shift = j->succ_low;
+
+      if (j->eob_run) {
+         --j->eob_run;
+         return 1;
+      }
+
+      k = j->spec_start;
+      do {
+         unsigned int zig;
+         int c,r,s;
+         if (j->code_bits < 16) stbi__grow_buffer_unsafe(j);
+         c = (j->code_buffer >> (32 - FAST_BITS)) & ((1 << FAST_BITS)-1);
+         r = fac[c];
+         if (r) { // fast-AC path
+            k += (r >> 4) & 15; // run
+            s = r & 15; // combined length
+            if (s > j->code_bits) return stbi__err("bad huffman code", "Combined length longer than code bits available");
+            j->code_buffer <<= s;
+            j->code_bits -= s;
+            zig = stbi__jpeg_dezigzag[k++];
+            data[zig] = (short) ((r >> 8) * (1 << shift));
+         } else {
+            int rs = stbi__jpeg_huff_decode(j, hac);
+            if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+            s = rs & 15;
+            r = rs >> 4;
+            if (s == 0) {
+               if (r < 15) {
+                  j->eob_run = (1 << r);
+                  if (r)
+                     j->eob_run += stbi__jpeg_get_bits(j, r);
+                  --j->eob_run;
+                  break;
+               }
+               k += 16;
+            } else {
+               k += r;
+               zig = stbi__jpeg_dezigzag[k++];
+               data[zig] = (short) (stbi__extend_receive(j,s) * (1 << shift));
+            }
+         }
+      } while (k <= j->spec_end);
+   } else {
+      // refinement scan for these AC coefficients
+
+      short bit = (short) (1 << j->succ_low);
+
+      if (j->eob_run) {
+         --j->eob_run;
+         for (k = j->spec_start; k <= j->spec_end; ++k) {
+            short *p = &data[stbi__jpeg_dezigzag[k]];
+            if (*p != 0)
+               if (stbi__jpeg_get_bit(j))
+                  if ((*p & bit)==0) {
+                     if (*p > 0)
+                        *p += bit;
+                     else
+                        *p -= bit;
+                  }
+         }
+      } else {
+         k = j->spec_start;
+         do {
+            int r,s;
+            int rs = stbi__jpeg_huff_decode(j, hac); // @OPTIMIZE see if we can use the fast path here, advance-by-r is so slow, eh
+            if (rs < 0) return stbi__err("bad huffman code","Corrupt JPEG");
+            s = rs & 15;
+            r = rs >> 4;
+            if (s == 0) {
+               if (r < 15) {
+                  j->eob_run = (1 << r) - 1;
+                  if (r)
+                     j->eob_run += stbi__jpeg_get_bits(j, r);
+                  r = 64; // force end of block
+               } else {
+                  // r=15 s=0 should write 16 0s, so we just do
+                  // a run of 15 0s and then write s (which is 0),
+                  // so we don't have to do anything special here
+               }
+            } else {
+               if (s != 1) return stbi__err("bad huffman code", "Corrupt JPEG");
+               // sign bit
+               if (stbi__jpeg_get_bit(j))
+                  s = bit;
+               else
+                  s = -bit;
+            }
+
+            // advance by r
+            while (k <= j->spec_end) {
+               short *p = &data[stbi__jpeg_dezigzag[k++]];
+               if (*p != 0) {
+                  if (stbi__jpeg_get_bit(j))
+                     if ((*p & bit)==0) {
+                        if (*p > 0)
+                           *p += bit;
+                        else
+                           *p -= bit;
+                     }
+               } else {
+                  if (r == 0) {
+                     *p = (short) s;
+                     break;
+                  }
+                  --r;
+               }
+            }
+         } while (k <= j->spec_end);
+      }
+   }
+   return 1;
+}
+
+// take a -128..127 value and stbi__clamp it and convert to 0..255
+stbi_inline static stbi_uc stbi__clamp(int x)
+{
+   // trick to use a single test to catch both cases
+   if ((unsigned int) x > 255) {
+      if (x < 0) return 0;
+      if (x > 255) return 255;
+   }
+   return (stbi_uc) x;
+}
+
+#define stbi__f2f(x)  ((int) (((x) * 4096 + 0.5)))
+#define stbi__fsh(x)  ((x) * 4096)
+
+// derived from jidctint -- DCT_ISLOW
+#define STBI__IDCT_1D(s0,s1,s2,s3,s4,s5,s6,s7) \
+   int t0,t1,t2,t3,p1,p2,p3,p4,p5,x0,x1,x2,x3; \
+   p2 = s2;                                    \
+   p3 = s6;                                    \
+   p1 = (p2+p3) * stbi__f2f(0.5411961f);       \
+   t2 = p1 + p3*stbi__f2f(-1.847759065f);      \
+   t3 = p1 + p2*stbi__f2f( 0.765366865f);      \
+   p2 = s0;                                    \
+   p3 = s4;                                    \
+   t0 = stbi__fsh(p2+p3);                      \
+   t1 = stbi__fsh(p2-p3);                      \
+   x0 = t0+t3;                                 \
+   x3 = t0-t3;                                 \
+   x1 = t1+t2;                                 \
+   x2 = t1-t2;                                 \
+   t0 = s7;                                    \
+   t1 = s5;                                    \
+   t2 = s3;                                    \
+   t3 = s1;                                    \
+   p3 = t0+t2;                                 \
+   p4 = t1+t3;                                 \
+   p1 = t0+t3;                                 \
+   p2 = t1+t2;                                 \
+   p5 = (p3+p4)*stbi__f2f( 1.175875602f);      \
+   t0 = t0*stbi__f2f( 0.298631336f);           \
+   t1 = t1*stbi__f2f( 2.053119869f);           \
+   t2 = t2*stbi__f2f( 3.072711026f);           \
+   t3 = t3*stbi__f2f( 1.501321110f);           \
+   p1 = p5 + p1*stbi__f2f(-0.899976223f);      \
+   p2 = p5 + p2*stbi__f2f(-2.562915447f);      \
+   p3 = p3*stbi__f2f(-1.961570560f);           \
+   p4 = p4*stbi__f2f(-0.390180644f);           \
+   t3 += p1+p4;                                \
+   t2 += p2+p3;                                \
+   t1 += p2+p4;                                \
+   t0 += p1+p3;
+
+static void stbi__idct_block(stbi_uc *out, int out_stride, short data[64])
+{
+   int i,val[64],*v=val;
+   stbi_uc *o;
+   short *d = data;
+
+   // columns
+   for (i=0; i < 8; ++i,++d, ++v) {
+      // if all zeroes, shortcut -- this avoids dequantizing 0s and IDCTing
+      if (d[ 8]==0 && d[16]==0 && d[24]==0 && d[32]==0
+           && d[40]==0 && d[48]==0 && d[56]==0) {
+         //    no shortcut                 0     seconds
+         //    (1|2|3|4|5|6|7)==0          0     seconds
+         //    all separate               -0.047 seconds
+         //    1 && 2|3 && 4|5 && 6|7:    -0.047 seconds
+         int dcterm = d[0]*4;
+         v[0] = v[8] = v[16] = v[24] = v[32] = v[40] = v[48] = v[56] = dcterm;
+      } else {
+         STBI__IDCT_1D(d[ 0],d[ 8],d[16],d[24],d[32],d[40],d[48],d[56])
+         // constants scaled things up by 1<<12; let's bring them back
+         // down, but keep 2 extra bits of precision
+         x0 += 512; x1 += 512; x2 += 512; x3 += 512;
+         v[ 0] = (x0+t3) >> 10;
+         v[56] = (x0-t3) >> 10;
+         v[ 8] = (x1+t2) >> 10;
+         v[48] = (x1-t2) >> 10;
+         v[16] = (x2+t1) >> 10;
+         v[40] = (x2-t1) >> 10;
+         v[24] = (x3+t0) >> 10;
+         v[32] = (x3-t0) >> 10;
+      }
+   }
+
+   for (i=0, v=val, o=out; i < 8; ++i,v+=8,o+=out_stride) {
+      // no fast case since the first 1D IDCT spread components out
+      STBI__IDCT_1D(v[0],v[1],v[2],v[3],v[4],v[5],v[6],v[7])
+      // constants scaled things up by 1<<12, plus we had 1<<2 from first
+      // loop, plus horizontal and vertical each scale by sqrt(8) so together
+      // we've got an extra 1<<3, so 1<<17 total we need to remove.
+      // so we want to round that, which means adding 0.5 * 1<<17,
+      // aka 65536. Also, we'll end up with -128 to 127 that we want
+      // to encode as 0..255 by adding 128, so we'll add that before the shift
+      x0 += 65536 + (128<<17);
+      x1 += 65536 + (128<<17);
+      x2 += 65536 + (128<<17);
+      x3 += 65536 + (128<<17);
+      // tried computing the shifts into temps, or'ing the temps to see
+      // if any were out of range, but that was slower
+      o[0] = stbi__clamp((x0+t3) >> 17);
+      o[7] = stbi__clamp((x0-t3) >> 17);
+      o[1] = stbi__clamp((x1+t2) >> 17);
+      o[6] = stbi__clamp((x1-t2) >> 17);
+      o[2] = stbi__clamp((x2+t1) >> 17);
+      o[5] = stbi__clamp((x2-t1) >> 17);
+      o[3] = stbi__clamp((x3+t0) >> 17);
+      o[4] = stbi__clamp((x3-t0) >> 17);
+   }
+}
+
+#ifdef STBI_SSE2
+// sse2 integer IDCT. not the fastest possible implementation but it
+// produces bit-identical results to the generic C version so it's
+// fully "transparent".
+static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
+{
+   // This is constructed to match our regular (generic) integer IDCT exactly.
+   __m128i row0, row1, row2, row3, row4, row5, row6, row7;
+   __m128i tmp;
+
+   // dot product constant: even elems=x, odd elems=y
+   #define dct_const(x,y)  _mm_setr_epi16((x),(y),(x),(y),(x),(y),(x),(y))
+
+   // out(0) = c0[even]*x + c0[odd]*y   (c0, x, y 16-bit, out 32-bit)
+   // out(1) = c1[even]*x + c1[odd]*y
+   #define dct_rot(out0,out1, x,y,c0,c1) \
+      __m128i c0##lo = _mm_unpacklo_epi16((x),(y)); \
+      __m128i c0##hi = _mm_unpackhi_epi16((x),(y)); \
+      __m128i out0##_l = _mm_madd_epi16(c0##lo, c0); \
+      __m128i out0##_h = _mm_madd_epi16(c0##hi, c0); \
+      __m128i out1##_l = _mm_madd_epi16(c0##lo, c1); \
+      __m128i out1##_h = _mm_madd_epi16(c0##hi, c1)
+
+   // out = in << 12  (in 16-bit, out 32-bit)
+   #define dct_widen(out, in) \
+      __m128i out##_l = _mm_srai_epi32(_mm_unpacklo_epi16(_mm_setzero_si128(), (in)), 4); \
+      __m128i out##_h = _mm_srai_epi32(_mm_unpackhi_epi16(_mm_setzero_si128(), (in)), 4)
+
+   // wide add
+   #define dct_wadd(out, a, b) \
+      __m128i out##_l = _mm_add_epi32(a##_l, b##_l); \
+      __m128i out##_h = _mm_add_epi32(a##_h, b##_h)
+
+   // wide sub
+   #define dct_wsub(out, a, b) \
+      __m128i out##_l = _mm_sub_epi32(a##_l, b##_l); \
+      __m128i out##_h = _mm_sub_epi32(a##_h, b##_h)
+
+   // butterfly a/b, add bias, then shift by "s" and pack
+   #define dct_bfly32o(out0, out1, a,b,bias,s) \
+      { \
+         __m128i abiased_l = _mm_add_epi32(a##_l, bias); \
+         __m128i abiased_h = _mm_add_epi32(a##_h, bias); \
+         dct_wadd(sum, abiased, b); \
+         dct_wsub(dif, abiased, b); \
+         out0 = _mm_packs_epi32(_mm_srai_epi32(sum_l, s), _mm_srai_epi32(sum_h, s)); \
+         out1 = _mm_packs_epi32(_mm_srai_epi32(dif_l, s), _mm_srai_epi32(dif_h, s)); \
+      }
+
+   // 8-bit interleave step (for transposes)
+   #define dct_interleave8(a, b) \
+      tmp = a; \
+      a = _mm_unpacklo_epi8(a, b); \
+      b = _mm_unpackhi_epi8(tmp, b)
+
+   // 16-bit interleave step (for transposes)
+   #define dct_interleave16(a, b) \
+      tmp = a; \
+      a = _mm_unpacklo_epi16(a, b); \
+      b = _mm_unpackhi_epi16(tmp, b)
+
+   #define dct_pass(bias,shift) \
+      { \
+         /* even part */ \
+         dct_rot(t2e,t3e, row2,row6, rot0_0,rot0_1); \
+         __m128i sum04 = _mm_add_epi16(row0, row4); \
+         __m128i dif04 = _mm_sub_epi16(row0, row4); \
+         dct_widen(t0e, sum04); \
+         dct_widen(t1e, dif04); \
+         dct_wadd(x0, t0e, t3e); \
+         dct_wsub(x3, t0e, t3e); \
+         dct_wadd(x1, t1e, t2e); \
+         dct_wsub(x2, t1e, t2e); \
+         /* odd part */ \
+         dct_rot(y0o,y2o, row7,row3, rot2_0,rot2_1); \
+         dct_rot(y1o,y3o, row5,row1, rot3_0,rot3_1); \
+         __m128i sum17 = _mm_add_epi16(row1, row7); \
+         __m128i sum35 = _mm_add_epi16(row3, row5); \
+         dct_rot(y4o,y5o, sum17,sum35, rot1_0,rot1_1); \
+         dct_wadd(x4, y0o, y4o); \
+         dct_wadd(x5, y1o, y5o); \
+         dct_wadd(x6, y2o, y5o); \
+         dct_wadd(x7, y3o, y4o); \
+         dct_bfly32o(row0,row7, x0,x7,bias,shift); \
+         dct_bfly32o(row1,row6, x1,x6,bias,shift); \
+         dct_bfly32o(row2,row5, x2,x5,bias,shift); \
+         dct_bfly32o(row3,row4, x3,x4,bias,shift); \
+      }
+
+   __m128i rot0_0 = dct_const(stbi__f2f(0.5411961f), stbi__f2f(0.5411961f) + stbi__f2f(-1.847759065f));
+   __m128i rot0_1 = dct_const(stbi__f2f(0.5411961f) + stbi__f2f( 0.765366865f), stbi__f2f(0.5411961f));
+   __m128i rot1_0 = dct_const(stbi__f2f(1.175875602f) + stbi__f2f(-0.899976223f), stbi__f2f(1.175875602f));
+   __m128i rot1_1 = dct_const(stbi__f2f(1.175875602f), stbi__f2f(1.175875602f) + stbi__f2f(-2.562915447f));
+   __m128i rot2_0 = dct_const(stbi__f2f(-1.961570560f) + stbi__f2f( 0.298631336f), stbi__f2f(-1.961570560f));
+   __m128i rot2_1 = dct_const(stbi__f2f(-1.961570560f), stbi__f2f(-1.961570560f) + stbi__f2f( 3.072711026f));
+   __m128i rot3_0 = dct_const(stbi__f2f(-0.390180644f) + stbi__f2f( 2.053119869f), stbi__f2f(-0.390180644f));
+   __m128i rot3_1 = dct_const(stbi__f2f(-0.390180644f), stbi__f2f(-0.390180644f) + stbi__f2f( 1.501321110f));
+
+   // rounding biases in column/row passes, see stbi__idct_block for explanation.
+   __m128i bias_0 = _mm_set1_epi32(512);
+   __m128i bias_1 = _mm_set1_epi32(65536 + (128<<17));
+
+   // load
+   row0 = _mm_load_si128((const __m128i *) (data + 0*8));
+   row1 = _mm_load_si128((const __m128i *) (data + 1*8));
+   row2 = _mm_load_si128((const __m128i *) (data + 2*8));
+   row3 = _mm_load_si128((const __m128i *) (data + 3*8));
+   row4 = _mm_load_si128((const __m128i *) (data + 4*8));
+   row5 = _mm_load_si128((const __m128i *) (data + 5*8));
+   row6 = _mm_load_si128((const __m128i *) (data + 6*8));
+   row7 = _mm_load_si128((const __m128i *) (data + 7*8));
+
+   // column pass
+   dct_pass(bias_0, 10);
+
+   {
+      // 16bit 8x8 transpose pass 1
+      dct_interleave16(row0, row4);
+      dct_interleave16(row1, row5);
+      dct_interleave16(row2, row6);
+      dct_interleave16(row3, row7);
+
+      // transpose pass 2
+      dct_interleave16(row0, row2);
+      dct_interleave16(row1, row3);
+      dct_interleave16(row4, row6);
+      dct_interleave16(row5, row7);
+
+      // transpose pass 3
+      dct_interleave16(row0, row1);
+      dct_interleave16(row2, row3);
+      dct_interleave16(row4, row5);
+      dct_interleave16(row6, row7);
+   }
+
+   // row pass
+   dct_pass(bias_1, 17);
+
+   {
+      // pack
+      __m128i p0 = _mm_packus_epi16(row0, row1); // a0a1a2a3...a7b0b1b2b3...b7
+      __m128i p1 = _mm_packus_epi16(row2, row3);
+      __m128i p2 = _mm_packus_epi16(row4, row5);
+      __m128i p3 = _mm_packus_epi16(row6, row7);
+
+      // 8bit 8x8 transpose pass 1
+      dct_interleave8(p0, p2); // a0e0a1e1...
+      dct_interleave8(p1, p3); // c0g0c1g1...
+
+      // transpose pass 2
+      dct_interleave8(p0, p1); // a0c0e0g0...
+      dct_interleave8(p2, p3); // b0d0f0h0...
+
+      // transpose pass 3
+      dct_interleave8(p0, p2); // a0b0c0d0...
+      dct_interleave8(p1, p3); // a4b4c4d4...
+
+      // store
+      _mm_storel_epi64((__m128i *) out, p0); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p0, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p2); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p2, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p1); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p1, 0x4e)); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, p3); out += out_stride;
+      _mm_storel_epi64((__m128i *) out, _mm_shuffle_epi32(p3, 0x4e));
+   }
+
+#undef dct_const
+#undef dct_rot
+#undef dct_widen
+#undef dct_wadd
+#undef dct_wsub
+#undef dct_bfly32o
+#undef dct_interleave8
+#undef dct_interleave16
+#undef dct_pass
+}
+
+#endif // STBI_SSE2
+
+#ifdef STBI_NEON
+
+// NEON integer IDCT. should produce bit-identical
+// results to the generic C version.
+static void stbi__idct_simd(stbi_uc *out, int out_stride, short data[64])
+{
+   int16x8_t row0, row1, row2, row3, row4, row5, row6, row7;
+
+   int16x4_t rot0_0 = vdup_n_s16(stbi__f2f(0.5411961f));
+   int16x4_t rot0_1 = vdup_n_s16(stbi__f2f(-1.847759065f));
+   int16x4_t rot0_2 = vdup_n_s16(stbi__f2f( 0.765366865f));
+   int16x4_t rot1_0 = vdup_n_s16(stbi__f2f( 1.175875602f));
+   int16x4_t rot1_1 = vdup_n_s16(stbi__f2f(-0.899976223f));
+   int16x4_t rot1_2 = vdup_n_s16(stbi__f2f(-2.562915447f));
+   int16x4_t rot2_0 = vdup_n_s16(stbi__f2f(-1.961570560f));
+   int16x4_t rot2_1 = vdup_n_s16(stbi__f2f(-0.390180644f));
+   int16x4_t rot3_0 = vdup_n_s16(stbi__f2f( 0.298631336f));
+   int16x4_t rot3_1 = vdup_n_s16(stbi__f2f( 2.053119869f));
+   int16x4_t rot3_2 = vdup_n_s16(stbi__f2f( 3.072711026f));
+   int16x4_t rot3_3 = vdup_n_s16(stbi__f2f( 1.501321110f));
+
+#define dct_long_mul(out, inq, coeff) \
+   int32x4_t out##_l = vmull_s16(vget_low_s16(inq), coeff); \
+   int32x4_t out##_h = vmull_s16(vget_high_s16(inq), coeff)
+
+#define dct_long_mac(out, acc, inq, coeff) \
+   int32x4_t out##_l = vmlal_s16(acc##_l, vget_low_s16(inq), coeff); \
+   int32x4_t out##_h = vmlal_s16(acc##_h, vget_high_s16(inq), coeff)
+
+#define dct_widen(out, inq) \
+   int32x4_t out##_l = vshll_n_s16(vget_low_s16(inq), 12); \
+   int32x4_t out##_h = vshll_n_s16(vget_high_s16(inq), 12)
+
+// wide add
+#define dct_wadd(out, a, b) \
+   int32x4_t out##_l = vaddq_s32(a##_l, b##_l); \
+   int32x4_t out##_h = vaddq_s32(a##_h, b##_h)
+
+// wide sub
+#define dct_wsub(out, a, b) \
+   int32x4_t out##_l = vsubq_s32(a##_l, b##_l); \
+   int32x4_t out##_h = vsubq_s32(a##_h, b##_h)
+
+// butterfly a/b, then shift using "shiftop" by "s" and pack
+#define dct_bfly32o(out0,out1, a,b,shiftop,s) \
+   { \
+      dct_wadd(sum, a, b); \
+      dct_wsub(dif, a, b); \
+      out0 = vcombine_s16(shiftop(sum_l, s), shiftop(sum_h, s)); \
+      out1 = vcombine_s16(shiftop(dif_l, s), shiftop(dif_h, s)); \
+   }
+
+#define dct_pass(shiftop, shift) \
+   { \
+      /* even part */ \
+      int16x8_t sum26 = vaddq_s16(row2, row6); \
+      dct_long_mul(p1e, sum26, rot0_0); \
+      dct_long_mac(t2e, p1e, row6, rot0_1); \
+      dct_long_mac(t3e, p1e, row2, rot0_2); \
+      int16x8_t sum04 = vaddq_s16(row0, row4); \
+      int16x8_t dif04 = vsubq_s16(row0, row4); \
+      dct_widen(t0e, sum04); \
+      dct_widen(t1e, dif04); \
+      dct_wadd(x0, t0e, t3e); \
+      dct_wsub(x3, t0e, t3e); \
+      dct_wadd(x1, t1e, t2e); \
+      dct_wsub(x2, t1e, t2e); \
+      /* odd part */ \
+      int16x8_t sum15 = vaddq_s16(row1, row5); \
+      int16x8_t sum17 = vaddq_s16(row1, row7); \
+      int16x8_t sum35 = vaddq_s16(row3, row5); \
+      int16x8_t sum37 = vaddq_s16(row3, row7); \
+      int16x8_t sumodd = vaddq_s16(sum17, sum35); \
+      dct_long_mul(p5o, sumodd, rot1_0); \
+      dct_long_mac(p1o, p5o, sum17, rot1_1); \
+      dct_long_mac(p2o, p5o, sum35, rot1_2); \
+      dct_long_mul(p3o, sum37, rot2_0); \
+      dct_long_mul(p4o, sum15, rot2_1); \
+      dct_wadd(sump13o, p1o, p3o); \
+      dct_wadd(sump24o, p2o, p4o); \
+      dct_wadd(sump23o, p2o, p3o); \
+      dct_wadd(sump14o, p1o, p4o); \
+      dct_long_mac(x4, sump13o, row7, rot3_0); \
+      dct_long_mac(x5, sump24o, row5, rot3_1); \
+      dct_long_mac(x6, sump23o, row3, rot3_2); \
+      dct_long_mac(x7, sump14o, row1, rot3_3); \
+      dct_bfly32o(row0,row7, x0,x7,shiftop,shift); \
+      dct_bfly32o(row1,row6, x1,x6,shiftop,shift); \
+      dct_bfly32o(row2,row5, x2,x5,shiftop,shift); \
+      dct_bfly32o(row3,row4, x3,x4,shiftop,shift); \
+   }
+
+   // load
+   row0 = vld1q_s16(data + 0*8);
+   row1 = vld1q_s16(data + 1*8);
+   row2 = vld1q_s16(data + 2*8);
+   row3 = vld1q_s16(data + 3*8);
+   row4 = vld1q_s16(data + 4*8);
+   row5 = vld1q_s16(data + 5*8);
+   row6 = vld1q_s16(data + 6*8);
+   row7 = vld1q_s16(data + 7*8);
+
+   // add DC bias
+   row0 = vaddq_s16(row0, vsetq_lane_s16(1024, vdupq_n_s16(0), 0));
+
+   // column pass
+   dct_pass(vrshrn_n_s32, 10);
+
+   // 16bit 8x8 transpose
+   {
+// these three map to a single VTRN.16, VTRN.32, and VSWP, respectively.
+// whether compilers actually get this is another story, sadly.
+#define dct_trn16(x, y) { int16x8x2_t t = vtrnq_s16(x, y); x = t.val[0]; y = t.val[1]; }
+#define dct_trn32(x, y) { int32x4x2_t t = vtrnq_s32(vreinterpretq_s32_s16(x), vreinterpretq_s32_s16(y)); x = vreinterpretq_s16_s32(t.val[0]); y = vreinterpretq_s16_s32(t.val[1]); }
+#define dct_trn64(x, y) { int16x8_t x0 = x; int16x8_t y0 = y; x = vcombine_s16(vget_low_s16(x0), vget_low_s16(y0)); y = vcombine_s16(vget_high_s16(x0), vget_high_s16(y0)); }
+
+      // pass 1
+      dct_trn16(row0, row1); // a0b0a2b2a4b4a6b6
+      dct_trn16(row2, row3);
+      dct_trn16(row4, row5);
+      dct_trn16(row6, row7);
+
+      // pass 2
+      dct_trn32(row0, row2); // a0b0c0d0a4b4c4d4
+      dct_trn32(row1, row3);
+      dct_trn32(row4, row6);
+      dct_trn32(row5, row7);
+
+      // pass 3
+      dct_trn64(row0, row4); // a0b0c0d0e0f0g0h0
+      dct_trn64(row1, row5);
+      dct_trn64(row2, row6);
+      dct_trn64(row3, row7);
+
+#undef dct_trn16
+#undef dct_trn32
+#undef dct_trn64
+   }
+
+   // row pass
+   // vrshrn_n_s32 only supports shifts up to 16, we need
+   // 17. so do a non-rounding shift of 16 first then follow
+   // up with a rounding shift by 1.
+   dct_pass(vshrn_n_s32, 16);
+
+   {
+      // pack and round
+      uint8x8_t p0 = vqrshrun_n_s16(row0, 1);
+      uint8x8_t p1 = vqrshrun_n_s16(row1, 1);
+      uint8x8_t p2 = vqrshrun_n_s16(row2, 1);
+      uint8x8_t p3 = vqrshrun_n_s16(row3, 1);
+      uint8x8_t p4 = vqrshrun_n_s16(row4, 1);
+      uint8x8_t p5 = vqrshrun_n_s16(row5, 1);
+      uint8x8_t p6 = vqrshrun_n_s16(row6, 1);
+      uint8x8_t p7 = vqrshrun_n_s16(row7, 1);
+
+      // again, these can translate into one instruction, but often don't.
+#define dct_trn8_8(x, y) { uint8x8x2_t t = vtrn_u8(x, y); x = t.val[0]; y = t.val[1]; }
+#define dct_trn8_16(x, y) { uint16x4x2_t t = vtrn_u16(vreinterpret_u16_u8(x), vreinterpret_u16_u8(y)); x = vreinterpret_u8_u16(t.val[0]); y = vreinterpret_u8_u16(t.val[1]); }
+#define dct_trn8_32(x, y) { uint32x2x2_t t = vtrn_u32(vreinterpret_u32_u8(x), vreinterpret_u32_u8(y)); x = vreinterpret_u8_u32(t.val[0]); y = vreinterpret_u8_u32(t.val[1]); }
+
+      // sadly can't use interleaved stores here since we only write
+      // 8 bytes to each scan line!
+
+      // 8x8 8-bit transpose pass 1
+      dct_trn8_8(p0, p1);
+      dct_trn8_8(p2, p3);
+      dct_trn8_8(p4, p5);
+      dct_trn8_8(p6, p7);
+
+      // pass 2
+      dct_trn8_16(p0, p2);
+      dct_trn8_16(p1, p3);
+      dct_trn8_16(p4, p6);
+      dct_trn8_16(p5, p7);
+
+      // pass 3
+      dct_trn8_32(p0, p4);
+      dct_trn8_32(p1, p5);
+      dct_trn8_32(p2, p6);
+      dct_trn8_32(p3, p7);
+
+      // store
+      vst1_u8(out, p0); out += out_stride;
+      vst1_u8(out, p1); out += out_stride;
+      vst1_u8(out, p2); out += out_stride;
+      vst1_u8(out, p3); out += out_stride;
+      vst1_u8(out, p4); out += out_stride;
+      vst1_u8(out, p5); out += out_stride;
+      vst1_u8(out, p6); out += out_stride;
+      vst1_u8(out, p7);
+
+#undef dct_trn8_8
+#undef dct_trn8_16
+#undef dct_trn8_32
+   }
+
+#undef dct_long_mul
+#undef dct_long_mac
+#undef dct_widen
+#undef dct_wadd
+#undef dct_wsub
+#undef dct_bfly32o
+#undef dct_pass
+}
+
+#endif // STBI_NEON
+
+#define STBI__MARKER_none  0xff
+// if there's a pending marker from the entropy stream, return that
+// otherwise, fetch from the stream and get a marker. if there's no
+// marker, return 0xff, which is never a valid marker value
+static stbi_uc stbi__get_marker(stbi__jpeg *j)
+{
+   stbi_uc x;
+   if (j->marker != STBI__MARKER_none) { x = j->marker; j->marker = STBI__MARKER_none; return x; }
+   x = stbi__get8(j->s);
+   if (x != 0xff) return STBI__MARKER_none;
+   while (x == 0xff)
+      x = stbi__get8(j->s); // consume repeated 0xff fill bytes
+   return x;
+}
+
+// in each scan, we'll have scan_n components, and the order
+// of the components is specified by order[]
+#define STBI__RESTART(x)     ((x) >= 0xd0 && (x) <= 0xd7)
+
+// after a restart interval, stbi__jpeg_reset the entropy decoder and
+// the dc prediction
+static void stbi__jpeg_reset(stbi__jpeg *j)
+{
+   j->code_bits = 0;
+   j->code_buffer = 0;
+   j->nomore = 0;
+   j->img_comp[0].dc_pred = j->img_comp[1].dc_pred = j->img_comp[2].dc_pred = j->img_comp[3].dc_pred = 0;
+   j->marker = STBI__MARKER_none;
+   j->todo = j->restart_interval ? j->restart_interval : 0x7fffffff;
+   j->eob_run = 0;
+   // no more than 1<<31 MCUs if no restart_interal? that's plenty safe,
+   // since we don't even allow 1<<30 pixels
+}
+
+static int stbi__parse_entropy_coded_data(stbi__jpeg *z)
+{
+   stbi__jpeg_reset(z);
+   if (!z->progressive) {
+      if (z->scan_n == 1) {
+         int i,j;
+         STBI_SIMD_ALIGN(short, data[64]);
+         int n = z->order[0];
+         // non-interleaved data, we just need to process one block at a time,
+         // in trivial scanline order
+         // number of blocks to do just depends on how many actual "pixels" this
+         // component has, independent of interleaved MCU blocking and such
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               int ha = z->img_comp[n].ha;
+               if (!stbi__jpeg_decode_block(z, data, z->huff_dc+z->img_comp[n].hd, z->huff_ac+ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
+               z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*j*8+i*8, z->img_comp[n].w2, data);
+               // every data block is an MCU, so countdown the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  // if it's NOT a restart, then just bail, so we get corrupt data
+                  // rather than no data
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      } else { // interleaved
+         int i,j,k,x,y;
+         STBI_SIMD_ALIGN(short, data[64]);
+         for (j=0; j < z->img_mcu_y; ++j) {
+            for (i=0; i < z->img_mcu_x; ++i) {
+               // scan an interleaved mcu... process scan_n components in order
+               for (k=0; k < z->scan_n; ++k) {
+                  int n = z->order[k];
+                  // scan out an mcu's worth of this component; that's just determined
+                  // by the basic H and V specified for the component
+                  for (y=0; y < z->img_comp[n].v; ++y) {
+                     for (x=0; x < z->img_comp[n].h; ++x) {
+                        int x2 = (i*z->img_comp[n].h + x)*8;
+                        int y2 = (j*z->img_comp[n].v + y)*8;
+                        int ha = z->img_comp[n].ha;
+                        if (!stbi__jpeg_decode_block(z, data, z->huff_dc+z->img_comp[n].hd, z->huff_ac+ha, z->fast_ac[ha], n, z->dequant[z->img_comp[n].tq])) return 0;
+                        z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*y2+x2, z->img_comp[n].w2, data);
+                     }
+                  }
+               }
+               // after all interleaved components, that's an interleaved MCU,
+               // so now count down the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      }
+   } else {
+      if (z->scan_n == 1) {
+         int i,j;
+         int n = z->order[0];
+         // non-interleaved data, we just need to process one block at a time,
+         // in trivial scanline order
+         // number of blocks to do just depends on how many actual "pixels" this
+         // component has, independent of interleaved MCU blocking and such
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+               if (z->spec_start == 0) {
+                  if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
+                     return 0;
+               } else {
+                  int ha = z->img_comp[n].ha;
+                  if (!stbi__jpeg_decode_block_prog_ac(z, data, &z->huff_ac[ha], z->fast_ac[ha]))
+                     return 0;
+               }
+               // every data block is an MCU, so countdown the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      } else { // interleaved
+         int i,j,k,x,y;
+         for (j=0; j < z->img_mcu_y; ++j) {
+            for (i=0; i < z->img_mcu_x; ++i) {
+               // scan an interleaved mcu... process scan_n components in order
+               for (k=0; k < z->scan_n; ++k) {
+                  int n = z->order[k];
+                  // scan out an mcu's worth of this component; that's just determined
+                  // by the basic H and V specified for the component
+                  for (y=0; y < z->img_comp[n].v; ++y) {
+                     for (x=0; x < z->img_comp[n].h; ++x) {
+                        int x2 = (i*z->img_comp[n].h + x);
+                        int y2 = (j*z->img_comp[n].v + y);
+                        short *data = z->img_comp[n].coeff + 64 * (x2 + y2 * z->img_comp[n].coeff_w);
+                        if (!stbi__jpeg_decode_block_prog_dc(z, data, &z->huff_dc[z->img_comp[n].hd], n))
+                           return 0;
+                     }
+                  }
+               }
+               // after all interleaved components, that's an interleaved MCU,
+               // so now count down the restart interval
+               if (--z->todo <= 0) {
+                  if (z->code_bits < 24) stbi__grow_buffer_unsafe(z);
+                  if (!STBI__RESTART(z->marker)) return 1;
+                  stbi__jpeg_reset(z);
+               }
+            }
+         }
+         return 1;
+      }
+   }
+}
+
+static void stbi__jpeg_dequantize(short *data, stbi__uint16 *dequant)
+{
+   int i;
+   for (i=0; i < 64; ++i)
+      data[i] *= dequant[i];
+}
+
+static void stbi__jpeg_finish(stbi__jpeg *z)
+{
+   if (z->progressive) {
+      // dequantize and idct the data
+      int i,j,n;
+      for (n=0; n < z->s->img_n; ++n) {
+         int w = (z->img_comp[n].x+7) >> 3;
+         int h = (z->img_comp[n].y+7) >> 3;
+         for (j=0; j < h; ++j) {
+            for (i=0; i < w; ++i) {
+               short *data = z->img_comp[n].coeff + 64 * (i + j * z->img_comp[n].coeff_w);
+               stbi__jpeg_dequantize(data, z->dequant[z->img_comp[n].tq]);
+               z->idct_block_kernel(z->img_comp[n].data+z->img_comp[n].w2*j*8+i*8, z->img_comp[n].w2, data);
+            }
+         }
+      }
+   }
+}
+
+static int stbi__process_marker(stbi__jpeg *z, int m)
+{
+   int L;
+   switch (m) {
+      case STBI__MARKER_none: // no marker found
+         return stbi__err("expected marker","Corrupt JPEG");
+
+      case 0xDD: // DRI - specify restart interval
+         if (stbi__get16be(z->s) != 4) return stbi__err("bad DRI len","Corrupt JPEG");
+         z->restart_interval = stbi__get16be(z->s);
+         return 1;
+
+      case 0xDB: // DQT - define quantization table
+         L = stbi__get16be(z->s)-2;
+         while (L > 0) {
+            int q = stbi__get8(z->s);
+            int p = q >> 4, sixteen = (p != 0);
+            int t = q & 15,i;
+            if (p != 0 && p != 1) return stbi__err("bad DQT type","Corrupt JPEG");
+            if (t > 3) return stbi__err("bad DQT table","Corrupt JPEG");
+
+            for (i=0; i < 64; ++i)
+               z->dequant[t][stbi__jpeg_dezigzag[i]] = (stbi__uint16)(sixteen ? stbi__get16be(z->s) : stbi__get8(z->s));
+            L -= (sixteen ? 129 : 65);
+         }
+         return L==0;
+
+      case 0xC4: // DHT - define huffman table
+         L = stbi__get16be(z->s)-2;
+         while (L > 0) {
+            stbi_uc *v;
+            int sizes[16],i,n=0;
+            int q = stbi__get8(z->s);
+            int tc = q >> 4;
+            int th = q & 15;
+            if (tc > 1 || th > 3) return stbi__err("bad DHT header","Corrupt JPEG");
+            for (i=0; i < 16; ++i) {
+               sizes[i] = stbi__get8(z->s);
+               n += sizes[i];
+            }
+            if(n > 256) return stbi__err("bad DHT header","Corrupt JPEG"); // Loop over i < n would write past end of values!
+            L -= 17;
+            if (tc == 0) {
+               if (!stbi__build_huffman(z->huff_dc+th, sizes)) return 0;
+               v = z->huff_dc[th].values;
+            } else {
+               if (!stbi__build_huffman(z->huff_ac+th, sizes)) return 0;
+               v = z->huff_ac[th].values;
+            }
+            for (i=0; i < n; ++i)
+               v[i] = stbi__get8(z->s);
+            if (tc != 0)
+               stbi__build_fast_ac(z->fast_ac[th], z->huff_ac + th);
+            L -= n;
+         }
+         return L==0;
+   }
+
+   // check for comment block or APP blocks
+   if ((m >= 0xE0 && m <= 0xEF) || m == 0xFE) {
+      L = stbi__get16be(z->s);
+      if (L < 2) {
+         if (m == 0xFE)
+            return stbi__err("bad COM len","Corrupt JPEG");
+         else
+            return stbi__err("bad APP len","Corrupt JPEG");
+      }
+      L -= 2;
+
+      if (m == 0xE0 && L >= 5) { // JFIF APP0 segment
+         static const unsigned char tag[5] = {'J','F','I','F','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 5; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 5;
+         if (ok)
+            z->jfif = 1;
+      } else if (m == 0xEE && L >= 12) { // Adobe APP14 segment
+         static const unsigned char tag[6] = {'A','d','o','b','e','\0'};
+         int ok = 1;
+         int i;
+         for (i=0; i < 6; ++i)
+            if (stbi__get8(z->s) != tag[i])
+               ok = 0;
+         L -= 6;
+         if (ok) {
+            stbi__get8(z->s); // version
+            stbi__get16be(z->s); // flags0
+            stbi__get16be(z->s); // flags1
+            z->app14_color_transform = stbi__get8(z->s); // color transform
+            L -= 6;
+         }
+      }
+
+      stbi__skip(z->s, L);
+      return 1;
+   }
+
+   return stbi__err("unknown marker","Corrupt JPEG");
+}
+
+// after we see SOS
+static int stbi__process_scan_header(stbi__jpeg *z)
+{
+   int i;
+   int Ls = stbi__get16be(z->s);
+   z->scan_n = stbi__get8(z->s);
+   if (z->scan_n < 1 || z->scan_n > 4 || z->scan_n > (int) z->s->img_n) return stbi__err("bad SOS component count","Corrupt JPEG");
+   if (Ls != 6+2*z->scan_n) return stbi__err("bad SOS len","Corrupt JPEG");
+   for (i=0; i < z->scan_n; ++i) {
+      int id = stbi__get8(z->s), which;
+      int q = stbi__get8(z->s);
+      for (which = 0; which < z->s->img_n; ++which)
+         if (z->img_comp[which].id == id)
+            break;
+      if (which == z->s->img_n) return 0; // no match
+      z->img_comp[which].hd = q >> 4;   if (z->img_comp[which].hd > 3) return stbi__err("bad DC huff","Corrupt JPEG");
+      z->img_comp[which].ha = q & 15;   if (z->img_comp[which].ha > 3) return stbi__err("bad AC huff","Corrupt JPEG");
+      z->order[i] = which;
+   }
+
+   {
+      int aa;
+      z->spec_start = stbi__get8(z->s);
+      z->spec_end   = stbi__get8(z->s); // should be 63, but might be 0
+      aa = stbi__get8(z->s);
+      z->succ_high = (aa >> 4);
+      z->succ_low  = (aa & 15);
+      if (z->progressive) {
+         if (z->spec_start > 63 || z->spec_end > 63  || z->spec_start > z->spec_end || z->succ_high > 13 || z->succ_low > 13)
+            return stbi__err("bad SOS", "Corrupt JPEG");
+      } else {
+         if (z->spec_start != 0) return stbi__err("bad SOS","Corrupt JPEG");
+         if (z->succ_high != 0 || z->succ_low != 0) return stbi__err("bad SOS","Corrupt JPEG");
+         z->spec_end = 63;
+      }
+   }
+
+   return 1;
+}
+
+static int stbi__free_jpeg_components(stbi__jpeg *z, int ncomp, int why)
+{
+   int i;
+   for (i=0; i < ncomp; ++i) {
+      if (z->img_comp[i].raw_data) {
+         STBI_FREE(z->img_comp[i].raw_data);
+         z->img_comp[i].raw_data = NULL;
+         z->img_comp[i].data = NULL;
+      }
+      if (z->img_comp[i].raw_coeff) {
+         STBI_FREE(z->img_comp[i].raw_coeff);
+         z->img_comp[i].raw_coeff = 0;
+         z->img_comp[i].coeff = 0;
+      }
+      if (z->img_comp[i].linebuf) {
+         STBI_FREE(z->img_comp[i].linebuf);
+         z->img_comp[i].linebuf = NULL;
+      }
+   }
+   return why;
+}
+
+static int stbi__process_frame_header(stbi__jpeg *z, int scan)
+{
+   stbi__context *s = z->s;
+   int Lf,p,i,q, h_max=1,v_max=1,c;
+   Lf = stbi__get16be(s);         if (Lf < 11) return stbi__err("bad SOF len","Corrupt JPEG"); // JPEG
+   p  = stbi__get8(s);            if (p != 8) return stbi__err("only 8-bit","JPEG format not supported: 8-bit only"); // JPEG baseline
+   s->img_y = stbi__get16be(s);   if (s->img_y == 0) return stbi__err("no header height", "JPEG format not supported: delayed height"); // Legal, but we don't handle it--but neither does IJG
+   s->img_x = stbi__get16be(s);   if (s->img_x == 0) return stbi__err("0 width","Corrupt JPEG"); // JPEG requires
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   c = stbi__get8(s);
+   if (c != 3 && c != 1 && c != 4) return stbi__err("bad component count","Corrupt JPEG");
+   s->img_n = c;
+   for (i=0; i < c; ++i) {
+      z->img_comp[i].data = NULL;
+      z->img_comp[i].linebuf = NULL;
+   }
+
+   if (Lf != 8+3*s->img_n) return stbi__err("bad SOF len","Corrupt JPEG");
+
+   z->rgb = 0;
+   for (i=0; i < s->img_n; ++i) {
+      static const unsigned char rgb[3] = { 'R', 'G', 'B' };
+      z->img_comp[i].id = stbi__get8(s);
+      if (s->img_n == 3 && z->img_comp[i].id == rgb[i])
+         ++z->rgb;
+      q = stbi__get8(s);
+      z->img_comp[i].h = (q >> 4);  if (!z->img_comp[i].h || z->img_comp[i].h > 4) return stbi__err("bad H","Corrupt JPEG");
+      z->img_comp[i].v = q & 15;    if (!z->img_comp[i].v || z->img_comp[i].v > 4) return stbi__err("bad V","Corrupt JPEG");
+      z->img_comp[i].tq = stbi__get8(s);  if (z->img_comp[i].tq > 3) return stbi__err("bad TQ","Corrupt JPEG");
+   }
+
+   if (scan != STBI__SCAN_load) return 1;
+
+   if (!stbi__mad3sizes_valid(s->img_x, s->img_y, s->img_n, 0)) return stbi__err("too large", "Image too large to decode");
+
+   for (i=0; i < s->img_n; ++i) {
+      if (z->img_comp[i].h > h_max) h_max = z->img_comp[i].h;
+      if (z->img_comp[i].v > v_max) v_max = z->img_comp[i].v;
+   }
+
+   // check that plane subsampling factors are integer ratios; our resamplers can't deal with fractional ratios
+   // and I've never seen a non-corrupted JPEG file actually use them
+   for (i=0; i < s->img_n; ++i) {
+      if (h_max % z->img_comp[i].h != 0) return stbi__err("bad H","Corrupt JPEG");
+      if (v_max % z->img_comp[i].v != 0) return stbi__err("bad V","Corrupt JPEG");
+   }
+
+   // compute interleaved mcu info
+   z->img_h_max = h_max;
+   z->img_v_max = v_max;
+   z->img_mcu_w = h_max * 8;
+   z->img_mcu_h = v_max * 8;
+   // these sizes can't be more than 17 bits
+   z->img_mcu_x = (s->img_x + z->img_mcu_w-1) / z->img_mcu_w;
+   z->img_mcu_y = (s->img_y + z->img_mcu_h-1) / z->img_mcu_h;
+
+   for (i=0; i < s->img_n; ++i) {
+      // number of effective pixels (e.g. for non-interleaved MCU)
+      z->img_comp[i].x = (s->img_x * z->img_comp[i].h + h_max-1) / h_max;
+      z->img_comp[i].y = (s->img_y * z->img_comp[i].v + v_max-1) / v_max;
+      // to simplify generation, we'll allocate enough memory to decode
+      // the bogus oversized data from using interleaved MCUs and their
+      // big blocks (e.g. a 16x16 iMCU on an image of width 33); we won't
+      // discard the extra data until colorspace conversion
+      //
+      // img_mcu_x, img_mcu_y: <=17 bits; comp[i].h and .v are <=4 (checked earlier)
+      // so these muls can't overflow with 32-bit ints (which we require)
+      z->img_comp[i].w2 = z->img_mcu_x * z->img_comp[i].h * 8;
+      z->img_comp[i].h2 = z->img_mcu_y * z->img_comp[i].v * 8;
+      z->img_comp[i].coeff = 0;
+      z->img_comp[i].raw_coeff = 0;
+      z->img_comp[i].linebuf = NULL;
+      z->img_comp[i].raw_data = stbi__malloc_mad2(z->img_comp[i].w2, z->img_comp[i].h2, 15);
+      if (z->img_comp[i].raw_data == NULL)
+         return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
+      // align blocks for idct using mmx/sse
+      z->img_comp[i].data = (stbi_uc*) (((size_t) z->img_comp[i].raw_data + 15) & ~15);
+      if (z->progressive) {
+         // w2, h2 are multiples of 8 (see above)
+         z->img_comp[i].coeff_w = z->img_comp[i].w2 / 8;
+         z->img_comp[i].coeff_h = z->img_comp[i].h2 / 8;
+         z->img_comp[i].raw_coeff = stbi__malloc_mad3(z->img_comp[i].w2, z->img_comp[i].h2, sizeof(short), 15);
+         if (z->img_comp[i].raw_coeff == NULL)
+            return stbi__free_jpeg_components(z, i+1, stbi__err("outofmem", "Out of memory"));
+         z->img_comp[i].coeff = (short*) (((size_t) z->img_comp[i].raw_coeff + 15) & ~15);
+      }
+   }
+
+   return 1;
+}
+
+// use comparisons since in some cases we handle more than one case (e.g. SOF)
+#define stbi__DNL(x)         ((x) == 0xdc)
+#define stbi__SOI(x)         ((x) == 0xd8)
+#define stbi__EOI(x)         ((x) == 0xd9)
+#define stbi__SOF(x)         ((x) == 0xc0 || (x) == 0xc1 || (x) == 0xc2)
+#define stbi__SOS(x)         ((x) == 0xda)
+
+#define stbi__SOF_progressive(x)   ((x) == 0xc2)
+
+static int stbi__decode_jpeg_header(stbi__jpeg *z, int scan)
+{
+   int m;
+   z->jfif = 0;
+   z->app14_color_transform = -1; // valid values are 0,1,2
+   z->marker = STBI__MARKER_none; // initialize cached marker to empty
+   m = stbi__get_marker(z);
+   if (!stbi__SOI(m)) return stbi__err("no SOI","Corrupt JPEG");
+   if (scan == STBI__SCAN_type) return 1;
+   m = stbi__get_marker(z);
+   while (!stbi__SOF(m)) {
+      if (!stbi__process_marker(z,m)) return 0;
+      m = stbi__get_marker(z);
+      while (m == STBI__MARKER_none) {
+         // some files have extra padding after their blocks, so ok, we'll scan
+         if (stbi__at_eof(z->s)) return stbi__err("no SOF", "Corrupt JPEG");
+         m = stbi__get_marker(z);
+      }
+   }
+   z->progressive = stbi__SOF_progressive(m);
+   if (!stbi__process_frame_header(z, scan)) return 0;
+   return 1;
+}
+
+static stbi_uc stbi__skip_jpeg_junk_at_end(stbi__jpeg *j)
+{
+   // some JPEGs have junk at end, skip over it but if we find what looks
+   // like a valid marker, resume there
+   while (!stbi__at_eof(j->s)) {
+      stbi_uc x = stbi__get8(j->s);
+      while (x == 0xff) { // might be a marker
+         if (stbi__at_eof(j->s)) return STBI__MARKER_none;
+         x = stbi__get8(j->s);
+         if (x != 0x00 && x != 0xff) {
+            // not a stuffed zero or lead-in to another marker, looks
+            // like an actual marker, return it
+            return x;
+         }
+         // stuffed zero has x=0 now which ends the loop, meaning we go
+         // back to regular scan loop.
+         // repeated 0xff keeps trying to read the next byte of the marker.
+      }
+   }
+   return STBI__MARKER_none;
+}
+
+// decode image to YCbCr format
+static int stbi__decode_jpeg_image(stbi__jpeg *j)
+{
+   int m;
+   for (m = 0; m < 4; m++) {
+      j->img_comp[m].raw_data = NULL;
+      j->img_comp[m].raw_coeff = NULL;
+   }
+   j->restart_interval = 0;
+   if (!stbi__decode_jpeg_header(j, STBI__SCAN_load)) return 0;
+   m = stbi__get_marker(j);
+   while (!stbi__EOI(m)) {
+      if (stbi__SOS(m)) {
+         if (!stbi__process_scan_header(j)) return 0;
+         if (!stbi__parse_entropy_coded_data(j)) return 0;
+         if (j->marker == STBI__MARKER_none ) {
+         j->marker = stbi__skip_jpeg_junk_at_end(j);
+            // if we reach eof without hitting a marker, stbi__get_marker() below will fail and we'll eventually return 0
+         }
+         m = stbi__get_marker(j);
+         if (STBI__RESTART(m))
+            m = stbi__get_marker(j);
+      } else if (stbi__DNL(m)) {
+         int Ld = stbi__get16be(j->s);
+         stbi__uint32 NL = stbi__get16be(j->s);
+         if (Ld != 4) return stbi__err("bad DNL len", "Corrupt JPEG");
+         if (NL != j->s->img_y) return stbi__err("bad DNL height", "Corrupt JPEG");
+         m = stbi__get_marker(j);
+      } else {
+         if (!stbi__process_marker(j, m)) return 1;
+         m = stbi__get_marker(j);
+      }
+   }
+   if (j->progressive)
+      stbi__jpeg_finish(j);
+   return 1;
+}
+
+// static jfif-centered resampling (across block boundaries)
+
+typedef stbi_uc *(*resample_row_func)(stbi_uc *out, stbi_uc *in0, stbi_uc *in1,
+                                    int w, int hs);
+
+#define stbi__div4(x) ((stbi_uc) ((x) >> 2))
+
+static stbi_uc *resample_row_1(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   STBI_NOTUSED(out);
+   STBI_NOTUSED(in_far);
+   STBI_NOTUSED(w);
+   STBI_NOTUSED(hs);
+   return in_near;
+}
+
+static stbi_uc* stbi__resample_row_v_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate two samples vertically for every one in input
+   int i;
+   STBI_NOTUSED(hs);
+   for (i=0; i < w; ++i)
+      out[i] = stbi__div4(3*in_near[i] + in_far[i] + 2);
+   return out;
+}
+
+static stbi_uc*  stbi__resample_row_h_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate two samples horizontally for every one in input
+   int i;
+   stbi_uc *input = in_near;
+
+   if (w == 1) {
+      // if only one sample, can't do any interpolation
+      out[0] = out[1] = input[0];
+      return out;
+   }
+
+   out[0] = input[0];
+   out[1] = stbi__div4(input[0]*3 + input[1] + 2);
+   for (i=1; i < w-1; ++i) {
+      int n = 3*input[i]+2;
+      out[i*2+0] = stbi__div4(n+input[i-1]);
+      out[i*2+1] = stbi__div4(n+input[i+1]);
+   }
+   out[i*2+0] = stbi__div4(input[w-2]*3 + input[w-1] + 2);
+   out[i*2+1] = input[w-1];
+
+   STBI_NOTUSED(in_far);
+   STBI_NOTUSED(hs);
+
+   return out;
+}
+
+#define stbi__div16(x) ((stbi_uc) ((x) >> 4))
+
+static stbi_uc *stbi__resample_row_hv_2(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate 2x2 samples for every one in input
+   int i,t0,t1;
+   if (w == 1) {
+      out[0] = out[1] = stbi__div4(3*in_near[0] + in_far[0] + 2);
+      return out;
+   }
+
+   t1 = 3*in_near[0] + in_far[0];
+   out[0] = stbi__div4(t1+2);
+   for (i=1; i < w; ++i) {
+      t0 = t1;
+      t1 = 3*in_near[i]+in_far[i];
+      out[i*2-1] = stbi__div16(3*t0 + t1 + 8);
+      out[i*2  ] = stbi__div16(3*t1 + t0 + 8);
+   }
+   out[w*2-1] = stbi__div4(t1+2);
+
+   STBI_NOTUSED(hs);
+
+   return out;
+}
+
+#if defined(STBI_SSE2) || defined(STBI_NEON)
+static stbi_uc *stbi__resample_row_hv_2_simd(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // need to generate 2x2 samples for every one in input
+   int i=0,t0,t1;
+
+   if (w == 1) {
+      out[0] = out[1] = stbi__div4(3*in_near[0] + in_far[0] + 2);
+      return out;
+   }
+
+   t1 = 3*in_near[0] + in_far[0];
+   // process groups of 8 pixels for as long as we can.
+   // note we can't handle the last pixel in a row in this loop
+   // because we need to handle the filter boundary conditions.
+   for (; i < ((w-1) & ~7); i += 8) {
+#if defined(STBI_SSE2)
+      // load and perform the vertical filtering pass
+      // this uses 3*x + y = 4*x + (y - x)
+      __m128i zero  = _mm_setzero_si128();
+      __m128i farb  = _mm_loadl_epi64((__m128i *) (in_far + i));
+      __m128i nearb = _mm_loadl_epi64((__m128i *) (in_near + i));
+      __m128i farw  = _mm_unpacklo_epi8(farb, zero);
+      __m128i nearw = _mm_unpacklo_epi8(nearb, zero);
+      __m128i diff  = _mm_sub_epi16(farw, nearw);
+      __m128i nears = _mm_slli_epi16(nearw, 2);
+      __m128i curr  = _mm_add_epi16(nears, diff); // current row
+
+      // horizontal filter works the same based on shifted vers of current
+      // row. "prev" is current row shifted right by 1 pixel; we need to
+      // insert the previous pixel value (from t1).
+      // "next" is current row shifted left by 1 pixel, with first pixel
+      // of next block of 8 pixels added in.
+      __m128i prv0 = _mm_slli_si128(curr, 2);
+      __m128i nxt0 = _mm_srli_si128(curr, 2);
+      __m128i prev = _mm_insert_epi16(prv0, t1, 0);
+      __m128i next = _mm_insert_epi16(nxt0, 3*in_near[i+8] + in_far[i+8], 7);
+
+      // horizontal filter, polyphase implementation since it's convenient:
+      // even pixels = 3*cur + prev = cur*4 + (prev - cur)
+      // odd  pixels = 3*cur + next = cur*4 + (next - cur)
+      // note the shared term.
+      __m128i bias  = _mm_set1_epi16(8);
+      __m128i curs = _mm_slli_epi16(curr, 2);
+      __m128i prvd = _mm_sub_epi16(prev, curr);
+      __m128i nxtd = _mm_sub_epi16(next, curr);
+      __m128i curb = _mm_add_epi16(curs, bias);
+      __m128i even = _mm_add_epi16(prvd, curb);
+      __m128i odd  = _mm_add_epi16(nxtd, curb);
+
+      // interleave even and odd pixels, then undo scaling.
+      __m128i int0 = _mm_unpacklo_epi16(even, odd);
+      __m128i int1 = _mm_unpackhi_epi16(even, odd);
+      __m128i de0  = _mm_srli_epi16(int0, 4);
+      __m128i de1  = _mm_srli_epi16(int1, 4);
+
+      // pack and write output
+      __m128i outv = _mm_packus_epi16(de0, de1);
+      _mm_storeu_si128((__m128i *) (out + i*2), outv);
+#elif defined(STBI_NEON)
+      // load and perform the vertical filtering pass
+      // this uses 3*x + y = 4*x + (y - x)
+      uint8x8_t farb  = vld1_u8(in_far + i);
+      uint8x8_t nearb = vld1_u8(in_near + i);
+      int16x8_t diff  = vreinterpretq_s16_u16(vsubl_u8(farb, nearb));
+      int16x8_t nears = vreinterpretq_s16_u16(vshll_n_u8(nearb, 2));
+      int16x8_t curr  = vaddq_s16(nears, diff); // current row
+
+      // horizontal filter works the same based on shifted vers of current
+      // row. "prev" is current row shifted right by 1 pixel; we need to
+      // insert the previous pixel value (from t1).
+      // "next" is current row shifted left by 1 pixel, with first pixel
+      // of next block of 8 pixels added in.
+      int16x8_t prv0 = vextq_s16(curr, curr, 7);
+      int16x8_t nxt0 = vextq_s16(curr, curr, 1);
+      int16x8_t prev = vsetq_lane_s16(t1, prv0, 0);
+      int16x8_t next = vsetq_lane_s16(3*in_near[i+8] + in_far[i+8], nxt0, 7);
+
+      // horizontal filter, polyphase implementation since it's convenient:
+      // even pixels = 3*cur + prev = cur*4 + (prev - cur)
+      // odd  pixels = 3*cur + next = cur*4 + (next - cur)
+      // note the shared term.
+      int16x8_t curs = vshlq_n_s16(curr, 2);
+      int16x8_t prvd = vsubq_s16(prev, curr);
+      int16x8_t nxtd = vsubq_s16(next, curr);
+      int16x8_t even = vaddq_s16(curs, prvd);
+      int16x8_t odd  = vaddq_s16(curs, nxtd);
+
+      // undo scaling and round, then store with even/odd phases interleaved
+      uint8x8x2_t o;
+      o.val[0] = vqrshrun_n_s16(even, 4);
+      o.val[1] = vqrshrun_n_s16(odd,  4);
+      vst2_u8(out + i*2, o);
+#endif
+
+      // "previous" value for next iter
+      t1 = 3*in_near[i+7] + in_far[i+7];
+   }
+
+   t0 = t1;
+   t1 = 3*in_near[i] + in_far[i];
+   out[i*2] = stbi__div16(3*t1 + t0 + 8);
+
+   for (++i; i < w; ++i) {
+      t0 = t1;
+      t1 = 3*in_near[i]+in_far[i];
+      out[i*2-1] = stbi__div16(3*t0 + t1 + 8);
+      out[i*2  ] = stbi__div16(3*t1 + t0 + 8);
+   }
+   out[w*2-1] = stbi__div4(t1+2);
+
+   STBI_NOTUSED(hs);
+
+   return out;
+}
+#endif
+
+static stbi_uc *stbi__resample_row_generic(stbi_uc *out, stbi_uc *in_near, stbi_uc *in_far, int w, int hs)
+{
+   // resample with nearest-neighbor
+   int i,j;
+   STBI_NOTUSED(in_far);
+   for (i=0; i < w; ++i)
+      for (j=0; j < hs; ++j)
+         out[i*hs+j] = in_near[i];
+   return out;
+}
+
+// this is a reduced-precision calculation of YCbCr-to-RGB introduced
+// to make sure the code produces the same results in both SIMD and scalar
+#define stbi__float2fixed(x)  (((int) ((x) * 4096.0f + 0.5f)) << 8)
+static void stbi__YCbCr_to_RGB_row(stbi_uc *out, const stbi_uc *y, const stbi_uc *pcb, const stbi_uc *pcr, int count, int step)
+{
+   int i;
+   for (i=0; i < count; ++i) {
+      int y_fixed = (y[i] << 20) + (1<<19); // rounding
+      int r,g,b;
+      int cr = pcr[i] - 128;
+      int cb = pcb[i] - 128;
+      r = y_fixed +  cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + (cr*-stbi__float2fixed(0.71414f)) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                     +   cb* stbi__float2fixed(1.77200f);
+      r >>= 20;
+      g >>= 20;
+      b >>= 20;
+      if ((unsigned) r > 255) { if (r < 0) r = 0; else r = 255; }
+      if ((unsigned) g > 255) { if (g < 0) g = 0; else g = 255; }
+      if ((unsigned) b > 255) { if (b < 0) b = 0; else b = 255; }
+      out[0] = (stbi_uc)r;
+      out[1] = (stbi_uc)g;
+      out[2] = (stbi_uc)b;
+      out[3] = 255;
+      out += step;
+   }
+}
+
+#if defined(STBI_SSE2) || defined(STBI_NEON)
+static void stbi__YCbCr_to_RGB_simd(stbi_uc *out, stbi_uc const *y, stbi_uc const *pcb, stbi_uc const *pcr, int count, int step)
+{
+   int i = 0;
+
+#ifdef STBI_SSE2
+   // step == 3 is pretty ugly on the final interleave, and i'm not convinced
+   // it's useful in practice (you wouldn't use it for textures, for example).
+   // so just accelerate step == 4 case.
+   if (step == 4) {
+      // this is a fairly straightforward implementation and not super-optimized.
+      __m128i signflip  = _mm_set1_epi8(-0x80);
+      __m128i cr_const0 = _mm_set1_epi16(   (short) ( 1.40200f*4096.0f+0.5f));
+      __m128i cr_const1 = _mm_set1_epi16( - (short) ( 0.71414f*4096.0f+0.5f));
+      __m128i cb_const0 = _mm_set1_epi16( - (short) ( 0.34414f*4096.0f+0.5f));
+      __m128i cb_const1 = _mm_set1_epi16(   (short) ( 1.77200f*4096.0f+0.5f));
+      __m128i y_bias = _mm_set1_epi8((char) (unsigned char) 128);
+      __m128i xw = _mm_set1_epi16(255); // alpha channel
+
+      for (; i+7 < count; i += 8) {
+         // load
+         __m128i y_bytes = _mm_loadl_epi64((__m128i *) (y+i));
+         __m128i cr_bytes = _mm_loadl_epi64((__m128i *) (pcr+i));
+         __m128i cb_bytes = _mm_loadl_epi64((__m128i *) (pcb+i));
+         __m128i cr_biased = _mm_xor_si128(cr_bytes, signflip); // -128
+         __m128i cb_biased = _mm_xor_si128(cb_bytes, signflip); // -128
+
+         // unpack to short (and left-shift cr, cb by 8)
+         __m128i yw  = _mm_unpacklo_epi8(y_bias, y_bytes);
+         __m128i crw = _mm_unpacklo_epi8(_mm_setzero_si128(), cr_biased);
+         __m128i cbw = _mm_unpacklo_epi8(_mm_setzero_si128(), cb_biased);
+
+         // color transform
+         __m128i yws = _mm_srli_epi16(yw, 4);
+         __m128i cr0 = _mm_mulhi_epi16(cr_const0, crw);
+         __m128i cb0 = _mm_mulhi_epi16(cb_const0, cbw);
+         __m128i cb1 = _mm_mulhi_epi16(cbw, cb_const1);
+         __m128i cr1 = _mm_mulhi_epi16(crw, cr_const1);
+         __m128i rws = _mm_add_epi16(cr0, yws);
+         __m128i gwt = _mm_add_epi16(cb0, yws);
+         __m128i bws = _mm_add_epi16(yws, cb1);
+         __m128i gws = _mm_add_epi16(gwt, cr1);
+
+         // descale
+         __m128i rw = _mm_srai_epi16(rws, 4);
+         __m128i bw = _mm_srai_epi16(bws, 4);
+         __m128i gw = _mm_srai_epi16(gws, 4);
+
+         // back to byte, set up for transpose
+         __m128i brb = _mm_packus_epi16(rw, bw);
+         __m128i gxb = _mm_packus_epi16(gw, xw);
+
+         // transpose to interleave channels
+         __m128i t0 = _mm_unpacklo_epi8(brb, gxb);
+         __m128i t1 = _mm_unpackhi_epi8(brb, gxb);
+         __m128i o0 = _mm_unpacklo_epi16(t0, t1);
+         __m128i o1 = _mm_unpackhi_epi16(t0, t1);
+
+         // store
+         _mm_storeu_si128((__m128i *) (out + 0), o0);
+         _mm_storeu_si128((__m128i *) (out + 16), o1);
+         out += 32;
+      }
+   }
+#endif
+
+#ifdef STBI_NEON
+   // in this version, step=3 support would be easy to add. but is there demand?
+   if (step == 4) {
+      // this is a fairly straightforward implementation and not super-optimized.
+      uint8x8_t signflip = vdup_n_u8(0x80);
+      int16x8_t cr_const0 = vdupq_n_s16(   (short) ( 1.40200f*4096.0f+0.5f));
+      int16x8_t cr_const1 = vdupq_n_s16( - (short) ( 0.71414f*4096.0f+0.5f));
+      int16x8_t cb_const0 = vdupq_n_s16( - (short) ( 0.34414f*4096.0f+0.5f));
+      int16x8_t cb_const1 = vdupq_n_s16(   (short) ( 1.77200f*4096.0f+0.5f));
+
+      for (; i+7 < count; i += 8) {
+         // load
+         uint8x8_t y_bytes  = vld1_u8(y + i);
+         uint8x8_t cr_bytes = vld1_u8(pcr + i);
+         uint8x8_t cb_bytes = vld1_u8(pcb + i);
+         int8x8_t cr_biased = vreinterpret_s8_u8(vsub_u8(cr_bytes, signflip));
+         int8x8_t cb_biased = vreinterpret_s8_u8(vsub_u8(cb_bytes, signflip));
+
+         // expand to s16
+         int16x8_t yws = vreinterpretq_s16_u16(vshll_n_u8(y_bytes, 4));
+         int16x8_t crw = vshll_n_s8(cr_biased, 7);
+         int16x8_t cbw = vshll_n_s8(cb_biased, 7);
+
+         // color transform
+         int16x8_t cr0 = vqdmulhq_s16(crw, cr_const0);
+         int16x8_t cb0 = vqdmulhq_s16(cbw, cb_const0);
+         int16x8_t cr1 = vqdmulhq_s16(crw, cr_const1);
+         int16x8_t cb1 = vqdmulhq_s16(cbw, cb_const1);
+         int16x8_t rws = vaddq_s16(yws, cr0);
+         int16x8_t gws = vaddq_s16(vaddq_s16(yws, cb0), cr1);
+         int16x8_t bws = vaddq_s16(yws, cb1);
+
+         // undo scaling, round, convert to byte
+         uint8x8x4_t o;
+         o.val[0] = vqrshrun_n_s16(rws, 4);
+         o.val[1] = vqrshrun_n_s16(gws, 4);
+         o.val[2] = vqrshrun_n_s16(bws, 4);
+         o.val[3] = vdup_n_u8(255);
+
+         // store, interleaving r/g/b/a
+         vst4_u8(out, o);
+         out += 8*4;
+      }
+   }
+#endif
+
+   for (; i < count; ++i) {
+      int y_fixed = (y[i] << 20) + (1<<19); // rounding
+      int r,g,b;
+      int cr = pcr[i] - 128;
+      int cb = pcb[i] - 128;
+      r = y_fixed + cr* stbi__float2fixed(1.40200f);
+      g = y_fixed + cr*-stbi__float2fixed(0.71414f) + ((cb*-stbi__float2fixed(0.34414f)) & 0xffff0000);
+      b = y_fixed                                   +   cb* stbi__float2fixed(1.77200f);
+      r >>= 20;
+      g >>= 20;
+      b >>= 20;
+      if ((unsigned) r > 255) { if (r < 0) r = 0; else r = 255; }
+      if ((unsigned) g > 255) { if (g < 0) g = 0; else g = 255; }
+      if ((unsigned) b > 255) { if (b < 0) b = 0; else b = 255; }
+      out[0] = (stbi_uc)r;
+      out[1] = (stbi_uc)g;
+      out[2] = (stbi_uc)b;
+      out[3] = 255;
+      out += step;
+   }
+}
+#endif
+
+// set up the kernels
+static void stbi__setup_jpeg(stbi__jpeg *j)
+{
+   j->idct_block_kernel = stbi__idct_block;
+   j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_row;
+   j->resample_row_hv_2_kernel = stbi__resample_row_hv_2;
+
+#ifdef STBI_SSE2
+   if (stbi__sse2_available()) {
+      j->idct_block_kernel = stbi__idct_simd;
+      j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
+      j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
+   }
+#endif
+
+#ifdef STBI_NEON
+   j->idct_block_kernel = stbi__idct_simd;
+   j->YCbCr_to_RGB_kernel = stbi__YCbCr_to_RGB_simd;
+   j->resample_row_hv_2_kernel = stbi__resample_row_hv_2_simd;
+#endif
+}
+
+// clean up the temporary component buffers
+static void stbi__cleanup_jpeg(stbi__jpeg *j)
+{
+   stbi__free_jpeg_components(j, j->s->img_n, 0);
+}
+
+typedef struct
+{
+   resample_row_func resample;
+   stbi_uc *line0,*line1;
+   int hs,vs;   // expansion factor in each axis
+   int w_lores; // horizontal pixels pre-expansion
+   int ystep;   // how far through vertical expansion we are
+   int ypos;    // which pre-expansion row we're on
+} stbi__resample;
+
+// fast 0..255 * 0..255 => 0..255 rounded multiplication
+static stbi_uc stbi__blinn_8x8(stbi_uc x, stbi_uc y)
+{
+   unsigned int t = x*y + 128;
+   return (stbi_uc) ((t + (t >>8)) >> 8);
+}
+
+static stbi_uc *load_jpeg_image(stbi__jpeg *z, int *out_x, int *out_y, int *comp, int req_comp)
+{
+   int n, decode_n, is_rgb;
+   z->s->img_n = 0; // make stbi__cleanup_jpeg safe
+
+   // validate req_comp
+   if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
+
+   // load a jpeg image from whichever source, but leave in YCbCr format
+   if (!stbi__decode_jpeg_image(z)) { stbi__cleanup_jpeg(z); return NULL; }
+
+   // determine actual number of components to generate
+   n = req_comp ? req_comp : z->s->img_n >= 3 ? 3 : 1;
+
+   is_rgb = z->s->img_n == 3 && (z->rgb == 3 || (z->app14_color_transform == 0 && !z->jfif));
+
+   if (z->s->img_n == 3 && n < 3 && !is_rgb)
+      decode_n = 1;
+   else
+      decode_n = z->s->img_n;
+
+   // nothing to do if no components requested; check this now to avoid
+   // accessing uninitialized coutput[0] later
+   if (decode_n <= 0) { stbi__cleanup_jpeg(z); return NULL; }
+
+   // resample and color-convert
+   {
+      int k;
+      unsigned int i,j;
+      stbi_uc *output;
+      stbi_uc *coutput[4] = { NULL, NULL, NULL, NULL };
+
+      stbi__resample res_comp[4];
+
+      for (k=0; k < decode_n; ++k) {
+         stbi__resample *r = &res_comp[k];
+
+         // allocate line buffer big enough for upsampling off the edges
+         // with upsample factor of 4
+         z->img_comp[k].linebuf = (stbi_uc *) stbi__malloc(z->s->img_x + 3);
+         if (!z->img_comp[k].linebuf) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
+
+         r->hs      = z->img_h_max / z->img_comp[k].h;
+         r->vs      = z->img_v_max / z->img_comp[k].v;
+         r->ystep   = r->vs >> 1;
+         r->w_lores = (z->s->img_x + r->hs-1) / r->hs;
+         r->ypos    = 0;
+         r->line0   = r->line1 = z->img_comp[k].data;
+
+         if      (r->hs == 1 && r->vs == 1) r->resample = resample_row_1;
+         else if (r->hs == 1 && r->vs == 2) r->resample = stbi__resample_row_v_2;
+         else if (r->hs == 2 && r->vs == 1) r->resample = stbi__resample_row_h_2;
+         else if (r->hs == 2 && r->vs == 2) r->resample = z->resample_row_hv_2_kernel;
+         else                               r->resample = stbi__resample_row_generic;
+      }
+
+      // can't error after this so, this is safe
+      output = (stbi_uc *) stbi__malloc_mad3(n, z->s->img_x, z->s->img_y, 1);
+      if (!output) { stbi__cleanup_jpeg(z); return stbi__errpuc("outofmem", "Out of memory"); }
+
+      // now go ahead and resample
+      for (j=0; j < z->s->img_y; ++j) {
+         stbi_uc *out = output + n * z->s->img_x * j;
+         for (k=0; k < decode_n; ++k) {
+            stbi__resample *r = &res_comp[k];
+            int y_bot = r->ystep >= (r->vs >> 1);
+            coutput[k] = r->resample(z->img_comp[k].linebuf,
+                                     y_bot ? r->line1 : r->line0,
+                                     y_bot ? r->line0 : r->line1,
+                                     r->w_lores, r->hs);
+            if (++r->ystep >= r->vs) {
+               r->ystep = 0;
+               r->line0 = r->line1;
+               if (++r->ypos < z->img_comp[k].y)
+                  r->line1 += z->img_comp[k].w2;
+            }
+         }
+         if (n >= 3) {
+            stbi_uc *y = coutput[0];
+            if (z->s->img_n == 3) {
+               if (is_rgb) {
+                  for (i=0; i < z->s->img_x; ++i) {
+                     out[0] = y[i];
+                     out[1] = coutput[1][i];
+                     out[2] = coutput[2][i];
+                     out[3] = 255;
+                     out += n;
+                  }
+               } else {
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+               }
+            } else if (z->s->img_n == 4) {
+               if (z->app14_color_transform == 0) { // CMYK
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(coutput[0][i], m);
+                     out[1] = stbi__blinn_8x8(coutput[1][i], m);
+                     out[2] = stbi__blinn_8x8(coutput[2][i], m);
+                     out[3] = 255;
+                     out += n;
+                  }
+               } else if (z->app14_color_transform == 2) { // YCCK
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+                  for (i=0; i < z->s->img_x; ++i) {
+                     stbi_uc m = coutput[3][i];
+                     out[0] = stbi__blinn_8x8(255 - out[0], m);
+                     out[1] = stbi__blinn_8x8(255 - out[1], m);
+                     out[2] = stbi__blinn_8x8(255 - out[2], m);
+                     out += n;
+                  }
+               } else { // YCbCr + alpha?  Ignore the fourth channel for now
+                  z->YCbCr_to_RGB_kernel(out, y, coutput[1], coutput[2], z->s->img_x, n);
+               }
+            } else
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = out[1] = out[2] = y[i];
+                  out[3] = 255; // not used if n==3
+                  out += n;
+               }
+         } else {
+            if (is_rgb) {
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i)
+                     *out++ = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+               else {
+                  for (i=0; i < z->s->img_x; ++i, out += 2) {
+                     out[0] = stbi__compute_y(coutput[0][i], coutput[1][i], coutput[2][i]);
+                     out[1] = 255;
+                  }
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 0) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  stbi_uc m = coutput[3][i];
+                  stbi_uc r = stbi__blinn_8x8(coutput[0][i], m);
+                  stbi_uc g = stbi__blinn_8x8(coutput[1][i], m);
+                  stbi_uc b = stbi__blinn_8x8(coutput[2][i], m);
+                  out[0] = stbi__compute_y(r, g, b);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else if (z->s->img_n == 4 && z->app14_color_transform == 2) {
+               for (i=0; i < z->s->img_x; ++i) {
+                  out[0] = stbi__blinn_8x8(255 - coutput[0][i], coutput[3][i]);
+                  out[1] = 255;
+                  out += n;
+               }
+            } else {
+               stbi_uc *y = coutput[0];
+               if (n == 1)
+                  for (i=0; i < z->s->img_x; ++i) out[i] = y[i];
+               else
+                  for (i=0; i < z->s->img_x; ++i) { *out++ = y[i]; *out++ = 255; }
+            }
+         }
+      }
+      stbi__cleanup_jpeg(z);
+      *out_x = z->s->img_x;
+      *out_y = z->s->img_y;
+      if (comp) *comp = z->s->img_n >= 3 ? 3 : 1; // report original components, not output
+      return output;
+   }
+}
+
+static void *stbi__jpeg_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   unsigned char* result;
+   stbi__jpeg* j = (stbi__jpeg*) stbi__malloc(sizeof(stbi__jpeg));
+   if (!j) return stbi__errpuc("outofmem", "Out of memory");
+   memset(j, 0, sizeof(stbi__jpeg));
+   STBI_NOTUSED(ri);
+   j->s = s;
+   stbi__setup_jpeg(j);
+   result = load_jpeg_image(j, x,y,comp,req_comp);
+   STBI_FREE(j);
+   return result;
+}
+
+static int stbi__jpeg_test(stbi__context *s)
+{
+   int r;
+   stbi__jpeg* j = (stbi__jpeg*)stbi__malloc(sizeof(stbi__jpeg));
+   if (!j) return stbi__err("outofmem", "Out of memory");
+   memset(j, 0, sizeof(stbi__jpeg));
+   j->s = s;
+   stbi__setup_jpeg(j);
+   r = stbi__decode_jpeg_header(j, STBI__SCAN_type);
+   stbi__rewind(s);
+   STBI_FREE(j);
+   return r;
+}
+
+static int stbi__jpeg_info_raw(stbi__jpeg *j, int *x, int *y, int *comp)
+{
+   if (!stbi__decode_jpeg_header(j, STBI__SCAN_header)) {
+      stbi__rewind( j->s );
+      return 0;
+   }
+   if (x) *x = j->s->img_x;
+   if (y) *y = j->s->img_y;
+   if (comp) *comp = j->s->img_n >= 3 ? 3 : 1;
+   return 1;
+}
+
+static int stbi__jpeg_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int result;
+   stbi__jpeg* j = (stbi__jpeg*) (stbi__malloc(sizeof(stbi__jpeg)));
+   if (!j) return stbi__err("outofmem", "Out of memory");
+   memset(j, 0, sizeof(stbi__jpeg));
+   j->s = s;
+   result = stbi__jpeg_info_raw(j, x, y, comp);
+   STBI_FREE(j);
+   return result;
+}
+#endif
+
+// public domain zlib decode    v0.2  Sean Barrett 2006-11-18
+//    simple implementation
+//      - all input must be provided in an upfront buffer
+//      - all output is written to a single output buffer (can malloc/realloc)
+//    performance
+//      - fast huffman
+
+#ifndef STBI_NO_ZLIB
+
+// fast-way is faster to check than jpeg huffman, but slow way is slower
+#define STBI__ZFAST_BITS  9 // accelerate all cases in default tables
+#define STBI__ZFAST_MASK  ((1 << STBI__ZFAST_BITS) - 1)
+#define STBI__ZNSYMS 288 // number of symbols in literal/length alphabet
+
+// zlib-style huffman encoding
+// (jpegs packs from left, zlib from right, so can't share code)
+typedef struct
+{
+   stbi__uint16 fast[1 << STBI__ZFAST_BITS];
+   stbi__uint16 firstcode[16];
+   int maxcode[17];
+   stbi__uint16 firstsymbol[16];
+   stbi_uc  size[STBI__ZNSYMS];
+   stbi__uint16 value[STBI__ZNSYMS];
+} stbi__zhuffman;
+
+stbi_inline static int stbi__bitreverse16(int n)
+{
+  n = ((n & 0xAAAA) >>  1) | ((n & 0x5555) << 1);
+  n = ((n & 0xCCCC) >>  2) | ((n & 0x3333) << 2);
+  n = ((n & 0xF0F0) >>  4) | ((n & 0x0F0F) << 4);
+  n = ((n & 0xFF00) >>  8) | ((n & 0x00FF) << 8);
+  return n;
+}
+
+stbi_inline static int stbi__bit_reverse(int v, int bits)
+{
+   STBI_ASSERT(bits <= 16);
+   // to bit reverse n bits, reverse 16 and shift
+   // e.g. 11 bits, bit reverse and shift away 5
+   return stbi__bitreverse16(v) >> (16-bits);
+}
+
+static int stbi__zbuild_huffman(stbi__zhuffman *z, const stbi_uc *sizelist, int num)
+{
+   int i,k=0;
+   int code, next_code[16], sizes[17];
+
+   // DEFLATE spec for generating codes
+   memset(sizes, 0, sizeof(sizes));
+   memset(z->fast, 0, sizeof(z->fast));
+   for (i=0; i < num; ++i)
+      ++sizes[sizelist[i]];
+   sizes[0] = 0;
+   for (i=1; i < 16; ++i)
+      if (sizes[i] > (1 << i))
+         return stbi__err("bad sizes", "Corrupt PNG");
+   code = 0;
+   for (i=1; i < 16; ++i) {
+      next_code[i] = code;
+      z->firstcode[i] = (stbi__uint16) code;
+      z->firstsymbol[i] = (stbi__uint16) k;
+      code = (code + sizes[i]);
+      if (sizes[i])
+         if (code-1 >= (1 << i)) return stbi__err("bad codelengths","Corrupt PNG");
+      z->maxcode[i] = code << (16-i); // preshift for inner loop
+      code <<= 1;
+      k += sizes[i];
+   }
+   z->maxcode[16] = 0x10000; // sentinel
+   for (i=0; i < num; ++i) {
+      int s = sizelist[i];
+      if (s) {
+         int c = next_code[s] - z->firstcode[s] + z->firstsymbol[s];
+         stbi__uint16 fastv = (stbi__uint16) ((s << 9) | i);
+         z->size [c] = (stbi_uc     ) s;
+         z->value[c] = (stbi__uint16) i;
+         if (s <= STBI__ZFAST_BITS) {
+            int j = stbi__bit_reverse(next_code[s],s);
+            while (j < (1 << STBI__ZFAST_BITS)) {
+               z->fast[j] = fastv;
+               j += (1 << s);
+            }
+         }
+         ++next_code[s];
+      }
+   }
+   return 1;
+}
+
+// zlib-from-memory implementation for PNG reading
+//    because PNG allows splitting the zlib stream arbitrarily,
+//    and it's annoying structurally to have PNG call ZLIB call PNG,
+//    we require PNG read all the IDATs and combine them into a single
+//    memory buffer
+
+typedef struct
+{
+   stbi_uc *zbuffer, *zbuffer_end;
+   int num_bits;
+   int hit_zeof_once;
+   stbi__uint32 code_buffer;
+
+   char *zout;
+   char *zout_start;
+   char *zout_end;
+   int   z_expandable;
+
+   stbi__zhuffman z_length, z_distance;
+} stbi__zbuf;
+
+stbi_inline static int stbi__zeof(stbi__zbuf *z)
+{
+   return (z->zbuffer >= z->zbuffer_end);
+}
+
+stbi_inline static stbi_uc stbi__zget8(stbi__zbuf *z)
+{
+   return stbi__zeof(z) ? 0 : *z->zbuffer++;
+}
+
+static void stbi__fill_bits(stbi__zbuf *z)
+{
+   do {
+      if (z->code_buffer >= (1U << z->num_bits)) {
+        z->zbuffer = z->zbuffer_end;  /* treat this as EOF so we fail. */
+        return;
+      }
+      z->code_buffer |= (unsigned int) stbi__zget8(z) << z->num_bits;
+      z->num_bits += 8;
+   } while (z->num_bits <= 24);
+}
+
+stbi_inline static unsigned int stbi__zreceive(stbi__zbuf *z, int n)
+{
+   unsigned int k;
+   if (z->num_bits < n) stbi__fill_bits(z);
+   k = z->code_buffer & ((1 << n) - 1);
+   z->code_buffer >>= n;
+   z->num_bits -= n;
+   return k;
+}
+
+static int stbi__zhuffman_decode_slowpath(stbi__zbuf *a, stbi__zhuffman *z)
+{
+   int b,s,k;
+   // not resolved by fast table, so compute it the slow way
+   // use jpeg approach, which requires MSbits at top
+   k = stbi__bit_reverse(a->code_buffer, 16);
+   for (s=STBI__ZFAST_BITS+1; ; ++s)
+      if (k < z->maxcode[s])
+         break;
+   if (s >= 16) return -1; // invalid code!
+   // code size is s, so:
+   b = (k >> (16-s)) - z->firstcode[s] + z->firstsymbol[s];
+   if (b >= STBI__ZNSYMS) return -1; // some data was corrupt somewhere!
+   if (z->size[b] != s) return -1;  // was originally an assert, but report failure instead.
+   a->code_buffer >>= s;
+   a->num_bits -= s;
+   return z->value[b];
+}
+
+stbi_inline static int stbi__zhuffman_decode(stbi__zbuf *a, stbi__zhuffman *z)
+{
+   int b,s;
+   if (a->num_bits < 16) {
+      if (stbi__zeof(a)) {
+         if (!a->hit_zeof_once) {
+            // This is the first time we hit eof, insert 16 extra padding btis
+            // to allow us to keep going; if we actually consume any of them
+            // though, that is invalid data. This is caught later.
+            a->hit_zeof_once = 1;
+            a->num_bits += 16; // add 16 implicit zero bits
+         } else {
+            // We already inserted our extra 16 padding bits and are again
+            // out, this stream is actually prematurely terminated.
+            return -1;
+         }
+      } else {
+         stbi__fill_bits(a);
+      }
+   }
+   b = z->fast[a->code_buffer & STBI__ZFAST_MASK];
+   if (b) {
+      s = b >> 9;
+      a->code_buffer >>= s;
+      a->num_bits -= s;
+      return b & 511;
+   }
+   return stbi__zhuffman_decode_slowpath(a, z);
+}
+
+static int stbi__zexpand(stbi__zbuf *z, char *zout, int n)  // need to make room for n bytes
+{
+   char *q;
+   unsigned int cur, limit, old_limit;
+   z->zout = zout;
+   if (!z->z_expandable) return stbi__err("output buffer limit","Corrupt PNG");
+   cur   = (unsigned int) (z->zout - z->zout_start);
+   limit = old_limit = (unsigned) (z->zout_end - z->zout_start);
+   if (UINT_MAX - cur < (unsigned) n) return stbi__err("outofmem", "Out of memory");
+   while (cur + n > limit) {
+      if(limit > UINT_MAX / 2) return stbi__err("outofmem", "Out of memory");
+      limit *= 2;
+   }
+   q = (char *) STBI_REALLOC_SIZED(z->zout_start, old_limit, limit);
+   STBI_NOTUSED(old_limit);
+   if (q == NULL) return stbi__err("outofmem", "Out of memory");
+   z->zout_start = q;
+   z->zout       = q + cur;
+   z->zout_end   = q + limit;
+   return 1;
+}
+
+static const int stbi__zlength_base[31] = {
+   3,4,5,6,7,8,9,10,11,13,
+   15,17,19,23,27,31,35,43,51,59,
+   67,83,99,115,131,163,195,227,258,0,0 };
+
+static const int stbi__zlength_extra[31]=
+{ 0,0,0,0,0,0,0,0,1,1,1,1,2,2,2,2,3,3,3,3,4,4,4,4,5,5,5,5,0,0,0 };
+
+static const int stbi__zdist_base[32] = { 1,2,3,4,5,7,9,13,17,25,33,49,65,97,129,193,
+257,385,513,769,1025,1537,2049,3073,4097,6145,8193,12289,16385,24577,0,0};
+
+static const int stbi__zdist_extra[32] =
+{ 0,0,0,0,1,1,2,2,3,3,4,4,5,5,6,6,7,7,8,8,9,9,10,10,11,11,12,12,13,13};
+
+static int stbi__parse_huffman_block(stbi__zbuf *a)
+{
+   char *zout = a->zout;
+   for(;;) {
+      int z = stbi__zhuffman_decode(a, &a->z_length);
+      if (z < 256) {
+         if (z < 0) return stbi__err("bad huffman code","Corrupt PNG"); // error in huffman codes
+         if (zout >= a->zout_end) {
+            if (!stbi__zexpand(a, zout, 1)) return 0;
+            zout = a->zout;
+         }
+         *zout++ = (char) z;
+      } else {
+         stbi_uc *p;
+         int len,dist;
+         if (z == 256) {
+            a->zout = zout;
+            if (a->hit_zeof_once && a->num_bits < 16) {
+               // The first time we hit zeof, we inserted 16 extra zero bits into our bit
+               // buffer so the decoder can just do its speculative decoding. But if we
+               // actually consumed any of those bits (which is the case when num_bits < 16),
+               // the stream actually read past the end so it is malformed.
+               return stbi__err("unexpected end","Corrupt PNG");
+            }
+            return 1;
+         }
+         if (z >= 286) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, length codes 286 and 287 must not appear in compressed data
+         z -= 257;
+         len = stbi__zlength_base[z];
+         if (stbi__zlength_extra[z]) len += stbi__zreceive(a, stbi__zlength_extra[z]);
+         z = stbi__zhuffman_decode(a, &a->z_distance);
+         if (z < 0 || z >= 30) return stbi__err("bad huffman code","Corrupt PNG"); // per DEFLATE, distance codes 30 and 31 must not appear in compressed data
+         dist = stbi__zdist_base[z];
+         if (stbi__zdist_extra[z]) dist += stbi__zreceive(a, stbi__zdist_extra[z]);
+         if (zout - a->zout_start < dist) return stbi__err("bad dist","Corrupt PNG");
+         if (len > a->zout_end - zout) {
+            if (!stbi__zexpand(a, zout, len)) return 0;
+            zout = a->zout;
+         }
+         p = (stbi_uc *) (zout - dist);
+         if (dist == 1) { // run of one byte; common in images.
+            stbi_uc v = *p;
+            if (len) { do *zout++ = v; while (--len); }
+         } else {
+            if (len) { do *zout++ = *p++; while (--len); }
+         }
+      }
+   }
+}
+
+static int stbi__compute_huffman_codes(stbi__zbuf *a)
+{
+   static const stbi_uc length_dezigzag[19] = { 16,17,18,0,8,7,9,6,10,5,11,4,12,3,13,2,14,1,15 };
+   stbi__zhuffman z_codelength;
+   stbi_uc lencodes[286+32+137];//padding for maximum single op
+   stbi_uc codelength_sizes[19];
+   int i,n;
+
+   int hlit  = stbi__zreceive(a,5) + 257;
+   int hdist = stbi__zreceive(a,5) + 1;
+   int hclen = stbi__zreceive(a,4) + 4;
+   int ntot  = hlit + hdist;
+
+   memset(codelength_sizes, 0, sizeof(codelength_sizes));
+   for (i=0; i < hclen; ++i) {
+      int s = stbi__zreceive(a,3);
+      codelength_sizes[length_dezigzag[i]] = (stbi_uc) s;
+   }
+   if (!stbi__zbuild_huffman(&z_codelength, codelength_sizes, 19)) return 0;
+
+   n = 0;
+   while (n < ntot) {
+      int c = stbi__zhuffman_decode(a, &z_codelength);
+      if (c < 0 || c >= 19) return stbi__err("bad codelengths", "Corrupt PNG");
+      if (c < 16)
+         lencodes[n++] = (stbi_uc) c;
+      else {
+         stbi_uc fill = 0;
+         if (c == 16) {
+            c = stbi__zreceive(a,2)+3;
+            if (n == 0) return stbi__err("bad codelengths", "Corrupt PNG");
+            fill = lencodes[n-1];
+         } else if (c == 17) {
+            c = stbi__zreceive(a,3)+3;
+         } else if (c == 18) {
+            c = stbi__zreceive(a,7)+11;
+         } else {
+            return stbi__err("bad codelengths", "Corrupt PNG");
+         }
+         if (ntot - n < c) return stbi__err("bad codelengths", "Corrupt PNG");
+         memset(lencodes+n, fill, c);
+         n += c;
+      }
+   }
+   if (n != ntot) return stbi__err("bad codelengths","Corrupt PNG");
+   if (!stbi__zbuild_huffman(&a->z_length, lencodes, hlit)) return 0;
+   if (!stbi__zbuild_huffman(&a->z_distance, lencodes+hlit, hdist)) return 0;
+   return 1;
+}
+
+static int stbi__parse_uncompressed_block(stbi__zbuf *a)
+{
+   stbi_uc header[4];
+   int len,nlen,k;
+   if (a->num_bits & 7)
+      stbi__zreceive(a, a->num_bits & 7); // discard
+   // drain the bit-packed data into header
+   k = 0;
+   while (a->num_bits > 0) {
+      header[k++] = (stbi_uc) (a->code_buffer & 255); // suppress MSVC run-time check
+      a->code_buffer >>= 8;
+      a->num_bits -= 8;
+   }
+   if (a->num_bits < 0) return stbi__err("zlib corrupt","Corrupt PNG");
+   // now fill header the normal way
+   while (k < 4)
+      header[k++] = stbi__zget8(a);
+   len  = header[1] * 256 + header[0];
+   nlen = header[3] * 256 + header[2];
+   if (nlen != (len ^ 0xffff)) return stbi__err("zlib corrupt","Corrupt PNG");
+   if (a->zbuffer + len > a->zbuffer_end) return stbi__err("read past buffer","Corrupt PNG");
+   if (a->zout + len > a->zout_end)
+      if (!stbi__zexpand(a, a->zout, len)) return 0;
+   memcpy(a->zout, a->zbuffer, len);
+   a->zbuffer += len;
+   a->zout += len;
+   return 1;
+}
+
+static int stbi__parse_zlib_header(stbi__zbuf *a)
+{
+   int cmf   = stbi__zget8(a);
+   int cm    = cmf & 15;
+   /* int cinfo = cmf >> 4; */
+   int flg   = stbi__zget8(a);
+   if (stbi__zeof(a)) return stbi__err("bad zlib header","Corrupt PNG"); // zlib spec
+   if ((cmf*256+flg) % 31 != 0) return stbi__err("bad zlib header","Corrupt PNG"); // zlib spec
+   if (flg & 32) return stbi__err("no preset dict","Corrupt PNG"); // preset dictionary not allowed in png
+   if (cm != 8) return stbi__err("bad compression","Corrupt PNG"); // DEFLATE required for png
+   // window = 1 << (8 + cinfo)... but who cares, we fully buffer output
+   return 1;
+}
+
+static const stbi_uc stbi__zdefault_length[STBI__ZNSYMS] =
+{
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,
+   8,8,8,8,8,8,8,8,8,8,8,8,8,8,8,8, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, 9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
+   7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, 7,7,7,7,7,7,7,7,8,8,8,8,8,8,8,8
+};
+static const stbi_uc stbi__zdefault_distance[32] =
+{
+   5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5,5
+};
+/*
+Init algorithm:
+{
+   int i;   // use <= to match clearly with spec
+   for (i=0; i <= 143; ++i)     stbi__zdefault_length[i]   = 8;
+   for (   ; i <= 255; ++i)     stbi__zdefault_length[i]   = 9;
+   for (   ; i <= 279; ++i)     stbi__zdefault_length[i]   = 7;
+   for (   ; i <= 287; ++i)     stbi__zdefault_length[i]   = 8;
+
+   for (i=0; i <=  31; ++i)     stbi__zdefault_distance[i] = 5;
+}
+*/
+
+static int stbi__parse_zlib(stbi__zbuf *a, int parse_header)
+{
+   int final, type;
+   if (parse_header)
+      if (!stbi__parse_zlib_header(a)) return 0;
+   a->num_bits = 0;
+   a->code_buffer = 0;
+   a->hit_zeof_once = 0;
+   do {
+      final = stbi__zreceive(a,1);
+      type = stbi__zreceive(a,2);
+      if (type == 0) {
+         if (!stbi__parse_uncompressed_block(a)) return 0;
+      } else if (type == 3) {
+         return 0;
+      } else {
+         if (type == 1) {
+            // use fixed code lengths
+            if (!stbi__zbuild_huffman(&a->z_length  , stbi__zdefault_length  , STBI__ZNSYMS)) return 0;
+            if (!stbi__zbuild_huffman(&a->z_distance, stbi__zdefault_distance,  32)) return 0;
+         } else {
+            if (!stbi__compute_huffman_codes(a)) return 0;
+         }
+         if (!stbi__parse_huffman_block(a)) return 0;
+      }
+   } while (!final);
+   return 1;
+}
+
+static int stbi__do_zlib(stbi__zbuf *a, char *obuf, int olen, int exp, int parse_header)
+{
+   a->zout_start = obuf;
+   a->zout       = obuf;
+   a->zout_end   = obuf + olen;
+   a->z_expandable = exp;
+
+   return stbi__parse_zlib(a, parse_header);
+}
+
+STBIDEF char *stbi_zlib_decode_malloc_guesssize(const char *buffer, int len, int initial_size, int *outlen)
+{
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(initial_size);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer + len;
+   if (stbi__do_zlib(&a, p, initial_size, 1, 1)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
+}
+
+STBIDEF char *stbi_zlib_decode_malloc(char const *buffer, int len, int *outlen)
+{
+   return stbi_zlib_decode_malloc_guesssize(buffer, len, 16384, outlen);
+}
+
+STBIDEF char *stbi_zlib_decode_malloc_guesssize_headerflag(const char *buffer, int len, int initial_size, int *outlen, int parse_header)
+{
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(initial_size);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer + len;
+   if (stbi__do_zlib(&a, p, initial_size, 1, parse_header)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
+}
+
+STBIDEF int stbi_zlib_decode_buffer(char *obuffer, int olen, char const *ibuffer, int ilen)
+{
+   stbi__zbuf a;
+   a.zbuffer = (stbi_uc *) ibuffer;
+   a.zbuffer_end = (stbi_uc *) ibuffer + ilen;
+   if (stbi__do_zlib(&a, obuffer, olen, 0, 1))
+      return (int) (a.zout - a.zout_start);
+   else
+      return -1;
+}
+
+STBIDEF char *stbi_zlib_decode_noheader_malloc(char const *buffer, int len, int *outlen)
+{
+   stbi__zbuf a;
+   char *p = (char *) stbi__malloc(16384);
+   if (p == NULL) return NULL;
+   a.zbuffer = (stbi_uc *) buffer;
+   a.zbuffer_end = (stbi_uc *) buffer+len;
+   if (stbi__do_zlib(&a, p, 16384, 1, 0)) {
+      if (outlen) *outlen = (int) (a.zout - a.zout_start);
+      return a.zout_start;
+   } else {
+      STBI_FREE(a.zout_start);
+      return NULL;
+   }
+}
+
+STBIDEF int stbi_zlib_decode_noheader_buffer(char *obuffer, int olen, const char *ibuffer, int ilen)
+{
+   stbi__zbuf a;
+   a.zbuffer = (stbi_uc *) ibuffer;
+   a.zbuffer_end = (stbi_uc *) ibuffer + ilen;
+   if (stbi__do_zlib(&a, obuffer, olen, 0, 0))
+      return (int) (a.zout - a.zout_start);
+   else
+      return -1;
+}
+#endif
+
+// public domain "baseline" PNG decoder   v0.10  Sean Barrett 2006-11-18
+//    simple implementation
+//      - only 8-bit samples
+//      - no CRC checking
+//      - allocates lots of intermediate memory
+//        - avoids problem of streaming data between subsystems
+//        - avoids explicit window management
+//    performance
+//      - uses stb_zlib, a PD zlib implementation with fast huffman decoding
+
+#ifndef STBI_NO_PNG
+typedef struct
+{
+   stbi__uint32 length;
+   stbi__uint32 type;
+} stbi__pngchunk;
+
+static stbi__pngchunk stbi__get_chunk_header(stbi__context *s)
+{
+   stbi__pngchunk c;
+   c.length = stbi__get32be(s);
+   c.type   = stbi__get32be(s);
+   return c;
+}
+
+static int stbi__check_png_header(stbi__context *s)
+{
+   static const stbi_uc png_sig[8] = { 137,80,78,71,13,10,26,10 };
+   int i;
+   for (i=0; i < 8; ++i)
+      if (stbi__get8(s) != png_sig[i]) return stbi__err("bad png sig","Not a PNG");
+   return 1;
+}
+
+typedef struct
+{
+   stbi__context *s;
+   stbi_uc *idata, *expanded, *out;
+   int depth;
+} stbi__png;
+
+
+enum {
+   STBI__F_none=0,
+   STBI__F_sub=1,
+   STBI__F_up=2,
+   STBI__F_avg=3,
+   STBI__F_paeth=4,
+   // synthetic filter used for first scanline to avoid needing a dummy row of 0s
+   STBI__F_avg_first
+};
+
+static stbi_uc first_row_filter[5] =
+{
+   STBI__F_none,
+   STBI__F_sub,
+   STBI__F_none,
+   STBI__F_avg_first,
+   STBI__F_sub // Paeth with b=c=0 turns out to be equivalent to sub
+};
+
+static int stbi__paeth(int a, int b, int c)
+{
+   // This formulation looks very different from the reference in the PNG spec, but is
+   // actually equivalent and has favorable data dependencies and admits straightforward
+   // generation of branch-free code, which helps performance significantly.
+   int thresh = c*3 - (a + b);
+   int lo = a < b ? a : b;
+   int hi = a < b ? b : a;
+   int t0 = (hi <= thresh) ? lo : c;
+   int t1 = (thresh <= lo) ? hi : t0;
+   return t1;
+}
+
+static const stbi_uc stbi__depth_scale_table[9] = { 0, 0xff, 0x55, 0, 0x11, 0,0,0, 0x01 };
+
+// adds an extra all-255 alpha channel
+// dest == src is legal
+// img_n must be 1 or 3
+static void stbi__create_png_alpha_expand8(stbi_uc *dest, stbi_uc *src, stbi__uint32 x, int img_n)
+{
+   int i;
+   // must process data backwards since we allow dest==src
+   if (img_n == 1) {
+      for (i=x-1; i >= 0; --i) {
+         dest[i*2+1] = 255;
+         dest[i*2+0] = src[i];
+      }
+   } else {
+      STBI_ASSERT(img_n == 3);
+      for (i=x-1; i >= 0; --i) {
+         dest[i*4+3] = 255;
+         dest[i*4+2] = src[i*3+2];
+         dest[i*4+1] = src[i*3+1];
+         dest[i*4+0] = src[i*3+0];
+      }
+   }
+}
+
+// create the png data from post-deflated data
+static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 raw_len, int out_n, stbi__uint32 x, stbi__uint32 y, int depth, int color)
+{
+   int bytes = (depth == 16 ? 2 : 1);
+   stbi__context *s = a->s;
+   stbi__uint32 i,j,stride = x*out_n*bytes;
+   stbi__uint32 img_len, img_width_bytes;
+   stbi_uc *filter_buf;
+   int all_ok = 1;
+   int k;
+   int img_n = s->img_n; // copy it into a local for later
+
+   int output_bytes = out_n*bytes;
+   int filter_bytes = img_n*bytes;
+   int width = x;
+
+   STBI_ASSERT(out_n == s->img_n || out_n == s->img_n+1);
+   a->out = (stbi_uc *) stbi__malloc_mad3(x, y, output_bytes, 0); // extra bytes to write off the end into
+   if (!a->out) return stbi__err("outofmem", "Out of memory");
+
+   // note: error exits here don't need to clean up a->out individually,
+   // stbi__do_png always does on error.
+   if (!stbi__mad3sizes_valid(img_n, x, depth, 7)) return stbi__err("too large", "Corrupt PNG");
+   img_width_bytes = (((img_n * x * depth) + 7) >> 3);
+   if (!stbi__mad2sizes_valid(img_width_bytes, y, img_width_bytes)) return stbi__err("too large", "Corrupt PNG");
+   img_len = (img_width_bytes + 1) * y;
+
+   // we used to check for exact match between raw_len and img_len on non-interlaced PNGs,
+   // but issue #276 reported a PNG in the wild that had extra data at the end (all zeros),
+   // so just check for raw_len < img_len always.
+   if (raw_len < img_len) return stbi__err("not enough pixels","Corrupt PNG");
+
+   // Allocate two scan lines worth of filter workspace buffer.
+   filter_buf = (stbi_uc *) stbi__malloc_mad2(img_width_bytes, 2, 0);
+   if (!filter_buf) return stbi__err("outofmem", "Out of memory");
+
+   // Filtering for low-bit-depth images
+   if (depth < 8) {
+      filter_bytes = 1;
+      width = img_width_bytes;
+   }
+
+   for (j=0; j < y; ++j) {
+      // cur/prior filter buffers alternate
+      stbi_uc *cur = filter_buf + (j & 1)*img_width_bytes;
+      stbi_uc *prior = filter_buf + (~j & 1)*img_width_bytes;
+      stbi_uc *dest = a->out + stride*j;
+      int nk = width * filter_bytes;
+      int filter = *raw++;
+
+      // check filter type
+      if (filter > 4) {
+         all_ok = stbi__err("invalid filter","Corrupt PNG");
+         break;
+      }
+
+      // if first row, use special filter that doesn't sample previous row
+      if (j == 0) filter = first_row_filter[filter];
+
+      // perform actual filtering
+      switch (filter) {
+      case STBI__F_none:
+         memcpy(cur, raw, nk);
+         break;
+      case STBI__F_sub:
+         memcpy(cur, raw, filter_bytes);
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + cur[k-filter_bytes]);
+         break;
+      case STBI__F_up:
+         for (k = 0; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + prior[k]);
+         break;
+      case STBI__F_avg:
+         for (k = 0; k < filter_bytes; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + (prior[k]>>1));
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + ((prior[k] + cur[k-filter_bytes])>>1));
+         break;
+      case STBI__F_paeth:
+         for (k = 0; k < filter_bytes; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + prior[k]); // prior[k] == stbi__paeth(0,prior[k],0)
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + stbi__paeth(cur[k-filter_bytes], prior[k], prior[k-filter_bytes]));
+         break;
+      case STBI__F_avg_first:
+         memcpy(cur, raw, filter_bytes);
+         for (k = filter_bytes; k < nk; ++k)
+            cur[k] = STBI__BYTECAST(raw[k] + (cur[k-filter_bytes] >> 1));
+         break;
+      }
+
+      raw += nk;
+
+      // expand decoded bits in cur to dest, also adding an extra alpha channel if desired
+      if (depth < 8) {
+         stbi_uc scale = (color == 0) ? stbi__depth_scale_table[depth] : 1; // scale grayscale values to 0..255 range
+         stbi_uc *in = cur;
+         stbi_uc *out = dest;
+         stbi_uc inb = 0;
+         stbi__uint32 nsmp = x*img_n;
+
+         // expand bits to bytes first
+         if (depth == 4) {
+            for (i=0; i < nsmp; ++i) {
+               if ((i & 1) == 0) inb = *in++;
+               *out++ = scale * (inb >> 4);
+               inb <<= 4;
+            }
+         } else if (depth == 2) {
+            for (i=0; i < nsmp; ++i) {
+               if ((i & 3) == 0) inb = *in++;
+               *out++ = scale * (inb >> 6);
+               inb <<= 2;
+            }
+         } else {
+            STBI_ASSERT(depth == 1);
+            for (i=0; i < nsmp; ++i) {
+               if ((i & 7) == 0) inb = *in++;
+               *out++ = scale * (inb >> 7);
+               inb <<= 1;
+            }
+         }
+
+         // insert alpha=255 values if desired
+         if (img_n != out_n)
+            stbi__create_png_alpha_expand8(dest, dest, x, img_n);
+      } else if (depth == 8) {
+         if (img_n == out_n)
+            memcpy(dest, cur, x*img_n);
+         else
+            stbi__create_png_alpha_expand8(dest, cur, x, img_n);
+      } else if (depth == 16) {
+         // convert the image data from big-endian to platform-native
+         stbi__uint16 *dest16 = (stbi__uint16*)dest;
+         stbi__uint32 nsmp = x*img_n;
+
+         if (img_n == out_n) {
+            for (i = 0; i < nsmp; ++i, ++dest16, cur += 2)
+               *dest16 = (cur[0] << 8) | cur[1];
+         } else {
+            STBI_ASSERT(img_n+1 == out_n);
+            if (img_n == 1) {
+               for (i = 0; i < x; ++i, dest16 += 2, cur += 2) {
+                  dest16[0] = (cur[0] << 8) | cur[1];
+                  dest16[1] = 0xffff;
+               }
+            } else {
+               STBI_ASSERT(img_n == 3);
+               for (i = 0; i < x; ++i, dest16 += 4, cur += 6) {
+                  dest16[0] = (cur[0] << 8) | cur[1];
+                  dest16[1] = (cur[2] << 8) | cur[3];
+                  dest16[2] = (cur[4] << 8) | cur[5];
+                  dest16[3] = 0xffff;
+               }
+            }
+         }
+      }
+   }
+
+   STBI_FREE(filter_buf);
+   if (!all_ok) return 0;
+
+   return 1;
+}
+
+static int stbi__create_png_image(stbi__png *a, stbi_uc *image_data, stbi__uint32 image_data_len, int out_n, int depth, int color, int interlaced)
+{
+   int bytes = (depth == 16 ? 2 : 1);
+   int out_bytes = out_n * bytes;
+   stbi_uc *final;
+   int p;
+   if (!interlaced)
+      return stbi__create_png_image_raw(a, image_data, image_data_len, out_n, a->s->img_x, a->s->img_y, depth, color);
+
+   // de-interlacing
+   final = (stbi_uc *) stbi__malloc_mad3(a->s->img_x, a->s->img_y, out_bytes, 0);
+   if (!final) return stbi__err("outofmem", "Out of memory");
+   for (p=0; p < 7; ++p) {
+      int xorig[] = { 0,4,0,2,0,1,0 };
+      int yorig[] = { 0,0,4,0,2,0,1 };
+      int xspc[]  = { 8,8,4,4,2,2,1 };
+      int yspc[]  = { 8,8,8,4,4,2,2 };
+      int i,j,x,y;
+      // pass1_x[4] = 0, pass1_x[5] = 1, pass1_x[12] = 1
+      x = (a->s->img_x - xorig[p] + xspc[p]-1) / xspc[p];
+      y = (a->s->img_y - yorig[p] + yspc[p]-1) / yspc[p];
+      if (x && y) {
+         stbi__uint32 img_len = ((((a->s->img_n * x * depth) + 7) >> 3) + 1) * y;
+         if (!stbi__create_png_image_raw(a, image_data, image_data_len, out_n, x, y, depth, color)) {
+            STBI_FREE(final);
+            return 0;
+         }
+         for (j=0; j < y; ++j) {
+            for (i=0; i < x; ++i) {
+               int out_y = j*yspc[p]+yorig[p];
+               int out_x = i*xspc[p]+xorig[p];
+               memcpy(final + out_y*a->s->img_x*out_bytes + out_x*out_bytes,
+                      a->out + (j*x+i)*out_bytes, out_bytes);
+            }
+         }
+         STBI_FREE(a->out);
+         image_data += img_len;
+         image_data_len -= img_len;
+      }
+   }
+   a->out = final;
+
+   return 1;
+}
+
+static int stbi__compute_transparency(stbi__png *z, stbi_uc tc[3], int out_n)
+{
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi_uc *p = z->out;
+
+   // compute color-based transparency, assuming we've
+   // already got 255 as the alpha value in the output
+   STBI_ASSERT(out_n == 2 || out_n == 4);
+
+   if (out_n == 2) {
+      for (i=0; i < pixel_count; ++i) {
+         p[1] = (p[0] == tc[0] ? 0 : 255);
+         p += 2;
+      }
+   } else {
+      for (i=0; i < pixel_count; ++i) {
+         if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
+            p[3] = 0;
+         p += 4;
+      }
+   }
+   return 1;
+}
+
+static int stbi__compute_transparency16(stbi__png *z, stbi__uint16 tc[3], int out_n)
+{
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi__uint16 *p = (stbi__uint16*) z->out;
+
+   // compute color-based transparency, assuming we've
+   // already got 65535 as the alpha value in the output
+   STBI_ASSERT(out_n == 2 || out_n == 4);
+
+   if (out_n == 2) {
+      for (i = 0; i < pixel_count; ++i) {
+         p[1] = (p[0] == tc[0] ? 0 : 65535);
+         p += 2;
+      }
+   } else {
+      for (i = 0; i < pixel_count; ++i) {
+         if (p[0] == tc[0] && p[1] == tc[1] && p[2] == tc[2])
+            p[3] = 0;
+         p += 4;
+      }
+   }
+   return 1;
+}
+
+static int stbi__expand_png_palette(stbi__png *a, stbi_uc *palette, int len, int pal_img_n)
+{
+   stbi__uint32 i, pixel_count = a->s->img_x * a->s->img_y;
+   stbi_uc *p, *temp_out, *orig = a->out;
+
+   p = (stbi_uc *) stbi__malloc_mad2(pixel_count, pal_img_n, 0);
+   if (p == NULL) return stbi__err("outofmem", "Out of memory");
+
+   // between here and free(out) below, exitting would leak
+   temp_out = p;
+
+   if (pal_img_n == 3) {
+      for (i=0; i < pixel_count; ++i) {
+         int n = orig[i]*4;
+         p[0] = palette[n  ];
+         p[1] = palette[n+1];
+         p[2] = palette[n+2];
+         p += 3;
+      }
+   } else {
+      for (i=0; i < pixel_count; ++i) {
+         int n = orig[i]*4;
+         p[0] = palette[n  ];
+         p[1] = palette[n+1];
+         p[2] = palette[n+2];
+         p[3] = palette[n+3];
+         p += 4;
+      }
+   }
+   STBI_FREE(a->out);
+   a->out = temp_out;
+
+   STBI_NOTUSED(len);
+
+   return 1;
+}
+
+static int stbi__unpremultiply_on_load_global = 0;
+static int stbi__de_iphone_flag_global = 0;
+
+STBIDEF void stbi_set_unpremultiply_on_load(int flag_true_if_should_unpremultiply)
+{
+   stbi__unpremultiply_on_load_global = flag_true_if_should_unpremultiply;
+}
+
+STBIDEF void stbi_convert_iphone_png_to_rgb(int flag_true_if_should_convert)
+{
+   stbi__de_iphone_flag_global = flag_true_if_should_convert;
+}
+
+#ifndef STBI_THREAD_LOCAL
+#define stbi__unpremultiply_on_load  stbi__unpremultiply_on_load_global
+#define stbi__de_iphone_flag  stbi__de_iphone_flag_global
+#else
+static STBI_THREAD_LOCAL int stbi__unpremultiply_on_load_local, stbi__unpremultiply_on_load_set;
+static STBI_THREAD_LOCAL int stbi__de_iphone_flag_local, stbi__de_iphone_flag_set;
+
+STBIDEF void stbi_set_unpremultiply_on_load_thread(int flag_true_if_should_unpremultiply)
+{
+   stbi__unpremultiply_on_load_local = flag_true_if_should_unpremultiply;
+   stbi__unpremultiply_on_load_set = 1;
+}
+
+STBIDEF void stbi_convert_iphone_png_to_rgb_thread(int flag_true_if_should_convert)
+{
+   stbi__de_iphone_flag_local = flag_true_if_should_convert;
+   stbi__de_iphone_flag_set = 1;
+}
+
+#define stbi__unpremultiply_on_load  (stbi__unpremultiply_on_load_set           \
+                                       ? stbi__unpremultiply_on_load_local      \
+                                       : stbi__unpremultiply_on_load_global)
+#define stbi__de_iphone_flag  (stbi__de_iphone_flag_set                         \
+                                ? stbi__de_iphone_flag_local                    \
+                                : stbi__de_iphone_flag_global)
+#endif // STBI_THREAD_LOCAL
+
+static void stbi__de_iphone(stbi__png *z)
+{
+   stbi__context *s = z->s;
+   stbi__uint32 i, pixel_count = s->img_x * s->img_y;
+   stbi_uc *p = z->out;
+
+   if (s->img_out_n == 3) {  // convert bgr to rgb
+      for (i=0; i < pixel_count; ++i) {
+         stbi_uc t = p[0];
+         p[0] = p[2];
+         p[2] = t;
+         p += 3;
+      }
+   } else {
+      STBI_ASSERT(s->img_out_n == 4);
+      if (stbi__unpremultiply_on_load) {
+         // convert bgr to rgb and unpremultiply
+         for (i=0; i < pixel_count; ++i) {
+            stbi_uc a = p[3];
+            stbi_uc t = p[0];
+            if (a) {
+               stbi_uc half = a / 2;
+               p[0] = (p[2] * 255 + half) / a;
+               p[1] = (p[1] * 255 + half) / a;
+               p[2] = ( t   * 255 + half) / a;
+            } else {
+               p[0] = p[2];
+               p[2] = t;
+            }
+            p += 4;
+         }
+      } else {
+         // convert bgr to rgb
+         for (i=0; i < pixel_count; ++i) {
+            stbi_uc t = p[0];
+            p[0] = p[2];
+            p[2] = t;
+            p += 4;
+         }
+      }
+   }
+}
+
+#define STBI__PNG_TYPE(a,b,c,d)  (((unsigned) (a) << 24) + ((unsigned) (b) << 16) + ((unsigned) (c) << 8) + (unsigned) (d))
+
+static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
+{
+   stbi_uc palette[1024], pal_img_n=0;
+   stbi_uc has_trans=0, tc[3]={0};
+   stbi__uint16 tc16[3];
+   stbi__uint32 ioff=0, idata_limit=0, i, pal_len=0;
+   int first=1,k,interlace=0, color=0, is_iphone=0;
+   stbi__context *s = z->s;
+
+   z->expanded = NULL;
+   z->idata = NULL;
+   z->out = NULL;
+
+   if (!stbi__check_png_header(s)) return 0;
+
+   if (scan == STBI__SCAN_type) return 1;
+
+   for (;;) {
+      stbi__pngchunk c = stbi__get_chunk_header(s);
+      switch (c.type) {
+         case STBI__PNG_TYPE('C','g','B','I'):
+            is_iphone = 1;
+            stbi__skip(s, c.length);
+            break;
+         case STBI__PNG_TYPE('I','H','D','R'): {
+            int comp,filter;
+            if (!first) return stbi__err("multiple IHDR","Corrupt PNG");
+            first = 0;
+            if (c.length != 13) return stbi__err("bad IHDR len","Corrupt PNG");
+            s->img_x = stbi__get32be(s);
+            s->img_y = stbi__get32be(s);
+            if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+            if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+            z->depth = stbi__get8(s);  if (z->depth != 1 && z->depth != 2 && z->depth != 4 && z->depth != 8 && z->depth != 16)  return stbi__err("1/2/4/8/16-bit only","PNG not supported: 1/2/4/8/16-bit only");
+            color = stbi__get8(s);  if (color > 6)         return stbi__err("bad ctype","Corrupt PNG");
+            if (color == 3 && z->depth == 16)                  return stbi__err("bad ctype","Corrupt PNG");
+            if (color == 3) pal_img_n = 3; else if (color & 1) return stbi__err("bad ctype","Corrupt PNG");
+            comp  = stbi__get8(s);  if (comp) return stbi__err("bad comp method","Corrupt PNG");
+            filter= stbi__get8(s);  if (filter) return stbi__err("bad filter method","Corrupt PNG");
+            interlace = stbi__get8(s); if (interlace>1) return stbi__err("bad interlace method","Corrupt PNG");
+            if (!s->img_x || !s->img_y) return stbi__err("0-pixel image","Corrupt PNG");
+            if (!pal_img_n) {
+               s->img_n = (color & 2 ? 3 : 1) + (color & 4 ? 1 : 0);
+               if ((1 << 30) / s->img_x / s->img_n < s->img_y) return stbi__err("too large", "Image too large to decode");
+            } else {
+               // if paletted, then pal_n is our final components, and
+               // img_n is # components to decompress/filter.
+               s->img_n = 1;
+               if ((1 << 30) / s->img_x / 4 < s->img_y) return stbi__err("too large","Corrupt PNG");
+            }
+            // even with SCAN_header, have to scan to see if we have a tRNS
+            break;
+         }
+
+         case STBI__PNG_TYPE('P','L','T','E'):  {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (c.length > 256*3) return stbi__err("invalid PLTE","Corrupt PNG");
+            pal_len = c.length / 3;
+            if (pal_len * 3 != c.length) return stbi__err("invalid PLTE","Corrupt PNG");
+            for (i=0; i < pal_len; ++i) {
+               palette[i*4+0] = stbi__get8(s);
+               palette[i*4+1] = stbi__get8(s);
+               palette[i*4+2] = stbi__get8(s);
+               palette[i*4+3] = 255;
+            }
+            break;
+         }
+
+         case STBI__PNG_TYPE('t','R','N','S'): {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (z->idata) return stbi__err("tRNS after IDAT","Corrupt PNG");
+            if (pal_img_n) {
+               if (scan == STBI__SCAN_header) { s->img_n = 4; return 1; }
+               if (pal_len == 0) return stbi__err("tRNS before PLTE","Corrupt PNG");
+               if (c.length > pal_len) return stbi__err("bad tRNS len","Corrupt PNG");
+               pal_img_n = 4;
+               for (i=0; i < c.length; ++i)
+                  palette[i*4+3] = stbi__get8(s);
+            } else {
+               if (!(s->img_n & 1)) return stbi__err("tRNS with alpha","Corrupt PNG");
+               if (c.length != (stbi__uint32) s->img_n*2) return stbi__err("bad tRNS len","Corrupt PNG");
+               has_trans = 1;
+               // non-paletted with tRNS = constant alpha. if header-scanning, we can stop now.
+               if (scan == STBI__SCAN_header) { ++s->img_n; return 1; }
+               if (z->depth == 16) {
+                  for (k = 0; k < s->img_n && k < 3; ++k) // extra loop test to suppress false GCC warning
+                     tc16[k] = (stbi__uint16)stbi__get16be(s); // copy the values as-is
+               } else {
+                  for (k = 0; k < s->img_n && k < 3; ++k)
+                     tc[k] = (stbi_uc)(stbi__get16be(s) & 255) * stbi__depth_scale_table[z->depth]; // non 8-bit images will be larger
+               }
+            }
+            break;
+         }
+
+         case STBI__PNG_TYPE('I','D','A','T'): {
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (pal_img_n && !pal_len) return stbi__err("no PLTE","Corrupt PNG");
+            if (scan == STBI__SCAN_header) {
+               // header scan definitely stops at first IDAT
+               if (pal_img_n)
+                  s->img_n = pal_img_n;
+               return 1;
+            }
+            if (c.length > (1u << 30)) return stbi__err("IDAT size limit", "IDAT section larger than 2^30 bytes");
+            if ((int)(ioff + c.length) < (int)ioff) return 0;
+            if (ioff + c.length > idata_limit) {
+               stbi__uint32 idata_limit_old = idata_limit;
+               stbi_uc *p;
+               if (idata_limit == 0) idata_limit = c.length > 4096 ? c.length : 4096;
+               while (ioff + c.length > idata_limit)
+                  idata_limit *= 2;
+               STBI_NOTUSED(idata_limit_old);
+               p = (stbi_uc *) STBI_REALLOC_SIZED(z->idata, idata_limit_old, idata_limit); if (p == NULL) return stbi__err("outofmem", "Out of memory");
+               z->idata = p;
+            }
+            if (!stbi__getn(s, z->idata+ioff,c.length)) return stbi__err("outofdata","Corrupt PNG");
+            ioff += c.length;
+            break;
+         }
+
+         case STBI__PNG_TYPE('I','E','N','D'): {
+            stbi__uint32 raw_len, bpl;
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if (scan != STBI__SCAN_load) return 1;
+            if (z->idata == NULL) return stbi__err("no IDAT","Corrupt PNG");
+            // initial guess for decoded data size to avoid unnecessary reallocs
+            bpl = (s->img_x * z->depth + 7) / 8; // bytes per line, per component
+            raw_len = bpl * s->img_y * s->img_n /* pixels */ + s->img_y /* filter mode per row */;
+            z->expanded = (stbi_uc *) stbi_zlib_decode_malloc_guesssize_headerflag((char *) z->idata, ioff, raw_len, (int *) &raw_len, !is_iphone);
+            if (z->expanded == NULL) return 0; // zlib should set error
+            STBI_FREE(z->idata); z->idata = NULL;
+            if ((req_comp == s->img_n+1 && req_comp != 3 && !pal_img_n) || has_trans)
+               s->img_out_n = s->img_n+1;
+            else
+               s->img_out_n = s->img_n;
+            if (!stbi__create_png_image(z, z->expanded, raw_len, s->img_out_n, z->depth, color, interlace)) return 0;
+            if (has_trans) {
+               if (z->depth == 16) {
+                  if (!stbi__compute_transparency16(z, tc16, s->img_out_n)) return 0;
+               } else {
+                  if (!stbi__compute_transparency(z, tc, s->img_out_n)) return 0;
+               }
+            }
+            if (is_iphone && stbi__de_iphone_flag && s->img_out_n > 2)
+               stbi__de_iphone(z);
+            if (pal_img_n) {
+               // pal_img_n == 3 or 4
+               s->img_n = pal_img_n; // record the actual colors we had
+               s->img_out_n = pal_img_n;
+               if (req_comp >= 3) s->img_out_n = req_comp;
+               if (!stbi__expand_png_palette(z, palette, pal_len, s->img_out_n))
+                  return 0;
+            } else if (has_trans) {
+               // non-paletted image with tRNS -> source image has (constant) alpha
+               ++s->img_n;
+            }
+            STBI_FREE(z->expanded); z->expanded = NULL;
+            // end of PNG chunk, read and skip CRC
+            stbi__get32be(s);
+            return 1;
+         }
+
+         default:
+            // if critical, fail
+            if (first) return stbi__err("first not IHDR", "Corrupt PNG");
+            if ((c.type & (1 << 29)) == 0) {
+               #ifndef STBI_NO_FAILURE_STRINGS
+               // not threadsafe
+               static char invalid_chunk[] = "XXXX PNG chunk not known";
+               invalid_chunk[0] = STBI__BYTECAST(c.type >> 24);
+               invalid_chunk[1] = STBI__BYTECAST(c.type >> 16);
+               invalid_chunk[2] = STBI__BYTECAST(c.type >>  8);
+               invalid_chunk[3] = STBI__BYTECAST(c.type >>  0);
+               #endif
+               return stbi__err(invalid_chunk, "PNG not supported: unknown PNG chunk type");
+            }
+            stbi__skip(s, c.length);
+            break;
+      }
+      // end of PNG chunk, read and skip CRC
+      stbi__get32be(s);
+   }
+}
+
+static void *stbi__do_png(stbi__png *p, int *x, int *y, int *n, int req_comp, stbi__result_info *ri)
+{
+   void *result=NULL;
+   if (req_comp < 0 || req_comp > 4) return stbi__errpuc("bad req_comp", "Internal error");
+   if (stbi__parse_png_file(p, STBI__SCAN_load, req_comp)) {
+      if (p->depth <= 8)
+         ri->bits_per_channel = 8;
+      else if (p->depth == 16)
+         ri->bits_per_channel = 16;
+      else
+         return stbi__errpuc("bad bits_per_channel", "PNG not supported: unsupported color depth");
+      result = p->out;
+      p->out = NULL;
+      if (req_comp && req_comp != p->s->img_out_n) {
+         if (ri->bits_per_channel == 8)
+            result = stbi__convert_format((unsigned char *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         else
+            result = stbi__convert_format16((stbi__uint16 *) result, p->s->img_out_n, req_comp, p->s->img_x, p->s->img_y);
+         p->s->img_out_n = req_comp;
+         if (result == NULL) return result;
+      }
+      *x = p->s->img_x;
+      *y = p->s->img_y;
+      if (n) *n = p->s->img_n;
+   }
+   STBI_FREE(p->out);      p->out      = NULL;
+   STBI_FREE(p->expanded); p->expanded = NULL;
+   STBI_FREE(p->idata);    p->idata    = NULL;
+
+   return result;
+}
+
+static void *stbi__png_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi__png p;
+   p.s = s;
+   return stbi__do_png(&p, x,y,comp,req_comp, ri);
+}
+
+static int stbi__png_test(stbi__context *s)
+{
+   int r;
+   r = stbi__check_png_header(s);
+   stbi__rewind(s);
+   return r;
+}
+
+static int stbi__png_info_raw(stbi__png *p, int *x, int *y, int *comp)
+{
+   if (!stbi__parse_png_file(p, STBI__SCAN_header, 0)) {
+      stbi__rewind( p->s );
+      return 0;
+   }
+   if (x) *x = p->s->img_x;
+   if (y) *y = p->s->img_y;
+   if (comp) *comp = p->s->img_n;
+   return 1;
+}
+
+static int stbi__png_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   stbi__png p;
+   p.s = s;
+   return stbi__png_info_raw(&p, x, y, comp);
+}
+
+static int stbi__png_is16(stbi__context *s)
+{
+   stbi__png p;
+   p.s = s;
+   if (!stbi__png_info_raw(&p, NULL, NULL, NULL))
+	   return 0;
+   if (p.depth != 16) {
+      stbi__rewind(p.s);
+      return 0;
+   }
+   return 1;
+}
+#endif
+
+// Microsoft/Windows BMP image
+
+#ifndef STBI_NO_BMP
+static int stbi__bmp_test_raw(stbi__context *s)
+{
+   int r;
+   int sz;
+   if (stbi__get8(s) != 'B') return 0;
+   if (stbi__get8(s) != 'M') return 0;
+   stbi__get32le(s); // discard filesize
+   stbi__get16le(s); // discard reserved
+   stbi__get16le(s); // discard reserved
+   stbi__get32le(s); // discard data offset
+   sz = stbi__get32le(s);
+   r = (sz == 12 || sz == 40 || sz == 56 || sz == 108 || sz == 124);
+   return r;
+}
+
+static int stbi__bmp_test(stbi__context *s)
+{
+   int r = stbi__bmp_test_raw(s);
+   stbi__rewind(s);
+   return r;
+}
+
+
+// returns 0..31 for the highest set bit
+static int stbi__high_bit(unsigned int z)
+{
+   int n=0;
+   if (z == 0) return -1;
+   if (z >= 0x10000) { n += 16; z >>= 16; }
+   if (z >= 0x00100) { n +=  8; z >>=  8; }
+   if (z >= 0x00010) { n +=  4; z >>=  4; }
+   if (z >= 0x00004) { n +=  2; z >>=  2; }
+   if (z >= 0x00002) { n +=  1;/* >>=  1;*/ }
+   return n;
+}
+
+static int stbi__bitcount(unsigned int a)
+{
+   a = (a & 0x55555555) + ((a >>  1) & 0x55555555); // max 2
+   a = (a & 0x33333333) + ((a >>  2) & 0x33333333); // max 4
+   a = (a + (a >> 4)) & 0x0f0f0f0f; // max 8 per 4, now 8 bits
+   a = (a + (a >> 8)); // max 16 per 8 bits
+   a = (a + (a >> 16)); // max 32 per 8 bits
+   return a & 0xff;
+}
+
+// extract an arbitrarily-aligned N-bit value (N=bits)
+// from v, and then make it 8-bits long and fractionally
+// extend it to full full range.
+static int stbi__shiftsigned(unsigned int v, int shift, int bits)
+{
+   static unsigned int mul_table[9] = {
+      0,
+      0xff/*0b11111111*/, 0x55/*0b01010101*/, 0x49/*0b01001001*/, 0x11/*0b00010001*/,
+      0x21/*0b00100001*/, 0x41/*0b01000001*/, 0x81/*0b10000001*/, 0x01/*0b00000001*/,
+   };
+   static unsigned int shift_table[9] = {
+      0, 0,0,1,0,2,4,6,0,
+   };
+   if (shift < 0)
+      v <<= -shift;
+   else
+      v >>= shift;
+   STBI_ASSERT(v < 256);
+   v >>= (8-bits);
+   STBI_ASSERT(bits >= 0 && bits <= 8);
+   return (int) ((unsigned) v * mul_table[bits]) >> shift_table[bits];
+}
+
+typedef struct
+{
+   int bpp, offset, hsz;
+   unsigned int mr,mg,mb,ma, all_a;
+   int extra_read;
+} stbi__bmp_data;
+
+static int stbi__bmp_set_mask_defaults(stbi__bmp_data *info, int compress)
+{
+   // BI_BITFIELDS specifies masks explicitly, don't override
+   if (compress == 3)
+      return 1;
+
+   if (compress == 0) {
+      if (info->bpp == 16) {
+         info->mr = 31u << 10;
+         info->mg = 31u <<  5;
+         info->mb = 31u <<  0;
+      } else if (info->bpp == 32) {
+         info->mr = 0xffu << 16;
+         info->mg = 0xffu <<  8;
+         info->mb = 0xffu <<  0;
+         info->ma = 0xffu << 24;
+         info->all_a = 0; // if all_a is 0 at end, then we loaded alpha channel but it was all 0
+      } else {
+         // otherwise, use defaults, which is all-0
+         info->mr = info->mg = info->mb = info->ma = 0;
+      }
+      return 1;
+   }
+   return 0; // error
+}
+
+static void *stbi__bmp_parse_header(stbi__context *s, stbi__bmp_data *info)
+{
+   int hsz;
+   if (stbi__get8(s) != 'B' || stbi__get8(s) != 'M') return stbi__errpuc("not BMP", "Corrupt BMP");
+   stbi__get32le(s); // discard filesize
+   stbi__get16le(s); // discard reserved
+   stbi__get16le(s); // discard reserved
+   info->offset = stbi__get32le(s);
+   info->hsz = hsz = stbi__get32le(s);
+   info->mr = info->mg = info->mb = info->ma = 0;
+   info->extra_read = 14;
+
+   if (info->offset < 0) return stbi__errpuc("bad BMP", "bad BMP");
+
+   if (hsz != 12 && hsz != 40 && hsz != 56 && hsz != 108 && hsz != 124) return stbi__errpuc("unknown BMP", "BMP type not supported: unknown");
+   if (hsz == 12) {
+      s->img_x = stbi__get16le(s);
+      s->img_y = stbi__get16le(s);
+   } else {
+      s->img_x = stbi__get32le(s);
+      s->img_y = stbi__get32le(s);
+   }
+   if (stbi__get16le(s) != 1) return stbi__errpuc("bad BMP", "bad BMP");
+   info->bpp = stbi__get16le(s);
+   if (hsz != 12) {
+      int compress = stbi__get32le(s);
+      if (compress == 1 || compress == 2) return stbi__errpuc("BMP RLE", "BMP type not supported: RLE");
+      if (compress >= 4) return stbi__errpuc("BMP JPEG/PNG", "BMP type not supported: unsupported compression"); // this includes PNG/JPEG modes
+      if (compress == 3 && info->bpp != 16 && info->bpp != 32) return stbi__errpuc("bad BMP", "bad BMP"); // bitfields requires 16 or 32 bits/pixel
+      stbi__get32le(s); // discard sizeof
+      stbi__get32le(s); // discard hres
+      stbi__get32le(s); // discard vres
+      stbi__get32le(s); // discard colorsused
+      stbi__get32le(s); // discard max important
+      if (hsz == 40 || hsz == 56) {
+         if (hsz == 56) {
+            stbi__get32le(s);
+            stbi__get32le(s);
+            stbi__get32le(s);
+            stbi__get32le(s);
+         }
+         if (info->bpp == 16 || info->bpp == 32) {
+            if (compress == 0) {
+               stbi__bmp_set_mask_defaults(info, compress);
+            } else if (compress == 3) {
+               info->mr = stbi__get32le(s);
+               info->mg = stbi__get32le(s);
+               info->mb = stbi__get32le(s);
+               info->extra_read += 12;
+               // not documented, but generated by photoshop and handled by mspaint
+               if (info->mr == info->mg && info->mg == info->mb) {
+                  // ?!?!?
+                  return stbi__errpuc("bad BMP", "bad BMP");
+               }
+            } else
+               return stbi__errpuc("bad BMP", "bad BMP");
+         }
+      } else {
+         // V4/V5 header
+         int i;
+         if (hsz != 108 && hsz != 124)
+            return stbi__errpuc("bad BMP", "bad BMP");
+         info->mr = stbi__get32le(s);
+         info->mg = stbi__get32le(s);
+         info->mb = stbi__get32le(s);
+         info->ma = stbi__get32le(s);
+         if (compress != 3) // override mr/mg/mb unless in BI_BITFIELDS mode, as per docs
+            stbi__bmp_set_mask_defaults(info, compress);
+         stbi__get32le(s); // discard color space
+         for (i=0; i < 12; ++i)
+            stbi__get32le(s); // discard color space parameters
+         if (hsz == 124) {
+            stbi__get32le(s); // discard rendering intent
+            stbi__get32le(s); // discard offset of profile data
+            stbi__get32le(s); // discard size of profile data
+            stbi__get32le(s); // discard reserved
+         }
+      }
+   }
+   return (void *) 1;
+}
+
+
+static void *stbi__bmp_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *out;
+   unsigned int mr=0,mg=0,mb=0,ma=0, all_a;
+   stbi_uc pal[256][4];
+   int psize=0,i,j,width;
+   int flip_vertically, pad, target;
+   stbi__bmp_data info;
+   STBI_NOTUSED(ri);
+
+   info.all_a = 255;
+   if (stbi__bmp_parse_header(s, &info) == NULL)
+      return NULL; // error code already set
+
+   flip_vertically = ((int) s->img_y) > 0;
+   s->img_y = abs((int) s->img_y);
+
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   mr = info.mr;
+   mg = info.mg;
+   mb = info.mb;
+   ma = info.ma;
+   all_a = info.all_a;
+
+   if (info.hsz == 12) {
+      if (info.bpp < 24)
+         psize = (info.offset - info.extra_read - 24) / 3;
+   } else {
+      if (info.bpp < 16)
+         psize = (info.offset - info.extra_read - info.hsz) >> 2;
+   }
+   if (psize == 0) {
+      // accept some number of extra bytes after the header, but if the offset points either to before
+      // the header ends or implies a large amount of extra data, reject the file as malformed
+      int bytes_read_so_far = s->callback_already_read + (int)(s->img_buffer - s->img_buffer_original);
+      int header_limit = 1024; // max we actually read is below 256 bytes currently.
+      int extra_data_limit = 256*4; // what ordinarily goes here is a palette; 256 entries*4 bytes is its max size.
+      if (bytes_read_so_far <= 0 || bytes_read_so_far > header_limit) {
+         return stbi__errpuc("bad header", "Corrupt BMP");
+      }
+      // we established that bytes_read_so_far is positive and sensible.
+      // the first half of this test rejects offsets that are either too small positives, or
+      // negative, and guarantees that info.offset >= bytes_read_so_far > 0. this in turn
+      // ensures the number computed in the second half of the test can't overflow.
+      if (info.offset < bytes_read_so_far || info.offset - bytes_read_so_far > extra_data_limit) {
+         return stbi__errpuc("bad offset", "Corrupt BMP");
+      } else {
+         stbi__skip(s, info.offset - bytes_read_so_far);
+      }
+   }
+
+   if (info.bpp == 24 && ma == 0xff000000)
+      s->img_n = 3;
+   else
+      s->img_n = ma ? 4 : 3;
+   if (req_comp && req_comp >= 3) // we can directly decode 3 or 4
+      target = req_comp;
+   else
+      target = s->img_n; // if they want monochrome, we'll post-convert
+
+   // sanity-check size
+   if (!stbi__mad3sizes_valid(target, s->img_x, s->img_y, 0))
+      return stbi__errpuc("too large", "Corrupt BMP");
+
+   out = (stbi_uc *) stbi__malloc_mad3(target, s->img_x, s->img_y, 0);
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   if (info.bpp < 16) {
+      int z=0;
+      if (psize == 0 || psize > 256) { STBI_FREE(out); return stbi__errpuc("invalid", "Corrupt BMP"); }
+      for (i=0; i < psize; ++i) {
+         pal[i][2] = stbi__get8(s);
+         pal[i][1] = stbi__get8(s);
+         pal[i][0] = stbi__get8(s);
+         if (info.hsz != 12) stbi__get8(s);
+         pal[i][3] = 255;
+      }
+      stbi__skip(s, info.offset - info.extra_read - info.hsz - psize * (info.hsz == 12 ? 3 : 4));
+      if (info.bpp == 1) width = (s->img_x + 7) >> 3;
+      else if (info.bpp == 4) width = (s->img_x + 1) >> 1;
+      else if (info.bpp == 8) width = s->img_x;
+      else { STBI_FREE(out); return stbi__errpuc("bad bpp", "Corrupt BMP"); }
+      pad = (-width)&3;
+      if (info.bpp == 1) {
+         for (j=0; j < (int) s->img_y; ++j) {
+            int bit_offset = 7, v = stbi__get8(s);
+            for (i=0; i < (int) s->img_x; ++i) {
+               int color = (v>>bit_offset)&0x1;
+               out[z++] = pal[color][0];
+               out[z++] = pal[color][1];
+               out[z++] = pal[color][2];
+               if (target == 4) out[z++] = 255;
+               if (i+1 == (int) s->img_x) break;
+               if((--bit_offset) < 0) {
+                  bit_offset = 7;
+                  v = stbi__get8(s);
+               }
+            }
+            stbi__skip(s, pad);
+         }
+      } else {
+         for (j=0; j < (int) s->img_y; ++j) {
+            for (i=0; i < (int) s->img_x; i += 2) {
+               int v=stbi__get8(s),v2=0;
+               if (info.bpp == 4) {
+                  v2 = v & 15;
+                  v >>= 4;
+               }
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+               if (i+1 == (int) s->img_x) break;
+               v = (info.bpp == 8) ? stbi__get8(s) : v2;
+               out[z++] = pal[v][0];
+               out[z++] = pal[v][1];
+               out[z++] = pal[v][2];
+               if (target == 4) out[z++] = 255;
+            }
+            stbi__skip(s, pad);
+         }
+      }
+   } else {
+      int rshift=0,gshift=0,bshift=0,ashift=0,rcount=0,gcount=0,bcount=0,acount=0;
+      int z = 0;
+      int easy=0;
+      stbi__skip(s, info.offset - info.extra_read - info.hsz);
+      if (info.bpp == 24) width = 3 * s->img_x;
+      else if (info.bpp == 16) width = 2*s->img_x;
+      else /* bpp = 32 and pad = 0 */ width=0;
+      pad = (-width) & 3;
+      if (info.bpp == 24) {
+         easy = 1;
+      } else if (info.bpp == 32) {
+         if (mb == 0xff && mg == 0xff00 && mr == 0x00ff0000 && ma == 0xff000000)
+            easy = 2;
+      }
+      if (!easy) {
+         if (!mr || !mg || !mb) { STBI_FREE(out); return stbi__errpuc("bad masks", "Corrupt BMP"); }
+         // right shift amt to put high bit in position #7
+         rshift = stbi__high_bit(mr)-7; rcount = stbi__bitcount(mr);
+         gshift = stbi__high_bit(mg)-7; gcount = stbi__bitcount(mg);
+         bshift = stbi__high_bit(mb)-7; bcount = stbi__bitcount(mb);
+         ashift = stbi__high_bit(ma)-7; acount = stbi__bitcount(ma);
+         if (rcount > 8 || gcount > 8 || bcount > 8 || acount > 8) { STBI_FREE(out); return stbi__errpuc("bad masks", "Corrupt BMP"); }
+      }
+      for (j=0; j < (int) s->img_y; ++j) {
+         if (easy) {
+            for (i=0; i < (int) s->img_x; ++i) {
+               unsigned char a;
+               out[z+2] = stbi__get8(s);
+               out[z+1] = stbi__get8(s);
+               out[z+0] = stbi__get8(s);
+               z += 3;
+               a = (easy == 2 ? stbi__get8(s) : 255);
+               all_a |= a;
+               if (target == 4) out[z++] = a;
+            }
+         } else {
+            int bpp = info.bpp;
+            for (i=0; i < (int) s->img_x; ++i) {
+               stbi__uint32 v = (bpp == 16 ? (stbi__uint32) stbi__get16le(s) : stbi__get32le(s));
+               unsigned int a;
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mr, rshift, rcount));
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mg, gshift, gcount));
+               out[z++] = STBI__BYTECAST(stbi__shiftsigned(v & mb, bshift, bcount));
+               a = (ma ? stbi__shiftsigned(v & ma, ashift, acount) : 255);
+               all_a |= a;
+               if (target == 4) out[z++] = STBI__BYTECAST(a);
+            }
+         }
+         stbi__skip(s, pad);
+      }
+   }
+
+   // if alpha channel is all 0s, replace with all 255s
+   if (target == 4 && all_a == 0)
+      for (i=4*s->img_x*s->img_y-1; i >= 0; i -= 4)
+         out[i] = 255;
+
+   if (flip_vertically) {
+      stbi_uc t;
+      for (j=0; j < (int) s->img_y>>1; ++j) {
+         stbi_uc *p1 = out +      j     *s->img_x*target;
+         stbi_uc *p2 = out + (s->img_y-1-j)*s->img_x*target;
+         for (i=0; i < (int) s->img_x*target; ++i) {
+            t = p1[i]; p1[i] = p2[i]; p2[i] = t;
+         }
+      }
+   }
+
+   if (req_comp && req_comp != target) {
+      out = stbi__convert_format(out, target, req_comp, s->img_x, s->img_y);
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+
+   *x = s->img_x;
+   *y = s->img_y;
+   if (comp) *comp = s->img_n;
+   return out;
+}
+#endif
+
+// Targa Truevision - TGA
+// by Jonathan Dummer
+#ifndef STBI_NO_TGA
+// returns STBI_rgb or whatever, 0 on error
+static int stbi__tga_get_comp(int bits_per_pixel, int is_grey, int* is_rgb16)
+{
+   // only RGB or RGBA (incl. 16bit) or grey allowed
+   if (is_rgb16) *is_rgb16 = 0;
+   switch(bits_per_pixel) {
+      case 8:  return STBI_grey;
+      case 16: if(is_grey) return STBI_grey_alpha;
+               // fallthrough
+      case 15: if(is_rgb16) *is_rgb16 = 1;
+               return STBI_rgb;
+      case 24: // fallthrough
+      case 32: return bits_per_pixel/8;
+      default: return 0;
+   }
+}
+
+static int stbi__tga_info(stbi__context *s, int *x, int *y, int *comp)
+{
+    int tga_w, tga_h, tga_comp, tga_image_type, tga_bits_per_pixel, tga_colormap_bpp;
+    int sz, tga_colormap_type;
+    stbi__get8(s);                   // discard Offset
+    tga_colormap_type = stbi__get8(s); // colormap type
+    if( tga_colormap_type > 1 ) {
+        stbi__rewind(s);
+        return 0;      // only RGB or indexed allowed
+    }
+    tga_image_type = stbi__get8(s); // image type
+    if ( tga_colormap_type == 1 ) { // colormapped (paletted) image
+        if (tga_image_type != 1 && tga_image_type != 9) {
+            stbi__rewind(s);
+            return 0;
+        }
+        stbi__skip(s,4);       // skip index of first colormap entry and number of entries
+        sz = stbi__get8(s);    //   check bits per palette color entry
+        if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) {
+            stbi__rewind(s);
+            return 0;
+        }
+        stbi__skip(s,4);       // skip image x and y origin
+        tga_colormap_bpp = sz;
+    } else { // "normal" image w/o colormap - only RGB or grey allowed, +/- RLE
+        if ( (tga_image_type != 2) && (tga_image_type != 3) && (tga_image_type != 10) && (tga_image_type != 11) ) {
+            stbi__rewind(s);
+            return 0; // only RGB or grey allowed, +/- RLE
+        }
+        stbi__skip(s,9); // skip colormap specification and image x/y origin
+        tga_colormap_bpp = 0;
+    }
+    tga_w = stbi__get16le(s);
+    if( tga_w < 1 ) {
+        stbi__rewind(s);
+        return 0;   // test width
+    }
+    tga_h = stbi__get16le(s);
+    if( tga_h < 1 ) {
+        stbi__rewind(s);
+        return 0;   // test height
+    }
+    tga_bits_per_pixel = stbi__get8(s); // bits per pixel
+    stbi__get8(s); // ignore alpha bits
+    if (tga_colormap_bpp != 0) {
+        if((tga_bits_per_pixel != 8) && (tga_bits_per_pixel != 16)) {
+            // when using a colormap, tga_bits_per_pixel is the size of the indexes
+            // I don't think anything but 8 or 16bit indexes makes sense
+            stbi__rewind(s);
+            return 0;
+        }
+        tga_comp = stbi__tga_get_comp(tga_colormap_bpp, 0, NULL);
+    } else {
+        tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3) || (tga_image_type == 11), NULL);
+    }
+    if(!tga_comp) {
+      stbi__rewind(s);
+      return 0;
+    }
+    if (x) *x = tga_w;
+    if (y) *y = tga_h;
+    if (comp) *comp = tga_comp;
+    return 1;                   // seems to have passed everything
+}
+
+static int stbi__tga_test(stbi__context *s)
+{
+   int res = 0;
+   int sz, tga_color_type;
+   stbi__get8(s);      //   discard Offset
+   tga_color_type = stbi__get8(s);   //   color type
+   if ( tga_color_type > 1 ) goto errorEnd;   //   only RGB or indexed allowed
+   sz = stbi__get8(s);   //   image type
+   if ( tga_color_type == 1 ) { // colormapped (paletted) image
+      if (sz != 1 && sz != 9) goto errorEnd; // colortype 1 demands image type 1 or 9
+      stbi__skip(s,4);       // skip index of first colormap entry and number of entries
+      sz = stbi__get8(s);    //   check bits per palette color entry
+      if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) goto errorEnd;
+      stbi__skip(s,4);       // skip image x and y origin
+   } else { // "normal" image w/o colormap
+      if ( (sz != 2) && (sz != 3) && (sz != 10) && (sz != 11) ) goto errorEnd; // only RGB or grey allowed, +/- RLE
+      stbi__skip(s,9); // skip colormap specification and image x/y origin
+   }
+   if ( stbi__get16le(s) < 1 ) goto errorEnd;      //   test width
+   if ( stbi__get16le(s) < 1 ) goto errorEnd;      //   test height
+   sz = stbi__get8(s);   //   bits per pixel
+   if ( (tga_color_type == 1) && (sz != 8) && (sz != 16) ) goto errorEnd; // for colormapped images, bpp is size of an index
+   if ( (sz != 8) && (sz != 15) && (sz != 16) && (sz != 24) && (sz != 32) ) goto errorEnd;
+
+   res = 1; // if we got this far, everything's good and we can return 1 instead of 0
+
+errorEnd:
+   stbi__rewind(s);
+   return res;
+}
+
+// read 16bit value and convert to 24bit RGB
+static void stbi__tga_read_rgb16(stbi__context *s, stbi_uc* out)
+{
+   stbi__uint16 px = (stbi__uint16)stbi__get16le(s);
+   stbi__uint16 fiveBitMask = 31;
+   // we have 3 channels with 5bits each
+   int r = (px >> 10) & fiveBitMask;
+   int g = (px >> 5) & fiveBitMask;
+   int b = px & fiveBitMask;
+   // Note that this saves the data in RGB(A) order, so it doesn't need to be swapped later
+   out[0] = (stbi_uc)((r * 255)/31);
+   out[1] = (stbi_uc)((g * 255)/31);
+   out[2] = (stbi_uc)((b * 255)/31);
+
+   // some people claim that the most significant bit might be used for alpha
+   // (possibly if an alpha-bit is set in the "image descriptor byte")
+   // but that only made 16bit test images completely translucent..
+   // so let's treat all 15 and 16bit TGAs as RGB with no alpha.
+}
+
+static void *stbi__tga_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   //   read in the TGA header stuff
+   int tga_offset = stbi__get8(s);
+   int tga_indexed = stbi__get8(s);
+   int tga_image_type = stbi__get8(s);
+   int tga_is_RLE = 0;
+   int tga_palette_start = stbi__get16le(s);
+   int tga_palette_len = stbi__get16le(s);
+   int tga_palette_bits = stbi__get8(s);
+   int tga_x_origin = stbi__get16le(s);
+   int tga_y_origin = stbi__get16le(s);
+   int tga_width = stbi__get16le(s);
+   int tga_height = stbi__get16le(s);
+   int tga_bits_per_pixel = stbi__get8(s);
+   int tga_comp, tga_rgb16=0;
+   int tga_inverted = stbi__get8(s);
+   // int tga_alpha_bits = tga_inverted & 15; // the 4 lowest bits - unused (useless?)
+   //   image data
+   unsigned char *tga_data;
+   unsigned char *tga_palette = NULL;
+   int i, j;
+   unsigned char raw_data[4] = {0};
+   int RLE_count = 0;
+   int RLE_repeating = 0;
+   int read_next_pixel = 1;
+   STBI_NOTUSED(ri);
+   STBI_NOTUSED(tga_x_origin); // @TODO
+   STBI_NOTUSED(tga_y_origin); // @TODO
+
+   if (tga_height > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (tga_width > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   //   do a tiny bit of precessing
+   if ( tga_image_type >= 8 )
+   {
+      tga_image_type -= 8;
+      tga_is_RLE = 1;
+   }
+   tga_inverted = 1 - ((tga_inverted >> 5) & 1);
+
+   //   If I'm paletted, then I'll use the number of bits from the palette
+   if ( tga_indexed ) tga_comp = stbi__tga_get_comp(tga_palette_bits, 0, &tga_rgb16);
+   else tga_comp = stbi__tga_get_comp(tga_bits_per_pixel, (tga_image_type == 3), &tga_rgb16);
+
+   if(!tga_comp) // shouldn't really happen, stbi__tga_test() should have ensured basic consistency
+      return stbi__errpuc("bad format", "Can't find out TGA pixelformat");
+
+   //   tga info
+   *x = tga_width;
+   *y = tga_height;
+   if (comp) *comp = tga_comp;
+
+   if (!stbi__mad3sizes_valid(tga_width, tga_height, tga_comp, 0))
+      return stbi__errpuc("too large", "Corrupt TGA");
+
+   tga_data = (unsigned char*)stbi__malloc_mad3(tga_width, tga_height, tga_comp, 0);
+   if (!tga_data) return stbi__errpuc("outofmem", "Out of memory");
+
+   // skip to the data's starting position (offset usually = 0)
+   stbi__skip(s, tga_offset );
+
+   if ( !tga_indexed && !tga_is_RLE && !tga_rgb16 ) {
+      for (i=0; i < tga_height; ++i) {
+         int row = tga_inverted ? tga_height -i - 1 : i;
+         stbi_uc *tga_row = tga_data + row*tga_width*tga_comp;
+         stbi__getn(s, tga_row, tga_width * tga_comp);
+      }
+   } else  {
+      //   do I need to load a palette?
+      if ( tga_indexed)
+      {
+         if (tga_palette_len == 0) {  /* you have to have at least one entry! */
+            STBI_FREE(tga_data);
+            return stbi__errpuc("bad palette", "Corrupt TGA");
+         }
+
+         //   any data to skip? (offset usually = 0)
+         stbi__skip(s, tga_palette_start );
+         //   load the palette
+         tga_palette = (unsigned char*)stbi__malloc_mad2(tga_palette_len, tga_comp, 0);
+         if (!tga_palette) {
+            STBI_FREE(tga_data);
+            return stbi__errpuc("outofmem", "Out of memory");
+         }
+         if (tga_rgb16) {
+            stbi_uc *pal_entry = tga_palette;
+            STBI_ASSERT(tga_comp == STBI_rgb);
+            for (i=0; i < tga_palette_len; ++i) {
+               stbi__tga_read_rgb16(s, pal_entry);
+               pal_entry += tga_comp;
+            }
+         } else if (!stbi__getn(s, tga_palette, tga_palette_len * tga_comp)) {
+               STBI_FREE(tga_data);
+               STBI_FREE(tga_palette);
+               return stbi__errpuc("bad palette", "Corrupt TGA");
+         }
+      }
+      //   load the data
+      for (i=0; i < tga_width * tga_height; ++i)
+      {
+         //   if I'm in RLE mode, do I need to get a RLE stbi__pngchunk?
+         if ( tga_is_RLE )
+         {
+            if ( RLE_count == 0 )
+            {
+               //   yep, get the next byte as a RLE command
+               int RLE_cmd = stbi__get8(s);
+               RLE_count = 1 + (RLE_cmd & 127);
+               RLE_repeating = RLE_cmd >> 7;
+               read_next_pixel = 1;
+            } else if ( !RLE_repeating )
+            {
+               read_next_pixel = 1;
+            }
+         } else
+         {
+            read_next_pixel = 1;
+         }
+         //   OK, if I need to read a pixel, do it now
+         if ( read_next_pixel )
+         {
+            //   load however much data we did have
+            if ( tga_indexed )
+            {
+               // read in index, then perform the lookup
+               int pal_idx = (tga_bits_per_pixel == 8) ? stbi__get8(s) : stbi__get16le(s);
+               if ( pal_idx >= tga_palette_len ) {
+                  // invalid index
+                  pal_idx = 0;
+               }
+               pal_idx *= tga_comp;
+               for (j = 0; j < tga_comp; ++j) {
+                  raw_data[j] = tga_palette[pal_idx+j];
+               }
+            } else if(tga_rgb16) {
+               STBI_ASSERT(tga_comp == STBI_rgb);
+               stbi__tga_read_rgb16(s, raw_data);
+            } else {
+               //   read in the data raw
+               for (j = 0; j < tga_comp; ++j) {
+                  raw_data[j] = stbi__get8(s);
+               }
+            }
+            //   clear the reading flag for the next pixel
+            read_next_pixel = 0;
+         } // end of reading a pixel
+
+         // copy data
+         for (j = 0; j < tga_comp; ++j)
+           tga_data[i*tga_comp+j] = raw_data[j];
+
+         //   in case we're in RLE mode, keep counting down
+         --RLE_count;
+      }
+      //   do I need to invert the image?
+      if ( tga_inverted )
+      {
+         for (j = 0; j*2 < tga_height; ++j)
+         {
+            int index1 = j * tga_width * tga_comp;
+            int index2 = (tga_height - 1 - j) * tga_width * tga_comp;
+            for (i = tga_width * tga_comp; i > 0; --i)
+            {
+               unsigned char temp = tga_data[index1];
+               tga_data[index1] = tga_data[index2];
+               tga_data[index2] = temp;
+               ++index1;
+               ++index2;
+            }
+         }
+      }
+      //   clear my palette, if I had one
+      if ( tga_palette != NULL )
+      {
+         STBI_FREE( tga_palette );
+      }
+   }
+
+   // swap RGB - if the source data was RGB16, it already is in the right order
+   if (tga_comp >= 3 && !tga_rgb16)
+   {
+      unsigned char* tga_pixel = tga_data;
+      for (i=0; i < tga_width * tga_height; ++i)
+      {
+         unsigned char temp = tga_pixel[0];
+         tga_pixel[0] = tga_pixel[2];
+         tga_pixel[2] = temp;
+         tga_pixel += tga_comp;
+      }
+   }
+
+   // convert to target component count
+   if (req_comp && req_comp != tga_comp)
+      tga_data = stbi__convert_format(tga_data, tga_comp, req_comp, tga_width, tga_height);
+
+   //   the things I do to get rid of an error message, and yet keep
+   //   Microsoft's C compilers happy... [8^(
+   tga_palette_start = tga_palette_len = tga_palette_bits =
+         tga_x_origin = tga_y_origin = 0;
+   STBI_NOTUSED(tga_palette_start);
+   //   OK, done
+   return tga_data;
+}
+#endif
+
+// *************************************************************************************************
+// Photoshop PSD loader -- PD by Thatcher Ulrich, integration by Nicolas Schulz, tweaked by STB
+
+#ifndef STBI_NO_PSD
+static int stbi__psd_test(stbi__context *s)
+{
+   int r = (stbi__get32be(s) == 0x38425053);
+   stbi__rewind(s);
+   return r;
+}
+
+static int stbi__psd_decode_rle(stbi__context *s, stbi_uc *p, int pixelCount)
+{
+   int count, nleft, len;
+
+   count = 0;
+   while ((nleft = pixelCount - count) > 0) {
+      len = stbi__get8(s);
+      if (len == 128) {
+         // No-op.
+      } else if (len < 128) {
+         // Copy next len+1 bytes literally.
+         len++;
+         if (len > nleft) return 0; // corrupt data
+         count += len;
+         while (len) {
+            *p = stbi__get8(s);
+            p += 4;
+            len--;
+         }
+      } else if (len > 128) {
+         stbi_uc   val;
+         // Next -len+1 bytes in the dest are replicated from next source byte.
+         // (Interpret len as a negative 8-bit int.)
+         len = 257 - len;
+         if (len > nleft) return 0; // corrupt data
+         val = stbi__get8(s);
+         count += len;
+         while (len) {
+            *p = val;
+            p += 4;
+            len--;
+         }
+      }
+   }
+
+   return 1;
+}
+
+static void *stbi__psd_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri, int bpc)
+{
+   int pixelCount;
+   int channelCount, compression;
+   int channel, i;
+   int bitdepth;
+   int w,h;
+   stbi_uc *out;
+   STBI_NOTUSED(ri);
+
+   // Check identifier
+   if (stbi__get32be(s) != 0x38425053)   // "8BPS"
+      return stbi__errpuc("not PSD", "Corrupt PSD image");
+
+   // Check file type version.
+   if (stbi__get16be(s) != 1)
+      return stbi__errpuc("wrong version", "Unsupported version of PSD image");
+
+   // Skip 6 reserved bytes.
+   stbi__skip(s, 6 );
+
+   // Read the number of channels (R, G, B, A, etc).
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16)
+      return stbi__errpuc("wrong channel count", "Unsupported number of channels in PSD image");
+
+   // Read the rows and columns of the image.
+   h = stbi__get32be(s);
+   w = stbi__get32be(s);
+
+   if (h > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (w > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   // Make sure the depth is 8 bits.
+   bitdepth = stbi__get16be(s);
+   if (bitdepth != 8 && bitdepth != 16)
+      return stbi__errpuc("unsupported bit depth", "PSD bit depth is not 8 or 16 bit");
+
+   // Make sure the color mode is RGB.
+   // Valid options are:
+   //   0: Bitmap
+   //   1: Grayscale
+   //   2: Indexed color
+   //   3: RGB color
+   //   4: CMYK color
+   //   7: Multichannel
+   //   8: Duotone
+   //   9: Lab color
+   if (stbi__get16be(s) != 3)
+      return stbi__errpuc("wrong color format", "PSD is not in RGB color format");
+
+   // Skip the Mode Data.  (It's the palette for indexed color; other info for other modes.)
+   stbi__skip(s,stbi__get32be(s) );
+
+   // Skip the image resources.  (resolution, pen tool paths, etc)
+   stbi__skip(s, stbi__get32be(s) );
+
+   // Skip the reserved data.
+   stbi__skip(s, stbi__get32be(s) );
+
+   // Find out if the data is compressed.
+   // Known values:
+   //   0: no compression
+   //   1: RLE compressed
+   compression = stbi__get16be(s);
+   if (compression > 1)
+      return stbi__errpuc("bad compression", "PSD has an unknown compression format");
+
+   // Check size
+   if (!stbi__mad3sizes_valid(4, w, h, 0))
+      return stbi__errpuc("too large", "Corrupt PSD");
+
+   // Create the destination image.
+
+   if (!compression && bitdepth == 16 && bpc == 16) {
+      out = (stbi_uc *) stbi__malloc_mad3(8, w, h, 0);
+      ri->bits_per_channel = 16;
+   } else
+      out = (stbi_uc *) stbi__malloc(4 * w*h);
+
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   pixelCount = w*h;
+
+   // Initialize the data to zero.
+   //memset( out, 0, pixelCount * 4 );
+
+   // Finally, the image data.
+   if (compression) {
+      // RLE as used by .PSD and .TIFF
+      // Loop until you get the number of unpacked bytes you are expecting:
+      //     Read the next source byte into n.
+      //     If n is between 0 and 127 inclusive, copy the next n+1 bytes literally.
+      //     Else if n is between -127 and -1 inclusive, copy the next byte -n+1 times.
+      //     Else if n is 128, noop.
+      // Endloop
+
+      // The RLE-compressed data is preceded by a 2-byte data count for each row in the data,
+      // which we're going to just skip.
+      stbi__skip(s, h * channelCount * 2 );
+
+      // Read the RLE data by channel.
+      for (channel = 0; channel < 4; channel++) {
+         stbi_uc *p;
+
+         p = out+channel;
+         if (channel >= channelCount) {
+            // Fill this channel with default data.
+            for (i = 0; i < pixelCount; i++, p += 4)
+               *p = (channel == 3 ? 255 : 0);
+         } else {
+            // Read the RLE data.
+            if (!stbi__psd_decode_rle(s, p, pixelCount)) {
+               STBI_FREE(out);
+               return stbi__errpuc("corrupt", "bad RLE data");
+            }
+         }
+      }
+
+   } else {
+      // We're at the raw image data.  It's each channel in order (Red, Green, Blue, Alpha, ...)
+      // where each channel consists of an 8-bit (or 16-bit) value for each pixel in the image.
+
+      // Read the data by channel.
+      for (channel = 0; channel < 4; channel++) {
+         if (channel >= channelCount) {
+            // Fill this channel with default data.
+            if (bitdepth == 16 && bpc == 16) {
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               stbi__uint16 val = channel == 3 ? 65535 : 0;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = val;
+            } else {
+               stbi_uc *p = out+channel;
+               stbi_uc val = channel == 3 ? 255 : 0;
+               for (i = 0; i < pixelCount; i++, p += 4)
+                  *p = val;
+            }
+         } else {
+            if (ri->bits_per_channel == 16) {    // output bpc
+               stbi__uint16 *q = ((stbi__uint16 *) out) + channel;
+               for (i = 0; i < pixelCount; i++, q += 4)
+                  *q = (stbi__uint16) stbi__get16be(s);
+            } else {
+               stbi_uc *p = out+channel;
+               if (bitdepth == 16) {  // input bpc
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = (stbi_uc) (stbi__get16be(s) >> 8);
+               } else {
+                  for (i = 0; i < pixelCount; i++, p += 4)
+                     *p = stbi__get8(s);
+               }
+            }
+         }
+      }
+   }
+
+   // remove weird white matte from PSD
+   if (channelCount >= 4) {
+      if (ri->bits_per_channel == 16) {
+         for (i=0; i < w*h; ++i) {
+            stbi__uint16 *pixel = (stbi__uint16 *) out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 65535) {
+               float a = pixel[3] / 65535.0f;
+               float ra = 1.0f / a;
+               float inv_a = 65535.0f * (1 - ra);
+               pixel[0] = (stbi__uint16) (pixel[0]*ra + inv_a);
+               pixel[1] = (stbi__uint16) (pixel[1]*ra + inv_a);
+               pixel[2] = (stbi__uint16) (pixel[2]*ra + inv_a);
+            }
+         }
+      } else {
+         for (i=0; i < w*h; ++i) {
+            unsigned char *pixel = out + 4*i;
+            if (pixel[3] != 0 && pixel[3] != 255) {
+               float a = pixel[3] / 255.0f;
+               float ra = 1.0f / a;
+               float inv_a = 255.0f * (1 - ra);
+               pixel[0] = (unsigned char) (pixel[0]*ra + inv_a);
+               pixel[1] = (unsigned char) (pixel[1]*ra + inv_a);
+               pixel[2] = (unsigned char) (pixel[2]*ra + inv_a);
+            }
+         }
+      }
+   }
+
+   // convert to desired output format
+   if (req_comp && req_comp != 4) {
+      if (ri->bits_per_channel == 16)
+         out = (stbi_uc *) stbi__convert_format16((stbi__uint16 *) out, 4, req_comp, w, h);
+      else
+         out = stbi__convert_format(out, 4, req_comp, w, h);
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+
+   if (comp) *comp = 4;
+   *y = h;
+   *x = w;
+
+   return out;
+}
+#endif
+
+// *************************************************************************************************
+// Softimage PIC loader
+// by Tom Seddon
+//
+// See http://softimage.wiki.softimage.com/index.php/INFO:_PIC_file_format
+// See http://ozviz.wasp.uwa.edu.au/~pbourke/dataformats/softimagepic/
+
+#ifndef STBI_NO_PIC
+static int stbi__pic_is4(stbi__context *s,const char *str)
+{
+   int i;
+   for (i=0; i<4; ++i)
+      if (stbi__get8(s) != (stbi_uc)str[i])
+         return 0;
+
+   return 1;
+}
+
+static int stbi__pic_test_core(stbi__context *s)
+{
+   int i;
+
+   if (!stbi__pic_is4(s,"\x53\x80\xF6\x34"))
+      return 0;
+
+   for(i=0;i<84;++i)
+      stbi__get8(s);
+
+   if (!stbi__pic_is4(s,"PICT"))
+      return 0;
+
+   return 1;
+}
+
+typedef struct
+{
+   stbi_uc size,type,channel;
+} stbi__pic_packet;
+
+static stbi_uc *stbi__readval(stbi__context *s, int channel, stbi_uc *dest)
+{
+   int mask=0x80, i;
+
+   for (i=0; i<4; ++i, mask>>=1) {
+      if (channel & mask) {
+         if (stbi__at_eof(s)) return stbi__errpuc("bad file","PIC file too short");
+         dest[i]=stbi__get8(s);
+      }
+   }
+
+   return dest;
+}
+
+static void stbi__copyval(int channel,stbi_uc *dest,const stbi_uc *src)
+{
+   int mask=0x80,i;
+
+   for (i=0;i<4; ++i, mask>>=1)
+      if (channel&mask)
+         dest[i]=src[i];
+}
+
+static stbi_uc *stbi__pic_load_core(stbi__context *s,int width,int height,int *comp, stbi_uc *result)
+{
+   int act_comp=0,num_packets=0,y,chained;
+   stbi__pic_packet packets[10];
+
+   // this will (should...) cater for even some bizarre stuff like having data
+    // for the same channel in multiple packets.
+   do {
+      stbi__pic_packet *packet;
+
+      if (num_packets==sizeof(packets)/sizeof(packets[0]))
+         return stbi__errpuc("bad format","too many packets");
+
+      packet = &packets[num_packets++];
+
+      chained = stbi__get8(s);
+      packet->size    = stbi__get8(s);
+      packet->type    = stbi__get8(s);
+      packet->channel = stbi__get8(s);
+
+      act_comp |= packet->channel;
+
+      if (stbi__at_eof(s))          return stbi__errpuc("bad file","file too short (reading packets)");
+      if (packet->size != 8)  return stbi__errpuc("bad format","packet isn't 8bpp");
+   } while (chained);
+
+   *comp = (act_comp & 0x10 ? 4 : 3); // has alpha channel?
+
+   for(y=0; y<height; ++y) {
+      int packet_idx;
+
+      for(packet_idx=0; packet_idx < num_packets; ++packet_idx) {
+         stbi__pic_packet *packet = &packets[packet_idx];
+         stbi_uc *dest = result+y*width*4;
+
+         switch (packet->type) {
+            default:
+               return stbi__errpuc("bad format","packet has bad compression type");
+
+            case 0: {//uncompressed
+               int x;
+
+               for(x=0;x<width;++x, dest+=4)
+                  if (!stbi__readval(s,packet->channel,dest))
+                     return 0;
+               break;
+            }
+
+            case 1://Pure RLE
+               {
+                  int left=width, i;
+
+                  while (left>0) {
+                     stbi_uc count,value[4];
+
+                     count=stbi__get8(s);
+                     if (stbi__at_eof(s))   return stbi__errpuc("bad file","file too short (pure read count)");
+
+                     if (count > left)
+                        count = (stbi_uc) left;
+
+                     if (!stbi__readval(s,packet->channel,value))  return 0;
+
+                     for(i=0; i<count; ++i,dest+=4)
+                        stbi__copyval(packet->channel,dest,value);
+                     left -= count;
+                  }
+               }
+               break;
+
+            case 2: {//Mixed RLE
+               int left=width;
+               while (left>0) {
+                  int count = stbi__get8(s), i;
+                  if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (mixed read count)");
+
+                  if (count >= 128) { // Repeated
+                     stbi_uc value[4];
+
+                     if (count==128)
+                        count = stbi__get16be(s);
+                     else
+                        count -= 127;
+                     if (count > left)
+                        return stbi__errpuc("bad file","scanline overrun");
+
+                     if (!stbi__readval(s,packet->channel,value))
+                        return 0;
+
+                     for(i=0;i<count;++i, dest += 4)
+                        stbi__copyval(packet->channel,dest,value);
+                  } else { // Raw
+                     ++count;
+                     if (count>left) return stbi__errpuc("bad file","scanline overrun");
+
+                     for(i=0;i<count;++i, dest+=4)
+                        if (!stbi__readval(s,packet->channel,dest))
+                           return 0;
+                  }
+                  left-=count;
+               }
+               break;
+            }
+         }
+      }
+   }
+
+   return result;
+}
+
+static void *stbi__pic_load(stbi__context *s,int *px,int *py,int *comp,int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *result;
+   int i, x,y, internal_comp;
+   STBI_NOTUSED(ri);
+
+   if (!comp) comp = &internal_comp;
+
+   for (i=0; i<92; ++i)
+      stbi__get8(s);
+
+   x = stbi__get16be(s);
+   y = stbi__get16be(s);
+
+   if (y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   if (stbi__at_eof(s))  return stbi__errpuc("bad file","file too short (pic header)");
+   if (!stbi__mad3sizes_valid(x, y, 4, 0)) return stbi__errpuc("too large", "PIC image too large to decode");
+
+   stbi__get32be(s); //skip `ratio'
+   stbi__get16be(s); //skip `fields'
+   stbi__get16be(s); //skip `pad'
+
+   // intermediate buffer is RGBA
+   result = (stbi_uc *) stbi__malloc_mad3(x, y, 4, 0);
+   if (!result) return stbi__errpuc("outofmem", "Out of memory");
+   memset(result, 0xff, x*y*4);
+
+   if (!stbi__pic_load_core(s,x,y,comp, result)) {
+      STBI_FREE(result);
+      result=0;
+   }
+   *px = x;
+   *py = y;
+   if (req_comp == 0) req_comp = *comp;
+   result=stbi__convert_format(result,4,req_comp,x,y);
+
+   return result;
+}
+
+static int stbi__pic_test(stbi__context *s)
+{
+   int r = stbi__pic_test_core(s);
+   stbi__rewind(s);
+   return r;
+}
+#endif
+
+// *************************************************************************************************
+// GIF loader -- public domain by Jean-Marc Lienher -- simplified/shrunk by stb
+
+#ifndef STBI_NO_GIF
+typedef struct
+{
+   stbi__int16 prefix;
+   stbi_uc first;
+   stbi_uc suffix;
+} stbi__gif_lzw;
+
+typedef struct
+{
+   int w,h;
+   stbi_uc *out;                 // output buffer (always 4 components)
+   stbi_uc *background;          // The current "background" as far as a gif is concerned
+   stbi_uc *history;
+   int flags, bgindex, ratio, transparent, eflags;
+   stbi_uc  pal[256][4];
+   stbi_uc lpal[256][4];
+   stbi__gif_lzw codes[8192];
+   stbi_uc *color_table;
+   int parse, step;
+   int lflags;
+   int start_x, start_y;
+   int max_x, max_y;
+   int cur_x, cur_y;
+   int line_size;
+   int delay;
+} stbi__gif;
+
+static int stbi__gif_test_raw(stbi__context *s)
+{
+   int sz;
+   if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8') return 0;
+   sz = stbi__get8(s);
+   if (sz != '9' && sz != '7') return 0;
+   if (stbi__get8(s) != 'a') return 0;
+   return 1;
+}
+
+static int stbi__gif_test(stbi__context *s)
+{
+   int r = stbi__gif_test_raw(s);
+   stbi__rewind(s);
+   return r;
+}
+
+static void stbi__gif_parse_colortable(stbi__context *s, stbi_uc pal[256][4], int num_entries, int transp)
+{
+   int i;
+   for (i=0; i < num_entries; ++i) {
+      pal[i][2] = stbi__get8(s);
+      pal[i][1] = stbi__get8(s);
+      pal[i][0] = stbi__get8(s);
+      pal[i][3] = transp == i ? 0 : 255;
+   }
+}
+
+static int stbi__gif_header(stbi__context *s, stbi__gif *g, int *comp, int is_info)
+{
+   stbi_uc version;
+   if (stbi__get8(s) != 'G' || stbi__get8(s) != 'I' || stbi__get8(s) != 'F' || stbi__get8(s) != '8')
+      return stbi__err("not GIF", "Corrupt GIF");
+
+   version = stbi__get8(s);
+   if (version != '7' && version != '9')    return stbi__err("not GIF", "Corrupt GIF");
+   if (stbi__get8(s) != 'a')                return stbi__err("not GIF", "Corrupt GIF");
+
+   stbi__g_failure_reason = "";
+   g->w = stbi__get16le(s);
+   g->h = stbi__get16le(s);
+   g->flags = stbi__get8(s);
+   g->bgindex = stbi__get8(s);
+   g->ratio = stbi__get8(s);
+   g->transparent = -1;
+
+   if (g->w > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+   if (g->h > STBI_MAX_DIMENSIONS) return stbi__err("too large","Very large image (corrupt?)");
+
+   if (comp != 0) *comp = 4;  // can't actually tell whether it's 3 or 4 until we parse the comments
+
+   if (is_info) return 1;
+
+   if (g->flags & 0x80)
+      stbi__gif_parse_colortable(s,g->pal, 2 << (g->flags & 7), -1);
+
+   return 1;
+}
+
+static int stbi__gif_info_raw(stbi__context *s, int *x, int *y, int *comp)
+{
+   stbi__gif* g = (stbi__gif*) stbi__malloc(sizeof(stbi__gif));
+   if (!g) return stbi__err("outofmem", "Out of memory");
+   if (!stbi__gif_header(s, g, comp, 1)) {
+      STBI_FREE(g);
+      stbi__rewind( s );
+      return 0;
+   }
+   if (x) *x = g->w;
+   if (y) *y = g->h;
+   STBI_FREE(g);
+   return 1;
+}
+
+static void stbi__out_gif_code(stbi__gif *g, stbi__uint16 code)
+{
+   stbi_uc *p, *c;
+   int idx;
+
+   // recurse to decode the prefixes, since the linked-list is backwards,
+   // and working backwards through an interleaved image would be nasty
+   if (g->codes[code].prefix >= 0)
+      stbi__out_gif_code(g, g->codes[code].prefix);
+
+   if (g->cur_y >= g->max_y) return;
+
+   idx = g->cur_x + g->cur_y;
+   p = &g->out[idx];
+   g->history[idx / 4] = 1;
+
+   c = &g->color_table[g->codes[code].suffix * 4];
+   if (c[3] > 128) { // don't render transparent pixels;
+      p[0] = c[2];
+      p[1] = c[1];
+      p[2] = c[0];
+      p[3] = c[3];
+   }
+   g->cur_x += 4;
+
+   if (g->cur_x >= g->max_x) {
+      g->cur_x = g->start_x;
+      g->cur_y += g->step;
+
+      while (g->cur_y >= g->max_y && g->parse > 0) {
+         g->step = (1 << g->parse) * g->line_size;
+         g->cur_y = g->start_y + (g->step >> 1);
+         --g->parse;
+      }
+   }
+}
+
+static stbi_uc *stbi__process_gif_raster(stbi__context *s, stbi__gif *g)
+{
+   stbi_uc lzw_cs;
+   stbi__int32 len, init_code;
+   stbi__uint32 first;
+   stbi__int32 codesize, codemask, avail, oldcode, bits, valid_bits, clear;
+   stbi__gif_lzw *p;
+
+   lzw_cs = stbi__get8(s);
+   if (lzw_cs > 12) return NULL;
+   clear = 1 << lzw_cs;
+   first = 1;
+   codesize = lzw_cs + 1;
+   codemask = (1 << codesize) - 1;
+   bits = 0;
+   valid_bits = 0;
+   for (init_code = 0; init_code < clear; init_code++) {
+      g->codes[init_code].prefix = -1;
+      g->codes[init_code].first = (stbi_uc) init_code;
+      g->codes[init_code].suffix = (stbi_uc) init_code;
+   }
+
+   // support no starting clear code
+   avail = clear+2;
+   oldcode = -1;
+
+   len = 0;
+   for(;;) {
+      if (valid_bits < codesize) {
+         if (len == 0) {
+            len = stbi__get8(s); // start new block
+            if (len == 0)
+               return g->out;
+         }
+         --len;
+         bits |= (stbi__int32) stbi__get8(s) << valid_bits;
+         valid_bits += 8;
+      } else {
+         stbi__int32 code = bits & codemask;
+         bits >>= codesize;
+         valid_bits -= codesize;
+         // @OPTIMIZE: is there some way we can accelerate the non-clear path?
+         if (code == clear) {  // clear code
+            codesize = lzw_cs + 1;
+            codemask = (1 << codesize) - 1;
+            avail = clear + 2;
+            oldcode = -1;
+            first = 0;
+         } else if (code == clear + 1) { // end of stream code
+            stbi__skip(s, len);
+            while ((len = stbi__get8(s)) > 0)
+               stbi__skip(s,len);
+            return g->out;
+         } else if (code <= avail) {
+            if (first) {
+               return stbi__errpuc("no clear code", "Corrupt GIF");
+            }
+
+            if (oldcode >= 0) {
+               p = &g->codes[avail++];
+               if (avail > 8192) {
+                  return stbi__errpuc("too many codes", "Corrupt GIF");
+               }
+
+               p->prefix = (stbi__int16) oldcode;
+               p->first = g->codes[oldcode].first;
+               p->suffix = (code == avail) ? p->first : g->codes[code].first;
+            } else if (code == avail)
+               return stbi__errpuc("illegal code in raster", "Corrupt GIF");
+
+            stbi__out_gif_code(g, (stbi__uint16) code);
+
+            if ((avail & codemask) == 0 && avail <= 0x0FFF) {
+               codesize++;
+               codemask = (1 << codesize) - 1;
+            }
+
+            oldcode = code;
+         } else {
+            return stbi__errpuc("illegal code in raster", "Corrupt GIF");
+         }
+      }
+   }
+}
+
+// this function is designed to support animated gifs, although stb_image doesn't support it
+// two back is the image from two frames ago, used for a very specific disposal format
+static stbi_uc *stbi__gif_load_next(stbi__context *s, stbi__gif *g, int *comp, int req_comp, stbi_uc *two_back)
+{
+   int dispose;
+   int first_frame;
+   int pi;
+   int pcount;
+   STBI_NOTUSED(req_comp);
+
+   // on first frame, any non-written pixels get the background colour (non-transparent)
+   first_frame = 0;
+   if (g->out == 0) {
+      if (!stbi__gif_header(s, g, comp,0)) return 0; // stbi__g_failure_reason set by stbi__gif_header
+      if (!stbi__mad3sizes_valid(4, g->w, g->h, 0))
+         return stbi__errpuc("too large", "GIF image is too large");
+      pcount = g->w * g->h;
+      g->out = (stbi_uc *) stbi__malloc(4 * pcount);
+      g->background = (stbi_uc *) stbi__malloc(4 * pcount);
+      g->history = (stbi_uc *) stbi__malloc(pcount);
+      if (!g->out || !g->background || !g->history)
+         return stbi__errpuc("outofmem", "Out of memory");
+
+      // image is treated as "transparent" at the start - ie, nothing overwrites the current background;
+      // background colour is only used for pixels that are not rendered first frame, after that "background"
+      // color refers to the color that was there the previous frame.
+      memset(g->out, 0x00, 4 * pcount);
+      memset(g->background, 0x00, 4 * pcount); // state of the background (starts transparent)
+      memset(g->history, 0x00, pcount);        // pixels that were affected previous frame
+      first_frame = 1;
+   } else {
+      // second frame - how do we dispose of the previous one?
+      dispose = (g->eflags & 0x1C) >> 2;
+      pcount = g->w * g->h;
+
+      if ((dispose == 3) && (two_back == 0)) {
+         dispose = 2; // if I don't have an image to revert back to, default to the old background
+      }
+
+      if (dispose == 3) { // use previous graphic
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &two_back[pi * 4], 4 );
+            }
+         }
+      } else if (dispose == 2) {
+         // restore what was changed last frame to background before that frame;
+         for (pi = 0; pi < pcount; ++pi) {
+            if (g->history[pi]) {
+               memcpy( &g->out[pi * 4], &g->background[pi * 4], 4 );
+            }
+         }
+      } else {
+         // This is a non-disposal case eithe way, so just
+         // leave the pixels as is, and they will become the new background
+         // 1: do not dispose
+         // 0:  not specified.
+      }
+
+      // background is what out is after the undoing of the previou frame;
+      memcpy( g->background, g->out, 4 * g->w * g->h );
+   }
+
+   // clear my history;
+   memset( g->history, 0x00, g->w * g->h );        // pixels that were affected previous frame
+
+   for (;;) {
+      int tag = stbi__get8(s);
+      switch (tag) {
+         case 0x2C: /* Image Descriptor */
+         {
+            stbi__int32 x, y, w, h;
+            stbi_uc *o;
+
+            x = stbi__get16le(s);
+            y = stbi__get16le(s);
+            w = stbi__get16le(s);
+            h = stbi__get16le(s);
+            if (((x + w) > (g->w)) || ((y + h) > (g->h)))
+               return stbi__errpuc("bad Image Descriptor", "Corrupt GIF");
+
+            g->line_size = g->w * 4;
+            g->start_x = x * 4;
+            g->start_y = y * g->line_size;
+            g->max_x   = g->start_x + w * 4;
+            g->max_y   = g->start_y + h * g->line_size;
+            g->cur_x   = g->start_x;
+            g->cur_y   = g->start_y;
+
+            // if the width of the specified rectangle is 0, that means
+            // we may not see *any* pixels or the image is malformed;
+            // to make sure this is caught, move the current y down to
+            // max_y (which is what out_gif_code checks).
+            if (w == 0)
+               g->cur_y = g->max_y;
+
+            g->lflags = stbi__get8(s);
+
+            if (g->lflags & 0x40) {
+               g->step = 8 * g->line_size; // first interlaced spacing
+               g->parse = 3;
+            } else {
+               g->step = g->line_size;
+               g->parse = 0;
+            }
+
+            if (g->lflags & 0x80) {
+               stbi__gif_parse_colortable(s,g->lpal, 2 << (g->lflags & 7), g->eflags & 0x01 ? g->transparent : -1);
+               g->color_table = (stbi_uc *) g->lpal;
+            } else if (g->flags & 0x80) {
+               g->color_table = (stbi_uc *) g->pal;
+            } else
+               return stbi__errpuc("missing color table", "Corrupt GIF");
+
+            o = stbi__process_gif_raster(s, g);
+            if (!o) return NULL;
+
+            // if this was the first frame,
+            pcount = g->w * g->h;
+            if (first_frame && (g->bgindex > 0)) {
+               // if first frame, any pixel not drawn to gets the background color
+               for (pi = 0; pi < pcount; ++pi) {
+                  if (g->history[pi] == 0) {
+                     g->pal[g->bgindex][3] = 255; // just in case it was made transparent, undo that; It will be reset next frame if need be;
+                     memcpy( &g->out[pi * 4], &g->pal[g->bgindex], 4 );
+                  }
+               }
+            }
+
+            return o;
+         }
+
+         case 0x21: // Comment Extension.
+         {
+            int len;
+            int ext = stbi__get8(s);
+            if (ext == 0xF9) { // Graphic Control Extension.
+               len = stbi__get8(s);
+               if (len == 4) {
+                  g->eflags = stbi__get8(s);
+                  g->delay = 10 * stbi__get16le(s); // delay - 1/100th of a second, saving as 1/1000ths.
+
+                  // unset old transparent
+                  if (g->transparent >= 0) {
+                     g->pal[g->transparent][3] = 255;
+                  }
+                  if (g->eflags & 0x01) {
+                     g->transparent = stbi__get8(s);
+                     if (g->transparent >= 0) {
+                        g->pal[g->transparent][3] = 0;
+                     }
+                  } else {
+                     // don't need transparent
+                     stbi__skip(s, 1);
+                     g->transparent = -1;
+                  }
+               } else {
+                  stbi__skip(s, len);
+                  break;
+               }
+            }
+            while ((len = stbi__get8(s)) != 0) {
+               stbi__skip(s, len);
+            }
+            break;
+         }
+
+         case 0x3B: // gif stream termination code
+            return (stbi_uc *) s; // using '1' causes warning on some compilers
+
+         default:
+            return stbi__errpuc("unknown code", "Corrupt GIF");
+      }
+   }
+}
+
+static void *stbi__load_gif_main_outofmem(stbi__gif *g, stbi_uc *out, int **delays)
+{
+   STBI_FREE(g->out);
+   STBI_FREE(g->history);
+   STBI_FREE(g->background);
+
+   if (out) STBI_FREE(out);
+   if (delays && *delays) STBI_FREE(*delays);
+   return stbi__errpuc("outofmem", "Out of memory");
+}
+
+static void *stbi__load_gif_main(stbi__context *s, int **delays, int *x, int *y, int *z, int *comp, int req_comp)
+{
+   if (stbi__gif_test(s)) {
+      int layers = 0;
+      stbi_uc *u = 0;
+      stbi_uc *out = 0;
+      stbi_uc *two_back = 0;
+      stbi__gif g;
+      int stride;
+      int out_size = 0;
+      int delays_size = 0;
+
+      STBI_NOTUSED(out_size);
+      STBI_NOTUSED(delays_size);
+
+      memset(&g, 0, sizeof(g));
+      if (delays) {
+         *delays = 0;
+      }
+
+      do {
+         u = stbi__gif_load_next(s, &g, comp, req_comp, two_back);
+         if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
+
+         if (u) {
+            *x = g.w;
+            *y = g.h;
+            ++layers;
+            stride = g.w * g.h * 4;
+
+            if (out) {
+               void *tmp = (stbi_uc*) STBI_REALLOC_SIZED( out, out_size, layers * stride );
+               if (!tmp)
+                  return stbi__load_gif_main_outofmem(&g, out, delays);
+               else {
+                   out = (stbi_uc*) tmp;
+                   out_size = layers * stride;
+               }
+
+               if (delays) {
+                  int *new_delays = (int*) STBI_REALLOC_SIZED( *delays, delays_size, sizeof(int) * layers );
+                  if (!new_delays)
+                     return stbi__load_gif_main_outofmem(&g, out, delays);
+                  *delays = new_delays;
+                  delays_size = layers * sizeof(int);
+               }
+            } else {
+               out = (stbi_uc*)stbi__malloc( layers * stride );
+               if (!out)
+                  return stbi__load_gif_main_outofmem(&g, out, delays);
+               out_size = layers * stride;
+               if (delays) {
+                  *delays = (int*) stbi__malloc( layers * sizeof(int) );
+                  if (!*delays)
+                     return stbi__load_gif_main_outofmem(&g, out, delays);
+                  delays_size = layers * sizeof(int);
+               }
+            }
+            memcpy( out + ((layers - 1) * stride), u, stride );
+            if (layers >= 2) {
+               two_back = out - 2 * stride;
+            }
+
+            if (delays) {
+               (*delays)[layers - 1U] = g.delay;
+            }
+         }
+      } while (u != 0);
+
+      // free temp buffer;
+      STBI_FREE(g.out);
+      STBI_FREE(g.history);
+      STBI_FREE(g.background);
+
+      // do the final conversion after loading everything;
+      if (req_comp && req_comp != 4)
+         out = stbi__convert_format(out, 4, req_comp, layers * g.w, g.h);
+
+      *z = layers;
+      return out;
+   } else {
+      return stbi__errpuc("not GIF", "Image was not as a gif type.");
+   }
+}
+
+static void *stbi__gif_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *u = 0;
+   stbi__gif g;
+   memset(&g, 0, sizeof(g));
+   STBI_NOTUSED(ri);
+
+   u = stbi__gif_load_next(s, &g, comp, req_comp, 0);
+   if (u == (stbi_uc *) s) u = 0;  // end of animated gif marker
+   if (u) {
+      *x = g.w;
+      *y = g.h;
+
+      // moved conversion to after successful load so that the same
+      // can be done for multiple frames.
+      if (req_comp && req_comp != 4)
+         u = stbi__convert_format(u, 4, req_comp, g.w, g.h);
+   } else if (g.out) {
+      // if there was an error and we allocated an image buffer, free it!
+      STBI_FREE(g.out);
+   }
+
+   // free buffers needed for multiple frame loading;
+   STBI_FREE(g.history);
+   STBI_FREE(g.background);
+
+   return u;
+}
+
+static int stbi__gif_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   return stbi__gif_info_raw(s,x,y,comp);
+}
+#endif
+
+// *************************************************************************************************
+// Radiance RGBE HDR loader
+// originally by Nicolas Schulz
+#ifndef STBI_NO_HDR
+static int stbi__hdr_test_core(stbi__context *s, const char *signature)
+{
+   int i;
+   for (i=0; signature[i]; ++i)
+      if (stbi__get8(s) != signature[i])
+          return 0;
+   stbi__rewind(s);
+   return 1;
+}
+
+static int stbi__hdr_test(stbi__context* s)
+{
+   int r = stbi__hdr_test_core(s, "#?RADIANCE\n");
+   stbi__rewind(s);
+   if(!r) {
+       r = stbi__hdr_test_core(s, "#?RGBE\n");
+       stbi__rewind(s);
+   }
+   return r;
+}
+
+#define STBI__HDR_BUFLEN  1024
+static char *stbi__hdr_gettoken(stbi__context *z, char *buffer)
+{
+   int len=0;
+   char c = '\0';
+
+   c = (char) stbi__get8(z);
+
+   while (!stbi__at_eof(z) && c != '\n') {
+      buffer[len++] = c;
+      if (len == STBI__HDR_BUFLEN-1) {
+         // flush to end of line
+         while (!stbi__at_eof(z) && stbi__get8(z) != '\n')
+            ;
+         break;
+      }
+      c = (char) stbi__get8(z);
+   }
+
+   buffer[len] = 0;
+   return buffer;
+}
+
+static void stbi__hdr_convert(float *output, stbi_uc *input, int req_comp)
+{
+   if ( input[3] != 0 ) {
+      float f1;
+      // Exponent
+      f1 = (float) ldexp(1.0f, input[3] - (int)(128 + 8));
+      if (req_comp <= 2)
+         output[0] = (input[0] + input[1] + input[2]) * f1 / 3;
+      else {
+         output[0] = input[0] * f1;
+         output[1] = input[1] * f1;
+         output[2] = input[2] * f1;
+      }
+      if (req_comp == 2) output[1] = 1;
+      if (req_comp == 4) output[3] = 1;
+   } else {
+      switch (req_comp) {
+         case 4: output[3] = 1; /* fallthrough */
+         case 3: output[0] = output[1] = output[2] = 0;
+                 break;
+         case 2: output[1] = 1; /* fallthrough */
+         case 1: output[0] = 0;
+                 break;
+      }
+   }
+}
+
+static float *stbi__hdr_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   char buffer[STBI__HDR_BUFLEN];
+   char *token;
+   int valid = 0;
+   int width, height;
+   stbi_uc *scanline;
+   float *hdr_data;
+   int len;
+   unsigned char count, value;
+   int i, j, k, c1,c2, z;
+   const char *headerToken;
+   STBI_NOTUSED(ri);
+
+   // Check identifier
+   headerToken = stbi__hdr_gettoken(s,buffer);
+   if (strcmp(headerToken, "#?RADIANCE") != 0 && strcmp(headerToken, "#?RGBE") != 0)
+      return stbi__errpf("not HDR", "Corrupt HDR image");
+
+   // Parse header
+   for(;;) {
+      token = stbi__hdr_gettoken(s,buffer);
+      if (token[0] == 0) break;
+      if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
+   }
+
+   if (!valid)    return stbi__errpf("unsupported format", "Unsupported HDR format");
+
+   // Parse width and height
+   // can't use sscanf() if we're not using stdio!
+   token = stbi__hdr_gettoken(s,buffer);
+   if (strncmp(token, "-Y ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
+   token += 3;
+   height = (int) strtol(token, &token, 10);
+   while (*token == ' ') ++token;
+   if (strncmp(token, "+X ", 3))  return stbi__errpf("unsupported data layout", "Unsupported HDR format");
+   token += 3;
+   width = (int) strtol(token, NULL, 10);
+
+   if (height > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Very large image (corrupt?)");
+   if (width > STBI_MAX_DIMENSIONS) return stbi__errpf("too large","Very large image (corrupt?)");
+
+   *x = width;
+   *y = height;
+
+   if (comp) *comp = 3;
+   if (req_comp == 0) req_comp = 3;
+
+   if (!stbi__mad4sizes_valid(width, height, req_comp, sizeof(float), 0))
+      return stbi__errpf("too large", "HDR image is too large");
+
+   // Read data
+   hdr_data = (float *) stbi__malloc_mad4(width, height, req_comp, sizeof(float), 0);
+   if (!hdr_data)
+      return stbi__errpf("outofmem", "Out of memory");
+
+   // Load image data
+   // image data is stored as some number of sca
+   if ( width < 8 || width >= 32768) {
+      // Read flat data
+      for (j=0; j < height; ++j) {
+         for (i=0; i < width; ++i) {
+            stbi_uc rgbe[4];
+           main_decode_loop:
+            stbi__getn(s, rgbe, 4);
+            stbi__hdr_convert(hdr_data + j * width * req_comp + i * req_comp, rgbe, req_comp);
+         }
+      }
+   } else {
+      // Read RLE-encoded data
+      scanline = NULL;
+
+      for (j = 0; j < height; ++j) {
+         c1 = stbi__get8(s);
+         c2 = stbi__get8(s);
+         len = stbi__get8(s);
+         if (c1 != 2 || c2 != 2 || (len & 0x80)) {
+            // not run-length encoded, so we have to actually use THIS data as a decoded
+            // pixel (note this can't be a valid pixel--one of RGB must be >= 128)
+            stbi_uc rgbe[4];
+            rgbe[0] = (stbi_uc) c1;
+            rgbe[1] = (stbi_uc) c2;
+            rgbe[2] = (stbi_uc) len;
+            rgbe[3] = (stbi_uc) stbi__get8(s);
+            stbi__hdr_convert(hdr_data, rgbe, req_comp);
+            i = 1;
+            j = 0;
+            STBI_FREE(scanline);
+            goto main_decode_loop; // yes, this makes no sense
+         }
+         len <<= 8;
+         len |= stbi__get8(s);
+         if (len != width) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("invalid decoded scanline length", "corrupt HDR"); }
+         if (scanline == NULL) {
+            scanline = (stbi_uc *) stbi__malloc_mad2(width, 4, 0);
+            if (!scanline) {
+               STBI_FREE(hdr_data);
+               return stbi__errpf("outofmem", "Out of memory");
+            }
+         }
+
+         for (k = 0; k < 4; ++k) {
+            int nleft;
+            i = 0;
+            while ((nleft = width - i) > 0) {
+               count = stbi__get8(s);
+               if (count > 128) {
+                  // Run
+                  value = stbi__get8(s);
+                  count -= 128;
+                  if ((count == 0) || (count > nleft)) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
+                  for (z = 0; z < count; ++z)
+                     scanline[i++ * 4 + k] = value;
+               } else {
+                  // Dump
+                  if ((count == 0) || (count > nleft)) { STBI_FREE(hdr_data); STBI_FREE(scanline); return stbi__errpf("corrupt", "bad RLE data in HDR"); }
+                  for (z = 0; z < count; ++z)
+                     scanline[i++ * 4 + k] = stbi__get8(s);
+               }
+            }
+         }
+         for (i=0; i < width; ++i)
+            stbi__hdr_convert(hdr_data+(j*width + i)*req_comp, scanline + i*4, req_comp);
+      }
+      if (scanline)
+         STBI_FREE(scanline);
+   }
+
+   return hdr_data;
+}
+
+static int stbi__hdr_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   char buffer[STBI__HDR_BUFLEN];
+   char *token;
+   int valid = 0;
+   int dummy;
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+
+   if (stbi__hdr_test(s) == 0) {
+       stbi__rewind( s );
+       return 0;
+   }
+
+   for(;;) {
+      token = stbi__hdr_gettoken(s,buffer);
+      if (token[0] == 0) break;
+      if (strcmp(token, "FORMAT=32-bit_rle_rgbe") == 0) valid = 1;
+   }
+
+   if (!valid) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token = stbi__hdr_gettoken(s,buffer);
+   if (strncmp(token, "-Y ", 3)) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token += 3;
+   *y = (int) strtol(token, &token, 10);
+   while (*token == ' ') ++token;
+   if (strncmp(token, "+X ", 3)) {
+       stbi__rewind( s );
+       return 0;
+   }
+   token += 3;
+   *x = (int) strtol(token, NULL, 10);
+   *comp = 3;
+   return 1;
+}
+#endif // STBI_NO_HDR
+
+#ifndef STBI_NO_BMP
+static int stbi__bmp_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   void *p;
+   stbi__bmp_data info;
+
+   info.all_a = 255;
+   p = stbi__bmp_parse_header(s, &info);
+   if (p == NULL) {
+      stbi__rewind( s );
+      return 0;
+   }
+   if (x) *x = s->img_x;
+   if (y) *y = s->img_y;
+   if (comp) {
+      if (info.bpp == 24 && info.ma == 0xff000000)
+         *comp = 3;
+      else
+         *comp = info.ma ? 4 : 3;
+   }
+   return 1;
+}
+#endif
+
+#ifndef STBI_NO_PSD
+static int stbi__psd_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int channelCount, dummy, depth;
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+   if (stbi__get32be(s) != 0x38425053) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 1) {
+       stbi__rewind( s );
+       return 0;
+   }
+   stbi__skip(s, 6);
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   *y = stbi__get32be(s);
+   *x = stbi__get32be(s);
+   depth = stbi__get16be(s);
+   if (depth != 8 && depth != 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 3) {
+       stbi__rewind( s );
+       return 0;
+   }
+   *comp = 4;
+   return 1;
+}
+
+static int stbi__psd_is16(stbi__context *s)
+{
+   int channelCount, depth;
+   if (stbi__get32be(s) != 0x38425053) {
+       stbi__rewind( s );
+       return 0;
+   }
+   if (stbi__get16be(s) != 1) {
+       stbi__rewind( s );
+       return 0;
+   }
+   stbi__skip(s, 6);
+   channelCount = stbi__get16be(s);
+   if (channelCount < 0 || channelCount > 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   STBI_NOTUSED(stbi__get32be(s));
+   STBI_NOTUSED(stbi__get32be(s));
+   depth = stbi__get16be(s);
+   if (depth != 16) {
+       stbi__rewind( s );
+       return 0;
+   }
+   return 1;
+}
+#endif
+
+#ifndef STBI_NO_PIC
+static int stbi__pic_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int act_comp=0,num_packets=0,chained,dummy;
+   stbi__pic_packet packets[10];
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+
+   if (!stbi__pic_is4(s,"\x53\x80\xF6\x34")) {
+      stbi__rewind(s);
+      return 0;
+   }
+
+   stbi__skip(s, 88);
+
+   *x = stbi__get16be(s);
+   *y = stbi__get16be(s);
+   if (stbi__at_eof(s)) {
+      stbi__rewind( s);
+      return 0;
+   }
+   if ( (*x) != 0 && (1 << 28) / (*x) < (*y)) {
+      stbi__rewind( s );
+      return 0;
+   }
+
+   stbi__skip(s, 8);
+
+   do {
+      stbi__pic_packet *packet;
+
+      if (num_packets==sizeof(packets)/sizeof(packets[0]))
+         return 0;
+
+      packet = &packets[num_packets++];
+      chained = stbi__get8(s);
+      packet->size    = stbi__get8(s);
+      packet->type    = stbi__get8(s);
+      packet->channel = stbi__get8(s);
+      act_comp |= packet->channel;
+
+      if (stbi__at_eof(s)) {
+          stbi__rewind( s );
+          return 0;
+      }
+      if (packet->size != 8) {
+          stbi__rewind( s );
+          return 0;
+      }
+   } while (chained);
+
+   *comp = (act_comp & 0x10 ? 4 : 3);
+
+   return 1;
+}
+#endif
+
+// *************************************************************************************************
+// Portable Gray Map and Portable Pixel Map loader
+// by Ken Miller
+//
+// PGM: http://netpbm.sourceforge.net/doc/pgm.html
+// PPM: http://netpbm.sourceforge.net/doc/ppm.html
+//
+// Known limitations:
+//    Does not support comments in the header section
+//    Does not support ASCII image data (formats P2 and P3)
+
+#ifndef STBI_NO_PNM
+
+static int      stbi__pnm_test(stbi__context *s)
+{
+   char p, t;
+   p = (char) stbi__get8(s);
+   t = (char) stbi__get8(s);
+   if (p != 'P' || (t != '5' && t != '6')) {
+       stbi__rewind( s );
+       return 0;
+   }
+   return 1;
+}
+
+static void *stbi__pnm_load(stbi__context *s, int *x, int *y, int *comp, int req_comp, stbi__result_info *ri)
+{
+   stbi_uc *out;
+   STBI_NOTUSED(ri);
+
+   ri->bits_per_channel = stbi__pnm_info(s, (int *)&s->img_x, (int *)&s->img_y, (int *)&s->img_n);
+   if (ri->bits_per_channel == 0)
+      return 0;
+
+   if (s->img_y > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+   if (s->img_x > STBI_MAX_DIMENSIONS) return stbi__errpuc("too large","Very large image (corrupt?)");
+
+   *x = s->img_x;
+   *y = s->img_y;
+   if (comp) *comp = s->img_n;
+
+   if (!stbi__mad4sizes_valid(s->img_n, s->img_x, s->img_y, ri->bits_per_channel / 8, 0))
+      return stbi__errpuc("too large", "PNM too large");
+
+   out = (stbi_uc *) stbi__malloc_mad4(s->img_n, s->img_x, s->img_y, ri->bits_per_channel / 8, 0);
+   if (!out) return stbi__errpuc("outofmem", "Out of memory");
+   if (!stbi__getn(s, out, s->img_n * s->img_x * s->img_y * (ri->bits_per_channel / 8))) {
+      STBI_FREE(out);
+      return stbi__errpuc("bad PNM", "PNM file truncated");
+   }
+
+   if (req_comp && req_comp != s->img_n) {
+      if (ri->bits_per_channel == 16) {
+         out = (stbi_uc *) stbi__convert_format16((stbi__uint16 *) out, s->img_n, req_comp, s->img_x, s->img_y);
+      } else {
+         out = stbi__convert_format(out, s->img_n, req_comp, s->img_x, s->img_y);
+      }
+      if (out == NULL) return out; // stbi__convert_format frees input on failure
+   }
+   return out;
+}
+
+static int      stbi__pnm_isspace(char c)
+{
+   return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
+}
+
+static void     stbi__pnm_skip_whitespace(stbi__context *s, char *c)
+{
+   for (;;) {
+      while (!stbi__at_eof(s) && stbi__pnm_isspace(*c))
+         *c = (char) stbi__get8(s);
+
+      if (stbi__at_eof(s) || *c != '#')
+         break;
+
+      while (!stbi__at_eof(s) && *c != '\n' && *c != '\r' )
+         *c = (char) stbi__get8(s);
+   }
+}
+
+static int      stbi__pnm_isdigit(char c)
+{
+   return c >= '0' && c <= '9';
+}
+
+static int      stbi__pnm_getinteger(stbi__context *s, char *c)
+{
+   int value = 0;
+
+   while (!stbi__at_eof(s) && stbi__pnm_isdigit(*c)) {
+      value = value*10 + (*c - '0');
+      *c = (char) stbi__get8(s);
+      if((value > 214748364) || (value == 214748364 && *c > '7'))
+          return stbi__err("integer parse overflow", "Parsing an integer in the PPM header overflowed a 32-bit int");
+   }
+
+   return value;
+}
+
+static int      stbi__pnm_info(stbi__context *s, int *x, int *y, int *comp)
+{
+   int maxv, dummy;
+   char c, p, t;
+
+   if (!x) x = &dummy;
+   if (!y) y = &dummy;
+   if (!comp) comp = &dummy;
+
+   stbi__rewind(s);
+
+   // Get identifier
+   p = (char) stbi__get8(s);
+   t = (char) stbi__get8(s);
+   if (p != 'P' || (t != '5' && t != '6')) {
+       stbi__rewind(s);
+       return 0;
+   }
+
+   *comp = (t == '6') ? 3 : 1;  // '5' is 1-component .pgm; '6' is 3-component .ppm
+
+   c = (char) stbi__get8(s);
+   stbi__pnm_skip_whitespace(s, &c);
+
+   *x = stbi__pnm_getinteger(s, &c); // read width
+   if(*x == 0)
+       return stbi__err("invalid width", "PPM image header had zero or overflowing width");
+   stbi__pnm_skip_whitespace(s, &c);
+
+   *y = stbi__pnm_getinteger(s, &c); // read height
+   if (*y == 0)
+       return stbi__err("invalid width", "PPM image header had zero or overflowing width");
+   stbi__pnm_skip_whitespace(s, &c);
+
+   maxv = stbi__pnm_getinteger(s, &c);  // read max value
+   if (maxv > 65535)
+      return stbi__err("max value > 65535", "PPM image supports only 8-bit and 16-bit images");
+   else if (maxv > 255)
+      return 16;
+   else
+      return 8;
+}
+
+static int stbi__pnm_is16(stbi__context *s)
+{
+   if (stbi__pnm_info(s, NULL, NULL, NULL) == 16)
+	   return 1;
+   return 0;
+}
+#endif
+
+static int stbi__info_main(stbi__context *s, int *x, int *y, int *comp)
+{
+   #ifndef STBI_NO_JPEG
+   if (stbi__jpeg_info(s, x, y, comp)) return 1;
+   #endif
+
+   #ifndef STBI_NO_PNG
+   if (stbi__png_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_GIF
+   if (stbi__gif_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_BMP
+   if (stbi__bmp_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PIC
+   if (stbi__pic_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_info(s, x, y, comp))  return 1;
+   #endif
+
+   #ifndef STBI_NO_HDR
+   if (stbi__hdr_info(s, x, y, comp))  return 1;
+   #endif
+
+   // test tga last because it's a crappy test!
+   #ifndef STBI_NO_TGA
+   if (stbi__tga_info(s, x, y, comp))
+       return 1;
+   #endif
+   return stbi__err("unknown image type", "Image not of any known type, or corrupt");
+}
+
+static int stbi__is_16_main(stbi__context *s)
+{
+   #ifndef STBI_NO_PNG
+   if (stbi__png_is16(s))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PSD
+   if (stbi__psd_is16(s))  return 1;
+   #endif
+
+   #ifndef STBI_NO_PNM
+   if (stbi__pnm_is16(s))  return 1;
+   #endif
+   return 0;
+}
+
+#ifndef STBI_NO_STDIO
+STBIDEF int stbi_info(char const *filename, int *x, int *y, int *comp)
+{
+    FILE *f = stbi__fopen(filename, "rb");
+    int result;
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    result = stbi_info_from_file(f, x, y, comp);
+    fclose(f);
+    return result;
+}
+
+STBIDEF int stbi_info_from_file(FILE *f, int *x, int *y, int *comp)
+{
+   int r;
+   stbi__context s;
+   long pos = ftell(f);
+   stbi__start_file(&s, f);
+   r = stbi__info_main(&s,x,y,comp);
+   fseek(f,pos,SEEK_SET);
+   return r;
+}
+
+STBIDEF int stbi_is_16_bit(char const *filename)
+{
+    FILE *f = stbi__fopen(filename, "rb");
+    int result;
+    if (!f) return stbi__err("can't fopen", "Unable to open file");
+    result = stbi_is_16_bit_from_file(f);
+    fclose(f);
+    return result;
+}
+
+STBIDEF int stbi_is_16_bit_from_file(FILE *f)
+{
+   int r;
+   stbi__context s;
+   long pos = ftell(f);
+   stbi__start_file(&s, f);
+   r = stbi__is_16_main(&s);
+   fseek(f,pos,SEEK_SET);
+   return r;
+}
+#endif // !STBI_NO_STDIO
+
+STBIDEF int stbi_info_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__info_main(&s,x,y,comp);
+}
+
+STBIDEF int stbi_info_from_callbacks(stbi_io_callbacks const *c, void *user, int *x, int *y, int *comp)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi__info_main(&s,x,y,comp);
+}
+
+STBIDEF int stbi_is_16_bit_from_memory(stbi_uc const *buffer, int len)
+{
+   stbi__context s;
+   stbi__start_mem(&s,buffer,len);
+   return stbi__is_16_main(&s);
+}
+
+STBIDEF int stbi_is_16_bit_from_callbacks(stbi_io_callbacks const *c, void *user)
+{
+   stbi__context s;
+   stbi__start_callbacks(&s, (stbi_io_callbacks *) c, user);
+   return stbi__is_16_main(&s);
+}
+
+#endif // STB_IMAGE_IMPLEMENTATION
+
+/*
+   revision history:
+      2.20  (2019-02-07) support utf8 filenames in Windows; fix warnings and platform ifdefs
+      2.19  (2018-02-11) fix warning
+      2.18  (2018-01-30) fix warnings
+      2.17  (2018-01-29) change sbti__shiftsigned to avoid clang -O2 bug
+                         1-bit BMP
+                         *_is_16_bit api
+                         avoid warnings
+      2.16  (2017-07-23) all functions have 16-bit variants;
+                         STBI_NO_STDIO works again;
+                         compilation fixes;
+                         fix rounding in unpremultiply;
+                         optimize vertical flip;
+                         disable raw_len validation;
+                         documentation fixes
+      2.15  (2017-03-18) fix png-1,2,4 bug; now all Imagenet JPGs decode;
+                         warning fixes; disable run-time SSE detection on gcc;
+                         uniform handling of optional "return" values;
+                         thread-safe initialization of zlib tables
+      2.14  (2017-03-03) remove deprecated STBI_JPEG_OLD; fixes for Imagenet JPGs
+      2.13  (2016-11-29) add 16-bit API, only supported for PNG right now
+      2.12  (2016-04-02) fix typo in 2.11 PSD fix that caused crashes
+      2.11  (2016-04-02) allocate large structures on the stack
+                         remove white matting for transparent PSD
+                         fix reported channel count for PNG & BMP
+                         re-enable SSE2 in non-gcc 64-bit
+                         support RGB-formatted JPEG
+                         read 16-bit PNGs (only as 8-bit)
+      2.10  (2016-01-22) avoid warning introduced in 2.09 by STBI_REALLOC_SIZED
+      2.09  (2016-01-16) allow comments in PNM files
+                         16-bit-per-pixel TGA (not bit-per-component)
+                         info() for TGA could break due to .hdr handling
+                         info() for BMP to shares code instead of sloppy parse
+                         can use STBI_REALLOC_SIZED if allocator doesn't support realloc
+                         code cleanup
+      2.08  (2015-09-13) fix to 2.07 cleanup, reading RGB PSD as RGBA
+      2.07  (2015-09-13) fix compiler warnings
+                         partial animated GIF support
+                         limited 16-bpc PSD support
+                         #ifdef unused functions
+                         bug with < 92 byte PIC,PNM,HDR,TGA
+      2.06  (2015-04-19) fix bug where PSD returns wrong '*comp' value
+      2.05  (2015-04-19) fix bug in progressive JPEG handling, fix warning
+      2.04  (2015-04-15) try to re-enable SIMD on MinGW 64-bit
+      2.03  (2015-04-12) extra corruption checking (mmozeiko)
+                         stbi_set_flip_vertically_on_load (nguillemot)
+                         fix NEON support; fix mingw support
+      2.02  (2015-01-19) fix incorrect assert, fix warning
+      2.01  (2015-01-17) fix various warnings; suppress SIMD on gcc 32-bit without -msse2
+      2.00b (2014-12-25) fix STBI_MALLOC in progressive JPEG
+      2.00  (2014-12-25) optimize JPG, including x86 SSE2 & NEON SIMD (ryg)
+                         progressive JPEG (stb)
+                         PGM/PPM support (Ken Miller)
+                         STBI_MALLOC,STBI_REALLOC,STBI_FREE
+                         GIF bugfix -- seemingly never worked
+                         STBI_NO_*, STBI_ONLY_*
+      1.48  (2014-12-14) fix incorrectly-named assert()
+      1.47  (2014-12-14) 1/2/4-bit PNG support, both direct and paletted (Omar Cornut & stb)
+                         optimize PNG (ryg)
+                         fix bug in interlaced PNG with user-specified channel count (stb)
+      1.46  (2014-08-26)
+              fix broken tRNS chunk (colorkey-style transparency) in non-paletted PNG
+      1.45  (2014-08-16)
+              fix MSVC-ARM internal compiler error by wrapping malloc
+      1.44  (2014-08-07)
+              various warning fixes from Ronny Chevalier
+      1.43  (2014-07-15)
+              fix MSVC-only compiler problem in code changed in 1.42
+      1.42  (2014-07-09)
+              don't define _CRT_SECURE_NO_WARNINGS (affects user code)
+              fixes to stbi__cleanup_jpeg path
+              added STBI_ASSERT to avoid requiring assert.h
+      1.41  (2014-06-25)
+              fix search&replace from 1.36 that messed up comments/error messages
+      1.40  (2014-06-22)
+              fix gcc struct-initialization warning
+      1.39  (2014-06-15)
+              fix to TGA optimization when req_comp != number of components in TGA;
+              fix to GIF loading because BMP wasn't rewinding (whoops, no GIFs in my test suite)
+              add support for BMP version 5 (more ignored fields)
+      1.38  (2014-06-06)
+              suppress MSVC warnings on integer casts truncating values
+              fix accidental rename of 'skip' field of I/O
+      1.37  (2014-06-04)
+              remove duplicate typedef
+      1.36  (2014-06-03)
+              convert to header file single-file library
+              if de-iphone isn't set, load iphone images color-swapped instead of returning NULL
+      1.35  (2014-05-27)
+              various warnings
+              fix broken STBI_SIMD path
+              fix bug where stbi_load_from_file no longer left file pointer in correct place
+              fix broken non-easy path for 32-bit BMP (possibly never used)
+              TGA optimization by Arseny Kapoulkine
+      1.34  (unknown)
+              use STBI_NOTUSED in stbi__resample_row_generic(), fix one more leak in tga failure case
+      1.33  (2011-07-14)
+              make stbi_is_hdr work in STBI_NO_HDR (as specified), minor compiler-friendly improvements
+      1.32  (2011-07-13)
+              support for "info" function for all supported filetypes (SpartanJ)
+      1.31  (2011-06-20)
+              a few more leak fixes, bug in PNG handling (SpartanJ)
+      1.30  (2011-06-11)
+              added ability to load files via callbacks to accomidate custom input streams (Ben Wenger)
+              removed deprecated format-specific test/load functions
+              removed support for installable file formats (stbi_loader) -- would have been broken for IO callbacks anyway
+              error cases in bmp and tga give messages and don't leak (Raymond Barbiero, grisha)
+              fix inefficiency in decoding 32-bit BMP (David Woo)
+      1.29  (2010-08-16)
+              various warning fixes from Aurelien Pocheville
+      1.28  (2010-08-01)
+              fix bug in GIF palette transparency (SpartanJ)
+      1.27  (2010-08-01)
+              cast-to-stbi_uc to fix warnings
+      1.26  (2010-07-24)
+              fix bug in file buffering for PNG reported by SpartanJ
+      1.25  (2010-07-17)
+              refix trans_data warning (Won Chun)
+      1.24  (2010-07-12)
+              perf improvements reading from files on platforms with lock-heavy fgetc()
+              minor perf improvements for jpeg
+              deprecated type-specific functions so we'll get feedback if they're needed
+              attempt to fix trans_data warning (Won Chun)
+      1.23    fixed bug in iPhone support
+      1.22  (2010-07-10)
+              removed image *writing* support
+              stbi_info support from Jetro Lauha
+              GIF support from Jean-Marc Lienher
+              iPhone PNG-extensions from James Brown
+              warning-fixes from Nicolas Schulz and Janez Zemva (i.stbi__err. Janez (U+017D)emva)
+      1.21    fix use of 'stbi_uc' in header (reported by jon blow)
+      1.20    added support for Softimage PIC, by Tom Seddon
+      1.19    bug in interlaced PNG corruption check (found by ryg)
+      1.18  (2008-08-02)
+              fix a threading bug (local mutable static)
+      1.17    support interlaced PNG
+      1.16    major bugfix - stbi__convert_format converted one too many pixels
+      1.15    initialize some fields for thread safety
+      1.14    fix threadsafe conversion bug
+              header-file-only version (#define STBI_HEADER_FILE_ONLY before including)
+      1.13    threadsafe
+      1.12    const qualifiers in the API
+      1.11    Support installable IDCT, colorspace conversion routines
+      1.10    Fixes for 64-bit (don't use "unsigned long")
+              optimized upsampling by Fabian "ryg" Giesen
+      1.09    Fix format-conversion for PSD code (bad global variables!)
+      1.08    Thatcher Ulrich's PSD code integrated by Nicolas Schulz
+      1.07    attempt to fix C++ warning/errors again
+      1.06    attempt to fix C++ warning/errors again
+      1.05    fix TGA loading to return correct *comp and use good luminance calc
+      1.04    default float alpha is 1, not 255; use 'void *' for stbi_image_free
+      1.03    bugfixes to STBI_NO_STDIO, STBI_NO_HDR
+      1.02    support for (subset of) HDR files, float interface for preferred access to them
+      1.01    fix bug: possible bug in handling right-side up bmps... not sure
+              fix bug: the stbi__bmp_load() and stbi__tga_load() functions didn't work at all
+      1.00    interface to zlib that skips zlib header
+      0.99    correct handling of alpha in palette
+      0.98    TGA loader by lonesock; dynamically add loaders (untested)
+      0.97    jpeg errors on too large a file; also catch another malloc failure
+      0.96    fix detection of invalid v value - particleman@mollyrocket forum
+      0.95    during header scan, seek to markers in case of padding
+      0.94    STBI_NO_STDIO to disable stdio usage; rename all #defines the same
+      0.93    handle jpegtran output; verbose errors
+      0.92    read 4,8,16,24,32-bit BMP files of several formats
+      0.91    output 24-bit Windows 3.0 BMP files
+      0.90    fix a few more warnings; bump version number to approach 1.0
+      0.61    bugfixes due to Marc LeBlanc, Christopher Lloyd
+      0.60    fix compiling as c++
+      0.59    fix warnings: merge Dave Moore's -Wall fixes
+      0.58    fix bug: zlib uncompressed mode len/nlen was wrong endian
+      0.57    fix bug: jpg last huffman symbol before marker was >9 bits but less than 16 available
+      0.56    fix bug: zlib uncompressed mode len vs. nlen
+      0.55    fix bug: restart_interval not initialized to 0
+      0.54    allow NULL for 'int *comp'
+      0.53    fix bug in png 3->4; speedup png decoding
+      0.52    png handles req_comp=3,4 directly; minor cleanup; jpeg comments
+      0.51    obey req_comp requests, 1-component jpegs return as 1-component,
+              on 'test' only check type, not whether we support this variant
+      0.50  (2006-11-19)
+              first released version
+*/
+
+
+/*
+------------------------------------------------------------------------------
+This software is available under 2 licenses -- choose whichever you prefer.
+------------------------------------------------------------------------------
+ALTERNATIVE A - MIT License
+Copyright (c) 2017 Sean Barrett
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+------------------------------------------------------------------------------
+ALTERNATIVE B - Public Domain (www.unlicense.org)
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or distribute this
+software, either in source code form or as a compiled binary, for any purpose,
+commercial or non-commercial, and by any means.
+In jurisdictions that recognize copyright laws, the author or authors of this
+software dedicate any and all copyright interest in the software to the public
+domain. We make this dedication for the benefit of the public at large and to
+the detriment of our heirs and successors. We intend this dedication to be an
+overt act of relinquishment in perpetuity of all present and future rights to
+this software under copyright law.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+------------------------------------------------------------------------------
+*/


### PR DESCRIPTION
Adds image **input** to sparkinfer: an image arrives as an OpenAI `image_url` content part on
`/v1/chat/completions`, runs through the checkpoint's own vision tower, and its embeddings are
spliced into the prompt. Text-only behaviour is unchanged, byte for byte.

```
POST /v1/chat/completions   {"content":[{"type":"image_url","image_url":{"url":"data:image/png;base64,..."}},
                                        {"type":"text","text":"What object is shown?"}]}
→ "Torch"     prompt_tokens 359 (294 image + text) · ttft 256 ms · decode 71.5 tok/s
```

## The bug this found

The tower was **wrong**. It applied no 2D rotary position embeddings at all — the reference
rotates q and k in every one of the 27 blocks by a head_dim/2-wide frequency vector, first half
driven by a patch's row, second by its column. Against transformers:

| | cosine |
|---|---|
| before | 0.770186 |
| after, 28x28 grid | 0.999437 (bf16 floor 0.998865) |
| after, 58x38 grid | 0.994902 (bf16 floor 0.995620) |

It hid well because the learned `pos_embed` is added once before block 0, so coarse layout
survived: control images with unambiguous answers — a left/right split, a top/bottom split, four
coloured quadrants — all came back correct. What it cost was fine relative position. On a cartoon
torch the model reported "a fireplace, or burning logs, with a dark charred base"; with the rotary
it reports a torch, white-to-red flame gradient, detached embers, and a brown bowl-shaped holder
above a wooden handle. Same weights, same image, same prompt.

`bench/scripts/vision_ref.py` — a NumPy reference written by hand from the architecture —
**omitted the rotary identically**, so it and the CUDA agreed at cosine 0.99915 while both
disagreed with the real implementation. A reference written by the same hand as the code can only
catch mistakes its author did not also make. `bench/scripts/vision_hf_check.py` now diffs against
`transformers.Qwen3_5VisionModel` itself and is the gate.

## Preprocessing

Also fixed: we rescaled uint8 to [0,1] and resized in float; transformers resizes the uint8 image
and casts back, which rounds *and* clamps bicubic's overshoot, and PIL's intermediate image between
the horizontal and vertical passes is uint8 too, so that happens twice.

    rescale first, round once      max 0.1266   mean 0.001568
    + correct order                max 0.0549   mean 0.000425
    + intermediate rounding        max 0.007843 mean 0.000000   <- one uint8 LSB, the floor

Both gates judge against a **measured** floor, not a constant. An earlier draft of the
preprocessing gate passed the 0.127-off preprocessor because it judged on cosine, which barely
moves when a few edge pixels are wrong.

## Threading

Images ride on `ContinuousBatchEngine::Request`, not staged on the model. `set_pending_vision` is
a single slot on the shared model consumed by the next prefill, and the worker prefills whichever
job it picks up, on its own thread, independent of the submitting thread's mutex — staging from an
HTTP thread would splice one request's image into another's prefill, the same shape as the
`clear_prefix_cache` race that already corrupted the KV cache under load.

They ride as **pixels**, not embeddings: `qwen_vision_forward` issues on the legacy default stream,
which cannot overlap another job's CUDA graph capture. CPU preprocessing stays with the caller;
every GPU op is on the worker. Pixels are `shared_ptr` because the validation-retry path re-encodes
the whole prompt — returning bare placeholders at new offsets — so each branch re-expands against
its own rebuilt prompt, and branches run concurrently.

## Verification

| Layer | Against | Result |
|---|---|---|
| Vision tower | transformers `Qwen3_5VisionModel` | 0.99944 |
| Preprocessing | real `Qwen2VLImageProcessor` | <= 1 uint8 LSB, mean 0 |
| `smart_resize` | Python reference, 441 shapes | exact |
| **Text path** | **origin/main, teacher-forced logprobs** | **identical** |
| Single image | PNG / JPEG / BMP over HTTP | correct on all three |
| Two images, different grids | — | 573 tok = 294+196+83, both answers correct |
| Validation retry + image | — | re-encode -> re-expand -> correct answer |
| Splice / expansion | unit tests | 15/15 |
| Request parser | unit tests | 3 new |

## Scope

`data:` URLs only — remote fetching is refused as an SSRF primitive, which is a deployment
decision, not a default. `/v1/tokenize` and `/v1/score` reject images rather than silently
dropping them. No video; a non-empty `deepstack_visual_indexes` is refused at load. See
[`docs/image_input.md`](docs/image_input.md).

## Pre-existing failures, not from this branch

Both reproduce on unmodified `origin/main` and will block a full `BUILD_TESTS=ON` run either way:

- `chat_tools_test` fails at line 228 (`parse_qwen36_tool_output` on `tool_choice=required`).
  Because the suite aborts at the first failure, the three new parser tests here do not run in
  place; they were verified by running them ahead of it.
- `runtime/tests/topk_topp_sample_gpu_test.cpp` does not compile (`finite_indices` undeclared).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
