### PR TITLE
perf(muse): run the dense down projection on the int8 tensor cores for wide packed batches (1.23x concurrent decode @c32)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -16,6 +16,10 @@
 // Portable CUDA — sm_89/90/100/120, the set CMAKE_CUDA_ARCHITECTURES actually builds.
 // sm_121 is excluded (needs CUDA 12.9+); see CMakeLists.txt.
 
+#ifndef SPARKINFER_NVRTC_DEVICE_ONLY
+#include <mutex>
+#endif
+
 #include <cuda_bf16.h>
 #include <cuda_fp16.h>
 #ifndef SPARKINFER_NVRTC_DEVICE_ONLY
@@ -1846,7 +1850,27 @@ static inline bool launch_down_q6k_mmvq_splitk(
 #if __CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)
 namespace {
 constexpr int SI_MMA_BN = 32;      // output rows per block
+// K-splits. H/BN = 208 blocks is only 1.2 per SM on 170 SMs while the kernel fits 8, so the GRID,
+// not the tile, was the limit: splitting K multiplies the block count without shrinking the tile.
+// Measured at the real shape, M=32: SK 1 -> 349.7 us, 2 -> 225.1, 4 -> 178.1, 8 -> 171.2,
+// 16 -> 168.9. Eight is the knee.
+constexpr int SI_MMA_SK = 8;
 constexpr int SI_MMA_MMAX = 32;    // decode batch ceiling
+// Split-K needs an fp32 accumulator, and neither scratch the caller hands us is free: out_scratch
+// is reinterpreted as the Q8_1 activations this kernel READS, and h_scratch holds the gate/up
+// output. Own one instead -- 32 x 6656 floats is 852 KB per slot, sized for the widths the
+// dispatch gates to.
+//
+// A slot per stream, because decode is not single-stream: it runs on the main stream while a
+// prefill chunk short enough to reach this arm can be in flight on its own, and one buffer would
+// have the two accumulate into each other. Launches within ONE stream are ordered, so a slot bound
+// to a stream is exclusively that stream's; a stream past the table declines to the MMVQ.
+//
+// Static, and deliberately not allocated on demand: decode captures CUDA graphs, and a cudaMalloc
+// during capture invalidates the graph -- which shows up as "verify graph launch: invalid
+// argument" and a step that returns without doing the work.
+constexpr int SI_MMA_SLOTS = 4;
+__device__ float si_mma_down_acc[SI_MMA_SLOTS][SI_MMA_MMAX * 6656];
 constexpr int SI_MMA_NW = 4;
 
 __device__ __forceinline__ int si_mma_swz(int k, int row) {
@@ -1877,11 +1901,17 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
                               const int* __restrict__ expert_ids,
                               const float* __restrict__ expert_weights,
                               const si_block_q8_1* __restrict__ hq8,
-                              __nv_bfloat16* __restrict__ output,
+                              float* __restrict__ acc_out,
                               int H, int F, int top_k, int M, int pdl) {
     if (pdl) si_pdl_sync();
     const int nblk = F >> 8;
     const int n0 = blockIdx.x * SI_MMA_BN;
+    // Balanced, not ceil: 78 super-blocks over 8 splits is 10,10,10,10,10,10,9,9 rather than seven
+    // 10s and an 8, and the launch waits for the longest split.
+    const int sk = (int)gridDim.y;
+    const int sb_base = nblk / sk, sb_extra = nblk % sk;
+    const int sb_lo = (int)blockIdx.y * sb_base + ((int)blockIdx.y < sb_extra ? (int)blockIdx.y : sb_extra);
+    const int sb_hi = sb_lo + sb_base + ((int)blockIdx.y < sb_extra ? 1 : 0);
     const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
     const int grp = lane >> 2, tig = lane & 3, sub = lane >> 3, lrow = lane & 7;
     const int e0 = expert_ids[0];
@@ -1898,7 +1928,7 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
         #pragma unroll
         for (int e = 0; e < 4; e++) facc[i][e] = 0.f;
 
-    for (int sb = 0; sb < nblk; sb++) {
+    for (int sb = sb_lo; sb < sb_hi; sb++) {
         // One 16B output chunk per unit: the swizzle permutes whole 16B chunks, so addresses
         // inside a chunk are contiguous and each unit is a single uint4 store.
         for (int u = tid; u < SI_MMA_BN * 16; u += SI_MMA_NW * 32) {
@@ -1989,21 +2019,58 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
         for (int e = 0; e < 4; e++) {
             const int lm = i * 16 + grp + (e >> 1) * 8;
             const int gn = n0 + warp * 8 + tig * 2 + (e & 1);
-            if (lm < M && gn < H)
-                output[(size_t)lm * H + gn] =
-                    __float2bfloat16(facc[i][e] * expert_weights[(size_t)lm * top_k]);
+            if (lm < M && gn < H) atomicAdd(&acc_out[(size_t)lm * H + gn], facc[i][e]);
         }
+}
+
+// Scales by the expert weight, narrows to bf16, and re-zeroes what it consumed so the next call
+// needs no memset of its own.
+__global__ void down_q4k_mma_epilogue_kernel(float* __restrict__ acc,
+                                            const float* __restrict__ expert_weights,
+                                            __nv_bfloat16* __restrict__ output,
+                                            int H, int top_k, int M) {
+    const size_t i = (size_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= (size_t)M * H) return;
+    const int lm = (int)(i / (size_t)H);
+    output[i] = __float2bfloat16(acc[i] * expert_weights[(size_t)lm * top_k]);
+    acc[i] = 0.f;
+}
+
+// Claim this stream's slot, first call wins. The table only ever grows and holds a handful of
+// entries, so the lock is contended only on the few calls that add a stream.
+static int si_mma_down_slot_for(cudaStream_t stream) {
+    static std::mutex mu;
+    static cudaStream_t owners[SI_MMA_SLOTS] = {};
+    static int used = 0;
+    std::lock_guard<std::mutex> lk(mu);
+    for (int i = 0; i < used; i++) if (owners[i] == stream) return i;
+    if (used >= SI_MMA_SLOTS) return -1;
+    owners[used] = stream;
+    return used++;
 }
 
 static inline bool launch_down_q4k_mma_rows(
     int pdl, const unsigned char* down_q, const int* expert_ids, const float* expert_weights,
-    const si_block_q8_1* hq8, __nv_bfloat16* output, int H, int F, int top_k, int M,
-    cudaStream_t stream
+    const si_block_q8_1* hq8, __nv_bfloat16* output,
+    int H, int F, int top_k, int M, cudaStream_t stream
 ) {
     if (M < 2 || M > SI_MMA_MMAX || top_k != 1 || (F & 255) || (H % SI_MMA_BN)) return false;
-    launch_pdl_kernel(pdl, dim3(H / SI_MMA_BN), dim3(SI_MMA_NW * 32), 0, stream,
-                      down_q4k_mma_rows_kernel, down_q, expert_ids, expert_weights, hq8, output,
-                      H, F, top_k, M, pdl);
+    if ((size_t)M * (size_t)H > (size_t)SI_MMA_MMAX * 6656u) return false;
+    const int slot = si_mma_down_slot_for(stream);
+    if (slot < 0) return false;
+    float* acc_scratch = nullptr;
+    if (cudaGetSymbolAddress(reinterpret_cast<void**>(&acc_scratch), si_mma_down_acc) != cudaSuccess)
+        return false;
+    acc_scratch += (size_t)slot * SI_MMA_MMAX * 6656u;
+    const int nblk = F >> 8;
+    int sk = SI_MMA_SK; if (sk > nblk) sk = nblk;   // never launch a split with nothing to reduce
+    const size_t n = (size_t)M * (size_t)H;
+    launch_pdl_kernel(pdl, dim3(H / SI_MMA_BN, sk), dim3(SI_MMA_NW * 32), 0, stream,
+                      down_q4k_mma_rows_kernel, down_q, expert_ids, expert_weights, hq8,
+                      acc_scratch, H, F, top_k, M, pdl);
+    const int thr = 256;
+    down_q4k_mma_epilogue_kernel<<<(unsigned)((n + thr - 1) / thr), thr, 0, stream>>>(
+        acc_scratch, expert_weights, output, H, top_k, M);
     return true;
 }
 #endif
@@ -2770,7 +2837,15 @@ void launch_moe_expert_ffn_q4k(
             // SPARKINFER_DOWN_MMA=0 keeps every width on the MMVQ.
             static int down_mma = -1;
             if (down_mma < 0) { const char* e = getenv("SPARKINFER_DOWN_MMA"); down_mma = (e && e[0] == '0') ? 0 : 1; }
-            if (down_mma && num_tokens >= 24 && top_k == 1 &&
+            // Eight rows is where the tensor-core arm starts paying, and the floor is about the
+            // weight traffic rather than the arithmetic. The MMVQ chunks at eight rows, so at or
+            // below that width it already reads ffn_down exactly once -- the same as the mma
+            // kernel, which pads M to the 16 rows of an m16n8k32 tile. Below eight there is no
+            // traffic to win back and the padding is pure waste: four rows measured 5.9% slower
+            // end to end, while eight is 5.2% faster and sixteen 23% faster.
+            static int down_mma_min = -1;
+            if (down_mma_min < 0) { const char* e = getenv("SPARKINFER_DOWN_MMA_MINROWS"); down_mma_min = e ? atoi(e) : 8; }
+            if (down_mma && num_tokens >= down_mma_min && top_k == 1 &&
                 launch_down_q4k_mma_rows(pdl, reinterpret_cast<const unsigned char*>(down_q),
                                          expert_ids, expert_weights, hq8,
                                          reinterpret_cast<__nv_bfloat16*>(output),

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1831,6 +1831,183 @@ static inline bool launch_down_q6k_mmvq_splitk(
         default: return false;
     }
 }
+// ---- Q4_K straight into the int8 tensor cores, for batches the MMVQ cannot amortise ----
+// The per-row MMVQ below re-does the dot product once per row, so its cost is ~21.7 + 14.9*M us
+// per layer -- at 32 rows that is ~520 us against a 74.8 MB / 1792 GB/s = 41.7 us weight-read
+// floor. This is the Marlin shape instead: dequantise inside the mainloop and let mma.sync do the
+// arithmetic, so the weights are read once for the whole batch. m16n8k32 spans exactly 32 K, which
+// is exactly one Q4_K scale group, so the group scales fold in per-mma with the accumulator still
+// in registers.
+//
+// Same arithmetic as si_vec_dot_q4_K, per 32-group:
+//     sum(w*a) = (d * sc_j * d8) * sum(q_w*q_a) - (dmin * m_j) * s
+// with s the Q8_1 ds.y, so sum(q_a) needs no second mma. NOT bit-identical to the MMVQ -- the
+// reduction order differs -- so it is gated to batches where it is a clear win.
+#if __CUDA_ARCH__ >= 800 || !defined(__CUDA_ARCH__)
+namespace {
+constexpr int SI_MMA_BN = 32;      // output rows per block
+constexpr int SI_MMA_MMAX = 32;    // decode batch ceiling
+constexpr int SI_MMA_NW = 4;
+
+__device__ __forceinline__ int si_mma_swz(int k, int row) {
+    return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
+}
+__device__ __forceinline__ void si_mma_ldm(unsigned& r0, unsigned& r1, unsigned& r2, unsigned& r3,
+                                           const signed char* p) {
+    const unsigned a = (unsigned)__cvta_generic_to_shared(p);
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+                 : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3) : "r"(a));
+}
+// The 6-bit (sc, m) pair for sub-blocks 2j and 2j+1, exactly as si_vec_dot_q4_K unpacks them.
+__device__ __forceinline__ void si_mma_q4k_scales(const unsigned char* sc12, int j,
+                                                  unsigned char& a0, unsigned char& a1,
+                                                  unsigned char& b0, unsigned char& b1) {
+    const unsigned short* s = reinterpret_cast<const unsigned short*>(sc12);
+    unsigned short aux[2];
+    if (j < 2) { aux[0] = s[j] & 0x3f3f; aux[1] = s[j + 2] & 0x3f3f; }
+    else       { aux[0] = ((s[j + 2] >> 0) & 0x0f0f) | ((s[j - 2] & 0xc0c0) >> 2);
+                 aux[1] = ((s[j + 2] >> 4) & 0x0f0f) | ((s[j]     & 0xc0c0) >> 2); }
+    const unsigned char* u = reinterpret_cast<const unsigned char*>(aux);
+    a0 = u[0]; a1 = u[1]; b0 = u[2]; b1 = u[3];
+}
+}  // namespace
+
+__global__ __launch_bounds__(SI_MMA_NW * 32, 8)
+void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
+                              const int* __restrict__ expert_ids,
+                              const float* __restrict__ expert_weights,
+                              const si_block_q8_1* __restrict__ hq8,
+                              __nv_bfloat16* __restrict__ output,
+                              int H, int F, int top_k, int M, int pdl) {
+    if (pdl) si_pdl_sync();
+    const int nblk = F >> 8;
+    const int n0 = blockIdx.x * SI_MMA_BN;
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int grp = lane >> 2, tig = lane & 3, sub = lane >> 3, lrow = lane & 7;
+    const int e0 = expert_ids[0];
+
+    __shared__ signed char As[SI_MMA_MMAX][256];
+    __shared__ signed char Bs[SI_MMA_BN][256];
+    __shared__ unsigned char Ssc[SI_MMA_BN][8], Smn[SI_MMA_BN][8];
+    __shared__ float2 Wdm[SI_MMA_BN];
+    __shared__ float Ad[SI_MMA_MMAX][8], Asum[SI_MMA_MMAX][8];
+
+    float facc[2][4];
+    #pragma unroll
+    for (int i = 0; i < 2; i++)
+        #pragma unroll
+        for (int e = 0; e < 4; e++) facc[i][e] = 0.f;
+
+    for (int sb = 0; sb < nblk; sb++) {
+        // One 16B output chunk per unit: the swizzle permutes whole 16B chunks, so addresses
+        // inside a chunk are contiguous and each unit is a single uint4 store.
+        for (int u = tid; u < SI_MMA_BN * 16; u += SI_MMA_NW * 32) {
+            const int r = u >> 4, c = u & 15;
+            const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
+                down_q + ((size_t)e0 * H + (n0 + r)) * (size_t)nblk * 144) + sb;
+            const int j = c >> 2, sc_ = c & 3;
+            const bool hi = (sc_ >> 1) & 1;
+            const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + (sc_ & 1) * 16);
+            signed char out[16];
+            #pragma unroll
+            for (int v = 0; v < 4; v++) {
+                const unsigned x = src[v];
+                #pragma unroll
+                for (int t = 0; t < 4; t++) {
+                    const unsigned char q = (unsigned char)((x >> (8 * t)) & 0xFF);
+                    out[4 * v + t] = (signed char)(hi ? (q >> 4) : (q & 0xF));
+                }
+            }
+            const int kb = 64 * j + (sc_ >> 1) * 32 + (sc_ & 1) * 16;
+            *reinterpret_cast<uint4*>(&Bs[r][si_mma_swz(kb, r)]) = *reinterpret_cast<const uint4*>(out);
+            if (c == 0) {
+                Wdm[r] = __half22float2(b->dm);
+                #pragma unroll
+                for (int jj = 0; jj < 4; jj++) {
+                    unsigned char x0, x1, y0, y1;
+                    si_mma_q4k_scales(b->scales, jj, x0, x1, y0, y1);
+                    Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
+                    Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                }
+            }
+        }
+        // hq8's qs sits at offset 4 of a 36B struct: 4B-aligned, never 16B. Read four uints.
+        for (int u = tid; u < M * 16; u += SI_MMA_NW * 32) {
+            const int r = u >> 4, c = u & 15;
+            const si_block_q8_1* a = hq8 + (size_t)r * (F >> 5) + sb * 8 + (c >> 1);
+            const unsigned* src = reinterpret_cast<const unsigned*>(a->qs + (c & 1) * 16);
+            uint4 v; v.x = src[0]; v.y = src[1]; v.z = src[2]; v.w = src[3];
+            *reinterpret_cast<uint4*>(&As[r][si_mma_swz(16 * c, r)]) = v;
+            if ((c & 1) == 0) {
+                const float2 ds = __half22float2(a->ds);
+                Ad[r][c >> 1] = ds.x; Asum[r][c >> 1] = ds.y;
+            }
+        }
+        __syncthreads();
+
+        #pragma unroll 1
+        for (int g = 0; g < 8; g++) {
+            const int kk = g * 32;
+            unsigned af[2][4], bf[2];
+            #pragma unroll
+            for (int i = 0; i < 2; i++) {
+                const int row = i * 16 + (sub & 1) * 8 + lrow;
+                si_mma_ldm(af[i][0], af[i][1], af[i][2], af[i][3],
+                           &As[row < SI_MMA_MMAX ? row : 0][si_mma_swz(kk + (sub >> 1) * 16, row)]);
+            }
+            unsigned bx, by;
+            const int col = warp * 8 + lrow;
+            si_mma_ldm(bf[0], bf[1], bx, by, &Bs[col][si_mma_swz(kk + (sub & 1) * 16, col)]);
+            (void)bx; (void)by;
+
+            #pragma unroll
+            for (int i = 0; i < 2; i++) {
+                int acc[4] = {0, 0, 0, 0};
+                asm volatile(
+                    "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                    : "+r"(acc[0]), "+r"(acc[1]), "+r"(acc[2]), "+r"(acc[3])
+                    : "r"(af[i][0]), "r"(af[i][1]), "r"(af[i][2]), "r"(af[i][3]),
+                      "r"(bf[0]), "r"(bf[1]));
+                #pragma unroll
+                for (int e = 0; e < 4; e++) {
+                    const int lm = i * 16 + grp + (e >> 1) * 8;
+                    const int ln = warp * 8 + tig * 2 + (e & 1);
+                    if (lm >= M) continue;
+                    const float2 dm = Wdm[ln];
+                    facc[i][e] += dm.x * (float)Ssc[ln][g] * Ad[lm][g] * (float)acc[e]
+                                - dm.y * (float)Smn[ln][g] * Asum[lm][g];
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 2; i++)
+        #pragma unroll
+        for (int e = 0; e < 4; e++) {
+            const int lm = i * 16 + grp + (e >> 1) * 8;
+            const int gn = n0 + warp * 8 + tig * 2 + (e & 1);
+            if (lm < M && gn < H)
+                output[(size_t)lm * H + gn] =
+                    __float2bfloat16(facc[i][e] * expert_weights[(size_t)lm * top_k]);
+        }
+}
+
+static inline bool launch_down_q4k_mma_rows(
+    int pdl, const unsigned char* down_q, const int* expert_ids, const float* expert_weights,
+    const si_block_q8_1* hq8, __nv_bfloat16* output, int H, int F, int top_k, int M,
+    cudaStream_t stream
+) {
+    if (M < 2 || M > SI_MMA_MMAX || top_k != 1 || (F & 255) || (H % SI_MMA_BN)) return false;
+    launch_pdl_kernel(pdl, dim3(H / SI_MMA_BN), dim3(SI_MMA_NW * 32), 0, stream,
+                      down_q4k_mma_rows_kernel, down_q, expert_ids, expert_weights, hq8, output,
+                      H, F, top_k, M, pdl);
+    return true;
+}
+#endif
+
 // Row-batched counterpart of launch_down_q4k_mmvq_splitk. Only the generic (non shape-specialized)
 // split-K kernel has a rows form, so this declines anything it does not cover and the caller falls
 // back to the per-token grid.
@@ -2585,6 +2762,20 @@ void launch_moe_expert_ffn_q4k(
             //
             // A one-row tail has no instantiation (the launcher declines M < 2), so when the
             // remainder would be 1 the preceding chunk gives up a row and the tail runs as 2.
+            // Wide batches go to the tensor-core path instead of being chunked: the MMVQ costs
+            // ~21.7 + 14.9*M us per layer, so at 32 rows four (or two) chunks re-read the weights
+            // and still pay the per-row arithmetic, while the mma kernel reads them once for the
+            // whole batch. It loses below ~24 rows, where the MMVQ's cheaper setup still wins, so
+            // the crossover is a floor and not a preference.
+            // SPARKINFER_DOWN_MMA=0 keeps every width on the MMVQ.
+            static int down_mma = -1;
+            if (down_mma < 0) { const char* e = getenv("SPARKINFER_DOWN_MMA"); down_mma = (e && e[0] == '0') ? 0 : 1; }
+            if (down_mma && num_tokens >= 24 && top_k == 1 &&
+                launch_down_q4k_mma_rows(pdl, reinterpret_cast<const unsigned char*>(down_q),
+                                         expert_ids, expert_weights, hq8,
+                                         reinterpret_cast<__nv_bfloat16*>(output),
+                                         hidden, ffn, top_k, num_tokens, stream))
+                return;
             if (down_rows && num_tokens >= 2 && top_k == 1) {
                 // One pass over ffn_down per chunk, so the chunk width IS the number of times
                 // a packed step re-reads 3.9 GB. Eight was the widest instantiation; the arm now

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -37,3 +37,8 @@ set_tests_properties(sparse_gate_up_rows_gpu_test PROPERTIES SKIP_RETURN_CODE 77
 add_executable(mmvq_mma_accuracy_gpu_test mmvq_mma_accuracy_gpu_test.cpp)
 target_link_libraries(mmvq_mma_accuracy_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
 set_target_properties(mmvq_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)
+# The tensor-core down projection against the MMVQ, dumped per process so the two can be diffed.
+# Not a ctest: it needs two runs with different env to be meaningful, and ~1 GB of device memory.
+add_executable(down_mma_accuracy_gpu_test down_mma_accuracy_gpu_test.cpp)
+target_link_libraries(down_mma_accuracy_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
+set_target_properties(down_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)

--- a/kernels/tests/down_mma_accuracy_gpu_test.cpp
+++ b/kernels/tests/down_mma_accuracy_gpu_test.cpp
@@ -1,0 +1,104 @@
+// Dumps the dense down-projection output at Muse Glimmer's real 6656x19968 shape so the two
+// implementations can be diffed across processes:
+//
+//     SPARKINFER_DOWN_MMA=0 DOWN_MMA_DUMP=/tmp/mmvq.bin ./down_mma_accuracy_gpu_test
+//     SPARKINFER_DOWN_MMA=1 DOWN_MMA_DUMP=/tmp/mma.bin  ./down_mma_accuracy_gpu_test
+//
+// Two processes, not two calls: the dispatch caches its env read in a function-local static, so a
+// single process can only ever exercise one arm.
+//
+// This is deliberately NOT a bit-identity test. The mma path reduces over K in a different order
+// (one m16n8k32 per 32-value scale group, accumulated in float) than the per-row dp4a MMVQ, so the
+// two cannot agree bit-for-bit. What must hold is that the gap is rounding rather than a different
+// answer, which is what comparing the two dumps shows.
+#include "sparkinfer/kernels/moe.h"
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cmath>
+#include <vector>
+#include <cstring>
+#include <cuda_fp16.h>
+
+namespace {
+constexpr int H = 6656, F = 19968, Q4K = 12;
+uint32_t lcg(uint32_t& s) { s = s * 1664525u + 1013904223u; return s; }
+template <class T> T* dev(size_t n, const void* host = nullptr) {
+    void* p = nullptr;
+    if (cudaMalloc(&p, n * sizeof(T)) != cudaSuccess) return nullptr;
+    if (host) cudaMemcpy(p, host, n * sizeof(T), cudaMemcpyHostToDevice);
+    else      cudaMemset(p, 0, n * sizeof(T));
+    return static_cast<T*>(p);
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+    int nd = 0;
+    if (cudaGetDeviceCount(&nd) != cudaSuccess || nd == 0) return 77;
+    const int M = argc > 1 ? atoi(argv[1]) : 32;
+
+    const size_t down_bytes = (size_t)H * (F / 256) * 144;
+    std::vector<unsigned char> h_down(down_bytes);
+    uint32_t seed = 0xA11CE5u;                       // fixed: both processes build identical inputs
+    for (size_t i = 0; i < down_bytes; ++i) h_down[i] = (unsigned char)(lcg(seed) >> 17);
+    // Random bytes across the whole block would randomise the dm/dmin half2 too, which makes the
+    // dequantised weights overflow and the comparison meaningless (rms comes out NaN). Write a
+    // realistic scale pair into every super-block, and keep the 6-bit scale fields in range.
+    for (size_t b = 0; b < down_bytes; b += 144) {
+        const float d    = 0.008f + (lcg(seed) % 64) * 1e-4f;
+        const float dmin = 0.004f + (lcg(seed) % 32) * 1e-4f;
+        const __half2 dm = __floats2half2_rn(d, dmin);
+        std::memcpy(&h_down[b], &dm, sizeof(__half2));
+        for (int i = 0; i < 12; i++) h_down[b + 4 + i] = (unsigned char)(lcg(seed) & 0x3f);
+    }
+    std::vector<__nv_bfloat16> h_gu((size_t)M * F);
+    for (auto& v : h_gu) v = __float2bfloat16(((int)(lcg(seed) >> 24) - 128) * 0.01f);
+    std::vector<int>   h_ids((size_t)M, 0);
+    std::vector<float> h_wts((size_t)M, 1.0f);
+
+    auto* d_down = dev<unsigned char>(down_bytes, h_down.data());
+    auto* d_gate = dev<__nv_bfloat16>((size_t)M * F, h_gu.data());
+    auto* d_up   = dev<__nv_bfloat16>((size_t)M * F, h_gu.data());
+    auto* d_ids  = dev<int>((size_t)M, h_ids.data());
+    auto* d_wts  = dev<float>((size_t)M, h_wts.data());
+    auto* d_out  = dev<__nv_bfloat16>((size_t)M * H);
+    auto* d_hs   = dev<float>((size_t)M * F);
+    auto* d_os   = dev<float>((size_t)M * H);
+    if (!d_down || !d_gate || !d_up || !d_ids || !d_wts || !d_out || !d_hs || !d_os) {
+        std::printf("[SKIP] allocation failed (needs ~%.1f GB)\n", (double)down_bytes / 1e9);
+        return 77;
+    }
+
+    sparkinfer::kernels::launch_moe_expert_ffn_q4k(
+        nullptr, nullptr, nullptr, d_down, Q4K, Q4K, Q4K,
+        d_ids, d_wts, d_out, d_hs, d_os, M, 1, H, F,
+        nullptr, nullptr, false, d_gate, d_up);
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        std::printf("[FAIL] launch: %s\n", cudaGetErrorString(cudaGetLastError()));
+        return 1;
+    }
+    std::vector<__nv_bfloat16> out((size_t)M * H);
+    cudaMemcpy(out.data(), d_out, out.size() * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost);
+
+    double sum = 0.0, amax = 0.0;
+    for (size_t i = 0; i < out.size(); i++) {
+        const double v = (double)__bfloat162float(out[i]);
+        sum += v * v; if (std::fabs(v) > amax) amax = std::fabs(v);
+    }
+    const char* mode = getenv("SPARKINFER_DOWN_MMA");
+    std::printf("M=%d mode=%s rms=%.9e amax=%.9e n=%zu\n",
+                M, mode ? mode : "(default)", std::sqrt(sum / (double)out.size()), amax, out.size());
+    if (const char* path = getenv("DOWN_MMA_DUMP")) {
+        FILE* f = fopen(path, "wb");
+        if (!f) { std::printf("[FAIL] cannot write %s\n", path); return 1; }
+        fwrite(out.data(), sizeof(__nv_bfloat16), out.size(), f);
+        fclose(f);
+        std::printf("wrote %s\n", path);
+    }
+
+    cudaFree(d_down); cudaFree(d_gate); cudaFree(d_up); cudaFree(d_ids);
+    cudaFree(d_wts); cudaFree(d_out); cudaFree(d_hs); cudaFree(d_os);
+    return 0;
+}

--- a/kernels/tests/down_mma_accuracy_gpu_test.cpp
+++ b/kernels/tests/down_mma_accuracy_gpu_test.cpp
@@ -82,6 +82,7 @@ int main(int argc, char** argv) {
     std::vector<__nv_bfloat16> out((size_t)M * H);
     cudaMemcpy(out.data(), d_out, out.size() * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost);
 
+
     double sum = 0.0, amax = 0.0;
     for (size_t i = 0; i < out.size(); i++) {
         const double v = (double)__bfloat162float(out[i]);

--- a/kernels/tests/down_rows_chunk_gpu_test.cpp
+++ b/kernels/tests/down_rows_chunk_gpu_test.cpp
@@ -14,6 +14,7 @@
 #include <cuda_runtime.h>
 #include <cstdio>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -39,6 +40,12 @@ template <class T> T* dev(size_t n, const void* host = nullptr) {
 int main() {
     int devcount = 0;
     if (cudaGetDeviceCount(&devcount) != cudaSuccess || devcount == 0) return 77;
+
+    // Pin the arm this test is about. The tensor-core down projection now intercepts eight rows and
+    // up, so without this every width below would run there instead and the chunk arithmetic these
+    // cases exist to cover would go unexercised. It is still a live path: it serves the narrow
+    // widths, and it is the fallback whenever the mma arm declines a shape.
+    setenv("SPARKINFER_DOWN_MMA", "0", 1);
 
     // Q4_K down weights for a single expert: [1, H, F], 144 bytes per 256 values.
     const size_t down_bytes = (size_t)H * (F / 256) * 144;


### PR DESCRIPTION
## Summary

The row-batched down projection redoes its dot product once per row, so its cost is about `21.7 + 14.9*M` µs per layer — at 32 rows that is far above the 41.7 µs the weights alone cost (74.8 MB at 1792 GB/s). Nothing in this tree fed Q4_K into an MMA pipe, so a wide packed batch could not reach the tensor cores at all. This adds that path and routes wide batches to it.

`m16n8k32` spans exactly 32 K, which is exactly one Q4_K scale group, so the group scales fold in per-`mma` with the accumulator still in its four registers — no partial-group bookkeeping, and no dequantised copy of the weights anywhere (a resident int8 one is 6.9 GB and does not fit beside the model and the KV pool).

The tile alone was not enough. `H/BN` is 208 blocks on 170 SMs — 1.22 per SM while the kernel's 19200 B of shared memory fits 8 — so the kernel ran at under 8% of the device no matter how good the inner loop was. Splitting K eight ways multiplies the block count without shrinking the tile, which is where most of the speedup is:

| K-splits | blocks | µs at M=32 |
|---:|---:|---:|
| 1 | 208 | 349.7 |
| 2 | 416 | 225.1 |
| 4 | 832 | 178.1 |
| **8** | **1664** | **171.2** |
| 16 | 3328 | 168.9 |

The floor is eight rows, and it is about weight traffic rather than arithmetic: the MMVQ chunks at eight, so at or below that width it already reads `ffn_down` exactly once — the same as this kernel, which still pads M to the sixteen rows of an `m16n8k32` tile. Four rows measured **5.9% slower** end to end before the floor was raised.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

Reached only through the dense top-1 FFN down projection at `num_tokens >= 8` and the
`6656 x 19968` shape, which is Muse's packed continuous-batch decode. A single request decodes at
`num_tokens == 1` and cannot reach it. The Qwen3.6 and ModelOpt Qwen3.8 guards still run over this
file.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 458.1 |
| after (this PR) | **564.1** |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_DOWN_MMA=0/1`, interleaved

| c | before | after | |
|---|--:|--:|--:|
| 32 | 458.1 | **564.1** | **+23.1%** |
| 16 | 357.5 | **439.3** | **+22.9%** |
| 8 | 292.6 | **307.6** | **+5.1%** |
| 4 | 190.3 | 190.6 | — |
| 2 | 136.8 | 136.9 | — |

Median of three interleaved rounds. Per round, before / after:

```text
c=32: before [458.0, 458.1, 477.4]  after [563.0, 564.1, 591.8]
c=16: before [357.5, 357.5, 358.8]  after [437.2, 439.3, 440.2]
c=8: before [292.3, 292.6, 292.7]  after [307.3, 307.6, 308.0]
c=4: before [190.0, 190.3, 190.4]  after [190.4, 190.6, 190.9]
c=2: before [136.8, 136.8, 136.8]  after [136.5, 136.9, 136.9]
```

c=4 and c=2 sit below the eight-row floor, so the same binary runs the same MMVQ in both
arms there -- which is what those two rows show.

### Correctness

Not bit-identical, and not claimed to be: this path reduces over K in a different order than the
per-row dp4a MMVQ, and split-K accumulates across blocks. So the agreement is measured.
`kernels/tests/down_mma_accuracy_gpu_test.cpp` dumps the dense down output for both arms at the
real `6656 x 19968` shape and 32 rows — two processes, because the dispatch caches its env read in
a function-local static — and the diff is:

```text
bit-identical:        212958 / 212992  (99.984%)
relative RMS:         7.7690e-05
worst elementwise:    7.7780e-03       <- one bf16 ulp (2^-7)
aggregate rms         8228.572131 (MMVQ)  vs  8228.571638 (mma)
```

`down_rows_chunk_gpu_test` now pins `SPARKINFER_DOWN_MMA=0`: it exists to cover the chunked MMVQ's
pointer arithmetic, and eight rows and up would otherwise be served by this arm instead. That arm
is still live — it serves the narrow widths, and it is the fallback whenever this one declines.

### Notes

The fp32 accumulator split-K needs is a static per-stream slot, not an allocation. Decode captures
CUDA graphs and a `cudaMalloc` reached during capture invalidates the graph — which surfaces as
`verify graph launch: invalid argument` and a step that returns without doing the work. One slot
per stream because decode runs on the main stream while a prefill chunk short enough to reach this
arm can be in flight on its own; a stream past the table declines to the MMVQ.
