### PR TITLE
perf(muse): run the 16:1 GQA decode attention on the int8 tensor cores (1.18x decode@64k)

### DIFF
--- a/kernels/csrc/cuda/attention/flash_decode_split.cu
+++ b/kernels/csrc/cuda/attention/flash_decode_split.cu
@@ -906,6 +906,14 @@ template __global__ void fa_combine_gated_q8_kernel<256, FA_COMBINE_DG, 16>(
 template <int HEAD_DIM, int GQA> struct fa_mma_block_threads { static constexpr int v = GQA * 32; };
 template <> struct fa_mma_block_threads<256, 4> { static constexpr int v = 256; };
 template <> struct fa_mma_block_threads<256, 6> { static constexpr int v = 256; };
+// The 16:1 group (Muse Glimmer) also pins 8 warps. The block width here is NOT the q-head count:
+// every loop below is written for exactly 8 warps -- Q quantize gives each warp rows 2w and 2w+1
+// to cover the wmma's 16 M rows, the KV loop walks 8 physical blocks per pass with one warp each
+// (s_ks/s_vs are sized [128] = 8*16 for that), and the PV store lays 8 warps across a 128-wide
+// slab. GQA*32 would be 16 warps and would run all three off the end of those buffers. Taking 256
+// also keeps __launch_bounds__(.., 5) legal: 5*256 = 1280 threads/SM against the 2048 limit, where
+// 5*512 = 2560 is what kept this group off the tensor cores.
+template <> struct fa_mma_block_threads<128, 16> { static constexpr int v = 256; };
 
 // Tensor-core (wmma int8) GQA flash-decode split for long context. The 8 GQA q-heads of a kv-head are
 // the batch (M) dim, so S = Q·Kᵀ and O = P·V become small matmuls on the tensor cores, replacing the
@@ -1095,6 +1103,15 @@ __global__ void __launch_bounds__(fa_mma_block_threads<HEAD_DIM, GQA>::v, 5) fa_
 }
 #ifndef _MSC_VER
 template __global__ void fa_split_gqa_mma_i8_kernel<128, 8>(const __nv_bfloat16*, const signed char*,
+    const signed char*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int,
+    const __half*, const __half*);
+#endif
+// Muse Glimmer's 16:1 group. This is the one shape where the wmma M tile is FULLY live: the kernel
+// pads M to 16 regardless, so GQA=8 spends half of every QK/PV mma on padding rows that are then
+// discarded, while GQA=16 fills all sixteen with real q-heads. Same 8 warps and the same KV walk,
+// so the 436 MB the 13 global layers read at 64k is read once for twice the useful work.
+#ifndef _MSC_VER
+template __global__ void fa_split_gqa_mma_i8_kernel<128, 16>(const __nv_bfloat16*, const signed char*,
     const signed char*, const int*, const int*, float*, float*, float*, float, int, int, int, int, int,
     const __half*, const __half*);
 #endif
