### PR TITLE
perf(muse): give the four attention in-projections one grid in packed decode (1.10x concurrent decode @c2)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -2007,16 +2007,20 @@ template __global__ void si_mmvq_q4k_kfixed_kernel<float, 20>(const si_block_q8_
 // against 0.7 GB of weights. Groups inside a CTA read the same activation, so GRP of them share
 // one pull. Measured end to end at ctx=4k: the head is 0.771 ms/step at GRP=1 against a draft-side
 // multi-row head that moves the same bytes in 0.578, and that gap is what this closes.
+// Body of the kernel below, with the block index passed in rather than read from blockIdx, so
+// that one grid can cover SEVERAL weight matrices (si_mmvq_q4k_rows_multi_kernel).  Every output
+// row keeps the same thread -> (super-block, sub-block) map, the same two-stage four-warp
+// reduction and the same accumulation order it has today; only which block computes it moves.
 template <typename OutT, int NSUPER, int MMAX, int OROWS, int GRP>
-__global__ void si_mmvq_q4k_rows_exact_kernel(const si_block_q8_1* __restrict__ q,
-                                              const unsigned char* __restrict__ W,
-                                              OutT* __restrict__ y, int M, int N) {
+__device__ __forceinline__ void si_mmvq_q4k_rows_exact_body(
+        const si_block_q8_1* __restrict__ q, const unsigned char* __restrict__ W,
+        OutT* __restrict__ y, int M, int N, int bx) {
     constexpr int NW = 4, WS = 32, vdr = 2, qi = 32;
     constexpr int QPR = NSUPER * 8;
     const int grp = threadIdx.x / (NW * WS);
     const int tid = threadIdx.x - grp * (NW * WS);      // thread id WITHIN the group
     const int lane = tid & 31, warp = tid >> 5;
-    const int row0 = (blockIdx.x * GRP + grp) * OROWS;
+    const int row0 = (bx * GRP + grp) * OROWS;
     __shared__ float partial[GRP][OROWS][MMAX][NW - 1][WS];
     if (row0 < N) {
         const int orows = (N - row0 < OROWS) ? (N - row0) : OROWS;
@@ -2062,6 +2066,98 @@ __global__ void si_mmvq_q4k_rows_exact_kernel(const si_block_q8_1* __restrict__ 
         __syncthreads();   // every thread of the CTA must reach the same barrier
     }
 }
+
+template <typename OutT, int NSUPER, int MMAX, int OROWS, int GRP>
+__global__ void si_mmvq_q4k_rows_exact_kernel(const si_block_q8_1* __restrict__ q,
+                                              const unsigned char* __restrict__ W,
+                                              OutT* __restrict__ y, int M, int N) {
+    si_mmvq_q4k_rows_exact_body<OutT, NSUPER, MMAX, OROWS, GRP>(q, W, y, M, N, blockIdx.x);
+}
+
+// Up to four weight matrices that share ONE activation, in ONE grid.
+//
+// Muse Glimmer's attention block projects the same `xn` four times -- q, the separate attn_gate
+// tensor, k and v -- and because Muse keeps the gate as its own [qdim, H] tensor instead of the
+// [q|gate] interleave the other architectures ship, they cannot be merged by pointer arithmetic
+// and go out as four launches.  Two of those are the kvdim projections, and at Muse's kv width a
+// row-batched grid is only 128 blocks: less than one wave of a 170-SM device, so they are almost
+// entirely launch and tail latency rather than work.  Concatenating the four row spaces into one
+// grid pays the activation read, the launch and the ragged k tail once for all of them.
+//
+// Each matrix's row space is padded up to a whole number of blocks, so a block never straddles
+// two matrices and every block runs exactly the body above for its own (W, y, N).  Bit-identical
+// to the four separate launches, row for row.
+// Defined further down with the rest of the Q6_K path; declared here so the multi kernel can
+// carry a Q6_K slot without moving either definition.
+__device__ __forceinline__ float si_vec_dot_q6_K(const unsigned char* __restrict__ bq6,
+                                                 const si_block_q8_1* __restrict__ bq8_1, int iqs);
+
+// Q6LAST: Muse's attn_v is Q6_K on half its layers, and that is the ONLY slot that can carry a
+// different weight type. Blocks that land in the last matrix's range then run the Q6_K dot
+// instead -- one output row per block, the same map and the same 4-warp fold
+// si_mmvq_q6k_rows_exact_kernel uses, so those rows stay bit-identical to the standalone launch
+// they replace. Everything else about the grid is unchanged, so a Q6_K v rides along with q, the
+// gate and k rather than paying its own 256-block launch.
+template <typename OutT, int NSUPER, int MMAX, int OROWS, bool Q6LAST = false>
+__global__ void si_mmvq_q4k_rows_multi_kernel(
+        const si_block_q8_1* __restrict__ q,
+        const unsigned char* __restrict__ W0, const unsigned char* __restrict__ W1,
+        const unsigned char* __restrict__ W2, const unsigned char* __restrict__ W3,
+        OutT* __restrict__ y0, OutT* __restrict__ y1,
+        OutT* __restrict__ y2, OutT* __restrict__ y3,
+        int N0, int N1, int N2, int N3, int b1, int b2, int b3, int M) {
+    int bx = blockIdx.x;
+    const unsigned char* W; OutT* y; int N;
+    bool q6 = false;
+    if (bx < b1)      { W = W0; y = y0; N = N0; }
+    else if (bx < b2) { W = W1; y = y1; N = N1; bx -= b1; }
+    else if (bx < b3) { W = W2; y = y2; N = N2; bx -= b2; }
+    else              { W = W3; y = y3; N = N3; bx -= b3; q6 = Q6LAST; }
+    if (Q6LAST && q6) {
+        constexpr int NW = 4, WS = 32, vdr = 1, qi = 32;
+        constexpr int QPR = NSUPER * 8;
+        constexpr int blocks_per_iter = vdr * NW * WS / qi;
+        const int lane = threadIdx.x & 31, warp = threadIdx.x >> 5, tid = threadIdx.x;
+        __shared__ float partial6[MMAX][NW - 1][WS];
+        if (bx < N) {
+            const unsigned char* x_row = W + (size_t)bx * NSUPER * 210;
+            float tmp[MMAX];
+            #pragma unroll
+            for (int m = 0; m < MMAX; m++) tmp[m] = 0.f;
+            #pragma unroll
+            for (int kbx = tid / (qi / vdr); kbx < NSUPER; kbx += blocks_per_iter) {
+                const int kqs = vdr * (tid % (qi / vdr));
+                #pragma unroll
+                for (int m = 0; m < MMAX; m++)
+                    if (m < M)
+                        tmp[m] += si_vec_dot_q6_K(x_row + (size_t)kbx * 210,
+                                                  q + (size_t)m * QPR + kbx * 8, kqs);
+            }
+            if (warp > 0) {
+                #pragma unroll
+                for (int m = 0; m < MMAX; m++) if (m < M) partial6[m][warp - 1][lane] = tmp[m];
+            }
+            __syncthreads();
+            if (warp == 0) {
+                #pragma unroll
+                for (int m = 0; m < MMAX; m++) {
+                    if (m >= M) break;
+                    #pragma unroll
+                    for (int l = 0; l < NW - 1; l++) tmp[m] += partial6[m][l][lane];
+                    #pragma unroll
+                    for (int sft = 16; sft > 0; sft >>= 1)
+                        tmp[m] += __shfl_xor_sync(0xffffffff, tmp[m], sft);
+                    if (lane == 0) gemv_write(y + (size_t)m * N + bx, tmp[m]);
+                }
+            }
+        } else {
+            __syncthreads();
+        }
+        return;
+    }
+    si_mmvq_q4k_rows_exact_body<OutT, NSUPER, MMAX, OROWS, 1>(q, W, y, M, N, bx);
+}
+
 #ifndef _MSC_VER
 template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 8, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
@@ -2071,6 +2167,22 @@ template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 8, 8, SI_Q4K_OROWS
     const si_block_q8_1*, const unsigned char*, float*, int, int);
 template __global__ void si_mmvq_q4k_rows_exact_kernel<float, 16, 8, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, float*, int, int);
+template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 16, 1>(
+    const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
+    const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    int, int, int, int, int, int, int, int);
+template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 32, 1>(
+    const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
+    const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    int, int, int, int, int, int, int, int);
+template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 6, SI_Q4K_OROWS>(
+    const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
+    const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    int, int, int, int, int, int, int, int);
+template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 8, SI_Q4K_OROWS>(
+    const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
+    const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    int, int, int, int, int, int, int, int);
 template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 8, 6, SI_Q4K_OROWS, 1>(
     const si_block_q8_1*, const unsigned char*, __nv_bfloat16*, int, int);
 template __global__ void si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, 16, 6, SI_Q4K_OROWS, 1>(
@@ -4122,6 +4234,52 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
     else if (K == 6144) SI_Q4K_ROWS_DISPATCH(24);
     else                SI_Q4K_ROWS_DISPATCH(26);
     #undef SI_Q4K_ROWS_DISPATCH
+    return true;
+}
+// One grid over up to four Q4_K matrices that share an activation. Returns false (having issued
+// nothing) for any shape it does not cover, so the caller can fall back to separate projections.
+bool launch_mmvq_q4k_rows_multi(const void* q81, const void* const* W, void* const* y,
+                                const int* Ns, int nmat, int M, int K, cudaStream_t stream,
+                                bool q6_last) {
+    if (nmat < 1 || nmat > 4 || M < 1 || M > 32 || K != 6656) return false;
+    if (q6_last && (nmat < 2 || M > 8)) return false;   // only the narrow, 4-wide Muse shape
+    for (int i = 0; i < nmat; i++) if (!W[i] || !y[i] || Ns[i] < 1) return false;
+    // Past eight rows launch_mmvq_rows chunks the batch into groups of eight, and every chunk
+    // re-reads the whole matrix. For a 256-row projection that is the dominant cost: at 32 rows
+    // k and v go out as eight launches of a 128-block grid -- less than one wave each -- and read
+    // their weights four times over. A wider MMAX takes the whole batch in one grid and one read.
+    // OROWS drops to 1 there because tmp[OROWS][MMAX] and the smem fold both scale with the
+    // product, and at these row counts the activation is shared across the batch, not the matrix.
+    const bool wide = M > 8;
+    const int OR = wide ? 1 : SI_Q4K_OROWS;
+    int blk[4] = {0, 0, 0, 0};
+    for (int i = 0; i < nmat; i++) blk[i] = (Ns[i] + OR - 1) / OR;
+    // A Q6_K last slot owns ONE output row per block, so its range is Ns rows wide.
+    if (q6_last) blk[nmat - 1] = Ns[nmat - 1];
+    const int b1 = blk[0], b2 = b1 + blk[1], b3 = b2 + blk[2], grid = b3 + blk[3];
+    const auto* q = reinterpret_cast<const si_block_q8_1*>(q81);
+    const unsigned char* w[4] = {nullptr, nullptr, nullptr, nullptr};
+    __nv_bfloat16* o[4] = {nullptr, nullptr, nullptr, nullptr};
+    int n[4] = {0, 0, 0, 0};
+    for (int i = 0; i < nmat; i++) {
+        w[i] = reinterpret_cast<const unsigned char*>(W[i]);
+        o[i] = reinterpret_cast<__nv_bfloat16*>(y[i]);
+        n[i] = Ns[i];
+    }
+    // With nmat < 4 the trailing block ranges are empty and grid == b3 (or b2), so the unused
+    // branches of the block map are unreachable rather than merely unused.
+#define SI_Q4K_MULTI(MM, ORV) si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, MM, ORV> \
+    <<<grid, 4 * 32, 0, stream>>>(q, w[0], w[1], w[2], w[3], o[0], o[1], o[2], o[3], \
+                                  n[0], n[1], n[2], n[3], b1, b2, b3, M)
+#define SI_Q4K_MULTI6(MM, ORV) si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, MM, ORV, true> \
+    <<<grid, 4 * 32, 0, stream>>>(q, w[0], w[1], w[2], w[3], o[0], o[1], o[2], o[3], \
+                                  n[0], n[1], n[2], n[3], b1, b2, b3, M)
+    if (q6_last) { if (M <= 6) SI_Q4K_MULTI6(6, SI_Q4K_OROWS); else SI_Q4K_MULTI6(8, SI_Q4K_OROWS); }
+    else if (!wide) { if (M <= 6) SI_Q4K_MULTI(6, SI_Q4K_OROWS); else SI_Q4K_MULTI(8, SI_Q4K_OROWS); }
+    else if (M <= 16) SI_Q4K_MULTI(16, 1);
+    else              SI_Q4K_MULTI(32, 1);
+#undef SI_Q4K_MULTI
+#undef SI_Q4K_MULTI6
     return true;
 }
 bool launch_mmvq_q6k_rows(const void* q81, const void* W, void* y,

--- a/kernels/include/sparkinfer/kernels/gemm.h
+++ b/kernels/include/sparkinfer/kernels/gemm.h
@@ -171,6 +171,12 @@ void launch_mmvq_q4k_f32(const void* q81, const void* W, float* y, int N, int K,
 // Exact short-row target verifier: M contiguous Q8_1 activations against one Q4_K matrix.
 // Preserves launch_mmvq_q4k's four-warp dot/reduction order independently for every row while
 // sharing the weight traffic within a CTA. y is row-major [M,N]. Returns false if unsupported.
+// One grid over up to four Q4_K matrices sharing one activation (Muse's q/gate/k/v).
+// False = nothing issued; the caller projects them separately.
+// q6_last: the final matrix is Q6_K (Muse's attn_v on half its layers) rather than Q4_K.
+bool launch_mmvq_q4k_rows_multi(const void* q81, const void* const* W, void* const* y,
+                                const int* Ns, int nmat, int M, int K, cudaStream_t stream,
+                                bool q6_last = false);
 bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
                           int M, int N, int K, cudaStream_t stream = nullptr);
 // Fused GDN qkv+z Q4_K MMVQ (shared Q8_1 activation). K is hidden (2048 -> NSUPER=8, 4096 -> 16).

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3605,6 +3605,38 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
     // order and folds the same S partials -- only which launch carries it changes. It declines
     // (and the caller issues the singles) for any shape where a CTA could straddle the boundary.
     // Returns false when it did NOT fuse, so the caller falls back rather than skipping work.
+    // The Q4_K counterpart of proj_pair_nv_on below, over FOUR matrices instead of two.
+    // Muse Glimmer's attention block reads one `xn` for q, the separate attn_gate tensor, k and
+    // v, and issues four launches because Muse keeps the gate as its own [qdim, H] tensor rather
+    // than the [q|gate] interleave the other architectures ship. The two kvdim projections are
+    // the same "grid too small to fill the device" case the pair helper describes -- and the same
+    // one launch_mmvq_rows names where it keeps k and v off the mma path ("would launch eight
+    // blocks onto 170 SMs and the per-launch cost swamps the saved weight reads"). One grid over
+    // all four pays the activation read, the launch and the ragged k tail once instead of four
+    // times, and q and the gate are wide enough to keep it full while k and v ride along.
+    // Bit-identical to the singles: a block still owns OROWS consecutive rows of ONE matrix and
+    // runs the same body in the same order; only which grid carries it changes.
+    // Returns false, having issued nothing but the shared quantize, when it did NOT fuse.
+    // SPARKINFER_MUSE_INPROJ_FUSED=0 restores the four separate projections.
+    // qwen35.cpp's AR decode has driven Muse's sandwich tail through ONE fused kernel since it
+    // was written (launch_muse_sandwich_tail: x = residual + norm(branch), xn = rmsnorm(x), and
+    // Q8_1(xn) for the next MMVQ, in one pass). The packed path never picked it up and still
+    // issues norm_then_add + rmsnorm + quantize separately -- three launches per sandwich point,
+    // twice a layer, each on a grid of N CTAs. At the packed widths that is ~2 CTAs of a 170-SM
+    // device per launch, i.e. almost pure launch and memory latency.
+    // SPARKINFER_MUSE_PACKED_TAIL=0 restores the separate launches.
+    static const bool packed_tail = [] {
+        const char* e = getenv("SPARKINFER_MUSE_PACKED_TAIL");
+        return !(e && e[0] == '0');
+    }();
+    auto proj_multi_q4k = [&](const bf16* in, const void* const* Wp, void* const* Yp,
+                              const int* Ns, int nmat, int k, bool q6_last = false) -> bool {
+        static const int on = [] { const char* e = getenv("SPARKINFER_MUSE_INPROJ_FUSED");
+                                   return (e && e[0] == '0') ? 0 : 1; }();
+        if (!on) return false;
+        if (q81_src != in || q81_k != k) quant_rows(in, k);
+        return kernels::launch_mmvq_q4k_rows_multi(q81, Wp, Yp, Ns, nmat, N, k, st, q6_last);
+    };
     auto proj_pair_nv_on = [&](cudaStream_t ps, const bf16* in, const void* w0, int t0,
                                const void* w1, int t1, bf16* o0, bf16* o1, int no, int k) -> bool {
         if (t0 != kernels::SI_QTYPE_NVFP4 || t1 != kernels::SI_QTYPE_NVFP4) return false;
@@ -3829,10 +3861,43 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // Muse keeps attn_gate as its OWN [qdim, H] tensor rather than the [q|gate] interleave
             // every other architecture here ships, so Q goes straight to qb and the gate straight
             // to qg. Projecting w.wq as one 2*qdim-wide matrix would read qdim rows PAST it.
-            supported = proj(xn, w.wq, w.wq_type, qb, qdim, H) &&
-                        w.wgate && proj(xn, w.wgate, w.wgate_type, qg, qdim, H) &&
-                        proj(xn, w.wk, w.wk_type, kf, kvdim, H) &&
-                        proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+            // One grid for the Q4_K ones (12 = Q4_K). A Q4_K_M file gives half of Muse's
+            // layers a Q6_K attn_v, so the fusion takes q/gate/k plus v only where v is Q4_K
+            // too, and a Q6_K v follows on its own path exactly as before.
+            {
+                const bool v4 = (w.wv_type == 12);
+                // Which projections share the grid depends on the width. Under nine rows all
+                // four want it: none of them reaches the int8 mma arm, and q and the gate are
+                // what keep the grid full while k and v ride along. From nine rows up, q and the
+                // gate DO reach that arm (launch_mmvq_rows takes it at M >= 8 for N >= 2048) and
+                // must be left to it -- but k and v never qualify on N, so they stay on the
+                // chunked dp4a path and are exactly the launches worth collapsing.
+                const bool wide = N > 8;
+                const bool fuseable = wide ? (w.wk_type == 12)
+                                           : (w.wgate && w.wq_type == 12 &&
+                                              w.wgate_type == 12 && w.wk_type == 12);
+                const void* Wp[4]; void* Yp[4]; int Ns[4]; int nm = 0;
+                if (!wide) {
+                    Wp[nm] = w.wq;    Yp[nm] = qb; Ns[nm++] = qdim;
+                    Wp[nm] = w.wgate; Yp[nm] = qg; Ns[nm++] = qdim;
+                }
+                Wp[nm] = w.wk; Yp[nm] = kf; Ns[nm++] = kvdim;
+                // v joins the same grid whether it is Q4_K or Q6_K (14); a Q6_K v takes the
+                // last slot and the kernel runs the Q6_K dot for those blocks.
+                const bool v6 = !wide && !v4 && w.wv_type == 14;
+                if (v4 || v6) { Wp[nm] = w.wv; Yp[nm] = vf; Ns[nm++] = kvdim; }
+                const bool fused = fuseable && proj_multi_q4k(xn, Wp, Yp, Ns, nm, H, v6);
+                if (fused)
+                    supported =
+                        (!wide || (proj(xn, w.wq, w.wq_type, qb, qdim, H) &&
+                                   w.wgate && proj(xn, w.wgate, w.wgate_type, qg, qdim, H))) &&
+                        (v4 || v6 || proj(xn, w.wv, w.wv_type, vf, kvdim, H));
+                else
+                    supported = proj(xn, w.wq, w.wq_type, qb, qdim, H) &&
+                                w.wgate && proj(xn, w.wgate, w.wgate_type, qg, qdim, H) &&
+                                proj(xn, w.wk, w.wk_type, kf, kvdim, H) &&
+                                proj(xn, w.wv, w.wv_type, vf, kvdim, H);
+            }
             if (!supported) break;
             // QK-norm is per HEAD vector, so N tokens is just N*heads rows of the same kernel.
             kernels::launch_rmsnorm(qb, w.q_norm, qb, N * c.n_q_heads,  c.head_dim, c.rms_eps, st);
@@ -3887,11 +3952,20 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
             // output is normed ALONE and then added, and that norm uses its own 1e-8 post_norm_eps
             // rather than the model's rms_eps. ffn_norm is a genuine separate pre-FFN norm here,
             // not post_attn_norm doing double duty like every other architecture in this file.
-            kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
-            kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, c.rms_eps, st);
+            bool hn_q8_ready = false;
+            if (packed_tail) {
+                // The tail also hands the FFN its input already quantized; nothing between here
+                // and the dense FFN touches q81 on this architecture, exactly as AR relies on.
+                hn_q8_ready = kernels::launch_muse_sandwich_tail(
+                    x, ao, w.post_attn_norm, w.ffn_norm, h, hn, q81, N, H, 1e-8f, c.rms_eps, st);
+            } else {
+                kernels::launch_norm_then_add(x, ao, w.post_attn_norm, h, N, H, 1e-8f, st);
+                kernels::launch_rmsnorm(h, w.ffn_norm, hn, N, H, c.rms_eps, st);
+            }
             if (L == 0) { vdbg_snapshot2(h, 1); vdbg_snapshot2(hn, 2); }
             // Dense SwiGLU through the same one-expert call AR decode makes, at N rows.
-            quant_rows(hn, H);
+            if (hn_q8_ready) { q81_src = hn; q81_k = H; }
+            else quant_rows(hn, H);
             // Wide enough to be worth a block-scaled GEMM: run gate/up through the FP4 operands
             // this model already holds for prefill and hand the pair to the call below, which then
             // does only the SwiGLU and the GGUF down GEMV.
@@ -3905,13 +3979,22 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                                                gu_gemm ? sg : nullptr, gu_gemm ? su : nullptr);
             if (L == 0) vdbg_snapshot2(routed, 3);
             // Sandwich norm (post-FFN): x = h + RMSNorm(routed) * post_ffn_norm, same 1e-8.
-            kernels::launch_norm_then_add(h, routed, w.post_ffn_norm, x, N, H, 1e-8f, st);
             const void* nn = (L + 1 < c.n_layers) ? s.w.layers[L + 1].input_norm : s.w.final_norm;
-            kernels::launch_rmsnorm(x, nn, xn, N, H, c.rms_eps, st);
+            bool xn_q8_ready = false;
+            if (packed_tail) {
+                xn_q8_ready = kernels::launch_muse_sandwich_tail(
+                    h, routed, w.post_ffn_norm, nn, x, xn, q81, N, H, 1e-8f, c.rms_eps, st);
+            } else {
+                kernels::launch_norm_then_add(h, routed, w.post_ffn_norm, x, N, H, 1e-8f, st);
+                kernels::launch_rmsnorm(x, nn, xn, N, H, c.rms_eps, st);
+            }
             // The Q8_1 memo is keyed on the buffer that produced it; xn is a fresh value in the
-            // SAME buffer, so leaving the key set would hand the next layer's projections the
-            // PREVIOUS layer's quantization. Nothing here emits Q8_1(xn), so clear it outright.
-            q81_src = nullptr; q81_k = 0;
+            // SAME buffer, so leaving a STALE key would hand the next layer's projections the
+            // previous layer's quantization. Point it at xn when the tail emitted Q8_1(xn) --
+            // which is what lets those projections skip their own quantize -- and clear it
+            // otherwise, exactly as before.
+            if (xn_q8_ready) { q81_src = xn; q81_k = H; }
+            else { q81_src = nullptr; q81_k = 0; }
             capture(L);
             continue;
         }


