### PR TITLE
perf(moe): precompute Q4_K scales for Muse concurrent decode

### DIFF
--- a/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
+++ b/kernels/csrc/cuda/moe/expert_ffn_q4k.cu
@@ -1980,11 +1980,10 @@ __device__ __forceinline__ void si_mma_q4k_scales(const unsigned char* sc12, int
 // things here were sized for the 32-row ceiling on EVERY launch, and a packed step narrower than
 // 32 rows paid both:
 //
-//   * the shared A tile -- As + Ad + Asum is 10 KB of the CTA's 18.75 KB at MM=32, and at 100 KB
-//     of shared per SM that 18.75 KB is what holds the kernel to five CTAs per SM. Its own
-//     __launch_bounds__ asks for eight, and the register allocator already honours that; only
-//     shared memory was standing in the way. MM=16 is 13.75 KB (seven CTAs), MM=8 is 11.25 KB
-//     (eight).
+//   * the shared A tile -- As + Ad + Asum is 10 KB at MM=32. Including the precomputed, padded
+//     B scale pairs below, total shared storage is 20.25 KB at MM=32, 15.25 KB at MM=16 and
+//     12.75 KB at MM=8. Under a 100 KB shared-memory budget these permit four, six and seven
+//     CTAs respectively (before other resource limits), instead of sizing every width for 32.
 //   * the M-tile loop, which issued BOTH m16n8k32 tiles unconditionally and then discarded the
 //     second through `lm < M`. At sixteen rows or fewer the second tile is pure waste: half the
 //     mma.sync and half the ldmatrix on As.
@@ -2015,8 +2014,11 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
 
     __shared__ signed char As[MM][256];
     __shared__ signed char Bs[SI_MMA_BN][256];
-    __shared__ unsigned char Ssc[SI_MMA_BN][8], Smn[SI_MMA_BN][8];
-    __shared__ float2 Wdm[SI_MMA_BN];
+    // Each loading lane expands one scale group, instead of c==0 serially unpacking all eight.
+    // A half times a six-bit integer fits exactly in float (at most 17 significant bits), so
+    // storing these products adds no rounding to the existing fold. The consumer reads columns
+    // spaced two rows apart; a nine-pair stride avoids their four-way shared-bank aliasing.
+    __shared__ float2 Bscale[SI_MMA_BN][9];
     __shared__ float Ad[MM][8], Asum[MM][8];
 
     constexpr int NT = (MM + 15) / 16;   // 16-row mma tiles this width actually needs
@@ -2058,16 +2060,11 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
                     *reinterpret_cast<const uint4*>(lo);
                 *reinterpret_cast<uint4*>(&Bs[r][si_mma_swz(kb + 32, r)]) =
                     *reinterpret_cast<const uint4*>(hi);
-                if (c == 0) {
-                    Wdm[r] = __half22float2(b->dm);
-                    #pragma unroll
-                    for (int jj = 0; jj < 4; jj++) {
-                        unsigned char x0, x1, y0, y1;
-                        si_mma_q4k_scales(b->scales, jj, x0, x1, y0, y1);
-                        Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
-                        Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
-                    }
-                }
+                unsigned char x0, x1, y0, y1;
+                si_mma_q4k_scales(b->scales, c >> 1, x0, x1, y0, y1);
+                const float2 dm = __half22float2(b->dm);
+                Bscale[r][c] = make_float2(dm.x * (float)((c & 1) ? x1 : x0),
+                                          dm.y * (float)((c & 1) ? y1 : y0));
             }
         } else {
             for (int u = tid; u < SI_MMA_BN * 16; u += SI_MMA_NW * 32) {
@@ -2089,15 +2086,12 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
                 }
                 const int kb = 64 * j + (sc_ >> 1) * 32 + (sc_ & 1) * 16;
                 *reinterpret_cast<uint4*>(&Bs[r][si_mma_swz(kb, r)]) = *reinterpret_cast<const uint4*>(out);
-                if (c == 0) {
-                    Wdm[r] = __half22float2(b->dm);
-                    #pragma unroll
-                    for (int jj = 0; jj < 4; jj++) {
-                        unsigned char x0, x1, y0, y1;
-                        si_mma_q4k_scales(b->scales, jj, x0, x1, y0, y1);
-                        Ssc[r][2 * jj] = x0; Ssc[r][2 * jj + 1] = x1;
-                        Smn[r][2 * jj] = y0; Smn[r][2 * jj + 1] = y1;
-                    }
+                if (c < 8) {
+                    unsigned char x0, x1, y0, y1;
+                    si_mma_q4k_scales(b->scales, c >> 1, x0, x1, y0, y1);
+                    const float2 dm = __half22float2(b->dm);
+                    Bscale[r][c] = make_float2(dm.x * (float)((c & 1) ? x1 : x0),
+                                              dm.y * (float)((c & 1) ? y1 : y0));
                 }
             }
         }
