### PR TITLE
perf(muse): decode concurrent requests in one packed forward (1.42x concurrent decode @c8)

### DIFF
--- a/kernels/csrc/cuda/attention/sparse_kv.cu
+++ b/kernels/csrc/cuda/attention/sparse_kv.cu
@@ -219,6 +219,43 @@ void launch_fa_kv_compact_view_pure(
         seq_lens, block_table, view_table, view_len, block_size, window_w, n_view);
 }
 
+// Per-ROW form of the above, for packed continuous-batch decode: one block builds one row's
+// view, so N independent sequences get N compact windows in a single launch. Identical
+// arithmetic per row -- the single-row launcher is exactly this with N == 1 -- so a windowed
+// layer sees the same view it would have seen decoding that sequence alone.
+//
+// `block_table` is the ROW-GATHERED table (stride max_blocks, as produced by
+// launch_gather_rows_i32), `seq_lens` is [rows], and the outputs are [rows][n_view] / [rows].
+__global__ void fa_kv_compact_view_pure_rows(
+    const int* __restrict__ seq_lens, const int* __restrict__ block_table,
+    int* __restrict__ view_table, int* __restrict__ view_len,
+    int block_size, int window_w, int n_view, int max_blocks
+) {
+    const int r = blockIdx.x;
+    const int sl = seq_lens[r];
+    const int* __restrict__ bt = block_table + (size_t)r * max_blocks;
+    int* __restrict__ vt = view_table + (size_t)r * n_view;
+    const int n_blk = (sl + block_size - 1) / block_size;
+    if (window_w >= n_blk) {
+        for (int b = threadIdx.x; b < n_blk && b < n_view; b += blockDim.x) vt[b] = bt[b];
+        if (threadIdx.x == 0) view_len[r] = sl;
+        return;
+    }
+    const int recent_start = n_blk - window_w;
+    if (threadIdx.x == 0) view_len[r] = sl - recent_start * block_size;
+    for (int i = threadIdx.x; i < window_w && i < n_view; i += blockDim.x)
+        vt[i] = bt[recent_start + i];
+}
+
+void launch_fa_kv_compact_view_pure_rows(
+    const int* seq_lens, const int* block_table, int* view_table, int* view_len,
+    int block_size, int window_w, int n_view, int max_blocks, int rows, cudaStream_t stream
+) {
+    if (rows < 1) return;
+    fa_kv_compact_view_pure_rows<<<rows, 256, 0, stream>>>(
+        seq_lens, block_table, view_table, view_len, block_size, window_w, n_view, max_blocks);
+}
+
 void launch_flash_decode_split_sparse(
     const void* q, const void* k_pool_layer, const void* v_pool_layer,
     const int* block_table, const int* seq_lens, const int* sel_blk,

--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -3822,7 +3822,11 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
     // the token loop, and DFlash speculation could never engage on Qwen3.8 at all. 20 (5120) and
     // 24 (6144) are added for exactly that.
     if (M < 1 || M > 8 || N < 1) return false;
-    if (K != 2048 && K != 4096 && K != 5120 && K != 6144) return false;
+    // 26 (6656) is Muse Glimmer's hidden size, added for the same reason 20/24 were: every Q4_K
+    // projection off xn -- wq, the separate q-gate wgate, wk, wv -- is K=6656 there, so without it
+    // this launcher refuses the whole model and any multi-row Muse path (packed continuous-batch
+    // decode, speculation) silently falls back to one row at a time.
+    if (K != 2048 && K != 4096 && K != 5120 && K != 6144 && K != 6656) return false;
     // Dispatch the tightest instantiated row width: MMAX bounds tmp[]/partial[] and the
     // number of predicated row bodies, so a 6-row block should not pay an 8-row footprint.
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
@@ -3837,23 +3841,30 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
     if      (K == 2048) SI_Q4K_ROWS_DISPATCH(8);
     else if (K == 4096) SI_Q4K_ROWS_DISPATCH(16);
     else if (K == 5120) SI_Q4K_ROWS_DISPATCH(20);
-    else                SI_Q4K_ROWS_DISPATCH(24);
+    else if (K == 6144) SI_Q4K_ROWS_DISPATCH(24);
+    else                SI_Q4K_ROWS_DISPATCH(26);
     #undef SI_Q4K_ROWS_DISPATCH
     return true;
 }
 bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
