### PR TITLE
fix(prefill): write the GQA P' plane with the stride it is read with (#976)

### DIFF
--- a/bench/scripts/long_context_determinism_check.py
+++ b/bench/scripts/long_context_determinism_check.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Long-context greedy decode must be CORRECT and REPRODUCIBLE (issue #976).
+
+The accuracy smoke this repo already runs works at short context -- which is precisely the regime
+that still worked while #976 was live. The fused GQA prefill attention wrote its P' plane with row
+stride GN while allocating and reading it with pld; below 2048 tokens pad==0 so the two agreed, and
+at or above 2048 every row was read shifted by 16r with the last row reading past all initialised
+shared memory. Output was simultaneously wrong and nondeterministic, and nothing in CI could see it.
+
+So this asks the narrowest question that would have caught it: one arithmetic question with an
+unambiguous answer, a growing natural-prose prefix, N greedy runs at each depth. Two assertions,
+and the second is the one that matters -- greedy decode must be a function of its input:
+
+  1. every run at every depth answers correctly
+  2. the runs at a given depth are IDENTICAL to each other
+
+A correctness-only check would pass on a build that is stably wrong; a determinism-only check
+would pass on a build that is consistently garbage. Both are needed.
+
+Usage:
+  python3 bench/scripts/long_context_determinism_check.py --base-url http://127.0.0.1:8080
+"""
+import argparse, json, sys, urllib.request
+
+# Deliberately trivial arithmetic: the answer is not in dispute, so any deviation is the engine's.
+QUESTION = "What is 17 multiplied by 23? Reply with only the number."
+ANSWER = "391"
+
+
+def ask(base_url, prose, max_tokens, timeout):
+    body = json.dumps({
+        "model": "q", "max_tokens": max_tokens, "temperature": 0.0,
+        "enable_thinking": False,
+        "messages": [{"role": "user", "content": (prose + "\n\n" + QUESTION) if prose else QUESTION}],
+    }).encode()
+    req = urllib.request.Request(base_url.rstrip("/") + "/v1/chat/completions",
+                                 data=body, headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as r:
+        d = json.load(r)
+    if "error" in d:
+        raise RuntimeError(json.dumps(d["error"])[:200])
+    msg = d["choices"][0]["message"]
+    return (msg.get("content") or "").strip(), d.get("usage", {}).get("prompt_tokens", 0)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base-url", default="http://127.0.0.1:8080")
+    ap.add_argument("--corpus", default="bench/scripts/bench_prompt_32k.txt")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--max-tokens", type=int, default=24)
+    ap.add_argument("--timeout", type=float, default=900.0)
+    # Prefix lengths in CHARACTERS. The defaults straddle the 2048-token cliff #976 lived at:
+    # one clearly below, then several above, since a check that only probes the working regime is
+    # exactly the hole this closes.
+    ap.add_argument("--chars", default="0,8000,30000,90000,200000")
+    args = ap.parse_args()
+
+    try:
+        corpus = open(args.corpus).read()
+    except OSError as e:
+        print(f"cannot read corpus: {e}")
+        return 2
+
+    failures = 0
+    for spec in [int(c) for c in args.chars.split(",")]:
+        prose = corpus[:spec]
+        outs = []
+        toks = 0
+        for _ in range(args.runs):
+            try:
+                text, toks = ask(args.base_url, prose, args.max_tokens, args.timeout)
+            except Exception as e:                      # noqa: BLE001 -- report, do not abort the sweep
+                print(f"  chars={spec:<7} REQUEST FAILED: {e}")
+                failures += 1
+                outs = None
+                break
+            outs.append(text)
+        if outs is None:
+            continue
+
+        stable = len(set(outs)) == 1
+        # Substring, not equality: a correct engine may legitimately answer "391" or "391." etc.
+        correct = all(ANSWER in o for o in outs)
+        status = "OK" if (stable and correct) else ("WRONG" if stable else "FLAKY")
+        print(f"  chars={spec:<7} tokens={toks:<7} {status:<6} " +
+              " | ".join(repr(o[:26]) for o in outs))
+        if not (stable and correct):
+            failures += 1
+
+    print()
+    if failures:
+        print(f"FAILED — {failures} depth(s) wrong or nondeterministic")
+        print("Greedy decode must be a function of its input; see issue #976.")
+        return 1
+    print("PASSED — every depth is correct and reproducible")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -673,7 +673,21 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (GROUP_BLKS >= 16 ? 1 : (RQH <= 3 
             // wrote. The shipped tiers keep that byte for byte -- it is their numerics and there
             // is nothing to gain by moving them -- but the new tier is new code and is written
             // the way the sibling already does it.
-            const int pstr = (SPL == RQH) ? GN : pld;
+            // pld, unconditionally. The plane is ALLOCATED with a pld row stride (s_pi is
+            // [RQH][BM][pld], and s_s starts at s_pi + RQH*BM*pld) and every reader uses pld --
+            // the ldmatrix at the PV mma, and the base pointer above. Only this write used GN.
+            //
+            // Below 2048 tokens pad==0 so pld==GN and the two agreed, which is why this survived.
+            // At or above 2048 pad==16, so every row was written 16 columns short of where it is
+            // read: row r came back shifted by 16r, and the last row read past everything any row
+            // had written -- i.e. off the end of the initialised region, into whatever shared
+            // memory happened to hold. That is what made long-context output simultaneously WRONG
+            // and NONDETERMINISTIC under greedy decode (#976), with a cliff exactly at 2048.
+            //
+            // This was known and left in place as "their numerics". Reading uninitialised shared
+            // memory is not a numerics choice, so it is fixed rather than preserved -- it does
+            // move the shipped tiers' long-context prefill numbers, which is the honest cost.
+            const int pstr = pld;
             auto softmax_head = [&](auto FULLT, int h, int hp) {
                 constexpr bool FULL = decltype(FULLT)::value;
                 {


### PR DESCRIPTION
Fixes #976 — long-context greedy decode was simultaneously **wrong** and **nondeterministic** from
~2048 prompt tokens.

## Root cause

The fused GQA prefill attention **allocates** its P′ plane with a `pld` row stride (`s_pi` is
`[RQH][BM][pld]`, and `s_s` begins at `s_pi + RQH*BM*pld`) and **every reader uses `pld`** — the
`ldmatrix` feeding the PV mma, and the base pointer. Only the **write** used `GN`.

Below 2048 tokens `pad == 0`, so `pld == GN` and the two agreed — which is why this survived every
existing test. At or above 2048, `pad == 16`:

- each row is written 16 columns short of where it is read, so **row r comes back shifted by 16r**;
- the **last row reads past everything any row wrote**, off the end of the initialised region into
  whatever shared memory happened to hold.

Wrong output, run-to-run variation under greedy decode, and a cliff exactly at 2048 all follow from
that one mismatch. `pstr` is now `pld` unconditionally, matching the reader and the allocation.

## Triangulation, before fixing

At 6,812 prompt tokens on the released checkpoint, greedy, three runs each:

| path | result |
|---|---|
| batched prefill, default (RQH=4) | three **different** wrong answers |
| batched prefill, RQH=1 fallback | `391`, `391`, `391` |
| token-loop prefill | `391`, `391`, `391` |

After the fix, on **default settings** (no `DETERMINISTIC`, no `RQH` override):

| prompt tokens | before | after |
|---:|---|---|
| 1,800 | `391` ×3 | `391` ×3 |
| 6,812 | 3 different wrong answers | **`391` ×3** |
| 21,453 | flaky, wrong | **`391` ×3** |

## The cost, measured like-for-like

| | before | after | delta |
|---|---:|---:|---:|
| prefill@16k | 13577.49 pp/s | 13516.13 pp/s | **-0.45%** |
| prefill@32k | 11526.97 pp/s | 11504.38 pp/s | **-0.20%** |

## This was known, and the trade-off was never real

The comment above the `RQH` default already recorded the cliff, a measured KL table
(`0.00022` at 2000 → `0.18672` at 2100, "and varies run to run"), and the decision to keep the
fused tiers on because turning them off "moves the long-context prefill numbers the eval scores
against."

That reasoning was about **disabling GQA fusion**, which genuinely costs throughput. Nobody tried
**repairing the stride**, which keeps the fusion — and costs 0.2–0.45%. Reading uninitialised
shared memory is not "their numerics" either way.

The same comment says the defect "is reported separately". **No such issue was ever filed.** #976
came from an outside user two days later, having noticed that vLLM on the identical checkpoint
answered correctly at the same depths.

## Why CI could not see it

The accuracy smoke runs at short context — precisely the regime that still worked. Long context is
a headline claim for this engine (262,144 tokens on a 32 GB card, flat decode to 244k), and those
are throughput numbers; while this was live they described generating increasingly wrong text.

`bench/scripts/long_context_determinism_check.py` closes the hole: one arithmetic question with an
unambiguous answer, a growing natural-prose prefix, N greedy runs per depth, asserting **both**
that every answer is correct **and** that the runs at each depth are identical. Correctness alone
would pass a stably-wrong build; determinism alone would pass a consistently-garbage one. The
default depths straddle the 2048 cliff.
