### PR TITLE
perf(muse): stop materialising two prefill activations the FP4 path never reads (1.027x prefill@4k)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -324,10 +324,14 @@ __global__ void pf_split_q_gate_kernel(const __nv_bfloat16* __restrict__ qraw,
 }
 
 __global__ void pf_mul_sigmoid_kernel(__nv_bfloat16* __restrict__ attn,
-                                      const __nv_bfloat16* __restrict__ gate, long n) {
+                                      const __nv_bfloat16* __restrict__ gate, long n,
+                                      int dim, int gate_ld) {
     const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
     if (i >= n) return;
-    attn[i] = __float2bfloat16(pf_to_f(attn[i]) * pf_sigmoid(pf_to_f(gate[i])));
+    // gate_ld != 0: `gate` is a column slice of a wider packed buffer, so its row pitch is not
+    // `dim`. attn stays tight, which is what every consumer of it expects.
+    const long g = gate_ld ? ((long)(i / dim) * gate_ld + (i % dim)) : i;
+    attn[i] = __float2bfloat16(pf_to_f(attn[i]) * pf_sigmoid(pf_to_f(gate[g])));
 }
 
 // One tap of the Gated-DeltaNet causal conv, by token index relative to THIS pass. A windowed
@@ -1156,7 +1160,13 @@ __global__ void pf_qknorm_ropenorm_kv_kernel(
     __half* __restrict__ k_scale, __half* __restrict__ v_scale,
     const int* __restrict__ block_table,
     int n_q_heads, int n_kv_heads, int head_dim, int rotary_dim, float theta, float eps,
-    int block_size, int max_blocks_per_seq, int pos0) {
+    int block_size, int max_blocks_per_seq, int pos0,
+    // src_ld > 0: q/k/v are COLUMN SLICES of one row-major [n_tokens, src_ld] buffer -- the
+    // packed q|gate|k|v this kernel's caller gets straight out of a single GEMM -- rather than
+    // three tight arrays. Each pointer still addresses its own column base; only the row pitch
+    // changes. q is written to `q_out` TIGHT either way, because the attention that reads it next
+    // wants a tight stride. src_ld == 0 keeps the original addressing for every other caller.
+    __nv_bfloat16* __restrict__ q_out, int src_ld) {
     auto* k_pool = static_cast<__nv_bfloat16*>(k_pool_v);
     auto* v_pool = static_cast<__nv_bfloat16*>(v_pool_v);
     auto* k_pool8 = static_cast<signed char*>(k_pool_v);
@@ -1183,7 +1193,9 @@ __global__ void pf_qknorm_ropenorm_kv_kernel(
 
     if (is_q || is_k) {
         const int hh = is_q ? unit : (unit - n_q_heads);
-        const size_t base = ((size_t)tok * (is_q ? n_q_heads : n_kv_heads) + hh) * head_dim;
+        const int nh = is_q ? n_q_heads : n_kv_heads;
+        const size_t base = src_ld ? ((size_t)tok * src_ld + (size_t)hh * head_dim)
+                                   : ((size_t)tok * nh + hh) * head_dim;
         const __nv_bfloat16* src = is_q ? q : k;
         const __nv_bfloat16* nrm = is_q ? q_w : k_w;
         const float xv = pf_to_f(src[base + t]);
@@ -1211,7 +1223,8 @@ __global__ void pf_qknorm_ropenorm_kv_kernel(
             out = ((t & 1) == 0) ? (x0 * c - x1 * s) : (x0 * s + x1 * c);
         }
         if (is_q) {
-            q[base + t] = __float2bfloat16(out);      // Q is never quantised
+            // Tight destination: `base` above follows the (possibly packed) SOURCE pitch.
+            q_out[((size_t)tok * n_q_heads + hh) * head_dim + t] = __float2bfloat16(out);
         } else {
             const size_t dst = (ctok * n_kv_heads + hh) * head_dim;
             if constexpr (INT8) {
@@ -1224,7 +1237,8 @@ __global__ void pf_qknorm_ropenorm_kv_kernel(
         }
     } else {                                          // V: append as-is (no norm, no rope)
         const int hh = unit - n_q_heads - n_kv_heads;
-        const size_t base = ((size_t)tok * n_kv_heads + hh) * head_dim;
+        const size_t base = src_ld ? ((size_t)tok * src_ld + (size_t)hh * head_dim)
+                                   : ((size_t)tok * n_kv_heads + hh) * head_dim;
         const size_t dst  = (ctok * n_kv_heads + hh) * head_dim;
         if constexpr (INT8) {
             const float val = pf_to_f(v[base + t]);
@@ -1622,10 +1636,12 @@ void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,
         reinterpret_cast<__nv_bfloat16*>(gate), n_tokens, n_heads, head_dim);
 }
 
-void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int dim, cudaStream_t stream) {
+void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int dim,
+                                cudaStream_t stream, int gate_ld) {
     const long n = (long)n_tokens * dim;
     pf_mul_sigmoid_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
-        reinterpret_cast<__nv_bfloat16*>(attn), reinterpret_cast<const __nv_bfloat16*>(gate), n);
+        reinterpret_cast<__nv_bfloat16*>(attn), reinterpret_cast<const __nv_bfloat16*>(gate), n,
+        dim, gate_ld);
 }
 
 void launch_prefill_gdn_conv(const void* qkv, const void* conv_w, void* conv_state,
@@ -1880,7 +1896,7 @@ void launch_prefill_qknorm_ropenorm_kv_bf16(
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream, int pos0) {
+    cudaStream_t stream, int pos0, void* q_out, int src_ld) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
     const size_t shmem = (size_t)head_dim * sizeof(float);
     pf_qknorm_ropenorm_kv_kernel<false><<<grid, head_dim, shmem, stream>>>(
@@ -1888,7 +1904,8 @@ void launch_prefill_qknorm_ropenorm_kv_bf16(
         reinterpret_cast<const __nv_bfloat16*>(v), reinterpret_cast<const __nv_bfloat16*>(q_w),
         reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool, nullptr, nullptr,
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq, pos0);
+        block_size, max_blocks_per_seq, pos0,
+        reinterpret_cast<__nv_bfloat16*>(q_out ? q_out : q), src_ld);
 }
 
 // int8-KV twin of the above: same QK-norm and NORMAL-RoPE math, but each K/V head vector is
@@ -1900,7 +1917,7 @@ void launch_prefill_qknorm_ropenorm_kv_int8(
     void* k_pool, void* v_pool, void* k_scale, void* v_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream, int pos0) {
+    cudaStream_t stream, int pos0, void* q_out, int src_ld) {
     dim3 grid(n_tokens, n_q_heads + 2 * n_kv_heads);   // token on grid.x
     const size_t shmem = (size_t)head_dim * sizeof(float);
     pf_qknorm_ropenorm_kv_kernel<true><<<grid, head_dim, shmem, stream>>>(
@@ -1909,7 +1926,8 @@ void launch_prefill_qknorm_ropenorm_kv_int8(
         reinterpret_cast<const __nv_bfloat16*>(k_w), k_pool, v_pool,
         reinterpret_cast<__half*>(k_scale), reinterpret_cast<__half*>(v_scale),
         block_table, n_q_heads, n_kv_heads, head_dim, rotary_dim, theta, eps,
-        block_size, max_blocks_per_seq, pos0);
+        block_size, max_blocks_per_seq, pos0,
+        reinterpret_cast<__nv_bfloat16*>(q_out ? q_out : q), src_ld);
 }
 
 void launch_prefill_qknorm_rope_kv_bf16_vi8(

--- a/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
+++ b/kernels/csrc/cuda/fused/prefill_nvfp4_sm120.cu
@@ -378,7 +378,7 @@ template <class Layout>
 __global__ void gate_quant_rows(const __nv_bfloat16* __restrict__ src,
                                 const __nv_bfloat16* __restrict__ gate,
                                 unsigned char* dst, cutlass::float_ue4m3_t* sf,
-                                int rows, int cols, Layout layout) {
+                                int rows, int cols, Layout layout, int gate_ld) {
     constexpr int V = 16, LPG = V / 2;
     const int glane = threadIdx.x & (LPG - 1);
     const int groups = rows * (cols / V);
@@ -389,8 +389,9 @@ __global__ void gate_quant_rows(const __nv_bfloat16* __restrict__ src,
     for (int grp = (blockIdx.x * blockDim.x + threadIdx.x) / LPG; grp < groups; grp += stride) {
         const int row = grp / (cols / V), k0 = (grp % (cols / V)) * V;
         const size_t base = (size_t)row * cols + k0 + 2 * glane;
-        const float s0 = __bfloat162float(src[base]),     g0 = __bfloat162float(gate[base]);
-        const float s1 = __bfloat162float(src[base + 1]), g1 = __bfloat162float(gate[base + 1]);
+        const size_t gbase = gate_ld ? ((size_t)row * gate_ld + k0 + 2 * glane) : base;
+        const float s0 = __bfloat162float(src[base]),     g0 = __bfloat162float(gate[gbase]);
+        const float s1 = __bfloat162float(src[base + 1]), g1 = __bfloat162float(gate[gbase + 1]);
         // Same expression and same bf16 rounding as pf_mul_sigmoid_kernel.
         const float x0 = __bfloat162float(__float2bfloat16(s0 / (1.f + __expf(-g0))));
         const float x1 = __bfloat162float(__float2bfloat16(s1 / (1.f + __expf(-g1))));
@@ -601,12 +602,12 @@ bool launch_prefill_nvfp4_rmsnorm_quant_a(const void* s, const void* w, void* d,
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_gate_quant_a(const void* sr, const void* g, void* d, void* sf,
-                                       int m, int k, cudaStream_t st) {
+                                       int m, int k, cudaStream_t st, int gate_ld) {
     if (!sr || !g || !d || !sf || !prefill_nvfp4_supported(m,128,k)) return false;
     auto l = sfa_layout(m,128,k);
     int blocks = (m * (k / 16) * 8 + 255) / 256; if (blocks > 4096) blocks = 4096;
     gate_quant_rows<<<blocks,256,0,st>>>((const __nv_bfloat16*)sr,(const __nv_bfloat16*)g,
-                                          (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l);
+                                          (unsigned char*)d,(cutlass::float_ue4m3_t*)sf,m,k,l,gate_ld);
     return cudaPeekAtLastError() == cudaSuccess;
 }
 bool launch_prefill_nvfp4_swiglu_quant_a(const void* g, const void* u, void* d, void* sf,

--- a/kernels/csrc/cuda/quant/prefill_quant_rows.cu
+++ b/kernels/csrc/cuda/quant/prefill_quant_rows.cu
@@ -126,11 +126,12 @@ template <int BLOCK, int VEC, int SLOTS>
 __global__ __launch_bounds__(BLOCK) void pf_gate_quant_rows_kernel(
         const __nv_bfloat16* __restrict__ x, const __nv_bfloat16* __restrict__ gate,
         signed char* __restrict__ q, float* __restrict__ scale, int rows, int cols,
-        signed char* __restrict__ qp) {
+        signed char* __restrict__ qp, int gate_ld) {
     const int r   = blockIdx.x;
     const int tid = threadIdx.x;
     if (r >= rows) return;
     const size_t base = (size_t)r * cols;
+    const size_t gbase = gate_ld ? (size_t)r * gate_ld : base;
 
     __nv_bfloat16 reg[SLOTS][VEC];
     float amax = 0.f;
@@ -140,7 +141,7 @@ __global__ __launch_bounds__(BLOCK) void pf_gate_quant_rows_kernel(
         if (c < cols) {
             __nv_bfloat16 xv[VEC], gv[VEC];
             *reinterpret_cast<uint4*>(xv) = *reinterpret_cast<const uint4*>(&x[base + c]);
-            *reinterpret_cast<uint4*>(gv) = *reinterpret_cast<const uint4*>(&gate[base + c]);
+            *reinterpret_cast<uint4*>(gv) = *reinterpret_cast<const uint4*>(&gate[gbase + c]);
             #pragma unroll
             for (int v = 0; v < VEC; v++) {
                 const float g = qr_to_f(gv[v]);
@@ -184,7 +185,7 @@ __global__ __launch_bounds__(BLOCK) void pf_gate_quant_rows_kernel(
 
 bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed char* q, float* scale,
                                        int rows, int cols, cudaStream_t stream,
-                                       signed char* qp) {
+                                       signed char* qp, int gate_ld) {
     constexpr int BLOCK = 256, VEC = 8;
     // The k-tiled copy is only defined on whole 32-column groups; K into the dense GEMM is always a
     // whole number of 256-value super-blocks, so this only ever declines shapes it never serves.
@@ -197,9 +198,9 @@ bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed c
     auto xb = reinterpret_cast<const __nv_bfloat16*>(x);
     auto gb = reinterpret_cast<const __nv_bfloat16*>(gate);
     const int vecs = cols / VEC;
-    if (vecs <= BLOCK * 1)      pf_gate_quant_rows_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp);
-    else if (vecs <= BLOCK * 2) pf_gate_quant_rows_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp);
-    else if (vecs <= BLOCK * 4) pf_gate_quant_rows_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp);
+    if (vecs <= BLOCK * 1)      pf_gate_quant_rows_kernel<BLOCK, VEC, 1><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp, gate_ld);
+    else if (vecs <= BLOCK * 2) pf_gate_quant_rows_kernel<BLOCK, VEC, 2><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp, gate_ld);
+    else if (vecs <= BLOCK * 4) pf_gate_quant_rows_kernel<BLOCK, VEC, 4><<<rows, BLOCK, 0, stream>>>(xb, gb, q, scale, rows, cols, qp, gate_ld);
     else return false;
     return true;
 }

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -47,8 +47,9 @@ void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,
                                  cudaStream_t stream = nullptr);
 
 // Batched attn *= sigmoid(gate), elementwise over n_tokens*dim (Qwen3.6 q-gate).
+// gate_ld: row pitch of `gate` in elements when it is a column slice of a wider packed buffer.
 void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int dim,
-                                cudaStream_t stream = nullptr);
+                                cudaStream_t stream = nullptr, int gate_ld = 0);
 
 // Gated-DeltaNet causal depthwise conv (conv_kernel taps) + split(q,k,v) + SiLU + L2-norm(q,k),
 // over all N tokens. Leaves the last conv_kernel-1 raw qkv rows in conv_state (decode layout).
@@ -187,13 +188,18 @@ bool launch_prefill_attn_mma_bf16_vi8(
     int head_dim, int block_size, int max_blocks_per_seq, float scale,
     cudaStream_t stream, int q_pos0 = 0);
 
+// q_out/src_ld: when the caller already holds q|gate|k|v as ONE packed [n_tokens, src_ld] GEMM
+// output, pass each column base plus that row pitch and this kernel reads it in place -- the
+// separate copies out to tight arrays are then pure duplicated traffic. q still lands tight in
+// q_out (the attention wants that stride); k and v go straight to the pools and need no tight
+// form at all. Defaults keep the three-tight-arrays contract every other caller has.
 void launch_prefill_qknorm_ropenorm_kv_bf16(
     void* q, void* k, const void* v, const void* q_w, const void* k_w,
     void* k_pool, void* v_pool,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
     cudaStream_t stream = nullptr,
-    int pos0 = 0);
+    int pos0 = 0, void* q_out = nullptr, int src_ld = 0);
 
 // int8-KV twin of the above (Muse Glimmer at ctx >= 4096): same QK-norm + NORMAL RoPE, K/V
 // quantised to int8 with one fp16 scale per (token, kv_head).
@@ -202,7 +208,7 @@ void launch_prefill_qknorm_ropenorm_kv_int8(
     void* k_pool, void* v_pool, void* k_scale, void* v_scale,
     const int* block_table, int n_tokens, int n_q_heads, int n_kv_heads, int head_dim,
     int rotary_dim, float theta, float eps, int block_size, int max_blocks_per_seq,
-    cudaStream_t stream, int pos0 = 0);
+    cudaStream_t stream, int pos0 = 0, void* q_out = nullptr, int src_ld = 0);
 
 // Full-attention prefill: causal attention over the paged int8 KV pool just filled above.
 // One warp per (token, q-head); online softmax over keys 0..q_pos0+token (causal). q is the rope'd

--- a/kernels/include/sparkinfer/kernels/prefill_i8.h
+++ b/kernels/include/sparkinfer/kernels/prefill_i8.h
@@ -22,9 +22,11 @@ namespace sparkinfer { namespace kernels {
 // One warp per row. Used for both the per-token activation A and (once, resident) the weight W.
 // Muse: fold attn *= sigmoid(gate) into the row-quantize load phase (bit-identical).
 // `qp` (optional): also emit the k-tiled [k/32][row][32] copy for the dense prefill GEMM.
+// gate_ld: row pitch of `gate` in elements, when it is a COLUMN SLICE of a wider packed
+// buffer instead of a tight [rows, cols] array. 0 = tight (every pre-existing caller).
 bool launch_prefill_gate_quant_rows_i8(const void* x, const void* gate, signed char* q,
                                       float* scale, int rows, int cols, cudaStream_t stream,
-                                      signed char* qp = nullptr);
+                                      signed char* qp = nullptr, int gate_ld = 0);
 
 // Returns false only when `qp` was requested but the path that ran cannot write it (the
 // warp-per-row fallback), i.e. the caller's k-tiled copy is now stale and must not be used.

--- a/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
+++ b/kernels/include/sparkinfer/kernels/prefill_nvfp4.h
@@ -20,9 +20,12 @@ bool launch_prefill_nvfp4_rmsnorm_quant_a(const void* src_bf16, const void* weig
                                           cudaStream_t stream = nullptr);
 // Muse's attention gate fused into the A-operand quantize: x * sigmoid(g) straight to FP4, the
 // same fold launch_prefill_gate_quant_rows_i8 does for the int8 o-projection.
+// gate_ld: row pitch of `gate` in elements, when it is a COLUMN SLICE of a wider packed
+// buffer instead of a tight [rows, cols] array. 0 = tight (every pre-existing caller).
 bool launch_prefill_nvfp4_gate_quant_a(const void* src_bf16, const void* gate_bf16,
                                        void* dst_fp4, void* dst_sf,
-                                       int m, int k, cudaStream_t stream = nullptr);
+                                       int m, int k, cudaStream_t stream = nullptr,
+                                       int gate_ld = 0);
 // Fuse the dense FFN's bf16-rounded SwiGLU producer into the down projection's FP4 A quantize.
 bool launch_prefill_nvfp4_swiglu_quant_a(const void* gate_bf16, const void* up_bf16,
                                          void* dst_fp4, void* dst_sf,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -1713,6 +1713,9 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             use_i8 = restore_i8_gdn;
         } else {
             // ---- full softmax-attention layer (q_has_gate, partial RoPE, int8 KV) ----
+            // Set when q|gate|k|v came out of ONE GEMM and q/k/v were left in that packed buffer
+            // instead of being copied to tight arrays (see the Muse arm below).
+            bool qkv_packed = false;
             // Long-ctx: optionally keep Q/K/V/O on int8 (no GDN recurrence here).
             const bool restore_i8 = use_i8;
             if (use_i8_attn) use_i8 = true;
@@ -1744,18 +1747,37 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                     kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_as, N, H, st) &&
                     kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.qkvg_fp4, w.qkvg_fp4_sf,
                                                        fp4_qkv, N, qkvg_n, H, fp4_ws, st)) {
+                    // q, k and v are NOT copied out: the QK-norm + RoPE + KV-append kernel below
+                    // already reads every one of those elements, so handing it the packed pitch
+                    // costs nothing and the three copies -- 2.10 MB of the 2.23 MB per layer, at
+                    // 445 GB/s across four 2-D transfers -- disappear. Only the gate is still
+                    // copied out; its consumers are a three-way branch that would each need the
+                    // pitch. Measured over the whole pass: 208 copies, 0.261 ms, 2.0% of
+                    // prefill@128.
                     const size_t sp = (size_t)qkvg_n * sizeof(bf16);
-                    struct { void* dst; int off, n; } cut[4] = {
-                        { qb, 0,            qdim  }, { qg, qdim,          qdim  },
-                        { kf, 2 * qdim,     kvdim }, { vf, 2 * qdim + kvdim, kvdim },
-                    };
                     qkvg_fp4 = true;
-                    for (auto& cu : cut)
-                        qkvg_fp4 &= cudaMemcpy2DAsync(cu.dst, (size_t)cu.n * sizeof(bf16),
-                                                      fp4_qkv + cu.off, sp,
-                                                      (size_t)cu.n * sizeof(bf16), N,
-                                                      cudaMemcpyDeviceToDevice, st) == cudaSuccess;
-                    if (qkvg_fp4) inq = ing = ink = inv = true;
+                    {
+                        inq = ing = ink = inv = true;
+                        // SPARKINFER_MUSE_QKV_PACKED=0 copies q/k/v out as before, for an A/B
+                        // out of one binary.
+                        static const bool packed_on = [] {
+                            const char* e = getenv("SPARKINFER_MUSE_QKV_PACKED");
+                            return !(e && e[0] == '0');
+                        }();
+                        qkv_packed = packed_on;
+                        if (!qkv_packed) {
+                            struct { void* dst; int off, n; } cut[4] = {
+                                { qb, 0, qdim }, { qg, qdim, qdim },
+                                { kf, 2 * qdim, kvdim },
+                                { vf, 2 * qdim + kvdim, kvdim },
+                            };
+                            for (auto& cu : cut)
+                                qkvg_fp4 &= cudaMemcpy2DAsync(cu.dst, (size_t)cu.n * sizeof(bf16),
+                                                              fp4_qkv + cu.off, sp,
+                                                              (size_t)cu.n * sizeof(bf16), N,
+                                                              cudaMemcpyDeviceToDevice, st) == cudaSuccess;
+                        }
+                    }
                 }
                 if (!qkvg_fp4 && muse_group && muse_qb && use_i8 &&
                     kernels::pfm_moe_gemm_qi8_supported(w.wq_type)) {
@@ -1851,18 +1873,28 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                     signed char* vpool8 = (signed char*)s.kv->v_pool() + s.kv->layer_base_elems(L);
                     void* kscale = (char*)s.kv->k_scale_pool() + s.kv->scale_layer_base_elems(L) * 2;
                     void* vscale = (char*)s.kv->v_scale_pool() + s.kv->scale_layer_base_elems(L) * 2;
-                    kernels::launch_prefill_qknorm_ropenorm_kv_int8(qb, kf, vf, w.q_norm, w.k_norm,
+                    kernels::launch_prefill_qknorm_ropenorm_kv_int8(
+                        qkv_packed ? fp4_qkv : qb,
+                        qkv_packed ? fp4_qkv + 2 * qdim : kf,
+                        qkv_packed ? fp4_qkv + 2 * qdim + kvdim : vf,
+                        w.q_norm, w.k_norm,
                         kpool8, vpool8, kscale, vscale, btable, N, c.n_q_heads, c.n_kv_heads,
-                        c.head_dim, muse_rot, rope_theta, eps, bs, mbs, st, pos0);
+                        c.head_dim, muse_rot, rope_theta, eps, bs, mbs, st, pos0,
+                        qkv_packed ? qb : nullptr, qkv_packed ? qkvg_n : 0);
                     kernels::launch_prefill_attn_swa_pure_int8(qb, kpool8, vpool8, kscale, vscale,
                         btable, att, N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale,
                         win_blocks, st, pos0);
                 } else {
                     bf16* kpool_bf = (bf16*)s.kv->k_pool() + s.kv->layer_base_elems(L);
                     bf16* vpool_bf = (bf16*)s.kv->v_pool() + s.kv->layer_base_elems(L);
-                    kernels::launch_prefill_qknorm_ropenorm_kv_bf16(qb, kf, vf, w.q_norm, w.k_norm,
+                    kernels::launch_prefill_qknorm_ropenorm_kv_bf16(
+                        qkv_packed ? fp4_qkv : qb,
+                        qkv_packed ? fp4_qkv + 2 * qdim : kf,
+                        qkv_packed ? fp4_qkv + 2 * qdim + kvdim : vf,
+                        w.q_norm, w.k_norm,
                         kpool_bf, vpool_bf, btable, N, c.n_q_heads, c.n_kv_heads, c.head_dim,
-                        muse_rot, rope_theta, eps, bs, mbs, st, pos0);
+                        muse_rot, rope_theta, eps, bs, mbs, st, pos0,
+                        qkv_packed ? qb : nullptr, qkv_packed ? qkvg_n : 0);
                     kernels::launch_prefill_attn_swa_pure_bf16(qb, kpool_bf, vpool_bf, btable, att,
                         N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, attn_scale, win_blocks,
                         st, pos0);
@@ -1935,6 +1967,10 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
                     }
                 }
             }
