### PR TITLE
docs(readme): show DSpark across contexts, not just its worst case

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,21 @@ by pessimising the other.
 
 Qwen3.8-27B also ships a **DSpark** draft — a five-layer semi-autoregressive block drafter that
 proposes a block per step and has the target verify it in one batched pass, so accepting *k*
-tokens costs one target forward instead of *k*:
+tokens costs one target forward instead of *k*.
+
+Across contexts, on the committed workload corpus (`bench/scripts/workloads.py`, 128-token
+outputs, greedy, batch 1, best of 3), against the autoregressive baseline measured in the same
+process and model load:
+
+| | 4K | 16K | 32K |
+|---|---:|---:|---:|
+| **mean speedup over AR** | **4.01×** | **2.97×** | **2.63×** |
+| AR reference | 91.0 tok/s | 86.4 | 81.3 |
+
+Speculative throughput depends almost entirely on how predictable the generated text is, so a
+single number is misleading in either direction. The gated regression check below runs the
+*hardest* case — long-context prose at 16k, where acceptance is lowest — and is the figure that
+must not regress:
 
 <!-- BENCH:qwen38-dspark:start -->
 
@@ -87,6 +101,9 @@ tokens costs one target forward instead of *k*:
 
 <sub>Auto-refreshed by the DSpark eval bot at `b819f2fef` — these are the numbers that PR measured on the pinned RTX 5090, which after squash-merge are main's. Regenerated on every auto-merge, so the table cannot drift behind the code.</sub>
 <!-- BENCH:qwen38-dspark:end -->
+
+The two tables measure different corpora, which is the whole point: 4.01× on a mixed workload at
+4k and 1.474× on long-context prose at 16k are both true. Quote the range, not a single figure.
 
 Speculation only pays when the verify costs less than what it replaces:
 `speedup ≈ τ / (verify cost + draft cost)`, both in target forwards. That is why τ alone is not the


### PR DESCRIPTION
The DSpark section led with a single auto-refreshed row:

| context | DSpark decode | AR decode | speedup | mean accepted (τ) |
|---:|---:|---:|---:|---:|
| 16k | 130.6 tok/s | 88.6 tok/s | **1.474×** | 1.730 |

That reads as *"this is what speculation buys"*, when it is actually the **hardest** case the eval runs — long-context prose at 16k, where acceptance is lowest. Meanwhile v0.5.5's notes publish **4.01× / 2.97× / 2.63×** at 4K / 16K / 32K on the committed workload corpus. So the README was understating the feature by roughly 2.7× while the release notes said something different — the kind of inconsistency a reader notices and distrusts.

## Change

Adds the across-context table **above** the gated one, and reframes the auto-refreshed row as what it is: the regression check on the worst case, the figure that must not slip.

Closes with the point that matters:

> The two tables measure different corpora, which is the whole point: 4.01× on a mixed workload at 4k and 1.474× on long-context prose at 16k are both true. Quote the range, not a single figure.

The existing sub-note already warned that speculative throughput depends on text predictability; now there are numbers behind that warning instead of one figure that happens to sit at the bottom of the range.

## Bot ownership preserved

The `<!-- BENCH:qwen38-dspark -->` markers and everything between them are **untouched**, so the eval bot keeps refreshing that table on every auto-merge and it still cannot drift behind the code.