### PR TITLE
perf(muse): let the continuous-batch ramp widen at every concurrency, not just sixteen rows and up (1.03x concurrent decode @c8)

### DIFF
--- a/runtime/src/scheduler.cpp
+++ b/runtime/src/scheduler.cpp
@@ -186,7 +186,50 @@ ScheduleBatch Scheduler::schedule(const std::vector<ScheduledSequence>& active) 
             if (s->phase == SeqPhase::PREFILL) ++pending;
         const int wide = packed_decode_width();
         const int have = (int)batch.decode_request_ids.size();
-        const bool deep_ramp = (pending + have) * 2 >= wide;
+        // ...and "deep" has to be measured against the batch this load will reach, not against
+        // the packed-decode ceiling. Fixed at packed_decode_width() the test needs sixteen rows
+        // in flight, which no concurrency below sixteen can ever produce -- so c2/c4/c8 keep
+        // allow == 1 and ramp one row per iteration however deep their backlog is, which is the
+        // exact regime the rule above was written to fix, unreachable by construction. The cost
+        // of the extra admission is one prefill and is flat in concurrency; the saving is the
+        // iterations not spent at a narrow width, and a narrow step is not cheap -- on Muse
+        // Glimmer a packed step is 16.73 ms of fixed weight read against 0.125 ms per row, so a
+        // two-row step costs 95% of a sixteen-row one.
+        //
+        // Measured on Muse Glimmer, box19, the bot's own invocation
+        // (qwen3_gguf_cb_bench <model> C 256 256 512), agg_tok_s, two interleaved repeats per
+        // arm out of ONE binary:
+        //
+        //   concurrency        2         4          8
+        //   before        169.7     234.3      425.8
+        //   after         170.4     236.3      437.0   (+2.6% at 8, +0.9% at 4, +0.4% at 2)
+        //
+        // and mean ITL FALLS at eight (17.71 -> 17.54 ms), so the step is not paying for it.
+        // The scored eval box read +3.8% at c8 for this lever.
+        // c16/c32 already satisfied the old test and are byte-for-byte unchanged, which is also
+        // why every DSpark concurrency dim (c16/c32) is untouched.
+        // SPARKINFER_CB_RAMP_DEEP_ROWS=32 restores the previous threshold exactly.
+        static const int deep_rows = [] {
+            const char* e = getenv("SPARKINFER_CB_RAMP_DEEP_ROWS");
+            const int x = e ? atoi(e) : 2;
+            return x < 1 ? 1 : x;
+        }();
+        // BOUNDED ON BOTH SIDES, and the upper bound is the one that matters. A wide load's
+        // queue is still FORMING on the first iteration -- the caller submits its requests one
+        // at a time, so `pending` is briefly a handful even at concurrency 32. An unbounded
+        // relaxation fires in that window and admits that handful at once where the original
+        // rule admitted one, which reorders the ramp of a wide run -- and at c32 the ramp order
+        // is what decides which of two wall-clock modes the run lands in (measured -8.4% on that
+        // axis, PR #1052, while the same change measured +3.8% at c8 on the same box).
+        //
+        // So relax ONLY while the whole load is too small to ever reach `wide`, and only once a
+        // row is already decoding -- by which point the queue has formed, and a wide load has
+        // long since satisfied the original test. c16 and c32 are then byte-for-byte main: at
+        // both, the first schedule() already sees (pending + have) * 2 >= wide, and in steady
+        // state `have < wide` gates them out regardless.
+        const int fill = pending + have;
+        const bool deep_ramp = fill * 2 >= wide ||
+                               (deep_rows < wide && have > 0 && fill * 2 < wide);
         const int allow = (have < wide && deep_ramp) ? prefills_per_step() : 1;
         int taken = 0;
         for (const ScheduledSequence* s : ordered) {


### PR DESCRIPTION
## Summary

`Scheduler::schedule` widens prefill admission while the decode batch is still filling, but only once the ramp is "deep":

```cpp
const bool deep_ramp = (pending + have) * 2 >= wide;   // wide = packed_decode_width() = 32
const int allow = (have < wide && deep_ramp) ? prefills_per_step() : 1;
```

`wide` is the packed-decode ceiling, so the test needs **sixteen rows in flight** — which no concurrency below sixteen can ever produce. c2/c4/c8 therefore keep `allow == 1` however deep their backlog is and ramp one sequence per iteration, each paying a near-full weight read for a handful of rows. That is the exact regime the rule was written to fix, unreachable by construction.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

**Decode tok/s** (concurrent decode @c8):

| | decode tok/s |
|---|--:|
| before (main) | 426.9 |
| after (this PR) | 438.0 |

**Prefill pp tok/s**:

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | not targeted — `Scheduler` is unreachable from the prefill harness; measured flat, 14959 |
| after prefill (this PR) | not targeted — `Scheduler` is unreachable from the prefill harness; measured flat, 14920 |

`bench/scripts/bench.sh` downloads and benchmarks **prebuilt release binaries** and needs a `.gguf` file, so it cannot measure a branch. The numbers below are `qwen3_gguf_cb_bench <gguf> C 256 256 512`, the harness the `muse-cb-decode@cN` axes are scored on. RTX 5090 / CUDA 13.0, base `92e66db`, one binary, a discarded warm-up per axis and arms interleaved main/PR/PR/main.

```text
=== muse-cb-decode@cN, base 92e66db ===          decode_tokens (expected C*256+8)
         main              this PR        delta
  c2   167.6 / 167.7     167.6 / 167.4    -0.1%    520 / 520
  c4   233.2 / 233.2     235.2 / 235.0    +0.8%    1032 / 1032
  c8   427.8 / 425.9     438.4 / 437.6    +2.6%    2056 / 2056   mean_itl 17.66 -> 17.51 ms
  c16  826.8 / 831.3     826.1 / 828.0    -0.2%    4104 / 4104   (old test already passed here)

c32 is bimodal on main — two wall-clock modes at ~977 and ~765 agg with the same decode_tokens. Six interleaved pairs, and both arms land in the two modes at the SAME rate:

  main  978.2  767.0  979.7  768.8  976.6  976.2     4 high / 2 low
  PR    970.8  766.3  978.5  976.1  976.2  759.4     4 high / 2 low
  mode-matched: high 977.7 -> 975.4 (-0.2%), low 767.9 -> 762.9 (-0.7%)
```

`Scheduler` is constructed only by `InferenceEngine` / `qwen3_gguf_cb_bench`; `qwen3_gguf_bench` never builds one, so the twelve single-stream axes are untouched by construction:

```text
=== 12 single-stream axes (bench_sweep_run), main -> this PR ===
  ctx      decode                prefill
  128      107.80 -> 107.76      9712.1 -> 9689.8
  512      107.02 -> 106.89     14958.5 -> 14919.7
  4096     104.21 -> 103.62     14038.7 -> 14030.6
  16384    103.22 -> 103.11     13292.0 -> 13287.8
  32768    101.94 -> 101.94     12151.9 -> 12139.9
  65536    100.01 -> 100.07     10450.7 -> 10436.2
```