### PR TITLE
fix(prefix): keep the cached prefix across requests instead of re-prefilling it

### DIFF
--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -278,6 +278,17 @@ public:
     // whose prompt starts with the same token sequence. Returns false on allocation failure.
     bool cache_prefix(const std::vector<int>& tokens);
 
+    // Restore the Gated-DeltaNet recurrent state to its end-of-prefix snapshot taken by
+    // cache_prefix(). Required before reusing a cached prefix: the KV blocks survive a
+    // request, but generation advances lin_state/lin_conv_state past the prefix, and the
+    // 48 hybrid layers would otherwise carry the PREVIOUS request's history. No-op (returns
+    // false) when no prefix is installed.
+    bool restore_prefix_state();
+
+    // Logical KV blocks the installed prefix occupies, for callers that want to keep them
+    // across requests via KVCacheManager::truncate_blocks(). 0 when no prefix is active.
+    int prefix_block_count() const;
+
     // Drop the installed prefix cache and free its KV blocks.
     void clear_prefix_cache();
 

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -205,6 +205,11 @@ uint64_t ContinuousBatchEngine::submit_locked(Job job, const std::function<bool(
             seq_id = 0;
             if (!kv_->allocate(seq_id, budget)) return fail(EnqueueError::OVERLOADED);
             model_->activate_session(seq_id);
+            // The KV blocks survived the previous request, but its decoding advanced the hybrid
+            // recurrent state past the prefix. Replay the end-of-prefix snapshot so the 48
+            // Gated-DeltaNet layers start where the prefix ended rather than carrying the last
+            // request's history -- silently wrong output otherwise, not a crash.
+            model_->restore_prefix_state();
             model_->reset_penalty_counts(seq_id);   // session 0 is shared across unrelated requests
             model_->set_logit_bias(seq_id, job.req.logit_bias);   // same reason
         } else {
@@ -353,8 +358,19 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
             // full prompt would tell close_session a longer range is valid than actually is.
             model_->close_session(j.seq_id, j.phase != SeqPhase::PREFILL ? &j.req.prompt : nullptr);
         } else {
-            kv_->free(j.seq_id);
-            if (j.req.use_prefix_session) model_->release_prefix_session();
+            // Session 0 is the shared prefix session. Freeing it wholesale is what made the
+            // prefix cache cache nothing: prefix_cached_len() then returned 0 and the next
+            // matching request re-prefilled the entire prefix. Keep the prefix's own blocks and
+            // drop only the suffix + generated tail, so the next request reuses them. The
+            // recurrent state is NOT kept -- decoding mutated it -- and is replayed from
+            // cache_prefix()'s snapshot by restore_prefix_state() on the next reuse.
+            const int keep = j.req.use_prefix_session ? model_->prefix_block_count() : 0;
+            if (keep > 0 && kv_->truncate_blocks(j.seq_id, keep)) {
+                // prefix stays installed and active; nothing else to do
+            } else {
+                kv_->free(j.seq_id);
+                if (j.req.use_prefix_session) model_->release_prefix_session();
+            }
         }
         j.seq_id = 0;
     };

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -250,6 +250,11 @@ struct Qwen35Model::Impl {
     bf16 *nvfp4_g = nullptr, *nvfp4_u = nullptr, *nvfp4_h = nullptr;  // native NVFP4 dense-FFN decode scratch
     bf16 *lin_conv_state = nullptr;
     float* lin_state = nullptr;
+    // End-of-prefix snapshot of the hybrid recurrent state, taken by cache_prefix() and
+    // replayed by restore_prefix_state(). The prefix's KV blocks can simply be kept, but
+    // this state cannot: decoding mutates it in place.
+    float* prefix_lin_state = nullptr;
+    bf16*  prefix_lin_conv_state = nullptr;
     // "Current" session's penalty_counts (swapped by activate_session(), unconditionally, for
     // every model -- see SessionBuffers). penalty_counts_default backs session 0's entry, alloc'd
     // once at load time; sessions[seq_id].penalty_counts for every other session is alloc'd by
@@ -2765,11 +2770,56 @@ bool Qwen35Model::cache_prefix(const std::vector<int>& tokens) {
         return false;
     }
     cudaDeviceSynchronize();
+    // Snapshot the recurrent state as it stands at the end of the prefix. Every later reuse
+    // replays this; without it the hybrid layers would resume from whatever the last request
+    // left behind, which is wrong output rather than a crash.
+    if (s.cfg.hybrid && s.lin_state && s.lin_conv_state) {
+        const size_t st_n = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
+                            s.cfg.linear_head_dim * s.cfg.linear_head_dim;
+        const size_t cv_n = (size_t)s.cfg.n_layers * (s.cfg.linear_conv_kernel - 1) *
+                            s.linear_qkvdim;
+        if (!s.prefix_lin_state)      s.prefix_lin_state      = s.alloc<float>(st_n);
+        if (!s.prefix_lin_conv_state) s.prefix_lin_conv_state = s.alloc<bf16>(cv_n);
+        if (!s.prefix_lin_state || !s.prefix_lin_conv_state) {
+            s.kv->free(s.active_seq_id);
+            return false;
+        }
+        cu(cudaMemcpyAsync(s.prefix_lin_state, s.lin_state, st_n * sizeof(float),
+                           cudaMemcpyDeviceToDevice, s.stream), "prefix state snapshot");
+        cu(cudaMemcpyAsync(s.prefix_lin_conv_state, s.lin_conv_state, cv_n * sizeof(bf16),
+                           cudaMemcpyDeviceToDevice, s.stream), "prefix conv snapshot");
+        cu(cudaStreamSynchronize(s.stream), "prefix snapshot sync");
+    }
     s.prefix_tokens = tokens;
     s.prefix_len = (int)tokens.size();
     s.prefix_next = next;
     s.prefix_active = true;
     return true;
+}
+
+bool Qwen35Model::restore_prefix_state() {
+    std::lock_guard<std::recursive_mutex> device_lock(p_->device_mu);
+    Impl& s = *p_;
+    if (!s.prefix_active) return false;
+    if (!s.cfg.hybrid) return true;            // nothing recurrent to restore
+    if (!s.prefix_lin_state || !s.prefix_lin_conv_state) return false;
+    if (!s.lin_state || !s.lin_conv_state) return false;
+    const size_t st_n = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
+                        s.cfg.linear_head_dim * s.cfg.linear_head_dim;
+    const size_t cv_n = (size_t)s.cfg.n_layers * (s.cfg.linear_conv_kernel - 1) * s.linear_qkvdim;
+    cu(cudaMemcpyAsync(s.lin_state, s.prefix_lin_state, st_n * sizeof(float),
+                       cudaMemcpyDeviceToDevice, s.stream), "prefix state restore");
+    cu(cudaMemcpyAsync(s.lin_conv_state, s.prefix_lin_conv_state, cv_n * sizeof(bf16),
+                       cudaMemcpyDeviceToDevice, s.stream), "prefix conv restore");
+    cu(cudaStreamSynchronize(s.stream), "prefix restore sync");
+    return true;
+}
+
+int Qwen35Model::prefix_block_count() const {
+    const Impl& s = *p_;
+    if (!s.prefix_active || s.prefix_len <= 0) return 0;
+    const int bs = s.kv->block_size();
+    return (s.prefix_len + bs - 1) / bs;
 }
 
 void Qwen35Model::clear_prefix_cache() {


### PR DESCRIPTION
The prefix cache never cached anything **across** requests. `finish_job()` freed the shared prefix session outright:

```cpp
kv_->free(j.seq_id);
if (j.req.use_prefix_session) model_->release_prefix_session();
```

so `prefix_cached_len()` returned 0 on the next request and `cache_prefix()` re-prefilled the whole thing. Instrumented against a 32,022-token prefix, **every** request logged `cached_len=0 want=32026 -> REPREFILL` and paid the full 5.9 s prefill. The feature only ever avoided re-prefill *within* one request.

## Two things are needed here, and only the first is obvious

**1. Keep the KV.** `truncate_blocks()` — already present for speculative decode — drops the suffix and generated tail while keeping the prefix's own blocks, instead of freeing the session.

**2. Restore the recurrent state.** 48 of Qwen3.8's 64 layers are Gated-DeltaNet. Their state is *not* paged and decoding mutates it in place, so keeping the KV alone would leave those layers carrying the **previous request's history** — wrong output, not a crash. `cache_prefix()` now snapshots `lin_state`/`lin_conv_state` at end-of-prefix, and `restore_prefix_state()` replays it before the suffix is prefilled.

## Measured

RTX 5090, 32,022-token shared prefix, wall clock:

| request | before | after |
|---|---:|---:|
| 1 (cold) | 5.88 s | 5.87 s |
| 2 | 5.85 s | **0.45 s** |
| 3 | 5.72 s | **0.31 s** |
| 4 | 5.87 s | **0.42 s** |

**~14× on every request after the first.** The server log flips from `REPREFILL` on every request to `cached_len=32026 blocks=2002 -> REUSE`.

## Correctness gate

Run at **~1.6k context**, because this engine is deterministic there — see the caveat below. Eight questions, greedy, three runs of each build:

| check | result |
|---|---|
| unpatched, run-to-run | stable except one open-ended item |
| patched, run-to-run | stable except **the same** open-ended item |
| patched vs unpatched | **byte-identical on all 7 unambiguous questions** |

The one item that varies is an open-ended sentence, and it varies in the unpatched build too — pre-existing near-tie divergence, not something this change introduces.

## Caveat worth raising separately

I first ran this gate at 32k and it looked like the patch had broken determinism. It hadn't: **the unpatched engine is itself nondeterministic at long context**, and increasingly wrong. On the released 0.5.5 image, no prefix configured, asking `"What is 17 multiplied by 23? Reply with only the number."` after a natural-prose system prompt:

| prompt tokens | result |
|---:|---|
| 1,955 | `391`, `391`, `391` |
| 4,076 | three different non-answers |
| 8,192 | stable but wrong |
| 24,869 | `391`, `299`, `46` |

vLLM v0.28 on the **same checkpoint** answers `391` stably at 29, 30,498 and 32,044 tokens, so this is not the weights or the prompt. Setting `SPARKINFER_SPARSE_KV=0` does not change it. That looks like a real long-context bug and I will open it as its own issue — flagging it here because it is why the gate for this PR is run at 1.6k rather than 32k.

## Scope

This fixes **sequential** reuse. The `prefix_exclusive` (`num_active() == 0`) gate is untouched, so the prefix path still does not engage under concurrency; sharing a prefix across simultaneous sessions needs block-level refcounting plus a per-session copy of the restored state, which is separate work.