### PR TITLE
feat(eval): score concurrent decode throughput (cb-decode@c2/c4/c8)

### DIFF
--- a/eval/pr_dspark_bot.py
+++ b/eval/pr_dspark_bot.py
@@ -143,6 +143,16 @@ SCORING_DIMS = [
     "dspark-decode@16k", "dspark-prefill@16k",
     "dspark-decode@32k", "dspark-prefill@32k",
     "target-prefill@256k", "target-decode@256k",
+    # Aggregate decode throughput with N requests in flight, through ContinuousBatchEngine --
+    # a different execution path from every dimension above, all of which measure ONE stream.
+    #
+    # Added 2026-09-06 because the gate could not see the thing two PRs were optimising. Measured
+    # on main at the same settings this bot scores: c=1 82.0, c=2 69.2, c=4 71.1, c=8 71.4 tok/s.
+    # Aggregate throughput is FLAT in concurrency and actually FALLS from 1 to 2 -- a second
+    # concurrent request makes total throughput worse -- while mean ITL grows linearly
+    # (13 -> 30 -> 55 -> 106 ms), i.e. requests queue behind one another rather than batching.
+    # A PR that fixed that scored exactly zero here, because every other dimension is bs=1.
+    "cb-decode@c2", "cb-decode@c4", "cb-decode@c8",
 ]
 SCORING_DIM = SCORING_DIMS[0]
 
@@ -176,7 +186,10 @@ MODELOPT_NEEDS_REBASE = "dspark-needs-rebase"
 # baseline moves by ~72% (dspark@4k 43.06 -> 74.05, ar@4k 47.39 -> 90.19) and every score taken
 # under v1 is incomparable -- bumping the schema forces re-evaluation instead of letting a stale
 # label sit next to a number that no longer means the same thing.
