### PR TITLE
fix(score): pass the scored token id by value, not through a raced device buffer

### DIFF
--- a/kernels/csrc/cuda/fused/topk_topp_ops.cu
+++ b/kernels/csrc/cuda/fused/topk_topp_ops.cu
@@ -86,6 +86,15 @@ __global__ void extract_chosen_logit_kernel(const int* __restrict__ out_id,
     if (threadIdx.x == 0 && blockIdx.x == 0) *chosen_logit = sorted_logits[rank_by_id[*out_id]];
 }
 
+// By-value id variant -- see launch_extract_chosen_logit_id in fused.h for why the device-buffer
+// form must not be used outside a captured graph.
+__global__ void extract_chosen_logit_id_kernel(int token_id,
+                                               const int* __restrict__ rank_by_id,
+                                               const float* __restrict__ sorted_logits,
+                                               float* __restrict__ chosen_logit) {
+    if (threadIdx.x == 0 && blockIdx.x == 0) *chosen_logit = sorted_logits[rank_by_id[token_id]];
+}
+
 // logits[v] -= frequency_penalty * counts[v] + presence_penalty * (counts[v] > 0 ? 1 : 0), for
 // every v in [0, vocab). OpenAI's exact presence/frequency-penalty formula (counts[v] = number of
 // times vocab id v has appeared in THIS request's generated completion so far, accumulated across
