### PR TITLE
perf(muse): budget the NVFP4 output legs against the prefill arena, not a context proxy (1.39x prefill@4k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -5775,10 +5775,15 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         size_t fp4_free = 0, fp4_total = 0;
         cudaMemGetInfo(&fp4_free, &fp4_total);
         (void)fp4_free; (void)fp4_total;
-        bool down_fp4_on = c.max_seq <= 2048;
+        // These two legs used to be gated `c.max_seq <= 2048` -- a context proxy standing in for
+        // "will the per-run prefill arena still fit". It answers wrong in both directions: the
+        // ffn_down copy pays +32% at ctx=4096 (11787 -> 15498 pp) and the proxy refuses it, while
+        // at ctx=16384 the copy leaves the run 77 MB and the WHOLE prompt falls to the token loop
+        // ("[prefill] scratch alloc failed ... free=77/32110 MB", 10759 -> 98 pp). Ask the real
+        // question below instead, with a reserve that models the arena rather than a flat number.
+        bool down_fp4_on = true;
         if (fp4o_env)
             down_fp4_on = fp4o_env[0] == '1' || fp4o_env[0] == 'd';
-        wo_fp4_on = wo_fp4_on && c.max_seq <= 2048;
         // Cost EVERY copy that grows the footprint against the free VRAM that is actually there,
         // and drop legs in ascending order of what they are worth until the set fits. Only these
         // three grow it: gate/up convert and then release their native prefill copy, so they are
@@ -5792,10 +5797,22 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         // A card that genuinely cannot spare it still declines here, and declines for the real
         // reason rather than for its label.
         {
-            const size_t reserve = [] {
+            // The reserve has to cover the per-run batched-prefill scratch arena, and that arena
+            // scales with the prompt -- a constant cannot separate a context where these copies
+            // pay from one where they starve the run. Model its two dominant terms at the largest
+            // single-pass prompt this session can take: the FFN staging (ffg|ffu|down, chunked at
+            // FC) and the per-token activations. Calibrated against both endpoints on this
+            // checkpoint: ~1.0 GB at ctx=4096, where the legs fit and pay, and ~3.9 GB at 16384,
+            // where they must be declined. SPARKINFER_MUSE_NVFP4_RESERVE_MB still overrides.
+            const size_t reserve = [&] {
                 const char* e = getenv("SPARKINFER_MUSE_NVFP4_RESERVE_MB");
-                long long mb = e ? atoll(e) : 384; if (mb < 0) mb = 0;
-                return (size_t)mb << 20;
+                if (e) { long long mb = atoll(e); if (mb < 0) mb = 0; return (size_t)mb << 20; }
+                const size_t n_max = (size_t)std::min(c.max_seq, prefill_single_pass_max_tokens());
+                const size_t fc_max = std::min<size_t>(n_max, 16384);   // FP4 FFN runs unchunked
+                const size_t ffn_stage = (size_t)3 * fc_max * (size_t)c.moe_ffn * sizeof(bf16);
+                const size_t act = (size_t)10 * n_max * (size_t)H * sizeof(bf16);
+                const size_t est = ffn_stage + act + ((size_t)256 << 20);
+                return est;
             }();
             const size_t want_qkvg = qkvg_fp4_on ? (size_t)c.n_layers *
                 (kernels::prefill_nvfp4_data_bytes(2 * qdim_a + 2 * kvdim_a, H) +


### PR DESCRIPTION
## Summary

> **Stacked on #1010 → #1009.** The diff below carries those commits; it reduces to this change
> alone once they merge and this branch is rebased.

The o-projection and `ffn_down` FP4 copies were gated `c.max_seq <= 2048` — a context proxy standing
in for "will the per-run prefill arena still fit". It answers wrong in **both** directions on the
card this model is scored on:

| ctx | with the copies | what the proxy does |
|---|---|---|
| 4096 | `ffn_down` is worth **+33.6%** (12260 → 16383 pp) | refuses it |
| 16384 | the copy leaves the run **77 MB**, the scratch allocation fails, and the **whole prompt** falls back to the token loop (10759 → 98 pp) | would allow it, if the reserve were the only guard |

```text
[prefill] scratch alloc failed (ctx=16384, chunk=1024, held=2016 MB, free=77/32110 MB) -> fallback
```

The preflight beside it already costs every copy against real free VRAM — it was written to replace
exactly this kind of proxy ("This replaces a `total >= 40 GiB` card-size test, which is a proxy for
the question and answers it wrong") — but its reserve was a flat 384 MB while the arena it stands
for scales with the prompt. So the conversion passed at 16384 and the *run* failed later.

Drop the proxy and make the reserve model the arena: the FFN staging (`gate|up|down` at `FC`) plus
the per-token activations, evaluated at the largest single-pass prompt the session can take. Both
endpoints now come out right, and a refusal is diagnosable rather than a silent fallback.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (unchanged — prefill-path change):

| | decode tok/s |
|---|--:|
| before (main) | 97.5 |
| after (this PR) | 97.5 |

**Prefill pp tok/s** (Muse Glimmer 30B, `--ctx 4096`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 12283 |
| after prefill (this PR) | 17068 |

```text
$ bench/scripts/bench.sh Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf --tokens 16 --ctx <N>
  Measured on this PR's base (#1010) vs this PR, GPU confirmed idle before every run:

    ctx=512     12063 -> 12098 pp   1.003   (legs pay nothing here, and cost nothing)
    ctx=4096    12283 -> 17068 pp   1.390
    ctx=16384   11311 -> 11364 pp   1.005   (legs declined: 4.4 GB reserve > free VRAM)

  ctx=512 was 0.984 on a single rep, which is why it was re-measured: four interleaved reps give
  1.0029 (+F 12091/12104/11994/12230 against E 12045/12080/11931/12658). The first reading was
  noise, not a regression.

  Two-sided acceptance at defaults -- must enable where it pays AND decline without collapse:
    ctx=4096   down 52/52 enabled          16508 / 16256 pp
    ctx=16384  declined, 4.4 GB reserve    10921 / 10775 pp   (98 pp with a flat 384 MB reserve)
    ctx=32768  declined, 6.6 GB reserve     6805 / 6731 pp
```

The acceptance test is deliberately **two-sided** — it must enable at 4k *and* decline without
collapse at 16k/32k. A one-sided "is it faster at 4k" check ships the 16k regression, which is what
the original proxy was crudely protecting against.

Output at 4096 with the legs on reproduces the int8 reference stream exactly (24/24 greedy tokens on
a real tokenized prompt).
