### PR TITLE
fix(eval): derive the generic eval:* tier instead of letting each bot overwrite it

### DIFF
--- a/eval/pr_dflash_bot.py
+++ b/eval/pr_dflash_bot.py
@@ -1293,9 +1293,11 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
     # Also apply the AR bot's eval:* convention (same tier value) — SN74 scoring reads eval:*
     # tiers, not eval-dflash:*, and the AR bot no longer runs on cron to post them itself. Without
     # this a DFlash-verified speedup would be invisible to anything that only looks at eval:*.
-    for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
-        arb.remove_label(repo, num, lab)
-    arb.add_label(repo, num, f"eval:{label}")
+    # Derived from every per-bot `eval-<model>:<tier>` label rather than overwritten with this
+    # bot's own verdict -- this bot only measures Qwen3.6, so writing the generic label
+    # directly let a `none` here erase another model's real tier depending purely on which
+    # staggered cron ran last. See arb.sync_generic_eval_label().
+    arb.sync_generic_eval_label(repo, num)
     arb.gh(["pr", "comment", str(num), "-R", repo, "--body", body])
     if res.get("ok"):
         upload_dflash_eval_log(repo, num, title, commit, res)

--- a/eval/pr_dspark_bot.py
+++ b/eval/pr_dspark_bot.py
@@ -3010,9 +3010,11 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
     # eval:* tiers, so this makes Qwen3.8-27B submissions count toward that live incentive
     # mechanism. Explicit user decision, 2026-08-11 (originally deliberately NOT mirrored, given
     # Qwen3.8-27B's youth at the time -- see git history on this line for that reasoning).
-    for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
-        arb.remove_label(repo, num, lab)
-    arb.add_label(repo, num, f"eval:{label}")
+    # Derived from every per-bot `eval-<model>:<tier>` label rather than overwritten with this
+    # bot's own verdict -- this bot only measures Qwen3.8-27B, so writing the generic label
+    # directly let a `none` here erase another model's real tier depending purely on which
+    # staggered cron ran last. See arb.sync_generic_eval_label().
+    arb.sync_generic_eval_label(repo, num)
     # The verdict comment is the ONLY place a contributor sees why their PR was labelled and (for
     # a non-speedup) closed, so a dropped post is worse than a dropped label. Post via the REST
     # issues endpoint rather than `gh pr comment`: the latter resolves the PR through a GraphQL

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1093,6 +1093,52 @@ def remove_label(repo, num, label):
     return gh(["api", f"repos/{owner}/{r}/issues/{num}/labels/{label}", "--method", "DELETE"],
               quiet=True)
 
+# Tier vocabulary shared by every model bot's own `eval-<model>:<tier>` label. REJECT is not a
+# tier -- it means a gate failed (regression, accuracy, losslessness) -- so it is ranked below
+# "no measured speedup" and handled specially in sync_generic_eval_label() below.
+GENERIC_TIER_RANK = {"REJECT": -1, "none": 0, "XS": 1, "S": 2, "M": 3, "L": 4, "XL": 5}
+
+# Per-bot verdict labels: `eval-museglimmer:L`, `eval-dspark:none`, ... Deliberately does NOT match
+# the generic `eval:<tier>` label this function writes.
+_PER_BOT_EVAL_RE = re.compile(r"^eval-[a-z0-9]+:(.+)$")
+
+
+def sync_generic_eval_label(repo, num):
+    """Recompute the generic `eval:<tier>` label from every per-bot `eval-<model>:<tier>` label.
+
+    The generic label is what SN74 scoring reads, and EVERY model bot mirrors into it. Each bot
+    used to strip all `eval:*` labels and write its own verdict, which made the value
+    last-writer-wins ACROSS bots: the hourly crons are staggered (Muse :00, DSpark :30, ...), and a
+    bot only ever measures its OWN model, so a PR that optimises one model scores `none` on every
+    other bot. Whether a contributor kept their real tier therefore depended on which cron happened
+    to run last after their final push -- e.g. a Muse PR scored `eval:L` at :00 was silently
+    overwritten with `eval:none` at :30 by the DSpark bot, which had benched Qwen3.8 and correctly
+    found no change. Observed on #1018 (kept `eval:L` only because Muse ran second that round).
+
+    Derived, not overwritten: the generic tier is the BEST tier across the per-bot labels present,
+    so one bot cannot erase another's result and a bot re-running against its own model can still
+    lower its own contribution. REJECT wins outright regardless of rank -- a PR that regresses or
+    fails a gate on ANY model must not advertise a positive tier because a different model improved.
+    """
+    labs = labels_on(repo, num)
+    tiers = []
+    for lab in labs:
+        m = _PER_BOT_EVAL_RE.match(lab)
+        if m:
+            t = m.group(1).strip()
+            if t in GENERIC_TIER_RANK:
+                tiers.append(t)
+    if not tiers:
+        return None            # nothing to mirror; leave whatever is there alone
+    want = "REJECT" if "REJECT" in tiers else max(tiers, key=lambda t: GENERIC_TIER_RANK[t])
+    for lab in {l for l in labs if l.startswith("eval:")}:
+        if lab != f"eval:{want}":
+            remove_label(repo, num, lab)
+    if f"eval:{want}" not in labs:
+        add_label(repo, num, f"eval:{want}")
+    return want
+
+
 def apply_area_labels(repo, num, areas):
     want = {f"area:{a}" for a in areas}
     have = {l for l in labels_on(repo, num) if l.startswith("area:")}