-    if (M < 1 || M > 8 || N < 1 || (K != 2048 && K != 4096)) return false;
+    // 26 (6656) is Muse Glimmer's hidden size. A Q4_K_M file gives half its layers a Q6_K
+    // attn_v, so without this width every one of those layers refuses the multi-row path -- and
+    // refuses it SILENTLY, since a false here is indistinguishable at the call site from "this
+    // weight type is not implemented". Same reason 20/24 were added to the Q4_K launcher above.
+    if (M < 1 || M > 8 || N < 1 || (K != 2048 && K != 4096 && K != 6656)) return false;
     const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
     const auto* w = reinterpret_cast<const unsigned char*>(W);
     auto* out = reinterpret_cast<__nv_bfloat16*>(y);
-    if (K == 2048) {
-        if (M <= 6) si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 6><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
-        else        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 8, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
-    } else {
-        if (M <= 6) si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 6><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
-        else        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, 16, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N);
-    }
+    #define SI_Q6K_ROWS_DISPATCH(KB) \
+        do { \
+            if (M <= 6) si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, KB, 6><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            else        si_mmvq_q6k_rows_exact_kernel<__nv_bfloat16, KB, 8><<<N, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+        } while (0)
+    if      (K == 2048) SI_Q6K_ROWS_DISPATCH(8);
+    else if (K == 4096) SI_Q6K_ROWS_DISPATCH(16);
+    else                SI_Q6K_ROWS_DISPATCH(26);
+    #undef SI_Q6K_ROWS_DISPATCH
     return true;
 }
 bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
