### PR TITLE
feat(server): LM Studio + Ollama REST APIs; eval: 12-axis Muse matrix, safer auto-close

### DIFF
--- a/eval/pr_dspark_bot.py
+++ b/eval/pr_dspark_bot.py
@@ -80,7 +80,8 @@ divergence that stayed hidden until the gate's prompt corpus was lengthened enou
 run at all. Enabling it here would REJECT every PR until that is fixed.
 
 Applies `eval-dspark:<TIER>` AND mirrors it to the generic `eval:<TIER>` label (SN74 scoring reads
-eval:* tiers). Auto-close on none/REJECT is live; auto-merge stays OFF unless
+eval:* tiers). Auto-close is live for REJECT ONLY -- never for "none", which for a PR
+aimed at another model is the expected outcome rather than a verdict; auto-merge stays OFF unless
 SPARKINFER_DSPARK_AUTOMERGE=1 is explicitly set.
 
   python eval/pr_dspark_bot.py
@@ -3061,7 +3062,7 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
             "updated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         }
         _save_scores(scores)
-        # Auto-close on "none"/"REJECT" -- same policy as pr_dflash_bot.py. Re-enabled 2026-08-11
+        # Auto-close on "REJECT" ONLY (narrowed 2026-09-09; was none/REJECT). Re-enabled 2026-08-11
         # after an explicit, informed decision: the very first supervised run of this bot closed a
         # real external contributor's unrelated PR (#768) this exact same way, since
         # arb.greenlight_status() is generic (any PR with a checked "tested" box + a decode/
@@ -3072,7 +3073,23 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
         # (broad scope, matching pr_dflash_bot.py) rather than narrow evaluation to only
         # Muse-Glimmer-relevant PRs. If this causes another wrongful close, reopen + apologize the
         # same way, and reconsider the scope-narrowing alternative that was declined here.
-        if label in ("none", "REJECT"):
+        # AUTO-CLOSE ONLY ON REJECT, NEVER ON "none" (changed 2026-09-09).
+        #
+        # "none" means THIS bot measured no change on ITS axes. For a PR aimed at a different
+        # model that is the expected, uninformative outcome -- not a verdict on the PR. Closing on
+        # it destroys good work: this bot is currently the only one on cron, so every PR in the
+        # repo is scored against one model's metrics, and a genuine improvement to another model
+        # measures "none" here by construction. PR #1008 (a 15x Muse prefill win) was minutes away
+        # from being auto-closed by the DSpark bot for exactly this reason and had to be caught by
+        # hand; the same trap now points the other way.
+        #
+        # "REJECT" is different in kind and still closes: it means a measured REGRESSION on a
+        # scored axis, an accuracy-gate failure, or a cross-model guard failure. That is real,
+        # attributable harm and is worth acting on no matter what the PR was aiming at.
+        #
+        # Abandoned PRs are still handled -- by the age-based stale close, which is about
+        # inactivity rather than about a measurement.
+        if label == "REJECT":
             if not res.get("lossless", True) or not res.get("lossless4", True) or not res.get("lossless32", True):
                 fail_clause = "and failed exact DSpark-vs-AR losslessness at one or more contexts"
             elif not res.get("accuracy_ok"):
@@ -3083,7 +3100,7 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
                 fail_clause = "(dspark decode@16k regression)"
             elif res.get("prefill_regressed"):
                 fail_clause = "(prefill@32k regression)"
