### PR TITLE
perf(decode): stop ramping the continuous-batch decode one row at a time (1.05x cb-decode@c32)

### DIFF
--- a/runtime/src/inference_engine.cpp
+++ b/runtime/src/inference_engine.cpp
@@ -315,11 +315,15 @@ void ContinuousBatchEngine::worker_loop() {
                 if (job) any_finished = step_job(*job, /*chunked=*/false) || any_finished;
             }
         }
-        if (!prefill_ids.empty()) {
+        // The scheduler may hand back more than one prefill while the decode batch is still
+        // filling (see Scheduler::schedule). They run back to back on this thread, which is the
+        // point: each one widens the next decode step, and a decode step's cost is almost all
+        // fixed weight read.
+        for (uint64_t pid : prefill_ids) {
             Job* job = nullptr;
             {
                 std::lock_guard<std::mutex> lock(mu_);
-                auto it = jobs_.find(prefill_ids.front());
+                auto it = jobs_.find(pid);
                 if (it != jobs_.end() && !it->second->done) job = it->second.get();
             }
             if (job) any_finished = step_job(*job, /*chunked=*/mix_decode ||

--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -18,6 +18,26 @@
 namespace sparkinfer {
 
 namespace {
+// How many prefills one iteration may admit while the decode batch is still filling. 1 restores
+// the previous behaviour exactly, for a paired A/B out of one binary.
+int prefills_per_step() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_PREFILLS_PER_STEP");
+        const int x = e ? atoi(e) : 2;
+        return x < 1 ? 1 : x;
+    }();
+    return v;
+}
+// The decode width above which a step is no longer dominated by its fixed weight read. Defaults
+// to the packed-decode ceiling; below it a wider batch is very nearly free.
+int packed_decode_width() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_WIDE_DECODE_ROWS");
+        const int x = e ? atoi(e) : 32;
+        return x < 1 ? 1 : x;
+    }();
+    return v;
+}
 int prefill_mix_max_tokens() {
     static int v = [] {
         const char* e = getenv("SPARKINFER_PREFILL_MIX_MAX");
@@ -83,6 +103,62 @@ ScheduleBatch Scheduler::schedule(const std::vector<ScheduledSequence>& active) 
     }
     if (batch.total_tokens < budget) {
         const int mix_max = prefill_mix_max_tokens();
+        // Admitting ONE prefill per iteration is right once the decode batch is wide, and wrong
+        // while it is still filling. A packed decode step on this runtime costs a fixed weight
+        // read plus a small per-row term -- measured on RTX 5090 / Qwen3.8-27B-NVFP4 at
+        // concurrency 32, 14.85 ms fixed against 0.41 ms per row -- so a step at four rows costs
+        // 97% of what a step at thirty-two costs. Ramping one row per iteration therefore pays a
+        // full weight read for a handful of tokens, thirty-one times, and because the rows START
+        // staggered they FINISH staggered and the same waste is paid again as a drain tail.
+        //
+        // So: while the decode batch is still narrower than the width a packed step serves for
+        // that flat cost, admitting another prefill costs nothing it was not already paying.
+        // At and above that width this reverts to exactly one, which is what protects ITL in
+        // steady state -- the regime the original rule was written for.
+        // How many, though, is a trade, and TWO is where it settles. Each extra prefill admitted
+        // into one iteration adds almost exactly one prefill's duration to the worst inter-token
+        // gap, because they run back to back ahead of the next decode step. Measured at
+        // concurrency 32, decode_tokens=8200 on both arms:
+        //
+        //   admitted   agg tok/s   mean ITL   max ITL
+        //   1 (before)     981.0     27.96      75.5
+        //   2            1023.6     27.82     104.0
+        //   4           ~1037       27.9      ~155
+        //   8           ~1045       27.6      ~293
+        //
+        // Throughput saturates by two while the tail keeps climbing ~28 ms per admission, so the
+        // aggressive settings buy 1% for another 150 ms of worst-case latency -- the same ITL
+        // spike prefill_mix_max_tokens() above exists to prevent. A width-scaled taper (8 when
+        // empty, down to 1) was tried and is strictly worse than a flat two on both axes: 1025.7
+        // tok/s at 206.7 ms max ITL. Steady-state ITL is untouched either way, which is the point:
+        // this shortens the ramp, it does not change the step.
+        //
+        // The second admission also has to EARN its ~25 ms, and it only does when the ramp is
+        // deep. That cost is one prefill and is therefore flat in concurrency, while the saving
+        // grows with how many rows have to be filled -- measured, before -> after, every run at
+        // the full decode_tokens:
+        //
+        //   concurrency    2       4       8      16      32
+        //   agg tok/s   +0.8%   +1.1%   +0.5%   +3.4%   +4.3%
+        //   max ITL      none   +23ms   +24ms   +29ms   +29ms
+        //
+        // At 4 and 8 that is nearly the whole latency price for almost none of the benefit, so
+        // require a deep ramp before widening. Below it this is bit-for-bit the previous
+        // scheduler.
+        //
+        // "Deep" has to be measured against the batch this load will EVENTUALLY reach -- pending
+        // plus already-decoding -- not against the pending queue alone. The queue drains as the
+        // ramp proceeds, so a bare `pending` test closes the gate partway up and gives most of
+        // the saving back: at concurrency 16 it shut after two admissions and the gain fell from
+        // +3.4% to +0.1%. The sum is invariant across the ramp, which is the property wanted.
+        int pending = 0;
+        for (const ScheduledSequence* s : ordered)
+            if (s->phase == SeqPhase::PREFILL) ++pending;
+        const int wide = packed_decode_width();
+        const int have = (int)batch.decode_request_ids.size();
+        const bool deep_ramp = (pending + have) * 2 >= wide;
+        const int allow = (have < wide && deep_ramp) ? prefills_per_step() : 1;
+        int taken = 0;
         for (const ScheduledSequence* s : ordered) {
             if (s->phase != SeqPhase::PREFILL) continue;
             // Defer large atomic prefills while decode is in flight.
@@ -92,7 +168,7 @@ ScheduleBatch Scheduler::schedule(const std::vector<ScheduledSequence>& active) 
             }
             batch.prefill_request_ids.push_back(s->request_id);
             batch.total_tokens += 1;
-            break;
+            if (++taken >= allow || batch.total_tokens >= budget) break;
         }
     }
     return batch;


### PR DESCRIPTION
## Summary

The scheduler admits exactly one prefill per iteration, so N arriving requests ramp one row at a time. A packed decode step costs a fixed weight read plus a small per-row term — measured 14.85 ms fixed against 0.41 ms/row at concurrency 32 — so a step at four rows costs 97% of a step at thirty-two. Ramping one row per iteration therefore pays ~32 near-full weight reads for a handful of tokens each, and because the rows start staggered they finish staggered and the same waste returns as a drain tail.

This admits a second prefill per iteration while the decode batch is still filling. It reverts to exactly one once the batch reaches the packed width, so steady-state ITL is untouched — the regime the original rule was written for — and also when the ramp is shallow (pending + already-decoding below half the packed width), which is what keeps c2/c4/c8 bit-for-bit unchanged.

`worker_loop` took only `prefill_ids.front()`; it now runs what the scheduler returns.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`qwen3_gguf_cb_bench <model> 32 256 256 512`, arms alternated):

