### PR TITLE
perf(muse): stop staging an ffn-wide int8 activation for a prefill whose FFN runs on FP4 (1.27x prefill@64k)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -648,8 +648,69 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     // fit, and neither one bounds the other once FC and N can differ.
     const int a_wide_k = imax(H, imax(qdim, lvdim));   // widest K quantized with N rows
     const size_t a_i8_rows_n = (size_t)N * (size_t)a_wide_k;
-    const size_t a_i8_dense = (a_i8_rows_n > (size_t)FC * ffn) ? a_i8_rows_n : (size_t)FC * ffn;
+    const size_t a_i8_ffn = (size_t)FC * (size_t)ffn;
+    const size_t a_i8_full = (a_i8_rows_n > a_i8_ffn) ? a_i8_rows_n : a_i8_ffn;
+    // Moved up from the FP4 block below: the sizing right underneath has to know whether the
+    // FFN will run on FP4, and this is the knob that can refuse it.
+    static const int muse_fp4_maxN = [] {
+        const char* e = getenv("SPARKINFER_MUSE_NVFP4_MAXN");
+        return e ? atoi(e) : (1 << 30);
+    }();
+    // Does EVERY FFN chunk in this pass take the FP4 route? Muse's FP4 FFN quantizes its
+    // activation into fp4_a, folds the SwiGLU straight into fp4_down_a and lets the down GEMM
+    // read that -- A_i8 is never written at ffn width, so the FC*ffn term above is reserve for a
+    // fallback that cannot happen. All-or-nothing across layers, because ONE layer without an
+    // FP4 gate/up operand still needs the buffer.
+    const bool ffn_all_fp4 = !moe && c.muse_glimmer && !s.w.layers.empty() &&
+        FC == N && N >= 128 && N <= muse_fp4_maxN &&
+        kernels::prefill_nvfp4_supported(N, ffn, H) &&
+        [&] {
+            for (const Qwen35LayerWeights& lw : s.w.layers)
+                if (!lw.gate_fp4 || !lw.gate_fp4_sf || !lw.up_fp4 || !lw.up_fp4_sf) return false;
+            return true;
+        }();
+    // ...and that reserve is not free. The FP4 operands come out of THIS arena, after these two
+    // buffers, so where free VRAM is short they are what does not get allocated -- silently, the
+    // pointers being optional at every use site. Measured on an RTX 5090 at ctx=65536, where a
+    // 64k KV cache leaves 1001 MB once ffg/ffu are up: A_i8 and its k-tiled copy take 624 MB of
+    // it, and the qkv-gate operand (272 MB) and the ffn_down operand (156 MB) BOTH come back
+    // nullptr. Both legs drop onto the int8 GEMM -- 104 CUTLASS FP4 launches per rep where 16384
+    // and 32768, which have the VRAM, run 208 -- and nothing anywhere reports it.
+    //
+    // So drop the term, but only where it is the thing standing in the way: every context that
+    // already fits keeps today's sizing and stays bit-identical. The estimate below covers the
+    // four operands this arena hands out; the margin covers the GEMM workspace and the ffn_down
+    // conversion scratch, which are cudaMalloc'd beside it.
+    const size_t fp4_want = ffn_all_fp4
+        ? kernels::prefill_nvfp4_data_bytes(N, H) + kernels::prefill_nvfp4_scale_bytes_a(N, H) +
+          (size_t)N * (size_t)(2 * qdim + 2 * kvdim) * sizeof(bf16) +
+          kernels::prefill_nvfp4_data_bytes(FC, ffn) +
+          kernels::prefill_nvfp4_scale_bytes_a(FC, ffn)
+        : 0;
+    // SPARKINFER_PREFILL_FFN_I8_STAGE=1 keeps the ffn-wide staging unconditionally (A/B in ONE
+    // binary, and today's sizing with it).
+    static const bool ffn_i8_stage_force = [] {
+        const char* e = getenv("SPARKINFER_PREFILL_FFN_I8_STAGE");
+        return e && e[0] == '1';
+    }();
+    bool ffn_i8_stage = true;
+    if (ffn_all_fp4 && !ffn_i8_stage_force && a_i8_full > a_i8_rows_n) {
+        size_t fb = 0, tb = 0;
+        if (cudaMemGetInfo(&fb, &tb) == cudaSuccess) {
+            const size_t margin = (size_t)256 << 20;
+            if (fb <= 2 * a_i8_full + maxw + fp4_want + margin) ffn_i8_stage = false;
+        }
+    }
+    const size_t a_i8_dense = ffn_i8_stage ? a_i8_full : a_i8_rows_n;
     const size_t a_i8_sz = moe ? (size_t)N * maxAK : a_i8_dense;
