### PR TITLE
docs(readme): lead with Qwen3.8-27B and a docker run, drop SparkDistill

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,104 +4,47 @@
 
 **Agentic AI inference. Optimized for every Blackwell GPU.**
 
-**+86% faster** than llama.cpp with Blackwell-native **Custom CUDA kernels** (Qwen3.6-35B-A3B SOTA, RTX 5090, v0.4.3). SparkInfer is the runtime layer for **Private AI** agents — optimized MoE/LLM decoding from desk-side RTX to workstation PRO 6000. Continuously optimized by competition at **[SN74 on Gittensor](https://gittensor.io/miners/repository?name=gittensor-ai-lab%2Fsparkinfer)** and **Kernel Design Agents**.
-
-**Why fastest?** Faster inference means more intelligence, more responsive agents, and more efficient compute.
+A native C++/CUDA runtime for MoE/LLM decoding on Blackwell — from desk-side RTX to workstation
+PRO 6000. No Python stack, a **2.5 MB** binary, and Blackwell-native kernels that run **+86%
+faster than llama.cpp** on our SOTA model. Continuously optimized by open competition at
+**[SN74 on Gittensor](https://gittensor.io/miners/repository?name=gittensor-ai-lab%2Fsparkinfer)**.
 
 > **Fewer models. Deeper optimization. Faster evolution.**
 
-## Frontier models
+## Run it
 
-SparkInfer focuses on the models driving the future of AI — not thousands of legacy architectures.
+One command to an OpenAI-compatible endpoint. Weights download themselves on first run.
 
-| Model | Role |
-|---|---|
-| [**Qwen3.6-35B-A3B**](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF) | Primary SOTA — hybrid Gated-DeltaNet + full-attention MoE |
-| [**Qwen3.8-27B**](https://huggingface.co/Qwen/Qwen3.8-27B) | Dense hybrid Gated-DeltaNet · current eval scope — native NVFP4 from **[our RTX 5090 build](https://huggingface.co/gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090)** or [unsloth](https://huggingface.co/unsloth/Qwen3.8-27B-NVFP4), both supported |
-| [**SparkDistill**](https://github.com/gittensor-model-hub/SparkDistill/) | Fable 5 / OpenAI 5.6-level CoT *(coming soon)* |
+```bash
+docker run --gpus all -p 8080:8080 -v qwen38:/models \
+  ghcr.io/gittensor-ai-lab/sparkinfer-qwen38:latest
+```
 
-## Blackwell native
+```bash
+curl localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
+  "model": "qwen38-nvfp4",
+  "messages": [{"role": "user", "content": "What is the capital of Japan?"}]
+}'
+```
 
-**Consumer → Workstation → Datacenter** — built for NVIDIA Blackwell from the beginning (`sm_120` + `sm_121`, not datacenter `sm_100`).
+Serves text, **images and video**. ~1 GB image, Blackwell (`sm_120`) only.
+Build from source instead: [Quickstart](#quickstart).
 
-| GPU | Arch | Target |
-|---|---|---|
-| [RTX Spark GB10](https://nvidianews.nvidia.com/news/nvidia-microsoft-windows-pcs-agents-rtx-spark) | `sm_121` | Personal AI PC · desk-side agents |
-| [DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/) | `sm_121` | AI workstation |
-| [RTX 5090](https://www.nvidia.com/en-us/geforce/graphics-cards/50-series/rtx-5090/) | `sm_120` | Consumer Blackwell · current dev platform |
-| [RTX PRO 6000](https://www.nvidia.com/en-us/products/workstations/) | `sm_120` | 96 GB workstation · 32k/4k API profile |
+Provenance is attested to the image digest:
 
-## Benchmark · Qwen3.6-35B-A3B SOTA
+```bash
+gh attestation verify oci://ghcr.io/gittensor-ai-lab/sparkinfer-qwen38:latest \
+  -R gittensor-ai-lab/sparkinfer
+```
 
-RTX 5090 · same `UD-Q4_K_M` GGUF · greedy bs=1 · warm interleaved · **v0.4.4** frontier (same-box main guards).
+## Qwen3.8-27B — the model we optimize hardest
 
-### Decode
+A dense hybrid Gated-DeltaNet model, and the checkpoint the automated eval scores **every PR**
+against. We quantize it in house with NVIDIA ModelOpt for the RTX 5090's FP4 tensor cores:
 
-| context | SparkInfer | llama.cpp | Δ |
-|---:|---:|---:|---:|
-| 128 | **512** tok/s | 276 tok/s | **+86%** |
-| 512 | **506** tok/s | 276 tok/s | +83% |
-| 4k | **486** tok/s | 276 tok/s | +76% |
-| 16k | **467** tok/s | 281 tok/s | +66% |
-| 32k | **437** tok/s | 280 tok/s | +56% |
+### 📦 [gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090](https://huggingface.co/gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090)
 
-### Prefill
-
-| context | SparkInfer | llama.cpp | Δ |
-|---:|---:|---:|---:|
-| 4k | **13,800** tok/s | 8,726 tok/s | **+58%** |
-| 16k | **17,700** tok/s | 8,390 tok/s | **+111%** |
-| 32k | **18,150** tok/s | 7,984 tok/s | **+127%** |
-
-Quality parity vs llama.cpp: top-1 **0.953** · KL **0.031** · IFEval **83%** · BFCL **75%**.
-
-Full competitor matrix (vLLM, SGLang, TensorRT-LLM) and quality tables:
-[`bench/competitors/latest-results.md`](bench/competitors/latest-results.md) ·
-[`bench/quality/README.md`](bench/quality/README.md).
-
-## Benchmark · Qwen3.8-27B
-
-RTX 5090 · **same `Q4_K_M` GGUF** ([unsloth/Qwen3.8-27B-GGUF](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF)) · greedy bs=1 · 5 reps ·
-sparkinfer `d8e1c74` vs `llama.cpp d8df12e` (`-ngl 99`; `-fa 1` was measured too and came out
-marginally slower on this model, so llama.cpp's better configuration is the one reported).
-
-### Decode
-
-| context | SparkInfer | llama.cpp | Δ |
-|---:|---:|---:|---:|
-| 128 | **86.9** tok/s | 80.2 tok/s | **+8.4%** |
-| 4k | **85.2** tok/s | 77.0 tok/s | **+10.6%** |
-| 16k | **82.3** tok/s | 73.9 tok/s | **+11.5%** |
-
-### Prefill
-
-| context | SparkInfer | llama.cpp | Δ |
-|---:|---:|---:|---:|
-| 128 | 2,033 tok/s | **2,782** tok/s | **−26.9%** |
-| 512 | **3,790** tok/s | 3,680 tok/s | **+3.0%** |
-| 4k | **7,548** tok/s | 3,670 tok/s | **+105.7%** |
-| 16k | **7,596** tok/s | 3,496 tok/s | **+117.2%** |
-
-Prefill crosses over at ~512 tokens: below it llama.cpp leads, above it sparkinfer pulls away to
-roughly 2× while llama.cpp stays flat near 3,700 pp. The short-prompt loss is published rather
-than omitted, and it has a cause — reading a Q4_K_M GGUF means dequantizing Q4_K into the GEMM
-operand on every pass, a fixed cost that 128 tokens cannot amortize but 4k easily does
-(2,033 → 3,114 → 3,790 → 6,325 → 7,349 → 7,515 pp across 128 → 4k). It is a live optimisation
-target, tracked by the same automated eval that gates every PR.
-
-Note this is the **GGUF** path, kept identical to llama.cpp's input on purpose. sparkinfer's own
-NVFP4 checkpoints do not pay that dequant and reach 5,031–6,546 pp at the same ctx=128 — see the
-two tables below, which is where a ~5,000 pp figure for this model comes from.
-
-### Native NVFP4 — two supported checkpoints
-
-The GGUF numbers above exist to make the engine comparison fair. They are **not** how sparkinfer
-runs this model: it reads Qwen3.8-27B's NVFP4 weights directly, from **either** of two supported
-checkpoints.
-
-**[gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090](https://huggingface.co/gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090)**
-— ours: uniform NVFP4 on every `Linear`, quantized in house with NVIDIA ModelOpt for the RTX 5090's
-FP4 tensor cores, and the checkpoint the automated eval scores every PR against:
+Uniform NVFP4 on every `Linear`, 17.9 GB, full **262,144-token** context on one 32 GB card.
 
 <!-- BENCH:qwen38-modelopt:start -->
 
@@ -114,43 +57,23 @@ FP4 tensor cores, and the checkpoint the automated eval scores every PR against:
 <sub>Auto-refreshed by the ModelOpt eval bot at `44e1c4505` — these are the numbers that PR measured on the pinned RTX 5090, which after squash-merge are main's. Regenerated on every auto-merge, so the table cannot drift behind the code.</sub>
 <!-- BENCH:qwen38-modelopt:end -->
 
-Same weights the model was released with, re-quantized for the hardware it runs on. Measured at
-`d8e1c74` that was **+9–10% decode and +28–222% prefill** over the same engine reading a Q4_K_M
-GGUF, and **+19–22% decode / +135–179% prefill** over llama.cpp on its GGUF — including the one
-dimension llama.cpp wins above, 6,546 pp at ctx=128 against 2,782. Those comparisons are a
-snapshot: only the table above self-updates, because a round measures this checkpoint and nothing
-else.
+Same weights the model was released with, re-quantized for the hardware it runs on — **+19–22%
+decode / +135–179% prefill** over llama.cpp reading its best GGUF. llama.cpp cannot load NVFP4
+compressed-tensors at all, so that is *each engine on the format it actually runs*, not a
+same-weights benchmark. The same-weights comparison is [below](#same-weights-gguf-on-both-sides),
+short-prompt loss included.
 
-**[unsloth/Qwen3.8-27B-NVFP4](https://huggingface.co/unsloth/Qwen3.8-27B-NVFP4)** — upstream: NVFP4
-FFN + FP8 attention/GDN projections, equally supported, and measured on the same box at the same
-commit:
+[unsloth/Qwen3.8-27B-NVFP4](https://huggingface.co/unsloth/Qwen3.8-27B-NVFP4) (NVFP4 FFN + FP8
+attention) is equally supported and loads through the same path — 84.9 tok/s decode / 5,031 tok/s
+prefill at ctx=128, measured at `d8e1c74`. The eval *scores* PRs on our build and runs a separate
+*no-regression guard* on the upstream one, which stops an optimisation winning on one checkpoint
+by pessimising the other.
 
-| context | decode | prefill |
-|---:|---:|---:|
-| 128 | 84.9 tok/s | 5,031 tok/s |
-| 4k | 83.2 tok/s | 9,548 tok/s |
-| 16k | 80.6 tok/s | 8,727 tok/s |
+### DSpark speculative decode
 
-<sub>Measured at `d8e1c74`. Not auto-refreshed — a round scores the ModelOpt checkpoint and only
-guards this one, so these move when someone re-measures, not on every merge.</sub>
-
-Both load through the same `load_compressed_tensors` path and share the batched prefill and every
-decode kernel — the mixed-precision build is simply a different quantization of the same weights,
-so it lands a little slower on this hardware. The eval *scores* PRs on our build and runs a
-separate *no-regression guard* on the upstream one, which is what stops an optimisation from
-winning on the scored checkpoint by pessimising the other.
-
-Read that last column for what it is. llama.cpp cannot load NVFP4 compressed-tensors at all, so
-`vs llama.cpp` there is **each engine on the format it actually runs** — our NVFP4 against
-llama.cpp's best GGUF result — not a same-weights benchmark. The same-weights comparison is the
-one at the top of this section, GGUF on both sides, prefill@128 loss included.
-
-#### DSpark speculative decode
-
-Every decode number above is autoregressive. Qwen3.8-27B also ships a **DSpark** draft, a
-five-layer semi-autoregressive block drafter that proposes a block of tokens per step and has the
-target verify them in one batched pass, so accepting *k* tokens costs one target forward instead of
-*k*:
+Qwen3.8-27B also ships a **DSpark** draft — a five-layer semi-autoregressive block drafter that
+proposes a block per step and has the target verify it in one batched pass, so accepting *k*
+tokens costs one target forward instead of *k*:
 
 <!-- BENCH:qwen38-dspark:start -->
 
@@ -165,12 +88,53 @@ target verify them in one batched pass, so accepting *k* tokens costs one target
 <sub>Auto-refreshed by the DSpark eval bot at `b819f2fef` — these are the numbers that PR measured on the pinned RTX 5090, which after squash-merge are main's. Regenerated on every auto-merge, so the table cannot drift behind the code.</sub>
 <!-- BENCH:qwen38-dspark:end -->
 
-Speculation only pays when the verify costs less than what it replaces: `speedup ≈ τ / (verify cost
-+ draft cost)`, both in target forwards. That is why τ alone is not the story — a block that
-accepts more tokens but costs more to verify is slower, and for most of this feature's life DSpark
-ran *below* plain AR decode for exactly that reason.
+Speculation only pays when the verify costs less than what it replaces:
+`speedup ≈ τ / (verify cost + draft cost)`, both in target forwards. That is why τ alone is not the
+story — a block that accepts more tokens but costs more to verify is slower, and for most of this
+feature's life DSpark ran *below* plain AR decode for exactly that reason.
 
-Runtime footprint (excluding model weights):
+### Same weights, GGUF on both sides
+
+To make the engine comparison fair, the same `Q4_K_M` GGUF
+([unsloth](https://huggingface.co/unsloth/Qwen3.8-27B-GGUF)) through both engines. RTX 5090,
+greedy bs=1, sparkinfer `d8e1c74` vs `llama.cpp d8df12e`:
+
+| context | decode | | prefill | |
+|---:|---:|---:|---:|---:|
+| | **SparkInfer** | llama.cpp | **SparkInfer** | llama.cpp |
+| 128 | **86.9** (+8.4%) | 80.2 | 2,033 (−26.9%) | **2,782** |
+| 4k | **85.2** (+10.6%) | 77.0 | **7,548** (+105.7%) | 3,670 |
+| 16k | **82.3** (+11.5%) | 73.9 | **7,596** (+117.2%) | 3,496 |
+
+Prefill crosses over at ~512 tokens. The short-prompt loss is published rather than omitted, and it
+has a cause: reading a Q4_K_M GGUF means dequantizing Q4_K into the GEMM operand on every pass, a
+fixed cost 128 tokens cannot amortize but 4k easily does. It is a live optimisation target, tracked
+by the same automated eval that gates every PR. sparkinfer's own NVFP4 checkpoints do not pay that
+dequant and reach 5,031–6,942 pp at the same ctx=128.
+
+## Other models
+
+**[Qwen3.6-35B-A3B](https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF)** — hybrid
+Gated-DeltaNet + full-attention MoE, our SOTA speed target:
+**512 tok/s decode vs llama.cpp's 276 on the same GGUF and GPU — +86%**, rising to **+127% prefill
+at 32k**. Quality parity: top-1 **0.953** · KL **0.031** · IFEval **83%** · BFCL **75%**.
+Full tables: [`bench/competitors/latest-results.md`](bench/competitors/latest-results.md) ·
+[`bench/quality/README.md`](bench/quality/README.md).
+
+SparkInfer focuses on the models driving the future of AI — not thousands of legacy architectures.
+
+## Blackwell native
+
+Built for NVIDIA Blackwell from the beginning (`sm_120` + `sm_121`, not datacenter `sm_100`).
+
+| GPU | Arch | Target |
+|---|---|---|
+| [RTX Spark GB10](https://nvidianews.nvidia.com/news/nvidia-microsoft-windows-pcs-agents-rtx-spark) | `sm_121` | Personal AI PC · desk-side agents |
+| [DGX Spark](https://www.nvidia.com/en-us/products/workstations/dgx-spark/) | `sm_121` | AI workstation |
+| [RTX 5090](https://www.nvidia.com/en-us/geforce/graphics-cards/50-series/rtx-5090/) | `sm_120` | Consumer Blackwell · current dev platform |
+| [RTX PRO 6000](https://www.nvidia.com/en-us/products/workstations/) | `sm_120` | 96 GB workstation · 32k/4k API profile |
+
+Runtime footprint, excluding model weights:
 
 | runtime | size | vs sparkinfer |
 |---|---:|---:|
@@ -178,9 +142,13 @@ Runtime footprint (excluding model weights):
 | llama.cpp CUDA | 80 MB | 33× larger |
 | vLLM | 605 MB | 243× larger |
 
-## Powered by SN74 — moving at the speed of ⚡
+## Powered by SN74 — optimization that never stops
 
-Contributors submit PRs; the bot verifies correctness and speed on real RTX 5090 hardware; SN74 rewards verified marginal speedups. **15 releases in 3 weeks** — from first llama.cpp beat to **+86% decode / +127% prefill @ 32k on Qwen3.6 SOTA**.
+This runtime is not optimized by a team on a roadmap. It is optimized by **open competition**:
+contributors submit PRs, a bot verifies correctness and speed on real RTX 5090 hardware, and SN74
+rewards **verified marginal speedups**. Every merge has to prove itself on the same GPU.
+
+**15 releases in 3 weeks** — from first llama.cpp beat to +86% decode / +127% prefill @ 32k.
 
 1. Pick a narrow bottleneck in the Blackwell decode path.
 2. Submit a PR with source changes and benchmark evidence.
@@ -189,32 +157,33 @@ Contributors submit PRs; the bot verifies correctness and speed on real RTX 5090
 5. Strongest context improvement scores; regressions get `regression-*` labels.
 6. Frontier merges; the [dashboard](https://gittensor-ai-lab.github.io/sparkinfer/dashboard/) updates.
 
-Miner workflow: [`docs/miner-guide.md`](docs/miner-guide.md).
+Because the benchmark tables above are regenerated on every auto-merge, they cannot drift behind
+the code. Miner workflow: [`docs/miner-guide.md`](docs/miner-guide.md).
 
 ## Roadmap
 
-### Milestone 1 · Now — Fast on every Blackwell edge GPU
+### Milestone 1 · Now — fast on every Blackwell edge GPU
 
 *Fastest = cost-effective inference* — more tokens per dollar on Blackwell edge first.
 
-- Qwen3.6 SOTA: **+86%** decode / **+127%** prefill @ 32k vs llama.cpp on RTX 5090 (512 tok/s decode @ 128 ctx)
+- Qwen3.6 SOTA: **+86%** decode / **+127%** prefill @ 32k vs llama.cpp on RTX 5090
 - RTX PRO 6000 — **32k input + 4k output**, full MoE resident
 - RTX Spark + DGX Spark `sm_121` bring-up for desk-side agents
 - Fastest AI runtime at the edge · desktop app, RAG, memory
 
-### Milestone 2 · Next — Trustable AI on confidential compute
+### Milestone 2 · Next — trustable AI on confidential compute
 
 Attested builds and sealed execution on PRO 6000 server and B200.
 
 - TDX + NVIDIA CC attestation for `sparkinfer-server` workloads
 - Source-verified binaries — same eval loop, inside the enclave
 - Privacy guardrails and end-to-end encryption
-- Domain-specific models via [SparkDistill](https://github.com/gittensor-model-hub/SparkDistill/)
 - Licensed on-prem runtime for regulated enterprise
 
 ## Quickstart
 
-On NVIDIA Blackwell (CUDA 12.8+) — scripts auto-detect GPU arch, fetch prebuilt binaries (or build from source), and download the model:
+Prefer the [Docker image](#run-it). To build and benchmark from source on Blackwell (CUDA 12.8+) —
+scripts auto-detect GPU arch, fetch prebuilt binaries or build from source, and download the model:
 
 ```bash
 # decode throughput (fetches Qwen3-30B-A3B Q4_K_M on first run)
@@ -227,7 +196,8 @@ bench/scripts/bench.sh --download --compare
 bench/scripts/accuracy.sh --download
 ```
 
-Your own model: `bench/scripts/bench.sh /path/to/model.gguf --tokens 256`. Options: [`bench/scripts/README.md`](bench/scripts/README.md).
+Your own model: `bench/scripts/bench.sh /path/to/model.gguf --tokens 256`.
+Options: [`bench/scripts/README.md`](bench/scripts/README.md).
 
 ## Layout & scoring
 


### PR DESCRIPTION
Restructures the README so the first thing a reader can *do* is run the thing.

## Changes

- **`## Run it` is now the first section** — the GHCR image, one `docker run`, a `curl`, and the provenance command. Previously the fastest path to a running server was a source build two thirds of the way down the page.
- **Qwen3.8-27B promoted to the headline model**, with [its model card](https://huggingface.co/gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090) linked prominently — it is the checkpoint the automated eval scores every PR against, so it should lead. Its NVFP4 table, DSpark, and the same-weights GGUF comparison are now grouped under one heading instead of scattered across the page.
- **Qwen3.6-35B-A3B condensed** to a one-line result under `## Other models`: 512 vs 276 tok/s on the same GGUF and GPU (**+86%**), rising to **+127%** prefill at 32k, with quality parity kept.
- **SN74 section reframed** around what it actually is — optimization by open competition, where every merge proves itself on the same RTX 5090 — rather than only a numbered process.
- **SparkDistill removed** (model-table row and roadmap bullet).
- Decode/prefill for the GGUF comparison merged into one table instead of two.

272 → 242 lines, despite adding the Docker section.

## Preserved deliberately

The `<!-- BENCH:qwen38-modelopt -->` and `<!-- BENCH:qwen38-dspark -->` blocks are carried over **byte-for-byte**, so the eval bots keep refreshing them and the tables cannot drift behind the code.

Every caveat that makes the numbers believable is kept, not trimmed for brevity:

- the prefill@128 **loss** to llama.cpp, and the Q4_K dequant cost that explains it
- that NVFP4-vs-llama.cpp is *each engine on the format it actually runs*, not a same-weights benchmark
- that DSpark's losslessness is byte-identical token comparison, not distributional agreement
- that speculative throughput is workload-dependent, so τ at one context is not a serving figure

Those lines are what make the rest of the numbers worth trusting; a shorter README that dropped them would be a worse one.

## Note

The `docker run` command points at `ghcr.io/gittensor-ai-lab/sparkinfer-qwen38:latest`, published by `publish-docker.yml` (#969). **That package is currently private**, so the command will fail for external users until its visibility is switched to public in the org package settings.