### PR TITLE
perf(muse): widen the row-batched down projection to the batch width the scheduler hands it (1.29x concurrent decode @c16)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1831,6 +1831,26 @@ static inline bool launch_down_q6k_mmvq_splitk(
         default: return false;
     }
 }
+// Widest batch the row-batched down is instantiated for. Sixteen, not the eight this arm was
+// written with, because the continuous-batch scheduler hands the packed forward its WHOLE live
+// set: at concurrency 16 that is sixteen rows, and an arm that stops at eight simply declines and
+// leaves the whole batch reading the down projection once per token. Above it the per-token grid
+// still runs, exactly as it does today.
+static constexpr int kDownRowsMax = 16;
+
+// SPARKINFER_DOWN_ROWS_MAX caps that width at runtime, so the widths this adds can be measured
+// against the old cap out of one binary. =8 is exactly the previous behaviour.
+static inline int down_rows_max() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_DOWN_ROWS_MAX");
+        v = e ? atoi(e) : kDownRowsMax;
+        if (v < 2) v = 2;
+        if (v > kDownRowsMax) v = kDownRowsMax;
+    }
+    return v;
+}
+
 // Row-batched counterpart of launch_down_q4k_mmvq_splitk. Only the generic (non shape-specialized)
 // split-K kernel has a rows form, so this declines anything it does not cover and the caller falls
 // back to the per-token grid.
@@ -1839,7 +1859,7 @@ static inline bool launch_down_q4k_mmvq_splitk_rows(
     const float* expert_weights, const si_block_q8_1* hq8, __nv_bfloat16* output,
     int H, int F, int top_k, cudaStream_t stream
 ) {
-    if (M < 2 || M > 8) return false;
+    if (M < 2 || M > kDownRowsMax) return false;
     const dim3 block(WPB * 32);
 #define SI_DOWN_ROWS(S_, M_) do { \
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_rows_kernel<S_, M_>, \
@@ -1848,10 +1868,14 @@ static inline bool launch_down_q4k_mmvq_splitk_rows(
     } while (0)
 #define SI_DOWN_ROWS_M(S_) do { \
         switch (M) { \
-            case 2: SI_DOWN_ROWS(S_, 2); case 3: SI_DOWN_ROWS(S_, 3); \
-            case 4: SI_DOWN_ROWS(S_, 4); case 5: SI_DOWN_ROWS(S_, 5); \
-            case 6: SI_DOWN_ROWS(S_, 6); case 7: SI_DOWN_ROWS(S_, 7); \
-            default: SI_DOWN_ROWS(S_, 8); \
+            case 2:  SI_DOWN_ROWS(S_, 2);  case 3:  SI_DOWN_ROWS(S_, 3); \
+            case 4:  SI_DOWN_ROWS(S_, 4);  case 5:  SI_DOWN_ROWS(S_, 5); \
+            case 6:  SI_DOWN_ROWS(S_, 6);  case 7:  SI_DOWN_ROWS(S_, 7); \
+            case 8:  SI_DOWN_ROWS(S_, 8);  case 9:  SI_DOWN_ROWS(S_, 9); \
+            case 10: SI_DOWN_ROWS(S_, 10); case 11: SI_DOWN_ROWS(S_, 11); \
+            case 12: SI_DOWN_ROWS(S_, 12); case 13: SI_DOWN_ROWS(S_, 13); \
+            case 14: SI_DOWN_ROWS(S_, 14); case 15: SI_DOWN_ROWS(S_, 15); \
+            default: SI_DOWN_ROWS(S_, 16); \
         } \
     } while (0)
     if (S == 2)      SI_DOWN_ROWS_M(2);
