### PR TITLE
perf(muse): give the 16:1 GQA group its whole kv-head in the prefill attention (1.16x prefill@64k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -1262,6 +1262,45 @@ bool launch_prefill_attn_mma_muse_hd128(
     if (n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0) return false;
     if (n_q_heads % 4 != 0) return false;                  // RQH=4 owns 4 q-heads per block
     if ((n_q_heads / n_kv_heads) % 4 != 0) return false;   // ...all sharing one kv-head
+    // A block stages one kv-head's K/V tile and feeds it to RQH q-heads, so the group's K/V is
+    // re-read (GQA / RQH) times per query tile. Muse Glimmer is 16:1 -- the widest group in the
+    // tree -- and at RQH=4 that is four passes over the same keys. Widening it is what the rolling
+    // score plane (PLANES) exists for: it holds PLANES heads at a time instead of RQH, so the
+    // plane stops being what caps RQH.
+    //
+    // But RQH also DIVIDES the grid: blocks = ceil(n/BM) * (n_q_heads/RQH). A short prompt has few
+    // query tiles, so widening the group empties the machine -- at n=128 RQH=16 leaves 16 blocks
+    // for 170 SMs. Measured on Muse Glimmer, prefill pp against the RQH=4 default:
+    //
+    //     n      128     512    4096   16384   32768   65536
+    //     RQH16 -11.7%  -7.3%  +2.8%  +5.8%   +9.6%  +15.6%
+    //
+    // So take the widest group that still fills the device, and keep the shipped shape below that.
+    // Two waves of blocks is the threshold that separates the measured win from the measured loss.
+    // Bit-identical either way: RQH changes only how many heads share a staged tile, not the
+    // per-row arithmetic or its order (verified at prefix=4096: TOP1 11/16, KL 0.04134, seed 220
+    // on both).
+    const int gqa = n_q_heads / n_kv_heads;
+    int sms = 0;
+    if (cudaDeviceGetAttribute(&sms, cudaDevAttrMultiProcessorCount, 0) != cudaSuccess || sms <= 0)
+        sms = 1;
+    const long tiles  = (n_tokens + 15) / 16;
+    const long want   = 2L * sms;
+    auto fills = [&](int rqh) { return tiles * (long)(n_q_heads / rqh) >= want; };
+    // Descending, and NEVER falling through to the caller's scalar path on a refusal: an
+    // over-budget shape costs ~4x (measured: the 113 KB RQH=16/PLANES=4 shape drops 11667 -> 2677
+    // pp because the smem opt-in fails and no mma tier runs at all). A refusal here just tries the
+    // next narrower tier, and RQH=4 is the shape that ships today.
+    #define MUSE_ATTN_TIER(RQH, PL)                                                               \
+        if (gqa % (RQH) == 0 && n_q_heads % (RQH) == 0 && fills(RQH) &&                           \
+            launch_attn_gqa<128, 8, (RQH), (PL), false, false, 1, false>(                         \
+                q, k_pool, v_pool, k_scale, v_scale, block_table, attn, n_tokens, n_q_heads,      \
+                n_kv_heads, block_size, max_blocks_per_seq, scale, win_blocks, stream, q_pos0))   \
+            return true;                                                                          \
+        cudaGetLastError();   /* a refused opt-in must not poison the next tier's peek */
+    MUSE_ATTN_TIER(16, 2)
+    MUSE_ATTN_TIER(8, 2)
+    #undef MUSE_ATTN_TIER
     return launch_attn_gqa<128, /*GROUP_BLKS=*/8, /*RQH=*/4, /*PLANES=*/0,
                            /*VT=*/false, /*WIDEK=*/false, /*PVU=*/1, /*SINK=*/false>(
         q, k_pool, v_pool, k_scale, v_scale, block_table, attn, n_tokens, n_q_heads, n_kv_heads,


### PR DESCRIPTION
## Summary

One block of the tensor-core prefill attention stages a kv-head's K/V tile and feeds it to `RQH`
q-heads, so the group's keys are re-read `GQA / RQH` times per query tile. Muse Glimmer is 32Q/2KV
— a 16:1 group — against `RQH=4`, so every key is read four times.

Widening it is what the rolling score plane exists for: `PLANES` holds that many heads at a time
instead of `RQH`, so the plane stops being what caps `RQH`. At `<128, RQH=16, PLANES=2>` the block
takes 96,256 B, where `RQH=16` with a full plane would need 302 KB.

`RQH` also divides the grid — `blocks = ceil(n/BM) * (n_q_heads/RQH)` — so a short prompt has too
few query tiles to fill the device once the group is wide (at n=128, `RQH=16` leaves 16 blocks for
170 SMs). So this takes the widest group that still covers the machine twice over, and keeps the
shipped shape below that.

**Bit-identical.** `RQH` changes which heads share a staged tile, not the per-row arithmetic or the
order it accumulates in — `qwen3_gguf_prefill_check` at prefix=4096 returns TOP1 11/16, KL 0.04134,
seed 220 on both. Below the batched verify's `seqlen > 512` the tensor-core tier is not armed at
all, so 128 and 512 run main's path untouched.

**The tiers step down rather than out.** An over-budget shape fails the smem opt-in and the caller
is then left with no mma tier and drops to the scalar kernel: the 113 KB `<128,16,PLANES=4>` shape
measures 2677 pp against 11667 at ctx=16384. A refused tier now tries the next narrower one, ending
at the `RQH=4` shape that ships today, and the last error is cleared between tiers so a refusal
cannot poison the next tier's launch check. `SPARKINFER_PREFILL_ATTN_TIER=1` prints the tier that
actually launched.

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (main binary vs this branch, same box, ctx=65536):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 8037.73 |
| after prefill (this PR) | 9329.52 |

**Decode tok/s**: not claimed — this PR targets prefill. Decode measures 98.2939 → 98.3283 tok/s at
ctx=65536, i.e. unchanged; the full numbers are in the block below.

```text
# main vs this branch, same box, SWEEP_REPS=3
main {"65536":{"decode_tps":98.2939,"prefill_pp":8037.7262}}
pr   {"65536":{"decode_tps":98.3283,"prefill_pp":9329.5155}}     1.161x prefill

# fixed-shape A/B in ONE binary (SWEEP_REPS=5), RQH=16 vs the RQH=4 default
                4096      16384     32768     65536
  RQH=4      13563.85   10718.79   9627.18   8046.32
  RQH=16     13944.25   11338.52  10549.85   9299.58
              +2.8%      +5.8%     +9.6%    +15.6%

# shape sweep at ctx=16384, one binary
  RQH=2  PLANES=0  smem=27264  11009.10
  RQH=4  PLANES=0  smem=54016  11113.71   <- shipped
  RQH=4  PLANES=2  smem=37120  11227.39
  RQH=8  PLANES=2  smem=56832  11568.21
  RQH=16 PLANES=2  smem=96256  11666.84
  RQH=16 PLANES=4  smem=113152  2677.33   <- over budget, falls to the scalar kernel

# tier actually launched, this branch
  n=4096   [pf-attn-tier] RQH=16 SPL=2 GB=8 GN=128 smem=96256 ok=1
  n=65536  [pf-attn-tier] RQH=16 SPL=2 GB=8 GN=128 smem=96256 n=16384 ok=1
  n=128 / n=512: no tier armed (seqlen>512 gate), main's path

# bit-identity, qwen3_gguf_prefill_check prefix=4096 SPARKINFER_KV_INT8=0
  RQH=4 : TOP1 11/16 0.6875  KL 0.04134  seed(batched)=220
  RQH=16: TOP1 11/16 0.6875  KL 0.04134  seed(batched)=220
```
