### PR TITLE
perf(gemv): default the NVFP4 multi-row GEMV to its pairwise kernel (1.025x cb-decode@c8)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -3324,8 +3324,18 @@ bool launch_gemv_nvfp4_rows_dp4a2(const void* xq, const void* xs,
     const auto* sp = reinterpret_cast<const float*>(xs);
     auto* yp0 = reinterpret_cast<__nv_bfloat16*>(y0);
     auto* yp1 = reinterpret_cast<__nv_bfloat16*>(y1);
+    // Opt-OUT. This kernel differs from the dp4a2 branch below only in which warp owns an output
+    // element -- same split rule (N>=4096 ? S=2 : S=8), same lane-owned group walk, so every
+    // output sums the same terms in the same order and the two are bit-identical. It wins once a
+    // batch is wide: measured on RTX 5090 / Qwen3.8-27B-NVFP4 through qwen3_gguf_cb_bench,
+    // aggregate decode 464.6 -> 475.7 tok/s at concurrency 8 (four alternating pairs, every arm
+    // separated), +1.77% at 2 and +0.86% at 4. Single-stream is untouched: the branch needs M>=2
+    // and continuous-batch decode declines below two rows, so cb@c1 reads 95.0 against 95.1.
+    // DSpark's verify runs at M=2..4 and is inert -- decode@4k/16k/32k move -0.03/-0.12/+1.33%
+    // with mean-accept EXACTLY equal (1.6883, 1.7297, 1.2800) and losslessness holding at all
+    // three, which is what bit-identity looks like from outside.
     static const bool pairwise = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_PAIRWISE");
-                                     return e && e[0] == '1'; }();
+                                     return !(e && e[0] == '0'); }();
 #define SI_NVFP4_PAIRWISE(S_, R_) do {                                                        \
         constexpr int S=(S_), R=(R_), NR=1, PAIR_WPB=(S==8)?8:4, RPB=PAIR_WPB/S;              \
         gemv_nvfp4_rows_dp4a_pairwise_kernel<__nv_bfloat16,S,R,NR>                             \


### PR DESCRIPTION
## Summary

The NVFP4 multi-row GEMV ships two kernels for the same shape, and the one that suits a wide batch
was opt-in. `gemv_nvfp4_rows_dp4a_pairwise_kernel` is fully instantiated for R=2..8 and nothing
routed to it unless `SPARKINFER_NVFP4_ROWS_PAIRWISE=1` was set. This makes it the default; the flag
now opts out instead of in.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, aggregate continuous-batch decode at concurrency 8):

| | decode tok/s |
|---|--:|
| before (main) | 467.1 |
| after (this PR) | 478.7 |

**Prefill pp tok/s** — not targeted by this PR:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

### Why it is faster

The kernel differs from the branch it replaces only in *which* warp owns an output element, not in
how that element is computed: both use the same split rule (`N>=4096 ? S=2 : S=8`) and the same
lane-owned group walk (`g = split*32 + lane`, stride `S*32`), so every output sums the same terms
in the same order. What changes is the block geometry — 4 warps per block with NR=1 rather than 8
with NR=2, which at `N=17408, S=2` runs 8704 blocks of 128 threads instead of 2176 of 256. That
trade only pays once several activation rows share a weight read, which is why it was left off:
single-stream decode never reaches those widths.

### Bit-identity

Mean accept is **exactly equal** before and after at every speculative-decode context, with
losslessness holding in all six runs. Since mean accept is `tokens/steps`, an equal value means the
verifier accepted the same tokens at the same positions across a whole generation.

| context | before | after | mean accept before/after | lossless |
|---|--:|--:|---|--:|
| 4k | 128.99 | 128.96 | 1.6883 / 1.6883 | 1 / 1 |
| 16k | 129.45 | 129.30 | 1.7297 / 1.7297 | 1 / 1 |
| 32k | 92.98 | 94.22 | 1.2800 / 1.2800 | 1 / 1 |

### Across concurrency

Single-stream is untouched by construction: the branch requires `M>=2`, and continuous-batch decode
declines a batch narrower than two rows.

| concurrency | before | after | |
|---|--:|--:|--:|
| 1 | 95.0 | 95.1 | floor, unchanged |
| 2 | 181.2 | 184.4 | +1.77% |
| 4 | 303.2 | 305.6 | +0.86% |
| 8 | 467.1 | 478.7 | +2.49% |

```text
# qwen3_gguf_cb_bench <model> 8 256 256 512, NVFP4 prefill+decode, int8 KV.
# Clocks are not pinnable on this box, so arms are alternated and every arm is separated.
# Baked default (one binary; SPARKINFER_NVFP4_ROWS_PAIRWISE=0 gives the "before" arm):
before  agg_tok_s=470.1
after   agg_tok_s=479.3
before  agg_tok_s=464.0
after   agg_tok_s=478.1
                -> before 467.1, after 478.7, +2.49%

# Four alternating pairs of the same comparison driven by the env flag, for the spread:
before  466.9  464.7  462.2  464.6    mean 464.6
after   476.9  476.7  475.6  473.6    mean 475.7   +2.39%
# every "after" exceeds every "before"; the distributions do not overlap.

# Speculative decode, dspark_tau_check, 128 tokens on the 4k/16k/32k prompts:
ctx=4096   before  DSPARK_TPS=128.9932  MEAN_ACCEPT=1.6883  AR_TPS=93.0267  LOSSLESS=1
ctx=4096   after   DSPARK_TPS=128.9567  MEAN_ACCEPT=1.6883  AR_TPS=92.7850  LOSSLESS=1
ctx=16384  before  DSPARK_TPS=129.4548  MEAN_ACCEPT=1.7297  AR_TPS=88.5158  LOSSLESS=1
ctx=16384  after   DSPARK_TPS=129.3043  MEAN_ACCEPT=1.7297  AR_TPS=88.2802  LOSSLESS=1
ctx=32768  before  DSPARK_TPS=92.9841   MEAN_ACCEPT=1.2800  AR_TPS=83.0076  LOSSLESS=1
ctx=32768  after   DSPARK_TPS=94.2245   MEAN_ACCEPT=1.2800  AR_TPS=82.9308  LOSSLESS=1
```
