### PR TITLE
perf(muse): stop the packed decode's tensor-core GEMVs paying for shapes it never runs (1.21x concurrent decode @c16)

### DIFF
--- a/kernels/csrc/cuda/gemm/gemv.cu
+++ b/kernels/csrc/cuda/gemm/gemv.cu
@@ -2175,6 +2175,14 @@ template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 32, 1>
     const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
     const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
     int, int, int, int, int, int, int, int);
+template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 16, 1, true>(
+    const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
+    const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    int, int, int, int, int, int, int, int);
+template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 32, 1, true>(
+    const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
+    const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
+    int, int, int, int, int, int, int, int);
 template __global__ void si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, 6, SI_Q4K_OROWS>(
     const si_block_q8_1*, const unsigned char*, const unsigned char*, const unsigned char*,
     const unsigned char*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*, __nv_bfloat16*,
@@ -3982,10 +3990,15 @@ __device__ __forceinline__ void si_am_scales(const unsigned char* sc12, int j,
 // needs to fill the grid. SPLITK=false is the single-split case and writes the caller's buffer
 // directly, so one K split costs exactly what it did before this change -- no scratch, no second
 // pass over the output.
-template <bool SPLITK, class OutT>
+// MM is the A-staging height: the width the caller actually dispatched, not SI_AM_MMAX. Same
+// shape and same reasoning as down_q4k_mma_rows_kernel in expert_ffn_q4k.cu, which carries the
+// full note -- the shared A tile (10 KB of 18.75 KB at MM=32) held the SM to five CTAs where the
+// __launch_bounds__ asks for eight, and the M-tile loop issued both m16n8k32 tiles only to
+// discard the second through `lm < M`. Bit-identical at every M.
+template <bool SPLITK, class OutT, int MM>
 __global__ __launch_bounds__(SI_AM_NW * 32, 8)
 void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned char* __restrict__ W,
-                            OutT* __restrict__ acc_out, int M, int N, int K) {
+                            OutT* __restrict__ acc_out, int M, int N, int K, int bdedup) {
     const int nblk = K >> 8;
     const int n0 = blockIdx.x * SI_AM_BN;
     // Balanced, not ceil: 26 super-blocks over 8 splits is 4,4,3,3,3,3,3,3 rather than seven 4s and
@@ -3997,47 +4010,91 @@ void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned 
     const int tid = threadIdx.x, warp = tid >> 5, lane = tid & 31;
     const int grp = lane >> 2, tig = lane & 3, sub = lane >> 3, lrow = lane & 7;
 
-    __shared__ signed char As[SI_AM_MMAX][256];
+    __shared__ signed char As[MM][256];
     __shared__ signed char Bs[SI_AM_BN][256];
     __shared__ unsigned char Ssc[SI_AM_BN][8], Smn[SI_AM_BN][8];
     __shared__ float2 Wdm[SI_AM_BN];
-    __shared__ float Ad[SI_AM_MMAX][8], Asum[SI_AM_MMAX][8];
+    __shared__ float Ad[MM][8], Asum[MM][8];
 
-    float facc[2][4];
+    constexpr int NT = (MM + 15) / 16;   // 16-row mma tiles this width actually needs
+    float facc[NT][4];
     #pragma unroll
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < NT; i++)
         #pragma unroll
         for (int e = 0; e < 4; e++) facc[i][e] = 0.f;
 
     for (int sb = sb_lo; sb < sb_hi; sb++) {
-        for (int u = tid; u < SI_AM_BN * 16; u += SI_AM_NW * 32) {
-            const int r = u >> 4, c = u & 15;
-            const int gn = n0 + r;
-            const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
-                W + (size_t)(gn < N ? gn : N - 1) * (size_t)nblk * 144) + sb;
-            const int j = c >> 2, sc_ = c & 3;
-            const bool hi = (sc_ >> 1) & 1;
-            const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + (sc_ & 1) * 16);
-            signed char out[16];
-            #pragma unroll
-            for (int v = 0; v < 4; v++) {
-                const unsigned x = src[v];
+        // A Q4_K byte carries TWO weights and the two land 32 int8 lanes apart in Bs. Indexing
+        // the 16 B chunk and the nibble half together (c = 0..15, hi = c>>1&1) made this loop
+        // walk the super-block's 128 B quant plane TWICE -- once fetching the low nibbles and
+        // once, from the identical addresses, the high ones. Eight units, one fetch, two stores:
+        // the same bytes reach the same shared addresses and the global load count halves.
+        // Bit-identical. SPARKINFER_MMA_BDEDUP=0 restores the two-pass loader.
+        if (bdedup) {
+            for (int u = tid; u < SI_AM_BN * 8; u += SI_AM_NW * 32) {
+                const int r = u >> 3, c = u & 7;
+                const int gn = n0 + r;
+                const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
+                    W + (size_t)(gn < N ? gn : N - 1) * (size_t)nblk * 144) + sb;
+                const int j = c >> 1, h = c & 1;
+                const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + h * 16);
+                signed char lo[16], hi[16];
                 #pragma unroll
-                for (int t = 0; t < 4; t++) {
-                    const unsigned char qq = (unsigned char)((x >> (8 * t)) & 0xFF);
-                    out[4 * v + t] = (signed char)(hi ? (qq >> 4) : (qq & 0xF));
+                for (int v = 0; v < 4; v++) {
+                    const unsigned x = src[v];
+                    #pragma unroll
+                    for (int t = 0; t < 4; t++) {
+                        const unsigned char qq = (unsigned char)((x >> (8 * t)) & 0xFF);
+                        lo[4 * v + t] = (signed char)(qq & 0xF);
+                        hi[4 * v + t] = (signed char)(qq >> 4);
+                    }
+                }
+                const int kb = 64 * j + h * 16;
+                *reinterpret_cast<uint4*>(&Bs[r][si_am_swz(kb, r)]) =
+                    *reinterpret_cast<const uint4*>(lo);
+                *reinterpret_cast<uint4*>(&Bs[r][si_am_swz(kb + 32, r)]) =
+                    *reinterpret_cast<const uint4*>(hi);
+                if (c == 0) {
+                    Wdm[r] = __half22float2(b->dm);
+                    #pragma unroll
+                    for (int jj = 0; jj < 4; jj++) {
+                        unsigned char x0, x1, y0, y1;
+                        si_am_scales(b->scales, jj, x0, x1, y0, y1);
+                        Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
+                        Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                    }
                 }
             }
-            const int kb = 64 * j + (sc_ >> 1) * 32 + (sc_ & 1) * 16;
-            *reinterpret_cast<uint4*>(&Bs[r][si_am_swz(kb, r)]) = *reinterpret_cast<const uint4*>(out);
-            if (c == 0) {
-                Wdm[r] = __half22float2(b->dm);
+        } else {
+            for (int u = tid; u < SI_AM_BN * 16; u += SI_AM_NW * 32) {
+                const int r = u >> 4, c = u & 15;
+                const int gn = n0 + r;
+                const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
+                    W + (size_t)(gn < N ? gn : N - 1) * (size_t)nblk * 144) + sb;
+                const int j = c >> 2, sc_ = c & 3;
+                const bool hi = (sc_ >> 1) & 1;
+                const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + (sc_ & 1) * 16);
+                signed char out[16];
                 #pragma unroll
-                for (int jj = 0; jj < 4; jj++) {
-                    unsigned char x0, x1, y0, y1;
-                    si_am_scales(b->scales, jj, x0, x1, y0, y1);
-                    Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
-                    Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                for (int v = 0; v < 4; v++) {
+                    const unsigned x = src[v];
+                    #pragma unroll
+                    for (int t = 0; t < 4; t++) {
+                        const unsigned char qq = (unsigned char)((x >> (8 * t)) & 0xFF);
+                        out[4 * v + t] = (signed char)(hi ? (qq >> 4) : (qq & 0xF));
+                    }
+                }
+                const int kb = 64 * j + (sc_ >> 1) * 32 + (sc_ & 1) * 16;
+                *reinterpret_cast<uint4*>(&Bs[r][si_am_swz(kb, r)]) = *reinterpret_cast<const uint4*>(out);
+                if (c == 0) {
+                    Wdm[r] = __half22float2(b->dm);
+                    #pragma unroll
+                    for (int jj = 0; jj < 4; jj++) {
+                        unsigned char x0, x1, y0, y1;
+                        si_am_scales(b->scales, jj, x0, x1, y0, y1);
+                        Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
+                        Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                    }
                 }
             }
         }
@@ -4067,9 +4124,9 @@ void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned 
             // Ablating this fold-in measured it at 111 us of the kernel's 169.
             const float sA = dmA.x * (float)Ssc[lnA][g],     mA = dmA.y * (float)Smn[lnA][g];
             const float sB = dmB.x * (float)Ssc[lnA + 1][g], mB = dmB.y * (float)Smn[lnA + 1][g];
-            float adv[2][2], asv[2][2];
+            float adv[NT][2], asv[NT][2];
             #pragma unroll
-            for (int ii = 0; ii < 2; ii++)
+            for (int ii = 0; ii < NT; ii++)
                 #pragma unroll
                 for (int eh = 0; eh < 2; eh++) {
                     const int lmv = ii * 16 + grp + eh * 8;
@@ -4077,18 +4134,18 @@ void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned 
                     asv[ii][eh] = lmv < M ? Asum[lmv][g] : 0.f;
                 }
 
-            unsigned af[2][4], bf0, bf1, bx, by;
+            unsigned af[NT][4], bf0, bf1, bx, by;
             #pragma unroll
-            for (int i = 0; i < 2; i++) {
+            for (int i = 0; i < NT; i++) {
                 const int row = i * 16 + (sub & 1) * 8 + lrow;
                 si_am_ldm(af[i][0], af[i][1], af[i][2], af[i][3],
-                          &As[row < SI_AM_MMAX ? row : 0][si_am_swz(kk + (sub >> 1) * 16, row)]);
+                          &As[row < MM ? row : 0][si_am_swz(kk + (sub >> 1) * 16, row)]);
             }
             const int col = warp * 8 + lrow;
             si_am_ldm(bf0, bf1, bx, by, &Bs[col][si_am_swz(kk + (sub & 1) * 16, col)]);
             (void)bx; (void)by;
             #pragma unroll
-            for (int i = 0; i < 2; i++) {
+            for (int i = 0; i < NT; i++) {
                 int acc[4] = {0, 0, 0, 0};
                 asm volatile(
                     "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
@@ -4112,7 +4169,7 @@ void si_mmvq_q4k_mma_kernel(const si_block_q8_1* __restrict__ q, const unsigned 
     }
 
     #pragma unroll
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < NT; i++)
         #pragma unroll
         for (int e = 0; e < 4; e++) {
             const int lm = i * 16 + grp + (e >> 1) * 8;
@@ -4148,6 +4205,26 @@ static int si_am_slot_for(cudaStream_t stream) {
     return used++;
 }
 
+// Narrowest instantiation that covers M -- see the note on the kernel. SPARKINFER_MMA_ASTAGE=0
+// pins every width back to the 32-row kernel, so both arms of an A/B come out of ONE binary.
+// SPARKINFER_MMA_BDEDUP=0 restores the two-pass B loader, so both arms come out of ONE binary.
+static inline int si_am_bdedup() {
+    static const int on = [] {
+        const char* e = getenv("SPARKINFER_MMA_BDEDUP");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    return on;
+}
+
+static inline int si_am_astage(int M) {
+    static const int on = [] {
+        const char* e = getenv("SPARKINFER_MMA_ASTAGE");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!on) return SI_AM_MMAX;
+    return M <= 8 ? 8 : (M <= 16 ? 16 : SI_AM_MMAX);
+}
+
 static inline bool launch_mmvq_q4k_mma_rows(const void* q81, const void* W, void* y,
                                             int M, int N, int K, cudaStream_t stream) {
     if (M < 2 || M > SI_AM_MMAX || (K & 255) || (N % SI_AM_BN)) return false;
@@ -4160,11 +4237,19 @@ static inline bool launch_mmvq_q4k_mma_rows(const void* q81, const void* W, void
     // One split needs no accumulator and no epilogue: straight into the caller's bf16, which is
     // what this arm did before split-K existed. SPARKINFER_MMVQ_MMA_SPLITK=1 therefore reproduces
     // the previous behaviour exactly, so both arms of an A/B come out of ONE binary.
+    const int st_ = si_am_astage(M);
+    const int bd = si_am_bdedup();
     if (nsk == 1) {
-        si_mmvq_q4k_mma_kernel<false, __nv_bfloat16>
-            <<<dim3(N / SI_AM_BN, 1), dim3(SI_AM_NW * 32), 0, stream>>>(
-            reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
-            reinterpret_cast<__nv_bfloat16*>(y), M, N, K);
+        const dim3 g1(N / SI_AM_BN, 1), b1(SI_AM_NW * 32);
+        const si_block_q8_1* qa = reinterpret_cast<const si_block_q8_1*>(q81);
+        const unsigned char* wa = reinterpret_cast<const unsigned char*>(W);
+        __nv_bfloat16* ya = reinterpret_cast<__nv_bfloat16*>(y);
+        if (st_ <= 8)       si_mmvq_q4k_mma_kernel<false, __nv_bfloat16, 8>
+                                <<<g1, b1, 0, stream>>>(qa, wa, ya, M, N, K, bd);
+        else if (st_ <= 16) si_mmvq_q4k_mma_kernel<false, __nv_bfloat16, 16>
+                                <<<g1, b1, 0, stream>>>(qa, wa, ya, M, N, K, bd);
+        else                si_mmvq_q4k_mma_kernel<false, __nv_bfloat16, SI_AM_MMAX>
+                                <<<g1, b1, 0, stream>>>(qa, wa, ya, M, N, K, bd);
         return true;
     }
     const int slot = si_am_slot_for(stream);
@@ -4172,9 +4257,17 @@ static inline bool launch_mmvq_q4k_mma_rows(const void* q81, const void* W, void
     float* acc = nullptr;
     if (cudaGetSymbolAddress(reinterpret_cast<void**>(&acc), si_am_acc) != cudaSuccess) return false;
     acc += (size_t)slot * SI_AM_MMAX * 6656u;
-    si_mmvq_q4k_mma_kernel<true, float><<<dim3(N / SI_AM_BN, nsk), dim3(SI_AM_NW * 32), 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
-        acc, M, N, K);
+    {
+        const dim3 gk(N / SI_AM_BN, nsk), bk(SI_AM_NW * 32);
+        const si_block_q8_1* qa = reinterpret_cast<const si_block_q8_1*>(q81);
+        const unsigned char* wa = reinterpret_cast<const unsigned char*>(W);
+        if (st_ <= 8)       si_mmvq_q4k_mma_kernel<true, float, 8>
+                                <<<gk, bk, 0, stream>>>(qa, wa, acc, M, N, K, bd);
+        else if (st_ <= 16) si_mmvq_q4k_mma_kernel<true, float, 16>
+                                <<<gk, bk, 0, stream>>>(qa, wa, acc, M, N, K, bd);
+        else                si_mmvq_q4k_mma_kernel<true, float, SI_AM_MMAX>
+                                <<<gk, bk, 0, stream>>>(qa, wa, acc, M, N, K, bd);
+    }
     const size_t n = (size_t)M * (size_t)N;
     const int thr = 256;
     si_mmvq_q4k_mma_epilogue_kernel<<<(unsigned)((n + thr - 1) / thr), thr, 0, stream>>>(
@@ -4197,9 +4290,19 @@ bool launch_mmvq_q4k_mma_head_f32(const void* q81, const void* W, float* y,
     static int head_mma_min = -1;
     if (head_mma_min < 0) { const char* e = getenv("SPARKINFER_HEAD_MMA_MINROWS"); head_mma_min = e ? atoi(e) : 8; }
     if (M < head_mma_min || M > SI_AM_MMAX || (K & 255) || (N % SI_AM_BN)) return false;
-    si_mmvq_q4k_mma_kernel<false, float><<<dim3(N / SI_AM_BN, 1), dim3(SI_AM_NW * 32), 0, stream>>>(
-        reinterpret_cast<const si_block_q8_1*>(q81), reinterpret_cast<const unsigned char*>(W),
-        y, M, N, K);
+    {
+        const dim3 gh(N / SI_AM_BN, 1), bh(SI_AM_NW * 32);
+        const si_block_q8_1* qa = reinterpret_cast<const si_block_q8_1*>(q81);
+        const unsigned char* wa = reinterpret_cast<const unsigned char*>(W);
+        const int sth = si_am_astage(M);
+        const int bd = si_am_bdedup();
+        if (sth <= 8)       si_mmvq_q4k_mma_kernel<false, float, 8>
+                                <<<gh, bh, 0, stream>>>(qa, wa, y, M, N, K, bd);
+        else if (sth <= 16) si_mmvq_q4k_mma_kernel<false, float, 16>
+                                <<<gh, bh, 0, stream>>>(qa, wa, y, M, N, K, bd);
+        else                si_mmvq_q4k_mma_kernel<false, float, SI_AM_MMAX>
+                                <<<gh, bh, 0, stream>>>(qa, wa, y, M, N, K, bd);
+    }
     return true;
 }
 
@@ -4242,7 +4345,12 @@ bool launch_mmvq_q4k_rows_multi(const void* q81, const void* const* W, void* con
                                 const int* Ns, int nmat, int M, int K, cudaStream_t stream,
                                 bool q6_last) {
     if (nmat < 1 || nmat > 4 || M < 1 || M > 32 || K != 6656) return false;
-    if (q6_last && (nmat < 2 || M > 8)) return false;   // only the narrow, 4-wide Muse shape
+    // The Q6_K slot is width-generic (its body loops m < M under an MMAX bound and folds through
+    // the same 4-warp reduction at every width); it was simply not instantiated past eight rows,
+    // so half of Muse's layers kept paying a 256-block launch of their own at c16/c32 -- 52
+    // launches and 0.68 ms of a 19.5 ms step to move 36 MB. SPARKINFER_MUSE_V6_WIDE=0 keeps the
+    // caller off the wide q6 path entirely, so both arms come out of ONE binary.
+    if (q6_last && nmat < 2) return false;
     for (int i = 0; i < nmat; i++) if (!W[i] || !y[i] || Ns[i] < 1) return false;
     // Past eight rows launch_mmvq_rows chunks the batch into groups of eight, and every chunk
     // re-reads the whole matrix. For a 256-row projection that is the dominant cost: at 32 rows
@@ -4274,7 +4382,8 @@ bool launch_mmvq_q4k_rows_multi(const void* q81, const void* const* W, void* con
 #define SI_Q4K_MULTI6(MM, ORV) si_mmvq_q4k_rows_multi_kernel<__nv_bfloat16, 26, MM, ORV, true> \
     <<<grid, 4 * 32, 0, stream>>>(q, w[0], w[1], w[2], w[3], o[0], o[1], o[2], o[3], \
                                   n[0], n[1], n[2], n[3], b1, b2, b3, M)
-    if (q6_last) { if (M <= 6) SI_Q4K_MULTI6(6, SI_Q4K_OROWS); else SI_Q4K_MULTI6(8, SI_Q4K_OROWS); }
+    if (q6_last && wide) { if (M <= 16) SI_Q4K_MULTI6(16, 1); else SI_Q4K_MULTI6(32, 1); }
+    else if (q6_last) { if (M <= 6) SI_Q4K_MULTI6(6, SI_Q4K_OROWS); else SI_Q4K_MULTI6(8, SI_Q4K_OROWS); }
     else if (!wide) { if (M <= 6) SI_Q4K_MULTI(6, SI_Q4K_OROWS); else SI_Q4K_MULTI(8, SI_Q4K_OROWS); }
     else if (M <= 16) SI_Q4K_MULTI(16, 1);
     else              SI_Q4K_MULTI(32, 1);

--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1976,13 +1976,30 @@ __device__ __forceinline__ void si_mma_q4k_scales(const unsigned char* sc12, int
 }
 }  // namespace
 
+// MM is the A-staging height: the width the caller actually dispatched, not SI_MMA_MMAX. Two
+// things here were sized for the 32-row ceiling on EVERY launch, and a packed step narrower than
+// 32 rows paid both:
+//
+//   * the shared A tile -- As + Ad + Asum is 10 KB of the CTA's 18.75 KB at MM=32, and at 100 KB
+//     of shared per SM that 18.75 KB is what holds the kernel to five CTAs per SM. Its own
+//     __launch_bounds__ asks for eight, and the register allocator already honours that; only
+//     shared memory was standing in the way. MM=16 is 13.75 KB (seven CTAs), MM=8 is 11.25 KB
+//     (eight).
+//   * the M-tile loop, which issued BOTH m16n8k32 tiles unconditionally and then discarded the
+//     second through `lm < M`. At sixteen rows or fewer the second tile is pure waste: half the
+//     mma.sync and half the ldmatrix on As.
+//
+// Rows that survive compute the same products from the same operands in the same order, so the
+// output is bit-identical to the MM=32 kernel at every M -- this only stops computing the rows
+// the `lm < M` guard was already throwing away.
+template <int MM>
 __global__ __launch_bounds__(SI_MMA_NW * 32, 8)
 void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
                               const int* __restrict__ expert_ids,
                               const float* __restrict__ expert_weights,
                               const si_block_q8_1* __restrict__ hq8,
                               float* __restrict__ acc_out,
-                              int H, int F, int top_k, int M, int pdl) {
+                              int H, int F, int top_k, int M, int pdl, int bdedup) {
     if (pdl) si_pdl_sync();
     const int nblk = F >> 8;
     const int n0 = blockIdx.x * SI_MMA_BN;
@@ -1996,48 +2013,91 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
     const int grp = lane >> 2, tig = lane & 3, sub = lane >> 3, lrow = lane & 7;
     const int e0 = expert_ids[0];
 
-    __shared__ signed char As[SI_MMA_MMAX][256];
+    __shared__ signed char As[MM][256];
     __shared__ signed char Bs[SI_MMA_BN][256];
     __shared__ unsigned char Ssc[SI_MMA_BN][8], Smn[SI_MMA_BN][8];
     __shared__ float2 Wdm[SI_MMA_BN];
-    __shared__ float Ad[SI_MMA_MMAX][8], Asum[SI_MMA_MMAX][8];
+    __shared__ float Ad[MM][8], Asum[MM][8];
 
-    float facc[2][4];
+    constexpr int NT = (MM + 15) / 16;   // 16-row mma tiles this width actually needs
+    float facc[NT][4];
     #pragma unroll
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < NT; i++)
         #pragma unroll
         for (int e = 0; e < 4; e++) facc[i][e] = 0.f;
 
     for (int sb = sb_lo; sb < sb_hi; sb++) {
         // One 16B output chunk per unit: the swizzle permutes whole 16B chunks, so addresses
         // inside a chunk are contiguous and each unit is a single uint4 store.
-        for (int u = tid; u < SI_MMA_BN * 16; u += SI_MMA_NW * 32) {
-            const int r = u >> 4, c = u & 15;
-            const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
-                down_q + ((size_t)e0 * H + (n0 + r)) * (size_t)nblk * 144) + sb;
-            const int j = c >> 2, sc_ = c & 3;
-            const bool hi = (sc_ >> 1) & 1;
-            const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + (sc_ & 1) * 16);
-            signed char out[16];
-            #pragma unroll
-            for (int v = 0; v < 4; v++) {
-                const unsigned x = src[v];
+        // A Q4_K byte carries TWO weights and the two land 32 int8 lanes apart in Bs. Indexing
+        // the 16 B chunk and the nibble half together (c = 0..15, hi = c>>1&1) made this loop
+        // walk the super-block's 128 B quant plane TWICE -- once fetching the low nibbles and
+        // once, from the identical addresses, the high ones. Eight units, one fetch, two stores:
+        // the same bytes reach the same shared addresses and the global load count halves.
+        // Bit-identical. SPARKINFER_MMA_BDEDUP=0 restores the two-pass loader.
+        if (bdedup) {
+            for (int u = tid; u < SI_MMA_BN * 8; u += SI_MMA_NW * 32) {
+                const int r = u >> 3, c = u & 7;
+                const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
+                    down_q + ((size_t)e0 * H + (n0 + r)) * (size_t)nblk * 144) + sb;
+                const int j = c >> 1, h = c & 1;
+                const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + h * 16);
+                signed char lo[16], hi[16];
                 #pragma unroll
-                for (int t = 0; t < 4; t++) {
-                    const unsigned char q = (unsigned char)((x >> (8 * t)) & 0xFF);
-                    out[4 * v + t] = (signed char)(hi ? (q >> 4) : (q & 0xF));
+                for (int v = 0; v < 4; v++) {
+                    const unsigned x = src[v];
+                    #pragma unroll
+                    for (int t = 0; t < 4; t++) {
+                        const unsigned char q = (unsigned char)((x >> (8 * t)) & 0xFF);
+                        lo[4 * v + t] = (signed char)(q & 0xF);
+                        hi[4 * v + t] = (signed char)(q >> 4);
+                    }
+                }
+                const int kb = 64 * j + h * 16;
+                *reinterpret_cast<uint4*>(&Bs[r][si_mma_swz(kb, r)]) =
+                    *reinterpret_cast<const uint4*>(lo);
+                *reinterpret_cast<uint4*>(&Bs[r][si_mma_swz(kb + 32, r)]) =
+                    *reinterpret_cast<const uint4*>(hi);
+                if (c == 0) {
+                    Wdm[r] = __half22float2(b->dm);
+                    #pragma unroll
+                    for (int jj = 0; jj < 4; jj++) {
+                        unsigned char x0, x1, y0, y1;
+                        si_mma_q4k_scales(b->scales, jj, x0, x1, y0, y1);
+                        Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
+                        Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                    }
                 }
             }
-            const int kb = 64 * j + (sc_ >> 1) * 32 + (sc_ & 1) * 16;
-            *reinterpret_cast<uint4*>(&Bs[r][si_mma_swz(kb, r)]) = *reinterpret_cast<const uint4*>(out);
-            if (c == 0) {
-                Wdm[r] = __half22float2(b->dm);
+        } else {
+            for (int u = tid; u < SI_MMA_BN * 16; u += SI_MMA_NW * 32) {
+                const int r = u >> 4, c = u & 15;
+                const si_block_q4_K* b = reinterpret_cast<const si_block_q4_K*>(
+                    down_q + ((size_t)e0 * H + (n0 + r)) * (size_t)nblk * 144) + sb;
+                const int j = c >> 2, sc_ = c & 3;
+                const bool hi = (sc_ >> 1) & 1;
+                const unsigned* src = reinterpret_cast<const unsigned*>(b->qs + 32 * j + (sc_ & 1) * 16);
+                signed char out[16];
                 #pragma unroll
-                for (int jj = 0; jj < 4; jj++) {
-                    unsigned char x0, x1, y0, y1;
-                    si_mma_q4k_scales(b->scales, jj, x0, x1, y0, y1);
-                    Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
-                    Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                for (int v = 0; v < 4; v++) {
+                    const unsigned x = src[v];
+                    #pragma unroll
+                    for (int t = 0; t < 4; t++) {
+                        const unsigned char q = (unsigned char)((x >> (8 * t)) & 0xFF);
+                        out[4 * v + t] = (signed char)(hi ? (q >> 4) : (q & 0xF));
+                    }
+                }
+                const int kb = 64 * j + (sc_ >> 1) * 32 + (sc_ & 1) * 16;
+                *reinterpret_cast<uint4*>(&Bs[r][si_mma_swz(kb, r)]) = *reinterpret_cast<const uint4*>(out);
+                if (c == 0) {
+                    Wdm[r] = __half22float2(b->dm);
+                    #pragma unroll
+                    for (int jj = 0; jj < 4; jj++) {
+                        unsigned char x0, x1, y0, y1;
+                        si_mma_q4k_scales(b->scales, jj, x0, x1, y0, y1);
+                        Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
+                        Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
+                    }
                 }
             }
         }
@@ -2067,9 +2127,9 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
             // Ablating this fold-in measured it at 111 us of the kernel's 169.
             const float sA = dmA.x * (float)Ssc[lnA][g],     mA = dmA.y * (float)Smn[lnA][g];
             const float sB = dmB.x * (float)Ssc[lnA + 1][g], mB = dmB.y * (float)Smn[lnA + 1][g];
-            float adv[2][2], asv[2][2];
+            float adv[NT][2], asv[NT][2];
             #pragma unroll
-            for (int ii = 0; ii < 2; ii++)
+            for (int ii = 0; ii < NT; ii++)
                 #pragma unroll
                 for (int eh = 0; eh < 2; eh++) {
                     const int lmv = ii * 16 + grp + eh * 8;
@@ -2077,12 +2137,12 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
                     asv[ii][eh] = lmv < M ? Asum[lmv][g] : 0.f;
                 }
 
-            unsigned af[2][4], bf[2];
+            unsigned af[NT][4], bf[2];
             #pragma unroll
-            for (int i = 0; i < 2; i++) {
+            for (int i = 0; i < NT; i++) {
                 const int row = i * 16 + (sub & 1) * 8 + lrow;
                 si_mma_ldm(af[i][0], af[i][1], af[i][2], af[i][3],
-                           &As[row < SI_MMA_MMAX ? row : 0][si_mma_swz(kk + (sub >> 1) * 16, row)]);
+                           &As[row < MM ? row : 0][si_mma_swz(kk + (sub >> 1) * 16, row)]);
             }
             unsigned bx, by;
             const int col = warp * 8 + lrow;
@@ -2090,7 +2150,7 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
             (void)bx; (void)by;
 
             #pragma unroll
-            for (int i = 0; i < 2; i++) {
+            for (int i = 0; i < NT; i++) {
                 int acc[4] = {0, 0, 0, 0};
                 asm volatile(
                     "mma.sync.aligned.m16n8k32.row.col.s32.s8.s8.s32 "
@@ -2114,7 +2174,7 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
     }
 
     #pragma unroll
-    for (int i = 0; i < 2; i++)
+    for (int i = 0; i < NT; i++)
         #pragma unroll
         for (int e = 0; e < 4; e++) {
             const int lm = i * 16 + grp + (e >> 1) * 8;
@@ -2149,6 +2209,26 @@ static int si_mma_down_slot_for(cudaStream_t stream) {
     return used++;
 }
 
+// Narrowest instantiation that covers M. SPARKINFER_MMA_ASTAGE=0 pins every width back to the
+// 32-row kernel, so both arms of an A/B come out of ONE binary.
+// SPARKINFER_MMA_BDEDUP=0 restores the two-pass B loader, so both arms come out of ONE binary.
+static inline int si_mma_bdedup() {
+    static const int on = [] {
+        const char* e = getenv("SPARKINFER_MMA_BDEDUP");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    return on;
+}
+
+static inline int si_mma_astage(int M) {
+    static const int on = [] {
+        const char* e = getenv("SPARKINFER_MMA_ASTAGE");
+        return (e && e[0] == '0') ? 0 : 1;
+    }();
+    if (!on) return SI_MMA_MMAX;
+    return M <= 8 ? 8 : (M <= 16 ? 16 : SI_MMA_MMAX);
+}
+
 static inline bool launch_down_q4k_mma_rows(
     int pdl, const unsigned char* down_q, const int* expert_ids, const float* expert_weights,
     const si_block_q8_1* hq8, __nv_bfloat16* output,
@@ -2165,9 +2245,17 @@ static inline bool launch_down_q4k_mma_rows(
     const int nblk = F >> 8;
     int sk = SI_MMA_SK; if (sk > nblk) sk = nblk;   // never launch a split with nothing to reduce
     const size_t n = (size_t)M * (size_t)H;
-    launch_pdl_kernel(pdl, dim3(H / SI_MMA_BN, sk), dim3(SI_MMA_NW * 32), 0, stream,
-                      down_q4k_mma_rows_kernel, down_q, expert_ids, expert_weights, hq8,
-                      acc_scratch, H, F, top_k, M, pdl);
+    const dim3 g(H / SI_MMA_BN, sk), blk(SI_MMA_NW * 32);
+    const int bd = si_mma_bdedup();
+    if (si_mma_astage(M) <= 8)
+        launch_pdl_kernel(pdl, g, blk, 0, stream, down_q4k_mma_rows_kernel<8>, down_q, expert_ids,
+                          expert_weights, hq8, acc_scratch, H, F, top_k, M, pdl, bd);
+    else if (si_mma_astage(M) <= 16)
+        launch_pdl_kernel(pdl, g, blk, 0, stream, down_q4k_mma_rows_kernel<16>, down_q, expert_ids,
+                          expert_weights, hq8, acc_scratch, H, F, top_k, M, pdl, bd);
+    else
+        launch_pdl_kernel(pdl, g, blk, 0, stream, down_q4k_mma_rows_kernel<SI_MMA_MMAX>, down_q,
+                          expert_ids, expert_weights, hq8, acc_scratch, H, F, top_k, M, pdl, bd);
     const int thr = 256;
     down_q4k_mma_epilogue_kernel<<<(unsigned)((n + thr - 1) / thr), thr, 0, stream>>>(
         acc_scratch, expert_weights, output, H, top_k, M);

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3884,7 +3884,16 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 Wp[nm] = w.wk; Yp[nm] = kf; Ns[nm++] = kvdim;
                 // v joins the same grid whether it is Q4_K or Q6_K (14); a Q6_K v takes the
                 // last slot and the kernel runs the Q6_K dot for those blocks.
-                const bool v6 = !wide && !v4 && w.wv_type == 14;
+                // A Q6_K v can ride the fused grid at ANY width -- the multi kernel carries a
+                // Q6_K last slot and runs the Q6_K dot for those blocks. Restricting it to the
+                // narrow branch left half of Muse's layers issuing a 256-block launch of their
+                // own at c16/c32: 52 launches and 0.68 ms of a 19.5 ms step to move 36 MB, i.e.
+                // 0.05 TB/s -- pure launch and tail latency. SPARKINFER_MUSE_V6_WIDE=0 restores.
+                static const bool v6_wide = [] {
+                    const char* e = getenv("SPARKINFER_MUSE_V6_WIDE");
+                    return !(e && e[0] == '0');
+                }();
+                const bool v6 = (v6_wide || !wide) && !v4 && w.wv_type == 14;
                 if (v4 || v6) { Wp[nm] = w.wv; Yp[nm] = vf; Ns[nm++] = kvdim; }
                 const bool fused = fuseable && proj_multi_q4k(xn, Wp, Yp, Ns, nm, H, v6);
                 if (fused)


### PR DESCRIPTION
## Summary

The two Q4_K int8 tensor-core GEMVs in Muse Glimmer's packed decode are 45% of a c16 step, and
every one of their costs is a shape the packed step never runs:

- **`As`/`Ad`/`Asum` are staged for 32 rows on every launch** — 10 KB of the CTA's 18.75 KB, which
  at 100 KB of shared per SM holds them to five CTAs where their own `__launch_bounds__(128, 8)`
  asks for eight. Instantiating at the dispatched width gives 13.75 KB (16 rows) / 11.25 KB (8).
- **Both `m16n8k32` M-tiles are issued and the second discarded** by `lm < M`. At ≤16 rows that is
  half the `mma.sync` and half the `ldmatrix`.
- **Every Q4_K quant byte is fetched twice.** A byte holds two weights, 32 int8 lanes apart in
  `Bs`; the loader indexed the chunk and the nibble half together, so it walked the super-block's
  128 B plane once per nibble plane. Eight units, one fetch, two stores.
- **The Q6_K `attn_v` slot was instantiated only to eight rows** though its body is width-generic,
  so half of Muse's layers kept a 256-block launch of their own at c16/c32 — 52 launches and
  0.68 ms of a 19 ms step to move 36 MB.

Bit-identical: nothing changes what is computed or the order it is folded in. `ctest` 23/23.
`SPARKINFER_MMA_ASTAGE=0`, `SPARKINFER_MMA_BDEDUP=0`, `SPARKINFER_MUSE_V6_WIDE=0` each restore
main, so both arms of every A/B come out of one binary.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

**Decode tok/s** (concurrent decode @c16):

| | decode tok/s |
|---|--:|
| before (main) | 650.4 |
| after (this PR) | 784.8 |

**Prefill pp tok/s**:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not targeted — path unreachable; measured flat, 9702 |
| after prefill (this PR) | not targeted — path unreachable; measured flat, 9700 |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries** and needs a `.gguf`
file, so it cannot measure a branch. The numbers below are `qwen3_gguf_cb_bench <gguf> C 256 256
512`, the harness the `muse-cb-decode@cN` axes are scored on. RTX 5090 / CUDA 13.0, base `4901b43`,
arms mirrored out of one binary.

```text
=== muse-cb-decode@cN, base 4901b43 ===        decode_tokens (expected C*256+8)
       main                    this PR          delta
  c2   167.4 / 167.5           167.3 / 167.4    -0.1%    520 / 520
  c4   233.5 / 233.6           233.5 / 233.6     0.0%    1032 / 1032
  c8   374.2 / 369.1           425.7 / 425.0   +14.4%    2056 / 2056
  c16  654.2 / 646.5           785.2 / 784.3   +20.7%    4104 / 4104
  c32  887.7 / 879.4 / 881.8   976.8 / 976.0 / 976.7
                                               +10.6%    8200 / 8200

c2/c4 are flat by construction: both mma arms are gated at M >= 8, and the Q6_K fold already
covered every width below nine.
c32 agg is bimodal on this box in prefill, in BOTH arms -- one of four this-PR runs read 767.9
with mean_itl 23.61, i.e. a full-speed step and a slow prefill. The three clean runs are quoted;
mean_itl_ms 27.42 -> 23.73 (-13.5%) is the mode-independent figure.

=== nsys, one steady packed step at c16 (--cuda-graph-trace=node) ===
  down_q4k_mma_rows        107.06 -> 72.41 us/launch  (52)
  si_mmvq_q4k_mma           30.12 -> 25.02 us/launch  (104: attn_q + attn_gate)
  si_mmvq_q6k_rows_exact    0.675 ms/step -> gone     (52 launches -> 0)
  step                      22.98 -> 18.92 ms

=== twelve single-stream axes: unreachable (AR decode is N=1), measured flat ===
  ctx        decode main / PR        prefill pp main / PR
  128       107.334 / 107.680         9702 / 9700
  512       107.025 / 106.852        14885 / 14925
  4096      103.737 / 104.236        14041 / 14012
  16384     103.299 / 103.300        13297 / 13286
  32768     101.908 / 101.961        12149 / 12150
  65536     100.045 / 100.025        10440 / 10441
```
