### PR TITLE
perf(muse): read the activation once for the gate and up dots in the packed Q3_A FFN (1.10x concurrent decode @c4)

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -686,6 +686,79 @@ __device__ __forceinline__ void si_vec_dot_q3_A_rows(
     }
 }
 
+// Gate and up are dotted against the SAME activation super-block at the same iqs -- the caller
+// drives both with one `vy + kbx * 8` -- but as two separate inlined calls of the helper above
+// nothing shares that side of the work. In the SASS for MMAX=4 that costs 48 activation LDG per
+// row where 24 cover it, 32 I2FP and 16 HADD2 re-converting the same `d8`, and a second copy of
+// `dot2` -- the sub-block's plain activation sum, which contains no weight at all and is therefore
+// bit-for-bit the same number for gate and for up.
+//
+// Taking both weight blocks in one pass reads the activation once, converts d8 once and computes
+// dot2 once, while each accumulator still gets its own dm.x*sumf_d - dm.y*sumf_m built from the
+// same per-i terms in the same i order as before. Removing a redundant load and a redundant copy
+// of an identical integer dot changes no value, so this is bit-identical to the pair it replaces.
+template <int MMAX>
+__device__ __forceinline__ void si_vec_dot_q3_A_rows2(
+    const si_block_q3_A* __restrict__ bg, const si_block_q3_A* __restrict__ bu,
+    const si_block_q8_1* __restrict__ bq8_1,
+    int row_blocks, int iqs, int M, float* __restrict__ accg, float* __restrict__ accu)
+{
+    const int L = iqs >> 1;
+    const int j = L >> 2, m4 = L & 3;
+
+    // ---- weight side: the same unpack as si_vec_dot_q3_A_rows, once per matrix ----
+    int v[2][2][2];                       // [matrix][i][half]
+    unsigned short aux[2][2];
+    float2 dm[2];
+    #pragma unroll
+    for (int t = 0; t < 2; t++) {
+        const si_block_q3_A* b = t ? bu : bg;
+        const int vl  = *(const int*)(b->qs + 16 * j + 4 * m4);
+        const int hlo = *(const int*)(b->qh + 8 * m4);
+        const int hhi = *(const int*)(b->qh + 8 * m4 + 4);
+        const unsigned short* scales = (const unsigned short*)b->scales;
+        if (j < 2) { aux[t][0] = scales[j] & 0x3f3f; aux[t][1] = scales[j + 2] & 0x3f3f; }
+        else { aux[t][0] = ((scales[j + 2] >> 0) & 0x0f0f) | ((scales[j - 2] & 0xc0c0) >> 2);
+               aux[t][1] = ((scales[j + 2] >> 4) & 0x0f0f) | ((scales[j]     & 0xc0c0) >> 2); }
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            const int sb = 2 * j + i;
+            v[t][i][0] = ((vl >> (2 * i))     & 0x03030303) | (((hlo >> sb) & 0x01010101) << 2);
+            v[t][i][1] = ((vl >> (2 * i + 4)) & 0x03030303) | (((hhi >> sb) & 0x01010101) << 2);
+        }
+        dm[t] = __half22float2(b->dm);
+    }
+    const unsigned char* scg = (const unsigned char*)aux[0]; const unsigned char* mng = scg + 2;
+    const unsigned char* scu = (const unsigned char*)aux[1]; const unsigned char* mnu = scu + 2;
+
+    #pragma unroll
+    for (int r = 0; r < MMAX; r++) {
+        if (r >= M) break;
+        const si_block_q8_1* base = bq8_1 + (size_t)r * row_blocks;
+        float gd = 0.f, gm = 0.f, ud = 0.f, um = 0.f;
+        #pragma unroll
+        for (int i = 0; i < 2; i++) {
+            const si_block_q8_1* bq8i = base + 2 * j + i;
+            const float d8 = __low2float(bq8i->ds);
+            const int* q8 = (const int*)bq8i->qs;
+            const int u0 = q8[2 * m4], u1 = q8[2 * m4 + 1];
+            // activation-only, so gate and up share it verbatim
+            const int dot2 = __dp4a(0x01010101, u0, __dp4a(0x01010101, u1, 0));
+            const int dotg = __dp4a(v[0][i][0], u0, __dp4a(v[0][i][1], u1, 0));
+            const int dotu = __dp4a(v[1][i][0], u0, __dp4a(v[1][i][1], u1, 0));
+            gd += d8 * (dotg * scg[i]); gm += d8 * (dot2 * mng[i]);
+            ud += d8 * (dotu * scu[i]); um += d8 * (dot2 * mnu[i]);
+        }
+        // Materialized before the add for the same reason the one-matrix helper does it: folding
+        // the accumulator in lets the compiler contract `acc + dm.x*sumf_d` into an FMA and round
+        // the pair differently.
+        const float pg = dm[0].x * gd - dm[0].y * gm;
+        const float pu = dm[1].x * ud - dm[1].y * um;
+        accg[r] += pg;
+        accu[r] += pu;
+    }
+}
+
 // One CTA per output row, weights read as Q3_A. Same tiling, same accumulation order and same
 // 4-warp reduction as gate_up_mmvq2_kernel below -- only the block format differs.
 __global__ void gate_up_q3a_kernel(
@@ -764,7 +837,7 @@ template <int H, int F, int MMAX>
 __global__ void gate_up_q3a_muse_rows_kernel(
     const si_block_q8_1* __restrict__ vy, const unsigned char* __restrict__ gate_q,
     const unsigned char* __restrict__ up_q, const int* __restrict__ expert_ids,
-    float* __restrict__ h_scratch, int M, int pdl
+    float* __restrict__ h_scratch, int M, int pdl, int gu2
 ) {
     constexpr int NW = 4, NB = H >> 8, RB = H >> 5;
     const int f = blockIdx.x;
@@ -776,10 +849,17 @@ __global__ void gate_up_q3a_muse_rows_kernel(
     float tg[MMAX], tu[MMAX];
     #pragma unroll
     for (int r = 0; r < MMAX; r++) { tg[r] = 0.f; tu[r] = 0.f; }
-    #pragma unroll
-    for (int kbx = kbx0; kbx < NB; kbx += 8) {
-        si_vec_dot_q3_A_rows<MMAX>(g_row + kbx, vy + (size_t)kbx * 8, RB, kqs, M, tg);
-        si_vec_dot_q3_A_rows<MMAX>(u_row + kbx, vy + (size_t)kbx * 8, RB, kqs, M, tu);
+    if (gu2) {
+        #pragma unroll
+        for (int kbx = kbx0; kbx < NB; kbx += 8)
+            si_vec_dot_q3_A_rows2<MMAX>(g_row + kbx, u_row + kbx, vy + (size_t)kbx * 8,
+                                        RB, kqs, M, tg, tu);
+    } else {
+        #pragma unroll
+        for (int kbx = kbx0; kbx < NB; kbx += 8) {
+            si_vec_dot_q3_A_rows<MMAX>(g_row + kbx, vy + (size_t)kbx * 8, RB, kqs, M, tg);
+            si_vec_dot_q3_A_rows<MMAX>(u_row + kbx, vy + (size_t)kbx * 8, RB, kqs, M, tu);
+        }
     }
     __shared__ float sg[MMAX][NW - 1][32], su[MMAX][NW - 1][32];
     if (warp > 0) {
@@ -2583,6 +2663,14 @@ void launch_moe_expert_ffn_q4k(
                 // Chunked at the register width the multi-row body carries. Wider than 8 rows the
                 // per-row accumulators start to spill, and 8 already turns the per-token weight
                 // stream into one pass for a batch that size.
+                //
+                // SPARKINFER_MUSE_Q3A_GU2=0 restores the two-pass gate/up dot, so both arms of
+                // an A/B come out of ONE binary.
+                static int q3_gu2 = -1;
+                if (q3_gu2 < 0) {
+                    const char* e = getenv("SPARKINFER_MUSE_Q3A_GU2");
+                    q3_gu2 = (e && e[0] == '0') ? 0 : 1;
+                }
                 constexpr int MMAX = 8;
                 for (int t0 = 0; t0 < num_tokens; t0 += MMAX) {
                     const int m = (num_tokens - t0) < MMAX ? (num_tokens - t0) : MMAX;
@@ -2591,7 +2679,7 @@ void launch_moe_expert_ffn_q4k(
                         q + (size_t)t0 * (6656 >> 5),
                         reinterpret_cast<const unsigned char*>(gate_q),
                         reinterpret_cast<const unsigned char*>(up_q), expert_ids,
-                        h_scratch + (size_t)t0 * 19968, m, gu_pdl);
+                        h_scratch + (size_t)t0 * 19968, m, gu_pdl, q3_gu2);
                 }
             } else
                 launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream, gate_up_q3a_kernel,


### PR DESCRIPTION
## Summary

In Muse Glimmer's packed continuous-batch decode the gate and up projections of the 42 Q3_A layers
are dotted against the **same** activation super-block at the same `iqs` — `gate_up_q3a_muse_rows_kernel`
drives both with one `vy + kbx * 8` — but as two separate inlined calls of `si_vec_dot_q3_A_rows`
nothing on the activation side is shared. This takes both weight blocks in one pass, so the
activation is read once, its `d8` is converted once, and `dot2` — the sub-block's plain activation
sum, which contains no weight at all and is therefore bit-for-bit the same number for gate and for
up — is computed once.

**Why that kernel.** It is the largest kernel in the packed step at these widths (25.6% of the c2
step, 33.3% of c4) and it fits `0.19 + 1.51 ms x M`: an intercept of ~0, so it shares almost nothing
across rows even though the *weight* unpack is already shared. At c2 it runs at 89% of the DRAM roof
(4.88 GB of Q3_A weights in 3.214 ms = 1.52 TB/s); at c4 the same weight stream takes 6.241 ms, i.e.
46%. The extra is all per-row.

**Where the per-row cost is.** Three arms, each removing exactly ONE thing that scales with M and
keeping the other two (c4, baseline `mean_itl_ms` 19.06):

| arm | c4 itl | vs base |
|---|--:|--:|
| every row reads row 0's activation blocks (kills activation traffic growth) | 17.45 | **-8.4%** |
| the dot accumulates row 0 only (kills ALL main-loop per-row work) | 15.27 | **-19.9%** |
| the cross-warp fold runs for row 0 only (kills the reduction tail's per-row work) | 18.89 | -0.9% |

So ~42% of the removable cost is activation traffic and ~58% is per-row issue — and the 4-warp
reduction tail is free, which rules out the shared-memory fold as the thing to change.

**The SASS said which.** In the `MMAX=4` instantiation nvcc does not CSE the two inlined calls: the
kernel issues **48 activation LDG per row where 24 cover it**, 32 `I2FP` and 16 `HADD2` re-converting
the same `d8`, and 64 of its 256 `IDP` are the second, identical copy of `dot2`. One pass over both
weight blocks removes exactly those.

**Numerically identical, not just "close".** Each accumulator still receives its own
`dm.x*sumf_d - dm.y*sumf_m`, built from the same per-`i` terms in the same `i` order, materialized
before the add for the same reason the one-matrix helper does it. Only a redundant load and a
redundant copy of an identical integer dot are gone. Verified rather than asserted: an FNV-1a hash
over every emitted token id (summed per request, so it is order-independent under continuous
batching) is **identical between the two arms, and reproducible within each arm**:

```
c2  gu2=1 e13ede0396c5f539   gu2=1 e13ede0396c5f539   gu2=0 e13ede0396c5f539   gu2=0 e13ede0396c5f539
c4  gu2=1 e8cb8ad848cb531f   gu2=1 e8cb8ad848cb531f   gu2=0 e8cb8ad848cb531f   gu2=0 e8cb8ad848cb531f
```

`SPARKINFER_MUSE_Q3A_GU2=0` restores the two-pass dot, so both arms of every A/B below come out of
**one binary**. `ctest` 23/23.

**Scope.** This kernel runs at **c2 and c4 only**: `gu_gemm_min_rows()` is 6, so from six rows up
gate/up already go through the flat block-scaled NVFP4 GEMM instead. The twelve single-stream axes
never reach it either — AR decode is `num_tokens == 1` and takes `gate_up_q3a_muse_kernel`, and
prefill's dense FFN takes the NVFP4 / grouped-int8 arms. The wide concurrency axes are measured
below anyway and are flat.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

**Decode tok/s** (end-to-end):

| | decode tok/s |
|---|--:|
| before (main) | 205.2 |
| after (this PR) | 225.5 |

**Prefill pp tok/s**:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not targeted — path unreachable (see Scope) |
| after prefill (this PR) | not targeted — path unreachable (see Scope) |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries** and needs a `.gguf`
file, so it cannot measure a branch. The numbers above are `qwen3_gguf_cb_bench` (the concurrency
harness the `muse-cb-decode@cN` axes are scored on), RTX 5090 / CUDA 13.0,
`SPARKINFER_SCHED_POLICY=continuous SPARKINFER_PREFILL_MIX_MAX=0`, 256-token prompts, 256 new tokens.

Arms are **mirrored** (`1 0 0 1 1 0 0 1`) because the box drifts downward through a session; the
mirror cancels it. Every point carries its `decode_tokens`.

```text
=== muse-cb-decode@c2 / @c4 -- four mirrored pairs, one binary ===
gu2=1   c2 164.6 (itl 12.15  decode_tokens 520)   c4 227.9 (itl 17.11  decode_tokens 1032)
gu2=0   c2 159.8 (itl 12.53  decode_tokens 520)   c4 206.3 (itl 18.96  decode_tokens 1032)
gu2=0   c2 159.6 (itl 12.54  decode_tokens 520)   c4 205.9 (itl 19.01  decode_tokens 1032)
gu2=1   c2 163.2 (itl 12.26  decode_tokens 520)   c4 225.4 (itl 17.31  decode_tokens 1032)
gu2=1   c2 163.1 (itl 12.27  decode_tokens 520)   c4 224.6 (itl 17.37  decode_tokens 1032)
gu2=0   c2 158.7 (itl 12.61  decode_tokens 520)   c4 204.6 (itl 19.12  decode_tokens 1032)
gu2=0   c2 158.5 (itl 12.63  decode_tokens 520)   c4 204.0 (itl 19.17  decode_tokens 1032)
gu2=1   c2 162.6 (itl 12.30  decode_tokens 520)   c4 224.0 (itl 17.41  decode_tokens 1032)

              mean agg_tok_s        mean mean_itl_ms
  c2   off 159.15  on 163.38  +2.66%      12.578 -> 12.245  -2.65%
  c4   off 205.20  on 225.48  +9.88%      19.065 -> 17.300  -9.26%

=== wide axes: the kernel is not reached (gate/up run as the block-scaled GEMM) ===
gu2=1   c8 328.9 (itl 23.28  decode_tokens 2056)  c16 413.8 (itl 37.10  4104)  c32 439.6 (itl 64.32  8200)
gu2=0   c8 322.9 (itl 23.69  decode_tokens 2056)  c16 407.7 (itl 37.66  4104)  c32 434.9 (itl 65.09  8200)
gu2=0   c8 320.6 (itl 23.86  decode_tokens 2056)  c16 406.0 (itl 37.81  4104)  c32 432.1 (itl 65.60  8200)
gu2=1   c8 320.3 (itl 23.90  decode_tokens 2056)  c16 404.3 (itl 37.98  4104)  c32 386.0 (itl 65.99  8200)

  c8  off 321.75  on 324.60  +0.9%      c16  off 406.85  on 409.05  +0.5%
  c32 is bimodal on this box (~385 vs ~433 with decode_tokens full in both modes); the 386.0
  reading above is the low mode, so no c32 delta is claimed from it. Both c32 arms are otherwise
  432-440, i.e. flat, which is what the scope argument predicts.
```

**Base of the measurements.** The A/B above was taken on `8c9d4f3` with PR #1042 (mine, still open)
also applied, with both arms coming out of that one binary via the env knob — so the delta isolates
*this* change alone, but the tree it sits on is not byte-for-byte this branch, which is rebased onto
`31eebd1` with #1042 absent. Re-measurement on exactly this branch is in progress and I will post it
here when it lands.
