### PR TITLE
fix(muse): honour the int8 KV cache instead of writing bf16 into it (40x prefill@4k)

### DIFF
--- a/kernels/csrc/cuda/attention/rope.cu
+++ b/kernels/csrc/cuda/attention/rope.cu
@@ -515,6 +515,85 @@ __global__ void rope_kv_append_partial_int8_kernel(
     }
 }
 
+// int8-KV decode append for Muse Glimmer. Muse's per-layer pattern is NORMAL (consecutive-pair)
+// RoPE on the SWA layers and NoPE on the global ones, and its KV write was unconditionally bf16 --
+// two-byte stores into a one-byte-per-element pool whenever the caller asked for an int8 cache,
+// which is why ctx >= 4096 (where the example mains switch the cache to int8) produced garbage.
+// Organised exactly like rope_kv_append_partial_int8_kernel: one block per (token, head-unit) with
+// blockDim == head_dim, so a whole K/V head vector reduces in-block for the per-(token, kv_head)
+// max-abs an int8 scale needs. Same scale layout the int8 flash-decode reads.
+// rope_normal == false is the NoPE global layer: pure quantize + append, Q untouched.
+__global__ void muse_kv_append_int8_kernel(
+    __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k,
+    const __nv_bfloat16* __restrict__ v,
+    signed char* __restrict__ k_pool, signed char* __restrict__ v_pool,
+    __half* __restrict__ k_scale, __half* __restrict__ v_scale,
+    const int* __restrict__ block_table, const int* __restrict__ positions,
+    int n_q_heads, int n_kv_heads, int head_dim, float theta, int rope_normal,
+    int block_size, int max_blocks_per_seq
+) {
+    const int tok  = blockIdx.y;
+    const int unit = blockIdx.x;          // [0,nq)=Q rope ; [nq,nq+nkv)=K ; [nq+nkv,..)=V
+    const int t    = threadIdx.x;         // 0..head_dim-1
+    const int half = head_dim >> 1;
+    const int pos    = positions[tok];
+    const int blk    = pos / block_size, within = pos % block_size;
+    const int phys   = block_table[tok * max_blocks_per_seq + blk];
+    const size_t ctok = (size_t)(phys * block_size + within);
+
+    if (unit < n_q_heads) {               // Q: NORMAL rope in place, bf16, no quantisation
+        if (rope_normal && t < half) {
+            const float freq = __powf(theta, -2.f * (float)t / (float)head_dim);
+            const float ang = (float)pos * freq, c = __cosf(ang), sn = __sinf(ang);
+            const size_t base = ((size_t)(tok * n_q_heads + unit)) * head_dim + 2 * t;
+            const float x0 = __bfloat162float(q[base]), x1 = __bfloat162float(q[base + 1]);
+            q[base]     = __float2bfloat16(x0 * c - x1 * sn);
+            q[base + 1] = __float2bfloat16(x0 * sn + x1 * c);
+        }
+        return;
+    }
+
+    const bool is_k = unit < n_q_heads + n_kv_heads;
+    const int  hh   = is_k ? (unit - n_q_heads) : (unit - n_q_heads - n_kv_heads);
+    const size_t base = ((size_t)(tok * n_kv_heads + hh)) * head_dim;
+    const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
+
+    // K on an SWA layer rotates the consecutive pair (2i, 2i+1); V and every NoPE layer are raw.
+    float val;
+    if (is_k && rope_normal) {
+        const int i = t >> 1;
+        const float freq = __powf(theta, -2.f * (float)i / (float)head_dim);
+        const float ang = (float)pos * freq, c = __cosf(ang), sn = __sinf(ang);
+        const float x0 = __bfloat162float(k[base + 2 * i]);
+        const float x1 = __bfloat162float(k[base + 2 * i + 1]);
+        val = (t & 1) ? (x0 * sn + x1 * c) : (x0 * c - x1 * sn);
+    } else {
+        val = __bfloat162float((is_k ? k : v)[base + t]);
+    }
+
+    __shared__ float s_red[8];            // head_dim/32 warp partials (<=256 -> <=8)
+    float amax = fabsf(val);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) amax = fmaxf(amax, __shfl_xor_sync(0xffffffff, amax, m));
+    if ((t & 31) == 0) s_red[t >> 5] = amax;
+    __syncthreads();
+    if (t == 0) {
+        float a = 0.f;
+        for (int w = 0; w < (head_dim >> 5); w++) a = fmaxf(a, s_red[w]);
+        s_red[0] = a;
+    }
+    __syncthreads();
+    const float d  = s_red[0] / 127.0f;
+    const int   qi = (s_red[0] == 0.f) ? 0 : (int)roundf(val / d);
+    if (is_k) {
+        k_pool[dst + t] = (signed char)qi;
+        if (t == 0) k_scale[ctok * n_kv_heads + hh] = __float2half(d);
+    } else {
+        v_pool[dst + t] = (signed char)qi;
+        if (t == 0) v_scale[ctok * n_kv_heads + hh] = __float2half(d);
+    }
+}
+
 // Fused QK-norm + partial-RoPE + int8 KV-append for Qwen3.6 hd256 full-attn layers.
 // Replaces launch_rmsnorm_qk + launch_rope_kv_append_partial_int8 (two graph nodes).
 __global__ void qknorm_rope_kv_partial_int8_kernel(
@@ -890,6 +969,23 @@ void launch_rope_kv_append_partial_int8(void* q, const void* k, const void* v,
         reinterpret_cast<signed char*>(k_pool), reinterpret_cast<signed char*>(v_pool),
         reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
         block_table, positions, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta,
+        block_size, max_blocks_per_seq);
+}
+
+void launch_muse_kv_append_int8(void* q, const void* k, const void* v,
+                                void* k_pool, void* v_pool, void* k_scale, void* v_scale,
+                                const int* block_table, const int* positions,
+                                int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+                                float theta, bool rope_normal,
+                                int block_size, int max_blocks_per_seq, cudaStream_t stream) {
+    // one block per (token, head-unit); blockDim == head_dim so a full K/V head vector reduces in-block.
+    dim3 grid(n_q_heads + 2 * n_kv_heads, n_tokens);
+    muse_kv_append_int8_kernel<<<grid, head_dim, 0, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<const __nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v),
+        reinterpret_cast<signed char*>(k_pool), reinterpret_cast<signed char*>(v_pool),
+        reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
+        block_table, positions, n_q_heads, n_kv_heads, head_dim, theta, rope_normal ? 1 : 0,
         block_size, max_blocks_per_seq);
 }
 