+    // Every int8/fp8 activation quantize below writes R*K bytes into A_i8. With the ffn-wide
+    // term dropped it no longer covers an ffn-wide one, so ask before taking that path rather
+    // than writing past the end -- the arms that fail this simply keep the bf16 GEMM, which is
+    // what a layer without an int8 arm already does. (This is the same class of overrun the
+    // a_wide_k comment above records; asking is cheap and makes the sizing self-enforcing.)
+    auto a_i8_fits = [&](long R, long K) {
+        return (size_t)R * (size_t)K <= a_i8_sz;
+    };
     // N, not FC: sx is the per-row scale that pairs with A_i8 above, and the non-FFN projections
     // write N of them regardless of how small the FFN chunk gets. Costs N floats.
     const size_t sx_n = (size_t)N;
@@ -741,10 +802,6 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     // sized for. With that sizing fixed, the shape question is exactly what
     // prefill_nvfp4_supported() already answers, so ask it instead of pinning one context.
     // SPARKINFER_MUSE_NVFP4_MAXN caps it again (128 restores the old behaviour).
-    static const int muse_fp4_maxN = [] {
-        const char* e = getenv("SPARKINFER_MUSE_NVFP4_MAXN");
-        return e ? atoi(e) : (1 << 30);
-    }();
     const bool muse_nvfp4 = c.muse_glimmer && N >= 128 && N <= muse_fp4_maxN &&
                             FC == N &&          // chunked FP4 FFN is not correct yet; see FC above
                             !s.w.layers.empty() &&
@@ -1357,6 +1414,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
         // projection (48 layers × qkv/z/out). Feed the packed e4m3 to the existing
         // fp8 GEMM instead. SPARKINFER_Q38_FP8_PREFILL=0 restores the requant path.
         if (!q38_fp8_prefill || !W || !A_i8 || !sx || !sw || n_out < 128) return false;
+        if (!a_i8_fits(R, K)) return false;
         a_q = nullptr; a_pk = false;
         kernels::launch_prefill_quantize_rows_fp8(A, A_i8, sx, R, K, st);
         kernels::launch_prefill_fp8_wscales_bf16(W, sw, n_out, st);
@@ -1374,7 +1432,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
         // projections (ssm_alpha/ssm_beta, n_out == v_heads) in bf16 — they feed the GDN
         // sigmoid gates, where per-row int8 quant of a 32-wide weight costs more accuracy
         // than the negligible time it saves.
-        if (use_i8 && n_out >= 128) {
+        if (use_i8 && n_out >= 128 && a_i8_fits(R, K)) {
             quant_a_i8(A, R, K);
             // fused Q4_K/Q6_K -> int8 rows skips the dequant-to-bf16 scratch round trip
             bool w_i8_ready = kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st);
@@ -1394,7 +1452,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                 kernels::launch_prefill_quantize_rows_i8(wb, W_i8, sw, n_out, K, st);
             }
             gemm_i8(A_i8, W_i8, sx, sw, C, R, n_out, K, false);
