### PR TITLE
perf(muse): run the wide attention projections on the int8 tensor cores (1.08x concurrent decode @c32)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -3813,6 +3813,158 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
     else if (K == 5120) si_mmvq_q4k_kfixed_kernel<float, 20><<<N, 4 * 32, 0, stream>>>(q, w, y, N);
     else                si_mmvq_q4k_kernel<float><<<N, 4 * 32, 0, stream>>>(q, w, y, N, K);
 }
+// ---- Q4_K attention projections on the int8 tensor cores ----
+// The rows MMVQ below redoes its dot product once per row, so a 32-row packed batch is chunked into
+// four 8-row launches and re-reads the weights four times. This dequantises inside the mainloop
+// instead: m16n8k32 spans exactly 32 K, which is exactly one Q4_K scale group, so the group scales
+// fold in per-mma with the accumulator still in registers. Same arithmetic as si_vec_dot_q4_K.
+// Not bit-identical to the MMVQ (different reduction order), so it is gated to wide batches.
+namespace {
+constexpr int SI_AM_BN = 32, SI_AM_MMAX = 32, SI_AM_NW = 4;
+
+__device__ __forceinline__ int si_am_swz(int k, int row) {
+    return (((k >> 4) ^ (row & 3)) << 4) | (k & 15);
+}
+__device__ __forceinline__ void si_am_ldm(unsigned& r0, unsigned& r1, unsigned& r2, unsigned& r3,
+                                          const signed char* p) {
+    const unsigned a = (unsigned)__cvta_generic_to_shared(p);
+    asm volatile("ldmatrix.sync.aligned.m8n8.x4.shared.b16 {%0,%1,%2,%3}, [%4];\n"
+                 : "=r"(r0), "=r"(r1), "=r"(r2), "=r"(r3) : "r"(a));
+}
+__device__ __forceinline__ void si_am_scales(const unsigned char* sc12, int j,
+                                             unsigned char& a0, unsigned char& a1,
+                                             unsigned char& b0, unsigned char& b1) {
+    const unsigned short* s = reinterpret_cast<const unsigned short*>(sc12);
+    unsigned short aux[2];
+    if (j < 2) { aux[0] = s[j] & 0x3f3f; aux[1] = s[j + 2] & 0x3f3f; }
+    else       { aux[0] = ((s[j + 2] >> 0) & 0x0f0f) | ((s[j - 2] & 0xc0c0) >> 2);
+                 aux[1] = ((s[j + 2] >> 4) & 0x0f0f) | ((s[j]     & 0xc0c0) >> 2); }
+    const unsigned char* u = reinterpret_cast<const unsigned char*>(aux);
+    a0 = u[0]; a1 = u[1]; b0 = u[2]; b1 = u[3];
+}
+}  // namespace
+
+__global__ __launch_bounds__(SI_AM_NW * 32, 8)
+void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned char* __restrict__ W,
+                            __nv_bfloat16* __restrict__ y, int M, int N, int K) {
+    const int nblk = K >> 8;
+    const int n0 = blockIdx.x * SI_AM_BN;
+    const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
+    const int grp = lane >> 2, tig = lane & 3, sub = lane >> 3, lrow = lane & 7;
+
+    __shared__ signed char As[SI_AM_MMAX][256];
+    __shared__ signed char Bs[SI_AM_BN][256];
+    __shared__ unsigned char Ssc[SI_AM_BN][8], Smn[SI_AM_BN][8];
+    __shared__ float2 Wdm[SI_AM_BN];
+    __shared__ float Ad[SI_AM_MMAX][8], Asum[SI_AM_MMAX][8];
+
+    float facc[2][4];
+    #pragma unroll
+    for (int i = 0; i < 2; i++)
+        #pragma unroll
+        for (int e = 0; e < 4; e++) facc[i][e] = 0.f;
+
+    for (int sb = 0; sb < nblk; sb++) {
+        for (int u = tid; u < SI_AM_BN * 16; u += SI_AM_NW * 32) {
+            const int r = u >> 4, c = u & 15;
+            const int gn = n0 + r;
+            const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
+                W + (size_t)(gn < N ? gn : N - 1) * (size_t)nblk * 144) + sb;
+            const int j = c >> 2, sc_ = c & 3;
+            const bool hi = (sc_ >> 1) & 1;
+            const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + (sc_ & 1) * 16);
+            signed char out[16];
+            #pragma unroll
+            for (int v = 0; v < 4; v++) {
+                const unsigned x = src[v];
+                #pragma unroll
+                for (int t = 0; t < 4; t++) {
+                    const unsigned char qq = (unsigned char)((x >> (8 * t)) & 0xFF);
+                    out[4 * v + t] = (signed char)(hi ? (qq >> 4) : (qq & 0xF));
+                }
+            }
+            const int kb = 64 * j + (sc_ >> 1) * 32 + (sc_ & 1) * 16;
+            *reinterpret_cast<uint4*>(&Bs[r][si_am_swz(kb, r)]) = *reinterpret_cast<const uint4*>(out);
+            if (c == 0) {
+                Wdm[r] = __half22float2(b->dm);
+                #pragma unroll
+                for (int jj = 0; jj < 4; jj++) {
+                    unsigned char x0, x1, y0, y1;
+                    si_am_scales(b->scales, jj, x0, x1, y0, y1);
+                    Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
+                    Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                }
+            }
+        }
+        // q8_1's qs is at offset 4 of a 36B struct: 4B-aligned, never 16B. Read four uints.
+        for (int u = tid; u < M * 16; u += SI_AM_NW * 32) {
+            const int r = u >> 4, c = u & 15;
+            const si_block_q8_1* a = q + (size_t)r * (K >> 5) + sb * 8 + (c >> 1);
+            const unsigned* src = reinterpret_cast<const unsigned*>(a->qs + (c & 1) * 16);
+            uint4 v; v.x = src[0]; v.y = src[1]; v.z = src[2]; v.w = src[3];
+            *reinterpret_cast<uint4*>(&As[r][si_am_swz(16 * c, r)]) = v;
+            if ((c & 1) == 0) {
+                const float2 ds = __half22float2(a->ds);
+                Ad[r][c >> 1] = ds.x; Asum[r][c >> 1] = ds.y;
+            }
+        }
+        __syncthreads();
+
+        #pragma unroll 1
+        for (int g = 0; g < 8; g++) {
+            const int kk = g * 32;
+            unsigned af[2][4], bf0, bf1, bx, by;
+            #pragma unroll
+            for (int i = 0; i < 2; i++) {
+                const int row = i * 16 + (sub & 1) * 8 + lrow;
+                si_am_ldm(af[i][0], af[i][1], af[i][2], af[i][3],
+                          &As[row < SI_AM_MMAX ? row : 0][si_am_swz(kk + (sub >> 1) * 16, row)]);
+            }
+            const int col = warp * 8 + lrow;
+            si_am_ldm(bf0, bf1, bx, by, &Bs[col][si_am_swz(kk + (sub & 1) * 16, col)]);
+            (void)bx; (void)by;
+            #pragma unroll
+            for (int i = 0; i < 2; i++) {
+                int acc[4] = {0, 0, 0, 0};
+                asm volatile(
+                    "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
+                    "{%0,%1,%2,%3}, {%4,%5,%6,%7}, {%8,%9}, {%0,%1,%2,%3};\n"
+                    : "+r"(acc[0]), "+r"(acc[1]), "+r"(acc[2]), "+r"(acc[3])
+                    : "r"(af[i][0]), "r"(af[i][1]), "r"(af[i][2]), "r"(af[i][3]),
+                      "r"(bf0), "r"(bf1));
+                #pragma unroll
+                for (int e = 0; e < 4; e++) {
+                    const int lm = i * 16 + grp + (e >> 1) * 8;
+                    const int ln = warp * 8 + tig * 2 + (e & 1);
+                    if (lm >= M) continue;
+                    const float2 dm = Wdm[ln];
+                    facc[i][e] += dm.x * (float)Ssc[ln][g] * Ad[lm][g] * (float)acc[e]
+                                - dm.y * (float)Smn[ln][g] * Asum[lm][g];
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+    #pragma unroll
+    for (int i = 0; i < 2; i++)
+        #pragma unroll
+        for (int e = 0; e < 4; e++) {
+            const int lm = i * 16 + grp + (e >> 1) * 8;
+            const int gn = n0 + warp * 8 + tig * 2 + (e & 1);
+            if (lm < M && gn < N) y[(size_t)lm * N + gn] = __float2bfloat16(facc[i][e]);
+        }
+}
+
+static inline bool launch_mmvq_q4k_mma_rows(const void* q81, const void* W, void* y,
+                                            int M, int N, int K, cudaStream_t stream) {
+    if (M < 2 || M > SI_AM_MMAX || (K & 255) || (N % SI_AM_BN)) return false;
+    si_mmvq_q4k_mma_kernel<<<dim3(N / SI_AM_BN), dim3(SI_AM_NW * 32), 0, stream>>>(
+        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
+        reinterpret_cast<__nv_bfloat16*>(y), M, N, K);
+    return true;
+}
+
 bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
     // K is templated (KB = K/256 bounds the per-thread accumulators), so only instantiated widths
@@ -3896,6 +4048,22 @@ bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
     // Chunk instead, exactly as launch_mmvq_rows_f32 already does: MMAX bounds the scratch and
     // the number of predicated row bodies, not the per-row dot or its reduction order, so a row
     // computes the same bits whichever chunk carries it.
+    // A wide batch goes to the tensor cores instead of being chunked: chunking still re-reads the
+    // weights once per chunk and still pays the per-row dot, while the mma kernel reads them once
+    // for the whole batch. It loses at narrow widths, so 24 is a floor and not a preference.
+    // SPARKINFER_MMVQ_MMA=0 keeps every width on the chunked MMVQ.
+    static int mmvq_mma = -1;
+    if (mmvq_mma < 0) { const char* e = getenv("SPARKINFER_MMVQ_MMA"); mmvq_mma = (e && e[0] == '0') ? 0 : 1; }
+    // N is the block count: at N=32 per block, k and v (N=256 on this checkpoint) would launch
+    // eight blocks onto 170 SMs and the per-launch cost swamps the saved weight reads. Only the
+    // wide projections -- q and the attention output -- have enough work to fill the device.
+    static int mmvq_mma_minn = -1;
+    if (mmvq_mma_minn < 0) {
+        const char* e = getenv("SPARKINFER_MMVQ_MMA_MINN");
+        mmvq_mma_minn = e ? atoi(e) : 2048;
+    }
+    if (mmvq_mma && M >= 24 && qtype == 12 && N >= mmvq_mma_minn &&
+        launch_mmvq_q4k_mma_rows(q81, W, y, M, N, K, stream)) return true;
     if (M > 8) {
         for (int r0 = 0; r0 < M; r0 += 8) {
             const int m = (M - r0) < 8 ? (M - r0) : 8;

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -33,3 +33,7 @@ target_link_libraries(sparse_gate_up_rows_gpu_test PRIVATE sparkinfer_kernels CU
 set_target_properties(sparse_gate_up_rows_gpu_test PROPERTIES CXX_STANDARD 17)
 add_test(NAME sparse_gate_up_rows_gpu_test COMMAND sparse_gate_up_rows_gpu_test)
 set_tests_properties(sparse_gate_up_rows_gpu_test PROPERTIES SKIP_RETURN_CODE 77)
+# The tensor-core attention projection against the MMVQ, dumped per process for a cross-run diff.
+add_executable(mmvq_mma_accuracy_gpu_test mmvq_mma_accuracy_gpu_test.cpp)
+target_link_libraries(mmvq_mma_accuracy_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
+set_target_properties(mmvq_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)

--- a/kernels/tests/mmvq_mma_accuracy_gpu_test.cpp
+++ b/kernels/tests/mmvq_mma_accuracy_gpu_test.cpp
@@ -1,0 +1,92 @@
+// Dumps a Q4_K attention projection at Muse Glimmer's real shapes so the tensor-core path and the
+// per-row MMVQ can be diffed across processes:
+//
+//     SPARKINFER_MMVQ_MMA=0 MMVQ_MMA_DUMP=/tmp/mmvq.bin ./mmvq_mma_accuracy_gpu_test 32 6656 4096
+//     SPARKINFER_MMVQ_MMA=1 MMVQ_MMA_DUMP=/tmp/mma.bin  ./mmvq_mma_accuracy_gpu_test 32 6656 4096
+//
+// Two processes, not two calls: launch_mmvq_rows caches its env read in a function-local static.
+//
+// Deliberately NOT a bit-identity test. The mma path reduces over K in a different order (one
+// m16n8k32 per 32-value scale group, accumulated in float) than the per-row dp4a MMVQ, so they
+// cannot agree bit-for-bit. What must hold is that the gap is rounding rather than a different
+// answer. Unlike the FFN down projection, these outputs feed the attention computation rather than
+// the residual, so the agreement is worth measuring here in its own right.
+#include "sparkinfer/kernels/gemm.h"
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <vector>
+
+namespace {
+struct blk_q8_1 { __half2 ds; signed char qs[32]; };
+struct blk_q4_K { __half2 dm; unsigned char scales[12]; unsigned char qs[128]; };
+uint32_t lcg(uint32_t& s) { s = s * 1664525u + 1013904223u; return s; }
+template <class T> T* dev(size_t n, const void* host = nullptr) {
+    void* p = nullptr;
+    if (cudaMalloc(&p, n * sizeof(T)) != cudaSuccess) return nullptr;
+    if (host) cudaMemcpy(p, host, n * sizeof(T), cudaMemcpyHostToDevice);
+    else      cudaMemset(p, 0, n * sizeof(T));
+    return static_cast<T*>(p);
+}
+}  // namespace
+
+int main(int argc, char** argv) {
+    int nd = 0;
+    if (cudaGetDeviceCount(&nd) != cudaSuccess || nd == 0) return 77;
+    const int M = argc > 1 ? atoi(argv[1]) : 32;     // packed batch width
+    const int N = argc > 2 ? atoi(argv[2]) : 6656;   // output dim (o-proj)
+    const int K = argc > 3 ? atoi(argv[3]) : 4096;   // input dim
+    const int nblk = K / 256, nq8 = K / 32;
+
+    std::vector<blk_q4_K> hW((size_t)N * nblk);
+    uint32_t seed = 0x5EEDu;                          // fixed: both processes build the same inputs
+    for (auto& b : hW) {
+        b.dm = __floats2half2_rn(0.008f + (lcg(seed) % 64) * 1e-4f,
+                                 0.004f + (lcg(seed) % 32) * 1e-4f);
+        for (int i = 0; i < 12; i++) b.scales[i] = (unsigned char)(lcg(seed) & 0x3f);
+        for (int i = 0; i < 128; i++) b.qs[i] = (unsigned char)(lcg(seed) & 0xff);
+    }
+    std::vector<blk_q8_1> hA((size_t)M * nq8);
+    for (auto& b : hA) {
+        const float d = 0.002f + (lcg(seed) % 31) * 1e-4f;
+        int s = 0;
+        for (int i = 0; i < 32; i++) { b.qs[i] = (signed char)((int)(lcg(seed) & 0xff) - 128); s += b.qs[i]; }
+        b.ds = __floats2half2_rn(d, d * (float)s);
+    }
+
+    auto* dW = dev<blk_q4_K>(hW.size(), hW.data());
+    auto* dA = dev<blk_q8_1>(hA.size(), hA.data());
+    auto* dY = dev<__nv_bfloat16>((size_t)M * N);
+    if (!dW || !dA || !dY) { std::printf("[SKIP] allocation failed\n"); return 77; }
+
+    if (!sparkinfer::kernels::launch_mmvq_rows(12, dA, dW, dY, M, N, K, nullptr)) {
+        std::printf("[FAIL] launch_mmvq_rows declined M=%d N=%d K=%d\n", M, N, K);
+        return 1;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        std::printf("[FAIL] %s\n", cudaGetErrorString(cudaGetLastError()));
+        return 1;
+    }
+    std::vector<__nv_bfloat16> out((size_t)M * N);
+    cudaMemcpy(out.data(), dY, out.size() * sizeof(__nv_bfloat16), cudaMemcpyDeviceToHost);
+
+    double sum = 0.0;
+    for (auto v : out) { const double x = (double)__bfloat162float(v); sum += x * x; }
+    const char* mode = getenv("SPARKINFER_MMVQ_MMA");
+    std::printf("M=%d N=%d K=%d mode=%s rms=%.9e n=%zu\n",
+                M, N, K, mode ? mode : "(default)", std::sqrt(sum / (double)out.size()), out.size());
+    if (const char* path = getenv("MMVQ_MMA_DUMP")) {
+        FILE* f = fopen(path, "wb");
+        if (!f) { std::printf("[FAIL] cannot write %s\n", path); return 1; }
+        fwrite(out.data(), sizeof(__nv_bfloat16), out.size(), f);
+        fclose(f);
+        std::printf("wrote %s\n", path);
+    }
+    cudaFree(dW); cudaFree(dA); cudaFree(dY);
+    return 0;
+}


### PR DESCRIPTION
## Summary

`launch_mmvq_rows` chunks a packed batch into 8-row launches, so a 32-row decode step walks each attention projection four times and re-reads its weights on every pass, while still paying the per-row dot. Nothing in this tree fed Q4_K into an MMA pipe, so a wide batch could not reach the tensor cores at all.

This dequantises inside the mainloop instead: `m16n8k32` spans exactly 32 K, which is exactly one Q4_K scale group, so the group scales fold in per-`mma` with the accumulator still in its four registers and the weights are read once for the whole batch.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

`launch_mmvq_rows` is shared, so the gates say why nothing else reaches this: Q4_K only
(`qtype == 12`), a packed batch of 24 rows or more, and an output width of 2048 or more. A single
request decodes at one row. The Qwen3.6 and ModelOpt Qwen3.8 guards still run over this file.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 421.1 |
| after (this PR) | 456.3 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_MMVQ_MMA=0/1`, interleaved, three rounds

| c | before | after | |
|---|--:|--:|--:|
| 16 | 357.5 | 357.3 | — |
| 32 | 421.1 | **456.3** | **+8.4%** |

c=32 reads 426.5 / 421.5 / 415.3 before against 457.0 / 456.4 / 455.6 after — the arms do not
overlap, and the spread inside the `after` arm is under 0.4%. c=16 is below the batch-width floor
and is the same binary doing the same thing.

### The output-width gate is the whole result

`N` is the block count at 32 output rows per block, so `k` and `v` (N = 256 on this checkpoint)
would launch **eight blocks onto 170 SMs**, where the per-launch cost swamps the saved weight
reads. Ungated across all four projections this measured **-5.2%** (461.8 → 437.9). Restricted to
the wide ones — `q` at N = 4096 and the attention output at N = 6656, with `k`/`v` left on the
MMVQ — it is **+8.4%**. The floor is where the shape has enough work to fill the device, not a
preference.

### Correctness

Not bit-identical, and not claimed to be: the mma path reduces over K in a different order than the
per-row dp4a MMVQ. So the agreement is measured. `kernels/tests/mmvq_mma_accuracy_gpu_test.cpp`
dumps a projection for both arms — two processes, because the dispatch caches its env read in a
function-local static — at both real shapes with 32 rows:

```text
N=6656 K=4096   bit-identical 212160/212992 (99.61%)   relative RMS 1.40e-04
N=4096 K=6656   bit-identical 129472/131072 (98.78%)   relative RMS 1.74e-04

output rms                  44.378
largest single disagreement  0.25   on an output of 58.5   (bf16 ulp there is 0.23)
mean absolute error          9.6e-06 of the output scale
```

The largest disagreement anywhere is one bf16 ulp at that value's own magnitude. A relative measure
looks worse on near-zero outputs, where one ulp is a large fraction of a small number — that is
cancellation, not error, which is why the bound above is stated against the output scale.

`SPARKINFER_MMVQ_MMA=0` keeps every width on the chunked MMVQ, for a paired A/B out of one binary;
`SPARKINFER_MMVQ_MMA_MINN` tunes the output-width floor.

`bench/scripts/bench.sh` benchmarks the prebuilt release binaries and cannot measure a branch, so the numbers above come from `qwen3_gguf_cb_bench` — the same binary, invocation and `agg_tok_s` parser this bot uses for `muse-cb-decode@cN`.