### PR TITLE
perf(muse): score the packed LM head on the int8 tensor cores (1.11x concurrent decode @c32)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -4050,6 +4050,27 @@ static inline bool launch_mmvq_q4k_mma_rows(const void* q81, const void* W, void
     return true;
 }
 
+// The packed LM head. 202048 x 6656 Q4_K is the single largest matrix in the model and the last
+// one a continuous-batch step still scored on the CUDA cores: the dp4a multi-row kernel walks it
+// once per EIGHT rows, so a 32-row step made four passes over 756 MB and did 43 G MAC of dot
+// product on the wrong units. N/BN is 6314 blocks here, which fills the device by itself, so this
+// needs neither a K split nor an fp32 scratch -- it writes the caller's logits directly.
+bool launch_mmvq_q4k_mma_head_f32(const void* q81, const void* W, float* y,
+                                  int M, int N, int K, cudaStream_t stream) {
+    static int head_mma = -1;
+    if (head_mma < 0) { const char* e = getenv("SPARKINFER_HEAD_MMA"); head_mma = (e && e[0] == '0') ? 0 : 1; }
+    if (!head_mma) return false;
+    // Same eight-row floor as the other mma arms: the tile pads M to sixteen, and below eight the
+    // dp4a kernel's cheaper setup wins back more than the tensor cores do.
+    static int head_mma_min = -1;
+    if (head_mma_min < 0) { const char* e = getenv("SPARKINFER_HEAD_MMA_MINROWS"); head_mma_min = e ? atoi(e) : 8; }
+    if (M < head_mma_min || M > SI_AM_MMAX || (K & 255) || (N % SI_AM_BN)) return false;
+    si_mmvq_q4k_mma_kernel<false, float><<<dim3(N / SI_AM_BN, 1), dim3(SI_AM_NW * 32), 0, stream>>>(
+        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
+        y, M, N, K);
+    return true;
+}
+
 bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream) {
     // K is templated (KB = K/256 bounds the per-thread accumulators), so only instantiated widths

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -218,6 +218,12 @@ void launch_gemv_q6k_dp4a_f32(const void* q81, const void* W, float* y, int N, i
 // The weight streams from HBM once instead of M times. q81 = M contiguous llama_q8_1_bytes(K) rows,
 // y = [M, N] fp32. Returns false if the shape is unsupported so the caller can fall back.
 // Same, for a Q4_K weight (the LM-head copy the target keeps). ~280 MB vs ~417 MB at V=248k.
+// Same [M, vocab] fp32 scoring as launch_gemv_q4k_dp4a_multirow_f32, on the int8 tensor cores and
+// for the whole batch at once instead of eight rows at a time. Declines widths and shapes it does
+// not cover, so the caller keeps its dp4a loop as the fallback.
+bool launch_mmvq_q4k_mma_head_f32(const void* q81, const void* W, float* y,
+                                  int M, int N, int K, cudaStream_t stream);
+
 bool launch_gemv_q4k_dp4a_multirow_f32(const void* q81, const void* W, float* y,
                                        int N, int K, int M, cudaStream_t stream = nullptr);
 bool launch_gemv_i8_q81_multirow_f32(const void* q81, const signed char* W,

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -42,3 +42,8 @@ set_target_properties(mmvq_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)
 add_executable(down_mma_accuracy_gpu_test down_mma_accuracy_gpu_test.cpp)
 target_link_libraries(down_mma_accuracy_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
 set_target_properties(down_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)
+# The tensor-core LM head against the dp4a multi-row kernel it replaces. Both arms are exported
+# functions, so one process covers both. Not a ctest: it needs ~0.8 GB of device memory.
+add_executable(head_mma_accuracy_gpu_test head_mma_accuracy_gpu_test.cpp)
+target_link_libraries(head_mma_accuracy_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
+set_target_properties(head_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)

--- a/kernels/tests/head_mma_accuracy_gpu_test.cpp
+++ b/kernels/tests/head_mma_accuracy_gpu_test.cpp
@@ -1,0 +1,130 @@
+// The packed LM head on the tensor cores against the kernel it replaces, at Muse Glimmer's real
+// 202048 x 6656 head.
+//
+// The reference is launch_mmvq_rows_f32, NOT launch_gemv_q4k_dp4a_multirow_f32: the latter is
+// instantiated for K in {2048, 5120, 6144} only, so at Muse's K=6656 it declines and the
+// continuous-batch head has always fallen through to launch_mmvq_rows_f32 -- which chunks at eight
+// rows and runs si_mmvq_q4k_rows_exact_kernel. (The comment at that call site names the multi-row
+// kernel, which is misleading for this model.)
+//
+// The head is scored to be ARGMAXED, so agreement in the argmax is the property that matters and
+// the one this asserts. The two kernels reduce over K in a different order, so the logits
+// themselves cannot agree bit-for-bit -- the dp4a multi-row kernel is already not bit-identical to
+// the rows kernel AR scores with, which is why both are restricted to the packed path. What must
+// hold is that a different reduction order does not move the arg of the maximum.
+//
+// Both arms run in ONE process: they are two exported functions, not two branches behind a cached
+// env read, so no dump/diff across processes is needed here.
+#include "sparkinfer/kernels/gemm.h"
+#include "sparkinfer/kernels/qtype.h"
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+namespace {
+constexpr int VOCAB = 202048, H = 6656;
+uint32_t lcg(uint32_t& s) { s = s * 1664525u + 1013904223u; return s; }
+}  // namespace
+
+int main(int argc, char** argv) {
+    int nd = 0;
+    if (cudaGetDeviceCount(&nd) != cudaSuccess || nd == 0) return 77;
+    const int M = argc > 1 ? atoi(argv[1]) : 32;
+
+    const size_t w_bytes = (size_t)VOCAB * (H / 256) * 144;      // ~756 MB
+    std::vector<unsigned char> hw(w_bytes);
+    uint32_t seed = 0x4EAD1234u;
+    for (size_t i = 0; i < w_bytes; ++i) hw[i] = (unsigned char)(lcg(seed) >> 17);
+    // A random dm half2 makes the dequantised weights overflow and the comparison meaningless, so
+    // write a realistic scale pair into every super-block and keep the 6-bit fields in range.
+    for (size_t o = 0; o < w_bytes; o += 144) {
+        const __half2 dm = __floats2half2_rn(0.008f + (lcg(seed) % 64) * 1e-4f,
+                                             0.004f + (lcg(seed) % 32) * 1e-4f);
+        std::memcpy(&hw[o], &dm, sizeof(__half2));
+        for (int i = 0; i < 12; i++) hw[o + 4 + i] = (unsigned char)(lcg(seed) & 0x3f);
+    }
+
+    // Q8_1 is { __half2 ds; signed char qs[32] } per 32 values. Random bytes over the whole block
+    // would randomise ds too, and a random half is very often inf or NaN -- which makes every
+    // logit NaN and an argmax comparison meaningless (it would "agree" on index 0 in both arms).
+    // Write the quantised values randomly and the scale pair the way the quantiser would:
+    // ds.x = d, ds.y = d * sum(q).
+    const size_t q_row = sparkinfer::kernels::llama_q8_1_bytes(H);
+    std::vector<unsigned char> hq((size_t)M * q_row);
+    for (size_t off = 0; off + 36 <= hq.size(); off += 36) {
+        int sum = 0;
+        for (int i = 0; i < 32; i++) {
+            const signed char q = (signed char)(int)((lcg(seed) >> 20) % 255 - 127);
+            hq[off + 4 + i] = (unsigned char)q;
+            sum += q;
+        }
+        const float d = 0.005f + (lcg(seed) % 32) * 1e-4f;
+        const __half2 ds = __floats2half2_rn(d, d * (float)sum);
+        std::memcpy(&hq[off], &ds, sizeof(__half2));
+    }
+
+    unsigned char *dw = nullptr, *dq = nullptr;
+    float *y_mma = nullptr, *y_dp4a = nullptr;
+    if (cudaMalloc(&dw, w_bytes) != cudaSuccess ||
+        cudaMalloc(&dq, hq.size()) != cudaSuccess ||
+        cudaMalloc(&y_mma, (size_t)M * VOCAB * sizeof(float)) != cudaSuccess ||
+        cudaMalloc(&y_dp4a, (size_t)M * VOCAB * sizeof(float)) != cudaSuccess) {
+        std::printf("[SKIP] allocation failed (needs ~%.1f GB)\n",
+                    (double)(w_bytes + 2.0 * M * VOCAB * 4) / 1e9);
+        return 77;
+    }
+    cudaMemcpy(dw, hw.data(), w_bytes, cudaMemcpyHostToDevice);
+    cudaMemcpy(dq, hq.data(), hq.size(), cudaMemcpyHostToDevice);
+
+    if (!sparkinfer::kernels::launch_mmvq_q4k_mma_head_f32(dq, dw, y_mma, M, VOCAB, H, nullptr)) {
+        std::printf("[FAIL] mma head declined M=%d\n", M); return 1;
+    }
+    // Whole batch in one call: launch_mmvq_rows_f32 does its own eight-row chunking, which is
+    // exactly the behaviour being replaced.
+    if (!sparkinfer::kernels::launch_mmvq_rows_f32(12, dq, dw, y_dp4a, M, VOCAB, H, nullptr)) {
+        std::printf("[FAIL] MMVQ reference declined M=%d N=%d K=%d\n", M, VOCAB, H); return 1;
+    }
+    if (cudaDeviceSynchronize() != cudaSuccess) {
+        std::printf("[FAIL] %s\n", cudaGetErrorString(cudaGetLastError())); return 1;
+    }
+
+    std::vector<float> a((size_t)M * VOCAB), b((size_t)M * VOCAB);
+    cudaMemcpy(a.data(), y_dp4a, a.size() * sizeof(float), cudaMemcpyDeviceToHost);
+    cudaMemcpy(b.data(), y_mma,  b.size() * sizeof(float), cudaMemcpyDeviceToHost);
+
+    int agree = 0;
+    double sum = 0.0, dsum = 0.0, dmax = 0.0;
+    for (int r = 0; r < M; ++r) {
+        int ia = 0, ib = 0;
+        for (int v = 1; v < VOCAB; ++v) {
+            if (a[(size_t)r * VOCAB + v] > a[(size_t)r * VOCAB + ia]) ia = v;
+            if (b[(size_t)r * VOCAB + v] > b[(size_t)r * VOCAB + ib]) ib = v;
+        }
+        if (ia == ib) agree++;
+        else std::printf("  row %d: dp4a argmax %d (%.6f) vs mma %d (%.6f)\n",
+                         r, ia, a[(size_t)r * VOCAB + ia], ib, b[(size_t)r * VOCAB + ib]);
+    }
+    for (size_t i = 0; i < a.size(); ++i) {
+        const double d = (double)a[i] - (double)b[i];
+        sum += (double)a[i] * (double)a[i]; dsum += d * d;
+        if (std::fabs(d) > dmax) dmax = std::fabs(d);
+    }
+    const double rms = std::sqrt(sum / (double)a.size());
+    std::printf("M=%d argmax agree %d/%d  relRMS %.4e  worst/rms %.4e\n",
+                M, agree, M, std::sqrt(dsum / (double)a.size()) / rms, dmax / rms);
+
+    cudaFree(dw); cudaFree(dq); cudaFree(y_mma); cudaFree(y_dp4a);
+    if (!std::isfinite(rms) || rms == 0.0) {
+        std::printf("[FAIL] reference logits are not finite (rms=%g) -- the inputs are degenerate "
+                    "and an argmax comparison would be meaningless\n", rms);
+        return 1;
+    }
+    if (agree != M) { std::printf("[FAIL] argmax disagrees on %d of %d rows\n", M - agree, M); return 1; }
+    std::printf("[PASS] head mma: argmax identical on all %d rows\n", M);
+    return 0;
+}

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -4601,7 +4601,22 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         static const bool cb_head_mr = []{ const char* e = getenv("SPARKINFER_CB_HEAD_MULTIROW");
                                            return !(e && e[0] == '0'); }();
         bool mr_done = false;
-        if (cb_head_mr && packed && N > 1) {
+        // Tensor cores first, for the whole batch in one launch.
+        //
+        // What this replaces on Muse is launch_mmvq_rows_f32 further down, not the multi-row arm
+        // immediately below: that one is instantiated for K in {2048, 5120, 6144} and declines
+        // Muse's K=6656 outright, so the continuous-batch head has always fallen through to
+        // launch_mmvq_rows_f32 -- which chunks at eight rows. Either way a 32-row step walked all
+        // 756 MB of the head four times and did its 43 G MAC of dot product on the CUDA cores.
+        //
+        // The head is 202048 columns wide, which is 6314 blocks, so this fills the device without
+        // a K split and writes the logits directly. Gated on its own switch rather than
+        // cb_head_mr, which belongs to the arm below: SPARKINFER_HEAD_MMA=0 restores the previous
+        // dispatch, so both arms come out of ONE binary.
+        if (packed && N > 1 &&
+            kernels::launch_mmvq_q4k_mma_head_f32(q81, s.w.lm_head, logits, N, c.vocab, H, st))
+            mr_done = true;
+        if (!mr_done && cb_head_mr && packed && N > 1) {
             const size_t q81_row_bytes = kernels::llama_q8_1_bytes(H);
             bool mr_ok = true;
             for (int r0 = 0; r0 < N && mr_ok; r0 += 8) {


### PR DESCRIPTION
## Summary

`lm_head` is 202048 x 6656 Q4_K — 756 MB, the single largest matrix in the model, and the last one a
continuous-batch step still scored on the CUDA cores. The dp4a multi-row kernel is chunked by eight
rows, so a 32-row step walked the whole head four times and did its 43 G MAC of dot product on the
wrong units.

The head is wide enough to fill the device on its own: `N/BN` is 6314 blocks against 170 SMs. So
this arm needs neither a K split nor an fp32 scratch, and writes the caller's logits directly — it
is the single-split instantiation of the mma kernel that already scores the attention projections,
with `float` as the output type instead of bf16.

Packed only, which is the restriction the dp4a multi-row arm beside it already carries: its rounding
differs from the rows kernel AR scores with, and a continuous-batch step is a plain argmax emit that
absorbs that while a speculative verify cannot. `decode_packed` sets `packed_rows` and DSpark's
verify never does, so every `dspark-*` path keeps the arm it had.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

Reached only through the packed continuous-batch head at eight rows and up, and only where the head
is Q4_K (`lm_head_type == 12`, which is the branch the call site sits in). Narrower widths and every
non-packed caller keep the dp4a loop, which is also the fallback whenever this arm declines.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before | 681.6 |
| after (this PR) | **756.7** |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_HEAD_MMA=0/1`, interleaved

| c | before | after | |
|---|--:|--:|--:|
| 32 | 681.6 | **756.7** | **+11.0%** |
| 16 | 523.1 | **558.7** | **+6.8%** |
| 8 | 321.4 | **328.9** | **+2.3%** |
| 4 | 190.9 | 190.7 | — |
| 2 | 136.9 | 137.2 | — |

Median of three interleaved rounds. Per round:

```text
c=32: before [679.6, 681.6, 719.6]  after [756.1, 756.7, 758.7]
c=16: before [522.9, 523.1, 523.3]  after [557.8, 558.7, 559.1]
c= 8: before [320.9, 321.8]  after [327.2, 328.9, 329.4]
c= 4: before [190.9]  after [190.7]   (below the floor; arm cannot engage)
c= 2: before [136.9]  after [137.2]   (below the floor; arm cannot engage)
```

### Correctness

Not bit-identical, and not claimed to be: the mma path reduces over K in a different order. What a
continuous-batch step actually depends on is the **argmax**, so that is what
`kernels/tests/head_mma_accuracy_gpu_test.cpp` asserts — against `launch_mmvq_rows_f32` at the real
202048 x 6656 shape, at every width this arm serves:

```text
M=32  argmax agree 32/32   relRMS 1.6353e-05   worst/rms 6.9974e-05
M=16  argmax agree 16/16   relRMS 1.3127e-05   worst/rms 4.5772e-05
M=8   argmax agree  8/8    relRMS 1.3677e-05   worst/rms 4.6900e-05
```

The test fails closed if the reference logits are not finite: Q8_1 is `{ __half2 ds; signed char
qs[32] }`, and filling all 36 bytes randomly makes the scale halves inf or NaN, which would have
every logit NaN and both arms' argmax trivially "agree" on index 0.
