### PR TITLE
fix(video): sample the whole clip instead of truncating to its first frames

### DIFF
--- a/server/src/video_input.cpp
+++ b/server/src/video_input.cpp
@@ -197,7 +197,7 @@ bool decode_video(const unsigned char* bytes, size_t n, int max_frames, double t
         std::vector<std::string> a = {"ffprobe", "-v", "error"};
         append_hardening(a);
         a.insert(a.end(), {"-select_streams", "v:0",
-                           "-show_entries", "stream=width,height,r_frame_rate",
+                           "-show_entries", "stream=width,height,r_frame_rate:format=duration",
                            "-of", "default=noprint_wrappers=1:nokey=0",
                            "-i", "pipe:0"});
         if (!run_tool(a, bytes, n, probe, 1 << 16, kVideoDecodeTimeoutSec, err)) {
@@ -205,7 +205,7 @@ bool decode_video(const unsigned char* bytes, size_t n, int max_frames, double t
             return false;
         }
     }
-    int W = 0, H = 0; double src_fps = 0.0;
+    int W = 0, H = 0; double src_fps = 0.0, duration = 0.0;
     {
         auto field = [&](const char* key) -> std::string {
             const std::string k = std::string(key) + "=";
@@ -217,6 +217,7 @@ bool decode_video(const unsigned char* bytes, size_t n, int max_frames, double t
         W = std::atoi(field("width").c_str());
         H = std::atoi(field("height").c_str());
         if (!parse_double(field("r_frame_rate"), src_fps)) src_fps = 0.0;
+        if (!parse_double(field("duration"), duration)) duration = 0.0;
     }
     if (W <= 0 || H <= 0) { err = "video has no decodable video stream"; return false; }
     // A single frame's pixels are bounded here, before ffmpeg is asked for any. Without this a
@@ -224,7 +225,18 @@ bool decode_video(const unsigned char* bytes, size_t n, int max_frames, double t
     // save the box.
     if ((long)W * H > 8192L * 8192L) { err = "video frame dimensions are too large"; return false; }
 
-    const double fps = target_fps > 0.0 ? target_fps : (src_fps > 0.0 ? src_fps : kDefaultVideoFps);
+    // Sampling rate. The default is kDefaultVideoFps rather than the clip's own rate: at a
+    // source rate of 30fps the frame budget is spent on the first second of the clip, which is
+    // the opposite of the "2 fps over at most 32 frames" the header documents.
+    double fps = target_fps > 0.0 ? target_fps : kDefaultVideoFps;
+
+    // Spread the frame budget over the WHOLE clip. `-frames:v max_frames` below keeps the FIRST
+    // max_frames frames, so any clip longer than max_frames/fps seconds silently loses its tail:
+    // the model is asked about a video it was only shown the beginning of, and nothing in the
+    // response says so. Lowering the rate instead samples the entire clip, just more sparsely.
+    if (duration > 0.0 && fps * duration > (double)max_frames) {
+        fps = (double)max_frames / duration;
+    }
 
     // --- decode: rawvideo rgb24 at the sampling rate, capped at max_frames -------------------
     const size_t frame_bytes = (size_t)W * H * 3;

--- a/server/tests/video_input_test.cpp
+++ b/server/tests/video_input_test.cpp
@@ -96,6 +96,30 @@ int main() {
         check(ok && v.frames.size() <= 3, "max_frames caps the sampled frames");
     }
 
+    // --- 2b. a clip longer than the frame budget is SAMPLED, not truncated ---------------------
+    {
+        // 6 s at 10fps = 60 source frames, with a budget of 8. Sampling at the source rate and
+        // keeping the first 8 frames would cover only the first 0.8 s, so the model would never
+        // see the end of the clip. The sampled indices must instead span the whole clip.
+        const std::string longpath = "/tmp/sparkinfer_video_test_long.mp4";
+        if (make_test_video(longpath, 128, 96, 10, 6)) {
+            auto lbytes = slurp(longpath);
+            DecodedVideo v;
+            const bool ok = decode_video(lbytes.data(), lbytes.size(), 8, 0.0, v, err);
+            check(ok, "long clip decodes with the default rate" + (ok ? "" : " -- " + err));
+            if (ok && !v.frame_indices.empty()) {
+                check(v.frames.size() <= 8, "budget still respected, got "
+                      + std::to_string(v.frames.size()));
+                const int last = v.frame_indices.back();
+                const int total = (int)(v.fps * 6.0);          // ~60 source frames
+                check(last > total / 2,
+                      "sampling reaches the clip's second half (last source index "
+                      + std::to_string(last) + " of ~" + std::to_string(total) + ")");
+            }
+            std::remove(longpath.c_str());
+        }
+    }
+
     // --- 3. malformed input is refused, not crashed on -----------------------------------------
     {
         DecodedVideo v;


### PR DESCRIPTION
## The bug

`decode_video()` asks ffmpeg for `-vf fps=N -frames:v max_frames`, which keeps the **first** `max_frames` frames. Any clip longer than `max_frames / fps` seconds silently loses its tail.

A second issue compounds it. The sampling rate defaulted to the clip's **own** frame rate:

```cpp
const double fps = target_fps > 0.0 ? target_fps : (src_fps > 0.0 ? src_fps : kDefaultVideoFps);
```

so `kDefaultVideoFps` only ever applied when ffprobe failed to report a rate. `video_input.hpp` documents the default as *"2 fps over at most 32 frames"*, but in practice a 30fps source sampled at 30fps spent the entire 32-frame budget on the **first ~1.1 seconds**.

The failure is quiet, which is what makes it worth fixing: the model answers questions about a video it was only shown the opening of, and nothing in the response indicates truncation. It reads as a model quality problem, not a preprocessing one.

## The fix

Probe the container duration, and when the budget wouldn't cover the clip, lower the sampling rate so the frames span the whole thing — just more sparsely. This is what Qwen's own processor does. `-frames:v` stays as a backstop for containers that misreport duration, and the default rate now honours the documented `kDefaultVideoFps`.

## Measured

Qwen3.8-27B-NVFP4 on an RTX 5090, 6 s clip of three 2 s colour segments (red → green → blue), asked *"What is the very LAST colour shown?"*:

| | vision tokens | answer |
|---|---|---|
| before | 3,291 | **green** — the middle segment; blue is never seen |
| after | 1,251 | **blue** — correct |

Correct *and* cheaper: the budget is spread over the clip rather than burned on its opening second. Before the fix the answer was wrong at 8 fps and only became correct at ≤4 fps, where the clip happened to fit inside the budget.

## Test

Adds a regression test to `video_input_test.cpp` asserting the sampled source indices reach the clip's second half. It is a real regression test — verified to fail on the current code and pass with the fix:

```
without fix:  FAIL: sampling reaches the clip's second half (last source index 7 of ~60)
with fix:     ok:   sampling reaches the clip's second half (last source index 53 of ~60)
```

The existing cases are unaffected — they all pass an explicit `target_fps`, so the default change doesn't touch them, and case 2's `max_frames=3` ceiling still holds.