### PR TITLE
perf(decode): serve the wide continuous-batch LM head from the checkpoint's own NVFP4 (1.09x cb-decode@c32)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -124,12 +124,14 @@ struct MmaEvictFirstB : Base {
     }
 };
 
-template <class TileShape, bool EvictFirstB = false>
+template <class TileShape, bool EvictFirstB = false, class ElemD = BF>
 struct Cfg {
+    // Alignment is 128 bits / sizeof(element): 8 for bf16, 4 for float.
+    static constexpr int kAlignD = 16 / (int)sizeof(ElemD);
     using Epilogue = typename cutlass::epilogue::collective::CollectiveBuilder<
         cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp, TileShape, Cluster,
         cutlass::epilogue::collective::EpilogueTileAuto, float, float,
-        BF, cutlass::layout::RowMajor, 8, BF, cutlass::layout::RowMajor, 8,
+        ElemD, cutlass::layout::RowMajor, kAlignD, ElemD, cutlass::layout::RowMajor, kAlignD,
         cutlass::epilogue::collective::EpilogueScheduleAuto>::CollectiveOp;
     using Mainloop = typename cutlass::gemm::collective::CollectiveBuilder<
         cutlass::arch::Sm120, cutlass::arch::OpClassBlockScaledTensorOp,
@@ -167,6 +169,10 @@ using NarrowEF = Cfg<Shape<_128, _64, _256>, true>;
 // -- and non-power-of-two tiles fail cute's stride-divisibility and the epilogue's
 // MMA_TILE_M | EPI_TILE_M check, so 256x128x128 is the reachable optimum.
 using BigM = Cfg<Shape<_256, _128, _128>, true>;
+// Same wide tile, float output. The LM head is the one GEMM in this runtime whose destination is
+// the logit buffer rather than an activation, and logits are float: rounding them to bf16 would
+// put ties into argmax that the Q4_K head it replaces does not have.
+using WideF32 = Cfg<Shape<_128, _128, _256>, false, float>;
 // M is the axis that pays (256x128 beat 128x128 by 6.7% at m=16384 while 128x256 lost 14%), so
 // probe further up it. K stays >=128: at 64 the mainloop has too few elements per stage to cover
 // its own latency and the GEMM collapses (measured 2494 pp, a 4x loss).
@@ -431,9 +437,10 @@ typename C::Gemm::Arguments args(const void* a, const void* sa, const void* b, c
     // beta MUST stay 0: the epilogue skips the C load entirely on beta == 0, and a non-zero beta
     // over a null pointer faults.
     const float beta = c ? 1.f : 0.f;
+    using ED = typename C::Gemm::ElementD;
     return {cutlass::gemm::GemmUniversalMode::kGemm, shape(m,n,k),
             {static_cast<const cutlass::float_e2m1_t*>(a), as, static_cast<const cutlass::float_e2m1_t*>(b), bs, static_cast<const cutlass::float_ue4m3_t*>(sa), sfa_layout(m,n,k), static_cast<const cutlass::float_ue4m3_t*>(sb), sfb_layout(m,n,k)},
-            {{alpha, beta}, static_cast<const BF*>(c), cs, static_cast<BF*>(d), ds}};
+            {{alpha, beta}, static_cast<const ED*>(c), cs, static_cast<ED*>(d), ds}};
 }
 
 int sm_count() {
@@ -582,6 +589,20 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
     quant_rows_dispatch(blocks,st,(const __nv_bfloat16*)s,(unsigned char*)d,
                         (cutlass::float_ue4m3_t*)sf,n,k,l);
     return cudaPeekAtLastError() == cudaSuccess;
+}
+size_t prefill_nvfp4_workspace_bytes_f32(int m, int n, int k) {
+    return WideF32::Gemm::get_workspace_size(
+        args<WideF32>(nullptr,nullptr,nullptr,nullptr,nullptr,m,n,k));
+}
+// Float-destination twin of launch_prefill_nvfp4_gemm. One tiling only: its single caller is the
+// LM head, whose n is the vocabulary (1940 CTAs of the wide tile at 248320 columns), so the
+// machine is covered many times over and the narrow/big-tile choices below have nothing to pick
+// between.
+bool launch_prefill_nvfp4_gemm_f32(const void* a,const void* sa,const void* b,const void* sb,
+                                   void* d,int m,int n,int k,void* ws,cudaStream_t st,
+                                   float alpha) {
+    if (!a||!sa||!b||!sb||!d||!prefill_nvfp4_supported(m,n,k)) return false;
+    return run_gemm<WideF32>(a,sa,b,sb,d,m,n,k,ws,st,alpha,nullptr);
 }
 bool launch_prefill_nvfp4_gemm(const void* a,const void* sa,const void* b,const void* sb,
                                void* d,int m,int n,int k,void* ws,cudaStream_t st, float alpha,

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -34,6 +34,10 @@ bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst
 // folded into the block-scaled GEMM rather than run as a separate full-tensor pass.
 // c_bf16 may alias d_bf16 (the in-place x += proj form); the epilogue reads each
 // output tile before it stores it.
+size_t prefill_nvfp4_workspace_bytes_f32(int m, int n, int k);
+bool launch_prefill_nvfp4_gemm_f32(const void* a, const void* sa, const void* b,
+                                   const void* sb, void* d, int m, int n, int k,
+                                   void* ws, cudaStream_t st, float alpha = 1.f);
 bool launch_prefill_nvfp4_gemm(const void* a_fp4, const void* sfa,
                                const void* b_fp4, const void* sfb,
                                void* d_bf16, int m, int n, int k,

--- a/runtime/include/sparkinfer/models/qwen35.h
+++ b/runtime/include/sparkinfer/models/qwen35.h
@@ -179,6 +179,12 @@ struct Qwen35Weights {
     const void* final_norm   = nullptr;  // [hidden]
     const void* lm_head      = nullptr;  // [hidden, vocab]  (pre-transposed)
     int lm_head_type = 0;                 // 0 = bf16; else ggml type -> on-read quantized GEMV
+    // The checkpoint's OWN NVFP4 lm_head in the block-scaled GEMM's operand layout, kept beside
+    // the Q4_K copy rather than replacing it: AR decode and the speculative verify keep reading
+    // lm_head above byte for byte, and only a packed decode wide enough to want a GEMM reads
+    // these. Built only when the checkpoint actually ships an NVFP4 head and VRAM allows.
+    const void* lm_head_fp4 = nullptr; const void* lm_head_fp4_sf = nullptr;
+    float lm_head_fp4_alpha = 1.f;
     std::vector<Qwen35LayerWeights> layers;
 };
 
@@ -428,6 +434,8 @@ public:
     // seed token, so last_token_logprobs() is valid immediately after this returns -- see
     // ingest_prompt_range's identical parameter. Off by default: it costs a full-vocab sort, and
     // the seed's logprob is only wanted when the request asked for logprobs.
+    // Hand back the NVFP4 LM-head operand (see Qwen35Weights::lm_head_fp4). Idempotent.
+    void release_lm_head_fp4();
     int prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob = false,
                         int pos0 = 0);
     // Same pass, ingested as position-windows so the scratch arena is bounded by the window

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -238,6 +238,9 @@ struct Qwen35Model::Impl {
     bool dflash_graph_ready = false;
     int dflash_graph_attn_mode = -1;
     bool dflash_graph_sparse = false;
+    // The NVFP4 LM-head operand, held here rather than in `owned` because it is releasable.
+    void* lm_head_fp4_payload = nullptr;
+    void* lm_head_fp4_sf_buf = nullptr;
     // Reusable device pointer arrays for packed decode (see Qwen35Model::decode_packed). Their
     // ADDRESSES are baked into the packed graph; their CONTENTS are rewritten every step, which
     // is what lets one graph per row count serve any set of sessions.
@@ -759,6 +762,8 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
 }
 
 Qwen35Model::~Qwen35Model() {
+    if (p_->lm_head_fp4_payload) cudaFree(p_->lm_head_fp4_payload);
+    if (p_->lm_head_fp4_sf_buf) cudaFree(p_->lm_head_fp4_sf_buf);
     for (void* b : p_->owned) cudaFree(b);
     cudaFree(p_->x); cudaFree(p_->xn); cudaFree(p_->q); cudaFree(p_->k); cudaFree(p_->v);
     cudaFree(p_->attn); cudaFree(p_->ao); cudaFree(p_->h); cudaFree(p_->hn);
@@ -2997,9 +3002,44 @@ double Qwen35Model::bench_ttft(const std::vector<int>& prompt) {
 
 // Thin adapter: hand the batched-prefill orchestration (qwen35_prefill.cpp) exactly the scratch
 // buffers, streams and config it needs, so Impl stays private to this file.
+// Give the NVFP4 LM-head operand back. It exists only to serve a packed decode wide enough to
+// want a GEMM, and it is the one piece of weight residency in this model that a run can decide it
+// does not need.
+void Qwen35Model::release_lm_head_fp4() {
+    Impl& s = *p_;
+    if (!s.lm_head_fp4_payload && !s.lm_head_fp4_sf_buf) return;
+    s.w.lm_head_fp4 = nullptr;
+    s.w.lm_head_fp4_sf = nullptr;
+    if (s.lm_head_fp4_payload) cudaFree(s.lm_head_fp4_payload);
+    if (s.lm_head_fp4_sf_buf) cudaFree(s.lm_head_fp4_sf_buf);
+    s.lm_head_fp4_payload = nullptr;
+    s.lm_head_fp4_sf_buf = nullptr;
+}
+
 int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_logprob,
                                  int pos0) {
     Impl& s = *p_;
+    // A long batched prefill needs the scratch arena more than a wide decode needs the head, and
+    // on a 32-GB card the two do not both fit: measured at ctx=32768 the arena wants 3.6 GB and
+    // the head operand's 0.81 GB is enough to make it fail, which drops the WHOLE prompt onto the
+    // token loop -- a ~30x regression on a no-regression floor, to buy a win that only exists at
+    // packed widths >= 16. So hand it back before sizing the arena rather than after failing to.
+    //
+    // A load-time VRAM check cannot make this call: measured free-at-load is 25.2 GB for the 32k
+    // DSpark harness against 22.9 GB for the concurrency harness, i.e. the run that must NOT keep
+    // the operand is the one with MORE headroom at the moment of the decision -- the KV cache and
+    // the arena are both taken afterwards. The prompt length is the signal that actually
+    // separates them.
+    static const int kHeadFp4YieldTokens = [] {
+        const char* e = getenv("SPARKINFER_Q38_HEAD_NVFP4_YIELD_TOKENS");
+        const int v = e ? atoi(e) : 1024;
+        return v < 1 ? 1 : v;
+    }();
+    if (n >= kHeadFp4YieldTokens && (s.lm_head_fp4_payload || s.lm_head_fp4_sf_buf)) {
+        fprintf(stderr, "[compressed-tensors] NVFP4 lm_head released for a %d-token batched "
+                        "prefill (the scratch arena needs the VRAM more)\n", n);
+        release_lm_head_fp4();
+    }
     auto it = s.sessions.find(s.active_seq_id);
     float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
     bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
@@ -6311,6 +6351,62 @@ bool Qwen35Model::load_compressed_tensors(const std::string& model_dir) {
     s.w.lm_head = requant_q4k(dequant_any("lm_head", c.vocab, H), (long)c.vocab * H,
                               s.w.lm_head_type);
     if (!s.w.embed_tokens || !s.w.final_norm || !s.w.lm_head) return false;
+    // ...and, when the checkpoint ships the head as NVFP4, keep its own bytes as well, in the
+    // block-scaled GEMM's operand layout. Every other big tensor already went this way (the FFN
+    // and, since the attention block above, q/k/v/o); the head was the last one still served only
+    // from a Q4_K refit of the checkpoint's own values.
+    //
+    // BESIDE the Q4_K copy, not instead of it: AR decode and the speculative verify keep reading
+    // lm_head byte for byte, so acceptance, losslessness and the accuracy gate are untouched.
+    // keep_nvfp4 aliases the GEMM's data operand onto the payload it just uploaded, so the only
+    // NEW residency beyond that payload is the re-laid-out scale copy -- 0.0625 B/weight, 79 MB
+    // at this head's 248320x5120.
+    //
+    // Gated on free VRAM with a reserve, decided here and once: this model already peaks near the
+    // card at long context, and the batched-prefill scratch arena is allocated later and per run.
+    // Spending the arena's headroom on a decode-only operand would trade a no-regression floor
+    // (prefill at 32k drops to the token loop when the arena cannot be carved) for a win that only
+    // exists at packed widths >= 16 -- which is a trade in the wrong direction, so when the
+    // reserve is not clear this simply stays off and the head keeps the path it had.
+    // SPARKINFER_Q38_HEAD_NVFP4=0 disables it; _RESERVE_MB tunes the reserve.
+    static const bool head_fp4_on = [] {
+        const char* e = getenv("SPARKINFER_Q38_HEAD_NVFP4");
+        return !(e && e[0] == '0');
+    }();
+    if (head_fp4_on) {
+        NvFp4Src head_probe{};
+        if (nvfp4_src("lm_head", c.vocab, H, head_probe)) {
+            const size_t need = (size_t)c.vocab * H * 5 / 8 +                    // payload
+                                kernels::prefill_nvfp4_scale_bytes_b(c.vocab, H); // SFB copy
+            static const size_t reserve_mb = [] {
+                const char* e = getenv("SPARKINFER_Q38_HEAD_NVFP4_RESERVE_MB");
+                const long v = e ? atol(e) : 3072;
+                return (size_t)(v < 0 ? 0 : v);
+            }();
+            size_t hfree = 0, htotal = 0;
+            cudaMemGetInfo(&hfree, &htotal);
+            if (hfree > need + reserve_mb * 1024ull * 1024ull) {
+                const size_t owned_before = s.owned.size();
+                keep_nvfp4("lm_head", c.vocab, H, &s.w.lm_head_fp4, &s.w.lm_head_fp4_sf,
+                           s.w.lm_head_fp4_alpha);
+                // Take the two buffers OUT of s.owned and hold them here instead. They are the
+                // only weights in this model that can be given back at runtime (see
+                // release_lm_head_fp4), and s.owned is freed wholesale at teardown -- an entry
+                // that a release has already freed would be a double free.
+                if (s.w.lm_head_fp4 && s.owned.size() == owned_before + 2) {
+                    s.lm_head_fp4_sf_buf = s.owned.back(); s.owned.pop_back();
+                    s.lm_head_fp4_payload = s.owned.back(); s.owned.pop_back();
+                }
+            }
+            if (!s.w.lm_head_fp4)
+                fprintf(stderr, "[compressed-tensors] NVFP4 lm_head not kept "
+                        "(free %.2f GB, need %.2f GB + %zu MB reserve)\n",
+                        hfree / 1073741824.0, need / 1073741824.0, reserve_mb);
+            else
+                fprintf(stderr, "[compressed-tensors] NVFP4 lm_head kept for wide packed decode "
+                        "(%.2f GB)\n", need / 1073741824.0);
+        }
+    }
 
     s.w.layers.resize(c.n_layers);
     int gu_ready = 0;

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -2839,6 +2839,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         size_t wb = kernels::prefill_nvfp4_workspace_bytes(NA, c.moe_ffn, H);
         const size_t wb2 = kernels::prefill_nvfp4_workspace_bytes(NA, H, c.moe_ffn);
         if (wb2 > wb) wb = wb2;
+        // ...and the LM head, when this build will run it through the block-scaled GEMM. One
+        // buffer serves whichever GEMM the pass launches, so it has to cover the widest of them
+        // or initialize() fails and the head silently falls back.
+        if (s.w.lm_head_fp4) {
+            const size_t wb3 = kernels::prefill_nvfp4_workspace_bytes_f32(NA, c.vocab, H);
+            if (wb3 > wb) wb = wb3;
+        }
         fp4_a   = a.alloc<unsigned char>(ab);
         fp4_asf = a.alloc<unsigned char>(sb);
         if (wb) fp4_ws = a.alloc<unsigned char>(wb);
@@ -3967,7 +3974,42 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         const char* e = getenv("SPARKINFER_DFLASH_VERIFY_HEAD_I8");
         return e && e[0] != '0';
     }();
-    if (verify_head_i8_on && verify_head_i8) {
+    // Wide packed decode: run the head as ONE block-scaled GEMM over the checkpoint's own NVFP4
+    // weights instead of chunk-of-8 Q4_K row-GEMVs over a refit of them.
+    //
+    // The Q4_K head is the single largest kernel left in a wide continuous-batch step -- 8.9% of
+    // the c16 wall and 15.5% at c32 -- and it is entirely on the critical path: forcing it onto
+    // its one-row form costs exactly the 4.60 ms/step its kernel time predicts. It reads 715 MB
+    // per launch at 670 GB/s, against the 1690 GB/s its OWN one-row twin reaches on the same
+    // bytes, and it is bound by neither of its traffic terms -- cutting the activation re-read 2x
+    // and 4x (GRP) and the weight passes 2x (MMAX=16) each measure flat, and OROWS in either
+    // direction loses. What is left is the Q4_K inner loop itself, so the way out is a different
+    // kernel, not a better shape for this one.
+    //
+    // At the vocabulary's width the GEMM is the shape CUTLASS wants: n=248320 is 1940 CTAs of the
+    // wide tile, eleven waves of a 170-SM part, where the FFN's own decode GEMMs get 40 to 136.
+    // And it collapses four chunked launches at c32 into one pass over the weights.
+    //
+    // Scoped to N >= kHeadGemmMinRows, which no speculative verify reaches (the proposal ceiling
+    // is the draft's block size, 7 here): AR decode, the verify, prefill and every accuracy and
+    // acceptance gate keep reading the Q4_K head byte for byte. This changes the wide packed
+    // decode path only.
+    static const int kHeadGemmMinRows = [] {
+        const char* e = getenv("SPARKINFER_Q38_HEAD_GEMM_MIN_ROWS");
+        const int v = e ? atoi(e) : 16;
+        return v < 1 ? 1 : v;
+    }();
+    if (packed && N >= kHeadGemmMinRows && !(N & 7) && s.w.lm_head_fp4 && s.w.lm_head_fp4_sf &&
+        fp4_a && fp4_asf) {
+        head_ok = kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_asf, N, H, st) &&
+                  kernels::launch_prefill_nvfp4_gemm_f32(fp4_a, fp4_asf, s.w.lm_head_fp4,
+                                                         s.w.lm_head_fp4_sf, logits,
+                                                         N, c.vocab, H, fp4_ws, st,
+                                                         s.w.lm_head_fp4_alpha);
+    }
+    if (head_ok) {
+        // served by the block-scaled GEMM above
+    } else if (verify_head_i8_on && verify_head_i8) {
         head_ok = kernels::launch_gemv_i8_q81_multirow_f32(
             q81, verify_head_i8, verify_head_scale, logits, c.vocab, H, N, st);
     } else if (s.w.lm_head_type == 12) {


### PR DESCRIPTION
## Summary

The packed-decode LM head still runs a Q4_K refit of weights the checkpoint already ships as NVFP4, in chunks of 8 rows. Keep the checkpoint's own bytes and score a packed batch of >= 16 rows as one block-scaled GEMM instead — four chunked GEMVs at c32 become a single pass over the head.

Gated on `packed` and on >= 16 rows, which no speculative verify reaches (the proposal ceiling is the draft's block size, 7). AR decode, the verify and every prefill keep the Q4_K head byte for byte, so acceptance is identical at all three scored contexts and losslessness holds.

The operand costs 0.81 GB, enough to starve the batched-prefill scratch arena at ctx=32768, so it is handed back before any batched prefill of >= 1024 tokens. A load-time VRAM check cannot make that call: free-at-load is 25.2 GB for the 32k harness against 22.9 GB for the concurrency harness — the run that must not keep it has *more* headroom at the moment of the decision.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`qwen3_gguf_cb_bench <ckpt> C 256 256 512`, ModelOpt NVFP4 checkpoint, two repeats per arm, all at the full `decode_tokens`):

| | decode tok/s |
|---|--:|
| before (main) | 1068.1 |
| after (this PR) | **1167.1** |

That is c32, **+9.27%**. c16 721.3 -> 752.8 (+4.37%); c1/c2/c4/c8 flat within 0.2% — the new path needs 16 packed rows.

**Prefill pp tok/s** (`--ctx 32768`) — not this PR's target, shown as a no-regression floor:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 11088.59 |
| after prefill (this PR) | 11061.02 |

```text
# qwen3_gguf_cb_bench <ckpt> C 256 256 512          main 19ef39e -> this PR
c=1    96.4 ->  96.4    c=2  190.0 -> 190.0    c=4  338.5 -> 338.4    c=8  522.9 -> 523.8
c=16  721.4 -> 751.8  |  721.1 -> 753.8        (mean itl 20.59 -> 19.66 ms)
c=32 1070.7 ->1167.1  | 1065.5 ->1167.1        (mean itl 26.54 -> 24.00 ms, max itl unchanged)

# dspark_tau_check <target> <draft> 128 @ids        main -> this PR
ctx=4096   decode 132.7624 -> 132.5900   prefill 15086.17 -> 15066.90   accept 1.6883 -> 1.6883   lossless 1 -> 1
ctx=16384  decode 132.8536 -> 133.0768   prefill 12436.59 -> 12409.14   accept 1.7297 -> 1.7297   lossless 1 -> 1
ctx=32768  decode 100.2038 -> 100.0850   prefill 11088.59 -> 11061.02   accept 1.3299 -> 1.3299   lossless 1 -> 1

# "scratch alloc failed" at ctx=32768: 0 occurrences.
```
