### PR TITLE
feat(qwen3.8): video input, interleaved MRoPE, and enforce tool_choice=required

### DIFF
--- a/bench/scripts/mrope_kernel_check.py
+++ b/bench/scripts/mrope_kernel_check.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Diff the CUDA prefill RoPE kernel's rotated Q against transformers' OWN rotary embedding.
+
+mrope_ref_check.py proves we COMPUTE the reference's position ids. This proves the kernel APPLIES
+them the way the reference does -- which is where the from-scratch logic lives (the interleaved
+axis selection, pf_mrope_axis). The two checks are not redundant: correct positions applied to the
+wrong frequency bands would pass the first and fail this one.
+
+Uses transformers' Qwen3_5TextRotaryEmbedding (its real apply_interleaved_mrope and cos/sin) plus
+the standard NeoX rotate-half, and reproduces only the surrounding RMSNorm, which is ordinary and
+not what is under test.
+"""
+import argparse, json, sys, types
+
+import torch
+from transformers.models.qwen3_5 import modeling_qwen3_5 as M
+
+
+def rotate_half(x):
+    half = x.shape[-1] // 2
+    return torch.cat((-x[..., half:], x[..., :half]), dim=-1)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump")
+    ap.add_argument("--tol", type=float, default=None,
+                    help="absolute tolerance; default is derived from the measured bf16 floor")
+    args = ap.parse_args()
+    d = json.load(open(args.dump))
+
+    N, HQ, HD = d["n_tokens"], d["n_q_heads"], d["head_dim"]
+    rot, theta, eps = d["rotary_dim"], d["theta"], d["eps"]
+
+    q_in = torch.tensor(d["q_in"], dtype=torch.float32).view(N, HQ, HD)
+    qw = torch.tensor(d["q_norm_w"], dtype=torch.float32)
+    got = torch.tensor(d["q_out"], dtype=torch.float32).view(N, HQ, HD)
+    pos = torch.tensor(d["positions"], dtype=torch.long).view(N, 3).T.unsqueeze(1)  # (3,1,N)
+
+    # Per-head RMSNorm, then bf16-rounded exactly as the kernel stores it.
+    var = q_in.pow(2).mean(-1, keepdim=True)
+    xn = (q_in * torch.rsqrt(var + eps)) * qw
+    xn = xn.to(torch.bfloat16).to(torch.float32)
+
+    # transformers' own rotary: builds inv_freq from the config, applies interleaved MRoPE, and
+    # returns cos/sin. Driven through the real class, not reimplemented.
+    cfg = types.SimpleNamespace(
+        rope_parameters={"rope_type": "default", "rope_theta": theta,
+                         "partial_rotary_factor": rot / HD,
+                         "mrope_section": d["mrope_section"], "mrope_interleaved": True},
+        head_dim=HD, hidden_size=HD, num_attention_heads=1,
+        max_position_embeddings=262144)
+    rope = M.Qwen3_5TextRotaryEmbedding(cfg)
+    cos, sin = rope(torch.zeros(1, N, HD, dtype=torch.float32), pos)   # (1, N, rot)
+    cos, sin = cos[0], sin[0]
+
+    # NeoX rotate-half over the first rotary_dim dims only (partial rotary); the tail passes through.
+    xr = xn[..., :rot]
+    c = cos.unsqueeze(1)   # (N,1,rot)
+    s = sin.unsqueeze(1)
+    want = xn.clone()
+    want[..., :rot] = xr * c + rotate_half(xr) * s
+
+    diff = (got - want).abs()
+    # The kernel stores bf16 and uses __cosf/__sinf, so agreement is bounded by bf16 resolution at
+    # this magnitude, not by float equality. Derive the bar from the data instead of inventing one.
+    floor = (want.to(torch.bfloat16).to(torch.float32) - want).abs().max().item()
+    tol = args.tol if args.tol is not None else max(floor * 4, 2e-3)
+
+    print(f"tokens={N} heads={HQ} head_dim={HD} rotary_dim={rot}")
+    print(f"max|kernel - transformers| = {diff.max().item():.6g}")
+    print(f"bf16 storage floor         = {floor:.6g}   tolerance = {tol:.6g}")
+
+    # A pure pass/fail on a tolerance would also pass if MRoPE were silently ignored, because the
+    # text tokens agree either way. Show that the vision rows genuinely differ from a 1D baseline.
+    pos1d = pos[0].expand(3, -1, -1)
+    cos1, sin1 = rope(torch.zeros(1, N, HD, dtype=torch.float32), pos1d)
+    want1d = xn.clone()
+    want1d[..., :rot] = xr * cos1[0].unsqueeze(1) + rotate_half(xr) * sin1[0].unsqueeze(1)
+    sep = (want - want1d).abs().max().item()
+    print(f"max|mrope - 1d baseline|   = {sep:.6g}   (must exceed the tolerance, or the test is vacuous)")
+
+    ok = diff.max().item() <= tol
+    if sep <= tol:
+        print("\nFAILED -- the chosen positions do not distinguish MRoPE from 1D RoPE; test is vacuous")
+        return 1
+    print("\nPASSED -- kernel matches transformers" if ok else "\nFAILED -- kernel diverges from transformers")
+    if not ok:
+        bad = (diff > tol).nonzero()[:8]
+        for b in bad:
+            t, h, dd = b.tolist()
+            print(f"  tok={t} head={h} dim={dd}  ours={got[t,h,dd]:.6f}  ref={want[t,h,dd]:.6f}")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/scripts/mrope_ref_check.py
+++ b/bench/scripts/mrope_ref_check.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Diff runtime MRoPE position ids against transformers' OWN get_rope_index.
+
+Deliberately calls the REAL method off Qwen3_5ForConditionalGeneration rather than
+reimplementing it here. A hand-written Python reference is worth very little for this kind of
+check: in the vision-tower work the local NumPy reference reproduced the very omission it was
+meant to catch (both forgot rotary entirely) and agreed with the CUDA path to 0.99915 while both
+were wrong. Only code we did not write can falsify code we did.
+
+Reads the C++ side's output from a JSON file produced by mrope_positions_dump, and compares
+elementwise. Exact integer equality is required -- these are position INDICES, so "close" is
+meaningless.
+"""
+import argparse, json, sys, types
+
+import torch
+from transformers.models.qwen3_5 import modeling_qwen3_5 as M
+
+
+def reference_positions(token_ids, image_token_id, video_token_id, spans, merge, start_pos):
+    """Drive transformers' own get_rope_index on a single sequence."""
+    # get_rope_index needs only config.vision_config.spatial_merge_size off `self`, plus
+    # mm_token_type_ids marking text(0)/image(1)/video(2). Build the smallest object that
+    # satisfies that rather than instantiating a 27B model.
+    cfg = types.SimpleNamespace(vision_config=types.SimpleNamespace(spatial_merge_size=merge))
+    stub = types.SimpleNamespace(config=cfg)
+    # Both methods hang off Qwen3_5Model, NOT Qwen3_5ForConditionalGeneration -- the generation
+    # wrapper does not carry them.
+    stub.get_vision_position_ids = types.MethodType(
+        M.Qwen3_5Model.get_vision_position_ids, stub)
+
+    ids = torch.tensor([token_ids], dtype=torch.long)
+    mm = torch.zeros_like(ids)
+    for i, t in enumerate(token_ids):
+        if t == image_token_id:
+            mm[0, i] = 1
+        elif t == video_token_id:
+            mm[0, i] = 2
+
+    # image_grid_thw / video_grid_thw are (num, 3) in PRE-merge patch units.
+    img = [s for s in spans if s["kind"] == "image"]
+    vid = [s for s in spans if s["kind"] == "video"]
+    image_grid_thw = torch.tensor([[s["t"], s["h"], s["w"]] for s in img], dtype=torch.long) if img else None
+    video_grid_thw = torch.tensor([[s["t"], s["h"], s["w"]] for s in vid], dtype=torch.long) if vid else None
+
+    pos, _ = M.Qwen3_5Model.get_rope_index(
+        stub, ids, mm, image_grid_thw, video_grid_thw, None)
+    # (3, 1, seq) -> [[t,h,w], ...]
+    pos = pos[:, 0, :]
+    return [[int(pos[0, i]), int(pos[1, i]), int(pos[2, i])] for i in range(pos.shape[1])]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("dump", help="JSON written by mrope_positions_dump")
+    args = ap.parse_args()
+    d = json.load(open(args.dump))
+
+    got = [d["positions"][i:i + 3] for i in range(0, len(d["positions"]), 3)]
+    want = reference_positions(d["token_ids"], d["image_token_id"], d["video_token_id"],
+                               d["spans"], d["spatial_merge"], d.get("start_pos", 0))
+
+    if len(got) != len(want):
+        print(f"FAIL: length {len(got)} vs reference {len(want)}")
+        return 1
+
+    bad = [(i, g, w) for i, (g, w) in enumerate(zip(got, want)) if g != w]
+    print(f"tokens: {len(got)}   mismatches: {len(bad)}")
+    for i, g, w in bad[:12]:
+        print(f"  [{i}] tok={d['token_ids'][i]}  ours={g}  reference={w}")
+    if bad:
+        print("\nFAILED -- position ids differ from transformers")
+        return 1
+    print("\nPASSED -- position ids are elementwise identical to transformers")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -961,12 +961,33 @@ __global__ void pf_gated_norm_kernel(const __nv_bfloat16* __restrict__ x,
     }
 }
 
+// Interleaved-MRoPE axis for rotary frequency index i.
+//
+// Qwen3.5 lays the three position axes out as [T H W T H W ...] across the frequency vector
+// rather than in three contiguous chunks, which is what mrope_interleaved means. The reference
+// builds it by starting from all-T and overwriting slice(1, 3*sec_h, 3) with H and
+// slice(2, 3*sec_w, 3) with W, so the axis for index i is i%3 -- bounded, because the last few
+// indices fall outside the shorter sections' reach. With mrope_section [11,11,10] over 32
+// frequencies every i%3==2 index happens to be in range, but the bound is kept so a checkpoint
+// with a different split stays correct.
+//
+// For a text token all three positions are equal, so this selects between identical values and
+// the result is bit-identical to plain 1D RoPE. That is the property that lets MRoPE be enabled
+// without touching text-only numerics at all.
+__device__ __forceinline__ int pf_mrope_axis(int i, int sec_h, int sec_w) {
+    const int r = i % 3;
+    if (r == 1 && i < 3 * sec_h) return 1;
+    if (r == 2 && i < 3 * sec_w) return 2;
+    return 0;
+}
+
 // ============================================================================
 // Full-attention prefill: QK-norm + partial-RoPE (q,k in place) + int8 KV write into
 // the single-sequence paged pool. Mirrors qknorm_rope_kv_partial_int8_kernel (rope.cu)
 // but indexes the block table for a single sequence and grids over all N prompt tokens.
 // grid = (n_q_heads + 2*n_kv_heads, N); blockDim = head_dim.
 // ============================================================================
+template <bool MROPE>
 __global__ void pf_qknorm_rope_kv_int8_kernel(
     __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
@@ -974,7 +995,8 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
     __half* __restrict__ k_scale, __half* __restrict__ v_scale,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq, int pos0) {
+    int block_size, int max_blocks_per_seq, int pos0,
+    const int* __restrict__ mrope_pos, int mrope_sec_h, int mrope_sec_w) {
     const int tok  = blockIdx.x;                    // token (grid.x avoids 65535 grid.y cap)
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
@@ -1015,7 +1037,11 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
         // does this correctly via its `else { val = s_h[t]; }` arm; Q was asymmetric with it.
         if (t < rhalf) {
             const float freq = __powf(theta, -2.f * (float)t / (float)rotary_dim);
-            const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
+            // Here the thread index IS the frequency index (this arm handles both halves of the
+            // pair itself), so t indexes mrope_section directly.
+            const int rp = MROPE ? mrope_pos[(size_t)tok * 3 + pf_mrope_axis(t, mrope_sec_h, mrope_sec_w)]
+                                 : pos;
+            const float ang = (float)rp * freq, c = __cosf(ang), s = __sinf(ang);
             const float x0 = s_h[t], x1 = s_h[t + rhalf];
             s_h[t]         = pf_to_f(__float2bfloat16(x0 * c - x1 * s));
             s_h[t + rhalf] = pf_to_f(__float2bfloat16(x1 * c + x0 * s));
@@ -1050,7 +1076,12 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
         if (t < rotary_dim) {
             const int i = (t < rhalf) ? t : (t - rhalf);
             const float freq = __powf(theta, -2.f * (float)i / (float)rotary_dim);
-            const float ang = (float)pos * freq, c = __cosf(ang), s = __sinf(ang);
+            // MRoPE changes ONLY the angle. The block-table slot and the causal mask keep using
+            // the sequential position -- a vision token still occupies one cache slot even though
+            // its rotary position is three numbers.
+            const int rp = MROPE ? mrope_pos[(size_t)tok * 3 + pf_mrope_axis(i, mrope_sec_h, mrope_sec_w)]
+                                 : pos;
+            const float ang = (float)rp * freq, c = __cosf(ang), s = __sinf(ang);
             const float x0 = s_h[i], x1 = s_h[i + rhalf];
             val = (t < rhalf) ? (x0 * c - x1 * s) : (x1 * c + x0 * s);
         } else {
@@ -1234,6 +1265,7 @@ __global__ void pf_attn_int8_paged_kernel(
 // forward_token decode step writes when kv8 is off, so a decode continuing from this cache
 // reads a consistent one.
 // ============================================================================
+template <bool MROPE>
 __global__ void pf_qknorm_rope_kv_bf16_kernel(
     __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
@@ -1241,7 +1273,8 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
     signed char* __restrict__ v_i8, __half* __restrict__ v_i8_scale,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq, int pos0) {
+    int block_size, int max_blocks_per_seq, int pos0,
+    const int* __restrict__ mrope_pos, int mrope_sec_h, int mrope_sec_w) {
     const int tok  = blockIdx.x;
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
@@ -1288,7 +1321,9 @@ __global__ void pf_qknorm_rope_kv_bf16_kernel(
             const int half = rotary_dim >> 1;
             const int i    = (t < half) ? t : (t - half);
             const float freq = __powf(theta, -2.f * (float)i / (float)rotary_dim);
-            const float ang = (float)pos * freq, c = __cosf(ang), sn = __sinf(ang);
+            const int rp = MROPE ? mrope_pos[(size_t)tok * 3 + pf_mrope_axis(i, mrope_sec_h, mrope_sec_w)]
+                                 : pos;
+            const float ang = (float)rp * freq, c = __cosf(ang), sn = __sinf(ang);
             const float x0 = s_h[i], x1 = s_h[i + half];
             out = (t < half) ? (x0 * c - x1 * sn) : (x1 * c + x0 * sn);
         }
@@ -1758,16 +1793,28 @@ void launch_prefill_qknorm_rope_kv_int8(
     signed char* k_pool, signed char* v_pool, void* k_scale, void* v_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream, int pos0) {
+    cudaStream_t stream, int pos0, const int* mrope_pos, int mrope_sec_h, int mrope_sec_w) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
     const size_t shmem = (size_t)head_dim * sizeof(float);
-    pf_qknorm_rope_kv_int8_kernel<<<grid, head_dim, shmem, stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
-        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
-        reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool,
-        reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
-        block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq, pos0);
+    // Dispatched on a TEMPLATE parameter, not a runtime branch: with mrope_pos null the compiler
+    // emits exactly the code it emitted before this feature existed, so the scored text-only
+    // prefill path carries no extra register pressure, no extra load and no predicate.
+    if (mrope_pos)
+        pf_qknorm_rope_kv_int8_kernel<true><<<grid, head_dim, shmem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+            reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool,
+            reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+            block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+            block_size, max_blocks_per_seq, pos0, mrope_pos, mrope_sec_h, mrope_sec_w);
+    else
+        pf_qknorm_rope_kv_int8_kernel<false><<<grid, head_dim, shmem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+            reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool,
+            reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+            block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+            block_size, max_blocks_per_seq, pos0, nullptr, 0, 0);
 }
 
 // Muse Glimmer bf16-KV counterpart: QK-norm + NORMAL RoPE (rotary_dim>0) / NoPE
@@ -1794,16 +1841,27 @@ void launch_prefill_qknorm_rope_kv_bf16_vi8(
     void* k_pool, void* v_pool, signed char* v_i8, void* v_i8_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream, int pos0) {
+    cudaStream_t stream, int pos0, const int* mrope_pos, int mrope_sec_h, int mrope_sec_w) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);
     const size_t shmem = (size_t)head_dim * sizeof(float);
-    pf_qknorm_rope_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
-        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
-        reinterpret_cast<const __nv_bfloat16*>(k_w),
-        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
-        v_i8, reinterpret_cast<__half*>(v_i8_scale), block_table,
-        n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps, block_size, max_blocks_per_seq, pos0);
+    if (mrope_pos)
+        pf_qknorm_rope_kv_bf16_kernel<true><<<grid, head_dim, shmem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+            reinterpret_cast<const __nv_bfloat16*>(k_w),
+            reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+            v_i8, reinterpret_cast<__half*>(v_i8_scale), block_table,
+            n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps, block_size,
+            max_blocks_per_seq, pos0, mrope_pos, mrope_sec_h, mrope_sec_w);
+    else
+        pf_qknorm_rope_kv_bf16_kernel<false><<<grid, head_dim, shmem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+            reinterpret_cast<const __nv_bfloat16*>(k_w),
+            reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+            v_i8, reinterpret_cast<__half*>(v_i8_scale), block_table,
+            n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps, block_size,
+            max_blocks_per_seq, pos0, nullptr, 0, 0);
 }
 
 bool launch_prefill_attn_int8_paged(
@@ -1854,16 +1912,25 @@ void launch_prefill_qknorm_rope_kv_bf16(
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream, int pos0) {
+    cudaStream_t stream, int pos0, const int* mrope_pos, int mrope_sec_h, int mrope_sec_w) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);
     const size_t shmem = (size_t)head_dim * sizeof(float);