-            elif label == "none":
+            elif label == "none":   # unreachable: see the REJECT-only guard above
                 fail_clause = "with no verified improvement on the scored 4k/16k/32k decode/prefill and 256k prefill axes"
             else:
                 fail_clause = "(regression)"

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -1,31 +1,34 @@
 #!/usr/bin/env python3
 """sparkinfer Muse Glimmer PR auto-evaluator.
 
-SUPERSEDED by eval/pr_qwen38_bot.py, which scores Qwen3.8-27B (decode@128 on the NVFP4
-checkpoint) on a */30 schedule. Only one bot may hold /tmp/sparkinfer_bot.lock, and they all drive
-the same single pinned GPU, so the two are not meant to run concurrently.
+THE SCORED BOT as of 2026-09-09, by explicit instruction. It replaces pr_dspark_bot.py on the
+hourly cron; only one bot may hold /tmp/sparkinfer_bot.lock and they all drive the same single
+pinned GPU, so they must not run concurrently.
 
-NOTE: the crontab is machine state, not repo state -- merging the commit that added this note does
-NOT retire anything by itself. Until the `0 * * * * eval/run_museglimmer_cron.sh` line is removed
-from the eval host's crontab and replaced with run_qwen38_cron.sh's `*/30` line, THIS bot is still
-the one actually scoring PRs. Everything below describes how it behaves whenever it does run.
+NOTE: the crontab is machine state, not repo state -- merging a commit that changes this note
+does NOT change what runs. Whichever `eval/run_*_cron.sh` line is in the eval host's crontab is
+the bot actually scoring PRs.
 
-Sibling of pr_dflash_bot.py — narrowly scoped to Muse Glimmer's plain AR (autoregressive)
-decode + 128-ctx prefill. Not DFlash, not long-context beyond 128. This scope is deliberate:
-Muse Glimmer is a very young architecture (4 real correctness bugs found and fixed in a single
-bring-up session, commit 6d911d4 and preceding) with essentially zero production track record,
-so this bot stays small and strict rather than growing the same multi-context / cross-model-guard
-surface pr_dflash_bot.py has.
+Sibling of pr_dflash_bot.py. Scope as of 2026-09-09 (widened from decode@0 + prefill@128):
+Muse Glimmer's plain AR decode AND prefill across five contexts, plus two cross-model
+no-regression guards at 32k. The earlier narrow scope was deliberate -- Muse Glimmer was a very
+young architecture (4 real correctness bugs found and fixed in one bring-up session, 6d911d4 and
+preceding) -- but it had become the wrong tradeoff: every dimension sat at or below 128 tokens,
+so the gate was blind to long-context work. PR #1006 ("40x prefill@4k", int8 KV honoured at
+ctx >= 4096) moves nothing the old matrix measured.
 
 Scoring, same-box PR-vs-main on a single pinned GPU:
-  1. Speed  — decode (ctx=0) AND prefill@128 (ctx=128), one Muse Glimmer model load via
+  1. Speed  — decode AND prefill at ctx 128/512/4k/16k/32k (SCORED_CTXS), ten axes, one Muse
+              Glimmer model load via
               bench_sweep_run, PR vs a freshly-measured origin/main, same box, same run. Same
               tier buckets as the AR and DFlash bots (BUCKETS/SIG/REGRESS_TOL below — copied,
-              not reinvented). The two dimensions share a regression floor — REGRESS_TOL failing
-              on EITHER is a hard REJECT — but otherwise take the BETTER of the two tiers: a PR
-              that improves one dimension with the other merely flat (not regressed) still earns
-              credit for the real improvement it made, e.g. an XL decode win paired with a flat
-              prefill still reports XL. Added 2026-08-12 (pt. 4 below) because Muse Glimmer's
+              not reinvented). EVERY axis is also a no-regression floor — REGRESS_TOL failing on
+              ANY ONE of the ten is a hard REJECT, so a PR cannot buy a headline win at one
+              context by giving away another — but otherwise the tier is the BEST measured delta
+              across the set: a PR that improves one axis with the rest merely flat (not
+              regressed) still earns credit for the real improvement it made, e.g. an XL
+              prefill@4k win paired with flat decode still reports XL. Originally two dimensions,
+              added 2026-08-12 (pt. 4 below) because Muse Glimmer's
               `batched_prefill_enabled()` always returns false (its SWA/NoPE per-layer pattern
               has no batched kernel yet), so it *always* pays the slow token-loop prefill path —
               a decode-only gate could never see a prefill-specific regression.
@@ -47,9 +50,17 @@ after this bot's first live run wrongly auto-closed an unrelated PR (#768, reope
 apologized); the user was told the risk directly and chose to accept it rather than narrow the
 evaluation scope.
 
-  3. Qwen3.6 no-regression guard — decode + prefill at ctx 0/512/4k/16k/32k, same box, same PR
-              build, vs a freshly-measured origin/main. Reuses pr_dflash_bot.py's GUARD36 sweep
-              mechanism (bench_sweep_run, REGRESS_TOL=0.98) verbatim rather than reinventing it.
+  3. Cross-model no-regression guards @ 32k — decode + prefill on TWO models, same box, same PR
+              build, vs a freshly-measured origin/main:
+                * Qwen3.6-35B-A3B (Q36_GUARD_*), and
+                * the ModelOpt Qwen3.8-27B NVFP4 checkpoint (MODELOPT_MODEL_DIR) -- the one
+                  pr_dspark_bot.py scores, so a shared-code regression is caught here at Muse-PR
+                  time instead of surfacing later as a mystery in that bot's numbers.
+              Narrowed from the previous five-context Qwen3.6 sweep to 32k only: those extra
+              points cost a model load each on models this bot does not score, and 32k is where
+              shared prefill/KV code actually breaks. Both guards share one implementation
+              (_check_model_guard) so they cannot drift apart. Reuses pr_dflash_bot.py's GUARD36
+              sweep mechanism (bench_sweep_run, REGRESS_TOL=0.98) rather than reinventing it.
               A regression here is a hard REJECT regardless of Muse Glimmer's own speed/accuracy
               result — same discipline as the accuracy gate above. This reverses an earlier,
               explicit scope decision to leave cross-model guarding to a separate pushed backup
@@ -117,7 +128,11 @@ MUSEGLIMMER_NEEDS_REBASE = "museglimmer-needs-rebase"
 # Bumped for the Qwen3.6 no-regression guard (see module docstring, pt. 3), then again for
 # 128-ctx prefill scoring (pt. 4) — same reasoning as pr_dflash_bot.py's own v2-qwenguard bump: a
 # PR evaluated before a scoring change existed must not keep a stale-scored label/score forever.
-EVAL_SCHEMA_VERSION = "v3-prefill128"
+# v4 (2026-09-09): scoring matrix widened from {decode@0, prefill@128} to decode AND prefill at
+# 128/512/4k/16k/32k, Qwen3.6 guard narrowed to 32k, ModelOpt Qwen3.8 32k guard added. A PR
+# scored under v3 must not keep a two-dimension label forever, so the version changes and every
+# open PR is re-evaluated.
+EVAL_SCHEMA_VERSION = "v4-ctx5-prefill-decode-modelopt-guard"
 MARKER_RE = re.compile(
     r"<!-- sparkinfer-museglimmer-eval:" + re.escape(EVAL_SCHEMA_VERSION) + r":([0-9a-f]+)(?:\s+(\{.*?\}))? -->",
     re.DOTALL,
@@ -137,6 +152,10 @@ DEFAULT_MODELS_DIR = os.environ.get("MUSEGLIMMER_MODELS_DIR", "/root/workspace/m
 # checkout so `git clean -qfd` in the remote script's checkout step can never delete it).
 LLAMACPP_DIR = os.environ.get("LLAMACPP_DIR", "/root/workspace/.llamacpp")
 BENCH_TOKENS = int(os.environ.get("MUSEGLIMMER_BENCH_TOKENS", "128"))
+# Repeats per context; qwen3_gguf_bench's sweep mode takes the median internally. 5, not 1 --
+# see the two long incident comments in _remote_script (PR #785's bogus XL and PR #790's bogus
+# guard REJECT, both single-sample artefacts on a box where GPU clocks cannot be pinned).
+BENCH_REPS = 5
 ACC_TOPK = int(os.environ.get("MUSEGLIMMER_ACC_TOPK", "128"))
 # Fixed local port for the reference llama-server this bot starts/stops per run. Distinct from
 # accuracy.sh's interactive default (8081) purely so a manual accuracy.sh run on the same box
@@ -154,6 +173,61 @@ Q36_GUARD_MODEL_FILE = os.environ.get("Q36_GUARD_MODEL_FILE", "Qwen3.6-35B-A3B-U
 Q36_GUARD_MODEL_REPO = os.environ.get("PRIMARY36_MODEL_REPO", "unsloth/Qwen3.6-35B-A3B-GGUF")
 Q36_GUARD_TOK_REPO = os.environ.get("PRIMARY36_TOK_REPO", "Qwen/Qwen3.6-35B-A3B")
 GUARD_CTX_LABEL = {0: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k"}
+
+# Scored contexts, BOTH phases at every one (2026-09-09). Previously this bot scored exactly two
+# numbers: decode at ctx=0 and prefill at ctx=128. That could not see anything a long-context PR
+# did -- PR #1006 (int8 KV honoured, "40x prefill@4k") moves nothing this bot measured, because
+# every dimension it had sat at or below 128 tokens.
+#
+# 128 rather than 0 for the short point: qwen3_gguf_bench only emits a prefill number when ctx > 0
+# (see print_bench_block), so a 0 context can contribute decode but never prefill. Using 128 gives
+# both phases at every scored context and makes the matrix uniform.
+SCORED_CTXS = [128, 512, 4096, 16384, 32768]
+# Repeats PER CONTEXT, not one number for all five. The reps=5 rule recorded below exists because
+# a SHORT measurement is dominated by launch/dispatch jitter on a box where GPU clocks cannot be
+# pinned -- prefill@128 completes in ~1s, so a single sample is meaningless there. That argument
+# does not transfer to long contexts: measured on main 2026-09-09, Muse prefill runs ~100 pp tok/s
+# at EVERY context (the sequential token-loop path), so one 32k prefill pass already takes ~356
+# seconds. A measurement that long has averaged over its own jitter; repeating it five times buys
+# nothing and costs half an hour.
+#
+#   ctx     decode tok/s   prefill pp tok/s   one prefill pass
+#   128        105.50          111.65             ~1 s
+#   512        103.63          110.30             ~5 s
+#   4k          95.22          103.52            ~40 s
+#   16k         88.93           97.26           ~168 s
+#   32k         80.92           92.29           ~356 s
+#
+# 5/5/3/2/1 keeps the jitter defence exactly where it matters and brings one sweep from ~47 min to
+# ~14 min, which is what makes an hourly round possible at all (the round sweeps TWICE, main and
+# PR, before the two guards and the accuracy gate). Revisit once PR #1006-style work lands: when
+# prefill stops being ~100 pp/s everywhere, long contexts get cheap and reps can go back up.
+SCORED_REPS = {128: 5, 512: 5, 4096: 3, 16384: 2, 32768: 1}
+# The GUARDS deliberately keep BENCH_REPS (5) even at 32k, and that is not an inconsistency with
+# SCORED_REPS above. Repeat count should follow how long ONE measurement takes, and that is a
+# property of the model, not of the context: Muse prefills 32k in ~356s (self-averaging, reps=1 is
+# fine), while Qwen3.6 and the ModelOpt checkpoint prefill the same 32k in seconds -- short,
+# jitter-prone, and exactly the shape that made PR #790's guard REJECT on a single bogus 6501
+# reading when two re-runs of the same binary both returned ~8477. A guard that can hard-REJECT a
+# real PR is the last place to economise on samples.
+SCORED_CTX_LABEL = {128: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k"}
+# Order matters only for display; every entry is both a scored dimension AND a no-regression
+# floor, so a PR cannot buy a win at one context by giving one away at another.
+SCORING_DIMS = [f"muse-{phase}@{SCORED_CTX_LABEL[c]}"
+                for c in SCORED_CTXS for phase in ("decode", "prefill")]
+SCORING_DIM = SCORING_DIMS[0]
+
+# Cross-model no-regression guards, decode AND prefill, at 32k only (2026-09-09). Narrowed from
+# the previous 0/512/4k/16k/32k Qwen3.6 sweep: those five points cost five model loads per run on
+# a model this bot does not score, and 32k is where shared prefill/KV code actually breaks. The
+# time that buys is spent on Muse's own five scored contexts instead.
+Q36_GUARD_CTXS = [32768]
+MODELOPT_GUARD_CTXS = [32768]
+# The ModelOpt Qwen3.8-27B NVFP4 checkpoint -- the one pr_dspark_bot.py SCORES. Guarding it here
+# means a Muse PR that regresses shared code (qwen35.cpp, the prefill/KV kernels) is caught by
+# this bot before it lands, rather than showing up later as a mystery regression in the DSpark
+# bot's own numbers. Same env var name as that bot uses, so one .env.eval entry serves both.
+MODELOPT_GUARD_MODEL_DIR = os.environ.get("MODELOPT_MODEL_DIR", "/root/workspace/models_q38_modelopt")
 
 # Auto-merge is wired (mirrors pr_dflash_bot.py's auto_merge_ok_dflash/try_auto_merge_dflash
 # shape) but OFF unless this exact env var is set — NOT set in .env.eval, so it stays fully
@@ -232,15 +306,21 @@ def tier_from_gain(pr_tps: float, main_tps: float, metric: str = "decode"):
 _TIER_RANK = {"REJECT": -1, "none": 0, "XS": 1, "S": 2, "M": 3, "L": 4, "XL": 5}
 
 
-def check_q36_guard(pr: dict, main: dict, tol: float = REGRESS_TOL):
-    """No-regression check: PR vs same-box main, Qwen3.6 only, decode + prefill, every measured
-    context. Adapted from pr_dflash_bot.py's check_qwen_guard (its qwen3.5/Qwythos half dropped —
-    scoped to qwen3.6 only per explicit instruction, module docstring pt. 3). Returns
-    (ok, [human-readable regression/failure strings])."""
+def _check_model_guard(pr: dict, main: dict, key: str, model: str, tol: float = REGRESS_TOL):
+    """No-regression check for ONE guarded model: PR vs same-box main, decode + prefill, every
+    measured context. Adapted from pr_dflash_bot.py's check_qwen_guard.
+
+    Parameterised by `key` (the _parse_remote dict key holding that model's per-context numbers)
+    and `model` (its display name) so the Qwen3.6 and ModelOpt guards are the SAME code rather
+    than two copies that can drift apart -- the failure mode of a duplicated guard is that one of
+    them quietly stops guarding and nobody notices, which is exactly how the DSpark bot's Qwen3.8
+    guard spent its whole life benching the scored checkpoint against itself.
+
+    Returns (ok, [human-readable regression/failure strings])."""
     problems = []
-    if pr.get("guard36_failed") or main.get("guard36_failed") or not pr.get("guard36") or not main.get("guard36"):
-        problems.append("qwen3.6 guard measurement unavailable")
-    pr_ctxs, main_ctxs = pr.get("guard36") or {}, main.get("guard36") or {}
+    if pr.get(f"{key}_failed") or main.get(f"{key}_failed") or not pr.get(key) or not main.get(key):
+        problems.append(f"{model} guard measurement unavailable")
+    pr_ctxs, main_ctxs = pr.get(key) or {}, main.get(key) or {}
     # Iterate over MAIN's contexts (the reference set) — a PR build that crashes partway through
     # its own sweep must not make that context silently uncheckable. Fail closed: a real main
     # baseline (base > 0) with a missing/zero PR measurement (cur <= 0) is a regression, not a skip.
@@ -254,17 +334,29 @@ def check_q36_guard(pr: dict, main: dict, tol: float = REGRESS_TOL):
             cur = pr_vals.get(metric, 0)
             if cur <= 0:
                 problems.append(
-                    f"qwen3.6 {metric}@{label}: PR measurement missing/zero "
+                    f"{model} {metric}@{label}: PR measurement missing/zero "
                     f"(main {base:.1f}) — treated as regression"
                 )
                 continue
             if cur < base * tol:
                 pct = 100.0 * (cur - base) / base
                 problems.append(
-                    f"qwen3.6 {metric}@{label}: {cur:.1f} < {100 * tol:.0f}% of main "
+                    f"{model} {metric}@{label}: {cur:.1f} < {100 * tol:.0f}% of main "
                     f"{base:.1f} ({pct:+.1f}%)"
                 )
     return (len(problems) == 0, problems)
+
+
+def check_q36_guard(pr: dict, main: dict, tol: float = REGRESS_TOL):
+    """Qwen3.6 no-regression guard (module docstring pt. 3), decode + prefill @ 32k."""
+    return _check_model_guard(pr, main, "guard36", "qwen3.6", tol)
+
+
+def check_modelopt_guard(pr: dict, main: dict, tol: float = REGRESS_TOL):
+    """ModelOpt Qwen3.8-27B NVFP4 no-regression guard, decode + prefill @ 32k. Same discipline as
+    the Qwen3.6 guard and the same hard-REJECT consequence -- this is the checkpoint the DSpark
+    bot scores, so a Muse PR that regresses it via shared code must not land."""
+    return _check_model_guard(pr, main, "guardmo", "modelopt", tol)
 
 
 def museglimmer_evaluated_commits(repo, num):
@@ -467,6 +559,21 @@ def _remote_script(ref: str) -> str:
     q36_file = shlex.quote(Q36_GUARD_MODEL_FILE)
     q36_repo = shlex.quote(Q36_GUARD_MODEL_REPO)
     q36_tok = shlex.quote(Q36_GUARD_TOK_REPO)
+    mo_dir = shlex.quote(MODELOPT_GUARD_MODEL_DIR)
+    # bench_sweep_run takes alternating "<ctx> <reps>" pairs; the ctx-only list drives the shell
+    # for-loop that reads the results back out. Both are derived from the same SCORED_CTXS /
+    # *_GUARD_CTXS constants so the sweep and the read-back can never disagree about which
+    # contexts were measured.
+    #
+    # reps=5 everywhere, for the reason the long comments below record: this box cannot pin GPU
+    # clocks ("current user does not have permission to change clocks"), so median-of-N is the
+    # only defence against a single noisy sample hard-REJECTing a real PR.
+    scored_sweep_args = " ".join(f"{c} {SCORED_REPS.get(c, BENCH_REPS)}" for c in SCORED_CTXS)
+    scored_ctx_list = " ".join(str(c) for c in SCORED_CTXS)
+    q36_sweep_args = " ".join(f"{c} {BENCH_REPS}" for c in Q36_GUARD_CTXS)
+    q36_ctx_list = " ".join(str(c) for c in Q36_GUARD_CTXS)
+    mo_sweep_args = " ".join(f"{c} {BENCH_REPS}" for c in MODELOPT_GUARD_CTXS)
+    mo_ctx_list = " ".join(str(c) for c in MODELOPT_GUARD_CTXS)
     return f"""
 set -euo pipefail
 # Surface *why* a crash happened instead of dying silently — same diagnostic trap as
@@ -508,6 +615,7 @@ Q36_GUARD_MODELS_DIR={q36_dir}
 Q36_GUARD_MODEL_FILE={q36_file}
 Q36_GUARD_MODEL_REPO={q36_repo}
 Q36_GUARD_TOK_REPO={q36_tok}
+MODELOPT_GUARD_MODEL_DIR={mo_dir}
 
 cd "$REPO"
 git remote set-url origin https://github.com/gittensor-ai-lab/sparkinfer.git 2>/dev/null || true
@@ -561,15 +669,22 @@ source bench/scripts/_common.sh
 source bench/scripts/_eval_speed.sh
 SI_BIN="$PWD/build/runtime"; SI_LD=""
 wait_gpu_clear
-if bench_sweep_run "$GGUF" "$NTOK" 0 5 128 5; then
-  DECODE_TPS=$(_bench_sweep_get 0 decode_tps)
-  PREFILL128_PP=$(_bench_sweep_get 128 prefill_pp)
+# Five contexts, decode AND prefill at each, in ONE model load (bench_sweep_run sweeps all the
+# ctx points per load). Emitting one MUSE line per context rather than two fixed RESULT_ lines
+# keeps the wire format the same shape as the guards' and lets SCORED_CTXS change without
+# touching the parser.
+if bench_sweep_run "$GGUF" "$NTOK" {scored_sweep_args}; then
+  for ctx in {scored_ctx_list}; do
+    echo "MUSE $ctx $(_bench_sweep_get $ctx decode_tps) $(_bench_sweep_get $ctx prefill_pp)"
+  done
 else
-  DECODE_TPS=0
-  PREFILL128_PP=0
+  echo "MUSE_FAILED"
 fi
-echo "RESULT_DECODE_TPS ${{DECODE_TPS:-0}}"
-echo "RESULT_PREFILL128_PP ${{PREFILL128_PP:-0}}"
+# Back-compat: decode@128 / prefill@128 also go out under their old names. The PR comment
+# renderer, the Polaris payload and the published dashboard all read these two keys, and none of
+# them should have to change because the scoring matrix grew.
+echo "RESULT_DECODE_TPS $(_bench_sweep_get 128 decode_tps || echo 0)"
+echo "RESULT_PREFILL128_PP $(_bench_sweep_get 128 prefill_pp || echo 0)"
 
 # --- accuracy gate: sparkinfer teacher-forced score vs a live llama-server reference, same
 # GGUF, same eval_text.txt corpus this session already validated by hand (6d911d4) ---
@@ -678,20 +793,50 @@ Q36_GGUF="$Q36_GUARD_MODELS_DIR/$Q36_GUARD_MODEL_FILE"
 
 echo "GUARD_START"
 wait_gpu_clear
-if bench_sweep_run "$Q36_GGUF" 128 0 5 512 5 4096 5 16384 5 32768 5; then
-  for ctx in 0 512 4096 16384 32768; do
+if bench_sweep_run "$Q36_GGUF" 128 {q36_sweep_args}; then
+  for ctx in {q36_ctx_list}; do
     echo "GUARD36 $ctx $(_bench_sweep_get $ctx decode_tps) $(_bench_sweep_get $ctx prefill_pp)"
   done
 else
   echo "GUARD36_FAILED"
 fi
+
+# --- ModelOpt Qwen3.8-27B NVFP4 no-regression guard (decode + prefill @ 32k) ---
+# A compressed-tensors DIRECTORY, not a GGUF -- qwen3_gguf_bench accepts either (see its usage
+# line). This is the checkpoint pr_dspark_bot.py scores; guarding it here catches a shared-code
+# regression at Muse-PR time instead of leaving the other bot to discover it after the merge.
+# Skipped, not failed, when the checkpoint is absent: a box without it must not turn every PR
+# into a REJECT, and check_modelopt_guard reports SKIPPED so "guarded" is never claimed when
+# nothing was.
+if [ -d "$MODELOPT_GUARD_MODEL_DIR" ]; then
+  wait_gpu_clear
+  if bench_sweep_run "$MODELOPT_GUARD_MODEL_DIR" 128 {mo_sweep_args}; then
+    for ctx in {mo_ctx_list}; do
+      echo "GUARDMO $ctx $(_bench_sweep_get $ctx decode_tps) $(_bench_sweep_get $ctx prefill_pp)"
+    done
+  else
+    echo "GUARDMO_FAILED"
+  fi
+else
+  echo "GUARDMO_UNAVAILABLE"
+fi
 echo "GUARD_END"
 """
+
+
+def _at(res: dict, ctx: int, phase: str) -> float:
+    """One measurement out of a parsed run's matrix, 0.0 when that context/phase is missing.
+    Every consumer reads through this rather than indexing, so a sweep that dropped one context
+    degrades to a zero (which tier_from_gain scores as a regression) instead of a KeyError that
+    would fail the whole round."""
+    return float(((res.get("muse") or {}).get(ctx) or {}).get(phase, 0.0) or 0.0)
 
 
 def _parse_remote(stdout: str) -> dict:
     out = {}
     guard36 = {}
+    guardmo = {}
+    muse = {}
     for line in (stdout or "").splitlines():
         if line.startswith("REMOTE_HEAD "):
             out["head"] = line.split()[1]
@@ -730,6 +875,15 @@ def _parse_remote(stdout: str) -> dict:
                 out["token_count"] = int(line.split()[1])
             except ValueError:
                 pass
+        elif line.startswith("MUSE "):
+            parts = line.split()
+            if len(parts) >= 4:
+                try:
+                    muse[int(parts[1])] = {"decode": float(parts[2]), "prefill": float(parts[3])}
+                except ValueError:
+                    pass
+        elif line.strip() == "MUSE_FAILED":
+            out["muse_failed"] = True
         elif line.startswith("GUARD36 "):
             parts = line.split()
             if len(parts) >= 4:
@@ -739,7 +893,20 @@ def _parse_remote(stdout: str) -> dict:
                     pass
         elif line.strip() == "GUARD36_FAILED":
             out["guard36_failed"] = True
+        elif line.startswith("GUARDMO "):
+            parts = line.split()
+            if len(parts) >= 4:
+                try:
+                    guardmo[int(parts[1])] = {"decode": float(parts[2]), "prefill": float(parts[3])}
+                except ValueError:
+                    pass
+        elif line.strip() == "GUARDMO_FAILED":
+            out["guardmo_failed"] = True
+        elif line.strip() == "GUARDMO_UNAVAILABLE":
+            out["guardmo_unavailable"] = True
     out["guard36"] = guard36
+    out["guardmo"] = guardmo
+    out["muse"] = muse
     return out
 
 
@@ -904,10 +1071,14 @@ def measure_main_baseline(host, port):
         reason = "main run failed" + (f" — {crash}" if crash else " (no crash diagnostic captured, possible hard kill — retried once)")
         return {"ok": False, "reason": reason, "log": tail}
     main = _parse_remote(r.stdout or "")
-    if "decode_tps" not in main:
-        return {"ok": False, "reason": "main bench missing decode tok/s", "log": (r.stdout or "")[-1500:]}
-    if "prefill128_pp" not in main:
-        return {"ok": False, "reason": "main bench missing prefill@128 pp tok/s", "log": (r.stdout or "")[-1500:]}
+    # Fail the ROUND, not the PR, when the baseline is incomplete: comparing a PR against a
+    # partial baseline silently turns a missing context into a "regression".
+    missing = [SCORED_CTX_LABEL[c] for c in SCORED_CTXS
+               if not ((main.get("muse") or {}).get(c) or {}).get("decode")]
+    if main.get("muse_failed") or missing:
+        return {"ok": False,
+                "reason": "main bench missing Muse Glimmer measurements at ctx " + ",".join(missing or ["(sweep failed)"]),
+                "log": (r.stdout or "")[-1500:]}
     main["ok"] = True
     return main
 
@@ -923,38 +1094,61 @@ def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
         reason = "PR speed/accuracy run failed" + (f" — {crash}" if crash else " (no crash diagnostic captured, possible hard kill — retried once)")
         return {"ok": False, "reason": reason, "log": tail}
     pr = _parse_remote(r.stdout or "")
-    if "decode_tps" not in pr:
-        return {"ok": False, "reason": "PR bench missing decode tok/s", "log": (r.stdout or "")[-1500:]}
-    if "prefill128_pp" not in pr:
-        return {"ok": False, "reason": "PR bench missing prefill@128 pp tok/s", "log": (r.stdout or "")[-1500:]}
+    # A missing PR-side context is NOT treated as an infra failure here -- it is scored as a
+    # regression by tier_from_gain (cur=0 against a real main baseline), which is the fail-closed
+    # direction. Only a wholesale sweep failure is reported as a run failure.
+    if pr.get("muse_failed") or not (pr.get("muse") or {}):
+        return {"ok": False, "reason": "PR bench produced no Muse Glimmer measurements",
+                "log": (r.stdout or "")[-1500:]}
     if "top1" not in pr or "kl" not in pr:
         return {"ok": False, "reason": "PR run missing accuracy METRIC line", "log": (r.stdout or "")[-1500:]}
-    print(f">> PR decode={pr['decode_tps']:.2f} prefill128={pr['prefill128_pp']:.2f} "
-          f"top1={pr.get('top1', 0):.3f} kl={pr.get('kl', 99):.4f}")
+    for ctx in SCORED_CTXS:
+        pv = (pr.get("muse") or {}).get(ctx) or {}
+        mv = (main.get("muse") or {}).get(ctx) or {}
+        print(f">> PR @{SCORED_CTX_LABEL[ctx]:>4}: decode {pv.get('decode', 0):9.2f} "
+              f"(main {mv.get('decode', 0):9.2f})   prefill {pv.get('prefill', 0):10.2f} "
+              f"(main {mv.get('prefill', 0):10.2f})")
+    print(f">> PR accuracy top1={pr.get('top1', 0):.3f} kl={pr.get('kl', 99):.4f}")
 
-    decode_label, decode_delta_pct, decode_passed, decode_reason = tier_from_gain(
-        pr["decode_tps"], main["decode_tps"], metric="decode")
-    prefill_label, prefill_delta_pct, prefill_passed, prefill_reason = tier_from_gain(
-        pr["prefill128_pp"], main["prefill128_pp"], metric="prefill@128")
+    # Ten scored axes: decode and prefill at each of SCORED_CTXS. Every one is ALSO a
+    # no-regression floor -- any single axis regressing is a hard REJECT, so a PR cannot buy a
+    # headline win at one context by giving away another. Otherwise the tier is the best measured
+    # delta across the whole set, which preserves the previous behaviour that a PR improving one
+    # phase with the other merely flat still earns credit for the real improvement it made.
+    #
+    # Iterating SCORED_CTXS rather than restating the contexts keeps this in step with the
+    # constant; the DSpark bot's equivalent comment once named a dimension its list did not hold.
+    scored = []
+    for ctx in SCORED_CTXS:
+        clabel = SCORED_CTX_LABEL[ctx]
+        pr_vals = (pr.get("muse") or {}).get(ctx) or {}
+        main_vals = (main.get("muse") or {}).get(ctx) or {}
+        for phase, unit in (("decode", "decode"), ("prefill", "prefill")):
+            name = f"muse-{unit}@{clabel}"
+            lab, dlt, ok, why = tier_from_gain(
+                pr_vals.get(phase, 0.0), main_vals.get(phase, 0.0), metric=name)
+            scored.append({"dim": name, "label": lab, "delta": dlt, "passed": ok, "reason": why})
+    by_dim = {x["dim"]: x for x in scored}
 
-    # Shared regression floor, best-of-the-rest: either dimension regressing is a hard REJECT
-    # regardless of the other (same conservative, fail-closed philosophy as the accuracy gate and
-    # Q36 guard below, module docstring pt. 4) — but a PR that improves ONE dimension with the
-    # OTHER merely flat (not regressed) still earns credit for the real improvement it made. A
-    # pure prefill@128 optimization with unchanged decode should score on its own merits, not get
-    # dragged down to "none" just because decode wasn't also touched — no different from how a
-    # decode-only PR was never expected to also move prefill.
-    if decode_label == "REJECT" and prefill_label == "REJECT":
-        label, delta_pct, passed = "REJECT", min(decode_delta_pct, prefill_delta_pct), False
-        speed_reason = f"{decode_reason} | {prefill_reason}"
-    elif decode_label == "REJECT":
-        label, delta_pct, passed, speed_reason = "REJECT", decode_delta_pct, False, decode_reason
-    elif prefill_label == "REJECT":
-        label, delta_pct, passed, speed_reason = "REJECT", prefill_delta_pct, False, prefill_reason
-    elif _TIER_RANK[decode_label] >= _TIER_RANK[prefill_label]:
-        label, delta_pct, passed, speed_reason = decode_label, decode_delta_pct, decode_passed, decode_reason
+    regressed = [x for x in scored if x["label"] == "REJECT"]
+    if regressed:
+        worst = min(regressed, key=lambda x: x["delta"])
+        label, delta_pct, passed = "REJECT", worst["delta"], False
+        speed_reason = " | ".join(x["reason"] for x in regressed)
     else:
-        label, delta_pct, passed, speed_reason = prefill_label, prefill_delta_pct, prefill_passed, prefill_reason
+        # max() over measured deltas, not over tier letters: two axes can share a bucket while
+        # one is clearly the larger win, and the delta is what the tier came from anyway.
+        best = max((by_dim[d] for d in SCORING_DIMS if d in by_dim),
+                   key=lambda x: x["delta"], default=by_dim[SCORING_DIM])
+        label, delta_pct, passed, speed_reason = (
+            best["label"], best["delta"], best["passed"], best["reason"])
+
+    # Back-compat names for the report/dashboard/Polaris payload, taken from the 128 axes that
+    # used to be the only two dimensions this bot had.
+    decode_delta_pct = by_dim["muse-decode@128"]["delta"]
+    decode_label = by_dim["muse-decode@128"]["label"]
+    prefill_delta_pct = by_dim["muse-prefill@128"]["delta"]
+    prefill_label = by_dim["muse-prefill@128"]["label"]
 
     pr_top1 = pr.get("top1", 0.0)
     pr_kl = pr.get("kl", 99.0)
@@ -967,6 +1161,18 @@ def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
         acc_reason = (f"accuracy gate failed: top1={pr_top1:.3f} (bar >={ACC_TOP1_BAR}) "
                       f"kl={pr_kl:.4f} (bar <={ACC_KL_BAR})")
         reason = f"{acc_reason} | speed: {speed_reason}"
+        label = "REJECT"
+        passed = False
+
+    mo_ok, mo_problems = check_modelopt_guard(pr, main)
+    if pr.get("guardmo_unavailable") or main.get("guardmo_unavailable"):
+        # Absent checkpoint is a SKIP, not a REJECT -- but say so, so a round that guarded
+        # nothing never reads as a round that guarded successfully.
+        mo_ok, mo_problems = True, []
+        print(">> modelopt guard SKIPPED — checkpoint not installed (MODELOPT_MODEL_DIR)")
+    if not mo_ok:
+        mo_reason = "modelopt no-regression guard failed: " + "; ".join(mo_problems[:6])
+        reason = f"{mo_reason} | {reason}"
         label = "REJECT"
         passed = False
 
@@ -986,16 +1192,24 @@ def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
         "pass": passed and label != "REJECT",
         "reason": reason,
         "delta_pct": delta_pct,
-        "pr_decode_tps": pr["decode_tps"],
-        "main_decode_tps": main["decode_tps"],
+        "pr_decode_tps": _at(pr, 128, "decode"),
+        "main_decode_tps": _at(main, 128, "decode"),
         "decode_delta_pct": decode_delta_pct,
         "decode_regressed": decode_label == "REJECT",
-        "speedup_vs_main": round(pr["decode_tps"] / main["decode_tps"], 3) if main.get("decode_tps") else 0,
-        "pr_prefill128_pp": pr["prefill128_pp"],
-        "main_prefill128_pp": main["prefill128_pp"],
+        "speedup_vs_main": (round(_at(pr, 128, "decode") / _at(main, 128, "decode"), 3)
+                            if _at(main, 128, "decode") else 0),
+        "pr_prefill128_pp": _at(pr, 128, "prefill"),
+        "main_prefill128_pp": _at(main, 128, "prefill"),
         "prefill_delta_pct": prefill_delta_pct,
         "prefill_regressed": prefill_label == "REJECT",
-        "prefill_speedup_vs_main": round(pr["prefill128_pp"] / main["prefill128_pp"], 3) if main.get("prefill128_pp") else 0,
+        "prefill_speedup_vs_main": (round(_at(pr, 128, "prefill") / _at(main, 128, "prefill"), 3)
+                                    if _at(main, 128, "prefill") else 0),
+        # Every scored axis, so the PR comment and the published log can show the whole matrix
+        # rather than just the tier-winning row.
+        "scored_dims": scored,
+        "muse_pr": (pr.get("muse") or {}),
+        "muse_main": (main.get("muse") or {}),
+        "guardmo_skipped": bool(pr.get("guardmo_unavailable") or main.get("guardmo_unavailable")),
         "pr_top1": pr_top1,
         "pr_kl": pr_kl,
         "pr_ppl_spark": pr.get("ppl_spark"),
@@ -1014,6 +1228,29 @@ def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
     if polaris:
         res["polaris"] = polaris
     return res
+
+
+def _matrix_table(res: dict) -> str:
+    """The full PR-vs-main matrix. Rendered from res["scored_dims"] rather than from named keys so
+    it stays correct when SCORED_CTXS changes -- the previous comment hard-coded two rows and would
+    have silently kept showing two after the matrix grew to ten."""
+    dims = res.get("scored_dims") or []
+    if not dims:
+        return ""
+    pr_m, main_m = res.get("muse_pr") or {}, res.get("muse_main") or {}
+    rows = ["| ctx | phase | main | PR | delta |", "|---|---|---|---|---|"]
+    for ctx in SCORED_CTXS:
+        for phase in ("decode", "prefill"):
+            name = f"muse-{phase}@{SCORED_CTX_LABEL[ctx]}"
+            d = next((x for x in dims if x["dim"] == name), None)
+            if not d:
+                continue
+            mv = float((main_m.get(ctx) or {}).get(phase, 0) or 0)
+            pv = float((pr_m.get(ctx) or {}).get(phase, 0) or 0)
+            flag = " **REJECT**" if d["label"] == "REJECT" else ""
+            rows.append(f"| {SCORED_CTX_LABEL[ctx]} | {phase} | {mv:.2f} | {pv:.2f} | "
+                        f"{d['delta']:+.1f}%{flag} |")
+    return "\n".join(rows) + "\n\n"
 
 
 def format_comment(commit: str, res: dict) -> str:
@@ -1071,26 +1308,21 @@ def format_comment(commit: str, res: dict) -> str:
         f"{marker}\n## sparkinfer museglimmer auto-eval — `eval-museglimmer:{lab}`\n\n"
         f"| metric | value |\n|---|---|\n"
         f"| **label** | `eval-museglimmer:{lab}` |\n"
-        f"| scored at | 128-token decode (ctx=0) + 128-ctx prefill — shared regression floor, best of the two |\n"
-        f"| PR decode tok/s | {res['pr_decode_tps']:.2f} |\n"
-        f"| main decode tok/s | {res['main_decode_tps']:.2f} |\n"
-        f"| decode speedup vs main | **{res.get('speedup_vs_main', 0):.2f}×** ({res.get('decode_delta_pct', 0):+.1f}%) |\n"
-        f"| PR prefill@128 pp tok/s | {res.get('pr_prefill128_pp', 0):.2f} |\n"
-        f"| main prefill@128 pp tok/s | {res.get('main_prefill128_pp', 0):.2f} |\n"
-        f"| prefill speedup vs main | **{res.get('prefill_speedup_vs_main', 0):.2f}×** ({res.get('prefill_delta_pct', 0):+.1f}%) |\n"
+        f"| scored at | decode + prefill @ 128/512/4k/16k/32k — every axis is also a regression floor, label is the best |\n"
         f"{acc_row}"
         f"{main_acc_note}"
         f"{q36_row}"
         f"| PPL sparkinfer / llama.cpp | {res.get('pr_ppl_spark') or '?'} / {res.get('pr_ppl_llama') or '?'} |\n"
         f"{polaris_row}"
         f"| commit | `{commit[:9]}` |\n\n"
+        f"{_matrix_table(res)}"
         f"{res.get('reason') or ''}\n\n"
-        "<sub>Scored on the pinned eval box vs same-box `origin/main` — 128-token AR decode "
-        "(ctx=0) AND 128-ctx prefill throughput, from one model load; either dimension regressing "
-        "is a hard REJECT, but otherwise the reported label is the **better** of the two tiers — "
-        "a PR that improves just one, with the other flat, still earns credit for that "
-        "(no DFlash, no long-context beyond 128) — Muse Glimmer's narrow, deliberately "
-        "strict eval scope. This is informational, not a judgment on your PR: a `none` label just "
+        "<sub>Scored on the pinned eval box vs same-box `origin/main` — AR decode AND prefill at "
+        "ctx 128/512/4k/16k/32k, from one model load; ANY axis regressing is a hard REJECT, but "
+        "otherwise the reported label is the **best** measured delta across the ten — "
+        "a PR that improves just one, with the rest flat, still earns credit for that. "
+        "Cross-model no-regression guards run at 32k on Qwen3.6 and the ModelOpt Qwen3.8-27B "
+        "NVFP4 checkpoint. This is informational, not a judgment on your PR: a `none` label just "
         "means no measurable Muse Glimmer speedup was verified on either metric, which is expected "
         "and fine if that isn't what your change is about. "
         "Correctness gated against a live llama.cpp reference on the same GGUF. Also gated on a "

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -182,7 +182,24 @@ GUARD_CTX_LABEL = {0: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k"}
 # 128 rather than 0 for the short point: qwen3_gguf_bench only emits a prefill number when ctx > 0
 # (see print_bench_block), so a 0 context can contribute decode but never prefill. Using 128 gives
 # both phases at every scored context and makes the matrix uniform.
-SCORED_CTXS = [128, 512, 4096, 16384, 32768]
+#
+# 64k added 2026-09-09. prefill_single_pass_max_tokens() defaults to 32768, so a prompt LONGER than
+# that is ingested in windows with pos0 > 0 -- a different code path that no scored context reached.
+# Measured on main (post-#1006) at that boundary:
+#
+#     ctx=32768   prefill 2080.89 pp tok/s      (single pass)
+#     ctx=49152   prefill   89.11 pp tok/s      (windowed -> refused -> token loop)
+#
+# A 23x cliff the moment windowing engages, completely invisible to a matrix that stops at 32k.
+# 64k rather than 48k because it is the round number the work in this area is reported against and
+# sits further past the boundary; VRAM is flat across the two (28.0 GB at 32k, 28.4 GB at 48k --
+# the prefill arena SHRINKS as windowing bounds it, offsetting the KV growth), and Muse's own
+# context_length is 131072, so 64k is well inside the model's range.
+#
+# Cost note: while main refuses the windowed path, one 64k prefill pass takes ~12 min, which
+# roughly doubles a Muse sweep. That is temporary in exactly the way the 4k/16k/32k cost was
+# before #1006 -- once the windowed path works, 64k costs ~45s and the sweep returns to ~13 min.
+SCORED_CTXS = [128, 512, 4096, 16384, 32768, 65536]
 # Repeats PER CONTEXT, not one number for all five. The reps=5 rule recorded below exists because
 # a SHORT measurement is dominated by launch/dispatch jitter on a box where GPU clocks cannot be
 # pinned -- prefill@128 completes in ~1s, so a single sample is meaningless there. That argument
@@ -216,7 +233,7 @@ SCORED_CTXS = [128, 512, 4096, 16384, 32768]
 #
 # So: one bench_sweep_run call per tier. That costs one extra model load (~1 min) and is the only
 # way to get 5 samples where a measurement is ~1s and 1 sample where it is ~330s.
-SCORED_REPS_TIERS = [([128, 512], 5), ([4096, 16384, 32768], 1)]
+SCORED_REPS_TIERS = [([128, 512], 5), ([4096, 16384, 32768, 65536], 1)]
 SCORED_REPS = {c: r for ctxs, r in SCORED_REPS_TIERS for c in ctxs}
 # The GUARDS deliberately keep BENCH_REPS (5) even at 32k, and that is not an inconsistency with
 # SCORED_REPS above. Repeat count should follow how long ONE measurement takes, and that is a
@@ -225,7 +242,8 @@ SCORED_REPS = {c: r for ctxs, r in SCORED_REPS_TIERS for c in ctxs}
 # jitter-prone, and exactly the shape that made PR #790's guard REJECT on a single bogus 6501
 # reading when two re-runs of the same binary both returned ~8477. A guard that can hard-REJECT a
 # real PR is the last place to economise on samples.
-SCORED_CTX_LABEL = {128: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k"}
+SCORED_CTX_LABEL = {128: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k",
+                    65536: "64k"}
 # Order matters only for display; every entry is both a scored dimension AND a no-regression
 # floor, so a PR cannot buy a win at one context by giving one away at another.
 SCORING_DIMS = [f"muse-{phase}@{SCORED_CTX_LABEL[c]}"

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -143,9 +143,19 @@ MARKER_RE = re.compile(
 # session validated Muse Glimmer support against /root/sparkinfer_mg specifically, while
 # /root/sparkinfer carries unrelated uncommitted work from a different task that must not be
 # touched or built against.
-REMOTE_REPO = os.environ.get("MUSEGLIMMER_REMOTE_REPO", "/root/sparkinfer_mg")
+# Defaults are the paths that actually exist on the current eval box, NOT historical ones.
+#
+# Both of these were stale and only worked because .env.eval overrode them -- and .env.eval is
+# gitignored, so a box rebuilt from the repo alone, or a restored copy of that file, silently
+# broke the bot. MUSEGLIMMER_GGUF pointed at "muse-glimmer-30B-kquant-17gb.gguf" while the file on
+# disk is "Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf", and REMOTE_REPO at /root/sparkinfer_mg,
+# which does not exist on this box. The env vars still override; they are no longer load-bearing.
+REMOTE_REPO = os.environ.get("MUSEGLIMMER_REMOTE_REPO", "/workspace/eval/bot_repo")
+MUSEGLIMMER_MODELS_DIR = os.environ.get("MUSEGLIMMER_MODELS_DIR",
+                                        "/root/workspace/models_muse_glimmer")
 DEFAULT_GGUF = os.environ.get(
-    "MUSEGLIMMER_GGUF", "/root/workspace/models_muse_glimmer/muse-glimmer-30B-kquant-17gb.gguf"
+    "MUSEGLIMMER_GGUF",
+    os.path.join(MUSEGLIMMER_MODELS_DIR, "Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf"),
 )
 DEFAULT_MODELS_DIR = os.environ.get("MUSEGLIMMER_MODELS_DIR", "/root/workspace/models_muse_glimmer")
 # Shared llama.cpp checkout used by every eval bot on this box (persists outside any repo
@@ -729,6 +739,16 @@ test -x build/runtime/qwen3_gguf_score
 source bench/scripts/_common.sh
 source bench/scripts/_eval_speed.sh
 SI_BIN="$PWD/build/runtime"; SI_LD=""
+# Fail loudly and immediately on a missing checkpoint. Without this the sweep just returns no
+# rows, the baseline comes back empty, and the round reports a measurement problem several
+# minutes later with no hint that the PATH was the issue -- which is exactly how a stale
+# MUSEGLIMMER_GGUF hid for as long as it did.
+if [ ! -f "$GGUF" ]; then
+  echo "FAIL Muse Glimmer checkpoint not found at $GGUF" >&2
+  echo "     (set MUSEGLIMMER_GGUF, or place the model in MUSEGLIMMER_MODELS_DIR)" >&2
+  ls -la "$(dirname "$GGUF")" 2>&1 | head -10 >&2
+  exit 1
+fi
 wait_gpu_clear
 # Five contexts, decode AND prefill at each, in ONE model load (bench_sweep_run sweeps all the
 # ctx points per load). Emitting one MUSE line per context rather than two fixed RESULT_ lines
@@ -1647,7 +1667,7 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
             "updated": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         }
         _save_scores(scores)
-        # Auto-close on "none"/"REJECT" -- same policy as pr_dflash_bot.py. Re-enabled 2026-08-11
+        # Auto-close on "REJECT" ONLY (narrowed 2026-09-09; was none/REJECT). Re-enabled 2026-08-11
         # after an explicit, informed decision: the very first supervised run of this bot closed a
         # real external contributor's unrelated PR (#768) this exact same way, since
         # arb.greenlight_status() is generic (any PR with a checked "tested" box + a decode/
@@ -1658,7 +1678,23 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
         # (broad scope, matching pr_dflash_bot.py) rather than narrow evaluation to only
         # Muse-Glimmer-relevant PRs. If this causes another wrongful close, reopen + apologize the
         # same way, and reconsider the scope-narrowing alternative that was declined here.
-        if label in ("none", "REJECT"):
+        # AUTO-CLOSE ONLY ON REJECT, NEVER ON "none" (changed 2026-09-09).
+        #
+        # "none" means THIS bot measured no change on ITS axes. For a PR aimed at a different
+        # model that is the expected, uninformative outcome -- not a verdict on the PR. Closing on
+        # it destroys good work: this bot is currently the only one on cron, so every PR in the
+        # repo is scored against one model's metrics, and a genuine improvement to another model
+        # measures "none" here by construction. PR #1008 (a 15x Muse prefill win) was minutes away
+        # from being auto-closed by the DSpark bot for exactly this reason and had to be caught by
+        # hand; the same trap now points the other way.
+        #
+        # "REJECT" is different in kind and still closes: it means a measured REGRESSION on a
+        # scored axis, an accuracy-gate failure, or a cross-model guard failure. That is real,
+        # attributable harm and is worth acting on no matter what the PR was aiming at.
+        #
+        # Abandoned PRs are still handled -- by the age-based stale close, which is about
+        # inactivity rather than about a measurement.
+        if label == "REJECT":
             if not res.get("q36_guard_ok", True):
                 fail_clause = "and regressed the Qwen3.6 no-regression guard (decode/prefill on shared code)"
             elif not res.get("accuracy_ok"):
@@ -1667,7 +1703,7 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
                 fail_clause = "and regressed 128-ctx prefill throughput specifically"
             elif res.get("decode_regressed"):
                 fail_clause = "(decode regression)"
-            elif label == "none":
+            elif label == "none":   # unreachable: see the REJECT-only guard above
                 fail_clause = "with no verified improvement on both decode and prefill"
             else:
                 fail_clause = "(regression)"

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -1384,8 +1384,9 @@ def format_comment(commit: str, res: dict) -> str:
         "NVFP4 checkpoint. This is informational, not a judgment on your PR: a `none` label just "
         "means no measurable Muse Glimmer speedup was verified on either metric, which is expected "
         "and fine if that isn't what your change is about. "
-        "Correctness gated against a live llama.cpp reference on the same GGUF. Also gated on a "
-        "Qwen3.6 no-regression guard (decode+prefill, ctx 0/512/4k/16k/32k, same box vs main) — "
+        "Correctness gated against a live llama.cpp reference on the same GGUF. Also gated on two "
+        "cross-model no-regression guards at 32k (decode+prefill, same box vs main): "
+        "Qwen3.6-35B-A3B and the ModelOpt Qwen3.8-27B NVFP4 checkpoint — "
         "Muse Glimmer PRs can touch code shared with other models. "
         "Automated — **not merged**; merge manually after review.</sub>\n"
     )

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -1207,6 +1207,9 @@ def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
         # Every scored axis, so the PR comment and the published log can show the whole matrix
         # rather than just the tier-winning row.
         "scored_dims": scored,
+        "best_dim": (best["dim"] if not regressed else worst["dim"]),
+        "modelopt_guard_ok": mo_ok,
+        "modelopt_guard_problems": mo_problems,
         "muse_pr": (pr.get("muse") or {}),
         "muse_main": (main.get("muse") or {}),
         "guardmo_skipped": bool(pr.get("guardmo_unavailable") or main.get("guardmo_unavailable")),
@@ -1264,6 +1267,17 @@ def format_comment(commit: str, res: dict) -> str:
         "pass": res.get("pass"),
         "accuracy_ok": res.get("accuracy_ok"),
         "q36_guard_ok": res.get("q36_guard_ok"),
+        "modelopt_guard_ok": res.get("modelopt_guard_ok"),
+        "modelopt_guard_skipped": res.get("guardmo_skipped"),
+        # WHICH axis produced delta_pct. Necessary now that the tier comes from ten axes while the
+        # marker still carries only the 128 numbers for the dashboard: without this a reader sees
+        # a headline delta that does not match either number next to it (e.g. +3900% from
+        # prefill@4k printed beside a flat decode@128).
+        "best_dim": res.get("best_dim"),
+        # The whole matrix, so a consumer that wants more than the 128 pair does not have to
+        # re-scrape the rendered table.
+        "dims": {d["dim"]: {"delta": d["delta"], "label": d["label"]}
+                 for d in (res.get("scored_dims") or [])},
     }
     marker = (
         f"<!-- sparkinfer-museglimmer-eval:{EVAL_SCHEMA_VERSION}:{commit} "
@@ -1289,11 +1303,22 @@ def format_comment(commit: str, res: dict) -> str:
                           f"kl={res.get('main_kl'):.4f} — main ALSO misses the bar (informational; "
                           "not gated on main, but check the box/corpus if this persists) |\n")
     if res.get("q36_guard_ok"):
-        q36_row = "| qwen3.6 guard | ✅ no regression (decode+prefill, ctx 0/512/4k/16k/32k) |\n"
+        q36_row = "| qwen3.6 guard | ✅ no regression (decode+prefill @ 32k) |\n"
     else:
         problems = "; ".join((res.get("q36_guard_problems") or [])[:4])
         q36_row = (f"| qwen3.6 guard | ❌ **FAILED** — {problems} — "
                     "**verdict forced to REJECT regardless of speed/accuracy** |\n")
+    if res.get("guardmo_skipped"):
+        # Say SKIPPED explicitly. A guard that silently reports nothing reads identical to one
+        # that passed, which is how an unnoticed vacuous guard survives for months.
+        mo_row = ("| modelopt guard | ⚠️ SKIPPED — checkpoint not installed on the box "
+                  "(`MODELOPT_MODEL_DIR`); shared-code regressions on Qwen3.8 were NOT checked |\n")
+    elif res.get("modelopt_guard_ok"):
+        mo_row = "| modelopt guard | ✅ no regression (decode+prefill @ 32k, Qwen3.8-27B NVFP4) |\n"
+    else:
+        mo_problems = "; ".join((res.get("modelopt_guard_problems") or [])[:4])
+        mo_row = (f"| modelopt guard | ❌ **FAILED** — {mo_problems} — "
+                  "**verdict forced to REJECT regardless of speed/accuracy** |\n")
     polaris = res.get("polaris") or {}
     receipt = polaris.get("receipt")
     if receipt:
@@ -1309,9 +1334,11 @@ def format_comment(commit: str, res: dict) -> str:
         f"| metric | value |\n|---|---|\n"
         f"| **label** | `eval-museglimmer:{lab}` |\n"
         f"| scored at | decode + prefill @ 128/512/4k/16k/32k — every axis is also a regression floor, label is the best |\n"
+        f"| tier from | `{res.get('best_dim') or '?'}` ({res.get('delta_pct', 0):+.1f}%) |\n"
         f"{acc_row}"
         f"{main_acc_note}"
         f"{q36_row}"
+        f"{mo_row}"
         f"| PPL sparkinfer / llama.cpp | {res.get('pr_ppl_spark') or '?'} / {res.get('pr_ppl_llama') or '?'} |\n"
         f"{polaris_row}"
         f"| commit | `{commit[:9]}` |\n\n"

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -196,9 +196,20 @@ GUARD_CTX_LABEL = {0: "128", 512: "512", 4096: "4k", 16384: "16k", 32768: "32k"}
 # the prefill arena SHRINKS as windowing bounds it, offsetting the KV growth), and Muse's own
 # context_length is 131072, so 64k is well inside the model's range.
 #
-# Cost note: while main refuses the windowed path, one 64k prefill pass takes ~12 min, which
-# roughly doubles a Muse sweep. That is temporary in exactly the way the 4k/16k/32k cost was
-# before #1006 -- once the windowed path works, 64k costs ~45s and the sweep returns to ~13 min.
+# 64k gets its OWN tier, not a seat in the long tier, and that is a correctness requirement rather
+# than a cost decision. Contexts inside one bench_sweep_run share a session: KV is sized once for
+# the session's MAXIMUM context, while each context's prefill arena is sized for itself. Putting
+# 64k beside 32k therefore measures 32k under 64k-sized KV pressure, and 32k is the largest
+# single-pass context (prefill_single_pass_max_tokens = 32768), i.e. the most arena-hungry point.
+# Measured on the same main, same box, same day:
+#
+#     32k prefill, long tier ending at 32k    2080.89 pp tok/s
+#     32k prefill, long tier ending at 64k     939.13 pp tok/s     -55%
+#
+# 4k and 16k were unaffected (4128.99 / 2860.47, matching earlier rounds), so this is specifically
+# the big-arena-meets-big-KV interaction. A PR-vs-main delta stayed fair either way -- both legs saw
+# the same pressure -- but the 32k axis stopped measuring 32k serving, and the session also peaked
+# at 97.4% of VRAM. One extra model load (~1 min) buys back both.
 SCORED_CTXS = [128, 512, 4096, 16384, 32768, 65536]
 # Repeats PER CONTEXT, not one number for all five. The reps=5 rule recorded below exists because
 # a SHORT measurement is dominated by launch/dispatch jitter on a box where GPU clocks cannot be
@@ -233,7 +244,7 @@ SCORED_CTXS = [128, 512, 4096, 16384, 32768, 65536]
 #
 # So: one bench_sweep_run call per tier. That costs one extra model load (~1 min) and is the only
 # way to get 5 samples where a measurement is ~1s and 1 sample where it is ~330s.
-SCORED_REPS_TIERS = [([128, 512], 5), ([4096, 16384, 32768, 65536], 1)]
+SCORED_REPS_TIERS = [([128, 512], 5), ([4096, 16384, 32768], 1), ([65536], 1)]
 SCORED_REPS = {c: r for ctxs, r in SCORED_REPS_TIERS for c in ctxs}
 # The GUARDS deliberately keep BENCH_REPS (5) even at 32k, and that is not an inconsistency with
 # SCORED_REPS above. Repeat count should follow how long ONE measurement takes, and that is a
@@ -1283,6 +1294,12 @@ def eval_museglimmer_on_box(host, port, pr_ref: str, main: dict):
     return res
 
 
+def _ctx_list_str() -> str:
+    """"128/512/4k/16k/32k/64k" from SCORED_CTXS. Derived rather than written out: the PR comment
+    twice named a context list that had gone stale behind the constant."""
+    return "/".join(SCORED_CTX_LABEL[c] for c in SCORED_CTXS)
+
+
 def _matrix_table(res: dict) -> str:
     """The full PR-vs-main matrix. Rendered from res["scored_dims"] rather than from named keys so
     it stays correct when SCORED_CTXS changes -- the previous comment hard-coded two rows and would
@@ -1383,7 +1400,7 @@ def format_comment(commit: str, res: dict) -> str:
         f"{marker}\n## sparkinfer museglimmer auto-eval — `eval-museglimmer:{lab}`\n\n"
         f"| metric | value |\n|---|---|\n"
         f"| **label** | `eval-museglimmer:{lab}` |\n"
-        f"| scored at | decode + prefill @ 128/512/4k/16k/32k — every axis is also a regression floor, label is the best |\n"
+        f"| scored at | decode + prefill @ {_ctx_list_str()} — every axis is also a regression floor, label is the best |\n"
         f"| tier from | `{res.get('best_dim') or '?'}` ({res.get('delta_pct', 0):+.1f}%) |\n"
         f"{acc_row}"
         f"{main_acc_note}"
@@ -1394,9 +1411,10 @@ def format_comment(commit: str, res: dict) -> str:
         f"| commit | `{commit[:9]}` |\n\n"
         f"{_matrix_table(res)}"
         f"{res.get('reason') or ''}\n\n"
-        "<sub>Scored on the pinned eval box vs same-box `origin/main` — AR decode AND prefill at "
-        "ctx 128/512/4k/16k/32k, from one model load; ANY axis regressing is a hard REJECT, but "
-        "otherwise the reported label is the **best** measured delta across the ten — "
+        f"<sub>Scored on the pinned eval box vs same-box `origin/main` — AR decode AND prefill at "
+        f"ctx {_ctx_list_str()}; ANY axis regressing is a hard REJECT, but "
+        f"otherwise the reported label is the **best** measured delta across the "
+        f"{len(SCORING_DIMS)} — "
         "a PR that improves just one, with the rest flat, still earns credit for that. "
         "Cross-model no-regression guards run at 32k on Qwen3.6 and the ModelOpt Qwen3.8-27B "
         "NVFP4 checkpoint. This is informational, not a judgment on your PR: a `none` label just "

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -202,7 +202,22 @@ SCORED_CTXS = [128, 512, 4096, 16384, 32768]
 # ~14 min, which is what makes an hourly round possible at all (the round sweeps TWICE, main and
 # PR, before the two guards and the accuracy gate). Revisit once PR #1006-style work lands: when
 # prefill stops being ~100 pp/s everywhere, long contexts get cheap and reps can go back up.
-SCORED_REPS = {128: 5, 512: 5, 4096: 3, 16384: 2, 32768: 1}
+# Grouped as (contexts, reps) TIERS, not a per-context dict, because bench_sweep_run
+# (bench/scripts/_eval_speed.sh) accepts "<ctx> <reps>" pairs but then collapses them:
+#
+#     [ "$reps" -gt "$max_reps" ] && max_reps="$reps"
+#     export SPARKINFER_BENCH_SWEEP_REPS="$max_reps"
+#
+# One reps value is applied to EVERY context in the call -- the maximum. Every other bot passes
+# the same reps for every context, so this never mattered until this bot became the first to pass
+# differing values, and the pair syntax made per-context reps look supported. Passing
+# "128 5 ... 32768 1" therefore ran 32k FIVE times (~27 min for that context alone) instead of
+# once, turning a ~14 min sweep into ~45 min and the round into ~2.5 h.
+#
+# So: one bench_sweep_run call per tier. That costs one extra model load (~1 min) and is the only
+# way to get 5 samples where a measurement is ~1s and 1 sample where it is ~330s.
+SCORED_REPS_TIERS = [([128, 512], 5), ([4096, 16384, 32768], 1)]
+SCORED_REPS = {c: r for ctxs, r in SCORED_REPS_TIERS for c in ctxs}
 # The GUARDS deliberately keep BENCH_REPS (5) even at 32k, and that is not an inconsistency with
 # SCORED_REPS above. Repeat count should follow how long ONE measurement takes, and that is a
 # property of the model, not of the context: Muse prefills 32k in ~356s (self-averaging, reps=1 is
@@ -568,8 +583,25 @@ def _remote_script(ref: str) -> str:
     # reps=5 everywhere, for the reason the long comments below record: this box cannot pin GPU
     # clocks ("current user does not have permission to change clocks"), so median-of-N is the
     # only defence against a single noisy sample hard-REJECTing a real PR.
-    scored_sweep_args = " ".join(f"{c} {SCORED_REPS.get(c, BENCH_REPS)}" for c in SCORED_CTXS)
-    scored_ctx_list = " ".join(str(c) for c in SCORED_CTXS)
+    # One shell block per reps tier; see SCORED_REPS_TIERS for why this cannot be a single call.
+    scored_blocks = []
+    for ctxs, reps in SCORED_REPS_TIERS:
+        args = " ".join(f"{c} {reps}" for c in ctxs)
+        lst = " ".join(str(c) for c in ctxs)
+        scored_blocks.append(
+            f'wait_gpu_clear\n'
+            f'if bench_sweep_run "$GGUF" "$NTOK" {args}; then\n'
+            f'  for ctx in {lst}; do\n'
+            f'    echo "MUSE $ctx $(_bench_sweep_get $ctx decode_tps) $(_bench_sweep_get $ctx prefill_pp)"\n'
+            f'    if [ "$ctx" = "128" ]; then\n'
+            f'      BC_DECODE=$(_bench_sweep_get 128 decode_tps)\n'
+            f'      BC_PREFILL=$(_bench_sweep_get 128 prefill_pp)\n'
+            f'    fi\n'
+            f'  done\n'
+            f'else\n'
+            f'  MUSE_OK=0\n'
+            f'fi')
+    scored_sweep_blocks = "\n".join(scored_blocks)
     q36_sweep_args = " ".join(f"{c} {BENCH_REPS}" for c in Q36_GUARD_CTXS)
     q36_ctx_list = " ".join(str(c) for c in Q36_GUARD_CTXS)
     mo_sweep_args = " ".join(f"{c} {BENCH_REPS}" for c in MODELOPT_GUARD_CTXS)
@@ -673,18 +705,18 @@ wait_gpu_clear
 # ctx points per load). Emitting one MUSE line per context rather than two fixed RESULT_ lines
 # keeps the wire format the same shape as the guards' and lets SCORED_CTXS change without
 # touching the parser.
-if bench_sweep_run "$GGUF" "$NTOK" {scored_sweep_args}; then
-  for ctx in {scored_ctx_list}; do
-    echo "MUSE $ctx $(_bench_sweep_get $ctx decode_tps) $(_bench_sweep_get $ctx prefill_pp)"
-  done
-else
-  echo "MUSE_FAILED"
-fi
+MUSE_OK=1
+BC_DECODE=0
+BC_PREFILL=0
+{scored_sweep_blocks}
+[ "$MUSE_OK" = "1" ] || echo "MUSE_FAILED"
 # Back-compat: decode@128 / prefill@128 also go out under their old names. The PR comment
 # renderer, the Polaris payload and the published dashboard all read these two keys, and none of
 # them should have to change because the scoring matrix grew.
-echo "RESULT_DECODE_TPS $(_bench_sweep_get 128 decode_tps || echo 0)"
-echo "RESULT_PREFILL128_PP $(_bench_sweep_get 128 prefill_pp || echo 0)"
+# Captured during the tier that measured 128 -- _bench_sweep_get reads the LAST sweep's JSON, and
+# 128 is not in the last tier.
+echo "RESULT_DECODE_TPS ${{BC_DECODE:-0}}"
+echo "RESULT_PREFILL128_PP ${{BC_PREFILL:-0}}"
 
 # --- accuracy gate: sparkinfer teacher-forced score vs a live llama-server reference, same
 # GGUF, same eval_text.txt corpus this session already validated by hand (6d911d4) ---

--- a/eval/run_dspark_cron.sh
+++ b/eval/run_dspark_cron.sh
@@ -121,10 +121,48 @@ GPU_LABEL="${EVAL_SSH_HOST:-ssh}"
 [ "${EVAL_TRANSPORT:-vast}" = "ssh" ] || GPU_LABEL="${VAST_INSTANCE:-?}"
 
 TS="$(date -u +%FT%TZ)"
+
+# Outage escalation. A dead box does NOT stop the hourly tick — it degrades it to --labels-only,
+# which logs one ordinary-looking line and exits 0. On 2026-09-04/05 that ran 14 consecutive times
+# (box 87.16.117.183 went unreachable an hour after its last real round) and nothing anywhere got
+# louder, so the outage was only found by someone asking why there were no new numbers. Silent
+# degradation is the right RUNTIME behaviour — never rent, never fail a tick — but it must not be
+# silent to a reader. Count consecutive down ticks and escalate.
+DOWN_FILE="${DSPARK_DOWN_FILE:-$HOME/.sparkinfer_dspark_gpu_down}"
+note_gpu_up() { rm -f "$DOWN_FILE"; }
+note_gpu_down() {
+  local n first
+  n=0; first="$TS"
+  if [ -f "$DOWN_FILE" ]; then
+    n="$(sed -n 1p "$DOWN_FILE" 2>/dev/null | tr -dc '0-9')"; n="${n:-0}"
+    first="$(sed -n 2p "$DOWN_FILE" 2>/dev/null)"; first="${first:-$TS}"
+  fi
+  n=$((n + 1))
+  printf '%s\n%s\n' "$n" "$first" >"$DOWN_FILE"
+  # Loud at the 3rd consecutive miss, then once every 6 after that, so a long outage keeps
+  # reappearing in the log instead of scrolling away behind identical one-liners.
+  # Banner to STDERR, count to STDOUT. The caller reads the count through a $(...) substitution,
+  # which would otherwise swallow the banner entirely -- the exact bug this block exists to prevent.
+  # Cron's `>> log 2>&1` puts stderr in the same log, so the banner still lands next to the tick.
+  if [ "$n" -ge 3 ] && { [ "$n" -eq 3 ] || [ $((n % 6)) -eq 0 ]; }; then
+    {
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      echo "!! DSPARK EVAL DEGRADED: $n consecutive hourly ticks with NO GPU."
+      echo "!! Pinned box $GPU_LABEL unreachable since $first."
+      echo "!! Nothing has been measured, scored or auto-merged since then."
+      echo "!! Fix: point EVAL_SSH_HOST/EVAL_SSH_PORT in .env.eval at a live RTX 5090."
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    } >&2
+  fi
+  echo "$n"
+}
+
 if gpu_ready; then
+  note_gpu_up
   echo "[$TS] sparkinfer DSpark bot — pinned GPU $GPU_LABEL up — full eval (AUTOMERGE=${SPARKINFER_DSPARK_AUTOMERGE:-0})"
   python3 eval/pr_dspark_bot.py "${BOT_ARGS[@]}"
 else
-  echo "[$TS] sparkinfer DSpark bot — pinned GPU $GPU_LABEL down — labels only"
+  DOWN_N="$(note_gpu_down | tail -1)"
+  echo "[$TS] sparkinfer DSpark bot — pinned GPU $GPU_LABEL down (tick $DOWN_N) — labels only"
   python3 eval/pr_dspark_bot.py "${BOT_ARGS[@]}" --labels-only
 fi

--- a/eval/run_museglimmer_cron.sh
+++ b/eval/run_museglimmer_cron.sh
@@ -104,10 +104,49 @@ GPU_LABEL="${EVAL_SSH_HOST:-ssh}"
 [ "${EVAL_TRANSPORT:-vast}" = "ssh" ] || GPU_LABEL="${VAST_INSTANCE:-?}"
 
 TS="$(date -u +%FT%TZ)"
+
+# Outage escalation, ported verbatim from run_dspark_cron.sh (2026-09-09, when this bot became the
+# scored one). A dead box does NOT stop the hourly tick — it degrades it to --labels-only, which
+# logs one ordinary-looking line and exits 0. On 2026-09-04/05 that ran 14 consecutive times and
+# nothing got louder, so the outage was only found by someone asking why there were no new
+# numbers; on 2026-09-08 the counter below is what made a one-tick outage visible immediately.
+# Silent degradation is the right RUNTIME behaviour — never rent, never fail a tick — but it must
+# not be silent to a reader.
+DOWN_FILE="${MUSEGLIMMER_DOWN_FILE:-$HOME/.sparkinfer_museglimmer_gpu_down}"
+note_gpu_up() { rm -f "$DOWN_FILE"; }
+note_gpu_down() {
+  local n first
+  n=0; first="$TS"
+  if [ -f "$DOWN_FILE" ]; then
+    n="$(sed -n 1p "$DOWN_FILE" 2>/dev/null | tr -dc '0-9')"; n="${n:-0}"
+    first="$(sed -n 2p "$DOWN_FILE" 2>/dev/null)"; first="${first:-$TS}"
+  fi
+  n=$((n + 1))
+  printf '%s\n%s\n' "$n" "$first" >"$DOWN_FILE"
+  # Loud at the 3rd consecutive miss, then once every 6 after that, so a long outage keeps
+  # reappearing in the log instead of scrolling away behind identical one-liners.
+  # Banner to STDERR, count to STDOUT. The caller reads the count through a $(...) substitution,
+  # which would otherwise swallow the banner entirely -- the exact bug this block exists to prevent.
+  # Cron's `>> log 2>&1` puts stderr in the same log, so the banner still lands next to the tick.
+  if [ "$n" -ge 3 ] && { [ "$n" -eq 3 ] || [ $((n % 6)) -eq 0 ]; }; then
+    {
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+      echo "!! MUSE EVAL DEGRADED: $n consecutive hourly ticks with NO GPU."
+      echo "!! Pinned box $GPU_LABEL unreachable since $first."
+      echo "!! Nothing has been measured, scored or auto-merged since then."
+      echo "!! Fix: point EVAL_SSH_HOST/EVAL_SSH_PORT in .env.eval at a live RTX 5090."
+      echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+    } >&2
+  fi
+  echo "$n"
+}
+
 if gpu_ready; then
+  note_gpu_up
   echo "[$TS] sparkinfer Muse Glimmer bot — pinned GPU $GPU_LABEL up — full eval (AUTOMERGE=${SPARKINFER_MUSEGLIMMER_AUTOMERGE:-0})"
   python3 eval/pr_museglimmer_bot.py "${BOT_ARGS[@]}"
 else
-  echo "[$TS] sparkinfer Muse Glimmer bot — pinned GPU $GPU_LABEL down — labels only"
+  DOWN_N="$(note_gpu_down | tail -1)"
+  echo "[$TS] sparkinfer Muse Glimmer bot — pinned GPU $GPU_LABEL down (tick $DOWN_N) — labels only"
   python3 eval/pr_museglimmer_bot.py "${BOT_ARGS[@]}" --labels-only
 fi

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(sparkinfer_server
     src/model_engine.cpp
     src/chat_tokenizer.cpp
     src/chat_tools.cpp
+    src/lmstudio_api.cpp
 )
 
 target_include_directories(sparkinfer_server PRIVATE
@@ -70,6 +71,20 @@ if(BUILD_TESTS)
     )
     target_compile_features(chat_tools_test PRIVATE cxx_std_17)
     add_test(NAME chat_tools_test COMMAND chat_tools_test)
+
+    # LM Studio /api/v0 response shaping: pure JSON over plain structs, no engine/CUDA, so it
+    # runs on any box. The assertions are about exact field names and value vocabularies, which
+    # is the entire contract with an LM Studio client.
+    add_executable(lmstudio_api_test
+        tests/lmstudio_api_test.cpp
+        src/lmstudio_api.cpp
+    )
+    target_include_directories(lmstudio_api_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(lmstudio_api_test PRIVATE nlohmann_json::nlohmann_json)
+    target_compile_features(lmstudio_api_test PRIVATE cxx_std_17)
+    add_test(NAME lmstudio_api_test COMMAND lmstudio_api_test)
 
     # Image input: base64, data: URL parsing, decode -- and the refusals, which are the
     # security-relevant half (no remote fetch, bounded payloads, no silent truncation).

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -33,6 +33,7 @@ add_executable(sparkinfer_server
     src/chat_tokenizer.cpp
     src/chat_tools.cpp
     src/lmstudio_api.cpp
+    src/ollama_api.cpp
 )
 
 target_include_directories(sparkinfer_server PRIVATE
@@ -85,6 +86,20 @@ if(BUILD_TESTS)
     target_link_libraries(lmstudio_api_test PRIVATE nlohmann_json::nlohmann_json)
     target_compile_features(lmstudio_api_test PRIVATE cxx_std_17)
     add_test(NAME lmstudio_api_test COMMAND lmstudio_api_test)
+
+    # Ollama /api/* translation: exact field names, NANOSECOND durations, and the shape
+    # differences from OpenAI (message.content, done, done_reason) that are easy to get wrong
+    # while still emitting valid JSON.
+    add_executable(ollama_api_test
+        tests/ollama_api_test.cpp
+        src/ollama_api.cpp
+    )
+    target_include_directories(ollama_api_test PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
+    )
+    target_link_libraries(ollama_api_test PRIVATE nlohmann_json::nlohmann_json)
+    target_compile_features(ollama_api_test PRIVATE cxx_std_17)
+    add_test(NAME ollama_api_test COMMAND ollama_api_test)
 
     # Image input: base64, data: URL parsing, decode -- and the refusals, which are the
     # security-relevant half (no remote fetch, bounded payloads, no silent truncation).

--- a/server/include/lmstudio_api.hpp
+++ b/server/include/lmstudio_api.hpp
@@ -1,0 +1,96 @@
+#pragma once
+
+// LM Studio REST API (/api/v0/*) response shaping.
+//
+// WHY A SEPARATE MODULE: these are pure JSON-shaping functions over plain structs, with no
+// dependency on the engine, the HTTP server or CUDA. That keeps them unit-testable on a box with
+// no GPU -- the same reason chat_tools.cpp and chat_tokenizer.cpp are their own translation units.
+// The route handlers in sparkinfer_server.cpp supply the values; everything about the WIRE FORMAT
+// lives here, so a change to LM Studio's schema is a change to one file with tests behind it.
+//
+// WHICH VERSION, AND WHY THE DEPRECATED ONE: LM Studio 0.4.0 released a native /api/v1/* and
+// recommends it over /api/v0/*. v1 is deliberately NOT implemented here. Its additions beyond v0
+// are MCP support, stateful chats, auth, and model management -- /api/v1/models/load, /unload and
+// /download. Those last three assume a runtime that swaps models on demand; sparkinfer loads one
+// checkpoint at startup from -m and serves exactly that, so there is nothing to load or unload and
+// a v1 server would have to answer half its own contract with errors. v0's five endpoints map onto
+// what this server actually is. Revisit if sparkinfer ever grows a model manager.
+//
+// Schema source: https://lmstudio.ai/docs/developer/rest/endpoints (v0 reference).
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace sparkinfer_server {
+namespace lmstudio {
+
+// One entry of GET /api/v0/models. Field names and value vocabularies are LM Studio's, not ours:
+//   type                "llm" | "vlm" | "embeddings"
+//   compatibility_type  "gguf" | "mlx"   (LM Studio knows only these two)
+//   state               "loaded" | "not-loaded"
+struct ModelDesc {
+    std::string id;
+    std::string type = "llm";
+    std::string publisher;
+    std::string arch;
+    std::string compatibility_type = "gguf";
+    std::string quantization;
+    std::string state = "loaded";
+    int max_context_length = 0;
+    // Only meaningful while loaded. LM Studio omits it on a not-loaded model rather than sending
+    // 0, so a consumer can tell "no context in use" from "a context of zero".
+    int loaded_context_length = 0;
+};
+
+nlohmann::json model_object(const ModelDesc& m);
+nlohmann::json models_list(const std::vector<ModelDesc>& models);
+
+// The "stats" object LM Studio appends to a completion. Times are SECONDS (the server measures
+// milliseconds internally, so the caller converts) and tokens_per_second is decode throughput,
+// not end-to-end.
+struct Stats {
+    double tokens_per_second = 0.0;
+    double time_to_first_token = 0.0;
+    double generation_time = 0.0;
+    std::string stop_reason = "eosFound";
+};
+nlohmann::json stats_object(const Stats& s);
+
+// OpenAI finish_reason -> LM Studio stop_reason. The two vocabularies differ, and a client that
+// switches on stop_reason will silently mis-handle an unmapped value, so map explicitly.
+std::string stop_reason_from_finish(const std::string& finish_reason);
+
+struct ModelInfo {
+    std::string arch;
+    std::string quant;
+    std::string format = "gguf";
+    int context_length = 0;
+};
+nlohmann::json model_info_object(const ModelInfo& mi);
+
+struct RuntimeDesc {
+    std::string name;
+    std::string version;
+    std::vector<std::string> supported_formats{"gguf"};
+};
+nlohmann::json runtime_object(const RuntimeDesc& r);
+
+// Best-effort quantization label from a checkpoint path, e.g.
+//   ".../Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf" -> "Q4_K_M"
+// Filename-derived on purpose: the engine does not retain the GGUF after load, and LM Studio's
+// own field is a display string rather than something a client computes with. Returns "" when
+// nothing recognisable is present, and the caller decides what to report instead of guessing.
+std::string quantization_from_path(const std::string& path);
+
+// "gguf" for a .gguf file. Everything else this server can load (compressed-tensors directories,
+// legacy weight dirs) has no LM Studio vocabulary term; the caller passes what it wants reported.
+std::string compatibility_type_from_path(const std::string& path);
+
+// Publisher segment of a HuggingFace-style path (".../lmstudio-community/Foo-GGUF/x.gguf" ->
+// "lmstudio-community"), "" when the layout does not carry one.
+std::string publisher_from_path(const std::string& path);
+
+}  // namespace lmstudio
+}  // namespace sparkinfer_server

--- a/server/include/ollama_api.hpp
+++ b/server/include/ollama_api.hpp
@@ -79,7 +79,23 @@ bool model_name_matches(const std::string& requested, const std::string& served_
 nlohmann::json chat_request_to_openai(const nlohmann::json& in);
 
 // Ollama /api/generate body -> OpenAI /v1/completions body. Same treatment of `options`/`stream`.
+// ONLY correct for a raw request -- see generate_wants_raw.
 nlohmann::json generate_request_to_openai(const nlohmann::json& in);
+
+// True when /api/generate must bypass prompt templating, i.e. the request set "raw": true.
+//
+// This distinction is the whole reason /api/generate cannot simply map onto /v1/completions.
+// Ollama's /api/generate applies the MODEL'S TEMPLATE to the prompt by default; OpenAI's
+// /v1/completions is raw by definition. Mapping one onto the other sent `ollama run` an
+// unformatted prompt, and the model answered "Reply with exactly: OK" with
+// "OK: OK: OK: OK: ..." -- a working endpoint producing bad output, which is worse than an error
+// because nothing reports it. Only driving the real CLI surfaced it.
+bool generate_wants_raw(const nlohmann::json& in);
+
+// Ollama /api/generate body -> OpenAI /v1/chat/completions body, as a single user turn (plus a
+// system turn when the request carries one). This is the DEFAULT path: it is what makes the
+// server apply its chat template, matching Ollama's own behaviour.
+nlohmann::json generate_request_to_chat(const nlohmann::json& in);
 
 // ---- response translation -------------------------------------------------------------------
 
@@ -95,6 +111,23 @@ nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std:
 
 // RFC3339 UTC timestamp, the format Ollama's created_at uses.
 std::string rfc3339_now();
+
+// A stable 64-hex-character identifier derived from `seed`, for ModelEntry::digest.
+//
+// This is NOT a content hash, and the distinction matters enough to say twice. Ollama's digest is
+// a sha256 of the model blob, used for dedup when pulling; hashing a multi-GB checkpoint on every
+// request is out of the question, and doing it once at startup would add a minute to boot for a
+// field nothing here consumes.
+//
+// It cannot simply be left empty, which was the first attempt: `ollama list` and `ollama ps`
+// render the short hash as digest[:12] with no length check, so an empty string panics the
+// official CLI outright ("slice bounds out of range [:12] with length 0"). A client can only be
+// misled by a non-content digest if it can fetch blobs or pull from this server, and both are
+// refused with 501 -- so a stable synthetic value is strictly better than a crash.
+//
+// Stable across restarts and distinct across checkpoints, because the seed carries path, size and
+// mtime.
+std::string synthetic_digest(const std::string& seed);
 
 }  // namespace ollama
 }  // namespace sparkinfer_server

--- a/server/include/ollama_api.hpp
+++ b/server/include/ollama_api.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+// Ollama REST API (/api/*) request and response translation.
+//
+// Same structure and rationale as lmstudio_api.hpp: pure functions over JSON and plain structs,
+// no engine/HTTP/CUDA dependency, so the wire contract is unit-testable on a box with no GPU.
+//
+// WHY TRANSLATION RATHER THAN A SECOND GENERATOR: Ollama's shapes differ from OpenAI's throughout
+// -- message.content instead of choices[0].message.content, a `done` boolean instead of
+// finish_reason, and durations in NANOSECONDS -- but the generation itself is identical. So the
+// /api/* routes rewrite the request into the OpenAI shape, hand it to the SAME handler /v1/* uses,
+// and rewrite the response back. Nothing here generates, times, or samples anything.
+//
+// STREAMING, AND THE ONE HONEST COMPROMISE. Ollama streams by DEFAULT (`stream` is true when
+// absent), and its stream is NDJSON -- one JSON object per line -- not SSE. This server's stream
+// path is SSE-shaped end to end (write_sse_json emits "data: {...}\n\n"), and a wrapper cannot
+// re-frame it because the handler writes straight to the socket.
+//
+// So a streaming Ollama request is answered as NDJSON containing a SINGLE terminal chunk:
+// correct framing, correct fields, done=true, the whole message in one object. An Ollama client
+// parses it correctly and works. What it does NOT get is token-by-token delivery -- the response
+// arrives when generation finishes. That is a real limitation, stated here and in the response's
+// own shape rather than hidden: incremental delivery needs the SSE path generalised, which is a
+// change to the generation loop, not to this file.
+//
+// Schema source: https://github.com/ollama/ollama/blob/main/docs/api.md
+
+#include <string>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+namespace sparkinfer_server {
+namespace ollama {
+
+// ---- model metadata -------------------------------------------------------------------------
+
+// The "details" sub-object shared by /api/tags, /api/ps and /api/show.
+struct ModelDetails {
+    std::string parent_model;
+    std::string format = "gguf";
+    std::string family;
+    std::vector<std::string> families;
+    std::string parameter_size;      // display string, e.g. "7.6B"
+    std::string quantization_level;  // e.g. "Q4_K_M"
+};
+
+struct ModelEntry {
+    std::string name;       // Ollama uses "<model>:<tag>"; a bare id gets ":latest" appended
+    std::string model;      // same value as name in every Ollama response observed
+    std::string modified_at;
+    long long size = 0;     // bytes
+    std::string digest;
+    ModelDetails details;
+};
+
+nlohmann::json details_object(const ModelDetails& d);
+nlohmann::json model_entry(const ModelEntry& m);
+nlohmann::json tags_list(const std::vector<ModelEntry>& models);   // GET /api/tags
+nlohmann::json ps_list(const std::vector<ModelEntry>& models);     // GET /api/ps
+
+// POST /api/show. `capabilities` is Ollama's feature list, e.g. {"completion"} or
+// {"completion","vision"}.
+nlohmann::json show_object(const ModelEntry& m, const nlohmann::json& model_info,
+                           const std::vector<std::string>& capabilities,
+                           const std::string& tmpl);
+
+// Ollama names models "<name>:<tag>". A request may address the model with or without the tag,
+// so comparison is tag-insensitive when the request omits one.
+std::string with_latest_tag(const std::string& id);
+bool model_name_matches(const std::string& requested, const std::string& served_id);
+
+// ---- request translation --------------------------------------------------------------------
+
+// Ollama /api/chat body -> OpenAI /v1/chat/completions body. Maps `options` (num_predict,
+// temperature, top_p, seed, stop, ...) onto their OpenAI equivalents. `stream` is forced FALSE in
+// the translated request regardless of what the client asked for: the caller re-frames the
+// completed response, so the inner call must not stream.
+nlohmann::json chat_request_to_openai(const nlohmann::json& in);
+
+// Ollama /api/generate body -> OpenAI /v1/completions body. Same treatment of `options`/`stream`.
+nlohmann::json generate_request_to_openai(const nlohmann::json& in);
+
+// ---- response translation -------------------------------------------------------------------
+
+// Durations Ollama reports are NANOSECONDS; this server measures milliseconds.
+long long ms_to_ns(double ms);
+
+// OpenAI chat.completion -> Ollama /api/chat response. `model` is the name to echo back.
+nlohmann::json openai_to_chat_response(const nlohmann::json& oai, const std::string& model,
+                                       const std::string& created_at);
+// OpenAI text_completion -> Ollama /api/generate response.
+nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std::string& model,
+                                           const std::string& created_at);
+
+// RFC3339 UTC timestamp, the format Ollama's created_at uses.
+std::string rfc3339_now();
+
+}  // namespace ollama
+}  // namespace sparkinfer_server