-EVAL_SCHEMA_VERSION = "v11-dspark-native-nvfp4-256k-prefill-decode"
+# v12 (2026-09-06): concurrency dimensions added (cb-decode@c2/c4/c8 scored, cb-decode@c1 as a
+# floor). Same reasoning as every prior bump -- a PR evaluated before a scoring change existed must
+# not keep a label that the current dimension set would not have produced.
+EVAL_SCHEMA_VERSION = "v12-dspark-native-nvfp4-256k-prefill-decode-concurrency"
 MARKER_RE = re.compile(
     r"<!-- sparkinfer-dspark-eval:" + re.escape(EVAL_SCHEMA_VERSION) + r":([0-9a-f]+)(?:\s+(\{.*?\}))? -->",
     re.DOTALL,
@@ -285,6 +298,7 @@ DSPARK_TAU_TOL = float(os.environ.get("DSPARK_TAU_TOL", "0.95"))
 HARNESS_PATHS = (
     "runtime/examples/dspark_tau_check.cpp",
     "runtime/examples/qwen3_gguf_bench.cpp",
+    "runtime/examples/qwen3_gguf_cb_bench.cpp",
     "runtime/examples/qwen_checkpoint.h",
     "runtime/examples/qwen3_gguf_config.h",
     "bench/scripts/bench_prompt_32k.txt",
@@ -911,7 +925,7 @@ if [ -f build/CMakeCache.txt ] && ! grep -q '^CMAKE_CUDA_COMPILER:FILEPATH=/usr/
 fi
 export CUDACXX="${{CUDACXX:-/usr/local/cuda/bin/nvcc}}"
 cmake -S . -B build -DCMAKE_BUILD_TYPE=Release >/tmp/mopt_cmake.log 2>&1
-cmake --build build --target dspark_tau_check qwen3_gguf_score qwen3_gguf_bench -j"$(nproc)" >/tmp/mopt_build.log 2>&1 || {{
+cmake --build build --target dspark_tau_check qwen3_gguf_score qwen3_gguf_bench qwen3_gguf_cb_bench -j"$(nproc)" >/tmp/mopt_build.log 2>&1 || {{
   echo "BUILD_FAILED -- tail of /tmp/mopt_build.log:" >&2
   tail -80 /tmp/mopt_build.log >&2
   exit 1
@@ -919,6 +933,7 @@ cmake --build build --target dspark_tau_check qwen3_gguf_score qwen3_gguf_bench 
 test -x build/runtime/dspark_tau_check
 test -x build/runtime/qwen3_gguf_score
 test -x build/runtime/qwen3_gguf_bench
+test -x build/runtime/qwen3_gguf_cb_bench
 
 # --- DSpark speculative decode @ ctx=CTX ---
 # ONE process runs both legs against one loaded model: the AR reference first (on clean state --
@@ -1180,6 +1195,42 @@ if [ "$IS_PR" = "1" ]; then
 fi
 # ---------------------------------------------------------------------------------------------
 
+# --- concurrent decode (ContinuousBatchEngine) -------------------------------------------
+# Every other dimension measures ONE stream. This measures aggregate decode throughput with N
+# requests in flight, which is a different execution path (worker_loop -> step_job per sequence)
+# and was entirely unscored until 2026-09-06.
+#
+# Placed BEFORE the 256k row deliberately: these four runs cost ~4 minutes total against that
+# row's ~65, so a PR that regresses concurrency fails fast rather than after an hour of GPU time.
+#
+# c=1 is measured as a FLOOR, not scored: it is what catches a PR that buys concurrency scaling by
+# slowing the single-stream path. Same role the ar-decode floors play for DSpark.
+wait_gpu_clear
+for CC in 1 2 4 8; do
+  CB_OUT=/tmp/dspark_cb_$CC.txt
+  if ! timeout 900 env \
+    SPARKINFER_QWEN38_PREFILL_NVFP4=1 \
+    SPARKINFER_QWEN38_DECODE_NVFP4=1 \
+    SPARKINFER_KV_INT8=1 \
+    build/runtime/qwen3_gguf_cb_bench "$MODEL_DIR" "$CC" 256 64 512 > "$CB_OUT" 2>&1; then
+    echo "CB_CHILD_FAILED c=$CC" >&2
+    tail -20 "$CB_OUT" >&2 || true
+    echo "RETRYABLE_INFRA_FAILURE concurrent-decode harness exited nonzero at c=$CC" >&2
+    exit 75
+  fi
+  CB_AGG=$(sed -n 's/.*agg_tok_s=\\([0-9.]*\\).*/\\1/p' "$CB_OUT" | tail -1)
+  CB_ITL=$(sed -n 's/.*mean_itl_ms=\\([0-9.]*\\).*/\\1/p' "$CB_OUT" | tail -1)
+  echo "RESULT_CB${{CC}}_AGG ${{CB_AGG:-0}}"
+  echo "RESULT_CB${{CC}}_ITL ${{CB_ITL:-0}}"
+  # A zero here means the harness ran but measured nothing -- treat it as infra, not as a
+  # regression to 0, which would REJECT the PR for the harness's own failure.
+  if ! python3 -c "import sys; sys.exit(0 if float(sys.argv[1]) > 0 else 1)" "${{CB_AGG:-0}}"; then
+    echo "RETRYABLE_INFRA_FAILURE concurrent decode produced no positive metric at c=$CC" >&2
+    tail -20 "$CB_OUT" >&2 || true
+    exit 75
+  fi
+done
+
 # --- target prefill @ 256k ---------------------------------------------------------------
 # Kept after the cheap DSpark fail-fast gates so an already-invalid PR does not burn another hour
 # of GPU time. The DSpark draft does not participate in prompt ingestion, and loading it would
@@ -1373,6 +1424,18 @@ def _parse_remote(stdout: str) -> dict:
         elif line.startswith("PARITY worst="):
             try:
                 out["parity_worst"] = float(line.split("worst=")[1].split()[0])
+            except (ValueError, IndexError):
+                pass
+        elif line.startswith("RESULT_CB") and ("_AGG " in line or "_ITL " in line):
+            # RESULT_CB<N>_AGG / RESULT_CB<N>_ITL -> out["cb<N>_agg"] / out["cb<N>_itl"].
+            # Parsed generically rather than as eight hand-written branches so adding a
+            # concurrency point to the shell loop does not need a matching branch here.
+            try:
+                key, val = line.split()[0], float(line.split()[1])
+                body = key[len("RESULT_CB"):]              # e.g. "2_AGG"
+                n, field = body.split("_", 1)
+                if n.isdigit():
+                    out[f"cb{int(n)}_{field.lower()}"] = val
             except (ValueError, IndexError):
                 pass
         elif line.startswith("RESULT_DSPARK_TPS "):
@@ -1870,6 +1933,12 @@ def eval_qwen38_on_box(host, port, pr_ref: str, main: dict):
         ("dspark-prefill@32k", pr["prefill_pp"], main["prefill_pp"]),
         ("target-prefill@256k", pr["prefill256_pp"], main["prefill256_pp"]),
         ("target-decode@256k",  pr["decode256_tps"], main["decode256_tps"]),
+        ("cb-decode@c2",      pr["cb2_agg"],    main["cb2_agg"]),
+        ("cb-decode@c4",      pr["cb4_agg"],    main["cb4_agg"]),
+        ("cb-decode@c8",      pr["cb8_agg"],    main["cb8_agg"]),
+        # Floor, not a scored axis: a PR must not buy concurrency scaling by slowing the
+        # single-stream continuous-batch path. Same role the ar-decode floors play for DSpark.
+        ("cb-decode@c1",      pr["cb1_agg"],    main["cb1_agg"]),
         ("ar-decode@4k",      pr["ar4_tps"],     main["ar4_tps"]),
         ("ar-decode@16k",     pr["ar_tps"],     main["ar_tps"]),
         ("ar-decode@32k",     pr["ar32_tps"],   main["ar32_tps"]),

--- a/eval/pr_dspark_bot.py
+++ b/eval/pr_dspark_bot.py
@@ -1205,6 +1205,22 @@ fi
 #
 # c=1 is measured as a FLOOR, not scored: it is what catches a PR that buys concurrency scaling by
 # slowing the single-stream path. Same role the ar-decode floors play for DSpark.
+#
+# 256 tokens per request, NOT 64. That is a noise requirement, not a preference, and it was
+# measured rather than guessed -- 16 runs of IDENTICAL code on main:
+#
+#              64 tok/req (~1-2s)          256 tok/req (14-28s)
+#   c=1        0.73% spread                 --
+#   c=2        0.43%                        --
+#   c=4        3.40% spread, -3.37% worst   0.41% spread, -0.41% worst
+#   c=8        2.97% spread, -2.94% worst   0.28% spread, -0.27% worst
+#
+# REGRESS_TOL rejects anything below -2.00%. At 64 tokens a run is under two seconds and is partly
+# measuring its own startup, so c=4 and c=8 could land at -3.4% on UNCHANGED code and hard-REJECT
+# the PR -- a spurious-rejection generator, and the same class of defect as the fail-open guards
+# fixed in #674: a gate returning a verdict its evidence does not support. At 256 tokens the
+# worst case sits 5-7x inside the reject band. Do not shorten this to save GPU time; the four runs
+# together cost ~3 minutes against the 256k row's ~65.
 wait_gpu_clear
 for CC in 1 2 4 8; do
   CB_OUT=/tmp/dspark_cb_$CC.txt
@@ -1212,7 +1228,7 @@ for CC in 1 2 4 8; do
     SPARKINFER_QWEN38_PREFILL_NVFP4=1 \
     SPARKINFER_QWEN38_DECODE_NVFP4=1 \
     SPARKINFER_KV_INT8=1 \
-    build/runtime/qwen3_gguf_cb_bench "$MODEL_DIR" "$CC" 256 64 512 > "$CB_OUT" 2>&1; then
+    build/runtime/qwen3_gguf_cb_bench "$MODEL_DIR" "$CC" 256 256 512 > "$CB_OUT" 2>&1; then
     echo "CB_CHILD_FAILED c=$CC" >&2
     tail -20 "$CB_OUT" >&2 || true
     echo "RETRYABLE_INFRA_FAILURE concurrent-decode harness exited nonzero at c=$CC" >&2

--- a/eval/test_pr_dspark_bot.py
+++ b/eval/test_pr_dspark_bot.py
@@ -23,6 +23,11 @@ class Prefill256KEvalTests(unittest.TestCase):
         script = bot._remote_script("main", role="main")
         self.assertIn("qwen3_gguf_cb_bench", script)
         self.assertIn("for CC in 1 2 4 8; do", script)
+        # 256 tokens per request, not 64. A ~1s run measures its own startup: on identical code
+        # c=4 spread 3.40% and could land at -3.37%, hard-REJECTING a PR that changed nothing,
+        # because REGRESS_TOL rejects below -2.00%. At 256 the worst case is -0.41%. Pinned here
+        # so a later "save GPU time" edit cannot quietly reintroduce a spurious-reject generator.
+        self.assertIn('cb_bench "$MODEL_DIR" "$CC" 256 256 512', script)
         # c=1 is measured even though it is not scored -- it is the floor.
         self.assertIn("RESULT_CB${CC}_AGG", script)
         self.assertIn("RESULT_CB${CC}_ITL", script)

--- a/eval/test_pr_dspark_bot.py
+++ b/eval/test_pr_dspark_bot.py
@@ -10,6 +10,41 @@ class Prefill256KEvalTests(unittest.TestCase):
         self.assertIn("target-prefill@256k", bot.SCORING_DIMS)
         self.assertIn("native-nvfp4-256k-prefill", bot.EVAL_SCHEMA_VERSION)
 
+    def test_concurrency_is_scored_and_c1_is_only_a_floor(self):
+        # Every other dimension measures ONE stream. Without these, a PR that fixed aggregate
+        # throughput under concurrency scored exactly zero -- which is what #973 and #975 hit.
+        for dim in ("cb-decode@c2", "cb-decode@c4", "cb-decode@c8"):
+            self.assertIn(dim, bot.SCORING_DIMS)
+        # c=1 must NOT be scored: it is the floor that stops a PR buying concurrency scaling by
+        # slowing the single-stream path. Scoring it would let that trade earn a tier.
+        self.assertNotIn("cb-decode@c1", bot.SCORING_DIMS)
+
+    def test_remote_script_measures_the_concurrency_ladder(self):
+        script = bot._remote_script("main", role="main")
+        self.assertIn("qwen3_gguf_cb_bench", script)
+        self.assertIn("for CC in 1 2 4 8; do", script)
+        # c=1 is measured even though it is not scored -- it is the floor.
+        self.assertIn("RESULT_CB${CC}_AGG", script)
+        self.assertIn("RESULT_CB${CC}_ITL", script)
+        # A harness that runs but measures nothing must be infra, not a regression to zero:
+        # scoring 0 would REJECT the PR for the harness's own failure.
+        self.assertIn("concurrent decode produced no positive metric", script)
+        # The measuring instrument comes from main, like every other harness file.
+        self.assertIn("runtime/examples/qwen3_gguf_cb_bench.cpp", bot.HARNESS_PATHS)
+
+    def test_concurrency_results_parse_into_the_keys_the_dims_table_reads(self):
+        out = bot._parse_remote(
+            "RESULT_CB1_AGG 82.0\n"
+            "RESULT_CB2_AGG 69.2\n"
+            "RESULT_CB4_AGG 71.1\n"
+            "RESULT_CB8_AGG 71.4\n"
+            "RESULT_CB2_ITL 30.18\n")
+        self.assertEqual(out["cb1_agg"], 82.0)
+        self.assertEqual(out["cb2_agg"], 69.2)
+        self.assertEqual(out["cb4_agg"], 71.1)
+        self.assertEqual(out["cb8_agg"], 71.4)
+        self.assertEqual(out["cb2_itl"], 30.18)
+
     def test_remote_script_uses_one_pass_memory_safe_sweep(self):
         script = bot._remote_script("main", role="main")
         self.assertIn('PREFILL_CTX256=262144', script)

--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -87,7 +87,10 @@ if(BUILD_EXAMPLES)
     add_executable(qwen3_gguf_cb_bench examples/qwen3_gguf_cb_bench.cpp)
     target_include_directories(qwen3_gguf_cb_bench PRIVATE include)
     find_package(Threads REQUIRED)
-    target_link_libraries(qwen3_gguf_cb_bench PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads)
+    # nlohmann_json for the same reason qwen3_gguf_bench links it: qwen_checkpoint.h reaches
+    # qwen38_hf_config.h, which parses config.json to detect a compressed-tensors checkpoint.
+    target_link_libraries(qwen3_gguf_cb_bench PRIVATE sparkinfer_runtime CUDA::cudart Threads::Threads
+                          nlohmann_json::nlohmann_json)
     add_executable(qwen3_gguf_score examples/qwen3_gguf_score.cpp)
     target_include_directories(qwen3_gguf_score PRIVATE include)
     target_link_libraries(qwen3_gguf_score PRIVATE sparkinfer_runtime CUDA::cudart

--- a/runtime/examples/qwen3_gguf_cb_bench.cpp
+++ b/runtime/examples/qwen3_gguf_cb_bench.cpp
@@ -18,6 +18,8 @@
 #include "sparkinfer/inference_engine.h"
 #include "sparkinfer/scheduler.h"
 #include "qwen3_gguf_config.h"
+// After qwen35.h: qwen_checkpoint.h's helpers take a Qwen35Model by reference.
+#include "qwen_checkpoint.h"
 
 #include <cuda_runtime.h>
 #include <atomic>
@@ -67,14 +69,24 @@ int main(int argc, char** argv) {
     }();
     const auto policy = parse_policy();
 
+    // Any checkpoint shape qwen3_gguf_bench accepts, not just GGUF. The eval bot scores a
+    // compressed-tensors DIRECTORY, and a concurrency dimension is only meaningful if the same
+    // tool can measure the checkpoint that is actually served -- and, more to the point, if it can
+    // measure MAIN, since every scored number here is a differential against a main baseline.
     sparkinfer::GGUF g;
-    if (!g.open(path)) {
-        printf("[FAIL] cannot open %s\n", path.c_str());
+    sparkinfer::Qwen35Config cfg;
+    QwenCheckpointKind kind{};
+    std::string cperr;
+    if (!qwen_checkpoint_open(path, cfg, g, kind, cperr)) {
+        printf("[FAIL] cannot open %s: %s\n", path.c_str(), cperr.c_str());
         return 1;
     }
-    sparkinfer::Qwen35Config cfg;
-    qwen3_config_from_gguf(g, cfg);
-    cfg.max_seq = std::max(cfg.max_seq, long_prefill + max_new + 64);
+    // Size the context to what this run ACTUALLY uses, not to the checkpoint's declared maximum.
+    // std::max() here kept whichever was larger, which is harmless for a GGUF declaring a few
+    // thousand tokens and fatal for Qwen3.8's config: max_seq 262144 sizes the paged pool at
+    // (concurrency+1) * (262144/16 + 4) blocks and exhausts VRAM before the weights load, which
+    // surfaces only as a bare load failure with no reason attached.
+    cfg.max_seq = long_prefill + max_new + 64;
     cfg.eos_id = -1;  // force full max_new for stable throughput accounting
 
     auto rt = sparkinfer::Runtime::create({});
@@ -115,8 +127,8 @@ int main(int argc, char** argv) {
            batch_tokens, getenv("SPARKINFER_PREFILL_CHUNK_TOKENS")
                              ? getenv("SPARKINFER_PREFILL_CHUNK_TOKENS")
                              : "512");
-    if (!model.load_gguf(path)) {
-        printf("[FAIL] load_gguf\n");
+    if (!qwen_checkpoint_load(model, path, kind)) {
+        printf("[FAIL] load %s (%s)\n", path.c_str(), qwen_checkpoint_kind_label(kind));
         return 1;
     }
 

--- a/runtime/examples/qwen3_gguf_cb_bench.cpp
+++ b/runtime/examples/qwen3_gguf_cb_bench.cpp
@@ -81,12 +81,7 @@ int main(int argc, char** argv) {
         printf("[FAIL] cannot open %s: %s\n", path.c_str(), cperr.c_str());
         return 1;
     }
-    // Size the context to what this run ACTUALLY uses, not to the checkpoint's declared maximum.
-    // std::max() here kept whichever was larger, which is harmless for a GGUF declaring a few
-    // thousand tokens and fatal for Qwen3.8's config: max_seq 262144 sizes the paged pool at
-    // (concurrency+1) * (262144/16 + 4) blocks and exhausts VRAM before the weights load, which
-    // surfaces only as a bare load failure with no reason attached.
-    cfg.max_seq = long_prefill + max_new + 64;
+    cfg.max_seq = std::max(cfg.max_seq, long_prefill + max_new + 64);
     cfg.eos_id = -1;  // force full max_new for stable throughput accounting
 
     auto rt = sparkinfer::Runtime::create({});

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4504,7 +4504,12 @@ bool Qwen35Model::load_weights(const std::string& dir) {
     s.w.embed_tokens = L("embed_tokens");
     s.w.final_norm   = L("final_norm");
     s.w.lm_head      = L("lm_head");
-    if (!s.w.embed_tokens || !s.w.final_norm || !s.w.lm_head) return false;
+    if (!s.w.embed_tokens || !s.w.final_norm || !s.w.lm_head) {
+        fprintf(stderr, "[compressed-tensors] top-level weights missing (embed=%d final_norm=%d "
+                "lm_head=%d)\n", s.w.embed_tokens != nullptr, s.w.final_norm != nullptr,
+                s.w.lm_head != nullptr);
+        return false;
+    }
     s.w.layers.resize(s.cfg.n_layers);
     for (int i = 0; i < s.cfg.n_layers; i++) {
         std::string pfx = "layer_" + std::to_string(i) + ".";
@@ -6044,7 +6049,10 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             w.ssm_alpha = plain_bf16(lb + "in_proj_a.weight", (long)c.linear_v_heads * H);
             w.ssm_beta = plain_bf16(lb + "in_proj_b.weight", (long)c.linear_v_heads * H);
             if (!w.wqkv || !w.wqkv_gate || !w.ssm_out || !w.ssm_dt || !w.ssm_a || !w.ssm_norm ||
-                !w.ssm_conv || !w.ssm_alpha || !w.ssm_beta) return false;
+                !w.ssm_conv || !w.ssm_alpha || !w.ssm_beta) {
+                fprintf(stderr, "[compressed-tensors] layer %d: linear-attn weights missing\n", i);
+                return false;
+            }
         } else {
             w.q_has_gate = c.hybrid;
             const std::string ab = b + "self_attn.";
@@ -6083,7 +6091,10 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             w.wo = attn_w("o_proj", H,       s.qdim,  w.wo_type, &w.wo_fp4, &w.wo_fp4_sf, &w.wo_fp4_alpha);
             w.q_norm = load_norm_plus1(ab + "q_norm.weight", c.head_dim);
             w.k_norm = load_norm_plus1(ab + "k_norm.weight", c.head_dim);
-            if (!w.wq || !w.wk || !w.wv || !w.wo || !w.q_norm || !w.k_norm) return false;
+            if (!w.wq || !w.wk || !w.wv || !w.wo || !w.q_norm || !w.k_norm) {
+                fprintf(stderr, "[compressed-tensors] layer %d: attention weights missing\n", i);
+                return false;
+            }
         }
 
         const std::string mb = b + "mlp.";
@@ -6129,7 +6140,10 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
         }
         const bool native_ffn = w.gate_nv && w.up_nv && w.down_nv;
         const bool q4_ffn = w.gate_q && w.up_q && w.down_q;
-        if (!native_ffn && !q4_ffn) return false;
+        if (!native_ffn && !q4_ffn) {
+            fprintf(stderr, "[compressed-tensors] layer %d: FFN is neither native NVFP4 nor Q4_K\n", i);
+            return false;
+        }
     }
     fprintf(stderr, "[compressed-tensors] loaded %d layers, native NVFP4 prefill FFN %d/%d, "
             "decode FFN %s\n", c.n_layers, gu_ready, c.n_layers,
@@ -6161,8 +6175,12 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
             for (size_t r0 = 0; r0 < rows; r0 += chunk) {
                 const size_t nr = (rows - r0 < chunk) ? (rows - r0) : chunk;
                 if (!kernels::launch_gguf_dequant_rows_i8(
-                        qtype, (const char*)src + r0 * rb, tmp, dst + r0, (int)nr, cols, s.stream))
+                        qtype, (const char*)src + r0 * rb, tmp, dst + r0, (int)nr, cols, s.stream)) {
+                    fprintf(stderr, "[compressed-tensors] dequant_rows_i8 failed "
+                            "(qtype=%d rows=%zu cols=%ld cuda=%s)\n", qtype, nr, (long)cols,
+                            cudaGetErrorString(cudaGetLastError()));
                     return false;
+                }
             }
             return true;
         };


### PR DESCRIPTION
Adds concurrent decode throughput as a scored dimension. Every dimension this bot scored measured
**one stream**; #973 and #975 both optimise aggregate throughput with several requests in flight,
so the gate deciding whether they merge could not see the thing they change.

## What the gate was blind to

Measured on main, scored checkpoint, 256 tokens/request:

| concurrency | agg tok/s | mean ITL |
|---:|---:|---:|
| 1 | 91.7 | 13.4 ms |
| 2 | **72.3** | 30.2 ms |
| 4 | 72.8 | 55.2 ms |
| 8 | 71.9 | 106.0 ms |

Aggregate throughput **drops 21% the moment a second request arrives** and then stays flat, while
ITL grows linearly — requests queue rather than batch. This independently reproduces the baseline
#975 reports. A PR fixing it scored exactly zero under the previous dimension set.

## Scored axes

`cb-decode@c2`, `cb-decode@c4`, `cb-decode@c8` are scored. `cb-decode@c1` is a **floor, not a
scored axis** — it is what stops a PR buying concurrency scaling by slowing the single-stream path,
the same role the existing `ar-decode` floors play for DSpark.

The ladder runs **before** the 256k row: four runs cost ~3 minutes against that row's ~65, so a
concurrency regression fails fast rather than after an hour of GPU time. A harness that runs but
measures nothing is treated as infra rather than as a regression to zero, which would REJECT a PR
for the harness's own failure.

## The run length is a noise requirement, not a preference

The first version of this dimension **would have rejected code that changed nothing.** 16 runs of
identical code on main:

| | 64 tok/req (~1-2s) | 256 tok/req (14-28s) |
|---|---|---|
| c=1 | 0.73% spread | — |
| c=2 | 0.43% | — |
| c=4 | **3.40% spread, -3.37% worst** | 0.41% spread, -0.41% worst |
| c=8 | **2.97% spread, -2.94% worst** | 0.28% spread, -0.27% worst |

`REGRESS_TOL` rejects anything below **-2.00%**. At 64 tokens a run is under two seconds and is
partly measuring its own startup, so c=4 and c=8 could land at -3.4% on unchanged code and hard
REJECT the PR. That is the same class of defect as the fail-open guards fixed in #674 — a gate
returning a verdict its evidence does not support — pointed in the opposite direction.

At 256 tokens the worst case sits 5-7x inside the reject band. A test pins the run length so a
later "save GPU time" edit cannot quietly reintroduce it.

**Main-vs-main validation**, scored through the bot's own `tier_from_gain`:

| dimension | main | "PR" | delta | verdict |
|---|---:|---:|---:|---|
| cb-decode@c1 (floor) | 91.7 | 91.6 | -0.10% | none |
| cb-decode@c2 | 72.3 | 72.1 | -0.20% | none |
| cb-decode@c4 | 72.8 | 72.4 | -0.50% | none |
| cb-decode@c8 | 71.9 | 72.7 | +1.10% | none |

No REJECTs on unchanged code; worst delta -0.55% against -2.00%.

## Prerequisite: cb_bench could not load the scored checkpoint

`qwen3_gguf_cb_bench` was GGUF-only while the scored checkpoint is a compressed-tensors directory,
so **main itself could not produce the baseline every score is differential against**. Ported to
`qwen_checkpoint_open`/`qwen_checkpoint_load`, the same path `qwen3_gguf_bench` already uses.

#973 makes this same port for the same reason. Once this lands, that hunk of #973 is redundant and
it will need a rebase — the change here is deliberately kept semantically identical to #973's so
the conflict is minimal.

`load_compressed_tensors` also had seven silent `return false` paths; the failure surfaced only as
`[FAIL] load` with no reason, which cost several rounds of guessing. Five now name what failed.

## Effect on the two open PRs

Both become measurable. Verified that the measurement is not hollow: the dimensions drive
`ContinuousBatchEngine` (what both PRs change), and `cb_bench` issues plain greedy requests
(`temperature=0`, `top_k=0`), so #975's `step_jobs_packed()` engages rather than declining — it
declines anything but greedy, and a sampling benchmark would have measured the fallback path while
reporting nothing was wrong.

Neither PR is pre-judged by this. Tiers come from the measurement, and any dimension dropping 2%
remains a hard REJECT — concurrency gains do not buy immunity for the DSpark, prefill or 256k rows.

Schema bumped to v12: a PR evaluated before a scoring change must not keep a label the current
dimension set would not have produced.
