### PR TITLE
perf(muse): stop reserving Gated-DeltaNet state for a stack with no linear layers (1.21x concurrent decode @c32)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -163,6 +163,27 @@ bool is_qwen35_or_qwen36_hybrid_moe(const GGUF& g) {
 bool is_linear_layer(const Qwen35Config& c, int layer) {
     return c.hybrid && c.full_attn_interval > 0 && ((layer + 1) % c.full_attn_interval) != 0;
 }
+
+// True when the stack actually CARRIES Gated-DeltaNet layers. `hybrid` alone does not say that:
+// Muse Glimmer sets it to unlock the batched prefill and the attention-gate path while declaring
+// full_attn_interval = 0, which makes is_linear_layer() false for every layer -- it has the flag
+// and none of the layers. Anything that exists only to hold GDN state has to ask this, not
+// `hybrid`, or it allocates a recurrent state for a stack with no recurrence.
+bool has_linear_layers(const Qwen35Config& c) {
+    if (!c.hybrid || c.full_attn_interval <= 0) return false;
+    for (int L = 0; L < c.n_layers; ++L) if (is_linear_layer(c, L)) return true;
+    return false;
+}
+
+// Whether a session on this stack has to carry Gated-DeltaNet state at all.
+// SPARKINFER_MUSE_GDN_GATE=0 restores the old `cfg.hybrid` test, for an A/B out of one binary.
+bool needs_linear_state(const Qwen35Config& c) {
+    static const bool gate = [] {
+        const char* e = getenv("SPARKINFER_MUSE_GDN_GATE");
+        return !(e && e[0] == '0');
+    }();
+    return gate ? has_linear_layers(c) : c.hybrid;
+}
 }
 
 struct SessionBuffers {
@@ -1268,7 +1289,11 @@ int Qwen35Model::forward_token(int token_id, int position, bool sample, float te
         s.graph_prefill_ready = false;
         s.graph_prefill_attn_mode = -1;
     }
-    if (c.hybrid && position == 0) {
+    // The buffers behind these two resets are allocated only for a stack that actually carries
+    // Gated-DeltaNet layers (see needs_linear_state), so a `hybrid` stack with none of them has
+    // nothing to zero and the pointers are null. The sibling reset in qwen35_prefill.cpp guards on
+    // the pointers for the same reason; match it, so this is also safe if the alloc ever fails.
+    if (c.hybrid && position == 0 && s.lin_state && s.lin_conv_state) {
         cu(cudaMemsetAsync(s.lin_state, 0,
                            (size_t)c.n_layers * c.linear_v_heads * c.linear_head_dim * c.linear_head_dim * sizeof(float), st),
            "linear state reset");
@@ -3228,7 +3253,12 @@ uint64_t Qwen35Model::open_session(int num_tokens, bool* alloc_failed) {
     buf.penalty_counts = s.alloc<int>(s.cfg.vocab);
     buf.logit_bias = s.alloc<float>(s.cfg.vocab);
     bool alloc_ok = buf.penalty_counts != nullptr && buf.logit_bias != nullptr;
-    if (s.cfg.hybrid) {
+    // Per-session recurrent state, and it is not small: n_layers * v_heads * head_dim^2 floats is
+    // 109 MB on Muse Glimmer's 52 layers. That model declares `hybrid` but has no GDN layer at
+    // all, so every concurrent request was reserving 109 MB for a recurrence it never runs -- 3.6
+    // GB at 32 requests, on a card whose FP4 prefill operands already leave it with a few hundred
+    // MB of headroom. Ask whether the stack has the layers, not whether it has the flag.
+    if (needs_linear_state(s.cfg)) {
         buf.lin_state = s.alloc<float>((size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
                                        s.cfg.linear_head_dim * s.cfg.linear_head_dim);
         buf.lin_conv_state = s.alloc<bf16>((size_t)s.cfg.n_layers *
@@ -3375,7 +3405,10 @@ bool Qwen35Model::decode_packed(const int* tokens, const int* positions,
 
     for (int i = 0; i < n; i++) {
         auto it = s.sessions.find(seq_ids[i]);
-        if (it == s.sessions.end() || !it->second.lin_state || !it->second.lin_conv_state)
+        if (it == s.sessions.end()) return false;
+        // Only a stack that HAS the layers has the buffers; demanding them on one that does not
+        // refuses every row for a state the model never carried.
+        if (needs_linear_state(s.cfg) && (!it->second.lin_state || !it->second.lin_conv_state))
             return false;
         const int* tbl = s.kv->block_table(seq_ids[i]);
         if (!tbl) return false;
@@ -3407,7 +3440,7 @@ bool Qwen35Model::decode_packed(const int* tokens, const int* positions,
         return !(e && e[0] == '0');
     }();
     bool packed_state_b16 = false;
-    if (kGdnStateB16 && s.cfg.hybrid) {
+    if (kGdnStateB16 && needs_linear_state(s.cfg)) {
         const size_t st_n = (size_t)s.cfg.n_layers * s.cfg.linear_v_heads *
                             s.cfg.linear_head_dim * s.cfg.linear_head_dim;
         bool all_b16 = true;


### PR DESCRIPTION
## Summary

Every open session reserves a Gated-DeltaNet recurrent state sized `n_layers * v_heads * head_dim^2` floats — 109 MB on a 52-layer stack. Muse Glimmer sets `hybrid` to unlock the batched prefill and the attention-gate path but declares `full_attn_interval = 0`, so `is_linear_layer()` is false for every one of its layers: it has the flag and none of the layers, and reserved 109 MB per concurrent request for a recurrence it never runs.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

`qwen35.cpp` is shared code, so this says why the change is nonetheless unreachable for anything
else: the new test only differs from the old one for a stack that declares `hybrid` and has **no**
linear layer. Every other checkpoint in the basket carries `full_attn_interval > 0`, which makes
`has_linear_layers()` and `cfg.hybrid` agree, and the allocation it controls is byte-for-byte what
it was. The Qwen3.6 and ModelOpt Qwen3.8 guards still run over this file.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 86.0 |
| after (this PR) | 120.5 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_MUSE_GDN_GATE=0/1`, arms interleaved, three rounds

| c | before | after | |
|---|--:|--:|--:|
| 2 | 143.9 | 144.5 | +0.4% |
| 4 | 191.1 | 191.1 | +0.0% |
| 8 | 219.6 | 219.7 | +0.0% |
| 16 | 188.7 | 194.2 | +2.9% |
| 32 | 86.0 | 120.5 | **+40.1%** |

The three c=32 rounds read 120.7 / 121.6 / 119.2 against 86.3 / 85.9 / 85.8, i.e. the arms do not
overlap. Below c=16 the card is not short of memory and the change is correctly invisible.

At 32 requests the packed decode forward could not get its scratch on 254 of its calls and fell back to decoding the rows one at a time; with the state it never needed no longer reserved, that drops to 7.

### The change

`has_linear_layers(cfg)` asks whether the stack carries the layers rather than whether it carries the flag, and the per-session allocation asks that instead. Anything with `full_attn_interval > 0` — every hybrid checkpoint in the basket — is unaffected; only a stack that declares `hybrid` with no linear layer at all stops reserving the state.

The per-position reset in `forward_token()` follows too: it zeroed both buffers on `cfg.hybrid` alone, so once they are no longer allocated it handed `cudaMemsetAsync` a null pointer — 20 CUDA errors per concurrent run, all of them from this one site. It is now guarded on the pointers, exactly as the sibling reset in `qwen35_prefill.cpp` already was.

The per-row check in `decode_packed` follows: demanding those buffers on a stack that never had them refuses every row for a state the model does not carry. The bf16 state compaction is gated the same way, so it no longer walks 109 MB of a buffer nothing wrote.

### Why it shows up as throughput

At 32 concurrent requests that is 3.6 GB, on a card whose FP4 prefill operands already leave it with a few hundred MB of headroom. `[dflash-verify] scratch allocation failed (arena=41 MB, free=1/32110 MB)` and `[prefill] scratch alloc failed (ctx=256, chunk=256, held=49 MB, free=103/32110 MB)` are both the same shortage: the packed decode forward declines and the batched prefill falls back, so the whole step runs the slow path.

### The single-request axes

Same binary, same switch, sweep shapes as scored (128/512 at reps 5, 4k/16k/32k at reps 1):

| ctx | decode before → after | prefill before → after |
|---|---|---|
| 128 | 110.33 → 110.24 | 9984.6 → 9991.0 |
| 512 | 109.50 → 109.48 | 16157 → 16368 |
| 4096 | 106.51 → 106.51 | 15626 → 15603 |
| 16384 | 105.56 → 105.56 | 14977 → 14938 |
| 32768 | 104.27 → 104.27 | 13572 → 13557 |

`prefill@128` is bimodal on this box independently of the change: across twelve interleaved runs it
landed below 9500 pp once in each arm (8486 before, 8967 after) with the other ten between 9965 and
10034, and no run in either arm resized the FFN chunk. The figures above are therefore medians of
six runs per arm rather than single samples; a single sequential pair reads anywhere from -8% to
+18% and measures the sampling, not the change.

`SPARKINFER_MUSE_GDN_GATE=0` restores the old `cfg.hybrid` test, for a paired A/B out of one binary.

`bench/scripts/bench.sh` benchmarks the prebuilt release binaries and cannot measure a branch, so the numbers above come from `qwen3_gguf_cb_bench` and `qwen3_gguf_bench` — the same binaries, invocations and parsers this bot uses.