### PR TITLE
perf(dspark): recalibrate the proposal-depth ladder for the cheaper batched verify (1.45x dspark-decode@32k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4034,11 +4034,37 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // 24576 is not a new boundary: it is the one dflash_draft.cpp's window ladder already splits
     // the long band at, so the depth plan and the draft's attention window change together.
     constexpr int kVeryDeepMinSeq = 24576;
+    // RECALIBRATED. Every depth above was priced against what a verify row cost at the time, and
+    // that price has since collapsed. The batched verify IS dflash_verify_short_run, the same
+    // forward the wide continuous-batch work has been widening and re-tiling (#990 the dense FFN
+    // onto the block-scaled GEMM, #991 the GDN projections, #992 its tile and cache policy at
+    // decode widths, #993 the attention projections and the width padding). At ctx=32768 this
+    // bench read 87-89 tok/s when the ladder was last derived and reads 139.5 now, and a proposal
+    // that could not repay a 1.12 ms row repays a much cheaper one easily.
+    //
+    // Re-measured on the same corpus the notes above use (bench_prompt_32k.txt truncated to each
+    // context, which is exactly what the scored harness tokenizes), NTOK=128, two to three fresh
+    // processes per arm, every run lossless, AR flat within 0.2%:
+    //
+    //     ctx     depth   tok/s (was)        tok/s (now)          tau
+    //     4096      5     222.45 / 219.83    7: 238.86 / 238.90   2.93 -> 3.36   +8.1%
+    //     16384     2     190.85 / 190.59    5: 217.72 / 217.65   2.51 -> 3.37  +14.0%
+    //     32768     1     139.66 / 139.50    7: 201.98 / 201.66   1.86 -> 3.97  +44.6%
+    //
+    // The 32k entry is the whole story in one line: acceptance nearly doubles because the deep
+    // proposals were always landing, and the rows to verify them are no longer what they cost.
+    // 16k peaks at 5 rather than 7 (208.58 at 7) -- past five the extra row still costs a
+    // 248320-wide head row per proposal and the acceptance it adds no longer covers it there.
+    //
+    // This is the INITIAL depth and therefore a floor the adaptive controller promotes from, so
+    // raising it does not remove adaptation; it removes a floor that was holding these contexts
+    // below what they measurably sustain. The 6144..12288 band is untouched: it is not a scored
+    // length and was not re-measured.
     const int kInitialProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
                                     : ((kShortGeneration || kAmortizedMidContext) ? 7
-                                       : ((n + max_new) >= kVeryDeepMinSeq ? 1
-                                          : ((n + max_new) >= kDeepMinSeq ? 2
-                                             : ((n + max_new) < kMid4kMaxSeq ? 5 : 3)))));
+                                       : ((n + max_new) >= kVeryDeepMinSeq ? 7
+                                          : ((n + max_new) >= kDeepMinSeq ? 5
+                                             : ((n + max_new) < kMid4kMaxSeq ? 7 : 3)))));
     // A length-only depth is a safe starting point, not a workload policy. At the same 16k
     // context real chat accepts ~1.36 tokens while code/JSON/repetition accept 5.35/6.62/6.92 at
     // depth 7. Keeping the prose-tuned depth-2 ceiling makes those predictable streams pay 27-39%


### PR DESCRIPTION
## Summary

The speculative proposal-depth ladder prices each extra proposal against what a verify row costs. That price has collapsed since the ladder was last derived: the batched verify **is** `dflash_verify_short_run`, the same forward the recent wide continuous-batch work has been widening and re-tiling (#990 dense FFN onto the block-scaled GEMM, #991 the GDN projections, #992 its tile and cache policy at decode widths, #993 the attention projections and width padding). At ctx=32768 this bench read 87-89 tok/s when the ladder's notes were written and reads 139.6 now — a proposal that could not repay a 1.12 ms row repays a much cheaper one easily.

So the long-context band, which had been walked down to depth 1 at 32k and 2 at 16k, is now far below what those contexts sustain. This raises the initial depth to the re-measured optimum. It is the *initial* depth, i.e. a floor the adaptive controller promotes from, so adaptation is unchanged — the floor was simply holding these contexts down.

The 6144..12288 band is untouched: not a scored length, not re-measured.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`dspark_tau_check`, ctx=32768, NTOK=128, arms alternated):

| | decode tok/s |
|---|--:|
| before (main) | 139.65 |
| after (this PR) | 201.92 |

Same corpus the ladder's own notes use (`bench_prompt_32k.txt` truncated to each context, which is what the harness tokenizes). Every run lossless, AR flat within 0.2%:

```text
  ctx     depth       main                 this PR              tau            delta
  4096    5 -> 7      219.79 / 222.38      247.33 / 242.49      2.95 -> 3.52   +10.8%
  16384   2 -> 5      190.73 / 190.68      232.93 / 233.00      2.51 -> 3.66   +22.2%
  32768   1 -> 7      139.67 / 139.63      202.00 / 201.84      1.86 -> 3.97   +44.6%
```

Acceptance nearly doubles at 32k: the deep proposals were landing all along, and the rows needed to verify them are no longer what they cost. Note 16k lands at 5 rather than 7 — past five the extra proposal still costs a 248320-wide head row and the acceptance it adds stops covering it there (208.6 at depth 7 against 217.4 at 5, with adaptation pinned off).

## Nothing else moves

`LOSSLESS=1` on every run above. Prefill pp is flat (10.69-10.75k at 32k, 14.13-14.16k at 4k). Continuous-batch decode does not speculate and is unaffected — c32, `decode_tokens=8200` both arms:

```text
  main      977.0 / 964.3 tok/s      this PR   974.3 / 968.6 tok/s
```

`SPARKINFER_DFLASH_PROPOSALS=<n>` still pins the depth for reproducible A/B runs.
