### PR TITLE
perf(muse): stage ffn_down's NVFP4 conversion in slices so it reaches 16k/32k (1.22x prefill@16k)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_nvfp4.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4.cu
@@ -15,6 +15,8 @@ bool launch_prefill_nvfp4_gate_quant_a(const void*, const void*, void*, void*, i
 bool launch_prefill_nvfp4_swiglu_quant_a(const void*, const void*, void*, void*, int, int,
                                          cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_quant_b(const void*, void*, void*, int, int, cudaStream_t) { return false; }
+bool launch_prefill_nvfp4_quant_b_slice(const void*, void*, void*, int, int, int, int,
+                                        cudaStream_t) { return false; }
 bool launch_prefill_nvfp4_gemm(const void*, const void*, const void*, const void*, void*, int, int,
                                int, void*, cudaStream_t, float) { return false; }
 bool launch_ct_nvfp4_pack_sfb(const void*, void*, int, int, cudaStream_t) { return false; }

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -212,7 +212,8 @@ auto sfb_layout(int m, int n, int k) { return ScaleConfig::tile_atom_to_shape_SF
 // x / float(qs) rounding. LPV is a template parameter only so the two can be A/B'd in one binary.
 template <int LPV, class Layout>
 __global__ void quant_rows_t(const __nv_bfloat16* src, unsigned char* dst,
-                             cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout) {
+                             cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout,
+                             int n0) {
     constexpr int V = 16;
     constexpr int VPL = V / LPV;      // values per lane
     constexpr int GPW = 32 / LPV;     // scale groups per warp
@@ -255,8 +256,11 @@ __global__ void quant_rows_t(const __nv_bfloat16* src, unsigned char* dst,
         #pragma unroll
         for (int i = 0; i < VPL / 2; i++) dst[(base >> 1) + i] = packed[i];
         if (sub == 0) {
+            // `layout` describes the WHOLE operand and `n0` is this launch's first row in it, so a
+            // row-sliced call writes exactly the bytes the whole-operand call would have written
+            // for those rows -- the slicing is invisible to the GEMM that reads it.
             auto scales = cute::make_tensor(sf, layout);
-            scales(row, k0, 0) = qs;
+            scales(n0 + row, k0, 0) = qs;
         }
     }
 }
@@ -298,11 +302,11 @@ inline int nvfp4_quant_lpv(int rows) {
 }
 template <class Layout>
 void quant_rows_dispatch(int blocks, cudaStream_t st, const __nv_bfloat16* src, unsigned char* dst,
-                         cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout) {
+                         cutlass::float_ue4m3_t* sf, int rows, int cols, Layout layout, int n0) {
     switch (nvfp4_quant_lpv(rows)) {
-        case 8:  quant_rows_t<8><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout); break;
-        case 4:  quant_rows_t<4><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout); break;
-        default: quant_rows_t<2><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout); break;
+        case 8:  quant_rows_t<8><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout,n0); break;
+        case 4:  quant_rows_t<4><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout,n0); break;
+        default: quant_rows_t<2><<<blocks,256,0,st>>>(src,dst,sf,rows,cols,layout,n0); break;
     }
 }
 
