### PR TITLE
fix(server): tool-schema gaps and the missing video modality (#981, #983)

### DIFF
--- a/server/include/video_input.hpp
+++ b/server/include/video_input.hpp
@@ -47,6 +47,11 @@ bool parse_video_url(const std::string& url, std::vector<unsigned char>& bytes, 
 // needs ffmpeg on PATH" instead of failing inside a pipe with an empty read.
 bool video_decoder_available(std::string* detail = nullptr);
 
+// Uncached probe. video_decoder_available() memoises, because it is called from /v1/models on
+// every poll and each probe is a fork/exec. This variant re-probes; it exists for tests and for
+// any caller that genuinely needs to observe a mid-process change.
+bool video_decoder_available_uncached(std::string* detail = nullptr);
+
 // Ceiling on one clip's encoded bytes, applied BEFORE the decoder is handed anything. Larger than
 // the image ceiling because video legitimately is, but still bounded: the decode happens before
 // any pixel budget can apply.

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -482,6 +482,23 @@ bool valid_schema_node(const json& schema, const std::string& where, bool top_le
                                       " requires type number or integer");
         }
     }
+    // Composition branches are schemas too, and MUST be validated as such. Whitelisting anyOf at
+    // the parent while never descending into its branches would let a caller hide a rejected
+    // keyword inside one -- {"anyOf": [{"$ref": "..."}]} -- where validate_value() then ignores
+    // the unknown key, constrains nothing, and the branch matches anything. The anyOf would pass
+    // trivially while the caller believes a constraint is in force: exactly the silent weakening
+    // that refusing $ref at the top level exists to prevent.
+    for (const char* composition : {"anyOf", "oneOf"}) {
+        if (!schema.contains(composition)) continue;
+        const json& branches = schema[composition];
+        if (!branches.is_array() || branches.empty())
+            return set_error(err, where + "." + composition + " must be a non-empty array");
+        for (size_t i = 0; i < branches.size(); ++i) {
+            if (!valid_schema_node(branches[i],
+                                   where + "." + composition + "[" + std::to_string(i) + "]",
+                                   false, err)) return false;
+        }
+    }
     if (schema.contains("properties")) {
         if (!schema["properties"].is_object())
             return set_error(err, where + ".properties must be an object");

--- a/server/src/chat_tools.cpp
+++ b/server/src/chat_tools.cpp
@@ -1,6 +1,7 @@
 #include "chat_tools.hpp"
 
 #include <algorithm>
+#include <cmath>
 #include <cctype>
 #include <charconv>
 #include <cstdint>
@@ -199,10 +200,20 @@ std::string qwen_template_json(const json& value) {
 }
 
 bool is_allowed_key(const json& object, const std::set<std::string>& allowed,
-                    const std::string& where, std::string& err) {
+                    const std::string& where, std::string& err,
+                    bool allow_vendor_extensions = false) {
     for (const auto& item : object.items()) {
-        if (!allowed.count(item.key()))
-            return set_error(err, where + " contains unsupported field " + item.key());
+        if (allowed.count(item.key())) continue;
+        // Vendor extensions. JSON Schema reserves no "x-" prefix itself, but OpenAPI-derived
+        // tooling uses it universally and MCP servers emit it (x-mcp-header and friends). Like
+        // $schema/$comment these carry no constraint, so accepting and dropping them is faithful
+        // rather than permissive -- there is nothing for constrained decoding to enforce, so
+        // ignoring them cannot weaken a guarantee (#981).
+        //
+        // Opt-in per call site: this is right for a tool's JSON Schema, and wrong for the request
+        // envelope, where an unexpected x- key more likely means a client mistake worth surfacing.
+        if (allow_vendor_extensions && item.key().rfind("x-", 0) == 0) continue;
+        return set_error(err, where + " contains unsupported field " + item.key());
     }
     return true;
 }
@@ -404,13 +415,27 @@ bool valid_schema_node(const json& schema, const std::string& where, bool top_le
     // built on @ai-sdk/openai-compatible emit "$schema" on every tool schema, and rejecting it
     // failed the whole request. Structural "$" keywords ($ref/$defs/$id) are deliberately still
     // refused: silently ignoring a $ref would validate the arguments against nothing.
+    //
+    // allOf and prefixItems are likewise still refused. allOf needs schema intersection, which is
+    // genuinely hard in the general case; prefixItems needs positional item schemas. Neither is
+    // implemented in validate_value(), so accepting them would be exactly the silent weakening
+    // this comment warns about. A 400 naming the field is the honest answer until they are.
     if (!is_allowed_key(schema,
                         {"$schema", "$comment",
                          "type", "description", "default", "title", "properties",
                          "required", "additionalProperties", "items", "enum", "minimum",
                          "maximum", "exclusiveMinimum", "exclusiveMaximum", "minItems",
-                         "maxItems", "minLength", "maxLength", "pattern"},
-                        where, err)) return false;
+                         "maxItems", "minLength", "maxLength", "pattern",
+                         // Every keyword below is ENFORCED in validate_value(). Nothing is
+                         // whitelisted that the validator ignores: this backend has no
+                         // constrained decoding, so a keyword accepted but unchecked would turn
+                         // an honest 400 into a model silently violating the constraint.
+                         "const", "anyOf", "oneOf", "multipleOf",
+                         // "format" is the one exception, and it is not an exception to that
+                         // rule: JSON Schema defines format as an ANNOTATION by default, not an
+                         // assertion, so ignoring it enforces exactly what the spec requires.
+                         "format"},
+                        where, err, /*allow_vendor_extensions=*/true)) return false;
     for (const char* annotation : {"$schema", "$comment"}) {
         if (schema.contains(annotation) && !schema[annotation].is_string())
             return set_error(err, where + "." + annotation + " must be a string");
@@ -790,6 +815,59 @@ bool utf8_code_point_count(const std::string& value, std::size_t& count) {
 
 bool validate_value(const json& value, const json& schema, const std::string& path, std::string& err) {
     if (!schema.is_object()) return true;
+
+    // --- composition and single-literal keywords (#981) -------------------------------------
+    // These are ENFORCED here, not merely whitelisted. This backend does no constrained decoding
+    // -- arguments are validated after the fact -- so accepting a keyword the validator ignores
+    // would replace an honest 400 with a model silently violating the constraint, which is worse
+    // than rejecting it. Every keyword added to the schema whitelist alongside this must appear
+    // below.
+    //
+    // anyOf is the one that actually blocks MCP tools today: `anyOf: [T, null]` is how every
+    // optional/nullable field is expressed.
+    if (schema.contains("const")) {
+        if (value != schema["const"])
+            return set_error(err, path + " does not equal the value required by const");
+    }
+    if (schema.contains("anyOf")) {
+        if (!schema["anyOf"].is_array() || schema["anyOf"].empty())
+            return set_error(err, path + " has invalid anyOf schema");
+        bool any = false;
+        for (const json& sub : schema["anyOf"]) {
+            std::string ignored;   // a failing branch is not an error; only all-failing is
+            if (validate_value(value, sub, path, ignored)) { any = true; break; }
+        }
+        if (!any) return set_error(err, path + " does not match any anyOf branch");
+    }
+    if (schema.contains("oneOf")) {
+        if (!schema["oneOf"].is_array() || schema["oneOf"].empty())
+            return set_error(err, path + " has invalid oneOf schema");
+        int matched = 0;
+        for (const json& sub : schema["oneOf"]) {
+            std::string ignored;
+            if (validate_value(value, sub, path, ignored)) matched++;
+        }
+        // EXACTLY one, per the spec. Matching several is as much a failure as matching none --
+        // an overlapping oneOf means the caller's schema is ambiguous, and silently accepting the
+        // first hit would hide that.
+        if (matched != 1)
+            return set_error(err, path + " matches " + std::to_string(matched) +
+                                  " oneOf branches, expected exactly 1");
+    }
+    if (schema.contains("multipleOf") && schema["multipleOf"].is_number() && value.is_number()) {
+        const double step = schema["multipleOf"].get<double>();
+        if (step > 0.0) {
+            const double v = value.get<double>();
+            const double rem = std::fabs(v - step * std::round(v / step));
+            // Relative epsilon: 0.1 is not representable in binary, so an exact fmod test rejects
+            // legitimately-conforming values like 0.3 against multipleOf 0.1.
+            if (rem > 1e-9 * std::max(1.0, std::fabs(v)))
+                return set_error(err, path + " is not a multiple of the required step");
+        }
+    }
+    // "format" is deliberately absent: JSON Schema defines it as an ANNOTATION by default, not an
+    // assertion, so accepting and ignoring it is spec-correct rather than a silent weakening.
+
     if (schema.contains("type")) {
         auto matches = [&](const std::string& type) {
             if (type == "object") return value.is_object();
@@ -920,10 +998,40 @@ const json* property_schema_for_key(const json& object_schema, const json& prope
     return &unconstrained;
 }
 
+// Exact match first, then ASCII case-insensitive as a fallback.
+//
+// Qwen3.8 capitalises function names in its XML tool calls often enough to matter -- it emits
+// <function=Read> for an offered `read` -- and a strict compare turns that into "model called
+// unoffered function Read", failing an agent loop over a spelling difference the model chose.
+// SGLang and vLLM both normalise (#981).
+//
+// EXACT WINS. The fallback only runs when nothing matched exactly, so a caller that offers both
+// `read` and `Read` keeps the strict behaviour for both, and adding a second casing can never
+// change which tool an existing exact name resolves to.
+//
+// AMBIGUITY KEEPS THE STRICT BEHAVIOUR. If two offered tools differ only by case, a
+// case-insensitive hit is not well defined, so this returns nullptr and the caller reports the
+// name as unoffered -- guessing between them would silently invoke the wrong function.
+//
+// ASCII only, deliberately: a locale-aware or Unicode fold would make the set of matched names
+// depend on the server's locale, and tool names crossing that boundary should fail loudly.
 const ToolDefinition* offered_tool(const ChatRequest& request, const std::string& name) {
     for (const ToolDefinition& tool : request.tools)
         if (tool.name == name) return &tool;
-    return nullptr;
+
+    auto ascii_lower = [](std::string v) {
+        for (char& c : v)
+            if (c >= 'A' && c <= 'Z') c = (char)(c - 'A' + 'a');
+        return v;
+    };
+    const std::string want = ascii_lower(name);
+    const ToolDefinition* hit = nullptr;
+    for (const ToolDefinition& tool : request.tools) {
+        if (ascii_lower(tool.name) != want) continue;
+        if (hit) return nullptr;   // ambiguous: two offered tools differ only by case
+        hit = &tool;
+    }
+    return hit;
 }
 
 bool parse_one_xml_call(const std::string& block, const ChatRequest& request, ToolCall& call,
@@ -940,6 +1048,11 @@ bool parse_one_xml_call(const std::string& block, const ChatRequest& request, To
         return set_error(err, "tool call has an invalid function name");
     const ToolDefinition* tool = offered_tool(request, call.name);
     if (!tool) return set_error(err, "model called unoffered function " + call.name);
+    // Echo the name back exactly as the CLIENT offered it, not as the model spelled it. The client
+    // dispatches on its own spelling -- returning the model's "Read" for an offered "read" would
+    // resolve here and then miss in the caller's own handler table, moving the failure somewhere
+    // harder to diagnose. No-op when the match was exact (#981).
+    call.name = tool->name;
 
     const json& schema = tool->spec["function"]["parameters"];
     const json properties = schema.value("properties", json::object());

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -1,5 +1,6 @@
 #include "chat_tokenizer.hpp"
 #include "model_engine.hpp"
+#include "video_input.hpp"   // video_decoder_available() for /v1/models input_modalities
 #include "sparkinfer/kernels/deterministic.h"
 
 #include <nlohmann/json.hpp>
@@ -674,8 +675,17 @@ int main(int argc, char** argv) {
         // tower), so a listing in use today cannot be affected -- but verify against the model
         // monitor before registering a vision model.
         json input_modalities = json::array({std::move(input)});
-        if (engine.has_vision())
+        if (engine.has_vision()) {
             input_modalities.push_back({{"type", "image"}});
+            // Video is advertised only when a decoder is actually resolvable, not merely because
+            // the code path is compiled in. The whole point of this field is to let a client avoid
+            // sending something that cannot work: a deployment without ffmpeg accepts video_url
+            // parts and then fails every one of them, so advertising video there would be worse
+            // than silence. Downgrading instead makes the optional dependency discoverable up
+            // front rather than as a per-request error (#983).
+            if (sparkinfer_server::video_decoder_available(nullptr))
+                input_modalities.push_back({{"type", "video"}});
+        }
 
         json model = {
             {"schema_version", "2.4"}, {"id", g_model_name}, {"name", g_model_name},

--- a/server/src/video_input.cpp
+++ b/server/src/video_input.cpp
@@ -148,6 +148,27 @@ bool parse_double(const std::string& s, double& v) {
 }  // namespace
 
 bool video_decoder_available(std::string* detail) {
+    // Memoised. Each probe is a fork/exec, and this is called from /v1/models -- a listing
+    // endpoint that monitors and routers poll continuously -- so an un-cached implementation
+    // spawned two processes per poll and gave a burst of requests a cheap way to exhaust PIDs.
+    // Whether ffmpeg is on PATH cannot meaningfully change inside one process lifetime; if it
+    // does, a restart is the right way to pick that up.
+    struct Probe { bool ok; std::string detail; };
+    static const Probe probe = [] {
+        Probe p{true, {}};
+        std::string out, err;
+        if (!run_tool({"ffmpeg", "-version"}, nullptr, 0, out, 1 << 20, 10, err)) {
+            p.ok = false; p.detail = "ffmpeg unavailable: " + err;
+        } else if (!run_tool({"ffprobe", "-version"}, nullptr, 0, out, 1 << 20, 10, err)) {
+            p.ok = false; p.detail = "ffprobe unavailable: " + err;
+        }
+        return p;
+    }();
+    if (detail && !probe.ok) *detail = probe.detail;
+    return probe.ok;
+}
+
+bool video_decoder_available_uncached(std::string* detail) {
     std::string out, err;
     if (!run_tool({"ffmpeg", "-version"}, nullptr, 0, out, 1 << 20, 10, err)) {
         if (detail) *detail = "ffmpeg unavailable: " + err;

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -806,6 +806,16 @@ bool test_schema_keywords_981() {
     CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"type":"number","multipleOf":5}}})"), request));
     CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"type":"string","format":"date-time"}}})"), request));
 
+    // A rejected keyword must stay rejected INSIDE a composition branch too. Whitelisting anyOf
+    // at the parent while never descending into its branches would let a caller smuggle $ref into
+    // one, where validate_value ignores the unknown key and the branch then matches anything --
+    // the anyOf passes trivially while the caller believes a constraint is in force.
+    CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"anyOf":[{"$ref":"#/$defs/T"}]}}})"), request));
+    CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"oneOf":[{"type":"string"},{"allOf":[{"type":"string"}]}]}}})"), request));
+    // Empty or non-array compositions are refused rather than silently treated as "no constraint".
+    CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"anyOf":[]}}})"), request));
+    CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"anyOf":{"type":"string"}}}})"), request));
+
     // Still refused, because validate_value cannot enforce them. Accepting these would be the
     // silent weakening the whole design avoids.
     CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"$ref":"#/$defs/T"}}})"), request));

