### PR TITLE
perf(muse): run Muse's prefill attention on the int8 tensor cores (1.67x prefill@4k, 2.45x @16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -379,7 +379,10 @@ __device__ __forceinline__ void pf_mma_16832(int (&d)[4], const unsigned (&a)[4]
                  : "r"(a[0]), "r"(a[1]), "r"(a[2]), "r"(a[3]), "r"(b0), "r"(b1));
 }
 
-template <int HEAD_DIM, int GROUP_BLKS, int RQH, int PLANES = 0, bool VT = false, bool WIDEK = false, int PVU = 1>
+// SINK=false drops the always-attended block 0, giving the PURE sliding window Muse Glimmer's
+// SWA layers use. Defaulted true, so every existing instantiation compiles to what it did before.
+template <int HEAD_DIM, int GROUP_BLKS, int RQH, int PLANES = 0, bool VT = false, bool WIDEK = false, int PVU = 1,
+          bool SINK = true>
 __global__ __launch_bounds__(GROUP_BLKS * 32, (GROUP_BLKS >= 16 ? 1 : (RQH <= 3 ? 2 : 1))) void pf_attn_mma_gqa_kernel(
     const __nv_bfloat16* __restrict__ q, const signed char* __restrict__ k_pool,
     const signed char* __restrict__ v_pool, const __half* __restrict__ k_scale,
@@ -543,10 +546,11 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (GROUP_BLKS >= 16 ? 1 : (RQH <= 3 
     int blk_rs = 0;
     if (win_blocks > 0) {
         const int n_blk_q = (q_pos0 + qbase + BLKSZ) / BLKSZ;
-        const int rsb = (win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks);
+        const int rsb = SINK ? ((win_blocks >= n_blk_q - 1) ? 1 : (n_blk_q - win_blocks))
+                             : ((win_blocks >= n_blk_q)     ? 0 : (n_blk_q - win_blocks));
         blk_rs = rsb * BLKSZ;
     }
-    const bool split_sink = (win_blocks > 0) && (blk_rs > BLKSZ);
+    const bool split_sink = SINK && (win_blocks > 0) && (blk_rs > BLKSZ);
 
     // The sink range and the main range are the same loop over different bounds, and calling a
     // [&] lambda twice inlines its whole body twice: ~9.7k SASS instructions for this kernel,
@@ -556,7 +560,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (GROUP_BLKS >= 16 ? 1 : (RQH <= 3 
     // bearing: without it ptxas peels the two-iteration loop straight back into two bodies.
     #pragma unroll 1
     for (int rr_ = (split_sink ? 0 : 1); rr_ < 2; rr_++) {
-        const int lo = (rr_ == 0) ? 0 : (split_sink ? blk_rs : 0);
+        const int lo = (rr_ == 0) ? 0 : (SINK ? (split_sink ? blk_rs : 0) : blk_rs);
         const int hi = (rr_ == 0) ? BLKSZ : (last_q + 1);
         for (int k0 = lo; k0 < hi; k0 += GN) {
             const int nk   = min(GN, hi - k0);
@@ -683,7 +687,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (GROUP_BLKS >= 16 ? 1 : (RQH <= 3 
             // is the common path, not the rare one.
             const bool grp_full =
                 (nk == GN) && (qbase + BM <= n_tokens) && (k0 + GN <= q_pos0 + qbase + 1) &&
-                (win_blocks <= 0 || k0 >= blk_rs || k0 + GN <= BLKSZ);
+                (win_blocks <= 0 || k0 >= blk_rs || (SINK && k0 + GN <= BLKSZ));
 
             // ---- online softmax per head; quantize P' ----
             // Column ownership inside the warp is VECTOR, not strided. Lane `lane` used to own
@@ -777,7 +781,7 @@ __global__ __launch_bounds__(GROUP_BLKS * 32, (GROUP_BLKS >= 16 ? 1 : (RQH <= 3 
                                     const bool live =
                                         (t < gblk * 16) && (gtok < hi) && (qtok < n_tokens) &&
                                         (gtok <= q_pos0 + qtok) &&
-                                        (win_blocks <= 0 || gtok < BLKSZ || gtok >= blk_rs);
+                                        (win_blocks <= 0 || (SINK && gtok < BLKSZ) || gtok >= blk_rs);
                                     sc[u] = live ? (float)rw[j] * qs * PF_KS(u) : -1e30f;
                                 }
                                 mx = fmaxf(mx, sc[u]);
@@ -1153,7 +1157,8 @@ const signed char* vpack_build(const signed char* v_pool, const int* block_table
 }
 }  // namespace
 
-template <int HD, int GROUP_BLKS, int RQH, int PLANES = 0, bool VT = false, bool WIDEK = false, int PVU = 1>
+template <int HD, int GROUP_BLKS, int RQH, int PLANES = 0, bool VT = false, bool WIDEK = false, int PVU = 1,
+          bool SINK = true>
 static bool launch_attn_gqa(const void* q, const signed char* k_pool, const signed char* v_pool,
                             const void* k_scale, const void* v_scale, const int* block_table,
                             void* attn, int n_tokens, int n_q_heads, int n_kv_heads,
@@ -1205,13 +1210,13 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
                             + (size_t)2 * GN * sizeof(__half)
                             + (size_t)5 * RQH * BM * sizeof(float);
         const cudaError_t ce = cudaFuncSetAttribute(
-            pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH, PLANES, VT, WIDEK, PVU>,
+            pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH, PLANES, VT, WIDEK, PVU, SINK>,
             cudaFuncAttributeMaxDynamicSharedMemorySize, (int)sm_max);
         if (ce != cudaSuccess && sm_max > 48u * 1024u) return false;  // opt-in refused where required
         cfg[dev] = 1;
     }
     dim3 grid((n_tokens + BM - 1) / BM, n_q_heads / RQH);
-    pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH, PLANES, VT, WIDEK, PVU><<<grid, GROUP_BLKS * 32, sm, stream>>>(
+    pf_attn_mma_gqa_kernel<HD, GROUP_BLKS, RQH, PLANES, VT, WIDEK, PVU, SINK><<<grid, GROUP_BLKS * 32, sm, stream>>>(
         reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool,
         reinterpret_cast<const __half*>(k_scale), reinterpret_cast<const __half*>(v_scale),
         block_table, reinterpret_cast<__nv_bfloat16*>(attn), n_tokens, n_q_heads, n_kv_heads,
@@ -1235,6 +1240,32 @@ static bool launch_attn_gqa(const void* q, const signed char* k_pool, const sign
                 RQH, SPL, GROUP_BLKS, GN, sm, qld, pld, n_tokens, (int)VT, (int)WIDEK, PVU, (int)ok);
     }
     return ok;
+}
+
+// Muse Glimmer (hd128, GQA 32/2, block_size 16) on the int8 wmma path. The kernel above is
+// already templated on HEAD_DIM and already carries q_pos0; what kept Muse off it was the
+// launcher's hardcoded HD=256 and the sink. GROUP_BLKS must divide both BM(16) and HEAD_DIM/16,
+// which at hd128 is 8 -- so GB=8, NOT the hd256 default of 16. RQH=4 divides the GQA group of 16.
+// Returns false if the tier declines, so the caller keeps its own kernel.
+bool launch_prefill_attn_mma_muse_hd128(
+    const void* q, const signed char* k_pool, const signed char* v_pool,
+    const void* k_scale, const void* v_scale, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks, cudaStream_t stream,
+    int q_pos0) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_MUSE_ATTN_MMA");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled) return false;
+    if (head_dim != 128 || block_size != 16) return false;
+    if (n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0) return false;
+    if (n_q_heads % 4 != 0) return false;                  // RQH=4 owns 4 q-heads per block
+    if ((n_q_heads / n_kv_heads) % 4 != 0) return false;   // ...all sharing one kv-head
+    return launch_attn_gqa<128, /*GROUP_BLKS=*/8, /*RQH=*/4, /*PLANES=*/0,
+                           /*VT=*/false, /*WIDEK=*/false, /*PVU=*/1, /*SINK=*/false>(
+        q, k_pool, v_pool, k_scale, v_scale, block_table, attn, n_tokens, n_q_heads, n_kv_heads,
+        block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0);
 }
 
 bool launch_prefill_attn_mma(

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -972,6 +972,16 @@ void launch_prefill_attn_swa_pure_int8(
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
     cudaStream_t stream, int q_pos0) {
     (void)head_dim;   // Muse Glimmer attention is hd128 only; templated below.
+    // int8 tensor cores first: attention is 45.8% of Muse prefill at ctx=4096 and 68.9% at 16384
+    // (repeat-slope, two agreeing slopes), and the kernels below are scalar. Declines -> fall
+    // through to the lane-parallel kernel, which is what ran before.
+    // q_pos0 must be forwarded: a windowed ingest starts this pass at a nonzero sequence
+    // position, and the wmma kernel masks on the absolute position exactly as the kernels below
+    // do. Dropping it would silently mask every window against position zero.
+    if (launch_prefill_attn_mma_muse_hd128(q, k_pool, v_pool, k_scale, v_scale, block_table, attn,
+            n_tokens, n_q_heads, n_kv_heads, head_dim, block_size, max_blocks_per_seq, scale,
+            win_blocks, stream, q_pos0))
+        return;
     constexpr int HD = 128, TK = 32, KSTRIDE = HD + 8, NWARP = 8, QPW = 1, TQ = NWARP * QPW;
     // The int8 pool is dequantized into a BF16 tile during staging, so this shares the schedule,
     // the pure-window mask and the smem budget of the bf16 kernel: 18,944 B rather than the

--- a/kernels/include/sparkinfer/kernels/prefill_attn_window.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_window.h
@@ -47,6 +47,15 @@ void launch_prefill_attn_swa_pure_bf16(
 // INT8-KV counterpart of the above (Muse Glimmer at ctx >= 4096, where the cache is int8). Same
 // pure-window contract: win_blocks>0 => last win_blocks blocks (SWA layers); win_blocks<=0 =>
 // full causal (global/NoPE layers).
+// Muse Glimmer's int8 wmma prefill attention (hd128). Returns false if the tier declines, in
+// which case the caller runs its own kernel. Defined in prefill_attn_mma.cu.
+bool launch_prefill_attn_mma_muse_hd128(
+    const void* q, const signed char* k_pool, const signed char* v_pool,
+    const void* k_scale, const void* v_scale, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, int win_blocks,
+    cudaStream_t stream = nullptr, int q_pos0 = 0);
+
 void launch_prefill_attn_swa_pure_int8(
     const void* q, const signed char* k_pool, const signed char* v_pool,
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -759,10 +759,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
         return !(e && e[0] == '0');
     }();
     const int fp4_rows = fp4_chunk_a ? FC : N;
-    const size_t fp4_a_data_bytes = gu_nvfp4
-        ? kernels::prefill_nvfp4_data_bytes(fp4_rows, H) : 0;
-    const size_t fp4_a_sf_bytes = gu_nvfp4
-        ? kernels::prefill_nvfp4_scale_bytes_a(fp4_rows, H) : 0;
     // The attention projection group: q | gate | k | v stacked, so one GEMM covers all four. Its A
     // operand is `xn` at k = H -- the same shape gate/up already quantize -- so fp4_a/fp4_as serve
     // it unchanged; only the [N, qkvg_n] bf16 output and a possibly wider workspace are new.
@@ -778,6 +774,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                                kernels::prefill_nvfp4_supported(N, H, qdim);
     const size_t fp4_ws_wo = muse_nvfp4_wo
         ? kernels::prefill_nvfp4_workspace_bytes(N, H, qdim) : 0;
+    // fp4_a/fp4_as are SHARED by legs with DIFFERENT row counts. gate/up quantizes fn <= FC from
+    // inside the token-chunked FFN loop, but the qkv leg quantizes N rows in one call
+    // (launch_prefill_nvfp4_quant_a(xn, ..., N, H)) and so does the o projection
+    // (launch_prefill_nvfp4_gate_quant_a(att, qg, ..., N, qdim)). Sizing the buffer by FC
+    // therefore overruns it by (N - FC) rows as soon as either is enabled and N > FC -- an
+    // illegal memory access, not a quiet fallback. It stayed invisible because Muse only reached
+    // the FP4 path at N == 128, where FC == N by construction, so the two row counts coincided.
+    // Size by whichever consumer is actually enabled.
+    const int fp4_a_rows = (muse_nvfp4_qkv || muse_nvfp4_wo) ? N : fp4_rows;
+    const size_t fp4_a_data_bytes = gu_nvfp4
+        ? kernels::prefill_nvfp4_data_bytes(fp4_a_rows, H) : 0;
+    const size_t fp4_a_sf_bytes = gu_nvfp4
+        ? kernels::prefill_nvfp4_scale_bytes_a(fp4_a_rows, H) : 0;
     const bool muse_nvfp4_down = muse_nvfp4 && s.w.layers[0].down_fp4 &&
                                  kernels::prefill_nvfp4_supported(N, H, ffn);
     const bool q38_nvfp4_down = q38_nvfp4 && s.w.layers[0].down_fp4 &&


### PR DESCRIPTION
## Summary

Attention is what a long Muse prefill spends its time on — **45.8% at ctx=4096 and 68.9% at 16384** —
and it ran on a scalar kernel. Measured by running the attention kernel N times per layer and taking
the slope of time-per-token against N, two independent slopes per context agreeing to 1.4%.

The in-tree int8 wmma kernel is already templated on `HEAD_DIM`; what kept Muse off it was the
launcher's hardcoded `HD=256` and the attention sink.

- At hd128 the divisibility rule (`GROUP_BLKS` must divide both `BM=16` and `HEAD_DIM/16`) gives
  **`GROUP_BLKS=8`**, not the hd256 default of 16.
- Muse is 32 q-heads over 2 kv-heads, so the GQA group of 16 takes the `RQH=4` tier, and its KV
  block size is 16, so a page is exactly a wmma fragment.
- The kernel implements a sink **plus** a window; Muse needs a **pure** window. `SINK` becomes a
  defaulted template parameter — every existing instantiation keeps the code it had — and hd128 is
  instantiated with `SINK=false`.

The entry point returns `false` on any shape it cannot serve, so the caller keeps the kernel it uses
today rather than consuming an output buffer nothing wrote.

**Also folded in — a latent out-of-bounds write.** `fp4_a`/`fp4_as` are shared by legs with
different row counts: gate/up runs inside the token-chunked FFN loop and passes `fn <= FC`, but the
qkv leg quantizes `N` rows in one call and so does the o projection. The buffer was sized by `FC`,
so with either enabled and `N > FC` the quantize writes `(N - FC)` rows past the end. It is
unreachable rather than absent today — Muse is the only configuration enabling those legs, and it
only reaches the FP4 path at `N == 128`, where `FC == N` by construction. It rides along here
because it has no measurable effect of its own and is the prerequisite for ever raising that gate.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (unchanged — this is a prefill-path change):

| | decode tok/s |
|---|--:|
| before (main) | 97.49 |
| after (this PR) | 97.53 |

**Prefill pp tok/s** (Muse Glimmer 30B, `--ctx 4096`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4263.77 |
| after prefill (this PR) | 7122.49 |

```text
$ bench/scripts/bench.sh Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf --tokens 32 --ctx 4096
  (clocks pinned 2550; medians of 3, interleaved, both arms built from this branch's base)

  ctx=4096    main 4265 / 4264 / 4248   ->  this PR 7122 / 7126 / 6967    1.67x
  ctx=16384   main 2979 / 2975 / 2968   ->  this PR 7289 / 7288 / 7278    2.45x

$ ... --tokens 128 --ctx 4096      (decode, same pair)
  main    decode tg : 97.49 tok/s   prefill pp : 4253.71
  this PR decode tg : 97.53 tok/s   prefill pp : 7111.46
```

Bit-identical to the scalar kernel on a real tokenized prompt (24/24 greedy tokens), and the tier
debug confirms the wmma path is what launched rather than a silent fallback:

```text
[pf-attn-tier] RQH=4 SPL=4 GB=8 GN=128 smem=54016 qld=144 pld=144 n=4096 vt=0 widek=0 pvu=1 ok=1
```

Both gains sit under the ceiling the profile sets (1.845x at 4k, 3.22x at 16k) — that bound is what
distinguishes a real speedup from a kernel that stopped doing the work.

No regression on Muse's scored dims (decode@ctx=0, prefill@128) or on Qwen3.8 / modelopt at 4k and
16k; worst ratio 0.9987 against a 0.98 tolerance.
