### PR TITLE
perf(muse): walk the row-batched down projection in chunks instead of declining past eight rows (1.30x concurrent decode @c16)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -2336,12 +2336,38 @@ void launch_moe_expert_ffn_q4k(
             // down_q4k_mmvq_splitk_rows_kernel. SPARKINFER_DOWN_ROWS=0 restores the per-token grid.
             static int down_rows = -1;
             if (down_rows < 0) { const char* e = getenv("SPARKINFER_DOWN_ROWS"); down_rows = (e && e[0] == '0') ? 0 : 1; }
-            if (down_rows && num_tokens >= 2 && num_tokens <= 8 && top_k == 1) {
+            // Chunked rather than capped. The rows kernel is instantiated for 2..8 rows, and a
+            // batch wider than that used to decline outright and hand the WHOLE batch to the
+            // per-token grid below -- which reads the down projection once per token, so 16
+            // concurrent rows re-read it 16 times instead of twice. Walk it in 8-row chunks
+            // instead: ceil(M/8) passes over the weights, exactly what the gate/up rows arm beside
+            // it already does with its own MMAX. Each chunk is an independent set of output rows
+            // (output[t*H+hh] is a pure store, no accumulation across rows), so the split changes
+            // nothing a row computes.
+            //
+            // A one-row tail has no instantiation (the launcher declines M < 2), so when the
+            // remainder would be 1 the preceding chunk gives up a row and the tail runs as 2.
+            if (down_rows && num_tokens >= 2 && top_k == 1) {
+                constexpr int DMAX = 8;
                 dim3 dnr(1, (hidden + RPB - 1) / RPB);
-                if (launch_down_q4k_mmvq_splitk_rows(S, num_tokens, pdl, dnr,
-                        reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,
-                        reinterpret_cast<__nv_bfloat16*>(output), hidden, ffn, top_k, stream))
-                    return;
+                const size_t q8pb = (size_t)(ffn >> 5);
+                bool rows_ok = true;
+                for (int t0 = 0; t0 < num_tokens && rows_ok; ) {
+                    int m = num_tokens - t0;
+                    if (m > DMAX) { m = DMAX; if (num_tokens - t0 - m == 1) m = DMAX - 1; }
+                    rows_ok = launch_down_q4k_mmvq_splitk_rows(S, m, pdl, dnr,
+                        reinterpret_cast<const unsigned char*>(down_q),
+                        expert_ids + (size_t)t0 * top_k,
+                        expert_weights + (size_t)t0 * top_k,
+                        hq8 + (size_t)t0 * q8pb,
+                        reinterpret_cast<__nv_bfloat16*>(output) + (size_t)t0 * hidden,
+                        hidden, ffn, top_k, stream);
+                    t0 += m;
+                }
+                // A chunk that declined leaves the rows it already wrote correct, and the
+                // per-token grid below recomputes every row to the same values, so falling
+                // through is safe.
+                if (rows_ok) return;
             }
             dim3 dns(num_tokens, (hidden + RPB - 1) / RPB);
             if (launch_down_q4k_mmvq_splitk(S, pdl, dns,

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -13,3 +13,14 @@ if(BUILD_NVFP4_KERNELS)
   add_test(NAME prefill_nvfp4_gpu_test COMMAND prefill_nvfp4_gpu_test)
   set_tests_properties(prefill_nvfp4_gpu_test PROPERTIES SKIP_RETURN_CODE 77)
 endif()
+
+# The chunked row-batched down projection against the same rows run as their own batch. The rows
+# kernel is instantiated for 2..8, so a wider decode batch is walked in chunks and every chunk past
+# the first reads its inputs at an offset -- this pins that arithmetic.
+add_executable(down_rows_chunk_gpu_test down_rows_chunk_gpu_test.cpp)
+# sparkinfer_kernels, not the individual archives: it wraps them in --start-group so the
+# single-pass linker scan cannot drop a member (see the note in kernels/CMakeLists.txt).
+target_link_libraries(down_rows_chunk_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
+set_target_properties(down_rows_chunk_gpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME down_rows_chunk_gpu_test COMMAND down_rows_chunk_gpu_test)
+set_tests_properties(down_rows_chunk_gpu_test PROPERTIES SKIP_RETURN_CODE 77)

--- a/kernels/tests/down_rows_chunk_gpu_test.cpp
+++ b/kernels/tests/down_rows_chunk_gpu_test.cpp
@@ -1,0 +1,131 @@
+// The row-batched down projection is instantiated for 2..8 rows, so a wider decode batch is walked
+// in chunks. What is new in a chunk past the first is the pointer arithmetic: its activations,
+// expert ids/weights and output all start part-way into the caller's arrays. This pins exactly
+// that -- a chunked run of M rows must be BIT-IDENTICAL, row for row, to running each chunk on its
+// own as the caller-sized batch it already supported.
+//
+// It deliberately does NOT compare against the per-token grid: that is a different kernel with a
+// different reduction order, and the chunked path is not claimed to reproduce it bit-for-bit.
+//
+// gate_bf16/up_bf16 are supplied so only the SwiGLU + down half runs, which is the half the packed
+// continuous-batch decode step uses and the half this covers.
+#include "sparkinfer/kernels/moe.h"
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+constexpr int H = 6656;      // Muse Glimmer hidden
+constexpr int F = 19968;     // Muse Glimmer dense ffn
+constexpr int Q4K = 12;      // ggml type id
+
+// Deterministic, reproducible fill -- no rand(), so a failure is always the same failure.
+uint32_t lcg(uint32_t& s) { s = s * 1664525u + 1013904223u; return s; }
+
+template <class T> T* dev(size_t n, const void* host = nullptr) {
+    void* p = nullptr;
+    if (cudaMalloc(&p, n * sizeof(T)) != cudaSuccess) return nullptr;
+    if (host) { if (cudaMemcpy(p, host, n * sizeof(T), cudaMemcpyHostToDevice) != cudaSuccess) return nullptr; }
+    else      { if (cudaMemset(p, 0, n * sizeof(T)) != cudaSuccess) return nullptr; }
+    return static_cast<T*>(p);
+}
+
+}  // namespace
+
+int main() {
+    int devcount = 0;
+    if (cudaGetDeviceCount(&devcount) != cudaSuccess || devcount == 0) return 77;
+
+    // Q4_K down weights for a single expert: [1, H, F], 144 bytes per 256 values.
+    const size_t down_bytes = (size_t)H * (F / 256) * 144;
+    std::vector<unsigned char> h_down(down_bytes);
+    uint32_t seed = 0x5eed1234u;
+    for (size_t i = 0; i < down_bytes; ++i) h_down[i] = (unsigned char)(lcg(seed) >> 17);
+
+    constexpr int MMAX = 32;
+    std::vector<__nv_bfloat16> h_gate((size_t)MMAX * F), h_up((size_t)MMAX * F);
+    for (size_t i = 0; i < (size_t)MMAX * F; ++i) {
+        h_gate[i] = __float2bfloat16(((int)(lcg(seed) >> 24) - 128) * 0.01f);
+        h_up[i]   = __float2bfloat16(((int)(lcg(seed) >> 24) - 128) * 0.01f);
+    }
+    std::vector<int>   h_ids((size_t)MMAX, 0);
+    std::vector<float> h_wts((size_t)MMAX, 1.0f);
+
+    auto* d_down = dev<unsigned char>(down_bytes, h_down.data());
+    auto* d_gate = dev<__nv_bfloat16>((size_t)MMAX * F, h_gate.data());
+    auto* d_up   = dev<__nv_bfloat16>((size_t)MMAX * F, h_up.data());
+    auto* d_ids  = dev<int>((size_t)MMAX, h_ids.data());
+    auto* d_wts  = dev<float>((size_t)MMAX, h_wts.data());
+    auto* d_out  = dev<__nv_bfloat16>((size_t)MMAX * H);
+    auto* d_hs   = dev<float>((size_t)MMAX * F);
+    auto* d_os   = dev<float>((size_t)MMAX * H);
+    if (!d_down || !d_gate || !d_up || !d_ids || !d_wts || !d_out || !d_hs || !d_os) {
+        std::printf("[SKIP] down-rows chunk: allocation failed (needs ~%.1f GB)\n",
+                    (double)down_bytes / 1e9);
+        return 77;
+    }
+
+    // Run `m` rows starting at row `t0` of the shared inputs, into out + t0*H.
+    auto run = [&](int t0, int m) {
+        sparkinfer::kernels::launch_moe_expert_ffn_q4k(
+            /*input*/ nullptr, /*gate_q*/ nullptr, /*up_q*/ nullptr, d_down,
+            Q4K, Q4K, Q4K,
+            d_ids + t0, d_wts + t0, d_out + (size_t)t0 * H,
+            d_hs, d_os, m, /*top_k*/ 1, H, F,
+            /*input_q8*/ nullptr, /*stream*/ nullptr, /*ar_exact_splitk*/ false,
+            d_gate + (size_t)t0 * F, d_up + (size_t)t0 * F);
+        return cudaDeviceSynchronize() == cudaSuccess;
+    };
+
+    auto fetch = [&](int t0, int m, std::vector<__nv_bfloat16>& dst) {
+        dst.resize((size_t)m * H);
+        return cudaMemcpy(dst.data(), d_out + (size_t)t0 * H,
+                          (size_t)m * H * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost) == cudaSuccess;
+    };
+
+    // Every batch width the dispatch chunks, against the same rows run as their own batches.
+    // 9 is the tail case: it splits 7+2 rather than 8+1, because M==1 has no instantiation.
+    const int widths[]  = { 9, 16, 17, 24, 32 };
+    const int chunked[][2][2] = {   // { {t0,m}, {t0,m} } for the two chunks we verify against
+        { {0, 7}, {7, 2} },
+        { {0, 8}, {8, 8} },
+        { {0, 8}, {8, 7} },         // 17 -> 8,7,2 ; we check the first two boundaries
+        { {0, 8}, {8, 8} },
+        { {0, 8}, {8, 8} },
+    };
+
+    bool all_ok = true;
+    for (size_t w = 0; w < sizeof(widths) / sizeof(widths[0]); ++w) {
+        const int M = widths[w];
+        if (cudaMemset(d_out, 0, (size_t)MMAX * H * sizeof(__nv_bfloat16)) != cudaSuccess) return 77;
+        if (!run(0, M)) { std::printf("[FAIL] M=%d: launch failed\n", M); all_ok = false; continue; }
+        std::vector<__nv_bfloat16> full;
+        if (!fetch(0, M, full)) return 77;
+
+        bool ok = true;
+        for (int part = 0; part < 2; ++part) {
+            const int t0 = chunked[w][part][0], m = chunked[w][part][1];
+            if (t0 + m > M) continue;
+            if (cudaMemset(d_out, 0, (size_t)MMAX * H * sizeof(__nv_bfloat16)) != cudaSuccess) return 77;
+            if (!run(t0, m)) { ok = false; break; }
+            std::vector<__nv_bfloat16> ref;
+            if (!fetch(t0, m, ref)) return 77;
+            if (std::memcmp(full.data() + (size_t)t0 * H, ref.data(),
+                            (size_t)m * H * sizeof(__nv_bfloat16)) != 0) {
+                std::printf("[FAIL] M=%d rows [%d,%d) differ from the same rows run as their own batch\n",
+                            M, t0, t0 + m);
+                ok = false;
+            }
+        }
+        if (ok) std::printf("[PASS] down rows: M=%d chunked is bit-identical per row\n", M);
+        all_ok = all_ok && ok;
+    }
+
+    cudaFree(d_down); cudaFree(d_gate); cudaFree(d_up); cudaFree(d_ids);
+    cudaFree(d_wts); cudaFree(d_out); cudaFree(d_hs); cudaFree(d_os);
+    return all_ok ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

The row-batched down projection is instantiated for 2..8 rows. A decode batch wider than that did not chunk it — it declined outright and handed the whole batch to the per-token grid, which reads the down projection once per token. At 16 concurrent rows that is 16 passes over the weights instead of two. This walks it in 8-row chunks instead, which is what the gate/up rows arm beside it already does with its own `MMAX`.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

The arm is reached with `top_k == 1` on the dense FFN down projection, which is the path Muse's
packed continuous-batch decode takes. The Qwen3.6 and ModelOpt Qwen3.8 guards still run over this
file.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 315.2 |
| after (this PR) | 421.4 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_DOWN_ROWS=0/1`, interleaved, two rounds

| c | before | after | |
|---|--:|--:|--:|
| 16 | 307.6 | **396.9** | **+29.0%** |
| 32 | 315.2 | **421.4** | **+33.7%** |

Neither pair overlaps: 309.5 / 305.6 against 399.8 / 393.9 at 16, and 315.9 / 314.5 against
422.6 / 420.1 at 32.

Batches of eight or fewer take the same single launch they take today, with every pointer at offset
zero, so nothing below c=16 can move — `SPARKINFER_DOWN_ROWS=0` there disables the arm outright,
which is not the behaviour this replaces, so that comparison is left out rather than counted as a
gain.

The gain at 32 depends on the batched paths being able to get their scratch: before the prefill
reserve was sized for concurrency, c=32 could not, and the weights this kernel re-reads were not
what bounded the step — the same change measured only +1.2% there. c=16 was +30.1% either way.

### Correctness

The chunked path is **not** claimed to reproduce the per-token grid bit-for-bit — that is a different
kernel with a different reduction order. What is new is the pointer arithmetic for every chunk past
the first (`expert_ids + t0*top_k`, `hq8 + t0*(ffn>>5)`, `output + t0*hidden`), so the test pins
exactly that: a chunked run must be bit-identical, row for row, to the same rows run as their own
batch.

```text
[PASS] down rows: M=9 chunked is bit-identical per row
[PASS] down rows: M=16 chunked is bit-identical per row
[PASS] down rows: M=17 chunked is bit-identical per row
[PASS] down rows: M=24 chunked is bit-identical per row
[PASS] down rows: M=32 chunked is bit-identical per row
```

M=9 is the tail case: a one-row tail has no instantiation, so the preceding chunk gives up a row and
the tail runs as 2. Each chunk is an independent set of output rows — the store is
`output[t*H+hh]`, with no accumulation across rows — so the split changes nothing a row computes.

### The single-request axes

The arm requires `num_tokens >= 2`, so a single request cannot reach it at all. Measured over the
scored sweep shapes anyway, worst case −1.08%, on the prefill@512 dimension whose samples span
16157–17003 across repeated runs of the same build:

| ctx | decode before → after | prefill before → after |
|---|---|---|
| 128 | 110.44 → 110.43 | 10018 → 10076 |
| 512 | 109.64 → 109.66 | 16950 → 16767 |
| 4096 | 106.65 → 106.67 | 15865 → 15882 |
| 16384 | 105.72 → 105.73 | 15208 → 15181 |
| 32768 | 104.45 → 104.46 | 13785 → 13764 |

`SPARKINFER_DOWN_ROWS=0` restores the per-token grid.

`bench/scripts/bench.sh` benchmarks the prebuilt release binaries and cannot measure a branch, so the numbers above come from `qwen3_gguf_cb_bench` and `qwen3_gguf_bench` — the same binaries, invocations and parsers this bot uses.