+            // With q|gate|k|v left packed, the gate is a column slice of that buffer rather than
+            // a tight [N, qdim] array; its three consumers take the pitch instead of a copy.
+            const bf16* gate_src = qkv_packed ? (const bf16*)(fp4_qkv + qdim) : (const bf16*)qg;
+            const int gate_ld = qkv_packed ? qkvg_n : 0;
             // Muse: the gated attention output feeds exactly one consumer -- the o projection's
             // row-quantize -- so fold the gate into that quantize's load phase. `att` is then never
             // written back as bf16 and never re-read, and one launch per layer goes away.
@@ -1945,7 +1981,8 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             // first and the int8 fold is skipped when it succeeds. Every arm therefore consumes a
             // gated activation and nothing reads the raw `att` -- the invariant #816 broke.
             const bool wo_fp4_gated = muse_nvfp4_wo && w.wo_fp4 && w.wo_fp4_sf && fp4_a && fp4_as &&
-                kernels::launch_prefill_nvfp4_gate_quant_a(att, qg, fp4_a, fp4_as, N, qdim, st);
+                kernels::launch_prefill_nvfp4_gate_quant_a(att, gate_src, fp4_a, fp4_as, N, qdim,
+                                                           st, gate_ld);
             const bool wo_fp4_done = wo_fp4_gated && c.muse_glimmer &&
                 kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_as, w.wo_fp4, w.wo_fp4_sf,
                                                    ao, N, H, qdim, fp4_ws, st);