-        } else if ((use_fp8_gdn || moe_fp8) && n_out >= 128) {
+        } else if ((use_fp8_gdn || moe_fp8) && n_out >= 128 && a_i8_fits(R, K)) {
             // fp8 (e4m3) tensor-core path for the long-ctx GDN projections. A_i8/W_i8 (1 byte) hold
             // the e4m3 operands; dequant the weight to bf16 scratch, then row/channel fp8-quantize.
             a_q = nullptr; a_pk = false;                // A_i8 becomes e4m3 -- invalidate the memo
@@ -1432,6 +1490,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                           int rows = 0) -> bool {
         if (!resid_fuse || !use_i8 || n_out < 128 || wtype == kernels::SI_QTYPE_FP8) return false;
         const int R = rows > 0 ? rows : N;
+        if (!a_i8_fits(R, K)) return false;
         quant_a_i8(A, R, K);
         if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, W_i8, sw, n_out, K, st)) {
             const void* wb = dq(W, wtype, n_out, K);
@@ -1469,7 +1528,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     auto proj_fused_acc = [&](const bf16* A, const void* W, int wtype, const float* rs,
                               bf16* C, int n_out, int K, int* acc, int rows = 0) {
         const int R = rows > 0 ? rows : N;
-        if (use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
+        if (use_i8 && rs && n_out >= 128 && a_i8_fits(R, K) &&
+            kernels::pf_dense_gemm_qi8_supported(wtype)) {
             quant_a_i8(A, R, K);
             if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
                                                        qb_partials, QB_SPLITS, acc, apk()))
@@ -1480,7 +1540,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     auto proj_fused = [&](const bf16* A, const void* W, int wtype, const float* rs,
                           bf16* C, int n_out, int K, int rows = 0) {
         const int R = rows > 0 ? rows : N;
-        if (use_i8 && rs && n_out >= 128 && kernels::pf_dense_gemm_qi8_supported(wtype)) {
+        if (use_i8 && rs && n_out >= 128 && a_i8_fits(R, K) &&
+            kernels::pf_dense_gemm_qi8_supported(wtype)) {
             quant_a_i8(A, R, K);
             if (kernels::launch_prefill_gemm_qi8_dense(wtype, A_i8, sx, W, rs, C, R, n_out, K, st,
                                                        qb_partials, QB_SPLITS, nullptr, apk()))
@@ -2009,7 +2070,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             ffn_pf(nullptr, 0, w.down_q, w.down_qtype, w.down_nv, &down_pf, &down_pf_type);
             // Per-token independent, so this is numerically identical to the full-width pass.
             // Long-ctx: selective int8 FFN (GDN/attn stay bf16) + int8 weight cache across chunks.
-            const bool ffn_i8 = use_i8_ffn && ffn_Wg_i8 != nullptr;
+            const bool ffn_i8 = use_i8_ffn && ffn_i8_stage && ffn_Wg_i8 != nullptr;
             auto dequant_w_i8 = [&](int wtype, const void* W, signed char* dst, float* scale,
                                     int n_out, int K) {
                 if (!kernels::launch_gguf_dequant_rows_i8(wtype, W, dst, scale, n_out, K, st)) {
@@ -2017,7 +2078,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                     kernels::launch_prefill_quantize_rows_i8(wb, dst, scale, n_out, K, st);
                 }
             };
-            const bool ffn_qi8 = use_i8 && w.gate_rs && w.up_rs &&
+            const bool ffn_qi8 = use_i8 && ffn_i8_stage && w.gate_rs && w.up_rs &&
                 kernels::pf_dense_gemm_qi8_supported(gate_pf_type);
             if (ffn_i8 && !ffn_qi8) {
                 dequant_w_i8(gate_pf_type, gate_pf, ffn_Wg_i8, ffn_swg, ffn, H);
@@ -2196,7 +2257,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                     // Set by the grouped launcher when it folded the SwiGLU + int8 quantize into
                     // its split-K epilogue, so gate/up were never written out as bf16.
                     int ffn_fused_swiglu = 0;
-                    if (muse_ffn_group && muse_qb && use_i8 && w.gate_rs && w.up_rs &&
+                    if (muse_ffn_group && muse_qb && use_i8 && ffn_i8_stage &&
+                        w.gate_rs && w.up_rs &&
                         gate_pf_type == up_pf_type &&
                         kernels::pf_dense_gemm_qi8_supported(gate_pf_type)) {
                         const void*  Wf[2]  = { gate_pf, up_pf };
@@ -2219,7 +2281,7 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                         proj_fused(hn_c, gate_pf, gate_pf_type, w.gate_rs, ffg, ffn, H, fn);
                         proj_fused(hn_c, up_pf,   up_pf_type,   w.up_rs,   ffu, ffn, H, fn);
                     }
-                    if (use_i8) {
+                    if (use_i8 && ffn_i8_stage) {
                         // Same fused SwiGLU + per-row int8 quantize the long-ctx ffn_i8 branch
                         // runs (bit-identical to swiglu-then-quantize; both bf16-round first) --
                         // skips the ffg store + reload that proj()'s internal quantize would pay.


### PR DESCRIPTION
## Summary

At ctx=65536 Muse's prefill silently loses two of its four NVFP4 GEMM legs. Not to a shape or a fidelity rule -- to VRAM. The FFN's int8 activation staging (`A_i8` and the k-tiled copy beside it) is sized for `FC * ffn` = 312 MB **each** at a 16384-token window, and the FP4 operands come out of the same arena *after* it, so with a 64k KV cache resident the qkv-gate operand (272 MB) and the ffn_down operand (156 MB) both come back `nullptr`. Every use site treats those pointers as optional, so both legs just fall onto the int8 GEMM and nothing reports anything.

Nothing writes that staging when the FFN runs on FP4: gate/up read `fp4_a`, the SwiGLU quantizes straight into `fp4_down_a`, and the down GEMM reads that. So it is reserve for a fallback that cannot happen. This drops the term when every layer has an FP4 gate/up operand **and** free VRAM says it is the thing standing in the way -- so 128/512/4k/16k/32k, which already fit, keep today's sizing exactly and are bit-identical.

The result is that ctx=65536 runs the kernel mix 16384 and 32768 already run: **1776 kernels per window instead of 2245, and 208 CUTLASS FP4 launches per rep instead of 104.**

One knob, `SPARKINFER_PREFILL_FFN_I8_STAGE=1`, keeps the old sizing (A/B in one binary).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Prefill pp tok/s** (Muse Glimmer, `bench_sweep_run` — best axis is **65536**):

| | prefill pp tok/s |
|---|--:|
| before prefill (main `5b9fd0f`) | 8493.46 |
| after prefill (this PR) | 10764.94 |

**Decode tok/s** (this PR does not target decode; shown for the no-regression floor):

| | decode tok/s |
|---|--:|
| before (main `5b9fd0f`) | 101.02 |
| after (this PR) | 100.88 |

`bench/scripts/bench.sh` benchmarks **prebuilt release binaries** and cannot measure a branch, so the numbers below are `bench_sweep_run` (the same harness the 12-axis eval uses), run on this branch and on `main` in one interleaved session.

### All 12 scored axes

Mean of 2 interleaved replicas, ordered main / PR / PR / main to cancel the monotone position drift; `warm` is a burned warm-up arm and is not counted.

| ctx | decode main | decode PR | Δ | prefill main | prefill PR | Δ |
|--:|--:|--:|--:|--:|--:|--:|
| 128 | 109.228 | 109.186 | −0.04% | 9653.84 | 9644.74 | −0.09% |
| 512 | 108.524 | 108.491 | −0.03% | 15356.50 | 15387.24 | +0.20% |
| 4096 | 105.343 | 105.331 | −0.01% | 14334.43 | 14307.61 | −0.19% |
| 16384 | 104.310 | 104.321 | +0.01% | 13703.68 | 13680.66 | −0.17% |
| 32768 | 102.945 | 102.939 | −0.01% | 12526.33 | 12513.64 | −0.10% |
| **65536** | 101.025 | 100.882 | −0.14% | **8493.46** | **10764.94** | **+26.74%** |

Every axis clears the 0.98 no-regression floor. The sub-0.2% prefill cells at 128..32768 are position drift, not this change: against a **same-binary control** (this branch with `SPARKINFER_PREFILL_FFN_I8_STAGE=1`, i.e. the feature off) run last in the same session, the same cells read +0.02% / +0.17% / +0.15% / +0.07% / +0.18%, and 65536 reads **+27.06%**. The control also reproduces main at 65536 (8472.69 against 8493.46), so the whole delta is this change.

```text
AX <ctx> <decode_tps> <prefill_pp>            # bench_sweep_run, reps 5/1/1 per the eval tiers
== m1 (main 5b9fd0f)          == p1 (this PR)               == m2 (main)                  == ctl (PR, feature OFF)
AX 128    109.3246  9667.03   AX 128    109.1983  9650.45   AX 128    109.1308  9640.65   AX 128    109.1292  9642.96
AX 512    108.6093 15418.78   AX 512    108.4879 15383.27   AX 512    108.4392 15294.22   AX 512    108.4339 15361.75
AX 4096   105.3763 14369.99   AX 4096   105.3425 14318.65   AX 4096   105.3100 14298.88   AX 4096   105.3349 14286.47
AX 16384  104.3467 13730.12   AX 16384  104.3515 13685.57   AX 16384  104.2736 13677.23   AX 16384  104.3321 13671.60
AX 32768  102.9881 12543.17   AX 32768  102.9556 12521.94   AX 32768  102.9014 12509.49   AX 32768  102.9459 12491.61
AX 65536  101.0434  8503.28   AX 65536  100.8822 10768.14   AX 65536  101.0064  8483.64   AX 65536  101.0312  8472.69
                              AX 65536  100.8809 10761.73   (p2)
```

## Correctness

- **Not bit-identical at ctx=65536** — that is the point: qkv and ffn_down move from the int8 GEMM onto the NVFP4 GEMM there. It is not new arithmetic. A 64k prompt is ingested as four **N=16384** windows, and at N=16384 both legs already run NVFP4 on `main` (that is exactly what ctx=16384 and ctx=32768 do today). Same kernels, same shapes, same operands — 65536 stops being the odd one out.
- **Bit-identical at 128 / 512 / 4096 / 16384 / 32768**: the free-VRAM test leaves `ffn_i8_stage` true there, so `a_i8_dense` is the value it is today and every guarded arm passes unchanged. Confirmed by the same-binary control above.
- Prefill numerics are **not** covered by the PR accuracy gate (`qwen3_gguf_score` teacher-forces through `forward_token()` and never enters `prefill_batched_run`), so this was checked by hand with `qwen3_gguf_prefill_check` on **bf16 KV** (`SPARKINFER_KV_INT8=0`) at prefixes 128 / 512 / 2048 / 8192 / 16384: **identical to the last digit** on `main` and on this branch at every prefix, which is what "bit-identical below 65536" means in practice (the check's ids are synthetic, so judge the main-vs-PR delta, not the absolutes):

  | prefix | main TOP1 / KL | this PR TOP1 / KL |
  |--:|--:|--:|
  | 128 | 53/64 &nbsp; 0.07820 | 53/64 &nbsp; 0.07820 |
  | 512 | 41/64 &nbsp; 0.15950 | 41/64 &nbsp; 0.15950 |
  | 2048 | 45/64 &nbsp; 0.08070 | 45/64 &nbsp; 0.08070 |
  | 8192 | 55/64 &nbsp; 0.03684 | 55/64 &nbsp; 0.03684 |

- Guards @32768, reps=5, both models — all four clear the 0.98 floor, worst cell 0.9957x:

  | guard | main | this PR | ratio |
  |---|--:|--:|--:|
  | Qwen3.6-35B-A3B decode | 479.591 | 479.217 | 0.9992x |
  | Qwen3.6-35B-A3B prefill | 25223.15 | 25113.76 | 0.9957x |
  | ModelOpt Qwen3.8-27B NVFP4 decode | 94.1338 | 94.1233 | 0.9999x |
  | ModelOpt Qwen3.8-27B NVFP4 prefill | 11157.18 | 11137.72 | 0.9983x |

- `qwen3_gguf_score` dumps are **byte-identical** between `main` and this branch (PPL 5267.72593 over 255 positions on both), so the top1/KL gate cannot move.