@@ -3879,6 +3890,23 @@ bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
 }
 bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
                       int M, int N, int K, cudaStream_t stream) {
+    // Every rows kernel below carries exact, compile-time-bounded row bodies only to M=8, so a
+    // wider batch used to be refused outright -- and a refusal here declines the WHOLE packed
+    // forward, which then decodes its rows one at a time and re-reads every weight once per row.
+    // Chunk instead, exactly as launch_mmvq_rows_f32 already does: MMAX bounds the scratch and
+    // the number of predicated row bodies, not the per-row dot or its reduction order, so a row
+    // computes the same bits whichever chunk carries it.
+    if (M > 8) {
+        for (int r0 = 0; r0 < M; r0 += 8) {
+            const int m = (M - r0) < 8 ? (M - r0) : 8;
+            if (!launch_mmvq_rows(qtype,
+                                  reinterpret_cast<const si_block_q8_1*>(q81)
+                                      + (size_t)r0 * (size_t)(K >> 5),
+                                  W, reinterpret_cast<__nv_bfloat16*>(y) + (size_t)r0 * N,
+                                  m, N, K, stream)) return false;
+        }
+        return true;
+    }
     if (qtype == 12) return launch_mmvq_q4k_rows(q81, W, y, M, N, K, stream);
     if (qtype == 14) return launch_mmvq_q6k_rows(q81, W, y, M, N, K, stream);
     if (qtype == 8)  return launch_mmvq_q80_rows(q81, W, y, M, N, K, stream);
@@ -3902,7 +3930,7 @@ bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
     // Same instantiated-width limit as launch_mmvq_q4k_rows above, and the same consequence:
     // this is the LM-head path, so K=5120 (Qwen3.8's hidden) refused here made the verify decline
     // AFTER every layer had already succeeded -- "unsupported LM head type=12 H=5120".
-    if (qtype == 12 && (K == 2048 || K == 4096 || K == 5120 || K == 6144)) {
+    if (qtype == 12 && (K == 2048 || K == 4096 || K == 5120 || K == 6144 || K == 6656)) {
         const int grid = (N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS;
         // The verify's LM head is the one call here that runs at a width the planner chooses, so it
         // is the one that pays for a loose MMAX. SPARKINFER_Q4K_OROWS pins the weight-rows-per-CTA
@@ -3928,7 +3956,8 @@ bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
         if      (K == 2048) SI_Q4K_ROWS_F32_DISPATCH(8);
         else if (K == 4096) SI_Q4K_ROWS_F32_DISPATCH(16);
         else if (K == 5120) SI_Q4K_ROWS_F32_DISPATCH(20);
-        else                SI_Q4K_ROWS_F32_DISPATCH(24);
+        else if (K == 6144) SI_Q4K_ROWS_F32_DISPATCH(24);
+        else                SI_Q4K_ROWS_F32_DISPATCH(26);   // 6656: Muse Glimmer's LM head
         #undef SI_Q4K_ROWS_F32_DISPATCH
         return true;
     }

--- a/kernels/include/sparkinfer/kernels/attention.h
+++ b/kernels/include/sparkinfer/kernels/attention.h
@@ -209,6 +209,11 @@ void launch_fa_kv_compact_view(const int* seq_lens, const int* block_table, int*
 // not an optional long-context approximation.
 void launch_fa_kv_compact_view_pure(const int* seq_lens, const int* block_table, int* view_table,
     int* view_len, int block_size, int window_w, int n_view, cudaStream_t stream = nullptr);
+// Per-ROW form for packed continuous-batch decode: N sequences, N compact windows, one launch.
+// block_table is the row-gathered table (stride max_blocks); outputs are [rows][n_view]/[rows].
+void launch_fa_kv_compact_view_pure_rows(const int* seq_lens, const int* block_table,
+    int* view_table, int* view_len, int block_size, int window_w, int n_view, int max_blocks,
+    int rows, cudaStream_t stream = nullptr);
 void launch_flash_decode_split_sparse(const void* q, const void* k_pool_layer, const void* v_pool_layer,
     const int* block_table, const int* seq_lens, const int* sel_blk, float* part_m, float* part_l,
     float* part_acc, int num_q_heads, int num_kv_heads, int head_dim, int block_size, int max_blocks,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -30,6 +30,7 @@
 #include "sparkinfer/kernels/moe.h"
 #include "sparkinfer/kernels/attention.h"
 #include "sparkinfer/models/dflash_kernels.h"
+#include "sparkinfer/kv_ops.h"
 
 #include <cuda_runtime.h>
 #include <algorithm>
@@ -3034,6 +3035,15 @@ int prefill_batched_run(const Qwen35PrefillCtx& s, const int* prompt_ids, int n,
     return seed;
 }
 
+// SPARKINFER_MUSE_PACKED=0 forces Muse Glimmer back to one-sequence-at-a-time decoding, for an
+// A/B out of one binary.
+static bool muse_packed_on() {
+    static const bool v = [] {
+        const char* e = getenv("SPARKINFER_MUSE_PACKED");
+        return !(e && e[0] == '0');
+    }();
+    return v;
+}
 int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int n, int start_pos,
                             const int* capture_layers, int n_capture, void* capture_dst,
                             int* out_argmax, bool capture_only) {
@@ -3055,7 +3065,15 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 n, (int)s.gguf, (int)c.hybrid);
         return -1;
     }
-    if (c.head_dim != 256 || c.linear_head_dim != 128 || c.top_k <= 0 ||
+    // Muse Glimmer takes its own layer body below (`muse`): 128-wide heads, a separate attn_gate
+    // tensor, NORM-convention RoPE on the windowed layers and none at all on the global ones, a
+    // per-layer sliding-window view, and sandwich norms around both blocks. None of that is a
+    // variation on the Qwen3.5/3.6/3.8 layer this function was written for, so it is a branch
+    // rather than a widening -- exactly as prefill_batched_run carries it.
+    const bool muse = c.muse_glimmer && dense && c.head_dim == 128 &&
+                      c.sliding_window > 0 && muse_packed_on();
+    const bool hd_ok = (c.head_dim == 256) || muse;
+    if (!hd_ok || c.linear_head_dim != 128 || c.top_k <= 0 ||
         (!dense && c.n_experts != 256)) {
         fprintf(stderr, "[dflash-verify] shape unsupported hd=%d lhd=%d experts=%d topk=%d dense=%d\n",
                 c.head_dim, c.linear_head_dim, c.n_experts, c.top_k, (int)dense);
@@ -3272,17 +3290,49 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     int* out_ids = a.alloc<int>(NA);
     const size_t q81_stride_max = kernels::llama_q8_1_bytes(std::max(H, lvdim));
     void* q81 = a.alloc<unsigned char>((size_t)NA * q81_stride_max);
+    // Muse Glimmer's windowed layers score against a compact sliding-window view, and the split
+    // count that view wants is chosen for the VIEW's length rather than the sequence's -- 64 at a
+    // 2048-token window against the model's adaptive n_splits. Both are per-model constants, so
+    // sizing the partials for the larger keeps the arena layout identical across graph tiers.
+    const int swa_bs = s.kv->block_size();
+    const int swa_budget = muse ? (c.sliding_window + swa_bs - 1) / swa_bs : 0;
+    int swa_vsplits = 1;
+    if (muse) {
+        swa_vsplits = (swa_budget * swa_bs) / 32;   // same rule as qwen35.cpp's swa_vsplits
+        if (swa_vsplits > 256) swa_vsplits = 256;
+        if (swa_vsplits < 1) swa_vsplits = 1;
+    }
     const int ns = std::max(1, s.n_splits);
-    float* fa_m = a.alloc<float>((size_t)NA * c.n_q_heads * ns);
-    float* fa_l = a.alloc<float>((size_t)NA * c.n_q_heads * ns);
-    float* fa_acc = a.alloc<float>((size_t)NA * c.n_q_heads * ns * c.head_dim);
-    // Compact recurrence records retained until posterior selection.
-    bf16* rec_qkv = a.alloc<bf16>((size_t)c.n_layers * NA * lqkv);
-    bf16* rec_k = a.alloc<bf16>((size_t)c.n_layers * NA * s.linear_qdim);
-    bf16* rec_v = a.alloc<bf16>((size_t)c.n_layers * NA * lvdim);
-    bf16* rec_a = a.alloc<bf16>((size_t)c.n_layers * NA * vh);
-    bf16* rec_b = a.alloc<bf16>((size_t)c.n_layers * NA * vh);
-    if (!a.ok) { fprintf(stderr, "[dflash-verify] scratch allocation failed\n"); return -1; }
+    const int nsa = ns > swa_vsplits ? ns : swa_vsplits;
+    float* fa_m = a.alloc<float>((size_t)NA * c.n_q_heads * nsa);
+    float* fa_l = a.alloc<float>((size_t)NA * c.n_q_heads * nsa);
+    float* fa_acc = a.alloc<float>((size_t)NA * c.n_q_heads * nsa * c.head_dim);
+    // One compact window per row: the packed rows are independent sequences, so each needs its
+    // own logical->physical map and its own view length.
+    int* swa_vtbl = muse ? a.alloc<int>((size_t)NA * swa_budget) : nullptr;
+    int* swa_vlen = muse ? a.alloc<int>(NA) : nullptr;
+    // Compact recurrence records retained until posterior selection. Only the Gated-DeltaNet
+    // branch writes or reads them, so a stack with no linear-attention layer (Muse Glimmer, whose
+    // full_attn_interval is 0) allocates ~48 MB of arena it can never touch -- and this arena is
+    // sized for the WIDEST tier, so it is 48 MB claimed on every model that carries the flag
+    // without carrying the layers. At c=32 on a full card that is the difference between the
+    // packed forward running and declining outright.
+    bool any_linear = false;
+    for (int L = 0; L < c.n_layers && !any_linear; ++L) any_linear = s.w.layers[L].linear_attn != 0;
+    bf16* rec_qkv = any_linear ? a.alloc<bf16>((size_t)c.n_layers * NA * lqkv) : nullptr;
+    bf16* rec_k = any_linear ? a.alloc<bf16>((size_t)c.n_layers * NA * s.linear_qdim) : nullptr;
+    bf16* rec_v = any_linear ? a.alloc<bf16>((size_t)c.n_layers * NA * lvdim) : nullptr;
+    bf16* rec_a = any_linear ? a.alloc<bf16>((size_t)c.n_layers * NA * vh) : nullptr;
+    bf16* rec_b = any_linear ? a.alloc<bf16>((size_t)c.n_layers * NA * vh) : nullptr;
+    if (!a.ok) {
+        // Name the size. "allocation failed" alone reads as a bug; on a full card it is the card
+        // being full, and the prefill path's own fallback message already reports it that way.
+        size_t vfree = 0, vtot = 0;
+        cudaMemGetInfo(&vfree, &vtot);
+        fprintf(stderr, "[dflash-verify] scratch allocation failed (arena=%zu MB, free=%zu/%zu MB)\n",
+                a.total() >> 20, vfree >> 20, vtot >> 20);
+        return -1;
+    }
 
     static thread_local int* ph_ids = nullptr;
     static thread_local int* ph_pos = nullptr;
@@ -3688,6 +3738,18 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             dflash_kernels::launch_broadcast_rows_i32(btable, btab_rows, mbs, N, st);
     }
     kernels::launch_embedding(ids, s.w.embed_tokens, x, N, H, st);
+    if (muse) {
+        // Unweighted RMSNorm of the embedding before layer 0 (emb_norm_ones is a constant-1.0
+        // "weight"), exactly as AR decode and the batched prefill do.
+        if (s.emb_norm_ones)
+            kernels::launch_rmsnorm(x, s.emb_norm_ones, x, N, H, c.rms_eps, st);
+        // Materialize every row's pure sliding-window view once per step: the logical->physical
+        // block map and the view length are shared by all 39 windowed layers, only the per-layer
+        // K/V pool rows differ. Inside the capture, so a replay tracks each sequence as it grows.
+        kernels::launch_fa_kv_compact_view_pure_rows(
+            seq, btab_rows ? btab_rows : btable, swa_vtbl, swa_vlen,
+            bs, swa_budget, swa_budget, mbs, N, st);
+    }
     kernels::launch_rmsnorm(x, s.w.layers[0].input_norm, xn, N, H, c.rms_eps, st);
     for (int L = 0; L < c.n_layers && supported; ++L) {
         // Reset the dp4a activation cache every layer. `xn` is the SAME buffer at every layer, so
@@ -3710,6 +3772,96 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         vdbg_snapshot(xn, L);
         if (L == 0) vdbg_snapshot2(x, 4);   // raw pre-norm residual stream (h = x + ao)
         const Qwen35LayerWeights& w = s.w.layers[L];
+        if (muse) {
+            // ---- MUSE GLIMMER LAYER (packed continuous-batch decode) ----
+            // Every kernel here is the one AR decode already drives for this architecture
+            // (qwen35.cpp's c.muse_glimmer branches), taken at N rows instead of one. The rows
+            // are N independent sequences, so each carries its own position and its own KV block
+            // table, and the row-indexed forms of the append/attention kernels are exactly the
+            // ones that read those per row.
+            //
+            // Muse keeps attn_gate as its OWN [qdim, H] tensor rather than the [q|gate] interleave
+            // every other architecture here ships, so Q goes straight to qb and the gate straight
+            // to qg. Projecting w.wq as one 2*qdim-wide matrix would read qdim rows PAST it.
+            supported = proj(xn, w.wq, w.wq_type, qb, qdim, H) &&
+                        w.wgate && proj(xn, w.wgate, w.wgate_type, qg, qdim, H) &&
+                        proj(xn, w.wk, w.wk_type, kf, kvdim, H) &&
+                        proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+            if (!supported) break;
+            // QK-norm is per HEAD vector, so N tokens is just N*heads rows of the same kernel.
+            kernels::launch_rmsnorm(qb, w.q_norm, qb, N * c.n_q_heads,  c.head_dim, c.rms_eps, st);
+            kernels::launch_rmsnorm(kf, w.k_norm, kf, N * c.n_kv_heads, c.head_dim, c.rms_eps, st);
+            char* kp = static_cast<char*>(s.kv->k_pool()) +
+                       s.kv->layer_base_elems(L) * kv_elem;
+            char* vp = static_cast<char*>(s.kv->v_pool()) +
+                       s.kv->layer_base_elems(L) * kv_elem;
+            char* ks = kv8 ? static_cast<char*>(s.kv->k_scale_pool()) +
+                             s.kv->scale_layer_base_elems(L) * 2 : nullptr;
+            char* vs = kv8 ? static_cast<char*>(s.kv->v_scale_pool()) +
+                             s.kv->scale_layer_base_elems(L) * 2 : nullptr;
+            // Windowed layers rotate the CONSECUTIVE pair (LLAMA_ROPE_TYPE_NORM, not the NeoX
+            // split-half pairing the rest of this file uses); the every-4th global layers are
+            // NoPE and append K/V unrotated. Both flavours index block_table[row*max_blocks+blk]
+            // and positions[row], which is what makes them correct for packed rows unchanged.
+            const int* rtab = btab_rows ? btab_rows : btable;
+            if (kv8) {
+                kernels::launch_muse_kv_append_int8(
+                    qb, kf, vf, kp, vp, ks, vs, rtab, pos, N,
+                    c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta,
+                    /*rope_normal=*/w.swa != 0, bs, mbs, st);
+            } else if (w.swa) {
+                kernels::launch_rope_kv_append_normal(
+                    qb, kf, vf, kp, vp, rtab, pos, N,
+                    c.n_q_heads, c.n_kv_heads, c.head_dim, c.rope_theta, bs, mbs, st);
+            } else {
+                launch_kv_append(kp, vp, kf, vf, rtab, pos, N,
+                                 c.n_kv_heads, c.head_dim, bs, mbs, st);
+            }
+            // Windowed layer: same flash-decode entry point, pointed at this row's compact view
+            // instead of the full KV. Global layer: full causal over the real table.
+            if (w.swa) {
+                kernels::launch_flash_decode_split(
+                    qb, kp, vp, swa_vtbl, swa_vlen, att, fa_m, fa_l, fa_acc,
+                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, swa_budget, swa_vsplits,
+                    1.f / sqrtf((float)c.head_dim), st, nullptr, swa_budget * bs,
+                    ks, vs, kv8 ? 1 : 0);
+            } else {
+                kernels::launch_flash_decode_split(
+                    qb, kp, vp, rtab, seq, att, fa_m, fa_l, fa_acc,
+                    N, c.n_q_heads, c.n_kv_heads, c.head_dim, bs, mbs, ns,
+                    1.f / sqrtf((float)c.head_dim), st, nullptr,
+                    packed ? packed_seq_hint : start_pos + N,
+                    ks, vs, kv8 ? 1 : 0);
+            }
+            kernels::launch_qwen36_mul_sigmoid(att, qg, N * qdim, st);
+            supported = proj(att, w.wo, w.wo_type, ao, H, qdim);
+            if (!supported) break;
+            if (L == 0) vdbg_snapshot2(ao, 0);
+            // Sandwich norm (post-attn): h = x + RMSNorm(ao) * post_attn_norm -- the attention
+            // output is normed ALONE and then added, and that norm uses its own 1e-8 post_norm_eps
+            // rather than the model's rms_eps. ffn_norm is a genuine separate pre-FFN norm here,
+            // not post_attn_norm doing double duty like every other architecture in this file.
+            kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
+            kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, c.rms_eps, st);
+            if (L == 0) { vdbg_snapshot2(h, 1); vdbg_snapshot2(hn, 2); }
+            // Dense SwiGLU through the same one-expert call AR decode makes, at N rows.
+            quant_rows(hn, H);
+            kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
+                                               w.gate_qtype, w.up_qtype, w.down_qtype,
+                                               expert_ids, expert_w, routed, moe_h, moe_out,
+                                               N, topk, H, ffn, q81, st);
+            if (L == 0) vdbg_snapshot2(routed, 3);
+            // Sandwich norm (post-FFN): x = h + RMSNorm(routed) * post_ffn_norm, same 1e-8.
+            kernels::launch_norm_then_add(h, routed, w.post_ffn_norm, x, N, H, 1e-8f, st);
+            const void* nn = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
+            kernels::launch_rmsnorm(x, nn, xn, N, H, c.rms_eps, st);
+            // The Q8_1 memo is keyed on the buffer that produced it; xn is a fresh value in the
+            // SAME buffer, so leaving the key set would hand the next layer's projections the
+            // PREVIOUS layer's quantization. Nothing here emits Q8_1(xn), so clear it outright.
+            q81_src = nullptr; q81_k = 0;
+            capture(L);
+            continue;
+        }
         if (w.linear_attn) {
             bf16* rq = rec_qkv + (size_t)L * N * lqkv;
             bf16* rk = rec_k + (size_t)L * N * s.linear_qdim;
@@ -4440,6 +4592,12 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         abandon_capture();
         return -1;
     }
+    // Muse Glimmer softcaps the logits before the argmax (decode qwen35.cpp:2322, batched
+    // prefill above). Skipping it here would let a row pick a different token than AR decode
+    // would for the same state.
+    if (muse && c.final_logit_softcapping > 0.f)
+        kernels::launch_logit_softcap(logits, N, c.vocab, c.logit_scale,
+                                      c.final_logit_softcapping, st);
     kernels::launch_argmax(logits, out_ids, N, c.vocab, st);
     pf_cu(cudaMemcpyAsync(ph_out, out_ids, (size_t)N * sizeof(int), cudaMemcpyDeviceToHost, st),
           "verify argmax");


### PR DESCRIPTION
## Summary

Muse Glimmer never reached the packed continuous-batch decode forward, so every concurrent request re-read all ~17 GB of weights on its own — aggregate throughput is flat at ~103 tok/s from c=1 to c=16. This wires the architecture's layer into that forward.

## Proof of speedup

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

The packed forward is gated on `c.muse_glimmer`. The one piece outside that gate — chunking `launch_mmvq_rows` above 8 rows — only fires for a multi-row GGUF quantized decode, which the ModelOpt NVFP4 checkpoint does not take. The Qwen3.6 and ModelOpt no-regression guards still run either way.

- [x] Tested on **RTX 5090** (`sm_120`)

**Decode tok/s** (aggregate over 8 concurrent requests, `qwen3_gguf_cb_bench <gguf> 8 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 103.5 |
| after (this PR) | 147.4 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — main binary vs this branch, both built at the same commit

| c | before | after |
|---|--:|--:|
| 2 | 103.1 | 117.5 |
| 4 | 103.5 | 139.3 |
| 8 | 103.5 | 147.4 |
| 16 | 101.6 | 130.5 |

Aggregate throughput on main is flat from one request to sixteen: every concurrent request re-reads all ~17 GB of weights on its own, because the engine has no batched decode forward it can enter. For contrast, Qwen3.8-27B on the same engine goes 95 → 185 → 309 → 483 → 626.

c=32 is unchanged. The card has ~1 MB free there once the KV pool for 33 sequences is allocated, so the packed forward cannot get its scratch and the rows decode individually exactly as before; the batched prefill falls back at that width too, which is why main itself drops to ~52 tok/s.

### What kept it out — four gates, three of them silent

- `dflash_verify_short_run` refused `head_dim != 256`.
- `launch_mmvq_q4k_rows` had no K=6656 instantiation, so every projection off `xn` was refused.
- `launch_mmvq_q6k_rows` had no K=6656 either. A `Q4_K_M` file gives half the layers a Q6_K `attn_v`, and that refusal is a bare `false` inside `proj_on` — it surfaced 52 layers later as a decline with no cause.
- `launch_mmvq_rows` refused `M > 8` outright, which declined the whole forward at c=16 and c=32. It now chunks by 8, the way its f32 twin already did; `MMAX` bounds the scratch and the number of predicated row bodies, not the per-row dot or its reduction order.

### The layer is a branch, not a widening

Mirroring what the batched prefill already carries for this architecture: unweighted RMSNorm of the embedding, `attn_gate` as its own `[qdim, H]` tensor (projecting `wq` as `2*qdim` reads 4096 rows past it), NORM-convention RoPE on the windowed layers and none at all on the every-4th global ones, a pure sliding-window view per row, sandwich norms with their own 1e-8 eps, and the tanh logit softcap.

The per-row KV-append and attention kernels already index `block_table[row * max_blocks + blk]` and `positions[row]`, so they serve N independent sequences unchanged. Only the compact sliding-window view needed a rows form; at one row it reduces exactly to the existing launcher.

The Gated-DeltaNet recurrence records are no longer allocated when no layer has `linear_attn` — ~48 MB of verify arena this architecture can never touch.

### No scored dimension moves

main binary vs this branch at the evaluation's own tier shapes — 128/512 at reps=5 (two rounds per arm), 4k/16k/32k at reps=1:

| ctx | main decode | PR decode | main prefill pp | PR prefill pp |
|---|--:|--:|--:|--:|
| 128 | 105.88 | 105.80 | 9589.6 | 9616.9 |
| 512 | 105.21 | 105.19 | 15461.4 | 15372.3 |
| 4k | 102.33 | 102.40 | 14368.9 | 14382.1 |
| 16k | 101.48 | 101.54 | 13886.0 | 13898.5 |
| 32k | 100.13 | 100.19 | 12686.5 | 12698.6 |
| 64k | 98.81 | 98.65 | 11227.6 | 11147.5 |

Every point is within ±0.75%, the largest being prefill@64k at −0.71% and prefill@512 at −0.58% (the regression floor is −2%). By construction none of this is reachable from a single-request path: the packed forward is entered only from `decode_packed`, the `M > 8` chunk is new code on a branch a one-row call never takes, the added K widths leave every existing width's dispatch untouched, and the compact-window rows kernel has no other caller.

### Correctness

Token streams from the packed forward compared against the same build decoding the rows one at a time, distinct in-distribution prompts per row, greedy: most 64-token streams are identical and the divergence rate does not grow with the batch width. Every stream that crosses the 2048-token sliding window is identical, which is the per-row window view and the position handling. Packed decode is not bit-identical to autoregressive decode — the multi-row kernels partition their super-blocks differently — and `packed` is what keeps that separate from the speculative verify, which stays byte-for-byte on the row kernels.

```text
$ qwen3_gguf_cb_bench Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf 8 256 256 512
cb_bench policy=continuous concurrency=8 prompt=256 max_new=256 long_prefill=512

# before (SPARKINFER_MUSE_PACKED=0)
wall_s=19.900 decode_tokens=2056 agg_tok_s=103.3 mean_itl_ms=76.07 max_itl_ms=118.46

# after
wall_s=14.088 decode_tokens=2056 agg_tok_s=145.9 mean_itl_ms=53.48 max_itl_ms=94.17
```

### The axis

`muse-cb-decode@c2/c4/c8/c16/c32` now exists, and its invocation is `qwen3_gguf_cb_bench "$GGUF" "$CC" 256 256 512` — the same shape every number above was measured at.