### PR TITLE
fix(tools): accept $schema and $comment in tool parameter schemas

### DIFF
--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -399,12 +399,22 @@ bool require_keyword_type(const json& schema, const std::string& where,
 bool valid_schema_node(const json& schema, const std::string& where, bool top_level,
                        std::string& err) {
     if (!schema.is_object()) return set_error(err, where + " must be an object");
+    // "$schema" and "$comment" carry no constraints -- they are annotations a validator is
+    // required to ignore -- so accepting and dropping them is faithful, not permissive. Clients
+    // built on @ai-sdk/openai-compatible emit "$schema" on every tool schema, and rejecting it
+    // failed the whole request. Structural "$" keywords ($ref/$defs/$id) are deliberately still
+    // refused: silently ignoring a $ref would validate the arguments against nothing.
     if (!is_allowed_key(schema,
-                        {"type", "description", "default", "title", "properties",
+                        {"$schema", "$comment",
+                         "type", "description", "default", "title", "properties",
                          "required", "additionalProperties", "items", "enum", "minimum",
                          "maximum", "exclusiveMinimum", "exclusiveMaximum", "minItems",
                          "maxItems", "minLength", "maxLength", "pattern"},
                         where, err)) return false;
+    for (const char* annotation : {"$schema", "$comment"}) {
+        if (schema.contains(annotation) && !schema[annotation].is_string())
+            return set_error(err, where + "." + annotation + " must be a string");
+    }
     for (const char* annotation : {"description", "title"}) {
         if (schema.contains(annotation) && !schema[annotation].is_string())
             return set_error(err, where + "." + annotation + " must be a string");

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -581,6 +581,50 @@ bool test_schema_unions_and_dynamic_properties() {
     return true;
 }
 
+bool test_schema_annotations_accepted() {
+    // Regression for #972: @ai-sdk/openai-compatible clients (Kilo and friends) put
+    // "$schema" on every tool schema, which made every tool-calling request 400.
+    const std::string body = R"JSON({
+      "messages":[{"role":"user","content":"weather in Paris?"}],
+      "tools":[{"type":"function","function":{
+        "name":"get_weather",
+        "description":"Current weather",
+        "parameters":{
+          "$schema":"https://json-schema.org/draft/2020-12/schema",
+          "$comment":"generated",
+          "type":"object",
+          "properties":{"city":{"type":"string","$comment":"nested annotations too"}},
+          "required":["city"]
+        }}}]
+    })JSON";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+
+    // The request is accepted and the tool still renders with its real constraints intact.
+    // (The annotations themselves are passed through to the prompt today; they carry no
+    // constraints, so that is cosmetic rather than incorrect.)
+    const std::string prompt = apply_qwen36_tools_template(request, false);
+    CHECK(contains(prompt, "get_weather"));
+    CHECK(contains(prompt, "\"city\""));
+
+    // A non-string annotation is still a bad schema.
+    json bad = json::parse(body);
+    bad["tools"][0]["function"]["parameters"]["$schema"] = 7;
+    ChatRequest bad_request;
+    std::string bad_error;
+    CHECK(!parse_chat_request_json(bad.dump(), bad_request, bad_error));
+
+    // Structural "$" keywords stay refused: ignoring a $ref would validate against nothing.
+    for (const char* structural : {"$ref", "$defs", "$id"}) {
+        json refused = json::parse(body);
+        refused["tools"][0]["function"]["parameters"][structural] = "#/definitions/x";
+        ChatRequest refused_request;
+        std::string refused_error;
+        CHECK(!parse_chat_request_json(refused.dump(), refused_request, refused_error));
+    }
+    return true;
+}
+
 bool test_unicode_string_lengths() {
     const std::string body = R"JSON({
       "messages":[{"role":"user","content":"Send one character."}],
@@ -1648,6 +1692,7 @@ int main() {
     if (!test_schema_constraints()) return 1;
     if (!test_schema_pattern_is_linear_time()) return 1;
     if (!test_schema_unions_and_dynamic_properties()) return 1;
+    if (!test_schema_annotations_accepted()) return 1;
     if (!test_unicode_string_lengths()) return 1;
     if (!test_large_integer_bounds_are_exact()) return 1;
     if (!test_schema_keyword_type_applicability()) return 1;


### PR DESCRIPTION
Closes #972.

`valid_schema_node()` validates JSON Schema keys against a whitelist that omitted `"$schema"`, so any client emitting the draft identifier got a 400 on **every** tool-calling request:

```
tools[0].function.parameters contains unsupported field $schema
```

That is exactly what `@ai-sdk/openai-compatible` puts on every tool schema — Kilo and a good slice of the agent-framework ecosystem — so tool calling was simply unusable from those clients. Thanks @R-omk for the precise diagnosis; this is your suggested fix plus `$comment` and a test.

## What changed

`"$schema"` and `"$comment"` are **pure annotations** — a validator is required to ignore them — so accepting them is faithful rather than permissive. Both are still type-checked as strings, so a malformed schema stays an error.

**Structural `$` keywords are deliberately still refused.** Silently ignoring a `$ref` would validate the model's arguments against nothing at all, which is worse than rejecting the request outright.

## Verified against the built server

```
# the reporter's request
HTTP 200
  tool_calls: [{"function": {"arguments": "{\"city\":\"Paris\"}", "name": "get_weather"}, ...}]

# structural keyword, unchanged
HTTP 400
  tools[0].function.parameters contains unsupported field $ref
```

`chat_tools_test` passes, including a new `test_schema_annotations_accepted` covering: acceptance with `$schema`/`$comment` at both top level and nested in a property, a non-string annotation still being rejected, and `$ref`/`$defs`/`$id` still being refused.

## Note for a possible follow-up

Annotations are currently **forwarded verbatim** into the rendered tool block, so a schema-dialect URL reaches the model as a few tokens of noise. I tried stripping them here and backed it out: it is cosmetic rather than incorrect, and it widened the diff beyond the reported bug. Worth doing separately if anyone cares about the wasted context.