### PR TITLE
perf(runtime): decode a whole continuous-batch in one packed forward (1.95x/3.29x/5.11x cb-decode@c2/c4/c8)

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -310,6 +310,89 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
     if (lane == 0) out[(size_t)vh * HEAD_DIM + j] = __float2bfloat16(y);
 }
 
+// ---------------------------------------------------------------------------
+// BATCHED decode step: B INDEPENDENT sequences, one token each.
+//
+// Not the same shape as the chunked/compact scans next door. Those walk N CONSECUTIVE positions
+// of ONE sequence and therefore carry a serial dependence between rows. Here each row is a
+// different request advancing its own recurrent state by exactly one step, so the rows are fully
+// independent and the batch is just another grid axis.
+//
+// Why it exists: the continuous-batch worker runs one full 64-layer forward PER SEQUENCE, and
+// decode is bandwidth-bound on weight reads, so N concurrent requests read every weight N times
+// and aggregate throughput does not scale with concurrency. Packing the rows into one forward
+// fixes that, and the 48 Gated-DeltaNet layers are the only stage with no batched decode form --
+// the projections/FFN already take R rows through one weight read, and the paged attention
+// already takes num_seqs.
+//
+// The per-row state pointers arrive as a DEVICE ARRAY rather than a base + stride, because each
+// session's lin_state / lin_conv_state is its own cudaMalloc. That also keeps this CUDA-graph
+// safe: the graph bakes the ADDRESS of the pointer array, and the packer refreshes its CONTENTS
+// before each replay, the same trick d_scalars already uses for token id / position.
+//
+// Row b reads activation row b and state states[b]; with batch == 1 and states[0] equal to what
+// the unbatched launcher is handed, every lane does bit-identical arithmetic in the same order,
+// so a packed step and a sequential step agree exactly rather than approximately.
+template <int COLS, int HEAD_DIM>
+__global__ void gdn_ar_fast_batched_kernel(const __nv_bfloat16* __restrict__ q,
+                                           const __nv_bfloat16* __restrict__ k,
+                                           const __nv_bfloat16* __restrict__ v,
+                                           const __nv_bfloat16* __restrict__ alpha,
+                                           const __nv_bfloat16* __restrict__ beta,
+                                           const __nv_bfloat16* __restrict__ dt,
+                                           const __nv_bfloat16* __restrict__ a,
+                                           float* const* __restrict__ states,
+                                           size_t state_off,
+                                           __nv_bfloat16* __restrict__ out,
+                                           int q_heads, int v_heads, bool qh_block,
+                                           bool state_bf16) {
+    constexpr int NROW = HEAD_DIM / 32;
+    const int vh   = blockIdx.x;
+    const int j    = blockIdx.y * COLS + (threadIdx.x >> 5);
+    const int b    = blockIdx.z;
+    const int lane = threadIdx.x & 31;
+    if (vh >= v_heads || j >= HEAD_DIM) return;
+    const int qh   = qh_block ? (vh / (v_heads / q_heads)) : (vh % q_heads);
+    const float scale = rsqrtf((float)HEAD_DIM);
+    // Per-row activation strides. dt/a are WEIGHTS (one value per v-head, shared by every row)
+    // and are deliberately not strided; alpha/beta are per-token projections and are.
+    const int qdim = q_heads * HEAD_DIM, vdim = v_heads * HEAD_DIM;
+    const __nv_bfloat16* qrow = q + (size_t)b * qdim;
+    const __nv_bfloat16* krow = k + (size_t)b * qdim;
+    const __nv_bfloat16* vrow = v + (size_t)b * vdim;
+    const __nv_bfloat16* arow = alpha + (size_t)b * v_heads;
+    const __nv_bfloat16* brow = beta  + (size_t)b * v_heads;
+    const float bb = q36_sigmoid(q36_to_f(brow[vh]));
+    const float g  = __expf(q36_softplus(q36_to_f(arow[vh]) + q36_to_f(dt[vh])) * q36_to_f(a[vh]));
+    const __nv_bfloat16* qhptr = qrow + (size_t)qh * HEAD_DIM;
+    const __nv_bfloat16* khptr = krow + (size_t)qh * HEAD_DIM;
+    const __nv_bfloat16* vhptr = vrow + (size_t)vh * HEAD_DIM;
+    float* col = states[b] + state_off + ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
+
+    float sloc[NROW];
+    float part_sk = 0.f;
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) {
+        const int i = lane + r * 32;
+        const float sv = col[i];
+        sloc[r] = sv;
+        part_sk += sv * q36_to_f(khptr[i]);
+    }
+    const float sk = g * q36_wsum(part_sk);
+    const float delta = (q36_to_f(vhptr[j]) - sk) * bb;
+    float part_y = 0.f;
+    #pragma unroll
+    for (int r = 0; r < NROW; r++) {
+        const int i = lane + r * 32;
+        float s_new = sloc[r] * g + q36_to_f(khptr[i]) * delta;
+        if (state_bf16) s_new = q36_to_f(__float2bfloat16(s_new));
+        col[i] = s_new;
+        part_y += s_new * q36_to_f(qhptr[i]) * scale;
+    }
+    const float y = q36_wsum(part_y);
+    if (lane == 0) out[(size_t)b * vdim + (size_t)vh * HEAD_DIM + j] = __float2bfloat16(y);
+}
+
 // Default GDN path: warp-per-state-column with native [vh][row][col] layout (no transposed
 // state). One warp owns column j; row slices live in registers; grid fills the GPU.
 template <int WARPS_PER_BLK, int HEAD_DIM>
@@ -553,6 +636,50 @@ void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
         q_heads, head_dim, eps);
 }
 
+// Batched decode step over B independent sequences. Mirrors launch_qwen36_gdn_ar's dispatch so
+// the two stay on the same kernel family; only the grid gains a batch axis and the state arrives
+// as a per-row pointer array. Restricted to the fast head_dim==128 path, which is the only one
+// the packed decode path uses (Qwen3.8 linear_head_dim = 128); anything else must keep running
+// the unbatched launcher per row.
+bool launch_qwen36_gdn_ar_batched(const void* q_bf16, const void* k_bf16, const void* v_bf16,
+                                  const void* alpha_bf16, const void* beta_bf16,
+                                  const void* dt_bf16, const void* a_bf16,
+                                  float* const* states, size_t state_off, void* out_bf16,
+                                  int batch, int q_heads, int v_heads, int head_dim,
+                                  bool qh_block, cudaStream_t stream) {
+    if (batch < 1 || head_dim != 128) return false;
+    static const bool state_bf16 = [] {
+        const char* e = getenv("SPARKINFER_GDN_STATE_BF16");
+        return e && e[0] == '1';
+    }();
+    static int cols = -1;
+    if (cols < 0) {
+        const char* e = getenv("SPARKINFER_GDN_FAST_COLS");
+        if (e) cols = atoi(e);
+        else cols = (v_heads >= 32) ? 4 : 8;
+        if (!(cols == 4 || cols == 8 || cols == 16)) cols = 8;
+    }
+    constexpr int HD = 128;
+    const int c = cols;
+    dim3 grid(v_heads, (HD + c - 1) / c, batch);
+#define SI_GDN_AR_B(C_)                                                                    \
+    gdn_ar_fast_batched_kernel<C_, HD><<<grid, (C_) * 32, 0, stream>>>(                    \
+        reinterpret_cast<const __nv_bfloat16*>(q_bf16),                                    \
+        reinterpret_cast<const __nv_bfloat16*>(k_bf16),                                    \
+        reinterpret_cast<const __nv_bfloat16*>(v_bf16),                                    \
+        reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),                                \
+        reinterpret_cast<const __nv_bfloat16*>(beta_bf16),                                 \
+        reinterpret_cast<const __nv_bfloat16*>(dt_bf16),                                   \
+        reinterpret_cast<const __nv_bfloat16*>(a_bf16),                                    \
+        states, state_off, reinterpret_cast<__nv_bfloat16*>(out_bf16),                     \
+        q_heads, v_heads, qh_block, state_bf16)
+    if (c == 4)       SI_GDN_AR_B(4);
+    else if (c == 16) SI_GDN_AR_B(16);
+    else              SI_GDN_AR_B(8);
+#undef SI_GDN_AR_B
+    return true;
+}
+
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,
@@ -747,6 +874,91 @@ __global__ void conv_split_l2norm_fused_kernel(
     } else {
         out[0] = __float2bfloat16(oy);
     }
