### PR TITLE
fix(prefill): re-enable GQA fusion in deterministic mode, and correct its comment

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -1046,26 +1046,37 @@ bool launch_prefill_attn_mma(
     // GQA fusion: one block owns RQH q-heads sharing a kv-head, so each K page / V tile
     // is loaded once and fed RQH mma's instead of being re-read per q-head. RQH=1 disables.
     //
-    // DEFAULTS TO 1 (fusion off) IN DETERMINISTIC MODE. The GQA-fused tiers are both
-    // nondeterministic and materially INACCURATE once n_tokens passes ~2048 with int8 KV.
-    // Measured on an RTX 5090, Qwen3.6-35B-A3B (GQA-6), qwen3_gguf_prefill_check against the
-    // token-loop reference, mean KL over 16 teacher-forced positions:
+    // Fusion is ON by default, including in deterministic mode.
     //
-    //     prefix   1500      2000      2100      3000      4000
-    //     fused    0.00043   0.00022   0.18672   0.20657   0.23978   <- and varies run to run
-    //     RQH=1    ~0.0001   ~0.0001   ~0.0001   ~0.0001   0.00008   <- stable
+    // This used to default to 1 (fusion off) under deterministic_mode(), because the GQA-fused
+    // tiers were both nondeterministic and materially inaccurate above ~2048 tokens with int8 KV.
+    // That was real, and it was a stride bug, not a property of fusion: the P' plane was written
+    // with row stride GN while being allocated and read with pld. The two agree only while pad==0,
+    // i.e. below 2048 -- above it every row was read shifted by 16r and the last row read past all
+    // initialised shared memory. Fixed by writing with pld (#976 / PR #980).
     //
-    // The cliff is exactly at 2048 and it is not the RQH=3 tier's `n_tokens >= 2048` gate:
-    // RQH=2 is selected both below and above it and is equally wrong above, so the length
-    // dependence lives inside launch_attn_gqa itself. Only RQH=1, which skips the fused family
-    // for the per-q-head fallback, is correct there. That is a PRE-EXISTING defect independent of
-    // this mode -- it is the default serving path today, and the server enables int8 KV whenever
-    // max_seq >= 4096 -- and it is left ON by default here rather than silently changed, because
-    // turning it off moves the long-context prefill numbers the eval scores against. It is
-    // reported separately; deterministic mode simply refuses to build on top of it.
+    // Re-measured after that fix, Qwen3.8-27B ModelOpt NVFP4, int8 KV, qwen3_gguf_prefill_check
+    // against the token-loop reference on REAL token ids from bench/scripts/bench_prompt_32k.txt
+    // (the tool's synthetic default labels itself "NOISY -- smoke test only" and cannot resolve
+    // differences this small), mean KL over 16 teacher-forced positions:
+    //
+    //     prefix    1500      2000      2100      3000      4000
+    //     fused     0.00384   0.00237   0.00483   0.00675   0.01272
+    //     RQH=1     0.00580   0.00573   0.00651   0.00945   0.01475
+    //
+    // For comparison, the same table before the fix (Qwen3.6-35B-A3B, as originally recorded):
+    //
+    //     fused     0.00043   0.00022   0.18672   0.20657   0.23978   <- cliff at 2048
+    //
+    // The cliff is gone, and fused is now MORE accurate than the RQH=1 fallback at every depth --
+    // so forcing RQH=1 in deterministic mode would select a slower AND less accurate path.
+    //
+    // Determinism verified directly rather than assumed: three runs at prefix=4000 on identical
+    // ids return bit-identical TOP1 (15/16) and KL (0.01272). The reason the fused tiers were
+    // nondeterministic was the read past initialised shared memory, which no longer happens.
     static const int gqa_rqh = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_GQA_RQH");
-        const int dflt = deterministic_mode() ? 1 : 4;
+        const int dflt = 4;   // see above: fusion is deterministic and more accurate post-#980
         const int v = e ? atoi(e) : dflt;
         return (v == 1 || v == 2 || v == 3 || v == 4) ? v : dflt;
     }();


### PR DESCRIPTION
Follow-up to #980. That PR fixed the P′-plane stride bug behind #976, but left two things behind —
so the file still documented the bug as present, and deterministic mode still worked around it.