--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1126,13 +1126,41 @@ __global__ void pf_qknorm_rope_kv_int8_kernel(
 // / launch_kv_append, so a subsequent decode reads a consistent cache.
 // grid = (N, n_q_heads + 2*n_kv_heads); blockDim = head_dim.
 // ============================================================================
-__global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
+// Block-wide max-abs of one head vector (blockDim == head_dim), for the int8 KV scale. Same
+// reduce and the same amax/127 convention as pf_qknorm_rope_kv_int8_kernel above, on its own
+// shared buffer so it never races the RMSNorm reduce that runs just before it.
+__device__ __forceinline__ float pf_headvec_amax(float val, float* s_red, int t, int head_dim) {
+    float a = fabsf(val);
+    #pragma unroll
+    for (int m = 16; m > 0; m >>= 1) a = fmaxf(a, __shfl_xor_sync(0xffffffff, a, m));
+    if ((t & 31) == 0) s_red[t >> 5] = a;
+    __syncthreads();
+    if (t == 0) {
+        float aa = 0.f;
+        for (int w = 0; w < (head_dim + 31) / 32; w++) aa = fmaxf(aa, s_red[w]);
+        s_red[0] = aa;
+    }
+    __syncthreads();
+    return s_red[0];
+}
+
+// INT8 == false is the original bf16 writer, unchanged. INT8 == true quantises the K/V head
+// vector to int8 with one fp16 scale per (token, kv_head) -- the layout the int8 attention and
+// flash-decode read -- so Muse can run on the int8 cache the example mains request at ctx >= 4096
+// instead of writing bf16 into it. The math above the store is shared, so the two cannot drift.
+template <bool INT8>
+__global__ void pf_qknorm_ropenorm_kv_kernel(
     __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ k, const __nv_bfloat16* __restrict__ v,
     const __nv_bfloat16* __restrict__ q_w, const __nv_bfloat16* __restrict__ k_w,
-    __nv_bfloat16* __restrict__ k_pool, __nv_bfloat16* __restrict__ v_pool,
+    void* __restrict__ k_pool_v, void* __restrict__ v_pool_v,
+    __half* __restrict__ k_scale, __half* __restrict__ v_scale,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
     int block_size, int max_blocks_per_seq, int pos0) {
+    auto* k_pool = static_cast<__nv_bfloat16*>(k_pool_v);
+    auto* v_pool = static_cast<__nv_bfloat16*>(v_pool_v);
+    auto* k_pool8 = static_cast<signed char*>(k_pool_v);
+    auto* v_pool8 = static_cast<signed char*>(v_pool_v);
     const int tok  = blockIdx.x;
     const int unit = blockIdx.y;
     const int t    = threadIdx.x;
@@ -1147,6 +1175,7 @@ __global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
 
     extern __shared__ float s_h[];
     __shared__ float s_warp[32];
+    __shared__ float s_red[8];                        // int8 KV amax only; unused when !INT8
 
     const bool is_q = unit < n_q_heads;
     const bool is_k = !is_q && unit < n_q_heads + n_kv_heads;
@@ -1182,16 +1211,29 @@ __global__ void pf_qknorm_ropenorm_kv_bf16_kernel(
             out = ((t & 1) == 0) ? (x0 * c - x1 * s) : (x0 * s + x1 * c);
         }
         if (is_q) {
-            q[base + t] = __float2bfloat16(out);
+            q[base + t] = __float2bfloat16(out);      // Q is never quantised
         } else {
             const size_t dst = (ctok * n_kv_heads + hh) * head_dim;
-            k_pool[dst + t] = __float2bfloat16(out);
+            if constexpr (INT8) {
+                const float d = pf_headvec_amax(out, s_red, t, head_dim) / 127.0f;
+                k_pool8[dst + t] = (signed char)((d == 0.f) ? 0 : (int)roundf(out / d));
+                if (t == 0) k_scale[ctok * n_kv_heads + hh] = __float2half(d);
+            } else {
+                k_pool[dst + t] = __float2bfloat16(out);
+            }
         }
     } else {                                          // V: append as-is (no norm, no rope)
         const int hh = unit - n_q_heads - n_kv_heads;
         const size_t base = ((size_t)tok * n_kv_heads + hh) * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
-        v_pool[dst + t] = v[base + t];
+        if constexpr (INT8) {
+            const float val = pf_to_f(v[base + t]);
+            const float d = pf_headvec_amax(val, s_red, t, head_dim) / 127.0f;
+            v_pool8[dst + t] = (signed char)((d == 0.f) ? 0 : (int)roundf(val / d));
+            if (t == 0) v_scale[ctok * n_kv_heads + hh] = __float2half(d);
+        } else {
+            v_pool[dst + t] = v[base + t];
+        }
     }
 }
 
