### PR TITLE
perf(decode): keep the wide N tile and drop EVICT_FIRST at continuous-batch decode widths (1.11x cb-decode@c16)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -467,6 +467,32 @@ bool prefer_narrow(int m, int n) {
     // grid to still fit ONE wave (2*ceil(n/128) <= sms) keeps gate/up wide and leaves wo (52 CTAs)
     // and q|gate|k|v (68) narrow. Measured cold-L2 at m=128, us: gate/up narrow 60.51 -> wide 56.19;
     // wo wide 25.02 -> narrow 21.63; qkvg wide 39.14 -> narrow 31.84.
+    // ...but only down to the widths this rule was measured at. Continuous-batch decode (#990,
+    // #991) runs these same GEMMs at m=16..32, and there the premise above is inverted. Halving N
+    // buys memory parallelism only while the kernel is bandwidth-bound, which it is at m=128. At
+    // m <= 32 the M tile is already computing 4-8x the rows the batch needs -- and it cannot be
+    // shrunk, because the NVFP4 scale-factor atom is 32x4 = 128 rows in M, so an M=64 tile fails
+    // the SFA TMA copy and M=32 fails the epilogue's MMA_TILE_M | EPI_TILE_M check. The kernel is
+    // therefore tile-throughput bound at these widths, and a narrower N tile only wastes the tile
+    // in a second dimension on top of M.
+    //
+    // Measured on RTX 5090 at concurrency 16, on the shapes this rule selects (FFN down n=5120,
+    // GDN qkv n=10240, gate n=6144, out n=5120), narrow -> wide: mean ITL 24.60 -> 22.42 ms,
+    // aggregate 600.8 -> 653.4 tok/s. The same sweep in the other direction confirms the
+    // direction is monotonic rather than a local optimum -- taking N below 64 at these widths
+    // costs far more than it gains (128x64x256 itl 25.69, 128x32x256 31.67, 128x32x128 48.61),
+    // even though each of those fills the machine with MORE CTAs than the wide tile does.
+    //
+    // The floor is kQwen35MaxPackedRows, the widest batch the packed decode can hand us, so
+    // m=128 -- Muse Glimmer's shapes and the scored ctx=128 prefill, which is what the paragraph
+    // above was tuned on -- keeps exactly the tiling it had. 0 restores the old rule for a paired
+    // A/B out of one binary.
+    static const int wide_batch_max = [] {
+        const char* e = getenv("SPARKINFER_NVFP4_NARROW_MIN_ROWS");
+        const int v = e ? atoi(e) : 32;
+        return v < 0 ? 0 : v;
+    }();
+    if (m <= wide_batch_max) return false;
     return on && m <= 128 && sms > 0 && 2 * ((n + 127) / 128) <= sms;
 }
 
@@ -566,6 +592,20 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
         const char* e = getenv("SPARKINFER_NVFP4_EVICT_FIRST");
         return !e || atoi(e) != 0;
     }();
+    // ...but not at wide-batch decode widths, for the same reason the narrow-N rule stops there.
+    // EVICT_FIRST tells B to surrender its L2 lines first, which is right when B is a one-shot
+    // stream far larger than L2 -- a prefill pass over the whole weight set. A packed decode step
+    // issues ~5 of these GEMMs per layer back to back over 64 layers, and hinting every one of
+    // them to self-evict discards lines the next GEMM's tail still wants. Measured at
+    // decode_tokens-matched runs: c16 650.5 -> 665.1 tok/s (mean ITL 22.52 -> 21.96), c32
+    // 851.3 -> 858.1, c8 unchanged (it never enters this GEMM).
+    // Same floor as prefer_narrow, and 0 restores the old behaviour for a paired A/B.
+    static const int ef_max = [] {
+        const char* e = getenv("SPARKINFER_NVFP4_EVICT_FIRST_MIN_ROWS");
+        const int v = e ? atoi(e) : 32;
+        return v < 0 ? 0 : v;
+    }();
+    const bool use_ef = ef && m > ef_max;
     // Long-context: a taller/wider tile than the m=128-tuned pair above. Gated on a many-CTA-tall
     // grid so the scored ctx=128 shape is untouched, and it falls through if CUTLASS cannot
     // implement the shape.
@@ -574,7 +614,7 @@ bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const 
         if (run_gemm<BigM>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c)) return true;
 
     }
-    if (ef)
+    if (use_ef)
         return prefer_narrow(m,n) ? run_gemm<NarrowEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c)
                                   : run_gemm<WideEF>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c);
     return prefer_narrow(m,n) ? run_gemm<Narrow>(a,sa,b,sb,d,m,n,k,ws,st,alpha,c)


### PR DESCRIPTION
## Summary