@@ -1953,15 +1990,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             if (!wo_fp4_gated &&
                 c.muse_glimmer && muse_qb && use_i8 && w.wo_rs && H >= 128 &&
                 kernels::pf_dense_gemm_qi8_supported(w.wo_type) &&
-                kernels::launch_prefill_gate_quant_rows_i8(att, qg, A_i8, sx, N, qdim, st,
-                                                           A_i8p)) {
+                kernels::launch_prefill_gate_quant_rows_i8(att, gate_src, A_i8, sx, N, qdim, st,
+                                                           A_i8p, gate_ld)) {
                 a_q = att; a_qR = N; a_qK = qdim;      // quant_a_i8(att, N, qdim) is now a no-op
                 a_pk = A_i8p != nullptr;
                 gate_fused = true;
             }
             // If the fused quantize ran but the GEMM declined, `att` is still raw -- gate it here.
             if (!gate_fused && !wo_fp4_done) {
-                kernels::launch_prefill_mul_sigmoid(att, qg, N, qdim, st);
+                kernels::launch_prefill_mul_sigmoid(att, gate_src, N, qdim, st, gate_ld);
             }
             // o off the same NVFP4 bytes, reading the already-gated `att`, with the residual taken
             // by the epilogue's C operand (same fold as the GDN out_proj above) so no separate