@@ -1841,11 +1883,31 @@ void launch_prefill_qknorm_ropenorm_kv_bf16(
     cudaStream_t stream, int pos0) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
     const size_t shmem = (size_t)head_dim * sizeof(float);
-    pf_qknorm_ropenorm_kv_bf16_kernel<<<grid, head_dim, shmem, stream>>>(
+    pf_qknorm_ropenorm_kv_kernel<false><<<grid, head_dim, shmem, stream>>>(
         reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
         reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
-        reinterpret_cast<const __nv_bfloat16*>(k_w),
-        reinterpret_cast<__nv_bfloat16*>(k_pool), reinterpret_cast<__nv_bfloat16*>(v_pool),
+        reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool, nullptr, nullptr,
+        block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
+        block_size, max_blocks_per_seq, pos0);
+}
+
+// int8-KV twin of the above: same QK-norm and NORMAL-RoPE math, but each K/V head vector is
+// quantised to int8 with one fp16 scale per (token, kv_head). Muse needs this because the
+// example mains switch the cache to int8 at ctx >= 4096, and a bf16 write into that pool is
+// both wrong and forces the whole prompt onto the token-at-a-time path.
+void launch_prefill_qknorm_ropenorm_kv_int8(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, void* k_scale, void* v_scale,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream, int pos0) {
+    dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
+    const size_t shmem = (size_t)head_dim * sizeof(float);
+    pf_qknorm_ropenorm_kv_kernel<true><<<grid, head_dim, shmem, stream>>>(
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(k),
+        reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
+        reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool,
+        reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
         block_size, max_blocks_per_seq, pos0);
 }

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -258,7 +258,12 @@ __global__ void win_prefill_windowed_kernel(
 // identical to the kernels above; only the schedule (and thus fp32 rounding
 // order) changes. SPARKINFER_PREFILL_ATTN_LANEPAR=0 restores the old kernels.
 // ----------------------------------------------------------------------------
-template <int HEAD_DIM, int QPW, int TK, bool WINDOWED>
+// SINK=false drops the always-attended block 0, giving a PURE sliding window -- the contract
+// Muse Glimmer's layers use (and the one win_prefill_lanepar_bf16_kernel below implements over a
+// bf16 pool). NWARP is templated for the same reason that kernel templates it: Muse's short
+// prefill wants a narrower block and more of them. Both default to today's values, so every
+// existing instantiation compiles to exactly the code it did before.
+template <int HEAD_DIM, int QPW, int TK, bool WINDOWED, bool SINK = true, int NWARP = 16>
 __global__ void win_prefill_lanepar_kernel(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
@@ -267,7 +272,6 @@ __global__ void win_prefill_lanepar_kernel(
     int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
     constexpr int ELEMS = HEAD_DIM / 32;
     constexpr int KSTRIDE = HEAD_DIM + 4;   // +4 floats: lane-strided rows hit 32 banks, 16B-aligned
-    constexpr int NWARP = 16;
     constexpr int TQ = NWARP * QPW;         // queries per block
     static_assert(TK == 32, "one key per lane");
     const int warp = threadIdx.x >> 5, lane = threadIdx.x & 31;
@@ -278,8 +282,10 @@ __global__ void win_prefill_lanepar_kernel(
     const bool active = (q0 < n_tokens) && (head < n_q_heads);
 
     auto win_start = [&](int t) -> int {
+        if (!SINK && win_blocks <= 0) return 0;          // pure-window layers: 0 => full causal
         const int n_blk_q = (t + block_size) / block_size;
-        const int rsb = (win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks);
+        const int rsb = SINK ? ((win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks))
+                             : ((win_blocks >= n_blk_q)     ? 0 : (n_blk_q - win_blocks));
         return rsb * block_size;
     };
 
@@ -343,7 +349,7 @@ __global__ void win_prefill_lanepar_kernel(
 #pragma unroll
                 for (int i = 0; i < QPW; i++) {
                     if (WINDOWED) {
-                        const bool insink = kpos < block_size;
+                        const bool insink = SINK && (kpos < block_size);
                         const bool inwin = (kpos >= my_rs[i]) && (kpos <= qtok[i]);
                         in[i] = live && (insink || inwin) && (qtok[i] < n_tokens);
                     } else {
@@ -418,8 +424,8 @@ __global__ void win_prefill_lanepar_kernel(
     };
 
     if (WINDOWED) {
-        if (blk_rs > block_size) run_range(0, block_size);
-        const int wlo = (blk_rs > block_size) ? blk_rs : 0;
+        if (SINK && blk_rs > block_size) run_range(0, block_size);
+        const int wlo = SINK ? ((blk_rs > block_size) ? blk_rs : 0) : blk_rs;
         run_range(wlo, last_q + 1);
     } else {
         run_range(0, last_q + 1);
@@ -911,6 +917,32 @@ void launch_prefill_attn_swa_pure_bf16(
         reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
         reinterpret_cast<__nv_bfloat16*>(attn),
         n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
+}
+
+// INT8-KV counterpart of launch_prefill_attn_swa_pure_bf16, for Muse Glimmer at ctx >= 4096 where
+// the cache is int8. Same pure-window contract (win_blocks>0 => last win_blocks blocks, <=0 =>
+// full causal) and the same narrow-block schedule; the work is done by the in-tree int8
+// lane-parallel kernel with its sink switched off, so the dequant, the fp32 K/V tiles and the
+// online softmax are the ones the hd256 int8 layers already run.
+void launch_prefill_attn_swa_pure_int8(
+    const void* q, const signed char* k_pool, const signed char* v_pool,
+    const void* k_scale, const void* v_scale, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks,
+    cudaStream_t stream) {
+    (void)head_dim;   // Muse Glimmer attention is hd128 only; templated below.
+    constexpr int HD = 128, TK = 32, NWARP = 8, QPW = 1, TQ = NWARP * QPW;
+    // fp32 K tile (rows padded +4) + fp32 V tile + bf16 query tile == 35,328 B, under the 48 KB
+    // default, so unlike the hd256 instantiation this needs no cudaFuncSetAttribute opt-in.
+    const size_t sm = ((size_t)TK * (HD + 4) + (size_t)TK * HD) * sizeof(float)
+                    + (size_t)TQ * HD * sizeof(__nv_bfloat16);
+    dim3 g((n_tokens + TQ - 1) / TQ, n_q_heads);
+    win_prefill_lanepar_kernel<HD, QPW, TK, /*WINDOWED=*/true, /*SINK=*/false, NWARP>
+        <<<g, NWARP * 32, sm, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
+            reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),
+            block_table, reinterpret_cast<__nv_bfloat16*>(attn),
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
 }
 
 }  // namespace kernels

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -564,18 +564,31 @@ __global__ void win_prefill_pure_bf16_kernel(
 // 32 keys in flight) instead of strictly key-sequential, exactly the way the
 // in-tree int8 lanepar kernel already differs from the int8 sequential ones.
 //
-// K/V stay bf16 in smem (the int8 kernel dequantizes to fp32 because it must):
-// 18.9 KB/block keeps the same ~5 blocks/SM the sequential kernel gets, where
-// fp32 tiles would cost 35 KB and halve occupancy. KSTRIDE pads the K row to
-// HEAD_DIM+8 bf16 = 68 words, and 68 % 32 == 4, so the eight lanes of a 16-byte
-// phase cover banks {0-3, 4-7, ... 28-31}: conflict-free.
+// K/V stay bf16 in smem: 18.9 KB/block keeps the same ~5 blocks/SM the sequential
+// kernel gets, where fp32 tiles would cost 35 KB and halve occupancy. KSTRIDE pads
+// the K row to HEAD_DIM+8 bf16 = 68 words, and 68 % 32 == 4, so the eight lanes of
+// a 16-byte phase cover banks {0-3, 4-7, ... 28-31}: conflict-free.
+//
+// INT8=true reads an int8 K/V pool and dequantizes DURING STAGING, so the tile is
+// bf16 either way and everything below the staging loop is the same code. The
+// alternative -- the hd256 int8 kernel's fp32 tile -- costs 35,328 B at this shape,
+// which caps the SM at 6 resident blocks where 18,944 B reaches the 8 that 256
+// threads/block allow; and it makes the per-lane K row 32 float4 loads instead of
+// 16 uint4, on a kernel that profiles as shared-memory-ISSUE bound. Dequantizing
+// into bf16 costs ~2^-9 relative rounding on top of the int8 step itself, which is
+// small beside the 1/254 the quantization already spends.
 // ----------------------------------------------------------------------------
-template <int HEAD_DIM, int NWARP, int QPW, int TK>
+template <int HEAD_DIM, int NWARP, int QPW, int TK, bool INT8 = false>
 __global__ void win_prefill_lanepar_bf16_kernel(
-    const __nv_bfloat16* __restrict__ q, const __nv_bfloat16* __restrict__ k_pool,
-    const __nv_bfloat16* __restrict__ v_pool, const int* __restrict__ block_table,
+    const __nv_bfloat16* __restrict__ q, const void* __restrict__ k_pool_v,
+    const void* __restrict__ v_pool_v, const __half* __restrict__ k_scale,
+    const __half* __restrict__ v_scale, const int* __restrict__ block_table,
     __nv_bfloat16* __restrict__ attn, int n_tokens, int n_q_heads, int n_kv_heads,
     int block_size, int max_blocks_per_seq, float scale, int win_blocks) {
+    auto* k_pool  = static_cast<const __nv_bfloat16*>(k_pool_v);
+    auto* v_pool  = static_cast<const __nv_bfloat16*>(v_pool_v);
+    auto* k_pool8 = static_cast<const signed char*>(k_pool_v);
+    auto* v_pool8 = static_cast<const signed char*>(v_pool_v);
     constexpr int ELEMS = HEAD_DIM / 32;
     constexpr int KSTRIDE = HEAD_DIM + 8;   // bf16 elems; see bank note above
     constexpr int TQ = NWARP * QPW;         // queries per block
@@ -640,10 +653,32 @@ __global__ void win_prefill_lanepar_bf16_kernel(
             const int phys = block_table[blk];
             const size_t ckt = (size_t)phys * block_size + within;
             const size_t off = (ckt * n_kv_heads + kv_head) * HEAD_DIM + d;
-            *reinterpret_cast<uint4*>(sK + (size_t)kk * KSTRIDE + d) =
-                *reinterpret_cast<const uint4*>(k_pool + off);
-            *reinterpret_cast<uint4*>(sV + (size_t)kk * HEAD_DIM + d) =
-                *reinterpret_cast<const uint4*>(v_pool + off);
+            if constexpr (INT8) {
+                const float ksc = __half2float(k_scale[ckt * n_kv_heads + kv_head]);
+                const float vsc = __half2float(v_scale[ckt * n_kv_heads + kv_head]);
+                const char4 ka = *reinterpret_cast<const char4*>(k_pool8 + off);
+                const char4 kb = *reinterpret_cast<const char4*>(k_pool8 + off + 4);
+                const char4 va = *reinterpret_cast<const char4*>(v_pool8 + off);
+                const char4 vb = *reinterpret_cast<const char4*>(v_pool8 + off + 4);
+                __nv_bfloat162 kt[4], vt[4];
+                kt[0] = __floats2bfloat162_rn(ka.x * ksc, ka.y * ksc);
+                kt[1] = __floats2bfloat162_rn(ka.z * ksc, ka.w * ksc);
+                kt[2] = __floats2bfloat162_rn(kb.x * ksc, kb.y * ksc);
+                kt[3] = __floats2bfloat162_rn(kb.z * ksc, kb.w * ksc);
+                vt[0] = __floats2bfloat162_rn(va.x * vsc, va.y * vsc);
+                vt[1] = __floats2bfloat162_rn(va.z * vsc, va.w * vsc);
+                vt[2] = __floats2bfloat162_rn(vb.x * vsc, vb.y * vsc);
+                vt[3] = __floats2bfloat162_rn(vb.z * vsc, vb.w * vsc);
+                *reinterpret_cast<uint4*>(sK + (size_t)kk * KSTRIDE + d) =
+                    *reinterpret_cast<const uint4*>(kt);
+                *reinterpret_cast<uint4*>(sV + (size_t)kk * HEAD_DIM + d) =
+                    *reinterpret_cast<const uint4*>(vt);
+            } else {
+                *reinterpret_cast<uint4*>(sK + (size_t)kk * KSTRIDE + d) =
+                    *reinterpret_cast<const uint4*>(k_pool + off);
+                *reinterpret_cast<uint4*>(sV + (size_t)kk * HEAD_DIM + d) =
+                    *reinterpret_cast<const uint4*>(v_pool + off);
+            }
         }
         __syncthreads();
         if (active && k0 <= qtok[QPW - 1]) {
@@ -903,9 +938,8 @@ void launch_prefill_attn_swa_pure_bf16(
         const size_t sm = (size_t)(TK * KSTRIDE + TK * HD + TQB * HD) * sizeof(__nv_bfloat16);
         dim3 g((n_tokens + TQB - 1) / TQB, n_q_heads);
         win_prefill_lanepar_bf16_kernel<HD, NWARP, QPW, TK><<<g, NWARP * 32, sm, stream>>>(
-            reinterpret_cast<const __nv_bfloat16*>(q),
-            reinterpret_cast<const __nv_bfloat16*>(k_pool),
-            reinterpret_cast<const __nv_bfloat16*>(v_pool), block_table,
+            reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
+            nullptr, nullptr, block_table,
             reinterpret_cast<__nv_bfloat16*>(attn),
             n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
         return;
@@ -931,13 +965,29 @@ void launch_prefill_attn_swa_pure_int8(
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
     cudaStream_t stream) {
     (void)head_dim;   // Muse Glimmer attention is hd128 only; templated below.
-    constexpr int HD = 128, TK = 32, NWARP = 8, QPW = 1, TQ = NWARP * QPW;
-    // fp32 K tile (rows padded +4) + fp32 V tile + bf16 query tile == 35,328 B, under the 48 KB
-    // default, so unlike the hd256 instantiation this needs no cudaFuncSetAttribute opt-in.
-    const size_t sm = ((size_t)TK * (HD + 4) + (size_t)TK * HD) * sizeof(float)
-                    + (size_t)TQ * HD * sizeof(__nv_bfloat16);
+    constexpr int HD = 128, TK = 32, KSTRIDE = HD + 8, NWARP = 8, QPW = 1, TQ = NWARP * QPW;
+    // The int8 pool is dequantized into a BF16 tile during staging, so this shares the schedule,
+    // the pure-window mask and the smem budget of the bf16 kernel: 18,944 B rather than the
+    // 35,328 B an fp32 tile would take. SPARKINFER_MUSE_ATTN_I8_FP32=1 selects the fp32-tile
+    // kernel instead (same result, different rounding) if that trade ever needs re-measuring.
+    static const bool fp32_tile = [] {
+        const char* e = getenv("SPARKINFER_MUSE_ATTN_I8_FP32");
+        return e && e[0] == '1';
+    }();
     dim3 g((n_tokens + TQ - 1) / TQ, n_q_heads);
-    win_prefill_lanepar_kernel<HD, QPW, TK, /*WINDOWED=*/true, /*SINK=*/false, NWARP>
+    if (fp32_tile) {
+        const size_t sm = ((size_t)TK * (HD + 4) + (size_t)TK * HD) * sizeof(float)
+                        + (size_t)TQ * HD * sizeof(__nv_bfloat16);
+        win_prefill_lanepar_kernel<HD, QPW, TK, /*WINDOWED=*/true, /*SINK=*/false, NWARP>
+            <<<g, NWARP * 32, sm, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
+                reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),
+                block_table, reinterpret_cast<__nv_bfloat16*>(attn),
+                n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks);
+        return;
+    }
+    const size_t sm = (size_t)(TK * KSTRIDE + TK * HD + TQ * HD) * sizeof(__nv_bfloat16);
+    win_prefill_lanepar_bf16_kernel<HD, NWARP, QPW, TK, /*INT8=*/true>
         <<<g, NWARP * 32, sm, stream>>>(
             reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
             reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -105,6 +105,16 @@ void launch_rope_kv_append_partial(
     int n_tokens, int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim,
     float theta, int block_size, int max_blocks_per_seq, cudaStream_t stream = nullptr);
 // int8-KV variant: K/V appended as int8 (per-(token,kv_head) fp16 scale), Q RoPE'd bf16 in-place.
+// int8-KV decode append for Muse Glimmer: NORMAL (consecutive-pair) RoPE on SWA layers,
+// NoPE on the global ones (rope_normal == false). Muse's bf16 append wrote two-byte values into a
+// one-byte-per-element int8 pool, which is why ctx >= 4096 produced garbage.
+void launch_muse_kv_append_int8(void* q, const void* k, const void* v,
+                                void* k_pool, void* v_pool, void* k_scale, void* v_scale,
+                                const int* block_table, const int* positions,
+                                int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+                                float theta, bool rope_normal,
+                                int block_size, int max_blocks_per_seq, cudaStream_t stream);
+
 void launch_rope_kv_append_partial_int8(
     void* q, const void* k, const void* v, void* k_pool, void* v_pool, void* k_scale, void* v_scale,
     const int* block_table, const int* positions,

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -195,6 +195,15 @@ void launch_prefill_qknorm_ropenorm_kv_bf16(
     cudaStream_t stream = nullptr,
     int pos0 = 0);
 
+// int8-KV twin of the above (Muse Glimmer at ctx >= 4096): same QK-norm + NORMAL RoPE, K/V
+// quantised to int8 with one fp16 scale per (token, kv_head).
+void launch_prefill_qknorm_ropenorm_kv_int8(
+    void* q, void* k, const void* v, const void* q_w, const void* k_w,
+    void* k_pool, void* v_pool, void* k_scale, void* v_scale,
+    const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
+    cudaStream_t stream, int pos0 = 0);
+
 // Full-attention prefill: causal attention over the paged int8 KV pool just filled above.
 // One warp per (token, q-head); online softmax over keys 0..q_pos0+token (causal). q is the rope'd
 // bf16 query [N,n_q_heads*hd]; out attn[N,n_q_heads*hd].

--- a/kernels/include/sparkinfer/kernels/prefill_attn_window.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_window.h
@@ -44,5 +44,15 @@ void launch_prefill_attn_swa_pure_bf16(
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
     cudaStream_t stream = nullptr);
 
+// INT8-KV counterpart of the above (Muse Glimmer at ctx >= 4096, where the cache is int8). Same
+// pure-window contract: win_blocks>0 => last win_blocks blocks (SWA layers); win_blocks<=0 =>
+// full causal (global/NoPE layers).
+void launch_prefill_attn_swa_pure_int8(
+    const void* q, const signed char* k_pool, const signed char* v_pool,
+    const void* k_scale, const void* v_scale, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks,
+    cudaStream_t stream = nullptr);
+
 }  // namespace kernels
 }  // namespace sparkinfer

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -1775,6 +1775,16 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                     } else if (c.muse_glimmer && !w.swa) {
                         // Global/NoPE layer: no rotation at all (Q/K are already QK-normed
                         // above) -- append K/V as-is. Every 4th layer per sliding_window_pattern.
+                        // The bf16 append below casts the pool to bf16* unconditionally, so on an
+                        // int8 cache it wrote two bytes per one-byte element: correct-looking but
+                        // corrupt, and the reason Muse produced garbage at ctx >= 4096 (where the
+                        // example mains switch the cache to int8). Quantise instead when kv8.
+                        if (kv8)
+                            kernels::launch_muse_kv_append_int8(
+                                s.q, s.k, s.v, kpool, vpool, kscale, vscale, btable, s.d_writepos, 1,
+                                c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta, /*rope_normal=*/false,
+                                s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
+                        else
                         launch_kv_append((bf16*)kpool, (bf16*)vpool, s.k, s.v, btable, s.d_writepos, 1,
                                          c.n_kv_heads, c.head_dim, s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
                     } else if (partial_rope) {
@@ -1797,6 +1807,14 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
                         // Unconditional (not gated on s.use_ropekv) so a SPARKINFER_ROPEKV=0
                         // override can't silently fall through to the NeoX plain-launch_rope
                         // path in the final else below.
+                        // Same int8 hazard as the NoPE branch above: this writes bf16 straight
+                        // into the pool, which is wrong when the cache is int8.
+                        if (kv8)
+                            kernels::launch_muse_kv_append_int8(
+                                s.q, s.k, s.v, kpool, vpool, kscale, vscale, btable, s.d_pos, 1,
+                                c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta, /*rope_normal=*/true,
+                                s.kv->block_size(), s.kv->max_blocks_per_seq(), st);
+                        else
                         kernels::launch_rope_kv_append_normal(s.q, s.k, s.v, (bf16*)kpool, (bf16*)vpool, btable, s.d_pos, 1,
                                                               c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta,
                                                               s.kv->block_size(), s.kv->max_blocks_per_seq(), st);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -127,12 +127,13 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     // Its BF16 attention (windowed/full hd128) + bf16 KV write reuse the batched pipeline below
     // with muse-specific kernels; the full-attn scratch aliases (qb/qg<-gv/lnrm, kf/vf<-gq/gk) must
     // still fit, i.e. linear_vdim>=qdim and linear_qdim>=kvdim (4096>=4096, 2048>=256 for muse).
-    // Muse runs a BF16 KV cache (its decode KV write is unconditionally bf16); if the cache is
-    // int8 here the config is inconsistent -- fall back to the token loop rather than corrupt it.
+    // Muse honours whichever cache it is given: bf16, or int8 with per-(token,kv_head) fp16 scales.
+    // It used to decline an int8 cache outright, which sent the WHOLE prompt to the token loop --
+    // and the example mains ask for int8 at ctx >= 4096, so that is where every long Muse prompt
+    // went (4096: 103 pp against 4062 pp for the same prompt with the cache forced to bf16).
     if (c.muse_glimmer) {
         if (c.head_dim != 128 || !c.dense_ffn) return -1;
         if (s.linear_vdim < s.qdim || s.linear_qdim < s.kvdim) return -1;
-        if (s.kv->int8_kv()) return -1;
     } else if (c.head_dim != 256 || c.linear_head_dim != 128) {
         return -1;   // kernels specialize these
     }
@@ -1615,20 +1616,37 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                 kernels::launch_prefill_split_q_gate(b8, qb, qg, N, c.n_q_heads, c.head_dim, st);
             }
             if (c.muse_glimmer) {
-                // Muse Glimmer runs a BF16 KV cache (its decode KV-write is bf16, qwen35.cpp:1065/1087),
-                // not int8. QK-norm + NORMAL (consecutive-pair, LLAMA_ROPE_TYPE_NORM) RoPE on SWA layers
-                // / NoPE on global layers, bf16 append -- the same KV a forward_token decode writes via
-                // launch_rmsnorm + launch_rope_kv_append_normal / launch_kv_append. Then pure-window
-                // attention on SWA layers, full causal on global (win_blocks<=0), over the bf16 pool.
-                bf16* kpool_bf = (bf16*)s.kv->k_pool() + s.kv->layer_base_elems(L);
-                bf16* vpool_bf = (bf16*)s.kv->v_pool() + s.kv->layer_base_elems(L);
+                // QK-norm + NORMAL (consecutive-pair, LLAMA_ROPE_TYPE_NORM) RoPE on SWA layers /
+                // NoPE on global layers, then a KV append that writes exactly what a forward_token
+                // decode writes into the same cache. Then pure-window attention on SWA layers, full
+                // causal on global (win_blocks<=0).
+                //
+                // Both halves come in a bf16 and an int8 flavour and the cache picks. The int8 pair
+                // is what lets a long Muse prompt stay on this batched path at all: the example
+                // mains switch the cache to int8 at ctx >= 4096, and this function used to decline
+                // that outright.
                 const int muse_rot = w.swa ? c.head_dim : 0;      // SWA = full NORMAL rope; global = NoPE
-                kernels::launch_prefill_qknorm_ropenorm_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
-                    kpool_bf, vpool_bf, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                    muse_rot, rope_theta, eps, bs, mbs, st);
                 const int win_blocks = w.swa ? (c.sliding_window + bs - 1) / bs : 0;  // 0 => global full causal
-                kernels::launch_prefill_attn_swa_pure_bf16(qb, kpool_bf, vpool_bf, btable, att,
-                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks, st);
+                if (kv8) {
+                    signed char* kpool8 = (signed char*)s.kv->k_pool() + s.kv->layer_base_elems(L);
+                    signed char* vpool8 = (signed char*)s.kv->v_pool() + s.kv->layer_base_elems(L);
+                    void* kscale = (char*)s.kv->k_scale_pool() + s.kv->scale_layer_base_elems(L) * 2;
+                    void* vscale = (char*)s.kv->v_scale_pool() + s.kv->scale_layer_base_elems(L) * 2;
+                    kernels::launch_prefill_qknorm_ropenorm_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
+                        kpool8, vpool8, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads,
+                        c.head_dim, muse_rot, rope_theta, eps, bs, mbs, st);
+                    kernels::launch_prefill_attn_swa_pure_int8(qb, kpool8, vpool8, kscale, vscale,
+                        btable, att, N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale,
+                        win_blocks, st);
+                } else {
+                    bf16* kpool_bf = (bf16*)s.kv->k_pool() + s.kv->layer_base_elems(L);
+                    bf16* vpool_bf = (bf16*)s.kv->v_pool() + s.kv->layer_base_elems(L);
+                    kernels::launch_prefill_qknorm_ropenorm_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
+                        kpool_bf, vpool_bf, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
+                        muse_rot, rope_theta, eps, bs, mbs, st);
+                    kernels::launch_prefill_attn_swa_pure_bf16(qb, kpool_bf, vpool_bf, btable, att,
+                        N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks, st);
+                }
             } else {
                 signed char* kpool = (signed char*)s.kv->k_pool() + s.kv->layer_base_elems(L) * kv_elem;
                 signed char* vpool = (signed char*)s.kv->v_pool() + s.kv->layer_base_elems(L) * kv_elem;


### PR DESCRIPTION
## Summary

Muse Glimmer emitted garbage at ctx >= 4096 and lost most of its prefill throughput there. The
example mains switch the KV cache to int8 at ctx >= 4096, but Muse's decode KV append cast the pool
to bf16 unconditionally — two-byte writes into a one-byte-per-element pool — and the batched prefill
declined an int8 cache outright, dropping the whole prompt onto the token-at-a-time path. The model
takes `KVCacheManager*` and does not own it, so Muse has to honour int8 rather than avoid it.

- **decode KV write**: `muse_kv_append_int8_kernel` — NORMAL rope on SWA layers, NoPE on global,
  per-head-vector max-abs to int8 plus one fp16 scale (the `amax/127` convention the other int8
  appenders use).
- **prefill KV write**: the Muse writer is templated on `<bool INT8>`. The QK-norm and NORMAL-rope
  math is shared and only the store tail differs, so the two flavours cannot drift; `INT8=false` is
  the previous kernel unchanged.
- **prefill attention**: `win_prefill_lanepar_kernel` gains `<bool SINK, int NWARP>`. `SINK=false`
  drops the always-attended block 0 — the one semantic difference between the hd256 sink+window
  contract and Muse's pure sliding window. Both parameters default to today's values, so every
  existing instantiation compiles to the code it did before. The new hd128 entry point
  `launch_prefill_attn_swa_pure_int8` fits 35,328 B of smem and needs no `cudaFuncSetAttribute`.
- the `int8_kv()` decline in `prefill_batched_run` is removed.

A second commit then stages that int8 K/V into a **bf16** attention tile rather than fp32. At hd128
the fp32 tile costs 35,328 B of shared memory per block, capping the SM at 6 resident blocks where
18,944 B reaches the 8 that 256 threads/block allow, and it makes the per-lane K row 32 `float4`
loads instead of 16 `uint4` on a kernel that profiles as shared-memory-issue bound. Worth
+7.2% / +11.7% / +11.9% at 4k / 16k / 32k, with **bit-identical output** between the two tile
precisions (24/24 greedy tokens) — the int8 values are integers scaled by an fp16 scale, so bf16
carries them without moving an argmax. `SPARKINFER_MUSE_ATTN_I8_FP32=1` still selects the fp32 tile.

Correctness at ctx=4096 on a real tokenized prompt: the int8 arm goes from garbage to text that
tracks the bf16 reference for 18 of 24 greedy tokens. Batched prefill and the token loop diverge at
the same token under int8 as under bf16, so the residual difference is the pre-existing
prefill/decode numeric gap, not this path; and the token loop is bit-identical between an int8 and a
bf16 cache.

No regression, A/B interleaved against a stock build on the same box: Muse decode@ctx=0 0.9996 and
prefill@128 1.0027 (median of 5); Qwen3.8 and modelopt decode/prefill at 4k and 16k worst median
ratio 0.9993. The second commit was re-checked the same way against the first: worst ratio 0.9995
across Muse's decode@ctx=0 / prefill@128 and eight Qwen3.8 + modelopt dims.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh`):

| | decode tok/s |
|---|--:|
| before (main) | 94.64 |
| after (this PR) | 96.61 |

**Prefill pp tok/s** (Muse Glimmer 30B, `--ctx 4096`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 102.61 |
| after prefill (this PR) | 4165.65 |

Time-to-first-token at the same context falls from 39.588 s to 0.964 s.

```text
$ bench/scripts/bench.sh Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf --tokens 32 --ctx 4096

--- before (main) ---
ttft         : 39.588 s  (103.5 tok/s prefill, prompt=4096)
decode tg    : 94.64 tok/s  (10.6 ms/token, n=32, ctx=4096, bs=1)
prefill pp   : 102.61 tok/s  (ctx=4096, sequential KV fill)

--- after (this PR) ---
ttft         : 0.964 s  (4247.7 tok/s prefill, prompt=4096)
decode tg    : 96.61 tok/s  (10.4 ms/token, n=32, ctx=4096, bs=1)
prefill pp   : 4165.65 tok/s  (ctx=4096, sequential KV fill)


$ bench/scripts/bench.sh Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf --tokens 32 --ctx 32768

--- before (main) ---
ttft         : 354.857 s  (92.3 tok/s prefill, prompt=32768)
decode tg    : 80.61 tok/s  (12.4 ms/token, n=32, ctx=32768, bs=1)
prefill pp   : 91.90 tok/s  (ctx=32768, sequential KV fill)

--- after (this PR) ---
ttft         : 15.299 s  (2141.8 tok/s prefill, prompt=32768)
decode tg    : 81.62 tok/s  (12.3 ms/token, n=32, ctx=32768, bs=1)
prefill pp   : 2053.84 tok/s  (ctx=32768, sequential KV fill)

GPU: NVIDIA GeForce RTX 5090, sm_120, clocks pinned by bench.sh (2475-2535 MHz under load)
```