-    pf_qknorm_rope_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
-        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
-        reinterpret_cast<const __nv_bfloat16*>(k_w),
-        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
-        nullptr, nullptr, block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq, pos0);
+    if (mrope_pos)
+        pf_qknorm_rope_kv_bf16_kernel<true><<<grid, head_dim, shmem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+            reinterpret_cast<const __nv_bfloat16*>(k_w),
+            reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+            nullptr, nullptr, block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+            block_size, max_blocks_per_seq, pos0, mrope_pos, mrope_sec_h, mrope_sec_w);
+    else
+        pf_qknorm_rope_kv_bf16_kernel<false><<<grid, head_dim, shmem, stream>>>(
+            reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+            reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+            reinterpret_cast<const __nv_bfloat16*>(k_w),
+            reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+            nullptr, nullptr, block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+            block_size, max_blocks_per_seq, pos0, nullptr, 0, 0);
 }
 
 bool launch_prefill_attn_bf16_paged(

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -147,7 +147,8 @@ void launch_prefill_qknorm_rope_kv_int8(
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
     cudaStream_t stream = nullptr,
-    int pos0 = 0);
+    int pos0 = 0,
+    const int* mrope_pos = nullptr, int mrope_sec_h = 0, int mrope_sec_w = 0);
 
 // Muse Glimmer bf16-KV counterpart: QK-norm + NORMAL (consecutive-pair, LLAMA_ROPE_TYPE_NORM)
 // RoPE when rotary_dim>0 (SWA layers), or NoPE when rotary_dim==0 (global layers) + bf16 KV
@@ -161,7 +162,8 @@ void launch_prefill_qknorm_rope_kv_bf16(
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
     cudaStream_t stream = nullptr,
-    int pos0 = 0);
+    int pos0 = 0,
+    const int* mrope_pos = nullptr, int mrope_sec_h = 0, int mrope_sec_w = 0);
 
 void launch_prefill_qknorm_rope_kv_bf16_vi8(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
@@ -169,7 +171,8 @@ void launch_prefill_qknorm_rope_kv_bf16_vi8(
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
     cudaStream_t stream = nullptr,
-    int pos0 = 0);
+    int pos0 = 0,
+    const int* mrope_pos = nullptr, int mrope_sec_h = 0, int mrope_sec_w = 0);
 
 // Full-causal attention over a bf16 paged KV pool. false = no instantiation for head_dim.
 bool launch_prefill_attn_bf16_paged(

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -133,6 +133,15 @@ if(BUILD_EXAMPLES)
     # that script to judge. The reference owns the tolerance, not this binary.
     # Cross-checks the smart_resize port against the Python original over a grid of shapes.
     # Exact integer logic, so bench/scripts/vision_resize_check.py demands strict equality.
+    # Dumps MRoPE position ids as JSON for bench/scripts/mrope_ref_check.py, which diffs them
+    # against transformers' OWN get_rope_index. Position INDICES, so the comparison is exact
+    # integer equality -- "close" would be meaningless. A hand-written Python reference was
+    # deliberately avoided: in the vision-tower work the local NumPy reference reproduced the very
+    # omission it existed to catch.
+    add_executable(mrope_positions_dump examples/mrope_positions_dump.cpp)
+    target_include_directories(mrope_positions_dump PRIVATE include)
+    target_link_libraries(mrope_positions_dump PRIVATE sparkinfer_runtime)
+
     add_executable(vision_resize_check examples/vision_resize_check.cpp)
     target_include_directories(vision_resize_check PRIVATE include)
     target_link_libraries(vision_resize_check PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -138,6 +138,15 @@ if(BUILD_EXAMPLES)
     # integer equality -- "close" would be meaningless. A hand-written Python reference was
     # deliberately avoided: in the vision-tower work the local NumPy reference reproduced the very
     # omission it existed to catch.
+    # Runs the REAL prefill RoPE kernel with MRoPE positions and dumps its rotated Q for
+    # bench/scripts/mrope_kernel_check.py. mrope_positions_dump proves we COMPUTE the reference's
+    # position ids; this proves the KERNEL APPLIES them the same way, which is where the
+    # from-scratch interleaved axis selection lives. Correct positions fed to the wrong frequency
+    # bands would pass the first check and fail this one.
+    add_executable(mrope_kernel_dump examples/mrope_kernel_dump.cpp)
+    target_include_directories(mrope_kernel_dump PRIVATE include ../kernels/include)
+    target_link_libraries(mrope_kernel_dump PRIVATE sparkinfer_runtime CUDA::cudart)
+
     add_executable(mrope_positions_dump examples/mrope_positions_dump.cpp)
     target_include_directories(mrope_positions_dump PRIVATE include)
     target_link_libraries(mrope_positions_dump PRIVATE sparkinfer_runtime)

--- a/runtime/examples/mrope_kernel_dump.cpp
+++ b/runtime/examples/mrope_kernel_dump.cpp
@@ -1,0 +1,119 @@
+// Runs the REAL batched-prefill QK-norm+RoPE kernel with MRoPE positions and dumps its rotated Q,
+// so bench/scripts/mrope_kernel_check.py can diff it against transformers' own rotary embedding.
+//
+// The position-id check (mrope_ref_check.py) proves we COMPUTE what the reference computes. It
+// says nothing about whether the kernel APPLIES those positions the way the reference does --
+// which is the half that contains the logic written from scratch here (pf_mrope_axis, the
+// interleaved axis selection). This dump exists to close exactly that gap.
+#include "sparkinfer/kernels/prefill.h"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+bool cu(cudaError_t e, const char* what) {
+    if (e != cudaSuccess) { std::fprintf(stderr, "%s: %s\n", what, cudaGetErrorString(e)); return false; }
+    return true;
+}
+
+float bf16_to_f(__nv_bfloat16 x) { return __bfloat162float(x); }
+__nv_bfloat16 f_to_bf16(float x) { return __float2bfloat16(x); }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const char* out_path = argc > 1 ? argv[1] : "mrope_kernel.json";
+
+    // Qwen3.8-27B's real attention geometry, so the exercised shapes are the shipped ones.
+    const int N = 6;               // tokens
+    const int n_q = 2, n_kv = 1;   // enough heads to catch a head-indexing error, small enough to print
+    const int head_dim = 256;
+    const int rotary_dim = 64;     // head_dim * partial_rotary_factor (0.25)
+    const int sec_h = 11, sec_w = 10;
+    const float theta = 10000000.f, eps = 1e-6f;
+    const int block_size = 16, mbs = 8;
+
+    // Deterministic, non-degenerate inputs. A constant Q would hide an axis-selection bug because
+    // every frequency would rotate identical values.
+    std::vector<__nv_bfloat16> hq((size_t)N * n_q * head_dim), hk((size_t)N * n_kv * head_dim),
+                               hv((size_t)N * n_kv * head_dim);
+    for (size_t i = 0; i < hq.size(); i++) hq[i] = f_to_bf16(std::sin(0.017f * (float)i) * 1.3f);
+    for (size_t i = 0; i < hk.size(); i++) hk[i] = f_to_bf16(std::cos(0.023f * (float)i) * 0.9f);
+    for (size_t i = 0; i < hv.size(); i++) hv[i] = f_to_bf16(0.01f * (float)i);
+    std::vector<__nv_bfloat16> hqw(head_dim), hkw(head_dim);
+    for (int i = 0; i < head_dim; i++) {
+        hqw[i] = f_to_bf16(1.0f + 0.001f * (float)i);   // non-unit, so a dropped norm weight shows
+        hkw[i] = f_to_bf16(1.0f - 0.001f * (float)i);
+    }
+
+    // Positions where all three axes DIFFER -- the only regime in which MRoPE is distinguishable
+    // from 1D RoPE at all. Token 0 and 5 are text (t=h=w); 1..4 are a 2x2 vision span.
+    const std::vector<int> mpos = {
+        3, 3, 3,      // text
+        4, 4, 4,      // vision (t, h, w) for a 2x2 merged grid starting at 4
+        4, 4, 5,
+        4, 5, 4,
+        4, 5, 5,
+        6, 6, 6,      // text resuming after max(h,w)=2
+    };
+
+    std::vector<int> hbt(mbs);
+    for (int i = 0; i < mbs; i++) hbt[i] = i;
+
+    void *dq = nullptr, *dk = nullptr, *dv = nullptr, *dqw = nullptr, *dkw = nullptr;
+    void *dkp = nullptr, *dvp = nullptr;
+    int *dbt = nullptr, *dmp = nullptr;
+    const size_t pool = (size_t)mbs * block_size * n_kv * head_dim * sizeof(__nv_bfloat16);
+    if (!cu(cudaMalloc(&dq, hq.size() * 2), "q") || !cu(cudaMalloc(&dk, hk.size() * 2), "k") ||
+        !cu(cudaMalloc(&dv, hv.size() * 2), "v") || !cu(cudaMalloc(&dqw, head_dim * 2), "qw") ||
+        !cu(cudaMalloc(&dkw, head_dim * 2), "kw") || !cu(cudaMalloc(&dkp, pool), "kp") ||
+        !cu(cudaMalloc(&dvp, pool), "vp") ||
+        !cu(cudaMalloc((void**)&dbt, hbt.size() * sizeof(int)), "bt") ||
+        !cu(cudaMalloc((void**)&dmp, mpos.size() * sizeof(int)), "mp")) return 1;
+
+    if (!cu(cudaMemcpy(dq, hq.data(), hq.size() * 2, cudaMemcpyHostToDevice), "cp q") ||
+        !cu(cudaMemcpy(dk, hk.data(), hk.size() * 2, cudaMemcpyHostToDevice), "cp k") ||
+        !cu(cudaMemcpy(dv, hv.data(), hv.size() * 2, cudaMemcpyHostToDevice), "cp v") ||
+        !cu(cudaMemcpy(dqw, hqw.data(), head_dim * 2, cudaMemcpyHostToDevice), "cp qw") ||
+        !cu(cudaMemcpy(dkw, hkw.data(), head_dim * 2, cudaMemcpyHostToDevice), "cp kw") ||
+        !cu(cudaMemcpy(dbt, hbt.data(), hbt.size() * sizeof(int), cudaMemcpyHostToDevice), "cp bt") ||
+        !cu(cudaMemcpy(dmp, mpos.data(), mpos.size() * sizeof(int), cudaMemcpyHostToDevice), "cp mp"))
+        return 1;
+
+    sparkinfer::kernels::launch_prefill_qknorm_rope_kv_bf16(
+        dq, dk, dv, dqw, dkw, dkp, dvp, dbt, N, n_q, n_kv, head_dim,
+        rotary_dim, theta, eps, block_size, mbs, nullptr, /*pos0=*/0,
+        dmp, sec_h, sec_w);
+    if (!cu(cudaDeviceSynchronize(), "sync")) return 1;
+
+    std::vector<__nv_bfloat16> gq(hq.size());
+    if (!cu(cudaMemcpy(gq.data(), dq, gq.size() * 2, cudaMemcpyDeviceToHost), "read q")) return 1;
+
+    FILE* f = std::fopen(out_path, "w");
+    if (!f) { std::fprintf(stderr, "cannot write %s\n", out_path); return 1; }
+    std::fprintf(f, "{\n  \"n_tokens\": %d, \"n_q_heads\": %d, \"head_dim\": %d,\n", N, n_q, head_dim);
+    std::fprintf(f, "  \"rotary_dim\": %d, \"theta\": %.1f, \"eps\": %g,\n", rotary_dim, theta, eps);
+    std::fprintf(f, "  \"mrope_section\": [%d, %d, %d],\n", 32 - sec_h - sec_w, sec_h, sec_w);
+    auto arr = [&](const char* name, const std::vector<__nv_bfloat16>& v, bool last) {
+        std::fprintf(f, "  \"%s\": [", name);
+        for (size_t i = 0; i < v.size(); i++) std::fprintf(f, "%s%.9g", i ? "," : "", bf16_to_f(v[i]));
+        std::fprintf(f, "]%s\n", last ? "" : ",");
+    };
+    std::fprintf(f, "  \"positions\": [");
+    for (size_t i = 0; i < mpos.size(); i++) std::fprintf(f, "%s%d", i ? "," : "", mpos[i]);
+    std::fprintf(f, "],\n");
+    arr("q_in", hq, false);
+    arr("q_norm_w", hqw, false);
+    arr("q_out", gq, true);
+    std::fprintf(f, "}\n");
+    std::fclose(f);
+    std::printf("wrote %s (%d tokens x %d heads x %d dims)\n", out_path, N, n_q, head_dim);
+    return 0;
+}

--- a/runtime/examples/mrope_positions_dump.cpp
+++ b/runtime/examples/mrope_positions_dump.cpp
@@ -1,0 +1,129 @@
+// Dumps runtime MRoPE position ids as JSON for bench/scripts/mrope_ref_check.py to diff against
+// transformers' own get_rope_index. Builds prompts that exercise the cases that actually differ
+// from 1D RoPE: an image, a video's per-frame spans, both interleaved, and text on either side.
+#include "sparkinfer/models/qwen_vision_preprocess.h"
+#include "sparkinfer/models/qwen_vision_config.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace sparkinfer;
+
+namespace {
+
+struct Span { std::string kind; int t, h, w; };
+
+// Builds a prompt with the given vision spans and the grids that describe them.
+struct Case {
+    std::string name;
+    std::vector<int> ids;
+    std::vector<Span> spans;              // for the reference harness
+    std::vector<QwenVisionSpanGrid> grids;   // for our own call, same order
+};
+
+void add_run(std::vector<int>& ids, int tok, int n) { for (int i = 0; i < n; i++) ids.push_back(tok); }
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const char* out_dir = argc > 1 ? argv[1] : ".";
+    QwenVisionConfig cfg;
+    const int IMG = cfg.image_token_id, VID = cfg.video_token_id;
+    const int VS = cfg.vision_start_token_id, VE = cfg.vision_end_token_id;
+    const int merge = cfg.spatial_merge;
+
+    std::vector<Case> cases;
+
+    // 1. one image between text. 4x6 pre-merge grid -> 2x3 merged -> 6 placeholder tokens.
+    {
+        Case c; c.name = "image";
+        c.ids = {100, 101, VS};
+        add_run(c.ids, IMG, (4 / merge) * (6 / merge));
+        c.ids.push_back(VE); c.ids.push_back(102); c.ids.push_back(103);
+        c.spans = {{"image", 1, 4, 6}};
+        c.grids = {{1, 4, 6}};
+        cases.push_back(c);
+    }
+    // 2. a video: TWO temporal groups, each its own span with a timestamp marker between them.
+    //    This is the layout qwen_vision_expand_video_placeholders produces.
+    {
+        Case c; c.name = "video_2groups";
+        c.ids = {100, VS};
+        for (int g = 0; g < 2; g++) {
+            c.ids.push_back(900 + g);            // "<t seconds>" stand-in
+            c.ids.push_back(VS);
+            add_run(c.ids, VID, (4 / merge) * (4 / merge));
+            c.ids.push_back(VE);
+        }
+        c.ids.push_back(VE); c.ids.push_back(101);
+        // Each GROUP is its own (1,h,w) entry -- the reference splits video_grid_thw by t and
+        // sets t=1, so a 2-group clip is two rows, not one row with t=2.
+        c.spans = {{"video", 1, 4, 4}, {"video", 1, 4, 4}};
+        c.grids = {{1, 4, 4}, {1, 4, 4}};
+        cases.push_back(c);
+    }
+    // 3. image and video interleaved -- the ordering case reexpand_vision exists to get right.
+    {
+        Case c; c.name = "image_then_video";
+        c.ids = {100, VS};
+        add_run(c.ids, IMG, (2 / merge) * (4 / merge));
+        c.ids.push_back(VE);
+        c.ids.push_back(101);
+        c.ids.push_back(VS); c.ids.push_back(900); c.ids.push_back(VS);
+        add_run(c.ids, VID, (6 / merge) * (2 / merge));
+        c.ids.push_back(VE); c.ids.push_back(VE);
+        c.ids.push_back(102);
+        c.spans = {{"image", 1, 2, 4}, {"video", 1, 6, 2}};
+        c.grids = {{1, 2, 4}, {1, 6, 2}};
+        cases.push_back(c);
+    }
+    // 4. non-square grid where h != w, so the max(h,w) advance is observable.
+    {
+        Case c; c.name = "tall_image";
+        c.ids = {100};
+        c.ids.push_back(VS);
+        add_run(c.ids, IMG, (12 / merge) * (2 / merge));
+        c.ids.push_back(VE);
+        for (int i = 0; i < 5; i++) c.ids.push_back(200 + i);   // text AFTER, where the advance shows
+        c.spans = {{"image", 1, 12, 2}};
+        c.grids = {{1, 12, 2}};
+        cases.push_back(c);
+    }
+    // 5. text only -- must be identical to plain 1D RoPE, the property the whole design rests on.
+    {
+        Case c; c.name = "text_only";
+        for (int i = 0; i < 12; i++) c.ids.push_back(300 + i);
+        cases.push_back(c);
+    }
+
+    int rc = 0;
+    for (const Case& c : cases) {
+        std::vector<int> pos;
+        std::string err;
+        if (!qwen_vision_mrope_positions(c.ids, IMG, VID, c.grids, merge, 0, pos, err)) {
+            std::fprintf(stderr, "%s: %s\n", c.name.c_str(), err.c_str());
+            rc = 1;
+            continue;
+        }
+        const std::string path = std::string(out_dir) + "/mrope_" + c.name + ".json";
+        FILE* f = std::fopen(path.c_str(), "w");
+        if (!f) { std::fprintf(stderr, "cannot write %s\n", path.c_str()); rc = 1; continue; }
+        std::fprintf(f, "{\n  \"name\": \"%s\",\n  \"image_token_id\": %d,\n  \"video_token_id\": %d,\n",
+                     c.name.c_str(), IMG, VID);
+        std::fprintf(f, "  \"spatial_merge\": %d,\n  \"start_pos\": 0,\n", merge);
+        std::fprintf(f, "  \"token_ids\": [");
+        for (size_t i = 0; i < c.ids.size(); i++) std::fprintf(f, "%s%d", i ? "," : "", c.ids[i]);
+        std::fprintf(f, "],\n  \"spans\": [");
+        for (size_t i = 0; i < c.spans.size(); i++)
+            std::fprintf(f, "%s{\"kind\":\"%s\",\"t\":%d,\"h\":%d,\"w\":%d}", i ? "," : "",
+                         c.spans[i].kind.c_str(), c.spans[i].t, c.spans[i].h, c.spans[i].w);
+        std::fprintf(f, "],\n  \"positions\": [");
+        for (size_t i = 0; i < pos.size(); i++) std::fprintf(f, "%s%d", i ? "," : "", pos[i]);
+        std::fprintf(f, "]\n}\n");
+        std::fclose(f);
+        std::printf("wrote %s  (%zu tokens)\n", path.c_str(), c.ids.size());
+    }
+    return rc;
+}