--- a/server/tests/chat_tools_test.cpp
+++ b/server/tests/chat_tools_test.cpp
@@ -706,7 +706,16 @@ bool test_schema_keyword_type_applicability() {
 }
 
 bool test_unsupported_schema_keywords_are_rejected() {
-    for (const char* unsupported : {"const", "multipleOf", "oneOf"}) {
+    // const / multipleOf / oneOf MOVED OUT of this list in #981: validate_value() now enforces
+    // them, so rejecting them would refuse schemas this server can honour. They are covered by
+    // test_schema_keywords_981(), which asserts ENFORCEMENT rather than mere acceptance.
+    //
+    // What stays here is the set validate_value() cannot enforce. That distinction is the whole
+    // contract: a keyword is accepted only if the validator checks it, because this backend does
+    // no constrained decoding and an unchecked keyword would let the model violate a constraint
+    // the caller believes is in force. Do not move anything into the supported list without
+    // implementing it first.
+    for (const char* unsupported : {"$ref", "$defs", "allOf", "prefixItems"}) {
         json body = {
             {"messages", {{{"role", "user"}, {"content", "test"}}}},
             {"tools", json::array({{
@@ -716,9 +725,10 @@ bool test_unsupported_schema_keywords_are_rejected() {
                     {"parameters", {
                         {"type", "object"},
                         {"properties", {{"value", {{"type", "integer"},
-                                                     {unsupported, unsupported == std::string("oneOf")
+                                                     {unsupported, (unsupported == std::string("allOf") ||
+                                                                   unsupported == std::string("prefixItems"))
                                                          ? json::array({json{{"type", "integer"}}})
-                                                         : json(2)}}}}}
+                                                         : json("#/$defs/T")}}}}}
                     }}
                 }}
             }})}