Two knobs in `launch_prefill_nvfp4_gemm` were fitted at prefill row counts and are wrong at the row counts continuous-batch decode now calls it with. #990 moved the dense FFN onto this GEMM and #991 the GDN projections, so a packed decode step issues ~5 of these per layer at **m=16..32** — but the tile choice and the cache hint were both tuned at m=128 and above.

**1. The N tile.** `prefer_narrow()` halves N (128 -> 64) when the wide grid stops covering the machine, on the reasoning that halving N doubles the block count and the memory parallelism with it. That holds while the GEMM is bandwidth-bound, which it is at m=128. It is not at m<=32: the M tile is stuck at 128 — the NVFP4 scale-factor atom is 32x4 = 128 rows in M, so an M=64 tile fails the SFA TMA copy (`TMA requires CTA_Tile and SLayout top-level size equivalence`) and M=32 fails the epilogue's `MMA_TILE_M must divide CTA_M` — so at m=16 the GEMM already computes 8x the rows the batch needs and is tile-throughput bound. Halving N then only wastes the tile in a second dimension on top of M.

**2. The cache hint.** B and SFB are marked `EVICT_FIRST` so the weight stream surrenders its L2 lines first. That is right when B is a one-shot stream far larger than L2 — a prefill pass over the whole weight set. A packed decode step issues those ~5 GEMMs per layer back to back across 64 layers, and hinting every one of them to self-evict discards lines the next GEMM's tail still wants.

Both get the same floor, `kQwen35MaxPackedRows` — the widest batch the packed decode can hand this function. m=128 (Muse Glimmer's shapes and the scored ctx=128 prefill, which is what both rules were tuned on) keeps exactly the behaviour it had.

Shapes affected at decode widths: FFN `down` (n=5120) and, since #991, GDN `qkv` (n=10240), `gate` (n=6144), `out` (n=5120). `gate`/`up` (n=17408) were already wide.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`qwen3_gguf_cb_bench <model> 16 256 256 512`, arms alternated):

| | decode tok/s |
|---|--:|
| before (main) | 599.6 |
| after (this PR) | 665.1 |

`cb_bench` submits a fixed request set and never refills, so a run that loses a row early finishes in a low-concurrency tail and is not comparable to one where all 16 rows generate all 256 tokens. Every number below is from a run at the full `decode_tokens`, and mean ITL is quoted alongside as the mode-robust check.

```text
concurrency 16, every run at decode_tokens=4104
  main                    agg_tok_s=600.8 / 599.5 / 598.5   mean_itl_ms=24.60 / 24.61 / 24.69
  wide N tile only        agg_tok_s=650.5 / 649.5 / 650.0   mean_itl_ms=22.54 / 22.56 / 22.51
  + EVICT_FIRST dropped   agg_tok_s=666.0 / 664.1           mean_itl_ms=21.92 / 22.00
                                          -> 1.109x aggregate, 1.121x on step time

concurrency 32, decode_tokens=8200
  main                    agg_tok_s=852.1  mean_itl_ms=32.29
  this PR                 agg_tok_s=858.1  mean_itl_ms=32.00

concurrency 8, decode_tokens=2056
  main                    agg_tok_s=501.4 / 501.3  mean_itl_ms=14.90 / 14.89
  this PR                 agg_tok_s=500.3 / 501.6  mean_itl_ms=14.92 / 14.89
```

c32 barely moves because at m=32 the M tile wastes 4x rather than 8x, so the kernel sits close enough to bandwidth-bound that the tile effect largely cancels. c8 is untouched: the FFN never enters this GEMM there (`N >= kFfnGemmMinRows`, default 16).

The tile direction is monotonic rather than a local optimum. Sweeping N the other way at c16 (mean ITL, against 24.66 for stock): `128x64x256` **25.69**, `128x32x256` **31.67**, `128x32x128` **48.61** — each of which fills the machine with *more* CTAs than the wide tile does.

## Nothing outside the wide-batch widths moves

Both floors are `m <= 32`, so DSpark's prefill (m in the thousands) and its verify (which never reaches the block-scaled GEMM) keep the tiling and the cache hint they had. Measured rather than argued, ctx=16384:

```text
          DSPARK_TPS   AR_TPS   MEAN_ACCEPT   LOSSLESS   PREFILL_PP
main       191.0248   89.3036      2.5098        1       11918.34
this PR    191.0599   89.2969      2.5098        1       11926.04
```

Mean accept is tokens/steps, so equality to four decimals means the verifier accepted the same tokens at the same positions across the whole generation. `SPARKINFER_NVFP4_NARROW_MIN_ROWS=0` and `SPARKINFER_NVFP4_EVICT_FIRST_MIN_ROWS=0` restore the previous behaviour of each half independently, for a paired A/B out of one binary.