--- a/eval/pr_modelopt_bot.py
+++ b/eval/pr_modelopt_bot.py
@@ -1819,9 +1819,11 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
     # eval:* tiers, so this makes Qwen3.8-27B submissions count toward that live incentive
     # mechanism. Explicit user decision, 2026-08-11 (originally deliberately NOT mirrored, given
     # Qwen3.8-27B's youth at the time -- see git history on this line for that reasoning).
-    for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
-        arb.remove_label(repo, num, lab)
-    arb.add_label(repo, num, f"eval:{label}")
+    # Derived from every per-bot `eval-<model>:<tier>` label rather than overwritten with this
+    # bot's own verdict -- this bot only measures ModelOpt, so writing the generic label
+    # directly let a `none` here erase another model's real tier depending purely on which
+    # staggered cron ran last. See arb.sync_generic_eval_label().
+    arb.sync_generic_eval_label(repo, num)
     # The verdict comment is the ONLY place a contributor sees why their PR was labelled and (for
     # a non-speedup) closed, so a dropped post is worse than a dropped label. Post via the REST
     # issues endpoint rather than `gh pr comment`: the latter resolves the PR through a GraphQL

--- a/eval/pr_museglimmer_bot.py
+++ b/eval/pr_museglimmer_bot.py
@@ -1645,9 +1645,11 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
     # eval:* tiers, so this makes Muse Glimmer submissions count toward that live incentive
     # mechanism. Explicit user decision, 2026-08-11 (originally deliberately NOT mirrored, given
     # Muse Glimmer's youth at the time -- see git history on this line for that reasoning).
-    for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
-        arb.remove_label(repo, num, lab)
-    arb.add_label(repo, num, f"eval:{label}")
+    # Derived from every per-bot `eval-<model>:<tier>` label rather than overwritten with this
+    # bot's own verdict -- this bot only measures Muse Glimmer, so writing the generic label
+    # directly let a `none` here erase another model's real tier depending purely on which
+    # staggered cron ran last. See arb.sync_generic_eval_label().
+    arb.sync_generic_eval_label(repo, num)
     arb.gh(["pr", "comment", str(num), "-R", repo, "--body", body])
     if res.get("ok"):
         upload_museglimmer_eval_log(repo, num, title, commit, res)

--- a/eval/pr_qwen38_bot.py
+++ b/eval/pr_qwen38_bot.py
@@ -1407,9 +1407,11 @@ def apply_result(repo, num, commit, res, title="", dry_run=False):
     # eval:* tiers, so this makes Qwen3.8-27B submissions count toward that live incentive
     # mechanism. Explicit user decision, 2026-08-11 (originally deliberately NOT mirrored, given
     # Qwen3.8-27B's youth at the time -- see git history on this line for that reasoning).
-    for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
-        arb.remove_label(repo, num, lab)
-    arb.add_label(repo, num, f"eval:{label}")
+    # Derived from every per-bot `eval-<model>:<tier>` label rather than overwritten with this
+    # bot's own verdict -- this bot only measures Qwen3.8-27B, so writing the generic label
+    # directly let a `none` here erase another model's real tier depending purely on which
+    # staggered cron ran last. See arb.sync_generic_eval_label().
+    arb.sync_generic_eval_label(repo, num)
     arb.gh(["pr", "comment", str(num), "-R", repo, "--body", body])
     if res.get("ok"):
         upload_qwen38_eval_log(repo, num, title, commit, res)

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -1100,5 +1100,70 @@ class ExhaustedEvalCloseTest(unittest.TestCase):
         close_mock.assert_called_once()
 
 
