### PR TITLE
perf(runtime): park a session's decode graph instead of destroying it on every switch (1.24x cb-decode@c2/c4/c8)

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -545,6 +545,10 @@ public:
 
 private:
     void invalidate_decode_graph();
+    // Frees every decode graph parked under a non-active session id (see the parking lot in
+    // qwen35.cpp's Impl). Called by invalidate_decode_graph(), which is the "something global
+    // changed" path, and as a size backstop.
+    void drop_parked_decode_graphs();
     void dflash_maybe_capture_layer(int layer);
     // Depth-adaptive KV-split count for a given seqlen (32/128/160/256 tiers, GQA-8/hd256
     // occupancy correction). Shared by forward_token()'s normal per-token adaptation and

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -239,6 +239,41 @@ struct Qwen35Model::Impl {
     int dflash_graph_attn_mode = -1;
     bool dflash_graph_sparse = false;
 
+    // Per-session parking lot for the AR decode graph.
+    //
+    // activate_session() used to DESTROY cu_graph outright, because every node in it bakes this
+    // session's device pointers -- lin_state / lin_conv_state / penalty_counts / logit_bias, and
+    // kv->block_table(active_seq_id). Correct, but it made a session switch cost a full capture +
+    // instantiate of the whole 64-layer decode, and the continuous-batch worker switches sessions
+    // on EVERY token once two requests are in flight. Measured on RTX 5090 / Qwen3.8-27B-NVFP4,
+    // that is ~1.09 ms per token: per-token wall time goes 13.07 ms at concurrency 1 to 14.16 ms
+    // at concurrency 2, so aggregate throughput FALLS 84.9 -> 74.4 tok/s going 1 -> 2.
+    //
+    // Parking the outgoing session's graph under its own seq_id and restoring the incoming one
+    // keeps exactly the same "a decode graph only ever runs for the session it was captured for"
+    // guarantee, while making a switch a pointer swap.
+    //
+    // Safe because every pointer a decode node bakes is stable for the session's lifetime: the
+    // per-session buffers are allocated once in open_session(), and block_table(seq) is
+    // d_block_tables + slot * max_blocks_per_seq -- a fixed slab offset whose CONTENTS grow as
+    // blocks are appended but whose ADDRESS does not. That is the same assumption the pre-existing
+    // code already made by replaying one capture across a session's whole decode phase.
+    //
+    // n_splits is parked with the graph: the adaptive-splits check invalidates on
+    // `want != s.n_splits`, so restoring a graph without restoring the value it was captured at
+    // would tear it straight back down.
+    struct ParkedDecodeGraph {
+        cudaGraph_t graph{};
+        cudaGraphExec_t exec{};
+        int attn_mode = -1;
+        bool sparse = false;
+        int n_splits = 0;
+    };
+    std::unordered_map<uint64_t, ParkedDecodeGraph> parked_graphs;
+    // Bounded purely as a leak backstop -- close_session() drops a session's entry, so in steady
+    // state this holds one graph per LIVE session, which is the server's concurrency limit.
+    static constexpr size_t kMaxParkedGraphs = 64;
+
     // scratch (bf16)
     bf16 *x, *xn, *q, *k, *v, *attn, *ao, *h, *hn, *routed, *shared;
     bf16 *qraw = nullptr, *qgate = nullptr;
@@ -759,6 +794,11 @@ Qwen35Model::~Qwen35Model() {
         if (kv.second.lin_state) cudaFree(kv.second.lin_state);
         if (kv.second.lin_conv_state) cudaFree(kv.second.lin_conv_state);
     }
+    for (auto& kv : p_->parked_graphs) {
+        if (kv.second.exec) cudaGraphExecDestroy(kv.second.exec);
+        if (kv.second.graph) cudaGraphDestroy(kv.second.graph);
+    }
+    p_->parked_graphs.clear();
     if (p_->graph_ready) { cudaGraphExecDestroy(p_->cu_exec); cudaGraphDestroy(p_->cu_graph); }
     if (p_->graph_prefill_ready) { cudaGraphExecDestroy(p_->cu_prefill_exec); cudaGraphDestroy(p_->cu_prefill_graph); }
     if (p_->dflash_graph_ready) { cudaGraphExecDestroy(p_->cu_dflash_exec); cudaGraphDestroy(p_->cu_dflash_graph); }
@@ -2619,8 +2659,29 @@ Qwen35Model::BenchDecodeResult Qwen35Model::bench_decode(int warmup, int n, int 
     return out;
 }
 
+void Qwen35Model::drop_parked_decode_graphs() {
+    Impl& s = *p_;
+    // Self-guarding: most callers reach this through invalidate_decode_graph(), and while the
+    // device-touching ones (cache_prefix, clear_prefix_cache) already hold device_mu, the DSpark
+    // ones (set_dflash_capture, restore_spec_snapshot) do not. Destroying a raw graph handle
+    // unlocked was merely racy; mutating a std::unordered_map unlocked is undefined. Recursive,
+    // so the callers that do hold it are unaffected.
+    std::lock_guard<std::recursive_mutex> device_lock(s.device_mu);
+    for (auto& kv : s.parked_graphs) {
+        if (kv.second.exec) cudaGraphExecDestroy(kv.second.exec);
+        if (kv.second.graph) cudaGraphDestroy(kv.second.graph);
+    }
+    s.parked_graphs.clear();
+}
+
 void Qwen35Model::invalidate_decode_graph() {
     Impl& s = *p_;
+    // Parked graphs go too. This function means "something the capture depends on changed"
+    // (weights, splits policy, sparse budget, bench toggles), and a graph parked under the old
+    // setting is exactly as stale as the active one. activate_session() deliberately does NOT
+    // route its decode-graph handling through here -- a session switch invalidates nothing, it
+    // just moves which capture is current.
+    drop_parked_decode_graphs();
     if (s.graph_ready) {
         cudaGraphExecDestroy(s.cu_exec);
         cudaGraphDestroy(s.cu_graph);
@@ -3088,6 +3149,15 @@ void Qwen35Model::close_session(uint64_t seq_id, const std::vector<int>* store_t
     std::lock_guard<std::recursive_mutex> device_lock(p_->device_mu);
     Impl& s = *p_;
     if (seq_id == 0) return;
+    // Drop this session's parked decode graph before the buffers its nodes bake are freed below.
+    {
+        auto parked = s.parked_graphs.find(seq_id);
+        if (parked != s.parked_graphs.end()) {
+            if (parked->second.exec) cudaGraphExecDestroy(parked->second.exec);
+            if (parked->second.graph) cudaGraphDestroy(parked->second.graph);
+            s.parked_graphs.erase(parked);
+        }
+    }
     // Store to the external cache tier before freeing the blocks it reads -- this is the
     // "session close" eviction point (docs/lmcache_bridge_protocol.md's STORE trigger list).
     // store_tokens is null for most callers (this model class doesn't itself track a session's
@@ -3126,6 +3196,35 @@ void Qwen35Model::close_session(uint64_t seq_id, const std::vector<int>* store_t
 void Qwen35Model::activate_session(uint64_t seq_id) {
     Impl& s = *p_;
     if (s.active_seq_id == seq_id) return;
+    // Guards parked_graphs, which close_session() also mutates. The pre-existing code only
+    // touched raw graph handles here and could get away without it; a std::unordered_map cannot,
+    // since a concurrent insert/erase is undefined rather than merely racy. Recursive and the
+    // same mutex close_session() already holds when it calls activate_session(0) below, so the
+    // nesting is fine.
+    std::lock_guard<std::recursive_mutex> device_lock(s.device_mu);
+
+    // Park the OUTGOING session's decode graph rather than destroying it (see
+    // Impl::parked_graphs for why: destroying it here is what made concurrency 2 slower than
+    // concurrency 1). Everything the capture bakes belongs to the session it is parked under, so
+    // it stays valid until that session is closed or something global invalidates it.
+    if (s.graph_ready) {
+        auto& slot = s.parked_graphs[s.active_seq_id];
+        // A previous park for this same id can only exist if it was never restored; free it
+        // rather than leaking the graph it holds.
+        if (slot.exec) cudaGraphExecDestroy(slot.exec);
+        if (slot.graph) cudaGraphDestroy(slot.graph);
+        slot.graph = s.cu_graph;
+        slot.exec = s.cu_exec;
+        slot.attn_mode = s.graph_attn_mode;
+        slot.sparse = s.graph_sparse;
+        slot.n_splits = s.n_splits;
+        s.cu_graph = nullptr;
+        s.cu_exec = nullptr;
+        s.graph_ready = false;
+        s.graph_attn_mode = -1;
+        s.graph_sparse = false;
+    }
+
     s.active_seq_id = seq_id;
     auto it = s.sessions.find(seq_id);
     if (it == s.sessions.end() && seq_id == 0) it = s.sessions.find(0);  // defensive fallback
@@ -3140,7 +3239,44 @@ void Qwen35Model::activate_session(uint64_t seq_id) {
         s.penalty_counts = it->second.penalty_counts;
         s.logit_bias = it->second.logit_bias;
     }
-    invalidate_decode_graph();
+
+    // The PREFILL and DFlash graphs are still torn down on a switch. They bake the same
+    // session-owned pointers, but neither is replayed often enough for parking to pay: prefill
+    // runs once per request and the DFlash verify graph is not on the server's decode path at
+    // all. Keeping them on the old teardown keeps this change to the one graph that is replayed
+    // every token.
+    if (s.dflash_graph_ready) {
+        cudaGraphExecDestroy(s.cu_dflash_exec);
+        cudaGraphDestroy(s.cu_dflash_graph);
+        s.cu_dflash_exec = nullptr;
+        s.cu_dflash_graph = nullptr;
+        s.dflash_graph_ready = false;
+        s.dflash_graph_attn_mode = -1;
+        s.dflash_graph_sparse = false;
+    }
+    if (s.graph_prefill_ready) {
+        cudaGraphExecDestroy(s.cu_prefill_exec);
+        cudaGraphDestroy(s.cu_prefill_graph);
+        s.cu_prefill_exec = nullptr;
+        s.cu_prefill_graph = nullptr;
+        s.graph_prefill_ready = false;
+        s.graph_prefill_attn_mode = -1;
+    }
+
+    // Restore the INCOMING session's parked graph, if it still has one.
+    auto parked = s.parked_graphs.find(seq_id);
+    if (parked != s.parked_graphs.end()) {
+        s.cu_graph = parked->second.graph;
+        s.cu_exec = parked->second.exec;
+        s.graph_ready = s.cu_exec != nullptr;
+        s.graph_attn_mode = parked->second.attn_mode;
+        s.graph_sparse = parked->second.sparse;
+        s.n_splits = parked->second.n_splits;
+        s.parked_graphs.erase(parked);
+    }
+
+    // Leak backstop only -- close_session() is what normally reclaims these.
+    if (s.parked_graphs.size() > Impl::kMaxParkedGraphs) drop_parked_decode_graphs();
 }
 
 uint64_t Qwen35Model::active_session() const { return p_->active_seq_id; }


### PR DESCRIPTION
## Summary

`Qwen35Model::activate_session()` ended in `invalidate_decode_graph()`, because every node in the
captured decode graph bakes the active session's device pointers — `lin_state`, `lin_conv_state`,
`penalty_counts`, `logit_bias`, and `kv->block_table(active_seq_id)`. The continuous-batch worker
calls `activate_session()` for whichever job it is stepping, so once two requests are in flight it
switches sessions on **every token**, and every token pays a full capture + instantiate of the
whole 64-layer decode graph.

This parks the outgoing session's graph under its own `seq_id` and restores the incoming one, so a
switch is a pointer swap. The invariant is unchanged: a decode graph is still only ever replayed
for the session it was captured for. It is safe because every pointer a decode node bakes is stable
for that session's lifetime — the per-session buffers are allocated once in `open_session()`, and
`block_table(seq)` resolves to `d_block_tables + slot * max_blocks_per_seq`, a fixed slab offset
whose *contents* grow as blocks are appended but whose *address* does not. Replaying one capture
across a session's whole decode phase already relied on exactly that.

`invalidate_decode_graph()` drops the parked graphs too — it means "something the capture depends
on changed", and a graph parked under the old setting is as stale as the active one. The prefill
and DFlash graphs keep the old teardown on a switch: they bake the same session-owned pointers but
neither is replayed often enough for parking to pay. `activate_session()` and
`drop_parked_decode_graphs()` take `device_mu`, because destroying a raw graph handle unlocked was
merely racy while mutating a `std::unordered_map` unlocked is undefined, and two callers
(`set_dflash_capture`, `restore_spec_snapshot`) do not already hold it.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — aggregate across concurrent requests at **concurrency 2**:

| | decode tok/s |
|---|--:|
| before (main) | 75.50 |
| after (this PR) | 93.95 |

Full ladder, at exactly the settings `cb-decode@cN` uses (`qwen3_gguf_cb_bench <dir> C 256 256
512`). RTX 5090 32 GB, Qwen3.8-27B-NVFP4 (ModelOpt), base `8b56a8b`, arms **alternated**, 2 reps
each:

| dimension | before agg tok/s | after agg tok/s | change | before mean ITL | after mean ITL |
|---|--:|--:|--:|--:|--:|
| c1 (floor, not scored) | 92.05 | 93.15 | +1.2% | 11.11 ms | 10.96 ms |
| **cb-decode@c2** | 75.50 | 93.95 | **+24.4%** | 26.80 ms | 21.44 ms |
| **cb-decode@c4** | 76.00 | 94.30 | **+24.1%** | 52.44 ms | 42.07 ms |
| **cb-decode@c8** | 75.90 | 94.50 | **+24.5%** | 103.94 ms | 83.26 ms |

The c1 floor moves the right way (+1.2%), so the concurrency gain is not bought from the
single-stream path.

```text
$ build/runtime/qwen3_gguf_cb_bench <ModelOpt-NVFP4-dir> <C> 256 256 512

         c1              c2              c4              c8
BASE   92.1 / 92.0    75.6 / 75.4    76.1 / 75.9    75.9 / 75.9
PARK   93.2 / 93.1    94.0 / 93.9    94.3 / 94.3    94.5 / 94.5
```

**Single-stream AR decode and prefill are unmoved** — with one session there is no switch:

| | decode tok/s | prefill pp tok/s |
|---|--:|--:|
| before (main) | 94.442 | 16157.3 |
| after (this PR) | 94.463 | 16134.5 |

## Correctness

`dspark_tau_check` @ctx=4096 — the speculative path shares `qwen35.cpp`, so it is the regression
that matters here:

| | AR tok/s | DSpark tok/s | mean accepted | LOSSLESS |
|---|--:|--:|--:|--:|
| before (main) | 90.6078 | 127.9945 | **1.6883** | 1 |
| after (this PR) | 90.6325 | 128.0327 | **1.6883** | 1 |

Acceptance is identical to the digit and losslessness holds, i.e. this changes when a graph is
rebuilt, never what it computes.

## Note

Rebased onto `8b56a8b`. The earlier revision of this branch also carried a `qwen3_gguf_cb_bench`
change to make the compressed-tensors checkpoint benchmarkable under concurrency; that is now in
main and the file is a pinned harness path, so this branch is just the one-file fix plus its
header declaration.
