### PR TITLE
perf(muse): score the packed decode's attention in-projections on the resident NVFP4 qkv-gate operand (1.05x concurrent decode @c16)

### DIFF
--- a/kernels/csrc/cuda/fused/batched_prefill.cu
+++ b/kernels/csrc/cuda/fused/batched_prefill.cu
@@ -1628,6 +1628,34 @@ void launch_prefill_add(const void* a, const void* b, void* out, long n, cudaStr
         reinterpret_cast<__nv_bfloat16*>(out), n);
 }
 
+// Scatter one [rows, pitch] block-scaled GEMM output into the four tensors the layer expects.
+// The fused q|gate|k|v NVFP4 operand produces them contiguous in one row; every consumer
+// downstream (QK-norm, the KV append, the q-gate sigmoid) wants its own tight row stride.
+__global__ void pf_qkvg_unpack_kernel(const __nv_bfloat16* __restrict__ src, int pitch,
+                                      __nv_bfloat16* __restrict__ q, __nv_bfloat16* __restrict__ g,
+                                      __nv_bfloat16* __restrict__ k, __nv_bfloat16* __restrict__ v,
+                                      int rows, int qdim, int kvdim) {
+    const int w = 2 * qdim + 2 * kvdim;
+    const long i = (long)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= (long)rows * w) return;
+    const int r = (int)(i / w), c = (int)(i - (long)r * w);
+    const __nv_bfloat16 x = src[(long)r * pitch + c];
+    if (c < qdim)                  q[(long)r * qdim + c] = x;
+    else if (c < 2 * qdim)         g[(long)r * qdim + (c - qdim)] = x;
+    else if (c < 2 * qdim + kvdim) k[(long)r * kvdim + (c - 2 * qdim)] = x;
+    else                           v[(long)r * kvdim + (c - 2 * qdim - kvdim)] = x;
+}
+
+void launch_muse_qkvg_unpack(const void* src, int pitch, void* q, void* gate, void* k, void* v,
+                             int rows, int qdim, int kvdim, cudaStream_t stream) {
+    const long n = (long)rows * (2 * qdim + 2 * kvdim);
+    pf_qkvg_unpack_kernel<<<(int)((n + 255) / 256), 256, 0, stream>>>(
+        reinterpret_cast<const __nv_bfloat16*>(src), pitch,
+        reinterpret_cast<__nv_bfloat16*>(q), reinterpret_cast<__nv_bfloat16*>(gate),
+        reinterpret_cast<__nv_bfloat16*>(k), reinterpret_cast<__nv_bfloat16*>(v),
+        rows, qdim, kvdim);
+}
+
 void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,
                                  int n_tokens, int n_heads, int head_dim, cudaStream_t stream) {
     const long n = (long)n_tokens * n_heads * head_dim;

--- a/kernels/include/sparkinfer/kernels/prefill.h
+++ b/kernels/include/sparkinfer/kernels/prefill.h
@@ -46,6 +46,11 @@ void launch_prefill_split_q_gate(const void* qraw, void* q, void* gate,
                                  int n_tokens, int n_heads, int head_dim,
                                  cudaStream_t stream = nullptr);
 
+// Scatter a fused q|gate|k|v GEMM output -- src[rows, pitch] with pitch >= 2*qdim+2*kvdim -- into
+// the four tight-strided tensors the rest of a Muse Glimmer layer reads.
+void launch_muse_qkvg_unpack(const void* src, int pitch, void* q, void* gate, void* k, void* v,
+                             int rows, int qdim, int kvdim, cudaStream_t stream = nullptr);
+
 // Batched attn *= sigmoid(gate), elementwise over n_tokens*dim (Qwen3.6 q-gate).
 // gate_ld: row pitch of `gate` in elements when it is a column slice of a wider packed buffer.
 void launch_prefill_mul_sigmoid(void* attn, const void* gate, int n_tokens, int dim,

--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3222,6 +3222,9 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         return v < 1 ? 1 : v;
     }();
     unsigned char* fp4_a = nullptr; unsigned char* fp4_asf = nullptr; unsigned char* fp4_ws = nullptr;
+    // [NA, qkvg_n] bf16 landing pad for the fused q|gate|k|v block-scaled GEMM below.
+    bf16* fp4_qkv = nullptr;
+    const int qkvg_n = 2 * qdim + 2 * kvdim;
     if (packed && c.dense_ffn) {
         const size_t ab = kernels::prefill_nvfp4_data_bytes(NA, fp4_kwide);
         const size_t sb = kernels::prefill_nvfp4_scale_bytes_a(NA, fp4_kwide);
@@ -3234,6 +3237,13 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
         if (s.w.lm_head_fp4) {
             const size_t wb3 = kernels::prefill_nvfp4_workspace_bytes_f32(NA, c.vocab, H);
             if (wb3 > wb) wb = wb3;
+        }
+        // ...and the fused attention in-projection, same rule: one buffer serves whichever GEMM
+        // the pass launches, or initialize() fails and the arm silently declines.
+        if (c.muse_glimmer && s.w.layers[0].qkvg_fp4) {
+            const size_t wb4 = kernels::prefill_nvfp4_workspace_bytes(NA, qkvg_n, H);
+            if (wb4 > wb) wb = wb4;
+            fp4_qkv = a.alloc<bf16>((size_t)NA * qkvg_n);
         }
         fp4_a   = a.alloc<unsigned char>(ab);
         fp4_asf = a.alloc<unsigned char>(sb);
@@ -3895,8 +3905,37 @@ int dflash_verify_short_run(const Qwen35PrefillCtx& s, const int* token_ids, int
                 }();
                 const bool v6 = (v6_wide || !wide) && !v4 && w.wv_type == 14;
                 if (v4 || v6) { Wp[nm] = w.wv; Yp[nm] = vf; Ns[nm++] = kvdim; }
-                const bool fused = fuseable && proj_multi_q4k(xn, Wp, Yp, Ns, nm, H, v6);
-                if (fused)
+                // THE FUSED NVFP4 q|gate|k|v OPERAND IS ALREADY RESIDENT. qwen35.cpp converts
+                // it at load for prefill (`qkvg_fp4`, one [2*qdim+2*kvdim, H] block-scaled
+                // matrix), and prefill_batched_run has driven the attention in-projections
+                // through it since it was written -- but the packed decode never picked it up
+                // and still issues Q4_K: q and the gate on the int8 mma arm, k and v on the
+                // chunked row grid. Three launches, 2.14 + 0.90 ms of an 18.7 ms c16 step at
+                // 0.75 and 0.14 TB/s, against ONE block-scaled GEMM over the same 32.6 MB at the
+                // 1.10 TB/s the gate/up GEMM beside it already reaches. The operand costs no
+                // VRAM it was not already costing, and the layer's own consumers want tight row
+                // strides, so the one [N, qkvg_n] result is scattered back out.
+                // Under nine rows this stays on the Q4_K grid the narrow widths were fitted for.
+                // SPARKINFER_MUSE_QKVG_FP4=0 restores the Q4_K projections.
+                static const int qkvg_fp4_on = [] {
+                    const char* e = getenv("SPARKINFER_MUSE_QKVG_FP4");
+                    return (e && e[0] == '0') ? 0 : 1; }();
+                bool qkvg_done = false;
+                if (qkvg_fp4_on && wide && fp4_a && fp4_asf && fp4_qkv &&
+                    w.qkvg_fp4 && w.qkvg_fp4_sf && N >= kProjGemmMinRows &&
+                    kernels::prefill_nvfp4_supported(Ng, qkvg_n, H) &&
+                    kernels::launch_prefill_nvfp4_quant_a(xn, fp4_a, fp4_asf, Ng, H, st) &&
+                    kernels::launch_prefill_nvfp4_gemm(fp4_a, fp4_asf, w.qkvg_fp4, w.qkvg_fp4_sf,
+                                                       fp4_qkv, Ng, qkvg_n, H, fp4_ws, st)) {
+                    kernels::launch_muse_qkvg_unpack(fp4_qkv, qkvg_n, qb, qg, kf, vf,
+                                                     N, qdim, kvdim, st);
+                    qkvg_done = true;
+                    supported = true;
+                }
+                const bool fused = !qkvg_done && fuseable &&
+                                   proj_multi_q4k(xn, Wp, Yp, Ns, nm, H, v6);
+                if (qkvg_done) { /* issued above */ }
+                else if (fused)
                     supported =
                         (!wide || (proj(xn, w.wq, w.wq_type, qb, qdim, H) &&
                                    w.wgate && proj(xn, w.wgate, w.wgate_type, qg, qdim, H))) &&


### PR DESCRIPTION
## Summary

Muse Glimmer's packed continuous-batch decode issues its four attention in-projections as Q4_K — q and the gate on the int8 mma arm, k and v on the chunked row grid. Three launches, **3.04 ms of an 18.7 ms c16 step**, at 0.75 and 0.14 TB/s.

The fused NVFP4 `q|gate|k|v` operand they want is **already resident**: `qwen35.cpp` converts it at load (`qkvg_fp4`, one `[2*qdim+2*kvdim, H]` block-scaled matrix) and `prefill_batched_run` has driven these same four projections through it as ONE block-scaled GEMM since it was written. The packed path simply never picked it up. One GEMM over the same 32.6 MB runs at the 1.10 TB/s the gate/up GEMM beside it already reaches, and costs no VRAM that was not already spent; the single `[N, qkvg_n]` result is scattered back out to the tight row strides the layer's own consumers want.

Scoped to the packed path above eight rows, so c2/c4/c8 and all twelve single-stream axes are unreachable by construction (measured flat). Where the load-time VRAM budget drops the operand — concurrency 32 — the arm declines and main's Q4_K path runs unchanged. `SPARKINFER_MUSE_QKVG_FP4=0` restores main, so both arms of every A/B come out of one binary.

`ctest` 23/23.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

**Decode tok/s** (concurrent decode @c16):

| | decode tok/s |
|---|--:|
| before (main) | 786.7 |
| after (this PR) | 828.1 |

**Prefill pp tok/s**:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not targeted — path unreachable; measured flat, 14958 |
| after prefill (this PR) | not targeted — path unreachable; measured flat, 14925 |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries** and needs a `.gguf` file, so it cannot measure a branch. The numbers below are `qwen3_gguf_cb_bench <gguf> C 256 256 512`, the harness the `muse-cb-decode@cN` axes are scored on. RTX 5090 / CUDA 13.0, base `c00d7c4`, arms interleaved main/PR/PR/main out of ONE binary.

```text
=== muse-cb-decode@cN, base c00d7c4 ===          decode_tokens (expected C*256+8)
         main              this PR        delta
  c2   170.0 / 167.1     167.8 / 167.1    -0.7%    520 / 520
  c4   235.9 / 233.4     233.9 / 233.4    -0.4%    1032 / 1032
  c8   427.3 / 425.0     425.3 / 424.5    -0.3%    2056 / 2056
  c16  788.2 / 785.2     828.5 / 827.6    +5.3%    4104 / 4104   mean_itl 18.62 -> 17.59 ms
  c32  763.3 / 967.7     766.7 / 977.5       --    8200 / 8200

c32 is bimodal on main (~770 and ~975 wall-clock modes, same mean_itl); both arms landed in both modes in this batch, and the operand is dropped there by the load-time VRAM budget so this arm declines and runs main's path.

=== 12 single-stream axes (bench_sweep_run), main -> this PR ===
  ctx      decode                prefill
  128      107.67 -> 107.72      9696.2 -> 9690.2
  512      106.97 -> 106.99     14958.4 -> 14925.1
  4096     104.28 -> 103.64     14044.6 -> 14028.0
  16384    103.33 -> 103.32     13307.9 -> 13297.7
  32768    102.00 -> 102.00     12156.9 -> 12157.9
  65536    100.05 -> 100.04     10454.0 -> 10456.1
```
