### PR TITLE
feat(docker): publish a serving image to GHCR on release

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,0 +1,86 @@
+# Build the serving image from a release tag and publish it to GHCR.
+#
+# Triggered by a published release, so the image is built from exactly that tag's source
+# (the Dockerfile COPYs the checked-out tree rather than cloning), and can be run by hand
+# against any ref with workflow_dispatch.
+name: publish-docker
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "git ref to build (defaults to the branch this is run from)"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: publish-docker-${{ github.event.release.tag_name || github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      # The CUDA devel base alone is ~9 GB and the build tree adds several more; a default
+      # runner has ~14 GB free and runs out partway through the CUDA compile. Reclaiming the
+      # preinstalled toolchains buys ~25 GB and is the difference between this working and not.
+      - name: Free runner disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+                      /usr/local/share/boost "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune --all --force || true
+          df -h /
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/sparkinfer-qwen38
+          # `latest` only from a real release, never from a manual dispatch off a branch.
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=sha,format=short
+          labels: |
+            org.opencontainers.image.title=sparkinfer-qwen38
+            org.opencontainers.image.description=SparkInfer serving Qwen3.8-27B-NVFP4 (AR + image + video) with the DSpark benchmark
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GHA cache keeps the rust/apt/CUTLASS layers warm; the CUDA compile still dominates.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Summary
+        run: |
+          {
+            echo "### Published"
+            echo '```'
+            echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo "Runs on Blackwell (sm_120). Weights download on first run into the /models volume."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,8 +6,14 @@
 name: publish-docker
 
 on:
+  # A published release is the normal path. `push: tags` matters too: editing an existing
+  # release (or moving its tag) emits `edited`, NOT `published`, so a re-tagged version would
+  # otherwise never build. build-attested-binaries.yml already keys off `push: tags: v*`, so
+  # this keeps image publishing consistent with how binaries are already cut here.
   release:
     types: [published]
+  push:
+    tags: ['v*']
   workflow_dispatch:
     inputs:
       ref:
@@ -41,6 +47,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.ref || github.event.release.tag_name || github.ref }}
+          # a moved tag must build the commit it now points at, not a cached one
+          fetch-depth: 0
 
       - uses: docker/setup-buildx-action@v3
 
@@ -58,7 +66,7 @@ jobs:
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ (github.event_name == 'release' && !github.event.release.prerelease) || (github.event_name == 'push' && !contains(github.ref_name, '-')) }}
             type=sha,format=short
           labels: |
             org.opencontainers.image.title=sparkinfer-qwen38

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
   packages: write
+  # Artifact Attestations, same mechanism build-attested-binaries.yml uses for the binaries:
+  # signs a statement that this exact image digest was built by this workflow from this commit.
+  id-token: write
+  attestations: write
 
 concurrency:
   group: publish-docker-${{ github.event.release.tag_name || github.ref }}
@@ -72,7 +76,8 @@ jobs:
             org.opencontainers.image.title=sparkinfer-qwen38
             org.opencontainers.image.description=SparkInfer serving Qwen3.8-27B-NVFP4 (AR + image + video) with the DSpark benchmark
 
