### PR TITLE
perf(muse): instantiate the row-batched down projection out to sixteen rows (1.02x concurrent decode @c32)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1839,7 +1839,7 @@ static inline bool launch_down_q4k_mmvq_splitk_rows(
     const float* expert_weights, const si_block_q8_1* hq8, __nv_bfloat16* output,
     int H, int F, int top_k, cudaStream_t stream
 ) {
-    if (M < 2 || M > 8) return false;
+    if (M < 2 || M > 16) return false;
     const dim3 block(WPB * 32);
 #define SI_DOWN_ROWS(S_, M_) do { \
         launch_mmvq_down_kernel(pdl, grid, block, stream, down_q4k_mmvq_splitk_rows_kernel<S_, M_>, \
@@ -1851,7 +1851,11 @@ static inline bool launch_down_q4k_mmvq_splitk_rows(
             case 2: SI_DOWN_ROWS(S_, 2); case 3: SI_DOWN_ROWS(S_, 3); \
             case 4: SI_DOWN_ROWS(S_, 4); case 5: SI_DOWN_ROWS(S_, 5); \
             case 6: SI_DOWN_ROWS(S_, 6); case 7: SI_DOWN_ROWS(S_, 7); \
-            default: SI_DOWN_ROWS(S_, 8); \
+            case 8: SI_DOWN_ROWS(S_, 8); case 9: SI_DOWN_ROWS(S_, 9); \
+            case 10: SI_DOWN_ROWS(S_, 10); case 11: SI_DOWN_ROWS(S_, 11); \
+            case 12: SI_DOWN_ROWS(S_, 12); case 13: SI_DOWN_ROWS(S_, 13); \
+            case 14: SI_DOWN_ROWS(S_, 14); case 15: SI_DOWN_ROWS(S_, 15); \
+            default: SI_DOWN_ROWS(S_, 16); \
         } \
     } while (0)
     if (S == 2)      SI_DOWN_ROWS_M(2);
@@ -2348,7 +2352,9 @@ void launch_moe_expert_ffn_q4k(
             // A one-row tail has no instantiation (the launcher declines M < 2), so when the
             // remainder would be 1 the preceding chunk gives up a row and the tail runs as 2.
             if (down_rows && num_tokens >= 2 && top_k == 1) {
-                constexpr int DMAX = 8;
+                static int dw16 = -1;
+                if (dw16 < 0) { const char* e = getenv("SPARKINFER_DOWN_W16"); dw16 = (e && e[0] == '0') ? 0 : 1; }
+                const int DMAX = dw16 ? 16 : 8;
                 dim3 dnr(1, (hidden + RPB - 1) / RPB);
                 const size_t q8pb = (size_t)(ffn >> 5);
                 bool rows_ok = true;


### PR DESCRIPTION
## Summary

The row-batched down projection is instantiated to eight rows, so a 32-row packed decode batch walks it in four chunks and pays the fixed weight read four times. Instantiating out to sixteen halves that to two.

The width is close to free here, which is the part worth checking against intuition: `M = 16` compiles to **64 registers against `M = 8`'s 72**, so the wider instantiation fits **four** 256-thread blocks per SM where the narrow one fits three, with no spill at either width.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

The arm is reached through the dense top-1 FFN down projection at `num_tokens >= 2`, which is the
path Muse's packed continuous-batch decode takes. Single-request decode never enters it. The
Qwen3.6 and ModelOpt Qwen3.8 guards still run over this file.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 381.5 |
| after (this PR) | 390.3 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_DOWN_W16=0/1`, interleaved, three rounds

| c | before | after | |
|---|--:|--:|--:|
| 8 | 280.9 | 281.1 | +0.1% |
| 16 | 350.7 | 357.4 | **+1.9%** |
| 32 | 381.5 | 390.3 | **+2.3%** |

Raw, so the spread is visible: c=32 reads 387.7 / 378.8 / 378.1 before against 391.8 / 388.4 /
390.7 after; c=16 reads 352.6 / 350.2 / 349.3 against 358.7 / 357.3 / 356.3. A batch of eight or
fewer takes the identical single launch it takes today, with every pointer at offset zero, which is
what the c=8 row shows.

### The single-request axes cannot move

The arm needs `num_tokens >= 2`, so a single request never reaches it. Measured over the scored
sweep shapes anyway (128/512 at reps 5, 4k/16k/32k at reps 1), worst case **-0.14%**:

| ctx | decode before → after | prefill before → after |
|---|---|---|
| 128 | 105.87 → 105.72 | 9794.8 → 9807.6 |
| 512 | 105.12 → 105.01 | 15469.1 → 15606.6 |
| 4096 | 102.15 → 102.19 | 14551.5 → 14558.3 |
| 16384 | 101.36 → 101.43 | 13964.2 → 13972.8 |
| 32768 | 100.01 → 100.00 | 12746.7 → 12764.3 |

### Why it is worth about two percent and not more

Fitting the kernel's cost from two measured widths gives `t(M) ~ 21.7 + 14.9*M us`: the fixed
weight read is ~22 us and each row adds ~15 us of arithmetic. At 32 rows that is ~477 us of per-row
work against ~87 us of weight reads, so halving the number of passes only ever attacks the smaller
term. This is the honest ceiling for the change, not a first step toward more.

### Correctness

Per-row bit-identity is already covered by `kernels/tests/down_rows_chunk_gpu_test.cpp`, which
requires a chunked run to equal, row for row, the same rows run as their own batch. It exercises
every instantiated width and passes at M = 9, 16, 17, 24 and 32 with the wider range in place —
16 and 32 now resolving to the new 16-row body rather than two and four eight-row ones.

`SPARKINFER_DOWN_W16=0` restores the eight-row chunking for a paired A/B out of one binary.

`bench/scripts/bench.sh` benchmarks the prebuilt release binaries and cannot measure a branch, so the numbers above come from `qwen3_gguf_cb_bench` — the same binary, invocation and `agg_tok_s` parser this bot uses for `muse-cb-decode@cN`.