### PR TITLE
perf(prefill): window a single pass whose FFN chunk has collapsed (10.8x prefill@32k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -3151,9 +3151,25 @@ int Qwen35Model::prefill_batched_chunked(const int* prompt_ids, int n, bool want
     // threshold, NOT the window size -- a prompt between the two is still one pass.
     if (window <= 0 || n <= prefill_single_pass_max_tokens()) {
         const int seed = prefill_batched(prompt_ids, n, want_seed_logprob);
-        if (seed < 0 || seed >= s.cfg.vocab) return -1;
-        if (out_done) *out_done = n;
-        return seed;
+        if (seed >= 0 && seed < s.cfg.vocab) {
+            if (out_done) *out_done = n;
+            return seed;
+        }
+        // The single pass declined. Returning here sends the WHOLE prompt to the token loop, and
+        // at n == prefill_single_pass_max_tokens() that is exactly what happens in a session whose
+        // KV cache is sized for a longer context: the single-pass arena cannot be allocated beside
+        // it, while the windowed path -- which the very next context up already uses successfully
+        // -- allocates one window and runs. Measured on Muse Glimmer in one model load over
+        // 16k/32k/64k (what bench_sweep_run does): prefill@32k 923 pp against 11018 at 16k and
+        // 8045 at 64k, i.e. the boundary itself, not the length. Windowing it gives 9629 pp.
+        //
+        // Try windowing before giving up. It restarts from position 0, so a single pass that had
+        // already written part of the cache is simply recomputed -- prefill is deterministic in
+        // the prompt, and pos0 == 0 resets the recurrent state the same way the original call did.
+        // Nothing here changes a context where the single pass succeeds: that returns above.
+        if (window <= 0 || n <= window) return -1;
+        fprintf(stderr, "[prefill] single pass declined at n=%d -- windowing (%d) instead of the "
+                        "token loop\n", n, window);
     }
     for (int pos = 0; pos < n; pos += window) {
         const int len = std::min(window, n - pos);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -602,6 +602,28 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             if (FC != fc_before)
                 fprintf(stderr, "[prefill] ffn chunk %d -> %d (ctx=%d, free=%zu MB) to keep the "
                                 "batched pass\n", fc_before, FC, N, fb >> 20);
+            // ...but "keeping the batched pass" is not automatically the right trade. The FFN
+            // re-streams the layer's gate|up|down once per chunk, so a chunk driven far below the
+            // prompt turns this pass into N/FC passes over the weights. On a single pass at
+            // n == prefill_single_pass_max_tokens() in a session whose KV cache is sized for a
+            // longer context, that is what happens: measured on Muse Glimmer over 16k/32k/64k in
+            // ONE model load, prefill@32k runs at 923 pp while 16k does 11018 and 64k does 8045 --
+            // the boundary, not the length. The caller's windowed path sizes its arena for one
+            // window, keeps a healthy chunk, and gives 9629 pp at the same context.
+            // So when the chunk has collapsed and windowing is available, decline and let it run.
+            // Same knob and default as prefill_window_tokens() in qwen35.cpp; that one is in an
+            // anonymous namespace and so is not linkable from here.
+            static const int wtok = [] {
+                const char* e = getenv("SPARKINFER_PREFILL_WINDOW");
+                const int v = e ? atoi(e) : 16384;
+                return v < 0 ? 0 : v;
+            }();
+            if (pos0 == 0 && wtok > 0 && N > wtok && (long)FC * 4 <= (long)N) {
+                fprintf(stderr, "[prefill] ffn chunk collapsed to %d for a %d-token single pass -- "
+                                "declining so the caller can window it\n", FC, N);
+                a.free_all(); a8.free_all();
+                return -1;
+            }
         }
     }
     bf16* ffg  = ffn_alias ? b8 : a.alloc<bf16>((size_t)FC * ffn);   // ffn gate, bounded to FC tokens


### PR DESCRIPTION
## Summary

At `n == prefill_single_pass_max_tokens()`, in a session whose KV cache is sized for a **longer**
context, the single-pass arena has almost nothing left. The chunk-halving loop then shrinks `FC`
until the allocation fits and reports success — but the FFN re-streams the layer's `gate|up|down`
once per chunk, so the pass silently becomes `N/FC` passes over the weights. No error, no fallback
message, just an order of magnitude.

On Muse Glimmer this costs ~10x at exactly one context:

```
[prefill] ffn chunk 8192 -> 1024 (ctx=32768, free=687 MB) to keep the batched pass
prefill@32k = 912 pp   against 11608 at 4k, 10741 at 16k, 7999 at 64k
```

**64k is healthy, so this is the single-pass boundary rather than the length.** 32768 is the largest
prompt that still takes the single pass, and it is the one that cannot afford it — 64k already goes
down the windowed path and is fine.

It only reproduces in **one model load over several contexts**, which is what
`bench/scripts/_eval_speed.sh`'s `bench_sweep_run` does ("One model load, many contexts"). Measured
one context per process, a standalone 32k run sizes its cache for 32k, the arena fits, and the same
context does ~6800 pp — so this is invisible to per-context benchmarking.

Two narrow changes:

- **`prefill_batched_run` declines** when the chunk has collapsed to a quarter of the prompt or less
  *and* the caller has a window to fall back to (`pos0 == 0`, `N > window`). Running degraded is
  worse than handing the work back.
- **the single-pass caller, on a decline, tries the windowed path** before the token loop. It
  restarts at position 0, so a partially written cache is recomputed — prefill is deterministic in
  the prompt, and `pos0 == 0` resets the recurrent state exactly as the original call did.

A context whose single pass succeeds returns before either check and is untouched.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (unchanged — this is a prefill-path change):

| | decode tok/s |
|---|--:|
| before (main) | 82.27 |
| after (this PR) | 82.77 |

**Prefill pp tok/s** (Muse Glimmer 30B, `--ctx 32768`):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 912.46 |
| after prefill (this PR) | 9840.12 |

```text
One model load over 128/512/4k/16k/32k/64k (the shape bench_sweep_run uses), clocks pinned 2550,
GPU idle before each run, PR built from this branch with no instrumentation:

    ctx      prefill  main ->    PR    delta      decode  main ->   PR   delta
    128         6232 ->  6309   +1.2%          105.39 -> 105.92   +0.5%
    512         9461 ->  9576   +1.2%          103.74 -> 104.26   +0.5%
    4096       11608 -> 11814   +1.8%           96.19 ->  96.91   +0.7%
    16384      10741 -> 10973   +2.2%           89.85 ->  90.57   +0.8%
    32768        912 ->  9840   +978%           82.27 ->  82.77   +0.6%
    65536       7999 ->  8189   +2.4%           70.42 ->  70.92   +0.7%

The change firing, from the same run:
    [prefill] ffn chunk 8192 -> 1024 (ctx=32768, free=687 MB) to keep the batched pass
    [prefill] ffn chunk collapsed to 1024 for a 32768-token single pass -- declining so the
              caller can window it
    [prefill] single pass declined at n=32768 -- windowing (16384) instead of the token loop
```

No axis regresses. The sub-2.5% moves at the other five contexts are the arena being less contended
and sit within run-to-run noise; the 32k figure is the change. Output verified on a real tokenized
prompt after the switch to the windowed path.
