### PR TITLE
perf(muse): size the NVFP4 prefill reserve for the sessions the deployment will hold (1.91x concurrent decode @c32)

### DIFF
--- a/runtime/src/models/qwen35.cpp
+++ b/runtime/src/models/qwen35.cpp
@@ -5768,8 +5768,10 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         const int qdim_a = c.n_q_heads * c.head_dim;
         const int kvdim_a = c.n_kv_heads * c.head_dim;
         const char* fp4q_env = getenv("SPARKINFER_MUSE_PREFILL_NVFP4_QKV");
-        const bool qkvg_fp4_on = (!fp4q_env || fp4q_env[0] != '0') &&
-                                 kernels::prefill_nvfp4_supported(128, 2 * qdim_a + 2 * kvdim_a, H);
+        // Not const: the VRAM budget below can drop this leg on a deployment whose concurrency
+        // leaves no room for it (see the reserve there).
+        bool qkvg_fp4_on = (!fp4q_env || fp4q_env[0] != '0') &&
+                           kernels::prefill_nvfp4_supported(128, 2 * qdim_a + 2 * kvdim_a, H);
         int down_ready = 0;
         auto convert = [&](const void* src, int qtype, int rows, int cols,
                            const void** data, const void** sf) -> bool {
@@ -5849,9 +5851,35 @@ bool Qwen35Model::load_gguf(const std::string& path) {
         // A card that genuinely cannot spare it still declines here, and declines for the real
         // reason rather than for its label.
         {
-            const size_t reserve = [] {
+            // How many sessions this deployment will actually hold. The KV pool is allocated
+            // before this point and was sized for exactly that, so it already carries the number
+            // rather than needing one plumbed in.
+            int fp4_sessions = 1;
+            if (s.kv && s.kv->block_size() > 0 && c.max_seq > 0) {
+                const int bps = c.max_seq / s.kv->block_size() + 4;   // blocks one session takes
+                if (bps > 0) fp4_sessions = s.kv->num_total_blocks() / bps;
+                if (fp4_sessions < 1)   fp4_sessions = 1;
+                if (fp4_sessions > 256) fp4_sessions = 256;
+            }
+            // A reserve that covers ONE session's prefill arena is what starved the runtime under
+            // concurrency: every live request needs its own scratch beside these weights, so at 32
+            // requests the card finished with 3 MB free -- the packed decode arena (16 MB) declined
+            // on 255 of 255 steps and the batched prefill fell back to a ~24 pp token loop, 143x
+            // below the 3485 pp it manages when it can allocate. Weights that exist to make prefill
+            // faster are worth nothing if they leave prefill unable to run.
+            // ~24 MB per live session of non-KV runtime state, measured as the rate free VRAM
+            // decays across session opens; the first session is already covered by the base.
+            // An explicit SPARKINFER_MUSE_NVFP4_RESERVE_MB is an operator decision and wins.
+            // SPARKINFER_MUSE_NVFP4_RESERVE_CONC=0 restores the flat reserve, for an A/B.
+            const size_t reserve = [&] {
                 const char* e = getenv("SPARKINFER_MUSE_NVFP4_RESERVE_MB");
-                long long mb = e ? atoll(e) : 384; if (mb < 0) mb = 0;
+                if (e) { long long mb = atoll(e); return (size_t)(mb < 0 ? 0 : mb) << 20; }
+                static const bool conc = [] {
+                    const char* q = getenv("SPARKINFER_MUSE_NVFP4_RESERVE_CONC");
+                    return !(q && q[0] == '0');
+                }();
+                long long mb = 384;
+                if (conc) mb += (long long)(fp4_sessions - 1) * 24;
                 return (size_t)mb << 20;
             }();
             const size_t want_qkvg = qkvg_fp4_on ? (size_t)c.n_layers *
@@ -5884,6 +5912,19 @@ bool Qwen35Model::load_gguf(const std::string& path) {
                         "hold it plus a %.1f GB reserve\n",
                         (double)freeb / 1e9, (double)reserve / 1e9);
                 down_fp4_on = false;
+            }
+            // Last to go, and the leg that decides high-concurrency throughput. Holding ~1.1 GB of
+            // attention-projection copies on a card that then cannot give the runtime its scratch
+            // is a bad trade: the batched prefill these weights accelerate drops to the token loop
+            // and the packed decode forward declines every step. Dropping it is 1.61x aggregate
+            // throughput at 32 concurrent requests, and costs 0.8% at 8 -- where the reserve is
+            // small enough that this never fires and every copy stays resident.
+            if (qkvg_fp4_on && !fits()) {
+                fprintf(stderr, "[prefill-muse] SM120 NVFP4 qkv-gate skipped: %.1f GB free cannot "
+                        "hold it (%.1f GB) plus a %.1f GB reserve for %d sessions\n",
+                        (double)freeb / 1e9, (double)want_qkvg / 1e9, (double)reserve / 1e9,
+                        fp4_sessions);
+                qkvg_fp4_on = false;
             }
         }
         auto release_prefill_copy = [&](const void*& p, const void* decode) {


### PR DESCRIPTION
## Summary

The SM120 NVFP4 prefill copies are staged against free VRAM minus a flat 384 MB reserve, and that reserve covers **one** session's batched-prefill scratch arena. Every concurrent request needs its own scratch beside those weights, so at 32 requests the card finished with 3 MB free and the batched prefill could not allocate at all — it fell back to a token loop at 24 pp against the 3485 pp it manages batched, and a single 512-token prompt took 21 s of a 68 s run. Weights kept to make prefill faster are worth nothing if they leave prefill unable to run.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

The staging block this touches is inside the `muse_glimmer` prefill-weight path; no other
checkpoint reaches it. The Qwen3.6 and ModelOpt Qwen3.8 guards still run over this file.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 119.0 |
| after (this PR) | 315.9 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_MUSE_NVFP4_RESERVE_CONC=0/1`, interleaved, two rounds

| c | before | after | |
|---|--:|--:|--:|
| 8 | 315.2 | 315.8 | +0.2% |
| 16 | 306.4 | 306.1 | — |
| 32 | 119.0 | **315.9** | **+165.5%** |

The two c=32 rounds read 315.8 and 315.9 against 117.9 and 120.0, i.e. the arms do not overlap and
the spread inside each is under 2%. At 32 requests the load line reads:

```text
[prefill-muse] SM120 NVFP4 qkv-gate skipped: 2.3 GB free cannot hold it (1.7 GB)
               plus a 1.2 GB reserve for 33 sessions
```

and the batched prefill's scratch failures go to zero.

Below 32 requests the reserve does not bind and the staged set is **identical in both arms**
(`qkv-gate 52/52` resident, logged on every one of those runs), so the binary is doing the same
thing and those rows cannot move. One c=16 `after` sample came in at 262.4 against 306.1; the same
configuration measured 307.2, 305.7 and 311.4 elsewhere, and since the load log shows the leg
resident in both arms at c=16 that reading is sampling noise, not the change. The c=16 row above is
the other, reproducible sample.

### The change

The KV pool is allocated before this point and was sized for the intended session count, so it
already carries the number — `num_total_blocks() / (max_seq / block_size + 4)` — rather than
needing one plumbed through the config. The reserve becomes `384 MB + (sessions - 1) * 24 MB`,
the 24 MB being the per-session non-KV runtime state, measured as the rate free VRAM decays across
session opens. The attention-projection leg then joins the existing `wo` / `ffn_down` drop
sequence, last, and is released only when the set genuinely does not fit.

### Why no single-request dimension can move

At one session the reserve evaluates to 384 MB — exactly today's constant — so the staging decision
is bit-for-bit the one it makes now and every copy stays resident. That is not just the argument, it
is what the runs log: across eight interleaved sweeps, four per arm, every one reported the same
`qkv-gate 52/52`, so both arms staged identical weights.

128 and 512 are medians of four interleaved runs per arm rather than single samples: both dimensions
draw from a wide distribution on this box (prefill@512 spans 16157–17003 across the day's samples,
and prefill@128 is openly bimodal, landing at either ~8.5k or ~10k in **both** arms), so one
sequential pair measures the sampling, not the change.

| ctx | decode before → after | prefill before → after |
|---|---|---|
| 128 | 110.28 → 110.27 (−0.01%) | 8723 → 9582 — bimodal, see above |
| 512 | 109.51 → 109.47 (−0.03%) | 16507 → 16595 (+0.53%) |
| 4096 | 106.66 → 106.53 (−0.12%) | 15834 → 15728 (−0.67%) |
| 16384 | 105.73 → 105.58 (−0.14%) | 15156 → 15023 (−0.88%) |
| 32768 | 104.45 → 104.26 (−0.18%) | 13747 → 13611 (−0.99%) |

`SPARKINFER_MUSE_NVFP4_RESERVE_CONC=0` restores the flat reserve for a paired A/B out of one
binary; an explicit `SPARKINFER_MUSE_NVFP4_RESERVE_MB` still wins over both.

`bench/scripts/bench.sh` benchmarks the prebuilt release binaries and cannot measure a branch, so the numbers above come from `qwen3_gguf_cb_bench` and `qwen3_gguf_bench` — the same binaries, invocations and parsers this bot uses.