### PR TITLE
perf(muse): let the continuous-batch ramp widen at every concurrency, not just sixteen rows and up (1.03x concurrent decode @c8)

### DIFF
--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -186,7 +186,34 @@ ScheduleBatch Scheduler::schedule(const std::vector<ScheduledSequence>& active) 
             if (s->phase == SeqPhase::PREFILL) ++pending;
         const int wide = packed_decode_width();
         const int have = (int)batch.decode_request_ids.size();
-        const bool deep_ramp = (pending + have) * 2 >= wide;
+        // ...and "deep" has to be measured against the batch this load will reach, not against
+        // the packed-decode ceiling. Fixed at packed_decode_width() the test needs sixteen rows
+        // in flight, which no concurrency below sixteen can ever produce -- so c2/c4/c8 keep
+        // allow == 1 and ramp one row per iteration however deep their backlog is, which is the
+        // exact regime the rule above was written to fix, unreachable by construction. The cost
+        // of the extra admission is one prefill and is flat in concurrency; the saving is the
+        // iterations not spent at a narrow width, and a narrow step is not cheap -- on Muse
+        // Glimmer a packed step is 16.73 ms of fixed weight read against 0.125 ms per row, so a
+        // two-row step costs 95% of a sixteen-row one.
+        //
+        // Measured on Muse Glimmer, box19, the bot's own invocation
+        // (qwen3_gguf_cb_bench <model> C 256 256 512), agg_tok_s, two interleaved repeats per
+        // arm out of ONE binary:
+        //
+        //   concurrency        2         4          8
+        //   before        169.7     234.3      425.8
+        //   after         170.4     236.3      437.0   (+2.6% at 8, +0.9% at 4, +0.4% at 2)
+        //
+        // and mean ITL FALLS at eight (17.71 -> 17.54 ms), so the step is not paying for it.
+        // c16/c32 already satisfied the old test and are byte-for-byte unchanged, which is also
+        // why every DSpark concurrency dim (c16/c32) is untouched.
+        // SPARKINFER_CB_RAMP_DEEP_ROWS=32 restores the previous threshold exactly.
+        static const int deep_rows = [] {
+            const char* e = getenv("SPARKINFER_CB_RAMP_DEEP_ROWS");
+            const int x = e ? atoi(e) : 2;
+            return x < 1 ? 1 : x;
+        }();
+        const bool deep_ramp = (pending + have) * 2 >= deep_rows;
         const int allow = (have < wide && deep_ramp) ? prefills_per_step() : 1;
         int taken = 0;
         for (const ScheduledSequence* s : ordered) {


### PR DESCRIPTION
## Summary

`Scheduler::schedule` widens prefill admission while the decode batch is still filling, but only once the ramp is "deep":

```cpp
const bool deep_ramp = (pending + have) * 2 >= wide;   // wide = packed_decode_width() = 32 const int allow = (have < wide && deep_ramp) ? prefills_per_step() : 1;
```

`wide` is the packed-decode ceiling, so the test needs **sixteen rows in flight** — which no concurrency below sixteen can ever produce. c2/c4/c8 therefore keep `allow == 1` however deep their backlog is and ramp one sequence per iteration, each iteration paying a near-full weight read for a handful of rows. That is the exact regime the rule was written to fix, unreachable by construction.

Measured against the batch the load will actually reach instead. The cost of an extra admission is one prefill and is flat in concurrency; the saving is the iterations not spent at a narrow width, and a narrow step is not cheap here — a Muse packed step is **16.73 ms of fixed weight read against 0.125 ms per row**, so a two-row step costs 95% of a sixteen-row one.

c16/c32 already satisfied the old test and are unchanged, which is also why every DSpark concurrency dim is untouched. `SPARKINFER_CB_RAMP_DEEP_ROWS=32` restores the previous threshold exactly, so both arms of every A/B come out of one binary.

`ctest` 23/23.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

**Decode tok/s** (concurrent decode @c8):

| | decode tok/s |
|---|--:|
| before (main) | 425.8 |
| after (this PR) | 437.0 |

**Prefill pp tok/s**:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not targeted — `Scheduler` is unreachable from the prefill harness; measured flat, 14947 |
| after prefill (this PR) | not targeted — `Scheduler` is unreachable from the prefill harness; measured flat, 14936 |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries** and needs a `.gguf` file, so it cannot measure a branch. The numbers below are `qwen3_gguf_cb_bench <gguf> C 256 256 512`, the harness the `muse-cb-decode@cN` axes are scored on. RTX 5090 / CUDA 13.0, base `c00d7c4`, one binary, a discarded warm-up per axis and arms interleaved main/PR/PR/main.

```text
=== muse-cb-decode@cN, base c00d7c4 ===          decode_tokens (expected C*256+8)
         main              this PR        delta
  c2   170.0 / 169.3     169.7 / 171.1    +0.4%    520 / 520
  c4   234.5 / 234.1     235.9 / 236.7    +0.9%    1032 / 1032
  c8   426.0 / 425.6     437.0 / 437.0    +2.6%    2056 / 2056   mean_itl 17.71 -> 17.54 ms
  c16  785.1 / 784.6     784.8 / 785.1     0.0%    4104 / 4104   (old test already passed here)
  c32  766.7 / 976.9     761.5 / 975.5       --    8200 / 8200

c32 is bimodal on main (~765 and ~976 wall-clock modes at the same mean_itl); both arms landed in both modes in this batch. c16 and c32 satisfy the old threshold already, so their admission is unchanged.
```

`Scheduler` is constructed only by `InferenceEngine` / `qwen3_gguf_cb_bench`; `qwen3_gguf_bench` never builds one, so the twelve single-stream axes are untouched by construction:

```text
=== 12 single-stream axes (bench_sweep_run), main -> this PR ===
  ctx      decode                prefill
  128      107.33 -> 107.76      9672.3 -> 9699.1
  512      106.96 -> 106.99     14947.5 -> 14936.1
  4096     103.82 -> 104.22     13996.0 -> 14022.0
  16384    103.22 -> 103.27     13269.4 -> 13284.8
  32768    101.97 -> 101.93     12140.0 -> 12129.6
  65536    100.03 -> 100.01     10443.1 -> 10439.1
```
