### PR TITLE
perf(runtime): serve a wide continuous-batch decode with the block-scaled NVFP4 GEMM (1.35x cb-decode@c32)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -2881,7 +2881,18 @@ bool launch_gemv_rows(const void* x, const void* W, void* y,
 }
 bool launch_gemv_rows2(const void* x, const void* W0, const void* W1, void* y0, void* y1,
                        int M, int N0, int N1, int K, cudaStream_t stream) {
-    if (M < 1 || M > 8 || N0 < 1 || N1 < 1 || (K & 7)) return false;
+    if (M < 1 || N0 < 1 || N1 < 1 || (K & 7)) return false;
+    if (M > 8) {                       // chunk: see launch_gemv_nvfp4_rows_dp4a
+        for (int r0 = 0; r0 < M; r0 += 8) {
+            const int m = (M - r0) < 8 ? (M - r0) : 8;
+            if (!launch_gemv_rows2(reinterpret_cast<const __nv_bfloat16*>(x) + (size_t)r0 * K,
+                                   W0, W1,
+                                   reinterpret_cast<__nv_bfloat16*>(y0) + (size_t)r0 * N0,
+                                   reinterpret_cast<__nv_bfloat16*>(y1) + (size_t)r0 * N1,
+                                   m, N0, N1, K, stream)) return false;
+        }
+        return true;
+    }
 #ifdef _MSC_VER
     // gemv_bf16_rows_sk2_kernel is compiled out under MSVC (see #ifndef _MSC_VER above).
     // Two single-matrix launches are bit-identical to the fused path — just two grids.
@@ -3314,7 +3325,26 @@ bool launch_gemv_nvfp4_rows_dp4a2(const void* xq, const void* xs,
                                   int M, int N, int K, cudaStream_t stream) {
     if (!xq || !xs || !W0 || !W1 || !y0 || !y1 || N < 1 || K < 1 || (K & 15)) return false;
     if (!gemv_bf16_splitk()) return false;
-    if (M < 1 || M > 8) return false;
+    if (M < 1) return false;
+    // Wider than the instantiated row tiers: serve it as chunks of 8 rather than instantiating
+    // R=9..16. Measured on RTX 5090 at the real decode shapes, a 16-row instantiation costs
+    // t(16) = 1.002 * 2*t(8) with 495 spill stores -- `uint4 xg[GPT][R]` alone is 128 registers
+    // at R=16 -- so a wider template buys nothing over re-reading the weights, and chunking keeps
+    // every row on the tuned R<=8 kernel. Rows are the slow axis of y/xq/xs ([M,*] row-major),
+    // so a chunk is a pointer offset.
+    if (M > 8) {
+        const size_t ng = (size_t)(K >> 4);
+        for (int r0 = 0; r0 < M; r0 += 8) {
+            const int m = (M - r0) < 8 ? (M - r0) : 8;
+            if (!launch_gemv_nvfp4_rows_dp4a2(
+                    reinterpret_cast<const signed char*>(xq) + (size_t)r0 * K,
+                    reinterpret_cast<const float*>(xs) + (size_t)r0 * ng, W0, W1,
+                    reinterpret_cast<__nv_bfloat16*>(y0) + (size_t)r0 * N,
+                    reinterpret_cast<__nv_bfloat16*>(y1) + (size_t)r0 * N,
+                    m, N, K, stream)) return false;
+        }
+        return true;
+    }
     static const int nr_mode = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_NR");
                                    int v = e ? atoi(e) : 0; return (v == 1 || v == 2) ? v : 0; }();
     static const bool pair_on = []{ const char* e = getenv("SPARKINFER_NVFP4_ROWS_PAIR");
@@ -3396,7 +3426,25 @@ bool launch_gemv_nvfp4_rows_dp4a(const void* xq, const void* xs, const void* W, 
                                  int M, int N, int K, cudaStream_t stream) {
     if (!xq || !xs || !W || !y || N < 1 || K < 1 || (K & 15)) return false;
     if (!gemv_bf16_splitk()) return false;
-    if (M < 1 || M > 8) return false;
+    if (M < 1) return false;
+    // Wider than the instantiated row tiers: serve it as chunks of 8 rather than instantiating
+    // R=9..16. Measured on RTX 5090 at the real decode shapes, a 16-row instantiation costs
+    // t(16) = 1.002 * 2*t(8) with 495 spill stores -- `uint4 xg[GPT][R]` alone is 128 registers
+    // at R=16 -- so a wider template buys nothing over re-reading the weights, and chunking keeps
+    // every row on the tuned R<=8 kernel. Rows are the slow axis of y/xq/xs ([M,*] row-major),
+    // so a chunk is a pointer offset.
+    if (M > 8) {
+        const size_t ng = (size_t)(K >> 4);
+        for (int r0 = 0; r0 < M; r0 += 8) {
+            const int m = (M - r0) < 8 ? (M - r0) : 8;
+            if (!launch_gemv_nvfp4_rows_dp4a(
+                    reinterpret_cast<const signed char*>(xq) + (size_t)r0 * K,
+                    reinterpret_cast<const float*>(xs) + (size_t)r0 * ng, W,
+                    reinterpret_cast<__nv_bfloat16*>(y) + (size_t)r0 * N,
+                    m, N, K, stream)) return false;
+        }
+        return true;
+    }
     const auto* xp = reinterpret_cast<const signed char*>(xq);
     const auto* sp = reinterpret_cast<const float*>(xs);
     auto* yp = reinterpret_cast<__nv_bfloat16*>(y);
@@ -3838,7 +3886,17 @@ bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
 }
 bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
                           int M, int N, int K, cudaStream_t stream) {
-    if (M < 1 || M > 8 || N < 1) return false;
+    if (M < 1 || N < 1) return false;
+    if (M > 8) {   // chunk: see launch_gemv_nvfp4_rows_dp4a. q81 rows are (K>>5) blocks apart.
+        for (int r0 = 0; r0 < M; r0 += 8) {
+            const int m = (M - r0) < 8 ? (M - r0) : 8;
+            if (!launch_mmvq_rows_f32(qtype,
+                                      reinterpret_cast<const si_block_q8_1*>(q81)
+                                          + (size_t)r0 * (size_t)(K >> 5),
+                                      W, y + (size_t)r0 * N, m, N, K, stream)) return false;
+        }
+        return true;
+    }
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const auto* w = reinterpret_cast<const unsigned char*>(W);
     // Same instantiated-width limit as launch_mmvq_q4k_rows above, and the same consequence:

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -11,7 +11,7 @@ namespace sparkinfer {
 
 // Largest packed continuous-batch decode row count. Mirrors the verify graph tiers in
 // qwen35_prefill.cpp -- one captured graph per row count, so this bounds how many are kept.
-inline constexpr int kQwen35MaxPackedRows = 8;
+inline constexpr int kQwen35MaxPackedRows = 32;
 
 class ThermalGovernor;   // optional decode-time thermal pacing (thermal_governor.h)
 class BridgeClient;      // optional external KV cache tier (lmcache_bridge_client.h)

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3217,7 +3217,17 @@ void Qwen35Model::close_session(uint64_t seq_id, const std::vector<int>* store_t
     if (s.active_seq_id == seq_id) activate_session(0);
 }
 
-int Qwen35Model::max_packed_rows() { return kQwen35MaxPackedRows; }
+int Qwen35Model::max_packed_rows() {
+    // Runtime cap, so the widest packed batch can be A/B'd in ONE binary. The compile-time
+    // kQwen35MaxPackedRows still sizes every array; this only bounds what a step will pack.
+    static const int cap = [] {
+        const char* e = getenv("SPARKINFER_PACKED_MAX_ROWS");
+        int v = e ? atoi(e) : kQwen35MaxPackedRows;
+        if (v < 1) v = 1;
+        return v > kQwen35MaxPackedRows ? kQwen35MaxPackedRows : v;
+    }();
+    return cap;
+}
 
 bool Qwen35Model::decode_packed(const int* tokens, const int* positions,
                                 const uint64_t* seq_ids, int n, int* out_sampled) {

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -79,7 +79,12 @@ struct Arena {
 // Widest verify block dflash_verify_short_run accepts. Also the number of GRAPH TIERS it keeps:
 // one instantiated graph per row count, so the caller can pick the block width per step instead
 // of being locked to whatever width the single warm graph happened to be captured at.
-constexpr int kVerifyMaxRows = 8;
+// Was 8, which is DSpark's block_size 7 plus one. Continuous-batch decode reuses this same
+// forward, and there a wider batch is not a deeper speculation but more concurrent requests, so
+// the ceiling has to cover the batch the scheduler hands us. 32 rows of every arena buffer is
+// ~32 MB (the logits plane dominates at 32 x vocab x 4B) and a tier's graph is only captured if
+// that width is actually used, so unused tiers cost nothing.
+constexpr int kVerifyMaxRows = 32;
 
 struct VerifyGraphCache {
     Arena arena;
@@ -2758,6 +2763,26 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     float* nv_ps_a = a.alloc<float>((size_t)NA * (nv_pwide / 16) + 1);
     signed char* nv_pq_b = a.alloc<signed char>((size_t)NA * nv_pwide);
     float* nv_ps_b = a.alloc<float>((size_t)NA * (nv_pwide / 16) + 1);
+    // WIDE-BATCH FFN OPERANDS. Above a handful of rows the row-GEMV stops being the right kernel:
+    // it reads the weights once per chunk of 8, while a block-scaled GEMM reads them once for the
+    // whole batch. Measured per decode forward on RTX 5090 at the real FFN shapes, the crossover
+    // is sharp -- at 8 rows the GEMV wins 7.28 ms to 13.28, at 16 the GEMM wins 12.80 to 14.31,
+    // and at 32 the GEMM is 9.71 against 29.12 for four chunked GEMV passes. So the GEMM arm is
+    // taken only for a genuinely wide packed batch; DSpark's verify never reaches these widths.
+    // The B operands are the SAME *_fp4 / *_fp4_sf the prefill path already keeps resident, so
+    // this costs no extra weight memory -- only the A-side staging and a workspace, below.
+    const int fp4_kwide = (c.moe_ffn > H ? c.moe_ffn : H);
+    unsigned char* fp4_a = nullptr; unsigned char* fp4_asf = nullptr; unsigned char* fp4_ws = nullptr;
+    if (packed && c.dense_ffn) {
+        const size_t ab = kernels::prefill_nvfp4_data_bytes(NA, fp4_kwide);
+        const size_t sb = kernels::prefill_nvfp4_scale_bytes_a(NA, fp4_kwide);
+        size_t wb = kernels::prefill_nvfp4_workspace_bytes(NA, c.moe_ffn, H);
+        const size_t wb2 = kernels::prefill_nvfp4_workspace_bytes(NA, H, c.moe_ffn);
+        if (wb2 > wb) wb = wb2;
+        fp4_a   = a.alloc<unsigned char>(ab);
+        fp4_asf = a.alloc<unsigned char>(sb);
+        if (wb) fp4_ws = a.alloc<unsigned char>(wb);
+    }
     // DEBUG ONLY (dspark_tau_check bisection, 2026-08-17): SPARKINFER_DFLASH_VERIFY_DUMP_ROW=<row>
     // dumps that row's pre-attn-norm xn after EVERY layer, plus the post-final-norm xn, into
     // [n_layers+1, H] bf16 written to SPARKINFER_DFLASH_VERIFY_DUMP_FILE (default
@@ -2928,10 +2953,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         pf_cu(cudaEventCreateWithFlags(&ev_join_ab, cudaEventDisableTiming), "verify ab join event");
     }
     if (!ph_ids) {
-        pf_cu(cudaHostAlloc(&ph_ids, 16 * sizeof(int), cudaHostAllocDefault), "verify host ids");
-        pf_cu(cudaHostAlloc(&ph_pos, 16 * sizeof(int), cudaHostAllocDefault), "verify host pos");
-        pf_cu(cudaHostAlloc(&ph_seq, 16 * sizeof(int), cudaHostAllocDefault), "verify host lens");
-        pf_cu(cudaHostAlloc(&ph_out, 16 * sizeof(int), cudaHostAllocDefault), "verify host out");
+        // kVerifyMaxRows, not a literal. These were 16 when the widest block was 8 -- a margin
+        // that silently became an overflow the moment the ceiling was raised: the fill loop below
+        // writes ph_ids[0..N) and the upload copies N ints, so at N>16 it wrote past a pinned
+        // allocation and every copy returned "invalid argument". It shows up as a throughput
+        // cliff, not a crash, because the failed copies leave stale ids in place.
+        pf_cu(cudaHostAlloc(&ph_ids, kVerifyMaxRows * sizeof(int), cudaHostAllocDefault), "verify host ids");
+        pf_cu(cudaHostAlloc(&ph_pos, kVerifyMaxRows * sizeof(int), cudaHostAllocDefault), "verify host pos");
+        pf_cu(cudaHostAlloc(&ph_seq, kVerifyMaxRows * sizeof(int), cudaHostAllocDefault), "verify host lens");
+        pf_cu(cudaHostAlloc(&ph_out, kVerifyMaxRows * sizeof(int), cudaHostAllocDefault), "verify host out");
     }
     if (verify_head_key != s.w.lm_head && s.w.lm_head_type == 12 && H == 2048) {
         if (verify_head_i8) cudaFree(verify_head_i8);
@@ -3538,7 +3568,40 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // dp4a arm, selected by the SAME switch the decode branch reads (qwen35.cpp). One
             // quantize of hn feeds both gate and up; a second feeds down. Scratch comes from the
             // verify arena, so it is sized for N rows and released with the rest of the pass.
-            if (native_ffn && topk == 1 && kernels::qwen38_nvfp4_dp4a()) {
+            // Wide packed batch: one block-scaled GEMM per projection instead of chunked
+            // row-GEMVs. Gated on a row count the GEMM actually wants (its A-quantizer requires
+            // m % 8 == 0, and below 16 rows the GEMV is still ahead), and on the prefill fp4
+            // operands being resident -- they are whenever SPARKINFER_QWEN38_PREFILL_NVFP4 is on.
+            static const int kFfnGemmMinRows = [] {
+                const char* e = getenv("SPARKINFER_FFN_GEMM_MIN_ROWS");
+                const int v = e ? atoi(e) : 16;
+                return v < 1 ? 1 : v;
+            }();
+            const bool ffn_gemm = packed && topk == 1 && fp4_a && fp4_asf &&
+                                  N >= kFfnGemmMinRows && (N & 7) == 0 &&
+                                  w.gate_fp4 && w.gate_fp4_sf && w.up_fp4 && w.up_fp4_sf &&
+                                  w.down_fp4 && w.down_fp4_sf;
+            if (ffn_gemm) {
+                bool ok = kernels::launch_prefill_nvfp4_quant_a(hn, fp4_a, fp4_asf, N, H, st) &&
+                          kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_asf, w.gate_fp4,
+                                                             w.gate_fp4_sf, sg, N, ffn, H,
+                                                             fp4_ws, st, w.gate_fp4_alpha) &&
+                          kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_asf, w.up_fp4,
+                                                             w.up_fp4_sf, su, N, ffn, H,
+                                                             fp4_ws, st, w.up_fp4_alpha);
+                if (ok) {
+                    kernels::launch_prefill_swiglu(sg, su, sh, (long)N * ffn, st);
+                    ok = kernels::launch_prefill_nvfp4_quant_a(sh, fp4_a, fp4_asf, N, ffn, st) &&
+                         kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_asf, w.down_fp4,
+                                                            w.down_fp4_sf, routed, N, H, ffn,
+                                                            fp4_ws, st, w.down_fp4_alpha);
+                }
+                if (!ok) {
+                    fprintf(stderr, "[dflash-verify] wide FFN GEMM declined N=%d ffn=%d H=%d\n",
+                            N, ffn, H);
+                    supported = false; break;
+                }
+            } else if (native_ffn && topk == 1 && kernels::qwen38_nvfp4_dp4a()) {
                 signed char* xq = nv_xq;
                 float* xs = nv_xs;
                 if (!hn_nv_folded) kernels::launch_gemv_nvfp4_quant_x(hn, xq, xs, N, H, st);


### PR DESCRIPTION
Reopened after the `target-prefill@256k` reject, rebased onto `c1777f5`. **That regression does not
reproduce** — evidence in "The 256k row" below. Everything else is re-measured on the new base,
because #989 changed the prefill path and the old numbers no longer described this tree.

## Summary

Aggregate decode throughput stops scaling past 8 concurrent requests: `kQwen35MaxPackedRows` is 8,
so a wider decode batch is chunked into 8s and every chunk re-reads all ~15 GB of weights. This
raises that ceiling to 32 and, above 16 rows, runs the dense FFN through the checkpoint-native
block-scaled NVFP4 GEMM instead of the row-GEMV — the one kernel that reads the weights once for
the whole batch.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (aggregate continuous-batch decode, 32 concurrent requests):

| | decode tok/s |
|---|--:|
| before (main) | 514.9 |
| after (this PR) | 697.5 |

**Prefill pp tok/s** — not targeted by this PR:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

## The 256k row

The previous round rejected on `target-prefill@256k`: 3862.30 against main 4313.89, −10.5%. I could
not reproduce it. Five runs of the bot's exact command, arms sandwiched between controls so drift is
bounded rather than assumed:

| tree | arm | prefill pp |
|---|---|--:|
| pre-#989 | clean main | 4632.53 |
| pre-#989 | **this PR** | 4623.05 |
| pre-#989 | clean main (control after) | 4614.84 |
| `c1777f5` | clean main | 4620.33 |
| `c1777f5` | **this PR** | 4620.01 |

On the current base the PR lands within **0.007%** of clean. On the older tree it sits *between* two
clean controls that themselves differ by 0.38%. A sixth run of the patched build on `c1777f5` gave
4564.67, so the row's own run-to-run spread is ~1.2% — larger than any effect this change has.

Two structural reasons it cannot be this PR: every caller of the four launchers touched here is in
`dflash_verify_short_run`, AR decode at M=1, or a unit test — **none in the 256k prefill**, which
runs `launch_prefill_nvfp4_gemm`. And the new arena buffers are gated on `packed`, which a
target-only sweep never sets.

One observation for the harness, independent of this PR: that row is `SPARKINFER_BENCH_SWEEP_REPS=1`
— a single sample — and its speed is decided by a batched-prefill scratch ceiling (#984 is open to
reduce exactly that pressure). `cb-decode@c2/c4/c8` each got a multi-run noise study before being
trusted, and c16/c32 got one before they were added. This row has not had one.

## Results, re-measured on `c1777f5`

One binary for both arms; "before" reproduces main through the override pair
(`SPARKINFER_PACKED_MAX_ROWS=8 SPARKINFER_FFN_GEMM_MIN_ROWS=999`), "after" is plain defaults.

| | before | after | |
|---|--:|--:|--:|
| cb-decode@c8 | 506.1 | 505.1 | flat |
| cb-decode@c16 | 509.9 | 570.4 | **+11.9%** |
| cb-decode@c32 | 514.9 | 697.5 | **+35.5%** |
| target-prefill@256k | 4620.33 | 4620.01 | −0.01% |

| context | tps | mean accept | lossless |
|---|--:|--:|--:|
| dspark@4k | 126.42 | 1.6883 | yes |
| dspark@16k | 128.25 | 1.7297 | yes |
| dspark@32k | 95.84 | 1.3299 | yes |

Mean accept at 32k moved 1.2800 → 1.3299 between rounds; that is #989, not this PR. Clean main on
this tree measures **the same 1.3299** with tps 95.8132 against the PR's 95.8408, so the verify path
is bit-identical — as it must be, since the GEMM arm needs `N >= 16` and the chunk branches need
`M > 8`, and DSpark's verify never exceeds 8 rows.

**No environment is required.** Every value is a default: the packed ceiling defaults to 32 and the
FFN GEMM engages from 16 rows on its own. The two env names in the diff are *overrides* for A/B, not
switches — unset behaviour is the fast path.

## Why the crossover, and why 16

Measured per decode forward at the real FFN/GDN shapes, isolated, CUDA events:

| per-forward ms | m=8 | m=16 | m=24 | m=32 |
|---|--:|--:|--:|--:|
| dp4a row-GEMV | **7.28** | 14.31 | — | — |
| block-scaled GEMM | 13.28 | **12.80** | **10.08** | **9.71** |

A CUTLASS tile is ≥64 rows in M, so at 8 rows the GEMM throws away most of its tile and the row-GEMV
wins by 1.8×. By 16 it is behind, and at 32 one GEMM pass beats four chunked GEMV passes (9.71 vs
4 × 7.28 = 29.1) by 3×. Narrow batches keep the kernel that suits them.

The B operands are the `*_fp4` / `*_fp4_sf` pair the loader already keeps resident for prefill, so
this adds **no weight memory** — only A-side staging and a workspace, both from the existing verify
arena, allocated up front because `Arena::alloc` falls back to `cudaMalloc` and this function runs
under graph capture.

## Row counts above 8 chunk rather than instantiate

`launch_gemv_nvfp4_rows_dp4a`, `_dp4a2`, `launch_gemv_rows2` and `launch_mmvq_rows_f32` recurse in
chunks of 8 instead of refusing. Instantiating R=9..16 was tried and measured: `t(16)` came out at
`1.002 × 2·t(8)` with 495 spill stores — `uint4 xg[GPT][R]` alone is 128 registers at R=16 — so a
wider template costs exactly what re-reading the weights costs.

## Precision: a real trade, stated plainly

The row-GEMV quantizes activations to **int8** with a per-16 scale; the block-scaled GEMM requires an
**NVFP4 4-bit** A operand. A request decoded in a batch of ≥16 therefore runs at lower activation
precision than the same request decoded alone.

- For it: NVFP4 activations are already the shipped **prefill** representation for this checkpoint,
  and prefill output feeds the KV cache, so this is the same representation rather than a new one.
- Against: no scored gate sees it — the differential top1/KL gate runs through the DSpark dump, whose
  verify never exceeds 8 rows.

Flagging it rather than leaving review to find it. If the trade is unwanted, the same plumbing works
with the row-GEMV and simply gives up the gain.
