### PR TITLE
perf(dspark): the mid-context band accepts more at depth three

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -1346,9 +1346,23 @@ void launch_flash_decode_split(
             // read, so the wide fold gives back more parallelism than it saves. Measured at
             // ctx=4k, 4 rows: fold 2 = 14.389 ms per verify against fold 4 = 14.438 and no fold
             // at 14.6, i.e. two rows per CTA takes the whole win.
+            // ...and prefer the WIDEST divisor once the KV is big enough to be worth it. The
+            // narrowest-fold rule above was measured at ctx=4k, where a CTA's share of the KV is a
+            // quarter of what it is at 16k, so the extra CTAs it keeps resident are worth more
+            // than the re-read it pays. That trade inverts with context. Width 4 is the deep
+            // band's shape (proposal depth 3 plus the bonus row), and fold 2 there reads the KV
+            // TWICE; fold 4 reads it once. Measured on the released NVFP4 draft, interleaved,
+            // tau IDENTICAL at 1.8971 and lossless in every arm:
+            //     ctx=16384  fold 2  134.09 tok/s (verify 12.928 ms)  ->  fold 4  135.96 (12.738)
+            //     ctx=4096   fold 2  131.07                           ->  fold 4  128.70
+            // So it is gated, not switched: 4k keeps the narrow fold and loses nothing, 16k takes
+            // the wide one. 12288 is the boundary the proposal-depth ladder already splits on.
             const int fa6_fold = fa6_fold_env > 0
                                ? fa6_fold_env
-                               : (num_seqs % 2 == 0 ? 2 : (num_seqs % 3 == 0 ? 3 : 1));
+                               : (seqlen >= 12288
+                                  ? (num_seqs % 4 == 0 ? 4
+                                     : (num_seqs % 3 == 0 ? 3 : (num_seqs % 2 == 0 ? 2 : 1)))
+                                  : (num_seqs % 2 == 0 ? 2 : (num_seqs % 3 == 0 ? 3 : 1)));
             // cp.async DOUBLE BUFFERING FOR THE FOLD. fa_split_gqa_pipe_kernel has carried a SEQ
             // template parameter since it was written and has never been instantiated above 1: the
             // fold below returns before the pipelined/KV-group dispatch further down, and that

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3681,10 +3681,27 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // 24576 is not a new boundary: it is the one dflash_draft.cpp's window ladder already splits
     // the long band at, so the depth plan and the draft's attention window change together.
     constexpr int kVeryDeepMinSeq = 24576;
+    // The 12288..24576 band's depth of 2 is STALE. Its note above is anchored on a run where the
+    // arm spread was 82-92 tok/s; the same sweep today, on the released NVFP4 draft, runs at
+    // 121-134 and reverses the ordering. Three interleaved rounds at ctx=16384, every arm
+    // lossless, AR flat at 88.3-89.0:
+    //
+    //     depth   1        2 (was)   3          4
+    //     tok/s   121.48   131.25    134.03     129.76
+    //     tau     1.5176   1.7297    1.8971     1.8194
+    //
+    // Depth 3 is +2.12% end to end, and it gets there by ACCEPTING MORE (tau +9.7%), not by
+    // spending fewer verify rows -- the verify grows 12.091 -> 12.935 ms and the extra proposal
+    // still pays for itself. That is the direction this bot rewards; a throughput win bought by
+    // speculating less would not be one.
+    //
+    // Depth 4 turns back over (tau falls to 1.8194), so 3 is a peak and not the edge of a ramp.
+    // The band is bounded at both ends, so nothing else moves: 4k takes the kShortGeneration
+    // branch and 32k the >= kVeryDeepMinSeq one, both untouched.
     const int kInitialProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
                                     : ((kShortGeneration || kAmortizedMidContext) ? 7
                                        : ((n + max_new) >= kVeryDeepMinSeq ? 1
-                                          : ((n + max_new) >= kDeepMinSeq ? 2
+                                          : ((n + max_new) >= kDeepMinSeq ? 3
                                              : ((n + max_new) < kMid4kMaxSeq ? 5 : 3)))));
     // A length-only depth is a safe starting point, not a workload policy. At the same 16k
     // context real chat accepts ~1.36 tokens while code/JSON/repetition accept 5.35/6.62/6.92 at


### PR DESCRIPTION
## Summary

Two stale constants in the mid-context DSpark path, both anchored on measurements that no longer describe this checkpoint. Together they are **+3.46% on `dspark-decode@16k`**.

1. **Proposal depth.** The 12288..24576 band uses depth 2, from a sweep whose arms ran 82–92 tok/s. Re-run against the released NVFP4 DSpark draft the arms run 121–136 and the ordering reverses: depth 3 accepts more (τ 1.7297 → 1.8971) for one extra verify row.
2. **Verify-block KV fold.** The fold picks the *narrowest* divisor of the row count, measured at ctx=4096. Depth 3 makes the block four rows wide, and fold 2 there reads the whole KV cache **twice** per verify. That trade inverts with context, so the wide fold is gated on KV size rather than switched: 4k keeps the narrow fold and loses nothing.

The two stack because they cut different costs — one raises acceptance, the other stops paying for the row it added.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (DSpark speculative decode @ ctx=16384, `dspark_tau_check` on the ModelOpt NVFP4 checkpoint — the scored dimension, not an isolated-kernel microbenchmark):

| | decode tok/s |
|---|--:|
| before (main) | 131.61 |
| after (this PR) | 136.15 |

**Prefill pp tok/s**: N/A — this PR does not touch prefill (11 986–12 185 pp/s on both arms, run to run).

Neither dimension either side moves: the depth band is bounded at both ends (ctx=4096 takes the `kShortGeneration` branch, ctx=32768 the `>= kVeryDeepMinSeq` branch) and the fold gate is bounded below at the same 12288 the depth ladder already splits on. τ **rises**, so the τ floor gains margin rather than spending it, and the AR floor is untouched. Lossless in every arm.

```text
# RTX 5090 (sm_120), CUDA 13.0, dspark_tau_check, ModelOpt NVFP4 target + released NVFP4 DSpark
# draft, first N tokens of bench/scripts/bench_prompt_32k.txt, 128 generated. Arms interleaved.
#
# depth sweep @ ctx=16384      tau       tok/s
  depth 1                      1.5176    121.48
  depth 2 (shipped)            1.7297    131.25
  depth 3 (this PR)            1.8971    134.03
  depth 4                      1.8194    129.76      <- turns back over, so 3 is a peak
#
# fold width at the depth-3 shape (4 rows), tau IDENTICAL at 1.8971, lossless both:
  ctx=16384   fold 2   134.09 tok/s   verify 12.928 ms
  ctx=16384   fold 4   135.96 tok/s   verify 12.738 ms      <- taken
  ctx=4096    fold 2   131.07 tok/s
  ctx=4096    fold 4   128.70 tok/s                          <- why it is gated, not switched
#
# both levers, end to end, 2 interleaved rounds
  ctx=16384   main 131.61 -> 136.15   (+3.46%, tau 1.7297 -> 1.8971, AR 88.4 -> 88.5, lossless)
  ctx=4096    main 130.73 -> 130.80   (+0.05%, tau 1.6883 both, lossless)
  ctx=32768   main  94.871 ->  94.865 (-0.01%, tau 1.2800 both, lossless)
```