+
+class GenericEvalLabelTest(unittest.TestCase):
+    """sync_generic_eval_label(): the generic eval:* tier SN74 reads is derived from the per-bot
+    eval-<model>:* labels, so staggered bots cannot clobber each other's verdicts."""
+
+    def _run(self, labels):
+        """Returns (chosen_tier, final_label_set) after running the sync against `labels`."""
+        state = set(labels)
+        with mock.patch.object(bot, "labels_on", return_value=set(state)), \
+             mock.patch.object(bot, "add_label", side_effect=lambda r, n, l: state.add(l)), \
+             mock.patch.object(bot, "remove_label", side_effect=lambda r, n, l: state.discard(l)):
+            got = bot.sync_generic_eval_label("o/r", 1)
+        return got, state
+
+    def test_one_bots_none_cannot_erase_anothers_tier(self):
+        # The #1018 case: a Muse PR scored L by the Muse bot, then benched by the DSpark bot
+        # against a model it does not touch. Whichever cron ran last used to win.
+        got, state = self._run({"eval-museglimmer:L", "eval-dspark:none", "eval:L"})
+        self.assertEqual(got, "L")
+        self.assertIn("eval:L", state)
+        self.assertNotIn("eval:none", state)
+
+    def test_order_independent(self):
+        # Same two verdicts, whichever bot happens to write last -> same generic label.
+        a, _ = self._run({"eval-museglimmer:L", "eval-dspark:none", "eval:none"})
+        b, _ = self._run({"eval-dspark:none", "eval-museglimmer:L", "eval:L"})
+        self.assertEqual(a, b)
+        self.assertEqual(a, "L")
+
+    def test_best_tier_wins_across_bots(self):
+        got, _ = self._run({"eval-museglimmer:S", "eval-dspark:XL", "eval-qwen38:none"})
+        self.assertEqual(got, "XL")
+
+    def test_reject_beats_any_positive_tier(self):
+        # A regression on ANY model must not advertise a positive tier from another.
+        got, state = self._run({"eval-museglimmer:XL", "eval-dspark:REJECT"})
+        self.assertEqual(got, "REJECT")
+        self.assertIn("eval:REJECT", state)
+        self.assertNotIn("eval:XL", state)
+
+    def test_a_bot_can_still_lower_its_own_score(self):
+        # Re-evaluation after a push: sole bot drops XL -> S, generic must follow it down.
+        got, _ = self._run({"eval-museglimmer:S", "eval:XL"})
+        self.assertEqual(got, "S")
+
+    def test_all_none_stays_none(self):
+        got, _ = self._run({"eval-museglimmer:none", "eval-dspark:none"})
+        self.assertEqual(got, "none")
+
+    def test_no_per_bot_labels_leaves_generic_alone(self):
+        got, state = self._run({"eval:L", "hold"})
+        self.assertIsNone(got)
+        self.assertIn("eval:L", state)
+
+    def test_generic_label_is_not_mistaken_for_a_per_bot_label(self):
+        # `eval:XL` must not feed back into its own computation.
+        got, _ = self._run({"eval:XL", "eval-dspark:none"})
+        self.assertEqual(got, "none")
+
+    def test_unknown_tier_ignored(self):
+        got, _ = self._run({"eval-dspark:bogus", "eval-museglimmer:M"})
+        self.assertEqual(got, "M")
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## The bug

The generic `eval:<tier>` label is what SN74 scoring reads, and every model bot mirrors its verdict
into it. Each bot did that by stripping all `eval:*` labels and writing its own:

```python
for lab in {l for l in arb.labels_on(repo, num) if l.startswith("eval:")}:
    arb.remove_label(repo, num, lab)
arb.add_label(repo, num, f"eval:{label}")
```

That makes the value **last-writer-wins across bots**. The crons are staggered (Muse `:00`, DSpark
`:30`, ...) and each bot only measures its own model — so a PR optimising one model scores `none` on
every other bot, correctly and unavoidably. Which tier a contributor ends up with therefore depends
on which cron happened to run last after their final push:

| final push lands | order | outcome |
|---|---|---|
| `:10` | DSpark `:30`, Muse `:00` → Muse last | `eval:L` survives |
| `:40` | Muse `:00`, DSpark `:30` → DSpark last | **`eval:L` overwritten with `eval:none`** |

### Observed

#1018 (`perf(muse)`, prefill@64k) hit exactly this. DSpark benched it against **Qwen3.8**, measured
`+1.4%` — under the 2% `SIG` floor — and wrote `eval-dspark:none` + `eval:none`. The Muse bot then
scored it `eval-museglimmer:L` (**+15.3%**) and restored `eval:L`. It kept its tier only because Muse
happened to run second that round.

## The fix

The generic label is now **derived** from the per-bot `eval-<model>:<tier>` labels by
`arb.sync_generic_eval_label()`: the best tier across them, with `REJECT` winning outright so a
regression or failed gate on *any* model cannot advertise a positive tier earned on another.

Deriving it — rather than "only overwrite when better" — matters for the case that rule would break:
a bot re-evaluating after a push must still be able to lower its **own** contribution.

All five mirroring bots (`museglimmer`, `dspark`, `dflash`, `modelopt`, `qwen38`) now call the shared
helper instead of writing the label directly.

## Scope check

A scan of the last 60 PRs found **no already-corrupted labels** — the bug was latent, and #1018 was
the near miss that exposed it. No historical repair needed.

## Tests

9 new cases in `test_pr_eval_bot.py`: the #1018 ordering, order-independence, best-tier-across-bots,
`REJECT` precedence over a positive tier, a bot lowering its own score, all-`none`, no per-bot labels,
unknown tiers, and that the generic label never feeds back into its own computation.

```
eval/test_pr_eval_bot.py   73 tests OK   (9 new)
eval/test_pr_dspark_bot.py 10 tests OK
eval/test_copycat_guard.py  7 tests OK
```

All five patched bots pass `py_compile`. `eval/` is in `HARNESS_PATHS`, so the bots will skip
evaluating this PR rather than spending GPU on it.