@@ -772,6 +782,52 @@ bool test_parallel_tool_calls() {
     single_request["parallel_tool_calls"] = false;
     CHECK(parse_request(single_request.dump(), request));
     CHECK(!request.parallel_tool_calls);
+    return true;
+}
+
+bool test_schema_keywords_981() {
+    // #981: keywords are accepted ONLY if validate_value() enforces them. A keyword that is
+    // whitelisted but unchecked turns an honest 400 into a model silently violating a constraint,
+    // which is strictly worse -- so each accepted keyword is tested for ENFORCEMENT, not just for
+    // being parseable.
+    auto req_with = [](const std::string& params) {
+        return std::string(R"({"messages":[{"role":"user","content":"hi"}],"tools":[{"type":"function",)"
+                           R"("function":{"name":"f","description":"d","parameters":)") + params + "}}]}";
+    };
+    ChatRequest request;
+
+    // x-* vendor extensions: accepted and ignored (MCP servers emit these).
+    CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"type":"string",)"
+                                 R"("x-mcp-header":"X-Trace"}}})"), request));
+    // const / anyOf / oneOf / multipleOf / format now parse.
+    CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"const":"only"}}})"), request));
+    CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"anyOf":[{"type":"string"},{"type":"null"}]}}})"), request));
+    CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"oneOf":[{"type":"string"},{"type":"integer"}]}}})"), request));
+    CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"type":"number","multipleOf":5}}})"), request));
+    CHECK(parse_request(req_with(R"({"type":"object","properties":{"a":{"type":"string","format":"date-time"}}})"), request));
+
+    // Still refused, because validate_value cannot enforce them. Accepting these would be the
+    // silent weakening the whole design avoids.
+    CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"$ref":"#/$defs/T"}}})"), request));
+    CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"allOf":[{"type":"string"}]}}})"), request));
+    CHECK(!parse_request(req_with(R"({"type":"object","properties":{"a":{"prefixItems":[{"type":"string"}]}}})"), request));
+    return true;
+}
+
+bool test_case_insensitive_tool_names_981() {
+    // Qwen3.8 emits <function=Read> for an offered `read`; a strict compare failed the whole
+    // agent loop over the model's choice of spelling.
+    const std::string body =
+        R"({"messages":[{"role":"user","content":"go"}],"tools":[{"type":"function","function":)"
+        R"({"name":"read","description":"d","parameters":{"type":"object","properties":{}}}}]})";
+    ChatRequest request;
+    CHECK(parse_request(body, request));
+    const std::string raw = "<tool_call>\n<function=Read>\n</function>\n</tool_call>";
+    const ParsedToolOutput out = parse_qwen36_tool_output(raw, false, request);
+    CHECK(out.error.empty());
+    CHECK(out.tool_calls.size() == 1);
+    // Echoed back with the CLIENT's spelling, not the model's -- the client dispatches on its own.
+    CHECK(out.tool_calls[0].name == "read");
     return true;
 }
 
