### PR TITLE
perf(muse): give the o-projection its NVFP4 operand at the contexts the arena can hold it (1.046x prefill@4k)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -5802,7 +5802,30 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         bool down_fp4_on = c.max_seq <= 2048;
         if (fp4o_env)
             down_fp4_on = fp4o_env[0] == '1' || fp4o_env[0] == 'd';
-        wo_fp4_on = wo_fp4_on && c.max_seq <= 2048;
+        // The o-projection copy is worth ~2.3x on the GEMM it replaces -- nsys puts the int8 one
+        // at 7.0% of prefill@16k plus 1.1% for the row-quantize that feeds it, and it is the last
+        // dense int8 GEMM left in Muse's prefill layer. It was refused above max_seq 2048, which
+        // is a proxy for "the batched-prefill arena still fits" inherited from when wo was
+        // budgeted alongside an ffn_down copy 4.7x its size. The proxy was answering the question
+        // wrong on this card: at max_seq 32912 -- the session the scored 4096 / 16384 / 32768 axes
+        // actually run in, since bench_sweep_run loads ONE model at max(ctxs) -- the 52 copies are
+        // ~0.83 GB and the arena still allocates, measured on a 32-GB RTX 5090 at
+        // prefill 1.048x / 1.039x / 1.037x with decode flat and prefill@128 / @512 / @65536
+        // unchanged.
+        //
+        // It is still a proxy, so it is fitted to that measurement and no further: the 65536 axis
+        // loads at max_seq 65680, where the copy does NOT fit -- the arena that holds fp4_qkv and
+        // the ffn_down staging stops allocating and prefill@64k falls ~16-25% (measured both
+        // before and after #1021) -- so it stays out of the bound and keeps main's path exactly.
+        // The free-VRAM preflight below is unchanged and still has the last word.
+        // SPARKINFER_MUSE_NVFP4_WO_MAXSEQ moves the bound (2048 restores the old behaviour, for a
+        // paired A/B out of ONE binary).
+        static const int wo_maxseq = [] {
+            const char* e = getenv("SPARKINFER_MUSE_NVFP4_WO_MAXSEQ");
+            const long long v = e ? atoll(e) : 36864;
+            return (int)(v < 0 ? 0 : (v > (1 << 30) ? (1 << 30) : v));
+        }();
+        wo_fp4_on = wo_fp4_on && c.max_seq <= wo_maxseq;
         // Cost EVERY copy that grows the footprint against the free VRAM that is actually there,
         // and drop legs in ascending order of what they are worth until the set fits. Only these
         // three grow it: gate/up convert and then release their native prefill copy, so they are


### PR DESCRIPTION
## Summary

Muse Glimmer's o-projection is the last dense **int8** GEMM in its prefill layer at ctx 4096 and up
(7.0% of prefill@16k) — gate, up, ffn_down and q|gate|k|v are already NVFP4 there. The FP4 arm
already ships at ctx 128/512; it was refused above `max_seq` 2048 by a VRAM proxy inherited from
when `wo` was budgeted alongside an `ffn_down` copy 4.7x its size. One line moves that bound to
where the arena measurably still fits.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

The changed line is inside `if (c.muse_glimmer && ...)` in `qwen35.cpp`, so it is unreachable for
Qwen3.8 — I still ran the ModelOpt guard and its `qwen3_gguf_score` dump is byte-identical to main.

**Decode tok/s** (this PR does not target decode; all six decode axes are flat):

| | decode tok/s |
|---|--:|
| before (main) | 105.432 |
| after (this PR) | 105.402 |

**Prefill pp tok/s** (`--ctx 4096`, the best context):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 14338.37 |
| after prefill (this PR) | 15001.01 |

Also `--ctx 32768`: 12534.06 → 12977.21 (1.035x). `--ctx 65536` is unchanged — it loads at
`max_seq` 65680, where the copy does not fit, so it stays outside the bound.

`bench/scripts/bench.sh` benchmarks prebuilt release binaries and cannot measure a branch. Numbers
below are `bench_sweep_run` (the 12-axis scored sweep), arms interleaved main / PR / main out of
ONE binary with `SPARKINFER_MUSE_NVFP4_WO_MAXSEQ=2048` as the control.

```text
              control (main)              this PR
AX 128    109.3401   9669.7494      109.2166   9649.9481    1.000x
AX 512    108.5877  15408.2189      108.5027  15391.2154    0.999x
AX 4096   105.4551  14372.0773      105.4024  15001.0094    1.046x
AX 16384  104.4652  13747.0550      104.4115  14241.0456    1.038x
AX 32768  103.0689  12557.6769      102.9659  12977.2099    1.035x
AX 65536  100.9723  10794.5812      100.9174  10772.6534    0.999x

control repeat: 9635.9225 / 15416.2836 / 14304.6662 / 13688.6025 / 12510.4356 / 10764.2733
```

Lowest of the twelve axes is 0.9986x against the 0.98 floor. Guards (ctx 32768, reps 5) pass on
both models — Qwen3.6 0.991x prefill, ModelOpt 0.997x, and 0.995x / 1.002x with the run order
reversed — and the two `qwen3_gguf_score` dumps are byte-identical.

Not bit-identical above ctx 2048: one GEMM moves int8 → NVFP4. It is the same call site and the
same operand the scored ctx 128 / 512 axes already run on. ctx 128 / 512 / 65536 are untouched.