--- a/server/include/ollama_api.hpp
+++ b/server/include/ollama_api.hpp
@@ -11,17 +11,16 @@
 // /api/* routes rewrite the request into the OpenAI shape, hand it to the SAME handler /v1/* uses,
 // and rewrite the response back. Nothing here generates, times, or samples anything.
 //
-// STREAMING, AND THE ONE HONEST COMPROMISE. Ollama streams by DEFAULT (`stream` is true when
-// absent), and its stream is NDJSON -- one JSON object per line -- not SSE. This server's stream
-// path is SSE-shaped end to end (write_sse_json emits "data: {...}\n\n"), and a wrapper cannot
-// re-frame it because the handler writes straight to the socket.
+// STREAMING. Ollama streams by DEFAULT (`stream` is true when absent) and its stream is NDJSON --
+// one JSON object per line -- not SSE. This is now genuinely incremental: the server's single
+// stream writer (write_sse_json) is dialect-aware, so a request marked with the Ollama dialect has
+// every chunk re-framed as NDJSON in Ollama's message/done shape on the way out. The generation
+// loop is untouched and shared with /v1.
 //
-// So a streaming Ollama request is answered as NDJSON containing a SINGLE terminal chunk:
-// correct framing, correct fields, done=true, the whole message in one object. An Ollama client
-// parses it correctly and works. What it does NOT get is token-by-token delivery -- the response
-// arrives when generation finishes. That is a real limitation, stated here and in the response's
-// own shape rather than hidden: incremental delivery needs the SSE path generalised, which is a
-// change to the generation loop, not to this file.
+// Two consequences worth knowing. The done=true terminator is built from OpenAI's USAGE chunk, so
+// include_usage is forced on for this dialect -- without it the client would wait for an end that
+// never comes. And chunks with no Ollama counterpart (the role-only opener, the finish chunk) are
+// dropped rather than emitted as empty lines, which an NDJSON reader would reject.
 //
 // Schema source: https://github.com/ollama/ollama/blob/main/docs/api.md
 