@@ -1659,25 +1676,49 @@ void launch_flash_decode_split(
     // 16:1 GQA (Muse Glimmer, 32Q/2KV). Same shared-KV tile as the 8:1 branch below: one block per
     // (kv_head, split) stages the K/V tile once and all GQA warps reuse it, instead of one block per
     // q-head each re-reading it. Warp count doubles to 16 (512 threads) and the tile smem is
-    // unchanged, so the block is wider but reads 16x less KV. The int8 MMA sub-branch is NOT taken
-    // here: its __launch_bounds__ asks for 5 blocks/SM, which at 512 threads would demand 2560
-    // threads per SM against a 2048 limit. SPARKINFER_FAGQA16=0 restores the per-q-head kernel.
+    // unchanged, so the block is wider but reads 16x less KV. SPARKINFER_FAGQA16=0 restores the
+    // per-q-head kernel.
+    //
+    // The int8 MMA sub-branch WAS unreachable here, for an occupancy reason rather than a
+    // correctness one: __launch_bounds__(GQA*32, 5) at 512 threads asks for 2560 threads/SM against
+    // a 2048 limit. But GQA is the wmma M dim, not the block width -- the kernel is written for 8
+    // warps at any GQA (hd256 already pins 256 threads at GQA 4 and 6 for the same reason), so
+    // fa_mma_block_threads<128,16> takes 256 and 5*256 = 1280 fits. SPARKINFER_FAGQA16_MMA=0 keeps
+    // the tile kernel for a same-binary A/B.
     static int fagqa16 = -1;
     if (fagqa16 < 0) { const char* e = getenv("SPARKINFER_FAGQA16"); fagqa16 = (e && e[0] == '0') ? 0 : 1; }
+    static int fagqa16_mma = -1;
+    if (fagqa16_mma < 0) { const char* e = getenv("SPARKINFER_FAGQA16_MMA"); fagqa16_mma = (e && e[0] == '0') ? 0 : 1; }
     if (use_gqa && fagqa16 && num_kv_heads > 0 && num_q_heads == num_kv_heads * 16) {
         constexpr int GQA = 16, TILE = FA_GQA_TILE;
+        constexpr int MMA_THREADS = fa_mma_block_threads<128, GQA>::v;
         dim3 gq(num_kv_heads * n_splits, num_seqs);
-        const size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
-        if (int8_kv)
-            fa_split_gqa_kernel<128, GQA, TILE, true><<<gq, GQA * 32, smem, stream>>>(
-                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+        if (mma_aligned && int8_kv && fagqa16_mma) {
+            // Same tensor-core split the 8:1 group takes, on 8 warps (see fa_mma_block_threads
+            // <128,16>). The tile kernel above already reads each KV byte once per group; what this
+            // adds is the QK/PV dot on the int8 tensor cores instead of per-lane FMA plus the
+            // 5-shuffle reduction, and at 16:1 it does that with no wasted M rows.
+            const size_t i8_smem = (size_t)2 * 16 * 128 * sizeof(signed char)
+                                 + (size_t)(16 + GQA) * 128 * sizeof(float)   // s_s[16][HD] + s_o[GQA][HD]
+                                 + (size_t)(16 + 16 + 128 + 128 + 16 + 16) * sizeof(float);
+            fa_split_gqa_mma_i8_kernel<128, GQA><<<gq, MMA_THREADS, i8_smem, stream>>>(
+                reinterpret_cast<const __nv_bfloat16*>(q), reinterpret_cast<const signed char*>(k_pool),
+                reinterpret_cast<const signed char*>(v_pool), block_table, seq_lens,
                 part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
                 ksc, vsc);
-        else
-            fa_split_gqa_kernel<128, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
-                reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
-                part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
-                ksc, vsc);
+        } else {
+            const size_t smem = (size_t)2 * TILE * 128 * sizeof(__nv_bfloat16);
+            if (int8_kv)
+                fa_split_gqa_kernel<128, GQA, TILE, true><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    ksc, vsc);
+            else
+                fa_split_gqa_kernel<128, GQA, TILE, false><<<gq, GQA * 32, smem, stream>>>(
+                    reinterpret_cast<const __nv_bfloat16*>(q), k_pool, v_pool, block_table, seq_lens,
+                    part_m, part_l, part_acc, scale, num_q_heads, num_kv_heads, block_size, max_blocks, n_splits,
+                    ksc, vsc);
+        }
         if (cudaPeekAtLastError() != cudaSuccess) goto fa_gqa16_fallthrough;
         if (gate128)
             fa_launch_combine_gated_dispatch(part_m, part_l, part_acc, reinterpret_cast<__nv_bfloat16*>(out),


### PR DESCRIPTION
## Summary

Muse Glimmer's 32Q/2KV attention reaches the shared-KV decode tile but never the int8
tensor-core split. That was an occupancy conflict, not a correctness one:
`__launch_bounds__(GQA*32, 5)` asks for 2560 threads/SM at 512 threads against a 2048 limit.

GQA is the wmma **M** dimension, not the block width — every loop in that kernel is written for
exactly 8 warps (the Q quantize gives each warp rows `2w`/`2w+1` to fill the 16 M rows, the KV
loop walks 8 physical blocks one per warp with `s_ks`/`s_vs` sized `[128]` for it, and the PV
store lays 8 warps across a 128-wide slab). hd256 already pins 256 threads at GQA 4 and 6 for the
same reason, so `fa_mma_block_threads<128,16>` takes 256 and the bounds are legal at 1280
threads/SM. 16 warps would have run all three of those loops past the end of their buffers.

16:1 is the shape this kernel wants: M is padded to 16 regardless, so at 8:1 half of every QK/PV
mma is padding that gets discarded, while at 16:1 all sixteen rows are real q-heads — the same KV
bytes for twice the useful work.

At 64k the 13 global (NoPE) layers move 477 MB of int8 KV per token; the attention was 2.46 ms of
a 12.0 ms step, ~194 GB/s.

`SPARKINFER_FAGQA16_MMA=0` restores the tile kernel for a same-binary A/B.

**Correctness.** Not bit-identical (Q and P' are quantized per row for the tensor cores), so it is
measured teacher-forced over a 4096-token in-distribution sequence: PPL 1.04421 → 1.04148, top-1
4037/4095 → 4039/4095. Prefill is unchanged at every context, and decode at 128/512 is within
0.3% of main over three alternating runs (main's own round-to-round drift is 0.5%).

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (median of 5, one model load, same binary):

| ctx | before | after |
|---|--:|--:|
| 4096 | 100.05 | 102.27 |
| 16384 | 96.46 | 101.51 |
| 32768 | 91.61 | 100.13 |
| 65536 | 83.32 | 98.19 |

**Prefill pp tok/s**: not claimed — this PR targets decode. Prefill measures within ±0.8% at
every context, which is run-to-run noise on this box; the full sweep is in the block below.

```text
# qwen3_gguf_bench sweep, Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf, reps=5, RTX 5090
SPARKINFER_FAGQA16_MMA=0   (tile kernel == main)
{"128":{"decode_tps":105.5185,"prefill_pp":7612.8246},"512":{"decode_tps":104.6587,"prefill_pp":10104.4773},
 "4096":{"decode_tps":100.0541,"prefill_pp":13570.9859},"16384":{"decode_tps":96.4623,"prefill_pp":10675.9088},
 "32768":{"decode_tps":91.6074,"prefill_pp":9592.6552},"65536":{"decode_tps":83.3225,"prefill_pp":8070.2403}}

SPARKINFER_FAGQA16_MMA=1   (int8 tensor-core split)
{"128":{"decode_tps":103.6117,"prefill_pp":7591.5720},"512":{"decode_tps":103.2339,"prefill_pp":10081.3720},
 "4096":{"decode_tps":102.2705,"prefill_pp":13465.1655},"16384":{"decode_tps":101.5145,"prefill_pp":10702.0928},
 "32768":{"decode_tps":100.1277,"prefill_pp":9643.8584},"65536":{"decode_tps":98.1887,"prefill_pp":8101.8129}}

# 128/512 head-to-head, separate main and PR binaries, alternating, reps=5
r1 main 128=106.5095 512=105.4912   /   r1 pr 128=106.1462 512=105.3526
r2 main 128=106.0891 512=105.3146   /   r2 pr 128=105.9510 512=105.2649
r3 main 128=105.9656 512=105.2249   /   r3 pr 128=105.9503 512=105.2822

# teacher-forced accuracy, 4096-token in-distribution sequence
MMA=0: PPL 1.04421  ARGMATCH 4037/4095 0.9858
MMA=1: PPL 1.04148  ARGMATCH 4039/4095 0.9863
```