### PR TITLE
perf(muse): run the packed gate/up through the NVFP4 operands the model already holds (1.47x concurrent decode @c8)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -2024,13 +2024,24 @@ __global__ void gate_up_mmvq2_qwen_sparse_kernel(
     if (pdl) si_pdl_lc();
 }
 
+// SwiGLU over a gate/up pair a CALLER produced, into the float h the Q4_K/Q6_K down GEMV below
+// already reads. The expression is the one every gate/up kernel in this file ends with --
+// q4kf_silu(g) * u, product kept in float -- so supplying the projections changes where g and u
+// came from and nothing about what `down` is handed.
+__global__ void swiglu_rows_bf16_f32_kernel(const __nv_bfloat16* __restrict__ g,
+                                            const __nv_bfloat16* __restrict__ u,
+                                            float* __restrict__ h, long n) {
+    const long i = (long)blockIdx.x * (long)blockDim.x + threadIdx.x;
+    if (i < n) h[i] = q4kf_silu(__bfloat162float(g[i])) * __bfloat162float(u[i]);
+}
+
 void launch_moe_expert_ffn_q4k(
     const void* input, const void* gate_q, const void* up_q, const void* down_q,
     int gate_type, int up_type, int down_type,
     const int* expert_ids, const float* expert_weights, void* output,
     float* h_scratch, float* out_scratch,
     int num_tokens, int top_k, int hidden, int ffn, const void* input_q8, cudaStream_t stream,
-    bool ar_exact_splitk
+    bool ar_exact_splitk, const void* gate_bf16, const void* up_bf16
 ) {
     mg_sparse_ffn_init();
     // Qwythos dense hybrid fast path: pack2 gate/up without expert lookup + PDL-chained
@@ -2101,7 +2112,14 @@ void launch_moe_expert_ffn_q4k(
     if (gu_pack2 < 0) { const char* gp = getenv("SPARKINFER_GU_PACK2"); gu_pack2 = (gp && gp[0] == '0') ? 0 : 1; }
     const int gu_pdl = gu_mmvq_pdl();
     dim3 gu(num_tokens * top_k, (ffn + WPB - 1) / WPB);
-    if (mmvq && gu2 && ((gate_type == 12 && up_type == 12) ||
+    // Projections supplied by the caller: skip the whole in-projection dispatch below and go
+    // straight to the SwiGLU that feeds `down`.
+    if (gate_bf16 && up_bf16 && top_k == 1) {
+        const long n = (long)num_tokens * (long)ffn;
+        swiglu_rows_bf16_f32_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
+            reinterpret_cast<const __nv_bfloat16*>(gate_bf16),
+            reinterpret_cast<const __nv_bfloat16*>(up_bf16), h_scratch, n);
+    } else if (mmvq && gu2 && ((gate_type == 12 && up_type == 12) ||
                        (gate_type == SI_QTYPE_Q3A && up_type == SI_QTYPE_Q3A))) {   // faithful 4-warp mmvq gate/up
         const si_block_q8_1* q;
         if (input_q8) {   // pre-quantized Q8_1(hn) from the fused norm: skip the quantize node

--- a/kernels/include/sparkinfer/kernels/moe.h
+++ b/kernels/include/sparkinfer/kernels/moe.h
@@ -82,7 +82,14 @@ void launch_moe_expert_ffn_q4k(
     // aware choice. The split count sets the reduction order, so a caller that must reproduce
     // single-token decode bit-for-bit at num_tokens > 1 has to pin it; everyone else wants the
     // faster row-count aware default.
-    bool ar_exact_splitk = false);
+    bool ar_exact_splitk = false,
+    // A caller that has ALREADY produced this batch's gate and up projections passes them here as
+    // bf16 [num_tokens, ffn] and gets only the SwiGLU and the down projection. The packed
+    // continuous-batch step is the one that does: it runs gate and up as block-scaled NVFP4 GEMMs
+    // whose cost does not grow with the batch width, while its `down` weights have no FP4 copy and
+    // stay on the GEMV below. nullptr (the default) keeps the in-projection GEMV every other
+    // caller wants. top_k must be 1 -- a routed MoE has no single [num_tokens, ffn] pair.
+    const void* gate_bf16 = nullptr, const void* up_bf16 = nullptr);
 
 // Qwen3.6 UD shared expert: Q8_0 gate/up/down via int8 dp4a MMVQ. Reuses the FNQ
 // Q8_1(hn) buffer for gate/up; overwrites h_q8_buf with Q8_1(h) for down.

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3044,6 +3044,43 @@ static bool muse_packed_on() {
     }();
     return v;
 }
+// Row count from which a packed step runs the dense gate/up as ONE block-scaled NVFP4 GEMM per
+// projection instead of the row-batched dp4a GEMV. Fitted on an RTX 5090 against Muse Glimmer's
+// 6656x19968 FFN: the GEMV costs a fixed read plus ~0.76 ms per row across the model, the GEMM
+// 6.92 ms flat (0.0666 ms at 8 rows, 0.0668 at 16 -- it reads the same operand either way), so they
+// cross just under six rows.
+static int gu_gemm_min_rows() {
+    static const int v = [] {
+        const char* e = getenv("SPARKINFER_GU_GEMM_MIN_ROWS");
+        const int x = e ? atoi(e) : 6;
+        return x < 1 ? 1 : x;
+    }();
+    return v;
+}
+
+// Gate and up for `rows` packed rows through the prefill NVFP4 operands the model already holds,
+// into sg/su. Returns false when the weights, the scratch or the shape are not there, which leaves
+// the caller on the GEMV it was using.
+//
+// This is deliberately NOT gated on the DOWN operand. The block-scaled FFN arm in this function
+// requires gate, up AND down to have FP4 copies, and Muse Glimmer has exactly the first two:
+// qwen35.cpp converts gate/up on all 52 layers for prefill and refuses ffn_down, whose copy is
+// 3.9 GB the card has nowhere to put once the KV cache and the prefill arena are down. So that
+// predicate is false for the whole model -- for the sake of an operand only the third projection
+// needs -- and every packed step stayed on the GEMV.
+static bool packed_gate_up_nvfp4(const Qwen35LayerWeights& w, const void* hn, int rows,
+                                 int ffn, int H, unsigned char* fp4_a, unsigned char* fp4_asf,
+                                 unsigned char* fp4_ws, bf16* sg, bf16* su, cudaStream_t st) {
+    if (!fp4_a || !fp4_asf || !sg || !su) return false;
+    if (!w.gate_fp4 || !w.gate_fp4_sf || !w.up_fp4 || !w.up_fp4_sf) return false;
+    if (!kernels::prefill_nvfp4_supported(rows, ffn, H)) return false;
+    return kernels::launch_prefill_nvfp4_quant_a(hn, fp4_a, fp4_asf, rows, H, st) &&
+           kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_asf, w.gate_fp4, w.gate_fp4_sf, sg,
+                                              rows, ffn, H, fp4_ws, st, w.gate_fp4_alpha) &&
+           kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_asf, w.up_fp4, w.up_fp4_sf, su,
+                                              rows, ffn, H, fp4_ws, st, w.up_fp4_alpha);
+}
+
 int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int n, int start_pos,
                             const int* capture_layers, int n_capture, void* capture_dst,
                             int* out_argmax, bool capture_only) {
@@ -3846,10 +3883,17 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             if (L == 0) { vdbg_snapshot2(h, 1); vdbg_snapshot2(hn, 2); }
             // Dense SwiGLU through the same one-expert call AR decode makes, at N rows.
             quant_rows(hn, H);
+            // Wide enough to be worth a block-scaled GEMM: run gate/up through the FP4 operands
+            // this model already holds for prefill and hand the pair to the call below, which then
+            // does only the SwiGLU and the GGUF down GEMV.
+            const bool gu_gemm =
+                packed && topk == 1 && N >= gu_gemm_min_rows() &&
+                packed_gate_up_nvfp4(w, hn, Ng, ffn, H, fp4_a, fp4_asf, fp4_ws, sg, su, st);
             kernels::launch_moe_expert_ffn_q4k(hn, w.gate_q, w.up_q, w.down_q,
                                                w.gate_qtype, w.up_qtype, w.down_qtype,
                                                expert_ids, expert_w, routed, moe_h, moe_out,
-                                               N, topk, H, ffn, q81, st);
+                                               N, topk, H, ffn, q81, st, false,
+                                               gu_gemm ? sg : nullptr, gu_gemm ? su : nullptr);
             if (L == 0) vdbg_snapshot2(routed, 3);
             // Sandwich norm (post-FFN): x = h + RMSNorm(routed) * post_ffn_norm, same 1e-8.
             kernels::launch_norm_then_add(h, routed, w.post_ffn_norm, x, N, H, 1e-8f, st);