@@ -2116,7 +2110,6 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
         __syncthreads();
 
         const int lnA = warp * 8 + tig * 2;
-        const float2 dmA = Wdm[lnA], dmB = Wdm[lnA + 1];
         #pragma unroll 1
         for (int g = 0; g < 8; g++) {
             const int kk = g * 32;
@@ -2125,8 +2118,9 @@ void down_q4k_mma_rows_kernel(const unsigned char* __restrict__ down_q,
             // accumulator elements is being folded. Fetching them per element cost five shared
             // loads per output element per group; hoisting collapses that to a handful per group.
             // Ablating this fold-in measured it at 111 us of the kernel's 169.
-            const float sA = dmA.x * (float)Ssc[lnA][g],     mA = dmA.y * (float)Smn[lnA][g];
-            const float sB = dmB.x * (float)Ssc[lnA + 1][g], mB = dmB.y * (float)Smn[lnA + 1][g];
+            const float2 scaleA = Bscale[lnA][g], scaleB = Bscale[lnA + 1][g];
+            const float sA = scaleA.x, mA = scaleA.y;
+            const float sB = scaleB.x, mB = scaleB.y;
             float adv[NT][2], asv[NT][2];
             #pragma unroll
             for (int ii = 0; ii < NT; ii++)

--- a/kernels/tests/CMakeLists.txt
+++ b/kernels/tests/CMakeLists.txt
@@ -42,6 +42,15 @@ set_target_properties(mmvq_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)
 add_executable(down_mma_accuracy_gpu_test down_mma_accuracy_gpu_test.cpp)
 target_link_libraries(down_mma_accuracy_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
 set_target_properties(down_mma_accuracy_gpu_test PROPERTIES CXX_STANDARD 17)
+add_executable(down_mma_scales_gpu_test down_mma_scales_gpu_test.cpp)
+target_link_libraries(down_mma_scales_gpu_test PRIVATE sparkinfer_kernels CUDA::cudart)
+set_target_properties(down_mma_scales_gpu_test PROPERTIES CXX_STANDARD 17)
+add_test(NAME down_mma_scales_gpu_test COMMAND down_mma_scales_gpu_test)
+add_test(NAME down_mma_scales_legacy_loader_gpu_test COMMAND down_mma_scales_gpu_test)
+set_tests_properties(down_mma_scales_gpu_test down_mma_scales_legacy_loader_gpu_test
+                    PROPERTIES SKIP_RETURN_CODE 77)
+set_tests_properties(down_mma_scales_gpu_test PROPERTIES ENVIRONMENT "SPARKINFER_MMA_BDEDUP=1")
+set_tests_properties(down_mma_scales_legacy_loader_gpu_test PROPERTIES ENVIRONMENT "SPARKINFER_MMA_BDEDUP=0")
 # The tensor-core LM head against the dp4a multi-row kernel it replaces. Both arms are exported
 # functions, so one process covers both. Not a ctest: it needs ~0.8 GB of device memory.
 add_executable(head_mma_accuracy_gpu_test head_mma_accuracy_gpu_test.cpp)

--- a/kernels/tests/down_mma_scales_gpu_test.cpp
+++ b/kernels/tests/down_mma_scales_gpu_test.cpp
@@ -1,0 +1,196 @@
+// Exercise Q4_K scale/min decoding and the down-MMA scratch lifecycle through the
+// production launcher. Logical weights are generated before packing, so the
+// oracle never uses the production metadata decoder. Group-constant, exactly
+// representable activations make the Q8_1 scale and sum independently known.
+#include "sparkinfer/kernels/moe.h"
+#include <cuda_bf16.h>
+#include <cuda_fp16.h>
+#include <cuda_runtime.h>
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <stdexcept>
+#include <vector>
+
+namespace {
+void check(cudaError_t status) {
+    if (status != cudaSuccess) throw std::runtime_error(cudaGetErrorString(status));
+}
+template <class T> struct Buffer {
+    T* p = nullptr;
+    explicit Buffer(size_t n) { check(cudaMalloc(&p, n * sizeof(T))); }
+    ~Buffer() { cudaFree(p); }
+    Buffer(const Buffer&) = delete;
+    Buffer& operator=(const Buffer&) = delete;
+};
+
+struct Inputs {
+    Buffer<__nv_bfloat16> gate, up, output;
+    Buffer<float> weights, h, scratch;
+    Buffer<int> ids;
+    std::vector<__nv_bfloat16> host_up;
+    std::vector<float> host_weights;
+    Inputs(int H, int F) : gate(32u*F), up(32u*F), output(32u*H),
+        weights(32), h(32u*F), scratch(32u*H), ids(32),
+        host_up(32u*F), host_weights(32) {
+        std::vector<__nv_bfloat16> g(32u*F, __float2bfloat16(32.f));
+        check(cudaMemcpy(gate.p, g.data(), g.size()*sizeof(g[0]), cudaMemcpyHostToDevice));
+        check(cudaMemset(ids.p, 0, 32*sizeof(int)));
+        check(cudaMemset(scratch.p, 0, 32u*H*sizeof(float)));
+    }
+};
+
+void run_shape(int H, int F, const std::vector<int>& widths, cudaStream_t* streams) {
+    const int blocks = F / 256;
+    const size_t bytes = (size_t)2 * H * blocks * 144;
+    std::vector<unsigned char> packed(bytes, 0);
+    std::vector<double> dot_coefficient(2*H, 0), min_coefficient(2*H, 0);
+    for (int r = 0; r < 2*H; ++r) {
+        for (int b = 0; b < blocks; ++b) {
+            auto* p = packed.data() + ((size_t)r*blocks+b)*144;
+            const float d = std::ldexp(1.f, -10-(r%3));
+            const float dm = std::ldexp(1.f, -11-(b%2));
+            const __half hd = __float2half(d), hm = __float2half(dm);
+            std::memcpy(p, &hd, 2); std::memcpy(p+2, &hm, 2);
+            unsigned sc[8], mn[8];
+            for (int g = 0; g < 8; ++g) {
+                sc[g] = (13*r+7*b+9*g)%63+1;
+                mn[g] = (17*r+11*b+5*g)%64;
+                int sum_q = 0;
+                for (int j = 0; j < 32; ++j) {
+                    const unsigned q = (3*r+5*b+7*g+j)%16;
+                    p[16+(g/2)*32+j] |= (unsigned char)(q << (4*(g&1)));
+                    sum_q += (int)q;
+                }
+                // Eight distinct power-of-two activation magnitudes distinguish
+                // every scale/min group, including a permutation of two groups.
+                dot_coefficient[r] += (1u<<g)*(double)d*sc[g]*sum_q;
+                min_coefficient[r] += (1u<<g)*(double)dm*mn[g];
+            }
+            // Standard GGML Q4_K six-bit scale packing, independent of the
+            // kernel's pair-at-a-time uint16 decoder.
+            for (int g = 0; g < 4; ++g) {
+                p[4+g] = (unsigned char)(sc[g] | ((sc[g+4] >> 4) << 6));
+                p[8+g] = (unsigned char)(mn[g] | ((mn[g+4] >> 4) << 6));
+                p[12+g] = (unsigned char)((sc[g+4]&15) | ((mn[g+4]&15)<<4));
+            }
+        }
+    }
+    Buffer<unsigned char> down(bytes);
+    check(cudaMemcpy(down.p, packed.data(), bytes, cudaMemcpyHostToDevice));
+    Inputs a(H,F), b(H,F);
+    Inputs* inputs[] = {&a,&b};
+    std::vector<int> second_expert(32,1);
+    check(cudaMemcpy(b.ids.p,second_expert.data(),32*sizeof(int),cudaMemcpyHostToDevice));
+    // Initialization used the default stream; the two nonblocking streams must
+    // not race its copies, even with pageable host buffers.
+    check(cudaDeviceSynchronize());
+    const float values[] = {.25f,-.25f,.5f,-.5f,1.f,-1.f,.125f,-.125f};
+
+    auto fill = [&](int lane, int M, bool zero) {
+        auto& x = *inputs[lane];
+        for (int row = 0; row < M; ++row) {
+            const float u = zero ? 0.f : values[row%8]*(lane+1)/128.f;
+            for (int col = 0; col < F; ++col)
+                x.host_up[(size_t)row*F+col] = __float2bfloat16(u*(1u<<((col/32)%8)));
+            x.host_weights[row] = row%3==0 ? 1.f : (row%3==1 ? .5f : -1.f);
+        }
+        check(cudaMemcpyAsync(x.up.p, x.host_up.data(), (size_t)M*F*sizeof(__nv_bfloat16),
+                              cudaMemcpyHostToDevice, streams[lane]));
+        check(cudaMemcpyAsync(x.weights.p, x.host_weights.data(), M*sizeof(float),
+                              cudaMemcpyHostToDevice, streams[lane]));
+    };
+    auto launch = [&](int lane, int M) {
+        auto& x = *inputs[lane];
+        sparkinfer::kernels::launch_moe_expert_ffn_q4k(
+            nullptr,nullptr,nullptr,down.p,12,12,12,x.ids.p,x.weights.p,
+            x.output.p,x.h.p,x.scratch.p,M,1,H,F,nullptr,streams[lane],false,x.gate.p,x.up.p);
+        check(cudaPeekAtLastError());
+    };
+    auto verify = [&](int lane, int M, bool zero) {
+        auto& x = *inputs[lane];
+        check(cudaStreamSynchronize(streams[lane]));
+        std::vector<__nv_bfloat16> out((size_t)M*H);
+        check(cudaMemcpy(out.data(),x.output.p,out.size()*sizeof(out[0]),cudaMemcpyDeviceToHost));
+        for (int row = 0; row < M; ++row) {
+            // SiLU(32) rounds to32 in float; Q8 codes are exactly +/-127.
+            // The per-group factors were folded into the oracle coefficients.
+            // Scaling these normal half values by powers of two is exact.
+            const float hv = zero ? 0.f : 32.f*values[row%8]*(lane+1)/128.f;
+            const double qd = __half2float(__float2half(std::fabs(hv)/127.f));
+            const double qs = __half2float(__float2half(hv*32.f));
+            const int qi = hv>0 ? 127 : (hv<0 ? -127 : 0);
+            for (int col = 0; col < H; ++col) {
+                const double want = (qd*qi*dot_coefficient[lane*H+col]-qs*min_coefficient[lane*H+col])
+                                    * x.host_weights[row];
+                const double got = __bfloat162float(out[(size_t)row*H+col]);
+                // BF16 rounding plus FP32 split-K summation, not a relaxed
+                // quantization comparison. Zero must remain exactly zero.
+                const double tolerance = zero ? 0.0 : std::max(.015625, std::fabs(want)*.008);
+                if (!std::isfinite(got) || std::fabs(got-want)>tolerance) {
+                    std::printf("FAIL H=%d F=%d M=%d stream=%d row=%d col=%d got=%.9g want=%.9g tol=%.9g\n",
+                                H,F,M,lane,row,col,got,want,tolerance);
+                    throw std::runtime_error("down MMA numerical or scratch-lifecycle mismatch");
+                }
+            }
+        }
+    };
+    for (int M : widths) {
+        for (int lane = 0; lane < 2; ++lane) fill(lane,M,false);
+        for (int lane = 0; lane < 2; ++lane) launch(lane,M);
+        for (int lane = 0; lane < 2; ++lane) verify(lane,M,false);
+        cudaGraph_t graphs[2]{};
+        cudaGraphExec_t execs[2]{};
+        for (int lane = 0; lane < 2; ++lane) {
+            check(cudaStreamBeginCapture(streams[lane],cudaStreamCaptureModeGlobal));
+            launch(lane,M);
+            check(cudaStreamEndCapture(streams[lane],&graphs[lane]));
+            check(cudaGraphInstantiate(&execs[lane],graphs[lane],nullptr,nullptr,0));
+        }
+        // Reuse the same captured launches across A -> zero -> A. Two streams
+        // carry distinct inputs; four replays expose missed accumulator resets.
+        for (bool zero : {false,true,false}) {
+            for (int lane = 0; lane < 2; ++lane) fill(lane,M,zero);
+            for (int lane = 0; lane < 2; ++lane) {
+                for (int repeat = 0; repeat < 4; ++repeat)
+                    check(cudaGraphLaunch(execs[lane],streams[lane]));
+            }
+            for (int lane = 0; lane < 2; ++lane) verify(lane,M,zero);
+        }
+        for (int lane = 0; lane < 2; ++lane) {
+            check(cudaGraphExecDestroy(execs[lane]));
+            check(cudaGraphDestroy(graphs[lane]));
+        }
+        std::printf("PASS down MMA scales H=%d F=%d M=%d eager + two-stream graph A/zero/A\n",H,F,M);
+    }
+}
+} // namespace
+
+int main() {
+    int count = 0;
+    if (cudaGetDeviceCount(&count)!=cudaSuccess || count==0) return 77;
+    setenv("SPARKINFER_DOWN_MMA","1",1);
+    setenv("SPARKINFER_DOWN_MMA_MINROWS","8",1);
+    setenv("SPARKINFER_DOWN_MMVQ","1",1);
+    setenv("SPARKINFER_DOWN_Q4K","1",1);
+    setenv("SPARKINFER_DOWN_SPLITK_S_Q4","8",1);
+    setenv("SPARKINFER_MMA_ASTAGE","1",1);
+    setenv("SPARKINFER_DOWN_SPLITK_WIDE_ROWS","5",1);
+    setenv("SPARKINFER_DOWN_SPLITK_WIDE_S","2",1);
+    cudaStream_t streams[2]{};
+    try {
+        check(cudaStreamCreateWithFlags(&streams[0],cudaStreamNonBlocking));
+        check(cudaStreamCreateWithFlags(&streams[1],cudaStreamNonBlocking));
+        run_shape(256,256,{8,9,16,17,32},streams);    // one K split
+        run_shape(1024,2304,{8,16,32},streams);       // uneven multiple splits
+        run_shape(6656,19968,{8,9,16,17,32},streams);// real Muse widths
+        check(cudaStreamDestroy(streams[0]));
+        check(cudaStreamDestroy(streams[1]));
+    } catch (const std::exception& e) {
+        std::fprintf(stderr,"FAIL: %s\n",e.what());
+        return 1;
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary

**Replacement submission for [#1055](https://github.com/gittensor-ai-lab/sparkinfer/pull/1055), with the same source code.** GitHub refused to reopen that PR after a commit-message-only force-push; restoring its recorded head and trying both REST and GraphQL did not reopen it. The original PR remains closed and unmerged. Its [evaluation discussion](https://github.com/gittensor-ai-lab/sparkinfer/pull/1055#issuecomment-5646676091) and DSpark result remain part of this submission's history. This is not a second optimization or a claim for duplicate credit.

**Performance target: Muse Glimmer concurrent decode at c8/c16.** The local same-RTX-5090 measurements are +2.699% and +2.651%, respectively. These are local results awaiting official Muse verification; this PR does not claim a Qwen3.8 ModelOpt/DSpark speedup.

**Evaluation status:** the [published DSpark result](https://github.com/gittensor-ai-lab/sparkinfer/pull/1055#issuecomment-5646004688) for the original head reported +0.2% (`none`) with its correctness and no-regression gates passing. The requested next step is a complete run of the existing Muse evaluator, including all normal guards. The Muse c8/c16 axes already exist.

**Wording-only revision:** pushed branch commit `a7bd73c2c9b37bc9b041f88880872e7e311d9f1f` rewords the commit message of `1bb4f593659de504d71c51bd78221412324b1873`. This replacement requests the outstanding complete Muse evaluation, with all normal accuracy and cross-model/no-regression guards. Their source trees are identical (`f69c51b53937b7eea4ce2213390cfa1f04d516aa`). The measurements and test results below were collected for the original source before this message-only revision; no new GPU run or additional speedup is claimed.

### Kernel change

Precompute the eight Q4_K down-MMA B scale/min pairs cooperatively while loading
each weight tile, replacing the single-lane metadata expansion and repeated
consumer multiplications. Pad the shared array to a nine-pair row stride to
avoid the consumer's four-way bank aliasing. This targets Lane 1, real measured
inference speedup.

Both existing B loaders are supported. Split-K, row-width dispatch, A staging,
quantization, the MMA instructions and the remaining fold association are
unchanged. A binary16 value times a six-bit integer fits exactly in FP32, so
storing that product introduces no additional rounding. The tradeoff is 1536
additional shared bytes per CTA (12.75 / 15.25 / 20.25 KiB at M8 / M16 / M32).

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [x] **Shared / both** — shared Q4_K kernel; both model guards checked

**Decode tok/s** (end-to-end Muse concurrent decode @c16, aggregate):

| | decode tok/s |
|---|--:|
| before (main) | 814.9 |
| after (this PR) | 836.5 |

The source-built command is the evaluator's `qwen3_gguf_cb_bench "$GGUF" C 256 256 512`,
not an isolated-kernel microbenchmark. `bench/scripts/bench.sh` defaults to release
prebuilt binaries; these measurements use separate builds of clean main
`bc0e47b799cf39b0429f346b5901bfee208e357e` and this change. Same physical RTX 5090,
driver 595.71.05, CUDA 12.8.93, SM120, no implementation-toggle overrides.
`SPARKINFER_BENCH_SWEEP_CTXS/REPS` are set only for the documented sweep recipe.

Each CB axis has a discarded warmup for each build followed by six interleaved
measured legs (main/PR/PR/main/main/PR); table values are three-run medians.
Every leg checks `decode_tokens == C*256+8`. Downloads and profiling were stopped
before timing. All raw measured samples are included below, not just the best run.

| Axis | Main | This PR | Change |
|---|---:|---:|---:|
| Muse CB decode c2 | 156.7 | 157.3 | +0.383% |
| Muse CB decode c4 | 225.7 | 225.7 | +0.000% |
| Muse CB decode c8 | 407.6 | 418.6 | +2.699% |
| Muse CB decode c16 | 814.9 | 836.5 | +2.651% |
| Muse CB decode c32 | 1130.1 | 1138.9 | +0.779% |
| Muse decode ctx128 | 104.6295 | 104.4162 | -0.204% |
| Muse prefill ctx128 | 9748.7726 | 9739.2224 | -0.098% |
| Muse decode ctx512 | 103.8064 | 103.6790 | -0.123% |
| Muse prefill ctx512 | 15249.6373 | 15199.8482 | -0.326% |
| Muse decode ctx4096 | 101.2445 | 101.1920 | -0.052% |
| Muse prefill ctx4096 | 14434.1239 | 14408.8772 | -0.175% |
| Muse decode ctx16384 | 100.3656 | 100.2667 | -0.099% |
| Muse prefill ctx16384 | 13764.8172 | 13747.9518 | -0.123% |
| Muse decode ctx32768 | 99.1356 | 99.0909 | -0.045% |
| Muse prefill ctx32768 | 12640.3508 | 12629.3382 | -0.087% |
| Muse decode ctx65536 | 97.2415 | 97.1979 | -0.045% |
| Muse prefill ctx65536 | 10924.8947 | 10928.0034 | +0.028% |
| Qwen3.6 guard decode ctx32768 | 462.1273 | 461.8103 | -0.069% |
| Qwen3.6 guard prefill ctx32768 | 25468.5173 | 25515.2597 | +0.184% |
| Qwen3.8 ModelOpt guard decode ctx32768 | 94.5386 | 94.5328 | -0.006% |
| Qwen3.8 ModelOpt guard prefill ctx32768 | 10963.9644 | 10945.8229 | -0.165% |

```text
Raw measured CB agg_tok_s samples (main / this PR), warmups excluded:
c2   [157.9, 156.7, 156.4]    / [157.6, 157.3, 155.8]
c4   [225.7, 225.4, 225.7]    / [225.7, 225.5, 225.7]
c8   [407.3, 407.6, 407.7]    / [417.9, 419.1, 418.6]
c16  [814.9, 814.9, 813.7]    / [836.1, 836.5, 837.0]
c32  [1111.4, 1130.1, 1131.2] / [1138.9, 1139.1, 1118.0]

Representative real harness lines, c16, main then this PR:
wall_s=5.036 decode_tokens=4104 agg_tok_s=814.9 mean_itl_ms=17.92 max_itl_ms=459.32
wall_s=4.906 decode_tokens=4104 agg_tok_s=836.5 mean_itl_ms=17.40 max_itl_ms=461.50
```

c32 exhibited two timing patterns in both builds; all samples are retained above.
The repeatable c8/c16 gains, not the highest individual c32 observation, are the
speedup claim. Every measured axis remains above the 98% no-regression floor.

Muse AR uses the unmodified sweep executable, 128 generated tokens, contexts
128/512 at five repeats, 4k/16k/32k at one repeat, and 64k at one repeat in a
separate load, matching the current Muse evaluator's recipe. Both cross-model
guards use 32k and five repeats. These are local reproductions; the official
evaluator's result remains authoritative.

## Correctness and tests

- Full configured CTest suite: 25/25 reported passed, zero failures. Optional
  LMCache integration internally skips when its external sidecar is unavailable;
  this is not a claim of testing LMCache deployment.
- Added two CTest processes exercising both B loader variants through the
  production launcher. Independent pre-packing double-precision oracle covers
  full six-bit scale/min metadata, eight distinct group activation magnitudes,
  signed inputs and routing weights, two different experts, multiple K-split
  counts and uneven splits, H/F 256/256, 1024/2304, 6656/19968, and M8/9/16/17/32.
- Two persistent nonblocking streams, explicit initialization ordering, eager
  execution and four CUDA-graph replays across A -> zero -> A. Final test passed
  both loader modes on main and this PR (52 shape-width cases across four runs).
- Mutation check: using an even scale for an odd group fails the final oracle
  immediately (`got=177`, `want=80.8588639`, tolerance=0.646870911). Mutant isolated
  from the tested final build.
- Final test under compute-sanitizer memcheck: 0 errors for each loader mode.
- Existing down-MMA synthetic fixture: baseline/candidate output dumps
  byte-identical at M8/9/16/17/32, twice each.
- Muse teacher-forced `qwen3_gguf_score`: baseline/candidate numeric output
  byte-identical, SHA256 `002574803daad976ce0671340ef7ad50bbb2281daa29e5719747d20f839589e4`.
- Unmodified `accuracy_compare.py` against native Muse llama.cpp
  `5bda51bfbc62e64193221e639f6ad4e08767d760`: 99 positions,
  top1=0.969697, KL=0.090603, PPL_spark=2.6881. Both accuracy bars pass.

No evaluator, benchmark script, frozen reference, scoring rule or other
maintainer-owned path is modified.

### Reproducibility

Muse: `meta-models/Muse-Glimmer-30B-GGUF` revision
`70bf1b61ac09f91b24d39038091b41c582bc5d7a`, KQuant17GB Q4_K_M GGUF,
file SHA256 `4cc57c0f51040a226e5a72cc47b7613f7772950e460a665f7083de89f183f60e`.
Qwen3.6 guard: `unsloth/Qwen3.6-35B-A3B-GGUF` revision
`a483e9e6cbd595906af30beda3187c2663a1118c`, UD-Q4_K_M SHA256
`ac0e2c1189e055faa36eff361580e79c5bd6f8e76bffb4ce547f167d53e31a61`.
Qwen3.8 guard: `gittensor-model-hub/Qwen3.8-27B-NVFP4-RTX5090` revision
`5b7a687fc8211a5d631c8ca6a593dd37eb26ce33`, both safetensors shards hash-verified.

```bash
# Each source revision built separately with CUDA 12.8.93 and SM120.
cmake -S . -B build-cuda12.8 -G Ninja -DCMAKE_CUDA_ARCHITECTURES=120 \
  -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS_RELEASE="-O3 -UNDEBUG" \
  -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON -DBUILD_CUTE_KERNELS=OFF -DBUILD_SERVER=OFF
cmake --build build-cuda12.8 -j12
ctest --test-dir build-cuda12.8 --output-on-failure
SPARKINFER_MMA_BDEDUP=1 compute-sanitizer --tool memcheck --error-exitcode 99 \
  build-cuda12.8/kernels/tests/down_mma_scales_gpu_test
SPARKINFER_MMA_BDEDUP=0 compute-sanitizer --tool memcheck --error-exitcode 99 \
  build-cuda12.8/kernels/tests/down_mma_scales_gpu_test
build-cuda12.8/runtime/qwen3_gguf_cb_bench "$GGUF" 16 256 256 512
SPARKINFER_BENCH_SWEEP_CTXS=128,512 SPARKINFER_BENCH_SWEEP_REPS=5 \
  build-cuda12.8/runtime/qwen3_gguf_bench "$GGUF" 128 sweep
```