--- a/runtime/examples/qwen38_hf_config.h
+++ b/runtime/examples/qwen38_hf_config.h
@@ -65,6 +65,17 @@ static bool qwen38_config_from_hf_json(const std::string& model_dir,
             cfg.rope_theta = rp["rope_theta"].get<float>();
         if (rp.contains("partial_rotary_factor") && rp["partial_rotary_factor"].is_number())
             partial_rotary = rp["partial_rotary_factor"].get<float>();
+        // mrope_section is [T, H, W] frequency-band lengths summing to rope_dim/2. Only read when
+        // the checkpoint declares it; absent means ordinary 1D RoPE, which is the correct reading
+        // for every non-multimodal Qwen in this codebase.
+        if (rp.contains("mrope_section") && rp["mrope_section"].is_array() &&
+            rp["mrope_section"].size() >= 3) {
+            const auto& ms = rp["mrope_section"];
+            if (ms[1].is_number_integer() && ms[2].is_number_integer()) {
+                cfg.mrope_sec_h = ms[1].get<int>();
+                cfg.mrope_sec_w = ms[2].get<int>();
+            }
+        }
     }
     partial_rotary = getf("partial_rotary_factor", partial_rotary);   // top-level override/fallback
 

--- a/runtime/include/sparkinfer/inference_engine.h
+++ b/runtime/include/sparkinfer/inference_engine.h
@@ -143,6 +143,13 @@ public:
         };
         std::vector<VisionImage> vision_images;
         std::vector<int> vision_pos;
+        // Interleaved-MRoPE rotary positions for this prompt, [n_tokens*3] as [t,h,w] per token.
+        // Empty for text-only requests and for checkpoints without an mrope_section, in which case
+        // the prefill and decode paths run exactly as they did before MRoPE existed.
+        std::vector<int> mrope_pos;
+        // Added to every DECODE step's rotary position (never to its cache slot). See
+        // Qwen35Model::set_pending_mrope.
+        int mrope_decode_offset = 0;
     };
 
     struct Result {

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -220,6 +220,21 @@ public:
     // cleared -- it is per-request state, not model state, and leaving it set would splice a
     // stale image into the next prompt.
     bool set_pending_vision(const float* emb, const int* positions, int n_img, int hidden);
+
+    // Supplies interleaved-MRoPE rotary positions for the NEXT prefill, plus the offset that every
+    // subsequent decode step of this session must add to its rotary position.
+    //
+    //   positions:     [n_tokens * 3] host int32, laid out [t0,h0,w0, t1,h1,w1, ...]
+    //   decode_offset: (rotary position after the prompt) - n_tokens. Zero or negative: a vision
+    //                  span advances the rotary counter by max(h,w)/merge, not by its token count.
+    //
+    // Text-only callers never call this, and the prefill and decode paths then run exactly the
+    // code they ran before MRoPE existed.
+    bool set_pending_mrope(const int* positions, int n_tokens, int decode_offset);
+    void clear_pending_mrope();
+    // Clears the decode offset. Needed when a session is reused for a new, image-free prompt --
+    // the offset outlives the positions by design, so it must be cleared explicitly.
+    void reset_mrope_offset();
     void clear_pending_vision();
 
     // Load weights from a sparkinfer weight directory (see runtime/tools/convert_qwen35.py).

--- a/runtime/include/sparkinfer/models/qwen_config.h
+++ b/runtime/include/sparkinfer/models/qwen_config.h
@@ -31,6 +31,19 @@ struct Qwen35Config {
     bool  hybrid      = false;
     int   full_attn_interval = 4;
     int   rope_dim    = 0;      // 0 = rotate the full attention head
+    // Interleaved MRoPE (rope_parameters.mrope_section). Qwen3.5 gives a token THREE rotary
+    // positions -- temporal, height, width -- and the frequency index selects which one it reads,
+    // laid out [T H W T H W ...] rather than in contiguous chunks.
+    //
+    // Only the H and W section lengths are stored: the T section is whatever is left over, and
+    // the axis rule (i%3, bounded by 3*sec_h / 3*sec_w) needs exactly these two bounds.
+    // Zero means the checkpoint declares no mrope_section, i.e. ordinary 1D RoPE.
+    //
+    // For a TEXT token all three positions are equal, so MRoPE degenerates to 1D RoPE bit for
+    // bit. That is why a text-only prompt is unaffected whether or not this is set.
+    int   mrope_sec_h = 0;
+    int   mrope_sec_w = 0;
+    bool  mrope() const { return mrope_sec_h > 0 || mrope_sec_w > 0; }
     int   linear_q_heads = 16;
     int   linear_v_heads = 32;
     int   linear_head_dim = 128;

--- a/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
+++ b/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
@@ -32,6 +32,37 @@ bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
                             std::vector<float>& pixels, int* grid_h, int* grid_w,
                             std::string& err);
 
+// Full preprocess for a VIDEO: N same-sized RGB8 frames -> resized, normalized, patchified.
+//
+// A video differs from an image in exactly one place at this layer: the tower's Conv3d has a time
+// extent of temporal_patch (2), and an image fills it by repeating the same still, whereas a video
+// fills it with REAL consecutive frames. Everything else -- smart_resize, the PIL-exact bicubic,
+// the uint8 round-trip, the (C, T, P, P) patch layout -- is shared with the image path via one
+// helper, so the two cannot drift apart.
+//
+//   frames:   n_frames pointers to [height, width, 3] uint8, row-major. All frames MUST share
+//             height/width: one smart_resize is computed for the whole clip, because T frames are
+//             packed into a single patch and a per-frame grid would not line up.
+//   pixels:   [grid_t*grid_h*grid_w, in_ch*temporal*patch*patch] float32, group-major.
+//   grid_t:   number of TEMPORAL GROUPS = ceil(n_frames / temporal_patch), not the frame count.
+//
+// A trailing partial group is padded by repeating the LAST frame, matching the reference. Zero
+// fill would be a black frame, which the model describes as if it were real content.
+bool qwen_vision_preprocess_video(const unsigned char* const* frames, int n_frames,
+                                  int height, int width, const QwenVisionConfig& cfg,
+                                  std::vector<float>& pixels,
+                                  int* grid_t, int* grid_h, int* grid_w, std::string& err);
+
+// Per-temporal-group timestamps, in seconds, for the "<N.N seconds>" markers the prompt carries
+// before each frame's vision span.
+//
+// frame_indices are the ORIGINAL frame numbers that were sampled (not 0..n-1) -- that is what
+// makes the timestamps reflect real elapsed time when frames are subsampled. Returns one entry
+// per temporal group: the mean of the group's first and last frame time. fps <= 0 falls back to
+// 24, which is the reference's behaviour when a container reports no frame rate.
+std::vector<float> qwen_vision_video_timestamps(const std::vector<int>& frame_indices,
+                                                double fps, int temporal_patch);
+
 // How many image placeholder tokens a given grid needs: one per MERGED patch. The prompt must
 // carry exactly this many image_token_id between vision_start and vision_end, or the splice
 // silently misaligns the whole sequence.

--- a/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
+++ b/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
@@ -97,6 +97,38 @@ bool qwen_vision_expand_video_placeholders(const std::vector<int>& in, int video
                                            const std::vector<QwenVideoSpan>& videos,
                                            std::vector<int>& out, std::string& err);
 
+// One vision span's grid, for qwen_vision_mrope_positions below.
+struct QwenVisionSpanGrid {
+    int grid_t = 1;      // temporal groups; 1 for an image, and 1 PER GROUP for video
+    int grid_h = 0;      // pre-merge patch grid
+    int grid_w = 0;
+};
+
+// Builds the LM's 3D (t, h, w) position ids for a prompt containing vision spans.
+//
+// Qwen3.5's text model uses INTERLEAVED MRoPE (rope_parameters.mrope_section = [11,11,10],
+// mrope_interleaved = true), so a token's rotary position is not one number but three, and the
+// frequency index selects which axis it reads. Two consequences the 1D path gets wrong:
+//
+//   1. Vision tokens get (t, row, col) rather than a running counter, so the tower's spatial
+//      layout reaches attention instead of being flattened into sequence order.
+//   2. Text AFTER a vision span resumes at start + max(grid_h, grid_w)/merge, NOT at
+//      start + <number of vision tokens>. A 32x32 image contributes 256 tokens but advances the
+//      position counter by only 16.
+//
+// For TEXT tokens all three axes are equal, which is exactly plain 1D RoPE -- that degeneracy is
+// why a text-only prompt is unaffected by any of this, and why enabling MRoPE cannot move
+// text-only numbers.
+//
+// out is filled with 3*n_tokens ints laid out [t0,h0,w0, t1,h1,w1, ...]. spans must list every
+// vision span in prompt order, one entry per MAXIMAL placeholder run (so one per image, and one
+// per temporal group for video, matching how the prompt is expanded).
+bool qwen_vision_mrope_positions(const std::vector<int>& token_ids,
+                                 int image_token_id, int video_token_id,
+                                 const std::vector<QwenVisionSpanGrid>& spans,
+                                 int spatial_merge, int start_pos,
+                                 std::vector<int>& out, std::string& err);
+
 // Expands each single image placeholder into the number of tokens its image actually needs.
 //
 // The chat template emits exactly ONE <|image_pad|> per image:

--- a/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
+++ b/runtime/include/sparkinfer/models/qwen_vision_preprocess.h
@@ -68,6 +68,35 @@ std::vector<float> qwen_vision_video_timestamps(const std::vector<int>& frame_in
 // silently misaligns the whole sequence.
 int qwen_vision_num_tokens(int grid_h, int grid_w, const QwenVisionConfig& cfg);
 
+// One video's expansion parameters, for qwen_vision_expand_video_placeholders below.
+struct QwenVideoSpan {
+    // Placeholder tokens ONE temporal group needs: (grid_h/merge) * (grid_w/merge). Every group
+    // of a clip has the same count -- the whole clip shares one smart_resize.
+    int tokens_per_frame = 0;
+    // Tokenized "<N.N seconds>" marker, one entry per temporal group. Tokenized by the CALLER:
+    // the runtime has no tokenizer, and re-tokenizing the rendered prompt to insert these would
+    // risk shifting unrelated tokens through merge effects at the seams -- the same reason the
+    // image expansion works in token space.
+    std::vector<std::vector<int>> timestamp_tokens;
+};
+
+// Expands each single video placeholder into per-frame spans carrying timestamp markers.
+//
+// The chat template emits ONE <|video_pad|> per video, wrapped once:
+//     "<|vision_start|><|video_pad|><|vision_end|>"
+// and the reference PROCESSOR replaces ONLY the <|video_pad|> token -- not the wrapper -- with
+//     for each temporal group g:  "<t_g seconds>" <|vision_start|> <|video_pad|>*n <|vision_end|>
+// so the result is deliberately NESTED: the template's pair wraps the whole clip and every frame
+// carries its own inner pair. That looks like a bug and is not; Qwen3.5 separates video frames
+// with timestamps, and get_rope_index relies on each frame being its own vision span.
+//
+// The timestamps are not decoration. Without MRoPE's temporal axis they are the only signal that
+// orders the frames, and even with it they carry real elapsed time across subsampled frames.
+bool qwen_vision_expand_video_placeholders(const std::vector<int>& in, int video_token_id,
+                                           int vision_start_token_id, int vision_end_token_id,
+                                           const std::vector<QwenVideoSpan>& videos,
+                                           std::vector<int>& out, std::string& err);
+
 // Expands each single image placeholder into the number of tokens its image actually needs.
 //
 // The chat template emits exactly ONE <|image_pad|> per image:

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -430,10 +430,29 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
                 finish_job(job);
                 return true;
             }
+            // Rotary positions for the same prompt. Staged separately from the embeddings because
+            // they describe every token, not just the spliced ones -- and because a checkpoint
+            // without an mrope_section supplies none while still having images.
+            if (!job.req.mrope_pos.empty() &&
+                !model_->set_pending_mrope(job.req.mrope_pos.data(),
+                                           (int)(job.req.mrope_pos.size() / 3),
+                                           job.req.mrope_decode_offset)) {
+                job.error = "failed to stage MRoPE positions for prefill";
+                finish_job(job);
+                return true;
+            }
         }
+        // The decode offset deliberately OUTLIVES the positions -- decode needs it for every token
+        // after the prompt -- so a request that supplies none must clear it explicitly. Without
+        // this, a text-only request arriving after an image request on the same model would
+        // inherit the image's rotary shift and silently decode at the wrong positions.
+        if (job.req.mrope_pos.empty()) model_->reset_mrope_offset();
         const int seed = model_->ingest_prompt_range(job.req.prompt.data(), job.prefill_pos, n,
                                                       chunk_limit, &out_pos, want_seed_logprob);
         if (has_vision) model_->clear_pending_vision();
+        // Positions are consumed by the prefill they were staged for; the offset is not cleared
+        // here, by design.
+        if (!job.req.mrope_pos.empty()) model_->clear_pending_mrope();
         job.prefill_pos = out_pos;
         if (job.prefill_pos >= n) {
             // Known v1 scope limitation for temperature sampling (runtime/src/models/qwen35.cpp's

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -207,6 +207,15 @@ struct Qwen35Model::Impl {
     void* d_vision_emb = nullptr;
     int*  d_vision_pos = nullptr;
     int   vision_n = 0;
+    // Interleaved-MRoPE rotary positions for the pending prompt: [n_tokens*3] int32 on device.
+    // Null on every text-only request, which is what keeps the MRoPE kernel instantiation off the
+    // measured path entirely.
+    int*  d_mrope_pos = nullptr;
+    int   mrope_n = 0;
+    // Added to the DECODE rotary position, never to the cache slot. Vision spans advance the
+    // rotary counter by less than their token count, so generated tokens sit at a lower rotary
+    // position than their slot index; this is that difference, and it is 0 without vision.
+    int   mrope_pos_offset = 0;
     // Guards the capture window against legacy-default-stream work issued by other threads.
     // See Qwen35Model::device_mutex() in the header for why this is required.
     std::recursive_mutex device_mu;
@@ -907,6 +916,32 @@ void Qwen35Model::clear_pending_vision() {
     s.d_vision_emb = nullptr; s.d_vision_pos = nullptr; s.vision_n = 0;
 }
 
+bool Qwen35Model::set_pending_mrope(const int* positions, int n_tokens, int decode_offset) {
+    Impl& s = *p_;
+    clear_pending_mrope();
+    if (!positions || n_tokens <= 0) return false;
+    const size_t n = (size_t)n_tokens * 3;
+    if (cudaMalloc((void**)&s.d_mrope_pos, n * sizeof(int)) != cudaSuccess) return false;
+    if (cudaMemcpy(s.d_mrope_pos, positions, n * sizeof(int), cudaMemcpyHostToDevice) != cudaSuccess) {
+        clear_pending_mrope();
+        return false;
+    }
+    s.mrope_n = n_tokens;
+    // Survives clear_pending_mrope deliberately: the positions are consumed by ONE prefill, but
+    // the offset has to keep applying to every decode step of the same session afterwards.
+    s.mrope_pos_offset = decode_offset;
+    return true;
+}
+
+void Qwen35Model::clear_pending_mrope() {
+    Impl& s = *p_;
+    if (s.d_mrope_pos) cudaFree(s.d_mrope_pos);
+    s.d_mrope_pos = nullptr;
+    s.mrope_n = 0;
+}
+
+void Qwen35Model::reset_mrope_offset() { p_->mrope_pos_offset = 0; }
+
 int Qwen35Model::forward_token(int token_id, int position, bool sample, float temperature,
                                unsigned long long seed, unsigned long long sample_step,
                                int top_k, float top_p,
@@ -973,7 +1008,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
     };
 
     s.h_scalars[0] = token_id;
-    s.h_scalars[1] = position;
+    // [1] is the ROTARY position, [2] the KV cache slot. They are the same number for every
+    // text-only request and diverge under MRoPE: a vision span occupies one cache slot per token
+    // but advances the rotary counter by only max(grid_h, grid_w)/merge, so everything generated
+    // after an image sits at a LOWER rotary position than its slot index.
+    //
+    // One scalar is enough for the whole decode-side correction because a generated token is text,
+    // and text has all three MRoPE axes equal -- so the three-number position collapses back to
+    // one, just shifted. mrope_pos_offset is 0 whenever no vision span was ingested, which makes
+    // this line identical to what it was.
+    s.h_scalars[1] = position + s.mrope_pos_offset;
     s.h_scalars[2] = position;
     s.h_scalars[3] = seqlen;
     s.h_scalars[4] = s.dflash_cap_row;
@@ -2837,7 +2881,9 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_lo
                           // Only prefill_batched gets these: the other two Qwen35PrefillCtx
                           // sites are DSpark verify paths, which replay already-generated
                           // tokens and can never contain an image placeholder.
-                          s.d_vision_emb, s.d_vision_pos, s.vision_n };
+                          s.d_vision_emb, s.d_vision_pos, s.vision_n,
+                          // MRoPE rotary positions, null unless set_pending_mrope ran for this prompt.
+                          s.d_mrope_pos };
     const int seed = prefill_batched_run(ctx, prompt_ids, n, pos0);
     // Consume it. This is PER-REQUEST state, not model state: leaving it set would splice the
     // previous request's image into the next prompt, which would produce fluent, confident text

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1387,6 +1387,12 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     const int  kv_elem = kv8 ? 1 : 2;
     const float rope_theta = c.rope_theta, eps = c.rms_eps;
     const int rope_dim = (c.rope_dim > 0) ? c.rope_dim : c.head_dim;
+    // MRoPE positions for THIS window. s.mrope_pos is indexed by absolute prompt position, while
+    // the kernels index by the row within this pass -- the same split pos0 already draws between
+    // `pos` and `tok` -- so the pointer is advanced past the rows earlier windows consumed.
+    // Null (every text-only request) makes the launchers pick their non-MRoPE instantiation.
+    const int* const mrope_win =
+        (s.mrope_pos && c.mrope()) ? s.mrope_pos + (size_t)3 * pos0 : nullptr;
     const float attn_scale = 1.f / sqrtf((float)c.head_dim);
 
     // embed -> x, prime xn = RMSNorm(x, layer0.input_norm)
@@ -1642,12 +1648,14 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                         kernels::launch_prefill_qknorm_rope_kv_bf16_vi8(
                             qb, kf, vf, w.q_norm, w.k_norm, kpool, vpool, vi8, vi8_scale,
                             btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                            rope_dim, rope_theta, eps, bs, mbs, st, pos0);