@@ -111,6 +110,21 @@ nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std:
 
 // RFC3339 UTC timestamp, the format Ollama's created_at uses.
 std::string rfc3339_now();
+
+// Translate ONE OpenAI stream chunk into its Ollama NDJSON equivalent.
+//
+// Returns a null json for a chunk that has no Ollama counterpart (the role-only opener and the
+// finish chunk), which the caller drops rather than emitting as an empty line. Ollama's stream is
+// content chunks with done=false, terminated by exactly one done=true chunk carrying the metrics
+// -- so the terminating chunk is built from OpenAI's USAGE chunk, and the caller must ensure one
+// is emitted (see the include_usage forcing at the call site).
+//
+// `generate` selects the FIELD NAME the text is carried in: /api/generate streams
+// {"response": "..."} while /api/chat streams {"message":{"role","content"}}. They are not
+// interchangeable -- emitting the chat shape to an /api/generate client makes `ollama run` render
+// nothing at all, with no error, because it reads a key that is simply absent.
+nlohmann::json stream_chunk_from_openai(const nlohmann::json& oai, const std::string& model,
+                                        const std::string& created_at, bool generate = false);
 
 // A stable 64-hex-character identifier derived from `seed`, for ModelEntry::digest.
 //

--- a/server/src/lmstudio_api.cpp
+++ b/server/src/lmstudio_api.cpp
@@ -1,0 +1,145 @@
+#include "lmstudio_api.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+namespace sparkinfer_server {
+namespace lmstudio {
+
+namespace {
+
+bool is_sep(char c) { return c == '/' || c == '\\'; }
+
+std::string basename_of(const std::string& path) {
+    size_t last = std::string::npos;
+    for (size_t i = 0; i < path.size(); i++)
+        if (is_sep(path[i])) last = i;
+    return last == std::string::npos ? path : path.substr(last + 1);
+}
+
+std::string upper(std::string s) {
+    for (char& c : s) c = (char)std::toupper((unsigned char)c);
+    return s;
+}
+
+}  // namespace
+
+nlohmann::json model_object(const ModelDesc& m) {
+    nlohmann::json j = {
+        {"id", m.id},
+        {"object", "model"},
+        {"type", m.type},
+        {"publisher", m.publisher},
+        {"arch", m.arch},
+        {"compatibility_type", m.compatibility_type},
+        {"quantization", m.quantization},
+        {"state", m.state},
+        {"max_context_length", m.max_context_length},
+    };
+    // Present only while loaded — see ModelDesc::loaded_context_length for why this is omitted
+    // rather than sent as 0.
+    if (m.state == "loaded" && m.loaded_context_length > 0)
+        j["loaded_context_length"] = m.loaded_context_length;
+    return j;
+}
+
+nlohmann::json models_list(const std::vector<ModelDesc>& models) {
+    nlohmann::json data = nlohmann::json::array();
+    for (const ModelDesc& m : models) data.push_back(model_object(m));
+    return nlohmann::json{{"object", "list"}, {"data", std::move(data)}};
+}
+
+nlohmann::json stats_object(const Stats& s) {
+    return nlohmann::json{
+        {"tokens_per_second", s.tokens_per_second},
+        {"time_to_first_token", s.time_to_first_token},
+        {"generation_time", s.generation_time},
+        {"stop_reason", s.stop_reason},
+    };
+}
+
+std::string stop_reason_from_finish(const std::string& finish_reason) {
+    // LM Studio's vocabulary, from its v0 reference. "eosFound" is the natural end of a turn;
+    // "maxPredictedTokensReached" is the length cap; "userStopped" covers a client-supplied stop
+    // string. An unknown value maps to eosFound rather than passing OpenAI's word through, because
+    // a client switching on this field would otherwise hit a case it has no branch for.
+    if (finish_reason == "length") return "maxPredictedTokensReached";
+    if (finish_reason == "stop") return "eosFound";
+    if (finish_reason == "tool_calls") return "toolCalls";
+    if (finish_reason == "content_filter") return "userStopped";
+    return "eosFound";
+}
+
+nlohmann::json model_info_object(const ModelInfo& mi) {
+    return nlohmann::json{
+        {"arch", mi.arch},
+        {"quant", mi.quant},
+        {"format", mi.format},
+        {"context_length", mi.context_length},
+    };
+}
+
+nlohmann::json runtime_object(const RuntimeDesc& r) {
+    return nlohmann::json{
+        {"name", r.name},
+        {"version", r.version},
+        {"supported_formats", r.supported_formats},
+    };
+}
+
+std::string quantization_from_path(const std::string& path) {
+    const std::string base = upper(basename_of(path));
+    // Longest-first so Q4_K_M is not truncated to Q4_K, and IQ* before Q* for the same reason.
+    static const char* kTags[] = {
+        "IQ1_S", "IQ2_XXS", "IQ2_XS", "IQ2_S", "IQ2_M", "IQ3_XXS", "IQ3_XS", "IQ3_S", "IQ3_M",
+        "IQ4_XS", "IQ4_NL",
+        "Q2_K_S", "Q2_K", "Q3_K_S", "Q3_K_M", "Q3_K_L", "Q3_K",
+        "Q4_K_S", "Q4_K_M", "Q4_K", "Q4_0", "Q4_1",
+        "Q5_K_S", "Q5_K_M", "Q5_K", "Q5_0", "Q5_1",
+        "Q6_K", "Q8_0", "BF16", "FP16", "F16", "FP8", "NVFP4", "MXFP4",
+    };
+    std::string best;
+    for (const char* t : kTags) {
+        const std::string tag(t);
+        if (base.find(tag) != std::string::npos && tag.size() > best.size()) best = tag;
+    }
+    return best;
+}
+
+std::string compatibility_type_from_path(const std::string& path) {
+    const std::string base = basename_of(path);
+    if (base.size() >= 5) {
+        const std::string tail = base.substr(base.size() - 5);
+        std::string lower;
+        for (char c : tail) lower += (char)std::tolower((unsigned char)c);
+        if (lower == ".gguf") return "gguf";
+    }
+    return "";
+}
+
+std::string publisher_from_path(const std::string& path) {
+    // A publisher is reported ONLY when the path actually carries one, i.e. it sits under a
+    // directory named "models" in LM Studio's own layout:
+    //
+    //     ~/.lmstudio/models/<publisher>/<repo>/<file>.gguf
+    //
+    // The obvious alternative -- "take the segment two above the filename" -- reads a publisher
+    // out of any path at all, and produces nonsense for the ordinary case: it turned
+    // /root/spark25_models/Spark-X2.5-4B-Q8_0.gguf into publisher "root", which then shows up in
+    // LM Studio's model list as if it meant something. Returning nothing lets the caller
+    // substitute an honest default.
+    std::vector<std::string> parts;
+    std::string cur;
+    for (char c : path) {
+        if (is_sep(c)) { if (!cur.empty()) parts.push_back(cur); cur.clear(); }
+        else cur += c;
+    }
+    if (!cur.empty()) parts.push_back(cur);
+    // Need <models>/<publisher>/<repo>/<file>: the marker cannot be the last three segments.
+    for (size_t i = 0; i + 3 < parts.size(); i++)
+        if (parts[i] == "models") return parts[i + 1];
+    return "";
+}
+
+}  // namespace lmstudio
+}  // namespace sparkinfer_server