### PR DESCRIPTION
## Summary

A packed continuous-batch step runs Muse Glimmer's dense gate/up as a row-batched dp4a GEMV. #1029
made that GEMV weight-stationary, so the batch now shares the weight *read* — but not the
*arithmetic*, which still costs a fixed amount per row. The same two matrices already have
block-scaled NVFP4 copies resident (the model converts them at load, all 52 layers, for prefill),
and a GEMM against those is **flat in the batch width**: 0.0666 ms at 8 rows, 0.0668 ms at 16.

The packed forward could not use them. Its block-scaled FFN arm requires gate, up **and** `down` to
have FP4 copies, and Muse has exactly the first two — `ffn_down`'s copy is 3.9 GB the card has
nowhere to put once the KV cache and the prefill arena are down, so the preflight in `qwen35.cpp`
refuses it on all 52 layers and the whole predicate is false for the whole model.

This splits that predicate. The gate/up half of the GEMM does not need the down operand: run it, and
hand the bf16 pair to the FFN entry, which does the SwiGLU and keeps the GGUF `down` GEMV it was
already running. **No new allocation** — `fp4_a`, `fp4_asf`, `fp4_ws`, `sg` and `su` are already
allocated for every packed dense run.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

The arm is scoped to a packed batch (`packed && top_k == 1 && num_tokens >= 6`) on a layer body that
only Muse Glimmer enters, and it declines unless the FP4 gate/up operands are resident. Single-request
decode cannot reach it, prefill cannot reach it, and the existing all-three `ffn_gemm` arm and the
checkpoint-native NVFP4 arm are both untouched.

