### PR TITLE
feat(eval): declare the target model in the PR, and stop evaluating PRs that cannot move a bot's axes

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -32,6 +32,19 @@
 
 - [ ] Tested on **RTX 5090** (`sm_120`)
 
+**Target model(s)** — tick every model this change is meant to speed up. This decides which bots
+spend GPU time on it: a bot whose model you did **not** tick may skip your PR instead of spending a
+~20-minute round proving a change it cannot move. Tick nothing and every bot evaluates it, as before.
+
+- [ ] **Muse Glimmer**
+- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
+- [ ] **Shared / both** — the change is in code both models use and should help either
+
+> Tick **Shared / both** if you are unsure, or if the code you touched is shared (`qwen35.cpp`,
+> `qwen35_prefill.cpp`, most of `kernels/`). Over-ticking only costs eval time; under-ticking can
+> cost you a tier a bot would have awarded. Declaring a model you did not target in order to dodge
+> a no-regression guard is gaming, and is treated like false attestation.
+
 **Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):
 
 | | decode tok/s |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,27 @@ Requesting an axis is a normal, welcome contribution — most of the current axe
 somebody asked. What is *not* welcome is redefining what an existing axis measures in order to
 move it; see *Do not redefine what a scored dimension measures* below.
 
+**Declare which model(s) your PR targets.** The template has a **Target model(s)** block next to
+the RTX 5090 box — tick every model your change is meant to speed up. It decides which bots spend
+GPU on it:
+
+- a bot whose model you **did not** tick may skip your PR rather than spend a ~20-minute round
+  proving a change it cannot move;
+- **tick nothing and every bot evaluates it**, exactly as before this existed — the declaration can
+  only ever remove work you have said is pointless, never cause a PR to go unevaluated by accident;
+- **tick `Shared / both` when unsure**, or when you touched shared code (`qwen35.cpp`,
+  `qwen35_prefill.cpp`, most of `kernels/`) — most optimizations land there and genuinely help more
+  than one model. Over-ticking costs eval time; under-ticking can cost you a tier a bot would have
+  awarded.
+
+This exists because it was being paid for in wasted GPU: [#1025](../../pull/1025)
+(`perf(muse)`, a Muse Glimmer prefill change) consumed a full DSpark round to conclude `+0.1%` →
+`eval-dspark:none`, and [#1018](../../pull/1018) and [#1023](../../pull/1023) did the same before it.
+
+> **Declaring a model you did not target, to dodge a guard, is gaming.** The no-regression guards
+> exist because the code is shared — a change aimed at one model regularly lands in another's path.
+> Mis-declaring to route around one is treated like false attestation on the 5090 box.
+
 **Evaluation is opt-in and proof-gated.** The RTX 5090 eval runs only when **both** hold: you tick
 **`- [x] Tested on RTX 5090`** *and* fill **either** the template's **decode tok/s** table **or**
 its **prefill pp tok/s** table with a real end-to-end improvement (`after > before`, from
@@ -157,8 +178,20 @@ can lag them.
 | [`eval/pr_museglimmer_bot.py`](eval/pr_museglimmer_bot.py) | Muse Glimmer | prefill **and** decode at **ctx 128 / 512 / 4k / 16k / 32k / 64k** — twelve axes, any one of which can earn the tier |
 | [`eval/pr_dspark_bot.py`](eval/pr_dspark_bot.py) | Qwen3.8-27B ModelOpt NVFP4 + DSpark draft | DSpark decode and DSpark-enabled batched prefill at **ctx 4k / 16k / 32k**, plus target prefill and decode at **ctx 256k** |
 
-Both bots additionally run **no-regression guards** on models they are not scoring (Qwen3.6 and
-ModelOpt), because the code is shared — see the gate table in *Lane 1*.
+Both bots additionally run **no-regression guards** on models they are not scoring, because the
+code is shared — see the gate table in *Lane 1*:
+
+| Bot | Guards it runs |
+|---|---|
+| Muse Glimmer bot | Qwen3.6 **and** ModelOpt (Qwen3.8) @ ctx 32k |
+| DSpark bot | Qwen3.6 **and** Qwen3.8 @ ctx 16k |
+
+**Which bots honour your `Target model(s)` declaration follows from that table.** The DSpark bot
+skips a PR declared Muse-only, because the Muse bot's own run still guards Qwen3.8 and Qwen3.6 — so
+nothing goes unchecked. The Muse bot does **not** yet skip a PR declared Qwen3.8-only, because no
+bot currently guards Muse Glimmer from the other side; skipping there would let a Muse regression
+land unnoticed. That asymmetry is a gap in the harness, not a policy: it closes when a Muse guard
+is added to the DSpark bot.
 
 **This list is not a menu, and it is not exhaustive.** It is what happens to be wired up today.
 If your optimization is real and lands somewhere none of these axes reach, that is a reason to

--- a/eval/pr_dspark_bot.py
+++ b/eval/pr_dspark_bot.py
@@ -3185,6 +3185,20 @@ def main():
         if not args.reeval and head and head in qwen38_evaluated_commits(args.repo, num):
             print(f"PR #{num} @ {short}: already dspark-evaluated — skip")
             continue
+        # Before the greenlight and before any GPU time: did the author declare this PR targets a
+        # DIFFERENT model? A Muse-Glimmer prefill change cannot move the Qwen3.8 axes, and proving
+        # that costs a full ~20-minute round (#1025 scored `none` at +0.1%; #1018 and #1023 the
+        # same). arb.model_skip_reason() fails open — an absent or ambiguous declaration evaluates.
+        #
+        # Safe to skip here specifically because the Muse bot runs BOTH a ModelOpt (Qwen3.8) and a
+        # Qwen3.6 guard on every PR it scores, so a Muse-declared PR is still regression-checked
+        # against this bot's models. The reverse is NOT true (nothing guards Muse Glimmer from this
+        # bot's side), which is why pr_museglimmer_bot.py deliberately does not do this.
+        skip_why = arb.model_skip_reason(pr.get("body") or "", "qwen38")
+        if skip_why:
+            print(f"PR #{num}: {skip_why} — skip dspark eval (guarded by the Muse bot's "
+                  f"ModelOpt + Qwen3.6 guards)")
+            continue
         # Before the greenlight and before any GPU time: does this PR edit the measuring
         # instrument? Checked here rather than at auto-merge because a harness PR should not
         # consume a 20-minute round to produce a number that cannot be accepted either way.

--- a/eval/pr_eval_bot.py
+++ b/eval/pr_eval_bot.py
@@ -1006,6 +1006,59 @@ def rtx5090_should_close(body, areas=None):
         return True
     return rtx5090_has_checkbox(body)
 
+# --- declared target model ------------------------------------------------------------------
+#
+# The PR template asks which model(s) a change is meant to speed up. Bots use it to avoid burning
+# a ~20-minute round proving that a Muse-Glimmer prefill change does nothing for Qwen3.8 (the
+# case that motivated this: #1025, `perf(muse)`, scored `eval-dspark:none` at +0.1% after a full
+# DSpark eval; #1018 and #1023 before it).
+#
+# FAIL-OPEN BY DESIGN. A missing, empty, unparseable or ambiguous declaration means "evaluate
+# everywhere", exactly as before this existed. The declaration can only ever REMOVE work that the
+# author has explicitly said is pointless; it can never cause a PR to go unevaluated by accident.
+#
+# Skipping is only safe where some OTHER bot still guards the skipped model against regressions --
+# shared code means a change aimed at one model can break another. See model_skip_reason().
+MODEL_KEYS = {
+    "muse":    ("muse",),                       # Muse Glimmer
+    "qwen38":  ("qwen3.8", "qwen38", "dspark", "modelopt"),
+    "shared":  ("shared", "both", "all models", "any model"),
+}
+
+
+def declared_models(body):
+    """Parse the PR template's 'Target model(s)' ticked checkboxes.
+
+    Returns a set of keys from MODEL_KEYS, or an empty set when nothing is declared (or the
+    declaration cannot be read) -- callers must treat empty as "no opinion, evaluate"."""
+    out = set()
+    for ln in (body or "").splitlines():
+        m = re.match(r"\s*[-*]\s*\[\s*([xX])\s*\]\s*(.+)$", ln)
+        if not m:
+            continue
+        text = m.group(2).lower()
+        if "5090" in text:            # the attestation checkbox, not a model declaration
+            continue
+        for key, needles in MODEL_KEYS.items():
+            if any(n in text for n in needles):
+                out.add(key)
+    return out
+
+
+def model_skip_reason(body, my_model):
+    """Should a bot that scores `my_model` skip this PR on its declared target?
+
+    Returns a reason string to skip, or None to evaluate. Skips only when the author ticked a
+    specific model, did NOT tick this bot's model, and did NOT tick shared/both."""
+    declared = declared_models(body)
+    if not declared or "shared" in declared or my_model in declared:
+        return None
+    if not (declared - {"shared"}):
+        return None
+    names = ", ".join(sorted(declared))
+    return f"declared target model(s): {names} — not {my_model}"
+
+
 def greenlight_status(repo, num, pr_labels):
     """Decide whether a PR may be evaluated. Returns (status, reason):
       'ok'        — greenlit: box ticked + real decode and/or prefill before<after gain

--- a/eval/test_pr_eval_bot.py
+++ b/eval/test_pr_eval_bot.py
@@ -1165,5 +1165,65 @@ class GenericEvalLabelTest(unittest.TestCase):
 
 
 
+
+class DeclaredTargetModelTest(unittest.TestCase):
+    """declared_models()/model_skip_reason(): a bot may skip a PR the author says targets a
+    different model, but ONLY on an explicit declaration -- everything else evaluates."""
+
+    TICKED = ("- [x] Muse Glimmer\n"
+              "- [ ] Qwen3.8-27B (ModelOpt NVFP4 / DSpark)\n"
+              "- [ ] Shared / both\n")
+
+    def test_parses_ticked_model(self):
+        self.assertEqual(bot.declared_models(self.TICKED), {"muse"})
+
+    def test_dspark_skips_a_muse_only_pr(self):
+        # The #1025 case: perf(muse) burned a full DSpark round to score none at +0.1%.
+        why = bot.model_skip_reason(self.TICKED, "qwen38")
+        self.assertIsNotNone(why)
+        self.assertIn("muse", why)
+
+    def test_muse_bot_would_not_skip_its_own_pr(self):
+        self.assertIsNone(bot.model_skip_reason(self.TICKED, "muse"))
+
+    def test_shared_ticked_runs_everywhere(self):
+        body = ("- [x] Muse Glimmer\n- [ ] Qwen3.8-27B (ModelOpt NVFP4 / DSpark)\n"
+                "- [x] Shared / both\n")
+        self.assertIsNone(bot.model_skip_reason(body, "qwen38"))
+
+    def test_both_models_ticked_runs_everywhere(self):
+        body = "- [x] Muse Glimmer\n- [x] Qwen3.8-27B (ModelOpt NVFP4 / DSpark)\n"
+        self.assertIsNone(bot.model_skip_reason(body, "qwen38"))
+        self.assertIsNone(bot.model_skip_reason(body, "muse"))
+
+    # --- fail-open: none of these may ever cause a skip ---
+
+    def test_no_declaration_evaluates(self):
+        self.assertIsNone(bot.model_skip_reason("## Summary\nmakes it faster", "qwen38"))
+
+    def test_empty_body_evaluates(self):
+        self.assertIsNone(bot.model_skip_reason("", "qwen38"))
+        self.assertIsNone(bot.model_skip_reason(None, "qwen38"))
+
+    def test_unticked_boxes_evaluate(self):
+        body = "- [ ] Muse Glimmer\n- [ ] Qwen3.8-27B (ModelOpt NVFP4 / DSpark)\n"
+        self.assertIsNone(bot.model_skip_reason(body, "qwen38"))
+
+    def test_unrecognised_model_name_evaluates(self):
+        self.assertIsNone(bot.model_skip_reason("- [x] Some Future Model\n", "qwen38"))
+
+    def test_rtx5090_attestation_box_is_not_a_model(self):
+        # The attestation checkbox must never be read as a target declaration.
+        body = "- [x] Tested on **RTX 5090** (`sm_120`)\n"
+        self.assertEqual(bot.declared_models(body), set())
+        self.assertIsNone(bot.model_skip_reason(body, "qwen38"))
+
+    def test_dspark_and_modelopt_aliases_map_to_qwen38(self):
+        for alias in ("- [x] DSpark\n", "- [x] ModelOpt NVFP4\n", "- [x] Qwen3.8-27B\n"):
+            self.assertEqual(bot.declared_models(alias), {"qwen38"}, alias)
+            self.assertIsNone(bot.model_skip_reason(alias, "qwen38"), alias)
+
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## The waste

Both bots evaluate every greenlit PR, so a Muse Glimmer change pays for a full DSpark round to be
told it did nothing for Qwen3.8:

| PR | what it is | DSpark result |
|---|---|---|
| [#1025](../../pull/1025) | `perf(muse)`, Muse prefill | `eval-dspark:none`, **+0.1%**, after a ~20-min eval |
| [#1018](../../pull/1018) | `perf(muse)`, Muse prefill@64k | `eval-dspark:none`, +1.4% (scored `L` **+15.3%** by the Muse bot) |
| [#1023](../../pull/1023) | `perf(muse)`, Muse prefill@4k | judged on decode, skipped |

That is most of a GPU hour a day spent proving things the authors already knew.

## The change

The PR template gets a **Target model(s)** block next to the RTX 5090 box, and CONTRIBUTING
documents it. A bot whose model you did not tick may skip your PR.

```
- [ ] Muse Glimmer
- [ ] Qwen3.8-27B (ModelOpt NVFP4 / DSpark)
- [ ] Shared / both — the change is in code both models use and should help either
```

## Fail-open by construction

`arb.model_skip_reason()` skips **only** when the author ticked a specific model, did not tick this
bot's model, and did not tick `Shared / both`. Every other case evaluates exactly as before:

- nothing declared, or no box ticked
- an unrecognised model name
- `Shared / both` ticked, or more than one model ticked
- the `Tested on RTX 5090` attestation box (explicitly never read as a model declaration)

The declaration can only ever *remove* work the author has said is pointless — it can never cause a
PR to go unevaluated by accident. Verified against the real #1025 body, which predates the field:

```
declared    : (nothing — fails open)
dspark skip?: no — would evaluate
muse skip?  : no — would evaluate
```

## Why only the DSpark bot honours it

Deliberate, not partial work. Skipping is safe only where **another bot still guards the skipped
model** — shared code means a change aimed at one model regularly lands in another's path:

| Bot | Guards it runs |
|---|---|
| Muse | Qwen3.6 **and** ModelOpt (Qwen3.8) @32k |
| DSpark | Qwen3.6 **and** Qwen3.8 @16k — **nothing guards Muse Glimmer** |

So DSpark can skip a Muse-declared PR and lose no coverage. The Muse bot skipping a Qwen3.8-declared
PR would let a Muse regression land unnoticed, so it does not skip. CONTRIBUTING records this as a
harness gap that closes when a Muse guard is added to the DSpark bot — not as policy.

Mis-declaring to route around a guard is documented as gaming, treated like false attestation.

## Tests

11 new cases in `test_pr_eval_bot.py` — the #1025 skip, the `dspark`/`modelopt`/`qwen3.8` aliases,
`Shared / both`, both-ticked, and every fail-open path.

```
eval/test_pr_eval_bot.py   84 OK   (11 new)
eval/test_pr_dspark_bot.py 10 OK
eval/test_copycat_guard.py  7 OK
```

`eval/` is in `HARNESS_PATHS`, so the bots skip evaluating this PR rather than spending GPU on it.