+}
+
+// Batched twin of conv_split_l2norm_fused_kernel: B independent rows, each with its OWN conv
+// state (a device array of pointers, same reasoning as gdn_ar_fast_batched_kernel above).
+// blockIdx.y is the row; everything else is the unbatched kernel unchanged, so batch == 1 with
+// states[0] equal to the unbatched conv_state argument reproduces it exactly.
+__global__ void conv_split_l2norm_fused_batched_kernel(
+    const __nv_bfloat16* __restrict__ qkv,
+    const __nv_bfloat16* __restrict__ conv_w,
+    __nv_bfloat16* const* __restrict__ conv_states,
+    size_t conv_off,
+    __nv_bfloat16* __restrict__ q,
+    __nv_bfloat16* __restrict__ k,
+    __nv_bfloat16* __restrict__ v,
+    int q_heads, int v_heads, int head_dim, int conv_kernel, float eps)
+{
+    const int h  = blockIdx.x;
+    const int b  = blockIdx.y;
+    const int t  = threadIdx.x;
+    const int q_dim = q_heads * head_dim;
+    const int v_dim = v_heads * head_dim;
+    const int qkv_dim = 2 * q_dim + v_dim;
+
+    const __nv_bfloat16* qkv_row = qkv + (size_t)b * qkv_dim;
+    __nv_bfloat16* conv_state = conv_states[b] + conv_off;
+
+    bool do_norm = false;
+    int d;
+    __nv_bfloat16* out;
+    if (h < q_heads) {
+        d = h * head_dim + t;  out = q + (size_t)b * q_dim + d;  do_norm = true;
+    } else if (h < 2 * q_heads) {
+        d = q_dim + (h - q_heads) * head_dim + t;
+        out = k + (size_t)b * q_dim + d - q_dim;  do_norm = true;
+    } else {
+        d = 2 * q_dim + (h - 2 * q_heads) * head_dim + t;
+        out = v + (size_t)b * v_dim + d - 2 * q_dim;
+    }
+    if (d >= qkv_dim) return;
+
+    float y = 0.f;
+    for (int p = 0; p < conv_kernel - 1; p++)
+        y += q36_to_f(conv_state[(size_t)p * qkv_dim + d]) *
+             q36_to_f(conv_w[(size_t)d * conv_kernel + p]);
+    y += q36_to_f(qkv_row[d]) * q36_to_f(conv_w[(size_t)d * conv_kernel + (conv_kernel - 1)]);
+
+    for (int p = 0; p < conv_kernel - 2; p++)
+        conv_state[(size_t)p * qkv_dim + d] = conv_state[(size_t)(p + 1) * qkv_dim + d];
+    if (conv_kernel > 1)
+        conv_state[(size_t)(conv_kernel - 2) * qkv_dim + d] = qkv_row[d];
+
+    const float oy = q36_silu(y);
+
+    if (do_norm) {
+        const float ss = q36_wsum(oy * oy);
+        __shared__ float sw[32];
+        if ((t & 31) == 0) sw[t >> 5] = ss;
+        __syncthreads();
+        if (t < 32) {
+            float vv = (t < (head_dim + 31) / 32) ? sw[t] : 0.f;
+            vv = q36_wsum(vv);
+            if (t == 0) sw[0] = rsqrtf(vv + eps);
+        }
+        __syncthreads();
+        out[0] = __float2bfloat16(oy * sw[0]);
+    } else {
+        out[0] = __float2bfloat16(oy);
+    }
+}
+
+void launch_qwen36_conv_split_l2norm_fused_batched(
+    const void* qkv_bf16, const void* conv_w_bf16,
+    void* const* conv_states_bf16, size_t conv_off, void* q_bf16, void* k_bf16,
+    void* v_bf16, int batch, int q_heads, int v_heads, int head_dim,
+    int conv_kernel, float eps, cudaStream_t stream)
+{
+    if (batch < 1) return;
+    conv_split_l2norm_fused_batched_kernel<<<dim3(2 * q_heads + v_heads, batch), head_dim, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(qkv_bf16),
+        reinterpret_cast<const __nv_bfloat16*>(conv_w_bf16),
+        reinterpret_cast<__nv_bfloat16* const*>(conv_states_bf16), conv_off,
+        reinterpret_cast<__nv_bfloat16*>(q_bf16),
+        reinterpret_cast<__nv_bfloat16*>(k_bf16),
+        reinterpret_cast<__nv_bfloat16*>(v_bf16),
+        q_heads, v_heads, head_dim, conv_kernel, eps);
 }
 
 void launch_qwen36_conv_split_l2norm_fused(

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -325,6 +325,27 @@ void launch_qwen36_conv_split_l2norm_fused(const void* qkv_bf16, const void* con
 // (ratio 3) -- confirmed empirically against a real reference implementation (llama.cpp), since
 // the two checkpoints' own HF-side v-head layout conventions differ despite the shared
 // architecture family. This is a property of the loaded checkpoint, not a global default.
+// Batched decode step: B INDEPENDENT sequences advancing one token each, for packed
+// continuous-batch decode. Distinct from the chunked/compact scans, which walk N consecutive
+// positions of ONE sequence and are serial across rows. `states` is a DEVICE array of B state
+// pointers (each session owns its own allocation), which also keeps the call CUDA-graph safe:
+// the graph bakes the array's address and the packer rewrites its contents per replay.
+// Returns false (launching nothing) for shapes it is not instantiated for -- head_dim != 128.
+bool launch_qwen36_gdn_ar_batched(const void* q_bf16, const void* k_bf16, const void* v_bf16,
+                                  const void* alpha_bf16, const void* beta_bf16,
+                                  const void* dt_bf16, const void* a_bf16,
+                                  float* const* states, size_t state_off, void* out_bf16,
+                                  int batch, int q_heads, int v_heads, int head_dim,
+                                  bool qh_block, cudaStream_t stream = nullptr);
+
+// Batched twin of launch_qwen36_conv_split_l2norm_fused; `conv_states` is a device array of B
+// per-session conv-state pointers, same contract as above.
+void launch_qwen36_conv_split_l2norm_fused_batched(
+    const void* qkv_bf16, const void* conv_w_bf16,
+    void* const* conv_states_bf16, size_t conv_off, void* q_bf16, void* k_bf16,
+    void* v_bf16, int batch, int q_heads, int v_heads, int head_dim,
+    int conv_kernel, float eps, cudaStream_t stream = nullptr);
+
 void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                           const void* alpha_bf16, const void* beta_bf16,
                           const void* dt_bf16, const void* a_bf16,

--- a/runtime/csrc/cuda/dflash_kernels.cu
+++ b/runtime/csrc/cuda/dflash_kernels.cu
@@ -2176,6 +2176,32 @@ void launch_capture_rows(const void* src, void* dst, int rows, int hidden, int d
         (const bf16*)src, (bf16*)dst, rows, hidden, dst_row_stride);
 }
 
+// Per-row block-table GATHER for packed decode: row b's table is the slab row for ITS OWN
+// session, so dst[b][*] = table_base[slots[b]][*]. The broadcast twin below is the speculative
+// case, where all rows belong to one sequence.
+//
+// slots lives in DEVICE memory and the gather runs INSIDE the graph capture, which is what keeps
+// one packed-decode graph usable for any set of sessions: the capture bakes the address of
+// `slots` and of the destination, never a particular session's table, so a replay after the row
+// set rotates reads the new mapping instead of the captured one.
+__global__ void k_gather_rows_i32(const int* const* __restrict__ row_tables,
+                                  int* __restrict__ dst, int n, int rows) {
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    const int total = n * rows;
+    if (idx >= total) return;
+    const int r = idx / n, i = idx - r * n;
+    dst[idx] = row_tables[r][i];
+}
+
+void launch_gather_rows_i32(const int* const* row_tables, int* dst, int n, int rows,
+                            cudaStream_t stream) {
+    const int total = n * rows;
+    if (total <= 0) return;
+    const int threads = 256;
+    k_gather_rows_i32<<<(total + threads - 1) / threads, threads, 0, stream>>>(
+        row_tables, dst, n, rows);
+}
+
 void launch_broadcast_rows_i32(const int* src, int* dst, int n, int rows, cudaStream_t stream) {
     const int total = n * rows;
     if (total <= 0) return;

--- a/runtime/include/sparkinfer/inference_engine.h
+++ b/runtime/include/sparkinfer/inference_engine.h
@@ -223,6 +223,13 @@ private:
     Result wait_locked(uint64_t request_id);
     void worker_loop();
     bool step_job(Job& job, bool chunked = false);
+    // Advance a whole decode batch in ONE packed forward instead of one forward per sequence.
+    // Returns false having done NOTHING when the batch is not eligible, so the caller falls back
+    // to stepping the jobs individually. `any_finished` is set if any job completed.
+    bool step_jobs_packed(const std::vector<uint64_t>& ids, bool& any_finished);
+    // Retire a job: close/free its session and mark it done. Shared by step_job() and the packed
+    // path so "job is over" has exactly one implementation.
+    void finish_job_impl(Job& j);
 
     Qwen35Model* model_;
     KVCacheManager* kv_;

--- a/runtime/include/sparkinfer/models/dflash_kernels.h
+++ b/runtime/include/sparkinfer/models/dflash_kernels.h
@@ -192,6 +192,11 @@ void launch_capture_rows(const void* src, void* dst, int rows, int hidden, int d
                          cudaStream_t stream);
 
 void launch_broadcast_rows_i32(const int* src, int* dst, int n, int rows, cudaStream_t stream);
+// Packed-decode twin: dst[r][0..n) = row_tables[r][0..n). `row_tables` is a DEVICE array of
+// per-row block-table pointers, so the gather runs inside a graph capture and the captured graph
+// stays valid across row-set changes -- it bakes the array's address, never a session's table.
+void launch_gather_rows_i32(const int* const* row_tables, int* dst, int n, int rows,
+                            cudaStream_t stream);
 
 // DSpark's Markov head: a low-rank learned bigram bias, added in place to one row of draft
 // logits. bias[v] = sum_r(w1[prev_token][r] * w2[v][r]) -- w1 is a [verifier_vocab, rank]

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -9,6 +9,10 @@
 
 namespace sparkinfer {
 
+// Largest packed continuous-batch decode row count. Mirrors the verify graph tiers in
+// qwen35_prefill.cpp -- one captured graph per row count, so this bounds how many are kept.
+inline constexpr int kQwen35MaxPackedRows = 8;
+
 class ThermalGovernor;   // optional decode-time thermal pacing (thermal_governor.h)
 class BridgeClient;      // optional external KV cache tier (lmcache_bridge_client.h)
 
@@ -475,6 +479,25 @@ public:
     // have the original prompt at this call site and pass nullptr, which is a pure no-op.
     void close_session(uint64_t seq_id, const std::vector<int>* store_tokens = nullptr);
     void activate_session(uint64_t seq_id);
+
+    // PACKED CONTINUOUS-BATCH DECODE: advance `n` INDEPENDENT sequences by one token each in ONE
+    // forward, instead of one full forward per sequence.
+    //
+    // This is what makes aggregate throughput scale with concurrency. Decode is bandwidth-bound on
+    // weight reads, so N sequential forwards read every weight N times; packing the rows reads them
+    // once and pays only the per-row cost, which for the dominant GEMVs is a few percent because
+    // they already take R rows through a single weight read.
+    //
+    // tokens/positions/seq_ids are HOST arrays of n entries; out_sampled receives n token ids
+    // (greedy argmax, matching what forward_token returns at temperature 0). Returns false --
+    // having changed nothing -- when the shape is unsupported, so the caller can fall back to
+    // stepping the jobs one at a time.
+    //
+    // Every sequence must have an open session and live KV. n is capped by the packed graph tiers.
+    bool decode_packed(const int* tokens, const int* positions, const uint64_t* seq_ids, int n,
+                       int* out_sampled);
+    // Largest n decode_packed() accepts. Matches the packed graph tiers.
+    static int max_packed_rows();
     uint64_t active_session() const;
 
     // Zeros seq_id's running presence/frequency-penalty count buffer. MUST be called once per

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -302,14 +302,18 @@ void ContinuousBatchEngine::worker_loop() {
         // one prefill chunk if scheduled. Re-enter the scheduler after the step.
         bool any_finished = false;
         const bool mix_decode = !decode_ids.empty();
-        for (uint64_t id : decode_ids) {
-            Job* job = nullptr;
-            {
-                std::lock_guard<std::mutex> lock(mu_);
-                auto it = jobs_.find(id);
-                if (it != jobs_.end() && !it->second->done) job = it->second.get();
+        // One packed forward for the whole decode batch when every row is eligible; otherwise the
+        // original one-forward-per-sequence loop, unchanged.
+        if (!step_jobs_packed(decode_ids, any_finished)) {
+            for (uint64_t id : decode_ids) {
+                Job* job = nullptr;
+                {
+                    std::lock_guard<std::mutex> lock(mu_);
+                    auto it = jobs_.find(id);
+                    if (it != jobs_.end() && !it->second->done) job = it->second.get();
+                }
+                if (job) any_finished = step_job(*job, /*chunked=*/false) || any_finished;
             }
-            if (job) any_finished = step_job(*job, /*chunked=*/false) || any_finished;
         }
         if (!prefill_ids.empty()) {
             Job* job = nullptr;
@@ -323,6 +327,149 @@ void ContinuousBatchEngine::worker_loop() {
         }
         if (any_finished) cv_.notify_all();
     }
+}
+
+// Was a lambda inside step_job(); hoisted so the packed decode path retires a row through the
+// SAME code rather than a second copy that could drift from it.
+void ContinuousBatchEngine::finish_job_impl(Job& j) {
+    j.done = true;
+    if (j.seq_id != 0) {
+        // Offer this session's KV to the external cache tier (docs/lmcache_bridge_protocol.md)
+        // only once the full prompt has actually been ingested -- j.phase only advances past
+        // PREFILL once prefill_pos reaches the prompt's end (see step_job). A job
+        // cancelled/timed-out mid-prefill has KV for only part of its prompt range (possibly
+        // garbage past prefill_pos), so store_tokens must stay null in that case; passing the
+        // full prompt would tell close_session a longer range is valid than actually is.
+        model_->close_session(j.seq_id, j.phase != SeqPhase::PREFILL ? &j.req.prompt : nullptr);
+    } else {
+        // Session 0 is the shared prefix session. Freeing it wholesale is what made the
+        // prefix cache cache nothing: prefix_cached_len() then returned 0 and the next
+        // matching request re-prefilled the entire prefix. Keep the prefix's own blocks and
+        // drop only the suffix + generated tail, so the next request reuses them. The
+        // recurrent state is NOT kept -- decoding mutated it -- and is replayed from
+        // cache_prefix()'s snapshot by restore_prefix_state() on the next reuse.
+        const int keep = j.req.use_prefix_session ? model_->prefix_block_count() : 0;
+        if (keep > 0 && kv_->truncate_blocks(j.seq_id, keep)) {
+            // prefix stays installed and active; nothing else to do
+        } else {
+            kv_->free(j.seq_id);
+            if (j.req.use_prefix_session) model_->release_prefix_session();
+        }
+    }
+    j.seq_id = 0;
+}
+
+// Packed decode: one forward for the whole decode batch.
+//
+// worker_loop() below used to run `for (id : decode_ids) step_job(...)`, i.e. a full 64-layer
+// forward PER SEQUENCE. Decode is bandwidth-bound on weight reads, so N concurrent requests read
+// every weight N times and aggregate throughput does not scale with concurrency at all. The
+// scheduler already hands us the batch; this executes it as one.
+//
+// Declines (returning false having changed nothing) whenever a row would not decode identically
+// to what step_job would have produced: anything still prefilling, teacher-forced scoring,
+// per-token logprobs, or any sampler setting other than plain greedy -- decode_packed() returns
+// the argmax, which is exactly forward_token()'s result at temperature 0 with no truncation or
+// penalties, and nothing else. A declined batch just falls back to the sequential loop.
+bool ContinuousBatchEngine::step_jobs_packed(const std::vector<uint64_t>& ids, bool& any_finished) {
+    static const bool enabled = [] {
+        const char* e = getenv("SPARKINFER_PACKED_DECODE");
+        return !(e && e[0] == '0');
+    }();
+    if (!enabled || !model_) return false;
+    const int cap = Qwen35Model::max_packed_rows();
+    if ((int)ids.size() < 2 || (int)ids.size() > cap) return false;
+    const Qwen35Config& cfg = model_->config();
+
+    std::vector<Job*> jobs;
+    jobs.reserve(ids.size());
+    {
+        std::lock_guard<std::mutex> lock(mu_);
+        for (uint64_t id : ids) {
+            auto it = jobs_.find(id);
+            if (it == jobs_.end() || it->second->done) return false;
+            jobs.push_back(it->second.get());
+        }
+    }
+    for (Job* j : jobs) {
+        if (j->phase != SeqPhase::DECODE) return false;
+        if (j->next_token < 0 || j->next_token >= cfg.vocab) return false;
+        if (!j->req.forced_tokens.empty()) return false;
+        if (j->req.logprobs || j->on_token_logprob) return false;
+        if (j->req.temperature != 0.f) return false;
+        if (j->req.top_k > 0 || j->req.top_p < 1.0f) return false;
+        if (j->req.presence_penalty != 0.f || j->req.frequency_penalty != 0.f) return false;
+    }
+
+    // Emit each row's pending token and run the same termination checks step_job() does. A job
+    // that finishes here simply drops out of the packed forward below.
+    std::vector<Job*> live;
+    live.reserve(jobs.size());
+    for (Job* j : jobs) {
+        const auto t_emit = std::chrono::steady_clock::now();
+        if (!j->saw_first_tok) {
+            j->t_first = t_emit;
+            j->saw_first_tok = true;
+            j->ttft_ms = std::chrono::duration<double, std::milli>(j->t_first - j->t_submit).count();
+        }
+        j->output.push_back(j->next_token);
+        j->decode_emitted++;
+        if (j->on_token && !j->on_token(j->next_token)) {
+            j->cancelled = true;
+            j->generation_ms = std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - j->t_submit).count();
+            finish_job_impl(*j);
+            any_finished = true;
+            continue;
+        }
+        const bool hit_eos = j->next_token == cfg.eos_id ||
+                             (cfg.eos_id2 >= 0 && j->next_token == cfg.eos_id2);
+        const bool hit_limit = j->decode_emitted >= j->req.max_new_tokens;
+        if (hit_eos || hit_limit) {
+            j->reached_token_limit = hit_limit && !hit_eos;
+            const auto t_end = std::chrono::steady_clock::now();
+            j->generation_ms = std::chrono::duration<double, std::milli>(t_end - j->t_submit).count();
+            if (j->saw_first_tok && j->generation_ms > j->ttft_ms && j->decode_emitted > 0) {
+                const double decode_ms = std::max(j->generation_ms - j->ttft_ms, 1.0);
+                j->decode_tps = (double)j->decode_emitted * 1000.0 / decode_ms;
+            }
+            finish_job_impl(*j);
+            any_finished = true;
+            continue;
+        }
+        live.push_back(j);
+    }
+    if (live.empty()) return true;
+
+    std::vector<int> toks, pos, out((size_t)live.size(), -1);
+    std::vector<uint64_t> seqs;
+    toks.reserve(live.size()); pos.reserve(live.size()); seqs.reserve(live.size());
+    for (Job* j : live) {
+        toks.push_back(j->next_token);
+        pos.push_back((int)j->req.prompt.size() + j->decode_emitted - 1);
+        seqs.push_back(j->seq_id);
+    }
+
+    // One row left (the rest finished above) is not worth a packed forward, and decode_packed
+    // declines a batch it cannot serve; either way the remaining rows still have to advance, so
+    // fall through to the ordinary per-row forward. The tokens already emitted stay emitted --
+    // this is the same work by a different route, not a retry.
+    bool ok = false;
+    if (live.size() >= 2)
+        ok = model_->decode_packed(toks.data(), pos.data(), seqs.data(), (int)live.size(),
+                                   out.data());
+    if (!ok) {
+        for (size_t i = 0; i < live.size(); i++) {
+            Job* j = live[i];
+            model_->activate_session(j->seq_id);
+            out[i] = model_->forward_token(j->next_token, pos[i], true, j->req.temperature,
+                                           j->req.seed, (uint64_t)j->decode_emitted,
+                                           j->req.top_k, j->req.top_p,
+                                           j->req.presence_penalty, j->req.frequency_penalty);
+        }
+    }
+    for (size_t i = 0; i < live.size(); i++) live[i]->next_token = out[i];
+    return true;
 }
 
 bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
@@ -347,33 +494,7 @@ bool ContinuousBatchEngine::step_job(Job& job, bool chunked) {
     // paths quietly drifts out of sync with the others. A lambda (not a free function) because
     // Job is private to ContinuousBatchEngine; only code with this member function's access can
     // name it.
-    auto finish_job = [this](Job& j) {
-        j.done = true;
-        if (j.seq_id != 0) {
-            // Offer this session's KV to the external cache tier (docs/lmcache_bridge_protocol.md)
-            // only once the full prompt has actually been ingested -- j.phase only advances past
-            // PREFILL once prefill_pos reaches the prompt's end (see step_job). A job
-            // cancelled/timed-out mid-prefill has KV for only part of its prompt range (possibly
-            // garbage past prefill_pos), so store_tokens must stay null in that case; passing the
-            // full prompt would tell close_session a longer range is valid than actually is.
-            model_->close_session(j.seq_id, j.phase != SeqPhase::PREFILL ? &j.req.prompt : nullptr);
-        } else {
-            // Session 0 is the shared prefix session. Freeing it wholesale is what made the
-            // prefix cache cache nothing: prefix_cached_len() then returned 0 and the next
-            // matching request re-prefilled the entire prefix. Keep the prefix's own blocks and
-            // drop only the suffix + generated tail, so the next request reuses them. The
-            // recurrent state is NOT kept -- decoding mutated it -- and is replayed from
-            // cache_prefix()'s snapshot by restore_prefix_state() on the next reuse.
-            const int keep = j.req.use_prefix_session ? model_->prefix_block_count() : 0;
-            if (keep > 0 && kv_->truncate_blocks(j.seq_id, keep)) {
-                // prefix stays installed and active; nothing else to do
-            } else {
-                kv_->free(j.seq_id);
-                if (j.req.use_prefix_session) model_->release_prefix_session();
-            }
-        }
-        j.seq_id = 0;
-    };
+    auto finish_job = [this](Job& j) { finish_job_impl(j); };
 
     const double timeout_s = request_timeout_s_config();
     if (timeout_s > 0.0) {

--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -377,8 +377,12 @@ bool ContinuousBatchEngine::step_jobs_packed(const std::vector<uint64_t>& ids, b
         return !(e && e[0] == '0');
     }();
     if (!enabled || !model_) return false;
+    // A batch WIDER than the packed graph tiers is split into chunks of `cap`, not declined.
+    // Declining it fell all the way back to one forward per sequence, so crossing the cap cost
+    // more than never packing at all: measured on RTX 5090 / Qwen3.8-27B-NVFP4, aggregate went
+    // 334.9 tok/s at concurrency 8 to 79.0 at 12 -- a 4.2x collapse one request past the cap.
     const int cap = Qwen35Model::max_packed_rows();
-    if ((int)ids.size() < 2 || (int)ids.size() > cap) return false;
+    if ((int)ids.size() < 2) return false;
     const Qwen35Config& cfg = model_->config();
 
     std::vector<Job*> jobs;
@@ -441,34 +445,37 @@ bool ContinuousBatchEngine::step_jobs_packed(const std::vector<uint64_t>& ids, b
     }
     if (live.empty()) return true;
 
-    std::vector<int> toks, pos, out((size_t)live.size(), -1);
+    // Advance the survivors in chunks of `cap`. A chunk of one (the tail of an odd batch, or all
+    // but one row having finished above) is not worth a packed forward, and decode_packed declines
+    // a batch it cannot serve; either way those rows still have to advance, so they fall through
+    // to the ordinary per-row forward. Tokens already emitted stay emitted -- this is the same
+    // work by a different route, not a retry.
+    std::vector<int> toks, pos, out;
     std::vector<uint64_t> seqs;
-    toks.reserve(live.size()); pos.reserve(live.size()); seqs.reserve(live.size());
-    for (Job* j : live) {
-        toks.push_back(j->next_token);
-        pos.push_back((int)j->req.prompt.size() + j->decode_emitted - 1);
-        seqs.push_back(j->seq_id);
-    }
-
-    // One row left (the rest finished above) is not worth a packed forward, and decode_packed
-    // declines a batch it cannot serve; either way the remaining rows still have to advance, so
-    // fall through to the ordinary per-row forward. The tokens already emitted stay emitted --
-    // this is the same work by a different route, not a retry.
-    bool ok = false;
-    if (live.size() >= 2)
-        ok = model_->decode_packed(toks.data(), pos.data(), seqs.data(), (int)live.size(),
-                                   out.data());
-    if (!ok) {
-        for (size_t i = 0; i < live.size(); i++) {
-            Job* j = live[i];
-            model_->activate_session(j->seq_id);
-            out[i] = model_->forward_token(j->next_token, pos[i], true, j->req.temperature,
-                                           j->req.seed, (uint64_t)j->decode_emitted,
-                                           j->req.top_k, j->req.top_p,
-                                           j->req.presence_penalty, j->req.frequency_penalty);
+    for (size_t off = 0; off < live.size(); off += (size_t)cap) {
+        const size_t m = std::min((size_t)cap, live.size() - off);
+        toks.clear(); pos.clear(); seqs.clear(); out.assign(m, -1);
+        for (size_t i = 0; i < m; i++) {
+            Job* j = live[off + i];
+            toks.push_back(j->next_token);
+            pos.push_back((int)j->req.prompt.size() + j->decode_emitted - 1);
+            seqs.push_back(j->seq_id);
         }
+        bool ok = false;
+        if (m >= 2)
+            ok = model_->decode_packed(toks.data(), pos.data(), seqs.data(), (int)m, out.data());
+        if (!ok) {
+            for (size_t i = 0; i < m; i++) {
+                Job* j = live[off + i];
+                model_->activate_session(j->seq_id);
+                out[i] = model_->forward_token(j->next_token, pos[i], true, j->req.temperature,
+                                               j->req.seed, (uint64_t)j->decode_emitted,
+                                               j->req.top_k, j->req.top_p,
+                                               j->req.presence_penalty, j->req.frequency_penalty);
+            }
+        }
+        for (size_t i = 0; i < m; i++) live[off + i]->next_token = out[i];
     }
-    for (size_t i = 0; i < live.size(); i++) live[i]->next_token = out[i];
     return true;
 }
 

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -244,6 +244,13 @@ struct Qwen35Model::Impl {
     void* packed_dev_states = nullptr;
     void* packed_dev_convs = nullptr;
     void* packed_dev_tables = nullptr;
+    // Pinned staging + the seq_ids the device arrays currently hold, so an unchanged row set
+    // skips the upload entirely.
+    void* packed_host_states = nullptr;
+    void* packed_host_convs = nullptr;
+    void* packed_host_tables = nullptr;
+    void* packed_host_seqs = nullptr;
+    int   packed_rows_valid = 0;
 
     // Per-session parking lot for the AR decode graph.
     //
@@ -800,6 +807,10 @@ Qwen35Model::~Qwen35Model() {
         if (kv.second.lin_state) cudaFree(kv.second.lin_state);
         if (kv.second.lin_conv_state) cudaFree(kv.second.lin_conv_state);
     }
+    if (p_->packed_host_states) cudaFreeHost(p_->packed_host_states);
+    if (p_->packed_host_convs) cudaFreeHost(p_->packed_host_convs);
+    if (p_->packed_host_tables) cudaFreeHost(p_->packed_host_tables);
+    if (p_->packed_host_seqs) cudaFreeHost(p_->packed_host_seqs);
     if (p_->packed_dev_states) cudaFree(p_->packed_dev_states);
     if (p_->packed_dev_convs) cudaFree(p_->packed_dev_convs);
     if (p_->packed_dev_tables) cudaFree(p_->packed_dev_tables);
@@ -3167,6 +3178,10 @@ void Qwen35Model::close_session(uint64_t seq_id, const std::vector<int>* store_t
             s.parked_graphs.erase(parked);
         }
     }
+    // The packed row-set cache is keyed on seq_ids; a closing session frees the very buffers those
+    // device arrays point at, and a later session can be handed the same id. Force the next packed
+    // step to re-upload rather than trust a match.
+    s.packed_rows_valid = 0;
     // Store to the external cache tier before freeing the blocks it reads -- this is the
     // "session close" eviction point (docs/lmcache_bridge_protocol.md's STORE trigger list).
     // store_tokens is null for most callers (this model class doesn't itself track a session's
@@ -3215,33 +3230,59 @@ bool Qwen35Model::decode_packed(const int* tokens, const int* positions,
     // Resolve each row's per-session buffers. A row whose session is missing (or never got its
     // hybrid state) cannot be packed -- decline the whole batch rather than silently decode it
     // against another request's state.
-    float* h_states[kQwen35MaxPackedRows];
-    void*  h_convs[kQwen35MaxPackedRows];
-    const int* h_tables[kQwen35MaxPackedRows];
+    // PINNED staging, allocated once. The upload below must be async -- a synchronous copy, or an
+    // async one from a stack array that has to be waited on, forces the CPU to drain the GPU every
+    // step, and the engine's per-row callbacks then run with the device idle. Measured at
+    // concurrency 8 that stall was ~4.5 ms of a ~24 ms step, against ~19.5 ms of actual GPU work.
+    if (!s.packed_dev_states) {
+        const size_t np = kQwen35MaxPackedRows;
+        if (cudaMalloc(&s.packed_dev_states, np * sizeof(float*)) != cudaSuccess) return false;
+        if (cudaMalloc(&s.packed_dev_convs, np * sizeof(void*)) != cudaSuccess) return false;
+        if (cudaMalloc(&s.packed_dev_tables, np * sizeof(const int*)) != cudaSuccess) return false;
+        if (cudaHostAlloc(&s.packed_host_states, np * sizeof(float*), cudaHostAllocDefault)
+            != cudaSuccess) return false;
+        if (cudaHostAlloc(&s.packed_host_convs, np * sizeof(void*), cudaHostAllocDefault)
+            != cudaSuccess) return false;
+        if (cudaHostAlloc(&s.packed_host_tables, np * sizeof(const int*), cudaHostAllocDefault)
+            != cudaSuccess) return false;
+        if (cudaHostAlloc(&s.packed_host_seqs, np * sizeof(uint64_t), cudaHostAllocDefault)
+            != cudaSuccess) return false;
+    }
+    float** h_states = static_cast<float**>(s.packed_host_states);
+    void**  h_convs  = static_cast<void**>(s.packed_host_convs);
+    const int** h_tables = static_cast<const int**>(s.packed_host_tables);
+    uint64_t* h_seqs = static_cast<uint64_t*>(s.packed_host_seqs);
+
+    // Skip the upload entirely when the row set has not moved. Each session's buffers and its
+    // block-table slab row are fixed for its lifetime, so the same seq_ids imply the same three
+    // arrays -- and a steady stream of concurrent requests decodes the SAME set for many steps in
+    // a row.
+    bool same = (s.packed_rows_valid == n);
+    for (int i = 0; i < n && same; i++) same = h_seqs[i] == seq_ids[i];
+
     for (int i = 0; i < n; i++) {
         auto it = s.sessions.find(seq_ids[i]);
         if (it == s.sessions.end() || !it->second.lin_state || !it->second.lin_conv_state)
             return false;
         const int* tbl = s.kv->block_table(seq_ids[i]);
         if (!tbl) return false;
-        h_states[i] = it->second.lin_state;
-        h_convs[i]  = it->second.lin_conv_state;
-        h_tables[i] = tbl;
+        if (!same) {
+            h_states[i] = it->second.lin_state;
+            h_convs[i]  = it->second.lin_conv_state;
+            h_tables[i] = tbl;
+            h_seqs[i]   = seq_ids[i];
+        }
     }
 
-    if (!s.packed_dev_states) {
-        const size_t np = kQwen35MaxPackedRows;
-        if (cudaMalloc(&s.packed_dev_states, np * sizeof(float*)) != cudaSuccess) return false;
-        if (cudaMalloc(&s.packed_dev_convs, np * sizeof(void*)) != cudaSuccess) return false;
-        if (cudaMalloc(&s.packed_dev_tables, np * sizeof(const int*)) != cudaSuccess) return false;
+    if (!same) {
+        cu(cudaMemcpyAsync(s.packed_dev_states, h_states, (size_t)n * sizeof(float*),
+                           cudaMemcpyHostToDevice, s.stream), "packed states");
+        cu(cudaMemcpyAsync(s.packed_dev_convs, h_convs, (size_t)n * sizeof(void*),
+                           cudaMemcpyHostToDevice, s.stream), "packed convs");
+        cu(cudaMemcpyAsync(s.packed_dev_tables, h_tables, (size_t)n * sizeof(const int*),
+                           cudaMemcpyHostToDevice, s.stream), "packed tables");
+        s.packed_rows_valid = n;
     }
-    cu(cudaMemcpyAsync(s.packed_dev_states, h_states, (size_t)n * sizeof(float*),
-                       cudaMemcpyHostToDevice, s.stream), "packed states");
-    cu(cudaMemcpyAsync(s.packed_dev_convs, h_convs, (size_t)n * sizeof(void*),
-                       cudaMemcpyHostToDevice, s.stream), "packed convs");
-    cu(cudaMemcpyAsync(s.packed_dev_tables, h_tables, (size_t)n * sizeof(const int*),
-                       cudaMemcpyHostToDevice, s.stream), "packed tables");
-    cu(cudaStreamSynchronize(s.stream), "packed ptr upload");
 
     Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, seq_ids[0],
                           h_states[0], h_convs[0], s.logits, s.d_out_id, s.h_out_id, s.gguf,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -238,6 +238,12 @@ struct Qwen35Model::Impl {
     bool dflash_graph_ready = false;
     int dflash_graph_attn_mode = -1;
     bool dflash_graph_sparse = false;
+    // Reusable device pointer arrays for packed decode (see Qwen35Model::decode_packed). Their
+    // ADDRESSES are baked into the packed graph; their CONTENTS are rewritten every step, which
+    // is what lets one graph per row count serve any set of sessions.
+    void* packed_dev_states = nullptr;
+    void* packed_dev_convs = nullptr;
+    void* packed_dev_tables = nullptr;
 
     // Per-session parking lot for the AR decode graph.
     //
@@ -794,6 +800,9 @@ Qwen35Model::~Qwen35Model() {
         if (kv.second.lin_state) cudaFree(kv.second.lin_state);
         if (kv.second.lin_conv_state) cudaFree(kv.second.lin_conv_state);
     }
+    if (p_->packed_dev_states) cudaFree(p_->packed_dev_states);
+    if (p_->packed_dev_convs) cudaFree(p_->packed_dev_convs);
+    if (p_->packed_dev_tables) cudaFree(p_->packed_dev_tables);
     for (auto& kv : p_->parked_graphs) {
         if (kv.second.exec) cudaGraphExecDestroy(kv.second.exec);
         if (kv.second.graph) cudaGraphDestroy(kv.second.graph);
@@ -3191,6 +3200,62 @@ void Qwen35Model::close_session(uint64_t seq_id, const std::vector<int>* store_t
         s.sessions.erase(it);
     }
     if (s.active_seq_id == seq_id) activate_session(0);
+}
+
+int Qwen35Model::max_packed_rows() { return kQwen35MaxPackedRows; }
+
+bool Qwen35Model::decode_packed(const int* tokens, const int* positions,
+                                const uint64_t* seq_ids, int n, int* out_sampled) {
+    Impl& s = *p_;
+    if (!tokens || !positions || !seq_ids || !out_sampled) return false;
+    if (n < 1 || n > kQwen35MaxPackedRows) return false;
+    if (!s.cfg.hybrid || !s.gguf) return false;
+    std::lock_guard<std::recursive_mutex> device_lock(s.device_mu);
+
+    // Resolve each row's per-session buffers. A row whose session is missing (or never got its
+    // hybrid state) cannot be packed -- decline the whole batch rather than silently decode it
+    // against another request's state.
+    float* h_states[kQwen35MaxPackedRows];
+    void*  h_convs[kQwen35MaxPackedRows];
+    const int* h_tables[kQwen35MaxPackedRows];
+    for (int i = 0; i < n; i++) {
+        auto it = s.sessions.find(seq_ids[i]);
+        if (it == s.sessions.end() || !it->second.lin_state || !it->second.lin_conv_state)
+            return false;
+        const int* tbl = s.kv->block_table(seq_ids[i]);
+        if (!tbl) return false;
+        h_states[i] = it->second.lin_state;
+        h_convs[i]  = it->second.lin_conv_state;
+        h_tables[i] = tbl;
+    }
+
+    if (!s.packed_dev_states) {
+        const size_t np = kQwen35MaxPackedRows;
+        if (cudaMalloc(&s.packed_dev_states, np * sizeof(float*)) != cudaSuccess) return false;
+        if (cudaMalloc(&s.packed_dev_convs, np * sizeof(void*)) != cudaSuccess) return false;
+        if (cudaMalloc(&s.packed_dev_tables, np * sizeof(const int*)) != cudaSuccess) return false;
+    }
+    cu(cudaMemcpyAsync(s.packed_dev_states, h_states, (size_t)n * sizeof(float*),
+                       cudaMemcpyHostToDevice, s.stream), "packed states");
+    cu(cudaMemcpyAsync(s.packed_dev_convs, h_convs, (size_t)n * sizeof(void*),
+                       cudaMemcpyHostToDevice, s.stream), "packed convs");
+    cu(cudaMemcpyAsync(s.packed_dev_tables, h_tables, (size_t)n * sizeof(const int*),
+                       cudaMemcpyHostToDevice, s.stream), "packed tables");
+    cu(cudaStreamSynchronize(s.stream), "packed ptr upload");
+
+    Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, seq_ids[0],
+                          h_states[0], h_convs[0], s.logits, s.d_out_id, s.h_out_id, s.gguf,
+                          s.emb_norm_ones,
+                          s.qdim, s.kvdim, s.linear_qdim, s.linear_vdim, s.linear_qkvdim,
+                          s.moe_rs_gate, s.moe_rs_up, s.moe_rs_down, s.n_splits,
+                          nullptr, 0, nullptr, 0 };
+    ctx.packed_pos       = positions;
+    ctx.packed_rows      = reinterpret_cast<const int* const*>(s.packed_dev_tables);
+    ctx.packed_lin_state = reinterpret_cast<float* const*>(s.packed_dev_states);
+    ctx.packed_lin_conv  = reinterpret_cast<void* const*>(s.packed_dev_convs);
+    const int consumed = dflash_verify_short_run(ctx, tokens, n, positions[0],
+                                                 nullptr, 0, nullptr, out_sampled);
+    return consumed == n;
 }
 
 void Qwen35Model::activate_session(uint64_t seq_id) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2705,7 +2705,21 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 c.head_dim, c.linear_head_dim, c.n_experts, c.top_k, (int)dense);
         return -1;
     }
+    // PACKED CONTINUOUS-BATCH DECODE (see Qwen35PrefillCtx::packed_rows). Same forward, but the
+    // N rows are N INDEPENDENT sequences taking one decode step each rather than N consecutive
+    // positions of one sequence. Only four things differ, all below: the block table is gathered
+    // per row instead of broadcast, the GDN block runs the batched per-row AR step instead of the
+    // compact scan, the KV-append uses the per-row-table kernel instead of the single-sequence
+    // one, and there is no accepted-prefix commit because every row is already a real step.
+    const bool packed = s.packed_rows != nullptr;
     const int H = c.hidden, N = n, qdim = s.qdim, kvdim = s.kvdim;
+    // Host-side dispatch hint for the flash-decode split (it selects the tensor-core arm on
+    // seqlen > 512 and mma_chunk >= 32). Packed rows have independent lengths, so take the
+    // longest: the per-row lengths the kernel actually reads still come from `seq`.
+    int packed_seq_hint = 0;
+    if (packed)
+        for (int i = 0; i < N; i++)
+            if (s.packed_pos[i] + 1 > packed_seq_hint) packed_seq_hint = s.packed_pos[i] + 1;
     // Every arena buffer below is sized for the WIDEST verify tier, not for this call's N.
     // The per-tier graphs each bake their own device pointers, and Arena::alloc frees and
     // reallocates a slot the moment a later call asks it for more bytes -- which would leave an
@@ -2940,8 +2954,9 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     }
     for (int i = 0; i < N; ++i) {
         ph_ids[i] = token_ids[i];
-        ph_pos[i] = start_pos + i;
-        ph_seq[i] = start_pos + i + 1;
+        // Packed rows each sit at their OWN sequence's next position; verify rows are consecutive.
+        ph_pos[i] = packed ? s.packed_pos[i] : start_pos + i;
+        ph_seq[i] = ph_pos[i] + 1;
     }
 
     const bf16* q81_src = nullptr;
@@ -3141,7 +3156,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     // a few KB) so the 10 full-attention layers each run ONE split + ONE combine instead of one per
     // row. That removes 2*(N-1) graph nodes per attention layer, and the graph is ~1000 nodes deep
     // against only ~5.6 ms of kernel time, so node count is itself a real cost here.
-    int* btab_rows = (N > 1) ? a.alloc<int>((size_t)NA * mbs) : nullptr;
+    int* btab_rows = (N > 1 || packed) ? a.alloc<int>((size_t)NA * mbs) : nullptr;
     if (!a.ok) { fprintf(stderr, "[dflash-verify] block-table scratch allocation failed\n"); return -1; }
     bool supported = true;
     int  vfail_L = -1;   // layer whose stage declined, for the bailout diagnostic below
@@ -3162,9 +3177,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         recording = false;
     };
     bool head_ok = false;
-    if (graph_model_key != s.w.lm_head || graph_state_key != s.lin_state ||
-        graph_conv_key != s.lin_conv_state || graph_capture_key != capture_dst ||
-        graph_btable_key != btable || graph_seq_key != s.seq_id || graph_ns_key != ns) {
+    const void* state_key   = packed ? (const void*)s.packed_lin_state : (const void*)s.lin_state;
+    const void* conv_key    = packed ? (const void*)s.packed_lin_conv  : (const void*)s.lin_conv_state;
+    const void* btable_key  = packed ? (const void*)s.packed_rows      : (const void*)btable;
+    const uint64_t seq_key  = packed ? UINT64_MAX - 1 : s.seq_id;
+    if (graph_model_key != s.w.lm_head || graph_state_key != state_key ||
+        graph_conv_key != conv_key || graph_capture_key != capture_dst ||
+        graph_btable_key != btable_key || graph_seq_key != seq_key || graph_ns_key != ns) {
         for (int t = 1; t <= kVerifyMaxRows; t++) {
             if (verify_exec[t]) cudaGraphExecDestroy(verify_exec[t]);
             if (verify_graph[t]) cudaGraphDestroy(verify_graph[t]);
@@ -3173,11 +3192,11 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         }
         graph_warm = false;
         graph_model_key = s.w.lm_head;
-        graph_state_key = s.lin_state;
-        graph_conv_key = s.lin_conv_state;
+        graph_state_key = state_key;
+        graph_conv_key = conv_key;
         graph_capture_key = capture_dst;
-        graph_btable_key = btable;
-        graph_seq_key = s.seq_id;
+        graph_btable_key = btable_key;
+        graph_seq_key = seq_key;
         graph_ns_key = ns;
     }
     if (graph_ready_t[N] && capture_only) return 0;   // this tier is already built
@@ -3206,7 +3225,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         }
         goto verify_forward_done;
     }
-    recording = graph_warm || capture_only;
+    // Packed decode always records. `recording` gates the EndCapture/instantiate/launch trio at
+    // the bottom, while BeginCapture below is unconditional on this path (we only get here when
+    // this tier's graph is NOT ready), so a false `recording` begins a capture that is never
+    // ended and strands the stream -- every later call then fails with "operation not permitted
+    // when stream is capturing". DSpark never sees that because dflash_generate warms each tier
+    // with a capture_only call during session setup; packed decode has no such warmup.
+    recording = graph_warm || capture_only || packed;
     if (recording)
     // Dense FFN seeds: expert 0, weight 1.0 -- the same constants AR uses. Written ONCE, here,
     // SYNCHRONOUSLY, and deliberately BEFORE the capture begins.
@@ -3234,8 +3259,12 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     // Device-to-device inside the capture, so each replay re-reads the sequence's live table as it
     // grows instead of baking in the mapping from capture time. One kernel node rather than N
     // memcpy nodes -- same reason as the capture copies above.
-    if (btab_rows)
-        dflash_kernels::launch_broadcast_rows_i32(btable, btab_rows, mbs, N, st);
+    if (btab_rows) {
+        if (packed)
+            dflash_kernels::launch_gather_rows_i32(s.packed_rows, btab_rows, mbs, N, st);
+        else
+            dflash_kernels::launch_broadcast_rows_i32(btable, btab_rows, mbs, N, st);
+    }
     kernels::launch_embedding(ids, s.w.embed_tokens, x, N, H, st);
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, c.rms_eps, st);
     for (int L = 0; L < c.n_layers && supported; ++L) {
@@ -3312,15 +3341,37 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 if (!split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify gdn join wait");
             }
             if (!supported) break;
-            const bf16* conv_live = static_cast<const bf16*>(s.lin_conv_state) +
-                (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
+            const size_t conv_off = (size_t)L * (c.linear_conv_kernel - 1) * lqkv;
+            const size_t state_off = (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
+            if (packed) {
+                // Rows are independent sequences, so this is the ordinary AR decode step done B
+                // ways -- each row against its OWN conv window and recurrent state, mutating them
+                // in place. That in-place update is why packed mode has no commit stage: the
+                // compact pair below deliberately does NOT touch the live state, because a
+                // speculative verify must be able to discard rejected rows.
+                kernels::launch_qwen36_conv_split_l2norm_fused_batched(
+                    rq, w.ssm_conv, s.packed_lin_conv, conv_off, gq, rk, rv,
+                    N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel,
+                    c.rms_eps, st);
+                if (split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join_ab, 0), "packed gdn ab wait");
+                if (!kernels::launch_qwen36_gdn_ar_batched(
+                        gq, rk, rv, ra, rb, w.ssm_dt, w.ssm_a,
+                        s.packed_lin_state, state_off, att,
+                        N, c.linear_q_heads, vh, c.linear_head_dim, c.gdn_qh_block, st)) {
+                    supported = false;
+                    vfail_L = L;
+                    break;
+                }
+            } else {
+            const bf16* conv_live = static_cast<const bf16*>(s.lin_conv_state) + conv_off;
             kernels::launch_dflash_gdn_conv_compact(rq, w.ssm_conv, conv_live, gq, rk, rv,
                 N, c.linear_q_heads, vh, c.linear_head_dim, c.linear_conv_kernel, c.rms_eps, st);
-            const float* state = s.lin_state + (size_t)L * vh * c.linear_head_dim * c.linear_head_dim;
+            const float* state = s.lin_state + state_off;
             // ra/rb are the scan's only side-branch inputs.
             if (split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join_ab, 0), "verify gdn ab wait");
             kernels::launch_dflash_gdn_scan_compact(gq, rk, rv, ra, rb, w.ssm_dt, w.ssm_a,
                 state, att, N, c.linear_q_heads, vh, c.linear_head_dim, c.gdn_qh_block, st);
+            }
             // ...and lz is gated_norm's.
             if (split_ok) pf_cu(cudaStreamWaitEvent(st, ev_join, 0), "verify gdn z wait");
             // The out-projection is about to quantize lnrm to the NVFP4 activation form; this
@@ -3376,16 +3427,28 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             char* vs = kv8 ? static_cast<char*>(s.kv->v_scale_pool()) +
                              s.kv->scale_layer_base_elems(L) * 2 : nullptr;
             if (kv8) {
-                kernels::launch_dflash_qknorm_rope_kv_partial_int8_gated(
-                    b8, qb, qg, kf, vf, w.q_norm, w.k_norm, kp, vp, ks, vs, btable, pos,
-                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta, c.rms_eps,
-                    bs, mbs, st);
+                if (packed)
+                    kernels::launch_qknorm_rope_kv_partial_int8_gated(
+                        b8, qb, qg, kf, vf, w.q_norm, w.k_norm, kp, vp, ks, vs, btab_rows, pos,
+                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta,
+                        c.rms_eps, bs, mbs, st);
+                else
+                    kernels::launch_dflash_qknorm_rope_kv_partial_int8_gated(
+                        b8, qb, qg, kf, vf, w.q_norm, w.k_norm, kp, vp, ks, vs, btable, pos,
+                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta,
+                        c.rms_eps, bs, mbs, st);
             } else {
                 kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
-                kernels::launch_dflash_qknorm_rope_kv_partial(
-                    qb, kf, vf, w.q_norm, w.k_norm, kp, vp, btable, pos,
-                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta, c.rms_eps,
-                    bs, mbs, st);
+                if (packed)
+                    kernels::launch_qknorm_rope_kv_partial(
+                        qb, kf, vf, w.q_norm, w.k_norm, kp, vp, btab_rows, pos,
+                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta,
+                        c.rms_eps, bs, mbs, st);
+                else
+                    kernels::launch_dflash_qknorm_rope_kv_partial(
+                        qb, kf, vf, w.q_norm, w.k_norm, kp, vp, btable, pos,
+                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_dim, c.rope_theta,
+                        c.rms_eps, bs, mbs, st);
             }
             // Match the autoregressive decode path exactly. Its fused int8 attention gate is
             // enabled only for the 2048/4096-wide layouts; Qwen3.8 (H=5120) applies sigmoid(g)
@@ -3406,7 +3469,7 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 // computing what has to be the same number is precisely how the batched path
                 // drifts from AR at long context (#712). start_pos + N is the largest row
                 // length in this batch, matching what AR would report at the last row.
-                1.f / sqrtf((float)c.head_dim), st, nullptr, start_pos + N,
+                1.f / sqrtf((float)c.head_dim), st, nullptr, packed ? packed_seq_hint : start_pos + N,
                 ks, vs, kv8 ? 1 : 0, int8_gate_fused ? qg : nullptr);
             // att/qg rows are contiguous at stride qdim, and the gate is elementwise, so one
             // launch covers the whole block. N separate nodes cost N times the graph-node
@@ -3801,6 +3864,10 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         verify_dbg_call++;
     }
 verify_forward_done:
+    // Packed decode consumes every row by construction -- each is a real decode step for its own
+    // sequence, and the batched GDN block already advanced that session's conv window and
+    // recurrent state in place. There is no accepted prefix to select and nothing to commit.
+    if (packed) return N;
     int keep = 1;
     while (keep < N && token_ids[keep] == out_argmax[keep - 1]) ++keep;
     if (getenv("SPARKINFER_DFLASH_VERIFY_DUMP_ROW")) {

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -65,6 +65,26 @@ struct Qwen35PrefillCtx {
     // Indexed by the row within THIS PASS, so a windowed prefill must hand over the slice for its
     // own window rather than the whole prompt -- the same relationship `tok` already has to pos0.
     const int*           mrope_pos  = nullptr;
+
+    // PACKED CONTINUOUS-BATCH DECODE. Non-null `packed_rows` turns dflash_verify_short_run's N
+    // rows from "N consecutive positions of ONE sequence" into "N INDEPENDENT sequences, one
+    // decode token each" -- which is the same forward, since every stage below the GDN block
+    // already works per row: the projections and FFN take R rows through a single weight read, the
+    // paged attention takes num_seqs with a per-row block table, and the KV-append kernels are
+    // already instantiated for a per-row table (SINGLE_SEQUENCE=false).
+    //
+    // Every one of these is a DEVICE array of N entries, refreshed by the caller before each step
+    // and never baked into the capture, so ONE packed graph per row count serves any set of
+    // sessions. That is the whole reason they are pointer arrays rather than a base plus stride:
+    // each session's lin_state / lin_conv_state / block table is its own allocation.
+    //   packed_rows        [N] block-table pointers, one per row's sequence
+    //   packed_lin_state   [N] per-session GDN recurrent-state bases (layer selected by offset)
+    //   packed_lin_conv    [N] per-session GDN conv-window bases
+    //   packed_pos         [N] HOST array of each row's absolute position in its own sequence
+    const int*           packed_pos       = nullptr;
+    const int* const*    packed_rows      = nullptr;
+    float* const*        packed_lin_state = nullptr;
+    void* const*         packed_lin_conv  = nullptr;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.

--- a/runtime/tests/CMakeLists.txt
+++ b/runtime/tests/CMakeLists.txt
@@ -43,6 +43,11 @@ target_link_libraries(lmcache_bridge_client_cpu_test PRIVATE Threads::Threads)
 set_target_properties(lmcache_bridge_client_cpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME lmcache_bridge_client_cpu_test COMMAND lmcache_bridge_client_cpu_test)
 
+# Packed-decode GDN kernels vs the unbatched path, bit for bit.
+add_executable(gdn_batched_gpu_test gdn_batched_gpu_test.cpp)
+target_link_libraries(gdn_batched_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
+add_test(NAME gdn_batched_gpu_test COMMAND gdn_batched_gpu_test)
+
 add_executable(batch_engine_gpu_test batch_engine_gpu_test.cpp)
 target_link_libraries(batch_engine_gpu_test PRIVATE sparkinfer_runtime CUDA::cudart)
 add_test(NAME batch_engine_gpu_test COMMAND batch_engine_gpu_test)

--- a/runtime/tests/gdn_batched_gpu_test.cpp
+++ b/runtime/tests/gdn_batched_gpu_test.cpp
@@ -1,0 +1,196 @@
+// Packed-decode GDN kernels: B independent sequences in one launch must equal B sequential
+// single-sequence launches, BIT FOR BIT.
+//
+// Bit-exactness is the bar, not closeness. The recurrent state is carried across every decode
+// step, so a last-bit difference compounds; and packed decode has to reproduce what the
+// unbatched path would have emitted or it changes what users are served.
+#include "sparkinfer/kernels/fused.h"
+
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+std::vector<uint16_t> rand_bf16(size_t n, uint32_t seed, float scale) {
+    std::vector<uint16_t> h(n);
+    uint32_t x = seed | 1u;
+    for (size_t i = 0; i < n; i++) {
+        x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+        const float f = scale * (2.f * ((x >> 8) % 10000) / 10000.f - 1.f);
+        uint32_t b; memcpy(&b, &f, 4);
+        h[i] = (uint16_t)(b >> 16);
+    }
+    return h;
+}
+
+std::vector<float> rand_f32(size_t n, uint32_t seed, float scale) {
+    std::vector<float> h(n);
+    uint32_t x = seed | 1u;
+    for (size_t i = 0; i < n; i++) {
+        x ^= x << 13; x ^= x >> 17; x ^= x << 5;
+        h[i] = scale * (2.f * ((x >> 8) % 10000) / 10000.f - 1.f);
+    }
+    return h;
+}
+
+template <class T>
+T* upload(const std::vector<T>& h) {
+    void* d = nullptr;
+    if (cudaMalloc(&d, h.size() * sizeof(T)) != cudaSuccess) return nullptr;
+    cudaMemcpy(d, h.data(), h.size() * sizeof(T), cudaMemcpyHostToDevice);
+    return (T*)d;
+}
+
+template <class T>
+std::vector<T> download(const T* d, size_t n) {
+    std::vector<T> h(n);
+    cudaMemcpy(h.data(), d, n * sizeof(T), cudaMemcpyDeviceToHost);
+    return h;
+}
+
+bool test_gdn_ar(int B, int q_heads, int v_heads, int hd, bool qh_block, size_t off = 0) {
+    const size_t qdim = (size_t)q_heads * hd, vdim = (size_t)v_heads * hd;
+    const size_t st_n = (size_t)v_heads * hd * hd;
+
+    auto hq = rand_bf16(B * qdim, 11, 1.f), hk = rand_bf16(B * qdim, 22, 1.f);
+    auto hv = rand_bf16(B * vdim, 33, 1.f);
+    auto ha = rand_bf16(B * v_heads, 44, 1.f), hb = rand_bf16(B * v_heads, 55, 1.f);
+    auto hdt = rand_bf16(v_heads, 66, 0.5f), haa = rand_bf16(v_heads, 77, -0.5f);
+    auto hst = rand_f32(st_n + off, 88, 0.1f);   // off models a per-layer slice of a session's state
+
+    auto* dq = upload(hq); auto* dk = upload(hk); auto* dv = upload(hv);
+    auto* da = upload(ha); auto* db = upload(hb);
+    auto* ddt = upload(hdt); auto* daa = upload(haa);
+    if (!dq || !dk || !dv || !da || !db || !ddt || !daa) { printf("FAIL: alloc\n"); return false; }
+
+    // reference: B sequential unbatched calls, each on its own state
+    std::vector<float*> ref_states(B);
+    std::vector<uint16_t> ref_out(B * vdim);
+    for (int b = 0; b < B; b++) {
+        ref_states[b] = upload(hst);                       // every row starts from the SAME state
+        void* out = nullptr; cudaMalloc(&out, vdim * sizeof(uint16_t));
+        sparkinfer::kernels::launch_qwen36_gdn_ar(
+            (const char*)dq + b * qdim * 2, (const char*)dk + b * qdim * 2,
+            (const char*)dv + b * vdim * 2,
+            (const char*)da + b * v_heads * 2, (const char*)db + b * v_heads * 2,
+            ddt, daa, ref_states[b] + off, out, q_heads, v_heads, hd, qh_block, nullptr);
+        cudaDeviceSynchronize();
+        auto o = download((uint16_t*)out, vdim);
+        memcpy(&ref_out[(size_t)b * vdim], o.data(), vdim * sizeof(uint16_t));
+        cudaFree(out);
+    }
+
+    // batched: one launch, per-row state pointer array
+    std::vector<float*> bat_states(B);
+    for (int b = 0; b < B; b++) bat_states[b] = upload(hst);
+    auto* dstates = upload(bat_states);
+    void* bout = nullptr; cudaMalloc(&bout, B * vdim * sizeof(uint16_t));
+    if (!sparkinfer::kernels::launch_qwen36_gdn_ar_batched(
+            dq, dk, dv, da, db, ddt, daa, dstates, off, bout,
+            B, q_heads, v_heads, hd, qh_block, nullptr)) {
+        printf("FAIL: batched launcher declined hd=%d\n", hd);
+        return false;
+    }
+    cudaDeviceSynchronize();
+    if (cudaGetLastError() != cudaSuccess) { printf("FAIL: cuda error\n"); return false; }
+
+    auto got = download((uint16_t*)bout, B * vdim);
+    for (size_t i = 0; i < got.size(); i++) {
+        if (got[i] != ref_out[i]) {
+            printf("FAIL: gdn_ar out mismatch at %zu (row %zu): batched=%u ref=%u\n",
+                   i, i / vdim, got[i], ref_out[i]);
+            return false;
+        }
+    }
+    for (int b = 0; b < B; b++) {
+        auto rs = download(ref_states[b] + off, st_n), bs = download(bat_states[b] + off, st_n);
+        for (size_t i = 0; i < st_n; i++) {
+            if (memcmp(&rs[i], &bs[i], 4) != 0) {
+                printf("FAIL: gdn_ar state row %d mismatch at %zu\n", b, i);
+                return false;
+            }
+        }
+    }
+    printf("[ok] gdn_ar B=%d qh=%d vh=%d hd=%d qh_block=%d  out+state bit-identical\n",
+           B, q_heads, v_heads, hd, (int)qh_block);
+    return true;
+}
+
+bool test_conv(int B, int q_heads, int v_heads, int hd, int ck, size_t coff = 0) {
+    const size_t qdim = (size_t)q_heads * hd, vdim = (size_t)v_heads * hd;
+    const size_t qkv = 2 * qdim + vdim;
+    const size_t cs_n = (size_t)(ck - 1) * qkv;
+
+    auto hqkv = rand_bf16(B * qkv, 101, 1.f);
+    auto hw = rand_bf16(qkv * ck, 202, 0.5f);
+    auto hcs = rand_bf16(cs_n + coff, 303, 0.3f);
+    auto* dqkv = upload(hqkv); auto* dw = upload(hw);
+
+    std::vector<uint16_t*> ref_cs(B);
+    std::vector<uint16_t> ref_q(B * qdim), ref_k(B * qdim), ref_v(B * vdim);
+    for (int b = 0; b < B; b++) {
+        ref_cs[b] = upload(hcs);
+        void *oq = nullptr, *ok = nullptr, *ov = nullptr;
+        cudaMalloc(&oq, qdim * 2); cudaMalloc(&ok, qdim * 2); cudaMalloc(&ov, vdim * 2);
+        sparkinfer::kernels::launch_qwen36_conv_split_l2norm_fused(
+            (const char*)dqkv + b * qkv * 2, dw, ref_cs[b] + coff, oq, ok, ov,
+            q_heads, v_heads, hd, ck, 1e-6f, nullptr);
+        cudaDeviceSynchronize();
+        auto a = download((uint16_t*)oq, qdim), c = download((uint16_t*)ok, qdim),
+             e = download((uint16_t*)ov, vdim);
+        memcpy(&ref_q[(size_t)b * qdim], a.data(), qdim * 2);
+        memcpy(&ref_k[(size_t)b * qdim], c.data(), qdim * 2);
+        memcpy(&ref_v[(size_t)b * vdim], e.data(), vdim * 2);
+        cudaFree(oq); cudaFree(ok); cudaFree(ov);
+    }
+
+    std::vector<uint16_t*> bat_cs(B);
+    for (int b = 0; b < B; b++) bat_cs[b] = upload(hcs);
+    auto* dcs = upload(bat_cs);
+    void *bq = nullptr, *bk = nullptr, *bv = nullptr;
+    cudaMalloc(&bq, B * qdim * 2); cudaMalloc(&bk, B * qdim * 2); cudaMalloc(&bv, B * vdim * 2);
+    sparkinfer::kernels::launch_qwen36_conv_split_l2norm_fused_batched(
+        dqkv, dw, (void* const*)dcs, coff, bq, bk, bv, B, q_heads, v_heads, hd, ck, 1e-6f, nullptr);
+    cudaDeviceSynchronize();
+    if (cudaGetLastError() != cudaSuccess) { printf("FAIL: conv cuda error\n"); return false; }
+
+    auto gq = download((uint16_t*)bq, B * qdim), gk = download((uint16_t*)bk, B * qdim),
+         gv = download((uint16_t*)bv, B * vdim);
+    for (size_t i = 0; i < gq.size(); i++)
+        if (gq[i] != ref_q[i] || gk[i] != ref_k[i]) { printf("FAIL: conv q/k mismatch at %zu\n", i); return false; }
+    for (size_t i = 0; i < gv.size(); i++)
+        if (gv[i] != ref_v[i]) { printf("FAIL: conv v mismatch at %zu\n", i); return false; }
+    for (int b = 0; b < B; b++) {
+        auto rs = download(ref_cs[b] + coff, cs_n), bs = download(bat_cs[b] + coff, cs_n);
+        for (size_t i = 0; i < cs_n; i++)
+            if (rs[i] != bs[i]) { printf("FAIL: conv state row %d at %zu\n", b, i); return false; }
+    }
+    printf("[ok] conv    B=%d qh=%d vh=%d hd=%d ck=%d  out+state bit-identical\n",
+           B, q_heads, v_heads, hd, ck);
+    return true;
+}
+
+}  // namespace
+
+int main() {
+    int n = 0;
+    if (cudaGetDeviceCount(&n) != cudaSuccess || n == 0) { printf("[SKIP] no GPU\n"); return 0; }
+    bool ok = true;
+    // Qwen3.8-27B linear-attention shape: 16 q-heads, 32/48 v-heads, head_dim 128, conv kernel 4.
+    for (int B : {1, 2, 4, 8}) {
+        ok &= test_gdn_ar(B, 16, 32, 128, false);
+        ok &= test_gdn_ar(B, 16, 48, 128, true);
+        ok &= test_conv(B, 16, 32, 128, 4);
+        ok &= test_conv(B, 16, 48, 128, 4);
+        // non-zero offset: the packed path passes ONE array of session-base pointers and selects
+        // the layer with state_off, so a wrong offset must not pass as a wrong answer.
+        ok &= test_gdn_ar(B, 16, 48, 128, true, (size_t)48 * 128 * 128);
+        ok &= test_conv(B, 16, 48, 128, 4, (size_t)3 * (2 * 16 * 128 + 48 * 128));
+    }
+    printf(ok ? "[PASS] gdn_batched_gpu_test\n" : "[FAIL] gdn_batched_gpu_test\n");
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

`ContinuousBatchEngine::worker_loop()` built a decode batch and then ran it **one sequence at a
time** — `for (id : decode_ids) step_job(*job)`, each a full 64-layer `forward_token()`. Decode is
bandwidth-bound on weight reads, so N concurrent requests read every weight N times and aggregate
throughput does not scale with concurrency at all. The scheduler was already producing the batch;
only execution was unpacked.

This executes it as one forward. Almost everything needed was already in the tree, used by the
speculative verifier: the projections and FFN take R rows through a single weight read, the paged
attention takes `num_seqs`, and the KV-append kernels are already instantiated for a per-row block
table (`SINGLE_SEQUENCE=false`). So packed decode is `dflash_verify_short_run`'s forward with four
substitutions, gated on the new `Qwen35PrefillCtx::packed_rows`:

- the block table is **gathered** per row instead of broadcast from one sequence;
- the GDN block runs a **batched per-row AR step** (first commit) instead of the compact scan,
  advancing each session's conv window and recurrent state in place;
- the KV-append uses the **per-row-table** kernels instead of the single-sequence ones;
- there is **no accepted-prefix commit**, because every row is already a real decode step.

Every per-session pointer reaches the kernels through a **device array** whose contents the caller
rewrites each step, so one captured graph per row count serves any set of sessions. A batch wider
than the graph tiers is **split into chunks** rather than declined — declining fell back to one
forward per sequence, so crossing the cap cost more than never packing at all.

`step_jobs_packed()` declines, having changed nothing, whenever a row would not decode identically
to what `step_job` would have produced: still prefilling, teacher-forced, per-token logprobs, or
any sampler setting other than plain greedy. `SPARKINFER_PACKED_DECODE=0` disables it.

## Baseline

Rebased onto `f157a2a`. The session-graph-parking change this branch previously carried is now in
main, so these three commits are all that is left here, and the baseline below is main as it now
stands — the numbers isolate what packed decode itself contributes.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — aggregate across concurrent requests at **concurrency 2**:

| | decode tok/s |
|---|--:|
| before (main) | 93.95 |
| after (this PR) | 183.00 |

Full ladder, at exactly the settings `cb-decode@cN` uses (`qwen3_gguf_cb_bench <dir> C 256 256
512`). RTX 5090 32 GB, Qwen3.8-27B-NVFP4 (ModelOpt), base `8b56a8b`, arms **alternated**, 2 reps:

| dimension | main | this PR | change | before mean ITL | after mean ITL |
|---|--:|--:|--:|--:|--:|
| c1 (floor, not scored) | 93.20 | 95.25 | +2.2% | 10.96 ms | 10.72 ms |
| **cb-decode@c2** | 93.95 | 183.00 | **1.95×** | 21.46 ms | 10.87 ms |
| **cb-decode@c4** | 94.35 | 310.80 | **3.29×** | 42.05 ms | 12.34 ms |
| **cb-decode@c8** | 94.50 | 482.70 | **5.11×** | 83.26 ms | 15.49 ms |

Against main **before** the graph-parking change landed, i.e. what the two changes deliver
together: c2 75.50 → 183.00 (**2.42×**), c4 76.00 → 310.80 (**4.09×**), c8 75.90 → 482.70
(**6.36×**). Aggregate throughput was flat at ~75 tok/s at every concurrency; it now scales. Per-request latency improves as well — 5.4× at
concurrency 8 — because a request no longer queues behind seven other forwards.

The c1 floor moves the right way (+2.2%), so nothing here is bought from the single-stream path.

```text
$ build/runtime/qwen3_gguf_cb_bench <ModelOpt-NVFP4-dir> <C> 256 256 512

          c1              c2               c4               c8
main      93.2 / 93.2    94.0 / 93.9     94.4 / 94.3     94.5 / 94.5
this PR   95.3 / 95.2   183.0 / 183.0   311.1 / 310.5   483.4 / 482.0
```

**Single-stream AR decode and prefill are unmoved** — one sequence is never packed:

| | decode tok/s | prefill pp tok/s |
|---|--:|--:|
| before (main) | 94.474 | 16096.9 |
| after (this PR) | 94.465 | 16122.0 |

## Correctness

- **`gdn_batched_gpu_test`** (new): the batched GDN kernels against B sequential unbatched
  launches, **bit for bit**, on outputs *and* the updated recurrent state, at B = 1/2/4/8 for both
  v-head counts, both q-head broadcast conventions, and non-zero layer offsets. Bit-exactness
  rather than closeness because the state is carried across every decode step, so a last-bit
  difference compounds.
- **`batch_engine_gpu_test`** passes.
- **DSpark is untouched** — packed mode shares `dflash_verify_short_run`, so this is the regression
  that matters:

| | AR tok/s | DSpark tok/s | mean accepted | LOSSLESS |
|---|--:|--:|--:|--:|
| before (main) | 90.5933 | 128.0223 | **1.6883** | 1 |
| after (this PR) | 90.6478 | 128.2359 | **1.6883** | 1 |

- **Emitted tokens match the sequential path.** Compared with `SPARKINFER_PACKED_DECODE=1` against
  `=0` in the same binary, so packing is the only variable. At c2, c4 and c8 the generated ids are
  the same, and every stream's head is identical to the unpacked run's.

  One honest caveat: at c4 the *packed* run reported its four same-prompt streams diverging from
  each other later in the sequence (c2 and c8 did not, and the heads matched everywhere). Rows
  share no state — the GDN kernels are bit-exact per row, each row has its own KV, conv window and
  recurrent state — but the host-side attention-arm choice is made per launch from the batch's
  longest sequence, so batch composition can change a reduction order and flip a near-tie. That is
  the same class of effect main already shows across concurrency levels; it can be removed by
  pinning the arm independently of batch composition, at some throughput cost, if reviewers prefer
  determinism there.

## Note

Measurements were taken on the same code this branch now contains, with main's
graph-parking change applied — which is what main became when that landed, so they carry over
unchanged. An earlier revision of this branch carried a `qwen3_gguf_cb_bench` change; that file is
a pinned harness path and the equivalent support is already in main, so this branch touches no
harness. The token-equality check above was run with a temporary local instrument, not shipped
here.
