### PR TITLE
perf(decode): serve the GDN projections with the block-scaled NVFP4 GEMM at wide batch (1.15x cb-decode@c32)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2798,6 +2798,17 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     // The B operands are the SAME *_fp4 / *_fp4_sf the prefill path already keeps resident, so
     // this costs no extra weight memory -- only the A-side staging and a workspace, below.
     const int fp4_kwide = (c.moe_ffn > H ? c.moe_ffn : H);
+    // Wide packed batches run the SAME block-scaled NVFP4 GEMM the dense FFN already uses, for
+    // the GDN projections as well. Those are 48 of the 64 layers and ~3.1 GB of the ~4.1 GB of
+    // per-step weight traffic that is not FFN; chunked into 8s a 32-row batch reads every one of
+    // those bytes FOUR times. Same gate as the FFN arm: the A-quantizer needs m % 8 == 0, and
+    // below 16 rows the row-GEMV is still ahead (its tile wastes most of M).
+    // SPARKINFER_PROJ_GEMM_MIN_ROWS raises or disables the threshold for an A/B in one binary.
+    static const int kProjGemmMinRows = [] {
+        const char* e = getenv("SPARKINFER_PROJ_GEMM_MIN_ROWS");
+        const int v = e ? atoi(e) : 16;
+        return v < 1 ? 1 : v;
+    }();
     unsigned char* fp4_a = nullptr; unsigned char* fp4_asf = nullptr; unsigned char* fp4_ws = nullptr;
     if (packed && c.dense_ffn) {
         const size_t ab = kernels::prefill_nvfp4_data_bytes(NA, fp4_kwide);
@@ -3370,7 +3381,17 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 pf_cu(cudaEventRecord(ev_fork, st), "verify gdn fork");
                 pf_cu(cudaStreamWaitEvent(s.stream_k, ev_fork, 0), "verify gdn fork wait");
             }
-            supported = proj(xn, w.wqkv, w.wqkv_type, rq, lqkv, H);
+            // One quantize of xn feeds both in-projections, exactly as gate/up share theirs.
+            const bool gdn_in_gemm = packed && fp4_a && fp4_asf && N >= kProjGemmMinRows &&
+                                     (N & 7) == 0 && w.gdn_qkv_fp4 && w.gdn_qkv_fp4_sf &&
+                                     w.gdn_z_fp4 && w.gdn_z_fp4_sf;
+            if (gdn_in_gemm)
+                supported = kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_asf, N, H, st) &&
+                            kernels::launch_prefill_nvfp4_gemm(
+                                fp4_a, fp4_asf, w.gdn_qkv_fp4, w.gdn_qkv_fp4_sf,
+                                rq, N, lqkv, H, fp4_ws, st, w.gdn_qkv_fp4_alpha);
+            else
+                supported = proj(xn, w.wqkv, w.wqkv_type, rq, lqkv, H);
             // alpha and beta are v_heads-wide reads of the same xn — two launches whose cost is
             // almost entirely launch/graph-node latency. One fused launch, same per-row math.
             const bool ab_fused = w.ssm_alpha_type == 0 && w.ssm_beta_type == 0 &&
@@ -3389,7 +3410,11 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             const bool split_ok = fork_gdn && ab_fused;
             if (split_ok) pf_cu(cudaEventRecord(ev_join_ab, s.stream_k), "verify gdn ab join");
             supported = supported &&
-                        proj_on(gst, xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H) &&
+                        (gdn_in_gemm
+                         ? kernels::launch_prefill_nvfp4_gemm(
+                               fp4_a, fp4_asf, w.gdn_z_fp4, w.gdn_z_fp4_sf,
+                               lz, N, lvdim, H, fp4_ws, st, w.gdn_z_fp4_alpha)
+                         : proj_on(gst, xn, w.wqkv_gate, w.wqkv_gate_type, lz, lvdim, H)) &&
                         (ab_fused || (proj_on(gst, xn, w.ssm_alpha, w.ssm_alpha_type, ra, vh, H) &&
                                       proj_on(gst, xn, w.ssm_beta, w.ssm_beta_type, rb, vh, H)));
             if (fork_gdn) {
@@ -3446,7 +3471,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 kernels::launch_prefill_gated_norm(att, lz, w.ssm_norm, lnrm, N, vh,
                                                     c.linear_head_dim, c.rms_eps, st);
             }
