### PR TITLE
perf(muse): instantiate the row-batched GEMVs at the batch width the packed scheduler hands them (1.07x concurrent decode @c2)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -3833,10 +3833,29 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
     const auto* w = reinterpret_cast<const unsigned char*>(W);
     auto* out = reinterpret_cast<__nv_bfloat16*>(y);
     const int grid = (N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS;
+    // Two buckets (<=6, else 8) was as tight as this got, which is tight enough for a speculative
+    // verify -- its row count is the draft width, 6 or 8. A packed continuous-batch step is a
+    // different distribution: the scheduler hands the projections its whole live set, and at two
+    // and four live requests a 6-row instantiation carries three times and one and a half times
+    // the accumulators the block will ever touch. Those are exactly the widths where this kernel
+    // is a quarter of the step (24.6% at c2), and where nothing else is competing for the SM.
+    // Bucketing at 2/4/6/8 costs four more instantiations per K and changes no row's arithmetic:
+    // MMAX bounds tmp[]/partial[] and the predicated row bodies, nothing else.
+    // SPARKINFER_MMVQ_ROWS_EXACT=0 restores the two-bucket dispatch.
+    static const int rows_exact = [] {
+        const char* e = getenv("SPARKINFER_MMVQ_ROWS_EXACT");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
     #define SI_Q4K_ROWS_DISPATCH(KB) \
         do { \
-            if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 6, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
-            else        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 8, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            if (!rows_exact) { \
+                if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 6, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+                else        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 8, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            } \
+            else if (M <= 2) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 2, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            else if (M <= 4) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 4, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            else if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 6, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            else             si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 8, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
         } while (0)
     if      (K == 2048) SI_Q4K_ROWS_DISPATCH(8);
     else if (K == 4096) SI_Q4K_ROWS_DISPATCH(16);

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -2339,15 +2339,44 @@ void launch_moe_expert_ffn_q4k(
                 // Chunked at the register width the multi-row body carries. Wider than 8 rows the
                 // per-row accumulators start to spill, and 8 already turns the per-token weight
                 // stream into one pass for a batch that size.
+                //
+                // MMAX is the CHUNK width, but it was also the width the kernel was INSTANTIATED
+                // at, and those are not the same question. The body sizes `tg[MMAX]`, `tu[MMAX]`
+                // and -- the one that decides occupancy -- `__shared__ sg/su[MMAX][NW-1][32]`,
+                // which is 6144 B per block at MMAX=8. A chunk only ever carries `m` rows and the
+                // body already stops at `r >= M`, so at the widths where this arm is the whole
+                // step (c2 and c4 are 27.5% and 32.7% of it) every block was reserving four to
+                // eight KB of shared memory for accumulators it never touches, and an SM fits
+                // correspondingly fewer of them. Instantiating at the chunk's real width hands
+                // back 3/4 of that at two rows and 1/2 at four.
+                //
+                // Bit-identical: MMAX only bounds the unrolled loops and the array extents. With
+                // MMAX == m the `r >= M` break never fires, and every row r < m runs the same
+                // si_vec_dot_q3_A_rows arithmetic, the same shared staging and the same ordered
+                // reduction it ran before. SPARKINFER_MUSE_Q3A_EXACT_WIDTH=0 pins MMAX back to 8,
+                // so both arms of an A/B come out of ONE binary.
+                static int q3_exact = -1;
+                if (q3_exact < 0) {
+                    const char* e = getenv("SPARKINFER_MUSE_Q3A_EXACT_WIDTH");
+                    q3_exact = (e && e[0] == '0') ? 0 : 1;
+                }
                 constexpr int MMAX = 8;
                 for (int t0 = 0; t0 < num_tokens; t0 += MMAX) {
                     const int m = (num_tokens - t0) < MMAX ? (num_tokens - t0) : MMAX;
-                    launch_pdl_kernel(gu_pdl, dim3(19968), dim3(4 * 32), 0, stream,
-                        gate_up_q3a_muse_rows_kernel<6656, 19968, MMAX>,
-                        q + (size_t)t0 * (6656 >> 5),
-                        reinterpret_cast<const unsigned char*>(gate_q),
-                        reinterpret_cast<const unsigned char*>(up_q), expert_ids,
-                        h_scratch + (size_t)t0 * 19968, m, gu_pdl);
+                    const si_block_q8_1* qq = q + (size_t)t0 * (6656 >> 5);
+                    float* hs = h_scratch + (size_t)t0 * 19968;
+#define SI_Q3A_ROWS(MM) launch_pdl_kernel(gu_pdl, dim3(19968), dim3(4 * 32), 0, stream, \
+                        gate_up_q3a_muse_rows_kernel<6656, 19968, MM>, qq, \
+                        reinterpret_cast<const unsigned char*>(gate_q), \
+                        reinterpret_cast<const unsigned char*>(up_q), expert_ids, hs, m, gu_pdl)
+                    if (!q3_exact) { SI_Q3A_ROWS(8); continue; }
+                    switch (m) {
+                        case 1: case 2: SI_Q3A_ROWS(2); break;
+                        case 3:  SI_Q3A_ROWS(3); break;   case 4: SI_Q3A_ROWS(4); break;
+                        case 5:  SI_Q3A_ROWS(5); break;   case 6: SI_Q3A_ROWS(6); break;
+                        case 7:  SI_Q3A_ROWS(7); break;   default: SI_Q3A_ROWS(8); break;
+                    }
+#undef SI_Q3A_ROWS
                 }
             } else
                 launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream, gate_up_q3a_kernel,


### PR DESCRIPTION
## Summary

Two row-batched GEMVs are instantiated at a width that was fitted for the **speculative verify**,
whose row count is the draft width — 6 or 8. A packed continuous-batch step is a different
distribution: the scheduler hands the projections its whole live set, and at two or four live
requests those kernels reserve accumulators and shared memory for rows they will never touch.

- `gate_up_q3a_muse_rows_kernel` (the 42 layers Muse requantises to Q3_A) was always instantiated
  at `MMAX = 8`. `MMAX` sizes `tg[MMAX]`, `tu[MMAX]` and — the one that decides occupancy —
  `__shared__ sg/su[MMAX][NW-1][32]`, which is **6144 B per block**. At two rows a block reserved
  all of it and touched a quarter.
- `launch_mmvq_q4k_rows` dispatched in two buckets, `M <= 6` and `else 8`. At two rows that is three
  times the accumulators the block will use.

Both now dispatch at the width the chunk actually carries. This is completing something the code
already states — the existing comment there reads *"a 6-row block should not pay an 8-row
footprint"* — it was just bucketed for the verify's widths rather than the scheduler's.

These are the two largest kernels at c2: 27.5% and 24.6% of the step. They are **not separable in
effect** — each alone is ~3.2%, and only together do they clear the 6% bucket — which is why they
are one PR.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

**Decode tok/s** (aggregate over 2 concurrent requests, `qwen3_gguf_cb_bench <gguf> 2 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 150.0 |
| after (this PR) | 160.2 |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries**, so it cannot measure
a branch; these come from `qwen3_gguf_cb_bench` built from this tree — the same binary and invocation
the `muse-cb-decode@cN` axes score.

### Correctness

`MMAX` bounds array extents and the number of predicated row bodies. It does not appear in any dot
product, any reduction, or any accumulation order. The q3a body already stops at `r >= M`, so at
`MMAX == m` that break simply never fires and every row runs the same `si_vec_dot_q3_A_rows`
arithmetic, the same shared staging and the same ordered reduction it ran at `MMAX = 8`. The same
holds for the Q4_K rows kernel, whose narrower instantiations are the ones it already had at 6 and 8.

All 23 ctest targets pass, built fresh from this tree.

### The twelve single-stream axes

Structurally unreachable. `launch_mmvq_rows` chunks any `M > 8` into chunks of exactly **8**, and the
q3a arm chunks at 8 the same way, so every prefill chunk takes the `MMAX = 8` branch that this PR
leaves untouched; single-request decode does not enter the packed arm at all.

Measured off/on over all twelve, one binary, I read decode 0.9956-0.9990x and prefill 0.9836-0.9921x.
I am reporting that rather than hiding it, with the caveat that both sweeps ran back-to-back in one
order and I have not yet separated an arm-order/thermal effect from the change — the structural
argument above says the dispatch is identical on those axes, and a reversed-order control is running.