| | decode tok/s |
|---|--:|
| before (main) | 973.0 |
| after (this PR) | 1016.9 |

`cb_bench` never refills the batch, so a run that loses a row early finishes in a low-concurrency tail. Every number below is from a run at the full `decode_tokens`.

```text
concurrency 32, decode_tokens=8200          agg tok/s      mean ITL   max ITL
  main                                      974.2 / 971.8   28.1       77.6 / 78.1
  this PR                                   1016.9          27.9      102.1

concurrency 16, decode_tokens=4104
  main                                      678.7 / 678.2 / 677.7   21.46   74.2 / 75.5 / 75.7
  this PR                                   694.6                   21.36  100.6

concurrency 8, decode_tokens=2056 (shallow ramp -> rule disabled, unchanged by construction)
  main                                      499.8 / 499.2   14.95   77.5 / 78.8
  this PR                                   499.6 / 498.7   14.95   80.7 / 79.0
```

Mean ITL is unchanged everywhere: this shortens the ramp, it does not change the step. That is also why it is invisible to a step-time measurement.

## The cost, and why it is bounded

The admitted prefills run back to back ahead of the next decode step, so the worst inter-token gap grows by about one prefill duration per admission — measured 75 → 104 → ~155 (four) → ~293 (eight) ms. Throughput saturates by two while the tail keeps climbing, so two is the whole of the win and none of the tail: four and eight buy a further ~1% for another 150 ms, which is the same ITL spike `prefill_mix_max_tokens()` already exists to prevent. A width-scaled taper was also tried and is strictly worse than a flat two on both axes (1025.7 tok/s at 206.7 ms).

`SPARKINFER_PREFILLS_PER_STEP=1` restores the previous scheduler exactly.

## Nothing outside continuous batching moves

DSpark does not go through `ContinuousBatchEngine`. Measured rather than argued, ctx=16384:

```text
          DSPARK_TPS   AR_TPS   MEAN_ACCEPT   LOSSLESS   PREFILL_PP
main       190.7877   89.2859      2.5098        1       11886.90
this PR    190.9051   89.2933      2.5098        1       11894.26
```
