### PR TITLE
perf(muse): give the 16:1 GQA group a shared-KV decode tile (1.20x decode@64k, 1.13x @32k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -819,6 +819,18 @@ template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE, false>(const _
 template __global__ void fa_split_gqa_kernel<128, 8, FA_GQA_TILE, true>(const __nv_bfloat16*, const void*, const void*,
     const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
 #endif
+// Muse Glimmer is 32 q-heads over 2 kv-heads -- a 16:1 group, the widest in the tree. It never
+// reached any shared-KV tile: the hd256 dispatch covers GQA 4/6/8 and the hd128 one only GQA 8,
+// so Muse fell through to the per-q-head kernel and re-read the same KV sixteen times. At 64k its
+// 13 global layers hold 436 MB of int8 KV, far past L2, so that redundancy is DRAM traffic.
+#ifndef _MSC_VER
+template __global__ void fa_split_gqa_kernel<128, 16, FA_GQA_TILE, false>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
+#endif
+#ifndef _MSC_VER
+template __global__ void fa_split_gqa_kernel<128, 16, FA_GQA_TILE, true>(const __nv_bfloat16*, const void*, const void*,
+    const int*, const int*, float*, float*, float*, float, int, int, int, int, int, const __half*, const __half*);
+#endif
 #ifndef _MSC_VER
 template __global__ void fa_combine_kernel<128, FA_COMBINE_DG, FA_COMBINE_NW>(const float*, const float*, const float*, __nv_bfloat16*, int, int, fa_block_q8_1*);
 #endif
@@ -1644,6 +1656,40 @@ void launch_flash_decode_split(
     const bool mma_aligned = famma && seqlen > 512 && block_size == 16 && mma_chunk >= 32;
     const __half* ksc = reinterpret_cast<const __half*>(k_scale);
     const __half* vsc = reinterpret_cast<const __half*>(v_scale);
+    // 16:1 GQA (Muse Glimmer, 32Q/2KV). Same shared-KV tile as the 8:1 branch below: one block per
+    // (kv_head, split) stages the K/V tile once and all GQA warps reuse it, instead of one block per
+    // q-head each re-reading it. Warp count doubles to 16 (512 threads) and the tile smem is
+    // unchanged, so the block is wider but reads 16x less KV. The int8 MMA sub-branch is NOT taken
+    // here: its __launch_bounds__ asks for 5 blocks/SM, which at 512 threads would demand 2560
+    // threads per SM against a 2048 limit. SPARKINFER_FAGQA16=0 restores the per-q-head kernel.
+    static int fagqa16 = -1;
+    if (fagqa16 < 0) { const char* e = getenv("SPARKINFER_FAGQA16"); fagqa16 = (e && e[0] == '0') ? 0 : 1; }
+    if (use_gqa && fagqa16 && num_kv_heads > 0 && num_q_heads == num_kv_heads * 16) {
+        constexpr int GQA = 16, TILE = FA_GQA_TILE;
+        dim3 gq(num_kv_heads * n_splits, num_seqs);
+        const size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
+        if (int8_kv)
+            fa_split_gqa_kernel<128, GQA, TILE, true><<<gq, GQA * 32, smem, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                ksc, vsc);
+        else
+            fa_split_gqa_kernel<128, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                ksc, vsc);
+        if (cudaPeekAtLastError() != cudaSuccess) goto fa_gqa16_fallthrough;
+        if (gate128)
+            fa_launch_combine_gated_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                                             gate, num_q_heads, n_splits,
+                                             reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
+        else
+            fa_launch_combine_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),
+                                       num_q_heads, n_splits, reinterpret_cast<fa_block_q8_1*>(out_q8), num_seqs, stream);
+        (void)seqlen;
+        return;
+    }
+    fa_gqa16_fallthrough:
     if (use_gqa && num_kv_heads > 0 && num_q_heads == num_kv_heads * 8) {
         constexpr int GQA = 8, TILE = FA_GQA_TILE;
         dim3 gq(num_kv_heads * n_splits, num_seqs);


### PR DESCRIPTION
## Summary

Muse Glimmer is 32 q-heads over 2 kv-heads — a **16:1 GQA group, the widest in the tree** — and it
was the one shape with no shared-KV decode tile. That kernel is instantiated for hd256 at GQA 4/6/8
and for hd128 at GQA 8, so Muse matched none of them and fell through to the per-q-head kernel,
where each of the sixteen q-heads in a group re-reads the same K/V.

At long context that is not an L2 story: the 13 global (NoPE) layers hold **436 MB of int8 KV at
64k against a 96 MB L2**, so the redundant reads are DRAM traffic.

**Profiled before changing anything.** Repeating the decode attention and taking the slope of ITL
against the repeat count (two independent slopes per context, agreeing to 0.2%):

| ctx | ITL | decode-attention share |
|---|--:|--:|
| 32768 | 11.83 ms | 17.8% |
| 65536 | 13.84 ms | 26.8% |

At 64k that is ~477 MB moved in 3.70 ms — about **129 GB/s, some 7%** of what this part can do.
A latency/redundancy signature, not a bandwidth wall.

**`n_splits` was checked first and is not the lever.** Swept at 64k it is monotonic and already
saturating at the `MAX_NSPLITS` cap: 64 → 60.1, 128 → 64.7, 192 → 70.6, 256 → 71.8 tok/s.

The fix instantiates the existing tile kernel at `<128, 16>` and dispatches the 16:1 group to it.
One block per (kv_head, split) stages the K/V tile into shared memory once and all sixteen warps
reuse it. Warp count is unchanged — 512 blocks of 16 warps instead of 8192 of one — so only the KV
traffic drops.

The int8 MMA sub-branch is deliberately not taken for this group: its `__launch_bounds__` asks for
5 blocks/SM, which at `GQA*32 = 512` threads would demand 2560 threads per SM against a 2048 limit.
`SPARKINFER_FAGQA16=0` restores the per-q-head kernel for a same-binary A/B.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (end-to-end):

| | decode tok/s |
|---|--:|
| before (main) | 70.30 |
| after (this PR) | 84.49 |

**Prefill pp tok/s** — unchanged; this is a decode-path change.

```text
Measured the way the eval harness measures: ONE model load over 128/512/4k/16k/32k/64k
(bench_sweep_run's shape), clocks pinned 2550, GPU idle before each run, medians of 2.

    ctx      decode  main ->    PR    delta        prefill delta
    128       105.3 -> 105.7   +0.3%              +1.3%
    512       103.5 -> 104.9   +1.3%              +0.4%
    4096       95.9 -> 100.6   +4.9%              +0.8%
    16384      89.6 ->  97.3   +8.6%              +1.1%
    32768      81.9 ->  92.5  +13.0%              +0.9%
    65536      70.3 ->  84.5  +20.2%              +0.8%
```

Worth noting how this was measured: one process per context reported decode@32k at +12.9%, then a
single-load sweep reported **-5.8%** for the same code. That regression was not this change -- it
was decode running after the collapsed 32k prefill that #1013 fixed. On a main containing #1013 the
same axis is +13.0%. Session shape changes the answer here, so these numbers come from the
harness's shape rather than from per-context runs.

The gain grows with context because the redundant KV traffic it removes does. No context regresses.

Both long-context gains sit under the ceiling the profile allows (1.217x at 32k, 1.366x at 64k) —
that bound is what separates a real speedup from a kernel that stopped doing the work.

Output is **bit-identical** to the per-q-head kernel on a real tokenized prompt (24/24 greedy
tokens): only which CTA stages the tile changes, not the accumulation order.
