### PR TITLE
perf(muse): hoist the Q4_K scale fold-in out of the per-element loop (1.14x concurrent decode @c32)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -3943,9 +3943,28 @@ void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned 
         }
         __syncthreads();
 
+        const int lnA = warp * 8 + tig * 2;
+        const float2 dmA = Wdm[lnA], dmB = Wdm[lnA + 1];
         #pragma unroll 1
         for (int g = 0; g < 8; g++) {
             const int kk = g * 32;
+            // The (dm, sc, m) triple depends only on the output COLUMN and the scale group, and
+            // (Ad, Asum) only on the row and the group -- neither depends on which of the four
+            // accumulator elements is being folded. Fetching them per element cost five shared
+            // loads per output element per group; hoisting collapses that to a handful per group.
+            // Ablating this fold-in measured it at 111 us of the kernel's 169.
+            const float sA = dmA.x * (float)Ssc[lnA][g],     mA = dmA.y * (float)Smn[lnA][g];
+            const float sB = dmB.x * (float)Ssc[lnA + 1][g], mB = dmB.y * (float)Smn[lnA + 1][g];
+            float adv[2][2], asv[2][2];
+            #pragma unroll
+            for (int ii = 0; ii < 2; ii++)
+                #pragma unroll
+                for (int eh = 0; eh < 2; eh++) {
+                    const int lmv = ii * 16 + grp + eh * 8;
+                    adv[ii][eh] = lmv < M ? Ad[lmv][g]   : 0.f;
+                    asv[ii][eh] = lmv < M ? Asum[lmv][g] : 0.f;
+                }
+
             unsigned af[2][4], bf0, bf1, bx, by;
             #pragma unroll
             for (int i = 0; i < 2; i++) {
@@ -3968,11 +3987,12 @@ void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned 
                 #pragma unroll
                 for (int e = 0; e < 4; e++) {
                     const int lm = i * 16 + grp + (e >> 1) * 8;
-                    const int ln = warp * 8 + tig * 2 + (e & 1);
                     if (lm >= M) continue;
-                    const float2 dm = Wdm[ln];
-                    facc[i][e] += dm.x * (float)Ssc[ln][g] * Ad[lm][g] * (float)acc[e]
-                                - dm.y * (float)Smn[ln][g] * Asum[lm][g];
+                    // same products in the same association as the per-element form:
+                    // ((dm.x*sc)*Ad)*acc - (dm.y*m)*Asum
+                    const int ep = e & 1;
+                    const float sc = ep ? sB : sA, mn = ep ? mB : mA;
+                    facc[i][e] += sc * adv[i][e >> 1] * (float)acc[e] - mn * asv[i][e >> 1];
                 }
             }
         }

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -2055,9 +2055,28 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
         }
         __syncthreads();
 
+        const int lnA = warp * 8 + tig * 2;
+        const float2 dmA = Wdm[lnA], dmB = Wdm[lnA + 1];
         #pragma unroll 1
         for (int g = 0; g < 8; g++) {
             const int kk = g * 32;
+            // The (dm, sc, m) triple depends only on the output COLUMN and the scale group, and
+            // (Ad, Asum) only on the row and the group -- neither depends on which of the four
+            // accumulator elements is being folded. Fetching them per element cost five shared
+            // loads per output element per group; hoisting collapses that to a handful per group.
+            // Ablating this fold-in measured it at 111 us of the kernel's 169.
+            const float sA = dmA.x * (float)Ssc[lnA][g],     mA = dmA.y * (float)Smn[lnA][g];
+            const float sB = dmB.x * (float)Ssc[lnA + 1][g], mB = dmB.y * (float)Smn[lnA + 1][g];
+            float adv[2][2], asv[2][2];
+            #pragma unroll
+            for (int ii = 0; ii < 2; ii++)
+                #pragma unroll
+                for (int eh = 0; eh < 2; eh++) {
+                    const int lmv = ii * 16 + grp + eh * 8;
+                    adv[ii][eh] = lmv < M ? Ad[lmv][g]   : 0.f;
+                    asv[ii][eh] = lmv < M ? Asum[lmv][g] : 0.f;
+                }
+
             unsigned af[2][4], bf[2];
             #pragma unroll
             for (int i = 0; i < 2; i++) {
@@ -2082,11 +2101,12 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
                 #pragma unroll
                 for (int e = 0; e < 4; e++) {
                     const int lm = i * 16 + grp + (e >> 1) * 8;
-                    const int ln = warp * 8 + tig * 2 + (e & 1);
                     if (lm >= M) continue;
-                    const float2 dm = Wdm[ln];
-                    facc[i][e] += dm.x * (float)Ssc[ln][g] * Ad[lm][g] * (float)acc[e]
-                                - dm.y * (float)Smn[ln][g] * Asum[lm][g];
+                    // same products in the same association as the per-element form:
+                    // ((dm.x*sc)*Ad)*acc - (dm.y*m)*Asum
+                    const int ep = e & 1;
+                    const float sc = ep ? sB : sA, mn = ep ? mB : mA;
+                    facc[i][e] += sc * adv[i][e >> 1] * (float)acc[e] - mn * asv[i][e >> 1];
                 }
             }
         }