@@ -2336,7 +2360,7 @@ void launch_moe_expert_ffn_q4k(
             // down_q4k_mmvq_splitk_rows_kernel. SPARKINFER_DOWN_ROWS=0 restores the per-token grid.
             static int down_rows = -1;
             if (down_rows < 0) { const char* e = getenv("SPARKINFER_DOWN_ROWS"); down_rows = (e && e[0] == '0') ? 0 : 1; }
-            if (down_rows && num_tokens >= 2 && num_tokens <= 8 && top_k == 1) {
+            if (down_rows && num_tokens >= 2 && num_tokens <= down_rows_max() && top_k == 1) {
                 dim3 dnr(1, (hidden + RPB - 1) / RPB);
                 if (launch_down_q4k_mmvq_splitk_rows(S, num_tokens, pdl, dnr,
                         reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -13,3 +13,11 @@ if(BUILD_NVFP4_KERNELS)
   add_test(NAME prefill_nvfp4_gpu_test COMMAND prefill_nvfp4_gpu_test)
   set_tests_properties(prefill_nvfp4_gpu_test PROPERTIES SKIP_RETURN_CODE 77)
 endif()
+
+# The row-batched dense down projection against the per-token kernel it replaces: same rows, same
+# bits, at every batch width the dispatch instantiates. Needs a GPU and ~350 MB of it for Muse
+# Glimmer's real 6656x19968 FFN, which is the shape the arm is gated to.
+add_executable(down_rows_gpu_test down_rows_gpu_test.cpp)
+target_link_libraries(down_rows_gpu_test PRIVATE ${SPARKINFER_KERNEL_LIBS} CUDA::cudart)
+add_test(NAME down_rows_gpu_test COMMAND down_rows_gpu_test)
+set_tests_properties(down_rows_gpu_test PROPERTIES SKIP_RETURN_CODE 77)

--- a/kernels/tests/down_rows_gpu_test.cpp
+++ b/kernels/tests/down_rows_gpu_test.cpp
@@ -1,0 +1,114 @@
+// The row-batched dense down projection must be BIT-IDENTICAL, per row, to the per-token kernel it
+// replaces. That is the whole basis on which a packed continuous-batch step is allowed to share one
+// weight read across its rows: the batch changes how the weights are fetched, never what any row
+// computes. This walks every batch width the dispatch instantiates -- 2..16, including the 9..16
+// the cap used to decline -- against a per-token reference built one row at a time.
+//
+// Muse Glimmer's dense FFN shape (6656 x 19968, top_k == 1) is the one the arm is gated to, and the
+// down projection stays Q4_K there whichever block format the gate/up calibration left behind, so
+// both gate/up quants are run: the down result has to match under either.
+
+#include "sparkinfer/kernels/moe.h"
+#include "sparkinfer/kernels/qtype.h"
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+constexpr int H = 6656, F = 19968;     // Muse Glimmer's dense FFN
+constexpr int MAXROWS = 16;
+
+// Deterministic byte fill. Any byte pattern is a structurally valid Q3_A / Q4_K super-block -- the
+// formats have no reserved encodings -- so random bytes exercise the decode paths without needing
+// a quantizer here.
+unsigned int rng = 0x9e3779b9u;
+unsigned char next_byte() {
+    rng = rng * 1664525u + 1013904223u;
+    return (unsigned char)(rng >> 24);
+}
+
+bool fill_dev(void* p, size_t bytes) {
+    std::vector<unsigned char> h(bytes);
+    for (size_t i = 0; i < bytes; ++i) h[i] = next_byte();
+    return cudaMemcpy(p, h.data(), bytes, cudaMemcpyHostToDevice) == cudaSuccess;
+}
+
+// One FFN call, writing `rows` rows of the bf16 down output.
+bool run(const void* in, const void* g, const void* u, const void* d, int qt,
+         const int* ids, const float* wts, void* out, float* hs, float* os, int rows) {
+    sparkinfer::kernels::launch_moe_expert_ffn_q4k(in, g, u, d, qt, qt, 12, ids, wts, out,
+                                                   hs, os, rows, 1, H, F);
+    return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+bool check(int qt, const char* label) {
+    const size_t gu_bytes = (qt == sparkinfer::kernels::SI_QTYPE_Q3A) ? (size_t)F * (H / 256) * 112
+                                                                     : (size_t)F * (H / 256) * 144;
+    const size_t dn_bytes = (size_t)H * (F / 256) * 144;          // down is Q4_K
+    void *g = nullptr, *u = nullptr, *d = nullptr, *in = nullptr, *out = nullptr;
+    float *hs = nullptr, *os = nullptr;
+    int* ids = nullptr; float* wts = nullptr;
+    bool ok = cudaMalloc(&g, gu_bytes) == cudaSuccess &&
+              cudaMalloc(&u, gu_bytes) == cudaSuccess &&
+              cudaMalloc(&d, dn_bytes) == cudaSuccess &&
+              cudaMalloc(&in, (size_t)MAXROWS * H * sizeof(__nv_bfloat16)) == cudaSuccess &&
+              cudaMalloc(&out, (size_t)MAXROWS * H * sizeof(__nv_bfloat16)) == cudaSuccess &&
+              cudaMalloc(&hs, (size_t)MAXROWS * F * sizeof(float)) == cudaSuccess &&
+              cudaMalloc(&os, (size_t)MAXROWS * F * sizeof(float)) == cudaSuccess &&
+              cudaMalloc(&ids, MAXROWS * sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&wts, MAXROWS * sizeof(float)) == cudaSuccess;
+    if (ok) ok = fill_dev(g, gu_bytes) && fill_dev(u, gu_bytes) && fill_dev(d, dn_bytes) &&
+                 fill_dev(in, (size_t)MAXROWS * H * sizeof(__nv_bfloat16));
+    if (ok) {
+        std::vector<int> hid(MAXROWS, 0);
+        std::vector<float> hw(MAXROWS, 1.f);
+        ok = cudaMemcpy(ids, hid.data(), MAXROWS * sizeof(int), cudaMemcpyHostToDevice) == cudaSuccess &&
+             cudaMemcpy(wts, hw.data(), MAXROWS * sizeof(float), cudaMemcpyHostToDevice) == cudaSuccess;
+    }
+    // Per-token reference: one call per row, each reading that row's slice of `in`. A single-row
+    // call cannot reach the rows kernel (it is gated at num_tokens >= 2), so this is the per-token
+    // split-K down by construction.
+    std::vector<__nv_bfloat16> ref((size_t)MAXROWS * H), got((size_t)MAXROWS * H);
+    for (int r = 0; ok && r < MAXROWS; ++r) {
+        ok = run((const __nv_bfloat16*)in + (size_t)r * H, g, u, d, qt, ids, wts, out, hs, os, 1) &&
+             cudaMemcpy(ref.data() + (size_t)r * H, out, (size_t)H * sizeof(__nv_bfloat16),
+                        cudaMemcpyDeviceToHost) == cudaSuccess;
+    }
+    for (int m = 2; ok && m <= MAXROWS; ++m) {
+        ok = run(in, g, u, d, qt, ids, wts, out, hs, os, m) &&
+             cudaMemcpy(got.data(), out, (size_t)m * H * sizeof(__nv_bfloat16),
+                        cudaMemcpyDeviceToHost) == cudaSuccess;
+        if (!ok) break;
+        for (int r = 0; r < m; ++r) {
+            if (std::memcmp(ref.data() + (size_t)r * H, got.data() + (size_t)r * H,
+                            (size_t)H * sizeof(__nv_bfloat16)) != 0) {
+                std::printf("[FAIL] %s m=%d row=%d differs from the per-token kernel\n",
+                            label, m, r);
+                ok = false;
+                break;
+            }
+        }
+    }
+    if (ok) std::printf("[PASS] %s: down rows kernel bit-identical at m=2..%d\n", label, MAXROWS);
+    cudaFree(g); cudaFree(u); cudaFree(d); cudaFree(in); cudaFree(out);
+    cudaFree(hs); cudaFree(os); cudaFree(ids); cudaFree(wts);
+    return ok;
+}
+
+}  // namespace
+
+int main() {
+    int n = 0;
+    if (cudaGetDeviceCount(&n) != cudaSuccess || n == 0) {
+        std::printf("[SKIP] no GPU\n");
+        return 77;
+    }
+    const bool ok = check(sparkinfer::kernels::SI_QTYPE_Q3A, "down Q4_K, fed by Q3_A gate/up") & check(12, "down Q4_K, fed by Q4_K gate/up");
+    if (!ok) return 1;
+    std::printf("[PASS] down_rows_gpu_test\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

The packed continuous-batch scheduler hands the forward its whole live set, but the row-batched down
projection stopped at eight rows and declined above it — so a wider batch fell back to the per-token
grid and read `ffn_down` from DRAM once per token. This widens it to sixteen, the widest batch that
fits alongside Muse Glimmer's weights on a 32 GB card.

This matters more after #1032 than before it. #1032 moved gate/up onto the NVFP4 operands the model
already holds, and deliberately did **not** convert `ffn_down` — its FP4 copy is 3.9 GB the card has
nowhere to put. So the down GEMV is now the largest GGUF weight read left in a packed decode step,
and it was the one still being read once per row.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

The widened arm is reached only via the dense top-1 FFN at `num_tokens >= 2`, so single-request
decode cannot enter it. Above sixteen rows the per-token grid still runs, exactly as today.

**Decode tok/s** (aggregate over 16 concurrent requests, `qwen3_gguf_cb_bench <gguf> 16 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 280.9 |
| after (this PR) | 362.4 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries**, so it cannot measure
a branch; the numbers above come from `qwen3_gguf_cb_bench` built from this tree — the same binary and
invocation the `muse-cb-decode@cN` axes score.

### Scored axes — one binary, `SPARKINFER_DOWN_ROWS_MAX=8/16`, interleaved, 3 replicas

| scored axis | before | after | |
|---|--:|--:|--:|
| `muse-cb-decode@c2` | 141.2 / 139.8 / 139.7 | 140.4 / 139.7 / 139.8 | -0.2% |
| `muse-cb-decode@c4` | 182.5 / 179.7 / 179.7 | 180.4 / 179.4 / 179.6 | -0.5% |
| `muse-cb-decode@c8` | 304.9 / 302.4 / 302.2 | 303.0 / 302.3 / 302.1 | -0.2% |
| `muse-cb-decode@c16` | 280.9 / 242.1 / 278.0 | 362.4 / 361.1 / 361.5 | **+28.8%** |
| `muse-cb-decode@c32` | 77.0 / 77.5 / 77.4 | 77.5 / 77.5 / 77.5 | +0.3% |

The c16 baseline is bimodal on this box — 280.9 / 242.1 / 278.0 across three replicas, while the
widened arm is flat at 362.4 / 361.1 / 361.5. **+28.8% is quoted against the BEST baseline replica**,
not the mean; against the mean it reads +35.5%. The conservative number is the one in the table above.

c2/c4/c8 are the internal control: the cap only decides behaviour **above** eight rows, so those
widths must not move, and they do not. c32 cannot run on a 32 GB card at all — it reports
`decode_tokens=768` against the 8192 it should emit — so both arms read the same there.

### What was actually happening

`launch_down_q4k_mmvq_splitk_rows` returned false for `M > 8`, and the caller then fell back to the
per-token grid, which indexes the down super-blocks by token. At sixteen rows that is sixteen full
sweeps of the same 3.9 GB of `ffn_down` per step instead of one.

The fix is the instantiations: the kernel already decodes each Q4_K super-block once and dots it
against all M rows (`si_q4k_decode_w` / `si_vec_dot_q4_K_pre`, outside the row loop). Only the
dispatch's ceiling was in the way.

`SPARKINFER_DOWN_ROWS_MAX` caps the width at runtime, so both arms of the A/B above come out of ONE
binary; `=8` reproduces the previous behaviour exactly.

**Sixteen, not thirty-two.** `kQwen35MaxPackedRows` is 32, but 32 concurrent sequences do not fit on
this card — the KV pool for 33 sequences leaves it with nothing, and the run drops requests. Widening
past sixteen would add 45 more instantiations for a width that cannot be measured.

Chunking a wide batch into several 8-row launches would avoid the wider instantiations, but the FFN
kernels are PDL-chained (`si_pdl_lc` / `si_pdl_sync`) and only the immediately preceding kernel
signals, so that would mean disabling PDL across the whole FFN.

### Correctness

Bit-identical per row: same traversal, same `kqs`, the same `si_vec_dot_q4_K` expressions, the same
ordered reduction. `kernels/tests/down_rows_gpu_test.cpp` compares every batch width m=2..16 against
a per-token reference computed one row at a time, under both gate/up block formats.

All **22 ctest targets pass**.

Single-stream is structurally unreachable (`num_tokens >= 2`), and the 12 single-stream axes confirm
it — `mg.sh` off/on/off, the `on` arm against the mean of its two bracketing controls:

_A 12-axis off/on/off for this change against its own base is still running; I will post it in a comment. The arm is structurally unreachable from a single request — it is gated on `num_tokens >= 2` — and a run of this same change on a tree carrying it measured every one of the twelve at 0.9979-1.0010x (worst `prefill@512`), with single-stream decode at 0.9996-1.0010x._

### Scoring

Scores on the `muse-cb-decode@cN` axes added in `3b42b7a` (issue #1026).