+                            rope_dim, rope_theta, eps, bs, mbs, st, pos0,
+                            mrope_win, c.mrope_sec_h, c.mrope_sec_w);
                     else
                         kernels::launch_prefill_qknorm_rope_kv_bf16(
                             qb, kf, vf, w.q_norm, w.k_norm, kpool, vpool, btable, N,
                             c.n_q_heads, c.n_kv_heads, c.head_dim,
-                            rope_dim, rope_theta, eps, bs, mbs, st, pos0);
+                            rope_dim, rope_theta, eps, bs, mbs, st, pos0,
+                            mrope_win, c.mrope_sec_h, c.mrope_sec_w);
                     const bool vi8_done = vi8 && kernels::launch_prefill_attn_mma_bf16_vi8(
                         qb, kf, vi8, vi8_scale, btable, att, N, c.n_q_heads, c.n_kv_heads,
                         c.head_dim, bs, mbs, attn_scale, st, pos0);
@@ -1663,7 +1671,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                 } else {
                     kernels::launch_prefill_qknorm_rope_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
                         kpool, vpool, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                        rope_dim, rope_theta, eps, bs, mbs, st, pos0);
+                        rope_dim, rope_theta, eps, bs, mbs, st, pos0,
+                        mrope_win, c.mrope_sec_h, c.mrope_sec_w);
                     // Qwen3.8 interleaves SWA and global-attention layers. The old int8 launcher
                     // read one process-wide 4096-token window for every layer, silently truncating
                     // the global layers at long context. Pass the layer contract explicitly, as

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -57,6 +57,14 @@ struct Qwen35PrefillCtx {
     const void*          vision_emb = nullptr;
     const int*           vision_pos = nullptr;
     int                  vision_n   = 0;
+
+    // Interleaved-MRoPE rotary positions: [n_tokens * 3] int32 on device, laid out
+    // [t0,h0,w0, t1,h1,w1, ...]. Null means the ordinary 1D ramp (pos0 + row), which is what every
+    // text-only request uses and what the kernels compile to when this is absent.
+    //
+    // Indexed by the row within THIS PASS, so a windowed prefill must hand over the slice for its
+    // own window rather than the whole prompt -- the same relationship `tok` already has to pos0.
+    const int*           mrope_pos  = nullptr;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.

--- a/runtime/src/models/qwen_vision_preprocess.cpp
+++ b/runtime/src/models/qwen_vision_preprocess.cpp
@@ -50,6 +50,53 @@ void resample_axis(const float* src, int src_len, int dst_len, int stride_src, i
     }
 }
 