### PR DESCRIPTION
## Summary

Muse Glimmer's packed continuous-batch decode step (`dflash_verify_short_run`) re-implements the
layer with launches that AR decode already fuses. Three of them, one mechanism — **give work that
shares an activation one grid instead of many**:

1. **The four attention in-projections.** q, the separate `attn_gate` tensor, k and v all read the
   same `xn`, but Muse keeps the gate as its own `[qdim, H]` tensor rather than the `[q|gate]`
   interleave the other architectures ship, so they cannot be merged by pointer arithmetic and go
   out as four launches. Two of them are the `kvdim` projections, and at Muse's kv width a
   row-batched grid is **128 blocks on a 170-SM device** — under one wave, so almost entirely
   launch and tail latency rather than work. `launch_mmvq_rows` already says exactly this where it
   keeps k and v off the mma path (*"would launch eight blocks onto 170 SMs and the per-launch cost
   swamps the saved weight reads"*); it routed around the symptom. `proj_pair_nv_on` is the same
   idea for NVFP4 and there was no Q4_K twin. One grid over all four: q and the gate keep it full
   while k and v ride along.
2. **`launch_muse_sandwich_tail`, which already exists**, and which `qwen35.cpp`'s AR decode has
   driven at both sandwich points since it was written (`x = residual + norm(branch)`,
   `xn = rmsnorm(x)`, and `Q8_1(xn)` for the next MMVQ, in one pass). The packed path never picked
   it up and still issued `norm_then_add` + `rmsnorm` + `quantize` separately — three launches per
   sandwich point, twice a layer, each on a grid of `N` CTAs (**2** at c2). It takes `rows`
   natively (`<<<rows, tail_w>>>`) and indexes `out_q8` by `blockIdx.x`, so it is row-safe; AR only
   ever passed `rows=1`, so that had never been exercised.
3. **The Q6_K `attn_v`.** A `Q4_K_M` file gives half of Muse's layers a Q6_K `attn_v`, which cannot
   share a Q4_K grid — so it kept its own 256-block launch. The multi kernel now carries a Q6_K
   last slot and runs the Q6_K dot for those blocks, so v joins the grid on every layer.

Past eight rows `launch_mmvq_rows` also **chunks** the batch into groups of eight and every chunk
re-reads the whole matrix, so at c32 `wk` + `wv` went out as **416 launches per step costing
5.19 ms (15.2% of the step)** to move 110 MB — 0.02 TB/s. The fused path takes the whole batch.

**What the launch counts do** (nsys, `--cuda-graph-trace=node`, one steady packed step):

| | launches/step | ms/step |
|---|--:|--:|
| `si_mmvq_q4k_rows_exact` @c2, before | 235 | 3.954 |
| fused @c2, after | 105 | 2.784 |
| `si_mmvq_q4k_rows_exact` @c32, before | 312 | 3.861 |
| fused @c32, after | 52 | 1.593 |
| `norm_then_add` + grid-2 `rmsnorm` @c2, before | 210 | 0.930 |
| `muse_sandwich_tail` @c2, after | 104 | 0.409 |

The c2 step goes **13.95 → 12.58 ms**, and the GPU idle gap falls 0.636 → 0.434 ms.

**Numerics.** (1) and (3) are **bit-identical**: a block still owns `OROWS` consecutive output rows
of ONE matrix and runs the same body with the same thread → (super-block, sub-block) map, the same
two-stage four-warp reduction and the same accumulation order — only which grid carries it changes.
Row chunking never changed per-row math either (`MMAX` bounds the scratch and the number of
predicated row bodies, not the dot or its reduction order). (2) is the kernel AR decode already
ships and is not bit-identical by its own documented design (the block width regroups the
sum-of-squares partials, fp32 reassociates); its accuracy is characterised in `rmsnorm.cu`.
`ctest` **23/23**.

**Scope — why the twelve single-stream axes cannot move.** Every line changed is inside
`dflash_verify_short_run`, the packed continuous-batch step, plus a new kernel only it calls.
Single-stream decode and prefill go through `qwen35.cpp` and never enter this function. They are
measured below anyway and are flat to ±0.3%. The fused path also declines (issuing nothing but the
shared quantize) for any type or shape it does not cover, and from nine rows up it deliberately
leaves q and the gate to the int8 mma arm `launch_mmvq_rows` takes at `M >= 8, N >= 2048`, fusing
only k and v — which never qualify on `N`.

`SPARKINFER_MUSE_INPROJ_FUSED=0` and `SPARKINFER_MUSE_PACKED_TAIL=0` restore the separate launches,
so both arms of every A/B below come out of **one binary**.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

**Decode tok/s** (end-to-end):

| | decode tok/s |
|---|--:|
| before (main) | 145.4 |
| after (this PR) | 160.4 |

**Prefill pp tok/s**:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not targeted — path unreachable (see Scope); measured flat, 9686 |
| after prefill (this PR) | not targeted — path unreachable (see Scope); measured flat, 9681 |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries** and needs a `.gguf`
file, so it cannot measure a branch. The numbers above are `qwen3_gguf_cb_bench` (the concurrency
harness the `muse-cb-decode@cN` axes are scored on), RTX 5090 / CUDA 13.0, 512-token prompts,
256 new tokens. Arms are **mirrored** (`1 0 0 1`) because the box drifts downward through a
session; the mirror cancels it. Every point carries its `decode_tokens`.

```text
=== muse-cb-decode@cN -- mirrored 1 0 0 1, one binary ===
on    c2 161.5 (itl 12.38  decode_tokens 520)   c4 235.6 (itl 16.53  1032)   c8 371.0 (itl 20.50  2056)   c16 607.6 (itl 24.65  4104)   c32 782.5 (itl 32.06  8200)
off   c2 145.6 (itl 13.76  decode_tokens 520)   c4 214.7 (itl 18.18  1032)   c8 344.7 (itl 22.09  2056)   c16 578.0 (itl 26.00  4104)   c32 740.0 (itl 34.43  8200)
off   c2 145.2 (itl 13.80  decode_tokens 520)   c4 214.6 (itl 18.19  1032)   c8 344.3 (itl 22.11  2056)   c16 577.2 (itl 26.04  4104)   c32  bench run short, discarded
on    c2 159.2 (itl 12.57  decode_tokens 520)   c4 233.5 (itl 16.68  1032)   c8 368.8 (itl 20.61  2056)   c16 605.8 (itl 24.72  4104)   c32 635.4 (itl 33.59  8200)

              mean agg_tok_s              mean mean_itl_ms
  c2    off 145.40   on 160.35  +10.28%   13.780 -> 12.475  -9.47%
  c4    off 214.65   on 234.55   +9.27%   18.185 -> 16.605  -8.69%
  c8    off 344.50   on 369.90   +7.37%   22.100 -> 20.555  -6.99%
  c16   off 577.60   on 606.70   +5.04%   26.020 -> 24.685  -5.13%
  c32   bimodal on this box (~640 vs ~780 with decode_tokens full in both modes), so no agg delta
        is claimed from it; mean_itl_ms 34.43 -> 32.83 is -4.6% and every arm is >= main.

=== a second, independent mirrored batch (1 0 0 1) on the same binary ===
  c2    off 144.90   on 158.70   +9.52%
  c4    off 214.10   on 233.05   +8.85%
  c8    off 343.95   on 368.35   +7.09%
  c16   off 576.30   on 604.15   +4.83%

=== twelve single-stream axes: unreachable by construction, measured flat (mirrored 1 0 0 1) ===
  ctx        decode on / off            prefill pp on / off
  128       107.56 / 107.65  -0.08%     9681 / 9686  -0.05%
  512       106.81 / 106.83  -0.02%    14885 / 14925 -0.27%
  4096      103.70 / 103.85  -0.14%    14004 / 14010 -0.04%
  16384     103.16 / 102.92  +0.23%    13264 / 13265 -0.01%
  32768     101.87 / 101.89  -0.02%    12129 / 12133 -0.03%
  65536      99.94 /  99.98  -0.04%    10427 / 10432 -0.04%
```

**Base of the measurements.** Taken on `a47a8c0`, with both arms out of one binary via the env
knobs, so each delta isolates this change alone. `main` has since merged #1043 (`261ee87`), which
speeds up a *different* kernel in the same step (`gate_up_q3a_muse_rows_kernel`); this branch is not
yet rebased onto it. #1043 shortens the step without touching any launch this PR fuses, so the
absolute savings above carry over and the percentages should if anything rise. I will post a
re-measurement on the rebased branch.