### PR DESCRIPTION
## Summary

Both Q4_K tensor-core kernels folded the dequantisation scales in once per output **element**: five
shared-memory loads — `dm`, `sc`, `m`, `Ad`, `Asum` — for each of the four accumulator elements, of
each of two row halves, of each of eight scale groups, of every super-block.

None of those five depend on which element is being folded. `(dm, sc, m)` depend on the output
column and the scale group — `dm` not even on the group — and `(Ad, Asum)` on the row and the group.
Hoisting them collapses the fetch to a handful per group.

The arithmetic is left in the same association, so each product is formed from the same operands in
the same order: `((dm.x*sc)*Ad)*acc - (dm.y*m)*Asum`. The result is unchanged, which the bit-identity
check below shows rather than asserts.

**Why this loop and not another.** The down projection ran at 442 GB/s against a 1792 GB/s card with
its split-K already at its knee, so neither bandwidth nor occupancy explained it. Compiling out one
phase at a time at the real `6656 x 19968` shape located the cost:

| build | time |
|---|--:|
| full | 169.0 µs |
| staging + mma, no scale fold-in | **58.0 µs** |

The fold-in was ~111 µs of 169. Hoisted, the same shape measures **115.2 µs standalone — 1.47x**.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both** — the change is in code both models use and should help either

Reached through every Q4_K tensor-core arm a packed step uses: the dense FFN down projection, the
wide attention projections, and the LM head. All three share the fold-in, so all three change.

**Decode tok/s** (aggregate over 32 concurrent requests, `qwen3_gguf_cb_bench <gguf> 32 256 256 512`):

| | decode tok/s |
|---|--:|
| before (main) | 560.8 |
| after (this PR) | **593.7** |

**Prefill pp tok/s** (not targeted by this PR):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | — |
| after prefill (this PR) | — |

### Concurrent decode — two builds of one tree, interleaved

| c | before (main) | after | |
|---|--:|--:|--:|
| 32 | 758.3 | **865.3** | **+14.1%** |
| 16 | 560.8 | **593.7** | **+5.9%** |
| 8 | 329.5 | 328.6 | -0.3% |

Median per arm, interleaved at the build level (main, hoist, main, hoist) so slow drift in
the box shows up as disagreement within a pair rather than a win for whichever ran second.

```text
c=32: before [756.4, 756.7, 757.3, 759.3, 761.1, 807.7]  after [862.8, 864.5, 864.9, 865.7, 866.8, 922.1]
c=16: before [560.0, 560.1, 560.3, 561.2, 562.0, 562.0]  after [592.9, 592.9, 593.3, 594.1, 594.4, 594.6]
c= 8: before [329.3, 329.3, 329.4, 329.6, 329.7, 329.9]  after [328.4, 328.4, 328.5, 328.7, 328.7, 328.8]
```

c=8 is a real −0.3%, not noise: the two arms do not overlap. At eight rows the fold-in's
`lm >= M` guard already skips three quarters of the elements, so there is little redundant
fetching left to hoist, while the hoisted form still fills all four row slots predicated. It
is far inside REGRESS_TOL and the gain grows with width from there.

c=32 is bimodal on this box — both arms cluster into a slow and a fast group — so the median alone
would be a fair objection. It survives the split: the two modes are the same multiplicative factor
in each arm, and the gain is the same in either one.

```text
slow mode   main 756.4 756.7 757.3 759.3 761.1 (med 757.3)   ->  hoist 862.8 864.5 864.9 865.7 866.8 (med 864.9)   +14.2%
fast mode   main 807.7                                       ->  hoist 922.1                                       +14.2%
```

### Correctness

Bit-identical, and the check is against fixed references rather than a fresh comparison: the
existing MMA-vs-MMVQ dumps must reproduce the counts they produced before this change, element for
element. They do:

```text
down  6656x19968 M=32 : 212958 / 212992 (99.984%)   reference 212958 / 212992
wq    N=4096 K=6656   : 129536 / 131072 (98.828%)   reference 129536 / 131072
wo    N=6656 K=4096   : 212160 / 212992 (99.609%)   reference 212160 / 212992
```

Those percentages are the MMA path's standing (and unchanged) agreement with the dp4a MMVQ, which
reduces over K in a different order. What matters here is that they did not move.