## What was still wrong

The comment above the `RQH` default continued to state:

> The GQA-fused tiers are both nondeterministic and materially INACCURATE once n_tokens passes
> ~2048 with int8 KV. … Only RQH=1 … is correct there.

and `deterministic_mode()` still forced `RQH=1` on exactly that basis. After #980 both premises are
false, so the code contradicted its own documentation, and deterministic mode was selecting a path
that is **slower *and* less accurate**.

## Re-measured

`qwen3_gguf_prefill_check` against the token-loop reference, Qwen3.8-27B ModelOpt NVFP4, int8 KV,
**real token ids** from `bench/scripts/bench_prompt_32k.txt`, mean KL over 16 teacher-forced
positions:

| prefix | fused (default) | RQH=1 |
|---:|---:|---:|
| 1500 | 0.00384 | 0.00580 |
| 2000 | 0.00237 | 0.00573 |
| **2100** | **0.00483** | 0.00651 |
| 3000 | 0.00675 | 0.00945 |
| 4000 | 0.01272 | 0.01475 |

The row this replaces, pre-fix: `0.00022` at 2000 → **`0.18672`** at 2100. **The cliff is gone**, and
fused is now more accurate than the fallback at every depth.

## Why the KL measurement was necessary

#980's verification, and the reporter's independent confirmation, were both **greedy-token
equality**. Argmax can agree while the distribution is still wrong — and KL is the measure the
original defect was quantified with. Without this, "fixed" rested on the coarser of the two
available signals.

The first attempt at this table was discarded: it used the tool's synthetic ids, which it labels
`NOISY -- smoke test only`. Both columns sat at ~0.005, where a residual difference of a few
thousandths would have been invisible.

## Determinism, verified rather than assumed

- fused, three runs on identical ids: bit-identical `TOP1 15/16`, `KL 0.01272`
- deterministic mode with fusion on, two runs: bit-identical `TOP1 16/16`, `KL 0.01997`

The two modes still differ from each other, as they always have — `deterministic_mode()` also
disables split-K atomics and the MoE parallel path. What is established here is that fusion is
deterministic, which is the only premise the override rested on.

## Effect

Deterministic mode now runs the fused tiers. Default serving is unchanged (it was already `RQH=4`);
this only stops deterministic mode from opting into a worse path, and replaces documentation that
now describes a bug that no longer exists.

## Completeness check: are there other nondeterminism sources left?

#980 removed the read past initialised shared memory. Several fp32 `atomicAdd` split-K reductions
remain enabled by default (`prefill_gemm_skinny`, `_i8`, `_fp8`, and the MoE scatter), and the
kernel comments record that their reduction order — and therefore the result, to a few ULP —
"varies run to run". So "is #976 fully fixed" could not be answered by the stride fix alone.

Measured, split-K **on** (the default), `qwen3_gguf_prefill_check` on real token ids, KL reported to
five decimals over 16 positions — a much finer probe than comparing tokens:

| prefix | runs | result |
|---:|---:|---|
| 4000 | 6 | `15/16  KL 0.01272` — identical every run |
| 8000 | 6 | `16/16  KL 0.01950` — identical every run |

No observable nondeterminism on the scored path. Combined with the three-run check at 4000 and the
reporter's independent 24 runs across 8 depths in #980, greedy decode is reproducible in practice.

**Stated precisely: this is evidence, not proof.** The few-ULP ordering variation is real and still
documented; it simply does not surface at the resolution that matters here. `deterministic_mode()`
continues to disable those reductions for anyone who needs a bitwise guarantee — that is what that
mode is for, and it is unaffected by this PR.

## Eval-bot status

This PR is **not** greenlit by the DSpark bot, by design: that gate requires a ticked
"Tested on RTX 5090" box *and* a before/after table showing a throughput gain. This is a
correctness and documentation change with no speedup to claim on the default serving path
(default was already `RQH=4`), so ticking that box would be a false attestation. Merged as a
maintainer change rather than through the contribution flow.

The one measurable effect is on deterministic mode, which now runs the fused tiers instead of the
slower, less accurate `RQH=1` fallback.