@@ -1698,6 +1754,8 @@ int main() {
     if (!test_schema_keyword_type_applicability()) return 1;
     if (!test_unsupported_schema_keywords_are_rejected()) return 1;
     if (!test_parallel_tool_calls()) return 1;
+    if (!test_schema_keywords_981()) return 1;
+    if (!test_case_insensitive_tool_names_981()) return 1;
     if (!test_reasoning_effort_controls()) return 1;
     if (!test_plain_answer()) return 1;
     if (!test_control_markup_never_leaks_as_content()) return 1;


### PR DESCRIPTION
Fixes #983 and the three blockers in #981.

## #983 — `/v1/models` never advertised `video`

PR #965 added the video input path and not the advertisement, so a client that routes on
`input_modalities` would never send video and would report the model as image-only.

Gated on `video_decoder_available()` rather than `has_vision()` alone, following the reporter's
reasoning: the field exists so a client can avoid sending what cannot work. A deployment without
`ffmpeg` accepts `video_url` parts and then fails every one of them, so advertising there would be
worse than silence — downgrading makes the optional dependency discoverable up front instead of as
a per-request error.

## #981.3 — tool names matched case-sensitively

Qwen3.8 emits `<function=Read>` for an offered `read`, and a strict compare failed the whole agent
loop over the model's choice of spelling.

Exact match wins. The ASCII case-insensitive fallback runs only when nothing matched exactly, so
offering both `read` and `Read` keeps the strict behaviour for both. Ambiguity returns `nullptr`
rather than guessing between two tools that differ only by case.

The resolved call is rewritten to the **client's** spelling — the client dispatches on its own
names, so returning the model's `Read` would resolve here and then miss in the caller's handler
table, moving the failure somewhere harder to diagnose.

## #981.1 — `x-*` vendor extensions

Accepted and dropped. MCP servers emit them, they carry no constraint, so ignoring them cannot
weaken a guarantee. Opt-in per call site: right for a tool schema, wrong for the request envelope
where an unexpected `x-` key more likely means a client mistake worth surfacing.

## #981.2 — composition keywords, enforced rather than whitelisted

The report scoped `anyOf`/`oneOf` as the hard part, assuming a constrained-decoding grammar. **This
backend has none** — `validate_response_format` says so outright — so enforcement here is post-hoc
argument validation, where alternation is plain recursion. That makes the highest-value item
tractable now rather than later.

Enforced in `validate_value()`:

| keyword | behaviour |
|---|---|
| `const` | value must equal the literal |
| `anyOf` | must match ≥1 branch — `anyOf: [T, null]`, how every optional MCP field is expressed |
| `oneOf` | must match **exactly** 1; matching several is a failure, since an overlapping `oneOf` is an ambiguous caller schema worth surfacing |
| `multipleOf` | relative epsilon, because 0.1 is not binary-representable and an exact `fmod` rejects conforming values like 0.3 |

`format` is accepted and ignored. JSON Schema defines it as an **annotation** by default, not an
assertion, so ignoring it *is* the spec behaviour rather than a shortcut.

`$ref` / `$defs` / `allOf` / `prefixItems` remain honest `400`s. **Nothing is whitelisted that the
validator ignores** — an accepted-but-unchecked keyword replaces an honest error with a model
silently violating a constraint the caller believes is in force, which is strictly worse. That is
the reporter's own point, and it is the rule the tests now encode.

## Tests

`test_unsupported_schema_keywords_are_rejected` **caught this change** — it asserted `const`,
`multipleOf` and `oneOf` were rejected. Repointed rather than deleted: it now covers the set the
validator genuinely cannot enforce, and the three that moved are covered by a new test asserting
**enforcement**, not merely acceptance. Coverage is stronger than before, not weaker.

## Review found two defects in the first cut

Both were introduced by this PR and found by reviewing it, not by a failing test.

**A schema-validation bypass.** `valid_schema_node()` recurses into `properties`,
`additionalProperties` and `items` — but not into `anyOf`/`oneOf` branches. Whitelisting `anyOf` at
the parent while never descending into its branches let a caller smuggle a rejected keyword inside
one:

```json
{"anyOf": [{"$ref": "#/$defs/T"}]}
```

The outer node accepted `anyOf`, the branch was never validated, `validate_value()` ignored the
unknown `$ref` and constrained nothing — so the branch matched **anything** and the `anyOf` passed
trivially, while the caller believed a constraint was in force. Exactly the silent weakening that
refusing `$ref` at the top level exists to prevent, reintroduced one level down *while implementing
the rule against it*.

Branches are now validated as schemas; empty or non-array compositions are refused rather than read
as "no constraint".

**Two fork/execs per `/v1/models` request.** `video_decoder_available()` probes `ffmpeg` and
`ffprobe`, each a fork/exec with a 10s timeout, and the new modality advertisement called it on
every request to a listing endpoint that monitors and routers poll continuously — a burst of polls
was a cheap way to exhaust PIDs. Now memoised; the uncached probe stays available for tests.

Tests cover both: `$ref` and `allOf` smuggled inside `anyOf`/`oneOf`, and empty/non-array
compositions.