**Decode tok/s** (aggregate over 8 concurrent requests, `qwen3_gguf_cb_bench <gguf> 8 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 205.9 |
| after (this PR) | 302.3 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries**, so it cannot measure
a branch; the numbers above come from `qwen3_gguf_cb_bench` built from this tree, at exactly the
invocation the Muse bot's concurrent-decode axis uses (`<gguf> C 256 256 512`).

### The five scored concurrency points

One binary, `SPARKINFER_GU_GEMM_MIN_ROWS=64` (off) vs `6` (on), interleaved off/on/off/on, warm-up
arm burned first. Each cell is the mean of two runs.

| c | before | after | ratio |
|---|--:|--:|--:|
| 2 | 142.5 / 139.9 | 140.4 / 139.7 | 0.992x |
| 4 | 184.4 / 179.7 | 180.4 / 179.7 | 0.989x |
| 8 | 208.6 / 203.2 | 302.4 / 302.1 | **1.468x** |
| 16 | 181.2 / 177.6 | 278.9 / 278.3 | **1.553x** |
| 32 | 77.7 / 77.4 | 76.9 / 77.4 | 0.995x |

**c2 and c4 are flat by construction** — the admission test short-circuits at `num_tokens >= 6`
before anything is enqueued, so those widths execute byte-identical code. What the table shows there
is drift: the two `off` controls alone fall 1.8% at c2 and 2.5% at c4 over the sweep, monotonically,
and the `on` arm tracks them. Comparing the two runs that are adjacent in time, `off2` and `ON2`, c2
is 139.9 -> 139.7 and c4 is 179.7 -> 179.7. That is why the arms are interleaved.

**c32 does not decode on main.** Both arms emit 768 of the 8192 expected tokens — the KV pool cannot
hold 33 sequences — so its aggregate is not a throughput measurement on either side. Reported for
completeness, not claimed.

### Why the floor is six rows

The GEMV's cost per row against a GEMM that is flat in the width: they cross just under six rows.
Measured on an earlier revision of this branch at the crossing: c4 -7.6%, c5 -0.3%, c6 +4.4%,
c7 +6.8%. Below six the GEMV is still ahead, because NVFP4 is 0.5625 B/weight where 42 of the 52
layers hold gate/up as Q3_A at 0.4375 — the GEMM reads *more* bytes, and only wins once the
per-row arithmetic it removes outweighs that.

### Where the time goes (nsys, per decode step at c16)

| kernel | before | after |
|---|--:|--:|
| gate/up row-batched GEMV | 19.04 ms | — |
| `cutlass::device_kernel<GemmUniversal>` (104 launches) | — | 6.940 ms |
| `swiglu_rows_bf16_f32_kernel` (52) | — | 0.085 ms |
| `down_q4k_mmvq_splitk_rows_kernel` (52) | 12.924 ms | 12.197 ms |
| `si_mmvq_q4k_rows_exact_kernel<bf16>` (468) | 11.316 ms | 11.312 ms |
| **step wall** | **49.70 ms** | **37.17 ms** |

Nothing but the in-projection moves. (That profile was taken on an earlier revision of this branch
whose gate/up GEMV was the pre-#1029 one; the mechanism and the GEMM side are unchanged.)

### Numerics

Packed decode now reads gate/up at NVFP4 where it read Q3_A or Q4_K. This is not a precision
regression: NVFP4 carries 4.5 bits per weight against Q3_A's 3.5, which is what 42 of the 52 layers
were on, and the operand is bit-for-bit the one this model's **prefill** already runs every chunk
through — so a packed decode row now agrees with prefill of the same token rather than diverging from
it. Single-request decode is untouched and still runs the GGUF weights.

### The twelve single-stream axes

All twelve drive one request, so the arm is structurally unreachable from them. Measured anyway,
`mg.sh` off/on/off, comparing `on` to the mean of its two bracketing controls (the box drifts
monotonically downward across the three arms, which is why it is bracketed):

| ctx | 128 | 512 | 4k | 16k | 32k | 64k |
|---|--:|--:|--:|--:|--:|--:|
| decode | 0.9995x | 0.9996x | 0.9990x | 0.9994x | 0.9985x | 0.9996x |
| prefill | 0.9981x | 0.9963x | 0.9946x | 0.9936x | 0.9939x | 0.9956x |

Worst axis 0.9936x, against a 0.98 floor.

`ctest`: 21/21 pass.
