### PR TITLE
perf(decode): hold the continuous-batch GDN recurrent state in bf16 (1.11x cb-decode@c32)

### DIFF
--- a/kernels/csrc/cuda/fused/qwen36.cu
+++ b/kernels/csrc/cuda/fused/qwen36.cu
@@ -260,7 +260,23 @@ __global__ void gdn_ar_kernel(const __nv_bfloat16* __restrict__ q,
 // reorders the fp32 sum — so gate by self-consistency (top1/KL) over a long sequence, not cmp.
 // HEAD_DIM is a template param so NROW is compile-time -> the r-loops fully unroll and sloc[] stays in
 // registers (a runtime head_dim would force sloc[] to local memory and defeat the register cache).
-template <int COLS, int HEAD_DIM>
+// ---- compacted bf16 recurrent state (continuous-batch decode only) -------------------------
+// The GDN state is [v_heads][HEAD_DIM][HEAD_DIM] fp32 per layer PER SEQUENCE -- 3.1 MB at this
+// model's shape -- and every element of it is read and written on every decode step. At
+// concurrency 32 that is ~9.6 GB of traffic per step: the second-largest item in the step after
+// the weight GEMMs, 15.3% of it. Halving the state halves that traffic -- measured by touching
+// only half the state, aggregate goes 1162.8 -> 1301.4 tok/s.
+//
+// SCOPED to the packed path, and the scope is load-bearing: rounding the state to bf16 costs
+// 10.1% of acceptance at ctx=16384 (tau 1.7297 -> 1.5542) against a 0.95x floor, a hard reject.
+// A continuous-batch step is a plain argmax emit with no acceptance to lose; the speculative
+// decode path has everything to lose. Only a session that has been through decode_packed is
+// converted, and DSpark's verify never is, so every dspark-* path keeps the fp32 state
+// bit-for-bit.
+//
+// The compacted array occupies the FIRST half of the same fp32 allocation, so the conversion is a
+// one-off per session and costs no VRAM.
+template <int COLS, int HEAD_DIM, bool SB16>
 __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
                                    const __nv_bfloat16* __restrict__ k,
                                    const __nv_bfloat16* __restrict__ v,
@@ -284,14 +300,16 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
     const __nv_bfloat16* qhptr = q + (size_t)qh * HEAD_DIM;
     const __nv_bfloat16* khptr = k + (size_t)qh * HEAD_DIM;
     const __nv_bfloat16* vhptr = v + (size_t)vh * HEAD_DIM;
-    float* col = state + ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;   // contiguous [HEAD_DIM] rows of column j
+    const size_t col_off = ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
+    float* col = state + col_off;                             // contiguous [HEAD_DIM] rows of column j
+    __nv_bfloat16* colb = reinterpret_cast<__nv_bfloat16*>(state) + col_off;
 
     float sloc[NROW];
     float part_sk = 0.f;
     #pragma unroll
     for (int r = 0; r < NROW; r++) {
         const int i = lane + r * 32;
-        const float s = col[i];                               // coalesced read
+        const float s = SB16 ? q36_to_f(colb[i]) : col[i];    // coalesced read
         sloc[r] = s;
         part_sk += s * q36_to_f(khptr[i]);
     }
@@ -302,8 +320,8 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
     for (int r = 0; r < NROW; r++) {
         const int i = lane + r * 32;
         float s_new = sloc[r] * g + q36_to_f(khptr[i]) * delta;   // S[i][j]*g + k[i]*delta
-        if (state_bf16) s_new = q36_to_f(__float2bfloat16(s_new));
-        col[i] = s_new;                                       // coalesced write
+        if (SB16) { colb[i] = __float2bfloat16(s_new); s_new = q36_to_f(colb[i]); }
+        else { if (state_bf16) s_new = q36_to_f(__float2bfloat16(s_new)); col[i] = s_new; }
         part_y += s_new * q36_to_f(qhptr[i]) * scale;
     }
     const float y = q36_wsum(part_y);
@@ -333,7 +351,7 @@ __global__ void gdn_ar_fast_kernel(const __nv_bfloat16* __restrict__ q,
 // Row b reads activation row b and state states[b]; with batch == 1 and states[0] equal to what
 // the unbatched launcher is handed, every lane does bit-identical arithmetic in the same order,
 // so a packed step and a sequential step agree exactly rather than approximately.
-template <int COLS, int HEAD_DIM>
+template <int COLS, int HEAD_DIM, bool SB16>
 __global__ void gdn_ar_fast_batched_kernel(const __nv_bfloat16* __restrict__ q,
                                            const __nv_bfloat16* __restrict__ k,
                                            const __nv_bfloat16* __restrict__ v,
@@ -367,14 +385,16 @@ __global__ void gdn_ar_fast_batched_kernel(const __nv_bfloat16* __restrict__ q,
     const __nv_bfloat16* qhptr = qrow + (size_t)qh * HEAD_DIM;
     const __nv_bfloat16* khptr = krow + (size_t)qh * HEAD_DIM;
     const __nv_bfloat16* vhptr = vrow + (size_t)vh * HEAD_DIM;
-    float* col = states[b] + state_off + ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
+    const size_t col_off = state_off + ((size_t)vh * HEAD_DIM + j) * HEAD_DIM;
+    float* col = states[b] + col_off;
+    __nv_bfloat16* colb = reinterpret_cast<__nv_bfloat16*>(states[b]) + col_off;
 
     float sloc[NROW];
     float part_sk = 0.f;
     #pragma unroll
     for (int r = 0; r < NROW; r++) {
         const int i = lane + r * 32;
-        const float sv = col[i];
+        const float sv = SB16 ? q36_to_f(colb[i]) : col[i];
         sloc[r] = sv;
         part_sk += sv * q36_to_f(khptr[i]);
     }
@@ -385,8 +405,8 @@ __global__ void gdn_ar_fast_batched_kernel(const __nv_bfloat16* __restrict__ q,
     for (int r = 0; r < NROW; r++) {
         const int i = lane + r * 32;
         float s_new = sloc[r] * g + q36_to_f(khptr[i]) * delta;
-        if (state_bf16) s_new = q36_to_f(__float2bfloat16(s_new));
-        col[i] = s_new;
+        if (SB16) { colb[i] = __float2bfloat16(s_new); s_new = q36_to_f(colb[i]); }
+        else { if (state_bf16) s_new = q36_to_f(__float2bfloat16(s_new)); col[i] = s_new; }
         part_y += s_new * q36_to_f(qhptr[i]) * scale;
     }
     const float y = q36_wsum(part_y);
@@ -641,12 +661,40 @@ void launch_qwen36_conv_split_l2(const void* qkv_bf16, const void* conv_w_bf16,
 // as a per-row pointer array. Restricted to the fast head_dim==128 path, which is the only one
 // the packed decode path uses (Qwen3.8 linear_head_dim = 128); anything else must keep running
 // the unbatched launcher per row.
+// One-off fp32 -> compacted-bf16 conversion of a session's whole GDN state. Staged through a
+// scratch buffer rather than written in place: the destination (the first half of the same
+// allocation) overlaps the source, and a grid-wide shrink has no ordering between the block that
+// writes an element and the block that has yet to read the float underneath it.
+__global__ void gdn_state_f32_to_b16_kernel(const float* __restrict__ src,
+                                            __nv_bfloat16* __restrict__ dst, size_t n) {
+    for (size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x; i < n;
+         i += (size_t)gridDim.x * blockDim.x)
+        dst[i] = __float2bfloat16(src[i]);
+}
+__global__ void gdn_state_b16_copy_kernel(const __nv_bfloat16* __restrict__ src,
+                                          __nv_bfloat16* __restrict__ dst, size_t n) {
+    for (size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x; i < n;
+         i += (size_t)gridDim.x * blockDim.x)
+        dst[i] = src[i];
+}
+bool launch_qwen36_gdn_state_to_b16(float* state, void* staging, size_t n, cudaStream_t stream) {
+    if (!state || !staging || n == 0) return false;
+    const int threads = 256;
+    int blocks = (int)((n + threads - 1) / threads);
+    if (blocks > 8192) blocks = 8192;
+    auto* stg = reinterpret_cast<__nv_bfloat16*>(staging);
+    gdn_state_f32_to_b16_kernel<<<blocks, threads, 0, stream>>>(state, stg, n);
+    gdn_state_b16_copy_kernel<<<blocks, threads, 0, stream>>>(
+        stg, reinterpret_cast<__nv_bfloat16*>(state), n);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
+
 bool launch_qwen36_gdn_ar_batched(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                                   const void* alpha_bf16, const void* beta_bf16,
                                   const void* dt_bf16, const void* a_bf16,
                                   float* const* states, size_t state_off, void* out_bf16,
                                   int batch, int q_heads, int v_heads, int head_dim,
-                                  bool qh_block, cudaStream_t stream) {
+                                  bool qh_block, cudaStream_t stream, bool state_compact_b16) {
     if (batch < 1 || head_dim != 128) return false;
     static const bool state_bf16 = [] {
         const char* e = getenv("SPARKINFER_GDN_STATE_BF16");
@@ -662,8 +710,8 @@ bool launch_qwen36_gdn_ar_batched(const void* q_bf16, const void* k_bf16, const 
     constexpr int HD = 128;
     const int c = cols;
     dim3 grid(v_heads, (HD + c - 1) / c, batch);
-#define SI_GDN_AR_B(C_)                                                                    \
-    gdn_ar_fast_batched_kernel<C_, HD><<<grid, (C_) * 32, 0, stream>>>(                    \
+#define SI_GDN_AR_B(C_, B_)                                                                \
+    gdn_ar_fast_batched_kernel<C_, HD, B_><<<grid, (C_) * 32, 0, stream>>>(                    \
         reinterpret_cast<const __nv_bfloat16*>(q_bf16),                                    \
         reinterpret_cast<const __nv_bfloat16*>(k_bf16),                                    \
         reinterpret_cast<const __nv_bfloat16*>(v_bf16),                                    \
@@ -673,9 +721,12 @@ bool launch_qwen36_gdn_ar_batched(const void* q_bf16, const void* k_bf16, const 
         reinterpret_cast<const __nv_bfloat16*>(a_bf16),                                    \
         states, state_off, reinterpret_cast<__nv_bfloat16*>(out_bf16),                     \
         q_heads, v_heads, qh_block, state_bf16)
-    if (c == 4)       SI_GDN_AR_B(4);
-    else if (c == 16) SI_GDN_AR_B(16);
-    else              SI_GDN_AR_B(8);
+#define SI_GDN_AR_B_SEL(C_)  do { if (state_compact_b16) SI_GDN_AR_B(C_, true); \
+                                  else                   SI_GDN_AR_B(C_, false); } while (0)
+    if (c == 4)       SI_GDN_AR_B_SEL(4);
+    else if (c == 16) SI_GDN_AR_B_SEL(16);
+    else              SI_GDN_AR_B_SEL(8);
+#undef SI_GDN_AR_B_SEL
 #undef SI_GDN_AR_B
     return true;
 }
@@ -685,7 +736,7 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
                           const void* dt_bf16, const void* a_bf16,
                           float* state_f32, void* out_bf16,
                           int q_heads, int v_heads, int head_dim, bool qh_block,
-                          cudaStream_t stream) {
+                          cudaStream_t stream, bool state_compact_b16) {
     static const bool state_bf16 = [] {
         const char* e = getenv("SPARKINFER_GDN_STATE_BF16");
         return e && e[0] == '1';
@@ -695,7 +746,9 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
     // run — the static flag guarantees that. Requires head_dim a multiple of 32 (128 -> NROW=4).
     static int fast = -1;
     if (fast < 0) { const char* e = getenv("SPARKINFER_GDN_FAST"); fast = (e && e[0] == '0') ? 0 : 1; }
-    if (fast && head_dim == 128) {                            // Qwen3.6/Qwythos linear_head_dim=128
+    // `state_compact_b16` forces the fast path: it is the only single-row kernel that understands
+    // the compacted form, and a session that holds one must never reach a kernel that does not.
+    if ((fast || state_compact_b16) && head_dim == 128) {      // Qwen3.6/Qwythos linear_head_dim=128
         static int cols = -1;
         if (cols < 0) {
             const char* e = getenv("SPARKINFER_GDN_FAST_COLS");
@@ -706,40 +759,24 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
         constexpr int HD = 128;
         const int c = cols;
         dim3 grid(v_heads, (HD + c - 1) / c);
-        if (c == 4) {
-            gdn_ar_fast_kernel<4, HD><<<grid, 4 * 32, 0, stream>>>(
-                reinterpret_cast<const __nv_bfloat16*>(q_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(k_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(v_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(a_bf16),
-                state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
-                q_heads, v_heads, (bool)qh_block, state_bf16);
-        } else if (c == 16) {
-            gdn_ar_fast_kernel<16, HD><<<grid, 16 * 32, 0, stream>>>(
-                reinterpret_cast<const __nv_bfloat16*>(q_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(k_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(v_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(a_bf16),
-                state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
-                q_heads, v_heads, (bool)qh_block, state_bf16);
-        } else {
-            gdn_ar_fast_kernel<8, HD><<<grid, 8 * 32, 0, stream>>>(
-                reinterpret_cast<const __nv_bfloat16*>(q_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(k_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(v_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(beta_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(dt_bf16),
-                reinterpret_cast<const __nv_bfloat16*>(a_bf16),
-                state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),
-                q_heads, v_heads, (bool)qh_block, state_bf16);
-        }
+#define SI_GDN_AR_ONE(C_, B_)                                                              \
+        gdn_ar_fast_kernel<C_, HD, B_><<<grid, (C_) * 32, 0, stream>>>(                    \
+            reinterpret_cast<const __nv_bfloat16*>(q_bf16),                                \
+            reinterpret_cast<const __nv_bfloat16*>(k_bf16),                                \
+            reinterpret_cast<const __nv_bfloat16*>(v_bf16),                                \
+            reinterpret_cast<const __nv_bfloat16*>(alpha_bf16),                            \
+            reinterpret_cast<const __nv_bfloat16*>(beta_bf16),                              \
+            reinterpret_cast<const __nv_bfloat16*>(dt_bf16),                                \
+            reinterpret_cast<const __nv_bfloat16*>(a_bf16),                                 \
+            state_f32, reinterpret_cast<__nv_bfloat16*>(out_bf16),                          \
+            q_heads, v_heads, (bool)qh_block, state_bf16)
+#define SI_GDN_AR_ONE_SEL(C_) do { if (state_compact_b16) SI_GDN_AR_ONE(C_, true);         \
+                                   else                   SI_GDN_AR_ONE(C_, false); } while (0)
+        if (c == 4)       SI_GDN_AR_ONE_SEL(4);
+        else if (c == 16) SI_GDN_AR_ONE_SEL(16);
+        else              SI_GDN_AR_ONE_SEL(8);
+#undef SI_GDN_AR_ONE_SEL
+#undef SI_GDN_AR_ONE
         return;
     }
     static int warpgrid = -1;

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -331,12 +331,16 @@ void launch_qwen36_conv_split_l2norm_fused(const void* qkv_bf16, const void* con
 // pointers (each session owns its own allocation), which also keeps the call CUDA-graph safe:
 // the graph bakes the array's address and the packer rewrites its contents per replay.
 // Returns false (launching nothing) for shapes it is not instantiated for -- head_dim != 128.
+// One-off fp32 -> compacted-bf16 conversion of a GDN state array (see qwen36.cu). `staging` must
+// hold n bf16 values; the result lands in the first half of `state`.
+bool launch_qwen36_gdn_state_to_b16(float* state, void* staging, size_t n, cudaStream_t stream);
 bool launch_qwen36_gdn_ar_batched(const void* q_bf16, const void* k_bf16, const void* v_bf16,
                                   const void* alpha_bf16, const void* beta_bf16,
                                   const void* dt_bf16, const void* a_bf16,
                                   float* const* states, size_t state_off, void* out_bf16,
                                   int batch, int q_heads, int v_heads, int head_dim,
-                                  bool qh_block, cudaStream_t stream = nullptr);
+                                  bool qh_block, cudaStream_t stream = nullptr,
+                                  bool state_compact_b16 = false);
 
 // Batched twin of launch_qwen36_conv_split_l2norm_fused; `conv_states` is a device array of B
 // per-session conv-state pointers, same contract as above.
@@ -351,7 +355,7 @@ void launch_qwen36_gdn_ar(const void* q_bf16, const void* k_bf16, const void* v_
                           const void* dt_bf16, const void* a_bf16,
                           float* state_f32, void* out_bf16,
                           int q_heads, int v_heads, int head_dim, bool qh_block,
-                          cudaStream_t stream = nullptr);
+                          cudaStream_t stream = nullptr, bool state_compact_b16 = false);
 
 void launch_qwen36_gated_norm(const void* x_bf16, const void* z_bf16,
                               const void* weight_bf16, void* out_bf16,

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -168,6 +168,10 @@ bool is_linear_layer(const Qwen35Config& c, int layer) {
 struct SessionBuffers {
     float* lin_state = nullptr;
     bf16* lin_conv_state = nullptr;
+    // This session's GDN state has been compacted to bf16 in the first half of lin_state (see
+    // launch_qwen36_gdn_state_to_b16). Set only for sessions that have gone through
+    // decode_packed; a speculative-decode session never has, and neither does session 0.
+    bool lin_state_b16 = false;
     // Per-request running count of how many times each vocab id has appeared in THIS session's
     // generated completion so far -- for presence_penalty/frequency_penalty. Unlike lin_state/
     // lin_conv_state (hybrid-architecture-only), this exists for EVERY model. vocab-sized, alloc'd
@@ -241,6 +245,11 @@ struct Qwen35Model::Impl {
     // The NVFP4 LM-head operand, held here rather than in `owned` because it is releasable.
     void* lm_head_fp4_payload = nullptr;
     void* lm_head_fp4_sf_buf = nullptr;
+    // Scratch for the one-off GDN state compaction; sized for one session's state, reused by all.
+    void* gdn_state_stage = nullptr;
+    // Mirrors sessions[active_seq_id].lin_state_b16, swapped by activate_session() exactly the way
+    // lin_state/lin_conv_state are.
+    bool active_lin_state_b16 = false;
     // Reusable device pointer arrays for packed decode (see Qwen35Model::decode_packed). Their
     // ADDRESSES are baked into the packed graph; their CONTENTS are rewritten every step, which
     // is what lets one graph per row count serve any set of sessions.
@@ -764,6 +773,7 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
 Qwen35Model::~Qwen35Model() {
     if (p_->lm_head_fp4_payload) cudaFree(p_->lm_head_fp4_payload);
     if (p_->lm_head_fp4_sf_buf) cudaFree(p_->lm_head_fp4_sf_buf);
+    if (p_->gdn_state_stage) cudaFree(p_->gdn_state_stage);
     for (void* b : p_->owned) cudaFree(b);
     cudaFree(p_->x); cudaFree(p_->xn); cudaFree(p_->q); cudaFree(p_->k); cudaFree(p_->v);
     cudaFree(p_->attn); cudaFree(p_->ao); cudaFree(p_->h); cudaFree(p_->hn);
@@ -1584,11 +1594,15 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
             if (gdn_pipelined) cudaStreamWaitEvent(st, s.ev_gdn_ab, 0);
             float* layer_state = s.lin_state +
                 (size_t)L * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim;
+            // The compacted-state flag belongs to the ACTIVE session: a packed batch that declines
+            // (a tail chunk of one row) falls back to this path for rows whose state has already
+            // been converted, so the two must agree on the representation.
             kernels::launch_qwen36_gdn_ar(s.lin_q, s.lin_k, s.lin_v,
                                           s.lin_alpha, s.lin_beta, w.ssm_dt, w.ssm_a,
                                           layer_state, s.lin_gdn,
                                           c.linear_q_heads, c.linear_v_heads,
-                                          c.linear_head_dim, c.gdn_qh_block, st);
+                                          c.linear_head_dim, c.gdn_qh_block, st,
+                                          s.active_lin_state_b16);
             if (gdn_pipelined && !gdn_fused_proj) cudaStreamWaitEvent(st, s.ev_gdn_z, 0);
             const bool gdn_gn_q8 = s.gguf && s.use_pq && s.use_llama &&
                                    (w.ssm_out_type == 12 || w.ssm_out_type == 8) &&
@@ -3040,6 +3054,13 @@ int Qwen35Model::prefill_batched(const int* prompt_ids, int n, bool want_seed_lo
                         "prefill (the scratch arena needs the VRAM more)\n", n);
         release_lm_head_fp4();
     }
+    // Batched prefill is position-0 only and writes the whole recurrent state as fp32, so a
+    // session that had been compacted is back on the fp32 form afterwards.
+    {
+        auto sit = s.sessions.find(s.active_seq_id);
+        if (sit != s.sessions.end()) sit->second.lin_state_b16 = false;
+        s.active_lin_state_b16 = false;
+    }
     auto it = s.sessions.find(s.active_seq_id);
     float* lin_state = (it != s.sessions.end()) ? it->second.lin_state : s.lin_state;
     bf16* lin_conv = (it != s.sessions.end()) ? it->second.lin_conv_state : s.lin_conv_state;
@@ -3334,6 +3355,41 @@ bool Qwen35Model::decode_packed(const int* tokens, const int* positions,
         s.packed_rows_valid = n;
     }
 
+    // Compact this batch's recurrent state to bf16, once per session. A packed row is by
+    // definition a continuous-batch row -- decode_packed is the only caller that sets packed_rows,
+    // and DSpark's verify never does -- so this is exactly the scope the bf16 state is safe in
+    // (see the note over gdn_ar_fast_kernel). Session 0 is excluded: it is the shared prefix
+    // session, whose state is snapshotted and replayed as fp32 by cache_prefix().
+    static const bool kGdnStateB16 = [] {
+        const char* e = getenv("SPARKINFER_CB_GDN_STATE_B16");
+        return !(e && e[0] == '0');
+    }();
+    bool packed_state_b16 = false;
+    if (kGdnStateB16 && s.cfg.hybrid) {
+        const size_t st_n = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
+                            s.cfg.linear_head_dim * s.cfg.linear_head_dim;
+        bool all_b16 = true;
+        for (int i = 0; i < n; i++) {
+            auto sit = s.sessions.find(seq_ids[i]);
+            if (sit == s.sessions.end() || seq_ids[i] == 0) { all_b16 = false; continue; }
+            if (sit->second.lin_state_b16) continue;
+            if (!s.gdn_state_stage &&
+                cudaMalloc(&s.gdn_state_stage, st_n * sizeof(bf16)) != cudaSuccess) {
+                s.gdn_state_stage = nullptr;
+                all_b16 = false;
+                break;
+            }
+            if (kernels::launch_qwen36_gdn_state_to_b16(sit->second.lin_state, s.gdn_state_stage,
+                                                        st_n, s.stream)) {
+                sit->second.lin_state_b16 = true;
+                if (seq_ids[i] == s.active_seq_id) s.active_lin_state_b16 = true;
+            } else {
+                all_b16 = false;
+            }
+        }
+        packed_state_b16 = all_b16;
+    }
+
     Qwen35PrefillCtx ctx{ s.cfg, s.w, s.kv, s.stream, s.stream_k, s.stream_v, seq_ids[0],
                           h_states[0], h_convs[0], s.logits, s.d_out_id, s.h_out_id, s.gguf,
                           s.emb_norm_ones,
@@ -3344,6 +3400,7 @@ bool Qwen35Model::decode_packed(const int* tokens, const int* positions,
     ctx.packed_rows      = reinterpret_cast<const int* const*>(s.packed_dev_tables);
     ctx.packed_lin_state = reinterpret_cast<float* const*>(s.packed_dev_states);
     ctx.packed_lin_conv  = reinterpret_cast<void* const*>(s.packed_dev_convs);
+    ctx.packed_state_b16 = packed_state_b16;
     const int consumed = dflash_verify_short_run(ctx, tokens, n, positions[0],
                                                  nullptr, 0, nullptr, out_sampled);
     return consumed == n;
@@ -3388,6 +3445,7 @@ void Qwen35Model::activate_session(uint64_t seq_id) {
         if (s.cfg.hybrid) {
             s.lin_state = it->second.lin_state;
             s.lin_conv_state = it->second.lin_conv_state;
+            s.active_lin_state_b16 = it->second.lin_state_b16;
         }
         // penalty_counts/logit_bias swap for EVERY model (hybrid or not) -- unlike lin_state/
         // lin_conv_state above, these aren't architecture-specific, they're per-request sampling-

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3468,7 +3468,8 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 if (!kernels::launch_qwen36_gdn_ar_batched(
                         gq, rk, rv, ra, rb, w.ssm_dt, w.ssm_a,
                         s.packed_lin_state, state_off, att,
-                        N, c.linear_q_heads, vh, c.linear_head_dim, c.gdn_qh_block, st)) {
+                        N, c.linear_q_heads, vh, c.linear_head_dim, c.gdn_qh_block, st,
+                        s.packed_state_b16)) {
                     supported = false;
                     vfail_L = L;
                     break;

--- a/runtime/src/models/qwen35_prefill.h
+++ b/runtime/src/models/qwen35_prefill.h
@@ -85,6 +85,8 @@ struct Qwen35PrefillCtx {
     const int* const*    packed_rows      = nullptr;
     float* const*        packed_lin_state = nullptr;
     void* const*         packed_lin_conv  = nullptr;
+    // The packed rows' recurrent state is the compacted bf16 form (see Qwen35Model::decode_packed).
+    bool                 packed_state_b16 = false;
 };
 
 // Fill the paged KV cache + Gated-DeltaNet state for positions 0..n-1 in one batched pass.


### PR DESCRIPTION
## Summary

The Gated-DeltaNet recurrent state is fp32, and every element of it is read and written on every decode step — ~9.6 GB of traffic per step at concurrency 32, the second-largest item in the step after the weight GEMMs. Store it as bf16 for continuous-batch sessions and that halves.

Scoped to the packed path, and the scope is load-bearing: rounding the state to bf16 costs 10.1% of acceptance at ctx=16384 (tau 1.7297 -> 1.5542) against a 0.95x floor. A continuous-batch step is a plain argmax emit with no acceptance to lose; speculative decode has everything to lose. Only a session that has been through `decode_packed` is converted — DSpark's verify never is — so every dspark-* path keeps the fp32 state bit-for-bit, which the acceptance rows below show.

The compacted array lives in the first half of the same fp32 allocation, so the conversion is a one-off per session and costs no VRAM. `forward_token` takes the flag too: a packed batch whose tail chunk is a single row falls back to it, and both must agree on the representation.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (`qwen3_gguf_cb_bench <ckpt> 32 256 256 512`, ModelOpt NVFP4 checkpoint, three repeats, all at the full `decode_tokens`):

| | decode tok/s |
|---|--:|
| before (main) | 1167.0 |
| after (this PR) | **1299.6** |

That is c32, **+11.36%**. c16 752.9 -> 790.6 (+5.01%), c8 523.7 -> 538.3 (+2.79%), c4 338.5 -> 345.4, c2 189.9 -> 191.9, c1 96.4 -> 96.4 — c1 is never packed, so never converted.

**Prefill pp tok/s** (`--ctx 32768`) — not this PR's target, shown as a no-regression floor:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 11084.48 |
| after prefill (this PR) | 11062.54 |

```text
# qwen3_gguf_cb_bench <ckpt> C 256 256 512            main 53384f0 -> this PR
c=1   96.4 ->  96.4   c=2 189.9 -> 191.9   c=4 338.5 -> 345.4   c=8 523.7 -> 538.3
c=16 752.9 -> 790.6                                  (mean itl 19.66 -> 18.66 ms)
c=32 1168.0 -> 1299.2 | 1166.0 -> 1300.1 | 1299.6    (mean itl 24.00 -> 21.24 ms, max itl 104 -> 101)
# SPARKINFER_CB_GDN_STATE_B16=0 reproduces main exactly -- the arm is inert when disabled.

# dspark_tau_check <target> <draft> 128 @ids          main -> this PR
ctx=4096   decode 132.6668 -> 132.6751  prefill 15069.93 -> 15069.87  accept 1.6883 -> 1.6883  lossless 1 -> 1
ctx=16384  decode 133.1149 -> 133.0495  prefill 12424.14 -> 12414.79  accept 1.7297 -> 1.7297  lossless 1 -> 1
ctx=32768  decode 100.2108 -> 100.1385  prefill 11084.48 -> 11062.54  accept 1.3299 -> 1.3299  lossless 1 -> 1
```
