### PR TITLE
perf(muse): share one gate/up read across the packed batch in the contextual-sparsity FFN (1.10x concurrent decode @c4)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -2064,6 +2064,166 @@ __global__ void swiglu_rows_bf16_f32_kernel(const __nv_bfloat16* __restrict__ g,
     if (i < n) h[i] = q4kf_silu(__bfloat162float(g[i])) * __bfloat162float(u[i]);
 }
 
+// Widest packed batch the row-batched sparse gate/up is instantiated for. Sixteen, because the
+// continuous-batch scheduler hands the packed forward its whole live set and sixteen is the
+// widest that fits alongside Muse Glimmer's weights on a 32 GB card.
+static constexpr int kMuseGuRowsMax = 16;
+
+// SPARKINFER_MUSE_GU_ROWS_MAX caps that width at runtime so both arms come out of ONE binary.
+// =1 declines every packed width and is exactly the per-token behaviour this replaces.
+static inline int muse_gu_rows_max() {
+    static int v = -1;
+    if (v < 0) {
+        const char* e = getenv("SPARKINFER_MUSE_GU_ROWS_MAX");
+        v = e ? atoi(e) : kMuseGuRowsMax;
+        if (v < 1) v = 1;
+        if (v > kMuseGuRowsMax) v = kMuseGuRowsMax;
+    }
+    return v;
+}
+
+// M token rows against ONE set of gate/up rows, keeping the contextual-sparsity mask.
+//
+// gate_up_mmvq2_qwen_sparse_kernel above is launched over num_tokens*TOPK*F blocks with the token
+// index in blockIdx, and the grid is token-major -- block ts*F+f -- so a packed step walks the
+// whole 149 MB of one layer's gate/up for row 0 before row 1 starts, and nothing is left in L2 to
+// reuse. Both matrices were therefore pulled from DRAM once PER ROW. Muse Glimmer keeps ten
+// calibration-selected layers on native Q4_K (the other forty-two requantise to Q3_A, which has
+// its own row-batched arm), and on a c16 step those ten layers cost 13.1 ms of a 58.2 ms step --
+// 22.6% -- scaling as 0.082 ms per row per layer off a ~zero intercept, i.e. pure per-row work.
+//
+// Here the token index moves into the kernel and kbx stays the outer loop, so each super-block is
+// decoded once and dotted against all M rows while it is still in registers.
+//
+// The sparsity mask is preserved exactly, not dropped: a packed row must decode to the same token
+// it would have alone. Phase 1 reduces the gate projection for all M rows, each row's mask is
+// taken from its OWN silu, and phase 2 skips the up dot product for every row that is gated off.
+// What changes is only that the up super-blocks are fetched when ANY row wants them rather than
+// per row -- the arithmetic skip survives, the redundant fetch does not.
+//
+// Per-row arithmetic and reduction order are untouched: same kbx traversal, same kqs, the same
+// si_vec_dot_q4_K expressions via si_q4k_decode_w/si_vec_dot_q4_K_pre, the same ordered warp
+// shuffle followed by the same ascending sum over the four warp partials. Every row's output is
+// therefore bit-identical to the per-token launch it replaces.
+template <int H, int F, int TOPK, int M>
+__global__ void gate_up_mmvq2_qwen_sparse_rows_kernel(
+    const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
+    const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
+    float* __restrict__ h_scratch, float tau, int pdl
+) {
+    constexpr int NW = 4, NB = H >> 8;
+    const int f = blockIdx.x;
+    const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+    const int kbx0 = tid >> 4, kqs = 2 * (tid & 15);
+    __shared__ float sred[NW][M];
+    __shared__ float sg[M];        // silu(gate) per row; only thread 0 reads it back
+    float t[M];
+#pragma unroll
+    for (int r = 0; r < M; ++r) t[r] = 0.f;
+    // Every row on the same expert -- always, for the dense FFN this arm serves -- lets the Q4_K
+    // weight half be decoded once per super-block and shared. Otherwise each row decodes its own,
+    // which is what a top_k==1 MoE with genuinely different experts needs; same results either
+    // way, since si_vec_dot_q4_K_pre(si_q4k_decode_w(b, iqs), a, iqs) == si_vec_dot_q4_K(b, a, iqs).
+    const int e0 = expert_ids[0];
+    bool uniform = true;
+#pragma unroll
+    for (int r = 1; r < M; ++r) uniform &= (expert_ids[r * TOPK] == e0);
+    const si_block_q4_K* g0 = (const si_block_q4_K*)(gate_q + ((size_t)e0 * F + f) * NB * 144);
+    const si_block_q4_K* u0 = (const si_block_q4_K*)(up_q   + ((size_t)e0 * F + f) * NB * 144);
+
+    // Phase 1: the gate projection for every row -> each row's own silu decides its own mask.
+    if (uniform) {
+        for (int kbx = kbx0; kbx < NB; kbx += 8) {
+            const si_q4k_wdec gw = si_q4k_decode_w(g0 + kbx, kqs);
+#pragma unroll
+            for (int r = 0; r < M; ++r)
+                t[r] += si_vec_dot_q4_K_pre(gw, vy + (size_t)r * (H >> 5) + (size_t)kbx * 8, kqs);
+        }
+    } else {
+        for (int kbx = kbx0; kbx < NB; kbx += 8) {
+#pragma unroll
+            for (int r = 0; r < M; ++r) {
+                const si_block_q4_K* g = (const si_block_q4_K*)(
+                    gate_q + ((size_t)expert_ids[r * TOPK] * F + f) * NB * 144);
+                t[r] += si_vec_dot_q4_K(g + kbx, vy + (size_t)r * (H >> 5) + (size_t)kbx * 8, kqs);
+            }
+        }
+    }
+#pragma unroll
+    for (int r = 0; r < M; ++r) {
+#pragma unroll
+        for (int m = 16; m > 0; m >>= 1) t[r] += __shfl_xor_sync(0xffffffff, t[r], m);
+    }
+    if (lane == 0) {
+#pragma unroll
+        for (int r = 0; r < M; ++r) sred[warp][r] = t[r];
+    }
+    __syncthreads();
+    // g[] and the mask are uniform across the CTA -- every thread sums the same four partials in
+    // the same order -- so the phase-2 branch and its barriers are CTA-uniform.
+    unsigned act = 0u;
+#pragma unroll
+    for (int r = 0; r < M; ++r) {
+        float s = 0.f;
+#pragma unroll
+        for (int w = 0; w < NW; ++w) s += sred[w][r];
+        const float gr = q4kf_silu(s);
+        if (tid == 0) sg[r] = gr;
+        if (fabsf(gr) >= tau) act |= (1u << r);
+    }
+
+    // Phase 2: the up projection, fetched once for the whole batch, dotted only for active rows.
+    if (act) {
+#pragma unroll
+        for (int r = 0; r < M; ++r) t[r] = 0.f;
+        if (uniform) {
+            for (int kbx = kbx0; kbx < NB; kbx += 8) {
+                const si_q4k_wdec uw = si_q4k_decode_w(u0 + kbx, kqs);
+#pragma unroll
+                for (int r = 0; r < M; ++r)
+                    if (act & (1u << r))
+                        t[r] += si_vec_dot_q4_K_pre(uw, vy + (size_t)r * (H >> 5) + (size_t)kbx * 8, kqs);
+            }
+        } else {
+            for (int kbx = kbx0; kbx < NB; kbx += 8) {
+#pragma unroll
+                for (int r = 0; r < M; ++r) {
+                    if (!(act & (1u << r))) continue;
+                    const si_block_q4_K* u = (const si_block_q4_K*)(
+                        up_q + ((size_t)expert_ids[r * TOPK] * F + f) * NB * 144);
+                    t[r] += si_vec_dot_q4_K(u + kbx, vy + (size_t)r * (H >> 5) + (size_t)kbx * 8, kqs);
+                }
+            }
+        }
+#pragma unroll
+        for (int r = 0; r < M; ++r) {
+            if (!(act & (1u << r))) continue;   // CTA-uniform, so the shuffle stays convergent
+#pragma unroll
+            for (int m = 16; m > 0; m >>= 1) t[r] += __shfl_xor_sync(0xffffffff, t[r], m);
+        }
+        __syncthreads();          // sred is reused; every thread has read phase 1's partials
+        if (lane == 0) {
+#pragma unroll
+            for (int r = 0; r < M; ++r) sred[warp][r] = t[r];
+        }
+        __syncthreads();
+    }
+    if (tid == 0) {
+#pragma unroll
+        for (int r = 0; r < M; ++r) {
+            float hval = 0.f;
+            if (act & (1u << r)) {
+                float s = 0.f;
+#pragma unroll
+                for (int w = 0; w < NW; ++w) s += sred[w][r];
+                hval = sg[r] * s;
+            }
+            h_scratch[(size_t)r * F + f] = hval;
+        }
+    }
+    if (pdl) si_pdl_lc();
+}
+
 void launch_moe_expert_ffn_q4k(
     const void* input, const void* gate_q, const void* up_q, const void* down_q,
     int gate_type, int up_type, int down_type,
@@ -2249,7 +2409,32 @@ void launch_moe_expert_ffn_q4k(
         // on a 5090 at 128 decode, a pack2 arm for this shape gives back about four fifths of
         // what this arm wins, so it is deliberately absent rather than merely unwritten.
         else if (gu_spec && hidden == 6656 && ffn == 19968 && top_k == 1) {
-            if (g_mg_sparse_tau > 0.f)   // Muse Glimmer contextual-sparsity FFN (skip gated-off up reads)
+            // A packed continuous-batch step takes the row-batched sparse kernel, which walks F
+            // once instead of num_tokens*F and so reads gate/up from DRAM once for the whole batch
+            // instead of once per row. Every row keeps its own mask, bit-for-bit; see the kernel.
+            // SPARKINFER_MUSE_GU_SPARSE_ROWS=0 restores the per-token grid, so both arms of an A/B
+            // come out of ONE binary.
+            static int gu_sparse_rows = -1;
+            if (gu_sparse_rows < 0) { const char* e = getenv("SPARKINFER_MUSE_GU_SPARSE_ROWS"); gu_sparse_rows = (e && e[0] == '0') ? 0 : 1; }
+#define SI_GU_SPARSE_ROWS_MG(MM) launch_pdl_kernel(gu_pdl, dim3(ffn), dim3(4 * 32), 0, stream, \
+                gate_up_mmvq2_qwen_sparse_rows_kernel<6656, 19968, 1, MM>, \
+                q, reinterpret_cast<const unsigned char*>(gate_q), \
+                reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, \
+                g_mg_sparse_tau, gu_pdl)
+            if (g_mg_sparse_tau > 0.f && gu_sparse_rows && num_tokens >= 2
+                && num_tokens <= muse_gu_rows_max()) {
+                switch (num_tokens) {
+                    case 2:  SI_GU_SPARSE_ROWS_MG(2);  break;  case 3:  SI_GU_SPARSE_ROWS_MG(3);  break;
+                    case 4:  SI_GU_SPARSE_ROWS_MG(4);  break;  case 5:  SI_GU_SPARSE_ROWS_MG(5);  break;
+                    case 6:  SI_GU_SPARSE_ROWS_MG(6);  break;  case 7:  SI_GU_SPARSE_ROWS_MG(7);  break;
+                    case 8:  SI_GU_SPARSE_ROWS_MG(8);  break;  case 9:  SI_GU_SPARSE_ROWS_MG(9);  break;
+                    case 10: SI_GU_SPARSE_ROWS_MG(10); break;  case 11: SI_GU_SPARSE_ROWS_MG(11); break;
+                    case 12: SI_GU_SPARSE_ROWS_MG(12); break;  case 13: SI_GU_SPARSE_ROWS_MG(13); break;
+                    case 14: SI_GU_SPARSE_ROWS_MG(14); break;  case 15: SI_GU_SPARSE_ROWS_MG(15); break;
+                    default: SI_GU_SPARSE_ROWS_MG(16); break;
+                }
+            }
+            else if (g_mg_sparse_tau > 0.f)   // Muse Glimmer contextual-sparsity FFN (skip gated-off up reads)
                 launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream,
                     gate_up_mmvq2_qwen_sparse_kernel<6656, 19968, 1>,
                     q, reinterpret_cast<const unsigned char*>(gate_q),
@@ -2259,6 +2444,7 @@ void launch_moe_expert_ffn_q4k(
                     gate_up_mmvq2_qwen_kernel<6656, 19968, 1>,
                     q, reinterpret_cast<const unsigned char*>(gate_q),
                     reinterpret_cast<const unsigned char*>(up_q), expert_ids, h_scratch, gu_pdl);
+#undef SI_GU_SPARSE_ROWS_MG
         }
         // Qwen3.8-27B dense hybrid (hidden 5120, ffn 17408). Same recipe as Muse's 6656x19968
         // arm: F is already large enough that pack2 coarsens scheduling. Compile-time H/F

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -24,3 +24,12 @@ target_link_libraries(down_rows_chunk_gpu_test PRIVATE sparkinfer_kernels CUDA::
 set_target_properties(down_rows_chunk_gpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME down_rows_chunk_gpu_test COMMAND down_rows_chunk_gpu_test)
 set_tests_properties(down_rows_chunk_gpu_test PROPERTIES SKIP_RETURN_CODE 77)
+
+# The row-batched contextual-sparsity gate/up against the per-token kernel it replaces: same rows,
+# same bits, at every batch width the dispatch instantiates. Needs a GPU and ~350 MB of it for Muse
+# Glimmer's real 6656x19968 FFN, which is the shape the arm is gated to.
+add_executable(sparse_gate_up_rows_gpu_test sparse_gate_up_rows_gpu_test.cpp)
+target_link_libraries(sparse_gate_up_rows_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
+set_target_properties(sparse_gate_up_rows_gpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME sparse_gate_up_rows_gpu_test COMMAND sparse_gate_up_rows_gpu_test)
+set_tests_properties(sparse_gate_up_rows_gpu_test PROPERTIES SKIP_RETURN_CODE 77)

--- a/kernels/tests/sparse_gate_up_rows_gpu_test.cpp
+++ b/kernels/tests/sparse_gate_up_rows_gpu_test.cpp
@@ -1,0 +1,113 @@
+// The row-batched contextual-sparsity gate/up must be BIT-IDENTICAL, per row, to the per-token
+// kernel it replaces. That is the whole basis on which a packed continuous-batch step is allowed
+// to share one weight read across its rows: the batch changes how the weights are fetched, never
+// what any row computes -- and in particular never which neurons a row gates off.
+//
+// Muse Glimmer's dense FFN keeps ten of its 52 layers on native Q4_K (the Q3_A requantizer takes
+// the other 42), and those ten are the ones that reach this arm.
+//
+// Sparsity is left ON -- the default, and what production decodes with -- because the per-row mask
+// is exactly what is being asserted. g_mg_sparse_tau is read from the environment once and cached,
+// so it cannot be flipped inside one process.
+#include "sparkinfer/kernels/moe.h"
+#include "sparkinfer/kernels/qtype.h"
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+namespace {
+
+constexpr int H = 6656, F = 19968;     // Muse Glimmer's dense FFN
+constexpr int MAXROWS = 16;
+
+// Deterministic byte fill. Any byte pattern is a structurally valid Q4_K super-block -- the
+// formats have no reserved encodings -- so random bytes exercise the decode paths without needing
+// a quantizer here.
+unsigned int rng = 0x1234567u;
+unsigned char next_byte() {
+    rng = rng * 1664525u + 1013904223u;
+    return (unsigned char)(rng >> 24);
+}
+
+bool fill_dev(void* p, size_t bytes) {
+    std::vector<unsigned char> h(bytes);
+    for (size_t i = 0; i < bytes; ++i) h[i] = next_byte();
+    return cudaMemcpy(p, h.data(), bytes, cudaMemcpyHostToDevice) == cudaSuccess;
+}
+
+// One FFN call, writing h_scratch for `rows` tokens.
+bool run(const void* in, const void* g, const void* u, const void* d, int qt,
+         const int* ids, const float* wts, void* out, float* hs, float* os, int rows) {
+    sparkinfer::kernels::launch_moe_expert_ffn_q4k(in, g, u, d, qt, qt, 12, ids, wts, out,
+                                                   hs, os, rows, 1, H, F);
+    return cudaDeviceSynchronize() == cudaSuccess;
+}
+
+bool check(int qt, const char* label) {
+    const size_t gu_bytes = (size_t)F * (H / 256) * 144;   // Q4_K super-blocks
+    const size_t dn_bytes = (size_t)H * (F / 256) * 144;          // down stays Q4_K
+    void *g = nullptr, *u = nullptr, *d = nullptr, *in = nullptr, *out = nullptr;
+    float *hs = nullptr, *os = nullptr;
+    int* ids = nullptr; float* wts = nullptr;
+    bool ok = cudaMalloc(&g, gu_bytes) == cudaSuccess &&
+              cudaMalloc(&u, gu_bytes) == cudaSuccess &&
+              cudaMalloc(&d, dn_bytes) == cudaSuccess &&
+              cudaMalloc(&in, (size_t)MAXROWS * H * sizeof(__nv_bfloat16)) == cudaSuccess &&
+              cudaMalloc(&out, (size_t)MAXROWS * H * sizeof(__nv_bfloat16)) == cudaSuccess &&
+              cudaMalloc(&hs, (size_t)MAXROWS * F * sizeof(float)) == cudaSuccess &&
+              cudaMalloc(&os, (size_t)MAXROWS * F * sizeof(float)) == cudaSuccess &&
+              cudaMalloc(&ids, MAXROWS * sizeof(int)) == cudaSuccess &&
+              cudaMalloc(&wts, MAXROWS * sizeof(float)) == cudaSuccess;
+    if (ok) ok = fill_dev(g, gu_bytes) && fill_dev(u, gu_bytes) && fill_dev(d, dn_bytes) &&
+                 fill_dev(in, (size_t)MAXROWS * H * sizeof(__nv_bfloat16));
+    if (ok) {
+        std::vector<int> hid(MAXROWS, 0);
+        std::vector<float> hw(MAXROWS, 1.f);
+        ok = cudaMemcpy(ids, hid.data(), MAXROWS * sizeof(int), cudaMemcpyHostToDevice) == cudaSuccess &&
+             cudaMemcpy(wts, hw.data(), MAXROWS * sizeof(float), cudaMemcpyHostToDevice) == cudaSuccess;
+    }
+    // Per-token reference: one call per row, each reading that row's slice of `in`.
+    std::vector<float> ref((size_t)MAXROWS * F), got((size_t)MAXROWS * F);
+    for (int r = 0; ok && r < MAXROWS; ++r) {
+        ok = run((const __nv_bfloat16*)in + (size_t)r * H, g, u, d, qt, ids, wts, out, hs, os, 1) &&
+             cudaMemcpy(ref.data() + (size_t)r * F, hs, (size_t)F * sizeof(float),
+                        cudaMemcpyDeviceToHost) == cudaSuccess;
+    }
+    // Every batch width the dispatch instantiates, against the same reference.
+    for (int m = 2; ok && m <= MAXROWS; ++m) {
+        ok = run(in, g, u, d, qt, ids, wts, out, hs, os, m) &&
+             cudaMemcpy(got.data(), hs, (size_t)m * F * sizeof(float),
+                        cudaMemcpyDeviceToHost) == cudaSuccess;
+        if (!ok) break;
+        for (int r = 0; r < m; ++r) {
+            if (std::memcmp(ref.data() + (size_t)r * F, got.data() + (size_t)r * F,
+                            (size_t)F * sizeof(float)) != 0) {
+                std::printf("[FAIL] %s m=%d row=%d differs from the per-token kernel\n",
+                            label, m, r);
+                ok = false;
+                break;
+            }
+        }
+    }
+    if (ok) std::printf("[PASS] %s: sparse rows kernel bit-identical at m=2..%d\n", label, MAXROWS);
+    cudaFree(g); cudaFree(u); cudaFree(d); cudaFree(in); cudaFree(out);
+    cudaFree(hs); cudaFree(os); cudaFree(ids); cudaFree(wts);
+    return ok;
+}
+
+}  // namespace
+
+int main() {
+    int n = 0;
+    if (cudaGetDeviceCount(&n) != cudaSuccess || n == 0) {
+        std::printf("[SKIP] no GPU\n");
+        return 77;
+    }
+    const bool ok = check(12, "Q4_K sparse gate/up");   // 12 = ggml Q4_K
+    if (!ok) return 1;
+    std::printf("[PASS] sparse_gate_up_rows_gpu_test\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary

Muse Glimmer keeps ten calibration-selected layers on native Q4_K and runs their FFN through the
contextual-sparsity gate/up kernel. That kernel is launched over `num_tokens * top_k * ffn` blocks
with the token index in `blockIdx`, and the grid is **token-major**, so a packed continuous-batch
step walks the whole of one layer's gate and up for row 0 before row 1 starts and nothing is left in
L2 to reuse. Both matrices were pulled from DRAM **once per row**.

This moves the token index into the kernel and leaves `kbx` as the outer loop, so each Q4_K
super-block is decoded once and dotted against every row while it is still in registers.

The sparsity mask is kept exactly, not dropped. Phase 1 reduces the gate projection for all M rows,
each row's mask is taken from its **own** `silu`, and phase 2 skips the up dot product for every row
that is gated off. What changes is only that an up super-block is *fetched* when any row wants it
rather than once per row — the arithmetic skip survives, the redundant fetch does not.

It lands on the two widths nothing else reaches. #1032 routes the packed gate/up through a
block-scaled NVFP4 GEMM from six rows up, so at c8/c16/c32 this kernel is not launched at all;
**c2 and c4 are the widths that still run the GEMV, and they are the two weakest axes on the
board.** Measured on top of #1036.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

The arm is reached only through the dense top-1 FFN at `hidden==6656 && ffn==19968 && top_k==1`,
with contextual sparsity on, at `num_tokens >= 2`. Single-request decode and prefill enter neither.

**Decode tok/s** (aggregate over 4 concurrent requests, `qwen3_gguf_cb_bench <gguf> 4 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 181.4 |
| after (this PR) | 199.0 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries**, so it cannot measure
a branch; these come from `qwen3_gguf_cb_bench` built from this tree — the same binary and invocation
the `muse-cb-decode@cN` axes score.

### Scored axes — one binary, `SPARKINFER_MUSE_GU_SPARSE_ROWS` off/on

| scored axis | before | after | |
|---|--:|--:|--:|
| `muse-cb-decode@c2` | 141.2 / 140.0 | 147.7 / 147.7 | **+5.0%** |
| `muse-cb-decode@c4` | 182.7 / 180.1 | 199.2 / 198.7 | **+9.7%** |
| `muse-cb-decode@c8` | 321.5 / 319.4 | 320.8 / 319.9 | -0.0% |
| `muse-cb-decode@c16` | 407.3 / 404.6 | 405.6 / 404.7 | -0.2% |
| `muse-cb-decode@c32` | 387.5 / 385.6 | 384.8 / 432.3 | flat, see below |

Two replicates each, interleaved `base, rows, rows, base` so the two arms sit at the same mean
position within the run and this box's within-replicate drift cancels rather than accruing to one
side.

Every point completed its full token budget — `decode_tokens` 520 / 1032 / 2056 / 4104 / 8200
against the 512 / 1024 / 2048 / 4096 / 8192 expected, on all four arms — so none of these is a
dropped-request reading.

### The other three concurrency axes

c8, c16 and c32 are flat because this kernel is **not launched** there: #1032's NVFP4 GEMM takes
gate/up from six rows up, so the arm only runs while the batch is 2..5 wide.

`muse-cb-decode@c32` is bimodal on this box independently of this PR — readings cluster at ~385 and
~433, and the four A/B points came out 387.5 / 385.6 (base) and 384.8 / 432.3 (rows). Mode-matched
that is **-0.5%**, not the +5.7% the raw mean would suggest, and I am claiming nothing on that axis.
A kernel that is never launched at 32 rows cannot be what moved it.

### Correctness

Bit-identical per row: same `kbx` traversal, same `kqs`, the same `si_vec_dot_q4_K` expressions via
`si_q4k_decode_w` / `si_vec_dot_q4_K_pre`, the same ordered warp shuffle followed by the same
ascending sum over the four warp partials. Each row's mask is still taken from its own `silu` against
the same `tau`, and a gated-off row still contributes no up dot product.

`kernels/tests/sparse_gate_up_rows_gpu_test.cpp` runs Muse Glimmer's real `6656x19968` FFN one row at
a time to build a per-token reference, then `memcmp`s every batch width the dispatch instantiates
(m=2..16) against it — exact bytes, with contextual sparsity left on, which is what makes the shared
weight read legitimate. All ctest targets pass.

The 12 single-stream axes are structurally unreachable — the arm needs `num_tokens >= 2` and the
packed continuous-batch forward, and single-request decode and prefill are neither. An off/on of
this knob over all twelve, same binary, measures them at **0.9984-1.0032x** against a 0.98 floor:

| ctx | decode off -> on | | prefill off -> on | |
|---|--:|--:|--:|--:|
| 128 | 108.80 -> 108.83 | 1.0003 | 9811.3 -> 9821.7 | 1.0011 |
| 512 | 108.10 -> 108.02 | 0.9993 | 14902.6 -> 14950.7 | 1.0032 |
| 4096 | 105.22 -> 105.21 | 0.9999 | 14137.4 -> 14119.4 | 0.9987 |
| 16384 | 104.19 -> 104.18 | 0.9999 | 13349.3 -> 13358.2 | 1.0007 |
| 32768 | 102.75 -> 102.71 | 0.9996 | 12199.7 -> 12209.5 | 1.0008 |
| 65536 | 100.95 -> 100.78 | 0.9984 | 10504.2 -> 10510.5 | 1.0006 |


`SPARKINFER_MUSE_GU_SPARSE_ROWS=0` restores the per-token grid, so both arms of the A/B above come
out of ONE binary.
