### PR TITLE
perf(decode): score the continuous-batch head with the multi-row Q4_K kernel (1.075x cb-decode@c32)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -4003,9 +4003,45 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             const char* e = getenv("SPARKINFER_DFLASH_VERIFY_HEAD_ROWS");
             return !(e && e[0] == '0');
         }();
-        head_ok = head_rows_on && N > 1 &&
-                  kernels::launch_mmvq_rows_f32(s.w.lm_head_type, q81, s.w.lm_head, logits,
-                                                N, c.vocab, H, st);
+        // Continuous-batch decode scores its head with the multi-row kernel instead. Same Q4_K
+        // weights, same [M, vocab] output, but one warp owns an output row and reduces with a bare
+        // shfl_xor, where si_mmvq_q4k_rows_exact_kernel spends four warps and an smem fold on two
+        // rows. That kernel's own header already measured the gap on this exact head ("0.771 ms at
+        // GRP=1 against a draft-side multi-row head that moves the same bytes in 0.578") -- it was
+        // simply never wired to anything but the draft.
+        //
+        // Chunked by 8, not by the 16 the launcher accepts: it carries exact, compile-time-bounded
+        // bodies only to M=8, and 9..16 land in a predicated MMAX=16 body at 56 registers against
+        // 39-40. Measured, the narrower chunk wins despite re-reading the head twice as often --
+        // c=16 687.6 tok/s at width 8 against 664.2 at width 16.
+        //
+        // PACKED ONLY, and that restriction is load-bearing. The multi-row kernel partitions the
+        // super-blocks across lanes differently, so its rounding differs from the rows kernel AR
+        // scores with. A continuous-batch step is a plain argmax emit and absorbs that; the
+        // speculative verify cannot, because dspark_tau_check gates on the speculative tokens being
+        // IDENTICAL to the same build's AR tokens. `packed` separates them exactly -- decode_packed
+        // sets packed_rows, DSpark's verify never does -- so every dspark-* path keeps the rows
+        // kernel and stays bit-identical. Opt out with SPARKINFER_CB_HEAD_MULTIROW=0.
+        static const bool cb_head_mr = []{ const char* e = getenv("SPARKINFER_CB_HEAD_MULTIROW");
+                                           return !(e && e[0] == '0'); }();
+        bool mr_done = false;
+        if (cb_head_mr && packed && N > 1) {
+            const size_t q81_row_bytes = kernels::llama_q8_1_bytes(H);
+            bool mr_ok = true;
+            for (int r0 = 0; r0 < N && mr_ok; r0 += 8) {
+                const int m = (N - r0) < 8 ? (N - r0) : 8;
+                mr_ok = kernels::launch_gemv_q4k_dp4a_multirow_f32(
+                    static_cast<const unsigned char*>(q81) + (size_t)r0 * q81_row_bytes,
+                    s.w.lm_head, logits + (size_t)r0 * c.vocab, c.vocab, H, m, st);
+            }
+            // A partial run would have scored some rows and left the rest stale, so only a fully
+            // successful sweep may claim the head; anything else falls through and redoes all N.
+            mr_done = mr_ok;
+        }
+        head_ok = mr_done ||
+                  (head_rows_on && N > 1 &&
+                   kernels::launch_mmvq_rows_f32(s.w.lm_head_type, q81, s.w.lm_head, logits,
+                                                 N, c.vocab, H, st));
         if (!head_ok) {
             const size_t q81_row_bytes = kernels::llama_q8_1_bytes(H);
             for (int r = 0; r < N; ++r) {


### PR DESCRIPTION
## Summary

Continuous-batch decode scores its LM head with `si_mmvq_q4k_rows_exact_kernel`, which spends four
warps and a shared-memory fold on two output rows. A second Q4_K multi-row head already exists in
the tree, already instantiated for `NSUPER=20` (K=5120, this model's hidden size), giving one warp
per output row and a bare `shfl_xor` reduction — but it is only ever reached from the draft. This
routes the packed decode head to it.

Measured with the repeat probe below, the head is **10.2 / 12.9 / 20.5 %** of a decode step at
concurrency 8 / 16 / 32, so it is the largest single term left in a wide continuous-batch step.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (aggregate continuous-batch decode, 32 concurrent requests):

| | decode tok/s |
|---|--:|
| before (main) | 939.0 |
| after (this PR) | 1009.4 |

**Prefill pp tok/s** — not targeted by this PR:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

## Results

One binary for both arms — "before" is the `SPARKINFER_CB_HEAD_MULTIROW=0` opt-out, "after" is
plain defaults. A throwaway bench runs first so no timed arm sees cold clocks, and every `before`
is measured twice, either side of the `after`, so drift is bounded rather than assumed.

| | before | before (repeat) | after | |
|---|--:|--:|--:|--:|
| cb-decode@c1 | 95.1 | 95.1 | 95.0 | flat (declines at N=1) |
| cb-decode@c2 | 184.6 | 184.6 | 184.7 | flat |
| cb-decode@c4 | 308.5 | 308.2 | 315.0 | **+2.2%** |
| cb-decode@c8 | 480.5 | 478.1 | 498.6 | **+4.0%** |
| cb-decode@c16 | 654.1 | 653.9 | 687.3 | **+5.1%** |
| cb-decode@c32 | 938.2 | 939.8 | 1009.4 | **+7.5%** |

## Why chunk by 8 and not 16

`launch_gemv_q4k_dp4a_multirow_f32` accepts up to `M=16`, but carries exact, compile-time-bounded
bodies only to `M=8`; 9..16 land in a predicated `MMAX=16` body its own header measures at 56
registers against 39-40. The narrower chunk wins despite re-reading the head twice as often:

| | width 16 | width 8 |
|---|--:|--:|
| cb-decode@c16 | 664.2 | **687.6** |
| cb-decode@c32 | 964.4 | **1014.4** |

Adding exact `MFIXED=9..16` bodies recovers most of that at c32 (1013.7) but still loses at c16
(680.1), so the chunk width is the simpler and better answer and no kernel changes.

## Speculative decode is untouched, by construction

The multi-row kernel partitions super-blocks across lanes differently, so its rounding differs from
the rows kernel AR scores with. That is fine for a plain argmax emit and **not** fine for the
speculative verify, which is gated on reproducing AR exactly. The change is therefore gated on
`packed` — `decode_packed` sets `packed_rows`, DSpark's verify never does — so every `dspark-*`
path keeps the rows kernel.

`dspark_tau_check`, both arms, all three contexts:

| ctx | LOSSLESS | mean-accept before | mean-accept after | dspark tok/s before | after | AR before | after |
|---|:-:|--:|--:|--:|--:|--:|--:|
| 4k | 1 / 1 | 1.6883 | 1.6883 | 129.43 | 129.53 | 93.043 | 93.045 |
| 16k | 1 / 1 | 1.7297 | 1.7297 | 129.90 | 129.84 | 88.552 | 88.393 |
| 32k | 1 / 1 | 1.3299 | 1.3299 | 97.455 | 97.429 | 82.947 | 82.968 |

Mean-accept is **exactly equal** at every context and the dumped token streams are md5-identical,
which is what bit-identity looks like from outside. The 32k rows are means of three runs per arm
(within-arm spread 0.18%); a single earlier sample read 95.71 and was a ~2% outlier against six
subsequent readings.

## What changes in served output, measured rather than asserted

Emitted continuous-batch tokens do move. They also move between two runs of an unmodified build:

| c=16, per-sequence comparison | tokens differing | sequences |
|---|--:|--:|
| stock main, run b vs run a | 72.8% | 16/17 |
| stock main, run c vs run a | 57.1% | 15/17 |
| this PR vs opt-out | 66.3% | 15/17 |

Median first divergence is position ~22 in all three; greedy decoding then cascades, which is why a
single early flip shows up as most of the stream. The PR's divergence sits inside the range stock
main already spans against itself, so continuous-batch output is not a stable reference today and
this change does not make it less so. (Comparisons are hashed per sequence, not per step — batch
composition is timing-dependent, so a per-step hash compares different points in the stream.)

## Method note

The head's share was measured by running it 2x and 3x rather than by ablating it, so a launch that
silently fails reads as a slowdown instead of a speedup. Both slopes agree at every concurrency:
c8 +1.56/+1.62 ms, c16 +2.90/+2.91, c32 +5.87/+6.38.

```text
# one binary, SPARKINFER_CB_HEAD_MULTIROW toggles the arm
# qwen3_gguf_cb_bench <model> <concurrency> 256 256 512
cb-decode@c32  off   agg_tok_s=938.2   mean_itl_ms=30.04
cb-decode@c32  ON    agg_tok_s=1009.4  mean_itl_ms=27.64
cb-decode@c32  off2  agg_tok_s=939.8   mean_itl_ms=29.93
cb-decode@c16  off   agg_tok_s=654.1   mean_itl_ms=22.50
cb-decode@c16  ON    agg_tok_s=687.3   mean_itl_ms=21.41
cb-decode@c16  off2  agg_tok_s=653.9   mean_itl_ms=22.58
cb-decode@c8   off   agg_tok_s=480.5   mean_itl_ms=15.39
cb-decode@c8   ON    agg_tok_s=498.6   mean_itl_ms=14.85
cb-decode@c8   off2  agg_tok_s=478.1   mean_itl_ms=15.52
```
