### PR TITLE
perf(dspark): verify three proposals in the mid-context band, on the fold width that serves them (1.041x dspark-decode@16k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -1346,9 +1346,26 @@ void launch_flash_decode_split(
             // read, so the wide fold gives back more parallelism than it saves. Measured at
             // ctx=4k, 4 rows: fold 2 = 14.389 ms per verify against fold 4 = 14.438 and no fold
             // at 14.6, i.e. two rows per CTA takes the whole win.
+            // ...and prefer the WIDEST divisor once the KV is big enough to be worth it. The
+            // narrowest-fold rule above was measured at ctx=4k, where a CTA's share of the staged
+            // KV is a quarter of what it is at 16k, so the extra CTAs it keeps resident are worth
+            // more than the re-read it pays. That trade inverts with context. Width 4 is the
+            // 12288..24576 band's shape (proposal depth 3 plus the seed row), and fold 2 there
+            // reads the KV TWICE where fold 4 reads it once. Measured on this checkpoint, arms
+            // interleaved in ONE binary, tau IDENTICAL at 1.8971 and lossless in every arm:
+            //     ctx=16384  fold 2  136.63 / 136.60 tok/s  ->  fold 4  138.13 / 138.47
+            // Gated, not switched, because the rule above is right where it was measured: the
+            // scored ctx=4096 point stays on it byte for byte, and a wider fold there buys nothing
+            // anyway -- its width is 6, and forcing the wider divisor that does fit reads 134.76
+            // against 134.51, i.e. flat. 12288 is not a new boundary: it is the one the
+            // proposal-depth ladder in qwen35.cpp already splits on, and the width this serves is
+            // the one that ladder produces.
             const int fa6_fold = fa6_fold_env > 0
                                ? fa6_fold_env
-                               : (num_seqs % 2 == 0 ? 2 : (num_seqs % 3 == 0 ? 3 : 1));
+                               : (seqlen >= 12288
+                                  ? (num_seqs % 4 == 0 ? 4
+                                     : (num_seqs % 3 == 0 ? 3 : (num_seqs % 2 == 0 ? 2 : 1)))
+                                  : (num_seqs % 2 == 0 ? 2 : (num_seqs % 3 == 0 ? 3 : 1)));
             // cp.async DOUBLE BUFFERING FOR THE FOLD. fa_split_gqa_pipe_kernel has carried a SEQ
             // template parameter since it was written and has never been instantiated above 1: the
             // fold below returns before the pipelined/KV-group dispatch further down, and that

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -4132,10 +4132,30 @@ std::vector<int> Qwen35Model::dflash_generate(const std::vector<int>& prompt, in
     // 24576 is not a new boundary: it is the one dflash_draft.cpp's window ladder already splits
     // the long band at, so the depth plan and the draft's attention window change together.
     constexpr int kVeryDeepMinSeq = 24576;
+    // The 12288..24576 band's depth of 2 is STALE. The note above is anchored on a run whose arms
+    // spread 82-92 tok/s; the same sweep on today's tree runs at 124-137 and reverses the
+    // ordering -- every change since has made a verify row cheaper, which lowers the bar a third
+    // proposal has to clear. Re-measured at ctx=16384 on the first 16384 tokens of
+    // bench_prompt_32k.txt, NTOK=128, one binary with the arms alternated, every arm lossless and
+    // AR flat at 89.59-89.64:
+    //
+    //     depth   1        2 (was)   3          4
+    //     tok/s   123.80   132.88    136.60     131.54
+    //     tau     1.5176   1.7297    1.8971     1.8194
+    //
+    // Depth 3 is +2.60% end to end against the shipped band, and it gets there by ACCEPTING MORE
+    // (tau 1.7297 -> 1.8971, +9.7%), not by spending fewer verify rows -- the third proposal pays
+    // for its own row. Depth 4 turns back over (tau falls to 1.8194), so 3 is a peak and not the
+    // edge of a ramp.
+    //
+    // The band is bounded at both ends, so no other scored context moves: 4k is below kDeepMinSeq
+    // and 32k is above kVeryDeepMinSeq. Both were re-swept anyway and both keep the depth they
+    // have -- 4k reads 134.68 at 5 against 133.33/133.23 at 4/6, and 32k reads 100.01 at 1
+    // against 95.48 at 2.
     const int kInitialProposalDepth = std::min(B, kProposalDepthEnv > 0 ? kProposalDepthEnv
                                     : ((kShortGeneration || kAmortizedMidContext) ? 7
                                        : ((n + max_new) >= kVeryDeepMinSeq ? 1
-                                          : ((n + max_new) >= kDeepMinSeq ? 2
+                                          : ((n + max_new) >= kDeepMinSeq ? 3
                                              : ((n + max_new) < kMid4kMaxSeq ? 5 : 3)))));
     // A length-only depth is a safe starting point, not a workload policy. At the same 16k
     // context real chat accepts ~1.36 tokens while code/JSON/repetition accept 5.35/6.62/6.92 at


### PR DESCRIPTION
## Summary

The `12288..24576` proposal-depth band ships depth **2**, chosen on a run whose arms spread 82-92 tok/s; every change since has made a verify row cheaper, and on today's tree the same sweep runs at 124-137 and puts the peak at **3**. Depth 3 verifies width 4, and the GQA-6 fold rule — fitted at ctx=4096, where a CTA's share of the staged KV is a quarter of what it is at 16k — hands that width the *narrowest* divisor, so it reads the KV twice; at 16k the widest one reads it once. The second half is unreachable without the first: at main's width 3 the fold is 3 either way.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — `dspark-decode@16k`, two interleaved repeats per arm:

| | decode tok/s |
|---|--:|
| before (main) | 133.11 |
| after (this PR) | **138.56** |

**Prefill pp tok/s** — not a prefill change; measured on both builds for no-regression, ctx 16384:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 12435.69 |
| after prefill (this PR) | 12399.41 |

```text
$ dspark_tau_check <Qwen3.8-27B-NVFP4-RTX5090> <DSpark> 128 @ids_16384.txt
  # RTX 5090 (sm_120), CUDA 13.0. Both trees built at b1a7231, arms interleaved.

  main 133.1551  tau 1.7297 | PR 138.6400  tau 1.8971
  main 133.0639  tau 1.7297 | PR 138.4827  tau 1.8971
  mean 133.110 -> 138.561 = +4.10%    tau +9.68%    AR flat 89.64 -> 89.60

  # the two terms, isolated on main out of ONE binary (env knobs, no rebuild):
  #   proposal depth      1        2 (was)   3          4
  #     tok/s          123.80     132.88    136.60     131.54
  #     tau            1.5176     1.7297    1.8971     1.8194      <- 3 is a peak, not a ramp
  #   fold at depth 3     none       2         4
  #     tok/s          128.41     136.63    138.13/138.47          <- tau 1.8971 in all three

  # both bands re-swept and both KEEP the depth they have -- only the middle one moves:
  #   ctx=4096   depth 4 133.33 | 5 (shipped) 134.68 | 6 133.23 | 7 131.84
  #   ctx=32768  depth 1 (shipped) 100.01 | 2 95.48 | 3 88.99
  # draft window re-swept at all three contexts too; 2048/none stays optimal everywhere.

  # every scored dimension, main -> PR:
  #   dspark-decode    4k 134.386 -> 134.448 | 16k 133.110 -> 138.561 | 32k 100.084 -> 100.048
  #   dspark-prefill   4k 15926.3 -> 15936.8 | 16k 12435.7 -> 12399.4 | 32k 11044.5 -> 11007.6
  #   target@256k      prefill 4866.84 -> 4843.88 | decode 95.41 -> 95.38
  #   cb-decode        c2 191.9 -> 191.7 | c4 345.0 -> 344.5 | c8 536.8 -> 537.4
  #                    c16 813.4 -> 812.9 | c32 1377.1 -> 1374.7
  #   ar-decode        4k 94.05 -> 94.02 | 16k 89.66 -> 89.61 | 32k 84.17 -> 84.16

  # gates, PR build:
  #   LOSSLESS 3/3 at 4k AND 16k AND 32k;  tau 1.6974 / 1.8971 / 1.3299
  #   accuracy vs main: top1 101/101 = 1.000, KL 0.000000, PPL 3.0301 both sides
```

Acceptance is where the win comes from — tau 1.7297 -> 1.8971 — so this is not throughput bought by speculating less. The fold half is bit-exact by construction (each folded row keeps its own chunk/start/end and masks itself back), which is why tau is *identical* across the fold arms and the accuracy comparison against main is exactly zero.

Nothing outside the band is reachable: `cb-decode` never speculates and runs int8 KV, so neither the depth ladder nor the `!int8_kv` fold branch is entered; the Qwen3.6 guard is GQA-8 and never reaches this dispatch; and both cross-model guards decode at `num_seqs == 1`, which the fold requires to exceed 1.
