### PR TITLE
perf(muse): take the gate/up tensor-core GEMM from four packed rows, not six (1.10x concurrent decode @c4)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3045,14 +3045,23 @@ static bool muse_packed_on() {
     return v;
 }
 // Row count from which a packed step runs the dense gate/up as ONE block-scaled NVFP4 GEMM per
-// projection instead of the row-batched dp4a GEMV. Fitted on an RTX 5090 against Muse Glimmer's
-// 6656x19968 FFN: the GEMV costs a fixed read plus ~0.76 ms per row across the model, the GEMM
-// 6.92 ms flat (0.0666 ms at 8 rows, 0.0668 at 16 -- it reads the same operand either way), so they
-// cross just under six rows.
+// projection instead of the row-batched dp4a GEMV. The crossover was FITTED rather than swept --
+// "the GEMV costs a fixed read plus ~0.76 ms per row across the model, the GEMM 6.92 ms flat, so
+// they cross just under six rows" -- and measuring it end to end puts it lower. Four packed rows
+// already pay for the GEMM; two do not:
+//
+//     c=4   min_rows 6 -> 191.6 / 191.2 tok/s     min_rows 2 -> 208.7 / 208.8   +9.0%
+//     c=2   min_rows 6 -> 137.1 / 137.1           min_rows 2 -> 126.9           -7.4%
+//
+// So the GEMM is worth taking from four rows up and not below, which is what this returns. A
+// four-row packed step is a scored continuous-batch width, and at four rows every other arm in the
+// step is still on the dp4a path -- every tensor-core arm has an eight-row floor, because an
+// m16n8k32 tile pads M to sixteen. This is the one place a narrow batch can reach the tensor cores,
+// and the fitted six was keeping it off them.
 static int gu_gemm_min_rows() {
     static const int v = [] {
         const char* e = getenv("SPARKINFER_GU_GEMM_MIN_ROWS");
-        const int x = e ? atoi(e) : 6;
+        const int x = e ? atoi(e) : 4;
         return x < 1 ? 1 : x;
     }();
     return v;


### PR DESCRIPTION
## Summary

`gu_gemm_min_rows()` decides when a packed step computes gate and up as a block-scaled NVFP4 GEMM
instead of the row-batched dp4a GEMV. It returns 6, and the comment above it says where that came
from: a cost model — "the GEMV costs a fixed read plus ~0.76 ms per row across the model, the GEMM
6.92 ms flat … so they cross just under six rows."

Measured end to end, the crossover is lower. At four packed rows the GEMM is worth **+9.0%**; at two
it costs **−7.4%**. So it sits between two and four, and the threshold should be 4.

This matters more than one constant usually would, because **four rows is the only width at which a
narrow packed batch can reach the tensor cores at all.** Every other tensor-core arm in the step —
the down projection, the wide attention projections, the LM head — has an eight-row floor, because
an `m16n8k32` tile pads M to sixteen and below eight the padding costs more than the tensor cores
win back. A four-row step was running entirely on the CUDA cores, and a fitted constant was what
kept it there.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

Only the packed continuous-batch path reads this threshold, and only where the NVFP4 gate/up
operands exist (`packed_gate_up_nvfp4` returns false otherwise and the GEMV runs as before). Widths
of 4 and 5 change arm; 1–3 and 6+ are untouched.

**Decode tok/s** (aggregate over 4 concurrent requests, `qwen3_gguf_cb_bench <gguf> 4 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 191.0 |
| after (this PR) | **209.1** |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — one binary, `SPARKINFER_GU_GEMM_MIN_ROWS=6/4`, interleaved

| c | before (`=6`) | after (`=4`) | |
|---|--:|--:|--:|
| 16 | 523.5 | 523.4 | — |
| 8 | 321.8 | 321.6 | — |
| 4 | 191.0 | **209.1** | **+9.5%** |
| 2 | 137.0 | 136.9 | — |

Median of three interleaved rounds. Per round:

```text
c=16: before [523.4, 523.5]  after [523.2, 523.5]
c= 8: before [321.6, 321.8, 322.0]  after [321.4, 321.9]
c= 4: before [190.7, 191.0, 193.2]  after [208.7, 209.1, 209.4]
c= 2: before [136.8, 137.0, 137.5]  after [136.8, 136.9, 137.6]
```

c=2 is below the new threshold and c=8/c=16 were already above the old one, so all three are the
same binary doing the same thing — which is what those rows show.

`=6` reproduces main exactly, so both arms come out of one binary.

### Correctness

No kernel changes: this only moves which of two existing, already-shipping arms a four- or five-row
step takes. Both are in the tree today and each is used at some width — six rows and up has been on
the GEMM all along, and this widens that to four. `ctest` is green.

The threshold is deliberately 4 and not lower. Two rows measured **−7.4%** (137.1 → 126.9), so
pushing the GEMM further down would trade a c=4 gain for a c=2 regression:

```text
c=4   min_rows 6 -> 191.6 / 191.2      min_rows 2 -> 208.7 / 208.8
c=2   min_rows 6 -> 137.1 / 137.1      min_rows 2 -> 126.9
```