@@ -255,6 +264,13 @@ void launch_extract_chosen_logit(const int* out_id, const int* rank_by_id,
                                  const float* sorted_logits, float* chosen_logit,
                                  cudaStream_t stream) {
     extract_chosen_logit_kernel<<<1, 1, 0, stream>>>(out_id, rank_by_id, sorted_logits, chosen_logit);
+}
+
+void launch_extract_chosen_logit_id(int token_id, const int* rank_by_id,
+                                    const float* sorted_logits, float* chosen_logit,
+                                    cudaStream_t stream) {
+    extract_chosen_logit_id_kernel<<<1, 1, 0, stream>>>(token_id, rank_by_id, sorted_logits,
+                                                        chosen_logit);
 }
 
 void launch_presence_frequency_penalty(float* logits, const int* counts, int vocab,

--- a/kernels/include/sparkinfer/kernels/fused.h
+++ b/kernels/include/sparkinfer/kernels/fused.h
@@ -211,6 +211,24 @@ void launch_extract_chosen_logit(const int* out_id, const int* rank_by_id,
                                  const float* sorted_logits, float* chosen_logit,
                                  cudaStream_t stream = nullptr);
 
+// Same lookup for a token id the HOST already knows (teacher-forced scoring, /v1/score): the id
+// travels as a by-value kernel argument instead of through a device buffer.
+//
+// This exists because the device-buffer form is unsafe OUTSIDE a captured graph. Staging the id
+// with cudaMemcpy(..., cudaMemcpyHostToDevice) enqueues the write on the LEGACY DEFAULT stream,
+// while this kernel runs on Impl::stream, created with cudaStreamNonBlocking -- which by
+// definition does not serialize against the legacy stream. For a pageable source cudaMemcpy is
+// only "synchronous" in that it returns once the bytes are staged; the device-side write is still
+// queued. So the kernel could read the PREVIOUS id and report sorted_logits[rank_by_id[wrong id]]
+// -- a confident, wrong logprob for a token whose argmax and top_logprobs were both correct
+// (issue #1001: ~22 nats at position 1, where the stale id was the token scored just before).
+//
+// A kernel argument is copied into the launch command at launch time, so there is no second
+// stream and no ordering question. Prefer this form for any host-known id.
+void launch_extract_chosen_logit_id(int token_id, const int* rank_by_id,
+                                    const float* sorted_logits, float* chosen_logit,
+                                    cudaStream_t stream = nullptr);
+
 // OpenAI-style presence_penalty/frequency_penalty: logits[v] -= frequency_penalty*counts[v] +
 // presence_penalty*(counts[v]>0), for every v in [0,vocab). `counts` is the CURRENT session's
 // running per-vocab-id generation count (Qwen35Model::Impl::penalty_counts, already swapped in

--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -371,10 +371,12 @@ struct Qwen35Model::Impl {
     // by launch_extract_chosen_logit. See Qwen35Model::last_token_logprobs's doc comment.
     int* d_rank_by_id = nullptr;
     float* d_chosen_logit = nullptr;
-    // Device staging for token_logprob_for()'s arbitrary token id. The decode graph bakes
-    // d_out_id into its captured launch_extract_chosen_logit node, so a teacher-forced caller
-    // that wants some OTHER token's logit has to re-run that kernel against its own id buffer.
-    int* d_score_id = nullptr;
+    // NOTE: there is deliberately no device staging buffer for token_logprob_for()'s token id.
+    // The decode graph bakes d_out_id into its captured launch_extract_chosen_logit node, so a
+    // teacher-forced caller that wants some OTHER token's logit re-runs that kernel -- but it
+    // passes the id BY VALUE (launch_extract_chosen_logit_id). Staging it through a device buffer
+    // needs a host->device memcpy on the legacy default stream, which is unordered against
+    // s.stream (cudaStreamNonBlocking): the kernel could read the previous call's id. See #1001.
     // Deterministic-mode softmax normalizer (see launch_logprob_denom_det). 256 partials + total.
     float* d_denom_partials = nullptr;
     float* d_denom_det = nullptr;
@@ -619,7 +621,6 @@ Qwen35Model::Qwen35Model(const Qwen35Config& cfg, KVCacheManager* kv, moe::MoEEn
     // topk_topp_exp_kernel fully overwrites it every decode step before it is ever read.
     p_->d_rank_by_id=p_->alloc<int>(cfg.vocab);
     p_->d_chosen_logit=p_->alloc<float>(1);
-    p_->d_score_id=p_->alloc<int>(1);
     p_->d_denom_partials=p_->alloc<float>(256);
     p_->d_denom_det=p_->alloc<float>(1);
     p_->d_shared_ids=p_->alloc<int>(1); p_->d_shared_w=p_->alloc<float>(1);
@@ -794,7 +795,7 @@ Qwen35Model::~Qwen35Model() {
     cudaFree(p_->d_vocab_iota); cudaFree(p_->d_sorted_logits); cudaFree(p_->d_sorted_idx);
     cudaFree(p_->d_topk_exp); cudaFree(p_->d_topk_cumsum);
     cudaFree(p_->d_sort_temp); cudaFree(p_->d_scan_temp);
-    cudaFree(p_->d_rank_by_id); cudaFree(p_->d_chosen_logit); cudaFree(p_->d_score_id);
+    cudaFree(p_->d_rank_by_id); cudaFree(p_->d_chosen_logit);
     cudaFree(p_->d_denom_partials); cudaFree(p_->d_denom_det);
     cudaFree(p_->d_shared_ids); cudaFree(p_->d_shared_w);
     // Qwen3.6 Gated-DeltaNet buffers (allocated only for the hybrid model)
@@ -918,9 +919,16 @@ Qwen35Model::TokenLogprob Qwen35Model::token_logprob_for(int token_id, int top_n
     // instead of the argmax's. That keeps a teacher-forced score numerically IDENTICAL to what
     // /v1/chat/completions would report for the same token at the same position: same logits,
     // same fp32 logsumexp, same subtraction.
-    cudaMemcpy(s.d_score_id, &token_id, sizeof(int), cudaMemcpyHostToDevice);
-    kernels::launch_extract_chosen_logit(s.d_score_id, s.d_rank_by_id, s.d_sorted_logits,
-                                         s.d_chosen_logit, s.stream);
+    //
+    // The id travels as a by-value kernel ARGUMENT, never through a device buffer. Staging it
+    // with cudaMemcpy(..., HostToDevice) queues the write on the legacy default stream while this
+    // kernel runs on s.stream (cudaStreamNonBlocking), which does not serialize against it -- so
+    // the kernel could read the id from the PREVIOUS call and return the wrong token's logit,
+    // with the argmax and top_logprobs (which come from the sort, not from this lookup) still
+    // perfectly correct. That was issue #1001: ~22 nats of error at position 1 of every
+    // /v1/score, because the stale id was the token scored immediately before.
+    kernels::launch_extract_chosen_logit_id(token_id, s.d_rank_by_id, s.d_sorted_logits,
+                                            s.d_chosen_logit, s.stream);
     cu(cudaStreamSynchronize(s.stream), "token_logprob_for sync");
     out = last_token_logprobs(top_n);   // reads the d_chosen_logit we just rewrote
     out.token_id = token_id;            // ...whose token_id would otherwise be the argmax's

--- a/runtime/tests/logprob_extract_gpu_test.cpp
+++ b/runtime/tests/logprob_extract_gpu_test.cpp
@@ -206,6 +206,60 @@ bool test_logsumexp_hand_computed() {
     return ok;
 }
 
+// Teacher-forced scoring (/v1/score) path: launch_extract_chosen_logit_id takes the token id as a
+// by-value kernel ARGUMENT rather than through a device buffer, and must agree exactly with the
+// device-buffer form for every id.
+//
+// Regression guard for #1001. token_logprob_for() used to stage the id with a cudaMemcpy on the
+// legacy default stream and then launch the kernel on Impl::stream (cudaStreamNonBlocking), which
+// does not serialize against it -- so the kernel could read the PREVIOUS call's id and return a
+// confident, wrong logprob while the argmax and top_logprobs (which come from the sort, not from
+// this lookup) stayed correct. The by-value form has no second stream to race against.
+//
+// The loop below is the part that matters: it scores a SEQUENCE of different ids back to back on
+// one non-blocking stream, exactly as scoring a completion does. Under the old pattern that is
+// the shape that lets iteration i observe iteration i-1's id; here every value must be exact.
+bool test_chosen_logit_by_value_matches_device_buffer_form() {
+    const int vocab = 4096;
+    std::vector<float> logits(vocab);
+    for (int i = 0; i < vocab; i++) logits[i] = std::sin((float)i * 0.37f) * 40.0f;
+
+    Scratch s(vocab);
+    // Populate the sort/rank scratch once, the way a forward pass leaves it.
+    auto r = run_pipeline(s, logits, /*chosen_id=*/0);
+
+    cudaStream_t st = nullptr;
+    cudaStreamCreateWithFlags(&st, cudaStreamNonBlocking);
+
+    bool ok = true;
+    int checked = 0;
+    // Walk a run of distinct ids back to back, no sync between the id changing and the launch --
+    // the exact call shape /v1/score produces, one lookup per completion token.
+    for (int id = 1; id < vocab; id += 7) {
+        float got = 0.f;
+        sparkinfer::kernels::launch_extract_chosen_logit_id(id, s.rank_by_id, s.sorted_logits,
+                                                            s.chosen_logit, st);
+        cudaStreamSynchronize(st);
+        cudaMemcpy(&got, s.chosen_logit, sizeof(float), cudaMemcpyDeviceToHost);
+
+        const float want = r.sorted_logits[r.rank_by_id[id]];
+        if (got != want) {
+            printf("FAIL: by-value id=%d got %.6f, expected %.6f (rank %d)%s\n",
+                   id, got, want, r.rank_by_id[id],
+                   /* the signature of the old race: we saw the PREVIOUS id's logit */
+                   (id >= 8 && got == r.sorted_logits[r.rank_by_id[id - 7]]) ? "  <-- PREVIOUS id"
+                                                                            : "");
+            ok = false;
+            break;
+        }
+        checked++;
+    }
+    cudaStreamDestroy(st);
+    if (ok) printf("[OK] by-value chosen-logit matches the sorted/rank reference for %d "
+                   "back-to-back ids\n", checked);
+    return ok;
+}
+
 }  // namespace
 
 int main() {
@@ -220,6 +274,7 @@ int main() {
     ok = test_chosen_logit_matches_rank0_at_greedy() && ok;
     ok = test_chosen_logit_matches_arbitrary_nonzero_rank() && ok;
     ok = test_logsumexp_hand_computed() && ok;
+    ok = test_chosen_logit_by_value_matches_device_buffer_form() && ok;
     if (!ok) return 1;
     printf("logprob_extract_gpu_test: OK\n");
     return 0;


### PR DESCRIPTION
Refs #1001.

## What this fixes

`token_logprob_for()` — the teacher-forced lookup behind `POST /v1/score` — re-runs the
"which token did we pick" kernel pointed at the caller's token id instead of the argmax's.
It staged that id like this:

```cpp
cudaMemcpy(d_score_id, &token_id, sizeof(int), cudaMemcpyHostToDevice);   // legacy default stream
launch_extract_chosen_logit(d_score_id, d_rank_by_id, d_sorted_logits, d_chosen_logit, s.stream);
```

`s.stream` is created with `cudaStreamNonBlocking`, which by definition does **not** serialize
against the legacy default stream. For a pageable source `cudaMemcpy` is "synchronous" only in
that it returns once the bytes are staged — the device-side write is still queued. So the kernel
can read the **previous** call's id and return `sorted_logits[rank_by_id[wrong id]]`.

The asymmetry matters: `argmax` and `top_logprobs` come from the sort (`d_sorted_idx`) and stay
correct; only the scalar `logprob` goes through this lookup. Scoring position *i* with token
*i-1*'s id lands far down the sorted row — tens of nats — which is a confident, wrong number
rather than an obviously broken one. That is the failure shape #1001 reports.

## Evidence

A standalone reproduction of the pattern on this box (**RTX 5090, driver 595.84**):

```
legacy-default-stream memcpy vs non-blocking-stream kernel
  iterations : 20000
  mismatches : 1
  first bad  : iter 4295 wanted 4295 saw 4294   <-- read the PREVIOUS value
  verdict    : UNORDERED (pattern is unsafe)
```

The value observed was exactly the previous iteration's — the predicted failure mode, not
generic corruption.

## Honest limits of this evidence

**This is not confirmed to be the whole of #1001, and this PR does not close it.**

- The reported symptom did **not** reproduce here, on matching GPU, driver, NVFP4 ModelOpt
  checkpoint, `CTX=131072`, int8 KV, `SPARKINFER_DETERMINISTIC=1`, and even identical
  `prompt_tokens=23` — cold, warm, idle, under 56 concurrent completions, short and ~2k-token
  prompts. Every position matched generation.
- Follow-up runs of the standalone test gave 0 mismatches in 180k further iterations. The real
  rate here is roughly 1 in 10^4–10^5, which **cannot** produce #1001's every-call,
  same-value-on-repeat failure at position 1.

So: a proven data race with the right failure shape, but the wrong frequency. Fixed on its own
merits — a scoring endpoint exists to be compared numerically against another copy of itself, and
a silent, unchecked memcpy racing a kernel has no place in that path.

Two other candidate causes were ruled out with evidence, not reasoning:
- cross-job scratch clobbering — the engine runs a **single** worker thread;
- packed decode — `step_jobs_packed()` explicitly declines teacher-forced and logprob batches.

The elimination argument still points at the id: correct argmax ⇒ correct sort ⇒ correct
`rank_by_id` ⇒ the id reaching the lookup is wrong. On the reporting environment something makes
that happen every time.

## The change

The id travels as a **by-value kernel argument**. Arguments are copied into the launch at launch
time, so there is no second stream and no ordering question. `d_score_id` is deleted so the
pattern cannot be reintroduced against a buffer that still looks live.

## Verification

- `/v1/score` values **unchanged and correct** on the fixed build — Qwen3.8-27B-NVFP4, every
  position matching generation, cold/warm/idle/under-load/long-prompt.
- Full suite `27/27` with `-DBUILD_SERVER=ON`.
- New regression subtest walks 585 distinct ids back to back on a non-blocking stream — the shape
  scoring a completion produces — and names the old failure signature ("PREVIOUS id") in its
  failure message.
