### PR TITLE
perf(muse): give the down projection the batch width and the split-K the scheduler actually hands it (1.37x concurrent decode @c16)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1834,12 +1834,22 @@ static inline bool launch_down_q6k_mmvq_splitk(
 // Row-batched counterpart of launch_down_q4k_mmvq_splitk. Only the generic (non shape-specialized)
 // split-K kernel has a rows form, so this declines anything it does not cover and the caller falls
 // back to the per-token grid.
+// Widest chunk the row-batched down projection is instantiated for. Thirty-two, because the
+// packed scheduler hands up to kQwen35MaxPackedRows rows and every extra chunk is another full
+// pass over ffn_down's 3.9 GB -- at 32 rows, eight-row chunks read it four times.
+// Widths above sixteen exist only at S == 2: the split-K narrowing above pins S to 2 for every
+// packed width >= 5, so nothing else can reach them.
+static constexpr int kDownRowsMax = 32;
+
+static inline bool launch_down_rows_wide_ok(int S, int M) { return S == 2 || M <= 16; }
+
 static inline bool launch_down_q4k_mmvq_splitk_rows(
     int S, int M, int pdl, dim3 grid, const unsigned char* down_q, const int* expert_ids,
     const float* expert_weights, const si_block_q8_1* hq8, __nv_bfloat16* output,
     int H, int F, int top_k, cudaStream_t stream
 ) {
-    if (M < 2 || M > 8) return false;
+    if (M < 2 || M > kDownRowsMax) return false;
+    if (!launch_down_rows_wide_ok(S, M)) return false;
     const dim3 block(WPB * 32);
 #define SI_DOWN_ROWS(S_, M_) do { \
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_rows_kernel<S_, M_>, \
@@ -1848,15 +1858,34 @@ static inline bool launch_down_q4k_mmvq_splitk_rows(
     } while (0)
 #define SI_DOWN_ROWS_M(S_) do { \
         switch (M) { \
-            case 2: SI_DOWN_ROWS(S_, 2); case 3: SI_DOWN_ROWS(S_, 3); \
-            case 4: SI_DOWN_ROWS(S_, 4); case 5: SI_DOWN_ROWS(S_, 5); \
-            case 6: SI_DOWN_ROWS(S_, 6); case 7: SI_DOWN_ROWS(S_, 7); \
-            default: SI_DOWN_ROWS(S_, 8); \
+            case 2:  SI_DOWN_ROWS(S_, 2);  case 3:  SI_DOWN_ROWS(S_, 3); \
+            case 4:  SI_DOWN_ROWS(S_, 4);  case 5:  SI_DOWN_ROWS(S_, 5); \
+            case 6:  SI_DOWN_ROWS(S_, 6);  case 7:  SI_DOWN_ROWS(S_, 7); \
+            case 8:  SI_DOWN_ROWS(S_, 8);  case 9:  SI_DOWN_ROWS(S_, 9); \
+            case 10: SI_DOWN_ROWS(S_, 10); case 11: SI_DOWN_ROWS(S_, 11); \
+            case 12: SI_DOWN_ROWS(S_, 12); case 13: SI_DOWN_ROWS(S_, 13); \
+            case 14: SI_DOWN_ROWS(S_, 14); default: SI_DOWN_ROWS(S_, 15); \
         } \
     } while (0)
+#define SI_DOWN_ROWS_WIDE do { \
+        switch (M) { \
+            case 16: SI_DOWN_ROWS(2, 16); case 17: SI_DOWN_ROWS(2, 17); \
+            case 18: SI_DOWN_ROWS(2, 18); case 19: SI_DOWN_ROWS(2, 19); \
+            case 20: SI_DOWN_ROWS(2, 20); case 21: SI_DOWN_ROWS(2, 21); \
+            case 22: SI_DOWN_ROWS(2, 22); case 23: SI_DOWN_ROWS(2, 23); \
+            case 24: SI_DOWN_ROWS(2, 24); case 25: SI_DOWN_ROWS(2, 25); \
+            case 26: SI_DOWN_ROWS(2, 26); case 27: SI_DOWN_ROWS(2, 27); \
+            case 28: SI_DOWN_ROWS(2, 28); case 29: SI_DOWN_ROWS(2, 29); \
+            case 30: SI_DOWN_ROWS(2, 30); case 31: SI_DOWN_ROWS(2, 31); \
+            default: SI_DOWN_ROWS(2, 32); \
+        } \
+    } while (0)
+    if (S == 2 && M >= 16) SI_DOWN_ROWS_WIDE;
+    if (M > 15) return false;
     if (S == 2)      SI_DOWN_ROWS_M(2);
     else if (S == 4) SI_DOWN_ROWS_M(4);
     else if (S == 8) SI_DOWN_ROWS_M(8);
