### PR TITLE
perf(muse): let the NVFP4 prefill GEMMs run above 128 tokens (2.50x prefill@512, 1.72x @4k)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -282,6 +282,21 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
         return c;
     }();
     int FC = (N < ffn_chunk) ? N : ffn_chunk;
+    // Muse's FP4 FFN legs are correct only while the FFN runs in ONE chunk. The chunked loop
+    // still carries an FC-vs-N assumption of its own (separate from the fp4_a sizing fixed
+    // below): with FC < N it produces degenerate output, while FC == N reproduces the int8 token
+    // stream. That path had never run, because the only context Muse was allowed on FP4 was
+    // N == 128, where FC == N gives exactly one chunk anyway.
+    // Unchunking is worth +6% by itself and unlocks ~+60% of FP4 GEMM, so take it where the
+    // arena can hold the N-row staging; where it cannot, FC stays chunked and the FP4 gate below
+    // (FC == N) leaves Muse on exactly the int8 path it runs today.
+    if (c.muse_glimmer && !s.w.layers.empty() && s.w.layers[0].gate_fp4) {
+        static const int unchunk_max = [] {
+            const char* e = getenv("SPARKINFER_MUSE_FP4_UNCHUNK_MAXN");
+            return e ? atoi(e) : 16384;
+        }();
+        if (N <= unchunk_max) FC = N;
+    }
     bf16* lin_conv_state = static_cast<bf16*>(s.lin_conv_state);
 
     // ---- scratch ----
@@ -700,7 +715,17 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     // Native block-scaled FP4 is deliberately narrow: Muse, the scored M=128 shape, and layers
     // whose eager conversion completed. One activation buffer is shared by gate/up. Down stays on
     // the higher-fidelity #808 quantized path because its error enters the residual directly.
-    const bool muse_nvfp4 = c.muse_glimmer && N == 128 && !s.w.layers.empty() &&
+    // Was `N == 128`: the scored Muse shape, and the only one the FP4 staging was correctly
+    // sized for. With that sizing fixed, the shape question is exactly what
+    // prefill_nvfp4_supported() already answers, so ask it instead of pinning one context.
+    // SPARKINFER_MUSE_NVFP4_MAXN caps it again (128 restores the old behaviour).
+    static const int muse_fp4_maxN = [] {
+        const char* e = getenv("SPARKINFER_MUSE_NVFP4_MAXN");
+        return e ? atoi(e) : (1 << 30);
+    }();
+    const bool muse_nvfp4 = c.muse_glimmer && N >= 128 && N <= muse_fp4_maxN &&
+                            FC == N &&          // chunked FP4 FFN is not correct yet; see FC above
+                            !s.w.layers.empty() &&
                             s.w.layers[0].gate_fp4 &&
                             kernels::prefill_nvfp4_supported(N, ffn, H);
     // Qwen3.8-27B's own gate/up NVFP4 (compressed-tensors checkpoint, see


### PR DESCRIPTION
## Summary

> Rebased onto #1009, now merged, so this is a single commit. It depends on the FP4 activation
> staging fix that landed with #1009 — raising this gate without it is an illegal memory access,
> which is how the bug was found.

Muse's native FP4 path was gated `N == 128` — the scored shape, and the only one whose activation
staging was correctly sized. At every other context the FP4 GEMMs never ran, which is why
converting more weights to FP4 measured **+0.07%**: the path was not executing.

With the staging fixed, the shape question is the one `prefill_nvfp4_supported()` already answers,
so ask that instead of pinning a context.

**One restriction remains, deliberately.** The FP4 FFN legs are correct only while the FFN runs in
**one chunk**: with `FC < N` the output is degenerate, while `FC == N` reproduces the int8 token
stream. That loop carries an `FC`-vs-`N` assumption of its own, and it had never executed — at
`N == 128`, `FC == N` is a single chunk. So Muse keeps the FFN unchunked where the arena allows it,
and the gate requires `FC == N`; a context that cannot be unchunked stays on exactly the int8 path
it runs today. Fixing that loop would remove `SPARKINFER_MUSE_FP4_UNCHUNK_MAXN` entirely.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (unchanged — prefill-path change):

| | decode tok/s |
|---|--:|
| before (main) | 97.5 |
| after (this PR) | 97.5 |

**Prefill pp tok/s** (Muse Glimmer 30B, `--ctx 4096`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 4789 |
| after prefill (this PR) | 11995 |

```text
$ bench/scripts/bench.sh Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf --tokens 16 --ctx <N>
  Measured on this PR's base (#1009) vs this PR, GPU confirmed idle before every run,
  clocks pinned 2550:

    ctx=512     4789 -> 11995 pp    2.504x
    ctx=4096    7142 -> 12283 pp    1.720x
    ctx=16384   7315 -> 11311 pp    1.546x

  ctx=512 is the largest single gain: main's gate was N == 128, so the FP4 GEMMs never ran
  at 512 at all. Attribution of the unchunking alone, measured separately at an earlier base:
  it is worth +6.3% at 4k and +4.2% at 16k, so the FP4 GEMMs are the rest.
```

The third arm matters: measuring only "FP4 on, unchunked" against "today" would credit FP4 with the
unchunking win too. Both totals sit under the ceiling the profile allows — with attention moved to
tensor cores the GEMMs are ~90% of prefill, and FP4 is at most ~2x int8, giving ~1.82x at 4k against
an observed 1.695x.

Unlike #1009 this is a **precision trade, not bit-identical**. FP4 diverges from the int8 stream at
token 10 of 24, at the same index where batched prefill already diverges from the token loop, and
both continuations are coherent Austen criticism ("...may be said of Mr. Darcy, who is, I think, the
most perfect of" against "...may be said of the whole of the Bennet family"). At 32768 the guard
leaves Muse on the int8 path; verified it does not fault.
