### PR TITLE
fix(runtime): create model streams non-blocking so concurrent requests survive graph capture

### DIFF
--- a/runtime/src/models/dflash_draft.cpp
+++ b/runtime/src/models/dflash_draft.cpp
@@ -574,7 +574,8 @@ DFlashDraftModel::DFlashDraftModel(const DFlashDraftConfig& cfg) : p_(new Impl()
         p_->cfg.sliding_layers.assign(p_->cfg.n_layers, true);
         if (p_->cfg.n_layers > 0) p_->cfg.sliding_layers.back() = false;
     }
-    cudaStreamCreate(&p_->stream);
+    // Non-blocking, for the same reason as Qwen35Model's stream: see qwen35.cpp.
+    cudaStreamCreateWithFlags(&p_->stream, cudaStreamNonBlocking);
 }
 
 DFlashDraftModel::~DFlashDraftModel() {

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -447,12 +447,17 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     p_->linear_qdim = cfg.linear_q_heads * cfg.linear_head_dim;
     p_->linear_vdim = cfg.linear_v_heads * cfg.linear_head_dim;
     p_->linear_qkvdim = 2 * p_->linear_qdim + p_->linear_vdim;
-    cudaStreamCreate(&p_->stream);
-    cudaStreamCreate(&p_->stream_k); cudaStreamCreate(&p_->stream_v);
+    // Non-blocking: a blocking stream implicitly synchronises with the legacy stream, so a
+    // graph capture here makes any other thread's legacy-stream work fail with "operation
+    // would make the legacy stream depend on a capturing blocking stream". That is what
+    // breaks concurrent requests -- capture is per-thread, but the implicit legacy edge is not.
+    cudaStreamCreateWithFlags(&p_->stream, cudaStreamNonBlocking);
+    cudaStreamCreateWithFlags(&p_->stream_k, cudaStreamNonBlocking);
+    cudaStreamCreateWithFlags(&p_->stream_v, cudaStreamNonBlocking);
     // Prefetch stream/events exist ONLY for Muse Glimmer, so every other architecture keeps
     // byte-for-byte the stream and event set it had before this change.
     if (cfg.muse_glimmer) {
-        cudaStreamCreate(&p_->stream_pf);
+        cudaStreamCreateWithFlags(&p_->stream_pf, cudaStreamNonBlocking);
         cudaEventCreateWithFlags(&p_->ev_pf_fork, cudaEventDisableTiming);
         cudaEventCreateWithFlags(&p_->ev_pf_done, cudaEventDisableTiming);
     }


### PR DESCRIPTION
## The bug

The model's streams are created with `cudaStreamCreate()`, which makes a **blocking** stream — one that implicitly synchronises with the legacy stream. Decode captures a CUDA graph on that stream, so while one request is mid-capture, any other request thread touching the legacy stream fails:

```
operation would make the legacy stream depend on a capturing blocking stream
operation failed due to a previous error during capture
```

`cudaStreamCaptureModeThreadLocal` doesn't save us: it scopes the *prohibition* to the capturing thread, but the legacy stream's implicit dependency on a blocking stream is a property of the **stream**, not the thread.

The damage is worse than a warning. `generate()` returns success — the tokens are correct — and then `model_engine.cpp`'s post-decode `cudaGetLastError()` picks up the sticky flag and fails the request anyway:

```cpp
cudaError_t e = cudaGetLastError();
if (e != cudaSuccess) { out.error = "cuda error after decode: " ...; return out; }
```

So a multi-user server drops requests that had already been generated correctly.

## The fix

Create the model's streams with `cudaStreamNonBlocking`, removing the implicit legacy edge. `qwen35_prefill.cpp:2897` already creates its per-row verify streams this way — this brings the main, K/V and prefill streams plus the DFlash draft stream in line with that.

## Measured

RTX 5090, `Qwen3.8-27B-NVFP4`, `--ctx 32768`, 128 tokens/request, using `server/scripts/diagnose_concurrency.py`:

| concurrency | before | after |
|---|---|---|
| 1 | 1/1 | 1/1 |
| 2 | 1/2 | **2/2** |
| 4 | 4/4 | 4/4 |
| 8 | 7/8 | **8/8** |
| 16 | 11/16 | **16/16** |
| 32 | 24/32 | **32/32** |

The server log goes from 32× `previous error during capture` and 18× `capturing blocking stream` to **zero CUDA errors**.

No regression elsewhere: single-stream decode is unchanged at **94.5 tok/s**, a needle prompt still answers correctly, and an agentic run (3 tools, shared system prompt) returns a tool call on **16/16** concurrent requests.

## Scope

This fixes **reliability, not throughput**. Requests still serialise behind the device lock, so aggregate throughput stays ~76 tok/s regardless of concurrency — batched decode across requests is a separate piece of work. What changes here is that a concurrent request no longer fails after successfully generating its tokens.