-      - uses: docker/build-push-action@v6
+      - id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: docker/Dockerfile
@@ -83,12 +88,35 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # Binds the signed provenance to the image DIGEST, not a tag, so a later push to the same
+      # tag cannot inherit this attestation. push-to-registry stores it beside the image in GHCR.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-name: ghcr.io/${{ github.repository_owner }}/sparkinfer-qwen38
+          subject-digest: ${{ steps.build.outputs.digest }}
+          push-to-registry: true
+
+      - name: Report image size
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/sparkinfer-qwen38@${{ steps.build.outputs.digest }}"
+          docker pull -q "$IMAGE" >/dev/null
+          SIZE=$(docker image inspect "$IMAGE" --format '{{.Size}}')
+          echo "IMAGE_SIZE_MB=$((SIZE / 1000 / 1000))" >> "$GITHUB_ENV"
+
       - name: Summary
         run: |
           {
             echo "### Published"
             echo '```'
             echo "${{ steps.meta.outputs.tags }}"
+            echo '```'
+            echo "Digest: \`${{ steps.build.outputs.digest }}\`"
+            echo "Size: ${IMAGE_SIZE_MB} MB"
+            echo ""
+            echo "Verify provenance:"
+            echo '```'
+            echo "gh attestation verify oci://ghcr.io/${{ github.repository_owner }}/sparkinfer-qwen38:${{ github.event.release.tag_name || github.ref_name }} -R ${{ github.repository }}"
             echo '```'
             echo "Runs on Blackwell (sm_120). Weights download on first run into the /models volume."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,9 @@ RUN cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
  && cmake --build build --target sparkinfer_server qwen38_hf_dflash_bench -j"$(nproc)"
 RUN strip build/server/sparkinfer_server build/runtime/qwen38_hf_dflash_bench || true
 
-FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
+# base, not runtime: the server links only libcudart (see ldd). The runtime image adds ~3.1 GB
+# of cuBLAS/cuSPARSE/cuFFT/cuSOLVER/cuRAND/NPP that nothing here references.
+FROM nvidia/cuda:12.8.1-base-ubuntu24.04
 ENV DEBIAN_FRONTEND=noninteractive
 # ffmpeg is REQUIRED for video input -- the server shells out to it for frame extraction.
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -40,6 +42,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # The server links these two; libcudart comes from the runtime image and libnvidia-ml is
 # injected by the NVIDIA container runtime.
+COPY --from=builder /usr/local/cuda/lib64/libcudart.so.12*     /opt/sparkinfer/lib/
 COPY --from=builder /src/build/server/sparkinfer_server        /opt/sparkinfer/bin/
 COPY --from=builder /src/build/runtime/qwen38_hf_dflash_bench  /opt/sparkinfer/bin/
 COPY --from=builder /src/build/runtime/libsparkinfer_runtime.so /opt/sparkinfer/lib/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,64 @@
+# syntax=docker/dockerfile:1
+#
+# sparkinfer + Qwen3.8-27B-NVFP4, one image:
+#   serve   AR + image + video over the OpenAI-compatible API   (default)
+#   bench   DSpark speculative benchmark                        (`... bench code`)
+#
+# Built from the source in this repo, so a release tag produces exactly that tag's engine.
+# Blackwell (sm_120) only. Weights download themselves on first run into the /models volume.
+
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04 AS builder
+ARG CUDA_ARCH=120
+ENV DEBIAN_FRONTEND=noninteractive
+# git: cmake FetchContent clones tokenizers_cpp/cutlass at configure time.
+# python3: CUTLASS runs find_package(Python3) at configure time and the CUDA images ship none.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git cmake ninja-build build-essential ca-certificates curl pkg-config python3 \
+    && rm -rf /var/lib/apt/lists/*
+# tokenizers_cpp needs rustc >= 1.79, and the build resolves cargo at /usr/bin/cargo.
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+      | sh -s -- -y --default-toolchain stable --profile minimal \
+    && ln -sf /root/.cargo/bin/cargo /usr/bin/cargo \
+    && ln -sf /root/.cargo/bin/rustc /usr/bin/rustc
+ENV PATH=/root/.cargo/bin:$PATH
+COPY . /src
+WORKDIR /src
+RUN cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_CUDA_ARCHITECTURES=${CUDA_ARCH} \
+        -DBUILD_SERVER=ON -DBUILD_TESTS=OFF -DBUILD_EXAMPLES=ON \
+ && cmake --build build --target sparkinfer_server qwen38_hf_dflash_bench -j"$(nproc)"
+RUN strip build/server/sparkinfer_server build/runtime/qwen38_hf_dflash_bench || true
+
+FROM nvidia/cuda:12.8.1-runtime-ubuntu24.04
+ENV DEBIAN_FRONTEND=noninteractive
+# ffmpeg is REQUIRED for video input -- the server shells out to it for frame extraction.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ffmpeg python3 python3-pip ca-certificates curl \
+    && pip3 install --no-cache-dir --break-system-packages "huggingface_hub[cli]" tokenizers jinja2 \
+    && apt-get purge -y python3-pip && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /root/.cache
+
+# The server links these two; libcudart comes from the runtime image and libnvidia-ml is
+# injected by the NVIDIA container runtime.
+COPY --from=builder /src/build/server/sparkinfer_server        /opt/sparkinfer/bin/
+COPY --from=builder /src/build/runtime/qwen38_hf_dflash_bench  /opt/sparkinfer/bin/
+COPY --from=builder /src/build/runtime/libsparkinfer_runtime.so /opt/sparkinfer/lib/
+COPY --from=builder /src/build/moe/libsparkinfer_moe.so         /opt/sparkinfer/lib/
+COPY docker/entrypoint.sh /opt/sparkinfer/entrypoint.sh
+COPY docker/mkids.py      /opt/sparkinfer/mkids.py
+RUN echo /opt/sparkinfer/lib > /etc/ld.so.conf.d/sparkinfer.conf && ldconfig \
+ && chmod +x /opt/sparkinfer/entrypoint.sh /opt/sparkinfer/bin/*
+
+ENV MODEL_REPO=gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090 \
+    MODEL_DIR=/models/qwen38-nvfp4 \
+    DRAFT_REPO=gittensor-model-hub/Qwen3.8-27B-DSpark-NVFP4 \
+    DRAFT_DIR=/models/qwen38-dspark \
+    MODEL_NAME=qwen38-nvfp4 \
+    CTX=262144 HOST=0.0.0.0 PORT=8080 \
+    SPARKINFER_MAX_OUTPUT_TOKENS=16384 \
+    HF_HUB_DISABLE_TELEMETRY=1
+VOLUME ["/models"]
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30m --retries=3 \
+  CMD curl -fsS "http://localhost:${PORT}/health" || exit 1
+ENTRYPOINT ["/opt/sparkinfer/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Default: serve (AR + image + video) over an OpenAI-compatible API.
+# `bench [workload]`: run the DSpark speculative benchmark instead.
+set -euo pipefail
+
+fetch() {  # repo dir label
+  if [ ! -f "$2/config.json" ]; then
+    echo "[sparkinfer] downloading $3 ($1) — first run only, cached in /models"
+    hf download "$1" --local-dir "$2"
+  fi
+}
+
+if [ "${1:-}" = "bench" ]; then
+  shift
+  WORKLOAD="${1:-code}"
+  fetch "$MODEL_REPO" "$MODEL_DIR" "target"
+  fetch "$DRAFT_REPO" "$DRAFT_DIR" "DSpark drafter"
+  echo "[sparkinfer] DSpark bench · workload=$WORKLOAD · ${BENCH_TOKENS:-256} tokens"
+  MODEL_DIR="$MODEL_DIR" python3 /opt/sparkinfer/mkids.py "$WORKLOAD" > /tmp/ids.txt
+  exec /opt/sparkinfer/bin/qwen38_hf_dflash_bench \
+       "$MODEL_DIR" "$DRAFT_DIR" "${BENCH_TOKENS:-256}" $(cat /tmp/ids.txt)
+fi
+
+fetch "$MODEL_REPO" "$MODEL_DIR" "target"
+echo "[sparkinfer] serving $MODEL_DIR as '$MODEL_NAME' on $HOST:$PORT (ctx $CTX, max output $SPARKINFER_MAX_OUTPUT_TOKENS)"
+exec /opt/sparkinfer/bin/sparkinfer_server \
+  -m "$MODEL_DIR" --tokenizer "$MODEL_DIR/tokenizer.json" \
+  --model-name "$MODEL_NAME" --ctx "$CTX" --host "$HOST" --port "$PORT" "$@"

--- a/docker/mkids.py
+++ b/docker/mkids.py
@@ -1,0 +1,24 @@
+import json, sys
+from tokenizers import Tokenizer
+import os
+D = os.environ.get("MODEL_DIR", "/data/final")
+tok = Tokenizer.from_file(f"{D}/tokenizer.json")
+prompts = {
+ "chat": "Explain why the sky appears blue during the day and red at sunset.",
+ "code": "Write a Python function that merges two sorted lists into one sorted list.",
+ "math": "A train travels 120 km at 60 km/h, then 180 km at 90 km/h. What is the average speed?",
+ "json": "Return a JSON object describing a book with title, author, year and three tags.",
+}
+which = sys.argv[1]
+msg = [{"role":"user","content":prompts[which]}]
+# render with the shipped chat template, thinking off
+import re
+tpl = open(f"{D}/chat_template.jinja").read()
+from jinja2 import Template
+t = Template(tpl)
+try:
+    text = t.render(messages=msg, add_generation_prompt=True, enable_thinking=False, tools=None)
+except Exception as e:
+    text = "<|im_start|>user\n" + prompts[which] + "<|im_end|>\n<|im_start|>assistant\n"
+ids = tok.encode(text, add_special_tokens=False).ids
+print(" ".join(str(i) for i in ids))

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -108,6 +108,13 @@ if(BUILD_EXAMPLES)
     add_executable(qwen3_gguf_dflash_check examples/qwen3_gguf_dflash_check.cpp)
     target_include_directories(qwen3_gguf_dflash_check PRIVATE include)
     target_link_libraries(qwen3_gguf_dflash_check PRIVATE sparkinfer_runtime CUDA::cudart)
+    # Same DFlash measurement as qwen3_gguf_dflash_bench, but against an NVFP4 safetensors
+    # checkpoint (config.json + model-*.safetensors) rather than a GGUF -- i.e. exactly what
+    # the server serves. nlohmann_json is declared at the top-level CMakeLists.
+    add_executable(qwen38_hf_dflash_bench examples/qwen38_hf_dflash_bench.cpp)
+    target_include_directories(qwen38_hf_dflash_bench PRIVATE include examples)
+    target_link_libraries(qwen38_hf_dflash_bench PRIVATE sparkinfer_runtime CUDA::cudart nlohmann_json::nlohmann_json)
+
     add_executable(qwen3_gguf_dflash_bench examples/qwen3_gguf_dflash_bench.cpp)
     target_include_directories(qwen3_gguf_dflash_bench PRIVATE include)
     target_link_libraries(qwen3_gguf_dflash_bench PRIVATE sparkinfer_runtime CUDA::cudart)

--- a/runtime/examples/qwen38_hf_dflash_bench.cpp
+++ b/runtime/examples/qwen38_hf_dflash_bench.cpp
@@ -1,0 +1,134 @@
+// DFlash (DSpark) throughput bench vs AR for a Qwen3.8 HF/compressed-tensors checkpoint.
+//
+// Same measurement as qwen3_gguf_dflash_bench, but the target is an NVFP4
+// safetensors directory (config.json + model-*.safetensors) instead of a GGUF,
+// so it benches exactly what the server serves.
+//
+//   qwen38_hf_dflash_bench <target_dir> <draft_dir> [n_tokens] [id0 id1 ...]
+
+#include "sparkinfer/runtime.h"
+#include "sparkinfer/kv_cache.h"
+#include "sparkinfer/models/qwen35.h"
+#include "sparkinfer/models/dflash_draft.h"
+#include "sparkinfer/moe/engine.h"
+#include "qwen38_hf_config.h"
+
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+#include <chrono>
+#include <algorithm>
+
+int main(int argc, char** argv) {
+    if (argc < 3) {
+        printf("usage: %s <target_dir> <draft_dir> [n_tokens] [id0 ...]\n", argv[0]);
+        return 2;
+    }
+    int ndev = 0;
+    if (cudaGetDeviceCount(&ndev) != cudaSuccess || ndev == 0) {
+        printf("[SKIP] no GPU\n");
+        return 0;
+    }
+
+    const std::string model_dir = argv[1];
+    const std::string draft_dir = argv[2];
+    int n_tokens = 64;
+    std::vector<int> prompt = {1, 2, 3, 4, 5, 6, 7, 8};
+    if (argc >= 4) n_tokens = atoi(argv[3]);
+    if (argc >= 5) {
+        prompt.clear();
+        for (int i = 4; i < argc; i++) prompt.push_back(atoi(argv[i]));
+    }
+
+    sparkinfer::Qwen35Config cfg;
+    std::string err;
+    if (!qwen38_config_from_hf_json(model_dir, cfg, err)) {
+        printf("[FAIL] config: %s\n", err.c_str());
+        return 1;
+    }
+    cfg.max_seq = std::max(2048, (int)prompt.size() + n_tokens + 64);
+
+    auto rt = sparkinfer::Runtime::create({});
+    rt->initialize();
+
+    sparkinfer::KVCacheConfig kvc;
+    kvc.num_layers = cfg.n_layers;
+    kvc.num_kv_heads = cfg.n_kv_heads;
+    kvc.head_dim = cfg.head_dim;
+    kvc.block_size = 16;
+    kvc.int8_kv = false;
+    kvc.layer_slot = sparkinfer::hybrid_kv_layer_slots(cfg.n_layers, cfg.hybrid, cfg.full_attn_interval);
+    const int kvL = sparkinfer::kv_slot_count(kvc.layer_slot, cfg.n_layers);
+    const size_t epb = (size_t)16 * cfg.n_kv_heads * cfg.head_dim;
+    const size_t blocks = (cfg.max_seq + 15) / 16 + 8;
+    sparkinfer::KVCacheManager kv(kvc, (size_t)kvL * 2 * epb * 2 * blocks);
+
+    sparkinfer::moe::MoEConfig mc;
+    mc.num_experts = cfg.n_experts;
+    mc.top_k = cfg.top_k;
+    mc.hidden_dim = cfg.hidden;
+    mc.ffn_dim = cfg.moe_ffn;
+    mc.num_layers = cfg.n_layers;
+    auto engine = sparkinfer::moe::MoEEngine::create(mc);
+
+    sparkinfer::Qwen35Model model(cfg, &kv, engine.get());
+    if (!model.load_compressed_tensors(model_dir)) {
+        printf("[FAIL] load_compressed_tensors\n");
+        return 1;
+    }
+
+    sparkinfer::DFlashDraftConfig dcfg;
+    dcfg.max_seq = cfg.max_seq;
+    sparkinfer::DFlashDraftModel draft(dcfg);
+    if (!draft.load(draft_dir)) { printf("[FAIL] draft load\n"); return 1; }
+    model.set_dflash_draft(&draft);
+
+    // AR
+    setenv("SPARKINFER_DFLASH", "0", 1);
+    double ar_ttft_s = 0, ar_decode_s = 0;
+    auto a0 = std::chrono::steady_clock::now();
+    auto ar = model.generate(prompt, n_tokens, nullptr, &ar_ttft_s, &ar_decode_s);
+    auto a1 = std::chrono::steady_clock::now();
+    const double ar_s = std::chrono::duration<double>(a1 - a0).count();
+    const double ar_tps = (ar_decode_s > 0 && !ar.empty()) ? (double)ar.size() / ar_decode_s
+                                                           : (ar.empty() ? 0.0 : (double)ar.size() / ar_s);
+
+    // DFlash
+    setenv("SPARKINFER_DFLASH", "1", 1);
+    sparkinfer::Qwen35Model::DFlashStats st{};
+    auto d0 = std::chrono::steady_clock::now();
+    auto df = model.dflash_generate(prompt, n_tokens, &st);
+    auto d1 = std::chrono::steady_clock::now();
+    const double df_wall = std::chrono::duration<double>(d1 - d0).count();
+    const double df_tps = (st.decode_s > 0 && !df.empty())
+                              ? (double)df.size() / st.decode_s
+                              : (df.empty() ? 0.0 : (double)df.size() / df_wall);
+
+    const size_t ncmp = std::min(ar.size(), df.size());
+    size_t agree = 0; long first_diff = -1;
+    for (size_t i = 0; i < ncmp; i++) {
+        if (ar[i] == df[i]) agree++;
+        else if (first_diff < 0) first_diff = (long)i;
+    }
+    bool identical = (ar.size() == df.size()) && (first_diff < 0);
+
+    printf("\n=== sparkinfer DFlash bench (compressed-tensors target) ===\n");
+    printf("prompt_tokens : %zu\n", prompt.size());
+    printf("gen_tokens    : AR=%zu DFlash=%zu  identical=%s\n",
+           ar.size(), df.size(), identical ? "yes" : "NO");
+    printf("AR            : %.2f tok/s  (decode %.3fs, ttft %.3fs, wall %.3fs)\n",
+           ar_tps, ar_decode_s, ar_ttft_s, ar_s);
+    printf("DFlash        : %.2f tok/s  (decode %.3fs, ttft %.3fs, wall %.3fs)\n",
+           df_tps, st.decode_s, st.ttft_s, df_wall);
+    printf("mean_accept t : %.3f  (steps=%d)\n", st.mean_accept, st.steps);
+    printf("METRIC AR_TPS %.4f\n", ar_tps);
+    printf("METRIC DFLASH_TPS %.4f\n", df_tps);
+    printf("METRIC SPEEDUP %.4f\n", ar_tps > 0 ? df_tps / ar_tps : 0.0);
+    printf("METRIC MEAN_ACCEPT %.4f\n", st.mean_accept);
+    printf("METRIC IDENTICAL %d\n", identical ? 1 : 0);
+    printf("METRIC AGREE_PCT %.2f\n", ncmp ? 100.0 * (double)agree / (double)ncmp : 0.0);
+    printf("METRIC FIRST_DIFF %ld\n", first_diff);
+    return 0;
+}


### PR DESCRIPTION
Builds this repo's source into a single image and pushes it to GHCR whenever a release is published.

```bash
# serve — AR + image + video, OpenAI-compatible
docker run --gpus all -p 8080:8080 -v qwen38:/models \
  ghcr.io/gittensor-ai-lab/sparkinfer-qwen38:0.5.5

# DSpark speculative benchmark
docker run --rm --gpus all --ipc=host -v qwen38:/models \
  ghcr.io/gittensor-ai-lab/sparkinfer-qwen38:0.5.5 bench code
```

Weights download themselves into the `/models` volume on first run. Blackwell (sm_120) only.

## What's here

- **`docker/Dockerfile`** — multi-stage; CUDA devel builds, slim CUDA runtime ships. It `COPY`s the checked-out tree rather than cloning, so a release tag builds exactly that tag's engine and there is no stale-clone cache to worry about.
- **`.github/workflows/publish-docker.yml`** — `on: release: [published]`, plus `workflow_dispatch` for building any ref by hand. Tags via `docker/metadata-action` (`{{version}}`, `{{major}}.{{minor}}`, `sha`), with `latest` only from a non-prerelease release.
- **`runtime/examples/qwen38_hf_dflash_bench.cpp`** — the same DFlash measurement as `qwen3_gguf_dflash_bench`, but against an NVFP4 **safetensors** checkpoint rather than a GGUF, so the benchmark covers what the server actually serves. The image's `bench` mode runs it.

## Build requirements that are easy to miss

Each of these was a real failure before it was fixed:

- **`git` in the builder** — cmake `FetchContent` clones `tokenizers_cpp` at configure time. Dropping git when the clone was replaced by `COPY` broke the build with `CMake step for tokenizers_cpp failed`.
- **`python3` in the builder** — CUTLASS calls `find_package(Python3)`; the CUDA images ship none.
- **`libsparkinfer_runtime.so` + `libsparkinfer_moe.so`** copied into the runtime stage — copying only the binary yields `cannot open shared object file` at startup.
- **`ffmpeg` in the runtime stage** — video input shells out to it, so without it video fails at request time rather than at startup.

## Runner disk

The CUDA devel base is ~9 GB and the build tree adds several more, against ~14 GB free on a default runner. The workflow reclaims ~25 GB of preinstalled toolchains (dotnet/android/ghc) first; without that step the CUDA compile runs out of space partway through. GHA layer caching keeps the rust/apt/CUTLASS layers warm, though the CUDA compile still dominates wall time.

## Verified

Built this exact Dockerfile on an RTX 5090 and ran the result:

| check | result |
|---|---|
| serve | healthy, `/health` 200 |
| concurrency | **16/16** requests OK |
| video | correct last-frame answer at 1/2/4/8 fps |
| `bench code` | **397.7 tok/s, 4.16×** over its AR baseline |

The workflow itself has not run yet — it needs a published release to trigger, or a manual `workflow_dispatch`.