--- a/server/src/ollama_api.cpp
+++ b/server/src/ollama_api.cpp
@@ -71,6 +71,25 @@ bool model_name_matches(const std::string& requested, const std::string& served_
 }
 
 namespace {
+void add_metrics(const nlohmann::json& oai, nlohmann::json& out);   // defined below
+
+// Null-safe string read.
+//
+// nlohmann's value() returns the default only when the key is ABSENT. A key that is present and
+// JSON-null throws type_error.302 ("type must be string, but is null") -- and OpenAI stream chunks
+// are full of exactly that: delta.content is null on the role and finish chunks, finish_reason is
+// null on every non-final chunk. Using value() directly on those crashed the whole server mid
+// stream (terminate called after throwing ... type_error.302), taking every other in-flight
+// request with it. Every string read from an upstream body goes through this.
+std::string jstr(const nlohmann::json& j, const char* key, const char* dflt = "") {
+    if (!j.is_object()) return dflt;
+    auto it = j.find(key);
+    if (it == j.end() || !it->is_string()) return dflt;
+    return it->get<std::string>();
+}
+}  // namespace
+
+namespace {
 
 // Ollama nests sampling knobs under "options"; OpenAI puts them at the top level.
 void apply_options(const nlohmann::json& in, nlohmann::json& out, const char* max_tokens_key) {
@@ -93,7 +112,7 @@ void apply_options(const nlohmann::json& in, nlohmann::json& out, const char* ma
 
 nlohmann::json chat_request_to_openai(const nlohmann::json& in) {
     nlohmann::json out;
-    out["model"] = in.value("model", "");
+    out["model"] = jstr(in, "model");
     out["messages"] = in.value("messages", nlohmann::json::array());
     // Always false: the caller re-frames a COMPLETED response into NDJSON, so the inner handler
     // must produce a whole JSON document, not a stream. See ollama_api.hpp on streaming.
@@ -114,8 +133,8 @@ nlohmann::json chat_request_to_openai(const nlohmann::json& in) {
 
 nlohmann::json generate_request_to_openai(const nlohmann::json& in) {
     nlohmann::json out;
-    out["model"] = in.value("model", "");
-    out["prompt"] = in.value("prompt", "");
+    out["model"] = jstr(in, "model");
+    out["prompt"] = jstr(in, "prompt");
     out["stream"] = false;
     // Only a NON-EMPTY suffix is forwarded. The ollama CLI sends "suffix":"" on an ordinary
     // `ollama run`, and passing that through made /v1/completions reject the whole request with
@@ -132,11 +151,11 @@ bool generate_wants_raw(const nlohmann::json& in) {
 
 nlohmann::json generate_request_to_chat(const nlohmann::json& in) {
     nlohmann::json msgs = nlohmann::json::array();
-    const std::string sys = in.value("system", std::string());
+    const std::string sys = jstr(in, "system");
     if (!sys.empty()) msgs.push_back({{"role", "system"}, {"content", sys}});
-    msgs.push_back({{"role", "user"}, {"content", in.value("prompt", std::string())}});
+    msgs.push_back({{"role", "user"}, {"content", jstr(in, "prompt")}});
     nlohmann::json out;
-    out["model"] = in.value("model", "");
+    out["model"] = jstr(in, "model");
     out["messages"] = std::move(msgs);
     out["stream"] = false;
     if (in.contains("format")) {
@@ -192,9 +211,9 @@ nlohmann::json openai_to_chat_response(const nlohmann::json& oai, const std::str
     nlohmann::json tool_calls = nlohmann::json::array();
     if (oai.contains("choices") && oai["choices"].is_array() && !oai["choices"].empty()) {
         const auto& c = oai["choices"][0];
-        finish = c.value("finish_reason", "");
+        finish = jstr(c, "finish_reason");
         const auto msg = c.value("message", nlohmann::json::object());
-        content = msg.value("content", "");
+        content = jstr(msg, "content");
         if (msg.contains("tool_calls") && msg["tool_calls"].is_array())
             tool_calls = msg["tool_calls"];
     }
@@ -215,12 +234,12 @@ nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std:
     std::string text, finish;
     if (oai.contains("choices") && oai["choices"].is_array() && !oai["choices"].empty()) {
         const auto& c = oai["choices"][0];
-        finish = c.value("finish_reason", "");
+        finish = jstr(c, "finish_reason");
         // Either upstream shape: "text" from /v1/completions (raw path) or "message.content"
         // from /v1/chat/completions (the default, template-applied path).
-        text = c.value("text", "");
+        text = jstr(c, "text");
         if (text.empty() && c.contains("message"))
-            text = c["message"].value("content", "");
+            text = jstr(c["message"], "content");
     }
     out["response"] = text;
     out["done"] = true;
@@ -229,6 +248,40 @@ nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std:
     // This server keeps no such state, and returning a fabricated array would invite a client to
     // send it back as if it meant something. Omitted entirely.
     add_metrics(oai, out);
+    return out;
+}
+
+nlohmann::json stream_chunk_from_openai(const nlohmann::json& oai, const std::string& model,
+                                        const std::string& created_at, bool generate) {
+    nlohmann::json out;
+    out["model"] = model;
+    out["created_at"] = created_at;
+
+    // The usage chunk (choices empty, usage present) becomes Ollama's single done=true terminator.
+    const bool has_choices = oai.contains("choices") && oai["choices"].is_array()
+                             && !oai["choices"].empty();
+    if (!has_choices && oai.contains("usage")) {
+        if (generate) out["response"] = "";
+        else          out["message"] = {{"role", "assistant"}, {"content", ""}};
+        out["done"] = true;
+        out["done_reason"] = "stop";
+        add_metrics(oai, out);
+        return out;
+    }
+    if (!has_choices) return nlohmann::json();          // nothing to say
+
+    const auto& c = oai["choices"][0];
+    const auto delta = c.value("delta", nlohmann::json::object());
+    const std::string content = jstr(delta, "content");
+    if (content.empty()) {
+        // Role-only opener and the finish chunk carry no text. Ollama has no equivalent for
+        // either: an empty-content done=false chunk is legal but pure noise, and emitting
+        // done=true here would terminate the stream before the metrics chunk.
+        return nlohmann::json();
+    }
+    if (generate) out["response"] = content;
+    else          out["message"] = {{"role", "assistant"}, {"content", content}};
+    out["done"] = false;
     return out;
 }
 

--- a/server/src/ollama_api.cpp
+++ b/server/src/ollama_api.cpp
@@ -61,7 +61,12 @@ std::string with_latest_tag(const std::string& id) {
 }
 
 bool model_name_matches(const std::string& requested, const std::string& served_id) {
-    if (requested.empty()) return true;   // Ollama treats an absent model as "the loaded one"
+    // An EMPTY request name never matches. Ollama documents `model` as required on /api/chat and
+    // /api/generate, so an absent or null one is a malformed request, not a request for the
+    // default model. Treating it as a match made {"model": null} return 200 and generate from an
+    // empty prompt -- hiding an obvious client bug behind a successful-looking response. The
+    // caller rejects it with 400 before reaching here.
+    if (requested.empty()) return false;
     if (requested == served_id) return true;
     if (with_latest_tag(requested) == with_latest_tag(served_id)) return true;
     // "<id>:anything" also addresses this model: only one checkpoint is served, and refusing a

--- a/server/src/ollama_api.cpp
+++ b/server/src/ollama_api.cpp
@@ -1,0 +1,216 @@
+#include "ollama_api.hpp"
+
+#include <ctime>
+#include <cmath>
+
+namespace sparkinfer_server {
+namespace ollama {
+
+nlohmann::json details_object(const ModelDetails& d) {
+    return nlohmann::json{
+        {"parent_model", d.parent_model},
+        {"format", d.format},
+        {"family", d.family},
+        {"families", d.families},
+        {"parameter_size", d.parameter_size},
+        {"quantization_level", d.quantization_level},
+    };
+}
+
+nlohmann::json model_entry(const ModelEntry& m) {
+    return nlohmann::json{
+        {"name", m.name},
+        {"model", m.model},
+        {"modified_at", m.modified_at},
+        {"size", m.size},
+        {"digest", m.digest},
+        {"details", details_object(m.details)},
+    };
+}
+
+nlohmann::json tags_list(const std::vector<ModelEntry>& models) {
+    nlohmann::json arr = nlohmann::json::array();
+    for (const ModelEntry& m : models) arr.push_back(model_entry(m));
+    return nlohmann::json{{"models", std::move(arr)}};
+}
+
+nlohmann::json ps_list(const std::vector<ModelEntry>& models) {
+    // /api/ps carries the same entries as /api/tags in Ollama's own responses.
+    return tags_list(models);
+}
+
+nlohmann::json show_object(const ModelEntry& m, const nlohmann::json& model_info,
+                           const std::vector<std::string>& capabilities,
+                           const std::string& tmpl) {
+    return nlohmann::json{
+        // No Modelfile exists here -- this server was pointed at a checkpoint with -m, it did not
+        // build one from a Modelfile. Report the path it is actually serving rather than
+        // fabricating Modelfile syntax that would not round-trip through `ollama create`.
+        {"modelfile", "FROM " + m.name},
+        {"parameters", ""},
+        {"template", tmpl},
+        {"details", details_object(m.details)},
+        {"model_info", model_info},
+        {"capabilities", capabilities},
+    };
+}
+
+std::string with_latest_tag(const std::string& id) {
+    return id.find(':') == std::string::npos ? id + ":latest" : id;
+}
+
+bool model_name_matches(const std::string& requested, const std::string& served_id) {
+    if (requested.empty()) return true;   // Ollama treats an absent model as "the loaded one"
+    if (requested == served_id) return true;
+    if (with_latest_tag(requested) == with_latest_tag(served_id)) return true;
+    // "<id>:anything" also addresses this model: only one checkpoint is served, and refusing a
+    // tag we do not carry would break clients that pin a tag from `ollama list` output.
+    const size_t colon = requested.find(':');
+    return colon != std::string::npos && requested.substr(0, colon) == served_id;
+}
+
+namespace {
+
+// Ollama nests sampling knobs under "options"; OpenAI puts them at the top level.
+void apply_options(const nlohmann::json& in, nlohmann::json& out, const char* max_tokens_key) {
+    const auto opts = in.value("options", nlohmann::json::object());
+    if (opts.contains("temperature")) out["temperature"] = opts["temperature"];
+    if (opts.contains("top_p")) out["top_p"] = opts["top_p"];
+    if (opts.contains("seed")) out["seed"] = opts["seed"];
+    if (opts.contains("stop")) out["stop"] = opts["stop"];
+    if (opts.contains("presence_penalty")) out["presence_penalty"] = opts["presence_penalty"];
+    if (opts.contains("frequency_penalty")) out["frequency_penalty"] = opts["frequency_penalty"];
+    // num_predict is Ollama's max-new-tokens. -1 means "until the context is full" and has no
+    // OpenAI equivalent, so it is dropped rather than translated into a bogus finite cap.
+    if (opts.contains("num_predict") && opts["num_predict"].is_number_integer()) {
+        const long long n = opts["num_predict"].get<long long>();
+        if (n > 0) out[max_tokens_key] = n;
+    }
+}
+
+}  // namespace
+
+nlohmann::json chat_request_to_openai(const nlohmann::json& in) {
+    nlohmann::json out;
+    out["model"] = in.value("model", "");
+    out["messages"] = in.value("messages", nlohmann::json::array());
+    // Always false: the caller re-frames a COMPLETED response into NDJSON, so the inner handler
+    // must produce a whole JSON document, not a stream. See ollama_api.hpp on streaming.
+    out["stream"] = false;
+    if (in.contains("format")) {
+        // Ollama's "format":"json" is OpenAI's response_format. A JSON-schema object maps onto
+        // json_schema; the bare string maps onto json_object.
+        if (in["format"].is_string() && in["format"] == "json")
+            out["response_format"] = {{"type", "json_object"}};
+        else if (in["format"].is_object())
+            out["response_format"] = {{"type", "json_schema"},
+                                      {"json_schema", {{"schema", in["format"]}}}};
+    }
+    if (in.contains("tools")) out["tools"] = in["tools"];
+    apply_options(in, out, "max_tokens");
+    return out;
+}
+
+nlohmann::json generate_request_to_openai(const nlohmann::json& in) {
+    nlohmann::json out;
+    out["model"] = in.value("model", "");
+    out["prompt"] = in.value("prompt", "");
+    out["stream"] = false;
+    if (in.contains("suffix")) out["suffix"] = in["suffix"];
+    apply_options(in, out, "max_tokens");
+    return out;
+}
+
+long long ms_to_ns(double ms) {
+    if (!(ms > 0.0)) return 0;
+    return (long long)std::llround(ms * 1e6);
+}
+
+namespace {
+
+// The duration/count block shared by /api/chat and /api/generate responses.
+void add_metrics(const nlohmann::json& oai, nlohmann::json& out) {
+    const auto usage = oai.value("usage", nlohmann::json::object());
+    const int prompt_tokens = usage.value("prompt_tokens", 0);
+    const int completion_tokens = usage.value("completion_tokens", 0);
+    const double ttft_ms = usage.value("ttft_ms", 0.0);
+    const double generation_ms = usage.value("generation_ms", 0.0);
+
+    out["total_duration"] = ms_to_ns(ttft_ms + generation_ms);
+    // load_duration is model-load time. The model was loaded at startup, long before this
+    // request, so the honest value here is 0 rather than an invented share of the request.
+    out["load_duration"] = 0;
+    out["prompt_eval_count"] = prompt_tokens;
+    out["prompt_eval_duration"] = ms_to_ns(ttft_ms);
+    out["eval_count"] = completion_tokens;
+    out["eval_duration"] = ms_to_ns(generation_ms);
+}
+
+std::string done_reason_from_finish(const std::string& finish) {
+    // Ollama's vocabulary: "stop" for a natural end, "length" when the token cap was hit.
+    if (finish == "length") return "length";
+    return "stop";
+}
+
+}  // namespace
+
+nlohmann::json openai_to_chat_response(const nlohmann::json& oai, const std::string& model,
+                                       const std::string& created_at) {
+    nlohmann::json out;
+    out["model"] = model;
+    out["created_at"] = created_at;
+    std::string content, finish;
+    nlohmann::json tool_calls = nlohmann::json::array();
+    if (oai.contains("choices") && oai["choices"].is_array() && !oai["choices"].empty()) {
+        const auto& c = oai["choices"][0];
+        finish = c.value("finish_reason", "");
+        const auto msg = c.value("message", nlohmann::json::object());
+        content = msg.value("content", "");
+        if (msg.contains("tool_calls") && msg["tool_calls"].is_array())
+            tool_calls = msg["tool_calls"];
+    }
+    nlohmann::json message = {{"role", "assistant"}, {"content", content}};
+    if (!tool_calls.empty()) message["tool_calls"] = tool_calls;
+    out["message"] = std::move(message);
+    out["done"] = true;
+    out["done_reason"] = done_reason_from_finish(finish);
+    add_metrics(oai, out);
+    return out;
+}
+
+nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std::string& model,
+                                           const std::string& created_at) {
+    nlohmann::json out;
+    out["model"] = model;
+    out["created_at"] = created_at;
+    std::string text, finish;
+    if (oai.contains("choices") && oai["choices"].is_array() && !oai["choices"].empty()) {
+        const auto& c = oai["choices"][0];
+        finish = c.value("finish_reason", "");
+        text = c.value("text", "");
+    }
+    out["response"] = text;
+    out["done"] = true;
+    out["done_reason"] = done_reason_from_finish(finish);
+    // "context" is Ollama's opaque conversation-state token array, used to continue a generation.
+    // This server keeps no such state, and returning a fabricated array would invite a client to
+    // send it back as if it meant something. Omitted entirely.
+    add_metrics(oai, out);
+    return out;
+}
+
+std::string rfc3339_now() {
+    std::time_t t = std::time(nullptr);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &t);
+#else
+    gmtime_r(&t, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return std::string(buf);
+}
+
+}  // namespace ollama
+}  // namespace sparkinfer_server

--- a/server/src/ollama_api.cpp
+++ b/server/src/ollama_api.cpp
@@ -2,6 +2,7 @@
 
 #include <ctime>
 #include <cmath>
+#include <cstdio>
 
 namespace sparkinfer_server {
 namespace ollama {
@@ -116,7 +117,35 @@ nlohmann::json generate_request_to_openai(const nlohmann::json& in) {
     out["model"] = in.value("model", "");
     out["prompt"] = in.value("prompt", "");
     out["stream"] = false;
-    if (in.contains("suffix")) out["suffix"] = in["suffix"];
+    // Only a NON-EMPTY suffix is forwarded. The ollama CLI sends "suffix":"" on an ordinary
+    // `ollama run`, and passing that through made /v1/completions reject the whole request with
+    // 400 "suffix is not supported" -- so every `ollama run` failed on a field the user never set.
+    if (in.contains("suffix") && in["suffix"].is_string() && !in["suffix"].get<std::string>().empty())
+        out["suffix"] = in["suffix"];
+    apply_options(in, out, "max_tokens");
+    return out;
+}
+
+bool generate_wants_raw(const nlohmann::json& in) {
+    return in.value("raw", false);
+}
+
+nlohmann::json generate_request_to_chat(const nlohmann::json& in) {
+    nlohmann::json msgs = nlohmann::json::array();
+    const std::string sys = in.value("system", std::string());
+    if (!sys.empty()) msgs.push_back({{"role", "system"}, {"content", sys}});
+    msgs.push_back({{"role", "user"}, {"content", in.value("prompt", std::string())}});
+    nlohmann::json out;
+    out["model"] = in.value("model", "");
+    out["messages"] = std::move(msgs);
+    out["stream"] = false;
+    if (in.contains("format")) {
+        if (in["format"].is_string() && in["format"] == "json")
+            out["response_format"] = {{"type", "json_object"}};
+        else if (in["format"].is_object())
+            out["response_format"] = {{"type", "json_schema"},
+                                      {"json_schema", {{"schema", in["format"]}}}};
+    }
     apply_options(in, out, "max_tokens");
     return out;
 }
@@ -187,7 +216,11 @@ nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std:
     if (oai.contains("choices") && oai["choices"].is_array() && !oai["choices"].empty()) {
         const auto& c = oai["choices"][0];
         finish = c.value("finish_reason", "");
+        // Either upstream shape: "text" from /v1/completions (raw path) or "message.content"
+        // from /v1/chat/completions (the default, template-applied path).
         text = c.value("text", "");
+        if (text.empty() && c.contains("message"))
+            text = c["message"].value("content", "");
     }
     out["response"] = text;
     out["done"] = true;
@@ -197,6 +230,27 @@ nlohmann::json openai_to_generate_response(const nlohmann::json& oai, const std:
     // send it back as if it meant something. Omitted entirely.
     add_metrics(oai, out);
     return out;
+}
+
+std::string synthetic_digest(const std::string& seed) {
+    // FNV-1a over the seed, re-run with four different offset bases to fill 64 hex characters.
+    // Not cryptographic and not claimed to be -- it only has to be stable, well-distributed
+    // enough that two checkpoints differ, and exactly the shape Ollama clients slice.
+    static const unsigned long long kBases[4] = {
+        1469598103934665603ULL, 1099511628211ULL, 14695981039346656037ULL, 1231ULL};
+    std::string out;
+    out.reserve(64);
+    for (int k = 0; k < 4; k++) {
+        unsigned long long h = kBases[k];
+        for (unsigned char c : seed) {
+            h ^= (unsigned long long)c;
+            h *= 1099511628211ULL;
+        }
+        char buf[17];
+        std::snprintf(buf, sizeof(buf), "%016llx", h);
+        out += buf;
+    }
+    return out;   // exactly 64 lowercase hex characters
 }
 
 std::string rfc3339_now() {

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -1,4 +1,5 @@
 #include "chat_tokenizer.hpp"
+#include "lmstudio_api.hpp"
 #include "model_engine.hpp"
 #include "video_input.hpp"   // video_decoder_available() for /v1/models input_modalities
 #include "sparkinfer/kernels/deterministic.h"
@@ -1027,7 +1028,11 @@ int main(int argc, char** argv) {
         res.set_content(body.dump(), "application/json");
     });
 
-    svr.Post("/v1/chat/completions",
+    // Hoisted into a named handler so BOTH /v1/chat/completions and LM Studio's
+    // /api/v0/chat/completions are served by the SAME code rather than by two implementations
+    // that can drift apart. The v0 route wraps this one and augments its response; nothing about
+    // the v0 wire format leaks into the handler itself.
+    auto chat_completions_handler =
              [&engine](const httplib::Request& req, httplib::Response& res) {
                  if (!auth_ok(req)) {
                      res.status = 401;
@@ -2021,7 +2026,8 @@ int main(int argc, char** argv) {
                      {"model", g_model_name}, {"choices", choices}, {"usage", usage}};
                  g_requests_ok++;
                  res.set_content(body.dump(), "application/json");
-             });
+             };
+    svr.Post("/v1/chat/completions", chat_completions_handler);
 
     // Legacy pre-chat API: raw prompt string in, plain text out. No messages array, no chat
     // template, no tool-calling, no response_format, no reasoning split -- RequestControls/
@@ -2030,7 +2036,7 @@ int main(int argc, char** argv) {
     // from /v1/chat/completions above; ThinkingStreamSplitter/tool_protocol/json_mode_active have
     // no equivalent here and are deliberately not dragged in -- there is exactly ONE per-branch
     // shape, not a dispatcher between two.
-    svr.Post("/v1/completions",
+    auto text_completions_handler =
              [&engine](const httplib::Request& req, httplib::Response& res) {
                  if (!auth_ok(req)) {
                      res.status = 401;
@@ -2500,7 +2506,156 @@ int main(int argc, char** argv) {
                      {"model", g_model_name}, {"choices", choices}, {"usage", usage}};
                  g_requests_ok++;
                  res.set_content(body.dump(), "application/json");
+             };
+    svr.Post("/v1/completions", text_completions_handler);
+
+    // ---------------------------------------------------------------------------------------
+    // LM Studio REST API (/api/v0/*).
+    //
+    // Why v0 and not v1: LM Studio 0.4.0 shipped a native /api/v1/* and recommends it, but v1's
+    // additions over v0 are MCP, stateful chats, auth and MODEL MANAGEMENT -- /models/load,
+    // /unload, /download. Those assume a runtime that swaps checkpoints on demand. This server
+    // loads exactly one checkpoint from -m at startup, so a v1 implementation would have to
+    // answer half its own contract with errors. v0's five endpoints describe what this server
+    // actually is. See server/include/lmstudio_api.hpp.
+    //
+    // The two completion routes delegate to the SAME handlers /v1/* uses and then augment the
+    // response; there is no second implementation of generation here.
+    auto lmstudio_model_desc = [&engine]() {
+        sparkinfer_server::lmstudio::ModelDesc m;
+        m.id = g_model_name;
+        m.type = engine.has_vision() ? "vlm" : "llm";
+        const std::string path = engine.model_path();
+        m.publisher = sparkinfer_server::lmstudio::publisher_from_path(path);
+        if (m.publisher.empty()) m.publisher = "sparkinfer";
+        m.arch = engine.is_qwen38()      ? "qwen3_8"
+               : engine.is_museglimmer() ? "muse-glimmer"
+               : engine.is_spark25()     ? "spark2_5"
+                                         : "qwen3_6";
+        // LM Studio's vocabulary for this field is gguf|mlx only. A compressed-tensors directory
+        // is neither, and inventing a third value would break a client that switches on it, so
+        // report the closest true thing ("gguf" for a .gguf file) and leave it empty otherwise
+        // rather than claiming a format we are not serving.
+        m.compatibility_type = sparkinfer_server::lmstudio::compatibility_type_from_path(path);
+        m.quantization = sparkinfer_server::lmstudio::quantization_from_path(path);
+        m.state = engine.loaded() ? "loaded" : "not-loaded";
+        m.max_context_length = engine.max_seq();
+        m.loaded_context_length = engine.loaded() ? engine.max_seq() : 0;
+        return m;
+    };
+
+    svr.Get("/api/v0/models", [&engine, lmstudio_model_desc](const httplib::Request& req,
+                                                             httplib::Response& res) {
+        if (!auth_ok(req)) {
+            res.status = 401;
+            res.set_content("{\"error\":{\"message\":\"unauthorized\"}}", "application/json");
+            return;
+        }
+        res.set_content(sparkinfer_server::lmstudio::models_list({lmstudio_model_desc()}).dump(),
+                        "application/json");
+    });
+
+    svr.Get(R"(/api/v0/models/(.+))", [&engine, lmstudio_model_desc](const httplib::Request& req,
+                                                                     httplib::Response& res) {
+        if (!auth_ok(req)) {
+            res.status = 401;
+            res.set_content("{\"error\":{\"message\":\"unauthorized\"}}", "application/json");
+            return;
+        }
+        const std::string want = req.matches.size() > 1 ? req.matches[1].str() : "";
+        const auto m = lmstudio_model_desc();
+        if (want != m.id) {
+            res.status = 404;
+            res.set_content(nlohmann::json{{"error", {{"message", "model not found: " + want}}}}.dump(),
+                            "application/json");
+            return;
+        }
+        res.set_content(sparkinfer_server::lmstudio::model_object(m).dump(), "application/json");
+    });
+
+    // Augment a completed (non-streaming) OpenAI response with LM Studio's extra blocks. Derived
+    // ENTIRELY from the response the shared handler already produced -- ttft_ms/generation_ms/
+    // decode_tps are in its usage object and finish_reason is on the choice -- so generation is
+    // not re-run, re-timed, or measured twice.
+    //
+    // A streaming response is passed through untouched: its body is an SSE stream, not a JSON
+    // document, and rewriting chunks in flight would mean re-implementing the stream. A client
+    // that wants the stats block should use stream=false; that limitation is stated in the docs
+    // rather than papered over with an empty stats object that reads as "zero tokens/sec".
+    auto lmstudio_augment = [&engine, lmstudio_model_desc](httplib::Response& res) {
+        // httplib initialises Response::status to -1 and only substitutes 200 when it writes the
+        // response, and these handlers never set it explicitly on their success path. Testing for
+        // `status != 200` therefore rejected EVERY successful completion and this whole block
+        // silently did nothing -- the v0 responses came back well-formed but with no stats,
+        // model_info or runtime. Treat "unset" as success; only a status the handler set
+        // deliberately (4xx/5xx) is a real failure.
+        if (res.status > 0 && res.status != 200) return;
+        if (res.get_header_value("Content-Type").find("application/json") == std::string::npos) return;
+        nlohmann::json body;
+        try { body = nlohmann::json::parse(res.body); } catch (...) { return; }
+        if (!body.is_object()) return;
+
+        const auto& usage = body.value("usage", nlohmann::json::object());
+        sparkinfer_server::lmstudio::Stats st;
+        st.tokens_per_second = usage.value("decode_tps", 0.0);
+        st.time_to_first_token = usage.value("ttft_ms", 0.0) / 1000.0;   // ms -> s
+        st.generation_time = usage.value("generation_ms", 0.0) / 1000.0;
+        std::string finish;
+        if (body.contains("choices") && body["choices"].is_array() && !body["choices"].empty())
+            finish = body["choices"][0].value("finish_reason", "");
+        st.stop_reason = sparkinfer_server::lmstudio::stop_reason_from_finish(finish);
+
+        const auto m = lmstudio_model_desc();
+        sparkinfer_server::lmstudio::ModelInfo mi;
+        mi.arch = m.arch;
+        mi.quant = m.quantization;
+        mi.format = m.compatibility_type.empty() ? "compressed-tensors" : m.compatibility_type;
+        mi.context_length = m.loaded_context_length > 0 ? m.loaded_context_length : m.max_context_length;
+
+        sparkinfer_server::lmstudio::RuntimeDesc rt;
+        rt.name = "sparkinfer-linux-x86_64-nvidia-cuda-sm120";
+        // No version macro exists in this build, and inventing one that drifts from the real
+        // release would be worse than a stable honest string. LM Studio treats this as display
+        // text (it shows the runtime that served a response), not something it version-compares.
+        rt.version = "sparkinfer";
+        rt.supported_formats = {"gguf"};
+
+        body["stats"] = sparkinfer_server::lmstudio::stats_object(st);
+        body["model_info"] = sparkinfer_server::lmstudio::model_info_object(mi);
+        body["runtime"] = sparkinfer_server::lmstudio::runtime_object(rt);
+        res.set_content(body.dump(), "application/json");
+    };
+
+    svr.Post("/api/v0/chat/completions",
+             [chat_completions_handler, lmstudio_augment](const httplib::Request& req,
+                                                          httplib::Response& res) {
+                 chat_completions_handler(req, res);
+                 lmstudio_augment(res);
              });
+    svr.Post("/api/v0/completions",
+             [text_completions_handler, lmstudio_augment](const httplib::Request& req,
+                                                          httplib::Response& res) {
+                 text_completions_handler(req, res);
+                 lmstudio_augment(res);
+             });
+
+    // Embeddings: refused, explicitly. sparkinfer has no pooling/embedding path at all -- it is a
+    // generation runtime. Returning 501 with a reason is the honest answer; returning zeros, or
+    // the last hidden state dressed up as an embedding, would be silently wrong in a way a client
+    // cannot detect.
+    svr.Post("/api/v0/embeddings", [](const httplib::Request& req, httplib::Response& res) {
+        if (!auth_ok(req)) {
+            res.status = 401;
+            res.set_content("{\"error\":{\"message\":\"unauthorized\"}}", "application/json");
+            return;
+        }
+        res.status = 501;
+        res.set_content(nlohmann::json{{"error", {
+            {"message", "this server does not support embeddings: sparkinfer is a generation "
+                        "runtime and has no embedding model loaded"},
+            {"type", "not_implemented"},
+            {"code", "embeddings_unsupported"}}}}.dump(), "application/json");
+    });
 
     // Transport-level deadlines. Defaults are generous, not aggressive: a cold 32k-context
     // prefill has been measured taking ~90s of TTFT alone (see eval/pr_dflash_bot.py's 32k

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -2859,6 +2859,12 @@ int main(int argc, char** argv) {
             res.set_content("{\"error\":\"invalid json\"}", "application/json"); return; }
         std::string want = json_str(in, "model");
         if (want.empty()) want = json_str(in, "name");
+        if (want.empty()) {
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", "model is required"}}.dump(),
+                            "application/json");
+            return;
+        }
         if (!oll::model_name_matches(want, g_model_name)) {
             res.status = 404;
             res.set_content(nlohmann::json{{"error", "model '" + want + "' not found"}}.dump(),
@@ -2893,6 +2899,15 @@ int main(int argc, char** argv) {
         catch (...) { res.status = 400;
             res.set_content("{\"error\":\"invalid json\"}", "application/json"); return; }
         const std::string want = json_str(in, "model");
+        if (want.empty()) {
+            // Required by Ollama on both /api/chat and /api/generate. Rejected explicitly rather
+            // than defaulted to the loaded model: a null or missing model is a client bug, and
+            // answering it with a generation makes that bug invisible.
+            res.status = 400;
+            res.set_content(nlohmann::json{{"error", "model is required"}}.dump(),
+                            "application/json");
+            return;
+        }
         if (!oll::model_name_matches(want, g_model_name)) {
             res.status = 404;
             res.set_content(nlohmann::json{{"error", "model '" + want + "' not found"}}.dump(),

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -2673,12 +2673,10 @@ int main(int argc, char** argv) {
             m.size = 0;
             m.modified_at = oll::rfc3339_now();
         }
-        // digest is Ollama's CONTENT hash, used for blob dedup on pull. Computing a real sha256
-        // of a multi-GB checkpoint per request is out of the question, and a synthetic value
-        // would be a content hash that does not hash the content -- something a client could
-        // legitimately compare against another server and be misled by. Left empty: this server
-        // serves exactly one model and does not serve blobs, so nothing can act on it.
-        m.digest = "";
+        // Stable synthetic id, NOT a content hash -- see ollama::synthetic_digest for why it
+        // cannot be a real sha256 here, and why it must not be empty (an empty digest panics
+        // `ollama list` and `ollama ps`, which slice digest[:12] with no length check).
+        m.digest = oll::synthetic_digest(path + "|" + std::to_string(m.size) + "|" + m.modified_at);
         m.details.family = engine.is_qwen38()      ? "qwen3_8"
                          : engine.is_museglimmer() ? "muse-glimmer"
                          : engine.is_spark25()     ? "spark2_5"
@@ -2690,10 +2688,27 @@ int main(int argc, char** argv) {
         return m;
     };
 
+    // Root heartbeat. The ollama CLI issues `HEAD /` before EVERY command and aborts with a
+    // generic "something went wrong" if it does not get a success -- so without this route, every
+    // ollama command fails identically and none of /api/* is ever reached. curl tests of the
+    // individual endpoints all passed while the real client could not run a single command;
+    // nothing but driving the actual CLI would have surfaced it.
+    //
+    // The body carries Ollama's own sentinel string because some tools grep for it, and it names
+    // sparkinfer too so the response is not simply pretending to be an Ollama server.
+    // Registering GET is enough: httplib dispatches HEAD through the GET handler table
+    // (Server::routing -> `req.method == "GET" || req.method == "HEAD"`), and strips the body
+    // for a HEAD response itself. A separate Head() registration does not exist in this httplib.
+    svr.Get("/", [](const httplib::Request&, httplib::Response& res) {
+        res.set_content("sparkinfer - Ollama is running", "text/plain; charset=utf-8");
+    });
+
     svr.Get("/api/version", [](const httplib::Request&, httplib::Response& res) {
-        // Ollama clients version-gate features on this. Report a real Ollama-compatible version
-        // rather than a sparkinfer version string, which a client would fail to parse.
-        res.set_content(nlohmann::json{{"version", "0.5.0"}}.dump(), "application/json");
+        // Ollama clients version-gate features on this, and warn when the server looks older
+        // than the client ("Warning: client version is X"). Tracks the client generation this was
+        // validated against (v0.33.3) rather than a sparkinfer version string, which a client
+        // would fail to parse as a semver.
+        res.set_content(nlohmann::json{{"version", "0.33.3"}}.dump(), "application/json");
     });
 
     svr.Get("/api/tags", [&engine, ollama_entry](const httplib::Request& req, httplib::Response& res) {
@@ -2729,7 +2744,15 @@ int main(int argc, char** argv) {
                              {"general.parameter_count", (long long)0}};
         std::vector<std::string> caps{"completion"};
         if (engine.has_vision()) caps.push_back("vision");
-        res.set_content(oll::show_object(m, mi, caps, "").dump(), "application/json");
+        // A NON-EMPTY template is what tells the ollama CLI this is a chat model: with an empty
+        // one it classifies the model as completion-only and routes `ollama run` to /api/generate,
+        // which bypasses chat formatting entirely and feeds the model a raw prompt. This server
+        // does apply a chat template internally (ChatTokenizer), so advertising one is accurate
+        // about the model's shape. The string itself is indicative -- the real templating happens
+        // server-side and is not driven by anything the client sends back.
+        const char* kTmpl = "{{ if .System }}{{ .System }}{{ end }}"
+                            "{{ if .Prompt }}{{ .Prompt }}{{ end }}{{ .Response }}";
+        res.set_content(oll::show_object(m, mi, caps, kTmpl).dump(), "application/json");
     });
 
     // Shared body for /api/chat and /api/generate. `chat` selects which handler and which
@@ -2753,14 +2776,24 @@ int main(int argc, char** argv) {
         // Ollama omits `stream` to mean TRUE, unlike OpenAI where absent means false.
         const bool want_stream = in.value("stream", true);
 
+        // /api/generate applies the model's template unless the request asked for raw, so the
+        // DEFAULT generate path goes to the chat handler (which templates) and only an explicit
+        // "raw": true goes to the completions handler. Mapping generate straight onto
+        // /v1/completions fed `ollama run` an unformatted prompt -- see ollama_api.hpp.
+        const bool raw = !chat && oll::generate_wants_raw(in);
+        const bool use_chat_handler = chat || !raw;
+        nlohmann::json inner_body;
+        if (chat)      inner_body = oll::chat_request_to_openai(in);
+        else if (raw)  inner_body = oll::generate_request_to_openai(in);
+        else           inner_body = oll::generate_request_to_chat(in);
+
         httplib::Request inner = req;
-        inner.body = (chat ? oll::chat_request_to_openai(in)
-                           : oll::generate_request_to_openai(in)).dump();
+        inner.body = inner_body.dump();
         inner.set_header("Content-Type", "application/json");
 
         httplib::Response inner_res;
-        if (chat) chat_completions_handler(inner, inner_res);
-        else      text_completions_handler(inner, inner_res);
+        if (use_chat_handler) chat_completions_handler(inner, inner_res);
+        else                  text_completions_handler(inner, inner_res);
 
         // Pass a real failure through rather than dressing it as a completed Ollama response.
         if (inner_res.status > 0 && inner_res.status != 200) {

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -267,6 +267,32 @@ enum class StreamDialect {
 // The wrapper routes (/api/v0/*, /api/*) mark their inner request with this header so the shared
 // handler knows which dialect to stream in. A header rather than a global: it is per-request and
 // therefore correct under concurrency, and it needs no change to the handler's signature.
+// Null-safe JSON readers for CLIENT-SUPPLIED bodies.
+//
+// nlohmann's value(key, default) returns the default only when the key is ABSENT. A key that is
+// present and JSON-null throws type_error.302 -- and a throw out of a request handler calls
+// terminate(), which kills the WHOLE SERVER and every other in-flight request with it, not just
+// the offending request. That is a remote denial of service reachable with a one-line body like
+// {"model": null}.
+//
+// This already happened once on the Ollama stream path (delta.content is null on the first chunk
+// of every stream). These helpers exist so it cannot happen again on anything a caller controls.
+std::string json_str(const nlohmann::json& j, const char* key, const std::string& dflt = "") {
+    if (!j.is_object()) return dflt;
+    auto it = j.find(key);
+    return (it != j.end() && it->is_string()) ? it->get<std::string>() : dflt;
+}
+bool json_bool(const nlohmann::json& j, const char* key, bool dflt) {
+    if (!j.is_object()) return dflt;
+    auto it = j.find(key);
+    return (it != j.end() && it->is_boolean()) ? it->get<bool>() : dflt;
+}
+double json_num(const nlohmann::json& j, const char* key, double dflt = 0.0) {
+    if (!j.is_object()) return dflt;
+    auto it = j.find(key);
+    return (it != j.end() && it->is_number()) ? it->get<double>() : dflt;
+}
+
 constexpr const char* kStreamDialectHeader = "X-Sparkinfer-Stream-Dialect";
 
 StreamDialect stream_dialect_of(const httplib::Request& req) {
@@ -351,9 +377,9 @@ bool write_sse_json(GuardedSink& gs, const nlohmann::json& value) {
         if (gs.dialect == StreamDialect::LmStudioSse && out.contains("usage")) {
             const auto& u = out["usage"];
             sparkinfer_server::lmstudio::Stats st;
-            st.tokens_per_second = u.value("decode_tps", 0.0);
-            st.time_to_first_token = u.value("ttft_ms", 0.0) / 1000.0;
-            st.generation_time = u.value("generation_ms", 0.0) / 1000.0;
+            st.tokens_per_second = json_num(u, "decode_tps");
+            st.time_to_first_token = json_num(u, "ttft_ms") / 1000.0;
+            st.generation_time = json_num(u, "generation_ms") / 1000.0;
             st.stop_reason = "eosFound";
             out["stats"] = sparkinfer_server::lmstudio::stats_object(st);
         }
@@ -2682,11 +2708,12 @@ int main(int argc, char** argv) {
         try { body = nlohmann::json::parse(res.body); } catch (...) { return; }
         if (!body.is_object()) return;
 
-        const auto& usage = body.value("usage", nlohmann::json::object());
+        const nlohmann::json usage = body.contains("usage") && body["usage"].is_object()
+                                         ? body["usage"] : nlohmann::json::object();
         sparkinfer_server::lmstudio::Stats st;
-        st.tokens_per_second = usage.value("decode_tps", 0.0);
-        st.time_to_first_token = usage.value("ttft_ms", 0.0) / 1000.0;   // ms -> s
-        st.generation_time = usage.value("generation_ms", 0.0) / 1000.0;
+        st.tokens_per_second = json_num(usage, "decode_tps");
+        st.time_to_first_token = json_num(usage, "ttft_ms") / 1000.0;   // ms -> s
+        st.generation_time = json_num(usage, "generation_ms") / 1000.0;
         std::string finish;
         // Null-safe: nlohmann's value() returns the default only for an ABSENT key; a present
         // null throws type_error.302. finish_reason is null on any chunk that is not the last,
@@ -2726,8 +2753,8 @@ int main(int argc, char** argv) {
                                        const std::function<void(const httplib::Request&,
                                                                 httplib::Response&)>& handler) {
         bool streaming = false;
-        try { streaming = nlohmann::json::parse(req.body.empty() ? "{}" : req.body)
-                              .value("stream", false); } catch (...) {}
+        try { streaming = json_bool(nlohmann::json::parse(req.body.empty() ? "{}" : req.body),
+                                    "stream", false); } catch (...) {}
         httplib::Request inner = req;
         if (streaming) inner.set_header(kStreamDialectHeader, "lmstudio-sse");
         handler(inner, res);
@@ -2830,7 +2857,8 @@ int main(int argc, char** argv) {
         try { in = nlohmann::json::parse(req.body.empty() ? "{}" : req.body); }
         catch (...) { res.status = 400;
             res.set_content("{\"error\":\"invalid json\"}", "application/json"); return; }
-        const std::string want = in.value("model", in.value("name", std::string()));
+        std::string want = json_str(in, "model");
+        if (want.empty()) want = json_str(in, "name");
         if (!oll::model_name_matches(want, g_model_name)) {
             res.status = 404;
             res.set_content(nlohmann::json{{"error", "model '" + want + "' not found"}}.dump(),
@@ -2864,7 +2892,7 @@ int main(int argc, char** argv) {
         try { in = nlohmann::json::parse(req.body.empty() ? "{}" : req.body); }
         catch (...) { res.status = 400;
             res.set_content("{\"error\":\"invalid json\"}", "application/json"); return; }
-        const std::string want = in.value("model", std::string());
+        const std::string want = json_str(in, "model");
         if (!oll::model_name_matches(want, g_model_name)) {
             res.status = 404;
             res.set_content(nlohmann::json{{"error", "model '" + want + "' not found"}}.dump(),
@@ -2872,7 +2900,8 @@ int main(int argc, char** argv) {
             return;
         }
         // Ollama omits `stream` to mean TRUE, unlike OpenAI where absent means false.
-        const bool want_stream = in.value("stream", true);
+        // Ollama omits `stream` to mean TRUE, unlike OpenAI where absent means false.
+        const bool want_stream = json_bool(in, "stream", true);
 
         // /api/generate applies the model's template unless the request asked for raw, so the
         // DEFAULT generate path goes to the chat handler (which templates) and only an explicit

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -2618,7 +2618,6 @@ int main(int argc, char** argv) {
         if (m.publisher.empty()) m.publisher = "sparkinfer";
         m.arch = engine.is_qwen38()      ? "qwen3_8"
                : engine.is_museglimmer() ? "muse-glimmer"
-               : engine.is_spark25()     ? "spark2_5"
                                          : "qwen3_6";
         // LM Studio's vocabulary for this field is gguf|mlx only. A compressed-tensors directory
         // is neither, and inventing a third value would break a client that switches on it, so
@@ -2779,7 +2778,6 @@ int main(int argc, char** argv) {
         m.digest = oll::synthetic_digest(path + "|" + std::to_string(m.size) + "|" + m.modified_at);
         m.details.family = engine.is_qwen38()      ? "qwen3_8"
                          : engine.is_museglimmer() ? "muse-glimmer"
-                         : engine.is_spark25()     ? "spark2_5"
                                                    : "qwen3_6";
         m.details.families = {m.details.family};
         m.details.parameter_size = "";

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -1,5 +1,9 @@
 #include "chat_tokenizer.hpp"
 #include "lmstudio_api.hpp"
+#include "ollama_api.hpp"
+
+#include <sys/stat.h>
+#include <ctime>
 #include "model_engine.hpp"
 #include "video_input.hpp"   // video_decoder_available() for /v1/models input_modalities
 #include "sparkinfer/kernels/deterministic.h"
@@ -2638,6 +2642,185 @@ int main(int argc, char** argv) {
                  text_completions_handler(req, res);
                  lmstudio_augment(res);
              });
+
+    // ---------------------------------------------------------------------------------------
+    // Ollama REST API (/api/*).
+    //
+    // Same approach as the LM Studio routes above: rewrite the request into the OpenAI shape,
+    // hand it to the SAME handler /v1/* uses, rewrite the response back. Nothing here generates
+    // or times anything. See server/include/ollama_api.hpp for the shape differences and for the
+    // streaming compromise (Ollama streams by default and uses NDJSON; a streaming request is
+    // answered as a single terminal NDJSON chunk, correct on the wire but not incremental).
+    namespace oll = sparkinfer_server::ollama;
+
+    auto ollama_entry = [&engine]() {
+        oll::ModelEntry m;
+        m.name = oll::with_latest_tag(g_model_name);
+        m.model = m.name;
+        // Size and mtime come from the checkpoint file itself. A directory checkpoint
+        // (compressed-tensors) reports 0 rather than walking the tree on every request.
+        const std::string path = engine.model_path();
+        struct stat st{};
+        if (::stat(path.c_str(), &st) == 0 && S_ISREG(st.st_mode)) {
+            m.size = (long long)st.st_size;
+            char buf[32];
+            std::tm tm{};
+            const std::time_t mt = st.st_mtime;
+            gmtime_r(&mt, &tm);
+            std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+            m.modified_at = buf;
+        } else {
+            m.size = 0;
+            m.modified_at = oll::rfc3339_now();
+        }
+        // digest is Ollama's CONTENT hash, used for blob dedup on pull. Computing a real sha256
+        // of a multi-GB checkpoint per request is out of the question, and a synthetic value
+        // would be a content hash that does not hash the content -- something a client could
+        // legitimately compare against another server and be misled by. Left empty: this server
+        // serves exactly one model and does not serve blobs, so nothing can act on it.
+        m.digest = "";
+        m.details.family = engine.is_qwen38()      ? "qwen3_8"
+                         : engine.is_museglimmer() ? "muse-glimmer"
+                         : engine.is_spark25()     ? "spark2_5"
+                                                   : "qwen3_6";
+        m.details.families = {m.details.family};
+        m.details.parameter_size = "";
+        m.details.quantization_level =
+            sparkinfer_server::lmstudio::quantization_from_path(engine.model_path());
+        return m;
+    };
+
+    svr.Get("/api/version", [](const httplib::Request&, httplib::Response& res) {
+        // Ollama clients version-gate features on this. Report a real Ollama-compatible version
+        // rather than a sparkinfer version string, which a client would fail to parse.
+        res.set_content(nlohmann::json{{"version", "0.5.0"}}.dump(), "application/json");
+    });
+
+    svr.Get("/api/tags", [&engine, ollama_entry](const httplib::Request& req, httplib::Response& res) {
+        if (!auth_ok(req)) { res.status = 401;
+            res.set_content("{\"error\":\"unauthorized\"}", "application/json"); return; }
+        res.set_content(oll::tags_list({ollama_entry()}).dump(), "application/json");
+    });
+
+    svr.Get("/api/ps", [&engine, ollama_entry](const httplib::Request& req, httplib::Response& res) {
+        if (!auth_ok(req)) { res.status = 401;
+            res.set_content("{\"error\":\"unauthorized\"}", "application/json"); return; }
+        // The one checkpoint this process serves is resident for the life of the process, so it
+        // is always "running" — there is no load/unload lifecycle to report.
+        res.set_content(oll::ps_list({ollama_entry()}).dump(), "application/json");
+    });
+
+    svr.Post("/api/show", [&engine, ollama_entry](const httplib::Request& req, httplib::Response& res) {
+        if (!auth_ok(req)) { res.status = 401;
+            res.set_content("{\"error\":\"unauthorized\"}", "application/json"); return; }
+        nlohmann::json in;
+        try { in = nlohmann::json::parse(req.body.empty() ? "{}" : req.body); }
+        catch (...) { res.status = 400;
+            res.set_content("{\"error\":\"invalid json\"}", "application/json"); return; }
+        const std::string want = in.value("model", in.value("name", std::string()));
+        if (!oll::model_name_matches(want, g_model_name)) {
+            res.status = 404;
+            res.set_content(nlohmann::json{{"error", "model '" + want + "' not found"}}.dump(),
+                            "application/json");
+            return;
+        }
+        const auto m = ollama_entry();
+        nlohmann::json mi = {{"general.architecture", m.details.family},
+                             {"general.parameter_count", (long long)0}};
+        std::vector<std::string> caps{"completion"};
+        if (engine.has_vision()) caps.push_back("vision");
+        res.set_content(oll::show_object(m, mi, caps, "").dump(), "application/json");
+    });
+
+    // Shared body for /api/chat and /api/generate. `chat` selects which handler and which
+    // translation pair; everything else is identical, including the NDJSON re-framing.
+    auto ollama_completion = [&engine, ollama_entry, chat_completions_handler,
+                              text_completions_handler](const httplib::Request& req,
+                                                        httplib::Response& res, bool chat) {
+        if (!auth_ok(req)) { res.status = 401;
+            res.set_content("{\"error\":\"unauthorized\"}", "application/json"); return; }
+        nlohmann::json in;
+        try { in = nlohmann::json::parse(req.body.empty() ? "{}" : req.body); }
+        catch (...) { res.status = 400;
+            res.set_content("{\"error\":\"invalid json\"}", "application/json"); return; }
+        const std::string want = in.value("model", std::string());
+        if (!oll::model_name_matches(want, g_model_name)) {
+            res.status = 404;
+            res.set_content(nlohmann::json{{"error", "model '" + want + "' not found"}}.dump(),
+                            "application/json");
+            return;
+        }
+        // Ollama omits `stream` to mean TRUE, unlike OpenAI where absent means false.
+        const bool want_stream = in.value("stream", true);
+
+        httplib::Request inner = req;
+        inner.body = (chat ? oll::chat_request_to_openai(in)
+                           : oll::generate_request_to_openai(in)).dump();
+        inner.set_header("Content-Type", "application/json");
+
+        httplib::Response inner_res;
+        if (chat) chat_completions_handler(inner, inner_res);
+        else      text_completions_handler(inner, inner_res);
+
+        // Pass a real failure through rather than dressing it as a completed Ollama response.
+        if (inner_res.status > 0 && inner_res.status != 200) {
+            res.status = inner_res.status;
+            res.set_content(inner_res.body, "application/json");
+            return;
+        }
+        nlohmann::json oai;
+        try { oai = nlohmann::json::parse(inner_res.body); }
+        catch (...) { res.status = 500;
+            res.set_content("{\"error\":\"upstream produced no JSON\"}", "application/json"); return; }
+
+        const std::string model = oll::with_latest_tag(g_model_name);
+        const std::string ts = oll::rfc3339_now();
+        const nlohmann::json out = chat ? oll::openai_to_chat_response(oai, model, ts)
+                                        : oll::openai_to_generate_response(oai, model, ts);
+        if (want_stream) {
+            // NDJSON: one JSON object per line. This is a single terminal chunk (done=true) --
+            // correct framing and fields, but the whole message at once rather than
+            // token-by-token. See ollama_api.hpp for why, and what closing that gap requires.
+            res.set_content(out.dump() + "\n", "application/x-ndjson");
+        } else {
+            res.set_content(out.dump(), "application/json");
+        }
+    };
+
+    svr.Post("/api/chat", [ollama_completion](const httplib::Request& req, httplib::Response& res) {
+        ollama_completion(req, res, /*chat=*/true);
+    });
+    svr.Post("/api/generate", [ollama_completion](const httplib::Request& req, httplib::Response& res) {
+        ollama_completion(req, res, /*chat=*/false);
+    });
+
+    // Everything Ollama exposes that this server structurally cannot do. Each is refused with a
+    // reason rather than silently 404'ing as an unknown route, so a client (or a person reading
+    // the log) learns WHY instead of suspecting a typo or a version mismatch.
+    //   embed/embeddings — no pooling path; sparkinfer is a generation runtime
+    //   pull/push/create/copy/delete/blobs — no model management; -m fixes one checkpoint
+    {
+        auto unsupported = [](const char* why) {
+            return [why](const httplib::Request&, httplib::Response& res) {
+                res.status = 501;
+                res.set_content(nlohmann::json{{"error", std::string(why)}}.dump(),
+                                "application/json");
+            };
+        };
+        const char* no_embed =
+            "this server does not support embeddings: sparkinfer is a generation runtime and has "
+            "no embedding model loaded";
+        const char* no_mgmt =
+            "this server does not manage models: it serves exactly one checkpoint given with -m "
+            "at startup, so there is nothing to pull, create, copy or delete";
+        svr.Post("/api/embed", unsupported(no_embed));
+        svr.Post("/api/embeddings", unsupported(no_embed));
+        svr.Post("/api/pull", unsupported(no_mgmt));
+        svr.Post("/api/push", unsupported(no_mgmt));
+        svr.Post("/api/create", unsupported(no_mgmt));
+        svr.Post("/api/copy", unsupported(no_mgmt));
+        svr.Delete("/api/delete", unsupported(no_mgmt));
+    }
 
     // Embeddings: refused, explicitly. sparkinfer has no pooling/embedding path at all -- it is a
     // generation runtime. Returning 501 with a reason is the honest answer; returning zeros, or

--- a/server/src/sparkinfer_server.cpp
+++ b/server/src/sparkinfer_server.cpp
@@ -253,9 +253,41 @@ nlohmann::json stream_chunk_base(const std::string& cid, long long created,
 // into the SAME one DataSink for this one HTTP response -- every write must go through this one
 // mutex. Reads (sink.is_writable(), polled inside on_tok to detect a disconnected client) need no
 // lock; only concurrent writes are unsafe.
+// Which wire dialect this ONE response streams in.
+//
+// Every stream writer funnels through write_sse_json, so the dialect is applied there and the
+// generation loop never learns about it. That is the whole point: /v1, LM Studio and Ollama share
+// one generation path and differ only in how a chunk is framed and shaped on the way out.
+enum class StreamDialect {
+    OpenAiSse,      // data: {...}\n\n  -- the /v1 default, byte-identical to before
+    LmStudioSse,    // same framing; the usage chunk additionally carries LM Studio's stats block
+    OllamaNdjson,   // {...}\n per line, Ollama's message/done shape, no [DONE] sentinel
+};
+
+// The wrapper routes (/api/v0/*, /api/*) mark their inner request with this header so the shared
+// handler knows which dialect to stream in. A header rather than a global: it is per-request and
+// therefore correct under concurrency, and it needs no change to the handler's signature.
+constexpr const char* kStreamDialectHeader = "X-Sparkinfer-Stream-Dialect";
+
+StreamDialect stream_dialect_of(const httplib::Request& req) {
+    const std::string v = req.get_header_value(kStreamDialectHeader);
+    if (v == "ollama-ndjson" || v == "ollama-ndjson-generate") return StreamDialect::OllamaNdjson;
+    if (v == "lmstudio-sse") return StreamDialect::LmStudioSse;
+    return StreamDialect::OpenAiSse;
+}
+
 struct GuardedSink {
     httplib::DataSink& sink;
     std::mutex& mu;
+    StreamDialect dialect = StreamDialect::OpenAiSse;
+    // Ollama echoes the model name in every chunk and stamps each with a timestamp; both are
+    // fixed for the life of a response, so they are captured once here rather than recomputed
+    // per chunk.
+    std::string model_name;
+    std::string created_at;
+    // Ollama's /api/generate streams {"response": "..."} while /api/chat streams
+    // {"message":{...}}. Emitting the wrong one renders NOTHING in the client, with no error.
+    bool ollama_generate = false;
 };
 
 // SSE comments are ignored by OpenAI clients and prevent proxy idle timeouts during long prefill.
@@ -304,7 +336,29 @@ private:
 };
 
 bool write_sse_json(GuardedSink& gs, const nlohmann::json& value) {
-    const std::string event = "data: " + value.dump() + "\n\n";
+    std::string event;
+    if (gs.dialect == StreamDialect::OllamaNdjson) {
+        const nlohmann::json chunk = sparkinfer_server::ollama::stream_chunk_from_openai(
+            value, gs.model_name, gs.created_at, gs.ollama_generate);
+        // A null result means this OpenAI chunk has no Ollama counterpart (role-only opener,
+        // finish chunk). Drop it rather than writing an empty line, which would be a parse error
+        // for an NDJSON reader.
+        if (chunk.is_null()) return true;
+        event = chunk.dump() + "\n";
+    } else {
+        nlohmann::json out = value;
+        // LM Studio's stats ride on the usage chunk -- the only one that carries the timings.
+        if (gs.dialect == StreamDialect::LmStudioSse && out.contains("usage")) {
+            const auto& u = out["usage"];
+            sparkinfer_server::lmstudio::Stats st;
+            st.tokens_per_second = u.value("decode_tps", 0.0);
+            st.time_to_first_token = u.value("ttft_ms", 0.0) / 1000.0;
+            st.generation_time = u.value("generation_ms", 0.0) / 1000.0;
+            st.stop_reason = "eosFound";
+            out["stats"] = sparkinfer_server::lmstudio::stats_object(st);
+        }
+        event = "data: " + out.dump() + "\n\n";
+    }
     std::lock_guard<std::mutex> lock(gs.mu);
     return gs.sink.write(event.c_str(), event.size());
 }
@@ -470,6 +524,10 @@ nlohmann::json build_legacy_logprobs_json(const std::vector<sparkinfer_server::T
 // Only ever called once, single-threaded, after every branch has joined -- still routed through
 // the mutex for type consistency with every other writer (uncontended lock/unlock is negligible).
 bool write_stream_done(GuardedSink& gs) {
+    // "data: [DONE]" is an OpenAI-SSE sentinel. Ollama has no equivalent -- its stream ends with
+    // the done=true chunk and nothing after it -- and emitting this would be an unparseable line
+    // to an NDJSON reader.
+    if (gs.dialect == StreamDialect::OllamaNdjson) return true;
     static const std::string done = "data: [DONE]\n\n";
     std::lock_guard<std::mutex> lock(gs.mu);
     return gs.sink.write(done.c_str(), done.size());
@@ -1176,14 +1234,23 @@ int main(int argc, char** argv) {
                      res.set_header("Cache-Control", "no-cache");
                      res.set_header("X-Accel-Buffering", "no");
                      res.set_chunked_content_provider(
-                         "text/event-stream",
+                         stream_dialect_of(req) == StreamDialect::OllamaNdjson
+                             ? "application/x-ndjson" : "text/event-stream",
                          [&engine, prompt_ids, max_tokens, cid, created, enable_thinking,
                           // BY VALUE, like prompt_ids beside it: this provider runs after the
                           // handler returns, so a reference would dangle. Cheap -- PreparedImages
                           // shares its pixel buffers rather than owning them.
                           prepared,
                           chat_request, tool_protocol, json_mode_active,
-                          include_usage = controls.include_usage || always_stream_usage(), stop = controls.stop,
+                          dialect = stream_dialect_of(req),
+                          ollama_generate =
+                              req.get_header_value(kStreamDialectHeader) == "ollama-ndjson-generate",
+                          // Ollama's stream is terminated by the done=true chunk, which is built
+                          // from OpenAI's USAGE chunk -- so without usage the client would wait
+                          // for an end that never arrives. Forced on for that dialect only.
+                          include_usage = controls.include_usage || always_stream_usage()
+                                          || stream_dialect_of(req) == StreamDialect::OllamaNdjson,
+                          stop = controls.stop,
                           temperature = controls.temperature, seed = controls.seed,
                           top_k = controls.top_k, top_p = controls.top_p,
                           presence_penalty = controls.presence_penalty,
@@ -1198,7 +1265,11 @@ int main(int argc, char** argv) {
                              }
 
                              std::mutex sink_mu;
-                             GuardedSink gs{sink, sink_mu};
+                             GuardedSink gs{sink, sink_mu, dialect, g_model_name, "", ollama_generate};
+                             if (dialect == StreamDialect::OllamaNdjson) {
+                                 gs.model_name = sparkinfer_server::ollama::with_latest_tag(g_model_name);
+                                 gs.created_at = sparkinfer_server::ollama::rfc3339_now();
+                             }
                              SseHeartbeat heartbeat(gs);
 
                              for (int ci = 0; ci < n; ci++) {
@@ -2123,9 +2194,18 @@ int main(int argc, char** argv) {
                      res.set_header("Cache-Control", "no-cache");
                      res.set_header("X-Accel-Buffering", "no");
                      res.set_chunked_content_provider(
-                         "text/event-stream",
+                         stream_dialect_of(req) == StreamDialect::OllamaNdjson
+                             ? "application/x-ndjson" : "text/event-stream",
                          [&engine, prompt_ids, prompt, echo, max_tokens, cid, created,
-                          include_usage = controls.include_usage || always_stream_usage(), stop = controls.stop,
+                          dialect = stream_dialect_of(req),
+                          ollama_generate =
+                              req.get_header_value(kStreamDialectHeader) == "ollama-ndjson-generate",
+                          // Ollama's stream is terminated by the done=true chunk, which is built
+                          // from OpenAI's USAGE chunk -- so without usage the client would wait
+                          // for an end that never arrives. Forced on for that dialect only.
+                          include_usage = controls.include_usage || always_stream_usage()
+                                          || stream_dialect_of(req) == StreamDialect::OllamaNdjson,
+                          stop = controls.stop,
                           temperature = controls.temperature, seed = controls.seed,
                           top_k = controls.top_k, top_p = controls.top_p,
                           presence_penalty = controls.presence_penalty,
@@ -2140,7 +2220,11 @@ int main(int argc, char** argv) {
                              }
 
                              std::mutex sink_mu;
-                             GuardedSink gs{sink, sink_mu};
+                             GuardedSink gs{sink, sink_mu, dialect, g_model_name, "", ollama_generate};
+                             if (dialect == StreamDialect::OllamaNdjson) {
+                                 gs.model_name = sparkinfer_server::ollama::with_latest_tag(g_model_name);
+                                 gs.created_at = sparkinfer_server::ollama::rfc3339_now();
+                             }
                              SseHeartbeat heartbeat(gs);
 
                              struct BranchOutcome {
@@ -2605,8 +2689,14 @@ int main(int argc, char** argv) {
         st.time_to_first_token = usage.value("ttft_ms", 0.0) / 1000.0;   // ms -> s
         st.generation_time = usage.value("generation_ms", 0.0) / 1000.0;
         std::string finish;
-        if (body.contains("choices") && body["choices"].is_array() && !body["choices"].empty())
-            finish = body["choices"][0].value("finish_reason", "");
+        // Null-safe: nlohmann's value() returns the default only for an ABSENT key; a present
+        // null throws type_error.302. finish_reason is null on any chunk that is not the last,
+        // and that exact mistake crashed the server mid-stream on the Ollama path.
+        if (body.contains("choices") && body["choices"].is_array() && !body["choices"].empty()) {
+            const auto& c0 = body["choices"][0];
+            auto it = c0.find("finish_reason");
+            if (it != c0.end() && it->is_string()) finish = it->get<std::string>();
+        }
         st.stop_reason = sparkinfer_server::lmstudio::stop_reason_from_finish(finish);
 
         const auto m = lmstudio_model_desc();
@@ -2630,17 +2720,27 @@ int main(int argc, char** argv) {
         res.set_content(body.dump(), "application/json");
     };
 
+    // A STREAMING v0 request is passed straight through with the LM Studio dialect marked, so it
+    // streams incrementally and its usage chunk carries the stats block. Only a NON-streaming one
+    // needs the post-hoc augmentation, because only then is there a whole JSON document to amend.
+    auto v0_route = [lmstudio_augment](const httplib::Request& req, httplib::Response& res,
+                                       const std::function<void(const httplib::Request&,
+                                                                httplib::Response&)>& handler) {
+        bool streaming = false;
+        try { streaming = nlohmann::json::parse(req.body.empty() ? "{}" : req.body)
+                              .value("stream", false); } catch (...) {}
+        httplib::Request inner = req;
+        if (streaming) inner.set_header(kStreamDialectHeader, "lmstudio-sse");
+        handler(inner, res);
+        if (!streaming) lmstudio_augment(res);
+    };
     svr.Post("/api/v0/chat/completions",
-             [chat_completions_handler, lmstudio_augment](const httplib::Request& req,
-                                                          httplib::Response& res) {
-                 chat_completions_handler(req, res);
-                 lmstudio_augment(res);
+             [chat_completions_handler, v0_route](const httplib::Request& req, httplib::Response& res) {
+                 v0_route(req, res, chat_completions_handler);
              });
     svr.Post("/api/v0/completions",
-             [text_completions_handler, lmstudio_augment](const httplib::Request& req,
-                                                          httplib::Response& res) {
-                 text_completions_handler(req, res);
-                 lmstudio_augment(res);
+             [text_completions_handler, v0_route](const httplib::Request& req, httplib::Response& res) {
+                 v0_route(req, res, text_completions_handler);
              });
 
     // ---------------------------------------------------------------------------------------
@@ -2788,10 +2888,24 @@ int main(int argc, char** argv) {
         else           inner_body = oll::generate_request_to_chat(in);
 
         httplib::Request inner = req;
+        // A STREAMING request is handed to the shared handler with stream=true and the Ollama
+        // dialect marked: write_sse_json then re-frames every chunk as NDJSON in Ollama's
+        // message/done shape, so the client gets genuine token-by-token delivery rather than one
+        // terminal chunk. Only a non-streaming request needs the whole-document translation.
+        if (want_stream) inner_body["stream"] = true;
         inner.body = inner_body.dump();
         inner.set_header("Content-Type", "application/json");
+        if (want_stream)
+            inner.set_header(kStreamDialectHeader,
+                             chat ? "ollama-ndjson" : "ollama-ndjson-generate");
 
         httplib::Response inner_res;
+        if (want_stream) {
+            // Pass the handler's own response through untouched -- it IS the NDJSON stream.
+            if (use_chat_handler) chat_completions_handler(inner, res);
+            else                  text_completions_handler(inner, res);
+            return;
+        }
         if (use_chat_handler) chat_completions_handler(inner, inner_res);
         else                  text_completions_handler(inner, inner_res);
 
@@ -2810,14 +2924,7 @@ int main(int argc, char** argv) {
         const std::string ts = oll::rfc3339_now();
         const nlohmann::json out = chat ? oll::openai_to_chat_response(oai, model, ts)
                                         : oll::openai_to_generate_response(oai, model, ts);
-        if (want_stream) {
-            // NDJSON: one JSON object per line. This is a single terminal chunk (done=true) --
-            // correct framing and fields, but the whole message at once rather than
-            // token-by-token. See ollama_api.hpp for why, and what closing that gap requires.
-            res.set_content(out.dump() + "\n", "application/x-ndjson");
-        } else {
-            res.set_content(out.dump(), "application/json");
-        }
+        res.set_content(out.dump(), "application/json");
     };
 
     svr.Post("/api/chat", [ollama_completion](const httplib::Request& req, httplib::Response& res) {

--- a/server/tests/lmstudio_api_test.cpp
+++ b/server/tests/lmstudio_api_test.cpp
@@ -1,0 +1,120 @@
+// Unit tests for the LM Studio /api/v0 response shaping. Pure JSON over plain structs, so this
+// runs anywhere -- no GPU, no model, no HTTP server.
+//
+// The assertions are deliberately about EXACT field names and value vocabularies. That is the
+// whole contract: a client written against LM Studio switches on strings like "eosFound" and
+// reads keys like "max_context_length", and getting one of them subtly wrong produces a response
+// that parses fine and behaves wrongly.
+
+#include "lmstudio_api.hpp"
+
+#include <cstdio>
+#include <string>
+
+using namespace sparkinfer_server::lmstudio;
+
+#define CHECK(x) do { if (!(x)) { std::printf("FAIL: %s line %d\n", #x, __LINE__); return 1; } } while (0)
+
+int main() {
+    // ---- model object: every documented field present, exact names ----
+    {
+        ModelDesc m;
+        m.id = "muse-glimmer-30b";
+        m.type = "llm";
+        m.publisher = "sparkinfer";
+        m.arch = "muse-glimmer";
+        m.compatibility_type = "gguf";
+        m.quantization = "Q4_K_M";
+        m.state = "loaded";
+        m.max_context_length = 131072;
+        m.loaded_context_length = 4096;
+        const nlohmann::json j = model_object(m);
+        for (const char* k : {"id", "object", "type", "publisher", "arch", "compatibility_type",
+                              "quantization", "state", "max_context_length"})
+            CHECK(j.contains(k));
+        CHECK(j["object"] == "model");
+        CHECK(j["max_context_length"] == 131072);
+        CHECK(j["loaded_context_length"] == 4096);
+    }
+    // loaded_context_length is OMITTED when not loaded — a 0 would read as "a context of zero"
+    {
+        ModelDesc m; m.id = "x"; m.state = "not-loaded"; m.loaded_context_length = 0;
+        const nlohmann::json j = model_object(m);
+        CHECK(!j.contains("loaded_context_length"));
+        CHECK(j["state"] == "not-loaded");
+    }
+    // a loaded model that somehow reports 0 also omits it, rather than emitting a misleading 0
+    {
+        ModelDesc m; m.id = "x"; m.state = "loaded"; m.loaded_context_length = 0;
+        CHECK(!model_object(m).contains("loaded_context_length"));
+    }
+
+    // ---- list envelope ----
+    {
+        ModelDesc a; a.id = "a"; ModelDesc b; b.id = "b";
+        const nlohmann::json j = models_list({a, b});
+        CHECK(j["object"] == "list");
+        CHECK(j["data"].is_array() && j["data"].size() == 2);
+        CHECK(j["data"][0]["id"] == "a" && j["data"][1]["id"] == "b");
+        CHECK(models_list({})["data"].is_array() && models_list({})["data"].empty());
+    }
+
+    // ---- stats: seconds, and LM Studio's stop_reason vocabulary ----
+    {
+        Stats s; s.tokens_per_second = 51.4; s.time_to_first_token = 0.111;
+        s.generation_time = 0.954; s.stop_reason = "eosFound";
+        const nlohmann::json j = stats_object(s);
+        for (const char* k : {"tokens_per_second", "time_to_first_token", "generation_time", "stop_reason"})
+            CHECK(j.contains(k));
+        CHECK(j["stop_reason"] == "eosFound");
+    }
+    CHECK(stop_reason_from_finish("stop") == "eosFound");
+    CHECK(stop_reason_from_finish("length") == "maxPredictedTokensReached");
+    CHECK(stop_reason_from_finish("tool_calls") == "toolCalls");
+    // an unmapped/absent value must NOT leak OpenAI's word through
+    CHECK(stop_reason_from_finish("") == "eosFound");
+    CHECK(stop_reason_from_finish("something_new") == "eosFound");
+
+    // ---- model_info / runtime ----
+    {
+        ModelInfo mi; mi.arch = "muse-glimmer"; mi.quant = "Q4_K_M"; mi.format = "gguf";
+        mi.context_length = 4096;
+        const nlohmann::json j = model_info_object(mi);
+        for (const char* k : {"arch", "quant", "format", "context_length"}) CHECK(j.contains(k));
+        RuntimeDesc r; r.name = "sparkinfer-linux-x86_64-nvidia-cuda12-sm120"; r.version = "0.4.4";
+        const nlohmann::json rj = runtime_object(r);
+        CHECK(rj["supported_formats"].is_array());
+        CHECK(rj["supported_formats"][0] == "gguf");
+    }
+
+    // ---- quantization parsing: longest tag wins, so Q4_K_M never truncates to Q4_K ----
+    CHECK(quantization_from_path("/m/Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf") == "Q4_K_M");
+    CHECK(quantization_from_path("/m/Spark-X2.5-4B-Q8_0.gguf") == "Q8_0");
+    CHECK(quantization_from_path("/m/Model-q4_k_m.gguf") == "Q4_K_M");        // case-insensitive
+    CHECK(quantization_from_path("/m/Qwen3.6-35B-A3B-UD-Q4_K_M.gguf") == "Q4_K_M");
+    CHECK(quantization_from_path("/root/workspace/models_q38_modelopt") == "");  // dir, no tag
+    CHECK(quantization_from_path("") == "");
+
+    // ---- compatibility_type ----
+    CHECK(compatibility_type_from_path("/m/x.gguf") == "gguf");
+    CHECK(compatibility_type_from_path("/m/x.GGUF") == "gguf");
+    CHECK(compatibility_type_from_path("/root/workspace/models_q38_modelopt") == "");
+
+    // ---- publisher ----
+    // Only LM Studio's own layout carries a publisher: <...>/models/<publisher>/<repo>/<file>
+    CHECK(publisher_from_path("/home/u/.lmstudio/models/lmstudio-community/Foo-GGUF/foo-Q4_K_M.gguf")
+          == "lmstudio-community");
+    CHECK(publisher_from_path("/models/lmstudio-community/Foo-GGUF/foo.gguf") == "lmstudio-community");
+    // An ordinary path has NO publisher. Reading one out of the path shape alone reported "root"
+    // for /root/spark25_models/... and displayed it as if it were real.
+    CHECK(publisher_from_path("/root/spark25_models/Spark-X2.5-4B-Q8_0.gguf") == "");
+    CHECK(publisher_from_path("/root/workspace/models_muse_glimmer/Muse-Glimmer-30B-Q4_K_M.gguf") == "");
+    CHECK(publisher_from_path("/a/b/c.gguf") == "");
+    CHECK(publisher_from_path("c.gguf") == "");
+    CHECK(publisher_from_path("/x.gguf") == "");
+    // "models" as the immediate parent of the FILE is not a publisher layout either
+    CHECK(publisher_from_path("/opt/models/foo.gguf") == "");
+
+    std::printf("lmstudio_api_test: OK\n");
+    return 0;
+}

--- a/server/tests/ollama_api_test.cpp
+++ b/server/tests/ollama_api_test.cpp
@@ -179,6 +179,69 @@ int main() {
         CHECK(!j.contains("context"));
     }
 
+    // ---- NULL-valued fields must not throw (this crashed the server mid-stream) ----
+    // OpenAI stream chunks carry delta.content = null on the role/finish chunks and
+    // finish_reason = null on every non-final chunk. nlohmann's value() only defaults an ABSENT
+    // key; a present null throws type_error.302 and took the whole process down.
+    {
+        const nlohmann::json role_chunk = {{"object","chat.completion.chunk"},
+            {"choices",{{{"index",0},{"delta",{{"role","assistant"},{"content",nullptr}}},
+                         {"finish_reason",nullptr}}}}};
+        const nlohmann::json c = stream_chunk_from_openai(role_chunk, "m:latest", "t");
+        CHECK(c.is_null());                       // no Ollama counterpart, and no throw
+    }
+    {
+        const nlohmann::json finish_chunk = {{"choices",{{{"index",0},{"delta",nlohmann::json::object()},
+                                                          {"finish_reason","stop"}}}}};
+        CHECK(stream_chunk_from_openai(finish_chunk, "m", "t").is_null());
+    }
+    {   // a real content delta does translate
+        const nlohmann::json d = {{"choices",{{{"index",0},{"delta",{{"content","Hel"}}},
+                                               {"finish_reason",nullptr}}}}};
+        const nlohmann::json c = stream_chunk_from_openai(d, "m:latest", "ts");
+        CHECK(!c.is_null() && c["message"]["content"] == "Hel" && c["done"] == false);
+        CHECK(c["model"] == "m:latest" && c["created_at"] == "ts");
+    }
+    {   // the usage chunk becomes the single done=true terminator, with metrics
+        const nlohmann::json u = {{"choices",nlohmann::json::array()},
+            {"usage",{{"prompt_tokens",5},{"completion_tokens",7},
+                      {"ttft_ms",10.0},{"generation_ms",20.0}}}};
+        const nlohmann::json c = stream_chunk_from_openai(u, "m", "t");
+        CHECK(!c.is_null() && c["done"] == true);
+        CHECK(c["eval_count"] == 7 && c["eval_duration"] == 20000000LL);
+        CHECK(c["message"]["content"] == "");
+    }
+    {   // null-valued request fields must not throw either
+        const nlohmann::json in = {{"model",nullptr},{"prompt",nullptr},{"system",nullptr}};
+        CHECK(generate_request_to_chat(in)["messages"][0]["content"] == "");
+        CHECK(chat_request_to_openai({{"model",nullptr}})["model"] == "");
+    }
+    {   // a null content in a COMPLETED response (tool-call replies do this)
+        const nlohmann::json oai = {{"choices",{{{"finish_reason",nullptr},
+            {"message",{{"role","assistant"},{"content",nullptr}}}}}},{"usage",nlohmann::json::object()}};
+        CHECK(openai_to_chat_response(oai,"m","t")["message"]["content"] == "");
+        CHECK(openai_to_generate_response(oai,"m","t")["response"] == "");
+    }
+
+    // ---- generate streams "response", chat streams "message" -- NOT interchangeable ----
+    // Emitting the chat shape to an /api/generate client made `ollama run` print nothing at all,
+    // with no error, because it reads a key that is simply absent.
+    {
+        const nlohmann::json d = {{"choices",{{{"delta",{{"content","Par"}}},{"finish_reason",nullptr}}}}};
+        const nlohmann::json g = stream_chunk_from_openai(d, "m", "t", /*generate=*/true);
+        CHECK(g["response"] == "Par" && !g.contains("message"));
+        const nlohmann::json c = stream_chunk_from_openai(d, "m", "t", /*generate=*/false);
+        CHECK(c["message"]["content"] == "Par" && !c.contains("response"));
+    }
+    {   // the terminator too
+        const nlohmann::json u = {{"choices",nlohmann::json::array()},
+            {"usage",{{"completion_tokens",3},{"generation_ms",5.0}}}};
+        const nlohmann::json g = stream_chunk_from_openai(u, "m", "t", true);
+        CHECK(g["done"] == true && g["response"] == "" && !g.contains("message"));
+        const nlohmann::json c = stream_chunk_from_openai(u, "m", "t", false);
+        CHECK(c["done"] == true && c["message"]["content"] == "" && !c.contains("response"));
+    }
+
     // ---- digest: exactly 64 lowercase hex, stable, and NEVER empty ----
     // `ollama list`/`ps` render digest[:12] with no length check, so an empty or short value
     // panics the official CLI. This is the regression test for that crash.

--- a/server/tests/ollama_api_test.cpp
+++ b/server/tests/ollama_api_test.cpp
@@ -19,7 +19,9 @@ int main() {
     CHECK(model_name_matches("spark-x2.5-4b", "spark-x2.5-4b"));
     CHECK(model_name_matches("spark-x2.5-4b:latest", "spark-x2.5-4b"));
     CHECK(model_name_matches("spark-x2.5-4b:anything", "spark-x2.5-4b"));
-    CHECK(model_name_matches("", "spark-x2.5-4b"));          // absent == the loaded model
+    // An empty/absent name must NOT match. Ollama documents `model` as required; treating it as
+    // "the loaded model" made {"model": null} return 200 and generate from an empty prompt.
+    CHECK(!model_name_matches("", "spark-x2.5-4b"));
     CHECK(!model_name_matches("llama3.2", "spark-x2.5-4b"));
 
     // ---- /api/tags ----

--- a/server/tests/ollama_api_test.cpp
+++ b/server/tests/ollama_api_test.cpp
@@ -79,6 +79,50 @@ int main() {
         const nlohmann::json o = generate_request_to_openai(in);
         CHECK(o["prompt"] == "hello" && o["stream"] == false && o["max_tokens"] == 8);
     }
+    // An EMPTY suffix must not be forwarded: the ollama CLI sends "suffix":"" on an ordinary
+    // `ollama run`, and passing it through made /v1/completions 400 the whole request.
+    {
+        const nlohmann::json in = {{"model","m"},{"prompt","hi"},{"suffix",""}};
+        CHECK(!generate_request_to_openai(in).contains("suffix"));
+    }
+    { // a real suffix still gets through
+        const nlohmann::json in = {{"model","m"},{"prompt","hi"},{"suffix","tail"}};
+        CHECK(generate_request_to_openai(in)["suffix"] == "tail");
+    }
+
+    // ---- /api/generate is TEMPLATE-AWARE by default, raw only on request ----
+    // Ollama applies the model's template to `prompt`; OpenAI's /v1/completions does not. Mapping
+    // one onto the other made `ollama run "Reply with exactly: OK"` answer "OK: OK: OK: OK...".
+    CHECK(!generate_wants_raw({{"model","m"},{"prompt","hi"}}));            // default = templated
+    CHECK(generate_wants_raw({{"model","m"},{"prompt","hi"},{"raw",true}}));
+    {
+        const nlohmann::json o = generate_request_to_chat({{"model","m"},{"prompt","hi"}});
+        CHECK(o.contains("messages") && !o.contains("prompt"));
+        CHECK(o["messages"].size() == 1);
+        CHECK(o["messages"][0]["role"] == "user" && o["messages"][0]["content"] == "hi");
+        CHECK(o["stream"] == false);
+    }
+    { // a system field becomes a system turn ahead of the user turn
+        const nlohmann::json o = generate_request_to_chat(
+            {{"model","m"},{"prompt","hi"},{"system","be terse"}});
+        CHECK(o["messages"].size() == 2);
+        CHECK(o["messages"][0]["role"] == "system" && o["messages"][0]["content"] == "be terse");
+        CHECK(o["messages"][1]["role"] == "user");
+    }
+    { // options still map through on the chat path
+        const nlohmann::json o = generate_request_to_chat(
+            {{"model","m"},{"prompt","hi"},{"options",{{"num_predict",12},{"temperature",0}}}});
+        CHECK(o["max_tokens"] == 12 && o["temperature"] == 0);
+    }
+    // the generate response reads EITHER upstream shape
+    {
+        const nlohmann::json from_chat = {{"choices",{{{"finish_reason","stop"},
+            {"message",{{"role","assistant"},{"content","Paris"}}}}}},{"usage",nlohmann::json::object()}};
+        CHECK(openai_to_generate_response(from_chat,"m","t")["response"] == "Paris");
+        const nlohmann::json from_text = {{"choices",{{{"finish_reason","stop"},{"text","Paris"}}}},
+                                          {"usage",nlohmann::json::object()}};
+        CHECK(openai_to_generate_response(from_text,"m","t")["response"] == "Paris");
+    }
 
     // ---- durations are NANOSECONDS ----
     CHECK(ms_to_ns(1.0) == 1000000LL);
@@ -133,6 +177,20 @@ int main() {
         // "context" is opaque conversation state this server does not keep; fabricating one would
         // invite the client to send it back as if it meant something.
         CHECK(!j.contains("context"));
+    }
+
+    // ---- digest: exactly 64 lowercase hex, stable, and NEVER empty ----
+    // `ollama list`/`ps` render digest[:12] with no length check, so an empty or short value
+    // panics the official CLI. This is the regression test for that crash.
+    {
+        const std::string d = synthetic_digest("/m/x.gguf|123|2026-01-01T00:00:00Z");
+        CHECK(d.size() == 64);
+        for (char c : d) CHECK((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+        CHECK(d.size() >= 12);                                   // the exact CLI slice
+        CHECK(synthetic_digest("/m/x.gguf|123|2026-01-01T00:00:00Z") == d);   // stable
+        CHECK(synthetic_digest("/m/y.gguf|123|2026-01-01T00:00:00Z") != d);   // path matters
+        CHECK(synthetic_digest("/m/x.gguf|999|2026-01-01T00:00:00Z") != d);   // size matters
+        CHECK(synthetic_digest("").size() == 64);                // even a degenerate seed is safe
     }
 
     // ---- created_at is RFC3339 UTC ----

--- a/server/tests/ollama_api_test.cpp
+++ b/server/tests/ollama_api_test.cpp
@@ -1,0 +1,147 @@
+// Unit tests for Ollama /api/* request and response translation. Pure JSON, no engine or GPU.
+//
+// The assertions are about exact field names, units and value vocabularies. An Ollama client
+// reads `message.content`, switches on `done`, and divides durations assuming NANOSECONDS -- each
+// of those is a way to be wrong while still producing valid JSON.
+
+#include "ollama_api.hpp"
+
+#include <cstdio>
+
+using namespace sparkinfer_server::ollama;
+
+#define CHECK(x) do { if (!(x)) { std::printf("FAIL: %s line %d\n", #x, __LINE__); return 1; } } while (0)
+
+int main() {
+    // ---- model naming: Ollama addresses models as "<name>:<tag>" ----
+    CHECK(with_latest_tag("spark-x2.5-4b") == "spark-x2.5-4b:latest");
+    CHECK(with_latest_tag("spark-x2.5-4b:q8") == "spark-x2.5-4b:q8");
+    CHECK(model_name_matches("spark-x2.5-4b", "spark-x2.5-4b"));
+    CHECK(model_name_matches("spark-x2.5-4b:latest", "spark-x2.5-4b"));
+    CHECK(model_name_matches("spark-x2.5-4b:anything", "spark-x2.5-4b"));
+    CHECK(model_name_matches("", "spark-x2.5-4b"));          // absent == the loaded model
+    CHECK(!model_name_matches("llama3.2", "spark-x2.5-4b"));
+
+    // ---- /api/tags ----
+    {
+        ModelEntry m;
+        m.name = "spark-x2.5-4b:latest"; m.model = m.name;
+        m.modified_at = "2026-09-09T20:00:00Z"; m.size = 4380000000LL; m.digest = "abc";
+        m.details.family = "spark2_5"; m.details.families = {"spark2_5"};
+        m.details.parameter_size = "4.1B"; m.details.quantization_level = "Q8_0";
+        const nlohmann::json j = tags_list({m});
+        CHECK(j.contains("models") && j["models"].is_array() && j["models"].size() == 1);
+        const auto& e = j["models"][0];
+        for (const char* k : {"name","model","modified_at","size","digest","details"}) CHECK(e.contains(k));
+        for (const char* k : {"parent_model","format","family","families","parameter_size","quantization_level"})
+            CHECK(e["details"].contains(k));
+        CHECK(e["details"]["format"] == "gguf");
+        CHECK(ps_list({m})["models"].size() == 1);
+        CHECK(tags_list({})["models"].is_array() && tags_list({})["models"].empty());
+    }
+
+    // ---- request translation: options -> OpenAI top level, stream forced false ----
+    {
+        const nlohmann::json in = {
+            {"model","spark-x2.5-4b"},
+            {"messages",{{{"role","user"},{"content","hi"}}}},
+            {"stream", true},                                  // must NOT survive
+            {"options", {{"temperature",0.2},{"top_p",0.9},{"num_predict",64},{"seed",7}}},
+        };
+        const nlohmann::json o = chat_request_to_openai(in);
+        CHECK(o["stream"] == false);
+        CHECK(o["max_tokens"] == 64);
+        CHECK(o["temperature"] == 0.2);
+        CHECK(o["top_p"] == 0.9);
+        CHECK(o["seed"] == 7);
+        CHECK(o["messages"].size() == 1);
+    }
+    // num_predict = -1 ("until context is full") has no OpenAI equivalent and must be DROPPED,
+    // not turned into a finite cap the caller never asked for.
+    {
+        const nlohmann::json in = {{"model","m"},{"messages",nlohmann::json::array()},
+                                   {"options",{{"num_predict",-1}}}};
+        CHECK(!chat_request_to_openai(in).contains("max_tokens"));
+    }
+    // format:"json" -> response_format
+    {
+        const nlohmann::json in = {{"model","m"},{"messages",nlohmann::json::array()},{"format","json"}};
+        CHECK(chat_request_to_openai(in)["response_format"]["type"] == "json_object");
+    }
+    {
+        const nlohmann::json in = {{"model","m"},{"messages",nlohmann::json::array()},
+                                   {"format",{{"type","object"}}}};
+        CHECK(chat_request_to_openai(in)["response_format"]["type"] == "json_schema");
+    }
+    // generate
+    {
+        const nlohmann::json in = {{"model","m"},{"prompt","hello"},{"options",{{"num_predict",8}}}};
+        const nlohmann::json o = generate_request_to_openai(in);
+        CHECK(o["prompt"] == "hello" && o["stream"] == false && o["max_tokens"] == 8);
+    }
+
+    // ---- durations are NANOSECONDS ----
+    CHECK(ms_to_ns(1.0) == 1000000LL);
+    CHECK(ms_to_ns(85.982577) == 85982577LL);
+    CHECK(ms_to_ns(0.0) == 0);
+    CHECK(ms_to_ns(-5.0) == 0);        // never emit a negative duration
+
+    // ---- chat response translation ----
+    {
+        const nlohmann::json oai = {
+            {"choices",{{{"index",0},{"finish_reason","stop"},
+                         {"message",{{"role","assistant"},{"content","OK"}}}}}},
+            {"usage",{{"prompt_tokens",21},{"completion_tokens",2},
+                      {"ttft_ms",82.11786},{"generation_ms",85.707905}}},
+        };
+        const nlohmann::json j = openai_to_chat_response(oai, "spark-x2.5-4b:latest", "2026-09-09T20:00:00Z");
+        CHECK(j["model"] == "spark-x2.5-4b:latest");
+        CHECK(j["message"]["role"] == "assistant");
+        CHECK(j["message"]["content"] == "OK");       // NOT choices[0].message.content
+        CHECK(j["done"] == true);
+        CHECK(j["done_reason"] == "stop");
+        CHECK(j["prompt_eval_count"] == 21);
+        CHECK(j["eval_count"] == 2);
+        CHECK(j["prompt_eval_duration"] == 82117860LL);
+        CHECK(j["eval_duration"] == 85707905LL);
+        CHECK(j["total_duration"] == ms_to_ns(82.11786 + 85.707905));
+        CHECK(j["load_duration"] == 0);               // model was loaded at startup, not per-request
+        CHECK(!j.contains("choices") && !j.contains("usage"));   // OpenAI shape must not leak
+    }
+    // finish_reason "length" -> done_reason "length"
+    {
+        const nlohmann::json oai = {{"choices",{{{"finish_reason","length"},
+                                     {"message",{{"content","x"}}}}}},{"usage",nlohmann::json::object()}};
+        CHECK(openai_to_chat_response(oai,"m","t")["done_reason"] == "length");
+    }
+    // an empty/degenerate OpenAI body must still produce a well-formed Ollama response
+    {
+        const nlohmann::json j = openai_to_chat_response(nlohmann::json::object(), "m", "t");
+        CHECK(j["done"] == true && j["message"]["content"] == "" && j["eval_count"] == 0);
+    }
+
+    // ---- generate response translation ----
+    {
+        const nlohmann::json oai = {
+            {"choices",{{{"index",0},{"finish_reason","length"},{"text"," Paris."}}}},
+            {"usage",{{"prompt_tokens",5},{"completion_tokens",3},
+                      {"ttft_ms",10.0},{"generation_ms",20.0}}}};
+        const nlohmann::json j = openai_to_generate_response(oai, "m:latest", "t");
+        CHECK(j["response"] == " Paris.");            // NOT choices[0].text
+        CHECK(j["done"] == true && j["done_reason"] == "length");
+        CHECK(j["eval_count"] == 3);
+        // "context" is opaque conversation state this server does not keep; fabricating one would
+        // invite the client to send it back as if it meant something.
+        CHECK(!j.contains("context"));
+    }
+
+    // ---- created_at is RFC3339 UTC ----
+    {
+        const std::string ts = rfc3339_now();
+        CHECK(ts.size() == 20);
+        CHECK(ts[4]=='-' && ts[7]=='-' && ts[10]=='T' && ts[13]==':' && ts[16]==':' && ts[19]=='Z');
+    }
+
+    std::printf("ollama_api_test: OK\n");
+    return 0;
+}


### PR DESCRIPTION
Splits the model-agnostic work off `feat/spark-x25-4b`, which keeps the Spark-X2.5 support that is not being merged.

## Server — two new API surfaces beside OpenAI `/v1`

**LM Studio `/api/v0/*`** — models (+`/{model}`), chat/completions with LM Studio's `stats`/`model_info`/`runtime` blocks, embeddings refused 501.

**Ollama `/api/*`** — version, tags, ps, show, chat, generate; embeddings and all model-management endpoints refused 501 with a reason rather than a bare 404.

Both **delegate to the same handlers `/v1` uses** and translate around them — there is no second implementation of generation, and `/v1` responses are byte-identical to before (asserted by test).

Streaming is genuinely incremental on all three surfaces. Every stream writer already funnelled through one function, so a per-request `StreamDialect` is applied there and the generation loop is untouched:

| dialect | framing |
|---|---|
| `OpenAiSse` | `data: {...}\n\n` — `/v1`, unchanged |
| `LmStudioSse` | same framing; usage chunk also carries `stats` |
| `OllamaNdjson` | `{...}\n` per line, message/done shape, no `[DONE]` |

Measured live: `/api/chat` 36 chunks spread 145–273 ms with one `done=true` carrying `eval_count`/`eval_duration`; `/api/v0` 38 chunks with `stats`; `/v1` 33 chunks, no `stats` leaked.

## Eval — three behaviour changes

**Auto-close narrowed to `REJECT` only, in both bots.** `none` means *this bot measured nothing on its axes*, which for a PR aimed at another model is the expected outcome, not a verdict. PR #1008 (a 15× Muse prefill win) was minutes from being auto-closed by the DSpark bot for exactly that reason. `REJECT` — a measured regression or a failed gate — still closes.

**Muse matrix 2 → 12 axes**: decode *and* prefill at 128/512/4k/16k/32k/64k, plus 32k no-regression guards on Qwen3.6 **and** the ModelOpt Qwen3.8 checkpoint. Schema bumped, so open PRs are re-scored rather than keeping two-dimension labels.

**Outage escalation** in both cron wrappers: a dead box degrades to `--labels-only` and exits 0, which logged one ordinary line and ran 14 consecutive times unnoticed on 2026-09-04/05. Now counted and escalated.

## Verification

Integration-tested against the **real clients** — official `ollama` CLI v0.33.3 via `OLLAMA_HOST`, and the OpenAI SDK 3.11.0 — not curl. That found six bugs curl could not, including a `nullptr` field that threw `type_error.302` and called `terminate()`, killing the whole server mid-stream, and an `/api/generate` mapping that returned HTTP 200 with unusable output. Each has a regression test naming the failure it prevents.

Clean build from scratch on this base; all server unit tests pass.

## Note for the maintainer

Only `server/` is evaluated by the bots — `eval/` and `bench/scripts/` are in `HARNESS_PATHS` and skipped. The eval changes above are already running from the local cron checkout; merging makes them the versioned truth.