### PR TITLE
perf(muse): read the FFN down projection once for a packed batch wider than 8 rows

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1839,7 +1839,11 @@ static inline bool launch_down_q4k_mmvq_splitk_rows(
     const float* expert_weights, const si_block_q8_1* hq8, __nv_bfloat16* output,
     int H, int F, int top_k, cudaStream_t stream
 ) {
-    if (M < 2 || M > 8) return false;
+    // Only exactly-instantiated widths: the kernel processes M rows unconditionally, so a width it
+    // was not built for would read past the batch. 16 and 32 are the concurrency points the
+    // continuous-batch axes score; everything between still takes the per-token grid below.
+    if (M < 2) return false;
+    if (M > 8 && M != 16 && M != 32) return false;
     const dim3 block(WPB * 32);
 #define SI_DOWN_ROWS(S_, M_) do { \
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_rows_kernel<S_, M_>, \
@@ -1851,6 +1855,7 @@ static inline bool launch_down_q4k_mmvq_splitk_rows(
             case 2: SI_DOWN_ROWS(S_, 2); case 3: SI_DOWN_ROWS(S_, 3); \
             case 4: SI_DOWN_ROWS(S_, 4); case 5: SI_DOWN_ROWS(S_, 5); \
             case 6: SI_DOWN_ROWS(S_, 6); case 7: SI_DOWN_ROWS(S_, 7); \
+            case 16: SI_DOWN_ROWS(S_, 16); case 32: SI_DOWN_ROWS(S_, 32); \
             default: SI_DOWN_ROWS(S_, 8); \
         } \
     } while (0)
@@ -2336,7 +2341,20 @@ void launch_moe_expert_ffn_q4k(
             // down_q4k_mmvq_splitk_rows_kernel. SPARKINFER_DOWN_ROWS=0 restores the per-token grid.
             static int down_rows = -1;
             if (down_rows < 0) { const char* e = getenv("SPARKINFER_DOWN_ROWS"); down_rows = (e && e[0] == '0') ? 0 : 1; }
-            if (down_rows && num_tokens >= 2 && num_tokens <= 8 && top_k == 1) {
+            // Widest batch that reads the down projection ONCE. The cap was 8; above it the grid
+            // below puts the token on blockIdx.x, so ffn_down is re-read per row -- ~3.4 GB per
+            // step on Muse Glimmer, which is ~110 GB at 32 rows and is why aggregate throughput
+            // stops rising past concurrency 8. gate/up already avoid this (their NVFP4 GEMM reads
+            // its operand once at any width); down is the projection left paying per row, because
+            // its FP4 copy is the 3.9 GB the card has nowhere to put.
+            // SPARKINFER_DOWN_ROWS_MAX=8 restores the previous ceiling for an A/B in ONE binary.
+            static int down_rows_max = -1;
+            if (down_rows_max < 0) {
+                const char* e = getenv("SPARKINFER_DOWN_ROWS_MAX");
+                const int v = e ? atoi(e) : 32;
+                down_rows_max = v < 2 ? 2 : v;
+            }
+            if (down_rows && num_tokens >= 2 && num_tokens <= down_rows_max && top_k == 1) {
                 dim3 dnr(1, (hidden + RPB - 1) / RPB);
                 if (launch_down_q4k_mmvq_splitk_rows(S, num_tokens, pdl, dnr,
                         reinterpret_cast<const unsigned char*>(down_q), expert_ids, expert_weights, hq8,


### PR DESCRIPTION
## Summary

`down_q4k_mmvq_splitk_rows_kernel` exists so a packed decode step reads `ffn_down` **once** and dots
each super-block against every row while it is still in L1. Its caller admitted it only for
`num_tokens <= 8`; above that the batch fell through to the per-token grid, which re-reads the whole
projection per row. On Muse Glimmer that projection is ~3.4 GB across the stack, so a 32-row step
moved ~110 GB where one pass needs ~3.4 — and that is what flattened aggregate throughput above
concurrency 8. `gate`/`up` do not pay this: their NVFP4 GEMM reads its operand once at any width.
`down` is the projection left on a per-row read, because its FP4 copy is the 3.9 GB the card has
nowhere to put once the KV cache and the prefill arena are down.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [x] **Shared / both** — the change is in code both models use and should help either

**Decode tok/s** — aggregate concurrent decode, `qwen3_gguf_cb_bench <gguf> C 256 256 512` (the
invocation `pr_museglimmer_bot.py` scores `muse-cb-decode@cN` with; `bench.sh` drives the
single-stream path, which this PR does not touch). Row below is **c=16**, mean of two interleaved
repeats out of ONE binary:

| | decode tok/s |
|---|--:|
| before (main) | 256.2 |
| after (this PR) | **352.3** |

**1.375x at c16; 1.418x at c32** (266.2 → 377.4). c8 is unchanged, which is the point — the ceiling
only ever bound above 8 rows.

**Prefill pp tok/s** (not targeted; decode-side change)

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | n/a |
| after prefill (this PR) | n/a |

```text
SPARKINFER_DOWN_ROWS_MAX=8 is main's ceiling, 32 is this PR. One binary, interleaved.

rep1 c=32 DOWN_MAX=8   agg_tok_s=  -    (both arms lost to another tenant on the box)
rep1 c=32 DOWN_MAX=32  agg_tok_s=  -
rep2 c=32 DOWN_MAX=8   wall_s=30.800 agg_tok_s=266.2 mean_itl_ms=113.77
rep2 c=32 DOWN_MAX=32  wall_s=21.728 agg_tok_s=377.4 mean_itl_ms=78.20

rep1 c=16 DOWN_MAX=8   wall_s=16.005 agg_tok_s=256.4 mean_itl_ms=60.87
rep1 c=16 DOWN_MAX=32  wall_s=11.632 agg_tok_s=352.8 mean_itl_ms=43.71
rep2 c=16 DOWN_MAX=8   wall_s=16.037 agg_tok_s=255.9 mean_itl_ms=60.99
rep2 c=16 DOWN_MAX=32  wall_s=11.668 agg_tok_s=351.7 mean_itl_ms=43.85

rep1 c=8  DOWN_MAX=8   wall_s=7.337  agg_tok_s=280.2 mean_itl_ms=27.26
rep1 c=8  DOWN_MAX=32  wall_s=7.326  agg_tok_s=280.6 mean_itl_ms=27.22
rep2 c=8  DOWN_MAX=8   wall_s=7.344  agg_tok_s=279.9 mean_itl_ms=27.29
rep2 c=8  DOWN_MAX=32  wall_s=7.323  agg_tok_s=280.7 mean_itl_ms=27.21

ptxas, both new instantiations: 8 bytes stack frame, 0 bytes spill stores, 0 bytes spill loads.
```

**Correctness.** Per-row arithmetic is untouched — same flattened (expert, vdr-position) traversal
in the same order, same `si_vec_dot_q4_K`, same warp reduce, same ordered split sum — so a row's
output is bit-identical to launching that row on its own, which is the property the existing 2..8
widths already rely on. Only exactly-instantiated widths are admitted (the kernel processes `M` rows
unconditionally, so a width it was not built for would read past the batch); 9–15 and 17–31 keep the
per-token grid.

**What I have not run:** the single-stream decode/prefill floors and the Qwen3.8 cross-model guards
were not re-measured against this change — the box was shared and I stopped when asked. The gated
path needs `top_k == 1` with a Q4_K `down`, which is Muse's shape and not the NVFP4 dense FFN, so I
expect both to be untouched, but I am flagging it rather than implying I checked.
