### PR TITLE
fix(prefill): refresh xn for the GDN gate projections the FP4 norm deferral skips

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2591,7 +2591,24 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             [] { const char* e = getenv("SPARKINFER_Q38_ATTN_NORM_FP4");
                  return !e || e[0] != '0'; }();
         const void* next_norm = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-        if (!defer_next_attn_norm) kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
+        // The deferral is only sound for consumers that reach the normalisation through the fused
+        // rmsnorm+quantize -- the qkv/z arms do. A Gated-DeltaNet layer's ssm_alpha / ssm_beta
+        // projections do NOT: they read raw `xn` (the proj() calls in the GDN block above), and
+        // `xn` has exactly two writers in this function -- the pre-loop rmsnorm and this one. So
+        // with the deferral active, which is every layer at N >= 16384, 47 of the 48 GDN layers
+        // projected their decay gate and update rate from LAYER 0's normalisation.
+        //
+        // Refresh xn when the next layer is a GDN layer. The deferral itself is untouched, so the
+        // fused-quantize precision benefit it exists for is kept; only the raw-xn consumers stop
+        // reading a stale value. SPARKINFER_Q38_GDN_XN_FIX=0 restores the old behaviour so the
+        // two can be A/B'd in one binary.
+        static const bool gdn_xn_fix = [] {
+            const char* e = getenv("SPARKINFER_Q38_GDN_XN_FIX");
+            return !(e && e[0] == '0');
+        }();
+        const bool next_needs_raw_xn = gdn_xn_fix && nw && nw->linear_attn;
+        if (!defer_next_attn_norm || next_needs_raw_xn)
+            kernels::launch_rmsnorm(x, next_norm, xn, N, H, eps, st);
         attn_norm_deferred = defer_next_attn_norm;
     }
 


### PR DESCRIPTION
## Summary

`prefill_batched_run`'s FP4 norm deferral skips `launch_rmsnorm(x, next_norm, xn, ...)` for every layer at `N >= 16384`, handing the next layer's normalisation to its fused rmsnorm+quantize. That is correct for the qkv/z arms, which go through that fused form — but a Gated-DeltaNet layer's `ssm_alpha` / `ssm_beta` projections read **raw `xn`**, and `xn` has exactly two writers in the function: the pre-loop rmsnorm and the deferred one. So with the deferral active, **47 of the 48 GDN layers projected their decay gate and update rate from layer 0's normalisation.**

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (DSpark decode @32k, `dspark_tau_check <model> <draft> 128 @ids_32768`, arms interleaved, both from the same binary via `SPARKINFER_Q38_GDN_XN_FIX`):

| | decode tok/s |
|---|--:|
| before (main) | 125.70 |
| after (this PR) | **138.32** |

**Prefill pp tok/s** (same runs; this PR costs one rmsnorm per GDN layer above 16k):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 10843.56 / 10814.36 |
| after prefill (this PR) | 10746.83 / 10709.60 |

```text
# box11, RTX 5090 525W, main db26534, one binary, SPARKINFER_Q38_GDN_XN_FIX=0/1, interleaved x2
DS xnoff32  ctx=32768  DSPARK_TPS=125.6988 AR_TPS=83.8313 MEAN_ACCEPT=1.6842 LOSSLESS=1 PREFILL_PP=10843.5641
DS xnon32   ctx=32768  DSPARK_TPS=138.3239 AR_TPS=83.8121 MEAN_ACCEPT=1.8551 LOSSLESS=1 PREFILL_PP=10746.8301
DS xnoff32  ctx=32768  DSPARK_TPS=125.5183 AR_TPS=83.8280 MEAN_ACCEPT=1.6842 LOSSLESS=1 PREFILL_PP=10814.3619
DS xnon32   ctx=32768  DSPARK_TPS=138.2323 AR_TPS=83.7989 MEAN_ACCEPT=1.8551 LOSSLESS=1 PREFILL_PP=10709.5976
DS xnoff16  ctx=16384  DSPARK_TPS=189.5422 AR_TPS=89.3140 MEAN_ACCEPT=2.5098 LOSSLESS=1 PREFILL_PP=11879.6327
DS xnon16   ctx=16384  DSPARK_TPS=189.5601 AR_TPS=89.3306 MEAN_ACCEPT=2.5490 LOSSLESS=1 PREFILL_PP=11818.6819
DS xnoff16  ctx=16384  DSPARK_TPS=189.3467 AR_TPS=89.2822 MEAN_ACCEPT=2.5098 LOSSLESS=1 PREFILL_PP=11866.2954
DS xnon16   ctx=16384  DSPARK_TPS=189.4723 AR_TPS=89.2395 MEAN_ACCEPT=2.5490 LOSSLESS=1 PREFILL_PP=11808.6936
```

## Scored dimensions

| dimension | main | this PR | ratio |
|---|--:|--:|--:|
| **dspark-decode@32k** | 125.61 | **138.28** | **1.1009** |
| dspark-prefill@32k | 10828.96 | 10728.21 | 0.9907 |
| dspark-decode@16k | 189.44 | 189.52 | 1.0004 |
| dspark-prefill@16k | 11872.97 | 11813.69 | 0.9950 |
| dspark-decode@4k | 221.72 | 221.81 | 1.0004 |
| dspark-prefill@4k | 14202.97 | 14225.89 | 1.0016 |
| target-prefill@256k | 4431.45 | 4398.60 | 0.9926 |
| target-decode@256k | 95.11 | 95.05 | 0.9994 |