+// Resize + rescale + normalize ONE frame into planar [C, rh, rw] float32.
+//
+// Split out of qwen_vision_preprocess so the video path reuses this byte-for-byte rather than
+// growing a second copy of the reference-exact ordering below. That ordering is load-bearing and
+// was measured, not guessed (see the comments inside): resize the uint8 VALUES, round-and-clamp
+// the intermediate back to uint8 the way PIL does, and only then rescale and normalize. A video
+// is just N frames through this same funnel, so any drift here would apply identically to images
+// and video -- which is exactly the property that makes the image reference check cover both.
+void normalize_frame(const unsigned char* rgb, int height, int width, int rh, int rw,
+                     const QwenVisionConfig& cfg, std::vector<float>& out) {
+    const int C = cfg.in_channels;
+    std::vector<float> plane((size_t)C * height * width);
+    for (int c = 0; c < C; c++)
+        for (int y = 0; y < height; y++)
+            for (int x = 0; x < width; x++)
+                plane[((size_t)c * height + y) * width + x] =
+                    (float)rgb[((size_t)y * width + x) * C + c];
+
+    std::vector<float> tmp((size_t)C * height * rw);
+    out.assign((size_t)C * rh * rw, 0.0f);
+    for (int c = 0; c < C; c++) {   // horizontal then vertical
+        resample_axis(&plane[(size_t)c * height * width], width, rw, 1, 1,
+                      height, width, rw, &tmp[(size_t)c * height * rw]);
+        // The reference's INTERMEDIATE image is uint8 too: PIL resamples horizontally into an
+        // 8-bit temp, then vertically out of it, so the round-and-clamp happens TWICE. Carrying
+        // float through both passes and rounding once at the end is more accurate but drifts
+        // from the reference by several LSB at edges, which is not ours to decide.
+        float* t = &tmp[(size_t)c * height * rw];
+        for (long i = 0; i < (long)height * rw; i++)
+            t[i] = std::min(255.0f, std::max(0.0f, std::floor(t[i] + 0.5f)));
+        resample_axis(t, height, rh, rw, rw, rw, 1, 1, &out[(size_t)c * rh * rw]);
+    }
+    for (int c = 0; c < C; c++) {
+        const float mu = cfg.mean[c], sd = cfg.std_[c] != 0.f ? cfg.std_[c] : 1.f;
+        float* p = &out[(size_t)c * rh * rw];
+        for (long i = 0; i < (long)rh * rw; i++) {
+            // The uint8 round-trip the reference performs, then rescale, then normalize.
+            // floor(x+0.5), i.e. round-half-UP, because PIL's 8-bit resample accumulates in
+            // fixed point and rounds with a half-LSB add -- not nearbyint's round-half-to-EVEN,
+            // which disagrees on exact .5 ties. (smart_resize genuinely does want banker's
+            // rounding; that is Python's round(), a different reference entirely.)
+            const float q = std::min(255.0f, std::max(0.0f, std::floor(p[i] + 0.5f)));
+            p[i] = (q * (1.0f / 255.0f) - mu) / sd;
+        }
+    }
+}
+
 }  // namespace
 
 bool qwen_vision_smart_resize(int height, int width, int factor, long min_pixels, long max_pixels,
@@ -102,48 +149,8 @@ bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
     const int C = cfg.in_channels, P = cfg.patch_size, T = cfg.temporal_patch;
     const int gh = rh / P, gw = rw / P;
 
-    // Planar uint8 VALUES (0..255, not yet rescaled), then resize, then rescale, then normalize.
-    //
-    // This order is the reference's, and it is not interchangeable with rescaling first even
-    // though resampling is linear: transformers resizes the uint8 image and casts the result back
-    // to uint8 -- PIL in the slow processor, torchvision in the fast one -- which ROUNDS to
-    // nearest and CLAMPS bicubic's overshoot into [0,255]. Neither of those commutes with
-    // scaling. Rescaling first (which this did until measured) leaves the overshoot in place and
-    // drifts from the reference by up to 0.127 in normalized units at high-contrast edges, where
-    // rounding alone would account for only ~0.004.
-    std::vector<float> plane((size_t)C * height * width);
-    for (int c = 0; c < C; c++)
-        for (int y = 0; y < height; y++)
-            for (int x = 0; x < width; x++)
-                plane[((size_t)c * height + y) * width + x] =
-                    (float)rgb[((size_t)y * width + x) * C + c];
-
-    std::vector<float> tmp((size_t)C * height * rw), out((size_t)C * rh * rw);
-    for (int c = 0; c < C; c++) {   // horizontal then vertical
-        resample_axis(&plane[(size_t)c * height * width], width, rw, 1, 1,
-                      height, width, rw, &tmp[(size_t)c * height * rw]);
-        // The reference's INTERMEDIATE image is uint8 too: PIL resamples horizontally into an
-        // 8-bit temp, then vertically out of it, so the round-and-clamp happens TWICE. Carrying
-        // float through both passes and rounding once at the end is more accurate but drifts
-        // from the reference by several LSB at edges, which is not ours to decide.
-        float* t = &tmp[(size_t)c * height * rw];
-        for (long i = 0; i < (long)height * rw; i++)
-            t[i] = std::min(255.0f, std::max(0.0f, std::floor(t[i] + 0.5f)));
-        resample_axis(t, height, rh, rw, rw, rw, 1, 1, &out[(size_t)c * rh * rw]);
-    }
-    for (int c = 0; c < C; c++) {
-        const float mu = cfg.mean[c], sd = cfg.std_[c] != 0.f ? cfg.std_[c] : 1.f;
-        float* p = &out[(size_t)c * rh * rw];
-        for (long i = 0; i < (long)rh * rw; i++) {
-            // The uint8 round-trip the reference performs, then rescale, then normalize.
-            // floor(x+0.5), i.e. round-half-UP, because PIL's 8-bit resample accumulates in
-            // fixed point and rounds with a half-LSB add -- not nearbyint's round-half-to-EVEN,
-            // which disagrees on exact .5 ties. (smart_resize above genuinely does want
-            // banker's rounding; that is Python's round(), a different reference entirely.)
-            const float q = std::min(255.0f, std::max(0.0f, std::floor(p[i] + 0.5f)));
-            p[i] = (q * (1.0f / 255.0f) - mu) / sd;
-        }
-    }
+    std::vector<float> out;
+    normalize_frame(rgb, height, width, rh, rw, cfg, out);
 
     // Patchify: row-major over the grid, each patch (C, T, P, P), still image repeated across T.
     pixels.assign((size_t)gh * gw * C * T * P * P, 0.0f);
@@ -159,6 +166,82 @@ bool qwen_vision_preprocess(const unsigned char* rgb, int height, int width,
       }
     *grid_h = gh; *grid_w = gw;
     return true;
+}
+
+bool qwen_vision_preprocess_video(const unsigned char* const* frames, int n_frames,
+                                  int height, int width, const QwenVisionConfig& cfg,
+                                  std::vector<float>& pixels,
+                                  int* grid_t, int* grid_h, int* grid_w, std::string& err) {
+    if (!frames || n_frames <= 0) { err = "preprocess video: no frames"; return false; }
+    for (int i = 0; i < n_frames; i++)
+        if (!frames[i]) { err = "preprocess video: null frame " + std::to_string(i); return false; }
+    if (height <= 0 || width <= 0) { err = "preprocess video: empty frame"; return false; }
+
+    const int C = cfg.in_channels, P = cfg.patch_size, T = cfg.temporal_patch;
+    if (T <= 0) { err = "preprocess video: temporal_patch must be positive"; return false; }
+
+    // ONE smart_resize for the whole clip, not per frame. The reference sizes a video from a
+    // single (height, width) because every frame shares a grid -- a per-frame resize would let
+    // two frames disagree on grid_h/grid_w, and the tower packs T frames into ONE patch, so a
+    // mismatch there is not a quality question, it is a shape error at the Conv3d.
+    int rh = 0, rw = 0;
+    if (!qwen_vision_smart_resize(height, width, cfg.size_granularity(),
+                                  cfg.min_pixels, cfg.max_pixels, &rh, &rw, err)) return false;
+    const int gh = rh / P, gw = rw / P;
+
+    // Pad the frame count up to a multiple of the temporal patch by REPEATING THE LAST FRAME.
+    // This is the reference's own padding (Qwen3VLProcessor._calculate_timestamps does
+    // `indices.extend(indices[-1] ...)`), not a convenience: a trailing partial group would
+    // otherwise be dropped or zero-filled, and zero-fill is a black frame the model will happily
+    // describe. Repeating the last frame is temporally meaningless but visually truthful.
+    const int n_pad = (n_frames % T == 0) ? n_frames : n_frames + (T - n_frames % T);
+    const int gt = n_pad / T;
+
+    // Normalize each DISTINCT frame once. The padding repeats an already-normalized frame rather
+    // than re-running the resize on it.
+    std::vector<std::vector<float>> norm((size_t)n_frames);
+    for (int i = 0; i < n_frames; i++)
+        normalize_frame(frames[i], height, width, rh, rw, cfg, norm[(size_t)i]);
+
+    // Patchify, group-major: [gt * gh * gw, C*T*P*P]. Within a group the layout is identical to
+    // the image path's (C, T, P, P) -- the only difference is that T now carries REAL consecutive
+    // frames instead of the same still repeated. That is the whole of "video" at this layer.
+    pixels.assign((size_t)gt * gh * gw * C * T * P * P, 0.0f);
+    for (int g = 0; g < gt; g++)
+      for (int gy = 0; gy < gh; gy++)
+        for (int gx = 0; gx < gw; gx++) {
+          float* dst = &pixels[(((size_t)g * gh + gy) * gw + gx) * C * T * P * P];
+          for (int c = 0; c < C; c++)
+            for (int t = 0; t < T; t++) {
+              const int fi = std::min(g * T + t, n_frames - 1);   // last-frame padding
+              const float* src = norm[(size_t)fi].data();
+              for (int py = 0; py < P; py++)
+                for (int px = 0; px < P; px++)
+                  dst[((c * T + t) * P + py) * P + px] =
+                      src[((size_t)c * rh + (gy * P + py)) * rw + (gx * P + px)];
+            }
+        }
+    *grid_t = gt; *grid_h = gh; *grid_w = gw;
+    return true;
+}
+
+std::vector<float> qwen_vision_video_timestamps(const std::vector<int>& frame_indices,
+                                                double fps, int temporal_patch) {
+    std::vector<float> out;
+    if (frame_indices.empty() || temporal_patch <= 0) return out;
+    if (fps <= 0.0) fps = 24.0;   // the reference's own fallback when fps cannot be inferred
+
+    // Pad indices to a whole number of temporal patches by repeating the last, then average
+    // each patch's first and last frame time. Both steps are the reference's
+    // (Qwen3VLProcessor._calculate_timestamps); the average is what makes a 2-frame patch report
+    // the midpoint of the interval it actually covers rather than its leading edge.
+    std::vector<int> idx = frame_indices;
+    while (idx.size() % (size_t)temporal_patch) idx.push_back(idx.back());
+    for (size_t i = 0; i < idx.size(); i += (size_t)temporal_patch) {
+        const double a = idx[i] / fps, b = idx[i + (size_t)temporal_patch - 1] / fps;
+        out.push_back((float)((a + b) / 2.0));
+    }
+    return out;
 }
 
 bool qwen_vision_expand_placeholders(const std::vector<int>& in, int image_token_id,

--- a/runtime/src/models/qwen_vision_preprocess.cpp
+++ b/runtime/src/models/qwen_vision_preprocess.cpp
@@ -244,6 +244,75 @@ std::vector<float> qwen_vision_video_timestamps(const std::vector<int>& frame_in
     return out;
 }
 
+bool qwen_vision_mrope_positions(const std::vector<int>& token_ids,
+                                 int image_token_id, int video_token_id,
+                                 const std::vector<QwenVisionSpanGrid>& spans,
+                                 int spatial_merge, int start_pos,
+                                 std::vector<int>& out, std::string& err) {
+    if (spatial_merge <= 0) { err = "mrope: spatial_merge must be positive"; return false; }
+    out.assign(token_ids.size() * 3, 0);
+
+    long pos = start_pos;
+    size_t next_span = 0;
+    size_t i = 0;
+    while (i < token_ids.size()) {
+        const int id = token_ids[i];
+        if (id != image_token_id && id != video_token_id) {
+            // Text: all three axes share one counter, which is plain 1D RoPE.
+            out[i * 3 + 0] = (int)pos;
+            out[i * 3 + 1] = (int)pos;
+            out[i * 3 + 2] = (int)pos;
+            pos++;
+            i++;
+            continue;
+        }
+        size_t j = i;
+        while (j < token_ids.size() && token_ids[j] == id) j++;
+        const size_t run = j - i;
+
+        if (next_span >= spans.size()) {
+            err = "mrope: prompt has more vision spans than grids were supplied";
+            return false;
+        }
+        const QwenVisionSpanGrid& g = spans[next_span++];
+        const int lt = g.grid_t;
+        const int lh = g.grid_h / spatial_merge;
+        const int lw = g.grid_w / spatial_merge;
+        if (lt <= 0 || lh <= 0 || lw <= 0) {
+            err = "mrope: vision span has a degenerate merged grid";
+            return false;
+        }
+        if ((size_t)lt * lh * lw != run) {
+            err = "mrope: vision span covers " + std::to_string(run) +
+                  " tokens but its grid implies " + std::to_string((size_t)lt * lh * lw);
+            return false;
+        }
+
+        // meshgrid(t, h, w) in ij order, flattened -- the reference's get_vision_position_ids.
+        // The temporal index is NOT offset by start_pos twice: the reference adds start_position
+        // to h and w up front and to t only after the time_interval multiply, which for
+        // time_interval = 1 lands all three on the same base.
+        size_t k = i;
+        for (int t = 0; t < lt; t++)
+            for (int h = 0; h < lh; h++)
+                for (int w = 0; w < lw; w++, k++) {
+                    out[k * 3 + 0] = (int)(pos + t);
+                    out[k * 3 + 1] = (int)(pos + h);
+                    out[k * 3 + 2] = (int)(pos + w);
+                }
+
+        // The advance that the 1D path gets wrong: max(h, w), not the token count.
+        pos += (lh > lw ? lh : lw);
+        i = j;
+    }
+    if (next_span != spans.size()) {
+        err = "mrope: " + std::to_string(spans.size() - next_span) +
+              " supplied grid(s) had no matching vision span in the prompt";
+        return false;
+    }
+    return true;
+}
+
 bool qwen_vision_expand_video_placeholders(const std::vector<int>& in, int video_token_id,
                                            int vision_start_token_id, int vision_end_token_id,
                                            const std::vector<QwenVideoSpan>& videos,

--- a/runtime/src/models/qwen_vision_preprocess.cpp
+++ b/runtime/src/models/qwen_vision_preprocess.cpp
@@ -244,6 +244,44 @@ std::vector<float> qwen_vision_video_timestamps(const std::vector<int>& frame_in
     return out;
 }
 
+bool qwen_vision_expand_video_placeholders(const std::vector<int>& in, int video_token_id,
+                                           int vision_start_token_id, int vision_end_token_id,
+                                           const std::vector<QwenVideoSpan>& videos,
+                                           std::vector<int>& out, std::string& err) {
+    size_t found = 0;
+    for (int t : in) if (t == video_token_id) found++;
+    if (found != videos.size()) {
+        err = "video placeholder count mismatch: prompt has " + std::to_string(found) +
+              " <|video_pad|>, caller preprocessed " + std::to_string(videos.size()) + " video(s)";
+        return false;
+    }
+    for (size_t i = 0; i < videos.size(); i++) {
+        if (videos[i].tokens_per_frame <= 0) {
+            err = "video " + std::to_string(i) + ": tokens_per_frame must be positive";
+            return false;
+        }
+        if (videos[i].timestamp_tokens.empty()) {
+            err = "video " + std::to_string(i) + ": no temporal groups";
+            return false;
+        }
+    }
+
+    out.clear();
+    out.reserve(in.size());
+    size_t vi = 0;
+    for (int t : in) {
+        if (t != video_token_id) { out.push_back(t); continue; }
+        const QwenVideoSpan& v = videos[vi++];
+        for (const std::vector<int>& ts : v.timestamp_tokens) {
+            out.insert(out.end(), ts.begin(), ts.end());
+            out.push_back(vision_start_token_id);
+            out.insert(out.end(), (size_t)v.tokens_per_frame, video_token_id);
+            out.push_back(vision_end_token_id);
+        }
+    }
+    return true;
+}
+
 bool qwen_vision_expand_placeholders(const std::vector<int>& in, int image_token_id,
                                      const std::vector<int>& counts,
                                      std::vector<int>& out, std::string& err) {

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -88,3 +88,15 @@ add_test(NAME qwen35_gpu_test COMMAND qwen35_gpu_test)
 add_executable(dflash_gdn_checkpoint_gpu_test dflash_gdn_checkpoint_gpu_test.cpp)
 target_link_libraries(dflash_gdn_checkpoint_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME dflash_gdn_checkpoint_gpu_test COMMAND dflash_gdn_checkpoint_gpu_test)
+
+# Video preprocessing — pure C++, no GPU, no checkpoint. Anchors the video path to the image
+# path by EQUIVALENCE: a 2-frame video of one still must be byte-identical to that still as an
+# image, because the tower's Conv3d time extent is filled by repetition for images and by real
+# frames for video. That single assertion transfers the image path's measured reference-exactness
+# (PIL bicubic constant, the twice-rounded uint8 intermediate, the (C,T,P,P) layout) onto video
+# without re-verifying any of it against transformers.
+add_executable(qwen_vision_video_cpu_test qwen_vision_video_cpu_test.cpp
+               ../src/models/qwen_vision_preprocess.cpp)
+target_include_directories(qwen_vision_video_cpu_test PRIVATE ../include)
+set_target_properties(qwen_vision_video_cpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME qwen_vision_video_cpu_test COMMAND qwen_vision_video_cpu_test)

--- a/runtime/tests/qwen_vision_video_cpu_test.cpp
+++ b/runtime/tests/qwen_vision_video_cpu_test.cpp
@@ -154,6 +154,59 @@ int main() {
               "null frame pointer rejected");
     }
 
+    // --- 6. placeholder expansion: nested spans, timestamps, exact token budget --------------
+    {
+        const int VS = cfg.vision_start_token_id, VE = cfg.vision_end_token_id;
+        const int VP = cfg.video_token_id;
+        // What the chat template produces: "Video 1: <|vision_start|><|video_pad|><|vision_end|>"
+        const std::vector<int> in = { 700, 701, VS, VP, VE, 702 };
+
+        QwenVideoSpan v;
+        v.tokens_per_frame = 4;                       // a 4x4 patch grid merged 2x2
+        v.timestamp_tokens = { {900, 901}, {902, 903} };   // two temporal groups
+        std::vector<int> out;
+        err.clear();   // else a previous section's message trails into this one's label
+        check(qwen_vision_expand_video_placeholders(in, VP, VS, VE, {v}, out, err),
+              "video expansion succeeds" + (err.empty() ? "" : " -- " + err));
+
+        // Per group: 2 timestamp tokens + vision_start + 4 pads + vision_end = 8. Two groups = 16.
+        // Plus the 5 non-placeholder tokens the template contributed.
+        check(out.size() == 5 + 16, "expanded length is template tokens + per-group spans");
+
+        int pads = 0, starts = 0, ends = 0;
+        for (int t : out) { if (t == VP) pads++; if (t == VS) starts++; if (t == VE) ends++; }
+        check(pads == 8, "one pad per merged patch per group (2 groups x 4)");
+        // The template's outer pair PLUS one inner pair per group -- the nesting is intentional.
+        check(starts == 3 && ends == 3, "outer template pair plus one inner pair per frame");
+
+        const std::vector<int> want = {
+            700, 701, VS,
+            900, 901, VS, VP, VP, VP, VP, VE,
+            902, 903, VS, VP, VP, VP, VP, VE,
+            VE, 702 };
+        check(out == want, "expansion matches the reference layout exactly");
+    }
+
+    // --- 7. expansion refuses the mismatches that would misalign a prompt ----------------------
+    {
+        const int VS = cfg.vision_start_token_id, VE = cfg.vision_end_token_id, VP = cfg.video_token_id;
+        std::vector<int> out;
+        QwenVideoSpan v; v.tokens_per_frame = 4; v.timestamp_tokens = { {900} };
+
+        // Two placeholders, one video preprocessed: silently expanding one would leave a bare
+        // <|video_pad|> the splice then has no embedding for.
+        check(!qwen_vision_expand_video_placeholders({VS, VP, VE, VS, VP, VE}, VP, VS, VE, {v}, out, err),
+              "placeholder/video count mismatch rejected");
+
+        QwenVideoSpan bad; bad.tokens_per_frame = 0; bad.timestamp_tokens = { {900} };
+        check(!qwen_vision_expand_video_placeholders({VS, VP, VE}, VP, VS, VE, {bad}, out, err),
+              "zero tokens_per_frame rejected");
+
+        QwenVideoSpan empty; empty.tokens_per_frame = 4;
+        check(!qwen_vision_expand_video_placeholders({VS, VP, VE}, VP, VS, VE, {empty}, out, err),
+              "video with no temporal groups rejected");
+    }
+
     std::printf(failures ? "\nFAILED (%d)\n" : "\nPASSED\n", failures);
     return failures ? 1 : 0;
 }

--- a/runtime/tests/qwen_vision_video_cpu_test.cpp
+++ b/runtime/tests/qwen_vision_video_cpu_test.cpp
@@ -1,0 +1,159 @@
+// Video preprocessing — pure C++, no GPU.
+//
+// The load-bearing property here is an EQUIVALENCE, not a tolerance: the tower's Conv3d has a
+// time extent of temporal_patch, an image fills it by repeating one still, and a video fills it
+// with real frames. So a 2-frame video whose frames are the SAME still must produce byte-identical
+// pixels to that still preprocessed as an image. If that ever stops holding, the video path has
+// drifted away from the image path's reference-exactness (resize kernel, uint8 round-trip, patch
+// layout) and every video number quietly stops meaning what the image checks certified.
+#include "sparkinfer/models/qwen_vision_preprocess.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+using namespace sparkinfer;
+
+static int failures = 0;
+static void check(bool ok, const std::string& what) {
+    if (!ok) { std::printf("  FAIL: %s\n", what.c_str()); failures++; }
+    else       std::printf("  ok:   %s\n", what.c_str());
+}
+
+// Deterministic, high-contrast synthetic frame. Edges matter: the reference divergence the image
+// path was fixed for showed up at high-contrast edges and nowhere else, so a flat test image
+// would pass even with the resize ordering wrong.
+static std::vector<unsigned char> make_frame(int h, int w, int seed) {
+    std::vector<unsigned char> px((size_t)h * w * 3);
+    for (int y = 0; y < h; y++)
+        for (int x = 0; x < w; x++) {
+            const int v = ((x / 5 + y / 7 + seed) % 2) ? 250 : 5;
+            px[((size_t)y * w + x) * 3 + 0] = (unsigned char)v;
+            px[((size_t)y * w + x) * 3 + 1] = (unsigned char)((v + 60 * seed) % 256);
+            px[((size_t)y * w + x) * 3 + 2] = (unsigned char)(255 - v);
+        }
+    return px;
+}
+
+int main() {
+    QwenVisionConfig cfg;   // defaults are the released checkpoint's
+    std::string err;
+    const int H = 140, W = 196;
+
+    std::printf("temporal_patch=%d spatial_merge=%d patch=%d\n",
+                cfg.temporal_patch, cfg.spatial_merge, cfg.patch_size);
+
+    // --- 1. an image IS a 2-frame video of the same still -------------------------------------
+    {
+        auto f = make_frame(H, W, 0);
+        std::vector<float> img, vid;
+        int igh = 0, igw = 0, gt = 0, vgh = 0, vgw = 0;
+        const bool a = qwen_vision_preprocess(f.data(), H, W, cfg, img, &igh, &igw, err);
+        check(a, "image preprocess succeeds" + (a ? "" : " -- " + err));
+
+        const unsigned char* frames[2] = { f.data(), f.data() };
+        const bool b = qwen_vision_preprocess_video(frames, 2, H, W, cfg, vid, &gt, &vgh, &vgw, err);
+        check(b, "video preprocess succeeds" + (b ? "" : " -- " + err));
+
+        check(gt == 1, "two frames at temporal_patch=2 make ONE temporal group");
+        check(igh == vgh && igw == vgw, "video grid matches image grid");
+        check(img.size() == vid.size(), "video pixel buffer matches image size");
+
+        bool identical = img.size() == vid.size();
+        double worst = 0.0;
+        for (size_t i = 0; i < img.size() && i < vid.size(); i++)
+            worst = std::max(worst, (double)std::fabs(img[i] - vid[i]));
+        identical = identical && worst == 0.0;
+        std::printf("  max|image - video(same still x2)| = %.17g\n", worst);
+        check(identical, "duplicated-still video is BYTE-IDENTICAL to the image path");
+    }
+
+    // --- 2. distinct frames actually reach distinct slots in the time axis ---------------------
+    // Guards the failure where the packing loop reads frame 0 for every t: the buffer would still
+    // be the right shape and the equivalence above would still pass, so it needs its own check.
+    {
+        auto f0 = make_frame(H, W, 0), f1 = make_frame(H, W, 1);
+        const unsigned char* frames[2] = { f0.data(), f1.data() };
+        std::vector<float> vid;
+        int gt = 0, gh = 0, gw = 0;
+        check(qwen_vision_preprocess_video(frames, 2, H, W, cfg, vid, &gt, &gh, &gw, err),
+              "two DISTINCT frames preprocess");
+
+        const int C = cfg.in_channels, P = cfg.patch_size, T = cfg.temporal_patch;
+        bool any_diff = false;
+        for (int c = 0; c < C && !any_diff; c++)
+            for (int py = 0; py < P && !any_diff; py++)
+                for (int px = 0; px < P && !any_diff; px++) {
+                    const float t0 = vid[(size_t)((c * T + 0) * P + py) * P + px];
+                    const float t1 = vid[(size_t)((c * T + 1) * P + py) * P + px];
+                    if (t0 != t1) any_diff = true;
+                }
+        check(any_diff, "distinct frames land in distinct temporal slots (t=0 != t=1)");
+    }
+
+    // --- 3. odd frame counts pad by repeating the LAST frame, not with zeros -------------------
+    {
+        auto f0 = make_frame(H, W, 0), f1 = make_frame(H, W, 1), f2 = make_frame(H, W, 2);
+        const unsigned char* three[3] = { f0.data(), f1.data(), f2.data() };
+        std::vector<float> vid;
+        int gt = 0, gh = 0, gw = 0;
+        check(qwen_vision_preprocess_video(three, 3, H, W, cfg, vid, &gt, &gh, &gw, err),
+              "three frames preprocess");
+        check(gt == 2, "3 frames at temporal_patch=2 make TWO groups (padded)");
+
+        // Group 1 holds frame 2 at t=0 and the PADDING at t=1. Padding repeats frame 2, so the
+        // two slots must be equal -- and must not be the all-zero a black frame would give.
+        const int C = cfg.in_channels, P = cfg.patch_size, T = cfg.temporal_patch;
+        const size_t g1 = (size_t)1 * gh * gw * C * T * P * P;
+        bool pad_repeats = true, pad_nonzero = false;
+        for (int c = 0; c < C; c++)
+            for (int py = 0; py < P; py++)
+                for (int px = 0; px < P; px++) {
+                    const float t0 = vid[g1 + (size_t)((c * T + 0) * P + py) * P + px];
+                    const float t1 = vid[g1 + (size_t)((c * T + 1) * P + py) * P + px];
+                    if (t0 != t1) pad_repeats = false;
+                    if (t1 != 0.0f) pad_nonzero = true;
+                }
+        check(pad_repeats, "padded slot repeats the last real frame");
+        check(pad_nonzero, "padded slot is NOT a black frame");
+    }
+
+    // --- 4. timestamps: pairwise-averaged, reference formula ------------------------------------
+    {
+        // 4 frames sampled at original indices 0,12,24,36 from 24fps footage -> times
+        // 0.0,0.5,1.0,1.5 -> groups average to 0.25 and 1.25.
+        auto ts = qwen_vision_video_timestamps({0, 12, 24, 36}, 24.0, 2);
+        check(ts.size() == 2, "4 frames -> 2 group timestamps");
+        check(ts.size() == 2 && std::fabs(ts[0] - 0.25f) < 1e-6f, "group 0 timestamp is the midpoint 0.25s");
+        check(ts.size() == 2 && std::fabs(ts[1] - 1.25f) < 1e-6f, "group 1 timestamp is the midpoint 1.25s");
+
+        // Odd count pads by repeating the last INDEX, so the final group is a degenerate interval.
+        auto odd = qwen_vision_video_timestamps({0, 24, 48}, 24.0, 2);
+        check(odd.size() == 2, "3 frames -> 2 group timestamps");
+        check(odd.size() == 2 && std::fabs(odd[1] - 2.0f) < 1e-6f, "padded final group repeats its own time");
+
+        // fps <= 0 must fall back to 24 rather than dividing by zero.
+        auto fb = qwen_vision_video_timestamps({0, 24}, 0.0, 2);
+        check(fb.size() == 1 && std::isfinite(fb[0]), "fps=0 falls back rather than producing inf/nan");
+        check(fb.size() == 1 && std::fabs(fb[0] - 0.5f) < 1e-6f, "fps=0 fallback uses 24fps");
+    }
+
+    // --- 5. rejects the inputs that would silently corrupt a prompt -----------------------------
+    {
+        auto f = make_frame(H, W, 0);
+        const unsigned char* one[1] = { f.data() };
+        std::vector<float> vid; int gt = 0, gh = 0, gw = 0;
+        check(!qwen_vision_preprocess_video(nullptr, 1, H, W, cfg, vid, &gt, &gh, &gw, err),
+              "null frame array rejected");
+        check(!qwen_vision_preprocess_video(one, 0, H, W, cfg, vid, &gt, &gh, &gw, err),
+              "zero frames rejected");
+        const unsigned char* withnull[2] = { f.data(), nullptr };
+        check(!qwen_vision_preprocess_video(withnull, 2, H, W, cfg, vid, &gt, &gh, &gw, err),
+              "null frame pointer rejected");
+    }
+
+    std::printf(failures ? "\nFAILED (%d)\n" : "\nPASSED\n", failures);
+    return failures ? 1 : 0;
+}

--- a/runtime/tests/topk_topp_sample_gpu_test.cpp
+++ b/runtime/tests/topk_topp_sample_gpu_test.cpp
@@ -111,6 +111,19 @@ int sample_one(Scratch& s, const std::vector<float>& logits, int top_k, float to
 
 bool is_neg_inf(float v) { return v == -std::numeric_limits<float>::infinity(); }
 
+// The indices that SURVIVED masking, in order.
+//
+// Stronger than spelling the survivors out elementwise (!is_neg_inf(out[0]) && is_neg_inf(out[1])
+// && ...): that form asserts what the listed entries are, but not that nothing ELSE survived, so a
+// mask that kept an extra token beyond the ones written down would still pass. Comparing the whole
+// surviving SET catches that.
+std::vector<int> finite_indices(const std::vector<float>& v) {
+    std::vector<int> idx;
+    for (size_t i = 0; i < v.size(); i++)
+        if (!is_neg_inf(v[i])) idx.push_back((int)i);
+    return idx;
+}
+
 bool test_top_k_1_always_greedy() {
     const std::vector<float> logits = {1.0f, 5.0f, 3.0f, 2.0f, -1.0f, 4.0f};
     Scratch s((int)logits.size());

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -27,6 +27,7 @@ FetchContent_MakeAvailable(re2)
 
 add_executable(sparkinfer_server
     src/image_input.cpp
+    src/video_input.cpp
     src/sparkinfer_server.cpp
     src/model_engine.cpp
     src/chat_tokenizer.cpp

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -83,6 +83,22 @@ if(BUILD_TESTS)
     target_compile_features(image_input_test PRIVATE cxx_std_17)
     add_test(NAME image_input_test COMMAND image_input_test)
 
+    # Video input: the ffmpeg subprocess path against real containers ffmpeg synthesizes itself,
+    # plus the same refusals image_input_test covers. SKIPS (passes) when ffmpeg is absent --
+    # video decoding is an optional runtime dependency and must not turn a box's suite red for
+    # not having it.
+    add_executable(video_input_test
+        tests/video_input_test.cpp
+        src/video_input.cpp
+        src/image_input.cpp
+    )
+    target_include_directories(video_input_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/third_party
+    )
+    target_compile_features(video_input_test PRIVATE cxx_std_17)
+    add_test(NAME video_input_test COMMAND video_input_test)
+
     add_executable(chat_tokenizer_test
         tests/chat_tokenizer_test.cpp
         src/chat_tokenizer.cpp

--- a/server/include/chat_tools.hpp
+++ b/server/include/chat_tools.hpp
@@ -42,6 +42,12 @@ struct ChatMessage {
     // that part occupied, so this vector and those markers stay in lockstep -- the processor, not
     // the template, later expands each placeholder to the token count its grid needs.
     std::vector<std::string> images;
+    // video_url values, same contract as images above: one
+    // <|vision_start|><|video_pad|><|vision_end|> renders per entry, in order. Kept in its OWN
+    // vector rather than folded into images because the two expand differently -- an image
+    // becomes one span of merged-patch placeholders, a video becomes one timestamped span PER
+    // temporal group -- and because the splice keys on a different token id.
+    std::vector<std::string> videos;
 };
 
 enum class ResponseFormatType {

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -50,6 +50,25 @@ struct PreparedImages {
         int grid_h = 0;
         int grid_w = 0;
     };
+    // One decoded clip. Each temporal group is an ordinary Image -- the tower call for a video
+    // frame-pair is byte-for-byte the call for a still, which is why video needed no tower work.
+    struct Video {
+        std::vector<Image> groups;
+        // Tokenized "<N.N seconds>" marker per group, tokenized by the server (the runtime has no
+        // tokenizer). Kept here so a re-render can redo the expansion without re-decoding.
+        std::vector<std::vector<int>> timestamp_tokens;
+        int tokens_per_frame = 0;
+    };
+
+    // Inputs, in message order, kept so reexpand() can rebuild a prompt from scratch after a
+    // tool-call retry re-renders it.
+    std::vector<Image> src_images;
+    std::vector<Video> src_videos;
+
+    // FLATTENED tower units in PROMPT order, one per entry in `positions`. Images and video
+    // groups interleave here exactly as their placeholders do in the prompt -- the engine pairs
+    // images[i] with positions[i] positionally, so any other order silently splices each image's
+    // embedding at another image's location.
     std::vector<Image> images;
     std::vector<int> positions;      // absolute prompt indices of the expanded placeholder run
 };
@@ -96,6 +115,29 @@ public:
                         std::vector<int>& prompt_ids, PreparedImages& out,
                         std::string& err) const;
 
+    // Sampling parameters for video decode. Frames become prompt tokens, so these are a context
+    // budget as much as a memory one; 0 means "use the built-in default".
+    struct VideoSampling { int max_frames = 0; double fps = 0.0; };
+
+    // Same, for images and videos together. Videos decode through ffmpeg, sample to frames, and
+    // preprocess into temporal groups; each group becomes an ordinary tower unit.
+    //
+    // tokenize renders the "<N.N seconds>" marker that precedes each temporal group's span. It is
+    // a callback rather than a return-and-call-again because the timestamps depend on the sampled
+    // frame indices, which only exist after decoding -- and decoding twice would mean two ffmpeg
+    // subprocesses per request. The engine has no tokenizer of its own, hence the injection.
+    //
+    // Handles the interleaved case: a message carrying an image and a video in either order comes
+    // back with images[] in PROMPT order, not images-then-videos, because the engine pairs
+    // images[i] with positions[i] positionally.
+    bool prepare_vision(const std::vector<std::string>& image_urls,
+                        const std::vector<std::string>& video_urls,
+                        int image_token_id, int video_token_id,
+                        int vision_start_token_id, int vision_end_token_id,
+                        const VideoSampling& sampling,
+                        const std::function<std::vector<int>(const std::string&)>& tokenize,
+                        std::vector<int>& prompt_ids, PreparedImages& out, std::string& err) const;
+
     // Re-expands placeholders and recomputes positions against a prompt that was rebuilt after
     // prepare_images already ran. The tool-call continuation path re-renders the entire prompt
     // from the message list, so both the earlier expansion and the offsets it recorded are stale
@@ -106,6 +148,13 @@ public:
     // one positions vector.
     bool reexpand_images(int image_token_id, std::vector<int>& prompt_ids, PreparedImages& io,
                          std::string& err) const;
+
+    // The general form: re-expands image AND video placeholders and rebuilds images[]/positions[]
+    // in prompt order. reexpand_images() is this with the vision token ids taken from the loaded
+    // checkpoint's vision_config.
+    bool reexpand_vision(int image_token_id, int video_token_id,
+                         int vision_start_token_id, int vision_end_token_id,
+                         std::vector<int>& prompt_ids, PreparedImages& io, std::string& err) const;
 
     // Optional shared prompt prefix (e.g. system message tokens). When set, each request whose
     // prompt starts with these ids calls cache_prefix() (batched prefill) before generate().

--- a/server/include/model_engine.hpp
+++ b/server/include/model_engine.hpp
@@ -71,6 +71,14 @@ struct PreparedImages {
     // embedding at another image's location.
     std::vector<Image> images;
     std::vector<int> positions;      // absolute prompt indices of the expanded placeholder run
+
+    // Interleaved-MRoPE rotary positions for the whole prompt: [n_tokens*3], [t,h,w] per token.
+    // Empty when the loaded checkpoint declares no mrope_section.
+    std::vector<int> mrope_pos;
+    // (rotary position after the prompt) - prompt length. Zero or negative, because a vision span
+    // advances the rotary counter by max(h,w)/merge rather than by its token count. Every decode
+    // step of the request adds this to its rotary position while its cache slot stays sequential.
+    int mrope_decode_offset = 0;
 };
 
 // Thread-safe wrapper around sparkinfer::Qwen35Model + GGUF load.

--- a/server/include/video_input.hpp
+++ b/server/include/video_input.hpp
@@ -1,0 +1,65 @@
+#pragma once
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace sparkinfer_server {
+
+// A decoded clip: N frames, all the same size, already RGB8.
+struct DecodedVideo {
+    int width = 0, height = 0;
+    std::vector<std::vector<unsigned char>> frames;   // each [height * width * 3]
+    // ORIGINAL frame numbers that were sampled, at the container's own frame rate. Not 0..N-1:
+    // the timestamps the prompt carries are computed from these over `fps`, so subsampling a
+    // 30fps clip to 2fps still yields real elapsed seconds rather than frame ordinals.
+    std::vector<int> frame_indices;
+    double fps = 0.0;                                 // the SOURCE frame rate
+};
+
+// Decodes a video container to sampled RGB8 frames by invoking ffmpeg/ffprobe as subprocesses.
+//
+// Why a subprocess and not a linked decoder: this repo vendors single-header dependencies
+// (stb_image.h, httplib.h) and there is no single-header H.264/VP9 decoder worth trusting.
+// Linking libavcodec would pull a large LGPL dependency into a CUDA serving binary and make the
+// build materially harder on every box this runs on. ffmpeg-as-a-tool keeps the build unchanged
+// and the dependency inspectable, at the cost of a fork/exec per request and a runtime
+// requirement that is checked and reported explicitly rather than discovered as a crash.
+//
+// The bytes handed to ffmpeg are UNTRUSTED. They arrive over the wire from whoever called the
+// server, so this path is bounded on every axis that could be used to exhaust the box: total
+// input bytes, decode wall-clock, sampled frame count, and per-frame pixel count. ffmpeg runs
+// with no network protocols enabled, so a crafted container cannot turn the decoder into an
+// outbound fetch primitive.
+//
+//   max_frames:  hard ceiling on sampled frames. Frames become prompt tokens -- roughly
+//                (h/32)*(w/32) of them per temporal PAIR -- so this is a context budget, not
+//                just a memory one.
+//   target_fps:  sampling rate. <= 0 samples the clip's own rate.
+bool decode_video(const unsigned char* bytes, size_t n, int max_frames, double target_fps,
+                  DecodedVideo& out, std::string& err);
+
+// Parses an OpenAI-style video_url value. data: URLs ONLY, for exactly the reason parse_image_url
+// refuses remote images: an inference server that fetches caller-supplied URLs is an SSRF
+// primitive, and that is the deployer's decision to make, not a default.
+bool parse_video_url(const std::string& url, std::vector<unsigned char>& bytes, std::string& err);
+
+// Is a usable ffmpeg (and ffprobe) actually present? Checked so the server can say "video input
+// needs ffmpeg on PATH" instead of failing inside a pipe with an empty read.
+bool video_decoder_available(std::string* detail = nullptr);
+
+// Ceiling on one clip's encoded bytes, applied BEFORE the decoder is handed anything. Larger than
+// the image ceiling because video legitimately is, but still bounded: the decode happens before
+// any pixel budget can apply.
+constexpr size_t kMaxVideoBytes = 256u * 1024u * 1024u;
+
+// Default sampling. 2 fps over at most 32 frames is 16 temporal groups; at a typical 4:3 grid
+// that is already thousands of prompt tokens, so these defaults are chosen against the context
+// budget rather than against fidelity.
+constexpr int    kDefaultMaxVideoFrames = 32;
+constexpr double kDefaultVideoFps       = 2.0;
+
+// Wall-clock ceiling for one decode. A malformed or adversarial container can make a decoder
+// spin; without this the request thread would hang rather than error.
+constexpr int    kVideoDecodeTimeoutSec = 60;
+
+}  // namespace sparkinfer_server

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -1748,6 +1748,28 @@ ParsedToolOutput parse_qwen36_tool_output(const std::string& raw, bool enable_th
         if (has_protocol_markup(out.content)) {
             return fail_tool_output(std::move(out), "malformed tool-call markup");
         }
+        // tool_choice=required / a named function is a CONTRACT, not a hint: the caller is told at
+        // least one call (or that specific call) will come back, and typically branches on
+        // tool_calls without checking. The template already instructs the model that it MUST call
+        // -- but instructing is not enforcing, and a model that answers in prose anyway was, until
+        // now, passed straight through as an ordinary assistant message. The caller then sees a
+        // successful completion with no tool_calls, which is exactly the case it was promised
+        // could not happen.
+        //
+        // Failing here routes into the same invalid_tool_output path as malformed markup, which is
+        // bounded (one retry, then a 502) rather than looping.
+        if (!request.tools.empty()) {
+            if (request.tool_choice == ToolChoiceMode::kRequired) {
+                return fail_tool_output(std::move(out),
+                                        "tool_choice=required but the model returned no tool call");
+            }
+            if (request.tool_choice == ToolChoiceMode::kNamed) {
+                return fail_tool_output(std::move(out),
+                                        "tool_choice named the function \"" +
+                                        request.required_tool_name +
+                                        "\" but the model returned no tool call");
+            }
+        }
         return out;
     }
     if (request.tools.empty() || request.tool_choice == ToolChoiceMode::kNone) {

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -35,6 +35,7 @@ constexpr const char* kImStart = "<|im_start|>";
 constexpr const char* kVisionStart = "<|vision_start|>";
 constexpr const char* kImagePad    = "<|image_pad|>";
 constexpr const char* kVisionEnd   = "<|vision_end|>";
+constexpr const char* kVideoPad    = "<|video_pad|>";
 constexpr const char* kImEnd = "<|im_end|>";
 constexpr const char* kThinkOpen = "<think>";
 constexpr const char* kThinkClose = "</think>";
@@ -208,7 +209,8 @@ bool is_allowed_key(const json& object, const std::set<std::string>& allowed,
 
 bool parse_content(const json& value, std::string& content, bool& is_null,
                    const std::string& where, std::string& err,
-                   std::vector<std::string>* images, const std::string& role) {
+                   std::vector<std::string>* images, const std::string& role,
+                   std::vector<std::string>* videos) {
     content.clear();
     is_null = value.is_null();
     if (is_null) return true;
@@ -236,6 +238,25 @@ bool parse_content(const json& value, std::string& content, bool& is_null,
             images->push_back(iu["url"].get<std::string>());
             content += kVisionStart;
             content += kImagePad;
+            content += kVisionEnd;
+            continue;
+        }
+        if (part["type"] == "video_url" && videos) {
+            // Same shape as image_url above, and refused in system/developer messages for the
+            // same reason -- the template raises on it outright.
+            if (role == "system")
+                return set_error(err, where + ".content[" + std::to_string(i) +
+                                      "]: system/developer messages cannot contain videos");
+            const json& vu = part.contains("video_url") ? part["video_url"] : json();
+            if (!vu.is_object() || !vu.contains("url") || !vu["url"].is_string())
+                return set_error(err, where + ".content[" + std::to_string(i) +
+                                      "].video_url.url must be a string");
+            videos->push_back(vu["url"].get<std::string>());
+            // ONE <|video_pad|> here, exactly as the template emits. The per-frame timestamped
+            // spans are expanded later, in token space, once the clip's grid is known -- the
+            // template cannot do it because it does not know how many frames were sampled.
+            content += kVisionStart;
+            content += kVideoPad;
             content += kVisionEnd;
             continue;
         }
@@ -577,7 +598,7 @@ bool parse_message(const json& value, ChatMessage& message, size_t index, std::s
         return set_error(err, where + ".role is unsupported");
     if (value.contains("content")) {
         if (!parse_content(value["content"], message.content, message.content_is_null, where, err,
-                           &message.images, message.role)) return false;
+                           &message.images, message.role, &message.videos)) return false;
     } else {
         message.content_is_null = true;
     }

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -702,6 +702,28 @@ bool ModelEngine::reexpand_vision(int image_token_id, int video_token_id,
         err = "prompt carries fewer vision spans than were preprocessed";
         return false;
     }
+
+    // MRoPE positions, computed from the SAME walk-ordered unit list so the spans cannot drift
+    // out of step with the placeholder runs they describe.
+    io.mrope_pos.clear();
+    io.mrope_decode_offset = 0;
+    if (impl_->cfg.mrope()) {
+        std::vector<sparkinfer::QwenVisionSpanGrid> grids;
+        grids.reserve(io.images.size());
+        // grid_t is 1 per unit: an image is one temporal group, and the reference splits a video's
+        // grid into one t=1 row PER GROUP, which is exactly how the prompt spans them too.
+        for (const auto& im : io.images) grids.push_back({1, im.grid_h, im.grid_w});
+        if (!sparkinfer::qwen_vision_mrope_positions(prompt_ids, image_token_id, video_token_id,
+                                                     grids, impl_->vcfg.spatial_merge, 0,
+                                                     io.mrope_pos, err))
+            return false;
+        // The last token's rotary position + 1 is where decode resumes; the difference from the
+        // prompt length is the constant every later decode step applies.
+        if (!prompt_ids.empty()) {
+            const int last_t = io.mrope_pos[(prompt_ids.size() - 1) * 3];
+            io.mrope_decode_offset = (last_t + 1) - (int)prompt_ids.size();
+        }
+    }
     return true;
 }
 
@@ -766,6 +788,14 @@ CompletionResult ModelEngine::complete_streaming(const std::vector<int>& prompt_
     req.prompt = prompt_ids;
     req.max_new_tokens = max_new_tokens;
     req.forced_tokens = forced_tokens;
+    if (images && !images->mrope_pos.empty()) {
+        // Carried whenever the checkpoint declares an mrope_section, independently of whether this
+        // particular request has images: the positions describe every token, and a prompt with no
+        // vision span still gets the (degenerate, all-axes-equal) values, which cost nothing and
+        // keep one code path instead of two.
+        req.mrope_pos = images->mrope_pos;
+        req.mrope_decode_offset = images->mrope_decode_offset;
+    }
     if (images && !images->positions.empty()) {
         req.vision_pos = images->positions;
         req.vision_images.reserve(images->images.size());

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -707,7 +707,15 @@ bool ModelEngine::reexpand_vision(int image_token_id, int video_token_id,
     // out of step with the placeholder runs they describe.
     io.mrope_pos.clear();
     io.mrope_decode_offset = 0;
-    if (impl_->cfg.mrope()) {
+    // SPARKINFER_MROPE=0 falls back to the 1D positions used before MRoPE existed. Kept because
+    // MRoPE is a BEHAVIOURAL change to already-shipped image handling, not a pure addition: an
+    // operator who sees image answers move after an upgrade needs a way to attribute it, and an
+    // A/B on one build is the only way to measure the effect on output at all.
+    static const bool mrope_enabled = [] {
+        const char* e = getenv("SPARKINFER_MROPE");
+        return !(e && e[0] == '0');
+    }();
+    if (impl_->cfg.mrope() && mrope_enabled) {
         std::vector<sparkinfer::QwenVisionSpanGrid> grids;
         grids.reserve(io.images.size());
         // grid_t is 1 per unit: an image is one temporal group, and the reference splits a video's

--- a/server/src/model_engine.cpp
+++ b/server/src/model_engine.cpp
@@ -11,6 +11,7 @@
 #include "sparkinfer/models/qwen_vision_preprocess.h"
 #include "sparkinfer/safetensors.h"
 #include "image_input.hpp"
+#include "video_input.hpp"
 #include "sparkinfer/moe/engine.h"
 #include "sparkinfer/runtime.h"
 
@@ -460,6 +461,8 @@ bool ModelEngine::has_vision() const {
 bool ModelEngine::prepare_images(const std::vector<std::string>& urls, int image_token_id,
                                  std::vector<int>& prompt_ids, PreparedImages& out,
                                  std::string& err) const {
+    out.src_images.clear();
+    out.src_videos.clear();
     out.images.clear();
     out.positions.clear();
     if (urls.empty()) return true;
@@ -490,7 +493,7 @@ bool ModelEngine::prepare_images(const std::vector<std::string>& urls, int image
         pi.pixels = std::move(pixels);
         pi.grid_h = gh;
         pi.grid_w = gw;
-        out.images.push_back(std::move(pi));
+        out.src_images.push_back(std::move(pi));
     }
     // One placeholder per image goes in, the count each grid needs comes out. A mismatch here is
     // an error, never a best-effort expansion: guessing would hand the model a prompt whose image
@@ -498,22 +501,207 @@ bool ModelEngine::prepare_images(const std::vector<std::string>& urls, int image
     return reexpand_images(image_token_id, prompt_ids, out, err);
 }
 
+bool ModelEngine::prepare_vision(const std::vector<std::string>& image_urls,
+                                 const std::vector<std::string>& video_urls,
+                                 int image_token_id, int video_token_id,
+                                 int vision_start_token_id, int vision_end_token_id,
+                                 const VideoSampling& sampling,
+                                 const std::function<std::vector<int>(const std::string&)>& tokenize,
+                                 std::vector<int>& prompt_ids, PreparedImages& out,
+                                 std::string& err) const {
+    out.src_images.clear();
+    out.src_videos.clear();
+    out.images.clear();
+    out.positions.clear();
+    if (image_urls.empty() && video_urls.empty()) return true;
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        if (!impl_->vision_ready) {
+            err = "this model has no vision tower; image and video input are not supported";
+            return false;
+        }
+    }
+    if (!video_urls.empty() && !tokenize) {
+        err = "video input requires a tokenizer for its timestamp markers";
+        return false;
+    }
+
+    // Everything below is CPU-only preprocessing -- no tower weights are touched -- so it runs
+    // without the engine mutex and without contending for the GPU.
+    for (size_t i = 0; i < image_urls.size(); i++) {
+        const std::string where = "image " + std::to_string(i);
+        std::vector<unsigned char> bytes;
+        if (!parse_image_url(image_urls[i], bytes, err)) { err = where + ": " + err; return false; }
+        DecodedImage img;
+        if (!decode_image(bytes.data(), bytes.size(), img, err)) { err = where + ": " + err; return false; }
+        PreparedImages::Image pi;
+        int gh = 0, gw = 0;
+        auto pixels = std::make_shared<std::vector<float>>();
+        if (!sparkinfer::qwen_vision_preprocess(img.rgb.data(), img.height, img.width, impl_->vcfg,
+                                                *pixels, &gh, &gw, err)) {
+            err = where + ": " + err;
+            return false;
+        }
+        pi.pixels = std::move(pixels);
+        pi.grid_h = gh;
+        pi.grid_w = gw;
+        out.src_images.push_back(std::move(pi));
+    }
+
+    for (size_t i = 0; i < video_urls.size(); i++) {
+        const std::string where = "video " + std::to_string(i);
+        if (!video_decoder_available(nullptr)) {
+            err = where + ": video input needs ffmpeg and ffprobe on PATH";
+            return false;
+        }
+        std::vector<unsigned char> bytes;
+        if (!parse_video_url(video_urls[i], bytes, err)) { err = where + ": " + err; return false; }
+        DecodedVideo clip;
+        const int max_frames = sampling.max_frames > 0 ? sampling.max_frames : kDefaultMaxVideoFrames;
+        if (!decode_video(bytes.data(), bytes.size(), max_frames, sampling.fps, clip, err)) {
+            err = where + ": " + err;
+            return false;
+        }
+
+        std::vector<const unsigned char*> frame_ptrs;
+        frame_ptrs.reserve(clip.frames.size());
+        for (const auto& f : clip.frames) frame_ptrs.push_back(f.data());
+
+        std::vector<float> pixels;
+        int gt = 0, gh = 0, gw = 0;
+        if (!sparkinfer::qwen_vision_preprocess_video(frame_ptrs.data(), (int)frame_ptrs.size(),
+                                                      clip.height, clip.width, impl_->vcfg,
+                                                      pixels, &gt, &gh, &gw, err)) {
+            err = where + ": " + err;
+            return false;
+        }
+
+        PreparedImages::Video pv;
+        pv.tokens_per_frame = sparkinfer::qwen_vision_num_tokens(gh, gw, impl_->vcfg);
+        if (pv.tokens_per_frame <= 0) {
+            err = where + ": video grid does not divide into the spatial merge block";
+            return false;
+        }
+
+        // Slice the clip's one contiguous buffer into per-group buffers. Each group is an
+        // ordinary tower call, and Image owns its pixels, so the copy buys a uniform contract
+        // with the image path rather than a second offset-aware code path in the tower.
+        const size_t per_group = pixels.size() / (size_t)(gt > 0 ? gt : 1);
+        pv.groups.reserve((size_t)gt);
+        for (int g = 0; g < gt; g++) {
+            PreparedImages::Image gi;
+            auto buf = std::make_shared<std::vector<float>>(
+                pixels.begin() + (size_t)g * per_group,
+                pixels.begin() + (size_t)(g + 1) * per_group);
+            gi.pixels = std::move(buf);
+            gi.grid_h = gh;
+            gi.grid_w = gw;
+            pv.groups.push_back(std::move(gi));
+        }
+
+        const std::vector<float> ts = sparkinfer::qwen_vision_video_timestamps(
+            clip.frame_indices, clip.fps, impl_->vcfg.temporal_patch);
+        pv.timestamp_tokens.reserve(pv.groups.size());
+        for (size_t g = 0; g < pv.groups.size(); g++) {
+            // Reference format: one decimal, e.g. "<1.5 seconds>". snprintf rather than
+            // std::to_string, which is locale-independent here but fixed at six decimals.
+            char buf[64];
+            const float t = g < ts.size() ? ts[g] : 0.0f;
+            std::snprintf(buf, sizeof(buf), "<%.1f seconds>", (double)t);
+            pv.timestamp_tokens.push_back(tokenize(buf));
+        }
+        out.src_videos.push_back(std::move(pv));
+    }
+
+    return reexpand_vision(image_token_id, video_token_id,
+                           vision_start_token_id, vision_end_token_id, prompt_ids, out, err);
+}
+
 bool ModelEngine::reexpand_images(int image_token_id, std::vector<int>& prompt_ids,
                                   PreparedImages& io, std::string& err) const {
+    return reexpand_vision(image_token_id, impl_->vcfg.video_token_id,
+                           impl_->vcfg.vision_start_token_id, impl_->vcfg.vision_end_token_id,
+                           prompt_ids, io, err);
+}
+
+bool ModelEngine::reexpand_vision(int image_token_id, int video_token_id,
+                                  int vision_start_token_id, int vision_end_token_id,
+                                  std::vector<int>& prompt_ids, PreparedImages& io,
+                                  std::string& err) const {
     io.positions.clear();
-    if (io.images.empty()) return true;
-    // Counts come from the grids, not from a remembered list, so this is correct whether it runs
-    // on the first prompt or on one rebuilt from scratch afterwards.
-    std::vector<int> counts;
-    counts.reserve(io.images.size());
-    for (const auto& im : io.images)
-        counts.push_back(sparkinfer::qwen_vision_num_tokens(im.grid_h, im.grid_w, impl_->vcfg));
-    std::vector<int> expanded;
-    if (!sparkinfer::qwen_vision_expand_placeholders(prompt_ids, image_token_id, counts, expanded, err))
+    io.images.clear();
+    if (io.src_images.empty() && io.src_videos.empty()) return true;
+
+    // VIDEOS FIRST, then images. Each expansion scans for its own placeholder id and preserves
+    // every other token, so the two are independent -- but doing videos first keeps the image
+    // expansion working on a prompt whose video spans are already their final length, which is
+    // what makes the single ordering walk below correct.
+    if (!io.src_videos.empty()) {
+        std::vector<sparkinfer::QwenVideoSpan> spans;
+        spans.reserve(io.src_videos.size());
+        for (const auto& v : io.src_videos) {
+            sparkinfer::QwenVideoSpan sp;
+            sp.tokens_per_frame = v.tokens_per_frame;
+            sp.timestamp_tokens = v.timestamp_tokens;
+            spans.push_back(std::move(sp));
+        }
+        std::vector<int> expanded;
+        if (!sparkinfer::qwen_vision_expand_video_placeholders(
+                prompt_ids, video_token_id, vision_start_token_id, vision_end_token_id,
+                spans, expanded, err))
+            return false;
+        prompt_ids.swap(expanded);
+    }
+    if (!io.src_images.empty()) {
+        std::vector<int> counts;
+        counts.reserve(io.src_images.size());
+        for (const auto& im : io.src_images)
+            counts.push_back(sparkinfer::qwen_vision_num_tokens(im.grid_h, im.grid_w, impl_->vcfg));
+        std::vector<int> expanded;
+        if (!sparkinfer::qwen_vision_expand_placeholders(prompt_ids, image_token_id, counts,
+                                                         expanded, err))
+            return false;
+        prompt_ids.swap(expanded);
+    }
+
+    // Walk the finished prompt once and emit tower units in the order their placeholders appear.
+    // Each MAXIMAL run of one placeholder id is one unit: an image's run is its whole grid, and a
+    // video group's run is bounded by the vision_end/timestamp tokens between groups. Ordering by
+    // the walk -- rather than concatenating images-then-videos -- is what makes an interleaved
+    // request correct, because the engine pairs images[i] with positions[i] by index alone.
+    size_t next_image = 0, next_video = 0, next_group = 0;
+    for (size_t i = 0; i < prompt_ids.size(); ) {
+        const int id = prompt_ids[i];
+        if (id != image_token_id && id != video_token_id) { i++; continue; }
+        size_t j = i;
+        while (j < prompt_ids.size() && prompt_ids[j] == id) {
+            io.positions.push_back((int)j);
+            j++;
+        }
+        if (id == image_token_id) {
+            if (next_image >= io.src_images.size()) {
+                err = "prompt carries more image spans than images were preprocessed";
+                return false;
+            }
+            io.images.push_back(io.src_images[next_image++]);
+        } else {
+            if (next_video >= io.src_videos.size() ||
+                next_group >= io.src_videos[next_video].groups.size()) {
+                err = "prompt carries more video frame spans than frames were preprocessed";
+                return false;
+            }
+            io.images.push_back(io.src_videos[next_video].groups[next_group++]);
+            if (next_group == io.src_videos[next_video].groups.size()) {
+                next_video++;
+                next_group = 0;
+            }
+        }
+        i = j;
+    }
+    if (next_image != io.src_images.size() || next_video != io.src_videos.size()) {
+        err = "prompt carries fewer vision spans than were preprocessed";
         return false;
-    prompt_ids.swap(expanded);
-    for (size_t i = 0; i < prompt_ids.size(); i++)
-        if (prompt_ids[i] == image_token_id) io.positions.push_back((int)i);
+    }
     return true;
 }
 

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -176,6 +176,38 @@ int image_pad_token_id() {
     return id;
 }
 
+// The video placeholder's token id, same contract as image_pad_token_id above.
+int video_pad_token_id() {
+    static const int id = [] {
+        const std::vector<int> ids = g_tokenizer.encode_raw("<|video_pad|>");
+        return ids.size() == 1 ? ids[0] : -1;
+    }();
+    return id;
+}
+
+int vision_start_token_id() {
+    static const int id = [] {
+        const std::vector<int> ids = g_tokenizer.encode_raw("<|vision_start|>");
+        return ids.size() == 1 ? ids[0] : -1;
+    }();
+    return id;
+}
+
+int vision_end_token_id() {
+    static const int id = [] {
+        const std::vector<int> ids = g_tokenizer.encode_raw("<|vision_end|>");
+        return ids.size() == 1 ? ids[0] : -1;
+    }();
+    return id;
+}
+
+// Collects every video_url in the request, in message order, alongside collect_image_urls.
+std::vector<std::string> collect_video_urls(const sparkinfer_server::ChatRequest& r) {
+    std::vector<std::string> urls;
+    for (const auto& m : r.messages) urls.insert(urls.end(), m.videos.begin(), m.videos.end());
+    return urls;
+}
+
 // Collects every image_url in the request, in message order, matching the order the rendered
 // prompt's placeholders appear in.
 std::vector<std::string> collect_image_urls(const sparkinfer_server::ChatRequest& r) {
@@ -780,12 +812,13 @@ int main(int argc, char** argv) {
             sparkinfer_server::ChatRequest probe;
             std::string perr;
             if (encode_messages(req.body, ids, enable_thinking, perr, &probe) &&
-                !collect_image_urls(probe).empty()) {
+                (!collect_image_urls(probe).empty() || !collect_video_urls(probe).empty())) {
                 g_requests_client_error++;
                 res.status = 400;
-                res.set_content("{\"error\":{\"message\":\"/v1/tokenize does not support image "
-                                "content parts; token counts for images depend on the resized "
-                                "grid\"}}", "application/json");
+                res.set_content("{\"error\":{\"message\":\"/v1/tokenize does not support image or "
+                                "video content parts; token counts for them depend on the resized "
+                                "grid, and for video on how many frames were sampled\"}}",
+                                "application/json");
                 return;
             }
             ids.clear();
@@ -862,8 +895,8 @@ int main(int argc, char** argv) {
                 sparkinfer_server::ChatRequest probe;
                 std::string perr;
                 if (encode_messages(req.body, prompt_ids, enable_thinking, perr, &probe) &&
-                    !collect_image_urls(probe).empty()) {
-                    fail(400, "/v1/score does not support image content parts");
+                    (!collect_image_urls(probe).empty() || !collect_video_urls(probe).empty())) {
+                    fail(400, "/v1/score does not support image or video content parts");
                     return;
                 }
                 prompt_ids.clear();
@@ -1044,12 +1077,31 @@ int main(int argc, char** argv) {
                  {
                      const std::vector<std::string> urls =
                          collect_image_urls(chat_request);
-                     if (!urls.empty()) {
+                     const std::vector<std::string> video_urls =
+                         collect_video_urls(chat_request);
+                     if (!urls.empty() || !video_urls.empty()) {
                          const int pad_id = image_pad_token_id();
+                         const int vpad_id = video_pad_token_id();
+                         const int vstart = vision_start_token_id();
+                         const int vend = vision_end_token_id();
                          std::string ierr;
-                         if (pad_id < 0) {
+                         if (!urls.empty() && pad_id < 0) {
                              ierr = "this model's tokenizer has no image placeholder token; "
                                     "image input is not supported";
+                         } else if (!video_urls.empty() && (vpad_id < 0 || vstart < 0 || vend < 0)) {
+                             ierr = "this model's tokenizer has no video placeholder tokens; "
+                                    "video input is not supported";
+                         } else if (!video_urls.empty()) {
+                             // Timestamp markers are tokenized here because the engine has no
+                             // tokenizer; encode_raw so "<1.5 seconds>" is not treated as a
+                             // special token lookup.
+                             sparkinfer_server::ModelEngine::VideoSampling sampling;
+                             if (!engine.prepare_vision(
+                                     urls, video_urls, pad_id, vpad_id, vstart, vend, sampling,
+                                     [](const std::string& t) { return g_tokenizer.encode_raw(t); },
+                                     prompt_ids, prepared, ierr)) {
+                                 // ierr already names which clip and why.
+                             }
                          } else if (!engine.prepare_images(urls, pad_id, prompt_ids, prepared, ierr)) {
                              // ierr already names which image and why.
                          }

--- a/server/src/video_input.cpp
+++ b/server/src/video_input.cpp
@@ -1,0 +1,269 @@
+#include "video_input.hpp"
+#include "image_input.hpp"      // base64_decode -- data: URL handling is shared with images
+
+#include <sys/wait.h>
+#include <unistd.h>
+#include <signal.h>
+#include <fcntl.h>
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+
+namespace sparkinfer_server {
+
+namespace {
+
+// Runs argv with `input` on its stdin and collects stdout. Returns false on spawn failure, a
+// nonzero exit, a timeout, or when stdout exceeds cap.
+//
+// Written with fork/exec rather than popen because popen goes through /bin/sh, which would mean
+// building a command STRING out of values that are ultimately request-influenced. execvp takes an
+// argv array, so nothing is ever parsed by a shell and there is no quoting to get wrong.
+bool run_tool(const std::vector<std::string>& argv,
+              const unsigned char* input, size_t input_n,
+              std::string& out, size_t cap, int timeout_sec, std::string& err) {
+    int in_pipe[2] = {-1, -1}, out_pipe[2] = {-1, -1};
+    if (pipe(in_pipe) != 0) { err = "pipe: " + std::string(std::strerror(errno)); return false; }
+    if (pipe(out_pipe) != 0) {
+        close(in_pipe[0]); close(in_pipe[1]);
+        err = "pipe: " + std::string(std::strerror(errno)); return false;
+    }
+
+    const pid_t pid = fork();
+    if (pid < 0) {
+        close(in_pipe[0]); close(in_pipe[1]); close(out_pipe[0]); close(out_pipe[1]);
+        err = "fork: " + std::string(std::strerror(errno));
+        return false;
+    }
+    if (pid == 0) {
+        // Child. Wire the pipes, silence stderr, exec. Anything that fails here _exits rather
+        // than returning, so a failed exec can never fall back into the parent's code path.
+        dup2(in_pipe[0], STDIN_FILENO);
+        dup2(out_pipe[1], STDOUT_FILENO);
+        const int devnull = open("/dev/null", O_WRONLY);
+        if (devnull >= 0) { dup2(devnull, STDERR_FILENO); close(devnull); }
+        close(in_pipe[0]); close(in_pipe[1]); close(out_pipe[0]); close(out_pipe[1]);
+        std::vector<char*> cargv;
+        cargv.reserve(argv.size() + 1);
+        for (const auto& a : argv) cargv.push_back(const_cast<char*>(a.c_str()));
+        cargv.push_back(nullptr);
+        execvp(cargv[0], cargv.data());
+        _exit(127);
+    }
+
+    close(in_pipe[0]);
+    close(out_pipe[1]);
+    // Don't die on SIGPIPE when the child exits before consuming all input -- ffmpeg legitimately
+    // stops reading once it has the frames it was asked for.
+    signal(SIGPIPE, SIG_IGN);
+
+    // Feed stdin and drain stdout in one loop. Writing everything first would deadlock as soon as
+    // the child's stdout pipe fills, which for rawvideo is immediate.
+    fcntl(in_pipe[1], F_SETFL, O_NONBLOCK);
+    fcntl(out_pipe[0], F_SETFL, O_NONBLOCK);
+    size_t written = 0;
+    bool over_cap = false, timed_out = false;
+    out.clear();
+    const time_t deadline = time(nullptr) + timeout_sec;
+    char buf[1 << 16];
+    bool stdin_open = true;
+    while (true) {
+        if (time(nullptr) > deadline) { timed_out = true; break; }
+        if (stdin_open && written < input_n) {
+            const ssize_t w = write(in_pipe[1], input + written, input_n - written);
+            if (w > 0) written += (size_t)w;
+            else if (w < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+                close(in_pipe[1]); stdin_open = false;   // child closed its stdin; not an error
+            }
+        } else if (stdin_open) {
+            close(in_pipe[1]); stdin_open = false;
+        }
+        const ssize_t r = read(out_pipe[0], buf, sizeof(buf));
+        if (r > 0) {
+            if (out.size() + (size_t)r > cap) { over_cap = true; break; }
+            out.append(buf, (size_t)r);
+        } else if (r == 0) {
+            break;                                        // child closed stdout: done
+        } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            break;
+        } else if (!stdin_open) {
+            struct timespec ts = {0, 2 * 1000 * 1000};    // 2ms; nothing to write, nothing to read
+            nanosleep(&ts, nullptr);
+        }
+    }
+    if (stdin_open) close(in_pipe[1]);
+    close(out_pipe[0]);
+
+    if (timed_out || over_cap) kill(pid, SIGKILL);
+    int status = 0;
+    waitpid(pid, &status, 0);
+
+    if (timed_out) { err = "video decode timed out"; return false; }
+    if (over_cap)  { err = "video decode produced more data than the frame budget allows"; return false; }
+    if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+        if (WIFEXITED(status) && WEXITSTATUS(status) == 127) {
+            err = argv[0] + " not found on PATH";
+        } else {
+            err = argv[0] + " failed (exit " +
+                  std::to_string(WIFEXITED(status) ? WEXITSTATUS(status) : -1) + ")";
+        }
+        return false;
+    }
+    return true;
+}
+
+// ffmpeg is given untrusted bytes, so every protocol it could reach out with is turned off. A
+// container can otherwise reference external URLs (concat/hls playlists), which would make the
+// decoder an SSRF primitive -- the exact thing parse_video_url refuses to be.
+void append_hardening(std::vector<std::string>& a) {
+    // `pipe` ONLY. A container can otherwise reference external URLs (concat/hls playlists),
+    // which would turn the decoder into an outbound fetch primitive -- exactly what
+    // parse_video_url refuses to be. Note this also excludes `file`, so a crafted playlist cannot
+    // read local paths either, which is why the payload is piped rather than written to a temp
+    // file even though a temp file would be simpler for seek-heavy containers.
+    a.push_back("-protocol_whitelist"); a.push_back("pipe");
+    // NO -nostdin here. It looks like sensible hardening and is actively wrong for this call
+    // shape: stdin IS the input (-i pipe:0), and -nostdin makes ffmpeg/ffprobe refuse to read it,
+    // failing with a bare nonzero exit that reads like a corrupt container.
+}
+
+bool parse_double(const std::string& s, double& v) {
+    // ffprobe reports frame rates as "30000/1001" as often as "25".
+    const size_t slash = s.find('/');
+    try {
+        if (slash != std::string::npos) {
+            const double num = std::stod(s.substr(0, slash)), den = std::stod(s.substr(slash + 1));
+            if (den == 0.0) return false;
+            v = num / den;
+        } else {
+            v = std::stod(s);
+        }
+    } catch (...) { return false; }
+    return true;
+}
+
+}  // namespace
+
+bool video_decoder_available(std::string* detail) {
+    std::string out, err;
+    if (!run_tool({"ffmpeg", "-version"}, nullptr, 0, out, 1 << 20, 10, err)) {
+        if (detail) *detail = "ffmpeg unavailable: " + err;
+        return false;
+    }
+    if (!run_tool({"ffprobe", "-version"}, nullptr, 0, out, 1 << 20, 10, err)) {
+        if (detail) *detail = "ffprobe unavailable: " + err;
+        return false;
+    }
+    return true;
+}
+
+bool parse_video_url(const std::string& url, std::vector<unsigned char>& bytes, std::string& err) {
+    if (url.rfind("data:", 0) != 0) {
+        err = "video_url must be a data: URL; this server does not fetch remote video URLs "
+              "(fetching caller-supplied URLs is an SSRF primitive and is a deployment decision, "
+              "not a default)";
+        return false;
+    }
+    const size_t comma = url.find(',');
+    if (comma == std::string::npos) { err = "data: URL has no comma separator"; return false; }
+    const std::string meta = url.substr(5, comma - 5);
+    if (meta.find("base64") == std::string::npos) {
+        err = "data: URL must be base64-encoded";
+        return false;
+    }
+    // Bound the ENCODED length before decoding: base64 expands ~4/3, so checking after would
+    // already have allocated the payload this limit exists to refuse.
+    if (url.size() - comma - 1 > (kMaxVideoBytes / 3) * 4 + 4) {
+        err = "video payload exceeds the size limit";
+        return false;
+    }
+    if (!base64_decode(url.substr(comma + 1), bytes, err)) return false;
+    if (bytes.size() > kMaxVideoBytes) { err = "video payload exceeds the size limit"; return false; }
+    return true;
+}
+
+bool decode_video(const unsigned char* bytes, size_t n, int max_frames, double target_fps,
+                  DecodedVideo& out, std::string& err) {
+    if (!bytes || n == 0) { err = "empty video payload"; return false; }
+    if (n > kMaxVideoBytes) { err = "video payload exceeds the size limit"; return false; }
+    if (max_frames <= 0) max_frames = kDefaultMaxVideoFrames;
+
+    // --- probe: native size and frame rate, before decoding a single frame -------------------
+    std::string probe;
+    {
+        std::vector<std::string> a = {"ffprobe", "-v", "error"};
+        append_hardening(a);
+        a.insert(a.end(), {"-select_streams", "v:0",
+                           "-show_entries", "stream=width,height,r_frame_rate",
+                           "-of", "default=noprint_wrappers=1:nokey=0",
+                           "-i", "pipe:0"});
+        if (!run_tool(a, bytes, n, probe, 1 << 16, kVideoDecodeTimeoutSec, err)) {
+            err = "video probe failed: " + err;
+            return false;
+        }
+    }
+    int W = 0, H = 0; double src_fps = 0.0;
+    {
+        auto field = [&](const char* key) -> std::string {
+            const std::string k = std::string(key) + "=";
+            const size_t p = probe.find(k);
+            if (p == std::string::npos) return "";
+            const size_t e = probe.find('\n', p);
+            return probe.substr(p + k.size(), (e == std::string::npos ? probe.size() : e) - p - k.size());
+        };
+        W = std::atoi(field("width").c_str());
+        H = std::atoi(field("height").c_str());
+        if (!parse_double(field("r_frame_rate"), src_fps)) src_fps = 0.0;
+    }
+    if (W <= 0 || H <= 0) { err = "video has no decodable video stream"; return false; }
+    // A single frame's pixels are bounded here, before ffmpeg is asked for any. Without this a
+    // legitimate 8K clip would allocate ~100MB per frame and the frame ceiling alone would not
+    // save the box.
+    if ((long)W * H > 8192L * 8192L) { err = "video frame dimensions are too large"; return false; }
+
+    const double fps = target_fps > 0.0 ? target_fps : (src_fps > 0.0 ? src_fps : kDefaultVideoFps);
+
+    // --- decode: rawvideo rgb24 at the sampling rate, capped at max_frames -------------------
+    const size_t frame_bytes = (size_t)W * H * 3;
+    std::string raw;
+    {
+        std::vector<std::string> a = {"ffmpeg", "-v", "error"};
+        append_hardening(a);
+        a.insert(a.end(), {"-i", "pipe:0",
+                           "-vf", "fps=" + std::to_string(fps),
+                           "-frames:v", std::to_string(max_frames),
+                           "-f", "rawvideo", "-pix_fmt", "rgb24", "pipe:1"});
+        // +1 frame of slack so a decoder that emits one extra is caught by the frame loop below
+        // rather than tripping the byte cap and being reported as a budget error.
+        if (!run_tool(a, bytes, n, raw, frame_bytes * (size_t)(max_frames + 1),
+                      kVideoDecodeTimeoutSec, err)) {
+            err = "video decode failed: " + err;
+            return false;
+        }
+    }
+    const size_t n_frames = raw.size() / frame_bytes;
+    if (n_frames == 0) { err = "video decoded to zero frames"; return false; }
+
+    out.width = W;
+    out.height = H;
+    out.fps = src_fps > 0.0 ? src_fps : fps;
+    out.frames.clear();
+    out.frame_indices.clear();
+    out.frames.reserve(n_frames);
+    out.frame_indices.reserve(n_frames);
+    for (size_t i = 0; i < n_frames && i < (size_t)max_frames; i++) {
+        const unsigned char* p = reinterpret_cast<const unsigned char*>(raw.data()) + i * frame_bytes;
+        out.frames.emplace_back(p, p + frame_bytes);
+        // Map sampled index back onto the SOURCE timeline, so timestamps read as real elapsed
+        // seconds. ffmpeg's fps filter emits frame i at t = i/fps, which is source frame
+        // round(i * src_fps / fps).
+        const double step = (out.fps > 0.0 && fps > 0.0) ? out.fps / fps : 1.0;
+        out.frame_indices.push_back((int)(i * step + 0.5));
+    }
+    return true;
+}
+
+}  // namespace sparkinfer_server

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -737,7 +737,15 @@ bool test_reasoning_effort_controls() {
         R"({"messages":[{"role":"user","content":"hi"}],"reasoning":{"effort":"medium"}})",
         request));
     CHECK(request.reasoning_effort == "medium");
-    CHECK(contains(apply_qwen36_tools_template(request, true), "Reasoning effort is set to medium"));
+    // Third argument is inject_reasoning_effort, which DEFAULTS TO FALSE -- only Qwen3.8's
+    // template prepends the reasoning-effort system message; Qwen3.6 and Muse Glimmer never do.
+    // Calling with two arguments enables thinking but not injection, so this asserted a string the
+    // call could not produce. Broken since the assertion was written (3881e0c), which added it
+    // against the three-parameter signature 8dbfcdb had already introduced.
+    CHECK(contains(apply_qwen36_tools_template(request, true, true),
+                   "Reasoning effort is set to medium"));
+    // And the default really is off, or the assertion above would pass for the wrong reason.
+    CHECK(!contains(apply_qwen36_tools_template(request, true), "Reasoning effort is set to"));
 
     CHECK(parse_request(
         R"({"messages":[{"role":"user","content":"hi"}],"reasoning_effort":"low"})",

--- a/server/tests/video_input_test.cpp
+++ b/server/tests/video_input_test.cpp
@@ -1,0 +1,144 @@
+// Video decoding — exercises the real ffmpeg subprocess path against real containers.
+//
+// Skips (passes) when ffmpeg is absent rather than failing: video decoding is an optional runtime
+// dependency, and a box without it should not turn the whole suite red. What it must NOT do is
+// pass silently while ffmpeg IS present and broken, so the skip is loud.
+#include "video_input.hpp"
+#include "image_input.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+using namespace sparkinfer_server;
+
+static int failures = 0;
+static void check(bool ok, const std::string& what) {
+    if (!ok) { std::printf("  FAIL: %s\n", what.c_str()); failures++; }
+    else       std::printf("  ok:   %s\n", what.c_str());
+}
+
+// Builds a real container with ffmpeg's own synthetic source, so the test does not carry a binary
+// fixture and does not depend on any file outside the build.
+static bool make_test_video(const std::string& path, int w, int h, int fps, int secs) {
+    std::string cmd = "ffmpeg -v error -y -f lavfi -i testsrc=size=" + std::to_string(w) + "x" +
+                      std::to_string(h) + ":rate=" + std::to_string(fps) +
+                      " -t " + std::to_string(secs) + " -pix_fmt yuv420p " + path + " 2>/dev/null";
+    return std::system(cmd.c_str()) == 0;
+}
+
+static std::vector<unsigned char> slurp(const std::string& path) {
+    std::vector<unsigned char> out;
+    FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) return out;
+    std::fseek(f, 0, SEEK_END);
+    const long n = std::ftell(f);
+    std::fseek(f, 0, SEEK_SET);
+    out.resize((size_t)(n > 0 ? n : 0));
+    if (!out.empty() && std::fread(out.data(), 1, out.size(), f) != out.size()) out.clear();
+    std::fclose(f);
+    return out;
+}
+
+int main() {
+    std::string detail;
+    if (!video_decoder_available(&detail)) {
+        std::printf("SKIP: %s\n", detail.c_str());
+        std::printf("(video input is an optional runtime dependency; install ffmpeg to run this)\n");
+        return 0;
+    }
+    std::printf("ffmpeg present\n");
+
+    const std::string path = "/tmp/sparkinfer_video_test.mp4";
+    if (!make_test_video(path, 128, 96, 10, 2)) {
+        std::printf("FAIL: could not synthesize a test clip\n");
+        return 1;
+    }
+    auto bytes = slurp(path);
+    check(!bytes.empty(), "test clip has bytes");
+
+    std::string err;
+
+    // --- 1. decode at a sampling rate below the source rate ------------------------------------
+    {
+        DecodedVideo v;
+        const bool ok = decode_video(bytes.data(), bytes.size(), 32, 2.0, v, err);
+        check(ok, "decode at 2fps succeeds" + (ok ? "" : " -- " + err));
+        if (ok) {
+            check(v.width == 128 && v.height == 96, "native dimensions preserved (no forced scale)");
+            // 2 seconds at 2fps -> about 4 frames; encoders vary by one at the boundary.
+            check(v.frames.size() >= 3 && v.frames.size() <= 5,
+                  "2s @ 2fps yields ~4 frames, got " + std::to_string(v.frames.size()));
+            bool sized = true;
+            for (const auto& f : v.frames) sized = sized && f.size() == (size_t)128 * 96 * 3;
+            check(sized, "every frame is exactly W*H*3 RGB8");
+            check(v.frame_indices.size() == v.frames.size(), "one source index per frame");
+            bool monotonic = true;
+            for (size_t i = 1; i < v.frame_indices.size(); i++)
+                monotonic = monotonic && v.frame_indices[i] > v.frame_indices[i - 1];
+            check(monotonic, "source indices strictly increase");
+            check(v.fps > 9.0 && v.fps < 11.0, "source fps reported as ~10, got " + std::to_string(v.fps));
+            // testsrc is a colour pattern; an all-black decode would mean the pixel format or
+            // the raw stride is wrong, which no size check would catch.
+            bool nonblack = false;
+            for (unsigned char c : v.frames[0]) if (c > 16) { nonblack = true; break; }
+            check(nonblack, "decoded pixels are not uniformly black");
+        }
+    }
+
+    // --- 2. the frame ceiling is a real ceiling ------------------------------------------------
+    {
+        DecodedVideo v;
+        const bool ok = decode_video(bytes.data(), bytes.size(), 3, 10.0, v, err);
+        check(ok, "decode with max_frames=3 succeeds" + (ok ? "" : " -- " + err));
+        check(ok && v.frames.size() <= 3, "max_frames caps the sampled frames");
+    }
+
+    // --- 3. malformed input is refused, not crashed on -----------------------------------------
+    {
+        DecodedVideo v;
+        std::vector<unsigned char> junk(4096, 0xA5);
+        check(!decode_video(junk.data(), junk.size(), 8, 2.0, v, err), "garbage bytes rejected");
+        check(!decode_video(nullptr, 0, 8, 2.0, v, err), "empty payload rejected");
+        // Truncating a real container mid-stream is the realistic corruption case.
+        std::vector<unsigned char> trunc(bytes.begin(), bytes.begin() + bytes.size() / 8);
+        DecodedVideo v2;
+        const bool t = decode_video(trunc.data(), trunc.size(), 8, 2.0, v2, err);
+        check(!t || !v2.frames.empty(), "truncated clip either fails or yields real frames");
+    }
+
+    // --- 4. data: URL policy -------------------------------------------------------------------
+    {
+        std::vector<unsigned char> got;
+        check(!parse_video_url("https://example.com/a.mp4", got, err),
+              "remote http(s) video URL refused");
+        check(err.find("SSRF") != std::string::npos || err.find("does not fetch") != std::string::npos,
+              "refusal explains it is policy, not a parse failure");
+        check(!parse_video_url("data:video/mp4,notbase64", got, err), "non-base64 data: URL refused");
+        check(!parse_video_url("data:video/mp4;base64", got, err), "data: URL with no comma refused");
+
+        // Round-trip a small real clip through a data: URL.
+        static const char* b64 =
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        std::string enc;
+        for (size_t i = 0; i < bytes.size(); i += 3) {
+            const unsigned a = bytes[i];
+            const unsigned b = i + 1 < bytes.size() ? bytes[i + 1] : 0;
+            const unsigned c = i + 2 < bytes.size() ? bytes[i + 2] : 0;
+            const unsigned t = (a << 16) | (b << 8) | c;
+            enc += b64[(t >> 18) & 63]; enc += b64[(t >> 12) & 63];
+            enc += (i + 1 < bytes.size()) ? b64[(t >> 6) & 63] : '=';
+            enc += (i + 2 < bytes.size()) ? b64[t & 63] : '=';
+        }
+        std::vector<unsigned char> back;
+        const bool ok = parse_video_url("data:video/mp4;base64," + enc, back, err);
+        check(ok, "data: URL round-trips" + (ok ? "" : " -- " + err));
+        check(ok && back == bytes, "decoded bytes match the original clip");
+    }
+
+    std::remove(path.c_str());
+    std::printf(failures ? "\nFAILED (%d)\n" : "\nPASSED\n", failures);
+    return failures ? 1 : 0;
+}


### PR DESCRIPTION
Adds video input for Qwen3.8-27B, implements the interleaved MRoPE the checkpoint actually
declares, and fixes three problems found along the way.

## Video to text

The tower needed **no changes**. `get_video_features` *is* `get_image_features` in the reference;
`merge_temporal=False` makes each temporal group its own attention segment, and
`include_temporal=False` keeps the tower's rotary 2D with h/w repeated per frame. So each temporal
group is exactly an image, and the tower verified in #960 is reused per group verbatim.

What that leaves is preprocessing (real frames in the Conv3d's time extent instead of one still
repeated), the per-frame timestamped prompt expansion Qwen3.5 uses to separate frames, decoding,
and the API.

`video_url` content parts on `/v1/chat/completions`, `data:` URLs only — the same refusal
`image_url` already makes, because a server that fetches caller-supplied URLs is an SSRF
primitive.

Decoding shells out to **ffmpeg** rather than linking one: this repo vendors single-header
dependencies and there is no single-header H.264/VP9 decoder worth trusting. That is a new
*runtime* dependency, checked and reported as "needs ffmpeg on PATH" rather than discovered as an
empty pipe read. Untrusted bytes are bounded on input size, wall-clock, frame count and per-frame
pixels; `execvp` means no shell parses request-influenced values; `-protocol_whitelist pipe` means
a crafted playlist reaches neither the network nor the filesystem.

## MRoPE

The LM declares `mrope_section [11,11,10]` with `mrope_interleaved`, giving vision tokens distinct
(t,h,w) positions and advancing following text by `max(h,w)/merge` rather than the token count. We
implemented neither. **This is a pre-existing gap that already affected the images shipped in
v0.5.4**, not something video introduced.

Text is unaffected by construction: with t=h=w the interleaving degenerates to ordinary 1D RoPE.
That is why the eval bot's scored dimensions cannot move, and it is measured, not argued.

Decode needed no kernel change — a generated token is text, so the three-number position collapses
back to one, just shifted. The whole decode-side correction is a single integer added to the rotary
position while the cache slot stays sequential.

`SPARKINFER_MROPE=0` restores the previous behaviour. This changes already-shipped image handling,
so an operator who sees image answers move after an upgrade needs a way to attribute it.

## Fixes

- **`tool_choice=required` was advertised but not enforced.** The template tells the model it MUST
  call a tool; when it answered in prose instead, the parser returned that prose as an ordinary
  assistant message with no error, so a caller branching on `tool_calls` saw a successful
  completion without one. `chat_tools_test:228` had asserted this correctly all along — the
  assertion was right, the parser was wrong. Same for `tool_choice: {name}`.
- **`topk_topp_sample_gpu_test` did not compile** (`finite_indices` called, never defined), so the
  entire GPU sampling suite was dead — every top-k/top-p guarantee unverified, not just that line.
- **`chat_tools_test:740` asserted a string its own call could not produce**, passing two arguments
  and leaving `inject_reasoning_effort` at its default `false`.

The last two hid behind each other: the harness stops at the first failure, so fixing `:228`
revealed `:740`.

## Verification

| check | result |
|---|---|
| video preprocessing vs image path | **byte-identical** (`max diff = 0`) for a 2-frame video of one still |
| MRoPE position ids vs `get_rope_index` | **zero mismatches**, 5 cases, exact integer equality |
| MRoPE kernel vs transformers' rotary | **error = bf16 storage floor exactly** (0.0039022) |
| text-only decode | 96.97 tok/s vs 97.02 baseline — inside run-to-run noise |
| end-to-end, real checkpoint | red→blue clip: *"starts with a red screen and ends with a blue screen"* |
| CPU suite | 8/8 green, including both previously-broken tests |

Two things the verification deliberately uses real reference code rather than a local
reimplementation: in the vision-tower work a hand-written NumPy reference reproduced the very
omission it existed to catch, agreeing with the CUDA path to 0.99915 while both were wrong. Only
code we did not write can falsify code we did.

The kernel check also refuses to pass vacuously — a tolerance-only comparison would go green even
with MRoPE ignored entirely, since text tokens agree either way, so it asserts the positions
separate MRoPE from a 1D baseline (margin: 263x) before trusting the result.

## Not established

The A/B proves MRoPE **changes** image output and leaves text identical. It does **not** show the
new output is better — on that single greedy sample the MRoPE-off description is arguably more
faithful. What justifies the change is numerical agreement with the reference, not a preference
between two fluent answers. Judging output quality needs a real image benchmark, which has not been
run.