### PR TITLE
perf(muse): specialize exact two-row packed kernels (+3.42% c2 locally)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -4203,8 +4203,9 @@ bool launch_mmvq_q4k_mma_head_f32(const void* q81, const void* W, float* y,
     return true;
 }
 
-bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
-                          int M, int N, int K, cudaStream_t stream) {
+static bool launch_mmvq_q4k_rows_impl(const void* q81, const void* W, void* y,
+                                      int M, int N, int K, cudaStream_t stream,
+                                      bool allow_exact_m2) {
     // K is templated (KB = K/256 bounds the per-thread accumulators), so only instantiated widths
     // can run. It was 2048/4096 -- Qwen3.6-35B-A3B and Qwythos. Qwen3.8-27B is hidden=5120 with a
     // 6144-wide attention output, so EVERY Q4_K attention projection in that model was refused
@@ -4223,10 +4224,22 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
     const auto* w = reinterpret_cast<const unsigned char*>(W);
     auto* out = reinterpret_cast<__nv_bfloat16*>(y);
     const int grid = (N + SI_Q4K_OROWS - 1) / SI_Q4K_OROWS;
+    // Packed two-request decode used the MMAX=6 verify body, carrying three times the row-local
+    // accumulators it can touch. Keep the specialization exact: wider requests, including an M=2
+    // tail produced while chunking M>8, retain the established 6/8 dispatch below.
+    // SPARKINFER_MMVQ_ROWS_M2=0 restores that dispatch for a same-binary A/B.
+    static const int rows_m2 = [] {
+        const char* e = getenv("SPARKINFER_MMVQ_ROWS_M2");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
     #define SI_Q4K_ROWS_DISPATCH(KB) \
         do { \
-            if (M <= 6) si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 6, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
-            else        si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 8, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            if (allow_exact_m2 && rows_m2 && M == 2) \
+                si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 2, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            else if (M <= 6) \
+                si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 6, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
+            else \
+                si_mmvq_q4k_rows_exact_kernel<__nv_bfloat16, KB, 8, SI_Q4K_OROWS, 1><<<grid, 4 * 32, 0, stream>>>(q, w, out, M, N); \
         } while (0)
     if      (K == 2048) SI_Q4K_ROWS_DISPATCH(8);
     else if (K == 4096) SI_Q4K_ROWS_DISPATCH(16);
@@ -4235,6 +4248,11 @@ bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
     else                SI_Q4K_ROWS_DISPATCH(26);
     #undef SI_Q4K_ROWS_DISPATCH
     return true;
+}
+bool launch_mmvq_q4k_rows(const void* q81, const void* W, void* y,
+                          int M, int N, int K, cudaStream_t stream) {
+    return launch_mmvq_q4k_rows_impl(q81, W, y, M, N, K, stream,
+                                     /*allow_exact_m2=*/true);
 }
 // One grid over up to four Q4_K matrices that share an activation. Returns false (having issued
 // nothing) for any shape it does not cover, so the caller can fall back to separate projections.
@@ -4324,8 +4342,9 @@ bool launch_mmvq_q80_rows(const void* q81, const void* W, void* y,
 #undef SI_Q80_ROWS
     return true;
 }
-bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
-                      int M, int N, int K, cudaStream_t stream) {
+static bool launch_mmvq_rows_impl(int qtype, const void* q81, const void* W, void* y,
+                                   int M, int N, int K, cudaStream_t stream,
+                                   bool allow_exact_m2) {
     // Every rows kernel below carries exact, compile-time-bounded row bodies only to M=8, so a
     // wider batch used to be refused outright -- and a refusal here declines the WHOLE packed
     // forward, which then decodes its rows one at a time and re-reads every weight once per row.
@@ -4359,18 +4378,28 @@ bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
     if (M > 8) {
         for (int r0 = 0; r0 < M; r0 += 8) {
             const int m = (M - r0) < 8 ? (M - r0) : 8;
-            if (!launch_mmvq_rows(qtype,
-                                  reinterpret_cast<const si_block_q8_1*>(q81)
-                                      + (size_t)r0 * (size_t)(K >> 5),
-                                  W, reinterpret_cast<__nv_bfloat16*>(y) + (size_t)r0 * N,
-                                  m, N, K, stream)) return false;
+            const auto* qr = reinterpret_cast<const si_block_q8_1*>(q81)
+                           + (size_t)r0 * (size_t)(K >> 5);
+            auto* yr = reinterpret_cast<__nv_bfloat16*>(y) + (size_t)r0 * N;
+            // A two-row tail belongs to a wider request and therefore stays on the old MMAX=6
+            // body. Only a top-level M==2 request opts into the narrow specialization.
+            // Re-enter the generic dispatcher so each chunk still gets its existing MMA
+            // attempt when the full request exceeded the MMA row or scratch limit.
+            const bool launched = launch_mmvq_rows_impl(qtype, qr, W, yr, m, N, K, stream,
+                                                         /*allow_exact_m2=*/false);
+            if (!launched) return false;
         }
         return true;
     }
-    if (qtype == 12) return launch_mmvq_q4k_rows(q81, W, y, M, N, K, stream);
+    if (qtype == 12) return launch_mmvq_q4k_rows_impl(q81, W, y, M, N, K, stream, allow_exact_m2);
     if (qtype == 14) return launch_mmvq_q6k_rows(q81, W, y, M, N, K, stream);
     if (qtype == 8)  return launch_mmvq_q80_rows(q81, W, y, M, N, K, stream);
     return false;
+}
+bool launch_mmvq_rows(int qtype, const void* q81, const void* W, void* y,
+                      int M, int N, int K, cudaStream_t stream) {
+    return launch_mmvq_rows_impl(qtype, q81, W, y, M, N, K, stream,
+                                  /*allow_exact_m2=*/true);
 }
 bool launch_mmvq_rows_f32(int qtype, const void* q81, const void* W, float* y,
                           int M, int N, int K, cudaStream_t stream) {

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -2691,15 +2691,31 @@ void launch_moe_expert_ffn_q4k(
                     const char* e = getenv("SPARKINFER_MUSE_Q3A_GU2");
                     q3_gu2 = (e && e[0] == '0') ? 0 : 1;
                 }
-                constexpr int MMAX = 8;
-                for (int t0 = 0; t0 < num_tokens; t0 += MMAX) {
-                    const int m = (num_tokens - t0) < MMAX ? (num_tokens - t0) : MMAX;
+                // The c2 packed step used an MMAX=8 body, reserving row-local registers and
+                // shared storage for six rows it cannot touch. Specialize only a complete
+                // two-token request; an M=2 tail from a wider request remains on MMAX=8.
+                // SPARKINFER_MUSE_Q3A_ROWS_M2=0 restores the old body for a same-binary A/B.
+                static const int q3_rows_m2 = [] {
+                    const char* e = getenv("SPARKINFER_MUSE_Q3A_ROWS_M2");
+                    return (e && e[0] == '0') ? 0 : 1;
+                }();
+                if (q3_rows_m2 && num_tokens == 2) {
                     launch_pdl_kernel(gu_pdl, dim3(19968), dim3(4 * 32), 0, stream,
-                        gate_up_q3a_muse_rows_kernel<6656, 19968, MMAX>,
-                        q + (size_t)t0 * (6656 >> 5),
+                        gate_up_q3a_muse_rows_kernel<6656, 19968, 2>, q,
                         reinterpret_cast<const unsigned char*>(gate_q),
                         reinterpret_cast<const unsigned char*>(up_q), expert_ids,
-                        h_scratch + (size_t)t0 * 19968, m, gu_pdl, q3_gu2);
+                        h_scratch, 2, gu_pdl, q3_gu2);
+                } else {
+                    constexpr int MMAX = 8;
+                    for (int t0 = 0; t0 < num_tokens; t0 += MMAX) {
+                        const int m = (num_tokens - t0) < MMAX ? (num_tokens - t0) : MMAX;
+                        launch_pdl_kernel(gu_pdl, dim3(19968), dim3(4 * 32), 0, stream,
+                            gate_up_q3a_muse_rows_kernel<6656, 19968, MMAX>,
+                            q + (size_t)t0 * (6656 >> 5),
+                            reinterpret_cast<const unsigned char*>(gate_q),
+                            reinterpret_cast<const unsigned char*>(up_q), expert_ids,
+                            h_scratch + (size_t)t0 * 19968, m, gu_pdl, q3_gu2);
+                    }
                 }
             } else
                 launch_pdl_kernel(gu_pdl, dim3(num_tokens * top_k * ffn), dim3(4 * 32), 0, stream, gate_up_q3a_kernel,

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -37,6 +37,11 @@ set_tests_properties(sparse_gate_up_rows_gpu_test PROPERTIES SKIP_RETURN_CODE 77
 add_executable(mmvq_mma_accuracy_gpu_test mmvq_mma_accuracy_gpu_test.cpp)
 target_link_libraries(mmvq_mma_accuracy_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
 set_target_properties(mmvq_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)
+# A request larger than the MMA row limit must still let its eight-row chunks use MMA. K=8192
+# is supported by MMA but not the exact DP4A dispatcher, so bypassing MMA rejects this shape.
+add_test(NAME mmvq_mma_chunk_gpu_test COMMAND mmvq_mma_accuracy_gpu_test 40 6656 8192)
+set_tests_properties(mmvq_mma_chunk_gpu_test PROPERTIES SKIP_RETURN_CODE 77
+  ENVIRONMENT "SPARKINFER_MMVQ_MMA=1;SPARKINFER_MMVQ_MMA_MINM=8;SPARKINFER_MMVQ_MMA_MINN=2048")
 # The tensor-core down projection against the MMVQ, dumped per process so the two can be diffed.
 # Not a ctest: it needs two runs with different env to be meaningful, and ~1 GB of device memory.
 add_executable(down_mma_accuracy_gpu_test down_mma_accuracy_gpu_test.cpp)

--- a/kernels/tests/sparse_gate_up_rows_gpu_test.cpp
+++ b/kernels/tests/sparse_gate_up_rows_gpu_test.cpp
@@ -3,8 +3,8 @@
 // to share one weight read across its rows: the batch changes how the weights are fetched, never
 // what any row computes -- and in particular never which neurons a row gates off.
 //
-// Muse Glimmer's dense FFN keeps ten of its 52 layers on native Q4_K (the Q3_A requantizer takes
-// the other 42), and those ten are the ones that reach this arm.
+// Muse Glimmer's dense FFN keeps ten of its 52 layers on native Q4_K; the Q3_A requantizer feeds
+// the other 42 through the matching row kernel. Exercise both formats here.
 //
 // Sparsity is left ON -- the default, and what production decodes with -- because the per-row mask
 // is exactly what is being asserted. g_mg_sparse_tau is read from the environment once and cached,
@@ -16,6 +16,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cmath>
 #include <vector>
 
 namespace {
@@ -23,19 +24,27 @@ namespace {
 constexpr int H = 6656, F = 19968;     // Muse Glimmer's dense FFN
 constexpr int MAXROWS = 16;
 
-// Deterministic byte fill. Any byte pattern is a structurally valid Q4_K super-block -- the
-// formats have no reserved encodings -- so random bytes exercise the decode paths without needing
-// a quantizer here.
+// Random quantized bit planes with bounded, finite fp16 scale headers. Arbitrary bytes in a
+// scale or a bf16 activation can create NaNs/overflow and make a bitwise comparison vacuous.
 unsigned int rng = 0x1234567u;
 unsigned char next_byte() {
     rng = rng * 1664525u + 1013904223u;
     return (unsigned char)(rng >> 24);
 }
 
-bool fill_dev(void* p, size_t bytes) {
+bool fill_weights(void* p, size_t bytes, size_t block_bytes) {
     std::vector<unsigned char> h(bytes);
     for (size_t i = 0; i < bytes; ++i) h[i] = next_byte();
+    const __half scales[2] = {__float2half_rn(0.001f), __float2half_rn(0.001f)};
+    for (size_t i = 0; i < bytes; i += block_bytes)
+        std::memcpy(h.data() + i, scales, sizeof(scales));
     return cudaMemcpy(p, h.data(), bytes, cudaMemcpyHostToDevice) == cudaSuccess;
+}
+
+bool fill_activations(void* p) {
+    std::vector<__nv_bfloat16> h((size_t)MAXROWS * H);
+    for (auto& x : h) x = __float2bfloat16((static_cast<int>(next_byte()) - 128) / 512.f);
+    return cudaMemcpy(p, h.data(), h.size() * sizeof(h[0]), cudaMemcpyHostToDevice) == cudaSuccess;
 }
 
 // One FFN call, writing h_scratch for `rows` tokens.
@@ -47,7 +56,10 @@ bool run(const void* in, const void* g, const void* u, const void* d, int qt,
 }
 
 bool check(int qt, const char* label) {
-    const size_t gu_bytes = (size_t)F * (H / 256) * 144;   // Q4_K super-blocks
+    const size_t gu_block_bytes = qt == sparkinfer::kernels::SI_QTYPE_Q3A
+                                      ? (size_t)sparkinfer::kernels::SI_QTYPE_Q3A
+                                      : 144u;
+    const size_t gu_bytes = (size_t)F * (H / 256) * gu_block_bytes;
     const size_t dn_bytes = (size_t)H * (F / 256) * 144;          // down stays Q4_K
     void *g = nullptr, *u = nullptr, *d = nullptr, *in = nullptr, *out = nullptr;
     float *hs = nullptr, *os = nullptr;
@@ -61,8 +73,9 @@ bool check(int qt, const char* label) {
               cudaMalloc(&os, (size_t)MAXROWS * F * sizeof(float)) == cudaSuccess &&
               cudaMalloc(&ids, MAXROWS * sizeof(int)) == cudaSuccess &&
               cudaMalloc(&wts, MAXROWS * sizeof(float)) == cudaSuccess;
-    if (ok) ok = fill_dev(g, gu_bytes) && fill_dev(u, gu_bytes) && fill_dev(d, dn_bytes) &&
-                 fill_dev(in, (size_t)MAXROWS * H * sizeof(__nv_bfloat16));
+    if (ok) ok = fill_weights(g, gu_bytes, gu_block_bytes) &&
+                 fill_weights(u, gu_bytes, gu_block_bytes) && fill_weights(d, dn_bytes, 144) &&
+                 fill_activations(in);
     if (ok) {
         std::vector<int> hid(MAXROWS, 0);
         std::vector<float> hw(MAXROWS, 1.f);
@@ -76,9 +89,22 @@ bool check(int qt, const char* label) {
              cudaMemcpy(ref.data() + (size_t)r * F, hs, (size_t)F * sizeof(float),
                         cudaMemcpyDeviceToHost) == cudaSuccess;
     }
+    for (int r = 0; ok && r < MAXROWS; ++r) {
+        bool nonzero = false;
+        for (int f = 0; f < F; ++f) {
+            const float x = ref[(size_t)r * F + f];
+            if (!std::isfinite(x)) { ok = false; break; }
+            nonzero = nonzero || x != 0.f;
+        }
+        if (!ok || !nonzero) {
+            std::printf("[FAIL] %s reference row %d is non-finite or all zero\n", label, r);
+            ok = false;
+        }
+    }
     // Every batch width the dispatch instantiates, against the same reference.
     for (int m = 2; ok && m <= MAXROWS; ++m) {
-        ok = run(in, g, u, d, qt, ids, wts, out, hs, os, m) &&
+        ok = cudaMemset(hs, 0xff, (size_t)m * F * sizeof(float)) == cudaSuccess &&
+             run(in, g, u, d, qt, ids, wts, out, hs, os, m) &&
              cudaMemcpy(got.data(), hs, (size_t)m * F * sizeof(float),
                         cudaMemcpyDeviceToHost) == cudaSuccess;
         if (!ok) break;
@@ -106,7 +132,8 @@ int main() {
         std::printf("[SKIP] no GPU\n");
         return 77;
     }
-    const bool ok = check(12, "Q4_K sparse gate/up");   // 12 = ggml Q4_K
+    const bool ok = check(12, "Q4_K sparse gate/up") &&
+                    check(sparkinfer::kernels::SI_QTYPE_Q3A, "Q3_A fused gate/up");
     if (!ok) return 1;
     std::printf("[PASS] sparse_gate_up_rows_gpu_test\n");
     return 0;

--- a/runtime/tests/dflash_gdn_checkpoint_gpu_test.cpp
+++ b/runtime/tests/dflash_gdn_checkpoint_gpu_test.cpp
@@ -26,8 +26,11 @@ template <class T> T* device_copy(const std::vector<T>& h) {
 
 template <class T> bool equal_device(const T* a, const T* b, size_t n, const char* what) {
     std::vector<T> ha(n), hb(n);
-    cudaMemcpy(ha.data(), a, n * sizeof(T), cudaMemcpyDeviceToHost);
-    cudaMemcpy(hb.data(), b, n * sizeof(T), cudaMemcpyDeviceToHost);
+    if (cudaMemcpy(ha.data(), a, n * sizeof(T), cudaMemcpyDeviceToHost) != cudaSuccess ||
+        cudaMemcpy(hb.data(), b, n * sizeof(T), cudaMemcpyDeviceToHost) != cudaSuccess) {
+        std::printf("[FAIL] %s device copy failed\n", what);
+        return false;
+    }
     if (ha == hb) return true;
     size_t i = 0;
     while (i < n && ha[i] == hb[i]) i++;
@@ -256,6 +259,42 @@ int main() {
                                               dw, ys + (size_t)m * MN, MN, MH);
     cudaDeviceSynchronize();
     ok = equal_device(ym, ys, (size_t)N * MN, "Q4_K exact rows") && ok;
+    // Keep an explicit two-row assertion: the Muse narrow-batch dispatch has its own MMAX=2
+    // specialization, while the N=4 assertion above exercises the long-standing MMAX=6 body.
+    ok = cudaMemset(ym, 0xff, (size_t)2 * MN * sizeof(uint16_t)) == cudaSuccess && ok;
+    ok = sparkinfer::kernels::launch_mmvq_q4k_rows(dq81, dw, ym, 2, MN, MH) && ok;
+    ok = cudaDeviceSynchronize() == cudaSuccess && ok;
+    ok = equal_device(ym, ys, (size_t)2 * MN, "Q4_K exact rows M2") && ok;
+    // Muse's attention output projects K=4096 to N=6656. Exercise the public dispatcher at that
+    // shape as well, with poisoned output so a successful no-op launch cannot pass.
+    {
+        constexpr int K2 = 4096, N2 = 6656, M2 = 2;
+        auto a2 = make_bf16((size_t)M2 * K2, 37, 0.2f);
+        std::vector<unsigned char> w2((size_t)N2 * (K2 / 256) * 144);
+        for (size_t b = 0; b < w2.size(); b += 144) {
+            w2[b] = 0x1f; w2[b+1] = 0x21; w2[b+2] = 0x1f; w2[b+3] = 0x21;
+            for (int i = 4; i < 144; ++i) w2[b+i] = (unsigned char)((b / 144 * 17 + i * 13) & 255);
+        }
+        uint16_t *da2 = device_copy(a2), *got2 = nullptr, *ref2 = nullptr;
+        unsigned char* dw2 = device_copy(w2);
+        void* q2 = nullptr;
+        const size_t q2_stride = sparkinfer::kernels::llama_q8_1_bytes(K2);
+        bool ok2 = da2 && dw2 && cudaMalloc(&q2, M2 * q2_stride) == cudaSuccess &&
+                   cudaMalloc(&got2, (size_t)M2 * N2 * 2) == cudaSuccess &&
+                   cudaMalloc(&ref2, (size_t)M2 * N2 * 2) == cudaSuccess;
+        if (ok2) {
+            sparkinfer::kernels::launch_quantize_q8_1_rows(da2, q2, K2, M2, K2);
+            ok2 = cudaMemset(got2, 0xff, (size_t)M2 * N2 * 2) == cudaSuccess;
+            ok2 = sparkinfer::kernels::launch_mmvq_rows(12, q2, dw2, got2, M2, N2, K2) && ok2;
+            for (int r = 0; r < M2; ++r)
+                sparkinfer::kernels::launch_mmvq_q4k((const char*)q2 + r * q2_stride,
+                                                   dw2, ref2 + (size_t)r * N2, N2, K2);
+            ok2 = cudaDeviceSynchronize() == cudaSuccess && ok2;
+            ok2 = equal_device(got2, ref2, (size_t)M2 * N2, "Q4_K exact rows M2 K4096") && ok2;
+        }
+        ok = ok2 && ok;
+        cudaFree(da2); cudaFree(dw2); cudaFree(q2); cudaFree(got2); cudaFree(ref2);
+    }
     float *yfm = nullptr, *yfs = nullptr;
     cudaMalloc(&yfm, (size_t)N * MN * sizeof(float));
     cudaMalloc(&yfs, (size_t)N * MN * sizeof(float));


### PR DESCRIPTION
## Summary

Specialize the existing packed Q4_K and Muse fused Q3_A gate/up row kernels for a complete
two-row request. The Q4_K body currently reserves six rows of accumulators and the Q3_A body
eight; instantiating the same math with `MMAX=2` reduces their unused register footprint.

This builds on current main `4901b43fb017f6faa0046e35288e3194fd043062` (#1048), including its
fused attention in-projections. No evaluator, model, benchmark, reward, or maintainer-owned
files are changed.

Both switches default on and provide an exact same-binary dispatch control:

- `SPARKINFER_MMVQ_ROWS_M2=0`: restore the established Q4_K `MMAX=6/8` dispatch.
- `SPARKINFER_MUSE_Q3A_ROWS_M2=0`: restore the established Q3_A `MMAX=8` dispatch.

Only a top-level request containing exactly two rows selects the narrow body. Wider requests,
including two-row chunk tails, keep their established template bodies. The generic dispatcher
still tries MMA both for a full request and for each chunk when the full request exceeds MMA's
row/scratch limits.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [x] **Shared / both**

The intended performance target is Muse concurrent decode at c2. Shared/both is also checked
because the generic Q4_K rows dispatcher is shared code; no Qwen speedup is claimed and no
cross-model guard should be bypassed.

**Decode tok/s** (end-to-end aggregate concurrent decode at c2):

| | decode tok/s |
|---|--:|
| before (main) | 158.0 |
| after (this PR) | 163.4 |

**Prefill pp tok/s** (not targeted; no prefill speedup claimed):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not measured |
| after prefill (this PR) | not measured |

The decode table is from the unchanged current Muse evaluator's concurrent-decode command,
not a kernel microbenchmark or single-stream decode:

```bash
SPARKINFER_MMVQ_ROWS_M2=0 SPARKINFER_MUSE_Q3A_ROWS_M2=0 \
  build/runtime/qwen3_gguf_cb_bench MODEL.gguf 2 256 256 512
SPARKINFER_MMVQ_ROWS_M2=1 SPARKINFER_MUSE_Q3A_ROWS_M2=1 \
  build/runtime/qwen3_gguf_cb_bench MODEL.gguf 2 256 256 512
```

One RTX 5090, 32,607 MiB, 575 W limit, driver 595.58.03, CUDA 12.8.93, SM120 Release CUDA
build. C++ uses `-O3 -UNDEBUG` to retain test assertions. Both arms use one identical build:
"before" restores main's existing dispatch using both switches off. No clock or power-limit
settings were changed between arms. The model is `Muse-Glimmer-30B-KQuant-17GB-Q4_K_M.gguf`, SHA256
`4cc57c0f51040a226e5a72cc47b7613f7772950e460a665f7083de89f183f60e`.

After one warmup of each arm, measured in the order off/on/on/off/off/on:

```text
off  wall_s=3.282 decode_tokens=520 agg_tok_s=158.4 mean_itl_ms=12.58 max_itl_ms=84.41
on   wall_s=3.177 decode_tokens=520 agg_tok_s=163.7 mean_itl_ms=12.18 max_itl_ms=83.13
on   wall_s=3.182 decode_tokens=520 agg_tok_s=163.4 mean_itl_ms=12.20 max_itl_ms=83.83
off  wall_s=3.291 decode_tokens=520 agg_tok_s=158.0 mean_itl_ms=12.63 max_itl_ms=84.52
off  wall_s=3.297 decode_tokens=520 agg_tok_s=157.7 mean_itl_ms=12.65 max_itl_ms=84.84
on   wall_s=3.181 decode_tokens=520 agg_tok_s=163.4 mean_itl_ms=12.20 max_itl_ms=82.59
median agg_tok_s: 158.0 -> 163.4 (+3.42%)
```

Wider concurrency uses the same command with `c=4/8/16/32`, each in an off/on/on/off order.
The two samples per arm are shown so small negative deltas are not hidden:

| concurrency | off samples | on samples | median off | median on | delta |
|---|---|---|--:|--:|--:|
| c4 | 227.3, 225.0 | 226.1, 225.3 | 226.15 | 225.70 | -0.20% |
| c8 | 345.6, 344.8 | 344.9, 345.2 | 345.20 | 345.05 | -0.04% |
| c16 | 624.1, 623.0 | 623.7, 623.2 | 623.55 | 623.45 | -0.02% |
| c32 | 863.0, 861.3 | 862.7, 860.8 | 862.15 | 861.75 | -0.05% |

Every sample produced the full `c * 256 + 8` tokens: 1032/2056/4104/8200 respectively.
No wider-concurrency speedup is claimed; these deltas are small relative to the observed sample variation.

## Correctness and regression coverage

- Same per-row arithmetic and reduction order; only the compile-time row capacity changes.
- Exact-M2 Q4_K is compared byte-for-byte with serial rows, including Muse's `K=4096, N=6656`
  attention-output projection. Output is poisoned before the launch to reject a no-op.
- Both Q4_K and Q3_A gate/up compare every width `m=2..16` against serial rows. Bounded finite
  fixtures, finite/nonzero reference checks, and poisoned output prevent vacuous comparisons.
- Added `M=40, N=6656, K=8192` launch coverage for the generic MMA chunk fallback.
- On the RTX 5090, both switch settings completed the full 24-entry CTest suite with no failed
  entries. The optional real-LMCache-sidecar integration check printed a dependency skip; the
  other 23 entries executed. The unchanged socket-client CPU test stalled in an earlier run,
  then passed alone and in both subsequent full runs; no bridge code is part of this patch.
- Reproduced the Muse evaluator's teacher-forced comparison on the unchanged evaluation corpus,
  top-k 128, against a live native-Muse llama.cpp reference
  (`5bda51bfbc62e64193221e639f6ad4e08767d760`). For 99 positions: top-1 agreement
  `96/99 = 0.969697`, mean KL `0.090603`, SparkInfer full-softmax PPL `2.6881`, reference
  top-128+floor approximate PPL `3.0876`.
  The extracted `S`/`PPL` output is byte-identical with both switches off/on (SHA256
  `002574803daad976ce0671340ef7ad50bbb2281daa29e5719747d20f839589e4`). This single-stream
  accuracy check complements, but does not replace, the packed-path GPU equality tests above.
- The full single-stream context sweeps and Qwen cross-model model benchmarks were not run
  locally. Please retain the official full-context and cross-model no-regression gates.

No reward tier is claimed from these local measurements. Official current-main comparison,
cross-model guards, and maintainer/bot review remain authoritative.