+#undef SI_DOWN_ROWS_WIDE
 #undef SI_DOWN_ROWS_M
 #undef SI_DOWN_ROWS
     return false;
@@ -2371,7 +2400,16 @@ void launch_moe_expert_ffn_q4k(
             // A one-row tail has no instantiation (the launcher declines M < 2), so when the
             // remainder would be 1 the preceding chunk gives up a row and the tail runs as 2.
             if (down_rows && num_tokens >= 2 && top_k == 1) {
-                constexpr int DMAX = 8;
+                // One pass over ffn_down per chunk, so the chunk width IS the number of times
+                // a packed step re-reads 3.9 GB. Eight was the widest instantiation; the arm now
+                // reaches thirty-two, which is kQwen35MaxPackedRows.
+                // SPARKINFER_DOWN_ROWS_CHUNK=8 reproduces the previous behaviour exactly.
+                static const int DMAX = [] {
+                    const char* e = getenv("SPARKINFER_DOWN_ROWS_CHUNK");
+                    int v = e ? atoi(e) : kDownRowsMax;
+                    if (v < 2) v = 2;
+                    return v > kDownRowsMax ? kDownRowsMax : v;
+                }();
                 dim3 dnr(1, (hidden + RPB - 1) / RPB);
                 const size_t q8pb = (size_t)(ffn >> 5);
                 bool rows_ok = true;

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -2328,7 +2328,30 @@ void launch_moe_expert_ffn_q4k(
         const int q_pdl = gu_pdl && pdl;
         launch_pdl_kernel(q_pdl, dim3((nqb + (qthreads >> 5) - 1) / (qthreads >> 5)), dim3(qthreads), 0, stream,
             quant_h_q8_1_kernel, h_scratch, hq8, nqb, q_pdl);
-        const int S = dense_top1_down_splitk(down_splitk_s_q4(), top_k, "SPARKINFER_DOWN_SPLITK_S_Q4");
+        int S = dense_top1_down_splitk(down_splitk_s_q4(), top_k, "SPARKINFER_DOWN_SPLITK_S_Q4");
+        // The split-K factor was fitted at ONE row, where splitting hides a bs=1 occupancy stall.
+        // A packed batch already gives every block M rows of work, so the extra splits buy
+        // parallelism that is no longer scarce and pay a wider cross-warp reduction for it.
+        // Measured on Muse Glimmer's 6656x19968 FFN: at c8/c16 S=2 costs 4.3-4.8% LESS step time
+        // than the fitted 8, at c2/c4 it is neutral, and at ONE row it is a ~1.1% regression on
+        // every scored single-stream axis. So this narrows S only above the width where it
+        // measured better, and leaves single-request decode on exactly the S it has today.
+        // Scoped to this shape because that is the one the sweep covers.
+        // SPARKINFER_DOWN_SPLITK_WIDE_ROWS / _WIDE_S expose both for an A/B out of one binary;
+        // setting WIDE_ROWS above the packed cap reproduces the previous behaviour exactly.
+        if (hidden == 6656 && ffn == 19968 && top_k == 1) {
+            static const int wide_rows = [] {
+                const char* e = getenv("SPARKINFER_DOWN_SPLITK_WIDE_ROWS");
+                const int v = e ? atoi(e) : 5;
+                return v < 2 ? 2 : v;
+            }();
+            static const int wide_s = [] {
+                const char* e = getenv("SPARKINFER_DOWN_SPLITK_WIDE_S");
+                const int v = e ? atoi(e) : 2;
+                return (v == 1 || v == 2 || v == 4 || v == 8) ? v : 2;
+            }();
+            if (num_tokens >= wide_rows && S > wide_s) S = wide_s;
+        }
         if (S > 1) {
             const int RPB = WPB / S;
             // Multi-token callers walk hidden once instead of num_tokens*hidden, reading the down


### PR DESCRIPTION
## Summary

Two fixes to the same kernel, both about the width the packed continuous-batch scheduler actually
hands the FFN. The row-batched down projection declined past **eight** rows, so a wider batch fell
back to the per-token grid and read `ffn_down` from DRAM once per token; and the split-K factor that
arm uses was fitted at **one** row, where splitting hides a batch-size-1 occupancy stall it no
longer has at width.

They are not separable, which is why they are one PR: widening alone does nothing above sixteen
rows, and narrowing the split-K alone does nothing at sixteen. Together they cover the whole range
the scheduler produces — `+37.3%` at c16, `+14.0%` at c32, `+4.8%` at c8.

This supersedes #1035, which was the widening alone and was auto-closed on a `muse-cb-decode@c32`
regression. That regression is gone: it was an interaction with the VRAM-starved c32 path that
**#1031 and #1033 have since fixed**, and c32 now completes (`decode_tokens=8200` of 8192) instead
of dropping requests. Measured on top of both.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

Both changes are reached only through the dense top-1 FFN at `num_tokens >= 2` (the widened arm) and
`num_tokens >= 5` (the split-K), and the split-K narrowing is additionally scoped to Muse Glimmer's
`6656x19968` shape. Single-request decode enters neither.

**Decode tok/s** (aggregate over 16 concurrent requests, `qwen3_gguf_cb_bench <gguf> 16 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 291.9 |
| after (this PR) | 400.7 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries**, so it cannot measure
a branch; these come from `qwen3_gguf_cb_bench` built from this tree — the same binary and invocation
the `muse-cb-decode@cN` axes score.

### Scored axes — one binary, `SPARKINFER_DOWN_ROWS_MAX` x `SPARKINFER_DOWN_SPLITK_WIDE_ROWS`

| scored axis | before | after | |
|---|--:|--:|--:|
| `muse-cb-decode@c2` | 141.5 / 139.3 | 139.5 / 139.4 | -0.7% |
| `muse-cb-decode@c4` | 182.7 / 178.7 | 179.5 / 179.2 | -0.7% |
| `muse-cb-decode@c8` | 305.5 / 301.5 | 318.4 / 317.7 | **+4.8%** |
| `muse-cb-decode@c16` | 293.2 / 290.6 | 400.7 / 400.6 | **+37.3%** |
| `muse-cb-decode@c32` | 299.9 / 298.6 | 325.0 / 357.1 | **+14.0%** |

Every point completed its full token budget (`decode_tokens` 520 / 1032 / 2056 / 4104 / 8200 against
the 512 / 1024 / 2048 / 4096 / 8192 expected), so none of these is a dropped-request reading.

c2 and c4 read -0.7%: both are below the 2% significance gate and inside this box's arm-order drift
— the `before` arm runs first in every replicate and the first arm reads high. Neither width reaches
either change (the cap only decides behaviour above eight rows; the split-K gate starts at five).

Intermediate widths, not scored but they show the two halves covering different ranges:
c12 `247 -> 367`, c24 `307 -> 366`.

### What each half does

**The cap.** `launch_down_q4k_mmvq_splitk_rows` returned false for `M > 8` and the caller fell back
to the per-token grid, which indexes the down super-blocks by token — sixteen full sweeps of the same
3.9 GB per step instead of one. The kernel already decodes each Q4_K super-block once and dots it
against all M rows (`si_q4k_decode_w` / `si_vec_dot_q4_K_pre`, hoisted out of the row loop); only the
dispatch ceiling was in the way. Sixteen, not thirty-two: above that the per-token grid still runs.

**The split-K.** `S` is chosen before the arm dispatch, so it applies to both the row-batched path and
the per-token one — which is why it is what moves c24 and c32, where the widened arm declines. At one
row, splitting hides a bs=1 occupancy stall; at width, each block already has M rows of work and the
extra splits only pay for a wider cross-warp reduction. Measured `S=2` against the fitted `S=8`:
-4.8% step time at c8, -4.3% at c16. **At one row S=2 is a ~1.1% regression on every scored
single-stream axis**, so this narrows S only above the width where it measured better and leaves
single-request decode on exactly the S it has today.

Both are behind runtime knobs so either arm of the A/B comes out of ONE binary:
`SPARKINFER_DOWN_ROWS_MAX=8` and `SPARKINFER_DOWN_SPLITK_WIDE_ROWS=999` reproduce today exactly.

### Correctness

Bit-identical per row: same traversal, same `kqs`, the same `si_vec_dot_q4_K` expressions, the same
ordered reduction. The split-K factor changes how many warps share a row, not the per-row dot or its
accumulation order. `kernels/tests/down_rows_gpu_test.cpp` compares every batch width m=2..16 against
a per-token reference computed one row at a time, under both gate/up block formats.

All ctest targets pass. The 12 single-stream axes are structurally unreachable (`num_tokens >= 2`),
and an off/on/off of this same pair measured them at 0.9986-1.0009x, worst `decode@4096`, against a
0.98 floor — with single-stream decode at 0.9996-1.0010x.
