### PR TITLE
perf(prefill): run the scored 4k prefill attention on the 16k tier (1.06x prefill@4k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -1876,12 +1876,29 @@ bool launch_prefill_attn_mma_bf16(
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_BF16_PSPLIT");
         return e ? ((e[0] == '0') ? 0 : 1) : -1;
     }();
-    const int psplit = psplit_env >= 0 ? psplit_env : (n_tokens < 16384 ? 1 : 0);
+    // The 16384 cut-off above was the context this tier was first measured at, not a property of
+    // the arithmetic: it left EVERY shorter prompt paying for the hi+lo P plane, whose only cost
+    // centre is a SECOND PV mma over the same V fragment (see the PSPLIT arm of the PV loop).
+    // The scored ctx=4096 prefill is the one dimension that sat on the wrong side of it -- nsys
+    // puts its attention at 41.35 ms of a 282.51 ms pass while the 16k pass, on the single-P
+    // shape, runs the same kernel at nearly twice the mma efficiency.
+    // 2048 is not a new constant: it is the threshold the RQH=3 tier and attn_smem_pad() already
+    // use, and it is where the K/V re-read this tier exists to amortize starts to dominate. Every
+    // caller below it -- the scored ctx=128 prefill, continuous-batch decode's 256-token prefill,
+    // and the short accuracy paths -- keeps the 8-page split-P shape byte for byte, and 16k/32k/
+    // 256k are already on the >= 16384 side and are unchanged.
+    const int psplit = psplit_env >= 0 ? psplit_env : (n_tokens < 2048 ? 1 : 0);
     static const int group_blks_env = [] {
         const char* e = getenv("SPARKINFER_PREFILL_ATTN_BF16_GROUP_BLKS");
         return e ? ((atoi(e) == 16) ? 16 : 8) : 0;
     }();
-    const int group_blks = group_blks_env ? group_blks_env : (n_tokens >= 16384 ? 16 : 8);
+    // Same cut-off, same reason: GN=256 halves the group iterations (and the two barriers and the
+    // online-softmax rescale each one carries) over GN=128. It moves with psplit rather than
+    // separately -- the wide group only reaches the RQH=3 tier when split-P is off, because the
+    // RQH=3 split-P footprint is over the device's dynamic-smem ceiling; taking it alone would
+    // drop ctx=4096 to RQH=2 and cost more sharing than the wider group buys (measured: +1.68%
+    // prefill but -2.31% on decode@4k, which is its own scored dimension).
+    const int group_blks = group_blks_env ? group_blks_env : (n_tokens >= 2048 ? 16 : 8);
     if (group_blks == 16) {
         if (!psplit && rqh_env >= 3 && gqa % 3 == 0 &&
             launch_attn_bf16_gqa<HD, 16, 3, false>(


### PR DESCRIPTION
## Summary

`launch_prefill_attn_mma_bf16` picks its tier from two constants that are both cut at `n_tokens >= 16384`:

* `psplit` carries P as a **hi+lo BF16 pair**, and its only cost centre is a **second PV `mma` over the same V fragment** (the `if (PSPLIT)` arm of the PV loop) — so it is a straight 1.5x on the kernel's mma count, QK + 2xPV against QK + PV;
* `group_blks` picks GN=256 against GN=128 keys per group iteration, and with it the two barriers and the online-softmax rescale each iteration carries.

Both cut-offs are the context the tier was first measured at, not a property of the arithmetic. Everything at 16k and above already runs the fast single-P / wide-group shape; **the scored ctx=4096 prefill was the one dimension left on the wrong side of them**. `nsys` at the scored point puts its attention at **41.35 ms of a 282.51 ms pass (14.6%)**, running at roughly **31%** of this box's measured wmma ceiling, while the 16k pass runs the *same kernel* on the single-P shape at ~56%.

This moves both cut-offs to **2048**. That is not a new constant: it is the threshold the RQH=3 tier and `attn_smem_pad()` already use, and it is where the K/V re-read this tier exists to amortize starts to dominate.

The two knobs are **not separable**. The wide group only reaches the RQH=3 tier when split-P is off, because the RQH=3 split-P footprint is over the device's dynamic-smem ceiling; taking `group_blks` alone drops ctx=4096 to RQH=2 and costs more sharing than the wider group buys — measured **+1.68% prefill but −2.31% on decode@4k**, which is its own scored dimension. Both move together or neither does.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — `dspark-decode@4k`, same runs, `METRIC DSPARK_TPS`. Two interleaved repeats per arm, mean:

| | decode tok/s |
|---|--:|
| before (main) | **132.608** |
| after (this PR) | **134.636**  (+1.53%) |

**Prefill pp tok/s** — `dspark-prefill@4k`: `dspark_tau_check <ckpt> <draft> 128 @<4096 ids>`, the DSpark harness's own 4096-token prompt, `METRIC DSPARK_PREFILL_PP`. Two interleaved repeats per arm, mean:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | **15049.11** |
| after prefill (this PR) | **15974.31**  (+6.15%) |

```text
$ dspark_tau_check <Qwen3.8-27B-NVFP4-RTX5090> <Qwen3.8-27B-DSpark-NVFP4> 128 @<4096 prompt ids>
  # RTX 5090 (sm_120), CUDA 13.0, measured at base d0a9e0a, interleaved main/PR/main/PR,
  # both arms built from the same base and differing only in the one file above.

  main  DSPARK_PREFILL_PP 15048.7945  MEAN_ACCEPT 1.6883  LOSSLESS 1  DSPARK_TPS 132.6518  AR_TPS 94.0832
  PR    DSPARK_PREFILL_PP 15956.8877  MEAN_ACCEPT 1.6974  LOSSLESS 1  DSPARK_TPS 134.6150  AR_TPS 94.0285
  main  DSPARK_PREFILL_PP 15049.4320  MEAN_ACCEPT 1.6883  LOSSLESS 1  DSPARK_TPS 132.5635  AR_TPS 94.0472
  PR    DSPARK_PREFILL_PP 15991.7391  MEAN_ACCEPT 1.6974  LOSSLESS 1  DSPARK_TPS 134.6574  AR_TPS 94.0654

  mean  main 15049.11 -> PR 15974.31 pp/s  = +6.15%   (decode 132.608 -> 134.636 = +1.53%)

  # the two knobs, measured separately, each interleaved x2 against main in its own round:
  #   group_blks=16 alone  (drops to RQH=2)   prefill +1.68%, decode@4k -2.31%   <- REJECTED
  #   psplit=0 + group_blks=16 (RQH=3 tier)   prefill +6.15%, decode@4k +1.53%   <- this PR
```

**This is not a fidelity trade.** `qwen3_gguf_prefill_check` at prefix=4080 / cont=16 on real ids with `SPARKINFER_KV_INT8=0` (the scored BF16-KV path this change touches), batched prefill against the token loop:

| | TOP1 | KL |
|---|--:|--:|
| main | 15/16 | 0.00858 |
| this PR | 15/16 | **0.00738** |

Same top1 and a marginally *lower* KL — the hi+lo P plane was buying nothing measurable at this context, which is why dropping it is free.

Every other scored dimension is untouched **by construction**: 16k, 32k and the 256k windows (which ingest 16384 tokens at a time) are all already on the `>= 16384` side of both constants, and every caller below 2048 — the scored ctx=128 prefill, continuous-batch decode's 256-token prefill, and the short accuracy paths — keeps the 8-page split-P shape byte for byte. `MEAN_ACCEPT` is **identical to four decimals at 16k (1.7297) and 32k (1.3299)**, which is what that looks like from outside.

Same box, main vs this PR, both trees built from `d0a9e0a` and measured in one interleaved session:

| gate | main | this PR | ratio |
|---|--:|--:|--:|
| dspark-prefill@4k | 15049.11 | **15974.31** | **1.0615** |
| dspark-decode@4k | 132.608 | **134.636** | **1.0153** |
| dspark-prefill@16k / @32k | 12427.20 / 11100.10 | 12430.73 / 11075.49 | 1.0003 / 0.9978 |
| dspark-decode@16k / @32k | 133.098 / 100.230 | 133.143 / 100.155 | 1.0003 / 0.9993 |
| AR@4k / @16k / @32k | 94.065 / 89.606 / 84.182 | 94.047 / 89.606 / 84.178 | 0.9998 / 1.0000 / 1.0000 |
| mean accept @4k / @16k / @32k | 1.6883 / 1.7297 / 1.3299 | 1.6974 / 1.7297 / 1.3299 | 1.0054 / **1.0000** / **1.0000** |
| losslessness | 1 | 1 | |
| cb-decode@c16 / @c32 | 789.7 / 1297.7 | 789.5 / 1296.9 | 0.9997 / 0.9994 |
| target-prefill@256k | 4925.08 | 4879.59 | 0.9908 |
| target-decode@256k | 95.507 | 95.501 | 0.9999 |
