### PR TITLE
perf(decode): admit the whole continuous-batch ramp instead of two rows an iteration (1.06x cb-decode@c32)

### DIFF
--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -18,22 +18,52 @@
 namespace sparkinfer {
 
 namespace {
-// How many prefills one iteration may admit while the decode batch is still filling. 1 restores
-// the previous behaviour exactly, for a paired A/B out of one binary.
-int prefills_per_step() {
-    static const int v = [] {
-        const char* e = getenv("SPARKINFER_PREFILLS_PER_STEP");
-        const int x = e ? atoi(e) : 2;
-        return x < 1 ? 1 : x;
-    }();
-    return v;
-}
 // The decode width above which a step is no longer dominated by its fixed weight read. Defaults
 // to the packed-decode ceiling; below it a wider batch is very nearly free.
 int packed_decode_width() {
     static const int v = [] {
         const char* e = getenv("SPARKINFER_WIDE_DECODE_ROWS");
         const int x = e ? atoi(e) : 32;
+        return x < 1 ? 1 : x;
+    }();
+    return v;
+}
+// How many prefills one iteration may admit while the decode batch is still filling. 1 restores
+// the pre-#994 behaviour; 2 restores #994's, for a paired A/B out of one binary.
+//
+// This was 2 because that is the step #994 measured: it went from admitting ONE row per
+// iteration to two, and stopped there. Two is not a property of the trade -- it is where the
+// measurement stopped. The cost of admitting another prefill is one more row in this iteration's
+// packed forward, and #990/#992/#993 made that row nearly free up to `packed_decode_width()`
+// rows: the packed decode reads the whole ~15 GB weight set once per step whatever the width, so
+// every row admitted before the batch reaches that width is amortized against a read the step
+// was going to do anyway. What the cap actually costs is TIME AT A NARROW WIDTH -- every
+// iteration spent ramping is an iteration paying the full weight read for a fraction of the
+// rows.
+//
+// So the bound is the width the batch is ramping TOWARD, which is the same
+// `packed_decode_width()` the `deep_ramp` gate below is already written against, not a fixed 2.
+// Measured on an RTX 5090 at the bot's own invocation (qwen3_gguf_cb_bench <model> C 256 256 512),
+// aggregate tok/s, two interleaved repeats per arm out of ONE binary:
+//
+//   admit/step      2 (main)      6        8       12       16       32
+//   c16              790.80    805.55   810.15   811.70   815.80        -
+//   c32             1296.80         -        -        -  1370.15   1379.30
+//
+// Monotone in the cap at both widths, and mean ITL falls with it (c32 21.29 -> 19.74 ms), so
+// this is not a latency-for-throughput trade on the mean. It IS one on the tail: a deep ramp now
+// admits its whole backlog in one iteration, and max ITL over the run moves from ~103 ms to
+// 94-879 ms depending on where the burst lands. #994 made exactly this trade once already
+// (+29 ms max ITL for +4.3% at c32) and documented it; this takes the same trade to the end of
+// the curve.
+//
+// Narrow concurrencies cannot see any of it: `deep_ramp` requires (pending + have) * 2 >= width,
+// i.e. 16 in flight, so c1/c2/c4/c8 keep allow == 1 and the previous scheduler byte for byte.
+// Measured, same binary, admit/step 2 -> 32: c4 345.3 -> 345.5, c8 538.0 -> 538.5.
+int prefills_per_step() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_PREFILLS_PER_STEP");
+        const int x = e ? atoi(e) : packed_decode_width();
         return x < 1 ? 1 : x;
     }();
     return v;


### PR DESCRIPTION
## Summary

The continuous-batch scheduler admits at most **2** prefills per iteration while the decode batch ramps — which is where #994's measurement stopped, not a property of the trade. A packed step reads all ~15 GB of weights whatever its width, so this pins the cap to `packed_decode_width()`, the width the batch is ramping toward and the constant the `deep_ramp` gate below it already uses.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — `cb-decode@c32`, `agg_tok_s`, two interleaved repeats per arm out of **one binary** (`SPARKINFER_PREFILLS_PER_STEP=2` is main's default, so the arms differ only in it):

| | decode tok/s |
|---|--:|
| before (main) | 1298.80 |
| after (this PR) | **1378.80** |

**Prefill pp tok/s** — not a prefill change; the prefill harness never constructs a `Scheduler`. Measured on the PR build for no-regression, ctx 16384:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 12431.60 |
| after prefill (this PR) | 12415.03 |

```text
$ qwen3_gguf_cb_bench <Qwen3.8-27B-NVFP4-RTX5090> <C> 256 256 512
  # RTX 5090 (sm_120), CUDA 13.0, one binary built at 189aec4.

  main c16 agg=792.4 itl=18.61 | main c32 agg=1300.0 itl=21.25
  PR   c16 agg=815.7 itl=17.96 | PR   c32 agg=1378.4 itl=19.78
  main c16 agg=790.7 itl=18.66 | main c32 agg=1297.6 itl=21.27
  PR   c16 agg=813.7 itl=18.00 | PR   c32 agg=1379.2 itl=19.78
  mean c32 1298.80 -> 1378.80 = +6.16%   c16 791.55 -> 814.70 = +2.93%

  # monotone in the cap -- the end of the curve, not a point on it (2 reps/rung, agg_tok_s):
  #   admit/step    2      6      8     12     16     32
  #   c16         790.8  805.6  810.2  811.7  815.8      -
  #   c32        1296.8      -      -      -  1370.2  1379.3

  # narrower widths keep allow == 1 (deep_ramp needs 16 in flight) -- same binary, =2 vs default:
  #             c1     c2     c4     c8
  #   main     96.4  192.1  345.7  538.3
  #   PR       96.4  192.1  345.1  539.1

  # single-stream dimensions, PR build (dspark_tau_check) -- all on main's baseline within noise:
  #   ctx   dspark-prefill  dspark-decode  ar-decode  MEAN_ACCEPT  LOSSLESS
  #    4k       15993.75        134.530      94.050      1.6974       1
  #   16k       12415.03        133.099      89.593      1.7297       1
  #   32k       11075.45        100.199      84.221      1.3299       1
```

Mean ITL improves with it (c32 21.26 -> 19.78 ms), so this is not a latency-for-throughput trade on the mean. It **is** one on the tail: max ITL moves from ~103 ms to ~880 ms at c32. #994 made that trade once already (+29 ms for +4.3% at c32); this takes it to the end of the curve, and the cost is written into the comment.

No arithmetic changes — only the order in time that pending requests are admitted — so accuracy and the batched-prefill parity gate are unaffected.