-            supported = proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
+            const bool gdn_out_gemm = packed && fp4_a && fp4_asf && N >= kProjGemmMinRows &&
+                                      (N & 7) == 0 && w.gdn_out_fp4 && w.gdn_out_fp4_sf;
+            if (gdn_out_gemm)
+                supported = kernels::launch_prefill_nvfp4_quant_a(lnrm, fp4_a, fp4_asf, N, lvdim, st) &&
+                            kernels::launch_prefill_nvfp4_gemm(
+                                fp4_a, fp4_asf, w.gdn_out_fp4, w.gdn_out_fp4_sf,
+                                ao, N, H, lvdim, fp4_ws, st, w.gdn_out_fp4_alpha);
+            else
+                supported = proj(lnrm, w.ssm_out, w.ssm_out_type, ao, H, lvdim);
         } else {
             // Same shape of win as the GDN block: wq is 2*qdim rows and saturates, while wk and wv
             // are kvdim rows apiece and run at well under one CTA per SM.


### PR DESCRIPTION
## Summary

#990 raised `kQwen35MaxPackedRows` to 32 and moved the **dense FFN** onto the checkpoint-native block-scaled NVFP4 GEMM above 16 rows. Every other projection still chunks into 8s, so a 32-row packed decode reads the GDN weights **four times** per step. Those are 48 of the 64 layers and ~3.1 GB of the ~4.1 GB of per-step weight traffic that is not FFN. This routes them through the same GEMM, on the same threshold, using the `gdn_*_fp4` operands the loader already keeps resident.

`wqkv` and `wqkv_gate` share one quantize of `xn`, exactly as gate/up share theirs.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`qwen3_gguf_cb_bench <model> 32 256 256 512`, arms alternated):

| | decode tok/s |
|---|--:|
| before (main) | 741.7 |
| after (this PR) | 853.3 |

`cb_bench` submits a fixed request set and never refills, so a run where every row generates all 256 tokens keeps the batch at 32 throughout, while a run that loses a row early finishes in a low-concurrency tail. That splits aggregate throughput into two modes, so the pair above is matched on `decode_tokens=8200` (all rows complete) and the mean ITL is quoted alongside:

```text
concurrency 32, both arms at decode_tokens=8200
  main    agg_tok_s=741.7  mean_itl_ms=37.94     (main good mode, 3 runs: 37.98 / 37.94 / 37.93)
  this PR agg_tok_s=853.3  mean_itl_ms=32.28     -> 1.176x on step time

concurrency 32, second pair, both partial
  main    agg_tok_s=490.3  mean_itl_ms=55.51  decode_tokens=7599
  this PR agg_tok_s=601.0  mean_itl_ms=46.98  decode_tokens=8039  -> 1.182x on step time

concurrency 16 (2 alternating pairs, decode_tokens=4104)
  main    agg_tok_s=590.7  mean_itl_ms=25.04
  this PR agg_tok_s=599.8  mean_itl_ms=24.60
```

At 16 rows the GEMV chunks 2x rather than 4x, so only a third of the saving is available there, which is what the +1.5% reflects.

## Nothing below the threshold moves

The arm requires `packed`, so DSpark's speculative verify -- which is never packed and never reaches these widths -- cannot enter it. Measured rather than argued, ctx=16384:

```text
          DSPARK_TPS   AR_TPS   MEAN_ACCEPT   LOSSLESS   PREFILL_PP
main       190.9821   89.3270      2.5098        1        11898.30
this PR    190.9913   89.3008      2.5098        1        11894.51
```

Mean accept is tokens/steps, so equality to four decimals means the verifier accepted the same tokens at the same positions across the whole generation.

