### PR TITLE
perf(muse): keep four packed rows on the Q3_A gate/up arm instead of the 128-row NVFP4 tile (1.03x concurrent decode @c4)

### DIFF
--- a/runtime/src/models/qwen35_prefill.cpp
+++ b/runtime/src/models/qwen35_prefill.cpp
@@ -3112,10 +3112,29 @@ static bool muse_packed_on() {
 // step is still on the dp4a path -- every tensor-core arm has an eight-row floor, because an
 // m16n8k32 tile pads M to sixteen. This is the one place a narrow batch can reach the tensor cores,
 // and the fitted six was keeping it off them.
+// Row count from which a packed step runs the dense gate/up as ONE block-scaled NVFP4 GEMM per
+// projection instead of the row-batched Q3_A GEMV.
+//
+// Four was right when it was fitted, and it is not right any more. The block-scaled GEMM's cost is
+// INDEPENDENT of the row count -- its M tile is pinned at 128 rows, because the NVFP4 scale-factor
+// atom is 32x4 = 128 rows in M -- so at four rows it burns a 128-row tile to produce four. Measured
+// per gate/up launch on an RTX 5090 (N=19968, K=6656, a 74.76 MB operand) at c2/c4/c8/c16/c32:
+// 68.5 / 70.1 / 69.5 / 67.7 / 62.9 us, flat. The Q3_A arm beside it pays only for the rows it was
+// given, and at two rows it runs at 1.48 TB/s -- this box's streaming roof.
+//
+// #1051 and #1053 then changed what else is in the step, and the crossover moved with it. Measured
+// on the bot's own invocation, ABBA x2 plus a repeat: at four rows the Q3_A arm is now
+// 256.5 against 248.4 aggregate tok/s, and the sign of the earlier reading has flipped (the same
+// probe read -1.0% before those two landed). Eight rows still belongs to the GEMM (-3.0%), so this
+// moves exactly one width across and leaves every other axis on the arm it already ran:
+// c2/c8/c16/c32 within 0.1%, and all twelve single-stream axes within 0.2% -- AR decode is one row
+// and was already on the Q3_A arm.
+//
+// SPARKINFER_GU_GEMM_MIN_ROWS still overrides, so both arms come out of ONE binary.
 static int gu_gemm_min_rows() {
     static const int v = [] {
         const char* e = getenv("SPARKINFER_GU_GEMM_MIN_ROWS");
-        const int x = e ? atoi(e) : 4;
+        const int x = e ? atoi(e) : 5;
         return x < 1 ? 1 : x;
     }();
     return v;


### PR DESCRIPTION
## Summary

`gu_gemm_min_rows` decides where a packed continuous-batch step leaves the row-batched Q3_A gate/up GEMV for the block-scaled NVFP4 GEMM. It was fitted at 4; #1051 and #1053 changed what else is in the step and the crossover moved. At four rows the Q3_A arm is now faster, so this moves the threshold one width, to 5. Nothing else changes arm.

## Proof of speedup

- [x] Tested on **RTX 5090** (`sm_120`)

**Target model(s)**

- [x] **Muse Glimmer**
- [ ] **Qwen3.8-27B** (ModelOpt NVFP4 / DSpark)
- [ ] **Shared / both**

**Decode tok/s** (end-to-end, from `bench/scripts/bench.sh` — fill if this PR targets decode):

| | decode tok/s |
|---|--:|
| before (main) | 248.4 |
| after (this PR) | 256.5 |

**Prefill pp tok/s** (fill if this PR targets prefill; use `--ctx 4096`, `32768`, `65536`, or `131072` and copy the `prefill pp` line — report your best context. Keep the row labels as-is):

| | prefill pp tok/s |
|---|--:|
| before prefill (main) | 15166.8 |
| after prefill (this PR) | 15179.9 |

```text
# bench/scripts/bench.sh benchmarks PREBUILT RELEASE BINARIES and so cannot measure a branch.
# These are the evaluator's own invocations, run against separate builds of clean main
# bc0e47b and of this change, on the same physical RTX 5090 (575 W, CUDA 13.0, sm_120).
# The decode table above is muse-cb-decode@c4, which is the axis this PR moves.

# aggregate tok/s, qwen3_gguf_cb_bench <gguf> C 256 256 512
# ABBA, two interleaved repeats plus a repeated control; every leg checked decode_tokens == C*256+8.

  C     main                          this PR
  c2    179.4  179.5                  179.3  179.4
  c4    249.3  248.3  248.1  248.0    260.4  255.0  254.0
  c8    441.8  441.9                  441.8  441.5
  c16   847.6  847.1                  847.3
  c32   1185.6 1185.6                 1186.5

  c4: 248.4 -> 256.5  = +3.3%     every other concurrency within 0.1%

# twelve single-stream axes, bench_sweep_run (decode tok/s / prefill pp tok/s)
# AR decode is one row and was already on the Q3_A arm, so these are unchanged by construction.

  ctx      main                       this PR
  128      109.6235 /  9885.97        109.6306 /  9899.12
  512      108.8916 / 15990.76        108.9117 / 16024.19
  4096     105.8481 / 15166.85        105.8439 / 15179.89
  16384    104.8578 / 14395.59        104.8767 / 14396.70
  32768    103.6397 / 13103.33        103.6365 / 13106.85
  65536    101.6732 / 11183.70        101.7286 / 11188.22
```

### Why the crossover moved

The block-scaled GEMM's cost does not depend on the row count — its M tile is pinned at 128 rows, because the NVFP4 scale-factor atom is 32x4 = 128 rows in M. Measured per gate/up launch (N=19968, K=6656, a 74.76 MB operand) at c2/c4/c8/c16/c32: **68.5 / 70.1 / 69.5 / 67.7 / 62.9 us** — flat. At four rows it burns a 128-row tile to produce four. The Q3_A arm pays only for the rows it is given, and at two rows it runs at 1.48 TB/s, this box's streaming roof.

Eight rows still belongs to the GEMM (the same probe reads -3.0% there), so 5 is the first width that is on the right side, and it moves exactly one scored axis.

`SPARKINFER_GU_GEMM_MIN_ROWS` still overrides, so both arms come out of one binary.
