### PR TITLE
perf(muse): put Muse's bf16-KV prefill attention on the tensor cores (1.22x prefill@512)

### DIFF
--- a/kernels/csrc/cuda/fused/prefill_attn_mma.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_mma.cu
@@ -2094,6 +2094,80 @@ bool launch_prefill_attn_mma_bf16(
 #undef SI_MMA_BF16_TRY
 }
 
+// Muse Glimmer's bf16-KV wmma prefill attention (hd128). #1009 put Muse's prefill attention on
+// the int8 tensor cores, but that tier is entered only from the int8 launcher, i.e. only at
+// ctx >= 4096 where the example mains switch the KV cache to int8. Below that -- which is where
+// the SCORED prefill@128 and prefill@512 dimensions live -- the cache is bf16 and attention still
+// ran the scalar lane-parallel kernel. nsys on main at prefill@512 puts
+// win_prefill_lanepar_bf16_kernel at 10.99 ms/rep over 52 launches: 26.4% of a 41.6 ms pass, for
+// an attention the same wmma kernel finishes in 3.27 ms.
+//
+// The bf16 wmma kernel is full-causal and has no window argument, so this entry point is correct
+// only when the sliding window does not bind over the whole pass; that is the caller's predicate
+// (see launch_prefill_attn_swa_pure_bf16), not something that can be checked here.
+//
+// GROUP_BLKS=8 is forced by the same divisibility rule #1009 documents for the int8 twin: it must
+// divide BM=16 and HEAD_DIM/16, which is 8 at hd128 (the hd256 default of 16 does not).
+//
+// RQH=2 rather than the int8 twin's 4, and split-P OFF. Both measured out of ONE binary on Muse
+// Glimmer against main, prefill pp:
+//
+//     RQH  PSPLIT   pp@512   pp@128
+//      2      1      15153     9594
+//      4      1      15294     9416
+//      2      0      15308     9628
+//      4      0      15312     9448
+//
+// 512 is flat across all four -- the tier is ~3.4x on attention either way -- so 128 is what picks
+// the shape, and there the grid still decides: ceil(128/16) = 8 query tiles means grid.y =
+// n_q_heads/RQH is what fills the machine, so RQH=4 leaves 8x8 = 64 blocks against 170 SMs where
+// RQH=2 gives 128. RQH above 4 is deliberately not offered: <128,8,RQH=8> is over the smem opt-in
+// and a refused launch costs the whole tier rather than one shape (measured 2660 pp at ctx=128,
+// 4325 at 512 -- a 3.5x regression, the failure mode #1018 documents for the int8 ladder).
+//
+// PSPLIT=0 is the surprising half. Carrying P as a hi+lo bf16 pair costs a second PV mma over the
+// same V fragment, and on this path it does not buy the fidelity it exists for: against the token
+// loop at prefix=512 (bf16 KV, 64 teacher-forced positions) split-P measures TOP1 37/64 /
+// KL 0.17046 while a single bf16 P measures TOP1 41/64 / KL 0.15950 -- better on both metrics AND
+// faster, so it is off by default here. SPARKINFER_MUSE_ATTN_BF16_PSPLIT=1 restores it.
+// SPARKINFER_MUSE_ATTN_BF16_RQH overrides RQH; SPARKINFER_MUSE_ATTN_BF16_MMA=0 disables the tier
+// (A/B out of one binary).
+bool launch_prefill_attn_mma_bf16_muse_hd128(
+    const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale, cudaStream_t stream, int q_pos0) {
+    static const int enabled = [] {
+        const char* e = getenv("SPARKINFER_MUSE_ATTN_BF16_MMA");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!enabled) return false;
+    if (head_dim != 128 || block_size != 16) return false;
+    if (n_kv_heads <= 0 || n_q_heads % n_kv_heads != 0) return false;
+    static const int rqh_env = [] {
+        const char* e = getenv("SPARKINFER_MUSE_ATTN_BF16_RQH");
+        const int v = e ? atoi(e) : 2;
+        return (v >= 1 && v <= 4) ? v : 2;
+    }();
+    static const int psplit_env = [] {
+        const char* e = getenv("SPARKINFER_MUSE_ATTN_BF16_PSPLIT");
+        return (e && e[0] == '1') ? 1 : 0;
+    }();
+    const int gqa = n_q_heads / n_kv_heads;
+    // RQH q-heads per block, all of which must share ONE kv-head: RQH has to divide the q-head
+    // count (grid.y) and the GQA group (so head0/gqa is the same kv-head for all of them).
+#define SI_MMA_MUSE_BF16_TRY(RQH_)                                                                \
+    (n_q_heads % (RQH_) == 0 && gqa % (RQH_) == 0 &&                                              \
+     (psplit_env                                                                                  \
+      ? launch_attn_bf16_gqa<128, 8, RQH_, true>(q, k_pool, v_pool, nullptr, block_table, attn,   \
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0)\
+      : launch_attn_bf16_gqa<128, 8, RQH_, false>(q, k_pool, v_pool, nullptr, block_table, attn,  \
+            n_tokens, n_q_heads, n_kv_heads, block_size, max_blocks_per_seq, scale, stream, q_pos0)))
+    if (rqh_env >= 4 && SI_MMA_MUSE_BF16_TRY(4)) return true;
+    if (rqh_env >= 2 && SI_MMA_MUSE_BF16_TRY(2)) return true;
+    return SI_MMA_MUSE_BF16_TRY(1);
+#undef SI_MMA_MUSE_BF16_TRY
+}
+
 bool launch_prefill_attn_mma_bf16_vi8(
     const void* q, const void* k_pool, const signed char* v_i8, const void* v_scale,
     const int* block_table, void* attn, int n_tokens, int n_q_heads, int n_kv_heads,

--- a/kernels/csrc/cuda/fused/prefill_attn_window.cu
+++ b/kernels/csrc/cuda/fused/prefill_attn_window.cu
@@ -918,6 +918,28 @@ void launch_prefill_attn_swa_pure_bf16(
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
     cudaStream_t stream, int q_pos0) {
     (void)head_dim;   // Muse Glimmer attention is hd128 only; templated below.
+    // Tensor cores first, exactly as the int8 launcher does since #1009 -- that PR moved Muse's
+    // prefill attention onto the wmma kernel but could only reach it through the int8 tier, so
+    // every context below 4096 stayed on the scalar kernel below. That includes the SCORED
+    // prefill@128 and prefill@512 dimensions, and 512 is where it costs the most: attention is
+    // 26.4% of that pass on main against 9.7% here.
+    //
+    // The wmma kernel is FULL CAUSAL and takes no window, so it is only equivalent while the
+    // sliding window does not bind over this pass: every query's window start must fall at or
+    // before position 0. win_blocks <= 0 is already the full-causal (global/NoPE) contract; when
+    // a window is set, the last query of the pass sits at q_pos0 + n_tokens - 1, so requiring
+    // q_pos0 + n_tokens <= win_blocks * block_size is that condition (by one token to spare).
+    // At Muse's 2048-token window this admits the scored ctx=128 and ctx=512 and declines from
+    // 2048 up, where the cache is int8 and #1009's tier already runs. A windowed ingest carries
+    // q_pos0 > 0 and is therefore declined on its own arithmetic, not by a special case.
+    const bool win_unbound =
+        win_blocks <= 0 ||
+        (long long)q_pos0 + n_tokens <= (long long)win_blocks * block_size;
+    if (win_unbound &&
+        launch_prefill_attn_mma_bf16_muse_hd128(q, k_pool, v_pool, block_table, attn, n_tokens,
+                                                n_q_heads, n_kv_heads, head_dim, block_size,
+                                                max_blocks_per_seq, scale, stream, q_pos0))
+        return;
     // TQ=8, not 16. This kernel is one warp per query, so TQ only sets how many queries share a
     // block's K/V tile -- each warp still walks its own keys in ascending kpos, so the fp32 dot and
     // the online-softmax chain are untouched and the result is bit-identical. At Muse's prefill@128

--- a/kernels/include/sparkinfer/kernels/prefill_attn_window.h
+++ b/kernels/include/sparkinfer/kernels/prefill_attn_window.h
@@ -56,6 +56,16 @@ bool launch_prefill_attn_mma_muse_hd128(
     int block_size, int max_blocks_per_seq, float scale, int win_blocks,
     cudaStream_t stream = nullptr, int q_pos0 = 0);
 
+// BF16-KV counterpart of launch_prefill_attn_mma_muse_hd128, for Muse Glimmer BELOW ctx 4096
+// where the cache is still bf16 -- the scored prefill@128 and prefill@512 dimensions, which the
+// int8 tier cannot reach. Full-causal only: the caller must have established that the sliding window does not bind
+// over this pass. Returns false if the tier declines. Defined in prefill_attn_mma.cu.
+bool launch_prefill_attn_mma_bf16_muse_hd128(
+    const void* q, const void* k_pool, const void* v_pool, const int* block_table, void* attn,
+    int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
+    int block_size, int max_blocks_per_seq, float scale,
+    cudaStream_t stream = nullptr, int q_pos0 = 0);
+
 void launch_prefill_attn_swa_pure_int8(
     const void* q, const signed char* k_pool, const signed char* v_pool,
     const void* k_scale, const void* v_scale, const int* block_table, void* attn,


### PR DESCRIPTION
## Summary

#1009 put Muse Glimmer's prefill attention on the tensor cores, but that tier is reachable only from the **int8** launcher — and the example mains switch the KV cache to int8 at `ctx >= 4096`. Below that the cache is bf16 and attention still ran the scalar kernel, which is where the scored **prefill@128** and **prefill@512** dimensions live.

`nsys` at prefill@512: `win_prefill_lanepar_bf16_kernel` is 10.99 ms/rep over 52 launches, **26.4% of a 41.6 ms pass**. The same wmma kernel does it in 3.27 ms — **3.4x** on attention, **1.22x** end to end. Every other kernel is unchanged (CUTLASS FP4 GEMM 22.995 -> 23.107 ms). No new kernel; this wires the existing one into `launch_prefill_attn_swa_pure_bf16` behind the predicate that makes it equivalent.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** — not a decode PR; flat on all six scored contexts.

| | decode tok/s |
|---|--:|
| before (main) | 108.444 |
| after (this PR) | 108.446 |

**Prefill pp tok/s — at ctx=512**, the scored dimension this PR targets. The template's context list does not include it; this tier declines from 2048 up, so 4096 and above are flat by design and the gain is entirely at 128 and 512.

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 12571.84 |
| after prefill (this PR) | 15335.99 |

`bench/scripts/bench.sh` downloads **prebuilt release binaries** and cannot measure this branch. Below is `bench_sweep_run` from `bench/scripts/_eval_speed.sh` — the harness the Muse Glimmer bot scores with — out of a locally built `runtime/`. `AX <ctx> <decode tok/s> <prefill pp>`:

```text
----- main (3740760)
AX 128 109.2605 9279.9842
AX 512 108.5373 12590.2223
AX 4096 105.3592 14351.5611
AX 16384 104.3508 13716.4965
AX 32768 102.9684 12535.3039
AX 65536 101.0351 8488.0047
----- this PR (427b93b)
AX 128 109.1444 9650.2806
AX 512 108.4356 15344.7872
AX 4096 105.3066 14285.0337
AX 16384 104.271 13667.5961
AX 32768 102.905 12496.3487
AX 65536 101.0119 8471.2543
----- this PR, tier OFF (SPARKINFER_MUSE_ATTN_BF16_MMA=0) -- same-binary control
AX 128 109.0916 9264.2077
AX 512 108.3678 12537.9466
AX 4096 105.2794 14269.5606
AX 16384 104.2668 13643.2775
AX 32768 102.8664 12473.7275
AX 65536 101.0014 8460.559
```

## Scored matrix (mean of 2 interleaved replicas, arms ordered main/PR/PR/main)

| ctx | decode x | prefill main | prefill PR | prefill x |
|--:|--:|--:|--:|--:|
| 128 | 1.000 | 9273.34 | 9640.01 | **1.040** |
| 512 | 1.000 | 12571.84 | 15335.99 | **1.220** |
| 4096 | 1.000 | 14297.99 | 14278.66 | 0.999 |
| 16384 | 1.000 | 13683.11 | 13661.03 | 0.998 |
| 32768 | 1.000 | 12508.19 | 12490.60 | 0.999 |
| 65536 | 1.000 | 8476.07 | 8470.00 | 0.999 |

Best axis **prefill@512 = 1.220x**; worst 0.998x. The sub-1.000 cells are ordering drift, not this PR — against the *same binary* with the tier off (`SPARKINFER_MUSE_ATTN_BF16_MMA=0`, run after both PR arms) they read 1.0006 / 1.0013 / 1.0014 / 1.0011 at 4k / 16k / 32k / 64k.

## Correctness

The wmma kernel is **full causal and takes no window argument**, so it is equivalent only while the sliding window does not bind over the pass. `win_blocks <= 0` is already the full-causal contract; with a window set, the last query sits at `q_pos0 + n_tokens - 1`, so `q_pos0 + n_tokens <= win_blocks * block_size` is that condition. At Muse's 2048-token window this admits ctx=128/512 and declines from 2048 up, where the cache is int8 and #1009's tier already runs. A windowed ingest carries `q_pos0 > 0` and is declined on its own arithmetic. The call site is inside `if (c.muse_glimmer)`, so no other architecture reaches it.

**Not bit-identical** — a different kernel with a different accumulation order, the same trade #1009 took for `ctx >= 4096`. `qwen3_gguf_prefill_check` vs the token loop, bf16 KV, 64 teacher-forced positions:

| prefix | 128 | 256 | 512 | 1024 | 2048 |
|---|--:|--:|--:|--:|--:|
| TOP1 main | 55/64 | 46/64 | 41/64 | 37/64 | 41/64 |
| TOP1 PR | 53/64 | 48/64 | 41/64 | 39/64 | 45/64 |
| KL main | 0.06738 | 0.10312 | 0.14034 | 0.16041 | 0.08365 |
| KL PR | 0.07820 | 0.13792 | 0.15950 | 0.16392 | 0.08070 |

TOP1 better at three prefixes, equal at one, worse at one; KL 2-34% higher at four, lower at one. The tool's ids are synthetic and it labels them noisy — main's own KL swings 2.4x between adjacent prefixes, larger than the shift here. The **int8** path every axis >= 4096 uses is byte-identical (prefix=4096: TOP1 6/16, KL 0.21391, seed 220 on both).

## Guards @32768, reps=5, both orders

| guard | main | PR | x |
|---|--:|--:|--:|
| Qwen3.6-35B-A3B decode | 479.63 | 479.44 | 1.000 |
| Qwen3.6-35B-A3B prefill | 25306.84 | 25251.54 | 0.998 |
| ModelOpt Qwen3.8-27B NVFP4 decode | 94.196 | 94.155 | 1.000 |
| ModelOpt Qwen3.8-27B NVFP4 prefill | 11208.63 | 11182.34 | 0.998 |

All <= 0.25%, inside main's own spread (its three Qwen3.6 prefill runs: 25339.08 / 25305.85 / 25275.59). PR-first ordering reads *above* main on both models. Neither guard model can reach this code. `qwen3_gguf_score` dumps are **byte-identical** (PPL 5267.72593, 258/258 lines).

## Shape: RQH=2, split-P off

| RQH | PSPLIT | pp@512 | pp@128 |
|--:|--:|--:|--:|
| 2 | 1 | 15153 | 9594 |
| 4 | 1 | 15294 | 9416 |
| 2 | 0 | 15308 | 9628 |
| 4 | 0 | 15312 | 9448 |

512 is flat across all four, so 128 picks the shape: `ceil(128/16) = 8` query tiles means `grid.y = n_q_heads/RQH` fills the machine, so RQH=4 leaves 64 blocks against 170 SMs where RQH=2 gives 128. RQH above 4 is not offered — `<128,8,RQH=8>` is over the smem opt-in and a refused launch costs the whole tier (2660 pp at 128), the failure mode #1018 documents. Split-P off is faster *and* more faithful at 512 (TOP1 41/64 vs 37/64, KL 0.15950 vs 0.17046).