@@ -2024,7 +2061,26 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
             // hn's only consumer is the grouped FFN's row-quantize, so emit the int8 in the same
             // pass. Only when one chunk covers the prompt: a second chunk would need A_i8/sx again
             // after the first has overwritten them. The bf16 hn is still written either way.
-            if (muse_ffn_group && muse_qb && use_i8 && FC >= N &&
+            //
+            // ...but that consumer only exists when the FFN takes an int8 arm, and on this
+            // checkpoint it does not: gate/up carry NVFP4 operands at every scored context, so the
+            // block-scaled arm below runs and A_i8 is written and never read. The write is N*H
+            // int8 -- 109 MB per layer per window at a 16384-token window, 11.3 GB over a 32k
+            // prefill -- and the quantize is folded into a norm that would otherwise be a plain
+            // read-modify-write. Same class as the ffn-wide staging removed for this path already;
+            // this is the H-wide one that survived it.
+            //
+            // The test is the FP4 arm's own gate at the chunk width this branch requires (FC >= N,
+            // so a single chunk of N rows). SPARKINFER_MUSE_FFN_I8_SKIP=0 restores the staging for
+            // an A/B out of one binary.
+            static const bool ffn_i8_skip = [] {
+                const char* e = getenv("SPARKINFER_MUSE_FFN_I8_SKIP");
+                return !(e && e[0] == '0');
+            }();
+            const bool ffn_fp4_certain = ffn_i8_skip && !moe && gu_nvfp4 &&
+                w.gate_fp4 && w.gate_fp4_sf && w.up_fp4 && w.up_fp4_sf && fp4_a && fp4_as &&
+                kernels::prefill_nvfp4_supported(N, ffn, H);
+            if (!ffn_fp4_certain && muse_ffn_group && muse_qb && use_i8 && FC >= N &&
                 kernels::launch_rmsnorm_quant_i8(h, w.ffn_norm, hn, A_i8, sx, N, H, eps, st,
                                                  A_i8p)) {
                 hn_quantized = true;


### PR DESCRIPTION
## Summary

Muse Glimmer's batched prefill materialises two activations that no kernel on the FP4 path reads: it copies `q|gate|k|v` out of the single GEMM that produced them into four tight arrays, and its pre-FFN norm stages an int8 activation for an int8 FFN arm that never runs. Both are removed by handing the existing consumers a row pitch instead.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (not targeted by this PR — flat at every context):

| | decode tok/s |
|---|--:|
| before (main) | — |
| after (this PR) | — |

**Prefill pp tok/s** (best context, 4096):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 14377.0 |
| after prefill (this PR) | 14768.3 |

### Every prefill context, one binary, two rounds per arm

| ctx | before | after |
|---|--:|--:|
| 128 | 9615.2 | 9825.8 |
| 512 | 15500.7 | 15846.1 |
| 4096 | 14377.0 | 14768.3 |
| 16384 | 13875.6 | 14211.0 |
| 32768 | 12667.7 | 12953.4 |
| 65536 | 10921.5 | 11135.3 |

Decode over the same runs: 106.68 → 106.33 at ctx 128 and 98.09 → 98.09 at 65536, i.e. unmoved.

### The split copies

The attention projections are one block-scaled GEMM into a packed `[N, 8704]` buffer, followed by four `cudaMemcpy2DAsync` that cut it into tight `qb`/`qg`/`kf`/`vf`. Measured over a prefill@128 pass those are 208 transfers, 115.87 MB, **0.261 ms — 2.0% of the pass**, moving 231.7 MB of read+write traffic at 888 GB/s.

None of it needs to happen. The QK-norm + RoPE + KV-append kernel already reads every q, k and v element, so it takes the packed row pitch and reads them in place; q still lands tight in its own destination because the attention that consumes it next wants that stride, and k and v go straight to the pools and never need a tight form at all. The gate's three consumers (the FP4 A-quantize, the int8 one, and the plain sigmoid multiply) take the same pitch. Zero added traffic — the copies are absorbed into passes that were already streaming those tensors.

### The int8 staging

The pre-FFN norm emits `hn` and, in the same pass, an int8 copy of it for the grouped int8 FFN. On this checkpoint that consumer does not exist: gate/up carry NVFP4 operands at every scored context, so the block-scaled arm runs and the int8 activation is written and never read. It is `N*H` bytes — 109 MB per layer per window at a 16384-token window, **11.3 GB over a 32k prefill** — and dropping it also turns a fused norm+quantize back into a plain read-modify-write. The test is the FP4 arm's own gate evaluated at the chunk width this branch already requires.

This is the same class as the ffn-wide staging already removed from this path; this is the H-wide one that survived it.

### Correctness

Bit-identical. `qwen3_gguf_prefill_check` at prefix 512 (bf16 KV) and 4096 (int8 KV), both arms:

```text
P=512   TOP1 12/16 0.7500   KL 0.14302   seed 220
P=4096  TOP1  6/16 0.3750   KL 0.21411   seed 220
```

Only the row pitch of a load changes and only a write nothing reads is dropped, so every value that reaches a GEMM is the value it reached before.

`SPARKINFER_MUSE_QKV_PACKED=0` and `SPARKINFER_MUSE_FFN_I8_SKIP=0` restore the copies and the staging respectively, for a paired A/B out of one binary.