@@ -583,7 +587,7 @@ bool launch_prefill_nvfp4_quant_a(const void* s, void* d, void* sf, int m, int k
     auto l = sfa_layout(m,128,k);
     int blocks = (m * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
     quant_rows_dispatch(blocks,st,(const __nv_bfloat16*)s,(unsigned char*)d,
-                        (cutlass::float_ue4m3_t*)sf,m,k,l);
+                        (cutlass::float_ue4m3_t*)sf,m,k,l,0);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_rmsnorm_quant_a(const void* s, const void* w, void* d, void* sf,
@@ -625,7 +629,27 @@ bool launch_prefill_nvfp4_quant_b(const void* s, void* d, void* sf, int n, int k
     auto l = sfb_layout(128,n,k);
     int blocks = (n * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
     quant_rows_dispatch(blocks,st,(const __nv_bfloat16*)s,(unsigned char*)d,
-                        (cutlass::float_ue4m3_t*)sf,n,k,l);
+                        (cutlass::float_ue4m3_t*)sf,n,k,l,0);
+    return cudaPeekAtLastError() == cudaSuccess;
+}
+// Rows [n0, n0+rows) of an `n`-row B operand, quantized from a bf16 buffer holding ONLY those
+// rows. `d` and `sf` are the whole operand: the data offset is exact (n0 is a multiple of the
+// 32x4 = 128-row scale-factor atom, so n0*k nibbles are a whole number of bytes) and the scale
+// layout is the whole-operand one, indexed at n0+row. Every byte written is the byte the
+// whole-operand call would have written there, so a full sweep of slices is bit-identical to it.
+//
+// The point is the CALLER's staging buffer: the bf16 source is a pure intermediate between a
+// dequant and this quantize, so it never has to hold more than one slice, while only the FP4
+// operand -- a quarter the size -- has to be whole.
+bool launch_prefill_nvfp4_quant_b_slice(const void* s, void* d, void* sf, int n, int n0, int rows,
+                                        int k, cudaStream_t st) {
+    if (!s || !d || !sf || !prefill_nvfp4_supported(128,n,k)) return false;
+    if (n0 < 0 || rows <= 0 || n0 > n - rows || (n0 & 127) || (rows & 127)) return false;
+    auto l = sfb_layout(128,n,k);
+    int blocks = (rows * (k / 16) + 31) / 32; if (blocks > 4096) blocks = 4096;
+    quant_rows_dispatch(blocks,st,(const __nv_bfloat16*)s,
+                        (unsigned char*)d + (((size_t)n0 * k) >> 1),
+                        (cutlass::float_ue4m3_t*)sf,rows,k,l,n0);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 size_t prefill_nvfp4_workspace_bytes_f32(int m, int n, int k) {

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -29,6 +29,13 @@ bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_b
                                          int m, int k, cudaStream_t stream = nullptr);
 bool launch_prefill_nvfp4_quant_b(const void* src_bf16, void* dst_fp4, void* dst_sf,
                                   int n, int k, cudaStream_t stream = nullptr);
+// Rows [n0, n0+rows) of the same `n`-row operand, read from a bf16 buffer holding ONLY those rows
+// and written into the whole-operand dst_fp4/dst_sf. n0 and rows must be multiples of the 128-row
+// scale-factor atom. A full sweep of slices is bit-identical to the whole-operand call above, so
+// the caller's bf16 staging never has to be larger than one slice.
+bool launch_prefill_nvfp4_quant_b_slice(const void* src_bf16, void* dst_fp4, void* dst_sf,
+                                        int n, int n0, int rows, int k,
+                                        cudaStream_t stream = nullptr);
 // c_bf16 is the epilogue's source operand: non-null makes this compute
 // D = alpha*(A*B) + C instead of D = alpha*(A*B), which is how a residual add is
 // folded into the block-scaled GEMM rather than run as a separate full-tensor pass.

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -843,20 +843,61 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     // that uses it. That second half is not a tidiness point: at max_seq 65536 the session has
     // essentially no spare VRAM, and 341 MB held across a 64k prefill costs 85% of it -- measured
     // with the buffers allocated and never read, so it is the footprint alone, not this path.
-    // Hence a band. Below dn_min the fixed ~31 ms of conversion (52 layers) swamps a prefill that
-    // only takes ~36 ms; above dn_max the scratch cannot be spared beside a long-context KV cache.
+    // Hence a floor: below dn_min the fixed conversion cost (52 layers) swamps a prefill that only
+    // takes ~36 ms.
+    //
+    // There used to be a CEILING as well, at 8192, and it was the 265.8 MB bf16 staging that put it
+    // there -- 78% of that 341 MB. But the staging is a pure INTERMEDIATE: launch_gguf_dequant
+    // fills it and the quantizer drains it in the very next launch, and nothing reads it again.
+    // Only the FP4 operand (74.8 MB + its scale factors) is what the GEMM needs held. So the
+    // conversion runs a SLICE of the output rows at a time -- dequant those rows, quantize those
+    // rows into their place in the whole operand -- and the staging shrinks to one slice.
+    //
+    // 32 MB of staging (768 rows at Muse's 19968-wide FFN) puts the whole conversion at ~113 MB
+    // instead of 341 MB, which is what lets the band cover 16k/32k/64k. The slice boundary is a
+    // multiple of 128 rows -- the NVFP4 scale-factor atom is 32x4 = 128 rows in N -- so each slice
+    // writes exactly the bytes the whole-operand call wrote there and the operand is bit-identical.
+    // H is a multiple of 128 on this path (prefill_nvfp4_supported checks n & 127), so the tail
+    // slice is aligned too.
+    //
+    // The ceiling is now the allocator's to set, not a constant's: the three cudaMallocs are taken
+    // before the batched-prefill arena, so if a long-context KV cache really has left no room the
+    // conversion declines and the layer keeps today's int8 path. That is the same decline the
+    // partial-failure branch below already handled -- it just stops triggering 4x sooner.
     static const int dn_min = [] {
         const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN_MINN"); return e ? atoi(e) : 1024;
     }();
     static const int dn_max = [] {
-        const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN_MAXN"); return e ? atoi(e) : 8192;
+        const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN_MAXN"); return e ? atoi(e) : (1 << 30);
     }();
     static const bool dn_stream_on = [] {
         const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN_STREAM"); return !(e && e[0] == '0');
     }();
+    // Bytes of bf16 staging to hold at once. SPARKINFER_MUSE_NVFP4_DOWN_STAGEMB=0 restores the
+    // whole-layer staging this shipped with (A/B in ONE binary, and the old 341 MB with it).
+    static const long dn_stage_mb = [] {
+        const char* e = getenv("SPARKINFER_MUSE_NVFP4_DOWN_STAGEMB");
+        const long v = e ? atol(e) : 32;
+        return (v < 0) ? 32 : v;
+    }();
+    // Quantized bytes in one `cols`-long GGUF row, so a row slice can be read from the middle of
+    // the tensor. 0 = a type this cannot offset into, which keeps the whole-layer staging.
+    auto dn_q_row_bytes = [](int qtype, int cols) -> size_t {
+        switch (qtype) {
+            case 0:  return (size_t)cols * 4;                                  // F32
+            case 1:  return (size_t)cols * 2;                                  // F16
+            case 8:  return (cols & 31) ? 0 : (size_t)(cols >> 5) * 34;        // Q8_0
+            case 12: return (cols & 255) ? 0 : (size_t)(cols >> 8) * 144;      // Q4_K
+            case 13: return (cols & 255) ? 0 : (size_t)(cols >> 8) * 176;      // Q5_K
+            case 14: return (cols & 255) ? 0 : (size_t)(cols >> 8) * 210;      // Q6_K
+            default: return 0;
+        }
+    };
     // Frees on every exit path, including the two mid-function declines.
     struct DownFp4Scratch {
         void* tmp = nullptr; void* data = nullptr; void* sf = nullptr;
+        int rows = 0;                 // output rows staged at once; H = the whole layer
+        size_t row_bytes = 0;         // quantized bytes per row, for the sliced source offset
         ~DownFp4Scratch() {
             if (tmp) cudaFree(tmp);
             if (data) cudaFree(data);
@@ -865,7 +906,19 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     } dn_scratch;
     if (muse_nvfp4 && !s.w.layers[0].down_fp4 && dn_stream_on && N >= dn_min && N <= dn_max &&
         kernels::prefill_nvfp4_supported(N, H, ffn)) {
-        const size_t need_tmp = (size_t)H * ffn * sizeof(bf16);
+        const size_t rb = dn_q_row_bytes(s.w.layers[0].down_qtype, ffn);
+        int sr = H;
+        if (dn_stage_mb > 0 && rb) {
+            const size_t budget = (size_t)dn_stage_mb << 20;
+            const size_t per_row = (size_t)ffn * sizeof(bf16);
+            size_t r = budget / per_row;
+            r &= ~(size_t)127;                          // whole scale-factor atoms only
+            if (r < 128) r = 128;
+            if (r < (size_t)H) sr = (int)r;
+        }
+        dn_scratch.rows = sr;
+        dn_scratch.row_bytes = rb;
+        const size_t need_tmp = (size_t)sr * ffn * sizeof(bf16);
         if (cudaMalloc(&dn_scratch.tmp, need_tmp) != cudaSuccess) dn_scratch.tmp = nullptr;
         if (dn_scratch.tmp &&
             cudaMalloc(&dn_scratch.data, kernels::prefill_nvfp4_data_bytes(H, ffn)) != cudaSuccess)
@@ -2012,10 +2065,25 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             const void* dn_fp4    = w.down_fp4;
             const void* dn_fp4_sf = w.down_fp4_sf;
             if (!dn_fp4 && nvfp4_down && ffn_fp4_possible && dn_scratch.sf && w.down_q) {
-                kernels::launch_gguf_dequant(w.down_qtype, w.down_q,
-                                             (bf16*)dn_scratch.tmp, (long)H * ffn, st);
-                if (kernels::launch_prefill_nvfp4_quant_b(dn_scratch.tmp, dn_scratch.data,
-                                                          dn_scratch.sf, H, ffn, st)) {
+                // Row slices of the output, dequant then quantize, so the bf16 staging only ever
+                // holds dn_scratch.rows of them. The slices are ordered on `st` behind each other
+                // and ahead of the GEMMs that read the operand, so one staging buffer is correct.
+                // The stride is THIS layer's, not layer 0's: the staging was sized from layer 0
+                // but a layer that quantized differently would offset differently, so a slice
+                // sweep only runs when this layer's own row stride is known.
+                const size_t rb = dn_q_row_bytes(w.down_qtype, ffn);
+                const int sr = dn_scratch.rows;          // never wider than the staging buffer
+                bool dn_ok = sr > 0 && (sr >= H || rb != 0);
+                for (int r0 = 0; r0 < H && dn_ok; r0 += sr) {
+                    const int nr = (H - r0 < sr) ? (H - r0) : sr;
+                    kernels::launch_gguf_dequant(
+                        w.down_qtype,
+                        static_cast<const unsigned char*>(w.down_q) + (size_t)r0 * rb,
+                        (bf16*)dn_scratch.tmp, (long)nr * ffn, st);
+                    dn_ok = kernels::launch_prefill_nvfp4_quant_b_slice(
+                        dn_scratch.tmp, dn_scratch.data, dn_scratch.sf, H, r0, nr, ffn, st);
+                }
+                if (dn_ok) {
                     dn_fp4 = dn_scratch.data;
                     dn_fp4_sf = dn_scratch.sf;
                 }


### PR DESCRIPTION
## Summary

#1014's FP4 `ffn_down` operand is capped at 8192 tokens because its conversion holds 341 MB, which cannot be spared beside a 64k KV cache. But 265.8 MB of that is a bf16 buffer that only sits between `launch_gguf_dequant` and the NVFP4 quantize — nothing reads it again, and only the FP4 operand itself has to be whole. Staging the conversion in row slices drops it to ~113 MB, and the cap can go.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (Muse Glimmer 30B @ `--ctx 32768`; this PR targets prefill, shown for no-regression):

| | decode tok/s |
|---|--:|
| before (main) | 102.72 |
| after (this PR) | 102.79 |

**Prefill pp tok/s** (Muse Glimmer 30B, `--ctx 32768`; best axis is `--ctx 16384`, 10313.31 -> 12588.23 = 1.221x):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 9282.76 |
| after prefill (this PR) | 11098.19 |

```text
# bench_sweep_run -- the harness eval/pr_museglimmer_bot.py itself drives -- ntok=128.
# Two replicas per tree, interleaved and reversed, warm-up arm burned first.

--- before (main) ---                     --- after (this PR) ---
   ctx      decode     prefill               ctx      decode     prefill
   128      108.9783   9238.7334             128      108.9770   9242.4031
   512      108.2533   12402.1679            512      108.2450   12375.9950
   4096     105.2054   13353.1660            4096     105.2261   13698.7838
   16384    104.0620   10309.0821            16384    104.0806   12541.8586
   32768    102.7107   9280.0803             32768    102.7090   11057.9055
   65536    66.6180    1342.7404             65536    66.6156    1341.9812

   128      108.9832   9246.1953             128      109.3233   9291.4385
   512      108.2608   12434.5302            512      108.5171   12587.0328
   4096     105.2214   13365.4540            4096     105.3444   13839.9096
   16384    104.1328   10317.5297            16384    104.2446   12634.5875
   32768    102.7372   9285.4352             32768    102.8800   11138.4728
   65536    66.5969    1343.8396             65536    66.6368    1346.0784
```
